### PR TITLE
test: use httptest.NewRequest for mock requests

### DIFF
--- a/api_definition_test.go
+++ b/api_definition_test.go
@@ -28,8 +28,8 @@ const sampleDefiniton = `{
 				"expires": "2006-01-02 15:04",
 				"paths": {
 					"ignored": ["/v1/ignored/noregex", "/v1/ignored/with_id/{id}"],
-					"white_list": ["v1/disallowed/blacklist/literal", "v1/disallowed/blacklist/{id}"],
-					"black_list": ["v1/disallowed/whitelist/literal", "v1/disallowed/whitelist/{id}"]
+					"white_list": ["/v1/disallowed/blacklist/literal", "/v1/disallowed/blacklist/{id}"],
+					"black_list": ["/v1/disallowed/whitelist/literal", "/v1/disallowed/whitelist/{id}"]
 				}
 			}
 		}
@@ -57,8 +57,8 @@ const nonExpiringDef = `{
 				"expires": "3000-01-02 15:04",
 				"paths": {
 					"ignored": ["/v1/ignored/noregex", "/v1/ignored/with_id/{id}"],
-					"white_list": ["v1/allowed/whitelist/literal", "v1/allowed/whitelist/{id}"],
-					"black_list": ["v1/disallowed/blacklist/literal", "v1/disallowed/blacklist/{id}"]
+					"white_list": ["/v1/allowed/whitelist/literal", "/v1/allowed/whitelist/{id}"],
+					"black_list": ["/v1/disallowed/blacklist/literal", "/v1/disallowed/blacklist/{id}"]
 				}
 			}
 		}
@@ -86,8 +86,8 @@ const nonExpiringMultiDef = `{
 				"expires": "3000-01-02 15:04",
 				"paths": {
 					"ignored": ["/v1/ignored/noregex", "/v1/ignored/with_id/{id}"],
-					"white_list": ["v1/allowed/whitelist/literal", "v1/allowed/whitelist/{id}"],
-					"black_list": ["v1/disallowed/blacklist/literal", "v1/disallowed/blacklist/{id}"]
+					"white_list": ["/v1/allowed/whitelist/literal", "/v1/allowed/whitelist/{id}"],
+					"black_list": ["/v1/disallowed/blacklist/literal", "/v1/disallowed/blacklist/{id}"]
 				}
 			},
 			"v2": {
@@ -95,7 +95,7 @@ const nonExpiringMultiDef = `{
 				"expires": "3000-01-02 15:04",
 				"paths": {
 					"ignored": ["/v1/ignored/noregex", "/v1/ignored/with_id/{id}"],
-					"black_list": ["v1/disallowed/blacklist/literal"]
+					"black_list": ["/v1/disallowed/blacklist/literal"]
 				}
 			}
 		}
