### PR TITLE
RH: Change error on no key found to 401 rather than 400

### DIFF
--- a/middleware_auth_key.go
+++ b/middleware_auth_key.go
@@ -97,7 +97,7 @@ func (k *AuthKey) ProcessRequest(w http.ResponseWriter, r *http.Request, configu
 			"origin": GetIPFromRequest(r),
 		}).Info("Attempted access with malformed header, no auth header found.")
 
-		return errors.New("Authorization field missing"), 400
+		return errors.New("Authorization field missing"), 401
 	}
 
 	// Ignore Bearer prefix on token if it exists


### PR DESCRIPTION
400 is a very general error (that often means the request body is incorrect)

Whereas 401 is specifically saying there's a lack of Authorization