### PR TITLE
session: make MetaData a map[string]string

### DIFF
--- a/middleware_jwt.go
+++ b/middleware_jwt.go
@@ -264,7 +264,7 @@ func (k *JWTMiddleware) processCentralisedJWT(w http.ResponseWriter, r *http.Req
 
 		if err == nil {
 			thisSessionState = newSessionState
-			thisSessionState.MetaData = map[string]interface{}{"TykJWTSessionID": SessionID}
+			thisSessionState.MetaData = map[string]string{"TykJWTSessionID": SessionID}
 			thisSessionState.Alias = baseFieldData
 
 			// Update the session in the session manager in case it gets called again

--- a/middleware_modify_headers.go
+++ b/middleware_modify_headers.go
@@ -76,9 +76,9 @@ func (t *TransformHeaders) iterateAddHeaders(kv map[string]string, r *http.Reque
 			if found {
 				metaKey := strings.Replace(nVal, TYK_META_LABEL, "", 1)
 				if thisSessionState.MetaData != nil {
-					tempVal, ok := thisSessionState.MetaData.(map[string]interface{})[metaKey]
+					tempVal, ok := thisSessionState.MetaData[metaKey]
 					if ok {
-						nVal = tempVal.(string)
+						nVal = tempVal
 						r.Header.Add(nKey, nVal)
 					} else {
 						log.Warning("Session Meta Data not found for key in map: ", metaKey)

--- a/middleware_openid.go
+++ b/middleware_openid.go
@@ -197,7 +197,7 @@ func (k *OpenIDMW) ProcessRequest(w http.ResponseWriter, r *http.Request, config
 		}
 
 		thisSessionState = newSessionState
-		thisSessionState.MetaData = map[string]interface{}{"TykJWTSessionID": SessionID, "ClientID": thisClientID}
+		thisSessionState.MetaData = map[string]string{"TykJWTSessionID": SessionID, "ClientID": thisClientID}
 		thisSessionState.Alias = thisClientID + ":" + user.ID
 
 		// Update the session in the session manager in case it gets called again

--- a/middleware_url_rewrite.go
+++ b/middleware_url_rewrite.go
@@ -113,34 +113,10 @@ func (u URLRewriter) Rewrite(thisMeta *tykcommon.URLRewriteMeta, path string, us
 			contextKey := strings.Replace(v[0], "$tyk_meta.", "", 1)
 			log.Debug("Replacing: ", v[0])
 
-			tempVal, ok := thisSessionState.MetaData.(map[string]interface{})[contextKey]
+			tempVal, ok := thisSessionState.MetaData[contextKey]
 			if ok {
-				var nVal string
-				if ok {
-					switch tempVal.(type) {
-					case string:
-						nVal = tempVal.(string)
-					case []string:
-						nVal = strings.Join(tempVal.([]string), ",")
-						// Remove empty start
-						nVal = strings.TrimPrefix(nVal, ",")
-					case url.Values:
-						end := len(tempVal.(url.Values))
-						i := 0
-						nVal = ""
-						for key, val := range tempVal.(url.Values) {
-							nVal += key + ":" + strings.Join(val, ",")
-							if i < end-1 {
-								nVal += ";"
-							}
-							i++
-						}
-					default:
-						log.Error("Context variable type is not supported: ", reflect.TypeOf(tempVal))
-					}
-					newpath = strings.Replace(newpath, string(v[0]), url.QueryEscape(nVal), -1)
-				}
-
+				nVal := tempVal
+				newpath = strings.Replace(newpath, string(v[0]), url.QueryEscape(nVal), -1)
 			}
 
 		}

--- a/session_state.go
+++ b/session_state.go
@@ -61,7 +61,7 @@ type SessionState struct {
 		TriggerLimits []float64 `json:"trigger_limits" msg:"trigger_limits"`
 	} `json:"monitor" msg:"monitor"`
 	EnableDetailedRecording bool        `json:"enable_detail_recording" msg:"enable_detail_recording"`
-	MetaData                interface{} `json:"meta_data" msg:"meta_data"`
+	MetaData                map[string]string `json:"meta_data" msg:"meta_data"`
 	Tags                    []string    `json:"tags" msg:"tags"`
 	Alias                   string      `json:"alias" msg:"alias"`
 	LastUpdated             string      `json:"last_updated" msg:"last_updated"`


### PR DESCRIPTION
That's all we support and what the documentation says. We already
enforce this on master.

This way, if someone tries to create a key with metadata that isn't an
object or contains something other than keys, the key creation will just
error.

Fixes #944.