### PR TITLE
test: force ipv4 when listening on :0

### DIFF
--- a/api_definition_test.go
+++ b/api_definition_test.go
@@ -306,7 +306,7 @@ func startRPCMock(dispatcher *gorpc.Dispatcher) *gorpc.Server {
 	globalConf.SlaveOptions.RPCKey = "test_org"
 	globalConf.SlaveOptions.APIKey = "test"
 
-	server := gorpc.NewTCPServer(":0", dispatcher.NewHandlerFunc())
+	server := gorpc.NewTCPServer("127.0.0.1:0", dispatcher.NewHandlerFunc())
 	list := &customListener{}
 	server.Listener = list
 	server.LogError = gorpc.NilErrorLogger

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -789,10 +789,10 @@ func testHttp(t *testing.T, tests []tykHttpTest, separateControlPort bool) {
 	for _, m := range testMatrix {
 		var ln, cln net.Listener
 
-		ln, _ = net.Listen("tcp", ":0")
+		ln, _ = net.Listen("tcp", "127.0.0.1:0")
 
 		if separateControlPort {
-			cln, _ = net.Listen("tcp", ":0")
+			cln, _ = net.Listen("tcp", "127.0.0.1:0")
 
 			_, port, _ := net.SplitHostPort(cln.Addr().String())
 			globalConf.ControlAPIPort, _ = strconv.Atoi(port)

--- a/instrumentation_statsd_sink.go
+++ b/instrumentation_statsd_sink.go
@@ -90,7 +90,7 @@ const cmdChanBuffSize = 8192 // random-ass-guess
 const maxUdpBytes = 1440     // 1500(Ethernet MTU) - 60(Max UDP header size
 
 func NewStatsDSink(addr string, options *StatsDSinkOptions) (*StatsDSink, error) {
-	c, err := net.ListenPacket("udp", ":0")
+	c, err := net.ListenPacket("udp", "127.0.0.1:0")
 	if err != nil {
 		return nil, err
 	}

--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -160,7 +160,7 @@ func TykNewSingleHostReverseProxy(target *url.URL, spec *APISpec) *ReverseProxy 
 		handler := func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "all hosts are down", http.StatusServiceUnavailable)
 		}
-		listener, err := net.Listen("tcp", ":0")
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
To work around a docker issue that affects Buddy. This is fixed in Go
1.9, since it treats systems with half-broken ipv6 better and can handle
this without it breaking.

For now, since we need 1.8 to do releases, work around it here.