### PR TITLE
log: get rid of unnecessary checks

### DIFF
--- a/log_helpers.go
+++ b/log_helpers.go
@@ -9,9 +9,7 @@ import (
 )
 
 // identifies that field value was hidden before output to the log
-const (
-	logHiddenValue = "<hidden>"
-)
+const logHiddenValue = "<hidden>"
 
 func getLogEntryForRequest(r *http.Request, key string, data map[string]interface{}) *logrus.Entry {
 	// populate http request fields
@@ -27,10 +25,8 @@ func getLogEntryForRequest(r *http.Request, key string, data map[string]interfac
 		}
 	}
 	// add to log additional fields if any passed
-	if data != nil && len(data) > 0 {
-		for key, val := range data {
-			fields[key] = val
-		}
+	for key, val := range data {
+		fields[key] = val
 	}
 	return log.WithFields(fields)
 }


### PR DESCRIPTION
Ranging over a nil and/or empty map is already a no-op.