### PR TITLE
New set of RPC fixes

### DIFF
--- a/api_healthcheck.go
+++ b/api_healthcheck.go
@@ -61,11 +61,12 @@ func (h *DefaultHealthChecker) CreateKeyName(subKey HealthPrefix) string {
 // reportHealthValue is a shortcut we can use throughout the app to push a health check value
 func reportHealthValue(spec *APISpec, counter HealthPrefix, value string) {
 	configMu.Lock()
-	defer configMu.Unlock()
-
 	if !config.Global.HealthCheck.EnableHealthChecks {
+		configMu.Unlock()
 		return
 	}
+	configMu.Unlock()
+
 	spec.Health.StoreCounterVal(counter, value)
 }
 

--- a/api_loader.go
+++ b/api_loader.go
@@ -667,6 +667,7 @@ func loadApps(specs []*APISpec, muxer *mux.Router) {
 	}).Info("Initialised API Definitions")
 
 	if config.Global.SlaveOptions.UseRPC {
+		startRPCKeepaliveWatcher(rpcAuthStore)
 		startRPCKeepaliveWatcher(rpcOrgStore)
 	}
 }

--- a/api_loader.go
+++ b/api_loader.go
@@ -224,15 +224,11 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 
 	if spec.UseOauth2 {
 		log.Debug("Loading OAuth Manager")
-		if !rpcEmergencyMode {
-			oauthManager := addOAuthHandlers(spec, subrouter)
-			log.Debug("-- Added OAuth Handlers")
+		oauthManager := addOAuthHandlers(spec, subrouter)
+		log.Debug("-- Added OAuth Handlers")
 
-			spec.OAuthManager = oauthManager
-			log.Debug("Done loading OAuth Manager")
-		} else {
-			log.Warning("RPC Emergency mode detected! OAuth APIs will not function!")
-		}
+		spec.OAuthManager = oauthManager
+		log.Debug("Done loading OAuth Manager")
 	}
 
 	enableVersionOverrides := false

