### PR TITLE
start DRL after node registration completed

### DIFF
--- a/distributed_rate_limiter.go
+++ b/distributed_rate_limiter.go
@@ -91,7 +91,12 @@ func onServerStatusReceivedHandler(payload string) {
 	log.Debug("Received DRL data: ", serverData)
 
 	if DRLManager.Ready {
-		DRLManager.AddOrUpdateServer(serverData)
+		if err := DRLManager.AddOrUpdateServer(serverData); err != nil {
+			log.WithError(err).
+				WithField("serverData", serverData).
+				Error("AddOrUpdateServer error")
+			return
+		}
 		log.Debug(DRLManager.Report())
 	} else {
 		log.Warning("DRL not ready, skipping this notification")

--- a/main.go
+++ b/main.go
@@ -1171,8 +1171,6 @@ func listen(listener, controlListener net.Listener, err error) {
 		writeTimeout = time.Duration(config.Global.HttpServerOptions.WriteTimeout) * time.Second
 	}
 
-	drlOnce.Do(startDRL)
-
 	if config.Global.ControlAPIPort > 0 {
 		loadAPIEndpoints(controlRouter)
 	}
@@ -1295,6 +1293,10 @@ func listen(listener, controlListener net.Listener, err error) {
 
 		mainLog.Info("Resuming on", listener.Addr())
 	}
+
+	// at this point NodeID is ready to use by DRL
+	drlOnce.Do(startDRL)
+
 	address := config.Global.ListenAddress
 	if config.Global.ListenAddress == "" {
 		address = "(open interface)"

--- a/main.go
+++ b/main.go
@@ -1113,15 +1113,19 @@ func generateListener(listenPort int) (net.Listener, error) {
 	}
 }
 
+func dashboardServiceInit() {
+	if DashService == nil {
+		DashService = &HTTPDashboardHandler{}
+		DashService.Init()
+	}
+}
+
 func handleDashboardRegistration() {
 	if !config.Global.UseDBAppConfigs {
 		return
 	}
 
-	if DashService == nil {
-		DashService = &HTTPDashboardHandler{}
-		DashService.Init()
-	}
+	dashboardServiceInit()
 
 	// connStr := buildConnStr("/register/node")
 
@@ -1245,6 +1249,7 @@ func listen(listener, controlListener net.Listener, err error) {
 		}
 
 		if config.Global.UseDBAppConfigs {
+			dashboardServiceInit()
 			go DashService.StartBeating()
 		}
 


### PR DESCRIPTION
added fix for https://github.com/TykTechnologies/tyk/issues/1590

so we had this sequence:

1. set global `NodeID` to `solo-...`
2. setup `DRLManager` and start sending notifications
3. `DRLManager` sends notification with NodeID="solo-..."
4. run node registration which sets `NodeID` to some different value
5. DRL's method `NotifyCurrentServerStatus` uses global `NodeID` so starts sending notifications with new NodeID - which confuses underlying DRL which still has "solo-..." as ID for current server, so it treats new NodeID as other server

I've changed startup process - first we do node registration and then when we know that NodeID is "final" we start DRL