### PR TITLE
feature: Make MaxIdleConns configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -272,6 +272,7 @@ type Config struct {
 	EnableBundleDownloader            bool                                  `bson:"enable_bundle_downloader" json:"enable_bundle_downloader"`
 	AllowRemoteConfig                 bool                                  `bson:"allow_remote_config" json:"allow_remote_config"`
 	LegacyEnableAllowanceCountdown    bool                                  `bson:"legacy_enable_allowance_countdown" json:"legacy_enable_allowance_countdown"`
+	MaxIdleConns                      int                                   `bson:"max_idle_connections" json:"max_idle_connections"`
 	MaxIdleConnsPerHost               int                                   `bson:"max_idle_connections_per_host" json:"max_idle_connections_per_host"`
 	MaxConnTime                       int64                                 `json:"max_conn_time"`
 	ReloadWaitTime                    int                                   `bson:"reload_wait_time" json:"reload_wait_time"`

--- a/lint/schema.go
+++ b/lint/schema.go
@@ -416,6 +416,9 @@ const confSchema = `{
 	"max_idle_connections_per_host": {
 		"type": "integer"
 	},
+	"max_idle_connections": {
+		"type": "integer"
+	},
 	"max_conn_time": {
 		"type": "integer"
 	},

--- a/main.go
+++ b/main.go
@@ -884,9 +884,11 @@ func afterConfSetup(conf *config.Config) {
 	if conf.SlaveOptions.CallTimeout == 0 {
 		conf.SlaveOptions.CallTimeout = 30
 	}
+
 	if conf.SlaveOptions.PingTimeout == 0 {
 		conf.SlaveOptions.PingTimeout = 60
 	}
+
 	GlobalRPCPingTimeout = time.Second * time.Duration(conf.SlaveOptions.PingTimeout)
 	GlobalRPCCallTimeout = time.Second * time.Duration(conf.SlaveOptions.CallTimeout)
 	conf.EventTriggers = InitGenericEventHandlers(conf.EventHandlers)

--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -311,7 +311,7 @@ func defaultTransport() *http.Transport {
 			KeepAlive: 30 * time.Second,
 			DualStack: true,
 		}).DialContext,
-		MaxIdleConns:        100,
+		MaxIdleConns:        config.Global().MaxIdleConns,
 		MaxIdleConnsPerHost: config.Global().MaxIdleConnsPerHost, // default is 100
 		TLSHandshakeTimeout: 10 * time.Second,
 	}


### PR DESCRIPTION
fixes #1560

This PR could be a bit of a problem.

https://golang.org/src/net/http/transport.go#L156
> MaxIdleConns controls the maximum number of idle (keep-alive)
> connections across all hosts. Zero means no limit.

Zero value with this PR will set default MaxIdleConns to 100 - which matches existing behaviour. But that means that impossible to allow unlimited connections.

However without setting sensible default value, zero means that all prev installations will then change current functionality to unlimited idle connections.

Any thoughts @buger ?