### PR TITLE
bug: implement EnabledForSpec for TrackEndpointMiddleware

### DIFF
--- a/mw_track_endpoints.go
+++ b/mw_track_endpoints.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/config"
 )
 
 // TrackEndpointMiddleware sets context variables to enable or disable whether Tyk should record analytitcs for a specific path.
@@ -11,22 +12,36 @@ type TrackEndpointMiddleware struct {
 	BaseMiddleware
 }
 
-func (a *TrackEndpointMiddleware) Name() string {
+func (t *TrackEndpointMiddleware) Name() string {
 	return "TrackEndpointMiddleware"
 }
 
+func (t *TrackEndpointMiddleware) EnabledForSpec() bool {
+	if !config.Global.EnableAnalytics || t.Spec.DoNotTrack {
+		return false
+	}
+
+	for _, version := range t.Spec.VersionData.Versions {
+		if len(version.ExtendedPaths.TrackEndpoints) > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
-func (a *TrackEndpointMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
-	_, versionPaths, _, _ := a.Spec.Version(r)
-	foundTracked, metaTrack := a.Spec.CheckSpecMatchesStatus(r, versionPaths, RequestTracked)
+func (t *TrackEndpointMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
+	_, versionPaths, _, _ := t.Spec.Version(r)
+	foundTracked, metaTrack := t.Spec.CheckSpecMatchesStatus(r, versionPaths, RequestTracked)
 	if foundTracked {
 		ctxSetTrackedPath(r, metaTrack.(*apidef.TrackEndpointMeta).Path)
 	}
 
-	foundDnTrack, _ := a.Spec.CheckSpecMatchesStatus(r, versionPaths, RequestNotTracked)
+	foundDnTrack, _ := t.Spec.CheckSpecMatchesStatus(r, versionPaths, RequestNotTracked)
 	if foundDnTrack {
 		ctxSetDoNotTrack(r, true)
 	}
 
-	return nil, 200
+	return nil, http.StatusOK
 }


### PR DESCRIPTION
fixes: #1547

Because `EnabledForSpec` was not implemented for this middleware, the mw
would run for every request - even if it didn't need to.

Implementation of the method resolves this issue. When analytics are
disabled or api spec is set to do_not_track, the middleware will
no longer be loaded. This should also result in a slightly faster response
time.
