### PR TITLE
Benchmark user session hash function - to help with string casting ticket

### DIFF
--- a/user/session_test.go
+++ b/user/session_test.go
@@ -1,0 +1,23 @@
+package user
+
+import (
+	"testing"
+)
+
+func BenchmarkHash(b *testing.B) {
+	s := SessionState{
+		Allowance:        1000.0,
+		Rate:             1000.0,
+		Per:              1,
+		Expires:          1458669677,
+		QuotaRemaining:   1000,
+		QuotaRenewalRate: 3600,
+	}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		{
+			s.Hash()
+		}
+	}
+}


### PR DESCRIPTION
As suggested by @dencoded in comments of #1680 

I have done this as it's own PR so it can be merged to master separately as it is expansion of benchmarking rather than part of a fix.