### PR TITLE
api: fix gateway API router prefix

### DIFF
--- a/main.go
+++ b/main.go
@@ -306,7 +306,7 @@ func loadAPIEndpoints(muxer *mux.Router) {
 		hostname = globalConf.ControlAPIHostname
 	}
 	r := mux.NewRouter()
-	muxer.PathPrefix("/tyk").Handler(http.StripPrefix("/tyk",
+	muxer.PathPrefix("/tyk/").Handler(http.StripPrefix("/tyk",
 		checkIsAPIOwner(InstrumentationMW(r)),
 	))
 	if hostname != "" {


### PR DESCRIPTION
Use /tyk/, not /tyk, so that listen paths like /tyk-foo/ work.

Before the fix, the newly added test failed with 403s:

	--- FAIL: TestListenPathTykPrefix (0.14s)
		gateway_test.go:879: [1]GET /tyk-foo/ Status 403, want 404
		gateway_test.go:879: [3]GET /tyk-foo/ Status 403, want 200
		gateway_test.go:879: [1][OverrideDefaults]GET /tyk-foo/ Status 403, want 404
		gateway_test.go:879: [3][OverrideDefaults]GET /tyk-foo/ Status 403, want 200
		gateway_test.go:879: [1][Goagain][OverrideDefaults]GET /tyk-foo/ Status 403, want 404
		gateway_test.go:879: [3][Goagain][OverrideDefaults]GET /tyk-foo/ Status 403, want 200
		gateway_test.go:879: [1][Goagain]GET /tyk-foo/ Status 403, want 404
		gateway_test.go:879: [3][Goagain]GET /tyk-foo/ Status 403, want 200

Added ControlAPIPort resetting to testHttp. Otherwise,
TestControlListener would leave it at non-zero, breaking tests after it
like the new one.

Fixes #945.