### PR TITLE
api: rework code that filters by hostname

### DIFF
--- a/api_loader.go
+++ b/api_loader.go
@@ -538,6 +538,13 @@ func (d *DummyProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // Create the individual API (app) specs based on live configurations and assign middleware
 func loadApps(apiSpecs []*APISpec, muxer *mux.Router) {
+	hostname := config.HostName
+	if hostname != "" {
+		muxer = muxer.Host(hostname).Subrouter()
+		log.WithFields(logrus.Fields{
+			"prefix": "main",
+		}).Info("API hostname set: ", hostname)
+	}
 	ListenPathMap = cmap.New()
 	// load the APi defs
 	log.WithFields(logrus.Fields{

--- a/rpc_backup_handlers.go
+++ b/rpc_backup_handlers.go
@@ -95,20 +95,13 @@ func doLoadWithBackup(specs []*APISpec) {
 	newRouter := mux.NewRouter()
 	mainRouter = newRouter
 
-	var newMuxes *mux.Router
-	if getHostName() != "" {
-		newMuxes = newRouter.Host(getHostName()).Subrouter()
-	} else {
-		newMuxes = newRouter
-	}
-
 	log.Warning("[RPC Backup] --> Set up routers")
 	log.Warning("[RPC Backup] --> Loading endpoints")
 
-	loadAPIEndpoints(newMuxes)
+	loadAPIEndpoints(newRouter)
 
 	log.Warning("[RPC Backup] --> Loading APIs")
-	loadApps(specs, newMuxes)
+	loadApps(specs, newRouter)
 	log.Warning("[RPC Backup] --> API Load Done")
 
 	newServeMux := http.NewServeMux()


### PR DESCRIPTION
Make the routers filter by hostname in loadApps and loadAPIEndpoints.
The former has to filter by HostName if non-empty, and the latter has to
filter by either HostName or ControlAPIHostname, the latter taking
priority if both are set.

Do it in the funcs that actually add handlers to the routers as they are
called from many places, and this way we can be sure that the hostnames
are always set up correctly and they only affect the sub-router they
should be affecting.

In the case of the Control API, we were using getHostName() which just
used HostName, ignoring ControlAPIHostname. This resulted in
ControlAPIHostname not being used properly.

Fixes #670.