### PR TITLE
main: remove docopt error warning

### DIFF
--- a/main.go
+++ b/main.go
@@ -925,14 +925,12 @@ func getCmdArguments() map[string]interface{} {
 		--as-version=<version>       The version number to use when inserting
 		--log-instrumentation        Output instrumentation data to stdout
 	`
-
 	arguments, err := docopt.Parse(usage, nil, true, VERSION, false)
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "main",
-		}).Warning("Error while parsing arguments: ", err)
+		// docopt will exit on its own if there are any user
+		// errors, such as an unknown flag being used.
+		panic(err)
 	}
-
 	return arguments
 }
 


### PR DESCRIPTION
Since 36775eb4, we've told docopt to exit on any user errors instead of
returning them. The only other kind of errors that can happen is if the
usage text is malformed, in which case something went really wrong and
we want to panic instead of printing a warning and moving on.