### PR TITLE
new setting proxy.skip_target_path_escaping in api def added

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -348,6 +348,7 @@ type APIDefinition struct {
 		StructuredTargetList        *HostList                     `bson:"-" json:"-"`
 		CheckHostAgainstUptimeTests bool                          `bson:"check_host_against_uptime_tests" json:"check_host_against_uptime_tests"`
 		ServiceDiscovery            ServiceDiscoveryConfiguration `bson:"service_discovery" json:"service_discovery"`
+		SkipTargetPathEscaping      bool                          `bson:"skip_target_path_escaping" json:"skip_target_path_escaping"`
 	} `bson:"proxy" json:"proxy"`
 	DisableRateLimit          bool                   `bson:"disable_rate_limit" json:"disable_rate_limit"`
 	DisableQuota              bool                   `bson:"disable_quota" json:"disable_quota"`

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -267,50 +267,32 @@ func TestParambasedAuth(t *testing.T) {
 }
 
 func TestSkipTargetPassEscapingOff(t *testing.T) {
-	tests := map[string]struct {
-		SkipTargetPathEscaping bool
-		URI                    string
-		ExpectedUpstreamURI    string
-	}{
-		"skip_target_path_escaping=false": {
-			SkipTargetPathEscaping: false,
-			URI:                 "/v1/promotions/(abc,xyz)",
-			ExpectedUpstreamURI: "/get/promotions/%28abc,xyz%29",
-		},
-		"skip_target_path_escaping=true": {
-			SkipTargetPathEscaping: true,
-			URI:                 "/v1/promotions/(abc,xyz)",
-			ExpectedUpstreamURI: "/get/promotions/(abc,xyz)",
-		},
-	}
+	ts := newTykTestServer()
+	defer ts.Close()
 
-	for testName, test := range tests {
-		t.Run(testName, func(t *testing.T) {
-			spec := createSpecTest(t, fmt.Sprintf(skipPathEscapingDefinition, test.SkipTargetPathEscaping))
-			session := createStandardSession()
-			spec.SessionManager.UpdateSession("tyutyu345345dgh", session, 60)
-
-			recorder := httptest.NewRecorder()
-			req := testReq(t, http.MethodGet, test.URI, nil)
-			req.Header.Set("authorization", "tyutyu345345dgh")
-
-			chain := getChain(spec)
-			chain.ServeHTTP(recorder, req)
-
-			if recorder.Code != 200 {
-				t.Fatal("Initial request failed with non-200 code: ", recorder.Code)
-			}
-
-			var resp testHttpResponse
-			if err := json.NewDecoder(recorder.Body).Decode(&resp); err != nil {
-				t.Fatal("JSON decoding failed:", err)
-			}
-
-			if resp.Url != test.ExpectedUpstreamURI {
-				t.Errorf("Expected upstream path: '%s' Got: '%s'", test.ExpectedUpstreamURI, resp.Url)
-			}
+	t.Run("With escaping, default", func(t *testing.T) {
+		buildAndLoadAPI(func(spec *APISpec) {
+			spec.Proxy.SkipTargetPathEscaping = false
+			spec.Proxy.ListenPath = "/"
 		})
-	}
+
+		ts.Run(t, []test.TestCase{
+			{Path: "/(abc,xyz)?arg=val", BodyMatch: `"Url":"/%28abc,xyz%29"?arg=val`},
+			{Path: "/%28abc,xyz%29?arg=val", BodyMatch: `"Url":"/%28abc,xyz%29"?arg=val`},
+		}...)
+	})
+
+	t.Run("Without escaping", func(t *testing.T) {
+		buildAndLoadAPI(func(spec *APISpec) {
+			spec.Proxy.SkipTargetPathEscaping = true
+			spec.Proxy.ListenPath = "/"
+		})
+
+		ts.Run(t, []test.TestCase{
+			{Path: "/(abc,xyz)?arg=val", BodyMatch: `"Url":"/(abc,xyz)?arg=val"`},
+			{Path: "/%28abc,xyz%29?arg=val", BodyMatch: `"Url":"/%28abc,xyz%29?arg=val"`},
+		}...)
+	})
 }
 
 func TestQuota(t *testing.T) {

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -277,8 +277,8 @@ func TestSkipTargetPassEscapingOff(t *testing.T) {
 		})
 
 		ts.Run(t, []test.TestCase{
-			{Path: "/(abc,xyz)?arg=val", BodyMatch: `"Url":"/%28abc,xyz%29"?arg=val`},
-			{Path: "/%28abc,xyz%29?arg=val", BodyMatch: `"Url":"/%28abc,xyz%29"?arg=val`},
+			{Path: "/(abc,xyz)?arg=val", BodyMatch: `"Url":"/%28abc,xyz%29?arg=val`},
+			{Path: "/%28abc,xyz%29?arg=val", BodyMatch: `"Url":"/%28abc,xyz%29?arg=val`},
 		}...)
 	})
 
