### PR TITLE
pprof: expose CPU profile when httpProfile enabled

### DIFF
--- a/main.go
+++ b/main.go
@@ -366,6 +366,7 @@ func loadAPIEndpoints(muxer *mux.Router) {
 	}
 
 	if *httpProfile {
+		muxer.HandleFunc("/debug/pprof/profile", pprof_http.Profile)
 		muxer.HandleFunc("/debug/pprof/{_:.*}", pprof_http.Index)
 	}
 


### PR DESCRIPTION
When profiling, using tools like go-torch require http profiling enabled
and need access to `/debug/pprof/profile` which is not enabled by
default.

This exposes the `net/http/pprof` CPU profiler via HTTP. When
`httpprofile` is enabled, `cpuprofile` should not / cannot be used.
