### PR TITLE
bug: EOF when performing response body transform

### DIFF
--- a/res_handler_transform.go
+++ b/res_handler_transform.go
@@ -27,6 +27,7 @@ func (h *ResponseTransformMiddleware) Init(c interface{}, spec *APISpec) error {
 }
 
 func respBodyReader(req *http.Request, resp *http.Response) io.ReadCloser {
+
 	if req.Header.Get("Accept-Encoding") == "" {
 		return resp.Body
 	}
@@ -64,6 +65,14 @@ func compressBuffer(in bytes.Buffer, encoding string) (out bytes.Buffer) {
 }
 
 func (h *ResponseTransformMiddleware) HandleResponse(rw http.ResponseWriter, res *http.Response, req *http.Request, ses *user.SessionState) error {
+
+	logger := log.WithFields(logrus.Fields{
+		"prefix":      "outbound-transform",
+		"server_name": h.Spec.Proxy.TargetURL,
+		"api_id":      h.Spec.APIID,
+		"path":        req.URL.Path,
+	})
+
 	_, versionPaths, _, _ := h.Spec.Version(req)
 	found, meta := h.Spec.CheckSpecMatchesStatus(req, versionPaths, TransformedResponse)
 
@@ -82,35 +91,27 @@ func (h *ResponseTransformMiddleware) HandleResponse(rw http.ResponseWriter, res
 		mxj.XmlCharsetReader = WrappedCharsetReader
 		var err error
 
-		bodyData, err = mxj.NewMapXmlReader(respBody) // unmarshal
+		bodyBytes, err := ioutil.ReadAll(respBody)
 		if err != nil {
-			log.WithFields(logrus.Fields{
-				"prefix":      "outbound-transform",
-				"server_name": h.Spec.Proxy.TargetURL,
-				"api_id":      h.Spec.APIID,
-				"path":        req.URL.Path,
-			}).Error("Error unmarshalling XML: ", err)
+			logger.WithError(err).Error("Error reading XML body")
+			// not returning error, just break out of switch.
+			break
+		}
+
+		bodyData, err = mxj.NewMapXml(bodyBytes) // unmarshal
+		if err != nil {
+			logger.WithError(err).Error("Error unmarshalling XML")
 		}
 	default: // apidef.RequestJSON
 		if err := json.NewDecoder(respBody).Decode(&bodyData); err != nil {
-			log.WithFields(logrus.Fields{
-				"prefix":      "outbound-transform",
-				"server_name": h.Spec.Proxy.TargetURL,
-				"api_id":      h.Spec.APIID,
-				"path":        req.URL.Path,
-			}).Error("Error unmarshalling JSON: ", err)
+			logger.WithError(err).Error("Error unmarshalling JSON")
 		}
 	}
 
 	// Apply to template
 	var bodyBuffer bytes.Buffer
 	if err := tmeta.Template.Execute(&bodyBuffer, bodyData); err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix":      "outbound-transform",
-			"server_name": h.Spec.Proxy.TargetURL,
-			"api_id":      h.Spec.APIID,
-			"path":        req.URL.Path,
-		}).Error("Failed to apply template to request: ", err)
+		logger.WithError(err).Error("Failed to apply template to request")
 	}
 
 	// Re-compress if original upstream response was compressed


### PR DESCRIPTION
fixes: #1729

Description of bug:

1. Create an API with a mock XML response e.g. `/api-a/mock`.
2. Create an API which reverse proxies to `api-a` called `abi-b`.
3. perform a response body transform on `api-b/mock` endpoint. e.g.
convert to json.

Bug:

```
ERROR outbound-transform: Error unmarshalling XML:
xml.Decoder.Token() - XML syntax error on line 167: unexpected EOF
api_id=90a1e135513946cb437b5e5111422227 path=mock
server_name=https://tyk-gateway.dev:8080/api-a/
```

This occurs because the body looks like it has already been read.

Fix: reset the buffer by taking a copy of the http.Response.
