### PR TITLE
all: don't make the global api spec map a pointer

### DIFF
--- a/api_loader.go
+++ b/api_loader.go
@@ -146,7 +146,7 @@ func processSpec(referenceSpec *APISpec,
 		}
 		if !pathModified {
 			apisMu.RLock()
-			prev := (*ApiSpecRegister)[referenceSpec.APIID]
+			prev := ApiSpecRegister[referenceSpec.APIID]
 			apisMu.RUnlock()
 			if prev != nil && prev.Proxy.ListenPath == referenceSpec.Proxy.ListenPath {
 				// if this APIID was already loaded and
@@ -681,7 +681,7 @@ func loadApps(APISpecs *[]*APISpec, Muxer *mux.Router) {
 
 	// Swap in the new register
 	apisMu.Lock()
-	ApiSpecRegister = &tempSpecRegister
+	ApiSpecRegister = tempSpecRegister
 	apisMu.Unlock()
 
 	log.Debug("Checker host list")

--- a/api_test.go
+++ b/api_test.go
@@ -545,14 +545,14 @@ func TestGetOAuthClients(t *testing.T) {
 	var responseCode int
 
 	var tempSpecRegister = make(map[string]*APISpec)
-	ApiSpecRegister = &tempSpecRegister
+	ApiSpecRegister = tempSpecRegister
 
 	_, responseCode = getOauthClients(testAPIID)
 	if responseCode != 400 {
 		t.Fatal("Retrieving OAuth clients from nonexistent APIs must return error.")
 	}
 
-	(*ApiSpecRegister)[testAPIID] = &APISpec{}
+	ApiSpecRegister[testAPIID] = &APISpec{}
 
 	_, responseCode = getOauthClients(testAPIID)
 	if responseCode != 400 {

--- a/host_checker_manager.go
+++ b/host_checker_manager.go
@@ -215,7 +215,7 @@ func (hc *HostCheckerManager) OnHostDown(report HostHealthReport) {
 	hc.store.SetKey(hc.getHostKey(report), "1", int64(hc.checker.checkTimeout+1))
 
 	apisMu.RLock()
-	thisSpec, found := (*ApiSpecRegister)[report.MetaData[UnHealthyHostMetaDataAPIKey]]
+	thisSpec, found := ApiSpecRegister[report.MetaData[UnHealthyHostMetaDataAPIKey]]
 	apisMu.RUnlock()
 	if !found {
 		log.WithFields(logrus.Fields{
@@ -261,7 +261,7 @@ func (hc *HostCheckerManager) OnHostBackUp(report HostHealthReport) {
 	hc.store.DeleteKey(hc.getHostKey(report))
 
 	apisMu.RLock()
-	thisSpec, found := (*ApiSpecRegister)[report.MetaData[UnHealthyHostMetaDataAPIKey]]
+	thisSpec, found := ApiSpecRegister[report.MetaData[UnHealthyHostMetaDataAPIKey]]
 	apisMu.RUnlock()
 	if !found {
 		log.WithFields(logrus.Fields{
@@ -392,7 +392,7 @@ func (hc *HostCheckerManager) UpdateTrackingListByAPIID(hd []HostData, apiId str
 
 func (hc *HostCheckerManager) GetListFromService(APIID string) ([]HostData, error) {
 	apisMu.RLock()
-	spec, found := (*ApiSpecRegister)[APIID]
+	spec, found := ApiSpecRegister[APIID]
 	apisMu.RUnlock()
 	if !found {
 		return []HostData{}, errors.New("API ID not found in register!")
@@ -457,7 +457,7 @@ func (hc HostCheckerManager) RecordUptimeAnalytics(thisReport HostHealthReport) 
 	// If we are obfuscating API Keys, store the hashed representation (config check handled in hashing function)
 
 	apisMu.RLock()
-	thisSpec, found := (*ApiSpecRegister)[thisReport.MetaData[UnHealthyHostMetaDataAPIKey]]
+	thisSpec, found := ApiSpecRegister[thisReport.MetaData[UnHealthyHostMetaDataAPIKey]]
 	apisMu.RUnlock()
 	thisOrg := ""
 	if found {
@@ -527,7 +527,7 @@ func SetCheckerHostList() {
 	}).Info("Loading uptime tests...")
 	hostList := []HostData{}
 	apisMu.RLock()
-	for _, spec := range *ApiSpecRegister {
+	for _, spec := range ApiSpecRegister {
 		if spec.UptimeTests.Config.ServiceDiscovery.UseDiscoveryService {
 			thisHostList, sdErr := GlobalHostChecker.GetListFromService(spec.APIID)
 			if sdErr == nil {

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ var argumentsBackup map[string]interface{}
 var DashService DashboardServiceSender
 
 var apisMu sync.RWMutex
-var ApiSpecRegister *map[string]*APISpec //make(map[string]*APISpec)
+var ApiSpecRegister map[string]*APISpec //make(map[string]*APISpec)
 var keyGen = DefaultKeyGenerator{}
 
 var mainRouter *mux.Router


### PR DESCRIPTION
It's unnecessary, as maps are already pointers. This was done in master,
but not yet in stable.

The tricky part is that the double-pointer means that reads can't be
safely done without checking for nil first, which can be done if the
double pointer is removed.

This was missed in the backport of the API deduplication feature, which
led to a nil pointer dereference crash.

Fixes #938.