### PR TITLE
Add router tests and fix related issues

### DIFF
--- a/main.go
+++ b/main.go
@@ -1330,19 +1330,20 @@ func listen(l, controlListener net.Listener, err error) {
 			log.WithFields(logrus.Fields{
 				"prefix": "main",
 			}).Printf("Gateway started (%v)", VERSION)
-			if !RPC_EmergencyMode {
-				http.Handle("/", mainRouter)
-			}
-			go http.Serve(l, nil)
 
-			if controlListener != nil {
-				go http.Serve(controlListener, controlRouter)
+			if !RPC_EmergencyMode {
+				go http.Serve(l, mainRouter)
+
+				if controlListener != nil {
+					go http.Serve(controlListener, controlRouter)
+				}
+			} else {
+				go http.Serve(l, nil)
 			}
+
 			displayConfig()
 		}
-
 	} else {
-
 		// handle dashboard registration and nonces if available
 		nonce := os.Getenv("TYK_SERVICE_NONCE")
 		nodeID := os.Getenv("TYK_SERVICE_NODEID")
@@ -1410,8 +1411,12 @@ func listen(l, controlListener net.Listener, err error) {
 				"prefix": "main",
 			}).Printf("Gateway resumed (%v)", VERSION)
 			displayConfig()
-			http.Handle("/", mainRouter)
-			go http.Serve(l, nil)
+
+			go http.Serve(l, mainRouter)
+
+			if controlListener != nil {
+				go http.Serve(controlListener, controlRouter)
+			}
 		}
 
 		log.WithFields(logrus.Fields{

--- a/main.go
+++ b/main.go
@@ -1370,6 +1370,10 @@ func listen(l, controlListener net.Listener, err error) {
 			if specs != nil {
 				loadApps(specs, defaultRouter)
 				getPolicies()
+
+				if config.ControlAPIPort > 0 {
+					loadAPIEndpoints(controlRouter)
+				}
 			}
 
 			startHeartBeat()

--- a/main.go
+++ b/main.go
@@ -1261,11 +1261,11 @@ func startDRL() {
 }
 
 func listen(l, controlListener net.Listener, err error) {
-	readtimeout := 120
+	readTimeout := 120
 	writeTimeout := 120
 	targetPort := fmt.Sprintf("%s:%d", config.ListenAddress, config.ListenPort)
 	if config.HttpServerOptions.ReadTimeout > 0 {
-		readtimeout = config.HttpServerOptions.ReadTimeout
+		readTimeout = config.HttpServerOptions.ReadTimeout
 	}
 
 	if config.HttpServerOptions.WriteTimeout > 0 {
@@ -1308,7 +1308,7 @@ func listen(l, controlListener net.Listener, err error) {
 			}).Warning("HTTP Server Overrides detected, this could destabilise long-running http-requests")
 			s := &http.Server{
 				Addr:         ":" + targetPort,
-				ReadTimeout:  time.Duration(readtimeout) * time.Second,
+				ReadTimeout:  time.Duration(readTimeout) * time.Second,
 				WriteTimeout: time.Duration(writeTimeout) * time.Second,
 				Handler:      defaultRouter,
 			}
@@ -1386,7 +1386,7 @@ func listen(l, controlListener net.Listener, err error) {
 			}).Warning("HTTP Server Overrides detected, this could destabilise long-running http-requests")
 			s := &http.Server{
 				Addr:         ":" + targetPort,
-				ReadTimeout:  time.Duration(readtimeout) * time.Second,
+				ReadTimeout:  time.Duration(readTimeout) * time.Second,
 				WriteTimeout: time.Duration(writeTimeout) * time.Second,
 				Handler:      defaultRouter,
 			}

--- a/main.go
+++ b/main.go
@@ -333,6 +333,7 @@ func loadAPIEndpoints(muxer *mux.Router) {
 		apiMuxer.HandleFunc("/tyk/org/keys/{rest:.*}", checkIsAPIOwner(InstrumentationMW(orgHandler)))
 		apiMuxer.HandleFunc("/tyk/keys/policy/{rest:.*}", checkIsAPIOwner(InstrumentationMW(policyUpdateHandler)))
 		apiMuxer.HandleFunc("/tyk/keys/create", checkIsAPIOwner(InstrumentationMW(createKeyHandler)))
+		apiMuxer.HandleFunc("/tyk/apis", checkIsAPIOwner(InstrumentationMW(apiHandler)))
 		apiMuxer.HandleFunc("/tyk/apis/{rest:.*}", checkIsAPIOwner(InstrumentationMW(apiHandler)))
 		apiMuxer.HandleFunc("/tyk/health/", checkIsAPIOwner(InstrumentationMW(healthCheckhandler)))
 		apiMuxer.HandleFunc("/tyk/oauth/clients/create", checkIsAPIOwner(InstrumentationMW(createOauthClient)))

--- a/main.go
+++ b/main.go
@@ -1315,6 +1315,16 @@ func listen(l, controlListener net.Listener, err error) {
 
 			// Accept connections in a new goroutine.
 			go s.Serve(l)
+
+			if controlListener != nil {
+				cs := &http.Server{
+					ReadTimeout:  time.Duration(readTimeout) * time.Second,
+					WriteTimeout: time.Duration(writeTimeout) * time.Second,
+					Handler:      controlRouter,
+				}
+				go cs.Serve(controlListener)
+			}
+
 			displayConfig()
 		} else {
 			log.WithFields(logrus.Fields{
@@ -1380,6 +1390,16 @@ func listen(l, controlListener net.Listener, err error) {
 				"prefix": "main",
 			}).Info("Custom gateway started")
 			go s.Serve(l)
+
+			if controlListener != nil {
+				cs := &http.Server{
+					ReadTimeout:  time.Duration(readTimeout) * time.Second,
+					WriteTimeout: time.Duration(writeTimeout) * time.Second,
+					Handler:      controlRouter,
+				}
+				go cs.Serve(controlListener)
+			}
+
 			displayConfig()
 		} else {
 			log.WithFields(logrus.Fields{


### PR DESCRIPTION
Integration router tests run all combinations of using `goagain`, `config.HttpServerOptions.OverrideDefaults`, and control API on a separate port.

Following fixes are made:

* Fixed `/tyk/api` endpoint without slash #372
* Fixed control API when `config.HttpServerOptions.OverrideDefaults` is `true` (both when with
Goagain and without) #612 
* Fixed: do not bind control API if RPC_EmergencyMode turned on #612
* Fix Control API on a separate port in forked process #612
* Potential #531 fix by not using `http.Handle("/", …)` in favor of `http.Serve`