### PR TITLE
proxy: overwrite DialContext, not Dial

### DIFF
--- a/tyk_reverse_proxy_clone.go
+++ b/tyk_reverse_proxy_clone.go
@@ -418,10 +418,10 @@ func GetTransport(timeOut int, rw http.ResponseWriter, req *http.Request, p *Rev
 	// Use the default unless we've modified the timout
 	if timeOut > 0 {
 		log.Debug("Setting timeout for outbound request to: ", timeOut)
-		transport.Dial = (&net.Dialer{
+		transport.DialContext = (&net.Dialer{
 			Timeout:   time.Duration(timeOut) * time.Second,
 			KeepAlive: 30 * time.Second,
-		}).Dial
+		}).DialContext
 		transport.SetTimeout(timeOut)
 
 	}


### PR DESCRIPTION
Since context was added to Go 1.7, the Dialer type got a DialContext
method and Dial was deprecated.

We don't care much since we don't use the context ourselves, but it's
important to note that if both are set, DialContext takes priority since
the other is deprecated.

Overwrite the method that takes priority.

Found by staticcheck; fixes one of its warnings.