### PR TITLE
all: use raw string literals more often

### DIFF
--- a/command_mode.go
+++ b/command_mode.go
@@ -109,7 +109,7 @@ func printDef(def *apidef.APIDefinition) {
 	}
 
 	// The id attribute is for BSON only and breaks the parser if it's empty, cull it here.
-	fixed := strings.Replace(string(asJson), "    \"id\": \"\",", "", 1)
+	fixed := strings.Replace(string(asJson), `    "id": "",`, "", 1)
 	fmt.Printf(fixed)
 }
 

--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ var runningTests = false
 
 const (
 	// Generic system error
-	E_SYSTEM_ERROR = "{\"status\": \"system error, please contact administrator\"}"
+	E_SYSTEM_ERROR = `{"status": "system error, please contact administrator"}`
 	OAUTH_PREFIX   = "oauth-data."
 )
 

--- a/middleware_HMAC.go
+++ b/middleware_HMAC.go
@@ -307,7 +307,7 @@ func getFieldValues(authHeader string) (*HMACFieldValues, error) {
 		}
 
 		value := kv[1]
-		value = strings.Trim(value, "\"")
+		value = strings.Trim(value, `"`)
 
 		switch key {
 		case "keyid":


### PR DESCRIPTION
Using `` `"foo"` `` is much simpler than `"\"foo\""`.