### PR TITLE
apidef/importer: new package for blueprint/swagger

### DIFF
--- a/apidef/importer/importer.go
+++ b/apidef/importer/importer.go
@@ -1,0 +1,31 @@
+package importer
+
+import (
+	"errors"
+	"io"
+
+	"github.com/TykTechnologies/tyk/apidef"
+	logger "github.com/TykTechnologies/tyk/log"
+)
+
+var log = logger.Get()
+
+type APIImporter interface {
+	LoadFrom(io.Reader) error
+	ConvertIntoApiVersion(bool) (apidef.VersionInfo, error)
+	InsertIntoAPIDefinitionAsVersion(apidef.VersionInfo, *apidef.APIDefinition, string) error
+}
+
+type APIImporterSource string
+
+func GetImporterForSource(source APIImporterSource) (APIImporter, error) {
+	// Extend to add new importers
+	switch source {
+	case ApiaryBluePrint:
+		return &BluePrintAST{}, nil
+	case SwaggerSource:
+		return &SwaggerAST{}, nil
+	default:
+		return nil, errors.New("source not matched, failing")
+	}
+}

--- a/command_mode.go
+++ b/command_mode.go
@@ -6,9 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/satori/go.uuid"
-
 	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/apidef/importer"
 )
 
 var commandModeOptions = []string{
@@ -25,51 +24,50 @@ var commandModeOptions = []string{
 // ./tyk --import-blueprint=blueprint.json --create-api --org-id=<id> --upstream-target="http://widgets.com/api/"`
 func handleCommandModeArgs(arguments map[string]interface{}) {
 	if arguments["--import-blueprint"] != nil {
-		handleBluePrintMode(arguments)
+		if err := handleBluePrintMode(arguments); err != nil {
+			log.Error(err)
+		}
 	}
 
 	if arguments["--import-swagger"] != nil {
-		handleSwaggerMode(arguments)
+		if err := handleSwaggerMode(arguments); err != nil {
+			log.Error(err)
+		}
 	}
 }
 
-func handleBluePrintMode(arguments map[string]interface{}) {
+func handleBluePrintMode(arguments map[string]interface{}) error {
 	doCreate := arguments["--create-api"].(bool)
 	inputFile := arguments["--import-blueprint"]
 	if !doCreate {
 		// Different branch, here we need an API Definition to modify
 		forAPIPath := arguments["--for-api"]
 		if forAPIPath == nil {
-			log.Error("If ading to an API, the path to the defintiton must be listed")
-			return
+			return fmt.Errorf("If ading to an API, the path to the defintiton must be listed")
 		}
 
 		versionName := arguments["--as-version"]
 		if versionName == nil {
-			log.Error("No version defined for this import operation, please set an import ID using the --as-version flag")
-			return
+			return fmt.Errorf("No version defined for this import operation, please set an import ID using the --as-version flag")
 		}
 
 		defFromFile, err := apiDefLoadFile(forAPIPath.(string))
 		if err != nil {
-			log.Error("failed to load and decode file data for API Definition: ", err)
-			return
+			return fmt.Errorf("failed to load and decode file data for API Definition: %v", err)
 		}
 
 		bp, err := bluePrintLoadFile(inputFile.(string))
 		if err != nil {
-			log.Error("File load error: ", err)
-			return
+			return fmt.Errorf("File load error: %v", err)
 		}
 
 		versionData, err := bp.ConvertIntoApiVersion(arguments["--as-mock"].(bool))
 		if err != nil {
-			log.Error("onversion into API Def failed: ", err)
+			return fmt.Errorf("onversion into API Def failed: %v", err)
 		}
 
 		if err := bp.InsertIntoAPIDefinitionAsVersion(versionData, defFromFile, versionName.(string)); err != nil {
-			log.Error("Insertion failed: ", err)
-			return
+			return fmt.Errorf("Insertion failed: %v", err)
 		}
 
 		printDef(defFromFile)
@@ -80,24 +78,83 @@ func handleBluePrintMode(arguments map[string]interface{}) {
 	orgID := arguments["--org-id"]
 
 	if upstreamVal == nil && orgID == nil {
-		log.Error("No upstream target or org ID defined, these are both required")
-		return
+		return fmt.Errorf("No upstream target or org ID defined, these are both required")
 	}
 
 	// Create the API with the blueprint
 	bp, err := bluePrintLoadFile(inputFile.(string))
 	if err != nil {
-		log.Error("File load error: ", err)
-		return
+		return fmt.Errorf("File load error: %v", err)
 	}
 
-	def, err := createDefFromBluePrint(bp, orgID.(string), upstreamVal.(string), arguments["--as-mock"].(bool))
+	def, err := bp.ToAPIDefinition(orgID.(string), upstreamVal.(string), arguments["--as-mock"].(bool))
 	if err != nil {
-		log.Error("Failed to create API Defintition from file")
-		return
+		return fmt.Errorf("Failed to create API Defintition from file")
 	}
 
 	printDef(def)
+	return nil
+}
+
+func handleSwaggerMode(arguments map[string]interface{}) error {
+	doCreate := arguments["--create-api"]
+	inputFile := arguments["--import-swagger"]
+	if doCreate == true {
+		upstreamVal := arguments["--upstream-target"]
+		orgId := arguments["--org-id"]
+		if upstreamVal != nil && orgId != nil {
+			// Create the API with the blueprint
+			s, err := swaggerLoadFile(inputFile.(string))
+			if err != nil {
+				return fmt.Errorf("File load error: %v", err)
+			}
+
+			def, err := s.ToAPIDefinition(orgId.(string), upstreamVal.(string), arguments["--as-mock"].(bool))
+			if err != nil {
+				return fmt.Errorf("Failed to create API Defintition from file")
+			}
+
+			printDef(def)
+			return nil
+		}
+
+		return fmt.Errorf("No upstream target or org ID defined, these are both required")
+
+	} else {
+		// Different branch, here we need an API Definition to modify
+		forApiPath := arguments["--for-api"]
+		if forApiPath == nil {
+			return fmt.Errorf("If ading to an API, the path to the defintiton must be listed")
+		}
+
+		versionName := arguments["--as-version"]
+		if versionName == nil {
+			return fmt.Errorf("No version defined for this import operation, please set an import ID using the --as-version flag")
+		}
+
+		defFromFile, err := apiDefLoadFile(forApiPath.(string))
+		if err != nil {
+			return fmt.Errorf("failed to load and decode file data for API Definition: %v", err)
+		}
+
+		s, err := swaggerLoadFile(inputFile.(string))
+		if err != nil {
+			return fmt.Errorf("File load error: %v", err)
+		}
+
+		versionData, err := s.ConvertIntoApiVersion(arguments["--as-mock"].(bool))
+		if err != nil {
+			return fmt.Errorf("Conversion into API Def failed: %v", err)
+		}
+
+		if err := s.InsertIntoAPIDefinitionAsVersion(versionData, defFromFile, versionName.(string)); err != nil {
+			return fmt.Errorf("Insertion failed: %v", err)
+		}
+
+		printDef(defFromFile)
+
+	}
+	return nil
 }
 
 func printDef(def *apidef.APIDefinition) {
@@ -111,64 +168,51 @@ func printDef(def *apidef.APIDefinition) {
 	fmt.Println(fixed)
 }
 
-func createDefFromBluePrint(bp *BluePrintAST, orgID, upstreamURL string, asMock bool) (*apidef.APIDefinition, error) {
-	ad := apidef.APIDefinition{
-		Name:             bp.Name,
-		Active:           true,
-		UseKeylessAccess: true,
-		APIID:            uuid.NewV4().String(),
-		OrgID:            orgID,
-	}
-	ad.VersionDefinition.Key = "version"
-	ad.VersionDefinition.Location = "header"
-	ad.VersionData.Versions = make(map[string]apidef.VersionInfo)
-	ad.Proxy.ListenPath = "/" + ad.APIID + "/"
-	ad.Proxy.StripListenPath = true
-	ad.Proxy.TargetURL = upstreamURL
-
-	versionData, err := bp.ConvertIntoApiVersion(asMock)
+func swaggerLoadFile(path string) (*importer.SwaggerAST, error) {
+	swagger, err := importer.GetImporterForSource(importer.SwaggerSource)
 	if err != nil {
-		log.Error("onversion into API Def failed: ", err)
+		return nil, err
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	if err := swagger.LoadFrom(f); err != nil {
+		return nil, err
 	}
 
-	err = bp.InsertIntoAPIDefinitionAsVersion(versionData, &ad, strings.Trim(bp.Name, " "))
-	return &ad, err
+	return swagger.(*importer.SwaggerAST), nil
 }
 
-func bluePrintLoadFile(path string) (*BluePrintAST, error) {
-	blueprint, err := GetImporterForSource(ApiaryBluePrint)
+func bluePrintLoadFile(path string) (*importer.BluePrintAST, error) {
+	blueprint, err := importer.GetImporterForSource(importer.ApiaryBluePrint)
 	if err != nil {
-		log.Error("Couldn't get blueprint importer: ", err)
 		return nil, err
 	}
 
 	f, err := os.Open(path)
 	if err != nil {
-		log.Error("Couldn't open blueprint file: ", err)
 		return nil, err
 	}
 	defer f.Close()
 
 	if err := blueprint.LoadFrom(f); err != nil {
-		log.Error("Failed to decode object: ", err)
 		return nil, err
 	}
 
-	return blueprint.(*BluePrintAST), nil
+	return blueprint.(*importer.BluePrintAST), nil
 }
 
 func apiDefLoadFile(path string) (*apidef.APIDefinition, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		log.Error("Couldn't open API Definition file: ", err)
 		return nil, err
 	}
-
 	def := &apidef.APIDefinition{}
 	if err := json.NewDecoder(f).Decode(&def); err != nil {
-		log.Error("Failed to unmarshal the JSON definition: ", err)
 		return nil, err
 	}
-
 	return def, nil
 }


### PR DESCRIPTION
These chunks of code are separate from the rest of the main package, so
they make for clean decoupling.

While at it, return errors instead of logging them in most cases.