### PR TITLE
all: remove duplicate funcs

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -960,7 +960,7 @@ func (a *APISpec) getVersionFromRequest(r *http.Request) string {
 		return r.Header.Get(a.APIDefinition.VersionDefinition.Key)
 
 	case "url-param":
-		tempRes := copyRequest(r)
+		tempRes := CopyHttpRequest(r)
 		return tempRes.FormValue(a.APIDefinition.VersionDefinition.Key)
 
 	case "url":

--- a/middleware_jwt.go
+++ b/middleware_jwt.go
@@ -315,14 +315,14 @@ func (k *JWTMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, c
 	// Get the token
 	rawJWT := r.Header.Get(config.AuthHeaderName)
 	if config.UseParam {
-		tempRes := copyRequest(r)
+		tempRes := CopyHttpRequest(r)
 
 		// Set hte header name
 		rawJWT = tempRes.FormValue(config.AuthHeaderName)
 	}
 
 	if config.UseCookie {
-		tempRes := copyRequest(r)
+		tempRes := CopyHttpRequest(r)
 		authCookie, err := tempRes.Cookie(config.AuthHeaderName)
 		if err != nil {
 			rawJWT = ""

--- a/middleware_redis_cache.go
+++ b/middleware_redis_cache.go
@@ -65,21 +65,6 @@ func (m *RedisCacheMiddleware) CreateCheckSum(req *http.Request, keyName string)
 	return m.Spec.APIDefinition.APIID + keyName + reqChecksum
 }
 
-func getIP(ip string) (string, error) {
-	ipWithoutPort := strings.Split(ip, ":")
-
-	if len(ipWithoutPort) > 1 {
-		ip = ipWithoutPort[0]
-	} else {
-		if len(ipWithoutPort) == 1 {
-			return ip, nil
-		}
-		log.Warning(ipWithoutPort)
-		return ip, errors.New("IP Address malformed")
-	}
-	return ip, nil
-}
-
 func (m *RedisCacheMiddleware) getTimeTTL(cacheTTL int64) string {
 	timeNow := time.Now().Unix()
 	newTTL := timeNow + cacheTTL
@@ -163,11 +148,7 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 
 	// No authentication data? use the IP.
 	if authVal == nil {
-		var err error
-		if authHeaderValue, err = getIP(GetIPFromRequest(r)); err != nil {
-			log.Error(err)
-			return nil, 200
-		}
+		authHeaderValue = GetIPFromRequest(r)
 	} else {
 		authHeaderValue = authVal.(string)
 	}


### PR DESCRIPTION
copyRequest is an almost exact copy of CopyHttpRequest, so just use that
instead.

getIP is equally very similar to GetIPFromRequest. But it was being used
on the result of GetIPFromRequest so there is no port to strip. Worse
even, it assumes IPv4 and would break if given IPv6.