### PR TITLE
Add support for API `config_data` to Coprocess middleware

### DIFF
--- a/coprocess.go
+++ b/coprocess.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/Sirupsen/logrus"
@@ -107,9 +108,15 @@ func (c *CoProcessor) ObjectFromRequest(r *http.Request) *coprocess.Object {
 
 	// Append spec data:
 	if c.Middleware != nil {
+		configDataAsJson := []byte("{}")
+		if len(c.Middleware.Spec.ConfigData) > 0 {
+			configDataAsJson, _ = json.Marshal(c.Middleware.Spec.ConfigData)
+		}
+
 		object.Spec = map[string]string{
-			"OrgID": c.Middleware.Spec.OrgID,
-			"APIID": c.Middleware.Spec.APIID,
+			"OrgID":       c.Middleware.Spec.OrgID,
+			"APIID":       c.Middleware.Spec.APIID,
+			"config_data": string(configDataAsJson),
 		}
 	}
 

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -1269,5 +1269,7 @@ func TestWithCacheAllSafeRequests(t *testing.T) {
 		} else if !cached && tc.wantCached {
 			t.Fatalf("wanted %s %s to cache, but it didn't", tc.method, tc.path)
 		}
+
+		time.Sleep(10 * time.Millisecond)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -619,7 +619,12 @@ func rpcReloadLoop(rpcKey string) {
 	}
 }
 
+var reloadMu sync.Mutex
+
 func doReload() {
+	reloadMu.Lock()
+	defer reloadMu.Unlock()
+
 	// Load the API Policies
 	syncPolicies()
 	// load the specs


### PR DESCRIPTION
Spec object now have new key `config_data` which contains JSON string
representation of `APIDefinition.ConfigData`

Fix #1197