### PR TITLE
revproxy: don't append paths if we switched URLs

### DIFF
--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -205,11 +205,13 @@ func TykNewSingleHostReverseProxy(target *url.URL, spec *APISpec) *ReverseProxy 
 		}
 
 		// No override, and no load balancing? Use the existing target
-		req.URL.Scheme = targetToUse.Scheme
-		req.URL.Host = targetToUse.Host
 
-		// TODO: figure out a better fix for this
-		if targetToUse.Path != req.URL.Path {
+		// if this is false, there was an url rewrite, thus we
+		// don't want to do anything to the path - req.URL is
+		// already final.
+		if targetToUse == target {
+			req.URL.Scheme = targetToUse.Scheme
+			req.URL.Host = targetToUse.Host
 			req.URL.Path = singleJoiningSlash(targetToUse.Path, req.URL.Path)
 		}
 		if !spec.Proxy.PreserveHostHeader {

--- a/reverse_proxy_test.go
+++ b/reverse_proxy_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/TykTechnologies/tyk/apidef"
+)
+
+func TestReverseProxyRetainHost(t *testing.T) {
+	target, _ := url.Parse("http://target-host.com/targetpath")
+	cases := []struct {
+		name          string
+		inURL, inPath string
+		retainHost    bool
+		wantURL       string
+	}{
+		{
+			"no-retain-same-path",
+			"http://orig-host.com/origpath", "/origpath",
+			false, "http://target-host.com/targetpath/origpath",
+		},
+		{
+			"no-retain-minus-slash",
+			"http://orig-host.com/origpath", "origpath",
+			false, "http://target-host.com/targetpath/origpath",
+		},
+		{
+			"retain-same-path",
+			"http://orig-host.com/origpath", "/origpath",
+			true, "http://orig-host.com/origpath",
+		},
+		{
+			"retain-minus-slash",
+			"http://orig-host.com/origpath", "origpath",
+			true, "http://orig-host.com/origpath",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := &APISpec{APIDefinition: &apidef.APIDefinition{}}
+			spec.URLRewriteEnabled = true
+
+			req := testReq(t, "GET", tc.inURL, nil)
+			req.URL.Path = tc.inPath
+			if tc.retainHost {
+				setCtxValue(req, RetainHost, true)
+			}
+
+			proxy := TykNewSingleHostReverseProxy(target, spec)
+			proxy.Director(req)
+			if got := req.URL.String(); got != tc.wantURL {
+				t.Fatalf("wanted url %q, got %q", tc.wantURL, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Because if we did, we may end up with a duplicate path.

We already partially fixed this with a path string comparison. However,
after some debugging, it was discovered that under some circumstances,
paths may be of the form "path" instead of "/path".

Use a stronger logic, and add more tests.

Reproducing the issue manually, before and after:

	DEBUG Outbound Request: http://192.168.0.148:8888/_count/_count

	DEBUG Outbound Request: http://192.168.0.148:8888/_count

Also move the scheme and host swapping, as they too modify req.URL when
it's already final. Although these were harmless, as they were replacing
instead of appending.

Fixes #962.