### PR TITLE
api: remove API spec sorting by host

### DIFF
--- a/main.go
+++ b/main.go
@@ -532,30 +532,6 @@ func isRPCMode() bool {
 		globalConf.AuthOverride.AuthProvider.StorageEngine == RPCStorageEngine
 }
 
-type SortableAPISpecListByListen []*APISpec
-
-func (s SortableAPISpecListByListen) Len() int {
-	return len(s)
-}
-func (s SortableAPISpecListByListen) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-func (s SortableAPISpecListByListen) Less(i, j int) bool {
-	return len(s[i].Proxy.ListenPath) > len(s[j].Proxy.ListenPath)
-}
-
-type SortableAPISpecListByHost []*APISpec
-
-func (s SortableAPISpecListByHost) Len() int {
-	return len(s)
-}
-func (s SortableAPISpecListByHost) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-func (s SortableAPISpecListByHost) Less(i, j int) bool {
-	return len(s[i].Domain) > len(s[j].Domain)
-}
-
 func rpcReloadLoop(rpcKey string) {
 	for {
 		RPCListener.CheckForReload(rpcKey)


### PR DESCRIPTION
It is not required, as hosts are found by exact match, not by prefix. We
still want it for listen paths though, as that is indeed a prefix match.

While at it, since we dropped Go 1.7, simplify the code with sort.Slice.

Fixes #988.