### PR TITLE
new config var enable_key_logging added, request logging unified

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -260,6 +260,7 @@ type Config struct {
 	ProxyDefaultTimeout               int                                   `json:"proxy_default_timeout"`
 	LogLevel                          string                                `json:"log_level"`
 	Security                          SecurityConfig                        `json:"security"`
+	EnableKeyLogging                  bool                                  `json:"enable_key_logging"`
 }
 
 type CertData struct {

--- a/coprocess.go
+++ b/coprocess.go
@@ -252,11 +252,8 @@ func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 	// The CP middleware indicates this is a bad auth:
 	if returnObject.Request.ReturnOverrides.ResponseCode > 400 {
 
-		log.WithFields(logrus.Fields{
-			"path":   r.URL.Path,
-			"origin": requestIP(r),
-			"key":    token,
-		}).Info("Attempted access with invalid key.")
+		logEntry := getLogEntryForRequest(r, token, nil)
+		logEntry.Info("Attempted access with invalid key.")
 
 		// Fire Authfailed Event
 		AuthFailed(m, r, token)

--- a/coprocess_id_extractor.go
+++ b/coprocess_id_extractor.go
@@ -82,10 +82,8 @@ func (e *BaseExtractor) ExtractBody(r *http.Request) (bodyValue string, err erro
 
 // Error is a helper for logging the extractor errors. It always returns HTTP 400 (so we don't expose any details).
 func (e *BaseExtractor) Error(r *http.Request, err error, message string) (returnOverrides ReturnOverrides) {
-	log.WithFields(logrus.Fields{
-		"path":   r.URL.Path,
-		"origin": requestIP(r),
-	}).Info("Extractor error: ", message, ", ", err)
+	logEntry := getLogEntryForRequest(r, "", nil)
+	logEntry.Info("Extractor error: ", message, ", ", err)
 
 	return ReturnOverrides{
 		ResponseCode:  400,

--- a/lint/schema.go
+++ b/lint/schema.go
@@ -658,6 +658,9 @@ const confSchema = `{
 				}
 			}
 		}
+	},
+	"enable_key_logging": {
+		"type": "boolean"
 	}
 }
 }`

--- a/log_helpers.go
+++ b/log_helpers.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/Sirupsen/logrus"
+
+	"github.com/TykTechnologies/tyk/config"
+)
+
+func getLogEntryForRequest(r *http.Request, key string, data map[string]interface{}) *logrus.Entry {
+	// populate http request fields
+	fields := logrus.Fields{
+		"path":   r.URL.Path,
+		"origin": requestIP(r),
+	}
+	// add key to log if configured to do so
+	if key != "" && config.Global.EnableKeyLogging {
+		fields["key"] = key
+	}
+	// add to log additional fields if any passed
+	if data != nil && len(data) > 0 {
+		for key, val := range data {
+			fields[key] = val
+		}
+	}
+	return log.WithFields(fields)
+}

--- a/log_helpers.go
+++ b/log_helpers.go
@@ -8,6 +8,11 @@ import (
 	"github.com/TykTechnologies/tyk/config"
 )
 
+// identifies that field value was hidden before output to the log
+const (
+	logHiddenValue = "<hidden>"
+)
+
 func getLogEntryForRequest(r *http.Request, key string, data map[string]interface{}) *logrus.Entry {
 	// populate http request fields
 	fields := logrus.Fields{
@@ -15,8 +20,11 @@ func getLogEntryForRequest(r *http.Request, key string, data map[string]interfac
 		"origin": requestIP(r),
 	}
 	// add key to log if configured to do so
-	if key != "" && config.Global.EnableKeyLogging {
+	if key != "" {
 		fields["key"] = key
+		if !config.Global.EnableKeyLogging {
+			fields["key"] = logHiddenValue
+		}
 	}
 	// add to log additional fields if any passed
 	if data != nil && len(data) > 0 {

--- a/log_helpers_test.go
+++ b/log_helpers_test.go
@@ -72,6 +72,7 @@ func TestGetLogEntryForRequest(t *testing.T) {
 			Result: logrus.WithFields(logrus.Fields{
 				"path":   "/test",
 				"origin": "127.0.0.1",
+				"key":    logHiddenValue,
 			}),
 		},
 		// enable_key_logging is not set, key is not passed, no additional data field
@@ -94,6 +95,7 @@ func TestGetLogEntryForRequest(t *testing.T) {
 				"origin": "127.0.0.1",
 				"a":      1,
 				"b":      "test",
+				"key":    logHiddenValue,
 			}),
 		},
 		// enable_key_logging is not set, key is not passed, additional data fields are passed

--- a/log_helpers_test.go
+++ b/log_helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/Sirupsen/logrus"
+
 	"github.com/TykTechnologies/tyk/config"
 )
 

--- a/log_helpers_test.go
+++ b/log_helpers_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/TykTechnologies/tyk/config"
+)
+
+func TestGetLogEntryForRequest(t *testing.T) {
+	testReq := httptest.NewRequest("GET", "http://tyk.io/test", nil)
+	testReq.RemoteAddr = "127.0.0.1:80"
+	testData := []struct {
+		EnableKeyLogging bool
+		Key              string
+		Data             map[string]interface{}
+		Result           *logrus.Entry
+	}{
+		// enable_key_logging is set, key passed, no additional data fields
+		{
+			EnableKeyLogging: true,
+			Key:              "abc",
+			Data:             nil,
+			Result: logrus.WithFields(logrus.Fields{
+				"path":   "/test",
+				"origin": "127.0.0.1",
+				"key":    "abc",
+			}),
+		},
+		// enable_key_logging is set, key is not passed, no additional data fields
+		{
+			EnableKeyLogging: true,
+			Key:              "",
+			Data:             nil,
+			Result: logrus.WithFields(logrus.Fields{
+				"path":   "/test",
+				"origin": "127.0.0.1",
+			}),
+		},
+		// enable_key_logging is set, key passed, additional data fields are passed
+		{
+			EnableKeyLogging: true,
+			Key:              "abc",
+			Data:             map[string]interface{}{"a": 1, "b": "test"},
+			Result: logrus.WithFields(logrus.Fields{
+				"path":   "/test",
+				"origin": "127.0.0.1",
+				"key":    "abc",
+				"a":      1,
+				"b":      "test",
+			}),
+		},
+		// enable_key_logging is set, key is not passed, additional data fields are passed
+		{
+			EnableKeyLogging: true,
+			Key:              "",
+			Data:             map[string]interface{}{"a": 1, "b": "test"},
+			Result: logrus.WithFields(logrus.Fields{
+				"path":   "/test",
+				"origin": "127.0.0.1",
+				"a":      1,
+				"b":      "test",
+			}),
+		},
+		// enable_key_logging is not set, key passed, no additional data field
+		{
+			EnableKeyLogging: false,
+			Key:              "abc",
+			Data:             nil,
+			Result: logrus.WithFields(logrus.Fields{
+				"path":   "/test",
+				"origin": "127.0.0.1",
+			}),
+		},
+		// enable_key_logging is not set, key is not passed, no additional data field
+		{
+			EnableKeyLogging: false,
+			Key:              "",
+			Data:             nil,
+			Result: logrus.WithFields(logrus.Fields{
+				"path":   "/test",
+				"origin": "127.0.0.1",
+			}),
+		},
+		// enable_key_logging is not set, key passed, additional data fields are passed
+		{
+			EnableKeyLogging: false,
+			Key:              "abc",
+			Data:             map[string]interface{}{"a": 1, "b": "test"},
+			Result: logrus.WithFields(logrus.Fields{
+				"path":   "/test",
+				"origin": "127.0.0.1",
+				"a":      1,
+				"b":      "test",
+			}),
+		},
+		// enable_key_logging is not set, key is not passed, additional data fields are passed
+		{
+			EnableKeyLogging: false,
+			Key:              "",
+			Data:             map[string]interface{}{"a": 1, "b": "test"},
+			Result: logrus.WithFields(logrus.Fields{
+				"path":   "/test",
+				"origin": "127.0.0.1",
+				"a":      1,
+				"b":      "test",
+			}),
+		},
+	}
+	for _, test := range testData {
+		config.Global.EnableKeyLogging = test.EnableKeyLogging
+		logEntry := getLogEntryForRequest(testReq, test.Key, test.Data)
+		if logEntry.Data["path"] != test.Result.Data["path"] {
+			t.Error("Expected 'path':", test.Result.Data["path"], "Got:", logEntry.Data["path"])
+		}
+		if logEntry.Data["origin"] != test.Result.Data["origin"] {
+			t.Error("Expected 'origin':", test.Result.Data["origin"], "Got:", logEntry.Data["origin"])
+		}
+		if logEntry.Data["key"] != test.Result.Data["key"] {
+			t.Error("Expected 'key':", test.Result.Data["key"], "Got:", logEntry.Data["key"])
+		}
+		if test.Data != nil {
+			for key, val := range test.Data {
+				if logEntry.Data[key] != val {
+					t.Error("Expected data key:", key, "with value:", val, "Got:", logEntry.Data[key])
+				}
+			}
+		}
+	}
+}

--- a/mw_access_rights.go
+++ b/mw_access_rights.go
@@ -3,8 +3,6 @@ package main
 import (
 	"errors"
 	"net/http"
-
-	"github.com/Sirupsen/logrus"
 )
 
 // AccessRightsCheck is a middleware that will check if the key bing used to access the API has
@@ -29,12 +27,14 @@ func (a *AccessRightsCheck) ProcessRequest(w http.ResponseWriter, r *http.Reques
 		// Otherwise, run auth checks
 		versionList, apiExists := session.AccessRights[a.Spec.APIID]
 		if !apiExists {
-			log.WithFields(logrus.Fields{
-				"path":      r.URL.Path,
-				"origin":    requestIP(r),
-				"key":       token,
-				"api_found": false,
-			}).Info("Attempted access to unauthorised API.")
+			logEntry := getLogEntryForRequest(
+				r,
+				token,
+				map[string]interface{}{
+					"api_found": false,
+				},
+			)
+			logEntry.Info("Attempted access to unauthorised API.")
 
 			return errors.New("Access to this API has been disallowed"), 403
 		}
@@ -55,13 +55,15 @@ func (a *AccessRightsCheck) ProcessRequest(w http.ResponseWriter, r *http.Reques
 
 		if !found {
 			// Not found? Bounce
-			log.WithFields(logrus.Fields{
-				"path":          r.URL.Path,
-				"origin":        requestIP(r),
-				"key":           token,
-				"api_found":     true,
-				"version_found": false,
-			}).Info("Attempted access to unauthorised API version.")
+			logEntry := getLogEntryForRequest(
+				r,
+				token,
+				map[string]interface{}{
+					"api_found":     true,
+					"version_found": false,
+				},
+			)
+			logEntry.Info("Attempted access to unauthorised API version.")
 
 			return errors.New("Access to this API has been disallowed"), 403
 		}

--- a/mw_api_rate_limit.go
+++ b/mw_api_rate_limit.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/Sirupsen/logrus"
-
 	"strconv"
 	"time"
 
@@ -44,11 +42,8 @@ func (k *RateLimitForAPI) EnabledForSpec() bool {
 }
 
 func (k *RateLimitForAPI) handleRateLimitFailure(r *http.Request, token string) (error, int) {
-	log.WithFields(logrus.Fields{
-		"path":   r.URL.Path,
-		"origin": requestIP(r),
-		"key":    token,
-	}).Info("API rate limit exceeded.")
+	logEntry := getLogEntryForRequest(r, token, nil)
+	logEntry.Info("API rate limit exceeded.")
 
 	// Fire a rate limit exceeded event
 	k.FireEvent(EventRateLimitExceeded, EventKeyFailureMeta{

--- a/mw_auth_key.go
+++ b/mw_auth_key.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
-
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/certs"
 )
@@ -76,10 +74,8 @@ func (k *AuthKey) ProcessRequest(w http.ResponseWriter, r *http.Request, _ inter
 
 	if key == "" {
 		// No header value, fail
-		log.WithFields(logrus.Fields{
-			"path":   r.URL.Path,
-			"origin": requestIP(r),
-		}).Info("Attempted access with malformed header, no auth header found.")
+		logEntry := getLogEntryForRequest(r, "", nil)
+		logEntry.Info("Attempted access with malformed header, no auth header found.")
 
 		return errors.New("Authorization field missing"), 401
 	}
@@ -90,11 +86,8 @@ func (k *AuthKey) ProcessRequest(w http.ResponseWriter, r *http.Request, _ inter
 	// Check if API key valid
 	session, keyExists := k.CheckSessionAndIdentityForValidKey(key)
 	if !keyExists {
-		log.WithFields(logrus.Fields{
-			"path":   r.URL.Path,
-			"origin": requestIP(r),
-			"key":    key,
-		}).Info("Attempted access with non-existent key.")
+		logEntry := getLogEntryForRequest(r, key, nil)
+		logEntry.Info("Attempted access with non-existent key.")
 
 		// Fire Authfailed Event
 		AuthFailed(k, r, key)

--- a/mw_granular_access.go
+++ b/mw_granular_access.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"net/http"
 	"regexp"
-
-	"github.com/Sirupsen/logrus"
 )
 
 // GranularAccessMiddleware will check if a URL is specifically enabled for the key
@@ -54,12 +52,8 @@ func (m *GranularAccessMiddleware) ProcessRequest(w http.ResponseWriter, r *http
 
 	token := ctxGetAuthToken(r)
 	// No paths matched, disallow
-	log.WithFields(logrus.Fields{
-		"path":      r.URL.Path,
-		"origin":    requestIP(r),
-		"key":       token,
-		"api_found": false,
-	}).Info("Attempted access to unauthorised endpoint (Granular).")
+	logEntry := getLogEntryForRequest(r, token, map[string]interface{}{"api_found": false})
+	logEntry.Info("Attempted access to unauthorised endpoint (Granular).")
 
 	return errors.New("Access to this resource has been disallowed"), 403
 

--- a/mw_hmac.go
+++ b/mw_hmac.go
@@ -167,11 +167,8 @@ func (hm *HMACMiddleware) setContextVars(r *http.Request, token string) {
 }
 
 func (hm *HMACMiddleware) authorizationError(r *http.Request) (error, int) {
-	log.WithFields(logrus.Fields{
-		"prefix": "hmac",
-		"path":   r.URL.Path,
-		"origin": requestIP(r),
-	}).Info("Authorization field missing or malformed")
+	logEntry := getLogEntryForRequest(r, "", nil)
+	logEntry.Info("Authorization field missing or malformed")
 
 	AuthFailed(hm, r, r.Header.Get("Authorization"))
 

--- a/mw_jwt.go
+++ b/mw_jwt.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/dgrijalva/jwt-go"
 	cache "github.com/pmylund/go-cache"
 
@@ -317,10 +316,8 @@ func (k *JWTMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _
 
 	if rawJWT == "" {
 		// No header value, fail
-		log.WithFields(logrus.Fields{
-			"path":   r.URL.Path,
-			"origin": requestIP(r),
-		}).Info("Attempted access with malformed header, no JWT auth header found.")
+		logEntry := getLogEntryForRequest(r, "", nil)
+		logEntry.Info("Attempted access with malformed header, no JWT auth header found.")
 
 		log.Debug("Looked in: ", config.AuthHeaderName)
 		log.Debug("Raw data was: ", rawJWT)
@@ -385,16 +382,11 @@ func (k *JWTMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _
 		// No, let's try one-to-one mapping
 		return k.processOneToOneTokenMap(r, token)
 	}
-	log.WithFields(logrus.Fields{
-		"path":   r.URL.Path,
-		"origin": requestIP(r),
-	}).Info("Attempted JWT access with non-existent key.")
+	logEntry := getLogEntryForRequest(r, "", nil)
+	logEntry.Info("Attempted JWT access with non-existent key.")
 
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"path":   r.URL.Path,
-			"origin": requestIP(r),
-		}).Error("JWT validation error: ", err)
+		logEntry.Error("JWT validation error: ", err)
 	}
 
 	k.reportLoginFailure(tykId, r)

--- a/mw_rate_limiting.go
+++ b/mw_rate_limiting.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/Sirupsen/logrus"
-
 	"github.com/TykTechnologies/tyk/config"
 )
 
@@ -27,11 +25,8 @@ func (k *RateLimitAndQuotaCheck) EnabledForSpec() bool {
 }
 
 func (k *RateLimitAndQuotaCheck) handleRateLimitFailure(r *http.Request, token string) (error, int) {
-	log.WithFields(logrus.Fields{
-		"path":   r.URL.Path,
-		"origin": requestIP(r),
-		"key":    token,
-	}).Info("Key rate limit exceeded.")
+	logEntry := getLogEntryForRequest(r, token, nil)
+	logEntry.Info("Key rate limit exceeded.")
 
 	// Fire a rate limit exceeded event
 	k.FireEvent(EventRateLimitExceeded, EventKeyFailureMeta{
@@ -48,11 +43,8 @@ func (k *RateLimitAndQuotaCheck) handleRateLimitFailure(r *http.Request, token s
 }
 
 func (k *RateLimitAndQuotaCheck) handleQuotaFailure(r *http.Request, token string) (error, int) {
-	log.WithFields(logrus.Fields{
-		"path":   r.URL.Path,
-		"origin": requestIP(r),
-		"key":    token,
-	}).Info("Key quota limit exceeded.")
+	logEntry := getLogEntryForRequest(r, token, nil)
+	logEntry.Info("Key quota limit exceeded.")
 
 	// Fire a quota exceeded event
 	k.FireEvent(EventQuotaExceeded, EventKeyFailureMeta{

--- a/mw_request_size_limit.go
+++ b/mw_request_size_limit.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/Sirupsen/logrus"
-
 	"github.com/TykTechnologies/tyk/apidef"
 )
 
@@ -45,12 +43,15 @@ func (t *RequestSizeLimitMiddleware) checkRequestLimit(r *http.Request, sizeLimi
 
 	// Check stated size
 	if size > sizeLimit {
-		log.WithFields(logrus.Fields{
-			"path":   r.URL.Path,
-			"origin": requestIP(r),
-			"size":   size,
-			"limit":  sizeLimit,
-		}).Info("Attempted access with large request size, blocked.")
+		logEntry := getLogEntryForRequest(
+			r,
+			"",
+			map[string]interface{}{
+				"size":  size,
+				"limit": sizeLimit,
+			},
+		)
+		logEntry.Info("Attempted access with large request size, blocked.")
 
 		return errors.New("Request is too large"), 400
 	}

--- a/mw_transform.go
+++ b/mw_transform.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/clbanning/mxj"
 	"golang.org/x/net/html/charset"
 
@@ -46,12 +45,16 @@ func (t *TransformMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 	}
 	err := transformBody(r, meta.(*TransformSpec), t.Spec.EnableContextVars)
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix":      "inbound-transform",
-			"server_name": t.Spec.Proxy.TargetURL,
-			"api_id":      t.Spec.APIID,
-			"path":        r.URL.Path,
-		}).Error(err)
+		logEntry := getLogEntryForRequest(
+			r,
+			"",
+			map[string]interface{}{
+				"prefix":      "inbound-transform",
+				"server_name": t.Spec.Proxy.TargetURL,
+				"api_id":      t.Spec.APIID,
+			},
+		)
+		logEntry.Error(err)
 	}
 	return nil, 200
 }


### PR DESCRIPTION
added changes to fix https://github.com/TykTechnologies/tyk/issues/1203

1. added helper function to log request info and have more grain control about what to put in log for request
2. added new config parameter `enable_key_logging` with default value false which will switch on/off logging for tokens/keys

I tried to to catch all cases where we log info about http-request and changed them to use new helper function `getLogEntryForRequest`. It prepares logrus.Entry with passed data but leaves freedom to decide about message log-level to caller. If we go with this approach the assumption is to keep eye on how we log things and use this function to make sure sensitive info won't be logged.