### PR TITLE
mw: give configuration params shorter names

### DIFF
--- a/coprocess.go
+++ b/coprocess.go
@@ -197,7 +197,7 @@ func (m *CoProcessMiddleware) IsEnabledForSpec() bool {
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
-func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
+func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	log.WithFields(logrus.Fields{
 		"prefix": "coprocess",
 	}).Debug("CoProcess Request, HookType: ", m.HookType)

--- a/coprocess_dummy.go
+++ b/coprocess_dummy.go
@@ -39,7 +39,7 @@ func (m *CoProcessMiddleware) GetName() string {
 }
 
 func (m *CoProcessMiddleware) IsEnabledForSpec() bool { return false }
-func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
+func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	return nil, 200
 }
 

--- a/mw_access_rights.go
+++ b/mw_access_rights.go
@@ -19,7 +19,7 @@ func (a *AccessRightsCheck) GetName() string {
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
-func (a *AccessRightsCheck) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
+func (a *AccessRightsCheck) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	accessingVersion := a.Spec.getVersionFromRequest(r)
 	session := ctxGetSession(r)
 	token := ctxGetAuthToken(r)

--- a/mw_auth_key.go
+++ b/mw_auth_key.go
@@ -32,7 +32,7 @@ func (k *AuthKey) setContextVars(r *http.Request, token string) {
 	}
 }
 
-func (k *AuthKey) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
+func (k *AuthKey) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	var tempRes *http.Request
 
 	config := k.Spec.Auth

