### PR TITLE
jsvm: add rawlog func to print directly to log.Out

### DIFF
--- a/plugins.go
+++ b/plugins.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -287,6 +288,12 @@ func (j *JSVM) LoadTykJSApi() {
 			"prefix": "jsvm-logmsg",
 			"type":   "log-msg",
 		}).Info(call.Argument(0).String())
+		return otto.Value{}
+	})
+
+	j.VM.Set("rawlog", func(call otto.FunctionCall) otto.Value {
+		io.WriteString(log.Out, call.Argument(0).String())
+		log.Out.Write([]byte("\n"))
 		return otto.Value{}
 	})
 


### PR DESCRIPTION
Without going through logrus and the pretty formatter. This means that
there will be no timestamp and no labels, and that your string won't be
escaped at all.

Call it raw to describe those, and also to have a scary name so that
people wishing to use it are warned that they should know what they're
doing.

The test is a bit convoluted because of the timestamps and because
background goroutines might use the logger while the test is running.

Fixes #844.