### PR TITLE
config: incremental changes to prepare splitting up into separate package

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -102,12 +102,6 @@ func geoIPLookup(ipStr string) (*GeoData, error) {
 	return record, nil
 }
 
-type NormaliseURLPatterns struct {
-	UUIDs  *regexp.Regexp
-	IDs    *regexp.Regexp
-	Custom []*regexp.Regexp
-}
-
 func initNormalisationPatterns() (pats NormaliseURLPatterns) {
 	pats.UUIDs = regexp.MustCompile(`[0-9a-fA-F]{8}(-)?[0-9a-fA-F]{4}(-)?[0-9a-fA-F]{4}(-)?[0-9a-fA-F]{4}(-)?[0-9a-fA-F]{12}`)
 	pats.IDs = regexp.MustCompile(`\/(\d+)`)

--- a/analytics_test.go
+++ b/analytics_test.go
@@ -23,10 +23,10 @@ func TestGeoIPLookup(t *testing.T) {
 }
 
 func TestURLReplacer(t *testing.T) {
-	config.AnalyticsConfig.NormaliseUrls.Enabled = true
-	config.AnalyticsConfig.NormaliseUrls.NormaliseUUIDs = true
-	config.AnalyticsConfig.NormaliseUrls.NormaliseNumbers = true
-	config.AnalyticsConfig.NormaliseUrls.Custom = []string{"ihatethisstring"}
+	globalConf.AnalyticsConfig.NormaliseUrls.Enabled = true
+	globalConf.AnalyticsConfig.NormaliseUrls.NormaliseUUIDs = true
+	globalConf.AnalyticsConfig.NormaliseUrls.NormaliseNumbers = true
+	globalConf.AnalyticsConfig.NormaliseUrls.Custom = []string{"ihatethisstring"}
 
 	recordUUID1 := AnalyticsRecord{Path: "/15873a748894492162c402d67e92283b/search"}
 	recordUUID2 := AnalyticsRecord{Path: "/CA761232-ED42-11CE-BACD-00AA0057B223/search"}
@@ -35,7 +35,7 @@ func TestURLReplacer(t *testing.T) {
 	recordID1 := AnalyticsRecord{Path: "/widgets/123456/getParams"}
 	recordCust := AnalyticsRecord{Path: "/widgets/123456/getParams/ihatethisstring"}
 
-	config.AnalyticsConfig.NormaliseUrls.compiledPatternSet = initNormalisationPatterns()
+	globalConf.AnalyticsConfig.NormaliseUrls.compiledPatternSet = initNormalisationPatterns()
 
 	recordUUID1.NormalisePath()
 	recordUUID2.NormalisePath()
@@ -47,7 +47,7 @@ func TestURLReplacer(t *testing.T) {
 	if recordUUID1.Path != "/{uuid}/search" {
 		t.Error("Path not altered, is:")
 		t.Error(recordUUID1.Path)
-		t.Error(config.AnalyticsConfig.NormaliseUrls)
+		t.Error(globalConf.AnalyticsConfig.NormaliseUrls)
 	}
 
 	if recordUUID2.Path != "/{uuid}/search" {

--- a/api.go
+++ b/api.go
@@ -138,7 +138,7 @@ func doAddOrUpdate(keyName string, newSession *SessionState, dontReset bool) err
 		}
 	} else {
 		// nothing defined, add key to ALL
-		if !config.AllowMasterKeys {
+		if !globalConf.AllowMasterKeys {
 			log.Error("Master keys disallowed in configuration, key not added.")
 			return errors.New("Master keys not allowed")
 		}
@@ -308,7 +308,7 @@ type APIAllKeys struct {
 }
 
 func handleGetAllKeys(filter, apiID string) (interface{}, int) {
-	if config.HashKeys {
+	if globalConf.HashKeys {
 		return apiError("Configuration is secured, key listings not available in hashed configurations"), 400
 	}
 
@@ -481,7 +481,7 @@ func handleGetAPI(apiID string) (interface{}, int) {
 }
 
 func handleAddOrUpdateApi(apiID string, r *http.Request) (interface{}, int) {
-	if config.UseDBAppConfigs {
+	if globalConf.UseDBAppConfigs {
 		log.Error("Rejected new API Definition due to UseDBAppConfigs = true")
 		return apiError("Due to enabled use_db_app_configs, please use the Dashboard API"), 500
 	}
@@ -498,7 +498,7 @@ func handleAddOrUpdateApi(apiID string, r *http.Request) (interface{}, int) {
 	}
 
 	// Create a filename
-	defFilePath := filepath.Join(config.AppPath, newDef.APIID+".json")
+	defFilePath := filepath.Join(globalConf.AppPath, newDef.APIID+".json")
 
 	// If it exists, delete it
 	if _, err := os.Stat(defFilePath); err == nil {
@@ -533,7 +533,7 @@ func handleAddOrUpdateApi(apiID string, r *http.Request) (interface{}, int) {
 
 func handleDeleteAPI(apiID string) (interface{}, int) {
 	// Generate a filename
-	defFilePath := filepath.Join(config.AppPath, apiID+".json")
+	defFilePath := filepath.Join(globalConf.AppPath, apiID+".json")
 
 	// If it exists, delete it
 	if _, err := os.Stat(defFilePath); err != nil {
@@ -760,7 +760,7 @@ func handleOrgAddOrUpdate(keyName string, r *http.Request) (interface{}, int) {
 
 	if spec == nil {
 		log.Warning("Couldn't find org session store in active API list")
-		if config.SupressDefaultOrgStore {
+		if globalConf.SupressDefaultOrgStore {
 			return apiError("No such organisation found in Active API list"), 400
 		}
 		sessionManager = &DefaultOrgStore
@@ -932,7 +932,7 @@ func createKeyHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	} else {
-		if config.AllowMasterKeys {
+		if globalConf.AllowMasterKeys {
 			// nothing defined, add key to ALL
 			log.WithFields(logrus.Fields{
 				"prefix":      "api",
@@ -1333,7 +1333,7 @@ func getOauthClients(apiID string) (interface{}, int) {
 }
 
 func healthCheckhandler(w http.ResponseWriter, r *http.Request) {
-	if !config.HealthCheck.EnableHealthChecks {
+	if !globalConf.HealthCheck.EnableHealthChecks {
 		doJSONWrite(w, 400, apiError("Health checks are not enabled for this node"))
 		return
 	}

--- a/api_definition.go
+++ b/api_definition.go
@@ -159,7 +159,7 @@ func (a *APIDefinitionLoader) MakeSpec(appConfig *apidef.APIDefinition) *APISpec
 	newAppSpec.OrgSessionManager = &DefaultSessionManager{}
 
 	// Create and init the virtual Machine
-	if config.EnableJSVM {
+	if globalConf.EnableJSVM {
 		newAppSpec.JSVM = &JSVM{}
 		newAppSpec.JSVM.Init()
 	}
@@ -272,11 +272,11 @@ func (a *APIDefinitionLoader) LoadDefinitionsFromDashboardService(endpoint, secr
 	// Extract tagged entries only
 	apiDefs := make([]*apidef.APIDefinition, 0)
 
-	if config.DBAppConfOptions.NodeIsSegmented {
-		tagList := make(map[string]bool, len(config.DBAppConfOptions.Tags))
+	if globalConf.DBAppConfOptions.NodeIsSegmented {
+		tagList := make(map[string]bool, len(globalConf.DBAppConfOptions.Tags))
 		toLoad := make(map[string]*apidef.APIDefinition)
 
-		for _, mt := range config.DBAppConfOptions.Tags {
+		for _, mt := range globalConf.DBAppConfOptions.Tags {
 			tagList[mt] = true
 		}
 
@@ -316,14 +316,14 @@ func (a *APIDefinitionLoader) LoadDefinitionsFromDashboardService(endpoint, secr
 
 // LoadDefinitionsFromCloud will connect and download ApiDefintions from a Mongo DB instance.
 func (a *APIDefinitionLoader) LoadDefinitionsFromRPC(orgId string) []*APISpec {
-	store := RPCStorageHandler{UserKey: config.SlaveOptions.APIKey, Address: config.SlaveOptions.ConnectionString}
+	store := RPCStorageHandler{UserKey: globalConf.SlaveOptions.APIKey, Address: globalConf.SlaveOptions.ConnectionString}
 	store.Connect()
 
 	// enable segments
 	var tags []string
-	if config.DBAppConfOptions.NodeIsSegmented {
-		log.Info("Segmented node, loading: ", config.DBAppConfOptions.Tags)
-		tags = config.DBAppConfOptions.Tags
+	if globalConf.DBAppConfOptions.NodeIsSegmented {
+		log.Info("Segmented node, loading: ", globalConf.DBAppConfOptions.Tags)
+		tags = globalConf.DBAppConfOptions.Tags
 	}
 
 	apiCollection := store.GetApiDefinitions(orgId, tags)
@@ -355,7 +355,7 @@ func (a *APIDefinitionLoader) processRPCDefinitions(apiCollection string) []*API
 		appConfig.DecodeFromDB()
 		appConfig.RawData = strDefs[i] // Lets keep a copy for plugable modules
 
-		if config.SlaveOptions.BindToSlugsInsteadOfListenPaths {
+		if globalConf.SlaveOptions.BindToSlugsInsteadOfListenPaths {
 			newListenPath := "/" + appConfig.Slug //+ "/"
 			log.Warning("Binding to ",
 				newListenPath,
@@ -693,7 +693,7 @@ func (a *APIDefinitionLoader) compileURLRewritesPathSpec(paths []apidef.URLRewri
 }
 
 func (a *APIDefinitionLoader) compileVirtualPathspathSpec(paths []apidef.VirtualMeta, stat URLStatus, apiSpec *APISpec) []URLSpec {
-	if !config.EnableJSVM {
+	if !globalConf.EnableJSVM {
 		return nil
 	}
 

--- a/api_definition_test.go
+++ b/api_definition_test.go
@@ -310,13 +310,13 @@ func TestBlacklistLinksMulti(t *testing.T) {
 }
 
 func startRPCMock(dispatcher *gorpc.Dispatcher) *gorpc.Server {
-	config.SlaveOptions.UseRPC = true
-	config.SlaveOptions.RPCKey = "test_org"
-	config.SlaveOptions.APIKey = "test"
+	globalConf.SlaveOptions.UseRPC = true
+	globalConf.SlaveOptions.RPCKey = "test_org"
+	globalConf.SlaveOptions.APIKey = "test"
 
 	server := gorpc.NewTCPServer(":9090", dispatcher.NewHandlerFunc())
 	go server.Serve()
-	config.SlaveOptions.ConnectionString = server.Addr
+	globalConf.SlaveOptions.ConnectionString = server.Addr
 
 	RPCCLientSingleton = gorpc.NewTCPClient(server.Addr)
 	RPCCLientSingleton.Conns = 1
@@ -328,10 +328,10 @@ func startRPCMock(dispatcher *gorpc.Dispatcher) *gorpc.Server {
 }
 
 func stopRPCMock(server *gorpc.Server) {
-	config.SlaveOptions.ConnectionString = ""
-	config.SlaveOptions.RPCKey = ""
-	config.SlaveOptions.APIKey = ""
-	config.SlaveOptions.UseRPC = false
+	globalConf.SlaveOptions.ConnectionString = ""
+	globalConf.SlaveOptions.RPCKey = ""
+	globalConf.SlaveOptions.APIKey = ""
+	globalConf.SlaveOptions.UseRPC = false
 
 	server.Listener.Close()
 	server.Stop()
@@ -394,14 +394,14 @@ func TestGetAPISpecsDashboardSuccess(t *testing.T) {
 
 	apisByID = make(map[string]*APISpec)
 
-	config.UseDBAppConfigs = true
-	config.AllowInsecureConfigs = true
-	config.DBAppConfOptions.ConnectionString = ts.URL
+	globalConf.UseDBAppConfigs = true
+	globalConf.AllowInsecureConfigs = true
+	globalConf.DBAppConfOptions.ConnectionString = ts.URL
 
 	defer func() {
-		config.UseDBAppConfigs = false
-		config.AllowInsecureConfigs = false
-		config.DBAppConfOptions.ConnectionString = ""
+		globalConf.UseDBAppConfigs = false
+		globalConf.AllowInsecureConfigs = false
+		globalConf.DBAppConfOptions.ConnectionString = ""
 	}()
 
 	var wg sync.WaitGroup

--- a/api_healthcheck.go
+++ b/api_healthcheck.go
@@ -36,7 +36,7 @@ type DefaultHealthChecker struct {
 }
 
 func (h *DefaultHealthChecker) Init(storeType StorageHandler) {
-	if config.HealthCheck.EnableHealthChecks {
+	if globalConf.HealthCheck.EnableHealthChecks {
 		log.Debug("Health Checker initialised.")
 	}
 
@@ -56,29 +56,29 @@ func ReportHealthCheckValue(checker HealthChecker, counter HealthPrefix, value s
 }
 
 func (h *DefaultHealthChecker) StoreCounterVal(counterType HealthPrefix, value string) {
-	if !config.HealthCheck.EnableHealthChecks {
+	if !globalConf.HealthCheck.EnableHealthChecks {
 		return
 	}
 	searchStr := h.CreateKeyName(counterType)
 	log.Debug("Adding Healthcheck to: ", searchStr)
 	log.Debug("Val is: ", value)
-	//go h.storage.SetKey(searchStr, value, config.HealthCheck.HealthCheckValueTimeout)
+	//go h.storage.SetKey(searchStr, value, globalConf.HealthCheck.HealthCheckValueTimeout)
 	if value != "-1" {
 		// need to ensure uniqueness
 		now_string := strconv.Itoa(int(time.Now().UnixNano()))
 		value = now_string + "." + value
 		log.Debug("Set value to: ", value)
 	}
-	go h.storage.SetRollingWindow(searchStr, config.HealthCheck.HealthCheckValueTimeout, value)
+	go h.storage.SetRollingWindow(searchStr, globalConf.HealthCheck.HealthCheckValueTimeout, value)
 }
 
 func (h *DefaultHealthChecker) getAvgCount(prefix HealthPrefix) float64 {
 	searchStr := h.CreateKeyName(prefix)
 	log.Debug("Searching for: ", searchStr)
 
-	count, _ := h.storage.SetRollingWindow(searchStr, config.HealthCheck.HealthCheckValueTimeout, "-1")
+	count, _ := h.storage.SetRollingWindow(searchStr, globalConf.HealthCheck.HealthCheckValueTimeout, "-1")
 	log.Debug("Count is: ", count)
-	divisor := float64(config.HealthCheck.HealthCheckValueTimeout)
+	divisor := float64(globalConf.HealthCheck.HealthCheckValueTimeout)
 	if divisor == 0 {
 		log.Warning("The Health Check sample timeout is set to 0, samples will never be deleted!!!")
 		divisor = 60.0
@@ -106,7 +106,7 @@ func (h *DefaultHealthChecker) GetApiHealthValues() (HealthCheckValues, error) {
 	// Get the micro latency graph, an average upstream latency
 	searchStr := h.APIID + "." + string(RequestLog)
 	log.Debug("Searching KV for: ", searchStr)
-	_, vals := h.storage.SetRollingWindow(searchStr, config.HealthCheck.HealthCheckValueTimeout, "-1")
+	_, vals := h.storage.SetRollingWindow(searchStr, globalConf.HealthCheck.HealthCheckValueTimeout, "-1")
 	log.Debug("Found: ", vals)
 	if len(vals) == 0 {
 		return values, nil

--- a/api_test.go
+++ b/api_test.go
@@ -204,8 +204,8 @@ func TestApiHandlerPostDupPath(t *testing.T) {
 func TestApiHandlerPostDbConfig(t *testing.T) {
 	uri := "/tyk/apis/1"
 
-	config.UseDBAppConfigs = true
-	defer func() { config.UseDBAppConfigs = false }()
+	globalConf.UseDBAppConfigs = true
+	defer func() { globalConf.UseDBAppConfigs = false }()
 
 	recorder := httptest.NewRecorder()
 

--- a/auth_manager.go
+++ b/auth_manager.go
@@ -114,7 +114,7 @@ func (b *DefaultSessionManager) UpdateSession(keyName string, session *SessionSt
 	v, _ := json.Marshal(session)
 
 	// Keep the TTL
-	if config.UseAsyncSessionWrite {
+	if globalConf.UseAsyncSessionWrite {
 		go b.Store.SetKey(keyName, string(v), resetTTLTo)
 		return nil
 	}

--- a/batch_requests.go
+++ b/batch_requests.go
@@ -98,7 +98,7 @@ func (b *BatchRequestHandler) ConstructRequests(batchRequest BatchRequestStructu
 		// URLs need to be built absolute so they go through the rate limiting and request limiting machinery
 		var absURL string
 		if !unsafe {
-			absUrlHeader := "http://localhost:" + strconv.Itoa(config.ListenPort)
+			absUrlHeader := "http://localhost:" + strconv.Itoa(globalConf.ListenPort)
 			absURL = strings.Join([]string{absUrlHeader, strings.Trim(b.API.Proxy.ListenPath, "/"), requestDef.RelativeURL}, "/")
 		} else {
 			absURL = requestDef.RelativeURL

--- a/config.go
+++ b/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"regexp"
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
@@ -47,6 +48,12 @@ type NormalisedURLConfig struct {
 	compiledPatternSet NormaliseURLPatterns // see analytics.go
 }
 
+type NormaliseURLPatterns struct {
+	UUIDs  *regexp.Regexp
+	IDs    *regexp.Regexp
+	Custom []*regexp.Regexp
+}
+
 type AnalyticsConfigConfig struct {
 	Type                    string              `json:"type"`
 	IgnoredIPs              []string            `json:"ignored_ips"`
@@ -69,6 +76,14 @@ type MonitorConfig struct {
 	GlobalTriggerLimit    float64            `json:"global_trigger_limit"`
 	MonitorUserKeys       bool               `json:"monitor_user_keys"`
 	MonitorOrgKeys        bool               `json:"monitor_org_keys"`
+}
+
+type WebHookHandlerConf struct {
+	Method       string            `bson:"method" json:"method"`
+	TargetPath   string            `bson:"target_path" json:"target_path"`
+	TemplatePath string            `bson:"template_path" json:"template_path"`
+	HeaderList   map[string]string `bson:"header_map" json:"header_map"`
+	EventTimeout int64             `bson:"event_timeout" json:"event_timeout"`
 }
 
 type SlaveOptionsConfig struct {
@@ -221,6 +236,19 @@ type CertData struct {
 	Name     string `json:"domain_name"`
 	CertFile string `json:"cert_file"`
 	KeyFile  string `json:"key_file"`
+}
+
+// EventMessage is a standard form to send event data to handlers
+type EventMessage struct {
+	Type      apidef.TykEvent
+	Meta      interface{}
+	TimeStamp string
+}
+
+// TykEventHandler defines an event handler, e.g. LogMessageEventHandler will handle an event by logging it to stdout.
+type TykEventHandler interface {
+	New(interface{}) (TykEventHandler, error)
+	HandleEvent(EventMessage)
 }
 
 const envPrefix = "TYK_GW"

--- a/config.go
+++ b/config.go
@@ -150,6 +150,11 @@ type CoProcessConfig struct {
 
 // Config is the configuration object used by tyk to set up various parameters.
 type Config struct {
+	// OriginalPath is the path to the config file that was read. If
+	// none was found, it's the path to the default config file that
+	// was written.
+	OriginalPath string `json:"-"`
+
 	ListenAddress                     string                 `json:"listen_address"`
 	ListenPort                        int                    `json:"listen_port"`
 	Secret                            string                 `json:"secret"`
@@ -253,21 +258,6 @@ type TykEventHandler interface {
 
 const envPrefix = "TYK_GW"
 
-// confPaths is the series of paths to try to use as config files. The
-// first one to exist will be used. If none exists, a default config
-// will be written to the first path in the list.
-//
-// When --conf=foo is used, this will be replaced by []string{"foo"}.
-var confPaths = []string{
-	"tyk.conf",
-	// TODO: add ~/.config/tyk/tyk.conf here?
-	"/etc/tyk/tyk.conf",
-}
-
-// usedConfPath is the path to the config file that was read. If none
-// was found, it's the path to the default config file that was written.
-var usedConfPath string
-
 // writeDefaultConf will create a default configuration file and set the
 // storage type to "memory"
 func writeDefaultConf(path string, conf *Config) {
@@ -321,7 +311,7 @@ func loadConfig(paths []string, conf *Config) error {
 		var err error
 		bs, err = ioutil.ReadFile(path)
 		if err == nil {
-			usedConfPath = path
+			conf.OriginalPath = path
 			break
 		}
 		if os.IsNotExist(err) {

--- a/config.go
+++ b/config.go
@@ -321,7 +321,7 @@ func loadConfig(paths []string, conf *Config) error {
 }
 
 // afterConfSetup takes care of non-sensical config values (such as zero
-// timeouts) and sets up a few globals that depend on the config.
+// timeouts) and sets up a few globals that depend on the globalConf.
 func afterConfSetup(conf *Config) {
 	if conf.SlaveOptions.CallTimeout == 0 {
 		conf.SlaveOptions.CallTimeout = 30

--- a/config.go
+++ b/config.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"os"
 	"time"
 
@@ -341,12 +340,11 @@ func (c *Config) loadIgnoredIPs() {
 	}
 }
 
-func (c *Config) StoreAnalytics(r *http.Request) bool {
+func (c *Config) StoreAnalytics(ip string) bool {
 	if !c.EnableAnalytics {
 		return false
 	}
 
-	ip := GetIPFromRequest(r)
 	return !c.AnalyticsConfig.ignoredIPsCompiled[ip]
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -55,8 +55,8 @@ func TestConfigFiles(t *testing.T) {
 	if _, err := os.Stat(path2); err == nil {
 		t.Fatalf("loadConfig with no configs wrote too many default config files")
 	}
-	if usedConfPath != path1 {
-		t.Fatalf("usedConfPath was not set properly")
+	if conf.OriginalPath != path1 {
+		t.Fatalf("OriginalPath was not set properly")
 	}
 
 	// both exist, we use path1
@@ -64,8 +64,8 @@ func TestConfigFiles(t *testing.T) {
 	if err := loadConfig(paths, conf); err != nil {
 		t.Fatalf("loadConfig with an existing config errored")
 	}
-	if usedConfPath != path1 {
-		t.Fatalf("usedConfPath was not set properly")
+	if conf.OriginalPath != path1 {
+		t.Fatalf("OriginalPath was not set properly")
 	}
 
 	// path2 exists but path1 doesn't
@@ -76,8 +76,8 @@ func TestConfigFiles(t *testing.T) {
 	if _, err := os.Stat(path1); err == nil {
 		t.Fatalf("loadConfig with a config wrote a default config file")
 	}
-	if usedConfPath != path2 {
-		t.Fatalf("usedConfPath was not set properly")
+	if conf.OriginalPath != path2 {
+		t.Fatalf("OriginalPath was not set properly")
 	}
 
 	// path1 exists but is invalid

--- a/coprocess.go
+++ b/coprocess.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	// EnableCoProcess will be overridden by config.EnableCoProcess.
+	// EnableCoProcess will be overridden by globalConf.EnableCoProcess.
 	EnableCoProcess = false
 
 	// GlobalDispatcher will be implemented by the current CoProcess driver.
@@ -151,7 +151,7 @@ func (c *CoProcessor) ObjectPostProcess(object *coprocess.Object, r *http.Reques
 // CoProcessInit creates a new CoProcessDispatcher, it will be called when Tyk starts.
 func CoProcessInit() error {
 	var err error
-	if config.CoProcessOptions.EnableCoProcess {
+	if globalConf.CoProcessOptions.EnableCoProcess {
 		GlobalDispatcher, err = NewCoProcessDispatcher()
 		EnableCoProcess = true
 	}
@@ -161,7 +161,7 @@ func CoProcessInit() error {
 // IsEnabledForSpec checks if this middleware should be enabled for a given API.
 func (m *CoProcessMiddleware) IsEnabledForSpec() bool {
 	// This flag is true when Tyk has been compiled with CP support and when the configuration enables it.
-	enableCoProcess := config.CoProcessOptions.EnableCoProcess && EnableCoProcess
+	enableCoProcess := globalConf.CoProcessOptions.EnableCoProcess && EnableCoProcess
 	// This flag indicates if the current spec specifies any CP custom middleware.
 	var usesCoProcessMiddleware bool
 

--- a/coprocess_bundle.go
+++ b/coprocess_bundle.go
@@ -24,7 +24,7 @@ import (
 var tykBundlePath string
 
 func init() {
-	tykBundlePath = filepath.Join(config.MiddlewarePath, "middleware", "bundles")
+	tykBundlePath = filepath.Join(globalConf.MiddlewarePath, "middleware", "bundles")
 }
 
 // Bundle is the basic bundle data structure, it holds the bundle name and the data.
@@ -46,14 +46,14 @@ func (b *Bundle) Verify() error {
 	var bundleVerifier goverify.Verifier
 
 	// Perform signature verification if a public key path is set:
-	if config.PublicKeyPath != "" {
+	if globalConf.PublicKeyPath != "" {
 		if b.Manifest.Signature == "" {
 			// Error: A public key is set, but the bundle isn't signed.
 			return errors.New("Bundle isn't signed")
 		}
 		if notificationVerifier == nil {
 			var err error
-			bundleVerifier, err = goverify.LoadPublicKeyFromFile(config.PublicKeyPath)
+			bundleVerifier, err = goverify.LoadPublicKeyFromFile(globalConf.PublicKeyPath)
 			if err != nil {
 				return err
 			}
@@ -173,7 +173,7 @@ func (s *ZipBundleSaver) Save(bundle *Bundle, bundlePath string, spec *APISpec) 
 // fetchBundle will fetch a given bundle, using the right BundleGetter. The first argument is the bundle name, the base bundle URL will be used as prefix.
 func fetchBundle(spec *APISpec) (bundle Bundle, err error) {
 
-	if !config.EnableBundleDownloader {
+	if !globalConf.EnableBundleDownloader {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Warning("Bundle downloader is disabled.")
@@ -181,7 +181,7 @@ func fetchBundle(spec *APISpec) (bundle Bundle, err error) {
 		return bundle, err
 	}
 
-	bundleURL := config.BundleBaseURL + spec.CustomMiddlewareBundle
+	bundleURL := globalConf.BundleBaseURL + spec.CustomMiddlewareBundle
 
 	var getter BundleGetter
 
@@ -263,7 +263,7 @@ func loadBundle(spec *APISpec) {
 	}
 
 	// Skip if no bundle base URL is set.
-	if config.BundleBaseURL == "" {
+	if globalConf.BundleBaseURL == "" {
 		bundleError(spec, nil, "No bundle base URL set, skipping bundle")
 		return
 	}

--- a/coprocess_grpc.go
+++ b/coprocess_grpc.go
@@ -32,7 +32,7 @@ type GRPCDispatcher struct {
 }
 
 func dialer(addr string, timeout time.Duration) (net.Conn, error) {
-	grpcUrl, err := url.Parse(config.CoProcessOptions.CoProcessGRPCServer)
+	grpcUrl, err := url.Parse(globalConf.CoProcessOptions.CoProcessGRPCServer)
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "coprocess-grpc",
@@ -40,7 +40,7 @@ func dialer(addr string, timeout time.Duration) (net.Conn, error) {
 		return nil, err
 	}
 
-	if grpcUrl == nil || config.CoProcessOptions.CoProcessGRPCServer == "" {
+	if grpcUrl == nil || globalConf.CoProcessOptions.CoProcessGRPCServer == "" {
 		errString := "No gRPC URL is set!"
 		log.WithFields(logrus.Fields{
 			"prefix": "coprocess-grpc",
@@ -48,7 +48,7 @@ func dialer(addr string, timeout time.Duration) (net.Conn, error) {
 		return nil, errors.New(errString)
 	}
 
-	grpcUrlString := config.CoProcessOptions.CoProcessGRPCServer[len(grpcUrl.Scheme)+3:]
+	grpcUrlString := globalConf.CoProcessOptions.CoProcessGRPCServer[len(grpcUrl.Scheme)+3:]
 	return net.DialTimeout(grpcUrl.Scheme, grpcUrlString, timeout)
 }
 

--- a/dashboard_register.go
+++ b/dashboard_register.go
@@ -60,7 +60,7 @@ func (h *HTTPDashboardHandler) Init() error {
 	h.DeRegistrationEndpoint = buildConnStr("/system/node")
 	h.HeartBeatEndpoint = buildConnStr("/register/ping")
 
-	h.Secret = config.NodeSecret
+	h.Secret = globalConf.NodeSecret
 	return nil
 }
 

--- a/distributed_rate_limiter.go
+++ b/distributed_rate_limiter.go
@@ -20,7 +20,7 @@ func setupDRL() {
 }
 
 func startRateLimitNotifications() {
-	notificationFreq := config.DRLNotificationFrequency
+	notificationFreq := globalConf.DRLNotificationFrequency
 	if notificationFreq == 0 {
 		notificationFreq = 2
 	}
@@ -41,7 +41,7 @@ func startRateLimitNotifications() {
 
 func getTagHash() string {
 	th := ""
-	for _, tag := range config.DBAppConfOptions.Tags {
+	for _, tag := range globalConf.DBAppConfOptions.Tags {
 		th += tag
 	}
 	return th

--- a/event_handler_webhooks.go
+++ b/event_handler_webhooks.go
@@ -99,7 +99,7 @@ func (w *WebHookHandler) New(handlerConf interface{}) (TykEventHandler, error) {
 				"prefix": "webhooks",
 				"target": handler.conf.TargetPath,
 			}).Warning("Custom template load failure, using default: ", err)
-			defaultPath := filepath.Join(config.TemplatePath, "default_webhook.json")
+			defaultPath := filepath.Join(globalConf.TemplatePath, "default_webhook.json")
 			webHookTemplate, _ = template.ParseFiles(defaultPath)
 			templateLoaded = true
 		}
@@ -110,7 +110,7 @@ func (w *WebHookHandler) New(handlerConf interface{}) (TykEventHandler, error) {
 			"prefix": "webhooks",
 			"target": handler.conf.TargetPath,
 		}).Info("Loading default template.")
-		defaultPath := filepath.Join(config.TemplatePath, "default_webhook.json")
+		defaultPath := filepath.Join(globalConf.TemplatePath, "default_webhook.json")
 		webHookTemplate, _ = template.ParseFiles(defaultPath)
 	}
 

--- a/event_handler_webhooks.go
+++ b/event_handler_webhooks.go
@@ -30,14 +30,6 @@ const (
 	EH_WebHook apidef.TykEventHandlerName = "eh_web_hook_handler"
 )
 
-type WebHookHandlerConf struct {
-	Method       string            `bson:"method" json:"method"`
-	TargetPath   string            `bson:"target_path" json:"target_path"`
-	TemplatePath string            `bson:"template_path" json:"template_path"`
-	HeaderList   map[string]string `bson:"header_map" json:"header_map"`
-	EventTimeout int64             `bson:"event_timeout" json:"event_timeout"`
-}
-
 // WebHookHandler is an event handler that triggers web hooks
 type WebHookHandler struct {
 	conf     WebHookHandlerConf

--- a/event_system.go
+++ b/event_system.go
@@ -111,19 +111,6 @@ type EventTokenMeta struct {
 	Key string
 }
 
-// EventMessage is a standard form to send event data to handlers
-type EventMessage struct {
-	Type      apidef.TykEvent
-	Meta      interface{}
-	TimeStamp string
-}
-
-// TykEventHandler defines an event handler, e.g. LogMessageEventHandler will handle an event by logging it to stdout.
-type TykEventHandler interface {
-	New(interface{}) (TykEventHandler, error)
-	HandleEvent(EventMessage)
-}
-
 // EncodeRequestToEvent will write the request out in wire protocol and
 // encode it to base64 and store it in an Event object
 func EncodeRequestToEvent(r *http.Request) string {

--- a/event_system.go
+++ b/event_system.go
@@ -204,7 +204,7 @@ func (s *APISpec) FireEvent(name apidef.TykEvent, meta interface{}) {
 }
 
 func FireSystemEvent(name apidef.TykEvent, meta interface{}) {
-	fireEvent(name, meta, config.EventTriggers)
+	fireEvent(name, meta, globalConf.EventTriggers)
 }
 
 // LogMessageEventHandler is a sample Event Handler

--- a/handler_error.go
+++ b/handler_error.go
@@ -80,7 +80,8 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 	token := ctxGetAuthToken(r)
 	var alias string
 
-	if globalConf.StoreAnalytics(r) {
+	ip := GetIPFromRequest(r)
+	if globalConf.StoreAnalytics(ip) {
 
 		t := time.Now()
 
@@ -147,7 +148,7 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 			0,
 			rawRequest,
 			rawResponse,
-			GetIPFromRequest(r),
+			ip,
 			GeoData{},
 			tags,
 			alias,
@@ -155,7 +156,7 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 			time.Now(),
 		}
 
-		record.GetGeo(GetIPFromRequest(r))
+		record.GetGeo(ip)
 
 		expiresAfter := e.Spec.ExpireAnalyticsAfter
 		if globalConf.EnforceOrgDataAge {

--- a/handler_error.go
+++ b/handler_error.go
@@ -80,7 +80,7 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 	token := ctxGetAuthToken(r)
 	var alias string
 
-	if config.StoreAnalytics(r) {
+	if globalConf.StoreAnalytics(r) {
 
 		t := time.Now()
 
@@ -158,7 +158,7 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 		record.GetGeo(GetIPFromRequest(r))
 
 		expiresAfter := e.Spec.ExpireAnalyticsAfter
-		if config.EnforceOrgDataAge {
+		if globalConf.EnforceOrgDataAge {
 			orgExpireDataTime := e.GetOrgSessionExpiry(e.Spec.OrgID)
 
 			if orgExpireDataTime > 0 {
@@ -168,7 +168,7 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 		}
 
 		record.SetExpiry(expiresAfter)
-		if config.AnalyticsConfig.NormaliseUrls.Enabled {
+		if globalConf.AnalyticsConfig.NormaliseUrls.Enabled {
 			record.NormalisePath()
 		}
 
@@ -179,12 +179,12 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 	ReportHealthCheckValue(e.Spec.Health, BlockedRequestLog, "-1")
 
 	//If the config option is not set or is false, add the header
-	if !config.HideGeneratorHeader {
+	if !globalConf.HideGeneratorHeader {
 		w.Header().Add("X-Generator", "tyk.io")
 	}
 
 	// Close connections
-	if config.CloseConnections {
+	if globalConf.CloseConnections {
 		w.Header().Add("Connection", "close")
 	}
 

--- a/handler_success.go
+++ b/handler_success.go
@@ -214,7 +214,8 @@ func (s *SuccessHandler) RecordHit(r *http.Request, timing int64, code int, requ
 		return
 	}
 
-	if globalConf.StoreAnalytics(r) {
+	ip := GetIPFromRequest(r)
+	if globalConf.StoreAnalytics(ip) {
 
 		t := time.Now()
 
@@ -280,7 +281,7 @@ func (s *SuccessHandler) RecordHit(r *http.Request, timing int64, code int, requ
 			timing,
 			rawRequest,
 			rawResponse,
-			GetIPFromRequest(r),
+			ip,
 			GeoData{},
 			tags,
 			alias,
@@ -288,7 +289,7 @@ func (s *SuccessHandler) RecordHit(r *http.Request, timing int64, code int, requ
 			time.Now(),
 		}
 
-		record.GetGeo(GetIPFromRequest(r))
+		record.GetGeo(ip)
 
 		expiresAfter := s.Spec.ExpireAnalyticsAfter
 		if globalConf.EnforceOrgDataAge {

--- a/handler_success.go
+++ b/handler_success.go
@@ -57,7 +57,7 @@ func (t *TykMiddleware) GetOrgSession(key string) (SessionState, bool) {
 	session, found := t.Spec.OrgSessionManager.GetSessionDetail(key)
 	if found {
 		// If exists, assume it has been authorized and pass on
-		if config.EnforceOrgDataAge {
+		if globalConf.EnforceOrgDataAge {
 			// We cache org expiry data
 			log.Debug("Setting data expiry: ", session.OrgID)
 			go t.SetOrgExpiry(session.OrgID, session.DataExpires)
@@ -157,7 +157,7 @@ func (t *TykMiddleware) CheckSessionAndIdentityForValidKey(key string) (SessionS
 	// Try and get the session from the session store
 	log.Debug("Querying local cache")
 	// Check in-memory cache
-	if !config.LocalSessionCache.DisableCacheSessionState {
+	if !globalConf.LocalSessionCache.DisableCacheSessionState {
 		cachedVal, found := SessionCache.Get(key)
 		if found {
 			log.Debug("--> Key found in local cache")
@@ -214,7 +214,7 @@ func (s *SuccessHandler) RecordHit(r *http.Request, timing int64, code int, requ
 		return
 	}
 
-	if config.StoreAnalytics(r) {
+	if globalConf.StoreAnalytics(r) {
 
 		t := time.Now()
 
@@ -291,7 +291,7 @@ func (s *SuccessHandler) RecordHit(r *http.Request, timing int64, code int, requ
 		record.GetGeo(GetIPFromRequest(r))
 
 		expiresAfter := s.Spec.ExpireAnalyticsAfter
-		if config.EnforceOrgDataAge {
+		if globalConf.EnforceOrgDataAge {
 			orgExpireDataTime := s.GetOrgSessionExpiry(s.Spec.OrgID)
 
 			if orgExpireDataTime > 0 {
@@ -301,7 +301,7 @@ func (s *SuccessHandler) RecordHit(r *http.Request, timing int64, code int, requ
 
 		record.SetExpiry(expiresAfter)
 
-		if config.AnalyticsConfig.NormaliseUrls.Enabled {
+		if globalConf.AnalyticsConfig.NormaliseUrls.Enabled {
 			record.NormalisePath()
 		}
 

--- a/handler_websocket.go
+++ b/handler_websocket.go
@@ -29,7 +29,7 @@ type WSDialer struct {
 
 func (ws *WSDialer) RoundTrip(req *http.Request) (*http.Response, error) {
 
-	if !config.HttpServerOptions.EnableWebSockets {
+	if !globalConf.HttpServerOptions.EnableWebSockets {
 		return nil, errors.New("WebSockets has been disabled on this host")
 	}
 
@@ -114,7 +114,7 @@ func (ws *WSDialer) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func IsWebsocket(req *http.Request) bool {
-	if !config.HttpServerOptions.EnableWebSockets {
+	if !globalConf.HttpServerOptions.EnableWebSockets {
 		return false
 	}
 

--- a/host_checker_manager.go
+++ b/host_checker_manager.go
@@ -81,7 +81,7 @@ func (hc *HostCheckerManager) Start() {
 	// Start loop to check if we are active instance
 	if hc.Id != "" {
 		go hc.CheckActivePollerLoop()
-		if config.UptimeTests.Config.EnableUptimeAnalytics {
+		if globalConf.UptimeTests.Config.EnableUptimeAnalytics {
 			go hc.UptimePurgeLoop()
 		}
 	}
@@ -167,9 +167,9 @@ func (hc *HostCheckerManager) StartPoller() {
 		hc.checker = &HostUptimeChecker{}
 	}
 
-	hc.checker.Init(config.UptimeTests.Config.CheckerPoolSize,
-		config.UptimeTests.Config.FailureTriggerSampleSize,
-		config.UptimeTests.Config.TimeWait,
+	hc.checker.Init(globalConf.UptimeTests.Config.CheckerPoolSize,
+		globalConf.UptimeTests.Config.FailureTriggerSampleSize,
+		globalConf.UptimeTests.Config.TimeWait,
 		hc.currentHostList,
 		hc.OnHostDown,   // On failure
 		hc.OnHostBackUp, // On success
@@ -199,7 +199,7 @@ func (hc *HostCheckerManager) getHostKey(report HostHealthReport) string {
 }
 
 func (hc *HostCheckerManager) OnHostReport(report HostHealthReport) {
-	if config.UptimeTests.Config.EnableUptimeAnalytics {
+	if globalConf.UptimeTests.Config.EnableUptimeAnalytics {
 		go hc.RecordUptimeAnalytics(report)
 	}
 }

--- a/instrumentation_handlers.go
+++ b/instrumentation_handlers.go
@@ -23,14 +23,14 @@ func SetupInstrumentation(enabled bool) {
 		return
 	}
 
-	if config.StatsdConnectionString == "" {
+	if globalConf.StatsdConnectionString == "" {
 		log.Error("Instrumentation is enabled, but no connectionstring set for statsd")
 		return
 	}
 
-	log.Info("Sending stats to: ", config.StatsdConnectionString, " with prefix: ", config.StatsdPrefix)
-	statsdSink, err := NewStatsDSink(config.StatsdConnectionString,
-		&StatsDSinkOptions{Prefix: config.StatsdPrefix})
+	log.Info("Sending stats to: ", globalConf.StatsdConnectionString, " with prefix: ", globalConf.StatsdPrefix)
+	statsdSink, err := NewStatsDSink(globalConf.StatsdConnectionString,
+		&StatsDSinkOptions{Prefix: globalConf.StatsdPrefix})
 
 	if err != nil {
 		log.Fatal("Failed to start StatsD check: ", err)

--- a/le_helpers.go
+++ b/le_helpers.go
@@ -26,7 +26,7 @@ func StoreLEState(m *letsencrypt.Manager) {
 	}
 
 	state := m.Marshal()
-	secret := rightPad2Len(config.Secret, "=", 32)
+	secret := rightPad2Len(globalConf.Secret, "=", 32)
 	cryptoText := encrypt([]byte(secret), state)
 
 	if err := store.SetKey("cache", cryptoText, -1); err != nil {
@@ -54,7 +54,7 @@ func GetLEState(m *letsencrypt.Manager) {
 		return
 	}
 
-	secret := rightPad2Len(config.Secret, "=", 32)
+	secret := rightPad2Len(globalConf.Secret, "=", 32)
 	sslState := decrypt([]byte(secret), cryptoText)
 
 	m.Unmarshal(sslState)

--- a/main.go
+++ b/main.go
@@ -65,6 +65,17 @@ var (
 	NodeID string
 
 	runningTests = false
+
+	// confPaths is the series of paths to try to use as config files. The
+	// first one to exist will be used. If none exists, a default config
+	// will be written to the first path in the list.
+	//
+	// When --conf=foo is used, this will be replaced by []string{"foo"}.
+	confPaths = []string{
+		"tyk.conf",
+		// TODO: add ~/.config/tyk/tyk.conf here?
+		"/etc/tyk/tyk.conf",
+	}
 )
 
 // Display configuration options

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ import (
 
 var (
 	log                      = logger.Get()
-	config                   Config
+	globalConf               Config
 	templates                *template.Template
 	analytics                RedisAnalyticsHandler
 	GlobalEventsJSVM         JSVM
@@ -69,8 +69,8 @@ var (
 
 // Display configuration options
 func displayConfig() {
-	address := config.ListenAddress
-	if config.ListenAddress == "" {
+	address := globalConf.ListenAddress
+	if globalConf.ListenAddress == "" {
 		address = "(open interface)"
 	}
 	log.WithFields(logrus.Fields{
@@ -78,7 +78,7 @@ func displayConfig() {
 	}).Info("--> Listening on address: ", address)
 	log.WithFields(logrus.Fields{
 		"prefix": "main",
-	}).Info("--> Listening on port: ", config.ListenPort)
+	}).Info("--> Listening on port: ", globalConf.ListenPort)
 	log.WithFields(logrus.Fields{
 		"prefix": "main",
 	}).Info("--> PID: ", HostDetails.PID)
@@ -95,7 +95,7 @@ func setupGlobals() {
 
 	controlRouter = mux.NewRouter()
 
-	if config.EnableAnalytics && config.Storage.Type != "redis" {
+	if globalConf.EnableAnalytics && globalConf.Storage.Type != "redis" {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Panic("Analytics requires Redis Storage backend, please enable Redis in the tyk.conf file.")
@@ -105,8 +105,8 @@ func setupGlobals() {
 	healthCheckStore := &RedisClusterStorageManager{KeyPrefix: "host-checker:"}
 	InitHostCheckManager(healthCheckStore)
 
-	if config.EnableAnalytics {
-		config.loadIgnoredIPs()
+	if globalConf.EnableAnalytics {
+		globalConf.loadIgnoredIPs()
 		analyticsStore := RedisClusterStorageManager{KeyPrefix: "analytics-"}
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
@@ -118,7 +118,7 @@ func setupGlobals() {
 
 		analytics.Init()
 
-		if config.AnalyticsConfig.Type == "rpc" {
+		if globalConf.AnalyticsConfig.Type == "rpc" {
 			log.Debug("Using RPC cache purge")
 
 			purger := RPCPurger{Store: &analyticsStore}
@@ -130,15 +130,15 @@ func setupGlobals() {
 	}
 
 	// Load all the files that have the "error" prefix.
-	templatesDir := filepath.Join(config.TemplatePath, "error*")
+	templatesDir := filepath.Join(globalConf.TemplatePath, "error*")
 	templates = template.Must(template.ParseGlob(templatesDir))
 
 	// Set up global JSVM
-	if config.EnableJSVM {
+	if globalConf.EnableJSVM {
 		GlobalEventsJSVM.Init()
 	}
 
-	if config.CoProcessOptions.EnableCoProcess {
+	if globalConf.CoProcessOptions.EnableCoProcess {
 		CoProcessInit()
 	}
 
@@ -150,9 +150,9 @@ func setupGlobals() {
 	mainNotifierStore.Connect()
 	MainNotifier = RedisNotifier{&mainNotifierStore, RedisPubSubChannel}
 
-	if config.Monitor.EnableTriggerMonitors {
+	if globalConf.Monitor.EnableTriggerMonitors {
 		var err error
-		MonitoringHandler, err = (&WebHookHandler{}).New(config.Monitor.Config)
+		MonitoringHandler, err = (&WebHookHandler{}).New(globalConf.Monitor.Config)
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "main",
@@ -160,32 +160,32 @@ func setupGlobals() {
 		}
 	}
 
-	if config.AnalyticsConfig.NormaliseUrls.Enabled {
+	if globalConf.AnalyticsConfig.NormaliseUrls.Enabled {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Info("Setting up analytics normaliser")
-		config.AnalyticsConfig.NormaliseUrls.compiledPatternSet = initNormalisationPatterns()
+		globalConf.AnalyticsConfig.NormaliseUrls.compiledPatternSet = initNormalisationPatterns()
 	}
 
 }
 
 func buildConnStr(resource string) string {
 
-	if config.DBAppConfOptions.ConnectionString == "" && config.DisableDashboardZeroConf {
+	if globalConf.DBAppConfOptions.ConnectionString == "" && globalConf.DisableDashboardZeroConf {
 		log.Fatal("Connection string is empty, failing.")
 		return ""
 	}
 
-	if !config.DisableDashboardZeroConf && config.DBAppConfOptions.ConnectionString == "" {
+	if !globalConf.DisableDashboardZeroConf && globalConf.DBAppConfOptions.ConnectionString == "" {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Info("Waiting for zeroconf signal...")
-		for config.DBAppConfOptions.ConnectionString == "" {
+		for globalConf.DBAppConfOptions.ConnectionString == "" {
 			time.Sleep(1 * time.Second)
 		}
 	}
 
-	connStr := config.DBAppConfOptions.ConnectionString
+	connStr := globalConf.DBAppConfOptions.ConnectionString
 	connStr = connStr + resource
 	return connStr
 }
@@ -196,37 +196,37 @@ var APILoader = APIDefinitionLoader{}
 func getAPISpecs() []*APISpec {
 	var apiSpecs []*APISpec
 
-	if config.UseDBAppConfigs {
+	if globalConf.UseDBAppConfigs {
 
 		connStr := buildConnStr("/system/apis")
-		apiSpecs = APILoader.LoadDefinitionsFromDashboardService(connStr, config.NodeSecret)
+		apiSpecs = APILoader.LoadDefinitionsFromDashboardService(connStr, globalConf.NodeSecret)
 
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Debug("Downloading API Configurations from Dashboard Service")
-	} else if config.SlaveOptions.UseRPC {
+	} else if globalConf.SlaveOptions.UseRPC {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Debug("Using RPC Configuration")
 
-		apiSpecs = APILoader.LoadDefinitionsFromRPC(config.SlaveOptions.RPCKey)
+		apiSpecs = APILoader.LoadDefinitionsFromRPC(globalConf.SlaveOptions.RPCKey)
 	} else {
-		apiSpecs = APILoader.LoadDefinitions(config.AppPath)
+		apiSpecs = APILoader.LoadDefinitions(globalConf.AppPath)
 	}
 
 	log.WithFields(logrus.Fields{
 		"prefix": "main",
 	}).Printf("Detected %v APIs", len(apiSpecs))
 
-	if config.AuthOverride.ForceAuthProvider {
+	if globalConf.AuthOverride.ForceAuthProvider {
 		for i := range apiSpecs {
-			apiSpecs[i].AuthProvider = config.AuthOverride.AuthProvider
+			apiSpecs[i].AuthProvider = globalConf.AuthOverride.AuthProvider
 		}
 	}
 
-	if config.AuthOverride.ForceSessionProvider {
+	if globalConf.AuthOverride.ForceSessionProvider {
 		for i := range apiSpecs {
-			apiSpecs[i].SessionProvider = config.AuthOverride.SessionProvider
+			apiSpecs[i].SessionProvider = globalConf.AuthOverride.SessionProvider
 		}
 	}
 
@@ -239,17 +239,17 @@ func getPolicies() {
 		"prefix": "main",
 	}).Info("Loading policies")
 
-	switch config.Policies.PolicySource {
+	switch globalConf.Policies.PolicySource {
 	case "service":
-		if config.Policies.PolicyConnectionString != "" {
-			connStr := config.Policies.PolicyConnectionString
+		if globalConf.Policies.PolicyConnectionString != "" {
+			connStr := globalConf.Policies.PolicyConnectionString
 			connStr = connStr + "/system/policies"
 
 			log.WithFields(logrus.Fields{
 				"prefix": "main",
 			}).Info("Using Policies from Dashboard Service")
 
-			pols = LoadPoliciesFromDashboard(connStr, config.NodeSecret, config.Policies.AllowExplicitPolicyID)
+			pols = LoadPoliciesFromDashboard(connStr, globalConf.NodeSecret, globalConf.Policies.AllowExplicitPolicyID)
 
 		} else {
 			log.WithFields(logrus.Fields{
@@ -261,16 +261,16 @@ func getPolicies() {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Debug("Using Policies from RPC")
-		pols = LoadPoliciesFromRPC(config.SlaveOptions.RPCKey)
+		pols = LoadPoliciesFromRPC(globalConf.SlaveOptions.RPCKey)
 	default:
 		// this is the only case now where we need a policy record name
-		if config.Policies.PolicyRecordName == "" {
+		if globalConf.Policies.PolicyRecordName == "" {
 			log.WithFields(logrus.Fields{
 				"prefix": "main",
 			}).Debug("No policy record name defined, skipping...")
 			return
 		}
-		pols = LoadPoliciesFromFile(config.Policies.PolicyRecordName)
+		pols = LoadPoliciesFromFile(globalConf.Policies.PolicyRecordName)
 	}
 
 	if len(pols) > 0 {
@@ -280,9 +280,9 @@ func getPolicies() {
 
 // Set up default Tyk control API endpoints - these are global, so need to be added first
 func loadAPIEndpoints(muxer *mux.Router) {
-	hostname := config.HostName
-	if config.ControlAPIHostname != "" {
-		hostname = config.ControlAPIHostname
+	hostname := globalConf.HostName
+	if globalConf.ControlAPIHostname != "" {
+		hostname = globalConf.ControlAPIHostname
 	}
 	r := mux.NewRouter()
 	muxer.PathPrefix("/tyk").Handler(http.StripPrefix("/tyk",
@@ -333,7 +333,7 @@ func loadAPIEndpoints(muxer *mux.Router) {
 func checkIsAPIOwner(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		tykAuthKey := r.Header.Get("X-Tyk-Authorization")
-		if tykAuthKey != config.Secret {
+		if tykAuthKey != globalConf.Secret {
 			// Error
 			log.Warning("Attempted administrative access with invalid or missing key!")
 
@@ -358,7 +358,7 @@ func addOAuthHandlers(spec *APISpec, muxer *mux.Router, test bool) *OAuthManager
 	serverConfig.ErrorStatusCode = 403
 	serverConfig.AllowedAccessTypes = spec.Oauth2Meta.AllowedAccessTypes
 	serverConfig.AllowedAuthorizeTypes = spec.Oauth2Meta.AllowedAuthorizeTypes
-	serverConfig.RedirectUriSeparator = config.OauthRedirectUriSeparator
+	serverConfig.RedirectUriSeparator = globalConf.OauthRedirectUriSeparator
 
 	prefix := generateOAuthPrefix(spec.APIID)
 	storageManager := getGlobalStorageHandler(prefix, false)
@@ -380,12 +380,12 @@ func addOAuthHandlers(spec *APISpec, muxer *mux.Router, test bool) *OAuthManager
 
 		var redirectURI string
 		// If separator is not set that means multiple redirect uris not supported
-		if config.OauthRedirectUriSeparator == "" {
+		if globalConf.OauthRedirectUriSeparator == "" {
 			redirectURI = "http://client.oauth.com"
 
 			// If separator config is set that means multiple redirect uris are supported
 		} else {
-			redirectURI = strings.Join([]string{"http://client.oauth.com", "http://client2.oauth.com", "http://client3.oauth.com"}, config.OauthRedirectUriSeparator)
+			redirectURI = strings.Join([]string{"http://client.oauth.com", "http://client2.oauth.com", "http://client3.oauth.com"}, globalConf.OauthRedirectUriSeparator)
 		}
 		testClient := OAuthClient{
 			ClientID:          "1234",
@@ -465,7 +465,7 @@ func loadCustomMiddleware(referenceSpec *APISpec) ([]string, apidef.MiddlewareDe
 		{name: "post_auth", slice: &mwPostKeyAuthFuncs, session: true},
 		{name: "post", slice: &mwPostFuncs, session: true},
 	} {
-		dirPath := filepath.Join(config.MiddlewarePath, referenceSpec.APIID, folder.name)
+		dirPath := filepath.Join(globalConf.MiddlewarePath, referenceSpec.APIID, folder.name)
 		files, _ := ioutil.ReadDir(dirPath)
 		for _, f := range files {
 			if strings.Contains(f.Name(), ".js") {
@@ -560,8 +560,8 @@ func handleCORS(chain *[]alice.Constructor, spec *APISpec) {
 }
 
 func isRPCMode() bool {
-	return config.AuthOverride.ForceAuthProvider &&
-		config.AuthOverride.AuthProvider.StorageEngine == RPCStorageEngine
+	return globalConf.AuthOverride.ForceAuthProvider &&
+		globalConf.AuthOverride.AuthProvider.StorageEngine == RPCStorageEngine
 }
 
 type SortableAPISpecListByListen []*APISpec
@@ -589,7 +589,7 @@ func (s SortableAPISpecListByHost) Less(i, j int) bool {
 }
 
 func notifyAPILoaded(spec *APISpec) {
-	if config.UseRedisLog {
+	if globalConf.UseRedisLog {
 		log.WithFields(logrus.Fields{
 			"prefix":      "gateway",
 			"user_ip":     "--",
@@ -624,7 +624,7 @@ func doReload() {
 	// We have updated specs, lets load those...
 
 	// Reset the JSVM
-	if config.EnableJSVM {
+	if globalConf.EnableJSVM {
 		GlobalEventsJSVM.Init()
 	}
 
@@ -634,7 +634,7 @@ func doReload() {
 	newRouter := mux.NewRouter()
 	mainRouter = newRouter
 
-	if config.ControlAPIPort == 0 {
+	if globalConf.ControlAPIPort == 0 {
 		loadAPIEndpoints(newRouter)
 	}
 	loadApps(specs, newRouter)
@@ -691,11 +691,11 @@ func reloadURLStructure(fn func()) bool {
 }
 
 func setupLogger() {
-	if config.UseSentry {
+	if globalConf.UseSentry {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Debug("Enabling Sentry support")
-		hook, err := logrus_sentry.NewSentryHook(config.SentryCode, []logrus.Level{
+		hook, err := logrus_sentry.NewSentryHook(globalConf.SentryCode, []logrus.Level{
 			logrus.PanicLevel,
 			logrus.FatalLevel,
 			logrus.ErrorLevel,
@@ -711,12 +711,12 @@ func setupLogger() {
 		}).Debug("Sentry hook active")
 	}
 
-	if config.UseSyslog {
+	if globalConf.UseSyslog {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Debug("Enabling Syslog support")
-		hook, err := logrus_syslog.NewSyslogHook(config.SyslogTransport,
-			config.SyslogNetworkAddr,
+		hook, err := logrus_syslog.NewSyslogHook(globalConf.SyslogTransport,
+			globalConf.SyslogNetworkAddr,
 			syslog.LOG_INFO, "")
 
 		if err == nil {
@@ -727,11 +727,11 @@ func setupLogger() {
 		}).Debug("Syslog hook active")
 	}
 
-	if config.UseGraylog {
+	if globalConf.UseGraylog {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Debug("Enabling Graylog support")
-		hook := graylog.NewGraylogHook(config.GraylogNetworkAddr,
+		hook := graylog.NewGraylogHook(globalConf.GraylogNetworkAddr,
 			map[string]interface{}{"tyk-module": "gateway"})
 
 		log.Hooks.Add(hook)
@@ -741,12 +741,12 @@ func setupLogger() {
 		}).Debug("Graylog hook active")
 	}
 
-	if config.UseLogstash {
+	if globalConf.UseLogstash {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Debug("Enabling Logstash support")
-		hook, err := logrus_logstash.NewHook(config.LogstashTransport,
-			config.LogstashNetworkAddr,
+		hook, err := logrus_logstash.NewHook(globalConf.LogstashTransport,
+			globalConf.LogstashNetworkAddr,
 			"tyk-gateway")
 
 		if err == nil {
@@ -757,7 +757,7 @@ func setupLogger() {
 		}).Debug("Logstash hook active")
 	}
 
-	if config.UseRedisLog {
+	if globalConf.UseRedisLog {
 		redisHook := newRedisHook()
 		log.Hooks.Add(redisHook)
 
@@ -804,12 +804,12 @@ func initialiseSystem(arguments map[string]interface{}) error {
 	}
 
 	if !runningTests {
-		if err := loadConfig(confPaths, &config); err != nil {
+		if err := loadConfig(confPaths, &globalConf); err != nil {
 			return err
 		}
 	}
 
-	if config.Storage.Type != "redis" {
+	if globalConf.Storage.Type != "redis" {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Fatal("Redis connection details not set, please ensure that the storage type is set to Redis and that the connection parameters are correct.")
@@ -824,22 +824,22 @@ func initialiseSystem(arguments map[string]interface{}) error {
 				"prefix": "main",
 			}).Error("Port specified in flags must be a number: ", err)
 		} else {
-			config.ListenPort = portNum
+			globalConf.ListenPort = portNum
 		}
 	}
 
 	// Enable all the loggers
 	setupLogger()
 
-	if config.PIDFileLocation == "" {
-		config.PIDFileLocation = "/var/run/tyk-gateway.pid"
+	if globalConf.PIDFileLocation == "" {
+		globalConf.PIDFileLocation = "/var/run/tyk-gateway.pid"
 	}
 
 	log.WithFields(logrus.Fields{
 		"prefix": "main",
-	}).Info("PIDFile location set to: ", config.PIDFileLocation)
+	}).Info("PIDFile location set to: ", globalConf.PIDFileLocation)
 
-	pidfile.SetPidfilePath(config.PIDFileLocation)
+	pidfile.SetPidfilePath(globalConf.PIDFileLocation)
 	if err := pidfile.Write(); err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
@@ -951,8 +951,8 @@ func getGlobalLocalCacheStorageHandler(keyPrefix string, hashKeys bool) StorageH
 }
 
 func getGlobalStorageHandler(keyPrefix string, hashKeys bool) StorageHandler {
-	if config.SlaveOptions.UseRPC {
-		return &RPCStorageHandler{KeyPrefix: keyPrefix, HashKeys: hashKeys, UserKey: config.SlaveOptions.APIKey, Address: config.SlaveOptions.ConnectionString}
+	if globalConf.SlaveOptions.UseRPC {
+		return &RPCStorageHandler{KeyPrefix: keyPrefix, HashKeys: hashKeys, UserKey: globalConf.SlaveOptions.APIKey, Address: globalConf.SlaveOptions.ConnectionString}
 	}
 	return &RedisClusterStorageManager{KeyPrefix: keyPrefix, HashKeys: hashKeys}
 }
@@ -961,7 +961,7 @@ func getGlobalStorageHandler(keyPrefix string, hashKeys bool) StorageHandler {
 var amForked bool
 
 func onFork() {
-	if config.UseDBAppConfigs {
+	if globalConf.UseDBAppConfigs {
 		log.Info("Stopping heartbeat")
 		DashService.StopBeating()
 
@@ -996,8 +996,8 @@ func main() {
 			}).Fatalf("Error starting listener: %s", err)
 		}
 
-		if config.ControlAPIPort > 0 {
-			if controlListener, err = generateListener(config.ControlAPIPort); err != nil {
+		if globalConf.ControlAPIPort > 0 {
+			if controlListener, err = generateListener(globalConf.ControlAPIPort); err != nil {
 				log.WithFields(logrus.Fields{
 					"prefix": "main",
 				}).Fatalf("Error starting control API listener: %s", err)
@@ -1035,7 +1035,7 @@ func main() {
 	if !amForked {
 		log.Info("Stop signal received.")
 
-		if config.UseDBAppConfigs {
+		if globalConf.UseDBAppConfigs {
 			log.Info("Stopping heartbeat...")
 			DashService.StopBeating()
 			time.Sleep(2 * time.Second)
@@ -1085,7 +1085,7 @@ func start(arguments map[string]interface{}) {
 	}
 
 	// Set up a default org manager so we can traverse non-live paths
-	if !config.SupressDefaultOrgStore {
+	if !globalConf.SupressDefaultOrgStore {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Debug("Initialising default org store")
@@ -1095,28 +1095,28 @@ func start(arguments map[string]interface{}) {
 		DefaultQuotaStore.Init(getGlobalStorageHandler("orgkey.", false))
 	}
 
-	if config.ControlAPIPort == 0 {
+	if globalConf.ControlAPIPort == 0 {
 		loadAPIEndpoints(defaultRouter)
 	}
 
 	// Start listening for reload messages
-	if !config.SuppressRedisSignalReload {
+	if !globalConf.SuppressRedisSignalReload {
 		go startPubSubLoop()
 	}
 
-	if config.SlaveOptions.UseRPC {
+	if globalConf.SlaveOptions.UseRPC {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Debug("Starting RPC reload listener")
 		RPCListener = RPCStorageHandler{
 			KeyPrefix:        "rpc.listener.",
-			UserKey:          config.SlaveOptions.APIKey,
-			Address:          config.SlaveOptions.ConnectionString,
+			UserKey:          globalConf.SlaveOptions.APIKey,
+			Address:          globalConf.SlaveOptions.ConnectionString,
 			SuppressRegister: true,
 		}
 		RPCListener.Connect()
-		go rpcReloadLoop(config.SlaveOptions.RPCKey)
-		go RPCListener.StartRPCLoopCheck(config.SlaveOptions.RPCKey)
+		go rpcReloadLoop(globalConf.SlaveOptions.RPCKey)
+		go RPCListener.StartRPCLoopCheck(globalConf.SlaveOptions.RPCKey)
 	}
 
 	// 1s is the minimum amount of time between hot reloads. The
@@ -1125,20 +1125,20 @@ func start(arguments map[string]interface{}) {
 }
 
 func generateListener(listenPort int) (net.Listener, error) {
-	listenAddress := config.ListenAddress
+	listenAddress := globalConf.ListenAddress
 	if listenPort == 0 {
-		listenPort = config.ListenPort
+		listenPort = globalConf.ListenPort
 	}
 
 	targetPort := fmt.Sprintf("%s:%d", listenAddress, listenPort)
 
-	if config.HttpServerOptions.UseSSL {
+	if globalConf.HttpServerOptions.UseSSL {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Info("--> Using SSL (https)")
-		certs := make([]tls.Certificate, len(config.HttpServerOptions.Certificates))
+		certs := make([]tls.Certificate, len(globalConf.HttpServerOptions.Certificates))
 		certNameMap := make(map[string]*tls.Certificate)
-		for i, certData := range config.HttpServerOptions.Certificates {
+		for i, certData := range globalConf.HttpServerOptions.Certificates {
 			cert, err := tls.LoadX509KeyPair(certData.CertFile, certData.KeyFile)
 			if err != nil {
 				log.WithFields(logrus.Fields{
@@ -1152,13 +1152,13 @@ func generateListener(listenPort int) (net.Listener, error) {
 		config := tls.Config{
 			Certificates:       certs,
 			NameToCertificate:  certNameMap,
-			ServerName:         config.HttpServerOptions.ServerName,
-			MinVersion:         config.HttpServerOptions.MinVersion,
-			InsecureSkipVerify: config.HttpServerOptions.SSLInsecureSkipVerify,
+			ServerName:         globalConf.HttpServerOptions.ServerName,
+			MinVersion:         globalConf.HttpServerOptions.MinVersion,
+			InsecureSkipVerify: globalConf.HttpServerOptions.SSLInsecureSkipVerify,
 		}
 		return tls.Listen("tcp", targetPort, &config)
 
-	} else if config.HttpServerOptions.UseLE_SSL {
+	} else if globalConf.HttpServerOptions.UseLE_SSL {
 
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
@@ -1180,7 +1180,7 @@ func generateListener(listenPort int) (net.Listener, error) {
 }
 
 func handleDashboardRegistration() {
-	if config.UseDBAppConfigs {
+	if globalConf.UseDBAppConfigs {
 
 		if DashService == nil {
 			DashService = &HTTPDashboardHandler{}
@@ -1201,7 +1201,7 @@ func handleDashboardRegistration() {
 }
 
 func startHeartBeat() {
-	if config.UseDBAppConfigs {
+	if globalConf.UseDBAppConfigs {
 		if DashService == nil {
 			DashService = &HTTPDashboardHandler{}
 			DashService.Init()
@@ -1212,9 +1212,9 @@ func startHeartBeat() {
 
 func startDRL() {
 	switch {
-	case config.ManagementNode,
-		config.EnableSentinelRateLImiter,
-		config.EnableRedisRollingLimiter:
+	case globalConf.ManagementNode,
+		globalConf.EnableSentinelRateLImiter,
+		globalConf.EnableRedisRollingLimiter:
 		return
 	}
 	log.WithFields(logrus.Fields{
@@ -1227,13 +1227,13 @@ func startDRL() {
 func listen(l, controlListener net.Listener, err error) {
 	readTimeout := 120
 	writeTimeout := 120
-	targetPort := fmt.Sprintf("%s:%d", config.ListenAddress, config.ListenPort)
-	if config.HttpServerOptions.ReadTimeout > 0 {
-		readTimeout = config.HttpServerOptions.ReadTimeout
+	targetPort := fmt.Sprintf("%s:%d", globalConf.ListenAddress, globalConf.ListenPort)
+	if globalConf.HttpServerOptions.ReadTimeout > 0 {
+		readTimeout = globalConf.HttpServerOptions.ReadTimeout
 	}
 
-	if config.HttpServerOptions.WriteTimeout > 0 {
-		writeTimeout = config.HttpServerOptions.WriteTimeout
+	if globalConf.HttpServerOptions.WriteTimeout > 0 {
+		writeTimeout = globalConf.HttpServerOptions.WriteTimeout
 	}
 
 	// Handle reload when SIGUSR2 is received
@@ -1255,14 +1255,14 @@ func listen(l, controlListener net.Listener, err error) {
 				getPolicies()
 			}
 
-			if config.ControlAPIPort > 0 {
+			if globalConf.ControlAPIPort > 0 {
 				loadAPIEndpoints(controlRouter)
 			}
 		}
 
 		// Use a custom server so we can control keepalives
-		if config.HttpServerOptions.OverrideDefaults {
-			defaultRouter.SkipClean(config.HttpServerOptions.SkipURLCleaning)
+		if globalConf.HttpServerOptions.OverrideDefaults {
+			defaultRouter.SkipClean(globalConf.HttpServerOptions.SkipURLCleaning)
 
 			log.WithFields(logrus.Fields{
 				"prefix": "main",
@@ -1342,14 +1342,14 @@ func listen(l, controlListener net.Listener, err error) {
 				getPolicies()
 			}
 
-			if config.ControlAPIPort > 0 {
+			if globalConf.ControlAPIPort > 0 {
 				loadAPIEndpoints(controlRouter)
 			}
 
 			startHeartBeat()
 		}
 
-		if config.HttpServerOptions.OverrideDefaults {
+		if globalConf.HttpServerOptions.OverrideDefaults {
 			log.WithFields(logrus.Fields{
 				"prefix": "main",
 			}).Warning("HTTP Server Overrides detected, this could destabilise long-running http-requests")

--- a/monitor.go
+++ b/monitor.go
@@ -5,7 +5,7 @@ import "time"
 type Monitor struct{}
 
 func (m *Monitor) IsMonitorEnabled() bool {
-	return config.Monitor.EnableTriggerMonitors
+	return globalConf.Monitor.EnableTriggerMonitors
 }
 
 func (m *Monitor) Fire(sessionData *SessionState, key string, triggerLimit float64) {
@@ -43,13 +43,13 @@ func (m *Monitor) Check(sessionData *SessionState, key string) {
 		return
 	}
 
-	if config.Monitor.GlobalTriggerLimit > 0.0 && usagePerc >= config.Monitor.GlobalTriggerLimit {
+	if globalConf.Monitor.GlobalTriggerLimit > 0.0 && usagePerc >= globalConf.Monitor.GlobalTriggerLimit {
 		log.Info("Firing...")
-		m.Fire(sessionData, key, config.Monitor.GlobalTriggerLimit)
+		m.Fire(sessionData, key, globalConf.Monitor.GlobalTriggerLimit)
 	}
 
 	for _, triggerLimit := range sessionData.Monitor.TriggerLimits {
-		if usagePerc >= triggerLimit && triggerLimit != config.Monitor.GlobalTriggerLimit {
+		if usagePerc >= triggerLimit && triggerLimit != globalConf.Monitor.GlobalTriggerLimit {
 			log.Info("Firing...")
 			m.Fire(sessionData, key, triggerLimit)
 			break

--- a/mw_organisation_activity.go
+++ b/mw_organisation_activity.go
@@ -41,11 +41,11 @@ func (k *OrganizationMonitor) New() {
 func (k *OrganizationMonitor) IsEnabledForSpec() bool {
 	// If false, we aren't enforcing quotas so skip this mw
 	// altogether
-	return config.EnforceOrgQuotas
+	return globalConf.EnforceOrgQuotas
 }
 
 func (k *OrganizationMonitor) ProcessRequest(w http.ResponseWriter, r *http.Request, conf interface{}) (error, int) {
-	if config.ExperimentalProcessOrgOffThread {
+	if globalConf.ExperimentalProcessOrgOffThread {
 		return k.ProcessRequestOffThread(w, r, conf)
 	}
 	return k.ProcessRequestLive(w, r, conf)
@@ -54,7 +54,7 @@ func (k *OrganizationMonitor) ProcessRequest(w http.ResponseWriter, r *http.Requ
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (k *OrganizationMonitor) ProcessRequestLive(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 
-	if !config.EnforceOrgQuotas {
+	if !globalConf.EnforceOrgQuotas {
 		// We aren;t enforcing quotas, so skip this altogether
 		return nil, 200
 	}
@@ -106,7 +106,7 @@ func (k *OrganizationMonitor) ProcessRequestLive(w http.ResponseWriter, r *http.
 		return errors.New("This organisation quota has been exceeded, please contact your API administrator"), 403
 	}
 
-	if config.Monitor.MonitorOrgKeys {
+	if globalConf.Monitor.MonitorOrgKeys {
 		// Run the trigger monitor
 		k.mon.Check(&session, "")
 	}
@@ -129,7 +129,7 @@ func (k *OrganizationMonitor) SetOrgSentinel(orgChan chan bool, orgId string) {
 
 func (k *OrganizationMonitor) ProcessRequestOffThread(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 
-	if !config.EnforceOrgQuotas {
+	if !globalConf.EnforceOrgQuotas {
 		// We aren't enforcing quotas, so skip this altogether
 		return nil, 200
 	}
@@ -205,7 +205,7 @@ func (k *OrganizationMonitor) AllowAccessNext(orgChan chan bool, r *http.Request
 		//return errors.New("This organisation quota has been exceeded, please contact your API administrator"), 403
 		orgChan <- false
 
-		if config.Monitor.MonitorOrgKeys {
+		if globalConf.Monitor.MonitorOrgKeys {
 			// Run the trigger monitor
 			k.mon.Check(&session, "")
 		}
@@ -213,7 +213,7 @@ func (k *OrganizationMonitor) AllowAccessNext(orgChan chan bool, r *http.Request
 		return
 	}
 
-	if config.Monitor.MonitorOrgKeys {
+	if globalConf.Monitor.MonitorOrgKeys {
 		// Run the trigger monitor
 		k.mon.Check(&session, "")
 	}

--- a/mw_rate_limiting.go
+++ b/mw_rate_limiting.go
@@ -81,7 +81,7 @@ func (k *RateLimitAndQuotaCheck) ProcessRequest(w http.ResponseWriter, r *http.R
 	// If either are disabled, save the write roundtrip
 	if !k.Spec.DisableRateLimit || !k.Spec.DisableQuota {
 		// Ensure quota and rate data for this session are recorded
-		if config.UseAsyncSessionWrite {
+		if globalConf.UseAsyncSessionWrite {
 			go k.Spec.SessionManager.UpdateSession(token, session, getLifetime(k.Spec, session))
 		} else {
 			k.Spec.SessionManager.UpdateSession(token, session, getLifetime(k.Spec, session))
@@ -102,7 +102,7 @@ func (k *RateLimitAndQuotaCheck) ProcessRequest(w http.ResponseWriter, r *http.R
 		return errors.New("Access denied"), 403
 	}
 	// Run the trigger monitor
-	if config.Monitor.MonitorUserKeys {
+	if globalConf.Monitor.MonitorUserKeys {
 		sessionMonitor.Check(session, token)
 	}
 

--- a/mw_virtual_endpoint.go
+++ b/mw_virtual_endpoint.go
@@ -63,7 +63,7 @@ func PreLoadVirtualMetaCode(meta *apidef.VirtualMeta, j *JSVM) {
 			j.VM.Run(js)
 		}
 	case "blob":
-		if config.DisableVirtualPathBlobs {
+		if globalConf.DisableVirtualPathBlobs {
 			log.Error("[JSVM] Blobs not allowerd on this node")
 			return
 		}
@@ -98,7 +98,7 @@ func (d *VirtualEndpoint) configData() (conf VirtualEndpointConfig) {
 }
 
 func (d *VirtualEndpoint) IsEnabledForSpec() bool {
-	if !config.EnableJSVM {
+	if !globalConf.EnableJSVM {
 		return false
 	}
 	for _, version := range d.Spec.VersionData.Versions {
@@ -267,7 +267,7 @@ func (d *VirtualEndpoint) HandleResponse(rw http.ResponseWriter, res *http.Respo
 	defer res.Body.Close()
 
 	// Close connections
-	if config.CloseConnections {
+	if globalConf.CloseConnections {
 		res.Header.Set("Connection", "close")
 	}
 

--- a/oauth_manager.go
+++ b/oauth_manager.go
@@ -250,7 +250,7 @@ func (o *OAuthManager) HandleAccess(r *http.Request) *osin.Response {
 			username = r.Form.Get("username")
 			password := r.Form.Get("password")
 			keyName := o.API.OrgID + username
-			if config.HashKeys {
+			if globalConf.HashKeys {
 				// HASHING? FIX THE KEY
 				keyName = doHash(keyName)
 			}
@@ -499,7 +499,7 @@ func (r *RedisOsinStorageInterface) GetClients(filter string, ignorePrefix bool)
 	}
 
 	var clientJSON map[string]string
-	if !config.Storage.EnableCluster {
+	if !globalConf.Storage.EnableCluster {
 		clientJSON = r.store.GetKeysAndValuesWithFilter(key)
 	} else {
 		keyForSet := prefixClientset + prefixClient // Org ID
@@ -620,8 +620,8 @@ func (r *RedisOsinStorageInterface) SaveAccess(accessData *osin.AccessData) erro
 	log.Debug("Saving ACCESS key: ", key)
 
 	// Overide default ExpiresIn:
-	if config.OauthTokenExpire != 0 {
-		accessData.ExpiresIn = config.OauthTokenExpire
+	if globalConf.OauthTokenExpire != 0 {
+		accessData.ExpiresIn = globalConf.OauthTokenExpire
 	}
 
 	r.store.SetKey(key, string(authDataJSON), int64(accessData.ExpiresIn))
@@ -670,8 +670,8 @@ func (r *RedisOsinStorageInterface) SaveAccess(accessData *osin.AccessData) erro
 		key := prefixRefresh + accessData.RefreshToken
 		log.Debug("Saving REFRESH key: ", key)
 		refreshExpire := int64(1209600) // 14 days
-		if config.OauthRefreshExpire != 0 {
-			refreshExpire = config.OauthRefreshExpire
+		if globalConf.OauthRefreshExpire != 0 {
+			refreshExpire = globalConf.OauthRefreshExpire
 		}
 		r.store.SetKey(key, string(accessDataJSON), refreshExpire)
 		log.Debug("STORING ACCESS DATA: ", string(accessDataJSON))

--- a/oauth_manager_test.go
+++ b/oauth_manager_test.go
@@ -113,7 +113,7 @@ func TestAuthCodeRedirect(t *testing.T) {
 
 func TestAuthCodeRedirectMultipleURL(t *testing.T) {
 	// Enable multiple Redirect URIs
-	config.OauthRedirectUriSeparator = ","
+	globalConf.OauthRedirectUriSeparator = ","
 
 	spec := createSpecTest(t, oauthDefinition)
 	testMuxer := mux.NewRouter()
@@ -140,7 +140,7 @@ func TestAuthCodeRedirectMultipleURL(t *testing.T) {
 
 func TestAuthCodeRedirectInvalidMultipleURL(t *testing.T) {
 	// Disable multiple Redirect URIs
-	config.OauthRedirectUriSeparator = ""
+	globalConf.OauthRedirectUriSeparator = ""
 
 	spec := createSpecTest(t, oauthDefinition)
 	testMuxer := mux.NewRouter()

--- a/plugins.go
+++ b/plugins.go
@@ -233,7 +233,7 @@ func (j *JSVM) Init() {
 	vm := otto.New()
 
 	// Init TykJS namespace, constructors etc.
-	jscore, _ := ioutil.ReadFile(config.TykJSPath)
+	jscore, _ := ioutil.ReadFile(globalConf.TykJSPath)
 	vm.Run(jscore)
 
 	j.VM = vm

--- a/policy.go
+++ b/policy.go
@@ -180,7 +180,7 @@ func LoadPoliciesFromDashboard(endpoint, secret string, allowExplicit bool) map[
 func LoadPoliciesFromRPC(orgId string) map[string]Policy {
 	var dbPolicyList []Policy
 
-	store := &RPCStorageHandler{UserKey: config.SlaveOptions.APIKey, Address: config.SlaveOptions.ConnectionString}
+	store := &RPCStorageHandler{UserKey: globalConf.SlaveOptions.APIKey, Address: globalConf.SlaveOptions.ConnectionString}
 	store.Connect()
 
 	rpcPolicies := store.GetPolicies(orgId)

--- a/redis_cluster_handler.go
+++ b/redis_cluster_handler.go
@@ -32,10 +32,10 @@ type RedisClusterStorageManager struct {
 
 func NewRedisClusterPool(forceReconnect bool, isCache bool) *rediscluster.RedisCluster {
 	redisPtr := redisClusterSingleton
-	cfg := config.Storage
-	if isCache && config.EnableSeperateCacheStore {
+	cfg := globalConf.Storage
+	if isCache && globalConf.EnableSeperateCacheStore {
 		redisPtr = redisCacheClusterSingleton
-		cfg = config.CacheStorage
+		cfg = globalConf.CacheStorage
 	}
 
 	if !forceReconnect {

--- a/redis_signal_dash_zeroconf.go
+++ b/redis_signal_dash_zeroconf.go
@@ -44,23 +44,23 @@ func handleDashboardZeroConfMessage(payload string) {
 		return
 	}
 
-	if !config.UseDBAppConfigs {
+	if !globalConf.UseDBAppConfigs {
 		return
 	}
 
-	if config.DisableDashboardZeroConf {
+	if globalConf.DisableDashboardZeroConf {
 		return
 	}
 
 	hostname := createConnectionStringFromDashboardObject(dashPayload)
 	setHostname := false
-	if config.DBAppConfOptions.ConnectionString == "" {
-		config.DBAppConfOptions.ConnectionString = hostname
+	if globalConf.DBAppConfOptions.ConnectionString == "" {
+		globalConf.DBAppConfOptions.ConnectionString = hostname
 		setHostname = true
 	}
 
-	if config.Policies.PolicyConnectionString == "" {
-		config.Policies.PolicyConnectionString = hostname
+	if globalConf.Policies.PolicyConnectionString == "" {
+		globalConf.Policies.PolicyConnectionString = hostname
 		setHostname = true
 	}
 

--- a/redis_signal_handle_config.go
+++ b/redis_signal_handle_config.go
@@ -17,7 +17,7 @@ type ConfigPayload struct {
 }
 
 func backupConfiguration() error {
-	oldConfig, err := json.MarshalIndent(config, "", "    ")
+	oldConfig, err := json.MarshalIndent(globalConf, "", "    ")
 	if err != nil {
 		return err
 	}
@@ -69,7 +69,7 @@ func handleNewConfiguration(payload string) {
 		return
 	}
 
-	if config.AllowRemoteConfig {
+	if globalConf.AllowRemoteConfig {
 		log.WithFields(logrus.Fields{
 			"prefix": "pub-sub",
 		}).Warning("Ignoring new config: Remote configuration is not allowed for this node.")

--- a/redis_signal_handle_config_request.go
+++ b/redis_signal_handle_config_request.go
@@ -40,7 +40,7 @@ func sanitizeConfig(mc map[string]interface{}) map[string]interface{} {
 
 func getExistingConfig() (map[string]interface{}, error) {
 	var microConfig map[string]interface{}
-	dat, err := ioutil.ReadFile(usedConfPath)
+	dat, err := ioutil.ReadFile(globalConf.OriginalPath)
 	if err != nil {
 		return microConfig, err
 	}

--- a/redis_signals.go
+++ b/redis_signals.go
@@ -71,7 +71,7 @@ func handleRedisEvent(v interface{}, handled func(NotificationCommand), reloaded
 	case NoticeDashboardConfigRequest:
 		handleSendMiniConfig(notif.Payload)
 	case NoticeGatewayDRLNotification:
-		if config.ManagementNode {
+		if globalConf.ManagementNode {
 			// DRL is not initialized, going through would
 			// be mostly harmless but would flood the log
 			// with warnings since DRLManager.Ready == false
@@ -107,7 +107,7 @@ func isPayloadSignatureValid(notification Notification) bool {
 		return true
 	}
 
-	if notification.Signature == "" && config.AllowInsecureConfigs {
+	if notification.Signature == "" && globalConf.AllowInsecureConfigs {
 		if !warnedOnce {
 			log.WithFields(logrus.Fields{
 				"prefix": "pub-sub",
@@ -117,10 +117,10 @@ func isPayloadSignatureValid(notification Notification) bool {
 		return true
 	}
 
-	if config.PublicKeyPath != "" {
+	if globalConf.PublicKeyPath != "" {
 		if notificationVerifier == nil {
 			var err error
-			notificationVerifier, err = goverify.LoadPublicKeyFromFile(config.PublicKeyPath)
+			notificationVerifier, err = goverify.LoadPublicKeyFromFile(globalConf.PublicKeyPath)
 			if err != nil {
 				log.WithFields(logrus.Fields{
 					"prefix": "pub-sub",

--- a/rpc_backup_handlers.go
+++ b/rpc_backup_handlers.go
@@ -19,8 +19,8 @@ const BackupKeyBase = "node-definition-backup:"
 
 func getTagListAsString() string {
 	tagList := ""
-	if len(config.DBAppConfOptions.Tags) > 0 {
-		tagList = strings.Join(config.DBAppConfOptions.Tags, "-")
+	if len(globalConf.DBAppConfOptions.Tags) > 0 {
+		tagList = strings.Join(globalConf.DBAppConfOptions.Tags, "-")
 	}
 
 	return tagList
@@ -42,7 +42,7 @@ func saveRPCDefinitionsBackup(list string) {
 		return
 	}
 
-	secret := rightPad2Len(config.Secret, "=", 32)
+	secret := rightPad2Len(globalConf.Secret, "=", 32)
 	cryptoText := encrypt([]byte(secret), list)
 	err := store.SetKey(BackupKeyBase+tagList, cryptoText, -1)
 	if err != nil {
@@ -64,7 +64,7 @@ func LoadDefinitionsFromRPCBackup() []*APISpec {
 		return nil
 	}
 
-	secret := rightPad2Len(config.Secret, "=", 32)
+	secret := rightPad2Len(globalConf.Secret, "=", 32)
 	cryptoText, err := store.GetKey(checkKey)
 	apiListAsString := decrypt([]byte(secret), cryptoText)
 

--- a/rpc_storage_handler.go
+++ b/rpc_storage_handler.go
@@ -234,7 +234,7 @@ func (r *RPCStorageHandler) ReAttemptLogin(err error) {
 func (r *RPCStorageHandler) GroupLogin() {
 	groupLoginData := GroupLoginRequest{
 		UserKey: r.UserKey,
-		GroupID: config.SlaveOptions.GroupID,
+		GroupID: globalConf.SlaveOptions.GroupID,
 	}
 	ok, err := RPCFuncClientSingleton.CallTimeout("LoginWithGroup", groupLoginData, GlobalRPCCallTimeout)
 	if err != nil {
@@ -260,7 +260,7 @@ func (r *RPCStorageHandler) Login() {
 	}
 
 	// If we have a group ID, lets login as a group
-	if config.SlaveOptions.GroupID != "" {
+	if globalConf.SlaveOptions.GroupID != "" {
 		r.GroupLogin()
 		return
 	}
@@ -288,7 +288,7 @@ func (r *RPCStorageHandler) GetKey(keyName string) (string, error) {
 	log.Debug("[STORE] Getting: ", r.fixKey(keyName))
 
 	// Check the cache first
-	if config.SlaveOptions.EnableRPCCache {
+	if globalConf.SlaveOptions.EnableRPCCache {
 		log.Debug("Using cache for: ", keyName)
 		cachedVal, found := RPCGlobalCache.Get(r.fixKey(keyName))
 		log.Debug("--> Found? ", found)
@@ -315,7 +315,7 @@ func (r *RPCStorageHandler) GetKey(keyName string) (string, error) {
 	elapsed := time.Since(start)
 	log.Debug("GetKey took ", elapsed)
 
-	if config.SlaveOptions.EnableRPCCache {
+	if globalConf.SlaveOptions.EnableRPCCache {
 		// Cache it
 		RPCGlobalCache.Set(r.fixKey(keyName), value, cache.DefaultExpiration)
 	}
@@ -656,7 +656,7 @@ func (r *RPCStorageHandler) CheckForReload(orgId string) {
 }
 
 func (r *RPCStorageHandler) StartRPCLoopCheck(orgId string) {
-	if config.SlaveOptions.DisableKeySpaceSync {
+	if globalConf.SlaveOptions.DisableKeySpaceSync {
 		return
 	}
 
@@ -675,13 +675,13 @@ func (r *RPCStorageHandler) CheckForKeyspaceChanges(orgId string) {
 	var keys interface{}
 	var err error
 
-	if config.SlaveOptions.GroupID == "" {
+	if globalConf.SlaveOptions.GroupID == "" {
 		keys, err = RPCFuncClientSingleton.CallTimeout("GetKeySpaceUpdate", orgId, GlobalRPCCallTimeout)
 	} else {
 
 		grpReq := GroupKeySpaceRequest{
 			OrgID:   orgId,
-			GroupID: config.SlaveOptions.GroupID,
+			GroupID: globalConf.SlaveOptions.GroupID,
 		}
 		keys, err = RPCFuncClientSingleton.CallTimeout("GetGroupKeySpaceUpdate", grpReq, GlobalRPCCallTimeout)
 	}

--- a/session_state.go
+++ b/session_state.go
@@ -103,8 +103,8 @@ func (s *SessionState) HasChanged() bool {
 }
 
 func getLifetime(spec *APISpec, session *SessionState) int64 {
-	if config.ForceGlobalSessionLifetime {
-		return config.GlobalSessionLifetime
+	if globalConf.ForceGlobalSessionLifetime {
+		return globalConf.GlobalSessionLifetime
 	}
 	if session.SessionLifetime > 0 {
 		return session.SessionLifetime

--- a/storage_handlers.go
+++ b/storage_handlers.go
@@ -45,7 +45,7 @@ func doHash(in string) string {
 
 //Public function for use in classes that bypass elements of the storage manager
 func publicHash(in string) string {
-	if !config.HashKeys {
+	if !globalConf.HashKeys {
 		// Not hashing? Return the raw key
 		return in
 	}

--- a/tyk_reverse_proxy_clone.go
+++ b/tyk_reverse_proxy_clone.go
@@ -155,8 +155,8 @@ func TykNewSingleHostReverseProxy(target *url.URL, spec *APISpec) *ReverseProxy 
 		if ServiceCache == nil {
 			log.Debug("[PROXY] Service cache initialising")
 			expiry := 120
-			if config.ServiceDiscovery.DefaultCacheTimeout > 0 {
-				expiry = config.ServiceDiscovery.DefaultCacheTimeout
+			if globalConf.ServiceDiscovery.DefaultCacheTimeout > 0 {
+				expiry = globalConf.ServiceDiscovery.DefaultCacheTimeout
 			}
 			ServiceCache = cache.New(time.Duration(expiry)*time.Second, 15*time.Second)
 		}
@@ -217,7 +217,7 @@ func TykNewSingleHostReverseProxy(target *url.URL, spec *APISpec) *ReverseProxy 
 		}
 	}
 
-	return &ReverseProxy{Director: director, TykAPISpec: spec, FlushInterval: time.Duration(config.HttpServerOptions.FlushInterval) * time.Millisecond}
+	return &ReverseProxy{Director: director, TykAPISpec: spec, FlushInterval: time.Duration(globalConf.HttpServerOptions.FlushInterval) * time.Millisecond}
 }
 
 // onExitFlushLoop is a callback set by tests to detect the state of the
@@ -262,7 +262,7 @@ func (t *TykTransporter) SetTimeout(timeOut int) {
 }
 
 func getMaxIdleConns() int {
-	return config.MaxIdleConnsPerHost
+	return globalConf.MaxIdleConnsPerHost
 }
 
 var TykDefaultTransport = &TykTransporter{http.Transport{
@@ -383,7 +383,7 @@ func (p *ReverseProxy) CheckCircuitBreakerEnforced(spec *APISpec, req *http.Requ
 
 func GetTransport(timeOut int, rw http.ResponseWriter, req *http.Request, p *ReverseProxy) http.RoundTripper {
 	transport := TykDefaultTransport
-	transport.TLSClientConfig.InsecureSkipVerify = config.ProxySSLInsecureSkipVerify
+	transport.TLSClientConfig.InsecureSkipVerify = globalConf.ProxySSLInsecureSkipVerify
 
 	// Use the default unless we've modified the timout
 	if timeOut > 0 {
@@ -586,7 +586,7 @@ func (p *ReverseProxy) HandleResponse(rw http.ResponseWriter, res *http.Response
 	defer res.Body.Close()
 
 	// Close connections
-	if config.CloseConnections {
+	if globalConf.CloseConnections {
 		res.Header.Set("Connection", "close")
 	}
 

--- a/util_http_helpers.go
+++ b/util_http_helpers.go
@@ -83,15 +83,15 @@ func CopyHttpResponse(r *http.Response) *http.Response {
 
 func RecordDetail(r *http.Request) bool {
 	// Are we even checking?
-	if !config.EnforceOrgDataDeailLogging {
-		return config.AnalyticsConfig.EnableDetailedRecording
+	if !globalConf.EnforceOrgDataDeailLogging {
+		return globalConf.AnalyticsConfig.EnableDetailedRecording
 	}
 
 	// We are, so get session data
 	ses := r.Context().Value(OrgSessionContext)
 	if ses == nil {
 		// no session found, use global config
-		return config.AnalyticsConfig.EnableDetailedRecording
+		return globalConf.AnalyticsConfig.EnableDetailedRecording
 	}
 
 	// Session found


### PR DESCRIPTION
This will be necessary for the linter. The root package is getting bigger and bigger, and the linter will be complex, so we don't want it there too.

Luckily, the config object is fairly independent from the rest of the codebase. Do some changes to make it more so, before we split it up into a separate package.