### PR TITLE
WIP: policy: use api_name and api_id tags

### DIFF
--- a/policy.go
+++ b/policy.go
@@ -33,8 +33,8 @@ type Policy struct {
 }
 
 type DBAccessDefinition struct {
-	APIName     string       `json:"apiname"`
-	APIID       string       `json:"apiid"`
+	APIName     string       `json:"api_name"`
+	APIID       string       `json:"api_id"`
 	Versions    []string     `json:"versions"`
 	AllowedURLs []AccessSpec `bson:"allowed_urls"  json:"allowed_urls"` // mapped string MUST be a valid regex
 }


### PR DESCRIPTION
These are what the rest of the API objects use. Be consistent.

Fixes #192.

Note that I don't know if this change will break anything. The only place I can find after a quick search is https://github.com/TykTechnologies/tyk-analytics/blob/4521ce0d6c81a7d835f68ab50edbabc94df76631/ApiAdminMethods.go#L204.

There's also https://github.com/TykTechnologies/tyk-analytics/blob/7440dfdb619d70589f609e18ad9ec52d178bf358/ModelKeys.go#L35, but that's bson so should be unaffected.

This is the best search query I could come up with, since GitHub doesn't allow searching for special characters like `"` or `:`:

https://github.com/search?utf8=%E2%9C%93&q=org%3ATykTechnologies+language%3Ago+string+json+apiid&type=Code&ref=searchresults