### PR TITLE
test: don't delete apps/

### DIFF
--- a/gateway_test.go
+++ b/gateway_test.go
@@ -1032,10 +1032,11 @@ func TestProxyUserAgent(t *testing.T) {
 }
 
 func buildAndLoadAPI(apiGens ...func(spec *APISpec)) {
+	oldPath := globalConf.AppPath
 	globalConf.AppPath, _ = ioutil.TempDir("", "apps")
 	defer func() {
 		os.RemoveAll(globalConf.AppPath)
-		globalConf.AppPath = "apps/"
+		globalConf.AppPath = oldPath
 	}()
 
 	for i, gen := range apiGens {


### PR DESCRIPTION
Since TestMain also sets up a global tempdir for AppPath, we need to be
careful when reverting AppPath values in specific tests. In particular,
we can't force apps/ because then TestMain will delete that instead of
its global tempdir.