### PR TITLE
mw: fix leak in rate-limit with async writes

### DIFF
--- a/middleware_rate_limiting.go
+++ b/middleware_rate_limiting.go
@@ -96,13 +96,8 @@ func (k *RateLimitAndQuotaCheck) ProcessRequest(w http.ResponseWriter, r *http.R
 	// If either are disabled, save the write roundtrip
 	if k.Spec.DisableRateLimit == false || k.Spec.DisableQuota == false {
 		// Ensure quota and rate data for this session are recorded
-		if !config.UseAsyncSessionWrite {
-			k.Spec.SessionManager.UpdateSession(authHeaderValue, thisSessionState, GetLifetime(k.Spec, &thisSessionState))
-			context.Set(r, SessionData, thisSessionState)
-		} else {
-			go k.Spec.SessionManager.UpdateSession(authHeaderValue, thisSessionState, GetLifetime(k.Spec, &thisSessionState))
-			go context.Set(r, SessionData, thisSessionState)
-		}
+		k.Spec.SessionManager.UpdateSession(authHeaderValue, thisSessionState, GetLifetime(k.Spec, &thisSessionState))
+		context.Set(r, SessionData, thisSessionState)
 	}
 
 	log.Debug("SessionState: ", thisSessionState)


### PR DESCRIPTION
See the issue below for details.

Fixes #966.