### PR TITLE
all: set headers, don't append them

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -217,11 +217,11 @@ func (a *APIDefinitionLoader) LoadDefinitionsFromDashboardService(endpoint, secr
 		log.Error("Failed to create request: ", err)
 	}
 
-	newRequest.Header.Add("authorization", secret)
+	newRequest.Header.Set("authorization", secret)
 	log.Debug("Using: NodeID: ", NodeID)
-	newRequest.Header.Add("x-tyk-nodeid", NodeID)
+	newRequest.Header.Set("x-tyk-nodeid", NodeID)
 
-	newRequest.Header.Add("x-tyk-nonce", ServiceNonce)
+	newRequest.Header.Set("x-tyk-nonce", ServiceNonce)
 
 	c := &http.Client{
 		Timeout: 120 * time.Second,

--- a/api_definition_test.go
+++ b/api_definition_test.go
@@ -117,7 +117,7 @@ func createDefinitionFromString(defStr string) *APISpec {
 
 func TestExpiredRequest(t *testing.T) {
 	req := testReq(t, "GET", "/v1/bananaphone", nil)
-	req.Header.Add("version", "v1")
+	req.Header.Set("version", "v1")
 
 	spec := createDefinitionFromString(sampleDefiniton)
 
@@ -169,7 +169,7 @@ func TestMissingVersion(t *testing.T) {
 
 func TestWrongVersion(t *testing.T) {
 	req := testReq(t, "GET", "/v1/bananaphone", nil)
-	req.Header.Add("version", "v2")
+	req.Header.Set("version", "v2")
 
 	spec := createDefinitionFromString(sampleDefiniton)
 
@@ -186,7 +186,7 @@ func TestWrongVersion(t *testing.T) {
 
 func TestBlacklistLinks(t *testing.T) {
 	req := testReq(t, "GET", "v1/disallowed/blacklist/literal", nil)
-	req.Header.Add("version", "v1")
+	req.Header.Set("version", "v1")
 
 	spec := createDefinitionFromString(nonExpiringDef)
 
@@ -201,7 +201,7 @@ func TestBlacklistLinks(t *testing.T) {
 	}
 
 	req = testReq(t, "GET", "v1/disallowed/blacklist/abacab12345", nil)
-	req.Header.Add("version", "v1")
+	req.Header.Set("version", "v1")
 
 	ok, status, _ = spec.IsRequestValid(req)
 	if ok {
@@ -216,7 +216,7 @@ func TestBlacklistLinks(t *testing.T) {
 
 func TestWhiteLIstLinks(t *testing.T) {
 	req := testReq(t, "GET", "v1/allowed/whitelist/literal", nil)
-	req.Header.Add("version", "v1")
+	req.Header.Set("version", "v1")
 
 	spec := createDefinitionFromString(nonExpiringDef)
 
@@ -231,7 +231,7 @@ func TestWhiteLIstLinks(t *testing.T) {
 	}
 
 	req = testReq(t, "GET", "v1/allowed/whitelist/12345abans", nil)
-	req.Header.Add("version", "v1")
+	req.Header.Set("version", "v1")
 
 	ok, status, _ = spec.IsRequestValid(req)
 	if !ok {
@@ -246,7 +246,7 @@ func TestWhiteLIstLinks(t *testing.T) {
 
 func TestWhiteListBlock(t *testing.T) {
 	req := testReq(t, "GET", "v1/allowed/bananaphone", nil)
-	req.Header.Add("version", "v1")
+	req.Header.Set("version", "v1")
 
 	spec := createDefinitionFromString(nonExpiringDef)
 
@@ -263,7 +263,7 @@ func TestWhiteListBlock(t *testing.T) {
 
 func TestIgnored(t *testing.T) {
 	req := testReq(t, "GET", "/v1/ignored/noregex", nil)
-	req.Header.Add("version", "v1")
+	req.Header.Set("version", "v1")
 
 	spec := createDefinitionFromString(nonExpiringDef)
 
@@ -280,7 +280,7 @@ func TestIgnored(t *testing.T) {
 
 func TestBlacklistLinksMulti(t *testing.T) {
 	req := testReq(t, "GET", "v1/disallowed/blacklist/literal", nil)
-	req.Header.Add("version", "v2")
+	req.Header.Set("version", "v2")
 
 	spec := createDefinitionFromString(nonExpiringMultiDef)
 
@@ -295,7 +295,7 @@ func TestBlacklistLinksMulti(t *testing.T) {
 	}
 
 	req = testReq(t, "GET", "v1/disallowed/blacklist/abacab12345", nil)
-	req.Header.Add("version", "v2")
+	req.Header.Set("version", "v2")
 
 	ok, status, _ = spec.IsRequestValid(req)
 	if !ok {

--- a/api_test.go
+++ b/api_test.go
@@ -404,7 +404,7 @@ func TestAPIAuthFail(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", uri, nil)
-	req.Header.Add("x-tyk-authorization", "12345")
+	req.Header.Set("x-tyk-authorization", "12345")
 
 	mainRouter.ServeHTTP(recorder, req)
 

--- a/batch_requests.go
+++ b/batch_requests.go
@@ -112,7 +112,7 @@ func (b *BatchRequestHandler) ConstructRequests(batchRequest BatchRequestStructu
 
 		// Add headers
 		for k, v := range requestDef.Headers {
-			request.Header.Add(k, v)
+			request.Header.Set(k, v)
 		}
 
 		requestSet = append(requestSet, request)

--- a/coprocess_id_extractor_test.go
+++ b/coprocess_id_extractor_test.go
@@ -37,7 +37,7 @@ func TestValueExtractorHeaderSource(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/", nil)
-	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
+	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", encodedPass))
 
 	chain := getBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -73,8 +73,8 @@ func TestValueExtractorFormSource(t *testing.T) {
 	req := testReq(t, "POST", "/", nil)
 	req.Form = url.Values{}
 	req.Form.Add("auth", authValue)
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", encodedPass))
 
 	chain := getBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -103,7 +103,7 @@ func TestValueExtractorHeaderSourceValidation(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/", nil)
-	// req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
+	// req.Header.Set("Authorization", fmt.Sprintf("Basic %s", encodedPass))
 
 	chain := getBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -137,7 +137,7 @@ func TestRegexExtractorHeaderSource(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/", nil)
-	req.Header.Add("Authorization", fullHeaderValue)
+	req.Header.Set("Authorization", fullHeaderValue)
 
 	chain := getBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)

--- a/coprocess_test.go
+++ b/coprocess_test.go
@@ -150,7 +150,7 @@ func TestCoProcessMiddleware(t *testing.T) {
 	recorder := httptest.NewRecorder()
 
 	req := testReq(t, "GET", "/headers", nil)
-	req.Header.Add("authorization", "abc")
+	req.Header.Set("authorization", "abc")
 
 	chain.ServeHTTP(recorder, req)
 }
@@ -166,8 +166,8 @@ func TestCoProcessObjectPostProcess(t *testing.T) {
 	recorder := httptest.NewRecorder()
 
 	req := testReq(t, "GET", "/headers", nil)
-	req.Header.Add("authorization", "abc")
-	req.Header.Add("Deletethisheader", "value")
+	req.Header.Set("authorization", "abc")
+	req.Header.Set("Deletethisheader", "value")
 
 	chain.ServeHTTP(recorder, req)
 
@@ -186,7 +186,7 @@ func TestCoProcessObjectPostProcess(t *testing.T) {
 
 	uri := "/get?a=a_value&b=123&remove=3"
 	req = testReq(t, "GET", uri, nil)
-	req.Header.Add("authorization", "abc")
+	req.Header.Set("authorization", "abc")
 
 	chain.ServeHTTP(recorder, req)
 
@@ -220,7 +220,7 @@ func TestCoProcessAuth(t *testing.T) {
 	recorder := httptest.NewRecorder()
 
 	req := testReq(t, "GET", "/headers", nil)
-	req.Header.Add("authorization", "abc")
+	req.Header.Set("authorization", "abc")
 
 	chain.ServeHTTP(recorder, req)
 
@@ -239,7 +239,7 @@ func TestCoProcessReturnOverrides(t *testing.T) {
 	recorder := httptest.NewRecorder()
 
 	req := testReq(t, "GET", "/headers", nil)
-	req.Header.Add("authorization", "abc")
+	req.Header.Set("authorization", "abc")
 	chain.ServeHTTP(recorder, req)
 	if recorder.Code != 200 || recorder.Body.String() != "body" {
 		t.Fatal("ReturnOverrides HTTP response is invalid")

--- a/dashboard_register.go
+++ b/dashboard_register.go
@@ -76,8 +76,8 @@ func (h *HTTPDashboardHandler) Register() error {
 		log.Error("Failed to create request: ", err)
 	}
 
-	newRequest.Header.Add("authorization", secret)
-	newRequest.Header.Add("x-tyk-hostname", HostDetails.Hostname)
+	newRequest.Header.Set("authorization", secret)
+	newRequest.Header.Set("x-tyk-hostname", HostDetails.Hostname)
 
 	c := &http.Client{
 		Timeout: 5 * time.Second,
@@ -148,13 +148,13 @@ func (h *HTTPDashboardHandler) SendHeartBeat(endpoint, secret string) error {
 		log.Error("Failed to create request: ", err)
 	}
 
-	newRequest.Header.Add("authorization", secret)
-	newRequest.Header.Add("x-tyk-nodeid", NodeID)
-	newRequest.Header.Add("x-tyk-hostname", HostDetails.Hostname)
+	newRequest.Header.Set("authorization", secret)
+	newRequest.Header.Set("x-tyk-nodeid", NodeID)
+	newRequest.Header.Set("x-tyk-hostname", HostDetails.Hostname)
 
 	log.Debug("Sending Heartbeat as: ", NodeID)
 
-	newRequest.Header.Add("x-tyk-nonce", ServiceNonce)
+	newRequest.Header.Set("x-tyk-nonce", ServiceNonce)
 
 	c := &http.Client{
 		Timeout: 5 * time.Second,
@@ -190,13 +190,13 @@ func (h *HTTPDashboardHandler) DeRegister() error {
 		log.Error("Failed to create request: ", err)
 	}
 
-	newRequest.Header.Add("authorization", secret)
-	newRequest.Header.Add("x-tyk-nodeid", NodeID)
-	newRequest.Header.Add("x-tyk-hostname", HostDetails.Hostname)
+	newRequest.Header.Set("authorization", secret)
+	newRequest.Header.Set("x-tyk-nodeid", NodeID)
+	newRequest.Header.Set("x-tyk-hostname", HostDetails.Hostname)
 
 	log.Info("De-registering: ", NodeID)
 
-	newRequest.Header.Add("x-tyk-nonce", ServiceNonce)
+	newRequest.Header.Set("x-tyk-nonce", ServiceNonce)
 
 	c := &http.Client{
 		Timeout: 5 * time.Second,

--- a/event_handler_webhooks.go
+++ b/event_handler_webhooks.go
@@ -192,10 +192,10 @@ func (w *WebHookHandler) BuildRequest(reqBody string) (*http.Request, error) {
 		return nil, err
 	}
 
-	req.Header.Add("User-Agent", "Tyk-Hookshot")
+	req.Header.Set("User-Agent", "Tyk-Hookshot")
 
 	for key, val := range w.conf.HeaderList {
-		req.Header.Add(key, val)
+		req.Header.Set(key, val)
 	}
 
 	return req, nil

--- a/extended_method_versioning_test.go
+++ b/extended_method_versioning_test.go
@@ -213,7 +213,7 @@ const nonExpiringExtendedDefNoWhitelist = `{
 func TestExtendedBlacklistLinks(t *testing.T) {
 	uri := "v1/disallowed/blacklist/literal"
 	req := testReq(t, "GET", uri, nil)
-	req.Header.Add("version", "v1")
+	req.Header.Set("version", "v1")
 
 	spec := createDefinitionFromString(nonExpiringExtendedDefNoWhitelist)
 
@@ -229,7 +229,7 @@ func TestExtendedBlacklistLinks(t *testing.T) {
 
 	uri = "v1/disallowed/blacklist/abacab12345"
 	req = testReq(t, "GET", uri, nil)
-	req.Header.Add("version", "v1")
+	req.Header.Set("version", "v1")
 
 	ok, status, _ = spec.IsRequestValid(req)
 	if ok {
@@ -244,7 +244,7 @@ func TestExtendedBlacklistLinks(t *testing.T) {
 	// Test with POST (it's a GET, should pass through)
 	uri = "v1/disallowed/blacklist/abacab12345"
 	req = testReq(t, "POST", uri, nil)
-	req.Header.Add("version", "v1")
+	req.Header.Set("version", "v1")
 
 	ok, status, _ = spec.IsRequestValid(req)
 	if !ok {
@@ -260,7 +260,7 @@ func TestExtendedBlacklistLinks(t *testing.T) {
 func TestExtendedWhiteLIstLinks(t *testing.T) {
 	uri := "v1/allowed/whitelist/literal"
 	req := testReq(t, "GET", uri, nil)
-	req.Header.Add("version", "v1")
+	req.Header.Set("version", "v1")
 
 	spec := createDefinitionFromString(nonExpiringExtendedDef)
 
@@ -276,7 +276,7 @@ func TestExtendedWhiteLIstLinks(t *testing.T) {
 
 	uri = "v1/allowed/whitelist/12345abans"
 	req = testReq(t, "GET", uri, nil)
-	req.Header.Add("version", "v1")
+	req.Header.Set("version", "v1")
 
 	ok, status, _ = spec.IsRequestValid(req)
 	if !ok {
@@ -292,7 +292,7 @@ func TestExtendedWhiteLIstLinks(t *testing.T) {
 func TestExtendedWhiteListBlock(t *testing.T) {
 	uri := "v1/allowed/bananaphone"
 	req := testReq(t, "GET", uri, nil)
-	req.Header.Add("version", "v1")
+	req.Header.Set("version", "v1")
 
 	spec := createDefinitionFromString(nonExpiringExtendedDef)
 
@@ -310,7 +310,7 @@ func TestExtendedWhiteListBlock(t *testing.T) {
 func TestExtendedIgnored(t *testing.T) {
 	uri := "/v1/ignored/noregex"
 	req := testReq(t, "GET", uri, nil)
-	req.Header.Add("version", "v1")
+	req.Header.Set("version", "v1")
 
 	spec := createDefinitionFromString(nonExpiringExtendedDef)
 
@@ -328,7 +328,7 @@ func TestExtendedIgnored(t *testing.T) {
 func TestExtendedWhiteListWithRedirectedReply(t *testing.T) {
 	uri := "v1/allowed/whitelist/reply/12345"
 	req := testReq(t, "GET", uri, nil)
-	req.Header.Add("version", "v1")
+	req.Header.Set("version", "v1")
 
 	spec := createDefinitionFromString(nonExpiringExtendedDef)
 

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -567,7 +567,7 @@ func TestParambasedAuth(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "POST", uri, form.Encode())
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	chain := getChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -603,8 +603,8 @@ func TestVersioningRequestOK(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "", nil)
-	req.Header.Add("authorization", "96869686969")
-	req.Header.Add("version", "v1")
+	req.Header.Set("authorization", "96869686969")
+	req.Header.Set("version", "v1")
 
 	chain := getChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -624,8 +624,8 @@ func TestVersioningRequestFail(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "", nil)
-	req.Header.Add("authorization", "zz1234")
-	req.Header.Add("version", "v1")
+	req.Header.Set("authorization", "zz1234")
+	req.Header.Set("version", "v1")
 
 	chain := getChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -665,7 +665,7 @@ func TestWhitelistRequestReply(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", uri, nil)
-	req.Header.Add("authorization", keyId)
+	req.Header.Set("authorization", keyId)
 
 	chain := getChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -685,7 +685,7 @@ func TestQuota(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "", nil)
-	req.Header.Add("authorization", keyId)
+	req.Header.Set("authorization", keyId)
 
 	chain := getChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -718,7 +718,7 @@ func TestWithAnalytics(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "", nil)
-	req.Header.Add("authorization", "ert1234ert")
+	req.Header.Set("authorization", "ert1234ert")
 
 	chain := getChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -745,7 +745,7 @@ func TestWithAnalyticsErrorResponse(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "", nil)
-	req.Header.Add("authorization", "dfgjg345316ertdg")
+	req.Header.Set("authorization", "dfgjg345316ertdg")
 
 	chain := getChain(spec)
 	chain.ServeHTTP(recorder, req)

--- a/middleware_auth_key_test.go
+++ b/middleware_auth_key_test.go
@@ -52,7 +52,7 @@ func TestBearerTokenAuthKeySession(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/auth_key_test/", nil)
 
-	req.Header.Add("authorization", "Bearer "+customToken)
+	req.Header.Set("authorization", "Bearer "+customToken)
 
 	chain := getAuthKeyChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -145,7 +145,7 @@ func TestMultiAuthSession(t *testing.T) {
 	// Set the header
 	recorder = httptest.NewRecorder()
 	req = testReq(t, "GET", "/auth_key_test/?token=", nil)
-	req.Header.Add("authorization", customToken)
+	req.Header.Set("authorization", customToken)
 
 	chain.ServeHTTP(recorder, req)
 

--- a/middleware_basic_auth_test.go
+++ b/middleware_basic_auth_test.go
@@ -77,7 +77,7 @@ func TestBasicAuthSession(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/", nil)
-	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
+	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", encodedPass))
 
 	chain := getBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -100,7 +100,7 @@ func TestBasicAuthBadFormatting(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/", nil)
-	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
+	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", encodedPass))
 
 	chain := getBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -125,7 +125,7 @@ func TestBasicAuthBadData(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/", nil)
-	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
+	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", encodedPass))
 
 	chain := getBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -152,7 +152,7 @@ func TestBasicAuthBadOverFormatting(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/", nil)
-	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
+	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", encodedPass))
 
 	chain := getBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -178,7 +178,7 @@ func TestBasicAuthWrongUser(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/", nil)
-	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
+	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", encodedPass))
 
 	chain := getBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -231,7 +231,7 @@ func TestBasicAuthWrongPassword(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/", nil)
-	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
+	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", encodedPass))
 
 	chain := getBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)

--- a/middleware_context_vars_test.go
+++ b/middleware_context_vars_test.go
@@ -48,7 +48,7 @@ func TestContextVarsMiddleware(t *testing.T) {
 	param := make(url.Values)
 	req := testReq(t, method, uri+param.Encode(), nil)
 	req.RemoteAddr = "127.0.0.1:80"
-	req.Header.Add("authorization", "1234wer")
+	req.Header.Set("authorization", "1234wer")
 
 	chain := getChain(spec)
 	chain.ServeHTTP(recorder, req)

--- a/middleware_hmac_test.go
+++ b/middleware_hmac_test.go
@@ -85,7 +85,7 @@ func TestHMACAuthSessionPass(t *testing.T) {
 
 	// Prep the signature string
 	tim := time.Now().Format(refDate)
-	req.Header.Add("Date", tim)
+	req.Header.Set("Date", tim)
 	signatureString := strings.ToLower("Date") + ": " + tim
 
 	// Encode it
@@ -96,7 +96,7 @@ func TestHMACAuthSessionPass(t *testing.T) {
 	sigString := base64.StdEncoding.EncodeToString(h.Sum(nil))
 	encodedString := url.QueryEscape(sigString)
 
-	req.Header.Add("Authorization", fmt.Sprintf("Signature keyId=\"9876\",algorithm=\"hmac-sha1\",signature=\"%s\"", encodedString))
+	req.Header.Set("Authorization", fmt.Sprintf("Signature keyId=\"9876\",algorithm=\"hmac-sha1\",signature=\"%s\"", encodedString))
 
 	chain := getHMACAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -122,7 +122,7 @@ func TestHMACAuthSessionAuxDateHeader(t *testing.T) {
 
 	// Prep the signature string
 	tim := time.Now().Format(refDate)
-	req.Header.Add("x-aux-date", tim)
+	req.Header.Set("x-aux-date", tim)
 	signatureString := strings.ToLower("x-aux-date") + ": " + tim
 
 	// Encode it
@@ -133,7 +133,7 @@ func TestHMACAuthSessionAuxDateHeader(t *testing.T) {
 	sigString := base64.StdEncoding.EncodeToString(h.Sum(nil))
 	encodedString := url.QueryEscape(sigString)
 
-	req.Header.Add("Authorization", fmt.Sprintf("Signature keyId=\"9876\",algorithm=\"hmac-sha1\",signature=\"%s\"", encodedString))
+	req.Header.Set("Authorization", fmt.Sprintf("Signature keyId=\"9876\",algorithm=\"hmac-sha1\",signature=\"%s\"", encodedString))
 
 	chain := getHMACAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -159,7 +159,7 @@ func TestHMACAuthSessionFailureDateExpired(t *testing.T) {
 
 	// Prep the signature string
 	tim := time.Now().Format(refDate)
-	req.Header.Add("Date", tim)
+	req.Header.Set("Date", tim)
 	signatureString := strings.ToLower("Date") + ":" + tim
 
 	// Encode it
@@ -170,7 +170,7 @@ func TestHMACAuthSessionFailureDateExpired(t *testing.T) {
 	sigString := base64.StdEncoding.EncodeToString(h.Sum(nil))
 	encodedString := url.QueryEscape(sigString)
 
-	req.Header.Add("Authorization", fmt.Sprintf("Signature keyId=\"9876\",algorithm=\"hmac-sha1\",signature=\"%s\"", encodedString))
+	req.Header.Set("Authorization", fmt.Sprintf("Signature keyId=\"9876\",algorithm=\"hmac-sha1\",signature=\"%s\"", encodedString))
 
 	chain := getHMACAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -196,7 +196,7 @@ func TestHMACAuthSessionKeyMissing(t *testing.T) {
 
 	// Prep the signature string
 	tim := time.Now().Format(refDate)
-	req.Header.Add("Date", tim)
+	req.Header.Set("Date", tim)
 	signatureString := strings.ToLower("Date") + ":" + tim
 
 	// Encode it
@@ -207,7 +207,7 @@ func TestHMACAuthSessionKeyMissing(t *testing.T) {
 	sigString := base64.StdEncoding.EncodeToString(h.Sum(nil))
 	encodedString := url.QueryEscape(sigString)
 
-	req.Header.Add("Authorization", fmt.Sprintf("Signature keyId=\"98765\",algorithm=\"hmac-sha1\",signature=\"%s\"", encodedString))
+	req.Header.Set("Authorization", fmt.Sprintf("Signature keyId=\"98765\",algorithm=\"hmac-sha1\",signature=\"%s\"", encodedString))
 
 	chain := getHMACAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -233,7 +233,7 @@ func TestHMACAuthSessionMalformedHeader(t *testing.T) {
 
 	// Prep the signature string
 	tim := time.Now().Format(refDate)
-	req.Header.Add("Date", tim)
+	req.Header.Set("Date", tim)
 	signatureString := strings.ToLower("Date") + ":" + tim
 
 	// Encode it
@@ -244,7 +244,7 @@ func TestHMACAuthSessionMalformedHeader(t *testing.T) {
 	sigString := base64.StdEncoding.EncodeToString(h.Sum(nil))
 	encodedString := url.QueryEscape(sigString)
 
-	req.Header.Add("Authorization", fmt.Sprintf("Signature keyID=\"98765\", algorithm=\"hmac-sha256\", signature=\"%s\"", encodedString))
+	req.Header.Set("Authorization", fmt.Sprintf("Signature keyID=\"98765\", algorithm=\"hmac-sha256\", signature=\"%s\"", encodedString))
 
 	chain := getHMACAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -270,9 +270,9 @@ func TestHMACAuthSessionPassWithHeaderField(t *testing.T) {
 
 	// Prep the signature string
 	tim := time.Now().Format(refDate)
-	req.Header.Add("Date", tim)
-	req.Header.Add("X-Test-1", "hello")
-	req.Header.Add("X-Test-2", "world")
+	req.Header.Set("Date", tim)
+	req.Header.Set("X-Test-1", "hello")
+	req.Header.Set("X-Test-2", "world")
 	signatureString := strings.ToLower("(request-target): ") + "get /\n"
 	signatureString += strings.ToLower("Date") + ": " + tim + "\n"
 	signatureString += strings.ToLower("X-Test-1") + ": " + "hello" + "\n"
@@ -286,7 +286,7 @@ func TestHMACAuthSessionPassWithHeaderField(t *testing.T) {
 	sigString := base64.StdEncoding.EncodeToString(h.Sum(nil))
 	encodedString := url.QueryEscape(sigString)
 
-	req.Header.Add("Authorization", fmt.Sprintf("Signature keyId=\"9876\",algorithm=\"hmac-sha1\",headers=\"(request-target) date x-test-1 x-test-2\",signature=\"%s\"", encodedString))
+	req.Header.Set("Authorization", fmt.Sprintf("Signature keyId=\"9876\",algorithm=\"hmac-sha1\",headers=\"(request-target) date x-test-1 x-test-2\",signature=\"%s\"", encodedString))
 
 	chain := getHMACAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -328,9 +328,9 @@ func TestHMACAuthSessionPassWithHeaderFieldLowerCase(t *testing.T) {
 
 	// Prep the signature string
 	tim := time.Now().Format(refDate)
-	req.Header.Add("Date", tim)
-	req.Header.Add("X-Test-1", "hello?")
-	req.Header.Add("X-Test-2", "world£")
+	req.Header.Set("Date", tim)
+	req.Header.Set("X-Test-1", "hello?")
+	req.Header.Set("X-Test-2", "world£")
 	signatureString := strings.ToLower("(request-target): ") + "get /\n"
 	signatureString += strings.ToLower("Date") + ": " + tim + "\n"
 	signatureString += strings.ToLower("X-Test-1") + ": " + "hello?" + "\n"
@@ -347,7 +347,7 @@ func TestHMACAuthSessionPassWithHeaderFieldLowerCase(t *testing.T) {
 	_, upperCaseList := getUpperCaseEscaped(encodedString)
 	newEncodedSignature := replaceUpperCase(encodedString, upperCaseList)
 
-	req.Header.Add("Authorization", fmt.Sprintf("Signature keyId=\"9876\",algorithm=\"hmac-sha1\",headers=\"(request-target) date x-test-1 x-test-2\",signature=\"%s\"", newEncodedSignature))
+	req.Header.Set("Authorization", fmt.Sprintf("Signature keyId=\"9876\",algorithm=\"hmac-sha1\",headers=\"(request-target) date x-test-1 x-test-2\",signature=\"%s\"", newEncodedSignature))
 
 	chain := getHMACAuthChain(spec)
 	chain.ServeHTTP(recorder, req)

--- a/middleware_ip_whitelist_test.go
+++ b/middleware_ip_whitelist_test.go
@@ -73,7 +73,7 @@ func TestIpMiddlewareIPFail(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/", nil)
 	req.RemoteAddr = "127.0.0.1:80"
-	req.Header.Add("authorization", "1234wer")
+	req.Header.Set("authorization", "1234wer")
 
 	chain := getChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -101,9 +101,9 @@ func TestIPMiddlewarePass(t *testing.T) {
 		rec := httptest.NewRecorder()
 		req := testReq(t, "GET", "/", nil)
 		req.RemoteAddr = tc.remote
-		req.Header.Add("authorization", "gfgg1234")
+		req.Header.Set("authorization", "gfgg1234")
 		if tc.forwarded != "" {
-			req.Header.Add("X-Forwarded-For", tc.forwarded)
+			req.Header.Set("X-Forwarded-For", tc.forwarded)
 		}
 
 		chain := getChain(spec)
@@ -122,7 +122,7 @@ func TestIpMiddlewareIPMissing(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/", nil)
-	req.Header.Add("authorization", "1234rtyrty")
+	req.Header.Set("authorization", "1234rtyrty")
 
 	chain := getChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -139,7 +139,7 @@ func TestIpMiddlewareIPDisabled(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/", nil)
-	req.Header.Add("authorization", "1234iuouio")
+	req.Header.Set("authorization", "1234iuouio")
 
 	chain := getChain(spec)
 	chain.ServeHTTP(recorder, req)

--- a/middleware_jwt_test.go
+++ b/middleware_jwt_test.go
@@ -217,7 +217,7 @@ func TestJWTSessionHMAC(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/jwt_test/", nil)
-	req.Header.Add("authorization", tokenString)
+	req.Header.Set("authorization", tokenString)
 
 	chain := getJWTChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -253,7 +253,7 @@ func TestJWTSessionRSA(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/jwt_test/", nil)
-	req.Header.Add("authorization", tokenString)
+	req.Header.Set("authorization", tokenString)
 
 	chain := getJWTChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -282,7 +282,7 @@ func TestJWTSessionFailRSA_EmptyJWT(t *testing.T) {
 	req := testReq(t, "GET", "/jwt_test/", nil)
 
 	// Make it empty
-	req.Header.Add("authorization", "")
+	req.Header.Set("authorization", "")
 
 	chain := getJWTChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -346,7 +346,7 @@ func TestJWTSessionFailRSA_MalformedJWT(t *testing.T) {
 	req := testReq(t, "GET", "/jwt_test/", nil)
 
 	// Make it empty
-	req.Header.Add("authorization", tokenString+"ajhdkjhsdfkjashdkajshdkajhsdkajhsd")
+	req.Header.Set("authorization", tokenString+"ajhdkjhsdfkjashdkajshdkajhsdkajhsd")
 
 	chain := getJWTChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -385,7 +385,7 @@ func TestJWTSessionFailRSA_MalformedJWT_NOTRACK(t *testing.T) {
 	req := testReq(t, "GET", "/jwt_test/", nil)
 
 	// Make it empty
-	req.Header.Add("authorization", tokenString+"ajhdkjhsdfkjashdkajshdkajhsdkajhsd")
+	req.Header.Set("authorization", tokenString+"ajhdkjhsdfkjashdkajshdkajhsdkajhsd")
 
 	chain := getJWTChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -414,7 +414,7 @@ func TestJWTSessionFailRSA_WrongJWT(t *testing.T) {
 	req := testReq(t, "GET", "/jwt_test/", nil)
 
 	// Make it empty
-	req.Header.Add("authorization", "123")
+	req.Header.Set("authorization", "123")
 
 	chain := getJWTChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -451,7 +451,7 @@ func TestJWTSessionRSABearer(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/jwt_test/", nil)
-	req.Header.Add("authorization", "Bearer "+tokenString)
+	req.Header.Set("authorization", "Bearer "+tokenString)
 
 	chain := getJWTChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -488,7 +488,7 @@ func TestJWTSessionRSABearerInvalid(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/jwt_test/", nil)
 	// add a colon here
-	req.Header.Add("authorization", "Bearer: "+tokenString)
+	req.Header.Set("authorization", "Bearer: "+tokenString)
 
 	chain := getJWTChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -543,7 +543,7 @@ func TestJWTSessionRSAWithRawSourceOnWithClientID(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/jwt_test/", nil)
 	// add a colon here
-	req.Header.Add("authorization", "Bearer "+tokenString)
+	req.Header.Set("authorization", "Bearer "+tokenString)
 
 	chain := getJWTChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -591,7 +591,7 @@ func TestJWTSessionRSAWithRawSource(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/jwt_test/", nil)
 	// add a colon here
-	req.Header.Add("authorization", "Bearer "+tokenString)
+	req.Header.Set("authorization", "Bearer "+tokenString)
 
 	chain := getJWTChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -639,7 +639,7 @@ func TestJWTSessionRSAWithRawSourceInvalidPolicyID(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/jwt_test/", nil)
 	// add a colon here
-	req.Header.Add("authorization", "Bearer "+tokenString)
+	req.Header.Set("authorization", "Bearer "+tokenString)
 
 	chain := getJWTChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -687,7 +687,7 @@ func TestJWTSessionRSAWithJWK(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/jwt_test/", nil)
 	// add a colon here
-	req.Header.Add("authorization", "Bearer "+tokenString)
+	req.Header.Set("authorization", "Bearer "+tokenString)
 
 	chain := getJWTChain(spec)
 	chain.ServeHTTP(recorder, req)

--- a/middleware_modify_headers.go
+++ b/middleware_modify_headers.go
@@ -48,7 +48,7 @@ func (t *TransformHeaders) iterateAddHeaders(kv map[string]string, r *http.Reque
 				metaKey := strings.Replace(nVal, metaLabel, "", 1)
 				metaVal, ok := session.MetaData[metaKey]
 				if ok {
-					r.Header.Add(nKey, metaVal)
+					r.Header.Set(nKey, metaVal)
 				} else {
 					log.Warning("Session Meta Data not found for key in map: ", metaKey)
 				}
@@ -60,14 +60,14 @@ func (t *TransformHeaders) iterateAddHeaders(kv map[string]string, r *http.Reque
 				metaKey := strings.Replace(nVal, contextLabel, "", 1)
 				val, ok := contextData[metaKey]
 				if ok {
-					r.Header.Add(nKey, valToStr(val))
+					r.Header.Set(nKey, valToStr(val))
 				} else {
 					log.Warning("Context Data not found for key in map: ", metaKey)
 				}
 			}
 
 		} else {
-			r.Header.Add(nKey, nVal)
+			r.Header.Set(nKey, nVal)
 		}
 	}
 }

--- a/middleware_version_check_test.go
+++ b/middleware_version_check_test.go
@@ -15,8 +15,8 @@ func TestVersionMwExpiresHeader(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/v1/ignored/noregex", nil)
 	req.RemoteAddr = "127.0.0.1:80"
-	req.Header.Add("authorization", "1234xyz")
-	req.Header.Add("version", "v1")
+	req.Header.Set("authorization", "1234xyz")
+	req.Header.Set("version", "v1")
 
 	chain := getChain(spec)
 	chain.ServeHTTP(recorder, req)

--- a/middleware_virtual_endpoint.go
+++ b/middleware_virtual_endpoint.go
@@ -194,7 +194,7 @@ func (d *VirtualEndpoint) ServeHTTPForCache(w http.ResponseWriter, r *http.Reque
 	requestTime := time.Now().UTC().Format(http.TimeFormat)
 
 	for header, value := range newResponseData.Response.Headers {
-		newResponse.Header.Add(header, value)
+		newResponse.Header.Set(header, value)
 	}
 
 	newResponse.ContentLength = int64(len(responseMessage))
@@ -203,8 +203,8 @@ func (d *VirtualEndpoint) ServeHTTPForCache(w http.ResponseWriter, r *http.Reque
 	newResponse.Proto = "HTTP/1.0"
 	newResponse.ProtoMajor = 1
 	newResponse.ProtoMinor = 0
-	newResponse.Header.Add("Server", "tyk")
-	newResponse.Header.Add("Date", requestTime)
+	newResponse.Header.Set("Server", "tyk")
+	newResponse.Header.Set("Date", requestTime)
 
 	// Handle response middleware
 	if err := handleResponseChain(d.Spec.ResponseChain, w, newResponse, r, session); err != nil {
@@ -267,9 +267,9 @@ func (d *VirtualEndpoint) HandleResponse(rw http.ResponseWriter, res *http.Respo
 	// Add resource headers
 	if ses != nil {
 		// We have found a session, lets report back
-		res.Header.Add("X-RateLimit-Limit", strconv.Itoa(int(ses.QuotaMax)))
-		res.Header.Add("X-RateLimit-Remaining", strconv.Itoa(int(ses.QuotaRemaining)))
-		res.Header.Add("X-RateLimit-Reset", strconv.Itoa(int(ses.QuotaRenews)))
+		res.Header.Set("X-RateLimit-Limit", strconv.Itoa(int(ses.QuotaMax)))
+		res.Header.Set("X-RateLimit-Remaining", strconv.Itoa(int(ses.QuotaRemaining)))
+		res.Header.Set("X-RateLimit-Reset", strconv.Itoa(int(ses.QuotaRenews)))
 	}
 
 	copyHeader(rw.Header(), res.Header)

--- a/multiauth_test.go
+++ b/multiauth_test.go
@@ -103,8 +103,8 @@ func TestMultiSession_BA_Standard_OK(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/", nil)
-	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
-	req.Header.Add("x-standard-auth", fmt.Sprintf("Bearer %s", customToken))
+	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", encodedPass))
+	req.Header.Set("x-standard-auth", fmt.Sprintf("Bearer %s", customToken))
 
 	chain := getMultiAuthStandardAndBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -135,8 +135,8 @@ func TestMultiSession_BA_Standard_Identity(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/", nil)
-	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
-	req.Header.Add("x-standard-auth", fmt.Sprintf("Bearer %s", customToken))
+	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", encodedPass))
+	req.Header.Set("x-standard-auth", fmt.Sprintf("Bearer %s", customToken))
 
 	chain := getMultiAuthStandardAndBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -172,8 +172,8 @@ func TestMultiSession_BA_Standard_FAILBA(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/", nil)
-	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
-	req.Header.Add("x-standard-auth", fmt.Sprintf("Bearer %s", customToken))
+	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", encodedPass))
+	req.Header.Set("x-standard-auth", fmt.Sprintf("Bearer %s", customToken))
 
 	chain := getMultiAuthStandardAndBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -204,8 +204,8 @@ func TestMultiSession_BA_Standard_FAILAuth(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/", nil)
-	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedPass))
-	req.Header.Add("x-standard-auth", fmt.Sprintf("Bearer %s", "WRONGTOKEN"))
+	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", encodedPass))
+	req.Header.Set("x-standard-auth", fmt.Sprintf("Bearer %s", "WRONGTOKEN"))
 
 	chain := getMultiAuthStandardAndBasicAuthChain(spec)
 	chain.ServeHTTP(recorder, req)

--- a/plugins.go
+++ b/plugins.go
@@ -358,7 +358,7 @@ func (j *JSVM) LoadTykJSApi() {
 		}
 
 		for k, v := range hro.Headers {
-			r.Header.Add(k, v)
+			r.Header.Set(k, v)
 		}
 		r.Close = true
 		resp, err := client.Do(r)

--- a/policy.go
+++ b/policy.go
@@ -93,10 +93,10 @@ func LoadPoliciesFromDashboard(endpoint, secret string, allowExplicit bool) map[
 		log.Error("Failed to create request: ", err)
 	}
 
-	newRequest.Header.Add("authorization", secret)
-	newRequest.Header.Add("x-tyk-nodeid", NodeID)
+	newRequest.Header.Set("authorization", secret)
+	newRequest.Header.Set("x-tyk-nodeid", NodeID)
 
-	newRequest.Header.Add("x-tyk-nonce", ServiceNonce)
+	newRequest.Header.Set("x-tyk-nonce", ServiceNonce)
 
 	log.WithFields(logrus.Fields{
 		"prefix": "policy",

--- a/res_handler_header_injector.go
+++ b/res_handler_header_injector.go
@@ -38,7 +38,7 @@ func (h HeaderInjector) HandleResponse(rw http.ResponseWriter, res *http.Respons
 			res.Header.Del(dKey)
 		}
 		for nKey, nVal := range hmeta.AddHeaders {
-			res.Header.Add(nKey, nVal)
+			res.Header.Set(nKey, nVal)
 		}
 	}
 
@@ -47,7 +47,7 @@ func (h HeaderInjector) HandleResponse(rw http.ResponseWriter, res *http.Respons
 		res.Header.Del(n)
 	}
 	for h, v := range h.config.AddHeaders {
-		res.Header.Add(h, v)
+		res.Header.Set(h, v)
 	}
 
 	return nil

--- a/tyk_reverse_proxy_clone.go
+++ b/tyk_reverse_proxy_clone.go
@@ -616,9 +616,9 @@ func (p *ReverseProxy) HandleResponse(rw http.ResponseWriter, res *http.Response
 	// Add resource headers
 	if ses != nil {
 		// We have found a session, lets report back
-		res.Header.Add("X-RateLimit-Limit", strconv.Itoa(int(ses.QuotaMax)))
-		res.Header.Add("X-RateLimit-Remaining", strconv.Itoa(int(ses.QuotaRemaining)))
-		res.Header.Add("X-RateLimit-Reset", strconv.Itoa(int(ses.QuotaRenews)))
+		res.Header.Set("X-RateLimit-Limit", strconv.Itoa(int(ses.QuotaMax)))
+		res.Header.Set("X-RateLimit-Remaining", strconv.Itoa(int(ses.QuotaRemaining)))
+		res.Header.Set("X-RateLimit-Reset", strconv.Itoa(int(ses.QuotaRenews)))
 	}
 
 	copyHeader(rw.Header(), res.Header)


### PR DESCRIPTION
Otherwise, if the headers we're modifying were already set, we would
leave duplicates. We don't want to do that in any scenario.