### PR TITLE
all: simplify some string handling

### DIFF
--- a/api.go
+++ b/api.go
@@ -321,7 +321,7 @@ func handleGetAllKeys(filter, apiID string) (interface{}, int) {
 
 	fixed_sessions := make([]string, 0)
 	for _, s := range sessions {
-		if !strings.Contains(s, QuotaKeyPrefix) && !strings.Contains(s, RateLimitKeyPrefix) {
+		if !strings.HasPrefix(s, QuotaKeyPrefix) && !strings.HasPrefix(s, RateLimitKeyPrefix) {
 			fixed_sessions = append(fixed_sessions, s)
 		}
 	}
@@ -824,7 +824,7 @@ func handleGetAllOrgKeys(filter string) (interface{}, int) {
 	sessions := spec.OrgSessionManager.Sessions(filter)
 	fixed_sessions := make([]string, 0)
 	for _, s := range sessions {
-		if !strings.Contains(s, QuotaKeyPrefix) && !strings.Contains(s, RateLimitKeyPrefix) {
+		if !strings.HasPrefix(s, QuotaKeyPrefix) && !strings.HasPrefix(s, RateLimitKeyPrefix) {
 			fixed_sessions = append(fixed_sessions, s)
 		}
 	}

--- a/api_definition.go
+++ b/api_definition.go
@@ -927,20 +927,12 @@ func (a *APISpec) getVersionFromRequest(r *http.Request) string {
 
 	case "url":
 		url := strings.Replace(r.URL.Path, a.Proxy.ListenPath, "", 1)
-		if len(url) == 0 {
-			return ""
+		// First non-empty part of the path is the version ID
+		for _, part := range strings.Split(url, "/") {
+			if part != "" {
+				return part
+			}
 		}
-		if url[:1] == "/" {
-			url = url[1:]
-		}
-
-		// Assume first param is the version ID
-		firstParamEndsAt := strings.Index(url, "/")
-		if firstParamEndsAt == -1 {
-			return ""
-		}
-
-		return url[:firstParamEndsAt]
 	}
 	return ""
 }

--- a/main.go
+++ b/main.go
@@ -445,7 +445,7 @@ func loadCustomMiddleware(spec *APISpec) ([]string, apidef.MiddlewareDefinition,
 				"prefix": "main",
 			}).Debug("-- Middleware name ", mwDef.Name)
 			mwDef.Path = path
-			mwDef.RequireSession = strings.Contains(mwDef.Name, "_with_session")
+			mwDef.RequireSession = strings.HasSuffix(mwDef.Name, "_with_session")
 			if mwDef.RequireSession {
 				switch folder.name {
 				case "post_auth", "post":


### PR DESCRIPTION
Use prefix and suffix matches instead of Contains when that's what we
want.

Also refactor some manual string handling to get the first part of a URL
path. It is much clearer, as well as more foolproof, to use
strings.Split and a loop. For example, the old code worked with /v1/foo
but not with //v1/foo - and of course was more complex.