### PR TITLE
Integrate plugin bundler

### DIFF
--- a/cli/bundler/bundler.go
+++ b/cli/bundler/bundler.go
@@ -1,0 +1,232 @@
+package bundler
+
+import (
+	"archive/zip"
+	"bufio"
+	"bytes"
+	"crypto/md5"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/TykTechnologies/goverify"
+	"github.com/TykTechnologies/tyk/apidef"
+	logger "github.com/TykTechnologies/tyk/log"
+
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+)
+
+const (
+	cmdName = "bundle"
+	cmdDesc = "Manage plugin bundles"
+
+	defaultManifestPath = "manifest.json"
+	defaultBundlePath   = "bundle.zip"
+	defaultBundlePerm   = 0755
+)
+
+var (
+	bundler *Bundler
+
+	errNoHooks      = errors.New("No hooks defined")
+	errNoDriver     = errors.New("No driver specified")
+	errManifestLoad = errors.New("Couldn't load manifest file")
+	errBundleData   = errors.New("Couldn't read/write bundle data")
+	errBundleSign   = errors.New("Couldn't sign bundle")
+
+	log = logger.Get().WithField("prefix", "tyk")
+)
+
+// Bundler wraps the bundler data structure.
+type Bundler struct {
+	keyPath      *string
+	bundlePath   *string
+	skipSigning  *bool
+	manifestPath *string
+}
+
+func init() {
+	bundler = &Bundler{}
+}
+
+// Bundle is the entrypoint function for this subcommand.
+func (b *Bundler) Bundle(ctx *kingpin.ParseContext) error {
+	return nil
+}
+
+// Build builds a bundle.
+func (b *Bundler) Build(ctx *kingpin.ParseContext) error {
+	manifestPath := *b.manifestPath
+	bundlePath := *b.bundlePath
+	skipSigning := *b.skipSigning
+	key := *b.keyPath
+
+	log.Infof("Building bundle using '%s'", manifestPath)
+	manifest, err := b.loadManifest(manifestPath)
+	if err != nil {
+		log.WithError(err).Error(errManifestLoad)
+		return nil
+	}
+	if bundlePath == defaultBundlePath {
+		log.Warningf("Using default bundle path '%s'", defaultBundlePath)
+	}
+
+	// Write the file:
+	bundleBuf := new(bytes.Buffer)
+	for _, file := range manifest.FileList {
+		var data []byte
+		data, err = ioutil.ReadFile(file)
+		if err != nil {
+			break
+		}
+		bundleBuf.Write(data)
+	}
+	if err != nil {
+		log.WithError(err).Error(errBundleData)
+		return nil
+	}
+
+	// Compute the checksum and append it to the manifest data structure:
+	manifest.Checksum = fmt.Sprintf("%x", md5.Sum(bundleBuf.Bytes()))
+
+	if key == "" {
+		if skipSigning {
+			log.Warning("The bundle will be unsigned")
+		} else {
+			log.Warning("The bundle will be unsigned, type \"y\" or \"yes\" to confirm:")
+			reader := bufio.NewReader(os.Stdin)
+			text, _ := reader.ReadString('\n')
+			ch := text[0:1]
+			if ch != "y" {
+				log.Fatal("Aborting")
+				os.Exit(1)
+			}
+		}
+	} else {
+		err = b.sign(key, manifest, bundleBuf)
+		if err != nil {
+			log.WithError(err).Error(errBundleSign)
+			return nil
+		}
+	}
+
+	manifestData, err := json.Marshal(&manifest)
+	if err != nil {
+		log.WithError(err).Error(errBundleData)
+		return nil
+	}
+
+	// Write the ZIP contents into a buffer:
+	buf := new(bytes.Buffer)
+	zipWriter := zip.NewWriter(buf)
+	for _, file := range manifest.FileList {
+		var outputFile io.Writer
+		outputFile, err = zipWriter.Create(file)
+		if err != nil {
+			break
+		}
+		var data []byte
+		data, err = ioutil.ReadFile(file)
+		if err != nil {
+			break
+		}
+		if _, err = outputFile.Write(data); err != nil {
+			break
+		}
+	}
+	if err != nil {
+		log.WithError(err).Error(errBundleData)
+		return nil
+	}
+
+	// Append the updated manifest file to the ZIP file:
+	newManifest, err := zipWriter.Create(defaultManifestPath)
+	_, err = newManifest.Write(manifestData)
+	zipWriter.Close()
+	err = ioutil.WriteFile(bundlePath, buf.Bytes(), defaultBundlePerm)
+	if err != nil {
+		log.WithError(err).Error(errBundleData)
+		return nil
+	}
+	log.Infof("Wrote '%s' (%d bytes)", bundlePath, buf.Len())
+	return nil
+}
+
+func (b *Bundler) sign(key string, manifest *apidef.BundleManifest, bundle *bytes.Buffer) (err error) {
+	signer, err := goverify.LoadPrivateKeyFromFile(key)
+	if err != nil {
+		return err
+	}
+	signed, err := signer.Sign(bundle.Bytes())
+	if err != nil {
+		return err
+	}
+	manifest.Signature = base64.StdEncoding.EncodeToString(signed)
+	log.Infof("Signing bundle with key '%s'", key)
+	return nil
+}
+
+func (b *Bundler) validateManifest(manifest *apidef.BundleManifest) (err error) {
+	for _, f := range manifest.FileList {
+		if _, err := os.Stat(f); err != nil {
+			err = errors.New("Referencing a nonexistent file: " + f)
+			break
+		}
+	}
+
+	// The file list references a nonexistent file:
+	if err != nil {
+		return err
+	}
+
+	// The custom middleware block must specify at least one hook:
+	definedHooks := len(manifest.CustomMiddleware.Pre) + len(manifest.CustomMiddleware.Post) + len(manifest.CustomMiddleware.PostKeyAuth)
+
+	// We should count the auth check middleware (single), if it's present:
+	if manifest.CustomMiddleware.AuthCheck.Name != "" {
+		definedHooks++
+	}
+
+	if definedHooks == 0 {
+		return errNoHooks
+	}
+
+	// The custom middleware block must specify a driver:
+	if manifest.CustomMiddleware.Driver == "" {
+		return errNoDriver
+	}
+
+	return nil
+}
+
+func (b *Bundler) loadManifest(path string) (manifest *apidef.BundleManifest, err error) {
+	rawManifest, err := ioutil.ReadFile(path)
+	if err != nil {
+		return manifest, err
+	}
+	err = json.Unmarshal(rawManifest, &manifest)
+	if err != nil {
+		return manifest, err
+	}
+	err = b.validateManifest(manifest)
+	if err != nil {
+		return manifest, err
+	}
+	return manifest, err
+}
+
+// AddTo initializes an importer object.
+func AddTo(app *kingpin.Application) {
+	cmd := app.Command(cmdName, cmdDesc)
+
+	buildCmd := cmd.Command("build", "Build a new plugin bundle using a manifest file and its specified files")
+	bundler.keyPath = buildCmd.Flag("key", "Key for bundle signature").Short('k').String()
+	bundler.bundlePath = buildCmd.Flag("output", "Output file").Short('o').Default(defaultBundlePath).String()
+	bundler.skipSigning = buildCmd.Flag("skip-signing", "Skip bundle signing").Short('y').Bool()
+	bundler.manifestPath = buildCmd.Flag("manifest", "Path to manifest file").Default(defaultManifestPath).Short('m').String()
+	buildCmd.Action(bundler.Build)
+}

