### PR TITLE
test: make api method tests keep /1 in place

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -259,11 +259,11 @@ func TestApiHandlerMethodAPIID(t *testing.T) {
 		{"GET", "/missing", 404},
 		{"POST", "/", 200},
 		{"POST", "/1", 200},
-		// PUT and DELETE must use one
-		{"PUT", "/1", 200},
-		{"PUT", "/", 400},
+		// DELETE and PUT must use one
 		{"DELETE", "/1", 200},
 		{"DELETE", "/", 400},
+		{"PUT", "/1", 200},
+		{"PUT", "/", 400},
 
 		// apiid mismatch
 		{"POST", "/mismatch", 400},


### PR DESCRIPTION
Lots of tests create the api /1, and some depend on it - like the reload
tests, since a reload won't happen if there are no apis. Make this test
leave things as it found them, by not having the DELETE be the last
command.