### PR TITLE
USe asyncmap and avoid request copy

### DIFF
--- a/log_helpers.go
+++ b/log_helpers.go
@@ -30,3 +30,23 @@ func getLogEntryForRequest(r *http.Request, key string, data map[string]interfac
 	}
 	return log.WithFields(fields)
 }
+
+func getExplicitLogEntryForRequest(path string, IP string, key string, data map[string]interface{}) *logrus.Entry {
+	// populate http request fields
+	fields := logrus.Fields{
+		"path":   path,
+		"origin": IP,
+	}
+	// add key to log if configured to do so
+	if key != "" {
+		fields["key"] = key
+		if !config.Global.EnableKeyLogging {
+			fields["key"] = logHiddenValue
+		}
+	}
+	// add to log additional fields if any passed
+	for key, val := range data {
+		fields[key] = val
+	}
+	return log.WithFields(fields)
+}


### PR DESCRIPTION
This moves the `orgChanMap` into a`sync.Map` and removes reads from the request object by the AccessNext function, but retains the original request pointer in order to handle the context write required for the proxy at the end of the chain.

By having the request copy operation in there, the request is being copied for every request coming into the gateway. which potentially could impact throughput.