### PR TITLE
create config option and test for disablekeepalives

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -271,6 +271,7 @@ type Config struct {
 	EnableKeyLogging                  bool                                  `json:"enable_key_logging"`
 	NewRelic                          NewRelicConfig                        `json:"newrelic"`
 	VersionHeader                     string                                `json:"version_header"`
+	DisableKeepAlives                 bool                                  `json:"disable_keep_alives"`
 }
 
 type CertData struct {

--- a/config/config.go
+++ b/config/config.go
@@ -271,7 +271,6 @@ type Config struct {
 	EnableKeyLogging                  bool                                  `json:"enable_key_logging"`
 	NewRelic                          NewRelicConfig                        `json:"newrelic"`
 	VersionHeader                     string                                `json:"version_header"`
-	DisableKeepAlives                 bool                                  `json:"disable_keep_alives"`
 }
 
 type CertData struct {

--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -439,6 +439,14 @@ func httpTransport(timeOut int, rw http.ResponseWriter, req *http.Request, p *Re
 		transport.ResponseHeaderTimeout = time.Duration(timeOut) * time.Second
 	}
 
+	if config.Global.DisableKeepAlives {
+		transport.DisableKeepAlives = true
+		transport.DialContext = (&net.Dialer{
+
+			KeepAlive: 0,
+		}).DialContext
+	}
+
 	if IsWebsocket(req) {
 		wsTransport := &WSDialer{transport, rw, p.TLSClientConfig}
 		return wsTransport

--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -439,12 +439,8 @@ func httpTransport(timeOut int, rw http.ResponseWriter, req *http.Request, p *Re
 		transport.ResponseHeaderTimeout = time.Duration(timeOut) * time.Second
 	}
 
-	if config.Global.DisableKeepAlives {
+	if config.Global.CloseConnections {
 		transport.DisableKeepAlives = true
-		transport.DialContext = (&net.Dialer{
-
-			KeepAlive: 0,
-		}).DialContext
 	}
 
 	if IsWebsocket(req) {


### PR DESCRIPTION
Makes `close_connections` option explicitly disable keep-alive connections on network level, instead of relying on server. 

Fix https://github.com/TykTechnologies/tyk/issues/1413

