### PR TITLE
bench: caching bcrypt function for auth

### DIFF
--- a/api_loader.go
+++ b/api_loader.go
@@ -6,10 +6,12 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/gorilla/mux"
 	"github.com/justinas/alice"
+	"github.com/pmylund/go-cache"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
@@ -356,7 +358,7 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 			mainLog.WithField("api_name", spec.Name).Info("Checking security policy: OAuth")
 		}
 
-		if mwAppendEnabled(&authArray, &BasicAuthKeyIsValid{baseMid}) {
+		if mwAppendEnabled(&authArray, &BasicAuthKeyIsValid{baseMid, cache.New(60*time.Second, 60*time.Minute)}) {
 			mainLog.WithField("api_name", spec.Name).Info("Checking security policy: Basic")
 		}
 

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -329,8 +329,12 @@ type APIDefinition struct {
 		AllowedAuthorizeTypes  []osin.AuthorizeRequestType `bson:"allowed_authorize_types" json:"allowed_authorize_types"`
 		AuthorizeLoginRedirect string                      `bson:"auth_login_redirect" json:"auth_login_redirect"`
 	} `bson:"oauth_meta" json:"oauth_meta"`
-	Auth                          Auth                 `bson:"auth" json:"auth"`
-	UseBasicAuth                  bool                 `bson:"use_basic_auth" json:"use_basic_auth"`
+	Auth         Auth `bson:"auth" json:"auth"`
+	UseBasicAuth bool `bson:"use_basic_auth" json:"use_basic_auth"`
+	BasicAuth    struct {
+		DisableCaching bool `bson:"disable_caching" json:"disable_caching"`
+		CacheTTL       int  `bson:"cache_ttl" json:"cache_ttl"`
+	} `bson:"basic_auth" json:"basic_auth"`
 	UseMutualTLSAuth              bool                 `bson:"use_mutual_tls_auth" json:"use_mutual_tls_auth"`
 	ClientCertificates            []string             `bson:"client_certificates" json:"client_certificates"`
 	UpstreamCertificates          map[string]string    `bson:"upstream_certificates" json:"upstream_certificates"`

--- a/multiauth_test.go
+++ b/multiauth_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/justinas/alice"
 	"github.com/lonelycode/go-uuid/uuid"
+	"github.com/pmylund/go-cache"
 
 	"github.com/TykTechnologies/tyk/user"
 )
@@ -77,7 +78,7 @@ func getMultiAuthStandardAndBasicAuthChain(spec *APISpec) http.Handler {
 	chain := alice.New(mwList(
 		&IPWhiteListMiddleware{baseMid},
 		&IPBlackListMiddleware{BaseMiddleware: baseMid},
-		&BasicAuthKeyIsValid{baseMid},
+		&BasicAuthKeyIsValid{baseMid, cache.New(60*time.Second, 60*time.Minute)},
 		&AuthKey{baseMid},
 		&VersionCheck{BaseMiddleware: baseMid},
 		&KeyExpired{baseMid},


### PR DESCRIPTION
Fixes #1622 Fixes #1640

```
BenchmarkBasicAuth_CacheEnabled-4           3000            369157 ns/op           72023 B/op        451 allocs/op
BenchmarkBasicAuth_CacheDisabled-4            20          66711644 ns/op          509487 B/op       9704 allocs/op
```

Current Master:

```
BenchmarkBasicAuth-4          10         135002061 ns/op         1035518 B/op      19855 allocs/op
```