### PR TITLE
coprocess: fire AuthFailed event when using custom authentication middleware

### DIFF
--- a/coprocess.go
+++ b/coprocess.go
@@ -285,6 +285,8 @@ func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 	if m.Spec.EnableCoProcessAuth && m.HookType == coprocess.HookType_CustomKeyCheck {
 		// The CP middleware didn't setup a session:
 		if returnObject.Session == nil {
+			authHeaderValue := r.Header.Get(m.Spec.Auth.AuthHeaderName)
+			AuthFailed(m, r, authHeaderValue)
 			return errors.New("Key not authorised"), 403
 		}
 


### PR DESCRIPTION
Fixes #1279.

When the custom authentication middleware doesn't return a session object we already assume it's a bad auth (we return 403 by default), so this enhances the flow, allowing the user to setup event handlers on top of this.

It also assumes that the authentication header name is what the middleware is using to perform the authentication process.