### PR TITLE
Fix Uptime tests reverse logic

### DIFF
--- a/gateway_test.go
+++ b/gateway_test.go
@@ -44,6 +44,12 @@ const (
 	testHttpAny  = "http://" + testHttpListen
 	testHttpGet  = testHttpAny + "/get"
 	testHttpPost = testHttpAny + "/post"
+
+	// 16501 port should not be bind to anything, and can be used for testing failures
+	testHttpFailure     = "127.0.0.1:16501"
+	testHttpFailureAny  = "http://" + testHttpFailure
+	testHttpFailureGet  = testHttpFailureAny + "/get"
+	testHttpFailurePost = testHttpFailureAny + "/post"
 )
 
 type testHttpResponse struct {

--- a/host_checker_manager.go
+++ b/host_checker_manager.go
@@ -282,7 +282,7 @@ func (hc *HostCheckerManager) IsHostDown(urlStr string) bool {
 	_, err = hc.store.GetKey(PoolerHostSentinelKeyPrefix + u.Host)
 
 	// Found a key, the host is down
-	return err != nil
+	return err == nil
 }
 
 func (hc *HostCheckerManager) PrepareTrackingHost(checkObject apidef.HostCheckObject, apiID string) (HostData, error) {
@@ -489,6 +489,11 @@ func (hc *HostCheckerManager) RecordUptimeAnalytics(report HostHealthReport) err
 }
 
 func InitHostCheckManager(store *RedisClusterStorageManager) {
+	// Already initialized
+	if GlobalHostChecker.Id != "" {
+		return
+	}
+
 	GlobalHostChecker = HostCheckerManager{}
 	GlobalHostChecker.Init(store)
 	GlobalHostChecker.Start()

--- a/host_checker_test.go
+++ b/host_checker_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+	"text/template"
+
+	"github.com/TykTechnologies/tyk/apidef"
+)
+
+const sampleUptimeTestAPI = `{
+	"name": "API",
+	"slug": "api",
+	"api_id": "test",
+	"use_keyless": true,
+	"version_data": {
+		"not_versioned": true,
+		"versions": {
+			"Default": {
+				"name": "Default",
+				"expires": "3000-01-02 15:04"
+			}
+		}
+	},
+	"uptime_tests": {
+		"check_list": [
+			{
+				"url": "{{.ActiveHost}}/get",
+				"method": "GET",
+				"headers": {},
+				"body": ""
+			},
+			{
+				"url": "{{.InactiveHost}}/get",
+				"method": "GET",
+				"headers": {},
+				"body": ""
+			}
+		]
+	},
+	"proxy": {
+		"listen_path": "/",
+		"enable_load_balancing": true,
+		"check_host_against_uptime_tests": true,
+		"target_list": [
+			"{{.ActiveHost}}",
+			"{{.InactiveHost}}"
+		],
+		"strip_listen_path": true
+	},
+	"active": true
+}`
+
+type testEventHandler struct {
+	cb func(EventMessage)
+}
+
+func (w *testEventHandler) New(handlerConf interface{}) (TykEventHandler, error) {
+	return w, nil
+}
+
+func (w *testEventHandler) HandleEvent(em EventMessage) {
+	w.cb(em)
+}
+
+func TestHostChecker(t *testing.T) {
+	specTmpl := template.Must(template.New("spec").Parse(sampleUptimeTestAPI))
+
+	tmplData := struct {
+		ActiveHost   string
+		InactiveHost string
+	}{
+		testHttpAny,
+		testHttpFailureAny,
+	}
+
+	specBuf := &bytes.Buffer{}
+	specTmpl.ExecuteTemplate(specBuf, specTmpl.Name(), &tmplData)
+
+	spec := createDefinitionFromString(specBuf.String())
+
+	// From tyk_reverse_proxy_clone.go#TykNewSingleHostReverseProxy
+	spec.RoundRobin = &RoundRobin{}
+
+	// From api_loader.go#processSpec
+	sl := apidef.NewHostListFromList(spec.Proxy.Targets)
+	spec.Proxy.StructuredTargetList = sl
+
+	var wg sync.WaitGroup
+	cb := func(em EventMessage) {
+		wg.Done()
+	}
+
+	spec.EventPaths = map[apidef.TykEvent][]TykEventHandler{
+		"HostDown": {&testEventHandler{cb}},
+	}
+
+	ApiSpecRegister = map[string]*APISpec{spec.APIID: spec}
+	GlobalHostChecker.checker.sampleTriggerLimit = 1
+	defer func() {
+		ApiSpecRegister = make(map[string]*APISpec)
+		GlobalHostChecker.checker.sampleTriggerLimit = defaultSampletTriggerLimit
+	}()
+
+	SetCheckerHostList()
+	if len(GlobalHostChecker.currentHostList) != 2 {
+		t.Error("Should update hosts manager check list", GlobalHostChecker.currentHostList)
+	}
+
+	if len(GlobalHostChecker.checker.newList) != 2 {
+		t.Error("Should update host checker check list")
+	}
+
+	// Should receive one HostDown event
+	wg.Add(1)
+	for _, hostData := range GlobalHostChecker.checker.newList {
+		// By default host check should fail > 3 times in row
+		GlobalHostChecker.checker.CheckHost(hostData)
+	}
+
+	wg.Wait()
+
+	if GlobalHostChecker.IsHostDown(testHttpAny) {
+		t.Error("Should not mark as down")
+	}
+
+	if !GlobalHostChecker.IsHostDown(testHttpFailureAny) {
+		t.Error("Should mark as down")
+	}
+
+	host1 := GetNextTarget(spec.Proxy.StructuredTargetList, spec, 0)
+	host2 := GetNextTarget(spec.Proxy.StructuredTargetList, spec, 0)
+
+	if host1 != host2 || host1 != testHttpAny {
+		t.Error("Should return only active host", host1, host2)
+	}
+}

--- a/tyk_reverse_proxy_clone.go
+++ b/tyk_reverse_proxy_clone.go
@@ -120,7 +120,7 @@ func GetNextTarget(targetData *apidef.HostList, spec *APISpec, tryCount int) str
 
 		// Check hosts against uptime tests
 		if spec.Proxy.CheckHostAgainstUptimeTests {
-			if !GlobalHostChecker.IsHostDown(host) {
+			if GlobalHostChecker.IsHostDown(host) {
 				// Don't overdo it
 				if tryCount < targetData.Len() {
 					// Host is down, skip


### PR DESCRIPTION
Should fix #632

When limit set to 1, it did not mark host as failed and continue sending traffic to it, until next host check. Worth noticing that now it also use `>=` logic instead of `>`, so it will trigger failed host check earlier than before, but it looks more logical: if `trigger_limit` set to 1, we want to send notification on the first failure. 

Also, fixed Uptime tests reverse logic: `IsHostDown` function currently has reverse logic, and returns true for active hosts. Fun thing, Tyk still works fine because `GetNextTarget` have reverse
logic as well, and they fix each other :)

Writing tests for this functionality was tricky because functionality spread up across the app, but thankfully we can set the callback, similar to how webhooks work, and it worked quite well. 

Added test covering part of uptime tests functionality.