### PR TITLE
Add Listen Address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Develop
 
+- Added the option to set the listen path (defaults to binding to all addresses)
 - Fixed URL Rewriter to better handle query strings
 - Added XML transform support for requests and responses, simply set the data type to `xml` int he transforms section and create your template the same way you would for JSON. 
 

--- a/config.go
+++ b/config.go
@@ -11,6 +11,7 @@ import (
 
 // Config is the configuration object used by tyk to set up various parameters.
 type Config struct {
+	ListenAddress  string `json:"listen_address"`
 	ListenPort     int    `json:"listen_port"`
 	Secret         string `json:"secret"`
 	NodeSecret     string `json:"node_secret"`
@@ -149,6 +150,7 @@ type CertData struct {
 
 // WriteDefaultConf will create a default configuration file and set the storage type to "memory"
 func WriteDefaultConf(configStruct *Config) {
+	configStruct.ListenAddress = ""
 	configStruct.ListenPort = 8080
 	configStruct.Secret = "352d20ee67be67f6340b4c0605b044b7"
 	configStruct.TemplatePath = "./templates"

--- a/main.go
+++ b/main.go
@@ -63,6 +63,9 @@ const (
 func displayConfig() {
 	log.WithFields(logrus.Fields{
 		"prefix": "main",
+	}).Info("--> Listening on address: ", config.ListenAddress)
+	log.WithFields(logrus.Fields{
+		"prefix": "main",
 	}).Info("--> Listening on port: ", config.ListenPort)
 }
 
@@ -1256,7 +1259,7 @@ func listen() {
 	if config.HttpServerOptions.WriteTimeout > 0 {
 		WriteTimeout = config.HttpServerOptions.WriteTimeout
 	}
-	targetPort := fmt.Sprintf(":%d", config.ListenPort)
+	targetPort := fmt.Sprintf("%s:%d", config.ListenAddress, config.ListenPort)
 
 	// Handle reload when SIGUSR2 is received
 	l, err := goagain.Listener()

--- a/tyk.conf.example
+++ b/tyk.conf.example
@@ -1,4 +1,5 @@
 {
+  "listen_address": "",
   "listen_port": 8080,
   "secret": "352d20ee67be67f6340b4c0605b044b7",
   "template_path": "/etc/tyk/templates",


### PR DESCRIPTION
Addresses #239 

Allows you to set a port that the Tyk process will bind to

Will ignore requests made otherwise

I've left blank as the default, which is the same as current behaviour.

See https://golang.org/pkg/net/#Listen