### PR TITLE
api: rework to vastly simplify json logic

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,8 +66,6 @@ var (
 	NodeID string
 
 	runningTests = false
-
-	systemError = []byte(`{"status": "system error, please contact administrator"}`)
 )
 
 const (
@@ -342,9 +340,7 @@ func checkIsAPIOwner(handler http.HandlerFunc) http.HandlerFunc {
 			// Error
 			log.Warning("Attempted administrative access with invalid or missing key!")
 
-			responseMessage := createError("Forbidden")
-			w.WriteHeader(403)
-			w.Write(responseMessage)
+			doJSONWrite(w, 403, apiError("Forbidden"))
 			return
 		}
 

--- a/plugins.go
+++ b/plugins.go
@@ -401,9 +401,10 @@ func (j *JSVM) LoadTykJSApi() {
 		apiKey := call.Argument(0).String()
 		apiId := call.Argument(1).String()
 
-		byteArray, _ := handleGetDetail(apiKey, apiId)
+		obj, _ := handleGetDetail(apiKey, apiId)
+		bs, _ := json.Marshal(obj)
 
-		returnVal, err := j.VM.ToValue(string(byteArray))
+		returnVal, err := j.VM.ToValue(string(bs))
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "jsvm",


### PR DESCRIPTION
Each "handler" func would return raw JSON instead of an object to be
marshaled. This means that the logic to write a JSON response was
copy-pasted in dozens of places, including what to do when marshaling
fails.

Instead, have these return an interface{} and have the JSON be handled
in fewer places, and with a proper helper func.

This also lets us get rid of a lot of "success" logic clutter.