### PR TITLE
compileURLRewritesPathSpec fixed

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -693,10 +693,11 @@ func (a APIDefinitionLoader) compileURLRewritesPathSpec(paths []apidef.URLRewrit
 	urlSpec := []URLSpec{}
 
 	for _, stringSpec := range paths {
+		curStringSpec := stringSpec
 		newSpec := URLSpec{}
-		a.generateRegex(stringSpec.Path, &newSpec, stat)
+		a.generateRegex(curStringSpec.Path, &newSpec, stat)
 		// Extend with method actions
-		newSpec.URLRewrite = &stringSpec
+		newSpec.URLRewrite = &curStringSpec
 
 		urlSpec = append(urlSpec, newSpec)
 	}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -75,6 +75,7 @@ func bundleHandleFunc(w http.ResponseWriter, r *http.Request) {
 
 type testHttpResponse struct {
 	Method  string
+	URI     string
 	Url     string
 	Body    string
 	Headers map[string]string
@@ -138,6 +139,7 @@ func testHttpHandler() *mux.Router {
 
 		err := json.NewEncoder(w).Encode(testHttpResponse{
 			Method:  r.Method,
+			URI:     r.RequestURI,
 			Url:     r.URL.String(),
 			Headers: firstVals(r.Header),
 			Form:    firstVals(r.Form),


### PR DESCRIPTION
added fix for https://github.com/TykTechnologies/tyk/issues/1781

that was a tricky one - in Go's `for` the loop variable is being reused for each iteration so we were populating `[]URLSpec` array with the same url-rewrite (the last one form api definition `url_rewrites` array)