### PR TITLE
Fix JSVM event loading

### DIFF
--- a/main.go
+++ b/main.go
@@ -184,11 +184,6 @@ func setupGlobals() {
 	templatesDir := filepath.Join(config.Global.TemplatePath, "error*")
 	templates = template.Must(template.ParseGlob(templatesDir))
 
-	// Set up global JSVM
-	if config.Global.EnableJSVM {
-		GlobalEventsJSVM.Init(nil)
-	}
-
 	if config.Global.CoProcessOptions.EnableCoProcess {
 		CoProcessInit()
 	}
@@ -599,6 +594,11 @@ func doReload() {
 	reloadMu.Lock()
 	defer reloadMu.Unlock()
 
+	// Initialize/reset the JSVM
+	if config.Global.EnableJSVM {
+		GlobalEventsJSVM.Init(nil)
+	}
+
 	// Load the API Policies
 	syncPolicies()
 	// load the specs
@@ -611,11 +611,6 @@ func doReload() {
 	}
 
 	// We have updated specs, lets load those...
-
-	// Reset the JSVM
-	if config.Global.EnableJSVM {
-		GlobalEventsJSVM.Init(nil)
-	}
 
 	mainLog.Info("Preparing new router")
 	newRouter := mux.NewRouter()


### PR DESCRIPTION
See the last comment in #1678 for details.
This is a very simple patch that avoids calling `GlobalEventsJSVM.Init` twice by removing it from `main.listen`.
`main.listen` already calls `doReload` which contains the required call, also changed the order, it should be called before `syncPolicies` as this function interacts with the event system.
I'm refactoring this a bit for #1679 targeting `master`, adding tests and bechmarks.
Suggest trying different scenarios:
a) Start Tyk with no event handlers, add one, reload the gateway, trigger it.
b) Start Tyk with event handlers, trigger an event, remove it, reload the gateway, etc.