### PR TITLE
all: protect apisByID with a rwmutex

### DIFF
--- a/api_loader.go
+++ b/api_loader.go
@@ -130,7 +130,7 @@ func processSpec(referenceSpec *APISpec,
 			break
 		}
 		if !pathModified {
-			prev := apisByID[referenceSpec.APIID]
+			prev := getApiSpec(referenceSpec.APIID)
 			if prev != nil && prev.Proxy.ListenPath == referenceSpec.Proxy.ListenPath {
 				// if this APIID was already loaded and
 				// had this listen path, let it keep it.
@@ -619,7 +619,9 @@ func loadApps(apiSpecs []*APISpec, muxer *mux.Router) {
 	muxer.HandleFunc("/hello", pingTest)
 
 	// Swap in the new register
+	apisMu.Lock()
 	apisByID = tmpSpecRegister
+	apisMu.Unlock()
 
 	log.Debug("Checker host list")
 

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -961,3 +961,14 @@ func TestReloadPoliciesRace(t *testing.T) {
 	}
 	getPolicies()
 }
+
+func TestReloadApisRace(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		go func() {
+			apisMu.RLock()
+			_ = apisByID["foo"]
+			apisMu.RUnlock()
+		}()
+	}
+	loadSampleAPI(t, apiTestDef)
+}

--- a/host_checker_manager.go
+++ b/host_checker_manager.go
@@ -210,7 +210,7 @@ func (hc *HostCheckerManager) OnHostDown(report HostHealthReport) {
 	}).Debug("Update key: ", hc.getHostKey(report))
 	hc.store.SetKey(hc.getHostKey(report), "1", int64(hc.checker.checkTimeout+1))
 
-	spec := apisByID[report.MetaData[UnHealthyHostMetaDataAPIKey]]
+	spec := getApiSpec(report.MetaData[UnHealthyHostMetaDataAPIKey])
 	if spec == nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "host-check-mgr",
@@ -253,7 +253,7 @@ func (hc *HostCheckerManager) OnHostBackUp(report HostHealthReport) {
 	}).Debug("Delete key: ", hc.getHostKey(report))
 	hc.store.DeleteKey(hc.getHostKey(report))
 
-	spec := apisByID[report.MetaData[UnHealthyHostMetaDataAPIKey]]
+	spec := getApiSpec(report.MetaData[UnHealthyHostMetaDataAPIKey])
 	if spec == nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "host-check-mgr",
@@ -380,7 +380,7 @@ func (hc *HostCheckerManager) UpdateTrackingListByAPIID(hd []HostData, apiId str
 }
 
 func (hc *HostCheckerManager) GetListFromService(apiID string) ([]HostData, error) {
-	spec := apisByID[apiID]
+	spec := getApiSpec(apiID)
 	if spec == nil {
 		return nil, errors.New("API ID not found in register")
 	}
@@ -441,7 +441,7 @@ func (hc *HostCheckerManager) DoServiceDiscoveryListUpdateForID(apiID string) {
 func (hc *HostCheckerManager) RecordUptimeAnalytics(report HostHealthReport) error {
 	// If we are obfuscating API Keys, store the hashed representation (config check handled in hashing function)
 
-	spec := apisByID[report.MetaData[UnHealthyHostMetaDataAPIKey]]
+	spec := getApiSpec(report.MetaData[UnHealthyHostMetaDataAPIKey])
 	orgID := ""
 	if spec != nil {
 		orgID = spec.OrgID
@@ -509,6 +509,7 @@ func SetCheckerHostList() {
 		"prefix": "host-check-mgr",
 	}).Info("Loading uptime tests...")
 	hostList := []HostData{}
+	apisMu.RLock()
 	for _, spec := range apisByID {
 		if spec.UptimeTests.Config.ServiceDiscovery.UseDiscoveryService {
 			hostList, err := GlobalHostChecker.GetListFromService(spec.APIID)
@@ -542,6 +543,7 @@ func SetCheckerHostList() {
 			}
 		}
 	}
+	apisMu.RUnlock()
 
 	GlobalHostChecker.UpdateTrackingList(hostList)
 }

--- a/main.go
+++ b/main.go
@@ -53,7 +53,9 @@ var (
 	RPCListener              RPCStorageHandler
 	DashService              DashboardServiceSender
 
+	apisMu   sync.RWMutex
 	apisByID map[string]*APISpec
+
 	keyGen   DefaultKeyGenerator
 
 	policiesMu   sync.RWMutex
@@ -80,6 +82,13 @@ var (
 		"/etc/tyk/tyk.conf",
 	}
 )
+
+func getApiSpec(apiID string) *APISpec {
+	apisMu.RLock()
+	spec := apisByID[apiID]
+	apisMu.RUnlock()
+	return spec
+}
 
 // Display configuration options
 func displayConfig() {


### PR DESCRIPTION
Like in the case of the global policies map, reloads may swap this map
while other goroutines are using it. Add a test too.

Fixes the following race report from the test without the fix:

	WARNING: DATA RACE
	Write at 0x0000018a9fd8 by goroutine 494:
	  github.com/TykTechnologies/tyk.loadApps()
	      /home/mvdan/go/src/github.com/TykTechnologies/tyk/api_loader.go:622 +0xa0d
	  github.com/TykTechnologies/tyk.loadSampleAPI()
	      /home/mvdan/go/src/github.com/TykTechnologies/tyk/api_test.go:45 +0xd5
	  github.com/TykTechnologies/tyk.TestReloadApisRace()
	      /home/mvdan/go/src/github.com/TykTechnologies/tyk/gateway_test.go:973 +0x7c
	  testing.tRunner()
	      /home/mvdan/tip/src/testing/testing.go:754 +0x16c

	Previous read at 0x0000018a9fd8 by goroutine 394:
	  github.com/TykTechnologies/tyk.TestReloadApisRace.func1()
	      /home/mvdan/go/src/github.com/TykTechnologies/tyk/gateway_test.go:969 +0x4e