### PR TITLE
1545 mw ip blacklisting

### DIFF
--- a/api_loader.go
+++ b/api_loader.go
@@ -297,6 +297,7 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 
 		mwAppendEnabled(&chainArray, &RateCheckMW{BaseMiddleware: baseMid})
 		mwAppendEnabled(&chainArray, &IPWhiteListMiddleware{BaseMiddleware: baseMid})
+		mwAppendEnabled(&chainArray, &IPBlackListMiddleware{BaseMiddleware: baseMid})
 		mwAppendEnabled(&chainArray, &CertificateCheckMW{BaseMiddleware: baseMid})
 		mwAppendEnabled(&chainArray, &OrganizationMonitor{BaseMiddleware: baseMid})
 		mwAppendEnabled(&chainArray, &RateLimitForAPI{BaseMiddleware: baseMid})
@@ -349,6 +350,7 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 
 		mwAppendEnabled(&chainArray, &RateCheckMW{BaseMiddleware: baseMid})
 		mwAppendEnabled(&chainArray, &IPWhiteListMiddleware{BaseMiddleware: baseMid})
+		mwAppendEnabled(&chainArray, &IPBlackListMiddleware{BaseMiddleware: baseMid})
 		mwAppendEnabled(&chainArray, &CertificateCheckMW{BaseMiddleware: baseMid})
 		mwAppendEnabled(&chainArray, &OrganizationMonitor{BaseMiddleware: baseMid})
 		mwAppendEnabled(&chainArray, &VersionCheck{BaseMiddleware: baseMid})
@@ -470,6 +472,7 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 
 		var simpleArray []alice.Constructor
 		mwAppendEnabled(&simpleArray, &IPWhiteListMiddleware{baseMid})
