### PR TITLE
Add templates for Issues and PR's

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,9 @@
+**Do you want to request a *feature* or report a *bug*?**
+
+**What is the current behavior?**
+
+**What is the expected behavior?**
+
+**If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem**
+
+**Which versions of Tyk affected by this issue? Did this work in previous versions of Tyk?**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+*Before* submitting a pull request, please make sure the following is done...
+
+1. Fork the repo and create your branch from the **latest** `master`.
+2. If you've added code that should be tested, add tests!
+3. If you've changed APIs, describe what needs to be updated in the documentation.
+4. Ensure the test suite passes (`go test`).
+5. Make sure your code lints (`go fmt && go vet`).


### PR DESCRIPTION
In order to improve quality of user contributions we need require them fill some essential fields when they create issues or PR’s. See PR content.