### PR TITLE
mw: rename New to Init

### DIFF
--- a/handler_success.go
+++ b/handler_success.go
@@ -44,7 +44,7 @@ type BaseMiddleware struct {
 	Proxy ReturningHttpHandler
 }
 
-func (t *BaseMiddleware) New() {}
+func (t *BaseMiddleware) Init() {}
 func (t *BaseMiddleware) IsEnabledForSpec() bool {
 	return true
 }

--- a/middleware.go
+++ b/middleware.go
@@ -16,7 +16,7 @@ const mwStatusRespond = 666
 var GlobalRate = ratecounter.NewRateCounter(1 * time.Second)
 
 type TykMiddleware interface {
-	New()
+	Init()
 	GetConfig() (interface{}, error)
 	ProcessRequest(w http.ResponseWriter, r *http.Request, conf interface{}) (error, int) // Handles request
 	IsEnabledForSpec() bool
@@ -41,7 +41,7 @@ func CreateDynamicAuthMiddleware(name string, baseMid *BaseMiddleware) func(http
 // Generic middleware caller to make extension easier
 func CreateMiddleware(mw TykMiddleware, baseMid *BaseMiddleware) func(http.Handler) http.Handler {
 	// construct a new instance
-	mw.New()
+	mw.Init()
 
 	// Pull the configuration
 	mwConf, err := mw.GetConfig()

--- a/mw_example_test.go
+++ b/mw_example_test.go
@@ -24,8 +24,8 @@ func (m *modifiedMiddleware) GetName() string {
 	return "modifiedMiddleware"
 }
 
-// New lets you do any initialisations for the object can be done here
-func (m *modifiedMiddleware) New() {}
+// Init lets you do any initialisations for the object can be done here
+func (m *modifiedMiddleware) Init() {}
 
 // GetConfig retrieves the configuration from the API config - we user mapstructure for this for simplicity
 func (m *modifiedMiddleware) GetConfig() (interface{}, error) {

--- a/mw_hmac.go
+++ b/mw_hmac.go
@@ -30,7 +30,7 @@ func (hm *HMACMiddleware) GetName() string {
 	return "HMAC"
 }
 
-func (hm *HMACMiddleware) New() {
+func (hm *HMACMiddleware) Init() {
 	hm.lowercasePattern = regexp.MustCompile(`%[a-f0-9][a-f0-9]`)
 }
 

--- a/mw_openid.go
+++ b/mw_openid.go
@@ -28,7 +28,7 @@ func (k *OpenIDMW) GetName() string {
 	return "OpenIDMW"
 }
 
-func (k *OpenIDMW) New() {
+func (k *OpenIDMW) Init() {
 	k.provider_client_policymap = make(map[string]map[string]string)
 	// Create an OpenID Configuration and store
 	var err error

--- a/mw_organisation_activity.go
+++ b/mw_organisation_activity.go
@@ -32,12 +32,6 @@ func (k *OrganizationMonitor) GetName() string {
 	return "OrganizationMonitor"
 }
 
-// New lets you do any initialisations for the object can be done here
-func (k *OrganizationMonitor) New() {
-	k.sessionlimiter = SessionLimiter{}
-	k.mon = Monitor{}
-}
-
 func (k *OrganizationMonitor) IsEnabledForSpec() bool {
 	// If false, we aren't enforcing quotas so skip this mw
 	// altogether

--- a/mw_redis_cache.go
+++ b/mw_redis_cache.go
@@ -30,8 +30,7 @@ func (m *RedisCacheMiddleware) GetName() string {
 	return "RedisCacheMiddleware"
 }
 
-// New lets you do any initialisations for the object can be done here
-func (m *RedisCacheMiddleware) New() {
+func (m *RedisCacheMiddleware) Init() {
 	m.sh = SuccessHandler{m.BaseMiddleware}
 }
 
@@ -153,7 +152,7 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 		if isVirtual {
 			log.Debug("This is a virtual function")
 			vp := VirtualEndpoint{BaseMiddleware: m.BaseMiddleware}
-			vp.New()
+			vp.Init()
 			reqVal = vp.ServeHTTPForCache(w, r)
 		} else {
 			// This passes through and will write the value to the writer, but spit out a copy for the cache

--- a/mw_version_check.go
+++ b/mw_version_check.go
@@ -14,8 +14,7 @@ type VersionCheck struct {
 	sh SuccessHandler
 }
 
-// New lets you do any initialisations for the object can be done here
-func (v *VersionCheck) New() {
+func (v *VersionCheck) Init() {
 	v.sh = SuccessHandler{v.BaseMiddleware}
 }
 

--- a/mw_virtual_endpoint.go
+++ b/mw_virtual_endpoint.go
@@ -79,8 +79,7 @@ func PreLoadVirtualMetaCode(meta *apidef.VirtualMeta, j *JSVM) {
 	}
 }
 
-// New lets you do any initialisations for the object can be done here
-func (d *VirtualEndpoint) New() {
+func (d *VirtualEndpoint) Init() {
 	d.sh = SuccessHandler{d.BaseMiddleware}
 }
 

--- a/mw_virtual_endpoint_test.go
+++ b/mw_virtual_endpoint_test.go
@@ -70,7 +70,7 @@ func TestVirtualEndpoint(t *testing.T) {
 	virt := &VirtualEndpoint{BaseMiddleware: &BaseMiddleware{
 		spec, nil,
 	}}
-	virt.New()
+	virt.Init()
 	rec := httptest.NewRecorder()
 	r := testReq(t, "GET", "/v1/test-data", "initial body")
 	virt.ProcessRequest(rec, r, nil)

--- a/redis_logrus_hook.go
+++ b/redis_logrus_hook.go
@@ -14,9 +14,7 @@ type redisChannelHook struct {
 func newRedisHook() *redisChannelHook {
 	hook := &redisChannelHook{}
 	hook.formatter = new(logrus.JSONFormatter)
-	hook.Notifier = RedisNotificationHandler{}
 	hook.Notifier.Start()
-
 	return hook
 }
 


### PR DESCRIPTION
Like in the event handler interface, this is a method that initialises -
it doesn't create and return a new object.

While at it, remove some statements that just set struct fields to their
zero values in init funcs - that's unnecessary.