### PR TITLE
Remove already compiled expression from the URL rewriter code

### DIFF
--- a/mw_url_rewrite.go
+++ b/mw_url_rewrite.go
@@ -146,7 +146,6 @@ func urlRewrite(meta *apidef.URLRewriteMeta, r *http.Request) (string, error) {
 	if len(matchGroups) > 0 {
 		newpath = rewriteToPath
 		// get the indices for the replacements:
-		dollarMatch := regexp.MustCompile(`\$\d+`) // Prepare our regex
 		replaceGroups := dollarMatch.FindAllStringSubmatch(rewriteToPath, -1)
 
 		log.Debug(matchGroups)


### PR DESCRIPTION
This is already here: https://github.com/matiasinsaurralde/tyk/blob/5c27210a9a6aa19a44d0d1c5cecbb53b0bc0c49d/mw_url_rewrite.go#L24

Related to #1662.