### PR TITLE
Make buddyworks and release scripts work with new versioning

### DIFF
--- a/utils/buddy_build.sh
+++ b/utils/buddy_build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 echo Set version number
-export VERSION=$(perl -n -e'/v(\d+).(\d+).(\d+).(\d+)/'' && print "$1\.$2\.$3\.$4"' version.go)
+export VERSION=$(perl -n -e'/v(\d+).(\d+).(\d+)/'' && print "$1\.$2\.$3"' version.go)
 
 echo Generating key
 [[ $(gpg --list-keys | grep -w 729EA673) ]] && echo "Key exists" || gpg --import build_key.key

--- a/utils/buddy_push.sh
+++ b/utils/buddy_push.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export VERSION=$(perl -n -e'/v(\d+).(\d+).(\d+).(\d+)/'' && print "$1\.$2\.$3\.$4"' version.go)
+export VERSION=$(perl -n -e'/v(\d+).(\d+).(\d+)/'' && print "$1\.$2\.$3"' version.go)
 
 export SOURCEBIN=tyk
 export CLIBIN=tyk-cli

--- a/utils/release.sh
+++ b/utils/release.sh
@@ -3,7 +3,7 @@
 # Super hacky release script
 
 # ----- SET THE VERSION NUMBER -----
-CURRENTVERS=$(perl -n -e'/v(\d+).(\d+).(\d+).(\d+)/'' && print "v$1\.$2\.$3\.$4"' version.go)
+CURRENTVERS=$(perl -n -e'/v(\d+).(\d+).(\d+)/'' && print "v$1\.$2\.$3"' version.go)
 
 echo "Current version is: " $CURRENTVERS
 

--- a/utils/release_nightly.sh
+++ b/utils/release_nightly.sh
@@ -4,7 +4,7 @@ set -e
 # Super hacky release script
 
 # ----- SET THE VERSION NUMBER -----
-CURRENTVERS=$(perl -n -e'/v(\d+).(\d+).(\d+).(\d+)/'' && print "v$1\.$2\.$3\.$4"' version.go)
+CURRENTVERS=$(perl -n -e'/v(\d+).(\d+).(\d+)/'' && print "v$1\.$2\.$3"' version.go)
 
 echo "Current version is: " $CURRENTVERS 
 DATE=$(date +'%m-%d-%Y')

--- a/utils/set-version.sh
+++ b/utils/set-version.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-CURRENTVERS=$(perl -n -e'/v(\d+).(\d+).(\d+).(\d+)/'' && print "v$1\.$2\.$3\.$4"' version.go)
+CURRENTVERS=$(perl -n -e'/v(\d+).(\d+).(\d+)/'' && print "v$1\.$2\.$3"' version.go)
 
 echo "Current version is: " $CURRENTVERS
 
@@ -9,10 +9,8 @@ echo -n "Minor version [ENTER]: "
 read min 
 echo -n "Patch version [ENTER]: "
 read patch 
-echo -n "Release version [ENTER]: "
-read rel 
 
-NEWVERSION="v$maj.$min.$patch.$rel"
+NEWVERSION="v$maj.$min.$patch"
 echo "Setting new version in source: " $NEWVERSION
 
-perl -pi -e 's/var VERSION string = \"(.*)\"/var VERSION string = \"'$NEWVERSION'\"/g' version.go
+perl -pi -e 's/var VERSION = \"(.*)\"/var VERSION = \"'$NEWVERSION'\"/g' version.go


### PR DESCRIPTION
There were similar fix in tyk-analytcs. Currently because of it we can’t build packages.