### PR TITLE
Response middleware with header transformations.

### DIFF
--- a/res_handler_header_transform.go
+++ b/res_handler_header_transform.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"github.com/mitchellh/mapstructure"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type RevProxyTransform struct {
+	Headers     []string // List of HTTP headers to be modified
+	Target_host string   // Target host for reverse proxy
+}
+
+type HeaderTransformOptions struct {
+	RevProxyTransform RevProxyTransform `mapstructure:"rev_proxy_header_cleanup" \
+	bson:"rev_proxy_header_cleanup" \
+	json:"rev_proxy_header_cleanup"`
+}
+
+type HeaderTransform struct {
+	Spec   *APISpec
+	config HeaderTransformOptions
+}
+
+func (h HeaderTransform) New(c interface{}, spec *APISpec) (TykResponseHandler, error) {
+	thisHandler := HeaderTransform{}
+	thisModuleConfig := HeaderTransformOptions{}
+
+	err := mapstructure.Decode(c, &thisModuleConfig)
+	if err != nil {
+		log.Error(err)
+		return nil, err
+	}
+
+	thisHandler.config = thisModuleConfig
+	thisHandler.Spec = spec
+
+	return thisHandler, nil
+}
+
+func (h HeaderTransform) HandleResponse(rw http.ResponseWriter,
+	res *http.Response, req *http.Request, ses *SessionState) error {
+
+	// Parse target_host parameter from configuration
+	target_url, err := url.Parse(h.config.RevProxyTransform.Target_host)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	for _, v := range h.config.RevProxyTransform.Headers {
+		// check if header is present and its value is not empty
+		if len(res.Header[v]) == 0 || len(res.Header[v][0]) == 0 {
+			continue
+		}
+		// Replace scheme
+		NewHeaderValue := strings.Replace(
+			res.Header[v][0], h.Spec.target.Scheme, target_url.Scheme, -1)
+		// Replace host
+		NewHeaderValue = strings.Replace(
+			NewHeaderValue, h.Spec.target.Host, target_url.Host, -1)
+		// Transform path
+		if h.Spec.Proxy.StripListenPath {
+			if len(h.Spec.target.Path) != 0 {
+				NewHeaderValue = strings.Replace(
+					NewHeaderValue, h.Spec.target.Path,
+					h.Spec.Proxy.ListenPath, -1)
+			} else {
+				NewHeaderValue = strings.Replace(
+					NewHeaderValue, req.URL.Path,
+					h.Spec.Proxy.ListenPath+req.URL.Path, -1)
+			}
+		} else {
+			if len(h.Spec.target.Path) != 0 {
+				NewHeaderValue = strings.Replace(
+					NewHeaderValue, h.Spec.target.Path,
+					"/", -1)
+			}
+		}
+		res.Header[v][0] = NewHeaderValue
+	}
+	return nil
+}

--- a/response_middleware.go
+++ b/response_middleware.go
@@ -8,6 +8,7 @@ import (
 var RESPONSE_PROCESSORS map[string]TykResponseHandler = map[string]TykResponseHandler{
 	"header_injector":         HeaderInjector{},
 	"response_body_transform": ResponseTransformMiddleware{},
+	"header_transform":        HeaderTransform{},
 }
 
 type TykResponseHandler interface {


### PR DESCRIPTION
Actually there is only one transform supported - reverse proxy header
cleanup. Middleware with this transform active will change address
of each resource present in the header values of the headers
from middleware configuration.

Example configuration:
"response_processors": [
{
    "name": "header_transform",
        "options": {
            "rev_proxy_header_cleanup": {
                "headers": ["Link", "Location"],
                "target_host": "http://TykHost:TykPort"
            }
        }
}]

Signed-off-by: Krzysztof Jaskiewicz <krzysztof.jaskiewicz@open-rnd.pl>