### PR TITLE
Strip version when listen path is stripped

### DIFF
--- a/handler_success.go
+++ b/handler_success.go
@@ -245,7 +245,8 @@ func (s *SuccessHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) *http
 	defer s.Base().UpdateRequestSession(r)
 
 	versionDef := s.Spec.VersionDefinition
-	if !s.Spec.VersionData.NotVersioned && versionDef.Location == "url" && versionDef.StripPath {
+	log.Info(versionDef)
+	if !s.Spec.VersionData.NotVersioned && versionDef.Location == "url" && s.Spec.Proxy.StripListenPath {
 		part := s.Spec.getVersionFromRequest(r)
 
 		log.Info("Stripping version from url: ", part)
@@ -294,7 +295,7 @@ func (s *SuccessHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) *http
 func (s *SuccessHandler) ServeHTTPWithCache(w http.ResponseWriter, r *http.Request) *http.Response {
 
 	versionDef := s.Spec.VersionDefinition
-	if !s.Spec.VersionData.NotVersioned && versionDef.Location == "url" && versionDef.StripPath {
+	if !s.Spec.VersionData.NotVersioned && versionDef.Location == "url" && s.Spec.Proxy.StripListenPath {
 		part := s.Spec.getVersionFromRequest(r)
 
 		log.Info("Stripping version from url: ", part)


### PR DESCRIPTION
Fixes #1818 

Previously the statement would never evaluate to true so version never stripped from path.