### PR TITLE
dash: refactor heartbeat code

### DIFF
--- a/main.go
+++ b/main.go
@@ -1162,17 +1162,7 @@ func handleDashboardRegistration() {
 		log.Fatal("Registration failed: ", err)
 	}
 
-	startHeartBeat()
-}
-
-func startHeartBeat() {
-	if globalConf.UseDBAppConfigs {
-		if DashService == nil {
-			DashService = &HTTPDashboardHandler{}
-			DashService.Init()
-		}
-		go DashService.StartBeating()
-	}
+	go DashService.StartBeating()
 }
 
 func startDRL() {
@@ -1307,7 +1297,9 @@ func listen(l, controlListener net.Listener, err error) {
 				loadAPIEndpoints(controlRouter)
 			}
 
-			startHeartBeat()
+			if globalConf.UseDBAppConfigs {
+				go DashService.StartBeating()
+			}
 		}
 
 		if globalConf.HttpServerOptions.OverrideDefaults {


### PR DESCRIPTION
Return errors on funcs that return an error instead of just logging
them. Also treat errors when calling those funcs.

Also deduplicate some of the code, such as when creating new requests.
While at it, get rid of the redundant startHeartBeat func.