### PR TITLE
config: move global conf here

### DIFF
--- a/analytics_test.go
+++ b/analytics_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/TykTechnologies/tyk/config"
+)
 
 func TestGeoIPLookup(t *testing.T) {
 	testCases := [...]struct {
@@ -23,10 +27,10 @@ func TestGeoIPLookup(t *testing.T) {
 }
 
 func TestURLReplacer(t *testing.T) {
-	globalConf.AnalyticsConfig.NormaliseUrls.Enabled = true
-	globalConf.AnalyticsConfig.NormaliseUrls.NormaliseUUIDs = true
-	globalConf.AnalyticsConfig.NormaliseUrls.NormaliseNumbers = true
-	globalConf.AnalyticsConfig.NormaliseUrls.Custom = []string{"ihatethisstring"}
+	config.Global.AnalyticsConfig.NormaliseUrls.Enabled = true
+	config.Global.AnalyticsConfig.NormaliseUrls.NormaliseUUIDs = true
+	config.Global.AnalyticsConfig.NormaliseUrls.NormaliseNumbers = true
+	config.Global.AnalyticsConfig.NormaliseUrls.Custom = []string{"ihatethisstring"}
 
 	recordUUID1 := AnalyticsRecord{Path: "/15873a748894492162c402d67e92283b/search"}
 	recordUUID2 := AnalyticsRecord{Path: "/CA761232-ED42-11CE-BACD-00AA0057B223/search"}
@@ -35,7 +39,7 @@ func TestURLReplacer(t *testing.T) {
 	recordID1 := AnalyticsRecord{Path: "/widgets/123456/getParams"}
 	recordCust := AnalyticsRecord{Path: "/widgets/123456/getParams/ihatethisstring"}
 
-	globalConf.AnalyticsConfig.NormaliseUrls.CompiledPatternSet = initNormalisationPatterns()
+	config.Global.AnalyticsConfig.NormaliseUrls.CompiledPatternSet = initNormalisationPatterns()
 
 	recordUUID1.NormalisePath()
 	recordUUID2.NormalisePath()
@@ -47,7 +51,7 @@ func TestURLReplacer(t *testing.T) {
 	if recordUUID1.Path != "/{uuid}/search" {
 		t.Error("Path not altered, is:")
 		t.Error(recordUUID1.Path)
-		t.Error(globalConf.AnalyticsConfig.NormaliseUrls)
+		t.Error(config.Global.AnalyticsConfig.NormaliseUrls)
 	}
 
 	if recordUUID2.Path != "/{uuid}/search" {

--- a/api.go
+++ b/api.go
@@ -20,6 +20,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/config"
 )
 
 // APIModifyKeySuccess represents when a Key modification was successful
@@ -143,7 +144,7 @@ func doAddOrUpdate(keyName string, newSession *SessionState, dontReset bool) err
 		}
 	} else {
 		// nothing defined, add key to ALL
-		if !globalConf.AllowMasterKeys {
+		if !config.Global.AllowMasterKeys {
 			log.Error("Master keys disallowed in configuration, key not added.")
 			return errors.New("Master keys not allowed")
 		}
@@ -305,7 +306,7 @@ type APIAllKeys struct {
 }
 
 func handleGetAllKeys(filter, apiID string) (interface{}, int) {
-	if globalConf.HashKeys {
+	if config.Global.HashKeys {
 		return apiError("Configuration is secured, key listings not available in hashed configurations"), 400
 	}
 
@@ -445,7 +446,7 @@ func handleGetAPI(apiID string) (interface{}, int) {
 }
 
 func handleAddOrUpdateApi(apiID string, r *http.Request) (interface{}, int) {
-	if globalConf.UseDBAppConfigs {
+	if config.Global.UseDBAppConfigs {
 		log.Error("Rejected new API Definition due to UseDBAppConfigs = true")
 		return apiError("Due to enabled use_db_app_configs, please use the Dashboard API"), 500
 	}
@@ -462,7 +463,7 @@ func handleAddOrUpdateApi(apiID string, r *http.Request) (interface{}, int) {
 	}
 
 	// Create a filename
-	defFilePath := filepath.Join(globalConf.AppPath, newDef.APIID+".json")
+	defFilePath := filepath.Join(config.Global.AppPath, newDef.APIID+".json")
 
 	// If it exists, delete it
 	if _, err := os.Stat(defFilePath); err == nil {
@@ -497,7 +498,7 @@ func handleAddOrUpdateApi(apiID string, r *http.Request) (interface{}, int) {
 
 func handleDeleteAPI(apiID string) (interface{}, int) {
 	// Generate a filename
-	defFilePath := filepath.Join(globalConf.AppPath, apiID+".json")
+	defFilePath := filepath.Join(config.Global.AppPath, apiID+".json")
 
 	// If it exists, delete it
 	if _, err := os.Stat(defFilePath); err != nil {
@@ -720,7 +721,7 @@ func handleOrgAddOrUpdate(keyName string, r *http.Request) (interface{}, int) {
 
 	if spec == nil {
 		log.Warning("Couldn't find org session store in active API list")
-		if globalConf.SupressDefaultOrgStore {
+		if config.Global.SupressDefaultOrgStore {
 			return apiError("No such organisation found in Active API list"), 404
 		}
 		sessionManager = &DefaultOrgStore
@@ -913,7 +914,7 @@ func createKeyHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	} else {
-		if globalConf.AllowMasterKeys {
+		if config.Global.AllowMasterKeys {
 			// nothing defined, add key to ALL
 			log.WithFields(logrus.Fields{
 				"prefix":      "api",
@@ -1298,7 +1299,7 @@ func getOauthClients(apiID string) (interface{}, int) {
 }
 
 func healthCheckhandler(w http.ResponseWriter, r *http.Request) {
-	if !globalConf.HealthCheck.EnableHealthChecks {
+	if !config.Global.HealthCheck.EnableHealthChecks {
 		doJSONWrite(w, 400, apiError("Health checks are not enabled for this node"))
 		return
 	}

--- a/api_definition.go
+++ b/api_definition.go
@@ -159,7 +159,7 @@ func (a APIDefinitionLoader) MakeSpec(def *apidef.APIDefinition) *APISpec {
 	spec.OrgSessionManager = &DefaultSessionManager{}
 
 	// Create and init the virtual Machine
-	if globalConf.EnableJSVM {
+	if config.Global.EnableJSVM {
 		spec.JSVM.Init()
 	}
 
@@ -255,11 +255,11 @@ func (a APIDefinitionLoader) FromDashboardService(endpoint, secret string) []*AP
 	// Extract tagged entries only
 	apiDefs := make([]*apidef.APIDefinition, 0)
 
-	if globalConf.DBAppConfOptions.NodeIsSegmented {
-		tagList := make(map[string]bool, len(globalConf.DBAppConfOptions.Tags))
+	if config.Global.DBAppConfOptions.NodeIsSegmented {
+		tagList := make(map[string]bool, len(config.Global.DBAppConfOptions.Tags))
 		toLoad := make(map[string]*apidef.APIDefinition)
 
-		for _, mt := range globalConf.DBAppConfOptions.Tags {
+		for _, mt := range config.Global.DBAppConfOptions.Tags {
 			tagList[mt] = true
 		}
 
@@ -296,14 +296,14 @@ func (a APIDefinitionLoader) FromDashboardService(endpoint, secret string) []*AP
 
 // FromCloud will connect and download ApiDefintions from a Mongo DB instance.
 func (a APIDefinitionLoader) FromRPC(orgId string) []*APISpec {
-	store := RPCStorageHandler{UserKey: globalConf.SlaveOptions.APIKey, Address: globalConf.SlaveOptions.ConnectionString}
+	store := RPCStorageHandler{UserKey: config.Global.SlaveOptions.APIKey, Address: config.Global.SlaveOptions.ConnectionString}
 	store.Connect()
 
 	// enable segments
 	var tags []string
-	if globalConf.DBAppConfOptions.NodeIsSegmented {
-		log.Info("Segmented node, loading: ", globalConf.DBAppConfOptions.Tags)
-		tags = globalConf.DBAppConfOptions.Tags
+	if config.Global.DBAppConfOptions.NodeIsSegmented {
+		log.Info("Segmented node, loading: ", config.Global.DBAppConfOptions.Tags)
+		tags = config.Global.DBAppConfOptions.Tags
 	}
 
 	apiCollection := store.GetApiDefinitions(orgId, tags)
@@ -329,7 +329,7 @@ func (a APIDefinitionLoader) processRPCDefinitions(apiCollection string) []*APIS
 	for _, def := range apiDefs {
 		def.DecodeFromDB()
 
-		if globalConf.SlaveOptions.BindToSlugsInsteadOfListenPaths {
+		if config.Global.SlaveOptions.BindToSlugsInsteadOfListenPaths {
 			newListenPath := "/" + def.Slug //+ "/"
 			log.Warning("Binding to ",
 				newListenPath,
@@ -656,7 +656,7 @@ func (a APIDefinitionLoader) compileURLRewritesPathSpec(paths []apidef.URLRewrit
 }
 
 func (a APIDefinitionLoader) compileVirtualPathspathSpec(paths []apidef.VirtualMeta, stat URLStatus, apiSpec *APISpec) []URLSpec {
-	if !globalConf.EnableJSVM {
+	if !config.Global.EnableJSVM {
 		return nil
 	}
 

--- a/api_definition_test.go
+++ b/api_definition_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/garyburd/redigo/redis"
 	"github.com/lonelycode/gorpc"
+
+	"github.com/TykTechnologies/tyk/config"
 )
 
 const sampleDefiniton = `{
@@ -302,9 +304,9 @@ func TestBlacklistLinksMulti(t *testing.T) {
 }
 
 func startRPCMock(dispatcher *gorpc.Dispatcher) *gorpc.Server {
-	globalConf.SlaveOptions.UseRPC = true
-	globalConf.SlaveOptions.RPCKey = "test_org"
-	globalConf.SlaveOptions.APIKey = "test"
+	config.Global.SlaveOptions.UseRPC = true
+	config.Global.SlaveOptions.RPCKey = "test_org"
+	config.Global.SlaveOptions.APIKey = "test"
 
 	server := gorpc.NewTCPServer("127.0.0.1:0", dispatcher.NewHandlerFunc())
 	list := &customListener{}
@@ -314,16 +316,16 @@ func startRPCMock(dispatcher *gorpc.Dispatcher) *gorpc.Server {
 	if err := server.Start(); err != nil {
 		panic(err)
 	}
-	globalConf.SlaveOptions.ConnectionString = list.L.Addr().String()
+	config.Global.SlaveOptions.ConnectionString = list.L.Addr().String()
 
 	return server
 }
 
 func stopRPCMock(server *gorpc.Server) {
-	globalConf.SlaveOptions.ConnectionString = ""
-	globalConf.SlaveOptions.RPCKey = ""
-	globalConf.SlaveOptions.APIKey = ""
-	globalConf.SlaveOptions.UseRPC = false
+	config.Global.SlaveOptions.ConnectionString = ""
+	config.Global.SlaveOptions.RPCKey = ""
+	config.Global.SlaveOptions.APIKey = ""
+	config.Global.SlaveOptions.UseRPC = false
 
 	server.Listener.Close()
 	server.Stop()
@@ -387,14 +389,14 @@ func TestGetAPISpecsDashboardSuccess(t *testing.T) {
 	apisByID = make(map[string]*APISpec)
 	apisMu.Unlock()
 
-	globalConf.UseDBAppConfigs = true
-	globalConf.AllowInsecureConfigs = true
-	globalConf.DBAppConfOptions.ConnectionString = ts.URL
+	config.Global.UseDBAppConfigs = true
+	config.Global.AllowInsecureConfigs = true
+	config.Global.DBAppConfOptions.ConnectionString = ts.URL
 
 	defer func() {
-		globalConf.UseDBAppConfigs = false
-		globalConf.AllowInsecureConfigs = false
-		globalConf.DBAppConfOptions.ConnectionString = ""
+		config.Global.UseDBAppConfigs = false
+		config.Global.AllowInsecureConfigs = false
+		config.Global.DBAppConfOptions.ConnectionString = ""
 	}()
 
 	var wg sync.WaitGroup

--- a/api_healthcheck.go
+++ b/api_healthcheck.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/TykTechnologies/tyk/config"
 )
 
 type HealthPrefix string
@@ -39,7 +41,7 @@ type DefaultHealthChecker struct {
 var healthWarn sync.Once
 
 func (h *DefaultHealthChecker) Init(storeType StorageHandler) {
-	if globalConf.HealthCheck.EnableHealthChecks {
+	if config.Global.HealthCheck.EnableHealthChecks {
 		log.Debug("Health Checker initialised.")
 		healthWarn.Do(func() {
 			log.Warning("The Health Checker is deprecated and we do no longer recommend its use.")
@@ -57,7 +59,7 @@ func (h *DefaultHealthChecker) CreateKeyName(subKey HealthPrefix) string {
 
 // reportHealthValue is a shortcut we can use throughout the app to push a health check value
 func reportHealthValue(spec *APISpec, counter HealthPrefix, value string) {
-	if !globalConf.HealthCheck.EnableHealthChecks {
+	if !config.Global.HealthCheck.EnableHealthChecks {
 		return
 	}
 	spec.Health.StoreCounterVal(counter, value)
@@ -67,23 +69,23 @@ func (h *DefaultHealthChecker) StoreCounterVal(counterType HealthPrefix, value s
 	searchStr := h.CreateKeyName(counterType)
 	log.Debug("Adding Healthcheck to: ", searchStr)
 	log.Debug("Val is: ", value)
-	//go h.storage.SetKey(searchStr, value, globalConf.HealthCheck.HealthCheckValueTimeout)
+	//go h.storage.SetKey(searchStr, value, config.Global.HealthCheck.HealthCheckValueTimeout)
 	if value != "-1" {
 		// need to ensure uniqueness
 		now_string := strconv.Itoa(int(time.Now().UnixNano()))
 		value = now_string + "." + value
 		log.Debug("Set value to: ", value)
 	}
-	go h.storage.SetRollingWindow(searchStr, globalConf.HealthCheck.HealthCheckValueTimeout, value)
+	go h.storage.SetRollingWindow(searchStr, config.Global.HealthCheck.HealthCheckValueTimeout, value)
 }
 
 func (h *DefaultHealthChecker) getAvgCount(prefix HealthPrefix) float64 {
 	searchStr := h.CreateKeyName(prefix)
 	log.Debug("Searching for: ", searchStr)
 
-	count, _ := h.storage.SetRollingWindow(searchStr, globalConf.HealthCheck.HealthCheckValueTimeout, "-1")
+	count, _ := h.storage.SetRollingWindow(searchStr, config.Global.HealthCheck.HealthCheckValueTimeout, "-1")
 	log.Debug("Count is: ", count)
-	divisor := float64(globalConf.HealthCheck.HealthCheckValueTimeout)
+	divisor := float64(config.Global.HealthCheck.HealthCheckValueTimeout)
 	if divisor == 0 {
 		log.Warning("The Health Check sample timeout is set to 0, samples will never be deleted!!!")
 		divisor = 60.0
@@ -111,7 +113,7 @@ func (h *DefaultHealthChecker) ApiHealthValues() (HealthCheckValues, error) {
 	// Get the micro latency graph, an average upstream latency
 	searchStr := h.APIID + "." + string(RequestLog)
 	log.Debug("Searching KV for: ", searchStr)
-	_, vals := h.storage.SetRollingWindow(searchStr, globalConf.HealthCheck.HealthCheckValueTimeout, "-1")
+	_, vals := h.storage.SetRollingWindow(searchStr, config.Global.HealthCheck.HealthCheckValueTimeout, "-1")
 	log.Debug("Found: ", vals)
 	if len(vals) == 0 {
 		return values, nil

--- a/api_test.go
+++ b/api_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/config"
 )
 
 const apiTestDef = `{
@@ -47,9 +48,9 @@ type testAPIDefinition struct {
 
 func TestHealthCheckEndpoint(t *testing.T) {
 	uri := "/tyk/health/?api_id=1"
-	old := globalConf.HealthCheck.EnableHealthChecks
-	globalConf.HealthCheck.EnableHealthChecks = true
-	defer func() { globalConf.HealthCheck.EnableHealthChecks = old }()
+	old := config.Global.HealthCheck.EnableHealthChecks
+	config.Global.HealthCheck.EnableHealthChecks = true
+	defer func() { config.Global.HealthCheck.EnableHealthChecks = old }()
 
 	recorder := httptest.NewRecorder()
 	loadSampleAPI(t, apiTestDef)
@@ -208,8 +209,8 @@ func TestApiHandlerPostDupPath(t *testing.T) {
 func TestApiHandlerPostDbConfig(t *testing.T) {
 	uri := "/tyk/apis/1"
 
-	globalConf.UseDBAppConfigs = true
-	defer func() { globalConf.UseDBAppConfigs = false }()
+	config.Global.UseDBAppConfigs = true
+	defer func() { config.Global.UseDBAppConfigs = false }()
 
 	recorder := httptest.NewRecorder()
 

--- a/auth_manager.go
+++ b/auth_manager.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/satori/go.uuid"
 
+	"github.com/TykTechnologies/tyk/config"
+
 	"github.com/Sirupsen/logrus"
 )
 
@@ -114,7 +116,7 @@ func (b *DefaultSessionManager) UpdateSession(keyName string, session *SessionSt
 	v, _ := json.Marshal(session)
 
 	// Keep the TTL
-	if globalConf.UseAsyncSessionWrite {
+	if config.Global.UseAsyncSessionWrite {
 		go b.store.SetKey(keyName, string(v), resetTTLTo)
 		return nil
 	}

--- a/batch_requests.go
+++ b/batch_requests.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+
+	"github.com/TykTechnologies/tyk/config"
 )
 
 // RequestDefinition defines a batch request
@@ -73,7 +75,7 @@ func (b *BatchRequestHandler) ConstructRequests(batchRequest BatchRequestStructu
 		// URLs need to be built absolute so they go through the rate limiting and request limiting machinery
 		var absURL string
 		if !unsafe {
-			absUrlHeader := "http://localhost:" + strconv.Itoa(globalConf.ListenPort)
+			absUrlHeader := "http://localhost:" + strconv.Itoa(config.Global.ListenPort)
 			absURL = strings.Join([]string{absUrlHeader, strings.Trim(b.API.Proxy.ListenPath, "/"), requestDef.RelativeURL}, "/")
 		} else {
 			absURL = requestDef.RelativeURL

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,8 @@ import (
 
 var log = logger.Get()
 
+var Global Config
+
 type PoliciesConfig struct {
 	PolicySource           string `json:"policy_source"`
 	PolicyConnectionString string `json:"policy_connection_string"`

--- a/coprocess.go
+++ b/coprocess.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Sirupsen/logrus"
 
 	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/coprocess"
 
 	"errors"
@@ -16,7 +17,7 @@ import (
 )
 
 var (
-	// EnableCoProcess will be overridden by globalConf.EnableCoProcess.
+	// EnableCoProcess will be overridden by config.Global.EnableCoProcess.
 	EnableCoProcess = false
 
 	// GlobalDispatcher will be implemented by the current CoProcess driver.
@@ -152,7 +153,7 @@ func (c *CoProcessor) ObjectPostProcess(object *coprocess.Object, r *http.Reques
 // CoProcessInit creates a new CoProcessDispatcher, it will be called when Tyk starts.
 func CoProcessInit() error {
 	var err error
-	if globalConf.CoProcessOptions.EnableCoProcess {
+	if config.Global.CoProcessOptions.EnableCoProcess {
 		GlobalDispatcher, err = NewCoProcessDispatcher()
 		EnableCoProcess = true
 	}
@@ -162,7 +163,7 @@ func CoProcessInit() error {
 // IsEnabledForSpec checks if this middleware should be enabled for a given API.
 func (m *CoProcessMiddleware) IsEnabledForSpec() bool {
 	// This flag is true when Tyk has been compiled with CP support and when the configuration enables it.
-	enableCoProcess := globalConf.CoProcessOptions.EnableCoProcess && EnableCoProcess
+	enableCoProcess := config.Global.CoProcessOptions.EnableCoProcess && EnableCoProcess
 	// This flag indicates if the current spec specifies any CP custom middleware.
 	var usesCoProcessMiddleware bool
 

--- a/coprocess_bundle.go
+++ b/coprocess_bundle.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/TykTechnologies/goverify"
 	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/config"
 
 	"archive/zip"
 	"bytes"
@@ -24,7 +25,7 @@ import (
 var tykBundlePath string
 
 func init() {
-	tykBundlePath = filepath.Join(globalConf.MiddlewarePath, "middleware", "bundles")
+	tykBundlePath = filepath.Join(config.Global.MiddlewarePath, "middleware", "bundles")
 }
 
 // Bundle is the basic bundle data structure, it holds the bundle name and the data.
@@ -46,14 +47,14 @@ func (b *Bundle) Verify() error {
 	var bundleVerifier goverify.Verifier
 
 	// Perform signature verification if a public key path is set:
-	if globalConf.PublicKeyPath != "" {
+	if config.Global.PublicKeyPath != "" {
 		if b.Manifest.Signature == "" {
 			// Error: A public key is set, but the bundle isn't signed.
 			return errors.New("Bundle isn't signed")
 		}
 		if notificationVerifier == nil {
 			var err error
-			bundleVerifier, err = goverify.LoadPublicKeyFromFile(globalConf.PublicKeyPath)
+			bundleVerifier, err = goverify.LoadPublicKeyFromFile(config.Global.PublicKeyPath)
 			if err != nil {
 				return err
 			}
@@ -176,7 +177,7 @@ func (ZipBundleSaver) Save(bundle *Bundle, bundlePath string, spec *APISpec) err
 // fetchBundle will fetch a given bundle, using the right BundleGetter. The first argument is the bundle name, the base bundle URL will be used as prefix.
 func fetchBundle(spec *APISpec) (bundle Bundle, err error) {
 
-	if !globalConf.EnableBundleDownloader {
+	if !config.Global.EnableBundleDownloader {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Warning("Bundle downloader is disabled.")
@@ -184,7 +185,7 @@ func fetchBundle(spec *APISpec) (bundle Bundle, err error) {
 		return bundle, err
 	}
 
-	bundleURL := globalConf.BundleBaseURL + spec.CustomMiddlewareBundle
+	bundleURL := config.Global.BundleBaseURL + spec.CustomMiddlewareBundle
 
 	var getter BundleGetter
 
@@ -270,7 +271,7 @@ func loadBundle(spec *APISpec) {
 	}
 
 	// Skip if no bundle base URL is set.
-	if globalConf.BundleBaseURL == "" {
+	if config.Global.BundleBaseURL == "" {
 		bundleError(spec, nil, "No bundle base URL set, skipping bundle")
 		return
 	}

--- a/coprocess_grpc.go
+++ b/coprocess_grpc.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/coprocess"
 )
 
@@ -32,7 +33,7 @@ type GRPCDispatcher struct {
 }
 
 func dialer(addr string, timeout time.Duration) (net.Conn, error) {
-	grpcUrl, err := url.Parse(globalConf.CoProcessOptions.CoProcessGRPCServer)
+	grpcUrl, err := url.Parse(config.Global.CoProcessOptions.CoProcessGRPCServer)
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "coprocess-grpc",
@@ -40,7 +41,7 @@ func dialer(addr string, timeout time.Duration) (net.Conn, error) {
 		return nil, err
 	}
 
-	if grpcUrl == nil || globalConf.CoProcessOptions.CoProcessGRPCServer == "" {
+	if grpcUrl == nil || config.Global.CoProcessOptions.CoProcessGRPCServer == "" {
 		errString := "No gRPC URL is set!"
 		log.WithFields(logrus.Fields{
 			"prefix": "coprocess-grpc",
@@ -48,7 +49,7 @@ func dialer(addr string, timeout time.Duration) (net.Conn, error) {
 		return nil, errors.New(errString)
 	}
 
-	grpcUrlString := globalConf.CoProcessOptions.CoProcessGRPCServer[len(grpcUrl.Scheme)+3:]
+	grpcUrlString := config.Global.CoProcessOptions.CoProcessGRPCServer[len(grpcUrl.Scheme)+3:]
 	return net.DialTimeout(grpcUrl.Scheme, grpcUrlString, timeout)
 }
 

--- a/dashboard_register.go
+++ b/dashboard_register.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+
+	"github.com/TykTechnologies/tyk/config"
 )
 
 type NodeResponseOK struct {
@@ -69,7 +71,7 @@ func (h *HTTPDashboardHandler) Init() error {
 	h.DeRegistrationEndpoint = buildConnStr("/system/node")
 	h.HeartBeatEndpoint = buildConnStr("/register/ping")
 
-	h.Secret = globalConf.NodeSecret
+	h.Secret = config.Global.NodeSecret
 	return nil
 }
 

--- a/distributed_rate_limiter.go
+++ b/distributed_rate_limiter.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Sirupsen/logrus"
 
 	"github.com/TykTechnologies/drl"
+	"github.com/TykTechnologies/tyk/config"
 )
 
 var DRLManager = &drl.DRL{}
@@ -20,7 +21,7 @@ func setupDRL() {
 }
 
 func startRateLimitNotifications() {
-	notificationFreq := globalConf.DRLNotificationFrequency
+	notificationFreq := config.Global.DRLNotificationFrequency
 	if notificationFreq == 0 {
 		notificationFreq = 2
 	}
@@ -41,7 +42,7 @@ func startRateLimitNotifications() {
 
 func getTagHash() string {
 	th := ""
-	for _, tag := range globalConf.DBAppConfOptions.Tags {
+	for _, tag := range config.Global.DBAppConfOptions.Tags {
 		th += tag
 	}
 	return th

--- a/event_handler_webhooks.go
+++ b/event_handler_webhooks.go
@@ -86,7 +86,7 @@ func (w *WebHookHandler) Init(handlerConf interface{}) error {
 			"prefix": "webhooks",
 			"target": w.conf.TargetPath,
 		}).Info("Loading default template.")
-		defaultPath := filepath.Join(globalConf.TemplatePath, "default_webhook.json")
+		defaultPath := filepath.Join(config.Global.TemplatePath, "default_webhook.json")
 		w.template, err = template.ParseFiles(defaultPath)
 		if err != nil {
 			log.WithFields(logrus.Fields{

--- a/event_handler_webhooks_test.go
+++ b/event_handler_webhooks_test.go
@@ -190,9 +190,9 @@ func TestNewCustomTemplate(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.missingDefault {
-				old := globalConf.TemplatePath
-				globalConf.TemplatePath = "missing-dir"
-				defer func() { globalConf.TemplatePath = old }()
+				old := config.Global.TemplatePath
+				config.Global.TemplatePath = "missing-dir"
+				defer func() { config.Global.TemplatePath = old }()
 			}
 			h := &WebHookHandler{}
 			err := h.Init(map[string]interface{}{

--- a/event_system.go
+++ b/event_system.go
@@ -175,7 +175,7 @@ func (s *APISpec) FireEvent(name apidef.TykEvent, meta interface{}) {
 }
 
 func FireSystemEvent(name apidef.TykEvent, meta interface{}) {
-	fireEvent(name, meta, globalConf.EventTriggers)
+	fireEvent(name, meta, config.Global.EventTriggers)
 }
 
 // LogMessageEventHandler is a sample Event Handler

--- a/handler_error.go
+++ b/handler_error.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/TykTechnologies/tyk/config"
 )
 
 const (
@@ -81,7 +83,7 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 	var alias string
 
 	ip := requestIP(r)
-	if globalConf.StoreAnalytics(ip) {
+	if config.Global.StoreAnalytics(ip) {
 
 		t := time.Now()
 
@@ -159,7 +161,7 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 		record.GetGeo(ip)
 
 		expiresAfter := e.Spec.ExpireAnalyticsAfter
-		if globalConf.EnforceOrgDataAge {
+		if config.Global.EnforceOrgDataAge {
 			orgExpireDataTime := e.OrgSessionExpiry(e.Spec.OrgID)
 
 			if orgExpireDataTime > 0 {
@@ -169,7 +171,7 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 		}
 
 		record.SetExpiry(expiresAfter)
-		if globalConf.AnalyticsConfig.NormaliseUrls.Enabled {
+		if config.Global.AnalyticsConfig.NormaliseUrls.Enabled {
 			record.NormalisePath()
 		}
 
@@ -180,12 +182,12 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 	reportHealthValue(e.Spec, BlockedRequestLog, "-1")
 
 	//If the config option is not set or is false, add the header
-	if !globalConf.HideGeneratorHeader {
+	if !config.Global.HideGeneratorHeader {
 		w.Header().Add("X-Generator", "tyk.io")
 	}
 
 	// Close connections
-	if globalConf.CloseConnections {
+	if config.Global.CloseConnections {
 		w.Header().Add("Connection", "close")
 	}
 

--- a/handler_success.go
+++ b/handler_success.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	cache "github.com/pmylund/go-cache"
+
+	"github.com/TykTechnologies/tyk/config"
 )
 
 // Enums for keys to be stored in a session context - this is how gorilla expects
@@ -48,7 +50,7 @@ func (s *SuccessHandler) RecordHit(r *http.Request, timing int64, code int, requ
 	}
 
 	ip := requestIP(r)
-	if globalConf.StoreAnalytics(ip) {
+	if config.Global.StoreAnalytics(ip) {
 
 		t := time.Now()
 
@@ -125,7 +127,7 @@ func (s *SuccessHandler) RecordHit(r *http.Request, timing int64, code int, requ
 		record.GetGeo(ip)
 
 		expiresAfter := s.Spec.ExpireAnalyticsAfter
-		if globalConf.EnforceOrgDataAge {
+		if config.Global.EnforceOrgDataAge {
 			orgExpireDataTime := s.OrgSessionExpiry(s.Spec.OrgID)
 
 			if orgExpireDataTime > 0 {
@@ -135,7 +137,7 @@ func (s *SuccessHandler) RecordHit(r *http.Request, timing int64, code int, requ
 
 		record.SetExpiry(expiresAfter)
 
-		if globalConf.AnalyticsConfig.NormaliseUrls.Enabled {
+		if config.Global.AnalyticsConfig.NormaliseUrls.Enabled {
 			record.NormalisePath()
 		}
 
@@ -152,15 +154,15 @@ func (s *SuccessHandler) RecordHit(r *http.Request, timing int64, code int, requ
 
 func recordDetail(r *http.Request) bool {
 	// Are we even checking?
-	if !globalConf.EnforceOrgDataDeailLogging {
-		return globalConf.AnalyticsConfig.EnableDetailedRecording
+	if !config.Global.EnforceOrgDataDeailLogging {
+		return config.Global.AnalyticsConfig.EnableDetailedRecording
 	}
 
 	// We are, so get session data
 	ses := r.Context().Value(OrgSessionContext)
 	if ses == nil {
 		// no session found, use global config
-		return globalConf.AnalyticsConfig.EnableDetailedRecording
+		return config.Global.AnalyticsConfig.EnableDetailedRecording
 	}
 
 	// Session found

--- a/handler_websocket.go
+++ b/handler_websocket.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
+
+	"github.com/TykTechnologies/tyk/config"
 )
 
 func canonicalAddr(url *url.URL) string {
@@ -30,7 +32,7 @@ type WSDialer struct {
 
 func (ws *WSDialer) RoundTrip(req *http.Request) (*http.Response, error) {
 
-	if !globalConf.HttpServerOptions.EnableWebSockets {
+	if !config.Global.HttpServerOptions.EnableWebSockets {
 		return nil, errors.New("WebSockets has been disabled on this host")
 	}
 
@@ -116,7 +118,7 @@ func (ws *WSDialer) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func IsWebsocket(req *http.Request) bool {
-	if !globalConf.HttpServerOptions.EnableWebSockets {
+	if !config.Global.HttpServerOptions.EnableWebSockets {
 		return false
 	}
 

--- a/host_checker_manager.go
+++ b/host_checker_manager.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/vmihailenco/msgpack.v2"
 
 	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/config"
 )
 
 var GlobalHostChecker HostCheckerManager
@@ -81,7 +82,7 @@ func (hc *HostCheckerManager) Start() {
 	// Start loop to check if we are active instance
 	if hc.Id != "" {
 		go hc.CheckActivePollerLoop()
-		if globalConf.UptimeTests.Config.EnableUptimeAnalytics {
+		if config.Global.UptimeTests.Config.EnableUptimeAnalytics {
 			go hc.UptimePurgeLoop()
 		}
 	}
@@ -167,9 +168,9 @@ func (hc *HostCheckerManager) StartPoller() {
 		hc.checker = &HostUptimeChecker{}
 	}
 
-	hc.checker.Init(globalConf.UptimeTests.Config.CheckerPoolSize,
-		globalConf.UptimeTests.Config.FailureTriggerSampleSize,
-		globalConf.UptimeTests.Config.TimeWait,
+	hc.checker.Init(config.Global.UptimeTests.Config.CheckerPoolSize,
+		config.Global.UptimeTests.Config.FailureTriggerSampleSize,
+		config.Global.UptimeTests.Config.TimeWait,
 		hc.currentHostList,
 		hc.OnHostDown,   // On failure
 		hc.OnHostBackUp, // On success
@@ -199,7 +200,7 @@ func (hc *HostCheckerManager) getHostKey(report HostHealthReport) string {
 }
 
 func (hc *HostCheckerManager) OnHostReport(report HostHealthReport) {
-	if globalConf.UptimeTests.Config.EnableUptimeAnalytics {
+	if config.Global.UptimeTests.Config.EnableUptimeAnalytics {
 		go hc.RecordUptimeAnalytics(report)
 	}
 }

--- a/instrumentation_handlers.go
+++ b/instrumentation_handlers.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/gocraft/health"
+
+	"github.com/TykTechnologies/tyk/config"
 )
 
 var applicationGCStats = debug.GCStats{}
@@ -22,14 +24,14 @@ func setupInstrumentation(arguments map[string]interface{}) {
 		return
 	}
 
-	if globalConf.StatsdConnectionString == "" {
+	if config.Global.StatsdConnectionString == "" {
 		log.Error("Instrumentation is enabled, but no connectionstring set for statsd")
 		return
 	}
 
-	log.Info("Sending stats to: ", globalConf.StatsdConnectionString, " with prefix: ", globalConf.StatsdPrefix)
-	statsdSink, err := NewStatsDSink(globalConf.StatsdConnectionString,
-		&StatsDSinkOptions{Prefix: globalConf.StatsdPrefix})
+	log.Info("Sending stats to: ", config.Global.StatsdConnectionString, " with prefix: ", config.Global.StatsdPrefix)
+	statsdSink, err := NewStatsDSink(config.Global.StatsdConnectionString,
+		&StatsDSinkOptions{Prefix: config.Global.StatsdPrefix})
 
 	if err != nil {
 		log.Fatal("Failed to start StatsD check: ", err)

--- a/le_helpers.go
+++ b/le_helpers.go
@@ -6,6 +6,8 @@ import (
 	"rsc.io/letsencrypt"
 
 	"github.com/Sirupsen/logrus"
+
+	"github.com/TykTechnologies/tyk/config"
 )
 
 const LEKeyPrefix = "le_ssl:"
@@ -26,7 +28,7 @@ func StoreLEState(m *letsencrypt.Manager) {
 	}
 
 	state := m.Marshal()
-	secret := rightPad2Len(globalConf.Secret, "=", 32)
+	secret := rightPad2Len(config.Global.Secret, "=", 32)
 	cryptoText := encrypt([]byte(secret), state)
 
 	if err := store.SetKey("cache", cryptoText, -1); err != nil {
@@ -54,7 +56,7 @@ func GetLEState(m *letsencrypt.Manager) {
 		return
 	}
 
-	secret := rightPad2Len(globalConf.Secret, "=", 32)
+	secret := rightPad2Len(config.Global.Secret, "=", 32)
 	sslState := decrypt([]byte(secret), cryptoText)
 
 	m.Unmarshal(sslState)

--- a/middleware.go
+++ b/middleware.go
@@ -11,6 +11,7 @@ import (
 	cache "github.com/pmylund/go-cache"
 
 	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/config"
 )
 
 const mwStatusRespond = 666
@@ -125,7 +126,7 @@ func (t BaseMiddleware) Config() (interface{}, error) {
 func (t BaseMiddleware) OrgSession(key string) (SessionState, bool) {
 	// Try and get the session from the session store
 	session, found := t.Spec.OrgSessionManager.SessionDetail(key)
-	if found && globalConf.EnforceOrgDataAge {
+	if found && config.Global.EnforceOrgDataAge {
 		// If exists, assume it has been authorized and pass on
 		// We cache org expiry data
 		log.Debug("Setting data expiry: ", session.OrgID)
@@ -225,7 +226,7 @@ func (t BaseMiddleware) CheckSessionAndIdentityForValidKey(key string) (SessionS
 	// Try and get the session from the session store
 	log.Debug("Querying local cache")
 	// Check in-memory cache
-	if !globalConf.LocalSessionCache.DisableCacheSessionState {
+	if !config.Global.LocalSessionCache.DisableCacheSessionState {
 		cachedVal, found := SessionCache.Get(key)
 		if found {
 			log.Debug("--> Key found in local cache")

--- a/monitor.go
+++ b/monitor.go
@@ -9,7 +9,7 @@ import (
 type Monitor struct{}
 
 func (Monitor) IsMonitorEnabled() bool {
-	return globalConf.Monitor.EnableTriggerMonitors
+	return config.Global.Monitor.EnableTriggerMonitors
 }
 
 func (Monitor) Fire(sessionData *SessionState, key string, triggerLimit float64) {
@@ -47,13 +47,13 @@ func (m Monitor) Check(sessionData *SessionState, key string) {
 		return
 	}
 
-	if globalConf.Monitor.GlobalTriggerLimit > 0.0 && usagePerc >= globalConf.Monitor.GlobalTriggerLimit {
+	if config.Global.Monitor.GlobalTriggerLimit > 0.0 && usagePerc >= config.Global.Monitor.GlobalTriggerLimit {
 		log.Info("Firing...")
-		m.Fire(sessionData, key, globalConf.Monitor.GlobalTriggerLimit)
+		m.Fire(sessionData, key, config.Global.Monitor.GlobalTriggerLimit)
 	}
 
 	for _, triggerLimit := range sessionData.Monitor.TriggerLimits {
-		if usagePerc >= triggerLimit && triggerLimit != globalConf.Monitor.GlobalTriggerLimit {
+		if usagePerc >= triggerLimit && triggerLimit != config.Global.Monitor.GlobalTriggerLimit {
 			log.Info("Firing...")
 			m.Fire(sessionData, key, triggerLimit)
 			break

--- a/mw_organisation_activity.go
+++ b/mw_organisation_activity.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 
 	"github.com/Sirupsen/logrus"
+
+	"github.com/TykTechnologies/tyk/config"
 )
 
 var orgChanMap = make(map[string]chan bool)
@@ -35,11 +37,11 @@ func (k *OrganizationMonitor) Name() string {
 func (k *OrganizationMonitor) IsEnabledForSpec() bool {
 	// If false, we aren't enforcing quotas so skip this mw
 	// altogether
-	return globalConf.EnforceOrgQuotas
+	return config.Global.EnforceOrgQuotas
 }
 
 func (k *OrganizationMonitor) ProcessRequest(w http.ResponseWriter, r *http.Request, conf interface{}) (error, int) {
-	if globalConf.ExperimentalProcessOrgOffThread {
+	if config.Global.ExperimentalProcessOrgOffThread {
 		return k.ProcessRequestOffThread(r)
 	}
 	return k.ProcessRequestLive(r)
@@ -94,7 +96,7 @@ func (k *OrganizationMonitor) ProcessRequestLive(r *http.Request) (error, int) {
 		return errors.New("This organisation quota has been exceeded, please contact your API administrator"), 403
 	}
 
-	if globalConf.Monitor.MonitorOrgKeys {
+	if config.Global.Monitor.MonitorOrgKeys {
 		// Run the trigger monitor
 		k.mon.Check(&session, "")
 	}
@@ -186,7 +188,7 @@ func (k *OrganizationMonitor) AllowAccessNext(orgChan chan bool, r *http.Request
 		//return errors.New("This organisation quota has been exceeded, please contact your API administrator"), 403
 		orgChan <- false
 
-		if globalConf.Monitor.MonitorOrgKeys {
+		if config.Global.Monitor.MonitorOrgKeys {
 			// Run the trigger monitor
 			k.mon.Check(&session, "")
 		}
@@ -194,7 +196,7 @@ func (k *OrganizationMonitor) AllowAccessNext(orgChan chan bool, r *http.Request
 		return
 	}
 
-	if globalConf.Monitor.MonitorOrgKeys {
+	if config.Global.Monitor.MonitorOrgKeys {
 		// Run the trigger monitor
 		k.mon.Check(&session, "")
 	}

--- a/mw_rate_limiting.go
+++ b/mw_rate_limiting.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 
 	"github.com/Sirupsen/logrus"
+
+	"github.com/TykTechnologies/tyk/config"
 )
 
 var sessionLimiter = SessionLimiter{}
@@ -98,7 +100,7 @@ func (k *RateLimitAndQuotaCheck) ProcessRequest(w http.ResponseWriter, r *http.R
 		return errors.New("Access denied"), 403
 	}
 	// Run the trigger monitor
-	if globalConf.Monitor.MonitorUserKeys {
+	if config.Global.Monitor.MonitorUserKeys {
 		sessionMonitor.Check(session, token)
 	}
 

--- a/mw_virtual_endpoint.go
+++ b/mw_virtual_endpoint.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/config"
 )
 
 // RequestObject is marshalled to JSON string and passed into JSON middleware
@@ -57,7 +58,7 @@ func preLoadVirtualMetaCode(meta *apidef.VirtualMeta, j *JSVM) {
 		}
 		src = f
 	case "blob":
-		if globalConf.DisableVirtualPathBlobs {
+		if config.Global.DisableVirtualPathBlobs {
 			log.Error("[JSVM] Blobs not allowed on this node")
 			return
 		}
@@ -82,7 +83,7 @@ func (d *VirtualEndpoint) Init() {
 }
 
 func (d *VirtualEndpoint) IsEnabledForSpec() bool {
-	if !globalConf.EnableJSVM {
+	if !config.Global.EnableJSVM {
 		return false
 	}
 	for _, version := range d.Spec.VersionData.Versions {
@@ -247,7 +248,7 @@ func handleForcedResponse(rw http.ResponseWriter, res *http.Response, ses *Sessi
 	defer res.Body.Close()
 
 	// Close connections
-	if globalConf.CloseConnections {
+	if config.Global.CloseConnections {
 		res.Header.Set("Connection", "close")
 	}
 

--- a/oauth_manager.go
+++ b/oauth_manager.go
@@ -11,6 +11,8 @@ import (
 	osin "github.com/lonelycode/osin"
 	"github.com/satori/go.uuid"
 	"golang.org/x/crypto/bcrypt"
+
+	"github.com/TykTechnologies/tyk/config"
 )
 
 /*
@@ -248,7 +250,7 @@ func (o *OAuthManager) HandleAccess(r *http.Request) *osin.Response {
 			username = r.Form.Get("username")
 			password := r.Form.Get("password")
 			keyName := o.API.OrgID + username
-			if globalConf.HashKeys {
+			if config.Global.HashKeys {
 				// HASHING? FIX THE KEY
 				keyName = doHash(keyName)
 			}
@@ -497,7 +499,7 @@ func (r *RedisOsinStorageInterface) GetClients(filter string, ignorePrefix bool)
 	}
 
 	var clientJSON map[string]string
-	if !globalConf.Storage.EnableCluster {
+	if !config.Global.Storage.EnableCluster {
 		clientJSON = r.store.GetKeysAndValuesWithFilter(key)
 	} else {
 		keyForSet := prefixClientset + prefixClient // Org ID
@@ -618,8 +620,8 @@ func (r *RedisOsinStorageInterface) SaveAccess(accessData *osin.AccessData) erro
 	log.Debug("Saving ACCESS key: ", key)
 
 	// Overide default ExpiresIn:
-	if globalConf.OauthTokenExpire != 0 {
-		accessData.ExpiresIn = globalConf.OauthTokenExpire
+	if config.Global.OauthTokenExpire != 0 {
+		accessData.ExpiresIn = config.Global.OauthTokenExpire
 	}
 
 	r.store.SetKey(key, string(authDataJSON), int64(accessData.ExpiresIn))
@@ -668,8 +670,8 @@ func (r *RedisOsinStorageInterface) SaveAccess(accessData *osin.AccessData) erro
 		key := prefixRefresh + accessData.RefreshToken
 		log.Debug("Saving REFRESH key: ", key)
 		refreshExpire := int64(1209600) // 14 days
-		if globalConf.OauthRefreshExpire != 0 {
-			refreshExpire = globalConf.OauthRefreshExpire
+		if config.Global.OauthRefreshExpire != 0 {
+			refreshExpire = config.Global.OauthRefreshExpire
 		}
 		r.store.SetKey(key, string(accessDataJSON), refreshExpire)
 		log.Debug("STORING ACCESS DATA: ", string(accessDataJSON))

--- a/oauth_manager_test.go
+++ b/oauth_manager_test.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/justinas/alice"
+
+	"github.com/TykTechnologies/tyk/config"
 )
 
 const (
@@ -84,12 +86,12 @@ func getOAuthChain(spec *APISpec, muxer *mux.Router) {
 
 	var redirectURI string
 	// If separator is not set that means multiple redirect uris not supported
-	if globalConf.OauthRedirectUriSeparator == "" {
+	if config.Global.OauthRedirectUriSeparator == "" {
 		redirectURI = "http://client.oauth.com"
 
 		// If separator config is set that means multiple redirect uris are supported
 	} else {
-		redirectURI = strings.Join([]string{"http://client.oauth.com", "http://client2.oauth.com", "http://client3.oauth.com"}, globalConf.OauthRedirectUriSeparator)
+		redirectURI = strings.Join([]string{"http://client.oauth.com", "http://client2.oauth.com", "http://client3.oauth.com"}, config.Global.OauthRedirectUriSeparator)
 	}
 	testClient := OAuthClient{
 		ClientID:          "1234",
@@ -139,7 +141,7 @@ func TestAuthCodeRedirect(t *testing.T) {
 
 func TestAuthCodeRedirectMultipleURL(t *testing.T) {
 	// Enable multiple Redirect URIs
-	globalConf.OauthRedirectUriSeparator = ","
+	config.Global.OauthRedirectUriSeparator = ","
 
 	spec := createSpecTest(t, oauthDefinition)
 	testMuxer := mux.NewRouter()
@@ -166,7 +168,7 @@ func TestAuthCodeRedirectMultipleURL(t *testing.T) {
 
 func TestAuthCodeRedirectInvalidMultipleURL(t *testing.T) {
 	// Disable multiple Redirect URIs
-	globalConf.OauthRedirectUriSeparator = ""
+	config.Global.OauthRedirectUriSeparator = ""
 
 	spec := createSpecTest(t, oauthDefinition)
 	testMuxer := mux.NewRouter()

--- a/plugins.go
+++ b/plugins.go
@@ -16,6 +16,8 @@ import (
 	"github.com/robertkrimen/otto"
 	_ "github.com/robertkrimen/otto/underscore"
 
+	"github.com/TykTechnologies/tyk/config"
+
 	"github.com/Sirupsen/logrus"
 )
 
@@ -286,7 +288,7 @@ func (j *JSVM) Init() {
 	vm := otto.New()
 
 	// Init TykJS namespace, constructors etc.
-	f, err := os.Open(globalConf.TykJSPath)
+	f, err := os.Open(config.Global.TykJSPath)
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "jsvm",

--- a/policy.go
+++ b/policy.go
@@ -10,6 +10,8 @@ import (
 	"gopkg.in/mgo.v2/bson"
 
 	"github.com/Sirupsen/logrus"
+
+	"github.com/TykTechnologies/tyk/config"
 )
 
 type Policy struct {
@@ -167,7 +169,7 @@ func LoadPoliciesFromDashboard(endpoint, secret string, allowExplicit bool) map[
 func LoadPoliciesFromRPC(orgId string) map[string]Policy {
 	var dbPolicyList []Policy
 
-	store := &RPCStorageHandler{UserKey: globalConf.SlaveOptions.APIKey, Address: globalConf.SlaveOptions.ConnectionString}
+	store := &RPCStorageHandler{UserKey: config.Global.SlaveOptions.APIKey, Address: config.Global.SlaveOptions.ConnectionString}
 	store.Connect()
 
 	rpcPolicies := store.GetPolicies(orgId)

--- a/redis_cluster_handler.go
+++ b/redis_cluster_handler.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/garyburd/redigo/redis"
 	"github.com/lonelycode/redigocluster/rediscluster"
+
+	"github.com/TykTechnologies/tyk/config"
 )
 
 // ------------------- REDIS CLUSTER STORAGE MANAGER -------------------------------
@@ -37,9 +39,9 @@ type RedisClusterStorageManager struct {
 
 func NewRedisClusterPool(isCache bool) *rediscluster.RedisCluster {
 	// redisSingletonMu is locked and we know the singleton is nil
-	cfg := globalConf.Storage
-	if isCache && globalConf.EnableSeperateCacheStore {
-		cfg = globalConf.CacheStorage
+	cfg := config.Global.Storage
+	if isCache && config.Global.EnableSeperateCacheStore {
+		cfg = config.Global.CacheStorage
 	}
 
 	log.Debug("Creating new Redis connection pool")

--- a/redis_signal_dash_zeroconf.go
+++ b/redis_signal_dash_zeroconf.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
+
+	"github.com/TykTechnologies/tyk/config"
 )
 
 type DashboardConfigPayload struct {
@@ -44,23 +46,23 @@ func handleDashboardZeroConfMessage(payload string) {
 		return
 	}
 
-	if !globalConf.UseDBAppConfigs {
+	if !config.Global.UseDBAppConfigs {
 		return
 	}
 
-	if globalConf.DisableDashboardZeroConf {
+	if config.Global.DisableDashboardZeroConf {
 		return
 	}
 
 	hostname := createConnectionStringFromDashboardObject(dashPayload)
 	setHostname := false
-	if globalConf.DBAppConfOptions.ConnectionString == "" {
-		globalConf.DBAppConfOptions.ConnectionString = hostname
+	if config.Global.DBAppConfOptions.ConnectionString == "" {
+		config.Global.DBAppConfOptions.ConnectionString = hostname
 		setHostname = true
 	}
 
-	if globalConf.Policies.PolicyConnectionString == "" {
-		globalConf.Policies.PolicyConnectionString = hostname
+	if config.Global.Policies.PolicyConnectionString == "" {
+		config.Global.Policies.PolicyConnectionString = hostname
 		setHostname = true
 	}
 

--- a/redis_signal_handle_config.go
+++ b/redis_signal_handle_config.go
@@ -19,7 +19,7 @@ type ConfigPayload struct {
 }
 
 func backupConfiguration() error {
-	oldConfig, err := json.MarshalIndent(globalConf, "", "    ")
+	oldConfig, err := json.MarshalIndent(config.Global, "", "    ")
 	if err != nil {
 		return err
 	}
@@ -71,7 +71,7 @@ func handleNewConfiguration(payload string) {
 		return
 	}
 
-	if globalConf.AllowRemoteConfig {
+	if config.Global.AllowRemoteConfig {
 		log.WithFields(logrus.Fields{
 			"prefix": "pub-sub",
 		}).Warning("Ignoring new config: Remote configuration is not allowed for this node.")

--- a/redis_signal_handle_config_request.go
+++ b/redis_signal_handle_config_request.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+
+	"github.com/TykTechnologies/tyk/config"
 )
 
 type GetConfigPayload struct {
@@ -36,7 +38,7 @@ func sanitizeConfig(mc map[string]interface{}) map[string]interface{} {
 }
 
 func getExistingConfig() (map[string]interface{}, error) {
-	f, err := os.Open(globalConf.OriginalPath)
+	f, err := os.Open(config.Global.OriginalPath)
 	if err != nil {
 		return nil, err
 	}

--- a/redis_signals.go
+++ b/redis_signals.go
@@ -10,6 +10,7 @@ import (
 	"github.com/garyburd/redigo/redis"
 
 	"github.com/TykTechnologies/goverify"
+	"github.com/TykTechnologies/tyk/config"
 )
 
 type NotificationCommand string
@@ -93,7 +94,7 @@ func handleRedisEvent(v interface{}, handled func(NotificationCommand), reloaded
 	case NoticeDashboardConfigRequest:
 		handleSendMiniConfig(notif.Payload)
 	case NoticeGatewayDRLNotification:
-		if globalConf.ManagementNode {
+		if config.Global.ManagementNode {
 			// DRL is not initialized, going through would
 			// be mostly harmless but would flood the log
 			// with warnings since DRLManager.Ready == false
@@ -129,7 +130,7 @@ func isPayloadSignatureValid(notification Notification) bool {
 		return true
 	}
 
-	if notification.Signature == "" && globalConf.AllowInsecureConfigs {
+	if notification.Signature == "" && config.Global.AllowInsecureConfigs {
 		redisInsecureWarn.Do(func() {
 			log.WithFields(logrus.Fields{
 				"prefix": "pub-sub",
@@ -138,9 +139,9 @@ func isPayloadSignatureValid(notification Notification) bool {
 		return true
 	}
 
-	if globalConf.PublicKeyPath != "" && notificationVerifier == nil {
+	if config.Global.PublicKeyPath != "" && notificationVerifier == nil {
 		var err error
-		notificationVerifier, err = goverify.LoadPublicKeyFromFile(globalConf.PublicKeyPath)
+		notificationVerifier, err = goverify.LoadPublicKeyFromFile(config.Global.PublicKeyPath)
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "pub-sub",

--- a/rpc_backup_handlers.go
+++ b/rpc_backup_handlers.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/TykTechnologies/tyk/config"
+
 	"github.com/Sirupsen/logrus"
 )
 
@@ -19,8 +21,8 @@ const BackupKeyBase = "node-definition-backup:"
 
 func getTagListAsString() string {
 	tagList := ""
-	if len(globalConf.DBAppConfOptions.Tags) > 0 {
-		tagList = strings.Join(globalConf.DBAppConfOptions.Tags, "-")
+	if len(config.Global.DBAppConfOptions.Tags) > 0 {
+		tagList = strings.Join(config.Global.DBAppConfOptions.Tags, "-")
 	}
 
 	return tagList
@@ -42,7 +44,7 @@ func saveRPCDefinitionsBackup(list string) {
 		return
 	}
 
-	secret := rightPad2Len(globalConf.Secret, "=", 32)
+	secret := rightPad2Len(config.Global.Secret, "=", 32)
 	cryptoText := encrypt([]byte(secret), list)
 	err := store.SetKey(BackupKeyBase+tagList, cryptoText, -1)
 	if err != nil {
@@ -64,7 +66,7 @@ func LoadDefinitionsFromRPCBackup() []*APISpec {
 		return nil
 	}
 
-	secret := rightPad2Len(globalConf.Secret, "=", 32)
+	secret := rightPad2Len(config.Global.Secret, "=", 32)
 	cryptoText, err := store.GetKey(checkKey)
 	apiListAsString := decrypt([]byte(secret), cryptoText)
 

--- a/rpc_storage_handler.go
+++ b/rpc_storage_handler.go
@@ -14,6 +14,8 @@ import (
 	cache "github.com/pmylund/go-cache"
 	"github.com/satori/go.uuid"
 
+	"github.com/TykTechnologies/tyk/config"
+
 	"github.com/Sirupsen/logrus"
 )
 
@@ -139,9 +141,9 @@ func (r *RPCStorageHandler) Connect() bool {
 		panic("connID is too long")
 	}
 
-	if globalConf.SlaveOptions.UseSSL {
+	if config.Global.SlaveOptions.UseSSL {
 		clientCfg := &tls.Config{
-			InsecureSkipVerify: globalConf.SlaveOptions.SSLInsecureSkipVerify,
+			InsecureSkipVerify: config.Global.SlaveOptions.SSLInsecureSkipVerify,
 		}
 
 		RPCCLientSingleton = gorpc.NewTLSClient(r.Address, clientCfg)
@@ -161,9 +163,9 @@ func (r *RPCStorageHandler) Connect() bool {
 			KeepAlive: 30 * time.Second,
 		}
 
-		if globalConf.SlaveOptions.UseSSL {
+		if config.Global.SlaveOptions.UseSSL {
 			cfg := &tls.Config{
-				InsecureSkipVerify: globalConf.SlaveOptions.SSLInsecureSkipVerify,
+				InsecureSkipVerify: config.Global.SlaveOptions.SSLInsecureSkipVerify,
 			}
 
 			conn, err = tls.DialWithDialer(dialer, "tcp", addr, cfg)
@@ -258,7 +260,7 @@ func (r *RPCStorageHandler) ReAttemptLogin(err error) {
 func (r *RPCStorageHandler) GroupLogin() {
 	groupLoginData := GroupLoginRequest{
 		UserKey: r.UserKey,
-		GroupID: globalConf.SlaveOptions.GroupID,
+		GroupID: config.Global.SlaveOptions.GroupID,
 	}
 	ok, err := RPCFuncClientSingleton.CallTimeout("LoginWithGroup", groupLoginData, GlobalRPCCallTimeout)
 	if err != nil {
@@ -284,7 +286,7 @@ func (r *RPCStorageHandler) Login() {
 	}
 
 	// If we have a group ID, lets login as a group
-	if globalConf.SlaveOptions.GroupID != "" {
+	if config.Global.SlaveOptions.GroupID != "" {
 		r.GroupLogin()
 		return
 	}
@@ -312,7 +314,7 @@ func (r *RPCStorageHandler) GetKey(keyName string) (string, error) {
 	log.Debug("[STORE] Getting: ", r.fixKey(keyName))
 
 	// Check the cache first
-	if globalConf.SlaveOptions.EnableRPCCache {
+	if config.Global.SlaveOptions.EnableRPCCache {
 		log.Debug("Using cache for: ", keyName)
 		cachedVal, found := RPCGlobalCache.Get(r.fixKey(keyName))
 		log.Debug("--> Found? ", found)
@@ -338,7 +340,7 @@ func (r *RPCStorageHandler) GetKey(keyName string) (string, error) {
 	elapsed := time.Since(start)
 	log.Debug("GetKey took ", elapsed)
 
-	if globalConf.SlaveOptions.EnableRPCCache {
+	if config.Global.SlaveOptions.EnableRPCCache {
 		// Cache it
 		RPCGlobalCache.Set(r.fixKey(keyName), value, cache.DefaultExpiration)
 	}
@@ -658,7 +660,7 @@ func (r *RPCStorageHandler) CheckForReload(orgId string) {
 }
 
 func (r *RPCStorageHandler) StartRPCLoopCheck(orgId string) {
-	if globalConf.SlaveOptions.DisableKeySpaceSync {
+	if config.Global.SlaveOptions.DisableKeySpaceSync {
 		return
 	}
 
@@ -677,13 +679,13 @@ func (r *RPCStorageHandler) CheckForKeyspaceChanges(orgId string) {
 	var keys interface{}
 	var err error
 
-	if globalConf.SlaveOptions.GroupID == "" {
+	if config.Global.SlaveOptions.GroupID == "" {
 		keys, err = RPCFuncClientSingleton.CallTimeout("GetKeySpaceUpdate", orgId, GlobalRPCCallTimeout)
 	} else {
 
 		grpReq := GroupKeySpaceRequest{
 			OrgID:   orgId,
-			GroupID: globalConf.SlaveOptions.GroupID,
+			GroupID: config.Global.SlaveOptions.GroupID,
 		}
 		keys, err = RPCFuncClientSingleton.CallTimeout("GetGroupKeySpaceUpdate", grpReq, GlobalRPCCallTimeout)
 	}

--- a/session_state.go
+++ b/session_state.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/spaolacci/murmur3"
 	"gopkg.in/vmihailenco/msgpack.v2"
+
+	"github.com/TykTechnologies/tyk/config"
 )
 
 type HashType string
@@ -103,8 +105,8 @@ func (s *SessionState) HasChanged() bool {
 }
 
 func getLifetime(spec *APISpec, session *SessionState) int64 {
-	if globalConf.ForceGlobalSessionLifetime {
-		return globalConf.GlobalSessionLifetime
+	if config.Global.ForceGlobalSessionLifetime {
+		return config.Global.GlobalSessionLifetime
 	}
 	if session.SessionLifetime > 0 {
 		return session.SessionLifetime

--- a/storage_handlers.go
+++ b/storage_handlers.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 
 	"github.com/spaolacci/murmur3"
+
+	"github.com/TykTechnologies/tyk/config"
 )
 
 // errKeyNotFound is a standard error for when a key is not found in the storage engine
@@ -45,7 +47,7 @@ func doHash(in string) string {
 
 //Public function for use in classes that bypass elements of the storage manager
 func publicHash(in string) string {
-	if !globalConf.HashKeys {
+	if !config.Global.HashKeys {
 		// Not hashing? Return the raw key
 		return in
 	}


### PR DESCRIPTION
This will enable sub-packages to access the global config without
needing circular dependencies into main.

Initially this wasn't done since the proper way to organize the project
would be to not have such a global state. However, there's no need for
this to block splitting main into multiple packages - this change has no
disadvantages.