### PR TITLE
Adds Upstart version detection and separate conf, fixes sysv script, compatible service stopping

### DIFF
--- a/install/inits/systemd/system/tyk-gateway-lua.service
+++ b/install/inits/systemd/system/tyk-gateway-lua.service
@@ -10,7 +10,7 @@ Group=root
 # exist, it continues onward.
 EnvironmentFile=-/etc/default/tyk-gateway
 EnvironmentFile=-/etc/sysconfig/tyk-gateway
-ExecStart=/opt/tyk-gateway/tyk-lua --conf=/opt/tyk-gateway/tyk.conf
+ExecStart=/opt/tyk-gateway/tyk-lua --conf /opt/tyk-gateway/tyk.conf
 Restart=always
 WorkingDirectory=/opt/tyk-gateway
 RuntimeDirectory=tyk

--- a/install/inits/systemd/system/tyk-gateway-python.service
+++ b/install/inits/systemd/system/tyk-gateway-python.service
@@ -10,7 +10,7 @@ Group=root
 # exist, it continues onward.
 EnvironmentFile=-/etc/default/tyk-gateway
 EnvironmentFile=-/etc/sysconfig/tyk-gateway
-ExecStart=/opt/tyk-gateway/tyk-python --conf=/opt/tyk-gateway/tyk.conf
+ExecStart=/opt/tyk-gateway/tyk-python --conf /opt/tyk-gateway/tyk.conf
 Restart=always
 WorkingDirectory=/opt/tyk-gateway
 RuntimeDirectory=tyk

--- a/install/inits/systemd/system/tyk-gateway.service
+++ b/install/inits/systemd/system/tyk-gateway.service
@@ -10,7 +10,7 @@ Group=root
 # exist, it continues onward.
 EnvironmentFile=-/etc/default/tyk-gateway
 EnvironmentFile=-/etc/sysconfig/tyk-gateway
-ExecStart=/opt/tyk-gateway/tyk --conf=/opt/tyk-gateway/tyk.conf
+ExecStart=/opt/tyk-gateway/tyk --conf /opt/tyk-gateway/tyk.conf
 Restart=always
 WorkingDirectory=/opt/tyk-gateway
 RuntimeDirectory=tyk

--- a/install/inits/sysv/init.d/tyk-gateway
+++ b/install/inits/sysv/init.d/tyk-gateway
@@ -20,7 +20,7 @@ export PATH
 
 name=tyk-gateway
 program=/opt/tyk-gateway/tyk
-args='--conf=/opt/tyk-gateway/tyk.conf'
+args='--conf /opt/tyk-gateway/tyk.conf'
 pidfile="/var/run/tyk-gateway.pid"
 
 [ -r /etc/default/$name ] && . /etc/default/$name
