### PR TITLE
api: deduplicate baseMid from mw chain lines

### DIFF
--- a/api_loader.go
+++ b/api_loader.go
@@ -286,19 +286,19 @@ func processSpec(referenceSpec *APISpec,
 		handleCORS(&chainArray, referenceSpec)
 
 		baseChainArray := []alice.Constructor{}
-		AppendMiddleware(&baseChainArray, &RateCheckMW{BaseMiddleware: baseMid}, baseMid)
-		AppendMiddleware(&baseChainArray, &IPWhiteListMiddleware{BaseMiddleware: baseMid}, baseMid)
-		AppendMiddleware(&baseChainArray, &OrganizationMonitor{BaseMiddleware: baseMid}, baseMid)
-		AppendMiddleware(&baseChainArray, &MiddlewareContextVars{BaseMiddleware: baseMid}, baseMid)
-		AppendMiddleware(&baseChainArray, &VersionCheck{BaseMiddleware: baseMid}, baseMid)
-		AppendMiddleware(&baseChainArray, &RequestSizeLimitMiddleware{baseMid}, baseMid)
-		AppendMiddleware(&baseChainArray, &TrackEndpointMiddleware{baseMid}, baseMid)
-		AppendMiddleware(&baseChainArray, &TransformMiddleware{baseMid}, baseMid)
-		AppendMiddleware(&baseChainArray, &TransformHeaders{BaseMiddleware: baseMid}, baseMid)
-		AppendMiddleware(&baseChainArray, &RedisCacheMiddleware{BaseMiddleware: baseMid, CacheStore: cacheStore}, baseMid)
-		AppendMiddleware(&baseChainArray, &VirtualEndpoint{BaseMiddleware: baseMid}, baseMid)
-		AppendMiddleware(&baseChainArray, &URLRewriteMiddleware{BaseMiddleware: baseMid}, baseMid)
-		AppendMiddleware(&baseChainArray, &TransformMethod{BaseMiddleware: baseMid}, baseMid)
+		AppendMiddleware(&baseChainArray, &RateCheckMW{BaseMiddleware: baseMid})
+		AppendMiddleware(&baseChainArray, &IPWhiteListMiddleware{BaseMiddleware: baseMid})
+		AppendMiddleware(&baseChainArray, &OrganizationMonitor{BaseMiddleware: baseMid})
+		AppendMiddleware(&baseChainArray, &MiddlewareContextVars{BaseMiddleware: baseMid})
+		AppendMiddleware(&baseChainArray, &VersionCheck{BaseMiddleware: baseMid})
+		AppendMiddleware(&baseChainArray, &RequestSizeLimitMiddleware{baseMid})
+		AppendMiddleware(&baseChainArray, &TrackEndpointMiddleware{baseMid})
+		AppendMiddleware(&baseChainArray, &TransformMiddleware{baseMid})
+		AppendMiddleware(&baseChainArray, &TransformHeaders{BaseMiddleware: baseMid})
+		AppendMiddleware(&baseChainArray, &RedisCacheMiddleware{BaseMiddleware: baseMid, CacheStore: cacheStore})
+		AppendMiddleware(&baseChainArray, &VirtualEndpoint{BaseMiddleware: baseMid})
+		AppendMiddleware(&baseChainArray, &URLRewriteMiddleware{BaseMiddleware: baseMid})
+		AppendMiddleware(&baseChainArray, &TransformMethod{BaseMiddleware: baseMid})
 
 		log.Debug(referenceSpec.Name, " - CHAIN SIZE: ", len(baseChainArray))
 
@@ -308,7 +308,7 @@ func processSpec(referenceSpec *APISpec,
 					"prefix":   "coprocess",
 					"api_name": referenceSpec.Name,
 				}).Debug("Registering coprocess middleware, hook name: ", obj.Name, "hook type: Pre", ", driver: ", mwDriver)
