### PR TITLE
Fix "Host" header access in middleware

### DIFF
--- a/coprocess.go
+++ b/coprocess.go
@@ -76,8 +76,18 @@ func (c *CoProcessor) ObjectFromRequest(r *http.Request) *coprocess.Object {
 		body = string(originalBody)
 	}
 
+	headers := ProtoMap(r.Header)
+
+	host := r.Host
+	if host == "" && r.URL != nil {
+		host = r.URL.Host
+	}
+	if host != "" {
+		headers["Host"] = host
+	}
+
 	miniRequestObject := &coprocess.MiniRequestObject{
-		Headers:        ProtoMap(r.Header),
+		Headers:        headers,
 		SetHeaders:     map[string]string{},
 		DeleteHeaders:  []string{},
 		Body:           body,

--- a/mw_js_plugin.go
+++ b/mw_js_plugin.go
@@ -97,8 +97,21 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 		return nil, 200
 	}
 
+	headers := r.Header
+	host := r.Host
+	if host == "" && r.URL != nil {
+		host = r.URL.Host
+	}
+	if host != "" {
+		headers = make(http.Header)
+		for k, v := range r.Header {
+			headers[k] = v
+		}
+		headers.Set("Host", host)
+	}
+
 	requestData := MiniRequestObject{
-		Headers:        r.Header,
+		Headers:        headers,
 		SetHeaders:     map[string]string{},
 		DeleteHeaders:  []string{},
 		Body:           originalBody,


### PR DESCRIPTION
Host header have special treatment and removed from HTTP request
headers map (recommended to use r.Host instead).

Fix https://github.com/TykTechnologies/tyk/issues/1421 and #994