### PR TITLE
mw: remove copy-pasted boilerplate

### DIFF
--- a/coprocess.go
+++ b/coprocess.go
@@ -3,8 +3,6 @@
 package main
 
 import (
-	"github.com/mitchellh/mapstructure"
-
 	"github.com/Sirupsen/logrus"
 
 	"github.com/TykTechnologies/tyk/apidef"
@@ -158,29 +156,6 @@ func CoProcessInit() error {
 		EnableCoProcess = true
 	}
 	return err
-}
-
-// CoProcessMiddlewareConfig holds the middleware configuration.
-type CoProcessMiddlewareConfig struct {
-	ConfigData map[string]string `mapstructure:"config_data" bson:"config_data" json:"config_data"`
-}
-
-// New lets you do any initialisations for the object can be done here
-func (m *CoProcessMiddleware) New() {}
-
-// GetConfig retrieves the configuration from the API config - we user mapstructure for this for simplicity
-func (m *CoProcessMiddleware) GetConfig() (interface{}, error) {
-	var moduleConfig CoProcessMiddlewareConfig
-
-	err := mapstructure.Decode(m.Spec.RawData, &moduleConfig)
-	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "jsvm",
-		}).Error(err)
-		return nil, err
-	}
-
-	return moduleConfig, nil
 }
 
 // IsEnabledForSpec checks if this middleware should be enabled for a given API.

--- a/coprocess_dummy.go
+++ b/coprocess_dummy.go
@@ -38,11 +38,7 @@ func (m *CoProcessMiddleware) GetName() string {
 	return "CoProcessMiddlewareDummy"
 }
 
-func (m *CoProcessMiddleware) New()                   {}
 func (m *CoProcessMiddleware) IsEnabledForSpec() bool { return false }
-func (m *CoProcessMiddleware) GetConfig() (interface{}, error) {
-	return nil, nil
-}
 func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
 	return nil, 200
 }

--- a/handler_success.go
+++ b/handler_success.go
@@ -45,6 +45,14 @@ type TykMiddleware struct {
 	Proxy ReturningHttpHandler
 }
 
+func (t *TykMiddleware) New() {}
+func (t *TykMiddleware) IsEnabledForSpec() bool {
+	return true
+}
+func (t *TykMiddleware) GetConfig() (interface{}, error) {
+	return nil, nil
+}
+
 func (t *TykMiddleware) GetOrgSession(key string) (SessionState, bool) {
 	// Try and get the session from the session store
 	session, found := t.Spec.OrgSessionManager.GetSessionDetail(key)

--- a/middleware.go
+++ b/middleware.go
@@ -106,24 +106,24 @@ func AppendMiddleware(chain *[]alice.Constructor, mw TykMiddlewareImplementation
 	}
 }
 
