### PR TITLE
test: use apisMu and policiesMu in the tests too

### DIFF
--- a/api_definition_test.go
+++ b/api_definition_test.go
@@ -392,7 +392,9 @@ func TestGetAPISpecsDashboardSuccess(t *testing.T) {
 	}))
 	defer ts.Close()
 
+	apisMu.Lock()
 	apisByID = make(map[string]*APISpec)
+	apisMu.Unlock()
 
 	globalConf.UseDBAppConfigs = true
 	globalConf.AllowInsecureConfigs = true
@@ -422,9 +424,11 @@ func TestGetAPISpecsDashboardSuccess(t *testing.T) {
 
 	// Wait for the reload to finish, then check it worked
 	wg.Wait()
+	apisMu.Lock()
 	if len(apisByID) != 1 {
 		t.Error("Should return array with one spec", apisByID)
 	}
+	apisMu.Unlock()
 }
 
 func TestRoundRobin(t *testing.T) {

--- a/host_checker_test.go
+++ b/host_checker_test.go
@@ -89,12 +89,16 @@ func TestHostChecker(t *testing.T) {
 		"HostDown": {&testEventHandler{cb}},
 	}
 
+	apisMu.Lock()
 	apisByID = map[string]*APISpec{spec.APIID: spec}
+	apisMu.Unlock()
 	GlobalHostChecker.checkerMu.Lock()
 	GlobalHostChecker.checker.sampleTriggerLimit = 1
 	GlobalHostChecker.checkerMu.Unlock()
 	defer func() {
+		apisMu.Lock()
 		apisByID = make(map[string]*APISpec)
+		apisMu.Unlock()
 		GlobalHostChecker.checkerMu.Lock()
 		GlobalHostChecker.checker.sampleTriggerLimit = defaultSampletTriggerLimit
 		GlobalHostChecker.checkerMu.Unlock()

--- a/main.go
+++ b/main.go
@@ -54,12 +54,12 @@ var (
 	DashService              DashboardServiceSender
 
 	apisMu   sync.RWMutex
-	apisByID map[string]*APISpec
+	apisByID = map[string]*APISpec{}
 
 	keyGen DefaultKeyGenerator
 
 	policiesMu   sync.RWMutex
-	policiesByID map[string]Policy
+	policiesByID = map[string]Policy{}
 
 	mainRouter    *mux.Router
 	defaultRouter *mux.Router

--- a/mw_jwt_test.go
+++ b/mw_jwt_test.go
@@ -507,6 +507,7 @@ func TestJWTSessionRSAWithRawSourceOnWithClientID(t *testing.T) {
 	spec.SessionManager.ResetQuota(tokenID, session)
 	spec.SessionManager.UpdateSession(tokenID, session, 60)
 
+	policiesMu.Lock()
 	policiesByID["987654321"] = Policy{
 		ID:               "987654321",
 		OrgID:            "default",
@@ -522,6 +523,7 @@ func TestJWTSessionRSAWithRawSourceOnWithClientID(t *testing.T) {
 		Active:       true,
 		KeyExpiresIn: 60,
 	}
+	policiesMu.Unlock()
 
 	// Create the token
 	token := jwt.New(jwt.GetSigningMethod("RS512"))
@@ -557,6 +559,7 @@ func TestJWTSessionRSAWithRawSource(t *testing.T) {
 	spec := createSpecTest(t, jwtWithCentralDef)
 	spec.JWTSigningMethod = "rsa"
 
+	policiesMu.Lock()
 	policiesByID["987654321"] = Policy{
 		ID:               "987654321",
 		OrgID:            "default",
@@ -568,6 +571,7 @@ func TestJWTSessionRSAWithRawSource(t *testing.T) {
 		Active:           true,
 		KeyExpiresIn:     60,
 	}
+	policiesMu.Unlock()
 
 	// Create the token
 	token := jwt.New(jwt.GetSigningMethod("RS512"))
@@ -605,6 +609,7 @@ func TestJWTSessionRSAWithRawSourceInvalidPolicyID(t *testing.T) {
 	spec := createSpecTest(t, jwtWithCentralDef)
 	spec.JWTSigningMethod = "rsa"
 
+	policiesMu.Lock()
 	policiesByID["987654321"] = Policy{
 		ID:               "987654321",
 		OrgID:            "default",
@@ -616,6 +621,7 @@ func TestJWTSessionRSAWithRawSourceInvalidPolicyID(t *testing.T) {
 		Active:           true,
 		KeyExpiresIn:     60,
 	}
+	policiesMu.Unlock()
 
 	// Create the token
 	token := jwt.New(jwt.GetSigningMethod("RS512"))
@@ -653,6 +659,7 @@ func TestJWTSessionRSAWithJWK(t *testing.T) {
 	spec := createSpecTest(t, jwtWithJWKDef)
 	spec.JWTSigningMethod = "rsa"
 
+	policiesMu.Lock()
 	policiesByID["987654321"] = Policy{
 		ID:               "987654321",
 		OrgID:            "default",
@@ -664,6 +671,7 @@ func TestJWTSessionRSAWithJWK(t *testing.T) {
 		Active:           true,
 		KeyExpiresIn:     60,
 	}
+	policiesMu.Unlock()
 
 	// Create the token
 	token := jwt.New(jwt.GetSigningMethod("RS512"))

--- a/oauth_manager_test.go
+++ b/oauth_manager_test.go
@@ -82,7 +82,9 @@ func getOAuthChain(spec *APISpec, muxer *mux.Router) {
 	testPolicy.QuotaMax = -1
 	testPolicy.QuotaRenewalRate = 1000000000
 
+	policiesMu.Lock()
 	policiesByID["TEST-4321"] = testPolicy
+	policiesMu.Unlock()
 
 	var redirectURI string
 	// If separator is not set that means multiple redirect uris not supported


### PR DESCRIPTION
And move the tests that ensure the locks are used properly. Instead of
them being separate tests, have the test program continuously write to
the maps in the background. If any test is racy - even if it's in the
test code - then -race will catch it.

This should also make these races show up faster.

And leave the background loop with a 10ms sleep to not spin the CPU too
much. I tried with a runtime.Gosched but it still bumped the test time
from ~2s to upwards of ~3s.

Fixes #891.