### PR TITLE
Added strip auth option and middleware

### DIFF
--- a/api_loader.go
+++ b/api_loader.go
@@ -9,13 +9,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/TykTechnologies/logrus"
-	"github.com/TykTechnologies/tyk/coprocess"
-	"github.com/TykTechnologies/tykcommon"
 	"github.com/gorilla/context"
 	"github.com/gorilla/mux"
 	"github.com/justinas/alice"
 	"github.com/streamrail/concurrent-map"
+
+	"github.com/TykTechnologies/logrus"
+	"github.com/TykTechnologies/tyk/coprocess"
+	"github.com/TykTechnologies/tykcommon"
 )
 
 type ChainObject struct {
@@ -506,6 +507,7 @@ func processSpec(referenceSpec *APISpec,
 		}
 
 		var baseChainArray_PostAuth = []alice.Constructor{}
+		AppendMiddleware(&baseChainArray_PostAuth, &MWStripAuthData{tykMiddleware}, tykMiddleware)
 		AppendMiddleware(&baseChainArray_PostAuth, &KeyExpired{tykMiddleware}, tykMiddleware)
 		AppendMiddleware(&baseChainArray_PostAuth, &AccessRightsCheck{tykMiddleware}, tykMiddleware)
 		AppendMiddleware(&baseChainArray_PostAuth, &RateLimitAndQuotaCheck{tykMiddleware}, tykMiddleware)
@@ -602,7 +604,7 @@ func loadApps(APISpecs *[]*APISpec, Muxer *mux.Router) {
 		}).Info("API hostname set: ", hostname)
 	}
 
