### PR TITLE
all: protect global policies map with a rwmutex

### DIFF
--- a/api.go
+++ b/api.go
@@ -84,7 +84,9 @@ func checkAndApplyTrialPeriod(keyName, apiId string, newSession *SessionState) {
 	if newSession.ApplyPolicyID == "" {
 		return
 	}
-	policy, ok := Policies[newSession.ApplyPolicyID]
+	policiesMu.RLock()
+	policy, ok := policiesByID[newSession.ApplyPolicyID]
+	policiesMu.RUnlock()
 	if !ok {
 		return
 	}

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -946,3 +946,18 @@ func TestManagementNodeRedisEvents(t *testing.T) {
 	}
 	handleRedisEvent(msg, notHandle, nil)
 }
+
+func TestReloadPoliciesRace(t *testing.T) {
+	defer func(orig string) {
+		globalConf.Policies.PolicyRecordName = orig
+	}(globalConf.Policies.PolicyRecordName)
+	globalConf.Policies.PolicyRecordName = "policies/policies.json"
+	for i := 0; i < 10; i++ {
+		go func() {
+			policiesMu.RLock()
+			_ = policiesByID["foo"]
+			policiesMu.RUnlock()
+		}()
+	}
+	getPolicies()
+}

--- a/handler_success.go
+++ b/handler_success.go
@@ -85,7 +85,9 @@ func (t *TykMiddleware) ApplyPolicyIfExists(key string, session *SessionState) {
 	if session.ApplyPolicyID == "" {
 		return
 	}
-	policy, ok := Policies[session.ApplyPolicyID]
+	policiesMu.RLock()
+	policy, ok := policiesByID[session.ApplyPolicyID]
+	policiesMu.RUnlock()
 	if !ok {
 		return
 	}

--- a/mw_jwt.go
+++ b/mw_jwt.go
@@ -425,7 +425,9 @@ func (k *JWTMiddleware) setContextVars(r *http.Request, token *jwt.Token) {
 }
 
 func generateSessionFromPolicy(policyID, orgID string, enforceOrg bool) (SessionState, error) {
-	policy, ok := Policies[policyID]
+	policiesMu.RLock()
+	policy, ok := policiesByID[policyID]
+	policiesMu.RUnlock()
 	session := SessionState{}
 	if !ok {
 		return session, errors.New("Policy not found")

--- a/mw_jwt_test.go
+++ b/mw_jwt_test.go
@@ -507,7 +507,7 @@ func TestJWTSessionRSAWithRawSourceOnWithClientID(t *testing.T) {
 	spec.SessionManager.ResetQuota(tokenID, session)
 	spec.SessionManager.UpdateSession(tokenID, session, 60)
 
-	Policies["987654321"] = Policy{
+	policiesByID["987654321"] = Policy{
 		ID:               "987654321",
 		OrgID:            "default",
 		Rate:             1000.0,
@@ -557,7 +557,7 @@ func TestJWTSessionRSAWithRawSource(t *testing.T) {
 	spec := createSpecTest(t, jwtWithCentralDef)
 	spec.JWTSigningMethod = "rsa"
 
-	Policies["987654321"] = Policy{
+	policiesByID["987654321"] = Policy{
 		ID:               "987654321",
 		OrgID:            "default",
 		Rate:             1000.0,
@@ -605,7 +605,7 @@ func TestJWTSessionRSAWithRawSourceInvalidPolicyID(t *testing.T) {
 	spec := createSpecTest(t, jwtWithCentralDef)
 	spec.JWTSigningMethod = "rsa"
 
-	Policies["987654321"] = Policy{
+	policiesByID["987654321"] = Policy{
 		ID:               "987654321",
 		OrgID:            "default",
 		Rate:             1000.0,
@@ -653,7 +653,7 @@ func TestJWTSessionRSAWithJWK(t *testing.T) {
 	spec := createSpecTest(t, jwtWithJWKDef)
 	spec.JWTSigningMethod = "rsa"
 
-	Policies["987654321"] = Policy{
+	policiesByID["987654321"] = Policy{
 		ID:               "987654321",
 		OrgID:            "default",
 		Rate:             1000.0,


### PR DESCRIPTION
Since reloads will change the map at any point, while other goroutines
may be reading.

And add a test too, to prove that this was an issue and help avoid a
regression.

Race report from the new test, before the fix:

	WARNING: DATA RACE
	Write at 0x0000018a9f78 by goroutine 186:
	  github.com/TykTechnologies/tyk.getPolicies()
	      /home/mvdan/go/src/github.com/TykTechnologies/tyk/main.go:286 +0x437
	  github.com/TykTechnologies/tyk.doReload()
	      /home/mvdan/go/src/github.com/TykTechnologies/tyk/main.go:622 +0x44
	  github.com/TykTechnologies/tyk.TestReloadGlobalRaces()
	      /home/mvdan/go/src/github.com/TykTechnologies/tyk/gateway_test.go:960 +0xe3
	  testing.tRunner()
	      /home/mvdan/tip/src/testing/testing.go:754 +0x16c

	Previous read at 0x0000018a9f78 by goroutine 190:
	  github.com/TykTechnologies/tyk.TestReloadGlobalRaces.func2()
	      /home/mvdan/go/src/github.com/TykTechnologies/tyk/gateway_test.go:957 +0x4f