### PR TITLE
mw: avoid double goroutine in rate limiting

### DIFF
--- a/mw_rate_limiting.go
+++ b/mw_rate_limiting.go
@@ -81,11 +81,7 @@ func (k *RateLimitAndQuotaCheck) ProcessRequest(w http.ResponseWriter, r *http.R
 	// If either are disabled, save the write roundtrip
 	if !k.Spec.DisableRateLimit || !k.Spec.DisableQuota {
 		// Ensure quota and rate data for this session are recorded
-		if globalConf.UseAsyncSessionWrite {
-			go k.Spec.SessionManager.UpdateSession(token, session, getLifetime(k.Spec, session))
-		} else {
-			k.Spec.SessionManager.UpdateSession(token, session, getLifetime(k.Spec, session))
-		}
+		k.Spec.SessionManager.UpdateSession(token, session, getLifetime(k.Spec, session))
 		ctxSetSession(r, session)
 	}
 


### PR DESCRIPTION
If UseAsyncSessionWrite is true, DefaultSessionManager.UpdateSession
does the actual store write in a goroutine. Other than that, the
function has very little logic and a json marshal.

As such, it's redundant for this middleware to also use a goroutine. It
would only lead to extra CPU use and delay in writing the session to the
store, given how two goroutines need to be scheduled instead of just
one.