### PR TITLE
test: remove a bunch of unnecessary mux work

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -50,17 +50,7 @@ const apiTestDef = `{
 
 func makeSampleAPI(t *testing.T) *APISpec {
 	spec := createSpecTest(t, apiTestDef)
-
-	specs := []*APISpec{spec}
-	newMuxes := mux.NewRouter()
-	loadAPIEndpoints(newMuxes)
-	loadApps(specs, newMuxes)
-
-	newHttmMuxer := http.NewServeMux()
-
-	newHttmMuxer.Handle("/", newMuxes)
-
-	http.DefaultServeMux = newHttmMuxer
+	loadApps([]*APISpec{spec}, discardMuxer)
 	return spec
 }
 

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -14,12 +14,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/justinas/alice"
 )
 
 func init() {
 	runningTests = true
 }
+
+var discardMuxer = mux.NewRouter()
 
 func TestMain(m *testing.M) {
 	WriteDefaultConf(&config)

--- a/middleware_ip_whitelist_test.go
+++ b/middleware_ip_whitelist_test.go
@@ -5,8 +5,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
-
-	"github.com/gorilla/mux"
 )
 
 const ipMiddlewareTestDefinitionEnabledFail = `{
@@ -148,19 +146,8 @@ const ipMiddlewareTestDefinitionMissing = `{
 }`
 
 func createIPSampleAPI(t *testing.T, apiTestDef string) *APISpec {
-	log.Debug("CREATING TEMPORARY API FOR IP WHITELIST")
 	spec := createSpecTest(t, apiTestDef)
-
-	specs := []*APISpec{spec}
-	newMuxes := mux.NewRouter()
-	loadAPIEndpoints(newMuxes)
-	loadApps(specs, newMuxes)
-	newHttpMuxer := http.NewServeMux()
-	newHttpMuxer.Handle("/", newMuxes)
-
-	http.DefaultServeMux = newHttpMuxer
-	log.Debug("IP TEST Reload complete")
-
+	loadApps([]*APISpec{spec}, discardMuxer)
 	return spec
 }
 

--- a/oauth_manager_test.go
+++ b/oauth_manager_test.go
@@ -102,16 +102,7 @@ func getOAuthChain(spec *APISpec, Muxer *mux.Router) {
 
 func makeOAuthAPI(t *testing.T) *APISpec {
 	spec := createSpecTest(t, oauthDefinition)
-
-	specs := []*APISpec{spec}
-	newMuxes := mux.NewRouter()
-	loadAPIEndpoints(newMuxes)
-	loadApps(specs, newMuxes)
-
-	newHttpMux := http.NewServeMux()
-	newHttpMux.Handle("/", newMuxes)
-	http.DefaultServeMux = newHttpMux
-
+	loadApps([]*APISpec{spec}, discardMuxer)
 	return spec
 }
 


### PR DESCRIPTION
These set up muxers and load endpoints into them, but then just throw
them away. They are set up as http.DefaultServeMux, but that's never
used.

@lonelycode @buger if either of you know why this was written like this, please let me know.

Also weird that removing the `loadApps(..., discardMuxer)` lines makes the tests fail and the gateway panic.