### PR TITLE
api: replace some erroneous 403 status codes

### DIFF
--- a/api.go
+++ b/api.go
@@ -954,7 +954,7 @@ func createKeyHandler(w http.ResponseWriter, r *http.Request) {
 				}
 				err := apiSpec.SessionManager.UpdateSession(newKey, newSession, getLifetime(apiSpec, newSession))
 				if err != nil {
-					doJSONWrite(w, 403, apiError("Failed to create key - "+err.Error()))
+					doJSONWrite(w, 500, apiError("Failed to create key - "+err.Error()))
 					return
 				}
 			} else {
@@ -964,7 +964,7 @@ func createKeyHandler(w http.ResponseWriter, r *http.Request) {
 				sessionManager.ResetQuota(newKey, newSession)
 				err := sessionManager.UpdateSession(newKey, newSession, -1)
 				if err != nil {
-					doJSONWrite(w, 403, apiError("Failed to create key - "+err.Error()))
+					doJSONWrite(w, 500, apiError("Failed to create key - "+err.Error()))
 					return
 				}
 			}
@@ -992,7 +992,7 @@ func createKeyHandler(w http.ResponseWriter, r *http.Request) {
 				}
 				err := spec.SessionManager.UpdateSession(newKey, newSession, getLifetime(spec, newSession))
 				if err != nil {
-					doJSONWrite(w, 403, apiError("Failed to create key - "+err.Error()))
+					doJSONWrite(w, 500, apiError("Failed to create key - "+err.Error()))
 					return
 				}
 			}
@@ -1009,7 +1009,7 @@ func createKeyHandler(w http.ResponseWriter, r *http.Request) {
 				"server_name": "system",
 			}).Error("Master keys disallowed in configuration, key not added.")
 
-			doJSONWrite(w, 403, apiError("Failed to create key, keys must have at least one Access Rights record set."))
+			doJSONWrite(w, 400, apiError("Failed to create key, keys must have at least one Access Rights record set."))
 			return
 		}
 

--- a/middleware_jwt.go
+++ b/middleware_jwt.go
@@ -290,7 +290,7 @@ func (k *JWTMiddleware) processOneToOneTokenMap(r *http.Request, token *jwt.Toke
 
 	if !found {
 		k.reportLoginFailure(tykId, r)
-		return errors.New("Key id not found"), 403
+		return errors.New("Key id not found"), 404
 	}
 
 	log.Debug("Using raw key ID: ", tykId)

--- a/middleware_key_expired_check.go
+++ b/middleware_key_expired_check.go
@@ -30,7 +30,7 @@ func (k *KeyExpired) IsEnabledForSpec() bool { return true }
 func (k *KeyExpired) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
 	session := ctxGetSession(r)
 	if session == nil {
-		return errors.New("Session state is missing or unset! Please make sure that auth headers are properly applied"), 403
+		return errors.New("Session state is missing or unset! Please make sure that auth headers are properly applied"), 400
 	}
 
 	token := ctxGetAuthToken(r)
@@ -75,7 +75,7 @@ func (k *KeyExpired) ProcessRequest(w http.ResponseWriter, r *http.Request, conf
 		// Report in health check
 		ReportHealthCheckValue(k.Spec.Health, KeyFailure, "-1")
 
-		return errors.New("Key has expired, please renew"), 403
+		return errors.New("Key has expired, please renew"), 401
 	}
 
 	return nil, 200


### PR DESCRIPTION
* If the DB failed, that's a 500 (internal server error)
* If the session/key was wrong/missing, that's a 400 (bad request)
* If something was not found, that's a 404 (not found)
* If a key/token expired, that's a 401 (unauthorized, not logged in)

Note that there is nothing to fix in the oauth2 module in this manner,
as status codes are handled entirely in the osin library. That library
only allows for one OK and one error status code, which are 200 and 403
(as configured in main.go). Which is correct, as in the oauth2 scenario
the user is always logged in.