### PR TITLE
mw: simplify urlRewrite func signature

### DIFF
--- a/mw_url_rewrite.go
+++ b/mw_url_rewrite.go
@@ -11,13 +11,14 @@ import (
 	"github.com/TykTechnologies/tyk/apidef"
 )
 
-func urlRewrite(meta *apidef.URLRewriteMeta, path string, r *http.Request) (string, error) {
+func urlRewrite(meta *apidef.URLRewriteMeta, r *http.Request) (string, error) {
 	// Find all the matching groups:
 	mp, err := regexp.Compile(meta.MatchPattern)
 	if err != nil {
 		log.Debug("Compilation error: ", err)
 		return "", err
 	}
+	path := r.URL.String()
 	log.Debug("Inbound path: ", path)
 	newpath := path
 
@@ -150,7 +151,7 @@ func (m *URLRewriteMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 	umeta := meta.(*apidef.URLRewriteMeta)
 	log.Debug(r.URL)
 	oldPath := r.URL.String()
-	p, err := urlRewrite(umeta, r.URL.String(), r)
+	p, err := urlRewrite(umeta, r)
 	if err != nil {
 		return err, 500
 	}

--- a/mw_url_rewrite_test.go
+++ b/mw_url_rewrite_test.go
@@ -15,43 +15,43 @@ func TestRewriter(t *testing.T) {
 	}{
 		{
 			"Straight",
-			"test/straight/rewrite", "change/to/me",
-			"test/straight/rewrite", "change/to/me",
+			"/test/straight/rewrite", "/change/to/me",
+			"/test/straight/rewrite", "/change/to/me",
 		},
 		{
 			"OneVal",
 			"test/val/(.*)", "change/to/$1",
-			"test/val/VALUE", "change/to/VALUE",
+			"/test/val/VALUE", "change/to/VALUE",
 		},
 		{
 			"ThreeVals",
-			"test/val/(.*)/space/(.*)/and/then/(.*)", "change/to/$1/$2/$3",
-			"test/val/ONE/space/TWO/and/then/THREE", "change/to/ONE/TWO/THREE",
+			"/test/val/(.*)/space/(.*)/and/then/(.*)", "/change/to/$1/$2/$3",
+			"/test/val/ONE/space/TWO/and/then/THREE", "/change/to/ONE/TWO/THREE",
 		},
 		{
 			"Reverse",
-			"test/val/(.*)/space/(.*)/and/then/(.*)", "change/to/$3/$2/$1",
-			"test/val/ONE/space/TWO/and/then/THREE", "change/to/THREE/TWO/ONE",
+			"/test/val/(.*)/space/(.*)/and/then/(.*)", "/change/to/$3/$2/$1",
+			"/test/val/ONE/space/TWO/and/then/THREE", "/change/to/THREE/TWO/ONE",
 		},
 		{
 			"Missing",
-			"test/val/(.*)/space/(.*)/and/then/(.*)", "change/to/$1/$2",
-			"test/val/ONE/space/TWO/and/then/THREE", "change/to/ONE/TWO",
+			"/test/val/(.*)/space/(.*)/and/then/(.*)", "/change/to/$1/$2",
+			"/test/val/ONE/space/TWO/and/then/THREE", "/change/to/ONE/TWO",
 		},
 		{
 			"MissingAgain",
-			"test/val/(.*)/space/(.*)/and/then/(.*)", "change/to/$3/$1",
-			"test/val/ONE/space/TWO/and/then/THREE", "change/to/THREE/ONE",
+			"/test/val/(.*)/space/(.*)/and/then/(.*)", "/change/to/$3/$1",
+			"/test/val/ONE/space/TWO/and/then/THREE", "/change/to/THREE/ONE",
 		},
 		{
 			"QS",
 			"(.*)", "$1&newParam=that",
-			"foo/bar?param1=this", "foo/bar?param1=this&newParam=that",
+			"/foo/bar?param1=this", "/foo/bar?param1=this&newParam=that",
 		},
 		{
 			"QS2",
-			"test/val/(.*)/space/(.*)/and/then(.*)", "change/to/$2/$1$3",
-			"test/val/ONE/space/TWO/and/then?param1=this", "change/to/TWO/ONE?param1=this",
+			"/test/val/(.*)/space/(.*)/and/then(.*)", "/change/to/$2/$1$3",
+			"/test/val/ONE/space/TWO/and/then?param1=this", "/change/to/TWO/ONE?param1=this",
 		},
 	}
 	for _, tc := range tests {
@@ -60,8 +60,8 @@ func TestRewriter(t *testing.T) {
 				MatchPattern: tc.pattern,
 				RewriteTo:    tc.to,
 			}
-			r := httptest.NewRequest("GET", "/", nil)
-			got, err := urlRewrite(&testConf, tc.in, r)
+			r := httptest.NewRequest("GET", tc.in, nil)
+			got, err := urlRewrite(&testConf, r)
 			if err != nil {
 				t.Error("compile failed:", err)
 			}


### PR DESCRIPTION
Reuse r for the path. Simplify the tests too.

The test request paths must start with a slash to be valid requests,
otherwise httptest panics.