### PR TITLE
mw: rename TykMiddleware to BaseMiddleware

### DIFF
--- a/api_loader.go
+++ b/api_loader.go
@@ -264,9 +264,9 @@ func processSpec(referenceSpec *APISpec,
 	// Create the response processors
 	creeateResponseMiddlewareChain(referenceSpec)
 
-	tykMiddleware := &TykMiddleware{referenceSpec, proxy}
-	CheckCBEnabled(tykMiddleware)
-	CheckETEnabled(tykMiddleware)
+	baseMid := &BaseMiddleware{referenceSpec, proxy}
+	CheckCBEnabled(baseMid)
+	CheckETEnabled(baseMid)
 
 	keyPrefix := "cache-" + referenceSpec.APIID
 	cacheStore := &RedisClusterStorageManager{KeyPrefix: keyPrefix, IsCache: true}
@@ -286,19 +286,19 @@ func processSpec(referenceSpec *APISpec,
 		handleCORS(&chainArray, referenceSpec)
 
 		baseChainArray := []alice.Constructor{}
-		AppendMiddleware(&baseChainArray, &RateCheckMW{TykMiddleware: tykMiddleware}, tykMiddleware)
-		AppendMiddleware(&baseChainArray, &IPWhiteListMiddleware{TykMiddleware: tykMiddleware}, tykMiddleware)
-		AppendMiddleware(&baseChainArray, &OrganizationMonitor{TykMiddleware: tykMiddleware}, tykMiddleware)
-		AppendMiddleware(&baseChainArray, &MiddlewareContextVars{TykMiddleware: tykMiddleware}, tykMiddleware)
-		AppendMiddleware(&baseChainArray, &VersionCheck{TykMiddleware: tykMiddleware}, tykMiddleware)
-		AppendMiddleware(&baseChainArray, &RequestSizeLimitMiddleware{tykMiddleware}, tykMiddleware)
-		AppendMiddleware(&baseChainArray, &TrackEndpointMiddleware{tykMiddleware}, tykMiddleware)
-		AppendMiddleware(&baseChainArray, &TransformMiddleware{tykMiddleware}, tykMiddleware)
-		AppendMiddleware(&baseChainArray, &TransformHeaders{TykMiddleware: tykMiddleware}, tykMiddleware)
-		AppendMiddleware(&baseChainArray, &RedisCacheMiddleware{TykMiddleware: tykMiddleware, CacheStore: cacheStore}, tykMiddleware)
-		AppendMiddleware(&baseChainArray, &VirtualEndpoint{TykMiddleware: tykMiddleware}, tykMiddleware)
-		AppendMiddleware(&baseChainArray, &URLRewriteMiddleware{TykMiddleware: tykMiddleware}, tykMiddleware)
-		AppendMiddleware(&baseChainArray, &TransformMethod{TykMiddleware: tykMiddleware}, tykMiddleware)
+		AppendMiddleware(&baseChainArray, &RateCheckMW{BaseMiddleware: baseMid}, baseMid)
+		AppendMiddleware(&baseChainArray, &IPWhiteListMiddleware{BaseMiddleware: baseMid}, baseMid)
+		AppendMiddleware(&baseChainArray, &OrganizationMonitor{BaseMiddleware: baseMid}, baseMid)
+		AppendMiddleware(&baseChainArray, &MiddlewareContextVars{BaseMiddleware: baseMid}, baseMid)
+		AppendMiddleware(&baseChainArray, &VersionCheck{BaseMiddleware: baseMid}, baseMid)
+		AppendMiddleware(&baseChainArray, &RequestSizeLimitMiddleware{baseMid}, baseMid)
+		AppendMiddleware(&baseChainArray, &TrackEndpointMiddleware{baseMid}, baseMid)
+		AppendMiddleware(&baseChainArray, &TransformMiddleware{baseMid}, baseMid)
+		AppendMiddleware(&baseChainArray, &TransformHeaders{BaseMiddleware: baseMid}, baseMid)
+		AppendMiddleware(&baseChainArray, &RedisCacheMiddleware{BaseMiddleware: baseMid, CacheStore: cacheStore}, baseMid)
+		AppendMiddleware(&baseChainArray, &VirtualEndpoint{BaseMiddleware: baseMid}, baseMid)
+		AppendMiddleware(&baseChainArray, &URLRewriteMiddleware{BaseMiddleware: baseMid}, baseMid)
+		AppendMiddleware(&baseChainArray, &TransformMethod{BaseMiddleware: baseMid}, baseMid)
 
 		log.Debug(referenceSpec.Name, " - CHAIN SIZE: ", len(baseChainArray))
 
@@ -308,9 +308,9 @@ func processSpec(referenceSpec *APISpec,
 					"prefix":   "coprocess",
 					"api_name": referenceSpec.Name,
 				}).Debug("Registering coprocess middleware, hook name: ", obj.Name, "hook type: Pre", ", driver: ", mwDriver)
-				AppendMiddleware(&chainArray, &CoProcessMiddleware{tykMiddleware, coprocess.HookType_Pre, obj.Name, mwDriver}, tykMiddleware)
+				AppendMiddleware(&chainArray, &CoProcessMiddleware{baseMid, coprocess.HookType_Pre, obj.Name, mwDriver}, baseMid)
 			} else {
-				chainArray = append(chainArray, CreateDynamicMiddleware(obj.Name, true, obj.RequireSession, tykMiddleware))
+				chainArray = append(chainArray, CreateDynamicMiddleware(obj.Name, true, obj.RequireSession, baseMid))
 			}
 		}
 
@@ -322,14 +322,14 @@ func processSpec(referenceSpec *APISpec,
 					"prefix":   "coprocess",
 					"api_name": referenceSpec.Name,
 				}).Debug("Registering coprocess middleware, hook name: ", obj.Name, "hook type: Post", ", driver: ", mwDriver)
-				AppendMiddleware(&chainArray, &CoProcessMiddleware{tykMiddleware, coprocess.HookType_Post, obj.Name, mwDriver}, tykMiddleware)
+				AppendMiddleware(&chainArray, &CoProcessMiddleware{baseMid, coprocess.HookType_Post, obj.Name, mwDriver}, baseMid)
 			} else {
-				chainArray = append(chainArray, CreateDynamicMiddleware(obj.Name, false, obj.RequireSession, tykMiddleware))
+				chainArray = append(chainArray, CreateDynamicMiddleware(obj.Name, false, obj.RequireSession, baseMid))
 			}
 		}
 
 		// for KeyLessAccess we can't support rate limiting, versioning or access rules
