### PR TITLE
all: get rid of a couple of interface fields

### DIFF
--- a/oauth_manager.go
+++ b/oauth_manager.go
@@ -37,11 +37,11 @@ Effort required by Resource Owner:
 
 // OAuthClient is a representation within an APISpec of a client
 type OAuthClient struct {
-	ClientID          string      `json:"id"`
-	ClientSecret      string      `json:"secret"`
-	ClientRedirectURI string      `json:"redirecturi"`
-	UserData          interface{} `json:",omitempty"`
-	PolicyID          string      `json:"policyid"`
+	ClientID          string `json:"id"`
+	ClientSecret      string `json:"secret"`
+	ClientRedirectURI string `json:"redirecturi"`
+	UserData          string `json:",omitempty"`
+	PolicyID          string `json:"policyid"`
 }
 
 func (oc *OAuthClient) GetId() string {

--- a/redis_signal_outbound.go
+++ b/redis_signal_outbound.go
@@ -11,7 +11,6 @@ type InterfaceNotification struct {
 	Type      string
 	Message   string
 	OrgID     string
-	Payload   interface{}
 	Timestamp time.Time
 }
 


### PR DESCRIPTION
One is unused, and the other is always a string.

In the latter case we still have to use it as an interface{} due to the
osin library, though. But having a specific type for the field gives us
a bit more confidence in our type assertions.