### PR TITLE
Applying `global_headers_remove` to X-Forwarded-For

### DIFF
--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -374,6 +374,7 @@ func (p *ReverseProxy) CheckHardTimeoutEnforced(spec *APISpec, req *http.Request
 func (p *ReverseProxy) CheckHeaderAllowed(hdr string, spec *APISpec, req *http.Request) bool {
 	vInfo, _, _, _ := spec.Version(req)
 	for _, gdKey := range vInfo.GlobalHeadersRemove {
+		log.Debug("Checking if header allowed: ", gdKey)
 		if strings.ToLower(gdKey) == strings.ToLower(hdr) {
 			return false
 		}
@@ -500,7 +501,11 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 	addrs := requestIPHops(req)
 	forwadedForHdr := "X-Forwarded-For"
 	if p.CheckHeaderAllowed(forwadedForHdr, p.TykAPISpec, req) {
+		log.Debug("Setting HDR: ", forwadedForHdr)
 		outreq.Header.Set(forwadedForHdr, addrs)
+	} else {
+		log.Debug("Header not allowed: ", forwadedForHdr)
+		outreq.Header.Del(forwadedForHdr)
 	}
 
 	// Circuit breaker

--- a/reverse_proxy_test.go
+++ b/reverse_proxy_test.go
@@ -169,7 +169,7 @@ func TestCheckHeaderAllowed(t *testing.T) {
 		t.Run(fmt.Sprintf("%s: %t", tc.header, tc.expected), func(t *testing.T) {
 			actual := rp.CheckHeaderAllowed(tc.header, tc.spec, r)
 			if actual != tc.expected {
-				t.Fatalf("want %t, got %t")
+				t.Fatalf("want %t, got %t", tc.expected, actual)
 			}
 		})
 	}

--- a/reverse_proxy_test.go
+++ b/reverse_proxy_test.go
@@ -259,7 +259,6 @@ func TestCheckHeaderAllowed(t *testing.T) {
 			r.URL = &url.URL{Path: "test"}
 
 			spec := createSpecTest(t, tc.spec)
-			//fmt.Printf("SPEC: %+v\n", spec.APIDefinition.VersionData)
 			actual := rp.CheckHeaderAllowed(tc.header, spec, r)
 			if actual != tc.expected {
 				t.Fatalf("want %t, got %t", tc.expected, actual)

--- a/reverse_proxy_test.go
+++ b/reverse_proxy_test.go
@@ -133,7 +133,7 @@ func TestRequestIP(t *testing.T) {
 	}
 }
 
-func TestCheckHeaderAllowed(t *testing.T) {
+func TestCheckHeaderInRemoveList(t *testing.T) {
 	tests := []struct {
 		header   string
 		spec     string
@@ -142,7 +142,7 @@ func TestCheckHeaderAllowed(t *testing.T) {
 		{
 			header:   "X-Forwarded-For",
 			spec:     "",
-			expected: true,
+			expected: false,
 		},
 		{
 			header: "X-Forwarded-For",
@@ -159,7 +159,7 @@ func TestCheckHeaderAllowed(t *testing.T) {
 					}
 				}
 			}`,
-			expected: true,
+			expected: false,
 		},
 		{
 			header: "X-Forwarded-For",
@@ -182,7 +182,7 @@ func TestCheckHeaderAllowed(t *testing.T) {
 					}
 				}
 			}`,
-			expected: true,
+			expected: false,
 		},
 		{
 			header: "X-Forwarded-For",
@@ -199,7 +199,7 @@ func TestCheckHeaderAllowed(t *testing.T) {
 					}
 				}
 			}`,
-			expected: false,
+			expected: true,
 		},
 		{
 			header: "X-Forwarded-For",
@@ -223,7 +223,7 @@ func TestCheckHeaderAllowed(t *testing.T) {
 					}
 				}
 			}`,
-			expected: false,
+			expected: true,
 		},
 		{
 			header: "X-Forwarded-For",
@@ -247,7 +247,7 @@ func TestCheckHeaderAllowed(t *testing.T) {
 					}
 				}
 			}`,
-			expected: false,
+			expected: true,
 		},
 	}
 
@@ -259,7 +259,7 @@ func TestCheckHeaderAllowed(t *testing.T) {
 			r.URL = &url.URL{Path: "test"}
 
 			spec := createSpecTest(t, tc.spec)
-			actual := rp.CheckHeaderAllowed(tc.header, spec, r)
+			actual := rp.CheckHeaderInRemoveList(tc.header, spec, r)
 			if actual != tc.expected {
 				t.Fatalf("want %t, got %t", tc.expected, actual)
 			}


### PR DESCRIPTION
Fixed #1149

My first PR here (in fact, first time looking at the code). Tried to follow the same style I saw around, but please let me know if anything too strange :)
# Overview
## What is it doing:
Applying the `global_headers_remove` rule to `X-Forwarded-For`, too.
## Motivation:
### TL;DR version
`Tyk` -> `AWS API Gateway w/ custom URL` doesn't work because of `X-Forwarded-For` header; trying to get around it. 
### Long explanation
I'm having to add a Serverless API (AWS API Gateway + Lambda) to Tyk. This API gateway has a custom URL (ie not the standard `execute-api` URL from AWS).
The issue is that it generates a CloudFront distribution which can't be configured, and by default it doesn't allow the `X-Forwarded-For` header, replying with a `307 - Temporary Redirection` and a `Location` header pointing to the custom URL (i.e. trying to bypass Tyk).
Since it's not configurable on the AWS side, I'm creating this PR to prevent X-Forwarded-For to be set.
## Why `global_headers_remove`
Because it makes sense. When I looked at the code, I wondered if I should add a new config flag (it makes sense considering how the code implemented it), but as an user I would be very confused.
I actually tried adding `X-Forwarded-For` to `global_headers_remove` as my first attempt, which made a lot of sense to me.