### PR TITLE
proxy: fix and test multi-target reverse proxy

### DIFF
--- a/api_loader.go
+++ b/api_loader.go
@@ -243,9 +243,8 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 	}
 
 	// Already vetted
-	remote, _ := url.Parse(spec.Proxy.TargetURL)
+	spec.target, _ = url.Parse(spec.Proxy.TargetURL)
 
-	spec.target = remote
 	var proxy ReturningHttpHandler
 	if enableVersionOverrides {
 		log.WithFields(logrus.Fields{
@@ -254,7 +253,7 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 		}).Info("Multi target enabled")
 		proxy = NewMultiTargetProxy(spec)
 	} else {
-		proxy = TykNewSingleHostReverseProxy(remote, spec)
+		proxy = TykNewSingleHostReverseProxy(spec.target, spec)
 	}
 
 	// Create the response processors

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -880,6 +880,10 @@ func testHttp(t *testing.T, tests []tykHttpTest, separateControlPort bool) {
 const sampleAPI = `{
 	"api_id": "test",
 	"use_keyless": true,
+	"definition": {
+		"location": "header",
+		"key": "version"
+	},
 	"version_data": {
 		"not_versioned": true,
 		"versions": {
@@ -1097,5 +1101,78 @@ func TestSkipUrlCleaning(t *testing.T) {
 
 	if string(body) != "/http://example.com" {
 		t.Error("Should not strip URL", string(body))
+	}
+}
+
+const multiTargetDef = `{
+	"api_id": "1",
+	"use_keyless": true,
+	"definition": {
+		"location": "header",
+		"key": "version"
+	},
+	"version_data": {
+		"versions": {
+			"vdef": {
+				"name": "vdef"
+			},
+			"vother": {
+				"name": "vother",
+				"override_target": "` + testHttpAny + `/vother"
+			}
+		}
+	},
+	"proxy": {
+		"listen_path": "/",
+		"target_url": "` + testHttpAny + `"
+	}
+}`
+
+func TestMultiTargetProxy(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseURL := "http://" + ln.Addr().String()
+	listen(ln, nil, nil)
+
+	defer ln.Close()
+
+	buildAndLoadAPI(func(spec *APISpec) {
+		spec.VersionData.NotVersioned = false
+		spec.VersionData.Versions = map[string]apidef.VersionInfo{
+			"vdef": {Name: "vdef"},
+			"vother": {
+				Name:           "vother",
+				OverrideTarget: testHttpAny + "/vother",
+			},
+		}
+		spec.Proxy.ListenPath = "/"
+	})
+	tests := []struct {
+		version, wantPath string
+	}{
+		{"vdef", "/"},
+		{"vother", "/vother"},
+	}
+
+	for _, tc := range tests {
+		req, err := http.NewRequest("GET", baseURL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("version", tc.version)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		var testResp testHttpResponse
+		if err := json.NewDecoder(resp.Body).Decode(&testResp); err != nil {
+			t.Fatal(err)
+		}
+		if testResp.Url != tc.wantPath {
+			t.Fatalf("wanted path %s, got %s", tc.wantPath, testResp.Url)
+		}
 	}
 }


### PR DESCRIPTION
I broke it when replacing the false Init method with a regular
constructor, since I forgot to replace the nil return with the actual
object.

Add a test that covers both the default proxy and an overriding one. It
was crashing as expected. Fix the constructor, making the test pass.

While at it, clean up the code quite a bit:

* no need to parse TargetURL again
* getProxyForRequest can be much simpler
* unindent some of the code

Fixes #1177.