### PR TITLE
all: disable and deprecate health check

### DIFF
--- a/api_healthcheck.go
+++ b/api_healthcheck.go
@@ -38,6 +38,7 @@ type DefaultHealthChecker struct {
 func (h *DefaultHealthChecker) Init(storeType StorageHandler) {
 	if globalConf.HealthCheck.EnableHealthChecks {
 		log.Debug("Health Checker initialised.")
+		log.Warning("The Health Checker is deprecated and we do no longer recommend its use.")
 	}
 
 	h.storage = storeType

--- a/api_test.go
+++ b/api_test.go
@@ -52,6 +52,9 @@ type testAPIDefinition struct {
 
 func TestHealthCheckEndpoint(t *testing.T) {
 	uri := "/tyk/health/?api_id=1"
+	old := globalConf.HealthCheck.EnableHealthChecks
+	globalConf.HealthCheck.EnableHealthChecks = true
+	defer func() { globalConf.HealthCheck.EnableHealthChecks = old }()
 
 	recorder := httptest.NewRecorder()
 	loadSampleAPI(t, apiTestDef)
@@ -417,7 +420,7 @@ func TestCreateKeyHandlerCreateNewKey(t *testing.T) {
 }
 
 func TestAPIAuthFail(t *testing.T) {
-	uri := "/tyk/health/?api_id=1"
+	uri := "/tyk/apis/"
 	loadSampleAPI(t, apiTestDef)
 
 	recorder := httptest.NewRecorder()
@@ -432,7 +435,7 @@ func TestAPIAuthFail(t *testing.T) {
 }
 
 func TestAPIAuthOk(t *testing.T) {
-	uri := "/tyk/health/?api_id=1"
+	uri := "/tyk/apis/"
 
 	recorder := httptest.NewRecorder()
 	req := withAuth(testReq(t, "GET", uri, nil))

--- a/config/config.go
+++ b/config/config.go
@@ -278,10 +278,6 @@ func WriteDefault(path string, conf *Config) {
 			MaxIdle: 100,
 			Port:    6379,
 		},
-		HealthCheck: HealthCheckConfig{
-			EnableHealthChecks:      true,
-			HealthCheckValueTimeout: 60,
-		},
 		AnalyticsConfig: AnalyticsConfigConfig{
 			IgnoredIPs: make([]string, 0),
 		},

--- a/tyk.conf.example
+++ b/tyk.conf.example
@@ -26,10 +26,6 @@
     "purge_delay": -1,
     "ignored_ips": []
   },
-  "health_check": {
-    "enable_health_checks": true,
-    "health_check_value_timeouts": 60
-  },
   "optimisations_use_async_session_write": true,
   "allow_master_keys": false,
   "policies": {


### PR DESCRIPTION
Disable it by default and remove from the sample config. Also show a
warning if used.

Fixes #784.