### PR TITLE
Fix for #411: JWT Claims are not included in context vars in subsequent requests

### DIFF
--- a/middleware_jwt.go
+++ b/middleware_jwt.go
@@ -281,6 +281,7 @@ func (k *JWTMiddleware) processCentralisedJWT(w http.ResponseWriter, r *http.Req
 		context.Set(r, SessionData, sessionState)
 		context.Set(r, AuthHeaderValue, SessionID)
 	}
+	k.setContextVars(r, token)
 	return nil, 200
 }
 


### PR DESCRIPTION
Simple enough fix, just added the setContextVars outside of first time session check. 