### PR TITLE
all: better use of sync.RWMutex

### DIFF
--- a/apidef/host_list.go
+++ b/apidef/host_list.go
@@ -11,18 +11,15 @@ type HostList struct {
 }
 
 func NewHostList() *HostList {
-	thisHL := HostList{}
-	thisHL.hosts = make([]string, 0)
-	thisHL.hMutex = sync.RWMutex{}
-
-	return &thisHL
+	hl := HostList{}
+	hl.hosts = make([]string, 0)
+	return &hl
 }
 
 func NewHostListFromList(newList []string) *HostList {
-	thisHL := NewHostList()
-	thisHL.Set(newList)
-
-	return thisHL
+	hl := NewHostList()
+	hl.Set(newList)
+	return hl
 }
 
 func (h *HostList) Set(newList []string) {

--- a/mw_openid.go
+++ b/mw_openid.go
@@ -35,8 +35,6 @@ func (k *OpenIDMW) New() {
 	k.providerConfiguration, err = openid.NewConfiguration(openid.ProvidersGetter(k.getProviders),
 		openid.ErrorHandler(k.dummyErrorHandler))
 
-	k.lock = sync.RWMutex{}
-
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": OIDPREFIX,
@@ -116,9 +114,9 @@ func (k *OpenIDMW) ProcessRequest(w http.ResponseWriter, r *http.Request, _ inte
 		return errors.New("Key not authorised"), 403
 	}
 
-	k.lock.Lock()
+	k.lock.RLock()
 	clientSet, foundIssuer := k.provider_client_policymap[iss.(string)]
-	k.lock.Unlock()
+	k.lock.RUnlock()
 	if !foundIssuer {
 		log.WithFields(logrus.Fields{
 			"prefix": OIDPREFIX,

--- a/rpc_storage_handler.go
+++ b/rpc_storage_handler.go
@@ -56,7 +56,7 @@ var (
 
 // ------------------- CLOUD STORAGE MANAGER -------------------------------
 
-var RPCCLientRWMutex = sync.RWMutex{}
+var RPCCLientRWMutex sync.RWMutex
 var RPCClients = map[string]chan int{}
 
 func rpcKeepAliveCheck(r *RPCStorageHandler) {


### PR DESCRIPTION
In mw_openid, don't lock when all we need is a rlock.

And simplify a few places where we set mutexes's values. Their zero
value is already valid, so there's no need to.