### PR TITLE
Fix using of context vars inside advanced url rewrite

### DIFF
--- a/mw_context_vars.go
+++ b/mw_context_vars.go
@@ -36,6 +36,7 @@ func (m *MiddlewareContextVars) ProcessRequest(w http.ResponseWriter, r *http.Re
 		n := "headers_" + strings.Replace(hname, "-", "_", -1)
 		contextDataObject[n] = vals[0]
 	}
+	contextDataObject["headers_Host"] = copiedRequest.Host
 
 	// Path parts
 	segmentedPathArray := strings.Split(copiedRequest.URL.Path, "/")

--- a/mw_url_rewrite.go
+++ b/mw_url_rewrite.go
@@ -170,8 +170,12 @@ func urlRewrite(meta *apidef.URLRewriteMeta, r *http.Request) (string, error) {
 		contextKey := strings.Replace(v[0], "$tyk_context.", "", 1)
 
 		if val, ok := contextData[contextKey]; ok {
-			newpath = strings.Replace(newpath, v[0],
-				url.QueryEscape(valToStr(val)), -1)
+			valStr := valToStr(val)
+			// If contains url with domain
+			if !strings.HasPrefix(valStr, "http") {
+				valStr = url.QueryEscape(valStr)
+			}
+			newpath = strings.Replace(newpath, v[0], valStr, -1)
 		}
 	}
 
@@ -186,8 +190,12 @@ func urlRewrite(meta *apidef.URLRewriteMeta, r *http.Request) (string, error) {
 
 			val, ok := session.MetaData[contextKey]
 			if ok {
-				newpath = strings.Replace(newpath, v[0],
-					url.QueryEscape(valToStr(val)), -1)
+				valStr := valToStr(val)
+				// If contains url with domain
+				if !strings.HasPrefix(valStr, "http") {
+					valStr = url.QueryEscape(valStr)
+				}
+				newpath = strings.Replace(newpath, v[0], valStr, -1)
 			}
 
 		}


### PR DESCRIPTION
Fixes the case when context var contains full url, not path.
Fixes https://github.com/TykTechnologies/tyk/issues/1453

Additionally added support for Host header in tyk_context. Now it is
accessible via `$tyk_context.headers_Host`.
Fixes https://github.com/TykTechnologies/tyk/issues/1448