### PR TITLE
coprocess_python: enforce main OS thread lock when reloading bundles

### DIFF
--- a/coprocess_python.go
+++ b/coprocess_python.go
@@ -171,6 +171,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"unsafe"
 
@@ -212,8 +213,11 @@ func (d *PythonDispatcher) Reload() {
 
 // HandleMiddlewareCache isn't used by Python.
 func (d *PythonDispatcher) HandleMiddlewareCache(b *apidef.BundleManifest, basePath string) {
-	CBundlePath := C.CString(basePath)
-	C.Python_HandleMiddlewareCache(CBundlePath)
+	go func() {
+		runtime.LockOSThread()
+		CBundlePath := C.CString(basePath)
+		C.Python_HandleMiddlewareCache(CBundlePath)
+	}()
 }
 
 // PythonInit initializes the Python interpreter.


### PR DESCRIPTION
This fixes the issue described [here](https://community.tyk.io/t/python-gil-error/1624/4), I thought about making this more general and following this approach on the functions that call `HandleMiddlewareCache` (this is part of the dispatcher interface), however this is specific to the Python runtime.