### PR TITLE
Added default version feature for versioned APIs

### DIFF
--- a/api.go
+++ b/api.go
@@ -1479,3 +1479,10 @@ func ctxGetUrlRewritePath(r *http.Request) string {
 	}
 	return ""
 }
+func ctxGetDefaultVersion(r *http.Request) bool {
+	return r.Context().Value(VersionDefault) != nil
+}
+
+func ctxSetDefaultVersion(r *http.Request) {
+	setCtxValue(r, VersionDefault, true)
+}

--- a/api_definition.go
+++ b/api_definition.go
@@ -1032,8 +1032,13 @@ func (a *APISpec) Version(r *http.Request) (*apidef.VersionInfo, []URLSpec, bool
 			}
 		} else {
 			// Extract Version Info
+			// First checking for if default version is set
 			vname := a.getVersionFromRequest(r)
-			if vname == "" {
+			if vname == "" && a.VersionData.DefaultVersion != "" {
+				vname = a.VersionData.DefaultVersion
+				ctxSetDefaultVersion(r)
+			}
+			if vname == "" && a.VersionData.DefaultVersion == "" {
 				return &version, nil, false, VersionNotFound
 			}
 			// Load Version Data - General
@@ -1045,6 +1050,7 @@ func (a *APISpec) Version(r *http.Request) (*apidef.VersionInfo, []URLSpec, bool
 
 		// cache for the future
 		ctxSetVersionInfo(r, &version)
+
 	}
 
 	// Load path data and whitelist data for version

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -326,8 +326,9 @@ type APIDefinition struct {
 		Key      string `bson:"key" json:"key"`
 	} `bson:"definition" json:"definition"`
 	VersionData struct {
-		NotVersioned bool                   `bson:"not_versioned" json:"not_versioned"`
-		Versions     map[string]VersionInfo `bson:"versions" json:"versions"`
+		NotVersioned   bool                   `bson:"not_versioned" json:"not_versioned"`
+		DefaultVersion string                 `bson:"default_version" json:"default_version"`
+		Versions       map[string]VersionInfo `bson:"versions" json:"versions"`
 	} `bson:"version_data" json:"version_data"`
 	UptimeTests struct {
 		CheckList []HostCheckObject `bson:"check_list" json:"check_list"`

--- a/config/config.go
+++ b/config/config.go
@@ -269,6 +269,7 @@ type Config struct {
 	Security                          SecurityConfig                        `json:"security"`
 	EnableKeyLogging                  bool                                  `json:"enable_key_logging"`
 	NewRelic                          NewRelicConfig                        `json:"newrelic"`
+	VersionHeader                     string                                `json:"version_header"`
 }
 
 type CertData struct {

--- a/handler_error.go
+++ b/handler_error.go
@@ -87,6 +87,8 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 
 		t := time.Now()
 
+		addVersionHeader(w, r)
+
 		version := e.Spec.getVersionFromRequest(r)
 		if version == "" {
 			version = "Non Versioned"

--- a/lint/schema.go
+++ b/lint/schema.go
@@ -194,6 +194,9 @@ const confSchema = `{
 			}
 		}
 	},
+	"version_header":{
+		"type": "string"
+	},
 	"disable_dashboard_zeroconf": {
 		"type": "boolean"
 	},


### PR DESCRIPTION
Fixes #955 

If default_version is not set or left as an empty string, the current behaviour is kept and an error is returned if no default version is explicitly requested in a header, url query param, or url path.

Note that this won't change the behavior if a request asks for a version that doesn't exist - that will still be the same error.

An example config:

```
"version_data": {
    "not_versioned": true,
    "default_version": "v2",
    "versions": {
        "v1": {"name": "v1", ...},
        "v2": {"name": "v2", ...}
    }
}
```


