### PR TITLE
Add DNS ttl tests

### DIFF
--- a/helpers_test.go
+++ b/helpers_test.go
@@ -514,11 +514,7 @@ func buildAndLoadAPI(apiGens ...func(spec *APISpec)) (specs []*APISpec) {
 	return loadAPI(buildAPI(apiGens...)...)
 }
 
-var domainsToAddresses = map[string]string{
-	"host1.local.": "127.0.0.1",
-	"host2.local.": "127.0.0.1",
-	"host3.local.": "127.0.0.1",
-}
+var domainsToAddresses sync.Map
 
 type dnsMockHandler struct{}
 
@@ -530,7 +526,7 @@ func (d *dnsMockHandler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 		msg.Authoritative = true
 		domain := msg.Question[0].Name
 
-		address, ok := domainsToAddresses[domain]
+		address, ok := domainsToAddresses.Load(domain)
 		if !ok {
 			// ^ 				start of line
 			// localhost\.		match literally
@@ -545,8 +541,8 @@ func (d *dnsMockHandler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 		}
 
 		msg.Answer = append(msg.Answer, &dns.A{
-			Hdr: dns.RR_Header{Name: domain, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
-			A:   net.ParseIP(address),
+			Hdr: dns.RR_Header{Name: domain, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 1},
+			A:   net.ParseIP(address.(string)),
 		})
 	}
 	w.WriteMsg(&msg)
@@ -560,15 +556,21 @@ func initDNSMock() {
 	dnsMock.Handler = &dnsMockHandler{}
 	go dnsMock.ActivateAndServe()
 
+	domainsToAddresses.Store("host1.local.", "127.0.0.1")
+	domainsToAddresses.Store("host2.local.", "127.0.0.1")
+	domainsToAddresses.Store("host3.local.", "127.0.0.1")
+
+	defaultResolver = &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			d := net.Dialer{}
+			return d.DialContext(ctx, network, dnsMock.PacketConn.LocalAddr().String())
+		},
+	}
+
 	http.DefaultTransport = &http.Transport{
 		DialContext: (&net.Dialer{
-			Resolver: &net.Resolver{
-				PreferGo: true,
-				Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-					d := net.Dialer{}
-					return d.DialContext(ctx, network, dnsMock.PacketConn.LocalAddr().String())
-				},
-			},
+			Resolver: defaultResolver,
 		}).DialContext,
 	}
 }

--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -407,6 +407,8 @@ func (p *ReverseProxy) CheckCircuitBreakerEnforced(spec *APISpec, req *http.Requ
 	return false, nil
 }
 
+var defaultResolver *net.Resolver
+
 func httpTransport(timeOut int, rw http.ResponseWriter, req *http.Request, p *ReverseProxy) http.RoundTripper {
 	transport := defaultTransport() // modifies a newly created transport
 	transport.TLSClientConfig = &tls.Config{}
@@ -421,6 +423,7 @@ func httpTransport(timeOut int, rw http.ResponseWriter, req *http.Request, p *Re
 		transport.DialContext = (&net.Dialer{
 			Timeout:   time.Duration(timeOut) * time.Second,
 			KeepAlive: 30 * time.Second,
+			Resolver:  defaultResolver,
 		}).DialContext
 		transport.ResponseHeaderTimeout = time.Duration(timeOut) * time.Second
 	}


### PR DESCRIPTION
I'm not sure that it should be merged because this test adds 2 seconds to test suite. 
Initially, it was made to replicate reported issue with Tyk not picking up new DNS changes.