### PR TITLE
all: use http.DefaultClient more often

### DIFF
--- a/batch_requests.go
+++ b/batch_requests.go
@@ -38,8 +38,7 @@ type BatchRequestHandler struct {
 
 // doAsyncRequest runs an async request and replies to a channel
 func (b *BatchRequestHandler) doAsyncRequest(req *http.Request, relURL string, out chan BatchReplyUnit) {
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		log.Error("Webhook request failed: ", err)
 		return
@@ -62,8 +61,7 @@ func (b *BatchRequestHandler) doAsyncRequest(req *http.Request, relURL string, o
 
 // doSyncRequest will make the same request but return a BatchReplyUnit
 func (b *BatchRequestHandler) doSyncRequest(req *http.Request, relURL string) BatchReplyUnit {
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		log.Error("Webhook request failed: ", err)
 		return BatchReplyUnit{}

--- a/event_handler_webhooks.go
+++ b/event_handler_webhooks.go
@@ -210,8 +210,7 @@ func (w *WebHookHandler) HandleEvent(em config.EventMessage) {
 	}
 	// Fire web hook routine (setHookFired())
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "webhooks",

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -824,8 +824,6 @@ func testHttp(t *testing.T, tests []tykHttpTest, separateControlPort bool) {
 			listen(ln, cln, fmt.Errorf("Without goagain"))
 		}
 
-		client := &http.Client{}
-
 		for ti, tc := range tests {
 			tPrefix := ""
 			if m.goagain {
@@ -858,7 +856,7 @@ func testHttp(t *testing.T, tests []tykHttpTest, separateControlPort bool) {
 				req = withAuth(req)
 			}
 
-			resp, err := client.Do(req)
+			resp, err := http.DefaultClient.Do(req)
 			if err != nil {
 				t.Error(err)
 				continue

--- a/plugins.go
+++ b/plugins.go
@@ -425,8 +425,6 @@ func (j *JSVM) LoadTykJSApi() {
 		u.Path = hro.Resource
 		urlStr := u.String() // "https://api.com/user/"
 
-		client := &http.Client{}
-
 		var d string
 		if hro.Body != "" {
 			d = hro.Body
@@ -444,7 +442,7 @@ func (j *JSVM) LoadTykJSApi() {
 			r.Header.Set(k, v)
 		}
 		r.Close = true
-		resp, err := client.Do(r)
+		resp, err := http.DefaultClient.Do(r)
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "jsvm",


### PR DESCRIPTION
Using &http.Client{} means an extra allocation and a bit of added
complexity. Using the same client more often will also simplify changing
the global client in certain ways.