### PR TITLE
all: simplify funcs that take method and url

### DIFF
--- a/mw_method_transform.go
+++ b/mw_method_transform.go
@@ -29,7 +29,7 @@ func (t *TransformMethod) IsEnabledForSpec() bool {
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (t *TransformMethod) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	_, versionPaths, _, _ := t.Spec.GetVersionData(r)
-	found, meta := t.Spec.CheckSpecMatchesStatus(r.URL.Path, r.Method, versionPaths, MethodTransformed)
+	found, meta := t.Spec.CheckSpecMatchesStatus(r, versionPaths, MethodTransformed)
 	if !found {
 		return nil, 200
 	}

--- a/mw_modify_headers.go
+++ b/mw_modify_headers.go
@@ -87,7 +87,7 @@ func (t *TransformHeaders) ProcessRequest(w http.ResponseWriter, r *http.Request
 		t.iterateAddHeaders(vInfo.GlobalHeaders, r)
 	}
 
-	found, meta := t.Spec.CheckSpecMatchesStatus(r.URL.Path, r.Method, versionPaths, HeaderInjected)
+	found, meta := t.Spec.CheckSpecMatchesStatus(r, versionPaths, HeaderInjected)
 	if found {
 		hmeta := meta.(*apidef.HeaderInjectionMeta)
 		for _, dKey := range hmeta.DeleteHeaders {

--- a/mw_redis_cache.go
+++ b/mw_redis_cache.go
@@ -119,8 +119,8 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 	} else {
 		// New request checker, more targeted, less likely to fail
 		_, versionPaths, _, _ := m.Spec.GetVersionData(r)
-		found, _ := m.Spec.CheckSpecMatchesStatus(r.URL.Path, r.Method, versionPaths, Cached)
-		isVirtual, _ = m.Spec.CheckSpecMatchesStatus(r.URL.Path, r.Method, versionPaths, VirtualPath)
+		found, _ := m.Spec.CheckSpecMatchesStatus(r, versionPaths, Cached)
+		isVirtual, _ = m.Spec.CheckSpecMatchesStatus(r, versionPaths, VirtualPath)
 		if found {
 			stat = StatusCached
 		}

--- a/mw_request_size_limit.go
+++ b/mw_request_size_limit.go
@@ -91,7 +91,7 @@ func (t *RequestSizeLimitMiddleware) ProcessRequest(w http.ResponseWriter, r *ht
 	}
 
 	// If there's a potential match, try to match
-	found, meta := t.Spec.CheckSpecMatchesStatus(r.URL.Path, r.Method, versionPaths, RequestSizeLimit)
+	found, meta := t.Spec.CheckSpecMatchesStatus(r, versionPaths, RequestSizeLimit)
 	if found {
 		log.Debug("Request size limit matched for this URL, checking...")
 		rmeta := meta.(*apidef.RequestSizeMeta)

--- a/mw_track_endpoints.go
+++ b/mw_track_endpoints.go
@@ -18,12 +18,12 @@ func (a *TrackEndpointMiddleware) GetName() string {
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (a *TrackEndpointMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	_, versionPaths, _, _ := a.Spec.GetVersionData(r)
-	foundTracked, metaTrack := a.Spec.CheckSpecMatchesStatus(r.URL.Path, r.Method, versionPaths, RequestTracked)
+	foundTracked, metaTrack := a.Spec.CheckSpecMatchesStatus(r, versionPaths, RequestTracked)
 	if foundTracked {
 		ctxSetTrackedPath(r, metaTrack.(*apidef.TrackEndpointMeta).Path)
 	}
 
-	foundDnTrack, _ := a.Spec.CheckSpecMatchesStatus(r.URL.Path, r.Method, versionPaths, RequestNotTracked)
+	foundDnTrack, _ := a.Spec.CheckSpecMatchesStatus(r, versionPaths, RequestNotTracked)
 	if foundDnTrack {
 		ctxSetDoNotTrack(r, true)
 	}

--- a/mw_transform.go
+++ b/mw_transform.go
@@ -39,7 +39,7 @@ func (t *TransformMiddleware) IsEnabledForSpec() bool {
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (t *TransformMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	_, versionPaths, _, _ := t.Spec.GetVersionData(r)
-	found, meta := t.Spec.CheckSpecMatchesStatus(r.URL.Path, r.Method, versionPaths, Transformed)
+	found, meta := t.Spec.CheckSpecMatchesStatus(r, versionPaths, Transformed)
 	if !found {
 		return nil, 200
 	}

--- a/mw_url_rewrite.go
+++ b/mw_url_rewrite.go
@@ -141,7 +141,7 @@ func (m *URLRewriteMiddleware) CheckHostRewrite(oldPath, newTarget string, r *ht
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (m *URLRewriteMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	_, versionPaths, _, _ := m.Spec.GetVersionData(r)
-	found, meta := m.Spec.CheckSpecMatchesStatus(r.URL.Path, r.Method, versionPaths, URLRewrite)
+	found, meta := m.Spec.CheckSpecMatchesStatus(r, versionPaths, URLRewrite)
 	if !found {
 		return nil, 200
 	}

--- a/mw_virtual_endpoint.go
+++ b/mw_virtual_endpoint.go
@@ -97,7 +97,7 @@ func (d *VirtualEndpoint) IsEnabledForSpec() bool {
 
 func (d *VirtualEndpoint) ServeHTTPForCache(w http.ResponseWriter, r *http.Request) *http.Response {
 	_, versionPaths, _, _ := d.Spec.GetVersionData(r)
-	found, meta := d.Spec.CheckSpecMatchesStatus(r.URL.Path, r.Method, versionPaths, VirtualPath)
+	found, meta := d.Spec.CheckSpecMatchesStatus(r, versionPaths, VirtualPath)
 
 	if !found {
 		return nil

--- a/res_handler_header_injector.go
+++ b/res_handler_header_injector.go
@@ -31,7 +31,7 @@ func (h *HeaderInjector) HandleResponse(rw http.ResponseWriter, res *http.Respon
 	// TODO: This should only target specific paths
 
 	_, versionPaths, _, _ := h.Spec.GetVersionData(req)
-	found, meta := h.Spec.CheckSpecMatchesStatus(req.URL.Path, req.Method, versionPaths, HeaderInjectedResponse)
+	found, meta := h.Spec.CheckSpecMatchesStatus(req, versionPaths, HeaderInjectedResponse)
 	if found {
 		hmeta := meta.(*apidef.HeaderInjectionMeta)
 		for _, dKey := range hmeta.DeleteHeaders {

--- a/res_handler_transform.go
+++ b/res_handler_transform.go
@@ -36,7 +36,7 @@ func (h *ResponseTransformMiddleware) Init(c interface{}, spec *APISpec) error {
 
 func (h *ResponseTransformMiddleware) HandleResponse(rw http.ResponseWriter, res *http.Response, req *http.Request, ses *SessionState) error {
 	_, versionPaths, _, _ := h.Spec.GetVersionData(req)
-	found, meta := h.Spec.CheckSpecMatchesStatus(req.URL.Path, req.Method, versionPaths, TransformedResponse)
+	found, meta := h.Spec.CheckSpecMatchesStatus(req, versionPaths, TransformedResponse)
 	if !found {
 		return nil
 	}

--- a/tyk_reverse_proxy_clone.go
+++ b/tyk_reverse_proxy_clone.go
@@ -379,7 +379,7 @@ func (p *ReverseProxy) CheckHardTimeoutEnforced(spec *APISpec, req *http.Request
 	}
 
 	_, versionPaths, _, _ := spec.GetVersionData(req)
-	found, meta := spec.CheckSpecMatchesStatus(req.URL.Path, req.Method, versionPaths, HardTimeout)
+	found, meta := spec.CheckSpecMatchesStatus(req, versionPaths, HardTimeout)
 	if found {
 		intMeta := meta.(*int)
 		log.Debug("HARD TIMEOUT ENFORCED: ", *intMeta)
@@ -395,7 +395,7 @@ func (p *ReverseProxy) CheckCircuitBreakerEnforced(spec *APISpec, req *http.Requ
 	}
 
 	_, versionPaths, _, _ := spec.GetVersionData(req)
-	found, meta := spec.CheckSpecMatchesStatus(req.URL.Path, req.Method, versionPaths, CircuitBreaker)
+	found, meta := spec.CheckSpecMatchesStatus(req, versionPaths, CircuitBreaker)
 	if found {
 		exMeta := meta.(*ExtendedCircuitBreakerMeta)
 		log.Debug("CB Enforced for path: ", *exMeta)


### PR DESCRIPTION
Have them take an http.Request instead. Since all methods and urls came
from r.Method and r.URL.Path anyway, this simplifies the call sites too.