### PR TITLE
rpc: simplify bits of code

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -321,7 +321,7 @@ func (a APIDefinitionLoader) FromRPC(orgId string) []*APISpec {
 
 	//store.Disconnect()
 
-	if RPC_LoadCount > 0 {
+	if rpcLoadCount > 0 {
 		saveRPCDefinitionsBackup(apiCollection)
 	}
 

--- a/api_loader.go
+++ b/api_loader.go
@@ -220,7 +220,7 @@ func processSpec(spec *APISpec,
 
 	if spec.UseOauth2 {
 		log.Debug("Loading OAuth Manager")
-		if !RPC_EmergencyMode {
+		if !rpcEmergencyMode {
 			oauthManager := addOAuthHandlers(spec, subrouter)
 			log.Debug("-- Added OAuth Handlers")
 

--- a/main.go
+++ b/main.go
@@ -579,8 +579,8 @@ func doReload() {
 	}).Info("API reload complete")
 
 	// Unset these
-	RPC_EmergencyModeLoaded = false
-	RPC_EmergencyMode = false
+	rpcEmergencyModeLoaded = false
+	rpcEmergencyMode = false
 }
 
 // startReloadChan and reloadDoneChan are used by the two reload loops
@@ -1223,7 +1223,7 @@ func listen(l, controlListener net.Listener, err error) {
 
 		startDRL()
 
-		if !RPC_EmergencyMode {
+		if !rpcEmergencyMode {
 			specs := getAPISpecs()
 			if specs != nil {
 				loadApps(specs, defaultRouter)
@@ -1273,7 +1273,7 @@ func listen(l, controlListener net.Listener, err error) {
 
 			go http.Serve(l, nil)
 
-			if !RPC_EmergencyMode {
+			if !rpcEmergencyMode {
 				newServeMux := http.NewServeMux()
 				newServeMux.Handle("/", mainRouter)
 				http.DefaultServeMux = newServeMux
@@ -1306,7 +1306,7 @@ func listen(l, controlListener net.Listener, err error) {
 		startDRL()
 
 		// Resume accepting connections in a new goroutine.
-		if !RPC_EmergencyMode {
+		if !rpcEmergencyMode {
 			specs := getAPISpecs()
 			if specs != nil {
 				loadApps(specs, defaultRouter)
@@ -1354,7 +1354,7 @@ func listen(l, controlListener net.Listener, err error) {
 
 			go http.Serve(l, nil)
 
-			if !RPC_EmergencyMode {
+			if !rpcEmergencyMode {
 				newServeMux := http.NewServeMux()
 				newServeMux.Handle("/", mainRouter)
 				http.DefaultServeMux = newServeMux

--- a/rpc_backup_handlers.go
+++ b/rpc_backup_handlers.go
@@ -115,7 +115,7 @@ func doLoadWithBackup(specs []*APISpec) {
 	}).Info("API backup load complete")
 
 	log.Warning("[RPC Backup] --> Ready to listen")
-	RPC_EmergencyModeLoaded = true
+	rpcEmergencyModeLoaded = true
 
 	l, err := generateListener(0)
 	if err != nil {


### PR DESCRIPTION
Unexport the RPC_* variables, remove some unnecessary returns and get
rid of some redundant variables.