### PR TITLE
api: don't copy request to get an URL parameter

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -959,8 +959,7 @@ func (a *APISpec) getVersionFromRequest(r *http.Request) string {
 		return r.Header.Get(a.APIDefinition.VersionDefinition.Key)
 
 	case "url-param":
-		tempRes := CopyHttpRequest(r)
-		return tempRes.FormValue(a.APIDefinition.VersionDefinition.Key)
+		return r.URL.Query().Get(a.APIDefinition.VersionDefinition.Key)
 
 	case "url":
 		url := strings.Replace(r.URL.Path, a.Proxy.ListenPath, "", 1)


### PR DESCRIPTION
This is when getting the key to find the name of the API version to use.

FormValue did the trick because on top of POST and PUT body forms it
also uses URL query parameters. But that may also parses the body, hence
why we needed the copy.

But all we want is URL parameters, so use that directly and avoid the
request copy.

As just discussed AFK with @lonelycode. No change in behavior, other than we no longer unnecessarily buffer and copoy a request in this case.