### PR TITLE
api: re-allow empty keyName path argument in GETs

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -314,24 +314,26 @@ func TestKeyHandlerUpdateKey(t *testing.T) {
 }
 
 func TestKeyHandlerGetKey(t *testing.T) {
-	for _, api_id := range []string{"1", "none", ""} {
-		loadSampleAPI(t, apiTestDef)
-		createKey(t)
+	for _, pathSuffix := range []string{"/", "/1234"} {
+		for _, api_id := range []string{"1", "none", ""} {
+			loadSampleAPI(t, apiTestDef)
+			createKey(t)
 
-		uri := "/tyk/keys/1234"
+			uri := "/tyk/keys" + pathSuffix
 
-		recorder := httptest.NewRecorder()
-		param := make(url.Values)
+			recorder := httptest.NewRecorder()
+			param := make(url.Values)
 
-		if api_id != "" {
-			param.Set("api_id", api_id)
-		}
-		req := withAuth(testReq(t, "GET", uri+"?"+param.Encode(), nil))
+			if api_id != "" {
+				param.Set("api_id", api_id)
+			}
+			req := withAuth(testReq(t, "GET", uri+"?"+param.Encode(), nil))
 
-		mainRouter.ServeHTTP(recorder, req)
+			mainRouter.ServeHTTP(recorder, req)
 
-		if recorder.Code != 200 {
-			t.Error("key not requested, status error:\n", recorder.Body.String())
+			if recorder.Code != 200 {
+				t.Error("key not requested, status error:\n", recorder.Body.String())
+			}
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -326,7 +326,7 @@ func loadAPIEndpoints(muxer *mux.Router) {
 	r.HandleFunc("/reload{_:/?}", allowMethods(resetHandler(nil), "GET"))
 
 	if !isRPCMode() {
-		r.HandleFunc("/org/keys/{keyName}", allowMethods(orgHandler, "POST", "PUT", "GET", "DELETE"))
+		r.HandleFunc("/org/keys/{keyName:[^/]*}", allowMethods(orgHandler, "POST", "PUT", "GET", "DELETE"))
 		r.HandleFunc("/keys/policy/{keyName}", allowMethods(policyUpdateHandler, "POST"))
 		r.HandleFunc("/keys/create{_:/?}", allowMethods(createKeyHandler, "POST"))
 		r.HandleFunc("/apis{_:/?}", allowMethods(apiHandler, "GET", "POST", "PUT", "DELETE"))
@@ -341,9 +341,9 @@ func loadAPIEndpoints(muxer *mux.Router) {
 		}).Info("Node is slaved, REST API minimised")
 	}
 
-	r.HandleFunc("/keys/{keyName}", allowMethods(keyHandler, "POST", "PUT", "GET", "DELETE"))
+	r.HandleFunc("/keys/{keyName:[^/]*}", allowMethods(keyHandler, "POST", "PUT", "GET", "DELETE"))
 	r.HandleFunc("/oauth/clients/{apiID}", allowMethods(oAuthClientHandler, "GET", "DELETE"))
-	r.HandleFunc("/oauth/clients/{apiID}/{keyName}", allowMethods(oAuthClientHandler, "GET", "DELETE"))
+	r.HandleFunc("/oauth/clients/{apiID}/{keyName:[^/]*}", allowMethods(oAuthClientHandler, "GET", "DELETE"))
 
 	log.WithFields(logrus.Fields{
 		"prefix": "main",


### PR DESCRIPTION
When I removed all ".*" regexes from gorilla/mux, I thought the default
regex was "[^/]*" - i.e. that an empty value was accepted. But the
default value is actually "[^/]+", where an empty value doesn't match
the route.

This broke a few endpoints that used an empty keyName in GET requests to
list all the keys.

Modify one of the tests to check this.

Fixes #901.