### PR TITLE
Allow urls to be rewritten in a coprocess middleware

### DIFF
--- a/coprocess.go
+++ b/coprocess.go
@@ -145,6 +145,7 @@ func (c *CoProcessor) ObjectPostProcess(object *coprocess.Object, r *http.Reques
 		values.Set(p, v)
 	}
 
+	r.URL.Path = object.Request.Url
 	r.URL.RawQuery = values.Encode()
 }
 


### PR DESCRIPTION
This PR allows urls to be rewritten within a coprocess middleware.

For example:
```
from tyk.decorators import Hook
from gateway import TykGateway as tyk

@Hook
def PostMiddleware(request, session, metadata, spec):
  request.object.url = '/hello/world'

  return request, session, metadata
```

The existing pattern in the mini request object is to define a variable prefixed with the verb describing the action to be performed such as `SetHeaders` and `DeleteParams` but all existing examples are updating dictionaries.

As this is mutating a string I'm not sure if the existing pattern makes sense?

Happy to discuss.

This PR relates to this thread that I posted on the forum. https://community.tyk.io/t/rewrite-upstream-url-in-plugin-python/1746