### PR TITLE
oauth: simplify extended interface declaration

### DIFF
--- a/oauth_manager.go
+++ b/oauth_manager.go
@@ -345,6 +345,8 @@ const (
 )
 
 type ExtendedOsinStorageInterface interface {
+	osin.Storage
+
 	// Create OAuth clients
 	SetClient(id string, client osin.Client, ignorePrefix bool) error
 
@@ -354,49 +356,6 @@ type ExtendedOsinStorageInterface interface {
 	GetClients(filter string, ignorePrefix bool) ([]osin.Client, error)
 
 	DeleteClient(id string, ignorePrefix bool) error
-
-	// Clone the storage if needed. For example, using mgo, you can clone the session with session.Clone
-	// to avoid concurrent access problems.
-	// This is to avoid cloning the connection at each method access.
-	// Can return itself if not a problem.
-	Clone() osin.Storage
-
-	// Close the resources the Storate potentially holds (using Clone for example)
-	Close()
-
-	// GetClient loads the client by id (client_id)
-	GetClient(id string) (osin.Client, error)
-
-	// SaveAuthorize saves authorize data.
-	SaveAuthorize(*osin.AuthorizeData) error
-
-	// LoadAuthorize looks up AuthorizeData by a code.
-	// Client information MUST be loaded together.
-	// Optionally can return error if expired.
-	LoadAuthorize(code string) (*osin.AuthorizeData, error)
-
-	// RemoveAuthorize revokes or deletes the authorization code.
-	RemoveAuthorize(code string) error
-
-	// SaveAccess writes AccessData.
-	// If RefreshToken is not blank, it must save in a way that can be loaded using LoadRefresh.
-	SaveAccess(*osin.AccessData) error
-
-	// LoadAccess retrieves access data by token. Client information MUST be loaded together.
-	// AuthorizeData and AccessData DON'T NEED to be loaded if not easily available.
-	// Optionally can return error if expired.
-	LoadAccess(token string) (*osin.AccessData, error)
-
-	// RemoveAccess revokes or deletes an AccessData.
-	RemoveAccess(token string) error
-
-	// LoadRefresh retrieves refresh AccessData. Client information MUST be loaded together.
-	// AuthorizeData and AccessData DON'T NEED to be loaded if not easily available.
-	// Optionally can return error if expired.
-	LoadRefresh(token string) (*osin.AccessData, error)
-
-	// RemoveRefresh revokes or deletes refresh AccessData.
-	RemoveRefresh(token string) error
 
 	// GetUser retrieves a Basic Access user token type from the key store
 	GetUser(string) (*user.SessionState, error)


### PR DESCRIPTION
We can extend an interface without listing all of its methods again, by
simply writing the interface name.