### PR TITLE
main: don't use .* regex for url arguments

### DIFF
--- a/main.go
+++ b/main.go
@@ -326,22 +326,22 @@ func loadAPIEndpoints(muxer *mux.Router) {
 	r.HandleFunc("/reload{_:/?}", allowMethods(resetHandler(nil), "GET"))
 
 	if !isRPCMode() {
-		r.HandleFunc("/org/keys/{keyName:.*}", allowMethods(orgHandler, "POST", "PUT", "GET", "DELETE"))
-		r.HandleFunc("/keys/policy/{keyName:.*}", allowMethods(policyUpdateHandler, "POST"))
+		r.HandleFunc("/org/keys/{keyName}", allowMethods(orgHandler, "POST", "PUT", "GET", "DELETE"))
+		r.HandleFunc("/keys/policy/{keyName}", allowMethods(policyUpdateHandler, "POST"))
 		r.HandleFunc("/keys/create{_:/?}", allowMethods(createKeyHandler, "POST"))
 		r.HandleFunc("/apis{_:/?}", allowMethods(apiHandler, "GET", "POST", "PUT", "DELETE"))
-		r.HandleFunc("/apis/{apiID:.*}", allowMethods(apiHandler, "GET", "POST", "PUT", "DELETE"))
+		r.HandleFunc("/apis/{apiID}", allowMethods(apiHandler, "GET", "POST", "PUT", "DELETE"))
 		r.HandleFunc("/health{_:/?}", allowMethods(healthCheckhandler, "GET"))
 		r.HandleFunc("/oauth/clients/create{_:/?}", allowMethods(createOauthClient, "POST"))
-		r.HandleFunc("/oauth/refresh/{keyName:.*}", allowMethods(invalidateOauthRefresh, "DELETE"))
-		r.HandleFunc("/cache/{apiID:.*}", allowMethods(invalidateCacheHandler, "DELETE"))
+		r.HandleFunc("/oauth/refresh/{keyName}", allowMethods(invalidateOauthRefresh, "DELETE"))
+		r.HandleFunc("/cache/{apiID}", allowMethods(invalidateCacheHandler, "DELETE"))
 	} else {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Info("Node is slaved, REST API minimised")
 	}
 
-	r.HandleFunc("/keys/{keyName:.*}", allowMethods(keyHandler, "POST", "PUT", "GET", "DELETE"))
+	r.HandleFunc("/keys/{keyName}", allowMethods(keyHandler, "POST", "PUT", "GET", "DELETE"))
 	r.HandleFunc("/oauth/clients/{keyCombined:.*}", allowMethods(oAuthClientHandler, "GET", "DELETE"))
 
 	log.WithFields(logrus.Fields{


### PR DESCRIPTION
If we don't include a regex, gorilla/mux uses all characters until the
next slash. This is what we want. Otherwise, /apis/foo/bar would use the
API ID "foo/bar" instead of doing the correct thing, which is a 404
since that's not a valid endpoint.