### PR TITLE
RH: Closes #193 by adding new config option for hiding the X-Generator heaer

### DIFF
--- a/config.go
+++ b/config.go
@@ -121,6 +121,7 @@ type Config struct {
 	ControlAPIHostname   string `json:"control_api_hostname"`
 	EnableCustomDomains  bool   `json:"enable_custom_domains"`
 	EnableJSVM           bool   `json:"enable_jsvm"`
+	HideGeneratorHeader  bool   `json:"hide_generator_header"`
 }
 
 type CertData struct {
@@ -151,6 +152,7 @@ func WriteDefaultConf(configStruct *Config) {
 	configStruct.AnalyticsConfig.Type = "csv"
 	configStruct.AnalyticsConfig.IgnoredIPs = make([]string, 0)
 	configStruct.UseAsyncSessionWrite = false
+	configStruct.HideGeneratorHeader = false
 	newConfig, err := json.MarshalIndent(configStruct, "", "    ")
 	if err != nil {
 		log.Error("Problem marshalling default configuration!")

--- a/handler_error.go
+++ b/handler_error.go
@@ -119,7 +119,12 @@ func (e ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, err st
 	ReportHealthCheckValue(e.Spec.Health, BlockedRequestLog, "-1")
 
 	w.Header().Add("Content-Type", "application/json")
-	w.Header().Add("X-Generator", "tyk.io")
+
+	//If the config option is not set or is false, add the header
+	if !config.HideGeneratorHeader {
+		w.Header().Add("X-Generator", "tyk.io")
+	}
+
 	// Close connections
 	if config.CloseConnections {
 		w.Header().Add("Connection", "close")


### PR DESCRIPTION
Made it so setting the config option to true 'hides' the header, so if the option is not set then behaviour continues as before

I've got redis running locally but can't get the tests to pass on master or develop or my branch, but as this is literally just hiding a header on a config change I assumed it would be OK

EDIT: I believe the only failing test locally is TestServiceDiscovery_ETCD_NOLIST - no real idea on where to start looking as to why that fails...? Seems to have passed on CI though