### PR TITLE
mw: bump hmac clock skew in tests to 5s

### DIFF
--- a/mw_hmac_test.go
+++ b/mw_hmac_test.go
@@ -20,7 +20,7 @@ const hmacAuthDef = `{
 	"api_id": "1",
 	"org_id": "default",
 	"enable_signature_checking": true,
-	"hmac_allowed_clock_skew": 1000,
+	"hmac_allowed_clock_skew": 5000,
 	"auth": {
 		"auth_header_name": "authorization"
 	},


### PR DESCRIPTION
1s is usually enough, but on Travis the public machines are busy and the
tests might run slow since they're low on CPU time.

Bump it to 5s to make these flakes much less likely.

There's probably a way to do this better (e.g. not using time.Now) but
this is good enough for now.

Fixes #429.