### PR TITLE
Hostcheck fixes backport

### DIFF
--- a/host_checker_manager.go
+++ b/host_checker_manager.go
@@ -343,8 +343,8 @@ func (hc *HostCheckerManager) UpdateTrackingList(hd []HostData) {
 		newHostList[host.CheckURL] = host
 	}
 
-	hc.currentHostList = newHostList
 	hc.checkerMu.Lock()
+	hc.currentHostList = newHostList
 	if hc.checker != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "host-check-mgr",
@@ -360,6 +360,7 @@ func (hc *HostCheckerManager) UpdateTrackingListByAPIID(hd []HostData, apiId str
 	}).Debug("--- Setting tracking list up for ID: ", apiId)
 	newHostList := make(map[string]HostData)
 
+	hc.checkerMu.Lock()
 	for _, existingHost := range hc.currentHostList {
 		if existingHost.MetaData[UnHealthyHostMetaDataAPIKey] != apiId {
 			// Add the old check list that excludes this API
@@ -379,6 +380,7 @@ func (hc *HostCheckerManager) UpdateTrackingListByAPIID(hd []HostData, apiId str
 		}).Debug("Reset initiated")
 		hc.checker.ResetList(&newHostList)
 	}
+	hc.checkerMu.Unlock()
 	log.WithFields(logrus.Fields{
 		"prefix": "host-check-mgr",
 	}).Info("--- Queued tracking list update for API: ", apiId)

--- a/round_robin.go
+++ b/round_robin.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"sync"
+
 	"github.com/TykTechnologies/tykcommon"
 )
 
 type RoundRobin struct {
+	sync.Mutex
 	pos int
 	max int
 	cur int

--- a/tyk_reverse_proxy_clone.go
+++ b/tyk_reverse_proxy_clone.go
@@ -98,14 +98,10 @@ func GetNextTarget(targetData *tykcommon.HostList, spec *APISpec, tryCount int) 
 	if spec.Proxy.EnableLoadBalancing {
 		log.Debug("[PROXY] [LOAD BALANCING] Load balancer enabled, getting upstream target")
 		// Use a HostList
+		spec.RoundRobin.Lock()
 		spec.RoundRobin.SetMax(targetData)
-
 		pos := spec.RoundRobin.GetPos()
-		if pos > (targetData.Len() - 1) {
-			// problem
-			spec.RoundRobin.SetMax(targetData)
-			pos = 0
-		}
+		spec.RoundRobin.Unlock()
 
 		gotHost, err := targetData.GetIndex(pos)
 		if err != nil {


### PR DESCRIPTION
Covers #822 and #825 for 2.3.7.

There are no tests for this in 2.3.x, so we need QA to confirm that the issue is still fixed after backporting.