### PR TITLE
RPC client should send pool ID on connection

### DIFF
--- a/api_definition_test.go
+++ b/api_definition_test.go
@@ -479,7 +479,7 @@ func (ln *customListener) Accept() (conn io.ReadWriteCloser, clientAddr string, 
 		return
 	}
 
-	handshake := make([]byte, 8)
+	handshake := make([]byte, 6)
 	if _, err = io.ReadFull(c, handshake); err != nil {
 		return
 	}

--- a/api_definition_test.go
+++ b/api_definition_test.go
@@ -476,24 +476,18 @@ func (ln *customListener) Accept() (conn io.ReadWriteCloser, clientAddr string, 
 	}
 
 	handshake := make([]byte, 8)
-	_, err = c.Read(handshake)
-
-	// Let gorpc handle it
-	if err != nil {
+	if _, err = io.ReadFull(c, handshake); err != nil {
 		return
 	}
 
 	idLenBuf := make([]byte, 1)
-	_, err = c.Read(idLenBuf)
-	if err != nil {
+	if _, err = io.ReadFull(c, idLenBuf); err != nil {
 		return
 	}
 
 	idLen := uint8(idLenBuf[0])
 	id := make([]byte, idLen)
-	_, err = c.Read(id)
-
-	if err != nil {
+	if _, err = io.ReadFull(c, id); err != nil {
 		return
 	}
 

--- a/api_definition_test.go
+++ b/api_definition_test.go
@@ -317,6 +317,8 @@ func startRPCMock(dispatcher *gorpc.Dispatcher) *gorpc.Server {
 
 	server := gorpc.NewTCPServer(":9090", dispatcher.NewHandlerFunc())
 	server.Listener = &customListener{}
+	server.LogError = gorpc.NilErrorLogger
+
 	globalConf.SlaveOptions.ConnectionString = server.Addr
 
 	go server.Serve()

--- a/api_definition_test.go
+++ b/api_definition_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -315,14 +317,10 @@ func startRPCMock(dispatcher *gorpc.Dispatcher) *gorpc.Server {
 	config.SlaveOptions.APIKey = "test"
 
 	server := gorpc.NewTCPServer(":9090", dispatcher.NewHandlerFunc())
-	go server.Serve()
+	server.Listener = &customListener{}
 	config.SlaveOptions.ConnectionString = server.Addr
 
-	RPCCLientSingleton = gorpc.NewTCPClient(server.Addr)
-	RPCCLientSingleton.Conns = 1
-	RPCCLientSingleton.Start()
-	RPCClientIsConnected = true
-	RPCFuncClientSingleton = getDispatcher().NewFuncClient(RPCCLientSingleton)
+	go server.Serve()
 
 	return server
 }
@@ -436,4 +434,72 @@ func TestRoundRobin(t *testing.T) {
 			t.Errorf("RR Pos wrong: want %d got %d", want, got)
 		}
 	}
+}
+
+func setupKeepalive(conn net.Conn) error {
+	tcpConn := conn.(*net.TCPConn)
+	if err := tcpConn.SetKeepAlive(true); err != nil {
+		return err
+	}
+	if err := tcpConn.SetKeepAlivePeriod(30 * time.Second); err != nil {
+		return err
+	}
+	return nil
+}
+
+type customListener struct {
+	L net.Listener
+}
+
+func (ln *customListener) Init(addr string) (err error) {
+	ln.L, err = net.Listen("tcp", addr)
+	return
+}
+
+func (ln *customListener) ListenAddr() net.Addr {
+	if ln.L != nil {
+		return ln.L.Addr()
+	}
+	return nil
+}
+
+func (ln *customListener) Accept() (conn io.ReadWriteCloser, clientAddr string, err error) {
+	c, err := ln.L.Accept()
+
+	if err != nil {
+		return
+	}
+
+	if err = setupKeepalive(c); err != nil {
+		c.Close()
+		return
+	}
+
+	handshake := make([]byte, 8)
+	_, err = c.Read(handshake)
+
+	// Let gorpc handle it
+	if err != nil {
+		return
+	}
+
+	idLenBuf := make([]byte, 1)
+	_, err = c.Read(idLenBuf)
+	if err != nil {
+		return
+	}
+
+	idLen := uint8(idLenBuf[0])
+	id := make([]byte, idLen)
+	_, err = c.Read(id)
+
+	if err != nil {
+		return
+	}
+
+	return c, string(id), nil
+}
+
+func (ln *customListener) Close() error {
+	return ln.L.Close()
 }

--- a/config.go
+++ b/config.go
@@ -74,6 +74,8 @@ type MonitorConfig struct {
 
 type SlaveOptionsConfig struct {
 	UseRPC                          bool   `json:"use_rpc"`
+	UseSSL                          bool   `json:"use_ssl"`
+	SSLInsecureSkipVerify           bool   `json:"ssl_insecure_skip_verify"`
 	ConnectionString                string `json:"connection_string"`
 	RPCKey                          string `json:"rpc_key"`
 	APIKey                          string `json:"api_key"`

--- a/rpc_storage_handler.go
+++ b/rpc_storage_handler.go
@@ -184,7 +184,7 @@ func (r *RPCStorageHandler) Connect() bool {
 			return
 		}
 
-		conn.Write([]byte("register"))
+		conn.Write([]byte("proto2"))
 		conn.Write([]byte{byte(len(RPCClientSingletonConnectionID))})
 		conn.Write([]byte(RPCClientSingletonConnectionID))
 		return conn, nil

--- a/rpc_storage_handler.go
+++ b/rpc_storage_handler.go
@@ -159,7 +159,7 @@ func (r *RPCStorageHandler) Connect() bool {
 	}
 
 	if log.Level != logrus.DebugLevel {
-		gorpc.SetErrorLogger(gorpc.NilErrorLogger)
+		RPCCLientSingleton.LogError = gorpc.NilErrorLogger
 	}
 
 	RPCCLientSingleton.OnConnect = r.OnConnectFunc

--- a/rpc_storage_handler.go
+++ b/rpc_storage_handler.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"errors"
 	"io"
 	"strings"
@@ -144,7 +145,15 @@ func (r *RPCStorageHandler) Connect() bool {
 	// RPC Client is unset
 	// Set up the cache
 	log.Info("Setting new RPC connection!")
-	RPCCLientSingleton = gorpc.NewTCPClient(r.Address)
+	if config.SlaveOptions.UseSSL {
+		clientCfg := &tls.Config{
+			InsecureSkipVerify: config.SlaveOptions.SSLInsecureSkipVerify,
+		}
+
+		RPCCLientSingleton = gorpc.NewTLSClient(r.Address, clientCfg)
+	} else {
+		RPCCLientSingleton = gorpc.NewTCPClient(r.Address)
+	}
 
 	if log.Level != logrus.DebugLevel {
 		gorpc.SetErrorLogger(gorpc.NilErrorLogger)

--- a/rpc_storage_handler.go
+++ b/rpc_storage_handler.go
@@ -142,12 +142,12 @@ func (r *RPCStorageHandler) Connect() bool {
 
 	RPCClientSingletonConnectionID = uuid.NewV4().String()
 
-    // Length should fit into 1 byte. Protection if we decide change uuid in future.
-    if len(RPCClientSingletonConnectionID) > 255 {
-        panic("RPCClientSingletonConnectionID is too long")
-    }
+	// Length should fit into 1 byte. Protection if we decide change uuid in future.
+	if len(RPCClientSingletonConnectionID) > 255 {
+		panic("RPCClientSingletonConnectionID is too long")
+	}
 
-    if globalConf.SlaveOptions.UseSSL {
+	if globalConf.SlaveOptions.UseSSL {
 		clientCfg := &tls.Config{
 			InsecureSkipVerify: globalConf.SlaveOptions.SSLInsecureSkipVerify,
 		}

--- a/rpc_storage_handler.go
+++ b/rpc_storage_handler.go
@@ -142,6 +142,11 @@ func (r *RPCStorageHandler) Connect() bool {
 
 	RPCClientSingletonConnectionID = uuid.NewV4().String()
 
+    // Length should fit into 1 byte. Protection if we decide change uuid in future.
+    if len(RPCClientSingletonConnectionID) > 255 {
+        panic("RPCClientSingletonConnectionID is too long")
+    }
+
     if globalConf.SlaveOptions.UseSSL {
 		clientCfg := &tls.Config{
 			InsecureSkipVerify: globalConf.SlaveOptions.SSLInsecureSkipVerify,

--- a/rpc_storage_handler.go
+++ b/rpc_storage_handler.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/garyburd/redigo/redis"
@@ -123,6 +124,7 @@ func (r *RPCStorageHandler) ReConnect() {
 }
 
 var RPCCLientSingleton *gorpc.Client
+var RPCCLientSingletonMu sync.Mutex
 var RPCClientSingletonConnectionID string
 var RPCFuncClientSingleton *gorpc.DispatcherClient
 var RPCGlobalCache = cache.New(30*time.Second, 15*time.Second)
@@ -130,7 +132,6 @@ var RPCClientIsConnected bool
 
 // Connect will establish a connection to the DB
 func (r *RPCStorageHandler) Connect() bool {
-
 	if RPCClientIsConnected {
 		log.Debug("Using RPC singleton for connection")
 		return true
@@ -206,6 +207,9 @@ func (r *RPCStorageHandler) Connect() bool {
 }
 
 func (r *RPCStorageHandler) OnConnectFunc(remoteAddr string, rwc io.ReadWriteCloser) (io.ReadWriteCloser, error) {
+	RPCCLientSingletonMu.Lock()
+	defer RPCCLientSingletonMu.Unlock()
+
 	RPCClientIsConnected = true
 	return rwc, nil
 }


### PR DESCRIPTION
Now we generate pool ID to unique identify Gateway instance, so MDCB
can use it instead of API address.

It is implemented on TCP level, by overriding Dial function. Once we
have connection object, we write handshake “register” message, so Sink
can distinguish legacy clients from new ones. Next, we send the length of ID
(max 256, or single byte), and the third message is ID itself.

Note that tests include simple MDCB mock, which shows how we read the ID and apply it.

Part of https://github.com/TykTechnologies/tyk-sink/pull/11 