### PR TITLE
Implemented autocert

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -121,6 +121,7 @@ type HttpServerOptionsConfig struct {
 	WriteTimeout           int        `json:"write_timeout"`
 	UseSSL                 bool       `json:"use_ssl"`
 	UseLE_SSL              bool       `json:"use_ssl_le"`
+	AcceptLetsEncryptTOS   bool 	  `json:"accept_lets_encrypt_tos"`
 	SSLInsecureSkipVerify  bool       `json:"ssl_insecure_skip_verify"`
 	EnableWebSockets       bool       `json:"enable_websockets"`
 	Certificates           []CertData `json:"certificates"`

--- a/le_helpers.go
+++ b/le_helpers.go
@@ -3,15 +3,15 @@ package main
 import (
 	"encoding/json"
 
+	"context"
+	"errors"
 	"github.com/Sirupsen/logrus"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/storage"
 	"golang.org/x/crypto/acme/autocert"
-	"time"
-	"net/http"
 	"net"
-	"context"
-	"errors"
+	"net/http"
+	"time"
 )
 
 // Errors
@@ -31,7 +31,7 @@ func NewRedisCache() *RedisCache {
 	}
 }
 
-func ConnectToRedisStore() (*storage.RedisCluster, error){
+func ConnectToRedisStore() (*storage.RedisCluster, error) {
 	store := storage.RedisCluster{KeyPrefix: LEKeyPrefix}
 
 	connected := store.Connect()
@@ -84,7 +84,7 @@ func (m RedisCache) Put(ctx context.Context, name string, data []byte) error {
 	secret := rightPad2Len(config.Global.Secret, "=", 32)
 	cryptoText := encrypt([]byte(secret), string(data))
 
-	if err := store.SetKey("cache-" + name, cryptoText, -1); err != nil {
+	if err := store.SetKey("cache-"+name, cryptoText, -1); err != nil {
 		log.Error("[SSL] --> Failed to store SSL backup: ", err)
 		return ErrRedisConnection
 	}
@@ -148,7 +148,7 @@ func MakeLEValidationHttpServer() *http.Server {
 	mux.HandleFunc("/", handleRedirect)
 
 	validationServer := &http.Server{
-		Addr: ":80",
+		Addr:         ":80",
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 5 * time.Second,
 		IdleTimeout:  120 * time.Second,

--- a/lint/schema.go
+++ b/lint/schema.go
@@ -358,6 +358,9 @@ const confSchema = `{
 			"use_ssl_le": {
 				"type": "boolean"
 			},
+			"accept_lets_encrypt_tos:": {
+				"type": "boolean"
+			},
 			"write_timeout": {
 				"type": "integer"
 			},

--- a/main.go
+++ b/main.go
@@ -3,6 +3,30 @@ package main
 import (
 	"crypto/tls"
 	"fmt"
+	"github.com/Sirupsen/logrus"
+	logrus_syslog "github.com/Sirupsen/logrus/hooks/syslog"
+	"github.com/TykTechnologies/goagain"
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/certs"
+	"github.com/TykTechnologies/tyk/checkup"
+	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/lint"
+	logger "github.com/TykTechnologies/tyk/log"
+	"github.com/TykTechnologies/tyk/storage"
+	"github.com/TykTechnologies/tyk/user"
+	logstashHook "github.com/bshuster-repo/logrus-logstash-hook"
+	"github.com/evalphobia/logrus_sentry"
+	"github.com/facebookgo/pidfile"
+	graylogHook "github.com/gemnasium/logrus-graylog-hook"
+	"github.com/gorilla/mux"
+	"github.com/justinas/alice"
+	"github.com/lonelycode/gorpc"
+	"github.com/lonelycode/osin"
+	"github.com/newrelic/go-agent"
+	"github.com/rs/cors"
+	"github.com/satori/go.uuid"
+	"golang.org/x/crypto/acme/autocert"
+	"gopkg.in/alecthomas/kingpin.v2"
 	"html/template"
 	"io/ioutil"
 	stdlog "log"
@@ -17,30 +41,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"github.com/newrelic/go-agent"
-	"github.com/TykTechnologies/tyk/checkup"
-	"github.com/Sirupsen/logrus"
-	logrus_syslog "github.com/Sirupsen/logrus/hooks/syslog"
-	logstashHook "github.com/bshuster-repo/logrus-logstash-hook"
-	"github.com/evalphobia/logrus_sentry"
-	"github.com/facebookgo/pidfile"
-	graylogHook "github.com/gemnasium/logrus-graylog-hook"
-	"github.com/gorilla/mux"
-	"github.com/justinas/alice"
-	"github.com/lonelycode/gorpc"
-	"github.com/lonelycode/osin"
-	"github.com/rs/cors"
-	"github.com/satori/go.uuid"
-	"gopkg.in/alecthomas/kingpin.v2"
-	"github.com/TykTechnologies/goagain"
-	"github.com/TykTechnologies/tyk/apidef"
-	"github.com/TykTechnologies/tyk/certs"
-	"github.com/TykTechnologies/tyk/config"
-	"github.com/TykTechnologies/tyk/lint"
-	logger "github.com/TykTechnologies/tyk/log"
-	"github.com/TykTechnologies/tyk/storage"
-	"github.com/TykTechnologies/tyk/user"
-	"golang.org/x/crypto/acme/autocert"
 )
 
 var (
@@ -861,7 +861,7 @@ func initialiseSystem() error {
 	if config.Global.HttpServerOptions.UseLE_SSL {
 		LE_MANAGER = &autocert.Manager{
 			Prompt: AcceptLetsEncryptTOS,
-			Cache: NewRedisCache(),
+			Cache:  NewRedisCache(),
 		}
 	}
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -529,6 +529,18 @@
 			"revisionTime": "2017-10-25T06:06:43Z"
 		},
 		{
+			"checksumSHA1": "zHLlCNnnX/KNVue2tHr+FWxbszA=",
+			"path": "golang.org/x/crypto/acme",
+			"revision": "12892e8c234f4fe6f6803f052061de9057903bb2",
+			"revisionTime": "2018-03-28T23:19:55Z"
+		},
+		{
+			"checksumSHA1": "6NdRp9OYL38e71vEtcQtSkN/ZbA=",
+			"path": "golang.org/x/crypto/acme/autocert",
+			"revision": "12892e8c234f4fe6f6803f052061de9057903bb2",
+			"revisionTime": "2018-03-28T23:19:55Z"
+		},
+		{
 			"checksumSHA1": "vE43s37+4CJ2CDU6TlOUOYE0K9c=",
 			"path": "golang.org/x/crypto/bcrypt",
 			"revision": "22ddb68eccda408bbf17759ac18d3120ce0d4f3f",


### PR DESCRIPTION
This is a work in progress, I updated to autocert as described in this issue: https://github.com/TykTechnologies/tyk/issues/834

A few things: 

- Lets Encrypt disabled TLS-SNI http://www.zdnet.com/article/lets-encrypt-disables-tls-sni-01-validation/ which is what tyk is currently using to generate the certificates
- I had to use the http-01 ACME challenge (see http://letsencrypt.readthedocs.io/en/latest/challenges.html for more informations) which needs to have the port 80 available. 
- I have no idea what the NoticeGatewayLENotification is, it's not used anywhere in the source code, does anyone have any idea what it refers to in the current code base?
- I made a redirection to the https endpoint in case someone tries to access the gateway from the port 80.
- I created a new config variable a user has to set to agree with Letsencrypt's TOS

I'd appreciate to have feedbacks