### PR TITLE
proxy insecure skip verify per api

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -384,9 +384,10 @@ type APIDefinition struct {
 		CheckHostAgainstUptimeTests bool                          `bson:"check_host_against_uptime_tests" json:"check_host_against_uptime_tests"`
 		ServiceDiscovery            ServiceDiscoveryConfiguration `bson:"service_discovery" json:"service_discovery"`
 		Transport                   struct {
-			SSLCipherSuites []string `bson:"ssl_ciphers" json:"ssl_ciphers"`
-			SSLMinVersion   uint16   `bson:"ssl_min_version" json:"ssl_min_version"`
-			ProxyURL        string   `bson:"proxy_url" json:"proxy_url"`
+			SSLInsecureSkipVerify bool     `bson:"ssl_insecure_skip_verify" json:"ssl_insecure_skip_verify"`
+			SSLCipherSuites       []string `bson:"ssl_ciphers" json:"ssl_ciphers"`
+			SSLMinVersion         uint16   `bson:"ssl_min_version" json:"ssl_min_version"`
+			ProxyURL              string   `bson:"proxy_url" json:"proxy_url"`
 		} `bson:"transport" json:"transport"`
 	} `bson:"proxy" json:"proxy"`
 	DisableRateLimit          bool                   `bson:"disable_rate_limit" json:"disable_rate_limit"`

--- a/mw_js_plugin.go
+++ b/mw_js_plugin.go
@@ -504,6 +504,10 @@ func (j *JSVM) LoadTykJSApi() {
 			tr.TLSClientConfig.InsecureSkipVerify = true
 		}
 
+		if j.Spec.Proxy.Transport.SSLInsecureSkipVerify {
+			tr.TLSClientConfig.InsecureSkipVerify = true
+		}
+
 		tr.DialTLS = dialTLSPinnedCheck(j.Spec, tr.TLSClientConfig)
 
 		tr.Proxy = proxyFromAPI(j.Spec)

--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -438,6 +438,10 @@ func httpTransport(timeOut int, rw http.ResponseWriter, req *http.Request, p *Re
 		transport.TLSClientConfig.InsecureSkipVerify = true
 	}
 
+	if p.TykAPISpec.Proxy.Transport.SSLInsecureSkipVerify {
+		transport.TLSClientConfig.InsecureSkipVerify = true
+	}
+
 	// When request routed through the proxy `DialTLS` is not used, and only VerifyPeerCertificate is supported
 	// The reason behind two separate checks is that `DialTLS` supports specifying public keys per hostname, and `VerifyPeerCertificate` only global ones, e.g. `*`
 	if proxyURL, _ := transport.Proxy(req); proxyURL != nil {


### PR DESCRIPTION
fixes #1837

This feature allows control at the API level of which upstreams to skip
insecure verification.

Update `TykMakeHttpRequest` to support proxy insecure verification as per
apidefinition