### PR TITLE
Remove the test dependency on redis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,8 @@ matrix:
       env: SKIP_LINT=true
     - go: 1.7.x
 
-services:
-  - redis-server
-
 install:
+  - go get -t ./... # test deps
   - go install -v ./...
   - go get -u golang.org/x/tools/cmd/goimports
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,8 +69,6 @@ You need to have working Go enironment: see [golang.org](https://golang.org/doc/
 
 To build and test Tyk use built-in `go` commands: `go build` and `go test -v`. If you want to just test a subset of the project, you can pass the `-run` argument with name of the test.
 
-Currently in order for tests to pass, a **Redis host is required**. We know, this is terrible and should be handled with an interface, and it is, however in the current version there is a hard requirement for the application to have its default memory setup to use redis as part of a deployment, this is to make it easier to install the application for the end-user. Future versions will work around this, or we may drop the memory requirement. Simplest way to run Redis is to use official Docker image [https://hub.docker.com/_/redis/](https://hub.docker.com/_/redis/)
-
 ### Adding dependencies
 
 If your patch depends on new packages, ensure that they will be put in `/vendor` folder. `git` is very handy when it comes to vendoring, because it automatically creates needed directories, example: `git clone https://github.com/Shopify/sarama.git vendor/github.com/Shopify/sarama`.

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -2,23 +2,34 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis"
 	"github.com/justinas/alice"
 )
 
 func init() {
-	fmt.Println("THIS IS THE TEST SETUP INIT")
 	runningTests = true
+}
+
+func TestMain(m *testing.M) {
+	s, err := miniredis.Run()
+	if err != nil {
+		panic(err)
+	}
+	defer s.Close()
+	config.Storage.Port, _ = strconv.Atoi(s.Port())
 	initialiseSystem(map[string]interface{}{})
+	os.Exit(m.Run())
 }
 
 var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")


### PR DESCRIPTION
Use miniredis instead.

main.go reads the config and sets up the storage, so there is no easy
way to replace the port when running the tests. The smallest change that
I could think of is not resetting it when running tests.

Fixes #361.