### PR TITLE
optimise configurations

### DIFF
--- a/install/data/tyk.self_contained.conf
+++ b/install/data/tyk.self_contained.conf
@@ -20,10 +20,10 @@
     "type": "",
     "ignored_ips": [],
     "normalise_urls": {
-        "enabled": true,
-        "normalise_uuids": true,
-        "normalise_numbers": true,
-        "custom_patterns": []
+      "enabled": true,
+      "normalise_uuids": true,
+      "normalise_numbers": true,
+      "custom_patterns": []
     }
   },
   "health_check": {
@@ -33,12 +33,12 @@
   "optimisations_use_async_session_write": true,
   "allow_master_keys": false,
   "policies": {
-  	"policy_source": "file",
-  	"policy_record_name": "policies"
-    },
+    "policy_source": "file",
+    "policy_record_name": "policies"
+  },
   "hash_keys": true,
   "suppress_redis_signal_reload": false,
-  "close_connections": true,
+  "close_connections": false,
   "enable_non_transactional_rate_limiter": true,
   "enable_sentinel_rate_limiter": false,
   "local_session_cache": {
@@ -54,7 +54,7 @@
     }
   },
   "http_server_options": {
-        "enable_websockets": true
+    "enable_websockets": true
   },
   "hostname": "",
   "enable_custom_domains": true,
@@ -73,5 +73,5 @@
   "bundle_base_url": "",
   "global_session_lifetime": 100,
   "force_global_session_lifetime": false,
-  "max_idle_connections_per_host": 100
+  "max_idle_connections_per_host": 500
 }

--- a/install/data/tyk.with_dash.conf
+++ b/install/data/tyk.with_dash.conf
@@ -5,9 +5,9 @@
   "template_path": "/opt/tyk-gateway/templates",
   "use_db_app_configs": true,
   "db_app_conf_options": {
-        "connection_string": "",
-        "node_is_segmented": false,
-        "tags": []
+    "connection_string": "",
+    "node_is_segmented": false,
+    "tags": []
   },
   "disable_dashboard_zeroconf": false,
   "app_path": "/opt/tyk-gateway/apps",
@@ -30,11 +30,11 @@
     "enable_geo_ip": false,
     "geo_ip_db_path": "",
     "normalise_urls": {
-          "enabled": true,
-          "normalise_uuids": true,
-          "normalise_numbers": true,
-          "custom_patterns": []
-      }
+      "enabled": true,
+      "normalise_uuids": true,
+      "normalise_numbers": true,
+      "custom_patterns": []
+    }
   },
   "health_check": {
     "enable_health_checks": false,
@@ -51,7 +51,7 @@
   "hash_keys": true,
   "suppress_redis_signal_reload": false,
   "use_redis_log": true,
-  "close_connections": true,
+  "close_connections": false,
   "enable_non_transactional_rate_limiter": true,
   "enable_sentinel_rate_limiter": false,
   "experimental_process_org_off_thread": false,
@@ -59,7 +59,7 @@
     "disable_cached_session_state": false
   },
   "http_server_options": {
-        "enable_websockets": true
+    "enable_websockets": true
   },
   "uptime_tests": {
     "disable": false,
@@ -87,5 +87,5 @@
   "bundle_base_url": "",
   "global_session_lifetime": 100,
   "force_global_session_lifetime": false,
-  "max_idle_connections_per_host": 100
+  "max_idle_connections_per_host": 500
 }

--- a/tyk.conf.example
+++ b/tyk.conf.example
@@ -13,7 +13,8 @@
     "username": "",
     "password": "",
     "database": 0,
-    "optimisation_max_idle": 500
+    "optimisation_max_idle": 2000,
+    "optimisation_max_active": 4000
   },
   "enable_analytics": false,
   "analytics_config": {
@@ -26,5 +27,7 @@
     "policy_source": "file"
   },
   "hash_keys": true,
-  "suppress_redis_signal_reload": false
+  "suppress_redis_signal_reload": false,
+  "force_global_session_lifetime": false,
+  "max_idle_connections_per_host": 500
 }


### PR DESCRIPTION
fixes #1799

Set `"max_idle_connections_per_host": 500` where previously was capped at 100.
Ensure `"close_connections":false` is the default.
