### PR TITLE
revproxy: give it a better file name

### DIFF
--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -2,7 +2,12 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// HTTP reverse proxy handler
+// Fork of Go's net/http/httputil/reverseproxy.go with multiple changes,
+// including:
+//
+// * caching
+// * load balancing
+// * service discovery
 
 package main
 


### PR DESCRIPTION
This is the tyk repo, so a tyk_ prefix is silly. _clone is also
redundant.

Add some details as to the purpose of the fork in the file's content
too.