+		mwAppendEnabled(&chainArray, &IPBlackListMiddleware{BaseMiddleware: baseMid})
 		mwAppendEnabled(&simpleArray, &OrganizationMonitor{BaseMiddleware: baseMid})
 		mwAppendEnabled(&simpleArray, &VersionCheck{BaseMiddleware: baseMid})
 		simpleArray = append(simpleArray, authArray...)

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -376,6 +376,8 @@ type APIDefinition struct {
 	EnableBatchRequestSupport bool                   `bson:"enable_batch_request_support" json:"enable_batch_request_support"`
 	EnableIpWhiteListing      bool                   `mapstructure:"enable_ip_whitelisting" bson:"enable_ip_whitelisting" json:"enable_ip_whitelisting"`
 	AllowedIPs                []string               `mapstructure:"allowed_ips" bson:"allowed_ips" json:"allowed_ips"`
+	EnableIpBlacklisting      bool                   `mapstructure:"enable_ip_blacklisting" bson:"enable_ip_blacklisting" json:"enable_ip_blacklisting"`
+	BlacklistedIPs            []string               `mapstructure:"blacklisted_ips" bson:"blacklisted_ips" json:"blacklisted_ips"`
 	DontSetQuotasOnCreate     bool                   `mapstructure:"dont_set_quota_on_create" bson:"dont_set_quota_on_create" json:"dont_set_quota_on_create"`
 	ExpireAnalyticsAfter      int64                  `mapstructure:"expire_analytics_after" bson:"expire_analytics_after" json:"expire_analytics_after"` // must have an expireAt TTL index set (http://docs.mongodb.org/manual/tutorial/expire-data/)
 	ResponseProcessors        []ResponseProcessor    `bson:"response_processors" json:"response_processors"`

--- a/multiauth_test.go
+++ b/multiauth_test.go
@@ -70,6 +70,7 @@ func getMultiAuthStandardAndBasicAuthChain(spec *APISpec) http.Handler {
 	baseMid := BaseMiddleware{spec, proxy}
 	chain := alice.New(mwList(
 		&IPWhiteListMiddleware{baseMid},
+		&IPBlackListMiddleware{BaseMiddleware: baseMid},
 		&BasicAuthKeyIsValid{baseMid},
 		&AuthKey{baseMid},
 		&VersionCheck{BaseMiddleware: baseMid},

--- a/mw_api_rate_limit_test.go
+++ b/mw_api_rate_limit_test.go
@@ -35,6 +35,7 @@ func getRLOpenChain(spec *APISpec) http.Handler {
 	baseMid := BaseMiddleware{spec, proxy}
 	chain := alice.New(mwList(
 		&IPWhiteListMiddleware{baseMid},
+		&IPBlackListMiddleware{BaseMiddleware: baseMid},
 		&VersionCheck{BaseMiddleware: baseMid},
 		&RateLimitForAPI{BaseMiddleware: baseMid},
 	)...).Then(proxyHandler)
@@ -48,6 +49,7 @@ func getGlobalRLAuthKeyChain(spec *APISpec) http.Handler {
 	baseMid := BaseMiddleware{spec, proxy}
 	chain := alice.New(mwList(
 		&IPWhiteListMiddleware{baseMid},
+		&IPBlackListMiddleware{BaseMiddleware: baseMid},
 		&AuthKey{baseMid},
 		&VersionCheck{BaseMiddleware: baseMid},
 		&KeyExpired{baseMid},

--- a/mw_auth_key_test.go
+++ b/mw_auth_key_test.go
@@ -35,6 +35,7 @@ func getAuthKeyChain(spec *APISpec) http.Handler {
 	baseMid := BaseMiddleware{spec, proxy}
 	chain := alice.New(mwList(
 		&IPWhiteListMiddleware{baseMid},
+		&IPBlackListMiddleware{BaseMiddleware: baseMid},
 		&AuthKey{baseMid},
 		&VersionCheck{BaseMiddleware: baseMid},
 		&KeyExpired{baseMid},

--- a/mw_hmac_test.go
+++ b/mw_hmac_test.go
@@ -61,6 +61,7 @@ func getHMACAuthChain(spec *APISpec) http.Handler {
 	baseMid := BaseMiddleware{spec, proxy}
 	chain := alice.New(mwList(
 		&IPWhiteListMiddleware{baseMid},
+		&IPBlackListMiddleware{BaseMiddleware: baseMid},
 		&HMACMiddleware{BaseMiddleware: baseMid},
 		&VersionCheck{BaseMiddleware: baseMid},
 		&KeyExpired{baseMid},

--- a/mw_ip_blacklist.go
+++ b/mw_ip_blacklist.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"errors"
+	"net"
+	"net/http"
+)
+
+// IPBlackListMiddleware lets you define a list of IPs to block from upstream
+type IPBlackListMiddleware struct {
+	BaseMiddleware
+}
+
+func (i *IPBlackListMiddleware) Name() string {
+	return "IPBlackListMiddleware"
+}
+
+func (i *IPBlackListMiddleware) EnabledForSpec() bool {
+	return i.Spec.EnableIpBlacklisting && len(i.Spec.BlacklistedIPs) > 0
+}
+
+// ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
+func (i *IPBlackListMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
+	remoteIP := net.ParseIP(requestIP(r))
+
+	// Enabled, check incoming IP address
+	for _, ip := range i.Spec.BlacklistedIPs {
+		// Might be CIDR, try this one first then fallback to IP parsing later
+		blockedIP, blockedNet, err := net.ParseCIDR(ip)
+		if err != nil {
+			blockedIP = net.ParseIP(ip)
+		}
+
+		// Check CIDR if possible
+		if blockedNet != nil && blockedNet.Contains(remoteIP) {
+
+			return i.handleError(r, remoteIP.String())
+		}
+
+		// We parse the IP to manage IPv4 and IPv6 easily
+		if blockedIP.Equal(remoteIP) {
+
+			return i.handleError(r, remoteIP.String())
+		}
+	}
+
+	return nil, http.StatusOK
+}
+
+func (i *IPBlackListMiddleware) handleError(r *http.Request, blacklistedIP string) (error, int) {
+
+	// Fire Authfailed Event
+	AuthFailed(i, r, blacklistedIP)
+	// Report in health check
+	reportHealthValue(i.Spec, KeyFailure, "-1")
+	return errors.New("access from this IP has been disallowed"), http.StatusForbidden
+}

--- a/mw_ip_blacklist_test.go
+++ b/mw_ip_blacklist_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIPBlacklistMiddleware(t *testing.T) {
+	spec := buildAPI(func(spec *APISpec) {
+		spec.EnableIpBlacklisting = true
+		spec.BlacklistedIPs = []string{"127.0.0.1", "127.0.0.1/24"}
+	})[0]
+
+	for ti, tc := range []struct {
+		remote, forwarded string
+		wantCode          int
+	}{
+		{"127.0.0.1:80", "", http.StatusForbidden},         // remote exact match
+		{"127.0.0.2:80", "", http.StatusForbidden},         // remote CIDR match
+		{"10.0.0.1:80", "", http.StatusOK},                 // no match
+		{"10.0.0.1:80", "127.0.0.1", http.StatusForbidden}, // forwarded exact match
+		{"10.0.0.1:80", "127.0.0.2", http.StatusForbidden}, // forwarded CIDR match
+	} {
+		rec := httptest.NewRecorder()
+		req := testReq(t, "GET", "/", nil)
+		req.RemoteAddr = tc.remote
+		if tc.forwarded != "" {
+			req.Header.Set("X-Forwarded-For", tc.forwarded)
+		}
+
+		mw := &IPBlackListMiddleware{}
+		mw.Spec = spec
+		_, code := mw.ProcessRequest(rec, req, nil)
+
+		if code != tc.wantCode {
+			t.Errorf("[%d] Response code %d should be %d\n%q %q", ti,
+				code, tc.wantCode, tc.remote, tc.forwarded)
+		}
+	}
+}

--- a/mw_ip_whitelist.go
+++ b/mw_ip_whitelist.go
@@ -34,13 +34,13 @@ func (i *IPWhiteListMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Re
 		// Check CIDR if possible
 		if allowedNet != nil && allowedNet.Contains(remoteIP) {
 			// matched, pass through
-			return nil, 200
+			return nil, http.StatusOK
 		}
 
 		// We parse the IP to manage IPv4 and IPv6 easily
 		if allowedIP.Equal(remoteIP) {
 			// matched, pass through
-			return nil, 200
+			return nil, http.StatusOK
 		}
 	}
 
@@ -50,5 +50,5 @@ func (i *IPWhiteListMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Re
 	reportHealthValue(i.Spec, KeyFailure, "-1")
 
 	// Not matched, fail
-	return errors.New("Access from this IP has been disallowed"), 403
+	return errors.New("access from this IP has been disallowed"), http.StatusForbidden
 }

--- a/mw_ip_whitelist_test.go
+++ b/mw_ip_whitelist_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"testing"
 )
@@ -15,11 +16,11 @@ func TestIPMiddlewarePass(t *testing.T) {
 		remote, forwarded string
 		wantCode          int
 	}{
-		{"127.0.0.1:80", "", 200},         // remote exact match
-		{"127.0.0.2:80", "", 200},         // remote CIDR match
-		{"10.0.0.1:80", "", 403},          // no match
-		{"10.0.0.1:80", "127.0.0.1", 200}, // forwarded exact match
-		{"10.0.0.1:80", "127.0.0.2", 200}, // forwarded CIDR match
+		{"127.0.0.1:80", "", http.StatusOK},         // remote exact match
+		{"127.0.0.2:80", "", http.StatusOK},         // remote CIDR match
+		{"10.0.0.1:80", "", http.StatusForbidden},   // no match
+		{"10.0.0.1:80", "127.0.0.1", http.StatusOK}, // forwarded exact match
+		{"10.0.0.1:80", "127.0.0.2", http.StatusOK}, // forwarded CIDR match
 	} {
 		rec := httptest.NewRecorder()
 		req := testReq(t, "GET", "/", nil)


### PR DESCRIPTION
refs: #1545
    
This PR adds IP Blacklisting Middleware. It works in similar way to
IP Whitelisting.

Once merged:

- requires dashboard update to API Definition
- Requires UI
- Requires documentation