### PR TITLE
jsvm: kill copies after a timeout (goroutine leak) plus test

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -161,7 +161,7 @@ func (a *APIDefinitionLoader) MakeSpec(appConfig *apidef.APIDefinition) *APISpec
 	// Create and init the virtual Machine
 	if config.EnableJSVM {
 		newAppSpec.JSVM = &JSVM{}
-		newAppSpec.JSVM.Init(config.TykJSPath)
+		newAppSpec.JSVM.Init()
 	}
 
 	// Set up Event Handlers

--- a/main.go
+++ b/main.go
@@ -159,7 +159,7 @@ func setupGlobals() {
 
 	// Set up global JSVM
 	if config.EnableJSVM {
-		GlobalEventsJSVM.Init(config.TykJSPath)
+		GlobalEventsJSVM.Init()
 	}
 
 	if config.CoProcessOptions.EnableCoProcess {
@@ -646,7 +646,7 @@ func doReload() {
 
 	// Reset the JSVM
 	if config.EnableJSVM {
-		GlobalEventsJSVM.Init(config.TykJSPath)
+		GlobalEventsJSVM.Init()
 	}
 
 	log.WithFields(logrus.Fields{

--- a/plugins.go
+++ b/plugins.go
@@ -226,12 +226,12 @@ type JSVM struct {
 }
 
 // Init creates the JSVM with the core library (tyk.js)
-func (j *JSVM) Init(coreJS string) {
+func (j *JSVM) Init() {
 	vm := otto.New()
-	coreJs, _ := ioutil.ReadFile(config.TykJSPath)
 
 	// Init TykJS namespace, constructors etc.
-	vm.Run(coreJs)
+	jscore, _ := ioutil.ReadFile(config.TykJSPath)
+	vm.Run(jscore)
 
 	j.VM = vm
 

--- a/plugins_test.go
+++ b/plugins_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestJSVMProcessTimeout(t *testing.T) {
+	dynMid := &DynamicMiddleware{
+		TykMiddleware: &TykMiddleware{
+			Spec: &APISpec{},
+		},
+		MiddlewareClassName: "leakMid",
+		Pre:                 true,
+	}
+	req := httptest.NewRequest("GET", "/foo", strings.NewReader("body"))
+	jsvm := &JSVM{}
+	jsvm.Init()
+
+	// this js plugin just loops forever, keeping Otto at 100% CPU
+	// usage and running forever.
+	const js = `
+var leakMid = new TykJS.TykMiddleware.NewMiddleware({});
+
+leakMid.NewProcessRequest(function(request, session) {
+       while (true) {
+       }
+       return leakMid.ReturnData(request, session.meta_data);
+});
+`
+	if _, err := jsvm.VM.Run(js); err != nil {
+		t.Fatalf("failed to set up js plugin: %v", err)
+	}
+	dynMid.Spec.JSVM = jsvm
+
+	done := make(chan bool)
+	go func() {
+		dynMid.ProcessRequest(nil, req, nil)
+		done <- true
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("js vm wasn't killed after its timeout")
+	}
+}

--- a/plugins_test.go
+++ b/plugins_test.go
@@ -18,6 +18,7 @@ func TestJSVMProcessTimeout(t *testing.T) {
 	req := httptest.NewRequest("GET", "/foo", strings.NewReader("body"))
 	jsvm := &JSVM{}
 	jsvm.Init()
+	jsvm.Timeout = time.Millisecond
 
 	// this js plugin just loops forever, keeping Otto at 100% CPU
 	// usage and running forever.

--- a/rpc_backup_handlers.go
+++ b/rpc_backup_handlers.go
@@ -89,7 +89,7 @@ func doLoadWithBackup(specs []*APISpec) {
 	}
 
 	// Reset the JSVM
-	GlobalEventsJSVM.Init(config.TykJSPath)
+	GlobalEventsJSVM.Init()
 	log.Warning("[RPC Backup] --> Initialised JSVM")
 
 	newRouter := mux.NewRouter()


### PR DESCRIPTION
To show progress until it's ready, and in case anyone wants to start reviewing any of it.

The actual fix isn't part of this yet, so CI should be red.