@@ -291,6 +291,62 @@ func TestSkipTargetPassEscapingOff(t *testing.T) {
 		ts.Run(t, []test.TestCase{
 			{Path: "/(abc,xyz)?arg=val", BodyMatch: `"Url":"/(abc,xyz)?arg=val"`},
 			{Path: "/%28abc,xyz%29?arg=val", BodyMatch: `"Url":"/%28abc,xyz%29?arg=val"`},
+		}...)
+	})
+
+	t.Run("With escaping, listen path and target URL are set, StripListenPath is OFF", func(t *testing.T) {
+		buildAndLoadAPI(func(spec *APISpec) {
+			spec.Proxy.StripListenPath = false
+			spec.Proxy.SkipTargetPathEscaping = false
+			spec.Proxy.ListenPath = "/listen_me"
+			spec.Proxy.TargetURL = testHttpAny + "/sent_to_me"
+		})
+
+		ts.Run(t, []test.TestCase{
+			{Path: "/listen_me/(abc,xyz)?arg=val", BodyMatch: `"Url":"/sent_to_me/listen_me/%28abc,xyz%29?arg=val"`},
+			{Path: "/listen_me/%28abc,xyz%29?arg=val", BodyMatch: `"Url":"/sent_to_me/listen_me/%28abc,xyz%29?arg=val"`},
+		}...)
+	})
+
+	t.Run("Without escaping, listen path and target URL are set, StripListenPath is OFF", func(t *testing.T) {
+		buildAndLoadAPI(func(spec *APISpec) {
+			spec.Proxy.StripListenPath = false
+			spec.Proxy.SkipTargetPathEscaping = true
+			spec.Proxy.ListenPath = "/listen_me"
+			spec.Proxy.TargetURL = testHttpAny + "/sent_to_me"
+		})
+
+		ts.Run(t, []test.TestCase{
+			{Path: "/listen_me/(abc,xyz)?arg=val", BodyMatch: `"Url":"/sent_to_me/listen_me/(abc,xyz)?arg=val"`},
+			{Path: "/listen_me/%28abc,xyz%29?arg=val", BodyMatch: `"Url":"/sent_to_me/listen_me/%28abc,xyz%29?arg=val"`},
+		}...)
+	})
+
+	t.Run("With escaping, listen path and target URL are set, StripListenPath is ON", func(t *testing.T) {
+		buildAndLoadAPI(func(spec *APISpec) {
+			spec.Proxy.StripListenPath = true
+			spec.Proxy.SkipTargetPathEscaping = false
+			spec.Proxy.ListenPath = "/listen_me"
+			spec.Proxy.TargetURL = testHttpAny + "/sent_to_me"
+		})
+
+		ts.Run(t, []test.TestCase{
+			{Path: "/listen_me/(abc,xyz)?arg=val", BodyMatch: `"Url":"/sent_to_me/%28abc,xyz%29?arg=val"`},
+			{Path: "/listen_me/%28abc,xyz%29?arg=val", BodyMatch: `"Url":"/sent_to_me/%28abc,xyz%29?arg=val"`},
+		}...)
+	})
+
+	t.Run("Without escaping, listen path and target URL are set, StripListenPath is ON", func(t *testing.T) {
+		buildAndLoadAPI(func(spec *APISpec) {
+			spec.Proxy.StripListenPath = true
+			spec.Proxy.SkipTargetPathEscaping = true
+			spec.Proxy.ListenPath = "/listen_me"
+			spec.Proxy.TargetURL = testHttpAny + "/sent_to_me"
+		})
+
+		ts.Run(t, []test.TestCase{
+			{Path: "/listen_me/(abc,xyz)?arg=val", BodyMatch: `"Url":"/sent_to_me/(abc,xyz)?arg=val"`},
+			{Path: "/listen_me/%28abc,xyz%29?arg=val", BodyMatch: `"Url":"/sent_to_me/%28abc,xyz%29?arg=val"`},
 		}...)
 	})
 }

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -47,6 +47,7 @@ var (
 const defaultListenPort = 8080
 
 var defaultTestConfig config.Config
+var testServerRouter *mux.Router
 
 func resetTestConfig() {
 	configMu.Lock()
@@ -75,9 +76,10 @@ func reloadSimulation() {
 }
 
 func TestMain(m *testing.M) {
+	testServerRouter = testHttpHandler()
 	testServer := &http.Server{
 		Addr:           testHttpListen,
-		Handler:        testHttpHandler(),
+		Handler:        testServerRouter,
 		ReadTimeout:    1 * time.Second,
 		WriteTimeout:   1 * time.Second,
 		MaxHeaderBytes: 1 << 20,
@@ -351,6 +353,105 @@ func TestSkipTargetPassEscapingOff(t *testing.T) {
 	})
 }
 
+func TestSkipTargetPassEscapingOffWithSkipURLCleaningTrue(t *testing.T) {
+	config.Global.HttpServerOptions.OverrideDefaults = true
+	config.Global.HttpServerOptions.SkipURLCleaning = true
+	defer resetTestConfig()
+
+	// here we expect that test gateway will be sending to test upstream requests with not cleaned URI
+	// so test upstream shouldn't reply with 301 and process them as well
+	prevSkipClean := defaultTestConfig.HttpServerOptions.OverrideDefaults &&
+		defaultTestConfig.HttpServerOptions.SkipURLCleaning
+	testServerRouter.SkipClean(true)
+	defer testServerRouter.SkipClean(prevSkipClean)
+
+	ts := newTykTestServer()
+	defer ts.Close()
+
+	t.Run("With escaping, default", func(t *testing.T) {
+		buildAndLoadAPI(func(spec *APISpec) {
+			spec.Proxy.SkipTargetPathEscaping = false
+			spec.Proxy.ListenPath = "/"
+		})
+
+		ts.Run(t, []test.TestCase{
+			{Path: "/abc/xyz/http%3A%2F%2Ftest.com?arg=val", BodyMatch: `"Url":"/abc/xyz/http%3A%2F%2Ftest.com?arg=val`},
+		}...)
+	})
+
+	t.Run("Without escaping, default", func(t *testing.T) {
+		buildAndLoadAPI(func(spec *APISpec) {
+			spec.Proxy.SkipTargetPathEscaping = true
+			spec.Proxy.ListenPath = "/"
+		})
+
+		ts.Run(t, []test.TestCase{
+			{Path: "/abc/xyz/http%3A%2F%2Ftest.com?arg=val", BodyMatch: `"Url":"/abc/xyz/http%3A%2F%2Ftest.com?arg=val`},
+		}...)
+	})
+
+	t.Run("With escaping, listen path and target URL are set, StripListenPath is OFF", func(t *testing.T) {
+		buildAndLoadAPI(func(spec *APISpec) {
+			spec.Proxy.StripListenPath = false
+			spec.Proxy.SkipTargetPathEscaping = false
+			spec.Proxy.ListenPath = "/listen_me"
+			spec.Proxy.TargetURL = testHttpAny + "/sent_to_me"
+		})
+
+		ts.Run(t, []test.TestCase{
+			{Path: "/listen_me/(abc,xyz)?arg=val", BodyMatch: `"Url":"/sent_to_me/listen_me/%28abc,xyz%29?arg=val"`},
+			{Path: "/listen_me/%28abc,xyz%29?arg=val", BodyMatch: `"Url":"/sent_to_me/listen_me/%28abc,xyz%29?arg=val"`},
+			{Path: "/listen_me/http%3A%2F%2Ftest.com?arg=val", BodyMatch: `"Url":"/sent_to_me/listen_me/http%3A%2F%2Ftest.com?arg=val`},
+		}...)
+	})
+
+	t.Run("Without escaping, listen path and target URL are set, StripListenPath is OFF", func(t *testing.T) {
+		buildAndLoadAPI(func(spec *APISpec) {
+			spec.Proxy.StripListenPath = false
+			spec.Proxy.SkipTargetPathEscaping = true
+			spec.Proxy.ListenPath = "/listen_me"
+			spec.Proxy.TargetURL = testHttpAny + "/sent_to_me"
+		})
+
+		ts.Run(t, []test.TestCase{
+			{Path: "/listen_me/(abc,xyz)?arg=val", BodyMatch: `"Url":"/sent_to_me/listen_me/(abc,xyz)?arg=val"`},
+			{Path: "/listen_me/%28abc,xyz%29?arg=val", BodyMatch: `"Url":"/sent_to_me/listen_me/%28abc,xyz%29?arg=val"`},
+			{Path: "/listen_me/http%3A%2F%2Ftest.com?arg=val", BodyMatch: `"Url":"/sent_to_me/listen_me/http%3A%2F%2Ftest.com?arg=val`},
+		}...)
+	})
+
+	t.Run("With escaping, listen path and target URL are set, StripListenPath is ON", func(t *testing.T) {
+		buildAndLoadAPI(func(spec *APISpec) {
+			spec.Proxy.StripListenPath = true
+			spec.Proxy.SkipTargetPathEscaping = false
+			spec.Proxy.ListenPath = "/listen_me"
+			spec.Proxy.TargetURL = testHttpAny + "/sent_to_me"
+		})
+
+		ts.Run(t, []test.TestCase{
+			{Path: "/listen_me/(abc,xyz)?arg=val", BodyMatch: `"Url":"/sent_to_me/%28abc,xyz%29?arg=val"`},
+			{Path: "/listen_me/%28abc,xyz%29?arg=val", BodyMatch: `"Url":"/sent_to_me/%28abc,xyz%29?arg=val"`},
+			{Path: "/listen_me/http%3A%2F%2Ftest.com?arg=val", BodyMatch: `"Url":"/sent_to_me/http%3A%2F%2Ftest.com?arg=val`},
+		}...)
+	})
+
+	t.Run("Without escaping, listen path and target URL are set, StripListenPath is ON", func(t *testing.T) {
+		buildAndLoadAPI(func(spec *APISpec) {
+			spec.Proxy.StripListenPath = true
+			spec.Proxy.SkipTargetPathEscaping = true
+			spec.Proxy.ListenPath = "/listen_me"
+			spec.Proxy.TargetURL = testHttpAny + "/sent_to_me"
+		})
+
+		ts.Run(t, []test.TestCase{
+			{Path: "/listen_me/(abc,xyz)?arg=val", BodyMatch: `"Url":"/sent_to_me/(abc,xyz)?arg=val"`},
+			{Path: "/listen_me/%28abc,xyz%29?arg=val", BodyMatch: `"Url":"/sent_to_me/%28abc,xyz%29?arg=val"`},
+			{Path: "/listen_me/http%3A%2F%2Ftest.com?arg=val", BodyMatch: `"Url":"/sent_to_me/http%3A%2F%2Ftest.com?arg=val`},
+		}...)
+	})
+
+}
+
 func TestQuota(t *testing.T) {
 	ts := newTykTestServer()
 	defer ts.Close()
@@ -491,7 +592,7 @@ func TestAnalytics(t *testing.T) {
 }
 
 func TestListener(t *testing.T) {
-	// Trcik to get spec JSON, without loading API
+	// Trick to get spec JSON, without loading API
 	// Specs will be reseted when we do `newTykTestServer`
 	specs := buildAndLoadAPI()
 	specJSON, _ := json.Marshal(specs[0].APIDefinition)

--- a/handler_success.go
+++ b/handler_success.go
@@ -227,6 +227,7 @@ func (s *SuccessHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) *http
 	if s.Spec.Proxy.StripListenPath {
 		log.Debug("Stripping: ", s.Spec.Proxy.ListenPath)
 		r.URL.Path = strings.Replace(r.URL.Path, s.Spec.Proxy.ListenPath, "", 1)
+		r.URL.RawPath = strings.Replace(r.URL.RawPath, s.Spec.Proxy.ListenPath, "", 1)
 		log.Debug("Upstream Path is: ", r.URL.Path)
 	}
 
@@ -262,6 +263,7 @@ func (s *SuccessHandler) ServeHTTPWithCache(w http.ResponseWriter, r *http.Reque
 	// Make sure we get the correct target URL
 	if s.Spec.Proxy.StripListenPath {
 		r.URL.Path = strings.Replace(r.URL.Path, s.Spec.Proxy.ListenPath, "", 1)
+		r.URL.RawPath = strings.Replace(r.URL.RawPath, s.Spec.Proxy.ListenPath, "", 1)
 	}
 
 	var copiedRequest *http.Request

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -124,6 +124,7 @@ func testHttpHandler() http.Handler {
 			httpError(w, http.StatusInternalServerError)
 			return
 		}
+		r.URL.Opaque = r.URL.RawPath
 		err := json.NewEncoder(w).Encode(testHttpResponse{
 			Method:  r.Method,
 			Url:     r.URL.String(),

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -156,9 +156,9 @@ func testHttpHandler() *mux.Router {
 	r.HandleFunc("/jwk.json", func(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, jwkTestJson)
 	})
+	r.HandleFunc("/bundles/{rest:.*}", bundleHandleFunc)
 	r.HandleFunc("/{rest:.*}", handleMethod(""))
 
-	r.HandleFunc("/bundles/", bundleHandleFunc)
 	return r
 }
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/miekg/dns"
 	"github.com/satori/go.uuid"
 
+	"github.com/gorilla/mux"
+
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/test"
@@ -92,7 +94,7 @@ const (
 	testHttpFailureAny = "http://" + testHttpFailure
 )
 
-func testHttpHandler() http.Handler {
+func testHttpHandler() *mux.Router {
 	var upgrader = websocket.Upgrader{
 		ReadBufferSize:  1024,
 		WriteBufferSize: 1024,
@@ -144,17 +146,20 @@ func testHttpHandler() http.Handler {
 			}
 		}
 	}
-	mux := http.NewServeMux()
-	mux.HandleFunc("/", handleMethod(""))
-	mux.HandleFunc("/get", handleMethod("GET"))
-	mux.HandleFunc("/post", handleMethod("POST"))
-	mux.HandleFunc("/ws", wsHandler)
-	mux.HandleFunc("/jwk.json", func(w http.ResponseWriter, r *http.Request) {
+
+	// use gorilla's mux as it allows to cancel URI cleaning
+	// (it is not configurable in standard http mux)
+	r := mux.NewRouter()
+	r.HandleFunc("/get", handleMethod("GET"))
+	r.HandleFunc("/post", handleMethod("POST"))
+	r.HandleFunc("/ws", wsHandler)
+	r.HandleFunc("/jwk.json", func(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, jwkTestJson)
 	})
+	r.HandleFunc("/{rest:.*}", handleMethod(""))
 
-	mux.HandleFunc("/bundles/", bundleHandleFunc)
-	return mux
+	r.HandleFunc("/bundles/", bundleHandleFunc)
+	return r
 }
 
 const jwkTestJson = `{

--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -235,7 +235,6 @@ func TykNewSingleHostReverseProxy(target *url.URL, spec *APISpec) *ReverseProxy 
 			req.URL.Scheme = targetToUse.Scheme
 			req.URL.Host = targetToUse.Host
 			req.URL.Path = singleJoiningSlash(targetToUse.Path, req.URL.Path)
-			// force RequestURI to skip escaping if API's proxy is set for this
 		}
 		if !spec.Proxy.PreserveHostHeader {
 			req.Host = targetToUse.Host
@@ -252,7 +251,13 @@ func TykNewSingleHostReverseProxy(target *url.URL, spec *APISpec) *ReverseProxy 
 		}
 
 		if spec.Proxy.SkipTargetPathEscaping {
-			req.URL.Opaque = req.URL.RawPath // if we set opaque here it will force URL.RequestURI to skip escaping
+			// force RequestURI to skip escaping if API's proxy is set for this
+			// if we set opaque here it will force URL.RequestURI to skip escaping
+			if req.URL.RawPath != "" {
+				req.URL.Opaque = singleJoiningSlash(targetToUse.Path, req.URL.RawPath)
+			}
+		} else {
+			req.URL.RawPath = ""
 		}
 	}
 

--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -235,6 +235,10 @@ func TykNewSingleHostReverseProxy(target *url.URL, spec *APISpec) *ReverseProxy 
 			req.URL.Scheme = targetToUse.Scheme
 			req.URL.Host = targetToUse.Host
 			req.URL.Path = singleJoiningSlash(targetToUse.Path, req.URL.Path)
+			// force RequestURI to skip escaping if API's proxy is set for this
+			if spec.Proxy.SkipTargetPathEscaping {
+				req.URL.Opaque = req.URL.Path // if we set opaque here it will force URL.RequestURI to skip escaping
+			}
 		}
 		if !spec.Proxy.PreserveHostHeader {
 			req.Host = targetToUse.Host

--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -236,9 +236,6 @@ func TykNewSingleHostReverseProxy(target *url.URL, spec *APISpec) *ReverseProxy 
 			req.URL.Host = targetToUse.Host
 			req.URL.Path = singleJoiningSlash(targetToUse.Path, req.URL.Path)
 			// force RequestURI to skip escaping if API's proxy is set for this
-			if spec.Proxy.SkipTargetPathEscaping {
-				req.URL.Opaque = req.URL.Path // if we set opaque here it will force URL.RequestURI to skip escaping
-			}
 		}
 		if !spec.Proxy.PreserveHostHeader {
 			req.Host = targetToUse.Host
@@ -252,6 +249,10 @@ func TykNewSingleHostReverseProxy(target *url.URL, spec *APISpec) *ReverseProxy 
 			// Set Tyk's own default user agent. Without
 			// this line, we would get the net/http default.
 			req.Header.Set("User-Agent", defaultUserAgent)
+		}
+
+		if spec.Proxy.SkipTargetPathEscaping {
+			req.URL.Opaque = req.URL.RawPath // if we set opaque here it will force URL.RequestURI to skip escaping
 		}
 	}
 

--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -235,6 +235,9 @@ func TykNewSingleHostReverseProxy(target *url.URL, spec *APISpec) *ReverseProxy 
 			req.URL.Scheme = targetToUse.Scheme
 			req.URL.Host = targetToUse.Host
 			req.URL.Path = singleJoiningSlash(targetToUse.Path, req.URL.Path)
+			if req.URL.RawPath != "" {
+				req.URL.RawPath = singleJoiningSlash(targetToUse.Path, req.URL.RawPath)
+			}
 		}
 		if !spec.Proxy.PreserveHostHeader {
 			req.Host = targetToUse.Host
@@ -254,9 +257,10 @@ func TykNewSingleHostReverseProxy(target *url.URL, spec *APISpec) *ReverseProxy 
 			// force RequestURI to skip escaping if API's proxy is set for this
 			// if we set opaque here it will force URL.RequestURI to skip escaping
 			if req.URL.RawPath != "" {
-				req.URL.Opaque = singleJoiningSlash(targetToUse.Path, req.URL.RawPath)
+				req.URL.Opaque = req.URL.RawPath
 			}
-		} else {
+		} else if req.URL.RawPath == req.URL.Path {
+			// this should force URL to do escaping
 			req.URL.RawPath = ""
 		}
 	}


### PR DESCRIPTION
changes to fix https://github.com/TykTechnologies/tyk/issues/1374

as part of reverse proxying we [do escaping when we write actual request to upstream](https://golang.org/src/net/http/request.go?#L520) - we always do `req.URL.RequestURI()` which is doing escaping for path in request for upstream.

We don't have too much choice here. I've noticed that [RequestURI](https://golang.org/src/net/url/url.go?#L983) doesn't do any escaping if URL.Opaque has value, so I build a logic around it and introduced new `skip_target_path_escaping` flag which can be set in `proxy` section of API definition. It is a little bit hacky but I think it will work as URL struct is used here just in context of preparing URI for http request to be sent.

If we go with that approach we will need to document this param with note that customers should use it at their own risk (in case of some specific upstreams like SFCC) as all this RFCs about escaping were done on purpose.
  