### PR TITLE
analytics: remove config enabled check

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -123,18 +123,15 @@ func initNormalisationPatterns() (pats NormaliseURLPatterns) {
 }
 
 func (a *AnalyticsRecord) NormalisePath() {
-	if config.AnalyticsConfig.NormaliseUrls.Enabled {
-		if config.AnalyticsConfig.NormaliseUrls.NormaliseUUIDs {
-			a.Path = config.AnalyticsConfig.NormaliseUrls.compiledPatternSet.UUIDs.ReplaceAllString(a.Path, "{uuid}")
-		}
-		if config.AnalyticsConfig.NormaliseUrls.NormaliseNumbers {
-			a.Path = config.AnalyticsConfig.NormaliseUrls.compiledPatternSet.IDs.ReplaceAllString(a.Path, "/{id}")
-		}
-		for _, r := range config.AnalyticsConfig.NormaliseUrls.compiledPatternSet.Custom {
-			a.Path = r.ReplaceAllString(a.Path, "{var}")
-		}
+	if config.AnalyticsConfig.NormaliseUrls.NormaliseUUIDs {
+		a.Path = config.AnalyticsConfig.NormaliseUrls.compiledPatternSet.UUIDs.ReplaceAllString(a.Path, "{uuid}")
 	}
-
+	if config.AnalyticsConfig.NormaliseUrls.NormaliseNumbers {
+		a.Path = config.AnalyticsConfig.NormaliseUrls.compiledPatternSet.IDs.ReplaceAllString(a.Path, "/{id}")
+	}
+	for _, r := range config.AnalyticsConfig.NormaliseUrls.compiledPatternSet.Custom {
+		a.Path = r.ReplaceAllString(a.Path, "{var}")
+	}
 }
 
 func (a *AnalyticsRecord) SetExpiry(expiresInSeconds int64) {


### PR DESCRIPTION
All NormalisePath call sites (handler_success and handler_error) wrap
the call in the very same if, so this is redundant.