### PR TITLE
session: make MetaData a map[string]string

### DIFF
--- a/middleware_jwt.go
+++ b/middleware_jwt.go
@@ -247,7 +247,7 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 
 		if err == nil {
 			session = newSession
-			session.MetaData = map[string]interface{}{"TykJWTSessionID": sessionID}
+			session.MetaData = map[string]string{"TykJWTSessionID": sessionID}
 			session.Alias = baseFieldData
 
 			// Update the session in the session manager in case it gets called again

--- a/middleware_modify_headers.go
+++ b/middleware_modify_headers.go
@@ -59,10 +59,9 @@ func (t *TransformHeaders) iterateAddHeaders(kv map[string]string, r *http.Reque
 			// Using meta_data key
 			if session != nil {
 				metaKey := strings.Replace(nVal, metaLabel, "", 1)
-				tempVal, ok := session.MetaData[metaKey]
+				metaVal, ok := session.MetaData[metaKey]
 				if ok {
-					nVal = tempVal.(string)
-					r.Header.Add(nKey, nVal)
+					r.Header.Add(nKey, metaVal)
 				} else {
 					log.Warning("Session Meta Data not found for key in map: ", metaKey)
 				}

--- a/middleware_openid.go
+++ b/middleware_openid.go
@@ -195,7 +195,7 @@ func (k *OpenIDMW) ProcessRequest(w http.ResponseWriter, r *http.Request, config
 		}
 
 		session = newSession
-		session.MetaData = map[string]interface{}{"TykJWTSessionID": sessionID, "ClientID": clientID}
+		session.MetaData = map[string]string{"TykJWTSessionID": sessionID, "ClientID": clientID}
 		session.Alias = clientID + ":" + user.ID
 
 		// Update the session in the session manager in case it gets called again

--- a/middleware_virtual_endpoint.go
+++ b/middleware_virtual_endpoint.go
@@ -202,7 +202,7 @@ func (d *VirtualEndpoint) ServeHTTPForCache(w http.ResponseWriter, r *http.Reque
 
 	// Save the sesison data (if modified)
 	if vmeta.UseSession {
-		session.MetaData = mapStrsToIfaces(newResponseData.SessionMeta)
+		session.MetaData = newResponseData.SessionMeta
 		d.Spec.SessionManager.UpdateSession(authHeaderValue, session, getLifetime(d.Spec, session))
 	}
 

--- a/plugins.go
+++ b/plugins.go
@@ -232,7 +232,7 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 
 	// Save the sesison data (if modified)
 	if !d.Pre && d.UseSession && len(newRequestData.SessionMeta) > 0 {
-		session.MetaData = mapStrsToIfaces(newRequestData.SessionMeta)
+		session.MetaData = newRequestData.SessionMeta
 		d.Spec.SessionManager.UpdateSession(authHeaderValue, session, getLifetime(d.Spec, session))
 	}
 
@@ -250,16 +250,6 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 	}
 
 	return nil, 200
-}
-
-func mapStrsToIfaces(m map[string]string) map[string]interface{} {
-	// TODO: do we really need this conversion? perhaps make
-	// SessionState.MetaData a map[string]string?
-	m2 := make(map[string]interface{}, len(m))
-	for k, v := range m {
-		m2[k] = v
-	}
-	return m2
 }
 
 // --- Utility functions during startup to ensure a sane VM is present for each API Def ----

--- a/session_state.go
+++ b/session_state.go
@@ -58,13 +58,13 @@ type SessionState struct {
 	Monitor       struct {
 		TriggerLimits []float64 `json:"trigger_limits" msg:"trigger_limits"`
 	} `json:"monitor" msg:"monitor"`
-	EnableDetailedRecording bool                   `json:"enable_detail_recording" msg:"enable_detail_recording"`
-	MetaData                map[string]interface{} `json:"meta_data" msg:"meta_data"`
-	Tags                    []string               `json:"tags" msg:"tags"`
-	Alias                   string                 `json:"alias" msg:"alias"`
-	LastUpdated             string                 `json:"last_updated" msg:"last_updated"`
-	IdExtractorDeadline     int64                  `json:"id_extractor_deadline" msg:"id_extractor_deadline"`
-	SessionLifetime         int64                  `bson:"session_lifetime" json:"session_lifetime"`
+	EnableDetailedRecording bool              `json:"enable_detail_recording" msg:"enable_detail_recording"`
+	MetaData                map[string]string `json:"meta_data" msg:"meta_data"`
+	Tags                    []string          `json:"tags" msg:"tags"`
+	Alias                   string            `json:"alias" msg:"alias"`
+	LastUpdated             string            `json:"last_updated" msg:"last_updated"`
+	IdExtractorDeadline     int64             `json:"id_extractor_deadline" msg:"id_extractor_deadline"`
+	SessionLifetime         int64             `bson:"session_lifetime" json:"session_lifetime"`
 
 	firstSeenHash string
 }


### PR DESCRIPTION
In a recent commit we replaced interface{} with map[string]interface{}.
Remove the last bit of empty interface.

Nothing to be done; we always used strings as values. Remove the useless
clutter around it.