### PR TITLE
event: join all key failure meta structs

### DIFF
--- a/coprocess_test.go
+++ b/coprocess_test.go
@@ -49,7 +49,7 @@ func TestCoProcessDispatchEvent(t *testing.T) {
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
 	baseMid := BaseMiddleware{spec, proxy}
 
-	meta := EventAuthFailureMeta{
+	meta := EventKeyFailureMeta{
 		EventMetaDefault: EventMetaDefault{Message: "Auth Failure"},
 		Path:             "/",
 		Origin:           "127.0.0.1",

--- a/event_handler_webhooks_test.go
+++ b/event_handler_webhooks_test.go
@@ -121,7 +121,7 @@ func TestGet(t *testing.T) {
 
 	eventMessage := config.EventMessage{
 		Type: EventKeyExpired,
-		Meta: EventAuthFailureMeta{
+		Meta: EventKeyFailureMeta{
 			EventMetaDefault: EventMetaDefault{Message: "THIS IS A TEST"},
 			Path:             "/banana",
 			Origin:           "tyk.io",
@@ -155,7 +155,7 @@ func TestPost(t *testing.T) {
 
 	eventMessage := config.EventMessage{
 		Type: EventKeyExpired,
-		Meta: EventAuthFailureMeta{
+		Meta: EventKeyFailureMeta{
 			EventMetaDefault: EventMetaDefault{Message: "THIS IS A TEST"},
 			Path:             "/banana",
 			Origin:           "tyk.io",

--- a/event_system.go
+++ b/event_system.go
@@ -46,24 +46,9 @@ type EventHostStatusMeta struct {
 	HostInfo HostHealthReport
 }
 
-// EventQuotaExceededMeta is the metadata structure for a quota exceeded event (EventQuotaExceeded)
-type EventQuotaExceededMeta struct {
-	EventMetaDefault
-	Path   string
-	Origin string
-	Key    string
-}
-
-// EventRateLimitExceededMeta is the metadata structure for a rate limit exceeded event (EventRateLimitExceeded)
-type EventRateLimitExceededMeta struct {
-	EventMetaDefault
-	Path   string
-	Origin string
-	Key    string
-}
-
-// EventAuthFailureMeta is the metadata structure for an auth failure (EventAuthFailure)
-type EventAuthFailureMeta struct {
+// EventKeyFailureMeta is the metadata structure for any failure related
+// to a key, such as quota or auth failures.
+type EventKeyFailureMeta struct {
 	EventMetaDefault
 	Path   string
 	Origin string
@@ -78,14 +63,6 @@ type EventCurcuitBreakerMeta struct {
 	CircuitEvent circuit.BreakerEvent
 }
 
-// EventKeyExpiredMeta is the metadata structure for an auth failure (EventKeyExpired)
-type EventKeyExpiredMeta struct {
-	EventMetaDefault
-	Path   string
-	Origin string
-	Key    string
-}
-
 // EventVersionFailureMeta is the metadata structure for an auth failure (EventKeyExpired)
 type EventVersionFailureMeta struct {
 	EventMetaDefault
@@ -95,7 +72,6 @@ type EventVersionFailureMeta struct {
 	Reason string
 }
 
-// EventVersionFailureMeta is the metadata structure for an auth failure (EventKeyExpired)
 type EventTriggerExceededMeta struct {
 	EventMetaDefault
 	Org          string
@@ -103,7 +79,6 @@ type EventTriggerExceededMeta struct {
 	TriggerLimit int64
 }
 
-// EventVersionFailureMeta is the metadata structure for an auth failure (EventKeyExpired)
 type EventTokenMeta struct {
 	EventMetaDefault
 	Org string
@@ -195,7 +170,7 @@ func (l *LogMessageEventHandler) HandleEvent(em config.EventMessage) {
 
 	// We can handle specific event types easily
 	if em.Type == EventQuotaExceeded {
-		msgConf := em.Meta.(EventQuotaExceededMeta)
+		msgConf := em.Meta.(EventKeyFailureMeta)
 		formattedMsgString = fmt.Sprintf("%s:%s:%s:%s", formattedMsgString, msgConf.Key, msgConf.Origin, msgConf.Path)
 	}
 

--- a/mw_api_rate_limit.go
+++ b/mw_api_rate_limit.go
@@ -44,7 +44,7 @@ func (k *RateLimitForAPI) handleRateLimitFailure(r *http.Request, token string) 
 	}).Info("API rate limit exceeded.")
 
 	// Fire a rate limit exceeded event
-	k.FireEvent(EventRateLimitExceeded, EventRateLimitExceededMeta{
+	k.FireEvent(EventRateLimitExceeded, EventKeyFailureMeta{
 		EventMetaDefault: EventMetaDefault{Message: "API Rate Limit Exceeded", OriginatingRequest: EncodeRequestToEvent(r)},
 		Path:             r.URL.Path,
 		Origin:           requestIP(r),

--- a/mw_auth_key.go
+++ b/mw_auth_key.go
@@ -117,7 +117,7 @@ func stripBearer(token string) string {
 }
 
 func AuthFailed(m TykMiddleware, r *http.Request, token string) {
-	m.Base().FireEvent(EventAuthFailure, EventAuthFailureMeta{
+	m.Base().FireEvent(EventAuthFailure, EventKeyFailureMeta{
 		EventMetaDefault: EventMetaDefault{Message: "Auth Failure", OriginatingRequest: EncodeRequestToEvent(r)},
 		Path:             r.URL.Path,
 		Origin:           requestIP(r),

--- a/mw_key_expired_check.go
+++ b/mw_key_expired_check.go
@@ -32,7 +32,7 @@ func (k *KeyExpired) ProcessRequest(w http.ResponseWriter, r *http.Request, _ in
 		}).Info("Attempted access from inactive key.")
 
 		// Fire a key expired event
-		k.FireEvent(EventKeyExpired, EventKeyExpiredMeta{
+		k.FireEvent(EventKeyExpired, EventKeyFailureMeta{
 			EventMetaDefault: EventMetaDefault{Message: "Attempted access from inactive key.", OriginatingRequest: EncodeRequestToEvent(r)},
 			Path:             r.URL.Path,
 			Origin:           requestIP(r),

--- a/mw_organisation_activity.go
+++ b/mw_organisation_activity.go
@@ -86,7 +86,7 @@ func (k *OrganizationMonitor) ProcessRequestLive(r *http.Request) (error, int) {
 		}).Warning("Organisation quota has been exceeded.")
 
 		// Fire a quota exceeded event
-		k.FireEvent(EventOrgQuotaExceeded, EventQuotaExceededMeta{
+		k.FireEvent(EventOrgQuotaExceeded, EventKeyFailureMeta{
 			EventMetaDefault: EventMetaDefault{Message: "Organisation quota has been exceeded", OriginatingRequest: EncodeRequestToEvent(r)},
 			Path:             r.URL.Path,
 			Origin:           requestIP(r),
@@ -178,7 +178,7 @@ func (k *OrganizationMonitor) AllowAccessNext(orgChan chan bool, r *http.Request
 		}).Warning("Organisation quota has been exceeded.")
 
 		// Fire a quota exceeded event
-		k.FireEvent(EventOrgQuotaExceeded, EventQuotaExceededMeta{
+		k.FireEvent(EventOrgQuotaExceeded, EventKeyFailureMeta{
 			EventMetaDefault: EventMetaDefault{Message: "Organisation quota has been exceeded", OriginatingRequest: EncodeRequestToEvent(r)},
 			Path:             r.URL.Path,
 			Origin:           requestIP(r),

--- a/mw_rate_limiting.go
+++ b/mw_rate_limiting.go
@@ -34,7 +34,7 @@ func (k *RateLimitAndQuotaCheck) handleRateLimitFailure(r *http.Request, token s
 	}).Info("Key rate limit exceeded.")
 
 	// Fire a rate limit exceeded event
-	k.FireEvent(EventRateLimitExceeded, EventRateLimitExceededMeta{
+	k.FireEvent(EventRateLimitExceeded, EventKeyFailureMeta{
 		EventMetaDefault: EventMetaDefault{Message: "Key Rate Limit Exceeded", OriginatingRequest: EncodeRequestToEvent(r)},
 		Path:             r.URL.Path,
 		Origin:           requestIP(r),
@@ -55,7 +55,7 @@ func (k *RateLimitAndQuotaCheck) handleQuotaFailure(r *http.Request, token strin
 	}).Info("Key quota limit exceeded.")
 
 	// Fire a quota exceeded event
-	k.FireEvent(EventQuotaExceeded, EventQuotaExceededMeta{
+	k.FireEvent(EventQuotaExceeded, EventKeyFailureMeta{
 		EventMetaDefault: EventMetaDefault{Message: "Key Quota Limit Exceeded", OriginatingRequest: EncodeRequestToEvent(r)},
 		Path:             r.URL.Path,
 		Origin:           requestIP(r),


### PR DESCRIPTION
This removes quite a bit of duplicated code on its own, but it also
opens the door to deduplicating some of the handle*Failure code in
middlewares too.