### PR TITLE
hc: deflake test by controlling the sleep ticker

### DIFF
--- a/host_checker.go
+++ b/host_checker.go
@@ -16,7 +16,11 @@ const (
 	defaultSampletTriggerLimit = 3
 )
 
-var HostCheckerClient = &http.Client{Timeout: 500 * time.Millisecond}
+var (
+	HostCheckerClient = &http.Client{Timeout: 500 * time.Millisecond}
+
+	hostCheckTicker = make(chan struct{})
+)
 
 type HostData struct {
 	CheckURL string
@@ -84,7 +88,11 @@ func (h *HostUptimeChecker) HostCheckLoop() {
 			}
 		}
 
-		time.Sleep(h.getStaggeredTime())
+		if runningTests {
+			<-hostCheckTicker
+		} else {
+			time.Sleep(h.getStaggeredTime())
+		}
 	}
 	log.Info("[HOST CHECKER] Checker stopped")
 }

--- a/host_checker_test.go
+++ b/host_checker_test.go
@@ -85,6 +85,8 @@ func TestHostChecker(t *testing.T) {
 	spec.Proxy.StructuredTargetList = sl
 
 	var wg sync.WaitGroup
+	// Should receive one HostDown event
+	wg.Add(1)
 	cb := func(em EventMessage) {
 		wg.Done()
 	}
@@ -109,13 +111,7 @@ func TestHostChecker(t *testing.T) {
 		t.Error("Should update host checker check list")
 	}
 
-	// Should receive one HostDown event
-	wg.Add(1)
-	for _, hostData := range GlobalHostChecker.checker.newList {
-		// By default host check should fail > 3 times in row
-		GlobalHostChecker.checker.CheckHost(hostData)
-	}
-
+	hostCheckTicker <- struct{}{}
 	wg.Wait()
 
 	if GlobalHostChecker.IsHostDown(testHttpAny) {
@@ -133,7 +129,7 @@ func TestHostChecker(t *testing.T) {
 		t.Error("Should return only active host", host1, host2)
 	}
 
-	if GlobalHostChecker.checker.checkTimeout != 10 {
+	if GlobalHostChecker.checker.checkTimeout != defaultTimeout {
 		t.Error("Should set defaults", GlobalHostChecker.checker.checkTimeout)
 	}
 


### PR DESCRIPTION
First, don't rely on time.Sleep in the tests. If the machine is slow
enough, even a timeout of seconds can finish and make our tests fail as
we've seen in the "sync: negative WaitGroup counter" panic on Travis.

Second, don't run CheckHost manually. That defies the purpose of using
the GlobalHostChecker altogether. We're not really testing that it works
if we just use its checker directly, completely bypassing its worker
pool and all its surrounding logic.

With the use of a ticker, the test still takes no time as there is zero
sleep:

	--- PASS: TestHostChecker (0.01s)

Fixes #770.