### PR TITLE
Set version to v2.4-HEAD

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-var VERSION = "v2.3.2"
+var VERSION = "v2.3.99"


### PR DESCRIPTION
master will become 2.4 at some point, so it should be 2.4* not 2.3*.
Don't call it just 2.4.0 as it's not yet finished. Don't call it alpha
or beta either as we haven't released anything.

Ideally, this would include the commit hash of the build. But this is
currently not possible to do with a simple `go get`, so just call it
HEAD.

This removes the confusion of Tyk reporting "version 2.3.2" on master,
which isn't true.