### PR TITLE
test: use a random port for the mock rpc server

### DIFF
--- a/api_definition_test.go
+++ b/api_definition_test.go
@@ -315,15 +315,15 @@ func startRPCMock(dispatcher *gorpc.Dispatcher) *gorpc.Server {
 	globalConf.SlaveOptions.RPCKey = "test_org"
 	globalConf.SlaveOptions.APIKey = "test"
 
-	server := gorpc.NewTCPServer(":9090", dispatcher.NewHandlerFunc())
-	server.Listener = &customListener{}
+	server := gorpc.NewTCPServer(":0", dispatcher.NewHandlerFunc())
+	list := &customListener{}
+	server.Listener = list
 	server.LogError = gorpc.NilErrorLogger
-
-	globalConf.SlaveOptions.ConnectionString = server.Addr
 
 	if err := server.Start(); err != nil {
 		panic(err)
 	}
+	globalConf.SlaveOptions.ConnectionString = list.L.Addr().String()
 
 	return server
 }
@@ -462,7 +462,6 @@ func (ln *customListener) Init(addr string) (err error) {
 
 func (ln *customListener) Accept() (conn io.ReadWriteCloser, clientAddr string, err error) {
 	c, err := ln.L.Accept()
-
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
We tried this before, but failed because we weren't waiting for the
server to start up, thus we didn't have the final address.

Now that we do, this is fairly trivial. This should get rid of the
"address in use" flake on CI. It's not clear what is causing the flake,
as we haven't been able to reproduce it locally, but there is no need to
use a fixed port in any case.

Fixes #835.