### PR TITLE
vendor: update drl with mutex fix

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -31,10 +31,10 @@
 			"revisionTime": "2016-09-08T20:14:09Z"
 		},
 		{
-			"checksumSHA1": "dHkTVWqfuiW9oJTGa48eFJnYZQo=",
+			"checksumSHA1": "xK7PRpDoE+8idiyAlbqNqHiMu9E=",
 			"path": "github.com/TykTechnologies/drl",
-			"revision": "434bbccf78ee303df47c2b747e41fb7462b55d8a",
-			"revisionTime": "2016-11-02T10:42:53Z"
+			"revision": "5f99c27a1a55314fd0b33f47ad39028f55978763",
+			"revisionTime": "2017-10-18T14:32:39Z"
 		},
 		{
 			"checksumSHA1": "RE/gJeawCK3Zl9U2GkoQhpxcb5M=",


### PR DESCRIPTION
cleanServerList was modifying the map without grabbing any lock at all.
Change how the lock is used in this code. Grab the lock only in exposed
methods, as the others are only called once from the exposed ones.

And use a single Mutex instead of a RWMutex, as both exposed methods do
writes. Previously, AddOrUpdateServer would first grab a write lock and
then grab some read locks. However, that's wasteful and can lead to
subtle inconsistencies and bugs. Grab the same lock throughout the func.

Fixes #1216.