### PR TITLE
revproxy: don't include port in X-Forwarded-For

### DIFF
--- a/api.go
+++ b/api.go
@@ -928,7 +928,7 @@ func createKeyHandler(w http.ResponseWriter, r *http.Request) {
 				"org_id":      newSession.OrgID,
 				"api_id":      "--",
 				"user_id":     "system",
-				"user_ip":     requestAddrs(r),
+				"user_ip":     requestIPHops(r),
 				"path":        "--",
 				"server_name": "system",
 			}).Warning("No API Access Rights set on key session, adding key to all APIs.")
@@ -956,7 +956,7 @@ func createKeyHandler(w http.ResponseWriter, r *http.Request) {
 				"org_id":      newSession.OrgID,
 				"api_id":      "--",
 				"user_id":     "system",
-				"user_ip":     requestAddrs(r),
+				"user_ip":     requestIPHops(r),
 				"path":        "--",
 				"server_name": "system",
 			}).Error("Master keys disallowed in configuration, key not added.")
@@ -989,7 +989,7 @@ func createKeyHandler(w http.ResponseWriter, r *http.Request) {
 		"api_id":      "--",
 		"org_id":      newSession.OrgID,
 		"user_id":     "system",
-		"user_ip":     requestAddrs(r),
+		"user_ip":     requestIPHops(r),
 		"path":        "--",
 		"server_name": "system",
 	}).Info("Generated new key: (", ObfuscateKeyString(newKey), ")")
@@ -1362,7 +1362,7 @@ func invalidateCacheHandler(w http.ResponseWriter, r *http.Request) {
 			"err":         err,
 			"org_id":      orgid,
 			"user_id":     "system",
-			"user_ip":     requestAddrs(r),
+			"user_ip":     requestIPHops(r),
 			"path":        "--",
 			"server_name": "system",
 		}).Error("Failed to delete cache: ", err)

--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -504,7 +504,7 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 		}
 	}
 
-	addrs := requestAddrs(req)
+	addrs := requestIPHops(req)
 	outreq.Header.Set("X-Forwarded-For", addrs)
 
 	// Circuit breaker

--- a/util_http_helpers.go
+++ b/util_http_helpers.go
@@ -26,15 +26,18 @@ func requestIP(r *http.Request) string {
 	return host
 }
 
-func requestAddrs(r *http.Request) string {
-	addrs := r.RemoteAddr
+func requestIPHops(r *http.Request) string {
+	clientIP, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return ""
+	}
 	// If we aren't the first proxy retain prior
 	// X-Forwarded-For information as a comma+space
 	// separated list and fold multiple headers into one.
 	if prior, ok := r.Header["X-Forwarded-For"]; ok {
-		addrs = strings.Join(prior, ", ") + ", " + addrs
+		clientIP = strings.Join(prior, ", ") + ", " + clientIP
 	}
-	return addrs
+	return clientIP
 }
 
 func CopyHttpRequest(r *http.Request) *http.Request {


### PR DESCRIPTION
In f5e90899 we reintroduced the function that joined all the hops in a
request. However, a mistake was made - the hops are just IPs, not
addresses with a port.

Get the code back to how it was in 2.3.x, which removed the port from
r.RemoteAddr before appending it to the list. And rename the helper
function to clarify what it does.