### PR TITLE
test: don't set up global analytics three times

### DIFF
--- a/gateway_test.go
+++ b/gateway_test.go
@@ -776,16 +776,7 @@ func TestQuota(t *testing.T) {
 	}
 }
 
-func TestWithAnalyticsTestWithAnalytics(t *testing.T) {
-	AnalyticsStore := RedisClusterStorageManager{KeyPrefix: "analytics-"}
-	log.Info("Setting up analytics DB connection")
-
-	analytics = RedisAnalyticsHandler{
-		Store: &AnalyticsStore,
-	}
-	analytics.Store.Connect()
-	analytics.Init()
-
+func TestWithAnalytics(t *testing.T) {
 	spec := createNonVersionedDefinition()
 	specInitTest(t, spec)
 	session := createNonThrottledSession()
@@ -821,15 +812,6 @@ func TestWithAnalyticsTestWithAnalytics(t *testing.T) {
 }
 
 func TestWithAnalyticsErrorResponse(t *testing.T) {
-	AnalyticsStore := RedisClusterStorageManager{KeyPrefix: "analytics-"}
-	log.Info("Setting up analytics DB connection")
-
-	analytics = RedisAnalyticsHandler{
-		Store: &AnalyticsStore,
-	}
-	analytics.Store.Connect()
-	analytics.Init()
-
 	spec := createNonVersionedDefinition()
 	specInitTest(t, spec)
 	session := createNonThrottledSession()


### PR DESCRIPTION
It's already set in initialiseSystem, and the two other times we set it
up in tests it's with an equal store. Moreover, this is a global so it
ends in data races when 'go test -race' is used.

Since it's a global we can't use a per-test unique KeyPrefix, so just
give up and set it up in TestMain.

Also fix the stutter in the test name.