### PR TITLE
all: simplify bytes and strings use

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -129,7 +130,7 @@ func TestApiHandler(t *testing.T) {
 
 		makeSampleAPI(t, apiTestDef)
 
-		req, err := http.NewRequest(method, uri+param.Encode(), strings.NewReader(string(body)))
+		req, err := http.NewRequest(method, uri+param.Encode(), bytes.NewReader(body))
 
 		if err != nil {
 			t.Fatal(err)
@@ -166,7 +167,7 @@ func TestApiHandlerGetSingle(t *testing.T) {
 
 	makeSampleAPI(t, apiTestDef)
 
-	req, err := http.NewRequest(method, uri+param.Encode(), strings.NewReader(string(body)))
+	req, err := http.NewRequest(method, uri+param.Encode(), bytes.NewReader(body))
 
 	if err != nil {
 		t.Fatal(err)
@@ -255,7 +256,7 @@ func TestKeyHandlerNewKey(t *testing.T) {
 
 	makeSampleAPI(t, apiTestDef)
 	param.Set("api_id", "1")
-	req, err := http.NewRequest(method, uri+param.Encode(), strings.NewReader(string(body)))
+	req, err := http.NewRequest(method, uri+param.Encode(), bytes.NewReader(body))
 
 	if err != nil {
 		t.Fatal(err)
@@ -288,7 +289,7 @@ func TestKeyHandlerUpdateKey(t *testing.T) {
 	param := make(url.Values)
 	makeSampleAPI(t, apiTestDef)
 	param.Set("api_id", "1")
-	req, err := http.NewRequest(method, uri+param.Encode(), strings.NewReader(string(body)))
+	req, err := http.NewRequest(method, uri+param.Encode(), bytes.NewReader(body))
 
 	if err != nil {
 		t.Fatal(err)
@@ -380,7 +381,7 @@ func createKey() {
 
 	recorder := httptest.NewRecorder()
 	param := make(url.Values)
-	req, _ := http.NewRequest(method, uri+param.Encode(), strings.NewReader(string(body)))
+	req, _ := http.NewRequest(method, uri+param.Encode(), bytes.NewReader(body))
 
 	keyHandler(recorder, req)
 }
@@ -431,7 +432,7 @@ func TestCreateKeyHandlerCreateNewKey(t *testing.T) {
 	param := make(url.Values)
 	makeSampleAPI(t, apiTestDef)
 	param.Set("api_id", "1")
-	req, err := http.NewRequest(method, uri+param.Encode(), strings.NewReader(string(body)))
+	req, err := http.NewRequest(method, uri+param.Encode(), bytes.NewReader(body))
 
 	if err != nil {
 		t.Fatal(err)
@@ -466,7 +467,7 @@ func TestCreateKeyHandlerCreateNewKeyNoAPIID(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	param := make(url.Values)
 	makeSampleAPI(t, apiTestDef)
-	req, err := http.NewRequest(method, uri+param.Encode(), strings.NewReader(string(body)))
+	req, err := http.NewRequest(method, uri+param.Encode(), bytes.NewReader(body))
 
 	if err != nil {
 		t.Fatal(err)

--- a/batch_requests.go
+++ b/batch_requests.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -110,7 +109,7 @@ func (b *BatchRequestHandler) ConstructRequests(batchRequest BatchRequestStructu
 			absURL = requestDef.RelativeURL
 		}
 
-		request, err := http.NewRequest(requestDef.Method, absURL, bytes.NewBuffer([]byte(requestDef.Body)))
+		request, err := http.NewRequest(requestDef.Method, absURL, strings.NewReader(requestDef.Body))
 		if err != nil {
 			log.Error("Failure generating batch request for request spec index: ", i)
 			return nil, err

--- a/event_handler_webhooks.go
+++ b/event_handler_webhooks.go
@@ -187,7 +187,7 @@ func (w *WebHookHandler) checkURL(r string) bool {
 func (w *WebHookHandler) GetChecksum(reqBody string) (string, error) {
 	var rawRequest bytes.Buffer
 	// We do this twice because fuck it.
-	localRequest, _ := http.NewRequest(string(w.getRequestMethod(w.conf.Method)), w.conf.TargetPath, bytes.NewBuffer([]byte(reqBody)))
+	localRequest, _ := http.NewRequest(string(w.getRequestMethod(w.conf.Method)), w.conf.TargetPath, strings.NewReader(reqBody))
 
 	localRequest.Write(&rawRequest)
 	h := md5.New()
@@ -204,7 +204,7 @@ func (w *WebHookHandler) GetChecksum(reqBody string) (string, error) {
 }
 
 func (w *WebHookHandler) BuildRequest(reqBody string) (*http.Request, error) {
-	req, err := http.NewRequest(string(w.getRequestMethod(w.conf.Method)), w.conf.TargetPath, bytes.NewBuffer([]byte(reqBody)))
+	req, err := http.NewRequest(string(w.getRequestMethod(w.conf.Method)), w.conf.TargetPath, strings.NewReader(reqBody))
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "webhooks",

--- a/middleware_redis_cache.go
+++ b/middleware_redis_cache.go
@@ -274,7 +274,7 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 				return nil, 200
 			}
 
-			retObj := bytes.NewReader([]byte(cachedData))
+			retObj := strings.NewReader(cachedData)
 			log.Debug("Cache got: ", cachedData)
 
 			asBufioReader := bufio.NewReader(retObj)


### PR DESCRIPTION
Don't convert from string to []byte and vice-versa to use the other
package. This simplifies code and likely avoids extra work and copying
of data.