### PR TITLE
test: depend on a real redis server again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ matrix:
       env: LATEST_GO=true # run linters and report coverage
     - go: 1.8rc3
 
+services:
+  - redis-server
+
 install:
   - go install ./...
   - go get -u golang.org/x/tools/cmd/goimports github.com/{wadey/gocovmerge,mattn/goveralls}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,8 @@ You need to have working Go enironment: see [golang.org](https://golang.org/doc/
 
 To build and test Tyk use built-in `go` commands: `go build` and `go test -v`. If you want to just test a subset of the project, you can pass the `-run` argument with name of the test. Note that logs are hidden by default when running the tests, which you can override by setting `TYK_LOGLEVEL=info`.
 
+Currently in order for tests to pass, a **Redis host is required**. We know, this is terrible and should be handled with an interface, and it is, however in the current version there is a hard requirement for the application to have its default memory setup to use redis as part of a deployment, this is to make it easier to install the application for the end-user. Future versions will work around this, or we may drop the memory requirement. Simplest way to run Redis is to use official Docker image [https://hub.docker.com/_/redis/](https://hub.docker.com/_/redis/)
+
 ### Adding dependencies
 
 If your patch depends on new packages, ensure that they will be put in `/vendor` folder. Here at Tyk we use `govendor` for managing our dependencies. Adding new dependencies can be done using following command: `govendor fetch github.com/alicebob/miniredis`.

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -9,12 +9,10 @@ import (
 	"net/url"
 	"os"
 	"reflect"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/alicebob/miniredis"
 	"github.com/justinas/alice"
 )
 
@@ -23,21 +21,16 @@ func init() {
 }
 
 func TestMain(m *testing.M) {
-	s, err := miniredis.Run()
-	if err != nil {
-		panic(err)
-	}
 	WriteDefaultConf(&config)
+	var err error
 	config.AppPath, err = ioutil.TempDir("", "tyk-test-")
 	if err != nil {
 		panic(err)
 	}
-	config.Storage.Port, _ = strconv.Atoi(s.Port())
 	config.EnableAnalytics = true
 	initialiseSystem(map[string]interface{}{})
 	exitCode := m.Run()
 
-	s.Close()
 	os.RemoveAll(config.AppPath)
 	os.Exit(exitCode)
 }


### PR DESCRIPTION
Remove our use of miniredis. It's lacking pub/sub, which we need for
some upcoming tests.

Don't delete the vendored package yet, as we might use it again after
some tweaks like pub/sub support on top. If that happens, better not
pollute the history twice.

Updates #469.

cc @buger @lonelycode @matiasinsaurralde 