### PR TITLE
Check if claims expiry longer than session

### DIFF
--- a/mw_jwt.go
+++ b/mw_jwt.go
@@ -284,6 +284,12 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 			log.Error("Could not find a valid policy to apply to this token!")
 			return errors.New("Key not authorized: no matching policy"), http.StatusForbidden
 		}
+		//override session expiry with JWT
+		if f, ok := claims["exp"].(float64); ok {
+			if int64(f) != session.Expires {
+				session.Expires = int64(f)
+			}
+		}
 
 		session = newSession
 		session.MetaData = map[string]interface{}{"TykJWTSessionID": sessionID}
@@ -334,6 +340,13 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 				k.reportLoginFailure(baseFieldData, r)
 				log.WithError(err).Error("Could not apply new policy from JWT to session")
 				return errors.New("Key not authorized: could not apply new policy"), http.StatusForbidden
+			}
+
+			//override session expiry with JWT
+			if f, ok := claims["exp"].(float64); ok {
+				if int64(f) != session.Expires {
+					session.Expires = int64(f)
+				}
 			}
 
 			go SessionCache.Set(session.KeyHash(), session, cache.DefaultExpiration)
@@ -486,7 +499,8 @@ func (k *JWTMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _
 func (k *JWTMiddleware) timeValidateJWTClaims(c jwt.MapClaims) *jwt.ValidationError {
 	vErr := new(jwt.ValidationError)
 	now := time.Now().Unix()
-
+	// The claims below are optional, by default, so if they are set to the
+	// default value in Go, let's not fail the verification for them.
 	if !c.VerifyExpiresAt(now-int64(k.Spec.JWTExpiresAtValidationSkew), false) {
 		vErr.Inner = errors.New("token has expired")
 		vErr.Errors |= jwt.ValidationErrorExpired

--- a/mw_jwt.go
+++ b/mw_jwt.go
@@ -287,7 +287,7 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 		//override session expiry with JWT
 		if f, ok := claims["exp"].(float64); ok {
 			if int64(f) != session.Expires {
-				session.Expires = int64(f)
+				newSession.Expires = int64(f)
 			}
 		}
 

--- a/mw_jwt.go
+++ b/mw_jwt.go
@@ -284,9 +284,9 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 			log.Error("Could not find a valid policy to apply to this token!")
 			return errors.New("Key not authorized: no matching policy"), http.StatusForbidden
 		}
-		//override session expiry with JWT
+		//override session expiry with JWT if longer lived
 		if f, ok := claims["exp"].(float64); ok {
-			if int64(f) != session.Expires {
+			if int64(f)-newSession.Expires > 0 {
 				newSession.Expires = int64(f)
 			}
 		}
@@ -342,9 +342,9 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 				return errors.New("Key not authorized: could not apply new policy"), http.StatusForbidden
 			}
 
-			//override session expiry with JWT
+			//override session expiry with JWT if longer lived
 			if f, ok := claims["exp"].(float64); ok {
-				if int64(f) != session.Expires {
+				if int64(f)-session.Expires > 0 {
 					session.Expires = int64(f)
 				}
 			}

--- a/mw_jwt_test.go
+++ b/mw_jwt_test.go
@@ -616,7 +616,7 @@ func TestJWTSessionRSAWithRawSourceInvalidPolicyID(t *testing.T) {
 		ts.Run(t, test.TestCase{
 			Headers:   authHeaders,
 			Code:      http.StatusForbidden,
-			BodyMatch: "Key not authorized: no matching policy",
+			BodyMatch: "key not authorized: no matching policy",
 		})
 	})
 }
@@ -899,8 +899,8 @@ func TestJWTExistingSessionRSAWithRawSourceInvalidPolicyID(t *testing.T) {
 	t.Run("Request with invalid policy in JWT", func(t *testing.T) {
 		ts.Run(t, test.TestCase{
 			Headers:   authHeaders,
+			BodyMatch: "key not authorized: no matching policy",
 			Code:      http.StatusForbidden,
-			BodyMatch: "Key not authorized: no matching policy",
 		})
 	})
 }


### PR DESCRIPTION
Fixes #1805 

At the moment only does this for when JWT is paired to policy.

In case of directly being tied to internal token i.e. with kid header the internal token expiry takes precedence