### PR TITLE
#1179 If use_db_app_configs is set to false, reLogin will no longer panic

### DIFF
--- a/dashboard_register.go
+++ b/dashboard_register.go
@@ -37,6 +37,10 @@ type HTTPDashboardHandler struct {
 }
 
 func reLogin() {
+	if !config.Global.UseDBAppConfigs {
+		return
+	}
+
 	log.WithFields(logrus.Fields{
 		"prefix": "main",
 	}).Info("Registering node (again).")

--- a/policy_test.go
+++ b/policy_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/TykTechnologies/tyk/config"
+)
+
+func TestLoadPoliciesFromDashboardReLogin(t *testing.T) {
+	// Mock Dashboard
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(403)
+	}))
+	defer ts.Close()
+
+	oldUseDBAppConfigs := config.Global.UseDBAppConfigs
+	config.Global.UseDBAppConfigs = false
+
+	defer func() { config.Global.UseDBAppConfigs = oldUseDBAppConfigs }()
+
+	allowExplicitPolicyID := config.Global.Policies.AllowExplicitPolicyID
+
+	policyMap := LoadPoliciesFromDashboard(ts.URL, "", allowExplicitPolicyID)
+
+	if policyMap != nil {
+		t.Error("Should be nil because got back 403 from Dashboard")
+	}
+}


### PR DESCRIPTION
Resolves #1179. 

When a 403 response is received from the dashboard, will no longer try to reLogin.