### PR TITLE
all: fix numerous global apiSpecs data races

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -281,17 +281,17 @@ func (a APIDefinitionLoader) FromDashboardService(endpoint, secret string) []*AP
 	}
 
 	// Process
-	var apiSpecs []*APISpec
+	var specs []*APISpec
 	for _, def := range apiDefs {
 		spec := a.MakeSpec(def)
-		apiSpecs = append(apiSpecs, spec)
+		specs = append(specs, spec)
 	}
 
 	// Set the nonce
 	ServiceNonce = list.Nonce
 	log.Debug("Loading APIS Finished: Nonce Set: ", ServiceNonce)
 
-	return apiSpecs
+	return specs
 }
 
 // FromCloud will connect and download ApiDefintions from a Mongo DB instance.
@@ -325,7 +325,7 @@ func (a APIDefinitionLoader) processRPCDefinitions(apiCollection string) []*APIS
 		return nil
 	}
 
-	var apiSpecs []*APISpec
+	var specs []*APISpec
 	for _, def := range apiDefs {
 		def.DecodeFromDB()
 
@@ -340,10 +340,10 @@ func (a APIDefinitionLoader) processRPCDefinitions(apiCollection string) []*APIS
 		}
 
 		spec := a.MakeSpec(def)
-		apiSpecs = append(apiSpecs, spec)
+		specs = append(specs, spec)
 	}
 
-	return apiSpecs
+	return specs
 }
 
 func (a APIDefinitionLoader) ParseDefinition(r io.Reader) *apidef.APIDefinition {
@@ -357,7 +357,7 @@ func (a APIDefinitionLoader) ParseDefinition(r io.Reader) *apidef.APIDefinition 
 // FromDir will load APIDefinitions from a directory on the filesystem. Definitions need
 // to be the JSON representation of APIDefinition object
 func (a APIDefinitionLoader) FromDir(dir string) []*APISpec {
-	var apiSpecs []*APISpec
+	var specs []*APISpec
 	// Grab json files from directory
 	paths, _ := filepath.Glob(filepath.Join(dir, "*.json"))
 	for _, path := range paths {
@@ -370,9 +370,9 @@ func (a APIDefinitionLoader) FromDir(dir string) []*APISpec {
 		def := a.ParseDefinition(f)
 		f.Close()
 		spec := a.MakeSpec(def)
-		apiSpecs = append(apiSpecs, spec)
+		specs = append(specs, spec)
 	}
-	return apiSpecs
+	return specs
 }
 
 func (a APIDefinitionLoader) getPathSpecs(apiVersionDef apidef.VersionInfo) ([]URLSpec, bool) {

--- a/api_definition_test.go
+++ b/api_definition_test.go
@@ -349,8 +349,8 @@ func TestSyncAPISpecsRPCFailure(t *testing.T) {
 	rpc := startRPCMock(dispatcher)
 	defer stopRPCMock(rpc)
 
-	syncAPISpecs()
-	if len(apiSpecs) != 0 {
+	count := syncAPISpecs()
+	if count != 0 {
 		t.Error("Should return empty value for malformed rpc response", apiSpecs)
 	}
 }
@@ -368,8 +368,8 @@ func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 	rpc := startRPCMock(dispatcher)
 	defer stopRPCMock(rpc)
 
-	syncAPISpecs()
-	if len(apiSpecs) != 1 {
+	count := syncAPISpecs()
+	if count != 1 {
 		t.Error("Should return array with one spec", apiSpecs)
 	}
 }
@@ -414,11 +414,11 @@ func TestSyncAPISpecsDashboardSuccess(t *testing.T) {
 
 	// Wait for the reload to finish, then check it worked
 	wg.Wait()
-	apisMu.Lock()
+	apisMu.RLock()
 	if len(apisByID) != 1 {
 		t.Error("Should return array with one spec", apisByID)
 	}
-	apisMu.Unlock()
+	apisMu.RUnlock()
 }
 
 func TestRoundRobin(t *testing.T) {

--- a/api_loader.go
+++ b/api_loader.go
@@ -518,6 +518,16 @@ func (d *DummyProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	d.SH.ServeHTTP(w, r)
 }
 
+func loadGlobalApps() {
+	// we need to make a full copy of the slice, as loadApps will
+	// use in-place to sort the apis.
+	apisMu.RLock()
+	specs := make([]*APISpec, len(apiSpecs))
+	copy(specs, apiSpecs)
+	apisMu.RUnlock()
+	loadApps(specs, mainRouter)
+}
+
 // Create the individual API (app) specs based on live configurations and assign middleware
 func loadApps(specs []*APISpec, muxer *mux.Router) {
 	hostname := config.Global.HostName

--- a/cert.go
+++ b/cert.go
@@ -102,6 +102,7 @@ func getTLSConfigForClient(baseConfig *tls.Config, listenPort int) func(hello *t
 			return newConfig, nil
 		}
 
+		apisMu.RLock()
 		for _, spec := range apiSpecs {
 			if spec.UseMutualTLSAuth && spec.Domain == hello.ServerName {
 				newConfig.ClientAuth = tls.RequireAndVerifyClientCert
@@ -110,6 +111,7 @@ func getTLSConfigForClient(baseConfig *tls.Config, listenPort int) func(hello *t
 				break
 			}
 		}
+		apisMu.RUnlock()
 
 		return newConfig, nil
 	}

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -176,6 +176,9 @@ func TestMain(m *testing.M) {
 			delete(policiesByID, "_")
 			policiesMu.Unlock()
 			apisMu.Lock()
+			old := apiSpecs
+			apiSpecs = append(apiSpecs, nil)
+			apiSpecs = old
 			apisByID["_"] = nil
 			delete(apisByID, "_")
 			apisMu.Unlock()


### PR DESCRIPTION
Also make gateway_test.go help the race detector by writing to it in the
background. This made the races show up on every 'go test -race' run on
my laptop, as opposed to just sometimes.

While at it, don't use apiSpecs as a name for local variables, as that
makes the code very confusing.