### PR TITLE
Fix API reloads and add related tests

### DIFF
--- a/main.go
+++ b/main.go
@@ -1300,8 +1300,11 @@ func listen(l, controlListener net.Listener, err error) {
 				Addr:         ":" + targetPort,
 				ReadTimeout:  time.Duration(readTimeout) * time.Second,
 				WriteTimeout: time.Duration(writeTimeout) * time.Second,
-				Handler:      defaultRouter,
 			}
+
+			newServeMux := http.NewServeMux()
+			newServeMux.Handle("/", defaultRouter)
+			http.DefaultServeMux = newServeMux
 
 			// Accept connections in a new goroutine.
 			go s.Serve(l)
@@ -1321,14 +1324,16 @@ func listen(l, controlListener net.Listener, err error) {
 				"prefix": "main",
 			}).Printf("Gateway started (%v)", VERSION)
 
+			go http.Serve(l, nil)
+
 			if !RPC_EmergencyMode {
-				go http.Serve(l, mainRouter)
+				newServeMux := http.NewServeMux()
+				newServeMux.Handle("/", mainRouter)
+				http.DefaultServeMux = newServeMux
 
 				if controlListener != nil {
 					go http.Serve(controlListener, controlRouter)
 				}
-			} else {
-				go http.Serve(l, nil)
 			}
 
 			displayConfig()
@@ -1378,8 +1383,11 @@ func listen(l, controlListener net.Listener, err error) {
 				Addr:         ":" + targetPort,
 				ReadTimeout:  time.Duration(readTimeout) * time.Second,
 				WriteTimeout: time.Duration(writeTimeout) * time.Second,
-				Handler:      defaultRouter,
 			}
+
+			newServeMux := http.NewServeMux()
+			newServeMux.Handle("/", defaultRouter)
+			http.DefaultServeMux = newServeMux
 
 			log.WithFields(logrus.Fields{
 				"prefix": "main",
@@ -1400,13 +1408,20 @@ func listen(l, controlListener net.Listener, err error) {
 			log.WithFields(logrus.Fields{
 				"prefix": "main",
 			}).Printf("Gateway resumed (%v)", VERSION)
-			displayConfig()
 
-			go http.Serve(l, mainRouter)
+			go http.Serve(l, nil)
 
-			if controlListener != nil {
-				go http.Serve(controlListener, controlRouter)
+			if !RPC_EmergencyMode {
+				newServeMux := http.NewServeMux()
+				newServeMux.Handle("/", mainRouter)
+				http.DefaultServeMux = newServeMux
+
+				if controlListener != nil {
+					go http.Serve(controlListener, controlRouter)
+				}
 			}
+
+			displayConfig()
 		}
 
 		log.WithFields(logrus.Fields{


### PR DESCRIPTION
It broke because `doReload` functionality was using `DefaultServeMux` for routing, but our initial `listen` logic used custom muxer, which is created automatically if you pass non nil second argument to `http.Serve`.

Change which broke this functionality (#596) was intended to fix `panic` caused by multiple registrations of “/“ route handle #531.

We did not noticed this bug because we had no tests covering API reloads, and this PR adds them as well.

This PR fixes API reloads, and still ensure that no multiple route registrations will be made. It is achieved by creating new `newServeMux` and updating `http.DefaultServeMux` with it.

Note that our routing and reload functionality have a lot of duplication (in 3 places), and should be unified one day. Goal of this PR is to fix the bug, and not to make refactoring.

Should fix #606