### PR TITLE
changed InitTriggerRx to traverse/change structure elemt with using  …

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -460,6 +460,10 @@ func (s *StringRegexMap) Check(value string) string {
 
 func (s *StringRegexMap) Init() error {
 	var err error
-	s.matchRegex, err = regexp.Compile(s.MatchPattern)
-	return err
+	if s.matchRegex, err = regexp.Compile(s.MatchPattern); err != nil {
+		log.WithError(err).WithField("MatchPattern", s.MatchPattern).
+			Error("Could not compile regexp for StringRegexMap")
+		return err
+	}
+	return nil
 }

--- a/mw_url_rewrite.go
+++ b/mw_url_rewrite.go
@@ -228,19 +228,25 @@ func (m *URLRewriteMiddleware) Name() string {
 
 func (m *URLRewriteMiddleware) InitTriggerRx() {
 	// Generate regexp for each special match parameter
-	for _, ver := range m.Spec.VersionData.Versions {
-		for _, path := range ver.ExtendedPaths.URLRewrite {
-			for _, tr := range path.Triggers {
-				for key, h := range tr.Options.HeaderMatches {
+	for verKey := range m.Spec.VersionData.Versions {
+		for pathKey := range m.Spec.VersionData.Versions[verKey].ExtendedPaths.URLRewrite {
+			for trKey := range m.Spec.VersionData.Versions[verKey].ExtendedPaths.URLRewrite[pathKey].Triggers {
+				for key, h := range m.Spec.VersionData.Versions[verKey].ExtendedPaths.URLRewrite[pathKey].
+					Triggers[trKey].Options.HeaderMatches {
 					h.Init()
-					tr.Options.HeaderMatches[key] = h
+					m.Spec.VersionData.Versions[verKey].ExtendedPaths.URLRewrite[pathKey].
+						Triggers[trKey].Options.HeaderMatches[key] = h
 				}
-				for key, q := range tr.Options.QueryValMatches {
+				for key, q := range m.Spec.VersionData.Versions[verKey].ExtendedPaths.URLRewrite[pathKey].
+					Triggers[trKey].Options.QueryValMatches {
 					q.Init()
-					tr.Options.QueryValMatches[key] = q
+					m.Spec.VersionData.Versions[verKey].ExtendedPaths.URLRewrite[pathKey].
+						Triggers[trKey].Options.QueryValMatches[key] = q
 				}
-				if tr.Options.PayloadMatches.MatchPattern != "" {
-					tr.Options.PayloadMatches.Init()
+				if m.Spec.VersionData.Versions[verKey].ExtendedPaths.URLRewrite[pathKey].
+					Triggers[trKey].Options.PayloadMatches.MatchPattern != "" {
+					m.Spec.VersionData.Versions[verKey].ExtendedPaths.URLRewrite[pathKey].
+						Triggers[trKey].Options.PayloadMatches.Init()
 				}
 			}
 		}

--- a/mw_url_rewrite_test.go
+++ b/mw_url_rewrite_test.go
@@ -512,66 +512,98 @@ func TestRewriterTriggers(t *testing.T) {
 }
 
 func TestInitTriggerRx(t *testing.T) {
+	// prepare test data
 	testRewriteMW := &URLRewriteMiddleware{
 		BaseMiddleware: BaseMiddleware{
 			Spec: &APISpec{
-				APIDefinition: &apidef.APIDefinition{
-					VersionData: struct {
-						NotVersioned   bool                          `bson:"not_versioned" json:"not_versioned"`
-						DefaultVersion string                        `bson:"default_version" json:"default_version"`
-						Versions       map[string]apidef.VersionInfo `bson:"versions" json:"versions"`
-					}{
-						NotVersioned:   true,
-						DefaultVersion: "Default",
-						Versions: map[string]apidef.VersionInfo{
-							"Default": {
-								ExtendedPaths: apidef.ExtendedPathsSet{
-									URLRewrite: []apidef.URLRewriteMeta{
-										{
-											Triggers: []apidef.RoutingTrigger{
-												{
-													Options: apidef.RoutingTriggerOptions{
-														HeaderMatches: map[string]apidef.StringRegexMap{
-															"abc": {
-																MatchPattern: "^abc.*",
-															},
-														},
-														QueryValMatches: map[string]apidef.StringRegexMap{
-															"def": {
-																MatchPattern: "^def.*",
-															},
-														},
-														PayloadMatches: apidef.StringRegexMap{
-															MatchPattern: "^ghi.*",
-														},
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
+				APIDefinition: &apidef.APIDefinition{},
+			},
+		},
+	}
+	testRewriteMW.Spec.APIDefinition.VersionData = struct {
+		NotVersioned   bool                          `bson:"not_versioned" json:"not_versioned"`
+		DefaultVersion string                        `bson:"default_version" json:"default_version"`
+		Versions       map[string]apidef.VersionInfo `bson:"versions" json:"versions"`
+	}{}
+
+	routingTriggerOptions := apidef.RoutingTriggerOptions{
+		HeaderMatches: map[string]apidef.StringRegexMap{
+			"abc": {
+				MatchPattern: "^abc.*",
+			},
+		},
+		QueryValMatches: map[string]apidef.StringRegexMap{
+			"def": {
+				MatchPattern: "^def.*",
+			},
+		},
+		PayloadMatches: apidef.StringRegexMap{
+			MatchPattern: "^ghi.*",
+		},
+	}
+
+	extendedPathsSet := apidef.ExtendedPathsSet{
+		URLRewrite: []apidef.URLRewriteMeta{
+			{
+				Triggers: []apidef.RoutingTrigger{
+					{
+						Options: routingTriggerOptions,
 					},
 				},
 			},
 		},
 	}
+	testRewriteMW.Spec.APIDefinition.VersionData.Versions = map[string]apidef.VersionInfo{
+		"Default": {
+			ExtendedPaths: extendedPathsSet,
+		},
+	}
 
+	// run method under test
 	testRewriteMW.InitTriggerRx()
 
-	if headerMatch := testRewriteMW.Spec.APIDefinition.VersionData.Versions["Default"].ExtendedPaths.URLRewrite[0].
-		Triggers[0].Options.HeaderMatches["abc"]; headerMatch.Check("abc") == "" {
+	// assert HeaderMatches
+	headerMatch := testRewriteMW.
+		Spec.
+		APIDefinition.
+		VersionData.
+		Versions["Default"].
+		ExtendedPaths.
+		URLRewrite[0].
+		Triggers[0].
+		Options.
+		HeaderMatches["abc"]
+	if headerMatch.Check("abc") == "" {
 		t.Errorf("Expected HeaderMatches initalized and matched, received no match")
 	}
 
-	if queryValMatch := testRewriteMW.Spec.APIDefinition.VersionData.Versions["Default"].ExtendedPaths.URLRewrite[0].
-		Triggers[0].Options.QueryValMatches["def"]; queryValMatch.Check("def") == "" {
+	// assert QueryValMatches
+	queryValMatch := testRewriteMW.
+		Spec.
+		APIDefinition.
+		VersionData.
+		Versions["Default"].
+		ExtendedPaths.
+		URLRewrite[0].
+		Triggers[0].
+		Options.
+		QueryValMatches["def"]
+	if queryValMatch.Check("def") == "" {
 		t.Errorf("Expected QueryValMatches initalized and matched, received no match")
 	}
 
-	if payloadMatch := testRewriteMW.Spec.APIDefinition.VersionData.Versions["Default"].ExtendedPaths.URLRewrite[0].
-		Triggers[0].Options.PayloadMatches; payloadMatch.Check("ghi") == "" {
+	// assert PayloadMatches
+	payloadMatch := testRewriteMW.
+		Spec.
+		APIDefinition.
+		VersionData.
+		Versions["Default"].
+		ExtendedPaths.
+		URLRewrite[0].
+		Triggers[0].
+		Options.
+		PayloadMatches
+	if payloadMatch.Check("ghi") == "" {
 		t.Errorf("Expected PayloadMatches initalized and matched, received no match")
 	}
 }


### PR DESCRIPTION
fix for https://github.com/TykTechnologies/tyk/issues/1425

with `for _, tr := range path.Triggers ..` and doing write-operations with elements on `tr` - the actual `m.Spec.VersionData.Versions` are never changed as `tr` receives copy of `Triggers` element.

everything which are maps (or already set pointers if any) were working as maps are passed/copied by reference

the change is ugly but I think thats the only way to guarantee that we walk through all structure and change things in place (not copies of things)