### PR TITLE
all: fix portability on a bunch of paths

### DIFF
--- a/api.go
+++ b/api.go
@@ -9,7 +9,7 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -689,7 +689,7 @@ func HandleAddOrUpdateApi(APIID string, r *http.Request) ([]byte, int) {
 
 	// Create a filename
 	defFilename := newDef.APIID + ".json"
-	defFilePath := path.Join(config.AppPath, defFilename)
+	defFilePath := filepath.Join(config.AppPath, defFilename)
 
 	// If it exists, delete it
 	if _, err := os.Stat(defFilePath); err == nil {
@@ -744,7 +744,7 @@ func HandleDeleteAPI(APIID string) ([]byte, int) {
 
 	// Generate a filename
 	defFilename := APIID + ".json"
-	defFilePath := path.Join(config.AppPath, defFilename)
+	defFilePath := filepath.Join(config.AppPath, defFilename)
 
 	// If it exists, delete it
 	if _, err := os.Stat(defFilePath); err != nil {

--- a/coprocess_bundle.go
+++ b/coprocess_bundle.go
@@ -24,7 +24,7 @@ import (
 var tykBundlePath string
 
 func init() {
-	tykBundlePath = filepath.Join(config.MiddlewarePath, "middleware/bundles")
+	tykBundlePath = filepath.Join(config.MiddlewarePath, "middleware", "bundles")
 }
 
 // Bundle is the basic bundle data structure, it holds the bundle name and the data.

--- a/coprocess_lua.go
+++ b/coprocess_lua.go
@@ -73,7 +73,6 @@ import "C"
 
 import (
 	"io/ioutil"
-	"path"
 	"path/filepath"
 	"unsafe"
 
@@ -134,7 +133,7 @@ func (d *LuaDispatcher) Reload() {
 	}
 
 	for _, f := range files {
-		middlewarePath := path.Join(MiddlewareBasePath, f.Name())
+		middlewarePath := filepath.Join(MiddlewareBasePath, f.Name())
 		contents, err := ioutil.ReadFile(middlewarePath)
 		if err != nil {
 			log.WithFields(logrus.Fields{
@@ -170,7 +169,7 @@ func (d *LuaDispatcher) LoadModules() {
 		gModuleCache = d.ModuleCache
 	}
 
-	middlewarePath := path.Join(ModuleBasePath, "bundle.lua")
+	middlewarePath := filepath.Join(ModuleBasePath, "bundle.lua")
 	contents, err := ioutil.ReadFile(middlewarePath)
 
 	if err == nil {

--- a/coprocess_python.go
+++ b/coprocess_python.go
@@ -171,7 +171,6 @@ import (
 	"errors"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"unsafe"
@@ -296,10 +295,10 @@ func NewCoProcessDispatcher() (coprocess.Dispatcher, error) {
 
 	workDir, _ := os.Getwd()
 
-	dispatcherPath := path.Join(workDir, "coprocess/python")
-	middlewarePath := path.Join(workDir, "middleware/python")
-	eventHandlerPath := path.Join(workDir, "event_handlers")
-	protoPath := path.Join(workDir, "coprocess/python/proto")
+	dispatcherPath := filepath.Join(workDir, "coprocess", "python")
+	middlewarePath := filepath.Join(workDir, "middleware", "python")
+	eventHandlerPath := filepath.Join(workDir, "event_handlers")
+	protoPath := filepath.Join(workDir, "coprocess", "python", "proto")
 
 	paths := []string{dispatcherPath, middlewarePath, eventHandlerPath, protoPath}
 

--- a/event_handler_webhooks.go
+++ b/event_handler_webhooks.go
@@ -10,7 +10,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/TykTechnologies/logrus"
@@ -99,7 +99,7 @@ func (w *WebHookHandler) New(handlerConf interface{}) (TykEventHandler, error) {
 				"prefix": "webhooks",
 				"target": handler.conf.TargetPath,
 			}).Warning("Custom template load failure, using default: ", err)
-			defaultPath := path.Join(config.TemplatePath, "default_webhook.json")
+			defaultPath := filepath.Join(config.TemplatePath, "default_webhook.json")
 			webHookTemplate, _ = template.ParseFiles(defaultPath)
 			templateLoaded = true
 		} else {
@@ -112,7 +112,7 @@ func (w *WebHookHandler) New(handlerConf interface{}) (TykEventHandler, error) {
 			"prefix": "webhooks",
 			"target": handler.conf.TargetPath,
 		}).Info("Loading default template.")
-		defaultPath := path.Join(config.TemplatePath, "default_webhook.json")
+		defaultPath := filepath.Join(config.TemplatePath, "default_webhook.json")
 		webHookTemplate, _ = template.ParseFiles(defaultPath)
 	}
 

--- a/main.go
+++ b/main.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime/pprof"
 	"strconv"
@@ -487,7 +486,7 @@ func loadCustomMiddleware(referenceSpec *APISpec) ([]string, apidef.MiddlewareDe
 	// Load from folder
 
 	// Get PRE folder path
-	middlwareFolderPath := path.Join(config.MiddlewarePath, referenceSpec.APIDefinition.APIID, "pre")
+	middlwareFolderPath := filepath.Join(config.MiddlewarePath, referenceSpec.APIDefinition.APIID, "pre")
 	files, _ := ioutil.ReadDir(middlwareFolderPath)
 	for _, f := range files {
 		if strings.Contains(f.Name(), ".js") {
@@ -515,7 +514,7 @@ func loadCustomMiddleware(referenceSpec *APISpec) ([]string, apidef.MiddlewareDe
 	}
 
 	// Get Auth folder path
-	middlewareAuthFolderPath := path.Join(config.MiddlewarePath, referenceSpec.APIDefinition.APIID, "auth")
+	middlewareAuthFolderPath := filepath.Join(config.MiddlewarePath, referenceSpec.APIDefinition.APIID, "auth")
 	mwAuthFiles, _ := ioutil.ReadDir(middlewareAuthFolderPath)
 	for _, f := range mwAuthFiles {
 		if strings.Contains(f.Name(), ".js") {
@@ -541,7 +540,7 @@ func loadCustomMiddleware(referenceSpec *APISpec) ([]string, apidef.MiddlewareDe
 	}
 
 	// Get POSTKeyAuth folder path
-	middlewarePostKeyAuthFolderPath := path.Join(config.MiddlewarePath, referenceSpec.APIDefinition.APIID, "post_auth")
+	middlewarePostKeyAuthFolderPath := filepath.Join(config.MiddlewarePath, referenceSpec.APIDefinition.APIID, "post_auth")
 	mwPostKeyAuthFiles, _ := ioutil.ReadDir(middlewarePostKeyAuthFolderPath)
 	for _, f := range mwPostKeyAuthFiles {
 		if strings.Contains(f.Name(), ".js") {
@@ -569,7 +568,7 @@ func loadCustomMiddleware(referenceSpec *APISpec) ([]string, apidef.MiddlewareDe
 	}
 
 	// Get POST folder path
-	middlewarePostFolderPath := path.Join(config.MiddlewarePath, referenceSpec.APIDefinition.APIID, "post")
+	middlewarePostFolderPath := filepath.Join(config.MiddlewarePath, referenceSpec.APIDefinition.APIID, "post")
 	mwPostFiles, _ := ioutil.ReadDir(middlewarePostFolderPath)
 	for _, f := range mwPostFiles {
 		if strings.Contains(f.Name(), ".js") {


### PR DESCRIPTION
* Use filepath.Join, not path.Join for disk paths
* Don't hard-code '/' in paths