### PR TITLE
Expose prefixed environment variables to gRPC middleware

### DIFF
--- a/coprocess_grpc.go
+++ b/coprocess_grpc.go
@@ -13,6 +13,8 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
+	"google.golang.org/grpc/metadata"
+
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/coprocess"
@@ -55,7 +57,10 @@ func dialer(addr string, timeout time.Duration) (net.Conn, error) {
 
 // Dispatch takes a CoProcessMessage and sends it to the CP.
 func (d *GRPCDispatcher) DispatchObject(object *coprocess.Object) (*coprocess.Object, error) {
-	newObject, err := grpcClient.Dispatch(context.Background(), object)
+	// Inject environment variables into the context:
+	md := metadata.New(getCtxEnv())
+	ctx := metadata.NewContext(context.Background(), md)
+	newObject, err := grpcClient.Dispatch(ctx, object)
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "coprocess-grpc",

--- a/mw_js_plugin_test.go
+++ b/mw_js_plugin_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http/httptest"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -304,5 +305,20 @@ testJSVMCore.NewProcessRequest(function(request, session, config) {
 
 	if want, got := "globalValue", r.Header.Get("global"); want != got {
 		t.Fatalf("wanted header to be %q, got %q", want, got)
+	}
+}
+func TestJSVMEnvVars(t *testing.T) {
+	testVal := "TEST_VALUE"
+	os.Setenv("TYK_CONTEXT_TEST", testVal)
+	jsvm := JSVM{}
+	jsvm.Init(nil)
+	const in = "TykJS.Environment[\"TYK_CONTEXT_TEST\"]"
+	v, _ := jsvm.VM.Run(in)
+	returnedVal, err := v.ToString()
+	if err != nil {
+		t.Fatal("Couldn't convert JSVM value")
+	}
+	if returnedVal != testVal {
+		t.Fatalf("wanted value to be %s, got %s", testVal, returnedVal)
 	}
 }


### PR DESCRIPTION
This is an enhancement related to #929, will need documentation as it uses gRPC metadata (set during a gRPC session, this can be accessed through any of the gRPC libraries) instead of injecting environment variables on every call.
#1616 needs to be merged first.
Go plugin sample, this is a hook implementation accessing environment variables through gRPC metadata:
```go
func MyAuthCheck(ctx context.Context, object *coprocess.Object) (*coprocess.Object, error) {
        md, err := metadata.FromIncomingContext(ctx)
        fmt.Println("TYK_CONTEXT_ABC is", md.Get("TYK_CONTEXT_ABC"))
        authHeader := object.Request.Headers["Authorization"]
        ...
}
```