### PR TITLE
Add way to control maximum connection time

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -141,6 +141,7 @@ type APISpec struct {
 	HasRun                   bool
 	ServiceRefreshInProgress bool
 	HTTPTransport            http.RoundTripper
+	HTTPTransportCreated     time.Time
 }
 
 // APIDefinitionLoader will load an Api definition from a storage

--- a/config/config.go
+++ b/config/config.go
@@ -265,6 +265,7 @@ type Config struct {
 	AllowRemoteConfig                 bool                                  `bson:"allow_remote_config" json:"allow_remote_config"`
 	LegacyEnableAllowanceCountdown    bool                                  `bson:"legacy_enable_allowance_countdown" json:"legacy_enable_allowance_countdown"`
 	MaxIdleConnsPerHost               int                                   `bson:"max_idle_connections_per_host" json:"max_idle_connections_per_host"`
+	MaxConnTime                       int64                                 `json:"max_conn_time"`
 	ReloadWaitTime                    int                                   `bson:"reload_wait_time" json:"reload_wait_time"`
 	ProxySSLInsecureSkipVerify        bool                                  `json:"proxy_ssl_insecure_skip_verify"`
 	ProxyDefaultTimeout               int                                   `json:"proxy_default_timeout"`

--- a/lint/schema.go
+++ b/lint/schema.go
@@ -407,6 +407,9 @@ const confSchema = `{
 	"max_idle_connections_per_host": {
 		"type": "integer"
 	},
+	"max_conn_time": {
+		"type": "integer"
+	},
 	"middleware_path": {
 		"type": "string",
 		"format": "path"

--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -454,12 +454,19 @@ func httpTransport(timeOut int, rw http.ResponseWriter, req *http.Request, p *Re
 func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Request, withCache bool) *http.Response {
 	// 1. Check if timeouts are set for this endpoint
 	p.TykAPISpec.Lock()
-	if p.TykAPISpec.HTTPTransport == nil {
+
+	createTransport := p.TykAPISpec.HTTPTransport == nil
+	if !createTransport && config.Global.MaxConnTime != 0 {
+		createTransport = time.Since(p.TykAPISpec.HTTPTransportCreated) > time.Duration(config.Global.MaxConnTime)*time.Second
+	}
+
+	if createTransport {
 		_, timeout := p.CheckHardTimeoutEnforced(p.TykAPISpec, req)
 		p.TykAPISpec.HTTPTransport = httpTransport(timeout, rw, req, p)
 	} else if IsWebsocket(req) { // check if it is an upgrade request to NEW WS-connection
 		// overwrite transport's ResponseWriter from previous upgrade request
 		// as it was already hijacked and now is being used for other connection
+		p.TykAPISpec.HTTPTransportCreated = time.Now()
 		p.TykAPISpec.HTTPTransport.(*WSDialer).RW = rw
 	}
 	p.TykAPISpec.Unlock()


### PR DESCRIPTION
Added new `max_conn_time` option which will re-create API HTTPTransport
after specified time. Added to force DNS cache flush.

Fix #1485