### PR TITLE
proxy: merge Init with constructors

### DIFF
--- a/api_loader.go
+++ b/api_loader.go
@@ -249,13 +249,10 @@ func processSpec(spec *APISpec,
 			"prefix":   "main",
 			"api_name": spec.Name,
 		}).Info("Multi target enabled")
-		proxy = &MultiTargetProxy{}
+		proxy = NewMultiTargetProxy(spec)
 	} else {
 		proxy = TykNewSingleHostReverseProxy(remote, spec)
 	}
-
-	// initialise the proxy
-	proxy.Init(spec)
 
 	// Create the response processors
 	creeateResponseMiddlewareChain(spec)

--- a/handler_success.go
+++ b/handler_success.go
@@ -31,7 +31,6 @@ var SessionCache = cache.New(10*time.Second, 5*time.Second)
 var ExpiryCache = cache.New(600*time.Second, 10*time.Minute)
 
 type ReturningHttpHandler interface {
-	Init(*APISpec) error
 	ServeHTTP(http.ResponseWriter, *http.Request) *http.Response
 	ServeHTTPForCache(http.ResponseWriter, *http.Request) *http.Response
 	CopyResponse(io.Writer, io.Reader)

--- a/host_checker_test.go
+++ b/host_checker_test.go
@@ -209,7 +209,6 @@ func TestReverseProxyAllDown(t *testing.T) {
 
 	remote, _ := url.Parse(testHttpAny)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
-	proxy.Init(spec)
 
 	req := testReq(t, "GET", "/", nil)
 	rec := httptest.NewRecorder()

--- a/multi_target_proxy_handler.go
+++ b/multi_target_proxy_handler.go
@@ -53,7 +53,8 @@ func (m *MultiTargetProxy) CopyResponse(dst io.Writer, src io.Reader) {
 	m.defaultProxy.CopyResponse(dst, src)
 }
 
-func (m *MultiTargetProxy) Init(spec *APISpec) error {
+func NewMultiTargetProxy(spec *APISpec) *MultiTargetProxy {
+	m := &MultiTargetProxy{}
 	m.VersionProxyMap = make(map[string]*ReverseProxy)
 	m.specReference = spec
 
@@ -64,7 +65,6 @@ func (m *MultiTargetProxy) Init(spec *APISpec) error {
 		}).Error("Couldn't parse default target URL in MultiTarget: ", err)
 	}
 	m.defaultProxy = TykNewSingleHostReverseProxy(remote, spec)
-	m.defaultProxy.Init(spec)
 
 	for versionName, versionData := range spec.VersionData.Versions {
 		if versionData.OverrideTarget == "" {
@@ -89,7 +89,6 @@ func (m *MultiTargetProxy) Init(spec *APISpec) error {
 				}).Error("Couldn't parse version target URL in MultiTarget: ", err)
 			}
 			versionProxy := TykNewSingleHostReverseProxy(versionRemote, spec)
-			versionProxy.Init(spec)
 			m.VersionProxyMap[versionName] = versionProxy
 		}
 	}


### PR DESCRIPTION
Init is a bit silly, because it's always passed the same spec that was
passed to the constructor. It also bit me when writing the "all hosts
are down" tests, since forgetting to call Init can lead to panics.

Convert the MultiTagetProxy to the same format, adding a constructor.