### PR TITLE
rpc: remove global RPCClients map

### DIFF
--- a/api_definition_test.go
+++ b/api_definition_test.go
@@ -338,7 +338,6 @@ func stopRPCMock(server *gorpc.Server) {
 
 	RPCCLientSingleton.Stop()
 	RPCClientIsConnected = false
-	RPCClients = map[string]chan int{}
 	RPCCLientSingleton = nil
 	RPCFuncClientSingleton = nil
 }


### PR DESCRIPTION
Its last use was removed in late 2016. Now we just set and delete
elements from it, so it's not used at all.

While at it, do an early return with RPCClientIsConnected.