### PR TITLE
Fix panic caused by URL based versioning

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -1049,6 +1049,10 @@ func (a *APISpec) CheckSpecMatchesStatus(r *http.Request, rxPaths []URLSpec, mod
 }
 
 func (a *APISpec) getVersionFromRequest(r *http.Request) string {
+	if a.VersionData.NotVersioned {
+		return ""
+	}
+
 	switch a.VersionDefinition.Location {
 	case "header":
 		return r.Header.Get(a.VersionDefinition.Key)
@@ -1057,7 +1061,9 @@ func (a *APISpec) getVersionFromRequest(r *http.Request) string {
 		return r.URL.Query().Get(a.VersionDefinition.Key)
 
 	case "url":
-		uPath := r.URL.Path[len(a.Proxy.ListenPath):]
+		uPath := strings.TrimPrefix(r.URL.Path, a.Proxy.ListenPath)
+		uPath = strings.TrimPrefix(uPath, "/"+a.Slug)
+
 		// First non-empty part of the path is the version ID
 		for _, part := range strings.Split(uPath, "/") {
 			if part != "" {

--- a/handler_success.go
+++ b/handler_success.go
@@ -245,7 +245,7 @@ func (s *SuccessHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) *http
 	defer s.Base().UpdateRequestSession(r)
 
 	versionDef := s.Spec.VersionDefinition
-	if versionDef.Location == "url" && versionDef.StripPath {
+	if !s.Spec.VersionData.NotVersioned && versionDef.Location == "url" && versionDef.StripPath {
 		part := s.Spec.getVersionFromRequest(r)
 
 		log.Info("Stripping version from url: ", part)
@@ -294,7 +294,7 @@ func (s *SuccessHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) *http
 func (s *SuccessHandler) ServeHTTPWithCache(w http.ResponseWriter, r *http.Request) *http.Response {
 
 	versionDef := s.Spec.VersionDefinition
-	if versionDef.Location == "url" && versionDef.StripPath {
+	if !s.Spec.VersionData.NotVersioned && versionDef.Location == "url" && versionDef.StripPath {
 		part := s.Spec.getVersionFromRequest(r)
 
 		log.Info("Stripping version from url: ", part)


### PR DESCRIPTION
`getVersionFromRequest` do not get in account `NotVersioned` flag, and UI by default writes `a.VersionDefinition.Location` field, so this check for version inside url was running for all non-versioned APIs.

In case of cloud, it was causing panics, because nginx layer maps `slug` to `listenpath` and actual user URL does not contain listen path, and can be even smaller (which cause panic). Replaced manual array operation with `strings.TrimPrefix` which checks array bounds, and added support for stripping slug from URL too (for cloud case).