### PR TITLE
websocket: handle request transmission errors

### DIFF
--- a/handler_websocket.go
+++ b/handler_websocket.go
@@ -98,9 +98,19 @@ func (ws *WSDialer) RoundTrip(req *http.Request) (*http.Response, error) {
 	go cp(d, nc)
 	go cp(nc, d)
 
-	<-errc
+	for i := 0; i < 2; i++ {
+		cerr := <-errc
+		if cerr == nil {
+			continue
+		}
+		err = cerr
+		log.WithFields(logrus.Fields{
+			"path":   req.URL.Path,
+			"origin": GetIPFromRequest(req),
+		}).Errorf("Error transmitting request: %v", err)
+	}
 
-	return nil, nil
+	return nil, err
 }
 
 func IsWebsocket(req *http.Request) bool {


### PR DESCRIPTION
These could be read/write errors, for example. If anything happened,
let's log and record it.

Fixes #471.