### PR TITLE
Do all hot reloads with a queue and a worker (backport)

### DIFF
--- a/api_definition_manager.go
+++ b/api_definition_manager.go
@@ -427,7 +427,6 @@ func (a *APIDefinitionLoader) LoadDefinitionsFromDashboardService(endpoint strin
 
 	if response.StatusCode == 403 {
 		log.Error("Login failure, Response was: ", string(retBody))
-		reloadScheduled = false
 		ReLogin()
 		return &APISpecs
 	}

--- a/main.go
+++ b/main.go
@@ -695,8 +695,6 @@ func RPCReloadLoop(RPCKey string) {
 }
 
 func doReload() {
-	time.Sleep(10 * time.Second)
-
 	// Load the API Policies
 	getPolicies()
 
@@ -714,7 +712,6 @@ func doReload() {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Warning("No API Definitions found, not reloading")
-		reloadScheduled = false
 		return
 	}
 
@@ -758,23 +755,40 @@ func doReload() {
 	// Unset these
 	RPC_EmergencyModeLoaded = false
 	RPC_EmergencyMode = false
-
-	reloadScheduled = false
 }
 
-var reloadScheduled bool
+var (
+	// reloadInterval is the amount of time to sleep after every
+	// reload. In other words, a reload will run at most once every
+	// reloadInterval.
+	reloadInterval = 10 * time.Second
 
-func checkReloadTimeout() {
-	if reloadScheduled {
-		wait := config.ReloadWaitTime
-		if config.ReloadWaitTime == 0 {
-			wait = 10
+	// reloadChan is a queue for incoming reload requests. At most,
+	// we want to have one reload running and one queued. If one is
+	// already queued, any reload requests should do nothing as a
+	// reload is already going to start at some point. Hence, buffer
+	// of size 1.
+	reloadChan = make(chan struct{}, 1)
+
+	// reloadDone is for the tests - for every reload request, the
+	// gateway will send true if it was queued and finished
+	// executing, or false if it wasn't queued since there already
+	// was one queued.
+	reloadDone chan (bool)
+)
+
+func reloadLoop() {
+	for range reloadChan {
+		log.Info("Initiating reload")
+		doReload()
+		log.Info("Initiating coprocess reload")
+		doCoprocessReload()
+
+		select {
+		case reloadDone <- true:
+		default:
 		}
-		time.Sleep(time.Duration(wait) * time.Second)
-		if reloadScheduled {
-			log.Warning("Reloader timed out! Removing sentinel")
-			reloadScheduled = false
-		}
+		time.Sleep(reloadInterval)
 	}
 }
 
@@ -782,14 +796,15 @@ func checkReloadTimeout() {
 // instance and then replace the DefaultServeMux with the new one, this enables a
 // reconfiguration to take place without stopping any requests from being handled.
 func ReloadURLStructure() {
-	if !reloadScheduled {
-		reloadScheduled = true
-		log.Info("Initiating reload")
-		go doReload()
-		log.Info("Initiating coprocess reload")
-		go doCoprocessReload()
-		log.Info("Starting reload monitor...")
-		go checkReloadTimeout()
+	select {
+	case reloadChan <- struct{}{}:
+		log.Info("Reload queued")
+	default:
+		log.Info("Reload already queued")
+		select {
+		case reloadDone <- false:
+		default:
+		}
 	}
 }
 
@@ -966,6 +981,8 @@ func initialiseSystem(arguments map[string]interface{}) {
 	//doInstrumentation, _ := arguments["--log-instrumentation"].(bool)
 	//SetupInstrumentation(doInstrumentation)
 	SetupInstrumentation(true)
+
+	go reloadLoop()
 
 	go StartPeriodicStateBackup(&LE_MANAGER)
 }

--- a/policy.go
+++ b/policy.go
@@ -139,8 +139,6 @@ func LoadPoliciesFromDashboard(endpoint string, secret string, allowExplicit boo
 
 	if response.StatusCode == 403 {
 		log.Error("Policy request login failure, Response was: ", string(retBody))
-		reloadScheduled = false
-
 		ReLogin()
 		return policies
 	}


### PR DESCRIPTION
The former method was racey and could lead to multiple reloads happening
simultaneously.

Keep the 10s sleep between reloads, but move it to the right place in
the new design. Set it to 0 in the tests to not have them wait for 10s
for no reason.

Fixes #506.

Note that this PR is a backport of https://github.com/TykTechnologies/tyk/pull/544 minus the tests and redis changes. Pulling the tests would mean pulling more non-test code, and this is all the non-test code we want to backport.

QA testing should suffice to verify that reloads still work, both when used normally and when tons of reloads are sent to the gateway at once.