### PR TITLE
mw: don't copy entire request to get a cookie

### DIFF
--- a/mw_auth_key.go
+++ b/mw_auth_key.go
@@ -59,11 +59,8 @@ func (k *AuthKey) ProcessRequest(w http.ResponseWriter, r *http.Request, _ inter
 		if cookieName == "" {
 			cookieName = config.AuthHeaderName
 		}
-		if tempRes == nil {
-			tempRes = CopyHttpRequest(r)
-		}
 
-		authCookie, err := tempRes.Cookie(cookieName)
+		authCookie, err := r.Cookie(cookieName)
 		cookieValue := ""
 		if err == nil {
 			cookieValue = authCookie.Value

--- a/mw_jwt.go
+++ b/mw_jwt.go
@@ -312,8 +312,7 @@ func (k *JWTMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _
 	}
 
 	if config.UseCookie {
-		tempRes := CopyHttpRequest(r)
-		authCookie, err := tempRes.Cookie(config.AuthHeaderName)
+		authCookie, err := r.Cookie(config.AuthHeaderName)
 		if err != nil {
 			rawJWT = ""
 		} else {


### PR DESCRIPTION
Cookies always sit in headers, so it's safe to reuse the same request as
there is no chance that we will read the body or otherwise modify the
request like when accessing form values.