### PR TITLE
Remove fmt call in the session for each call

### DIFF
--- a/event_system.go
+++ b/event_system.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"errors"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -167,17 +166,17 @@ func (l *LogMessageEventHandler) Init(handlerConf interface{}) error {
 
 // HandleEvent will be fired when the event handler instance is found in an APISpec EventPaths object during a request chain
 func (l *LogMessageEventHandler) HandleEvent(em config.EventMessage) {
-	logMsg := fmt.Sprintf("%s:%s", l.prefix, em.Type)
+	logMsg := l.prefix + ":" + string(em.Type)
 
 	// We can handle specific event types easily
 	if em.Type == EventQuotaExceeded {
 		msgConf := em.Meta.(EventKeyFailureMeta)
-		logMsg = fmt.Sprintf("%s:%s:%s:%s", logMsg, msgConf.Key, msgConf.Origin, msgConf.Path)
+		logMsg = logMsg + ":" + msgConf.Key + ":" + msgConf.Origin + ":" + msgConf.Path
 	}
 
 	if em.Type == EventBreakerTriggered {
 		msgConf := em.Meta.(EventCurcuitBreakerMeta)
-		logMsg = fmt.Sprintf("%s:%s:%s: [STATUS] %v", logMsg, msgConf.APIID, msgConf.Path, msgConf.CircuitEvent)
+		logMsg = logMsg + ":" + msgConf.APIID + ":" + msgConf.Path + ": [STATUS] " + string(msgConf.CircuitEvent)
 	}
 
 	log.Warning(logMsg)

--- a/handler_error.go
+++ b/handler_error.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"encoding/base64"
-	"fmt"
 	"net/http"
 	"runtime/pprof"
 	"strconv"
@@ -47,20 +46,20 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 
 	w.Header().Set("Content-Type", contentType)
 
-	templateName := fmt.Sprintf("error_%s.%s", strconv.Itoa(errCode), templateExtension)
+	templateName := "error_" + strconv.Itoa(errCode) + "." + templateExtension
 
 	// Try to use an error template that matches the HTTP error code and the content type: 500.json, 400.xml, etc.
 	tmpl := templates.Lookup(templateName)
 
 	// Fallback to a generic error template, but match the content type: error.json, error.xml, etc.
 	if tmpl == nil {
-		templateName = fmt.Sprintf("%s.%s", defaultTemplateName, templateExtension)
+		templateName = defaultTemplateName + "." + templateExtension
 		tmpl = templates.Lookup(templateName)
 	}
 
 	// If no template is available for this content type, fallback to "error.json".
 	if tmpl == nil {
-		templateName = fmt.Sprintf("%s.%s", defaultTemplateName, defaultTemplateFormat)
+		templateName = defaultTemplateName + "." + defaultTemplateFormat
 		tmpl = templates.Lookup(templateName)
 		w.Header().Set("Content-Type", defaultContentType)
 	}

--- a/handler_success.go
+++ b/handler_success.go
@@ -14,8 +14,6 @@ import (
 
 	"github.com/TykTechnologies/tyk/request"
 
-	"fmt"
-
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/user"
 )
@@ -62,7 +60,7 @@ func tagHeaders(r *http.Request, th []string, tags []string) []string {
 
 		if ok {
 			for _, val := range v {
-				tagName := fmt.Sprintf("%s-%s", cleanK, val)
+				tagName := cleanK + "-" + val
 				tags = append(tags, tagName)
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -1125,7 +1125,7 @@ func start() {
 func generateListener(listenPort int) (net.Listener, error) {
 	listenAddress := config.Global().ListenAddress
 
-	targetPort := fmt.Sprintf("%s:%d", listenAddress, listenPort)
+	targetPort := listenAddress + ":" + strconv.Itoa(listenPort)
 
 	if httpServerOptions := config.Global().HttpServerOptions; httpServerOptions.UseSSL {
 		mainLog.Info("--> Using SSL (https)")
@@ -1213,7 +1213,7 @@ func listen(listener, controlListener net.Listener, err error) {
 	readTimeout := defReadTimeout
 	writeTimeout := defWriteTimeout
 
-	targetPort := fmt.Sprintf("%s:%d", config.Global().ListenAddress, config.Global().ListenPort)
+	targetPort := config.Global().ListenAddress + ":" + strconv.Itoa(config.Global().ListenPort)
 	if config.Global().HttpServerOptions.ReadTimeout > 0 {
 		readTimeout = time.Duration(config.Global().HttpServerOptions.ReadTimeout) * time.Second
 	}

--- a/mw_api_rate_limit.go
+++ b/mw_api_rate_limit.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 
 	"strconv"
@@ -30,7 +29,7 @@ func (k *RateLimitForAPI) EnabledForSpec() bool {
 	}
 
 	// We'll init here
-	k.keyName = fmt.Sprintf("apilimiter-%s%s", k.Spec.OrgID, k.Spec.APIID)
+	k.keyName = "apilimiter-" + k.Spec.OrgID + k.Spec.APIID
 
 	// Set last updated on each load to ensure we always use a new rate limit bucket
 	k.apiSess = &user.SessionState{

--- a/mw_url_rewrite.go
+++ b/mw_url_rewrite.go
@@ -352,7 +352,7 @@ func checkHeaderTrigger(r *http.Request, options map[string]apidef.StringRegexMa
 			for i, v := range vals {
 				b := mr.Check(v)
 				if len(b) > 0 {
-					kn := fmt.Sprintf("trigger-%d-%s-%d", triggernum, mhCN, i)
+					kn := "trigger-" + strconv.Itoa(triggernum) + "-" + mhCN + "-" + strconv.Itoa(i)
 					contextData[kn] = b
 					fCount++
 				}
@@ -382,7 +382,8 @@ func checkQueryString(r *http.Request, options map[string]apidef.StringRegexMap,
 			for i, v := range vals {
 				b := mr.Check(v)
 				if len(b) > 0 {
-					kn := fmt.Sprintf("trigger-%d-%s-%d", triggernum, mv, i)
+					kn := "trigger-" + strconv.Itoa(triggernum) + "-" + mv + "-" + strconv.Itoa(i)
+
 					contextData[kn] = b
 					fCount++
 				}
@@ -411,7 +412,8 @@ func checkPathParts(r *http.Request, options map[string]apidef.StringRegexMap, a
 		for _, part := range pathParts {
 			b := mr.Check(part)
 			if len(b) > 0 {
-				kn := fmt.Sprintf("trigger-%d-%s-%d", triggernum, mv, fCount)
+				kn := "trigger-" + strconv.Itoa(triggernum) + "-" + mv + "-" + strconv.Itoa(fCount)
+
 				contextData[kn] = b
 				fCount++
 			}
@@ -440,7 +442,8 @@ func checkSessionTrigger(r *http.Request, sess *user.SessionState, options map[s
 			if valOk {
 				b := mr.Check(val)
 				if len(b) > 0 {
-					kn := fmt.Sprintf("trigger-%d-%s", triggernum, mh)
+					kn := "trigger-" + strconv.Itoa(triggernum) + "-" + mh
+
 					contextData[kn] = b
 					fCount++
 				}
@@ -467,7 +470,8 @@ func checkPayload(r *http.Request, options apidef.StringRegexMap, triggernum int
 
 	b := options.Check(string(bodyBytes))
 	if len(b) > 0 {
-		kn := fmt.Sprintf("trigger-%d-payload", triggernum)
+		kn := "trigger-" + strconv.Itoa(triggernum) + "-payload"
+
 		contextData[kn] = string(b)
 		return true
 	}

--- a/mw_validate_json.go
+++ b/mw_validate_json.go
@@ -82,7 +82,7 @@ func (k *ValidateJSON) formatError(schemaErrors []gojsonschema.ResultError) erro
 		if i == 0 {
 			errStr = desc.String()
 		} else {
-			errStr = fmt.Sprintf("%s; %s", errStr, desc)
+			errStr = errStr + "; " + desc.String()
 		}
 	}
 

--- a/user/session.go
+++ b/user/session.go
@@ -1,8 +1,6 @@
 package user
 
 import (
-	"fmt"
-
 	"github.com/spaolacci/murmur3"
 	"gopkg.in/vmihailenco/msgpack.v2"
 
@@ -89,7 +87,7 @@ func (s *SessionState) Hash() string {
 		log.Error("Error encoding session data: ", err)
 		return ""
 	}
-	return fmt.Sprintf("%x", murmurHasher.Sum(encoded))
+	return string(murmurHasher.Sum(encoded)[:])
 }
 
 func (s *SessionState) HasChanged() bool {


### PR DESCRIPTION
Fixes #1632 

Running gateway headless with auth-key.

Before change:

```
Showing top 10 nodes out of 182
      flat  flat%   sum%        cum   cum%
     0.04s  0.58%  0.58%      0.04s  0.58%  fmt.(*fmt).fmt_sbx
     0.04s  0.58%  1.16%      0.06s  0.87%  github.com/TykTechnologies/tyk/vendor/github.com/TykTechnologies/redigocluster/rediscluster.ConcurrentMap.Iter.func1.1
     0.02s  0.29%  1.45%      0.04s  0.58%  net/textproto.CanonicalMIMEHeaderKey
     0.02s  0.29%  1.74%      0.02s  0.29%  net/textproto.validHeaderFieldByte (inline)
     0.02s  0.29%  2.03%      0.02s  0.29%  strings.TrimLeftFunc
     0.01s  0.14%  2.17%      0.01s  0.14%  bufio.(*Reader).bufio.reset
     0.01s  0.14%  2.32%      0.01s  0.14%  bufio.(*Writer).WriteString
     0.01s  0.14%  2.46%      0.01s  0.14%  bytes.(*Buffer).grow
     0.01s  0.14%  2.61%      0.01s  0.14%  bytes.(*Buffer).tryGrowByReslice
     0.01s  0.14%  2.75%      0.01s  0.14%  encoding/json.(*arrayEncoder).encode
```

After:

```
Showing top 10 nodes out of 153
      flat  flat%   sum%        cum   cum%
     0.02s   0.3%   0.3%      0.02s   0.3%  bytes.(*Buffer).WriteString
     0.02s   0.3%  0.61%      0.02s   0.3%  context.(*cancelCtx).cancel
     0.02s   0.3%  0.91%      0.03s  0.46%  context.(*valueCtx).Value
     0.02s   0.3%  1.22%      0.02s   0.3%  github.com/TykTechnologies/tyk/config.Global (inline)
     0.02s   0.3%  1.52%      0.20s  3.04%  main.createMiddleware.func1.1
     0.02s   0.3%  1.82%      0.02s   0.3%  net/textproto.CanonicalMIMEHeaderKey
     0.02s   0.3%  2.13%      0.02s   0.3%  sync.(*RWMutex).RLock
     0.01s  0.15%  2.28%      0.01s  0.15%  bytes.(*Buffer).Write
     0.01s  0.15%  2.43%      0.01s  0.15%  bytes.(*Buffer).tryGrowByReslice (inline)
     0.01s  0.15%  2.58%      0.01s  0.15%  context.(*emptyCtx).Value
```