### PR TITLE
Remove go:generate msgp lines

### DIFF
--- a/coprocess.go
+++ b/coprocess.go
@@ -1,8 +1,5 @@
 // +build coprocess
 
-//go:generate msgp
-//msgp:ignore CoProcessor CoProcessMiddleware CoProcessMiddlewareConfig TykMiddleware
-
 package main
 
 import (

--- a/session_state.go
+++ b/session_state.go
@@ -1,5 +1,3 @@
-//go:generate msgp
-
 package main
 
 import (


### PR DESCRIPTION
These are only useful if we actually run them and commit the files.
Nobody did, as we have no *_gen.go files.

Remove them. If they are to be re-added, the generated files should be
too.