### PR TITLE
mw: add a body transform unit test

### DIFF
--- a/mw_transform_test.go
+++ b/mw_transform_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"io/ioutil"
+	"testing"
+	"text/template"
+
+	"github.com/TykTechnologies/tyk/apidef"
+)
+
+func TestTransformNonAscii(t *testing.T) {
+	in := `<?xml version="1.0" encoding="utf-8"?>
+<names>
+	<name>Jyväskylä</name>
+	<name>Hyvinkää</name>
+</names>`
+	want := `["Jyväskylä", "Hyvinkää"]`
+	tmpl := `[{{range $x, $s := .names.name}}"{{$s}}"{{if not $x}}, {{end}}{{end}}]`
+	r := testReq(t, "GET", "/", in)
+	tmeta := &TransformSpec{}
+	tmeta.TemplateData.Input = apidef.RequestXML
+	tmeta.Template = template.Must(template.New("blob").Parse(tmpl))
+	if err := transformBody(r, tmeta, false); err != nil {
+		t.Fatalf("wanted nil error, got %v", err)
+	}
+	gotBs, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(gotBs); got != want {
+		t.Fatalf("wanted body %q, got %q", want, got)
+	}
+}


### PR DESCRIPTION
Added this unit test while investigating #642. Still useful as a unit
test.

Also make this middleware error if the input type is unknown.