### PR TITLE
[WIP] gRPC tests and benchmarks

### DIFF
--- a/coprocess_grpc_test.go
+++ b/coprocess_grpc_test.go
@@ -1,0 +1,153 @@
+// +build coprocess
+// +build grpc
+
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"testing"
+
+	"context"
+
+	"google.golang.org/grpc"
+
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/coprocess"
+	"github.com/TykTechnologies/tyk/test"
+)
+
+const (
+	grpcListenAddr = ":9999"
+	grpcListenPath = "tcp://127.0.0.1:9999"
+
+	testHeaderName  = "Testheader"
+	testHeaderValue = "testvalue"
+)
+
+type dispatcher struct{}
+
+func (d *dispatcher) Dispatch(ctx context.Context, object *coprocess.Object) (*coprocess.Object, error) {
+	switch object.HookName {
+	case "testPreHook1":
+		object.Request.SetHeaders = map[string]string{
+			testHeaderName: testHeaderValue,
+		}
+	}
+	return object, nil
+}
+
+func (d *dispatcher) DispatchEvent(ctx context.Context, event *coprocess.Event) (*coprocess.EventReply, error) {
+	return &coprocess.EventReply{}, nil
+}
+
+func newTestGRPCServer() (s *grpc.Server) {
+	s = grpc.NewServer()
+	coprocess.RegisterDispatcherServer(s, &dispatcher{})
+	return s
+}
+
+func loadTestGRPCSpec() *APISpec {
+	spec := buildAndLoadAPI(func(spec *APISpec) {
+		spec.APIID = "999999"
+		spec.OrgID = "default"
+		spec.Auth = apidef.Auth{
+			AuthHeaderName: "authorization",
+		}
+		spec.VersionData = struct {
+			NotVersioned   bool                          `bson:"not_versioned" json:"not_versioned"`
+			DefaultVersion string                        `bson:"default_version" json:"default_version"`
+			Versions       map[string]apidef.VersionInfo `bson:"versions" json:"versions"`
+		}{
+			NotVersioned: true,
+			Versions: map[string]apidef.VersionInfo{
+				"v1": {
+					Name: "v1",
+				},
+			},
+		}
+		spec.Proxy.ListenPath = "/grpc-test-api/"
+		spec.Proxy.StripListenPath = true
+		spec.CustomMiddleware = apidef.MiddlewareSection{
+			Pre: []apidef.MiddlewareDefinition{
+				{Name: "testPreHook1"},
+			},
+			Driver: apidef.GrpcDriver,
+		}
+	})[0]
+
+	return spec
+}
+
+func startTykWithGRPC() (*tykTestServer, *grpc.Server) {
+	// Setup the gRPC server:
+	listener, _ := net.Listen("tcp", grpcListenAddr)
+	grpcServer := newTestGRPCServer()
+	go grpcServer.Serve(listener)
+
+	// Setup Tyk:
+	cfg := config.CoProcessConfig{
+		EnableCoProcess:     true,
+		CoProcessGRPCServer: grpcListenPath,
+	}
+	ts := newTykTestServer(tykTestServerConfig{coprocessConfig: cfg})
+
+	// Load a test API:
+	loadTestGRPCSpec()
+	return &ts, grpcServer
+}
+
+func TestGRPCDispatch(t *testing.T) {
+	ts, grpcServer := startTykWithGRPC()
+	defer ts.Close()
+	defer grpcServer.Stop()
+
+	t.Run("Pre Hook with SetHeaders", func(t *testing.T) {
+		res, err := ts.Run(t, test.TestCase{
+			Path:   "/grpc-test-api/",
+			Method: http.MethodGet,
+			Code:   http.StatusOK,
+		})
+		if err != nil {
+			t.Fatalf("Request failed: %s", err.Error())
+		}
+		data, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			t.Fatalf("Couldn't read response body: %s", err.Error())
+		}
+		var testResponse testHttpResponse
+		err = json.Unmarshal(data, &testResponse)
+		if err != nil {
+			t.Fatalf("Couldn't unmarshal test response JSON: %s", err.Error())
+		}
+		value, ok := testResponse.Headers[testHeaderName]
+		if !ok {
+			t.Fatalf("Header not found, expecting %s", testHeaderName)
+		}
+		if value != testHeaderValue {
+			t.Fatalf("Header value isn't %s", testHeaderValue)
+		}
+	})
+
+}
+
+func BenchmarkGRPCDispatch(b *testing.B) {
+	ts, grpcServer := startTykWithGRPC()
+	defer ts.Close()
+	defer grpcServer.Stop()
+
+	b.Run("Pre Hook with SetHeaders", func(b *testing.B) {
+		path := "/grpc-test-api/"
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			ts.Run(b, test.TestCase{
+				Path:   path,
+				Method: http.MethodGet,
+				Code:   http.StatusOK,
+			})
+		}
+	})
+}

--- a/coprocess_id_extractor_python_test.go
+++ b/coprocess_id_extractor_python_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/test"
 )
 
@@ -147,6 +148,9 @@ def MyAuthHook(request, session, metadata, spec):
 // With ID extractor, it should run multiple times (because cache)
 func TestValueExtractorHeaderSource(t *testing.T) {
 	ts := newTykTestServer(tykTestServerConfig{
+		coprocessConfig: config.CoProcessConfig{
+			EnableCoProcess: true,
+		},
 		delay: 10 * time.Millisecond,
 	})
 	defer ts.Close()

--- a/coprocess_python_test.go
+++ b/coprocess_python_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/test"
 )
 
@@ -42,7 +43,10 @@ def MyAuthHook(request, session, metadata, spec):
 }
 
 func TestPythonBundles(t *testing.T) {
-	ts := newTykTestServer()
+	ts := newTykTestServer(tykTestServerConfig{
+		coprocessConfig: config.CoProcessConfig{
+			EnableCoProcess: true,
+		}})
 	defer ts.Close()
 
 	bundleID := registerBundle("python_with_auth_check", pythonBundleWithAuthCheck)

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -282,6 +282,7 @@ type tykTestServerConfig struct {
 	delay              time.Duration
 	hotReload          bool
 	overrideDefaults   bool
+	coprocessConfig    config.CoProcessConfig
 }
 
 type tykTestServer struct {
@@ -305,6 +306,8 @@ func (s *tykTestServer) Start() {
 		_, port, _ = net.SplitHostPort(s.cln.Addr().String())
 		globalConf.ControlAPIPort, _ = strconv.Atoi(port)
 	}
+
+	globalConf.CoProcessOptions = s.config.coprocessConfig
 
 	config.SetGlobal(globalConf)
 


### PR DESCRIPTION
This is part of #1674, currently `benchcmp` looks like this:
I might drop the `TestCase` usage for benchmarks as it might affect the results, the dispatcher seems to perform a bit faster (are the allocations made by the test case code? still investigating this):
```
% benchcmp old new
benchmark                                            old ns/op     new ns/op     delta
BenchmarkGRPCDispatch/Pre_Hook_with_SetHeaders-8     558806        526713        -5.74%

benchmark                                            old allocs     new allocs     delta
BenchmarkGRPCDispatch/Pre_Hook_with_SetHeaders-8     669            803            +20.03%

benchmark                                            old bytes     new bytes     delta
BenchmarkGRPCDispatch/Pre_Hook_with_SetHeaders-8     84621         89969         +6.32%
```
I will add more scenarios and also an API with multiple hooks.