### PR TITLE
Do not panic on user generated regexp errors

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -392,7 +392,7 @@ func (a APIDefinitionLoader) getPathSpecs(apiVersionDef apidef.VersionInfo) ([]U
 func (a APIDefinitionLoader) generateRegex(stringSpec string, newSpec *URLSpec, specType URLStatus) {
 	apiLangIDsRegex := regexp.MustCompile(`{(.*?)}`)
 	asRegexStr := apiLangIDsRegex.ReplaceAllString(stringSpec, `(.*?)`)
-	asRegex := regexp.MustCompile(asRegexStr)
+	asRegex, _ := regexp.Compile(asRegexStr)
 	newSpec.Status = specType
 	newSpec.Spec = asRegex
 }


### PR DESCRIPTION
We should be protected over user input errors.

2.3 already behave like this, and MustCompile for this row was made by mistake