### PR TITLE
api: use a named constant for the special code 666

### DIFF
--- a/coprocess.go
+++ b/coprocess.go
@@ -296,7 +296,7 @@ func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 		}
 		w.WriteHeader(int(returnObject.Request.ReturnOverrides.ResponseCode))
 		w.Write([]byte(returnObject.Request.ReturnOverrides.ResponseError))
-		return nil, 666
+		return nil, mwStatusRespond
 	}
 
 	// Is this a CP authentication middleware?

--- a/middleware.go
+++ b/middleware.go
@@ -11,6 +11,8 @@ import (
 	"github.com/paulbellamy/ratecounter"
 )
 
+const mwStatusRespond = 666
+
 var GlobalRate = ratecounter.NewRateCounter(1 * time.Second)
 
 type TykMiddlewareImplementation interface {
@@ -77,18 +79,8 @@ func CreateMiddleware(mw TykMiddlewareImplementation, tykMwSuper *TykMiddleware)
 				return
 			}
 
-			// Special code, stops execution
-			if errCode == 1666 {
-				// Stop
-				log.Info("[Middleware] Received stop code")
-				meta["stopped"] = "1"
-				job.TimingKv("exec_time", time.Since(startTime).Nanoseconds(), meta)
-				job.TimingKv(eventName+".exec_time", time.Since(startTime).Nanoseconds(), meta)
-				return
-			}
-
 			// Special code, bypasses all other execution
-			if errCode != 666 {
+			if errCode != mwStatusRespond {
 				// No error, carry on...
 				meta["bypass"] = "1"
 				h.ServeHTTP(w, r)

--- a/middleware_redis_cache.go
+++ b/middleware_redis_cache.go
@@ -225,7 +225,7 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 			go m.CacheStore.SetKey(key, toStore, cacheTTL)
 
 		}
-		return nil, 666
+		return nil, mwStatusRespond
 
 	}
 
@@ -272,5 +272,5 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 	}
 
 	// Stop any further execution
-	return nil, 666
+	return nil, mwStatusRespond
 }

--- a/middleware_version_check.go
+++ b/middleware_version_check.go
@@ -61,7 +61,7 @@ func (v *VersionCheck) ProcessRequest(w http.ResponseWriter, r *http.Request, co
 	// We handle redirects before ignores in case we aren't using a whitelist
 	if stat == StatusRedirectFlowByReply {
 		v.DoMockReply(w, meta)
-		return nil, 666
+		return nil, mwStatusRespond
 	}
 
 	if expTime, _ := meta.(*time.Time); expTime != nil {
@@ -70,7 +70,7 @@ func (v *VersionCheck) ProcessRequest(w http.ResponseWriter, r *http.Request, co
 
 	if stat == StatusOkAndIgnore {
 		v.sh.ServeHTTP(w, r)
-		return nil, 666
+		return nil, mwStatusRespond
 	}
 
 	return nil, 200

--- a/middleware_virtual_endpoint.go
+++ b/middleware_virtual_endpoint.go
@@ -273,7 +273,7 @@ func (d *VirtualEndpoint) ProcessRequest(w http.ResponseWriter, r *http.Request,
 		return nil, 200
 	}
 
-	return nil, 666
+	return nil, mwStatusRespond
 }
 
 func (d *VirtualEndpoint) HandleResponse(rw http.ResponseWriter, res *http.Response, ses *SessionState) error {


### PR DESCRIPTION
Also remove handling of the special code 1666, which has never been
used.

Fixes #764.