### PR TITLE
storage: merge *Pipeline as a bool flag

### DIFF
--- a/api_healthcheck.go
+++ b/api_healthcheck.go
@@ -76,14 +76,14 @@ func (h *DefaultHealthChecker) StoreCounterVal(counterType HealthPrefix, value s
 		value = now_string + "." + value
 		log.Debug("Set value to: ", value)
 	}
-	go h.storage.SetRollingWindow(searchStr, config.Global.HealthCheck.HealthCheckValueTimeout, value)
+	go h.storage.SetRollingWindow(searchStr, config.Global.HealthCheck.HealthCheckValueTimeout, value, false)
 }
 
 func (h *DefaultHealthChecker) getAvgCount(prefix HealthPrefix) float64 {
 	searchStr := h.CreateKeyName(prefix)
 	log.Debug("Searching for: ", searchStr)
 
-	count, _ := h.storage.SetRollingWindow(searchStr, config.Global.HealthCheck.HealthCheckValueTimeout, "-1")
+	count, _ := h.storage.SetRollingWindow(searchStr, config.Global.HealthCheck.HealthCheckValueTimeout, "-1", false)
 	log.Debug("Count is: ", count)
 	divisor := float64(config.Global.HealthCheck.HealthCheckValueTimeout)
 	if divisor == 0 {
@@ -113,7 +113,7 @@ func (h *DefaultHealthChecker) ApiHealthValues() (HealthCheckValues, error) {
 	// Get the micro latency graph, an average upstream latency
 	searchStr := h.APIID + "." + string(RequestLog)
 	log.Debug("Searching KV for: ", searchStr)
-	_, vals := h.storage.SetRollingWindow(searchStr, config.Global.HealthCheck.HealthCheckValueTimeout, "-1")
+	_, vals := h.storage.SetRollingWindow(searchStr, config.Global.HealthCheck.HealthCheckValueTimeout, "-1", false)
 	log.Debug("Found: ", vals)
 	if len(vals) == 0 {
 		return values, nil

--- a/ldap_auth_handler.go
+++ b/ldap_auth_handler.go
@@ -153,12 +153,7 @@ func (l *LDAPStorageHandler) notifyReadOnly() bool {
 	return false
 }
 
-func (l *LDAPStorageHandler) SetRollingWindow(keyName string, per int64, val string) (int, []interface{}) {
-	log.Warning("Not Implemented!")
-	return 0, nil
-}
-
-func (l *LDAPStorageHandler) SetRollingWindowPipeline(keyName string, per int64, val string) (int, []interface{}) {
+func (l *LDAPStorageHandler) SetRollingWindow(keyName string, per int64, val string, pipeline bool) (int, []interface{}) {
 	log.Warning("Not Implemented!")
 	return 0, nil
 }

--- a/rpc_storage_handler.go
+++ b/rpc_storage_handler.go
@@ -553,7 +553,7 @@ func (r *RPCStorageHandler) AppendToSet(keyName, value string) {
 }
 
 // SetScrollingWindow is used in the rate limiter to handle rate limits fairly.
-func (r *RPCStorageHandler) SetRollingWindow(keyName string, per int64, val string) (int, []interface{}) {
+func (r *RPCStorageHandler) SetRollingWindow(keyName string, per int64, val string, pipeline bool) (int, []interface{}) {
 	start := time.Now() // get current time
 	ibd := InboundData{
 		KeyName: keyName,
@@ -564,7 +564,7 @@ func (r *RPCStorageHandler) SetRollingWindow(keyName string, per int64, val stri
 	intVal, err := RPCFuncClientSingleton.CallTimeout("SetRollingWindow", ibd, GlobalRPCCallTimeout)
 	if r.IsAccessError(err) {
 		r.Login()
-		return r.SetRollingWindow(keyName, per, val)
+		return r.SetRollingWindow(keyName, per, val, false)
 	}
 
 	elapsed := time.Since(start)
@@ -577,10 +577,6 @@ func (r *RPCStorageHandler) SetRollingWindow(keyName string, per int64, val stri
 
 	return intVal.(int), nil
 
-}
-
-func (r *RPCStorageHandler) SetRollingWindowPipeline(keyName string, per int64, val string) (int, []interface{}) {
-	return r.SetRollingWindow(keyName, per, val)
 }
 
 func (r RPCStorageHandler) GetSet(keyName string) (map[string]string, error) {

--- a/session_manager.go
+++ b/session_manager.go
@@ -34,12 +34,8 @@ type SessionLimiter struct {
 func (l *SessionLimiter) doRollingWindowWrite(key, rateLimiterKey, rateLimiterSentinelKey string, currentSession *SessionState, store StorageHandler) bool {
 	log.Debug("[RATELIMIT] Inbound raw key is: ", key)
 	log.Debug("[RATELIMIT] Rate limiter key is: ", rateLimiterKey)
-	var ratePerPeriodNow int
-	if config.Global.EnableNonTransactionalRateLimiter {
-		ratePerPeriodNow, _ = store.SetRollingWindowPipeline(rateLimiterKey, int64(currentSession.Per), "-1")
-	} else {
-		ratePerPeriodNow, _ = store.SetRollingWindow(rateLimiterKey, int64(currentSession.Per), "-1")
-	}
+	pipeline := config.Global.EnableNonTransactionalRateLimiter
+	ratePerPeriodNow, _ := store.SetRollingWindow(rateLimiterKey, int64(currentSession.Per), "-1", pipeline)
 
 	//log.Info("Num Requests: ", ratePerPeriodNow)
 

--- a/storage_handlers.go
+++ b/storage_handlers.go
@@ -29,8 +29,7 @@ type StorageHandler interface {
 	DeleteKeys([]string) bool
 	Decrement(string)
 	IncrememntWithExpire(string, int64) int64
-	SetRollingWindow(string, int64, string) (int, []interface{})
-	SetRollingWindowPipeline(string, int64, string) (int, []interface{})
+	SetRollingWindow(key string, per int64, val string, pipeline bool) (int, []interface{})
 	GetSet(string) (map[string]string, error)
 	AddToSet(string, string)
 	AppendToSet(string, string)


### PR DESCRIPTION
SetRollingWindowPipeline was only meaningful on Redis. On RPC it just
called SetRollingWindow, and on LDAP it was unimplemented.

But even on Redis, the function only differed from SetRollingWindow in a
single line. Use a bool flag instead, deduplicating more than 50 lines
of code.