### PR TITLE
main: always log all loaded policies

### DIFF
--- a/instrumentation_handlers.go
+++ b/instrumentation_handlers.go
@@ -33,7 +33,6 @@ func setupInstrumentation(arguments map[string]interface{}) {
 
 	if err != nil {
 		log.Fatal("Failed to start StatsD check: ", err)
-		return
 	}
 
 	log.Info("StatsD instrumentation sink started")

--- a/main.go
+++ b/main.go
@@ -174,7 +174,6 @@ func buildConnStr(resource string) string {
 
 	if globalConf.DBAppConfOptions.ConnectionString == "" && globalConf.DisableDashboardZeroConf {
 		log.Fatal("Connection string is empty, failing.")
-		return ""
 	}
 
 	if !globalConf.DisableDashboardZeroConf && globalConf.DBAppConfOptions.ConnectionString == "" {
@@ -240,21 +239,19 @@ func getPolicies() {
 
 	switch globalConf.Policies.PolicySource {
 	case "service":
-		if globalConf.Policies.PolicyConnectionString != "" {
-			connStr := globalConf.Policies.PolicyConnectionString
-			connStr = connStr + "/system/policies"
-
-			log.WithFields(logrus.Fields{
-				"prefix": "main",
-			}).Info("Using Policies from Dashboard Service")
-
-			pols = LoadPoliciesFromDashboard(connStr, globalConf.NodeSecret, globalConf.Policies.AllowExplicitPolicyID)
-
-		} else {
+		if globalConf.Policies.PolicyConnectionString == "" {
 			log.WithFields(logrus.Fields{
 				"prefix": "main",
 			}).Fatal("No connection string or node ID present. Failing.")
 		}
+		connStr := globalConf.Policies.PolicyConnectionString
+		connStr = connStr + "/system/policies"
+
+		log.WithFields(logrus.Fields{
+			"prefix": "main",
+		}).Info("Using Policies from Dashboard Service")
+
+		pols = LoadPoliciesFromDashboard(connStr, globalConf.NodeSecret, globalConf.Policies.AllowExplicitPolicyID)
 
 	case "rpc":
 		log.WithFields(logrus.Fields{
@@ -270,6 +267,14 @@ func getPolicies() {
 			return
 		}
 		pols = LoadPoliciesFromFile(globalConf.Policies.PolicyRecordName)
+	}
+	log.WithFields(logrus.Fields{
+		"prefix": "main",
+	}).Infof("Policies found (%d total):", len(pols))
+	for id := range pols {
+		log.WithFields(logrus.Fields{
+			"prefix": "main",
+		}).Infof(" - %s", id)
 	}
 
 	if len(pols) > 0 {

--- a/policy.go
+++ b/policy.go
@@ -150,20 +150,15 @@ func LoadPoliciesFromDashboard(endpoint, secret string, allowExplicit bool) map[
 			id = p.ID
 		}
 		p.ID = id
-		_, foundP := policies[id]
-		if !foundP {
-			policies[id] = p.ToRegularPolicy()
-			log.WithFields(logrus.Fields{
-				"prefix": "policy",
-			}).Info("--> Processing policy ID: ", p.ID)
-			log.Debug("POLICY ACCESS RIGHTS: ", p.AccessRights)
-		} else {
+		if _, ok := policies[id]; ok {
 			log.WithFields(logrus.Fields{
 				"prefix":   "policy",
 				"policyID": p.ID,
 				"OrgID":    p.OrgID,
 			}).Warning("--> Skipping policy, new item has a duplicate ID!")
+			continue
 		}
+		policies[id] = p.ToRegularPolicy()
 	}
 
 	return policies
@@ -188,15 +183,9 @@ func LoadPoliciesFromRPC(orgId string) map[string]Policy {
 
 	policies := make(map[string]Policy, len(dbPolicyList))
 
-	log.WithFields(logrus.Fields{
-		"prefix": "policy",
-	}).Info("Policies found: ", len(dbPolicyList))
 	for _, p := range dbPolicyList {
 		p.ID = p.MID.Hex()
 		policies[p.MID.Hex()] = p
-		log.WithFields(logrus.Fields{
-			"prefix": "policy",
-		}).Info("--> Processing policy ID: ", p.ID)
 	}
 
 	return policies


### PR DESCRIPTION
Instead of leaving it to each loader implementation, do it in the parent
function once loading is done.

This makes the logging of policy IDs consistent, and also simplifies
each loader by removing duplicate yet slightly different code.

Fixes #647.