### PR TITLE
Add JWT token header claims to tyk_context

### DIFF
--- a/mw_jwt.go
+++ b/mw_jwt.go
@@ -451,6 +451,11 @@ func (k *JWTMiddleware) setContextVars(r *http.Request, token *jwt.Token) {
 	if cnt := ctxGetData(r); cnt != nil {
 		claimPrefix := "jwt_claims_"
 
+		for claimName, claimValue := range token.Header {
+			claim := claimPrefix + claimName
+			cnt[claim] = claimValue
+		}
+
 		for claimName, claimValue := range token.Claims.(jwt.MapClaims) {
 			claim := claimPrefix + claimName
 			cnt[claim] = claimValue

--- a/mw_openid.go
+++ b/mw_openid.go
@@ -234,6 +234,11 @@ func (k *OpenIDMW) setContextVars(r *http.Request, token *jwt.Token) {
 	}
 	claimPrefix := "jwt_claims_"
 
+	for claimName, claimValue := range token.Header {
+		claim := claimPrefix + claimName
+		cnt[claim] = claimValue
+	}
+
 	for claimName, claimValue := range token.Claims.(jwt.MapClaims) {
 		claim := claimPrefix + claimName
 		cnt[claim] = claimValue


### PR DESCRIPTION
Right now we expose to context only body claims, this PR expose header
claims like `kid`  as well.

Should fix https://github.com/TykTechnologies/tyk/issues/1563