--- a/mw_basic_auth.go
+++ b/mw_basic_auth.go
@@ -30,7 +30,7 @@ func (k *BasicAuthKeyIsValid) requestForBasicAuth(w http.ResponseWriter, msg str
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
-func (k *BasicAuthKeyIsValid) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
+func (k *BasicAuthKeyIsValid) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	token := r.Header.Get("Authorization")
 	if token == "" {
 		// No header value, fail

--- a/mw_context_vars.go
+++ b/mw_context_vars.go
@@ -20,7 +20,7 @@ func (m *MiddlewareContextVars) IsEnabledForSpec() bool {
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
-func (m *MiddlewareContextVars) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
+func (m *MiddlewareContextVars) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 
 	if !m.Spec.EnableContextVars {
 		return nil, 200

--- a/mw_example_test.go
+++ b/mw_example_test.go
@@ -40,9 +40,9 @@ func (m *modifiedMiddleware) GetConfig() (interface{}, error) {
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
-func (m *modifiedMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
-	conf := configuration.(modifiedMiddlewareConfig)
-	if conf.CustomConfigVar == "error" {
+func (m *modifiedMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, conf interface{}) (error, int) {
+	mconf := conf.(modifiedMiddlewareConfig)
+	if mconf.CustomConfigVar == "error" {
 		return errors.New("Forced error called"), 400
 	}
 	return nil, 200

--- a/mw_granular_access.go
+++ b/mw_granular_access.go
@@ -18,7 +18,7 @@ func (m *GranularAccessMiddleware) GetName() string {
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
-func (m *GranularAccessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
+func (m *GranularAccessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	session := ctxGetSession(r)
 
 	sessionVersionData, foundAPI := session.AccessRights[m.Spec.APIID]

--- a/mw_hmac.go
+++ b/mw_hmac.go
@@ -34,7 +34,7 @@ func (hm *HMACMiddleware) New() {
 	hm.lowercasePattern = regexp.MustCompile(`%[a-f0-9][a-f0-9]`)
 }
 
-func (hm *HMACMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
+func (hm *HMACMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	token := r.Header.Get("Authorization")
 	if token == "" {
 		return hm.authorizationError(r)

--- a/mw_ip_whitelist.go
+++ b/mw_ip_whitelist.go
@@ -20,7 +20,7 @@ func (i *IPWhiteListMiddleware) IsEnabledForSpec() bool {
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
-func (i *IPWhiteListMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
+func (i *IPWhiteListMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	// Disabled, pass through
 	if !i.Spec.EnableIpWhiteListing {
 		return nil, 200

--- a/mw_jwt.go
+++ b/mw_jwt.go
@@ -298,7 +298,7 @@ func (k *JWTMiddleware) processOneToOneTokenMap(r *http.Request, token *jwt.Toke
 	return nil, 200
 }
 
-func (k *JWTMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
+func (k *JWTMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	config := k.Spec.Auth
 	var tykId string
 

--- a/mw_key_expired_check.go
+++ b/mw_key_expired_check.go
@@ -17,7 +17,7 @@ func (k *KeyExpired) GetName() string {
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
-func (k *KeyExpired) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
+func (k *KeyExpired) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	session := ctxGetSession(r)
 	if session == nil {
 		return errors.New("Session state is missing or unset! Please make sure that auth headers are properly applied"), 400

--- a/mw_method_transform.go
+++ b/mw_method_transform.go
@@ -27,7 +27,7 @@ func (t *TransformMethod) IsEnabledForSpec() bool {
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
-func (t *TransformMethod) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
+func (t *TransformMethod) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	_, versionPaths, _, _ := t.Spec.GetVersionData(r)
 	found, meta := t.Spec.CheckSpecMatchesStatus(r.URL.Path, r.Method, versionPaths, MethodTransformed)
 	if found {

--- a/mw_modify_headers.go
+++ b/mw_modify_headers.go
@@ -73,7 +73,7 @@ func (t *TransformHeaders) iterateAddHeaders(kv map[string]string, r *http.Reque
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
-func (t *TransformHeaders) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
+func (t *TransformHeaders) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	vInfo, versionPaths, _, _ := t.Spec.GetVersionData(r)
 
 	// Manage global headers first - remove

--- a/mw_oauth2_key_exists.go
+++ b/mw_oauth2_key_exists.go
@@ -21,7 +21,7 @@ func (k *Oauth2KeyExists) GetName() string {
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
-func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
+func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 
 	// We're using OAuth, start checking for access keys
 	token := r.Header.Get("Authorization")

--- a/mw_openid.go
+++ b/mw_openid.go
@@ -93,7 +93,7 @@ func (k *OpenIDMW) dummyErrorHandler(e error, w http.ResponseWriter, r *http.Req
 	return true
 }
 
-func (k *OpenIDMW) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
+func (k *OpenIDMW) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	// 1. Validate the JWT
 	user, token, halt := openid.AuthenticateOIDWithUser(k.providerConfiguration, w, r)
 

--- a/mw_organisation_activity.go
+++ b/mw_organisation_activity.go
@@ -46,15 +46,15 @@ func (k *OrganizationMonitor) IsEnabledForSpec() bool {
 	return config.EnforceOrgQuotas
 }
 
-func (k *OrganizationMonitor) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
+func (k *OrganizationMonitor) ProcessRequest(w http.ResponseWriter, r *http.Request, conf interface{}) (error, int) {
 	if config.ExperimentalProcessOrgOffThread {
-		return k.ProcessRequestOffThread(w, r, configuration)
+		return k.ProcessRequestOffThread(w, r, conf)
 	}
-	return k.ProcessRequestLive(w, r, configuration)
+	return k.ProcessRequestLive(w, r, conf)
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
-func (k *OrganizationMonitor) ProcessRequestLive(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
+func (k *OrganizationMonitor) ProcessRequestLive(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 
 	if !config.EnforceOrgQuotas {
 		// We aren;t enforcing quotas, so skip this altogether
@@ -127,7 +127,7 @@ func (k *OrganizationMonitor) SetOrgSentinel(orgChan chan bool, orgId string) {
 	}
 }
 
-func (k *OrganizationMonitor) ProcessRequestOffThread(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
+func (k *OrganizationMonitor) ProcessRequestOffThread(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 
 	if !config.EnforceOrgQuotas {
 		// We aren't enforcing quotas, so skip this altogether

--- a/mw_rate_check.go
+++ b/mw_rate_check.go
@@ -10,7 +10,7 @@ func (m *RateCheckMW) GetName() string {
 	return "RateCheckMW"
 }
 
-func (m *RateCheckMW) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
+func (m *RateCheckMW) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	// Let's track r/ps
 	GlobalRate.Incr(1)
 	return nil, 200

--- a/mw_rate_limiting.go
+++ b/mw_rate_limiting.go
@@ -67,7 +67,7 @@ func (k *RateLimitAndQuotaCheck) handleQuotaFailure(r *http.Request, token strin
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
-func (k *RateLimitAndQuotaCheck) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
+func (k *RateLimitAndQuotaCheck) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	session := ctxGetSession(r)
 	token := ctxGetAuthToken(r)
 

--- a/mw_redis_cache.go
+++ b/mw_redis_cache.go
@@ -101,7 +101,7 @@ func (m *RedisCacheMiddleware) decodePayload(payload string) (string, string, er
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
-func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
+func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 
 	// Allow global cache disabe
 	if !m.Spec.CacheOptions.EnableCache {

--- a/mw_request_size_limit.go
+++ b/mw_request_size_limit.go
@@ -69,7 +69,7 @@ func (t *RequestSizeLimitMiddleware) checkRequestLimit(r *http.Request, sizeLimi
 }
 
 // RequestSizeLimit will check a request for maximum request size, this can be a global limit or a matched limit.
-func (t *RequestSizeLimitMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
+func (t *RequestSizeLimitMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	log.Debug("Request size limiter active")
 
 	vInfo, versionPaths, _, _ := t.Spec.GetVersionData(r)

--- a/mw_track_endpoints.go
+++ b/mw_track_endpoints.go
@@ -16,7 +16,7 @@ func (a *TrackEndpointMiddleware) GetName() string {
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
-func (a *TrackEndpointMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
+func (a *TrackEndpointMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	_, versionPaths, _, _ := a.Spec.GetVersionData(r)
 	foundTracked, metaTrack := a.Spec.CheckSpecMatchesStatus(r.URL.Path, r.Method, versionPaths, RequestTracked)
 	if foundTracked {

--- a/mw_transform.go
+++ b/mw_transform.go
@@ -37,7 +37,7 @@ func (t *TransformMiddleware) IsEnabledForSpec() bool {
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
-func (t *TransformMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
+func (t *TransformMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	_, versionPaths, _, _ := t.Spec.GetVersionData(r)
 	found, meta := t.Spec.CheckSpecMatchesStatus(r.URL.Path, r.Method, versionPaths, Transformed)
 	if !found {

--- a/mw_url_rewrite.go
+++ b/mw_url_rewrite.go
@@ -152,7 +152,7 @@ func (m *URLRewriteMiddleware) CheckHostRewrite(oldPath, newTarget string, r *ht
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
-func (m *URLRewriteMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
+func (m *URLRewriteMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	_, versionPaths, _, _ := m.Spec.GetVersionData(r)
 	found, meta := m.Spec.CheckSpecMatchesStatus(r.URL.Path, r.Method, versionPaths, URLRewrite)
 	if found {

--- a/mw_version_check.go
+++ b/mw_version_check.go
@@ -36,7 +36,7 @@ func (v *VersionCheck) DoMockReply(w http.ResponseWriter, meta interface{}) {
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
-func (v *VersionCheck) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
+func (v *VersionCheck) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	// Check versioning, blacklist, whitelist and ignored status
 	requestValid, stat, meta := v.Spec.IsRequestValid(r)
 	if !requestValid {

--- a/mw_virtual_endpoint.go
+++ b/mw_virtual_endpoint.go
@@ -244,7 +244,7 @@ func (d *VirtualEndpoint) ServeHTTPForCache(w http.ResponseWriter, r *http.Reque
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
-func (d *VirtualEndpoint) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
+func (d *VirtualEndpoint) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 
 	res := d.ServeHTTPForCache(w, r)
 

--- a/plugins.go
+++ b/plugins.go
@@ -78,7 +78,7 @@ func (d *DynamicMiddleware) GetConfig() (interface{}, error) {
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
-func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
+func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 
 	t1 := time.Now().UnixNano()
 


### PR DESCRIPTION
To align with the interface and make lines shorter.

And just "_" if they're unused.
