### PR TITLE
all: get rid of some unnecessary globals

### DIFF
--- a/dashboard_register.go
+++ b/dashboard_register.go
@@ -134,7 +134,7 @@ func (h *HTTPDashboardHandler) newRequest(endpoint string) *http.Request {
 		panic(err)
 	}
 	req.Header.Set("authorization", h.Secret)
-	req.Header.Set("x-tyk-hostname", HostDetails.Hostname)
+	req.Header.Set("x-tyk-hostname", hostDetails.Hostname)
 	return req
 }
 

--- a/distributed_rate_limiter.go
+++ b/distributed_rate_limiter.go
@@ -14,7 +14,7 @@ var DRLManager = &drl.DRL{}
 func setupDRL() {
 	drlManager := &drl.DRL{}
 	drlManager.Init()
-	drlManager.ThisServerID = NodeID + "|" + HostDetails.Hostname
+	drlManager.ThisServerID = NodeID + "|" + hostDetails.Hostname
 	log.Debug("DRL: Setting node ID: ", drlManager.ThisServerID)
 	DRLManager = drlManager
 }
@@ -58,7 +58,7 @@ func NotifyCurrentServerStatus() {
 	}
 
 	server := drl.Server{
-		HostName:   HostDetails.Hostname,
+		HostName:   hostDetails.Hostname,
 		ID:         NodeID,
 		LoadPerSec: rate,
 		TagHash:    getTagHash(),

--- a/instrumentation_handlers.go
+++ b/instrumentation_handlers.go
@@ -63,7 +63,7 @@ func MonitorApplicationInstrumentation() {
 	go func() {
 		job := instrument.NewJob("GCActivity")
 		job_rl := instrument.NewJob("Load")
-		metadata := health.Kvs{"host": HostDetails.Hostname}
+		metadata := health.Kvs{"host": hostDetails.Hostname}
 		applicationGCStats.PauseQuantiles = make([]time.Duration, 5)
 
 		for {

--- a/redis_signal_handle_config.go
+++ b/redis_signal_handle_config.go
@@ -64,7 +64,7 @@ func handleNewConfiguration(payload string) {
 	}
 
 	// Make sure payload matches nodeID and hostname
-	if configPayload.ForHostname != HostDetails.Hostname && configPayload.ForNodeID != NodeID {
+	if configPayload.ForHostname != hostDetails.Hostname && configPayload.ForNodeID != NodeID {
 		log.WithFields(logrus.Fields{
 			"prefix": "pub-sub",
 		}).Info("Configuration update received, no NodeID/Hostname match found")
@@ -100,7 +100,7 @@ func handleNewConfiguration(payload string) {
 }
 
 func reloadConfiguration() {
-	myPID := HostDetails.PID
+	myPID := hostDetails.PID
 	if myPID == 0 {
 		log.Error("No PID found, cannot reload")
 		return

--- a/redis_signal_handle_config_request.go
+++ b/redis_signal_handle_config_request.go
@@ -59,7 +59,7 @@ func handleSendMiniConfig(payload string) {
 	}
 
 	// Make sure payload matches nodeID and hostname
-	if configPayload.FromHostname != HostDetails.Hostname && configPayload.FromNodeID != NodeID {
+	if configPayload.FromHostname != hostDetails.Hostname && configPayload.FromNodeID != NodeID {
 		log.WithFields(logrus.Fields{
 			"prefix": "pub-sub",
 		}).Debug("Configuration request received, no NodeID/Hostname match found, ignoring")
@@ -75,7 +75,7 @@ func handleSendMiniConfig(payload string) {
 	}
 
 	returnPayload := ReturnConfigPayload{
-		FromHostname:  HostDetails.Hostname,
+		FromHostname:  hostDetails.Hostname,
 		FromNodeID:    NodeID,
 		Configuration: config,
 		TimeStamp:     time.Now().Unix(),

--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -261,10 +261,6 @@ func TykNewSingleHostReverseProxy(target *url.URL, spec *APISpec) *ReverseProxy 
 	return proxy
 }
 
-// onExitFlushLoop is a callback set by tests to detect the state of the
-// flushLoop() goroutine.
-var onExitFlushLoop func()
-
 // ReverseProxy is an HTTP Handler that takes an incoming request and
 // sends it to another server, proxying the response back to the
 // client.
@@ -710,9 +706,6 @@ func (m *maxLatencyWriter) flushLoop() {
 	for {
 		select {
 		case <-m.done:
-			if onExitFlushLoop != nil {
-				onExitFlushLoop()
-			}
 			return
 		case <-t.C:
 			m.mu.Lock()


### PR DESCRIPTION
Skipped the ones in middlewares as they actually change behavior. Since
middlewares are set up per-API and re-created at each reload, a field is
not the same as a global.