### PR TITLE
Added public key pinning feature

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -331,6 +331,7 @@ type APIDefinition struct {
 	UseMutualTLSAuth        bool                 `bson:"use_mutual_tls_auth" json:"use_mutual_tls_auth"`
 	ClientCertificates      []string             `bson:"client_certificates" json:"client_certificates"`
 	UpstreamCertificates    map[string]string    `bson:"upstream_certificates" json:"upstream_certificates"`
+	PinnedPublicKeys        map[string]string    `bson:"pinned_public_keys" json:"pinned_public_keys"`
 	EnableJWT               bool                 `bson:"enable_jwt" json:"enable_jwt"`
 	UseStandardAuth         bool                 `bson:"use_standard_auth" json:"use_standard_auth"`
 	EnableCoProcessAuth     bool                 `bson:"enable_coprocess_auth" json:"enable_coprocess_auth"`

--- a/batch_requests.go
+++ b/batch_requests.go
@@ -48,6 +48,9 @@ func (b *BatchRequestHandler) doRequest(req *http.Request, relURL string) BatchR
 	}
 
 	tr.TLSClientConfig.InsecureSkipVerify = config.Global.ProxySSLInsecureSkipVerify
+
+	tr.DialTLS = dialTLSPinnedCheck(b.API, tr.TLSClientConfig)
+
 	client := &http.Client{Transport: tr}
 
 	resp, err := client.Do(req)

--- a/config/config.go
+++ b/config/config.go
@@ -173,6 +173,7 @@ type CertificatesConfig struct {
 type SecurityConfig struct {
 	PrivateCertificateEncodingSecret string             `json:"private_certificate_encoding_secret"`
 	ControlAPIUseMutualTLS           bool               `json:"control_api_use_mutual_tls"`
+	PinnedPublicKeys                 map[string]string  `json:"pinned_public_keys"`
 	Certificates                     CertificatesConfig `json:"certificates"`
 }
 

--- a/lint/schema.go
+++ b/lint/schema.go
@@ -660,6 +660,12 @@ const confSchema = `{
 			"control_api_use_mutual_tls": {
 				"type": "boolean"
 			},
+			"pinned_public_keys": {
+				"type": ["array", "null"],
+				"items": {
+					"type": "object"
+				}
+			},
 			"certificates": {
 				"type": ["object", "null"],
 				"additionalProperties": false,

--- a/mw_js_plugin.go
+++ b/mw_js_plugin.go
@@ -496,6 +496,8 @@ func (j *JSVM) LoadTykJSApi() {
 			tr.TLSClientConfig.InsecureSkipVerify = true
 		}
 
+		tr.DialTLS = dialTLSPinnedCheck(j.Spec, tr.TLSClientConfig)
+
 		// using new Client each time should be ok, since we closing connection every time
 		client := &http.Client{Transport: tr}
 		resp, err := client.Do(r)

--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -429,6 +429,8 @@ func httpTransport(timeOut int, rw http.ResponseWriter, req *http.Request, p *Re
 		transport.TLSClientConfig.InsecureSkipVerify = true
 	}
 
+	transport.DialTLS = dialTLSPinnedCheck(p.TykAPISpec, transport.TLSClientConfig)
+
 	// Use the default unless we've modified the timout
 	if timeOut > 0 {
 		log.Debug("Setting timeout for outbound request to: ", timeOut)


### PR DESCRIPTION
Certificate pinning is a feature which allows you to whitelist public keys used to generated certificates, so you will be protected in cases when upstream certificate is compromised.

Using Tyk you can white-list one or multiple public keys per domain. Wildcard domains also supported.

Public keys stored inside Tyk certificate storage, so you can use Certificate API to manage them.

You can define them globally, using Tyk configuration file and `security.pinned_public_keys` option, or via API definition `pinned_public_keys` field, using the following format:
```
{
    "example.com": "<key-id>",
    "foo.com": "/path/to/pub.pem",
    "*.wild.com": "<key-id>,<key-id-2>"
}
```

As `key-id` you should set ID returned after you uploaded public key using Certificate API. Additionally, you can just set path to public key, located on your server. You can specify multiple public keys by separating their IDs by a comma.

Note that only public keys in PEM format are supported.

If public keys are not provided by your upstream, you can extract them
by yourself using the following command:
> openssl s_client -connect the.host.name:443 | openssl x509 -pubkey -noout

If you already have a certificate, and just need to get its public key, you can do it using the following command:
> openssl x509 -pubkey -noout -in cert.pem

PS. Upstream certificates now also have wildcard domain support

Should fix https://github.com/TykTechnologies/tyk/issues/1537