### PR TITLE
test: discard all std log output too by default

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"html/template"
 	"io/ioutil"
+	stdlog "log"
 	"log/syslog"
 	"net"
 	"net/http"
@@ -799,6 +800,7 @@ func initialiseSystem(arguments map[string]interface{}) error {
 		log.Level = logrus.ErrorLevel
 		log.Out = ioutil.Discard
 		gorpc.SetErrorLogger(func(string, ...interface{}) {})
+		stdlog.SetOutput(ioutil.Discard)
 	} else if arguments["--debug"] == true {
 		log.Level = logrus.DebugLevel
 		log.WithFields(logrus.Fields{


### PR DESCRIPTION
Before:

	$ go test
	2017/11/21 15:58:57 http: TLS handshake error from [::1]:54058: tls: no certificates configured
	2017/11/21 15:58:58 http: TLS handshake error from [::1]:58572: tls: client didn't provide a certificate
	2017/11/21 15:58:58 http: TLS handshake error from [::1]:58574: tls: failed to verify client's certificate: x509: certificate signed by unknown authority
	2017/11/21 15:58:59 http: TLS handshake error from 127.0.0.1:46488: tls: client didn't provide a certificate
	2017/11/21 15:58:59 http: TLS handshake error from 127.0.0.1:46498: tls: failed to verify client's certificate: x509: certificate signed by unknown authority
	2017/11/21 15:59:00 http: TLS handshake error from 127.0.0.1:46502: tls: failed to verify client's certificate: x509: certificate signed by unknown authority (possibly because of "x5
	09: invalid signature: parent certificate cannot sign this kind of certificate" while trying to verify candidate authority certificate "serial:206981011806556900346702653301449444008
	")
	2017/11/21 15:59:00 http: TLS handshake error from 127.0.0.1:50170: tls: failed to verify client's certificate: x509: certificate signed by unknown authority
	PASS
	ok      github.com/TykTechnologies/tyk  6.257s

With this change, it's back to being quiet.

Updates #1299.