### PR TITLE
api: filter allowed methods in an HTTP middleware

### DIFF
--- a/api.go
+++ b/api.go
@@ -53,6 +53,18 @@ func doJSONWrite(w http.ResponseWriter, code int, obj interface{}) {
 	}
 }
 
+func allowMethods(next http.HandlerFunc, methods ...string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		for _, method := range methods {
+			if r.Method == method {
+				next(w, r)
+				return
+			}
+		}
+		doJSONWrite(w, 405, apiError("Method not supported"))
+	}
+}
+
 func GetSpecForOrg(apiID string) *APISpec {
 	var aKey string
 	for k, v := range apisByID {
@@ -574,9 +586,6 @@ func apiHandler(w http.ResponseWriter, r *http.Request) {
 		} else {
 			obj, code = apiError("Must specify an apiID to delete"), 400
 		}
-	default:
-		// Return Not supported message (and code)
-		obj, code = apiError("Method not supported"), 405
 	}
 
 	doJSONWrite(w, code, obj)
@@ -610,10 +619,6 @@ func keyHandler(w http.ResponseWriter, r *http.Request) {
 		} else {
 			obj, code = handleDeleteHashedKey(keyName, apiID)
 		}
-
-	default:
-		// Return Not supported message (and code)
-		obj, code = apiError("Method not supported"), 405
 	}
 
 	doJSONWrite(w, code, obj)
@@ -625,10 +630,6 @@ type PolicyUpdateObj struct {
 
 func policyUpdateHandler(w http.ResponseWriter, r *http.Request) {
 	log.Warning("Hashed key change request detected!")
-	if r.Method != "POST" {
-		doJSONWrite(w, 405, apiError("Method not supported"))
-		return
-	}
 
 	var policRecord PolicyUpdateObj
 	if err := json.NewDecoder(r.Body).Decode(&policRecord); err != nil {
@@ -743,10 +744,6 @@ func orgHandler(w http.ResponseWriter, r *http.Request) {
 	case "DELETE":
 		// Remove a key
 		obj, code = handleDeleteOrgKey(keyName)
-
-	default:
-		// Return Not supported message (and code)
-		obj, code = apiError("Method not supported"), 405
 	}
 
 	doJSONWrite(w, code, obj)
@@ -874,55 +871,23 @@ func handleDeleteOrgKey(orgID string) (interface{}, int) {
 }
 
 func groupResetHandler(w http.ResponseWriter, r *http.Request) {
-	var obj interface{}
-	var code int
+	log.WithFields(logrus.Fields{
+		"prefix": "api",
+		"status": "ok",
+	}).Info("Group reload accepted.")
 
-	if r.Method == "GET" {
-		log.WithFields(logrus.Fields{
-			"prefix": "api",
-			"status": "ok",
-		}).Info("Group reload accepted.")
-
-		obj, code = signalGroupReload()
-
-	} else {
-		log.WithFields(logrus.Fields{
-			"prefix": "api",
-			"status": "fail",
-			"err":    "wrong method",
-		}).Error("Group reload failed.")
-		obj, code = apiError("Method not supported"), 405
-	}
-
+	obj, code := signalGroupReload()
 	doJSONWrite(w, code, obj)
 }
 
 func resetHandler(fn func()) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		var obj interface{}
-		var code int
-
-		if r.Method == "GET" {
-			obj, code = handleURLReload(fn)
-		} else {
-			obj, code = apiError("Method not supported"), 405
-		}
-
+		obj, code := handleURLReload(fn)
 		doJSONWrite(w, code, obj)
 	}
 }
 
 func createKeyHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != "POST" {
-		log.WithFields(logrus.Fields{
-			"prefix": "api",
-			"status": "fail",
-			"method": r.Method,
-		}).Warning("Attempted to create key with wrong HTTP method.")
-		doJSONWrite(w, 405, apiError("Method not supported"))
-		return
-	}
-
 	newSession := new(SessionState)
 	if err := json.NewDecoder(r.Body).Decode(newSession); err != nil {
 		log.WithFields(logrus.Fields{
@@ -1059,11 +1024,6 @@ func createOauthClientStorageID(clientID string) string {
 }
 
 func createOauthClient(w http.ResponseWriter, r *http.Request) {
-
-	if r.Method != "POST" {
-		doJSONWrite(w, 405, apiError("Method not supported"))
-		return
-	}
 	var newOauthClient NewClientRequest
 	if err := json.NewDecoder(r.Body).Decode(&newOauthClient); err != nil {
 		log.WithFields(logrus.Fields{
@@ -1143,10 +1103,6 @@ func createOauthClient(w http.ResponseWriter, r *http.Request) {
 }
 
 func invalidateOauthRefresh(w http.ResponseWriter, r *http.Request) {
-	if r.Method != "DELETE" {
-		doJSONWrite(w, 405, apiError("Method not supported"))
-		return
-	}
 	apiID := r.FormValue("api_id")
 	if apiID == "" {
 		doJSONWrite(w, 400, apiError("Missing parameter api_id"))
@@ -1229,7 +1185,7 @@ func oAuthClientHandler(w http.ResponseWriter, r *http.Request) {
 	case 1:
 		apiID = parts[0]
 	default:
-		doJSONWrite(w, 405, apiError("Method not supported"))
+		doJSONWrite(w, 400, apiError("Missing URL params"))
 		return
 	}
 
@@ -1245,9 +1201,6 @@ func oAuthClientHandler(w http.ResponseWriter, r *http.Request) {
 	case "DELETE":
 		// Remove a key
 		obj, code = handleDeleteOAuthClient(keyName, apiID)
-	default:
-		// Return Not supported message (and code)
-		obj, code = apiError("Method not supported"), 405
 	}
 
 	doJSONWrite(w, code, obj)
@@ -1382,10 +1335,6 @@ func getOauthClients(apiID string) (interface{}, int) {
 }
 
 func healthCheckhandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != "GET" {
-		doJSONWrite(w, 405, apiError("Method not supported"))
-		return
-	}
 	if !config.HealthCheck.EnableHealthChecks {
 		doJSONWrite(w, 400, apiError("Health checks are not enabled for this node"))
 		return
@@ -1424,10 +1373,6 @@ func UserRatesCheck() http.HandlerFunc {
 }
 
 func invalidateCacheHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != "DELETE" {
-		doJSONWrite(w, 405, apiError("Method not supported"))
-		return
-	}
 	apiID := r.URL.Path[len("/tyk/cache/"):]
 
 	spec := apisByID[apiID]

--- a/api_test.go
+++ b/api_test.go
@@ -368,6 +368,16 @@ func TestKeyHandlerDeleteKey(t *testing.T) {
 	}
 }
 
+func TestMethodNotSupported(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	req := withAuth(testReq(t, "POST", "/tyk/reload/", nil))
+
+	mainRouter.ServeHTTP(recorder, req)
+	if recorder.Code != 405 {
+		t.Fatal(`Wanted response to be 405 since the wrong method was used`)
+	}
+}
+
 func TestCreateKeyHandlerCreateNewKey(t *testing.T) {
 	for _, api_id := range []string{"1", "none", ""} {
 		createKey(t)


### PR DESCRIPTION
Removes quite a lot of boilerplate.

Unfortunately, we can't use gorilla/mux's Methods() as that one results
in 404s instead of 405s. This is because it keeps the routes from
matching, resulting in no matching route being a 404.