### PR TITLE
Fix connection leak: make HTTP transport API spec property

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -135,6 +135,7 @@ type APISpec struct {
 	LastGoodHostList         *apidef.HostList
 	HasRun                   bool
 	ServiceRefreshInProgress bool
+	HTTPTransport            http.RoundTripper
 }
 
 // APIDefinitionLoader will load an Api definition from a storage

--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -436,8 +436,10 @@ func httpTransport(timeOut int, rw http.ResponseWriter, req *http.Request, p *Re
 
 func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Request, withCache bool) *http.Response {
 	// 1. Check if timeouts are set for this endpoint
-	_, timeout := p.CheckHardTimeoutEnforced(p.TykAPISpec, req)
-	transport := httpTransport(timeout, rw, req, p)
+	if p.TykAPISpec.HTTPTransport == nil {
+		_, timeout := p.CheckHardTimeoutEnforced(p.TykAPISpec, req)
+		p.TykAPISpec.HTTPTransport = httpTransport(timeout, rw, req, p)
+	}
 
 	ctx := req.Context()
 	if cn, ok := rw.(http.CloseNotifier); ok {
@@ -525,14 +527,14 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 			p.ErrorHandler.HandleError(rw, logreq, "Service temporarily unnavailable.", 503)
 			return nil
 		}
-		res, err = transport.RoundTrip(outreq)
+		res, err = p.TykAPISpec.HTTPTransport.RoundTrip(outreq)
 		if err != nil || res.StatusCode == 500 {
 			breakerConf.CB.Fail()
 		} else {
 			breakerConf.CB.Success()
 		}
 	} else {
-		res, err = transport.RoundTrip(outreq)
+		res, err = p.TykAPISpec.HTTPTransport.RoundTrip(outreq)
 	}
 
 	if err != nil {


### PR DESCRIPTION
Right now Transport is created for each requests, which means that
connection pooling is not used and on each request it creates new
connection to the upstream server.

This differs from 2.3 behavior, which had global Transport for all
APIs. During the 2.4 refactor it was changed to the behavior described
above.

This change introduces transport caching, so it gets re-used between API
calls. In addition, this is better than 2.3 approach, because each API
can have different transport settings and timeouts, and now each API
gets own transport.