### PR TITLE
Improve RPC stability in case of master failures

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -298,8 +298,14 @@ func (a APIDefinitionLoader) FromDashboardService(endpoint, secret string) []*AP
 
 // FromCloud will connect and download ApiDefintions from a Mongo DB instance.
 func (a APIDefinitionLoader) FromRPC(orgId string) []*APISpec {
+	if rpcEmergencyMode {
+		return LoadDefinitionsFromRPCBackup()
+	}
+
 	store := RPCStorageHandler{UserKey: config.Global.SlaveOptions.APIKey, Address: config.Global.SlaveOptions.ConnectionString}
-	store.Connect()
+	if !store.Connect() {
+		return nil
+	}
 
 	// enable segments
 	var tags []string

--- a/api_loader.go
+++ b/api_loader.go
@@ -665,8 +665,6 @@ func loadApps(specs []*APISpec, muxer *mux.Router) {
 	}).Info("Initialised API Definitions")
 
 	if config.Global.SlaveOptions.UseRPC {
-		//log.Warning("TODO: PUT THE KEEPALIVE WATCHER BACK")
-		startRPCKeepaliveWatcher(rpcAuthStore)
 		startRPCKeepaliveWatcher(rpcOrgStore)
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -66,6 +66,7 @@ type AnalyticsConfigConfig struct {
 	GeoIPDBLocation         string              `json:"geo_ip_db_path"`
 	NormaliseUrls           NormalisedURLConfig `json:"normalise_urls"`
 	PoolSize                int                 `json:"pool_size"`
+	StorageExpirationTime   int                 `json:"storage_expiration_time"`
 	ignoredIPsCompiled      map[string]bool
 }
 

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -113,6 +113,9 @@ func TestMain(m *testing.M) {
 	config.Global.BundleBaseURL = testHttpBundles
 	config.Global.MiddlewarePath = testMiddlewarePath
 
+	purgeTicker = make(chan time.Time)
+	rpcPurgeTicker = make(chan time.Time)
+
 	// force ipv4 for now, to work around the docker bug affecting
 	// Go 1.8 and ealier
 	config.Global.ListenAddress = "127.0.0.1"

--- a/ldap_auth_handler.go
+++ b/ldap_auth_handler.go
@@ -95,10 +95,16 @@ func (l *LDAPStorageHandler) GetRawKey(filter string) (string, error) {
 	return "", nil
 }
 
+func (l *LDAPStorageHandler) SetExp(cn string, exp int64) error {
+	log.Warning("Not implementated")
+	return nil
+}
+
 func (l *LDAPStorageHandler) GetExp(cn string) (int64, error) {
 	log.Warning("Not implementated")
 	return 0, nil
 }
+
 func (l *LDAPStorageHandler) GetKeys(filter string) []string {
 	log.Warning("Not implementated")
 	s := []string{}

--- a/lint/schema.go
+++ b/lint/schema.go
@@ -92,6 +92,9 @@ const confSchema = `{
 			"pool_size": {
 				"type": "integer"
 			},
+			"storage_expiration_time": {
+				"type": "integer"
+			},
 			"type": {
 				"type": "string"
 			}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -22,6 +22,7 @@ type Handler interface {
 	GetRawKey(string) (string, error)
 	SetKey(string, string, int64) error // Second input string is expected to be a JSON object (user.SessionState)
 	SetRawKey(string, string, int64) error
+	SetExp(string, int64) error   // Set key expiration
 	GetExp(string) (int64, error) // Returns expiry of a key
 	GetKeys(string) []string
 	DeleteKey(string) bool


### PR DESCRIPTION
There are a lot of small changes here:

Previously RPC layer recovery mechanism had own reloading functionality, conflicting with existing one, and we constantly forget to sync it with all the changes. Now it uses standard `doReload` and `syncApis`/`syncPolicies` functions know how to fetch backups if RPC layer is down. Worth noticing that it required refactoring how login functionality works, previously it was fully blocking call. So if I call `doReload` first time, it tries to connect to RPC layer, and if fails, `doReload` is stuck, and we can't even call it one more time, because of the mutexes used inside it. Now `Login` functionality is `async` and if Login failed, it will return error, `syncApis`/`syncPolicies` functions will return nil, and user will see normal reload with 0 apis. After it will trigger goroutine with reconnect functionality, which will load backups and call `doReload` one more time, and continue trying to login. When `Login` succeed, it will call `doReload` one more time, now trying to fetch latest API changes. 

When RPC layer is down, before purging analytics it will now do `Ping` first and only after success will call `GetSetAndDelete`, to get analytics from Redis and remove key. Previously if RPC layer is gone, analytics was discarded on the first call, now there is a `chance` for full recovery since analytic record does not get deleted.

Added Policy backup functionality, so now you can use OpenID, JWT or oAuth apis which depend on policies to create keys in local redis, even if RPC layer is down.

Additionally added protection to avoid infinite growths of analytics data if Pump or RPC layers are down. It is implemented by setting expiration to redis key which contains analytic records, and controlled using new attribute `analytics_config.storage_expiration_time`. The default value is 1 minute. If analytics key was not processed and re-created in given time, it will just expire, and data will be lost. 

Added tests for RPC layer failover and backups.

Tests to do:

### RPC failover
1) Start Hybrid with working RPC layer, so it will do backups
2) Stop RPC layer (or block it on firewall, or change RPC connection string to non-existent addr)
3) Start Hybrid test that it still works
4) Re-enable RPC, it should reconnect and fetch new changes

### Policies backup
Test that you can use oAuth or JWT apis without RPC layer

### Analytics overflow
Disable RPC layer, or Pump in case of on-premise, send lot of traffic to Tyk (maybe with detailed request data enabled), ensure that redis memory not grows infinite, and gets cut according to `analytics_config.storage_expiration_time` option