### PR TITLE
Make 'go test' hide all output by default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ You need to clone Tyk from GitHub to your GOPATH folder, or alternatively you ca
 ### Building the project
 You need to have working Go enironment: see [golang.org](https://golang.org/doc/code.html) for more info on how Go works with code.
 
-To build and test Tyk use built-in `go` commands: `go build` and `go test -v`. If you want to just test a subset of the project, you can pass the `-run` argument with name of the test.
+To build and test Tyk use built-in `go` commands: `go build` and `go test -v`. If you want to just test a subset of the project, you can pass the `-run` argument with name of the test. Note that logs are hidden by default when running the tests, which you can override by setting `TYK_LOGLEVEL=info`.
 
 ### Adding dependencies
 

--- a/api_test.go
+++ b/api_test.go
@@ -52,7 +52,6 @@ var apiTestDef = `
 `
 
 func makeSampleAPI(t *testing.T) *APISpec {
-	log.Debug("CREATING TEMPORARY API")
 	spec := createDefinitionFromString(apiTestDef)
 	specInitTest(t, spec)
 
@@ -66,8 +65,6 @@ func makeSampleAPI(t *testing.T) *APISpec {
 	newHttmMuxer.Handle("/", newMuxes)
 
 	http.DefaultServeMux = newHttmMuxer
-	log.Debug("TEST Reload complete")
-
 	return spec
 }
 
@@ -83,7 +80,6 @@ type testAPIDefinition struct {
 }
 
 func TestHealthCheckEndpoint(t *testing.T) {
-	log.Debug("TEST GET HEALTHCHECK")
 	uri := "/tyk/health/?api_id=1"
 	method := "GET"
 
@@ -173,7 +169,6 @@ func TestApiHandler(t *testing.T) {
 }
 
 func TestApiHandlerGetSingle(t *testing.T) {
-	log.Debug("TEST GET SINGLE API DEFINITION")
 	uri := "/tyk/apis/1"
 	method := "GET"
 	sampleKey := createSampleSession()
@@ -206,7 +201,6 @@ func TestApiHandlerGetSingle(t *testing.T) {
 }
 
 func TestApiHandlerPost(t *testing.T) {
-	log.Debug("TEST POST SINGLE API DEFINITION")
 	uri := "/tyk/apis/1"
 	method := "POST"
 
@@ -234,7 +228,6 @@ func TestApiHandlerPost(t *testing.T) {
 }
 
 func TestApiHandlerPostDbConfig(t *testing.T) {
-	log.Debug("TEST POST SINGLE API DEFINITION ON USE_DB_CONFIG")
 	uri := "/tyk/apis/1"
 	method := "POST"
 

--- a/main.go
+++ b/main.go
@@ -891,8 +891,10 @@ func initialiseSystem(arguments map[string]interface{}) {
 	}
 
 	if runningTests && os.Getenv("TYK_LOGLEVEL") == "" {
-		// `go test` without TYK_LOGLEVEL override
+		// `go test` without TYK_LOGLEVEL set defaults to no log
+		// output
 		log.Level = logrus.ErrorLevel
+		log.Out = ioutil.Discard
 	} else if dbg, _ := arguments["--debug"]; dbg == true {
 		log.Level = logrus.DebugLevel
 		log.WithFields(logrus.Fields{

--- a/oauth_manager.go
+++ b/oauth_manager.go
@@ -275,7 +275,7 @@ func (o *OAuthManager) HandleAuthorisation(r *http.Request, complete bool, sessi
 		}
 	}
 	if resp.IsError && resp.InternalError != nil {
-		fmt.Printf("ERROR: %s\n", resp.InternalError)
+		log.Error(resp.InternalError)
 	}
 
 	return resp

--- a/oauth_manager_test.go
+++ b/oauth_manager_test.go
@@ -95,7 +95,6 @@ func getOAuthChain(spec *APISpec, Muxer *mux.Router) {
 }
 
 func makeOAuthAPI(t *testing.T) *APISpec {
-	log.Debug("CREATING TEMPORARY API FOR OAUTH")
 	spec := createSpecTest(t, oauthDefinition)
 
 	specs := &[]*APISpec{spec}
@@ -106,8 +105,6 @@ func makeOAuthAPI(t *testing.T) *APISpec {
 	newHttpMux := http.NewServeMux()
 	newHttpMux.Handle("/", newMuxes)
 	http.DefaultServeMux = newHttpMux
-
-	log.Debug("OAUTH Test Reload complete")
 
 	return spec
 }
@@ -377,7 +374,6 @@ func getToken(t *testing.T) tokenData {
 	body, _ := ioutil.ReadAll(recorder.Body)
 	if err := json.Unmarshal(body, &response); err != nil {
 	}
-	log.Debug("TOKEN DATA: ", string(body))
 	return response
 }
 
@@ -406,7 +402,6 @@ func TestOAuthClientCredsGrant(t *testing.T) {
 	err := json.Unmarshal(body, &response)
 	if err != nil {
 	}
-	log.Debug("TOKEN DATA: ", string(body))
 	log.Info("Access token: ", response.AccessToken)
 
 	if recorder.Code != 200 {
@@ -602,7 +597,6 @@ func TestClientRefreshRequestDouble(t *testing.T) {
 	if err := json.Unmarshal(body, &responseData); err != nil {
 		t.Fatal("Decode failed:", err)
 	}
-	log.Debug("Refresh token body", string(body))
 	token, ok := responseData["refresh_token"].(string)
 	if !ok {
 		t.Fatal("No refresh token found")

--- a/redis_logrus_hook.go
+++ b/redis_logrus_hook.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/TykTechnologies/logrus"
@@ -30,7 +29,7 @@ func (hook *redisChannelHook) Fire(entry *logrus.Entry) error {
 
 	newEntry, fmtErr := hook.formatter.Format(entry)
 	if fmtErr != nil {
-		fmt.Println(fmtErr)
+		log.Error(fmtErr)
 		return nil
 	}
 


### PR DESCRIPTION
As discussed with @buger. This can still be overriden at any time, like:

    TYK_LOGLEVEL=info go test -run SomeTest