### PR TITLE
Include cookie values in mw context data

### DIFF
--- a/mw_context_vars.go
+++ b/mw_context_vars.go
@@ -53,7 +53,12 @@ func (m *MiddlewareContextVars) ProcessRequest(w http.ResponseWriter, r *http.Re
 	//Correlation ID
 	contextDataObject["request_id"] = uuid.NewV4().String()
 
+	for _, c := range copiedRequest.Cookies() {
+		name := "cookies_" + strings.Replace(c.Name, "-", "_", -1)
+		contextDataObject[name] = c.Value
+	}
+
 	ctxSetData(r, contextDataObject)
 
-	return nil, 200
+	return nil, http.StatusOK
 }

--- a/mw_ip_blacklist.go
+++ b/mw_ip_blacklist.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"net"
 	"net/http"
+
+	"github.com/TykTechnologies/tyk/request"
 )
 
 // IPBlackListMiddleware lets you define a list of IPs to block from upstream
@@ -21,7 +23,7 @@ func (i *IPBlackListMiddleware) EnabledForSpec() bool {
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (i *IPBlackListMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
-	remoteIP := net.ParseIP(requestIP(r))
+	remoteIP := net.ParseIP(request.RealIP(r))
 
 	// Enabled, check incoming IP address
 	for _, ip := range i.Spec.BlacklistedIPs {


### PR DESCRIPTION
#1544 
    
 This PR allows the context variables to access the cookie by it's field
 name for use within middleware.
    
 ```
 $tyk_context.cookies_COOKIEFIELDNAME
 ```