### PR TITLE
Fix spelling in log. "rate imiter" -> "rate limiter"

### DIFF
--- a/distributed_rate_limiter.go
+++ b/distributed_rate_limiter.go
@@ -25,7 +25,7 @@ func startRateLimitNotifications() {
 	}
 
 	go func() {
-		log.Info("Starting gateway rate imiter notifications...")
+		log.Info("Starting gateway rate limiter notifications...")
 		for {
 			if NodeID != "" {
 				NotifyCurrentServerStatus()


### PR DESCRIPTION
I keep noticing in the logs. Might as well just fix it. :)