### PR TITLE
create/get keys with hashed keys logic added

### DIFF
--- a/api.go
+++ b/api.go
@@ -27,9 +27,10 @@ import (
 
 // apiModifyKeySuccess represents when a Key modification was successful
 type apiModifyKeySuccess struct {
-	Key    string `json:"key"`
-	Status string `json:"status"`
-	Action string `json:"action"`
+	Key     string `json:"key"`
+	Status  string `json:"status"`
+	Action  string `json:"action"`
+	KeyHash string `json:"key_hash,omitempty"`
 }
 
 // apiStatusMessage represents an API status message
@@ -98,7 +99,7 @@ func checkAndApplyTrialPeriod(keyName, apiId string, newSession *user.SessionSta
 		// Are we foring an expiry?
 		if policy.KeyExpiresIn > 0 {
 			// We are, does the key exist?
-			_, found := getKeyDetail(keyName, apiId)
+			_, found := getKeyDetail(keyName, apiId, false)
 			if !found {
 				// this is a new key, lets expire it
 				newSession.Expires = time.Now().Unix() + policy.KeyExpiresIn
@@ -212,13 +213,13 @@ func setSessionPassword(session *user.SessionState) {
 	session.BasicAuthData.Password = string(newPass)
 }
 
-func getKeyDetail(key, apiID string) (user.SessionState, bool) {
+func getKeyDetail(key, apiID string, hashed bool) (user.SessionState, bool) {
 	sessionManager := FallbackKeySesionManager
 	if spec := getApiSpec(apiID); spec != nil {
 		sessionManager = spec.SessionManager
 	}
 
-	return sessionManager.SessionDetail(key)
+	return sessionManager.SessionDetail(key, hashed)
 }
 
 func handleAddOrUpdate(keyName string, r *http.Request) (interface{}, int) {
@@ -242,7 +243,7 @@ func handleAddOrUpdate(keyName string, r *http.Request) (interface{}, int) {
 			var originalKey user.SessionState
 			var found bool
 			for apiID := range newSession.AccessRights {
-				originalKey, found = getKeyDetail(keyName, apiID)
+				originalKey, found = getKeyDetail(keyName, apiID, false)
 				if found {
 					break
 				}
@@ -280,21 +281,32 @@ func handleAddOrUpdate(keyName string, r *http.Request) (interface{}, int) {
 	})
 
 	response := apiModifyKeySuccess{
-		keyName,
-		"ok",
-		action,
+		Key:    keyName,
+		Status: "ok",
+		Action: action,
+	}
+
+	// add key hash for newly created key
+	if config.Global.HashKeys && r.Method == http.MethodPost {
+		response.KeyHash = storage.HashKey(keyName)
 	}
 
 	return response, 200
 }
 
-func handleGetDetail(sessionKey, apiID string) (interface{}, int) {
+func handleGetDetail(sessionKey, apiID string, byHash bool) (interface{}, int) {
+	if byHash && !config.Global.HashKeys {
+		return apiError("Key requested by hash but key hashing is not enabled"), 400
+	}
+
 	sessionManager := FallbackKeySesionManager
 	if spec := getApiSpec(apiID); spec != nil {
 		sessionManager = spec.SessionManager
 	}
 
-	session, ok := sessionManager.SessionDetail(sessionKey)
+	var session user.SessionState
+	var ok bool
+	session, ok = sessionManager.SessionDetail(sessionKey, byHash)
 	if !ok {
 		return apiError("Key not found"), 404
 	}
@@ -314,10 +326,6 @@ type apiAllKeys struct {
 }
 
 func handleGetAllKeys(filter, apiID string) (interface{}, int) {
-	if config.Global.HashKeys {
-		return apiError("Configuration is secured, key listings not available in hashed configurations"), 400
-	}
-
 	sessionManager := FallbackKeySesionManager
 	if spec := getApiSpec(apiID); spec != nil {
 		sessionManager = spec.SessionManager
@@ -347,7 +355,7 @@ func handleDeleteKey(keyName, apiID string) (interface{}, int) {
 		// Go through ALL managed API's and delete the key
 		apisMu.RLock()
 		for _, spec := range apisByID {
-			spec.SessionManager.RemoveSession(keyName)
+			spec.SessionManager.RemoveSession(keyName, false)
 			spec.SessionManager.ResetQuota(keyName, &user.SessionState{})
 		}
 		apisMu.RUnlock()
@@ -368,10 +376,14 @@ func handleDeleteKey(keyName, apiID string) (interface{}, int) {
 		sessionManager = spec.SessionManager
 	}
 
-	sessionManager.RemoveSession(keyName)
+	sessionManager.RemoveSession(keyName, false)
 	sessionManager.ResetQuota(keyName, &user.SessionState{})
 
-	statusObj := apiModifyKeySuccess{keyName, "ok", "deleted"}
+	statusObj := apiModifyKeySuccess{
+		Key:    keyName,
+		Status: "ok",
+		Action: "deleted",
+	}
 
 	FireSystemEvent(EventTokenDeleted, EventTokenMeta{
 		EventMetaDefault: EventMetaDefault{Message: "Key deleted."},
@@ -393,7 +405,7 @@ func handleDeleteHashedKey(keyName, apiID string) (interface{}, int) {
 		// Go through ALL managed API's and delete the key
 		apisMu.RLock()
 		for _, spec := range apisByID {
-			spec.SessionManager.RemoveSession(keyName)
+			spec.SessionManager.RemoveSession(keyName, true)
 		}
 		apisMu.RUnlock()
 
@@ -410,15 +422,13 @@ func handleDeleteHashedKey(keyName, apiID string) (interface{}, int) {
 	if spec := getApiSpec(apiID); spec != nil {
 		sessionManager = spec.SessionManager
 	}
+	sessionManager.RemoveSession(keyName, true)
 
-	// This is so we bypass the hash function
-	sessStore := sessionManager.Store()
-
-	// TODO: This is pretty ugly
-	setKeyName := "apikey-" + keyName
-	sessStore.DeleteRawKey(setKeyName)
-
-	statusObj := apiModifyKeySuccess{keyName, "ok", "deleted"}
+	statusObj := apiModifyKeySuccess{
+		Key:    keyName,
+		Status: "ok",
+		Action: "deleted",
+	}
 
 	log.WithFields(logrus.Fields{
 		"prefix": "api",
@@ -497,9 +507,10 @@ func handleAddOrUpdateApi(apiID string, r *http.Request) (interface{}, int) {
 	}
 
 	response := apiModifyKeySuccess{
-		newDef.APIID,
-		"ok",
-		action}
+		Key:    newDef.APIID,
+		Status: "ok",
+		Action: action,
+	}
 
 	return response, 200
 }
@@ -517,9 +528,10 @@ func handleDeleteAPI(apiID string) (interface{}, int) {
 	os.Remove(defFilePath)
 
 	response := apiModifyKeySuccess{
-		apiID,
-		"ok",
-		"deleted"}
+		Key:    apiID,
+		Status: "ok",
+		Action: "deleted",
+	}
 
 	return response, 200
 }
@@ -563,8 +575,9 @@ func apiHandler(w http.ResponseWriter, r *http.Request) {
 
 func keyHandler(w http.ResponseWriter, r *http.Request) {
 	keyName := mux.Vars(r)["keyName"]
-	filter := r.URL.Query().Get("filter")
 	apiID := r.URL.Query().Get("api_id")
+	isHashed := r.URL.Query().Get("hashed") != ""
+
 	var obj interface{}
 	var code int
 
@@ -575,16 +588,21 @@ func keyHandler(w http.ResponseWriter, r *http.Request) {
 	case "GET":
 		if keyName != "" {
 			// Return single key detail
-			obj, code = handleGetDetail(keyName, apiID)
+			obj, code = handleGetDetail(keyName, apiID, isHashed)
 		} else {
 			// Return list of keys
-			obj, code = handleGetAllKeys(filter, apiID)
+			if isHashed {
+				// we don't use filter for hashed keys
+				obj, code = handleGetAllKeys("", apiID)
+			} else {
+				filter := r.URL.Query().Get("filter")
+				obj, code = handleGetAllKeys(filter, apiID)
+			}
 		}
 
 	case "DELETE":
-		hashed := r.URL.Query().Get("hashed")
 		// Remove a key
-		if hashed == "" {
+		if !isHashed {
 			obj, code = handleDeleteKey(keyName, apiID)
 		} else {
 			obj, code = handleDeleteHashedKey(keyName, apiID)
@@ -620,53 +638,23 @@ func handleUpdateHashedKey(keyName, apiID, policyId string) (interface{}, int) {
 		sessionManager = spec.SessionManager
 	}
 
-	// This is so we bypass the hash function
-	sessStore := sessionManager.Store()
-
-	// TODO: This is pretty ugly
-	setKeyName := "apikey-" + keyName
-	rawSessionData, err := sessStore.GetRawKey(setKeyName)
-
-	if err != nil {
+	sess, ok := sessionManager.SessionDetail(keyName, true)
+	if !ok {
 		log.WithFields(logrus.Fields{
 			"prefix": "api",
 			"key":    keyName,
 			"status": "fail",
-			"err":    err,
 		}).Error("Failed to update hashed key.")
 
 		return apiError("Key not found"), 404
-	}
-
-	sess := user.SessionState{}
-	if err := json.Unmarshal([]byte(rawSessionData), &sess); err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "api",
-			"key":    keyName,
-			"status": "fail",
-			"err":    err,
-		}).Error("Failed to update hashed key.")
-
-		return apiError("Unmarshalling failed"), 400
 	}
 
 	// Set the policy
 	sess.LastUpdated = strconv.Itoa(int(time.Now().Unix()))
 	sess.SetPolicies(policyId)
 
-	sessAsJS, err := json.Marshal(sess)
+	err := sessionManager.UpdateSession(keyName, &sess, 0)
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "api",
-			"key":    keyName,
-			"status": "fail",
-			"err":    err,
-		}).Error("Failed to update hashed key.")
-
-		return apiError("Marshalling failed"), 500
-	}
-
-	if err := sessStore.SetRawKey(setKeyName, string(sessAsJS), 0); err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "api",
 			"key":    keyName,
@@ -677,7 +665,11 @@ func handleUpdateHashedKey(keyName, apiID, policyId string) (interface{}, int) {
 		return apiError("Could not write key data"), 500
 	}
 
-	statusObj := apiModifyKeySuccess{keyName, "ok", "updated"}
+	statusObj := apiModifyKeySuccess{
+		Key:    keyName,
+		Status: "ok",
+		Action: "updated",
+	}
 
 	log.WithFields(logrus.Fields{
 		"prefix": "api",
@@ -743,7 +735,7 @@ func handleOrgAddOrUpdate(keyName string, r *http.Request) (interface{}, int) {
 		rawKey := QuotaKeyPrefix + storage.HashKey(keyName)
 
 		// manage quotas separately
-		DefaultQuotaStore.RemoveSession(rawKey)
+		DefaultQuotaStore.Store().DeleteRawKey(rawKey)
 	}
 
 	err := sessionManager.UpdateSession(keyName, newSession, 0)
@@ -763,9 +755,9 @@ func handleOrgAddOrUpdate(keyName string, r *http.Request) (interface{}, int) {
 	}
 
 	response := apiModifyKeySuccess{
-		keyName,
-		"ok",
-		action,
+		Key:    keyName,
+		Status: "ok",
+		Action: action,
 	}
 
 	return response, 200
@@ -777,7 +769,7 @@ func handleGetOrgDetail(orgID string) (interface{}, int) {
 		return apiError("Org not found"), 404
 	}
 
-	session, ok := spec.OrgSessionManager.SessionDetail(orgID)
+	session, ok := spec.OrgSessionManager.SessionDetail(orgID, false)
 	if !ok {
 		log.WithFields(logrus.Fields{
 			"prefix": "api",
@@ -825,14 +817,18 @@ func handleDeleteOrgKey(orgID string) (interface{}, int) {
 		return apiError("Org not found"), 404
 	}
 
-	spec.OrgSessionManager.RemoveSession(orgID)
+	spec.OrgSessionManager.RemoveSession(orgID, false)
 	log.WithFields(logrus.Fields{
 		"prefix": "api",
 		"key":    orgID,
 		"status": "ok",
 	}).Info("Org key deleted.")
 
-	statusObj := apiModifyKeySuccess{orgID, "ok", "deleted"}
+	statusObj := apiModifyKeySuccess{
+		Key:    orgID,
+		Status: "ok",
+		Action: "deleted",
+	}
 	return statusObj, 200
 }
 
@@ -979,6 +975,11 @@ func createKeyHandler(w http.ResponseWriter, r *http.Request) {
 		Action: "added",
 		Key:    newKey,
 		Status: "ok",
+	}
+
+	// add key hash to reply
+	if config.Global.HashKeys {
+		obj.KeyHash = storage.HashKey(newKey)
 	}
 
 	FireSystemEvent(EventTokenCreated, EventTokenMeta{
@@ -1244,7 +1245,11 @@ func handleDeleteOAuthClient(keyName, apiID string) (interface{}, int) {
 		return apiError("Delete failed"), 500
 	}
 
-	statusObj := apiModifyKeySuccess{keyName, "ok", "deleted"}
+	statusObj := apiModifyKeySuccess{
+		Key:    keyName,
+		Status: "ok",
+		Action: "deleted",
+	}
 
 	log.WithFields(logrus.Fields{
 		"prefix": "api",

--- a/api_test.go
+++ b/api_test.go
@@ -252,7 +252,14 @@ func TestHashKeyHandler(t *testing.T) {
 	// make it to use hashes for Redis keys
 	hashKeys := config.Global.HashKeys
 	config.Global.HashKeys = true
-	defer func() { config.Global.HashKeys = hashKeys }()
+	// enable hashed keys listing
+	enableListing := config.Global.EnableHashedKeysListing
+	config.Global.EnableHashedKeysListing = true
+
+	defer func() {
+		config.Global.HashKeys = hashKeys
+		config.Global.EnableHashedKeysListing = enableListing
+	}()
 
 	ts := newTykTestServer()
 	defer ts.Close()
@@ -361,6 +368,217 @@ func TestHashKeyHandler(t *testing.T) {
 				Data:      string(withAccessJSON),
 				AdminAuth: true,
 				Code:      404,
+			},
+		}...)
+	})
+}
+
+func TestHashKeyListingDisabled(t *testing.T) {
+	// make it to use hashes for Redis keys
+	hashKeys := config.Global.HashKeys
+	config.Global.HashKeys = true
+	// disable hashed keys listing
+	enableListing := config.Global.EnableHashedKeysListing
+	config.Global.EnableHashedKeysListing = false
+
+	defer func() {
+		config.Global.HashKeys = hashKeys
+		config.Global.EnableHashedKeysListing = enableListing
+	}()
+
+	ts := newTykTestServer()
+	defer ts.Close()
+
+	buildAndLoadAPI()
+
+	withAccess := createStandardSession()
+	withAccess.AccessRights = map[string]user.AccessDefinition{"test": {
+		APIID: "test", Versions: []string{"v1"},
+	}}
+	withAccessJSON, _ := json.Marshal(withAccess)
+
+	myKey := "my_key_id"
+	myKeyHash := storage.HashKey(myKey)
+
+	t.Run("Create, get and delete key with key hashing", func(t *testing.T) {
+		ts.Run(t, []test.TestCase{
+			// create key
+			{
+				Method:    "POST",
+				Path:      "/tyk/keys/create",
+				Data:      string(withAccessJSON),
+				AdminAuth: true,
+				Code:      200,
+				BodyMatch: `"key_hash"`,
+			},
+			{
+				Method:    "POST",
+				Path:      "/tyk/keys",
+				Data:      string(withAccessJSON),
+				AdminAuth: true,
+				Code:      200,
+				BodyMatch: `"key_hash"`,
+			},
+			// create key with custom value
+			{
+				Method:    "POST",
+				Path:      "/tyk/keys/" + myKey,
+				Data:      string(withAccessJSON),
+				AdminAuth: true,
+				Code:      200,
+				BodyMatch: fmt.Sprintf(`"key_hash":"%s"`, myKeyHash),
+			},
+			// get one key by key name
+			{
+				Method:    "GET",
+				Path:      "/tyk/keys/" + myKey,
+				Data:      string(withAccessJSON),
+				AdminAuth: true,
+				Code:      200,
+			},
+			// get one key by hash value with specifying hashed=true (no API specified)
+			{
+				Method:    "GET",
+				Path:      "/tyk/keys/" + myKeyHash + "?hashed=true",
+				Data:      string(withAccessJSON),
+				AdminAuth: true,
+				Code:      200,
+			},
+			// get one key by hash value with specifying hashed=true (API specified)
+			{
+				Method:    "GET",
+				Path:      "/tyk/keys/" + myKeyHash + "?hashed=true&api_id=test",
+				Data:      string(withAccessJSON),
+				AdminAuth: true,
+				Code:      200,
+			},
+			// get one key by hash value without specifying hashed=true
+			{
+				Method:    "GET",
+				Path:      "/tyk/keys/" + myKeyHash,
+				Data:      string(withAccessJSON),
+				AdminAuth: true,
+				Code:      404,
+			},
+			// get list of keys' hashes, no API specified
+			{
+				Method:    "GET",
+				Path:      "/tyk/keys",
+				Data:      string(withAccessJSON),
+				AdminAuth: true,
+				Code:      404,
+			},
+			// get list of keys' hashes, API specified
+			{
+				Method:    "GET",
+				Path:      "/tyk/keys?api_id=test",
+				Data:      string(withAccessJSON),
+				AdminAuth: true,
+				Code:      404,
+			},
+			// delete one key by hash value with specifying hashed=true
+			{
+				Method:    "DELETE",
+				Path:      "/tyk/keys/" + myKeyHash + "?hashed=true&api_id=test",
+				Data:      string(withAccessJSON),
+				AdminAuth: true,
+				Code:      200,
+			},
+			// check that key is not present any more
+			{
+				Method:    "GET",
+				Path:      "/tyk/keys/" + myKeyHash + "?hashed=true&api_id=test",
+				Data:      string(withAccessJSON),
+				AdminAuth: true,
+				Code:      404,
+			},
+		}...)
+	})
+}
+
+func TestHashKeyHandlerHashingDisabled(t *testing.T) {
+	// make it to NOT use hashes for Redis keys
+	hashKeys := config.Global.HashKeys
+	config.Global.HashKeys = false
+
+	defer func() {
+		config.Global.HashKeys = hashKeys
+	}()
+
+	ts := newTykTestServer()
+	defer ts.Close()
+
+	buildAndLoadAPI()
+
+	withAccess := createStandardSession()
+	withAccess.AccessRights = map[string]user.AccessDefinition{"test": {
+		APIID: "test", Versions: []string{"v1"},
+	}}
+	withAccessJSON, _ := json.Marshal(withAccess)
+
+	myKey := "my_key_id"
+	myKeyHash := storage.HashKey(myKey)
+
+	t.Run("Create, get and delete key with key hashing", func(t *testing.T) {
+		ts.Run(t, []test.TestCase{
+			// create key
+			{
+				Method:       "POST",
+				Path:         "/tyk/keys/create",
+				Data:         string(withAccessJSON),
+				AdminAuth:    true,
+				Code:         200,
+				BodyNotMatch: `"key_hash"`,
+			},
+			{
+				Method:       "POST",
+				Path:         "/tyk/keys",
+				Data:         string(withAccessJSON),
+				AdminAuth:    true,
+				Code:         200,
+				BodyNotMatch: `"key_hash"`,
+			},
+			// create key with custom value
+			{
+				Method:       "POST",
+				Path:         "/tyk/keys/" + myKey,
+				Data:         string(withAccessJSON),
+				AdminAuth:    true,
+				Code:         200,
+				BodyMatch:    fmt.Sprintf(`"key":"%s"`, myKey),
+				BodyNotMatch: fmt.Sprintf(`"key_hash":"%s"`, myKeyHash),
+			},
+			// get one key by key name
+			{
+				Method:    "GET",
+				Path:      "/tyk/keys/" + myKey,
+				Data:      string(withAccessJSON),
+				AdminAuth: true,
+				Code:      200,
+			},
+			// get one key by hash value with specifying hashed=true (no API specified)
+			{
+				Method:    "GET",
+				Path:      "/tyk/keys/" + myKeyHash + "?hashed=true",
+				Data:      string(withAccessJSON),
+				AdminAuth: true,
+				Code:      400,
+			},
+			// get one key by hash value with specifying hashed=true (API specified)
+			{
+				Method:    "GET",
+				Path:      "/tyk/keys/" + myKeyHash + "?hashed=true&api_id=test",
+				Data:      string(withAccessJSON),
+				AdminAuth: true,
+				Code:      400,
+			},
+			// delete one key by hash value with specifying hashed=true
+			{
+				Method:    "DELETE",
+				Path:      "/tyk/keys/" + myKeyHash + "?hashed=true&api_id=test",
+				Data:      string(withAccessJSON),
+				AdminAuth: true,
+				Code:      200,
 			},
 		}...)
 	})

--- a/api_test.go
+++ b/api_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/satori/go.uuid"
 
+	"fmt"
+
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/storage"
@@ -242,6 +244,124 @@ func TestKeyHandler(t *testing.T) {
 		ts.Run(t, []test.TestCase{
 			{Method: "DELETE", Path: "/tyk/keys/" + knownKey, AdminAuth: true, Code: 200, BodyMatch: `"action":"deleted"`},
 			{Method: "GET", Path: "/tyk/keys/" + knownKey, AdminAuth: true, Code: 404},
+		}...)
+	})
+}
+
+func TestHashKeyHandler(t *testing.T) {
+	// make it to use hashes for Redis keys
+	hashKeys := config.Global.HashKeys
+	config.Global.HashKeys = true
+	defer func() { config.Global.HashKeys = hashKeys }()
+
+	ts := newTykTestServer()
+	defer ts.Close()
+
+	buildAndLoadAPI()
+
+	withAccess := createStandardSession()
+	withAccess.AccessRights = map[string]user.AccessDefinition{"test": {
+		APIID: "test", Versions: []string{"v1"},
+	}}
+	withAccessJSON, _ := json.Marshal(withAccess)
+
+	myKey := "my_key_id"
+	myKeyHash := storage.HashKey(myKey)
+
+	t.Run("Create, get and delete key with key hashing", func(t *testing.T) {
+		ts.Run(t, []test.TestCase{
+			// create key
+			{
+				Method:    "POST",
+				Path:      "/tyk/keys/create",
+				Data:      string(withAccessJSON),
+				AdminAuth: true,
+				Code:      200,
+				BodyMatch: `"key_hash"`,
+			},
+			{
+				Method:    "POST",
+				Path:      "/tyk/keys",
+				Data:      string(withAccessJSON),
+				AdminAuth: true,
+				Code:      200,
+				BodyMatch: `"key_hash"`,
+			},
+			// create key with custom value
+			{
+				Method:    "POST",
+				Path:      "/tyk/keys/" + myKey,
+				Data:      string(withAccessJSON),
+				AdminAuth: true,
+				Code:      200,
+				BodyMatch: fmt.Sprintf(`"key_hash":"%s"`, myKeyHash),
+			},
+			// get one key by key name
+			{
+				Method:    "GET",
+				Path:      "/tyk/keys/" + myKey,
+				Data:      string(withAccessJSON),
+				AdminAuth: true,
+				Code:      200,
+			},
+			// get one key by hash value with specifying hashed=true (no API specified)
+			{
+				Method:    "GET",
+				Path:      "/tyk/keys/" + myKeyHash + "?hashed=true",
+				Data:      string(withAccessJSON),
+				AdminAuth: true,
+				Code:      200,
+			},
+			// get one key by hash value with specifying hashed=true (API specified)
+			{
+				Method:    "GET",
+				Path:      "/tyk/keys/" + myKeyHash + "?hashed=true&api_id=test",
+				Data:      string(withAccessJSON),
+				AdminAuth: true,
+				Code:      200,
+			},
+			// get one key by hash value without specifying hashed=true
+			{
+				Method:    "GET",
+				Path:      "/tyk/keys/" + myKeyHash,
+				Data:      string(withAccessJSON),
+				AdminAuth: true,
+				Code:      404,
+			},
+			// get list of keys' hashes, no API specified
+			{
+				Method:    "GET",
+				Path:      "/tyk/keys",
+				Data:      string(withAccessJSON),
+				AdminAuth: true,
+				Code:      200,
+				BodyMatch: myKeyHash,
+			},
+			// get list of keys' hashes, API specified
+			{
+				Method:    "GET",
+				Path:      "/tyk/keys?api_id=test",
+				Data:      string(withAccessJSON),
+				AdminAuth: true,
+				Code:      200,
+				BodyMatch: myKeyHash,
+			},
+			// delete one key by hash value with specifying hashed=true
+			{
+				Method:    "DELETE",
+				Path:      "/tyk/keys/" + myKeyHash + "?hashed=true&api_id=test",
+				Data:      string(withAccessJSON),
+				AdminAuth: true,
+				Code:      200,
+			},
+			// check that key is not present any more
+			{
+				Method:    "GET",
+				Path:      "/tyk/keys/" + myKeyHash + "?hashed=true&api_id=test",
+				Data:      string(withAccessJSON),
+				AdminAuth: true,
+				Code:      404,
+			},
 		}...)
 	})
 }

--- a/auth_manager.go
+++ b/auth_manager.go
@@ -30,8 +30,8 @@ type AuthorisationHandler interface {
 type SessionHandler interface {
 	Init(store storage.Handler)
 	UpdateSession(keyName string, session *user.SessionState, resetTTLTo int64) error
-	RemoveSession(keyName string)
-	SessionDetail(keyName string) (user.SessionState, bool)
+	RemoveSession(keyName string, hashed bool)
+	SessionDetail(keyName string, hashed bool) (user.SessionState, bool)
 	Sessions(filter string) []string
 	Store() storage.Handler
 	ResetQuota(string, *user.SessionState)
@@ -122,17 +122,32 @@ func (b *DefaultSessionManager) UpdateSession(keyName string, session *user.Sess
 		go b.store.SetKey(keyName, string(v), resetTTLTo)
 		return nil
 	}
+
 	return b.store.SetKey(keyName, string(v), resetTTLTo)
 }
 
-func (b *DefaultSessionManager) RemoveSession(keyName string) {
-	b.store.DeleteKey(keyName)
+// RemoveSession removes session from storage
+func (b *DefaultSessionManager) RemoveSession(keyName string, hashed bool) {
+	if hashed {
+		b.store.DeleteRawKey(b.store.GetKeyPrefix() + keyName)
+	} else {
+		b.store.DeleteKey(keyName)
+	}
 }
 
 // SessionDetail returns the session detail using the storage engine (either in memory or Redis)
-func (b *DefaultSessionManager) SessionDetail(keyName string) (user.SessionState, bool) {
-	jsonKeyVal, err := b.store.GetKey(keyName)
+func (b *DefaultSessionManager) SessionDetail(keyName string, hashed bool) (user.SessionState, bool) {
+	var jsonKeyVal string
+	var err error
 	var session user.SessionState
+
+	// get session by key
+	if hashed {
+		jsonKeyVal, err = b.store.GetRawKey(b.store.GetKeyPrefix() + keyName)
+	} else {
+		jsonKeyVal, err = b.store.GetKey(keyName)
+	}
+
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix":      "auth-mgr",

--- a/config/config.go
+++ b/config/config.go
@@ -274,6 +274,7 @@ type Config struct {
 	EnableKeyLogging                  bool                                  `json:"enable_key_logging"`
 	NewRelic                          NewRelicConfig                        `json:"newrelic"`
 	VersionHeader                     string                                `json:"version_header"`
+	EnableHashedKeysListing           bool                                  `json:"enable_hashed_keys_listing"`
 }
 
 type CertData struct {

--- a/coprocess.go
+++ b/coprocess.go
@@ -310,7 +310,7 @@ func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 		if extractor == nil {
 			sessionLifetime := returnedSession.Lifetime(m.Spec.SessionLifetime)
 			// This API is not using the ID extractor, but we've got a session:
-			m.Spec.SessionManager.UpdateSession(token, returnedSession, sessionLifetime)
+			m.Spec.SessionManager.UpdateSession(token, returnedSession, sessionLifetime, false)
 			ctxSetSession(r, returnedSession)
 			ctxSetAuthToken(r, token)
 		} else {

--- a/coprocess_id_extractor.go
+++ b/coprocess_id_extractor.go
@@ -44,7 +44,7 @@ func (e *BaseExtractor) ExtractAndCheck(r *http.Request) (sessionID string, retu
 // PostProcess sets context variables and updates the storage.
 func (e *BaseExtractor) PostProcess(r *http.Request, session *user.SessionState, sessionID string) {
 	sessionLifetime := session.Lifetime(e.Spec.SessionLifetime)
-	e.Spec.SessionManager.UpdateSession(sessionID, session, sessionLifetime)
+	e.Spec.SessionManager.UpdateSession(sessionID, session, sessionLifetime, false)
 
 	ctxSetSession(r, session)
 	ctxSetAuthToken(r, sessionID)

--- a/coprocess_test.go
+++ b/coprocess_test.go
@@ -143,7 +143,7 @@ func TestCoProcessMiddleware(t *testing.T) {
 	chain := buildCoProcessChain(spec, "hook_test", coprocess.HookType_Pre, apidef.MiddlewareDriver("python"))
 
 	session := createStandardSession()
-	spec.SessionManager.UpdateSession("abc", session, 60)
+	spec.SessionManager.UpdateSession("abc", session, 60, false)
 
 	recorder := httptest.NewRecorder()
 
@@ -159,7 +159,7 @@ func TestCoProcessObjectPostProcess(t *testing.T) {
 	chain := buildCoProcessChain(spec, "hook_test_object_postprocess", coprocess.HookType_Pre, apidef.MiddlewareDriver("python"))
 
 	session := createStandardSession()
-	spec.SessionManager.UpdateSession("abc", session, 60)
+	spec.SessionManager.UpdateSession("abc", session, 60, false)
 
 	recorder := httptest.NewRecorder()
 
@@ -213,7 +213,7 @@ func TestCoProcessAuth(t *testing.T) {
 	chain := buildCoProcessChain(spec, "hook_test_bad_auth", coprocess.HookType_CustomKeyCheck, apidef.MiddlewareDriver("python"))
 
 	session := createStandardSession()
-	spec.SessionManager.UpdateSession("abc", session, 60)
+	spec.SessionManager.UpdateSession("abc", session, 60, false)
 
 	recorder := httptest.NewRecorder()
 
@@ -232,7 +232,7 @@ func TestCoProcessReturnOverrides(t *testing.T) {
 	spec := createSpecTest(t, basicCoProcessDef)
 	chain := buildCoProcessChain(spec, "hook_test_return_overrides", coprocess.HookType_Pre, apidef.MiddlewareDriver("python"))
 	session := createStandardSession()
-	spec.SessionManager.UpdateSession("abc", session, 60)
+	spec.SessionManager.UpdateSession("abc", session, 60, false)
 
 	recorder := httptest.NewRecorder()
 
@@ -252,7 +252,7 @@ func TestCoProcessReturnOverridesErrorMessage(t *testing.T) {
 	spec := createSpecTest(t, basicCoProcessDef)
 	chain := buildCoProcessChain(spec, "hook_test_return_overrides_error", coprocess.HookType_Pre, apidef.MiddlewareDriver("python"))
 	session := createStandardSession()
-	spec.SessionManager.UpdateSession("abc", session, 60)
+	spec.SessionManager.UpdateSession("abc", session, 60, false)
 
 	recorder := httptest.NewRecorder()
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -192,7 +192,7 @@ func createSession(sGen ...func(s *user.SessionState)) string {
 		key = session.Certificate
 	}
 
-	FallbackKeySesionManager.UpdateSession(key, session, 60)
+	FallbackKeySesionManager.UpdateSession(key, session, 60, false)
 	return key
 }
 

--- a/ldap_auth_handler.go
+++ b/ldap_auth_handler.go
@@ -190,3 +190,8 @@ func (l LDAPStorageHandler) DeleteScanMatch(pattern string) bool {
 	log.Error("Not implemented")
 	return false
 }
+
+func (l LDAPStorageHandler) GetKeyPrefix() string {
+	log.Error("Not implemented")
+	return ""
+}

--- a/lint/schema.go
+++ b/lint/schema.go
@@ -697,6 +697,9 @@ const confSchema = `{
 				"type": "string"
 			}
 		}
+	},
+	"enable_hashed_keys_listing": {
+		"type": "boolean"
 	}
 }
 }`

--- a/middleware.go
+++ b/middleware.go
@@ -260,7 +260,7 @@ func (t BaseMiddleware) ApplyPolicies(key string, session *user.SessionState) er
 		session.Tags = append(session.Tags, tag)
 	}
 	// Update the session in the session manager in case it gets called again
-	return t.Spec.SessionManager.UpdateSession(key, session, session.Lifetime(t.Spec.SessionLifetime))
+	return t.Spec.SessionManager.UpdateSession(key, session, session.Lifetime(t.Spec.SessionLifetime), false)
 }
 
 // CheckSessionAndIdentityForValidKey will check first the Session store for a valid key, if not found, it will try
@@ -315,7 +315,7 @@ func (t BaseMiddleware) CheckSessionAndIdentityForValidKey(key string) (user.Ses
 		log.Debug("Lifetime is: ", session.Lifetime(t.Spec.SessionLifetime))
 		// Need to set this in order for the write to work!
 		session.LastUpdated = time.Now().String()
-		t.Spec.SessionManager.UpdateSession(key, &session, session.Lifetime(t.Spec.SessionLifetime))
+		t.Spec.SessionManager.UpdateSession(key, &session, session.Lifetime(t.Spec.SessionLifetime), false)
 	}
 
 	return session, found

--- a/middleware.go
+++ b/middleware.go
@@ -139,7 +139,7 @@ func (t BaseMiddleware) Config() (interface{}, error) {
 
 func (t BaseMiddleware) OrgSession(key string) (user.SessionState, bool) {
 	// Try and get the session from the session store
-	session, found := t.Spec.OrgSessionManager.SessionDetail(key)
+	session, found := t.Spec.OrgSessionManager.SessionDetail(key, false)
 	if found && config.Global.EnforceOrgDataAge {
 		// If exists, assume it has been authorized and pass on
 		// We cache org expiry data
@@ -283,7 +283,7 @@ func (t BaseMiddleware) CheckSessionAndIdentityForValidKey(key string) (user.Ses
 
 	// Check session store
 	log.Debug("Querying keystore")
-	session, found := t.Spec.SessionManager.SessionDetail(key)
+	session, found := t.Spec.SessionManager.SessionDetail(key, false)
 	if found {
 		// If exists, assume it has been authorized and pass on
 		// cache it

--- a/multiauth_test.go
+++ b/multiauth_test.go
@@ -88,13 +88,13 @@ func TestMultiSession_BA_Standard_OK(t *testing.T) {
 	username := "0987876"
 	password := "TEST"
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
-	spec.SessionManager.UpdateSession("default0987876", baSession, 60)
+	spec.SessionManager.UpdateSession("default0987876", baSession, 60, false)
 
 	// Create key
 	session := createMultiAuthKeyAuthSession()
 	customToken := "84573485734587384888723487243"
 	// AuthKey sessions are stored by {token}
-	spec.SessionManager.UpdateSession(customToken, session, 60)
+	spec.SessionManager.UpdateSession(customToken, session, 60, false)
 
 	to_encode := strings.Join([]string{username, password}, ":")
 	encodedPass := base64.StdEncoding.EncodeToString([]byte(to_encode))
@@ -120,13 +120,13 @@ func TestMultiSession_BA_Standard_Identity(t *testing.T) {
 	username := "0987876"
 	password := "TEST"
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
-	spec.SessionManager.UpdateSession("default0987876", baSession, 60)
+	spec.SessionManager.UpdateSession("default0987876", baSession, 60, false)
 
 	// Create key
 	session := createMultiAuthKeyAuthSession()
 	customToken := "84573485734587384888723487243"
 	// AuthKey sessions are stored by {token}
-	spec.SessionManager.UpdateSession(customToken, session, 60)
+	spec.SessionManager.UpdateSession(customToken, session, 60, false)
 
 	to_encode := strings.Join([]string{username, password}, ":")
 	encodedPass := base64.StdEncoding.EncodeToString([]byte(to_encode))
@@ -157,13 +157,13 @@ func TestMultiSession_BA_Standard_FAILBA(t *testing.T) {
 	username := "0987876"
 	password := "WRONG"
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
-	spec.SessionManager.UpdateSession("default0987876", baSession, 60)
+	spec.SessionManager.UpdateSession("default0987876", baSession, 60, false)
 
 	// Create key
 	session := createMultiAuthKeyAuthSession()
 	customToken := "84573485734587384888723487243"
 	// AuthKey sessions are stored by {token}
-	spec.SessionManager.UpdateSession(customToken, session, 60)
+	spec.SessionManager.UpdateSession(customToken, session, 60, false)
 
 	to_encode := strings.Join([]string{username, password}, ":")
 	encodedPass := base64.StdEncoding.EncodeToString([]byte(to_encode))
@@ -189,13 +189,13 @@ func TestMultiSession_BA_Standard_FAILAuth(t *testing.T) {
 	username := "0987876"
 	password := "TEST"
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
-	spec.SessionManager.UpdateSession("default0987876", baSession, 60)
+	spec.SessionManager.UpdateSession("default0987876", baSession, 60, false)
 
 	// Create key
 	session := createMultiAuthKeyAuthSession()
 	customToken := "84573485734587384888723487243"
 	// AuthKey sessions are stored by {token}
-	spec.SessionManager.UpdateSession(customToken, session, 60)
+	spec.SessionManager.UpdateSession(customToken, session, 60, false)
 
 	to_encode := strings.Join([]string{username, password}, ":")
 	encodedPass := base64.StdEncoding.EncodeToString([]byte(to_encode))

--- a/mw_api_rate_limit_test.go
+++ b/mw_api_rate_limit_test.go
@@ -95,7 +95,7 @@ func TestRLClosed(t *testing.T) {
 	session := createRLSession()
 	customToken := uuid.NewV4().String()
 	// AuthKey sessions are stored by {token}
-	spec.SessionManager.UpdateSession(customToken, session, 60)
+	spec.SessionManager.UpdateSession(customToken, session, 60, false)
 	req.Header.Set("authorization", "Bearer "+customToken)
 
 	DRLManager.CurrentTokenValue = 1

--- a/mw_auth_key_test.go
+++ b/mw_auth_key_test.go
@@ -49,7 +49,7 @@ func TestBearerTokenAuthKeySession(t *testing.T) {
 	session := createAuthKeyAuthSession()
 	customToken := "54321111"
 	// AuthKey sessions are stored by {token}
-	spec.SessionManager.UpdateSession(customToken, session, 60)
+	spec.SessionManager.UpdateSession(customToken, session, 60, false)
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/auth_key_test/", nil)
@@ -86,7 +86,7 @@ func TestMultiAuthBackwardsCompatibleSession(t *testing.T) {
 	session := createAuthKeyAuthSession()
 	customToken := "54321111"
 	// AuthKey sessions are stored by {token}
-	spec.SessionManager.UpdateSession(customToken, session, 60)
+	spec.SessionManager.UpdateSession(customToken, session, 60, false)
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", fmt.Sprintf("/auth_key_test/?token=%s", customToken), nil)
@@ -124,7 +124,7 @@ func TestMultiAuthSession(t *testing.T) {
 	session := createAuthKeyAuthSession()
 	customToken := "54321111"
 	// AuthKey sessions are stored by {token}
-	spec.SessionManager.UpdateSession(customToken, session, 60)
+	spec.SessionManager.UpdateSession(customToken, session, 60, false)
 
 	// Set the url param
 	recorder := httptest.NewRecorder()

--- a/mw_hmac_test.go
+++ b/mw_hmac_test.go
@@ -111,7 +111,7 @@ func TestHMACAuthSessionPass(t *testing.T) {
 	}
 
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
-	spec.SessionManager.UpdateSession("9876", session, 60)
+	spec.SessionManager.UpdateSession("9876", session, 60, false)
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/", nil)
@@ -163,7 +163,7 @@ func TestHMACAuthSessionAuxDateHeader(t *testing.T) {
 	}
 
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
-	spec.SessionManager.UpdateSession("9876", session, 60)
+	spec.SessionManager.UpdateSession("9876", session, 60, false)
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/", nil)
@@ -215,7 +215,7 @@ func TestHMACAuthSessionFailureDateExpired(t *testing.T) {
 	}
 
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
-	spec.SessionManager.UpdateSession("9876", session, 60)
+	spec.SessionManager.UpdateSession("9876", session, 60, false)
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/", nil)
@@ -267,7 +267,7 @@ func TestHMACAuthSessionKeyMissing(t *testing.T) {
 	}
 
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
-	spec.SessionManager.UpdateSession("9876", session, 60)
+	spec.SessionManager.UpdateSession("9876", session, 60, false)
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/", nil)
@@ -319,7 +319,7 @@ func TestHMACAuthSessionMalformedHeader(t *testing.T) {
 	}
 
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
-	spec.SessionManager.UpdateSession("9876", session, 60)
+	spec.SessionManager.UpdateSession("9876", session, 60, false)
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/", nil)
@@ -371,7 +371,7 @@ func TestHMACAuthSessionPassWithHeaderField(t *testing.T) {
 	}
 
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
-	spec.SessionManager.UpdateSession("9876", session, 60)
+	spec.SessionManager.UpdateSession("9876", session, 60, false)
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/", nil)
@@ -444,7 +444,7 @@ func TestHMACAuthSessionPassWithHeaderFieldLowerCase(t *testing.T) {
 	}
 
 	// Basic auth sessions are stored as {org-id}{username}, so we need to append it here when we create the session.
-	spec.SessionManager.UpdateSession("9876", session, 60)
+	spec.SessionManager.UpdateSession("9876", session, 60, false)
 
 	recorder := httptest.NewRecorder()
 	req := testReq(t, "GET", "/", nil)

--- a/mw_js_plugin.go
+++ b/mw_js_plugin.go
@@ -250,7 +250,7 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 	// Save the sesison data (if modified)
 	if !d.Pre && d.UseSession && len(newRequestData.SessionMeta) > 0 {
 		session.MetaData = mapStrsToIfaces(newRequestData.SessionMeta)
-		d.Spec.SessionManager.UpdateSession(token, session, session.Lifetime(d.Spec.SessionLifetime))
+		d.Spec.SessionManager.UpdateSession(token, session, session.Lifetime(d.Spec.SessionLifetime), false)
 	}
 
 	log.WithFields(logrus.Fields{

--- a/mw_js_plugin.go
+++ b/mw_js_plugin.go
@@ -530,7 +530,7 @@ func (j *JSVM) LoadTykJSApi() {
 		apiKey := call.Argument(0).String()
 		apiId := call.Argument(1).String()
 
-		obj, _ := handleGetDetail(apiKey, apiId)
+		obj, _ := handleGetDetail(apiKey, apiId, false)
 		bs, _ := json.Marshal(obj)
 
 		returnVal, err := j.VM.ToValue(string(bs))

--- a/mw_jwt.go
+++ b/mw_jwt.go
@@ -255,7 +255,7 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 		session.Alias = baseFieldData
 
 		// Update the session in the session manager in case it gets called again
-		k.Spec.SessionManager.UpdateSession(sessionID, &session, session.Lifetime(k.Spec.SessionLifetime))
+		k.Spec.SessionManager.UpdateSession(sessionID, &session, session.Lifetime(k.Spec.SessionLifetime), false)
 		log.Debug("Policy applied to key")
 
 		switch k.Spec.BaseIdentityProvidedBy {
@@ -298,7 +298,7 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 			// update session storage
 			session.SetPolicies(policyID)
 			session.LastUpdated = time.Now().String()
-			k.Spec.SessionManager.UpdateSession(sessionID, &session, session.Lifetime(k.Spec.SessionLifetime))
+			k.Spec.SessionManager.UpdateSession(sessionID, &session, session.Lifetime(k.Spec.SessionLifetime), false)
 			// update session in cache
 			go SessionCache.Set(sessionID, session, cache.DefaultExpiration)
 		}

--- a/mw_jwt_test.go
+++ b/mw_jwt_test.go
@@ -97,7 +97,7 @@ func TestJWTSessionHMAC(t *testing.T) {
 	spec = loadAPI(spec)[0]
 	session := createJWTSession()
 	tokenKID := testKey(t, "token")
-	spec.SessionManager.UpdateSession(tokenKID, session, 60)
+	spec.SessionManager.UpdateSession(tokenKID, session, 60, false)
 
 	jwtToken := createJWKTokenHMAC(func(t *jwt.Token) {
 		t.Header["kid"] = tokenKID
@@ -127,7 +127,7 @@ func TestJWTSessionRSA(t *testing.T) {
 	spec = loadAPI(spec)[0]
 	session := createJWTSessionWithRSA()
 	tokenKID := testKey(t, "token")
-	spec.SessionManager.UpdateSession(tokenKID, session, 60)
+	spec.SessionManager.UpdateSession(tokenKID, session, 60, false)
 
 	jwtToken := createJWKToken(func(t *jwt.Token) {
 		t.Header["kid"] = tokenKID
@@ -157,7 +157,7 @@ func TestJWTSessionFailRSA_EmptyJWT(t *testing.T) {
 	spec = loadAPI(spec)[0]
 	session := createJWTSessionWithRSA()
 	tokenKID := testKey(t, "token")
-	spec.SessionManager.UpdateSession(tokenKID, session, 60)
+	spec.SessionManager.UpdateSession(tokenKID, session, 60, false)
 
 	authHeaders := map[string]string{"authorization": ""}
 	t.Run("Request with empty authorization header", func(t *testing.T) {
@@ -181,7 +181,7 @@ func TestJWTSessionFailRSA_NoAuthHeader(t *testing.T) {
 	spec = loadAPI(spec)[0]
 	session := createJWTSessionWithRSA()
 	tokenKID := testKey(t, "token")
-	spec.SessionManager.UpdateSession(tokenKID, session, 60)
+	spec.SessionManager.UpdateSession(tokenKID, session, 60, false)
 
 	authHeaders := map[string]string{}
 	t.Run("Request without authorization header", func(t *testing.T) {
@@ -205,7 +205,7 @@ func TestJWTSessionFailRSA_MalformedJWT(t *testing.T) {
 	spec = loadAPI(spec)[0]
 	session := createJWTSessionWithRSA()
 	tokenKID := testKey(t, "token")
-	spec.SessionManager.UpdateSession(tokenKID, session, 60)
+	spec.SessionManager.UpdateSession(tokenKID, session, 60, false)
 
 	jwtToken := createJWKToken(func(t *jwt.Token) {
 		t.Header["kid"] = tokenKID
@@ -236,7 +236,7 @@ func TestJWTSessionFailRSA_MalformedJWT_NOTRACK(t *testing.T) {
 	spec = loadAPI(spec)[0]
 	session := createJWTSessionWithRSA()
 	tokenKID := testKey(t, "token")
-	spec.SessionManager.UpdateSession(tokenKID, session, 60)
+	spec.SessionManager.UpdateSession(tokenKID, session, 60, false)
 
 	jwtToken := createJWKToken(func(t *jwt.Token) {
 		t.Header["kid"] = tokenKID
@@ -266,7 +266,7 @@ func TestJWTSessionFailRSA_WrongJWT(t *testing.T) {
 	spec = loadAPI(spec)[0]
 	session := createJWTSessionWithRSA()
 	tokenKID := testKey(t, "token")
-	spec.SessionManager.UpdateSession(tokenKID, session, 60)
+	spec.SessionManager.UpdateSession(tokenKID, session, 60, false)
 
 	authHeaders := map[string]string{"authorization": "123"}
 	t.Run("Request with invalid JWT", func(t *testing.T) {
@@ -290,7 +290,7 @@ func TestJWTSessionRSABearer(t *testing.T) {
 	spec = loadAPI(spec)[0]
 	session := createJWTSessionWithRSA()
 	tokenKID := testKey(t, "token")
-	spec.SessionManager.UpdateSession(tokenKID, session, 60)
+	spec.SessionManager.UpdateSession(tokenKID, session, 60, false)
 
 	jwtToken := createJWKToken(func(t *jwt.Token) {
 		t.Header["kid"] = tokenKID
@@ -321,7 +321,7 @@ func TestJWTSessionRSABearerInvalid(t *testing.T) {
 	session := createJWTSessionWithRSA()
 	tokenKID := testKey(t, "token")
 	spec.SessionManager.ResetQuota(tokenKID, session)
-	spec.SessionManager.UpdateSession(tokenKID, session, 60)
+	spec.SessionManager.UpdateSession(tokenKID, session, 60, false)
 
 	jwtToken := createJWKToken(func(t *jwt.Token) {
 		t.Header["kid"] = tokenKID
@@ -368,7 +368,7 @@ func TestJWTSessionRSAWithRawSourceOnWithClientID(t *testing.T) {
 	session := createJWTSessionWithRSAWithPolicy(policyID)
 
 	spec.SessionManager.ResetQuota(tokenID, session)
-	spec.SessionManager.UpdateSession(tokenID, session, 60)
+	spec.SessionManager.UpdateSession(tokenID, session, 60, false)
 
 	jwtToken := createJWKToken(func(t *jwt.Token) {
 		t.Header["kid"] = "12345"

--- a/mw_openid.go
+++ b/mw_openid.go
@@ -194,7 +194,7 @@ func (k *OpenIDMW) ProcessRequest(w http.ResponseWriter, r *http.Request, _ inte
 		session.Alias = clientID + ":" + ouser.ID
 
 		// Update the session in the session manager in case it gets called again
-		k.Spec.SessionManager.UpdateSession(sessionID, &session, session.Lifetime(k.Spec.SessionLifetime))
+		k.Spec.SessionManager.UpdateSession(sessionID, &session, session.Lifetime(k.Spec.SessionLifetime), false)
 		log.Debug("Policy applied to key")
 
 	}

--- a/mw_organisation_activity.go
+++ b/mw_organisation_activity.go
@@ -60,7 +60,7 @@ func (k *OrganizationMonitor) ProcessRequestLive(r *http.Request) (error, int) {
 		k.Spec.OrgID,
 		k.Spec.OrgSessionManager.Store(), false, false)
 
-	k.Spec.OrgSessionManager.UpdateSession(k.Spec.OrgID, &session, session.Lifetime(k.Spec.SessionLifetime))
+	k.Spec.OrgSessionManager.UpdateSession(k.Spec.OrgID, &session, session.Lifetime(k.Spec.SessionLifetime), false)
 
 	// org limits apply only to quotas, so we don't care about
 	// sessionFailRateLimit.
@@ -149,7 +149,7 @@ func (k *OrganizationMonitor) AllowAccessNext(orgChan chan bool, path string, IP
 	// We found a session, apply the quota limiter
 	isQuotaExceeded := k.sessionlimiter.RedisQuotaExceeded(&session, k.Spec.OrgID, k.Spec.OrgSessionManager.Store())
 
-	k.Spec.OrgSessionManager.UpdateSession(k.Spec.OrgID, &session, session.Lifetime(k.Spec.SessionLifetime))
+	k.Spec.OrgSessionManager.UpdateSession(k.Spec.OrgID, &session, session.Lifetime(k.Spec.SessionLifetime), false)
 
 	if isQuotaExceeded {
 		logEntry.Warning("Organisation quota has been exceeded.")

--- a/mw_rate_limiting.go
+++ b/mw_rate_limiting.go
@@ -75,7 +75,7 @@ func (k *RateLimitAndQuotaCheck) ProcessRequest(w http.ResponseWriter, r *http.R
 	// If either are disabled, save the write roundtrip
 	if !k.Spec.DisableRateLimit || !k.Spec.DisableQuota {
 		// Ensure quota and rate data for this session are recorded
-		k.Spec.SessionManager.UpdateSession(token, session, session.Lifetime(k.Spec.SessionLifetime))
+		k.Spec.SessionManager.UpdateSession(token, session, session.Lifetime(k.Spec.SessionLifetime), false)
 		ctxSetSession(r, session)
 	}
 

--- a/mw_virtual_endpoint.go
+++ b/mw_virtual_endpoint.go
@@ -215,7 +215,7 @@ func (d *VirtualEndpoint) ServeHTTPForCache(w http.ResponseWriter, r *http.Reque
 	// Save the sesison data (if modified)
 	if vmeta.UseSession {
 		session.MetaData = mapStrsToIfaces(newResponseData.SessionMeta)
-		d.Spec.SessionManager.UpdateSession(token, session, session.Lifetime(d.Spec.SessionLifetime))
+		d.Spec.SessionManager.UpdateSession(token, session, session.Lifetime(d.Spec.SessionLifetime), false)
 	}
 
 	log.Debug("JSVM Virtual Endpoint execution took: (ns) ", time.Now().UnixNano()-t1)

--- a/oauth_manager.go
+++ b/oauth_manager.go
@@ -300,7 +300,7 @@ func (o *OAuthManager) HandleAccess(r *http.Request) *osin.Response {
 			if foundKey {
 				log.Info("Found old token, revoking: ", oldToken)
 
-				o.API.SessionManager.RemoveSession(oldToken)
+				o.API.SessionManager.RemoveSession(oldToken, false)
 			}
 		}
 
@@ -660,7 +660,7 @@ func (r *RedisOsinStorageInterface) RemoveAccess(token string) error {
 	r.store.DeleteKey(key)
 
 	// remove the access token from central storage too
-	r.sessionManager.RemoveSession(token)
+	r.sessionManager.RemoveSession(token, false)
 
 	return nil
 }

--- a/oauth_manager.go
+++ b/oauth_manager.go
@@ -320,7 +320,7 @@ func (o *OAuthManager) HandleAccess(r *http.Request) *osin.Response {
 			keyName := o.API.OrgID + username
 
 			log.Debug("Updating user:", keyName)
-			err := o.API.SessionManager.UpdateSession(keyName, session, session.Lifetime(o.API.SessionLifetime))
+			err := o.API.SessionManager.UpdateSession(keyName, session, session.Lifetime(o.API.SessionLifetime), false)
 			if err != nil {
 				log.Error(err)
 			}
@@ -612,7 +612,7 @@ func (r *RedisOsinStorageInterface) SaveAccess(accessData *osin.AccessData) erro
 	newSession.Expires = time.Now().Unix() + int64(accessData.ExpiresIn)
 
 	// Use the default session expiry here as this is OAuth
-	r.sessionManager.UpdateSession(accessData.AccessToken, &newSession, int64(accessData.ExpiresIn))
+	r.sessionManager.UpdateSession(accessData.AccessToken, &newSession, int64(accessData.ExpiresIn), false)
 
 	// Store the refresh token too
 	if accessData.RefreshToken != "" {

--- a/policy_test.go
+++ b/policy_test.go
@@ -38,7 +38,7 @@ type dummySessionManager struct {
 	DefaultSessionManager
 }
 
-func (dummySessionManager) UpdateSession(key string, sess *user.SessionState, ttl int64) error {
+func (dummySessionManager) UpdateSession(key string, sess *user.SessionState, ttl int64, hashed bool) error {
 	return nil
 }
 

--- a/rpc_storage_handler.go
+++ b/rpc_storage_handler.go
@@ -955,6 +955,11 @@ func (r *RPCStorageHandler) DeleteScanMatch(pattern string) bool {
 	return false
 }
 
+func (r *RPCStorageHandler) GetKeyPrefix() string {
+	log.Error("Not implemented")
+	return ""
+}
+
 func getDispatcher() *gorpc.Dispatcher {
 	dispatch := gorpc.NewDispatcher()
 

--- a/storage/redis_cluster.go
+++ b/storage/redis_cluster.go
@@ -316,7 +316,11 @@ func (r RedisCluster) IncrememntWithExpire(keyName string, expire int64) int64 {
 // GetKeys will return all keys according to the filter (filter is a prefix - e.g. tyk.keys.*)
 func (r RedisCluster) GetKeys(filter string) []string {
 	r.ensureConnection()
-	searchStr := r.KeyPrefix + r.hashKey(filter) + "*"
+	filterHash := ""
+	if filter != "" {
+		filterHash = r.hashKey(filter)
+	}
+	searchStr := r.KeyPrefix + filterHash + "*"
 	sessionsInterface, err := r.singleton().Do("KEYS", searchStr)
 	if err != nil {
 		log.Error("Error trying to get all keys: ", err)
@@ -333,7 +337,11 @@ func (r RedisCluster) GetKeys(filter string) []string {
 // GetKeysAndValuesWithFilter will return all keys and their values with a filter
 func (r RedisCluster) GetKeysAndValuesWithFilter(filter string) map[string]string {
 	r.ensureConnection()
-	searchStr := r.KeyPrefix + r.hashKey(filter) + "*"
+	filterHash := ""
+	if filter != "" {
+		filterHash = r.hashKey(filter)
+	}
+	searchStr := r.KeyPrefix + filterHash + "*"
 	log.Debug("[STORE] Getting list by: ", searchStr)
 	sessionsInterface, err := r.singleton().Do("KEYS", searchStr)
 	if err != nil {
@@ -670,4 +678,9 @@ func (r RedisCluster) SetRollingWindow(keyName string, per int64, value_override
 	log.Debug("Returned: ", intVal)
 
 	return intVal, redVal[1].([]interface{})
+}
+
+// GetPrefix returns storage key prefix
+func (r RedisCluster) GetKeyPrefix() string {
+	return r.KeyPrefix
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -40,6 +40,7 @@ type Handler interface {
 	GetAndDeleteSet(string) []interface{}
 	RemoveFromSet(string, string)
 	DeleteScanMatch(string) bool
+	GetKeyPrefix() string
 }
 
 func HashStr(in string) string {


### PR DESCRIPTION
added changes for https://github.com/TykTechnologies/tyk/issues/1256

- creating key - `POST /keys/create`, `POST /keys` and `POST /keys/{keyName}` also return field `"key_hash"` if key hashing is switched on
- get all (or per API) keys  - `GET /keys` returns list of key hashes if key hashing is switched on
- get one key info by hash `GET /keys/{keyName}?hashed=true"`
- `DELETE /keys/{keyName}?hashed=true"` - remains the same (delete by hash)
