### PR TITLE
Deduplicate some types

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -795,11 +795,11 @@ func (a *APIDefinitionLoader) getExtendedPathSpecs(apiVersionDef apidef.VersionI
 	return combinedPath, len(whiteListPaths) > 0
 }
 
-func (a *APISpec) Init(authStore StorageHandler, sessionStore StorageHandler, healthStorageHandler StorageHandler, orgStorageHandler StorageHandler) {
+func (a *APISpec) Init(authStore, sessionStore, healthStore, orgStore StorageHandler) {
 	a.AuthManager.Init(authStore)
 	a.SessionManager.Init(sessionStore)
-	a.Health.Init(healthStorageHandler)
-	a.OrgSessionManager.Init(orgStorageHandler)
+	a.Health.Init(healthStore)
+	a.OrgSessionManager.Init(orgStore)
 }
 
 func (a *APISpec) getURLStatus(stat URLStatus) RequestStatus {

--- a/api_definition_test.go
+++ b/api_definition_test.go
@@ -434,7 +434,7 @@ func TestGetAPISpecsRPCFailure(t *testing.T) {
 	dispatcher.AddFunc("GetApiDefinitions", func(clientAddr string, dr *DefRequest) (string, error) {
 		return "malformed json", nil
 	})
-	dispatcher.AddFunc("Login", func(clientAddr string, userKey string) bool {
+	dispatcher.AddFunc("Login", func(clientAddr, userKey string) bool {
 		return true
 	})
 
@@ -453,7 +453,7 @@ func TestGetAPISpecsRPCSuccess(t *testing.T) {
 	dispatcher.AddFunc("GetApiDefinitions", func(clientAddr string, dr *DefRequest) (string, error) {
 		return "[{}]", nil
 	})
-	dispatcher.AddFunc("Login", func(clientAddr string, userKey string) bool {
+	dispatcher.AddFunc("Login", func(clientAddr, userKey string) bool {
 		return true
 	})
 

--- a/coprocess_api.go
+++ b/coprocess_api.go
@@ -29,7 +29,7 @@ const CoProcessDefaultKeyPrefix = "coprocess-data:"
 
 // TykStoreData is a CoProcess API function for storing data.
 //export TykStoreData
-func TykStoreData(CKey *C.char, CValue *C.char, CTTL C.int) {
+func TykStoreData(CKey, CValue *C.char, CTTL C.int) {
 	key := C.GoString(CKey)
 	value := C.GoString(CValue)
 	ttl := int64(CTTL)
@@ -51,7 +51,7 @@ func TykGetData(CKey *C.char) *C.char {
 
 // TykTriggerEvent is a CoProcess API function for triggering Tyk system events.
 //export TykTriggerEvent
-func TykTriggerEvent(CEventName *C.char, CPayload *C.char) {
+func TykTriggerEvent(CEventName, CPayload *C.char) {
 	eventName := C.GoString(CEventName)
 	payload := C.GoString(CPayload)
 
@@ -62,7 +62,7 @@ func TykTriggerEvent(CEventName *C.char, CPayload *C.char) {
 
 // CoProcessLog is a bridge for using Tyk log from CP.
 //export CoProcessLog
-func CoProcessLog(CMessage *C.char, CLogLevel *C.char) {
+func CoProcessLog(CMessage, CLogLevel *C.char) {
 	message := C.GoString(CMessage)
 	logLevel := C.GoString(CLogLevel)
 	switch logLevel {

--- a/main.go
+++ b/main.go
@@ -1259,7 +1259,7 @@ func startDRL() {
 	}
 }
 
-func listen(l net.Listener, controlListener net.Listener, err error) {
+func listen(l, controlListener net.Listener, err error) {
 	readtimeout := 120
 	writeTimeout := 120
 	targetPort := fmt.Sprintf("%s:%d", config.ListenAddress, config.ListenPort)


### PR DESCRIPTION
Func signatures don't need to duplicate contiguous types.