### PR TITLE
bug: OAuth handler header return application/json media type

### DIFF
--- a/oauth_manager.go
+++ b/oauth_manager.go
@@ -170,6 +170,8 @@ func (o *OAuthHandlers) HandleAuthorizePassthrough(w http.ResponseWriter, r *htt
 // returns a response to the client and notifies the provider of the access request (in order to track identity against
 // OAuth tokens without revealing tokens before they are requested).
 func (o *OAuthHandlers) HandleAccessRequest(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
 	// Handle response
 	resp := o.Manager.HandleAccess(r)
 	msg := o.generateOAuthOutputFromOsinResponse(resp)
@@ -211,7 +213,7 @@ func (o *OAuthHandlers) HandleAccessRequest(w http.ResponseWriter, r *http.Reque
 
 	o.notifyClientOfNewOauth(newNotification)
 
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	w.Write(msg)
 }
 


### PR DESCRIPTION
resolves #1585

Current implementation, requests to `/myapi/oauth/token/` return `text/plain` media type header.
    
Response header Content-Type should be `application/json`. This PR resolves issue.
