### PR TITLE
Remove useless code from redis pub/sub loop (backport)

### DIFF
--- a/redis_signals.go
+++ b/redis_signals.go
@@ -29,9 +29,6 @@ func StartPubSubLoop() {
 			log.WithFields(logrus.Fields{
 				"prefix": "pub-sub",
 			}).Warning("Reconnecting")
-
-			CacheStore.Connect()
-			CacheStore.StartPubSubHandler(RedisPubSubChannel, HandleRedisMsg)
 		}
 
 	}


### PR DESCRIPTION
Calling Connect() multiple times is useless, as it doesn't actually
reconnect. It is handled under the hood by rediscluster.

We also call StartPubSubHandler twice per loop iteration. It's not
particularly harmful, but it's worrying that we run it here without
checking for an error.