-				AppendMiddleware(&chainArray, &CoProcessMiddleware{baseMid, coprocess.HookType_Pre, obj.Name, mwDriver}, baseMid)
+				AppendMiddleware(&chainArray, &CoProcessMiddleware{baseMid, coprocess.HookType_Pre, obj.Name, mwDriver})
 			} else {
 				chainArray = append(chainArray, CreateDynamicMiddleware(obj.Name, true, obj.RequireSession, baseMid))
 			}
@@ -322,7 +322,7 @@ func processSpec(referenceSpec *APISpec,
 					"prefix":   "coprocess",
 					"api_name": referenceSpec.Name,
 				}).Debug("Registering coprocess middleware, hook name: ", obj.Name, "hook type: Post", ", driver: ", mwDriver)
-				AppendMiddleware(&chainArray, &CoProcessMiddleware{baseMid, coprocess.HookType_Post, obj.Name, mwDriver}, baseMid)
+				AppendMiddleware(&chainArray, &CoProcessMiddleware{baseMid, coprocess.HookType_Post, obj.Name, mwDriver})
 			} else {
 				chainArray = append(chainArray, CreateDynamicMiddleware(obj.Name, false, obj.RequireSession, baseMid))
 			}
@@ -338,13 +338,13 @@ func processSpec(referenceSpec *APISpec,
 		handleCORS(&chainArray, referenceSpec)
 
 		var baseChainArray_PreAuth []alice.Constructor
-		AppendMiddleware(&baseChainArray_PreAuth, &RateCheckMW{BaseMiddleware: baseMid}, baseMid)
-		AppendMiddleware(&baseChainArray_PreAuth, &IPWhiteListMiddleware{BaseMiddleware: baseMid}, baseMid)
-		AppendMiddleware(&baseChainArray_PreAuth, &OrganizationMonitor{BaseMiddleware: baseMid}, baseMid)
-		AppendMiddleware(&baseChainArray_PreAuth, &VersionCheck{BaseMiddleware: baseMid}, baseMid)
-		AppendMiddleware(&baseChainArray_PreAuth, &RequestSizeLimitMiddleware{baseMid}, baseMid)
-		AppendMiddleware(&baseChainArray_PreAuth, &MiddlewareContextVars{BaseMiddleware: baseMid}, baseMid)
-		AppendMiddleware(&baseChainArray_PreAuth, &TrackEndpointMiddleware{baseMid}, baseMid)
+		AppendMiddleware(&baseChainArray_PreAuth, &RateCheckMW{BaseMiddleware: baseMid})
+		AppendMiddleware(&baseChainArray_PreAuth, &IPWhiteListMiddleware{BaseMiddleware: baseMid})
+		AppendMiddleware(&baseChainArray_PreAuth, &OrganizationMonitor{BaseMiddleware: baseMid})
+		AppendMiddleware(&baseChainArray_PreAuth, &VersionCheck{BaseMiddleware: baseMid})
+		AppendMiddleware(&baseChainArray_PreAuth, &RequestSizeLimitMiddleware{baseMid})
+		AppendMiddleware(&baseChainArray_PreAuth, &MiddlewareContextVars{BaseMiddleware: baseMid})
+		AppendMiddleware(&baseChainArray_PreAuth, &TrackEndpointMiddleware{baseMid})
 
 		// Add pre-process MW
 		for _, obj := range mwPreFuncs {
@@ -353,7 +353,7 @@ func processSpec(referenceSpec *APISpec,
 					"prefix":   "coprocess",
 					"api_name": referenceSpec.Name,
 				}).Debug("Registering coprocess middleware, hook name: ", obj.Name, "hook type: Pre", ", driver: ", mwDriver)
-				AppendMiddleware(&chainArray, &CoProcessMiddleware{baseMid, coprocess.HookType_Pre, obj.Name, mwDriver}, baseMid)
+				AppendMiddleware(&chainArray, &CoProcessMiddleware{baseMid, coprocess.HookType_Pre, obj.Name, mwDriver})
 			} else {
 				chainArray = append(chainArray, CreateDynamicMiddleware(obj.Name, true, obj.RequireSession, baseMid))
 			}
