### PR TITLE
hello endpoint not dependent on there being more than 0 apis at load

### DIFF
--- a/gateway_test.go
+++ b/gateway_test.go
@@ -634,6 +634,28 @@ func TestCustomDomain(t *testing.T) {
 	})
 }
 
+func TestHelloHealthcheck(t *testing.T) {
+	ts := newTykTestServer()
+	defer ts.Close()
+
+	t.Run("Without APIs", func(t *testing.T) {
+		ts.Run(t, []test.TestCase{
+			{Method: "GET", Path: "/hello", Code: 200},
+		}...)
+	})
+
+	t.Run("With APIs", func(t *testing.T) {
+		buildAndLoadAPI(func(spec *APISpec) {
+			spec.Proxy.ListenPath = "/sample"
+		})
+
+		ts.Run(t, []test.TestCase{
+			{Method: "GET", Path: "/hello", Code: 200},
+			{Method: "GET", Path: "/sample/hello", Code: 200},
+		}...)
+	})
+}
+
 func TestWithCacheAllSafeRequests(t *testing.T) {
 	ts := newTykTestServer(tykTestServerConfig{
 		delay: 10 * time.Millisecond,

--- a/main.go
+++ b/main.go
@@ -1471,4 +1471,8 @@ func listen(l, controlListener net.Listener, err error) {
 	log.WithFields(logrus.Fields{
 		"prefix": "main",
 	}).Info("--> PID: ", hostDetails.PID)
+
+	mainRouter.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Hello Tiki")
+	})
 }


### PR DESCRIPTION
Really dumb fix for issue where hello endpoint is not loaded in gateway when there are no api's present.

fixes #1393 