### PR TITLE
Limit hot reloads to once per 1s, not 10s

### DIFF
--- a/main.go
+++ b/main.go
@@ -701,7 +701,7 @@ var (
 	// reloadInterval is the amount of time to sleep after every
 	// reload. In other words, a reload will run at most once every
 	// reloadInterval.
-	reloadInterval = 10 * time.Second
+	reloadInterval = 1 * time.Second
 
 	// reloadChan is a queue for incoming reload requests. At most,
 	// we want to have one reload running and one queued. If one is


### PR DESCRIPTION
It makes sense to have some limit, as we don't want to allow continuous
reloads which could spin the CPU and slow down the gateway.

On the other hand, 10s seems a bit excessive. 1s still keeps the cpu
from spinning, yet reduces the amount of time that a user has to wait
for a reload from 0-10s to 0-1s.

This means we can say that hot reloads should take effect within a
second, which means they take effect almost instantaneously.

/cc @buger @lonelycode 