@@ -133,7 +133,7 @@ func TestExpiredRequest(t *testing.T) {
 }
 
 func TestNotVersioned(t *testing.T) {
-	req := testReq(t, "GET", "v1/allowed/whitelist/literal", nil)
+	req := testReq(t, "GET", "/v1/allowed/whitelist/literal", nil)
 
 	spec := createDefinitionFromString(nonExpiringDef)
 	spec.VersionData.NotVersioned = true
@@ -185,7 +185,7 @@ func TestWrongVersion(t *testing.T) {
 }
 
 func TestBlacklistLinks(t *testing.T) {
-	req := testReq(t, "GET", "v1/disallowed/blacklist/literal", nil)
+	req := testReq(t, "GET", "/v1/disallowed/blacklist/literal", nil)
 	req.Header.Set("version", "v1")
 
 	spec := createDefinitionFromString(nonExpiringDef)
@@ -200,7 +200,7 @@ func TestBlacklistLinks(t *testing.T) {
 		t.Error(status)
 	}
 
-	req = testReq(t, "GET", "v1/disallowed/blacklist/abacab12345", nil)
+	req = testReq(t, "GET", "/v1/disallowed/blacklist/abacab12345", nil)
 	req.Header.Set("version", "v1")
 
 	ok, status, _ = spec.IsRequestValid(req)
@@ -215,7 +215,7 @@ func TestBlacklistLinks(t *testing.T) {
 }
 
 func TestWhiteLIstLinks(t *testing.T) {
-	req := testReq(t, "GET", "v1/allowed/whitelist/literal", nil)
+	req := testReq(t, "GET", "/v1/allowed/whitelist/literal", nil)
 	req.Header.Set("version", "v1")
 
 	spec := createDefinitionFromString(nonExpiringDef)
@@ -230,7 +230,7 @@ func TestWhiteLIstLinks(t *testing.T) {
 		t.Error(status)
 	}
 
-	req = testReq(t, "GET", "v1/allowed/whitelist/12345abans", nil)
+	req = testReq(t, "GET", "/v1/allowed/whitelist/12345abans", nil)
 	req.Header.Set("version", "v1")
 
 	ok, status, _ = spec.IsRequestValid(req)
@@ -245,7 +245,7 @@ func TestWhiteLIstLinks(t *testing.T) {
 }
 
 func TestWhiteListBlock(t *testing.T) {
-	req := testReq(t, "GET", "v1/allowed/bananaphone", nil)
+	req := testReq(t, "GET", "/v1/allowed/bananaphone", nil)
 	req.Header.Set("version", "v1")
 
 	spec := createDefinitionFromString(nonExpiringDef)
@@ -279,7 +279,7 @@ func TestIgnored(t *testing.T) {
 }
 
 func TestBlacklistLinksMulti(t *testing.T) {
-	req := testReq(t, "GET", "v1/disallowed/blacklist/literal", nil)
+	req := testReq(t, "GET", "/v1/disallowed/blacklist/literal", nil)
 	req.Header.Set("version", "v2")
 
 	spec := createDefinitionFromString(nonExpiringMultiDef)
@@ -294,7 +294,7 @@ func TestBlacklistLinksMulti(t *testing.T) {
 		t.Error(status)
 	}
 
-	req = testReq(t, "GET", "v1/disallowed/blacklist/abacab12345", nil)
+	req = testReq(t, "GET", "/v1/disallowed/blacklist/abacab12345", nil)
 	req.Header.Set("version", "v2")
 
 	ok, status, _ = spec.IsRequestValid(req)

--- a/batch_requests_test.go
+++ b/batch_requests_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/http"
 	"testing"
 )
 
@@ -95,7 +96,10 @@ func TestMakeSyncRequest(t *testing.T) {
 	batchHandler := BatchRequestHandler{API: spec}
 
 	relURL := "/"
-	req := testReq(t, "GET", testHttpGet, nil)
+	req, err := http.NewRequest("GET", testHttpGet, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	replyUnit := batchHandler.doSyncRequest(req, relURL)
 
@@ -115,7 +119,10 @@ func TestMakeASyncRequest(t *testing.T) {
 	batchHandler := BatchRequestHandler{API: spec}
 
 	relURL := "/"
-	req := testReq(t, "GET", testHttpGet, nil)
+	req, err := http.NewRequest("GET", testHttpGet, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	replies := make(chan BatchReplyUnit)
 	go batchHandler.doAsyncRequest(req, relURL, replies)

--- a/extended_method_versioning_test.go
+++ b/extended_method_versioning_test.go
@@ -50,7 +50,7 @@ const nonExpiringExtendedDef = `{
 					],
 					"white_list": [
 						{
-							"path": "v1/allowed/whitelist/literal",
+							"path": "/v1/allowed/whitelist/literal",
 							"method_actions": {
 								"GET": {
 									"action": "no_action",
@@ -63,7 +63,7 @@ const nonExpiringExtendedDef = `{
 							}
 						},
 						{
-							"path": "v1/allowed/whitelist/reply/{id}",
+							"path": "/v1/allowed/whitelist/reply/{id}",
 							"method_actions": {
 								"GET": {
 									"action": "reply",
@@ -77,7 +77,7 @@ const nonExpiringExtendedDef = `{
 							}
 						},
 						{
-							"path": "v1/allowed/whitelist/{id}",
+							"path": "/v1/allowed/whitelist/{id}",
 							"method_actions": {
 								"GET": {
 									"action": "no_action",
@@ -92,7 +92,7 @@ const nonExpiringExtendedDef = `{
 					],
 					"black_list": [
 						{
-							"path": "v1/disallowed/blacklist/literal",
+							"path": "/v1/disallowed/blacklist/literal",
 							"method_actions": {
 								"GET": {
 									"action": "no_action",
@@ -105,7 +105,7 @@ const nonExpiringExtendedDef = `{
 							}
 						},
 						{
-							"path": "v1/disallowed/blacklist/{id}",
+							"path": "/v1/disallowed/blacklist/{id}",
 							"method_actions": {
 								"GET": {
 									"action": "no_action",
@@ -174,7 +174,7 @@ const nonExpiringExtendedDefNoWhitelist = `{
 					],
 					"black_list": [
 						{
-							"path": "v1/disallowed/blacklist/literal",
+							"path": "/v1/disallowed/blacklist/literal",
 							"method_actions": {
 								"GET": {
 									"action": "no_action",
@@ -187,7 +187,7 @@ const nonExpiringExtendedDefNoWhitelist = `{
 							}
 						},
 						{
-							"path": "v1/disallowed/blacklist/{id}",
+							"path": "/v1/disallowed/blacklist/{id}",
 							"method_actions": {
 								"GET": {
 									"action": "no_action",
@@ -211,7 +211,7 @@ const nonExpiringExtendedDefNoWhitelist = `{
 }`
 
 func TestExtendedBlacklistLinks(t *testing.T) {
-	uri := "v1/disallowed/blacklist/literal"
+	uri := "/v1/disallowed/blacklist/literal"
 	req := testReq(t, "GET", uri, nil)
 	req.Header.Set("version", "v1")
 
@@ -227,7 +227,7 @@ func TestExtendedBlacklistLinks(t *testing.T) {
 		t.Error(status)
 	}
 
-	uri = "v1/disallowed/blacklist/abacab12345"
+	uri = "/v1/disallowed/blacklist/abacab12345"
 	req = testReq(t, "GET", uri, nil)
 	req.Header.Set("version", "v1")
 
@@ -242,7 +242,7 @@ func TestExtendedBlacklistLinks(t *testing.T) {
 	}
 
 	// Test with POST (it's a GET, should pass through)
-	uri = "v1/disallowed/blacklist/abacab12345"
+	uri = "/v1/disallowed/blacklist/abacab12345"
 	req = testReq(t, "POST", uri, nil)
 	req.Header.Set("version", "v1")
 
@@ -258,7 +258,7 @@ func TestExtendedBlacklistLinks(t *testing.T) {
 }
 
 func TestExtendedWhiteLIstLinks(t *testing.T) {
-	uri := "v1/allowed/whitelist/literal"
+	uri := "/v1/allowed/whitelist/literal"
 	req := testReq(t, "GET", uri, nil)
 	req.Header.Set("version", "v1")
 
@@ -274,7 +274,7 @@ func TestExtendedWhiteLIstLinks(t *testing.T) {
 		t.Error(status)
 	}
 
-	uri = "v1/allowed/whitelist/12345abans"
+	uri = "/v1/allowed/whitelist/12345abans"
 	req = testReq(t, "GET", uri, nil)
 	req.Header.Set("version", "v1")
 
@@ -290,7 +290,7 @@ func TestExtendedWhiteLIstLinks(t *testing.T) {
 }
 
 func TestExtendedWhiteListBlock(t *testing.T) {
-	uri := "v1/allowed/bananaphone"
+	uri := "/v1/allowed/bananaphone"
 	req := testReq(t, "GET", uri, nil)
 	req.Header.Set("version", "v1")
 
@@ -326,7 +326,7 @@ func TestExtendedIgnored(t *testing.T) {
 }
 
 func TestExtendedWhiteListWithRedirectedReply(t *testing.T) {
-	uri := "v1/allowed/whitelist/reply/12345"
+	uri := "/v1/allowed/whitelist/reply/12345"
 	req := testReq(t, "GET", uri, nil)
 	req.Header.Set("version", "v1")
 


### PR DESCRIPTION
But do use http.NewRequest for the ones that do get sent to a real HTTP
server, in this case our local version of httpbin.

This is the proper thing to do, as http.NewRequest isn't suitable for
passing directly to an http.Handler as per the httptest docs. Likewise,
httptest is not suitable for creating real requests that will go through
a real HTTP server.

While at it, add client.Do error checking to testHttp which was helpful
in debugging this.