### PR TITLE
all: simplify global api spec map usage

### DIFF
--- a/api_definition_test.go
+++ b/api_definition_test.go
@@ -439,7 +439,7 @@ func TestGetAPISpecsDashboardSuccess(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	ApiSpecRegister = make(map[string]*APISpec)
+	apisByID = make(map[string]*APISpec)
 
 	config.UseDBAppConfigs = true
 	config.AllowInsecureConfigs = true
@@ -469,8 +469,8 @@ func TestGetAPISpecsDashboardSuccess(t *testing.T) {
 
 	// Wait for the reload to finish, then check it worked
 	wg.Wait()
-	if len(ApiSpecRegister) != 1 {
-		t.Error("Should return array with one spec", ApiSpecRegister)
+	if len(apisByID) != 1 {
+		t.Error("Should return array with one spec", apisByID)
 	}
 }
 

--- a/api_loader.go
+++ b/api_loader.go
@@ -130,7 +130,7 @@ func processSpec(referenceSpec *APISpec,
 			break
 		}
 		if !pathModified {
-			prev := ApiSpecRegister[referenceSpec.APIID]
+			prev := apisByID[referenceSpec.APIID]
 			if prev != nil && prev.Proxy.ListenPath == referenceSpec.Proxy.ListenPath {
 				// if this APIID was already loaded and
 				// had this listen path, let it keep it.
@@ -619,7 +619,7 @@ func loadApps(apiSpecs []*APISpec, muxer *mux.Router) {
 	muxer.HandleFunc("/hello", pingTest)
 
 	// Swap in the new register
-	ApiSpecRegister = tmpSpecRegister
+	apisByID = tmpSpecRegister
 
 	log.Debug("Checker host list")
 

--- a/api_test.go
+++ b/api_test.go
@@ -208,45 +208,45 @@ func TestApiHandlerPostDupPath(t *testing.T) {
 	var s2, s3 *APISpec
 
 	// both dups added at the same time
-	ApiSpecRegister = nil
+	apisByID = nil
 	loadApps(specs(), discardMuxer)
 
-	s2 = ApiSpecRegister["2"]
+	s2 = apisByID["2"]
 	if want, got := "/v1-2", s2.Proxy.ListenPath; want != got {
 		t.Errorf("API spec %s want path %s, got %s", "2", want, got)
 	}
-	s3 = ApiSpecRegister["3"]
+	s3 = apisByID["3"]
 	if want, got := "/v1-3", s3.Proxy.ListenPath; want != got {
 		t.Errorf("API spec %s want path %s, got %s", "3", want, got)
 	}
 
 	// one dup was there first, gets to keep its path. apiids are
 	// not used to mandate priority. survives multiple reloads too.
-	ApiSpecRegister = nil
+	apisByID = nil
 	loadApps(specs()[1:], discardMuxer)
 	loadApps(specs(), discardMuxer)
 	loadApps(specs(), discardMuxer)
 
-	s2 = ApiSpecRegister["2"]
+	s2 = apisByID["2"]
 	if want, got := "/v1-2", s2.Proxy.ListenPath; want != got {
 		t.Errorf("API spec %s want path %s, got %s", "2", want, got)
 	}
-	s3 = ApiSpecRegister["3"]
+	s3 = apisByID["3"]
 	if want, got := "/v1", s3.Proxy.ListenPath; want != got {
 		t.Errorf("API spec %s want path %s, got %s", "3", want, got)
 	}
 
 	// both dups were there first, neither gets to keep its original
 	// path.
-	ApiSpecRegister = nil
+	apisByID = nil
 	loadApps(specs(), discardMuxer)
 	loadApps(specs(), discardMuxer)
 
-	s2 = ApiSpecRegister["2"]
+	s2 = apisByID["2"]
 	if want, got := "/v1-2", s2.Proxy.ListenPath; want != got {
 		t.Errorf("API spec %s want path %s, got %s", "2", want, got)
 	}
-	s3 = ApiSpecRegister["3"]
+	s3 = apisByID["3"]
 	if want, got := "/v1-3", s3.Proxy.ListenPath; want != got {
 		t.Errorf("API spec %s want path %s, got %s", "3", want, got)
 	}
@@ -555,20 +555,20 @@ func TestGetOAuthClients(t *testing.T) {
 		t.Fatal("Retrieving OAuth clients from nonexistent APIs must return error.")
 	}
 
-	ApiSpecRegister = make(map[string]*APISpec)
-	ApiSpecRegister[testAPIID] = &APISpec{}
+	apisByID = make(map[string]*APISpec)
+	apisByID[testAPIID] = &APISpec{}
 
 	_, responseCode = getOauthClients(testAPIID)
 	if responseCode != 400 {
 		t.Fatal("Retrieving OAuth clients from APIs with no OAuthManager must return an error.")
 	}
 
-	ApiSpecRegister = nil
+	apisByID = nil
 }
 
 func TestResetHandler(t *testing.T) {
 	uri := "/tyk/reload/"
-	ApiSpecRegister = make(map[string]*APISpec)
+	apisByID = make(map[string]*APISpec)
 
 	makeSampleAPI(t, apiTestDef)
 	recorder := httptest.NewRecorder()
@@ -587,7 +587,7 @@ func TestResetHandler(t *testing.T) {
 	reloadTick <- time.Time{}
 	wg.Wait()
 
-	if len(ApiSpecRegister) == 0 {
+	if len(apisByID) == 0 {
 		t.Fatal("Hot reload was triggered but no APIs were found.")
 	}
 }
@@ -622,7 +622,7 @@ func TestGroupResetHandler(t *testing.T) {
 
 	uri := "/tyk/reload/group"
 
-	ApiSpecRegister = make(map[string]*APISpec)
+	apisByID = make(map[string]*APISpec)
 
 	makeSampleAPI(t, apiTestDef)
 
@@ -642,7 +642,7 @@ func TestGroupResetHandler(t *testing.T) {
 		t.Fatal("Hot reload (group) failed, response code was: ", recorder.Code)
 	}
 
-	if len(ApiSpecRegister) == 0 {
+	if len(apisByID) == 0 {
 		t.Fatal("Hot reload (group) was triggered but no APIs were found.")
 	}
 

--- a/host_checker_manager.go
+++ b/host_checker_manager.go
@@ -204,7 +204,7 @@ func (hc *HostCheckerManager) OnHostDown(report HostHealthReport) {
 	}).Debug("Update key: ", hc.getHostKey(report))
 	hc.store.SetKey(hc.getHostKey(report), "1", int64(hc.checker.checkTimeout+1))
 
-	spec, found := ApiSpecRegister[report.MetaData[UnHealthyHostMetaDataAPIKey]]
+	spec, found := apisByID[report.MetaData[UnHealthyHostMetaDataAPIKey]]
 	if !found {
 		log.WithFields(logrus.Fields{
 			"prefix": "host-check-mgr",
@@ -247,7 +247,7 @@ func (hc *HostCheckerManager) OnHostBackUp(report HostHealthReport) {
 	}).Debug("Delete key: ", hc.getHostKey(report))
 	hc.store.DeleteKey(hc.getHostKey(report))
 
-	spec, found := ApiSpecRegister[report.MetaData[UnHealthyHostMetaDataAPIKey]]
+	spec, found := apisByID[report.MetaData[UnHealthyHostMetaDataAPIKey]]
 	if !found {
 		log.WithFields(logrus.Fields{
 			"prefix": "host-check-mgr",
@@ -370,7 +370,7 @@ func (hc *HostCheckerManager) UpdateTrackingListByAPIID(hd []HostData, apiId str
 }
 
 func (hc *HostCheckerManager) GetListFromService(apiID string) ([]HostData, error) {
-	spec, found := ApiSpecRegister[apiID]
+	spec, found := apisByID[apiID]
 	if !found {
 		return nil, errors.New("API ID not found in register")
 	}
@@ -431,7 +431,7 @@ func (hc *HostCheckerManager) DoServiceDiscoveryListUpdateForID(apiID string) {
 func (hc *HostCheckerManager) RecordUptimeAnalytics(report HostHealthReport) error {
 	// If we are obfuscating API Keys, store the hashed representation (config check handled in hashing function)
 
-	spec, found := ApiSpecRegister[report.MetaData[UnHealthyHostMetaDataAPIKey]]
+	spec, found := apisByID[report.MetaData[UnHealthyHostMetaDataAPIKey]]
 	orgID := ""
 	if found {
 		orgID = spec.OrgID
@@ -499,7 +499,7 @@ func SetCheckerHostList() {
 		"prefix": "host-check-mgr",
 	}).Info("Loading uptime tests...")
 	hostList := []HostData{}
-	for _, spec := range ApiSpecRegister {
+	for _, spec := range apisByID {
 		if spec.UptimeTests.Config.ServiceDiscovery.UseDiscoveryService {
 			hostList, err := GlobalHostChecker.GetListFromService(spec.APIID)
 			if err == nil {

--- a/host_checker_test.go
+++ b/host_checker_test.go
@@ -93,10 +93,10 @@ func TestHostChecker(t *testing.T) {
 		"HostDown": {&testEventHandler{cb}},
 	}
 
-	ApiSpecRegister = map[string]*APISpec{spec.APIID: spec}
+	apisByID = map[string]*APISpec{spec.APIID: spec}
 	GlobalHostChecker.checker.sampleTriggerLimit = 1
 	defer func() {
-		ApiSpecRegister = make(map[string]*APISpec)
+		apisByID = make(map[string]*APISpec)
 		GlobalHostChecker.checker.sampleTriggerLimit = defaultSampletTriggerLimit
 	}()
 

--- a/main.go
+++ b/main.go
@@ -53,8 +53,8 @@ var (
 	RPCListener              RPCStorageHandler
 	DashService              DashboardServiceSender
 
-	ApiSpecRegister map[string]*APISpec
-	keyGen          DefaultKeyGenerator
+	apisByID map[string]*APISpec
+	keyGen   DefaultKeyGenerator
 
 	mainRouter    *mux.Router
 	defaultRouter *mux.Router

--- a/oauth_manager_test.go
+++ b/oauth_manager_test.go
@@ -472,7 +472,7 @@ func TestOAuthAPIRefreshInvalidate(t *testing.T) {
 	} else {
 		if newSuccess.Status != "ok" {
 			t.Error("key not deleted, status error:\n", recorder.Body.String())
-			t.Error(ApiSpecRegister)
+			t.Error(apisByID)
 		}
 		if newSuccess.Action != "deleted" {
 			t.Error("Response is incorrect - action is not 'deleted' :\n", recorder.Body.String())


### PR DESCRIPTION
Unexport the map and use a better name to reflect that the key is the
API ID.

There's also no need for a wrapper func. One can read from a nil map
just fine, and the result will be nil just like in our old code.