### PR TITLE
test: wait for mock gorpc server to start

### DIFF
--- a/api_definition_test.go
+++ b/api_definition_test.go
@@ -321,7 +321,9 @@ func startRPCMock(dispatcher *gorpc.Dispatcher) *gorpc.Server {
 
 	globalConf.SlaveOptions.ConnectionString = server.Addr
 
-	go server.Serve()
+	if err := server.Start(); err != nil {
+		panic(err)
+	}
 
 	return server
 }


### PR DESCRIPTION
And catch its start error, if any.

The problem with using Serve is that it blocks until the server is
stopped, so we must use a goroutine. But then it's impossible to wait
for the server to be ready to accept connections. This lead to the RPC
tests being flakey and sometimes slow, due to the fact that we might
send requests to it before the server is ready.

I was able to reproduce the test timeout that CI was running into, as
well as test runs that took ~1s instead of ~0s, by chaining multiple
goroutines when calling Serve to randomize further when the server may
be started.

Fixes #835.