### PR TITLE
Collapse error logs into single calls

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -411,8 +411,7 @@ func (a *APIDefinitionLoader) processRPCDefinitions(apiCollection string) []*API
 func (a *APIDefinitionLoader) ParseDefinition(apiDef []byte) (*apidef.APIDefinition, map[string]interface{}) {
 	appConfig := &apidef.APIDefinition{}
 	if err := json.Unmarshal(apiDef, appConfig); err != nil {
-		log.Error("[RPC] --> Couldn't unmarshal api configuration")
-		log.Error(err)
+		log.Error("[RPC] --> Couldn't unmarshal api configuration: ", err)
 	}
 
 	// Got the structured version - now lets get a raw copy for modules
@@ -435,8 +434,7 @@ func (a *APIDefinitionLoader) LoadDefinitions(dir string) []*APISpec {
 			appConfigBody, err := ioutil.ReadFile(filePath)
 			appConfig, rawConfig := a.ParseDefinition(appConfigBody)
 			if err != nil {
-				log.Error("Couldn't load app configuration file")
-				log.Error(err)
+				log.Error("Couldn't load app configuration file: ", err)
 			}
 
 			appConfig.RawData = rawConfig // Lets keep a copy for plugable modules
@@ -1068,8 +1066,7 @@ func (a *APISpec) IsThisAPIVersionExpired(versionDef *apidef.VersionInfo) bool {
 	// otherwise - calculate the time
 	t, err := time.Parse("2006-01-02 15:04", versionDef.Expires)
 	if err != nil {
-		log.Error("Could not parse expiry date for API, dissallow")
-		log.Error(err)
+		log.Error("Could not parse expiry date for API, dissallow: ", err)
 		return true
 	}
 

--- a/auth_manager.go
+++ b/auth_manager.go
@@ -61,8 +61,7 @@ func (b *DefaultAuthorisationManager) IsKeyAuthorised(keyName string) (SessionSt
 	}
 
 	if err := json.Unmarshal([]byte(jsonKeyVal), &newSession); err != nil {
-		log.Error("Couldn't unmarshal session object")
-		log.Error(err)
+		log.Error("Couldn't unmarshal session object: ", err)
 		return newSession, false
 	}
 

--- a/config.go
+++ b/config.go
@@ -266,8 +266,7 @@ func WriteDefaultConf(conf *Config) {
 	}
 	newConfig, err := json.MarshalIndent(conf, "", "    ")
 	if err != nil {
-		log.Error("Problem marshalling default configuration!")
-		log.Error(err)
+		log.Error("Problem marshalling default configuration: ", err)
 	} else if !runningTests {
 		ioutil.WriteFile("tyk.conf", newConfig, 0644)
 	}
@@ -280,8 +279,7 @@ func loadConfig(filePath string, conf *Config) {
 	configuration, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		if !runningTests {
-			log.Error("Couldn't load configuration file")
-			log.Error(err)
+			log.Error("Couldn't load configuration file: ", err)
 			log.Info("Writing a default file to ./tyk.conf")
 			WriteDefaultConf(conf)
 			log.Info("Loading default configuration...")
@@ -289,8 +287,7 @@ func loadConfig(filePath string, conf *Config) {
 		}
 	} else {
 		if err := json.Unmarshal(configuration, &conf); err != nil {
-			log.Error("Couldn't unmarshal configuration")
-			log.Error(err)
+			log.Error("Couldn't unmarshal configuration: ", err)
 		}
 
 		if err := envconfig.Process(ENV_PREVIX, conf); err != nil {

--- a/main.go
+++ b/main.go
@@ -933,10 +933,7 @@ func initialiseSystem(arguments map[string]interface{}) {
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "main",
-			}).Error("Port specified in flags must be a number!")
-			log.WithFields(logrus.Fields{
-				"prefix": "main",
-			}).Error(err)
+			}).Error("Port specified in flags must be a number: ", err)
 		} else {
 			config.ListenPort = portNum
 		}

--- a/oauth_manager.go
+++ b/oauth_manager.go
@@ -505,15 +505,13 @@ func (r *RedisOsinStorageInterface) GetClient(id string) (osin.Client, error) {
 
 	clientJSON, err := r.store.GetKey(key)
 	if err != nil {
-		log.Error("Failure retreiving client ID key: ", key)
-		log.Error(err)
+		log.Errorf("Failure retreiving client ID key %q: %v", key, err)
 		return nil, err
 	}
 
 	client := new(OAuthClient)
 	if err := json.Unmarshal([]byte(clientJSON), &client); err != nil {
-		log.Error("Couldn't unmarshal OAuth client object")
-		log.Error(err)
+		log.Error("Couldn't unmarshal OAuth client object: ", err)
 	}
 
 	return client, nil
@@ -528,15 +526,13 @@ func (r *RedisOsinStorageInterface) GetClientNoPrefix(id string) (osin.Client, e
 	clientJSON, err := r.store.GetKey(key)
 
 	if err != nil {
-		log.Error("Failure retreiving client ID key")
-		log.Error(err)
+		log.Error("Failure retreiving client ID key: ", err)
 		return nil, err
 	}
 
 	client := new(OAuthClient)
 	if err := json.Unmarshal([]byte(clientJSON), &client); err != nil {
-		log.Error("Couldn't unmarshal OAuth client object")
-		log.Error(err)
+		log.Error("Couldn't unmarshal OAuth client object: ", err)
 	}
 
 	return client, nil
@@ -565,8 +561,7 @@ func (r *RedisOsinStorageInterface) GetClients(filter string, ignorePrefix bool)
 	for _, clientJSON := range clientJSON {
 		client := new(OAuthClient)
 		if err := json.Unmarshal([]byte(clientJSON), &client); err != nil {
-			log.Error("Couldn't unmarshal OAuth client object")
-			log.Error(err)
+			log.Error("Couldn't unmarshal OAuth client object: ", err)
 			return theseClients, err
 		}
 		theseClients = append(theseClients, client)
@@ -580,8 +575,7 @@ func (r *RedisOsinStorageInterface) SetClient(id string, client osin.Client, ign
 	clientDataJSON, err := json.Marshal(client)
 
 	if err != nil {
-		log.Error("Couldn't marshal client data")
-		log.Error(err)
+		log.Error("Couldn't marshal client data: ", err)
 		return err
 	}
 
@@ -642,16 +636,14 @@ func (r *RedisOsinStorageInterface) LoadAuthorize(code string) (*osin.AuthorizeD
 	authJSON, err := r.store.GetKey(key)
 
 	if err != nil {
-		log.Error("Failure retreiving auth code key")
-		log.Error(err)
+		log.Error("Failure retreiving auth code key: ", err)
 		return nil, err
 	}
 
 	authData := osin.AuthorizeData{}
 	authData.Client = new(OAuthClient)
 	if err := json.Unmarshal([]byte(authJSON), &authData); err != nil {
-		log.Error("Couldn't unmarshal OAuth auth data object (LoadAuthorize)")
-		log.Error(err)
+		log.Error("Couldn't unmarshal OAuth auth data object (LoadAuthorize): ", err)
 		return nil, err
 	}
 
@@ -744,16 +736,14 @@ func (r *RedisOsinStorageInterface) LoadAccess(token string) (*osin.AccessData, 
 	accessJSON, err := r.store.GetKey(key)
 
 	if err != nil {
-		log.Error("Failure retreiving access token by key")
-		log.Error(err)
+		log.Error("Failure retreiving access token by key: ", err)
 		return nil, err
 	}
 
 	accessData := osin.AccessData{}
 	accessData.Client = new(OAuthClient)
 	if err := json.Unmarshal([]byte(accessJSON), &accessData); err != nil {
-		log.Error("Couldn't unmarshal OAuth auth data object (LoadAccess)")
-		log.Error(err)
+		log.Error("Couldn't unmarshal OAuth auth data object (LoadAccess): ", err)
 		return nil, err
 	}
 
@@ -778,8 +768,7 @@ func (r *RedisOsinStorageInterface) LoadRefresh(token string) (*osin.AccessData,
 	accessJSON, err := r.store.GetKey(key)
 
 	if err != nil {
-		log.Error("Failure retreiving access token by key")
-		log.Error(err)
+		log.Error("Failure retreiving access token by key: ", err)
 		return nil, err
 	}
 

--- a/redis_cluster_handler.go
+++ b/redis_cluster_handler.go
@@ -280,8 +280,7 @@ func (r *RedisClusterStorageManager) GetKeys(filter string) []string {
 	searchStr := r.KeyPrefix + r.hashKey(filter) + "*"
 	sessionsInterface, err := GetRelevantClusterReference(r.IsCache).Do("KEYS", searchStr)
 	if err != nil {
-		log.Error("Error trying to get all keys:")
-		log.Error(err)
+		log.Error("Error trying to get all keys: ", err)
 
 	} else {
 		sessions, _ := redis.Strings(sessionsInterface, err)
@@ -308,8 +307,7 @@ func (r *RedisClusterStorageManager) GetKeysAndValuesWithFilter(filter string) m
 	log.Debug("[STORE] Getting list by: ", searchStr)
 	sessionsInterface, err := GetRelevantClusterReference(r.IsCache).Do("KEYS", searchStr)
 	if err != nil {
-		log.Error("Error trying to get filtered client keys:")
-		log.Error(err)
+		log.Error("Error trying to get filtered client keys: ", err)
 
 	} else {
 		keys, _ := redis.Strings(sessionsInterface, err)
@@ -338,8 +336,7 @@ func (r *RedisClusterStorageManager) GetKeysAndValues() map[string]string {
 	searchStr := r.KeyPrefix + "*"
 	sessionsInterface, err := GetRelevantClusterReference(r.IsCache).Do("KEYS", searchStr)
 	if err != nil {
-		log.Error("Error trying to get all keys:")
-		log.Error(err)
+		log.Error("Error trying to get all keys: ", err)
 
 	} else {
 		keys, _ := redis.Strings(sessionsInterface, err)
@@ -369,8 +366,7 @@ func (r *RedisClusterStorageManager) DeleteKey(keyName string) bool {
 	log.Debug("DEL Key became: ", r.fixKey(keyName))
 	_, err := GetRelevantClusterReference(r.IsCache).Do("DEL", r.fixKey(keyName))
 	if err != nil {
-		log.Error("Error trying to delete key:")
-		log.Error(err)
+		log.Error("Error trying to delete key: ", err)
 	}
 
 	return true
@@ -387,8 +383,7 @@ func (r *RedisClusterStorageManager) DeleteRawKey(keyName string) bool {
 
 	_, err := GetRelevantClusterReference(r.IsCache).Do("DEL", keyName)
 	if err != nil {
-		log.Error("Error trying to delete key:")
-		log.Error(err)
+		log.Error("Error trying to delete key: ", err)
 	}
 
 	return true
@@ -464,8 +459,7 @@ func (r *RedisClusterStorageManager) DeleteKeys(keys []string) bool {
 		log.Debug("Deleting: ", asInterface)
 		_, err := GetRelevantClusterReference(r.IsCache).Do("DEL", asInterface...)
 		if err != nil {
-			log.Error("Error trying to delete keys:")
-			log.Error(err)
+			log.Error("Error trying to delete keys: ", err)
 		}
 	} else {
 		log.Debug("RedisClusterStorageManager called DEL - Nothing to delete")
@@ -492,8 +486,7 @@ func (r *RedisClusterStorageManager) DeleteRawKeys(keys []string, prefix string)
 		log.Debug("Deleting: ", asInterface)
 		_, err := GetRelevantClusterReference(r.IsCache).Do("DEL", asInterface...)
 		if err != nil {
-			log.Error("Error trying to delete keys:")
-			log.Error(err)
+			log.Error("Error trying to delete keys: ", err)
 		}
 	} else {
 		log.Debug("RedisClusterStorageManager called DEL - Nothing to delete")
@@ -540,8 +533,7 @@ func (r *RedisClusterStorageManager) Publish(channel, message string) error {
 	} else {
 		_, err := GetRelevantClusterReference(r.IsCache).Do("PUBLISH", channel, message)
 		if err != nil {
-			log.Error("Error trying to set value:")
-			log.Error(err)
+			log.Error("Error trying to set value: ", err)
 			return err
 		}
 	}
@@ -599,8 +591,7 @@ func (r *RedisClusterStorageManager) AppendToSet(keyName, value string) {
 		_, err := GetRelevantClusterReference(r.IsCache).Do("RPUSH", r.fixKey(keyName), value)
 
 		if err != nil {
-			log.Error("Error trying to delete keys:")
-			log.Error(err)
+			log.Error("Error trying to delete keys: ", err)
 		}
 
 		return
@@ -644,8 +635,7 @@ func (r *RedisClusterStorageManager) AddToSet(keyName, value string) {
 		_, err := GetRelevantClusterReference(r.IsCache).Do("SADD", r.fixKey(keyName), value)
 
 		if err != nil {
-			log.Error("Error trying to append keys:")
-			log.Error(err)
+			log.Error("Error trying to append keys: ", err)
 		}
 
 		return
@@ -663,8 +653,7 @@ func (r *RedisClusterStorageManager) RemoveFromSet(keyName, value string) {
 		_, err := GetRelevantClusterReference(r.IsCache).Do("SREM", r.fixKey(keyName), value)
 
 		if err != nil {
-			log.Error("Error trying to remove keys:")
-			log.Error(err)
+			log.Error("Error trying to remove keys: ", err)
 		}
 
 		return

--- a/redis_notifier_outbound.go
+++ b/redis_notifier_outbound.go
@@ -41,14 +41,12 @@ var _ Notifier = &RedisNotifier{}
 func (r *RedisNotifier) Notify(notification Notification) bool {
 	toSend, err := json.Marshal(notification)
 	if err != nil {
-		log.Error("Problem marshalling notification!")
-		log.Error(err)
+		log.Error("Problem marshalling notification: ", err)
 		return false
 	}
 	log.Debug("Sending notification", notification)
 	if err := r.store.Publish(r.channel, string(toSend)); err != nil {
-		log.Error("Could not send notification")
-		log.Error(err)
+		log.Error("Could not send notification: ", err)
 		return false
 	}
 	return true

--- a/rpc_analytics_purger.go
+++ b/rpc_analytics_purger.go
@@ -53,8 +53,7 @@ func (r *RPCPurger) PurgeCache() {
 			err := msgpack.Unmarshal(v.([]byte), &decoded)
 			log.Debug("Decoded Record: ", decoded)
 			if err != nil {
-				log.Error("Couldn't unmarshal analytics data:")
-				log.Error(err)
+				log.Error("Couldn't unmarshal analytics data: ", err)
 			} else {
 				keys[i] = decoded
 			}


### PR DESCRIPTION
For some reason, some error logs are split in two calls. This means that
the logs are more verbose since they take more lines, but worse than
that it means that due to multiple goroutines (race condition) the two
lines might not appear next to each other. That would mean a very
confusing log.

Note that logrus - unlike fmt.Print* funcs - doens't space arguments, so
we need to use ("foo: ", err) instead of ("foo:", err).

@buger as discussed. There weren't as many as I expected, though.