### PR TITLE
all: remove two params that are just constants

### DIFF
--- a/api.go
+++ b/api.go
@@ -737,7 +737,7 @@ func orgHandler(w http.ResponseWriter, r *http.Request) {
 			obj, code = handleGetOrgDetail(keyName)
 		} else {
 			// Return list of keys
-			obj, code = handleGetAllOrgKeys(filter, "")
+			obj, code = handleGetAllOrgKeys(filter)
 		}
 
 	case "DELETE":
@@ -832,8 +832,8 @@ func handleGetOrgDetail(orgID string) (interface{}, int) {
 	return session, 200
 }
 
-func handleGetAllOrgKeys(filter, orgID string) (interface{}, int) {
-	spec := GetSpecForOrg(orgID)
+func handleGetAllOrgKeys(filter string) (interface{}, int) {
+	spec := GetSpecForOrg("")
 	if spec == nil {
 		return apiError("ORG not found"), 404
 	}

--- a/main.go
+++ b/main.go
@@ -989,14 +989,14 @@ func main() {
 
 	if goAgainErr != nil {
 		var err error
-		if l, err = generateListener("", 0); err != nil {
+		if l, err = generateListener(0); err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "main",
 			}).Fatalf("Error starting listener: %s", err)
 		}
 
 		if config.ControlAPIPort > 0 {
-			if controlListener, err = generateListener("", config.ControlAPIPort); err != nil {
+			if controlListener, err = generateListener(config.ControlAPIPort); err != nil {
 				log.WithFields(logrus.Fields{
 					"prefix": "main",
 				}).Fatalf("Error starting control API listener: %s", err)
@@ -1123,10 +1123,8 @@ func start(arguments map[string]interface{}) {
 	go reloadLoop(time.Tick(time.Second))
 }
 
-func generateListener(listenAddress string, listenPort int) (net.Listener, error) {
-	if listenAddress == "" {
-		listenAddress = config.ListenAddress
-	}
+func generateListener(listenPort int) (net.Listener, error) {
+	listenAddress := config.ListenAddress
 	if listenPort == 0 {
 		listenPort = config.ListenPort
 	}

--- a/rpc_backup_handlers.go
+++ b/rpc_backup_handlers.go
@@ -117,7 +117,7 @@ func doLoadWithBackup(specs []*APISpec) {
 	log.Warning("[RPC Backup] --> Ready to listen")
 	RPC_EmergencyModeLoaded = true
 
-	l, err := generateListener("", 0)
+	l, err := generateListener(0)
 	if err != nil {
 		log.Error("Failed to generate listener:", err)
 	}


### PR DESCRIPTION
handleGetAllOrgKeys always gets "" as orgID. Likewise, generateListener
always gets "" as listenAddress.