### PR TITLE
events: fix handler interface to have an Init

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -253,7 +253,7 @@ type EventMessage struct {
 
 // TykEventHandler defines an event handler, e.g. LogMessageEventHandler will handle an event by logging it to stdout.
 type TykEventHandler interface {
-	New(interface{}) (TykEventHandler, error)
+	Init(interface{}) error
 	HandleEvent(EventMessage)
 }
 

--- a/coprocess_dummy.go
+++ b/coprocess_dummy.go
@@ -44,11 +44,14 @@ func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 	return nil, 200
 }
 
-type CoProcessEventHandler JSVMEventHandler
-
-func (l CoProcessEventHandler) New(handlerConf interface{}) (config.TykEventHandler, error) {
-	return nil, nil
+type CoProcessEventHandler struct {
+	Spec *APISpec
 }
+
+func (l *CoProcessEventHandler) Init(handlerConf interface{}) error {
+	return nil
+}
+func (l *CoProcessEventHandler) HandleEvent(em config.EventMessage) {}
 
 func CoProcessInit() {
 	log.WithFields(logrus.Fields{

--- a/coprocess_events.go
+++ b/coprocess_events.go
@@ -26,10 +26,8 @@ type CoProcessEventWrapper struct {
 	SpecJSON *json.RawMessage    `json:"spec"`
 }
 
-func (l CoProcessEventHandler) New(handlerConf interface{}) (config.TykEventHandler, error) {
-	handler := CoProcessEventHandler{}
-	handler.Spec = l.Spec
-	handler.conf = handlerConf.(map[string]interface{})
+func (l *CoProcessEventHandler) Init(handlerConf interface{}) error {
+	l.conf = handlerConf.(map[string]interface{})
 
 	// Set the VM globals
 	globalVals := JSVMContextGlobal{
@@ -42,11 +40,11 @@ func (l CoProcessEventHandler) New(handlerConf interface{}) (config.TykEventHand
 		log.Error("Failed to marshal globals! ", err)
 	}
 
-	handler.SpecJSON = json.RawMessage(gValAsJSON)
-	return handler, nil
+	l.SpecJSON = json.RawMessage(gValAsJSON)
+	return nil
 }
 
-func (l CoProcessEventHandler) HandleEvent(em config.EventMessage) {
+func (l *CoProcessEventHandler) HandleEvent(em config.EventMessage) {
 	// 1. Get the methodName for the Event Handler
 	methodName := l.conf["name"].(string)
 

--- a/event_handler_webhooks_test.go
+++ b/event_handler_webhooks_test.go
@@ -15,13 +15,16 @@ func createGetHandler() *WebHookHandler {
 		TemplatePath: "templates/default_webhook.json",
 		HeaderList:   map[string]string{"x-tyk-test": "TEST"},
 	}
-	ev, _ := (&WebHookHandler{}).New(eventHandlerConf)
-	return ev.(*WebHookHandler)
+	ev := &WebHookHandler{}
+	if err := ev.Init(eventHandlerConf); err != nil {
+		panic(err)
+	}
+	return ev
 }
 
 func TestNewValid(t *testing.T) {
-	o := WebHookHandler{}
-	_, err := o.New(map[string]interface{}{
+	h := &WebHookHandler{}
+	err := h.Init(map[string]interface{}{
 		"method":        "POST",
 		"target_path":   testHttpPost,
 		"template_path": "templates/default_webhook.json",
@@ -34,8 +37,8 @@ func TestNewValid(t *testing.T) {
 }
 
 func TestNewInvlalid(t *testing.T) {
-	o := WebHookHandler{}
-	_, err := o.New(map[string]interface{}{
+	h := &WebHookHandler{}
+	err := h.Init(map[string]interface{}{
 		"method":        123,
 		"target_path":   testHttpPost,
 		"template_path": "templates/default_webhook.json",
@@ -119,17 +122,7 @@ func TestCreateBody(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
-	eventHandlerConf := config.WebHookHandlerConf{
-		TargetPath:   testHttpGet,
-		Method:       "GET",
-		EventTimeout: 10,
-		TemplatePath: "templates/default_webhook.json",
-		HeaderList:   map[string]string{"x-tyk-test": "TEST"},
-	}
-
-	ev, _ := (&WebHookHandler{}).New(eventHandlerConf)
-
-	eventHandler := ev.(*WebHookHandler)
+	eventHandler := createGetHandler()
 
 	eventMessage := config.EventMessage{
 		Type: EventKeyExpired,
@@ -160,8 +153,10 @@ func TestPost(t *testing.T) {
 		HeaderList:   map[string]string{"x-tyk-test": "TEST POST"},
 	}
 
-	ev, _ := (&WebHookHandler{}).New(eventHandlerConf)
-	eventHandler := ev.(*WebHookHandler)
+	eventHandler := &WebHookHandler{}
+	if err := eventHandler.Init(eventHandlerConf); err != nil {
+		t.Fatal(err)
+	}
 
 	eventMessage := config.EventMessage{
 		Type: EventKeyExpired,

--- a/host_checker_test.go
+++ b/host_checker_test.go
@@ -50,8 +50,8 @@ type testEventHandler struct {
 	cb func(config.EventMessage)
 }
 
-func (w *testEventHandler) New(handlerConf interface{}) (config.TykEventHandler, error) {
-	return w, nil
+func (w *testEventHandler) Init(handlerConf interface{}) error {
+	return nil
 }
 
 func (w *testEventHandler) HandleEvent(em config.EventMessage) {

--- a/jsvm_event_handler.go
+++ b/jsvm_event_handler.go
@@ -22,10 +22,8 @@ type JSVMEventHandler struct {
 }
 
 // New enables the intitialisation of event handler instances when they are created on ApiSpec creation
-func (l *JSVMEventHandler) New(handlerConf interface{}) (config.TykEventHandler, error) {
-	handler := &JSVMEventHandler{}
-	handler.Spec = l.Spec
-	handler.conf = handlerConf.(map[string]interface{})
+func (l *JSVMEventHandler) Init(handlerConf interface{}) error {
+	l.conf = handlerConf.(map[string]interface{})
 
 	// Set the VM globals
 	globalVals := JSVMContextGlobal{
@@ -38,9 +36,8 @@ func (l *JSVMEventHandler) New(handlerConf interface{}) (config.TykEventHandler,
 		log.Error("Failed to marshal globals! ", err)
 	}
 
-	handler.SpecJSON = string(gValAsJSON)
-
-	return handler, nil
+	l.SpecJSON = string(gValAsJSON)
+	return nil
 }
 
 // HandleEvent will be fired when the event handler instance is found in an APISpec EventPaths object during a request chain

--- a/main.go
+++ b/main.go
@@ -162,12 +162,13 @@ func setupGlobals() {
 	MainNotifier = RedisNotifier{&mainNotifierStore, RedisPubSubChannel}
 
 	if globalConf.Monitor.EnableTriggerMonitors {
-		var err error
-		MonitoringHandler, err = (&WebHookHandler{}).New(globalConf.Monitor.Config)
-		if err != nil {
+		h := &WebHookHandler{}
+		if err := h.Init(globalConf.Monitor.Config); err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "main",
 			}).Error("Failed to initialise monitor! ", err)
+		} else {
+			MonitoringHandler = h
 		}
 	}
 


### PR DESCRIPTION
First, the name "New" was confusing. Use "Init" instead.

Second, it both received a handler and returned a handler. Make it
modify the handler it receives and just return an error.