### PR TITLE
[WIP | PoC] feature: check os file descriptor limit and num cpus

### DIFF
--- a/checkup/checkup.go
+++ b/checkup/checkup.go
@@ -1,0 +1,36 @@
+package checkup
+
+import (
+	"runtime"
+	"syscall"
+
+	logger "github.com/TykTechnologies/tyk/log"
+)
+
+var log = logger.Get()
+
+const (
+	minCPU             = 2
+	minFileDescriptors = 80000
+)
+
+func CheckFileDescriptors() {
+
+	rlimit := &syscall.Rlimit{}
+	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, rlimit)
+	if err == nil && rlimit.Cur < minFileDescriptors {
+		log.Warningf("File descriptor limit %d too low for production use. Min %d recommended.\n"+
+			"\tThis could have a significant negative impact on performance.\n"+
+			"\tPlease refer to https://tyk.io/docs/deploy-tyk-premise-production/#file-handles for further guidance.", rlimit.Cur, minFileDescriptors)
+	}
+}
+
+func CheckCpus() {
+
+	cpus := runtime.NumCPU()
+	if cpus < minCPU {
+		log.Warningf("Num CPUs %d too low for production use. Min %d recommended.\n"+
+			"\tThis could have a significant negative impact on performance.\n"+
+			"\tPlease refer to https://tyk.io/docs/deploy-tyk-premise-production/#use-the-right-hardware for further guidance.", cpus, minCPU)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/newrelic/go-agent"
 
+	"github.com/TykTechnologies/tyk/checkup"
+
 	"github.com/Sirupsen/logrus"
 	logrus_syslog "github.com/Sirupsen/logrus/hooks/syslog"
 	logstashHook "github.com/bshuster-repo/logrus-logstash-hook"
@@ -1069,6 +1071,9 @@ func main() {
 	}
 
 	start()
+
+	checkup.CheckFileDescriptors()
+	checkup.CheckCpus()
 
 	// Wait while Redis connection pools are ready before start serving traffic
 	if !storage.IsConnected() {


### PR DESCRIPTION
#1507 

Logs a warning if numbers below acceptable levels.

```
[Mar  2 18:36:55]  WARN File descriptor limit 4864 too low for production use. Min 80000 recommended.
	This could have a significant negative impact on performance.
	Please refer to https://tyk.io/docs/deploy-tyk-premise-production/#file-handles for further guidance.
[Mar  2 18:36:55]  WARN Num CPU(s) 1 too low for production use. Min 2 recommended.
	This could have a significant negative impact on performance.
	Please refer to https://tyk.io/docs/deploy-tyk-premise-production/#use-the-right-hardware for further guidance.
```