### PR TITLE
Settable Redis database in configuration

### DIFF
--- a/config.go
+++ b/config.go
@@ -18,6 +18,7 @@ type Config struct {
 		Port     int    `json:"port"`
 		Username string `json:"username"`
 		Password string `json:"password"`
+		Database int    `json:"database"`
 	} `json:"storage"`
 	EnableAnalytics bool `json:"enable_analytics"`
 	AnalyticsConfig struct {
@@ -40,6 +41,7 @@ func WriteDefaultConf(configStruct *Config) {
 	configStruct.Storage.Host = "localhost"
 	configStruct.Storage.Username = "user"
 	configStruct.Storage.Password = "password"
+	configStruct.Storage.Database = 0
 	configStruct.Storage.Port = 6379
 	configStruct.EnableAnalytics = false
 	configStruct.AnalyticsConfig.CSVDir = "/tmp"


### PR DESCRIPTION
We use Redis databases to keep different data sets separated (sessions, cache etc).  Using `Storage.Database` now allows for a specific database to be selected rather than the default of 0.
