### PR TITLE
all: remove Get prefix from getter func names

### DIFF
--- a/api.go
+++ b/api.go
@@ -209,7 +209,7 @@ func GetKeyDetail(key, apiID string) (SessionState, bool) {
 		sessionManager = spec.SessionManager
 	}
 
-	return sessionManager.GetSessionDetail(key)
+	return sessionManager.SessionDetail(key)
 }
 
 func handleAddOrUpdate(keyName string, r *http.Request) (interface{}, int) {
@@ -287,7 +287,7 @@ func handleGetDetail(sessionKey, apiID string) (interface{}, int) {
 		sessionManager = spec.SessionManager
 	}
 
-	session, ok := sessionManager.GetSessionDetail(sessionKey)
+	session, ok := sessionManager.SessionDetail(sessionKey)
 	if !ok {
 		return apiError("Key not found"), 404
 	}
@@ -316,7 +316,7 @@ func handleGetAllKeys(filter, apiID string) (interface{}, int) {
 		sessionManager = spec.SessionManager
 	}
 
-	sessions := sessionManager.GetSessions(filter)
+	sessions := sessionManager.Sessions(filter)
 
 	fixed_sessions := make([]string, 0)
 	for _, s := range sessions {
@@ -796,7 +796,7 @@ func handleGetOrgDetail(orgID string) (interface{}, int) {
 		return apiError("Org not found"), 404
 	}
 
-	session, ok := spec.OrgSessionManager.GetSessionDetail(orgID)
+	session, ok := spec.OrgSessionManager.SessionDetail(orgID)
 	if !ok {
 		log.WithFields(logrus.Fields{
 			"prefix": "api",
@@ -820,7 +820,7 @@ func handleGetAllOrgKeys(filter string) (interface{}, int) {
 		return apiError("ORG not found"), 404
 	}
 
-	sessions := spec.OrgSessionManager.GetSessions(filter)
+	sessions := spec.OrgSessionManager.Sessions(filter)
 	fixed_sessions := make([]string, 0)
 	for _, s := range sessions {
 		if !strings.Contains(s, QuotaKeyPrefix) && !strings.Contains(s, RateLimitKeyPrefix) {
@@ -1322,7 +1322,7 @@ func healthCheckhandler(w http.ResponseWriter, r *http.Request) {
 		doJSONWrite(w, 404, apiError("API ID not found"))
 		return
 	}
-	health, _ := apiSpec.Health.GetApiHealthValues()
+	health, _ := apiSpec.Health.ApiHealthValues()
 	doJSONWrite(w, 200, health)
 }
 

--- a/api_definition.go
+++ b/api_definition.go
@@ -172,7 +172,7 @@ func (a APIDefinitionLoader) MakeSpec(def *apidef.APIDefinition) *APISpec {
 		log.Debug("FOUND EVENTS TO INIT")
 		for _, handlerConf := range eventHandlerConfs {
 			log.Debug("CREATING EVENT HANDLERS")
-			eventHandlerInstance, err := GetEventHandlerByName(handlerConf, spec)
+			eventHandlerInstance, err := EventHandlerByName(handlerConf, spec)
 
 			if err != nil {
 				log.Error("Failed to init event handler: ", err)
@@ -984,7 +984,7 @@ func (a *APISpec) IsThisAPIVersionExpired(versionDef *apidef.VersionInfo) (bool,
 // data and return a RequestStatus that describes the status of the
 // request
 func (a *APISpec) IsRequestValid(r *http.Request) (bool, RequestStatus, interface{}) {
-	versionMetaData, versionPaths, whiteListStatus, stat := a.GetVersionData(r)
+	versionMetaData, versionPaths, whiteListStatus, stat := a.Version(r)
 
 	// Screwed up version info - fail and pass through
 	if stat != StatusOk {
@@ -1025,9 +1025,9 @@ func (a *APISpec) IsRequestValid(r *http.Request) (bool, RequestStatus, interfac
 
 }
 
-// GetVersionData attempts to extract the version data from a request, depending on where it is stored in the
+// Version attempts to extract the version data from a request, depending on where it is stored in the
 // request (currently only "header" is supported)
-func (a *APISpec) GetVersionData(r *http.Request) (*apidef.VersionInfo, []URLSpec, bool, RequestStatus) {
+func (a *APISpec) Version(r *http.Request) (*apidef.VersionInfo, []URLSpec, bool, RequestStatus) {
 	var version apidef.VersionInfo
 	var versionRxPaths []URLSpec
 	var versionWLStatus bool
@@ -1104,7 +1104,7 @@ func (r *RoundRobin) SetMax(max int) {
 
 func (r *RoundRobin) SetLen(len int) { r.SetMax(len - 1) }
 
-func (r *RoundRobin) GetPos() int {
+func (r *RoundRobin) Pos() int {
 	cur := r.pos
 	if r.pos++; r.pos > r.max {
 		r.pos = 0

--- a/api_definition_test.go
+++ b/api_definition_test.go
@@ -434,7 +434,7 @@ func TestRoundRobin(t *testing.T) {
 	rr.SetMax(2)
 
 	for _, want := range []int{0, 1, 2, 0} {
-		if got := rr.GetPos(); got != want {
+		if got := rr.Pos(); got != want {
 			t.Errorf("RR Pos wrong: want %d got %d", want, got)
 		}
 	}

--- a/api_healthcheck.go
+++ b/api_healthcheck.go
@@ -18,7 +18,7 @@ const (
 
 type HealthChecker interface {
 	Init(StorageHandler)
-	GetApiHealthValues() (HealthCheckValues, error)
+	ApiHealthValues() (HealthCheckValues, error)
 	StoreCounterVal(HealthPrefix, string)
 }
 
@@ -94,7 +94,7 @@ func roundValue(untruncated float64) float64 {
 	return float64(int(untruncated*100)) / 100
 }
 
-func (h *DefaultHealthChecker) GetApiHealthValues() (HealthCheckValues, error) {
+func (h *DefaultHealthChecker) ApiHealthValues() (HealthCheckValues, error) {
 	values := HealthCheckValues{}
 
 	// Get the counted / average values

--- a/auth_manager.go
+++ b/auth_manager.go
@@ -27,8 +27,8 @@ type SessionHandler interface {
 	Init(store StorageHandler)
 	UpdateSession(keyName string, session *SessionState, resetTTLTo int64) error
 	RemoveSession(keyName string)
-	GetSessionDetail(keyName string) (SessionState, bool)
-	GetSessions(filter string) []string
+	SessionDetail(keyName string) (SessionState, bool)
+	Sessions(filter string) []string
 	GetStore() StorageHandler
 	ResetQuota(string, *SessionState)
 }
@@ -125,8 +125,8 @@ func (b *DefaultSessionManager) RemoveSession(keyName string) {
 	b.Store.DeleteKey(keyName)
 }
 
-// GetSessionDetail returns the session detail using the storage engine (either in memory or Redis)
-func (b *DefaultSessionManager) GetSessionDetail(keyName string) (SessionState, bool) {
+// SessionDetail returns the session detail using the storage engine (either in memory or Redis)
+func (b *DefaultSessionManager) SessionDetail(keyName string) (SessionState, bool) {
 	jsonKeyVal, err := b.Store.GetKey(keyName)
 	var session SessionState
 	if err != nil {
@@ -148,8 +148,8 @@ func (b *DefaultSessionManager) GetSessionDetail(keyName string) (SessionState, 
 	return session, true
 }
 
-// GetSessions returns all sessions in the key store that match a filter key (a prefix)
-func (b *DefaultSessionManager) GetSessions(filter string) []string {
+// Sessions returns all sessions in the key store that match a filter key (a prefix)
+func (b *DefaultSessionManager) Sessions(filter string) []string {
 	return b.Store.GetKeys(filter)
 }
 

--- a/coprocess.go
+++ b/coprocess.go
@@ -30,7 +30,7 @@ type CoProcessMiddleware struct {
 	MiddlewareDriver apidef.MiddlewareDriver
 }
 
-func (mw *CoProcessMiddleware) GetName() string {
+func (mw *CoProcessMiddleware) Name() string {
 	return "CoProcessMiddleware"
 }
 
@@ -62,8 +62,8 @@ type CoProcessor struct {
 	Middleware *CoProcessMiddleware
 }
 
-// GetObjectFromRequest constructs a CoProcessObject from a given http.Request.
-func (c *CoProcessor) GetObjectFromRequest(r *http.Request) *coprocess.Object {
+// ObjectFromRequest constructs a CoProcessObject from a given http.Request.
+func (c *CoProcessor) ObjectFromRequest(r *http.Request) *coprocess.Object {
 	var body string
 	if r.Body == nil {
 		body = ""
@@ -232,7 +232,7 @@ func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 		// HookType: coprocess.PreHook,
 	}
 
-	object := coProcessor.GetObjectFromRequest(r)
+	object := coProcessor.ObjectFromRequest(r)
 
 	returnObject, err := coProcessor.Dispatch(object)
 	if err != nil {
@@ -252,7 +252,7 @@ func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 
 		log.WithFields(logrus.Fields{
 			"path":   r.URL.Path,
-			"origin": GetIPFromRequest(r),
+			"origin": requestIP(r),
 			"key":    token,
 		}).Info("Attempted access with invalid key.")
 

--- a/coprocess_dummy.go
+++ b/coprocess_dummy.go
@@ -35,7 +35,7 @@ type CoProcessMiddleware struct {
 	MiddlewareDriver apidef.MiddlewareDriver
 }
 
-func (m *CoProcessMiddleware) GetName() string {
+func (m *CoProcessMiddleware) Name() string {
 	return "CoProcessMiddlewareDummy"
 }
 

--- a/coprocess_id_extractor.go
+++ b/coprocess_id_extractor.go
@@ -84,7 +84,7 @@ func (e *BaseExtractor) ExtractBody(r *http.Request) (bodyValue string, err erro
 func (e *BaseExtractor) Error(r *http.Request, err error, message string) (returnOverrides ReturnOverrides) {
 	log.WithFields(logrus.Fields{
 		"path":   r.URL.Path,
-		"origin": GetIPFromRequest(r),
+		"origin": requestIP(r),
 	}).Info("Extractor error: ", message, ", ", err)
 
 	return ReturnOverrides{

--- a/event_handler_webhooks.go
+++ b/event_handler_webhooks.go
@@ -167,7 +167,7 @@ func (w *WebHookHandler) checkURL(r string) bool {
 	return true
 }
 
-func (w *WebHookHandler) GetChecksum(reqBody string) (string, error) {
+func (w *WebHookHandler) Checksum(reqBody string) (string, error) {
 	// We do this twice because fuck it.
 	localRequest, _ := http.NewRequest(string(w.getRequestMethod(w.conf.Method)), w.conf.TargetPath, strings.NewReader(reqBody))
 	h := md5.New()
@@ -213,7 +213,7 @@ func (w *WebHookHandler) HandleEvent(em config.EventMessage) {
 	}
 
 	// Generate signature for request
-	reqChecksum, _ := w.GetChecksum(reqBody)
+	reqChecksum, _ := w.Checksum(reqBody)
 
 	// Check request velocity for this hook (wasHookFired())
 	if w.WasHookFired(reqChecksum) {

--- a/event_handler_webhooks_test.go
+++ b/event_handler_webhooks_test.go
@@ -50,7 +50,7 @@ func TestNewInvlalid(t *testing.T) {
 	}
 }
 
-func TestGetChecksum(t *testing.T) {
+func TestChecksum(t *testing.T) {
 	rBody := `{
 		"event": "QuotaExceeded",
 		"message": "Key Quota Limit Exceeded",
@@ -61,7 +61,7 @@ func TestGetChecksum(t *testing.T) {
 	}`
 
 	hook := createGetHandler()
-	checksum, err := hook.GetChecksum(rBody)
+	checksum, err := hook.Checksum(rBody)
 
 	if err != nil {
 		t.Error("Checksum should not have failed with good objet and body")
@@ -135,7 +135,7 @@ func TestGet(t *testing.T) {
 	}
 	body, _ := eventHandler.CreateBody(eventMessage)
 
-	checksum, _ := eventHandler.GetChecksum(body)
+	checksum, _ := eventHandler.Checksum(body)
 	eventHandler.HandleEvent(eventMessage)
 
 	if wasFired := eventHandler.WasHookFired(checksum); !wasFired {
@@ -170,7 +170,7 @@ func TestPost(t *testing.T) {
 
 	body, _ := eventHandler.CreateBody(eventMessage)
 
-	checksum, _ := eventHandler.GetChecksum(body)
+	checksum, _ := eventHandler.Checksum(body)
 	eventHandler.HandleEvent(eventMessage)
 
 	if wasFired := eventHandler.WasHookFired(checksum); !wasFired {

--- a/event_system.go
+++ b/event_system.go
@@ -119,8 +119,8 @@ func EncodeRequestToEvent(r *http.Request) string {
 	return base64.StdEncoding.EncodeToString(asBytes.Bytes())
 }
 
-// GetEventHandlerByName is a convenience function to get event handler instances from an API Definition
-func GetEventHandlerByName(handlerConf apidef.EventHandlerTriggerConfig, spec *APISpec) (config.TykEventHandler, error) {
+// EventHandlerByName is a convenience function to get event handler instances from an API Definition
+func EventHandlerByName(handlerConf apidef.EventHandlerTriggerConfig, spec *APISpec) (config.TykEventHandler, error) {
 
 	conf := handlerConf.HandlerMeta
 	switch handlerConf.Handler {
@@ -218,7 +218,7 @@ func InitGenericEventHandlers(theseEvents apidef.EventHandlerMetaConfig) map[api
 		log.Debug("FOUND EVENTS TO INIT")
 		for _, handlerConf := range eventHandlerConfs {
 			log.Debug("CREATING EVENT HANDLERS")
-			eventHandlerInstance, err := GetEventHandlerByName(handlerConf, nil)
+			eventHandlerInstance, err := EventHandlerByName(handlerConf, nil)
 
 			if err != nil {
 				log.Error("Failed to init event handler: ", err)

--- a/handler_error.go
+++ b/handler_error.go
@@ -80,7 +80,7 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 	token := ctxGetAuthToken(r)
 	var alias string
 
-	ip := GetIPFromRequest(r)
+	ip := requestIP(r)
 	if globalConf.StoreAnalytics(ip) {
 
 		t := time.Now()
@@ -160,7 +160,7 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 
 		expiresAfter := e.Spec.ExpireAnalyticsAfter
 		if globalConf.EnforceOrgDataAge {
-			orgExpireDataTime := e.GetOrgSessionExpiry(e.Spec.OrgID)
+			orgExpireDataTime := e.OrgSessionExpiry(e.Spec.OrgID)
 
 			if orgExpireDataTime > 0 {
 				expiresAfter = orgExpireDataTime

--- a/handler_websocket.go
+++ b/handler_websocket.go
@@ -60,7 +60,7 @@ func (ws *WSDialer) RoundTrip(req *http.Request) (*http.Response, error) {
 		http.Error(ws.RW, "Error contacting backend server.", 500)
 		log.WithFields(logrus.Fields{
 			"path":   target,
-			"origin": GetIPFromRequest(req),
+			"origin": requestIP(req),
 		}).Error("Error dialing websocket backend", target, ": ", err)
 		return nil, err
 	}
@@ -76,7 +76,7 @@ func (ws *WSDialer) RoundTrip(req *http.Request) (*http.Response, error) {
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"path":   req.URL.Path,
-			"origin": GetIPFromRequest(req),
+			"origin": requestIP(req),
 		}).Errorf("Hijack error: %v", err)
 		return nil, err
 	}
@@ -85,7 +85,7 @@ func (ws *WSDialer) RoundTrip(req *http.Request) (*http.Response, error) {
 	if err := req.Write(d); err != nil {
 		log.WithFields(logrus.Fields{
 			"path":   req.URL.Path,
-			"origin": GetIPFromRequest(req),
+			"origin": requestIP(req),
 		}).Errorf("Error copying request to target: %v", err)
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func (ws *WSDialer) RoundTrip(req *http.Request) (*http.Response, error) {
 		err = cerr
 		log.WithFields(logrus.Fields{
 			"path":   req.URL.Path,
-			"origin": GetIPFromRequest(req),
+			"origin": requestIP(req),
 		}).Errorf("Error transmitting request: %v", err)
 	}
 

--- a/host_checker_manager.go
+++ b/host_checker_manager.go
@@ -379,14 +379,14 @@ func (hc *HostCheckerManager) UpdateTrackingListByAPIID(hd []HostData, apiId str
 	}).Info("--- Queued tracking list update for API: ", apiId)
 }
 
-func (hc *HostCheckerManager) GetListFromService(apiID string) ([]HostData, error) {
+func (hc *HostCheckerManager) ListFromService(apiID string) ([]HostData, error) {
 	spec := getApiSpec(apiID)
 	if spec == nil {
 		return nil, errors.New("API ID not found in register")
 	}
 	sd := ServiceDiscovery{}
 	sd.Init(&spec.UptimeTests.Config.ServiceDiscovery)
-	data, err := sd.GetTarget(spec.UptimeTests.Config.ServiceDiscovery.QueryEndpoint)
+	data, err := sd.Target(spec.UptimeTests.Config.ServiceDiscovery.QueryEndpoint)
 
 	if err != nil {
 		log.WithFields(logrus.Fields{
@@ -423,7 +423,7 @@ func (hc *HostCheckerManager) DoServiceDiscoveryListUpdateForID(apiID string) {
 	log.WithFields(logrus.Fields{
 		"prefix": "host-check-mgr",
 	}).Debug("[HOST CHECKER MANAGER] Getting data from service")
-	hostData, err := hc.GetListFromService(apiID)
+	hostData, err := hc.ListFromService(apiID)
 	if err != nil {
 		return
 	}
@@ -512,7 +512,7 @@ func SetCheckerHostList() {
 	apisMu.RLock()
 	for _, spec := range apisByID {
 		if spec.UptimeTests.Config.ServiceDiscovery.UseDiscoveryService {
-			hostList, err := GlobalHostChecker.GetListFromService(spec.APIID)
+			hostList, err := GlobalHostChecker.ListFromService(spec.APIID)
 			if err == nil {
 				hostList = append(hostList, hostList...)
 				for _, t := range hostList {

--- a/host_checker_test.go
+++ b/host_checker_test.go
@@ -133,7 +133,7 @@ func TestHostChecker(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		targetWG.Add(1)
 		go func() {
-			host := GetNextTarget(spec.Proxy.StructuredTargetList, spec)
+			host := nextTarget(spec.Proxy.StructuredTargetList, spec)
 			if host != testHttpAny {
 				t.Error("Should return only active host, got", host)
 			}

--- a/main.go
+++ b/main.go
@@ -507,7 +507,7 @@ func creeateResponseMiddlewareChain(referenceSpec *APISpec) {
 
 	responseChain := make([]TykResponseHandler, len(referenceSpec.ResponseProcessors))
 	for i, processorDetail := range referenceSpec.ResponseProcessors {
-		processor, err := GetResponseProcessorByName(processorDetail.Name)
+		processor, err := ResponseProcessorByName(processorDetail.Name)
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "main",

--- a/middleware.go
+++ b/middleware.go
@@ -18,10 +18,10 @@ var GlobalRate = ratecounter.NewRateCounter(1 * time.Second)
 type TykMiddleware interface {
 	Init()
 	Base() *BaseMiddleware
-	GetConfig() (interface{}, error)
+	Config() (interface{}, error)
 	ProcessRequest(w http.ResponseWriter, r *http.Request, conf interface{}) (error, int) // Handles request
 	IsEnabledForSpec() bool
-	GetName() string
+	Name() string
 }
 
 func CreateDynamicMiddleware(name string, isPre, useSession bool, baseMid *BaseMiddleware) func(http.Handler) http.Handler {
@@ -45,7 +45,7 @@ func CreateMiddleware(mw TykMiddleware) func(http.Handler) http.Handler {
 	mw.Init()
 
 	// Pull the configuration
-	mwConf, err := mw.GetConfig()
+	mwConf, err := mw.Config()
 	if err != nil {
 		log.Fatal("[Middleware] Configuration load failed")
 	}
@@ -59,9 +59,9 @@ func CreateMiddleware(mw TykMiddleware) func(http.Handler) http.Handler {
 				"endpoint": r.URL.Path,
 				"raw_url":  r.URL.String(),
 				"size":     strconv.Itoa(int(r.ContentLength)),
-				"mw_name":  mw.GetName(),
+				"mw_name":  mw.Name(),
 			}
-			eventName := mw.GetName() + "." + "executed"
+			eventName := mw.Name() + "." + "executed"
 			job.EventKv("executed", meta)
 			job.EventKv(eventName, meta)
 			startTime := time.Now()
@@ -124,7 +124,7 @@ type TykResponseHandler interface {
 	HandleResponse(http.ResponseWriter, *http.Response, *http.Request, *SessionState) error
 }
 
-func GetResponseProcessorByName(name string) (TykResponseHandler, error) {
+func ResponseProcessorByName(name string) (TykResponseHandler, error) {
 	switch name {
 	case "header_injector":
 		return &HeaderInjector{}, nil

--- a/multi_target_proxy_handler.go
+++ b/multi_target_proxy_handler.go
@@ -16,7 +16,7 @@ type MultiTargetProxy struct {
 }
 
 func (m *MultiTargetProxy) getProxyForRequest(r *http.Request) (*ReverseProxy, error) {
-	version, _, _, _ := m.specReference.GetVersionData(r)
+	version, _, _, _ := m.specReference.Version(r)
 	proxy, found := m.VersionProxyMap[version.Name]
 
 	if !found {

--- a/mw_access_rights.go
+++ b/mw_access_rights.go
@@ -14,7 +14,7 @@ type AccessRightsCheck struct {
 	*BaseMiddleware
 }
 
-func (a *AccessRightsCheck) GetName() string {
+func (a *AccessRightsCheck) Name() string {
 	return "AccessRightsCheck"
 }
 
@@ -31,7 +31,7 @@ func (a *AccessRightsCheck) ProcessRequest(w http.ResponseWriter, r *http.Reques
 		if !apiExists {
 			log.WithFields(logrus.Fields{
 				"path":      r.URL.Path,
-				"origin":    GetIPFromRequest(r),
+				"origin":    requestIP(r),
 				"key":       token,
 				"api_found": false,
 			}).Info("Attempted access to unauthorised API.")
@@ -57,7 +57,7 @@ func (a *AccessRightsCheck) ProcessRequest(w http.ResponseWriter, r *http.Reques
 			// Not found? Bounce
 			log.WithFields(logrus.Fields{
 				"path":          r.URL.Path,
-				"origin":        GetIPFromRequest(r),
+				"origin":        requestIP(r),
 				"key":           token,
 				"api_found":     true,
 				"version_found": false,

--- a/mw_auth_key.go
+++ b/mw_auth_key.go
@@ -16,7 +16,7 @@ type AuthKey struct {
 	*BaseMiddleware
 }
 
-func (k *AuthKey) GetName() string {
+func (k *AuthKey) Name() string {
 	return "AuthKey"
 }
 
@@ -72,7 +72,7 @@ func (k *AuthKey) ProcessRequest(w http.ResponseWriter, r *http.Request, _ inter
 		// No header value, fail
 		log.WithFields(logrus.Fields{
 			"path":   r.URL.Path,
-			"origin": GetIPFromRequest(r),
+			"origin": requestIP(r),
 		}).Info("Attempted access with malformed header, no auth header found.")
 
 		return errors.New("Authorization field missing"), 401
@@ -86,7 +86,7 @@ func (k *AuthKey) ProcessRequest(w http.ResponseWriter, r *http.Request, _ inter
 	if !keyExists {
 		log.WithFields(logrus.Fields{
 			"path":   r.URL.Path,
-			"origin": GetIPFromRequest(r),
+			"origin": requestIP(r),
 			"key":    key,
 		}).Info("Attempted access with non-existent key.")
 
@@ -120,7 +120,7 @@ func AuthFailed(m *BaseMiddleware, r *http.Request, token string) {
 	m.FireEvent(EventAuthFailure, EventAuthFailureMeta{
 		EventMetaDefault: EventMetaDefault{Message: "Auth Failure", OriginatingRequest: EncodeRequestToEvent(r)},
 		Path:             r.URL.Path,
-		Origin:           GetIPFromRequest(r),
+		Origin:           requestIP(r),
 		Key:              token,
 	})
 }

--- a/mw_basic_auth.go
+++ b/mw_basic_auth.go
@@ -17,7 +17,7 @@ type BasicAuthKeyIsValid struct {
 	*BaseMiddleware
 }
 
-func (k *BasicAuthKeyIsValid) GetName() string {
+func (k *BasicAuthKeyIsValid) Name() string {
 	return "BasicAuthKeyIsValid"
 }
 
@@ -36,7 +36,7 @@ func (k *BasicAuthKeyIsValid) ProcessRequest(w http.ResponseWriter, r *http.Requ
 		// No header value, fail
 		log.WithFields(logrus.Fields{
 			"path":   r.URL.Path,
-			"origin": GetIPFromRequest(r),
+			"origin": requestIP(r),
 		}).Info("Attempted access with malformed header, no auth header found.")
 
 		return k.requestForBasicAuth(w, "Authorization field missing")
@@ -47,7 +47,7 @@ func (k *BasicAuthKeyIsValid) ProcessRequest(w http.ResponseWriter, r *http.Requ
 		// Header malformed
 		log.WithFields(logrus.Fields{
 			"path":   r.URL.Path,
-			"origin": GetIPFromRequest(r),
+			"origin": requestIP(r),
 		}).Info("Attempted access with malformed header, header not in basic auth format.")
 
 		return errors.New("Attempted access with malformed header, header not in basic auth format"), 400
@@ -58,7 +58,7 @@ func (k *BasicAuthKeyIsValid) ProcessRequest(w http.ResponseWriter, r *http.Requ
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"path":   r.URL.Path,
-			"origin": GetIPFromRequest(r),
+			"origin": requestIP(r),
 		}).Info("Base64 Decoding failed of basic auth data: ", err)
 
 		return errors.New("Attempted access with malformed header, auth data not encoded correctly"), 400
@@ -69,7 +69,7 @@ func (k *BasicAuthKeyIsValid) ProcessRequest(w http.ResponseWriter, r *http.Requ
 		// Header malformed
 		log.WithFields(logrus.Fields{
 			"path":   r.URL.Path,
-			"origin": GetIPFromRequest(r),
+			"origin": requestIP(r),
 		}).Info("Attempted access with malformed header, values not in basic auth format.")
 
 		return errors.New("Attempted access with malformed header, values not in basic auth format"), 400
@@ -81,7 +81,7 @@ func (k *BasicAuthKeyIsValid) ProcessRequest(w http.ResponseWriter, r *http.Requ
 	if !keyExists {
 		log.WithFields(logrus.Fields{
 			"path":   r.URL.Path,
-			"origin": GetIPFromRequest(r),
+			"origin": requestIP(r),
 			"key":    keyName,
 		}).Info("Attempted access with non-existent user.")
 
@@ -113,7 +113,7 @@ func (k *BasicAuthKeyIsValid) ProcessRequest(w http.ResponseWriter, r *http.Requ
 	if !passMatch {
 		log.WithFields(logrus.Fields{
 			"path":   r.URL.Path,
-			"origin": GetIPFromRequest(r),
+			"origin": requestIP(r),
 			"key":    keyName,
 		}).Info("Attempted access with existing user but failed password check.")
 

--- a/mw_context_vars.go
+++ b/mw_context_vars.go
@@ -11,7 +11,7 @@ type MiddlewareContextVars struct {
 	*BaseMiddleware
 }
 
-func (m *MiddlewareContextVars) GetName() string {
+func (m *MiddlewareContextVars) Name() string {
 	return "MiddlewareContextVars"
 }
 

--- a/mw_example_test.go
+++ b/mw_example_test.go
@@ -20,15 +20,15 @@ type modifiedMiddlewareConfig struct {
 	CustomData string `mapstructure:"custom_data" json:"custom_data"`
 }
 
-func (m *modifiedMiddleware) GetName() string {
+func (m *modifiedMiddleware) Name() string {
 	return "modifiedMiddleware"
 }
 
 // Init lets you do any initialisations for the object can be done here
 func (m *modifiedMiddleware) Init() {}
 
-// GetConfig retrieves the configuration from the API config - we user mapstructure for this for simplicity
-func (m *modifiedMiddleware) GetConfig() (interface{}, error) {
+// Config retrieves the configuration from the API config - we user mapstructure for this for simplicity
+func (m *modifiedMiddleware) Config() (interface{}, error) {
 	var conf modifiedMiddlewareConfig
 
 	err := mapstructure.Decode(m.Spec.ConfigData, &conf)

--- a/mw_granular_access.go
+++ b/mw_granular_access.go
@@ -13,7 +13,7 @@ type GranularAccessMiddleware struct {
 	*BaseMiddleware
 }
 
-func (m *GranularAccessMiddleware) GetName() string {
+func (m *GranularAccessMiddleware) Name() string {
 	return "GranularAccessMiddleware"
 }
 
@@ -56,7 +56,7 @@ func (m *GranularAccessMiddleware) ProcessRequest(w http.ResponseWriter, r *http
 	// No paths matched, disallow
 	log.WithFields(logrus.Fields{
 		"path":      r.URL.Path,
-		"origin":    GetIPFromRequest(r),
+		"origin":    requestIP(r),
 		"key":       token,
 		"api_found": false,
 	}).Info("Attempted access to unauthorised endpoint (Granular).")

--- a/mw_hmac.go
+++ b/mw_hmac.go
@@ -26,7 +26,7 @@ type HMACMiddleware struct {
 	lowercasePattern *regexp.Regexp
 }
 
-func (hm *HMACMiddleware) GetName() string {
+func (hm *HMACMiddleware) Name() string {
 	return "HMAC"
 }
 

--- a/mw_ip_whitelist.go
+++ b/mw_ip_whitelist.go
@@ -11,7 +11,7 @@ type IPWhiteListMiddleware struct {
 	*BaseMiddleware
 }
 
-func (i *IPWhiteListMiddleware) GetName() string {
+func (i *IPWhiteListMiddleware) Name() string {
 	return "IPWhiteListMiddleware"
 }
 
@@ -26,7 +26,7 @@ func (i *IPWhiteListMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Re
 		return nil, 200
 	}
 
-	remoteIP := net.ParseIP(GetIPFromRequest(r))
+	remoteIP := net.ParseIP(requestIP(r))
 
 	// Enabled, check incoming IP address
 	for _, ip := range i.Spec.AllowedIPs {

--- a/mw_jwt.go
+++ b/mw_jwt.go
@@ -22,7 +22,7 @@ type JWTMiddleware struct {
 	*BaseMiddleware
 }
 
-func (k *JWTMiddleware) GetName() string {
+func (k *JWTMiddleware) Name() string {
 	return "JWTMiddleware"
 }
 
@@ -322,7 +322,7 @@ func (k *JWTMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _
 		// No header value, fail
 		log.WithFields(logrus.Fields{
 			"path":   r.URL.Path,
-			"origin": GetIPFromRequest(r),
+			"origin": requestIP(r),
 		}).Info("Attempted access with malformed header, no JWT auth header found.")
 
 		log.Debug("Looked in: ", config.AuthHeaderName)
@@ -390,13 +390,13 @@ func (k *JWTMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _
 	}
 	log.WithFields(logrus.Fields{
 		"path":   r.URL.Path,
-		"origin": GetIPFromRequest(r),
+		"origin": requestIP(r),
 	}).Info("Attempted JWT access with non-existent key.")
 
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"path":   r.URL.Path,
-			"origin": GetIPFromRequest(r),
+			"origin": requestIP(r),
 		}).Error("JWT validation error: ", err)
 	}
 

--- a/mw_key_expired_check.go
+++ b/mw_key_expired_check.go
@@ -12,7 +12,7 @@ type KeyExpired struct {
 	*BaseMiddleware
 }
 
-func (k *KeyExpired) GetName() string {
+func (k *KeyExpired) Name() string {
 	return "KeyExpired"
 }
 
@@ -27,7 +27,7 @@ func (k *KeyExpired) ProcessRequest(w http.ResponseWriter, r *http.Request, _ in
 	if session.IsInactive {
 		log.WithFields(logrus.Fields{
 			"path":   r.URL.Path,
-			"origin": GetIPFromRequest(r),
+			"origin": requestIP(r),
 			"key":    token,
 		}).Info("Attempted access from inactive key.")
 
@@ -35,7 +35,7 @@ func (k *KeyExpired) ProcessRequest(w http.ResponseWriter, r *http.Request, _ in
 		k.FireEvent(EventKeyExpired, EventKeyExpiredMeta{
 			EventMetaDefault: EventMetaDefault{Message: "Attempted access from inactive key.", OriginatingRequest: EncodeRequestToEvent(r)},
 			Path:             r.URL.Path,
-			Origin:           GetIPFromRequest(r),
+			Origin:           requestIP(r),
 			Key:              token,
 		})
 
@@ -50,7 +50,7 @@ func (k *KeyExpired) ProcessRequest(w http.ResponseWriter, r *http.Request, _ in
 	if keyExpired {
 		log.WithFields(logrus.Fields{
 			"path":   r.URL.Path,
-			"origin": GetIPFromRequest(r),
+			"origin": requestIP(r),
 			"key":    token,
 		}).Info("Attempted access from expired key.")
 
@@ -58,7 +58,7 @@ func (k *KeyExpired) ProcessRequest(w http.ResponseWriter, r *http.Request, _ in
 		k.FireEvent(EventKeyExpired, EventKeyExpiredMeta{
 			EventMetaDefault: EventMetaDefault{Message: "Attempted access from expired key."},
 			Path:             r.URL.Path,
-			Origin:           GetIPFromRequest(r),
+			Origin:           requestIP(r),
 			Key:              token,
 		})
 

--- a/mw_method_transform.go
+++ b/mw_method_transform.go
@@ -13,7 +13,7 @@ type TransformMethod struct {
 	*BaseMiddleware
 }
 
-func (t *TransformMethod) GetName() string {
+func (t *TransformMethod) Name() string {
 	return "TransformMethod"
 }
 
@@ -28,7 +28,7 @@ func (t *TransformMethod) IsEnabledForSpec() bool {
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (t *TransformMethod) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
-	_, versionPaths, _, _ := t.Spec.GetVersionData(r)
+	_, versionPaths, _, _ := t.Spec.Version(r)
 	found, meta := t.Spec.CheckSpecMatchesStatus(r, versionPaths, MethodTransformed)
 	if !found {
 		return nil, 200

--- a/mw_modify_headers.go
+++ b/mw_modify_headers.go
@@ -17,7 +17,7 @@ const (
 	contextLabel = "$tyk_context."
 )
 
-func (t *TransformHeaders) GetName() string {
+func (t *TransformHeaders) Name() string {
 	return "TransformHeaders"
 }
 
@@ -74,7 +74,7 @@ func (t *TransformHeaders) iterateAddHeaders(kv map[string]string, r *http.Reque
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (t *TransformHeaders) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
-	vInfo, versionPaths, _, _ := t.Spec.GetVersionData(r)
+	vInfo, versionPaths, _, _ := t.Spec.Version(r)
 
 	// Manage global headers first - remove
 	for _, gdKey := range vInfo.GlobalHeadersRemove {

--- a/mw_oauth2_key_exists.go
+++ b/mw_oauth2_key_exists.go
@@ -16,7 +16,7 @@ type Oauth2KeyExists struct {
 	*BaseMiddleware
 }
 
-func (k *Oauth2KeyExists) GetName() string {
+func (k *Oauth2KeyExists) Name() string {
 	return "Oauth2KeyExists"
 }
 
@@ -29,7 +29,7 @@ func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request,
 	if len(parts) < 2 {
 		log.WithFields(logrus.Fields{
 			"path":   r.URL.Path,
-			"origin": GetIPFromRequest(r),
+			"origin": requestIP(r),
 		}).Info("Attempted access with malformed header, no auth header found.")
 
 		return errors.New("Authorization field missing"), 400
@@ -38,7 +38,7 @@ func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request,
 	if strings.ToLower(parts[0]) != "bearer" {
 		log.WithFields(logrus.Fields{
 			"path":   r.URL.Path,
-			"origin": GetIPFromRequest(r),
+			"origin": requestIP(r),
 		}).Info("Bearer token malformed")
 
 		return errors.New("Bearer token malformed"), 400
@@ -50,7 +50,7 @@ func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request,
 	if !keyExists {
 		log.WithFields(logrus.Fields{
 			"path":   r.URL.Path,
-			"origin": GetIPFromRequest(r),
+			"origin": requestIP(r),
 			"key":    accessToken,
 		}).Info("Attempted access with non-existent key.")
 

--- a/mw_openid.go
+++ b/mw_openid.go
@@ -24,7 +24,7 @@ type OpenIDMW struct {
 	lock                      sync.RWMutex
 }
 
-func (k *OpenIDMW) GetName() string {
+func (k *OpenIDMW) Name() string {
 	return "OpenIDMW"
 }
 

--- a/mw_organisation_activity.go
+++ b/mw_organisation_activity.go
@@ -28,7 +28,7 @@ type OrganizationMonitor struct {
 	mon            Monitor
 }
 
-func (k *OrganizationMonitor) GetName() string {
+func (k *OrganizationMonitor) Name() string {
 	return "OrganizationMonitor"
 }
 
@@ -53,7 +53,7 @@ func (k *OrganizationMonitor) ProcessRequestLive(w http.ResponseWriter, r *http.
 		return nil, 200
 	}
 
-	session, found := k.GetOrgSession(k.Spec.OrgID)
+	session, found := k.OrgSession(k.Spec.OrgID)
 
 	if !found {
 		// No organisation session has been created, should not be a pre-requisite in site setups, so we pass the request on
@@ -64,7 +64,7 @@ func (k *OrganizationMonitor) ProcessRequestLive(w http.ResponseWriter, r *http.
 	if session.IsInactive {
 		log.WithFields(logrus.Fields{
 			"path":   r.URL.Path,
-			"origin": GetIPFromRequest(r),
+			"origin": requestIP(r),
 			"key":    k.Spec.OrgID,
 		}).Warning("Organisation access is disabled.")
 
@@ -85,7 +85,7 @@ func (k *OrganizationMonitor) ProcessRequestLive(w http.ResponseWriter, r *http.
 	case sessionFailQuota:
 		log.WithFields(logrus.Fields{
 			"path":   r.URL.Path,
-			"origin": GetIPFromRequest(r),
+			"origin": requestIP(r),
 			"key":    k.Spec.OrgID,
 		}).Warning("Organisation quota has been exceeded.")
 
@@ -93,7 +93,7 @@ func (k *OrganizationMonitor) ProcessRequestLive(w http.ResponseWriter, r *http.
 		k.FireEvent(EventOrgQuotaExceeded, EventQuotaExceededMeta{
 			EventMetaDefault: EventMetaDefault{Message: "Organisation quota has been exceeded", OriginatingRequest: EncodeRequestToEvent(r)},
 			Path:             r.URL.Path,
-			Origin:           GetIPFromRequest(r),
+			Origin:           requestIP(r),
 			Key:              k.Spec.OrgID,
 		})
 
@@ -153,7 +153,7 @@ func (k *OrganizationMonitor) ProcessRequestOffThread(w http.ResponseWriter, r *
 
 func (k *OrganizationMonitor) AllowAccessNext(orgChan chan bool, r *http.Request) {
 
-	session, found := k.GetOrgSession(k.Spec.OrgID)
+	session, found := k.OrgSession(k.Spec.OrgID)
 
 	if !found {
 		// No organisation session has been created, should not be a pre-requisite in site setups, so we pass the request on
@@ -165,7 +165,7 @@ func (k *OrganizationMonitor) AllowAccessNext(orgChan chan bool, r *http.Request
 	if session.IsInactive {
 		log.WithFields(logrus.Fields{
 			"path":   r.URL.Path,
-			"origin": GetIPFromRequest(r),
+			"origin": requestIP(r),
 			"key":    k.Spec.OrgID,
 		}).Warning("Organisation access is disabled.")
 
@@ -182,7 +182,7 @@ func (k *OrganizationMonitor) AllowAccessNext(orgChan chan bool, r *http.Request
 	if isQuotaExceeded {
 		log.WithFields(logrus.Fields{
 			"path":   r.URL.Path,
-			"origin": GetIPFromRequest(r),
+			"origin": requestIP(r),
 			"key":    k.Spec.OrgID,
 		}).Warning("Organisation quota has been exceeded.")
 
@@ -190,7 +190,7 @@ func (k *OrganizationMonitor) AllowAccessNext(orgChan chan bool, r *http.Request
 		k.FireEvent(EventOrgQuotaExceeded, EventQuotaExceededMeta{
 			EventMetaDefault: EventMetaDefault{Message: "Organisation quota has been exceeded", OriginatingRequest: EncodeRequestToEvent(r)},
 			Path:             r.URL.Path,
-			Origin:           GetIPFromRequest(r),
+			Origin:           requestIP(r),
 			Key:              k.Spec.OrgID,
 		})
 

--- a/mw_rate_check.go
+++ b/mw_rate_check.go
@@ -6,7 +6,7 @@ type RateCheckMW struct {
 	*BaseMiddleware
 }
 
-func (m *RateCheckMW) GetName() string {
+func (m *RateCheckMW) Name() string {
 	return "RateCheckMW"
 }
 

--- a/mw_rate_limiting.go
+++ b/mw_rate_limiting.go
@@ -16,7 +16,7 @@ type RateLimitAndQuotaCheck struct {
 	*BaseMiddleware
 }
 
-func (k *RateLimitAndQuotaCheck) GetName() string {
+func (k *RateLimitAndQuotaCheck) Name() string {
 	return "RateLimitAndQuotaCheck"
 }
 
@@ -27,7 +27,7 @@ func (k *RateLimitAndQuotaCheck) IsEnabledForSpec() bool {
 func (k *RateLimitAndQuotaCheck) handleRateLimitFailure(r *http.Request, token string) (error, int) {
 	log.WithFields(logrus.Fields{
 		"path":   r.URL.Path,
-		"origin": GetIPFromRequest(r),
+		"origin": requestIP(r),
 		"key":    token,
 	}).Info("Key rate limit exceeded.")
 
@@ -35,7 +35,7 @@ func (k *RateLimitAndQuotaCheck) handleRateLimitFailure(r *http.Request, token s
 	k.FireEvent(EventRateLimitExceeded, EventRateLimitExceededMeta{
 		EventMetaDefault: EventMetaDefault{Message: "Key Rate Limit Exceeded", OriginatingRequest: EncodeRequestToEvent(r)},
 		Path:             r.URL.Path,
-		Origin:           GetIPFromRequest(r),
+		Origin:           requestIP(r),
 		Key:              token,
 	})
 
@@ -48,7 +48,7 @@ func (k *RateLimitAndQuotaCheck) handleRateLimitFailure(r *http.Request, token s
 func (k *RateLimitAndQuotaCheck) handleQuotaFailure(r *http.Request, token string) (error, int) {
 	log.WithFields(logrus.Fields{
 		"path":   r.URL.Path,
-		"origin": GetIPFromRequest(r),
+		"origin": requestIP(r),
 		"key":    token,
 	}).Info("Key quota limit exceeded.")
 
@@ -56,7 +56,7 @@ func (k *RateLimitAndQuotaCheck) handleQuotaFailure(r *http.Request, token strin
 	k.FireEvent(EventQuotaExceeded, EventQuotaExceededMeta{
 		EventMetaDefault: EventMetaDefault{Message: "Key Quota Limit Exceeded", OriginatingRequest: EncodeRequestToEvent(r)},
 		Path:             r.URL.Path,
-		Origin:           GetIPFromRequest(r),
+		Origin:           requestIP(r),
 		Key:              token,
 	})
 

--- a/mw_redis_cache.go
+++ b/mw_redis_cache.go
@@ -26,7 +26,7 @@ type RedisCacheMiddleware struct {
 	sh         SuccessHandler
 }
 
-func (m *RedisCacheMiddleware) GetName() string {
+func (m *RedisCacheMiddleware) Name() string {
 	return "RedisCacheMiddleware"
 }
 
@@ -118,7 +118,7 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 		stat = StatusCached
 	} else {
 		// New request checker, more targeted, less likely to fail
-		_, versionPaths, _, _ := m.Spec.GetVersionData(r)
+		_, versionPaths, _, _ := m.Spec.Version(r)
 		found, _ := m.Spec.CheckSpecMatchesStatus(r, versionPaths, Cached)
 		isVirtual, _ = m.Spec.CheckSpecMatchesStatus(r, versionPaths, VirtualPath)
 		if found {
@@ -134,7 +134,7 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 
 	// No authentication data? use the IP.
 	if token == "" {
-		token = GetIPFromRequest(r)
+		token = requestIP(r)
 	}
 
 	var copiedRequest *http.Request

--- a/mw_request_size_limit.go
+++ b/mw_request_size_limit.go
@@ -15,7 +15,7 @@ type RequestSizeLimitMiddleware struct {
 	*BaseMiddleware
 }
 
-func (t *RequestSizeLimitMiddleware) GetName() string {
+func (t *RequestSizeLimitMiddleware) Name() string {
 	return "RequestSizeLimitMiddleware"
 }
 
@@ -44,7 +44,7 @@ func (t *RequestSizeLimitMiddleware) checkRequestLimit(r *http.Request, sizeLimi
 	if int64(asInt) > sizeLimit {
 		log.WithFields(logrus.Fields{
 			"path":   r.URL.Path,
-			"origin": GetIPFromRequest(r),
+			"origin": requestIP(r),
 			"size":   statedCL,
 			"limit":  sizeLimit,
 		}).Info("Attempted access with large request size, blocked.")
@@ -57,7 +57,7 @@ func (t *RequestSizeLimitMiddleware) checkRequestLimit(r *http.Request, sizeLimi
 		// Request size is too big for globals
 		log.WithFields(logrus.Fields{
 			"path":   r.URL.Path,
-			"origin": GetIPFromRequest(r),
+			"origin": requestIP(r),
 			"size":   r.ContentLength,
 			"limit":  sizeLimit,
 		}).Info("Attempted access with large request size, blocked.")
@@ -72,7 +72,7 @@ func (t *RequestSizeLimitMiddleware) checkRequestLimit(r *http.Request, sizeLimi
 func (t *RequestSizeLimitMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	log.Debug("Request size limiter active")
 
-	vInfo, versionPaths, _, _ := t.Spec.GetVersionData(r)
+	vInfo, versionPaths, _, _ := t.Spec.Version(r)
 
 	log.Debug("Global limit is: ", vInfo.GlobalSizeLimit)
 	// Manage global headers first

--- a/mw_track_endpoints.go
+++ b/mw_track_endpoints.go
@@ -11,13 +11,13 @@ type TrackEndpointMiddleware struct {
 	*BaseMiddleware
 }
 
-func (a *TrackEndpointMiddleware) GetName() string {
+func (a *TrackEndpointMiddleware) Name() string {
 	return "TrackEndpointMiddleware"
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (a *TrackEndpointMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
-	_, versionPaths, _, _ := a.Spec.GetVersionData(r)
+	_, versionPaths, _, _ := a.Spec.Version(r)
 	foundTracked, metaTrack := a.Spec.CheckSpecMatchesStatus(r, versionPaths, RequestTracked)
 	if foundTracked {
 		ctxSetTrackedPath(r, metaTrack.(*apidef.TrackEndpointMeta).Path)

--- a/mw_transform.go
+++ b/mw_transform.go
@@ -24,7 +24,7 @@ type TransformMiddleware struct {
 	*BaseMiddleware
 }
 
-func (t *TransformMiddleware) GetName() string {
+func (t *TransformMiddleware) Name() string {
 	return "TransformMiddleware"
 }
 
@@ -39,7 +39,7 @@ func (t *TransformMiddleware) IsEnabledForSpec() bool {
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (t *TransformMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
-	_, versionPaths, _, _ := t.Spec.GetVersionData(r)
+	_, versionPaths, _, _ := t.Spec.Version(r)
 	found, meta := t.Spec.CheckSpecMatchesStatus(r, versionPaths, Transformed)
 	if !found {
 		return nil, 200

--- a/mw_url_rewrite.go
+++ b/mw_url_rewrite.go
@@ -116,7 +116,7 @@ type URLRewriteMiddleware struct {
 	*BaseMiddleware
 }
 
-func (m *URLRewriteMiddleware) GetName() string {
+func (m *URLRewriteMiddleware) Name() string {
 	return "URLRewriteMiddleware"
 }
 
@@ -141,7 +141,7 @@ func (m *URLRewriteMiddleware) CheckHostRewrite(oldPath, newTarget string, r *ht
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (m *URLRewriteMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
-	_, versionPaths, _, _ := m.Spec.GetVersionData(r)
+	_, versionPaths, _, _ := m.Spec.Version(r)
 	found, meta := m.Spec.CheckSpecMatchesStatus(r, versionPaths, URLRewrite)
 	if !found {
 		return nil, 200

--- a/mw_version_check.go
+++ b/mw_version_check.go
@@ -18,7 +18,7 @@ func (v *VersionCheck) Init() {
 	v.sh = SuccessHandler{v.BaseMiddleware}
 }
 
-func (v *VersionCheck) GetName() string {
+func (v *VersionCheck) Name() string {
 	return "VersionCheck"
 }
 
@@ -43,7 +43,7 @@ func (v *VersionCheck) ProcessRequest(w http.ResponseWriter, r *http.Request, _ 
 		v.FireEvent(EventVersionFailure, EventVersionFailureMeta{
 			EventMetaDefault: EventMetaDefault{Message: "Attempted access to disallowed version / path.", OriginatingRequest: EncodeRequestToEvent(r)},
 			Path:             r.URL.Path,
-			Origin:           GetIPFromRequest(r),
+			Origin:           requestIP(r),
 			Key:              "",
 			Reason:           string(stat),
 		})

--- a/mw_virtual_endpoint.go
+++ b/mw_virtual_endpoint.go
@@ -38,7 +38,7 @@ type VirtualEndpoint struct {
 	sh SuccessHandler
 }
 
-func (d *VirtualEndpoint) GetName() string {
+func (d *VirtualEndpoint) Name() string {
 	return "VirtualEndpoint"
 }
 
@@ -96,7 +96,7 @@ func (d *VirtualEndpoint) IsEnabledForSpec() bool {
 }
 
 func (d *VirtualEndpoint) ServeHTTPForCache(w http.ResponseWriter, r *http.Request) *http.Response {
-	_, versionPaths, _, _ := d.Spec.GetVersionData(r)
+	_, versionPaths, _, _ := d.Spec.Version(r)
 	found, meta := d.Spec.CheckSpecMatchesStatus(r, versionPaths, VirtualPath)
 
 	if !found {

--- a/plugins.go
+++ b/plugins.go
@@ -54,7 +54,7 @@ type DynamicMiddleware struct {
 	Auth                bool
 }
 
-func (d *DynamicMiddleware) GetName() string {
+func (d *DynamicMiddleware) Name() string {
 	return "DynamicMiddleware"
 }
 

--- a/res_handler_header_injector.go
+++ b/res_handler_header_injector.go
@@ -30,7 +30,7 @@ func (h *HeaderInjector) Init(c interface{}, spec *APISpec) error {
 func (h *HeaderInjector) HandleResponse(rw http.ResponseWriter, res *http.Response, req *http.Request, ses *SessionState) error {
 	// TODO: This should only target specific paths
 
-	_, versionPaths, _, _ := h.Spec.GetVersionData(req)
+	_, versionPaths, _, _ := h.Spec.Version(req)
 	found, meta := h.Spec.CheckSpecMatchesStatus(req, versionPaths, HeaderInjectedResponse)
 	if found {
 		hmeta := meta.(*apidef.HeaderInjectionMeta)

--- a/res_handler_transform.go
+++ b/res_handler_transform.go
@@ -35,7 +35,7 @@ func (h *ResponseTransformMiddleware) Init(c interface{}, spec *APISpec) error {
 }
 
 func (h *ResponseTransformMiddleware) HandleResponse(rw http.ResponseWriter, res *http.Response, req *http.Request, ses *SessionState) error {
-	_, versionPaths, _, _ := h.Spec.GetVersionData(req)
+	_, versionPaths, _, _ := h.Spec.Version(req)
 	found, meta := h.Spec.CheckSpecMatchesStatus(req, versionPaths, TransformedResponse)
 	if !found {
 		return nil

--- a/service_discovery.go
+++ b/service_discovery.go
@@ -97,7 +97,7 @@ func (s *ServiceDiscovery) addPortFromObject(host string, obj *gabs.Container) s
 	return host + ":" + portToUse
 }
 
-func (s *ServiceDiscovery) GetNestedObject(item *gabs.Container) string {
+func (s *ServiceDiscovery) NestedObject(item *gabs.Container) string {
 	parentData := s.decodeToNameSpace(s.parentPath, item)
 	// Get the data path from the decoded object
 	subContainer := gabs.Container{}
@@ -108,10 +108,10 @@ func (s *ServiceDiscovery) GetNestedObject(item *gabs.Container) string {
 		log.Debug("Get Nested Object: parentData is not a string")
 		return ""
 	}
-	return s.GetObject(&subContainer)
+	return s.Object(&subContainer)
 }
 
-func (s *ServiceDiscovery) GetObject(item *gabs.Container) string {
+func (s *ServiceDiscovery) Object(item *gabs.Container) string {
 	hostnameData := s.decodeToNameSpace(s.dataPath, item)
 	if str, ok := hostnameData.(string); ok {
 		// Get the port
@@ -122,13 +122,13 @@ func (s *ServiceDiscovery) GetObject(item *gabs.Container) string {
 	return ""
 }
 
-func (s *ServiceDiscovery) GetHostname(item *gabs.Container) string {
+func (s *ServiceDiscovery) Hostname(item *gabs.Container) string {
 	var hostname string
 	// Get a nested object
 	if s.isNested {
-		hostname = s.GetNestedObject(item)
+		hostname = s.NestedObject(item)
 	} else {
-		hostname = s.GetObject(item)
+		hostname = s.Object(item)
 	}
 	return hostname
 }
@@ -137,7 +137,7 @@ func (s *ServiceDiscovery) isList(val string) bool {
 	return strings.HasPrefix(val, "[")
 }
 
-func (s *ServiceDiscovery) GetSubObjectFromList(objList *gabs.Container) []string {
+func (s *ServiceDiscovery) SubObjectFromList(objList *gabs.Container) []string {
 	hostList := []string{}
 	var hostname string
 	var set []*gabs.Container
@@ -168,7 +168,7 @@ func (s *ServiceDiscovery) GetSubObjectFromList(objList *gabs.Container) []strin
 				// Hijack this here because we need to use a non-nested get
 				for _, item := range set {
 					log.Debug("Child in list: ", item)
-					hostname = s.GetObject(item) + s.targetPath
+					hostname = s.Object(item) + s.targetPath
 					// Add to list
 					hostList = append(hostList, hostname)
 				}
@@ -187,7 +187,7 @@ func (s *ServiceDiscovery) GetSubObjectFromList(objList *gabs.Container) []strin
 	if set != nil {
 		for _, item := range set {
 			log.Debug("Child in list: ", item)
-			hostname = s.GetHostname(item) + s.targetPath
+			hostname = s.Hostname(item) + s.targetPath
 			// Add to list
 			hostList = append(hostList, hostname)
 		}
@@ -197,8 +197,8 @@ func (s *ServiceDiscovery) GetSubObjectFromList(objList *gabs.Container) []strin
 	return hostList
 }
 
-func (s *ServiceDiscovery) GetSubObject(obj *gabs.Container) string {
-	return s.GetHostname(obj) + s.targetPath
+func (s *ServiceDiscovery) SubObject(obj *gabs.Container) string {
+	return s.Hostname(obj) + s.targetPath
 }
 
 func (s *ServiceDiscovery) rawListToObj(rawData string) string {
@@ -234,14 +234,14 @@ func (s *ServiceDiscovery) ProcessRawData(rawData string) (*apidef.HostList, err
 		// Treat JSON as a list and then apply the data path
 		if s.isTargetList {
 			// Get all values
-			asList := s.GetSubObjectFromList(&jsonParsed)
+			asList := s.SubObjectFromList(&jsonParsed)
 			log.Debug("Host list:", asList)
 			hostlist.Set(asList)
 			return hostlist, nil
 		}
 
 		// Get the top value
-		list := s.GetSubObjectFromList(&jsonParsed)
+		list := s.SubObjectFromList(&jsonParsed)
 		var host string
 		for _, v := range list {
 			host = v
@@ -259,20 +259,20 @@ func (s *ServiceDiscovery) ProcessRawData(rawData string) (*apidef.HostList, err
 		log.Debug("It's a target list - getting sub object from list")
 		log.Debug("Passing in: ", jsonParsed)
 
-		asList := s.GetSubObjectFromList(&jsonParsed)
+		asList := s.SubObjectFromList(&jsonParsed)
 		hostlist.Set(asList)
 		log.Debug("Got from object: ", hostlist)
 		return hostlist, nil
 	}
 
 	// It's a single object
-	host := s.GetSubObject(&jsonParsed)
+	host := s.SubObject(&jsonParsed)
 	hostlist.Set([]string{host})
 
 	return hostlist, nil
 }
 
-func (s *ServiceDiscovery) GetTarget(serviceURL string) (*apidef.HostList, error) {
+func (s *ServiceDiscovery) Target(serviceURL string) (*apidef.HostList, error) {
 	// Get the data
 	rawData, err := s.getServiceData(serviceURL)
 	if err != nil {

--- a/session_state.go
+++ b/session_state.go
@@ -81,7 +81,7 @@ func (s *SessionState) SetFirstSeenHash() {
 	s.firstSeenHash = fmt.Sprintf("%x", murmurHasher.Sum(encoded))
 }
 
-func (s *SessionState) GetHash() string {
+func (s *SessionState) Hash() string {
 	encoded, err := msgpack.Marshal(s)
 	if err != nil {
 		log.Error("Error encoding session data: ", err)
@@ -95,10 +95,10 @@ func (s *SessionState) HasChanged() bool {
 	if s.firstSeenHash == "" {
 		return true
 	}
-	if s.firstSeenHash == s.GetHash() {
+	if s.firstSeenHash == s.Hash() {
 		return false
 	}
-	// log.Debug("s.firstSeenHash: ", s.firstSeenHash, " current hash: ", s.GetHash())
+	// log.Debug("s.firstSeenHash: ", s.firstSeenHash, " current hash: ", s.Hash())
 	return true
 }
 

--- a/util_http_helpers.go
+++ b/util_http_helpers.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-func GetIPFromRequest(r *http.Request) string {
+func requestIP(r *http.Request) string {
 	if fw := r.Header.Get("X-Forwarded-For"); fw != "" {
 		// X-Forwarded-For has no port
 		if i := strings.IndexByte(fw, ','); i >= 0 {

--- a/util_http_helpers_test.go
+++ b/util_http_helpers_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestGetIPFromRequest(t *testing.T) {
+func TestRequestIP(t *testing.T) {
 	tests := []struct {
 		remote, forwarded, want string
 	}{
@@ -24,9 +24,9 @@ func TestGetIPFromRequest(t *testing.T) {
 	for _, tc := range tests {
 		r := &http.Request{RemoteAddr: tc.remote, Header: http.Header{}}
 		r.Header.Set("x-forwarded-for", tc.forwarded)
-		got := GetIPFromRequest(r)
+		got := requestIP(r)
 		if got != tc.want {
-			t.Errorf("GetIPFromRequest({%q, %q}) got %q, want %q",
+			t.Errorf("requestIP({%q, %q}) got %q, want %q",
 				tc.remote, tc.forwarded, got, tc.want)
 		}
 	}


### PR DESCRIPTION
See https://golang.org/doc/effective_go.html#Getters.

While at it, unexport a couple of helper funcs.

Some of them, like GetVersionData, were renamed into Version since
VersionData is already a field.