### PR TITLE
Limit RPC ReLogin to run only copy at a time

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -50,6 +50,8 @@ var cipherSuites = map[string]uint16{
 	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305":  0xcca9,
 }
 
+var certLog = log.WithField("prefix", "certs")
+
 func getUpstreamCertificate(host string, spec *APISpec) (cert *tls.Certificate) {
 	var certID string
 
@@ -108,6 +110,8 @@ func verifyPeerCertificatePinnedCheck(spec *APISpec, tlsConfig *tls.Config) func
 	}
 
 	return func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+		certLog.Debug("Checking certificate public key")
+
 		for _, rawCert := range rawCerts {
 			cert, _ := x509.ParseCertificate(rawCert)
 			pub, err := x509.MarshalPKIXPublicKey(cert.PublicKey)
@@ -147,6 +151,8 @@ func dialTLSPinnedCheck(spec *APISpec, tc *tls.Config) func(network, addr string
 		if len(whitelist) == 0 {
 			return c, nil
 		}
+
+		certLog.Debug("Checking certificate public key for host:", host)
 
 		state := c.ConnectionState()
 		for _, peercert := range state.PeerCertificates {

--- a/rpc_storage_handler.go
+++ b/rpc_storage_handler.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/garyburd/redigo/redis"
@@ -260,11 +261,15 @@ func (r *RPCStorageHandler) cleanKey(keyName string) string {
 }
 
 var rpcLoginMu sync.Mutex
+var reLoginRunning uint32
 
 func (r *RPCStorageHandler) ReAttemptLogin(err error) bool {
-	rpcLoginMu.Lock()
-	log.Warning("[RPC Store] Login failed, waiting 3s to re-attempt")
+	if atomic.LoadUint32(&reLoginRunning) == 1 {
+		return false
+	}
+	atomic.StoreUint32(&reLoginRunning, 1)
 
+	rpcLoginMu.Lock()
 	if rpcLoadCount == 0 && !rpcEmergencyModeLoaded {
 		log.Warning("[RPC Store] --> Detected cold start, attempting to load from cache")
 		log.Warning("[RPC Store] ----> Found APIs... beginning emergency load")
@@ -274,10 +279,15 @@ func (r *RPCStorageHandler) ReAttemptLogin(err error) bool {
 	rpcLoginMu.Unlock()
 
 	time.Sleep(time.Second * 3)
+	atomic.StoreUint32(&reLoginRunning, 0)
+
 	if strings.Contains(err.Error(), "Cannot obtain response during timeout") {
 		r.ReConnect()
 		return false
 	}
+
+	log.Warning("[RPC Store] Login failed, waiting 3s to re-attempt")
+
 	return r.Login()
 }
 
@@ -887,6 +897,8 @@ func (r *RPCStorageHandler) CheckForReload(orgId string) {
 		} else if !strings.Contains(err.Error(), "Cannot obtain response during") {
 			log.Warning("[RPC STORE] RPC Reload Checker encountered unexpected error: ", err)
 		}
+
+		time.Sleep(1 * time.Second)
 	} else if reload == true {
 		// Do the reload!
 		log.Warning("[RPC STORE] Received Reload instruction!")


### PR DESCRIPTION
Currently, it slams MDCB a lot, can cause a lot of login requests when there is an issue with login (like hybrid not enabled).

Additionally added timeout to CheckReload function, when the request returns error (and in this case does not apply internal timeout).

Improved cert pining logging