### PR TITLE
Expose mux.Router SkipClean functionality

### DIFF
--- a/config.go
+++ b/config.go
@@ -111,6 +111,7 @@ type HttpServerOptionsConfig struct {
 	ServerName       string     `json:"server_name"`
 	MinVersion       uint16     `json:"min_version"`
 	FlushInterval    int        `json:"flush_interval"`
+	SkipURLCleaning  bool       `json:"skip_url_cleaning"`
 }
 
 type AuthOverrideConf struct {

--- a/main.go
+++ b/main.go
@@ -1320,6 +1320,8 @@ func listen(l net.Listener, err error) {
 
 		// Use a custom server so we can control keepalives
 		if config.HttpServerOptions.OverrideDefaults {
+			defaultRouter.SkipClean(config.HttpServerOptions.SkipURLCleaning)
+
 			log.WithFields(logrus.Fields{
 				"prefix": "main",
 			}).Info("Custom gateway started")
@@ -1340,10 +1342,11 @@ func listen(l net.Listener, err error) {
 			log.WithFields(logrus.Fields{
 				"prefix": "main",
 			}).Printf("Gateway started (%v)", VERSION)
-			if !RPC_EmergencyMode {
-				http.Handle("/", mainRouter)
+			if RPC_EmergencyMode {
+				go http.Serve(l, nil)
+			} else {
+				go http.Serve(l, mainRouter)
 			}
-			go http.Serve(l, nil)
 			displayConfig()
 		}
 


### PR DESCRIPTION
This is related to #340, when `HttpServerOptionsConfig.OverrideDefaults` is enabled, Tyk will check `HttpServerOptionsConfig.SkipURLCleaning`.

Sample request:

```
curl http://localhost:8080/quickstart//headers
```

**SkipClean = true, no redirections**

**SkipClean = false, you get a 301 redirect to `/quickstart/headers`**

This behavior is described [here](http://www.gorillatoolkit.org/pkg/mux#Router.SkipClean).