### PR TITLE
Fix uptime_tests.time_wait defaults

### DIFF
--- a/host_checker.go
+++ b/host_checker.go
@@ -40,7 +40,7 @@ type HostUptimeChecker struct {
 	pingCallback       func(HostHealthReport)
 	workerPoolSize     int
 	sampleTriggerLimit int
-	checkTimout        int
+	checkTimeout       int
 	HostList           map[string]HostData
 	unHealthyList      map[string]bool
 	pool               *tunny.WorkPool
@@ -55,13 +55,13 @@ type HostUptimeChecker struct {
 }
 
 func (h *HostUptimeChecker) getStaggeredTime() time.Duration {
-	if h.checkTimout <= 5 {
-		return time.Duration(h.checkTimout) * time.Second
+	if h.checkTimeout <= 5 {
+		return time.Duration(h.checkTimeout) * time.Second
 	}
 
 	rand.Seed(time.Now().Unix())
-	min := h.checkTimout - 3
-	max := h.checkTimout + 3
+	min := h.checkTimeout - 3
+	max := h.checkTimeout + 3
 
 	dur := rand.Intn(max-min) + min
 
@@ -197,13 +197,13 @@ func (h *HostUptimeChecker) Init(workers, triggerLimit, timeout int, hostList ma
 		h.sampleTriggerLimit = defaultSampletTriggerLimit
 	}
 
-	h.checkTimout = timeout
+	h.checkTimeout = timeout
 	if timeout == 0 {
-		h.checkTimout = defaultTimeout
+		h.checkTimeout = defaultTimeout
 	}
 
 	log.Debug("[HOST CHECKER] Config:TriggerLimit: ", h.sampleTriggerLimit)
-	log.Debug("[HOST CHECKER] Config:Timeout: ~", h.checkTimout)
+	log.Debug("[HOST CHECKER] Config:Timeout: ~", h.checkTimeout)
 	log.Debug("[HOST CHECKER] Config:WorkerPool: ", h.workerPoolSize)
 
 	var err error

--- a/host_checker_manager.go
+++ b/host_checker_manager.go
@@ -206,7 +206,7 @@ func (hc *HostCheckerManager) OnHostDown(report HostHealthReport) {
 	log.WithFields(logrus.Fields{
 		"prefix": "host-check-mgr",
 	}).Debug("Update key: ", hc.getHostKey(report))
-	hc.store.SetKey(hc.getHostKey(report), "1", int64(config.UptimeTests.Config.TimeWait+1))
+	hc.store.SetKey(hc.getHostKey(report), "1", int64(hc.checker.checkTimeout+1))
 
 	spec, found := ApiSpecRegister[report.MetaData[UnHealthyHostMetaDataAPIKey]]
 	if !found {

--- a/host_checker_test.go
+++ b/host_checker_test.go
@@ -135,4 +135,12 @@ func TestHostChecker(t *testing.T) {
 	if host1 != host2 || host1 != testHttpAny {
 		t.Error("Should return only active host", host1, host2)
 	}
+
+	if GlobalHostChecker.checker.checkTimeout != 10 {
+		t.Error("Should set defaults", GlobalHostChecker.checker.checkTimeout)
+	}
+
+	if ttl, _ := GlobalHostChecker.store.GetKeyTTL(PoolerHostSentinelKeyPrefix + testHttpFailure); int(ttl) != GlobalHostChecker.checker.checkTimeout+1 {
+		t.Error("HostDown expiration key should be checkTimeout + 1", ttl)
+	}
 }

--- a/redis_cluster_handler.go
+++ b/redis_cluster_handler.go
@@ -152,6 +152,11 @@ func (r *RedisClusterStorageManager) GetKey(keyName string) (string, error) {
 	return value, nil
 }
 
+func (r *RedisClusterStorageManager) GetKeyTTL(keyName string) (ttl int64, err error) {
+	r.ensureConnection()
+	return redis.Int64(GetRelevantClusterReference(r.IsCache).Do("TTL", r.fixKey(keyName)))
+}
+
 func (r *RedisClusterStorageManager) GetRawKey(keyName string) (string, error) {
 	r.ensureConnection()
 	value, err := redis.String(GetRelevantClusterReference(r.IsCache).Do("GET", keyName))


### PR DESCRIPTION
Fix #669

Fix Redis key expiration for down host key. Now instead of config
value, it use value if `checker` object, which internally handle
default values logic.

Also fixed few typos.