### PR TITLE
Fix all remaining "go test -race" races

### DIFF
--- a/gateway_test.go
+++ b/gateway_test.go
@@ -809,7 +809,7 @@ func testHttp(t *testing.T, tests []tykHttpTest, separateControlPort bool) {
 			panic(err)
 		}
 
-		initialiseSystem(nil)
+		setupGlobals()
 		// This is emulate calling start()
 		// But this lines is the only thing needed for this tests
 		if globalConf.ControlAPIPort == 0 {

--- a/main.go
+++ b/main.go
@@ -116,17 +116,14 @@ func setupGlobals() {
 	healthCheckStore := &RedisClusterStorageManager{KeyPrefix: "host-checker:"}
 	InitHostCheckManager(healthCheckStore)
 
-	if globalConf.EnableAnalytics {
+	if globalConf.EnableAnalytics && analytics.Store == nil {
 		globalConf.LoadIgnoredIPs()
 		analyticsStore := RedisClusterStorageManager{KeyPrefix: "analytics-"}
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Debug("Setting up analytics DB connection")
 
-		analytics = RedisAnalyticsHandler{
-			Store: &analyticsStore,
-		}
-
+		analytics.Store = &analyticsStore
 		analytics.Init()
 
 		if globalConf.AnalyticsConfig.Type == "rpc" {

--- a/plugins_test.go
+++ b/plugins_test.go
@@ -16,17 +16,11 @@ import (
 
 func TestJSVMLogs(t *testing.T) {
 	var buf bytes.Buffer
-	defer func(origLog *logrus.Logger) {
-		log = origLog
-	}(log)
-	// need to set up an entire new logger, as the output writer
-	// can't be safely changed once the logger is used. For example,
-	// detection of whether log.Out is a console is done only once.
-	log = logrus.New()
-	log.Out = &buf
-	log.Formatter = new(prefixed.TextFormatter)
 	jsvm := &JSVM{}
 	jsvm.Init()
+	jsvm.Log = logrus.New()
+	jsvm.Log.Out = &buf
+	jsvm.Log.Formatter = new(prefixed.TextFormatter)
 
 	const in = `
 log("foo")


### PR DESCRIPTION
I ran it a few times and nothing remains.

There are probably still a couple hidden - I need to abuse `-race -count 100` before enabling this on CI.