### PR TITLE
loader: remove some temporary mw chains

### DIFF
--- a/coprocess.go
+++ b/coprocess.go
@@ -44,7 +44,7 @@ func CreateCoProcessMiddleware(hookName string, hookType coprocess.HookType, mwD
 		MiddlewareDriver: mwDriver,
 	}
 
-	return CreateMiddleware(dMiddleware)
+	return createMiddleware(dMiddleware)
 }
 
 func doCoprocessReload() {

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -288,14 +288,14 @@ func getChain(spec *APISpec) http.Handler {
 	proxyHandler := ProxyHandler(proxy, spec)
 	baseMid := &BaseMiddleware{spec, proxy}
 	chain := alice.New(
-		CreateMiddleware(&IPWhiteListMiddleware{baseMid}),
-		CreateMiddleware(&MiddlewareContextVars{BaseMiddleware: baseMid}),
-		CreateMiddleware(&AuthKey{baseMid}),
-		CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid}),
-		CreateMiddleware(&KeyExpired{baseMid}),
-		CreateMiddleware(&AccessRightsCheck{baseMid}),
-		CreateMiddleware(&RateLimitAndQuotaCheck{baseMid}),
-		CreateMiddleware(&TransformHeaders{baseMid})).Then(proxyHandler)
+		createMiddleware(&IPWhiteListMiddleware{baseMid}),
+		createMiddleware(&MiddlewareContextVars{BaseMiddleware: baseMid}),
+		createMiddleware(&AuthKey{baseMid}),
+		createMiddleware(&VersionCheck{BaseMiddleware: baseMid}),
+		createMiddleware(&KeyExpired{baseMid}),
+		createMiddleware(&AccessRightsCheck{baseMid}),
+		createMiddleware(&RateLimitAndQuotaCheck{baseMid}),
+		createMiddleware(&TransformHeaders{baseMid})).Then(proxyHandler)
 
 	return chain
 }

--- a/middleware.go
+++ b/middleware.go
@@ -32,7 +32,7 @@ func CreateDynamicMiddleware(name string, isPre, useSession bool, baseMid *BaseM
 		UseSession:          useSession,
 	}
 
-	return CreateMiddleware(dMiddleware)
+	return createMiddleware(dMiddleware)
 }
 
 func CreateDynamicAuthMiddleware(name string, baseMid *BaseMiddleware) func(http.Handler) http.Handler {
@@ -40,7 +40,7 @@ func CreateDynamicAuthMiddleware(name string, baseMid *BaseMiddleware) func(http
 }
 
 // Generic middleware caller to make extension easier
-func CreateMiddleware(mw TykMiddleware) func(http.Handler) http.Handler {
+func createMiddleware(mw TykMiddleware) func(http.Handler) http.Handler {
 	// construct a new instance
 	mw.Init()
 
@@ -93,9 +93,9 @@ func CreateMiddleware(mw TykMiddleware) func(http.Handler) http.Handler {
 	}
 }
 
-func AppendMiddleware(chain *[]alice.Constructor, mw TykMiddleware) {
+func appendMiddleware(chain *[]alice.Constructor, mw TykMiddleware) {
 	if mw.IsEnabledForSpec() {
-		*chain = append(*chain, CreateMiddleware(mw))
+		*chain = append(*chain, createMiddleware(mw))
 	}
 }
 

--- a/multiauth_test.go
+++ b/multiauth_test.go
@@ -71,13 +71,13 @@ func getMultiAuthStandardAndBasicAuthChain(spec *APISpec) http.Handler {
 	proxyHandler := ProxyHandler(proxy, spec)
 	baseMid := &BaseMiddleware{spec, proxy}
 	chain := alice.New(
-		CreateMiddleware(&IPWhiteListMiddleware{baseMid}),
-		CreateMiddleware(&BasicAuthKeyIsValid{baseMid}),
-		CreateMiddleware(&AuthKey{baseMid}),
-		CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid}),
-		CreateMiddleware(&KeyExpired{baseMid}),
-		CreateMiddleware(&AccessRightsCheck{baseMid}),
-		CreateMiddleware(&RateLimitAndQuotaCheck{baseMid})).Then(proxyHandler)
+		createMiddleware(&IPWhiteListMiddleware{baseMid}),
+		createMiddleware(&BasicAuthKeyIsValid{baseMid}),
+		createMiddleware(&AuthKey{baseMid}),
+		createMiddleware(&VersionCheck{BaseMiddleware: baseMid}),
+		createMiddleware(&KeyExpired{baseMid}),
+		createMiddleware(&AccessRightsCheck{baseMid}),
+		createMiddleware(&RateLimitAndQuotaCheck{baseMid})).Then(proxyHandler)
 
 	return chain
 }

--- a/mw_auth_key_test.go
+++ b/mw_auth_key_test.go
@@ -32,12 +32,12 @@ func getAuthKeyChain(spec *APISpec) http.Handler {
 	proxyHandler := ProxyHandler(proxy, spec)
 	baseMid := &BaseMiddleware{spec, proxy}
 	chain := alice.New(
-		CreateMiddleware(&IPWhiteListMiddleware{baseMid}),
-		CreateMiddleware(&AuthKey{baseMid}),
-		CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid}),
-		CreateMiddleware(&KeyExpired{baseMid}),
-		CreateMiddleware(&AccessRightsCheck{baseMid}),
-		CreateMiddleware(&RateLimitAndQuotaCheck{baseMid})).Then(proxyHandler)
+		createMiddleware(&IPWhiteListMiddleware{baseMid}),
+		createMiddleware(&AuthKey{baseMid}),
+		createMiddleware(&VersionCheck{BaseMiddleware: baseMid}),
+		createMiddleware(&KeyExpired{baseMid}),
+		createMiddleware(&AccessRightsCheck{baseMid}),
+		createMiddleware(&RateLimitAndQuotaCheck{baseMid})).Then(proxyHandler)
 
 	return chain
 }

