### PR TITLE
Modify Plugins to add `Params` field to Request object in middleware

### DIFF
--- a/plugins.go
+++ b/plugins.go
@@ -4,15 +4,16 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/gorilla/context"
-	"github.com/mitchellh/mapstructure"
-	"github.com/robertkrimen/otto"
-	_ "github.com/robertkrimen/otto/underscore"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/gorilla/context"
+	"github.com/mitchellh/mapstructure"
+	"github.com/robertkrimen/otto"
+	_ "github.com/robertkrimen/otto/underscore"
 )
 
 // MiniRequestObject is marshalled to JSON string and pased into JSON middleware
@@ -22,6 +23,7 @@ type MiniRequestObject struct {
 	DeleteHeaders []string
 	Body          string
 	URL           string
+	Params        map[string][]string
 	AddParams     map[string]string
 	DeleteParams  []string
 }
@@ -86,6 +88,7 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 		DeleteHeaders: make([]string, 0),
 		Body:          string(originalBody),
 		URL:           r.URL.Path,
+		Params:        r.URL.Query(),
 		AddParams:     make(map[string]string),
 		DeleteParams:  make([]string, 0),
 	}


### PR DESCRIPTION
  * This enables middleware developers to inspect querystring and form data
when developing rate-limiting and other middleware.