@@ -369,7 +369,7 @@ func processSpec(referenceSpec *APISpec,
 				"prefix":   "main",
 				"api_name": referenceSpec.Name,
 			}).Info("Checking security policy: OAuth")
-			authArray = append(authArray, CreateMiddleware(&Oauth2KeyExists{baseMid}, baseMid))
+			authArray = append(authArray, CreateMiddleware(&Oauth2KeyExists{baseMid}))
 
 		}
 
@@ -386,7 +386,7 @@ func processSpec(referenceSpec *APISpec,
 				"prefix":   "main",
 				"api_name": referenceSpec.Name,
 			}).Info("Checking security policy: Basic")
-			authArray = append(authArray, CreateMiddleware(&BasicAuthKeyIsValid{baseMid}, baseMid))
+			authArray = append(authArray, CreateMiddleware(&BasicAuthKeyIsValid{baseMid}))
 		}
 
 		if referenceSpec.EnableSignatureChecking {
@@ -395,7 +395,7 @@ func processSpec(referenceSpec *APISpec,
 				"prefix":   "main",
 				"api_name": referenceSpec.Name,
 			}).Info("Checking security policy: HMAC")
-			authArray = append(authArray, CreateMiddleware(&HMACMiddleware{BaseMiddleware: baseMid}, baseMid))
+			authArray = append(authArray, CreateMiddleware(&HMACMiddleware{BaseMiddleware: baseMid}))
 		}
 
 		if referenceSpec.EnableJWT {
@@ -404,7 +404,7 @@ func processSpec(referenceSpec *APISpec,
 				"prefix":   "main",
 				"api_name": referenceSpec.Name,
 			}).Info("Checking security policy: JWT")
-			authArray = append(authArray, CreateMiddleware(&JWTMiddleware{baseMid}, baseMid))
+			authArray = append(authArray, CreateMiddleware(&JWTMiddleware{baseMid}))
 		}
 
 		if referenceSpec.UseOpenID {
@@ -415,7 +415,7 @@ func processSpec(referenceSpec *APISpec,
 			}).Info("Checking security policy: OpenID")
 
 			// initialise the OID configuration on this reference Spec
-			authArray = append(authArray, CreateMiddleware(&OpenIDMW{BaseMiddleware: baseMid}, baseMid))
+			authArray = append(authArray, CreateMiddleware(&OpenIDMW{BaseMiddleware: baseMid}))
 		}
 
 		if useCoProcessAuth {
@@ -432,7 +432,7 @@ func processSpec(referenceSpec *APISpec,
 
 			if useCoProcessAuth {
 				newExtractor(referenceSpec, baseMid)
-				AppendMiddleware(&authArray, &CoProcessMiddleware{baseMid, coprocess.HookType_CustomKeyCheck, mwAuthCheckFunc.Name, mwDriver}, baseMid)
+				AppendMiddleware(&authArray, &CoProcessMiddleware{baseMid, coprocess.HookType_CustomKeyCheck, mwAuthCheckFunc.Name, mwDriver})
 			}
 		}
 
@@ -450,7 +450,7 @@ func processSpec(referenceSpec *APISpec,
 				"prefix":   "main",
 				"api_name": referenceSpec.Name,
 			}).Info("Checking security policy: Token")
-			authArray = append(authArray, CreateMiddleware(&AuthKey{baseMid}, baseMid))
+			authArray = append(authArray, CreateMiddleware(&AuthKey{baseMid}))
 		}
 
 		chainArray = append(chainArray, authArray...)
@@ -460,20 +460,20 @@ func processSpec(referenceSpec *APISpec,
 				"prefix":   "coprocess",
 				"api_name": referenceSpec.Name,
 			}).Debug("Registering coprocess middleware, hook name: ", obj.Name, "hook type: Pre", ", driver: ", mwDriver)
