### PR TITLE
if json req/res is array, unmarshal to map["array"]

### DIFF
--- a/mw_transform.go
+++ b/mw_transform.go
@@ -76,9 +76,18 @@ func transformBody(r *http.Request, tmeta *TransformSpec, contextVars bool) erro
 				return fmt.Errorf("error unmarshalling XML: %v", err)
 			}
 		case apidef.RequestJSON:
-			if err := json.Unmarshal(body, &bodyData); err != nil {
+			var tempBody interface{}
+			if err := json.Unmarshal(body, &tempBody); err != nil {
 				return err
 			}
+
+			switch tempBody.(type) {
+			case []interface{}:
+				bodyData["array"] = tempBody
+			case map[string]interface{}:
+				bodyData = tempBody.(map[string]interface{})
+			}
+
 		default:
 			return fmt.Errorf("unsupported request input type: %v", tmeta.TemplateData.Input)
 		}


### PR DESCRIPTION
#1733

Better handling of arrays in both request & response body transforms.
Places the array in map[array] so that we can unmarshal into
map[string]interface{}