### PR TITLE
Response overrides

### DIFF
--- a/coprocess_id_extractor.go
+++ b/coprocess_id_extractor.go
@@ -39,7 +39,7 @@ func (e *BaseExtractor) ExtractAndCheck(r *http.Request) (sessionID string, retu
 	log.WithFields(logrus.Fields{
 		"prefix": "idextractor",
 	}).Error("This extractor doesn't implement an extraction method, rejecting.")
-	return "", ReturnOverrides{403, "Key not authorised"}
+	return "", ReturnOverrides{ResponseCode:403, ResponseError:"Key not authorised"}
 }
 
 // PostProcess sets context variables and updates the storage.

--- a/coprocess_id_extractor.go
+++ b/coprocess_id_extractor.go
@@ -39,7 +39,7 @@ func (e *BaseExtractor) ExtractAndCheck(r *http.Request) (sessionID string, retu
 	log.WithFields(logrus.Fields{
 		"prefix": "idextractor",
 	}).Error("This extractor doesn't implement an extraction method, rejecting.")
-	return "", ReturnOverrides{ResponseCode:403, ResponseError:"Key not authorised"}
+	return "", ReturnOverrides{ResponseCode: 403, ResponseError: "Key not authorised"}
 }
 
 // PostProcess sets context variables and updates the storage.

