### PR TITLE
Profile benchmark copy request response

### DIFF
--- a/coprocess_id_extractor.go
+++ b/coprocess_id_extractor.go
@@ -50,14 +50,13 @@ func (e *BaseExtractor) ExtractHeader(r *http.Request) (headerValue string, err 
 
 // ExtractForm is used when a FormSource is specified.
 func (e *BaseExtractor) ExtractForm(r *http.Request, paramName string) (formValue string, err error) {
-	copiedRequest := copyRequest(r)
-	copiedRequest.ParseForm()
+	r.ParseForm()
 
 	if paramName == "" {
 		return "", errors.New("no form param name set")
 	}
 
-	values := copiedRequest.Form[paramName]
+	values := r.Form[paramName]
 	if len(values) == 0 {
 		return "", errors.New("no form value")
 	}
@@ -67,8 +66,7 @@ func (e *BaseExtractor) ExtractForm(r *http.Request, paramName string) (formValu
 
 // ExtractBody is used when BodySource is specified.
 func (e *BaseExtractor) ExtractBody(r *http.Request) (string, error) {
-	copiedRequest := copyRequest(r)
-	body, err := ioutil.ReadAll(copiedRequest.Body)
+	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		return "", err
 	}

--- a/handler_error.go
+++ b/handler_error.go
@@ -119,10 +119,9 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 		rawRequest := ""
 		rawResponse := ""
 		if recordDetail(r, e.Spec.GlobalConfig) {
-			requestCopy := copyRequest(r)
 			// Get the wire format representation
 			var wireFormatReq bytes.Buffer
-			requestCopy.Write(&wireFormatReq)
+			r.Write(&wireFormatReq)
 			rawRequest = base64.StdEncoding.EncodeToString(wireFormatReq.Bytes())
 		}
 

--- a/main.go
+++ b/main.go
@@ -1159,6 +1159,10 @@ type mainHandler struct{}
 
 func (_ mainHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	AddNewRelicInstrumentation(NewRelicApplication, mainRouter)
+
+	// make request body to be nopCloser and re-readable before serve it through chain of middlewares
+	nopCloseRequestBody(r)
+
 	mainRouter.ServeHTTP(w, r)
 }
 

--- a/mw_redis_cache.go
+++ b/mw_redis_cache.go
@@ -132,11 +132,6 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 		token = request.RealIP(r)
 	}
 
-	var copiedRequest *http.Request
-	if recordDetail(r, m.Spec.GlobalConfig) {
-		copiedRequest = copyRequest(r)
-	}
-
 	key := m.CreateCheckSum(r, token)
 	retBlob, err := m.CacheStore.GetKey(key)
 	if err != nil {
@@ -268,7 +263,7 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 
 	// Record analytics
 	if !m.Spec.DoNotTrack {
-		go m.sh.RecordHit(r, 0, newRes.StatusCode, copiedRequest, nil)
+		go m.sh.RecordHit(r, 0, newRes.StatusCode, nil)
 	}
 
 	// Stop any further execution

--- a/mw_url_rewrite.go
+++ b/mw_url_rewrite.go
@@ -463,8 +463,7 @@ func checkSessionTrigger(r *http.Request, sess *user.SessionState, options map[s
 
 func checkPayload(r *http.Request, options apidef.StringRegexMap, triggernum int) bool {
 	contextData := ctxGetData(r)
-	cp := copyRequest(r)
-	bodyBytes, _ := ioutil.ReadAll(cp.Body)
+	bodyBytes, _ := ioutil.ReadAll(r.Body)
 
 	b := options.Check(string(bodyBytes))
 	if len(b) > 0 {

--- a/mw_validate_json.go
+++ b/mw_validate_json.go
@@ -49,12 +49,11 @@ func (k *ValidateJSON) ProcessRequest(w http.ResponseWriter, r *http.Request, _ 
 	}
 
 	// Load input body into gojsonschema
-	rCopy := copyRequest(r)
-	bodyBytes, err := ioutil.ReadAll(rCopy.Body)
+	bodyBytes, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		return err, http.StatusBadRequest
 	}
-	defer rCopy.Body.Close()
+	defer r.Body.Close()
 	inputLoader := gojsonschema.NewBytesLoader(bodyBytes)
 
 	// Perform validation


### PR DESCRIPTION
added changes for https://github.com/TykTechnologies/tyk/issues/1668

these are pretty low level changes so I think we need to test it carefully.

changes include:
- don't do copy of `Request` or `Response` as it is shallow one anyways and we have pointers to the same data
- convert `Request.Body` to `nopCloser` only once and then use the same instance of `Request` passed everywhere
- convert `Response.Body` to `nopCloser` only once and then use the same instance of `Response` passed everywhere
- `nopCloser` in addition to no-op Close has nested `ReadSeeker` inside and rewinds position in buffer every time body was read up to EOF, or `Close` was called, or outer logic tried to convert to `nopCloser` while it was already `nopCloser`
- `nopCloser` doesn't create new buffer "descriptor" struct every time as it was before as it is safe to use the same `Body` for reading now (unless we read some request or response body in parallel, which is not the case)

benchcmp of BenchmarkCopyRequestResponse vs master:
```
benchmark                          old ns/op     new ns/op     delta
BenchmarkCopyRequestResponse-8     15244         9930          -34.86%

benchmark                          old allocs     new allocs     delta
BenchmarkCopyRequestResponse-8     76             18             -76.32%

benchmark                          old bytes     new bytes     delta
BenchmarkCopyRequestResponse-8     35585         29120         -18.17%
```

if we run all benchmarks we see that performance gain is not super big but still looks good (under heavy traffic less allocation will pay off imho):
benchcmp vs master:
```
benchmark                                                                                                   old ns/op     new ns/op     delta
BenchmarkURLReplacer-8                                                                                      1912          1900          -0.63%
BenchmarkTagHeaders-8                                                                                       971           951           -2.06%
BenchmarkDefaultVersion-8                                                                                   1019890       1028861       +0.88%
BenchmarkGetVersionFromRequest/Header_location-8                                                            508853        489835        -3.74%
BenchmarkGetVersionFromRequest/URL_param_location-8                                                         478896        475751        -0.66%
BenchmarkGetVersionFromRequest/URL_location-8                                                               466637        468053        +0.30%
BenchmarkApiReload-8                                                                                        3524971       3373055       -4.31%
BenchmarkValueExtractor/HeaderSource-8                                                                      121268        121406        +0.11%
BenchmarkValueExtractor/FormSource-8                                                                        131743        130182        -1.18%
BenchmarkRegexExtractor/HeaderSource-8                                                                      127317        121678        -4.43%
BenchmarkRegexExtractor/BodySource-8                                                                        127746        123120        -3.62%
BenchmarkRegexExtractor/FormSource-8                                                                        132134        128779        -2.54%
BenchmarkXPathExtractor/HeaderSource-8                                                                      138297        138369        +0.05%
BenchmarkXPathExtractor/BodySource-8                                                                        140240        138969        -0.91%
BenchmarkXPathExtractor/FormSource-8                                                                        155063        147433        -4.92%
BenchmarkInitGenericEventHandlers-8                                                                         764           746           -2.36%
BenchmarkMultiSession_BA_Standard_OK-8                                                                      2173834       2173240       -0.03%
BenchmarkBearerTokenAuthKeySession-8                                                                        1875938       1881379       +0.29%
BenchmarkMultiAuthBackwardsCompatibleSession-8                                                              1836189       1841490       +0.29%
BenchmarkBasicAuth-8                                                                                        159470374     159430462     -0.03%
BenchmarkContextVarsMiddleware-8                                                                            1326295       1317404       -0.67%
BenchmarkContextVarsMiddlewareProcessRequest/POST_with_query_string_and_encoded_form_data_and_cookies-8     14779         14200         -3.92%
BenchmarkContextVarsMiddlewareProcessRequest/GET_with_query_string-8                                        7483          7773          +3.88%
BenchmarkContextVarsMiddlewareProcessRequest/POST_with_query_string_and_encoded_form_data-8                 11964         11817         -1.23%
BenchmarkHMACAuthSessionPass-8                                                                              1167237       1200765       +2.87%
BenchmarkHMACAuthSessionPassWithHeaderField-8                                                               1184539       1196382       +1.00%
BenchmarkIPBlacklistMiddleware-8                                                                            27293         27838         +2.00%
BenchmarkIPMiddlewarePass-8                                                                                 17862         17584         -1.56%
BenchmarkJWTSessionHMAC-8                                                                                   373044        350506        -6.04%
BenchmarkJWTSessionRSA-8                                                                                    471476        478391        +1.47%
BenchmarkJWTSessionRSABearer-8                                                                              459664        476327        +3.63%
BenchmarkJWTSessionRSAWithRawSourceOnWithClientID-8                                                         475111        484502        +1.98%
BenchmarkJWTSessionRSAWithRawSource-8                                                                       468430        475777        +1.57%
BenchmarkJWTSessionRSAWithJWK-8                                                                             476170        487224        +2.32%
BenchmarkJWTSessionRSAWithEncodedJWK-8                                                                      467302        470044        +0.59%
BenchmarkProcessRequestLiveQuotaLimit-8                                                                     570396        584883        +2.54%
BenchmarkProcessRequestOffThreadQuotaLimit-8                                                                437996        436923        -0.24%
BenchmarkProcessRequestLiveRedisRollingLimiter-8                                                            941738        933364        -0.89%
BenchmarkProcessRequestOffThreadRedisRollingLimiter-8                                                       717807        713155        -0.65%
BenchmarkStripAuth_stripFromHeaders-8                                                                       8765          8734          -0.35%
BenchmarkStripAuth_stripFromParams-8                                                                        40096         39812         -0.71%
BenchmarkTransformNonAscii-8                                                                                15767         15489         -1.76%
BenchmarkTransformJSONMarshal-8                                                                             16631         16570         -0.37%
BenchmarkRewriter-8                                                                                         33130         33588         +1.38%
BenchmarkValidateJSONSchema-8                                                                               1783442       1741470       -2.35%
BenchmarkVersioning-8                                                                                       2079299       2104417       +1.21%
BenchmarkVirtualEndpoint-8                                                                                  345046        344628        -0.12%
BenchmarkApplyPolicies-8                                                                                    20838         20876         +0.18%
BenchmarkResponseHeaderInjection-8                                                                          2020732       2082476       +3.06%
BenchmarkRequestIPHops-8                                                                                    416           411           -1.20%
BenchmarkWrappedServeHTTP-8                                                                                 139846        139661        -0.13%
BenchmarkCopyRequestResponse-8                                                                              14534         9411          -35.25%

benchmark                                                                                                   old allocs     new allocs     delta
BenchmarkURLReplacer-8                                                                                      12             12             +0.00%
BenchmarkTagHeaders-8                                                                                       15             15             +0.00%
BenchmarkDefaultVersion-8                                                                                   1340           1351           +0.82%
BenchmarkGetVersionFromRequest/Header_location-8                                                            564            551            -2.30%
BenchmarkGetVersionFromRequest/URL_param_location-8                                                         529            535            +1.13%
BenchmarkGetVersionFromRequest/URL_location-8                                                               510            515            +0.98%
BenchmarkApiReload-8                                                                                        23903          23903          +0.00%
BenchmarkValueExtractor/HeaderSource-8                                                                      50             50             +0.00%
BenchmarkValueExtractor/FormSource-8                                                                        77             70             -9.09%
BenchmarkRegexExtractor/HeaderSource-8                                                                      52             52             +0.00%
BenchmarkRegexExtractor/BodySource-8                                                                        62             55             -11.29%
BenchmarkRegexExtractor/FormSource-8                                                                        79             72             -8.86%
BenchmarkXPathExtractor/HeaderSource-8                                                                      108            108            +0.00%
BenchmarkXPathExtractor/BodySource-8                                                                        116            109            -6.03%
BenchmarkXPathExtractor/FormSource-8                                                                        140            133            -5.00%
BenchmarkInitGenericEventHandlers-8                                                                         8              8              +0.00%
BenchmarkMultiSession_BA_Standard_OK-8                                                                      273            273            +0.00%
BenchmarkBearerTokenAuthKeySession-8                                                                        241            241            +0.00%
BenchmarkMultiAuthBackwardsCompatibleSession-8                                                              246            246            +0.00%
BenchmarkBasicAuth-8                                                                                        19876          19886          +0.05%
BenchmarkContextVarsMiddleware-8                                                                            1691           1695           +0.24%
BenchmarkContextVarsMiddlewareProcessRequest/POST_with_query_string_and_encoded_form_data_and_cookies-8     80             80             +0.00%
BenchmarkContextVarsMiddlewareProcessRequest/GET_with_query_string-8                                        40             40             +0.00%
BenchmarkContextVarsMiddlewareProcessRequest/POST_with_query_string_and_encoded_form_data-8                 64             64             +0.00%
BenchmarkHMACAuthSessionPass-8                                                                              233            235            +0.86%
BenchmarkHMACAuthSessionPassWithHeaderField-8                                                               256            257            +0.39%
BenchmarkIPBlacklistMiddleware-8                                                                            152            152            +0.00%
BenchmarkIPMiddlewarePass-8                                                                                 95             95             +0.00%
BenchmarkJWTSessionHMAC-8                                                                                   477            478            +0.21%
BenchmarkJWTSessionRSA-8                                                                                    576            577            +0.17%
BenchmarkJWTSessionRSABearer-8                                                                              578            579            +0.17%
BenchmarkJWTSessionRSAWithRawSourceOnWithClientID-8                                                         600            601            +0.17%
BenchmarkJWTSessionRSAWithRawSource-8                                                                       598            599            +0.17%
BenchmarkJWTSessionRSAWithJWK-8                                                                             601            602            +0.17%
BenchmarkJWTSessionRSAWithEncodedJWK-8                                                                      606            607            +0.17%
BenchmarkProcessRequestLiveQuotaLimit-8                                                                     466            467            +0.21%
BenchmarkProcessRequestOffThreadQuotaLimit-8                                                                439            440            +0.23%
BenchmarkProcessRequestLiveRedisRollingLimiter-8                                                            2013           2012           -0.05%
BenchmarkProcessRequestOffThreadRedisRollingLimiter-8                                                       2275           2293           +0.79%
BenchmarkStripAuth_stripFromHeaders-8                                                                       66             66             +0.00%
BenchmarkStripAuth_stripFromParams-8                                                                        220            220            +0.00%
BenchmarkTransformNonAscii-8                                                                                98             98             +0.00%
BenchmarkTransformJSONMarshal-8                                                                             101            101            +0.00%
BenchmarkRewriter-8                                                                                         238            238            +0.00%
BenchmarkValidateJSONSchema-8                                                                               2261           2252           -0.40%
BenchmarkVersioning-8                                                                                       2854           2867           +0.46%
BenchmarkVirtualEndpoint-8                                                                                  319            320            +0.31%
BenchmarkApplyPolicies-8                                                                                    86             86             +0.00%
BenchmarkResponseHeaderInjection-8                                                                          2259           2263           +0.18%
BenchmarkRequestIPHops-8                                                                                    4              4              +0.00%
BenchmarkWrappedServeHTTP-8                                                                                 144            144            +0.00%
BenchmarkCopyRequestResponse-8                                                                              76             18             -76.32%

benchmark                                                                                                   old bytes     new bytes     delta
BenchmarkURLReplacer-8                                                                                      1088          1088          +0.00%
BenchmarkTagHeaders-8                                                                                       384           384           +0.00%
BenchmarkDefaultVersion-8                                                                                   191657        188955        -1.41%
BenchmarkGetVersionFromRequest/Header_location-8                                                            86656         84557         -2.42%
BenchmarkGetVersionFromRequest/URL_param_location-8                                                         85647         84237         -1.65%
BenchmarkGetVersionFromRequest/URL_location-8                                                               82864         81457         -1.70%
BenchmarkApiReload-8                                                                                        1788991       1788963       -0.00%
BenchmarkValueExtractor/HeaderSource-8                                                                      4241          4240          -0.02%
BenchmarkValueExtractor/FormSource-8                                                                        10337         7776          -24.78%
BenchmarkRegexExtractor/HeaderSource-8                                                                      4274          4274          +0.00%
BenchmarkRegexExtractor/BodySource-8                                                                        8727          6167          -29.33%
BenchmarkRegexExtractor/FormSource-8                                                                        10376         7816          -24.67%
BenchmarkXPathExtractor/HeaderSource-8                                                                      9046          9047          +0.01%
BenchmarkXPathExtractor/BodySource-8                                                                        13465         10905         -19.01%
BenchmarkXPathExtractor/FormSource-8                                                                        15660         13098         -16.36%
BenchmarkInitGenericEventHandlers-8                                                                         528           528           +0.00%
BenchmarkMultiSession_BA_Standard_OK-8                                                                      59008         59010         +0.00%
BenchmarkBearerTokenAuthKeySession-8                                                                        56498         56502         +0.01%
BenchmarkMultiAuthBackwardsCompatibleSession-8                                                              58099         58100         +0.00%
BenchmarkBasicAuth-8                                                                                        1038397       1033834       -0.44%
BenchmarkContextVarsMiddleware-8                                                                            279248        279008        -0.09%
BenchmarkContextVarsMiddlewareProcessRequest/POST_with_query_string_and_encoded_form_data_and_cookies-8     12186         12186         +0.00%
BenchmarkContextVarsMiddlewareProcessRequest/GET_with_query_string-8                                        7112          7112          +0.00%
BenchmarkContextVarsMiddlewareProcessRequest/POST_with_query_string_and_encoded_form_data-8                 10501         10501         +0.00%
BenchmarkHMACAuthSessionPass-8                                                                              46621         47490         +1.86%
BenchmarkHMACAuthSessionPassWithHeaderField-8                                                               48162         48316         +0.32%
BenchmarkIPBlacklistMiddleware-8                                                                            32343         32342         -0.00%
BenchmarkIPMiddlewarePass-8                                                                                 26733         26735         +0.01%
BenchmarkJWTSessionHMAC-8                                                                                   74227         74160         -0.09%
BenchmarkJWTSessionRSA-8                                                                                    94668         94622         -0.05%
BenchmarkJWTSessionRSABearer-8                                                                              95814         95784         -0.03%
BenchmarkJWTSessionRSAWithRawSourceOnWithClientID-8                                                         98304         98262         -0.04%
BenchmarkJWTSessionRSAWithRawSource-8                                                                       98171         98118         -0.05%
BenchmarkJWTSessionRSAWithJWK-8                                                                             97171         97125         -0.05%
BenchmarkJWTSessionRSAWithEncodedJWK-8                                                                      97373         97331         -0.04%
BenchmarkProcessRequestLiveQuotaLimit-8                                                                     75893         75841         -0.07%
BenchmarkProcessRequestOffThreadQuotaLimit-8                                                                74937         74904         -0.04%
BenchmarkProcessRequestLiveRedisRollingLimiter-8                                                            138233        138171        -0.04%
BenchmarkProcessRequestOffThreadRedisRollingLimiter-8                                                       148999        149677        +0.46%
BenchmarkStripAuth_stripFromHeaders-8                                                                       2801          2801          +0.00%
BenchmarkStripAuth_stripFromParams-8                                                                        14163         14163         +0.00%
BenchmarkTransformNonAscii-8                                                                                11061         11060         -0.01%
BenchmarkTransformJSONMarshal-8                                                                             11509         11509         +0.00%
BenchmarkRewriter-8                                                                                         45600         45600         +0.00%
BenchmarkValidateJSONSchema-8                                                                               263497        261908        -0.60%
BenchmarkVersioning-8                                                                                       273525        269895        -1.33%
BenchmarkVirtualEndpoint-8                                                                                  65421         65373         -0.07%
BenchmarkApplyPolicies-8                                                                                    5925          5925          +0.00%
BenchmarkResponseHeaderInjection-8                                                                          376106        375832        -0.07%
BenchmarkRequestIPHops-8                                                                                    432           432           +0.00%
BenchmarkWrappedServeHTTP-8                                                                                 48435         48436         +0.00%
BenchmarkCopyRequestResponse-8                                                                              35585         29120         -18.17%
```