### PR TITLE
Add support for MDCB secure connection

### DIFF
--- a/config.go
+++ b/config.go
@@ -74,6 +74,8 @@ type MonitorConfig struct {
 
 type SlaveOptionsConfig struct {
 	UseRPC                          bool   `json:"use_rpc"`
+	UseSSL                          bool   `json:"use_ssl"`
+	SSLInsecureSkipVerify           bool   `json:"ssl_insecure_skip_verify"`
 	ConnectionString                string `json:"connection_string"`
 	RPCKey                          string `json:"rpc_key"`
 	APIKey                          string `json:"api_key"`

--- a/rpc_storage_handler.go
+++ b/rpc_storage_handler.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"errors"
 	"io"
 	"strings"
@@ -144,7 +145,15 @@ func (r *RPCStorageHandler) Connect() bool {
 	// RPC Client is unset
 	// Set up the cache
 	log.Info("Setting new RPC connection!")
-	RPCCLientSingleton = gorpc.NewTCPClient(r.Address)
+	if config.SlaveOptions.UseSSL {
+		clientCfg := &tls.Config{
+			InsecureSkipVerify: config.SlaveOptions.SSLInsecureSkipVerify,
+		}
+
+		RPCCLientSingleton = gorpc.NewTLSClient(r.Address, clientCfg)
+	} else {
+		RPCCLientSingleton = gorpc.NewTCPClient(r.Address)
+	}
 
 	if log.Level != logrus.DebugLevel {
 		gorpc.SetErrorLogger(gorpc.NilErrorLogger)


### PR DESCRIPTION
Now hybrid and mdcb clients can use secured connection.
Added new boolean options to “slave_options” section: `use_ssl` and
`ssl_insecure_skip_verify`

MDCB part https://github.com/TykTechnologies/tyk-sink/pull/10

Fixes https://github.com/TykTechnologies/tyk/issues/826