### PR TITLE
api: dedup auth and instrumentation mware usage

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -433,7 +433,7 @@ func TestAPIAuthOk(t *testing.T) {
 	mainRouter.ServeHTTP(recorder, req)
 
 	if recorder.Code != 200 {
-		t.Error("Access to API should have been blocked, but response code was: ", recorder.Code)
+		t.Error("Access to API should have gone through, but response code was: ", recorder.Code)
 	}
 }
 

--- a/instrumentation_handlers.go
+++ b/instrumentation_handlers.go
@@ -44,11 +44,11 @@ func SetupInstrumentation(enabled bool) {
 }
 
 // InstrumentationMW will set basic instrumentation events, variables and timers on API jobs
-func InstrumentationMW(handler http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+func InstrumentationMW(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		job := instrument.NewJob("SystemAPICall")
 
-		handler(w, r)
+		next.ServeHTTP(w, r)
 		job.EventKv("called", health.Kvs{
 			"from_ip":  r.RemoteAddr,
 			"method":   r.Method,
@@ -57,7 +57,7 @@ func InstrumentationMW(handler http.HandlerFunc) http.HandlerFunc {
 			"size":     strconv.Itoa(int(r.ContentLength)),
 		})
 		job.Complete(health.Success)
-	}
+	})
 }
 
 func MonitorApplicationInstrumentation() {


### PR DESCRIPTION
Make them proper HTTP middlewares that use http.Handlers, not
http.HandlerFuncs. This way, we can layer them at the router level for
all routes.

We need two routers and it's a bit ugly because gorilla/mux has no
built-in support for chaining middlewares. But it still works.