### PR TITLE
Update default uptime test configuration

### DIFF
--- a/install/data/tyk.self_contained.conf
+++ b/install/data/tyk.self_contained.conf
@@ -55,8 +55,8 @@
     "disable": false,
     "config": {
       "enable_uptime_analytics": false,
-      "failure_trigger_sample_size": 3,
-      "time_wait": 300,
+      "failure_trigger_sample_size": 2,
+      "time_wait": 10,
       "checker_pool_size": 50
     }
   },

--- a/install/data/tyk.with_dash.conf
+++ b/install/data/tyk.with_dash.conf
@@ -72,8 +72,8 @@
     "disable": false,
     "config": {
       "enable_uptime_analytics": true,
-      "failure_trigger_sample_size": 3,
-      "time_wait": 300,
+      "failure_trigger_sample_size": 2,
+      "time_wait": 10,
       "checker_pool_size": 50
     }
   },


### PR DESCRIPTION
Currently, default gateway config assume that it should wait 20 minutes to mark host as down.
Reduced to 20 seconds.

Fix #668 