### PR TITLE
test: close response bodies in testHttp

### DIFF
--- a/gateway_test.go
+++ b/gateway_test.go
@@ -863,6 +863,7 @@ func testHttp(t *testing.T, tests []tykHttpTest, separateControlPort bool) {
 				t.Error(err)
 				continue
 			}
+			resp.Body.Close()
 
 			if resp.StatusCode != tc.code {
 				t.Errorf("[%d]%s%s %s Status %d, want %d", ti, tPrefix, tc.method, tc.path, resp.StatusCode, tc.code)


### PR DESCRIPTION
Otherwise, the request connections are kept open since we never finish
reading the response body.