### PR TITLE
all: replace gorilla/context with std's context

### DIFF
--- a/handler_error.go
+++ b/handler_error.go
@@ -9,8 +9,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/gorilla/context"
 )
 
 const (
@@ -75,7 +73,6 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 	}
 
 	if e.Spec.DoNotTrack {
-		context.Clear(r)
 		return
 	}
 
@@ -194,7 +191,4 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 	if memProfFile != nil {
 		pprof.WriteHeapProfile(memProfFile)
 	}
-
-	// Clean up
-	context.Clear(r)
 }

--- a/handler_success.go
+++ b/handler_success.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gorilla/context"
 	"github.com/pmylund/go-cache"
 )
 
@@ -315,8 +314,6 @@ func (s *SuccessHandler) RecordHit(r *http.Request, timing int64, code int, requ
 	if memProfFile != nil {
 		pprof.WriteHeapProfile(memProfFile)
 	}
-
-	context.Clear(r)
 }
 
 // ServeHTTP will store the request details in the analytics store if necessary and proxy the request to it's

--- a/mw_organisation_activity.go
+++ b/mw_organisation_activity.go
@@ -6,8 +6,6 @@ import (
 
 	"errors"
 
-	"github.com/gorilla/context"
-
 	"github.com/Sirupsen/logrus"
 )
 
@@ -112,7 +110,7 @@ func (k *OrganizationMonitor) ProcessRequestLive(w http.ResponseWriter, r *http.
 	}
 
 	// Lets keep a reference of the org
-	context.Set(r, OrgSessionContext, session)
+	setCtxValue(r, OrgSessionContext, session)
 
 	// Request is valid, carry on
 	return nil, 200
@@ -219,7 +217,7 @@ func (k *OrganizationMonitor) AllowAccessNext(orgChan chan bool, r *http.Request
 	}
 
 	// Lets keep a reference of the org
-	context.Set(r, OrgSessionContext, session)
+	setCtxValue(r, OrgSessionContext, session)
 
 	orgChan <- true
 }

--- a/mw_url_rewrite.go
+++ b/mw_url_rewrite.go
@@ -8,8 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gorilla/context"
-
 	"github.com/TykTechnologies/tyk/apidef"
 )
 
@@ -147,7 +145,7 @@ func (m *URLRewriteMiddleware) CheckHostRewrite(oldPath, newTarget string, r *ht
 	newAsURL, _ := url.Parse(newTarget)
 	if oldAsURL.Host != newAsURL.Host {
 		log.Debug("Detected a host rewrite in pattern!")
-		context.Set(r, RetainHost, true)
+		setCtxValue(r, RetainHost, true)
 	}
 }
 

--- a/mw_url_rewrite_test.go
+++ b/mw_url_rewrite_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/http/httptest"
 	"testing"
 
 	"github.com/TykTechnologies/tyk/apidef"
@@ -60,7 +61,8 @@ func TestRewriter(t *testing.T) {
 				MatchPattern: tc.pattern,
 				RewriteTo:    tc.to,
 			}
-			got, err := rw.Rewrite(&testConf, tc.in, false, nil)
+			r := httptest.NewRequest("GET", "/", nil)
+			got, err := rw.Rewrite(&testConf, tc.in, false, r)
 			if err != nil {
 				t.Error("compile failed:", err)
 			}

--- a/util_http_helpers.go
+++ b/util_http_helpers.go
@@ -7,8 +7,6 @@ import (
 	"net"
 	"net/http"
 	"strings"
-
-	"github.com/gorilla/context"
 )
 
 func GetIPFromRequest(r *http.Request) string {
@@ -90,7 +88,7 @@ func RecordDetail(r *http.Request) bool {
 	}
 
 	// We are, so get session data
-	ses := context.Get(r, OrgSessionContext)
+	ses := r.Context().Value(OrgSessionContext)
 	if ses == nil {
 		// no session found, use global config
 		return config.AnalyticsConfig.EnableDetailedRecording


### PR DESCRIPTION
Instead of using a global map, store the context data inside each
http.Request.

This removes an external dependency and removes the necessity to use
gorilla/context.Clear to avoid memory leaks.

Most importantly, not using a hidden global map means that Go plugins as
middlewares will be able to modify request contexts easily.

See the TODO as to why we modify a request's context in-place.

We can't remove gorilla/context from vendor/ as gorilla/mux still
imports it (even though it's not used in Go 1.7+).

Fixes #683.