### PR TITLE
all: remove spec.APIDefinition.Foo stutter

### DIFF
--- a/api.go
+++ b/api.go
@@ -464,7 +464,7 @@ func handleGetAPIList() (interface{}, int) {
 
 func handleGetAPI(apiID string) (interface{}, int) {
 	for _, apiSpec := range ApiSpecRegister {
-		if apiSpec.APIDefinition.APIID == apiID {
+		if apiSpec.APIID == apiID {
 			return apiSpec.APIDefinition, 200
 		}
 	}

--- a/api_loader.go
+++ b/api_loader.go
@@ -50,8 +50,8 @@ func skipSpecBecauseInvalid(referenceSpec *APISpec) bool {
 	if referenceSpec.Proxy.ListenPath == "" {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
-			"org_id": referenceSpec.APIDefinition.OrgID,
-			"api_id": referenceSpec.APIDefinition.APIID,
+			"org_id": referenceSpec.OrgID,
+			"api_id": referenceSpec.APIID,
 		}).Error("Listen path is empty, skipping API ID: ", referenceSpec.APIID)
 		return true
 	}
@@ -59,18 +59,18 @@ func skipSpecBecauseInvalid(referenceSpec *APISpec) bool {
 	if strings.Contains(referenceSpec.Proxy.ListenPath, " ") {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
-			"org_id": referenceSpec.APIDefinition.OrgID,
-			"api_id": referenceSpec.APIDefinition.APIID,
+			"org_id": referenceSpec.OrgID,
+			"api_id": referenceSpec.APIID,
 		}).Error("Listen path contains spaces, is invalid, skipping API ID: ", referenceSpec.APIID)
 		return true
 	}
 
-	_, err := url.Parse(referenceSpec.APIDefinition.Proxy.TargetURL)
+	_, err := url.Parse(referenceSpec.Proxy.TargetURL)
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
-			"org_id": referenceSpec.APIDefinition.OrgID,
-			"api_id": referenceSpec.APIDefinition.APIID,
+			"org_id": referenceSpec.OrgID,
+			"api_id": referenceSpec.APIID,
 		}).Error("Couldn't parse target URL: ", err)
 		return true
 	}
@@ -99,7 +99,7 @@ func generateListenPathMap(apiSpecs []*APISpec) {
 			}
 			log.WithFields(logrus.Fields{
 				"prefix":   "main",
-				"api_name": referenceSpec.APIDefinition.Name,
+				"api_name": referenceSpec.Name,
 				"domain":   dN,
 			}).Info("Tracking hostname")
 
