### PR TITLE
Add X-Forwarded-For support to IP Whitelist

### DIFF
--- a/middleware_ip_whitelist.go
+++ b/middleware_ip_whitelist.go
@@ -40,6 +40,15 @@ func (i *IPWhiteListMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Re
 
 		splitIP := strings.Split(r.RemoteAddr, ":")
 		remoteIPString := splitIP[0]
+
+		// If X-Forwarded-For is set, override remoteIPString
+		forwarded := r.Header.Get("X-Forwarded-For")
+		if forwarded != "" {
+			ips := strings.Split(forwarded, ", ")
+			remoteIPString = ips[0]
+			log.Info("X-Forwarded-For set, remote IP: ", remoteIPString)
+		}
+
 		if len(splitIP) > 2 {
 			// Might be an IPv6 address, don't mess with it
 			remoteIPString = r.RemoteAddr


### PR DESCRIPTION
Noticed that IP Whitelisting does not work when Tyk Gateway is behind a proxy/load balancer.  This commit adds support for X-Forwarded-For header.