### PR TITLE
api: don't make JSVM field a pointer

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -123,7 +123,7 @@ type APISpec struct {
 	OrgSessionManager        SessionHandler
 	EventPaths               map[apidef.TykEvent][]config.TykEventHandler
 	Health                   HealthChecker
-	JSVM                     *JSVM
+	JSVM                     JSVM
 	ResponseChain            []TykResponseHandler
 	RoundRobin               RoundRobin
 	URLRewriteEnabled        bool
@@ -161,7 +161,6 @@ func (a APIDefinitionLoader) MakeSpec(def *apidef.APIDefinition) *APISpec {
 
 	// Create and init the virtual Machine
 	if globalConf.EnableJSVM {
-		spec.JSVM = &JSVM{}
 		spec.JSVM.Init()
 	}
 
@@ -684,7 +683,7 @@ func (a APIDefinitionLoader) compileVirtualPathspathSpec(paths []apidef.VirtualM
 		// Extend with method actions
 		newSpec.VirtualPathSpec = stringSpec
 
-		PreLoadVirtualMetaCode(&newSpec.VirtualPathSpec, apiSpec.JSVM)
+		PreLoadVirtualMetaCode(&newSpec.VirtualPathSpec, &apiSpec.JSVM)
 
 		urlSpec = append(urlSpec, newSpec)
 	}

--- a/plugins_test.go
+++ b/plugins_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestJSVMLogs(t *testing.T) {
 	var buf bytes.Buffer
-	jsvm := &JSVM{}
+	jsvm := JSVM{}
 	jsvm.Init()
 	jsvm.Log = logrus.New()
 	jsvm.Log.Out = &buf
@@ -68,7 +68,7 @@ func TestJSVMProcessTimeout(t *testing.T) {
 		Pre:                 true,
 	}
 	req := httptest.NewRequest("GET", "/foo", strings.NewReader("body"))
-	jsvm := &JSVM{}
+	jsvm := JSVM{}
 	jsvm.Init()
 	jsvm.Timeout = time.Millisecond
 
@@ -116,7 +116,7 @@ testJSVMData.NewProcessRequest(function(request, session, config) {
 		MiddlewareClassName: "testJSVMData",
 		Pre:                 true,
 	}
-	jsvm := &JSVM{}
+	jsvm := JSVM{}
 	jsvm.Init()
 	if _, err := jsvm.VM.Run(js); err != nil {
 		t.Fatalf("failed to set up js plugin: %v", err)


### PR DESCRIPTION
There's no need to - it's tiny. Also removes the need to allocate in an
extra line.