### PR TITLE
all: simplify last getter method

### DIFF
--- a/api.go
+++ b/api.go
@@ -409,7 +409,7 @@ func handleDeleteHashedKey(keyName, apiID string) (interface{}, int) {
 	}
 
 	// This is so we bypass the hash function
-	sessStore := sessionManager.GetStore()
+	sessStore := sessionManager.Store()
 
 	// TODO: This is pretty ugly
 	setKeyName := "apikey-" + keyName
@@ -641,7 +641,7 @@ func handleUpdateHashedKey(keyName, apiID, policyId string) (interface{}, int) {
 	}
 
 	// This is so we bypass the hash function
-	sessStore := sessionManager.GetStore()
+	sessStore := sessionManager.Store()
 
 	// TODO: This is pretty ugly
 	setKeyName := "apikey-" + keyName

--- a/mw_organisation_activity.go
+++ b/mw_organisation_activity.go
@@ -74,7 +74,7 @@ func (k *OrganizationMonitor) ProcessRequestLive(w http.ResponseWriter, r *http.
 	// We found a session, apply the quota limiter
 	reason := k.sessionlimiter.ForwardMessage(&session,
 		k.Spec.OrgID,
-		k.Spec.OrgSessionManager.GetStore(), false, false)
+		k.Spec.OrgSessionManager.Store(), false, false)
 
 	k.Spec.OrgSessionManager.UpdateSession(k.Spec.OrgID, &session, getLifetime(k.Spec, &session))
 
@@ -175,7 +175,7 @@ func (k *OrganizationMonitor) AllowAccessNext(orgChan chan bool, r *http.Request
 	}
 
 	// We found a session, apply the quota limiter
-	isQuotaExceeded := k.sessionlimiter.IsRedisQuotaExceeded(&session, k.Spec.OrgID, k.Spec.OrgSessionManager.GetStore())
+	isQuotaExceeded := k.sessionlimiter.IsRedisQuotaExceeded(&session, k.Spec.OrgID, k.Spec.OrgSessionManager.Store())
 
 	k.Spec.OrgSessionManager.UpdateSession(k.Spec.OrgID, &session, getLifetime(k.Spec, &session))
 

--- a/mw_rate_limiting.go
+++ b/mw_rate_limiting.go
@@ -71,7 +71,7 @@ func (k *RateLimitAndQuotaCheck) ProcessRequest(w http.ResponseWriter, r *http.R
 	session := ctxGetSession(r)
 	token := ctxGetAuthToken(r)
 
-	storeRef := k.Spec.SessionManager.GetStore()
+	storeRef := k.Spec.SessionManager.Store()
 	reason := sessionLimiter.ForwardMessage(session,
 		token,
 		storeRef,


### PR DESCRIPTION
Missed this in the refactor that removed useless Get prefixes from
getters.