### PR TITLE
apidef: make HandlerMeta a map[string]interface

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -183,8 +183,8 @@ type SessionProviderMeta struct {
 }
 
 type EventHandlerTriggerConfig struct {
-	Handler     TykEventHandlerName `bson:"handler_name" json:"handler_name"`
-	HandlerMeta interface{}         `bson:"handler_meta" json:"handler_meta"`
+	Handler     TykEventHandlerName    `bson:"handler_name" json:"handler_name"`
+	HandlerMeta map[string]interface{} `bson:"handler_meta" json:"handler_meta"`
 }
 
 type EventHandlerMetaConfig struct {


### PR DESCRIPTION
All example and documentation show it as such, i.e.:

	"handler_meta": { ... }

In fact, Tyk would crash if this wasn't the case, as many of the Init
functions type assert it like "handlerConf.(map[string]interface{})".

Instead, make it part of the input type, so that the JSON and BSON
decoders will error instead with a better error message.

While at it, remove the bson.M case - the bson godoc shows:

	type M map[string]interface{}

So it was really just a convenience alias for a map. Since we're
decoding into a map[string]interface{} instead of an interface{}, we
don't need to worry about bson selecting bson.M instead of the regular
map type.