### PR TITLE
jsvm: send config_data to JS plugins too

### DIFF
--- a/js/tyk.js
+++ b/js/tyk.js
@@ -11,13 +11,13 @@ var TykJS = {
         }
 };
 
-TykJS.TykMiddleware.MiddlewareComponentMeta.prototype.ProcessRequest = function(request, session) {
+TykJS.TykMiddleware.MiddlewareComponentMeta.prototype.ProcessRequest = function(request, session, config) {
     log("Process Request Not Implemented");
     return request;
 };
 
-TykJS.TykMiddleware.MiddlewareComponentMeta.prototype.DoProcessRequest = function(request, session) {
-    var processed_request = this.ProcessRequest(request, session);
+TykJS.TykMiddleware.MiddlewareComponentMeta.prototype.DoProcessRequest = function(request, session, config) {
+    var processed_request = this.ProcessRequest(request, session, config);
 
     if (!processed_request) {
         log("Middleware didn't return request object!");

--- a/mw_virtual_endpoint_test.go
+++ b/mw_virtual_endpoint_test.go
@@ -67,7 +67,6 @@ func TestVirtualEndpoint(t *testing.T) {
 	spec := createSpecTest(t, virtTestDef)
 	defer os.Remove(mwPath)
 
-	//loadApps([]*APISpec{spec}, discardMuxer)
 	virt := &VirtualEndpoint{TykMiddleware: &TykMiddleware{
 		spec, nil,
 	}}


### PR DESCRIPTION
jsvm: send config_data to JS plugins too

Like in the JS code for virtual paths. JS plugins can now take 2 or 3
parameters, depending on whether or not they need config_data. Since JS
functions don't check the number of parameters received, the third one
for config_data is "optional".

Updates #829.