### PR TITLE
Do all hot reloads with a queue and a worker

### DIFF
--- a/api.go
+++ b/api.go
@@ -566,7 +566,7 @@ func handleURLReload() ([]byte, int) {
 	var responseMessage []byte
 	var err error
 
-	ReloadURLStructure()
+	ReloadURLStructure(nil)
 
 	code := 200
 

--- a/api_definition.go
+++ b/api_definition.go
@@ -273,7 +273,6 @@ func (a *APIDefinitionLoader) LoadDefinitionsFromDashboardService(endpoint, secr
 
 	if response.StatusCode == 403 {
 		log.Error("Login failure, Response was: ", string(retBody))
-		reloadScheduled = false
 		ReLogin()
 		return APISpecs
 	}

--- a/coprocess_test_helpers.go
+++ b/coprocess_test_helpers.go
@@ -47,6 +47,7 @@ var CoProcessDispatchEvent = make(chan []byte)
 
 type TestDispatcher struct {
 	coprocess.Dispatcher
+	reloaded bool
 }
 
 /* Basic CoProcessDispatcher functions */
@@ -62,7 +63,7 @@ func (d *TestDispatcher) DispatchEvent(eventJSON []byte) {
 }
 
 func (d *TestDispatcher) Reload() {
-	CoProcessReload <- true
+	d.reloaded = true
 }
 
 /* General test helpers */

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -22,7 +22,7 @@ import (
 
 func init() {
 	runningTests = true
-	reloadInterval = 0
+	reloadInterval = 5 * time.Millisecond
 }
 
 // to register to, but never used

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -22,6 +22,7 @@ import (
 
 func init() {
 	runningTests = true
+	reloadInterval = 0
 }
 
 // to register to, but never used

--- a/policy.go
+++ b/policy.go
@@ -135,8 +135,6 @@ func LoadPoliciesFromDashboard(endpoint, secret string, allowExplicit bool) map[
 
 	if response.StatusCode == 403 {
 		log.Error("Policy request login failure, Response was: ", string(retBody))
-		reloadScheduled = false
-
 		ReLogin()
 		return policies
 	}

--- a/redis_cluster_handler.go
+++ b/redis_cluster_handler.go
@@ -432,8 +432,9 @@ func (r *RedisClusterStorageManager) DeleteRawKeys(keys []string, prefix string)
 	return true
 }
 
-// StartPubSubHandler will listen for a signal and run the callback with the message
-func (r *RedisClusterStorageManager) StartPubSubHandler(channel string, callback func(redis.Message)) error {
+// StartPubSubHandler will listen for a signal and run the callback for
+// every subscription and message event.
+func (r *RedisClusterStorageManager) StartPubSubHandler(channel string, callback func(interface{})) error {
 	if GetRelevantClusterReference(r.IsCache) == nil {
 		return errors.New("Redis connection failed")
 	}
@@ -455,7 +456,7 @@ func (r *RedisClusterStorageManager) StartPubSubHandler(channel string, callback
 			callback(v)
 
 		case redis.Subscription:
-			log.Debug("Subscription started: ", v.Channel)
+			callback(v)
 
 		case error:
 			log.Error("Redis disconnected or error received, attempting to reconnect: ", v)

--- a/redis_signal_outbound.go
+++ b/redis_signal_outbound.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
-
 	"github.com/TykTechnologies/logrus"
 )
 
@@ -47,7 +45,7 @@ func (u *RedisNotificationHandler) StartUIPubSubConn() {
 	u.CacheStore.Connect()
 	// On message, synchronize
 	for {
-		err := u.CacheStore.StartPubSubHandler(UIChanName, u.HandleIncommingRedisMessage)
+		err := u.CacheStore.StartPubSubHandler(UIChanName, u.HandleIncommingRedisEvent)
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "log-notifications",
@@ -60,12 +58,12 @@ func (u *RedisNotificationHandler) StartUIPubSubConn() {
 			}).Warning("Reconnecting")
 
 			u.CacheStore.Connect()
-			u.CacheStore.StartPubSubHandler(UIChanName, u.HandleIncommingRedisMessage)
+			u.CacheStore.StartPubSubHandler(UIChanName, u.HandleIncommingRedisEvent)
 		}
 
 	}
 }
 
-func (u *RedisNotificationHandler) HandleIncommingRedisMessage(message redis.Message) {
-	log.Debug("Inbound message received")
+func (u *RedisNotificationHandler) HandleIncommingRedisEvent(v interface{}) {
+	log.Debug("Inbound redis event received")
 }

--- a/redis_signals.go
+++ b/redis_signals.go
@@ -93,7 +93,7 @@ func HandleReloadMsg() {
 	log.WithFields(logrus.Fields{
 		"prefix": "pub-sub",
 	}).Info("Reloading endpoints")
-	ReloadURLStructure()
+	ReloadURLStructure(nil)
 }
 
 var warnedOnce bool

--- a/redis_signals.go
+++ b/redis_signals.go
@@ -20,7 +20,7 @@ func StartPubSubLoop() {
 	CacheStore.Connect()
 	// On message, synchronise
 	for {
-		err := CacheStore.StartPubSubHandler(RedisPubSubChannel, HandleRedisMsg)
+		err := CacheStore.StartPubSubHandler(RedisPubSubChannel, HandleRedisEvent)
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "pub-sub",
@@ -33,13 +33,17 @@ func StartPubSubLoop() {
 			}).Warning("Reconnecting")
 
 			CacheStore.Connect()
-			CacheStore.StartPubSubHandler(RedisPubSubChannel, HandleRedisMsg)
+			CacheStore.StartPubSubHandler(RedisPubSubChannel, HandleRedisEvent)
 		}
 
 	}
 }
 
-func HandleRedisMsg(message redis.Message) {
+func HandleRedisEvent(v interface{}) {
+	message, ok := v.(redis.Message)
+	if !ok {
+		return
+	}
 	notif := Notification{}
 	if err := json.Unmarshal(message.Data, &notif); err != nil {
 		log.Error("Unmarshalling message body failed, malformed: ", err)


### PR DESCRIPTION
The former method was racey and could lead to multiple reloads happening
simultaneously.

Fixes #506.