### PR TITLE
revproxy: avoid path duplication after url rewrite

### DIFF
--- a/tyk_reverse_proxy_clone.go
+++ b/tyk_reverse_proxy_clone.go
@@ -206,7 +206,11 @@ func TykNewSingleHostReverseProxy(target *url.URL, spec *APISpec) *ReverseProxy 
 		}
 		req.URL.Scheme = targetToUse.Scheme
 		req.URL.Host = targetToUse.Host
-		req.URL.Path = singleJoiningSlash(targetToUse.Path, req.URL.Path)
+
+		// TODO: figure out a better fix for this
+		if targetToUse.Path != req.URL.Path {
+			req.URL.Path = singleJoiningSlash(targetToUse.Path, req.URL.Path)
+		}
 		if !spec.Proxy.PreserveHostHeader {
 			req.Host = targetToUse.Host
 		}


### PR DESCRIPTION
The logic here seems broken, since we might be calling
singleJoiningSlash with the same path in both of its arguments. This
results in some forms of URL rewriting having the final path duplicated.

This likely needs rethinking or redesigning. For now, apply a much
smaller fix for 2.3.7 since it's safer and since this repository doesn't
have tests involving both the URL rewrite middleware and the reverse
proxy.

Fixes #855.