### PR TITLE
Use GetIPFromRequest helper func everywhere

### DIFF
--- a/api.go
+++ b/api.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -1291,7 +1290,7 @@ func createKeyHandler(w http.ResponseWriter, r *http.Request) {
 						"org_id":      newSession.OrgID,
 						"api_id":      "--",
 						"user_id":     "system",
-						"user_ip":     getIPHelper(r),
+						"user_ip":     GetIPFromRequest(r),
 						"path":        "--",
 						"server_name": "system",
 					}).Warning("No API Access Rights set on key session, adding key to all APIs.")
@@ -1318,7 +1317,7 @@ func createKeyHandler(w http.ResponseWriter, r *http.Request) {
 						"org_id":      newSession.OrgID,
 						"api_id":      "--",
 						"user_id":     "system",
-						"user_ip":     getIPHelper(r),
+						"user_ip":     GetIPFromRequest(r),
 						"path":        "--",
 						"server_name": "system",
 					}).Error("Master keys disallowed in configuration, key not added.")
@@ -1345,7 +1344,7 @@ func createKeyHandler(w http.ResponseWriter, r *http.Request) {
 					"org_id":      newSession.OrgID,
 					"api_id":      "--",
 					"user_id":     "system",
-					"user_ip":     getIPHelper(r),
+					"user_ip":     GetIPFromRequest(r),
 					"path":        "--",
 					"server_name": "system",
 				}).Error("System error, failed to generate key.")
@@ -1370,7 +1369,7 @@ func createKeyHandler(w http.ResponseWriter, r *http.Request) {
 					"api_id":      "--",
 					"org_id":      newSession.OrgID,
 					"user_id":     "system",
-					"user_ip":     getIPHelper(r),
+					"user_ip":     GetIPFromRequest(r),
 					"path":        "--",
 					"server_name": "system",
 				}).Info("Generated new key: (", ObfuscateKeyString(newKey), ")")
@@ -1884,19 +1883,6 @@ func UserRatesCheck() http.HandlerFunc {
 	}
 }
 
-func getIPHelper(r *http.Request) string {
-	if clientIP, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
-		// If we aren't the first proxy retain prior
-		// X-Forwarded-For information as a comma+space
-		// separated list and fold multiple headers into one.
-		if prior, ok := r.Header["X-Forwarded-For"]; ok {
-			clientIP = strings.Join(prior, ", ") + ", " + clientIP
-		}
-		return clientIP
-	}
-	return ""
-}
-
 func invalidateCacheHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "DELETE" {
 		doJSONWrite(w, 405, createError("Method not supported"))
@@ -1918,7 +1904,7 @@ func invalidateCacheHandler(w http.ResponseWriter, r *http.Request) {
 			"err":         err,
 			"org_id":      orgid,
 			"user_id":     "system",
-			"user_ip":     getIPHelper(r),
+			"user_ip":     GetIPFromRequest(r),
 			"path":        "--",
 			"server_name": "system",
 		}).Error("Failed to delete cache: ", err)
@@ -1935,7 +1921,7 @@ func invalidateCacheHandler(w http.ResponseWriter, r *http.Request) {
 		"org_id":      orgid,
 		"api_id":      apiID,
 		"user_id":     "system",
-		"user_ip":     getIPHelper(r),
+		"user_ip":     GetIPFromRequest(r),
 		"path":        "--",
 		"server_name": "system",
 	}).Info("Cache invalidated successfully")

--- a/config.go
+++ b/config.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -320,13 +319,7 @@ func (c *Config) StoreAnalytics(r *http.Request) bool {
 		return false
 	}
 
-	ip, _, _ := net.SplitHostPort(r.RemoteAddr)
-
-	forwarded := r.Header.Get("X-FORWARDED-FOR")
-	if forwarded != "" {
-		ips := strings.Split(forwarded, ", ")
-		ip = ips[0]
-	}
+	ip := GetIPFromRequest(r)
 	return !c.AnalyticsConfig.ignoredIPsCompiled[ip]
 }
 

