### PR TITLE
Fix call to envconfig when setting conf defaults

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestWriteDefaultConf(t *testing.T) {
+	conf := &Config{}
+	WriteDefaultConf(conf)
+	if conf.ListenPort != 8080 {
+		t.Error("Expected ListenPort to be set to its default")
+	}
+	*conf = Config{}
+	os.Setenv("TYK_GW_LISTENPORT", "9090")
+	WriteDefaultConf(conf)
+	if conf.ListenPort != 9090 {
+		t.Error("Expected ListenPort to be set to 9090")
+	}
+}

--- a/config_utils.go
+++ b/config_utils.go
@@ -38,7 +38,7 @@ func WriteDefaultConf(conf *Config) {
 	conf.HideGeneratorHeader = false
 	conf.OauthRedirectUriSeparator = ""
 	newConfig, err := json.MarshalIndent(conf, "", "    ")
-	overrideErr := envconfig.Process(ENV_PREVIX, &conf)
+	overrideErr := envconfig.Process(ENV_PREVIX, conf)
 	if overrideErr != nil {
 		log.Error("Failed to process environment variables: ", overrideErr)
 	}


### PR DESCRIPTION
envconfig.Process requires a pointer to a struct (i.e. *Config), but
we're passing it a pointer to a pointer to a struct (**Config). This
results in envconfig apparently never being useful:

	ERROR Failed to process environment variables: specification must be a struct pointer

@buger @lonelycode this seems like a bad regression, perhaps it could go into a bugfix.