### PR TITLE
acces to config.Global is protected with atomic.Value

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/Jeffail/tunny"
+	"github.com/jeffail/tunny"
 	"github.com/oschwald/maxminddb-golang"
 	"gopkg.in/vmihailenco/msgpack.v2"
 

--- a/analytics_test.go
+++ b/analytics_test.go
@@ -27,10 +27,13 @@ func TestGeoIPLookup(t *testing.T) {
 }
 
 func TestURLReplacer(t *testing.T) {
-	config.Global.AnalyticsConfig.NormaliseUrls.Enabled = true
-	config.Global.AnalyticsConfig.NormaliseUrls.NormaliseUUIDs = true
-	config.Global.AnalyticsConfig.NormaliseUrls.NormaliseNumbers = true
-	config.Global.AnalyticsConfig.NormaliseUrls.Custom = []string{"ihatethisstring"}
+	defer resetTestConfig()
+	globalConf := config.Global()
+	globalConf.AnalyticsConfig.NormaliseUrls.Enabled = true
+	globalConf.AnalyticsConfig.NormaliseUrls.NormaliseUUIDs = true
+	globalConf.AnalyticsConfig.NormaliseUrls.NormaliseNumbers = true
+	globalConf.AnalyticsConfig.NormaliseUrls.Custom = []string{"ihatethisstring"}
+	config.SetGlobal(globalConf)
 
 	recordUUID1 := AnalyticsRecord{Path: "/15873a748894492162c402d67e92283b/search"}
 	recordUUID2 := AnalyticsRecord{Path: "/CA761232-ED42-11CE-BACD-00AA0057B223/search"}
@@ -39,7 +42,8 @@ func TestURLReplacer(t *testing.T) {
 	recordID1 := AnalyticsRecord{Path: "/widgets/123456/getParams"}
 	recordCust := AnalyticsRecord{Path: "/widgets/123456/getParams/ihatethisstring"}
 
-	config.Global.AnalyticsConfig.NormaliseUrls.CompiledPatternSet = initNormalisationPatterns()
+	globalConf.AnalyticsConfig.NormaliseUrls.CompiledPatternSet = initNormalisationPatterns()
+	config.SetGlobal(globalConf)
 
 	recordUUID1.NormalisePath()
 	recordUUID2.NormalisePath()
@@ -51,7 +55,7 @@ func TestURLReplacer(t *testing.T) {
 	if recordUUID1.Path != "/{uuid}/search" {
 		t.Error("Path not altered, is:")
 		t.Error(recordUUID1.Path)
-		t.Error(config.Global.AnalyticsConfig.NormaliseUrls)
+		t.Error(config.Global().AnalyticsConfig.NormaliseUrls)
 	}
 
 	if recordUUID2.Path != "/{uuid}/search" {

--- a/api.go
+++ b/api.go
@@ -154,7 +154,7 @@ func doAddOrUpdate(keyName string, newSession *user.SessionState, dontReset bool
 		}
 	} else {
 		// nothing defined, add key to ALL
-		if !config.Global.AllowMasterKeys {
+		if !config.Global().AllowMasterKeys {
 			log.Error("Master keys disallowed in configuration, key not added.")
 			return errors.New("Master keys not allowed")
 		}
@@ -287,7 +287,7 @@ func handleAddOrUpdate(keyName string, r *http.Request) (interface{}, int) {
 	}
 
 	// add key hash for newly created key
-	if config.Global.HashKeys && r.Method == http.MethodPost {
+	if config.Global().HashKeys && r.Method == http.MethodPost {
 		response.KeyHash = storage.HashKey(keyName)
 	}
 
@@ -295,7 +295,7 @@ func handleAddOrUpdate(keyName string, r *http.Request) (interface{}, int) {
 }
 
 func handleGetDetail(sessionKey, apiID string, byHash bool) (interface{}, int) {
-	if byHash && !config.Global.HashKeys {
+	if byHash && !config.Global().HashKeys {
 		return apiError("Key requested by hash but key hashing is not enabled"), 400
 	}
 
@@ -464,7 +464,7 @@ func handleGetAPI(apiID string) (interface{}, int) {
 }
 
 func handleAddOrUpdateApi(apiID string, r *http.Request) (interface{}, int) {
-	if config.Global.UseDBAppConfigs {
+	if config.Global().UseDBAppConfigs {
 		log.Error("Rejected new API Definition due to UseDBAppConfigs = true")
 		return apiError("Due to enabled use_db_app_configs, please use the Dashboard API"), 500
 	}
@@ -481,7 +481,7 @@ func handleAddOrUpdateApi(apiID string, r *http.Request) (interface{}, int) {
 	}
 
 	// Create a filename
-	defFilePath := filepath.Join(config.Global.AppPath, newDef.APIID+".json")
+	defFilePath := filepath.Join(config.Global().AppPath, newDef.APIID+".json")
 
 	// If it exists, delete it
 	if _, err := os.Stat(defFilePath); err == nil {
@@ -517,7 +517,7 @@ func handleAddOrUpdateApi(apiID string, r *http.Request) (interface{}, int) {
 
 func handleDeleteAPI(apiID string) (interface{}, int) {
 	// Generate a filename
-	defFilePath := filepath.Join(config.Global.AppPath, apiID+".json")
+	defFilePath := filepath.Join(config.Global().AppPath, apiID+".json")
 
 	// If it exists, delete it
 	if _, err := os.Stat(defFilePath); err != nil {
@@ -591,9 +591,9 @@ func keyHandler(w http.ResponseWriter, r *http.Request) {
 			obj, code = handleGetDetail(keyName, apiID, isHashed)
 		} else {
 			// Return list of keys
-			if config.Global.HashKeys {
+			if config.Global().HashKeys {
 				// get all keys is disabled by default
-				if !config.Global.EnableHashedKeysListing {
+				if !config.Global().EnableHashedKeysListing {
 					doJSONWrite(
 						w,
 						http.StatusNotFound,
@@ -731,7 +731,7 @@ func handleOrgAddOrUpdate(keyName string, r *http.Request) (interface{}, int) {
 
 	if spec == nil {
 		log.Warning("Couldn't find org session store in active API list")
-		if config.Global.SupressDefaultOrgStore {
+		if config.Global().SupressDefaultOrgStore {
 			return apiError("No such organisation found in Active API list"), 404
 		}
 		sessionManager = &DefaultOrgStore
@@ -934,7 +934,7 @@ func createKeyHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	} else {
-		if config.Global.AllowMasterKeys {
+		if config.Global().AllowMasterKeys {
 			// nothing defined, add key to ALL
 			log.WithFields(logrus.Fields{
 				"prefix":      "api",
@@ -988,7 +988,7 @@ func createKeyHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// add key hash to reply
-	if config.Global.HashKeys {
+	if config.Global().HashKeys {
 		obj.KeyHash = storage.HashKey(newKey)
 	}
 
@@ -1407,7 +1407,7 @@ func getOauthClients(apiID string) (interface{}, int) {
 }
 
 func healthCheckhandler(w http.ResponseWriter, r *http.Request) {
-	if !config.Global.HealthCheck.EnableHealthChecks {
+	if !config.Global().HealthCheck.EnableHealthChecks {
 		doJSONWrite(w, 400, apiError("Health checks are not enabled for this node"))
 		return
 	}

--- a/api_definition_test.go
+++ b/api_definition_test.go
@@ -234,15 +234,13 @@ func TestSyncAPISpecsDashboardSuccess(t *testing.T) {
 	apisByID = make(map[string]*APISpec)
 	apisMu.Unlock()
 
-	config.Global.UseDBAppConfigs = true
-	config.Global.AllowInsecureConfigs = true
-	config.Global.DBAppConfOptions.ConnectionString = ts.URL
+	globalConf := config.Global()
+	globalConf.UseDBAppConfigs = true
+	globalConf.AllowInsecureConfigs = true
+	globalConf.DBAppConfOptions.ConnectionString = ts.URL
+	config.SetGlobal(globalConf)
 
-	defer func() {
-		config.Global.UseDBAppConfigs = false
-		config.Global.AllowInsecureConfigs = false
-		config.Global.DBAppConfOptions.ConnectionString = ""
-	}()
+	defer resetTestConfig()
 
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/api_loader.go
+++ b/api_loader.go
@@ -29,11 +29,11 @@ type ChainObject struct {
 }
 
 func prepareStorage() (storage.RedisCluster, storage.RedisCluster, storage.RedisCluster, *RPCStorageHandler, *RPCStorageHandler) {
-	redisStore := storage.RedisCluster{KeyPrefix: "apikey-", HashKeys: config.Global.HashKeys}
+	redisStore := storage.RedisCluster{KeyPrefix: "apikey-", HashKeys: config.Global().HashKeys}
 	redisOrgStore := storage.RedisCluster{KeyPrefix: "orgkey."}
 	healthStore := storage.RedisCluster{KeyPrefix: "apihealth."}
-	rpcAuthStore := RPCStorageHandler{KeyPrefix: "apikey-", HashKeys: config.Global.HashKeys, UserKey: config.Global.SlaveOptions.APIKey, Address: config.Global.SlaveOptions.ConnectionString}
-	rpcOrgStore := RPCStorageHandler{KeyPrefix: "orgkey.", UserKey: config.Global.SlaveOptions.APIKey, Address: config.Global.SlaveOptions.ConnectionString}
+	rpcAuthStore := RPCStorageHandler{KeyPrefix: "apikey-", HashKeys: config.Global().HashKeys, UserKey: config.Global().SlaveOptions.APIKey, Address: config.Global().SlaveOptions.ConnectionString}
+	rpcOrgStore := RPCStorageHandler{KeyPrefix: "orgkey.", UserKey: config.Global().SlaveOptions.APIKey, Address: config.Global().SlaveOptions.ConnectionString}
 
 	FallbackKeySesionManager.Init(&redisStore)
 
@@ -175,7 +175,10 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 	case RPCStorageEngine:
 		authStore = rpcAuthStore
 		orgStore = rpcOrgStore
-		config.Global.EnforceOrgDataAge = true
+		spec.GlobalConfig.EnforceOrgDataAge = true
+		globalConf := config.Global()
+		globalConf.EnforceOrgDataAge = true
+		config.SetGlobal(globalConf)
 	}
 
 	sessionStore := redisStore
@@ -200,7 +203,7 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 	}
 
 	// TODO: use config.Global.EnableCoProcess
-	if config.Global.EnableJSVM || EnableCoProcess {
+	if config.Global().EnableJSVM || EnableCoProcess {
 		log.WithFields(logrus.Fields{
 			"prefix":   "main",
 			"api_name": spec.Name,
@@ -209,7 +212,7 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 		var mwPaths []string
 		mwPaths, mwAuthCheckFunc, mwPreFuncs, mwPostFuncs, mwPostAuthCheckFuncs, mwDriver = loadCustomMiddleware(spec)
 
-		if config.Global.EnableJSVM && mwDriver == apidef.OttoDriver {
+		if config.Global().EnableJSVM && mwDriver == apidef.OttoDriver {
 			var pathPrefix string
 			if spec.CustomMiddlewareBundle != "" {
 				pathPrefix = spec.APIID + "-" + spec.CustomMiddlewareBundle
@@ -499,7 +502,7 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 	chainDef.ThisHandler = chain
 	chainDef.ListenOn = spec.Proxy.ListenPath + "{rest:.*}"
 
-	if config.Global.UseRedisLog {
+	if config.Global().UseRedisLog {
 		log.WithFields(logrus.Fields{
 			"prefix":      "gateway",
 			"user_ip":     "--",
@@ -530,7 +533,7 @@ func loadGlobalApps(router *mux.Router) {
 	apisMu.RUnlock()
 	loadApps(specs, router)
 
-	if config.Global.NewRelic.AppName != "" {
+	if config.Global().NewRelic.AppName != "" {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Info("Adding NewRelic instrumentation")
@@ -540,7 +543,7 @@ func loadGlobalApps(router *mux.Router) {
 
 // Create the individual API (app) specs based on live configurations and assign middleware
 func loadApps(specs []*APISpec, muxer *mux.Router) {
-	hostname := config.Global.HostName
+	hostname := config.Global().HostName
 	if hostname != "" {
 		muxer = muxer.Host(hostname).Subrouter()
 		log.WithFields(logrus.Fields{
@@ -590,7 +593,7 @@ func loadApps(specs []*APISpec, muxer *mux.Router) {
 		return h1 > h2
 	})
 	for _, host := range hosts {
-		if !config.Global.EnableCustomDomains {
+		if !config.Global().EnableCustomDomains {
 			continue // disabled
 		}
 		if hostRouters[host] != nil {
@@ -657,7 +660,7 @@ func loadApps(specs []*APISpec, muxer *mux.Router) {
 	log.Debug("Checker host list")
 
 	// Kick off our host checkers
-	if !config.Global.UptimeTests.Disable {
+	if !config.Global().UptimeTests.Disable {
 		SetCheckerHostList()
 	}
 

--- a/api_test.go
+++ b/api_test.go
@@ -51,7 +51,9 @@ type testAPIDefinition struct {
 }
 
 func TestHealthCheckEndpoint(t *testing.T) {
-	config.Global.HealthCheck.EnableHealthChecks = true
+	globalConf := config.Global()
+	globalConf.HealthCheck.EnableHealthChecks = true
+	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
 	ts := newTykTestServer()
@@ -249,17 +251,14 @@ func TestKeyHandler(t *testing.T) {
 }
 
 func TestHashKeyHandler(t *testing.T) {
+	globalConf := config.Global()
 	// make it to use hashes for Redis keys
-	hashKeys := config.Global.HashKeys
-	config.Global.HashKeys = true
+	globalConf.HashKeys = true
 	// enable hashed keys listing
-	enableListing := config.Global.EnableHashedKeysListing
-	config.Global.EnableHashedKeysListing = true
+	globalConf.EnableHashedKeysListing = true
+	config.SetGlobal(globalConf)
 
-	defer func() {
-		config.Global.HashKeys = hashKeys
-		config.Global.EnableHashedKeysListing = enableListing
-	}()
+	defer resetTestConfig()
 
 	ts := newTykTestServer()
 	defer ts.Close()
@@ -374,17 +373,14 @@ func TestHashKeyHandler(t *testing.T) {
 }
 
 func TestHashKeyListingDisabled(t *testing.T) {
+	globalConf := config.Global()
 	// make it to use hashes for Redis keys
-	hashKeys := config.Global.HashKeys
-	config.Global.HashKeys = true
+	globalConf.HashKeys = true
 	// disable hashed keys listing
-	enableListing := config.Global.EnableHashedKeysListing
-	config.Global.EnableHashedKeysListing = false
+	globalConf.EnableHashedKeysListing = false
+	config.SetGlobal(globalConf)
 
-	defer func() {
-		config.Global.HashKeys = hashKeys
-		config.Global.EnableHashedKeysListing = enableListing
-	}()
+	defer resetTestConfig()
 
 	ts := newTykTestServer()
 	defer ts.Close()
@@ -497,13 +493,12 @@ func TestHashKeyListingDisabled(t *testing.T) {
 }
 
 func TestHashKeyHandlerHashingDisabled(t *testing.T) {
+	globalConf := config.Global()
 	// make it to NOT use hashes for Redis keys
-	hashKeys := config.Global.HashKeys
-	config.Global.HashKeys = false
+	globalConf.HashKeys = false
+	config.SetGlobal(globalConf)
 
-	defer func() {
-		config.Global.HashKeys = hashKeys
-	}()
+	defer resetTestConfig()
 
 	ts := newTykTestServer()
 	defer ts.Close()
@@ -777,7 +772,10 @@ func TestContextSession(t *testing.T) {
 }
 
 func TestApiLoaderLongestPathFirst(t *testing.T) {
-	config.Global.EnableCustomDomains = true
+	globalConf := config.Global()
+	globalConf.EnableCustomDomains = true
+	config.SetGlobal(globalConf)
+
 	defer resetTestConfig()
 
 	type hostAndPath struct {

--- a/batch_requests.go
+++ b/batch_requests.go
@@ -47,7 +47,7 @@ func (b *BatchRequestHandler) doRequest(req *http.Request, relURL string) BatchR
 		tr.TLSClientConfig.Certificates = []tls.Certificate{*cert}
 	}
 
-	tr.TLSClientConfig.InsecureSkipVerify = config.Global.ProxySSLInsecureSkipVerify
+	tr.TLSClientConfig.InsecureSkipVerify = config.Global().ProxySSLInsecureSkipVerify
 
 	tr.DialTLS = dialTLSPinnedCheck(b.API, tr.TLSClientConfig)
 
@@ -90,7 +90,7 @@ func (b *BatchRequestHandler) ConstructRequests(batchRequest BatchRequestStructu
 		// URLs need to be built absolute so they go through the rate limiting and request limiting machinery
 		var absURL string
 		if !unsafe {
-			absUrlHeader := "http://localhost:" + strconv.Itoa(config.Global.ListenPort)
+			absUrlHeader := "http://localhost:" + strconv.Itoa(config.Global().ListenPort)
 			absURL = strings.Join([]string{absUrlHeader, strings.Trim(b.API.Proxy.ListenPath, "/"), requestDef.RelativeURL}, "/")
 		} else {
 			absURL = requestDef.RelativeURL

--- a/batch_requests_test.go
+++ b/batch_requests_test.go
@@ -140,7 +140,10 @@ func TestVirtualEndpointBatch(t *testing.T) {
 
 	upstreamHost := strings.TrimPrefix(upstream.URL, "https://")
 
-	config.Global.Security.Certificates.Upstream = map[string]string{upstreamHost: clientCertID}
+	globalConf := config.Global()
+	globalConf.Security.Certificates.Upstream = map[string]string{upstreamHost: clientCertID}
+	config.SetGlobal(globalConf)
+
 	defer resetTestConfig()
 
 	ts := newTykTestServer()
@@ -164,13 +167,17 @@ func TestVirtualEndpointBatch(t *testing.T) {
 	})
 
 	t.Run("Skip verification", func(t *testing.T) {
-		config.Global.ProxySSLInsecureSkipVerify = true
+		globalConf := config.Global()
+		globalConf.ProxySSLInsecureSkipVerify = true
+		config.SetGlobal(globalConf)
 
 		ts.Run(t, test.TestCase{Path: "/virt", Code: 202})
 	})
 
 	t.Run("Verification required", func(t *testing.T) {
-		config.Global.ProxySSLInsecureSkipVerify = false
+		globalConf := config.Global()
+		globalConf.ProxySSLInsecureSkipVerify = false
+		config.SetGlobal(globalConf)
 
 		ts.Run(t, test.TestCase{Path: "/virt", Code: 500})
 	})

--- a/cert_test.go
+++ b/cert_test.go
@@ -752,32 +752,40 @@ func TestProxyTransport(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	config.Global.ProxySSLInsecureSkipVerify = true
+	globalConf := config.Global()
+	globalConf.ProxySSLInsecureSkipVerify = true
 	// force creating new transport on each reque
-	config.Global.MaxConnTime = -1
+	globalConf.MaxConnTime = -1
+	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
 	ts := newTykTestServer()
 	defer ts.Close()
 
-	buildAndLoadAPI(func(spec *APISpec) {
-		spec.Proxy.ListenPath = "/"
-		spec.Proxy.TargetURL = upstream.URL
-	})
-
 	//matching ciphers
 	t.Run("Global: Cipher match", func(t *testing.T) {
-		config.Global.ProxySSLCipherSuites = []string{"TLS_RSA_WITH_AES_128_CBC_SHA"}
+		globalConf.ProxySSLCipherSuites = []string{"TLS_RSA_WITH_AES_128_CBC_SHA"}
+		config.SetGlobal(globalConf)
+		buildAndLoadAPI(func(spec *APISpec) {
+			spec.Proxy.ListenPath = "/"
+			spec.Proxy.TargetURL = upstream.URL
+		})
 		ts.Run(t, test.TestCase{Path: "/", Code: 200})
 	})
 
 	t.Run("Global: Cipher not match", func(t *testing.T) {
-		config.Global.ProxySSLCipherSuites = []string{"TLS_RSA_WITH_RC4_128_SHA"}
+		globalConf.ProxySSLCipherSuites = []string{"TLS_RSA_WITH_RC4_128_SHA"}
+		config.SetGlobal(globalConf)
+		buildAndLoadAPI(func(spec *APISpec) {
+			spec.Proxy.ListenPath = "/"
+			spec.Proxy.TargetURL = upstream.URL
+		})
 		ts.Run(t, test.TestCase{Path: "/", Code: 500})
 	})
 
 	t.Run("API: Cipher override", func(t *testing.T) {
-		config.Global.ProxySSLCipherSuites = []string{"TLS_RSA_WITH_RC4_128_SHA"}
+		globalConf.ProxySSLCipherSuites = []string{"TLS_RSA_WITH_RC4_128_SHA"}
+		config.SetGlobal(globalConf)
 		buildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.Proxy.TargetURL = upstream.URL
@@ -788,7 +796,8 @@ func TestProxyTransport(t *testing.T) {
 	})
 
 	t.Run("API: MinTLS not match", func(t *testing.T) {
-		config.Global.ProxySSLMinVersion = 772
+		globalConf.ProxySSLMinVersion = 772
+		config.SetGlobal(globalConf)
 		buildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.Proxy.TargetURL = upstream.URL
@@ -799,7 +808,8 @@ func TestProxyTransport(t *testing.T) {
 	})
 
 	t.Run("API: Proxy", func(t *testing.T) {
-		config.Global.ProxySSLMinVersion = 771
+		globalConf.ProxySSLMinVersion = 771
+		config.SetGlobal(globalConf)
 		buildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.Proxy.TargetURL = upstream.URL

--- a/coprocess.go
+++ b/coprocess.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	// EnableCoProcess will be overridden by config.Global.EnableCoProcess.
+	// EnableCoProcess will be overridden by config.Global().EnableCoProcess.
 	EnableCoProcess = false
 
 	// GlobalDispatcher will be implemented by the current CoProcess driver.
@@ -177,7 +177,7 @@ func (c *CoProcessor) ObjectPostProcess(object *coprocess.Object, r *http.Reques
 // CoProcessInit creates a new CoProcessDispatcher, it will be called when Tyk starts.
 func CoProcessInit() error {
 	var err error
-	if config.Global.CoProcessOptions.EnableCoProcess {
+	if config.Global().CoProcessOptions.EnableCoProcess {
 		GlobalDispatcher, err = NewCoProcessDispatcher()
 		EnableCoProcess = true
 	}
@@ -187,7 +187,7 @@ func CoProcessInit() error {
 // EnabledForSpec checks if this middleware should be enabled for a given API.
 func (m *CoProcessMiddleware) EnabledForSpec() bool {
 	// This flag is true when Tyk has been compiled with CP support and when the configuration enables it.
-	enableCoProcess := config.Global.CoProcessOptions.EnableCoProcess && EnableCoProcess
+	enableCoProcess := config.Global().CoProcessOptions.EnableCoProcess && EnableCoProcess
 	// This flag indicates if the current spec specifies any CP custom middleware.
 	var usesCoProcessMiddleware bool
 

--- a/coprocess_bundle.go
+++ b/coprocess_bundle.go
@@ -41,14 +41,14 @@ func (b *Bundle) Verify() error {
 	var bundleVerifier goverify.Verifier
 
 	// Perform signature verification if a public key path is set:
-	if config.Global.PublicKeyPath != "" {
+	if config.Global().PublicKeyPath != "" {
 		if b.Manifest.Signature == "" {
 			// Error: A public key is set, but the bundle isn't signed.
 			return errors.New("Bundle isn't signed")
 		}
 		if notificationVerifier == nil {
 			var err error
-			bundleVerifier, err = goverify.LoadPublicKeyFromFile(config.Global.PublicKeyPath)
+			bundleVerifier, err = goverify.LoadPublicKeyFromFile(config.Global().PublicKeyPath)
 			if err != nil {
 				return err
 			}
@@ -175,7 +175,7 @@ func (ZipBundleSaver) Save(bundle *Bundle, bundlePath string, spec *APISpec) err
 // fetchBundle will fetch a given bundle, using the right BundleGetter. The first argument is the bundle name, the base bundle URL will be used as prefix.
 func fetchBundle(spec *APISpec) (bundle Bundle, err error) {
 
-	if !config.Global.EnableBundleDownloader {
+	if !config.Global().EnableBundleDownloader {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Warning("Bundle downloader is disabled.")
@@ -183,7 +183,7 @@ func fetchBundle(spec *APISpec) (bundle Bundle, err error) {
 		return bundle, err
 	}
 
-	bundleURL := config.Global.BundleBaseURL + spec.CustomMiddlewareBundle
+	bundleURL := config.Global().BundleBaseURL + spec.CustomMiddlewareBundle
 
 	var getter BundleGetter
 
@@ -271,11 +271,11 @@ func loadBundle(spec *APISpec) error {
 	}
 
 	// Skip if no bundle base URL is set.
-	if config.Global.BundleBaseURL == "" {
+	if config.Global().BundleBaseURL == "" {
 		return bundleError(spec, nil, "No bundle base URL set, skipping bundle")
 	}
 
-	tykBundlePath := filepath.Join(config.Global.MiddlewarePath, "bundles")
+	tykBundlePath := filepath.Join(config.Global().MiddlewarePath, "bundles")
 	// Skip if the bundle destination path already exists.
 	bundlePath := spec.APIID + "-" + spec.CustomMiddlewareBundle
 	destPath := filepath.Join(tykBundlePath, bundlePath)

--- a/coprocess_grpc.go
+++ b/coprocess_grpc.go
@@ -33,7 +33,7 @@ type GRPCDispatcher struct {
 }
 
 func dialer(addr string, timeout time.Duration) (net.Conn, error) {
-	grpcUrl, err := url.Parse(config.Global.CoProcessOptions.CoProcessGRPCServer)
+	grpcUrl, err := url.Parse(config.Global().CoProcessOptions.CoProcessGRPCServer)
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "coprocess-grpc",
@@ -41,7 +41,7 @@ func dialer(addr string, timeout time.Duration) (net.Conn, error) {
 		return nil, err
 	}
 
-	if grpcUrl == nil || config.Global.CoProcessOptions.CoProcessGRPCServer == "" {
+	if grpcUrl == nil || config.Global().CoProcessOptions.CoProcessGRPCServer == "" {
 		errString := "No gRPC URL is set!"
 		log.WithFields(logrus.Fields{
 			"prefix": "coprocess-grpc",
@@ -49,7 +49,7 @@ func dialer(addr string, timeout time.Duration) (net.Conn, error) {
 		return nil, errors.New(errString)
 	}
 
-	grpcUrlString := config.Global.CoProcessOptions.CoProcessGRPCServer[len(grpcUrl.Scheme)+3:]
+	grpcUrlString := config.Global().CoProcessOptions.CoProcessGRPCServer[len(grpcUrl.Scheme)+3:]
 	return net.DialTimeout(grpcUrl.Scheme, grpcUrlString, timeout)
 }
 

--- a/coprocess_python.go
+++ b/coprocess_python.go
@@ -268,7 +268,7 @@ func PythonSetEnv(pythonPaths ...string) {
 
 // getBundlePaths will return an array of the available bundle directories:
 func getBundlePaths() []string {
-	bundlePath := filepath.Join(config.Global.MiddlewarePath, "bundles")
+	bundlePath := filepath.Join(config.Global().MiddlewarePath, "bundles")
 	directories := make([]string, 0)
 	bundles, _ := ioutil.ReadDir(bundlePath)
 	for _, f := range bundles {
@@ -282,7 +282,7 @@ func getBundlePaths() []string {
 
 // NewCoProcessDispatcher wraps all the actions needed for this CP.
 func NewCoProcessDispatcher() (dispatcher coprocess.Dispatcher, err error) {
-	workDir := config.Global.CoProcessOptions.PythonPathPrefix
+	workDir := config.Global().CoProcessOptions.PythonPathPrefix
 
 	dispatcherPath := filepath.Join(workDir, "coprocess", "python")
 	middlewarePath := filepath.Join(workDir, "middleware", "python")

--- a/dashboard_register.go
+++ b/dashboard_register.go
@@ -37,7 +37,7 @@ type HTTPDashboardHandler struct {
 }
 
 func reLogin() {
-	if !config.Global.UseDBAppConfigs {
+	if !config.Global().UseDBAppConfigs {
 		return
 	}
 
@@ -74,7 +74,7 @@ func (h *HTTPDashboardHandler) Init() error {
 	h.RegistrationEndpoint = buildConnStr("/register/node")
 	h.DeRegistrationEndpoint = buildConnStr("/system/node")
 	h.HeartBeatEndpoint = buildConnStr("/register/ping")
-	if h.Secret = config.Global.NodeSecret; h.Secret == "" {
+	if h.Secret = config.Global().NodeSecret; h.Secret == "" {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Fatal("Node secret is not set, required for dashboard connection")

--- a/distributed_rate_limiter.go
+++ b/distributed_rate_limiter.go
@@ -21,7 +21,7 @@ func setupDRL() {
 }
 
 func startRateLimitNotifications() {
-	notificationFreq := config.Global.DRLNotificationFrequency
+	notificationFreq := config.Global().DRLNotificationFrequency
 	if notificationFreq == 0 {
 		notificationFreq = 2
 	}
@@ -42,7 +42,7 @@ func startRateLimitNotifications() {
 
 func getTagHash() string {
 	th := ""
-	for _, tag := range config.Global.DBAppConfOptions.Tags {
+	for _, tag := range config.Global().DBAppConfOptions.Tags {
 		th += tag
 	}
 	return th

--- a/event_handler_webhooks.go
+++ b/event_handler_webhooks.go
@@ -87,7 +87,7 @@ func (w *WebHookHandler) Init(handlerConf interface{}) error {
 			"prefix": "webhooks",
 			"target": w.conf.TargetPath,
 		}).Info("Loading default template.")
-		defaultPath := filepath.Join(config.Global.TemplatePath, "default_webhook.json")
+		defaultPath := filepath.Join(config.Global().TemplatePath, "default_webhook.json")
 		w.template, err = template.ParseFiles(defaultPath)
 		if err != nil {
 			log.WithFields(logrus.Fields{

--- a/event_handler_webhooks_test.go
+++ b/event_handler_webhooks_test.go
@@ -190,9 +190,14 @@ func TestNewCustomTemplate(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.missingDefault {
-				old := config.Global.TemplatePath
-				config.Global.TemplatePath = "missing-dir"
-				defer func() { config.Global.TemplatePath = old }()
+				globalConf := config.Global()
+				old := globalConf.TemplatePath
+				globalConf.TemplatePath = "missing-dir"
+				config.SetGlobal(globalConf)
+				defer func() {
+					globalConf.TemplatePath = old
+					config.SetGlobal(globalConf)
+				}()
 			}
 			h := &WebHookHandler{}
 			err := h.Init(map[string]interface{}{

--- a/event_system.go
+++ b/event_system.go
@@ -151,7 +151,7 @@ func (s *APISpec) FireEvent(name apidef.TykEvent, meta interface{}) {
 }
 
 func FireSystemEvent(name apidef.TykEvent, meta interface{}) {
-	fireEvent(name, meta, config.Global.EventTriggers)
+	fireEvent(name, meta, config.Global().EventTriggers)
 }
 
 // LogMessageEventHandler is a sample Event Handler

--- a/handler_websocket.go
+++ b/handler_websocket.go
@@ -34,7 +34,7 @@ type WSDialer struct {
 
 func (ws *WSDialer) RoundTrip(req *http.Request) (*http.Response, error) {
 
-	if !config.Global.HttpServerOptions.EnableWebSockets {
+	if !config.Global().HttpServerOptions.EnableWebSockets {
 		return nil, errors.New("WebSockets has been disabled on this host")
 	}
 
@@ -121,7 +121,7 @@ func (ws *WSDialer) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func IsWebsocket(req *http.Request) bool {
-	if !config.Global.HttpServerOptions.EnableWebSockets {
+	if !config.Global().HttpServerOptions.EnableWebSockets {
 		return false
 	}
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -326,6 +326,7 @@ func (s *tykTestServer) Start() {
 	}
 
 	s.URL = "http://" + s.ln.Addr().String()
+	s.globalConfig = globalConf
 }
 
 func (s *tykTestServer) Close() {
@@ -341,7 +342,7 @@ func (s *tykTestServer) Close() {
 
 func (s *tykTestServer) Do(tc test.TestCase) (*http.Response, error) {
 	scheme := "http://"
-	if config.Global().HttpServerOptions.UseSSL {
+	if s.globalConfig.HttpServerOptions.UseSSL {
 		scheme = "https://"
 	}
 
@@ -355,8 +356,8 @@ func (s *tykTestServer) Do(tc test.TestCase) (*http.Response, error) {
 	if tc.ControlRequest {
 		if s.config.sepatateControlAPI {
 			baseUrl = scheme + s.cln.Addr().String()
-		} else if config.Global().ControlAPIHostname != "" {
-			baseUrl = strings.Replace(baseUrl, "127.0.0.1", config.Global().ControlAPIHostname, 1)
+		} else if s.globalConfig.ControlAPIHostname != "" {
+			baseUrl = strings.Replace(baseUrl, "127.0.0.1", s.globalConfig.ControlAPIHostname, 1)
 		}
 	}
 

--- a/host_checker.go
+++ b/host_checker.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/jeffail/tunny"
+	"github.com/Jeffail/tunny"
 	cache "github.com/pmylund/go-cache"
 
 	"github.com/TykTechnologies/tyk/config"
@@ -165,7 +165,7 @@ func (h *HostUptimeChecker) CheckHost(toCheck HostData) {
 
 	HostCheckerClient.Transport = &http.Transport{
 		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: config.Global.ProxySSLInsecureSkipVerify,
+			InsecureSkipVerify: config.Global().ProxySSLInsecureSkipVerify,
 		},
 	}
 

--- a/host_checker.go
+++ b/host_checker.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Jeffail/tunny"
+	"github.com/jeffail/tunny"
 	cache "github.com/pmylund/go-cache"
 
 	"github.com/TykTechnologies/tyk/config"

--- a/host_checker_manager.go
+++ b/host_checker_manager.go
@@ -83,7 +83,7 @@ func (hc *HostCheckerManager) Start() {
 	// Start loop to check if we are active instance
 	if hc.Id != "" {
 		go hc.CheckActivePollerLoop()
-		if config.Global.UptimeTests.Config.EnableUptimeAnalytics {
+		if config.Global().UptimeTests.Config.EnableUptimeAnalytics {
 			go hc.UptimePurgeLoop()
 		}
 	}
@@ -169,9 +169,9 @@ func (hc *HostCheckerManager) StartPoller() {
 		hc.checker = &HostUptimeChecker{}
 	}
 
-	hc.checker.Init(config.Global.UptimeTests.Config.CheckerPoolSize,
-		config.Global.UptimeTests.Config.FailureTriggerSampleSize,
-		config.Global.UptimeTests.Config.TimeWait,
+	hc.checker.Init(config.Global().UptimeTests.Config.CheckerPoolSize,
+		config.Global().UptimeTests.Config.FailureTriggerSampleSize,
+		config.Global().UptimeTests.Config.TimeWait,
 		hc.currentHostList,
 		hc.OnHostDown,   // On failure
 		hc.OnHostBackUp, // On success
@@ -201,7 +201,7 @@ func (hc *HostCheckerManager) getHostKey(report HostHealthReport) string {
 }
 
 func (hc *HostCheckerManager) OnHostReport(report HostHealthReport) {
-	if config.Global.UptimeTests.Config.EnableUptimeAnalytics {
+	if config.Global().UptimeTests.Config.EnableUptimeAnalytics {
 		go hc.RecordUptimeAnalytics(report)
 	}
 }

--- a/instrumentation_handlers.go
+++ b/instrumentation_handlers.go
@@ -26,14 +26,14 @@ func setupInstrumentation() {
 		return
 	}
 
-	if config.Global.StatsdConnectionString == "" {
+	if config.Global().StatsdConnectionString == "" {
 		log.Error("Instrumentation is enabled, but no connectionstring set for statsd")
 		return
 	}
 
-	log.Info("Sending stats to: ", config.Global.StatsdConnectionString, " with prefix: ", config.Global.StatsdPrefix)
-	statsdSink, err := NewStatsDSink(config.Global.StatsdConnectionString,
-		&StatsDSinkOptions{Prefix: config.Global.StatsdPrefix})
+	log.Info("Sending stats to: ", config.Global().StatsdConnectionString, " with prefix: ", config.Global().StatsdPrefix)
+	statsdSink, err := NewStatsDSink(config.Global().StatsdConnectionString,
+		&StatsDSinkOptions{Prefix: config.Global().StatsdPrefix})
 
 	if err != nil {
 		log.Fatal("Failed to start StatsD check: ", err)

--- a/le_helpers.go
+++ b/le_helpers.go
@@ -29,7 +29,7 @@ func StoreLEState(m *letsencrypt.Manager) {
 	}
 
 	state := m.Marshal()
-	secret := rightPad2Len(config.Global.Secret, "=", 32)
+	secret := rightPad2Len(config.Global().Secret, "=", 32)
 	cryptoText := encrypt([]byte(secret), state)
 
 	if err := store.SetKey("cache", cryptoText, -1); err != nil {
@@ -57,7 +57,7 @@ func GetLEState(m *letsencrypt.Manager) {
 		return
 	}
 
-	secret := rightPad2Len(config.Global.Secret, "=", 32)
+	secret := rightPad2Len(config.Global().Secret, "=", 32)
 	sslState := decrypt([]byte(secret), cryptoText)
 
 	m.Unmarshal(sslState)

--- a/log_helpers.go
+++ b/log_helpers.go
@@ -22,7 +22,7 @@ func getLogEntryForRequest(r *http.Request, key string, data map[string]interfac
 	// add key to log if configured to do so
 	if key != "" {
 		fields["key"] = key
-		if !config.Global.EnableKeyLogging {
+		if !config.Global().EnableKeyLogging {
 			fields["key"] = logHiddenValue
 		}
 	}
@@ -42,7 +42,7 @@ func getExplicitLogEntryForRequest(path string, IP string, key string, data map[
 	// add key to log if configured to do so
 	if key != "" {
 		fields["key"] = key
-		if !config.Global.EnableKeyLogging {
+		if !config.Global().EnableKeyLogging {
 			fields["key"] = logHiddenValue
 		}
 	}

--- a/log_helpers_test.go
+++ b/log_helpers_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestGetLogEntryForRequest(t *testing.T) {
+	defer resetTestConfig()
+
 	testReq := httptest.NewRequest("GET", "http://tyk.io/test", nil)
 	testReq.RemoteAddr = "127.0.0.1:80"
 	testData := []struct {
@@ -111,8 +113,10 @@ func TestGetLogEntryForRequest(t *testing.T) {
 			}),
 		},
 	}
+	globalConf := config.Global()
 	for _, test := range testData {
-		config.Global.EnableKeyLogging = test.EnableKeyLogging
+		globalConf.EnableKeyLogging = test.EnableKeyLogging
+		config.SetGlobal(globalConf)
 		logEntry := getLogEntryForRequest(testReq, test.Key, test.Data)
 		if logEntry.Data["path"] != test.Result.Data["path"] {
 			t.Error("Expected 'path':", test.Result.Data["path"], "Got:", logEntry.Data["path"])

--- a/main.go
+++ b/main.go
@@ -146,7 +146,7 @@ func setupGlobals() {
 	mainRouter = mux.NewRouter()
 	controlRouter = mux.NewRouter()
 
-	if config.Global.EnableAnalytics && config.Global.Storage.Type != "redis" {
+	if config.Global().EnableAnalytics && config.Global().Storage.Type != "redis" {
 		mainLog.Fatal("Analytics requires Redis Storage backend, please enable Redis in the tyk.conf file.")
 	}
 
@@ -154,8 +154,10 @@ func setupGlobals() {
 	healthCheckStore := storage.RedisCluster{KeyPrefix: "host-checker:"}
 	InitHostCheckManager(healthCheckStore)
 
-	if config.Global.EnableAnalytics && analytics.Store == nil {
-		config.Global.LoadIgnoredIPs()
+	if config.Global().EnableAnalytics && analytics.Store == nil {
+		globalConf := config.Global()
+		globalConf.LoadIgnoredIPs()
+		config.SetGlobal(globalConf)
 		mainLog.Debug("Setting up analytics DB connection")
 
 		analyticsStore := storage.RedisCluster{KeyPrefix: "analytics-"}
@@ -168,7 +170,7 @@ func setupGlobals() {
 			go redisPurger.PurgeLoop(purgeTicker)
 		})
 
-		if config.Global.AnalyticsConfig.Type == "rpc" {
+		if config.Global().AnalyticsConfig.Type == "rpc" {
 			mainLog.Debug("Using RPC cache purge")
 
 			rpcPurgeOnce.Do(func() {
@@ -181,15 +183,15 @@ func setupGlobals() {
 	}
 
 	// Load all the files that have the "error" prefix.
-	templatesDir := filepath.Join(config.Global.TemplatePath, "error*")
+	templatesDir := filepath.Join(config.Global().TemplatePath, "error*")
 	templates = template.Must(template.ParseGlob(templatesDir))
 
 	// Set up global JSVM
-	if config.Global.EnableJSVM {
+	if config.Global().EnableJSVM {
 		GlobalEventsJSVM.Init(nil)
 	}
 
-	if config.Global.CoProcessOptions.EnableCoProcess {
+	if config.Global().CoProcessOptions.EnableCoProcess {
 		CoProcessInit()
 	}
 
@@ -199,46 +201,47 @@ func setupGlobals() {
 	mainNotifierStore.Connect()
 	MainNotifier = RedisNotifier{mainNotifierStore, RedisPubSubChannel}
 
-	if config.Global.Monitor.EnableTriggerMonitors {
+	if config.Global().Monitor.EnableTriggerMonitors {
 		h := &WebHookHandler{}
-		if err := h.Init(config.Global.Monitor.Config); err != nil {
+		if err := h.Init(config.Global().Monitor.Config); err != nil {
 			mainLog.Error("Failed to initialise monitor! ", err)
 		} else {
 			MonitoringHandler = h
 		}
 	}
 
-	if config.Global.AnalyticsConfig.NormaliseUrls.Enabled {
+	if globalConfig := config.Global(); globalConfig.AnalyticsConfig.NormaliseUrls.Enabled {
 		mainLog.Info("Setting up analytics normaliser")
-		config.Global.AnalyticsConfig.NormaliseUrls.CompiledPatternSet = initNormalisationPatterns()
+		globalConfig.AnalyticsConfig.NormaliseUrls.CompiledPatternSet = initNormalisationPatterns()
+		config.SetGlobal(globalConfig)
 	}
 
-	certificateSecret := config.Global.Secret
-	if config.Global.Security.PrivateCertificateEncodingSecret != "" {
-		certificateSecret = config.Global.Security.PrivateCertificateEncodingSecret
+	certificateSecret := config.Global().Secret
+	if config.Global().Security.PrivateCertificateEncodingSecret != "" {
+		certificateSecret = config.Global().Security.PrivateCertificateEncodingSecret
 	}
 
 	CertificateManager = certs.NewCertificateManager(getGlobalStorageHandler("cert-", false), certificateSecret, log)
 
-	if config.Global.NewRelic.AppName != "" {
+	if config.Global().NewRelic.AppName != "" {
 		NewRelicApplication = SetupNewRelic()
 	}
 }
 
 func buildConnStr(resource string) string {
 
-	if config.Global.DBAppConfOptions.ConnectionString == "" && config.Global.DisableDashboardZeroConf {
+	if config.Global().DBAppConfOptions.ConnectionString == "" && config.Global().DisableDashboardZeroConf {
 		mainLog.Fatal("Connection string is empty, failing.")
 	}
 
-	if !config.Global.DisableDashboardZeroConf && config.Global.DBAppConfOptions.ConnectionString == "" {
+	if !config.Global().DisableDashboardZeroConf && config.Global().DBAppConfOptions.ConnectionString == "" {
 		mainLog.Info("Waiting for zeroconf signal...")
-		for config.Global.DBAppConfOptions.ConnectionString == "" {
+		for config.Global().DBAppConfOptions.ConnectionString == "" {
 			time.Sleep(1 * time.Second)
 		}
 	}
 
-	return config.Global.DBAppConfOptions.ConnectionString + resource
+	return config.Global().DBAppConfOptions.ConnectionString + resource
 }
 
 func syncAPISpecs() int {
@@ -247,31 +250,31 @@ func syncAPISpecs() int {
 	apisMu.Lock()
 	defer apisMu.Unlock()
 
-	if config.Global.UseDBAppConfigs {
+	if config.Global().UseDBAppConfigs {
 
 		connStr := buildConnStr("/system/apis")
-		apiSpecs = loader.FromDashboardService(connStr, config.Global.NodeSecret)
+		apiSpecs = loader.FromDashboardService(connStr, config.Global().NodeSecret)
 
 		mainLog.Debug("Downloading API Configurations from Dashboard Service")
-	} else if config.Global.SlaveOptions.UseRPC {
+	} else if config.Global().SlaveOptions.UseRPC {
 		mainLog.Debug("Using RPC Configuration")
 
-		apiSpecs = loader.FromRPC(config.Global.SlaveOptions.RPCKey)
+		apiSpecs = loader.FromRPC(config.Global().SlaveOptions.RPCKey)
 	} else {
-		apiSpecs = loader.FromDir(config.Global.AppPath)
+		apiSpecs = loader.FromDir(config.Global().AppPath)
 	}
 
 	mainLog.Printf("Detected %v APIs", len(apiSpecs))
 
-	if config.Global.AuthOverride.ForceAuthProvider {
+	if config.Global().AuthOverride.ForceAuthProvider {
 		for i := range apiSpecs {
-			apiSpecs[i].AuthProvider = config.Global.AuthOverride.AuthProvider
+			apiSpecs[i].AuthProvider = config.Global().AuthOverride.AuthProvider
 		}
 	}
 
-	if config.Global.AuthOverride.ForceSessionProvider {
+	if config.Global().AuthOverride.ForceSessionProvider {
 		for i := range apiSpecs {
-			apiSpecs[i].SessionProvider = config.Global.AuthOverride.SessionProvider
+			apiSpecs[i].SessionProvider = config.Global().AuthOverride.SessionProvider
 		}
 	}
 
@@ -283,28 +286,28 @@ func syncPolicies() int {
 
 	mainLog.Info("Loading policies")
 
-	switch config.Global.Policies.PolicySource {
+	switch config.Global().Policies.PolicySource {
 	case "service":
-		if config.Global.Policies.PolicyConnectionString == "" {
+		if config.Global().Policies.PolicyConnectionString == "" {
 			mainLog.Fatal("No connection string or node ID present. Failing.")
 		}
-		connStr := config.Global.Policies.PolicyConnectionString
+		connStr := config.Global().Policies.PolicyConnectionString
 		connStr = connStr + "/system/policies"
 
 		mainLog.Info("Using Policies from Dashboard Service")
 
-		pols = LoadPoliciesFromDashboard(connStr, config.Global.NodeSecret, config.Global.Policies.AllowExplicitPolicyID)
+		pols = LoadPoliciesFromDashboard(connStr, config.Global().NodeSecret, config.Global().Policies.AllowExplicitPolicyID)
 
 	case "rpc":
 		mainLog.Debug("Using Policies from RPC")
-		pols = LoadPoliciesFromRPC(config.Global.SlaveOptions.RPCKey)
+		pols = LoadPoliciesFromRPC(config.Global().SlaveOptions.RPCKey)
 	default:
 		// this is the only case now where we need a policy record name
-		if config.Global.Policies.PolicyRecordName == "" {
+		if config.Global().Policies.PolicyRecordName == "" {
 			mainLog.Debug("No policy record name defined, skipping...")
 			return 0
 		}
-		pols = LoadPoliciesFromFile(config.Global.Policies.PolicyRecordName)
+		pols = LoadPoliciesFromFile(config.Global().Policies.PolicyRecordName)
 	}
 	mainLog.Infof("Policies found (%d total):", len(pols))
 	for id := range pols {
@@ -337,8 +340,8 @@ func stripSlashes(next http.Handler) http.Handler {
 
 func controlAPICheckClientCertificate(certLevel string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if config.Global.Security.ControlAPIUseMutualTLS {
-			if err := CertificateManager.ValidateRequestCertificate(config.Global.Security.Certificates.ControlAPI, r); err != nil {
+		if config.Global().Security.ControlAPIUseMutualTLS {
+			if err := CertificateManager.ValidateRequestCertificate(config.Global().Security.Certificates.ControlAPI, r); err != nil {
 				doJSONWrite(w, 403, apiError(err.Error()))
 				return
 			}
@@ -350,9 +353,9 @@ func controlAPICheckClientCertificate(certLevel string, next http.Handler) http.
 
 // Set up default Tyk control API endpoints - these are global, so need to be added first
 func loadAPIEndpoints(muxer *mux.Router) {
-	hostname := config.Global.HostName
-	if config.Global.ControlAPIHostname != "" {
-		hostname = config.Global.ControlAPIHostname
+	hostname := config.Global().HostName
+	if config.Global().ControlAPIHostname != "" {
+		hostname = config.Global().ControlAPIHostname
 	}
 
 	r := mux.NewRouter()
@@ -407,9 +410,10 @@ func loadAPIEndpoints(muxer *mux.Router) {
 // client and the owner and is set in the tyk.conf file. This should
 // never be made public!
 func checkIsAPIOwner(next http.Handler) http.Handler {
+	secret := config.Global().Secret
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		tykAuthKey := r.Header.Get("X-Tyk-Authorization")
-		if tykAuthKey != config.Global.Secret {
+		if tykAuthKey != secret {
 			// Error
 			mainLog.Warning("Attempted administrative access with invalid or missing key!")
 
@@ -434,7 +438,7 @@ func addOAuthHandlers(spec *APISpec, muxer *mux.Router) *OAuthManager {
 	serverConfig.ErrorStatusCode = 403
 	serverConfig.AllowedAccessTypes = spec.Oauth2Meta.AllowedAccessTypes
 	serverConfig.AllowedAuthorizeTypes = spec.Oauth2Meta.AllowedAuthorizeTypes
-	serverConfig.RedirectUriSeparator = config.Global.OauthRedirectUriSeparator
+	serverConfig.RedirectUriSeparator = config.Global().OauthRedirectUriSeparator
 
 	prefix := generateOAuthPrefix(spec.APIID)
 	storageManager := getGlobalStorageHandler(prefix, false)
@@ -500,7 +504,7 @@ func loadCustomMiddleware(spec *APISpec) ([]string, apidef.MiddlewareDefinition,
 		{name: "post_auth", slice: &mwPostKeyAuthFuncs},
 		{name: "post", slice: &mwPostFuncs},
 	} {
-		globPath := filepath.Join(config.Global.MiddlewarePath, spec.APIID, folder.name, "*.js")
+		globPath := filepath.Join(config.Global().MiddlewarePath, spec.APIID, folder.name, "*.js")
 		paths, _ := filepath.Glob(globPath)
 		for _, path := range paths {
 			mainLog.Debug("Loading file middleware from ", path)
@@ -584,8 +588,8 @@ func handleCORS(chain *[]alice.Constructor, spec *APISpec) {
 }
 
 func isRPCMode() bool {
-	return config.Global.AuthOverride.ForceAuthProvider &&
-		config.Global.AuthOverride.AuthProvider.StorageEngine == RPCStorageEngine
+	return config.Global().AuthOverride.ForceAuthProvider &&
+		config.Global().AuthOverride.AuthProvider.StorageEngine == RPCStorageEngine
 }
 
 func rpcReloadLoop(rpcKey string) {
@@ -614,17 +618,17 @@ func doReload() {
 	// We have updated specs, lets load those...
 
 	// Reset the JSVM
-	if config.Global.EnableJSVM {
+	if config.Global().EnableJSVM {
 		GlobalEventsJSVM.Init(nil)
 	}
 
 	mainLog.Info("Preparing new router")
 	newRouter := mux.NewRouter()
-	if config.Global.HttpServerOptions.OverrideDefaults {
-		newRouter.SkipClean(config.Global.HttpServerOptions.SkipURLCleaning)
+	if config.Global().HttpServerOptions.OverrideDefaults {
+		newRouter.SkipClean(config.Global().HttpServerOptions.SkipURLCleaning)
 	}
 
-	if config.Global.ControlAPIPort == 0 {
+	if config.Global().ControlAPIPort == 0 {
 		loadAPIEndpoints(newRouter)
 	}
 
@@ -703,9 +707,9 @@ func reloadURLStructure(done func()) {
 }
 
 func setupLogger() {
-	if config.Global.UseSentry {
+	if config.Global().UseSentry {
 		mainLog.Debug("Enabling Sentry support")
-		hook, err := logrus_sentry.NewSentryHook(config.Global.SentryCode, []logrus.Level{
+		hook, err := logrus_sentry.NewSentryHook(config.Global().SentryCode, []logrus.Level{
 			logrus.PanicLevel,
 			logrus.FatalLevel,
 			logrus.ErrorLevel,
@@ -720,10 +724,10 @@ func setupLogger() {
 		mainLog.Debug("Sentry hook active")
 	}
 
-	if config.Global.UseSyslog {
+	if config.Global().UseSyslog {
 		mainLog.Debug("Enabling Syslog support")
-		hook, err := logrus_syslog.NewSyslogHook(config.Global.SyslogTransport,
-			config.Global.SyslogNetworkAddr,
+		hook, err := logrus_syslog.NewSyslogHook(config.Global().SyslogTransport,
+			config.Global().SyslogNetworkAddr,
 			syslog.LOG_INFO, "")
 
 		if err == nil {
@@ -733,9 +737,9 @@ func setupLogger() {
 		mainLog.Debug("Syslog hook active")
 	}
 
-	if config.Global.UseGraylog {
+	if config.Global().UseGraylog {
 		mainLog.Debug("Enabling Graylog support")
-		hook := graylogHook.NewGraylogHook(config.Global.GraylogNetworkAddr,
+		hook := graylogHook.NewGraylogHook(config.Global().GraylogNetworkAddr,
 			map[string]interface{}{"tyk-module": "gateway"})
 
 		log.Hooks.Add(hook)
@@ -744,10 +748,10 @@ func setupLogger() {
 		mainLog.Debug("Graylog hook active")
 	}
 
-	if config.Global.UseLogstash {
+	if config.Global().UseLogstash {
 		mainLog.Debug("Enabling Logstash support")
-		hook, err := logstashHook.NewHook(config.Global.LogstashTransport,
-			config.Global.LogstashNetworkAddr,
+		hook, err := logstashHook.NewHook(config.Global().LogstashTransport,
+			config.Global().LogstashNetworkAddr,
 			"tyk-gateway")
 
 		if err == nil {
@@ -757,7 +761,7 @@ func setupLogger() {
 		mainLog.Debug("Logstash hook active")
 	}
 
-	if config.Global.UseRedisLog {
+	if config.Global().UseRedisLog {
 		hook := newRedisHook()
 		log.Hooks.Add(hook)
 		rawLog.Hooks.Add(hook)
@@ -765,8 +769,6 @@ func setupLogger() {
 		mainLog.Debug("Redis log hook active")
 	}
 }
-
-var configMu sync.Mutex
 
 func initialiseSystem() error {
 
@@ -809,14 +811,19 @@ func initialiseSystem() error {
 	}
 
 	if !runningTests {
-		if err := config.Load(confPaths, &config.Global); err != nil {
+		globalConf := config.Config{}
+		if err := config.Load(confPaths, &globalConf); err != nil {
 			return err
 		}
-		afterConfSetup(&config.Global)
+		afterConfSetup(&globalConf)
+		if globalConf.PIDFileLocation == "" {
+			globalConf.PIDFileLocation = "/var/run/tyk/tyk-gateway.pid"
+		}
+		config.SetGlobal(globalConf)
 	}
 
 	if os.Getenv("TYK_LOGLEVEL") == "" && !*debugMode {
-		level := strings.ToLower(config.Global.LogLevel)
+		level := strings.ToLower(config.Global().LogLevel)
 		switch level {
 		case "", "info":
 			// default, do nothing
@@ -831,7 +838,7 @@ func initialiseSystem() error {
 		}
 	}
 
-	if config.Global.Storage.Type != "redis" {
+	if config.Global().Storage.Type != "redis" {
 		mainLog.Fatal("Redis connection details not set, please ensure that the storage type is set to Redis and that the connection parameters are correct.")
 	}
 
@@ -842,20 +849,18 @@ func initialiseSystem() error {
 		if err != nil {
 			mainLog.Error("Port specified in flags must be a number: ", err)
 		} else {
-			config.Global.ListenPort = portNum
+			globalConf := config.Global()
+			globalConf.ListenPort = portNum
+			config.SetGlobal(globalConf)
 		}
 	}
 
 	// Enable all the loggers
 	setupLogger()
 
-	if config.Global.PIDFileLocation == "" {
-		config.Global.PIDFileLocation = "/var/run/tyk-gateway.pid"
-	}
+	mainLog.Info("PIDFile location set to: ", config.Global().PIDFileLocation)
 
-	mainLog.Info("PIDFile location set to: ", config.Global.PIDFileLocation)
-
-	pidfile.SetPidfilePath(config.Global.PIDFileLocation)
+	pidfile.SetPidfilePath(config.Global().PIDFileLocation)
 	if err := pidfile.Write(); err != nil {
 		mainLog.Error("Failed to write PIDFile: ", err)
 	}
@@ -863,7 +868,7 @@ func initialiseSystem() error {
 	getHostDetails()
 	setupInstrumentation()
 
-	if config.Global.HttpServerOptions.UseLE_SSL {
+	if config.Global().HttpServerOptions.UseLE_SSL {
 		go StartPeriodicStateBackup(&LE_MANAGER)
 	}
 
@@ -900,8 +905,13 @@ func getHostDetails() {
 }
 
 func getGlobalStorageHandler(keyPrefix string, hashKeys bool) storage.Handler {
-	if config.Global.SlaveOptions.UseRPC {
-		return &RPCStorageHandler{KeyPrefix: keyPrefix, HashKeys: hashKeys, UserKey: config.Global.SlaveOptions.APIKey, Address: config.Global.SlaveOptions.ConnectionString}
+	if config.Global().SlaveOptions.UseRPC {
+		return &RPCStorageHandler{
+			KeyPrefix: keyPrefix,
+			HashKeys:  hashKeys,
+			UserKey:   config.Global().SlaveOptions.APIKey,
+			Address:   config.Global().SlaveOptions.ConnectionString,
+		}
 	}
 	return storage.RedisCluster{KeyPrefix: keyPrefix, HashKeys: hashKeys}
 }
@@ -944,7 +954,7 @@ func main() {
 			mainLog.Info("Control listen closed")
 		}
 
-		if config.Global.UseDBAppConfigs {
+		if config.Global().UseDBAppConfigs {
 			mainLog.Info("Stopping heartbeat")
 			DashService.StopBeating()
 			mainLog.Info("Waiting to de-register")
@@ -957,12 +967,12 @@ func main() {
 
 	listener, goAgainErr := goagain.Listener(onFork)
 
-	if config.Global.ControlAPIPort > 0 {
+	if controlAPIPort := config.Global().ControlAPIPort; controlAPIPort > 0 {
 		var err error
-		if controlListener, err = generateListener(config.Global.ControlAPIPort); err != nil {
+		if controlListener, err = generateListener(controlAPIPort); err != nil {
 			mainLog.Fatalf("Error starting control API listener: %s", err)
 		} else {
-			mainLog.Info("Starting control API listener: ", controlListener, err, config.Global.ControlAPIPort)
+			mainLog.Info("Starting control API listener: ", controlListener, err, controlAPIPort)
 		}
 	}
 
@@ -997,7 +1007,7 @@ func main() {
 
 	if goAgainErr != nil {
 		var err error
-		if listener, err = generateListener(config.Global.ListenPort); err != nil {
+		if listener, err = generateListener(config.Global().ListenPort); err != nil {
 			mainLog.Fatalf("Error starting listener: %s", err)
 		}
 
@@ -1025,7 +1035,7 @@ func main() {
 
 	mainLog.Info("Stop signal received.")
 
-	if config.Global.UseDBAppConfigs {
+	if config.Global().UseDBAppConfigs {
 		mainLog.Info("Stopping heartbeat...")
 		DashService.StopBeating()
 		time.Sleep(2 * time.Second)
@@ -1039,35 +1049,35 @@ func main() {
 
 func start() {
 	// Set up a default org manager so we can traverse non-live paths
-	if !config.Global.SupressDefaultOrgStore {
+	if !config.Global().SupressDefaultOrgStore {
 		mainLog.Debug("Initialising default org store")
 		DefaultOrgStore.Init(getGlobalStorageHandler("orgkey.", false))
 		//DefaultQuotaStore.Init(getGlobalStorageHandler(CloudHandler, "orgkey.", false))
 		DefaultQuotaStore.Init(getGlobalStorageHandler("orgkey.", false))
 	}
 
-	if config.Global.ControlAPIPort == 0 {
+	if config.Global().ControlAPIPort == 0 {
 		loadAPIEndpoints(mainRouter)
 	}
 
 	// Start listening for reload messages
-	if !config.Global.SuppressRedisSignalReload {
+	if !config.Global().SuppressRedisSignalReload {
 		go startPubSubLoop()
 	}
 
-	if config.Global.SlaveOptions.UseRPC {
+	if slaveOptions := config.Global().SlaveOptions; slaveOptions.UseRPC {
 		mainLog.Debug("Starting RPC reload listener")
 		RPCListener = RPCStorageHandler{
 			KeyPrefix:        "rpc.listener.",
-			UserKey:          config.Global.SlaveOptions.APIKey,
-			Address:          config.Global.SlaveOptions.ConnectionString,
+			UserKey:          slaveOptions.APIKey,
+			Address:          slaveOptions.ConnectionString,
 			SuppressRegister: true,
 		}
 
 		RPCListener.Connect()
-		go rpcReloadLoop(config.Global.SlaveOptions.RPCKey)
+		go rpcReloadLoop(slaveOptions.RPCKey)
 		go RPCListener.StartRPCKeepaliveWatcher()
-		go RPCListener.StartRPCLoopCheck(config.Global.SlaveOptions.RPCKey)
+		go RPCListener.StartRPCLoopCheck(slaveOptions.RPCKey)
 	}
 
 	// 1s is the minimum amount of time between hot reloads. The
@@ -1077,26 +1087,26 @@ func start() {
 }
 
 func generateListener(listenPort int) (net.Listener, error) {
-	listenAddress := config.Global.ListenAddress
+	listenAddress := config.Global().ListenAddress
 
 	targetPort := fmt.Sprintf("%s:%d", listenAddress, listenPort)
 
-	if config.Global.HttpServerOptions.UseSSL {
+	if httpServerOptions := config.Global().HttpServerOptions; httpServerOptions.UseSSL {
 		mainLog.Info("--> Using SSL (https)")
 
 		tlsConfig := tls.Config{
 			GetCertificate:     dummyGetCertificate,
-			ServerName:         config.Global.HttpServerOptions.ServerName,
-			MinVersion:         config.Global.HttpServerOptions.MinVersion,
+			ServerName:         httpServerOptions.ServerName,
+			MinVersion:         httpServerOptions.MinVersion,
 			ClientAuth:         tls.RequestClientCert,
-			InsecureSkipVerify: config.Global.HttpServerOptions.SSLInsecureSkipVerify,
-			CipherSuites:       getCipherAliases(config.Global.HttpServerOptions.Ciphers),
+			InsecureSkipVerify: httpServerOptions.SSLInsecureSkipVerify,
+			CipherSuites:       getCipherAliases(httpServerOptions.Ciphers),
 		}
 
 		tlsConfig.GetConfigForClient = getTLSConfigForClient(&tlsConfig, listenPort)
 
 		return tls.Listen("tcp", targetPort, &tlsConfig)
-	} else if config.Global.HttpServerOptions.UseLE_SSL {
+	} else if config.Global().HttpServerOptions.UseLE_SSL {
 
 		mainLog.Info("--> Using SSL LE (https)")
 
@@ -1122,7 +1132,7 @@ func dashboardServiceInit() {
 }
 
 func handleDashboardRegistration() {
-	if !config.Global.UseDBAppConfigs {
+	if !config.Global().UseDBAppConfigs {
 		return
 	}
 
@@ -1142,10 +1152,10 @@ var drlOnce sync.Once
 
 func startDRL() {
 	switch {
-	case config.Global.ManagementNode:
+	case config.Global().ManagementNode:
 		return
-	case config.Global.EnableSentinelRateLImiter,
-		config.Global.EnableRedisRollingLimiter:
+	case config.Global().EnableSentinelRateLImiter,
+		config.Global().EnableRedisRollingLimiter:
 		mainLog.Warning("The old, non-distributed rate limiter is deprecated and we no longer recommend its use.")
 		return
 	}
@@ -1167,16 +1177,16 @@ func listen(listener, controlListener net.Listener, err error) {
 	readTimeout := defReadTimeout
 	writeTimeout := defWriteTimeout
 
-	targetPort := fmt.Sprintf("%s:%d", config.Global.ListenAddress, config.Global.ListenPort)
-	if config.Global.HttpServerOptions.ReadTimeout > 0 {
-		readTimeout = time.Duration(config.Global.HttpServerOptions.ReadTimeout) * time.Second
+	targetPort := fmt.Sprintf("%s:%d", config.Global().ListenAddress, config.Global().ListenPort)
+	if config.Global().HttpServerOptions.ReadTimeout > 0 {
+		readTimeout = time.Duration(config.Global().HttpServerOptions.ReadTimeout) * time.Second
 	}
 
-	if config.Global.HttpServerOptions.WriteTimeout > 0 {
-		writeTimeout = time.Duration(config.Global.HttpServerOptions.WriteTimeout) * time.Second
+	if config.Global().HttpServerOptions.WriteTimeout > 0 {
+		writeTimeout = time.Duration(config.Global().HttpServerOptions.WriteTimeout) * time.Second
 	}
 
-	if config.Global.ControlAPIPort > 0 {
+	if config.Global().ControlAPIPort > 0 {
 		loadAPIEndpoints(controlRouter)
 	}
 
@@ -1189,8 +1199,8 @@ func listen(listener, controlListener net.Listener, err error) {
 		handleDashboardRegistration()
 
 		// Use a custom server so we can control tves
-		if config.Global.HttpServerOptions.OverrideDefaults {
-			mainRouter.SkipClean(config.Global.HttpServerOptions.SkipURLCleaning)
+		if config.Global().HttpServerOptions.OverrideDefaults {
+			mainRouter.SkipClean(config.Global().HttpServerOptions.SkipURLCleaning)
 
 			mainLog.Infof("Custom gateway started (%s)", VERSION)
 
@@ -1203,7 +1213,7 @@ func listen(listener, controlListener net.Listener, err error) {
 				Handler:      mainHandler{},
 			}
 
-			if config.Global.CloseConnections {
+			if config.Global().CloseConnections {
 				s.SetKeepAlivesEnabled(false)
 			}
 
@@ -1222,7 +1232,7 @@ func listen(listener, controlListener net.Listener, err error) {
 			mainLog.Printf("Gateway started (%s)", VERSION)
 
 			s := &http.Server{Handler: mainHandler{}}
-			if config.Global.CloseConnections {
+			if config.Global().CloseConnections {
 				s.SetKeepAlivesEnabled(false)
 			}
 
@@ -1249,13 +1259,13 @@ func listen(listener, controlListener net.Listener, err error) {
 			os.Setenv("TYK_SERVICE_NODEID", "")
 		}
 
-		if config.Global.UseDBAppConfigs {
+		if config.Global().UseDBAppConfigs {
 			dashboardServiceInit()
 			go DashService.StartBeating()
 		}
 
-		if config.Global.HttpServerOptions.OverrideDefaults {
-			mainRouter.SkipClean(config.Global.HttpServerOptions.SkipURLCleaning)
+		if config.Global().HttpServerOptions.OverrideDefaults {
+			mainRouter.SkipClean(config.Global().HttpServerOptions.SkipURLCleaning)
 
 			mainLog.Warning("HTTP Server Overrides detected, this could destabilise long-running http-requests")
 			s := &http.Server{
@@ -1265,7 +1275,7 @@ func listen(listener, controlListener net.Listener, err error) {
 				Handler:      mainHandler{},
 			}
 
-			if config.Global.CloseConnections {
+			if config.Global().CloseConnections {
 				s.SetKeepAlivesEnabled(false)
 			}
 
@@ -1284,7 +1294,7 @@ func listen(listener, controlListener net.Listener, err error) {
 			mainLog.Printf("Gateway resumed (%s)", VERSION)
 
 			s := &http.Server{Handler: mainHandler{}}
-			if config.Global.CloseConnections {
+			if config.Global().CloseConnections {
 				s.SetKeepAlivesEnabled(false)
 			}
 
@@ -1303,12 +1313,12 @@ func listen(listener, controlListener net.Listener, err error) {
 	// at this point NodeID is ready to use by DRL
 	drlOnce.Do(startDRL)
 
-	address := config.Global.ListenAddress
-	if config.Global.ListenAddress == "" {
+	address := config.Global().ListenAddress
+	if config.Global().ListenAddress == "" {
 		address = "(open interface)"
 	}
 	mainLog.Info("--> Listening on address: ", address)
-	mainLog.Info("--> Listening on port: ", config.Global.ListenPort)
+	mainLog.Info("--> Listening on port: ", config.Global().ListenPort)
 	mainLog.Info("--> PID: ", hostDetails.PID)
 
 	mainRouter.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {

--- a/monitor.go
+++ b/monitor.go
@@ -10,7 +10,7 @@ import (
 type Monitor struct{}
 
 func (Monitor) Enabled() bool {
-	return config.Global.Monitor.EnableTriggerMonitors
+	return config.Global().Monitor.EnableTriggerMonitors
 }
 
 func (Monitor) Fire(sessionData *user.SessionState, key string, triggerLimit float64) {
@@ -48,13 +48,13 @@ func (m Monitor) Check(sessionData *user.SessionState, key string) {
 		return
 	}
 
-	if config.Global.Monitor.GlobalTriggerLimit > 0.0 && usagePerc >= config.Global.Monitor.GlobalTriggerLimit {
+	if config.Global().Monitor.GlobalTriggerLimit > 0.0 && usagePerc >= config.Global().Monitor.GlobalTriggerLimit {
 		log.Info("Firing...")
-		m.Fire(sessionData, key, config.Global.Monitor.GlobalTriggerLimit)
+		m.Fire(sessionData, key, config.Global().Monitor.GlobalTriggerLimit)
 	}
 
 	for _, triggerLimit := range sessionData.Monitor.TriggerLimits {
-		if usagePerc >= triggerLimit && triggerLimit != config.Global.Monitor.GlobalTriggerLimit {
+		if usagePerc >= triggerLimit && triggerLimit != config.Global().Monitor.GlobalTriggerLimit {
 			log.Info("Firing...")
 			m.Fire(sessionData, key, triggerLimit)
 			break

--- a/mw_api_rate_limit.go
+++ b/mw_api_rate_limit.go
@@ -67,7 +67,9 @@ func (k *RateLimitForAPI) ProcessRequest(w http.ResponseWriter, r *http.Request,
 		k.keyName,
 		storeRef,
 		true,
-		false)
+		false,
+		k.Spec.GlobalConfig,
+	)
 
 	if reason == sessionFailRateLimit {
 		return k.handleRateLimitFailure(r, k.keyName)

--- a/mw_certificate_check.go
+++ b/mw_certificate_check.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"net/http"
-
-	"github.com/TykTechnologies/tyk/config"
 )
 
 // CertificateCheckMW is used if domain was not detected or multiple APIs bind on the same domain. In this case authentification check happens not on TLS side but on HTTP level using this middleware
@@ -21,7 +19,7 @@ func (m *CertificateCheckMW) EnabledForSpec() bool {
 
 func (m *CertificateCheckMW) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	if m.Spec.UseMutualTLSAuth {
-		certIDs := append(m.Spec.ClientCertificates, config.Global.Security.Certificates.API...)
+		certIDs := append(m.Spec.ClientCertificates, m.Spec.GlobalConfig.Security.Certificates.API...)
 
 		if err := CertificateManager.ValidateRequestCertificate(certIDs, r); err != nil {
 			return err, 403

--- a/mw_js_plugin.go
+++ b/mw_js_plugin.go
@@ -319,7 +319,7 @@ func (j *JSVM) Init(spec *APISpec) {
 	}
 
 	// Load user's TykJS on top, if any
-	if path := config.Global.TykJSPath; path != "" {
+	if path := config.Global().TykJSPath; path != "" {
 		f, err := os.Open(path)
 		if err == nil {
 			_, err = vm.Run(f)
@@ -339,13 +339,13 @@ func (j *JSVM) Init(spec *APISpec) {
 	// Add environment API
 	j.LoadTykJSApi()
 
-	if config.Global.JSVMTimeout <= 0 {
+	if jsvmTimeout := config.Global().JSVMTimeout; jsvmTimeout <= 0 {
 		j.Timeout = time.Duration(defaultJSVMTimeout) * time.Second
 		log.WithFields(logrus.Fields{
 			"prefix": "jsvm",
 		}).Debugf("Default JSVM timeout used: %v", j.Timeout)
 	} else {
-		j.Timeout = time.Duration(config.Global.JSVMTimeout) * time.Second
+		j.Timeout = time.Duration(jsvmTimeout) * time.Second
 		log.WithFields(logrus.Fields{
 			"prefix": "jsvm",
 		}).Debugf("Custom JSVM timeout: %v", j.Timeout)
@@ -357,7 +357,7 @@ func (j *JSVM) Init(spec *APISpec) {
 
 // LoadJSPaths will load JS classes and functionality in to the VM by file
 func (j *JSVM) LoadJSPaths(paths []string, pathPrefix string) {
-	tykBundlePath := filepath.Join(config.Global.MiddlewarePath, "bundles")
+	tykBundlePath := filepath.Join(config.Global().MiddlewarePath, "bundles")
 	for _, mwPath := range paths {
 		if pathPrefix != "" {
 			mwPath = filepath.Join(tykBundlePath, pathPrefix, mwPath)
@@ -492,7 +492,7 @@ func (j *JSVM) LoadTykJSApi() {
 			tr.TLSClientConfig.Certificates = []tls.Certificate{*cert}
 		}
 
-		if config.Global.ProxySSLInsecureSkipVerify {
+		if config.Global().ProxySSLInsecureSkipVerify {
 			tr.TLSClientConfig.InsecureSkipVerify = true
 		}
 

--- a/mw_js_plugin_test.go
+++ b/mw_js_plugin_test.go
@@ -284,9 +284,14 @@ testJSVMCore.NewProcessRequest(function(request, session, config) {
 	if _, err := io.WriteString(tfile, `var globalVar = "globalValue"`); err != nil {
 		t.Fatal(err)
 	}
-	old := config.Global.TykJSPath
-	config.Global.TykJSPath = tfile.Name()
-	defer func() { config.Global.TykJSPath = old }()
+	globalConf := config.Global()
+	old := globalConf.TykJSPath
+	globalConf.TykJSPath = tfile.Name()
+	config.SetGlobal(globalConf)
+	defer func() {
+		globalConf.TykJSPath = old
+		config.SetGlobal(globalConf)
+	}()
 	jsvm := JSVM{}
 	jsvm.Init(nil)
 	if _, err := jsvm.VM.Run(js); err != nil {

--- a/mw_jwt.go
+++ b/mw_jwt.go
@@ -14,7 +14,6 @@ import (
 	cache "github.com/pmylund/go-cache"
 
 	"github.com/TykTechnologies/tyk/apidef"
-	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/storage"
 	"github.com/TykTechnologies/tyk/user"
 )
@@ -306,7 +305,7 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 			}
 
 			cacheKey := sessionID
-			if config.Global.HashKeys {
+			if k.Spec.GlobalConfig.HashKeys {
 				cacheKey = storage.HashStr(sessionID)
 			}
 			// update session in cache

--- a/mw_organization_activity_test.go
+++ b/mw_organization_activity_test.go
@@ -13,8 +13,11 @@ import (
 
 func TestProcessRequestLiveQuotaLimit(t *testing.T) {
 	// setup global config
-	config.Global.EnforceOrgQuotas = true
-	config.Global.ExperimentalProcessOrgOffThread = false
+	globalConf := config.Global()
+	globalConf.EnforceOrgQuotas = true
+	globalConf.ExperimentalProcessOrgOffThread = false
+	config.SetGlobal(globalConf)
+	defer resetTestConfig()
 
 	// run test server
 	ts := newTykTestServer()
@@ -67,8 +70,11 @@ func TestProcessRequestLiveQuotaLimit(t *testing.T) {
 
 func TestProcessRequestOffThreadQuotaLimit(t *testing.T) {
 	// setup global config
-	config.Global.EnforceOrgQuotas = true
-	config.Global.ExperimentalProcessOrgOffThread = true
+	globalConf := config.Global()
+	globalConf.EnforceOrgQuotas = true
+	globalConf.ExperimentalProcessOrgOffThread = true
+	config.SetGlobal(globalConf)
+	defer resetTestConfig()
 
 	// run test server
 	ts := newTykTestServer()
@@ -144,9 +150,12 @@ func TestProcessRequestOffThreadQuotaLimit(t *testing.T) {
 
 func TestProcessRequestLiveRedisRollingLimiter(t *testing.T) {
 	// setup global config
-	config.Global.EnforceOrgQuotas = true
-	config.Global.EnableRedisRollingLimiter = true
-	config.Global.ExperimentalProcessOrgOffThread = false
+	globalConf := config.Global()
+	globalConf.EnforceOrgQuotas = true
+	globalConf.EnableRedisRollingLimiter = true
+	globalConf.ExperimentalProcessOrgOffThread = false
+	config.SetGlobal(globalConf)
+	defer resetTestConfig()
 
 	// run test server
 	ts := newTykTestServer()
@@ -207,9 +216,12 @@ func TestProcessRequestLiveRedisRollingLimiter(t *testing.T) {
 
 func TestProcessRequestOffThreadRedisRollingLimiter(t *testing.T) {
 	// setup global config
-	config.Global.EnforceOrgQuotas = true
-	config.Global.EnableRedisRollingLimiter = true
-	config.Global.ExperimentalProcessOrgOffThread = true
+	globalConf := config.Global()
+	globalConf.EnforceOrgQuotas = true
+	globalConf.EnableRedisRollingLimiter = true
+	globalConf.ExperimentalProcessOrgOffThread = true
+	config.SetGlobal(globalConf)
+	defer resetTestConfig()
 
 	// run test server
 	ts := newTykTestServer()

--- a/mw_rate_limiting.go
+++ b/mw_rate_limiting.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/request"
 )
 
@@ -71,7 +70,9 @@ func (k *RateLimitAndQuotaCheck) ProcessRequest(w http.ResponseWriter, r *http.R
 		token,
 		storeRef,
 		!k.Spec.DisableRateLimit,
-		!k.Spec.DisableQuota)
+		!k.Spec.DisableQuota,
+		k.Spec.GlobalConfig,
+	)
 
 	// If either are disabled, save the write roundtrip
 	if !k.Spec.DisableRateLimit || !k.Spec.DisableQuota {
@@ -91,7 +92,7 @@ func (k *RateLimitAndQuotaCheck) ProcessRequest(w http.ResponseWriter, r *http.R
 		return errors.New("Access denied"), 403
 	}
 	// Run the trigger monitor
-	if config.Global.Monitor.MonitorUserKeys {
+	if k.Spec.GlobalConfig.Monitor.MonitorUserKeys {
 		sessionMonitor.Check(session, token)
 	}
 

--- a/mw_redis_cache.go
+++ b/mw_redis_cache.go
@@ -133,7 +133,7 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 	}
 
 	var copiedRequest *http.Request
-	if recordDetail(r) {
+	if recordDetail(r, m.Spec.GlobalConfig) {
 		copiedRequest = copyRequest(r)
 	}
 

--- a/mw_track_endpoints.go
+++ b/mw_track_endpoints.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"github.com/TykTechnologies/tyk/apidef"
-	"github.com/TykTechnologies/tyk/config"
 )
 
 // TrackEndpointMiddleware sets context variables to enable or disable whether Tyk should record analytitcs for a specific path.
@@ -17,7 +16,7 @@ func (t *TrackEndpointMiddleware) Name() string {
 }
 
 func (t *TrackEndpointMiddleware) EnabledForSpec() bool {
-	if !config.Global.EnableAnalytics || t.Spec.DoNotTrack {
+	if !t.Spec.GlobalConfig.EnableAnalytics || t.Spec.DoNotTrack {
 		return false
 	}
 

--- a/newrelic.go
+++ b/newrelic.go
@@ -20,8 +20,8 @@ func SetupNewRelic() (app newrelic.Application) {
 
 	logger.Info("Initializing NewRelic...")
 
-	cfg := newrelic.NewConfig(config.Global.NewRelic.AppName, config.Global.NewRelic.LicenseKey)
-	if config.Global.NewRelic.AppName != "" {
+	cfg := newrelic.NewConfig(config.Global().NewRelic.AppName, config.Global().NewRelic.LicenseKey)
+	if config.Global().NewRelic.AppName != "" {
 		cfg.Enabled = true
 	}
 	cfg.Logger = &newRelicLogger{logger}

--- a/oauth_manager.go
+++ b/oauth_manager.go
@@ -466,7 +466,7 @@ func (r *RedisOsinStorageInterface) GetClients(filter string, ignorePrefix bool)
 	}
 
 	var clientJSON map[string]string
-	if !config.Global.Storage.EnableCluster {
+	if !config.Global().Storage.EnableCluster {
 		clientJSON = r.store.GetKeysAndValuesWithFilter(key)
 	} else {
 		keyForSet := prefixClientset + prefixClient // Org ID
@@ -504,8 +504,8 @@ func (r *RedisOsinStorageInterface) GetClientTokens(id string) ([]OAuthClientTok
 	}
 
 	// clean up expired tokens in sorted set (remove all tokens with score up to current timestamp minus retention)
-	if config.Global.OauthTokenExpiredRetainPeriod > 0 {
-		cleanupStartScore := strconv.FormatInt(nowTs-int64(config.Global.OauthTokenExpiredRetainPeriod), 10)
+	if config.Global().OauthTokenExpiredRetainPeriod > 0 {
+		cleanupStartScore := strconv.FormatInt(nowTs-int64(config.Global().OauthTokenExpiredRetainPeriod), 10)
 		go r.store.RemoveSortedSetRange(key, "-inf", cleanupStartScore)
 	}
 
@@ -621,8 +621,8 @@ func (r *RedisOsinStorageInterface) SaveAccess(accessData *osin.AccessData) erro
 	log.Debug("Saving ACCESS key: ", key)
 
 	// Overide default ExpiresIn:
-	if config.Global.OauthTokenExpire != 0 {
-		accessData.ExpiresIn = config.Global.OauthTokenExpire
+	if oauthTokenExpire := config.Global().OauthTokenExpire; oauthTokenExpire != 0 {
+		accessData.ExpiresIn = oauthTokenExpire
 	}
 
 	r.store.SetKey(key, string(authDataJSON), int64(accessData.ExpiresIn))
@@ -680,8 +680,8 @@ func (r *RedisOsinStorageInterface) SaveAccess(accessData *osin.AccessData) erro
 		key := prefixRefresh + accessData.RefreshToken
 		log.Debug("Saving REFRESH key: ", key)
 		refreshExpire := int64(1209600) // 14 days
-		if config.Global.OauthRefreshExpire != 0 {
-			refreshExpire = config.Global.OauthRefreshExpire
+		if oauthRefreshExpire := config.Global().OauthRefreshExpire; oauthRefreshExpire != 0 {
+			refreshExpire = oauthRefreshExpire
 		}
 		r.store.SetKey(key, string(accessDataJSON), refreshExpire)
 		log.Debug("STORING ACCESS DATA: ", string(accessDataJSON))

--- a/oauth_manager_test.go
+++ b/oauth_manager_test.go
@@ -106,12 +106,12 @@ func createTestOAuthClient(spec *APISpec, clientID string) {
 
 	var redirectURI string
 	// If separator is not set that means multiple redirect uris not supported
-	if config.Global.OauthRedirectUriSeparator == "" {
+	if config.Global().OauthRedirectUriSeparator == "" {
 		redirectURI = "http://client.oauth.com"
 
 		// If separator config is set that means multiple redirect uris are supported
 	} else {
-		redirectURI = strings.Join([]string{"http://client.oauth.com", "http://client2.oauth.com", "http://client3.oauth.com"}, config.Global.OauthRedirectUriSeparator)
+		redirectURI = strings.Join([]string{"http://client.oauth.com", "http://client2.oauth.com", "http://client3.oauth.com"}, config.Global().OauthRedirectUriSeparator)
 	}
 	testClient := OAuthClient{
 		ClientID:          clientID,
@@ -151,12 +151,11 @@ func TestAuthCodeRedirect(t *testing.T) {
 }
 
 func TestAuthCodeRedirectMultipleURL(t *testing.T) {
-	oauthRedirectUriSeparator := config.Global.OauthRedirectUriSeparator
-	defer func() {
-		config.Global.OauthRedirectUriSeparator = oauthRedirectUriSeparator
-	}()
 	// Enable multiple Redirect URIs
-	config.Global.OauthRedirectUriSeparator = ","
+	globalConf := config.Global()
+	globalConf.OauthRedirectUriSeparator = ","
+	config.SetGlobal(globalConf)
+	defer resetTestConfig()
 
 	ts := newTykTestServer()
 	defer ts.Close()
@@ -186,12 +185,11 @@ func TestAuthCodeRedirectMultipleURL(t *testing.T) {
 }
 
 func TestAuthCodeRedirectInvalidMultipleURL(t *testing.T) {
-	oauthRedirectUriSeparator := config.Global.OauthRedirectUriSeparator
-	defer func() {
-		config.Global.OauthRedirectUriSeparator = oauthRedirectUriSeparator
-	}()
 	// Disable multiple Redirect URIs
-	config.Global.OauthRedirectUriSeparator = ""
+	globalConf := config.Global()
+	globalConf.OauthRedirectUriSeparator = ""
+	config.SetGlobal(globalConf)
+	defer resetTestConfig()
 
 	ts := newTykTestServer()
 	defer ts.Close()
@@ -362,18 +360,14 @@ func getAuthCode(t *testing.T, ts *tykTestServer) map[string]string {
 }
 
 func TestGetClientTokens(t *testing.T) {
-	// restore global config after test is done
-	oauthTokenExpire := config.Global.OauthTokenExpire
-	oauthTokenExpiredRetainPeriod := config.Global.OauthTokenExpiredRetainPeriod
-	defer func() {
-		config.Global.OauthTokenExpire = oauthTokenExpire
-		config.Global.OauthTokenExpiredRetainPeriod = oauthTokenExpiredRetainPeriod
-	}()
-
+	globalConf := config.Global()
 	// set tokens to be expired after 1 second
-	config.Global.OauthTokenExpire = 1
+	globalConf.OauthTokenExpire = 1
 	// cleanup tokens older than 3 seconds
-	config.Global.OauthTokenExpiredRetainPeriod = 3
+	globalConf.OauthTokenExpiredRetainPeriod = 3
+	config.SetGlobal(globalConf)
+
+	defer resetTestConfig()
 
 	ts := newTykTestServer()
 	defer ts.Close()

--- a/policy.go
+++ b/policy.go
@@ -161,7 +161,7 @@ func LoadPoliciesFromRPC(orgId string) map[string]user.Policy {
 		return LoadPoliciesFromRPCBackup()
 	}
 
-	store := &RPCStorageHandler{UserKey: config.Global.SlaveOptions.APIKey, Address: config.Global.SlaveOptions.ConnectionString}
+	store := &RPCStorageHandler{UserKey: config.Global().SlaveOptions.APIKey, Address: config.Global().SlaveOptions.ConnectionString}
 	if !store.Connect() {
 		return nil
 	}

--- a/policy_test.go
+++ b/policy_test.go
@@ -20,12 +20,17 @@ func TestLoadPoliciesFromDashboardReLogin(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	oldUseDBAppConfigs := config.Global.UseDBAppConfigs
-	config.Global.UseDBAppConfigs = false
+	globalConf := config.Global()
+	oldUseDBAppConfigs := globalConf.UseDBAppConfigs
+	globalConf.UseDBAppConfigs = false
+	config.SetGlobal(globalConf)
 
-	defer func() { config.Global.UseDBAppConfigs = oldUseDBAppConfigs }()
+	defer func() {
+		globalConf.UseDBAppConfigs = oldUseDBAppConfigs
+		config.SetGlobal(globalConf)
+	}()
 
-	allowExplicitPolicyID := config.Global.Policies.AllowExplicitPolicyID
+	allowExplicitPolicyID := config.Global().Policies.AllowExplicitPolicyID
 
 	policyMap := LoadPoliciesFromDashboard(ts.URL, "", allowExplicitPolicyID)
 

--- a/redis_signal_handle_config.go
+++ b/redis_signal_handle_config.go
@@ -63,7 +63,7 @@ func handleNewConfiguration(payload string) {
 		return
 	}
 
-	if !config.Global.AllowRemoteConfig {
+	if !config.Global().AllowRemoteConfig {
 		log.WithFields(logrus.Fields{
 			"prefix": "pub-sub",
 		}).Warning("Ignoring new config: Remote configuration is not allowed for this node.")
@@ -128,7 +128,7 @@ func sanitizeConfig(mc map[string]interface{}) map[string]interface{} {
 }
 
 func getExistingConfig() (map[string]interface{}, error) {
-	f, err := os.Open(config.Global.OriginalPath)
+	f, err := os.Open(config.Global().OriginalPath)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc_analytics_purger.go
+++ b/rpc_analytics_purger.go
@@ -89,9 +89,7 @@ func (r RedisPurger) PurgeLoop(ticker <-chan time.Time) {
 }
 
 func (r *RedisPurger) PurgeCache() {
-	configMu.Lock()
-	expireAfter := config.Global.AnalyticsConfig.StorageExpirationTime
-	configMu.Unlock()
+	expireAfter := config.Global().AnalyticsConfig.StorageExpirationTime
 	if expireAfter == 0 {
 		expireAfter = 60 // 1 minute
 	}

--- a/rpc_backup_handlers.go
+++ b/rpc_backup_handlers.go
@@ -21,8 +21,8 @@ const BackupPolicyKeyBase = "node-policy-backup:"
 
 func getTagListAsString() string {
 	tagList := ""
-	if len(config.Global.DBAppConfOptions.Tags) > 0 {
-		tagList = strings.Join(config.Global.DBAppConfOptions.Tags, "-")
+	if tags := config.Global().DBAppConfOptions.Tags; len(tags) > 0 {
+		tagList = strings.Join(tags, "-")
 	}
 
 	return tagList
@@ -41,7 +41,7 @@ func LoadDefinitionsFromRPCBackup() []*APISpec {
 		return nil
 	}
 
-	secret := rightPad2Len(config.Global.Secret, "=", 32)
+	secret := rightPad2Len(config.Global().Secret, "=", 32)
 	cryptoText, err := store.GetKey(checkKey)
 	apiListAsString := decrypt([]byte(secret), cryptoText)
 
@@ -70,7 +70,7 @@ func saveRPCDefinitionsBackup(list string) {
 		return
 	}
 
-	secret := rightPad2Len(config.Global.Secret, "=", 32)
+	secret := rightPad2Len(config.Global().Secret, "=", 32)
 	cryptoText := encrypt([]byte(secret), list)
 	err := store.SetKey(BackupApiKeyBase+tagList, cryptoText, -1)
 	if err != nil {
@@ -92,7 +92,7 @@ func LoadPoliciesFromRPCBackup() map[string]user.Policy {
 		return nil
 	}
 
-	secret := rightPad2Len(config.Global.Secret, "=", 32)
+	secret := rightPad2Len(config.Global().Secret, "=", 32)
 	cryptoText, err := store.GetKey(checkKey)
 	listAsString := decrypt([]byte(secret), cryptoText)
 
@@ -127,7 +127,7 @@ func saveRPCPoliciesBackup(list string) {
 		return
 	}
 
-	secret := rightPad2Len(config.Global.Secret, "=", 32)
+	secret := rightPad2Len(config.Global().Secret, "=", 32)
 	cryptoText := encrypt([]byte(secret), list)
 	err := store.SetKey(BackupPolicyKeyBase+tagList, cryptoText, -1)
 	if err != nil {

--- a/service_discovery.go
+++ b/service_discovery.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Jeffail/gabs"
+	"github.com/jeffail/gabs"
 
 	"github.com/TykTechnologies/tyk/apidef"
 )

--- a/storage/redis_cluster.go
+++ b/storage/redis_cluster.go
@@ -54,7 +54,7 @@ func IsConnected() bool {
 	testClusters := []*RedisCluster{
 		{},
 	}
-	if config.Global.EnableSeperateCacheStore {
+	if config.Global().EnableSeperateCacheStore {
 		testClusters = append(testClusters, &RedisCluster{IsCache: true})
 	}
 	for _, cluster := range testClusters {
@@ -93,9 +93,9 @@ func IsConnected() bool {
 
 func NewRedisClusterPool(isCache bool) *rediscluster.RedisCluster {
 	// redisSingletonMu is locked and we know the singleton is nil
-	cfg := config.Global.Storage
-	if isCache && config.Global.EnableSeperateCacheStore {
-		cfg = config.Global.CacheStorage
+	cfg := config.Global().Storage
+	if isCache && config.Global().EnableSeperateCacheStore {
+		cfg = config.Global().CacheStorage
 	}
 
 	log.Debug("Creating new Redis connection pool")

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -53,7 +53,7 @@ func HashStr(in string) string {
 }
 
 func HashKey(in string) string {
-	if !config.Global.HashKeys {
+	if !config.Global().HashKeys {
 		// Not hashing? Return the raw key
 		return in
 	}

--- a/user/session.go
+++ b/user/session.go
@@ -97,8 +97,8 @@ func (s *SessionState) HasChanged() bool {
 }
 
 func (s *SessionState) Lifetime(fallback int64) int64 {
-	if config.Global.ForceGlobalSessionLifetime {
-		return config.Global.GlobalSessionLifetime
+	if config.Global().ForceGlobalSessionLifetime {
+		return config.Global().GlobalSessionLifetime
 	}
 	if s.SessionLifetime > 0 {
 		return s.SessionLifetime


### PR DESCRIPTION
refactoring for https://github.com/TykTechnologies/tyk/issues/1573

PR has lots of changes but the main idea is:
- global var `config.Global` and mutex `configMu` with logic around it are gone
- to read config - there is a new method `config.Global()` which returns `config.Config` and uses `sync/atomic`'s `Value` inside to provide atomic reads
- to write to config we should always have changed copy of it and the call `config.SetGlobal(conf Config)` which again provides atomic write
- all `APISpec` instances have a new field `GlobalConfig` which is set to `config.Global()` at API-load time and  is supposed to be used everywhere when we have `APISpec` instances - middle-wares and handlers to avoid to much calls to `config.Global()`

Also, maybe as a good side affect - we can introduce some alternative ways to do hot reload config with new version. 

I used our current benchmarking to see how we did:
```
➜  tyk git:(master) ./utils/ci-benchmark.sh > /tmp/old.txt
➜  tyk git:(master) git checkout config-global-races-fix
➜  tyk git:(config-global-races-fix) ./utils/ci-benchmark.sh > /tmp/new.txt
➜  tyk git:(config-global-races-fix) benchcmp /tmp/old.txt /tmp/new.txt    
benchmark                                               old ns/op     new ns/op     delta
BenchmarkApiReload-8                                    3403631       3742793       +9.96%
BenchmarkJWTSessionHMAC-8                               688676        714382        +3.73%
BenchmarkJWTSessionRSA-8                                859050        853650        -0.63%
BenchmarkJWTSessionRSABearer-8                          864115        845534        -2.15%
BenchmarkJWTSessionRSAWithRawSourceOnWithClientID-8     746854        732055        -1.98%
BenchmarkJWTSessionRSAWithRawSource-8                   737400        719759        -2.39%
BenchmarkJWTSessionRSAWithJWK-8                         745282        725662        -2.63%
BenchmarkJWTSessionRSAWithEncodedJWK-8                  739275        730120        -1.24%
BenchmarkCopyRequestResponse-8                          15344         15502         +1.03%

benchmark                                               old allocs     new allocs     delta
BenchmarkApiReload-8                                    23907          23907          +0.00%
BenchmarkJWTSessionHMAC-8                               714            713            -0.14%
BenchmarkJWTSessionRSA-8                                792            791            -0.13%
BenchmarkJWTSessionRSABearer-8                          793            793            +0.00%
BenchmarkJWTSessionRSAWithRawSourceOnWithClientID-8     814            814            +0.00%
BenchmarkJWTSessionRSAWithRawSource-8                   797            797            +0.00%
BenchmarkJWTSessionRSAWithJWK-8                         801            801            +0.00%
BenchmarkJWTSessionRSAWithEncodedJWK-8                  805            805            +0.00%
BenchmarkCopyRequestResponse-8                          76             76             +0.00%

benchmark                                               old bytes     new bytes     delta
BenchmarkApiReload-8                                    1789646       1789704       +0.00%
BenchmarkJWTSessionHMAC-8                               117808        117699        -0.09%
BenchmarkJWTSessionRSA-8                                161132        160781        -0.22%
BenchmarkJWTSessionRSABearer-8                          162085        161953        -0.08%
BenchmarkJWTSessionRSAWithRawSourceOnWithClientID-8     140062        140033        -0.02%
BenchmarkJWTSessionRSAWithRawSource-8                   132024        131912        -0.08%
BenchmarkJWTSessionRSAWithJWK-8                         132034        131847        -0.14%
BenchmarkJWTSessionRSAWithEncodedJWK-8                  132030        131888        -0.11%
BenchmarkCopyRequestResponse-8                          35584         35584         +0.00%
``` 

As we see:
- `B/op` and `allocs/op` are OK or maybe even better
-  `ns/op` - `BenchmarkApiReload` increased  `+9.96%` which I think is expected, however, I think we can do better
-  `ns/op` - JWT middleware looks OK except `BenchmarkJWTSessionHMAC`'s `+3.73%` - needs to be investigated
