### PR TITLE
coprocess_bundle: add HTTPS scheme

### DIFF
--- a/coprocess_bundle.go
+++ b/coprocess_bundle.go
@@ -191,6 +191,10 @@ func fetchBundle(spec *APISpec) (bundle Bundle, err error) {
 		getter = &HTTPBundleGetter{
 			URL: bundleURL,
 		}
+	case "https":
+		getter = &HTTPBundleGetter{
+			URL: bundleURL,
+		}
 	default:
 		err = errors.New("Unknown URL scheme")
 	}


### PR DESCRIPTION
Fixes #925, for a patch it might be ok to use the same Getter but if we add additional SSL related options for HTTPS bundle URLs, it would be better to implement its own `BundleGetter`.
This was reported by a user in the forum.