### PR TITLE
hostchecker: remove ID field

### DIFF
--- a/host_checker_manager.go
+++ b/host_checker_manager.go
@@ -311,7 +311,6 @@ func (hc *HostCheckerManager) PrepareTrackingHost(checkObject apidef.HostCheckOb
 
 	hostData = HostData{
 		CheckURL: checkObject.CheckURL,
-		ID:       checkObject.CheckURL,
 		MetaData: make(map[string]string),
 		Method:   checkObject.Method,
 		Headers:  checkObject.Headers,


### PR DESCRIPTION
It seems to be used to uniquely identify hosts to check. But it's always
just CheckURL. To avoid confusion, remove it and always use that
instead. If an ID of some sort is ever actually needed, it can be added
back.

This makes the fix for #678 trivial. Since the second field is gone,
just remove it from the log call.

Fixes #678.