### PR TITLE
upstream cache control configurable ttl header

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -215,11 +215,12 @@ type MiddlewareSection struct {
 }
 
 type CacheOptions struct {
-	CacheTimeout               int64 `bson:"cache_timeout" json:"cache_timeout"`
-	EnableCache                bool  `bson:"enable_cache" json:"enable_cache"`
-	CacheAllSafeRequests       bool  `bson:"cache_all_safe_requests" json:"cache_all_safe_requests"`
-	CacheOnlyResponseCodes     []int `bson:"cache_response_codes" json:"cache_response_codes"`
-	EnableUpstreamCacheControl bool  `bson:"enable_upstream_cache_control" json:"enable_upstream_cache_control"`
+	CacheTimeout               int64  `bson:"cache_timeout" json:"cache_timeout"`
+	EnableCache                bool   `bson:"enable_cache" json:"enable_cache"`
+	CacheAllSafeRequests       bool   `bson:"cache_all_safe_requests" json:"cache_all_safe_requests"`
+	CacheOnlyResponseCodes     []int  `bson:"cache_response_codes" json:"cache_response_codes"`
+	EnableUpstreamCacheControl bool   `bson:"enable_upstream_cache_control" json:"enable_upstream_cache_control"`
+	CacheControlTTLHeader      string `bson:"cache_control_ttl_header" json:"cache_control_ttl_header"`
 }
 
 type ResponseProcessor struct {

--- a/mw_redis_cache.go
+++ b/mw_redis_cache.go
@@ -191,8 +191,13 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 				log.Warning("Upstream cache action not found, not caching")
 				cacheThisRequest = false
 			}
-			// Do we override TTL?
-			ttl := reqVal.Header.Get(upstreamCacheTTLHeader)
+
+			cacheTTLHeader := upstreamCacheTTLHeader
+			if m.Spec.CacheOptions.CacheControlTTLHeader != "" {
+				cacheTTLHeader = m.Spec.CacheOptions.CacheControlTTLHeader
+			}
+
+			ttl := reqVal.Header.Get(cacheTTLHeader)
 			if ttl != "" {
 				log.Debug("TTL Set upstream")
 				cacheAsInt, err := strconv.Atoi(ttl)
@@ -215,8 +220,8 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 			go m.CacheStore.SetKey(key, toStore, cacheTTL)
 
 		}
-		return nil, mwStatusRespond
 
+		return nil, mwStatusRespond
 	}
 
 	cachedData, timestamp, err := m.decodePayload(retBlob)


### PR DESCRIPTION
resolves #1194

Extends the existing EnableUpstreamCacheControl option to add a
configuration object that lets the header to listen for the TTL value
that is currently used. This defaults to our existing custom header if
unset (retaining backwards compatibility), and allows the user to
specify Expires as the header to use in order to offer an MvP of the
functionality
