### PR TITLE
loader: simplify auth chain construction

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -92,10 +92,12 @@ func createMiddleware(mw TykMiddleware) func(http.Handler) http.Handler {
 	}
 }
 
-func mwAppendEnabled(chain *[]alice.Constructor, mw TykMiddleware) {
+func mwAppendEnabled(chain *[]alice.Constructor, mw TykMiddleware) bool {
 	if mw.EnabledForSpec() {
 		*chain = append(*chain, createMiddleware(mw))
+		return true
 	}
+	return false
 }
 
 func mwList(mws ...TykMiddleware) []alice.Constructor {

--- a/mw_basic_auth.go
+++ b/mw_basic_auth.go
@@ -21,6 +21,10 @@ func (k *BasicAuthKeyIsValid) Name() string {
 	return "BasicAuthKeyIsValid"
 }
 
+func (k *BasicAuthKeyIsValid) EnabledForSpec() bool {
+	return k.Spec.UseBasicAuth
+}
+
 // requestForBasicAuth sends error code and message along with WWW-Authenticate header to client.
 func (k *BasicAuthKeyIsValid) requestForBasicAuth(w http.ResponseWriter, msg string) (error, int) {
 	authReply := "Basic realm=\"" + k.Spec.Name + "\""

--- a/mw_hmac.go
+++ b/mw_hmac.go
@@ -30,6 +30,10 @@ func (hm *HMACMiddleware) Name() string {
 	return "HMAC"
 }
 
+func (k *HMACMiddleware) EnabledForSpec() bool {
+	return k.Spec.EnableSignatureChecking
+}
+
 func (hm *HMACMiddleware) Init() {
 	hm.lowercasePattern = regexp.MustCompile(`%[a-f0-9][a-f0-9]`)
 }

--- a/mw_jwt.go
+++ b/mw_jwt.go
@@ -25,6 +25,10 @@ func (k *JWTMiddleware) Name() string {
 	return "JWTMiddleware"
 }
 
+func (k *JWTMiddleware) EnabledForSpec() bool {
+	return k.Spec.EnableJWT
+}
+
 var JWKCache *cache.Cache
 
 type JWK struct {

--- a/mw_oauth2_key_exists.go
+++ b/mw_oauth2_key_exists.go
@@ -20,6 +20,10 @@ func (k *Oauth2KeyExists) Name() string {
 	return "Oauth2KeyExists"
 }
 
+func (k *Oauth2KeyExists) EnabledForSpec() bool {
+	return k.Spec.UseOauth2
+}
+
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 

--- a/mw_openid.go
+++ b/mw_openid.go
@@ -28,6 +28,10 @@ func (k *OpenIDMW) Name() string {
 	return "OpenIDMW"
 }
 
+func (k *OpenIDMW) EnabledForSpec() bool {
+	return k.Spec.UseOpenID
+}
+
 func (k *OpenIDMW) Init() {
 	k.provider_client_policymap = make(map[string]map[string]string)
 	// Create an OpenID Configuration and store


### PR DESCRIPTION
First, move the "enabled" checks to EnabledForSpec, which is why it's
there in the interface to begin with. Let the loader still log when a
middleware was appended by making mwAppendEnabled return a bool.

Second, remove a duplicate useCoProcessAuth if statement.

Third, greatly simplify the logic to decide whether or not to use
AuthKey. The second part of the conditional checked that no other auth
middleware was loaded. We can do this by simply checking if the auth
chain is empty, instead of using a very complex and hard to maintain
chain of bools.