-		chain = alice.New(chainArray...).Then(&DummyProxyHandler{SH: SuccessHandler{tykMiddleware}})
+		chain = alice.New(chainArray...).Then(&DummyProxyHandler{SH: SuccessHandler{baseMid}})
 
 	} else {
 
@@ -338,13 +338,13 @@ func processSpec(referenceSpec *APISpec,
 		handleCORS(&chainArray, referenceSpec)
 
 		var baseChainArray_PreAuth []alice.Constructor
-		AppendMiddleware(&baseChainArray_PreAuth, &RateCheckMW{TykMiddleware: tykMiddleware}, tykMiddleware)
-		AppendMiddleware(&baseChainArray_PreAuth, &IPWhiteListMiddleware{TykMiddleware: tykMiddleware}, tykMiddleware)
-		AppendMiddleware(&baseChainArray_PreAuth, &OrganizationMonitor{TykMiddleware: tykMiddleware}, tykMiddleware)
-		AppendMiddleware(&baseChainArray_PreAuth, &VersionCheck{TykMiddleware: tykMiddleware}, tykMiddleware)
-		AppendMiddleware(&baseChainArray_PreAuth, &RequestSizeLimitMiddleware{tykMiddleware}, tykMiddleware)
-		AppendMiddleware(&baseChainArray_PreAuth, &MiddlewareContextVars{TykMiddleware: tykMiddleware}, tykMiddleware)
-		AppendMiddleware(&baseChainArray_PreAuth, &TrackEndpointMiddleware{tykMiddleware}, tykMiddleware)
+		AppendMiddleware(&baseChainArray_PreAuth, &RateCheckMW{BaseMiddleware: baseMid}, baseMid)
+		AppendMiddleware(&baseChainArray_PreAuth, &IPWhiteListMiddleware{BaseMiddleware: baseMid}, baseMid)
+		AppendMiddleware(&baseChainArray_PreAuth, &OrganizationMonitor{BaseMiddleware: baseMid}, baseMid)
+		AppendMiddleware(&baseChainArray_PreAuth, &VersionCheck{BaseMiddleware: baseMid}, baseMid)
+		AppendMiddleware(&baseChainArray_PreAuth, &RequestSizeLimitMiddleware{baseMid}, baseMid)
+		AppendMiddleware(&baseChainArray_PreAuth, &MiddlewareContextVars{BaseMiddleware: baseMid}, baseMid)
+		AppendMiddleware(&baseChainArray_PreAuth, &TrackEndpointMiddleware{baseMid}, baseMid)
 
 		// Add pre-process MW
 		for _, obj := range mwPreFuncs {
@@ -353,9 +353,9 @@ func processSpec(referenceSpec *APISpec,
 					"prefix":   "coprocess",
 					"api_name": referenceSpec.Name,
 				}).Debug("Registering coprocess middleware, hook name: ", obj.Name, "hook type: Pre", ", driver: ", mwDriver)
-				AppendMiddleware(&chainArray, &CoProcessMiddleware{tykMiddleware, coprocess.HookType_Pre, obj.Name, mwDriver}, tykMiddleware)
+				AppendMiddleware(&chainArray, &CoProcessMiddleware{baseMid, coprocess.HookType_Pre, obj.Name, mwDriver}, baseMid)
 			} else {
-				chainArray = append(chainArray, CreateDynamicMiddleware(obj.Name, true, obj.RequireSession, tykMiddleware))
+				chainArray = append(chainArray, CreateDynamicMiddleware(obj.Name, true, obj.RequireSession, baseMid))
 			}
 		}
 
@@ -369,7 +369,7 @@ func processSpec(referenceSpec *APISpec,
 				"prefix":   "main",
 				"api_name": referenceSpec.Name,
 			}).Info("Checking security policy: OAuth")
-			authArray = append(authArray, CreateMiddleware(&Oauth2KeyExists{tykMiddleware}, tykMiddleware))
+			authArray = append(authArray, CreateMiddleware(&Oauth2KeyExists{baseMid}, baseMid))
 
 		}
 
@@ -386,7 +386,7 @@ func processSpec(referenceSpec *APISpec,
 				"prefix":   "main",
 				"api_name": referenceSpec.Name,
 			}).Info("Checking security policy: Basic")
-			authArray = append(authArray, CreateMiddleware(&BasicAuthKeyIsValid{tykMiddleware}, tykMiddleware))
+			authArray = append(authArray, CreateMiddleware(&BasicAuthKeyIsValid{baseMid}, baseMid))
 		}
 
 		if referenceSpec.EnableSignatureChecking {
@@ -395,7 +395,7 @@ func processSpec(referenceSpec *APISpec,
 				"prefix":   "main",
 				"api_name": referenceSpec.Name,
 			}).Info("Checking security policy: HMAC")
-			authArray = append(authArray, CreateMiddleware(&HMACMiddleware{TykMiddleware: tykMiddleware}, tykMiddleware))
+			authArray = append(authArray, CreateMiddleware(&HMACMiddleware{BaseMiddleware: baseMid}, baseMid))
 		}
 
 		if referenceSpec.EnableJWT {
@@ -404,7 +404,7 @@ func processSpec(referenceSpec *APISpec,
 				"prefix":   "main",
 				"api_name": referenceSpec.Name,
 			}).Info("Checking security policy: JWT")
-			authArray = append(authArray, CreateMiddleware(&JWTMiddleware{tykMiddleware}, tykMiddleware))
+			authArray = append(authArray, CreateMiddleware(&JWTMiddleware{baseMid}, baseMid))
 		}
 
 		if referenceSpec.UseOpenID {
@@ -415,7 +415,7 @@ func processSpec(referenceSpec *APISpec,
 			}).Info("Checking security policy: OpenID")
 
 			// initialise the OID configuration on this reference Spec
-			authArray = append(authArray, CreateMiddleware(&OpenIDMW{TykMiddleware: tykMiddleware}, tykMiddleware))
+			authArray = append(authArray, CreateMiddleware(&OpenIDMW{BaseMiddleware: baseMid}, baseMid))
 		}
 
 		if useCoProcessAuth {
@@ -431,8 +431,8 @@ func processSpec(referenceSpec *APISpec,
 			}).Debug("Registering coprocess middleware, hook name: ", mwAuthCheckFunc.Name, "hook type: CustomKeyCheck", ", driver: ", mwDriver)
 
 			if useCoProcessAuth {
-				newExtractor(referenceSpec, tykMiddleware)
-				AppendMiddleware(&authArray, &CoProcessMiddleware{tykMiddleware, coprocess.HookType_CustomKeyCheck, mwAuthCheckFunc.Name, mwDriver}, tykMiddleware)
+				newExtractor(referenceSpec, baseMid)
+				AppendMiddleware(&authArray, &CoProcessMiddleware{baseMid, coprocess.HookType_CustomKeyCheck, mwAuthCheckFunc.Name, mwDriver}, baseMid)
 			}
 		}
 
@@ -441,7 +441,7 @@ func processSpec(referenceSpec *APISpec,
 				"prefix": "main",
 			}).Info("----> Checking security policy: JS Plugin")
 
-			authArray = append(authArray, CreateDynamicAuthMiddleware(mwAuthCheckFunc.Name, tykMiddleware))
+			authArray = append(authArray, CreateDynamicAuthMiddleware(mwAuthCheckFunc.Name, baseMid))
 		}
 
 		if referenceSpec.UseStandardAuth || (!referenceSpec.UseOpenID && !referenceSpec.EnableJWT && !referenceSpec.EnableSignatureChecking && !referenceSpec.UseBasicAuth && !referenceSpec.UseOauth2 && !useCoProcessAuth && !useOttoAuth) {
@@ -450,7 +450,7 @@ func processSpec(referenceSpec *APISpec,
 				"prefix":   "main",
 				"api_name": referenceSpec.Name,
 			}).Info("Checking security policy: Token")
-			authArray = append(authArray, CreateMiddleware(&AuthKey{tykMiddleware}, tykMiddleware))
+			authArray = append(authArray, CreateMiddleware(&AuthKey{baseMid}, baseMid))
 		}
 
 		chainArray = append(chainArray, authArray...)
@@ -460,20 +460,20 @@ func processSpec(referenceSpec *APISpec,
 				"prefix":   "coprocess",
 				"api_name": referenceSpec.Name,
 			}).Debug("Registering coprocess middleware, hook name: ", obj.Name, "hook type: Pre", ", driver: ", mwDriver)
