### PR TITLE
coprocess_python: fix backport of #1237

### DIFF
--- a/coprocess/python/dispatcher.py
+++ b/coprocess/python/dispatcher.py
@@ -26,7 +26,6 @@ class TykDispatcher:
 
         self.middlewares = []
         self.hook_table = {}
-        self.load_middlewares()
 
     def get_modules(self, the_path):
         files = glob(the_path)
@@ -37,7 +36,7 @@ class TykDispatcher:
         found_middleware = None
         if len(self.middlewares) > 0:
             for middleware in self.middlewares:
-                if middleware.filepath == path and not found_middleware:
+                if middleware.module_path == path and not found_middleware:
                     found_middleware = middleware
                     break
         return found_middleware
@@ -47,11 +46,13 @@ class TykDispatcher:
         bundle_modules = self.get_modules(bundle_path)
         sys.path.append(base_bundle_path)
         for module_name in bundle_modules:
+            module_filename = "{0}.py".format(module_name)
+            module_path = path.join(base_bundle_path, module_filename)
             middleware = self.find_middleware(module_name)
             if middleware:
                 middleware.reload()
             else:
-                middleware = TykMiddleware(module_name)
+                middleware = TykMiddleware(module_path, module_name)
                 self.middlewares.append(middleware)
 
         self.update_hook_table()
@@ -145,5 +146,4 @@ class TykDispatcher:
         tyk.log( "Reloading event handlers and middlewares.", "info" )
         self.purge_event_handlers()
         self.load_event_handlers()
-
         self.load_middlewares()

--- a/coprocess/python/tyk/middleware.py
+++ b/coprocess/python/tyk/middleware.py
@@ -11,13 +11,12 @@ from gateway import TykGateway as tyk
 HandlerDecorators = list( map( lambda m: m[1], inspect.getmembers(decorators, inspect.isclass) ) )
 
 class TykMiddleware:
-    def __init__(self, filepath):
-        tyk.log( "Loading module: '{0}'".format(filepath), "info")
-        self.filepath = filepath
+    def __init__(self, module_path, module_name):
+        tyk.log( "Loading module: '{0}'".format(module_name), "info")
+        self.module_path = module_path
         self.handlers = {}
-
         try:
-            source = SourceFileLoader('middleware', self.filepath)
+            source = SourceFileLoader(module_name, self.module_path)
             self.module = source.load_module()
             self.register_handlers()
         except:


### PR DESCRIPTION
This enhances the usage of absolute Python module paths.
It also drops the call to "load_middlewares" that occurs during the dispatcher initialization because "load_bundle" is used instead, #1260 implements more enhancements related to this.
