### PR TITLE
Add ReportAllocs call to sub-benchmarks

### DIFF
--- a/api_definition_test.go
+++ b/api_definition_test.go
@@ -459,6 +459,7 @@ func BenchmarkGetVersionFromRequest(b *testing.B) {
 	versionInfo.Paths.BlackList = []string{"/bar"}
 
 	b.Run("Header location", func(b *testing.B) {
+		b.ReportAllocs()
 		buildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.VersionData.NotVersioned = false
@@ -476,6 +477,7 @@ func BenchmarkGetVersionFromRequest(b *testing.B) {
 	})
 
 	b.Run("URL param location", func(b *testing.B) {
+		b.ReportAllocs()
 		buildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.VersionData.NotVersioned = false
@@ -493,6 +495,7 @@ func BenchmarkGetVersionFromRequest(b *testing.B) {
 	})
 
 	b.Run("URL location", func(b *testing.B) {
+		b.ReportAllocs()
 		buildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.VersionData.NotVersioned = false

--- a/coprocess_id_extractor_test.go
+++ b/coprocess_id_extractor_test.go
@@ -326,8 +326,8 @@ func TestXPathExtractor(t *testing.T) {
 }
 
 func BenchmarkValueExtractor(b *testing.B) {
-	b.ReportAllocs()
 	b.Run("HeaderSource", func(b *testing.B) {
+		b.ReportAllocs()
 		extractor, _ := prepareExtractor(b, apidef.HeaderSource, apidef.ValueExtractor, map[string]interface{}{
 			"header_name": extractorHeaderName,
 		})
@@ -338,6 +338,7 @@ func BenchmarkValueExtractor(b *testing.B) {
 		}
 	})
 	b.Run("FormSource", func(b *testing.B) {
+		b.ReportAllocs()
 		extractor, _ := prepareExtractor(b, apidef.FormSource, apidef.ValueExtractor, map[string]interface{}{
 			"param_name": extractorParamName,
 		})
@@ -350,8 +351,8 @@ func BenchmarkValueExtractor(b *testing.B) {
 }
 
 func BenchmarkRegexExtractor(b *testing.B) {
-	b.ReportAllocs()
 	b.Run("HeaderSource", func(b *testing.B) {
+		b.ReportAllocs()
 		headerName := "testheader"
 		extractor, _ := prepareExtractor(b, apidef.HeaderSource, apidef.RegexExtractor, map[string]interface{}{
 			"regex_expression":  extractorRegexExpr,
@@ -365,6 +366,7 @@ func BenchmarkRegexExtractor(b *testing.B) {
 		}
 	})
 	b.Run("BodySource", func(b *testing.B) {
+		b.ReportAllocs()
 		extractor, _ := prepareExtractor(b, apidef.BodySource, apidef.RegexExtractor, map[string]interface{}{
 			"regex_expression":  extractorRegexExpr,
 			"regex_match_index": extractorRegexMatchIndex,
@@ -375,6 +377,7 @@ func BenchmarkRegexExtractor(b *testing.B) {
 		}
 	})
 	b.Run("FormSource", func(b *testing.B) {
+		b.ReportAllocs()
 		extractor, _ := prepareExtractor(b, apidef.FormSource, apidef.RegexExtractor, map[string]interface{}{
 			"regex_expression":  extractorRegexExpr,
 			"regex_match_index": extractorRegexMatchIndex,
@@ -389,8 +392,8 @@ func BenchmarkRegexExtractor(b *testing.B) {
 }
 
 func BenchmarkXPathExtractor(b *testing.B) {
-	b.ReportAllocs()
 	b.Run("HeaderSource", func(b *testing.B) {
+		b.ReportAllocs()
 		extractor, _ := prepareExtractor(b, apidef.HeaderSource, apidef.XPathExtractor, map[string]interface{}{
 			"xpath_expression": extractorXPathExpr,
 			"header_name":      extractorHeaderName,
@@ -402,6 +405,7 @@ func BenchmarkXPathExtractor(b *testing.B) {
 		}
 	})
 	b.Run("BodySource", func(b *testing.B) {
+		b.ReportAllocs()
 		extractor, _ := prepareExtractor(b, apidef.BodySource, apidef.XPathExtractor, map[string]interface{}{
 			"xpath_expression": extractorXPathExpr,
 		})
@@ -411,6 +415,7 @@ func BenchmarkXPathExtractor(b *testing.B) {
 		}
 	})
 	b.Run("FormSource", func(b *testing.B) {
+		b.ReportAllocs()
 		extractor, _ := prepareExtractor(b, apidef.FormSource, apidef.XPathExtractor, map[string]interface{}{
 			"xpath_expression": extractorXPathExpr,
 			"param_name":       extractorParamName,


### PR DESCRIPTION
I've noticed that when running `utils/ci-benchmark.sh` the allocations aren't reported on sub-benchmarks, `reportAllocs` should be called on each one, before:
```
% ./utils/ci-benchmark.sh 
[May 17 20:32:25]  INFO coprocess: Disabled feature
goos: darwin
goarch: amd64
pkg: github.com/TykTechnologies/tyk
BenchmarkURLReplacer-8                                    	  100000	     19863 ns/op	     849 B/op	      44 allocs/op
BenchmarkTagHeaders-8                                     	 1000000	      1152 ns/op	     392 B/op	      15 allocs/op
BenchmarkDefaultVersion-8                                 	    1000	   1540715 ns/op	  250687 B/op	    1781 allocs/op
BenchmarkGetVersionFromRequest/Header_location-8          	    2000	    504904 ns/op
BenchmarkGetVersionFromRequest/URL_param_location-8       	    3000	    508010 ns/op
BenchmarkGetVersionFromRequest/URL_location-8             	    2000	    511611 ns/op
```
After this change:
```
% ./utils/ci-benchmark.sh 
[May 17 20:33:52]  INFO coprocess: Disabled feature
goos: darwin
goarch: amd64
pkg: github.com/TykTechnologies/tyk
BenchmarkURLReplacer-8                                    	  100000	     20413 ns/op	     849 B/op	      44 allocs/op
BenchmarkTagHeaders-8                                     	 1000000	      1257 ns/op	     392 B/op	      15 allocs/op
BenchmarkDefaultVersion-8                                 	    1000	   1629333 ns/op	  250729 B/op	    1781 allocs/op
BenchmarkGetVersionFromRequest/Header_location-8          	    2000	    538670 ns/op	   97333 B/op	     672 allocs/op
BenchmarkGetVersionFromRequest/URL_param_location-8       	    2000	    517635 ns/op	   96758 B/op	     656 allocs/op
BenchmarkGetVersionFromRequest/URL_location-8             	    2000	    555567 ns/op	   94055 B/op	     645 allocs/op
```