### PR TITLE
api: use a strip slashes middleware

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -333,7 +333,8 @@ func TestKeyHandlerGetKey(t *testing.T) {
 			mainRouter.ServeHTTP(recorder, req)
 
 			if recorder.Code != 200 {
-				t.Error("key not requested, status error:\n", recorder.Body.String())
+				t.Errorf("key not requested, path %s status error %s",
+					req.URL.Path, recorder.Body.String())
 			}
 		}
 	}

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -954,6 +954,7 @@ func TestHttpPprof(t *testing.T) {
 	testHttp(t, []tykHttpTest{
 		{method: "GET", path: "/debug/pprof/", code: 404},
 		{method: "GET", path: "/debug/pprof/", code: 200, controlRequest: true},
+		{method: "GET", path: "/debug/pprof/heap", code: 200, controlRequest: true},
 	}, true)
 }
 


### PR DESCRIPTION
To end the gorilla/mux trailing slash madness. Do this only for the
admin API, where we were using this workaround.

While at it, remove an unnecessary subrouter, improve a test error
message, and test that nested net/http/pprof endpoints work.

Note that a new keys route was added, as the existing one requires a
slash. Before, we only supported /keys/ and /keys/foo, but not /keys.
Now all three are supported. This surfaced now given how we rewrite the
/keys/ path into /keys.