### PR TITLE
Expose prefixed environment variables to JS middleware

### DIFF
--- a/mw_js_plugin_test.go
+++ b/mw_js_plugin_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http/httptest"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -304,5 +305,20 @@ testJSVMCore.NewProcessRequest(function(request, session, config) {
 
 	if want, got := "globalValue", r.Header.Get("global"); want != got {
 		t.Fatalf("wanted header to be %q, got %q", want, got)
+	}
+}
+func TestJSVMEnvVars(t *testing.T) {
+	testVal := "TEST_VALUE"
+	os.Setenv("TYK_CONTEXT_TEST", testVal)
+	jsvm := JSVM{}
+	jsvm.Init(nil)
+	const in = "TykJS.Environment[\"TYK_CONTEXT_TEST\"]"
+	v, _ := jsvm.VM.Run(in)
+	returnedVal, err := v.ToString()
+	if err != nil {
+		t.Fatal("Couldn't convert JSVM value")
+	}
+	if returnedVal != testVal {
+		t.Fatalf("wanted value to be %s, got %s", testVal, returnedVal)
 	}
 }


### PR DESCRIPTION
Discussed in #929.

With this you can access environment variables:
```js
var sampleMiddleware = new TykJS.TykMiddleware.NewMiddleware({});
sampleMiddleware.NewProcessRequest(function(request, session) {
    var myvar = TykJS.Environment["TYK_CONTEXT_MY_VAR"]
    return sampleMiddleware.ReturnData(request, session.meta_data);
});
```
We may optionally strip the "TYK_CONTEXT_" prefix, so that it becomes "MY_VAR". Environment variables that don't start with "TYK_CONTEXT_" will be ignored.
VE should also benefit from this. We avoid having this in the request context.
`getCtxEnv` can be re-used for rich plugins code.