### PR TITLE
all: simplify redis manager object logic

### DIFF
--- a/api.go
+++ b/api.go
@@ -1388,7 +1388,7 @@ func invalidateCacheHandler(w http.ResponseWriter, r *http.Request) {
 func handleInvalidateAPICache(apiID string) error {
 	keyPrefix := "cache-" + apiID
 	matchPattern := keyPrefix + "*"
-	store := getGlobalLocalCacheStorageHandler(keyPrefix, false)
+	store := &RedisClusterStorageManager{KeyPrefix: keyPrefix, IsCache: true}
 
 	if ok := store.DeleteScanMatch(matchPattern); !ok {
 		return errors.New("scan/delete failed")

--- a/coprocess_api.go
+++ b/coprocess_api.go
@@ -33,8 +33,8 @@ func TykStoreData(CKey, CValue *C.char, CTTL C.int) {
 	value := C.GoString(CValue)
 	ttl := int64(CTTL)
 
-	storageHandler := getGlobalLocalStorageHandler(CoProcessDefaultKeyPrefix, false)
-	storageHandler.SetKey(key, value, ttl)
+	store := &RedisClusterStorageManager{KeyPrefix: CoProcessDefaultKeyPrefix}
+	store.SetKey(key, value, ttl)
 }
 
 // TykGetData is a CoProcess API function for fetching data.
@@ -42,9 +42,9 @@ func TykStoreData(CKey, CValue *C.char, CTTL C.int) {
 func TykGetData(CKey *C.char) *C.char {
 	key := C.GoString(CKey)
 
-	storageHandler := getGlobalLocalStorageHandler(CoProcessDefaultKeyPrefix, false)
+	store := &RedisClusterStorageManager{KeyPrefix: CoProcessDefaultKeyPrefix}
 	// TODO: return error
-	val, _ := storageHandler.GetKey(key)
+	val, _ := store.GetKey(key)
 	return C.CString(val)
 }
 

--- a/event_handler_webhooks.go
+++ b/event_handler_webhooks.go
@@ -38,19 +38,6 @@ type WebHookHandler struct {
 	store    StorageHandler
 }
 
-// Not Pretty, but will avoi dmillions of connections
-var WebHookRedisStorePointer *RedisClusterStorageManager
-
-// GetRedisInterfacePointer creates a reference to a redis connection pool that can be shared across all webhook instances
-func GetRedisInterfacePointer() *RedisClusterStorageManager {
-	if WebHookRedisStorePointer == nil {
-		WebHookRedisStorePointer = &RedisClusterStorageManager{KeyPrefix: "webhook.cache."}
-		WebHookRedisStorePointer.Connect()
-	}
-
-	return WebHookRedisStorePointer
-}
-
 // createConfigObject by default tyk will provide a ma[string]interface{} type as a conf, converting it
 // specifically here makes it easier to handle, only happens once, so not a massive issue, but not pretty
 func (w *WebHookHandler) createConfigObject(handlerConf interface{}) (config.WebHookHandlerConf, error) {
@@ -78,8 +65,8 @@ func (w *WebHookHandler) Init(handlerConf interface{}) error {
 		return err
 	}
 
-	// Get a storage reference
-	w.store = GetRedisInterfacePointer()
+	w.store = &RedisClusterStorageManager{KeyPrefix: "webhook.cache."}
+	w.store.Connect()
 
 	// Pre-load template on init
 	if w.conf.TemplatePath != "" {

--- a/main.go
+++ b/main.go
@@ -913,14 +913,6 @@ func startRPCKeepaliveWatcher(engine *RPCStorageHandler) {
 	}()
 }
 
-func getGlobalLocalStorageHandler(keyPrefix string, hashKeys bool) StorageHandler {
-	return &RedisClusterStorageManager{KeyPrefix: keyPrefix, HashKeys: hashKeys}
-}
-
-func getGlobalLocalCacheStorageHandler(keyPrefix string, hashKeys bool) StorageHandler {
-	return &RedisClusterStorageManager{KeyPrefix: keyPrefix, HashKeys: hashKeys, IsCache: true}
-}
-
 func getGlobalStorageHandler(keyPrefix string, hashKeys bool) StorageHandler {
 	if globalConf.SlaveOptions.UseRPC {
 		return &RPCStorageHandler{KeyPrefix: keyPrefix, HashKeys: hashKeys, UserKey: globalConf.SlaveOptions.APIKey, Address: globalConf.SlaveOptions.ConnectionString}


### PR DESCRIPTION
First, get rid of a shared object in the webhook handler code. All redis
managers share a redis client singleton under the hood nowadays, so it's
completely unnecessary. But most of all, that code is racy.

While at it, get rid of an unused getter and inline another that had a
single use.