### PR TITLE
Fixes RPC session being zapped due to struct member rename

### DIFF
--- a/rpc_storage_handler.go
+++ b/rpc_storage_handler.go
@@ -21,12 +21,12 @@ import (
 )
 
 type InboundData struct {
-	KeyName string
-	Value   string
-	Session string
-	Timeout int64
-	Per     int64
-	Expire  int64
+	KeyName      string
+	Value        string
+	SessionState string
+	Timeout      int64
+	Per          int64
+	Expire       int64
 }
 
 type DefRequest struct {

--- a/rpc_storage_handler.go
+++ b/rpc_storage_handler.go
@@ -372,9 +372,9 @@ func (r *RPCStorageHandler) GetExp(keyName string) (int64, error) {
 func (r *RPCStorageHandler) SetKey(keyName, session string, timeout int64) error {
 	start := time.Now() // get current time
 	ibd := InboundData{
-		KeyName: r.fixKey(keyName),
-		Session: session,
-		Timeout: timeout,
+		KeyName:      r.fixKey(keyName),
+		SessionState: session,
+		Timeout:      timeout,
 	}
 
 	_, err := RPCFuncClientSingleton.CallTimeout("SetKey", ibd, GlobalRPCCallTimeout)


### PR DESCRIPTION
This is a side effect of 2a9d7d5b6c289ac75d, which renamed `InboundData.SessionState` to `InboundData.Session`. The receiving part didn't recognize a new member and initialised the old `SessionState` to an empty string, effectively killing the org session on the first call to `SetKey`.