### PR TITLE
Backport: missing package description in the build script

### DIFF
--- a/utils/dist_build.sh
+++ b/utils/dist_build.sh
@@ -27,6 +27,7 @@ ARCHTGZDIRS=(
 
 cliDIR=$ORGDIR/tyk-cli
 cliTmpDir=$SOURCEBINPATH/temp/cli
+DESCRIPTION="Tyk Open Source API Gateway written in Go"
 
 echo "Clearing CLI temp folder"
 rm -rf $cliTmpDir


### PR DESCRIPTION
Package description went missing from the backport somehow (it's present in the master). This makes deb parser and therefore PackageCloud unhappy.