### PR TITLE
main: register net/http/pprof on reloads too

### DIFF
--- a/gateway_test.go
+++ b/gateway_test.go
@@ -935,6 +935,22 @@ func TestControlListener(t *testing.T) {
 	testHttp(t, tests, true)
 }
 
+func TestHttpPprof(t *testing.T) {
+	old := httpProfile
+	defer func() { httpProfile = old }()
+
+	testHttp(t, []tykHttpTest{
+		{method: "GET", path: "/debug/pprof/", code: 404},
+		{method: "GET", path: "/debug/pprof/", code: 404, controlRequest: true},
+	}, true)
+	httpProfile = true
+	doReload()
+	testHttp(t, []tykHttpTest{
+		{method: "GET", path: "/debug/pprof/", code: 404},
+		{method: "GET", path: "/debug/pprof/", code: 200, controlRequest: true},
+	}, true)
+}
+
 func TestManagementNodeRedisEvents(t *testing.T) {
 	defer func() {
 		config.Global.ManagementNode = false

--- a/mw_js_plugin.go
+++ b/mw_js_plugin.go
@@ -295,13 +295,13 @@ func (j *JSVM) Init() {
 		}).Error("Could not open TykJS: ", err)
 		return
 	}
+	defer f.Close()
 	if _, err := vm.Run(f); err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "jsvm",
 		}).Error("Could not load TykJS: ", err)
 		return
 	}
-	f.Close()
 
 	j.VM = vm
 


### PR DESCRIPTION
We didn't need to in the past as we layered the routers, meaning that we
never fully replaced the main router. Now that we do, we must set it up.
Otherwise, its routes will be 404s after any reload.

Also a small file closing fix.