### PR TITLE
Fix coprocess test

### DIFF
--- a/coprocess_helpers.go
+++ b/coprocess_helpers.go
@@ -83,7 +83,7 @@ func TykSessionState(session *coprocess.SessionState) *user.SessionState {
 		ApplyPolicyID:           session.ApplyPolicyId,
 		ApplyPolicies:           session.ApplyPolicies,
 		DataExpires:             session.DataExpires,
-		Metadata:                metadata,
+		MetaData:                metadata,
 		Monitor:                 monitor,
 		EnableDetailedRecording: session.EnableDetailedRecording,
 		Tags:                session.Tags,


### PR DESCRIPTION
This file runs only with `coprocess` tag, so I missed the typo.

Issue here is that Coprocess and UserSession have different field naming: MetaData vs Metadata