### PR TITLE
mw: don't use a goroutine for ctxSetSession

### DIFF
--- a/middleware_rate_limiting.go
+++ b/middleware_rate_limiting.go
@@ -89,13 +89,12 @@ func (k *RateLimitAndQuotaCheck) ProcessRequest(w http.ResponseWriter, r *http.R
 	// If either are disabled, save the write roundtrip
 	if !k.Spec.DisableRateLimit || !k.Spec.DisableQuota {
 		// Ensure quota and rate data for this session are recorded
-		if !config.UseAsyncSessionWrite {
-			k.Spec.SessionManager.UpdateSession(token, session, getLifetime(k.Spec, session))
-			ctxSetSession(r, session)
-		} else {
+		if config.UseAsyncSessionWrite {
 			go k.Spec.SessionManager.UpdateSession(token, session, getLifetime(k.Spec, session))
-			go ctxSetSession(r, session)
+		} else {
+			k.Spec.SessionManager.UpdateSession(token, session, getLifetime(k.Spec, session))
 		}
+		ctxSetSession(r, session)
 	}
 
 	log.Debug("SessionState: ", session)


### PR DESCRIPTION
This func is very cheap and non-blocking. There is no reason to run it
in the background. This is unlike the SessionManager call, which might
do a call on our key-value store and do network work.

In fact, if further down the line the session is fetched from the
request context, it might not yet have been saved if this goroutine
hasn't been ran by any chance.

Also flip the if/else to remove the '!'.