### PR TITLE
Add extended routing capability, fixes #639

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -129,6 +129,7 @@ type StringRegexMap struct {
 type RoutingTriggerOptions struct {
 	HeaderMatches   map[string]StringRegexMap `bson:"header_matches" json:"header_matches"`
 	QueryValMatches map[string]StringRegexMap `bson:"query_val_matches" json:"query_val_matches"`
+	PathPartMatches map[string]StringRegexMap `bson:"path_part_matches" json:"path_part_matches"`
 	PayloadMatches  StringRegexMap            `bson:"payload_matches" json:"payload_matches"`
 }
 

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -3,6 +3,8 @@ package apidef
 import (
 	"encoding/base64"
 
+	"regexp"
+
 	"github.com/lonelycode/osin"
 	"gopkg.in/mgo.v2/bson"
 )
@@ -20,6 +22,7 @@ type MiddlewareDriver string
 type IdExtractorSource string
 type IdExtractorType string
 type AuthTypeEnum string
+type RoutingTriggerOnType string
 
 const (
 	NoAction EndpointMethodAction = "no_action"
@@ -53,6 +56,11 @@ const (
 	OIDCUser      AuthTypeEnum = "oidc_user"
 	OAuthKey      AuthTypeEnum = "oauth_key"
 	UnsetAuth     AuthTypeEnum = ""
+
+	// For routing triggers
+	All    RoutingTriggerOnType = "all"
+	Any    RoutingTriggerOnType = "any"
+	Ignore RoutingTriggerOnType = ""
 )
 
 type EndpointMethodMeta struct {
@@ -113,11 +121,29 @@ type CircuitBreakerMeta struct {
 	ReturnToServiceAfter int     `bson:"return_to_service_after" json:"return_to_service_after"`
 }
 
+type StringRegexMap struct {
+	MatchPattern string `bson:"match_rx" json:"match_rx"`
+	matchRegex   *regexp.Regexp
+}
+
+type RoutingTriggerOptions struct {
+	HeaderMatches   map[string]StringRegexMap `bson:"header_matches" json:"header_matches"`
+	QueryValMatches map[string]StringRegexMap `bson:"query_val_matches" json:"query_val_matches"`
+	PayloadMatches  StringRegexMap            `bson:"payload_matches" json:"payload_matches"`
+}
+
+type RoutingTrigger struct {
+	On        RoutingTriggerOnType  `bson:"on" json:"on"`
+	Options   RoutingTriggerOptions `bson:"options" json:"options"`
+	RewriteTo string                `bson:"rewrite_to" json:"rewrite_to"`
+}
+
 type URLRewriteMeta struct {
-	Path         string `bson:"path" json:"path"`
-	Method       string `bson:"method" json:"method"`
-	MatchPattern string `bson:"match_pattern" json:"match_pattern"`
-	RewriteTo    string `bson:"rewrite_to" json:"rewrite_to"`
+	Path         string           `bson:"path" json:"path"`
+	Method       string           `bson:"method" json:"method"`
+	MatchPattern string           `bson:"match_pattern" json:"match_pattern"`
+	RewriteTo    string           `bson:"rewrite_to" json:"rewrite_to"`
+	Triggers     []RoutingTrigger `bson:"triggers" json:"triggers"`
 }
 
 type VirtualMeta struct {
@@ -393,4 +419,14 @@ func (a *APIDefinition) DecodeFromDB() {
 	}
 
 	a.VersionData.Versions = new_version
+}
+
+func (s *StringRegexMap) Check(value string) string {
+	return s.matchRegex.FindString(value)
+}
+
+func (s *StringRegexMap) Init() error {
+	var err error
+	s.matchRegex, err = regexp.Compile(s.MatchPattern)
+	return err
 }

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -127,10 +127,11 @@ type StringRegexMap struct {
 }
 
 type RoutingTriggerOptions struct {
-	HeaderMatches   map[string]StringRegexMap `bson:"header_matches" json:"header_matches"`
-	QueryValMatches map[string]StringRegexMap `bson:"query_val_matches" json:"query_val_matches"`
-	PathPartMatches map[string]StringRegexMap `bson:"path_part_matches" json:"path_part_matches"`
-	PayloadMatches  StringRegexMap            `bson:"payload_matches" json:"payload_matches"`
+	HeaderMatches      map[string]StringRegexMap `bson:"header_matches" json:"header_matches"`
+	QueryValMatches    map[string]StringRegexMap `bson:"query_val_matches" json:"query_val_matches"`
+	PathPartMatches    map[string]StringRegexMap `bson:"path_part_matches" json:"path_part_matches"`
+	SessionMetaMatches map[string]StringRegexMap `bson:"session_meta_matches" json:"session_meta_matches"`
+	PayloadMatches     StringRegexMap            `bson:"payload_matches" json:"payload_matches"`
 }
 
 type RoutingTrigger struct {

--- a/mw_url_rewrite.go
+++ b/mw_url_rewrite.go
@@ -8,6 +8,10 @@ import (
 	"strconv"
 	"strings"
 
+	"fmt"
+	"io/ioutil"
+	"net/textproto"
+
 	"github.com/TykTechnologies/tyk/apidef"
 )
 
@@ -23,13 +27,84 @@ func urlRewrite(meta *apidef.URLRewriteMeta, r *http.Request) (string, error) {
 	newpath := path
 
 	result_slice := mp.FindAllStringSubmatch(path, -1)
+
+	// Check triggers
+	rewriteToPath := meta.RewriteTo
+	if len(meta.Triggers) > 0 {
+
+		// This feature uses context, we must force it if it doesn't exist
+		contextData := ctxGetData(r)
+		if contextData == nil {
+			contextDataObject := make(map[string]interface{})
+			ctxSetData(r, contextDataObject)
+		}
+
+		for tn, triggerOpts := range meta.Triggers {
+			checkAny := false
+			setCount := 0
+			if triggerOpts.On == apidef.Any {
+				checkAny = true
+			}
+
+			// Check headers
+			if len(triggerOpts.Options.HeaderMatches) > 0 {
+				if checkHeaderTrigger(r, triggerOpts.Options.HeaderMatches, checkAny, tn) {
+					setCount += 1
+					if checkAny {
+						rewriteToPath = triggerOpts.RewriteTo
+						break
+					}
+				}
+			}
+
+			// Check query string
+			if len(triggerOpts.Options.QueryValMatches) > 0 {
+				if checkQueryString(r, triggerOpts.Options.QueryValMatches, checkAny, tn) {
+					setCount += 1
+					if checkAny {
+						rewriteToPath = triggerOpts.RewriteTo
+						break
+					}
+				}
+			}
+
+			// Check payload
+			if triggerOpts.Options.PayloadMatches.MatchPattern != "" {
+				if checkPayload(r, triggerOpts.Options.PayloadMatches, tn) {
+					setCount += 1
+					if checkAny {
+						rewriteToPath = triggerOpts.RewriteTo
+						break
+					}
+				}
+			}
+
+			if !checkAny {
+				// Set total count:
+				total := 0
+				if len(triggerOpts.Options.HeaderMatches) > 0 {
+					total += 1
+				}
+				if len(triggerOpts.Options.QueryValMatches) > 0 {
+					total += 1
+				}
+				if triggerOpts.Options.PayloadMatches.MatchPattern != "" {
+					total += 1
+				}
+				if total == setCount {
+					rewriteToPath = triggerOpts.RewriteTo
+				}
+			}
+		}
+	}
+
 	// Make sure it matches the string
 	log.Debug("Rewriter checking matches, len is: ", len(result_slice))
 	if len(result_slice) > 0 {
-		newpath = meta.RewriteTo
+		newpath = rewriteToPath
 		// get the indices for the replacements:
 		dollarMatch := regexp.MustCompile(`\$\d+`) // Prepare our regex
-		replace_slice := dollarMatch.FindAllStringSubmatch(meta.RewriteTo, -1)
+		replace_slice := dollarMatch.FindAllStringSubmatch(rewriteToPath, -1)
 
 		log.Debug(result_slice)
 		log.Debug(replace_slice)
@@ -54,11 +129,10 @@ func urlRewrite(meta *apidef.URLRewriteMeta, r *http.Request) (string, error) {
 
 	contextData := ctxGetData(r)
 
-	dollarMatch := regexp.MustCompile(`\$tyk_context.(\w+)`)
-	replace_slice := dollarMatch.FindAllStringSubmatch(meta.RewriteTo, -1)
+	dollarMatch := regexp.MustCompile(`\$tyk_context.(.+)`)
+	replace_slice := dollarMatch.FindAllStringSubmatch(rewriteToPath, -1)
 	for _, v := range replace_slice {
 		contextKey := strings.Replace(v[0], "$tyk_context.", "", 1)
-		log.Debug("Replacing: ", v[0])
 
 		if val, ok := contextData[contextKey]; ok {
 			newpath = strings.Replace(newpath, v[0],
@@ -70,7 +144,7 @@ func urlRewrite(meta *apidef.URLRewriteMeta, r *http.Request) (string, error) {
 	if session := ctxGetSession(r); session != nil {
 
 		metaDollarMatch := regexp.MustCompile(`\$tyk_meta.(\w+)`)
-		metaReplace_slice := metaDollarMatch.FindAllStringSubmatch(meta.RewriteTo, -1)
+		metaReplace_slice := metaDollarMatch.FindAllStringSubmatch(rewriteToPath, -1)
 		for _, v := range metaReplace_slice {
 			contextKey := strings.Replace(v[0], "$tyk_meta.", "", 1)
 			log.Debug("Replacing: ", v[0])
@@ -120,10 +194,30 @@ func (m *URLRewriteMiddleware) Name() string {
 	return "URLRewriteMiddleware"
 }
 
+func (m *URLRewriteMiddleware) InitTriggerRx() {
+	// Generate regexp for each special match parameter
+	for _, ver := range m.Spec.VersionData.Versions {
+		for _, path := range ver.ExtendedPaths.URLRewrite {
+			for _, tr := range path.Triggers {
+				for _, h := range tr.Options.HeaderMatches {
+					h.Init()
+				}
+				for _, q := range tr.Options.QueryValMatches {
+					q.Init()
+				}
+				if tr.Options.PayloadMatches.MatchPattern != "" {
+					tr.Options.PayloadMatches.Init()
+				}
+			}
+		}
+	}
+}
+
 func (m *URLRewriteMiddleware) EnabledForSpec() bool {
 	for _, version := range m.Spec.VersionData.Versions {
 		if len(version.ExtendedPaths.URLRewrite) > 0 {
 			m.Spec.URLRewriteEnabled = true
+			m.InitTriggerRx()
 			return true
 		}
 	}
@@ -165,4 +259,79 @@ func (m *URLRewriteMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 		r.URL = newURL
 	}
 	return nil, 200
+}
+
+func checkHeaderTrigger(r *http.Request, options map[string]apidef.StringRegexMap, any bool, triggernum int) bool {
+	contextData := ctxGetData(r)
+	fCount := 0
+	for mh, mr := range options {
+		mhCN := textproto.CanonicalMIMEHeaderKey(mh)
+		vals, ok := r.Header[mhCN]
+		if ok {
+			for i, v := range vals {
+				b := mr.Check(v)
+				if len(b) > 0 {
+					kn := fmt.Sprintf("trigger-%d-%s-%d", triggernum, mhCN, i)
+					contextData[kn] = b
+					fCount++
+				}
+			}
+		}
+	}
+
+	if fCount > 0 {
+		ctxSetData(r, contextData)
+		if any {
+			return true
+		}
+
+		return len(options) == fCount
+	}
+
+	return false
+}
+
+func checkQueryString(r *http.Request, options map[string]apidef.StringRegexMap, any bool, triggernum int) bool {
+	contextData := ctxGetData(r)
+	fCount := 0
+	for mv, mr := range options {
+		qvals := r.URL.Query()
+		vals, ok := qvals[mv]
+		if ok {
+			for i, v := range vals {
+				b := mr.Check(v)
+				if len(b) > 0 {
+					kn := fmt.Sprintf("trigger-%d-%s-%d", triggernum, mv, i)
+					contextData[kn] = b
+					fCount++
+				}
+			}
+		}
+	}
+
+	if fCount > 0 {
+		ctxSetData(r, contextData)
+		if any {
+			return true
+		}
+
+		return len(options) == fCount
+	}
+
+	return false
+}
+
+func checkPayload(r *http.Request, options apidef.StringRegexMap, triggernum int) bool {
+	contextData := ctxGetData(r)
+	cp := copyRequest(r)
+	bodyBytes, _ := ioutil.ReadAll(cp.Body)
+
+	b := options.Check(string(bodyBytes))
+	if len(b) > 0 {
+		kn := fmt.Sprintf("trigger-%d-payload", triggernum)
+		contextData[kn] = string(b)
+		return true
+	}
+
+	return false
 }

--- a/mw_url_rewrite_test.go
+++ b/mw_url_rewrite_test.go
@@ -4,6 +4,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"bytes"
+	"net/http"
+
 	"github.com/TykTechnologies/tyk/apidef"
 )
 
@@ -62,6 +65,365 @@ func TestRewriter(t *testing.T) {
 			}
 			r := httptest.NewRequest("GET", tc.in, nil)
 			got, err := urlRewrite(&testConf, r)
+			if err != nil {
+				t.Error("compile failed:", err)
+			}
+			if got != tc.want {
+				t.Errorf("rewrite failed, want %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestRewriterTriggers(t *testing.T) {
+	type TestDef struct {
+		name        string
+		pattern, to string
+		in, want    string
+		triggerConf []apidef.RoutingTrigger
+		req         *http.Request
+	}
+	tests := []func() TestDef{
+		func() TestDef {
+			r, _ := http.NewRequest("GET", "/test/straight/rewrite", nil)
+
+			patt := "hello"
+			r.Header.Set("x-test", patt)
+
+			hOpt := apidef.StringRegexMap{MatchPattern: "hello"}
+			hOpt.Init()
+
+			return TestDef{
+				"Header Single",
+				"/test/straight/rewrite", "/change/to/me/ignore",
+				"/test/straight/rewrite", "/change/to/me/hello",
+				[]apidef.RoutingTrigger{
+					{
+						On: apidef.Any,
+						Options: apidef.RoutingTriggerOptions{
+							HeaderMatches: map[string]apidef.StringRegexMap{
+								"x-test": hOpt,
+							},
+						},
+						RewriteTo: "/change/to/me/$tyk_context.trigger-0-X-Test-0",
+					},
+				},
+				r,
+			}
+		},
+		func() TestDef {
+			r, _ := http.NewRequest("GET", "/test/straight/rewrite", nil)
+
+			patt := "bar"
+			r.Header.Set("x-test-Two", patt)
+
+			hOpt := apidef.StringRegexMap{MatchPattern: "hello"}
+			hOpt.Init()
+			hOpt2 := apidef.StringRegexMap{MatchPattern: "bar"}
+			hOpt2.Init()
+
+			return TestDef{
+				"Header Multi Any",
+				"/test/straight/rewrite", "/change/to/me/ignore",
+				"/test/straight/rewrite", "/change/to/me/bar",
+				[]apidef.RoutingTrigger{
+					{
+						On: apidef.Any,
+						Options: apidef.RoutingTriggerOptions{
+							HeaderMatches: map[string]apidef.StringRegexMap{
+								"x-test":     hOpt,
+								"x-test-Two": hOpt2,
+							},
+						},
+						RewriteTo: "/change/to/me/$tyk_context.trigger-0-X-Test-Two-0",
+					},
+				},
+				r,
+			}
+		},
+		func() TestDef {
+			r, _ := http.NewRequest("GET", "/test/straight/rewrite", nil)
+
+			patt := "bar"
+			r.Header.Set("x-test-Two", patt)
+
+			hOpt := apidef.StringRegexMap{MatchPattern: "hello"}
+			hOpt.Init()
+			hOpt2 := apidef.StringRegexMap{MatchPattern: "bar"}
+			hOpt2.Init()
+
+			return TestDef{
+				"Header Multi All Fail",
+				"/test/straight/rewrite", "/change/to/me/ignore",
+				"/test/straight/rewrite", "/change/to/me/ignore",
+				[]apidef.RoutingTrigger{
+					{
+						On: apidef.All,
+						Options: apidef.RoutingTriggerOptions{
+							HeaderMatches: map[string]apidef.StringRegexMap{
+								"x-test":     hOpt,
+								"x-test-Two": hOpt2,
+							},
+						},
+						RewriteTo: "/change/to/me/$tyk_context.trigger-0-X-Test-Two-0",
+					},
+				},
+				r,
+			}
+		},
+		func() TestDef {
+			r, _ := http.NewRequest("GET", "/test/straight/rewrite", nil)
+
+			r.Header.Set("x-test-Two", "bar")
+			r.Header.Set("x-test", "hello")
+
+			hOpt := apidef.StringRegexMap{MatchPattern: "hello"}
+			hOpt.Init()
+			hOpt2 := apidef.StringRegexMap{MatchPattern: "bar"}
+			hOpt2.Init()
+
+			return TestDef{
+				"Header Multi All Pass",
+				"/test/straight/rewrite", "/change/to/me/ignore",
+				"/test/straight/rewrite", "/change/to/me/hello",
+				[]apidef.RoutingTrigger{
+					{
+						On: apidef.All,
+						Options: apidef.RoutingTriggerOptions{
+							HeaderMatches: map[string]apidef.StringRegexMap{
+								"x-test":     hOpt,
+								"x-test-Two": hOpt2,
+							},
+						},
+						RewriteTo: "/change/to/me/$tyk_context.trigger-0-X-Test-0",
+					},
+				},
+				r,
+			}
+		},
+		func() TestDef {
+			r, _ := http.NewRequest("GET", "/test/straight/rewrite", nil)
+
+			r.Header.Set("y-test", "baz")
+			r.Header.Set("y-test-Two", "qux")
+
+			hOpt := apidef.StringRegexMap{MatchPattern: "hello"}
+			hOpt.Init()
+			hOpt2 := apidef.StringRegexMap{MatchPattern: "bar"}
+			hOpt2.Init()
+
+			hOpt3 := apidef.StringRegexMap{MatchPattern: "baz"}
+			hOpt3.Init()
+			hOpt4 := apidef.StringRegexMap{MatchPattern: "fnee"}
+			hOpt4.Init()
+
+			return TestDef{
+				"Header Many Multi Any Pass",
+				"/test/straight/rewrite", "/change/to/me/ignore",
+				"/test/straight/rewrite", "/change/to/me/baz",
+				[]apidef.RoutingTrigger{
+					{
+						On: apidef.Any,
+						Options: apidef.RoutingTriggerOptions{
+							HeaderMatches: map[string]apidef.StringRegexMap{
+								"x-test":     hOpt,
+								"x-test-Two": hOpt2,
+							},
+						},
+						RewriteTo: "/change/to/me/$tyk_context.trigger-0-X-Test-0",
+					},
+					{
+						On: apidef.Any,
+						Options: apidef.RoutingTriggerOptions{
+							HeaderMatches: map[string]apidef.StringRegexMap{
+								"y-test":     hOpt3,
+								"y-test-Two": hOpt4,
+							},
+						},
+						RewriteTo: "/change/to/me/$tyk_context.trigger-1-Y-Test-0",
+					},
+				},
+				r,
+			}
+		},
+		func() TestDef {
+			r, _ := http.NewRequest("GET", "/test/query/rewrite?x_test=foo", nil)
+
+			hOpt := apidef.StringRegexMap{MatchPattern: "foo"}
+			hOpt.Init()
+
+			return TestDef{
+				"Query Single",
+				"/test/query/rewrite", "/change/to/me/ignore",
+				"/test/query/rewrite", "/change/to/me/foo",
+				[]apidef.RoutingTrigger{
+					{
+						On: apidef.Any,
+						Options: apidef.RoutingTriggerOptions{
+							QueryValMatches: map[string]apidef.StringRegexMap{
+								"x_test": hOpt,
+							},
+						},
+						RewriteTo: "/change/to/me/$tyk_context.trigger-0-x_test-0",
+					},
+				},
+				r,
+			}
+		},
+		func() TestDef {
+			r, _ := http.NewRequest("GET", "/test/query/rewrite?x_test=foo&y_test=bar", nil)
+
+			hOpt := apidef.StringRegexMap{MatchPattern: "foo"}
+			hOpt.Init()
+			hOpt2 := apidef.StringRegexMap{MatchPattern: "bar"}
+			hOpt2.Init()
+
+			return TestDef{
+				"Query Multi All",
+				"/test/query/rewrite", "/change/to/me/ignore",
+				"/test/query/rewrite", "/change/to/me/bar",
+				[]apidef.RoutingTrigger{
+					{
+						On: apidef.All,
+						Options: apidef.RoutingTriggerOptions{
+							QueryValMatches: map[string]apidef.StringRegexMap{
+								"x_test": hOpt,
+								"y_test": hOpt2,
+							},
+						},
+						RewriteTo: "/change/to/me/$tyk_context.trigger-0-y_test-0",
+					},
+				},
+				r,
+			}
+		},
+		func() TestDef {
+			r, _ := http.NewRequest("GET", "/test/query/rewrite?x_test=foo", nil)
+			r.Header.Set("y-test", "qux")
+
+			hOpt := apidef.StringRegexMap{MatchPattern: "foo"}
+			hOpt.Init()
+			hOpt2 := apidef.StringRegexMap{MatchPattern: "bar"}
+			hOpt2.Init()
+
+			return TestDef{
+				"Multi Multi Type Any",
+				"/test/query/rewrite", "/change/to/me/ignore",
+				"/test/query/rewrite", "/change/to/me/foo",
+				[]apidef.RoutingTrigger{
+					{
+						On: apidef.Any,
+						Options: apidef.RoutingTriggerOptions{
+							QueryValMatches: map[string]apidef.StringRegexMap{
+								"x_test": hOpt,
+							},
+							HeaderMatches: map[string]apidef.StringRegexMap{
+								"y-test": hOpt2,
+							},
+						},
+						RewriteTo: "/change/to/me/$tyk_context.trigger-0-x_test-0",
+					},
+				},
+				r,
+			}
+		},
+		func() TestDef {
+			r, _ := http.NewRequest("GET", "/test/query/rewrite?x_test=foo", nil)
+			r.Header.Set("y-test", "bar")
+
+			hOpt := apidef.StringRegexMap{MatchPattern: "foo"}
+			hOpt.Init()
+			hOpt2 := apidef.StringRegexMap{MatchPattern: "bar"}
+			hOpt2.Init()
+
+			return TestDef{
+				"Multi Multi Type All",
+				"/test/query/rewrite", "/change/to/me/ignore",
+				"/test/query/rewrite", "/change/to/me/bar",
+				[]apidef.RoutingTrigger{
+					{
+						On: apidef.All,
+						Options: apidef.RoutingTriggerOptions{
+							QueryValMatches: map[string]apidef.StringRegexMap{
+								"x_test": hOpt,
+							},
+							HeaderMatches: map[string]apidef.StringRegexMap{
+								"y-test": hOpt2,
+							},
+						},
+						RewriteTo: "/change/to/me/$tyk_context.trigger-0-Y-Test-0",
+					},
+				},
+				r,
+			}
+		},
+		func() TestDef {
+			r, _ := http.NewRequest("GET", "/test/query/rewrite?x_test=foo", nil)
+			r.Header.Set("y-test", "bar")
+			r.Header.Set("z-test", "fnee")
+
+			hOpt := apidef.StringRegexMap{MatchPattern: "foo"}
+			hOpt.Init()
+			hOpt2 := apidef.StringRegexMap{MatchPattern: "bar"}
+			hOpt2.Init()
+			hOpt3 := apidef.StringRegexMap{MatchPattern: "baz"}
+			hOpt3.Init()
+
+			return TestDef{
+				"Multi Multi Type All Fail",
+				"/test/query/rewrite", "/change/to/me/ignore",
+				"/test/query/rewrite", "/change/to/me/ignore",
+				[]apidef.RoutingTrigger{
+					{
+						On: apidef.All,
+						Options: apidef.RoutingTriggerOptions{
+							QueryValMatches: map[string]apidef.StringRegexMap{
+								"x_test": hOpt,
+							},
+							HeaderMatches: map[string]apidef.StringRegexMap{
+								"y-test": hOpt2,
+								"z-test": hOpt3,
+							},
+						},
+						RewriteTo: "/change/to/me/$tyk_context.trigger-0-Y-Test-0",
+					},
+				},
+				r,
+			}
+		},
+		func() TestDef {
+			var jsonStr = []byte(`{"foo":"bar"}`)
+			r, _ := http.NewRequest("POST", "/test/pl/rewrite", bytes.NewBuffer(jsonStr))
+
+			hOpt := apidef.StringRegexMap{MatchPattern: "bar"}
+			hOpt.Init()
+
+			return TestDef{
+				"Payload Single",
+				"/test/pl/rewrite", "/change/to/me/ignore",
+				"/test/pl/rewrite", "/change/to/me/bar",
+				[]apidef.RoutingTrigger{
+					{
+						On: apidef.Any,
+						Options: apidef.RoutingTriggerOptions{
+							PayloadMatches: hOpt,
+						},
+						RewriteTo: "/change/to/me/$tyk_context.trigger-0-payload",
+					},
+				},
+				r,
+			}
+		},
+	}
+	for _, tf := range tests {
+		tc := tf()
+		t.Run(tc.name, func(t *testing.T) {
+			testConf := apidef.URLRewriteMeta{
+				MatchPattern: tc.pattern,
+				RewriteTo:    tc.to,
+				Triggers:     tc.triggerConf,
+			}
+			got, err := urlRewrite(&testConf, tc.req)
 			if err != nil {
 				t.Error("compile failed:", err)
 			}

--- a/mw_url_rewrite_test.go
+++ b/mw_url_rewrite_test.go
@@ -414,6 +414,52 @@ func TestRewriterTriggers(t *testing.T) {
 				r,
 			}
 		},
+		func() TestDef {
+			r, _ := http.NewRequest("GET", "/test/foo/rewrite", nil)
+			hOpt := apidef.StringRegexMap{MatchPattern: "foo"}
+			hOpt.Init()
+
+			return TestDef{
+				"PathPart Single",
+				"/test/foo/rewrite", "/change/to/me/ignore",
+				"/test/foo/rewrite", "/change/to/me/foo",
+				[]apidef.RoutingTrigger{
+					{
+						On: apidef.Any,
+						Options: apidef.RoutingTriggerOptions{
+							PathPartMatches: map[string]apidef.StringRegexMap{
+								"pathpart": hOpt,
+							},
+						},
+						RewriteTo: "/change/to/me/$tyk_context.trigger-0-pathpart-0",
+					},
+				},
+				r,
+			}
+		},
+		func() TestDef {
+			r, _ := http.NewRequest("GET", "/test/foo/rewrite/foo", nil)
+			hOpt := apidef.StringRegexMap{MatchPattern: "foo"}
+			hOpt.Init()
+
+			return TestDef{
+				"PathPart MoreParts",
+				"/test/foo/rewrite/foo", "/change/to/me/ignore",
+				"/test/foo/rewrite/foo", "/change/to/me/foo/biz/foo",
+				[]apidef.RoutingTrigger{
+					{
+						On: apidef.Any,
+						Options: apidef.RoutingTriggerOptions{
+							PathPartMatches: map[string]apidef.StringRegexMap{
+								"pathpart": hOpt,
+							},
+						},
+						RewriteTo: "/change/to/me/$tyk_context.trigger-0-pathpart-0/biz/$tyk_context.trigger-0-pathpart-1",
+					},
+				},
+				r,
+			}
+		},
 	}
 	for _, tf := range tests {
 		tc := tf()


### PR DESCRIPTION
Fixed #639 

This PR adds rewrite "triggers" on top of the existing rewrite functionality. These are essentially sub-matches to allow a rewrite rule to have variations.

For example, for the URL `/foo/bar/baz` I want to rewrite to `/fooble/barble/bazble` if the query string variable `culprit` is set to `kronk`, but I want to redirect to `/foozle/barzle/bazzle` if the variable `culprit` is set to `yzma`.

I can do this with the new URL Rewriter as follows:

```
{
	"url_rewrites": [
		{
			"path": "/foo/bar/baz",
			"method": "GET",
			"match_pattern": "/foo/bar/baz",
			"rewrite_to": "/foo/bar/baz",
			"triggers": [
				{
					"on": "any",
					"options": {
						"query_val_matches": {
							"culprit": {
								match_rx": "kronk"
							}
						}
					}
					"rewrite_to": "/fooble/barble/bazble"
				}
				{
					"on": "any",
					"options": {
						"query_val_matches": {
							"culprit": {
								match_rx": "yzma"
							}
						}
					}
					"rewrite_to": "/foozle/barzle/bazzle"
				}
			]
		}
	]
}
```

Here if there is no trigger match, the rwrite will fallback to the parent `rewrite_to`, but if either of the other two are triggered, the rewrite target is changed.

Each trigger also sets a context variable for each match it finds, these context vars can then be used in the rewrites, so the above example with context vars could be rewritten to:

```
{
	"url_rewrites": [
		{
			"path": "/foo/bar/baz",
			"method": "GET",
			"match_pattern": "/foo/bar/baz",
			"rewrite_to": "/foo/bar/baz",
			"triggers": [
				{
					"on": "any",
					"options": {
						"query_val_matches": {
							"culprit": {
								match_rx": "kronk"
							}
						}
					}
					"rewrite_to": "/fooble/barble/bazble?victim=$tyk_context.trigger-0-culprit-0"
				}
				{
					"on": "any",
					"options": {
						"query_val_matches": {
							"culprit": {
								match_rx": "yzma"
							}
						}
					}
					"rewrite_to": "/foozle/barzle/bazzle?victim=$tyk_context.trigger-1-culprit-0"
				}
			]
		}
	]
}
```

Trigger contexts take the format: `$tyk_context.trigger-{n}-{name}-{i}` where `n` is the trigger index in the array, `nam` is the rx matcher name and `i` is the index of that match (since querystrings and headers can be arrays of values). 

The Trigger functionality supports:

1. Header matches
2. Query string variable/value matches
3. Path part matches, i.e. components of the path itself
4. Session meta data values (edit)
5. Payload matches

For each trigger, the trigger can either use the `on: any` or `on: all` formatting, for `any`, if any one of the options in the trigger is true, the rewrite rule is fired. for `all`, all the options must be satisfied. This is limited to triggers, not groups of triggers, these will be evaluated one by one.