### PR TITLE
api: simplify reload benchmark

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -727,20 +727,16 @@ const apiBenchDef = `{
 	}
 }`
 
-func BenchmarkApiInsertReload(b *testing.B) {
-	redisStore := &RedisClusterStorageManager{KeyPrefix: "apikey."}
-	healthStore := &RedisClusterStorageManager{KeyPrefix: "apihealth."}
-	orgStore := &RedisClusterStorageManager{KeyPrefix: "orgKey."}
-
+func BenchmarkApiReload(b *testing.B) {
 	specs := make([]*APISpec, 1000)
 	for i := range specs {
 		id := strconv.Itoa(i + 1)
 		def := strings.Replace(apiBenchDef, "REPLACE", id, -1)
 		spec := createDefinitionFromString(def)
-		spec.Init(redisStore, redisStore, healthStore, orgStore)
 		specs[i] = spec
 	}
 
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		newMuxes := mux.NewRouter()
 		loadAPIEndpoints(newMuxes)


### PR DESCRIPTION
No need to set up stores and initialise the specs, since we won't
actually use them.

Also reset the timer, to more accurately get the reload time, not the
initialisation time.

benchstat below shows that the benchmark numbers aren't changed
substantially.

name               old time/op    new time/op    delta
ApiInsertReload-4    61.8ms ± 0%    63.0ms ± 0%   ~     (p=1.000 n=1+1)

name               old alloc/op   new alloc/op   delta
ApiInsertReload-4    28.1MB ± 0%    28.1MB ± 0%   ~     (p=1.000 n=1+1)

name               old allocs/op  new allocs/op  delta
ApiInsertReload-4      390k ± 0%      390k ± 0%   ~     (p=1.000 n=1+1)