### PR TITLE
Fixed panic when loading spec with Domain on env without custom domain support

### DIFF
--- a/api_loader.go
+++ b/api_loader.go
@@ -585,6 +585,15 @@ func loadApps(specs []*APISpec, muxer *mux.Router) {
 	for i, spec := range specs {
 		go func(spec *APISpec, i int) {
 			subrouter := hostRouters[spec.Domain]
+			if subrouter == nil {
+				log.WithFields(logrus.Fields{
+					"prefix": "main",
+					"domain": spec.Domain,
+					"api_id": spec.APIID,
+				}).Warning("Trying to load API with Domain when custom domains are disabled.")
+				subrouter = muxer
+			}
+
 			chainObj := processSpec(spec, apisByListen, redisStore, redisOrgStore, healthStore, rpcAuthStore, rpcOrgStore, subrouter)
 			chainObj.Index = i
 			chainChannel <- chainObj

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -1182,3 +1182,28 @@ func TestMultiTargetProxy(t *testing.T) {
 		}
 	}
 }
+
+func TestCustomDomain(t *testing.T) {
+	t.Run("With custom domain support", func(t *testing.T) {
+		config.Global.EnableCustomDomains = true
+		defer func() {
+			config.Global.EnableCustomDomains = false
+		}()
+
+		buildAndLoadAPI(func(spec *APISpec) {
+			spec.Domain = "localhost"
+		},
+			func(spec *APISpec) {
+				spec.Domain = ""
+			})
+	})
+
+	t.Run("Without custom domain support", func(t *testing.T) {
+		buildAndLoadAPI(func(spec *APISpec) {
+			spec.Domain = "localhost"
+		},
+			func(spec *APISpec) {
+				spec.Domain = ""
+			})
+	})
+}


### PR DESCRIPTION
If Domain is non empty and enable_custom_domains is false, API router
becomes nil, and panics.

This was part of recent change to fix order of API loading. Restored
original behavior when default router picked as fallback.