### PR TITLE
all: always make mainRouter == defaultRouter

### DIFF
--- a/main.go
+++ b/main.go
@@ -727,6 +727,7 @@ func doReload() {
 	}).Info("Preparing new router")
 	newRouter := mux.NewRouter()
 	mainRouter = newRouter
+	defaultRouter = mainRouter
 
 	loadAPIEndpoints(newRouter)
 	loadApps(specs, newRouter)

--- a/rpc_backup_handlers.go
+++ b/rpc_backup_handlers.go
@@ -94,6 +94,7 @@ func doLoadWithBackup(specs *[]*APISpec) {
 
 	newRouter := mux.NewRouter()
 	mainRouter = newRouter
+	defaultRouter = mainRouter
 
 	log.Warning("[RPC Backup] --> Set up routers")
 	log.Warning("[RPC Backup] --> Loading endpoints")


### PR DESCRIPTION
setupGlobals sets them up to be equal, but they might diverge under some
circumstances like a reload.

In some cases we register things on defaultRouter instead of mainRouter.
If they're not the same pointers, things start breaking.

This was the case with OverrideDefaults.

Don't merge the two global vars in stable, as that change is a bit too
invasive. Simply fix the two occurences where they can diverge.

Fixes #940.