### PR TITLE
Fix hmac bug when timezone have no code, only numeric representation

### DIFF
--- a/mw_hmac.go
+++ b/mw_hmac.go
@@ -178,10 +178,15 @@ func (hm *HMACMiddleware) authorizationError(r *http.Request) (error, int) {
 
 func (hm HMACMiddleware) checkClockSkew(dateHeaderValue string) bool {
 	// Reference layout for parsing time: "Mon Jan 2 15:04:05 MST 2006"
-
 	refDate := "Mon, 02 Jan 2006 15:04:05 MST"
 
+	// Fall back to a numeric timezone, since some environments don't provide a timezone name code
+	refDateNumeric := "Mon, 02 Jan 2006 15:04:05 -07"
+
 	tim, err := time.Parse(refDate, dateHeaderValue)
+	if err != nil {
+		tim, err = time.Parse(refDateNumeric, dateHeaderValue)
+	}
 
 	if err != nil {
 		log.WithFields(logrus.Fields{


### PR DESCRIPTION
Not all timezones have abbreviations. I found this bug while testing
in my location, and since my timezone has no abbreviation, even if
date template tells use TZ code, Go replaced it with number value (in
my case -5). Because of this, all HMAC tests was failing on my machine.

Go date parsing mechanism do not support parsing timezone both with
numeric and abbreviation timezones, so we have to manually fallback to
it.