### PR TITLE
[WIP] Allow json response transforms to handle array responses

### DIFF
--- a/res_handler_transform.go
+++ b/res_handler_transform.go
@@ -76,7 +76,7 @@ func (h *ResponseTransformMiddleware) HandleResponse(rw http.ResponseWriter, res
 	defer respBody.Close()
 
 	// Put into an interface:
-	var bodyData map[string]interface{}
+	var bodyData interface{}
 	switch tmeta.TemplateData.Input {
 	case apidef.RequestXML:
 		mxj.XmlCharsetReader = WrappedCharsetReader


### PR DESCRIPTION
#1733

Create a json response body transform. Use it to filter an array.

Because the gateway unmarshals `bodyData` into `map[string]interface{}`,
this means that it is unable to unmarshal an array.

```
[May 25 19:49:13] ERROR outbound-transform: Error unmarshalling JSON:
json: cannot unmarshal array into Go value of type map[string]interface
{} api_id=62498653ade2405b64537d94d2666dc0 path=example-array
server_name=https://my-upstream.com/
```

This fix resolves the response body transform by unmarshaling into an
`interface{}`.

We need to find a suitable solution for request body transforms. This is
currently not possible due to:

```
if tmeta.TemplateData.EnableSession {
	session := ctxGetSession(r)
	bodyData["_tyk_meta"] = session.MetaData
}

if contextVars {
	bodyData["_tyk_context"] = ctxGetData(r)
}
```
