### PR TITLE
api: use helper funcs for ctx's ContextData

### DIFF
--- a/api.go
+++ b/api.go
@@ -1822,3 +1822,17 @@ func handleInvalidateAPICache(apiID string) error {
 	}
 	return nil
 }
+
+func ctxGetData(r *http.Request) map[string]interface{} {
+	if v := context.Get(r, ContextData); v != nil {
+		return v.(map[string]interface{})
+	}
+	return nil
+}
+
+func ctxSetData(r *http.Request, m map[string]interface{}) {
+	if m == nil {
+		panic("setting a nil context ContextData")
+	}
+	context.Set(r, ContextData, m)
+}

--- a/api_test.go
+++ b/api_test.go
@@ -736,3 +736,20 @@ func BenchmarkApiInsertReload(b *testing.B) {
 		loadApps(specs, newMuxes)
 	}
 }
+
+func TestContextData(t *testing.T) {
+	r := new(http.Request)
+	if ctxGetData(r) != nil {
+		t.Fatal("expected ctxGetData to return nil")
+	}
+	ctxSetData(r, map[string]interface{}{"foo": "bar"})
+	if ctxGetData(r) == nil {
+		t.Fatal("expected ctxGetData to return non-nil")
+	}
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected ctxSetData of zero val to panic")
+		}
+	}()
+	ctxSetData(r, nil)
+}

--- a/middleware_auth_key.go
+++ b/middleware_auth_key.go
@@ -35,11 +35,10 @@ func (k *AuthKey) setContextVars(r *http.Request, token string) {
 	if !k.Spec.EnableContextVars {
 		return
 	}
-	if cnt := context.Get(r, ContextData); cnt != nil {
+	if cnt := ctxGetData(r); cnt != nil {
 		// Key data
-		contextDataObject := cnt.(map[string]interface{})
-		contextDataObject["token"] = token
-		context.Set(r, ContextData, contextDataObject)
+		cnt["token"] = token
+		ctxSetData(r, cnt)
 	}
 }
 

--- a/middleware_context_vars.go
+++ b/middleware_context_vars.go
@@ -3,8 +3,6 @@ package main
 import (
 	"net/http"
 	"strings"
-
-	"github.com/gorilla/context"
 )
 
 type MiddlewareContextVars struct {
@@ -62,7 +60,7 @@ func (m *MiddlewareContextVars) ProcessRequest(w http.ResponseWriter, r *http.Re
 	// IP:Port
 	contextDataObject["remote_addr"] = copiedRequest.RemoteAddr
 
-	context.Set(r, ContextData, contextDataObject)
+	ctxSetData(r, contextDataObject)
 
 	return nil, 200
 }

--- a/middleware_hmac.go
+++ b/middleware_hmac.go
@@ -166,11 +166,10 @@ func (hm *HMACMiddleware) setContextVars(r *http.Request, token string) {
 		return
 	}
 	// Flatten claims and add to context
-	if cnt := context.Get(r, ContextData); cnt != nil {
+	if cnt := ctxGetData(r); cnt != nil {
 		// Key data
-		contextDataObject := cnt.(map[string]interface{})
-		contextDataObject["token"] = token
-		context.Set(r, ContextData, contextDataObject)
+		cnt["token"] = token
+		ctxSetData(r, cnt)
 	}
 }
 

--- a/middleware_jwt.go
+++ b/middleware_jwt.go
@@ -421,20 +421,19 @@ func (k *JWTMiddleware) setContextVars(r *http.Request, token *jwt.Token) {
 	if !k.Spec.EnableContextVars {
 		return
 	}
-	if cnt := context.Get(r, ContextData); cnt != nil {
-		contextDataObject := cnt.(map[string]interface{})
+	if cnt := ctxGetData(r); cnt != nil {
 		claimPrefix := "jwt_claims_"
 
 		for claimName, claimValue := range token.Claims.(jwt.MapClaims) {
 			claim := claimPrefix + claimName
-			contextDataObject[claim] = claimValue
+			cnt[claim] = claimValue
 		}
 
 		// Key data
 		authHeaderValue := context.Get(r, AuthHeaderValue)
-		contextDataObject["token"] = authHeaderValue
+		cnt["token"] = authHeaderValue
 
-		context.Set(r, ContextData, contextDataObject)
+		ctxSetData(r, cnt)
 	}
 }
 

--- a/middleware_modify_headers.go
+++ b/middleware_modify_headers.go
@@ -57,11 +57,7 @@ func (t *TransformHeaders) iterateAddHeaders(kv map[string]string, r *http.Reque
 		sessionState = ses.(SessionState)
 	}
 
-	var contextData map[string]interface{}
-	cnt := context.Get(r, ContextData)
-	if cnt != nil {
-		contextData = cnt.(map[string]interface{})
-	}
+	contextData := ctxGetData(r)
 
 	// Iterate and manage key array injection
 	for nKey, nVal := range kv {
@@ -85,7 +81,7 @@ func (t *TransformHeaders) iterateAddHeaders(kv map[string]string, r *http.Reque
 
 		} else if strings.Contains(nVal, contextLabel) {
 			// Using context key
-			if cnt != nil {
+			if contextData != nil {
 				metaKey := strings.Replace(nVal, contextLabel, "", 1)
 				if contextData != nil {
 					tempVal, ok := contextData[metaKey]

--- a/middleware_openid.go
+++ b/middleware_openid.go
@@ -233,21 +233,20 @@ func (k *OpenIDMW) setContextVars(r *http.Request, token *jwt.Token) {
 		return
 	}
 	// Flatten claims and add to context
-	cnt := context.Get(r, ContextData)
+	cnt := ctxGetData(r)
 	if cnt == nil {
 		return
 	}
-	contextDataObject := cnt.(map[string]interface{})
 	claimPrefix := "jwt_claims_"
 
 	for claimName, claimValue := range token.Claims.(jwt.MapClaims) {
 		claim := claimPrefix + claimName
-		contextDataObject[claim] = claimValue
+		cnt[claim] = claimValue
 	}
 
 	// Key data
 	authHeaderValue := context.Get(r, AuthHeaderValue)
-	contextDataObject["token"] = authHeaderValue
+	cnt["token"] = authHeaderValue
 
-	context.Set(r, ContextData, contextDataObject)
+	ctxSetData(r, cnt)
 }

--- a/middleware_transform.go
+++ b/middleware_transform.go
@@ -95,10 +95,9 @@ func (t *TransformMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 	}
 
 	if t.Spec.EnableContextVars {
-		contextData := context.Get(r, ContextData)
 		switch x := bodyData.(type) {
 		case map[string]interface{}:
-			x["_tyk_context"] = contextData
+			x["_tyk_context"] = ctxGetData(r)
 		}
 	}
 

--- a/middleware_url_rewrite.go
+++ b/middleware_url_rewrite.go
@@ -57,10 +57,7 @@ func (u URLRewriter) Rewrite(meta *apidef.URLRewriteMeta, path string, useContex
 
 	if useContext {
 		log.Debug("Using context")
-		var contextData map[string]interface{}
-		if cnt := context.Get(r, ContextData); cnt != nil {
-			contextData = cnt.(map[string]interface{})
-		}
+		contextData := ctxGetData(r)
 
 		dollarMatch := regexp.MustCompile(`\$tyk_context.(\w+)`)
 		replace_slice := dollarMatch.FindAllStringSubmatch(meta.RewriteTo, -1)


### PR DESCRIPTION
To be able to enforce type and non-zero value, and to be able to unit
test it.

For #683.