### PR TITLE
Allow passwordless redis connection

### DIFF
--- a/storage_handlers.go
+++ b/storage_handlers.go
@@ -116,9 +116,11 @@ func (r *RedisStorageManager) newPool(server, password string) *redis.Pool {
 			if err != nil {
 				return nil, err
 			}
-			if _, err := c.Do("AUTH", password); err != nil {
-				c.Close()
-				return nil, err
+			if password != "" {
+				if _, err := c.Do("AUTH", password); err != nil {
+					c.Close()
+					return nil, err
+				}
 			}
 			return c, err
 		},


### PR DESCRIPTION
This patch allows passwordless connection to redis.  Without it I get the following when running tyk:

```
ERRO[0001] ERR Client sent AUTH, but no password is set
```
