### PR TITLE
plugin: marshal body into json as []byte

### DIFF
--- a/js/tyk.js
+++ b/js/tyk.js
@@ -17,6 +17,7 @@ TykJS.TykMiddleware.MiddlewareComponentMeta.prototype.ProcessRequest = function(
 };
 
 TykJS.TykMiddleware.MiddlewareComponentMeta.prototype.DoProcessRequest = function(request, session, config) {
+    request.Body = b64dec(request.Body)
     var processed_request = this.ProcessRequest(request, session, config);
 
     if (!processed_request) {
@@ -26,6 +27,7 @@ TykJS.TykMiddleware.MiddlewareComponentMeta.prototype.DoProcessRequest = functio
     
     // Reset the headers object
     processed_request.Request.Headers = {}
+    processed_request.Request.Body = b64enc(processed_request.Request.Body)
 
     return JSON.stringify(processed_request)
 };


### PR DESCRIPTION
The encoding/json godoc reads:

	String values encode as JSON strings coerced to valid UTF-8,
	replacing invalid bytes with the Unicode replacement rune.

	... []byte encodes as a base64-encoded string, ...

We need to marshal the body as a []byte, not a string. Since JSON needs
to be valid UTF-8, we can't just keep the bytes as-is.

We can't simply quote the string, as JSON does not have a way to escape
bytes like \xff. It does have \u, but that is only for valid unicode
characters, which binary bytes may not be.

Using []byte in JSON means encoding to base64 in Go, so we must
introduce functions in the JSVM to decode and encode base64. This is so
that JS plugins can replace or modify the body in plaintext, not base64.
This is required for backwards compatibility.

This may or may not work in some JS implementations depending on whether
or not their strings can contain non-UTF8. Luckily, Otto supports that
just fine. We check this via the added test, which has ASCII, non-ASCII
unicode and non-unicode characters in one string that is modified.

Fixes #351.