### PR TITLE
Make logging output level a config option. Fixes #1182

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -242,6 +242,7 @@ type Config struct {
 	ReloadWaitTime                    int                                   `bson:"reload_wait_time" json:"reload_wait_time"`
 	ProxySSLInsecureSkipVerify        bool                                  `json:"proxy_ssl_insecure_skip_verify"`
 	ProxyDefaultTimeout               int                                   `json:"proxy_default_timeout"`
+	LogLevel                          string                                `json:"log_level"`
 }
 
 type CertData struct {

--- a/main.go
+++ b/main.go
@@ -779,6 +779,24 @@ func initialiseSystem(arguments map[string]interface{}) error {
 		afterConfSetup(&config.Global)
 	}
 
+	if os.Getenv("TYK_LOGLEVEL") == "" && arguments["--debug"] == false {
+		level := strings.ToLower(config.Global.LogLevel)
+		switch level {
+		case "", "info":
+			// default, do nothing
+		case "error":
+			log.Level = logrus.ErrorLevel
+		case "warn":
+			log.Level = logrus.WarnLevel
+		case "debug":
+			log.Level = logrus.DebugLevel
+		default:
+			log.WithFields(logrus.Fields{
+				"prefix": "main",
+			}).Fatalf("Invalid log level %q specified in config, must be error, warn, debug or info. ", level)
+		}
+	}
+
 	if config.Global.Storage.Type != "redis" {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",


### PR DESCRIPTION
- log_level field added to Tyk configuration. 

- If TYK_LOGLEVEL enviroment variable is unset and no --debug flag is used when executing Tyk then the configuration file will be searched for an alternative to the default info level logging output. The log_level value can be error, warn or debug; Info is redundant as that is the default logger output set in log/log.go. Fixes #1182

