### PR TITLE
2.3.7 backport of the JS fixes

### DIFF
--- a/js/tyk.js
+++ b/js/tyk.js
@@ -11,13 +11,13 @@ var TykJS = {
         }
 };
 
-TykJS.TykMiddleware.MiddlewareComponentMeta.prototype.ProcessRequest = function(request, session) {
+TykJS.TykMiddleware.MiddlewareComponentMeta.prototype.ProcessRequest = function(request, session, config) {
     log("Process Request Not Implemented");
     return request;
 };
 
-TykJS.TykMiddleware.MiddlewareComponentMeta.prototype.DoProcessRequest = function(request, session) {
-    var processed_request = this.ProcessRequest(request, session);
+TykJS.TykMiddleware.MiddlewareComponentMeta.prototype.DoProcessRequest = function(request, session, config) {
+    var processed_request = this.ProcessRequest(request, session, config);
 
     if (!processed_request) {
         log("Middleware didn't return request object!");

--- a/plugins.go
+++ b/plugins.go
@@ -345,6 +345,12 @@ func (j *JSVM) LoadTykJSApi() {
 		return otto.Value{}
 	})
 
+	j.VM.Set("rawlog", func(call otto.FunctionCall) otto.Value {
+		io.WriteString(log.Out, call.Argument(0).String())
+		log.Out.Write([]byte("\n"))
+		return otto.Value{}
+	})
+
 	// Enable the creation of HTTP Requsts
 	j.VM.Set("TykMakeHttpRequest", func(call otto.FunctionCall) otto.Value {
 

--- a/plugins_test.go
+++ b/plugins_test.go
@@ -5,12 +5,14 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/TykTechnologies/tykcommon"
 )
 
 func TestJSVMProcessTimeout(t *testing.T) {
 	dynMid := &DynamicMiddleware{
 		TykMiddleware: &TykMiddleware{
-			Spec: &APISpec{},
+			Spec: &APISpec{APIDefinition: &tykcommon.APIDefinition{}},
 		},
 		MiddlewareClassName: "leakMid",
 		Pre:                 true,
@@ -29,8 +31,7 @@ leakMid.NewProcessRequest(function(request, session) {
        while (true) {
        }
        return leakMid.ReturnData(request, session.meta_data);
-});
-`
+});`
 	if _, err := jsvm.VM.Run(js); err != nil {
 		t.Fatalf("failed to set up js plugin: %v", err)
 	}
@@ -45,5 +46,38 @@ leakMid.NewProcessRequest(function(request, session) {
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("js vm wasn't killed after its timeout")
+	}
+}
+
+func TestJSVMConfigData(t *testing.T) {
+	spec := &APISpec{APIDefinition: &tykcommon.APIDefinition{}}
+	spec.RawData = map[string]interface{}{
+		"config_data": map[string]interface{}{
+			"foo": "bar",
+		},
+	}
+	const js = `
+var testJSVMData = new TykJS.TykMiddleware.NewMiddleware({});
+
+testJSVMData.NewProcessRequest(function(request, session, config) {
+	request.SetHeaders["data-foo"] = config.config_data.foo;
+	return testJSVMData.ReturnData(request, {});
+});`
+	dynMid := &DynamicMiddleware{
+		TykMiddleware:       &TykMiddleware{spec, nil},
+		MiddlewareClassName: "testJSVMData",
+		Pre:                 true,
+	}
+	jsvm := &JSVM{}
+	jsvm.Init()
+	if _, err := jsvm.VM.Run(js); err != nil {
+		t.Fatalf("failed to set up js plugin: %v", err)
+	}
+	dynMid.Spec.JSVM = jsvm
+
+	r := httptest.NewRequest("GET", "/v1/test-data", nil)
+	dynMid.ProcessRequest(nil, r, nil)
+	if want, got := "bar", r.Header.Get("data-foo"); want != got {
+		t.Fatalf("wanted header to be %q, got %q", want, got)
 	}
 }


### PR DESCRIPTION
I was able to backport the JSVM config_data test, so everything should still work even though there were plenty of conflicts.