@@ -36,13 +36,6 @@ emit() {
 }
 
 start() {
-
-  # Ensure the log directory is setup correctly.
-  [ ! -d "/var/log/" ] && mkdir "/var/log/"
-  chown "$user":"$group" "/var/log/"
-  chmod 755 "/var/log/"
-
-
   # Setup any environmental stuff beforehand
   
 

--- a/install/inits/sysv/init.d/tyk-gateway-lua
+++ b/install/inits/sysv/init.d/tyk-gateway-lua
@@ -20,7 +20,7 @@ export PATH
 
 name=tyk-gateway-lua
 program=/opt/tyk-gateway/tyk-lua
-args='--conf=/opt/tyk-gateway/tyk.conf'
+args='--conf /opt/tyk-gateway/tyk.conf'
 pidfile="/var/run/tyk-gateway.pid"
 
 [ -r /etc/default/$name ] && . /etc/default/$name
@@ -36,13 +36,6 @@ emit() {
 }
 
 start() {
-
-  # Ensure the log directory is setup correctly.
-  [ ! -d "/var/log/" ] && mkdir "/var/log/"
-  chown "$user":"$group" "/var/log/"
-  chmod 755 "/var/log/"
-
-
   # Setup any environmental stuff beforehand
   
 

--- a/install/inits/sysv/init.d/tyk-gateway-python
+++ b/install/inits/sysv/init.d/tyk-gateway-python
@@ -20,7 +20,7 @@ export PATH
 
 name=tyk-gateway-python
 program=/opt/tyk-gateway/tyk-python
-args='--conf=/opt/tyk-gateway/tyk.conf'
+args='--conf /opt/tyk-gateway/tyk.conf'
 pidfile="/var/run/tyk-gateway.pid"
 
 [ -r /etc/default/$name ] && . /etc/default/$name
@@ -36,13 +36,6 @@ emit() {
 }
 
 start() {
-
-  # Ensure the log directory is setup correctly.
-  [ ! -d "/var/log/" ] && mkdir "/var/log/"
-  chown "$user":"$group" "/var/log/"
-  chmod 755 "/var/log/"
-
-
   # Setup any environmental stuff beforehand
   
 

--- a/install/inits/upstart/init/0.x/tyk-gateway-lua.conf
+++ b/install/inits/upstart/init/0.x/tyk-gateway-lua.conf
@@ -1,11 +1,11 @@
-description     "Tyk API Gateway"
+description     "Tyk API Gateway (Lua)"
 start on filesystem or runlevel [2345]
 stop on runlevel [!2345]
 
 respawn
 umask 022
-#nice 
-chroot /
+#nice
+#chroot /
 chdir /opt/tyk-gateway/
 #limit core <softlimit> <hardlimit>
 #limit cpu <softlimit> <hardlimit>
@@ -20,9 +20,6 @@ chdir /opt/tyk-gateway/
 #limit rtprio <softlimit> <hardlimit>
 #limit sigpending <softlimit> <hardlimit>
 #limit stack <softlimit> <hardlimit>
-setuid root
-setgid root
-console log # log stdout/stderr to /var/log/upstart/
 
 script
   # When loading default and sysconfig files, we use `set -a` to make
@@ -31,5 +28,5 @@ script
   [ -r /etc/default/tyk-gateway ] && . /etc/default/tyk-gateway
   [ -r /etc/sysconfig/tyk-gateway ] && . /etc/sysconfig/tyk-gateway
   set +a
-  exec /opt/tyk-gateway/tyk --conf=/opt/tyk-gateway/tyk.conf
+  exec chroot --userspec root:root / sh -c "cd /opt/tyk-gateway; exec /opt/tyk-gateway/tyk-lua --conf /opt/tyk-gateway/tyk.conf" >> /var/log/tyk-gateway.stdout 2>> /var/log/tyk-gateway.stderr
 end script

--- a/install/inits/upstart/init/0.x/tyk-gateway-python.conf
+++ b/install/inits/upstart/init/0.x/tyk-gateway-python.conf
@@ -1,0 +1,32 @@
+description     "Tyk API Gateway (Python)"
+start on filesystem or runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+umask 022
+#nice
+#chroot /
+chdir /opt/tyk-gateway/
+#limit core <softlimit> <hardlimit>
+#limit cpu <softlimit> <hardlimit>
+#limit data <softlimit> <hardlimit>
+#limit fsize <softlimit> <hardlimit>
+#limit memlock <softlimit> <hardlimit>
+#limit msgqueue <softlimit> <hardlimit>
+#limit nice <softlimit> <hardlimit>
+#limit nofile <softlimit> <hardlimit>
+#limit nproc <softlimit> <hardlimit>
+#limit rss <softlimit> <hardlimit>
+#limit rtprio <softlimit> <hardlimit>
+#limit sigpending <softlimit> <hardlimit>
+#limit stack <softlimit> <hardlimit>
+
+script
+  # When loading default and sysconfig files, we use `set -a` to make
+  # all variables automatically into environment variables.
+  set -a
+  [ -r /etc/default/tyk-gateway ] && . /etc/default/tyk-gateway
+  [ -r /etc/sysconfig/tyk-gateway ] && . /etc/sysconfig/tyk-gateway
+  set +a
+  exec chroot --userspec root:root / sh -c "cd /opt/tyk-gateway; exec /opt/tyk-gateway/tyk-python --conf /opt/tyk-gateway/tyk.conf" >> /var/log/tyk-gateway.stdout 2>> /var/log/tyk-gateway.stderr
+end script

--- a/install/inits/upstart/init/0.x/tyk-gateway.conf
+++ b/install/inits/upstart/init/0.x/tyk-gateway.conf
@@ -1,11 +1,11 @@
-description     "Tyk API Gateway (Python)"
+description     "Tyk API Gateway"
 start on filesystem or runlevel [2345]
 stop on runlevel [!2345]
 
 respawn
 umask 022
-#nice 
-chroot /
+#nice
+#chroot /
 chdir /opt/tyk-gateway/
 #limit core <softlimit> <hardlimit>
 #limit cpu <softlimit> <hardlimit>
@@ -20,9 +20,6 @@ chdir /opt/tyk-gateway/
 #limit rtprio <softlimit> <hardlimit>
 #limit sigpending <softlimit> <hardlimit>
 #limit stack <softlimit> <hardlimit>
-setuid root
-setgid root
-console log # log stdout/stderr to /var/log/upstart/
 
 script
   # When loading default and sysconfig files, we use `set -a` to make
@@ -31,5 +28,5 @@ script
   [ -r /etc/default/tyk-gateway ] && . /etc/default/tyk-gateway
   [ -r /etc/sysconfig/tyk-gateway ] && . /etc/sysconfig/tyk-gateway
   set +a
-  exec /opt/tyk-gateway/tyk-python --conf=/opt/tyk-gateway/tyk.conf
+  exec chroot --userspec root:root / sh -c "cd /opt/tyk-gateway; exec /opt/tyk-gateway/tyk --conf /opt/tyk-gateway/tyk.conf" >> /var/log/tyk-gateway.stdout 2>> /var/log/tyk-gateway.stderr
 end script

--- a/install/inits/upstart/init/1.x/tyk-gateway-lua.conf
+++ b/install/inits/upstart/init/1.x/tyk-gateway-lua.conf
@@ -4,7 +4,7 @@ stop on runlevel [!2345]
 
 respawn
 umask 022
-#nice 
+#nice
 chroot /
 chdir /opt/tyk-gateway/
 #limit core <softlimit> <hardlimit>

--- a/install/inits/upstart/init/1.x/tyk-gateway-python.conf
+++ b/install/inits/upstart/init/1.x/tyk-gateway-python.conf
@@ -1,0 +1,35 @@
+description     "Tyk API Gateway (Python)"
+start on filesystem or runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+umask 022
+#nice
+chroot /
+chdir /opt/tyk-gateway/
+#limit core <softlimit> <hardlimit>
+#limit cpu <softlimit> <hardlimit>
+#limit data <softlimit> <hardlimit>
+#limit fsize <softlimit> <hardlimit>
+#limit memlock <softlimit> <hardlimit>
+#limit msgqueue <softlimit> <hardlimit>
+#limit nice <softlimit> <hardlimit>
+#limit nofile <softlimit> <hardlimit>
+#limit nproc <softlimit> <hardlimit>
+#limit rss <softlimit> <hardlimit>
+#limit rtprio <softlimit> <hardlimit>
+#limit sigpending <softlimit> <hardlimit>
+#limit stack <softlimit> <hardlimit>
+setuid root
+setgid root
+console log # log stdout/stderr to /var/log/upstart/
+
+script
+  # When loading default and sysconfig files, we use `set -a` to make
+  # all variables automatically into environment variables.
+  set -a
+  [ -r /etc/default/tyk-gateway ] && . /etc/default/tyk-gateway
+  [ -r /etc/sysconfig/tyk-gateway ] && . /etc/sysconfig/tyk-gateway
+  set +a
+  exec /opt/tyk-gateway/tyk-python --conf=/opt/tyk-gateway/tyk.conf
+end script

--- a/install/inits/upstart/init/1.x/tyk-gateway.conf
+++ b/install/inits/upstart/init/1.x/tyk-gateway.conf
@@ -1,0 +1,35 @@
+description     "Tyk API Gateway"
+start on filesystem or runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+umask 022
+#nice
+chroot /
+chdir /opt/tyk-gateway/
+#limit core <softlimit> <hardlimit>
+#limit cpu <softlimit> <hardlimit>
+#limit data <softlimit> <hardlimit>
+#limit fsize <softlimit> <hardlimit>
+#limit memlock <softlimit> <hardlimit>
+#limit msgqueue <softlimit> <hardlimit>
+#limit nice <softlimit> <hardlimit>
+#limit nofile <softlimit> <hardlimit>
+#limit nproc <softlimit> <hardlimit>
+#limit rss <softlimit> <hardlimit>
+#limit rtprio <softlimit> <hardlimit>
+#limit sigpending <softlimit> <hardlimit>
+#limit stack <softlimit> <hardlimit>
+setuid root
+setgid root
+console log # log stdout/stderr to /var/log/upstart/
+
+script
+  # When loading default and sysconfig files, we use `set -a` to make
+  # all variables automatically into environment variables.
+  set -a
+  [ -r /etc/default/tyk-gateway ] && . /etc/default/tyk-gateway
+  [ -r /etc/sysconfig/tyk-gateway ] && . /etc/sysconfig/tyk-gateway
+  set +a
+  exec /opt/tyk-gateway/tyk --conf=/opt/tyk-gateway/tyk.conf
+end script

--- a/install/post_install.sh
+++ b/install/post_install.sh
@@ -18,11 +18,18 @@ if [ -d "$SYSTEMD" ] && systemctl status > /dev/null 2> /dev/null; then
 fi
 
 if [ -d "$UPSTART" ]; then
-	echo "Found upstart"
 	[ -f /etc/default/tyk-gateway ] || cp $DIR/inits/upstart/default/tyk-gateway /etc/default/
-	cp $DIR/inits/upstart/init/tyk-gateway.conf /etc/init/
-	cp $DIR/inits/upstart/init/tyk-gateway-lua.conf /etc/init/
-	cp $DIR/inits/upstart/init/tyk-gateway-python.conf /etc/init/
+	if [[ "$(initctl version)" =~ .*upstart[[:space:]]1\..* ]]; then
+		echo "Found upstart 1.x+"
+		cp $DIR/inits/upstart/init/1.x/tyk-gateway.conf /etc/init/
+		cp $DIR/inits/upstart/init/1.x/tyk-gateway-lua.conf /etc/init/
+		cp $DIR/inits/upstart/init/1.x/tyk-gateway-python.conf /etc/init/
+	else
+		echo "Found upstart 0.x"
+		cp $DIR/inits/upstart/init/0.x/tyk-gateway.conf /etc/init/
+		cp $DIR/inits/upstart/init/0.x/tyk-gateway-lua.conf /etc/init/
+		cp $DIR/inits/upstart/init/0.x/tyk-gateway-python.conf /etc/init/
+	fi
 	exit
 fi
 

--- a/install/post_remove.sh
+++ b/install/post_remove.sh
@@ -23,9 +23,9 @@ fi
 if [ -f "/etc/init/tyk-gateway.conf" ]; then
 	echo "Found upstart"
 	echo "Stopping the service"
-	service tyk-gateway stop
-	service tyk-gateway-python stop
-	service tyk-gateway-lua stop
+	stop tyk-gateway
+	stop tyk-gateway-python
+	stop tyk-gateway-lua
 	echo "Removing the service"
 	rm /etc/init/tyk-gateway.conf
 	rm /etc/init/tyk-gateway-python.conf


### PR DESCRIPTION
This mends init scripts incompatibility with Upstart 0.x (e.g. 0.6.5 as found on CentOS6/RHEL6/Amazon Linux, etc.)