### PR TITLE
Improve async session updates 

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -832,6 +832,11 @@ func (a *APISpec) Init(authStore, sessionStore, healthStore, orgStore storage.Ha
 	a.OrgSessionManager.Init(orgStore)
 }
 
+func (a *APISpec) StopSessionManagerPool() {
+	a.SessionManager.Stop()
+	a.OrgSessionManager.Stop()
+}
+
 func (a *APISpec) getURLStatus(stat URLStatus) RequestStatus {
 	switch stat {
 	case Ignored:

--- a/auth_manager.go
+++ b/auth_manager.go
@@ -40,6 +40,9 @@ type SessionHandler interface {
 	Stop()
 }
 
+const sessionPoolDefaultSize = 50
+const sessionBufferDefaultSize = 1000
+
 // DefaultAuthorisationManager implements AuthorisationHandler,
 // requires a storage.Handler to interact with key store
 type DefaultAuthorisationManager struct {
@@ -108,15 +111,15 @@ func (b *DefaultSessionManager) Init(store storage.Handler) {
 		// check pool size in config and set to 50 if unset
 		b.poolSize = config.Global().SessionUpdatePoolSize
 		if b.poolSize <= 0 {
-			b.poolSize = 50
+			b.poolSize = sessionPoolDefaultSize
 		}
 		//check size for channel buffer and set to 1000 if unset
 		b.bufferSize = config.Global().SessionUpdateBufferSize
 		if b.bufferSize <= 0 {
-			b.bufferSize = 1000
+			b.bufferSize = sessionBufferDefaultSize
 		}
 
-		log.WithField("Auth Manager", b.poolSize).Debug("Session update async pool size")
+		log.WithField("SessionManager poolsize", b.poolSize).Debug("Session update async pool size")
 
 		b.updateChan = make(chan *SessionUpdate, b.bufferSize)
 
@@ -134,13 +137,11 @@ func (b *DefaultSessionManager) Init(store storage.Handler) {
 func (b *DefaultSessionManager) updateWorker() {
 	defer b.poolWG.Done()
 
-	for range b.updateChan {
-		// grab update object from channel
-		u := <-b.updateChan
+	for u := range b.updateChan {
 
 		v, err := json.Marshal(u.session)
 		if err != nil {
-			log.Error("Error marshalling session for async session update")
+			log.WithError(err).Error("Error marshalling session for async session update")
 			continue
 		}
 
@@ -148,7 +149,7 @@ func (b *DefaultSessionManager) updateWorker() {
 			u.keyVal = b.keyPrefix + u.keyVal
 			err := b.store.SetRawKey(u.keyVal, string(v), u.ttl)
 			if err != nil {
-				log.Errorf("Error updating hashed key: %v", err)
+				log.WithError(err).Error("Error updating hashed key")
 			}
 			continue
 
@@ -156,7 +157,7 @@ func (b *DefaultSessionManager) updateWorker() {
 
 		err = b.store.SetKey(u.keyVal, string(v), u.ttl)
 		if err != nil {
-			log.Errorf("Error updating non-hashed key: %v", err)
+			log.WithError(err).Error("Error updating key")
 		}
 	}
 }
@@ -221,12 +222,9 @@ func (b *DefaultSessionManager) UpdateSession(keyName string, session *user.Sess
 		return err
 	}
 
-	if hashed {
-		keyName = b.store.GetKeyPrefix() + keyName
-	}
-
 	// sync update
 	if hashed {
+		keyName = b.store.GetKeyPrefix() + keyName
 		err = b.store.SetRawKey(keyName, string(v), resetTTLTo)
 	} else {
 		err = b.store.SetKey(keyName, string(v), resetTTLTo)

--- a/cli/lint/schema.go
+++ b/cli/lint/schema.go
@@ -494,6 +494,9 @@ const confSchema = `{
 	"session_update_pool_size":{
 		"type": "integer"
 	},
+	"session_update_buffer_size":{
+		"type": "integer"
+	},
 	"pid_file_location": {
 		"type": "string"
 	},

--- a/cli/lint/schema.go
+++ b/cli/lint/schema.go
@@ -491,6 +491,9 @@ const confSchema = `{
 	"optimisations_use_async_session_write": {
 		"type": "boolean"
 	},
+	"session_update_pool_size":{
+		"type": "integer"
+	},
 	"pid_file_location": {
 		"type": "string"
 	},

--- a/config/config.go
+++ b/config/config.go
@@ -213,6 +213,7 @@ type Config struct {
 	HealthCheck                       HealthCheckConfig                     `json:"health_check"`
 	UseAsyncSessionWrite              bool                                  `json:"optimisations_use_async_session_write"`
 	SessionUpdatePoolSize             int                                   `json:"session_update_pool_size"`
+	SessionUpdateBufferSize           int                                   `json:"session_update_buffer_size"`
 	AllowMasterKeys                   bool                                  `json:"allow_master_keys"`
 	HashKeys                          bool                                  `json:"hash_keys"`
 	HashKeyFunction                   string                                `json:"hash_key_function"`

--- a/config/config.go
+++ b/config/config.go
@@ -212,6 +212,7 @@ type Config struct {
 	AnalyticsConfig                   AnalyticsConfigConfig                 `json:"analytics_config"`
 	HealthCheck                       HealthCheckConfig                     `json:"health_check"`
 	UseAsyncSessionWrite              bool                                  `json:"optimisations_use_async_session_write"`
+	SessionUpdatePoolSize             int                                   `json:"session_update_pool_size"`
 	AllowMasterKeys                   bool                                  `json:"allow_master_keys"`
 	HashKeys                          bool                                  `json:"hash_keys"`
 	HashKeyFunction                   string                                `json:"hash_key_function"`

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -1268,8 +1268,8 @@ func TestRateLimitForAPIAndRateLimitAndQuotaCheck(t *testing.T) {
 
 	ts.Run(t, []test.TestCase{
 		{Headers: map[string]string{"Authorization": sess1token}, Code: http.StatusOK, Path: "/"},
-		{Headers: map[string]string{"Authorization": sess1token}, Code: http.StatusTooManyRequests, Path: "/"},
 		{Headers: map[string]string{"Authorization": sess2token}, Code: http.StatusOK, Path: "/"},
+		{Headers: map[string]string{"Authorization": sess1token}, Code: http.StatusTooManyRequests, Path: "/"},
 		{Headers: map[string]string{"Authorization": sess2token}, Code: http.StatusTooManyRequests, Path: "/"},
 	}...)
 }

--- a/main.go
+++ b/main.go
@@ -999,11 +999,13 @@ func main() {
 		analytics.Stop()
 	}
 
-	//if using async session writes stop workers
+	// if using async session writes stop workers
 	if config.Global().UseAsyncSessionWrite {
 		DefaultOrgStore.Stop()
-		DefaultQuotaStore.Stop()
-		FallbackKeySesionManager.Stop()
+		for i := range apiSpecs {
+			apiSpecs[i].StopSessionManagerPool()
+		}
+
 	}
 
 	// write pprof profiles

--- a/main.go
+++ b/main.go
@@ -999,6 +999,13 @@ func main() {
 		analytics.Stop()
 	}
 
+	//if using async session writes stop workers
+	if config.Global().UseAsyncSessionWrite {
+		DefaultOrgStore.Stop()
+		DefaultQuotaStore.Stop()
+		FallbackKeySesionManager.Stop()
+	}
+
 	// write pprof profiles
 	writeProfiles()
 

--- a/policy_test.go
+++ b/policy_test.go
@@ -43,7 +43,7 @@ type dummySessionManager struct {
 	DefaultSessionManager
 }
 
-func (dummySessionManager) UpdateSession(key string, sess *user.SessionState, ttl int64, hashed bool) error {
+func (*dummySessionManager) UpdateSession(key string, sess *user.SessionState, ttl int64, hashed bool) error {
 	return nil
 }
 

--- a/session_manager.go
+++ b/session_manager.go
@@ -48,7 +48,8 @@ func (l *SessionLimiter) doRollingWindowWrite(key, rateLimiterKey, rateLimiterSe
 		// and another subtraction because of the preemptive limit
 		subtractor = 2
 	}
-
+	// The test TestRateLimitForAPIAndRateLimitAndQuotaCheck
+	// will only work with ththese two lines here
 	//log.Info("break: ", (int(currentSession.Rate) - subtractor))
 	if ratePerPeriodNow > int(currentSession.Rate)-subtractor {
 		// Set a sentinel value with expire


### PR DESCRIPTION
Fixes #1758 

Current solution for session updates when async is enabled is just to spawn a new goroutine per redis operation. 

This change allows setting a configurable pool of workers to handle the session updates - with the slower parts of the session update such as json marshalling moved into the pool. Default value if unset is currently 15 and worker pool will gracefully exit on gateway shutdown.

Also changed the dummySessionManager in policy_test.go pass by ref to stop go vet failing because of passed mutex.