### PR TITLE
Do not require client certificate unless necessary

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -226,6 +226,17 @@ func getTLSConfigForClient(baseConfig *tls.Config, listenPort int) func(hello *t
 				break
 			}
 		}
+
+		// No mutual tls APIs with matched domain found
+		// Check if one of APIs without domain, require asking client cert
+		if newConfig.ClientAuth == tls.NoClientCert {
+			for _, spec := range apiSpecs {
+				if spec.Auth.UseCertificate || (spec.Domain == "" && spec.UseMutualTLSAuth) {
+					newConfig.ClientAuth = tls.RequestClientCert
+					break
+				}
+			}
+		}
 		apisMu.RUnlock()
 
 		return newConfig, nil

--- a/cert_test.go
+++ b/cert_test.go
@@ -253,68 +253,6 @@ func TestGatewayControlAPIMutualTLS(t *testing.T) {
 			Path: "/tyk/certs", Code: 200, ControlRequest: true, AdminAuth: true, Client: clientWithCert,
 		})
 	})
-
-	t.Run("Same domain", func(t *testing.T) {
-		certID, _ := CertificateManager.Add(combinedPEM, "")
-		defer CertificateManager.Delete(certID)
-
-		globalConf = config.Global()
-		globalConf.ControlAPIHostname = "localhost"
-		globalConf.HttpServerOptions.SSLCertificates = []string{certID}
-		config.SetGlobal(globalConf)
-
-		defer func() {
-			globalConf = config.Global()
-			globalConf.HttpServerOptions.SSLCertificates = nil
-			globalConf.Security.Certificates.ControlAPI = nil
-			config.SetGlobal(globalConf)
-			CertificateManager.FlushCache()
-
-		}()
-
-		ts := newTykTestServer()
-		defer ts.Close()
-
-		certNotMatchErr := `Certificate with SHA256 ` + certs.HexSHA256(clientCert.Certificate[0]) + ` not allowed`
-
-		t.Run("Without or not valid certificates", func(t *testing.T) {
-			ts.Run(t, []test.TestCase{
-				// Should acess tyk without client certificates
-				{Client: clientWithoutCert},
-
-				// Error for client without certificate
-				{Path: "/tyk/certs", AdminAuth: true, Code: 403, BodyMatch: `"message":"Client TLS certificate is required"`, Client: clientWithoutCert},
-
-				// Error for client with unknown certificate
-				{Path: "/tyk/certs", AdminAuth: true, Code: 403, BodyMatch: `"message":"` + certNotMatchErr, Client: clientWithCert},
-			}...)
-		})
-
-		t.Run("Redis certificate", func(t *testing.T) {
-			clientCertID, _ := CertificateManager.Add(clientCertPem, "")
-			defer CertificateManager.Delete(clientCertID)
-			globalConf = config.Global()
-			globalConf.Security.Certificates.ControlAPI = []string{clientCertID}
-			config.SetGlobal(globalConf)
-
-			ts.Run(t, []test.TestCase{
-				{Path: "/tyk/certs", AdminAuth: true, Code: 200, Client: clientWithCert},
-			}...)
-		})
-
-		t.Run("File certificate", func(t *testing.T) {
-			certPath := filepath.Join(dir, "client.pem")
-			ioutil.WriteFile(certPath, clientCertPem, 0666)
-
-			globalConf = config.Global()
-			globalConf.Security.Certificates.ControlAPI = []string{certPath}
-			config.SetGlobal(globalConf)
-
-			ts.Run(t, []test.TestCase{
-				{Path: "/tyk/certs", AdminAuth: true, Code: 200, Client: clientWithCert},
-			}...)
-		})
-	})
 }
 
 func TestAPIMutualTLS(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -1132,7 +1132,7 @@ func generateListener(listenPort int) (net.Listener, error) {
 			GetCertificate:     dummyGetCertificate,
 			ServerName:         httpServerOptions.ServerName,
 			MinVersion:         httpServerOptions.MinVersion,
-			ClientAuth:         tls.RequestClientCert,
+			ClientAuth:         tls.NoClientCert,
 			InsecureSkipVerify: httpServerOptions.SSLInsecureSkipVerify,
 			CipherSuites:       getCipherAliases(httpServerOptions.Ciphers),
 		}


### PR DESCRIPTION
Client cert now asked only if one APIs, which share same domain,
require this feature.

Fix https://github.com/TykTechnologies/tyk/issues/1381