### PR TITLE
mw: remove useContext param from urlRewrite

### DIFF
--- a/mw_url_rewrite_test.go
+++ b/mw_url_rewrite_test.go
@@ -61,7 +61,7 @@ func TestRewriter(t *testing.T) {
 				RewriteTo:    tc.to,
 			}
 			r := httptest.NewRequest("GET", "/", nil)
-			got, err := urlRewrite(&testConf, tc.in, false, r)
+			got, err := urlRewrite(&testConf, tc.in, r)
 			if err != nil {
 				t.Error("compile failed:", err)
 			}


### PR DESCRIPTION
It was always true in production code. And in the tests it was false.
This was presumably because of gorilla/context, which might misbehave
given how test requests don't have any context values.

Now that we use net/http request contexts, there's nothing to worry
about.

Most importantly, we want the test to run the same code that prod would.
And if we want to add tests that use $tyk_context-style variables, we
now can.