-			AppendMiddleware(&chainArray, &CoProcessMiddleware{tykMiddleware, coprocess.HookType_PostKeyAuth, obj.Name, mwDriver}, tykMiddleware)
+			AppendMiddleware(&chainArray, &CoProcessMiddleware{baseMid, coprocess.HookType_PostKeyAuth, obj.Name, mwDriver}, baseMid)
 		}
 
 		var baseChainArray_PostAuth []alice.Constructor
-		AppendMiddleware(&baseChainArray_PostAuth, &KeyExpired{tykMiddleware}, tykMiddleware)
-		AppendMiddleware(&baseChainArray_PostAuth, &AccessRightsCheck{tykMiddleware}, tykMiddleware)
-		AppendMiddleware(&baseChainArray_PostAuth, &RateLimitAndQuotaCheck{tykMiddleware}, tykMiddleware)
-		AppendMiddleware(&baseChainArray_PostAuth, &GranularAccessMiddleware{tykMiddleware}, tykMiddleware)
-		AppendMiddleware(&baseChainArray_PostAuth, &TransformMiddleware{tykMiddleware}, tykMiddleware)
-		AppendMiddleware(&baseChainArray_PostAuth, &TransformHeaders{TykMiddleware: tykMiddleware}, tykMiddleware)
-		AppendMiddleware(&baseChainArray_PostAuth, &URLRewriteMiddleware{TykMiddleware: tykMiddleware}, tykMiddleware)
-		AppendMiddleware(&baseChainArray_PostAuth, &RedisCacheMiddleware{TykMiddleware: tykMiddleware, CacheStore: cacheStore}, tykMiddleware)
-		AppendMiddleware(&baseChainArray_PostAuth, &TransformMethod{TykMiddleware: tykMiddleware}, tykMiddleware)
-		AppendMiddleware(&baseChainArray_PostAuth, &VirtualEndpoint{TykMiddleware: tykMiddleware}, tykMiddleware)
+		AppendMiddleware(&baseChainArray_PostAuth, &KeyExpired{baseMid}, baseMid)
+		AppendMiddleware(&baseChainArray_PostAuth, &AccessRightsCheck{baseMid}, baseMid)
+		AppendMiddleware(&baseChainArray_PostAuth, &RateLimitAndQuotaCheck{baseMid}, baseMid)
+		AppendMiddleware(&baseChainArray_PostAuth, &GranularAccessMiddleware{baseMid}, baseMid)
+		AppendMiddleware(&baseChainArray_PostAuth, &TransformMiddleware{baseMid}, baseMid)
+		AppendMiddleware(&baseChainArray_PostAuth, &TransformHeaders{BaseMiddleware: baseMid}, baseMid)
+		AppendMiddleware(&baseChainArray_PostAuth, &URLRewriteMiddleware{BaseMiddleware: baseMid}, baseMid)
+		AppendMiddleware(&baseChainArray_PostAuth, &RedisCacheMiddleware{BaseMiddleware: baseMid, CacheStore: cacheStore}, baseMid)
+		AppendMiddleware(&baseChainArray_PostAuth, &TransformMethod{BaseMiddleware: baseMid}, baseMid)
+		AppendMiddleware(&baseChainArray_PostAuth, &VirtualEndpoint{BaseMiddleware: baseMid}, baseMid)
 
 		chainArray = append(chainArray, baseChainArray_PostAuth...)
 
@@ -483,9 +483,9 @@ func processSpec(referenceSpec *APISpec,
 					"prefix":   "coprocess",
 					"api_name": referenceSpec.Name,
 				}).Debug("Registering coprocess middleware, hook name: ", obj.Name, "hook type: Post", ", driver: ", mwDriver)
-				AppendMiddleware(&chainArray, &CoProcessMiddleware{tykMiddleware, coprocess.HookType_Post, obj.Name, mwDriver}, tykMiddleware)
+				AppendMiddleware(&chainArray, &CoProcessMiddleware{baseMid, coprocess.HookType_Post, obj.Name, mwDriver}, baseMid)
 			} else {
-				chainArray = append(chainArray, CreateDynamicMiddleware(obj.Name, false, obj.RequireSession, tykMiddleware))
+				chainArray = append(chainArray, CreateDynamicMiddleware(obj.Name, false, obj.RequireSession, baseMid))
 			}
 		}
 
@@ -494,20 +494,20 @@ func processSpec(referenceSpec *APISpec,
 			"api_name": referenceSpec.Name,
 		}).Debug("Custom middleware completed processing")
 
-		// Use CreateMiddleware(&ModifiedMiddleware{tykMiddleware}, tykMiddleware)  to run custom middleware
-		chain = alice.New(chainArray...).Then(&DummyProxyHandler{SH: SuccessHandler{tykMiddleware}})
+		// Use CreateMiddleware(&ModifiedMiddleware{baseMid}, baseMid)  to run custom middleware
+		chain = alice.New(chainArray...).Then(&DummyProxyHandler{SH: SuccessHandler{baseMid}})
 
 		log.Debug("Chain completed")
 
 		userCheckHandler := UserRatesCheck()
 		simpleChain_PreAuth := []alice.Constructor{
-			CreateMiddleware(&IPWhiteListMiddleware{tykMiddleware}, tykMiddleware),
-			CreateMiddleware(&OrganizationMonitor{TykMiddleware: tykMiddleware}, tykMiddleware),
-			CreateMiddleware(&VersionCheck{TykMiddleware: tykMiddleware}, tykMiddleware)}
+			CreateMiddleware(&IPWhiteListMiddleware{baseMid}, baseMid),
+			CreateMiddleware(&OrganizationMonitor{BaseMiddleware: baseMid}, baseMid),
+			CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid}, baseMid)}
 
 		simpleChain_PostAuth := []alice.Constructor{
-			CreateMiddleware(&KeyExpired{tykMiddleware}, tykMiddleware),
-			CreateMiddleware(&AccessRightsCheck{tykMiddleware}, tykMiddleware)}
+			CreateMiddleware(&KeyExpired{baseMid}, baseMid),
+			CreateMiddleware(&AccessRightsCheck{baseMid}, baseMid)}
 
 		var fullSimpleChain []alice.Constructor
 		fullSimpleChain = append(fullSimpleChain, simpleChain_PreAuth...)

