### PR TITLE
config: fatal on config parse errors, try multiple files, add tests

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -277,7 +278,7 @@ func writeDefaultConf(conf *Config) {
 // LoadConfig will load the configuration file from filePath, if it can't open
 // the file for reading, it assumes there is no configuration file and will try to create
 // one on the default path (tyk.conf in the local directory)
-func loadConfig(filePath string, conf *Config) {
+func loadConfig(filePath string, conf *Config) error {
 	configuration, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		if !runningTests {
@@ -285,15 +286,15 @@ func loadConfig(filePath string, conf *Config) {
 			log.Info("Writing a default file to tyk.conf")
 			writeDefaultConf(conf)
 			log.Info("Loading default configuration...")
-			loadConfig("tyk.conf", conf)
+			return loadConfig("tyk.conf", conf)
 		}
 	} else {
 		if err := json.Unmarshal(configuration, &conf); err != nil {
-			log.Error("Couldn't unmarshal configuration: ", err)
+			return fmt.Errorf("couldn't unmarshal config: %v", err)
 		}
 
 		if err := envconfig.Process(envPrefix, conf); err != nil {
-			log.Error("Failed to process environment variables after file load: ", err)
+			return fmt.Errorf("failed to process config env vars: %v", err)
 		}
 	}
 
@@ -306,6 +307,7 @@ func loadConfig(filePath string, conf *Config) {
 	GlobalRPCPingTimeout = time.Second * time.Duration(conf.SlaveOptions.PingTimeout)
 	GlobalRPCCallTimeout = time.Second * time.Duration(conf.SlaveOptions.CallTimeout)
 	conf.EventTriggers = InitGenericEventHandlers(conf.EventHandlers)
+	return nil
 }
 
 func (c *Config) loadIgnoredIPs() {

--- a/config.go
+++ b/config.go
@@ -242,27 +242,27 @@ const envPrefix = "TYK_GW"
 
 // writeDefaultConf will create a default configuration file and set the storage type to "memory"
 func writeDefaultConf(conf *Config) {
-	conf.ListenAddress = ""
-	conf.ListenPort = 8080
-	conf.Secret = "352d20ee67be67f6340b4c0605b044b7"
-	conf.TemplatePath = "templates"
-	conf.TykJSPath = "js/tyk.js"
-	conf.MiddlewarePath = "middleware"
-	conf.Storage.Type = "redis"
-	conf.AppPath = "apps/"
-	conf.Storage.Host = "localhost"
-	conf.Storage.Username = ""
-	conf.Storage.Password = ""
-	conf.Storage.Database = 0
-	conf.Storage.MaxIdle = 100
-	conf.Storage.Port = 6379
-	conf.EnableAnalytics = false
-	conf.HealthCheck.EnableHealthChecks = true
-	conf.HealthCheck.HealthCheckValueTimeout = 60
-	conf.AnalyticsConfig.IgnoredIPs = make([]string, 0)
-	conf.UseAsyncSessionWrite = false
-	conf.HideGeneratorHeader = false
-	conf.OauthRedirectUriSeparator = ""
+	*conf = Config{
+		ListenPort:     8080,
+		Secret:         "352d20ee67be67f6340b4c0605b044b7",
+		TemplatePath:   "templates",
+		TykJSPath:      "js/tyk.js",
+		MiddlewarePath: "middleware",
+		AppPath:        "apps/",
+		Storage: StorageOptionsConf{
+			Type:    "redis",
+			Host:    "localhost",
+			MaxIdle: 100,
+			Port:    6379,
+		},
+		HealthCheck: HealthCheckConfig{
+			EnableHealthChecks:      true,
+			HealthCheckValueTimeout: 60,
+		},
+		AnalyticsConfig: AnalyticsConfigConfig{
+			IgnoredIPs: make([]string, 0),
+		},
+	}
 	if err := envconfig.Process(envPrefix, conf); err != nil {
 		log.Error("Failed to process environment variables: ", err)
 	}

--- a/config.go
+++ b/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -241,8 +242,24 @@ type CertData struct {
 
 const envPrefix = "TYK_GW"
 
-// writeDefaultConf will create a default configuration file and set the storage type to "memory"
-func writeDefaultConf(conf *Config) {
+// confPaths is the series of paths to try to use as config files. The
+// first one to exist will be used. If none exists, a default config
+// will be written to the first path in the list.
+//
+// When --conf=foo is used, this will be replaced by []string{"foo"}.
+var confPaths = []string{
+	"tyk.conf",
+	// TODO: add ~/.config/tyk/tyk.conf here?
+	"/etc/tyk/tyk.conf",
+}
+
+// usedConfPath is the path to the config file that was read. If none
+// was found, it's the path to the default config file that was written.
+var usedConfPath string
+
+// writeDefaultConf will create a default configuration file and set the
+// storage type to "memory"
+func writeDefaultConf(path string, conf *Config) {
 	*conf = Config{
 		ListenPort:     8080,
 		Secret:         "352d20ee67be67f6340b4c0605b044b7",
@@ -267,37 +284,61 @@ func writeDefaultConf(conf *Config) {
 	if err := envconfig.Process(envPrefix, conf); err != nil {
 		log.Error("Failed to process environment variables: ", err)
 	}
+	if path == "" {
+		return
+	}
 	newConfig, err := json.MarshalIndent(conf, "", "    ")
 	if err != nil {
 		log.Error("Problem marshalling default configuration: ", err)
-	} else if !runningTests {
-		ioutil.WriteFile("tyk.conf", newConfig, 0644)
+	} else {
+		ioutil.WriteFile(path, newConfig, 0644)
 	}
 }
 
-// LoadConfig will load the configuration file from filePath, if it can't open
-// the file for reading, it assumes there is no configuration file and will try to create
-// one on the default path (tyk.conf in the local directory)
-func loadConfig(filePath string, conf *Config) error {
-	configuration, err := ioutil.ReadFile(filePath)
-	if err != nil {
-		if !runningTests {
-			log.Error("Couldn't load configuration file: ", err)
-			log.Info("Writing a default file to tyk.conf")
-			writeDefaultConf(conf)
-			log.Info("Loading default configuration...")
-			return loadConfig("tyk.conf", conf)
+// LoadConfig will load a configuration file, trying each of the paths
+// given and using the first one that is a regular file and can be
+// opened.
+//
+// If none exists, a default config will be written to the first path in
+// the list.
+//
+// An error will be returned only if any of the paths existed but was
+// not a valid config file.
+func loadConfig(paths []string, conf *Config) error {
+	var bs []byte
+	for _, path := range paths {
+		var err error
+		bs, err = ioutil.ReadFile(path)
+		if err == nil {
+			usedConfPath = path
+			break
 		}
-	} else {
-		if err := json.Unmarshal(configuration, &conf); err != nil {
-			return fmt.Errorf("couldn't unmarshal config: %v", err)
+		if os.IsNotExist(err) {
+			continue
 		}
-
-		if err := envconfig.Process(envPrefix, conf); err != nil {
-			return fmt.Errorf("failed to process config env vars: %v", err)
-		}
+		return err
+	}
+	if bs == nil {
+		path := paths[0]
+		log.Warnf("No config file found, writing default to %s", path)
+		writeDefaultConf(path, conf)
+		log.Info("Loading default configuration...")
+		return loadConfig([]string{path}, conf)
+	}
+	if err := json.Unmarshal(bs, &conf); err != nil {
+		return fmt.Errorf("couldn't unmarshal config: %v", err)
 	}
 
+	if err := envconfig.Process(envPrefix, conf); err != nil {
+		return fmt.Errorf("failed to process config env vars: %v", err)
+	}
+	afterConfSetup(conf)
+	return nil
+}
+
+// afterConfSetup takes care of non-sensical config values (such as zero
+// timeouts) and sets up a few globals that depend on the config.
+func afterConfSetup(conf *Config) {
 	if conf.SlaveOptions.CallTimeout == 0 {
 		conf.SlaveOptions.CallTimeout = 30
 	}
@@ -307,7 +348,6 @@ func loadConfig(filePath string, conf *Config) error {
 	GlobalRPCPingTimeout = time.Second * time.Duration(conf.SlaveOptions.PingTimeout)
 	GlobalRPCCallTimeout = time.Second * time.Duration(conf.SlaveOptions.CallTimeout)
 	conf.EventTriggers = InitGenericEventHandlers(conf.EventHandlers)
-	return nil
 }
 
 func (c *Config) loadIgnoredIPs() {

--- a/config_test.go
+++ b/config_test.go
@@ -8,13 +8,13 @@ import (
 func TestWriteDefaultConf(t *testing.T) {
 	conf := &Config{}
 	os.Unsetenv("TYK_GW_LISTENPORT")
-	writeDefaultConf(conf)
+	writeDefaultConf("", conf)
 	if conf.ListenPort != 8080 {
 		t.Error("Expected ListenPort to be set to its default")
 	}
 	*conf = Config{}
 	os.Setenv("TYK_GW_LISTENPORT", "9090")
-	writeDefaultConf(conf)
+	writeDefaultConf("", conf)
 	if conf.ListenPort != 9090 {
 		t.Error("Expected ListenPort to be set to 9090")
 	}

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -130,7 +130,7 @@ func TestMain(m *testing.M) {
 	go func() {
 		panic(testServer.ListenAndServe())
 	}()
-	writeDefaultConf(&config)
+	writeDefaultConf("", &config)
 	config.Storage.Database = 1
 	if err := emptyRedis(); err != nil {
 		panic(err)
@@ -146,6 +146,7 @@ func TestMain(m *testing.M) {
 	config.EnableJSVM = true
 	config.Monitor.EnableTriggerMonitors = true
 	config.AnalyticsConfig.NormaliseUrls.Enabled = true
+	afterConfSetup(&config)
 	initialiseSystem(nil)
 	if analytics.GeoIPDB == nil {
 		panic("GeoIPDB was not initialized")

--- a/main.go
+++ b/main.go
@@ -777,7 +777,7 @@ func setupLogger() {
 
 }
 
-func initialiseSystem(arguments map[string]interface{}) {
+func initialiseSystem(arguments map[string]interface{}) error {
 
 	// Enable command mode
 	for _, opt := range commandModeOptions {
@@ -813,7 +813,9 @@ func initialiseSystem(arguments map[string]interface{}) {
 		}).Debug("No configuration file defined, will try to use default (tyk.conf)")
 	}
 
-	loadConfig(filename, &config)
+	if err := loadConfig(filename, &config); err != nil {
+		return err
+	}
 
 	if config.Storage.Type != "redis" {
 		log.WithFields(logrus.Fields{
@@ -859,6 +861,8 @@ func initialiseSystem(arguments map[string]interface{}) {
 	SetupInstrumentation(true)
 
 	go StartPeriodicStateBackup(&LE_MANAGER)
+
+	return nil
 }
 
 type AuditHostDetails struct {
@@ -986,7 +990,11 @@ func main() {
 	l, goAgainErr := goagain.Listener(onFork)
 	controlListener, goAgainErr := goagain.Listener(onFork)
 
-	initialiseSystem(arguments)
+	if err := initialiseSystem(arguments); err != nil {
+		log.WithFields(logrus.Fields{
+			"prefix": "main",
+		}).Fatalf("Error initialising system: %v", err)
+	}
 	start(arguments)
 
 	if goAgainErr != nil {

--- a/main.go
+++ b/main.go
@@ -51,7 +51,6 @@ var (
 	FallbackKeySesionManager = SessionHandler(&DefaultSessionManager{})
 	MonitoringHandler        TykEventHandler
 	RPCListener              = RPCStorageHandler{}
-	argumentsBackup          map[string]interface{}
 	DashService              DashboardServiceSender
 
 	ApiSpecRegister map[string]*APISpec
@@ -801,20 +800,21 @@ func initialiseSystem(arguments map[string]interface{}) error {
 		}).Debug("Enabling debug-level output")
 	}
 
-	filename := "/etc/tyk/tyk.conf"
 	if conf := arguments["--conf"]; conf != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Debugf("Using %s for configuration", conf.(string))
-		filename = arguments["--conf"].(string)
+		confPaths = []string{conf.(string)}
 	} else {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Debug("No configuration file defined, will try to use default (tyk.conf)")
 	}
 
-	if err := loadConfig(filename, &config); err != nil {
-		return err
+	if !runningTests {
+		if err := loadConfig(confPaths, &config); err != nil {
+			return err
+		}
 	}
 
 	if config.Storage.Type != "redis" {
@@ -915,7 +915,6 @@ func getCmdArguments() map[string]interface{} {
 		}).Warning("Error while parsing arguments: ", err)
 	}
 
-	argumentsBackup = arguments
 	return arguments
 }
 

--- a/redis_signal_handle_config.go
+++ b/redis_signal_handle_config.go
@@ -35,38 +35,13 @@ func writeNewConfiguration(payload ConfigPayload) error {
 		return err
 	}
 
-	filename := "tyk.conf"
-	if conf := argumentsBackup["--conf"]; conf != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "pub-sub",
-		}).Infof("Using %s for configuration", conf.(string))
-		filename = conf.(string)
-	} else {
-		log.WithFields(logrus.Fields{
-			"prefix": "pub-sub",
-		}).Info("No configuration file defined, will try to use default (tyk.conf)")
-	}
-
-	ioutil.WriteFile(filename, newConfig, 0644)
+	ioutil.WriteFile(confPaths[0], newConfig, 0644)
 	return nil
 }
 
 func getExistingRawConfig() Config {
-	filename := "tyk.conf"
-	if conf := argumentsBackup["--conf"]; conf != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "pub-sub",
-		}).Infof("Using %s for configuration", conf.(string))
-		filename = conf.(string)
-	} else {
-		log.WithFields(logrus.Fields{
-			"prefix": "pub-sub",
-		}).Info("No configuration file defined, will try to use default (tyk.conf)")
-	}
-
 	existingConfig := Config{}
-	loadConfig(filename, &existingConfig)
-
+	loadConfig(confPaths, &existingConfig)
 	return existingConfig
 }
 

--- a/redis_signal_handle_config_request.go
+++ b/redis_signal_handle_config_request.go
@@ -41,22 +41,8 @@ func sanitizeConfig(mc MicroConfig) MicroConfig {
 }
 
 func getExistingConfig() (MicroConfig, error) {
-	value := argumentsBackup["--conf"]
 	microConfig := MicroConfig{}
-
-	filename := "tyk.conf"
-	if value != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "pub-sub",
-		}).Infof("Using %s for configuration", value.(string))
-		filename = argumentsBackup["--conf"].(string)
-	} else {
-		log.WithFields(logrus.Fields{
-			"prefix": "pub-sub",
-		}).Info("No configuration file defined, will try to use default (tyk.conf)")
-	}
-
-	dat, err := ioutil.ReadFile(filename)
+	dat, err := ioutil.ReadFile(usedConfPath)
 	if err != nil {
 		return microConfig, err
 	}


### PR DESCRIPTION
Split in a few commits to help code review.

For now, we only read `tyk.conf` before `/etc/tyk/tyk.conf`. More paths can be easily added later, and the precedence can also be easily modified.

Fixes #501.