### PR TITLE
all: cleanup test methods, uris and params

### DIFF
--- a/api_definition_test.go
+++ b/api_definition_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"sync"
 	"testing"
 	"time"
@@ -128,15 +127,11 @@ func createDefinitionFromString(defStr string) *APISpec {
 }
 
 func TestExpiredRequest(t *testing.T) {
-	uri := "/v1/bananaphone"
-	method := "GET"
-
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
-	req.Header.Add("version", "v1")
+	req, err := http.NewRequest("GET", "/v1/bananaphone", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	req.Header.Add("version", "v1")
 
 	spec := createDefinitionFromString(sampleDefiniton)
 
@@ -152,12 +147,7 @@ func TestExpiredRequest(t *testing.T) {
 }
 
 func TestNotVersioned(t *testing.T) {
-	uri := "v1/allowed/whitelist/literal"
-	method := "GET"
-
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
-
+	req, err := http.NewRequest("GET", "v1/allowed/whitelist/literal", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -179,11 +169,7 @@ func TestNotVersioned(t *testing.T) {
 }
 
 func TestMissingVersion(t *testing.T) {
-	uri := "/v1/bananaphone"
-	method := "GET"
-
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/v1/bananaphone", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,11 +188,7 @@ func TestMissingVersion(t *testing.T) {
 }
 
 func TestWrongVersion(t *testing.T) {
-	uri := "/v1/bananaphone"
-	method := "GET"
-
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/v1/bananaphone", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -226,10 +208,7 @@ func TestWrongVersion(t *testing.T) {
 }
 
 func TestBlacklistLinks(t *testing.T) {
-	uri := "v1/disallowed/blacklist/literal"
-	method := "GET"
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "v1/disallowed/blacklist/literal", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -247,10 +226,7 @@ func TestBlacklistLinks(t *testing.T) {
 		t.Error(status)
 	}
 
-	uri = "v1/disallowed/blacklist/abacab12345"
-	method = "GET"
-	param = make(url.Values)
-	req, err = http.NewRequest(method, uri+param.Encode(), nil)
+	req, err = http.NewRequest("GET", "v1/disallowed/blacklist/abacab12345", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -268,10 +244,7 @@ func TestBlacklistLinks(t *testing.T) {
 }
 
 func TestWhiteLIstLinks(t *testing.T) {
-	uri := "v1/allowed/whitelist/literal"
-	method := "GET"
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "v1/allowed/whitelist/literal", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -289,10 +262,7 @@ func TestWhiteLIstLinks(t *testing.T) {
 		t.Error(status)
 	}
 
-	uri = "v1/allowed/whitelist/12345abans"
-	method = "GET"
-	param = make(url.Values)
-	req, err = http.NewRequest(method, uri+param.Encode(), nil)
+	req, err = http.NewRequest("GET", "v1/allowed/whitelist/12345abans", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -310,10 +280,7 @@ func TestWhiteLIstLinks(t *testing.T) {
 }
 
 func TestWhiteListBlock(t *testing.T) {
-	uri := "v1/allowed/bananaphone"
-	method := "GET"
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "v1/allowed/bananaphone", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -333,10 +300,7 @@ func TestWhiteListBlock(t *testing.T) {
 }
 
 func TestIgnored(t *testing.T) {
-	uri := "/v1/ignored/noregex"
-	method := "GET"
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/v1/ignored/noregex", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -356,10 +320,7 @@ func TestIgnored(t *testing.T) {
 }
 
 func TestBlacklistLinksMulti(t *testing.T) {
-	uri := "v1/disallowed/blacklist/literal"
-	method := "GET"
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "v1/disallowed/blacklist/literal", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -377,10 +338,7 @@ func TestBlacklistLinksMulti(t *testing.T) {
 		t.Error(status)
 	}
 
-	uri = "v1/disallowed/blacklist/abacab12345"
-	method = "GET"
-	param = make(url.Values)
-	req, err = http.NewRequest(method, uri+param.Encode(), nil)
+	req, err = http.NewRequest("GET", "v1/disallowed/blacklist/abacab12345", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api_test.go
+++ b/api_test.go
@@ -71,15 +71,11 @@ type testAPIDefinition struct {
 
 func TestHealthCheckEndpoint(t *testing.T) {
 	uri := "/tyk/health/?api_id=1"
-	method := "GET"
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-
 	makeSampleAPI(t, apiTestDef)
 
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
-
+	req, err := http.NewRequest("GET", uri, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +84,6 @@ func TestHealthCheckEndpoint(t *testing.T) {
 
 	var apiHealthValues HealthCheckValues
 	err = json.Unmarshal(recorder.Body.Bytes(), &apiHealthValues)
-
 	if err != nil {
 		t.Error("Could not unmarshal API Health check:\n", err, recorder.Body.String())
 	}
@@ -123,16 +118,14 @@ func TestApiHandler(t *testing.T) {
 	uris := []string{"/tyk/apis/", "/tyk/apis"}
 
 	for _, uri := range uris {
-		method := "GET"
 		sampleKey := createSampleSession()
 		body, _ := json.Marshal(&sampleKey)
 
 		recorder := httptest.NewRecorder()
-		param := make(url.Values)
 
 		makeSampleAPI(t, apiTestDef)
 
-		req, err := http.NewRequest(method, uri+param.Encode(), bytes.NewReader(body))
+		req, err := http.NewRequest("GET", uri, bytes.NewReader(body))
 
 		if err != nil {
 			t.Fatal(err)
@@ -160,17 +153,14 @@ func TestApiHandler(t *testing.T) {
 
 func TestApiHandlerGetSingle(t *testing.T) {
 	uri := "/tyk/apis/1"
-	method := "GET"
 	sampleKey := createSampleSession()
 	body, _ := json.Marshal(&sampleKey)
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
 
 	makeSampleAPI(t, apiTestDef)
 
-	req, err := http.NewRequest(method, uri+param.Encode(), bytes.NewReader(body))
-
+	req, err := http.NewRequest("GET", uri, bytes.NewReader(body))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,13 +182,9 @@ func TestApiHandlerGetSingle(t *testing.T) {
 
 func TestApiHandlerPost(t *testing.T) {
 	uri := "/tyk/apis/1"
-	method := "POST"
-
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
 
-	req, err := http.NewRequest(method, uri+param.Encode(), strings.NewReader(apiTestDef))
-
+	req, err := http.NewRequest("POST", uri, strings.NewReader(apiTestDef))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,16 +205,13 @@ func TestApiHandlerPost(t *testing.T) {
 
 func TestApiHandlerPostDbConfig(t *testing.T) {
 	uri := "/tyk/apis/1"
-	method := "POST"
 
 	config.UseDBAppConfigs = true
 	defer func() { config.UseDBAppConfigs = false }()
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
 
-	req, err := http.NewRequest(method, uri+param.Encode(), strings.NewReader(apiTestDef))
-
+	req, err := http.NewRequest("POST", uri, strings.NewReader(apiTestDef))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -288,7 +271,6 @@ func TestApiHandlerMethodAPIID(t *testing.T) {
 func TestKeyHandlerNewKey(t *testing.T) {
 	for _, api_id := range []string{"1", "none", ""} {
 		uri := "/tyk/keys/1234"
-		method := "POST"
 		sampleKey := createSampleSession()
 		body, _ := json.Marshal(&sampleKey)
 
@@ -299,7 +281,7 @@ func TestKeyHandlerNewKey(t *testing.T) {
 		if api_id != "" {
 			param.Set("api_id", api_id)
 		}
-		req, err := http.NewRequest(method, uri+param.Encode(), bytes.NewReader(body))
+		req, err := http.NewRequest("POST", uri+param.Encode(), bytes.NewReader(body))
 
 		if err != nil {
 			t.Fatal(err)
@@ -326,7 +308,6 @@ func TestKeyHandlerNewKey(t *testing.T) {
 func TestKeyHandlerUpdateKey(t *testing.T) {
 	for _, api_id := range []string{"1", "none", ""} {
 		uri := "/tyk/keys/1234"
-		method := "PUT"
 		sampleKey := createSampleSession()
 		body, _ := json.Marshal(&sampleKey)
 
@@ -336,7 +317,7 @@ func TestKeyHandlerUpdateKey(t *testing.T) {
 		if api_id != "" {
 			param.Set("api_id", api_id)
 		}
-		req, err := http.NewRequest(method, uri+param.Encode(), bytes.NewReader(body))
+		req, err := http.NewRequest("PUT", uri+param.Encode(), bytes.NewReader(body))
 
 		if err != nil {
 			t.Fatal(err)
@@ -366,7 +347,6 @@ func TestKeyHandlerGetKey(t *testing.T) {
 		createKey()
 
 		uri := "/tyk/keys/1234"
-		method := "GET"
 
 		recorder := httptest.NewRecorder()
 		param := make(url.Values)
@@ -374,7 +354,7 @@ func TestKeyHandlerGetKey(t *testing.T) {
 		if api_id != "" {
 			param.Set("api_id", api_id)
 		}
-		req, err := http.NewRequest(method, uri+"?"+param.Encode(), nil)
+		req, err := http.NewRequest("GET", uri+"?"+param.Encode(), nil)
 
 		if err != nil {
 			t.Fatal(err)
@@ -397,13 +377,11 @@ func TestKeyHandlerGetKey(t *testing.T) {
 
 func createKey() {
 	uri := "/tyk/keys/1234"
-	method := "POST"
 	sampleKey := createSampleSession()
 	body, _ := json.Marshal(&sampleKey)
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, _ := http.NewRequest(method, uri+param.Encode(), bytes.NewReader(body))
+	req, _ := http.NewRequest("POST", uri, bytes.NewReader(body))
 
 	keyHandler(recorder, req)
 }
@@ -413,7 +391,6 @@ func TestKeyHandlerDeleteKey(t *testing.T) {
 		createKey()
 
 		uri := "/tyk/keys/1234?"
-		method := "DELETE"
 
 		recorder := httptest.NewRecorder()
 		param := make(url.Values)
@@ -421,7 +398,7 @@ func TestKeyHandlerDeleteKey(t *testing.T) {
 		if api_id != "" {
 			param.Set("api_id", api_id)
 		}
-		req, err := http.NewRequest(method, uri+param.Encode(), nil)
+		req, err := http.NewRequest("DELETE", uri+param.Encode(), nil)
 
 		if err != nil {
 			t.Fatal(err)
@@ -450,7 +427,6 @@ func TestCreateKeyHandlerCreateNewKey(t *testing.T) {
 		createKey()
 
 		uri := "/tyk/keys/create"
-		method := "POST"
 
 		sampleKey := createSampleSession()
 		body, _ := json.Marshal(&sampleKey)
@@ -461,8 +437,7 @@ func TestCreateKeyHandlerCreateNewKey(t *testing.T) {
 		if api_id != "" {
 			param.Set("api_id", api_id)
 		}
-		req, err := http.NewRequest(method, uri+param.Encode(), bytes.NewReader(body))
-
+		req, err := http.NewRequest("POST", uri+param.Encode(), bytes.NewReader(body))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -486,18 +461,14 @@ func TestCreateKeyHandlerCreateNewKey(t *testing.T) {
 }
 
 func TestAPIAuthFail(t *testing.T) {
-
 	uri := "/tyk/health/?api_id=1"
-	method := "GET"
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
-	req.Header.Add("x-tyk-authorization", "12345")
-
+	req, err := http.NewRequest("GET", uri, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	req.Header.Add("x-tyk-authorization", "12345")
 
 	makeSampleAPI(t, apiTestDef)
 	checkIsAPIOwner(healthCheckhandler)(recorder, req)
@@ -508,13 +479,10 @@ func TestAPIAuthFail(t *testing.T) {
 }
 
 func TestAPIAuthOk(t *testing.T) {
-
 	uri := "/tyk/health/?api_id=1"
-	method := "GET"
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", uri, nil)
 	req.Header.Add("x-tyk-authorization", "352d20ee67be67f6340b4c0605b044b7")
 
 	if err != nil {
@@ -551,16 +519,12 @@ func TestGetOAuthClients(t *testing.T) {
 
 func TestResetHandler(t *testing.T) {
 	uri := "/tyk/reload/"
-
 	ApiSpecRegister = make(map[string]*APISpec)
 
 	makeSampleAPI(t, apiTestDef)
-
 	recorder := httptest.NewRecorder()
-	params := make(url.Values)
 
-	req, err := http.NewRequest("GET", uri+params.Encode(), nil)
-
+	req, err := http.NewRequest("GET", uri, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -614,13 +578,11 @@ func TestGroupResetHandler(t *testing.T) {
 	makeSampleAPI(t, apiTestDef)
 
 	recorder := httptest.NewRecorder()
-	params := make(url.Values)
 
 	// If we don't wait for the subscription to be done, we might do
 	// the reload before pub/sub is in place to receive our message.
 	<-didSubscribe
-	req, err := http.NewRequest("GET", uri+params.Encode(), nil)
-
+	req, err := http.NewRequest("GET", uri, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/coprocess_id_extractor_test.go
+++ b/coprocess_id_extractor_test.go
@@ -35,12 +35,9 @@ func TestValueExtractorHeaderSource(t *testing.T) {
 
 	to_encode := strings.Join([]string{username, password}, ":")
 	encodedPass := base64.StdEncoding.EncodeToString([]byte(to_encode))
-	uri := "/"
-	method := "GET"
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/", nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
 
 	if err != nil {
@@ -75,17 +72,12 @@ func TestValueExtractorFormSource(t *testing.T) {
 
 	to_encode := strings.Join([]string{username, password}, ":")
 	encodedPass := base64.StdEncoding.EncodeToString([]byte(to_encode))
-	uri := "/"
-	method := "POST"
-
 	authValue := "abc"
 
-	form := url.Values{}
-	form.Add("auth", authValue)
-
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest(method, uri, nil)
-	req.Form = form
+	req, err := http.NewRequest("POST", "/", nil)
+	req.Form = url.Values{}
+	req.Form.Add("auth", authValue)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
 
@@ -118,12 +110,8 @@ func TestValueExtractorHeaderSourceValidation(t *testing.T) {
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
 	spec.SessionManager.UpdateSession("default4321", session, 60)
 
-	uri := "/"
-	method := "GET"
-
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/", nil)
 	// req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
 
 	if err != nil {
@@ -160,12 +148,8 @@ func TestRegexExtractorHeaderSource(t *testing.T) {
 	fullHeaderValue := "token-12345"
 	matchedHeaderValue := []byte("12345")
 
-	uri := "/"
-	method := "GET"
-
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/", nil)
 	req.Header.Add("Authorization", fullHeaderValue)
 
 	if err != nil {

--- a/coprocess_test.go
+++ b/coprocess_test.go
@@ -5,11 +5,11 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -148,13 +148,9 @@ func TestCoProcessMiddleware(t *testing.T) {
 	session := createNonThrottledSession()
 	spec.SessionManager.UpdateSession("abc", session, 60)
 
-	uri := "/headers"
-
 	recorder := httptest.NewRecorder()
 
-	param := make(url.Values)
-
-	req, err := http.NewRequest("GET", uri, bytes.NewBufferString(param.Encode()))
+	req, err := http.NewRequest("GET", "/headers", strings.NewReader(""))
 	req.Header.Add("authorization", "abc")
 
 	if err != nil {
@@ -172,13 +168,9 @@ func TestCoProcessObjectPostProcess(t *testing.T) {
 	session := createNonThrottledSession()
 	spec.SessionManager.UpdateSession("abc", session, 60)
 
-	uri := "/headers"
-
 	recorder := httptest.NewRecorder()
 
-	param := make(url.Values)
-
-	req, err := http.NewRequest("GET", uri, bytes.NewBufferString(param.Encode()))
+	req, err := http.NewRequest("GET", "/headers", strings.NewReader(""))
 	req.Header.Add("authorization", "abc")
 	req.Header.Add("Deletethisheader", "value")
 
@@ -201,8 +193,8 @@ func TestCoProcessObjectPostProcess(t *testing.T) {
 
 	recorder = httptest.NewRecorder()
 
-	uri = "/get?a=a_value&b=123&remove=3"
-	getReq, err := http.NewRequest("GET", uri, bytes.NewBufferString(param.Encode()))
+	uri := "/get?a=a_value&b=123&remove=3"
+	getReq, err := http.NewRequest("GET", uri, strings.NewReader(""))
 	getReq.Header.Add("authorization", "abc")
 
 	if err != nil {
@@ -238,13 +230,9 @@ func TestCoProcessAuth(t *testing.T) {
 	session := createNonThrottledSession()
 	spec.SessionManager.UpdateSession("abc", session, 60)
 
-	uri := "/headers"
-
 	recorder := httptest.NewRecorder()
 
-	param := make(url.Values)
-
-	req, err := http.NewRequest("GET", uri, bytes.NewBufferString(param.Encode()))
+	req, err := http.NewRequest("GET", "/headers", strings.NewReader(""))
 	req.Header.Add("authorization", "abc")
 
 	if err != nil {

--- a/extended_method_versioning_test.go
+++ b/extended_method_versioning_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"net/http"
-	"net/url"
 	"testing"
 )
 
@@ -243,9 +242,7 @@ const nonExpiringExtendedDefNoWhitelist = `{
 
 func TestExtendedBlacklistLinks(t *testing.T) {
 	uri := "v1/disallowed/blacklist/literal"
-	method := "GET"
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", uri, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -264,9 +261,7 @@ func TestExtendedBlacklistLinks(t *testing.T) {
 	}
 
 	uri = "v1/disallowed/blacklist/abacab12345"
-	method = "GET"
-	param = make(url.Values)
-	req, err = http.NewRequest(method, uri+param.Encode(), nil)
+	req, err = http.NewRequest("GET", uri, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -284,9 +279,7 @@ func TestExtendedBlacklistLinks(t *testing.T) {
 
 	// Test with POST (it's a GET, should pass through)
 	uri = "v1/disallowed/blacklist/abacab12345"
-	method = "POST"
-	param = make(url.Values)
-	req, err = http.NewRequest(method, uri+param.Encode(), nil)
+	req, err = http.NewRequest("POST", uri, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -305,9 +298,7 @@ func TestExtendedBlacklistLinks(t *testing.T) {
 
 func TestExtendedWhiteLIstLinks(t *testing.T) {
 	uri := "v1/allowed/whitelist/literal"
-	method := "GET"
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", uri, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -326,9 +317,7 @@ func TestExtendedWhiteLIstLinks(t *testing.T) {
 	}
 
 	uri = "v1/allowed/whitelist/12345abans"
-	method = "GET"
-	param = make(url.Values)
-	req, err = http.NewRequest(method, uri+param.Encode(), nil)
+	req, err = http.NewRequest("GET", uri, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -347,9 +336,7 @@ func TestExtendedWhiteLIstLinks(t *testing.T) {
 
 func TestExtendedWhiteListBlock(t *testing.T) {
 	uri := "v1/allowed/bananaphone"
-	method := "GET"
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", uri, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -370,9 +357,7 @@ func TestExtendedWhiteListBlock(t *testing.T) {
 
 func TestExtendedIgnored(t *testing.T) {
 	uri := "/v1/ignored/noregex"
-	method := "GET"
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", uri, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -393,9 +378,7 @@ func TestExtendedIgnored(t *testing.T) {
 
 func TestExtendedWhiteListWithRedirectedReply(t *testing.T) {
 	uri := "v1/allowed/whitelist/reply/12345"
-	method := "GET"
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", uri, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -588,13 +588,11 @@ func TestParambasedAuth(t *testing.T) {
 	form.Add("baz", "swoogetty")
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest("POST", uri+param.Encode(), strings.NewReader(form.Encode()))
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-
+	req, err := http.NewRequest("POST", uri, strings.NewReader(form.Encode()))
 	if err != nil {
 		t.Fatal(err)
 	}
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	chain := getChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -629,14 +627,12 @@ func TestVersioningRequestOK(t *testing.T) {
 	spec.SessionManager.UpdateSession("96869686969", session, 60)
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest("GET", param.Encode(), nil)
-	req.Header.Add("authorization", "96869686969")
-	req.Header.Add("version", "v1")
-
+	req, err := http.NewRequest("GET", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	req.Header.Add("authorization", "96869686969")
+	req.Header.Add("version", "v1")
 
 	chain := getChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -655,14 +651,12 @@ func TestVersioningRequestFail(t *testing.T) {
 	spec.SessionManager.UpdateSession("zz1234", session, 60)
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest("GET", param.Encode(), nil)
-	req.Header.Add("authorization", "zz1234")
-	req.Header.Add("version", "v1")
-
+	req, err := http.NewRequest("GET", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	req.Header.Add("authorization", "zz1234")
+	req.Header.Add("version", "v1")
 
 	chain := getChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -680,8 +674,7 @@ func TestIgnoredPathRequestOK(t *testing.T) {
 	uri := "/v1/ignored/noregex"
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest("GET", uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", uri, nil)
 
 	// No auth information, it's an ignored path!
 	//	req.Header.Add("authorization", "1234")
@@ -708,14 +701,11 @@ func TestWhitelistRequestReply(t *testing.T) {
 	uri := "/v1/allowed/whitelist/reply/"
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest("GET", uri+param.Encode(), nil)
-
-	req.Header.Add("authorization", keyId)
-
+	req, err := http.NewRequest("GET", uri, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	req.Header.Add("authorization", keyId)
 
 	chain := getChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -735,8 +725,7 @@ func TestQuota(t *testing.T) {
 	defer spec.SessionManager.ResetQuota(keyId, session)
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest("GET", param.Encode(), nil)
+	req, err := http.NewRequest("GET", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -772,13 +761,11 @@ func TestWithAnalytics(t *testing.T) {
 	spec.SessionManager.UpdateSession("ert1234ert", session, 60)
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest("GET", param.Encode(), nil)
-	req.Header.Add("authorization", "ert1234ert")
-
+	req, err := http.NewRequest("GET", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	req.Header.Add("authorization", "ert1234ert")
 
 	chain := getChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -804,13 +791,11 @@ func TestWithAnalyticsErrorResponse(t *testing.T) {
 	spec.SessionManager.UpdateSession("fgh561234", session, 60)
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest("GET", param.Encode(), nil)
-	req.Header.Add("authorization", "dfgjg345316ertdg")
-
+	req, err := http.NewRequest("GET", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	req.Header.Add("authorization", "dfgjg345316ertdg")
 
 	chain := getChain(spec)
 	chain.ServeHTTP(recorder, req)

--- a/middleware_basic_auth_test.go
+++ b/middleware_basic_auth_test.go
@@ -89,12 +89,9 @@ func TestBasicAuthSession(t *testing.T) {
 
 	to_encode := strings.Join([]string{username, password}, ":")
 	encodedPass := base64.StdEncoding.EncodeToString([]byte(to_encode))
-	uri := "/"
-	method := "GET"
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/", nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
 
 	if err != nil {
@@ -119,12 +116,9 @@ func TestBasicAuthBadFormatting(t *testing.T) {
 
 	to_encode := strings.Join([]string{username, password}, "-")
 	encodedPass := base64.StdEncoding.EncodeToString([]byte(to_encode))
-	uri := "/"
-	method := "GET"
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/", nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
 
 	if err != nil {
@@ -151,12 +145,9 @@ func TestBasicAuthBadData(t *testing.T) {
 
 	to_encode := "ldhflsdflksjfdlksjflksdjlskdjflkjsfd:::jhdsgfkjahsgdkhasdgjhgasdjhads:::aksdakjsdh:adskasdkjhasdkjhad-asdads"
 	encodedPass := base64.StdEncoding.EncodeToString([]byte(to_encode))
-	uri := "/"
-	method := "GET"
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/", nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
 
 	if err != nil {
@@ -185,12 +176,9 @@ func TestBasicAuthBadOverFormatting(t *testing.T) {
 
 	to_encode := strings.Join([]string{username, password, "banana"}, ":")
 	encodedPass := base64.StdEncoding.EncodeToString([]byte(to_encode))
-	uri := "/"
-	method := "GET"
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/", nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
 
 	if err != nil {
@@ -218,12 +206,9 @@ func TestBasicAuthWrongUser(t *testing.T) {
 
 	to_encode := strings.Join([]string{"1234", password}, ":")
 	encodedPass := base64.StdEncoding.EncodeToString([]byte(to_encode))
-	uri := "/"
-	method := "GET"
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/", nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
 
 	if err != nil {
@@ -253,12 +238,8 @@ func TestBasicMissingHeader(t *testing.T) {
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
 	spec.SessionManager.UpdateSession("default4321", session, 60)
 
-	uri := "/"
-	method := "GET"
-
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/", nil)
 
 	if err != nil {
 		t.Fatal(err)
@@ -286,12 +267,9 @@ func TestBasicAuthWrongPassword(t *testing.T) {
 
 	to_encode := strings.Join([]string{username, "WRONGPASSTEST"}, ":")
 	encodedPass := base64.StdEncoding.EncodeToString([]byte(to_encode))
-	uri := "/"
-	method := "GET"
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/", nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
 
 	if err != nil {

--- a/middleware_hmac_test.go
+++ b/middleware_hmac_test.go
@@ -91,12 +91,8 @@ func TestHMACAuthSessionPass(t *testing.T) {
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
 	spec.SessionManager.UpdateSession("9876", session, 60)
 
-	uri := "/"
-	method := "GET"
-
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/", nil)
 
 	refDate := "Mon, 02 Jan 2006 15:04:05 MST"
 
@@ -136,12 +132,8 @@ func TestHMACAuthSessionAuxDateHeader(t *testing.T) {
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
 	spec.SessionManager.UpdateSession("9876", session, 60)
 
-	uri := "/"
-	method := "GET"
-
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/", nil)
 
 	refDate := "Mon, 02 Jan 2006 15:04:05 MST"
 
@@ -181,12 +173,8 @@ func TestHMACAuthSessionFailureDateExpired(t *testing.T) {
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
 	spec.SessionManager.UpdateSession("9876", session, 60)
 
-	uri := "/"
-	method := "GET"
-
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/", nil)
 
 	refDate := "Mon, 02 Jan 2006 15:04:05 MST"
 
@@ -226,12 +214,8 @@ func TestHMACAuthSessionKeyMissing(t *testing.T) {
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
 	spec.SessionManager.UpdateSession("9876", session, 60)
 
-	uri := "/"
-	method := "GET"
-
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/", nil)
 
 	refDate := "Mon, 02 Jan 2006 15:04:05 MST"
 
@@ -271,12 +255,8 @@ func TestHMACAuthSessionMalformedHeader(t *testing.T) {
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
 	spec.SessionManager.UpdateSession("9876", session, 60)
 
-	uri := "/"
-	method := "GET"
-
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/", nil)
 
 	refDate := "Mon, 02 Jan 2006 15:04:05 MST"
 
@@ -316,12 +296,8 @@ func TestHMACAuthSessionPassWithHeaderField(t *testing.T) {
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
 	spec.SessionManager.UpdateSession("9876", session, 60)
 
-	uri := "/"
-	method := "GET"
-
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/", nil)
 
 	refDate := "Mon, 02 Jan 2006 15:04:05 MST"
 
@@ -382,12 +358,8 @@ func TestHMACAuthSessionPassWithHeaderFieldLowerCase(t *testing.T) {
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
 	spec.SessionManager.UpdateSession("9876", session, 60)
 
-	uri := "/"
-	method := "GET"
-
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/", nil)
 
 	refDate := "Mon, 02 Jan 2006 15:04:05 MST"
 

--- a/middleware_ip_whitelist_test.go
+++ b/middleware_ip_whitelist_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 )
 
@@ -155,12 +154,9 @@ func TestIpMiddlewareIPFail(t *testing.T) {
 	spec := createIPSampleAPI(t, ipMiddlewareTestDefinitionEnabledFail)
 	session := createNonThrottledSession()
 	spec.SessionManager.UpdateSession("1234wer", session, 60)
-	uri := "/"
-	method := "GET"
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/", nil)
 	req.RemoteAddr = "127.0.0.1:80"
 	req.Header.Add("authorization", "1234wer")
 
@@ -180,12 +176,9 @@ func TestIpMiddlewareIPPass(t *testing.T) {
 	spec := createIPSampleAPI(t, ipMiddlewareTestDefinitionEnabledPass)
 	session := createNonThrottledSession()
 	spec.SessionManager.UpdateSession("gfgg1234", session, 60)
-	uri := "/"
-	method := "GET"
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/", nil)
 	req.RemoteAddr = "127.0.0.1:80"
 	req.Header.Add("authorization", "gfgg1234")
 
@@ -205,12 +198,9 @@ func TestIpMiddlewareIPPassCIDR(t *testing.T) {
 	spec := createIPSampleAPI(t, ipMiddlewareTestDefinitionEnabledPass)
 	session := createNonThrottledSession()
 	spec.SessionManager.UpdateSession("gfgg1234", session, 60)
-	uri := "/"
-	method := "GET"
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/", nil)
 	req.RemoteAddr = "127.0.0.2:80"
 	req.Header.Add("authorization", "gfgg1234")
 
@@ -230,12 +220,9 @@ func TestIPMiddlewareIPFailXForwardedFor(t *testing.T) {
 	spec := createIPSampleAPI(t, ipMiddlewareTestDefinitionEnabledPass)
 	session := createNonThrottledSession()
 	spec.SessionManager.UpdateSession("gfgg1234", session, 60)
-	uri := "/"
-	method := "GET"
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/", nil)
 	req.RemoteAddr = "10.0.0.1:80"
 	req.Header.Add("authorization", "gfgg1234")
 
@@ -255,12 +242,9 @@ func TestIPMiddlewareIPPassXForwardedFor(t *testing.T) {
 	spec := createIPSampleAPI(t, ipMiddlewareTestDefinitionEnabledPass)
 	session := createNonThrottledSession()
 	spec.SessionManager.UpdateSession("gfgg1234", session, 60)
-	uri := "/"
-	method := "GET"
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/", nil)
 	req.RemoteAddr = "10.0.0.1:80"
 	req.Header.Add("X-Forwarded-For", "127.0.0.1")
 	req.Header.Add("authorization", "gfgg1234")
@@ -281,12 +265,9 @@ func TestIpMiddlewareIPMissing(t *testing.T) {
 	spec := createIPSampleAPI(t, ipMiddlewareTestDefinitionMissing)
 	session := createNonThrottledSession()
 	spec.SessionManager.UpdateSession("1234rtyrty", session, 60)
-	uri := "/"
-	method := "GET"
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/", nil)
 	req.Header.Add("authorization", "1234rtyrty")
 
 	if err != nil {
@@ -305,12 +286,9 @@ func TestIpMiddlewareIPDisabled(t *testing.T) {
 	spec := createIPSampleAPI(t, ipMiddlewareTestDefinitionDisabled)
 	session := createNonThrottledSession()
 	spec.SessionManager.UpdateSession("1234iuouio", session, 60)
-	uri := "/"
-	method := "GET"
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/", nil)
 	req.Header.Add("authorization", "1234iuouio")
 
 	if err != nil {

--- a/middleware_jwt_test.go
+++ b/middleware_jwt_test.go
@@ -268,8 +268,7 @@ func TestJWTSessionHMAC(t *testing.T) {
 	}
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest("GET", "/jwt_test/?"+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/jwt_test/", nil)
 	req.Header.Add("authorization", tokenString)
 
 	if err != nil {
@@ -309,8 +308,7 @@ func TestJWTSessionRSA(t *testing.T) {
 	}
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest("GET", "/jwt_test/?"+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/jwt_test/", nil)
 	req.Header.Add("authorization", tokenString)
 
 	if err != nil {
@@ -341,8 +339,7 @@ func TestJWTSessionFailRSA_EmptyJWT(t *testing.T) {
 	token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour * 72).Unix()
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest("GET", "/jwt_test/?"+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/jwt_test/", nil)
 
 	// Make it empty
 	req.Header.Add("authorization", "")
@@ -375,8 +372,7 @@ func TestJWTSessionFailRSA_NoAuthHeader(t *testing.T) {
 	token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour * 72).Unix()
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest("GET", "/jwt_test/?"+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/jwt_test/", nil)
 
 	if err != nil {
 		t.Fatal("Problem generating the test token: ", err)
@@ -415,8 +411,7 @@ func TestJWTSessionFailRSA_MalformedJWT(t *testing.T) {
 	}
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest("GET", "/jwt_test/?"+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/jwt_test/", nil)
 
 	// Make it empty
 	req.Header.Add("authorization", tokenString+"ajhdkjhsdfkjashdkajshdkajhsdkajhsd")
@@ -459,8 +454,7 @@ func TestJWTSessionFailRSA_MalformedJWT_NOTRACK(t *testing.T) {
 	}
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest("GET", "/jwt_test/?"+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/jwt_test/", nil)
 
 	// Make it empty
 	req.Header.Add("authorization", tokenString+"ajhdkjhsdfkjashdkajshdkajhsdkajhsd")
@@ -493,8 +487,7 @@ func TestJWTSessionFailRSA_WrongJWT(t *testing.T) {
 	token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour * 72).Unix()
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest("GET", "/jwt_test/?"+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/jwt_test/", nil)
 
 	// Make it empty
 	req.Header.Add("authorization", "123")
@@ -537,8 +530,7 @@ func TestJWTSessionRSABearer(t *testing.T) {
 	}
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest("GET", "/jwt_test/?"+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/jwt_test/", nil)
 	req.Header.Add("authorization", "Bearer "+tokenString)
 
 	if err != nil {
@@ -578,8 +570,7 @@ func TestJWTSessionRSABearerInvalid(t *testing.T) {
 	}
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest("GET", "/jwt_test/?"+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/jwt_test/", nil)
 	// add a colon here
 	req.Header.Add("authorization", "Bearer: "+tokenString)
 
@@ -638,8 +629,7 @@ func TestJWTSessionRSAWithRawSourceOnWithClientID(t *testing.T) {
 	}
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest("GET", "/jwt_test/?"+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/jwt_test/", nil)
 	// add a colon here
 	req.Header.Add("authorization", "Bearer "+tokenString)
 
@@ -691,8 +681,7 @@ func TestJWTSessionRSAWithRawSource(t *testing.T) {
 	}
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest("GET", "/jwt_test/?"+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/jwt_test/", nil)
 	// add a colon here
 	req.Header.Add("authorization", "Bearer "+tokenString)
 
@@ -744,8 +733,7 @@ func TestJWTSessionRSAWithRawSourceInvalidPolicyID(t *testing.T) {
 	}
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest("GET", "/jwt_test/?"+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/jwt_test/", nil)
 	// add a colon here
 	req.Header.Add("authorization", "Bearer "+tokenString)
 
@@ -797,8 +785,7 @@ func TestJWTSessionRSAWithJWK(t *testing.T) {
 	}
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest("GET", "/jwt_test/?"+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/jwt_test/", nil)
 	// add a colon here
 	req.Header.Add("authorization", "Bearer "+tokenString)
 

--- a/multiauth_test.go
+++ b/multiauth_test.go
@@ -113,12 +113,9 @@ func TestMultiSession_BA_Standard_OK(t *testing.T) {
 
 	to_encode := strings.Join([]string{username, password}, ":")
 	encodedPass := base64.StdEncoding.EncodeToString([]byte(to_encode))
-	uri := "/"
-	method := "GET"
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/", nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
 	req.Header.Add("x-standard-auth", fmt.Sprintf("Bearer %s", customToken))
 
@@ -152,12 +149,9 @@ func TestMultiSession_BA_Standard_Identity(t *testing.T) {
 
 	to_encode := strings.Join([]string{username, password}, ":")
 	encodedPass := base64.StdEncoding.EncodeToString([]byte(to_encode))
-	uri := "/"
-	method := "GET"
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/", nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
 	req.Header.Add("x-standard-auth", fmt.Sprintf("Bearer %s", customToken))
 
@@ -196,12 +190,9 @@ func TestMultiSession_BA_Standard_FAILBA(t *testing.T) {
 
 	to_encode := strings.Join([]string{username, password}, ":")
 	encodedPass := base64.StdEncoding.EncodeToString([]byte(to_encode))
-	uri := "/"
-	method := "GET"
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/", nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
 	req.Header.Add("x-standard-auth", fmt.Sprintf("Bearer %s", customToken))
 
@@ -235,12 +226,9 @@ func TestMultiSession_BA_Standard_FAILAuth(t *testing.T) {
 
 	to_encode := strings.Join([]string{username, password}, ":")
 	encodedPass := base64.StdEncoding.EncodeToString([]byte(to_encode))
-	uri := "/"
-	method := "GET"
 
 	recorder := httptest.NewRecorder()
-	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req, err := http.NewRequest("GET", "/", nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
 	req.Header.Add("x-standard-auth", fmt.Sprintf("Bearer %s", "WRONGTOKEN"))
 

--- a/oauth_manager_test.go
+++ b/oauth_manager_test.go
@@ -112,13 +112,12 @@ func TestAuthCodeRedirect(t *testing.T) {
 	getOAuthChain(spec, testMuxer)
 
 	uri := "/APIID/oauth/authorize/"
-	method := "POST"
 
 	param := make(url.Values)
 	param.Set("response_type", "code")
 	param.Set("redirect_uri", authRedirectUri)
 	param.Set("client_id", authClientID)
-	req, err := http.NewRequest(method, uri, bytes.NewBufferString(param.Encode()))
+	req, err := http.NewRequest("POST", uri, bytes.NewBufferString(param.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	if err != nil {
@@ -144,13 +143,12 @@ func TestAuthCodeRedirectMultipleURL(t *testing.T) {
 	getOAuthChain(spec, testMuxer)
 
 	uri := "/APIID/oauth/authorize/"
-	method := "POST"
 
 	param := make(url.Values)
 	param.Set("response_type", "code")
 	param.Set("redirect_uri", authRedirectUri2)
 	param.Set("client_id", authClientID)
-	req, err := http.NewRequest(method, uri, bytes.NewBufferString(param.Encode()))
+	req, err := http.NewRequest("POST", uri, bytes.NewBufferString(param.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	if err != nil {
@@ -176,13 +174,12 @@ func TestAuthCodeRedirectInvalidMultipleURL(t *testing.T) {
 	getOAuthChain(spec, testMuxer)
 
 	uri := "/APIID/oauth/authorize/"
-	method := "POST"
 
 	param := make(url.Values)
 	param.Set("response_type", "code")
 	param.Set("redirect_uri", authRedirectUri2)
 	param.Set("client_id", authClientID)
-	req, err := http.NewRequest(method, uri, bytes.NewBufferString(param.Encode()))
+	req, err := http.NewRequest("POST", uri, bytes.NewBufferString(param.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	if err != nil {
@@ -205,14 +202,13 @@ func TestAPIClientAuthorizeAuthCode(t *testing.T) {
 	getOAuthChain(spec, testMuxer)
 
 	uri := "/APIID/tyk/oauth/authorize-client/"
-	method := "POST"
 
 	param := make(url.Values)
 	param.Set("response_type", "code")
 	param.Set("redirect_uri", authRedirectUri)
 	param.Set("client_id", authClientID)
 	param.Set("key_rules", keyRules)
-	req, err := http.NewRequest(method, uri, bytes.NewBufferString(param.Encode()))
+	req, err := http.NewRequest("POST", uri, bytes.NewBufferString(param.Encode()))
 	req.Header.Set("x-tyk-authorization", "352d20ee67be67f6340b4c0605b044b7")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
@@ -236,14 +232,13 @@ func TestAPIClientAuthorizeToken(t *testing.T) {
 	getOAuthChain(spec, testMuxer)
 
 	uri := "/APIID/tyk/oauth/authorize-client/"
-	method := "POST"
 
 	param := make(url.Values)
 	param.Set("response_type", "token")
 	param.Set("redirect_uri", authRedirectUri)
 	param.Set("client_id", authClientID)
 	param.Set("key_rules", keyRules)
-	req, err := http.NewRequest(method, uri, bytes.NewBufferString(param.Encode()))
+	req, err := http.NewRequest("POST", uri, bytes.NewBufferString(param.Encode()))
 	req.Header.Set("x-tyk-authorization", "352d20ee67be67f6340b4c0605b044b7")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
@@ -267,14 +262,13 @@ func TestAPIClientAuthorizeTokenWithPolicy(t *testing.T) {
 	getOAuthChain(spec, testMuxer)
 
 	uri := "/APIID/tyk/oauth/authorize-client/"
-	method := "POST"
 
 	param := make(url.Values)
 	param.Set("response_type", "token")
 	param.Set("redirect_uri", authRedirectUri)
 	param.Set("client_id", authClientID)
 
-	req, err := http.NewRequest(method, uri, bytes.NewBufferString(param.Encode()))
+	req, err := http.NewRequest("POST", uri, bytes.NewBufferString(param.Encode()))
 	req.Header.Set("x-tyk-authorization", "352d20ee67be67f6340b4c0605b044b7")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
@@ -317,14 +311,13 @@ func getAuthCode(t *testing.T) map[string]string {
 	getOAuthChain(spec, testMuxer)
 
 	uri := "/APIID/tyk/oauth/authorize-client/"
-	method := "POST"
 
 	param := make(url.Values)
 	param.Set("response_type", "code")
 	param.Set("redirect_uri", authRedirectUri)
 	param.Set("client_id", authClientID)
 	param.Set("key_rules", keyRules)
-	req, _ := http.NewRequest(method, uri, bytes.NewBufferString(param.Encode()))
+	req, _ := http.NewRequest("POST", uri, bytes.NewBufferString(param.Encode()))
 	req.Header.Set("x-tyk-authorization", "352d20ee67be67f6340b4c0605b044b7")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
@@ -351,14 +344,13 @@ func getToken(t *testing.T) tokenData {
 	getOAuthChain(spec, testMuxer)
 
 	uri := "/APIID/oauth/token/"
-	method := "POST"
 
 	param := make(url.Values)
 	param.Set("grant_type", "authorization_code")
 	param.Set("redirect_uri", authRedirectUri)
 	param.Set("client_id", authClientID)
 	param.Set("code", authData["code"])
-	req, _ := http.NewRequest(method, uri, bytes.NewBufferString(param.Encode()))
+	req, _ := http.NewRequest("POST", uri, bytes.NewBufferString(param.Encode()))
 	req.Header.Set("Authorization", "Basic MTIzNDphYWJiY2NkZA==")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
@@ -377,14 +369,13 @@ func TestOAuthClientCredsGrant(t *testing.T) {
 	getOAuthChain(spec, testMuxer)
 
 	uri := "/APIID/oauth/token/"
-	method := "POST"
 
 	param := make(url.Values)
 	param.Set("grant_type", "client_credentials")
 	param.Set("client_id", authClientID)
 	param.Set("client_secret", authClientSecret)
 
-	req, _ := http.NewRequest(method, uri, bytes.NewBufferString(param.Encode()))
+	req, _ := http.NewRequest("POST", uri, bytes.NewBufferString(param.Encode()))
 	req.Header.Set("Authorization", "Basic MTIzNDphYWJiY2NkZA==")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
@@ -420,14 +411,13 @@ func TestClientAccessRequest(t *testing.T) {
 	getOAuthChain(spec, testMuxer)
 
 	uri := "/APIID/oauth/token/"
-	method := "POST"
 
 	param := make(url.Values)
 	param.Set("grant_type", "authorization_code")
 	param.Set("redirect_uri", authRedirectUri)
 	param.Set("client_id", authClientID)
 	param.Set("code", authData["code"])
-	req, err := http.NewRequest(method, uri, bytes.NewBufferString(param.Encode()))
+	req, err := http.NewRequest("POST", uri, bytes.NewBufferString(param.Encode()))
 	req.Header.Set("Authorization", "Basic MTIzNDphYWJiY2NkZA==")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
@@ -458,13 +448,12 @@ func TestOAuthAPIRefreshInvalidate(t *testing.T) {
 	// Step 2 - invalidate the refresh token
 
 	uri1 := "/tyk/oauth/refresh/" + tokenData.RefreshToken + "?"
-	method1 := "DELETE"
 
 	recorder := httptest.NewRecorder()
 	param1 := make(url.Values)
 	//MakeSampleAPI()
 	param1.Set("api_id", "999999")
-	req1, err1 := http.NewRequest(method1, uri1+param1.Encode(), nil)
+	req1, err1 := http.NewRequest("DELETE", uri1+param1.Encode(), nil)
 
 	if err1 != nil {
 		t.Fatal(err1)
@@ -493,14 +482,13 @@ func TestOAuthAPIRefreshInvalidate(t *testing.T) {
 	// Step 3 - try to refresh
 
 	uri := "/APIID/oauth/token/"
-	method := "POST"
 
 	param := make(url.Values)
 	param.Set("grant_type", "refresh_token")
 	param.Set("redirect_uri", authRedirectUri)
 	param.Set("client_id", authClientID)
 	param.Set("refresh_token", tokenData.RefreshToken)
-	req, err := http.NewRequest(method, uri, bytes.NewBufferString(param.Encode()))
+	req, err := http.NewRequest("POST", uri, bytes.NewBufferString(param.Encode()))
 	req.Header.Set("Authorization", "Basic MTIzNDphYWJiY2NkZA==")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
@@ -528,14 +516,13 @@ func TestClientRefreshRequest(t *testing.T) {
 	getOAuthChain(spec, testMuxer)
 
 	uri := "/APIID/oauth/token/"
-	method := "POST"
 
 	param := make(url.Values)
 	param.Set("grant_type", "refresh_token")
 	param.Set("redirect_uri", authRedirectUri)
 	param.Set("client_id", authClientID)
 	param.Set("refresh_token", tokenData.RefreshToken)
-	req, err := http.NewRequest(method, uri, bytes.NewBufferString(param.Encode()))
+	req, err := http.NewRequest("POST", uri, bytes.NewBufferString(param.Encode()))
 	req.Header.Set("Authorization", "Basic MTIzNDphYWJiY2NkZA==")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
@@ -563,7 +550,6 @@ func TestClientRefreshRequestDouble(t *testing.T) {
 	getOAuthChain(spec, testMuxer)
 
 	uri := "/APIID/oauth/token/"
-	method := "POST"
 
 	// req 1
 	param := make(url.Values)
@@ -571,7 +557,7 @@ func TestClientRefreshRequestDouble(t *testing.T) {
 	param.Set("redirect_uri", authRedirectUri)
 	param.Set("client_id", authClientID)
 	param.Set("refresh_token", tokenData.RefreshToken)
-	req, err := http.NewRequest(method, uri, bytes.NewBufferString(param.Encode()))
+	req, err := http.NewRequest("POST", uri, bytes.NewBufferString(param.Encode()))
 	req.Header.Set("Authorization", "Basic MTIzNDphYWJiY2NkZA==")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
@@ -598,7 +584,7 @@ func TestClientRefreshRequestDouble(t *testing.T) {
 	param2.Set("redirect_uri", authRedirectUri)
 	param2.Set("client_id", authClientID)
 	param2.Set("refresh_token", token)
-	req2, err2 := http.NewRequest(method, uri, bytes.NewBufferString(param2.Encode()))
+	req2, err2 := http.NewRequest("POST", uri, bytes.NewBufferString(param2.Encode()))
 	req2.Header.Set("Authorization", "Basic MTIzNDphYWJiY2NkZA==")
 	req2.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 


### PR DESCRIPTION
Mostly remove unnecessary variables and non-use of url.Values.

The use of url.Values as url queries is often broken, but that will be
done in a separate commit.