### PR TITLE
Simplify util_http copy funcs

### DIFF
--- a/util_http_helpers.go
+++ b/util_http_helpers.go
@@ -30,11 +30,6 @@ func GetIPFromRequest(r *http.Request) string {
 
 func CopyHttpRequest(r *http.Request) *http.Request {
 	reqCopy := new(http.Request)
-
-	if r == nil {
-		return reqCopy
-	}
-
 	*reqCopy = *r
 
 	if r.Body != nil {
@@ -56,12 +51,7 @@ func CopyHttpRequest(r *http.Request) *http.Request {
 }
 
 func CopyHttpResponse(r *http.Response) *http.Response {
-
 	resCopy := new(http.Response)
-	if r == nil {
-		return resCopy
-	}
-
 	*resCopy = *r
 
 	if r.Body != nil {


### PR DESCRIPTION
new() can never return nil. I presume this was done thinking of
languages that do when they OOM, but Go doesn't.