### PR TITLE
cache: don't depend on timings for the test

### DIFF
--- a/gateway_test.go
+++ b/gateway_test.go
@@ -1248,6 +1248,8 @@ func TestWithCacheAllSafeRequests(t *testing.T) {
 		{"GET", "/", true},   // still cached after the POST
 	}
 	highestID := -1
+	cachedRequest = make(chan bool)
+	defer func() { cachedRequest = nil }()
 	for _, tc := range tests {
 		req, err := http.NewRequest(tc.method, baseURL+tc.path, nil)
 		if err != nil {
@@ -1271,5 +1273,6 @@ func TestWithCacheAllSafeRequests(t *testing.T) {
 		if testResp.ID > highestID {
 			highestID = testResp.ID
 		}
+		<-cachedRequest
 	}
 }


### PR DESCRIPTION
We were seeing failures on CI, like:

	--- FAIL: TestWithCacheAllSafeRequests (0.06s)
		gateway_test.go:1269: wanted GET / to cache, but it didn't

They can be easily reproduced locally if a delay on Redis is forced,
such as by adding a time.Sleep(10 * time.Millisecond) right before the
"go m.CacheStore.SetKey" line.

The reason is that the redis write is asynchronous, so we need to wait
for it to be done before we can do the next request and see whether or
not its response was cached.

Much like with the reload queue, add a channel so that the request
handling goroutine and the test goroutine can communicate and
coordinate.

The tests passed 100 runs with the sleep after the fix, confirming that
the flake should be gone for good.