### PR TITLE
Simplify a bunch of relative paths

### DIFF
--- a/config.go
+++ b/config.go
@@ -245,11 +245,11 @@ func writeDefaultConf(conf *Config) {
 	conf.ListenAddress = ""
 	conf.ListenPort = 8080
 	conf.Secret = "352d20ee67be67f6340b4c0605b044b7"
-	conf.TemplatePath = "./templates"
-	conf.TykJSPath = "./js/tyk.js"
-	conf.MiddlewarePath = "./middleware"
+	conf.TemplatePath = "templates"
+	conf.TykJSPath = "js/tyk.js"
+	conf.MiddlewarePath = "middleware"
 	conf.Storage.Type = "redis"
-	conf.AppPath = "./apps/"
+	conf.AppPath = "apps/"
 	conf.Storage.Host = "localhost"
 	conf.Storage.Username = ""
 	conf.Storage.Password = ""
@@ -282,7 +282,7 @@ func loadConfig(filePath string, conf *Config) {
 	if err != nil {
 		if !runningTests {
 			log.Error("Couldn't load configuration file: ", err)
-			log.Info("Writing a default file to ./tyk.conf")
+			log.Info("Writing a default file to tyk.conf")
 			writeDefaultConf(conf)
 			log.Info("Loading default configuration...")
 			loadConfig("tyk.conf", conf)

--- a/main.go
+++ b/main.go
@@ -834,7 +834,7 @@ func initialiseSystem(arguments map[string]interface{}) {
 	} else {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
-		}).Debug("No configuration file defined, will try to use default (./tyk.conf)")
+		}).Debug("No configuration file defined, will try to use default (tyk.conf)")
 	}
 
 	loadConfig(filename, &config)

--- a/redis_signal_handle_config.go
+++ b/redis_signal_handle_config.go
@@ -35,7 +35,7 @@ func WriteNewConfiguration(payload ConfigPayload) error {
 		return err
 	}
 
-	filename := "./tyk.conf"
+	filename := "tyk.conf"
 	if conf := argumentsBackup["--conf"]; conf != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "pub-sub",
@@ -44,7 +44,7 @@ func WriteNewConfiguration(payload ConfigPayload) error {
 	} else {
 		log.WithFields(logrus.Fields{
 			"prefix": "pub-sub",
-		}).Info("No configuration file defined, will try to use default (./tyk.conf)")
+		}).Info("No configuration file defined, will try to use default (tyk.conf)")
 	}
 
 	ioutil.WriteFile(filename, newConfig, 0644)
@@ -52,7 +52,7 @@ func WriteNewConfiguration(payload ConfigPayload) error {
 }
 
 func GetExistingRawConfig() Config {
-	filename := "./tyk.conf"
+	filename := "tyk.conf"
 	if conf := argumentsBackup["--conf"]; conf != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "pub-sub",
@@ -61,7 +61,7 @@ func GetExistingRawConfig() Config {
 	} else {
 		log.WithFields(logrus.Fields{
 			"prefix": "pub-sub",
-		}).Info("No configuration file defined, will try to use default (./tyk.conf)")
+		}).Info("No configuration file defined, will try to use default (tyk.conf)")
 	}
 
 	existingConfig := Config{}

--- a/redis_signal_handle_config_request.go
+++ b/redis_signal_handle_config_request.go
@@ -44,7 +44,7 @@ func GetExistingConfig() (MicroConfig, error) {
 	value, _ := argumentsBackup["--conf"]
 	microConfig := MicroConfig{}
 
-	filename := "./tyk.conf"
+	filename := "tyk.conf"
 	if value != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "pub-sub",
@@ -53,7 +53,7 @@ func GetExistingConfig() (MicroConfig, error) {
 	} else {
 		log.WithFields(logrus.Fields{
 			"prefix": "pub-sub",
-		}).Info("No configuration file defined, will try to use default (./tyk.conf)")
+		}).Info("No configuration file defined, will try to use default (tyk.conf)")
 	}
 
 	dat, err := ioutil.ReadFile(filename)


### PR DESCRIPTION
Especially in the default config, since they're visible to the user.
"./" is only useful in Unix-like systems to execute a binary relative to
the current dir. But when reading dirs and files, it's redundant.