### PR TITLE
Tyk cache should respect etags

### DIFF
--- a/helpers_test.go
+++ b/helpers_test.go
@@ -368,8 +368,13 @@ func (s *tykTestServer) Run(t *testing.T, testCases ...test.TestCase) (*http.Res
 			t.Errorf("[%d] %s. %s", ti, lastError.Error(), string(tcJSON))
 		}
 
-		if s.config.delay > 0 {
-			time.Sleep(s.config.delay)
+		delay := tc.Delay
+		if delay == 0 {
+			delay = s.config.delay
+		}
+
+		if delay > 0 {
+			time.Sleep(delay)
 		}
 	}
 

--- a/test/http.go
+++ b/test/http.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"time"
 )
 
 type TestCase struct {
@@ -18,6 +19,7 @@ type TestCase struct {
 	Headers         map[string]string `json:",omitempty"`
 	PathParams      map[string]string `json:",omitempty"`
 	Cookies         []*http.Cookie    `json:",omitempty"`
+	Delay           time.Duration     `json:",omitempty"`
 	BodyMatch       string            `json:",omitempty"`
 	BodyNotMatch    string            `json:",omitempty"`
 	HeadersMatch    map[string]string `json:",omitempty"`


### PR DESCRIPTION
if upstream and client both provide Etags, and Tyk cached response, it
now should properly response with “304” status code without body, if
client etag match cached etag.

Fix #1370 