### PR TITLE
Fix 404 during reloads

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"text/template"
 	"time"
@@ -116,6 +117,7 @@ type ExtendedCircuitBreakerMeta struct {
 // flattened URL list is checked for matching paths and then it's status evaluated if found.
 type APISpec struct {
 	*apidef.APIDefinition
+	sync.Mutex
 
 	RxPaths                  map[string][]URLSpec
 	WhiteListEnabled         map[string]bool

--- a/api_loader.go
+++ b/api_loader.go
@@ -518,20 +518,20 @@ func (d *DummyProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	d.SH.ServeHTTP(w, r)
 }
 
-func loadGlobalApps() {
+func loadGlobalApps(router *mux.Router) {
 	// we need to make a full copy of the slice, as loadApps will
 	// use in-place to sort the apis.
 	apisMu.RLock()
 	specs := make([]*APISpec, len(apiSpecs))
 	copy(specs, apiSpecs)
 	apisMu.RUnlock()
-	loadApps(specs, mainRouter)
+	loadApps(specs, router)
 
 	if config.Global.NewRelic.AppName != "" {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Info("Adding NewRelic instrumentation")
-		AddNewRelicInstrumentation(NewRelicApplication, mainRouter)
+		AddNewRelicInstrumentation(NewRelicApplication, router)
 	}
 }
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -253,7 +253,6 @@ type tykTestServerConfig struct {
 	delay              time.Duration
 	hotReload          bool
 	overrideDefaults   bool
-	lastResponse       *http.Response
 }
 
 type tykTestServer struct {
@@ -488,10 +487,11 @@ func buildAPI(apiGens ...func(spec *APISpec)) (specs []*APISpec) {
 func loadAPI(specs ...*APISpec) (out []*APISpec) {
 	oldPath := config.Global.AppPath
 	config.Global.AppPath, _ = ioutil.TempDir("", "apps")
+
 	defer func() {
+		os.RemoveAll(config.Global.AppPath)
 		config.Global.AppPath = oldPath
 	}()
-	defer os.RemoveAll(config.Global.AppPath)
 
 	for i, spec := range specs {
 		specBytes, _ := json.Marshal(spec)

--- a/rpc_backup_handlers.go
+++ b/rpc_backup_handlers.go
@@ -95,7 +95,6 @@ func doLoadWithBackup(specs []*APISpec) {
 	log.Warning("[RPC Backup] --> Initialised JSVM")
 
 	newRouter := mux.NewRouter()
-	mainRouter = newRouter
 
 	log.Warning("[RPC Backup] --> Set up routers")
 	log.Warning("[RPC Backup] --> Loading endpoints")
@@ -108,12 +107,14 @@ func doLoadWithBackup(specs []*APISpec) {
 
 	if config.Global.NewRelic.AppName != "" {
 		log.Warning("[RPC Backup] --> Adding NewRelic instrumentation")
-		AddNewRelicInstrumentation(NewRelicApplication, mainRouter)
+		AddNewRelicInstrumentation(NewRelicApplication, newRouter)
 		log.Warning("[RPC Backup] --> NewRelic instrumentation added")
 	}
 
 	newServeMux := http.NewServeMux()
-	newServeMux.Handle("/", mainRouter)
+	newServeMux.Handle("/", newRouter)
+
+	mainRouter = newRouter
 
 	http.DefaultServeMux = newServeMux
 	log.Warning("[RPC Backup] --> Replaced muxer")


### PR DESCRIPTION
Issue was happening on high load, because mainRouter object was
initialized with the fresh router, before API routes were loaded into it.

Additionally added more mutexes.

Fix https://github.com/TykTechnologies/tyk/issues/1402