### PR TITLE
Release 2.3.4 backport

### DIFF
--- a/config.go
+++ b/config.go
@@ -187,6 +187,7 @@ type Config struct {
 	EnableNonTransactionalRateLimiter bool                   `json:"enable_non_transactional_rate_limiter"`
 	EnableSentinelRateLImiter         bool                   `json:"enable_sentinel_rate_limiter"`
 	EnableRedisRollingLimiter         bool                   `json:"enable_redis_rolling_limiter"`
+	ManagementNode                    bool                   `json:"management_node"`
 	Monitor                           MonitorConfig
 	OauthRefreshExpire                int64                                    `json:"oauth_refresh_token_expire"`
 	OauthTokenExpire                  int32                                    `json:"oauth_token_expire"`

--- a/main.go
+++ b/main.go
@@ -1331,13 +1331,17 @@ func startHeartBeat() {
 }
 
 func StartDRL() {
-	if !config.EnableSentinelRateLImiter && !config.EnableRedisRollingLimiter {
-		log.WithFields(logrus.Fields{
-			"prefix": "main",
-		}).Info("Initialising distributed rate limiter")
-		SetupDRL()
-		StartRateLimitNotifications()
+	switch {
+	case config.ManagementNode,
+		config.EnableSentinelRateLImiter,
+		config.EnableRedisRollingLimiter:
+		return
 	}
+	log.WithFields(logrus.Fields{
+		"prefix": "main",
+	}).Info("Initialising distributed rate limiter")
+	SetupDRL()
+	StartRateLimitNotifications()
 }
 
 func listen(l net.Listener, err error) {

--- a/main.go
+++ b/main.go
@@ -332,6 +332,7 @@ func loadAPIEndpoints(Muxer *mux.Router) {
 		ApiMuxer.HandleFunc("/tyk/org/keys/"+"{rest:.*}", CheckIsAPIOwner(InstrumentationMW(orgHandler)))
 		ApiMuxer.HandleFunc("/tyk/keys/policy/"+"{rest:.*}", CheckIsAPIOwner(InstrumentationMW(policyUpdateHandler)))
 		ApiMuxer.HandleFunc("/tyk/keys/create", CheckIsAPIOwner(InstrumentationMW(createKeyHandler)))
+		ApiMuxer.HandleFunc("/tyk/apis", CheckIsAPIOwner(InstrumentationMW(apiHandler)))
 		ApiMuxer.HandleFunc("/tyk/apis/"+"{rest:.*}", CheckIsAPIOwner(InstrumentationMW(apiHandler)))
 		ApiMuxer.HandleFunc("/tyk/health/", CheckIsAPIOwner(InstrumentationMW(healthCheckhandler)))
 		ApiMuxer.HandleFunc("/tyk/oauth/clients/create", CheckIsAPIOwner(InstrumentationMW(createOauthClient)))

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package main
 
 
-var VERSION = "v2.3.3"
+var VERSION = "v2.3.4"


### PR DESCRIPTION
- [x] #619 Add ManagementNode config option to disable DRL @mvdan 
- [x] e4580701c03bd65cea9f532aa603553311867818 Creating API using `/tyk/apis` should not require trailing slash @buger