### PR TITLE
mw: remove anonymous field stutters

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -902,7 +902,7 @@ func (a *APISpec) CheckSpecMatchesStatus(url string, method string, rxPaths []UR
 		case Ignored, BlackList, WhiteList, Cached:
 			return true, nil
 		case Transformed:
-			if method == v.TransformAction.TemplateMeta.Method {
+			if method == v.TransformAction.Method {
 				return true, &v.TransformAction
 			}
 		case HeaderInjected:
@@ -914,7 +914,7 @@ func (a *APISpec) CheckSpecMatchesStatus(url string, method string, rxPaths []UR
 				return true, &v.InjectHeadersResponse
 			}
 		case TransformedResponse:
-			if method == v.TransformResponseAction.TemplateMeta.Method {
+			if method == v.TransformResponseAction.Method {
 				return true, &v.TransformResponseAction
 			}
 		case HardTimeout:

--- a/middleware_method_transform.go
+++ b/middleware_method_transform.go
@@ -27,7 +27,7 @@ func (t *TransformMethod) GetConfig() (interface{}, error) {
 
 func (t *TransformMethod) IsEnabledForSpec() bool {
 	var used bool
-	for _, version := range t.TykMiddleware.Spec.VersionData.Versions {
+	for _, version := range t.Spec.VersionData.Versions {
 		if len(version.ExtendedPaths.MethodTransforms) > 0 {
 			used = true
 			break
@@ -39,8 +39,8 @@ func (t *TransformMethod) IsEnabledForSpec() bool {
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (t *TransformMethod) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
-	_, versionPaths, _, _ := t.TykMiddleware.Spec.GetVersionData(r)
-	found, meta := t.TykMiddleware.Spec.CheckSpecMatchesStatus(r.URL.Path, r.Method, versionPaths, MethodTransformed)
+	_, versionPaths, _, _ := t.Spec.GetVersionData(r)
+	found, meta := t.Spec.CheckSpecMatchesStatus(r.URL.Path, r.Method, versionPaths, MethodTransformed)
 	if found {
 		mmeta := meta.(*apidef.MethodTransformMeta)
 

--- a/middleware_modify_headers.go
+++ b/middleware_modify_headers.go
@@ -35,7 +35,7 @@ func (t *TransformHeaders) GetConfig() (interface{}, error) {
 
 func (t *TransformHeaders) IsEnabledForSpec() bool {
 	var used bool
-	for _, version := range t.TykMiddleware.Spec.VersionData.Versions {
+	for _, version := range t.Spec.VersionData.Versions {
 		if len(version.ExtendedPaths.TransformHeader) > 0 ||
 			len(version.GlobalHeaders) > 0 ||
 			len(version.GlobalHeadersRemove) > 0 {
@@ -129,7 +129,7 @@ func (t *TransformHeaders) iterateAddHeaders(kv map[string]string, r *http.Reque
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (t *TransformHeaders) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
-	vInfo, versionPaths, _, _ := t.TykMiddleware.Spec.GetVersionData(r)
+	vInfo, versionPaths, _, _ := t.Spec.GetVersionData(r)
 
 	// Manage global headers first - remove
 	for _, gdKey := range vInfo.GlobalHeadersRemove {
@@ -142,7 +142,7 @@ func (t *TransformHeaders) ProcessRequest(w http.ResponseWriter, r *http.Request
 		t.iterateAddHeaders(vInfo.GlobalHeaders, r)
 	}
 
-	found, meta := t.TykMiddleware.Spec.CheckSpecMatchesStatus(r.URL.Path, r.Method, versionPaths, HeaderInjected)
+	found, meta := t.Spec.CheckSpecMatchesStatus(r.URL.Path, r.Method, versionPaths, HeaderInjected)
 	if found {
 		hmeta := meta.(*apidef.HeaderInjectionMeta)
 		for _, dKey := range hmeta.DeleteHeaders {

--- a/middleware_request_size_limit.go
+++ b/middleware_request_size_limit.go
@@ -29,7 +29,7 @@ func (t *RequestSizeLimitMiddleware) GetConfig() (interface{}, error) {
 
 func (t *RequestSizeLimitMiddleware) IsEnabledForSpec() bool {
 	var used bool
-	for _, version := range t.TykMiddleware.Spec.VersionData.Versions {
+	for _, version := range t.Spec.VersionData.Versions {
 		if len(version.ExtendedPaths.SizeLimit) > 0 {
 			used = true
 			break
@@ -83,7 +83,7 @@ func (t *RequestSizeLimitMiddleware) checkRequestLimit(r *http.Request, sizeLimi
 func (t *RequestSizeLimitMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
 	log.Debug("Request size limiter active")
 
-	vInfo, versionPaths, _, _ := t.TykMiddleware.Spec.GetVersionData(r)
+	vInfo, versionPaths, _, _ := t.Spec.GetVersionData(r)
 
 	log.Debug("Global limit is: ", vInfo.GlobalSizeLimit)
 	// Manage global headers first
@@ -102,7 +102,7 @@ func (t *RequestSizeLimitMiddleware) ProcessRequest(w http.ResponseWriter, r *ht
 	}
 
 	// If there's a potential match, try to match
-	found, meta := t.TykMiddleware.Spec.CheckSpecMatchesStatus(r.URL.Path, r.Method, versionPaths, RequestSizeLimit)
+	found, meta := t.Spec.CheckSpecMatchesStatus(r.URL.Path, r.Method, versionPaths, RequestSizeLimit)
 	if found {
 		log.Debug("Request size limit matched for this URL, checking...")
 		rmeta := meta.(*apidef.RequestSizeMeta)

--- a/middleware_transform.go
+++ b/middleware_transform.go
@@ -38,7 +38,7 @@ func (t *TransformMiddleware) GetConfig() (interface{}, error) {
 
 func (t *TransformMiddleware) IsEnabledForSpec() bool {
 	var used bool
-	for _, version := range t.TykMiddleware.Spec.VersionData.Versions {
+	for _, version := range t.Spec.VersionData.Versions {
 		if len(version.ExtendedPaths.Transform) > 0 {
 			used = true
 			break
@@ -50,8 +50,8 @@ func (t *TransformMiddleware) IsEnabledForSpec() bool {
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (t *TransformMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
-	_, versionPaths, _, _ := t.TykMiddleware.Spec.GetVersionData(r)
-	found, meta := t.TykMiddleware.Spec.CheckSpecMatchesStatus(r.URL.Path, r.Method, versionPaths, Transformed)
+	_, versionPaths, _, _ := t.Spec.GetVersionData(r)
+	found, meta := t.Spec.CheckSpecMatchesStatus(r.URL.Path, r.Method, versionPaths, Transformed)
 	if !found {
 		return nil, 200
 	}
@@ -66,7 +66,7 @@ func (t *TransformMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 
 	// Put into an interface:
 	var bodyData interface{}
-	switch tmeta.TemplateMeta.TemplateData.Input {
+	switch tmeta.TemplateData.Input {
 	case apidef.RequestXML:
 		mxj.XmlCharsetReader = WrappedCharsetReader
 		var err error
@@ -86,7 +86,7 @@ func (t *TransformMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 		bodyData = make(map[string]interface{})
 	}
 
-	if tmeta.TemplateMeta.TemplateData.EnableSession {
+	if tmeta.TemplateData.EnableSession {
 		ses := context.Get(r, SessionData).(SessionState)
 		switch x := bodyData.(type) {
 		case map[string]interface{}:

--- a/res_handler_transform.go
+++ b/res_handler_transform.go
@@ -57,7 +57,7 @@ func (rt ResponseTransformMiddleware) HandleResponse(rw http.ResponseWriter, res
 
 	// Put into an interface:
 	var bodyData interface{}
-	switch tmeta.TemplateMeta.TemplateData.Input {
+	switch tmeta.TemplateData.Input {
 	case apidef.RequestXML:
 		mxj.XmlCharsetReader = WrappedCharsetReader
 		bodyData, err = mxj.NewMapXml(body) // unmarshal


### PR DESCRIPTION
We can access t.Spec and tmeta.TemplateData directly. Both stuttered
before - t is already a middleware, and tmeta is already a template.