### PR TITLE
test: re-add WriteDefault in TestMain

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -295,17 +295,15 @@ func WriteConf(path string, conf *Config) error {
 
 // writeDefault will set conf to the default config and write it to disk
 // in path, if the path is non-empty.
-func writeDefault(path string, conf *Config) {
+func WriteDefault(path string, conf *Config) error {
 	*conf = Default
 	if err := envconfig.Process(envPrefix, conf); err != nil {
-		log.Error("Failed to process environment variables: ", err)
+		return err
 	}
 	if path == "" {
-		return
+		return nil
 	}
-	if err := WriteConf(path, conf); err != nil {
-		log.Error("Problem saving the default configuration: ", err)
-	}
+	return WriteConf(path, conf)
 }
 
 // Load will load a configuration file, trying each of the paths given
@@ -333,7 +331,9 @@ func Load(paths []string, conf *Config) error {
 	if r == nil {
 		path := paths[0]
 		log.Warnf("No config file found, writing default to %s", path)
-		writeDefault(path, conf)
+		if err := WriteDefault(path, conf); err != nil {
+			return err
+		}
 		log.Info("Loading default configuration...")
 		return Load([]string{path}, conf)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -12,13 +12,17 @@ func TestWriteDefaultConf(t *testing.T) {
 	conf := &Config{}
 	os.Unsetenv("TYK_GW_LISTENPORT")
 	defer os.Unsetenv("TYK_GW_LISTENPORT")
-	writeDefault("", conf)
+	if err := WriteDefault("", conf); err != nil {
+		t.Fatal(err)
+	}
 	if conf.ListenPort != 8080 {
 		t.Fatalf("Expected ListenPort to be set to its default")
 	}
 	*conf = Config{}
 	os.Setenv("TYK_GW_LISTENPORT", "9090")
-	writeDefault("", conf)
+	if err := WriteDefault("", conf); err != nil {
+		t.Fatal(err)
+	}
 	if conf.ListenPort != 9090 {
 		t.Fatalf("Expected ListenPort to be set to 9090")
 	}
@@ -34,7 +38,9 @@ func TestConfigFiles(t *testing.T) {
 	path1 := filepath.Join(dir, "tyk1.conf")
 	path2 := filepath.Join(dir, "tyk2.conf")
 
-	writeDefault(path1, conf)
+	if err := WriteDefault(path1, conf); err != nil {
+		t.Fatal(err)
+	}
 	if conf.ListenPort != 8080 {
 		t.Fatalf("Expected ListenPort to be set to its default")
 	}

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -135,7 +135,9 @@ func TestMain(m *testing.M) {
 	go func() {
 		panic(testServer.ListenAndServe())
 	}()
-	config.Global = config.Default
+	if err := config.WriteDefault("", &config.Global); err != nil {
+		panic(err)
+	}
 	config.Global.Storage.Database = 1
 	if err := emptyRedis(); err != nil {
 		panic(err)


### PR DESCRIPTION
In order to apply envconfig on top of the default config, which is
useful for Buddy.