### PR TITLE
ci: move script to separate file, enforce gofmt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,4 @@ install:
 secure: "F3GrvKUQkuIJyzamGM3fw5tTZfYtSCmR+02t5KpqsqkBt1iBM2w4wlZjm+kMzisz8NDVZYfXYDYIqLhfBa4kwSPGgUqxqXAsMhI7hEco3P2FZ6nre0HC0QYhvKks07644KsVq1J2Xn7JMT+61rXKeEk4Ncu1spZCfWbhiJk+MKA="
 
 script:
-  - go test -v
-  - go test -tags coprocess -v
+  - ./utils/ci-test.sh

--- a/utils/ci-test.sh
+++ b/utils/ci-test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+# print a command and execute it
+show() {
+    echo "$@"
+    eval "$@"
+}
+
+PKGS="$(go list ./... | grep -v /vendor/)"
+
+show go test -v $PKGS
+show go test -v -tags coprocess $PKGS
+
+FMT_FILES="$(go fmt $PKGS)"
+if [[ -n $FMT_FILES ]]; then
+	echo "Run 'gofmt -w' on these files:\n$FMT_FILES"
+	exit 1
+fi


### PR DESCRIPTION
Don't enforce it with -s for now.

Also run tests on all of the non-vendor packages, since we were only
running tests for the root package until now.