### PR TITLE
Configure `skip_target_path_escaping` using tyk conf instead of API definition

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -348,7 +348,6 @@ type APIDefinition struct {
 		StructuredTargetList        *HostList                     `bson:"-" json:"-"`
 		CheckHostAgainstUptimeTests bool                          `bson:"check_host_against_uptime_tests" json:"check_host_against_uptime_tests"`
 		ServiceDiscovery            ServiceDiscoveryConfiguration `bson:"service_discovery" json:"service_discovery"`
-		SkipTargetPathEscaping      bool                          `bson:"skip_target_path_escaping" json:"skip_target_path_escaping"`
 	} `bson:"proxy" json:"proxy"`
 	DisableRateLimit          bool                   `bson:"disable_rate_limit" json:"disable_rate_limit"`
 	DisableQuota              bool                   `bson:"disable_quota" json:"disable_quota"`

--- a/config/config.go
+++ b/config/config.go
@@ -113,20 +113,21 @@ type LocalSessionCacheConf struct {
 }
 
 type HttpServerOptionsConfig struct {
-	OverrideDefaults      bool       `json:"override_defaults"`
-	ReadTimeout           int        `json:"read_timeout"`
-	WriteTimeout          int        `json:"write_timeout"`
-	UseSSL                bool       `json:"use_ssl"`
-	UseLE_SSL             bool       `json:"use_ssl_le"`
-	SSLInsecureSkipVerify bool       `json:"ssl_insecure_skip_verify"`
-	EnableWebSockets      bool       `json:"enable_websockets"`
-	Certificates          []CertData `json:"certificates"`
-	SSLCertificates       []string   `json:"ssl_certificates"`
-	ServerName            string     `json:"server_name"`
-	MinVersion            uint16     `json:"min_version"`
-	FlushInterval         int        `json:"flush_interval"`
-	SkipURLCleaning       bool       `json:"skip_url_cleaning"`
-	Ciphers               []string   `json:"ssl_ciphers"`
+	OverrideDefaults       bool       `json:"override_defaults"`
+	ReadTimeout            int        `json:"read_timeout"`
+	WriteTimeout           int        `json:"write_timeout"`
+	UseSSL                 bool       `json:"use_ssl"`
+	UseLE_SSL              bool       `json:"use_ssl_le"`
+	SSLInsecureSkipVerify  bool       `json:"ssl_insecure_skip_verify"`
+	EnableWebSockets       bool       `json:"enable_websockets"`
+	Certificates           []CertData `json:"certificates"`
+	SSLCertificates        []string   `json:"ssl_certificates"`
+	ServerName             string     `json:"server_name"`
+	MinVersion             uint16     `json:"min_version"`
+	FlushInterval          int        `json:"flush_interval"`
+	SkipURLCleaning        bool       `json:"skip_url_cleaning"`
+	SkipTargetPathEscaping bool       `json:"skip_target_path_escaping"`
+	Ciphers                []string   `json:"ssl_ciphers"`
 }
 
 type AuthOverrideConf struct {

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -271,10 +271,12 @@ func TestParambasedAuth(t *testing.T) {
 func TestSkipTargetPassEscapingOff(t *testing.T) {
 	ts := newTykTestServer()
 	defer ts.Close()
+	defer resetTestConfig()
 
 	t.Run("With escaping, default", func(t *testing.T) {
+		config.Global.HttpServerOptions.SkipTargetPathEscaping = false
+
 		buildAndLoadAPI(func(spec *APISpec) {
-			spec.Proxy.SkipTargetPathEscaping = false
 			spec.Proxy.ListenPath = "/"
 		})
 
@@ -285,8 +287,9 @@ func TestSkipTargetPassEscapingOff(t *testing.T) {
 	})
 
 	t.Run("Without escaping", func(t *testing.T) {
+		config.Global.HttpServerOptions.SkipTargetPathEscaping = true
+
 		buildAndLoadAPI(func(spec *APISpec) {
-			spec.Proxy.SkipTargetPathEscaping = true
 			spec.Proxy.ListenPath = "/"
 		})
 
@@ -297,9 +300,10 @@ func TestSkipTargetPassEscapingOff(t *testing.T) {
 	})
 
 	t.Run("With escaping, listen path and target URL are set, StripListenPath is OFF", func(t *testing.T) {
+		config.Global.HttpServerOptions.SkipTargetPathEscaping = false
+
 		buildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.StripListenPath = false
-			spec.Proxy.SkipTargetPathEscaping = false
 			spec.Proxy.ListenPath = "/listen_me"
 			spec.Proxy.TargetURL = testHttpAny + "/sent_to_me"
 		})
@@ -311,9 +315,10 @@ func TestSkipTargetPassEscapingOff(t *testing.T) {
 	})
 
 	t.Run("Without escaping, listen path and target URL are set, StripListenPath is OFF", func(t *testing.T) {
+		config.Global.HttpServerOptions.SkipTargetPathEscaping = true
+
 		buildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.StripListenPath = false
-			spec.Proxy.SkipTargetPathEscaping = true
 			spec.Proxy.ListenPath = "/listen_me"
 			spec.Proxy.TargetURL = testHttpAny + "/sent_to_me"
 		})
@@ -325,9 +330,10 @@ func TestSkipTargetPassEscapingOff(t *testing.T) {
 	})
 
 	t.Run("With escaping, listen path and target URL are set, StripListenPath is ON", func(t *testing.T) {
+		config.Global.HttpServerOptions.SkipTargetPathEscaping = false
+
 		buildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.StripListenPath = true
-			spec.Proxy.SkipTargetPathEscaping = false
 			spec.Proxy.ListenPath = "/listen_me"
 			spec.Proxy.TargetURL = testHttpAny + "/sent_to_me"
 		})
@@ -339,9 +345,10 @@ func TestSkipTargetPassEscapingOff(t *testing.T) {
 	})
 
 	t.Run("Without escaping, listen path and target URL are set, StripListenPath is ON", func(t *testing.T) {
+		config.Global.HttpServerOptions.SkipTargetPathEscaping = true
+
 		buildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.StripListenPath = true
-			spec.Proxy.SkipTargetPathEscaping = true
 			spec.Proxy.ListenPath = "/listen_me"
 			spec.Proxy.TargetURL = testHttpAny + "/sent_to_me"
 		})
@@ -369,8 +376,9 @@ func TestSkipTargetPassEscapingOffWithSkipURLCleaningTrue(t *testing.T) {
 	defer ts.Close()
 
 	t.Run("With escaping, default", func(t *testing.T) {
+		config.Global.HttpServerOptions.SkipTargetPathEscaping = false
+
 		buildAndLoadAPI(func(spec *APISpec) {
-			spec.Proxy.SkipTargetPathEscaping = false
 			spec.Proxy.ListenPath = "/"
 		})
 
@@ -380,8 +388,9 @@ func TestSkipTargetPassEscapingOffWithSkipURLCleaningTrue(t *testing.T) {
 	})
 
 	t.Run("Without escaping, default", func(t *testing.T) {
+		config.Global.HttpServerOptions.SkipTargetPathEscaping = true
+
 		buildAndLoadAPI(func(spec *APISpec) {
-			spec.Proxy.SkipTargetPathEscaping = true
 			spec.Proxy.ListenPath = "/"
 		})
 
@@ -391,9 +400,10 @@ func TestSkipTargetPassEscapingOffWithSkipURLCleaningTrue(t *testing.T) {
 	})
 
 	t.Run("With escaping, listen path and target URL are set, StripListenPath is OFF", func(t *testing.T) {
+		config.Global.HttpServerOptions.SkipTargetPathEscaping = false
+
 		buildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.StripListenPath = false
-			spec.Proxy.SkipTargetPathEscaping = false
 			spec.Proxy.ListenPath = "/listen_me"
 			spec.Proxy.TargetURL = testHttpAny + "/sent_to_me"
 		})
@@ -406,9 +416,10 @@ func TestSkipTargetPassEscapingOffWithSkipURLCleaningTrue(t *testing.T) {
 	})
 
 	t.Run("Without escaping, listen path and target URL are set, StripListenPath is OFF", func(t *testing.T) {
+		config.Global.HttpServerOptions.SkipTargetPathEscaping = true
+
 		buildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.StripListenPath = false
-			spec.Proxy.SkipTargetPathEscaping = true
 			spec.Proxy.ListenPath = "/listen_me"
 			spec.Proxy.TargetURL = testHttpAny + "/sent_to_me"
 		})
@@ -421,9 +432,10 @@ func TestSkipTargetPassEscapingOffWithSkipURLCleaningTrue(t *testing.T) {
 	})
 
 	t.Run("With escaping, listen path and target URL are set, StripListenPath is ON", func(t *testing.T) {
+		config.Global.HttpServerOptions.SkipTargetPathEscaping = false
+
 		buildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.StripListenPath = true
-			spec.Proxy.SkipTargetPathEscaping = false
 			spec.Proxy.ListenPath = "/listen_me"
 			spec.Proxy.TargetURL = testHttpAny + "/sent_to_me"
 		})
@@ -436,9 +448,10 @@ func TestSkipTargetPassEscapingOffWithSkipURLCleaningTrue(t *testing.T) {
 	})
 
 	t.Run("Without escaping, listen path and target URL are set, StripListenPath is ON", func(t *testing.T) {
+		config.Global.HttpServerOptions.SkipTargetPathEscaping = true
+
 		buildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.StripListenPath = true
-			spec.Proxy.SkipTargetPathEscaping = true
 			spec.Proxy.ListenPath = "/listen_me"
 			spec.Proxy.TargetURL = testHttpAny + "/sent_to_me"
 		})

--- a/lint/schema.go
+++ b/lint/schema.go
@@ -331,6 +331,9 @@ const confSchema = `{
 			"skip_url_cleaning": {
 				"type": "boolean"
 			},
+			"skip_target_path_escaping": {
+				"type": "boolean"
+			},
 			"ssl_insecure_skip_verify": {
 				"type": "boolean"
 			},

--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -253,7 +253,7 @@ func TykNewSingleHostReverseProxy(target *url.URL, spec *APISpec) *ReverseProxy 
 			req.Header.Set("User-Agent", defaultUserAgent)
 		}
 
-		if spec.Proxy.SkipTargetPathEscaping {
+		if config.Global.HttpServerOptions.SkipTargetPathEscaping {
 			// force RequestURI to skip escaping if API's proxy is set for this
 			// if we set opaque here it will force URL.RequestURI to skip escaping
 			if req.URL.RawPath != "" {


### PR DESCRIPTION
White nature of this issue depends on upstream, its usage very similar
to `skip_url_cleaning`.

And additionally helps us avoid doing UI for this feature.

Updates #1374 