### PR TITLE
JSVM bundle fix

### DIFF
--- a/api_loader.go
+++ b/api_loader.go
@@ -218,7 +218,10 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 	}).Debug("Loading Middleware")
 	var mwPaths []string
 	mwPaths, mwAuthCheckFunc, mwPreFuncs, mwPostFuncs, mwPostAuthCheckFuncs, mwDriver = loadCustomMiddleware(spec)
-	spec.JSVM.LoadJSPaths(mwPaths, prefix)
+
+	if spec.CustomMiddleware.Driver == apidef.OttoDriver {
+		spec.JSVM.LoadJSPaths(mwPaths, prefix)
+	}
 
 	if spec.EnableBatchRequestSupport {
 		addBatchEndpoint(spec, subrouter)

--- a/api_loader.go
+++ b/api_loader.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"crypto/md5"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -196,27 +199,26 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 
 	var mwDriver apidef.MiddlewareDriver
 
-	if EnableCoProcess {
-		loadBundle(spec)
-	}
-
-	// TODO: use config.Global.EnableCoProcess
-	if config.Global().EnableJSVM || EnableCoProcess {
-		mainLog.WithFields(logrus.Fields{
-			"api_name": spec.Name,
-		}).Debug("Loading Middleware")
-
-		var mwPaths []string
-		mwPaths, mwAuthCheckFunc, mwPreFuncs, mwPostFuncs, mwPostAuthCheckFuncs, mwDriver = loadCustomMiddleware(spec)
-
-		if config.Global().EnableJSVM && mwDriver == apidef.OttoDriver {
-			var pathPrefix string
-			if spec.CustomMiddlewareBundle != "" {
-				pathPrefix = spec.APIID + "-" + spec.CustomMiddlewareBundle
-			}
-			spec.JSVM.LoadJSPaths(mwPaths, pathPrefix)
+	var prefix string
+	if spec.CustomMiddlewareBundle != "" {
+		if err := loadBundle(spec); err != nil {
+			mainLog.WithFields(logrus.Fields{
+				"api_name": spec.Name,
+			}).Error("Couldn't load bundle")
 		}
+		tykBundlePath := filepath.Join(config.Global().MiddlewarePath, "bundles")
+		bundleNameHash := md5.New()
+		io.WriteString(bundleNameHash, spec.CustomMiddlewareBundle)
+		bundlePath := fmt.Sprintf("%s_%x", spec.APIID, bundleNameHash.Sum(nil))
+		prefix = filepath.Join(tykBundlePath, bundlePath)
 	}
+
+	mainLog.WithFields(logrus.Fields{
+		"api_name": spec.Name,
+	}).Debug("Loading Middleware")
+	var mwPaths []string
+	mwPaths, mwAuthCheckFunc, mwPreFuncs, mwPostFuncs, mwPostAuthCheckFuncs, mwDriver = loadCustomMiddleware(spec)
+	spec.JSVM.LoadJSPaths(mwPaths, prefix)
 
 	if spec.EnableBatchRequestSupport {
 		addBatchEndpoint(spec, subrouter)

--- a/mw_js_plugin.go
+++ b/mw_js_plugin.go
@@ -359,11 +359,10 @@ func (j *JSVM) Init(spec *APISpec) {
 }
 
 // LoadJSPaths will load JS classes and functionality in to the VM by file
-func (j *JSVM) LoadJSPaths(paths []string, pathPrefix string) {
-	tykBundlePath := filepath.Join(config.Global().MiddlewarePath, "bundles")
+func (j *JSVM) LoadJSPaths(paths []string, prefix string) {
 	for _, mwPath := range paths {
-		if pathPrefix != "" {
-			mwPath = filepath.Join(tykBundlePath, pathPrefix, mwPath)
+		if prefix != "" {
+			mwPath = filepath.Join(prefix, mwPath)
 		}
 		log.WithFields(logrus.Fields{
 			"prefix": "jsvm",


### PR DESCRIPTION
This modifies the JSVM behavior to use `loadBundle` (implemented in `coprocess_bundle.go` and used by rich plugins).
Fixes #1839.