### PR TITLE
main: reduce exit sleep from 3s to 1s

### DIFF
--- a/main.go
+++ b/main.go
@@ -1016,7 +1016,7 @@ func main() {
 		log.Info("Terminated from fork.")
 	}
 
-	time.Sleep(3 * time.Second)
+	time.Sleep(time.Second)
 }
 
 func start(arguments map[string]interface{}) {


### PR DESCRIPTION
We haven't refactored this bit to properly shutdown all http servers
yet. For now, reduce the sleep from 3 to 1 seconds to reduce the
everyday pain of developers (mostly me) watching the screen for three
seconds dozens of times a day.

Updates #630.