### PR TITLE
compile tracked endpoints logic change to set empty path

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -693,6 +693,13 @@ func (a APIDefinitionLoader) compileTrackedEndpointPathspathSpec(paths []apidef.
 	for _, stringSpec := range paths {
 		newSpec := URLSpec{}
 		a.generateRegex(stringSpec.Path, &newSpec, stat)
+
+		// set Path if it wasn't set
+		if stringSpec.Path == "" {
+			// even if it is empty (and regex matches everything) some middlewares expect to be value here
+			stringSpec.Path = "/"
+		}
+
 		// Extend with method actions
 		newSpec.TrackEndpoint = stringSpec
 		urlSpec = append(urlSpec, newSpec)


### PR DESCRIPTION
added fix for https://github.com/TykTechnologies/tyk-analytics/issues/574

I think we have to set it to `/` as allowing it to be stored in context as empty string (to avoid [current panic](https://github.com/TykTechnologies/tyk/blob/v2.5.1/api.go#L1443)) would confuse our tracked endpoint logic in places:

https://github.com/TykTechnologies/tyk/blob/v2.5.1/handler_success.go#L142

and

https://github.com/TykTechnologies/tyk/blob/master/handler_error.go#L133