### PR TITLE
add tyk_context to response body transform

### DIFF
--- a/mw_transform.go
+++ b/mw_transform.go
@@ -87,7 +87,6 @@ func transformBody(r *http.Request, tmeta *TransformSpec, contextVars bool) erro
 			case map[string]interface{}:
 				bodyData = tempBody.(map[string]interface{})
 			}
-
 		default:
 			return fmt.Errorf("unsupported request input type: %v", tmeta.TemplateData.Input)
 		}

--- a/mw_url_rewrite.go
+++ b/mw_url_rewrite.go
@@ -1,16 +1,15 @@
 package main
 
 import (
+	"fmt"
+	"io/ioutil"
 	"net/http"
+	"net/textproto"
 	"net/url"
 	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
-
-	"fmt"
-	"io/ioutil"
-	"net/textproto"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/user"

--- a/res_handler_transform.go
+++ b/res_handler_transform.go
@@ -102,7 +102,7 @@ func (h *ResponseTransformMiddleware) HandleResponse(rw http.ResponseWriter, res
 		if err != nil {
 			logger.WithError(err).Error("Error unmarshalling XML")
 		}
-	default:
+	default: // apidef.RequestJSON
 		var tempBody interface{}
 		if err := json.NewDecoder(respBody).Decode(&tempBody); err != nil {
 			logger.WithError(err).Error("Error unmarshalling JSON")
@@ -114,6 +114,15 @@ func (h *ResponseTransformMiddleware) HandleResponse(rw http.ResponseWriter, res
 		case map[string]interface{}:
 			bodyData = tempBody.(map[string]interface{})
 		}
+	}
+
+	if h.Spec.EnableContextVars {
+		bodyData["_tyk_context"] = ctxGetData(req)
+	}
+
+	if tmeta.TemplateData.EnableSession {
+		session := ctxGetSession(req)
+		bodyData["_tyk_meta"] = session.MetaData
 	}
 
 	// Apply to template


### PR DESCRIPTION
 When `EnableContextVars: true`, request context data is added to
`bodyData["_tyk_context"]` for use within response body transform
templates.
    
Similarly, we have also included `bodyData["_tyk_meta"]`.
