### PR TITLE
test: deduplicate http.NewRequest logic

### DIFF
--- a/api_definition_test.go
+++ b/api_definition_test.go
@@ -116,10 +116,7 @@ func createDefinitionFromString(defStr string) *APISpec {
 }
 
 func TestExpiredRequest(t *testing.T) {
-	req, err := http.NewRequest("GET", "/v1/bananaphone", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	req := testReq(t, "GET", "/v1/bananaphone", nil)
 	req.Header.Add("version", "v1")
 
 	spec := createDefinitionFromString(sampleDefiniton)
@@ -136,10 +133,7 @@ func TestExpiredRequest(t *testing.T) {
 }
 
 func TestNotVersioned(t *testing.T) {
-	req, err := http.NewRequest("GET", "v1/allowed/whitelist/literal", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	req := testReq(t, "GET", "v1/allowed/whitelist/literal", nil)
 
 	spec := createDefinitionFromString(nonExpiringDef)
 	spec.VersionData.NotVersioned = true
@@ -158,10 +152,7 @@ func TestNotVersioned(t *testing.T) {
 }
 
 func TestMissingVersion(t *testing.T) {
-	req, err := http.NewRequest("GET", "/v1/bananaphone", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	req := testReq(t, "GET", "/v1/bananaphone", nil)
 
 	spec := createDefinitionFromString(sampleDefiniton)
 
@@ -177,10 +168,7 @@ func TestMissingVersion(t *testing.T) {
 }
 
 func TestWrongVersion(t *testing.T) {
-	req, err := http.NewRequest("GET", "/v1/bananaphone", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	req := testReq(t, "GET", "/v1/bananaphone", nil)
 	req.Header.Add("version", "v2")
 
 	spec := createDefinitionFromString(sampleDefiniton)
@@ -197,10 +185,7 @@ func TestWrongVersion(t *testing.T) {
 }
 
 func TestBlacklistLinks(t *testing.T) {
-	req, err := http.NewRequest("GET", "v1/disallowed/blacklist/literal", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	req := testReq(t, "GET", "v1/disallowed/blacklist/literal", nil)
 	req.Header.Add("version", "v1")
 
 	spec := createDefinitionFromString(nonExpiringDef)
@@ -215,10 +200,7 @@ func TestBlacklistLinks(t *testing.T) {
 		t.Error(status)
 	}
 
-	req, err = http.NewRequest("GET", "v1/disallowed/blacklist/abacab12345", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	req = testReq(t, "GET", "v1/disallowed/blacklist/abacab12345", nil)
 	req.Header.Add("version", "v1")
 
 	ok, status, _ = spec.IsRequestValid(req)
@@ -233,10 +215,7 @@ func TestBlacklistLinks(t *testing.T) {
 }
 
 func TestWhiteLIstLinks(t *testing.T) {
-	req, err := http.NewRequest("GET", "v1/allowed/whitelist/literal", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	req := testReq(t, "GET", "v1/allowed/whitelist/literal", nil)
 	req.Header.Add("version", "v1")
 
 	spec := createDefinitionFromString(nonExpiringDef)
@@ -251,10 +230,7 @@ func TestWhiteLIstLinks(t *testing.T) {
 		t.Error(status)
 	}
 
-	req, err = http.NewRequest("GET", "v1/allowed/whitelist/12345abans", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	req = testReq(t, "GET", "v1/allowed/whitelist/12345abans", nil)
 	req.Header.Add("version", "v1")
 
 	ok, status, _ = spec.IsRequestValid(req)
@@ -269,10 +245,7 @@ func TestWhiteLIstLinks(t *testing.T) {
 }
 
 func TestWhiteListBlock(t *testing.T) {
-	req, err := http.NewRequest("GET", "v1/allowed/bananaphone", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	req := testReq(t, "GET", "v1/allowed/bananaphone", nil)
 	req.Header.Add("version", "v1")
 
 	spec := createDefinitionFromString(nonExpiringDef)
@@ -289,10 +262,7 @@ func TestWhiteListBlock(t *testing.T) {
 }
 
 func TestIgnored(t *testing.T) {
-	req, err := http.NewRequest("GET", "/v1/ignored/noregex", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	req := testReq(t, "GET", "/v1/ignored/noregex", nil)
 	req.Header.Add("version", "v1")
 
 	spec := createDefinitionFromString(nonExpiringDef)
@@ -309,10 +279,7 @@ func TestIgnored(t *testing.T) {
 }
 
 func TestBlacklistLinksMulti(t *testing.T) {
-	req, err := http.NewRequest("GET", "v1/disallowed/blacklist/literal", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	req := testReq(t, "GET", "v1/disallowed/blacklist/literal", nil)
 	req.Header.Add("version", "v2")
 
 	spec := createDefinitionFromString(nonExpiringMultiDef)
@@ -327,10 +294,7 @@ func TestBlacklistLinksMulti(t *testing.T) {
 		t.Error(status)
 	}
 
-	req, err = http.NewRequest("GET", "v1/disallowed/blacklist/abacab12345", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	req = testReq(t, "GET", "v1/disallowed/blacklist/abacab12345", nil)
 	req.Header.Add("version", "v2")
 
 	ok, status, _ = spec.IsRequestValid(req)

--- a/batch_requests_test.go
+++ b/batch_requests_test.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"net/http"
-	"strings"
 	"testing"
 )
 
@@ -55,10 +53,10 @@ func TestBatchSuccess(t *testing.T) {
 
 	batchHandler := BatchRequestHandler{API: spec}
 
-	r, _ := http.NewRequest("POST", "/vi/tyk/batch/", strings.NewReader(testBatchRequest))
+	req := testReq(t, "POST", "/vi/tyk/batch/", testBatchRequest)
 
 	// Test decode
-	batchRequest, err := batchHandler.DecodeBatchRequest(r)
+	batchRequest, err := batchHandler.DecodeBatchRequest(req)
 	if err != nil {
 		t.Error("Decode batch request body failed: ", err)
 	}
@@ -97,9 +95,9 @@ func TestMakeSyncRequest(t *testing.T) {
 	batchHandler := BatchRequestHandler{API: spec}
 
 	relURL := "/"
-	request, _ := http.NewRequest("GET", testHttpGet, nil)
+	req := testReq(t, "GET", testHttpGet, nil)
 
-	replyUnit := batchHandler.doSyncRequest(request, relURL)
+	replyUnit := batchHandler.doSyncRequest(req, relURL)
 
 	if replyUnit.RelativeURL != relURL {
 		t.Error("Relativce URL in reply is wrong")
@@ -117,10 +115,10 @@ func TestMakeASyncRequest(t *testing.T) {
 	batchHandler := BatchRequestHandler{API: spec}
 
 	relURL := "/"
-	request, _ := http.NewRequest("GET", testHttpGet, nil)
+	req := testReq(t, "GET", testHttpGet, nil)
 
 	replies := make(chan BatchReplyUnit)
-	go batchHandler.doAsyncRequest(request, relURL, replies)
+	go batchHandler.doAsyncRequest(req, relURL, replies)
 	replyUnit := BatchReplyUnit{}
 	replyUnit = <-replies
 

--- a/coprocess_id_extractor_test.go
+++ b/coprocess_id_extractor_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/md5"
 	"encoding/base64"
 	"fmt"
-	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
@@ -37,12 +36,8 @@ func TestValueExtractorHeaderSource(t *testing.T) {
 	encodedPass := base64.StdEncoding.EncodeToString([]byte(to_encode))
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/", nil)
+	req := testReq(t, "GET", "/", nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	chain := getBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -75,15 +70,11 @@ func TestValueExtractorFormSource(t *testing.T) {
 	authValue := "abc"
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("POST", "/", nil)
+	req := testReq(t, "POST", "/", nil)
 	req.Form = url.Values{}
 	req.Form.Add("auth", authValue)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	chain := getBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -111,12 +102,8 @@ func TestValueExtractorHeaderSourceValidation(t *testing.T) {
 	spec.SessionManager.UpdateSession("default4321", session, 60)
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/", nil)
+	req := testReq(t, "GET", "/", nil)
 	// req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	chain := getBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -149,12 +136,8 @@ func TestRegexExtractorHeaderSource(t *testing.T) {
 	matchedHeaderValue := []byte("12345")
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/", nil)
+	req := testReq(t, "GET", "/", nil)
 	req.Header.Add("Authorization", fullHeaderValue)
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	chain := getBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)

--- a/coprocess_test.go
+++ b/coprocess_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -150,12 +149,8 @@ func TestCoProcessMiddleware(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 
-	req, err := http.NewRequest("GET", "/headers", strings.NewReader(""))
+	req := testReq(t, "GET", "/headers", "")
 	req.Header.Add("authorization", "abc")
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	chain.ServeHTTP(recorder, req)
 }
@@ -170,18 +165,14 @@ func TestCoProcessObjectPostProcess(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 
-	req, err := http.NewRequest("GET", "/headers", strings.NewReader(""))
+	req := testReq(t, "GET", "/headers", "")
 	req.Header.Add("authorization", "abc")
 	req.Header.Add("Deletethisheader", "value")
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	chain.ServeHTTP(recorder, req)
 
 	resp := testHttpResponse{}
-	if err = json.Unmarshal(recorder.Body.Bytes(), &resp); err != nil {
+	if err := json.Unmarshal(recorder.Body.Bytes(), &resp); err != nil {
 		t.Fatal(err)
 	}
 	if resp.Headers["Test"] != "value" {
@@ -194,14 +185,10 @@ func TestCoProcessObjectPostProcess(t *testing.T) {
 	recorder = httptest.NewRecorder()
 
 	uri := "/get?a=a_value&b=123&remove=3"
-	getReq, err := http.NewRequest("GET", uri, strings.NewReader(""))
-	getReq.Header.Add("authorization", "abc")
+	req = testReq(t, "GET", uri, "")
+	req.Header.Add("authorization", "abc")
 
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	chain.ServeHTTP(recorder, getReq)
+	chain.ServeHTTP(recorder, req)
 
 	resp = testHttpResponse{}
 	if err := json.Unmarshal(recorder.Body.Bytes(), &resp); err != nil {
@@ -232,12 +219,8 @@ func TestCoProcessAuth(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 
-	req, err := http.NewRequest("GET", "/headers", strings.NewReader(""))
+	req := testReq(t, "GET", "/headers", "")
 	req.Header.Add("authorization", "abc")
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	chain.ServeHTTP(recorder, req)
 
@@ -255,12 +238,8 @@ func TestCoProcessReturnOverrides(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 
-	req, err := http.NewRequest("GET", "/headers", nil)
+	req := testReq(t, "GET", "/headers", nil)
 	req.Header.Add("authorization", "abc")
-
-	if err != nil {
-		t.Fatal(err)
-	}
 	chain.ServeHTTP(recorder, req)
 	if recorder.Code != 200 || recorder.Body.String() != "body" {
 		t.Fatal("ReturnOverrides HTTP response is invalid")

--- a/extended_method_versioning_test.go
+++ b/extended_method_versioning_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"net/http"
 	"testing"
 )
 
@@ -213,10 +212,7 @@ const nonExpiringExtendedDefNoWhitelist = `{
 
 func TestExtendedBlacklistLinks(t *testing.T) {
 	uri := "v1/disallowed/blacklist/literal"
-	req, err := http.NewRequest("GET", uri, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	req := testReq(t, "GET", uri, nil)
 	req.Header.Add("version", "v1")
 
 	spec := createDefinitionFromString(nonExpiringExtendedDefNoWhitelist)
@@ -232,10 +228,7 @@ func TestExtendedBlacklistLinks(t *testing.T) {
 	}
 
 	uri = "v1/disallowed/blacklist/abacab12345"
-	req, err = http.NewRequest("GET", uri, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	req = testReq(t, "GET", uri, nil)
 	req.Header.Add("version", "v1")
 
 	ok, status, _ = spec.IsRequestValid(req)
@@ -250,10 +243,7 @@ func TestExtendedBlacklistLinks(t *testing.T) {
 
 	// Test with POST (it's a GET, should pass through)
 	uri = "v1/disallowed/blacklist/abacab12345"
-	req, err = http.NewRequest("POST", uri, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	req = testReq(t, "POST", uri, nil)
 	req.Header.Add("version", "v1")
 
 	ok, status, _ = spec.IsRequestValid(req)
@@ -269,10 +259,7 @@ func TestExtendedBlacklistLinks(t *testing.T) {
 
 func TestExtendedWhiteLIstLinks(t *testing.T) {
 	uri := "v1/allowed/whitelist/literal"
-	req, err := http.NewRequest("GET", uri, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	req := testReq(t, "GET", uri, nil)
 	req.Header.Add("version", "v1")
 
 	spec := createDefinitionFromString(nonExpiringExtendedDef)
@@ -288,10 +275,7 @@ func TestExtendedWhiteLIstLinks(t *testing.T) {
 	}
 
 	uri = "v1/allowed/whitelist/12345abans"
-	req, err = http.NewRequest("GET", uri, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	req = testReq(t, "GET", uri, nil)
 	req.Header.Add("version", "v1")
 
 	ok, status, _ = spec.IsRequestValid(req)
@@ -307,10 +291,7 @@ func TestExtendedWhiteLIstLinks(t *testing.T) {
 
 func TestExtendedWhiteListBlock(t *testing.T) {
 	uri := "v1/allowed/bananaphone"
-	req, err := http.NewRequest("GET", uri, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	req := testReq(t, "GET", uri, nil)
 	req.Header.Add("version", "v1")
 
 	spec := createDefinitionFromString(nonExpiringExtendedDef)
@@ -328,10 +309,7 @@ func TestExtendedWhiteListBlock(t *testing.T) {
 
 func TestExtendedIgnored(t *testing.T) {
 	uri := "/v1/ignored/noregex"
-	req, err := http.NewRequest("GET", uri, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	req := testReq(t, "GET", uri, nil)
 	req.Header.Add("version", "v1")
 
 	spec := createDefinitionFromString(nonExpiringExtendedDef)
@@ -349,10 +327,7 @@ func TestExtendedIgnored(t *testing.T) {
 
 func TestExtendedWhiteListWithRedirectedReply(t *testing.T) {
 	uri := "v1/allowed/whitelist/reply/12345"
-	req, err := http.NewRequest("GET", uri, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	req := testReq(t, "GET", uri, nil)
 	req.Header.Add("version", "v1")
 
 	spec := createDefinitionFromString(nonExpiringExtendedDef)

--- a/middleware_auth_key_test.go
+++ b/middleware_auth_key_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strings"
 	"testing"
 	"time"
 
@@ -51,11 +50,7 @@ func TestBearerTokenAuthKeySession(t *testing.T) {
 	spec.SessionManager.UpdateSession(customToken, session, 60)
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/auth_key_test/", nil)
-
-	if err != nil {
-		t.Fatal("Problem creating new request object.", err)
-	}
+	req := testReq(t, "GET", "/auth_key_test/", nil)
 
 	req.Header.Add("authorization", "Bearer "+customToken)
 
@@ -96,11 +91,7 @@ func TestMultiAuthBackwardsCompatibleSession(t *testing.T) {
 	spec.SessionManager.UpdateSession(customToken, session, 60)
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", fmt.Sprintf("/auth_key_test/?token=%s", customToken), strings.NewReader(""))
-
-	if err != nil {
-		t.Fatal("Problem creating new request object.", err)
-	}
+	req := testReq(t, "GET", fmt.Sprintf("/auth_key_test/?token=%s", customToken), "")
 
 	chain := getAuthKeyChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -139,14 +130,9 @@ func TestMultiAuthSession(t *testing.T) {
 	// AuthKey sessions are stored by {token}
 	spec.SessionManager.UpdateSession(customToken, session, 60)
 
-	var req *http.Request
-	var err error
-
 	// Set the url param
 	recorder := httptest.NewRecorder()
-	if req, err = http.NewRequest("GET", fmt.Sprintf("/auth_key_test/?token=%s", customToken), strings.NewReader("")); err != nil {
-		t.Fatal("Problem creating new request object.", err)
-	}
+	req := testReq(t, "GET", fmt.Sprintf("/auth_key_test/?token=%s", customToken), "")
 
 	chain := getAuthKeyChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -158,9 +144,7 @@ func TestMultiAuthSession(t *testing.T) {
 
 	// Set the header
 	recorder = httptest.NewRecorder()
-	if req, err = http.NewRequest("GET", "/auth_key_test/?token=", strings.NewReader("")); err != nil {
-		t.Fatal("Problem creating new request object.", err)
-	}
+	req = testReq(t, "GET", "/auth_key_test/?token=", "")
 	req.Header.Add("authorization", customToken)
 
 	chain.ServeHTTP(recorder, req)
@@ -172,9 +156,7 @@ func TestMultiAuthSession(t *testing.T) {
 
 	// Set the cookie
 	recorder = httptest.NewRecorder()
-	if req, err = http.NewRequest("GET", "/auth_key_test/?token=", strings.NewReader("")); err != nil {
-		t.Fatal("Problem creating new request object.", err)
-	}
+	req = testReq(t, "GET", "/auth_key_test/?token=", "")
 	req.AddCookie(&http.Cookie{Name: "oreo", Value: customToken})
 
 	chain.ServeHTTP(recorder, req)
@@ -186,9 +168,7 @@ func TestMultiAuthSession(t *testing.T) {
 
 	// No header, param or cookie
 	recorder = httptest.NewRecorder()
-	if req, err = http.NewRequest("GET", "/auth_key_test/", strings.NewReader("")); err != nil {
-		t.Fatal("Problem creating new request object.", err)
-	}
+	req = testReq(t, "GET", "/auth_key_test/", "")
 
 	chain.ServeHTTP(recorder, req)
 

--- a/middleware_basic_auth_test.go
+++ b/middleware_basic_auth_test.go
@@ -76,12 +76,8 @@ func TestBasicAuthSession(t *testing.T) {
 	encodedPass := base64.StdEncoding.EncodeToString([]byte(to_encode))
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/", nil)
+	req := testReq(t, "GET", "/", nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	chain := getBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -103,12 +99,8 @@ func TestBasicAuthBadFormatting(t *testing.T) {
 	encodedPass := base64.StdEncoding.EncodeToString([]byte(to_encode))
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/", nil)
+	req := testReq(t, "GET", "/", nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	chain := getBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -132,12 +124,8 @@ func TestBasicAuthBadData(t *testing.T) {
 	encodedPass := base64.StdEncoding.EncodeToString([]byte(to_encode))
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/", nil)
+	req := testReq(t, "GET", "/", nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	chain := getBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -163,12 +151,8 @@ func TestBasicAuthBadOverFormatting(t *testing.T) {
 	encodedPass := base64.StdEncoding.EncodeToString([]byte(to_encode))
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/", nil)
+	req := testReq(t, "GET", "/", nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	chain := getBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -193,12 +177,8 @@ func TestBasicAuthWrongUser(t *testing.T) {
 	encodedPass := base64.StdEncoding.EncodeToString([]byte(to_encode))
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/", nil)
+	req := testReq(t, "GET", "/", nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	chain := getBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -224,11 +204,7 @@ func TestBasicMissingHeader(t *testing.T) {
 	spec.SessionManager.UpdateSession("default4321", session, 60)
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/", nil)
-
-	if err != nil {
-		t.Fatal(err)
-	}
+	req := testReq(t, "GET", "/", nil)
 
 	chain := getBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -254,12 +230,8 @@ func TestBasicAuthWrongPassword(t *testing.T) {
 	encodedPass := base64.StdEncoding.EncodeToString([]byte(to_encode))
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/", nil)
+	req := testReq(t, "GET", "/", nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	chain := getBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)

--- a/middleware_context_vars_test.go
+++ b/middleware_context_vars_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
@@ -47,13 +46,9 @@ func TestContextVarsMiddleware(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	param := make(url.Values)
-	req, err := http.NewRequest(method, uri+param.Encode(), nil)
+	req := testReq(t, method, uri+param.Encode(), nil)
 	req.RemoteAddr = "127.0.0.1:80"
 	req.Header.Add("authorization", "1234wer")
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	chain := getChain(spec)
 	chain.ServeHTTP(recorder, req)

--- a/middleware_hmac_test.go
+++ b/middleware_hmac_test.go
@@ -77,7 +77,7 @@ func TestHMACAuthSessionPass(t *testing.T) {
 	spec.SessionManager.UpdateSession("9876", session, 60)
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/", nil)
+	req := testReq(t, "GET", "/", nil)
 
 	refDate := "Mon, 02 Jan 2006 15:04:05 MST"
 
@@ -98,10 +98,6 @@ func TestHMACAuthSessionPass(t *testing.T) {
 
 	req.Header.Add("Authorization", fmt.Sprintf("Signature keyId=\"9876\",algorithm=\"hmac-sha1\",signature=\"%s\"", encodedString))
 
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	chain := getHMACAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
 
@@ -118,7 +114,7 @@ func TestHMACAuthSessionAuxDateHeader(t *testing.T) {
 	spec.SessionManager.UpdateSession("9876", session, 60)
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/", nil)
+	req := testReq(t, "GET", "/", nil)
 
 	refDate := "Mon, 02 Jan 2006 15:04:05 MST"
 
@@ -139,10 +135,6 @@ func TestHMACAuthSessionAuxDateHeader(t *testing.T) {
 
 	req.Header.Add("Authorization", fmt.Sprintf("Signature keyId=\"9876\",algorithm=\"hmac-sha1\",signature=\"%s\"", encodedString))
 
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	chain := getHMACAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
 
@@ -159,7 +151,7 @@ func TestHMACAuthSessionFailureDateExpired(t *testing.T) {
 	spec.SessionManager.UpdateSession("9876", session, 60)
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/", nil)
+	req := testReq(t, "GET", "/", nil)
 
 	refDate := "Mon, 02 Jan 2006 15:04:05 MST"
 
@@ -180,10 +172,6 @@ func TestHMACAuthSessionFailureDateExpired(t *testing.T) {
 
 	req.Header.Add("Authorization", fmt.Sprintf("Signature keyId=\"9876\",algorithm=\"hmac-sha1\",signature=\"%s\"", encodedString))
 
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	chain := getHMACAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
 
@@ -200,7 +188,7 @@ func TestHMACAuthSessionKeyMissing(t *testing.T) {
 	spec.SessionManager.UpdateSession("9876", session, 60)
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/", nil)
+	req := testReq(t, "GET", "/", nil)
 
 	refDate := "Mon, 02 Jan 2006 15:04:05 MST"
 
@@ -221,10 +209,6 @@ func TestHMACAuthSessionKeyMissing(t *testing.T) {
 
 	req.Header.Add("Authorization", fmt.Sprintf("Signature keyId=\"98765\",algorithm=\"hmac-sha1\",signature=\"%s\"", encodedString))
 
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	chain := getHMACAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
 
@@ -241,7 +225,7 @@ func TestHMACAuthSessionMalformedHeader(t *testing.T) {
 	spec.SessionManager.UpdateSession("9876", session, 60)
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/", nil)
+	req := testReq(t, "GET", "/", nil)
 
 	refDate := "Mon, 02 Jan 2006 15:04:05 MST"
 
@@ -262,10 +246,6 @@ func TestHMACAuthSessionMalformedHeader(t *testing.T) {
 
 	req.Header.Add("Authorization", fmt.Sprintf("Signature keyID=\"98765\", algorithm=\"hmac-sha256\", signature=\"%s\"", encodedString))
 
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	chain := getHMACAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
 
@@ -282,7 +262,7 @@ func TestHMACAuthSessionPassWithHeaderField(t *testing.T) {
 	spec.SessionManager.UpdateSession("9876", session, 60)
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/", nil)
+	req := testReq(t, "GET", "/", nil)
 
 	refDate := "Mon, 02 Jan 2006 15:04:05 MST"
 
@@ -307,10 +287,6 @@ func TestHMACAuthSessionPassWithHeaderField(t *testing.T) {
 	encodedString := url.QueryEscape(sigString)
 
 	req.Header.Add("Authorization", fmt.Sprintf("Signature keyId=\"9876\",algorithm=\"hmac-sha1\",headers=\"(request-target) date x-test-1 x-test-2\",signature=\"%s\"", encodedString))
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	chain := getHMACAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -344,7 +320,7 @@ func TestHMACAuthSessionPassWithHeaderFieldLowerCase(t *testing.T) {
 	spec.SessionManager.UpdateSession("9876", session, 60)
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/", nil)
+	req := testReq(t, "GET", "/", nil)
 
 	refDate := "Mon, 02 Jan 2006 15:04:05 MST"
 
@@ -372,10 +348,6 @@ func TestHMACAuthSessionPassWithHeaderFieldLowerCase(t *testing.T) {
 	newEncodedSignature := replaceUpperCase(encodedString, upperCaseList)
 
 	req.Header.Add("Authorization", fmt.Sprintf("Signature keyId=\"9876\",algorithm=\"hmac-sha1\",headers=\"(request-target) date x-test-1 x-test-2\",signature=\"%s\"", newEncodedSignature))
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	chain := getHMACAuthChain(spec)
 	chain.ServeHTTP(recorder, req)

--- a/middleware_ip_whitelist_test.go
+++ b/middleware_ip_whitelist_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"net/http"
 	"net/http/httptest"
 	"testing"
 )
@@ -72,13 +71,9 @@ func TestIpMiddlewareIPFail(t *testing.T) {
 	spec.SessionManager.UpdateSession("1234wer", session, 60)
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/", nil)
+	req := testReq(t, "GET", "/", nil)
 	req.RemoteAddr = "127.0.0.1:80"
 	req.Header.Add("authorization", "1234wer")
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	chain := getChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -104,10 +99,7 @@ func TestIPMiddlewarePass(t *testing.T) {
 	} {
 
 		rec := httptest.NewRecorder()
-		req, err := http.NewRequest("GET", "/", nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		req := testReq(t, "GET", "/", nil)
 		req.RemoteAddr = tc.remote
 		req.Header.Add("authorization", "gfgg1234")
 		if tc.forwarded != "" {
@@ -129,12 +121,8 @@ func TestIpMiddlewareIPMissing(t *testing.T) {
 	spec.SessionManager.UpdateSession("1234rtyrty", session, 60)
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/", nil)
+	req := testReq(t, "GET", "/", nil)
 	req.Header.Add("authorization", "1234rtyrty")
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	chain := getChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -150,12 +138,8 @@ func TestIpMiddlewareIPDisabled(t *testing.T) {
 	spec.SessionManager.UpdateSession("1234iuouio", session, 60)
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/", nil)
+	req := testReq(t, "GET", "/", nil)
 	req.Header.Add("authorization", "1234iuouio")
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	chain := getChain(spec)
 	chain.ServeHTTP(recorder, req)

--- a/middleware_jwt_test.go
+++ b/middleware_jwt_test.go
@@ -216,12 +216,8 @@ func TestJWTSessionHMAC(t *testing.T) {
 	}
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/jwt_test/", nil)
+	req := testReq(t, "GET", "/jwt_test/", nil)
 	req.Header.Add("authorization", tokenString)
-
-	if err != nil {
-		t.Fatal("Problem generating the test token: ", err)
-	}
 
 	chain := getJWTChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -256,12 +252,8 @@ func TestJWTSessionRSA(t *testing.T) {
 	}
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/jwt_test/", nil)
+	req := testReq(t, "GET", "/jwt_test/", nil)
 	req.Header.Add("authorization", tokenString)
-
-	if err != nil {
-		t.Fatal("Problem generating the test token: ", err)
-	}
 
 	chain := getJWTChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -287,14 +279,10 @@ func TestJWTSessionFailRSA_EmptyJWT(t *testing.T) {
 	token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour * 72).Unix()
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/jwt_test/", nil)
+	req := testReq(t, "GET", "/jwt_test/", nil)
 
 	// Make it empty
 	req.Header.Add("authorization", "")
-
-	if err != nil {
-		t.Fatal("Problem generating the test token: ", err)
-	}
 
 	chain := getJWTChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -320,11 +308,7 @@ func TestJWTSessionFailRSA_NoAuthHeader(t *testing.T) {
 	token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour * 72).Unix()
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/jwt_test/", nil)
-
-	if err != nil {
-		t.Fatal("Problem generating the test token: ", err)
-	}
+	req := testReq(t, "GET", "/jwt_test/", nil)
 
 	chain := getJWTChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -359,14 +343,10 @@ func TestJWTSessionFailRSA_MalformedJWT(t *testing.T) {
 	}
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/jwt_test/", nil)
+	req := testReq(t, "GET", "/jwt_test/", nil)
 
 	// Make it empty
 	req.Header.Add("authorization", tokenString+"ajhdkjhsdfkjashdkajshdkajhsdkajhsd")
-
-	if err != nil {
-		t.Fatal("Problem generating the test token: ", err)
-	}
 
 	chain := getJWTChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -402,14 +382,10 @@ func TestJWTSessionFailRSA_MalformedJWT_NOTRACK(t *testing.T) {
 	}
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/jwt_test/", nil)
+	req := testReq(t, "GET", "/jwt_test/", nil)
 
 	// Make it empty
 	req.Header.Add("authorization", tokenString+"ajhdkjhsdfkjashdkajshdkajhsdkajhsd")
-
-	if err != nil {
-		t.Fatal("Problem generating the test token: ", err)
-	}
 
 	chain := getJWTChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -435,14 +411,10 @@ func TestJWTSessionFailRSA_WrongJWT(t *testing.T) {
 	token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour * 72).Unix()
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/jwt_test/", nil)
+	req := testReq(t, "GET", "/jwt_test/", nil)
 
 	// Make it empty
 	req.Header.Add("authorization", "123")
-
-	if err != nil {
-		t.Fatal("Problem generating the test token: ", err)
-	}
 
 	chain := getJWTChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -478,12 +450,8 @@ func TestJWTSessionRSABearer(t *testing.T) {
 	}
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/jwt_test/", nil)
+	req := testReq(t, "GET", "/jwt_test/", nil)
 	req.Header.Add("authorization", "Bearer "+tokenString)
-
-	if err != nil {
-		t.Fatal("Problem generating the test token: ", err)
-	}
 
 	chain := getJWTChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -518,13 +486,9 @@ func TestJWTSessionRSABearerInvalid(t *testing.T) {
 	}
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/jwt_test/", nil)
+	req := testReq(t, "GET", "/jwt_test/", nil)
 	// add a colon here
 	req.Header.Add("authorization", "Bearer: "+tokenString)
-
-	if err != nil {
-		t.Fatal("Problem generating the test token: ", err)
-	}
 
 	chain := getJWTChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -577,13 +541,9 @@ func TestJWTSessionRSAWithRawSourceOnWithClientID(t *testing.T) {
 	}
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/jwt_test/", nil)
+	req := testReq(t, "GET", "/jwt_test/", nil)
 	// add a colon here
 	req.Header.Add("authorization", "Bearer "+tokenString)
-
-	if err != nil {
-		t.Fatal("Problem generating the test token: ", err)
-	}
 
 	chain := getJWTChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -629,13 +589,9 @@ func TestJWTSessionRSAWithRawSource(t *testing.T) {
 	}
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/jwt_test/", nil)
+	req := testReq(t, "GET", "/jwt_test/", nil)
 	// add a colon here
 	req.Header.Add("authorization", "Bearer "+tokenString)
-
-	if err != nil {
-		t.Fatal("Problem generating the test token: ", err)
-	}
 
 	chain := getJWTChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -681,13 +637,9 @@ func TestJWTSessionRSAWithRawSourceInvalidPolicyID(t *testing.T) {
 	}
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/jwt_test/", nil)
+	req := testReq(t, "GET", "/jwt_test/", nil)
 	// add a colon here
 	req.Header.Add("authorization", "Bearer "+tokenString)
-
-	if err != nil {
-		t.Fatal("Problem generating the test token: ", err)
-	}
 
 	chain := getJWTChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -733,13 +685,9 @@ func TestJWTSessionRSAWithJWK(t *testing.T) {
 	}
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/jwt_test/", nil)
+	req := testReq(t, "GET", "/jwt_test/", nil)
 	// add a colon here
 	req.Header.Add("authorization", "Bearer "+tokenString)
-
-	if err != nil {
-		t.Fatal("Problem generating the test token: ", err)
-	}
 
 	chain := getJWTChain(spec)
 	chain.ServeHTTP(recorder, req)

--- a/middleware_version_check_test.go
+++ b/middleware_version_check_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"net/http"
 	"net/http/httptest"
 	"testing"
 )
@@ -14,10 +13,7 @@ func TestVersionMwExpiresHeader(t *testing.T) {
 	spec.SessionManager.UpdateSession("1234xyz", session, 60)
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/v1/ignored/noregex", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	req := testReq(t, "GET", "/v1/ignored/noregex", nil)
 	req.RemoteAddr = "127.0.0.1:80"
 	req.Header.Add("authorization", "1234xyz")
 	req.Header.Add("version", "v1")

--- a/multiauth_test.go
+++ b/multiauth_test.go
@@ -102,13 +102,9 @@ func TestMultiSession_BA_Standard_OK(t *testing.T) {
 	encodedPass := base64.StdEncoding.EncodeToString([]byte(to_encode))
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/", nil)
+	req := testReq(t, "GET", "/", nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
 	req.Header.Add("x-standard-auth", fmt.Sprintf("Bearer %s", customToken))
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	chain := getMultiAuthStandardAndBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -138,13 +134,9 @@ func TestMultiSession_BA_Standard_Identity(t *testing.T) {
 	encodedPass := base64.StdEncoding.EncodeToString([]byte(to_encode))
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/", nil)
+	req := testReq(t, "GET", "/", nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
 	req.Header.Add("x-standard-auth", fmt.Sprintf("Bearer %s", customToken))
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	chain := getMultiAuthStandardAndBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -179,13 +171,9 @@ func TestMultiSession_BA_Standard_FAILBA(t *testing.T) {
 	encodedPass := base64.StdEncoding.EncodeToString([]byte(to_encode))
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/", nil)
+	req := testReq(t, "GET", "/", nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
 	req.Header.Add("x-standard-auth", fmt.Sprintf("Bearer %s", customToken))
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	chain := getMultiAuthStandardAndBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -215,13 +203,9 @@ func TestMultiSession_BA_Standard_FAILAuth(t *testing.T) {
 	encodedPass := base64.StdEncoding.EncodeToString([]byte(to_encode))
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/", nil)
+	req := testReq(t, "GET", "/", nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
 	req.Header.Add("x-standard-auth", fmt.Sprintf("Bearer %s", "WRONGTOKEN"))
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	chain := getMultiAuthStandardAndBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)

--- a/oauth_manager_test.go
+++ b/oauth_manager_test.go
@@ -5,9 +5,7 @@ package main
 */
 
 import (
-	"bytes"
 	"encoding/json"
-	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
@@ -100,12 +98,8 @@ func TestAuthCodeRedirect(t *testing.T) {
 	param.Set("response_type", "code")
 	param.Set("redirect_uri", authRedirectUri)
 	param.Set("client_id", authClientID)
-	req, err := http.NewRequest("POST", uri, bytes.NewBufferString(param.Encode()))
+	req := testReq(t, "POST", uri, param.Encode())
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	recorder := httptest.NewRecorder()
 	testMuxer.ServeHTTP(recorder, req)
@@ -131,12 +125,8 @@ func TestAuthCodeRedirectMultipleURL(t *testing.T) {
 	param.Set("response_type", "code")
 	param.Set("redirect_uri", authRedirectUri2)
 	param.Set("client_id", authClientID)
-	req, err := http.NewRequest("POST", uri, bytes.NewBufferString(param.Encode()))
+	req := testReq(t, "POST", uri, param.Encode())
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	recorder := httptest.NewRecorder()
 	testMuxer.ServeHTTP(recorder, req)
@@ -162,12 +152,8 @@ func TestAuthCodeRedirectInvalidMultipleURL(t *testing.T) {
 	param.Set("response_type", "code")
 	param.Set("redirect_uri", authRedirectUri2)
 	param.Set("client_id", authClientID)
-	req, err := http.NewRequest("POST", uri, bytes.NewBufferString(param.Encode()))
+	req := testReq(t, "POST", uri, param.Encode())
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	recorder := httptest.NewRecorder()
 	testMuxer.ServeHTTP(recorder, req)
@@ -191,13 +177,9 @@ func TestAPIClientAuthorizeAuthCode(t *testing.T) {
 	param.Set("redirect_uri", authRedirectUri)
 	param.Set("client_id", authClientID)
 	param.Set("key_rules", keyRules)
-	req, err := http.NewRequest("POST", uri, bytes.NewBufferString(param.Encode()))
+	req := testReq(t, "POST", uri, param.Encode())
 	req.Header.Set("x-tyk-authorization", "352d20ee67be67f6340b4c0605b044b7")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	recorder := httptest.NewRecorder()
 	testMuxer.ServeHTTP(recorder, req)
@@ -221,13 +203,9 @@ func TestAPIClientAuthorizeToken(t *testing.T) {
 	param.Set("redirect_uri", authRedirectUri)
 	param.Set("client_id", authClientID)
 	param.Set("key_rules", keyRules)
-	req, err := http.NewRequest("POST", uri, bytes.NewBufferString(param.Encode()))
+	req := testReq(t, "POST", uri, param.Encode())
 	req.Header.Set("x-tyk-authorization", "352d20ee67be67f6340b4c0605b044b7")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	recorder := httptest.NewRecorder()
 	testMuxer.ServeHTTP(recorder, req)
@@ -251,13 +229,9 @@ func TestAPIClientAuthorizeTokenWithPolicy(t *testing.T) {
 	param.Set("redirect_uri", authRedirectUri)
 	param.Set("client_id", authClientID)
 
-	req, err := http.NewRequest("POST", uri, bytes.NewBufferString(param.Encode()))
+	req := testReq(t, "POST", uri, param.Encode())
 	req.Header.Set("x-tyk-authorization", "352d20ee67be67f6340b4c0605b044b7")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	recorder := httptest.NewRecorder()
 	testMuxer.ServeHTTP(recorder, req)
@@ -300,7 +274,7 @@ func getAuthCode(t *testing.T) map[string]string {
 	param.Set("redirect_uri", authRedirectUri)
 	param.Set("client_id", authClientID)
 	param.Set("key_rules", keyRules)
-	req, _ := http.NewRequest("POST", uri, bytes.NewBufferString(param.Encode()))
+	req := testReq(t, "POST", uri, param.Encode())
 	req.Header.Set("x-tyk-authorization", "352d20ee67be67f6340b4c0605b044b7")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
@@ -331,7 +305,7 @@ func getToken(t *testing.T) tokenData {
 	param.Set("redirect_uri", authRedirectUri)
 	param.Set("client_id", authClientID)
 	param.Set("code", authData["code"])
-	req, _ := http.NewRequest("POST", uri, bytes.NewBufferString(param.Encode()))
+	req := testReq(t, "POST", uri, param.Encode())
 	req.Header.Set("Authorization", "Basic MTIzNDphYWJiY2NkZA==")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
@@ -355,7 +329,7 @@ func TestOAuthClientCredsGrant(t *testing.T) {
 	param.Set("client_id", authClientID)
 	param.Set("client_secret", authClientSecret)
 
-	req, _ := http.NewRequest("POST", uri, bytes.NewBufferString(param.Encode()))
+	req := testReq(t, "POST", uri, param.Encode())
 	req.Header.Set("Authorization", "Basic MTIzNDphYWJiY2NkZA==")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
@@ -394,13 +368,9 @@ func TestClientAccessRequest(t *testing.T) {
 	param.Set("redirect_uri", authRedirectUri)
 	param.Set("client_id", authClientID)
 	param.Set("code", authData["code"])
-	req, err := http.NewRequest("POST", uri, bytes.NewBufferString(param.Encode()))
+	req := testReq(t, "POST", uri, param.Encode())
 	req.Header.Set("Authorization", "Basic MTIzNDphYWJiY2NkZA==")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	recorder := httptest.NewRecorder()
 	testMuxer.ServeHTTP(recorder, req)
@@ -431,15 +401,11 @@ func TestOAuthAPIRefreshInvalidate(t *testing.T) {
 	param1 := make(url.Values)
 	//MakeSampleAPI()
 	param1.Set("api_id", "999999")
-	req1, err1 := http.NewRequest("DELETE", uri1+param1.Encode(), nil)
+	req := testReq(t, "DELETE", uri1+param1.Encode(), nil)
 
-	if err1 != nil {
-		t.Fatal(err1)
-	}
+	req.Header.Add("x-tyk-authorization", "352d20ee67be67f6340b4c0605b044b7")
 
-	req1.Header.Add("x-tyk-authorization", "352d20ee67be67f6340b4c0605b044b7")
-
-	testMuxer.ServeHTTP(recorder, req1)
+	testMuxer.ServeHTTP(recorder, req)
 
 	newSuccess := APIModifyKeySuccess{}
 	json.NewDecoder(recorder.Body).Decode(&newSuccess)
@@ -461,13 +427,9 @@ func TestOAuthAPIRefreshInvalidate(t *testing.T) {
 	param.Set("redirect_uri", authRedirectUri)
 	param.Set("client_id", authClientID)
 	param.Set("refresh_token", tokenData.RefreshToken)
-	req, err := http.NewRequest("POST", uri, bytes.NewBufferString(param.Encode()))
+	req = testReq(t, "POST", uri, param.Encode())
 	req.Header.Set("Authorization", "Basic MTIzNDphYWJiY2NkZA==")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	recorder = httptest.NewRecorder()
 	testMuxer.ServeHTTP(recorder, req)
@@ -495,13 +457,9 @@ func TestClientRefreshRequest(t *testing.T) {
 	param.Set("redirect_uri", authRedirectUri)
 	param.Set("client_id", authClientID)
 	param.Set("refresh_token", tokenData.RefreshToken)
-	req, err := http.NewRequest("POST", uri, bytes.NewBufferString(param.Encode()))
+	req := testReq(t, "POST", uri, param.Encode())
 	req.Header.Set("Authorization", "Basic MTIzNDphYWJiY2NkZA==")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	recorder := httptest.NewRecorder()
 	testMuxer.ServeHTTP(recorder, req)
@@ -530,13 +488,9 @@ func TestClientRefreshRequestDouble(t *testing.T) {
 	param.Set("redirect_uri", authRedirectUri)
 	param.Set("client_id", authClientID)
 	param.Set("refresh_token", tokenData.RefreshToken)
-	req, err := http.NewRequest("POST", uri, bytes.NewBufferString(param.Encode()))
+	req := testReq(t, "POST", uri, param.Encode())
 	req.Header.Set("Authorization", "Basic MTIzNDphYWJiY2NkZA==")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	recorder := httptest.NewRecorder()
 	testMuxer.ServeHTTP(recorder, req)
@@ -554,21 +508,17 @@ func TestClientRefreshRequestDouble(t *testing.T) {
 	param2.Set("redirect_uri", authRedirectUri)
 	param2.Set("client_id", authClientID)
 	param2.Set("refresh_token", token)
-	req2, err2 := http.NewRequest("POST", uri, bytes.NewBufferString(param2.Encode()))
-	req2.Header.Set("Authorization", "Basic MTIzNDphYWJiY2NkZA==")
-	req2.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	if err2 != nil {
-		t.Fatal(err2)
-	}
+	req = testReq(t, "POST", uri, param2.Encode())
+	req.Header.Set("Authorization", "Basic MTIzNDphYWJiY2NkZA==")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	recorder2 := httptest.NewRecorder()
-	testMuxer.ServeHTTP(recorder2, req2)
+	testMuxer.ServeHTTP(recorder2, req)
 
 	if recorder2.Code != 200 {
 		t.Error("Response code should have been 200 but is: ", recorder2.Code)
 		t.Error(recorder2.Body)
-		t.Error(req2.Body)
+		t.Error(req.Body)
 	}
 
 }


### PR DESCRIPTION
Handle both errors and []byte/string readers in the helper. This greatly
reduces copy-pasting of code.