### PR TITLE
Coprocess plugins should be able to override error messages

### DIFF
--- a/coprocess.go
+++ b/coprocess.go
@@ -263,7 +263,12 @@ func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 		// Report in health check
 		ReportHealthCheckValue(m.Spec.Health, KeyFailure, "1")
 
-		return errors.New("Key not authorised"), int(returnObject.Request.ReturnOverrides.ResponseCode)
+		errorMsg := "Key not authorised"
+		if returnObject.Request.ReturnOverrides.ResponseError != "" {
+			errorMsg = returnObject.Request.ReturnOverrides.ResponseError
+		}
+
+		return errors.New(errorMsg), int(returnObject.Request.ReturnOverrides.ResponseCode)
 	}
 
 	if returnObject.Request.ReturnOverrides.ResponseCode > 0 {

--- a/coprocess_test.go
+++ b/coprocess_test.go
@@ -250,6 +250,22 @@ func TestCoProcessReturnOverrides(t *testing.T) {
 	}
 }
 
+func TestCoProcessReturnOverridesErrorMessage(t *testing.T) {
+	spec := createSpecTest(t, basicCoProcessDef)
+	chain := buildCoProcessChain(spec, "hook_test_return_overrides_error", coprocess.HookType_Pre, apidef.MiddlewareDriver("python"))
+	session := createNonThrottledSession()
+	spec.SessionManager.UpdateSession("abc", session, 60)
+
+	recorder := httptest.NewRecorder()
+
+	req := testReq(t, "GET", "/headers", nil)
+	req.Header.Set("authorization", "abc")
+	chain.ServeHTTP(recorder, req)
+	if recorder.Code != 401 || recorder.Body.String() != "{\n    \"error\": \"custom error message\"\n}" {
+		t.Fatal("ReturnOverrides HTTP response is invalid", recorder.Code, recorder.Body)
+	}
+}
+
 const basicCoProcessDef = `{
 	"api_id": "1",
 	"org_id": "default",

--- a/coprocess_test_helpers.go
+++ b/coprocess_test_helpers.go
@@ -159,6 +159,11 @@ func applyTestHooks(objectPtr unsafe.Pointer) {
 			ResponseCode:  200,
 			ResponseError: "body",
 		}
+	case "hook_test_return_overrides_error":
+		object.Request.ReturnOverrides = &coprocess.ReturnOverrides{
+			ResponseCode:  401,
+			ResponseError: "custom error message",
+		}
 	case "hook_test_bad_auth_using_id_extractor":
 	case "hook_test_bad_auth_cp_error":
 	case "hook_test_successful_auth":


### PR DESCRIPTION
Use `Request.ReturnOverrides.ResponseError`, and retain compatibility
by serving default error message.

Fix #872