### PR TITLE
Lower log verbosity for some DRL and RPC events

### DIFF
--- a/distributed_rate_limiter.go
+++ b/distributed_rate_limiter.go
@@ -94,7 +94,7 @@ func onServerStatusReceivedHandler(payload string) {
 		if err := DRLManager.AddOrUpdateServer(serverData); err != nil {
 			log.WithError(err).
 				WithField("serverData", serverData).
-				Error("AddOrUpdateServer error")
+				Debug("AddOrUpdateServer error. Seems like you running multiple segmented Tyk groups in same Redis.")
 			return
 		}
 		log.Debug(DRLManager.Report())

--- a/main.go
+++ b/main.go
@@ -833,11 +833,11 @@ func initialiseSystem() error {
 		case "", "info":
 			// default, do nothing
 		case "error":
-			mainLog.Level = logrus.ErrorLevel
+			log.Level = logrus.ErrorLevel
 		case "warn":
-			mainLog.Level = logrus.WarnLevel
+			log.Level = logrus.WarnLevel
 		case "debug":
-			mainLog.Level = logrus.DebugLevel
+			log.Level = logrus.DebugLevel
 		default:
 			mainLog.Fatalf("Invalid log level %q specified in config, must be error, warn, debug or info. ", level)
 		}

--- a/rpc_analytics_purger.go
+++ b/rpc_analytics_purger.go
@@ -72,7 +72,7 @@ func (r *RPCPurger) PurgeCache() {
 	// Send keys to RPC
 	if _, err := RPCFuncClientSingleton.Call("PurgeAnalyticsData", string(data)); err != nil {
 		emitRPCErrorEvent(rpcFuncClientSingletonCall, "PurgeAnalyticsData", err)
-		log.Error("Failed to call purge: ", err)
+		log.Warn("Failed to call purge, retrying: ", err)
 	}
 
 }


### PR DESCRIPTION
- Running multiple Tyk groups in the same Redis is a normal setup (while not
very common). In this case, DRL will receive messages from different
groups and will ignore them.
- RPC analytics purger can fail in case of MDCB auto-scaling events or a session timeout. Should not be an error log.

Fix https://github.com/TykTechnologies/tyk/issues/1715

Additionally fixed setting log level though tyk config. It was setting
log level only for `mainLog` which used only for initialization.

Fix https://github.com/TykTechnologies/tyk/issues/1716