### PR TITLE
all: collect more Otto.Run errors

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -683,7 +683,7 @@ func (a APIDefinitionLoader) compileVirtualPathspathSpec(paths []apidef.VirtualM
 		// Extend with method actions
 		newSpec.VirtualPathSpec = stringSpec
 
-		PreLoadVirtualMetaCode(&newSpec.VirtualPathSpec, &apiSpec.JSVM)
+		preLoadVirtualMetaCode(&newSpec.VirtualPathSpec, &apiSpec.JSVM)
 
 		urlSpec = append(urlSpec, newSpec)
 	}


### PR DESCRIPTION
In particular, when loading the JS core, when loading people's
middlewares and when loading a virtual endpoint js program. There are
plenty of ways for users to get errors, such as missing files or bad
syntax, so they're very useful.

While at it, avoid the unnecessary use of ioutil.ReadFile. Otto.Run
supports an io.Reader too, so there's no need to read the entire file
into memory.

No tests because errors in these scenarios aren't fatal at the moment.
Adding regression tests would require a major refactor for little gain.