### PR TITLE
Replace lonelycode/go-uuid with satori/go.uuid

### DIFF
--- a/command_mode.go
+++ b/command_mode.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/lonelycode/go-uuid/uuid"
+	"github.com/satori/go.uuid"
 
 	"github.com/TykTechnologies/tyk/apidef"
 )
@@ -117,7 +117,7 @@ func createDefFromBluePrint(bp *BluePrintAST, orgID, upstreamURL string, asMock 
 		Name:             bp.Name,
 		Active:           true,
 		UseKeylessAccess: true,
-		APIID:            uuid.NewUUID().String(),
+		APIID:            uuid.NewV4().String(),
 		OrgID:            orgID,
 	}
 	ad.VersionDefinition.Key = "version"

--- a/host_checker_manager.go
+++ b/host_checker_manager.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/lonelycode/go-uuid/uuid"
+	"github.com/satori/go.uuid"
 	"gopkg.in/vmihailenco/msgpack.v2"
 
 	"github.com/TykTechnologies/tyk/apidef"
@@ -86,7 +86,7 @@ func (hc *HostCheckerManager) Start() {
 }
 
 func (hc *HostCheckerManager) GenerateCheckerId() {
-	hc.Id = uuid.NewUUID().String()
+	hc.Id = uuid.NewV4().String()
 }
 
 func (hc *HostCheckerManager) CheckActivePollerLoop() {

--- a/rpc_storage_handler.go
+++ b/rpc_storage_handler.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	"github.com/garyburd/redigo/redis"
-	"github.com/lonelycode/go-uuid/uuid"
 	"github.com/lonelycode/gorpc"
 	"github.com/pmylund/go-cache"
+	"github.com/satori/go.uuid"
 
 	"github.com/Sirupsen/logrus"
 )
@@ -106,7 +106,7 @@ type RPCStorageHandler struct {
 }
 
 func (r *RPCStorageHandler) Register() {
-	r.ID = uuid.NewUUID().String()
+	r.ID = uuid.NewV4().String()
 	myChan := make(chan int)
 	RPCCLientRWMutex.Lock()
 	RPCClients[r.ID] = myChan

--- a/swagger.go
+++ b/swagger.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/lonelycode/go-uuid/uuid"
+	"github.com/satori/go.uuid"
 
 	"github.com/TykTechnologies/tyk/apidef"
 )
@@ -210,7 +210,7 @@ func createDefFromSwagger(s *SwaggerAST, orgId, upstreamURL string, as_mock bool
 		Name:             s.Info.Title,
 		Active:           true,
 		UseKeylessAccess: true,
-		APIID:            uuid.NewUUID().String(),
+		APIID:            uuid.NewV4().String(),
 		OrgID:            orgId,
 	}
 	ad.VersionDefinition.Key = "version"


### PR DESCRIPTION
Another outdated uuid library. Unify with the main one we use.

go-uuid's NewUUID actually returns v1 instead of v4, but that was simply
a misunderstanding - when the library was initially added, the intention
was to use v4 like in the rest of the codebase.

The old String method behaves just like the new one. The format and
length of the strings is the same.

Fixes #524.