### PR TITLE
whitelist for ciphersuites available for TLSconfig

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -22,6 +22,31 @@ type APIAllCertificates struct {
 	CertIDs []string `json:"certs"`
 }
 
+var cipherSuites = map[string]uint16{
+	"TLS_RSA_WITH_RC4_128_SHA":                0x0005,
+	"TLS_RSA_WITH_3DES_EDE_CBC_SHA":           0x000a,
+	"TLS_RSA_WITH_AES_128_CBC_SHA":            0x002f,
+	"TLS_RSA_WITH_AES_256_CBC_SHA":            0x0035,
+	"TLS_RSA_WITH_AES_128_CBC_SHA256":         0x003c,
+	"TLS_RSA_WITH_AES_128_GCM_SHA256":         0x009c,
+	"TLS_RSA_WITH_AES_256_GCM_SHA384":         0x009d,
+	"TLS_ECDHE_ECDSA_WITH_RC4_128_SHA":        0xc007,
+	"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA":    0xc009,
+	"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA":    0xc00a,
+	"TLS_ECDHE_RSA_WITH_RC4_128_SHA":          0xc011,
+	"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA":     0xc012,
+	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA":      0xc013,
+	"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA":      0xc014,
+	"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256": 0xc023,
+	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256":   0xc027,
+	"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":   0xc02f,
+	"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256": 0xc02b,
+	"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384":   0xc030,
+	"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384": 0xc02c,
+	"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305":    0xcca8,
+	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305":  0xcca9,
+}
+
 func getUpstreamCertificate(host string, spec *APISpec) (cert *tls.Certificate) {
 	var certID string
 
@@ -176,4 +201,15 @@ func certHandler(w http.ResponseWriter, r *http.Request) {
 		CertificateManager.Delete(certID)
 		doJSONWrite(w, 200, &apiStatusMessage{"ok", "removed"})
 	}
+}
+
+func getCipherAliases(ciphers []string) (cipherCodes []uint16) {
+	for k, v := range cipherSuites {
+		for _, str := range ciphers {
+			if str == k {
+				cipherCodes = append(cipherCodes, v)
+			}
+		}
+	}
+	return cipherCodes
 }

--- a/cert_test.go
+++ b/cert_test.go
@@ -599,3 +599,44 @@ func TestCertificateHandlerTLS(t *testing.T) {
 		}...)
 	})
 }
+
+func TestCipherSuites(t *testing.T) {
+	//configure server so we can useSSL and utilize the logic, but skip verification in the clients
+	_, _, combinedPEM, _ := genServerCertificate()
+	serverCertID, _ := CertificateManager.Add(combinedPEM, "")
+	defer CertificateManager.Delete(serverCertID)
+
+	config.Global.HttpServerOptions.UseSSL = true
+	config.Global.HttpServerOptions.Ciphers = []string{"TLS_RSA_WITH_RC4_128_SHA", "TLS_RSA_WITH_3DES_EDE_CBC_SHA", "TLS_RSA_WITH_AES_128_CBC_SHA"}
+	config.Global.HttpServerOptions.SSLCertificates = []string{serverCertID}
+	defer resetTestConfig()
+
+	ts := newTykTestServer()
+	defer ts.Close()
+
+	buildAndLoadAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/"
+	})
+
+	//matching ciphers
+	t.Run("Cipher match", func(t *testing.T) {
+
+		client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{
+			CipherSuites:       getCipherAliases([]string{"TLS_RSA_WITH_RC4_128_SHA", "TLS_RSA_WITH_3DES_EDE_CBC_SHA", "TLS_RSA_WITH_AES_128_CBC_SHA"}),
+			InsecureSkipVerify: true,
+		}}}
+
+		// If there is an internal TLS error it will fail test
+		ts.Run(t, test.TestCase{Client: client, Path: "/"})
+	})
+
+	t.Run("Cipher non-match", func(t *testing.T) {
+
+		client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{
+			CipherSuites:       getCipherAliases([]string{"TLS_RSA_WITH_AES_256_CBC_SHA"}), // not matching ciphers
+			InsecureSkipVerify: true,
+		}}}
+
+		ts.Run(t, test.TestCase{Client: client, Path: "/", ErrorMatch: "tls: handshake failure"})
+	})
+}

--- a/config/config.go
+++ b/config/config.go
@@ -126,6 +126,7 @@ type HttpServerOptionsConfig struct {
 	MinVersion            uint16     `json:"min_version"`
 	FlushInterval         int        `json:"flush_interval"`
 	SkipURLCleaning       bool       `json:"skip_url_cleaning"`
+	Ciphers               []string   `json:"ciphers"`
 }
 
 type AuthOverrideConf struct {

--- a/config/config.go
+++ b/config/config.go
@@ -126,7 +126,7 @@ type HttpServerOptionsConfig struct {
 	MinVersion            uint16     `json:"min_version"`
 	FlushInterval         int        `json:"flush_interval"`
 	SkipURLCleaning       bool       `json:"skip_url_cleaning"`
-	Ciphers               []string   `json:"ciphers"`
+	Ciphers               []string   `json:"ssl_ciphers"`
 }
 
 type AuthOverrideConf struct {

--- a/lint/schema.go
+++ b/lint/schema.go
@@ -346,7 +346,7 @@ const confSchema = `{
 					"type": "string"
 				}
 			},
-			"ciphers":{
+			"ssl_ciphers":{
 				"type": ["array", "null"],
 				"items": {
 					"type": "string"

--- a/lint/schema.go
+++ b/lint/schema.go
@@ -345,6 +345,12 @@ const confSchema = `{
 				"items": {
 					"type": "string"
 				}
+			},
+			"ciphers":{
+				"type": ["array", "null"],
+				"items": {
+					"type": "string"
+				}
 			}
 		}
 	},

--- a/main.go
+++ b/main.go
@@ -72,7 +72,6 @@ var (
 	controlRouter *mux.Router
 	LE_MANAGER    letsencrypt.Manager
 	LE_FIRSTRUN   bool
-	tlsCiphers    []uint16
 
 	NodeID string
 
@@ -1205,17 +1204,13 @@ func generateListener(listenPort int) (net.Listener, error) {
 			"prefix": "main",
 		}).Info("--> Using SSL (https)")
 
-		if config.Global.HttpServerOptions.Ciphers != nil {
-			tlsCiphers = getCipherAliases(config.Global.HttpServerOptions.Ciphers)
-		}
-
 		tlsConfig := tls.Config{
 			GetCertificate:     dummyGetCertificate,
 			ServerName:         config.Global.HttpServerOptions.ServerName,
 			MinVersion:         config.Global.HttpServerOptions.MinVersion,
 			ClientAuth:         tls.RequestClientCert,
 			InsecureSkipVerify: config.Global.HttpServerOptions.SSLInsecureSkipVerify,
-			CipherSuites:       tlsCiphers,
+			CipherSuites:       getCipherAliases(config.Global.HttpServerOptions.Ciphers),
 		}
 
 		tlsConfig.GetConfigForClient = getTLSConfigForClient(&tlsConfig, listenPort)


### PR DESCRIPTION
User can add values of TLS ciphersuites to array in config, the values of which are defined in the Go TLS lib https://golang.org/pkg/crypto/tls/#Config


Fixes #1372 