### PR TITLE
hostcheck: fix test ticker flake

### DIFF
--- a/host_checker.go
+++ b/host_checker.go
@@ -76,6 +76,9 @@ func (h *HostUptimeChecker) getStaggeredTime() time.Duration {
 
 func (h *HostUptimeChecker) HostCheckLoop() {
 	for !h.stopLoop {
+		if runningTests {
+			<-hostCheckTicker
+		}
 		h.resetListMu.Lock()
 		if h.doResetList {
 			if h.newList != nil {
@@ -93,9 +96,7 @@ func (h *HostUptimeChecker) HostCheckLoop() {
 			}
 		}
 
-		if runningTests {
-			<-hostCheckTicker
-		} else {
+		if !runningTests {
 			time.Sleep(h.getStaggeredTime())
 		}
 	}


### PR DESCRIPTION
When running the tests, the host checker uses a ticker channel so that
the tests can control when the uptime checks happen without relying on
times and sleeps.

However, the host checker only blocked waiting for the tick after doing
a host check. In other words, the first host check would happen without
waiting for a tick.

This could lead to a test receiving two host check events when it
expected exactly one.

Move the blocking channel receive to not do that first host check at a
random time.

Fixes #919.