### PR TITLE
Check CacheOptions.EnableCache

### DIFF
--- a/tyk_reverse_proxy_clone.go
+++ b/tyk_reverse_proxy_clone.go
@@ -314,7 +314,7 @@ func (p *ReverseProxy) New(c interface{}, spec *APISpec) (TykResponseHandler, er
 }
 
 func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) *http.Response {
-	return p.WrappedServeHTTP(rw, req, RecordDetail(req))
+	return p.WrappedServeHTTP(rw, req, p.TykAPISpec.APIDefinition.CacheOptions.EnableCache)
 	// return nil
 }
 


### PR DESCRIPTION
Hi, I'm not sure about the usage of `RecordDetail` in this context, however I've found that #262 wasn't working as expected because of `withCache`.

I did this test using the dashboard, I activated/deactivated `Enable caching` from the dashboard and `WrapedServeHTTP` would take `withCache` as `true`, always:

<img width="286" alt="dashboard_cache" src="https://cloud.githubusercontent.com/assets/20110/16132243/47fb4b48-33e0-11e6-9ed3-6a5f83e54953.png">

Using `withCache` breaks the fast, "streaming" response, even if the `FlushInterval` is set to something > 0, this is due to the buffering (the block starting on line 447) that occurs when the cache is enabled.
This patch seems to work and I think it should be considered when using a `FlushInterval` > 0.

Best regards!