--- a/mw_virtual_endpoint.go
+++ b/mw_virtual_endpoint.go
@@ -174,6 +174,19 @@ func (d *VirtualEndpoint) ServeHTTPForCache(w http.ResponseWriter, r *http.Reque
 
 	log.Debug("JSVM Virtual Endpoint execution took: (ns) ", time.Now().UnixNano()-t1)
 
+	copiedResponse, code := ForceResponse(w, r, &newResponseData, d.Spec, session, false)
+
+	go d.sh.RecordHit(r, 0, code, copiedRequest, copiedResponse)
+
+	return copiedResponse
+
+}
+
+func ForceResponse(w http.ResponseWriter,
+	r *http.Request,
+	newResponseData *VMResponseObject,
+	spec *APISpec,
+	session *SessionState, isPre bool) (*http.Response, int) {
 	responseMessage := []byte(newResponseData.Response.Body)
 
 	// Create an http.Response object so we can send it tot he cache middleware
@@ -195,15 +208,11 @@ func (d *VirtualEndpoint) ServeHTTPForCache(w http.ResponseWriter, r *http.Reque
 	newResponse.Header.Set("Server", "tyk")
 	newResponse.Header.Set("Date", requestTime)
 
-	// Handle response middleware
-	if err := handleResponseChain(d.Spec.ResponseChain, w, newResponse, r, session); err != nil {
-		log.Error("Response chain failed! ", err)
-	}
-
-	// deep logging
-	var copiedResponse *http.Response
-	if RecordDetail(r) {
-		copiedResponse = CopyHttpResponse(newResponse)
+	if !isPre {
+		// Handle response middleware
+		if err := handleResponseChain(spec.ResponseChain, w, newResponse, r, session); err != nil {
+			log.Error("Response chain failed! ", err)
+		}
 	}
 
 	// Clone the response so we can save it
@@ -223,13 +232,10 @@ func (d *VirtualEndpoint) ServeHTTPForCache(w http.ResponseWriter, r *http.Reque
 	newResponse.Body = ioutil.NopCloser(&bodyBuffer)
 	copiedRes.Body = ioutil.NopCloser(bodyBuffer2)
 
-	d.HandleResponse(w, newResponse, session)
+	HandleForcedResponse(w, newResponse, session)
 
 	// Record analytics
-	go d.sh.RecordHit(r, 0, newResponse.StatusCode, copiedRequest, copiedResponse)
-
-	return copiedRes
-
+	return copiedRes, newResponse.StatusCode
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
@@ -245,7 +251,12 @@ func (d *VirtualEndpoint) ProcessRequest(w http.ResponseWriter, r *http.Request,
 }
 
 func (d *VirtualEndpoint) HandleResponse(rw http.ResponseWriter, res *http.Response, ses *SessionState) error {
+	// Externalising this from the MW so we can re-use it elsewhere
+	return HandleForcedResponse(rw, res, ses)
 
+}
+
+func HandleForcedResponse(rw http.ResponseWriter, res *http.Response, ses *SessionState) error {
 	defer res.Body.Close()
 
 	// Close connections

--- a/mw_virtual_endpoint.go
+++ b/mw_virtual_endpoint.go
@@ -250,13 +250,12 @@ func (d *VirtualEndpoint) ProcessRequest(w http.ResponseWriter, r *http.Request,
 	return nil, mwStatusRespond
 }
 
-func (d *VirtualEndpoint) HandleResponse(rw http.ResponseWriter, res *http.Response, ses *SessionState) error {
+func (d *VirtualEndpoint) HandleResponse(rw http.ResponseWriter, res *http.Response, ses *SessionState) {
 	// Externalising this from the MW so we can re-use it elsewhere
-	return handleForcedResponse(rw, res, ses)
-
+	handleForcedResponse(rw, res, ses)
 }
 
-func handleForcedResponse(rw http.ResponseWriter, res *http.Response, ses *SessionState) error {
+func handleForcedResponse(rw http.ResponseWriter, res *http.Response, ses *SessionState) {
 	defer res.Body.Close()
 
 	// Close connections
@@ -276,5 +275,4 @@ func handleForcedResponse(rw http.ResponseWriter, res *http.Response, ses *Sessi
 
 	rw.WriteHeader(res.StatusCode)
 	io.Copy(rw, res.Body)
-	return nil
 }

--- a/plugins.go
+++ b/plugins.go
@@ -229,7 +229,7 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 		return errors.New(newRequestData.Request.ReturnOverrides.ResponseError), newRequestData.Request.ReturnOverrides.ResponseCode
 	}
 
-	if newRequestData.Request.ReturnOverrides.ResponseCode != 0 && newRequestData.Request.ReturnOverrides.ResponseCode <= 300 {
+	if newRequestData.Request.ReturnOverrides.ResponseCode != 0 && newRequestData.Request.ReturnOverrides.ResponseCode < 300 {
 
 		responseObject := VMResponseObject{
 			Response: ResponseObject{

--- a/plugins.go
+++ b/plugins.go
@@ -18,8 +18,8 @@ import (
 
 // Lets the user override and return a response from middleware
 type ReturnOverrides struct {
-	ResponseCode  int
-	ResponseError string
+	ResponseCode    int
+	ResponseError   string
 	ResponseHeaders map[string]string
 }
 
@@ -225,22 +225,22 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 		"prefix": "jsvm",
 	}).Debug("JSVM middleware execution took: (ns) ", time.Now().UnixNano()-t1)
 
-	if newRequestData.Request.ReturnOverrides.ResponseCode != 0 && newRequestData.Request.ReturnOverrides.ResponseCode > 300 {
+	if newRequestData.Request.ReturnOverrides.ResponseCode >= 400 {
 		return errors.New(newRequestData.Request.ReturnOverrides.ResponseError), newRequestData.Request.ReturnOverrides.ResponseCode
 	}
 
-	if newRequestData.Request.ReturnOverrides.ResponseCode != 0 && newRequestData.Request.ReturnOverrides.ResponseCode < 300 {
+	if newRequestData.Request.ReturnOverrides.ResponseCode != 0 && newRequestData.Request.ReturnOverrides.ResponseCode <= 300 {
 
 		responseObject := VMResponseObject{
 			Response: ResponseObject{
-				Body: newRequestData.Request.ReturnOverrides.ResponseError,
-				Code: newRequestData.Request.ReturnOverrides.ResponseCode,
+				Body:    newRequestData.Request.ReturnOverrides.ResponseError,
+				Code:    newRequestData.Request.ReturnOverrides.ResponseCode,
 				Headers: newRequestData.Request.ReturnOverrides.ResponseHeaders,
 			},
 		}
 
-		ForceResponse(w, r, &responseObject, d.Spec, session, d.Pre)
-		return nil, 666
+		forceResponse(w, r, &responseObject, d.Spec, session, d.Pre)
+		return nil, mwStatusRespond
 	}
 
 	if d.Auth {

--- a/plugins.go
+++ b/plugins.go
@@ -14,13 +14,13 @@ import (
 	_ "github.com/robertkrimen/otto/underscore"
 
 	"github.com/Sirupsen/logrus"
-	"fmt"
 )
 
 // Lets the user override and return a response from middleware
 type ReturnOverrides struct {
 	ResponseCode  int
 	ResponseError string
+	ResponseHeaders map[string]string
 }
 
 // MiniRequestObject is marshalled to JSON string and passed into JSON middleware
@@ -235,6 +235,7 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 			Response: ResponseObject{
 				Body: newRequestData.Request.ReturnOverrides.ResponseError,
 				Code: newRequestData.Request.ReturnOverrides.ResponseCode,
+				Headers: newRequestData.Request.ReturnOverrides.ResponseHeaders,
 			},
 		}
 

--- a/plugins_test.go
+++ b/plugins_test.go
@@ -134,3 +134,91 @@ testJSVMData.NewProcessRequest(function(request, session, config) {
 		t.Fatalf("wanted header to be %q, got %q", want, got)
 	}
 }
+
+func TestJSVMReturnOverridesFullResponse(t *testing.T) {
+	spec := &APISpec{APIDefinition: &apidef.APIDefinition{}}
+	spec.ConfigData = map[string]interface{}{
+		"foo": "bar",
+	}
+	const js = `
+var testJSVMData = new TykJS.TykMiddleware.NewMiddleware({});
+
+testJSVMData.NewProcessRequest(function(request, session, config) {
+	request.ReturnOverrides.ResponseError = "Foobarbaz"
+	request.ReturnOverrides.ResponseCode = 200
+	request.ReturnOverrides.ResponseHeaders = {
+		"X-Foo": "Bar",
+		"X-Baz": "Qux"
+	}
+	return testJSVMData.ReturnData(request, {});
+});`
+	dynMid := &DynamicMiddleware{
+		BaseMiddleware:      &BaseMiddleware{spec, nil},
+		MiddlewareClassName: "testJSVMData",
+		Pre:                 true,
+	}
+	jsvm := JSVM{}
+	jsvm.Init()
+	if _, err := jsvm.VM.Run(js); err != nil {
+		t.Fatalf("failed to set up js plugin: %v", err)
+	}
+	dynMid.Spec.JSVM = jsvm
+
+	rec := httptest.NewRecorder()
+	r := testReq(t, "GET", "/v1/test-data", nil)
+	dynMid.ProcessRequest(rec, r, nil)
+
+	wantBody := "Foobarbaz"
+	gotBody := rec.Body.String()
+	if wantBody != gotBody {
+		t.Fatalf("wanted body to be %q, got %q", wantBody, gotBody)
+	}
+	if want, got := "Bar", rec.HeaderMap.Get("x-foo"); got != want {
+		t.Fatalf("wanted header to be %q, got %q", want, got)
+	}
+	if want, got := "Qux", rec.HeaderMap.Get("x-baz"); got != want {
+		t.Fatalf("wanted header to be %q, got %q", want, got)
+	}
+
+	if want := 200; rec.Code != 200 {
+		t.Fatalf("wanted code to be %d, got %d", want, rec.Code)
+	}
+}
+
+func TestJSVMReturnOverridesError(t *testing.T) {
+	spec := &APISpec{APIDefinition: &apidef.APIDefinition{}}
+	spec.ConfigData = map[string]interface{}{
+		"foo": "bar",
+	}
+	const js = `
+var testJSVMData = new TykJS.TykMiddleware.NewMiddleware({});
+
+testJSVMData.NewProcessRequest(function(request, session, config) {
+	request.ReturnOverrides.ResponseError = "Foobarbaz"
+	request.ReturnOverrides.ResponseCode = 401
+	return testJSVMData.ReturnData(request, {});
+});`
+	dynMid := &DynamicMiddleware{
+		BaseMiddleware:      &BaseMiddleware{spec, nil},
+		MiddlewareClassName: "testJSVMData",
+		Pre:                 true,
+	}
+	jsvm := JSVM{}
+	jsvm.Init()
+	if _, err := jsvm.VM.Run(js); err != nil {
+		t.Fatalf("failed to set up js plugin: %v", err)
+	}
+	dynMid.Spec.JSVM = jsvm
+
+	r := testReq(t, "GET", "/v1/test-data", nil)
+	err, code := dynMid.ProcessRequest(nil, r, nil)
+
+	if want := 401; code != 401 {
+		t.Fatalf("wanted code to be %d, got %d", want, code)
+	}
+
+	wantBody := "Foobarbaz"
+	if !strings.Contains(err.Error(), wantBody) {
+		t.Fatalf("wanted body to contain to be %d, got %d", wantBody, err.Error())
+	}
+}

--- a/plugins_test.go
+++ b/plugins_test.go
@@ -219,6 +219,6 @@ testJSVMData.NewProcessRequest(function(request, session, config) {
 
 	wantBody := "Foobarbaz"
 	if !strings.Contains(err.Error(), wantBody) {
-		t.Fatalf("wanted body to contain to be %d, got %d", wantBody, err.Error())
+		t.Fatalf("wanted body to contain to be %v, got %v", wantBody, err.Error())
 	}
 }


### PR DESCRIPTION
This just adds support to override the response from the JSVM in terms of the Body, Headers and Status code, it adds more support than the current version which just allows overriding an error.

@matiasinsaurralde I'll need your help with the CP integration, I think the ReturnOverrides are only used in the AuthChecker at the moment, and not in Otto, so they will start diverging in behaviour?