### PR TITLE
user: move Policy here

### DIFF
--- a/gateway_test.go
+++ b/gateway_test.go
@@ -168,7 +168,7 @@ func TestMain(m *testing.M) {
 		// racy way like the policies and api specs maps.
 		for {
 			policiesMu.Lock()
-			policiesByID["_"] = Policy{}
+			policiesByID["_"] = user.Policy{}
 			delete(policiesByID, "_")
 			policiesMu.Unlock()
 			apisMu.Lock()

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/TykTechnologies/tyk/config"
 	logger "github.com/TykTechnologies/tyk/log"
 	"github.com/TykTechnologies/tyk/storage"
+	"github.com/TykTechnologies/tyk/user"
 )
 
 var (
@@ -60,7 +61,7 @@ var (
 	keyGen DefaultKeyGenerator
 
 	policiesMu   sync.RWMutex
-	policiesByID = map[string]Policy{}
+	policiesByID = map[string]user.Policy{}
 
 	mainRouter    *mux.Router
 	controlRouter *mux.Router
@@ -227,7 +228,7 @@ func getAPISpecs() []*APISpec {
 }
 
 func getPolicies() {
-	var pols map[string]Policy
+	var pols map[string]user.Policy
 	log.WithFields(logrus.Fields{
 		"prefix": "main",
 	}).Info("Loading policies")

--- a/mw_jwt_test.go
+++ b/mw_jwt_test.go
@@ -494,7 +494,7 @@ func TestJWTSessionRSAWithRawSourceOnWithClientID(t *testing.T) {
 	spec.SessionManager.UpdateSession(tokenID, session, 60)
 
 	policiesMu.Lock()
-	policiesByID["987654321"] = Policy{
+	policiesByID["987654321"] = user.Policy{
 		ID:               "987654321",
 		OrgID:            "default",
 		Rate:             1000.0,
@@ -546,7 +546,7 @@ func TestJWTSessionRSAWithRawSource(t *testing.T) {
 	spec.JWTSigningMethod = "rsa"
 
 	policiesMu.Lock()
-	policiesByID["987654321"] = Policy{
+	policiesByID["987654321"] = user.Policy{
 		ID:               "987654321",
 		OrgID:            "default",
 		Rate:             1000.0,
@@ -596,7 +596,7 @@ func TestJWTSessionRSAWithRawSourceInvalidPolicyID(t *testing.T) {
 	spec.JWTSigningMethod = "rsa"
 
 	policiesMu.Lock()
-	policiesByID["987654321"] = Policy{
+	policiesByID["987654321"] = user.Policy{
 		ID:               "987654321",
 		OrgID:            "default",
 		Rate:             1000.0,
@@ -646,7 +646,7 @@ func TestJWTSessionRSAWithJWK(t *testing.T) {
 	spec.JWTSigningMethod = "rsa"
 
 	policiesMu.Lock()
-	policiesByID["987654321"] = Policy{
+	policiesByID["987654321"] = user.Policy{
 		ID:               "987654321",
 		OrgID:            "default",
 		Rate:             1000.0,

--- a/oauth_manager_test.go
+++ b/oauth_manager_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/justinas/alice"
 
 	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/user"
 )
 
 const (
@@ -75,7 +76,7 @@ func getOAuthChain(spec *APISpec, muxer *mux.Router) {
 	manager := addOAuthHandlers(spec, muxer)
 
 	// add a test client
-	testPolicy := Policy{}
+	testPolicy := user.Policy{}
 	testPolicy.Rate = 100
 	testPolicy.Per = 1
 	testPolicy.QuotaMax = -1

--- a/policy.go
+++ b/policy.go
@@ -7,37 +7,11 @@ import (
 	"os"
 	"time"
 
-	"gopkg.in/mgo.v2/bson"
-
 	"github.com/Sirupsen/logrus"
 
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/user"
 )
-
-type Policy struct {
-	MID              bson.ObjectId                    `bson:"_id,omitempty" json:"_id"`
-	ID               string                           `bson:"id,omitempty" json:"id"`
-	OrgID            string                           `bson:"org_id" json:"org_id"`
-	Rate             float64                          `bson:"rate" json:"rate"`
-	Per              float64                          `bson:"per" json:"per"`
-	QuotaMax         int64                            `bson:"quota_max" json:"quota_max"`
-	QuotaRenewalRate int64                            `bson:"quota_renewal_rate" json:"quota_renewal_rate"`
-	AccessRights     map[string]user.AccessDefinition `bson:"access_rights" json:"access_rights"`
-	HMACEnabled      bool                             `bson:"hmac_enabled" json:"hmac_enabled"`
-	Active           bool                             `bson:"active" json:"active"`
-	IsInactive       bool                             `bson:"is_inactive" json:"is_inactive"`
-	Tags             []string                         `bson:"tags" json:"tags"`
-	KeyExpiresIn     int64                            `bson:"key_expires_in" json:"key_expires_in"`
-	Partitions       PolicyPartitions                 `bson:"partitions" json:"partitions"`
-	LastUpdated      string                           `bson:"last_updated" json:"last_updated"`
-}
-
-type PolicyPartitions struct {
-	Quota     bool `bson:"quota" json:"quota"`
-	RateLimit bool `bson:"rate_limit" json:"rate_limit"`
-	Acl       bool `bson:"acl" json:"acl"`
-}
 
 type DBAccessDefinition struct {
 	APIName     string            `json:"apiname"`
@@ -56,11 +30,11 @@ func (d *DBAccessDefinition) ToRegularAD() user.AccessDefinition {
 }
 
 type DBPolicy struct {
-	Policy
+	user.Policy
 	AccessRights map[string]DBAccessDefinition `bson:"access_rights" json:"access_rights"`
 }
 
-func (d *DBPolicy) ToRegularPolicy() Policy {
+func (d *DBPolicy) ToRegularPolicy() user.Policy {
 	policy := d.Policy
 	policy.AccessRights = make(map[string]user.AccessDefinition)
 
@@ -70,7 +44,7 @@ func (d *DBPolicy) ToRegularPolicy() Policy {
 	return policy
 }
 
-func LoadPoliciesFromFile(filePath string) map[string]Policy {
+func LoadPoliciesFromFile(filePath string) map[string]user.Policy {
 	f, err := os.Open(filePath)
 	if err != nil {
 		log.WithFields(logrus.Fields{
@@ -80,7 +54,7 @@ func LoadPoliciesFromFile(filePath string) map[string]Policy {
 	}
 	defer f.Close()
 
-	var policies map[string]Policy
+	var policies map[string]user.Policy
 	if err := json.NewDecoder(f).Decode(&policies); err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "policy",
@@ -90,7 +64,7 @@ func LoadPoliciesFromFile(filePath string) map[string]Policy {
 }
 
 // LoadPoliciesFromDashboard will connect and download Policies from a Tyk Dashboard instance.
-func LoadPoliciesFromDashboard(endpoint, secret string, allowExplicit bool) map[string]Policy {
+func LoadPoliciesFromDashboard(endpoint, secret string, allowExplicit bool) map[string]user.Policy {
 
 	// Get the definitions
 	newRequest, err := http.NewRequest("GET", endpoint, nil)
@@ -144,7 +118,7 @@ func LoadPoliciesFromDashboard(endpoint, secret string, allowExplicit bool) map[
 	ServiceNonce = list.Nonce
 	log.Debug("Loading Policies Finished: Nonce Set: ", ServiceNonce)
 
-	policies := make(map[string]Policy, len(list.Message))
+	policies := make(map[string]user.Policy, len(list.Message))
 
 	log.WithFields(logrus.Fields{
 		"prefix": "policy",
@@ -169,8 +143,8 @@ func LoadPoliciesFromDashboard(endpoint, secret string, allowExplicit bool) map[
 	return policies
 }
 
-func LoadPoliciesFromRPC(orgId string) map[string]Policy {
-	var dbPolicyList []Policy
+func LoadPoliciesFromRPC(orgId string) map[string]user.Policy {
+	var dbPolicyList []user.Policy
 
 	store := &RPCStorageHandler{UserKey: config.Global.SlaveOptions.APIKey, Address: config.Global.SlaveOptions.ConnectionString}
 	store.Connect()
@@ -186,7 +160,7 @@ func LoadPoliciesFromRPC(orgId string) map[string]Policy {
 		return nil
 	}
 
-	policies := make(map[string]Policy, len(dbPolicyList))
+	policies := make(map[string]user.Policy, len(dbPolicyList))
 
 	for _, p := range dbPolicyList {
 		p.ID = p.MID.Hex()

--- a/policy_test.go
+++ b/policy_test.go
@@ -44,42 +44,42 @@ func (dummySessionManager) UpdateSession(key string, sess *user.SessionState, tt
 
 func TestApplyPolicies(t *testing.T) {
 	policiesMu.RLock()
-	policiesByID = map[string]Policy{
+	policiesByID = map[string]user.Policy{
 		"nonpart1": {},
 		"nonpart2": {},
 		"difforg":  {OrgID: "different"},
 		"tags1": {
-			Partitions: PolicyPartitions{Quota: true},
+			Partitions: user.PolicyPartitions{Quota: true},
 			Tags:       []string{"tagA"},
 		},
 		"tags2": {
-			Partitions: PolicyPartitions{RateLimit: true},
+			Partitions: user.PolicyPartitions{RateLimit: true},
 			Tags:       []string{"tagX", "tagY"},
 		},
 		"inactive1": {
-			Partitions: PolicyPartitions{RateLimit: true},
+			Partitions: user.PolicyPartitions{RateLimit: true},
 			IsInactive: true,
 		},
 		"inactive2": {
-			Partitions: PolicyPartitions{Quota: true},
+			Partitions: user.PolicyPartitions{Quota: true},
 			IsInactive: true,
 		},
 		"quota1": {
-			Partitions: PolicyPartitions{Quota: true},
+			Partitions: user.PolicyPartitions{Quota: true},
 			QuotaMax:   2,
 		},
-		"quota2": {Partitions: PolicyPartitions{Quota: true}},
+		"quota2": {Partitions: user.PolicyPartitions{Quota: true}},
 		"rate1": {
-			Partitions: PolicyPartitions{RateLimit: true},
+			Partitions: user.PolicyPartitions{RateLimit: true},
 			Rate:       3,
 		},
-		"rate2": {Partitions: PolicyPartitions{RateLimit: true}},
+		"rate2": {Partitions: user.PolicyPartitions{RateLimit: true}},
 		"acl1": {
-			Partitions:   PolicyPartitions{Acl: true},
+			Partitions:   user.PolicyPartitions{Acl: true},
 			AccessRights: map[string]user.AccessDefinition{"a": {}},
 		},
 		"acl2": {
-			Partitions:   PolicyPartitions{Acl: true},
+			Partitions:   user.PolicyPartitions{Acl: true},
 			AccessRights: map[string]user.AccessDefinition{"b": {}},
 		},
 	}

--- a/user/policy.go
+++ b/user/policy.go
@@ -1,0 +1,27 @@
+package user
+
+import "gopkg.in/mgo.v2/bson"
+
+type Policy struct {
+	MID              bson.ObjectId               `bson:"_id,omitempty" json:"_id"`
+	ID               string                      `bson:"id,omitempty" json:"id"`
+	OrgID            string                      `bson:"org_id" json:"org_id"`
+	Rate             float64                     `bson:"rate" json:"rate"`
+	Per              float64                     `bson:"per" json:"per"`
+	QuotaMax         int64                       `bson:"quota_max" json:"quota_max"`
+	QuotaRenewalRate int64                       `bson:"quota_renewal_rate" json:"quota_renewal_rate"`
+	AccessRights     map[string]AccessDefinition `bson:"access_rights" json:"access_rights"`
+	HMACEnabled      bool                        `bson:"hmac_enabled" json:"hmac_enabled"`
+	Active           bool                        `bson:"active" json:"active"`
+	IsInactive       bool                        `bson:"is_inactive" json:"is_inactive"`
+	Tags             []string                    `bson:"tags" json:"tags"`
+	KeyExpiresIn     int64                       `bson:"key_expires_in" json:"key_expires_in"`
+	Partitions       PolicyPartitions            `bson:"partitions" json:"partitions"`
+	LastUpdated      string                      `bson:"last_updated" json:"last_updated"`
+}
+
+type PolicyPartitions struct {
+	Quota     bool `bson:"quota" json:"quota"`
+	RateLimit bool `bson:"rate_limit" json:"rate_limit"`
+	Acl       bool `bson:"acl" json:"acl"`
+}


### PR DESCRIPTION
So that it can be reused by other components and packages easier. It
also belongs next to AccessDefinition.