### PR TITLE
all: simplify error naming

### DIFF
--- a/api_definition_manager.go
+++ b/api_definition_manager.go
@@ -258,16 +258,15 @@ func (a *APIDefinitionLoader) LoadDefinitionsFromDashboardService(endpoint strin
 	c := &http.Client{
 		Timeout: 120 * time.Second,
 	}
-	response, reqErr := c.Do(newRequest)
-
-	if reqErr != nil {
-		log.Error("Request failed: ", reqErr)
+	response, err := c.Do(newRequest)
+	if err != nil {
+		log.Error("Request failed: ", err)
 		return &APISpecs
 	}
 
-	retBody, bErr := a.readBody(response)
-	if bErr != nil {
-		log.Error("Failed to read body: ", bErr)
+	retBody, err := a.readBody(response)
+	if err != nil {
+		log.Error("Failed to read body: ", err)
 		return &APISpecs
 	}
 
@@ -299,9 +298,8 @@ func (a *APIDefinitionLoader) LoadDefinitionsFromDashboardService(endpoint strin
 	}
 
 	rawList := make(map[string]interface{})
-	rawdecErr := json.Unmarshal(retBody, &rawList)
-	if rawdecErr != nil {
-		log.Error("Failed to decode body (raw): ", rawdecErr)
+	if err := json.Unmarshal(retBody, &rawList); err != nil {
+		log.Error("Failed to decode body (raw): ", err)
 		return &APISpecs
 	}
 
@@ -555,18 +553,18 @@ func (a *APIDefinitionLoader) compileTransformPathSpec(paths []apidef.TemplateMe
 		newTransformSpec := TransformSpec{TemplateMeta: stringSpec}
 
 		// Load the templates
-		var templErr error
+		var err error
 
 		switch stringSpec.TemplateData.Mode {
 		case apidef.UseFile:
 			log.Debug("-- Using File mode")
-			newTransformSpec.Template, templErr = a.loadFileTemplate(stringSpec.TemplateData.TemplateSource)
+			newTransformSpec.Template, err = a.loadFileTemplate(stringSpec.TemplateData.TemplateSource)
 		case apidef.UseBlob:
 			log.Debug("-- Blob mode")
-			newTransformSpec.Template, templErr = a.loadBlobTemplate(stringSpec.TemplateData.TemplateSource)
+			newTransformSpec.Template, err = a.loadBlobTemplate(stringSpec.TemplateData.TemplateSource)
 		default:
 			log.Warning("[Transform Templates] No template mode defined! Found: ", stringSpec.TemplateData.Mode)
-			templErr = errors.New("No valid template mode defined, must be either 'file' or 'blob'")
+			err = errors.New("No valid template mode defined, must be either 'file' or 'blob'")
 		}
 
 		if stat == Transformed {
@@ -575,11 +573,11 @@ func (a *APIDefinitionLoader) compileTransformPathSpec(paths []apidef.TemplateMe
 			newSpec.TransformResponseAction = newTransformSpec
 		}
 
-		if templErr == nil {
+		if err == nil {
 			urlSpec = append(urlSpec, newSpec)
 			log.Debug("-- Loaded")
 		} else {
-			log.Error("Template load failure! Skipping transformation: ", templErr)
+			log.Error("Template load failure! Skipping transformation: ", err)
 		}
 
 	}

--- a/api_healthcheck.go
+++ b/api_healthcheck.go
@@ -126,9 +126,9 @@ func (h *DefaultHealthChecker) GetApiHealthValues() (HealthCheckValues, error) {
 			log.Debug("V is: ", string(v.([]byte)))
 			splitValues := strings.Split(string(v.([]byte)), ".")
 			if len(splitValues) > 1 {
-				vInt, cErr := strconv.Atoi(splitValues[1])
-				if cErr != nil {
-					log.Error("Couldn't convert tracked latency value to Int, vl is: ", cErr)
+				vInt, err := strconv.Atoi(splitValues[1])
+				if err != nil {
+					log.Error("Couldn't convert tracked latency value to Int, vl is: ", err)
 				} else {
 					runningTotal += vInt
 				}

--- a/auth_manager.go
+++ b/auth_manager.go
@@ -60,9 +60,9 @@ func (b *DefaultAuthorisationManager) IsKeyAuthorised(keyName string) (SessionSt
 		return newSession, false
 	}
 
-	if marshalErr := json.Unmarshal([]byte(jsonKeyVal), &newSession); marshalErr != nil {
+	if err := json.Unmarshal([]byte(jsonKeyVal), &newSession); err != nil {
 		log.Error("Couldn't unmarshal session object")
-		log.Error(marshalErr)
+		log.Error(err)
 		return newSession, false
 	}
 
@@ -139,8 +139,8 @@ func (b *DefaultSessionManager) GetSessionDetail(keyName string) (SessionState, 
 		return session, false
 	}
 
-	if marshalErr := json.Unmarshal([]byte(jsonKeyVal), &session); marshalErr != nil {
-		log.Error("Couldn't unmarshal session object (may be cache miss): ", marshalErr)
+	if err := json.Unmarshal([]byte(jsonKeyVal), &session); err != nil {
+		log.Error("Couldn't unmarshal session object (may be cache miss): ", err)
 		return session, false
 	}
 

--- a/batch_requests.go
+++ b/batch_requests.go
@@ -40,17 +40,16 @@ type BatchRequestHandler struct {
 // doAsyncRequest runs an async request and replies to a channel
 func (b *BatchRequestHandler) doAsyncRequest(req *http.Request, relURL string, out chan BatchReplyUnit) {
 	client := &http.Client{}
-	resp, doReqErr := client.Do(req)
-
-	if doReqErr != nil {
-		log.Error("Webhook request failed: ", doReqErr)
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Error("Webhook request failed: ", err)
 		return
 	}
 
 	defer resp.Body.Close()
-	content, readErr := ioutil.ReadAll(resp.Body)
-	if readErr != nil {
-		log.Warning("Body read failure! ", readErr)
+	content, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Warning("Body read failure! ", err)
 		return
 	}
 
@@ -68,17 +67,16 @@ func (b *BatchRequestHandler) doAsyncRequest(req *http.Request, relURL string, o
 // doSyncRequest will make the same request but return a BatchReplyUnit
 func (b *BatchRequestHandler) doSyncRequest(req *http.Request, relURL string) BatchReplyUnit {
 	client := &http.Client{}
-	resp, doReqErr := client.Do(req)
-
-	if doReqErr != nil {
-		log.Error("Webhook request failed: ", doReqErr)
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Error("Webhook request failed: ", err)
 		return BatchReplyUnit{}
 	}
 
 	defer resp.Body.Close()
-	content, readErr := ioutil.ReadAll(resp.Body)
-	if readErr != nil {
-		log.Warning("Body read failure! ", readErr)
+	content, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Warning("Body read failure! ", err)
 		return BatchReplyUnit{}
 	}
 
@@ -93,11 +91,9 @@ func (b *BatchRequestHandler) doSyncRequest(req *http.Request, relURL string) Ba
 }
 
 func (b *BatchRequestHandler) DecodeBatchRequest(r *http.Request) (BatchRequestStructure, error) {
-	decoder := json.NewDecoder(r.Body)
 	var batchRequest BatchRequestStructure
-	decodeErr := decoder.Decode(&batchRequest)
-
-	return batchRequest, decodeErr
+	err := json.NewDecoder(r.Body).Decode(&batchRequest)
+	return batchRequest, err
 }
 
 func (b *BatchRequestHandler) ConstructRequests(batchRequest BatchRequestStructure, unsafe bool) ([]*http.Request, error) {
@@ -165,9 +161,9 @@ func (b *BatchRequestHandler) HandleBatchRequest(w http.ResponseWriter, r *http.
 	if r.Method == "POST" {
 
 		// Decode request
-		batchRequest, decodeErr := b.DecodeBatchRequest(r)
-		if decodeErr != nil {
-			log.Error("Could not decode batch request, decoding failed: ", decodeErr)
+		batchRequest, err := b.DecodeBatchRequest(r)
+		if err != nil {
+			log.Error("Could not decode batch request, decoding failed: ", err)
 			ReturnError("Batch request malformed", w)
 			return
 		}
@@ -183,9 +179,9 @@ func (b *BatchRequestHandler) HandleBatchRequest(w http.ResponseWriter, r *http.
 		ReplySet := b.MakeRequests(batchRequest, requestSet)
 
 		// Encode responses
-		replyMessage, encErr := json.Marshal(&ReplySet)
-		if encErr != nil {
-			log.Error("Couldn't encode response to string! ", encErr)
+		replyMessage, err := json.Marshal(&ReplySet)
+		if err != nil {
+			log.Error("Couldn't encode response to string! ", err)
 			return
 		}
 
@@ -200,10 +196,8 @@ func (b *BatchRequestHandler) ManualBatchRequest(RequestObject []byte) []byte {
 
 	// Decode request
 	var batchRequest BatchRequestStructure
-	decodeErr := json.Unmarshal(RequestObject, &batchRequest)
-
-	if decodeErr != nil {
-		log.Error("Could not decode batch request, decoding failed: ", decodeErr)
+	if err := json.Unmarshal(RequestObject, &batchRequest); err != nil {
+		log.Error("Could not decode batch request, decoding failed: ", err)
 		return []byte{}
 	}
 
@@ -218,9 +212,9 @@ func (b *BatchRequestHandler) ManualBatchRequest(RequestObject []byte) []byte {
 	ReplySet := b.MakeRequests(batchRequest, requestSet)
 
 	// Encode responses
-	replyMessage, encErr := json.Marshal(&ReplySet)
-	if encErr != nil {
-		log.Error("Couldn't encode response to string! ", encErr)
+	replyMessage, err := json.Marshal(&ReplySet)
+	if err != nil {
+		log.Error("Couldn't encode response to string! ", err)
 		return []byte{}
 	}
 

--- a/batch_requests_test.go
+++ b/batch_requests_test.go
@@ -86,9 +86,9 @@ func TestBatchSuccess(t *testing.T) {
 	r, _ := http.NewRequest("POST", "/vi/tyk/batch/", strings.NewReader(testBatchRequest))
 
 	// Test decode
-	batchRequest, decodeErr := batchHandler.DecodeBatchRequest(r)
-	if decodeErr != nil {
-		t.Error("Decode batch request body failed: ", decodeErr)
+	batchRequest, err := batchHandler.DecodeBatchRequest(r)
+	if err != nil {
+		t.Error("Decode batch request body failed: ", err)
 	}
 
 	if len(batchRequest.Requests) != 3 {
@@ -101,8 +101,8 @@ func TestBatchSuccess(t *testing.T) {
 
 	// Test request constructions:
 
-	requestSet, createReqErr := batchHandler.ConstructRequests(batchRequest, false)
-	if createReqErr != nil {
+	requestSet, err := batchHandler.ConstructRequests(batchRequest, false)
+	if err != nil {
 		t.Error("Batch request creation failed , request structure malformed")
 	}
 

--- a/blueprint.go
+++ b/blueprint.go
@@ -113,12 +113,10 @@ type BluePrintAST struct {
 }
 
 func (b *BluePrintAST) ReadString(asJson string) error {
-	marshallErr := json.Unmarshal([]byte(asJson), &b)
-	if marshallErr != nil {
-		log.Error("Marshalling failed: ", marshallErr)
+	if err := json.Unmarshal([]byte(asJson), &b); err != nil {
+		log.Error("Marshalling failed: ", err)
 		return errors.New("Could not unmarshal string for Bluprint AST object")
 	}
-
 	return nil
 }
 

--- a/command_mode.go
+++ b/command_mode.go
@@ -48,8 +48,8 @@ func handleBluePrintMode(arguments map[string]interface{}) {
 				return
 			}
 
-			def, dErr := createDefFromBluePrint(bp, orgId.(string), upstreamVal.(string), arguments["--as-mock"].(bool))
-			if dErr != nil {
+			def, err := createDefFromBluePrint(bp, orgId.(string), upstreamVal.(string), arguments["--as-mock"].(bool))
+			if err != nil {
 				log.Error("Failed to create API Defintition from file")
 				return
 			}
@@ -91,9 +91,8 @@ func handleBluePrintMode(arguments map[string]interface{}) {
 			log.Error("onversion into API Def failed: ", err)
 		}
 
-		insertErr := bp.InsertIntoAPIDefinitionAsVersion(versionData, defFromFile, versionName.(string))
-		if insertErr != nil {
-			log.Error("Insertion failed: ", insertErr)
+		if err := bp.InsertIntoAPIDefinitionAsVersion(versionData, defFromFile, versionName.(string)); err != nil {
+			log.Error("Insertion failed: ", err)
 			return
 		}
 
@@ -139,11 +138,10 @@ func createDefFromBluePrint(bp *BluePrintAST, orgId, upstreamURL string, as_mock
 }
 
 func bluePrintLoadFile(filePath string) (*BluePrintAST, error) {
-	blueprint, astErr := GetImporterForSource(ApiaryBluePrint)
-
-	if astErr != nil {
-		log.Error("Couldn't get blueprint importer: ", astErr)
-		return blueprint.(*BluePrintAST), astErr
+	blueprint, err := GetImporterForSource(ApiaryBluePrint)
+	if err != nil {
+		log.Error("Couldn't get blueprint importer: ", err)
+		return blueprint.(*BluePrintAST), err
 	}
 
 	bluePrintFileData, err := ioutil.ReadFile(filePath)
@@ -153,10 +151,9 @@ func bluePrintLoadFile(filePath string) (*BluePrintAST, error) {
 		return blueprint.(*BluePrintAST), err
 	}
 
-	readErr := blueprint.ReadString(string(bluePrintFileData))
-	if readErr != nil {
+	if err := blueprint.ReadString(string(bluePrintFileData)); err != nil {
 		log.Error("Failed to decode object")
-		return blueprint.(*BluePrintAST), readErr
+		return blueprint.(*BluePrintAST), err
 	}
 
 	return blueprint.(*BluePrintAST), nil
@@ -172,10 +169,9 @@ func apiDefLoadFile(filePath string) (*apidef.APIDefinition, error) {
 		return def, err
 	}
 
-	jsonErr := json.Unmarshal(defFileData, &def)
-	if jsonErr != nil {
-		log.Error("Failed to unmarshal the JSON definition: ", jsonErr)
-		return def, jsonErr
+	if err := json.Unmarshal(defFileData, &def); err != nil {
+		log.Error("Failed to unmarshal the JSON definition: ", err)
+		return def, err
 	}
 
 	return def, nil

--- a/config.go
+++ b/config.go
@@ -261,11 +261,10 @@ func WriteDefaultConf(conf *Config) {
 	conf.UseAsyncSessionWrite = false
 	conf.HideGeneratorHeader = false
 	conf.OauthRedirectUriSeparator = ""
-	newConfig, err := json.MarshalIndent(conf, "", "    ")
-	overrideErr := envconfig.Process(ENV_PREVIX, conf)
-	if overrideErr != nil {
-		log.Error("Failed to process environment variables: ", overrideErr)
+	if err := envconfig.Process(ENV_PREVIX, conf); err != nil {
+		log.Error("Failed to process environment variables: ", err)
 	}
+	newConfig, err := json.MarshalIndent(conf, "", "    ")
 	if err != nil {
 		log.Error("Problem marshalling default configuration!")
 		log.Error(err)
@@ -294,9 +293,8 @@ func loadConfig(filePath string, conf *Config) {
 			log.Error(err)
 		}
 
-		overrideErr := envconfig.Process(ENV_PREVIX, conf)
-		if overrideErr != nil {
-			log.Error("Failed to process environment variables after file load: ", overrideErr)
+		if err := envconfig.Process(ENV_PREVIX, conf); err != nil {
+			log.Error("Failed to process environment variables after file load: ", err)
 		}
 	}
 

--- a/coprocess.go
+++ b/coprocess.go
@@ -265,9 +265,8 @@ func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 
 	object := coProcessor.GetObjectFromRequest(r)
 
-	returnObject, dispatchErr := coProcessor.Dispatch(object)
-
-	if dispatchErr != nil {
+	returnObject, err := coProcessor.Dispatch(object)
+	if err != nil {
 		if m.HookType == coprocess.HookType_CustomKeyCheck {
 			return errors.New("Key not authorised"), 403
 		} else {

--- a/coprocess_bundle.go
+++ b/coprocess_bundle.go
@@ -330,8 +330,7 @@ func loadBundle(spec *APISpec) {
 	if err := loadBundleManifest(&bundle, spec, false); err != nil {
 		bundleError(spec, err, "Couldn't load bundle")
 
-		removeErr := os.RemoveAll(bundle.Path)
-		if removeErr != nil {
+		if err := os.RemoveAll(bundle.Path); err != nil {
 			bundleError(spec, err, "Couldn't remove bundle")
 		}
 		return

--- a/coprocess_events.go
+++ b/coprocess_events.go
@@ -36,9 +36,9 @@ func (l CoProcessEventHandler) New(handlerConf interface{}) (TykEventHandler, er
 		OrgID: l.Spec.OrgID,
 	}
 
-	gValAsJSON, gErr := json.Marshal(globalVals)
-	if gErr != nil {
-		log.Error("Failed to marshal globals! ", gErr)
+	gValAsJSON, err := json.Marshal(globalVals)
+	if err != nil {
+		log.Error("Failed to marshal globals! ", err)
 	}
 
 	// handler.SpecJSON = string(gValAsJSON)
@@ -58,9 +58,9 @@ func (l CoProcessEventHandler) HandleEvent(em EventMessage) {
 	}
 
 	// 2. JSON-encode the event data object
-	msgAsJSON, encErr := json.Marshal(eventWrapper)
-	if encErr != nil {
-		log.Error("Failed to encode event data: ", encErr)
+	msgAsJSON, err := json.Marshal(eventWrapper)
+	if err != nil {
+		log.Error("Failed to encode event data: ", err)
 		return
 	}
 

--- a/dashboard_register.go
+++ b/dashboard_register.go
@@ -83,10 +83,9 @@ func (h *HTTPDashboardHandler) Register() error {
 	c := &http.Client{
 		Timeout: 5 * time.Second,
 	}
-	response, reqErr := c.Do(newRequest)
-
-	if reqErr != nil {
-		log.Error("Request failed: ", reqErr)
+	response, err := c.Do(newRequest)
+	if err != nil {
+		log.Error("Request failed: ", err)
 		time.Sleep(time.Second * 5)
 		return h.Register()
 	}
@@ -106,10 +105,9 @@ func (h *HTTPDashboardHandler) Register() error {
 	}
 
 	val := NodeResponseOK{}
-	decErr := json.Unmarshal(retBody, &val)
-	if decErr != nil {
-		log.Error("Failed to decode body: ", decErr)
-		return decErr
+	if err := json.Unmarshal(retBody, &val); err != nil {
+		log.Error("Failed to decode body: ", err)
+		return err
 	}
 
 	// Set the NodeID
@@ -170,9 +168,8 @@ func (h *HTTPDashboardHandler) SendHeartBeat(endpoint string, secret string) err
 	c := &http.Client{
 		Timeout: 5 * time.Second,
 	}
-	response, reqErr := c.Do(newRequest)
-
-	if reqErr != nil || response.StatusCode != 200 {
+	response, err := c.Do(newRequest)
+	if err != nil || response.StatusCode != 200 {
 		return errors.New("dashboard is down? Heartbeat is failing")
 	}
 
@@ -184,10 +181,9 @@ func (h *HTTPDashboardHandler) SendHeartBeat(endpoint string, secret string) err
 	}
 
 	val := NodeResponseOK{}
-	decErr := json.Unmarshal(retBody, &val)
-	if decErr != nil {
-		log.Error("Failed to decode body: ", decErr)
-		return decErr
+	if err := json.Unmarshal(retBody, &val); err != nil {
+		log.Error("Failed to decode body: ", err)
+		return err
 	}
 
 	// Set the nonce
@@ -220,11 +216,10 @@ func (h *HTTPDashboardHandler) DeRegister() error {
 	c := &http.Client{
 		Timeout: 5 * time.Second,
 	}
-	response, reqErr := c.Do(newRequest)
-
-	if reqErr != nil {
-		log.Error("Dashboard is down? Failed fo de-register: ", reqErr)
-		return reqErr
+	response, err := c.Do(newRequest)
+	if err != nil {
+		log.Error("Dashboard is down? Failed fo de-register: ", err)
+		return err
 	}
 
 	if response.StatusCode != 200 {
@@ -240,10 +235,9 @@ func (h *HTTPDashboardHandler) DeRegister() error {
 	}
 
 	val := NodeResponseOK{}
-	decErr := json.Unmarshal(retBody, &val)
-	if decErr != nil {
-		log.Error("Failed to decode body: ", decErr)
-		return decErr
+	if err := json.Unmarshal(retBody, &val); err != nil {
+		log.Error("Failed to decode body: ", err)
+		return err
 	}
 
 	// Set the nonce

--- a/event_handler_webhooks.go
+++ b/event_handler_webhooks.go
@@ -175,11 +175,10 @@ func (w *WebHookHandler) checkURL(r string) bool {
 	log.WithFields(logrus.Fields{
 		"prefix": "webhooks",
 	}).Debug("Checking URL: ", r)
-	_, urlErr := url.ParseRequestURI(r)
-	if urlErr != nil {
+	if _, err := url.ParseRequestURI(r); err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "webhooks",
-		}).Error("Failed to parse URL! ", urlErr, r)
+		}).Error("Failed to parse URL! ", err, r)
 		return false
 	}
 	return true
@@ -205,12 +204,12 @@ func (w *WebHookHandler) GetChecksum(reqBody string) (string, error) {
 }
 
 func (w *WebHookHandler) BuildRequest(reqBody string) (*http.Request, error) {
-	req, reqErr := http.NewRequest(string(w.getRequestMethod(w.conf.Method)), w.conf.TargetPath, bytes.NewBuffer([]byte(reqBody)))
-	if reqErr != nil {
+	req, err := http.NewRequest(string(w.getRequestMethod(w.conf.Method)), w.conf.TargetPath, bytes.NewBuffer([]byte(reqBody)))
+	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "webhooks",
-		}).Error("Failed to create request object: ", reqErr)
-		return nil, reqErr
+		}).Error("Failed to create request object: ", err)
+		return nil, err
 	}
 
 	req.Header.Add("User-Agent", "Tyk-Hookshot")
@@ -236,8 +235,8 @@ func (w *WebHookHandler) HandleEvent(em EventMessage) {
 	reqBody, _ := w.CreateBody(em)
 
 	// Construct request (method, body, params)
-	req, reqErr := w.BuildRequest(reqBody)
-	if reqErr != nil {
+	req, err := w.BuildRequest(reqBody)
+	if err != nil {
 		return
 	}
 
@@ -249,23 +248,23 @@ func (w *WebHookHandler) HandleEvent(em EventMessage) {
 		// Fire web hook routine (setHookFired())
 
 		client := &http.Client{}
-		resp, doReqErr := client.Do(req)
+		resp, err := client.Do(req)
 
-		if doReqErr != nil {
+		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "webhooks",
-			}).Error("Webhook request failed: ", doReqErr)
+			}).Error("Webhook request failed: ", err)
 		} else {
 			defer resp.Body.Close()
-			content, readErr := ioutil.ReadAll(resp.Body)
-			if readErr == nil {
+			content, err := ioutil.ReadAll(resp.Body)
+			if err == nil {
 				log.WithFields(logrus.Fields{
 					"prefix": "webhooks",
 				}).Debug(string(content))
 			} else {
 				log.WithFields(logrus.Fields{
 					"prefix": "webhooks",
-				}).Error(readErr)
+				}).Error(err)
 			}
 		}
 

--- a/event_system.go
+++ b/event_system.go
@@ -144,9 +144,8 @@ func GetEventHandlerByName(handlerConf apidef.EventHandlerTriggerConfig, Spec *A
 		if ok != nil {
 			log.Error("Failed to unmarshal handler meta! ", ok)
 		}
-		mErr := json.Unmarshal(asByte, &conf)
-		if mErr != nil {
-			log.Error("Return conversion failed, ", mErr)
+		if err := json.Unmarshal(asByte, &conf); err != nil {
+			log.Error("Return conversion failed, ", err)
 		}
 	default:
 		conf = handlerConf.HandlerMeta

--- a/handler_error.go
+++ b/handler_error.go
@@ -53,7 +53,7 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, err s
 		var tmpl *template.Template
 		templateName := fmt.Sprintf("error_%s.%s", strconv.Itoa(errCode), templateExtension)
 
-		// templateError := templates.ExecuteTemplate(w, templateName, &apiErr)
+		// templateError := templates.ExecuteTemplate(w, templateName, &apiError)
 
 		// Try to use an error template that matches the HTTP error code and the content type: 500.json, 400.xml, etc.
 		tmpl = templates.Lookup(templateName)
@@ -74,8 +74,8 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, err s
 		// Need to return the correct error code!
 		w.WriteHeader(errCode)
 
-		apiErr := APIError{fmt.Sprintf("%s", err)}
-		tmpl.Execute(w, &apiErr)
+		apiError := APIError{fmt.Sprintf("%s", err)}
+		tmpl.Execute(w, &apiError)
 
 		if doMemoryProfile {
 			pprof.WriteHeapProfile(profileFile)
@@ -225,7 +225,7 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, err s
 	}
 
 	var ip string
-	if clientIP, _, derr := net.SplitHostPort(r.RemoteAddr); derr == nil {
+	if clientIP, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
 		// If we aren't the first proxy retain prior
 		// X-Forwarded-For information as a comma+space
 		// separated list and fold multiple headers into one.
@@ -246,8 +246,8 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, err s
 
 	log.Debug("Returning error header")
 	w.WriteHeader(errCode)
-	apiErr := APIError{fmt.Sprintf("%s", err)}
-	templates.ExecuteTemplate(w, "error.json", &apiErr)
+	apiError := APIError{fmt.Sprintf("%s", err)}
+	templates.ExecuteTemplate(w, "error.json", &apiError)
 	if doMemoryProfile {
 		pprof.WriteHeapProfile(profileFile)
 	}

--- a/host_checker.go
+++ b/host_checker.go
@@ -140,9 +140,6 @@ func (h *HostUptimeChecker) CheckHost(toCheck HostData) {
 
 	t1 := time.Now()
 
-	var response *http.Response
-	var respErr error
-
 	useMethod := toCheck.Method
 	if toCheck.Method == "" {
 		useMethod = "GET"
@@ -159,7 +156,7 @@ func (h *HostUptimeChecker) CheckHost(toCheck HostData) {
 	}
 	req.Header.Set("Connection", "close")
 
-	response, respErr = HostCheckerClient.Do(req)
+	response, err := HostCheckerClient.Do(req)
 
 	t2 := time.Now()
 
@@ -170,7 +167,7 @@ func (h *HostUptimeChecker) CheckHost(toCheck HostData) {
 		Latency:  millisec,
 	}
 
-	if respErr != nil {
+	if err != nil {
 		report.IsTCPError = true
 		h.errorChan <- report
 		return

--- a/jsvm_event_handler.go
+++ b/jsvm_event_handler.go
@@ -34,9 +34,9 @@ func (l *JSVMEventHandler) New(handlerConf interface{}) (TykEventHandler, error)
 		OrgID: l.Spec.OrgID,
 	}
 
-	gValAsJSON, gErr := json.Marshal(globalVals)
-	if gErr != nil {
-		log.Error("Failed to marshal globals! ", gErr)
+	gValAsJSON, err := json.Marshal(globalVals)
+	if err != nil {
+		log.Error("Failed to marshal globals! ", err)
 	}
 
 	handler.SpecJSON = string(gValAsJSON)
@@ -50,9 +50,9 @@ func (l *JSVMEventHandler) HandleEvent(em EventMessage) {
 	methodName := l.conf["name"].(string)
 
 	// 2. JSON-encode the event data object
-	msgAsJSON, encErr := json.Marshal(em)
-	if encErr != nil {
-		log.Error("Failed to encode event data: ", encErr)
+	msgAsJSON, err := json.Marshal(em)
+	if err != nil {
+		log.Error("Failed to encode event data: ", err)
 		return
 	}
 

--- a/le_helpers.go
+++ b/le_helpers.go
@@ -67,11 +67,10 @@ type LE_ServerInfo struct {
 
 func OnLESSLStatusReceivedHandler(payload string) {
 	serverData := LE_ServerInfo{}
-	jsErr := json.Unmarshal([]byte(payload), &serverData)
-	if jsErr != nil {
+	if err := json.Unmarshal([]byte(payload), &serverData); err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "pub-sub",
-		}).Error("Failed unmarshal server data: ", jsErr)
+		}).Error("Failed unmarshal server data: ", err)
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -174,12 +174,12 @@ func setupGlobals() {
 	MainNotifier = RedisNotifier{&MainNotifierStore, RedisPubSubChannel}
 
 	if config.Monitor.EnableTriggerMonitors {
-		var monitorErr error
-		MonitoringHandler, monitorErr = (&WebHookHandler{}).New(config.Monitor.Config)
-		if monitorErr != nil {
+		var err error
+		MonitoringHandler, err = (&WebHookHandler{}).New(config.Monitor.Config)
+		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "main",
-			}).Error("Failed to initialise monitor! ", monitorErr)
+			}).Error("Failed to initialise monitor! ", err)
 		}
 	}
 
@@ -957,12 +957,10 @@ func initialiseSystem(arguments map[string]interface{}) {
 	}).Info("PIDFile location set to: ", config.PIDFileLocation)
 
 	pidfile.SetPidfilePath(config.PIDFileLocation)
-	pfErr := pidfile.Write()
-
-	if pfErr != nil {
+	if err := pidfile.Write(); err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
-		}).Error("Failed to write PIDFile: ", pfErr)
+		}).Error("Failed to write PIDFile: ", err)
 	}
 
 	GetHostDetails()

--- a/middleware.go
+++ b/middleware.go
@@ -48,9 +48,8 @@ func CreateMiddleware(mw TykMiddlewareImplementation, tykMwSuper *TykMiddleware)
 	mw.New()
 
 	// Pull the configuration
-	mwConf, confErr := mw.GetConfig()
-
-	if confErr != nil {
+	mwConf, err := mw.GetConfig()
+	if err != nil {
 		log.Fatal("[Middleware] Configuration load failed")
 	}
 
@@ -73,11 +72,11 @@ func CreateMiddleware(mw TykMiddlewareImplementation, tykMwSuper *TykMiddleware)
 			if tykMwSuper.Spec.CORS.OptionsPassthrough && r.Method == "OPTIONS" {
 				h.ServeHTTP(w, r)
 			} else {
-				reqErr, errCode := mw.ProcessRequest(w, r, mwConf)
-				if reqErr != nil {
+				err, errCode := mw.ProcessRequest(w, r, mwConf)
+				if err != nil {
 					handler := ErrorHandler{tykMwSuper}
-					handler.HandleError(w, r, reqErr.Error(), errCode)
-					meta["error"] = reqErr.Error()
+					handler.HandleError(w, r, err.Error(), errCode)
+					meta["error"] = err.Error()
 					job.TimingKv("exec_time", time.Since(startTime).Nanoseconds(), meta)
 					job.TimingKv(eventName+".exec_time", time.Since(startTime).Nanoseconds(), meta)
 					return

--- a/middleware_HMAC.go
+++ b/middleware_HMAC.go
@@ -56,22 +56,22 @@ func (hm *HMACMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request,
 	log.Debug(authHeaderValue)
 
 	// Separate out the field values
-	fieldValues, fErr := getFieldValues(authHeaderValue)
-	if fErr != nil {
+	fieldValues, err := getFieldValues(authHeaderValue)
+	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "hmac",
-			"error":  fErr,
+			"error":  err,
 			"header": authHeaderValue,
 		}).Error("Field extraction failed")
 		return hm.authorizationError(w, r)
 	}
 
 	// Generate a signature string
-	signatureString, sErr := generateHMACSignatureStringFromRequest(r, fieldValues)
-	if sErr != nil {
+	signatureString, err := generateHMACSignatureStringFromRequest(r, fieldValues)
+	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix":           "hmac",
-			"error":            fErr,
+			"error":            err,
 			"signature_string": signatureString,
 		}).Error("Signature string generation failed")
 		return hm.authorizationError(w, r)

--- a/middleware_auth_key.go
+++ b/middleware_auth_key.go
@@ -100,9 +100,9 @@ func (k *AuthKey) ProcessRequest(w http.ResponseWriter, r *http.Request, configu
 			tempRes = CopyRequest(r)
 		}
 
-		authCookie, notFoundErr := tempRes.Cookie(cookieName)
+		authCookie, err := tempRes.Cookie(cookieName)
 		cookieValue := ""
-		if notFoundErr == nil {
+		if err == nil {
 			cookieValue = authCookie.Value
 		}
 

--- a/middleware_granular_access.go
+++ b/middleware_granular_access.go
@@ -53,10 +53,9 @@ func (m *GranularAccessMiddleware) ProcessRequest(w http.ResponseWriter, r *http
 	for _, accessSpec := range sessionVersionData.AllowedURLs {
 		log.Debug("Checking: ", r.URL.Path)
 		log.Debug("Against: ", accessSpec.URL)
-		asRegex, regexpErr := regexp.Compile(accessSpec.URL)
-
-		if regexpErr != nil {
-			log.Error("Regex error: ", regexpErr)
+		asRegex, err := regexp.Compile(accessSpec.URL)
+		if err != nil {
+			log.Error("Regex error: ", err)
 			return nil, 200
 		}
 

--- a/middleware_jwt_test.go
+++ b/middleware_jwt_test.go
@@ -344,10 +344,10 @@ func TestJWTSessionRSA(t *testing.T) {
 	token.Claims.(jwt.MapClaims)["foo"] = "bar"
 	token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour * 72).Unix()
 	// Sign and get the complete encoded token as a string
-	signKey, getSignErr := jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtRSAPrivKey))
-	if getSignErr != nil {
+	signKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtRSAPrivKey))
+	if err != nil {
 		log.Error("Couldn't extract private key: ")
-		t.Fatal(getSignErr)
+		t.Fatal(err)
 	}
 	tokenString, err := token.SignedString(signKey)
 	if err != nil {
@@ -388,10 +388,10 @@ func TestJWTSessionFailRSA_EmptyJWT(t *testing.T) {
 	token.Claims.(jwt.MapClaims)["foo"] = "bar"
 	token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour * 72).Unix()
 	// Sign and get the complete encoded token as a string
-	signKey, getSignErr := jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtRSAPrivKey))
-	if getSignErr != nil {
+	signKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtRSAPrivKey))
+	if err != nil {
 		log.Error("Couldn't extract private key: ")
-		t.Fatal(getSignErr)
+		t.Fatal(err)
 	}
 	tokenString, err := token.SignedString(signKey)
 	if err != nil {
@@ -434,10 +434,10 @@ func TestJWTSessionFailRSA_NoAuthHeader(t *testing.T) {
 	token.Claims.(jwt.MapClaims)["foo"] = "bar"
 	token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour * 72).Unix()
 	// Sign and get the complete encoded token as a string
-	signKey, getSignErr := jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtRSAPrivKey))
-	if getSignErr != nil {
+	signKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtRSAPrivKey))
+	if err != nil {
 		log.Error("Couldn't extract private key: ")
-		t.Fatal(getSignErr)
+		t.Fatal(err)
 	}
 	tokenString, err := token.SignedString(signKey)
 	if err != nil {
@@ -477,10 +477,10 @@ func TestJWTSessionFailRSA_MalformedJWT(t *testing.T) {
 	token.Claims.(jwt.MapClaims)["foo"] = "bar"
 	token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour * 72).Unix()
 	// Sign and get the complete encoded token as a string
-	signKey, getSignErr := jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtRSAPrivKey))
-	if getSignErr != nil {
+	signKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtRSAPrivKey))
+	if err != nil {
 		log.Error("Couldn't extract private key: ")
-		t.Fatal(getSignErr)
+		t.Fatal(err)
 	}
 	tokenString, err := token.SignedString(signKey)
 	if err != nil {
@@ -524,10 +524,10 @@ func TestJWTSessionFailRSA_MalformedJWT_NOTRACK(t *testing.T) {
 	token.Claims.(jwt.MapClaims)["foo"] = "bar"
 	token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour * 72).Unix()
 	// Sign and get the complete encoded token as a string
-	signKey, getSignErr := jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtRSAPrivKey))
-	if getSignErr != nil {
+	signKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtRSAPrivKey))
+	if err != nil {
 		log.Error("Couldn't extract private key: ")
-		t.Fatal(getSignErr)
+		t.Fatal(err)
 	}
 	tokenString, err := token.SignedString(signKey)
 	if err != nil {
@@ -570,10 +570,10 @@ func TestJWTSessionFailRSA_WrongJWT(t *testing.T) {
 	token.Claims.(jwt.MapClaims)["foo"] = "bar"
 	token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour * 72).Unix()
 	// Sign and get the complete encoded token as a string
-	signKey, getSignErr := jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtRSAPrivKey))
-	if getSignErr != nil {
+	signKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtRSAPrivKey))
+	if err != nil {
 		log.Error("Couldn't extract private key: ")
-		t.Fatal(getSignErr)
+		t.Fatal(err)
 	}
 	tokenString, err := token.SignedString(signKey)
 	if err != nil {
@@ -617,10 +617,10 @@ func TestJWTSessionRSABearer(t *testing.T) {
 	token.Claims.(jwt.MapClaims)["foo"] = "bar"
 	token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour * 72).Unix()
 	// Sign and get the complete encoded token as a string
-	signKey, getSignErr := jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtRSAPrivKey))
-	if getSignErr != nil {
+	signKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtRSAPrivKey))
+	if err != nil {
 		log.Error("Couldn't extract private key: ")
-		t.Fatal(getSignErr)
+		t.Fatal(err)
 	}
 	tokenString, err := token.SignedString(signKey)
 	if err != nil {
@@ -661,10 +661,10 @@ func TestJWTSessionRSABearerInvalid(t *testing.T) {
 	token.Claims.(jwt.MapClaims)["foo"] = "bar"
 	token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour * 72).Unix()
 	// Sign and get the complete encoded token as a string
-	signKey, getSignErr := jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtRSAPrivKey))
-	if getSignErr != nil {
+	signKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtRSAPrivKey))
+	if err != nil {
 		log.Error("Couldn't extract private key: ")
-		t.Fatal(getSignErr)
+		t.Fatal(err)
 	}
 	tokenString, err := token.SignedString(signKey)
 	if err != nil {
@@ -724,10 +724,10 @@ func TestJWTSessionRSAWithRawSourceOnWithClientID(t *testing.T) {
 	token.Claims.(jwt.MapClaims)["azp"] = tokenID
 	token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour * 72).Unix()
 	// Sign and get the complete encoded token as a string
-	signKey, getSignErr := jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtRSAPrivKey))
-	if getSignErr != nil {
+	signKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtRSAPrivKey))
+	if err != nil {
 		log.Error("Couldn't extract private key: ")
-		t.Fatal(getSignErr)
+		t.Fatal(err)
 	}
 	tokenString, err := token.SignedString(signKey)
 	if err != nil {
@@ -780,10 +780,10 @@ func TestJWTSessionRSAWithRawSource(t *testing.T) {
 	token.Claims.(jwt.MapClaims)["policy_id"] = "987654321"
 	token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour * 72).Unix()
 	// Sign and get the complete encoded token as a string
-	signKey, getSignErr := jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtRSAPrivKey))
-	if getSignErr != nil {
+	signKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtRSAPrivKey))
+	if err != nil {
 		log.Error("Couldn't extract private key: ")
-		t.Fatal(getSignErr)
+		t.Fatal(err)
 	}
 	tokenString, err := token.SignedString(signKey)
 	if err != nil {
@@ -836,10 +836,10 @@ func TestJWTSessionRSAWithRawSourceInvalidPolicyID(t *testing.T) {
 	token.Claims.(jwt.MapClaims)["policy_id"] = "1234567898978788"
 	token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour * 72).Unix()
 	// Sign and get the complete encoded token as a string
-	signKey, getSignErr := jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtRSAPrivKey))
-	if getSignErr != nil {
+	signKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtRSAPrivKey))
+	if err != nil {
 		log.Error("Couldn't extract private key: ")
-		t.Fatal(getSignErr)
+		t.Fatal(err)
 	}
 	tokenString, err := token.SignedString(signKey)
 	if err != nil {
@@ -892,10 +892,10 @@ func TestJWTSessionRSAWithJWK(t *testing.T) {
 	token.Claims.(jwt.MapClaims)["policy_id"] = "987654321"
 	token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour * 72).Unix()
 	// Sign and get the complete encoded token as a string
-	signKey, getSignErr := jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtRSAPrivKey))
-	if getSignErr != nil {
+	signKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtRSAPrivKey))
+	if err != nil {
 		log.Error("Couldn't extract private key: ")
-		t.Fatal(getSignErr)
+		t.Fatal(err)
 	}
 	tokenString, err := token.SignedString(signKey)
 	if err != nil {

--- a/middleware_redis_cache.go
+++ b/middleware_redis_cache.go
@@ -122,9 +122,9 @@ func (m *RedisCacheMiddleware) decodePayload(payload string) (string, string, er
 	}
 
 	if len(data) == 2 {
-		sDec, decodeErr := b64.StdEncoding.DecodeString(data[0])
-		if decodeErr != nil {
-			return "", "", decodeErr
+		sDec, err := b64.StdEncoding.DecodeString(data[0])
+		if err != nil {
+			return "", "", err
 		}
 
 		return string(sDec), data[1], nil
@@ -233,9 +233,9 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 					ttl := reqVal.Header.Get(UPSTREAM_CACHE_TTL_HEADER_NAME)
 					if ttl != "" {
 						log.Debug("TTL Set upstream")
-						cacheAsInt, valErr := strconv.Atoi(ttl)
-						if valErr != nil {
-							log.Error("Failed to decode TTL cache value: ", valErr)
+						cacheAsInt, err := strconv.Atoi(ttl)
+						if err != nil {
+							log.Error("Failed to decode TTL cache value: ", err)
 							cacheTTL = m.Spec.APIDefinition.CacheOptions.CacheTimeout
 						} else {
 							cacheTTL = int64(cacheAsInt)
@@ -257,8 +257,8 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 
 			}
 
-			cachedData, timestamp, decErr := m.decodePayload(retBlob)
-			if decErr != nil {
+			cachedData, timestamp, err := m.decodePayload(retBlob)
+			if err != nil {
 				// Tere was an issue with this cache entry - lets remove it:
 				m.CacheStore.DeleteKey(key)
 				return nil, 200
@@ -278,9 +278,9 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 			log.Debug("Cache got: ", cachedData)
 
 			asBufioReader := bufio.NewReader(retObj)
-			newRes, resErr := http.ReadResponse(asBufioReader, r)
-			if resErr != nil {
-				log.Error("Could not create response object: ", resErr)
+			newRes, err := http.ReadResponse(asBufioReader, r)
+			if err != nil {
+				log.Error("Could not create response object: ", err)
 			}
 
 			defer newRes.Body.Close()

--- a/middleware_request_size_limit.go
+++ b/middleware_request_size_limit.go
@@ -44,9 +44,9 @@ func (t *RequestSizeLimitMiddleware) checkRequestLimit(r *http.Request, sizeLimi
 		return errors.New("Content length is required for this request"), 411
 	}
 
-	asInt, convErr := strconv.Atoi(statedCL)
-	if convErr != nil {
-		log.Error("String conversion for content length failed:", convErr)
+	asInt, err := strconv.Atoi(statedCL)
+	if err != nil {
+		log.Error("String conversion for content length failed:", err)
 		return errors.New("content length is not a valid Integer"), 400
 	}
 
@@ -88,10 +88,10 @@ func (t *RequestSizeLimitMiddleware) ProcessRequest(w http.ResponseWriter, r *ht
 	// Manage global headers first
 	if vInfo.GlobalSizeLimit > 0 {
 		log.Debug("Checking global limit")
-		globErr, code := t.checkRequestLimit(r, vInfo.GlobalSizeLimit)
+		err, code := t.checkRequestLimit(r, vInfo.GlobalSizeLimit)
 		// If not OK, block
 		if code != 200 {
-			return globErr, code
+			return err, code
 		}
 	}
 

--- a/middleware_url_rewrite.go
+++ b/middleware_url_rewrite.go
@@ -16,10 +16,10 @@ type URLRewriter struct{}
 
 func (u URLRewriter) Rewrite(meta *apidef.URLRewriteMeta, path string, useContext bool, r *http.Request) (string, error) {
 	// Find all the matching groups:
-	mp, mpErr := regexp.Compile(meta.MatchPattern)
-	if mpErr != nil {
-		log.Debug("Compilation error: ", mpErr)
-		return "", mpErr
+	mp, err := regexp.Compile(meta.MatchPattern)
+	if err != nil {
+		log.Debug("Compilation error: ", err)
+		return "", err
 	}
 	log.Debug("Inbound path: ", path)
 	newpath := path
@@ -176,15 +176,15 @@ func (m *URLRewriteMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 		umeta := meta.(*apidef.URLRewriteMeta)
 		log.Debug(r.URL)
 		oldPath := r.URL.String()
-		p, pErr := m.Rewriter.Rewrite(umeta, r.URL.String(), true, r)
-		if pErr != nil {
-			return pErr, 500
+		p, err := m.Rewriter.Rewrite(umeta, r.URL.String(), true, r)
+		if err != nil {
+			return err, 500
 		}
 
 		m.CheckHostRewrite(oldPath, p, r)
 
-		newURL, uErr := url.Parse(p)
-		if uErr != nil {
+		newURL, err := url.Parse(p)
+		if err != nil {
 			log.Error("URL Rewrite failed, could not parse: ", p)
 		} else {
 			r.URL = newURL

--- a/middleware_virtual_endpoint.go
+++ b/middleware_virtual_endpoint.go
@@ -51,9 +51,9 @@ func PreLoadVirtualMetaCode(meta *apidef.VirtualMeta, j *JSVM) {
 	}
 	if meta != nil {
 		if meta.FunctionSourceType == "file" {
-			js, loadErr := ioutil.ReadFile(meta.FunctionSourceURI)
-			if loadErr != nil {
-				log.Error("Failed to load Endpoint JS: ", loadErr)
+			js, err := ioutil.ReadFile(meta.FunctionSourceURI)
+			if err != nil {
+				log.Error("Failed to load Endpoint JS: ", err)
 			} else {
 				// No error, load the JS into the VM
 				log.Debug("Loading JS Endpoint File: ", meta.FunctionSourceURI)
@@ -65,9 +65,9 @@ func PreLoadVirtualMetaCode(meta *apidef.VirtualMeta, j *JSVM) {
 				return
 			}
 
-			js, loadErr := b64.StdEncoding.DecodeString(meta.FunctionSourceURI)
-			if loadErr != nil {
-				log.Error("Failed to load blob JS: ", loadErr)
+			js, err := b64.StdEncoding.DecodeString(meta.FunctionSourceURI)
+			if err != nil {
+				log.Error("Failed to load blob JS: ", err)
 			} else {
 				// No error, load the JS into the VM
 				log.Debug("Loading JS blob")
@@ -150,22 +150,22 @@ func (d *VirtualEndpoint) ServeHTTPForCache(w http.ResponseWriter, r *http.Reque
 	r.ParseForm()
 	requestData.Params = r.Form
 
-	asJsonRequestObj, encErr := json.Marshal(requestData)
-	if encErr != nil {
-		log.Error("Failed to encode request object for virtual endpoint: ", encErr)
+	asJsonRequestObj, err := json.Marshal(requestData)
+	if err != nil {
+		log.Error("Failed to encode request object for virtual endpoint: ", err)
 		return nil
 	}
 
 	// Encode the configuration data too
-	configData, cErr := d.GetConfig()
-	if cErr != nil {
-		log.Error("Failed to parse configuration data: ", cErr)
+	configData, err := d.GetConfig()
+	if err != nil {
+		log.Error("Failed to parse configuration data: ", err)
 		configData = make(map[string]string)
 	}
 
-	asJsonConfigData, encErr := json.Marshal(configData)
-	if encErr != nil {
-		log.Error("Failed to encode request object for virtual endpoint: ", encErr)
+	asJsonConfigData, err := json.Marshal(configData)
+	if err != nil {
+		log.Error("Failed to encode request object for virtual endpoint: ", err)
 		return nil
 	}
 
@@ -178,10 +178,9 @@ func (d *VirtualEndpoint) ServeHTTPForCache(w http.ResponseWriter, r *http.Reque
 		authHeaderValue = context.Get(r, AuthHeaderValue).(string)
 	}
 
-	sessionAsJsonObj, sessEncErr := json.Marshal(sessionState)
-
-	if sessEncErr != nil {
-		log.Error("Failed to encode session for VM: ", sessEncErr)
+	sessionAsJsonObj, err := json.Marshal(sessionState)
+	if err != nil {
+		log.Error("Failed to encode session for VM: ", err)
 		return nil
 	}
 
@@ -192,10 +191,8 @@ func (d *VirtualEndpoint) ServeHTTPForCache(w http.ResponseWriter, r *http.Reque
 
 	// Decode the return object
 	newResponseData := VMResponseObject{}
-	decErr := json.Unmarshal([]byte(returnDataStr), &newResponseData)
-
-	if decErr != nil {
-		log.Error("Failed to decode virtual endpoint response data on return from VM: ", decErr)
+	if err := json.Unmarshal([]byte(returnDataStr), &newResponseData); err != nil {
+		log.Error("Failed to decode virtual endpoint response data on return from VM: ", err)
 		log.Error("--> Returned: ", returnDataStr)
 		return nil
 	}
@@ -232,9 +229,8 @@ func (d *VirtualEndpoint) ServeHTTPForCache(w http.ResponseWriter, r *http.Reque
 	// Handle response middleware
 	ResponseHandler := ResponseChain{}
 
-	chainErr := ResponseHandler.Go(d.TykMiddleware.Spec.ResponseChain, w, newResponse, r, &sessionState)
-	if chainErr != nil {
-		log.Error("Response chain failed! ", chainErr)
+	if err := ResponseHandler.Go(d.TykMiddleware.Spec.ResponseChain, w, newResponse, r, &sessionState); err != nil {
+		log.Error("Response chain failed! ", err)
 	}
 
 	// deep logging

--- a/multi_target_proxy_handler.go
+++ b/multi_target_proxy_handler.go
@@ -73,7 +73,7 @@ func (m *MultiTargetProxy) New(c interface{}, spec *APISpec) (TykResponseHandler
 			}).Info("----> Version ", versionName, " has no override target")
 			m.VersionProxyMap[versionName] = m.defaultProxy
 		} else {
-			versionRemote, vRemoteErr := url.Parse(versionData.OverrideTarget)
+			versionRemote, err := url.Parse(versionData.OverrideTarget)
 			log.WithFields(logrus.Fields{
 				"prefix": "multi-target",
 			}).Info("----> Version ", versionName, " has '", versionData.OverrideTarget, "' for override target")
@@ -83,10 +83,10 @@ func (m *MultiTargetProxy) New(c interface{}, spec *APISpec) (TykResponseHandler
 			log.WithFields(logrus.Fields{
 				"prefix": "multi-target",
 			}).Debug("Multi-target URL (obj): ", versionRemote)
-			if vRemoteErr != nil {
+			if err != nil {
 				log.WithFields(logrus.Fields{
 					"prefix": "multi-target",
-				}).Error("Couldn't parse version target URL in MultiTarget: ", vRemoteErr)
+				}).Error("Couldn't parse version target URL in MultiTarget: ", err)
 			}
 			versionProxy := TykNewSingleHostReverseProxy(versionRemote, spec)
 			versionProxy.New(nil, spec)

--- a/plugins.go
+++ b/plugins.go
@@ -141,12 +141,11 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
-	sessionAsJsonObj, sessEncErr := json.Marshal(sessionState)
-
-	if sessEncErr != nil {
+	sessionAsJsonObj, err := json.Marshal(sessionState)
+	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "jsvm",
-		}).Error("Failed to encode session for VM: ", sessEncErr)
+		}).Error("Failed to encode session for VM: ", err)
 		return nil, 200
 	}
 
@@ -162,12 +161,10 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 	// Decode the return object
 	newRequestData := VMReturnObject{}
 
-	decErr := json.Unmarshal([]byte(returnDataStr), &newRequestData)
-
-	if decErr != nil {
+	if err := json.Unmarshal([]byte(returnDataStr), &newRequestData); err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "jsvm",
-		}).Error("Failed to decode middleware request data on return from VM: ", decErr)
+		}).Error("Failed to decode middleware request data on return from VM: ", err)
 		log.WithFields(logrus.Fields{
 			"prefix": "jsvm",
 		}).Debug(returnDataStr)
@@ -265,11 +262,11 @@ func (j *JSVM) LoadJSPaths(paths []string, pathPrefix string) {
 		if pathPrefix != "" {
 			mwPath = filepath.Join(tykBundlePath, pathPrefix, mwPath)
 		}
-		js, loadErr := ioutil.ReadFile(mwPath)
-		if loadErr != nil {
+		js, err := ioutil.ReadFile(mwPath)
+		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "jsvm",
-			}).Error("Failed to load Middleware JS: ", loadErr)
+			}).Error("Failed to load Middleware JS: ", err)
 		} else {
 			// No error, load the JS into the VM
 			log.WithFields(logrus.Fields{
@@ -311,8 +308,7 @@ func (j *JSVM) LoadTykJSApi() {
 		jsonHRO := call.Argument(0).String()
 		HRO := TykJSHttpRequest{}
 		if jsonHRO != "undefined" {
-			jsonErr := json.Unmarshal([]byte(jsonHRO), &HRO)
-			if jsonErr != nil {
+			if err := json.Unmarshal([]byte(jsonHRO), &HRO); err != nil {
 				log.WithFields(logrus.Fields{
 					"prefix": "jsvm",
 				}).Error("JSVM: Failed to deserialise HTTP Request object")
@@ -349,12 +345,11 @@ func (j *JSVM) LoadTykJSApi() {
 				r.Header.Add(k, v)
 			}
 			r.Close = true
-			resp, respErr := client.Do(r)
-
-			if respErr != nil {
+			resp, err := client.Do(r)
+			if err != nil {
 				log.WithFields(logrus.Fields{
 					"prefix": "jsvm",
-				}).Error("[JSVM]: Request failed: ", respErr)
+				}).Error("[JSVM]: Request failed: ", err)
 				return otto.Value{}
 			}
 
@@ -366,11 +361,11 @@ func (j *JSVM) LoadTykJSApi() {
 			}
 
 			retAsStr, _ := json.Marshal(tykResp)
-			returnVal, retErr := j.VM.ToValue(string(retAsStr))
-			if retErr != nil {
+			returnVal, err := j.VM.ToValue(string(retAsStr))
+			if err != nil {
 				log.WithFields(logrus.Fields{
 					"prefix": "jsvm",
-				}).Error("[JSVM]: Failed to encode return value: ", retErr)
+				}).Error("[JSVM]: Failed to encode return value: ", err)
 				return otto.Value{}
 			}
 
@@ -390,11 +385,11 @@ func (j *JSVM) LoadTykJSApi() {
 
 		byteArray, _ := handleGetDetail(apiKey, apiId)
 
-		returnVal, retErr := j.VM.ToValue(string(byteArray))
-		if retErr != nil {
+		returnVal, err := j.VM.ToValue(string(byteArray))
+		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "jsvm",
-			}).Error("[JSVM]: Failed to encode return value: ", retErr)
+			}).Error("[JSVM]: Failed to encode return value: ", err)
 			return otto.Value{}
 		}
 
@@ -407,9 +402,8 @@ func (j *JSVM) LoadTykJSApi() {
 		suppress_reset := call.Argument(2).String()
 
 		newSession := SessionState{}
-		decErr := json.Unmarshal([]byte(encoddedSession), &newSession)
-
-		if decErr != nil {
+		err := json.Unmarshal([]byte(encoddedSession), &newSession)
+		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "jsvm",
 			}).Error("[JSVM]: Failed to decode the sesison data")
@@ -435,11 +429,11 @@ func (j *JSVM) LoadTykJSApi() {
 
 		byteArray := unsafeBatchHandler.ManualBatchRequest([]byte(requestSet))
 
-		returnVal, retErr := j.VM.ToValue(string(byteArray))
-		if retErr != nil {
+		returnVal, err := j.VM.ToValue(string(byteArray))
+		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "jsvm",
-			}).Error("[JSVM]: Failed to encode return value: ", retErr)
+			}).Error("[JSVM]: Failed to encode return value: ", err)
 			return otto.Value{}
 		}
 

--- a/policy.go
+++ b/policy.go
@@ -74,11 +74,10 @@ func LoadPoliciesFromFile(filePath string) map[string]Policy {
 		return policies
 	}
 
-	mErr := json.Unmarshal(policyConfig, &policies)
-	if mErr != nil {
+	if err := json.Unmarshal(policyConfig, &policies); err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "policy",
-		}).Error("Couldn't unmarshal policies: ", mErr)
+		}).Error("Couldn't unmarshal policies: ", err)
 	}
 
 	return policies
@@ -110,10 +109,9 @@ func LoadPoliciesFromDashboard(endpoint string, secret string, allowExplicit boo
 	log.WithFields(logrus.Fields{
 		"prefix": "policy",
 	}).Info("Calling dashboard service for policy list")
-	response, reqErr := c.Do(newRequest)
-
-	if reqErr != nil {
-		log.Error("Policy request failed: ", reqErr)
+	response, err := c.Do(newRequest)
+	if err != nil {
+		log.Error("Policy request failed: ", err)
 
 		return policies
 	}
@@ -144,9 +142,8 @@ func LoadPoliciesFromDashboard(endpoint string, secret string, allowExplicit boo
 
 	list := NodeResponseOK{}
 
-	decErr := json.Unmarshal(retBody, &list)
-	if decErr != nil {
-		log.Error("Failed to decode policy body: ", decErr, "Returned: ", string(retBody))
+	if err := json.Unmarshal(retBody, &list); err != nil {
+		log.Error("Failed to decode policy body: ", err, "Returned: ", string(retBody))
 
 		return policies
 	}

--- a/redis_cluster_handler.go
+++ b/redis_cluster_handler.go
@@ -191,10 +191,10 @@ func (r *RedisClusterStorageManager) SetKey(keyName string, sessionState string,
 	}
 	_, err := GetRelevantClusterReference(r.IsCache).Do("SET", r.fixKey(keyName), sessionState)
 	if timeout > 0 {
-		_, expErr := GetRelevantClusterReference(r.IsCache).Do("EXPIRE", r.fixKey(keyName), timeout)
-		if expErr != nil {
-			log.Error("Could not EXPIRE key: ", expErr)
-			return expErr
+		_, err := GetRelevantClusterReference(r.IsCache).Do("EXPIRE", r.fixKey(keyName), timeout)
+		if err != nil {
+			log.Error("Could not EXPIRE key: ", err)
+			return err
 		}
 	}
 	if err != nil {
@@ -213,10 +213,10 @@ func (r *RedisClusterStorageManager) SetRawKey(keyName string, sessionState stri
 	}
 	_, err := GetRelevantClusterReference(r.IsCache).Do("SET", keyName, sessionState)
 	if timeout > 0 {
-		_, expErr := GetRelevantClusterReference(r.IsCache).Do("EXPIRE", keyName, timeout)
-		if expErr != nil {
-			log.Error("Could not EXPIRE key: ", expErr)
-			return expErr
+		_, err := GetRelevantClusterReference(r.IsCache).Do("EXPIRE", keyName, timeout)
+		if err != nil {
+			log.Error("Could not EXPIRE key: ", err)
+			return err
 		}
 	}
 	if err != nil {

--- a/redis_logrus_hook.go
+++ b/redis_logrus_hook.go
@@ -27,9 +27,9 @@ func (hook *redisChannelHook) Fire(entry *logrus.Entry) error {
 		return nil
 	}
 
-	newEntry, fmtErr := hook.formatter.Format(entry)
-	if fmtErr != nil {
-		log.Error(fmtErr)
+	newEntry, err := hook.formatter.Format(entry)
+	if err != nil {
+		log.Error(err)
 		return nil
 	}
 

--- a/redis_notifier_outbound.go
+++ b/redis_notifier_outbound.go
@@ -46,8 +46,7 @@ func (r *RedisNotifier) Notify(notification Notification) bool {
 		return false
 	}
 	log.Debug("Sending notification", notification)
-	sentErr := r.store.Publish(r.channel, string(toSend))
-	if sentErr != nil {
+	if err := r.store.Publish(r.channel, string(toSend)); err != nil {
 		log.Error("Could not send notification")
 		log.Error(err)
 		return false

--- a/redis_signal_handle_config.go
+++ b/redis_signal_handle_config.go
@@ -104,19 +104,17 @@ func HandleNewConfiguration(payload string) {
 		return
 	}
 
-	backupErr := BackupConfiguration()
-	if backupErr != nil {
+	if err := BackupConfiguration(); err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "pub-sub",
-		}).Error("Failed to backup existing configuration: ", backupErr)
+		}).Error("Failed to backup existing configuration: ", err)
 		return
 	}
 
-	writeErr := WriteNewConfiguration(configPayload)
-	if writeErr != nil {
+	if err := WriteNewConfiguration(configPayload); err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "pub-sub",
-		}).Error("Failed to write new configuration: ", writeErr)
+		}).Error("Failed to write new configuration: ", err)
 		return
 	}
 
@@ -135,9 +133,7 @@ func ReloadConfiguration() {
 	}
 
 	log.Info("Sending reload signal to PID: ", myPID)
-
-	callErr := syscall.Kill(myPID, syscall.SIGUSR2)
-	if callErr != nil {
-		log.Error("Process reload failed: ", callErr)
+	if err := syscall.Kill(myPID, syscall.SIGUSR2); err != nil {
+		log.Error("Process reload failed: ", err)
 	}
 }

--- a/redis_signal_handle_config_request.go
+++ b/redis_signal_handle_config_request.go
@@ -101,11 +101,11 @@ func HandleSendMiniConfig(payload string) {
 		TimeStamp:     time.Now().Unix(),
 	}
 
-	payloadAsJSON, jsmErr := json.Marshal(returnPayload)
-	if jsmErr != nil {
+	payloadAsJSON, err := json.Marshal(returnPayload)
+	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "pub-sub",
-		}).Error("Failed to get marshal configuration: ", jsmErr)
+		}).Error("Failed to get marshal configuration: ", err)
 		return
 	}
 

--- a/redis_signal_outbound.go
+++ b/redis_signal_outbound.go
@@ -29,13 +29,13 @@ func (u *RedisNotificationHandler) Start() {
 }
 
 func (u *RedisNotificationHandler) Notify(n InterfaceNotification) error {
-	json_err, encErr := json.Marshal(n)
-	if encErr != nil {
-		return encErr
+	jsonError, err := json.Marshal(n)
+	if err != nil {
+		return err
 	}
 
 	if u.CacheStore != nil {
-		u.CacheStore.Publish(UIChanName, string(json_err))
+		u.CacheStore.Publish(UIChanName, string(jsonError))
 	}
 
 	return nil

--- a/redis_signals.go
+++ b/redis_signals.go
@@ -125,15 +125,14 @@ func IsPayloadSignatureValid(notification Notification) bool {
 	}
 
 	if notificationVerifier != nil {
-		signed, decErr := b64.StdEncoding.DecodeString(notification.Signature)
-		if decErr != nil {
+		signed, err := b64.StdEncoding.DecodeString(notification.Signature)
+		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "pub-sub",
-			}).Error("Failed to decode signature: ", decErr)
+			}).Error("Failed to decode signature: ", err)
 			return false
 		}
-		err := notificationVerifier.Verify([]byte(notification.Payload), signed)
-		if err != nil {
+		if err := notificationVerifier.Verify([]byte(notification.Payload), signed); err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "pub-sub",
 			}).Error("Could not verify notification: ", err, ": ", notification)

--- a/response_middleware.go
+++ b/response_middleware.go
@@ -35,9 +35,8 @@ func (r ResponseChain) Go(chain *[]TykResponseHandler, rw http.ResponseWriter, r
 	}
 
 	for _, rh := range *chain {
-		mwErr := rh.HandleResponse(rw, res, req, ses)
-		if mwErr != nil {
-			return mwErr
+		if err := rh.HandleResponse(rw, res, req, ses); err != nil {
+			return err
 		}
 	}
 

--- a/rpc_analytics_purger.go
+++ b/rpc_analytics_purger.go
@@ -87,16 +87,15 @@ func (r *RPCPurger) PurgeCache() {
 			}
 		}
 
-		data, dErr := json.Marshal(keys)
-		if dErr != nil {
+		data, err := json.Marshal(keys)
+		if err != nil {
 			log.Error("Failed to marshal analytics data")
 			return
 		}
 
 		// Send keys to RPC
-		_, callErr := r.Client.Call("PurgeAnalyticsData", string(data))
-		if callErr != nil {
-			log.Error("Failed to call purge (reconnecting): ", callErr)
+		if _, err := r.Client.Call("PurgeAnalyticsData", string(data)); err != nil {
+			log.Error("Failed to call purge (reconnecting): ", err)
 			r.ReConnect()
 		}
 	}

--- a/rpc_backup_handlers.go
+++ b/rpc_backup_handlers.go
@@ -45,9 +45,9 @@ func SaveRPCDefinitionsBackup(list string) {
 
 	secret := rightPad2Len(config.Secret, "=", 32)
 	cryptoText := encrypt([]byte(secret), list)
-	rErr := store.SetKey(BackupKeyBase+tagList, cryptoText, -1)
-	if rErr != nil {
-		log.Error("Failed to store node backup: ", rErr)
+	err := store.SetKey(BackupKeyBase+tagList, cryptoText, -1)
+	if err != nil {
+		log.Error("Failed to store node backup: ", err)
 	}
 }
 
@@ -66,11 +66,11 @@ func LoadDefinitionsFromRPCBackup() *[]*APISpec {
 	}
 
 	secret := rightPad2Len(config.Secret, "=", 32)
-	cryptoText, rErr := store.GetKey(checkKey)
+	cryptoText, err := store.GetKey(checkKey)
 	apiListAsString := decrypt([]byte(secret), cryptoText)
 
-	if rErr != nil {
-		log.Error("[RPC] --> Failed to get node backup (", checkKey, "): ", rErr)
+	if err != nil {
+		log.Error("[RPC] --> Failed to get node backup (", checkKey, "): ", err)
 		return nil
 	}
 

--- a/service_discovery.go
+++ b/service_discovery.go
@@ -51,9 +51,9 @@ func (s *ServiceDiscovery) getServiceData(name string) (string, error) {
 	}
 
 	defer resp.Body.Close()
-	contents, readErr := ioutil.ReadAll(resp.Body)
+	contents, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return "", readErr
+		return "", err
 	}
 
 	return string(contents), nil
@@ -235,13 +235,13 @@ func (s *ServiceDiscovery) ConvertRawListToObj(RawData *string) {
 
 func (s *ServiceDiscovery) ParseObject(contents string, jsonParsed *gabs.Container) error {
 	log.Debug("Parsing raw data: ", contents)
-	jp, pErr := gabs.ParseJSON([]byte(contents))
-	if pErr != nil {
-		log.Error(pErr)
+	jp, err := gabs.ParseJSON([]byte(contents))
+	if err != nil {
+		log.Error(err)
 	}
 	*jsonParsed = *jp
 	log.Debug("Got:", jsonParsed)
-	return pErr
+	return err
 }
 
 func (s *ServiceDiscovery) ProcessRawData(rawData string) (*apidef.HostList, error) {

--- a/session_manager.go
+++ b/session_manager.go
@@ -96,11 +96,10 @@ func (l *SessionLimiter) ForwardMessage(currentSession *SessionState, key string
 				rate = uint(DRLManager.CurrentTokenValue)
 			}
 
-			userBucket, cErr := BucketStore.Create(bucketKey,
+			userBucket, err := BucketStore.Create(bucketKey,
 				rate,
 				time.Duration(currentSession.Per)*time.Second)
-
-			if cErr != nil {
+			if err != nil {
 				log.Error("Failed to create bucket!")
 				return false, 1
 			}

--- a/swagger.go
+++ b/swagger.go
@@ -76,12 +76,10 @@ type SwaggerAST struct {
 }
 
 func (s *SwaggerAST) ReadString(asJson string) error {
-	marshallErr := json.Unmarshal([]byte(asJson), &s)
-	if marshallErr != nil {
-		log.Error("Marshalling failed: ", marshallErr)
-		return marshallErr
+	if err := json.Unmarshal([]byte(asJson), &s); err != nil {
+		log.Error("Marshalling failed: ", err)
+		return err
 	}
-
 	return nil
 }
 
@@ -153,8 +151,8 @@ func handleSwaggerMode(arguments map[string]interface{}) {
 				return
 			}
 
-			def, dErr := createDefFromSwagger(s, orgId.(string), upstreamVal.(string), arguments["--as-mock"].(bool))
-			if dErr != nil {
+			def, err := createDefFromSwagger(s, orgId.(string), upstreamVal.(string), arguments["--as-mock"].(bool))
+			if err != nil {
 				log.Error("Failed to create API Defintition from file")
 				return
 			}
@@ -196,9 +194,8 @@ func handleSwaggerMode(arguments map[string]interface{}) {
 			log.Error("Conversion into API Def failed: ", err)
 		}
 
-		insertErr := s.InsertIntoAPIDefinitionAsVersion(versionData, defFromFile, versionName.(string))
-		if insertErr != nil {
-			log.Error("Insertion failed: ", insertErr)
+		if err := s.InsertIntoAPIDefinitionAsVersion(versionData, defFromFile, versionName.(string)); err != nil {
+			log.Error("Insertion failed: ", err)
 			return
 		}
 
@@ -236,11 +233,10 @@ func createDefFromSwagger(s *SwaggerAST, orgId, upstreamURL string, as_mock bool
 }
 
 func swaggerLoadFile(filePath string) (*SwaggerAST, error) {
-	swagger, astErr := GetImporterForSource(SwaggerSource)
-
-	if astErr != nil {
-		log.Error("Couldn't get swagger importer: ", astErr)
-		return swagger.(*SwaggerAST), astErr
+	swagger, err := GetImporterForSource(SwaggerSource)
+	if err != nil {
+		log.Error("Couldn't get swagger importer: ", err)
+		return swagger.(*SwaggerAST), err
 	}
 
 	swaggerFileData, err := ioutil.ReadFile(filePath)
@@ -250,10 +246,9 @@ func swaggerLoadFile(filePath string) (*SwaggerAST, error) {
 		return swagger.(*SwaggerAST), err
 	}
 
-	readErr := swagger.ReadString(string(swaggerFileData))
-	if readErr != nil {
+	if err := swagger.ReadString(string(swaggerFileData)); err != nil {
 		log.Error("Failed to decode object")
-		return swagger.(*SwaggerAST), readErr
+		return swagger.(*SwaggerAST), err
 	}
 
 	return swagger.(*SwaggerAST), nil

--- a/tyk_reverse_proxy_clone.go
+++ b/tyk_reverse_proxy_clone.go
@@ -171,9 +171,9 @@ func TykNewSingleHostReverseProxy(target *url.URL, spec *APISpec) *ReverseProxy 
 	director := func(req *http.Request) {
 		var targetSet bool
 		if spec.Proxy.ServiceDiscovery.UseDiscoveryService {
-			tempTargetURL, tErr := GetURLFromService(spec)
-			if tErr != nil {
-				log.Error("[PROXY] [SERVICE DISCOVERY] Failed target lookup: ", tErr)
+			tempTargetURL, err := GetURLFromService(spec)
+			if err != nil {
+				log.Error("[PROXY] [SERVICE DISCOVERY] Failed target lookup: ", err)
 			} else {
 				// No error, replace the target
 				if spec.Proxy.EnableLoadBalancing {
@@ -204,9 +204,9 @@ func TykNewSingleHostReverseProxy(target *url.URL, spec *APISpec) *ReverseProxy 
 			// no override, better check if LB is enabled
 			if spec.Proxy.EnableLoadBalancing {
 				// it is, lets get that target data
-				lbRemote, lbErr := url.Parse(GetNextTarget(spec.Proxy.StructuredTargetList, spec, 0))
-				if lbErr != nil {
-					log.Error("[PROXY] [LOAD BALANCING] Couldn't parse target URL:", lbErr)
+				lbRemote, err := url.Parse(GetNextTarget(spec.Proxy.StructuredTargetList, spec, 0))
+				if err != nil {
+					log.Error("[PROXY] [LOAD BALANCING] Couldn't parse target URL:", err)
 				} else {
 					// Only replace target if everything is OK
 					target = lbRemote
@@ -224,9 +224,9 @@ func TykNewSingleHostReverseProxy(target *url.URL, spec *APISpec) *ReverseProxy 
 			if found {
 				if URLRewriteContainsTarget.(bool) {
 					log.Debug("Detected host rewrite, overriding target")
-					tmpTarget, pErr := url.Parse(req.URL.String())
-					if pErr != nil {
-						log.Error("Failed to parse URL! Err: ", pErr)
+					tmpTarget, err := url.Parse(req.URL.String())
+					if err != nil {
+						log.Error("Failed to parse URL! Err: ", err)
 					} else {
 						newTarget = tmpTarget
 						switchTargets = true
@@ -617,9 +617,9 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 
 	if p.TykAPISpec.ResponseHandlersActive {
 		// Middleware chain handling here - very simple, but should do the trick
-		chainErr := p.ResponseHandler.Go(p.TykAPISpec.ResponseChain, rw, res, req, &ses)
-		if chainErr != nil {
-			log.Error("Response chain failed! ", chainErr)
+		err := p.ResponseHandler.Go(p.TykAPISpec.ResponseChain, rw, res, req, &ses)
+		if err != nil {
+			log.Error("Response chain failed! ", err)
 		}
 	}
 


### PR DESCRIPTION
Don't call them fooErr. Call most of them just "err". This has several
advantages:

* Error values are overriden, so we can't possibly use the wrong error
  by mistake
* Less names in a given scope
* Simpler, shorter code

Errors should only have special names if they are long-lived, like
goAgainErr in main.go.