### PR TITLE
CI: also run go test -race

### DIFF
--- a/utils/ci-test.sh
+++ b/utils/ci-test.sh
@@ -32,9 +32,11 @@ for pkg in $PKGS; do
 done
 
 if [[ ! $LATEST_GO ]]; then
-	echo "Skipping linting and coverage report"
+	echo "Skipping race, checks, and coverage report"
 	exit 0
 fi
+
+go test -race $PKGS || fatal "go test -race failed"
 
 for opts in "${MATRIX[@]}"; do
 	show go vet -v $opts $PKGS || fatal "go vet errored"


### PR DESCRIPTION
Separately from the other "go test" run, for various reasons:

* It can be slow, so no need to run it in all Go versions
* If a test fails only when in race mode, that's useful info
* No need to run the race detector if the tests failed without it

Fixes #363.