### PR TITLE
all: clean up and simplify a bunch of code

### DIFF
--- a/api.go
+++ b/api.go
@@ -1459,17 +1459,3 @@ func ctxSetVersionInfo(r *http.Request, v *apidef.VersionInfo) {
 	}
 	setCtxValue(r, VersionData, v)
 }
-
-func ctxGetVersionKey(r *http.Request) string {
-	if v := r.Context().Value(VersionKeyContext); v != nil {
-		return v.(string)
-	}
-	return ""
-}
-
-func ctxSetVersionKey(r *http.Request, k string) {
-	if k == "" {
-		panic("setting a nil context VersionKeyContext")
-	}
-	setCtxValue(r, VersionKeyContext, k)
-}

--- a/api_definition_test.go
+++ b/api_definition_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -103,7 +104,7 @@ const nonExpiringMultiDef = `{
 
 func createDefinitionFromString(defStr string) *APISpec {
 	loader := APIDefinitionLoader{}
-	def := loader.ParseDefinition([]byte(defStr))
+	def := loader.ParseDefinition(strings.NewReader(defStr))
 	spec := loader.MakeSpec(def)
 	spec.APIDefinition = def
 	return spec

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -1102,30 +1102,6 @@ func TestSkipUrlCleaning(t *testing.T) {
 	}
 }
 
-const multiTargetDef = `{
-	"api_id": "1",
-	"use_keyless": true,
-	"definition": {
-		"location": "header",
-		"key": "version"
-	},
-	"version_data": {
-		"versions": {
-			"vdef": {
-				"name": "vdef"
-			},
-			"vother": {
-				"name": "vother",
-				"override_target": "` + testHttpAny + `/vother"
-			}
-		}
-	},
-	"proxy": {
-		"listen_path": "/",
-		"target_url": "` + testHttpAny + `"
-	}
-}`
-
 func TestMultiTargetProxy(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/handler_success.go
+++ b/handler_success.go
@@ -21,7 +21,6 @@ const (
 	SessionData = iota
 	AuthHeaderValue
 	VersionData
-	VersionKeyContext
 	OrgSessionContext
 	ContextData
 	RetainHost


### PR DESCRIPTION
First, we know that in the versions map, the key will always be equal to
value.Name. The docs don't explicitly state this, but other parts of the
code such as elsewhere in the gateway and the dashboard use the two
interchangeably.

Do the same in the API definition loader. It was caching both the key
and value in the request's context. Cache only the value. We only ever
needed to cache the version key here, and it won't be useful in the
future, so remove the machinery too.

While at it, collapse some identical switch cases and make
ParseDefinition take a reader, since a string is not necessary.

Finally, remove a test API definition file I recently introduced by
mistake.