### PR TITLE
add configurable parameter ping_timeout to slave_options

### DIFF
--- a/config.go
+++ b/config.go
@@ -91,6 +91,7 @@ type SlaveOptionsConfig struct {
 	DisableKeySpaceSync             bool   `json:"disable_keyspace_sync"`
 	GroupID                         string `json:"group_id"`
 	CallTimeout                     int    `json:"call_timeout"`
+	PingTimeout                     int    `json:"ping_timeout"`
 }
 
 type LocalSessionCacheConf struct {

--- a/config_utils.go
+++ b/config_utils.go
@@ -79,7 +79,10 @@ func loadConfig(filePath string, configStruct *Config) {
 	if configStruct.SlaveOptions.CallTimeout == 0 {
 		configStruct.SlaveOptions.CallTimeout = 30
 	}
-
+	if configStruct.SlaveOptions.PingTimeout == 0 {
+		configStruct.SlaveOptions.PingTimeout = 60
+	}
+	GlobalRPCPingTimeout = time.Second * time.Duration(configStruct.SlaveOptions.PingTimeout)
 	GlobalRPCCallTimeout = time.Second * time.Duration(configStruct.SlaveOptions.CallTimeout)
 	configStruct.EventTriggers = InitGenericEventHandlers(configStruct.EventHandlers)
 }

--- a/rpc_storage_handler.go
+++ b/rpc_storage_handler.go
@@ -51,6 +51,8 @@ var RPC_EmergencyModeLoaded bool
 var ErrorDenied error = errors.New("Access Denied")
 
 var GlobalRPCCallTimeout time.Duration
+var GlobalRPCPingTimeout time.Duration
+
 
 // ------------------- CLOUD STORAGE MANAGER -------------------------------
 
@@ -705,7 +707,7 @@ func (r *RPCStorageHandler) GetPolicies(orgId string) string {
 // CheckForReload will start a long poll
 func (r *RPCStorageHandler) CheckForReload(orgId string) {
 	log.Debug("[RPC STORE] Check Reload called...")
-	reload, err := RPCFuncClientSingleton.CallTimeout("CheckReload", orgId, time.Second*60)
+	reload, err := RPCFuncClientSingleton.CallTimeout("CheckReload", orgId, GlobalRPCPingTimeout)
 	if err != nil {
 		if r.IsAccessError(err) {
 			log.Warning("[RPC STORE] CheckReload: Not logged in")


### PR DESCRIPTION
I have problem that our loadbalancer tcp timeout is 50 seconds, and we cannot change that. Currently default checkreload timeout is 60 seconds which will lead to problems between gateway and MDCB component.

Log:
```
time="Dec 13 08:22:40" level=warning msg="[RPC STORE] RPC Reload Checker encountered unexpected error: gorpc.Client: [10.222.131.166:9090]. Cannot decode response: [unexpected EOF]"
time="Dec 13 08:22:40" level=info msg="Setting new RPC connection!"
time="Dec 13 08:22:40" level=info msg=Reconnected.
time="Dec 13 08:23:30" level=warning msg="[RPC STORE] RPC Reload Checker encountered unexpected error: gorpc.Client: [10.222.131.166:9090]. Cannot decode response: [unexpected EOF]"
time="Dec 13 08:23:30" level=info msg="Setting new RPC connection!"
time="Dec 13 08:23:30" level=info msg=Reconnected.
time="Dec 13 08:24:20" level=warning msg="[RPC STORE] RPC Reload Checker encountered unexpected error: gorpc.Client: [10.222.131.166:9090]. Cannot decode response: [unexpected EOF]"
time="Dec 13 08:24:20" level=info msg="Setting new RPC connection!"
```

With this PR users could define ping_timeout by themselves. Default timeout is 60 seconds if they do not define anything.
