### PR TITLE
Update api_definition.go

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -86,7 +86,7 @@ const (
 )
 
 // URLSpec represents a flattened specification for URLs, used to check if a proxy URL
-// path is on any of the white, plack or ignored lists. This is generated as part of the
+// path is on any of the white, black or ignored lists. This is generated as part of the
 // configuration init
 type URLSpec struct {
 	Spec                    *regexp.Regexp


### PR DESCRIPTION
fix typo

also our of interest is this description still up to date? It's used a bit more widely than that no? 