### PR TITLE
redis: remove another duplicate pub/sub call

### DIFF
--- a/redis_signal_outbound.go
+++ b/redis_signal_outbound.go
@@ -56,9 +56,6 @@ func (u *RedisNotificationHandler) StartUIPubSubConn() {
 			log.WithFields(logrus.Fields{
 				"prefix": "log-notifications",
 			}).Warning("Reconnecting")
-
-			u.CacheStore.Connect()
-			u.CacheStore.StartPubSubHandler(UIChanName, u.HandleIncommingRedisEvent)
 		}
 
 	}


### PR DESCRIPTION
In b9530aba, we removed a duplicate StartPubSubHandler call that wasn't
checking for errors. This is another case. Like in the previous commit,
the extra Connect() call is unnecessary as RedisClusterStorageManager
only connects once - it's the underlying rediscluster that manages
reconnects.

Updates #520.

@buger this would be a good candidate to backport into 2.3, as it could help with #520 and we backported the other commit that did the same but somewhere else.