-			AppendMiddleware(&chainArray, &CoProcessMiddleware{baseMid, coprocess.HookType_PostKeyAuth, obj.Name, mwDriver}, baseMid)
+			AppendMiddleware(&chainArray, &CoProcessMiddleware{baseMid, coprocess.HookType_PostKeyAuth, obj.Name, mwDriver})
 		}
 
 		var baseChainArray_PostAuth []alice.Constructor
-		AppendMiddleware(&baseChainArray_PostAuth, &KeyExpired{baseMid}, baseMid)
-		AppendMiddleware(&baseChainArray_PostAuth, &AccessRightsCheck{baseMid}, baseMid)
-		AppendMiddleware(&baseChainArray_PostAuth, &RateLimitAndQuotaCheck{baseMid}, baseMid)
-		AppendMiddleware(&baseChainArray_PostAuth, &GranularAccessMiddleware{baseMid}, baseMid)
-		AppendMiddleware(&baseChainArray_PostAuth, &TransformMiddleware{baseMid}, baseMid)
-		AppendMiddleware(&baseChainArray_PostAuth, &TransformHeaders{BaseMiddleware: baseMid}, baseMid)
-		AppendMiddleware(&baseChainArray_PostAuth, &URLRewriteMiddleware{BaseMiddleware: baseMid}, baseMid)
-		AppendMiddleware(&baseChainArray_PostAuth, &RedisCacheMiddleware{BaseMiddleware: baseMid, CacheStore: cacheStore}, baseMid)
-		AppendMiddleware(&baseChainArray_PostAuth, &TransformMethod{BaseMiddleware: baseMid}, baseMid)
-		AppendMiddleware(&baseChainArray_PostAuth, &VirtualEndpoint{BaseMiddleware: baseMid}, baseMid)
+		AppendMiddleware(&baseChainArray_PostAuth, &KeyExpired{baseMid})
+		AppendMiddleware(&baseChainArray_PostAuth, &AccessRightsCheck{baseMid})
+		AppendMiddleware(&baseChainArray_PostAuth, &RateLimitAndQuotaCheck{baseMid})
+		AppendMiddleware(&baseChainArray_PostAuth, &GranularAccessMiddleware{baseMid})
+		AppendMiddleware(&baseChainArray_PostAuth, &TransformMiddleware{baseMid})
+		AppendMiddleware(&baseChainArray_PostAuth, &TransformHeaders{BaseMiddleware: baseMid})
+		AppendMiddleware(&baseChainArray_PostAuth, &URLRewriteMiddleware{BaseMiddleware: baseMid})
+		AppendMiddleware(&baseChainArray_PostAuth, &RedisCacheMiddleware{BaseMiddleware: baseMid, CacheStore: cacheStore})
+		AppendMiddleware(&baseChainArray_PostAuth, &TransformMethod{BaseMiddleware: baseMid})
+		AppendMiddleware(&baseChainArray_PostAuth, &VirtualEndpoint{BaseMiddleware: baseMid})
 
 		chainArray = append(chainArray, baseChainArray_PostAuth...)
 
@@ -483,7 +483,7 @@ func processSpec(referenceSpec *APISpec,
 					"prefix":   "coprocess",
 					"api_name": referenceSpec.Name,
 				}).Debug("Registering coprocess middleware, hook name: ", obj.Name, "hook type: Post", ", driver: ", mwDriver)
-				AppendMiddleware(&chainArray, &CoProcessMiddleware{baseMid, coprocess.HookType_Post, obj.Name, mwDriver}, baseMid)
+				AppendMiddleware(&chainArray, &CoProcessMiddleware{baseMid, coprocess.HookType_Post, obj.Name, mwDriver})
 			} else {
 				chainArray = append(chainArray, CreateDynamicMiddleware(obj.Name, false, obj.RequireSession, baseMid))
 			}
