### PR TITLE
Use FlushInterval as time.Millisecond

### DIFF
--- a/tyk_reverse_proxy_clone.go
+++ b/tyk_reverse_proxy_clone.go
@@ -159,7 +159,7 @@ func TykNewSingleHostReverseProxy(target *url.URL, spec *APISpec) *ReverseProxy 
 		}
 	}
 
-	return &ReverseProxy{Director: director, TykAPISpec: spec, FlushInterval: time.Duration(config.HttpServerOptions.FlushInterval) * time.Second}
+	return &ReverseProxy{Director: director, TykAPISpec: spec, FlushInterval: time.Duration(config.HttpServerOptions.FlushInterval) * time.Millisecond}
 }
 
 // onExitFlushLoop is a callback set by tests to detect the state of the
@@ -276,7 +276,7 @@ func NewSingleHostReverseProxy(target *url.URL) *ReverseProxy {
 			req.URL.RawQuery = targetQuery + "&" + req.URL.RawQuery
 		}
 	}
-	return &ReverseProxy{Director: director, FlushInterval: 1 * time.Second}
+	return &ReverseProxy{Director: director, FlushInterval: 1000 * time.Millisecond}
 }
 
 func copyHeader(dst, src http.Header) {


### PR DESCRIPTION
Hi, I think this is related to #106.

I've been trying to use Tyk for chunked responses but I find it too slow, so I started to play with the ```FlushInterval``` parameter and I found that's limited to ```time.Second```, I applied the current PR as a patch to my development server and now I'm able to specify a flush interval that's less than 1 second, and the experience of sending the request through Tyk is almost like what I'm getting when sending a request directly to my endpoint.

**Note:** My endpoint does some async stuff and sends chunks as fast as possible, so I get a chunk after 500 ms, another one after 2000 ms and so on. So during my tests, setting ```FlushInterval``` to 500 or 200 ms, improves the experience (I get the chunks ASAP), this is a very specific thing, but I do find useful to use milliseconds instead of seconds, it's more flexible!

Best regards!