### PR TITLE
api: disallow PUT /tyk/apis/

### DIFF
--- a/api.go
+++ b/api.go
@@ -781,7 +781,6 @@ func apiHandler(w http.ResponseWriter, r *http.Request) {
 	var responseMessage []byte
 	var code int
 
-	log.Debug(r.Method)
 	switch r.Method {
 	case "GET":
 		if APIID != "" {
@@ -795,10 +794,14 @@ func apiHandler(w http.ResponseWriter, r *http.Request) {
 		log.Debug("Creating new definition file")
 		responseMessage, code = HandleAddOrUpdateApi(APIID, r)
 	case "PUT":
-		log.Debug("Updating existing API: ", APIID)
-		responseMessage, code = HandleAddOrUpdateApi(APIID, r)
+		if APIID != "" {
+			log.Debug("Updating existing API: ", APIID)
+			responseMessage, code = HandleAddOrUpdateApi(APIID, r)
+		} else {
+			code = 400
+			responseMessage = createError("Must specify an APIID to update")
+		}
 	case "DELETE":
-		log.Debug("Deleting existing API: ", APIID)
 		if APIID != "" {
 			log.Debug("Deleting API definition for: ", APIID)
 			responseMessage, code = HandleDeleteAPI(APIID)

--- a/api_test.go
+++ b/api_test.go
@@ -245,6 +245,44 @@ func TestApiHandlerPostDbConfig(t *testing.T) {
 	}
 }
 
+func TestApiHandlerMethodAPIID(t *testing.T) {
+	base := "/tyk/apis"
+	tests := [...]struct {
+		method, path string
+		code         int
+	}{
+		// GET and POST can do either
+		{"GET", "/", 200},
+		{"GET", "/missing", 404},
+		{"POST", "/", 200},
+		{"POST", "/1", 200},
+		// PUT and DELETE must use one
+		{"PUT", "/1", 200},
+		{"PUT", "/", 400},
+		{"DELETE", "/1", 200},
+		{"DELETE", "/", 400},
+
+		// apiid mismatch
+		{"POST", "/mismatch", 400},
+		{"PUT", "/mismatch", 400},
+	}
+	for _, tc := range tests {
+		rec := httptest.NewRecorder()
+		url := base + tc.path
+		req, err := http.NewRequest(tc.method, url,
+			strings.NewReader(apiTestDef))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		apiHandler(rec, req)
+		if tc.code != rec.Code {
+			t.Errorf("%s %s got %d, want %d", tc.method, url,
+				rec.Code, tc.code)
+		}
+	}
+}
+
 func TestKeyHandlerNewKey(t *testing.T) {
 	uri := "/tyk/keys/1234"
 	method := "POST"


### PR DESCRIPTION
PUT without an argument doesn't make sense. Even worse, it can lead to
confusing outcomes like the creation of apps/.json.

Add tests too.

Fixes #157.
