### PR TITLE
Remove all prints from test code

### DIFF
--- a/coprocess_bundle_test.go
+++ b/coprocess_bundle_test.go
@@ -1,9 +1,6 @@
 package main
 
-import (
-	"fmt"
-	"testing"
-)
+import "testing"
 
 func TestBundleGetter(t *testing.T) {
 }
@@ -13,8 +10,6 @@ func TestHttpBundleGetter(t *testing.T) {
 	thisGetter = &HttpBundleGetter{}
 
 	thisGetter.Get()
-
-	fmt.Println(thisGetter)
 }
 
 func TestBundleSaver(t *testing.T) {

--- a/coprocess_id_extractor_test.go
+++ b/coprocess_id_extractor_test.go
@@ -24,8 +24,7 @@ func TestValueExtractorHeaderSource(t *testing.T) {
 
 	newExtractor(spec, tykMiddleware)
 
-	var thisExtractor IdExtractor
-	thisExtractor = tykMiddleware.Spec.CustomMiddleware.IdExtractor.Extractor.(IdExtractor)
+	thisExtractor := tykMiddleware.Spec.CustomMiddleware.IdExtractor.Extractor.(IdExtractor)
 
 	thisSession := createBasicAuthSession()
 	username := "4321"
@@ -51,14 +50,8 @@ func TestValueExtractorHeaderSource(t *testing.T) {
 	chain := getBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
 
-	var returnOverrides ReturnOverrides
-	var SessionID string
-
-	SessionID, returnOverrides = thisExtractor.ExtractAndCheck(req)
-
-	fmt.Println("SessionID=", SessionID)
-	fmt.Println("returnOverrides", returnOverrides)
-
+	SessionID, returnOverrides := thisExtractor.ExtractAndCheck(req)
+	_, _ = SessionID, returnOverrides
 }
 
 /* Value Extractor tests, using "form" source */
@@ -71,8 +64,7 @@ func TestValueExtractorFormSource(t *testing.T) {
 
 	newExtractor(spec, tykMiddleware)
 
-	var thisExtractor IdExtractor
-	thisExtractor = tykMiddleware.Spec.CustomMiddleware.IdExtractor.Extractor.(IdExtractor)
+	thisExtractor := tykMiddleware.Spec.CustomMiddleware.IdExtractor.Extractor.(IdExtractor)
 
 	thisSession := createBasicAuthSession()
 	username := "4321"
@@ -86,7 +78,7 @@ func TestValueExtractorFormSource(t *testing.T) {
 	uri := "/"
 	method := "POST"
 
-	var authValue = "abc"
+	authValue := "abc"
 
 	form := url.Values{}
 	form.Add("auth", authValue)
@@ -104,19 +96,12 @@ func TestValueExtractorFormSource(t *testing.T) {
 	chain := getBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
 
-	var returnOverrides ReturnOverrides
-	var SessionID string
-
-	SessionID, _ = thisExtractor.ExtractAndCheck(req)
+	SessionID, _ := thisExtractor.ExtractAndCheck(req)
 	expectedSessionID := computeSessionID([]byte(authValue), tykMiddleware)
 
 	if SessionID != expectedSessionID {
 		t.Fatal("Value Extractor output (using form source) doesn't match the computed session ID.")
 	}
-
-	fmt.Println("SessionID=", SessionID)
-	fmt.Println("returnOverrides", returnOverrides)
-
 }
 
 func TestValueExtractorHeaderSourceValidation(t *testing.T) {
@@ -127,8 +112,7 @@ func TestValueExtractorHeaderSourceValidation(t *testing.T) {
 
 	newExtractor(spec, tykMiddleware)
 
-	var thisExtractor IdExtractor
-	thisExtractor = tykMiddleware.Spec.CustomMiddleware.IdExtractor.Extractor.(IdExtractor)
+	thisExtractor := tykMiddleware.Spec.CustomMiddleware.IdExtractor.Extractor.(IdExtractor)
 
 	thisSession := createBasicAuthSession()
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
@@ -149,8 +133,7 @@ func TestValueExtractorHeaderSourceValidation(t *testing.T) {
 	chain := getBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
 
-	var returnOverrides ReturnOverrides
-	_, returnOverrides = thisExtractor.ExtractAndCheck(req)
+	_, returnOverrides := thisExtractor.ExtractAndCheck(req)
 
 	if returnOverrides.ResponseCode != 400 && returnOverrides.ResponseError != "Authorization field missing" {
 		t.Fatal("ValueExtractor should return an error when the header is missing.")
@@ -167,8 +150,7 @@ func TestRegexExtractorHeaderSource(t *testing.T) {
 
 	newExtractor(spec, tykMiddleware)
 
-	var thisExtractor IdExtractor
-	thisExtractor = tykMiddleware.Spec.CustomMiddleware.IdExtractor.Extractor.(IdExtractor)
+	thisExtractor := tykMiddleware.Spec.CustomMiddleware.IdExtractor.Extractor.(IdExtractor)
 
 	thisSession := createBasicAuthSession()
 
@@ -193,10 +175,7 @@ func TestRegexExtractorHeaderSource(t *testing.T) {
 	chain := getBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
 
-	// var returnOverrides ReturnOverrides
-	var SessionID string
-
-	SessionID, _ = thisExtractor.ExtractAndCheck(req)
+	SessionID, _ := thisExtractor.ExtractAndCheck(req)
 	expectedSessionID := computeSessionID(matchedHeaderValue, tykMiddleware)
 
 	if SessionID != expectedSessionID {
@@ -207,9 +186,7 @@ func TestRegexExtractorHeaderSource(t *testing.T) {
 
 func computeSessionID(input []byte, tykMiddleware *TykMiddleware) (sessionID string) {
 	tokenID := fmt.Sprintf("%x", md5.Sum(input))
-	sessionID = tykMiddleware.Spec.OrgID + tokenID
-
-	return sessionID
+	return tykMiddleware.Spec.OrgID + tokenID
 }
 
 var idExtractorCoProcessDef = `

--- a/coprocess_test_helpers.go
+++ b/coprocess_test_helpers.go
@@ -22,8 +22,6 @@ static int TestMessageLength(struct CoProcessMessage* object) {
 static struct CoProcessMessage* TestDispatchHook(struct CoProcessMessage* object) {
 	struct CoProcessMessage* outputObject = malloc(sizeof *outputObject);
 
-	printf("TestDispatchHook: %p\n", object);
-
 	outputObject->p_data = object->p_data;
 	outputObject->length = object->length;
 

--- a/oauth_manager_test.go
+++ b/oauth_manager_test.go
@@ -7,7 +7,6 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -349,12 +348,10 @@ func TestAPIClientAuthorizeTokenWithPolicy(t *testing.T) {
 	key, fnd := redisStore.GetKey(token)
 	if fnd != nil {
 		t.Error("Key was not created (Can't find it)!")
-		fmt.Println(fnd)
 	}
 
 	if !strings.Contains(key, `"apply_policy_id":"TEST-4321"`) {
 		t.Error("Policy not added to token!")
-		fmt.Println(key)
 	}
 }
 
@@ -385,7 +382,6 @@ func getAuthCode() map[string]string {
 	var thisResponse = map[string]string{}
 	body, _ := ioutil.ReadAll(recorder.Body)
 	if err := json.Unmarshal(body, &thisResponse); err != nil {
-		fmt.Println(err)
 	}
 
 	return thisResponse
@@ -424,9 +420,7 @@ func getToken() tokenData {
 
 	var thisResponse = tokenData{}
 	body, _ := ioutil.ReadAll(recorder.Body)
-	//	fmt.Println(string(body))
 	if err := json.Unmarshal(body, &thisResponse); err != nil {
-		fmt.Println(err)
 	}
 	log.Debug("TOKEN DATA: ", string(body))
 	return thisResponse
@@ -458,10 +452,8 @@ func TestOAuthClientCredsGrant(t *testing.T) {
 
 	var thisResponse = tokenData{}
 	body, _ := ioutil.ReadAll(recorder.Body)
-	//	fmt.Println(string(body))
 	err := json.Unmarshal(body, &thisResponse)
 	if err != nil {
-		fmt.Println(err)
 	}
 	log.Debug("TOKEN DATA: ", string(body))
 	log.Info("Access token: ", thisResponse.AccessToken)


### PR DESCRIPTION
They look like debugging prints used while writing the tests, so just
remove them.

Updates #330.