@@ -494,20 +494,20 @@ func processSpec(referenceSpec *APISpec,
 			"api_name": referenceSpec.Name,
 		}).Debug("Custom middleware completed processing")
 
-		// Use CreateMiddleware(&ModifiedMiddleware{baseMid}, baseMid)  to run custom middleware
+		// Use CreateMiddleware(&ModifiedMiddleware{baseMid})  to run custom middleware
 		chain = alice.New(chainArray...).Then(&DummyProxyHandler{SH: SuccessHandler{baseMid}})
 
 		log.Debug("Chain completed")
 
 		userCheckHandler := UserRatesCheck()
 		simpleChain_PreAuth := []alice.Constructor{
-			CreateMiddleware(&IPWhiteListMiddleware{baseMid}, baseMid),
-			CreateMiddleware(&OrganizationMonitor{BaseMiddleware: baseMid}, baseMid),
-			CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid}, baseMid)}
+			CreateMiddleware(&IPWhiteListMiddleware{baseMid}),
+			CreateMiddleware(&OrganizationMonitor{BaseMiddleware: baseMid}),
+			CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid})}
 
 		simpleChain_PostAuth := []alice.Constructor{
-			CreateMiddleware(&KeyExpired{baseMid}, baseMid),
-			CreateMiddleware(&AccessRightsCheck{baseMid}, baseMid)}
+			CreateMiddleware(&KeyExpired{baseMid}),
+			CreateMiddleware(&AccessRightsCheck{baseMid})}
 
 		var fullSimpleChain []alice.Constructor
 		fullSimpleChain = append(fullSimpleChain, simpleChain_PreAuth...)

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -286,14 +286,14 @@ func getChain(spec *APISpec) http.Handler {
 	proxyHandler := ProxyHandler(proxy, spec)
 	baseMid := &BaseMiddleware{spec, proxy}
 	chain := alice.New(
-		CreateMiddleware(&IPWhiteListMiddleware{baseMid}, baseMid),
-		CreateMiddleware(&MiddlewareContextVars{BaseMiddleware: baseMid}, baseMid),
-		CreateMiddleware(&AuthKey{baseMid}, baseMid),
-		CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid}, baseMid),
-		CreateMiddleware(&KeyExpired{baseMid}, baseMid),
-		CreateMiddleware(&AccessRightsCheck{baseMid}, baseMid),
-		CreateMiddleware(&RateLimitAndQuotaCheck{baseMid}, baseMid),
-		CreateMiddleware(&TransformHeaders{baseMid}, baseMid)).Then(proxyHandler)
+		CreateMiddleware(&IPWhiteListMiddleware{baseMid}),
+		CreateMiddleware(&MiddlewareContextVars{BaseMiddleware: baseMid}),
+		CreateMiddleware(&AuthKey{baseMid}),
+		CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid}),
+		CreateMiddleware(&KeyExpired{baseMid}),
+		CreateMiddleware(&AccessRightsCheck{baseMid}),
+		CreateMiddleware(&RateLimitAndQuotaCheck{baseMid}),
+		CreateMiddleware(&TransformHeaders{baseMid})).Then(proxyHandler)
 
 	return chain
 }

--- a/handler_success.go
+++ b/handler_success.go
@@ -44,6 +44,8 @@ type BaseMiddleware struct {
 	Proxy ReturningHttpHandler
 }
 
