### PR TITLE
Support B64 Encoded Schema

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/rubyist/circuitbreaker"
 
+	"github.com/TykTechnologies/gojsonschema"
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/storage"
@@ -724,6 +725,8 @@ func (a APIDefinitionLoader) compileValidateJSONPathspathSpec(paths []apidef.Val
 		newSpec := URLSpec{}
 		a.generateRegex(stringSpec.Path, &newSpec, stat)
 		// Extend with method actions
+
+		stringSpec.SchemaCache = gojsonschema.NewGoLoader(stringSpec.Schema)
 		newSpec.ValidatePathMeta = stringSpec
 		urlSpec[i] = newSpec
 	}
@@ -1091,7 +1094,6 @@ func (a *APISpec) Version(r *http.Request) (*apidef.VersionInfo, []URLSpec, bool
 
 		// cache for the future
 		ctxSetVersionInfo(r, &version)
-
 	}
 
 	// Load path data and whitelist data for version


### PR DESCRIPTION
- feature: #1163 B64 encodes schema for storage. Decodes for sending to gateway & exporting.
- feature: #1163 If $schema supplied, check that is Draft-04
- fix: SchemaVersion unnessesary. Schema itself versioned
- bug: Fix caching so that the schema loads and caches at compile stage
- lint: snake case to camel case
