### PR TITLE
requestIP to package, tests, benchmarks & context

### DIFF
--- a/handler_error.go
+++ b/handler_error.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/request"
 )
 
 const (
@@ -82,7 +83,7 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 	token := ctxGetAuthToken(r)
 	var alias string
 
-	ip := requestIP(r)
+	ip := request.RealIP(r)
 	if config.Global.StoreAnalytics(ip) {
 		t := time.Now()
 

--- a/handler_success.go
+++ b/handler_success.go
@@ -12,6 +12,8 @@ import (
 
 	cache "github.com/pmylund/go-cache"
 
+	"github.com/TykTechnologies/tyk/request"
+
 	"fmt"
 
 	"github.com/TykTechnologies/tyk/config"
@@ -85,7 +87,7 @@ func (s *SuccessHandler) RecordHit(r *http.Request, timing int64, code int, requ
 		return
 	}
 
-	ip := requestIP(r)
+	ip := request.RealIP(r)
 	if config.Global.StoreAnalytics(ip) {
 
 		t := time.Now()

--- a/handler_websocket.go
+++ b/handler_websocket.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/Sirupsen/logrus"
 
+	"github.com/TykTechnologies/tyk/request"
+
 	"github.com/TykTechnologies/tyk/config"
 )
 
@@ -37,6 +39,7 @@ func (ws *WSDialer) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	target := canonicalAddr(req.URL)
+	ip := request.RealIP(req)
 
 	// TLS
 	dial := ws.DialContext
@@ -64,7 +67,7 @@ func (ws *WSDialer) RoundTrip(req *http.Request) (*http.Response, error) {
 		http.Error(ws.RW, "Error contacting backend server.", 500)
 		log.WithFields(logrus.Fields{
 			"path":   target,
-			"origin": requestIP(req),
+			"origin": ip,
 		}).Error("Error dialing websocket backend", target, ": ", err)
 		return nil, err
 	}
@@ -80,7 +83,7 @@ func (ws *WSDialer) RoundTrip(req *http.Request) (*http.Response, error) {
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"path":   req.URL.Path,
-			"origin": requestIP(req),
+			"origin": ip,
 		}).Errorf("Hijack error: %v", err)
 		return nil, err
 	}
@@ -89,7 +92,7 @@ func (ws *WSDialer) RoundTrip(req *http.Request) (*http.Response, error) {
 	if err := req.Write(d); err != nil {
 		log.WithFields(logrus.Fields{
 			"path":   req.URL.Path,
-			"origin": requestIP(req),
+			"origin": ip,
 		}).Errorf("Error copying request to target: %v", err)
 		return nil, err
 	}
@@ -110,7 +113,7 @@ func (ws *WSDialer) RoundTrip(req *http.Request) (*http.Response, error) {
 		err = cerr
 		log.WithFields(logrus.Fields{
 			"path":   req.URL.Path,
-			"origin": requestIP(req),
+			"origin": ip,
 		}).Errorf("Error transmitting request: %v", err)
 	}
 

--- a/instrumentation_handlers.go
+++ b/instrumentation_handlers.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/gocraft/health"
 
+	"github.com/TykTechnologies/tyk/request"
+
 	"github.com/TykTechnologies/tyk/config"
 )
 
@@ -50,7 +52,7 @@ func InstrumentationMW(next http.Handler) http.Handler {
 
 		next.ServeHTTP(w, r)
 		job.EventKv("called", health.Kvs{
-			"from_ip":  requestIP(r),
+			"from_ip":  request.RealIP(r),
 			"method":   r.Method,
 			"endpoint": r.URL.Path,
 			"raw_url":  r.URL.String(),

--- a/log_helpers.go
+++ b/log_helpers.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/Sirupsen/logrus"
 
+	"github.com/TykTechnologies/tyk/request"
+
 	"github.com/TykTechnologies/tyk/config"
 )
 
@@ -15,7 +17,7 @@ func getLogEntryForRequest(r *http.Request, key string, data map[string]interfac
 	// populate http request fields
 	fields := logrus.Fields{
 		"path":   r.URL.Path,
-		"origin": requestIP(r),
+		"origin": request.RealIP(r),
 	}
 	// add key to log if configured to do so
 	if key != "" {

--- a/middleware.go
+++ b/middleware.go
@@ -12,6 +12,8 @@ import (
 	"github.com/paulbellamy/ratecounter"
 	cache "github.com/pmylund/go-cache"
 
+	"github.com/TykTechnologies/tyk/request"
+
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/user"
@@ -62,7 +64,7 @@ func createMiddleware(mw TykMiddleware) func(http.Handler) http.Handler {
 
 			job := instrument.NewJob("MiddlewareCall")
 			meta := health.Kvs{
-				"from_ip":  requestIP(r),
+				"from_ip":  request.RealIP(r),
 				"method":   r.Method,
 				"endpoint": r.URL.Path,
 				"raw_url":  r.URL.String(),

--- a/mw_api_rate_limit.go
+++ b/mw_api_rate_limit.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/TykTechnologies/tyk/request"
 	"github.com/TykTechnologies/tyk/user"
 )
 
@@ -49,7 +50,7 @@ func (k *RateLimitForAPI) handleRateLimitFailure(r *http.Request, token string) 
 	k.FireEvent(EventRateLimitExceeded, EventKeyFailureMeta{
 		EventMetaDefault: EventMetaDefault{Message: "API Rate Limit Exceeded", OriginatingRequest: EncodeRequestToEvent(r)},
 		Path:             r.URL.Path,
-		Origin:           requestIP(r),
+		Origin:           request.RealIP(r),
 		Key:              token,
 	})
 

--- a/mw_auth_key.go
+++ b/mw_auth_key.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/certs"
+	"github.com/TykTechnologies/tyk/request"
 )
 
 // KeyExists will check if the key being used to access the API is in the request data,
@@ -119,7 +120,7 @@ func AuthFailed(m TykMiddleware, r *http.Request, token string) {
 	m.Base().FireEvent(EventAuthFailure, EventKeyFailureMeta{
 		EventMetaDefault: EventMetaDefault{Message: "Auth Failure", OriginatingRequest: EncodeRequestToEvent(r)},
 		Path:             r.URL.Path,
-		Origin:           requestIP(r),
+		Origin:           request.RealIP(r),
 		Key:              token,
 	})
 }

--- a/mw_context_vars.go
+++ b/mw_context_vars.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/satori/go.uuid"
+
+	"github.com/TykTechnologies/tyk/request"
 )
 
 type MiddlewareContextVars struct {
@@ -45,8 +47,8 @@ func (m *MiddlewareContextVars) ProcessRequest(w http.ResponseWriter, r *http.Re
 	// path data
 	contextDataObject["path"] = copiedRequest.URL.Path
 
-	// IP:Port
-	contextDataObject["remote_addr"] = requestIP(copiedRequest)
+	// IP
+	contextDataObject["remote_addr"] = request.RealIP(copiedRequest)
 
 	//Correlation ID
 	contextDataObject["request_id"] = uuid.NewV4().String()

--- a/mw_ip_whitelist.go
+++ b/mw_ip_whitelist.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"net"
 	"net/http"
+
+	"github.com/TykTechnologies/tyk/request"
 )
 
 // IPWhiteListMiddleware lets you define a list of IPs to allow upstream
@@ -21,7 +23,7 @@ func (i *IPWhiteListMiddleware) EnabledForSpec() bool {
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (i *IPWhiteListMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
-	remoteIP := net.ParseIP(requestIP(r))
+	remoteIP := net.ParseIP(request.RealIP(r))
 
 	// Enabled, check incoming IP address
 	for _, ip := range i.Spec.AllowedIPs {

--- a/mw_key_expired_check.go
+++ b/mw_key_expired_check.go
@@ -3,6 +3,8 @@ package main
 import (
 	"errors"
 	"net/http"
+
+	"github.com/TykTechnologies/tyk/request"
 )
 
 // KeyExpired middleware will check if the requesting key is expired or not. It makes use of the authManager to do so.
@@ -29,7 +31,7 @@ func (k *KeyExpired) ProcessRequest(w http.ResponseWriter, r *http.Request, _ in
 		k.FireEvent(EventKeyExpired, EventKeyFailureMeta{
 			EventMetaDefault: EventMetaDefault{Message: "Attempted access from inactive key.", OriginatingRequest: EncodeRequestToEvent(r)},
 			Path:             r.URL.Path,
-			Origin:           requestIP(r),
+			Origin:           request.RealIP(r),
 			Key:              token,
 		})
 

--- a/mw_organisation_activity.go
+++ b/mw_organisation_activity.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 
 	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/request"
 )
 
 type orgChanMapMu struct {
@@ -77,7 +78,7 @@ func (k *OrganizationMonitor) ProcessRequestLive(r *http.Request) (error, int) {
 		k.FireEvent(EventOrgQuotaExceeded, EventKeyFailureMeta{
 			EventMetaDefault: EventMetaDefault{Message: "Organisation quota has been exceeded", OriginatingRequest: EncodeRequestToEvent(r)},
 			Path:             r.URL.Path,
-			Origin:           requestIP(r),
+			Origin:           request.RealIP(r),
 			Key:              k.Spec.OrgID,
 		})
 
@@ -118,7 +119,7 @@ func (k *OrganizationMonitor) ProcessRequestOffThread(r *http.Request) (error, i
 	orgChanMap.Unlock()
 	active, found := orgActiveMap.Load(k.Spec.OrgID)
 
-	go k.AllowAccessNext(orgChan, r.URL.Path, requestIP(r), r)
+	go k.AllowAccessNext(orgChan, r.URL.Path, request.RealIP(r), r)
 
 	if found && !active.(bool) {
 		log.Debug("Is not active")

--- a/mw_rate_limiting.go
+++ b/mw_rate_limiting.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/request"
 )
 
 var sessionLimiter = SessionLimiter{}
@@ -32,7 +33,7 @@ func (k *RateLimitAndQuotaCheck) handleRateLimitFailure(r *http.Request, token s
 	k.FireEvent(EventRateLimitExceeded, EventKeyFailureMeta{
 		EventMetaDefault: EventMetaDefault{Message: "Key Rate Limit Exceeded", OriginatingRequest: EncodeRequestToEvent(r)},
 		Path:             r.URL.Path,
-		Origin:           requestIP(r),
+		Origin:           request.RealIP(r),
 		Key:              token,
 	})
 
@@ -50,7 +51,7 @@ func (k *RateLimitAndQuotaCheck) handleQuotaFailure(r *http.Request, token strin
 	k.FireEvent(EventQuotaExceeded, EventKeyFailureMeta{
 		EventMetaDefault: EventMetaDefault{Message: "Key Quota Limit Exceeded", OriginatingRequest: EncodeRequestToEvent(r)},
 		Path:             r.URL.Path,
-		Origin:           requestIP(r),
+		Origin:           request.RealIP(r),
 		Key:              token,
 	})
 

--- a/mw_redis_cache.go
+++ b/mw_redis_cache.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/TykTechnologies/tyk/request"
 	"github.com/TykTechnologies/tyk/storage"
 )
 
@@ -128,7 +129,7 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 
 	// No authentication data? use the IP.
 	if token == "" {
-		token = requestIP(r)
+		token = request.RealIP(r)
 	}
 
 	var copiedRequest *http.Request

--- a/mw_version_check.go
+++ b/mw_version_check.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/request"
 )
 
 // VersionCheck will check whether the version of the requested API the request is accessing has any restrictions on URL endpoints
@@ -43,7 +44,7 @@ func (v *VersionCheck) ProcessRequest(w http.ResponseWriter, r *http.Request, _ 
 		v.FireEvent(EventVersionFailure, EventVersionFailureMeta{
 			EventMetaDefault: EventMetaDefault{Message: "Attempted access to disallowed version / path.", OriginatingRequest: EncodeRequestToEvent(r)},
 			Path:             r.URL.Path,
-			Origin:           requestIP(r),
+			Origin:           request.RealIP(r),
 			Reason:           string(stat),
 		})
 		return errors.New(string(stat)), 403

--- a/request/real_ip.go
+++ b/request/real_ip.go
@@ -1,0 +1,36 @@
+package request
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// RealIP takes a request object, and returns the real Client IP address.
+func RealIP(r *http.Request) string {
+
+	if contextIp := r.Context().Value("remote_addr"); contextIp != nil {
+		return contextIp.(string)
+	}
+
+	if realIP := r.Header.Get("X-Real-IP"); realIP != "" {
+		return realIP
+	}
+
+	if fw := r.Header.Get("X-Forwarded-For"); fw != "" {
+		// X-Forwarded-For has no port
+		if i := strings.IndexByte(fw, ','); i >= 0 {
+
+			return fw[:i]
+		}
+
+		return fw
+	}
+
+	// From net/http.Request.RemoteAddr:
+	//   The HTTP server in this package sets RemoteAddr to an
+	//   "IP:port" address before invoking a handler.
+	// So we can ignore the case of the port missing.
+	host, _, _ := net.SplitHostPort(r.RemoteAddr)
+	return host
+}

--- a/request/real_ip_test.go
+++ b/request/real_ip_test.go
@@ -1,0 +1,106 @@
+package request
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+var ipHeaderTests = []struct {
+	remoteAddr string
+	key        string
+	value      string
+	expected   string
+	comment    string
+}{
+	{remoteAddr: "10.0.1.4:8080", key: "X-Real-IP", value: "10.0.0.1", expected: "10.0.0.1", comment: "X-Real-IP"},
+	{remoteAddr: "10.0.1.4:8080", key: "X-Forwarded-For", value: "10.0.0.2", expected: "10.0.0.2", comment: "X-Forwarded-For (single)"},
+	{remoteAddr: "10.0.1.4:8080", key: "X-Forwarded-For", value: "10.0.0.3, 10.0.0.2, 10.0.0.1", expected: "10.0.0.3", comment: "X-Forwarded-For (multiple)"},
+	{remoteAddr: "10.0.1.4:8080", expected: "10.0.1.4", comment: "RemoteAddr"},
+}
+
+func TestRealIP(t *testing.T) {
+
+	for _, test := range ipHeaderTests {
+		t.Log(test.comment)
+
+		r, _ := http.NewRequest(http.MethodGet, "http://abc.com:8080", nil)
+		r.Header.Set(test.key, test.value)
+		r.RemoteAddr = test.remoteAddr
+
+		ip := RealIP(r)
+
+		if ip != test.expected {
+			t.Errorf("\texpected %s got %s", test.expected, ip)
+		}
+	}
+
+	t.Log("Context")
+	r, _ := http.NewRequest(http.MethodGet, "http://abc.com:8080", nil)
+
+	ctx := context.WithValue(r.Context(), "remote_addr", "10.0.0.5")
+	r = r.WithContext(ctx)
+
+	ip := RealIP(r)
+	if ip != "10.0.0.5" {
+		t.Errorf("\texpected %s got %s", "10.0.0.5", ip)
+	}
+}
+
+func BenchmarkRealIP_RemoteAddr(b *testing.B) {
+	b.ReportAllocs()
+
+	r, _ := http.NewRequest(http.MethodGet, "http://abc.com:8080", nil)
+	r.RemoteAddr = "10.0.1.4:8081"
+
+	for n := 0; n < b.N; n++ {
+		ip := RealIP(r)
+		if ip != "10.0.1.4" {
+			b.Errorf("\texpected %s got %s", "10.0.1.4", ip)
+		}
+	}
+}
+
+func BenchmarkRealIP_ForwardedFor(b *testing.B) {
+	b.ReportAllocs()
+
+	r, _ := http.NewRequest(http.MethodGet, "http://abc.com:8080", nil)
+	r.Header.Set("X-Forwarded-For", "10.0.0.3, 10.0.0.2, 10.0.0.1")
+
+	for n := 0; n < b.N; n++ {
+		ip := RealIP(r)
+		if ip != "10.0.0.3" {
+			b.Errorf("\texpected %s got %s", "10.0.1.3", ip)
+		}
+	}
+}
+
+func BenchmarkRealIP_RealIP(b *testing.B) {
+	b.ReportAllocs()
+
+	r, _ := http.NewRequest(http.MethodGet, "http://abc.com:8080", nil)
+	r.Header.Set("X-Real-IP", "10.0.0.1")
+
+	for n := 0; n < b.N; n++ {
+		ip := RealIP(r)
+		if ip != "10.0.0.1" {
+			b.Errorf("\texpected %s got %s", "10.0.0.1", ip)
+		}
+	}
+}
+
+func BenchmarkRealIP_Context(b *testing.B) {
+	b.ReportAllocs()
+
+	r, _ := http.NewRequest(http.MethodGet, "http://abc.com:8080", nil)
+	r.Header.Set("X-Real-IP", "10.0.0.1")
+	ctx := context.WithValue(r.Context(), "remote_addr", "10.0.0.5")
+	r = r.WithContext(ctx)
+
+	for n := 0; n < b.N; n++ {
+		ip := RealIP(r)
+		if ip != "10.0.0.5" {
+			b.Errorf("\texpected %s got %s", "10.0.0.5", ip)
+		}
+	}
+}

--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -791,26 +791,6 @@ func (m *maxLatencyWriter) flushLoop() {
 
 func (m *maxLatencyWriter) stop() { m.done <- true }
 
-func requestIP(r *http.Request) string {
-	if realIP := r.Header.Get("X-Real-IP"); realIP != "" {
-		return realIP
-	}
-	if fw := r.Header.Get("X-Forwarded-For"); fw != "" {
-		// X-Forwarded-For has no port
-		if i := strings.IndexByte(fw, ','); i >= 0 {
-			return fw[:i]
-		}
-		return fw
-	}
-
-	// From net/http.Request.RemoteAddr:
-	//   The HTTP server in this package sets RemoteAddr to an
-	//   "IP:port" address before invoking a handler.
-	// So we can ignore the case of the port missing.
-	host, _, _ := net.SplitHostPort(r.RemoteAddr)
-	return host
-}
-
 func requestIPHops(r *http.Request) string {
 	clientIP, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {

--- a/reverse_proxy_test.go
+++ b/reverse_proxy_test.go
@@ -11,6 +11,7 @@ import (
 	"text/template"
 
 	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/request"
 )
 
 func TestReverseProxyRetainHost(t *testing.T) {
@@ -129,7 +130,7 @@ func TestRequestIP(t *testing.T) {
 		r := &http.Request{RemoteAddr: tc.remote, Header: http.Header{}}
 		r.Header.Set("x-real-ip", tc.real)
 		r.Header.Set("x-forwarded-for", tc.forwarded)
-		got := requestIP(r)
+		got := request.RealIP(r)
 		if got != tc.want {
 			t.Errorf("requestIP({%q, %q, %q}) got %q, want %q",
 				tc.remote, tc.real, tc.forwarded, got, tc.want)


### PR DESCRIPTION
If we store IP in context in mw_context_vars, then when we need the IP address again,
we can do so with ~90% performance improvement.

```
BenchmarkRealIP_RemoteAddr-4            10000000               184 ns/op              16 B/op          1 allocs/op
BenchmarkRealIP_ForwardedFor-4          10000000               185 ns/op              16 B/op          1 allocs/op
BenchmarkRealIP_RealIP-4                10000000               139 ns/op              16 B/op          1 allocs/op
BenchmarkRealIP_Context-4               100000000               15.2 ns/op             0 B/op          0 allocs/op
PASS
ok      github.com/TykTechnologies/tyk/helpers  7.155s
```
