### PR TITLE
api: ignore status when decoding lists

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -239,9 +239,7 @@ func (a APIDefinitionLoader) FromDashboardService(endpoint, secret string) []*AP
 	}
 
 	// Extract tagged APIs#
-
 	var list struct {
-		Status  string
 		Message []struct {
 			ApiDefinition *apidef.APIDefinition `bson:"api_definition" json:"api_definition"`
 		}

--- a/policy.go
+++ b/policy.go
@@ -103,7 +103,6 @@ func LoadPoliciesFromDashboard(endpoint, secret string, allowExplicit bool) map[
 
 	// Extract Policies
 	var list struct {
-		Status  string
 		Message []DBPolicy
 		Nonce   string
 	}


### PR DESCRIPTION
We don't ever use that field, so there is no need to decode it.