### PR TITLE
Remove hour-long sleep from analytics.go

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -191,7 +191,6 @@ func (r *RedisAnalyticsHandler) reloadDB() {
 		}
 
 	}
-	time.Sleep(time.Hour * 1)
 }
 
 // RecordHit will store an AnalyticsRecord in Redis


### PR DESCRIPTION
This func is always called from a new goroutine. Having the goroutine
sleep for an hour for no reason just wastes resources.

@lonelycode please confirm this sleep has no purpose.