### PR TITLE
Fix whitelists failing when modify headers on same path V2

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -870,6 +870,7 @@ func (a *APISpec) URLAllowedAndIgnored(r *http.Request, rxPaths []URLSpec, white
 		if !v.Spec.MatchString(strings.ToLower(r.URL.Path)) {
 			continue
 		}
+
 		if v.MethodActions != nil {
 			// We are using an extended path set, check for the method
 			methodMeta, matchMethodOk := v.MethodActions[r.Method]
@@ -889,6 +890,14 @@ func (a *APISpec) URLAllowedAndIgnored(r *http.Request, rxPaths []URLSpec, white
 				return StatusRedirectFlowByReply, &methodMeta
 			default:
 				log.Error("URL Method Action was not set to NoAction, blocking.")
+				return EndPointNotAllowed, nil
+			}
+		}
+
+		if whiteListStatus {
+			switch v.Status {
+			case WhiteList, BlackList, Ignored:
+			default:
 				return EndPointNotAllowed, nil
 			}
 		}

--- a/api_definition.go
+++ b/api_definition.go
@@ -895,6 +895,7 @@ func (a *APISpec) URLAllowedAndIgnored(r *http.Request, rxPaths []URLSpec, white
 		}
 
 		if whiteListStatus {
+			// We have a whitelist, nothing gets through unless specifically defined
 			switch v.Status {
 			case WhiteList, BlackList, Ignored:
 			default:

--- a/cert_go1.10_test.go
+++ b/cert_go1.10_test.go
@@ -200,9 +200,7 @@ func TestProxyTransport(t *testing.T) {
 
 		buildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
-			spec.Proxy.TargetURL = upstream.URL
 			spec.Proxy.Transport.SSLCipherSuites = []string{"TLS_RSA_WITH_AES_128_CBC_SHA"}
-			// Invalid proxy
 			spec.Proxy.Transport.ProxyURL = proxy.URL
 		})
 


### PR DESCRIPTION
Our rxPaths always built with the same order. First comes Whitelist, Ignore, and Blacking, the rest of plugins after.

So, if after we checked for whitelisting, we did not return early from the cycle, we can safely tell that white-listing failed.

Fixes #1732