### PR TITLE
Decouple RoundRobin from apidef

### DIFF
--- a/round_robin.go
+++ b/round_robin.go
@@ -1,15 +1,11 @@
 package main
 
-import (
-	"github.com/TykTechnologies/tyk/apidef"
-)
-
 type RoundRobin struct {
 	pos, max, cur int
 }
 
-func (r *RoundRobin) SetMax(rp *apidef.HostList) {
-	if r.max = rp.Len() - 1; r.max < 0 {
+func (r *RoundRobin) SetMax(max int) {
+	if r.max = max; r.max < 0 {
 		r.max = 0
 	}
 
@@ -21,6 +17,8 @@ func (r *RoundRobin) SetMax(rp *apidef.HostList) {
 		r.pos = 0
 	}
 }
+
+func (r *RoundRobin) SetLen(len int) { r.SetMax(len - 1) }
 
 func (r *RoundRobin) GetPos() int {
 	r.cur = r.pos

--- a/round_robin_test.go
+++ b/round_robin_test.go
@@ -1,35 +1,14 @@
 package main
 
-import (
-	"testing"
+import "testing"
 
-	"github.com/TykTechnologies/tyk/apidef"
-)
-
-func TestRR(t *testing.T) {
-	arr1 := []string{"1", "2", "3"}
-
+func TestRoundRobin(t *testing.T) {
 	rr := RoundRobin{}
-	asHL := apidef.NewHostListFromList(arr1)
-	rr.SetMax(asHL)
+	rr.SetMax(2)
 
-	val := rr.GetPos()
-	if val != 0 {
-		t.Error("RR Pos wrong, expected: 0 but got: ", val)
-	}
-
-	val = rr.GetPos()
-	if val != 1 {
-		t.Error("RR Pos wrong, expected: 1 but got: ", val)
-	}
-
-	val = rr.GetPos()
-	if val != 2 {
-		t.Error("RR Pos wrong, expected: 2 but got: ", val)
-	}
-
-	val = rr.GetPos()
-	if val != 0 {
-		t.Error("RR Pos wrong, expected: 0 but got: ", val)
+	for _, want := range []int{0, 1, 2, 0} {
+		if got := rr.GetPos(); got != want {
+			t.Errorf("RR Pos wrong: want %d got %d", want, got)
+		}
 	}
 }

--- a/tyk_reverse_proxy_clone.go
+++ b/tyk_reverse_proxy_clone.go
@@ -101,12 +101,12 @@ func GetNextTarget(targetData *apidef.HostList, spec *APISpec, tryCount int) str
 	if spec.Proxy.EnableLoadBalancing {
 		log.Debug("[PROXY] [LOAD BALANCING] Load balancer enabled, getting upstream target")
 		// Use a HostList
-		spec.RoundRobin.SetMax(targetData)
+		spec.RoundRobin.SetLen(targetData.Len())
 
 		pos := spec.RoundRobin.GetPos()
 		if pos > targetData.Len()-1 {
 			// problem
-			spec.RoundRobin.SetMax(targetData)
+			spec.RoundRobin.SetLen(targetData.Len())
 			pos = 0
 		}
 
@@ -152,7 +152,6 @@ func GetNextTarget(targetData *apidef.HostList, spec *APISpec, tryCount int) str
 func TykNewSingleHostReverseProxy(target *url.URL, spec *APISpec) *ReverseProxy {
 	// initialise round robin
 	spec.RoundRobin = &RoundRobin{}
-	spec.RoundRobin.SetMax(apidef.NewHostList())
 
 	if spec.Proxy.ServiceDiscovery.UseDiscoveryService {
 		log.Debug("[PROXY] Service discovery enabled")


### PR DESCRIPTION
There is no need to limit it to host lists. Also improve readability a
bit by using better method names.

And remove a useless use of SetMax - it would set the actual maximum to
0, since the length of a new hostlist is 0. And a newly allocated
RoundRobin will already have its max set to 0.