### PR TITLE
all: replace def RawData with simpler ConfigData

### DIFF
--- a/api.go
+++ b/api.go
@@ -452,11 +452,9 @@ func handleGetAPIList() (interface{}, int) {
 	apisMu.RLock()
 	defer apisMu.RUnlock()
 	apiIDList := make([]*apidef.APIDefinition, len(apisByID))
-
 	c := 0
 	for _, apiSpec := range apisByID {
 		apiIDList[c] = apiSpec.APIDefinition
-		apiIDList[c].RawData = nil
 		c++
 	}
 	return apiIDList, 200

--- a/api_definition_test.go
+++ b/api_definition_test.go
@@ -108,8 +108,7 @@ const nonExpiringMultiDef = `{
 
 func createDefinitionFromString(defStr string) *APISpec {
 	loader := APIDefinitionLoader{}
-	def, rawDef := loader.ParseDefinition([]byte(defStr))
-	def.RawData = rawDef
+	def := loader.ParseDefinition([]byte(defStr))
 	spec := loader.MakeSpec(def)
 	spec.APIDefinition = def
 	return spec

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -351,7 +351,7 @@ type APIDefinition struct {
 	DoNotTrack        bool                   `bson:"do_not_track" json:"do_not_track"`
 	Tags              []string               `bson:"tags" json:"tags"`
 	EnableContextVars bool                   `bson:"enable_context_vars" json:"enable_context_vars"`
-	RawData           map[string]interface{} `bson:"raw_data,omitempty" json:"raw_data,omitempty"` // Not used in actual configuration, loaded by config for plugable arc
+	ConfigData        map[string]interface{} `bson:"config_data" json:"config_data"`
 }
 
 type BundleManifest struct {

--- a/mw_example_test.go
+++ b/mw_example_test.go
@@ -17,7 +17,7 @@ type modifiedMiddleware struct {
 }
 
 type modifiedMiddlewareConfig struct {
-	CustomConfigVar string `mapstructure:"custom_config_var" bson:"custom_config_var" json:"custom_config_var"`
+	CustomData string `mapstructure:"custom_data" json:"custom_data"`
 }
 
 func (m *modifiedMiddleware) GetName() string {
@@ -31,7 +31,7 @@ func (m *modifiedMiddleware) Init() {}
 func (m *modifiedMiddleware) GetConfig() (interface{}, error) {
 	var conf modifiedMiddlewareConfig
 
-	err := mapstructure.Decode(m.Spec.RawData, &conf)
+	err := mapstructure.Decode(m.Spec.ConfigData, &conf)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +42,7 @@ func (m *modifiedMiddleware) GetConfig() (interface{}, error) {
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (m *modifiedMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, conf interface{}) (error, int) {
 	mconf := conf.(modifiedMiddlewareConfig)
-	if mconf.CustomConfigVar == "error" {
+	if mconf.CustomData == "error" {
 		return errors.New("Forced error called"), 400
 	}
 	return nil, 200

--- a/plugins.go
+++ b/plugins.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/mitchellh/mapstructure"
 	"github.com/robertkrimen/otto"
 	_ "github.com/robertkrimen/otto/underscore"
 
@@ -59,17 +58,13 @@ func (d *DynamicMiddleware) GetName() string {
 	return "DynamicMiddleware"
 }
 
-type configDataDef struct {
-	ConfigData map[string]string `mapstructure:"config_data" bson:"config_data" json:"config_data"`
-}
-
 func jsonConfigData(spec *APISpec) string {
-	var conf configDataDef
-	if err := mapstructure.Decode(spec.RawData, &conf); err != nil {
-		log.Error("Failed to parse configuration data: ", err)
-		return ""
+	m := map[string]interface{}{
+		// For backwards compatibility within 2.x.
+		// TODO: simplify or refactor in 3.x or later.
+		"config_data": spec.ConfigData,
 	}
-	bs, err := json.Marshal(conf)
+	bs, err := json.Marshal(m)
 	if err != nil {
 		log.Error("Failed to encode configuration data: ", err)
 		return ""

--- a/plugins_test.go
+++ b/plugins_test.go
@@ -101,10 +101,8 @@ leakMid.NewProcessRequest(function(request, session) {
 
 func TestJSVMConfigData(t *testing.T) {
 	spec := &APISpec{APIDefinition: &apidef.APIDefinition{}}
-	spec.RawData = map[string]interface{}{
-		"config_data": map[string]interface{}{
-			"foo": "bar",
-		},
+	spec.ConfigData = map[string]interface{}{
+		"foo": "bar",
 	}
 	const js = `
 var testJSVMData = new TykJS.TykMiddleware.NewMiddleware({});


### PR DESCRIPTION
Before this commit, RawData was an entire copy of the APIDefinition as a
map[string]interface{}, all the way down. This was only used in a few
middlewares to obtain certain structured data via mapstructure.

In practice, this was only used to obtain the config_data field of type
map[string]interface{}.

Remove the entire copy of APIDefinition in memory and just add a
ConfigData field of type map[string]interface{}. This way, we can also
get rid of all the code that was gluing RawData to its final purpose.

This is in line with the changes being made in other repos to add
config_data to the API definition schema. We don't want to allow
arbitrary root fields - we only want to allow config_data, at least for
now. This makes sure that the gateway doesn't support anything else
unless we meant to.