### PR TITLE
Access the URL rewriter meta data structure using a pointer

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -105,7 +105,7 @@ type URLSpec struct {
 	InjectHeadersResponse     apidef.HeaderInjectionMeta
 	HardTimeout               apidef.HardTimeoutMeta
 	CircuitBreaker            ExtendedCircuitBreakerMeta
-	URLRewrite                apidef.URLRewriteMeta
+	URLRewrite                *apidef.URLRewriteMeta
 	VirtualPathSpec           apidef.VirtualMeta
 	RequestSize               apidef.RequestSizeMeta
 	MethodTransform           apidef.MethodTransformMeta
@@ -678,7 +678,7 @@ func (a APIDefinitionLoader) compileURLRewritesPathSpec(paths []apidef.URLRewrit
 		newSpec := URLSpec{}
 		a.generateRegex(stringSpec.Path, &newSpec, stat)
 		// Extend with method actions
-		newSpec.URLRewrite = stringSpec
+		newSpec.URLRewrite = &stringSpec
 
 		urlSpec = append(urlSpec, newSpec)
 	}
@@ -990,7 +990,7 @@ func (a *APISpec) CheckSpecMatchesStatus(r *http.Request, rxPaths []URLSpec, mod
 			}
 		case URLRewrite:
 			if r.Method == v.URLRewrite.Method {
-				return true, &v.URLRewrite
+				return true, v.URLRewrite
 			}
 		case VirtualPath:
 			if r.Method == v.VirtualPathSpec.Method {

--- a/mw_url_rewrite_test.go
+++ b/mw_url_rewrite_test.go
@@ -76,16 +76,14 @@ func TestRewriter(t *testing.T) {
 		})
 	}
 }
-
 func BenchmarkRewriter(b *testing.B) {
 	b.ReportAllocs()
-
-	for i := 0; i < b.N; i++ {
-		for _, tc := range testRewriterData {
-			testConf := apidef.URLRewriteMeta{
-				MatchPattern: tc.pattern,
-				RewriteTo:    tc.to,
-			}
+	for _, tc := range testRewriterData {
+		testConf := apidef.URLRewriteMeta{
+			MatchPattern: tc.pattern,
+			RewriteTo:    tc.to,
+		}
+		for i := 0; i < b.N; i++ {
 			r := httptest.NewRequest("GET", tc.in, nil)
 			urlRewrite(&testConf, r)
 		}


### PR DESCRIPTION
Need to do some more tests on this, the idea is to avoid changing other parts of the code like this: https://github.com/TykTechnologies/tyk/commit/c2f80ff6bac2f2c7c92c559be3ae02a452a5c882#diff-e174c6f6100dfee8c74de8323d464e36

With this PR, the regular expressions used in the URL rewriter are compiled only once, following the idea of #1629, #1624. This is part of #1662.