### PR TITLE
fire AuthFailed if HMAC middleware fails auth

### DIFF
--- a/mw_hmac.go
+++ b/mw_hmac.go
@@ -171,6 +171,8 @@ func (hm *HMACMiddleware) authorizationError(r *http.Request) (error, int) {
 		"origin": r.RemoteAddr,
 	}).Info("Authorization field missing or malformed")
 
+	AuthFailed(hm.BaseMiddleware, r, r.Header.Get("Authorization"))
+
 	return errors.New("Authorization field missing, malformed or invalid"), 400
 }
 


### PR DESCRIPTION
this fixes #963 so that any failure in the HMAC authorization will
fire a AuthFailed event so users can write webhooks to log possible
attacks