### PR TITLE
all: remove the last few direct r.RemoteAddr uses

### DIFF
--- a/instrumentation_handlers.go
+++ b/instrumentation_handlers.go
@@ -50,7 +50,7 @@ func InstrumentationMW(next http.Handler) http.Handler {
 
 		next.ServeHTTP(w, r)
 		job.EventKv("called", health.Kvs{
-			"from_ip":  r.RemoteAddr,
+			"from_ip":  requestIP(r),
 			"method":   r.Method,
 			"endpoint": r.URL.Path,
 			"raw_url":  r.URL.String(),

--- a/middleware.go
+++ b/middleware.go
@@ -54,7 +54,7 @@ func createMiddleware(mw TykMiddleware) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			job := instrument.NewJob("MiddlewareCall")
 			meta := health.Kvs{
-				"from_ip":  r.RemoteAddr,
+				"from_ip":  requestIP(r),
 				"method":   r.Method,
 				"endpoint": r.URL.Path,
 				"raw_url":  r.URL.String(),

--- a/mw_context_vars.go
+++ b/mw_context_vars.go
@@ -49,7 +49,7 @@ func (m *MiddlewareContextVars) ProcessRequest(w http.ResponseWriter, r *http.Re
 	contextDataObject["path"] = copiedRequest.URL.Path
 
 	// IP:Port
-	contextDataObject["remote_addr"] = copiedRequest.RemoteAddr
+	contextDataObject["remote_addr"] = requestIP(copiedRequest)
 
 	//Correlation ID
 	contextDataObject["request_id"] = uuid.NewV4().String()

--- a/mw_context_vars_test.go
+++ b/mw_context_vars_test.go
@@ -47,6 +47,7 @@ func TestContextVarsMiddleware(t *testing.T) {
 	req := testReq(t, method, uri+param.Encode(), nil)
 	req.RemoteAddr = "127.0.0.1:80"
 	req.Header.Set("authorization", "1234wer")
+	req.Header.Set("x-forwarded-for", "1.2.3.4, 5.6.7.8")
 
 	chain := getChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -63,8 +64,11 @@ func TestContextVarsMiddleware(t *testing.T) {
 		t.Fatal("Could not find Path in header")
 	}
 
-	if req.Header.Get("X-Remote-Addr") == "" {
+	addr := req.Header.Get("X-Remote-Addr")
+	if addr == "" {
 		t.Fatal("Could not find Remote-Addr in header")
+	} else if addr != "1.2.3.4" {
+		t.Fatal("Remote-Addr is not the expected value")
 	}
 
 	if req.Header.Get("X-Request-ID") == "" {

--- a/mw_hmac.go
+++ b/mw_hmac.go
@@ -168,7 +168,7 @@ func (hm *HMACMiddleware) authorizationError(r *http.Request) (error, int) {
 	log.WithFields(logrus.Fields{
 		"prefix": "hmac",
 		"path":   r.URL.Path,
-		"origin": r.RemoteAddr,
+		"origin": requestIP(r),
 	}).Info("Authorization field missing or malformed")
 
 	AuthFailed(hm, r, r.Header.Get("Authorization"))


### PR DESCRIPTION
They should all be using either requestIP or requestAddrs, depending on
whether they want the real IP or all the addresses of all the hops.

This fixes an issue found in the context vars code. While at it, fix a
couple of other occurences.

Fixes #1017.