### PR TITLE
test: deduplicate spec init code

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -51,13 +51,10 @@ var apiTestDef = `
 
 `
 
-func makeSampleAPI() *APISpec {
+func makeSampleAPI(t *testing.T) *APISpec {
 	log.Debug("CREATING TEMPORARY API")
 	spec := createDefinitionFromString(apiTestDef)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	specInitTest(t, spec)
 
 	specs := &[]*APISpec{spec}
 	newMuxes := mux.NewRouter()
@@ -93,7 +90,7 @@ func TestHealthCheckEndpoint(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	param := make(url.Values)
 
-	makeSampleAPI()
+	makeSampleAPI(t)
 
 	req, err := http.NewRequest(method, uri+param.Encode(), nil)
 
@@ -147,7 +144,7 @@ func TestApiHandler(t *testing.T) {
 		recorder := httptest.NewRecorder()
 		param := make(url.Values)
 
-		makeSampleAPI()
+		makeSampleAPI(t)
 
 		req, err := http.NewRequest(method, uri+param.Encode(), strings.NewReader(string(body)))
 
@@ -185,7 +182,7 @@ func TestApiHandlerGetSingle(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	param := make(url.Values)
 
-	makeSampleAPI()
+	makeSampleAPI(t)
 
 	req, err := http.NewRequest(method, uri+param.Encode(), strings.NewReader(string(body)))
 
@@ -276,7 +273,7 @@ func TestKeyHandlerNewKey(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	param := make(url.Values)
 
-	makeSampleAPI()
+	makeSampleAPI(t)
 	param.Set("api_id", "1")
 	req, err := http.NewRequest(method, uri+param.Encode(), strings.NewReader(string(body)))
 
@@ -309,7 +306,7 @@ func TestKeyHandlerUpdateKey(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	param := make(url.Values)
-	makeSampleAPI()
+	makeSampleAPI(t)
 	param.Set("api_id", "1")
 	req, err := http.NewRequest(method, uri+param.Encode(), strings.NewReader(string(body)))
 
@@ -335,7 +332,7 @@ func TestKeyHandlerUpdateKey(t *testing.T) {
 }
 
 func TestKeyHandlerGetKey(t *testing.T) {
-	makeSampleAPI()
+	makeSampleAPI(t)
 	createKey()
 
 	uri := "/tyk/keys/1234"
@@ -366,7 +363,7 @@ func TestKeyHandlerGetKey(t *testing.T) {
 }
 
 func TestKeyHandlerGetKeyNoAPIID(t *testing.T) {
-	makeSampleAPI()
+	makeSampleAPI(t)
 	createKey()
 
 	uri := "/tyk/keys/1234"
@@ -416,7 +413,7 @@ func TestKeyHandlerDeleteKey(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	param := make(url.Values)
-	makeSampleAPI()
+	makeSampleAPI(t)
 	param.Set("api_id", "1")
 	req, err := http.NewRequest(method, uri+param.Encode(), nil)
 
@@ -452,7 +449,7 @@ func TestCreateKeyHandlerCreateNewKey(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	param := make(url.Values)
-	makeSampleAPI()
+	makeSampleAPI(t)
 	param.Set("api_id", "1")
 	req, err := http.NewRequest(method, uri+param.Encode(), strings.NewReader(string(body)))
 
@@ -488,7 +485,7 @@ func TestCreateKeyHandlerCreateNewKeyNoAPIID(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	param := make(url.Values)
-	makeSampleAPI()
+	makeSampleAPI(t)
 	req, err := http.NewRequest(method, uri+param.Encode(), strings.NewReader(string(body)))
 
 	if err != nil {
@@ -526,7 +523,7 @@ func TestAPIAuthFail(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	makeSampleAPI()
+	makeSampleAPI(t)
 	CheckIsAPIOwner(healthCheckhandler)(recorder, req)
 
 	if recorder.Code == 200 {
@@ -548,7 +545,7 @@ func TestAPIAuthOk(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	makeSampleAPI()
+	makeSampleAPI(t)
 	CheckIsAPIOwner(healthCheckhandler)(recorder, req)
 
 	if recorder.Code != 200 {

--- a/batch_requests_test.go
+++ b/batch_requests_test.go
@@ -79,11 +79,7 @@ var testBatchRequest = `
 `
 
 func TestBatchSuccess(t *testing.T) {
-	spec := createDefinitionFromString(batchTestDef)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec := createSpecTest(t, batchTestDef)
 
 	batchHandler := BatchRequestHandler{API: spec}
 
@@ -125,11 +121,7 @@ func TestBatchSuccess(t *testing.T) {
 }
 
 func TestMakeSyncRequest(t *testing.T) {
-	spec := createDefinitionFromString(batchTestDef)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec := createSpecTest(t, batchTestDef)
 
 	batchHandler := BatchRequestHandler{API: spec}
 
@@ -153,11 +145,7 @@ func TestMakeSyncRequest(t *testing.T) {
 }
 
 func TestMakeASyncRequest(t *testing.T) {
-	spec := createDefinitionFromString(batchTestDef)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec := createSpecTest(t, batchTestDef)
 
 	batchHandler := BatchRequestHandler{API: spec}
 

--- a/coprocess_id_extractor_test.go
+++ b/coprocess_id_extractor_test.go
@@ -17,7 +17,7 @@ import (
 /* Value Extractor tests, using "header" source */
 
 func TestValueExtractorHeaderSource(t *testing.T) {
-	spec := makeCoProcessSampleAPI(idExtractorCoProcessDef)
+	spec := createSpecTest(t, idExtractorCoProcessDef)
 	remote, _ := url.Parse(spec.Proxy.TargetURL)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
 	tykMiddleware := &TykMiddleware{spec, proxy}
@@ -57,7 +57,7 @@ func TestValueExtractorHeaderSource(t *testing.T) {
 /* Value Extractor tests, using "form" source */
 
 func TestValueExtractorFormSource(t *testing.T) {
-	spec := makeCoProcessSampleAPI(valueExtractorFormSource)
+	spec := createSpecTest(t, valueExtractorFormSource)
 	remote, _ := url.Parse(spec.Proxy.TargetURL)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
 	tykMiddleware := &TykMiddleware{spec, proxy}
@@ -105,7 +105,7 @@ func TestValueExtractorFormSource(t *testing.T) {
 }
 
 func TestValueExtractorHeaderSourceValidation(t *testing.T) {
-	spec := makeCoProcessSampleAPI(idExtractorCoProcessDef)
+	spec := createSpecTest(t, idExtractorCoProcessDef)
 	remote, _ := url.Parse(spec.Proxy.TargetURL)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
 	tykMiddleware := &TykMiddleware{spec, proxy}
@@ -143,7 +143,7 @@ func TestValueExtractorHeaderSourceValidation(t *testing.T) {
 /* Regex Extractor tests, using "header" source */
 
 func TestRegexExtractorHeaderSource(t *testing.T) {
-	spec := makeCoProcessSampleAPI(regexExtractorDef)
+	spec := createSpecTest(t, regexExtractorDef)
 	remote, _ := url.Parse(spec.Proxy.TargetURL)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
 	tykMiddleware := &TykMiddleware{spec, proxy}

--- a/coprocess_test.go
+++ b/coprocess_test.go
@@ -48,7 +48,7 @@ func TestCoProcessDispatch(t *testing.T) {
 }
 
 func TestCoProcessDispatchEvent(t *testing.T) {
-	spec := makeCoProcessSampleAPI(basicCoProcessDef)
+	spec := createSpecTest(t, basicCoProcessDef)
 	remote, _ := url.Parse(spec.Proxy.TargetURL)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
 	tykMiddleware := &TykMiddleware{spec, proxy}
@@ -159,16 +159,6 @@ type httpbinHeadersResponse struct {
 	Headers map[string]string `json:"headers"`
 }
 
-func makeCoProcessSampleAPI(apiTestDef string) *APISpec {
-	log.Debug("CREATING TEMPORARY API FOR COPROCESS TEST")
-	spec := createDefinitionFromString(apiTestDef)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
-	return spec
-}
-
 func buildCoProcessChain(spec *APISpec, hookName string, hookType coprocess.HookType, driver tykcommon.MiddlewareDriver) http.Handler {
 	remote, _ := url.Parse(spec.Proxy.TargetURL)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
@@ -180,7 +170,7 @@ func buildCoProcessChain(spec *APISpec, hookName string, hookType coprocess.Hook
 }
 
 func TestCoProcessMiddleware(t *testing.T) {
-	spec := makeCoProcessSampleAPI(basicCoProcessDef)
+	spec := createSpecTest(t, basicCoProcessDef)
 
 	chain := buildCoProcessChain(spec, "hook_test", coprocess.HookType_Pre, tykcommon.MiddlewareDriver("python"))
 
@@ -206,7 +196,7 @@ func TestCoProcessMiddleware(t *testing.T) {
 }
 
 func TestCoProcessObjectPostProcess(t *testing.T) {
-	spec := makeCoProcessSampleAPI(basicCoProcessDef)
+	spec := createSpecTest(t, basicCoProcessDef)
 
 	chain := buildCoProcessChain(spec, "hook_test_object_postprocess", coprocess.HookType_Pre, tykcommon.MiddlewareDriver("python"))
 
@@ -282,7 +272,7 @@ func TestCoProcessObjectPostProcess(t *testing.T) {
 
 func TestCoProcessAuth(t *testing.T) {
 	t.Log("CP AUTH")
-	spec := makeCoProcessSampleAPI(protectedCoProcessDef)
+	spec := createSpecTest(t, protectedCoProcessDef)
 
 	chain := buildCoProcessChain(spec, "hook_test_bad_auth", coprocess.HookType_CustomKeyCheck, tykcommon.MiddlewareDriver("python"))
 

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -467,12 +467,22 @@ func createPathBasedDefinition() *APISpec {
 	return createDefinitionFromString(pathBasedDefinition)
 }
 
-func TestParambasedAuth(t *testing.T) {
-	spec := createPathBasedDefinition()
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
+func specInitTest(t *testing.T, spec *APISpec) {
+	redisStore := &RedisClusterStorageManager{KeyPrefix: "apikey-"}
 	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
 	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec.Init(redisStore, redisStore, healthStore, orgStore)
+}
+
+func createSpecTest(t *testing.T, def string) *APISpec {
+	spec := createDefinitionFromString(def)
+	specInitTest(t, spec)
+	return spec
+}
+
+func TestParambasedAuth(t *testing.T) {
+	spec := createPathBasedDefinition()
+	specInitTest(t, spec)
 	session := createParamAuthSession()
 	spec.SessionManager.UpdateSession("54321", session, 60)
 	uri := "/pathBased/post?authorization=54321"
@@ -605,10 +615,7 @@ func TestParambasedAuth(t *testing.T) {
 
 func TestVersioningRequestOK(t *testing.T) {
 	spec := createVersionedDefinition()
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	specInitTest(t, spec)
 	session := createVersionedSession()
 	spec.SessionManager.UpdateSession("96869686969", session, 60)
 	uri := "/"
@@ -634,10 +641,7 @@ func TestVersioningRequestOK(t *testing.T) {
 
 func TestVersioningRequestFail(t *testing.T) {
 	spec := createVersionedDefinition()
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	specInitTest(t, spec)
 	session := createVersionedSession()
 	session.AccessRights = map[string]AccessDefinition{"9991": {APIName: "Tyk Test API", APIID: "9991", Versions: []string{"v2"}}}
 
@@ -666,10 +670,7 @@ func TestVersioningRequestFail(t *testing.T) {
 
 func TestIgnoredPathRequestOK(t *testing.T) {
 	spec := createExtendedDefinitionWithPaths()
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	specInitTest(t, spec)
 	session := createStandardSession()
 
 	spec.SessionManager.UpdateSession("tyutyu345345dgh", session, 60)
@@ -697,10 +698,7 @@ func TestIgnoredPathRequestOK(t *testing.T) {
 
 func TestWhitelistRequestReply(t *testing.T) {
 	spec := createExtendedDefinitionWithPaths()
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	specInitTest(t, spec)
 	session := createStandardSession()
 
 	keyId := randSeq(10)
@@ -731,10 +729,7 @@ func TestWhitelistRequestReply(t *testing.T) {
 
 func TestQuota(t *testing.T) {
 	spec := createNonVersionedDefinition()
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	specInitTest(t, spec)
 	session := createQuotaSession()
 	keyId := randSeq(10)
 	spec.SessionManager.UpdateSession(keyId, session, 60)
@@ -789,10 +784,7 @@ func TestWithAnalyticsTestWithAnalytics(t *testing.T) {
 	analytics.Init()
 
 	spec := createNonVersionedDefinition()
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	specInitTest(t, spec)
 	session := createNonThrottledSession()
 	spec.SessionManager.UpdateSession("ert1234ert", session, 60)
 	uri := "/"
@@ -836,10 +828,7 @@ func TestWithAnalyticsErrorResponse(t *testing.T) {
 	analytics.Init()
 
 	spec := createNonVersionedDefinition()
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	specInitTest(t, spec)
 	session := createNonThrottledSession()
 	spec.SessionManager.UpdateSession("fgh561234", session, 60)
 	uri := "/"

--- a/middleware_auth_key_test.go
+++ b/middleware_auth_key_test.go
@@ -47,17 +47,8 @@ func getAuthKeyChain(spec *APISpec) http.Handler {
 	return chain
 }
 
-func setUp(def string) *APISpec {
-	spec := createDefinitionFromString(def)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
-	return spec
-}
-
 func TestBearerTokenAuthKeySession(t *testing.T) {
-	spec := setUp(authKeyDef)
+	spec := createSpecTest(t, authKeyDef)
 	session := createAuthKeyAuthSession()
 	customToken := "54321111"
 	// AuthKey sessions are stored by {token}
@@ -117,7 +108,7 @@ var authKeyDef = `
 }`
 
 func TestMultiAuthBackwardsCompatibleSession(t *testing.T) {
-	spec := setUp(multiAuthBackwardsCompatible)
+	spec := createSpecTest(t, multiAuthBackwardsCompatible)
 	session := createAuthKeyAuthSession()
 	customToken := "54321111"
 	// AuthKey sessions are stored by {token}
@@ -176,7 +167,7 @@ var multiAuthBackwardsCompatible = `
 }`
 
 func TestMultiAuthSession(t *testing.T) {
-	spec := setUp(multiAuthDef)
+	spec := createSpecTest(t, multiAuthDef)
 	session := createAuthKeyAuthSession()
 	customToken := "54321111"
 	// AuthKey sessions are stored by {token}

--- a/middleware_basic_auth_test.go
+++ b/middleware_basic_auth_test.go
@@ -68,10 +68,6 @@ func createBasicAuthSession() SessionState {
 }
 
 func getBasicAuthChain(spec *APISpec) http.Handler {
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
 	remote, _ := url.Parse("http://example.com/")
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
 	proxyHandler := http.HandlerFunc(ProxyHandler(proxy, spec))
@@ -88,11 +84,7 @@ func getBasicAuthChain(spec *APISpec) http.Handler {
 }
 
 func TestBasicAuthSession(t *testing.T) {
-	spec := createDefinitionFromString(basicAuthDef)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec := createSpecTest(t, basicAuthDef)
 	session := createBasicAuthSession()
 	username := "4321"
 	password := "TEST"
@@ -122,11 +114,7 @@ func TestBasicAuthSession(t *testing.T) {
 }
 
 func TestBasicAuthBadFormatting(t *testing.T) {
-	spec := createDefinitionFromString(basicAuthDef)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec := createSpecTest(t, basicAuthDef)
 	session := createBasicAuthSession()
 	username := "4321"
 	password := "TEST"
@@ -160,11 +148,7 @@ func TestBasicAuthBadFormatting(t *testing.T) {
 }
 
 func TestBasicAuthBadData(t *testing.T) {
-	spec := createDefinitionFromString(basicAuthDef)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec := createSpecTest(t, basicAuthDef)
 	session := createBasicAuthSession()
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
 	spec.SessionManager.UpdateSession("default4321", session, 60)
@@ -196,11 +180,7 @@ func TestBasicAuthBadData(t *testing.T) {
 }
 
 func TestBasicAuthBadOverFormatting(t *testing.T) {
-	spec := createDefinitionFromString(basicAuthDef)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec := createSpecTest(t, basicAuthDef)
 	session := createBasicAuthSession()
 	username := "4321"
 	password := "TEST"
@@ -234,11 +214,7 @@ func TestBasicAuthBadOverFormatting(t *testing.T) {
 }
 
 func TestBasicAuthWrongUser(t *testing.T) {
-	spec := createDefinitionFromString(basicAuthDef)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec := createSpecTest(t, basicAuthDef)
 	session := createBasicAuthSession()
 	password := "TEST"
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
@@ -275,11 +251,7 @@ func TestBasicAuthWrongUser(t *testing.T) {
 }
 
 func TestBasicMissingHeader(t *testing.T) {
-	spec := createDefinitionFromString(basicAuthDef)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec := createSpecTest(t, basicAuthDef)
 	session := createBasicAuthSession()
 
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
@@ -309,11 +281,7 @@ func TestBasicMissingHeader(t *testing.T) {
 }
 
 func TestBasicAuthWrongPassword(t *testing.T) {
-	spec := createDefinitionFromString(basicAuthDef)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec := createSpecTest(t, basicAuthDef)
 	session := createBasicAuthSession()
 	username := "4321"
 

--- a/middleware_check_HMAC_test.go
+++ b/middleware_check_HMAC_test.go
@@ -73,10 +73,6 @@ func createHMACAuthSession() SessionState {
 }
 
 func getHMACAuthChain(spec *APISpec) http.Handler {
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
 	remote, _ := url.Parse("http://example.com/")
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
 	proxyHandler := http.HandlerFunc(ProxyHandler(proxy, spec))
@@ -93,11 +89,7 @@ func getHMACAuthChain(spec *APISpec) http.Handler {
 }
 
 func TestHMACAuthSessionPass(t *testing.T) {
-	spec := createDefinitionFromString(hmacAuthDef)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec := createSpecTest(t, hmacAuthDef)
 	session := createHMACAuthSession()
 
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
@@ -147,11 +139,7 @@ func TestHMACAuthSessionPass(t *testing.T) {
 }
 
 func TestHMACAuthSessionAuxDateHeader(t *testing.T) {
-	spec := createDefinitionFromString(hmacAuthDef)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec := createSpecTest(t, hmacAuthDef)
 	session := createHMACAuthSession()
 
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
@@ -201,11 +189,7 @@ func TestHMACAuthSessionAuxDateHeader(t *testing.T) {
 }
 
 func TestHMACAuthSessionFailureDateExpired(t *testing.T) {
-	spec := createDefinitionFromString(hmacAuthDef)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec := createSpecTest(t, hmacAuthDef)
 	session := createHMACAuthSession()
 
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
@@ -255,11 +239,7 @@ func TestHMACAuthSessionFailureDateExpired(t *testing.T) {
 }
 
 func TestHMACAuthSessionKeyMissing(t *testing.T) {
-	spec := createDefinitionFromString(hmacAuthDef)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec := createSpecTest(t, hmacAuthDef)
 	session := createHMACAuthSession()
 
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
@@ -309,11 +289,7 @@ func TestHMACAuthSessionKeyMissing(t *testing.T) {
 }
 
 func TestHMACAuthSessionMalformedHeader(t *testing.T) {
-	spec := createDefinitionFromString(hmacAuthDef)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec := createSpecTest(t, hmacAuthDef)
 	session := createHMACAuthSession()
 
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
@@ -363,11 +339,7 @@ func TestHMACAuthSessionMalformedHeader(t *testing.T) {
 }
 
 func TestHMACAuthSessionPassWithHeaderField(t *testing.T) {
-	spec := createDefinitionFromString(hmacAuthDef)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec := createSpecTest(t, hmacAuthDef)
 	session := createHMACAuthSession()
 
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
@@ -444,11 +416,7 @@ func replaceUpperCase(originalSignature string, lowercaseList []string) string {
 }
 
 func TestHMACAuthSessionPassWithHeaderFieldLowerCase(t *testing.T) {
-	spec := createDefinitionFromString(hmacAuthDef)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec := createSpecTest(t, hmacAuthDef)
 	session := createHMACAuthSession()
 
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.

--- a/middleware_ip_whitelist_test.go
+++ b/middleware_ip_whitelist_test.go
@@ -159,13 +159,9 @@ var ipMiddlewareTestDefinitionMissing = `
 	}
 `
 
-func makeIPSampleAPI(apiTestDef string) *APISpec {
+func createIPSampleAPI(t *testing.T, apiTestDef string) *APISpec {
 	log.Debug("CREATING TEMPORARY API FOR IP WHITELIST")
-	spec := createDefinitionFromString(apiTestDef)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec := createSpecTest(t, apiTestDef)
 
 	specs := &[]*APISpec{spec}
 	newMuxes := mux.NewRouter()
@@ -181,11 +177,7 @@ func makeIPSampleAPI(apiTestDef string) *APISpec {
 }
 
 func TestIpMiddlewareIPFail(t *testing.T) {
-	spec := makeIPSampleAPI(ipMiddlewareTestDefinitionEnabledFail)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec := createIPSampleAPI(t, ipMiddlewareTestDefinitionEnabledFail)
 	session := createNonThrottledSession()
 	spec.SessionManager.UpdateSession("1234wer", session, 60)
 	uri := "/"
@@ -210,11 +202,7 @@ func TestIpMiddlewareIPFail(t *testing.T) {
 }
 
 func TestIpMiddlewareIPPass(t *testing.T) {
-	spec := makeIPSampleAPI(ipMiddlewareTestDefinitionEnabledPass)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec := createIPSampleAPI(t, ipMiddlewareTestDefinitionEnabledPass)
 	session := createNonThrottledSession()
 	spec.SessionManager.UpdateSession("gfgg1234", session, 60)
 	uri := "/"
@@ -239,11 +227,7 @@ func TestIpMiddlewareIPPass(t *testing.T) {
 }
 
 func TestIpMiddlewareIPPassCIDR(t *testing.T) {
-	spec := makeIPSampleAPI(ipMiddlewareTestDefinitionEnabledPass)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec := createIPSampleAPI(t, ipMiddlewareTestDefinitionEnabledPass)
 	session := createNonThrottledSession()
 	spec.SessionManager.UpdateSession("gfgg1234", session, 60)
 	uri := "/"
@@ -268,11 +252,7 @@ func TestIpMiddlewareIPPassCIDR(t *testing.T) {
 }
 
 func TestIPMiddlewareIPFailXForwardedFor(t *testing.T) {
-	spec := makeIPSampleAPI(ipMiddlewareTestDefinitionEnabledPass)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec := createIPSampleAPI(t, ipMiddlewareTestDefinitionEnabledPass)
 	session := createNonThrottledSession()
 	spec.SessionManager.UpdateSession("gfgg1234", session, 60)
 	uri := "/"
@@ -297,11 +277,7 @@ func TestIPMiddlewareIPFailXForwardedFor(t *testing.T) {
 }
 
 func TestIPMiddlewareIPPassXForwardedFor(t *testing.T) {
-	spec := makeIPSampleAPI(ipMiddlewareTestDefinitionEnabledPass)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec := createIPSampleAPI(t, ipMiddlewareTestDefinitionEnabledPass)
 	session := createNonThrottledSession()
 	spec.SessionManager.UpdateSession("gfgg1234", session, 60)
 	uri := "/"
@@ -327,11 +303,7 @@ func TestIPMiddlewareIPPassXForwardedFor(t *testing.T) {
 }
 
 func TestIpMiddlewareIPMissing(t *testing.T) {
-	spec := makeIPSampleAPI(ipMiddlewareTestDefinitionMissing)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec := createIPSampleAPI(t, ipMiddlewareTestDefinitionMissing)
 	session := createNonThrottledSession()
 	spec.SessionManager.UpdateSession("1234rtyrty", session, 60)
 	uri := "/"
@@ -355,11 +327,7 @@ func TestIpMiddlewareIPMissing(t *testing.T) {
 }
 
 func TestIpMiddlewareIPDisabled(t *testing.T) {
-	spec := makeIPSampleAPI(ipMiddlewareTestDefinitionDisabled)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec := createIPSampleAPI(t, ipMiddlewareTestDefinitionDisabled)
 	session := createNonThrottledSession()
 	spec.SessionManager.UpdateSession("1234iuouio", session, 60)
 	uri := "/"

--- a/middleware_jwt_test.go
+++ b/middleware_jwt_test.go
@@ -274,10 +274,6 @@ func createJWTSessionWithRSAWithPolicy() SessionState {
 }
 
 func getJWTChain(spec *APISpec) http.Handler {
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
 	remote, _ := url.Parse("http://example.com/")
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
 	proxyHandler := http.HandlerFunc(ProxyHandler(proxy, spec))
@@ -295,12 +291,8 @@ func getJWTChain(spec *APISpec) http.Handler {
 
 func TestJWTSessionHMAC(t *testing.T) {
 	tokenKID := randSeq(10)
-	spec := createDefinitionFromString(jwtDef)
+	spec := createSpecTest(t, jwtDef)
 	spec.JWTSigningMethod = "hmac"
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
 	session := createJWTSession()
 	spec.SessionManager.UpdateSession(tokenKID, session, 60)
 
@@ -339,12 +331,8 @@ func TestJWTSessionHMAC(t *testing.T) {
 
 func TestJWTSessionRSA(t *testing.T) {
 	tokenKID := randSeq(10)
-	spec := createDefinitionFromString(jwtDef)
+	spec := createSpecTest(t, jwtDef)
 	spec.JWTSigningMethod = "rsa"
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
 	session := createJWTSessionWithRSA()
 	spec.SessionManager.UpdateSession(tokenKID, session, 60)
 
@@ -387,12 +375,8 @@ func TestJWTSessionRSA(t *testing.T) {
 
 func TestJWTSessionFailRSA_EmptyJWT(t *testing.T) {
 	tokenKID := randSeq(10)
-	spec := createDefinitionFromString(jwtDef)
+	spec := createSpecTest(t, jwtDef)
 	spec.JWTSigningMethod = "rsa"
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
 	session := createJWTSessionWithRSA()
 	spec.SessionManager.UpdateSession(tokenKID, session, 60)
 
@@ -437,12 +421,8 @@ func TestJWTSessionFailRSA_EmptyJWT(t *testing.T) {
 
 func TestJWTSessionFailRSA_NoAuthHeader(t *testing.T) {
 	tokenKID := randSeq(10)
-	spec := createDefinitionFromString(jwtDef)
+	spec := createSpecTest(t, jwtDef)
 	spec.JWTSigningMethod = "rsa"
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
 	session := createJWTSessionWithRSA()
 	spec.SessionManager.UpdateSession(tokenKID, session, 60)
 
@@ -484,12 +464,8 @@ func TestJWTSessionFailRSA_NoAuthHeader(t *testing.T) {
 
 func TestJWTSessionFailRSA_MalformedJWT(t *testing.T) {
 	tokenKID := randSeq(10)
-	spec := createDefinitionFromString(jwtDef)
+	spec := createSpecTest(t, jwtDef)
 	spec.JWTSigningMethod = "rsa"
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
 	session := createJWTSessionWithRSA()
 	spec.SessionManager.UpdateSession(tokenKID, session, 60)
 
@@ -534,13 +510,9 @@ func TestJWTSessionFailRSA_MalformedJWT(t *testing.T) {
 
 func TestJWTSessionFailRSA_MalformedJWT_NOTRACK(t *testing.T) {
 	tokenKID := randSeq(10)
-	spec := createDefinitionFromString(jwtDef)
+	spec := createSpecTest(t, jwtDef)
 	spec.DoNotTrack = true
 	spec.JWTSigningMethod = "rsa"
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
 	session := createJWTSessionWithRSA()
 	spec.SessionManager.UpdateSession(tokenKID, session, 60)
 
@@ -585,12 +557,8 @@ func TestJWTSessionFailRSA_MalformedJWT_NOTRACK(t *testing.T) {
 
 func TestJWTSessionFailRSA_WrongJWT(t *testing.T) {
 	tokenKID := randSeq(10)
-	spec := createDefinitionFromString(jwtDef)
+	spec := createSpecTest(t, jwtDef)
 	spec.JWTSigningMethod = "rsa"
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
 	session := createJWTSessionWithRSA()
 	spec.SessionManager.UpdateSession(tokenKID, session, 60)
 
@@ -635,12 +603,8 @@ func TestJWTSessionFailRSA_WrongJWT(t *testing.T) {
 
 func TestJWTSessionRSABearer(t *testing.T) {
 	tokenKID := randSeq(10)
-	spec := createDefinitionFromString(jwtDef)
+	spec := createSpecTest(t, jwtDef)
 	spec.JWTSigningMethod = "rsa"
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
 	session := createJWTSessionWithRSA()
 	spec.SessionManager.ResetQuota(tokenKID, session)
 	spec.SessionManager.UpdateSession(tokenKID, session, 60)
@@ -684,12 +648,8 @@ func TestJWTSessionRSABearer(t *testing.T) {
 
 func TestJWTSessionRSABearerInvalid(t *testing.T) {
 	tokenKID := randSeq(10)
-	spec := createDefinitionFromString(jwtDef)
+	spec := createSpecTest(t, jwtDef)
 	spec.JWTSigningMethod = "rsa"
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
 	session := createJWTSessionWithRSA()
 	spec.SessionManager.UpdateSession(tokenKID, session, 60)
 
@@ -732,12 +692,8 @@ func TestJWTSessionRSABearerInvalid(t *testing.T) {
 }
 
 func TestJWTSessionRSAWithRawSourceOnWithClientID(t *testing.T) {
-	spec := createDefinitionFromString(jwtWithCentralDefNoPolicyBaseField)
+	spec := createSpecTest(t, jwtWithCentralDefNoPolicyBaseField)
 	spec.JWTSigningMethod = "rsa"
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
 
 	tokenID := "1234567891010101"
 	session := createJWTSessionWithRSAWithPolicy()
@@ -799,12 +755,8 @@ func TestJWTSessionRSAWithRawSourceOnWithClientID(t *testing.T) {
 }
 
 func TestJWTSessionRSAWithRawSource(t *testing.T) {
-	spec := createDefinitionFromString(jwtWithCentralDef)
+	spec := createSpecTest(t, jwtWithCentralDef)
 	spec.JWTSigningMethod = "rsa"
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
 
 	Policies["987654321"] = Policy{
 		ID:               "987654321",
@@ -859,12 +811,8 @@ func TestJWTSessionRSAWithRawSource(t *testing.T) {
 }
 
 func TestJWTSessionRSAWithRawSourceInvalidPolicyID(t *testing.T) {
-	spec := createDefinitionFromString(jwtWithCentralDef)
+	spec := createSpecTest(t, jwtWithCentralDef)
 	spec.JWTSigningMethod = "rsa"
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
 
 	Policies["987654321"] = Policy{
 		ID:               "987654321",
@@ -919,12 +867,8 @@ func TestJWTSessionRSAWithRawSourceInvalidPolicyID(t *testing.T) {
 }
 
 func TestJWTSessionRSAWithJWK(t *testing.T) {
-	spec := createDefinitionFromString(jwtWithJWKDef)
+	spec := createSpecTest(t, jwtWithJWKDef)
 	spec.JWTSigningMethod = "rsa"
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
 
 	Policies["987654321"] = Policy{
 		ID:               "987654321",

--- a/multiauth_test.go
+++ b/multiauth_test.go
@@ -88,10 +88,6 @@ func createMultiBasicAuthSession() SessionState {
 }
 
 func getMultiAuthStandardAndBasicAuthChain(spec *APISpec) http.Handler {
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
 	remote, _ := url.Parse("http://example.com/")
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
 	proxyHandler := http.HandlerFunc(ProxyHandler(proxy, spec))
@@ -109,11 +105,7 @@ func getMultiAuthStandardAndBasicAuthChain(spec *APISpec) http.Handler {
 }
 
 func TestMultiSession_BA_Standard_OK(t *testing.T) {
-	spec := createDefinitionFromString(multiAuthDev)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec := createSpecTest(t, multiAuthDev)
 
 	// Create BA
 	baSession := createMultiBasicAuthSession()
@@ -152,11 +144,7 @@ func TestMultiSession_BA_Standard_OK(t *testing.T) {
 }
 
 func TestMultiSession_BA_Standard_Identity(t *testing.T) {
-	spec := createDefinitionFromString(multiAuthDev)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec := createSpecTest(t, multiAuthDev)
 
 	// Create BA
 	baSession := createMultiBasicAuthSession()
@@ -200,11 +188,7 @@ func TestMultiSession_BA_Standard_Identity(t *testing.T) {
 }
 
 func TestMultiSession_BA_Standard_FAILBA(t *testing.T) {
-	spec := createDefinitionFromString(multiAuthDev)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec := createSpecTest(t, multiAuthDev)
 
 	// Create BA
 	baSession := createMultiBasicAuthSession()
@@ -243,11 +227,7 @@ func TestMultiSession_BA_Standard_FAILBA(t *testing.T) {
 }
 
 func TestMultiSession_BA_Standard_FAILAuth(t *testing.T) {
-	spec := createDefinitionFromString(multiAuthDev)
-	redisStore := RedisClusterStorageManager{KeyPrefix: "apikey-"}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-	spec.Init(&redisStore, &redisStore, healthStore, orgStore)
+	spec := createSpecTest(t, multiAuthDev)
 
 	// Create BA
 	baSession := createMultiBasicAuthSession()


### PR DESCRIPTION
Also add *testing.T to the whole flow in preparation for using t.Name()
to use unique key prefixes.