### PR TITLE
Disable Travis email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 sudo: false
 language: go
 
+notifications:
+  on_success: never
+  on_failure: always
+
 env:
   global:
     - TYK_LOGLEVEL=info


### PR DESCRIPTION
Since some (when I say some, I mean myself) prefer using branches, lot of people may get spammed by Travis notifications. We do not really need them for Tyk, because we using PR to check Travis builds.