### PR TITLE
analytics: don't throw errors on invalid IPs

### DIFF
--- a/analytics_test.go
+++ b/analytics_test.go
@@ -1,0 +1,23 @@
+package main
+
+import "testing"
+
+func TestGeoIPLookup(t *testing.T) {
+	testCases := [...]struct {
+		in      string
+		wantErr bool
+	}{
+		{"", false},
+		{"foobar", true},
+		{"1.2.3.4", false},
+	}
+	for _, tc := range testCases {
+		_, err := geoIPLookup(tc.in)
+		switch {
+		case tc.wantErr && err == nil:
+			t.Errorf("geoIPLookup(%q) did not error", tc.in)
+		case !tc.wantErr && err != nil:
+			t.Errorf("geoIPLookup(%q) errored", tc.in)
+		}
+	}
+}

--- a/util_http_helpers_test.go
+++ b/util_http_helpers_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestGetIPFromRequest(t *testing.T) {
+	tests := []struct {
+		remote, forwarded, want string
+	}{
+		{"", "", ""},
+		{":80", "", ""},
+		{":80", ":80, px1, px2", ""},
+		{"1.2.3.4", "", "1.2.3.4"},
+		{"1.2.3.4:80", "", "1.2.3.4"},
+		{"1.2.3.4", "5.6.7.8, px1, px2", "5.6.7.8"},
+		{"1.2.3.4:80", "5.6.7.8:80, px1, px2", "5.6.7.8"},
+	}
+	for _, tc := range tests {
+		r := &http.Request{RemoteAddr: tc.remote, Header: http.Header{}}
+		r.Header.Set("x-forwarded-for", tc.forwarded)
+		got := GetIPFromRequest(r)
+		if got != tc.want {
+			t.Errorf("GetIPFromRequest({%q, %q}) got %q, want %q",
+				tc.remote, tc.forwarded, got, tc.want)
+		}
+	}
+}

--- a/util_http_helpers_test.go
+++ b/util_http_helpers_test.go
@@ -9,13 +9,17 @@ func TestGetIPFromRequest(t *testing.T) {
 	tests := []struct {
 		remote, forwarded, want string
 	}{
+		// missing ip or port
 		{"", "", ""},
 		{":80", "", ""},
-		{":80", ":80, px1, px2", ""},
-		{"1.2.3.4", "", "1.2.3.4"},
+		{"1.2.3.4", "", ""},
+		{"[::1]", "", ""},
+		// not forwarded
 		{"1.2.3.4:80", "", "1.2.3.4"},
-		{"1.2.3.4", "5.6.7.8, px1, px2", "5.6.7.8"},
-		{"1.2.3.4:80", "5.6.7.8:80, px1, px2", "5.6.7.8"},
+		{"[::1]:80", "", "::1"},
+		// forwarded
+		{"1.2.3.4:80", "5.6.7.8, px1, px2", "5.6.7.8"},
+		{"[::1]:80", "::2", "::2"},
 	}
 	for _, tc := range tests {
 		r := &http.Request{RemoteAddr: tc.remote, Header: http.Header{}}


### PR DESCRIPTION
Empty IPs remain silent as before. Invalid IPs are logged better - now
they are:

	GeoIP Failure (not recorded): invalid IP address "foobar"

insteaf of:

	GeoIP Failure (not recorded): ipAddress passed to Lookup cannot be nil

Add tests too.

Also, these are now warnings instead of errors, since they are often
just noise.

Fixes #352.