### PR TITLE
cache: EnabledForSpec should just use EnableCache

### DIFF
--- a/mw_redis_cache.go
+++ b/mw_redis_cache.go
@@ -37,15 +37,7 @@ func (m *RedisCacheMiddleware) Init() {
 }
 
 func (m *RedisCacheMiddleware) EnabledForSpec() bool {
-	if !m.Spec.CacheOptions.EnableCache {
-		return false
-	}
-	for _, version := range m.Spec.VersionData.Versions {
-		if len(version.ExtendedPaths.Cached) > 0 {
-			return true
-		}
-	}
-	return false
+	return m.Spec.CacheOptions.EnableCache
 }
 
 func (m *RedisCacheMiddleware) CreateCheckSum(req *http.Request, keyName string) string {


### PR DESCRIPTION
Don't require there to be a cached extended path too. Otherwise, one
can't use any sort of caching on an API without adding cached extended
paths.

At the same time, don't run the middleware if there are any cached
extended paths yet EnableCache is false. The docs tell the user to
enable the cache for the whole API, so that is expected.

Add a test to prove that caching of a simple API works. This test was
failing before, as the API does not have any cached extended paths.

Fixes #1329.