### PR TITLE
api: split keyCombined args in gorilla/mux

### DIFF
--- a/api.go
+++ b/api.go
@@ -1163,26 +1163,11 @@ func invalidateOauthRefresh(w http.ResponseWriter, r *http.Request) {
 }
 
 func oAuthClientHandler(w http.ResponseWriter, r *http.Request) {
-	// TODO: split these two args in the router
-	keyCombined := mux.Vars(r)["keyCombined"]
+	apiID := mux.Vars(r)["apiID"]
+	keyName := mux.Vars(r)["keyName"]
+
 	var obj interface{}
 	var code int
-
-	keyName := ""
-	apiID := ""
-
-	parts := strings.Split(keyCombined, "/")
-	switch len(parts) {
-	case 2:
-		keyName = parts[1]
-		apiID = parts[0]
-	case 1:
-		apiID = parts[0]
-	default:
-		doJSONWrite(w, 400, apiError("Missing URL params"))
-		return
-	}
-
 	switch r.Method {
 	case "GET":
 		if keyName != "" {

--- a/main.go
+++ b/main.go
@@ -342,7 +342,8 @@ func loadAPIEndpoints(muxer *mux.Router) {
 	}
 
 	r.HandleFunc("/keys/{keyName}", allowMethods(keyHandler, "POST", "PUT", "GET", "DELETE"))
-	r.HandleFunc("/oauth/clients/{keyCombined:.*}", allowMethods(oAuthClientHandler, "GET", "DELETE"))
+	r.HandleFunc("/oauth/clients/{apiID}", allowMethods(oAuthClientHandler, "GET", "DELETE"))
+	r.HandleFunc("/oauth/clients/{apiID}/{keyName}", allowMethods(oAuthClientHandler, "GET", "DELETE"))
 
 	log.WithFields(logrus.Fields{
 		"prefix": "main",


### PR DESCRIPTION
We need two routes, as we support either one or two arguments.