### PR TITLE
all: replace New by Init in ReturningHttpHandler

### DIFF
--- a/api_loader.go
+++ b/api_loader.go
@@ -259,7 +259,7 @@ func processSpec(referenceSpec *APISpec,
 	}
 
 	// initialise the proxy
-	proxy.New(nil, referenceSpec)
+	proxy.Init(referenceSpec)
 
 	// Create the response processors
 	creeateResponseMiddlewareChain(referenceSpec)

--- a/handler_success.go
+++ b/handler_success.go
@@ -31,10 +31,10 @@ var SessionCache = cache.New(10*time.Second, 5*time.Second)
 var ExpiryCache = cache.New(600*time.Second, 10*time.Minute)
 
 type ReturningHttpHandler interface {
+	Init(*APISpec) error
 	ServeHTTP(http.ResponseWriter, *http.Request) *http.Response
 	ServeHTTPForCache(http.ResponseWriter, *http.Request) *http.Response
 	CopyResponse(io.Writer, io.Reader)
-	New(interface{}, *APISpec) (TykResponseHandler, error)
 }
 
 // BaseMiddleware wraps up the ApiSpec and Proxy objects to be included in a

--- a/multi_target_proxy_handler.go
+++ b/multi_target_proxy_handler.go
@@ -53,7 +53,7 @@ func (m *MultiTargetProxy) CopyResponse(dst io.Writer, src io.Reader) {
 	m.defaultProxy.CopyResponse(dst, src)
 }
 
-func (m *MultiTargetProxy) New(c interface{}, spec *APISpec) (TykResponseHandler, error) {
+func (m *MultiTargetProxy) Init(spec *APISpec) error {
 	m.VersionProxyMap = make(map[string]*ReverseProxy)
 	m.specReference = spec
 
@@ -64,7 +64,7 @@ func (m *MultiTargetProxy) New(c interface{}, spec *APISpec) (TykResponseHandler
 		}).Error("Couldn't parse default target URL in MultiTarget: ", err)
 	}
 	m.defaultProxy = TykNewSingleHostReverseProxy(remote, spec)
-	m.defaultProxy.New(nil, spec)
+	m.defaultProxy.Init(spec)
 
 	for versionName, versionData := range spec.VersionData.Versions {
 		if versionData.OverrideTarget == "" {
@@ -89,9 +89,9 @@ func (m *MultiTargetProxy) New(c interface{}, spec *APISpec) (TykResponseHandler
 				}).Error("Couldn't parse version target URL in MultiTarget: ", err)
 			}
 			versionProxy := TykNewSingleHostReverseProxy(versionRemote, spec)
-			versionProxy.New(nil, spec)
+			versionProxy.Init(spec)
 			m.VersionProxyMap[versionName] = versionProxy
 		}
 	}
-	return nil, nil
+	return nil
 }

--- a/tyk_reverse_proxy_clone.go
+++ b/tyk_reverse_proxy_clone.go
@@ -359,9 +359,9 @@ func (c *runOnFirstRead) Read(bs []byte) (int, error) {
 	return c.Reader.Read(bs)
 }
 
-func (p *ReverseProxy) New(c interface{}, spec *APISpec) (TykResponseHandler, error) {
+func (p *ReverseProxy) Init(spec *APISpec) error {
 	p.ErrorHandler = ErrorHandler{BaseMiddleware: &BaseMiddleware{spec, p}}
-	return nil, nil
+	return nil
 }
 
 func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) *http.Response {


### PR DESCRIPTION
Like in previous commits, to have a clearer name and remove the
duplication in the return value.

Also remove the interface{} argument, which was always nil and never
actually used.