### PR TITLE
coprocess_python: fix backport of #1237 (2.4)

### DIFF
--- a/coprocess/python/tyk/middleware.py
+++ b/coprocess/python/tyk/middleware.py
@@ -1,5 +1,6 @@
 from importlib import reload as reload_module
 from importlib import invalidate_caches as invalidate_caches
+
 from importlib.machinery import SourceFileLoader
 
 import inspect, sys
@@ -10,13 +11,12 @@ from gateway import TykGateway as tyk
 HandlerDecorators = list( map( lambda m: m[1], inspect.getmembers(decorators, inspect.isclass) ) )
 
 class TykMiddleware:
-    def __init__(self, filepath):
-        tyk.log( "Loading module: '{0}'".format(filepath), "info")
-        self.filepath = filepath
+    def __init__(self, module_path, module_name):
+        tyk.log( "Loading module: '{0}'".format(module_name), "info")
+        self.module_path = module_path
         self.handlers = {}
-
         try:
-            source = SourceFileLoader('middleware', self.filepath)
+            source = SourceFileLoader(module_name, self.module_path)
             self.module = source.load_module()
             self.register_handlers()
         except:


### PR DESCRIPTION
This enhances the usage of absolute Python module paths.
It also drops the call to "load_middlewares" that occurs during the dispatcher initialization because "load_bundle" is used instead, #1260 implements more enhancements related to this.