### PR TITLE
Fix error message for invalid admin auth

### DIFF
--- a/middleware_api_security_handler.go
+++ b/middleware_api_security_handler.go
@@ -14,7 +14,7 @@ func CheckIsAPIOwner(handler func(http.ResponseWriter, *http.Request)) func(http
 			// Error
 			log.Warning("Attempted administrative access with invalid or missing key!")
 
-			responseMessage := createError("Method not supported")
+			responseMessage := createError("Forbidden")
 			w.WriteHeader(403)
 			fmt.Fprintf(w, string(responseMessage))
 


### PR DESCRIPTION
Nice easy one, 403 is Fobidden, not Method no supported.
