### PR TITLE
test: enable a few more config options

### DIFF
--- a/gateway_test.go
+++ b/gateway_test.go
@@ -31,6 +31,9 @@ func TestMain(m *testing.M) {
 	config.EnableAnalytics = true
 	config.AnalyticsConfig.EnableGeoIP = true
 	config.AnalyticsConfig.GeoIPDBLocation = filepath.Join("testdata", "MaxMind-DB-test-ipv4-24.mmdb")
+	config.EnableJSVM = true
+	config.Monitor.EnableTriggerMonitors = true
+	config.AnalyticsConfig.NormaliseUrls.Enabled = true
 	initialiseSystem(nil)
 	if analytics.GeoIPDB == nil {
 		panic("GeoIPDB was not initialized")


### PR DESCRIPTION
Bumps code coverage from 31.2% to 31.9%. The newly covered code isn't
really tested against, but at least it's ran and we know it won't crash
under some very basic use.