### PR TITLE
Ensure that CI will fail if package not vendored

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ matrix:
     - go: 1.7.x
 
 install:
-  - go get -t ./... # test deps
   - go install -v ./...
   - go get -u golang.org/x/tools/cmd/goimports
 


### PR DESCRIPTION
We decided that all dependencies, even needed for tests should be vendored, so we do not depend on 3-rd party failures. 

Removing `go get` will cause CI to fail if it can't run test due to missing package.