### PR TITLE
Revert "Loading API specs should skip inactive APIs."

### DIFF
--- a/api_definition_test.go
+++ b/api_definition_test.go
@@ -38,8 +38,7 @@ const sampleDefiniton = `{
 	"proxy": {
 		"listen_path": "/v1",
 		"target_url": "` + testHttpAny + `"
-	},
-	"active": true
+	}
 }`
 
 const nonExpiringDef = `{
@@ -65,8 +64,7 @@ const nonExpiringDef = `{
 	"proxy": {
 		"listen_path": "/v1",
 		"target_url": "` + testHttpAny + `"
-	},
-	"active": true
+	}
 }`
 
 const nonExpiringMultiDef = `{
@@ -100,8 +98,7 @@ const nonExpiringMultiDef = `{
 	"proxy": {
 		"listen_path": "/v1",
 		"target_url": "` + testHttpAny + `"
-	},
-	"active": true
+	}
 }`
 
 func createDefinitionFromString(defStr string) *APISpec {
@@ -381,7 +378,7 @@ func TestGetAPISpecsDashboardSuccess(t *testing.T) {
 	// Mock Dashboard
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/system/apis" {
-			w.Write([]byte(`{"Status": "OK", "Nonce": "1", "Message": [{"api_definition": {"active": true}}]}`))
+			w.Write([]byte(`{"Status": "OK", "Nonce": "1", "Message": [{"api_definition": {}}]}`))
 		} else {
 			t.Fatal("Unknown dashboard API request", r)
 		}

--- a/api_loader.go
+++ b/api_loader.go
@@ -39,17 +39,7 @@ func prepareStorage() (*RedisClusterStorageManager, *RedisClusterStorageManager,
 	return &redisStore, &redisOrgStore, healthStore, &rpcAuthStore, &rpcOrgStore
 }
 
-func skipSpec(spec *APISpec) bool {
-
-	// Remove inactive APIs from the specs
-	if !spec.Active {
-		log.WithFields(logrus.Fields{
-			"prefix":   "main",
-			"api_name": spec.Name,
-			"domain":   spec.Domain,
-		}).Info("Skipping Inactive.")
-		return true
-	}
+func skipSpecBecauseInvalid(spec *APISpec) bool {
 
 	if spec.Proxy.ListenPath == "" {
 		log.WithFields(logrus.Fields{
@@ -119,7 +109,7 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 		"api_name": spec.Name,
 	}).Info("Loading API")
 
-	if skipSpec(spec) {
+	if skipSpecBecauseInvalid(spec) {
 		log.WithFields(logrus.Fields{
 			"prefix":   "main",
 			"api_name": spec.Name,
@@ -565,7 +555,6 @@ func loadApps(specs []*APISpec, muxer *mux.Router) {
 	loadList := make([]*ChainObject, len(specs))
 	apisByListen := countApisByListenHash(specs)
 	for i, spec := range specs {
-
 		go func(spec *APISpec, i int) {
 			subrouter := muxer
 			// Handle custom domains

--- a/api_test.go
+++ b/api_test.go
@@ -33,8 +33,7 @@ const apiTestDef = `{
 	"proxy": {
 		"listen_path": "/v1",
 		"target_url": "` + testHttpAny + `"
-	},
-	"active": true
+	}
 }`
 
 func loadSampleAPI(t *testing.T, def string) {

--- a/apps/app_sample.json
+++ b/apps/app_sample.json
@@ -29,6 +29,5 @@
         "target_url": "http://httpbin.org",
         "strip_listen_path": true
     },
-    "enable_batch_request_support": true,
-    "active": true
+    "enable_batch_request_support": true
 }

--- a/apps/coprocess_app_sample.json
+++ b/apps/coprocess_app_sample.json
@@ -45,6 +45,5 @@
       ],
       "driver": "python"
     },
-    "enable_batch_request_support": true,
-    "active": true
+    "enable_batch_request_support": true
 }

--- a/apps/coprocess_app_sample_protected.json
+++ b/apps/coprocess_app_sample_protected.json
@@ -37,6 +37,5 @@
       },
       "driver": "python"
     },
-    "enable_batch_request_support": true,
-    "active": true
+    "enable_batch_request_support": true
 }

--- a/apps/coprocess_grpc_app_sample.json
+++ b/apps/coprocess_grpc_app_sample.json
@@ -58,6 +58,5 @@
         ]
       }
     },
-    "enable_batch_request_support": true,
-    "active": true
+    "enable_batch_request_support": true
 }

--- a/apps/coprocess_grpc_app_sample_protected.json
+++ b/apps/coprocess_grpc_app_sample_protected.json
@@ -61,6 +61,5 @@
       "session_lifetime": 35
     },
     "custom_middleware_bundle": "test-bundle",
-    "enable_batch_request_support": true,
-    "active": true
+    "enable_batch_request_support": true
 }

--- a/apps/coprocess_lua_app_sample.json
+++ b/apps/coprocess_lua_app_sample.json
@@ -39,6 +39,5 @@
       ],
       "driver": "lua"
     },
-    "enable_batch_request_support": true,
-    "active": true
+    "enable_batch_request_support": true
 }

--- a/apps/quickstart.json
+++ b/apps/quickstart.json
@@ -30,6 +30,5 @@
         "target_url": "http://httpbin.org/",
         "strip_listen_path": true
     },
-    "do_not_track": true,
-    "active": true
+    "do_not_track": true
 }

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -889,8 +889,7 @@ const sampleAPI = `{
 	"proxy": {
 		"listen_path": "/sample",
 		"target_url": "` + testHttpAny + `"
-	},
-	"active": true
+	}
 }`
 
 func TestListener(t *testing.T) {
@@ -983,8 +982,7 @@ const apiWithTykListenPathPrefix = `{
 	"proxy": {
 		"listen_path": "/tyk-foo/",
 		"target_url": "` + testHttpAny + `"
-	},
-	"active": true
+	}
 }`
 
 func TestListenPathTykPrefix(t *testing.T) {

--- a/oauth_manager_test.go
+++ b/oauth_manager_test.go
@@ -65,8 +65,7 @@ const oauthDefinition = `{
 	"proxy": {
 		"listen_path": "/APIID/",
 		"target_url": "` + testHttpAny + `"
-	},
-	"active": true
+	}
 }`
 
 func getOAuthChain(spec *APISpec, muxer *mux.Router) {


### PR DESCRIPTION
Reverts TykTechnologies/tyk#1176

Unintended consequences for existing CE users. Users who do not use the active flag will have their APIs disabled.