### PR TITLE
Remove all uses of *[]*Foo

### DIFF
--- a/api_definition_manager.go
+++ b/api_definition_manager.go
@@ -239,7 +239,7 @@ func (a *APIDefinitionLoader) readBody(response *http.Response) ([]byte, error) 
 }
 
 // LoadDefinitionsFromDashboardService will connect and download ApiDefintions from a Tyk Dashboard instance.
-func (a *APIDefinitionLoader) LoadDefinitionsFromDashboardService(endpoint string, secret string) *[]*APISpec {
+func (a *APIDefinitionLoader) LoadDefinitionsFromDashboardService(endpoint string, secret string) []*APISpec {
 	var APISpecs = []*APISpec{}
 
 	// Get the definitions
@@ -261,20 +261,20 @@ func (a *APIDefinitionLoader) LoadDefinitionsFromDashboardService(endpoint strin
 	response, err := c.Do(newRequest)
 	if err != nil {
 		log.Error("Request failed: ", err)
-		return &APISpecs
+		return APISpecs
 	}
 
 	retBody, err := a.readBody(response)
 	if err != nil {
 		log.Error("Failed to read body: ", err)
-		return &APISpecs
+		return APISpecs
 	}
 
 	if response.StatusCode == 403 {
 		log.Error("Login failure, Response was: ", string(retBody))
 		reloadScheduled = false
 		ReLogin()
-		return &APISpecs
+		return APISpecs
 	}
 
 	// Extract tagged APIs#
@@ -293,14 +293,13 @@ func (a *APIDefinitionLoader) LoadDefinitionsFromDashboardService(endpoint strin
 	if err := json.Unmarshal(retBody, &list); err != nil {
 		log.Error("Failed to decode body: ", err, "Response was: ", string(retBody))
 		log.Info("--> Retrying in 5s")
-		return &APISpecs
-		// return &APISpecs
+		return APISpecs
 	}
 
 	rawList := make(map[string]interface{})
 	if err := json.Unmarshal(retBody, &rawList); err != nil {
 		log.Error("Failed to decode body (raw): ", err)
-		return &APISpecs
+		return APISpecs
 	}
 
 	// Extract tagged entries only
@@ -345,11 +344,11 @@ func (a *APIDefinitionLoader) LoadDefinitionsFromDashboardService(endpoint strin
 	ServiceNonce = list.Nonce
 	log.Debug("Loading APIS Finished: Nonce Set: ", ServiceNonce)
 
-	return &APISpecs
+	return APISpecs
 }
 
 // LoadDefinitionsFromCloud will connect and download ApiDefintions from a Mongo DB instance.
-func (a *APIDefinitionLoader) LoadDefinitionsFromRPC(orgId string) *[]*APISpec {
+func (a *APIDefinitionLoader) LoadDefinitionsFromRPC(orgId string) []*APISpec {
 	store := RPCStorageHandler{UserKey: config.SlaveOptions.APIKey, Address: config.SlaveOptions.ConnectionString}
 	store.Connect()
 
@@ -373,7 +372,7 @@ func (a *APIDefinitionLoader) LoadDefinitionsFromRPC(orgId string) *[]*APISpec {
 	return a.processRPCDefinitions(apiCollection)
 }
 
-func (a *APIDefinitionLoader) processRPCDefinitions(apiCollection string) *[]*APISpec {
+func (a *APIDefinitionLoader) processRPCDefinitions(apiCollection string) []*APISpec {
 	var APISpecs = []*APISpec{}
 
 	var APIDefinitions = []*apidef.APIDefinition{}
@@ -406,7 +405,7 @@ func (a *APIDefinitionLoader) processRPCDefinitions(apiCollection string) *[]*AP
 		APISpecs = append(APISpecs, newAppSpec)
 	}
 
-	return &APISpecs
+	return APISpecs
 }
 
 func (a *APIDefinitionLoader) ParseDefinition(apiDef []byte) (*apidef.APIDefinition, map[string]interface{}) {
@@ -425,7 +424,7 @@ func (a *APIDefinitionLoader) ParseDefinition(apiDef []byte) (*apidef.APIDefinit
 
 // LoadDefinitions will load APIDefinitions from a directory on the filesystem. Definitions need
 // to be the JSON representation of APIDefinition object
-func (a *APIDefinitionLoader) LoadDefinitions(dir string) *[]*APISpec {
+func (a *APIDefinitionLoader) LoadDefinitions(dir string) []*APISpec {
 	var APISpecs = []*APISpec{}
 	// Grab json files from directory
 	files, _ := ioutil.ReadDir(dir)
@@ -447,7 +446,7 @@ func (a *APIDefinitionLoader) LoadDefinitions(dir string) *[]*APISpec {
 		}
 	}
 
-	return &APISpecs
+	return APISpecs
 }
 
 func (a *APIDefinitionLoader) getPathSpecs(apiVersionDef apidef.VersionInfo) ([]URLSpec, bool) {

--- a/api_loader.go
+++ b/api_loader.go
@@ -40,9 +40,9 @@ func prepareStorage() (*RedisClusterStorageManager, *RedisClusterStorageManager,
 	return &redisStore, &redisOrgStore, healthStore, &rpcAuthStore, &rpcOrgStore
 }
 
-func prepareSortOrder(APISpecs *[]*APISpec) {
-	sort.Sort(SortableAPISpecListByHost(*APISpecs))
-	sort.Sort(SortableAPISpecListByListen(*APISpecs))
+func prepareSortOrder(APISpecs []*APISpec) {
+	sort.Sort(SortableAPISpecListByHost(APISpecs))
+	sort.Sort(SortableAPISpecListByListen(APISpecs))
 }
 
 func skipSpecBecauseInvalid(referenceSpec *APISpec) bool {
@@ -93,9 +93,9 @@ func generateDomainPath(hostname string, listenPath string) string {
 	return hostname + listenPath
 }
 
-func generateListenPathMap(APISpecs *[]*APISpec) {
+func generateListenPathMap(APISpecs []*APISpec) {
 	// We must track the hostname no matter what
-	for _, referenceSpec := range *APISpecs {
+	for _, referenceSpec := range APISpecs {
 		domainHash := generateDomainPath(referenceSpec.Domain, referenceSpec.Proxy.ListenPath)
 		val, ok := ListenPathMap.Get(domainHash)
 		if ok {
@@ -554,7 +554,7 @@ func (d *DummyProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // Create the individual API (app) specs based on live configurations and assign middleware
-func loadApps(APISpecs *[]*APISpec, Muxer *mux.Router) {
+func loadApps(APISpecs []*APISpec, Muxer *mux.Router) {
 	ListenPathMap = cmap.New()
 	// load the APi defs
 	log.WithFields(logrus.Fields{
@@ -571,9 +571,9 @@ func loadApps(APISpecs *[]*APISpec, Muxer *mux.Router) {
 	chainChannel := make(chan *ChainObject)
 
 	// Create a new handler for each API spec
-	loadList := make([]*ChainObject, len(*APISpecs))
+	loadList := make([]*ChainObject, len(APISpecs))
 	generateListenPathMap(APISpecs)
-	for i, referenceSpec := range *APISpecs {
+	for i, referenceSpec := range APISpecs {
 		go func(referenceSpec *APISpec, i int) {
 			subrouter := Muxer
 			// Handle custom domains
@@ -594,7 +594,7 @@ func loadApps(APISpecs *[]*APISpec, Muxer *mux.Router) {
 		tmpSpecRegister[referenceSpec.APIDefinition.APIID] = referenceSpec
 	}
 
-	for range *APISpecs {
+	for range APISpecs {
 		chObj := <-chainChannel
 		loadList[chObj.Index] = chObj
 	}

--- a/api_test.go
+++ b/api_test.go
@@ -51,7 +51,7 @@ const apiTestDef = `{
 func makeSampleAPI(t *testing.T) *APISpec {
 	spec := createSpecTest(t, apiTestDef)
 
-	specs := &[]*APISpec{spec}
+	specs := []*APISpec{spec}
 	newMuxes := mux.NewRouter()
 	loadAPIEndpoints(newMuxes)
 	loadApps(specs, newMuxes)
@@ -606,6 +606,6 @@ func BenchmarkApiInsertReload(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		newMuxes := mux.NewRouter()
 		loadAPIEndpoints(newMuxes)
-		loadApps(&specs, newMuxes)
+		loadApps(specs, newMuxes)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -218,8 +218,8 @@ func buildConnStr(resource string) string {
 // Pull API Specs from configuration
 var APILoader = APIDefinitionLoader{}
 
-func getAPISpecs() *[]*APISpec {
-	var APISpecs *[]*APISpec
+func getAPISpecs() []*APISpec {
+	var APISpecs []*APISpec
 
 	if config.UseDBAppConfigs {
 
@@ -242,18 +242,18 @@ func getAPISpecs() *[]*APISpec {
 
 	log.WithFields(logrus.Fields{
 		"prefix": "main",
-	}).Printf("Detected %v APIs", len(*APISpecs))
+	}).Printf("Detected %v APIs", len(APISpecs))
 
 	if config.AuthOverride.ForceAuthProvider {
-		for i := range *APISpecs {
-			(*APISpecs)[i].AuthProvider = config.AuthOverride.AuthProvider
+		for i := range APISpecs {
+			APISpecs[i].AuthProvider = config.AuthOverride.AuthProvider
 
 		}
 	}
 
 	if config.AuthOverride.ForceSessionProvider {
-		for i := range *APISpecs {
-			(*APISpecs)[i].SessionProvider = config.AuthOverride.SessionProvider
+		for i := range APISpecs {
+			APISpecs[i].SessionProvider = config.AuthOverride.SessionProvider
 		}
 	}
 
@@ -709,7 +709,7 @@ func doReload() {
 	// load the specs
 	specs := getAPISpecs()
 
-	if len(*specs) == 0 {
+	if len(specs) == 0 {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Warning("No API Definitions found, not reloading")

--- a/middleware_ip_whitelist_test.go
+++ b/middleware_ip_whitelist_test.go
@@ -151,7 +151,7 @@ func createIPSampleAPI(t *testing.T, apiTestDef string) *APISpec {
 	log.Debug("CREATING TEMPORARY API FOR IP WHITELIST")
 	spec := createSpecTest(t, apiTestDef)
 
-	specs := &[]*APISpec{spec}
+	specs := []*APISpec{spec}
 	newMuxes := mux.NewRouter()
 	loadAPIEndpoints(newMuxes)
 	loadApps(specs, newMuxes)

--- a/oauth_manager_test.go
+++ b/oauth_manager_test.go
@@ -103,7 +103,7 @@ func getOAuthChain(spec *APISpec, Muxer *mux.Router) {
 func makeOAuthAPI(t *testing.T) *APISpec {
 	spec := createSpecTest(t, oauthDefinition)
 
-	specs := &[]*APISpec{spec}
+	specs := []*APISpec{spec}
 	newMuxes := mux.NewRouter()
 	loadAPIEndpoints(newMuxes)
 	loadApps(specs, newMuxes)

--- a/rpc_backup_handlers.go
+++ b/rpc_backup_handlers.go
@@ -51,7 +51,7 @@ func SaveRPCDefinitionsBackup(list string) {
 	}
 }
 
-func LoadDefinitionsFromRPCBackup() *[]*APISpec {
+func LoadDefinitionsFromRPCBackup() []*APISpec {
 	tagList := getTagListAsString()
 	checkKey := BackupKeyBase + tagList
 
@@ -78,11 +78,11 @@ func LoadDefinitionsFromRPCBackup() *[]*APISpec {
 	return a.processRPCDefinitions(apiListAsString)
 }
 
-func doLoadWithBackup(specs *[]*APISpec) {
+func doLoadWithBackup(specs []*APISpec) {
 
 	log.Warning("[RPC Backup] --> Load Policies too!")
 
-	if len(*specs) == 0 {
+	if len(specs) == 0 {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Warning("No API Definitions found, not loading backup")

--- a/service_discovery.go
+++ b/service_discovery.go
@@ -65,12 +65,12 @@ func (s *ServiceDiscovery) decodeToNameSpace(namespace string, jsonParsed *gabs.
 	return value
 }
 
-func (s *ServiceDiscovery) decodeToNameSpaceAsArray(namespace string, jsonParsed *gabs.Container) *[]*gabs.Container {
+func (s *ServiceDiscovery) decodeToNameSpaceAsArray(namespace string, jsonParsed *gabs.Container) []*gabs.Container {
 	log.Debug("Array Namespace: ", namespace)
 	log.Debug("Container: ", jsonParsed)
 	value, _ := jsonParsed.Path(namespace).Children()
 	log.Debug("Array value:", value)
-	return &value
+	return value
 }
 
 func (s *ServiceDiscovery) GetPortFromObject(host *string, obj *gabs.Container) {
@@ -153,10 +153,10 @@ func (s *ServiceDiscovery) isList(val string) bool {
 	return strings.HasPrefix(val, "[")
 }
 
-func (s *ServiceDiscovery) GetSubObjectFromList(objList *gabs.Container) *[]string {
+func (s *ServiceDiscovery) GetSubObjectFromList(objList *gabs.Container) []string {
 	hostList := []string{}
 	var hostname string
-	var set *[]*gabs.Container
+	var set []*gabs.Container
 	if s.endpointReturnsList {
 		// pre-process the object since we've nested it
 		set = s.decodeToNameSpaceAsArray(ARRAY_NAME, objList)
@@ -172,7 +172,7 @@ func (s *ServiceDiscovery) GetSubObjectFromList(objList *gabs.Container) *[]stri
 			switch parentData.(type) {
 			default:
 				log.Debug("parentData is not a string")
-				return &hostList
+				return hostList
 			case string:
 			}
 			// Now check if this string is a list
@@ -184,13 +184,13 @@ func (s *ServiceDiscovery) GetSubObjectFromList(objList *gabs.Container) *[]stri
 				set = s.decodeToNameSpaceAsArray(ARRAY_NAME, &subContainer)
 
 				// Hijack this here because we need to use a non-nested get
-				for _, item := range *set {
+				for _, item := range set {
 					log.Debug("Child in list: ", item)
 					hostname = s.GetObject(item) + s.targetPath
 					// Add to list
 					hostList = append(hostList, hostname)
 				}
-				return &hostList
+				return hostList
 			}
 			log.Debug("Not a list")
 			switch parentData.(type) {
@@ -208,7 +208,7 @@ func (s *ServiceDiscovery) GetSubObjectFromList(objList *gabs.Container) *[]stri
 	}
 
 	if set != nil {
-		for _, item := range *set {
+		for _, item := range set {
 			log.Debug("Child in list: ", item)
 			hostname = s.GetHostname(item) + s.targetPath
 			// Add to list
@@ -217,7 +217,7 @@ func (s *ServiceDiscovery) GetSubObjectFromList(objList *gabs.Container) *[]stri
 	} else {
 		log.Debug("Set is nil")
 	}
-	return &hostList
+	return hostList
 }
 
 func (s *ServiceDiscovery) GetSubObject(obj *gabs.Container) string {
@@ -263,14 +263,14 @@ func (s *ServiceDiscovery) ProcessRawData(rawData string) (*apidef.HostList, err
 			// Get all values
 			asList := s.GetSubObjectFromList(&jsonParsed)
 			log.Debug("Host list:", asList)
-			hostlist.Set(*asList)
+			hostlist.Set(asList)
 			return hostlist, nil
 		}
 
 		// Get the top value
 		list := s.GetSubObjectFromList(&jsonParsed)
 		var host string
-		for _, v := range *list {
+		for _, v := range list {
 			host = v
 			break
 		}
@@ -287,7 +287,7 @@ func (s *ServiceDiscovery) ProcessRawData(rawData string) (*apidef.HostList, err
 		log.Debug("Passing in: ", jsonParsed)
 
 		asList := s.GetSubObjectFromList(&jsonParsed)
-		hostlist.Set(*asList)
+		hostlist.Set(asList)
 		log.Debug("Got from object: ", hostlist)
 		return hostlist, nil
 	}


### PR DESCRIPTION
This only makes sense if the variable is a parameter and it is modified,
e.g. appended to. None of these fall under that case.

Note that there are still some `*[]Foo` around, but I'm leaving those for another day.

@lonelycode PTAL