-    ListenPathMap = cmap.New()
+	ListenPathMap = cmap.New()
 	// load the APi defs
 	log.WithFields(logrus.Fields{
 		"prefix": "main",

--- a/mw_strip_auth.go
+++ b/mw_strip_auth.go
@@ -36,7 +36,7 @@ func (a *MWStripAuthData) IsEnabledForSpec() bool {
 func (m *MWStripAuthData) StripAuth(r *http.Request, spec *APISpec) {
 	if spec.APIDefinition.Auth.UseParam {
 		// Remove the query string value
-		copy, err := url.Parse(r.URL.String())
+		cp, err := url.Parse(r.URL.String())
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"path":   r.URL.Path,
@@ -46,14 +46,14 @@ func (m *MWStripAuthData) StripAuth(r *http.Request, spec *APISpec) {
 			return
 		}
 
-		q := copy.Query()
+		q := cp.Query()
 		n := spec.APIDefinition.Auth.ParamName
 		if n == "" {
 			n = spec.APIDefinition.Auth.AuthHeaderName
 		}
 		q.Del(n)
-		copy.RawQuery = q.Encode()
-		r.URL, err = r.URL.Parse(copy.String())
+		cp.RawQuery = q.Encode()
+		r.URL, err = r.URL.Parse(cp.String())
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"path":   r.URL.Path,

--- a/mw_strip_auth.go
+++ b/mw_strip_auth.go
@@ -27,10 +27,7 @@ func (m *MWStripAuthData) GetConfig() (interface{}, error) {
 }
 
 func (a *MWStripAuthData) IsEnabledForSpec() bool {
-	if a.Spec.StripAuthData {
-		return true
-	}
-	return false
+	return a.Spec.StripAuthData
 }
 
 func (m *MWStripAuthData) StripAuth(r *http.Request, spec *APISpec) {

--- a/mw_strip_auth.go
+++ b/mw_strip_auth.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/TykTechnologies/logrus"
+)
+
+type MWStripAuthData struct {
+	*TykMiddleware
+}
+
+type MWStripAuthDataConfig struct{}
+
+// New lets you do any initialisations for the object can be done here
+func (m *MWStripAuthData) New() {}
+
+func (mw *MWStripAuthData) GetName() string {
+	return "MWStripAuthData"
+}
+
+// GetConfig retrieves the configuration from the API config - we user mapstructure for this for simplicity
+func (m *MWStripAuthData) GetConfig() (interface{}, error) {
+	var thisModuleConfig MiddlewareContextVarsConfig
+	return thisModuleConfig, nil
+}
+
+func (a *MWStripAuthData) IsEnabledForSpec() bool {
+	if a.Spec.StripAuthData {
+		return true
+	}
+	return false
+}
+
+func (m *MWStripAuthData) StripAuth(r *http.Request, spec *APISpec) {
+	if spec.APIDefinition.Auth.UseParam {
+		// Remove the query string value
+		copy, err := url.Parse(r.URL.String())
+		if err != nil {
+			log.WithFields(logrus.Fields{
+				"path":   r.URL.Path,
+				"origin": GetIPFromRequest(r),
+				"key":    "",
+			}).Error("Failed to copy URL to strip auth: ", err)
+			return
+		}
+
+		q := copy.Query()
+		n := spec.APIDefinition.Auth.ParamName
+		if n == "" {
+			n = spec.APIDefinition.Auth.AuthHeaderName
+		}
+		q.Del(n)
+		copy.RawQuery = q.Encode()
+		r.URL, err = r.URL.Parse(copy.String())
+		if err != nil {
+			log.WithFields(logrus.Fields{
+				"path":   r.URL.Path,
+				"origin": GetIPFromRequest(r),
+				"key":    "",
+			}).Error("Failed to set new URL: ", err)
+			return
+		}
+	}
+
+	n := spec.APIDefinition.Auth.AuthHeaderName
+	if n == "" {
+		n = "Authorization"
+	}
+
+	key := r.Header.Get(n)
+	if key != "" {
+		r.Header.Del(n)
+	}
+}
+
+// ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
+func (m *MWStripAuthData) ProcessRequest(w http.ResponseWriter, r *http.Request, configuration interface{}) (error, int) {
+
+	if !m.Spec.StripAuthData {
+		return nil, 200
+	}
+
+	m.StripAuth(r, m.Spec)
+
+	return nil, 200
+}

--- a/mw_strip_auth_test.go
+++ b/mw_strip_auth_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+)
+
+var authedDef string = `
+  {
+		"name": "Tyk Auth Key Test",
+		"api_id": "99898",
+		"org_id": "default",
+        "use_keyless": false,
+		"definition": {
+			"location": "header",
+			"key": "version"
+		},
+		"auth": {
+			"auth_header_name": "token",
+            "use_param": true,
+            "param_name": "q_auth"
+		},
+		"version_data": {
+			"not_versioned": true,
+			"versions": {
+				"Default": {
+					"name": "Default",
+					"use_extended_paths": true,
+					"expires": "3000-01-02 15:04",
+					"paths": {
+						"ignored": [],
+						"white_list": [],
+						"black_list": []
+					}
+				}
+			}
+		},
+		"proxy": {
+			"listen_path": "/auth_key_test/",
+			"target_url": "http://example.com/",
+			"strip_listen_path": true
+		}
+	}`
+
+func TestStripAuth(t *testing.T) {
+	spec := setUp(authedDef)
+	mw := MWStripAuthData{}
+
+	r, _ := http.NewRequest("GET", "http://example.com/?q_auth=foo&bar=baz", nil)
+	r.Header.Add("token", "bar")
+	mw.StripAuth(r, spec)
+
+	if r.Header.Get("token") != "" {
+		t.Fatal("request still had auth header")
+	}
+
+	if r.URL.Query().Get("q_name") != "" {
+		t.Fatal("request still had auth query string")
+	}
+
+	if r.URL.String() != "http://example.com/?bar=baz" {
+		t.Fatalf("URL is unexpected: %v\n", r.URL.String())
+	}
+}

--- a/vendor/github.com/TykTechnologies/tykcommon/api_definitions.go
+++ b/vendor/github.com/TykTechnologies/tykcommon/api_definitions.go
@@ -2,6 +2,7 @@ package tykcommon
 
 import (
 	"encoding/base64"
+
 	"github.com/lonelycode/osin"
 	"gopkg.in/mgo.v2/bson"
 )
@@ -32,13 +33,13 @@ const (
 
 	OttoDriver   MiddlewareDriver = "otto"
 	PythonDriver MiddlewareDriver = "python"
-	LuaDriver MiddlewareDriver = "lua"
-	GrpcDriver MiddlewareDriver = "grpc"
+	LuaDriver    MiddlewareDriver = "lua"
+	GrpcDriver   MiddlewareDriver = "grpc"
 
-	BodySource IdExtractorSource = "body"
-	HeaderSource IdExtractorSource = "header"
+	BodySource        IdExtractorSource = "body"
+	HeaderSource      IdExtractorSource = "header"
 	QuerystringSource IdExtractorSource = "querystring"
-	FormSource IdExtractorSource = "form"
+	FormSource        IdExtractorSource = "form"
 
 	ValueExtractor IdExtractorType = "value"
 	XPathExtractor IdExtractorType = "xpath"
@@ -94,8 +95,8 @@ type HardTimeoutMeta struct {
 }
 
 type TrackEndpointMeta struct {
-	Path    string `bson:"path" json:"path"`
-	Method  string `bson:"method" json:"method"`
+	Path   string `bson:"path" json:"path"`
+	Method string `bson:"method" json:"method"`
 }
 
 type RequestSizeMeta struct {
@@ -149,8 +150,8 @@ type ExtendedPathsSet struct {
 	Virtual                 []VirtualMeta         `bson:"virtual" json:"virtual,omitempty"`
 	SizeLimit               []RequestSizeMeta     `bson:"size_limits" json:"size_limits,omitempty"`
 	MethodTransforms        []MethodTransformMeta `bson:"method_transforms" json:"method_transforms,omitempty"`
-	TrackEndpoints          []TrackEndpointMeta `bson:"track_endpoints" json:"track_endpoints,omitempty"`
-	DoNotTrackEndpoints 	[]TrackEndpointMeta `bson:"do_not_track_endpoints" json:"do_not_track_endpoints,omitempty"`
+	TrackEndpoints          []TrackEndpointMeta   `bson:"track_endpoints" json:"track_endpoints,omitempty"`
+	DoNotTrackEndpoints     []TrackEndpointMeta   `bson:"do_not_track_endpoints" json:"do_not_track_endpoints,omitempty"`
 }
 
 type VersionInfo struct {
@@ -197,10 +198,10 @@ type MiddlewareDefinition struct {
 }
 
 type MiddlewareIdExtractor struct {
-	ExtractFrom	IdExtractorSource	`bson:"extract_from" json:"extract_from"`
-	ExtractWith IdExtractorType	`bson:"extract_with" json:"extract_with"`
-	ExtractorConfig map[string]interface{}	`bson:"extractor_config" json:"extractor_config"`
-	Extractor interface{}	`bson:"-" json:"-"`
+	ExtractFrom     IdExtractorSource      `bson:"extract_from" json:"extract_from"`
+	ExtractWith     IdExtractorType        `bson:"extract_with" json:"extract_with"`
+	ExtractorConfig map[string]interface{} `bson:"extractor_config" json:"extractor_config"`
+	Extractor       interface{}            `bson:"-" json:"-"`
 }
 
 type MiddlewareSection struct {
@@ -210,7 +211,7 @@ type MiddlewareSection struct {
 	AuthCheck   MiddlewareDefinition   `bson:"auth_check" json:"auth_check"`
 	Response    []MiddlewareDefinition `bson:"response" json:"response"`
 	Driver      MiddlewareDriver       `bson:"driver" json:"driver"`
-	IdExtractor MiddlewareIdExtractor	 `bson:"id_extractor" json:"id_extractor"`
+	IdExtractor MiddlewareIdExtractor  `bson:"id_extractor" json:"id_extractor"`
 }
 
 type CacheOptions struct {
@@ -322,7 +323,7 @@ type APIDefinition struct {
 	DisableRateLimit          bool                   `bson:"disable_rate_limit" json:"disable_rate_limit"`
 	DisableQuota              bool                   `bson:"disable_quota" json:"disable_quota"`
 	CustomMiddleware          MiddlewareSection      `bson:"custom_middleware" json:"custom_middleware"`
-	CustomMiddlewareBundle 	string							 `bson:"custom_middleware_bundle" json:"custom_middleware_bundle"`
+	CustomMiddlewareBundle    string                 `bson:"custom_middleware_bundle" json:"custom_middleware_bundle"`
 	CacheOptions              CacheOptions           `bson:"cache_options" json:"cache_options"`
 	SessionLifetime           int64                  `bson:"session_lifetime" json:"session_lifetime"`
 	Active                    bool                   `bson:"active" json:"active"`
@@ -350,14 +351,15 @@ type APIDefinition struct {
 	DoNotTrack        bool                   `bson:"do_not_track" json:"do_not_track"`
 	Tags              []string               `bson:"tags" json:"tags"`
 	EnableContextVars bool                   `bson:"enable_context_vars" json:"enable_context_vars"`
+	StripAuthData     bool                   `bson:"strip_auth_data" json:"strip_auth_data"`
 	RawData           map[string]interface{} `bson:"raw_data,omitempty" json:"raw_data,omitempty"` // Not used in actual configuration, loaded by config for plugable arc
 }
 
 type BundleManifest struct {
-	FileList	[]string	`bson:"file_list" json:"file_list"`
-	CustomMiddleware MiddlewareSection	`bson:"custom_middleware" json:"custom_middleware"`
-	Checksum	string	`bson:"checksum" json:"checksum"`
-	Signature string	`bson:"signature" json:"signature"`
+	FileList         []string          `bson:"file_list" json:"file_list"`
+	CustomMiddleware MiddlewareSection `bson:"custom_middleware" json:"custom_middleware"`
+	Checksum         string            `bson:"checksum" json:"checksum"`
+	Signature        string            `bson:"signature" json:"signature"`
 }
 
 // Clean will URL encode map[string]struct variables for saving


### PR DESCRIPTION
Fixes #1273

Adds a new option to the API Definition (this PR modifies the vendored version, actual change to tykcommon to follow) called "strip_auth_data" to the root of the object.

Setting this to true will cause the middleware to:

- Check if there are query string params to remove (if enabled) and remove them
- Check if there is an auth header to remove, and remove it
- If no header name is enforced (e.g. Basic Auth, HMAC or OIDC all use the "Authorization" header), strip that name instead

