### PR TITLE
Host checker race fixes

### DIFF
--- a/host_checker_manager.go
+++ b/host_checker_manager.go
@@ -336,8 +336,8 @@ func (hc *HostCheckerManager) UpdateTrackingList(hd []HostData) {
 		newHostList[host.CheckURL] = host
 	}
 
-	hc.currentHostList = newHostList
 	hc.checkerMu.Lock()
+	hc.currentHostList = newHostList
 	if hc.checker != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "host-check-mgr",
@@ -353,6 +353,7 @@ func (hc *HostCheckerManager) UpdateTrackingListByAPIID(hd []HostData, apiId str
 	}).Debug("--- Setting tracking list up for ID: ", apiId)
 	newHostList := make(map[string]HostData)
 
+	hc.checkerMu.Lock()
 	for _, existingHost := range hc.currentHostList {
 		if existingHost.MetaData[UnHealthyHostMetaDataAPIKey] != apiId {
 			// Add the old check list that excludes this API
@@ -372,6 +373,7 @@ func (hc *HostCheckerManager) UpdateTrackingListByAPIID(hd []HostData, apiId str
 		}).Debug("Reset initiated")
 		hc.checker.ResetList(newHostList)
 	}
+	hc.checkerMu.Unlock()
 	log.WithFields(logrus.Fields{
 		"prefix": "host-check-mgr",
 	}).Info("--- Queued tracking list update for API: ", apiId)


### PR DESCRIPTION
For 2.3.7.

Most of the races left in `go test -race` are related to Redis now. Before this patch, about half of them were the host checker, which was entirely our fault for sure.

I realise `sync.Mutex` is perhaps not the best way to handle this. Options include `sync.RWMutex`, channels, and worker goroutines. But since this is something we want to include in 2.3.7, I went for the dumbest and simplest fix to get rid of the races.

Once `go test -race` is clean of all races, we can safely refactor this to be more elegant. Until then, it's hard to tell if we're introducing races or not as we have quite a lot of races left. For this PR, I had to read them one by one manually to know if they were related to the host checker or not.

Part of #825