### PR TITLE
Enhance Python errors

### DIFF
--- a/coprocess.go
+++ b/coprocess.go
@@ -266,6 +266,9 @@ func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 
 	returnObject, err := coProcessor.Dispatch(object)
 	if err != nil {
+		log.WithFields(logrus.Fields{
+			"prefix": "coprocess",
+		}).WithError(err).Error("Dispatch error")
 		if m.HookType == coprocess.HookType_CustomKeyCheck {
 			return errors.New("Key not authorised"), 403
 		} else {

--- a/coprocess/python/dispatcher.py
+++ b/coprocess/python/dispatcher.py
@@ -64,18 +64,14 @@ class TykDispatcher:
             raise Exception('Hook is not defined: {0}'.format(hook_name))
 
     def dispatch_hook(self, object_msg):
-        try:
-            object = TykCoProcessObject(object_msg)
-            api_id = object.spec['APIID']
-            middleware, hook_handler = self.find_hook(api_id, object.hook_name)
-            if hook_handler:
-                object = middleware.process(hook_handler, object)
-            else:
-                tyk.log( "Can't dispatch '{0}', hook is not defined.".format(object.hook_name), "error")
-            return object.dump()
-        except:
-            tyk.log_error( "Can't dispatch, error:" )
-            return object_msg
+        object = TykCoProcessObject(object_msg)
+        api_id = object.spec['APIID']
+        middleware, hook_handler = self.find_hook(api_id, object.hook_name)
+        if hook_handler:
+            object = middleware.process(hook_handler, object)
+        else:
+            tyk.log("Can't dispatch '{0}', hook is not defined.".format(object.hook_name), "error")
+        return object.dump()
 
     def dispatch_event(self, event_json):
         try:

--- a/coprocess/python/dispatcher.py
+++ b/coprocess/python/dispatcher.py
@@ -1,6 +1,5 @@
 from glob import glob
 from os import getcwd, chdir, path
-import sys
 
 import tyk
 from tyk.middleware import TykMiddleware
@@ -9,11 +8,17 @@ from tyk.event import TykEvent
 
 from gateway import TykGateway as tyk
 
+import sys
+def except_hook(type, value, traceback):
+    tyk.log_error("{0}".format(value))
+
+sys.excepthook = except_hook
+
 class TykDispatcher:
     '''A simple dispatcher'''
 
     def __init__(self, bundle_root_path):
-        tyk.log( "Initializing dispatcher", "info" )
+        tyk.log("Initializing dispatcher", "info")
         self.bundle_root_path = bundle_root_path
         self.bundles = []
         self.hook_table = {}
@@ -67,10 +72,10 @@ class TykDispatcher:
         object = TykCoProcessObject(object_msg)
         api_id = object.spec['APIID']
         middleware, hook_handler = self.find_hook(api_id, object.hook_name)
-        if hook_handler:
+        try:
             object = middleware.process(hook_handler, object)
-        else:
-            tyk.log("Can't dispatch '{0}', hook is not defined.".format(object.hook_name), "error")
+        except Exception as e:
+            raise Exception("Hook '{0}' returned an error: {1}".format(object.hook_name, e))
         return object.dump()
 
     def dispatch_event(self, event_json):
@@ -79,8 +84,8 @@ class TykDispatcher:
             api_id = event.spec['APIID']
             middleware, hook_handler = self.find_hook(api_id, event.handler_name)
             middleware.process(hook_handler, event)
-        except:
-            tyk.log_error( "Can't dispatch: ")
+        except Exception as e:
+            raise Exception("Couldn't dispatch '{0}' event: {1}", event.handler_name, e)
 
     def reload(self):
-        tyk.log( "Reloading event handlers and middlewares.", "info" )
+        tyk.log("Reloading event handlers and middlewares.", "info")

--- a/coprocess/python/gateway.py
+++ b/coprocess/python/gateway.py
@@ -27,7 +27,12 @@ class TykGateway:
     @classmethod
     def log_error(cls, *args):
         excp = exc_info()
-        if len(args) == 0:
+        nargs = len(args)
+        # For simpler errors:
+        if nargs == 1:
+            cls.log(args[0], "error")
+            return
+        if nargs == 0:
             cls.log("{0} {1}".format(excp[0], excp[1]), "error")
         else:
             cls.log("{0} {1} {2}".format(args[0], excp[0], excp[1]), "error")

--- a/coprocess/python/tyk/middleware.py
+++ b/coprocess/python/tyk/middleware.py
@@ -41,8 +41,8 @@ class TykMiddleware:
             self.module = imp.load_source(filepath, self.mw_path)
             self.register_handlers()
             self.cleanup()
-        except:
-            tyk.log_error( "Middleware initialization error:" )
+        except Exception as e:
+            tyk.log_error("Middleware initialization error: {0}".format(e))
 
     def register_handlers(self):
         new_handlers = {}
@@ -63,6 +63,7 @@ class TykMiddleware:
             for handler in self.handlers[hook_type]:
                 handler.middleware = self
                 hooks[handler.name] = handler
+                tyk.log("Loading hook '{0}' ({1})".format(handler.name, self.filepath), "debug")
         return hooks
 
     def cleanup(self):

--- a/coprocess_native.go
+++ b/coprocess_native.go
@@ -19,6 +19,8 @@ package main
 import "C"
 
 import (
+	"errors"
+
 	"github.com/golang/protobuf/proto"
 
 	"github.com/TykTechnologies/tyk/coprocess"
@@ -29,7 +31,9 @@ import (
 
 // Dispatch prepares a CoProcessMessage, sends it to the GlobalDispatcher and gets a reply.
 func (c *CoProcessor) Dispatch(object *coprocess.Object) (*coprocess.Object, error) {
-
+	if GlobalDispatcher == nil {
+		return nil, errors.New("Dispatcher not initialized")
+	}
 	var objectMsg []byte
 	switch MessageType {
 	case coprocess.ProtobufMessage:
@@ -47,6 +51,9 @@ func (c *CoProcessor) Dispatch(object *coprocess.Object) (*coprocess.Object, err
 	objectPtr.length = C.int(len(objectMsg))
 
 	newObjectPtr := (*C.struct_CoProcessMessage)(GlobalDispatcher.Dispatch(unsafe.Pointer(objectPtr)))
+	if newObjectPtr == nil {
+		return nil, errors.New("Dispatch error")
+	}
 
 	newObjectBytes := C.GoBytes(newObjectPtr.p_data, newObjectPtr.length)
 


### PR DESCRIPTION
This PR introduces some logging enhancements:
- When `tyk-python` is executed with `enable_coprocess` but `python_path_prefix` the following warning is logged:
```
WARN coprocess: Python path prefix isn't set (check "python_path_prefix" in tyk.conf)
```
- When a bundle is loaded and it fails during a request we throw an error:
```
@Hook
def MyHook(request, session, metadata, spec):
  inexistentfunction()
```
This will log:
```
ERROR python: Hook 'MyHook' returned an error: name 'inexistentfunction' is not defined
```
- When an inexistent hook is used in the manifest file and a HTTP request comes:
```
ERROR python: Hook is not defined: MyHook
```
- When the Python code contains a syntax error during initialization:
```
ERROR python: Middleware initialization error: invalid syntax (middleware.py, line 1)
```
- Under other scenarios where the hook table is empty (introduced by @buger):
```
ERROR python: No hooks defined for API: quickstart
```
- When the `cgo` call fails for any reason (in addition to #1727)
```
ERROR coprocess: Dispatch error
```
- When using debug mode, successfully loaded hooks are logged:
```
python: Loading hook 'MyHook' (quickstart_bff3f7c0a59f177778910dfe0c03224b)
```