### PR TITLE
Fix Control API on separate port if specs are empty

### DIFF
--- a/main.go
+++ b/main.go
@@ -240,7 +240,6 @@ func getAPISpecs() []*APISpec {
 
 		apiSpecs = APILoader.LoadDefinitionsFromRPC(config.SlaveOptions.RPCKey)
 	} else {
-
 		apiSpecs = APILoader.LoadDefinitions(config.AppPath)
 	}
 
@@ -1280,10 +1279,10 @@ func listen(l, controlListener net.Listener, err error) {
 			if specs != nil {
 				loadApps(specs, defaultRouter)
 				getPolicies()
+			}
 
-				if config.ControlAPIPort > 0 {
-					loadAPIEndpoints(controlRouter)
-				}
+			if config.ControlAPIPort > 0 {
+				loadAPIEndpoints(controlRouter)
 			}
 		}
 
@@ -1362,10 +1361,10 @@ func listen(l, controlListener net.Listener, err error) {
 			if specs != nil {
 				loadApps(specs, defaultRouter)
 				getPolicies()
+			}
 
-				if config.ControlAPIPort > 0 {
-					loadAPIEndpoints(controlRouter)
-				}
+			if config.ControlAPIPort > 0 {
+				loadAPIEndpoints(controlRouter)
 			}
 
 			startHeartBeat()


### PR DESCRIPTION
If Control API bind on separate port, and Tyk Gateways started first
time without any API’s, admin API will not work.

Addition to #612 fixes.

Tests was not failing, because some of the previous tests populate api
specs with test data. But if we run `TestControlListener` alone it will
fail.