### PR TITLE
test: wait for TestResetHandler to finish reload

### DIFF
--- a/api.go
+++ b/api.go
@@ -545,11 +545,11 @@ func handleDeleteHashedKey(keyName, apiID string) ([]byte, int) {
 	return responseMessage, 200
 }
 
-func handleURLReload() ([]byte, int) {
+func handleURLReload(fn func()) ([]byte, int) {
 	var responseMessage []byte
 	var err error
 
-	reloadURLStructure(nil)
+	reloadURLStructure(fn)
 
 	statusObj := APIErrorMessage{"ok", ""}
 	responseMessage, err = json.Marshal(&statusObj)
@@ -1220,19 +1220,21 @@ func groupResetHandler(w http.ResponseWriter, r *http.Request) {
 	doJSONWrite(w, code, responseMessage)
 }
 
-func resetHandler(w http.ResponseWriter, r *http.Request) {
-	var responseMessage []byte
-	var code int
+func resetHandler(fn func()) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var responseMessage []byte
+		var code int
 
-	if r.Method == "GET" {
-		responseMessage, code = handleURLReload()
+		if r.Method == "GET" {
+			responseMessage, code = handleURLReload(fn)
 
-	} else {
-		code = 405
-		responseMessage = createError("Method not supported")
+		} else {
+			code = 405
+			responseMessage = createError("Method not supported")
+		}
+
+		doJSONWrite(w, code, responseMessage)
 	}
-
-	doJSONWrite(w, code, responseMessage)
 }
 
 func createKeyHandler(w http.ResponseWriter, r *http.Request) {

--- a/api_test.go
+++ b/api_test.go
@@ -609,12 +609,15 @@ func TestResetHandler(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	resetHandler(recorder, req)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	resetHandler(wg.Done)(recorder, req)
 
 	if recorder.Code != 200 {
 		t.Fatal("Hot reload failed, response code was: ", recorder.Code)
 	}
+	reloadTick <- time.Time{}
+	wg.Wait()
 
 	if len(ApiSpecRegister) == 0 {
 		t.Fatal("Hot reload was triggered but no APIs were found.")
@@ -676,8 +679,6 @@ func TestGroupResetHandler(t *testing.T) {
 	if len(ApiSpecRegister) == 0 {
 		t.Fatal("Hot reload (group) was triggered but no APIs were found.")
 	}
-
-	reloadTick <- time.Time{}
 
 	// We wait for the right notification (NoticeGroupReload), other
 	// type of notifications may be received during tests, as this

--- a/main.go
+++ b/main.go
@@ -327,7 +327,7 @@ func loadAPIEndpoints(muxer *mux.Router) {
 
 	// set up main API handlers
 	apiMuxer.HandleFunc("/tyk/reload/group", checkIsAPIOwner(InstrumentationMW(groupResetHandler)))
-	apiMuxer.HandleFunc("/tyk/reload/", checkIsAPIOwner(InstrumentationMW(resetHandler)))
+	apiMuxer.HandleFunc("/tyk/reload/", checkIsAPIOwner(InstrumentationMW(resetHandler(nil))))
 
 	if !isRPCMode() {
 		apiMuxer.HandleFunc("/tyk/org/keys/{rest:.*}", checkIsAPIOwner(InstrumentationMW(orgHandler)))


### PR DESCRIPTION
First off, the tick was correct but it was added to the wrong test. The
group reset test doesn't actually fire a hot reload, as we use our own
pub/sub handler that doesn't fire one.

It's the single-node reset (reload) test that does fire a hot reload.

Moreover, we also need to wait for the reload to be done. Otherwise, it
could be that the reload worker doesn't have the chance to pick up the
job from the queue and other tests that need the queue to be empty would
fail:

	$ go test -run '^Test(ResetHandler|HotReloadSingle)$' -v
	=== RUN   TestResetHandler
	--- PASS: TestResetHandler (0.01s)
	=== RUN   TestHotReloadSingle
	--- FAIL: TestHotReloadSingle (0.00s)
		api_test.go:692: reload wasn't queued

Given that I was able to reproduce the issue locally and the logs are
identic to those of the Travis failures, I'm confident to say that this
particular flake is now fixed.

Fixes #588.