### PR TITLE
all: make all use_params not read body forms

### DIFF
--- a/mw_auth_key.go
+++ b/mw_auth_key.go
@@ -33,8 +33,6 @@ func (k *AuthKey) setContextVars(r *http.Request, token string) {
 }
 
 func (k *AuthKey) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
-	var tempRes *http.Request
-
 	config := k.Spec.Auth
 
 	key := r.Header.Get(config.AuthHeaderName)
@@ -45,8 +43,7 @@ func (k *AuthKey) ProcessRequest(w http.ResponseWriter, r *http.Request, _ inter
 			paramName = config.AuthHeaderName
 		}
 
-		tempRes = CopyHttpRequest(r)
-		paramValue := tempRes.FormValue(paramName)
+		paramValue := r.URL.Query().Get(paramName)
 
 		// Only use the paramValue if it has an actual value
 		if paramValue != "" {

--- a/mw_jwt.go
+++ b/mw_jwt.go
@@ -305,10 +305,8 @@ func (k *JWTMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _
 	// Get the token
 	rawJWT := r.Header.Get(config.AuthHeaderName)
 	if config.UseParam {
-		tempRes := CopyHttpRequest(r)
-
 		// Set hte header name
-		rawJWT = tempRes.FormValue(config.AuthHeaderName)
+		rawJWT = r.URL.Query().Get(config.AuthHeaderName)
 	}
 
 	if config.UseCookie {


### PR DESCRIPTION
Continuation of 498ddf6f. The feature was never intended to work with
POST/PUT request body forms, nor was that part of the feature
documented.