### PR TITLE
Throw error on POST /tyk/apis/ if UseDBAppConfigs is enabled

### DIFF
--- a/api.go
+++ b/api.go
@@ -544,6 +544,11 @@ func HandleGetAPI(APIID string) ([]byte, int) {
 }
 
 func HandleAddOrUpdateApi(APIID string, r *http.Request) ([]byte, int) {
+	if config.UseDBAppConfigs {
+		log.Error("Rejected new API Definition due to UseDBAppConfigs = true")
+		return createError("Due to enabled use_db_app_configs, please use Advanced Management API"), 500
+	}
+
 	success := true
 	decoder := json.NewDecoder(r.Body)
 	var responseMessage []byte


### PR DESCRIPTION
Refer to TykTechnologies/tyk#177

Calling POST to /tyk/apis/ when `UseDBAppConfigs` is enabled may
cause an unexpected behavior. It added a new API definition to
`config.AppPath` directory and didn't add to MongoDB, so it's not
available on the dashboard.

This commit changes the behavior of POST command by rejecting
request if `UseDBAppConfigs` setting is enabled and suggest user to
use an Advanced Management API instead.