### PR TITLE
all: simplify some code

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -368,7 +368,6 @@ func (a *APIDefinition) EncodeForDB() {
 		newK := base64.StdEncoding.EncodeToString([]byte(k))
 		v.Name = newK
 		new_version[newK] = v
-
 	}
 
 	a.VersionData.Versions = new_version

--- a/apidef/host_list.go
+++ b/apidef/host_list.go
@@ -37,32 +37,21 @@ func (h *HostList) All() []string {
 }
 
 func (h *HostList) GetIndex(i int) (string, error) {
+	if i < 0 {
+		return "", errors.New("index must be positive int")
+	}
 	h.hMutex.RLock()
 	defer h.hMutex.RUnlock()
-	if i < 0 {
-		return "", errors.New("Index must be positive int")
-	}
 
-	if i > (len(h.hosts) - 1) {
-		return "", errors.New("Index out of range")
+	if i > len(h.hosts)-1 {
+		return "", errors.New("index out of range")
 	}
 
 	return h.hosts[i], nil
 }
 
 func (h *HostList) Len() int {
-	if h == nil {
-		return 0
-	}
-
 	h.hMutex.RLock()
 	defer h.hMutex.RUnlock()
-
-	var thisLen int
-
-	if h.hosts != nil {
-		thisLen = len(h.hosts)
-	}
-
-	return thisLen
+	return len(h.hosts)
 }

--- a/redis_cluster_handler.go
+++ b/redis_cluster_handler.go
@@ -358,12 +358,11 @@ func (r *RedisClusterStorageManager) DeleteScanMatch(pattern string) bool {
 	}
 
 	if len(keys) > 0 {
-		for _, v := range keys {
-			name := "" + v
+		for _, name := range keys {
 			log.Info("Deleting: ", name)
 			_, err := GetRelevantClusterReference(r.IsCache).Do("DEL", name)
 			if err != nil {
-				log.Error("Error trying to delete key: ", v, " - ", err)
+				log.Error("Error trying to delete key: ", name, " - ", err)
 
 			}
 		}

--- a/redis_signal_handle_config_request.go
+++ b/redis_signal_handle_config_request.go
@@ -41,7 +41,7 @@ func SanitizeConfig(mc MicroConfig) MicroConfig {
 }
 
 func GetExistingConfig() (MicroConfig, error) {
-	value, _ := argumentsBackup["--conf"]
+	value := argumentsBackup["--conf"]
 	microConfig := MicroConfig{}
 
 	filename := "tyk.conf"

--- a/rpc_storage_handler.go
+++ b/rpc_storage_handler.go
@@ -467,10 +467,7 @@ func (r *RPCStorageHandler) DeleteKey(keyName string) bool {
 		return r.DeleteKey(keyName)
 	}
 
-	if ok == nil {
-		return false
-	}
-	return ok.(bool)
+	return ok == true
 }
 
 // DeleteKey will remove a key from the database without prefixing, assumes user knows what they are doing
@@ -482,10 +479,7 @@ func (r *RPCStorageHandler) DeleteRawKey(keyName string) bool {
 		return r.DeleteRawKey(keyName)
 	}
 
-	if ok == nil {
-		return false
-	}
-	return ok.(bool)
+	return ok == true
 }
 
 // DeleteKeys will remove a group of keys in bulk
@@ -504,11 +498,7 @@ func (r *RPCStorageHandler) DeleteKeys(keys []string) bool {
 			return r.DeleteKeys(keys)
 		}
 
-		if ok == nil {
-			return false
-		}
-
-		return ok.(bool)
+		return ok == true
 	}
 	log.Debug("RPCStorageHandler called DEL - Nothing to delete")
 	return true


### PR DESCRIPTION
In apidef, we don't need to guard against a nil slice to call len on it.
Moreover, the other methods don't guard against a nil receiver so Len()
shouldn't either. We also don't need to grab the lock just to check for
i < 0.

And in the rpc code, simply use ok == true. If ok is nil, that condition
will be false.

And a couple of small cleanups in the redis code.