--- a/coprocess.go
+++ b/coprocess.go
@@ -24,7 +24,7 @@ var (
 
 // CoProcessMiddleware is the basic CP middleware struct.
 type CoProcessMiddleware struct {
-	*TykMiddleware
+	*BaseMiddleware
 	HookType         coprocess.HookType
 	HookName         string
 	MiddlewareDriver apidef.MiddlewareDriver
@@ -35,15 +35,15 @@ func (mw *CoProcessMiddleware) GetName() string {
 }
 
 // CreateCoProcessMiddleware initializes a new CP middleware, takes hook type (pre, post, etc.), hook name ("my_hook") and driver ("python").
-func CreateCoProcessMiddleware(hookName string, hookType coprocess.HookType, mwDriver apidef.MiddlewareDriver, tykMwSuper *TykMiddleware) func(http.Handler) http.Handler {
+func CreateCoProcessMiddleware(hookName string, hookType coprocess.HookType, mwDriver apidef.MiddlewareDriver, baseMid *BaseMiddleware) func(http.Handler) http.Handler {
 	dMiddleware := &CoProcessMiddleware{
-		TykMiddleware:    tykMwSuper,
+		BaseMiddleware:   baseMid,
 		HookType:         hookType,
 		HookName:         hookName,
 		MiddlewareDriver: mwDriver,
 	}
 
-	return CreateMiddleware(dMiddleware, tykMwSuper)
+	return CreateMiddleware(dMiddleware, baseMid)
 }
 
 func doCoprocessReload() {
@@ -257,7 +257,7 @@ func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 		}).Info("Attempted access with invalid key.")
 
 		// Fire Authfailed Event
-		AuthFailed(m.TykMiddleware, r, token)
+		AuthFailed(m.BaseMiddleware, r, token)
 
 		// Report in health check
 		ReportHealthCheckValue(m.Spec.Health, KeyFailure, "1")

--- a/coprocess_dummy.go
+++ b/coprocess_dummy.go
@@ -29,7 +29,7 @@ var (
 )
 
 type CoProcessMiddleware struct {
-	*TykMiddleware
+	*BaseMiddleware
 	HookType         coprocess.HookType
 	HookName         string
 	MiddlewareDriver apidef.MiddlewareDriver
@@ -61,4 +61,4 @@ func CoProcessInit() {
 
 func doCoprocessReload() {}
 
-func newExtractor(referenceSpec *APISpec, mw *TykMiddleware) {}
+func newExtractor(referenceSpec *APISpec, mw *BaseMiddleware) {}

--- a/coprocess_id_extractor_test.go
+++ b/coprocess_id_extractor_test.go
@@ -19,11 +19,11 @@ func TestValueExtractorHeaderSource(t *testing.T) {
 	spec := createSpecTest(t, idExtractorCoProcessDef)
 	remote, _ := url.Parse(spec.Proxy.TargetURL)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
-	tykMiddleware := &TykMiddleware{spec, proxy}
+	baseMid := &BaseMiddleware{spec, proxy}
 
-	newExtractor(spec, tykMiddleware)
+	newExtractor(spec, baseMid)
 
-	extractor := tykMiddleware.Spec.CustomMiddleware.IdExtractor.Extractor.(IdExtractor)
+	extractor := baseMid.Spec.CustomMiddleware.IdExtractor.Extractor.(IdExtractor)
 
 	session := createBasicAuthSession()
 	username := "4321"
@@ -52,11 +52,11 @@ func TestValueExtractorFormSource(t *testing.T) {
 	spec := createSpecTest(t, valueExtractorFormSource)
 	remote, _ := url.Parse(spec.Proxy.TargetURL)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
-	tykMiddleware := &TykMiddleware{spec, proxy}
+	baseMid := &BaseMiddleware{spec, proxy}
 
-	newExtractor(spec, tykMiddleware)
+	newExtractor(spec, baseMid)
 
-	extractor := tykMiddleware.Spec.CustomMiddleware.IdExtractor.Extractor.(IdExtractor)
+	extractor := baseMid.Spec.CustomMiddleware.IdExtractor.Extractor.(IdExtractor)
 
 	session := createBasicAuthSession()
 	username := "4321"
@@ -80,7 +80,7 @@ func TestValueExtractorFormSource(t *testing.T) {
 	chain.ServeHTTP(recorder, req)
 
 	sessionID, _ := extractor.ExtractAndCheck(req)
-	expectedSessionID := computeSessionID([]byte(authValue), tykMiddleware)
+	expectedSessionID := computeSessionID([]byte(authValue), baseMid)
 
 	if sessionID != expectedSessionID {
 		t.Fatal("Value Extractor output (using form source) doesn't match the computed session ID.")
@@ -91,11 +91,11 @@ func TestValueExtractorHeaderSourceValidation(t *testing.T) {
 	spec := createSpecTest(t, idExtractorCoProcessDef)
 	remote, _ := url.Parse(spec.Proxy.TargetURL)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
-	tykMiddleware := &TykMiddleware{spec, proxy}
+	baseMid := &BaseMiddleware{spec, proxy}
 
-	newExtractor(spec, tykMiddleware)
+	newExtractor(spec, baseMid)
 
-	extractor := tykMiddleware.Spec.CustomMiddleware.IdExtractor.Extractor.(IdExtractor)
+	extractor := baseMid.Spec.CustomMiddleware.IdExtractor.Extractor.(IdExtractor)
 
 	session := createBasicAuthSession()
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
@@ -121,11 +121,11 @@ func TestRegexExtractorHeaderSource(t *testing.T) {
 	spec := createSpecTest(t, regexExtractorDef)
 	remote, _ := url.Parse(spec.Proxy.TargetURL)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
-	tykMiddleware := &TykMiddleware{spec, proxy}
+	baseMid := &BaseMiddleware{spec, proxy}
 
-	newExtractor(spec, tykMiddleware)
+	newExtractor(spec, baseMid)
 
-	extractor := tykMiddleware.Spec.CustomMiddleware.IdExtractor.Extractor.(IdExtractor)
+	extractor := baseMid.Spec.CustomMiddleware.IdExtractor.Extractor.(IdExtractor)
 
 	session := createBasicAuthSession()
 
@@ -143,7 +143,7 @@ func TestRegexExtractorHeaderSource(t *testing.T) {
 	chain.ServeHTTP(recorder, req)
 
 	sessionID, _ := extractor.ExtractAndCheck(req)
-	expectedSessionID := computeSessionID(matchedHeaderValue, tykMiddleware)
+	expectedSessionID := computeSessionID(matchedHeaderValue, baseMid)
 
 	if sessionID != expectedSessionID {
 		t.Fatal("Regex Extractor output doesn't match the computed session ID.")
@@ -151,9 +151,9 @@ func TestRegexExtractorHeaderSource(t *testing.T) {
 
 }
 
-func computeSessionID(input []byte, tykMiddleware *TykMiddleware) (sessionID string) {
+func computeSessionID(input []byte, baseMid *BaseMiddleware) (sessionID string) {
 	tokenID := fmt.Sprintf("%x", md5.Sum(input))
-	return tykMiddleware.Spec.OrgID + tokenID
+	return baseMid.Spec.OrgID + tokenID
 }
 
 const idExtractorCoProcessDef = `{

--- a/coprocess_test.go
+++ b/coprocess_test.go
@@ -47,7 +47,7 @@ func TestCoProcessDispatchEvent(t *testing.T) {
 	spec := createSpecTest(t, basicCoProcessDef)
 	remote, _ := url.Parse(spec.Proxy.TargetURL)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
-	mw := &TykMiddleware{spec, proxy}
+	baseMid := &BaseMiddleware{spec, proxy}
 
 	meta := EventAuthFailureMeta{
 		EventMetaDefault: EventMetaDefault{Message: "Auth Failure"},
@@ -56,7 +56,7 @@ func TestCoProcessDispatchEvent(t *testing.T) {
 		Key:              "abc",
 	}
 
-	mw.FireEvent(EventAuthFailure, meta)
+	baseMid.FireEvent(EventAuthFailure, meta)
 
 	wrapper := CoProcessEventWrapper{}
 	if err := json.Unmarshal(<-CoProcessDispatchEvent, &wrapper); err != nil {
@@ -134,8 +134,8 @@ func buildCoProcessChain(spec *APISpec, hookName string, hookType coprocess.Hook
 	remote, _ := url.Parse(spec.Proxy.TargetURL)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
 	proxyHandler := ProxyHandler(proxy, spec)
-	tykMiddleware := &TykMiddleware{spec, proxy}
-	mw := CreateCoProcessMiddleware(hookName, hookType, driver, tykMiddleware)
+	baseMid := &BaseMiddleware{spec, proxy}
+	mw := CreateCoProcessMiddleware(hookName, hookType, driver, baseMid)
 	return alice.New(mw).Then(proxyHandler)
 }
 

--- a/event_system.go
+++ b/event_system.go
@@ -157,8 +157,8 @@ func GetEventHandlerByName(handlerConf apidef.EventHandlerTriggerConfig, spec *A
 	return nil, errors.New("Handler not found")
 }
 
-// FireEvent is added to the tykMiddleware object so it is available across the entire stack
-func (t *TykMiddleware) FireEvent(name apidef.TykEvent, meta interface{}) {
+// FireEvent is added to the BaseMiddleware object so it is available across the entire stack
+func (t *BaseMiddleware) FireEvent(name apidef.TykEvent, meta interface{}) {
 	fireEvent(name, meta, t.Spec.EventPaths)
 }
 

--- a/handler_error.go
+++ b/handler_error.go
@@ -25,7 +25,7 @@ type APIError struct {
 // ErrorHandler is invoked whenever there is an issue with a proxied request, most middleware will invoke
 // the ErrorHandler if something is wrong with the request and halt the request processing through the chain
 type ErrorHandler struct {
-	*TykMiddleware
+	*BaseMiddleware
 }
 
 // HandleError is the actual error handler and will store the error details in analytics if analytics processing is enabled.

--- a/handler_success.go
+++ b/handler_success.go
@@ -37,22 +37,22 @@ type ReturningHttpHandler interface {
 	New(interface{}, *APISpec) (TykResponseHandler, error)
 }
 
-// TykMiddleware wraps up the ApiSpec and Proxy objects to be included in a
+// BaseMiddleware wraps up the ApiSpec and Proxy objects to be included in a
 // middleware handler, this can probably be handled better.
-type TykMiddleware struct {
+type BaseMiddleware struct {
 	Spec  *APISpec
 	Proxy ReturningHttpHandler
 }
 
-func (t *TykMiddleware) New() {}
-func (t *TykMiddleware) IsEnabledForSpec() bool {
+func (t *BaseMiddleware) New() {}
+func (t *BaseMiddleware) IsEnabledForSpec() bool {
 	return true
 }
-func (t *TykMiddleware) GetConfig() (interface{}, error) {
+func (t *BaseMiddleware) GetConfig() (interface{}, error) {
 	return nil, nil
 }
 
-func (t *TykMiddleware) GetOrgSession(key string) (SessionState, bool) {
+func (t *BaseMiddleware) GetOrgSession(key string) (SessionState, bool) {
 	// Try and get the session from the session store
 	session, found := t.Spec.OrgSessionManager.GetSessionDetail(key)
 	if found && globalConf.EnforceOrgDataAge {
@@ -64,11 +64,11 @@ func (t *TykMiddleware) GetOrgSession(key string) (SessionState, bool) {
 	return session, found
 }
 
-func (t *TykMiddleware) SetOrgExpiry(orgid string, expiry int64) {
+func (t *BaseMiddleware) SetOrgExpiry(orgid string, expiry int64) {
 	ExpiryCache.Set(orgid, expiry, cache.DefaultExpiration)
 }
 
-func (t *TykMiddleware) GetOrgSessionExpiry(orgid string) int64 {
+func (t *BaseMiddleware) GetOrgSessionExpiry(orgid string) int64 {
 	log.Debug("Checking: ", orgid)
 	cachedVal, found := ExpiryCache.Get(orgid)
 	if !found {
@@ -81,7 +81,7 @@ func (t *TykMiddleware) GetOrgSessionExpiry(orgid string) int64 {
 }
 
 // ApplyPolicyIfExists will check if a policy is loaded, if it is, it will overwrite the session state to use the policy values
-func (t *TykMiddleware) ApplyPolicyIfExists(key string, session *SessionState) {
+func (t *BaseMiddleware) ApplyPolicyIfExists(key string, session *SessionState) {
 	if session.ApplyPolicyID == "" {
 		return
 	}
@@ -151,7 +151,7 @@ func (t *TykMiddleware) ApplyPolicyIfExists(key string, session *SessionState) {
 
 // CheckSessionAndIdentityForValidKey will check first the Session store for a valid key, if not found, it will try
 // the Auth Handler, if not found it will fail
-func (t *TykMiddleware) CheckSessionAndIdentityForValidKey(key string) (SessionState, bool) {
+func (t *BaseMiddleware) CheckSessionAndIdentityForValidKey(key string) (SessionState, bool) {
 	// Try and get the session from the session store
 	log.Debug("Querying local cache")
 	// Check in-memory cache
@@ -203,7 +203,7 @@ func (t *TykMiddleware) CheckSessionAndIdentityForValidKey(key string) (SessionS
 
 // SuccessHandler represents the final ServeHTTP() request for a proxied API request
 type SuccessHandler struct {
-	*TykMiddleware
+	*BaseMiddleware
 }
 
 func (s *SuccessHandler) RecordHit(r *http.Request, timing int64, code int, requestCopy *http.Request, responseCopy *http.Response) {

--- a/multiauth_test.go
+++ b/multiauth_test.go
@@ -69,15 +69,15 @@ func getMultiAuthStandardAndBasicAuthChain(spec *APISpec) http.Handler {
 	remote, _ := url.Parse(testHttpAny)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
 	proxyHandler := ProxyHandler(proxy, spec)
-	tykMiddleware := &TykMiddleware{spec, proxy}
+	baseMid := &BaseMiddleware{spec, proxy}
 	chain := alice.New(
-		CreateMiddleware(&IPWhiteListMiddleware{tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&BasicAuthKeyIsValid{tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&AuthKey{tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&VersionCheck{TykMiddleware: tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&KeyExpired{tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&AccessRightsCheck{tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&RateLimitAndQuotaCheck{tykMiddleware}, tykMiddleware)).Then(proxyHandler)
+		CreateMiddleware(&IPWhiteListMiddleware{baseMid}, baseMid),
+		CreateMiddleware(&BasicAuthKeyIsValid{baseMid}, baseMid),
+		CreateMiddleware(&AuthKey{baseMid}, baseMid),
+		CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid}, baseMid),
+		CreateMiddleware(&KeyExpired{baseMid}, baseMid),
+		CreateMiddleware(&AccessRightsCheck{baseMid}, baseMid),
+		CreateMiddleware(&RateLimitAndQuotaCheck{baseMid}, baseMid)).Then(proxyHandler)
 
 	return chain
 }

--- a/mw_access_rights.go
+++ b/mw_access_rights.go
@@ -11,7 +11,7 @@ import (
 // permission to access the specific version. If no permission data is in the SessionState, then
 // it is assumed that the user can go through.
 type AccessRightsCheck struct {
-	*TykMiddleware
+	*BaseMiddleware
 }
 
 func (a *AccessRightsCheck) GetName() string {

--- a/mw_auth_key.go
+++ b/mw_auth_key.go
@@ -13,7 +13,7 @@ import (
 // KeyExists will check if the key being used to access the API is in the request data,
 // and then if the key is in the storage engine
 type AuthKey struct {
-	*TykMiddleware
+	*BaseMiddleware
 }
 
 func (k *AuthKey) GetName() string {
@@ -91,7 +91,7 @@ func (k *AuthKey) ProcessRequest(w http.ResponseWriter, r *http.Request, _ inter
 		}).Info("Attempted access with non-existent key.")
 
 		// Fire Authfailed Event
-		AuthFailed(k.TykMiddleware, r, key)
+		AuthFailed(k.BaseMiddleware, r, key)
 
 		// Report in health check
 		ReportHealthCheckValue(k.Spec.Health, KeyFailure, "1")
@@ -116,7 +116,7 @@ func stripBearer(token string) string {
 	return strings.TrimSpace(token)
 }
 
-func AuthFailed(m *TykMiddleware, r *http.Request, token string) {
+func AuthFailed(m *BaseMiddleware, r *http.Request, token string) {
 	m.FireEvent(EventAuthFailure, EventAuthFailureMeta{
 		EventMetaDefault: EventMetaDefault{Message: "Auth Failure", OriginatingRequest: EncodeRequestToEvent(r)},
 		Path:             r.URL.Path,

--- a/mw_auth_key_test.go
+++ b/mw_auth_key_test.go
@@ -30,14 +30,14 @@ func getAuthKeyChain(spec *APISpec) http.Handler {
 	remote, _ := url.Parse(spec.Proxy.TargetURL)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
 	proxyHandler := ProxyHandler(proxy, spec)
-	tykMiddleware := &TykMiddleware{spec, proxy}
+	baseMid := &BaseMiddleware{spec, proxy}
 	chain := alice.New(
-		CreateMiddleware(&IPWhiteListMiddleware{tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&AuthKey{tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&VersionCheck{TykMiddleware: tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&KeyExpired{tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&AccessRightsCheck{tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&RateLimitAndQuotaCheck{tykMiddleware}, tykMiddleware)).Then(proxyHandler)
+		CreateMiddleware(&IPWhiteListMiddleware{baseMid}, baseMid),
+		CreateMiddleware(&AuthKey{baseMid}, baseMid),
+		CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid}, baseMid),
+		CreateMiddleware(&KeyExpired{baseMid}, baseMid),
+		CreateMiddleware(&AccessRightsCheck{baseMid}, baseMid),
+		CreateMiddleware(&RateLimitAndQuotaCheck{baseMid}, baseMid)).Then(proxyHandler)
 
 	return chain
 }

--- a/mw_basic_auth.go
+++ b/mw_basic_auth.go
@@ -14,7 +14,7 @@ import (
 
 // BasicAuthKeyIsValid uses a username instead of
 type BasicAuthKeyIsValid struct {
-	*TykMiddleware
+	*BaseMiddleware
 }
 
 func (k *BasicAuthKeyIsValid) GetName() string {
@@ -86,7 +86,7 @@ func (k *BasicAuthKeyIsValid) ProcessRequest(w http.ResponseWriter, r *http.Requ
 		}).Info("Attempted access with non-existent user.")
 
 		// Fire Authfailed Event
-		AuthFailed(k.TykMiddleware, r, token)
+		AuthFailed(k.BaseMiddleware, r, token)
 
 		// Report in health check
 		ReportHealthCheckValue(k.Spec.Health, KeyFailure, "-1")
@@ -118,7 +118,7 @@ func (k *BasicAuthKeyIsValid) ProcessRequest(w http.ResponseWriter, r *http.Requ
 		}).Info("Attempted access with existing user but failed password check.")
 
 		// Fire Authfailed Event
-		AuthFailed(k.TykMiddleware, r, token)
+		AuthFailed(k.BaseMiddleware, r, token)
 
 		// Report in health check
 		ReportHealthCheckValue(k.Spec.Health, KeyFailure, "-1")

--- a/mw_basic_auth_test.go
+++ b/mw_basic_auth_test.go
@@ -52,14 +52,14 @@ func getBasicAuthChain(spec *APISpec) http.Handler {
 	remote, _ := url.Parse(testHttpAny)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
 	proxyHandler := ProxyHandler(proxy, spec)
-	tykMiddleware := &TykMiddleware{spec, proxy}
+	baseMid := &BaseMiddleware{spec, proxy}
 	chain := alice.New(
-		CreateMiddleware(&IPWhiteListMiddleware{tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&BasicAuthKeyIsValid{tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&VersionCheck{TykMiddleware: tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&KeyExpired{tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&AccessRightsCheck{tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&RateLimitAndQuotaCheck{tykMiddleware}, tykMiddleware)).Then(proxyHandler)
+		CreateMiddleware(&IPWhiteListMiddleware{baseMid}, baseMid),
+		CreateMiddleware(&BasicAuthKeyIsValid{baseMid}, baseMid),
+		CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid}, baseMid),
+		CreateMiddleware(&KeyExpired{baseMid}, baseMid),
+		CreateMiddleware(&AccessRightsCheck{baseMid}, baseMid),
+		CreateMiddleware(&RateLimitAndQuotaCheck{baseMid}, baseMid)).Then(proxyHandler)
 
 	return chain
 }

--- a/mw_context_vars.go
+++ b/mw_context_vars.go
@@ -8,7 +8,7 @@ import (
 )
 
 type MiddlewareContextVars struct {
-	*TykMiddleware
+	*BaseMiddleware
 }
 
 func (m *MiddlewareContextVars) GetName() string {

--- a/mw_example_test.go
+++ b/mw_example_test.go
@@ -13,7 +13,7 @@ import (
 // modifiedMiddleware is a sample custom middleware component, must inherit TykMiddleware
 // so you have access to spec and definition data
 type modifiedMiddleware struct {
-	*TykMiddleware
+	*BaseMiddleware
 }
 
 type modifiedMiddlewareConfig struct {

--- a/mw_granular_access.go
+++ b/mw_granular_access.go
@@ -10,7 +10,7 @@ import (
 
 // GranularAccessMiddleware will check if a URL is specifically enabled for the key
 type GranularAccessMiddleware struct {
-	*TykMiddleware
+	*BaseMiddleware
 }
 
 func (m *GranularAccessMiddleware) GetName() string {

--- a/mw_hmac.go
+++ b/mw_hmac.go
@@ -22,7 +22,7 @@ const altHeaderSpec = "x-aux-date"
 
 // HMACMiddleware will check if the request has a signature, and if the request is allowed through
 type HMACMiddleware struct {
-	*TykMiddleware
+	*BaseMiddleware
 	lowercasePattern *regexp.Regexp
 }
 

--- a/mw_hmac_test.go
+++ b/mw_hmac_test.go
@@ -57,14 +57,14 @@ func getHMACAuthChain(spec *APISpec) http.Handler {
 	remote, _ := url.Parse(testHttpAny)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
 	proxyHandler := ProxyHandler(proxy, spec)
-	tykMiddleware := &TykMiddleware{spec, proxy}
+	baseMid := &BaseMiddleware{spec, proxy}
 	chain := alice.New(
-		CreateMiddleware(&IPWhiteListMiddleware{tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&HMACMiddleware{TykMiddleware: tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&VersionCheck{TykMiddleware: tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&KeyExpired{tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&AccessRightsCheck{tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&RateLimitAndQuotaCheck{tykMiddleware}, tykMiddleware)).Then(proxyHandler)
+		CreateMiddleware(&IPWhiteListMiddleware{baseMid}, baseMid),
+		CreateMiddleware(&HMACMiddleware{BaseMiddleware: baseMid}, baseMid),
+		CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid}, baseMid),
+		CreateMiddleware(&KeyExpired{baseMid}, baseMid),
+		CreateMiddleware(&AccessRightsCheck{baseMid}, baseMid),
+		CreateMiddleware(&RateLimitAndQuotaCheck{baseMid}, baseMid)).Then(proxyHandler)
 
 	return chain
 }

--- a/mw_ip_whitelist.go
+++ b/mw_ip_whitelist.go
@@ -8,7 +8,7 @@ import (
 
 // IPWhiteListMiddleware lets you define a list of IPs to allow upstream
 type IPWhiteListMiddleware struct {
-	*TykMiddleware
+	*BaseMiddleware
 }
 
 func (i *IPWhiteListMiddleware) GetName() string {
@@ -50,7 +50,7 @@ func (i *IPWhiteListMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Re
 	}
 
 	// Fire Authfailed Event
-	AuthFailed(i.TykMiddleware, r, remoteIP.String())
+	AuthFailed(i.BaseMiddleware, r, remoteIP.String())
 	// Report in health check
 	ReportHealthCheckValue(i.Spec.Health, KeyFailure, "-1")
 

--- a/mw_jwt.go
+++ b/mw_jwt.go
@@ -19,7 +19,7 @@ import (
 )
 
 type JWTMiddleware struct {
-	*TykMiddleware
+	*BaseMiddleware
 }
 
 func (k *JWTMiddleware) GetName() string {
@@ -270,7 +270,7 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 
 func (k *JWTMiddleware) reportLoginFailure(tykId string, r *http.Request) {
 	// Fire Authfailed Event
-	AuthFailed(k.TykMiddleware, r, tykId)
+	AuthFailed(k.BaseMiddleware, r, tykId)
 
 	// Report in health check
 	ReportHealthCheckValue(k.Spec.Health, KeyFailure, "1")

--- a/mw_jwt_test.go
+++ b/mw_jwt_test.go
@@ -183,14 +183,14 @@ func getJWTChain(spec *APISpec) http.Handler {
 	remote, _ := url.Parse(testHttpAny)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
 	proxyHandler := ProxyHandler(proxy, spec)
-	tykMiddleware := &TykMiddleware{spec, proxy}
+	baseMid := &BaseMiddleware{spec, proxy}
 	chain := alice.New(
-		CreateMiddleware(&IPWhiteListMiddleware{tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&JWTMiddleware{tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&VersionCheck{TykMiddleware: tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&KeyExpired{tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&AccessRightsCheck{tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&RateLimitAndQuotaCheck{tykMiddleware}, tykMiddleware)).Then(proxyHandler)
+		CreateMiddleware(&IPWhiteListMiddleware{baseMid}, baseMid),
+		CreateMiddleware(&JWTMiddleware{baseMid}, baseMid),
+		CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid}, baseMid),
+		CreateMiddleware(&KeyExpired{baseMid}, baseMid),
+		CreateMiddleware(&AccessRightsCheck{baseMid}, baseMid),
+		CreateMiddleware(&RateLimitAndQuotaCheck{baseMid}, baseMid)).Then(proxyHandler)
 
 	return chain
 }

--- a/mw_key_expired_check.go
+++ b/mw_key_expired_check.go
@@ -9,7 +9,7 @@ import (
 
 // KeyExpired middleware will check if the requesting key is expired or not. It makes use of the authManager to do so.
 type KeyExpired struct {
-	*TykMiddleware
+	*BaseMiddleware
 }
 
 func (k *KeyExpired) GetName() string {

--- a/mw_method_transform.go
+++ b/mw_method_transform.go
@@ -10,7 +10,7 @@ import (
 
 // TransformMiddleware is a middleware that will apply a template to a request body to transform it's contents ready for an upstream API
 type TransformMethod struct {
-	*TykMiddleware
+	*BaseMiddleware
 }
 
 func (t *TransformMethod) GetName() string {

--- a/mw_modify_headers.go
+++ b/mw_modify_headers.go
@@ -9,7 +9,7 @@ import (
 
 // TransformMiddleware is a middleware that will apply a template to a request body to transform it's contents ready for an upstream API
 type TransformHeaders struct {
-	*TykMiddleware
+	*BaseMiddleware
 }
 
 const (

--- a/mw_oauth2_key_exists.go
+++ b/mw_oauth2_key_exists.go
@@ -13,7 +13,7 @@ import (
 // Oauth2KeyExists will check if the key being used to access the API is in the request data,
 // and then if the key is in the storage engine
 type Oauth2KeyExists struct {
-	*TykMiddleware
+	*BaseMiddleware
 }
 
 func (k *Oauth2KeyExists) GetName() string {
@@ -55,7 +55,7 @@ func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request,
 		}).Info("Attempted access with non-existent key.")
 
 		// Fire Authfailed Event
-		AuthFailed(k.TykMiddleware, r, accessToken)
+		AuthFailed(k.BaseMiddleware, r, accessToken)
 		// Report in health check
 		ReportHealthCheckValue(k.Spec.Health, KeyFailure, "-1")
 

--- a/mw_openid.go
+++ b/mw_openid.go
@@ -18,7 +18,7 @@ import (
 const OIDPREFIX = "openid"
 
 type OpenIDMW struct {
-	*TykMiddleware
+	*BaseMiddleware
 	providerConfiguration     *openid.Configuration
 	provider_client_policymap map[string]map[string]string
 	lock                      sync.RWMutex
@@ -214,7 +214,7 @@ func (k *OpenIDMW) reportLoginFailure(tykId string, r *http.Request) {
 	}).Warning("Attempted access with invalid key.")
 
 	// Fire Authfailed Event
-	AuthFailed(k.TykMiddleware, r, tykId)
+	AuthFailed(k.BaseMiddleware, r, tykId)
 
 	// Report in health check
 	ReportHealthCheckValue(k.Spec.Health, KeyFailure, "1")

--- a/mw_organisation_activity.go
+++ b/mw_organisation_activity.go
@@ -23,7 +23,7 @@ var orgActiveMap = orgActiveMapMu{
 // RateLimitAndQuotaCheck will check the incomming request and key whether it is within it's quota and
 // within it's rate limit, it makes use of the SessionLimiter object to do this
 type OrganizationMonitor struct {
-	*TykMiddleware
+	*BaseMiddleware
 	sessionlimiter SessionLimiter
 	mon            Monitor
 }

--- a/mw_rate_check.go
+++ b/mw_rate_check.go
@@ -3,7 +3,7 @@ package main
 import "net/http"
 
 type RateCheckMW struct {
-	*TykMiddleware
+	*BaseMiddleware
 }
 
 func (m *RateCheckMW) GetName() string {

--- a/mw_rate_limiting.go
+++ b/mw_rate_limiting.go
@@ -13,7 +13,7 @@ var sessionMonitor = Monitor{}
 // RateLimitAndQuotaCheck will check the incomming request and key whether it is within it's quota and
 // within it's rate limit, it makes use of the SessionLimiter object to do this
 type RateLimitAndQuotaCheck struct {
-	*TykMiddleware
+	*BaseMiddleware
 }
 
 func (k *RateLimitAndQuotaCheck) GetName() string {

--- a/mw_redis_cache.go
+++ b/mw_redis_cache.go
@@ -21,7 +21,7 @@ const (
 
 // RedisCacheMiddleware is a caching middleware that will pull data from Redis instead of the upstream proxy
 type RedisCacheMiddleware struct {
-	*TykMiddleware
+	*BaseMiddleware
 	CacheStore StorageHandler
 	sh         SuccessHandler
 }
@@ -32,7 +32,7 @@ func (m *RedisCacheMiddleware) GetName() string {
 
 // New lets you do any initialisations for the object can be done here
 func (m *RedisCacheMiddleware) New() {
-	m.sh = SuccessHandler{m.TykMiddleware}
+	m.sh = SuccessHandler{m.BaseMiddleware}
 }
 
 func (m *RedisCacheMiddleware) IsEnabledForSpec() bool {
@@ -152,7 +152,7 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 		var reqVal *http.Response
 		if isVirtual {
 			log.Debug("This is a virtual function")
-			vp := VirtualEndpoint{TykMiddleware: m.TykMiddleware}
+			vp := VirtualEndpoint{BaseMiddleware: m.BaseMiddleware}
 			vp.New()
 			reqVal = vp.ServeHTTPForCache(w, r)
 		} else {

--- a/mw_request_size_limit.go
+++ b/mw_request_size_limit.go
@@ -12,7 +12,7 @@ import (
 
 // TransformMiddleware is a middleware that will apply a template to a request body to transform it's contents ready for an upstream API
 type RequestSizeLimitMiddleware struct {
-	*TykMiddleware
+	*BaseMiddleware
 }
 
 func (t *RequestSizeLimitMiddleware) GetName() string {

--- a/mw_track_endpoints.go
+++ b/mw_track_endpoints.go
@@ -8,7 +8,7 @@ import (
 
 // TrackEndpointMiddleware sets context variables to enable or disable whether Tyk should record analytitcs for a specific path.
 type TrackEndpointMiddleware struct {
-	*TykMiddleware
+	*BaseMiddleware
 }
 
 func (a *TrackEndpointMiddleware) GetName() string {

--- a/mw_transform.go
+++ b/mw_transform.go
@@ -20,7 +20,7 @@ func WrappedCharsetReader(s string, i io.Reader) (io.Reader, error) {
 
 // TransformMiddleware is a middleware that will apply a template to a request body to transform it's contents ready for an upstream API
 type TransformMiddleware struct {
-	*TykMiddleware
+	*BaseMiddleware
 }
 
 func (t *TransformMiddleware) GetName() string {

--- a/mw_url_rewrite.go
+++ b/mw_url_rewrite.go
@@ -115,7 +115,7 @@ func valToStr(v interface{}) string {
 
 // URLRewriteMiddleware Will rewrite an inbund URL to a matching outbound one, it can also handle dynamic variable substitution
 type URLRewriteMiddleware struct {
-	*TykMiddleware
+	*BaseMiddleware
 }
 
 func (m *URLRewriteMiddleware) GetName() string {

--- a/mw_version_check.go
+++ b/mw_version_check.go
@@ -10,13 +10,13 @@ import (
 
 // VersionCheck will check whether the version of the requested API the request is accessing has any restrictions on URL endpoints
 type VersionCheck struct {
-	*TykMiddleware
+	*BaseMiddleware
 	sh SuccessHandler
 }
 
 // New lets you do any initialisations for the object can be done here
 func (v *VersionCheck) New() {
-	v.sh = SuccessHandler{v.TykMiddleware}
+	v.sh = SuccessHandler{v.BaseMiddleware}
 }
 
 func (v *VersionCheck) GetName() string {

--- a/mw_virtual_endpoint.go
+++ b/mw_virtual_endpoint.go
@@ -34,7 +34,7 @@ type VMResponseObject struct {
 
 // DynamicMiddleware is a generic middleware that will execute JS code before continuing
 type VirtualEndpoint struct {
-	*TykMiddleware
+	*BaseMiddleware
 	sh SuccessHandler
 }
 
@@ -81,7 +81,7 @@ func PreLoadVirtualMetaCode(meta *apidef.VirtualMeta, j *JSVM) {
 
 // New lets you do any initialisations for the object can be done here
 func (d *VirtualEndpoint) New() {
-	d.sh = SuccessHandler{d.TykMiddleware}
+	d.sh = SuccessHandler{d.BaseMiddleware}
 }
 
 func (d *VirtualEndpoint) IsEnabledForSpec() bool {

--- a/mw_virtual_endpoint_test.go
+++ b/mw_virtual_endpoint_test.go
@@ -67,7 +67,7 @@ func TestVirtualEndpoint(t *testing.T) {
 	spec := createSpecTest(t, virtTestDef)
 	defer os.Remove(mwPath)
 
-	virt := &VirtualEndpoint{TykMiddleware: &TykMiddleware{
+	virt := &VirtualEndpoint{BaseMiddleware: &BaseMiddleware{
 		spec, nil,
 	}}
 	virt.New()

--- a/oauth_manager_test.go
+++ b/oauth_manager_test.go
@@ -76,13 +76,13 @@ func getOAuthChain(spec *APISpec, muxer *mux.Router) {
 	remote, _ := url.Parse(testHttpAny)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
 	proxyHandler := ProxyHandler(proxy, spec)
-	tykMiddleware := &TykMiddleware{spec, proxy}
+	baseMid := &BaseMiddleware{spec, proxy}
 	chain := alice.New(
-		CreateMiddleware(&VersionCheck{TykMiddleware: tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&Oauth2KeyExists{tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&KeyExpired{tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&AccessRightsCheck{tykMiddleware}, tykMiddleware),
-		CreateMiddleware(&RateLimitAndQuotaCheck{tykMiddleware}, tykMiddleware)).Then(proxyHandler)
+		CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid}, baseMid),
+		CreateMiddleware(&Oauth2KeyExists{baseMid}, baseMid),
+		CreateMiddleware(&KeyExpired{baseMid}, baseMid),
+		CreateMiddleware(&AccessRightsCheck{baseMid}, baseMid),
+		CreateMiddleware(&RateLimitAndQuotaCheck{baseMid}, baseMid)).Then(proxyHandler)
 
 	muxer.Handle(spec.Proxy.ListenPath, chain)
 }

--- a/plugins.go
+++ b/plugins.go
@@ -48,7 +48,7 @@ type VMReturnObject struct {
 
 // DynamicMiddleware is a generic middleware that will execute JS code before continuing
 type DynamicMiddleware struct {
-	*TykMiddleware
+	*BaseMiddleware
 	MiddlewareClassName string
 	Pre                 bool
 	UseSession          bool

--- a/plugins_test.go
+++ b/plugins_test.go
@@ -61,7 +61,7 @@ rawlog('{"x": "y"}')
 
 func TestJSVMProcessTimeout(t *testing.T) {
 	dynMid := &DynamicMiddleware{
-		TykMiddleware: &TykMiddleware{
+		BaseMiddleware: &BaseMiddleware{
 			Spec: &APISpec{APIDefinition: &apidef.APIDefinition{}},
 		},
 		MiddlewareClassName: "leakMid",
@@ -114,7 +114,7 @@ testJSVMData.NewProcessRequest(function(request, session, config) {
 	return testJSVMData.ReturnData(request, {});
 });`
 	dynMid := &DynamicMiddleware{
-		TykMiddleware:       &TykMiddleware{spec, nil},
+		BaseMiddleware:      &BaseMiddleware{spec, nil},
 		MiddlewareClassName: "testJSVMData",
 		Pre:                 true,
 	}

--- a/tyk_reverse_proxy_clone.go
+++ b/tyk_reverse_proxy_clone.go
@@ -366,7 +366,7 @@ func (c *runOnFirstRead) Read(bs []byte) (int, error) {
 }
 
 func (p *ReverseProxy) New(c interface{}, spec *APISpec) (TykResponseHandler, error) {
-	p.ErrorHandler = ErrorHandler{TykMiddleware: &TykMiddleware{spec, p}}
+	p.ErrorHandler = ErrorHandler{BaseMiddleware: &BaseMiddleware{spec, p}}
 	return nil, nil
 }
 


### PR DESCRIPTION
Because that's what it is - it's the base on top of which all
middlewares are built. And rename TykMiddlewareImplementation, the
interface, to TykMiddleware.

While at it, also give some variables better and shorter names.