### PR TITLE
Fix RPC memory leaks

### DIFF
--- a/main.go
+++ b/main.go
@@ -138,7 +138,7 @@ func setupGlobals() {
 
 		if config.AnalyticsConfig.Type == "rpc" {
 			log.Debug("Using RPC cache purge")
-			purger := RPCPurger{Store: &AnalyticsStore, Address: config.SlaveOptions.ConnectionString}
+			purger := RPCPurger{Store: &AnalyticsStore}
 			purger.Connect()
 			analytics.Clean = &purger
 			go analytics.Clean.PurgeLoop(10 * time.Second)

--- a/rpc_storage_handler.go
+++ b/rpc_storage_handler.go
@@ -148,9 +148,12 @@ func (r *RPCStorageHandler) checkDisconnect() {
 func (r *RPCStorageHandler) ReConnect() {
 	// Should only be used by reload checker
 	// r.Disconnect()
-	RPCClientIsConnected = false
-	r.Connect()
-	log.Info("Reconnected.")
+
+	return
+
+	// RPCClientIsConnected = false
+	// r.Connect()
+	// log.Info("Reconnected.")
 }
 
 var RPCCLientSingleton *gorpc.Client

--- a/utils/buddy_build.sh
+++ b/utils/buddy_build.sh
@@ -129,7 +129,7 @@ AMDDEBNAME="tyk-gateway_"$VERSION"_amd64.deb"
 AMDRPMNAME="tyk-gateway-"$VERSION"-1.x86_64.rpm"
 
 echo "Signing AMD RPM"
-~/build_tools/rpm-sign.exp $amd64TGZDIR/$AMDRPMNAME
+/src/github.com/TykTechnologies/tyk/build_tools/rpm-sign.exp $amd64TGZDIR/$AMDRPMNAME
 
 echo Creating Deb Package for i386
 cd $i386TGZDIR/
@@ -140,7 +140,7 @@ i386DEBNAME="tyk-gateway_"$VERSION"_i386.deb"
 i386RPMNAME="tyk-gateway-"$VERSION"-1.i386.rpm"
 
 echo "Signing i386 RPM"
-~/build_tools/rpm-sign.exp $i386TGZDIR/$i386RPMNAME
+/src/github.com/TykTechnologies/tyk/build_tools/rpm-sign.exp $i386TGZDIR/$i386RPMNAME
 
 echo Creating Deb Package for ARM
 cd $armTGZDIR/
@@ -151,4 +151,4 @@ ARMDEBNAME="tyk-gateway_"$VERSION"_arm64.deb"
 ARMRPMNAME="tyk-gateway-"$VERSION"-1.arm64.rpm"
 
 echo "Signing Arm RPM"
-~/build_tools/rpm-sign.exp $armTGZDIR/$ARMRPMNAME
+/src/github.com/TykTechnologies/tyk/build_tools/rpm-sign.exp $armTGZDIR/$ARMRPMNAME

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-var VERSION = "v2.3.2"
+var VERSION = "v2.3.2-RPC-exp-1"


### PR DESCRIPTION
It is not completely clear why RCP purger creates so many connections.
But seems like using global RPCFuncClientSingleton fix the issue.

I checked it and confirmed that number of opened connections to Sink stays the same. 

@lonelycode  I rebased your changes and already 2.3 compatible. I think it makes sense include into 2.3.2.

While this change definitely fix "too many opened files" issue, I still see that `heap` increase from time to time. @mvdan do you have experience in debugging heap files? I attach both heap and goroutine report.
[goroutine.txt](https://github.com/TykTechnologies/tyk/files/758177/goroutine.txt)
[heap.txt](https://github.com/TykTechnologies/tyk/files/758178/heap.txt)
