### PR TITLE
KeyExpired event fires properly on key expiry

### DIFF
--- a/mw_key_expired_check.go
+++ b/mw_key_expired_check.go
@@ -46,6 +46,12 @@ func (k *KeyExpired) ProcessRequest(w http.ResponseWriter, r *http.Request, _ in
 	}
 	logEntry.Info("Attempted access from expired key.")
 
+	k.FireEvent(EventKeyExpired, EventKeyFailureMeta{
+		EventMetaDefault: EventMetaDefault{Message: "Attempted access from expired key.", OriginatingRequest: EncodeRequestToEvent(r)},
+		Path:             r.URL.Path,
+		Origin:           request.RealIP(r),
+		Key:              token,
+	})
 	// Report in health check
 	reportHealthValue(k.Spec, KeyFailure, "-1")
 


### PR DESCRIPTION
From what I can tell there are two possible cases the event should fire, if the session token is inactive or if the keyexpiry check returns true.

Added event for the latter.

Highlighted as issue in support ticket.