### PR TITLE
Fix dashboard API reloads

### DIFF
--- a/redis_notifier_outbound.go
+++ b/redis_notifier_outbound.go
@@ -7,7 +7,11 @@ import (
 type NotificationCommand string
 
 const (
+	NoticeApiUpdated             NotificationCommand = "ApiUpdated"
+	NoticeApiRemoved             NotificationCommand = "ApiRemoved"
+	NoticeApiAdded               NotificationCommand = "ApiAdded"
 	NoticeGroupReload            NotificationCommand = "GroupReload"
+	NoticePolicyChanged          NotificationCommand = "PolicyChanged"
 	NoticeConfigUpdate           NotificationCommand = "NoticeConfigUpdated"
 	NoticeDashboardZeroConf      NotificationCommand = "NoticeDashboardZeroConf"
 	NoticeDashboardConfigRequest NotificationCommand = "NoticeDashboardConfigRequest"

--- a/redis_signals.go
+++ b/redis_signals.go
@@ -72,7 +72,7 @@ func handleRedisEvent(v interface{}) {
 		onServerStatusReceivedHandler(notif.Payload)
 	case NoticeGatewayLENotification:
 		onLESSLStatusReceivedHandler(notif.Payload)
-	case NoticeGroupReload:
+	case NoticeApiUpdated, NoticeApiRemoved, NoticeApiAdded, NoticePolicyChanged, NoticeGroupReload:
 		handleReloadMsg()
 	default:
 		log.WithFields(logrus.Fields{


### PR DESCRIPTION
Not so long ago during refactoring, we removed handling of unknow redis
messages, which by default was triggering API reloads.
https://github.com/TykTechnologies/tyk/commit/8f6223e2328b579d1e95063191
97499874f2a0b9

It actually broke dashboard API reloads, because they were handling in
this `default` clause.

Another refactoring also removed some unused constants, which was
indeed unused, but I need to roll them back, because they are required
to whitelist redis messages which could trigger API reloads.

Should fix #606, again...

Worth noticing that previous PR was fixing API reloads as well, and it was a valid fixes, but not for API dashboard reloads. Previous PR included tests covering Dashboard API reloads, but it did not used redis messaging, only mocked http endpoint. This PR fix tests as well.