### PR TITLE
main: simplify net/http/pprof routes

### DIFF
--- a/main.go
+++ b/main.go
@@ -1118,11 +1118,7 @@ func start(arguments map[string]interface{}) {
 			"prefix": "main",
 		}).Debug("Adding pprof endpoints")
 
-		defaultRouter.HandleFunc("/debug/pprof/{rest:.*}", pprof_http.Index)
-		defaultRouter.HandleFunc("/debug/pprof/cmdline", pprof_http.Cmdline)
-		defaultRouter.HandleFunc("/debug/pprof/profile", pprof_http.Profile)
-		defaultRouter.HandleFunc("/debug/pprof/symbol", pprof_http.Symbol)
-		defaultRouter.HandleFunc("/debug/pprof/trace", pprof_http.Trace)
+		defaultRouter.HandleFunc("/debug/pprof/{_:.*}", pprof_http.Index)
 	}
 
 	// Set up a default org manager so we can traverse non-live paths


### PR DESCRIPTION
pprof.Index reads:

	Index responds with the pprof-formatted profile named by the
	request. For example, "/debug/pprof/heap" serves the "heap"
	profile. Index responds to a request for "/debug/pprof/" with an
	HTML page listing the available profiles.

In other words, sending all /debug/pprof/* requests to it is enough - we
don't have to add specific routes for all the kinds of profiles.

Verified that it still works by requesting /debug/pprof/heap before and
after this patch.