### PR TITLE
health: show deprecation warning only once

### DIFF
--- a/api_healthcheck.go
+++ b/api_healthcheck.go
@@ -3,6 +3,7 @@ package main
 import (
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -35,10 +36,14 @@ type DefaultHealthChecker struct {
 	APIID   string
 }
 
+var healthWarn sync.Once
+
 func (h *DefaultHealthChecker) Init(storeType StorageHandler) {
 	if globalConf.HealthCheck.EnableHealthChecks {
 		log.Debug("Health Checker initialised.")
-		log.Warning("The Health Checker is deprecated and we do no longer recommend its use.")
+		healthWarn.Do(func() {
+			log.Warning("The Health Checker is deprecated and we do no longer recommend its use.")
+		})
 	}
 
 	h.storage = storeType


### PR DESCRIPTION
Otherwise, if loading a thousand apis that use it, one would get the
same warning a thousand times, which isn't particularly useful.