### PR TITLE
api: deduplicate API listen paths if necessary (backport)

### DIFF
--- a/api_loader.go
+++ b/api_loader.go
@@ -77,19 +77,6 @@ func skipSpecBecauseInvalid(referenceSpec *APISpec) bool {
 		return true
 	}
 
-	domainHash := generateDomainPath(referenceSpec.Domain, referenceSpec.Proxy.ListenPath)
-	val, listenPathExists := ListenPathMap.Get(domainHash)
-	if listenPathExists {
-		if val.(int) > 1 {
-			log.WithFields(logrus.Fields{
-				"prefix": "main",
-				"org_id": referenceSpec.APIDefinition.OrgID,
-				"api_id": referenceSpec.APIDefinition.APIID,
-			}).Error("Listen path is a duplicate: ", domainHash)
-			return true
-		}
-	}
-
 	return false
 }
 
@@ -147,6 +134,35 @@ func processSpec(referenceSpec *APISpec,
 		}).Warning("Skipped!")
 		thisChainDefinition.Skip = true
 		return &thisChainDefinition
+	}
+
+	pathModified := false
+	for {
+		hash := generateDomainPath(referenceSpec.Domain, referenceSpec.Proxy.ListenPath)
+		if v, e := ListenPathMap.Get(hash); !e || v.(int) < 2 {
+			// not a duplicate
+			break
+		}
+		if !pathModified {
+			prev := (*ApiSpecRegister)[referenceSpec.APIID]
+			if prev != nil && prev.Proxy.ListenPath == referenceSpec.Proxy.ListenPath {
+				// if this APIID was already loaded and
+				// had this listen path, let it keep it.
+				break
+			}
+			referenceSpec.Proxy.ListenPath += "-" + referenceSpec.APIID
+			pathModified = true
+		} else {
+			// keep adding '_' chars
+			referenceSpec.Proxy.ListenPath += "_"
+		}
+	}
+	if pathModified {
+		log.WithFields(logrus.Fields{
+			"prefix": "main",
+			"org_id": referenceSpec.APIDefinition.OrgID,
+			"api_id": referenceSpec.APIDefinition.APIID,
+		}).Error("Listen path collision, changed to ", referenceSpec.Proxy.ListenPath)
 	}
 
 	// Set up LB targets:


### PR DESCRIPTION
First add "-$appid", and keep trying if necessary by adding '_'
characters. Thus, if we have two API definitions with the path "/foo"
and IDs 1 and 2, their paths will end up being "/foo-1" and "/foo-2".

As suggested by Leon, let APIs that were already loaded with unmodified
listen paths keep them without changes. This way, if an API definition
is added with a conflicting listen path by mistake, the existing API it
conflicts with won't suddenly disappear.

Fixes #658.