### PR TITLE
Don't check for nil and empty slices

### DIFF
--- a/main.go
+++ b/main.go
@@ -643,14 +643,6 @@ func doReload() {
 
 	// load the specs
 	specs := getAPISpecs()
-
-	if specs == nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "main",
-		}).Warning("No API Definitions found (nil), not reloading")
-		return
-	}
-
 	if len(specs) == 0 {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",

--- a/middleware_granular_access.go
+++ b/middleware_granular_access.go
@@ -39,11 +39,6 @@ func (m *GranularAccessMiddleware) ProcessRequest(w http.ResponseWriter, r *http
 		return nil, 200
 	}
 
-	if sessionVersionData.AllowedURLs == nil {
-		log.Debug("No allowed URLS")
-		return nil, 200
-	}
-
 	if len(sessionVersionData.AllowedURLs) == 0 {
 		log.Debug("No allowed URLS")
 		return nil, 200


### PR DESCRIPTION
If a slice is nil, its len() is already 0. Checking both is redundant.

This might have been useful back when these were *[]Foo, but we got rid
of them.