-func CheckCBEnabled(tykMwSuper *TykMiddleware) (used bool) {
+func CheckCBEnabled(tykMwSuper *TykMiddleware) bool {
 	for _, v := range tykMwSuper.Spec.VersionData.Versions {
 		if len(v.ExtendedPaths.CircuitBreaker) > 0 {
-			used = true
 			tykMwSuper.Spec.CircuitBreakerEnabled = true
+			return true
 		}
 	}
-	return
+	return false
 }
 
-func CheckETEnabled(tykMwSuper *TykMiddleware) (used bool) {
+func CheckETEnabled(tykMwSuper *TykMiddleware) bool {
 	for _, v := range tykMwSuper.Spec.VersionData.Versions {
 		if len(v.ExtendedPaths.HardTimeouts) > 0 {
-			used = true
 			tykMwSuper.Spec.EnforcedTimeoutEnabled = true
+			return true
 		}
 	}
-	return
+	return false
 }
 
 type TykResponseHandler interface {

--- a/middleware_access_rights.go
+++ b/middleware_access_rights.go
@@ -18,16 +18,6 @@ func (a *AccessRightsCheck) GetName() string {
 	return "AccessRightsCheck"
 }
 
-// New lets you do any initialisations for the object can be done here
-func (a *AccessRightsCheck) New() {}
-
-// GetConfig retrieves the configuration from the API config - we user mapstructure for this for simplicity
-func (a *AccessRightsCheck) GetConfig() (interface{}, error) {
-	return nil, nil
-}
-
-func (a *AccessRightsCheck) IsEnabledForSpec() bool { return true }
-
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (a *AccessRightsCheck) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
 	accessingVersion := a.Spec.getVersionFromRequest(r)

--- a/middleware_auth_key.go
+++ b/middleware_auth_key.go
@@ -20,15 +20,6 @@ func (k *AuthKey) GetName() string {
 	return "AuthKey"
 }
 
-func (k *AuthKey) New() {}
-
-// GetConfig retrieves the configuration from the API config
-func (k *AuthKey) GetConfig() (interface{}, error) {
-	return k.Spec.Auth, nil
-}
-
-func (k *AuthKey) IsEnabledForSpec() bool { return true }
-
 func (k *AuthKey) setContextVars(r *http.Request, token string) {
 	// Flatten claims and add to context
 	if !k.Spec.EnableContextVars {

--- a/middleware_basic_auth.go
+++ b/middleware_basic_auth.go
@@ -21,16 +21,6 @@ func (k *BasicAuthKeyIsValid) GetName() string {
 	return "BasicAuthKeyIsValid"
 }
 
-// New lets you do any initialisations for the object can be done here
-func (k *BasicAuthKeyIsValid) New() {}
-
-// GetConfig retrieves the configuration from the API config - we user mapstructure for this for simplicity
-func (k *BasicAuthKeyIsValid) GetConfig() (interface{}, error) {
-	return nil, nil
-}
-
-func (k *BasicAuthKeyIsValid) IsEnabledForSpec() bool { return true }
-
 // requestForBasicAuth sends error code and message along with WWW-Authenticate header to client.
 func (k *BasicAuthKeyIsValid) requestForBasicAuth(w http.ResponseWriter, msg string) (error, int) {
 	authReply := "Basic realm=\"" + k.Spec.Name + "\""

--- a/middleware_context_vars.go
+++ b/middleware_context_vars.go
@@ -11,19 +11,8 @@ type MiddlewareContextVars struct {
 	*TykMiddleware
 }
 
-type MiddlewareContextVarsConfig struct{}
-
-// New lets you do any initialisations for the object can be done here
-func (m *MiddlewareContextVars) New() {}
-
 func (m *MiddlewareContextVars) GetName() string {
 	return "MiddlewareContextVars"
-}
-
-// GetConfig retrieves the configuration from the API config - we user mapstructure for this for simplicity
-func (m *MiddlewareContextVars) GetConfig() (interface{}, error) {
-	var moduleConfig MiddlewareContextVarsConfig
-	return moduleConfig, nil
 }
 
 func (m *MiddlewareContextVars) IsEnabledForSpec() bool {

--- a/middleware_granular_access.go
+++ b/middleware_granular_access.go
@@ -13,18 +13,9 @@ type GranularAccessMiddleware struct {
 	*TykMiddleware
 }
 
-func (m *GranularAccessMiddleware) New() {}
-
 func (m *GranularAccessMiddleware) GetName() string {
 	return "GranularAccessMiddleware"
 }
-
-// GetConfig retrieves the configuration from the API config - we user mapstructure for this for simplicity
-func (m *GranularAccessMiddleware) GetConfig() (interface{}, error) {
-	return nil, nil
-}
-
-func (m *GranularAccessMiddleware) IsEnabledForSpec() bool { return true }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (m *GranularAccessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {

--- a/middleware_hmac.go
+++ b/middleware_hmac.go
@@ -30,16 +30,8 @@ func (hm *HMACMiddleware) GetName() string {
 	return "HMAC"
 }
 
-// New lets you do any initializations for the object can be done here
 func (hm *HMACMiddleware) New() {
 	hm.lowercasePattern = regexp.MustCompile(`%[a-f0-9][a-f0-9]`)
-}
-
-func (hm *HMACMiddleware) IsEnabledForSpec() bool { return true }
-
-// GetConfig retrieves the configuration from the API config - we user mapstructure for this for simplicity
-func (hm *HMACMiddleware) GetConfig() (interface{}, error) {
-	return nil, nil
 }
 
 func (hm *HMACMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {

--- a/middleware_ip_whitelist.go
+++ b/middleware_ip_whitelist.go
@@ -15,14 +15,6 @@ func (i *IPWhiteListMiddleware) GetName() string {
 	return "IPWhiteListMiddleware"
 }
 
-// New lets you do any initialisations for the object can be done here
-func (i *IPWhiteListMiddleware) New() {}
-
-// GetConfig retrieves the configuration from the API config - we user mapstructure for this for simplicity
-func (i *IPWhiteListMiddleware) GetConfig() (interface{}, error) {
-	return nil, nil
-}
-
 func (i *IPWhiteListMiddleware) IsEnabledForSpec() bool {
 	if !i.Spec.EnableIpWhiteListing {
 		return false

--- a/middleware_ip_whitelist.go
+++ b/middleware_ip_whitelist.go
@@ -16,15 +16,7 @@ func (i *IPWhiteListMiddleware) GetName() string {
 }
 
 func (i *IPWhiteListMiddleware) IsEnabledForSpec() bool {
-	if !i.Spec.EnableIpWhiteListing {
-		return false
-	}
-
-	if len(i.Spec.AllowedIPs) == 0 {
-		return false
-	}
-
-	return true
+	return i.Spec.EnableIpWhiteListing && len(i.Spec.AllowedIPs) > 0
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail

--- a/middleware_jwt.go
+++ b/middleware_jwt.go
@@ -43,15 +43,6 @@ type JWKs struct {
 	Keys []JWK `json:"keys"`
 }
 
-func (k JWTMiddleware) New() {}
-
-// GetConfig retrieves the configuration from the API config
-func (k *JWTMiddleware) GetConfig() (interface{}, error) {
-	return k.Spec.Auth, nil
-}
-
-func (k *JWTMiddleware) IsEnabledForSpec() bool { return true }
-
 func (k *JWTMiddleware) getSecretFromURL(url, kid, keyType string) ([]byte, error) {
 	// Implement a cache
 	if JWKCache == nil {

--- a/middleware_key_expired_check.go
+++ b/middleware_key_expired_check.go
@@ -12,19 +12,9 @@ type KeyExpired struct {
 	*TykMiddleware
 }
 
-// New lets you do any initialisations for the object can be done here
-func (k *KeyExpired) New() {}
-
 func (k *KeyExpired) GetName() string {
 	return "KeyExpired"
 }
-
-// GetConfig retrieves the configuration from the API config - Not used for this middleware
-func (k *KeyExpired) GetConfig() (interface{}, error) {
-	return nil, nil
-}
-
-func (k *KeyExpired) IsEnabledForSpec() bool { return true }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (k *KeyExpired) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {

--- a/middleware_method_transform.go
+++ b/middleware_method_transform.go
@@ -18,15 +18,12 @@ func (t *TransformMethod) GetName() string {
 }
 
 func (t *TransformMethod) IsEnabledForSpec() bool {
-	var used bool
 	for _, version := range t.Spec.VersionData.Versions {
 		if len(version.ExtendedPaths.MethodTransforms) > 0 {
-			used = true
-			break
+			return true
 		}
 	}
-
-	return used
+	return false
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail

--- a/middleware_method_transform.go
+++ b/middleware_method_transform.go
@@ -17,14 +17,6 @@ func (t *TransformMethod) GetName() string {
 	return "TransformMethod"
 }
 
-// New lets you do any initialisations for the object can be done here
-func (t *TransformMethod) New() {}
-
-// GetConfig retrieves the configuration from the API config - we user mapstructure for this for simplicity
-func (t *TransformMethod) GetConfig() (interface{}, error) {
-	return nil, nil
-}
-
 func (t *TransformMethod) IsEnabledForSpec() bool {
 	var used bool
 	for _, version := range t.Spec.VersionData.Versions {

--- a/middleware_modify_headers.go
+++ b/middleware_modify_headers.go
@@ -21,14 +21,6 @@ func (t *TransformHeaders) GetName() string {
 	return "TransformHeaders"
 }
 
-// New lets you do any initialisations for the object can be done here
-func (t *TransformHeaders) New() {}
-
-// GetConfig retrieves the configuration from the API config - we user mapstructure for this for simplicity
-func (t *TransformHeaders) GetConfig() (interface{}, error) {
-	return nil, nil
-}
-
 func (t *TransformHeaders) IsEnabledForSpec() bool {
 	var used bool
 	for _, version := range t.Spec.VersionData.Versions {

--- a/middleware_modify_headers.go
+++ b/middleware_modify_headers.go
@@ -22,17 +22,14 @@ func (t *TransformHeaders) GetName() string {
 }
 
 func (t *TransformHeaders) IsEnabledForSpec() bool {
-	var used bool
 	for _, version := range t.Spec.VersionData.Versions {
 		if len(version.ExtendedPaths.TransformHeader) > 0 ||
 			len(version.GlobalHeaders) > 0 ||
 			len(version.GlobalHeadersRemove) > 0 {
-			used = true
-			break
+			return true
 		}
 	}
-
-	return used
+	return false
 }
 
 // iterateAddHeaders is a helper functino that will iterate of a map and inject the key and value as a header in the request.

--- a/middleware_oauth2_key_exists.go
+++ b/middleware_oauth2_key_exists.go
@@ -16,19 +16,9 @@ type Oauth2KeyExists struct {
 	*TykMiddleware
 }
 
-// New lets you do any initialisations for the object can be done here
-func (k *Oauth2KeyExists) New() {}
-
 func (k *Oauth2KeyExists) GetName() string {
 	return "Oauth2KeyExists"
 }
-
-// GetConfig retrieves the configuration from the API config - we user mapstructure for this for simplicity
-func (k *Oauth2KeyExists) GetConfig() (interface{}, error) {
-	return nil, nil
-}
-
-func (k *Oauth2KeyExists) IsEnabledForSpec() bool { return true }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {

--- a/middleware_openid.go
+++ b/middleware_openid.go
@@ -44,8 +44,6 @@ func (k *OpenIDMW) New() {
 	}
 }
 
-func (k *OpenIDMW) IsEnabledForSpec() bool { return true }
-
 func (k *OpenIDMW) getProviders() ([]openid.Provider, error) {
 	providers := []openid.Provider{}
 	log.Debug("Setting up providers: ", k.Spec.OpenIDOptions.Providers)
@@ -93,11 +91,6 @@ func (k *OpenIDMW) dummyErrorHandler(e error, w http.ResponseWriter, r *http.Req
 		"prefix": OIDPREFIX,
 	}).Warning("JWT Invalid: ", e)
 	return true
-}
-
-// GetConfig retrieves the configuration from the API config
-func (k *OpenIDMW) GetConfig() (interface{}, error) {
-	return nil, nil
 }
 
 func (k *OpenIDMW) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {

--- a/middleware_organisation_activity.go
+++ b/middleware_organisation_activity.go
@@ -46,11 +46,6 @@ func (k *OrganizationMonitor) IsEnabledForSpec() bool {
 	return config.EnforceOrgQuotas
 }
 
-// GetConfig retrieves the configuration from the API config - we user mapstructure for this for simplicity
-func (k *OrganizationMonitor) GetConfig() (interface{}, error) {
-	return nil, nil
-}
-
 func (k *OrganizationMonitor) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
 	if config.ExperimentalProcessOrgOffThread {
 		return k.ProcessRequestOffThread(w, r, configuration)

--- a/middleware_rate_check.go
+++ b/middleware_rate_check.go
@@ -1,11 +1,7 @@
 package main
 
-import (
-	"net/http"
-)
+import "net/http"
 
-// ModifiedMiddleware is a sample custom middleware component, must inherit TykMiddleware
-// so you have access to spec and definition data
 type RateCheckMW struct {
 	*TykMiddleware
 }
@@ -14,20 +10,8 @@ func (m *RateCheckMW) GetName() string {
 	return "RateCheckMW"
 }
 
-// New lets you do any initialisations for the object can be done here
-func (m *RateCheckMW) New() {}
-
-func (m *RateCheckMW) IsEnabledForSpec() bool { return true }
-
-// GetConfig retrieves the configuration from the API config - we user mapstructure for this for simplicity
-func (m *RateCheckMW) GetConfig() (interface{}, error) {
-	return nil, nil
-}
-
-// ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (m *RateCheckMW) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
 	// Let's track r/ps
 	GlobalRate.Incr(1)
-
 	return nil, 200
 }

--- a/middleware_rate_limiting.go
+++ b/middleware_rate_limiting.go
@@ -20,14 +20,6 @@ func (k *RateLimitAndQuotaCheck) GetName() string {
 	return "RateLimitAndQuotaCheck"
 }
 
-// New lets you do any initialisations for the object can be done here
-func (k *RateLimitAndQuotaCheck) New() {}
-
-// GetConfig retrieves the configuration from the API config - we user mapstructure for this for simplicity
-func (k *RateLimitAndQuotaCheck) GetConfig() (interface{}, error) {
-	return nil, nil
-}
-
 func (k *RateLimitAndQuotaCheck) IsEnabledForSpec() bool {
 	return !k.Spec.DisableRateLimit || !k.Spec.DisableQuota
 }

--- a/middleware_redis_cache.go
+++ b/middleware_redis_cache.go
@@ -30,9 +30,6 @@ func (m *RedisCacheMiddleware) GetName() string {
 	return "RedisCacheMiddleware"
 }
 
-type RedisCacheMiddlewareConfig struct {
-}
-
 // New lets you do any initialisations for the object can be done here
 func (m *RedisCacheMiddleware) New() {
 	m.sh = SuccessHandler{m.TykMiddleware}
@@ -47,11 +44,6 @@ func (m *RedisCacheMiddleware) IsEnabledForSpec() bool {
 	}
 
 	return used
-}
-
-// GetConfig retrieves the configuration from the API config - we user mapstructure for this for simplicity
-func (m *RedisCacheMiddleware) GetConfig() (interface{}, error) {
-	return RedisCacheMiddlewareConfig{}, nil
 }
 
 func (m *RedisCacheMiddleware) CreateCheckSum(req *http.Request, keyName string) string {

--- a/middleware_redis_cache.go
+++ b/middleware_redis_cache.go
@@ -36,14 +36,12 @@ func (m *RedisCacheMiddleware) New() {
 }
 
 func (m *RedisCacheMiddleware) IsEnabledForSpec() bool {
-	var used bool
 	for _, version := range m.Spec.VersionData.Versions {
 		if len(version.ExtendedPaths.Cached) > 0 {
-			used = true
+			return true
 		}
 	}
-
-	return used
+	return false
 }
 
 func (m *RedisCacheMiddleware) CreateCheckSum(req *http.Request, keyName string) string {

--- a/middleware_request_size_limit.go
+++ b/middleware_request_size_limit.go
@@ -15,16 +15,8 @@ type RequestSizeLimitMiddleware struct {
 	*TykMiddleware
 }
 
-// New lets you do any initialisations for the object can be done here
-func (t *RequestSizeLimitMiddleware) New() {}
-
 func (t *RequestSizeLimitMiddleware) GetName() string {
 	return "RequestSizeLimitMiddleware"
-}
-
-// GetConfig retrieves the configuration from the API config - we user mapstructure for this for simplicity
-func (t *RequestSizeLimitMiddleware) GetConfig() (interface{}, error) {
-	return nil, nil
 }
 
 func (t *RequestSizeLimitMiddleware) IsEnabledForSpec() bool {

--- a/middleware_request_size_limit.go
+++ b/middleware_request_size_limit.go
@@ -20,15 +20,12 @@ func (t *RequestSizeLimitMiddleware) GetName() string {
 }
 
 func (t *RequestSizeLimitMiddleware) IsEnabledForSpec() bool {
-	var used bool
 	for _, version := range t.Spec.VersionData.Versions {
 		if len(version.ExtendedPaths.SizeLimit) > 0 {
-			used = true
-			break
+			return true
 		}
 	}
-
-	return used
+	return false
 }
 
 func (t *RequestSizeLimitMiddleware) checkRequestLimit(r *http.Request, sizeLimit int64) (error, int) {

--- a/middleware_track_endpoints.go
+++ b/middleware_track_endpoints.go
@@ -11,19 +11,9 @@ type TrackEndpointMiddleware struct {
 	*TykMiddleware
 }
 
-// New lets you do any initialisations for the object can be done here
-func (a *TrackEndpointMiddleware) New() {}
-
-// GetConfig retrieves the configuration from the API config - we user mapstructure for this for simplicity
-func (a *TrackEndpointMiddleware) GetConfig() (interface{}, error) {
-	return nil, nil
-}
-
 func (a *TrackEndpointMiddleware) GetName() string {
 	return "TrackEndpointMiddleware"
 }
-
-func (a *TrackEndpointMiddleware) IsEnabledForSpec() bool { return true }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (a *TrackEndpointMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {

--- a/middleware_transform.go
+++ b/middleware_transform.go
@@ -28,15 +28,12 @@ func (t *TransformMiddleware) GetName() string {
 }
 
 func (t *TransformMiddleware) IsEnabledForSpec() bool {
-	var used bool
 	for _, version := range t.Spec.VersionData.Versions {
 		if len(version.ExtendedPaths.Transform) > 0 {
-			used = true
-			break
+			return true
 		}
 	}
-
-	return used
+	return false
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail

--- a/middleware_transform.go
+++ b/middleware_transform.go
@@ -27,14 +27,6 @@ func (t *TransformMiddleware) GetName() string {
 	return "TransformMiddleware"
 }
 
-// New lets you do any initialisations for the object can be done here
-func (t *TransformMiddleware) New() {}
-
-// GetConfig retrieves the configuration from the API config - we user mapstructure for this for simplicity
-func (t *TransformMiddleware) GetConfig() (interface{}, error) {
-	return nil, nil
-}
-
 func (t *TransformMiddleware) IsEnabledForSpec() bool {
 	var used bool
 	for _, version := range t.Spec.VersionData.Versions {

--- a/middleware_url_rewrite.go
+++ b/middleware_url_rewrite.go
@@ -127,9 +127,6 @@ func (m *URLRewriteMiddleware) GetName() string {
 	return "URLRewriteMiddleware"
 }
 
-// New lets you do any initialisations for the object can be done here
-func (m *URLRewriteMiddleware) New() {}
-
 func (m *URLRewriteMiddleware) IsEnabledForSpec() bool {
 	var used bool
 	for _, version := range m.Spec.VersionData.Versions {
@@ -143,9 +140,7 @@ func (m *URLRewriteMiddleware) IsEnabledForSpec() bool {
 	return used
 }
 
-// GetConfig retrieves the configuration from the API config - we user mapstructure for this for simplicity
 func (m *URLRewriteMiddleware) GetConfig() (interface{}, error) {
-	log.Debug("URL Rewrite enabled")
 	m.Rewriter = &URLRewriter{}
 	return nil, nil
 }

--- a/middleware_url_rewrite.go
+++ b/middleware_url_rewrite.go
@@ -128,16 +128,13 @@ func (m *URLRewriteMiddleware) GetName() string {
 }
 
 func (m *URLRewriteMiddleware) IsEnabledForSpec() bool {
-	var used bool
 	for _, version := range m.Spec.VersionData.Versions {
 		if len(version.ExtendedPaths.URLRewrite) > 0 {
-			used = true
 			m.Spec.URLRewriteEnabled = true
-			break
+			return true
 		}
 	}
-
-	return used
+	return false
 }
 
 func (m *URLRewriteMiddleware) GetConfig() (interface{}, error) {

--- a/middleware_version_check.go
+++ b/middleware_version_check.go
@@ -23,13 +23,6 @@ func (v *VersionCheck) GetName() string {
 	return "VersionCheck"
 }
 
-// GetConfig retrieves the configuration from the API config
-func (v *VersionCheck) GetConfig() (interface{}, error) {
-	return nil, nil
-}
-
-func (v *VersionCheck) IsEnabledForSpec() bool { return true }
-
 func (v *VersionCheck) DoMockReply(w http.ResponseWriter, meta interface{}) {
 	// Reply with some alternate data
 	emeta := meta.(*apidef.EndpointMethodMeta)

--- a/middleware_virtual_endpoint.go
+++ b/middleware_virtual_endpoint.go
@@ -10,8 +10,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/mitchellh/mapstructure"
-
 	"github.com/TykTechnologies/tyk/apidef"
 )
 
@@ -81,26 +79,9 @@ func PreLoadVirtualMetaCode(meta *apidef.VirtualMeta, j *JSVM) {
 	}
 }
 
-type VirtualEndpointConfig struct {
-	ConfigData map[string]string `mapstructure:"config_data" bson:"config_data" json:"config_data"`
-}
-
 // New lets you do any initialisations for the object can be done here
 func (d *VirtualEndpoint) New() {
 	d.sh = SuccessHandler{d.TykMiddleware}
-}
-
-// GetConfig retrieves the configuration from the API config - we user mapstructure for this for simplicity
-func (d *VirtualEndpoint) GetConfig() (interface{}, error) {
-	var moduleConfig VirtualEndpointConfig
-
-	err := mapstructure.Decode(d.Spec.RawData, &moduleConfig)
-	if err != nil {
-		log.Error(err)
-		return nil, err
-	}
-
-	return moduleConfig, nil
 }
 
 func (d *VirtualEndpoint) IsEnabledForSpec() bool {

--- a/middleware_virtual_endpoint.go
+++ b/middleware_virtual_endpoint.go
@@ -88,14 +88,12 @@ func (d *VirtualEndpoint) IsEnabledForSpec() bool {
 	if !config.EnableJSVM {
 		return false
 	}
-	used := false
 	for _, version := range d.Spec.VersionData.Versions {
 		if len(version.ExtendedPaths.Virtual) > 0 {
-			used = true
-			break
+			return true
 		}
 	}
-	return used
+	return false
 }
 
 func (d *VirtualEndpoint) ServeHTTPForCache(w http.ResponseWriter, r *http.Request) *http.Response {

--- a/plugins.go
+++ b/plugins.go
@@ -62,11 +62,6 @@ func (d *DynamicMiddleware) GetName() string {
 	return "DynamicMiddleware"
 }
 
-// New lets you do any initialisations for the object can be done here
-func (d *DynamicMiddleware) New() {}
-
-func (d *DynamicMiddleware) IsEnabledForSpec() bool { return true }
-
 // GetConfig retrieves the configuration from the API config - we user mapstructure for this for simplicity
 func (d *DynamicMiddleware) GetConfig() (interface{}, error) {
 	var moduleConfig DynamicMiddlewareConfig


### PR DESCRIPTION
Take advantage of how embedding structs also inherits methods and how they can be overriden.

@lonelycode this solves one of my main concerns regarding our middleware structure, since we no longer have so much unnecessary boilerplate code - but with absolutely no API changes :)