### PR TITLE
test: remove last http get to the internet

### DIFF
--- a/gateway_test.go
+++ b/gateway_test.go
@@ -44,6 +44,7 @@ const (
 	testHttpAny  = "http://" + testHttpListen
 	testHttpGet  = testHttpAny + "/get"
 	testHttpPost = testHttpAny + "/post"
+	testHttpJWK  = testHttpAny + "/jwk.json"
 
 	// 16501 port should not be bind to anything, and can be used for testing failures
 	testHttpFailure     = "127.0.0.1:16501"
@@ -91,8 +92,24 @@ func testHttpHandler() http.Handler {
 	mux.HandleFunc("/", handleMethod(""))
 	mux.HandleFunc("/get", handleMethod("GET"))
 	mux.HandleFunc("/post", handleMethod("POST"))
+	mux.HandleFunc("/jwk.json", func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, jwkTestJson)
+	})
 	return mux
 }
+
+const jwkTestJson = `{
+	"keys": [{
+		"alg": "RS256",
+		"kty": "RSA",
+		"use": "sig",
+		"x5c": ["Ci0tLS0tQkVHSU4gUFVCTElDIEtFWS0tLS0tCk1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBeXFaNHJ3S0Y4cUNFeFM3a3BZNGMKbkphLzM3Rk1rSk5rYWxaM091c2xMQjBvUkw4VDRjOTRrZEY0YWVOelNGa1NlMm45OUlCSTZTc2w3OXZiZk1aYgordDA2TDBROTRrKy9QMzd4NysvUkpaaWZmNHkxVkdqcm5ybk1JMml1OWw0aUJCUll6Tm1HNmVibHJvRU1NV2xnCms1dHlzSGd4QjU5Q1NOSWNEOWdxazFoeDRuL0ZnT212S3NmUWdXSE5sUFNEVFJjV0dXR2hCMi9YZ05WWUcycE8KbFF4QVBxTGhCSGVxR1RYQmJQZkdGOWNIeml4cHNQcjZHdGJ6UHdoc1EvOGJQeG9KN2hkZm4rcnp6dGtzM2Q2KwpIV1VSY3lOVExSZTBtalhqamVlOVo2K2daK0grZlM0cG5QOXRxVDdJZ1U2ZVBVV1Rwam9pUHRMZXhnc0FhL2N0CmpRSURBUUFCCi0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo="],
+		"n": "xofiG8gsnv9-I_g-5OWTLhaZtgAGq1QEsBCPK9lmLqhuonHe8lT-nK1DM49f6J9QgaOjZ3DB50QkhBysnIFNcXFyzaYIPMoccvuHLPgdBawX4WYKm5gficD0WB0XnTt4sqTI5usFpuop9vvW44BwVGhRqMT7c11gA8TSWMBxDI4A5ARc4MuQtfm64oN-JQodSztArwb9wcmH8WrBvSUkR4pyi9MT8W27gqJ2e2Xn8jgGnswNQWOyCTN84PawOYaN-2ORHeIea1g-URln1bofcHN73vZCIrVbE6iA2D7Ybh22AVrCfunekEDEe2GZfLZLejiZiBWG7enJhcrQIzAQGw",
+		"e": "AQAB",
+		"kid": "12345",
+		"x5t": "12345"
+	}]
+}`
 
 func firstVals(vals map[string][]string) map[string]string {
 	m := make(map[string]string, len(vals))

--- a/middleware_jwt_test.go
+++ b/middleware_jwt_test.go
@@ -54,7 +54,7 @@ const jwtWithJWKDef = `{
 		"key": "version"
 	},
 	"enable_jwt": true,
-	"jwt_source": "http://keyserver.tyk.io/test_jwk.json",
+	"jwt_source": "` + testHttpJWK + `",
 	"jwt_signing_method": "RSA",
 	"jwt_identity_base_field": "user_id",
 	"jwt_policy_field_name": "policy_id",


### PR DESCRIPTION
Downloaded http://keyserver.tyk.io/test_jwk.json and put it in a
constant, to be served by the test HTTP server.

Reduces test time from ~2s to ~1.8s on my machine, and lets the full
test suite pass without internet access.