### PR TITLE
all: remove a bunch of ReadFile/ReadAll calls

### DIFF
--- a/blueprint.go
+++ b/blueprint.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"strconv"
 
 	"github.com/TykTechnologies/tyk/apidef"
@@ -13,7 +14,7 @@ type APIImporterSource string
 const ApiaryBluePrint APIImporterSource = "blueprint"
 
 type APIImporter interface {
-	ReadString(string) error
+	LoadFrom(io.Reader) error
 	ConvertIntoApiVersion(bool) (apidef.VersionInfo, error)
 	InsertIntoAPIDefinitionAsVersion(apidef.VersionInfo, *apidef.APIDefinition, string) error
 }
@@ -110,10 +111,10 @@ type BluePrintAST struct {
 	} `json:"resourceGroups"`
 }
 
-func (b *BluePrintAST) ReadString(asJson string) error {
-	if err := json.Unmarshal([]byte(asJson), &b); err != nil {
-		log.Error("Marshalling failed: ", err)
-		return errors.New("Could not unmarshal string for Bluprint AST object")
+func (b *BluePrintAST) LoadFrom(r io.Reader) error {
+	if err := json.NewDecoder(r).Decode(&b); err != nil {
+		log.Error("Unmarshalling failed: ", err)
+		return err
 	}
 	return nil
 }

--- a/coprocess_bundle.go
+++ b/coprocess_bundle.go
@@ -65,14 +65,17 @@ func (b *Bundle) Verify() error {
 	var bundleData bytes.Buffer
 
 	for _, f := range b.Manifest.FileList {
-		extractedFilePath := filepath.Join(b.Path, f)
+		extractedPath := filepath.Join(b.Path, f)
 
-		data, err := ioutil.ReadFile(extractedFilePath)
+		f, err := os.Open(extractedPath)
 		if err != nil {
-			break
+			return err
 		}
-
-		bundleData.Write(data)
+		_, err = io.Copy(&bundleData, f)
+		f.Close()
+		if err != nil {
+			return err
+		}
 	}
 
 	checksum := fmt.Sprintf("%x", md5.Sum(bundleData.Bytes()))

--- a/mw_jwt.go
+++ b/mw_jwt.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
@@ -55,21 +54,15 @@ func (k *JWTMiddleware) getSecretFromURL(url, kid, keyType string) ([]byte, erro
 	if !found {
 		// Get the JWK
 		log.Debug("Pulling JWK")
-		response, err := http.Get(url)
+		resp, err := http.Get(url)
 		if err != nil {
 			log.Error("Failed to get resource URL: ", err)
 			return nil, err
 		}
+		defer resp.Body.Close()
 
 		// Decode it
-		defer response.Body.Close()
-		contents, err := ioutil.ReadAll(response.Body)
-		if err != nil {
-			log.Error("Failed to read body data: ", err)
-			return nil, err
-		}
-
-		if err := json.Unmarshal(contents, &jwkSet); err != nil {
+		if err := json.NewDecoder(resp.Body).Decode(&jwkSet); err != nil {
 			log.Error("Failed to decode body JWK: ", err)
 			return nil, err
 		}

--- a/mw_transform.go
+++ b/mw_transform.go
@@ -59,10 +59,6 @@ func (t *TransformMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 func transformBody(r *http.Request, tmeta *TransformSpec, contextVars bool) error {
 	// Read the body:
 	defer r.Body.Close()
-	body, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		return err
-	}
 
 	// Put into an interface:
 	bodyData := make(map[string]interface{})
@@ -70,12 +66,14 @@ func transformBody(r *http.Request, tmeta *TransformSpec, contextVars bool) erro
 	case apidef.RequestXML:
 		mxj.XmlCharsetReader = WrappedCharsetReader
 		var err error
-		bodyData, err = mxj.NewMapXml(body) // unmarshal
+		bodyData, err = mxj.NewMapXmlReader(r.Body) // unmarshal
 		if err != nil {
 			return fmt.Errorf("error unmarshalling XML: %v", err)
 		}
 	case apidef.RequestJSON:
-		json.Unmarshal(body, &bodyData)
+		if err := json.NewDecoder(r.Body).Decode(&bodyData); err != nil {
+			return err
+		}
 	default:
 		return fmt.Errorf("unsupported request input type: %v", tmeta.TemplateData.Input)
 	}

--- a/redis_signal_handle_config_request.go
+++ b/redis_signal_handle_config_request.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -22,7 +22,6 @@ type ReturnConfigPayload struct {
 }
 
 func sanitizeConfig(mc map[string]interface{}) map[string]interface{} {
-
 	sanitzeFields := []string{
 		"secret",
 		"node_secret",
@@ -30,22 +29,20 @@ func sanitizeConfig(mc map[string]interface{}) map[string]interface{} {
 		"slave_options",
 		"auth_override",
 	}
-
 	for _, field_name := range sanitzeFields {
 		delete(mc, field_name)
 	}
-
 	return mc
 }
 
 func getExistingConfig() (map[string]interface{}, error) {
-	var microConfig map[string]interface{}
-	dat, err := ioutil.ReadFile(globalConf.OriginalPath)
+	f, err := os.Open(globalConf.OriginalPath)
 	if err != nil {
-		return microConfig, err
+		return nil, err
 	}
-	if err := json.Unmarshal(dat, &microConfig); err != nil {
-		return microConfig, err
+	var microConfig map[string]interface{}
+	if err := json.NewDecoder(f).Decode(&microConfig); err != nil {
+		return nil, err
 	}
 	return sanitizeConfig(microConfig), nil
 }


### PR DESCRIPTION
The standard library and plenty of libraries tend to work with
io.Readers as well as string/[]byte, so most of the time we don't need
to read entire bodies and files into memory.

This also simplifies the code a bit, since we remove an extra step in
some cases.

While at it, stop ignoring some unmarshalling and parsing errors that
were spotted while refactoring.