### PR TITLE
Remove all sleeps from test code

### DIFF
--- a/gateway_test.go
+++ b/gateway_test.go
@@ -857,9 +857,7 @@ func TestWithAnalyticsErrorResponse(t *testing.T) {
 		t.Error("Request failed with 200 code: \n", recorder.Code)
 	}
 
-	time.Sleep(1)
 	results := analytics.Store.GetKeysAndValues()
-
 	if len(results) < 1 {
 		t.Error("Not enough results! Should be 1, is: ", len(results))
 	}

--- a/middleware_check_HMAC_test.go
+++ b/middleware_check_HMAC_test.go
@@ -247,7 +247,6 @@ func TestHMACAuthSessionFailureDateExpired(t *testing.T) {
 	}
 
 	chain := getHMACAuthChain(spec)
-	time.Sleep(time.Second * 2)
 	chain.ServeHTTP(recorder, req)
 
 	if recorder.Code != 400 {
@@ -302,7 +301,6 @@ func TestHMACAuthSessionKeyMissing(t *testing.T) {
 	}
 
 	chain := getHMACAuthChain(spec)
-	time.Sleep(time.Second * 2)
 	chain.ServeHTTP(recorder, req)
 
 	if recorder.Code != 400 {
@@ -357,7 +355,6 @@ func TestHMACAuthSessionMalformedHeader(t *testing.T) {
 	}
 
 	chain := getHMACAuthChain(spec)
-	time.Sleep(time.Second * 2)
 	chain.ServeHTTP(recorder, req)
 
 	if recorder.Code != 400 {


### PR DESCRIPTION
This reduces 'go test' time on my machine from ~10s to ~4s.