--- a/handler_error.go
+++ b/handler_error.go
@@ -84,7 +84,6 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 
 	ip := requestIP(r)
 	if config.Global.StoreAnalytics(ip) {
-
 		t := time.Now()
 
 		addVersionHeader(w, r)

--- a/handler_success.go
+++ b/handler_success.go
@@ -117,6 +117,7 @@ func (s *SuccessHandler) RecordHit(r *http.Request, timing int64, code int, requ
 
 		rawRequest := ""
 		rawResponse := ""
+
 		if recordDetail(r) {
 			// Get the wire format representation
 			var wireFormatReq bytes.Buffer
@@ -250,6 +251,7 @@ func (s *SuccessHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) *http
 		if recordDetail(r) {
 			copiedResponse = copyResponse(resp)
 		}
+
 		s.RecordHit(r, int64(millisec), resp.StatusCode, copiedRequest, copiedResponse)
 	}
 	log.Debug("Done proxy")

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -494,6 +494,11 @@ func updateAPIVersion(spec *APISpec, name string, verGen func(version *apidef.Ve
 	spec.VersionData.Versions[name] = version
 }
 
+func jsonMarshalString(i interface{}) (out string) {
+	b, _ := json.Marshal(i)
+	return string(b)
+}
+
 func buildAPI(apiGens ...func(spec *APISpec)) (specs []*APISpec) {
 	if len(apiGens) == 0 {
 		apiGens = append(apiGens, func(spec *APISpec) {})

--- a/main.go
+++ b/main.go
@@ -1315,7 +1315,6 @@ func startDRL() {
 type mainHandler struct{}
 
 func (_ mainHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	log.Fatal(r)
 	AddNewRelicInstrumentation(NewRelicApplication, mainRouter)
 	mainRouter.ServeHTTP(w, r)
 }

--- a/main.go
+++ b/main.go
@@ -690,10 +690,6 @@ func doReload() {
 	}).Info("API reload complete")
 
 	mainRouter = newRouter
-
-	// // Unset these
-	// rpcEmergencyModeLoaded = false
-	// rpcEmergencyMode = false
 }
 
 // startReloadChan and reloadDoneChan are used by the two reload loops

--- a/rpc_storage_handler.go
+++ b/rpc_storage_handler.go
@@ -288,8 +288,8 @@ func (r *RPCStorageHandler) ReAttemptLogin(err error) bool {
 	if rpcLoadCount == 0 && !rpcEmergencyModeLoaded {
 		log.Warning("[RPC Store] --> Detected cold start, attempting to load from cache")
 		log.Warning("[RPC Store] ----> Found APIs... beginning emergency load")
-		doReload()
 		rpcEmergencyModeLoaded = true
+		reloadURLStructure(nil)
 	}
 
 	time.Sleep(time.Second * 3)

--- a/rpc_storage_handler.go
+++ b/rpc_storage_handler.go
@@ -288,7 +288,7 @@ func (r *RPCStorageHandler) ReAttemptLogin(err error) bool {
 	if rpcLoadCount == 0 && !rpcEmergencyModeLoaded {
 		log.Warning("[RPC Store] --> Detected cold start, attempting to load from cache")
 		log.Warning("[RPC Store] ----> Found APIs... beginning emergency load")
-		doReload()
+		reloadURLStructure(nil)
 		rpcEmergencyModeLoaded = true
 	}
 
@@ -332,7 +332,7 @@ func (r *RPCStorageHandler) GroupLogin() bool {
 
 	// Recovery
 	if rpcEmergencyMode {
-		doReload()
+		reloadURLStructure(nil)
 	}
 
 	rpcEmergencyMode = false
@@ -371,7 +371,7 @@ func (r *RPCStorageHandler) Login() bool {
 	rpcLoadCount++
 
 	if rpcEmergencyMode {
-		doReload()
+		reloadURLStructure(nil)
 	}
 
 	rpcEmergencyMode = false

--- a/rpc_storage_handler.go
+++ b/rpc_storage_handler.go
@@ -180,9 +180,9 @@ func (r *RPCStorageHandler) Connect() bool {
 		RPCCLientSingleton = gorpc.NewTCPClient(r.Address)
 	}
 
-	// if log.Level != logrus.DebugLevel {
-	RPCCLientSingleton.LogError = gorpc.NilErrorLogger
-	// }
+	if log.Level != logrus.DebugLevel {
+		RPCCLientSingleton.LogError = gorpc.NilErrorLogger
+	}
 
 	RPCCLientSingleton.OnConnect = r.OnConnectFunc
 

--- a/rpc_storage_handler.go
+++ b/rpc_storage_handler.go
@@ -288,9 +288,8 @@ func (r *RPCStorageHandler) ReAttemptLogin(err error) bool {
 	if rpcLoadCount == 0 && !rpcEmergencyModeLoaded {
 		log.Warning("[RPC Store] --> Detected cold start, attempting to load from cache")
 		log.Warning("[RPC Store] ----> Found APIs... beginning emergency load")
-		reloadURLStructure(func(){
-			rpcEmergencyModeLoaded = true
-		})
+		doReload()
+		rpcEmergencyModeLoaded = true
 	}
 
 	time.Sleep(time.Second * 3)
@@ -333,10 +332,9 @@ func (r *RPCStorageHandler) GroupLogin() bool {
 
 	// Recovery
 	if rpcEmergencyMode {
-		reloadURLStructure(func(){
-			rpcEmergencyMode = false
-			rpcEmergencyModeLoaded = false
-		})
+		rpcEmergencyMode = false
+		rpcEmergencyModeLoaded = false
+		reloadURLStructure(nil)
 	}
 
 	return true
@@ -373,10 +371,9 @@ func (r *RPCStorageHandler) Login() bool {
 	rpcLoadCount++
 
 	if rpcEmergencyMode {
-		reloadURLStructure(func(){
-			rpcEmergencyMode = false
-			rpcEmergencyModeLoaded = false
-		})
+		rpcEmergencyMode = false
+		rpcEmergencyModeLoaded = false
+		reloadURLStructure(nil)
 	}
 
 	return true

--- a/rpc_storage_handler.go
+++ b/rpc_storage_handler.go
@@ -288,8 +288,9 @@ func (r *RPCStorageHandler) ReAttemptLogin(err error) bool {
 	if rpcLoadCount == 0 && !rpcEmergencyModeLoaded {
 		log.Warning("[RPC Store] --> Detected cold start, attempting to load from cache")
 		log.Warning("[RPC Store] ----> Found APIs... beginning emergency load")
-		reloadURLStructure(nil)
-		rpcEmergencyModeLoaded = true
+		reloadURLStructure(func(){
+			rpcEmergencyModeLoaded = true
+		})
 	}
 
 	time.Sleep(time.Second * 3)
@@ -332,11 +333,12 @@ func (r *RPCStorageHandler) GroupLogin() bool {
 
 	// Recovery
 	if rpcEmergencyMode {
-		reloadURLStructure(nil)
+		reloadURLStructure(func(){
+			rpcEmergencyMode = false
+			rpcEmergencyModeLoaded = false
+		})
 	}
 
-	rpcEmergencyMode = false
-	rpcEmergencyModeLoaded = false
 	return true
 }
 
@@ -371,11 +373,12 @@ func (r *RPCStorageHandler) Login() bool {
 	rpcLoadCount++
 
 	if rpcEmergencyMode {
-		reloadURLStructure(nil)
+		reloadURLStructure(func(){
+			rpcEmergencyMode = false
+			rpcEmergencyModeLoaded = false
+		})
 	}
 
-	rpcEmergencyMode = false
-	rpcEmergencyModeLoaded = false
 	return true
 }
 

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -134,7 +134,9 @@ func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 		defer ts.Close()
 
 		// Wait for backup to load
-		time.Sleep(200 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
+		reloadTick <- time.Time{}
+		time.Sleep(100 * time.Millisecond)
 
 		// Still should work!
 		ts.Run(t, []test.TestCase{

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -140,6 +140,11 @@ func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 
 		// Wait for backup to load
 		time.Sleep(100 * time.Millisecond)
+		select {
+			case reloadTick <- time.Time{}:
+			case <-time.After(100 * time.Millisecond):
+		}
+		time.Sleep(100 * time.Millisecond)
 
 		cachedAuth := map[string]string{"Authorization": "test"}
 		notCachedAuth := map[string]string{"Authorization": "nope1"}

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -24,6 +23,8 @@ func startRPCMock(dispatcher *gorpc.Dispatcher) *gorpc.Server {
 	config.Global.Policies.PolicySource = "rpc"
 	config.Global.SlaveOptions.CallTimeout = 1
 	config.Global.SlaveOptions.RPCPoolSize = 2
+	config.Global.AuthOverride.ForceAuthProvider = true
+	config.Global.AuthOverride.AuthProvider.StorageEngine = "rpc"
 
 	server := gorpc.NewTCPServer("127.0.0.1:0", dispatcher.NewHandlerFunc())
 	list := &customListener{}
@@ -44,6 +45,7 @@ func stopRPCMock(server *gorpc.Server) {
 	config.Global.SlaveOptions.APIKey = ""
 	config.Global.SlaveOptions.UseRPC = false
 	config.Global.Policies.PolicySource = ""
+	config.Global.AuthOverride.ForceAuthProvider = false
 
 	if server != nil {
 		server.Listener.Close()
@@ -83,7 +85,9 @@ func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 	// Mock RPC
 	dispatcher := gorpc.NewDispatcher()
 	dispatcher.AddFunc("GetApiDefinitions", func(clientAddr string, dr *DefRequest) (string, error) {
-		return "[" + sampleAPI + "]", nil
+		return jsonMarshalString(buildAPI(func(spec *APISpec) {
+			spec.UseKeylessAccess = false
+		})), nil
 	})
 	dispatcher.AddFunc("GetPolicies", func(clientAddr string, orgid string) (string, error) {
 		return `[{"_id":"507f191e810c19729de860ea", "rate":1, "per":1}]`, nil
@@ -92,7 +96,7 @@ func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 		return true
 	})
 	dispatcher.AddFunc("GetKey", func(clientAddr, key string) (string, error) {
-		return "", fmt.Errorf("Not found")
+		return jsonMarshalString(createStandardSession()), nil
 	})
 
 	t.Run("RPC is live", func(t *testing.T) {
@@ -111,8 +115,9 @@ func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 			t.Fatal("Should have Policies in backup")
 		}
 
+		authHeaders := map[string]string{"Authorization": "test"}
 		ts.Run(t, []test.TestCase{
-			{Path: "/sample", Code: 200},
+			{Path: "/sample", Headers: authHeaders, Code: 200},
 		}...)
 
 		count := syncAPISpecs()
@@ -121,7 +126,7 @@ func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 		}
 	})
 
-	t.Run("RPC down, load backup", func(t *testing.T) {
+	t.Run("RPC down, cold start, load backup", func(t *testing.T) {
 		// Point rpc to non existent address
 		config.Global.SlaveOptions.ConnectionString = testHttpFailure
 		config.Global.SlaveOptions.UseRPC = true
@@ -138,21 +143,27 @@ func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 		reloadTick <- time.Time{}
 		time.Sleep(100 * time.Millisecond)
 
-		// Still should work!
+		cachedAuth := map[string]string{"Authorization": "test"}
+		notCachedAuth := map[string]string{"Authorization": "nope1"}
+		// Stil works, since it knows about cached key
 		ts.Run(t, []test.TestCase{
-			{Path: "/sample", Code: 200},
+			{Path: "/sample", Headers: cachedAuth, Code: 200},
+			{Path: "/sample", Headers: notCachedAuth, Code: 403},
 		}...)
 
 		stopRPCMock(nil)
 	})
 
-	t.Run("RPC is back", func(t *testing.T) {
+	t.Run("RPC is back, hard reload", func(t *testing.T) {
 		rpcEmergencyModeLoaded = false
 		rpcEmergencyMode = false
 
 		dispatcher := gorpc.NewDispatcher()
 		dispatcher.AddFunc("GetApiDefinitions", func(clientAddr string, dr *DefRequest) (string, error) {
-			return "[" + sampleAPI + "," + sampleAPI + "]", nil
+			return jsonMarshalString(buildAPI(
+				func(spec *APISpec) { spec.UseKeylessAccess = false },
+				func(spec *APISpec) { spec.UseKeylessAccess = false },
+			)), nil
 		})
 		dispatcher.AddFunc("GetPolicies", func(clientAddr string, orgid string) (string, error) {
 			return `[{"_id":"507f191e810c19729de860ea", "rate":1, "per":1}, {"_id":"507f191e810c19729de860eb", "rate":1, "per":1}]`, nil
@@ -161,7 +172,7 @@ func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 			return true
 		})
 		dispatcher.AddFunc("GetKey", func(clientAddr, key string) (string, error) {
-			return "", fmt.Errorf("Not found")
+			return jsonMarshalString(createStandardSession()), nil
 		})
 		// Back to live
 		rpc := startRPCMock(dispatcher)
@@ -171,8 +182,11 @@ func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 
 		time.Sleep(100 * time.Millisecond)
 
+		cachedAuth := map[string]string{"Authorization": "test"}
+		notCachedAuth := map[string]string{"Authorization": "nope2"}
 		ts.Run(t, []test.TestCase{
-			{Path: "/sample", Code: 200},
+			{Path: "/sample", Headers: cachedAuth, Code: 200},
+			{Path: "/sample", Headers: notCachedAuth, Code: 200},
 		}...)
 
 		if count := syncAPISpecs(); count != 2 {
@@ -182,5 +196,46 @@ func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 		if count := syncPolicies(); count != 2 {
 			t.Error("Should fetch latest policies", count)
 		}
+	})
+
+	t.Run("RPC is back, live reload", func(t *testing.T) {
+		rpc := startRPCMock(dispatcher)
+		ts := newTykTestServer()
+		defer ts.Close()
+
+		time.Sleep(100 * time.Millisecond)
+
+		authHeaders := map[string]string{"Authorization": "test"}
+		ts.Run(t, []test.TestCase{
+			{Path: "/sample", Headers: authHeaders, Code: 200},
+		}...)
+
+		rpc.Listener.Close()
+		rpc.Stop()
+
+		cached := map[string]string{"Authorization": "test"}
+		notCached := map[string]string{"Authorization": "nope3"}
+		ts.Run(t, []test.TestCase{
+			{Path: "/sample", Headers: cached, Code: 200},
+			{Path: "/sample", Headers: notCached, Code: 403},
+		}...)
+
+		// Dynamically restart RPC layer
+		rpc = gorpc.NewTCPServer(rpc.Listener.(*customListener).L.Addr().String(), dispatcher.NewHandlerFunc())
+		list := &customListener{}
+		rpc.Listener = list
+		rpc.LogError = gorpc.NilErrorLogger
+		if err := rpc.Start(); err != nil {
+			panic(err)
+		}
+		defer stopRPCMock(rpc)
+
+		// Internal gorpc reconnect timeout is 1 second
+		time.Sleep(1000 * time.Millisecond)
+
+		notCached = map[string]string{"Authorization": "nope4"}
+		ts.Run(t, []test.TestCase{
+			{Path: "/sample", Headers: notCached, Code: 200},
+		}...)
 	})
 }

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -140,8 +140,6 @@ func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 
 		// Wait for backup to load
 		time.Sleep(100 * time.Millisecond)
-		reloadTick <- time.Time{}
-		time.Sleep(100 * time.Millisecond)
 
 		cachedAuth := map[string]string{"Authorization": "test"}
 		notCachedAuth := map[string]string{"Authorization": "nope1"}

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -141,8 +141,8 @@ func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 		// Wait for backup to load
 		time.Sleep(100 * time.Millisecond)
 		select {
-			case reloadTick <- time.Time{}:
-			case <-time.After(100 * time.Millisecond):
+		case reloadTick <- time.Time{}:
+		case <-time.After(100 * time.Millisecond):
 		}
 		time.Sleep(100 * time.Millisecond)
 


### PR DESCRIPTION
- Removed deadlocks caused in some cases by mutexes
- Enable oAuth for RPC emergency mode,  should work since policies are here
- Simplified `listen` reload logic
- Simplified keep alive function
- Restrict concurrent "Connect" calls
- Set default connection pool to 20 (Our hybrid docker image already have it but in config file)
- Fixed concurrency issue causing multiple reloads when backup is loaded
- Added tests for protected APIs when in backup mode