### PR TITLE
allow transform response when path is equal to path of url rewrite

### DIFF
--- a/api.go
+++ b/api.go
@@ -1460,3 +1460,16 @@ func ctxSetVersionInfo(r *http.Request, v *apidef.VersionInfo) {
 	}
 	setCtxValue(r, VersionData, v)
 }
+
+func ctxSetUrlRewritePath(r *http.Request, path string) {
+	setCtxValue(r, UrlRewritePath, path)
+}
+
+func ctxGetUrlRewritePath(r *http.Request) string {
+	if v := r.Context().Value(UrlRewritePath); v != nil {
+		if strVal, ok := v.(string); ok {
+			return strVal
+		}
+	}
+	return ""
+}

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -306,6 +306,7 @@ func getChain(spec *APISpec) http.Handler {
 	}
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
 	proxyHandler := ProxyHandler(proxy, spec)
+	creeateResponseMiddlewareChain(spec)
 	baseMid := BaseMiddleware{spec, proxy}
 	chain := alice.New(mwList(
 		&IPWhiteListMiddleware{baseMid},
@@ -316,6 +317,7 @@ func getChain(spec *APISpec) http.Handler {
 		&AccessRightsCheck{baseMid},
 		&RateLimitAndQuotaCheck{baseMid},
 		&TransformHeaders{baseMid},
+		&URLRewriteMiddleware{baseMid},
 	)...).Then(proxyHandler)
 	return chain
 }

--- a/handler_success.go
+++ b/handler_success.go
@@ -29,6 +29,7 @@ const (
 	RetainHost
 	TrackThisEndpoint
 	DoNotTrackThisEndpoint
+	UrlRewritePath
 )
 
 var SessionCache = cache.New(10*time.Second, 5*time.Second)

--- a/mw_url_rewrite.go
+++ b/mw_url_rewrite.go
@@ -48,6 +48,9 @@ func urlRewrite(meta *apidef.URLRewriteMeta, r *http.Request) (string, error) {
 		log.Debug("URL Re-written from: ", path)
 		log.Debug("URL Re-written to: ", newpath)
 
+		// put url_rewrite path to context to be used in ResponseTransformMiddleware
+		ctxSetUrlRewritePath(r, meta.Path)
+
 		// matched?? Set the modified path
 		// return newpath, nil
 	}

--- a/res_handler_transform_test.go
+++ b/res_handler_transform_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"encoding/base64"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestTransformResponseWithURLRewrite(t *testing.T) {
+	testTemplateBlob := base64.StdEncoding.EncodeToString([]byte(`{"http_method":"{{.Method}}"}`))
+
+	testData := map[string]struct {
+		apiSpec      string
+		url          string
+		expectedCode int
+		expectedBody string
+	}{
+		"just_transform_response": {
+			apiSpec: `
+			{
+				"api_id": "1",
+				"auth": {"auth_header_name": "authorization"},
+				"version_data": {
+					"not_versioned": true,
+					"versions": {
+						"v1": {
+							"name": "v1",
+							"use_extended_paths": true,
+							"extended_paths": {
+								"transform_response": [
+									{
+										"path": "get",
+										"method": "GET",
+										"template_data": {
+											"template_mode": "blob",
+											"template_source": "` + testTemplateBlob + `"
+										}
+									}
+								]
+							}
+						}
+					}
+				},
+				"response_processors":[{"name": "response_body_transform"}],
+				"proxy": {
+					"listen_path": "/v1",
+					"target_url": "` + testHttpAny + `"
+				}
+			}
+			`,
+			url:          "/v1/get",
+			expectedCode: http.StatusOK,
+			expectedBody: `{"http_method":"GET"}`,
+		},
+		"transform_path_equal_to_rewrite_to": {
+			apiSpec: `
+			{
+				"api_id": "1",
+				"auth": {"auth_header_name": "authorization"},
+				"version_data": {
+					"not_versioned": true,
+					"versions": {
+						"v1": {
+							"name": "v1",
+							"use_extended_paths": true,
+							"extended_paths": {
+								"url_rewrites": [
+									{
+									  "path": "abc",
+									  "method": "GET",
+									  "match_pattern": "abc",
+									  "rewrite_to": "get"
+									}
+								],
+								"transform_response": [
+									{
+										"path": "get",
+										"method": "GET",
+										"template_data": {
+											"template_mode": "blob",
+											"template_source": "` + testTemplateBlob + `"
+										}
+									}
+								]
+							}
+						}
+					}
+				},
+				"response_processors":[{"name": "response_body_transform"}],
+				"proxy": {
+					"listen_path": "/v1",
+					"target_url": "` + testHttpAny + `"
+				}
+			}
+			`,
+			url:          "/v1/abc",
+			expectedCode: http.StatusOK,
+			expectedBody: `{"http_method":"GET"}`,
+		},
+		"transform_path_equal_to_rewrite_path": {
+			apiSpec: `
+			{
+				"api_id": "1",
+				"auth": {"auth_header_name": "authorization"},
+				"version_data": {
+					"not_versioned": true,
+					"versions": {
+						"v1": {
+							"name": "v1",
+							"use_extended_paths": true,
+							"extended_paths": {
+								"url_rewrites": [
+									{
+									  "path": "abc",
+									  "method": "GET",
+									  "match_pattern": "abc",
+									  "rewrite_to": "get"
+									}
+								],
+								"transform_response": [
+									{
+										"path": "abc",
+										"method": "GET",
+										"template_data": {
+											"template_mode": "blob",
+											"template_source": "` + testTemplateBlob + `"
+										}
+									}
+								]
+							}
+						}
+					}
+				},
+				"response_processors":[{"name": "response_body_transform"}],
+				"proxy": {
+					"listen_path": "/v1",
+					"target_url": "` + testHttpAny + `"
+				}
+			}
+			`,
+			url:          "/v1/abc",
+			expectedCode: http.StatusOK,
+			expectedBody: `{"http_method":"GET"}`,
+		},
+	}
+
+	for testName, test := range testData {
+		spec := createSpecTest(t, test.apiSpec)
+		session := createNonThrottledSession()
+		spec.SessionManager.UpdateSession("1234wer", session, 60)
+
+		recorder := httptest.NewRecorder()
+		req := testReq(t, http.MethodGet, test.url, nil)
+		req.Header.Set("authorization", "1234wer")
+		req.RemoteAddr = "127.0.0.1:80"
+
+		chain := getChain(spec)
+		chain.ServeHTTP(recorder, req)
+
+		if recorder.Code != 200 {
+			t.Fatalf("[%s] Invalid response code %d, should be 200\n", testName, recorder.Code)
+		}
+
+		// check that body was transformed
+		resp := recorder.Result()
+		bodyData, _ := ioutil.ReadAll(resp.Body)
+		body := string(bodyData)
+		if body != test.expectedBody {
+			t.Fatalf("[%s] Expected response body: '%s' Got response body: %s\n", testName, test.expectedBody, body)
+		}
+	}
+}


### PR DESCRIPTION
added changes to fix https://github.com/TykTechnologies/tyk/issues/187

also added some tests:

1. we use just transform_response
2. we use url_rewrite and transform_response, transform_response has in `path` value matching to URL request was rewritten to
3. we use url_rewrite and transform_response, transform_response has in `path` value equal to `path` specified in url_rewrite