### PR TITLE
all: get rid of context.GetOk usage

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -1051,9 +1051,8 @@ func (a *APISpec) GetVersionData(r *http.Request) (*apidef.VersionInfo, []URLSpe
 	var versionWLStatus bool
 
 	// try the context first
-	aVersion, foundInContext := context.GetOk(r, VersionData)
-
-	if foundInContext {
+	aVersion := context.Get(r, VersionData)
+	if aVersion != nil {
 		version = aVersion.(apidef.VersionInfo)
 		versionKey = context.Get(r, VersionKeyContext).(string)
 	} else {

--- a/handler_error.go
+++ b/handler_error.go
@@ -130,16 +130,15 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 			rawRequest = base64.StdEncoding.EncodeToString(wireFormatReq.Bytes())
 		}
 
-		trackThisEndpoint, ok := context.GetOk(r, TrackThisEndpoint)
+		trackThisEndpoint := context.Get(r, TrackThisEndpoint)
 		trackedPath := r.URL.Path
 		trackEP := false
-		if ok {
+		if trackThisEndpoint != nil {
 			trackEP = true
 			trackedPath = trackThisEndpoint.(string)
 		}
 
-		_, dnOk := context.GetOk(r, DoNotTrackThisEndpoint)
-		if dnOk {
+		if context.Get(r, DoNotTrackThisEndpoint) != nil {
 			trackEP = false
 			trackedPath = r.URL.Path
 		}

--- a/handler_success.go
+++ b/handler_success.go
@@ -249,16 +249,15 @@ func (s *SuccessHandler) RecordHit(r *http.Request, timing int64, code int, requ
 			rawResponse = base64.StdEncoding.EncodeToString(wireFormatRes.Bytes())
 		}
 
-		trackThisEndpoint, ok := context.GetOk(r, TrackThisEndpoint)
+		trackThisEndpoint := context.Get(r, TrackThisEndpoint)
 		trackedPath := r.URL.Path
 		trackEP := false
-		if ok {
+		if trackThisEndpoint != nil {
 			trackEP = true
 			trackedPath = trackThisEndpoint.(string)
 		}
 
-		_, dnOk := context.GetOk(r, DoNotTrackThisEndpoint)
-		if dnOk {
+		if context.Get(r, DoNotTrackThisEndpoint) != nil {
 			trackEP = false
 			trackedPath = r.URL.Path
 		}

--- a/middleware_auth_key.go
+++ b/middleware_auth_key.go
@@ -58,8 +58,7 @@ func (k *AuthKey) setContextVars(r *http.Request, token string) {
 	if !k.Spec.EnableContextVars {
 		return
 	}
-	cnt, contextFound := context.GetOk(r, ContextData)
-	if contextFound {
+	if cnt := context.Get(r, ContextData); cnt != nil {
 		// Key data
 		contextDataObject := cnt.(map[string]interface{})
 		contextDataObject["token"] = token

--- a/middleware_hmac.go
+++ b/middleware_hmac.go
@@ -166,8 +166,7 @@ func (hm *HMACMiddleware) setContextVars(r *http.Request, token string) {
 		return
 	}
 	// Flatten claims and add to context
-	cnt, contextFound := context.GetOk(r, ContextData)
-	if contextFound {
+	if cnt := context.Get(r, ContextData); cnt != nil {
 		// Key data
 		contextDataObject := cnt.(map[string]interface{})
 		contextDataObject["token"] = token

--- a/middleware_jwt.go
+++ b/middleware_jwt.go
@@ -421,8 +421,7 @@ func (k *JWTMiddleware) setContextVars(r *http.Request, token *jwt.Token) {
 	if !k.Spec.EnableContextVars {
 		return
 	}
-	cnt, contextFound := context.GetOk(r, ContextData)
-	if contextFound {
+	if cnt := context.Get(r, ContextData); cnt != nil {
 		contextDataObject := cnt.(map[string]interface{})
 		claimPrefix := "jwt_claims_"
 

--- a/middleware_key_expired_check.go
+++ b/middleware_key_expired_check.go
@@ -30,9 +30,8 @@ func (k *KeyExpired) IsEnabledForSpec() bool { return true }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (k *KeyExpired) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
-	sess, ok := context.GetOk(r, SessionData)
-
-	if !ok {
+	sess := context.Get(r, SessionData)
+	if sess == nil {
 		return errors.New("Session state is missing or unset! Please make sure that auth headers are properly applied"), 403
 	}
 

--- a/middleware_modify_headers.go
+++ b/middleware_modify_headers.go
@@ -51,16 +51,15 @@ func (t *TransformHeaders) IsEnabledForSpec() bool {
 // if the key and value contain a tyk session variable reference, then it will try to inject the value
 func (t *TransformHeaders) iterateAddHeaders(kv map[string]string, r *http.Request) {
 	// Get session data
-	ses, found := context.GetOk(r, SessionData)
-	cnt, contextFound := context.GetOk(r, ContextData)
 	var sessionState SessionState
-	var contextData map[string]interface{}
-
-	if found {
+	ses := context.Get(r, SessionData)
+	if ses != nil {
 		sessionState = ses.(SessionState)
 	}
 
-	if contextFound {
+	var contextData map[string]interface{}
+	cnt := context.Get(r, ContextData)
+	if cnt != nil {
 		contextData = cnt.(map[string]interface{})
 	}
 
@@ -68,7 +67,7 @@ func (t *TransformHeaders) iterateAddHeaders(kv map[string]string, r *http.Reque
 	for nKey, nVal := range kv {
 		if strings.Contains(nVal, metaLabel) {
 			// Using meta_data key
-			if found {
+			if ses != nil {
 				metaKey := strings.Replace(nVal, metaLabel, "", 1)
 				if sessionState.MetaData != nil {
 					tempVal, ok := sessionState.MetaData.(map[string]interface{})[metaKey]
@@ -86,7 +85,7 @@ func (t *TransformHeaders) iterateAddHeaders(kv map[string]string, r *http.Reque
 
 		} else if strings.Contains(nVal, contextLabel) {
 			// Using context key
-			if contextFound {
+			if cnt != nil {
 				metaKey := strings.Replace(nVal, contextLabel, "", 1)
 				if contextData != nil {
 					tempVal, ok := contextData[metaKey]

--- a/middleware_openid.go
+++ b/middleware_openid.go
@@ -233,8 +233,8 @@ func (k *OpenIDMW) setContextVars(r *http.Request, token *jwt.Token) {
 		return
 	}
 	// Flatten claims and add to context
-	cnt, contextFound := context.GetOk(r, ContextData)
-	if !contextFound {
+	cnt := context.Get(r, ContextData)
+	if cnt == nil {
 		return
 	}
 	contextDataObject := cnt.(map[string]interface{})

--- a/middleware_url_rewrite.go
+++ b/middleware_url_rewrite.go
@@ -58,9 +58,7 @@ func (u URLRewriter) Rewrite(meta *apidef.URLRewriteMeta, path string, useContex
 	if useContext {
 		log.Debug("Using context")
 		var contextData map[string]interface{}
-		cnt, contextFound := context.GetOk(r, ContextData)
-
-		if contextFound {
+		if cnt := context.Get(r, ContextData); cnt != nil {
 			contextData = cnt.(map[string]interface{})
 		}
 
@@ -70,19 +68,14 @@ func (u URLRewriter) Rewrite(meta *apidef.URLRewriteMeta, path string, useContex
 			contextKey := strings.Replace(v[0], "$tyk_context.", "", 1)
 			log.Debug("Replacing: ", v[0])
 
-			if contextFound {
-				if val, ok := contextData[contextKey]; ok {
-					newpath = strings.Replace(newpath, v[0], valToStr(val), -1)
-				}
-
+			if val, ok := contextData[contextKey]; ok {
+				newpath = strings.Replace(newpath, v[0], valToStr(val), -1)
 			}
-
 		}
 	}
 
 	// Meta data from the token
-	sess, sessFound := context.GetOk(r, SessionData)
-	if sessFound {
+	if sess := context.Get(r, SessionData); sess != nil {
 		sessionState := sess.(SessionState)
 
 		metaDollarMatch := regexp.MustCompile(`\$tyk_meta.(\w+)`)

--- a/util_http_helpers.go
+++ b/util_http_helpers.go
@@ -79,8 +79,8 @@ func RecordDetail(r *http.Request) bool {
 	}
 
 	// We are, so get session data
-	ses, found := context.GetOk(r, OrgSessionContext)
-	if !found {
+	ses := context.Get(r, OrgSessionContext)
+	if ses == nil {
 		// no session found, use global config
 		return config.AnalyticsConfig.EnableDetailedRecording
 	}


### PR DESCRIPTION
std's context has no "value, ok", version of a getter, so to transition
to it we first need to rewrite these into the simpler "value" return.

This should be a safe change since we only ever set non-nil values on
any context.

Updates #683.