### PR TITLE
revproxy: refactor default transport

### DIFF
--- a/handler_websocket.go
+++ b/handler_websocket.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"io"
@@ -22,7 +23,7 @@ func canonicalAddr(url *url.URL) string {
 }
 
 type WSDialer struct {
-	*TykTransporter
+	*http.Transport
 	RW        http.ResponseWriter
 	TLSConfig *tls.Config
 }
@@ -36,9 +37,10 @@ func (ws *WSDialer) RoundTrip(req *http.Request) (*http.Response, error) {
 	target := canonicalAddr(req.URL)
 
 	// TLS
-	dial := ws.Dial
+	dial := ws.DialContext
 	if dial == nil {
-		dial = net.Dial
+		var d net.Dialer
+		dial = d.DialContext
 	}
 
 	// We do not get this WSS scheme, need another way to identify it
@@ -50,12 +52,12 @@ func (ws *WSDialer) RoundTrip(req *http.Request) (*http.Response, error) {
 		} else {
 			tlsConfig = ws.TLSClientConfig
 		}
-		dial = func(network, address string) (net.Conn, error) {
+		dial = func(_ context.Context, network, address string) (net.Conn, error) {
 			return tls.Dial("tcp", target, tlsConfig)
 		}
 	}
 
-	d, err := dial("tcp", target)
+	d, err := dial(context.TODO(), "tcp", target)
 	if err != nil {
 		http.Error(ws.RW, "Error contacting backend server.", 500)
 		log.WithFields(logrus.Fields{


### PR DESCRIPTION
revproxy: refactor default transport

Remove the TykTransporter wrapper around the http.Transport. Its only
purpose was SetTimeout, which was only used once and was very limited -
it did not override the Dial family of methods.

Second, be consistent about overriding and using DialContext instead of
Dial. Dial is defined as deprecated, and many libraries including std
will ignore it if DialContext is set. For now, use context.TODO() when
calling, which will equal to the previous behavior.

Third, sync the default transport with http.DefaultTransport - namely,
adding fields like MaxIdleConns and DualStack.

Finally, use a separate http.Transport object per proxied request.
Before we were modifying and using a global in-place, which meant that
concurrent requests could run into race conditions and misbehave if
requiring different transport tweaks.

This also fixes one of the last two staticcheck warnings, stemming from
handler_websocket's use of net.Dial.

Updates #495 - we will need a consistent default transport to cache the
DNS queries, and this one seems logical.