### PR TITLE
Drop Go 1.6 build support, make 1.8 the main one

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,9 @@ addons:
 
 matrix:
   include:
-    - go: 1.6.x
     - go: 1.7.x
-      env: LATEST_GO=true # run linters and report coverage
     - go: 1.8rc3
+      env: LATEST_GO=true # run linters and report coverage
 
 services:
   - redis-server

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Tyk is a lightweight, open source API Gateway and Management Platform enables you to control who accesses your API, when they access it and how they access it. Tyk will
 also record detailed analytics on how your users are interacting with your API and when things go wrong.
 
-Go version 1.6 or later is required to build. Tyk is officially
+Go version 1.7 or later is required to build. Tyk is officially
 supported on `linux/amd64`, `linux/i386` and `linux/arm64`.
 
 ## What is an API Gateway?


### PR DESCRIPTION
See https://golang.org/doc/go1.7 for all the things that we can use now.

This will be especially useful since we'll be able to use sub-tests and
sub-benchmarks. Right now we use lots of copy-pasted code in our tests.

Fixes #405.