+func (t *BaseMiddleware) Base() *BaseMiddleware { return t }
+
 func (t *BaseMiddleware) Init() {}
 func (t *BaseMiddleware) IsEnabledForSpec() bool {
 	return true

--- a/multiauth_test.go
+++ b/multiauth_test.go
@@ -71,13 +71,13 @@ func getMultiAuthStandardAndBasicAuthChain(spec *APISpec) http.Handler {
 	proxyHandler := ProxyHandler(proxy, spec)
 	baseMid := &BaseMiddleware{spec, proxy}
 	chain := alice.New(
-		CreateMiddleware(&IPWhiteListMiddleware{baseMid}, baseMid),
-		CreateMiddleware(&BasicAuthKeyIsValid{baseMid}, baseMid),
-		CreateMiddleware(&AuthKey{baseMid}, baseMid),
-		CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid}, baseMid),
-		CreateMiddleware(&KeyExpired{baseMid}, baseMid),
-		CreateMiddleware(&AccessRightsCheck{baseMid}, baseMid),
-		CreateMiddleware(&RateLimitAndQuotaCheck{baseMid}, baseMid)).Then(proxyHandler)
+		CreateMiddleware(&IPWhiteListMiddleware{baseMid}),
+		CreateMiddleware(&BasicAuthKeyIsValid{baseMid}),
+		CreateMiddleware(&AuthKey{baseMid}),
+		CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid}),
+		CreateMiddleware(&KeyExpired{baseMid}),
+		CreateMiddleware(&AccessRightsCheck{baseMid}),
+		CreateMiddleware(&RateLimitAndQuotaCheck{baseMid})).Then(proxyHandler)
 
 	return chain
 }

--- a/mw_auth_key_test.go
+++ b/mw_auth_key_test.go
@@ -32,12 +32,12 @@ func getAuthKeyChain(spec *APISpec) http.Handler {
 	proxyHandler := ProxyHandler(proxy, spec)
 	baseMid := &BaseMiddleware{spec, proxy}
 	chain := alice.New(
-		CreateMiddleware(&IPWhiteListMiddleware{baseMid}, baseMid),
-		CreateMiddleware(&AuthKey{baseMid}, baseMid),
-		CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid}, baseMid),
-		CreateMiddleware(&KeyExpired{baseMid}, baseMid),
-		CreateMiddleware(&AccessRightsCheck{baseMid}, baseMid),
-		CreateMiddleware(&RateLimitAndQuotaCheck{baseMid}, baseMid)).Then(proxyHandler)
+		CreateMiddleware(&IPWhiteListMiddleware{baseMid}),
+		CreateMiddleware(&AuthKey{baseMid}),
+		CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid}),
+		CreateMiddleware(&KeyExpired{baseMid}),
+		CreateMiddleware(&AccessRightsCheck{baseMid}),
+		CreateMiddleware(&RateLimitAndQuotaCheck{baseMid})).Then(proxyHandler)
 
 	return chain
 }

--- a/mw_basic_auth_test.go
+++ b/mw_basic_auth_test.go
@@ -54,12 +54,12 @@ func getBasicAuthChain(spec *APISpec) http.Handler {
 	proxyHandler := ProxyHandler(proxy, spec)
 	baseMid := &BaseMiddleware{spec, proxy}
 	chain := alice.New(
-		CreateMiddleware(&IPWhiteListMiddleware{baseMid}, baseMid),
-		CreateMiddleware(&BasicAuthKeyIsValid{baseMid}, baseMid),
-		CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid}, baseMid),
-		CreateMiddleware(&KeyExpired{baseMid}, baseMid),
-		CreateMiddleware(&AccessRightsCheck{baseMid}, baseMid),
-		CreateMiddleware(&RateLimitAndQuotaCheck{baseMid}, baseMid)).Then(proxyHandler)
+		CreateMiddleware(&IPWhiteListMiddleware{baseMid}),
+		CreateMiddleware(&BasicAuthKeyIsValid{baseMid}),
+		CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid}),
+		CreateMiddleware(&KeyExpired{baseMid}),
+		CreateMiddleware(&AccessRightsCheck{baseMid}),
+		CreateMiddleware(&RateLimitAndQuotaCheck{baseMid})).Then(proxyHandler)
 
 	return chain
 }

