### PR TITLE
Simplify ignored redis notification commands

### DIFF
--- a/redis_signals.go
+++ b/redis_signals.go
@@ -48,13 +48,8 @@ func HandleRedisEvent(v interface{}) {
 	}
 
 	// Add messages to ignore here
-	ignoreMessageList := map[NotificationCommand]bool{
-		NoticeGatewayConfigResponse: true,
-	}
-
-	// Don't react to all messages
-	_, ignore := ignoreMessageList[notif.Command]
-	if ignore {
+	switch notif.Command {
+	case NoticeGatewayConfigResponse:
 		return
 	}
 


### PR DESCRIPTION
No need to construct a map to use it immediately, even less so if it's
got a really small amount of elements.