### PR TITLE
PYTHONPATH enhancement/fix

### DIFF
--- a/config.go
+++ b/config.go
@@ -143,6 +143,7 @@ type ServiceDiscoveryConf struct {
 type CoProcessConfig struct {
 	EnableCoProcess     bool   `json:"enable_coprocess"`
 	CoProcessGRPCServer string `json:"coprocess_grpc_server"`
+	PythonPathPrefix string `json:"python_path_prefix"`
 }
 
 // Config is the configuration object used by tyk to set up various parameters.

--- a/coprocess_bundle.go
+++ b/coprocess_bundle.go
@@ -22,12 +22,6 @@ import (
 	"strings"
 )
 
-var tykBundlePath string
-
-func init() {
-	tykBundlePath = filepath.Join(config.MiddlewarePath, "middleware/bundles")
-}
-
 // Bundle is the basic bundle data structure, it holds the bundle name and the data.
 type Bundle struct {
 	Name     string
@@ -295,6 +289,7 @@ func loadBundle(spec *APISpec) {
 		return
 	}
 
+	tykBundlePath := filepath.Join(config.MiddlewarePath, "bundles")
 	// Skip if the bundle destination path already exists.
 	bundlePath := strings.Join([]string{spec.APIID, spec.CustomMiddlewareBundle}, "-")
 	destPath := filepath.Join(tykBundlePath, bundlePath)

--- a/coprocess_python.go
+++ b/coprocess_python.go
@@ -168,7 +168,6 @@ import "C"
 import (
 	"errors"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -280,11 +279,12 @@ func PythonSetEnv(pythonPaths ...string) {
 
 // getBundlePaths will return an array of the available bundle directories:
 func getBundlePaths() []string {
+	bundlePath := filepath.Join(config.MiddlewarePath, "bundles")
 	directories := make([]string, 0)
-	bundles, _ := ioutil.ReadDir(tykBundlePath)
+	bundles, _ := ioutil.ReadDir(bundlePath)
 	for _, f := range bundles {
 		if f.IsDir() {
-			fullPath := filepath.Join(tykBundlePath, f.Name())
+			fullPath := filepath.Join(bundlePath, f.Name())
 			directories = append(directories, fullPath)
 		}
 	}
@@ -292,7 +292,7 @@ func getBundlePaths() []string {
 }
 
 func NewCoProcessDispatcher() (dispatcher coprocess.Dispatcher, err error) {
-	workDir, _ := os.Getwd()
+	workDir := config.CoProcessOptions.PythonPathPrefix
 
 	dispatcherPath := filepath.Join(workDir, "coprocess", "python")
 	middlewarePath := filepath.Join(workDir, "middleware", "python")

--- a/plugins.go
+++ b/plugins.go
@@ -163,7 +163,7 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 	// Run the middleware
 	middlewareClassname := d.MiddlewareClassName
 
-    vm := d.Spec.JSVM.VM.Copy()
+	vm := d.Spec.JSVM.VM.Copy()
 	vm.Interrupt = make(chan func(), 1)
 	log.WithFields(logrus.Fields{
 		"prefix": "jsvm",
@@ -314,6 +314,7 @@ func (j *JSVM) Init() {
 
 // LoadJSPaths will load JS classes and functionality in to the VM by file
 func (j *JSVM) LoadJSPaths(paths []string, pathPrefix string) {
+	tykBundlePath := filepath.Join(config.MiddlewarePath, "bundles")
 	for _, mwPath := range paths {
 		if pathPrefix != "" {
 			mwPath = filepath.Join(tykBundlePath, pathPrefix, mwPath)
@@ -359,7 +360,7 @@ func (j *JSVM) LoadTykJSApi() {
 	})
 
 	j.VM.Set("rawlog", func(call otto.FunctionCall) otto.Value {
-        rawLog.Print(call.Argument(0).String() + "\n")
+		rawLog.Print(call.Argument(0).String() + "\n")
 		return otto.Value{}
 	})
 


### PR DESCRIPTION
This is related to #1221. I'm open to discuss about this, the main thing here is to get rid of  `os.Getwd`.
To test this:
- Create a Python plugin and serve it as specified in [this guide](https://tyk.io/docs/customise-tyk/plugins/rich-plugins/python/custom-auth-python-tutorial/).
- Use the following configuration:
```json
{
    "enable_coprocess": true,
    "python_path_prefix": "/opt/tyk-gateway"
  }
```
- Run `tyk-python` or the Tyk binary from a different working directory, like:
```
cd /tmp
/opt/tyk-gateway/tyk-python
```
- The PYTHONPATH log line should include the `python_path_prefix`.