### PR TITLE
Handles Dashboard API failures, fixes #1725

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -12,15 +13,13 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"text/template"
 	"time"
 
 	"github.com/rubyist/circuitbreaker"
 
-	"sync"
-
-	"fmt"
 	"github.com/TykTechnologies/gojsonschema"
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"

--- a/api_definition_test.go
+++ b/api_definition_test.go
@@ -511,3 +511,73 @@ func BenchmarkGetVersionFromRequest(b *testing.B) {
 		}
 	})
 }
+
+func TestSyncAPISpecsDashboardJSONFailure(t *testing.T) {
+	// Mock Dashboard
+	callNum := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/system/apis" {
+			if callNum == 0 {
+				w.Write([]byte(`{"Status": "OK", "Nonce": "1", "Message": [{"api_definition": {}}]}`))
+			} else {
+				w.Write([]byte(`{"Status": "OK", "Nonce": "1", "Message": "this is a string"`))
+			}
+
+			callNum += 1
+		} else {
+			t.Fatal("Unknown dashboard API request", r)
+		}
+	}))
+	defer ts.Close()
+
+	apisMu.Lock()
+	apisByID = make(map[string]*APISpec)
+	apisMu.Unlock()
+
+	globalConf := config.Global()
+	globalConf.UseDBAppConfigs = true
+	globalConf.AllowInsecureConfigs = true
+	globalConf.DBAppConfOptions.ConnectionString = ts.URL
+	config.SetGlobal(globalConf)
+
+	defer resetTestConfig()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	msg := redis.Message{Data: []byte(`{"Command": "ApiUpdated"}`)}
+	handled := func(got NotificationCommand) {
+		if want := NoticeApiUpdated; got != want {
+			t.Fatalf("want %q, got %q", want, got)
+		}
+	}
+	handleRedisEvent(msg, handled, wg.Done)
+
+	// Since we already know that reload is queued
+	reloadTick <- time.Time{}
+
+	// Wait for the reload to finish, then check it worked
+	wg.Wait()
+	apisMu.RLock()
+	if len(apisByID) != 1 {
+		t.Error("should return array with one spec", apisByID)
+	}
+	apisMu.RUnlock()
+
+	// Second call
+
+	var wg2 sync.WaitGroup
+	wg2.Add(1)
+	handleRedisEvent(msg, handled, wg2.Done)
+
+	// Since we already know that reload is queued
+	reloadTick <- time.Time{}
+
+	// Wait for the reload to finish, then check it worked
+	wg2.Wait()
+	apisMu.RLock()
+	if len(apisByID) != 1 {
+		t.Error("second call should return array with one spec", apisByID)
+	}
+	apisMu.RUnlock()
+
+}

--- a/main.go
+++ b/main.go
@@ -251,9 +251,14 @@ func syncAPISpecs() int {
 	defer apisMu.Unlock()
 
 	if config.Global().UseDBAppConfigs {
-
 		connStr := buildConnStr("/system/apis")
-		apiSpecs = loader.FromDashboardService(connStr, config.Global().NodeSecret)
+		tmpSpecs, err := loader.FromDashboardService(connStr, config.Global().NodeSecret)
+		if err != nil {
+			log.Error("failed to load API specs: ", err)
+			return 0
+		}
+
+		apiSpecs = tmpSpecs
 
 		mainLog.Debug("Downloading API Configurations from Dashboard Service")
 	} else if config.Global().SlaveOptions.UseRPC {


### PR DESCRIPTION
Have added a test that simulates a running gateway with 1 definition, and then that same gateway pulling a malformed definition

The gateway will default to what is already loaded.

This introduces the potential for gateways to get out-of-step, but ensures existing services stay loaded until there has been a successful reload.

Perhaps a future improvement would be a signal to the dashboard notifying which gateways have successfully reloaded