### PR TITLE
Adds min-length check, adds more robust hash function, fixes #1681

### DIFF
--- a/auth_manager.go
+++ b/auth_manager.go
@@ -190,7 +190,9 @@ type DefaultKeyGenerator struct{}
 func (DefaultKeyGenerator) GenerateAuthKey(orgID string) string {
 	u5 := uuid.NewV4()
 	cleanSting := strings.Replace(u5.String(), "-", "", -1)
-	return orgID + cleanSting
+	withOrg := orgID + cleanSting
+
+	return storage.ModifyFromHashRange(withOrg)
 }
 
 // GenerateHMACSecret is a utility function for generating new auth keys. Returns the storage key name and the actual key

--- a/auth_manager_test.go
+++ b/auth_manager_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"github.com/TykTechnologies/tyk/storage"
+	"testing"
+)
+
+func TestDefaultKeyGenerator_GenerateAuthKey(t *testing.T) {
+	gen := DefaultKeyGenerator{}
+	k := gen.GenerateAuthKey("55d5927329415b000100003")
+
+	if !storage.InRange(k) {
+		t.Fatal("Key should have range suffix!")
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -285,6 +285,7 @@ type Config struct {
 	NewRelic                          NewRelicConfig                        `json:"newrelic"`
 	VersionHeader                     string                                `json:"version_header"`
 	EnableHashedKeysListing           bool                                  `json:"enable_hashed_keys_listing"`
+	MinTokenLength                    int                                   `json:"min_token_length"`
 }
 
 type CertData struct {

--- a/lint/schema.go
+++ b/lint/schema.go
@@ -727,6 +727,9 @@ const confSchema = `{
 	},
 	"enable_hashed_keys_listing": {
 		"type": "boolean"
+	},
+	"min_token_length": {
+		"type": "string"
 	}
 }
 }`

--- a/middleware.go
+++ b/middleware.go
@@ -278,9 +278,23 @@ func (t BaseMiddleware) ApplyPolicies(key string, session *user.SessionState) er
 	return t.Spec.SessionManager.UpdateSession(key, session, session.Lifetime(t.Spec.SessionLifetime), false)
 }
 
+func (t BaseMiddleware) keyValid(key string) bool {
+	if len(key) <= t.Spec.GlobalConfig.MinTokenLength || len(key) <= 3 {
+		return false
+	}
+
+	return true
+}
+
 // CheckSessionAndIdentityForValidKey will check first the Session store for a valid key, if not found, it will try
 // the Auth Handler, if not found it will fail
 func (t BaseMiddleware) CheckSessionAndIdentityForValidKey(key string) (user.SessionState, bool) {
+	// Validate first
+	if !t.keyValid(key) {
+		log.Error("key does not pass validity checks")
+		return user.SessionState{IsInactive: true}, false
+	}
+
 	// Try and get the session from the session store
 	log.Debug("Querying local cache")
 	cacheKey := key

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -6,8 +6,12 @@ import (
 
 	"github.com/spaolacci/murmur3"
 
+	"fmt"
 	"github.com/TykTechnologies/tyk/config"
 	logger "github.com/TykTechnologies/tyk/log"
+	murmur2 "github.com/aviddiviner/go-murmur"
+	"math/rand"
+	"time"
 )
 
 var log = logger.Get()
@@ -46,10 +50,83 @@ type Handler interface {
 	RemoveSortedSetRange(string, string, string) error
 }
 
-func HashStr(in string) string {
+func init() {
+	// Set of indicators that a token is from a new hash function
+	BuildRange(114, 414)
+}
+
+var HashRange []string
+
+func BuildRange(min, max int) {
+	top := max - min
+	HashRange = make([]string, top)
+
+	v := ""
+	ind := 0
+	for i := min; i < max; i++ {
+		v = fmt.Sprintf("%x", i)
+		if len(v) < 3 {
+			v = "x" + v
+		}
+
+		HashRange[ind] = v
+		ind++
+	}
+
+}
+
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
+func ModifyFromHashRange(in string) string {
+	rand.Seed(time.Now().UnixNano())
+	n := rand.Int() % len(HashRange)
+
+	out := in + HashRange[n]
+	return out
+}
+
+func InRange(key string) bool {
+	kLen := len(key)
+	if kLen == 56 {
+		// old hashing method OrgID+Token
+		return false
+	} else if kLen < 56 {
+		// likely custom token
+		return false
+	}
+
+	// Check if tail in range
+	lastThree := key[len(key)-3:]
+	return stringInSlice(lastThree, HashRange)
+}
+
+// See https://softwareengineering.stackexchange.com/questions/49550/which-hashing-algorithm-is-best-for-uniqueness-and-speed
+func HashMM2(in string) string {
+	// Uses 64-bit hash that has good randomness
+	h := murmur2.MurmurHash64A([]byte(in), 42)
+	return fmt.Sprintf("%x", h)
+}
+
+func HashMM3(in string) string {
 	h := murmur3.New32()
 	h.Write([]byte(in))
 	return hex.EncodeToString(h.Sum(nil))
+}
+
+func HashStr(in string) string {
+	if InRange(in) {
+		// use murmur2-based hash
+		return HashMM2(in)
+	}
+
+	return HashMM3(in)
 }
 
 func HashKey(in string) string {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -94,11 +94,8 @@ func ModifyFromHashRange(in string) string {
 
 func InRange(key string) bool {
 	kLen := len(key)
-	if kLen == 56 {
-		// old hashing method OrgID+Token
-		return false
-	} else if kLen < 56 {
-		// likely custom token
+	if kLen <= 56 {
+		// old hashing method OrgID+Token or a custom token
 		return false
 	}
 

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1,0 +1,91 @@
+package storage
+
+import (
+	"fmt"
+	"github.com/satori/go.uuid"
+	"testing"
+)
+
+func TestBuildRange(t *testing.T) {
+	for i, v := range HashRange {
+		if len(v) != 3 {
+			fmt.Printf("Val is: %s (index: %v) len is: %v \n", v, i, len(v))
+			t.Fatal("len is not 3")
+		}
+	}
+}
+
+func TestAppendCollision(t *testing.T) {
+	testRange := []string{
+		"111",
+		"112",
+		"113",
+		"55d5927329415b000100003bb0da4dcb354947eca50a995e8b7d1a80",
+		"55d5927329415b000100003bb0da4dcb354947eca50a995e8b7d1a801",
+		"55d5927329415b000100003bb0da4dcb354947eca50a995e8b7d1a8012",
+		"55d5927329415b000100003bb0da4dcb354947eca50a995e8b7d1a80123",
+		"55d5927329415b000100003bb0da4dcb354947eca50a995e8b7d1a801234",
+	}
+	seen := make([]string, len(testRange))
+
+	for i := range testRange {
+		testRange[i] = uuid.NewV4().String()
+	}
+
+	var h string
+	for i, v := range testRange {
+		h = HashMM2(v)
+		if stringInSlice(h, seen) {
+			t.Fatal("collison detected with incremental key")
+		}
+		seen[i] = v
+	}
+}
+
+func TestTypeSplit(t *testing.T) {
+	mm3Key := "55d5927329415b000100003bb0da4dcb354947eca50a995e8b7d1a80"
+	custKey := "customKey123"
+	mm2Key := "55d5927329415b000100003bb0da4dcb354947eca50a995e8b7d1a80xa7"
+
+	mm3Hash := HashStr(mm3Key)
+	custHash := HashStr(custKey)
+	m2Hash := HashStr(mm2Key)
+
+	if mm3Hash != "de6a0f23" {
+		t.Fatalf("incorrect MM3 hash, got %v", mm3Hash)
+	}
+
+	if custHash != "c6e73d88" {
+		t.Fatal("incorrect cust hash")
+	}
+
+	if m2Hash != "b187d7ca9320499" {
+		t.Fatal("incorrect MM2 hash")
+	}
+
+}
+
+func checkMM2Collisions(t *testing.T) {
+	testRange := make([]string, 50000)
+	seen := make([]string, 50000)
+
+	for i := range testRange {
+		testRange[i] = uuid.NewV4().String()
+	}
+
+	fmt.Println(testRange[:5])
+
+	collisions := 0
+	var h string
+	for i, v := range testRange {
+		h = HashMM2(v)
+		if stringInSlice(h, seen) {
+			collisions += 1
+		}
+		seen[i] = v
+
+		if i < 10 {
+			fmt.Println(h)
+		}
+	}
+}


### PR DESCRIPTION
This fixes #1681 by checking min length of token (must be at least 3 or a configurable parameter in the config file)

Adds a longer-term fix by using a psuedo-random suffix for new tokens, if this suffix is found, then Murmur2 is used (64 bit), otherwise, if it is exactly 56 characters (an org ID + UUIDv4) OR is less than 56, will revert to murmur3.

Choice for the hashing algo [was based on this rather amazing write-up](https://softwareengineering.stackexchange.com/questions/49550/which-hashing-algorithm-is-best-for-uniqueness-and-speed)


