### PR TITLE
api: list all addresses in user_ip log again

### DIFF
--- a/api.go
+++ b/api.go
@@ -1203,7 +1203,7 @@ func createKeyHandler(w http.ResponseWriter, r *http.Request) {
 				"org_id":      newSession.OrgID,
 				"api_id":      "--",
 				"user_id":     "system",
-				"user_ip":     GetIPFromRequest(r),
+				"user_ip":     requestAddrs(r),
 				"path":        "--",
 				"server_name": "system",
 			}).Warning("No API Access Rights set on key session, adding key to all APIs.")
@@ -1230,7 +1230,7 @@ func createKeyHandler(w http.ResponseWriter, r *http.Request) {
 				"org_id":      newSession.OrgID,
 				"api_id":      "--",
 				"user_id":     "system",
-				"user_ip":     GetIPFromRequest(r),
+				"user_ip":     requestAddrs(r),
 				"path":        "--",
 				"server_name": "system",
 			}).Error("Master keys disallowed in configuration, key not added.")
@@ -1256,7 +1256,7 @@ func createKeyHandler(w http.ResponseWriter, r *http.Request) {
 			"org_id":      newSession.OrgID,
 			"api_id":      "--",
 			"user_id":     "system",
-			"user_ip":     GetIPFromRequest(r),
+			"user_ip":     requestAddrs(r),
 			"path":        "--",
 			"server_name": "system",
 		}).Error("System error, failed to generate key.")
@@ -1281,7 +1281,7 @@ func createKeyHandler(w http.ResponseWriter, r *http.Request) {
 		"api_id":      "--",
 		"org_id":      newSession.OrgID,
 		"user_id":     "system",
-		"user_ip":     GetIPFromRequest(r),
+		"user_ip":     requestAddrs(r),
 		"path":        "--",
 		"server_name": "system",
 	}).Info("Generated new key: (", ObfuscateKeyString(newKey), ")")
@@ -1787,7 +1787,7 @@ func invalidateCacheHandler(w http.ResponseWriter, r *http.Request) {
 			"err":         err,
 			"org_id":      orgid,
 			"user_id":     "system",
-			"user_ip":     GetIPFromRequest(r),
+			"user_ip":     requestAddrs(r),
 			"path":        "--",
 			"server_name": "system",
 		}).Error("Failed to delete cache: ", err)
@@ -1804,7 +1804,7 @@ func invalidateCacheHandler(w http.ResponseWriter, r *http.Request) {
 		"org_id":      orgid,
 		"api_id":      apiID,
 		"user_id":     "system",
-		"user_ip":     GetIPFromRequest(r),
+		"user_ip":     requestAddrs(r),
 		"path":        "--",
 		"server_name": "system",
 	}).Info("Cache invalidated successfully")

--- a/tyk_reverse_proxy_clone.go
+++ b/tyk_reverse_proxy_clone.go
@@ -493,17 +493,8 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 		}
 	}
 
-	var ip string
-	if clientIP, _, err := net.SplitHostPort(req.RemoteAddr); err == nil {
-		// If we aren't the first proxy retain prior
-		// X-Forwarded-For information as a comma+space
-		// separated list and fold multiple headers into one.
-		if prior, ok := outreq.Header["X-Forwarded-For"]; ok {
-			clientIP = strings.Join(prior, ", ") + ", " + clientIP
-		}
-		outreq.Header.Set("X-Forwarded-For", clientIP)
-		ip = clientIP
-	}
+	addrs := requestAddrs(req)
+	outreq.Header.Set("X-Forwarded-For", addrs)
 
 	// Circuit breaker
 	breakerEnforced, breakerConf := p.CheckCircuitBreakerEnforced(p.TykAPISpec, req)
@@ -549,7 +540,7 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 
 		log.WithFields(logrus.Fields{
 			"prefix":      "proxy",
-			"user_ip":     ip,
+			"user_ip":     addrs,
 			"server_name": outreq.Host,
 			"user_id":     obfuscated,
 			"user_name":   alias,

--- a/util_http_helpers.go
+++ b/util_http_helpers.go
@@ -28,6 +28,17 @@ func GetIPFromRequest(r *http.Request) string {
 	return host
 }
 
+func requestAddrs(r *http.Request) string {
+	addrs := r.RemoteAddr
+	// If we aren't the first proxy retain prior
+	// X-Forwarded-For information as a comma+space
+	// separated list and fold multiple headers into one.
+	if prior, ok := r.Header["X-Forwarded-For"]; ok {
+		addrs = strings.Join(prior, ", ") + ", " + addrs
+	}
+	return addrs
+}
+
 func CopyHttpRequest(r *http.Request) *http.Request {
 	reqCopy := new(http.Request)
 	*reqCopy = *r


### PR DESCRIPTION
I unintentionally broke this when cleaning up and fixing our GetIPFromRequest code. Only in master though, so we're good.

Commits contain more info.