### PR TITLE
all: make SessionState.MetaData a non-iface type

### DIFF
--- a/middleware_modify_headers.go
+++ b/middleware_modify_headers.go
@@ -65,17 +65,12 @@ func (t *TransformHeaders) iterateAddHeaders(kv map[string]string, r *http.Reque
 			// Using meta_data key
 			if ses != nil {
 				metaKey := strings.Replace(nVal, metaLabel, "", 1)
-				if sessionState.MetaData != nil {
-					tempVal, ok := sessionState.MetaData.(map[string]interface{})[metaKey]
-					if ok {
-						nVal = tempVal.(string)
-						r.Header.Add(nKey, nVal)
-					} else {
-						log.Warning("Session Meta Data not found for key in map: ", metaKey)
-					}
-
+				tempVal, ok := sessionState.MetaData[metaKey]
+				if ok {
+					nVal = tempVal.(string)
+					r.Header.Add(nKey, nVal)
 				} else {
-					log.Debug("Meta data object is nil! Skipping.")
+					log.Warning("Session Meta Data not found for key in map: ", metaKey)
 				}
 			}
 

--- a/middleware_url_rewrite.go
+++ b/middleware_url_rewrite.go
@@ -81,7 +81,7 @@ func (u URLRewriter) Rewrite(meta *apidef.URLRewriteMeta, path string, useContex
 			contextKey := strings.Replace(v[0], "$tyk_meta.", "", 1)
 			log.Debug("Replacing: ", v[0])
 
-			val, ok := sessionState.MetaData.(map[string]interface{})[contextKey]
+			val, ok := sessionState.MetaData[contextKey]
 			if ok {
 				newpath = strings.Replace(newpath, v[0], valToStr(val), -1)
 			}

--- a/middleware_virtual_endpoint.go
+++ b/middleware_virtual_endpoint.go
@@ -202,7 +202,7 @@ func (d *VirtualEndpoint) ServeHTTPForCache(w http.ResponseWriter, r *http.Reque
 
 	// Save the sesison data (if modified)
 	if vmeta.UseSession {
-		sessionState.MetaData = newResponseData.SessionMeta
+		sessionState.MetaData = mapStrsToIfaces(newResponseData.SessionMeta)
 		d.Spec.SessionManager.UpdateSession(authHeaderValue, sessionState, getLifetime(d.Spec, &sessionState))
 	}
 

--- a/plugins.go
+++ b/plugins.go
@@ -234,7 +234,7 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 
 	// Save the sesison data (if modified)
 	if !d.Pre && d.UseSession && len(newRequestData.SessionMeta) > 0 {
-		sessionState.MetaData = newRequestData.SessionMeta
+		sessionState.MetaData = mapStrsToIfaces(newRequestData.SessionMeta)
 		d.Spec.SessionManager.UpdateSession(authHeaderValue, sessionState, getLifetime(d.Spec, &sessionState))
 	}
 
@@ -252,6 +252,16 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 	}
 
 	return nil, 200
+}
+
+func mapStrsToIfaces(m map[string]string) map[string]interface{} {
+	// TODO: do we really need this conversion? perhaps make
+	// SessionState.MetaData a map[string]string?
+	m2 := make(map[string]interface{}, len(m))
+	for k, v := range m {
+		m2[k] = v
+	}
+	return m2
 }
 
 // --- Utility functions during startup to ensure a sane VM is present for each API Def ----

--- a/session_state.go
+++ b/session_state.go
@@ -58,13 +58,13 @@ type SessionState struct {
 	Monitor       struct {
 		TriggerLimits []float64 `json:"trigger_limits" msg:"trigger_limits"`
 	} `json:"monitor" msg:"monitor"`
-	EnableDetailedRecording bool        `json:"enable_detail_recording" msg:"enable_detail_recording"`
-	MetaData                interface{} `json:"meta_data" msg:"meta_data"`
-	Tags                    []string    `json:"tags" msg:"tags"`
-	Alias                   string      `json:"alias" msg:"alias"`
-	LastUpdated             string      `json:"last_updated" msg:"last_updated"`
-	IdExtractorDeadline     int64       `json:"id_extractor_deadline" msg:"id_extractor_deadline"`
-	SessionLifetime         int64       `bson:"session_lifetime" json:"session_lifetime"`
+	EnableDetailedRecording bool                   `json:"enable_detail_recording" msg:"enable_detail_recording"`
+	MetaData                map[string]interface{} `json:"meta_data" msg:"meta_data"`
+	Tags                    []string               `json:"tags" msg:"tags"`
+	Alias                   string                 `json:"alias" msg:"alias"`
+	LastUpdated             string                 `json:"last_updated" msg:"last_updated"`
+	IdExtractorDeadline     int64                  `json:"id_extractor_deadline" msg:"id_extractor_deadline"`
+	SessionLifetime         int64                  `bson:"session_lifetime" json:"session_lifetime"`
 
 	firstSeenHash string
 }


### PR DESCRIPTION
Makes our code simpler, safer and cleaner.

Most importantly, the previous method was already risky as plugins.go
and middleware_virtual_endpoint.go were setting map[string]string, not
map[string]interface{}, which could very easily lead to type mismatch
panics.

We could eventually get rid of the interface{} type in the values in the
map, see the added TODO.

Fixes #730.