### PR TITLE
api: redesign round-robin with sync/atomic

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"sync"
+	"sync/atomic"
 	textTemplate "text/template"
 	"time"
 
@@ -1087,27 +1087,14 @@ func (a *APISpec) Version(r *http.Request) (*apidef.VersionInfo, []URLSpec, bool
 }
 
 type RoundRobin struct {
-	sync.Mutex
-	pos, max int
+	pos uint32
 }
 
-func (r *RoundRobin) SetMax(max int) {
-	if r.max = max; r.max < 0 {
-		r.max = 0
+func (r *RoundRobin) WithLen(len int) int {
+	if len < 1 {
+		return 0
 	}
-
-	// Can't have a new list substituted that's shorter
-	if r.pos > r.max {
-		r.pos = 0
-	}
-}
-
-func (r *RoundRobin) SetLen(len int) { r.SetMax(len - 1) }
-
-func (r *RoundRobin) Pos() int {
-	cur := r.pos
-	if r.pos++; r.pos > r.max {
-		r.pos = 0
-	}
-	return cur
+	// -1 to start at 0, not 1
+	cur := atomic.AddUint32(&r.pos, 1) - 1
+	return int(cur) % len
 }

--- a/api_definition_test.go
+++ b/api_definition_test.go
@@ -431,12 +431,13 @@ func TestGetAPISpecsDashboardSuccess(t *testing.T) {
 
 func TestRoundRobin(t *testing.T) {
 	rr := RoundRobin{}
-	rr.SetMax(2)
-
 	for _, want := range []int{0, 1, 2, 0} {
-		if got := rr.Pos(); got != want {
+		if got := rr.WithLen(3); got != want {
 			t.Errorf("RR Pos wrong: want %d got %d", want, got)
 		}
+	}
+	if got, want := rr.WithLen(0), 0; got != want {
+		t.Errorf("RR Pos of 0 wrong: want %d got %d", want, got)
 	}
 }
 

--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -106,12 +106,7 @@ func nextTarget(targetData *apidef.HostList, spec *APISpec) string {
 	if spec.Proxy.EnableLoadBalancing {
 		log.Debug("[PROXY] [LOAD BALANCING] Load balancer enabled, getting upstream target")
 		// Use a HostList
-		// TODO: do better than a mutex to avoid contention
-		spec.RoundRobin.Lock()
-		spec.RoundRobin.SetLen(targetData.Len())
-		startPos := spec.RoundRobin.Pos()
-		spec.RoundRobin.Unlock()
-
+		startPos := spec.RoundRobin.WithLen(targetData.Len())
 		pos := startPos
 		for {
 			gotHost, err := targetData.GetIndex(pos)


### PR DESCRIPTION
This means we no longer use a mutex around a number. The code should be
a bit faster, but most importantly it's much shorter and easier to
understand.

The only change in behavior is that when the max gets shortened, instead
of resetting back to 0, we wrap around with the remainder operation.
This is less predictable - the new position will be random - but it's
actually better. If we always reset to 0, the first elements of the list
would tend to get selected more often than the last elements.

Also test that we don't barf with a divide by zero if the length is zero
and there are no positions to select from.