### PR TITLE
Context vars now includes a correlation ID (`cid`), with test. Fixes #713

### DIFF
--- a/gateway_test.go
+++ b/gateway_test.go
@@ -268,11 +268,13 @@ func getChain(spec *APISpec) http.Handler {
 	tykMiddleware := &TykMiddleware{spec, proxy}
 	chain := alice.New(
 		CreateMiddleware(&IPWhiteListMiddleware{tykMiddleware}, tykMiddleware),
+		CreateMiddleware(&MiddlewareContextVars{TykMiddleware: tykMiddleware}, tykMiddleware),
 		CreateMiddleware(&AuthKey{tykMiddleware}, tykMiddleware),
 		CreateMiddleware(&VersionCheck{TykMiddleware: tykMiddleware}, tykMiddleware),
 		CreateMiddleware(&KeyExpired{tykMiddleware}, tykMiddleware),
 		CreateMiddleware(&AccessRightsCheck{tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&RateLimitAndQuotaCheck{tykMiddleware}, tykMiddleware)).Then(proxyHandler)
+		CreateMiddleware(&RateLimitAndQuotaCheck{tykMiddleware}, tykMiddleware),
+		CreateMiddleware(&TransformHeaders{tykMiddleware}, tykMiddleware)).Then(proxyHandler)
 
 	return chain
 }

--- a/middleware_context_vars.go
+++ b/middleware_context_vars.go
@@ -3,6 +3,8 @@ package main
 import (
 	"net/http"
 	"strings"
+
+	"github.com/satori/go.uuid"
 )
 
 type MiddlewareContextVars struct {
@@ -59,6 +61,9 @@ func (m *MiddlewareContextVars) ProcessRequest(w http.ResponseWriter, r *http.Re
 
 	// IP:Port
 	contextDataObject["remote_addr"] = copiedRequest.RemoteAddr
+
+	//Correlation ID
+	contextDataObject["request_id"] = uuid.NewV4().String()
 
 	ctxSetData(r, contextDataObject)
 

--- a/middleware_context_vars_test.go
+++ b/middleware_context_vars_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+const contextVarsMiddlewareDefinition = `{
+	"name": "Tyk Test API",
+	"api_id": "1",
+	"org_id": "default",
+	"definition": {
+		"location": "header",
+		"key": "version"
+	},
+	"auth": {
+		"auth_header_name": "authorization"
+	},
+	"version_data": {
+		"not_versioned": true,
+		"versions": {
+			"v1": {
+				"name": "v1",
+				"expires": "2100-01-02 15:04",
+				"use_extended_paths": true,
+				"paths": {
+					"ignored": [],
+					"white_list": [],
+					"black_list": []
+				},
+				"global_headers":{
+					"X-Static": "foo",
+					"X-Request-ID":"$tyk_context.request_id",
+					"X-Path": "$tyk_context.path",
+					"X-Remote-Addr": "$tyk_context.remote_addr"
+				}
+			}
+		}
+	},
+	"proxy": {
+		"listen_path": "/v1",
+		"target_url": "` + testHttpAny + `",
+		"strip_listen_path": false
+	},
+	"enable_context_vars": true
+}`
+
+func createContextVarsSampleAPI(t *testing.T, apiTestDef string) *APISpec {
+	spec := createSpecTest(t, apiTestDef)
+	loadApps([]*APISpec{spec}, discardMuxer)
+	return spec
+}
+
+func TestContextVarsMiddleware(t *testing.T) {
+	spec := createContextVarsSampleAPI(t, contextVarsMiddlewareDefinition)
+	session := createNonThrottledSession()
+	spec.SessionManager.UpdateSession("1234wer", session, 60)
+	uri := "/test/this/path"
+	method := "GET"
+
+	recorder := httptest.NewRecorder()
+	param := make(url.Values)
+	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req.RemoteAddr = "127.0.0.1:80"
+	req.Header.Add("authorization", "1234wer")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	chain := getChain(spec)
+	chain.ServeHTTP(recorder, req)
+
+	if recorder.Code != 200 {
+		t.Fatal("Invalid response code, should be 200:  \n", recorder.Code, recorder.Body)
+	}
+
+	if req.Header.Get("X-Static") == "" {
+		t.Fatal("Sanity check failed: could not find static const in header")
+	}
+
+	if req.Header.Get("X-Path") == "" {
+		t.Fatal("Could not find Path in header")
+	}
+
+	if req.Header.Get("X-Remote-Addr") == "" {
+		t.Fatal("Could not find Remote-Addr in header")
+	}
+
+	if req.Header.Get("X-Request-ID") == "" {
+		t.Fatal("Could not find Correlation ID in header")
+	}
+
+}


### PR DESCRIPTION
Also inadvertently tests other context variables and the global header injector. Fixes #713 