### PR TITLE
CI: add support for coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,16 +14,17 @@ addons:
 matrix:
   include:
     - go: 1.6.x
-      env: SKIP_LINT=true
     - go: 1.7.x
+      env: LATEST_GO=true # run linters and report coverage
     - go: 1.8rc3
 
 install:
   - go install ./...
-  - go get -u golang.org/x/tools/cmd/goimports
+  - go get -u golang.org/x/tools/cmd/goimports github.com/{wadey/gocovmerge,mattn/goveralls}
 
 script:
   - go build -tags 'coprocess python'
   - go build -tags 'coprocess lua'
   - go build -tags 'coprocess grpc'
   - ./utils/ci-test.sh
+  - if [[ $LATEST_GO ]]; then goveralls -coverprofile=<(gocovmerge *.cov); fi


### PR DESCRIPTION
Have each test run output a coverage file, and .travis.yml will merge
all of them and upload them to Coveralls. Do this only on the latest Go
version since we don't care about earlier Go versions we support and run
on Travis.