### PR TITLE
Removed mention of the Advanced Management API

### DIFF
--- a/api.go
+++ b/api.go
@@ -664,7 +664,7 @@ func HandleGetAPI(APIID string) ([]byte, int) {
 func HandleAddOrUpdateApi(APIID string, r *http.Request) ([]byte, int) {
 	if config.UseDBAppConfigs {
 		log.Error("Rejected new API Definition due to UseDBAppConfigs = true")
-		return createError("Due to enabled use_db_app_configs, please use Advanced Management API"), 500
+		return createError("Due to enabled use_db_app_configs, please use the Dashboard API"), 500
 	}
 
 	success := true

--- a/dashboard_register.go
+++ b/dashboard_register.go
@@ -188,7 +188,7 @@ func (h *HTTPDashboardHandler) SendHeartBeat(endpoint, secret string) error {
 
 	// Set the nonce
 	ServiceNonce = val.Nonce
-	log.Debug("Hearbeat Finished: Nonce Set: ", ServiceNonce)
+	log.Debug("Heartbeat Finished: Nonce Set: ", ServiceNonce)
 
 	return nil
 }


### PR DESCRIPTION
Have replaced mention of the "Advanced Management API" with its new name
(the "Dashboard API").
Have also fixed a minor typo that appeared in the Gateway logs.
Should fix #536 