### PR TITLE
batch: various cleanups and improvements

### DIFF
--- a/batch_requests_test.go
+++ b/batch_requests_test.go
@@ -87,7 +87,7 @@ func TestBatchSuccess(t *testing.T) {
 
 }
 
-func TestMakeSyncRequest(t *testing.T) {
+func TestMakeRequest(t *testing.T) {
 	spec := createSpecTest(t, batchTestDef)
 	batchHandler := BatchRequestHandler{API: spec}
 
@@ -97,33 +97,7 @@ func TestMakeSyncRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	replyUnit := batchHandler.doSyncRequest(req, relURL)
-
-	if replyUnit.RelativeURL != relURL {
-		t.Error("Relativce URL in reply is wrong")
-	}
-	if replyUnit.Code != 200 {
-		t.Error("Response reported a non-200 response")
-	}
-	if len(replyUnit.Body) < 1 {
-		t.Error("Reply body is too short, should be larger than 1!")
-	}
-}
-
-func TestMakeASyncRequest(t *testing.T) {
-	spec := createSpecTest(t, batchTestDef)
-	batchHandler := BatchRequestHandler{API: spec}
-
-	relURL := "/"
-	req, err := http.NewRequest("GET", testHttpGet, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	replies := make(chan BatchReplyUnit)
-	go batchHandler.doAsyncRequest(req, relURL, replies)
-	replyUnit := BatchReplyUnit{}
-	replyUnit = <-replies
+	replyUnit := batchHandler.doRequest(req, relURL)
 
 	if replyUnit.RelativeURL != relURL {
 		t.Error("Relativce URL in reply is wrong")

--- a/plugins.go
+++ b/plugins.go
@@ -372,14 +372,14 @@ func (j *JSVM) LoadTykJSApi() {
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "jsvm",
-			}).Error("[JSVM]: Failed to base64 decode: ", err)
+			}).Error("Failed to base64 decode: ", err)
 			return otto.Value{}
 		}
 		returnVal, err := j.VM.ToValue(string(out))
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "jsvm",
-			}).Error("[JSVM]: Failed to base64 decode: ", err)
+			}).Error("Failed to base64 decode: ", err)
 			return otto.Value{}
 		}
 		return returnVal
@@ -391,7 +391,7 @@ func (j *JSVM) LoadTykJSApi() {
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "jsvm",
-			}).Error("[JSVM]: Failed to base64 encode: ", err)
+			}).Error("Failed to base64 encode: ", err)
 			return otto.Value{}
 		}
 		return returnVal
@@ -445,7 +445,7 @@ func (j *JSVM) LoadTykJSApi() {
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "jsvm",
-			}).Error("[JSVM]: Request failed: ", err)
+			}).Error("Request failed: ", err)
 			return otto.Value{}
 		}
 
@@ -461,7 +461,7 @@ func (j *JSVM) LoadTykJSApi() {
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "jsvm",
-			}).Error("[JSVM]: Failed to encode return value: ", err)
+			}).Error("Failed to encode return value: ", err)
 			return otto.Value{}
 		}
 
@@ -480,7 +480,7 @@ func (j *JSVM) LoadTykJSApi() {
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "jsvm",
-			}).Error("[JSVM]: Failed to encode return value: ", err)
+			}).Error("Failed to encode return value: ", err)
 			return otto.Value{}
 		}
 
@@ -497,7 +497,7 @@ func (j *JSVM) LoadTykJSApi() {
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "jsvm",
-			}).Error("[JSVM]: Failed to decode the sesison data")
+			}).Error("Failed to decode the sesison data")
 			return otto.Value{}
 		}
 
@@ -514,13 +514,19 @@ func (j *JSVM) LoadTykJSApi() {
 			"prefix": "jsvm",
 		}).Debug("Batch input is: ", requestSet)
 
-		byteArray := unsafeBatchHandler.ManualBatchRequest([]byte(requestSet))
-
-		returnVal, err := j.VM.ToValue(string(byteArray))
+		bs, err := unsafeBatchHandler.ManualBatchRequest([]byte(requestSet))
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "jsvm",
-			}).Error("[JSVM]: Failed to encode return value: ", err)
+			}).Error(err)
+			return otto.Value{}
+		}
+
+		returnVal, err := j.VM.ToValue(string(bs))
+		if err != nil {
+			log.WithFields(logrus.Fields{
+				"prefix": "jsvm",
+			}).Error("Failed to encode return value: ", err)
 			return otto.Value{}
 		}
 


### PR DESCRIPTION
* doAsyncRequest and doSyncRequest were lazy copies; join them and do
  the appending/sending separately
* Funcs that return an error should just do that instead of logging
* Stop on batch errors in the JSVM