### PR TITLE
Add CIDR support for IP whitelist

### DIFF
--- a/middleware_ip_whitelist_test.go
+++ b/middleware_ip_whitelist_test.go
@@ -80,7 +80,7 @@ var ipMiddlewareTestDefinitionEnabledPass string = `
 			"strip_listen_path": false
 		},
 		"enable_ip_whitelisting": true,
-		"allowed_ips": ["127.0.0.1"]
+		"allowed_ips": ["127.0.0.1", "127.0.0.1/24"]
 	}
 `
 
@@ -223,6 +223,35 @@ func TestIpMiddlewareIPPass(t *testing.T) {
 	param := make(url.Values)
 	req, err := http.NewRequest(method, uri+param.Encode(), nil)
 	req.RemoteAddr = "127.0.0.1"
+	req.Header.Add("authorization", "gfgg1234")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	chain := getChain(*spec)
+	chain.ServeHTTP(recorder, req)
+
+	if recorder.Code != 200 {
+		t.Error("Invalid response code, should be 200:  \n", recorder.Code, recorder.Body, req.RemoteAddr)
+	}
+}
+
+func TestIpMiddlewareIPPassCIDR(t *testing.T) {
+	spec := MakeIPSampleAPI(ipMiddlewareTestDefinitionEnabledPass)
+	redisStore := RedisStorageManager{KeyPrefix: "apikey-"}
+	healthStore := &RedisStorageManager{KeyPrefix: "apihealth."}
+	orgStore := &RedisStorageManager{KeyPrefix: "orgKey."}
+	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	thisSession := createNonThrottledSession()
+	spec.SessionManager.UpdateSession("gfgg1234", thisSession, 60)
+	uri := "/about-lonelycoder/"
+	method := "GET"
+
+	recorder := httptest.NewRecorder()
+	param := make(url.Values)
+	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req.RemoteAddr = "127.0.0.2"
 	req.Header.Add("authorization", "gfgg1234")
 
 	if err != nil {


### PR DESCRIPTION
This commit adds CIDR support for IP whitelist.

It allows using CIDR e.g., 127.0.0.1/24 or 10.0.1.0/8 for IP whitelist which makes IP whitelist more feasible on real production use cases.