### PR TITLE
all: various cleanups and simplifications, fix response transforms

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -129,7 +129,6 @@ type APISpec struct {
 	URLRewriteEnabled        bool
 	CircuitBreakerEnabled    bool
 	EnforcedTimeoutEnabled   bool
-	ResponseHandlersActive   bool
 	LastGoodHostList         *apidef.HostList
 	HasRun                   bool
 	ServiceRefreshInProgress bool

--- a/main.go
+++ b/main.go
@@ -492,23 +492,24 @@ func creeateResponseMiddlewareChain(spec *APISpec) {
 
 	responseChain := make([]TykResponseHandler, len(spec.ResponseProcessors))
 	for i, processorDetail := range spec.ResponseProcessors {
-		processor, err := ResponseProcessorByName(processorDetail.Name)
-		if err != nil {
+		processor := responseProcessorByName(processorDetail.Name)
+		if processor == nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "main",
-			}).Error("Failed to load processor! ", err)
+			}).Error("No such processor: ", processorDetail.Name)
 			return
 		}
-		_ = processor.Init(processorDetail.Options, spec)
+		if err := processor.Init(processorDetail.Options, spec); err != nil {
+			log.WithFields(logrus.Fields{
+				"prefix": "main",
+			}).Debug("Failed to init processor: ", err)
+		}
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Debug("Loading Response processor: ", processorDetail.Name)
 		responseChain[i] = processor
 	}
 	spec.ResponseChain = responseChain
-	if len(responseChain) > 0 {
-		spec.ResponseHandlersActive = true
-	}
 }
 
 func handleCORS(chain *[]alice.Constructor, spec *APISpec) {

--- a/res_handler_header_injector.go
+++ b/res_handler_header_injector.go
@@ -21,7 +21,6 @@ type HeaderInjector struct {
 func (h *HeaderInjector) Init(c interface{}, spec *APISpec) error {
 	h.Spec = spec
 	if err := mapstructure.Decode(c, &h.config); err != nil {
-		log.Error(err)
 		return err
 	}
 	return nil

--- a/res_handler_header_transform.go
+++ b/res_handler_header_transform.go
@@ -24,7 +24,6 @@ type HeaderTransform struct {
 
 func (h *HeaderTransform) Init(c interface{}, spec *APISpec) error {
 	if err := mapstructure.Decode(c, &h.config); err != nil {
-		log.Error(err)
 		return err
 	}
 	h.Spec = spec
@@ -37,7 +36,6 @@ func (h *HeaderTransform) HandleResponse(rw http.ResponseWriter,
 	// Parse target_host parameter from configuration
 	target_url, err := url.Parse(h.config.RevProxyTransform.Target_host)
 	if err != nil {
-		log.Error(err)
 		return err
 	}
 

--- a/res_handler_transform.go
+++ b/res_handler_transform.go
@@ -9,28 +9,16 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/clbanning/mxj"
-	"github.com/mitchellh/mapstructure"
 
 	"github.com/TykTechnologies/tyk/apidef"
 )
 
-type ResponsetransformOptions struct {
-	//FlushInterval time.Duration
-}
-
 type ResponseTransformMiddleware struct {
-	Spec   *APISpec
-	config ResponsetransformOptions
+	Spec *APISpec
 }
 
 func (h *ResponseTransformMiddleware) Init(c interface{}, spec *APISpec) error {
-	handler := ResponseTransformMiddleware{}
-
-	if err := mapstructure.Decode(c, &h.config); err != nil {
-		log.Error(err)
-		return err
-	}
-	handler.Spec = spec
+	h.Spec = spec
 	return nil
 }
 


### PR DESCRIPTION
This started as a simplification of the API loader, but I kept finding
other stuff to do.

* Inline some small funcs that are only used once
* Remove no-op use of mapstructure
* Log errors on the Init call sites, not in their bodies
* ResponseHandlersActive is useless (ranging over empty slice is a no-op
  already)

Also happened to fix an Init that didn't properly assign the Spec field
of the receiver, which was already reported in the issue tracker due to
a panic.

Fixes #1041.