### PR TITLE
api: deduplicate getApiSpec copy-paste

### DIFF
--- a/api.go
+++ b/api.go
@@ -463,12 +463,8 @@ func handleGetAPIList() (interface{}, int) {
 }
 
 func handleGetAPI(apiID string) (interface{}, int) {
-	apisMu.RLock()
-	defer apisMu.RUnlock()
-	for _, apiSpec := range apisByID {
-		if apiSpec.APIID == apiID {
-			return apiSpec.APIDefinition, 200
-		}
+	if spec := getApiSpec(apiID); spec != nil {
+		return spec.APIDefinition, 200
 	}
 
 	log.WithFields(logrus.Fields{


### PR DESCRIPTION
handleGetAPI finds the API by ID, which is exactly what the global map
is indexed by. So there's no need to loop.

Moreover, getApiSpec already does this and takes care of the locking, so
we can just use it.