### PR TITLE
session: undo MetaData map[string]string switch

### DIFF
--- a/mw_jwt.go
+++ b/mw_jwt.go
@@ -235,7 +235,7 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 
 		if err == nil {
 			session = newSession
-			session.MetaData = map[string]string{"TykJWTSessionID": sessionID}
+			session.MetaData = map[string]interface{}{"TykJWTSessionID": sessionID}
 			session.Alias = baseFieldData
 
 			// Update the session in the session manager in case it gets called again

--- a/mw_modify_headers.go
+++ b/mw_modify_headers.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -46,9 +47,11 @@ func (t *TransformHeaders) iterateAddHeaders(kv map[string]string, r *http.Reque
 			// Using meta_data key
 			if session != nil {
 				metaKey := strings.Replace(nVal, metaLabel, "", 1)
-				metaVal, ok := session.MetaData[metaKey]
+				tempVal, ok := session.MetaData[metaKey]
 				if ok {
-					r.Header.Set(nKey, metaVal)
+					// TODO: do a better job than fmt's %v
+					nVal = fmt.Sprintf("%v", tempVal)
+					r.Header.Set(nKey, nVal)
 				} else {
 					log.Warning("Session Meta Data not found for key in map: ", metaKey)
 				}

--- a/mw_openid.go
+++ b/mw_openid.go
@@ -185,7 +185,7 @@ func (k *OpenIDMW) ProcessRequest(w http.ResponseWriter, r *http.Request, _ inte
 		}
 
 		session = newSession
-		session.MetaData = map[string]string{"TykJWTSessionID": sessionID, "ClientID": clientID}
+		session.MetaData = map[string]interface{}{"TykJWTSessionID": sessionID, "ClientID": clientID}
 		session.Alias = clientID + ":" + user.ID
 
 		// Update the session in the session manager in case it gets called again

--- a/mw_virtual_endpoint.go
+++ b/mw_virtual_endpoint.go
@@ -168,7 +168,7 @@ func (d *VirtualEndpoint) ServeHTTPForCache(w http.ResponseWriter, r *http.Reque
 
 	// Save the sesison data (if modified)
 	if vmeta.UseSession {
-		session.MetaData = newResponseData.SessionMeta
+		session.MetaData = mapStrsToIfaces(newResponseData.SessionMeta)
 		d.Spec.SessionManager.UpdateSession(token, session, getLifetime(d.Spec, session))
 	}
 

--- a/plugins.go
+++ b/plugins.go
@@ -216,7 +216,7 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 
 	// Save the sesison data (if modified)
 	if !d.Pre && d.UseSession && len(newRequestData.SessionMeta) > 0 {
-		session.MetaData = newRequestData.SessionMeta
+		session.MetaData = mapStrsToIfaces(newRequestData.SessionMeta)
 		d.Spec.SessionManager.UpdateSession(token, session, getLifetime(d.Spec, session))
 	}
 
@@ -234,6 +234,16 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 	}
 
 	return nil, 200
+}
+
+func mapStrsToIfaces(m map[string]string) map[string]interface{} {
+	// TODO: do we really need this conversion? note that we can't
+	// make SessionState.MetaData a map[string]string, however.
+	m2 := make(map[string]interface{}, len(m))
+	for k, v := range m {
+		m2[k] = v
+	}
+	return m2
 }
 
 // --- Utility functions during startup to ensure a sane VM is present for each API Def ----

--- a/session_state.go
+++ b/session_state.go
@@ -58,13 +58,13 @@ type SessionState struct {
 	Monitor       struct {
 		TriggerLimits []float64 `json:"trigger_limits" msg:"trigger_limits"`
 	} `json:"monitor" msg:"monitor"`
-	EnableDetailedRecording bool              `json:"enable_detail_recording" msg:"enable_detail_recording"`
-	MetaData                map[string]string `json:"meta_data" msg:"meta_data"`
-	Tags                    []string          `json:"tags" msg:"tags"`
-	Alias                   string            `json:"alias" msg:"alias"`
-	LastUpdated             string            `json:"last_updated" msg:"last_updated"`
-	IdExtractorDeadline     int64             `json:"id_extractor_deadline" msg:"id_extractor_deadline"`
-	SessionLifetime         int64             `bson:"session_lifetime" json:"session_lifetime"`
+	EnableDetailedRecording bool                   `json:"enable_detail_recording" msg:"enable_detail_recording"`
+	MetaData                map[string]interface{} `json:"meta_data" msg:"meta_data"`
+	Tags                    []string               `json:"tags" msg:"tags"`
+	Alias                   string                 `json:"alias" msg:"alias"`
+	LastUpdated             string                 `json:"last_updated" msg:"last_updated"`
+	IdExtractorDeadline     int64                  `json:"id_extractor_deadline" msg:"id_extractor_deadline"`
+	SessionLifetime         int64                  `bson:"session_lifetime" json:"session_lifetime"`
 
 	firstSeenHash string
 }


### PR DESCRIPTION
This was seen as a safe change because the gateway never uses values
other than strings, nor does it have tests that use it any other way.

However, the dashboard does use nested objects with strings in them.
Thus this change broke the dashboard.

Revert the change, updating the old map conversion TODO and adding
another one in the fmt.Sprintf call, since we probably want something
stricter and more predictable.

There is still work to do here, as this still allows for too many types.
However, reverting is the right decision now to un-break the dashboard
for 2.4.