### PR TITLE
proxy: avoid copying bodies multiple times

### DIFF
--- a/reverse_proxy_test.go
+++ b/reverse_proxy_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 	"text/template"
 
@@ -228,5 +230,19 @@ func TestCheckHeaderInRemoveList(t *testing.T) {
 				t.Fatalf("want %t, got %t", tc.expected, actual)
 			}
 		})
+	}
+}
+
+func BenchmarkCopyRequestResponse(b *testing.B) {
+	str := strings.Repeat("very long body line that is repeated", 128)
+	req := &http.Request{}
+	res := &http.Response{}
+	for i := 0; i < b.N; i++ {
+		req.Body = ioutil.NopCloser(strings.NewReader(str))
+		res.Body = ioutil.NopCloser(strings.NewReader(str))
+		for j := 0; j < 10; j++ {
+			req = copyRequest(req)
+			res = copyResponse(res)
+		}
 	}
 }


### PR DESCRIPTION
When we copy a request or response's body, we replace both results'
bodies with a NopCloser around a bytes.Buffer. We do this to be able to
read it multiple times from different places at different times.
However, once we put it in a bytes.Buffer once, it's already in memory
and doing the same again is useless.

Instead, buffer only once, and simply re-use a shallow copy of
bytes.Buffer from there on. This is enough, since it will make a copy of
the read offset yet share the same underlying buffer.

There is no indication that this is a bottleneck, but it's an easy win
and we do call copyRequest and copyResponse multiple times in the
codebase.

Benchmark of copying a request and response 10 times each, before and
after:

name                   old time/op    new time/op    delta
CopyRequestResponse-4     168µs ± 0%      26µs ± 1%  -84.39%  (p=0.004 n=5+6)

name                   old alloc/op   new alloc/op   delta
CopyRequestResponse-4     296kB ± 0%      36kB ± 0%  -87.98%  (p=0.000 n=5+6)

name                   old allocs/op  new allocs/op  delta
CopyRequestResponse-4       184 ± 0%        76 ± 0%  -58.70%  (p=0.002 n=6+6)