### PR TITLE
api: fix /tyk/cache/{apiID}/ (with trailing slash)

### DIFF
--- a/api.go
+++ b/api.go
@@ -1377,7 +1377,7 @@ func invalidateCacheHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleInvalidateAPICache(apiID string) error {
-	keyPrefix := "cache-" + strings.Replace(apiID, "/", "", -1)
+	keyPrefix := "cache-" + apiID
 	matchPattern := keyPrefix + "*"
 	store := getGlobalLocalCacheStorageHandler(keyPrefix, false)
 

--- a/api_test.go
+++ b/api_test.go
@@ -443,6 +443,25 @@ func TestAPIAuthOk(t *testing.T) {
 	}
 }
 
+func TestInvalidateCache(t *testing.T) {
+	for _, suffix := range []string{"", "/"} {
+		loadSampleAPI(t, apiTestDef)
+
+		// TODO: Note that this test is fairly dumb, as it doesn't check
+		// that the cache is empty and will pass even if the apiID does
+		// not exist. This test should be improved to check that the
+		// endpoint actually did what it's supposed to.
+		rec := httptest.NewRecorder()
+		req := withAuth(testReq(t, "DELETE", "/tyk/cache/1"+suffix, nil))
+
+		mainRouter.ServeHTTP(rec, req)
+
+		if rec.Code != 200 {
+			t.Errorf("Could not invalidate cache: %v\n%v", rec.Code, rec.Body)
+		}
+	}
+}
+
 func TestGetOAuthClients(t *testing.T) {
 	testAPIID := "1"
 	var responseCode int

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -149,6 +149,8 @@ func TestMain(m *testing.M) {
 	globalConf.AnalyticsConfig.NormaliseUrls.Enabled = true
 	afterConfSetup(&globalConf)
 	initialiseSystem(nil)
+	// Small part of start()
+	loadAPIEndpoints(mainRouter)
 	if analytics.GeoIPDB == nil {
 		panic("GeoIPDB was not initialized")
 	}

--- a/main.go
+++ b/main.go
@@ -334,7 +334,7 @@ func loadAPIEndpoints(muxer *mux.Router) {
 		r.HandleFunc("/health{_:/?}", allowMethods(healthCheckhandler, "GET"))
 		r.HandleFunc("/oauth/clients/create{_:/?}", allowMethods(createOauthClient, "POST"))
 		r.HandleFunc("/oauth/refresh/{keyName}", allowMethods(invalidateOauthRefresh, "DELETE"))
-		r.HandleFunc("/cache/{apiID}", allowMethods(invalidateCacheHandler, "DELETE"))
+		r.HandleFunc("/cache/{apiID}{_:/?}", allowMethods(invalidateCacheHandler, "DELETE"))
 	} else {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",


### PR DESCRIPTION
We supported this since we were using ".*" as a regex, and removing all
slashes from the apiID later. This is sloppy and confusing, hence why I
broke it.

Do it the proper way with a route matching regex, and add a test.

Fixes #900.