### PR TITLE
dash: don't force a reload after a relogin

### DIFF
--- a/dashboard_register.go
+++ b/dashboard_register.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -52,7 +53,10 @@ func reLogin() {
 	log.WithFields(logrus.Fields{
 		"prefix": "main",
 	}).Info("Recovering configurations, reloading...")
-	doReload()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	reloadURLStructure(wg.Done)
+	wg.Wait()
 }
 
 func (h *HTTPDashboardHandler) Init() error {


### PR DESCRIPTION
doReload just does an actual reload. It should never be used in
production code, as it's only meant for the reload loop. If it's used
directly, we might end up with two reloads happening concurrently.

If that happens, we can run into all kinds of race conditions.

Simply queue a reload and wait for it to finish.