### PR TITLE
all: simplify a couple of bool assigns

### DIFF
--- a/event_handler_webhooks.go
+++ b/event_handler_webhooks.go
@@ -102,8 +102,6 @@ func (w *WebHookHandler) New(handlerConf interface{}) (TykEventHandler, error) {
 			defaultPath := filepath.Join(config.TemplatePath, "default_webhook.json")
 			webHookTemplate, _ = template.ParseFiles(defaultPath)
 			templateLoaded = true
-		} else {
-			templateLoaded = false
 		}
 	}
 

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -847,11 +847,7 @@ func testHttp(t *testing.T, tests []tykHttpTest, separateControlPort bool) {
 			config.ControlAPIPort, _ = strconv.Atoi(port)
 		}
 
-		if m.overrideDefaults {
-			config.HttpServerOptions.OverrideDefaults = true
-		} else {
-			config.HttpServerOptions.OverrideDefaults = false
-		}
+		config.HttpServerOptions.OverrideDefaults = m.overrideDefaults
 
 		// Ensure that no local API's installed
 		os.RemoveAll(config.AppPath)


### PR DESCRIPTION
The default value of a bool is false, so no need to set that again.

Also, "if x { y = true } else { y = false }" can be just "y = x".