--- a/mw_hmac_test.go
+++ b/mw_hmac_test.go
@@ -59,12 +59,12 @@ func getHMACAuthChain(spec *APISpec) http.Handler {
 	proxyHandler := ProxyHandler(proxy, spec)
 	baseMid := &BaseMiddleware{spec, proxy}
 	chain := alice.New(
-		CreateMiddleware(&IPWhiteListMiddleware{baseMid}, baseMid),
-		CreateMiddleware(&HMACMiddleware{BaseMiddleware: baseMid}, baseMid),
-		CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid}, baseMid),
-		CreateMiddleware(&KeyExpired{baseMid}, baseMid),
-		CreateMiddleware(&AccessRightsCheck{baseMid}, baseMid),
-		CreateMiddleware(&RateLimitAndQuotaCheck{baseMid}, baseMid)).Then(proxyHandler)
+		CreateMiddleware(&IPWhiteListMiddleware{baseMid}),
+		CreateMiddleware(&HMACMiddleware{BaseMiddleware: baseMid}),
+		CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid}),
+		CreateMiddleware(&KeyExpired{baseMid}),
+		CreateMiddleware(&AccessRightsCheck{baseMid}),
+		CreateMiddleware(&RateLimitAndQuotaCheck{baseMid})).Then(proxyHandler)
 
 	return chain
 }

--- a/mw_jwt_test.go
+++ b/mw_jwt_test.go
@@ -185,12 +185,12 @@ func getJWTChain(spec *APISpec) http.Handler {
 	proxyHandler := ProxyHandler(proxy, spec)
 	baseMid := &BaseMiddleware{spec, proxy}
 	chain := alice.New(
-		CreateMiddleware(&IPWhiteListMiddleware{baseMid}, baseMid),
-		CreateMiddleware(&JWTMiddleware{baseMid}, baseMid),
-		CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid}, baseMid),
-		CreateMiddleware(&KeyExpired{baseMid}, baseMid),
-		CreateMiddleware(&AccessRightsCheck{baseMid}, baseMid),
-		CreateMiddleware(&RateLimitAndQuotaCheck{baseMid}, baseMid)).Then(proxyHandler)
+		CreateMiddleware(&IPWhiteListMiddleware{baseMid}),
+		CreateMiddleware(&JWTMiddleware{baseMid}),
+		CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid}),
+		CreateMiddleware(&KeyExpired{baseMid}),
+		CreateMiddleware(&AccessRightsCheck{baseMid}),
+		CreateMiddleware(&RateLimitAndQuotaCheck{baseMid})).Then(proxyHandler)
 
 	return chain
 }

--- a/oauth_manager_test.go
+++ b/oauth_manager_test.go
@@ -108,11 +108,11 @@ func getOAuthChain(spec *APISpec, muxer *mux.Router) {
 	proxyHandler := ProxyHandler(proxy, spec)
 	baseMid := &BaseMiddleware{spec, proxy}
 	chain := alice.New(
-		CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid}, baseMid),
-		CreateMiddleware(&Oauth2KeyExists{baseMid}, baseMid),
-		CreateMiddleware(&KeyExpired{baseMid}, baseMid),
-		CreateMiddleware(&AccessRightsCheck{baseMid}, baseMid),
-		CreateMiddleware(&RateLimitAndQuotaCheck{baseMid}, baseMid)).Then(proxyHandler)
+		CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid}),
+		CreateMiddleware(&Oauth2KeyExists{baseMid}),
+		CreateMiddleware(&KeyExpired{baseMid}),
+		CreateMiddleware(&AccessRightsCheck{baseMid}),
+		CreateMiddleware(&RateLimitAndQuotaCheck{baseMid})).Then(proxyHandler)
 
 	muxer.Handle(spec.Proxy.ListenPath, chain)
 }


### PR DESCRIPTION
This was all because CreateMiddleware needed access to Spec, which is in
BaseMiddleware.

Make it accessible in the middleware interface instead with Base().
Remove the BaseMiddleware parameters where funcs already get a
TykMiddleware.