### PR TITLE
Ignore CORS middleware when OptionsPassthrough on

### DIFF
--- a/api_loader.go
+++ b/api_loader.go
@@ -322,7 +322,9 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 
 		var chainArray []alice.Constructor
 
-		handleCORS(&chainArray, spec)
+		if spec.CORS.Enable && !spec.CORS.OptionsPassthrough {
+			handleCORS(&chainArray, spec)
+		}
 
 		// Add pre-process MW
 		for _, obj := range mwPreFuncs {


### PR DESCRIPTION
Resolves #757

When `CORS.options_passthrough` is set to true, before, the CORS
middleware would write it's own CORS headers, meaning that both the
upstreams headers and the CORS headers were returned in OPTIONS requests.

Before Passthrough On:
```
curl -X OPTIONS   http://127.0.0.1:8080/cors-auth/post   -H
'access-control-request-method: POST'   -H 'authorization:
453ec0823db443dd9a8fb6d234917e3d'   -H 'origin: abc.com' -I
HTTP/1.1 200 OK
Access-Control-Allow-Credentials: true
Access-Control-Allow-Methods: POST
Access-Control-Allow-Methods: GET, POST, PUT, DELETE, PATCH, OPTIONS
Access-Control-Allow-Origin: abc.com
Access-Control-Allow-Origin: abc.com
Access-Control-Max-Age: 24
Access-Control-Max-Age: 3600
Allow: POST, OPTIONS
Content-Length: 0
Content-Type: text/html; charset=utf-8
Date: Fri, 06 Oct 2017 11:13:29 GMT
Server: meinheld/0.6.1
Vary: Origin
Vary: Access-Control-Request-Method
Vary: Access-Control-Request-Headers
Via: 1.1 vegur
X-Powered-By: Flask
X-Processed-Time: 0.000757932662964
X-Ratelimit-Limit: 0
X-Ratelimit-Remaining: 0
X-Ratelimit-Reset: 0
```

After Passthrough On:
```
$ curl -X OPTIONS   http://127.0.0.1:8080/cors-auth/post   -H
'access-control-request-method: POST'   -H 'authorization:
453ec0823db443dd9a8fb6d234917e3d'   -H 'origin: abc.com' -I
HTTP/1.1 200 OK
Access-Control-Allow-Credentials: true
Access-Control-Allow-Methods: GET, POST, PUT, DELETE, PATCH, OPTIONS
Access-Control-Allow-Origin: abc.com
Access-Control-Max-Age: 3600
Allow: POST, OPTIONS
Content-Length: 0
Content-Type: text/html; charset=utf-8
Date: Fri, 06 Oct 2017 11:14:38 GMT
Server: meinheld/0.6.1
Via: 1.1 vegur
X-Powered-By: Flask
X-Processed-Time: 0.000485897064209
X-Ratelimit-Limit: 0
X-Ratelimit-Remaining: 0
X-Ratelimit-Reset: 0
```