### PR TITLE
Made RPC Connection pool size configurable but default to 50

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -103,6 +103,7 @@ type SlaveOptionsConfig struct {
 	GroupID                         string `json:"group_id"`
 	CallTimeout                     int    `json:"call_timeout"`
 	PingTimeout                     int    `json:"ping_timeout"`
+	RPCPoolSize                     int    `json:"rpc_pool_size"`
 }
 
 type LocalSessionCacheConf struct {

--- a/lint/schema.go
+++ b/lint/schema.go
@@ -537,6 +537,9 @@ const confSchema = `{
 			},
 			"use_ssl": {
 				"type": "boolean"
+			},
+			"rpc_pool_size": {
+				"type": "integer"
 			}
 		}
 	},

--- a/rpc_storage_handler.go
+++ b/rpc_storage_handler.go
@@ -157,7 +157,12 @@ func (r *RPCStorageHandler) Connect() bool {
 	}
 
 	RPCCLientSingleton.OnConnect = r.OnConnectFunc
-	RPCCLientSingleton.Conns = 50
+
+	RPCCLientSingleton.Conns = config.Global.SlaveOptions.RPCPoolSize
+	if config.Global.SlaveOptions.RPCPoolSize == 0 {
+		RPCCLientSingleton.Conns = 50
+	}
+
 	RPCCLientSingleton.Dial = func(addr string) (conn io.ReadWriteCloser, err error) {
 		dialer := &net.Dialer{
 			Timeout:   10 * time.Second,


### PR DESCRIPTION
Addresses #1361 by adding a new Slave option config: `rpc_pool_size` which can be set to anything, but if non-zero will default to 50 (the old hard-coded value).

To test, run gateway in slave mode with this config value set to a different value (e.g. 10) and then check how many open connections there are like this:

`netstat -anp | grep :80 | grep ESTABLISHED | wc -l`