### PR TITLE
coprocess: reuse driver consts from apidef

### DIFF
--- a/coprocess.go
+++ b/coprocess.go
@@ -190,7 +190,7 @@ func (m *CoProcessMiddleware) IsEnabledForSpec() bool {
 	supportedDrivers := []apidef.MiddlewareDriver{apidef.PythonDriver, apidef.LuaDriver, apidef.GrpcDriver}
 
 	for _, driver := range supportedDrivers {
-		if m.TykMiddleware.Spec.CustomMiddleware.Driver == driver && CoProcessName == string(driver) {
+		if m.TykMiddleware.Spec.CustomMiddleware.Driver == driver && CoProcessName == driver {
 			usesCoProcessMiddleware = true
 			break
 		}

--- a/coprocess_grpc.go
+++ b/coprocess_grpc.go
@@ -18,7 +18,7 @@ import (
 )
 
 // CoProcessName specifies the driver name.
-const CoProcessName = "grpc"
+const CoProcessName = apidef.GrpcDriver
 
 // MessageType sets the default message type.
 var MessageType = coprocess.ProtobufMessage

--- a/coprocess_lua.go
+++ b/coprocess_lua.go
@@ -83,7 +83,7 @@ import (
 )
 
 // CoProcessName specifies the driver name.
-const CoProcessName = "lua"
+const CoProcessName = apidef.LuaDriver
 
 const (
 	// ModuleBasePath points to the Tyk modules path.

--- a/coprocess_python.go
+++ b/coprocess_python.go
@@ -182,7 +182,7 @@ import (
 )
 
 // CoProcessName declares the driver name.
-const CoProcessName = "python"
+const CoProcessName = apidef.PythonDriver
 
 // MessageType sets the default message type.
 var MessageType = coprocess.ProtobufMessage

--- a/coprocess_test.go
+++ b/coprocess_test.go
@@ -24,7 +24,7 @@ import (
 const baseMiddlewarePath = "middleware/python"
 
 var (
-	CoProcessName     = "test"
+	CoProcessName     = apidef.MiddlewareDriver("test")
 	MessageType       = coprocess.ProtobufMessage
 	testDispatcher, _ = NewCoProcessDispatcher()
 )


### PR DESCRIPTION
This results in simpler code and deduplication of the values.