### PR TITLE
Allow "/tyk/apis" without trailing slash

### DIFF
--- a/api.go
+++ b/api.go
@@ -778,7 +778,12 @@ func HandleDeleteAPI(APIID string) ([]byte, int) {
 }
 
 func apiHandler(w http.ResponseWriter, r *http.Request) {
-	APIID := r.URL.Path[len("/tyk/apis/"):]
+	var APIID string
+
+	if r.URL.Path != "/tyk/apis" {
+		APIID = r.URL.Path[len("/tyk/apis/"):]
+	}
+
 	var responseMessage []byte
 	var code int
 

--- a/api_test.go
+++ b/api_test.go
@@ -123,36 +123,39 @@ func TestHealthCheckEndpoint(t *testing.T) {
 }
 
 func TestApiHandler(t *testing.T) {
-	uri := "/tyk/apis/"
-	method := "GET"
-	sampleKey := createSampleSession()
-	body, _ := json.Marshal(&sampleKey)
+	uris := []string{"/tyk/apis/", "/tyk/apis"}
 
-	recorder := httptest.NewRecorder()
-	param := make(url.Values)
+	for _, uri := range uris {
+		method := "GET"
+		sampleKey := createSampleSession()
+		body, _ := json.Marshal(&sampleKey)
 
-	MakeSampleAPI()
+		recorder := httptest.NewRecorder()
+		param := make(url.Values)
 
-	req, err := http.NewRequest(method, uri+param.Encode(), strings.NewReader(string(body)))
+		MakeSampleAPI()
 
-	if err != nil {
-		t.Fatal(err)
-	}
+		req, err := http.NewRequest(method, uri+param.Encode(), strings.NewReader(string(body)))
 
-	apiHandler(recorder, req)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	// We can't deserialize BSON ObjectID's if they are not in th test base!
-	var ApiList []testAPIDefinition
-	err = json.Unmarshal([]byte(recorder.Body.String()), &ApiList)
+		apiHandler(recorder, req)
 
-	if err != nil {
-		t.Error("Could not unmarshal API List:\n", err, recorder.Body.String())
-	} else {
-		if len(ApiList) != 1 {
-			t.Error("API's not returned, len was: \n", len(ApiList), recorder.Body.String())
+		// We can't deserialize BSON ObjectID's if they are not in th test base!
+		var ApiList []testAPIDefinition
+		err = json.Unmarshal([]byte(recorder.Body.String()), &ApiList)
+
+		if err != nil {
+			t.Error("Could not unmarshal API List:\n", err, recorder.Body.String(), uri)
 		} else {
-			if ApiList[0].APIID != "1" {
-				t.Error("Response is incorrect - no API ID value in struct :\n", recorder.Body.String())
+			if len(ApiList) != 1 {
+				t.Error("API's not returned, len was: \n", len(ApiList), recorder.Body.String(), uri)
+			} else {
+				if ApiList[0].APIID != "1" {
+					t.Error("Response is incorrect - no API ID value in struct :\n", recorder.Body.String(), uri)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Should fix #372 

This is the first URL user see when initializing Tyk, so it’s better to avoid any confusions. 

gorilla.Mux require you to make two handlers mappings if a route can be used with or without nested routes.

This is somehow related to #377, but our /tyk/* router already cleans the paths by default.

It is quite easy to test, before this change, any request to "/tyk/apis" (GET or POST) will return 404.