### PR TITLE
Fix data race in the host checker

### DIFF
--- a/host_checker_manager.go
+++ b/host_checker_manager.go
@@ -106,14 +106,14 @@ func (hc *HostCheckerManager) CheckActivePollerLoop() {
 					"prefix": "host-check-mgr",
 				}).Info("Starting Poller")
 				hc.pollerStarted = true
-				go hc.StartPoller()
+				hc.StartPoller()
 			}
 		} else {
 			log.WithFields(logrus.Fields{
 				"prefix": "host-check-mgr",
 			}).Debug("New master found, no tests running")
 			if hc.pollerStarted {
-				go hc.StopPoller()
+				hc.StopPoller()
 				hc.pollerStarted = false
 			}
 		}


### PR DESCRIPTION
Fix data race in the host checker

StartPoller() will start its own goroutine and StopPoller doesn't loop,
so both goroutines here are redundant. In fact they introduce a race:

        Write at 0x00c4202564e9 by goroutine 70:
          github.com/TykTechnologies/tyk.(*HostUptimeChecker).ResetList()
              /home/mvdan/go/src/github.com/TykTechnologies/tyk/host_checker.go:257 +0x40
          github.com/TykTechnologies/tyk.(*HostCheckerManager).UpdateTrackingList()
              /home/mvdan/go/src/github.com/TykTechnologies/tyk/host_checker_manager.go:346 +0x674
          [...]

        Previous write at 0x00c4202564e8 by goroutine 47:
          github.com/TykTechnologies/tyk.(*HostCheckerManager).StartPoller()
              /home/mvdan/go/src/github.com/TykTechnologies/tyk/host_checker_manager.go:169 +0x9cb

This is because we might use the poller before it's finished starting
up.