### PR TITLE
Fixes token update when using non-partitioned policies

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -254,7 +254,7 @@ func (t BaseMiddleware) ApplyPolicies(key string, session *user.SessionState) er
 			}
 
 			// ACL
-			session.AccessRights = policy.AccessRights
+			rights = policy.AccessRights
 			session.HMACEnabled = policy.HMACEnabled
 		}
 


### PR DESCRIPTION
Fixes #1559, I would recommend doing some tests with the scenario described in #1501.