### PR TITLE
Handling propagation of keys to slaves on creation and update events in RPC mode

### DIFF
--- a/api.go
+++ b/api.go
@@ -387,20 +387,24 @@ func handleAddKey(keyName, hashedName, sessionString, apiID string) {
 	json.Unmarshal([]byte(sessionString), &sess)
 
 	sess.LastUpdated = strconv.Itoa(int(time.Now().Unix()))
-	//mw.ApplyPolicies(keyName, &sess)
-	err := mw.Spec.SessionManager.UpdateSession(hashedName, &sess, 0, true)
+	var err error
+	if config.Global().HashKeys {
+		err = mw.Spec.SessionManager.UpdateSession(hashedName, &sess, 0, true)
+	} else {
+		err = mw.Spec.SessionManager.UpdateSession(keyName, &sess, 0, false)
+	}
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "api",
 			"key":    keyName,
 			"status": "fail",
 			"err":    err,
-		}).Error("Failed to update hashed key.")
+		}).Error("Failed to update key.")
 	}
 
 	log.WithFields(logrus.Fields{
 		"prefix": "RPC",
-		"key":    keyName,
+		"key":    obfuscateKey(keyName),
 		"status": "ok",
 	}).Info("Updated hashed key in slave storage.")
 }

--- a/templates/default_webhook.json
+++ b/templates/default_webhook.json
@@ -6,7 +6,7 @@
     "response_code": "{{.Meta.HostInfo.ResponseCode}}",
     "tcp_error": "{{.Meta.HostInfo.IsTCPError}}",
     "host": "{{.Meta.HostInfo.MetaData.host_name}}",
-    "api_id": "{{.Meta.HostInfo.MetaData.api_id}}",
+    "api_id": "{{.Meta.HostInfo.MetaData.api_id}}"
 }
 {{ else if eq .Type "HostUp"}}
 {
@@ -16,7 +16,7 @@
     "response_code": "{{.Meta.HostInfo.ResponseCode}}",
     "tcp_error": "{{.Meta.HostInfo.IsTCPError}}",
     "host": "{{.Meta.HostInfo.MetaData.host_name}}",
-    "api_id": "{{.Meta.HostInfo.MetaData.api_id}}",
+    "api_id": "{{.Meta.HostInfo.MetaData.api_id}}"
 }
 {{ else if eq .Type "TriggerExceeded"}}
 {

--- a/templates/default_webhook.json
+++ b/templates/default_webhook.json
@@ -6,7 +6,7 @@
     "response_code": "{{.Meta.HostInfo.ResponseCode}}",
     "tcp_error": "{{.Meta.HostInfo.IsTCPError}}",
     "host": "{{.Meta.HostInfo.MetaData.host_name}}",
-    "api_id": "{{.Meta.HostInfo.MetaData.api_id}}"
+    "api_id": "{{.Meta.HostInfo.MetaData.api_id}}",
 }
 {{ else if eq .Type "HostUp"}}
 {
@@ -16,7 +16,7 @@
     "response_code": "{{.Meta.HostInfo.ResponseCode}}",
     "tcp_error": "{{.Meta.HostInfo.IsTCPError}}",
     "host": "{{.Meta.HostInfo.MetaData.host_name}}",
-    "api_id": "{{.Meta.HostInfo.MetaData.api_id}}"
+    "api_id": "{{.Meta.HostInfo.MetaData.api_id}}",
 }
 {{ else if eq .Type "TriggerExceeded"}}
 {


### PR DESCRIPTION
Part of https://github.com/TykTechnologies/tyk-sink/issues/26

Currently in RPC we simply flush cache for all key events that are handled and populate local Redis on first use of a key.

This change now means that on key creation and update events the Redis cache in the slave gateway will have the key prepopulated in it's storage before any calls are made.