--- a/cli/bundler/bundler_test.go
+++ b/cli/bundler/bundler_test.go
@@ -16,10 +16,22 @@ import (
 
 var (
 	testApp *kingpin.Application
+
+	standardManifest = &apidef.BundleManifest{
+		FileList: []string{},
+		CustomMiddleware: apidef.MiddlewareSection{
+			Pre: []apidef.MiddlewareDefinition{
+				{
+					Name: "MyPreHook",
+				},
+			},
+			Driver: "python",
+		},
+	}
 )
 
 func init() {
-	testApp = kingpin.New("test", "")
+	testApp = kingpin.New("tyk-cli", "")
 	AddTo(testApp)
 
 	// Setup default values:
@@ -38,6 +50,9 @@ func writeManifestFile(t testing.TB, manifest interface{}, filename string) *str
 		if err != nil {
 			t.Fatalf("Couldn't marshal manifest file: %s", err.Error())
 		}
+	case string:
+		manifestString := manifest.(string)
+		data = []byte(manifestString)
 	}
 	ioutil.WriteFile(filename, data, 0600)
 	if err != nil {
@@ -47,7 +62,9 @@ func writeManifestFile(t testing.TB, manifest interface{}, filename string) *str
 }
 
 func TestCommands(t *testing.T) {
-	_, err := testApp.Parse([]string{"bundle", "build"})
+	defer os.Remove(defaultManifestPath)
+	writeManifestFile(t, standardManifest, defaultManifestPath)
+	_, err := testApp.Parse([]string{"bundle", "build", "-y"})
 	if err != nil {
 		t.Fatalf("Command not found")
 	}
@@ -72,7 +89,7 @@ func TestBuild(t *testing.T) {
 			FileList: []string{},
 			CustomMiddleware: apidef.MiddlewareSection{
 				Pre: []apidef.MiddlewareDefinition{
-					apidef.MiddlewareDefinition{
+					{
 						Name: "MyPreHook",
 					},
 				},
@@ -98,7 +115,7 @@ func TestBuild(t *testing.T) {
 			},
 			CustomMiddleware: apidef.MiddlewareSection{
 				Pre: []apidef.MiddlewareDefinition{
-					apidef.MiddlewareDefinition{
+					{
 						Name: "MyPreHook",
 					},
 				},
@@ -126,7 +143,7 @@ func TestBuild(t *testing.T) {
 			},
 			CustomMiddleware: apidef.MiddlewareSection{
 				Pre: []apidef.MiddlewareDefinition{
-					apidef.MiddlewareDefinition{
+					{
 						Name: "MyPreHook",
 					},
 				},

--- a/cli/bundler/bundler_test.go
+++ b/cli/bundler/bundler_test.go
@@ -1,0 +1,195 @@
+package bundler
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/TykTechnologies/tyk/apidef"
+
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+)
+
+var (
+	testApp *kingpin.Application
+)
+
+func init() {
+	testApp = kingpin.New("test", "")
+	AddTo(testApp)
+
+	// Setup default values:
+	bundlePath := defaultBundlePath
+	bundler.bundlePath = &bundlePath
+	manifestPath := defaultManifestPath
+	bundler.manifestPath = &manifestPath
+}
+
+func writeManifestFile(t testing.TB, manifest interface{}, filename string) *string {
+	var data []byte
+	var err error
+	switch manifest.(type) {
+	case *apidef.BundleManifest:
+		data, err = json.Marshal(&manifest)
+		if err != nil {
+			t.Fatalf("Couldn't marshal manifest file: %s", err.Error())
+		}
+	}
+	ioutil.WriteFile(filename, data, 0600)
+	if err != nil {
+		t.Fatalf("Couldn't write manifest file: %s", err.Error())
+	}
+	return &filename
+}
+
+func TestCommands(t *testing.T) {
+	_, err := testApp.Parse([]string{"bundle", "build"})
+	if err != nil {
+		t.Fatalf("Command not found")
+	}
+}
+func TestBuild(t *testing.T) {
+	defer os.Remove(defaultManifestPath)
+
+	// Test for common errors first:
+	t.Run("Bundle errors", func(t *testing.T) {
+		ctx := &kingpin.ParseContext{}
+		err := bundler.Build(ctx)
+		if err != errManifestLoad {
+			t.Fatalf("Expected manifest load error, got: %s", err.Error())
+		}
+		filename := writeManifestFile(t, "{", defaultManifestPath)
+		bundler.manifestPath = filename
+		err = bundler.Build(ctx)
+		if !strings.Contains("unexpected end of JSON input", err.Error()) {
+			t.Fatalf("Expected JSON error, got: %s", err.Error())
+		}
+		filename = writeManifestFile(t, &apidef.BundleManifest{
+			FileList: []string{},
+			CustomMiddleware: apidef.MiddlewareSection{
+				Pre: []apidef.MiddlewareDefinition{
+					apidef.MiddlewareDefinition{
+						Name: "MyPreHook",
+					},
+				},
+			},
+		}, defaultManifestPath)
+		bundler.manifestPath = filename
+		err = bundler.Build(ctx)
+		if err != errNoDriver {
+			t.Fatal("Expected no driver error")
+		}
+		filename = writeManifestFile(t, &apidef.BundleManifest{
+			FileList:         []string{},
+			CustomMiddleware: apidef.MiddlewareSection{},
+		}, defaultManifestPath)
+		bundler.manifestPath = filename
+		err = bundler.Build(ctx)
+		if err != errNoHooks {
+			t.Fatal("Expected no hooks error")
+		}
+		filename = writeManifestFile(t, &apidef.BundleManifest{
+			FileList: []string{
+				"middleware.py",
+			},
+			CustomMiddleware: apidef.MiddlewareSection{
+				Pre: []apidef.MiddlewareDefinition{
+					apidef.MiddlewareDefinition{
+						Name: "MyPreHook",
+					},
+				},
+				Driver: "python",
+			},
+		}, defaultManifestPath)
+		bundler.manifestPath = filename
+		err = bundler.Build(ctx)
+		if !strings.Contains(err.Error(), "nonexistent") {
+			t.Fatalf("Expected nonexistent file error, got %s", err.Error())
+		}
+	})
+
+	// Build a simple bundle:
+	t.Run("Simple bundle build", func(t *testing.T) {
+		ctx := &kingpin.ParseContext{}
+		err := ioutil.WriteFile("middleware.py", []byte(""), 0600)
+		if err != nil {
+			t.Fatalf("Couldn't write middleware.py: %s", err.Error())
+		}
+		defer os.Remove("middleware.py")
+		filename := writeManifestFile(t, &apidef.BundleManifest{
+			FileList: []string{
+				"middleware.py",
+			},
+			CustomMiddleware: apidef.MiddlewareSection{
+				Pre: []apidef.MiddlewareDefinition{
+					apidef.MiddlewareDefinition{
+						Name: "MyPreHook",
+					},
+				},
+				Driver: "python",
+			},
+		}, defaultManifestPath)
+		bundler.manifestPath = filename
+		skipSigning := true
+		bundler.skipSigning = &skipSigning
+		err = bundler.Build(ctx)
+		zipFile, err := zip.OpenReader("bundle.zip")
+		if err != nil {
+			t.Fatalf("Couldn't initialize ZIP reader: %s\n", err.Error())
+		}
+		defer func() {
+			zipFile.Close()
+			os.Remove("bundle.zip")
+		}()
+		if len(zipFile.File) != 2 {
+			t.Fatal("Number of bundled files doesn't match")
+		}
+		files := make(map[string][]byte)
+		for _, f := range zipFile.File {
+			reader, err := f.Open()
+			defer reader.Close()
+			if err != nil {
+				t.Fatalf("Couldn't read from ZIP file: %s", err.Error())
+			}
+			if f.Name != defaultManifestPath && f.Name != "middleware.py" {
+				t.Fatalf("Unexpected file: %s", f.Name)
+			}
+			var buf bytes.Buffer
+			_, err = buf.ReadFrom(reader)
+			if err != nil {
+				t.Fatalf("Couldn't read from ZIP file: %s", err.Error())
+			}
+			files[defaultManifestPath] = buf.Bytes()
+		}
+		manifestData, ok := files[defaultManifestPath]
+		if !ok {
+			t.Fatalf("Couldn't found manifest data: %s", err.Error())
+		}
+		var manifest apidef.BundleManifest
+		err = json.Unmarshal(manifestData, &manifest)
+		if err != nil {
+			t.Fatalf("Couldn't decode manifest data: %s", err.Error())
+		}
+		if manifest.Checksum != "d41d8cd98f00b204e9800998ecf8427e" {
+			t.Fatalf("Bundle checksum doesn't match")
+		}
+		preHooks := manifest.CustomMiddleware.Pre
+		if len(preHooks) != 1 {
+			t.Fatalf("Bundle hooks doesn't match, got %d, expected 1", len(preHooks))
+		}
+		fileList := manifest.FileList
+		if len(fileList) != 1 {
+			t.Fatalf("Bundle file list doesn't match, got %d, expected 1", len(fileList))
+		}
+		if fileList[0] != "middleware.py" {
+			t.Fatal("Bundle file 'middleware.py' wasn't found")
+		}
+		if manifest.CustomMiddleware.Driver != apidef.PythonDriver {
+			t.Fatalf("Bundle driver doesn't match, got %s, expected %s", manifest.CustomMiddleware.Driver, apidef.PythonDriver)
+		}
+	})
+}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -6,8 +6,11 @@ import (
 
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 
+	"github.com/TykTechnologies/tyk/cli/bundler"
 	"github.com/TykTechnologies/tyk/cli/importer"
 	"github.com/TykTechnologies/tyk/cli/lint"
+
+	logger "github.com/TykTechnologies/tyk/log"
 )
 
 const (
@@ -35,7 +38,12 @@ var (
 	// LogInstrumentation outputs instrumentation data to stdout.
 	LogInstrumentation *bool
 
+	// DefaultMode is set when default command is used.
+	DefaultMode bool
+
 	app *kingpin.Application
+
+	log = logger.Get()
 )
 
 // Init sets all flags and subcommands.
@@ -57,6 +65,7 @@ func Init(version string, confPaths []string) {
 	LogInstrumentation = startCmd.Flag("log-intrumentation", "output intrumentation output to stdout").Bool()
 
 	startCmd.Action(func(ctx *kingpin.ParseContext) error {
+		DefaultMode = true
 		return nil
 	})
 	startCmd.Default()
@@ -81,8 +90,11 @@ func Init(version string, confPaths []string) {
 		return nil
 	})
 
-	// Import command:
+	// Add import command:
 	importer.AddTo(app)
+
+	// Add bundler commands:
+	bundler.AddTo(app)
 }
 
 // Parse parses the command-line arguments.

--- a/main.go
+++ b/main.go
@@ -886,6 +886,10 @@ func getGlobalStorageHandler(keyPrefix string, hashKeys bool) storage.Handler {
 func main() {
 	cli.Init(VERSION, confPaths)
 	cli.Parse()
+	// Stop gateway process if not running in "start" mode:
+	if !cli.DefaultMode {
+		os.Exit(0)
+	}
 
 	NodeID = "solo-" + uuid.NewV4().String()
 


### PR DESCRIPTION
This is built on top of #1738, reimplements the plugin bundler as part of the new CLI code (#1492).
The syntax for this subcommand is the same and the logging has been enhanced with `logrus`.