--- a/handler_error.go
+++ b/handler_error.go
@@ -212,6 +212,7 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 		obfuscated = "****" + keyName[len(keyName)-4:]
 	}
 
+	// TODO: what is this bit of code for?
 	clientIP, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err == nil {
 		// If we aren't the first proxy retain prior

--- a/middleware_ip_whitelist.go
+++ b/middleware_ip_whitelist.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"net"
 	"net/http"
-	"strings"
 )
 
 // IPWhiteListMiddleware lets you define a list of IPs to allow upstream
@@ -53,21 +52,7 @@ func (i *IPWhiteListMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Re
 			allowedIP = net.ParseIP(ip)
 		}
 
-		splitIP := strings.Split(r.RemoteAddr, ":")
-		remoteIPString := splitIP[0]
-
-		// If X-Forwarded-For is set, override remoteIPString
-		forwarded := r.Header.Get("X-Forwarded-For")
-		if forwarded != "" {
-			ips := strings.Split(forwarded, ", ")
-			remoteIPString = ips[0]
-			log.Info("X-Forwarded-For set, remote IP: ", remoteIPString)
-		}
-
-		if len(splitIP) > 2 {
-			// Might be an IPv6 address, don't mess with it
-			remoteIPString = r.RemoteAddr
-		}
+		remoteIPString := GetIPFromRequest(r)
 		remoteIP = net.ParseIP(remoteIPString)
 
 		// Check CIDR if possible

--- a/middleware_ip_whitelist_test.go
+++ b/middleware_ip_whitelist_test.go
@@ -161,7 +161,7 @@ func TestIpMiddlewareIPFail(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	param := make(url.Values)
 	req, err := http.NewRequest(method, uri+param.Encode(), nil)
-	req.RemoteAddr = "127.0.0.1"
+	req.RemoteAddr = "127.0.0.1:80"
 	req.Header.Add("authorization", "1234wer")
 
 	if err != nil {
@@ -186,7 +186,7 @@ func TestIpMiddlewareIPPass(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	param := make(url.Values)
 	req, err := http.NewRequest(method, uri+param.Encode(), nil)
-	req.RemoteAddr = "127.0.0.1"
+	req.RemoteAddr = "127.0.0.1:80"
 	req.Header.Add("authorization", "gfgg1234")
 
 	if err != nil {
@@ -211,7 +211,7 @@ func TestIpMiddlewareIPPassCIDR(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	param := make(url.Values)
 	req, err := http.NewRequest(method, uri+param.Encode(), nil)
-	req.RemoteAddr = "127.0.0.2"
+	req.RemoteAddr = "127.0.0.2:80"
 	req.Header.Add("authorization", "gfgg1234")
 
 	if err != nil {
@@ -236,7 +236,7 @@ func TestIPMiddlewareIPFailXForwardedFor(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	param := make(url.Values)
 	req, err := http.NewRequest(method, uri+param.Encode(), nil)
-	req.RemoteAddr = "10.0.0.1"
+	req.RemoteAddr = "10.0.0.1:80"
 	req.Header.Add("authorization", "gfgg1234")
 
 	if err != nil {
@@ -261,7 +261,7 @@ func TestIPMiddlewareIPPassXForwardedFor(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	param := make(url.Values)
 	req, err := http.NewRequest(method, uri+param.Encode(), nil)
-	req.RemoteAddr = "10.0.0.1"
+	req.RemoteAddr = "10.0.0.1:80"
 	req.Header.Add("X-Forwarded-For", "127.0.0.1")
 	req.Header.Add("authorization", "gfgg1234")
 


### PR DESCRIPTION
We had semi-working copies all over the place. They were incomplete and
buggy like the old GetIPFromRequest, like how they missed ipv6 support.

Use the common helper func, which is also unit tested.