### PR TITLE
revproxy: greatly simplify singleJoiningSlash

### DIFF
--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -317,42 +317,13 @@ var TykDefaultTransport = &TykTransporter{http.Transport{
 	TLSClientConfig:     &tls.Config{},
 }}
 
-func cleanSlashes(a string) string {
-	endSlash := strings.HasSuffix(a, "//")
-	startSlash := strings.HasPrefix(a, "//")
-
-	if startSlash {
-		a = "/" + strings.TrimPrefix(a, "//")
-	}
-
-	if endSlash {
-		a = strings.TrimSuffix(a, "//") + "/"
-	}
-
-	return a
-}
-
 func singleJoiningSlash(a, b string) string {
-	a = cleanSlashes(a)
-	b = cleanSlashes(b)
-
-	aslash := strings.HasSuffix(a, "/")
-	bslash := strings.HasPrefix(b, "/")
-
-	switch {
-	case aslash && bslash:
-		log.Debug(a + b)
-		return a + b[1:]
-	case !aslash && !bslash:
-		if len(b) > 0 {
-			log.Debug(a + b)
-			return a + "/" + b
-		}
-		log.Debug(a + b)
-		return a
+	a = strings.TrimRight(a, "/")
+	b = strings.TrimLeft(b, "/")
+	if len(b) > 0 {
+		return a + "/" + b
 	}
-	log.Debug(a + b)
-	return a + b
+	return a
 }
 
 func copyHeader(dst, src http.Header) {

--- a/reverse_proxy_test.go
+++ b/reverse_proxy_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/url"
 	"testing"
 
@@ -51,6 +52,27 @@ func TestReverseProxyRetainHost(t *testing.T) {
 			proxy.Director(req)
 			if got := req.URL.String(); got != tc.wantURL {
 				t.Fatalf("wanted url %q, got %q", tc.wantURL, got)
+			}
+		})
+	}
+}
+
+func TestSingleJoiningSlash(t *testing.T) {
+	tests := []struct {
+		a, b, want string
+	}{
+		{"foo", "", "foo"},
+		{"foo", "bar", "foo/bar"},
+		{"foo/", "bar", "foo/bar"},
+		{"foo", "/bar", "foo/bar"},
+		{"foo/", "/bar", "foo/bar"},
+		{"foo//", "//bar", "foo/bar"},
+	}
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%s+%s", tc.a, tc.b), func(t *testing.T) {
+			got := singleJoiningSlash(tc.a, tc.b)
+			if got != tc.want {
+				t.Fatalf("want %s, got %s", tc.want, got)
 			}
 		})
 	}


### PR DESCRIPTION
Add tests to make sure we didn't break it. They pass both before and
after the reimplementation.