### PR TITLE
Use the rpc key argument in its reload loop

### DIFF
--- a/main.go
+++ b/main.go
@@ -632,9 +632,9 @@ func notifyAPILoaded(spec *APISpec) {
 
 }
 
-func RPCReloadLoop(RPCKey string) {
+func RPCReloadLoop(rpcKey string) {
 	for {
-		RPCListener.CheckForReload(config.SlaveOptions.RPCKey)
+		RPCListener.CheckForReload(rpcKey)
 	}
 }
 


### PR DESCRIPTION
Probably harmless, since config.SlaveOptions.RPCKey is the only thing it
ever gets passed, but still confusing.