### PR TITLE
Added CoProccessSpecExtras to the Tyk.Conf

### DIFF
--- a/coprocess.go
+++ b/coprocess.go
@@ -111,6 +111,15 @@ func (c *CoProcessor) ObjectFromRequest(r *http.Request) *coprocess.Object {
 			"OrgID": c.Middleware.Spec.OrgID,
 			"APIID": c.Middleware.Spec.APIID,
 		}
+
+		//Append ConfigData First Layer to Spec
+		for k, v := range c.Middleware.Spec.ConfigData {
+			switch v.(type) {
+			case string:
+				object.Spec[k] = v.(string)
+			}
+		}
+
 	}
 
 	// Encode the session object (if not a pre-process & not a custom key check):

--- a/coprocess_test.go
+++ b/coprocess_test.go
@@ -288,6 +288,12 @@ const basicCoProcessDef = `{
 	"proxy": {
 		"listen_path": "/v1",
 		"target_url": "` + testHttpGet + `"
+	},
+	"config_data": {
+		"key": "value",
+		"nest_key": {
+			"k": "v"
+		}
 	}
 }`
 
@@ -318,5 +324,11 @@ const protectedCoProcessDef = `{
 	"proxy": {
 		"listen_path": "/v1",
 		"target_url": "` + testHttpGet + `"
+	},
+	"config_data": {
+		"key": "value",
+		"nest_key": {
+			"k": "v"
+		}
 	}
 }`


### PR DESCRIPTION
We want to be able to pass any fields through the Spec object. We are aware of the ConfigData being available to JavaScript plugins, however, due to the map[string]interface{} type not being compatible with any protobuf3 field, that object can't be passed to CoProccess plugins.

Please see the following requests relating to this:
https://community.tyk.io/t/python-plugin-spec-fields/1925
https://community.tyk.io/t/config-data-in-a-python-middleware/1924

#1197