### PR TITLE
A couple of redis race fixes

### DIFF
--- a/vendor/github.com/lonelycode/redigocluster/rediscluster/concurrent_map.go
+++ b/vendor/github.com/lonelycode/redigocluster/rediscluster/concurrent_map.go
@@ -12,8 +12,6 @@ const (
 	SHARD_COUNT_ENV = "REDIGOCLUSTER_SHARDCOUNT"
 )
 
-var customShardCount string
-
 // A "thread" safe map of type string:Anything.
 // To avoid lock bottlenecks this map is dived to several (SHARD_COUNT) map shards.
 type ConcurrentMap []*ConcurrentMapShared
@@ -27,7 +25,7 @@ type ConcurrentMapShared struct {
 // Creates a new concurrent map.
 func NewCmap() ConcurrentMap {
 	var nShards int
-	customShardCount = os.Getenv(SHARD_COUNT_ENV)
+	customShardCount := os.Getenv(SHARD_COUNT_ENV)
 	if customShardCount == "" {
 		nShards = SHARD_COUNT
 	} else {


### PR DESCRIPTION
I realise I'm changing a vendored lib directly, but it's one that we've already forked and we're going to replace soon.

If we want that fix in the dashboard, pump or other uses of rediscluster, we can always port it.

`go test -race` is still fairly unhappy, especially with the analytics code. But this slashes the amount of reports by almost half.