### PR TITLE
loader: simplify method and var names

### DIFF
--- a/main.go
+++ b/main.go
@@ -211,16 +211,14 @@ func buildConnStr(resource string) string {
 	return connStr
 }
 
-// Pull API Specs from configuration
-var APILoader = APIDefinitionLoader{}
-
 func getAPISpecs() []*APISpec {
+	loader := APIDefinitionLoader{}
 	var apiSpecs []*APISpec
 
 	if globalConf.UseDBAppConfigs {
 
 		connStr := buildConnStr("/system/apis")
-		apiSpecs = APILoader.LoadDefinitionsFromDashboardService(connStr, globalConf.NodeSecret)
+		apiSpecs = loader.FromDashboardService(connStr, globalConf.NodeSecret)
 
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
@@ -230,9 +228,9 @@ func getAPISpecs() []*APISpec {
 			"prefix": "main",
 		}).Debug("Using RPC Configuration")
 
-		apiSpecs = APILoader.LoadDefinitionsFromRPC(globalConf.SlaveOptions.RPCKey)
+		apiSpecs = loader.FromRPC(globalConf.SlaveOptions.RPCKey)
 	} else {
-		apiSpecs = APILoader.LoadDefinitions(globalConf.AppPath)
+		apiSpecs = loader.FromDir(globalConf.AppPath)
 	}
 
 	log.WithFields(logrus.Fields{


### PR DESCRIPTION
The name of the type is APIDefinitionLoader, so there's no need for the
methods to have a LoadDefinitions prefix. Also, make the method without
suffix be FromDir, as that's descriptive of what it actually does.

Also make the receivers not be pointers - it's unnecessary, as the type
is an empty struct.

Finally, remove APILoader as a global - it's completely unnecessary.