### PR TITLE
all: make provider metas a map[string]interface{}

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -171,15 +171,15 @@ type VersionInfo struct {
 }
 
 type AuthProviderMeta struct {
-	Name          AuthProviderCode  `bson:"name" json:"name"`
-	StorageEngine StorageEngineCode `bson:"storage_engine" json:"storage_engine"`
-	Meta          interface{}       `bson:"meta" json:"meta"`
+	Name          AuthProviderCode       `bson:"name" json:"name"`
+	StorageEngine StorageEngineCode      `bson:"storage_engine" json:"storage_engine"`
+	Meta          map[string]interface{} `bson:"meta" json:"meta"`
 }
 
 type SessionProviderMeta struct {
-	Name          SessionProviderCode `bson:"name" json:"name"`
-	StorageEngine StorageEngineCode   `bson:"storage_engine" json:"storage_engine"`
-	Meta          interface{}         `bson:"meta" json:"meta"`
+	Name          SessionProviderCode    `bson:"name" json:"name"`
+	StorageEngine StorageEngineCode      `bson:"storage_engine" json:"storage_engine"`
+	Meta          map[string]interface{} `bson:"meta" json:"meta"`
 }
 
 type EventHandlerTriggerConfig struct {

--- a/ldap_auth_handler.go
+++ b/ldap_auth_handler.go
@@ -18,22 +18,21 @@ type LDAPStorageHandler struct {
 	store                *ldap.LDAPConnection
 }
 
-func (l *LDAPStorageHandler) LoadConfFromMeta(confMeta interface{}) {
-	asMap := confMeta.(map[string]interface{})
-	l.LDAPServer = asMap["ldap_server"].(string)
-	l.LDAPPort = uint16(asMap["ldap_port"].(float64))
-	l.BaseDN = asMap["base_dn"].(string)
+func (l *LDAPStorageHandler) LoadConfFromMeta(meta map[string]interface{}) {
+	l.LDAPServer = meta["ldap_server"].(string)
+	l.LDAPPort = uint16(meta["ldap_port"].(float64))
+	l.BaseDN = meta["base_dn"].(string)
 
 	attrArray := []string{}
 
-	for _, attr := range asMap["attributes"].([]interface{}) {
+	for _, attr := range meta["attributes"].([]interface{}) {
 		val := attr.(string)
 		attrArray = append(attrArray, val)
 	}
 
 	l.Attributes = attrArray
-	l.SessionAttributeName = asMap["session_attribute_name"].(string)
-	l.SearchString = asMap["search_string"].(string)
+	l.SessionAttributeName = meta["session_attribute_name"].(string)
+	l.SearchString = meta["search_string"].(string)
 
 }
 


### PR DESCRIPTION
They're always objects - both when used and in the docs. In fact, the
code will panic otherwise. Enforce the type better and simplify the
code.

We don't enforce a struct for now, but we might do that at some point.