### PR TITLE
main: fix hot restart regression in 2.4

### DIFF
--- a/main.go
+++ b/main.go
@@ -1025,8 +1025,8 @@ func main() {
 		}
 	}
 
-	l, _ := goagain.Listener(onFork)
-	controlListener, goAgainErr := goagain.Listener(onFork)
+	l, goAgainErr := goagain.Listener(onFork)
+	controlListener, _ := goagain.Listener(onFork)
 
 	if err := initialiseSystem(arguments); err != nil {
 		log.WithFields(logrus.Fields{
@@ -1164,9 +1164,6 @@ func start(arguments map[string]interface{}) {
 
 func generateListener(listenPort int) (net.Listener, error) {
 	listenAddress := config.Global.ListenAddress
-	if listenPort == 0 {
-		listenPort = config.Global.ListenPort
-	}
 
 	targetPort := fmt.Sprintf("%s:%d", listenAddress, listenPort)
 

--- a/main.go
+++ b/main.go
@@ -1011,9 +1011,30 @@ func main() {
 	}
 	NodeID = "solo-" + uuid.NewV4().String()
 
+	if err := initialiseSystem(arguments); err != nil {
+		log.WithFields(logrus.Fields{
+			"prefix": "main",
+		}).Fatalf("Error initialising system: %v", err)
+	}
+
 	amForked := false
 
+	var controlListener net.Listener
+
 	onFork := func() {
+		log.Warning("PREPARING TO FORK")
+
+		if controlListener != nil {
+			if err := controlListener.Close(); err != nil {
+				log.WithFields(logrus.Fields{
+					"prefix": "main",
+				}).Error("Control listen handler exit: ", err)
+			}
+			log.WithFields(logrus.Fields{
+				"prefix": "main",
+			}).Info("Control listen closed")
+		}
+
 		if config.Global.UseDBAppConfigs {
 			log.Info("Stopping heartbeat")
 			DashService.StopBeating()
@@ -1026,29 +1047,26 @@ func main() {
 	}
 
 	l, goAgainErr := goagain.Listener(onFork)
-	controlListener, _ := goagain.Listener(onFork)
 
-	if err := initialiseSystem(arguments); err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "main",
-		}).Fatalf("Error initialising system: %v", err)
+	if config.Global.ControlAPIPort > 0 {
+		var err error
+		if controlListener, err = generateListener(config.Global.ControlAPIPort); err != nil {
+			log.WithFields(logrus.Fields{
+				"prefix": "main",
+			}).Fatalf("Error starting control API listener: %s", err)
+		} else {
+			log.Info("Starting control API listener: ", controlListener, err, config.Global.ControlAPIPort)
+		}
 	}
+
 	start(arguments)
 
 	if goAgainErr != nil {
 		var err error
-		if l, err = generateListener(0); err != nil {
+		if l, err = generateListener(config.Global.ListenPort); err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "main",
 			}).Fatalf("Error starting listener: %s", err)
-		}
-
-		if config.Global.ControlAPIPort > 0 {
-			if controlListener, err = generateListener(config.Global.ControlAPIPort); err != nil {
-				log.WithFields(logrus.Fields{
-					"prefix": "main",
-				}).Fatalf("Error starting control API listener: %s", err)
-			}
 		}
 
 		listen(l, controlListener, goAgainErr)
@@ -1197,10 +1215,10 @@ func generateListener(listenPort int) (net.Listener, error) {
 		config.GetConfigForClient = getTLSConfigForClient(&config, listenPort)
 
 		return tls.Listen("tcp", targetPort, &config)
-
 	} else {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
+			"port":   targetPort,
 		}).Info("--> Standard listener (http)")
 		return net.Listen("tcp", targetPort)
 	}
@@ -1298,7 +1316,7 @@ func listen(l, controlListener net.Listener, err error) {
 				"prefix": "main",
 			}).Warning("HTTP Server Overrides detected, this could destabilise long-running http-requests")
 			s := &http.Server{
-				Addr:         ":" + targetPort,
+				Addr:         targetPort,
 				ReadTimeout:  time.Duration(readTimeout) * time.Second,
 				WriteTimeout: time.Duration(writeTimeout) * time.Second,
 				Handler:      mainHandler{},
@@ -1402,6 +1420,10 @@ func listen(l, controlListener net.Listener, err error) {
 
 			if !rpcEmergencyMode {
 				if controlListener != nil {
+					log.WithFields(logrus.Fields{
+						"prefix": "main",
+					}).Info("Control API listener started: ", controlListener, controlRouter)
+
 					go http.Serve(controlListener, controlRouter)
 				}
 			}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -37,10 +37,10 @@
 			"revisionTime": "2017-10-28T14:04:03Z"
 		},
 		{
-			"checksumSHA1": "RE/gJeawCK3Zl9U2GkoQhpxcb5M=",
+			"checksumSHA1": "HqPKaziJ4igBSUmO1i7W0cRkpVA=",
 			"path": "github.com/TykTechnologies/goagain",
-			"revision": "ad727fe0cb5f6c2843bd18436112acf95a399531",
-			"revisionTime": "2016-08-22T11:32:05Z"
+			"revision": "e23361255278b7e2dcdfe6d1407191725340fa00",
+			"revisionTime": "2017-11-17T14:56:08Z"
 		},
 		{
 			"checksumSHA1": "FEq3KG6Kgarh8P5XIUx3bH13zDM=",


### PR DESCRIPTION
In 26043b48, some changes were made to allow specifying a different
control API port.

However, this broke the SIGUSR2 hot restart in two ways. First, it added
a second goAgainErr, overwriting the one that we need to use to detect
that the fork happened. This meant that, when the child was forked, the
parent would never exit properly.

Second, it made it impossible for generateListener to use a port 0,
meaning to use a random port. This would result in both parent and child
trying to use the same port before the parent is killed, meaning that
the child would not be able to start up properly.

After these fixes, a hot restart with the default tyk.conf works again.
Writing a Go test for hot restarts is impossible though, so we will
write them separately as python end-to-end tests, covering all
possibilities of listen options combined with SIGUSR2.

Note that we will need further fixes to the goagain library once we
switch to Go 1.9, as it uses reflection and the struct it peeks at
changed in 1.9.

Fixes #1268.

*Before* submitting a pull request, please make sure the following is done...

1. Fork the repo and create your branch from the **latest** `master`.
2. If you've added code that should be tested, add tests!
3. If you've changed APIs, describe what needs to be updated in the documentation.
4. Ensure the test suite passes (`go test`).
5. Make sure your code lints (`go fmt && go vet`).