### PR TITLE
coprocess: fix CreateMiddleware broken call site

### DIFF
--- a/coprocess.go
+++ b/coprocess.go
@@ -43,7 +43,7 @@ func CreateCoProcessMiddleware(hookName string, hookType coprocess.HookType, mwD
 		MiddlewareDriver: mwDriver,
 	}
 
-	return CreateMiddleware(dMiddleware, baseMid)
+	return CreateMiddleware(dMiddleware)
 }
 
 func doCoprocessReload() {


### PR DESCRIPTION
After the last commit. We forgot about both build tags and CI.