### PR TITLE
only strip first instance of listen path

### DIFF
--- a/res_handler_header_transform.go
+++ b/res_handler_header_transform.go
@@ -62,7 +62,7 @@ func (h HeaderTransform) HandleResponse(rw http.ResponseWriter,
 			if len(h.Spec.target.Path) != 0 {
 				newHeaderValue = strings.Replace(
 					newHeaderValue, h.Spec.target.Path,
-					h.Spec.Proxy.ListenPath, -1)
+					h.Spec.Proxy.ListenPath, 1)
 			} else {
 				newHeaderValue = strings.Replace(
 					newHeaderValue, req.URL.Path,


### PR DESCRIPTION
Changes the call to strings.Replace to only replace 1 (the first) instance of matching listen path.

This is to solve an issue where your listen path might be something like `/api/`, and your application has a route that also matches `/api/`.

For example: your application has a route like `example.com/api/endpoint`).
In tyk, you configure the listen path to be `/api/` and the target url is `http://example.com/`. The way this currently functions, if you make a request to `your-tyk.com/api/api/endpoint`, both of the instances of `api` get trimmed off, leaving you with a malformed request.

I think most people would agree, when setting the listen path, the expected behavior is for it to only match against the first instance of that phrase.