--- a/mw_basic_auth_test.go
+++ b/mw_basic_auth_test.go
@@ -54,12 +54,12 @@ func getBasicAuthChain(spec *APISpec) http.Handler {
 	proxyHandler := ProxyHandler(proxy, spec)
 	baseMid := &BaseMiddleware{spec, proxy}
 	chain := alice.New(
-		CreateMiddleware(&IPWhiteListMiddleware{baseMid}),
-		CreateMiddleware(&BasicAuthKeyIsValid{baseMid}),
-		CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid}),
-		CreateMiddleware(&KeyExpired{baseMid}),
-		CreateMiddleware(&AccessRightsCheck{baseMid}),
-		CreateMiddleware(&RateLimitAndQuotaCheck{baseMid})).Then(proxyHandler)
+		createMiddleware(&IPWhiteListMiddleware{baseMid}),
+		createMiddleware(&BasicAuthKeyIsValid{baseMid}),
+		createMiddleware(&VersionCheck{BaseMiddleware: baseMid}),
+		createMiddleware(&KeyExpired{baseMid}),
+		createMiddleware(&AccessRightsCheck{baseMid}),
+		createMiddleware(&RateLimitAndQuotaCheck{baseMid})).Then(proxyHandler)
 
 	return chain
 }

--- a/mw_hmac_test.go
+++ b/mw_hmac_test.go
@@ -63,12 +63,12 @@ func getHMACAuthChain(spec *APISpec) http.Handler {
 	proxyHandler := ProxyHandler(proxy, spec)
 	baseMid := &BaseMiddleware{spec, proxy}
 	chain := alice.New(
-		CreateMiddleware(&IPWhiteListMiddleware{baseMid}),
-		CreateMiddleware(&HMACMiddleware{BaseMiddleware: baseMid}),
-		CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid}),
-		CreateMiddleware(&KeyExpired{baseMid}),
-		CreateMiddleware(&AccessRightsCheck{baseMid}),
-		CreateMiddleware(&RateLimitAndQuotaCheck{baseMid})).Then(proxyHandler)
+		createMiddleware(&IPWhiteListMiddleware{baseMid}),
+		createMiddleware(&HMACMiddleware{BaseMiddleware: baseMid}),
+		createMiddleware(&VersionCheck{BaseMiddleware: baseMid}),
+		createMiddleware(&KeyExpired{baseMid}),
+		createMiddleware(&AccessRightsCheck{baseMid}),
+		createMiddleware(&RateLimitAndQuotaCheck{baseMid})).Then(proxyHandler)
 
 	return chain
 }

--- a/mw_jwt_test.go
+++ b/mw_jwt_test.go
@@ -185,12 +185,12 @@ func getJWTChain(spec *APISpec) http.Handler {
 	proxyHandler := ProxyHandler(proxy, spec)
 	baseMid := &BaseMiddleware{spec, proxy}
 	chain := alice.New(
-		CreateMiddleware(&IPWhiteListMiddleware{baseMid}),
-		CreateMiddleware(&JWTMiddleware{baseMid}),
-		CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid}),
-		CreateMiddleware(&KeyExpired{baseMid}),
-		CreateMiddleware(&AccessRightsCheck{baseMid}),
-		CreateMiddleware(&RateLimitAndQuotaCheck{baseMid})).Then(proxyHandler)
+		createMiddleware(&IPWhiteListMiddleware{baseMid}),
+		createMiddleware(&JWTMiddleware{baseMid}),
+		createMiddleware(&VersionCheck{BaseMiddleware: baseMid}),
+		createMiddleware(&KeyExpired{baseMid}),
+		createMiddleware(&AccessRightsCheck{baseMid}),
+		createMiddleware(&RateLimitAndQuotaCheck{baseMid})).Then(proxyHandler)
 
 	return chain
 }

--- a/oauth_manager_test.go
+++ b/oauth_manager_test.go
@@ -108,11 +108,11 @@ func getOAuthChain(spec *APISpec, muxer *mux.Router) {
 	proxyHandler := ProxyHandler(proxy, spec)
 	baseMid := &BaseMiddleware{spec, proxy}
 	chain := alice.New(
-		CreateMiddleware(&VersionCheck{BaseMiddleware: baseMid}),
-		CreateMiddleware(&Oauth2KeyExists{baseMid}),
-		CreateMiddleware(&KeyExpired{baseMid}),
-		CreateMiddleware(&AccessRightsCheck{baseMid}),
-		CreateMiddleware(&RateLimitAndQuotaCheck{baseMid})).Then(proxyHandler)
+		createMiddleware(&VersionCheck{BaseMiddleware: baseMid}),
+		createMiddleware(&Oauth2KeyExists{baseMid}),
+		createMiddleware(&KeyExpired{baseMid}),
+		createMiddleware(&AccessRightsCheck{baseMid}),
+		createMiddleware(&RateLimitAndQuotaCheck{baseMid})).Then(proxyHandler)
 
 	muxer.Handle(spec.Proxy.ListenPath, chain)
 }


### PR DESCRIPTION
These all get almost immediately appended to the main chain and don't
have any other use. They make the code especially hard to read because
it's hard to tell the final order of the middlewares, since you have to
keep track of multiple chains and when they're merged.