### PR TITLE
Loading API specs should skip inactive APIs.

### DIFF
--- a/api_definition_test.go
+++ b/api_definition_test.go
@@ -38,7 +38,8 @@ const sampleDefiniton = `{
 	"proxy": {
 		"listen_path": "/v1",
 		"target_url": "` + testHttpAny + `"
-	}
+	},
+	"active": true
 }`
 
 const nonExpiringDef = `{
@@ -64,7 +65,8 @@ const nonExpiringDef = `{
 	"proxy": {
 		"listen_path": "/v1",
 		"target_url": "` + testHttpAny + `"
-	}
+	},
+	"active": true
 }`
 
 const nonExpiringMultiDef = `{
@@ -98,7 +100,8 @@ const nonExpiringMultiDef = `{
 	"proxy": {
 		"listen_path": "/v1",
 		"target_url": "` + testHttpAny + `"
-	}
+	},
+	"active": true
 }`
 
 func createDefinitionFromString(defStr string) *APISpec {
@@ -378,7 +381,7 @@ func TestGetAPISpecsDashboardSuccess(t *testing.T) {
 	// Mock Dashboard
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/system/apis" {
-			w.Write([]byte(`{"Status": "OK", "Nonce": "1", "Message": [{"api_definition": {}}]}`))
+			w.Write([]byte(`{"Status": "OK", "Nonce": "1", "Message": [{"api_definition": {"active": true}}]}`))
 		} else {
 			t.Fatal("Unknown dashboard API request", r)
 		}

--- a/api_test.go
+++ b/api_test.go
@@ -33,7 +33,8 @@ const apiTestDef = `{
 	"proxy": {
 		"listen_path": "/v1",
 		"target_url": "` + testHttpAny + `"
-	}
+	},
+	"active": true
 }`
 
 func loadSampleAPI(t *testing.T, def string) {

--- a/apps/app_sample.json
+++ b/apps/app_sample.json
@@ -29,5 +29,6 @@
         "target_url": "http://httpbin.org",
         "strip_listen_path": true
     },
-    "enable_batch_request_support": true
+    "enable_batch_request_support": true,
+    "active": true
 }

--- a/apps/coprocess_app_sample.json
+++ b/apps/coprocess_app_sample.json
@@ -45,5 +45,6 @@
       ],
       "driver": "python"
     },
-    "enable_batch_request_support": true
+    "enable_batch_request_support": true,
+    "active": true
 }

--- a/apps/coprocess_app_sample_protected.json
+++ b/apps/coprocess_app_sample_protected.json
@@ -37,5 +37,6 @@
       },
       "driver": "python"
     },
-    "enable_batch_request_support": true
+    "enable_batch_request_support": true,
+    "active": true
 }

--- a/apps/coprocess_grpc_app_sample.json
+++ b/apps/coprocess_grpc_app_sample.json
@@ -58,5 +58,6 @@
         ]
       }
     },
-    "enable_batch_request_support": true
+    "enable_batch_request_support": true,
+    "active": true
 }

--- a/apps/coprocess_grpc_app_sample_protected.json
+++ b/apps/coprocess_grpc_app_sample_protected.json
@@ -61,5 +61,6 @@
       "session_lifetime": 35
     },
     "custom_middleware_bundle": "test-bundle",
-    "enable_batch_request_support": true
+    "enable_batch_request_support": true,
+    "active": true
 }

--- a/apps/coprocess_lua_app_sample.json
+++ b/apps/coprocess_lua_app_sample.json
@@ -39,5 +39,6 @@
       ],
       "driver": "lua"
     },
-    "enable_batch_request_support": true
+    "enable_batch_request_support": true,
+    "active": true
 }

--- a/apps/quickstart.json
+++ b/apps/quickstart.json
@@ -30,5 +30,6 @@
         "target_url": "http://httpbin.org/",
         "strip_listen_path": true
     },
-    "do_not_track": true
+    "do_not_track": true,
+    "active": true
 }

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -889,7 +889,8 @@ const sampleAPI = `{
 	"proxy": {
 		"listen_path": "/sample",
 		"target_url": "` + testHttpAny + `"
-	}
+	},
+	"active": true
 }`
 
 func TestListener(t *testing.T) {
@@ -982,7 +983,8 @@ const apiWithTykListenPathPrefix = `{
 	"proxy": {
 		"listen_path": "/tyk-foo/",
 		"target_url": "` + testHttpAny + `"
-	}
+	},
+	"active": true
 }`
 
 func TestListenPathTykPrefix(t *testing.T) {

--- a/oauth_manager_test.go
+++ b/oauth_manager_test.go
@@ -65,7 +65,8 @@ const oauthDefinition = `{
 	"proxy": {
 		"listen_path": "/APIID/",
 		"target_url": "` + testHttpAny + `"
-	}
+	},
+	"active": true
 }`
 
 func getOAuthChain(spec *APISpec, muxer *mux.Router) {


### PR DESCRIPTION
Resolves #1151 