### PR TITLE
Do not run letsencrypt watcher unless explicitly enabled

### DIFF
--- a/main.go
+++ b/main.go
@@ -861,8 +861,10 @@ func initialiseSystem(arguments map[string]interface{}) error {
 	//doInstrumentation, _ := arguments["--log-instrumentation"].(bool)
 	//SetupInstrumentation(doInstrumentation)
 	SetupInstrumentation(true)
-
-	go StartPeriodicStateBackup(&LE_MANAGER)
+	
+	if config.HttpServerOptions.UseLE_SSL {
+		go StartPeriodicStateBackup(&LE_MANAGER)
+	}
 
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -862,7 +862,7 @@ func initialiseSystem(arguments map[string]interface{}) error {
 	//SetupInstrumentation(doInstrumentation)
 	SetupInstrumentation(true)
 	
-	if config.HttpServerOptions.UseLE_SSL {
+	if globalConf.HttpServerOptions.UseLE_SSL {
 		go StartPeriodicStateBackup(&LE_MANAGER)
 	}
 

--- a/main.go
+++ b/main.go
@@ -861,7 +861,7 @@ func initialiseSystem(arguments map[string]interface{}) error {
 	//doInstrumentation, _ := arguments["--log-instrumentation"].(bool)
 	//SetupInstrumentation(doInstrumentation)
 	SetupInstrumentation(true)
-	
+
 	if globalConf.HttpServerOptions.UseLE_SSL {
 		go StartPeriodicStateBackup(&LE_MANAGER)
 	}


### PR DESCRIPTION
LetsEncrypt is a third party service, and it is a bad idea to depend on it unless the user really wants.

While it is run in separate goroutine, it still can cause memory leaks, panics, and etc.