### PR TITLE
api: add "block" url parameter to /tyk/reload

### DIFF
--- a/api_definition_test.go
+++ b/api_definition_test.go
@@ -413,9 +413,6 @@ func TestGetAPISpecsDashboardSuccess(t *testing.T) {
 		}
 	}
 	handleRedisEvent(msg, handled, wg.Done)
-	if len(reloadChan) != 1 {
-		t.Fatal("Should trigger reload")
-	}
 
 	// Since we already know that reload is queued
 	reloadTick <- time.Time{}

--- a/coprocess_test.go
+++ b/coprocess_test.go
@@ -77,9 +77,7 @@ func TestCoProcessReload(t *testing.T) {
 	testDispatcher.reloaded = false
 	var wg sync.WaitGroup
 	wg.Add(1)
-	if !reloadURLStructure(wg.Done) {
-		t.Fatal("reload wasn't queued")
-	}
+	reloadURLStructure(wg.Done)
 	reloadTick <- time.Time{}
 	wg.Wait()
 	if !testDispatcher.reloaded {


### PR DESCRIPTION
The endpoint blocks even if a reload is already queued, in which case it waits for the queued reload to finish.

See the commits for details.

Fixes #703.