### PR TITLE
all: don't use Buffers as string readers

### DIFF
--- a/coprocess.go
+++ b/coprocess.go
@@ -3,12 +3,13 @@
 package main
 
 import (
+	"strings"
+
 	"github.com/Sirupsen/logrus"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/coprocess"
 
-	"bytes"
 	"errors"
 	"io/ioutil"
 	"net/http"
@@ -126,7 +127,7 @@ func (c *CoProcessor) ObjectFromRequest(r *http.Request) *coprocess.Object {
 // ObjectPostProcess does CoProcessObject post-processing (adding/removing headers or params, etc.).
 func (c *CoProcessor) ObjectPostProcess(object *coprocess.Object, r *http.Request) {
 	r.ContentLength = int64(len(object.Request.Body))
-	r.Body = ioutil.NopCloser(bytes.NewBufferString(object.Request.Body))
+	r.Body = ioutil.NopCloser(strings.NewReader(object.Request.Body))
 
 	for _, dh := range object.Request.DeleteHeaders {
 		r.Header.Del(dh)

--- a/coprocess_id_extractor.go
+++ b/coprocess_id_extractor.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"bytes"
 	"crypto/md5"
 	"errors"
 	"fmt"
@@ -251,7 +250,6 @@ func (e *XPathExtractor) ExtractAndCheck(r *http.Request) (SessionID string, ret
 	expressionString := e.Config.ExtractorConfig["xpath_expression"].(string)
 
 	expression, err := xmlpath.Compile(expressionString)
-
 	if err != nil {
 		returnOverrides = e.Error(r, err, "XPathExtractor: bad expression")
 		return SessionID, returnOverrides
@@ -265,21 +263,18 @@ func (e *XPathExtractor) ExtractAndCheck(r *http.Request) (SessionID string, ret
 	case apidef.FormSource:
 		extractorOutput, err = e.ExtractForm(r, config.FormParamName)
 	}
-
 	if err != nil {
 		returnOverrides = e.Error(r, err, "XPathExtractor error")
 		return SessionID, returnOverrides
 	}
 
-	extractedXml, err := xmlpath.Parse(bytes.NewBufferString(extractorOutput))
-
+	extractedXml, err := xmlpath.Parse(strings.NewReader(extractorOutput))
 	if err != nil {
 		returnOverrides = e.Error(r, err, "XPathExtractor: couldn't parse input")
 		return SessionID, returnOverrides
 	}
 
 	output, ok := expression.String(extractedXml)
-
 	if !ok {
 		returnOverrides = e.Error(r, err, "XPathExtractor: no input")
 		return SessionID, returnOverrides
@@ -288,7 +283,6 @@ func (e *XPathExtractor) ExtractAndCheck(r *http.Request) (SessionID string, ret
 	SessionID = e.GenerateSessionID(output, e.BaseMid)
 
 	previousSession, keyExists := e.BaseMid.CheckSessionAndIdentityForValidKey(SessionID)
-
 	if keyExists {
 
 		lastUpdated, _ := strconv.Atoi(previousSession.LastUpdated)

--- a/host_checker.go
+++ b/host_checker.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"bytes"
 	"math/rand"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -148,8 +148,7 @@ func (h *HostUptimeChecker) CheckHost(toCheck HostData) {
 		useMethod = "GET"
 	}
 
-	body := []byte(toCheck.Body)
-	req, err := http.NewRequest(useMethod, toCheck.CheckURL, bytes.NewBuffer(body))
+	req, err := http.NewRequest(useMethod, toCheck.CheckURL, strings.NewReader(toCheck.Body))
 	if err != nil {
 		log.Error("Could not create request: ", err)
 		return

--- a/mw_virtual_endpoint.go
+++ b/mw_virtual_endpoint.go
@@ -126,7 +126,7 @@ func (d *VirtualEndpoint) ServeHTTPForCache(w http.ResponseWriter, r *http.Reque
 	}
 
 	// We need to copy the body _back_ for the decode
-	r.Body = ioutil.NopCloser(bytes.NewBuffer(originalBody))
+	r.Body = ioutil.NopCloser(bytes.NewReader(originalBody))
 	r.ParseForm()
 	requestData.Params = r.Form
 

--- a/plugins.go
+++ b/plugins.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/robertkrimen/otto"
@@ -180,10 +181,10 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 	// Reconstruct the request parts
 	if newRequestData.Request.IgnoreBody {
 		r.ContentLength = int64(len(originalBody))
-		r.Body = ioutil.NopCloser(bytes.NewBuffer(originalBody))
+		r.Body = ioutil.NopCloser(bytes.NewReader(originalBody))
 	} else {
 		r.ContentLength = int64(len(newRequestData.Request.Body))
-		r.Body = ioutil.NopCloser(bytes.NewBuffer(newRequestData.Request.Body))
+		r.Body = ioutil.NopCloser(bytes.NewReader(newRequestData.Request.Body))
 	}
 
 	r.URL.Path = newRequestData.Request.URL
@@ -396,7 +397,7 @@ func (j *JSVM) LoadTykJSApi() {
 		r, _ := http.NewRequest(hro.Method, urlStr, nil)
 
 		if d != "" {
-			r, _ = http.NewRequest(hro.Method, urlStr, bytes.NewBufferString(d))
+			r, _ = http.NewRequest(hro.Method, urlStr, strings.NewReader(d))
 		}
 
 		for k, v := range hro.Headers {


### PR DESCRIPTION
It's overkill - bytes.Reader and strings.Reader are more lightweight and
make the code easier to understand.