### PR TITLE
Add way to configure proxy transport tls options

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -371,6 +371,10 @@ type APIDefinition struct {
 		StructuredTargetList        *HostList                     `bson:"-" json:"-"`
 		CheckHostAgainstUptimeTests bool                          `bson:"check_host_against_uptime_tests" json:"check_host_against_uptime_tests"`
 		ServiceDiscovery            ServiceDiscoveryConfiguration `bson:"service_discovery" json:"service_discovery"`
+		Transport                   struct {
+			SSLCipherSuites []string `bson:"ssl_ciphers" json:"ssl_ciphers"`
+			SSLMinVersion   uint16   `bson: "ssl_min_version" json: "ssl_min_version"`
+		} `bson:"transport" json:"transport"`
 	} `bson:"proxy" json:"proxy"`
 	DisableRateLimit          bool                   `bson:"disable_rate_limit" json:"disable_rate_limit"`
 	DisableQuota              bool                   `bson:"disable_quota" json:"disable_quota"`

--- a/cert_test.go
+++ b/cert_test.go
@@ -708,3 +708,56 @@ func TestCipherSuites(t *testing.T) {
 		ts.Run(t, test.TestCase{Client: client, Path: "/", ErrorMatch: "tls: handshake failure"})
 	})
 }
+
+func TestProxyCipherSuites(t *testing.T) {
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("test"))
+	}))
+	defer upstream.Close()
+
+	config.Global.ProxySSLInsecureSkipVerify = true
+	// force creating new transport on each reque
+	config.Global.MaxConnTime = -1
+	defer resetTestConfig()
+
+	ts := newTykTestServer()
+	defer ts.Close()
+
+	buildAndLoadAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/"
+		spec.Proxy.TargetURL = upstream.URL
+	})
+
+	//matching ciphers
+	t.Run("Global: Cipher match", func(t *testing.T) {
+		config.Global.ProxySSLCipherSuites = []string{"TLS_RSA_WITH_AES_128_CBC_SHA"}
+		ts.Run(t, test.TestCase{Path: "/", Code: 200})
+	})
+
+	t.Run("Global: Cipher not match", func(t *testing.T) {
+		config.Global.ProxySSLCipherSuites = []string{"TLS_RSA_WITH_RC4_128_SHA"}
+		ts.Run(t, test.TestCase{Path: "/", Code: 500})
+	})
+
+	t.Run("API: Cipher override", func(t *testing.T) {
+		config.Global.ProxySSLCipherSuites = []string{"TLS_RSA_WITH_RC4_128_SHA"}
+		buildAndLoadAPI(func(spec *APISpec) {
+			spec.Proxy.ListenPath = "/"
+			spec.Proxy.TargetURL = upstream.URL
+			spec.Proxy.Transport.SSLCipherSuites = []string{"TLS_RSA_WITH_AES_128_CBC_SHA"}
+		})
+
+		ts.Run(t, test.TestCase{Path: "/", Code: 200})
+	})
+
+	t.Run("API: MinTLS not match", func(t *testing.T) {
+		config.Global.ProxySSLMinVersion = 772
+		buildAndLoadAPI(func(spec *APISpec) {
+			spec.Proxy.ListenPath = "/"
+			spec.Proxy.TargetURL = upstream.URL
+			spec.Proxy.Transport.SSLCipherSuites = []string{"TLS_RSA_WITH_AES_128_CBC_SHA"}
+		})
+
+		ts.Run(t, test.TestCase{Path: "/", Code: 500})
+	})
+}

--- a/config/config.go
+++ b/config/config.go
@@ -273,6 +273,8 @@ type Config struct {
 	MaxConnTime                       int64                                 `json:"max_conn_time"`
 	ReloadWaitTime                    int                                   `bson:"reload_wait_time" json:"reload_wait_time"`
 	ProxySSLInsecureSkipVerify        bool                                  `json:"proxy_ssl_insecure_skip_verify"`
+	ProxySSLMinVersion                uint16                                `json:"proxy_ssl_min_version"`
+	ProxySSLCipherSuites              []string                              `json:"proxy_ssl_ciphers"`
 	ProxyDefaultTimeout               int                                   `json:"proxy_default_timeout"`
 	LogLevel                          string                                `json:"log_level"`
 	Security                          SecurityConfig                        `json:"security"`

--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -431,6 +431,22 @@ func httpTransport(timeOut int, rw http.ResponseWriter, req *http.Request, p *Re
 
 	transport.DialTLS = dialTLSPinnedCheck(p.TykAPISpec, transport.TLSClientConfig)
 
+	if config.Global.ProxySSLMinVersion > 0 {
+		transport.TLSClientConfig.MinVersion = config.Global.ProxySSLMinVersion
+	}
+
+	if p.TykAPISpec.Proxy.Transport.SSLMinVersion > 0 {
+		transport.TLSClientConfig.MinVersion = p.TykAPISpec.Proxy.Transport.SSLMinVersion
+	}
+
+	if len(config.Global.ProxySSLCipherSuites) > 0 {
+		transport.TLSClientConfig.CipherSuites = getCipherAliases(config.Global.ProxySSLCipherSuites)
+	}
+
+	if len(p.TykAPISpec.Proxy.Transport.SSLCipherSuites) > 0 {
+		transport.TLSClientConfig.CipherSuites = getCipherAliases(p.TykAPISpec.Proxy.Transport.SSLCipherSuites)
+	}
+
 	// Use the default unless we've modified the timout
 	if timeOut > 0 {
 		log.Debug("Setting timeout for outbound request to: ", timeOut)


### PR DESCRIPTION
Added way to configure SSL MinVersion and Ciphers for Tyk->Upstream
transport:

On global level: `proxy_ssl_ciphers` and `proxy_ssl_min_version`

On API level: `proxy.transport.ssl_ciphers` and
`proxy.transport.ssl_min_version`