### PR TITLE
jsvm: don't ignore otto's Run errors

### DIFF
--- a/plugins_test.go
+++ b/plugins_test.go
@@ -121,9 +121,9 @@ func TestJSVMProcessTimeout(t *testing.T) {
 var leakMid = new TykJS.TykMiddleware.NewMiddleware({});
 
 leakMid.NewProcessRequest(function(request, session) {
-       while (true) {
-       }
-       return leakMid.ReturnData(request, session.meta_data);
+	while (true) {
+	}
+	return leakMid.ReturnData(request, session.meta_data);
 });`
 	if _, err := jsvm.VM.Run(js); err != nil {
 		t.Fatalf("failed to set up js plugin: %v", err)


### PR DESCRIPTION
They often have helpful information about what went wrong, which greatly
helps with debugging. For example, given the following JS middlware:

	var errMid = new TykJS.TykMiddleware.NewMiddleware({});

	errMid.NewProcessRequest(function(request, session) {
	       log(forgot_to_define);
	       return errMid.ReturnData(request, session.meta_data);
	});

We would previously log:

	ERROR jsvm: Failed to decode middleware request data on return from VM: invalid character 'u' looking for beginning of value

Now we log:

	ERROR jsvm: Failed to run JS middleware: ReferenceError: 'forgot_to_define' is not defined

Don't add a test because all of this code ignores errors, and making the
tests aware of the errors would be a major refactor. The patch is
trivial and ignoring errors is usually a red flag, so it's very unlikely
that a regression test will be particularly useful.

Fixes #959.