### PR TITLE
all: use helper funcs for ctx's SessionData

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -93,8 +93,8 @@ func TestHealthCheckEndpoint(t *testing.T) {
 	}
 }
 
-func createSampleSession() SessionState {
-	return SessionState{
+func createSampleSession() *SessionState {
+	return &SessionState{
 		Rate:             5.0,
 		Allowance:        5.0,
 		LastCheck:        time.Now().Unix(),
@@ -119,7 +119,7 @@ func TestApiHandler(t *testing.T) {
 
 	for _, uri := range uris {
 		sampleKey := createSampleSession()
-		body, _ := json.Marshal(&sampleKey)
+		body, _ := json.Marshal(sampleKey)
 
 		recorder := httptest.NewRecorder()
 
@@ -154,7 +154,7 @@ func TestApiHandler(t *testing.T) {
 func TestApiHandlerGetSingle(t *testing.T) {
 	uri := "/tyk/apis/1"
 	sampleKey := createSampleSession()
-	body, _ := json.Marshal(&sampleKey)
+	body, _ := json.Marshal(sampleKey)
 
 	recorder := httptest.NewRecorder()
 
@@ -272,7 +272,7 @@ func TestKeyHandlerNewKey(t *testing.T) {
 	for _, api_id := range []string{"1", "none", ""} {
 		uri := "/tyk/keys/1234"
 		sampleKey := createSampleSession()
-		body, _ := json.Marshal(&sampleKey)
+		body, _ := json.Marshal(sampleKey)
 
 		recorder := httptest.NewRecorder()
 		param := make(url.Values)
@@ -309,7 +309,7 @@ func TestKeyHandlerUpdateKey(t *testing.T) {
 	for _, api_id := range []string{"1", "none", ""} {
 		uri := "/tyk/keys/1234"
 		sampleKey := createSampleSession()
-		body, _ := json.Marshal(&sampleKey)
+		body, _ := json.Marshal(sampleKey)
 
 		recorder := httptest.NewRecorder()
 		param := make(url.Values)
@@ -378,7 +378,7 @@ func TestKeyHandlerGetKey(t *testing.T) {
 func createKey() {
 	uri := "/tyk/keys/1234"
 	sampleKey := createSampleSession()
-	body, _ := json.Marshal(&sampleKey)
+	body, _ := json.Marshal(sampleKey)
 
 	recorder := httptest.NewRecorder()
 	req, _ := http.NewRequest("POST", uri, bytes.NewReader(body))
@@ -429,7 +429,7 @@ func TestCreateKeyHandlerCreateNewKey(t *testing.T) {
 		uri := "/tyk/keys/create"
 
 		sampleKey := createSampleSession()
-		body, _ := json.Marshal(&sampleKey)
+		body, _ := json.Marshal(sampleKey)
 
 		recorder := httptest.NewRecorder()
 		param := make(url.Values)
@@ -714,4 +714,21 @@ func TestContextData(t *testing.T) {
 		}
 	}()
 	ctxSetData(r, nil)
+}
+
+func TestContextSession(t *testing.T) {
+	r := new(http.Request)
+	if ctxGetSession(r) != nil {
+		t.Fatal("expected ctxGetSession to return nil")
+	}
+	ctxSetSession(r, &SessionState{})
+	if ctxGetSession(r) == nil {
+		t.Fatal("expected ctxGetSession to return non-nil")
+	}
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected ctxSetSession of zero val to panic")
+		}
+	}()
+	ctxSetSession(r, nil)
 }

--- a/auth_manager.go
+++ b/auth_manager.go
@@ -25,12 +25,12 @@ type AuthorisationHandler interface {
 // SessionState objects, not identity
 type SessionHandler interface {
 	Init(store StorageHandler)
-	UpdateSession(keyName string, session SessionState, resetTTLTo int64) error
+	UpdateSession(keyName string, session *SessionState, resetTTLTo int64) error
 	RemoveSession(keyName string)
 	GetSessionDetail(keyName string) (SessionState, bool)
 	GetSessions(filter string) []string
 	GetStore() StorageHandler
-	ResetQuota(string, SessionState)
+	ResetQuota(string, *SessionState)
 }
 
 // DefaultAuthorisationManager implements AuthorisationHandler,
@@ -87,7 +87,7 @@ func (b *DefaultSessionManager) GetStore() StorageHandler {
 	return b.Store
 }
 
-func (b *DefaultSessionManager) ResetQuota(keyName string, session SessionState) {
+func (b *DefaultSessionManager) ResetQuota(keyName string, session *SessionState) {
 
 	rawKey := QuotaKeyPrefix + publicHash(keyName)
 	log.WithFields(logrus.Fields{
@@ -105,7 +105,7 @@ func (b *DefaultSessionManager) ResetQuota(keyName string, session SessionState)
 }
 
 // UpdateSession updates the session state in the storage engine
-func (b *DefaultSessionManager) UpdateSession(keyName string, session SessionState, resetTTLTo int64) error {
+func (b *DefaultSessionManager) UpdateSession(keyName string, session *SessionState, resetTTLTo int64) error {
 	if !session.HasChanged() {
 		log.Debug("Session has not changed, not updating")
 		return nil

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -174,7 +174,8 @@ func emptyRedis() error {
 	return err
 }
 
-func createNonThrottledSession() (session SessionState) {
+func createNonThrottledSession() *SessionState {
+	session := new(SessionState)
 	session.Rate = 100.0
 	session.Allowance = session.Rate
 	session.LastCheck = time.Now().Unix()
@@ -185,10 +186,11 @@ func createNonThrottledSession() (session SessionState) {
 	session.QuotaRemaining = 10
 	session.QuotaMax = 10
 	session.Alias = "TEST-ALIAS"
-	return
+	return session
 }
 
-func createQuotaSession() (session SessionState) {
+func createQuotaSession() *SessionState {
+	session := new(SessionState)
 	session.Rate = 8.0
 	session.Allowance = session.Rate
 	session.LastCheck = time.Now().Unix()
@@ -198,10 +200,11 @@ func createQuotaSession() (session SessionState) {
 	session.QuotaRenews = time.Now().Unix() + 20
 	session.QuotaRemaining = 2
 	session.QuotaMax = 2
-	return
+	return session
 }
 
-func createVersionedSession() (session SessionState) {
+func createVersionedSession() *SessionState {
+	session := new(SessionState)
 	session.Rate = 10000
 	session.Allowance = session.Rate
 	session.LastCheck = time.Now().Unix()
@@ -212,10 +215,11 @@ func createVersionedSession() (session SessionState) {
 	session.QuotaRemaining = 10
 	session.QuotaMax = -1
 	session.AccessRights = map[string]AccessDefinition{"9991": {APIName: "Tyk Test API", APIID: "9991", Versions: []string{"v1"}}}
-	return
+	return session
 }
 
-func createParamAuthSession() (session SessionState) {
+func createParamAuthSession() *SessionState {
+	session := new(SessionState)
 	session.Rate = 10000
 	session.Allowance = session.Rate
 	session.LastCheck = time.Now().Unix()
@@ -226,10 +230,11 @@ func createParamAuthSession() (session SessionState) {
 	session.QuotaRemaining = 10
 	session.QuotaMax = -1
 	session.AccessRights = map[string]AccessDefinition{"9992": {APIName: "Tyk Test API", APIID: "9992", Versions: []string{"default"}}}
-	return
+	return session
 }
 
-func createStandardSession() (session SessionState) {
+func createStandardSession() *SessionState {
+	session := new(SessionState)
 	session.Rate = 10000
 	session.Allowance = session.Rate
 	session.LastCheck = time.Now().Unix()
@@ -239,7 +244,7 @@ func createStandardSession() (session SessionState) {
 	session.QuotaRenews = time.Now().Unix()
 	session.QuotaRemaining = 10
 	session.QuotaMax = -1
-	return
+	return session
 }
 
 type tykErrorResponse struct {

--- a/handler_error.go
+++ b/handler_error.go
@@ -109,12 +109,12 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 
 		oauthClientID := ""
 		tags := make([]string, 0)
-		sessionState := context.Get(r, SessionData)
+		session := ctxGetSession(r)
 
-		if sessionState != nil {
-			oauthClientID = sessionState.(SessionState).OauthClientID
-			alias = sessionState.(SessionState).Alias
-			tags = sessionState.(SessionState).Tags
+		if session != nil {
+			oauthClientID = session.OauthClientID
+			alias = session.Alias
+			tags = session.Tags
 		}
 
 		rawRequest := ""

--- a/handler_success.go
+++ b/handler_success.go
@@ -141,7 +141,7 @@ func (t *TykMiddleware) ApplyPolicyIfExists(key string, session *SessionState) {
 	session.Tags = policy.Tags
 
 	// Update the session in the session manager in case it gets called again
-	t.Spec.SessionManager.UpdateSession(key, *session, getLifetime(t.Spec, session))
+	t.Spec.SessionManager.UpdateSession(key, session, getLifetime(t.Spec, session))
 }
 
 // CheckSessionAndIdentityForValidKey will check first the Session store for a valid key, if not found, it will try
@@ -190,7 +190,7 @@ func (t *TykMiddleware) CheckSessionAndIdentityForValidKey(key string) (SessionS
 		log.Debug("Lifetime is: ", getLifetime(t.Spec, &session))
 		// Need to set this in order for the write to work!
 		session.LastUpdated = time.Now().String()
-		t.Spec.SessionManager.UpdateSession(key, session, getLifetime(t.Spec, &session))
+		t.Spec.SessionManager.UpdateSession(key, &session, getLifetime(t.Spec, &session))
 	}
 
 	return session, found
@@ -228,12 +228,12 @@ func (s *SuccessHandler) RecordHit(r *http.Request, timing int64, code int, requ
 		oauthClientID := ""
 		tags := make([]string, 0)
 		var alias string
-		sessionState := context.Get(r, SessionData)
+		session := ctxGetSession(r)
 
-		if sessionState != nil {
-			oauthClientID = sessionState.(SessionState).OauthClientID
-			tags = sessionState.(SessionState).Tags
-			alias = sessionState.(SessionState).Alias
+		if session != nil {
+			oauthClientID = session.OauthClientID
+			tags = session.Tags
+			alias = session.Alias
 		}
 
 		rawRequest := ""

--- a/middleware_access_rights.go
+++ b/middleware_access_rights.go
@@ -33,13 +33,13 @@ func (a *AccessRightsCheck) IsEnabledForSpec() bool { return true }
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (a *AccessRightsCheck) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
 	accessingVersion := a.Spec.getVersionFromRequest(r)
-	sessionState := context.Get(r, SessionData).(SessionState)
+	session := ctxGetSession(r)
 	authHeaderValue := context.Get(r, AuthHeaderValue)
 
 	// If there's nothing in our profile, we let them through to the next phase
-	if len(sessionState.AccessRights) > 0 {
+	if len(session.AccessRights) > 0 {
 		// Otherwise, run auth checks
-		versionList, apiExists := sessionState.AccessRights[a.Spec.APIID]
+		versionList, apiExists := session.AccessRights[a.Spec.APIID]
 		if !apiExists {
 			log.WithFields(logrus.Fields{
 				"path":      r.URL.Path,

--- a/middleware_auth_key.go
+++ b/middleware_auth_key.go
@@ -98,7 +98,7 @@ func (k *AuthKey) ProcessRequest(w http.ResponseWriter, r *http.Request, configu
 	key = stripBearer(key)
 
 	// Check if API key valid
-	sessionState, keyExists := k.TykMiddleware.CheckSessionAndIdentityForValidKey(key)
+	session, keyExists := k.TykMiddleware.CheckSessionAndIdentityForValidKey(key)
 	if !keyExists {
 		log.WithFields(logrus.Fields{
 			"path":   r.URL.Path,
@@ -118,7 +118,7 @@ func (k *AuthKey) ProcessRequest(w http.ResponseWriter, r *http.Request, configu
 	// Set session state on context, we will need it later
 	switch k.TykMiddleware.Spec.BaseIdentityProvidedBy {
 	case apidef.AuthToken, apidef.UnsetAuth:
-		context.Set(r, SessionData, sessionState)
+		ctxSetSession(r, &session)
 		context.Set(r, AuthHeaderValue, key)
 		k.setContextVars(r, key)
 	}

--- a/middleware_auth_key_test.go
+++ b/middleware_auth_key_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/justinas/alice"
 )
 
-func createAuthKeyAuthSession() SessionState {
-	var session SessionState
+func createAuthKeyAuthSession() *SessionState {
+	session := new(SessionState)
 	// essentially non-throttled
 	session.Rate = 100.0
 	session.Allowance = session.Rate
@@ -25,9 +25,7 @@ func createAuthKeyAuthSession() SessionState {
 	session.QuotaRenews = time.Now().Unix()
 	session.QuotaRemaining = 10
 	session.QuotaMax = 10
-
 	session.AccessRights = map[string]AccessDefinition{"31": {APIName: "Tyk Auth Key Test", APIID: "31", Versions: []string{"default"}}}
-
 	return session
 }
 

--- a/middleware_basic_auth_test.go
+++ b/middleware_basic_auth_test.go
@@ -47,8 +47,8 @@ const basicAuthDef = `{
 	}
 }`
 
-func createBasicAuthSession() SessionState {
-	var session SessionState
+func createBasicAuthSession() *SessionState {
+	session := new(SessionState)
 	session.Rate = 8.0
 	session.Allowance = session.Rate
 	session.LastCheck = time.Now().Unix()
@@ -59,7 +59,6 @@ func createBasicAuthSession() SessionState {
 	session.QuotaRemaining = 1
 	session.QuotaMax = -1
 	session.BasicAuthData.Password = "TEST"
-
 	return session
 }
 

--- a/middleware_granular_access.go
+++ b/middleware_granular_access.go
@@ -30,10 +30,10 @@ func (m *GranularAccessMiddleware) IsEnabledForSpec() bool { return true }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (m *GranularAccessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
-	sessionState := context.Get(r, SessionData).(SessionState)
+	session := ctxGetSession(r)
 	authHeaderValue := context.Get(r, AuthHeaderValue).(string)
 
-	sessionVersionData, foundAPI := sessionState.AccessRights[m.Spec.APIID]
+	sessionVersionData, foundAPI := session.AccessRights[m.Spec.APIID]
 	if !foundAPI {
 		log.Debug("Version not found")
 		return nil, 200

--- a/middleware_hmac_test.go
+++ b/middleware_hmac_test.go
@@ -51,8 +51,8 @@ const hmacAuthDef = `{
 	}
 }`
 
-func createHMACAuthSession() SessionState {
-	var session SessionState
+func createHMACAuthSession() *SessionState {
+	session := new(SessionState)
 	session.Rate = 8.0
 	session.Allowance = session.Rate
 	session.LastCheck = time.Now().Unix()
@@ -64,7 +64,6 @@ func createHMACAuthSession() SessionState {
 	session.QuotaMax = -1
 	session.HMACEnabled = true
 	session.HmacSecret = "9879879878787878"
-
 	return session
 }
 

--- a/middleware_jwt_test.go
+++ b/middleware_jwt_test.go
@@ -205,7 +205,8 @@ jQIDAQAB
 -----END PUBLIC KEY-----
 `
 
-func createJWTSession() (session SessionState) {
+func createJWTSession() *SessionState {
+	session := new(SessionState)
 	session.Rate = 1000000.0
 	session.Allowance = session.Rate
 	session.LastCheck = time.Now().Unix() - 10
@@ -216,16 +217,16 @@ func createJWTSession() (session SessionState) {
 	session.QuotaRemaining = 1
 	session.QuotaMax = -1
 	session.JWTData.Secret = jwtSecret
-	return
+	return session
 }
 
-func createJWTSessionWithRSA() SessionState {
+func createJWTSessionWithRSA() *SessionState {
 	session := createJWTSession()
 	session.JWTData.Secret = jwtRSAPubKey
 	return session
 }
 
-func createJWTSessionWithRSAWithPolicy() SessionState {
+func createJWTSessionWithRSAWithPolicy() *SessionState {
 	session := createJWTSessionWithRSA()
 	session.ApplyPolicyID = "987654321"
 	return session

--- a/middleware_modify_headers.go
+++ b/middleware_modify_headers.go
@@ -6,8 +6,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/gorilla/context"
-
 	"github.com/TykTechnologies/tyk/apidef"
 )
 
@@ -51,11 +49,7 @@ func (t *TransformHeaders) IsEnabledForSpec() bool {
 // if the key and value contain a tyk session variable reference, then it will try to inject the value
 func (t *TransformHeaders) iterateAddHeaders(kv map[string]string, r *http.Request) {
 	// Get session data
-	var sessionState SessionState
-	ses := context.Get(r, SessionData)
-	if ses != nil {
-		sessionState = ses.(SessionState)
-	}
+	session := ctxGetSession(r)
 
 	contextData := ctxGetData(r)
 
@@ -63,9 +57,9 @@ func (t *TransformHeaders) iterateAddHeaders(kv map[string]string, r *http.Reque
 	for nKey, nVal := range kv {
 		if strings.Contains(nVal, metaLabel) {
 			// Using meta_data key
-			if ses != nil {
+			if session != nil {
 				metaKey := strings.Replace(nVal, metaLabel, "", 1)
-				tempVal, ok := sessionState.MetaData[metaKey]
+				tempVal, ok := session.MetaData[metaKey]
 				if ok {
 					nVal = tempVal.(string)
 					r.Header.Add(nKey, nVal)

--- a/middleware_oauth2_key_exists.go
+++ b/middleware_oauth2_key_exists.go
@@ -56,7 +56,7 @@ func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request,
 	}
 
 	accessToken := parts[1]
-	sessionState, keyExists := k.TykMiddleware.CheckSessionAndIdentityForValidKey(accessToken)
+	session, keyExists := k.TykMiddleware.CheckSessionAndIdentityForValidKey(accessToken)
 
 	if !keyExists {
 		log.WithFields(logrus.Fields{
@@ -76,7 +76,7 @@ func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request,
 	// Set session state on context, we will need it later
 	switch k.TykMiddleware.Spec.BaseIdentityProvidedBy {
 	case apidef.OAuthKey, apidef.UnsetAuth:
-		context.Set(r, SessionData, sessionState)
+		ctxSetSession(r, &session)
 		context.Set(r, AuthHeaderValue, accessToken)
 	}
 

--- a/middleware_redis_cache.go
+++ b/middleware_redis_cache.go
@@ -259,15 +259,13 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 	}
 
 	copyHeader(w.Header(), newRes.Header)
-	sessObj := context.Get(r, SessionData)
-	var sessionState SessionState
+	session := ctxGetSession(r)
 
 	// Only add ratelimit data to keyed sessions
-	if sessObj != nil {
-		sessionState = sessObj.(SessionState)
-		w.Header().Set("X-RateLimit-Limit", strconv.Itoa(int(sessionState.QuotaMax)))
-		w.Header().Set("X-RateLimit-Remaining", strconv.Itoa(int(sessionState.QuotaRemaining)))
-		w.Header().Set("X-RateLimit-Reset", strconv.Itoa(int(sessionState.QuotaRenews)))
+	if session != nil {
+		w.Header().Set("X-RateLimit-Limit", strconv.Itoa(int(session.QuotaMax)))
+		w.Header().Set("X-RateLimit-Remaining", strconv.Itoa(int(session.QuotaRemaining)))
+		w.Header().Set("X-RateLimit-Reset", strconv.Itoa(int(session.QuotaRenews)))
 	}
 	w.Header().Add("x-tyk-cached-response", "1")
 	w.WriteHeader(newRes.StatusCode)

--- a/middleware_transform.go
+++ b/middleware_transform.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/clbanning/mxj"
-	"github.com/gorilla/context"
 	"golang.org/x/net/html/charset"
 
 	"github.com/TykTechnologies/tyk/apidef"
@@ -87,10 +86,10 @@ func (t *TransformMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 	}
 
 	if tmeta.TemplateData.EnableSession {
-		ses := context.Get(r, SessionData).(SessionState)
+		session := ctxGetSession(r)
 		switch x := bodyData.(type) {
 		case map[string]interface{}:
-			x["_tyk_meta"] = ses.MetaData
+			x["_tyk_meta"] = session.MetaData
 		}
 	}
 

--- a/middleware_url_rewrite.go
+++ b/middleware_url_rewrite.go
@@ -72,8 +72,7 @@ func (u URLRewriter) Rewrite(meta *apidef.URLRewriteMeta, path string, useContex
 	}
 
 	// Meta data from the token
-	if sess := context.Get(r, SessionData); sess != nil {
-		sessionState := sess.(SessionState)
+	if session := ctxGetSession(r); session != nil {
 
 		metaDollarMatch := regexp.MustCompile(`\$tyk_meta.(\w+)`)
 		metaReplace_slice := metaDollarMatch.FindAllStringSubmatch(meta.RewriteTo, -1)
@@ -81,7 +80,7 @@ func (u URLRewriter) Rewrite(meta *apidef.URLRewriteMeta, path string, useContex
 			contextKey := strings.Replace(v[0], "$tyk_meta.", "", 1)
 			log.Debug("Replacing: ", v[0])
 
-			val, ok := sessionState.MetaData[contextKey]
+			val, ok := session.MetaData[contextKey]
 			if ok {
 				newpath = strings.Replace(newpath, v[0], valToStr(val), -1)
 			}

--- a/multiauth_test.go
+++ b/multiauth_test.go
@@ -49,7 +49,8 @@ const multiAuthDev = `{
 	}
 }`
 
-func createMultiAuthKeyAuthSession() (session SessionState) {
+func createMultiAuthKeyAuthSession() *SessionState {
+	session := new(SessionState)
 	session.Rate = 100.0
 	session.Allowance = session.Rate
 	session.LastCheck = time.Now().Unix()
@@ -60,10 +61,11 @@ func createMultiAuthKeyAuthSession() (session SessionState) {
 	session.QuotaRemaining = 900
 	session.QuotaMax = 10
 	session.AccessRights = map[string]AccessDefinition{"55": {APIName: "Tyk Multi Key Test", APIID: "55", Versions: []string{"default"}}}
-	return
+	return session
 }
 
-func createMultiBasicAuthSession() (session SessionState) {
+func createMultiBasicAuthSession() *SessionState {
+	session := new(SessionState)
 	session.Rate = 8.0
 	session.Allowance = session.Rate
 	session.LastCheck = time.Now().Unix()
@@ -75,7 +77,7 @@ func createMultiBasicAuthSession() (session SessionState) {
 	session.QuotaMax = -1
 	session.BasicAuthData.Password = "TEST"
 	session.AccessRights = map[string]AccessDefinition{"55": {APIName: "Tyk Multi Key Test", APIID: "55", Versions: []string{"default"}}}
-	return
+	return session
 }
 
 func getMultiAuthStandardAndBasicAuthChain(spec *APISpec) http.Handler {


### PR DESCRIPTION
Also use a pointer type for more arguments and return values, as we need
a pointer for the context value. This is because we need to be able to
return nil (non-existing) in ctxGetSession. Besides, sticking
SessionState into an interface{} will need a dereference anyway.

Updates #683.