### PR TITLE
Simplify map accesses

### DIFF
--- a/main.go
+++ b/main.go
@@ -835,7 +835,7 @@ func initialiseSystem(arguments map[string]interface{}) {
 		log.Level = logrus.ErrorLevel
 		log.Out = ioutil.Discard
 		gorpc.SetErrorLogger(func(string, ...interface{}) {})
-	} else if dbg, _ := arguments["--debug"]; dbg == true {
+	} else if arguments["--debug"] == true {
 		log.Level = logrus.DebugLevel
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
@@ -843,11 +843,10 @@ func initialiseSystem(arguments map[string]interface{}) {
 	}
 
 	filename := "/etc/tyk/tyk.conf"
-	value, _ := arguments["--conf"]
-	if value != nil {
+	if conf := arguments["--conf"]; conf != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
-		}).Debugf("Using %s for configuration", value.(string))
+		}).Debugf("Using %s for configuration", conf.(string))
 		filename = arguments["--conf"].(string)
 	} else {
 		log.WithFields(logrus.Fields{
@@ -865,8 +864,7 @@ func initialiseSystem(arguments map[string]interface{}) {
 
 	setupGlobals()
 
-	port, _ := arguments["--port"]
-	if port != nil {
+	if port := arguments["--port"]; port != nil {
 		portNum, err := strconv.Atoi(port.(string))
 		if err != nil {
 			log.WithFields(logrus.Fields{

--- a/redis_signal_handle_config.go
+++ b/redis_signal_handle_config.go
@@ -35,13 +35,12 @@ func WriteNewConfiguration(payload ConfigPayload) error {
 		return err
 	}
 
-	value, _ := argumentsBackup["--conf"]
 	filename := "./tyk.conf"
-	if value != nil {
+	if conf := argumentsBackup["--conf"]; conf != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "pub-sub",
-		}).Infof("Using %s for configuration", value.(string))
-		filename = argumentsBackup["--conf"].(string)
+		}).Infof("Using %s for configuration", conf.(string))
+		filename = conf.(string)
 	} else {
 		log.WithFields(logrus.Fields{
 			"prefix": "pub-sub",
@@ -53,13 +52,12 @@ func WriteNewConfiguration(payload ConfigPayload) error {
 }
 
 func GetExistingRawConfig() Config {
-	value, _ := argumentsBackup["--conf"]
 	filename := "./tyk.conf"
-	if value != nil {
+	if conf := argumentsBackup["--conf"]; conf != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "pub-sub",
-		}).Infof("Using %s for configuration", value.(string))
-		filename = argumentsBackup["--conf"].(string)
+		}).Infof("Using %s for configuration", conf.(string))
+		filename = conf.(string)
 	} else {
 		log.WithFields(logrus.Fields{
 			"prefix": "pub-sub",


### PR DESCRIPTION
If we're ignoring the second variable - the one that tells us whether or
not it was present - we don't need to fetch it.

Also simplify some of the logic while at it.