### PR TITLE
Fix TestWriteDefaultConfig with -count 2

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -7,6 +7,7 @@ import (
 
 func TestWriteDefaultConf(t *testing.T) {
 	conf := &Config{}
+	os.Unsetenv("TYK_GW_LISTENPORT")
 	WriteDefaultConf(conf)
 	if conf.ListenPort != 8080 {
 		t.Error("Expected ListenPort to be set to its default")


### PR DESCRIPTION
I forgot to clear the environment, which means that the test may fail if
the dev's environment isn't what we expect. Even worse, it makes
subsequent runs of the same test fail:

	$ go test -run TestWriteDefaultConf -count 2
	--- FAIL: TestWriteDefaultConf (0.00s)
		config_test.go:12: Expected ListenPort to be set to its default