### PR TITLE
api: use x-tyk-api-expires to inform on API expiry

### DIFF
--- a/middleware_version_check.go
+++ b/middleware_version_check.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/TykTechnologies/tyk/apidef"
 )
@@ -61,6 +62,10 @@ func (v *VersionCheck) ProcessRequest(w http.ResponseWriter, r *http.Request, co
 	if stat == StatusRedirectFlowByReply {
 		v.DoMockReply(w, meta)
 		return nil, 666
+	}
+
+	if expTime, _ := meta.(*time.Time); expTime != nil {
+		w.Header().Set("x-tyk-api-expires", expTime.Format(time.RFC1123))
 	}
 
 	if stat == StatusOkAndIgnore {

--- a/middleware_version_check_test.go
+++ b/middleware_version_check_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestVersionMwExpiresHeader(t *testing.T) {
+	spec := createSpecTest(t, nonExpiringDef)
+	loadApps([]*APISpec{spec}, discardMuxer)
+
+	session := createNonThrottledSession()
+	spec.SessionManager.UpdateSession("1234xyz", session, 60)
+
+	recorder := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/v1/ignored/noregex", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.RemoteAddr = "127.0.0.1:80"
+	req.Header.Add("authorization", "1234xyz")
+	req.Header.Add("version", "v1")
+
+	chain := getChain(spec)
+	chain.ServeHTTP(recorder, req)
+
+	if recorder.Code != 200 {
+		t.Error("Invalid response code, should be 200: ", recorder.Code)
+	}
+
+	want := "Thu, 02 Jan 3000 15:04:00 UTC"
+	if got := recorder.Result().Header.Get("x-tyk-api-expires"); got != want {
+		t.Errorf("expires header want %q, got %q", want, got)
+	}
+}


### PR DESCRIPTION
If a request matched a version within an API definition, and it wasn't
expired, this adds a header informing the user of what the expiration
date will be.

Use the RFC1123 format, as the HTTP/1.1 spec says that headers should
be written with dates in that format only.

Fixes #437.