### PR TITLE
Shorten EventMessage fields

### DIFF
--- a/coprocess/python/README.md
+++ b/coprocess/python/README.md
@@ -142,14 +142,14 @@ This function will be called when the specified event occurs, Tyk will pass a Py
 ```json
 {  
    "TimeStamp": "2016-08-19 11:13:31.537047694 -0400 PYT",
-   "EventMetaData":{  
+   "Meta":{  
       "Path":"/coprocess-auth-tyk-api-test/",
       "Origin":"127.0.0.1",
       "Message":"Auth Failure",
       "OriginatingRequest":"R0VUIC9jb3Byb2Nlc3MtYXV0aC10eWstYXBpLXRlc3QvIEhUVFAvMS4xDQpIb3N0OiAxMjcuMC4wLjE6ODA4MA0KVXNlci1BZ2VudDogY3VybC83LjQzLjANCkFjY2VwdDogKi8qDQpBdXRob3JpemF0aW9uOiAxDQoNCg==",
       "Key":""
    },
-   "EventType": "AuthFailure"
+   "Type": "AuthFailure"
 }
 ```
 

--- a/coprocess_test.go
+++ b/coprocess_test.go
@@ -64,12 +64,12 @@ func TestCoProcessDispatchEvent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if wrapper.Event.EventType != EventAuthFailure {
+	if wrapper.Event.Type != EventAuthFailure {
 		t.Fatal("Wrong event type")
 	}
 
-	got := wrapper.Event.EventMetaData.(map[string]interface{})
-	if got["Message"] != meta.EventMetaDefault.Message || got["Path"] != meta.Path || got["Origin"] != meta.Origin || got["Key"] != meta.Key {
+	got := wrapper.Event.Meta.(map[string]interface{})
+	if got["Message"] != meta.Message || got["Path"] != meta.Path || got["Origin"] != meta.Origin || got["Key"] != meta.Key {
 		t.Fatalf("Wrong event metadata\ngot: %#v\nwant: %#v", got, meta)
 	}
 }

--- a/event_handler_webhooks_test.go
+++ b/event_handler_webhooks_test.go
@@ -100,7 +100,7 @@ func TestBuildRequest(t *testing.T) {
 
 func TestCreateBody(t *testing.T) {
 	em := EventMessage{
-		EventType: EventQuotaExceeded,
+		Type:      EventQuotaExceeded,
 		TimeStamp: "0",
 	}
 
@@ -130,8 +130,8 @@ func TestGet(t *testing.T) {
 	eventHandler := ev.(*WebHookHandler)
 
 	eventMessage := EventMessage{
-		EventType: EventKeyExpired,
-		EventMetaData: EventAuthFailureMeta{
+		Type: EventKeyExpired,
+		Meta: EventAuthFailureMeta{
 			EventMetaDefault: EventMetaDefault{Message: "THIS IS A TEST"},
 			Path:             "/banana",
 			Origin:           "tyk.io",
@@ -162,8 +162,8 @@ func TestPost(t *testing.T) {
 	eventHandler := ev.(*WebHookHandler)
 
 	eventMessage := EventMessage{
-		EventType: EventKeyExpired,
-		EventMetaData: EventAuthFailureMeta{
+		Type: EventKeyExpired,
+		Meta: EventAuthFailureMeta{
 			EventMetaDefault: EventMetaDefault{Message: "THIS IS A TEST"},
 			Path:             "/banana",
 			Origin:           "tyk.io",

--- a/event_handlers/sample/firebase_test.js
+++ b/event_handlers/sample/firebase_test.js
@@ -7,8 +7,8 @@ fbHandler.NewHandler(function(event, context) {
     
     /*      The Event object:
             {
-                "EventType": "Event Typ Code",
-                "EventMetaData": {
+                "Type": "Event Typ Code",
+                "Meta": {
                     "Message": "MEvent descriptions",
                     "Path": "/{{api_id}}/{{path}}",
                     "Origin": "1.1.1.1:PORT",
@@ -65,8 +65,8 @@ fbHandler.NewHandler(function(event, context) {
     log("URL: /middleware/fb/" + fbResponse.name + ".json")
     responseDetails = JSON.parse(TykMakeHttpRequest(JSON.stringify(getDetails))); 
     objDetails = JSON.parse(responseDetails.Body)
-    log("Key: " + objDetails.EventMetaData.Key);
-    log("Message: " + objDetails.EventMetaData.Message);
+    log("Key: " + objDetails.Meta.Key);
+    log("Message: " + objDetails.Meta.Message);
     log("--- DONE ---")
 });
 

--- a/event_handlers/sample/sample_event_handler.js
+++ b/event_handlers/sample/sample_event_handler.js
@@ -7,8 +7,8 @@ sampleHandler.NewHandler(function(event, context) {
     
     /* The Event object:
     {
-        "EventType": "Event Typ Code",
-        "EventMetaData": {
+        "Type": "Event Typ Code",
+        "Meta": {
             "Message": "MEvent descriptions",
             "Path": "/{{api_id}}/{{path}}",
             "Origin": "1.1.1.1:PORT",

--- a/event_handlers/sample/session_editor.js
+++ b/event_handlers/sample/session_editor.js
@@ -6,14 +6,14 @@ sessionHandler.NewHandler(function(event, context) {
     log("Running Session JSVM Handler");
     
     // Use the TykGetKeyData function to retrieve a session from the session store
-    var thisSession = JSON.parse(TykGetKeyData(event.EventMetaData.Key, context.APIID))
+    var thisSession = JSON.parse(TykGetKeyData(event.Meta.Key, context.APIID))
     log("Expires: " + thisSession.expires)
     
     // You can modify the object just like with the REST API
     thisSession.expires = thisSession.expires + 1000;
     
     // Use TykSetKeyData to set the key data back in the session store
-    TykSetKeyData(event.EventMetaData.Key, JSON.stringify(thisSession));
+    TykSetKeyData(event.Meta.Key, JSON.stringify(thisSession));
     
 });
 

--- a/event_system.go
+++ b/event_system.go
@@ -115,9 +115,9 @@ type EventTokenMeta struct {
 
 // EventMessage is a standard form to send event data to handlers
 type EventMessage struct {
-	EventType     apidef.TykEvent
-	EventMetaData interface{}
-	TimeStamp     string
+	Type      apidef.TykEvent
+	Meta      interface{}
+	TimeStamp string
 }
 
 // TykEventHandler defines an event handler, e.g. LogMessageEventHandler will handle an event by logging it to stdout.
@@ -191,9 +191,9 @@ func (t *TykMiddleware) FireEvent(name apidef.TykEvent, meta interface{}) {
 func fireEvent(name apidef.TykEvent, meta interface{}, handlers map[apidef.TykEvent][]TykEventHandler) {
 	if handlers, e := handlers[name]; e {
 		eventMessage := EventMessage{
-			EventMetaData: meta,
-			EventType:     name,
-			TimeStamp:     time.Now().Local().String(),
+			Meta:      meta,
+			Type:      name,
+			TimeStamp: time.Now().Local().String(),
 		}
 		for _, handler := range handlers {
 			go handler.HandleEvent(eventMessage)
@@ -223,16 +223,16 @@ func (l *LogMessageEventHandler) New(handlerConf interface{}) (TykEventHandler, 
 
 // HandleEvent will be fired when the event handler instance is found in an APISpec EventPaths object during a request chain
 func (l *LogMessageEventHandler) HandleEvent(em EventMessage) {
-	formattedMsgString := fmt.Sprintf("%s:%s", l.conf["prefix"].(string), em.EventType)
+	formattedMsgString := fmt.Sprintf("%s:%s", l.conf["prefix"].(string), em.Type)
 
 	// We can handle specific event types easily
-	if em.EventType == EventQuotaExceeded {
-		msgConf := em.EventMetaData.(EventQuotaExceededMeta)
+	if em.Type == EventQuotaExceeded {
+		msgConf := em.Meta.(EventQuotaExceededMeta)
 		formattedMsgString = fmt.Sprintf("%s:%s:%s:%s", formattedMsgString, msgConf.Key, msgConf.Origin, msgConf.Path)
 	}
 
-	if em.EventType == EventBreakerTriggered {
-		msgConf := em.EventMetaData.(EventCurcuitBreakerMeta)
+	if em.Type == EventBreakerTriggered {
+		msgConf := em.Meta.(EventCurcuitBreakerMeta)
 		formattedMsgString = fmt.Sprintf("%s:%s:%s: [STATUS] %v", formattedMsgString, msgConf.APIID, msgConf.Path, msgConf.CircuitEvent)
 	}
 

--- a/monitor.go
+++ b/monitor.go
@@ -10,8 +10,8 @@ func (m *Monitor) IsMonitorEnabled() bool {
 
 func (m *Monitor) Fire(sessionData *SessionState, key string, triggerLimit float64) {
 	em := EventMessage{
-		EventType: EventTriggerExceeded,
-		EventMetaData: EventTriggerExceededMeta{
+		Type: EventTriggerExceeded,
+		Meta: EventTriggerExceededMeta{
 			EventMetaDefault: EventMetaDefault{Message: "Quota trigger reached", OriginatingRequest: ""},
 			Org:              sessionData.OrgID,
 			Key:              key,

--- a/templates/breaker_webhook.json
+++ b/templates/breaker_webhook.json
@@ -1,7 +1,7 @@
 {
-    "event": "{{.EventType}}",
-    "message": "{{.EventMetaData.Message}}",
-    "api_id": "{{.EventMetaData.APIID}}",
-    "path": "{{.EventMetaData.Path}}",
-    "Status": "{{.EventMetaData.CircuitEvent}}"
+    "event": "{{.Type}}",
+    "message": "{{.Meta.Message}}",
+    "api_id": "{{.Meta.APIID}}",
+    "path": "{{.Meta.Path}}",
+    "Status": "{{.Meta.CircuitEvent}}"
 }

--- a/templates/default_webhook.json
+++ b/templates/default_webhook.json
@@ -1,46 +1,46 @@
-{{ if eq .EventType "HostDown"}}
+{{ if eq .Type "HostDown"}}
 {
-    "event": "{{.EventType}}",
-    "message": "{{.EventMetaData.Message}}",
-    "url": "{{.EventMetaData.HostInfo.CheckURL}}",
-    "response_code": "{{.EventMetaData.HostInfo.ResponseCode}}",
-    "tcp_error": "{{.EventMetaData.HostInfo.IsTCPError}}",
-    "host": "{{.EventMetaData.HostInfo.MetaData.host_name}}",
-    "api_id": "{{.EventMetaData.HostInfo.MetaData.api_id}}",
+    "event": "{{.Type}}",
+    "message": "{{.Meta.Message}}",
+    "url": "{{.Meta.HostInfo.CheckURL}}",
+    "response_code": "{{.Meta.HostInfo.ResponseCode}}",
+    "tcp_error": "{{.Meta.HostInfo.IsTCPError}}",
+    "host": "{{.Meta.HostInfo.MetaData.host_name}}",
+    "api_id": "{{.Meta.HostInfo.MetaData.api_id}}",
 }
-{{ else if eq .EventType "HostUp"}}
+{{ else if eq .Type "HostUp"}}
 {
-    "event": "{{.EventType}}",
-    "message": "{{.EventMetaData.Message}}",
-    "url": "{{.EventMetaData.HostInfo.CheckURL}}",
-    "response_code": "{{.EventMetaData.HostInfo.ResponseCode}}",
-    "tcp_error": "{{.EventMetaData.HostInfo.IsTCPError}}",
-    "host": "{{.EventMetaData.HostInfo.MetaData.host_name}}",
-    "api_id": "{{.EventMetaData.HostInfo.MetaData.api_id}}",
+    "event": "{{.Type}}",
+    "message": "{{.Meta.Message}}",
+    "url": "{{.Meta.HostInfo.CheckURL}}",
+    "response_code": "{{.Meta.HostInfo.ResponseCode}}",
+    "tcp_error": "{{.Meta.HostInfo.IsTCPError}}",
+    "host": "{{.Meta.HostInfo.MetaData.host_name}}",
+    "api_id": "{{.Meta.HostInfo.MetaData.api_id}}",
 }
-{{ else if eq .EventType "TriggerExceeded"}}
+{{ else if eq .Type "TriggerExceeded"}}
 {
-    "event": "{{.EventType}}",
-    "message": "{{.EventMetaData.Message}}",
-    "org": "{{.EventMetaData.Org}}",
-    "key": "{{.EventMetaData.Key}}",
-    "trigger_limit": "{{.EventMetaData.TriggerLimit}}"
+    "event": "{{.Type}}",
+    "message": "{{.Meta.Message}}",
+    "org": "{{.Meta.Org}}",
+    "key": "{{.Meta.Key}}",
+    "trigger_limit": "{{.Meta.TriggerLimit}}"
 }
-{{ else if eq .EventType "BreakerTriggered"}}
+{{ else if eq .Type "BreakerTriggered"}}
 {
-    "event": "{{.EventType}}",
-    "message": "{{.EventMetaData.Message}}",
-    "api_id": "{{.EventMetaData.APIID}}",
-    "path": "{{.EventMetaData.Path}}",
-    "Status": "{{.EventMetaData.CircuitEvent}}"
+    "event": "{{.Type}}",
+    "message": "{{.Meta.Message}}",
+    "api_id": "{{.Meta.APIID}}",
+    "path": "{{.Meta.Path}}",
+    "Status": "{{.Meta.CircuitEvent}}"
 }
 {{ else}}
 {
-    "event": "{{.EventType}}",
-    "message": "{{.EventMetaData.Message}}",
-    "path": "{{.EventMetaData.Path}}",
-    "origin": "{{.EventMetaData.Origin}}",
-    "key": "{{.EventMetaData.Key}}"
+    "event": "{{.Type}}",
+    "message": "{{.Meta.Message}}",
+    "path": "{{.Meta.Path}}",
+    "origin": "{{.Meta.Origin}}",
+    "key": "{{.Meta.Key}}"
 }
 {{ end }}
 

--- a/templates/monitor_template.json
+++ b/templates/monitor_template.json
@@ -1,7 +1,7 @@
 {
-    "event": "{{.EventType}}",
-    "message": "{{.EventMetaData.Message}}",
-    "org": "{{.EventMetaData.Org}}",
-    "key": "{{.EventMetaData.Key}}",
-    "trigger_limit": "{{.EventMetaData.TriggerLimit}}"
+    "event": "{{.Type}}",
+    "message": "{{.Meta.Message}}",
+    "org": "{{.Meta.Org}}",
+    "key": "{{.Meta.Key}}",
+    "trigger_limit": "{{.Meta.TriggerLimit}}"
 }


### PR DESCRIPTION
There is no reason for the fields to repeat Event. This simplifies its
usage.

Also simplify event meta selector in the tests.