### PR TITLE
health: remove extra goroutine

### DIFF
--- a/api_healthcheck.go
+++ b/api_healthcheck.go
@@ -49,16 +49,15 @@ func (h *DefaultHealthChecker) CreateKeyName(subKey HealthPrefix) string {
 	return h.APIID + "." + string(subKey)
 }
 
-// ReportHealthCheckValue is a shortcut we can use throughout the app to push a health check value
-func ReportHealthCheckValue(checker HealthChecker, counter HealthPrefix, value string) {
-	// TODO: Wrap this in a conditional so it can be deactivated
-	go checker.StoreCounterVal(counter, value)
-}
-
-func (h *DefaultHealthChecker) StoreCounterVal(counterType HealthPrefix, value string) {
+// reportHealthValue is a shortcut we can use throughout the app to push a health check value
+func reportHealthValue(spec *APISpec, counter HealthPrefix, value string) {
 	if !globalConf.HealthCheck.EnableHealthChecks {
 		return
 	}
+	spec.Health.StoreCounterVal(counter, value)
+}
+
+func (h *DefaultHealthChecker) StoreCounterVal(counterType HealthPrefix, value string) {
 	searchStr := h.CreateKeyName(counterType)
 	log.Debug("Adding Healthcheck to: ", searchStr)
 	log.Debug("Val is: ", value)

--- a/coprocess.go
+++ b/coprocess.go
@@ -262,7 +262,7 @@ func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 		AuthFailed(m, r, token)
 
 		// Report in health check
-		ReportHealthCheckValue(m.Spec.Health, KeyFailure, "1")
+		reportHealthValue(m.Spec, KeyFailure, "1")
 
 		errorMsg := "Key not authorised"
 		if returnObject.Request.ReturnOverrides.ResponseError != "" {

--- a/handler_error.go
+++ b/handler_error.go
@@ -177,7 +177,7 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 	}
 
 	// Report in health check
-	ReportHealthCheckValue(e.Spec.Health, BlockedRequestLog, "-1")
+	reportHealthValue(e.Spec, BlockedRequestLog, "-1")
 
 	//If the config option is not set or is false, add the header
 	if !globalConf.HideGeneratorHeader {

--- a/handler_success.go
+++ b/handler_success.go
@@ -309,7 +309,7 @@ func (s *SuccessHandler) RecordHit(r *http.Request, timing int64, code int, requ
 	}
 
 	// Report in health check
-	ReportHealthCheckValue(s.Spec.Health, RequestLog, strconv.FormatInt(timing, 10))
+	reportHealthValue(s.Spec, RequestLog, strconv.FormatInt(timing, 10))
 
 	if memProfFile != nil {
 		pprof.WriteHeapProfile(memProfFile)

--- a/mw_auth_key.go
+++ b/mw_auth_key.go
@@ -94,7 +94,7 @@ func (k *AuthKey) ProcessRequest(w http.ResponseWriter, r *http.Request, _ inter
 		AuthFailed(k, r, key)
 
 		// Report in health check
-		ReportHealthCheckValue(k.Spec.Health, KeyFailure, "1")
+		reportHealthValue(k.Spec, KeyFailure, "1")
 
 		return errors.New("Key not authorised"), 403
 	}

--- a/mw_basic_auth.go
+++ b/mw_basic_auth.go
@@ -89,7 +89,7 @@ func (k *BasicAuthKeyIsValid) ProcessRequest(w http.ResponseWriter, r *http.Requ
 		AuthFailed(k, r, token)
 
 		// Report in health check
-		ReportHealthCheckValue(k.Spec.Health, KeyFailure, "-1")
+		reportHealthValue(k.Spec, KeyFailure, "-1")
 
 		return k.requestForBasicAuth(w, "User not authorised")
 	}
@@ -119,7 +119,7 @@ func (k *BasicAuthKeyIsValid) ProcessRequest(w http.ResponseWriter, r *http.Requ
 		AuthFailed(k, r, token)
 
 		// Report in health check
-		ReportHealthCheckValue(k.Spec.Health, KeyFailure, "-1")
+		reportHealthValue(k.Spec, KeyFailure, "-1")
 
 		return k.requestForBasicAuth(w, "User not authorised")
 	}

--- a/mw_ip_whitelist.go
+++ b/mw_ip_whitelist.go
@@ -52,7 +52,7 @@ func (i *IPWhiteListMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Re
 	// Fire Authfailed Event
 	AuthFailed(i, r, remoteIP.String())
 	// Report in health check
-	ReportHealthCheckValue(i.Spec.Health, KeyFailure, "-1")
+	reportHealthValue(i.Spec, KeyFailure, "-1")
 
 	// Not matched, fail
 	return errors.New("Access from this IP has been disallowed"), 403

--- a/mw_jwt.go
+++ b/mw_jwt.go
@@ -271,7 +271,7 @@ func (k *JWTMiddleware) reportLoginFailure(tykId string, r *http.Request) {
 	AuthFailed(k, r, tykId)
 
 	// Report in health check
-	ReportHealthCheckValue(k.Spec.Health, KeyFailure, "1")
+	reportHealthValue(k.Spec, KeyFailure, "1")
 }
 
 func (k *JWTMiddleware) processOneToOneTokenMap(r *http.Request, token *jwt.Token) (error, int) {

--- a/mw_key_expired_check.go
+++ b/mw_key_expired_check.go
@@ -40,7 +40,7 @@ func (k *KeyExpired) ProcessRequest(w http.ResponseWriter, r *http.Request, _ in
 		})
 
 		// Report in health check
-		ReportHealthCheckValue(k.Spec.Health, KeyFailure, "-1")
+		reportHealthValue(k.Spec, KeyFailure, "-1")
 
 		return errors.New("Key is inactive, please renew"), 403
 	}
@@ -54,16 +54,8 @@ func (k *KeyExpired) ProcessRequest(w http.ResponseWriter, r *http.Request, _ in
 		"key":    token,
 	}).Info("Attempted access from expired key.")
 
-	// Fire a key expired event
-	k.FireEvent(EventKeyExpired, EventKeyExpiredMeta{
-		EventMetaDefault: EventMetaDefault{Message: "Attempted access from expired key."},
-		Path:             r.URL.Path,
-		Origin:           requestIP(r),
-		Key:              token,
-	})
-
 	// Report in health check
-	ReportHealthCheckValue(k.Spec.Health, KeyFailure, "-1")
+	reportHealthValue(k.Spec, KeyFailure, "-1")
 
 	return errors.New("Key has expired, please renew"), 401
 }

--- a/mw_oauth2_key_exists.go
+++ b/mw_oauth2_key_exists.go
@@ -57,7 +57,7 @@ func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request,
 		// Fire Authfailed Event
 		AuthFailed(k, r, accessToken)
 		// Report in health check
-		ReportHealthCheckValue(k.Spec.Health, KeyFailure, "-1")
+		reportHealthValue(k.Spec, KeyFailure, "-1")
 
 		return errors.New("Key not authorised"), 403
 	}

--- a/mw_openid.go
+++ b/mw_openid.go
@@ -215,7 +215,7 @@ func (k *OpenIDMW) reportLoginFailure(tykId string, r *http.Request) {
 	AuthFailed(k, r, tykId)
 
 	// Report in health check
-	ReportHealthCheckValue(k.Spec.Health, KeyFailure, "1")
+	reportHealthValue(k.Spec, KeyFailure, "1")
 }
 
 func (k *OpenIDMW) setContextVars(r *http.Request, token *jwt.Token) {

--- a/mw_rate_limiting.go
+++ b/mw_rate_limiting.go
@@ -40,7 +40,7 @@ func (k *RateLimitAndQuotaCheck) handleRateLimitFailure(r *http.Request, token s
 	})
 
 	// Report in health check
-	ReportHealthCheckValue(k.Spec.Health, Throttle, "-1")
+	reportHealthValue(k.Spec, Throttle, "-1")
 
 	return errors.New("Rate limit exceeded"), 429
 }
@@ -61,7 +61,7 @@ func (k *RateLimitAndQuotaCheck) handleQuotaFailure(r *http.Request, token strin
 	})
 
 	// Report in health check
-	ReportHealthCheckValue(k.Spec.Health, QuotaViolation, "-1")
+	reportHealthValue(k.Spec, QuotaViolation, "-1")
 
 	return errors.New("Quota exceeded"), 403
 }


### PR DESCRIPTION
StoreCounterVal does almost no synchronous work; the actual store write
is done in a goroutine. So calling it in a goroutine is completely
unnecessary.

While at it, simplify the value report calls.