### PR TITLE
Don't create analytics for requests from specified IPs

### DIFF
--- a/config.go
+++ b/config.go
@@ -3,6 +3,8 @@ package main
 import (
 	"encoding/json"
 	"io/ioutil"
+	"net"
+	"net/http"
 )
 
 // Config is the configuration object used by tyk to set up various parameters.
@@ -28,7 +30,8 @@ type Config struct {
 		MongoDbName     string `json:"mongo_db_name"`
 		MongoCollection string `json:"mongo_collection"`
 		PurgeDelay      int    `json:"purge_delay"`
-		IgnoredIPs      map[string]bool `json:"ignored_ips"`
+		IgnoredIPs      []string `json:"ignored_ips"`
+		ignoredIPsCompiled map[string]bool
 	} `json:"analytics_config"`
 }
 
@@ -47,7 +50,7 @@ func WriteDefaultConf(configStruct *Config) {
 	configStruct.EnableAnalytics = false
 	configStruct.AnalyticsConfig.CSVDir = "/tmp"
 	configStruct.AnalyticsConfig.Type = "csv"
-	configStruct.AnalyticsConfig.IgnoredIPs = make(map[string]bool);
+	configStruct.AnalyticsConfig.IgnoredIPs = make([]string, 0)
 	newConfig, err := json.Marshal(configStruct)
 	if err != nil {
 		log.Error("Problem marshalling default configuration!")
@@ -78,4 +81,18 @@ func loadConfig(filePath string, configStruct *Config) {
 			log.Error(err)
 		}
 	}
+}
+
+func loadIgnoredIPs(configStruct *Config) {
+	configStruct.AnalyticsConfig.ignoredIPsCompiled = make(map[string]bool, len(configStruct.AnalyticsConfig.IgnoredIPs))
+	for _, ip := range configStruct.AnalyticsConfig.IgnoredIPs {
+		configStruct.AnalyticsConfig.ignoredIPsCompiled[ip] = true;
+	}
+}
+
+func StoreAnalytics(configStruct *Config, r *http.Request) (bool) {
+	ip, _, _ := net.SplitHostPort(r.RemoteAddr)
+	_, ignore := configStruct.AnalyticsConfig.ignoredIPsCompiled[ip]
+
+	return !ignore
 }

--- a/handler_error.go
+++ b/handler_error.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"github.com/gorilla/context"
-	"net"
 	"net/http"
 	"runtime/pprof"
 	"strings"
@@ -24,11 +23,7 @@ type ErrorHandler struct {
 // HandleError is the actual error handler and will store the error details in analytics if analytics processing is enabled.
 func (e ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, err string, errCode int) {
 
-	// Check if we should create analytics data for this request
-	ip, _, _ := net.SplitHostPort(r.RemoteAddr)
-	_, ignore := config.AnalyticsConfig.IgnoredIPs[ip]
-
-	if config.EnableAnalytics && !ignore {
+	if StoreAnalytics(&config, r) {
 		t := time.Now()
 
 		// Track the key ID if it exists

--- a/handler_success.go
+++ b/handler_success.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/gorilla/context"
-	"net"
 	"net/http"
 	"net/http/httputil"
 	"runtime/pprof"
@@ -67,11 +66,7 @@ func (s SuccessHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		r.URL.Path = strings.Replace(r.URL.Path, s.Spec.Proxy.ListenPath, "", 1)
 	}
 
-	// Check if we should create analytics data for this request
-	ip, _, _ := net.SplitHostPort(r.RemoteAddr)
-	_, ignore := config.AnalyticsConfig.IgnoredIPs[ip]
-
-	if config.EnableAnalytics && !ignore {
+	if StoreAnalytics(&config, r) {
 		t := time.Now()
 
 		// Track the key ID if it exists

--- a/main.go
+++ b/main.go
@@ -59,6 +59,7 @@ func setupGlobals() {
 	}
 
 	if config.EnableAnalytics {
+		loadIgnoredIPs(&config)
 		AnalyticsStore := RedisStorageManager{KeyPrefix: "analytics-"}
 		log.Info("Setting up analytics DB connection")
 


### PR DESCRIPTION
Here's a first go at solving #18.  There's a couple of things I don't really like:

The config uses a map of string to bool so that it's easy to do a `config.AnalyticsConfig.IgnoredIPs[ip]` check but that means the json has to be

``` json
ignored_ips: {
    "127.0.0.1": true
}
```

when it should really be using an array of strings

``` json
ignored_ips: [
    "127.0.0.1"
]
```

I can change it to do that but it means adding a 'in array' function as go doesn't appear to ship with one.

Also I'm not keen on the repeated code to get and check the ip.  This could be refactored into a function so the if statement becomes something like `if StoreAnalytics() {` but I'm not sure where that function should be placed, I'm assuming `middleware.go`?
