### PR TITLE
[DO NOT MERGE] bug: CORS headers not returned when mw shortcircuits upsteam

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -193,7 +193,9 @@ func loopbackCORS(w http.ResponseWriter, r *http.Request, mw TykMiddleware) {
 	corsRes, err := corsClient.Do(corsRequest)
 	if err != nil {
 		log.WithError(err).Error("Error from upstream OPTIONS request, ignoring and returning default response")
+		return
 	}
+	defer corsRes.Body.Close()
 
 	corsHeaders := map[string]string{}
 	corsHeaders[response.AccessControlAllowOrigin] = corsRes.Header.Get(response.AccessControlAllowOrigin)

--- a/middleware.go
+++ b/middleware.go
@@ -189,7 +189,10 @@ func loopbackCORS(w http.ResponseWriter, r *http.Request, mw TykMiddleware) {
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: config.Global.HttpServerOptions.SSLInsecureSkipVerify},
 	}
 
-	corsClient := &http.Client{Transport: tr}
+	corsClient := &http.Client{
+		Transport: tr,
+		Timeout:   time.Second * 2,
+	}
 	corsRes, err := corsClient.Do(corsRequest)
 	if err != nil {
 		log.WithError(err).Error("Error from upstream OPTIONS request, ignoring and returning default response")

--- a/request/headers.go
+++ b/request/headers.go
@@ -1,0 +1,8 @@
+package request
+
+const (
+	// CORS request headers
+	Origin                      = "Origin"
+	AccessControlRequestMethod  = "Access-Control-Request-Method"
+	AccessControlRequestHeaders = "Access-Control-Request-Headers"
+)

--- a/response/headers.go
+++ b/response/headers.go
@@ -1,0 +1,9 @@
+package response
+
+const (
+	// CORS Response Headers
+	AccessControlAllowOrigin      = "Access-Control-Allow-Origin"
+	AccessControlAllowMethods     = "Access-Control-Allow-Methods"
+	AccessControlAllowCredentials = "Access-Control-Allow-Credentials"
+	AccessControlMaxAge           = "Access-Control-Max-Age"
+)


### PR DESCRIPTION
#1506

In the current scenario, when the gateway does not handle CORS, and
OptionsPassthrough is set to true, if the tyk middleware shortcircuits
the response, tyk is not able to return the required upstream CORS
headers.

This fixes the issue by detecting the appropriate conditions, and
sending an OPTIONS request via loopback, then appending the full set of
CORS headers to the error response.