### PR TITLE
jsvm: allow any objects inside config_data

### DIFF
--- a/coprocess.go
+++ b/coprocess.go
@@ -169,7 +169,7 @@ func CoProcessInit() (err error) {
 
 // CoProcessMiddlewareConfig holds the middleware configuration.
 type CoProcessMiddlewareConfig struct {
-	ConfigData map[string]string `mapstructure:"config_data" bson:"config_data" json:"config_data"`
+	ConfigData map[string]interface{} `mapstructure:"config_data" bson:"config_data" json:"config_data"`
 }
 
 // New lets you do any initialisations for the object can be done here

--- a/plugins.go
+++ b/plugins.go
@@ -65,7 +65,7 @@ type DynamicMiddleware struct {
 }
 
 type DynamicMiddlewareConfig struct {
-	ConfigData map[string]string `mapstructure:"config_data" bson:"config_data" json:"config_data"`
+	ConfigData map[string]interface{} `mapstructure:"config_data" bson:"config_data" json:"config_data"`
 }
 
 func (mw *DynamicMiddleware) GetName() string {
@@ -85,7 +85,7 @@ func (d *DynamicMiddleware) GetConfig() (interface{}, error) {
 }
 
 type configDataDef struct {
-	ConfigData map[string]string `mapstructure:"config_data" bson:"config_data" json:"config_data"`
+	ConfigData map[string]interface{} `mapstructure:"config_data" bson:"config_data" json:"config_data"`
 }
 
 func jsonConfigData(spec *APISpec) string {

--- a/plugins_test.go
+++ b/plugins_test.go
@@ -53,7 +53,8 @@ func TestJSVMConfigData(t *testing.T) {
 	spec := &APISpec{APIDefinition: &tykcommon.APIDefinition{}}
 	spec.RawData = map[string]interface{}{
 		"config_data": map[string]interface{}{
-			"foo": "bar",
+			"foo": "x",
+			"bar": map[string]interface{}{"y": 3},
 		},
 	}
 	const js = `
@@ -61,6 +62,7 @@ var testJSVMData = new TykJS.TykMiddleware.NewMiddleware({});
 
 testJSVMData.NewProcessRequest(function(request, session, config) {
 	request.SetHeaders["data-foo"] = config.config_data.foo;
+	request.SetHeaders["data-bar-y"] = config.config_data.bar.y.toString();
 	return testJSVMData.ReturnData(request, {});
 });`
 	dynMid := &DynamicMiddleware{
@@ -77,7 +79,10 @@ testJSVMData.NewProcessRequest(function(request, session, config) {
 
 	r := httptest.NewRequest("GET", "/v1/test-data", nil)
 	dynMid.ProcessRequest(nil, r, nil)
-	if want, got := "bar", r.Header.Get("data-foo"); want != got {
+	if want, got := "x", r.Header.Get("data-foo"); want != got {
+		t.Fatalf("wanted header to be %q, got %q", want, got)
+	}
+	if want, got := "3", r.Header.Get("data-bar-y"); want != got {
 		t.Fatalf("wanted header to be %q, got %q", want, got)
 	}
 }


### PR DESCRIPTION
Don't limit it to map[string]string. Add a test too, with a nested
object and an integer.

The only type that matters here is configDataDef, but change the others
for consistency.

Fixes #951.