### PR TITLE
Simplify some http.HandlerFunc code

### DIFF
--- a/coprocess_test.go
+++ b/coprocess_test.go
@@ -134,7 +134,7 @@ func TestCoProcessTykTriggerEvent(t *testing.T) {
 func buildCoProcessChain(spec *APISpec, hookName string, hookType coprocess.HookType, driver apidef.MiddlewareDriver) http.Handler {
 	remote, _ := url.Parse(spec.Proxy.TargetURL)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
-	proxyHandler := http.HandlerFunc(ProxyHandler(proxy, spec))
+	proxyHandler := ProxyHandler(proxy, spec)
 	tykMiddleware := &TykMiddleware{spec, proxy}
 	mw := CreateCoProcessMiddleware(hookName, hookType, driver, tykMiddleware)
 	return alice.New(mw).Then(proxyHandler)

--- a/main.go
+++ b/main.go
@@ -1106,11 +1106,11 @@ func start(arguments map[string]interface{}) {
 			"prefix": "main",
 		}).Debug("Adding pprof endpoints")
 
-		defaultRouter.HandleFunc("/debug/pprof/{rest:.*}", http.HandlerFunc(pprof_http.Index))
-		defaultRouter.HandleFunc("/debug/pprof/cmdline", http.HandlerFunc(pprof_http.Cmdline))
-		defaultRouter.HandleFunc("/debug/pprof/profile", http.HandlerFunc(pprof_http.Profile))
-		defaultRouter.HandleFunc("/debug/pprof/symbol", http.HandlerFunc(pprof_http.Symbol))
-		defaultRouter.HandleFunc("/debug/pprof/trace", http.HandlerFunc(pprof_http.Trace))
+		defaultRouter.HandleFunc("/debug/pprof/{rest:.*}", pprof_http.Index)
+		defaultRouter.HandleFunc("/debug/pprof/cmdline", pprof_http.Cmdline)
+		defaultRouter.HandleFunc("/debug/pprof/profile", pprof_http.Profile)
+		defaultRouter.HandleFunc("/debug/pprof/symbol", pprof_http.Symbol)
+		defaultRouter.HandleFunc("/debug/pprof/trace", pprof_http.Trace)
 	}
 
 	// Set up a default org manager so we can traverse non-live paths

--- a/middleware.go
+++ b/middleware.go
@@ -46,8 +46,8 @@ func CreateMiddleware(mw TykMiddlewareImplementation, tykMwSuper *TykMiddleware)
 		log.Fatal("[Middleware] Configuration load failed")
 	}
 
-	aliceHandler := func(h http.Handler) http.Handler {
-		handler := func(w http.ResponseWriter, r *http.Request) {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			job := instrument.NewJob("MiddlewareCall")
 			meta := health.Kvs{
 				"from_ip":  r.RemoteAddr,
@@ -95,10 +95,8 @@ func CreateMiddleware(mw TykMiddlewareImplementation, tykMwSuper *TykMiddleware)
 
 			job.TimingKv("exec_time", time.Since(startTime).Nanoseconds(), meta)
 			job.TimingKv(eventName+".exec_time", time.Since(startTime).Nanoseconds(), meta)
-		}
-		return http.HandlerFunc(handler)
+		})
 	}
-	return aliceHandler
 }
 
 func AppendMiddleware(chain *[]alice.Constructor, mw TykMiddlewareImplementation, tykMwSuper *TykMiddleware) {

--- a/middleware_auth_key_test.go
+++ b/middleware_auth_key_test.go
@@ -34,7 +34,7 @@ func createAuthKeyAuthSession() SessionState {
 func getAuthKeyChain(spec *APISpec) http.Handler {
 	remote, _ := url.Parse(spec.Proxy.TargetURL)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
-	proxyHandler := http.HandlerFunc(ProxyHandler(proxy, spec))
+	proxyHandler := ProxyHandler(proxy, spec)
 	tykMiddleware := &TykMiddleware{spec, proxy}
 	chain := alice.New(
 		CreateMiddleware(&IPWhiteListMiddleware{tykMiddleware}, tykMiddleware),

--- a/middleware_basic_auth_test.go
+++ b/middleware_basic_auth_test.go
@@ -66,7 +66,7 @@ func createBasicAuthSession() SessionState {
 func getBasicAuthChain(spec *APISpec) http.Handler {
 	remote, _ := url.Parse(testHttpAny)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
-	proxyHandler := http.HandlerFunc(ProxyHandler(proxy, spec))
+	proxyHandler := ProxyHandler(proxy, spec)
 	tykMiddleware := &TykMiddleware{spec, proxy}
 	chain := alice.New(
 		CreateMiddleware(&IPWhiteListMiddleware{tykMiddleware}, tykMiddleware),

--- a/middleware_hmac_test.go
+++ b/middleware_hmac_test.go
@@ -71,7 +71,7 @@ func createHMACAuthSession() SessionState {
 func getHMACAuthChain(spec *APISpec) http.Handler {
 	remote, _ := url.Parse(testHttpAny)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
-	proxyHandler := http.HandlerFunc(ProxyHandler(proxy, spec))
+	proxyHandler := ProxyHandler(proxy, spec)
 	tykMiddleware := &TykMiddleware{spec, proxy}
 	chain := alice.New(
 		CreateMiddleware(&IPWhiteListMiddleware{tykMiddleware}, tykMiddleware),

--- a/middleware_jwt_test.go
+++ b/middleware_jwt_test.go
@@ -234,7 +234,7 @@ func createJWTSessionWithRSAWithPolicy() SessionState {
 func getJWTChain(spec *APISpec) http.Handler {
 	remote, _ := url.Parse(testHttpAny)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
-	proxyHandler := http.HandlerFunc(ProxyHandler(proxy, spec))
+	proxyHandler := ProxyHandler(proxy, spec)
 	tykMiddleware := &TykMiddleware{spec, proxy}
 	chain := alice.New(
 		CreateMiddleware(&IPWhiteListMiddleware{tykMiddleware}, tykMiddleware),

--- a/multiauth_test.go
+++ b/multiauth_test.go
@@ -81,7 +81,7 @@ func createMultiBasicAuthSession() (session SessionState) {
 func getMultiAuthStandardAndBasicAuthChain(spec *APISpec) http.Handler {
 	remote, _ := url.Parse(testHttpAny)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
-	proxyHandler := http.HandlerFunc(ProxyHandler(proxy, spec))
+	proxyHandler := ProxyHandler(proxy, spec)
 	tykMiddleware := &TykMiddleware{spec, proxy}
 	chain := alice.New(
 		CreateMiddleware(&IPWhiteListMiddleware{tykMiddleware}, tykMiddleware),

--- a/oauth_manager_test.go
+++ b/oauth_manager_test.go
@@ -88,7 +88,7 @@ func getOAuthChain(spec *APISpec, muxer *mux.Router) {
 	addOAuthHandlers(spec, muxer, true)
 	remote, _ := url.Parse(testHttpAny)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
-	proxyHandler := http.HandlerFunc(ProxyHandler(proxy, spec))
+	proxyHandler := ProxyHandler(proxy, spec)
 	tykMiddleware := &TykMiddleware{spec, proxy}
 	chain := alice.New(
 		CreateMiddleware(&VersionCheck{TykMiddleware: tykMiddleware}, tykMiddleware),


### PR DESCRIPTION
Make ProxyHandler return an http.Handler to simplify its calling code.

Also, pprof_http funcs are already handler funcs, so no need to convert.