### PR TITLE
mw: add jsonMarshal to body transform templates

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -13,7 +13,7 @@ import (
 	"regexp"
 	"strings"
 	"sync/atomic"
-	textTemplate "text/template"
+	"text/template"
 	"time"
 
 	"github.com/rubyist/circuitbreaker"
@@ -104,7 +104,7 @@ type URLSpec struct {
 
 type TransformSpec struct {
 	apidef.TemplateMeta
-	Template *textTemplate.Template
+	Template *template.Template
 }
 
 type ExtendedCircuitBreakerMeta struct {
@@ -445,18 +445,25 @@ func (a APIDefinitionLoader) compileCachedPathSpec(paths []string) []URLSpec {
 	return urlSpec
 }
 
-func (a APIDefinitionLoader) loadFileTemplate(path string) (*textTemplate.Template, error) {
+var apiTemplate = template.New("").Funcs(map[string]interface{}{
+	"jsonMarshal": func(v interface{}) (string, error) {
+		bs, err := json.Marshal(v)
+		return string(bs), err
+	},
+})
+
+func (a APIDefinitionLoader) loadFileTemplate(path string) (*template.Template, error) {
 	log.Debug("-- Loading template: ", path)
-	return textTemplate.ParseFiles(path)
+	return apiTemplate.New("").ParseFiles(path)
 }
 
-func (a APIDefinitionLoader) loadBlobTemplate(blob string) (*textTemplate.Template, error) {
+func (a APIDefinitionLoader) loadBlobTemplate(blob string) (*template.Template, error) {
 	log.Debug("-- Loading blob")
 	uDec, err := base64.StdEncoding.DecodeString(blob)
 	if err != nil {
 		return nil, err
 	}
-	return textTemplate.New("blob").Parse(string(uDec))
+	return apiTemplate.New("").Parse(string(uDec))
 }
 
 func (a APIDefinitionLoader) compileTransformPathSpec(paths []apidef.TemplateMeta, stat URLStatus) []URLSpec {

--- a/mw_transform_test.go
+++ b/mw_transform_test.go
@@ -40,8 +40,31 @@ func TestTransformXMLCrash(t *testing.T) {
 	r := testReq(t, "GET", "/", in)
 	tmeta := &TransformSpec{}
 	tmeta.TemplateData.Input = apidef.RequestXML
-	tmeta.Template = template.Must(template.New("blob").Parse(""))
+	tmeta.Template = template.Must(apiTemplate.New("").Parse(""))
 	if err := transformBody(r, tmeta, false); err == nil {
 		t.Fatalf("wanted error, got nil")
+	}
+}
+
+func TestTransformJSONMarshal(t *testing.T) {
+	in := `<names>
+	<name>Foo"oo</name>
+	<name>Bàr</name>
+</names>`
+	want := `["Foo\"oo", "Bàr"]`
+	tmpl := `[{{range $x, $s := .names.name}}{{$s | jsonMarshal}}{{if not $x}}, {{end}}{{end}}]`
+	r := testReq(t, "GET", "/", in)
+	tmeta := &TransformSpec{}
+	tmeta.TemplateData.Input = apidef.RequestXML
+	tmeta.Template = template.Must(apiTemplate.New("").Parse(tmpl))
+	if err := transformBody(r, tmeta, false); err != nil {
+		t.Fatalf("wanted nil error, got %v", err)
+	}
+	gotBs, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(gotBs); got != want {
+		t.Fatalf("wanted body %q, got %q", want, got)
 	}
 }


### PR DESCRIPTION
So that one can use the body templates to change XML into JSON (or
otherwise construct JSON objects) without having to worry about properly
encoding values. The simplest case of this is strings, since using
plaintext could easily result in unescaped quote characters.

Now, instead of using the following template:

	"{{ $val }}"

One should do:

	{{ $val | jsonMarshal }}

Fixes #1145.