### PR TITLE
Squashed distributed quota branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ services:
   - redis-server
 
 install:
+  - go get github.com/TykTechnologies/dq
+  - go get github.com/TykTechnologies/tyk-cluster-framework/...
   - go install ./...
 
 script:

--- a/api.go
+++ b/api.go
@@ -103,7 +103,30 @@ func doAddOrUpdate(keyName string, newSession *SessionState, dontReset bool) err
 		// We have a specific list of access rules, only add / update those
 		for apiId := range newSession.AccessRights {
 			apiSpec := GetSpecForApi(apiId)
-			if apiSpec == nil {
+			if apiSpec != nil {
+
+				checkAndApplyTrialPeriod(keyName, apiId, newSession)
+
+				// Lets reset keys if they are edited by admin
+				if !apiSpec.DontSetQuotasOnCreate {
+					// Reset quote by default
+					if !dontReset {
+						if config.UseDistributedQuotaCounter {
+							QuotaHandler.TagDelete(keyName)
+						}
+						apiSpec.SessionManager.ResetQuota(keyName, newSession)
+
+						// Update the maximum
+						newSession.QuotaRemaining = newSession.QuotaMax
+						newSession.QuotaRenews = time.Now().Unix() + newSession.QuotaRenewalRate
+					}
+
+					err := apiSpec.SessionManager.UpdateSession(keyName, newSession, getLifetime(apiSpec, newSession))
+					if err != nil {
+						return err
+					}
+				}
+			} else {
 				log.WithFields(logrus.Fields{
 					"prefix":      "api",
 					"key":         keyName,

--- a/auth_manager.go
+++ b/auth_manager.go
@@ -102,6 +102,9 @@ func (b *DefaultSessionManager) ResetQuota(keyName string, session *SessionState
 	// Fix the raw key
 	go b.Store.DeleteRawKey(rawKey)
 	//go b.Store.SetKey(rawKey, "0", session.QuotaRenewalRate)
+	if config.UseDistributedQuotaCounter {
+		QuotaHandler.TagDelete(keyName)
+	}
 }
 
 // UpdateSession updates the session state in the storage engine

--- a/config.go
+++ b/config.go
@@ -234,6 +234,9 @@ type Config struct {
 	MaxIdleConnsPerHost               int                                   `bson:"max_idle_connections_per_host" json:"max_idle_connections_per_host"`
 	ReloadWaitTime                    int                                   `bson:"reload_wait_time" json:"reload_wait_time"`
 	ProxySSLInsecureSkipVerify        bool                                  `json:"proxy_ssl_insecure_skip_verify"`
+	UseDistributedQuotaCounter        bool                                  `bson:"use_distributed_counter" json:"use_distributed_counter"`
+	DistributedQuotaFlushIntervalInMS int                                   `bson:"distributed_quota_flush_interval_in_ms" json:"distributed_quota_flush_interval_in_ms"`
+	DQSetMaster                       bool                                  `bson:"distributed_quota_set_master" json:"distributed_quota_set_master"`
 }
 
 type CertData struct {

--- a/dq.go
+++ b/dq.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/TykTechnologies/tyk-cluster-framework/client"
+	"github.com/TykTechnologies/tyk-cluster-framework/encoding"
+
+	"github.com/jeffail/tunny"
+
+	"github.com/Sirupsen/logrus"
+
+	"github.com/TykTechnologies/dq"
+	"github.com/TykTechnologies/tyk/apidef"
+)
+
+var DQFlusherPool *tunny.WorkPool = tunny.CreatePoolGeneric(10)
+var QuotaHandler *dq.DistributedQuota
+
+type GetLeaderStatusFunc func() bool
+
+func getDQTopic() string {
+	topic := "tyk.dq"
+	if config.DBAppConfOptions.NodeIsSegmented {
+		if len(config.DBAppConfOptions.Tags) > 0 {
+			tags := strings.Join(config.DBAppConfOptions.Tags, ".")
+			topic += "." + tags
+
+		}
+	}
+
+	return topic
+}
+
+func dqErrorHandler(e error) {
+	log.WithFields(logrus.Fields{
+		"prefix": "main.DQ",
+	}).Error(e)
+}
+
+var dummyAPISpec = APISpec{APIDefinition: &apidef.APIDefinition{SessionLifetime: 0}}
+
+func dqFlusher(d map[string]*dq.Quota) error {
+	for k, v := range d {
+		DQFlusherPool.SendWork(func() {
+			// Ignore deleted flags
+			if v.Delete {
+				log.Warning("Key has been tagged for deletion, not writing counter")
+				return
+			}
+
+			// We will track all the session handlers for this key
+			processedSpecs := map[SessionHandler]struct{}{}
+
+			// Let's go through all the API IDs in the metadata so we capture all the handlers
+			apis := v.Meta.(map[string]interface{})["Apis"]
+
+			// I hate this
+			var exp int64
+			switch x := v.Meta.(map[string]interface{})["QuotaRenewal"].(type) {
+			case int64:
+				exp = x
+			case float64:
+				exp = int64(x)
+			}
+
+			expT := time.Unix(exp, 0)
+			for _, aid := range apis.([]interface{}) {
+				apiID := aid.(string)
+
+				// This will grab the session handler
+				spec := GetSpecForApi(apiID)
+				if spec == nil {
+					log.Warning("Can't find back-end for this API, skipping")
+					break
+				}
+
+				// Have we processed on this handler before (many APIs may use the same handler)?
+				_, processedOnSH := processedSpecs[spec.SessionManager]
+				if processedOnSH {
+					continue
+				}
+
+				// This handler hasn't been used yet for the API
+				// Get the session data
+				s, f := spec.SessionManager.GetSessionDetail(k)
+
+				// If it was found, lets process it for this handler
+				if !f {
+					// No longer in session store, delete
+					QuotaHandler.TagDelete(k)
+					continue
+				}
+
+				if !f || time.Now().After(expT) || s.IsExpired() {
+					QuotaHandler.TagDelete(k)
+					continue
+				}
+
+				qr := int64(v.Max - v.Counter.Count())
+				if qr < 0 {
+					qr = 0
+				}
+
+				// Only write on count difference
+				if qr != s.QuotaRemaining {
+					s.QuotaRemaining = qr
+					spec.SessionManager.UpdateSession(k, &s, getLifetime(&dummyAPISpec, &s))
+					// Since we've written the token, we don't need to re-do it at the end of the middleware chain
+					s.SetFirstSeenHash()
+					// We've performed a write on this SH now, lets tag that so we don't do it again
+					processedSpecs[spec.SessionManager] = struct{}{}
+				}
+
+			}
+		})
+	}
+
+	return nil
+
+}
+
+func startDQ(statusFunc GetLeaderStatusFunc) {
+	log.WithFields(logrus.Fields{
+		"prefix": "DQuota",
+	}).Info("Using Distributed Quota")
+	p := strconv.Itoa(config.Storage.Port)
+	cs := fmt.Sprintf("redis://%v:%v", config.Storage.Host, p)
+	c1, err := client.NewClient(cs, encoding.JSON)
+	if err != nil {
+		log.WithFields(logrus.Fields{
+			"prefix": "DQuota",
+		}).Error("Failed to create distributed quota client: ", err)
+	}
+
+	QuotaHandler = dq.NewDQ(dqFlusher, dqErrorHandler, NodeID)
+	broadcastTimer := time.Millisecond * 100
+	QuotaHandler.BroadcastWith(c1, broadcastTimer, getDQTopic())
+
+	// We always need a leader because otherwise we can;t persist data
+	QuotaHandler.SetLeader(statusFunc())
+
+	QuotaHandler.FlushInterval = time.Second * 3
+	if config.DistributedQuotaFlushIntervalInMS != 0 {
+		QuotaHandler.FlushInterval = time.Millisecond * time.Duration(config.DistributedQuotaFlushIntervalInMS)
+	}
+
+	DQFlusherPool.Open()
+
+	if err := QuotaHandler.Start(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Give us time to catch with the cluster
+	time.Sleep(broadcastTimer)
+}
+
+func (l SessionLimiter) IsDistributedQuotaExceeded(currentSession *SessionState, key string) bool {
+
+	// Are they unlimited?
+	if currentSession.QuotaMax == -1 {
+		// No quota set
+		return false
+	}
+
+	// store the old expiry so we propagate the right value
+	md := map[string]interface{}{
+		"QuotaRenewal": currentSession.QuotaRenews,
+	}
+
+	// Handle renewal
+	RenewalDate := time.Unix(currentSession.QuotaRenews, 0)
+	if time.Now().After(RenewalDate) {
+		// The renewal date is in the past, we should update the quota!
+		// Also, this fixes legacy issues where there is no TTL on quota buckets
+		log.Warning("Incorrect key expiry setting detected, correcting / or renewing quota")
+
+		// To reset a quota we just delete the ket from our distributed counter, this should propagate
+		QuotaHandler.TagDelete(key)
+
+		// Set the new renewal date
+		current := time.Now().Unix()
+		currentSession.QuotaRenews = current + currentSession.QuotaRenewalRate
+
+		// Reset the quota value:
+		currentSession.QuotaRemaining = currentSession.QuotaMax
+	}
+
+	// This is cleaner than just copying the access rights
+	ar := make([]interface{}, len(currentSession.AccessRights))
+	i := 0
+	for k := range currentSession.AccessRights {
+		ar[i] = k
+		i++
+	}
+
+	md["Apis"] = ar
+
+	used := int(currentSession.QuotaMax - currentSession.QuotaRemaining)
+
+	QuotaHandler.InitQuota(int(currentSession.QuotaMax),
+		used,
+		key,
+		md)
+
+	return QuotaHandler.IncrBy(key, 1) == dq.Quota_violated
+}

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -762,6 +762,55 @@ func TestQuota(t *testing.T) {
 	}
 }
 
+func TestDistributedQuotaSingleNode(t *testing.T) {
+	spec := createSpecTest(t, nonExpiringDefNoWhiteList)
+	session := createQuotaSession()
+	keyId := testKey(t, "key")
+	spec.SessionManager.UpdateSession(keyId, session, 60)
+	defer spec.SessionManager.ResetQuota(keyId, session)
+
+	recorder := httptest.NewRecorder()
+
+	req, err := http.NewRequest("GET", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Add("authorization", keyId)
+
+	config.DQSetMaster = true
+	config.UseDistributedQuotaCounter = true
+	config.DistributedQuotaFlushIntervalInMS = 100
+	defer func() {
+		config.DQSetMaster = false
+		config.UseDistributedQuotaCounter = false
+		config.DistributedQuotaFlushIntervalInMS = 0
+	}()
+
+	startDQ(decideLeaderMechanism())
+
+	chain := getChain(spec)
+	chain.ServeHTTP(recorder, req)
+	if recorder.Code != 200 {
+		t.Error("Initial request failed with non-200 code: \n", recorder.Code, " Header:", recorder.HeaderMap)
+	}
+
+	secondRecorder := httptest.NewRecorder()
+	chain.ServeHTTP(secondRecorder, req)
+	thirdRecorder := httptest.NewRecorder()
+	chain.ServeHTTP(thirdRecorder, req)
+
+	if thirdRecorder.Code != 403 {
+		t.Error("Third request returned invalid code, should 403, got: \n", thirdRecorder.Code)
+	}
+
+	newAPIError := tykErrorResponse{}
+	json.Unmarshal(thirdRecorder.Body.Bytes(), &newAPIError)
+
+	if newAPIError.Error != "Quota exceeded" {
+		t.Error("Third request returned invalid message, got: \n", newAPIError.Error)
+	}
+}
+
 func TestWithAnalytics(t *testing.T) {
 	spec := createSpecTest(t, nonExpiringDefNoWhiteList)
 	session := createNonThrottledSession()

--- a/main.go
+++ b/main.go
@@ -1226,8 +1226,28 @@ func startDRL() {
 	log.WithFields(logrus.Fields{
 		"prefix": "main",
 	}).Info("Initialising distributed rate limiter")
+
 	setupDRL()
 	startRateLimitNotifications()
+
+	if config.UseDistributedQuotaCounter {
+		// Start the distributed quota system
+		startDQ(decideLeaderMechanism())
+	}
+}
+
+// In case we want to use a channel or some other leadership checker
+func decideLeaderMechanism() GetLeaderStatusFunc {
+	switch config.Storage.Type {
+	case "redis":
+		// For redis we should distribute write in order to retain consistency
+		log.WithFields(logrus.Fields{
+			"prefix": "main",
+		}).Warning("If using redis with distributed quota it is recommended to make all gateways leader")
+		return func() bool { return config.DQSetMaster }
+	default:
+		return func() bool { return config.DQSetMaster }
+	}
 }
 
 func listen(l, controlListener net.Listener, err error) {

--- a/middleware_virtual_endpoint.go
+++ b/middleware_virtual_endpoint.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/mitchellh/mapstructure"
@@ -283,14 +282,6 @@ func (d *VirtualEndpoint) HandleResponse(rw http.ResponseWriter, res *http.Respo
 	// Close connections
 	if config.CloseConnections {
 		res.Header.Set("Connection", "close")
-	}
-
-	// Add resource headers
-	if ses != nil {
-		// We have found a session, lets report back
-		res.Header.Add("X-RateLimit-Limit", strconv.Itoa(int(ses.QuotaMax)))
-		res.Header.Add("X-RateLimit-Remaining", strconv.Itoa(int(ses.QuotaRemaining)))
-		res.Header.Add("X-RateLimit-Reset", strconv.Itoa(int(ses.QuotaRenews)))
 	}
 
 	copyHeader(rw.Header(), res.Header)

--- a/session_manager.go
+++ b/session_manager.go
@@ -118,9 +118,16 @@ func (l *SessionLimiter) ForwardMessage(currentSession *SessionState, key string
 			currentSession.Allowance--
 		}
 
-		if l.IsRedisQuotaExceeded(currentSession, key, store) {
-			return false, 2
+		if config.UseDistributedQuotaCounter {
+			if l.IsDistributedQuotaExceeded(currentSession, key) {
+				return false, 2
+			}
+		} else {
+			if l.IsRedisQuotaExceeded(currentSession, key, store) {
+				return false, 2
+			}
 		}
+
 	}
 
 	return true, 0

--- a/session_state.go
+++ b/session_state.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/spaolacci/murmur3"
 	"gopkg.in/vmihailenco/msgpack.v2"
@@ -70,6 +71,14 @@ type SessionState struct {
 }
 
 var murmurHasher = murmur3.New32()
+
+func (s *SessionState) IsExpired() bool {
+	return time.Now().After(time.Unix(s.Expires, 0))
+}
+
+func (s *SessionState) IsQuotaExpired() bool {
+	return time.Now().After(time.Unix(s.QuotaRenews, 0))
+}
 
 func (s *SessionState) SetFirstSeenHash() {
 	encoded, err := msgpack.Marshal(s)

--- a/tyk_reverse_proxy_clone.go
+++ b/tyk_reverse_proxy_clone.go
@@ -15,7 +15,6 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -611,14 +610,6 @@ func (p *ReverseProxy) HandleResponse(rw http.ResponseWriter, res *http.Response
 	// Close connections
 	if config.CloseConnections {
 		res.Header.Set("Connection", "close")
-	}
-
-	// Add resource headers
-	if ses != nil {
-		// We have found a session, lets report back
-		res.Header.Add("X-RateLimit-Limit", strconv.Itoa(int(ses.QuotaMax)))
-		res.Header.Add("X-RateLimit-Remaining", strconv.Itoa(int(ses.QuotaRemaining)))
-		res.Header.Add("X-RateLimit-Reset", strconv.Itoa(int(ses.QuotaRenews)))
 	}
 
 	copyHeader(rw.Header(), res.Header)


### PR DESCRIPTION
(This is a squashed version of #674, which is closed)

Ok this is a complicated one.

Distributed Quota feature (lets call it a beta): instead of having the quota enforced by a shared counter in redis, the counter is in-memory and counters are shared across a message bus to other cluster gateways, then merged, to create a distributed total. This means no centralised state and no one-to-one linkage with Redis.

**What we are trying to achieve:**

1. Stop having a one-to-one relationship with redis, when a counter-based quota is enforced, every inbound request means a roundtrip to redis, this is expensive and adds latency, even if done async it floods the redis connection counter pool and means performance degrades as traffic increases
2. Make counter operations faster: Since these are in-memory and are merged in the background, the counter is entirely in-memory and no round-trip or lookup is required. This should improve throughput for metered connections
3. The new DQ Quota object means that actually we can introduce new metering metrics because it is an abstraction
4. Managed redis writes (or any persistence), since the distributed cluster, with a single leader, will only write to the store every `x` interval (default to 3 seconds),  so no matter how high the load, the writes speed isn't a linear relation to throughput.

To enable set the following in `tyk.conf`:

- `use_distributed_counter` to `true`: This enables the feature 
- `distributed_quota_set_master` to `true`: Since we only have redis as a pub/sub mechanism at the moment, we need all nodes to be masters, this causes all nodes to persist the CRDT list and is therefore fault tolerant. This is optional, obviously, if you can be completely sure that your master will not fail - so long as one node is set as master we are clear.

It will work in single-host mode just like a regular quota.

There is a unit test, but multi-host testing was done manually, as well a failure conditions:

*Manual testing procedure:*

This is best done with a docker env because you need to generate a network of gateways.

1. Start 3 gateways against a dashboard and configure an API that uses token auth
2. Set up a gateway in CE mode and create an open API that round robins to the 3 other gateways, we are basically forcing distributed access via the CE gateway
3. Create a token with a quota inthe distributed nodes (dashboard)
4. Send traffic to the CE gateway APi that is round-robinning to the 3 nodes
5. Watch the returned headers of the response, there will be an X-Ratelimit-Remaining header that should count down
6. Ensure that an error is returned once you reach the quota

Note: The countdown is only partially accurate due to the distributed persistence, *however* the quota *will* be enforced accurately.

Further testing should then be the above procedure but with the following changes:

1. Start the cluster, then stop all instances mid-test, then start again
2. Start the cluster, kill one of the 3 nodes and then start it again while sending traffic (the requests will fail when the request hits a dead server, but that doesn;t matter, the quota should count down and continue to be enforced when it remains down AND when it is brought back online).