### PR TITLE
virtendp: don't ignore otto Run errors

### DIFF
--- a/mw_virtual_endpoint.go
+++ b/mw_virtual_endpoint.go
@@ -155,7 +155,11 @@ func (d *VirtualEndpoint) ServeHTTPForCache(w http.ResponseWriter, r *http.Reque
 
 	// Run the middleware
 	vm := d.Spec.JSVM.VM.Copy()
-	returnRaw, _ := vm.Run(vmeta.ResponseFunctionName + `(` + string(asJsonRequestObj) + `, ` + string(sessionAsJsonObj) + `, ` + confData + `);`)
+	returnRaw, err := vm.Run(vmeta.ResponseFunctionName + `(` + string(asJsonRequestObj) + `, ` + string(sessionAsJsonObj) + `, ` + confData + `);`)
+	if err != nil {
+		log.Error("Failed to run virtual endpoint JS code:", err)
+		return nil
+	}
 	returnDataStr, _ := returnRaw.ToString()
 
 	// Decode the return object


### PR DESCRIPTION
Just like the change applied to JS plugins. Can be tested in a similar
way, and a regression test is equally not very useful and requiring a
lot of refactoring.