### PR TITLE
Separate client keep alive and proxy keepalive options

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -242,6 +242,7 @@ type Config struct {
 	LocalSessionCache                 LocalSessionCacheConf                 `json:"local_session_cache"`
 	HttpServerOptions                 HttpServerOptionsConfig               `json:"http_server_options"`
 	ServiceDiscovery                  ServiceDiscoveryConf                  `json:"service_discovery"`
+	ProxyCloseConnections             bool                                  `json:"proxy_close_connections"`
 	CloseConnections                  bool                                  `json:"close_connections"`
 	AuthOverride                      AuthOverrideConf                      `json:"auth_override"`
 	UptimeTests                       UptimeTestsConfig                     `json:"uptime_tests"`

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -1114,7 +1114,7 @@ func TestKeepAliveConns(t *testing.T) {
 
 	t.Run("Should use same connection", func(t *testing.T) {
 		// set keep alive option
-		config.Global.CloseConnections = false
+		config.Global.ProxyCloseConnections = false
 
 		// Allow 1 connection with 3 reads
 		upstream := createTestUptream(t, 1, 3)
@@ -1133,7 +1133,7 @@ func TestKeepAliveConns(t *testing.T) {
 	})
 
 	t.Run("Should use separate connection", func(t *testing.T) {
-		config.Global.CloseConnections = true
+		config.Global.ProxyCloseConnections = true
 
 		// Allow 3 connections with 1 read
 		upstream := createTestUptream(t, 3, 1)
@@ -1152,7 +1152,7 @@ func TestKeepAliveConns(t *testing.T) {
 	})
 
 	t.Run("Should respect max_conn_time", func(t *testing.T) {
-		config.Global.CloseConnections = false
+		config.Global.ProxyCloseConnections = false
 		// Allow 2 connection with 2 reads
 		upstream := createTestUptream(t, 2, 2)
 		defer upstream.Close()

--- a/lint/schema.go
+++ b/lint/schema.go
@@ -161,6 +161,9 @@ const confSchema = `{
 	"close_connections": {
 		"type": "boolean"
 	},
+	"proxy_close_connections": {
+		"type": "boolean"
+	},
 	"close_idle_connections": {
 		"type": "boolean"
 	},

--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -439,7 +439,7 @@ func httpTransport(timeOut int, rw http.ResponseWriter, req *http.Request, p *Re
 		transport.ResponseHeaderTimeout = time.Duration(timeOut) * time.Second
 	}
 
-	if config.Global.CloseConnections {
+	if config.Global.ProxyCloseConnections {
 		transport.DisableKeepAlives = true
 	}
 


### PR DESCRIPTION
In 2.5 we (I), introduced confusing change, and `connection_close` option started to disable proxy keepalives in addition to client keepalives. This brings a lot of confusion since we recommend setting `connection_close` in production environments.

This change rollbacks `connection_close` behavior: now it controls only client keepalives. And additionally, it disables keep alive on tyk server level, so even if clients do not obey `Connection: close` header, the connection will be closed anyway.

Added new option called `proxy_connection_close`, which controls keep alive behavior between tyk and upstream.  

Should fix https://github.com/TykTechnologies/tyk/issues/1565