### PR TITLE
test: remove a bunch of ReadAll and Unmarshal uses

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -63,13 +63,6 @@ func TestHealthCheckEndpoint(t *testing.T) {
 	}
 
 	healthCheckhandler(recorder, req)
-
-	var apiHealthValues HealthCheckValues
-	err = json.Unmarshal(recorder.Body.Bytes(), &apiHealthValues)
-	if err != nil {
-		t.Error("Could not unmarshal API Health check:\n", err, recorder.Body.String())
-	}
-
 	if recorder.Code != 200 {
 		t.Error("Recorder should return 200 for health check")
 	}
@@ -107,7 +100,6 @@ func TestApiHandler(t *testing.T) {
 		loadSampleAPI(t, apiTestDef)
 
 		req, err := http.NewRequest("GET", uri, bytes.NewReader(body))
-
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -116,18 +108,12 @@ func TestApiHandler(t *testing.T) {
 
 		// We can't deserialize BSON ObjectID's if they are not in th test base!
 		var apiList []testAPIDefinition
-		err = json.Unmarshal(recorder.Body.Bytes(), &apiList)
+		json.NewDecoder(recorder.Body).Decode(&apiList)
 
-		if err != nil {
-			t.Error("Could not unmarshal API List:\n", err, recorder.Body.String(), uri)
-		} else {
-			if len(apiList) != 1 {
-				t.Error("API's not returned, len was: \n", len(apiList), recorder.Body.String(), uri)
-			} else {
-				if apiList[0].APIID != "1" {
-					t.Error("Response is incorrect - no API ID value in struct :\n", recorder.Body.String(), uri)
-				}
-			}
+		if len(apiList) != 1 {
+			t.Error("API's not returned, len was: \n", len(apiList), recorder.Body.String(), uri)
+		} else if apiList[0].APIID != "1" {
+			t.Error("Response is incorrect - no API ID value in struct :\n", recorder.Body.String(), uri)
 		}
 	}
 }
@@ -150,14 +136,10 @@ func TestApiHandlerGetSingle(t *testing.T) {
 
 	// We can't deserialize BSON ObjectID's if they are not in th test base!
 	var apiDef testAPIDefinition
-	err = json.Unmarshal(recorder.Body.Bytes(), &apiDef)
+	json.NewDecoder(recorder.Body).Decode(&apiDef)
 
-	if err != nil {
-		t.Error("Could not unmarshal API Definition:\n", err, recorder.Body.String())
-	} else {
-		if apiDef.APIID != "1" {
-			t.Error("Response is incorrect - no API ID value in struct :\n", recorder.Body.String())
-		}
+	if apiDef.APIID != "1" {
+		t.Error("Response is incorrect - no API ID value in struct :\n", recorder.Body.String())
 	}
 }
 
@@ -173,14 +155,10 @@ func TestApiHandlerPost(t *testing.T) {
 	apiHandler(recorder, req)
 
 	var success APIModifyKeySuccess
-	err = json.Unmarshal(recorder.Body.Bytes(), &success)
+	json.NewDecoder(recorder.Body).Decode(&success)
 
-	if err != nil {
-		t.Error("Could not unmarshal POST result:\n", err, recorder.Body.String())
-	} else {
-		if success.Status != "ok" {
-			t.Error("Response is incorrect - not success :\n", recorder.Body.String())
-		}
+	if success.Status != "ok" {
+		t.Error("Response is incorrect - not success :\n", recorder.Body.String())
 	}
 }
 
@@ -255,14 +233,9 @@ func TestApiHandlerPostDbConfig(t *testing.T) {
 	apiHandler(recorder, req)
 
 	var success APIModifyKeySuccess
-	err = json.Unmarshal(recorder.Body.Bytes(), &success)
-
-	if err != nil {
-		t.Error("Could not unmarshal POST result:\n", err, recorder.Body.String())
-	} else {
-		if success.Status == "ok" {
-			t.Error("Response is incorrect - expected error due to use_db_app_config :\n", recorder.Body.String())
-		}
+	json.NewDecoder(recorder.Body).Decode(&success)
+	if success.Status == "ok" {
+		t.Error("Response is incorrect - expected error due to use_db_app_config :\n", recorder.Body.String())
 	}
 }
 
@@ -326,17 +299,12 @@ func TestKeyHandlerNewKey(t *testing.T) {
 		keyHandler(recorder, req)
 
 		newSuccess := APIModifyKeySuccess{}
-		err = json.Unmarshal(recorder.Body.Bytes(), &newSuccess)
-
-		if err != nil {
-			t.Error("Could not unmarshal success message:\n", err)
-		} else {
-			if newSuccess.Status != "ok" {
-				t.Error("key not created, status error:\n", recorder.Body.String())
-			}
-			if newSuccess.Action != "added" {
-				t.Error("Response is incorrect - action is not 'added' :\n", recorder.Body.String())
-			}
+		json.NewDecoder(recorder.Body).Decode(&newSuccess)
+		if newSuccess.Status != "ok" {
+			t.Error("key not created, status error:\n", recorder.Body.String())
+		}
+		if newSuccess.Action != "added" {
+			t.Error("Response is incorrect - action is not 'added' :\n", recorder.Body.String())
 		}
 	}
 }
@@ -362,17 +330,12 @@ func TestKeyHandlerUpdateKey(t *testing.T) {
 		keyHandler(recorder, req)
 
 		newSuccess := APIModifyKeySuccess{}
-		err = json.Unmarshal(recorder.Body.Bytes(), &newSuccess)
-
-		if err != nil {
-			t.Error("Could not unmarshal success message:\n", err)
-		} else {
-			if newSuccess.Status != "ok" {
-				t.Error("key not created, status error:\n", recorder.Body.String())
-			}
-			if newSuccess.Action != "modified" {
-				t.Error("Response is incorrect - action is not 'modified' :\n", recorder.Body.String())
-			}
+		json.NewDecoder(recorder.Body).Decode(&newSuccess)
+		if newSuccess.Status != "ok" {
+			t.Error("key not created, status error:\n", recorder.Body.String())
+		}
+		if newSuccess.Action != "modified" {
+			t.Error("Response is incorrect - action is not 'modified' :\n", recorder.Body.String())
 		}
 	}
 }
@@ -397,16 +360,8 @@ func TestKeyHandlerGetKey(t *testing.T) {
 		}
 
 		keyHandler(recorder, req)
-
-		newSuccess := make(map[string]interface{})
-		err = json.Unmarshal(recorder.Body.Bytes(), &newSuccess)
-
-		if err != nil {
-			t.Error("Could not unmarshal success message:\n", err)
-		} else {
-			if recorder.Code != 200 {
-				t.Error("key not requested, status error:\n", recorder.Body.String())
-			}
+		if recorder.Code != 200 {
+			t.Error("key not requested, status error:\n", recorder.Body.String())
 		}
 	}
 }
@@ -443,17 +398,13 @@ func TestKeyHandlerDeleteKey(t *testing.T) {
 		keyHandler(recorder, req)
 
 		newSuccess := APIModifyKeySuccess{}
-		err = json.Unmarshal(recorder.Body.Bytes(), &newSuccess)
+		json.NewDecoder(recorder.Body).Decode(&newSuccess)
 
-		if err != nil {
-			t.Error("Could not unmarshal success message:\n", err)
-		} else {
-			if newSuccess.Status != "ok" {
-				t.Error("key not deleted, status error:\n", recorder.Body.String())
-			}
-			if newSuccess.Action != "deleted" {
-				t.Error("Response is incorrect - action is not 'deleted' :\n", recorder.Body.String())
-			}
+		if newSuccess.Status != "ok" {
+			t.Error("key not deleted, status error:\n", recorder.Body.String())
+		}
+		if newSuccess.Action != "deleted" {
+			t.Error("Response is incorrect - action is not 'deleted' :\n", recorder.Body.String())
 		}
 	}
 }
@@ -481,17 +432,13 @@ func TestCreateKeyHandlerCreateNewKey(t *testing.T) {
 		createKeyHandler(recorder, req)
 
 		newSuccess := APIModifyKeySuccess{}
-		err = json.Unmarshal(recorder.Body.Bytes(), &newSuccess)
+		json.NewDecoder(recorder.Body).Decode(&newSuccess)
 
-		if err != nil {
-			t.Error("Could not unmarshal success message:\n", err)
-		} else {
-			if newSuccess.Status != "ok" {
-				t.Error("key not created, status error:\n", recorder.Body.String())
-			}
-			if newSuccess.Action != "create" {
-				t.Error("Response is incorrect - action is not 'create' :\n", recorder.Body.String())
-			}
+		if newSuccess.Status != "ok" {
+			t.Error("key not created, status error:\n", recorder.Body.String())
+		}
+		if newSuccess.Action != "create" {
+			t.Error("Response is incorrect - action is not 'create' :\n", recorder.Body.String())
 		}
 	}
 }

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -657,10 +657,9 @@ func TestWhitelistRequestReply(t *testing.T) {
 	chain := getChain(spec)
 	chain.ServeHTTP(recorder, req)
 
-	contents, _ := ioutil.ReadAll(recorder.Body)
-
-	if string(contents) != "flump" {
-		t.Error("Request body is incorrect! Is: ", string(contents))
+	body := recorder.Body.String()
+	if body != "flump" {
+		t.Error("Request body is incorrect! Is: ", body)
 	}
 }
 

--- a/middleware_auth_key_test.go
+++ b/middleware_auth_key_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -65,7 +64,7 @@ func TestBearerTokenAuthKeySession(t *testing.T) {
 
 	if recorder.Code != 200 {
 		t.Error("Initial request failed with non-200 code, should have gone through!: \n", recorder.Code)
-		t.Error(ioutil.ReadAll(recorder.Body))
+		t.Error(recorder.Body.String())
 	}
 }
 
@@ -108,7 +107,7 @@ func TestMultiAuthBackwardsCompatibleSession(t *testing.T) {
 
 	if recorder.Code != 200 {
 		t.Error("Initial request failed with non-200 code, should have gone through!: \n", recorder.Code)
-		t.Error(ioutil.ReadAll(recorder.Body))
+		t.Error(recorder.Body.String())
 	}
 }
 
@@ -154,7 +153,7 @@ func TestMultiAuthSession(t *testing.T) {
 
 	if recorder.Code != 200 {
 		t.Error("First request failed with non-200 code, should have gone through!: \n", recorder.Code)
-		t.Error(ioutil.ReadAll(recorder.Body))
+		t.Error(recorder.Body.String())
 	}
 
 	// Set the header
@@ -168,7 +167,7 @@ func TestMultiAuthSession(t *testing.T) {
 
 	if recorder.Code != 200 {
 		t.Error("Second request failed with non-200 code, should have gone through!: \n", recorder.Code)
-		t.Error(ioutil.ReadAll(recorder.Body))
+		t.Error(recorder.Body.String())
 	}
 
 	// Set the cookie
@@ -182,7 +181,7 @@ func TestMultiAuthSession(t *testing.T) {
 
 	if recorder.Code != 200 {
 		t.Error("Third request failed with non-200 code, should have gone through!: \n", recorder.Code)
-		t.Error(ioutil.ReadAll(recorder.Body))
+		t.Error(recorder.Body.String())
 	}
 
 	// No header, param or cookie
@@ -195,7 +194,7 @@ func TestMultiAuthSession(t *testing.T) {
 
 	if recorder.Code == 200 {
 		t.Error("Request returned 200 code, should NOT have gone through!: \n", recorder.Code)
-		t.Error(ioutil.ReadAll(recorder.Body))
+		t.Error(recorder.Body.String())
 	}
 }
 

--- a/oauth_manager_test.go
+++ b/oauth_manager_test.go
@@ -7,7 +7,6 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -309,9 +308,7 @@ func getAuthCode(t *testing.T) map[string]string {
 	testMuxer.ServeHTTP(recorder, req)
 
 	response := map[string]string{}
-	body, _ := ioutil.ReadAll(recorder.Body)
-	_ = json.Unmarshal(body, &response)
-
+	json.NewDecoder(recorder.Body).Decode(&response)
 	return response
 }
 
@@ -342,8 +339,7 @@ func getToken(t *testing.T) tokenData {
 	testMuxer.ServeHTTP(recorder, req)
 
 	response := tokenData{}
-	body, _ := ioutil.ReadAll(recorder.Body)
-	_ = json.Unmarshal(body, &response)
+	json.NewDecoder(recorder.Body).Decode(&response)
 	return response
 }
 
@@ -367,10 +363,7 @@ func TestOAuthClientCredsGrant(t *testing.T) {
 	testMuxer.ServeHTTP(recorder, req)
 
 	response := tokenData{}
-	body, _ := ioutil.ReadAll(recorder.Body)
-	if err := json.Unmarshal(body, &response); err != nil {
-		t.Fatal(err)
-	}
+	json.NewDecoder(recorder.Body).Decode(&response)
 
 	if recorder.Code != 200 {
 		t.Error("Response code should have 200 error but is: ", recorder.Code)
@@ -449,19 +442,14 @@ func TestOAuthAPIRefreshInvalidate(t *testing.T) {
 	testMuxer.ServeHTTP(recorder, req1)
 
 	newSuccess := APIModifyKeySuccess{}
-	err := json.Unmarshal(recorder.Body.Bytes(), &newSuccess)
+	json.NewDecoder(recorder.Body).Decode(&newSuccess)
 
-	if err != nil {
-		t.Error("Could not unmarshal success message:\n", err)
-		t.Error(recorder.Body.String())
-	} else {
-		if newSuccess.Status != "ok" {
-			t.Error("key not deleted, status error:\n", recorder.Body.String())
-			t.Error(apisByID)
-		}
-		if newSuccess.Action != "deleted" {
-			t.Error("Response is incorrect - action is not 'deleted' :\n", recorder.Body.String())
-		}
+	if newSuccess.Status != "ok" {
+		t.Error("key not deleted, status error:\n", recorder.Body.String())
+		t.Error(apisByID)
+	}
+	if newSuccess.Action != "deleted" {
+		t.Error("Response is incorrect - action is not 'deleted' :\n", recorder.Body.String())
 	}
 
 	// Step 3 - try to refresh
@@ -555,10 +543,7 @@ func TestClientRefreshRequestDouble(t *testing.T) {
 
 	responseData := make(map[string]interface{})
 
-	body, _ := ioutil.ReadAll(recorder.Body)
-	if err := json.Unmarshal(body, &responseData); err != nil {
-		t.Fatal("Decode failed:", err)
-	}
+	json.NewDecoder(recorder.Body).Decode(&responseData)
 	token, ok := responseData["refresh_token"].(string)
 	if !ok {
 		t.Fatal("No refresh token found")


### PR DESCRIPTION
ReadAll is unnecessary on recorder.Body since it's already a buffer.
Simplify the code.

Also remove json unmarshal error checks, as the tests would already fail
if the decoded object doesn't have the contents we expect.