### PR TITLE
Rollback functionality requiring bundle to have "middleware.py" file

### DIFF
--- a/coprocess/python/dispatcher.py
+++ b/coprocess/python/dispatcher.py
@@ -43,9 +43,17 @@ class TykDispatcher:
         return found_middleware
 
     def load_bundle(self, base_bundle_path):
-        bundle_path = path.join(base_bundle_path, 'middleware.py')
-        middleware = TykMiddleware(bundle_path)
-        self.middlewares.append(middleware)
+        bundle_path = path.join(base_bundle_path, '*.py')
+        bundle_modules = self.get_modules(bundle_path)
+        sys.path.append(base_bundle_path)
+        for module_name in bundle_modules:
+            middleware = self.find_middleware(module_name)
+            if middleware:
+                middleware.reload()
+            else:
+                middleware = TykMiddleware(module_name)
+                self.middlewares.append(middleware)
+
         self.update_hook_table()
 
     def load_middlewares(self):


### PR DESCRIPTION
Rollback part of #1237 

Previously users could have any file name, and even multiple files, with the change introduced in #1237 they should have fixed `middleware.py`. This change broke a lot of user plugins. 

This change rollback function that finds middleware code.

Steps to test:
1. Take middleware examples from #1237, and rename `middleware.py` to a different name.
2. Plugin should still work, including hot reload 
