### PR TITLE
OAuth - Multiple Redirect URIs

### DIFF
--- a/config.go
+++ b/config.go
@@ -84,6 +84,7 @@ type Config struct {
 	}
 	OauthRefreshExpire int64 `json:"oauth_refresh_token_expire"`
 	OauthTokenExpire   int32 `json:"oauth_token_expire"`
+	OauthRedirectUriSeparator   string `json:"oauth_redirect_uri_separator"`
 	SlaveOptions       struct {
 		UseRPC                          bool   `json:"use_rpc"`
 		ConnectionString                string `json:"connection_string"`
@@ -168,6 +169,7 @@ func WriteDefaultConf(configStruct *Config) {
 	configStruct.AnalyticsConfig.IgnoredIPs = make([]string, 0)
 	configStruct.UseAsyncSessionWrite = false
 	configStruct.HideGeneratorHeader = false
+	configStruct.OauthRedirectUriSeparator = ""
 	newConfig, err := json.MarshalIndent(configStruct, "", "    ")
 	if err != nil {
 		log.Error("Problem marshalling default configuration!")

--- a/main.go
+++ b/main.go
@@ -315,6 +315,7 @@ func addOAuthHandlers(spec *APISpec, Muxer *mux.Router, test bool) *OAuthManager
 	serverConfig.ErrorStatusCode = 403
 	serverConfig.AllowedAccessTypes = spec.Oauth2Meta.AllowedAccessTypes
 	serverConfig.AllowedAuthorizeTypes = spec.Oauth2Meta.AllowedAuthorizeTypes
+	serverConfig.RedirectUriSeparator = config.OauthRedirectUriSeparator
 
 	OAuthPrefix := generateOAuthPrefix(spec.APIID)
 	//storageManager := RedisClusterStorageManager{KeyPrefix: OAuthPrefix}
@@ -335,10 +336,19 @@ func addOAuthHandlers(spec *APISpec, Muxer *mux.Router, test bool) *OAuthManager
 
 		Policies["TEST-4321"] = testPolicy
 
+		var redirectURI string
+		// If separator is not set that means multiple redirect uris not supported
+		if config.OauthRedirectUriSeparator == "" {
+			redirectURI = "http://client.oauth.com"
+
+		// If separator config is set that means multiple redirect uris are supported
+		} else {
+			redirectURI = strings.Join([]string{"http://client.oauth.com", "http://client2.oauth.com","http://client3.oauth.com"}, config.OauthRedirectUriSeparator)
+		}
 		testClient := OAuthClient{
 			ClientID:          "1234",
 			ClientSecret:      "aabbccdd",
-			ClientRedirectURI: "http://client.oauth.com",
+			ClientRedirectURI: redirectURI,
 			PolicyID:          "TEST-4321",
 		}
 		osinStorage.SetClient(testClient.ClientID, &testClient, false)


### PR DESCRIPTION
Added a configuration oauth_redirect_uri_separator when set will allow to use multiple redirect URIs for OAuth Client.

If set blank or empty will allow only one single URL as redirect URI of OAuth Client.