### PR TITLE
added changes to do less i/o to Redis

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -269,10 +269,17 @@ func (t BaseMiddleware) ApplyPolicies(key string, session *user.SessionState) er
 			tags[tag] = true
 		}
 	}
-	session.Tags = make([]string, 0, len(tags))
-	for tag := range tags {
-		session.Tags = append(session.Tags, tag)
+
+	// set tags
+	if len(tags) > 0 {
+		session.Tags = make([]string, 0, len(tags))
+		for tag := range tags {
+			session.Tags = append(session.Tags, tag)
+		}
+	} else {
+		session.Tags = nil
 	}
+
 	session.AccessRights = rights
 	// Update the session in the session manager in case it gets called again
 	return t.Spec.SessionManager.UpdateSession(key, session, session.Lifetime(t.Spec.SessionLifetime), false)

--- a/middleware.go
+++ b/middleware.go
@@ -323,7 +323,9 @@ func (t BaseMiddleware) CheckSessionAndIdentityForValidKey(key string) (user.Ses
 	if found {
 		// If exists, assume it has been authorized and pass on
 		// cache it
-		go SessionCache.Set(cacheKey, session, cache.DefaultExpiration)
+		if !t.Spec.GlobalConfig.LocalSessionCache.DisableCacheSessionState {
+			go SessionCache.Set(cacheKey, session, cache.DefaultExpiration)
+		}
 
 		// Check for a policy, if there is a policy, pull it and overwrite the session values
 		if err := t.ApplyPolicies(key, &session); err != nil {
@@ -341,7 +343,9 @@ func (t BaseMiddleware) CheckSessionAndIdentityForValidKey(key string) (user.Ses
 		log.Info("Recreating session for key: ", key)
 
 		// cache it
-		go SessionCache.Set(cacheKey, session, cache.DefaultExpiration)
+		if !t.Spec.GlobalConfig.LocalSessionCache.DisableCacheSessionState {
+			go SessionCache.Set(cacheKey, session, cache.DefaultExpiration)
+		}
 
 		// Check for a policy, if there is a policy, pull it and overwrite the session values
 		if err := t.ApplyPolicies(key, &session); err != nil {

--- a/mw_organization_activity_test.go
+++ b/mw_organization_activity_test.go
@@ -97,9 +97,9 @@ func BenchmarkProcessRequestLiveQuotaLimit(b *testing.B) {
 		b,
 		ts,
 		map[string]interface{}{
-			"quota_max":          1000000,
-			"quota_remaining":    1000000,
-			"quota_renewal_rate": 3,
+			"quota_max":          100000000,
+			"quota_remaining":    100000000,
+			"quota_renewal_rate": 300,
 		},
 	)
 
@@ -199,9 +199,9 @@ func BenchmarkProcessRequestOffThreadQuotaLimit(b *testing.B) {
 		b,
 		ts,
 		map[string]interface{}{
-			"quota_max":          1000000,
-			"quota_remaining":    1000000,
-			"quota_renewal_rate": 3,
+			"quota_max":          100000000,
+			"quota_remaining":    100000000,
+			"quota_renewal_rate": 300,
 		},
 	)
 

--- a/mw_virtual_endpoint.go
+++ b/mw_virtual_endpoint.go
@@ -216,6 +216,7 @@ func (d *VirtualEndpoint) ServeHTTPForCache(w http.ResponseWriter, r *http.Reque
 	if vmeta.UseSession {
 		session.MetaData = mapStrsToIfaces(newResponseData.SessionMeta)
 		d.Spec.SessionManager.UpdateSession(token, session, session.Lifetime(d.Spec.SessionLifetime), false)
+		ctxSetSession(r, session)
 	}
 
 	log.Debug("JSVM Virtual Endpoint execution took: (ns) ", time.Now().UnixNano()-t1)


### PR DESCRIPTION
While looking at performance I've noticed that we speak to redis too often than it is supposed to do. I tried to put break point and found that https://github.com/TykTechnologies/tyk/blob/v2.6.1/user/session.go#L96 almost never returning `false` so we always updating session in redis

Added some changes I believe should make speak to Redis much less:

- in `ApplyPolicies` we set Tags to zero value which was different when initial state was nil and session hash was different as well
- made `Session.FirstSeenHash` not to be public so no way it can appear in msgpack and be used to calculate new hash - https://github.com/TykTechnologies/tyk/blob/v2.6.1/user/session.go#L87 was always giving new data and it made hash to be different
- call `SetFirstSeenHash()` when we have real update for session in redis so next call to `UpdateSession` won't touch redis (if session hasn't changed)
- delete key from SessionCache when session was updated in Redis
- something not related - looks like we were calculating session hash in a wrong way, we had hasher but never wrote data there and calculated it, call of method `Sum(encoded)` is just giving current hash (empty as never calculated) appended to passed array, so it was always returning just the same `encoded` var value

some benchmarking vs. master:
```
benchmark                                                   old ns/op     new ns/op     delta
BenchmarkURLReplacer-8                                      18445         18449         +0.02%
BenchmarkTagHeaders-8                                       974           1072          +10.06%
BenchmarkDefaultVersion-8                                   1607676       1106262       -31.19%
BenchmarkGetVersionFromRequest/Header_location-8            497267        498422        +0.23%
BenchmarkGetVersionFromRequest/URL_param_location-8         483260        502072        +3.89%
BenchmarkGetVersionFromRequest/URL_location-8               483978        477496        -1.34%
BenchmarkApiReload-8                                        3900897       3607856       -7.51%
BenchmarkMultiSession_BA_Standard_OK-8                      1577178       2382575       +51.07%
BenchmarkBearerTokenAuthKeySession-8                        1748503       1915178       +9.53%
BenchmarkMultiAuthBackwardsCompatibleSession-8              1765264       1939514       +9.87%
BenchmarkBasicAuth-8                                        160339388     159637538     -0.44%
BenchmarkContextVarsMiddleware-8                            1360221       1373033       +0.94%
BenchmarkMiddlewareContextVars_ProcessRequest_cookies-8     139025        139807        +0.56%
BenchmarkHMACAuthSessionPass-8                              1516810       1247421       -17.76%
BenchmarkHMACAuthSessionPassWithHeaderField-8               1558462       1418480       -8.98%
BenchmarkIPBlacklistMiddleware-8                            28280         29024         +2.63%
BenchmarkIPMiddlewarePass-8                                 19031         18774         -1.35%
BenchmarkJWTSessionHMAC-8                                   657598        389382        -40.79%
BenchmarkJWTSessionRSA-8                                    774483        507916        -34.42%
BenchmarkJWTSessionRSABearer-8                              796075        499417        -37.27%
BenchmarkJWTSessionRSAWithRawSourceOnWithClientID-8         720965        507177        -29.65%
BenchmarkJWTSessionRSAWithRawSource-8                       713440        509946        -28.52%
BenchmarkJWTSessionRSAWithJWK-8                             713125        503046        -29.46%
BenchmarkJWTSessionRSAWithEncodedJWK-8                      712967        510735        -28.36%
BenchmarkProcessRequestLiveQuotaLimit-8                     600988        610759        +1.63%
BenchmarkProcessRequestOffThreadQuotaLimit-8                466115        458657        -1.60%
BenchmarkProcessRequestLiveRedisRollingLimiter-8            966534        898430        -7.05%
BenchmarkProcessRequestOffThreadRedisRollingLimiter-8       759907        742076        -2.35%
BenchmarkStripAuth_stripFromHeaders-8                       8860          8848          -0.14%
BenchmarkStripAuth_stripFromParams-8                        39959         40636         +1.69%
BenchmarkTransformNonAscii-8                                15489         15487         -0.01%
BenchmarkTransformJSONMarshal-8                             16552         16241         -1.88%
BenchmarkRewriter-8                                         197181        200454        +1.66%
BenchmarkValidateJSONSchema-8                               1834339       1820883       -0.73%
BenchmarkVersioning-8                                       2349581       2066859       -12.03%
BenchmarkVirtualEndpoint-8                                  353343        351438        -0.54%
BenchmarkApplyPolicies-8                                    26759         26631         -0.48%
BenchmarkResponseHeaderInjection-8                          2202799       2207808       +0.23%
BenchmarkCopyRequestResponse-8                              15302         15290         -0.08%

benchmark                                                   old allocs     new allocs     delta
BenchmarkURLReplacer-8                                      44             44             +0.00%
BenchmarkTagHeaders-8                                       15             15             +0.00%
BenchmarkDefaultVersion-8                                   1782           1694           -4.94%
BenchmarkApiReload-8                                        23907          23907          +0.00%
BenchmarkMultiSession_BA_Standard_OK-8                      464            290            -37.50%
BenchmarkBearerTokenAuthKeySession-8                        387            245            -36.69%
BenchmarkMultiAuthBackwardsCompatibleSession-8              391            247            -36.83%
BenchmarkBasicAuth-8                                        25994          25939          -0.21%
BenchmarkContextVarsMiddleware-8                            2009           2009           +0.00%
BenchmarkMiddlewareContextVars_ProcessRequest_cookies-8     28             28             +0.00%
BenchmarkHMACAuthSessionPass-8                              388            293            -24.48%
BenchmarkHMACAuthSessionPassWithHeaderField-8               415            383            -7.71%
BenchmarkIPBlacklistMiddleware-8                            148            148            +0.00%
BenchmarkIPMiddlewarePass-8                                 94             94             +0.00%
BenchmarkJWTSessionHMAC-8                                   707            618            -12.59%
BenchmarkJWTSessionRSA-8                                    782            693            -11.38%
BenchmarkJWTSessionRSABearer-8                              784            694            -11.48%
BenchmarkJWTSessionRSAWithRawSourceOnWithClientID-8         807            710            -12.02%
BenchmarkJWTSessionRSAWithRawSource-8                       791            702            -11.25%
BenchmarkJWTSessionRSAWithJWK-8                             795            706            -11.19%
BenchmarkJWTSessionRSAWithEncodedJWK-8                      799            710            -11.14%
BenchmarkProcessRequestLiveQuotaLimit-8                     572            585            +2.27%
BenchmarkProcessRequestOffThreadQuotaLimit-8                534            547            +2.43%
BenchmarkProcessRequestLiveRedisRollingLimiter-8            2095           2141           +2.20%
BenchmarkProcessRequestOffThreadRedisRollingLimiter-8       2321           2337           +0.69%
BenchmarkStripAuth_stripFromHeaders-8                       66             66             +0.00%
BenchmarkStripAuth_stripFromParams-8                        220            220            +0.00%
BenchmarkTransformNonAscii-8                                98             98             +0.00%
BenchmarkTransformJSONMarshal-8                             101            101            +0.00%
BenchmarkRewriter-8                                         626            626            +0.00%
BenchmarkValidateJSONSchema-8                               2588           2587           -0.04%
BenchmarkVersioning-8                                       3042           2975           -2.20%
BenchmarkVirtualEndpoint-8                                  384            384            +0.00%
BenchmarkApplyPolicies-8                                    102            102            +0.00%
BenchmarkResponseHeaderInjection-8                          2720           2719           -0.04%
BenchmarkCopyRequestResponse-8                              76             76             +0.00%

benchmark                                                   old bytes     new bytes     delta
BenchmarkURLReplacer-8                                      849           849           +0.00%
BenchmarkTagHeaders-8                                       384           384           +0.00%
BenchmarkDefaultVersion-8                                   251629        225030        -10.57%
BenchmarkApiReload-8                                        1789668       1789641       -0.00%
BenchmarkMultiSession_BA_Standard_OK-8                      90636         27633         -69.51%
BenchmarkBearerTokenAuthKeySession-8                        79509         22634         -71.53%
BenchmarkMultiAuthBackwardsCompatibleSession-8              80672         23099         -71.37%
BenchmarkBasicAuth-8                                        1341352       1322977       -1.37%
BenchmarkContextVarsMiddleware-8                            308360        308362        +0.00%
BenchmarkMiddlewareContextVars_ProcessRequest_cookies-8     2386          2386          +0.00%
BenchmarkHMACAuthSessionPass-8                              79035         47557         -39.83%
BenchmarkHMACAuthSessionPassWithHeaderField-8               81027         68852         -15.03%
BenchmarkIPBlacklistMiddleware-8                            32279         32273         -0.02%
BenchmarkIPMiddlewarePass-8                                 26720         26720         +0.00%
BenchmarkJWTSessionHMAC-8                                   107345        87272         -18.70%
BenchmarkJWTSessionRSA-8                                    136960        107958        -21.18%
BenchmarkJWTSessionRSABearer-8                              138167        109118        -21.02%
BenchmarkJWTSessionRSAWithRawSourceOnWithClientID-8         128578        109372        -14.94%
BenchmarkJWTSessionRSAWithRawSource-8                       122819        107191        -12.72%
BenchmarkJWTSessionRSAWithJWK-8                             122863        107254        -12.70%
BenchmarkJWTSessionRSAWithEncodedJWK-8                      123042        107397        -12.72%
BenchmarkProcessRequestLiveQuotaLimit-8                     88770         86782         -2.24%
BenchmarkProcessRequestOffThreadQuotaLimit-8                86994         85011         -2.28%
BenchmarkProcessRequestLiveRedisRollingLimiter-8            149933        145331        -3.07%
BenchmarkProcessRequestOffThreadRedisRollingLimiter-8       158852        153182        -3.57%
BenchmarkStripAuth_stripFromHeaders-8                       2800          2800          +0.00%
BenchmarkStripAuth_stripFromParams-8                        14161         14161         +0.00%
BenchmarkTransformNonAscii-8                                11060         11060         +0.00%
BenchmarkTransformJSONMarshal-8                             11508         11508         +0.00%
BenchmarkRewriter-8                                         405130        405130        +0.00%
BenchmarkValidateJSONSchema-8                               291872        291537        -0.11%
BenchmarkVersioning-8                                       318004        297837        -6.34%
BenchmarkVirtualEndpoint-8                                  70864         70866         +0.00%
BenchmarkApplyPolicies-8                                    12585         12585         +0.00%
BenchmarkResponseHeaderInjection-8                          528933        528867        -0.01%
BenchmarkCopyRequestResponse-8                              35584         35584         +0.00%
```

still need to figure out what happened with BenchmarkMultiSession_BA_Standard_OK