### PR TITLE
re-assigning map elements added

### DIFF
--- a/mw_url_rewrite.go
+++ b/mw_url_rewrite.go
@@ -231,11 +231,13 @@ func (m *URLRewriteMiddleware) InitTriggerRx() {
 	for _, ver := range m.Spec.VersionData.Versions {
 		for _, path := range ver.ExtendedPaths.URLRewrite {
 			for _, tr := range path.Triggers {
-				for _, h := range tr.Options.HeaderMatches {
+				for key, h := range tr.Options.HeaderMatches {
 					h.Init()
+					tr.Options.HeaderMatches[key] = h
 				}
-				for _, q := range tr.Options.QueryValMatches {
+				for key, q := range tr.Options.QueryValMatches {
 					q.Init()
+					tr.Options.QueryValMatches[key] = q
 				}
 				if tr.Options.PayloadMatches.MatchPattern != "" {
 					tr.Options.PayloadMatches.Init()


### PR DESCRIPTION
added changes to fix https://github.com/TykTechnologies/tyk/issues/1420

the problem was that iterating over slice, array or map with using `range` gives copy of element, not the real one, so `Init()` wasn't changing anything in actual API def structure. To change element we need to put there value by index.