### PR TITLE
Don't overwrite log.Level with InfoLevel

### DIFF
--- a/main.go
+++ b/main.go
@@ -900,9 +900,6 @@ func initialiseSystem(arguments map[string]interface{}) {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Debug("Enabling debug-level output")
-	} else {
-		// default is info
-		log.Level = logrus.InfoLevel
 	}
 
 	filename := "/etc/tyk/tyk.conf"


### PR DESCRIPTION
When we run GetLogger(), that func already reads TYK_LOGLEVEL to set the
proper value, defaulting to InfoLevel. If we overwrite it here, we are
ignoring TYK_LOGLEVEL. For example:

	$ TYK_LOGLEVEL=error go test
	[prints all logs, including INFO]

I introduced this regression in 6c629371.

Fixes #466.

@buger I did open an issue this time. I'd do a regression test, but this isn't easy now that our logger level logic is split among multiple git repos. We can open an issue about it and I'll add the test once #390 is done.