### PR TITLE
Backport httputil.ReverseProxy changes from early 2015 to mid 2016

### DIFF
--- a/tyk_reverse_proxy_clone.go
+++ b/tyk_reverse_proxy_clone.go
@@ -326,6 +326,7 @@ func copyHeader(dst, src http.Header) {
 // http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html
 var hopHeaders = []string{
 	"Connection",
+	"Proxy-Connection", // non-standard but still sent by libcurl and rejected by e.g. google
 	"Keep-Alive",
 	"Proxy-Authenticate",
 	"Proxy-Authorization",

--- a/tyk_reverse_proxy_clone.go
+++ b/tyk_reverse_proxy_clone.go
@@ -492,6 +492,16 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 	outreq.ProtoMinor = 1
 	outreq.Close = false
 
+	// Remove headers with the same name as the connection-tokens.
+	// See RFC 2616, section 14.10.
+	if c := outreq.Header.Get("Connection"); c != "" {
+		for _, f := range strings.Split(c, ",") {
+			if f = strings.TrimSpace(f); f != "" {
+				outreq.Header.Del(f)
+			}
+		}
+	}
+
 	log.Debug("Outbound Request: ", outreq.URL.String())
 
 	// Do not modify outbound request headers if they are WS

--- a/tyk_reverse_proxy_clone.go
+++ b/tyk_reverse_proxy_clone.go
@@ -340,7 +340,7 @@ type requestCanceler interface {
 }
 
 type runOnFirstRead struct {
-	io.Reader
+	io.Reader // optional; nil means empty body
 
 	fn func() // Run before first Read, then set to nil
 }
@@ -349,6 +349,9 @@ func (c *runOnFirstRead) Read(bs []byte) (int, error) {
 	if c.fn != nil {
 		c.fn()
 		c.fn = nil
+	}
+	if c.Reader == nil {
+		return 0, io.EOF
 	}
 	return c.Reader.Read(bs)
 }

--- a/tyk_reverse_proxy_clone.go
+++ b/tyk_reverse_proxy_clone.go
@@ -681,13 +681,13 @@ type maxLatencyWriter struct {
 	dst     writeFlusher
 	latency time.Duration
 
-	lk   sync.Mutex // protects Write + Flush
+	mu   sync.Mutex // protects Write + Flush
 	done chan bool
 }
 
 func (m *maxLatencyWriter) Write(p []byte) (int, error) {
-	m.lk.Lock()
-	defer m.lk.Unlock()
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.dst.Write(p)
 }
 
@@ -702,9 +702,9 @@ func (m *maxLatencyWriter) flushLoop() {
 			}
 			return
 		case <-t.C:
-			m.lk.Lock()
+			m.mu.Lock()
 			m.dst.Flush()
-			m.lk.Unlock()
+			m.mu.Unlock()
 		}
 	}
 }

--- a/tyk_reverse_proxy_clone.go
+++ b/tyk_reverse_proxy_clone.go
@@ -215,6 +215,10 @@ func TykNewSingleHostReverseProxy(target *url.URL, spec *APISpec) *ReverseProxy 
 		} else {
 			req.URL.RawQuery = targetQuery + "&" + req.URL.RawQuery
 		}
+		if _, ok := req.Header["User-Agent"]; !ok {
+			// explicitly disable User-Agent so it's not set to default value
+			req.Header.Set("User-Agent", "")
+		}
 	}
 
 	return &ReverseProxy{Director: director, TykAPISpec: spec, FlushInterval: time.Duration(globalConf.HttpServerOptions.FlushInterval) * time.Millisecond}

--- a/tyk_reverse_proxy_clone.go
+++ b/tyk_reverse_proxy_clone.go
@@ -329,8 +329,8 @@ var hopHeaders = []string{
 	"Keep-Alive",
 	"Proxy-Authenticate",
 	"Proxy-Authorization",
-	"Te", // canonicalized version of "TE"
-	"Trailers",
+	"Te",      // canonicalized version of "TE"
+	"Trailer", // not Trailers per URL above; http://www.rfc-editor.org/errata_search.php?eid=4522
 	"Transfer-Encoding",
 	"Upgrade",
 }


### PR DESCRIPTION
We forked in late 2014. This backports the changes from all of 2015 and half of 2016. Only the rest of 2016 and 2017 remain - this takes care of about half of the changes.

I've backported nearly every change, excluding some minor doc changes and a buffer pool thing that is a feature rather than a fix - and which we could roll out on our own if we needed to.

I've also excluded Trailers support (https://go-review.googlesource.com/c/11940/) as we've touched the code that it changes and it was a bit risky. And it's also more of a feature than a fix, which we can come back to if we ever need.

Updates #753.