@@ -116,13 +116,13 @@ func processSpec(referenceSpec *APISpec,
 
 	log.WithFields(logrus.Fields{
 		"prefix":   "main",
-		"api_name": referenceSpec.APIDefinition.Name,
+		"api_name": referenceSpec.Name,
 	}).Info("Loading API")
 
 	if skipSpecBecauseInvalid(referenceSpec) {
 		log.WithFields(logrus.Fields{
 			"prefix":   "main",
-			"api_name": referenceSpec.APIDefinition.Name,
+			"api_name": referenceSpec.Name,
 		}).Warning("Skipped!")
 		chainDef.Skip = true
 		return &chainDef
@@ -152,8 +152,8 @@ func processSpec(referenceSpec *APISpec,
 	if pathModified {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
-			"org_id": referenceSpec.APIDefinition.OrgID,
-			"api_id": referenceSpec.APIDefinition.APIID,
+			"org_id": referenceSpec.OrgID,
+			"api_id": referenceSpec.APIID,
 		}).Error("Listen path collision, changed to ", referenceSpec.Proxy.ListenPath)
 	}
 
@@ -209,7 +209,7 @@ func processSpec(referenceSpec *APISpec,
 	if config.EnableJSVM || EnableCoProcess {
 		log.WithFields(logrus.Fields{
 			"prefix":   "main",
-			"api_name": referenceSpec.APIDefinition.Name,
+			"api_name": referenceSpec.Name,
 		}).Debug("Loading Middleware")
 
 		var mwPaths []string
@@ -250,14 +250,14 @@ func processSpec(referenceSpec *APISpec,
 	}
 
 	// Already vetted
-	remote, _ := url.Parse(referenceSpec.APIDefinition.Proxy.TargetURL)
+	remote, _ := url.Parse(referenceSpec.Proxy.TargetURL)
 
 	referenceSpec.target = remote
 	var proxy ReturningHttpHandler
 	if enableVersionOverrides {
 		log.WithFields(logrus.Fields{
 			"prefix":   "main",
-			"api_name": referenceSpec.APIDefinition.Name,
+			"api_name": referenceSpec.Name,
 		}).Info("Multi target enabled")
 		proxy = &MultiTargetProxy{}
 	} else {
@@ -274,17 +274,17 @@ func processSpec(referenceSpec *APISpec,
 	CheckCBEnabled(tykMiddleware)
 	CheckETEnabled(tykMiddleware)
 
-	keyPrefix := "cache-" + referenceSpec.APIDefinition.APIID
+	keyPrefix := "cache-" + referenceSpec.APIID
 	cacheStore := &RedisClusterStorageManager{KeyPrefix: keyPrefix, IsCache: true}
 	cacheStore.Connect()
 
 	var chain http.Handler
 
-	if referenceSpec.APIDefinition.UseKeylessAccess {
+	if referenceSpec.UseKeylessAccess {
 		chainDef.Open = true
 		log.WithFields(logrus.Fields{
 			"prefix":   "main",
-			"api_name": referenceSpec.APIDefinition.Name,
+			"api_name": referenceSpec.Name,
 		}).Info("Checking security policy: Open")
 
 		// Add pre-process MW
@@ -306,13 +306,13 @@ func processSpec(referenceSpec *APISpec,
 		AppendMiddleware(&baseChainArray, &URLRewriteMiddleware{TykMiddleware: tykMiddleware}, tykMiddleware)
 		AppendMiddleware(&baseChainArray, &TransformMethod{TykMiddleware: tykMiddleware}, tykMiddleware)
 
-		log.Debug(referenceSpec.APIDefinition.Name, " - CHAIN SIZE: ", len(baseChainArray))
+		log.Debug(referenceSpec.Name, " - CHAIN SIZE: ", len(baseChainArray))
 
 		for _, obj := range mwPreFuncs {
 			if mwDriver != apidef.OttoDriver {
 				log.WithFields(logrus.Fields{
 					"prefix":   "coprocess",
-					"api_name": referenceSpec.APIDefinition.Name,
+					"api_name": referenceSpec.Name,
 				}).Debug("Registering coprocess middleware, hook name: ", obj.Name, "hook type: Pre", ", driver: ", mwDriver)
 				AppendMiddleware(&chainArray, &CoProcessMiddleware{tykMiddleware, coprocess.HookType_Pre, obj.Name, mwDriver}, tykMiddleware)
 			} else {
@@ -326,7 +326,7 @@ func processSpec(referenceSpec *APISpec,
 			if mwDriver != apidef.OttoDriver {
 				log.WithFields(logrus.Fields{
 					"prefix":   "coprocess",
-					"api_name": referenceSpec.APIDefinition.Name,
+					"api_name": referenceSpec.Name,
 				}).Debug("Registering coprocess middleware, hook name: ", obj.Name, "hook type: Post", ", driver: ", mwDriver)
 				AppendMiddleware(&chainArray, &CoProcessMiddleware{tykMiddleware, coprocess.HookType_Post, obj.Name, mwDriver}, tykMiddleware)
 			} else {
@@ -357,7 +357,7 @@ func processSpec(referenceSpec *APISpec,
 			if mwDriver != apidef.OttoDriver {
 				log.WithFields(logrus.Fields{
 					"prefix":   "coprocess",
-					"api_name": referenceSpec.APIDefinition.Name,
+					"api_name": referenceSpec.Name,
 				}).Debug("Registering coprocess middleware, hook name: ", obj.Name, "hook type: Pre", ", driver: ", mwDriver)
 				AppendMiddleware(&chainArray, &CoProcessMiddleware{tykMiddleware, coprocess.HookType_Pre, obj.Name, mwDriver}, tykMiddleware)
 			} else {
@@ -369,11 +369,11 @@ func processSpec(referenceSpec *APISpec,
 
 		// Select the keying method to use for setting session states
 		var authArray []alice.Constructor
-		if referenceSpec.APIDefinition.UseOauth2 {
+		if referenceSpec.UseOauth2 {
 			// Oauth2
 			log.WithFields(logrus.Fields{
 				"prefix":   "main",
-				"api_name": referenceSpec.APIDefinition.Name,
+				"api_name": referenceSpec.Name,
 			}).Info("Checking security policy: OAuth")
 			authArray = append(authArray, CreateMiddleware(&Oauth2KeyExists{tykMiddleware}, tykMiddleware))
 
@@ -386,11 +386,11 @@ func processSpec(referenceSpec *APISpec,
 			useOttoAuth = mwDriver == apidef.OttoDriver && referenceSpec.EnableCoProcessAuth
 		}
 
-		if referenceSpec.APIDefinition.UseBasicAuth {
+		if referenceSpec.UseBasicAuth {
 			// Basic Auth
 			log.WithFields(logrus.Fields{
 				"prefix":   "main",
-				"api_name": referenceSpec.APIDefinition.Name,
+				"api_name": referenceSpec.Name,
 			}).Info("Checking security policy: Basic")
 			authArray = append(authArray, CreateMiddleware(&BasicAuthKeyIsValid{tykMiddleware}, tykMiddleware))
 		}
@@ -399,7 +399,7 @@ func processSpec(referenceSpec *APISpec,
 			// HMAC Auth
 			log.WithFields(logrus.Fields{
 				"prefix":   "main",
-				"api_name": referenceSpec.APIDefinition.Name,
+				"api_name": referenceSpec.Name,
 			}).Info("Checking security policy: HMAC")
 			authArray = append(authArray, CreateMiddleware(&HMACMiddleware{TykMiddleware: tykMiddleware}, tykMiddleware))
 		}
@@ -408,7 +408,7 @@ func processSpec(referenceSpec *APISpec,
 			// JWT Auth
 			log.WithFields(logrus.Fields{
 				"prefix":   "main",
-				"api_name": referenceSpec.APIDefinition.Name,
+				"api_name": referenceSpec.Name,
 			}).Info("Checking security policy: JWT")
 			authArray = append(authArray, CreateMiddleware(&JWTMiddleware{tykMiddleware}, tykMiddleware))
 		}
@@ -417,7 +417,7 @@ func processSpec(referenceSpec *APISpec,
 			// JWT Auth
 			log.WithFields(logrus.Fields{
 				"prefix":   "main",
-				"api_name": referenceSpec.APIDefinition.Name,
+				"api_name": referenceSpec.Name,
 			}).Info("Checking security policy: OpenID")
 
 			// initialise the OID configuration on this reference Spec
@@ -428,12 +428,12 @@ func processSpec(referenceSpec *APISpec,
 			// TODO: check if mwAuthCheckFunc is available/valid
 			log.WithFields(logrus.Fields{
 				"prefix":   "main",
-				"api_name": referenceSpec.APIDefinition.Name,
+				"api_name": referenceSpec.Name,
 			}).Info("Checking security policy: CoProcess Plugin")
 
 			log.WithFields(logrus.Fields{
 				"prefix":   "coprocess",
-				"api_name": referenceSpec.APIDefinition.Name,
+				"api_name": referenceSpec.Name,
 			}).Debug("Registering coprocess middleware, hook name: ", mwAuthCheckFunc.Name, "hook type: CustomKeyCheck", ", driver: ", mwDriver)
 
 			if useCoProcessAuth {
@@ -450,11 +450,11 @@ func processSpec(referenceSpec *APISpec,
 			authArray = append(authArray, CreateDynamicAuthMiddleware(mwAuthCheckFunc.Name, tykMiddleware))
 		}
 
-		if referenceSpec.UseStandardAuth || (!referenceSpec.UseOpenID && !referenceSpec.EnableJWT && !referenceSpec.EnableSignatureChecking && !referenceSpec.APIDefinition.UseBasicAuth && !referenceSpec.APIDefinition.UseOauth2 && !useCoProcessAuth && !useOttoAuth) {
+		if referenceSpec.UseStandardAuth || (!referenceSpec.UseOpenID && !referenceSpec.EnableJWT && !referenceSpec.EnableSignatureChecking && !referenceSpec.UseBasicAuth && !referenceSpec.UseOauth2 && !useCoProcessAuth && !useOttoAuth) {
 			// Auth key
 			log.WithFields(logrus.Fields{
 				"prefix":   "main",
-				"api_name": referenceSpec.APIDefinition.Name,
+				"api_name": referenceSpec.Name,
 			}).Info("Checking security policy: Token")
 			authArray = append(authArray, CreateMiddleware(&AuthKey{tykMiddleware}, tykMiddleware))
 		}
@@ -464,7 +464,7 @@ func processSpec(referenceSpec *APISpec,
 		for _, obj := range mwPostAuthCheckFuncs {
 			log.WithFields(logrus.Fields{
 				"prefix":   "coprocess",
-				"api_name": referenceSpec.APIDefinition.Name,
+				"api_name": referenceSpec.Name,
 			}).Debug("Registering coprocess middleware, hook name: ", obj.Name, "hook type: Pre", ", driver: ", mwDriver)
 			AppendMiddleware(&chainArray, &CoProcessMiddleware{tykMiddleware, coprocess.HookType_PostKeyAuth, obj.Name, mwDriver}, tykMiddleware)
 		}
@@ -487,7 +487,7 @@ func processSpec(referenceSpec *APISpec,
 			if mwDriver != apidef.OttoDriver {
 				log.WithFields(logrus.Fields{
 					"prefix":   "coprocess",
-					"api_name": referenceSpec.APIDefinition.Name,
+					"api_name": referenceSpec.Name,
 				}).Debug("Registering coprocess middleware, hook name: ", obj.Name, "hook type: Post", ", driver: ", mwDriver)
 				AppendMiddleware(&chainArray, &CoProcessMiddleware{tykMiddleware, coprocess.HookType_Post, obj.Name, mwDriver}, tykMiddleware)
 			} else {
@@ -497,7 +497,7 @@ func processSpec(referenceSpec *APISpec,
 
 		log.WithFields(logrus.Fields{
 			"prefix":   "main",
-			"api_name": referenceSpec.APIDefinition.Name,
+			"api_name": referenceSpec.Name,
 		}).Debug("Custom middleware completed processing")
 
 		// Use CreateMiddleware(&ModifiedMiddleware{tykMiddleware}, tykMiddleware)  to run custom middleware
@@ -525,7 +525,7 @@ func processSpec(referenceSpec *APISpec,
 		rateLimitPath := referenceSpec.Proxy.ListenPath + "tyk/rate-limits/"
 		log.WithFields(logrus.Fields{
 			"prefix":   "main",
-			"api_name": referenceSpec.APIDefinition.Name,
+			"api_name": referenceSpec.Name,
 		}).Debug("Rate limit endpoint is: ", rateLimitPath)
 		//subrouter.Handle(rateLimitPath, simpleChain)
 		chainDef.RateLimitPath = rateLimitPath
@@ -534,7 +534,7 @@ func processSpec(referenceSpec *APISpec,
 
 	log.WithFields(logrus.Fields{
 		"prefix":   "main",
-		"api_name": referenceSpec.APIDefinition.Name,
+		"api_name": referenceSpec.Name,
 	}).Debug("Setting Listen Path: ", referenceSpec.Proxy.ListenPath)
 	//subrouter.Handle(referenceSpec.Proxy.ListenPath+"{rest:.*}", chain)
 
@@ -588,7 +588,7 @@ func loadApps(apiSpecs []*APISpec, muxer *mux.Router) {
 			if config.EnableCustomDomains && referenceSpec.Domain != "" {
 				log.WithFields(logrus.Fields{
 					"prefix":   "main",
-					"api_name": referenceSpec.APIDefinition.Name,
+					"api_name": referenceSpec.Name,
 					"domain":   referenceSpec.Domain,
 				}).Info("Custom Domain set.")
 				subrouter = mainRouter.Host(referenceSpec.Domain).Subrouter()
@@ -599,7 +599,7 @@ func loadApps(apiSpecs []*APISpec, muxer *mux.Router) {
 		}(referenceSpec, i)
 
 		// TODO: This will not deal with skipped APis well
-		tmpSpecRegister[referenceSpec.APIDefinition.APIID] = referenceSpec
+		tmpSpecRegister[referenceSpec.APIID] = referenceSpec
 	}
 
 	for range apiSpecs {

--- a/coprocess.go
+++ b/coprocess.go
@@ -167,7 +167,7 @@ func (m *CoProcessMiddleware) New() {}
 func (m *CoProcessMiddleware) GetConfig() (interface{}, error) {
 	var moduleConfig CoProcessMiddlewareConfig
 
-	err := mapstructure.Decode(m.TykMiddleware.Spec.APIDefinition.RawData, &moduleConfig)
+	err := mapstructure.Decode(m.TykMiddleware.Spec.RawData, &moduleConfig)
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "jsvm",

--- a/coprocess_bundle.go
+++ b/coprocess_bundle.go
@@ -97,7 +97,7 @@ func (b *Bundle) Verify() error {
 
 // AddToSpec attaches the custom middleware settings to an API definition.
 func (b *Bundle) AddToSpec() {
-	b.Spec.APIDefinition.CustomMiddleware = b.Manifest.CustomMiddleware
+	b.Spec.CustomMiddleware = b.Manifest.CustomMiddleware
 
 	if GlobalDispatcher != nil {
 		GlobalDispatcher.HandleMiddlewareCache(&b.Manifest, b.Path)
@@ -349,10 +349,10 @@ func bundleError(spec *APISpec, err error, message string) {
 	log.WithFields(logrus.Fields{
 		"prefix":      "main",
 		"user_ip":     "-",
-		"server_name": spec.APIDefinition.Proxy.TargetURL,
+		"server_name": spec.Proxy.TargetURL,
 		"user_id":     "-",
-		"org_id":      spec.APIDefinition.OrgID,
-		"api_id":      spec.APIDefinition.APIID,
+		"org_id":      spec.OrgID,
+		"api_id":      spec.APIID,
 		"path":        "-",
 	}).Error(message, ": ", err)
 }

--- a/handler_error.go
+++ b/handler_error.go
@@ -92,7 +92,7 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 			version = "Non Versioned"
 		}
 
-		if e.TykMiddleware.Spec.APIDefinition.Proxy.StripListenPath {
+		if e.TykMiddleware.Spec.Proxy.StripListenPath {
 			r.URL.Path = strings.Replace(r.URL.Path, e.TykMiddleware.Spec.Proxy.ListenPath, "", 1)
 		}
 
@@ -143,9 +143,9 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 			token,
 			t,
 			version,
-			e.Spec.APIDefinition.Name,
-			e.Spec.APIDefinition.APIID,
-			e.Spec.APIDefinition.OrgID,
+			e.Spec.Name,
+			e.Spec.APIID,
+			e.Spec.OrgID,
 			oauthClientID,
 			0,
 			rawRequest,

--- a/handler_success.go
+++ b/handler_success.go
@@ -88,7 +88,7 @@ func (t *TykMiddleware) ApplyPolicyIfExists(key string, session *SessionState) {
 	}
 	// Check ownership, policy org owner must be the same as API,
 	// otherwise youcould overwrite a session key with a policy from a different org!
-	if policy.OrgID != t.Spec.APIDefinition.OrgID {
+	if policy.OrgID != t.Spec.OrgID {
 		log.Error("Attempting to apply policy from different organisation to key, skipping")
 		return
 	}
@@ -266,9 +266,9 @@ func (s *SuccessHandler) RecordHit(r *http.Request, timing int64, code int, requ
 			token,
 			t,
 			version,
-			s.Spec.APIDefinition.Name,
-			s.Spec.APIDefinition.APIID,
-			s.Spec.APIDefinition.OrgID,
+			s.Spec.Name,
+			s.Spec.APIID,
+			s.Spec.OrgID,
 			oauthClientID,
 			timing,
 			rawRequest,
@@ -317,7 +317,7 @@ func (s *SuccessHandler) RecordHit(r *http.Request, timing int64, code int, requ
 func (s *SuccessHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) *http.Response {
 	log.Debug("Started proxy")
 	// Make sure we get the correct target URL
-	if s.Spec.APIDefinition.Proxy.StripListenPath {
+	if s.Spec.Proxy.StripListenPath {
 		log.Debug("Stripping: ", s.Spec.Proxy.ListenPath)
 		r.URL.Path = strings.Replace(r.URL.Path, s.Spec.Proxy.ListenPath, "", 1)
 		log.Debug("Upstream Path is: ", r.URL.Path)
@@ -351,7 +351,7 @@ func (s *SuccessHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) *http
 // Spec states the path is Ignored Itwill also return a response object for the cache
 func (s *SuccessHandler) ServeHTTPWithCache(w http.ResponseWriter, r *http.Request) *http.Response {
 	// Make sure we get the correct target URL
-	if s.Spec.APIDefinition.Proxy.StripListenPath {
+	if s.Spec.Proxy.StripListenPath {
 		r.URL.Path = strings.Replace(r.URL.Path, s.Spec.Proxy.ListenPath, "", 1)
 	}
 

--- a/main.go
+++ b/main.go
@@ -433,23 +433,23 @@ func loadCustomMiddleware(referenceSpec *APISpec) ([]string, apidef.MiddlewareDe
 	mwDriver := apidef.OttoDriver
 
 	// Set AuthCheck hook
-	if referenceSpec.APIDefinition.CustomMiddleware.AuthCheck.Name != "" {
-		mwAuthCheckFunc = referenceSpec.APIDefinition.CustomMiddleware.AuthCheck
-		if referenceSpec.APIDefinition.CustomMiddleware.AuthCheck.Path != "" {
+	if referenceSpec.CustomMiddleware.AuthCheck.Name != "" {
+		mwAuthCheckFunc = referenceSpec.CustomMiddleware.AuthCheck
+		if referenceSpec.CustomMiddleware.AuthCheck.Path != "" {
 			// Feed a JS file to Otto
-			mwPaths = append(mwPaths, referenceSpec.APIDefinition.CustomMiddleware.AuthCheck.Path)
+			mwPaths = append(mwPaths, referenceSpec.CustomMiddleware.AuthCheck.Path)
 		}
 	}
 
 	// Load from the configuration
-	for _, mwObj := range referenceSpec.APIDefinition.CustomMiddleware.Pre {
+	for _, mwObj := range referenceSpec.CustomMiddleware.Pre {
 		mwPaths = append(mwPaths, mwObj.Path)
 		mwPreFuncs = append(mwPreFuncs, mwObj)
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Debug("Loading custom PRE-PROCESSOR middleware: ", mwObj.Name)
 	}
-	for _, mwObj := range referenceSpec.APIDefinition.CustomMiddleware.Post {
+	for _, mwObj := range referenceSpec.CustomMiddleware.Post {
 		mwPaths = append(mwPaths, mwObj.Path)
 		mwPostFuncs = append(mwPostFuncs, mwObj)
 		log.WithFields(logrus.Fields{
@@ -469,7 +469,7 @@ func loadCustomMiddleware(referenceSpec *APISpec) ([]string, apidef.MiddlewareDe
 		{name: "post_auth", slice: &mwPostKeyAuthFuncs, session: true},
 		{name: "post", slice: &mwPostFuncs, session: true},
 	} {
-		dirPath := filepath.Join(config.MiddlewarePath, referenceSpec.APIDefinition.APIID, folder.name)
+		dirPath := filepath.Join(config.MiddlewarePath, referenceSpec.APIID, folder.name)
 		files, _ := ioutil.ReadDir(dirPath)
 		for _, f := range files {
 			if strings.Contains(f.Name(), ".js") {
@@ -502,12 +502,12 @@ func loadCustomMiddleware(referenceSpec *APISpec) ([]string, apidef.MiddlewareDe
 	}
 
 	// Set middleware driver, defaults to OttoDriver
-	if referenceSpec.APIDefinition.CustomMiddleware.Driver != "" {
-		mwDriver = referenceSpec.APIDefinition.CustomMiddleware.Driver
+	if referenceSpec.CustomMiddleware.Driver != "" {
+		mwDriver = referenceSpec.CustomMiddleware.Driver
 	}
 
 	// Load PostAuthCheck hooks
-	for _, mwObj := range referenceSpec.APIDefinition.CustomMiddleware.PostKeyAuth {
+	for _, mwObj := range referenceSpec.CustomMiddleware.PostKeyAuth {
 		if mwObj.Path != "" {
 			// Otto files are specified here
 			mwPaths = append(mwPaths, mwObj.Path)
@@ -521,8 +521,8 @@ func loadCustomMiddleware(referenceSpec *APISpec) ([]string, apidef.MiddlewareDe
 func creeateResponseMiddlewareChain(referenceSpec *APISpec) {
 	// Create the response processors
 
-	responseChain := make([]TykResponseHandler, len(referenceSpec.APIDefinition.ResponseProcessors))
-	for i, processorDetail := range referenceSpec.APIDefinition.ResponseProcessors {
+	responseChain := make([]TykResponseHandler, len(referenceSpec.ResponseProcessors))
+	for i, processorDetail := range referenceSpec.ResponseProcessors {
 		processorType, err := GetResponseProcessorByName(processorDetail.Name)
 		if err != nil {
 			log.WithFields(logrus.Fields{
@@ -599,9 +599,9 @@ func notifyAPILoaded(spec *APISpec) {
 			"user_ip":     "--",
 			"server_name": "--",
 			"user_id":     "--",
-			"org_id":      spec.APIDefinition.OrgID,
-			"api_id":      spec.APIDefinition.APIID,
-		}).Info("Loaded: ", spec.APIDefinition.Name)
+			"org_id":      spec.OrgID,
+			"api_id":      spec.APIID,
+		}).Info("Loaded: ", spec.Name)
 	}
 
 }

--- a/middleware_auth_key.go
+++ b/middleware_auth_key.go
@@ -24,7 +24,7 @@ func (k *AuthKey) New() {}
 
 // GetConfig retrieves the configuration from the API config
 func (k *AuthKey) GetConfig() (interface{}, error) {
-	return k.TykMiddleware.Spec.APIDefinition.Auth, nil
+	return k.TykMiddleware.Spec.Auth, nil
 }
 
 func (k *AuthKey) IsEnabledForSpec() bool { return true }
@@ -44,7 +44,7 @@ func (k *AuthKey) setContextVars(r *http.Request, token string) {
 func (k *AuthKey) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
 	var tempRes *http.Request
 
-	config := k.TykMiddleware.Spec.APIDefinition.Auth
+	config := k.TykMiddleware.Spec.Auth
 
 	key := r.Header.Get(config.AuthHeaderName)
 

--- a/middleware_example_test.go
+++ b/middleware_example_test.go
@@ -31,7 +31,7 @@ func (m *modifiedMiddleware) New() {}
 func (m *modifiedMiddleware) GetConfig() (interface{}, error) {
 	var conf modifiedMiddlewareConfig
 
-	err := mapstructure.Decode(m.TykMiddleware.Spec.APIDefinition.RawData, &conf)
+	err := mapstructure.Decode(m.TykMiddleware.Spec.RawData, &conf)
 	if err != nil {
 		return nil, err
 	}

--- a/middleware_jwt.go
+++ b/middleware_jwt.go
@@ -47,7 +47,7 @@ func (k JWTMiddleware) New() {}
 
 // GetConfig retrieves the configuration from the API config
 func (k *JWTMiddleware) GetConfig() (interface{}, error) {
-	return k.TykMiddleware.Spec.APIDefinition.Auth, nil
+	return k.TykMiddleware.Spec.Auth, nil
 }
 
 func (k *JWTMiddleware) IsEnabledForSpec() bool { return true }
@@ -172,8 +172,8 @@ func (k *JWTMiddleware) getSecret(token *jwt.Token) ([]byte, error) {
 }
 
 func (k *JWTMiddleware) getBasePolicyID(token *jwt.Token) (string, bool) {
-	if k.TykMiddleware.Spec.APIDefinition.JWTPolicyFieldName != "" {
-		basePolicyID, foundPolicy := token.Claims.(jwt.MapClaims)[k.TykMiddleware.Spec.APIDefinition.JWTPolicyFieldName].(string)
+	if k.TykMiddleware.Spec.JWTPolicyFieldName != "" {
+		basePolicyID, foundPolicy := token.Claims.(jwt.MapClaims)[k.TykMiddleware.Spec.JWTPolicyFieldName].(string)
 		if !foundPolicy {
 			log.Error("Could not identify a policy to apply to this token from field!")
 			return "", false
@@ -181,8 +181,8 @@ func (k *JWTMiddleware) getBasePolicyID(token *jwt.Token) (string, bool) {
 
 		return basePolicyID, true
 
-	} else if k.TykMiddleware.Spec.APIDefinition.JWTClientIDBaseField != "" {
-		clientID, clientIDFound := token.Claims.(jwt.MapClaims)[k.TykMiddleware.Spec.APIDefinition.JWTClientIDBaseField].(string)
+	} else if k.TykMiddleware.Spec.JWTClientIDBaseField != "" {
+		clientID, clientIDFound := token.Claims.(jwt.MapClaims)[k.TykMiddleware.Spec.JWTClientIDBaseField].(string)
 		if !clientIDFound {
 			log.Error("Could not identify a policy to apply to this token from field!")
 			return "", false
@@ -209,7 +209,7 @@ func (k *JWTMiddleware) getBasePolicyID(token *jwt.Token) (string, bool) {
 func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token) (error, int) {
 	log.Debug("JWT authority is centralised")
 	// Generate a virtual token
-	baseFieldData, baseFound := token.Claims.(jwt.MapClaims)[k.TykMiddleware.Spec.APIDefinition.JWTIdentityBaseField].(string)
+	baseFieldData, baseFound := token.Claims.(jwt.MapClaims)[k.TykMiddleware.Spec.JWTIdentityBaseField].(string)
 	if !baseFound {
 		log.Warning("Base Field not found, using SUB")
 		var found bool
@@ -241,7 +241,7 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 		}
 
 		newSession, err := generateSessionFromPolicy(basePolicyID,
-			k.TykMiddleware.Spec.APIDefinition.OrgID,
+			k.TykMiddleware.Spec.OrgID,
 			true)
 
 		if err == nil {
@@ -308,7 +308,7 @@ func (k *JWTMiddleware) processOneToOneTokenMap(r *http.Request, token *jwt.Toke
 }
 
 func (k *JWTMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
-	config := k.TykMiddleware.Spec.APIDefinition.Auth
+	config := k.TykMiddleware.Spec.Auth
 	var tykId string
 
 	// Get the token
@@ -393,7 +393,7 @@ func (k *JWTMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, c
 		// Token is valid - let's move on
 
 		// Are we mapping to a central JWT Secret?
-		if k.TykMiddleware.Spec.APIDefinition.JWTSource != "" {
+		if k.TykMiddleware.Spec.JWTSource != "" {
 			return k.processCentralisedJWT(r, token)
 		}
 

--- a/middleware_openid.go
+++ b/middleware_openid.go
@@ -182,7 +182,7 @@ func (k *OpenIDMW) ProcessRequest(w http.ResponseWriter, r *http.Request, config
 
 		// We need a base policy as a template, either get it from the token itself OR a proxy client ID within Tyk
 		newSession, err := generateSessionFromPolicy(policyID,
-			k.TykMiddleware.Spec.APIDefinition.OrgID,
+			k.TykMiddleware.Spec.OrgID,
 			true)
 
 		if err != nil {

--- a/middleware_transform.go
+++ b/middleware_transform.go
@@ -73,8 +73,8 @@ func (t *TransformMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix":      "inbound-transform",
-				"server_name": t.Spec.APIDefinition.Proxy.TargetURL,
-				"api_id":      t.Spec.APIDefinition.APIID,
+				"server_name": t.Spec.Proxy.TargetURL,
+				"api_id":      t.Spec.APIID,
 				"path":        r.URL.Path,
 			}).Error("Error unmarshalling XML: ", err)
 		}
@@ -105,8 +105,8 @@ func (t *TransformMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 	if err = tmeta.Template.Execute(&bodyBuffer, bodyData); err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix":      "inbound-transform",
-			"server_name": t.Spec.APIDefinition.Proxy.TargetURL,
-			"api_id":      t.Spec.APIDefinition.APIID,
+			"server_name": t.Spec.Proxy.TargetURL,
+			"api_id":      t.Spec.APIID,
 			"path":        r.URL.Path,
 		}).Error("Failed to apply template to request: ", err)
 	}

--- a/middleware_virtual_endpoint.go
+++ b/middleware_virtual_endpoint.go
@@ -94,7 +94,7 @@ func (d *VirtualEndpoint) New() {
 func (d *VirtualEndpoint) GetConfig() (interface{}, error) {
 	var moduleConfig VirtualEndpointConfig
 
-	err := mapstructure.Decode(d.TykMiddleware.Spec.APIDefinition.RawData, &moduleConfig)
+	err := mapstructure.Decode(d.TykMiddleware.Spec.RawData, &moduleConfig)
 	if err != nil {
 		log.Error(err)
 		return nil, err

--- a/plugins.go
+++ b/plugins.go
@@ -71,7 +71,7 @@ func (d *DynamicMiddleware) IsEnabledForSpec() bool { return true }
 func (d *DynamicMiddleware) GetConfig() (interface{}, error) {
 	var moduleConfig DynamicMiddlewareConfig
 
-	err := mapstructure.Decode(d.TykMiddleware.Spec.APIDefinition.RawData, &moduleConfig)
+	err := mapstructure.Decode(d.TykMiddleware.Spec.RawData, &moduleConfig)
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "jsvm",

--- a/res_handler_transform.go
+++ b/res_handler_transform.go
@@ -64,8 +64,8 @@ func (rt ResponseTransformMiddleware) HandleResponse(rw http.ResponseWriter, res
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix":      "outbound-transform",
-				"server_name": rt.Spec.APIDefinition.Proxy.TargetURL,
-				"api_id":      rt.Spec.APIDefinition.APIID,
+				"server_name": rt.Spec.Proxy.TargetURL,
+				"api_id":      rt.Spec.APIID,
 				"path":        req.URL.Path,
 			}).Error("Error unmarshalling XML: ", err)
 		}
@@ -80,8 +80,8 @@ func (rt ResponseTransformMiddleware) HandleResponse(rw http.ResponseWriter, res
 	if err = tmeta.Template.Execute(&bodyBuffer, bodyData); err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix":      "outbound-transform",
-			"server_name": rt.Spec.APIDefinition.Proxy.TargetURL,
-			"api_id":      rt.Spec.APIDefinition.APIID,
+			"server_name": rt.Spec.Proxy.TargetURL,
+			"api_id":      rt.Spec.APIID,
 			"path":        req.URL.Path,
 		}).Error("Failed to apply template to request: ", err)
 	}

--- a/tyk_reverse_proxy_clone.go
+++ b/tyk_reverse_proxy_clone.go
@@ -534,8 +534,8 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 			"server_name": outreq.Host,
 			"user_id":     obfuscated,
 			"user_name":   alias,
-			"org_id":      p.TykAPISpec.APIDefinition.OrgID,
-			"api_id":      p.TykAPISpec.APIDefinition.APIID,
+			"org_id":      p.TykAPISpec.OrgID,
+			"api_id":      p.TykAPISpec.APIID,
 		}).Error("http: proxy error: ", err)
 
 		if strings.Contains(err.Error(), "timeout awaiting response headers") {


### PR DESCRIPTION
Since APIDefinition is an embedded field in APISpec, its fields can be
accessed directly.