### PR TITLE
Fix JSVM `rawlog` to support hooks

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -9,9 +9,17 @@ import (
 )
 
 var log = logrus.New()
+var rawLog = logrus.New()
+
+type RawFormatter struct{}
+
+func (f *RawFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	return []byte(entry.Message), nil
+}
 
 func init() {
 	log.Formatter = new(prefixed.TextFormatter)
+	rawLog.Formatter = new(RawFormatter)
 }
 
 func Get() *logrus.Logger {
@@ -26,4 +34,8 @@ func Get() *logrus.Logger {
 		log.Level = logrus.InfoLevel
 	}
 	return log
+}
+
+func GetRaw() *logrus.Logger {
+	return rawLog
 }

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ import (
 
 var (
 	log                      = logger.Get()
+	rawLog                   = logger.GetRaw()
 	globalConf               config.Config
 	templates                *template.Template
 	analytics                RedisAnalyticsHandler
@@ -658,6 +659,7 @@ func setupLogger() {
 
 		if err == nil {
 			log.Hooks.Add(hook)
+			rawLog.Hooks.Add(hook)
 		}
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
@@ -674,6 +676,7 @@ func setupLogger() {
 
 		if err == nil {
 			log.Hooks.Add(hook)
+			rawLog.Hooks.Add(hook)
 		}
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
@@ -688,6 +691,7 @@ func setupLogger() {
 			map[string]interface{}{"tyk-module": "gateway"})
 
 		log.Hooks.Add(hook)
+		rawLog.Hooks.Add(hook)
 
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
@@ -704,6 +708,7 @@ func setupLogger() {
 
 		if err == nil {
 			log.Hooks.Add(hook)
+			rawLog.Hooks.Add(hook)
 		}
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
@@ -711,8 +716,9 @@ func setupLogger() {
 	}
 
 	if globalConf.UseRedisLog {
-		redisHook := newRedisHook()
-		log.Hooks.Add(redisHook)
+		hook := newRedisHook()
+		log.Hooks.Add(hook)
+		rawLog.Hooks.Add(hook)
 
 		log.WithFields(logrus.Fields{
 			"prefix": "main",

--- a/plugins.go
+++ b/plugins.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -310,8 +309,7 @@ func (j *JSVM) LoadTykJSApi() {
 	})
 
 	j.VM.Set("rawlog", func(call otto.FunctionCall) otto.Value {
-		io.WriteString(j.Log.Out, call.Argument(0).String())
-		j.Log.Out.Write([]byte("\n"))
+		rawLog.Print(call.Argument(0).String() + "\n")
 		return otto.Value{}
 	})
 


### PR DESCRIPTION
Previously it used only Logger.Out, but in fact, our external logging
like Syslog implemented as Logger Hook, and current `rawlog`
implementation does not support them.

Added new `rawLogger` which use custom formatter, which prints raw
messages.

Fix https://github.com/TykTechnologies/tyk/issues/998