### PR TITLE
mw: fix whitelisting of ips with ports, again

### DIFF
--- a/middleware_ip_whitelist.go
+++ b/middleware_ip_whitelist.go
@@ -63,7 +63,7 @@ func (i *IPWhiteListMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Re
 			log.Info("X-Forwarded-For set, remote IP: ", remoteIPString)
 		}
 
-		splitIP := strings.Split(r.RemoteAddr, ":")
+		splitIP := strings.Split(remoteIPString, ":")
 		if len(splitIP) == 2 {
 			remoteIPString = splitIP[0]
 		}


### PR DESCRIPTION
In the previous commit, I forgot to fix the Split call to work on
remoteIPString, not r.RemoteAddr.

Before this commit, if X-Forwarded-For was set but r.RemoteAddr
contained a ':', we would use r.RemoteAddr instead of X-Forwarded-For.

Spotted by Leonid during code review of the previous PR, but after it
was merged.

Updates #704.