### PR TITLE
Add delay to fix test failing in CI all the time

### DIFF
--- a/gateway_test.go
+++ b/gateway_test.go
@@ -1251,13 +1251,13 @@ func TestRateLimitForAPIAndRateLimitAndQuotaCheck(t *testing.T) {
 		spec.OrgID = "default"
 		spec.GlobalRateLimit = apidef.GlobalRateLimit{
 			Per:  60,
-			Rate: 2,
+			Rate: 4,
 		}
 		spec.Proxy.ListenPath = "/"
 	})
 
 	sess1token := createSession(func(s *user.SessionState) {
-		s.Rate = 1
+		s.Rate = 3
 		s.Per = 60
 	})
 
@@ -1267,6 +1267,8 @@ func TestRateLimitForAPIAndRateLimitAndQuotaCheck(t *testing.T) {
 	})
 
 	ts.Run(t, []test.TestCase{
+		{Headers: map[string]string{"Authorization": sess1token}, Code: http.StatusOK, Path: "/"},
+		{Headers: map[string]string{"Authorization": sess1token}, Code: http.StatusOK, Path: "/"},
 		{Headers: map[string]string{"Authorization": sess1token}, Code: http.StatusOK, Path: "/"},
 		{Headers: map[string]string{"Authorization": sess1token}, Code: http.StatusTooManyRequests, Path: "/"},
 		{Headers: map[string]string{"Authorization": sess2token}, Code: http.StatusOK, Path: "/"},

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -1250,14 +1250,14 @@ func TestRateLimitForAPIAndRateLimitAndQuotaCheck(t *testing.T) {
 		spec.DisableRateLimit = false
 		spec.OrgID = "default"
 		spec.GlobalRateLimit = apidef.GlobalRateLimit{
-			Per:  60,
-			Rate: 4,
+			Per:  2,
+			Rate: 60,
 		}
 		spec.Proxy.ListenPath = "/"
 	})
 
 	sess1token := createSession(func(s *user.SessionState) {
-		s.Rate = 3
+		s.Rate = 1
 		s.Per = 60
 	})
 
@@ -1267,11 +1267,9 @@ func TestRateLimitForAPIAndRateLimitAndQuotaCheck(t *testing.T) {
 	})
 
 	ts.Run(t, []test.TestCase{
-		{Headers: map[string]string{"Authorization": sess1token}, Code: http.StatusOK, Path: "/"},
-		{Headers: map[string]string{"Authorization": sess1token}, Code: http.StatusOK, Path: "/"},
-		{Headers: map[string]string{"Authorization": sess1token}, Code: http.StatusOK, Path: "/"},
+		{Headers: map[string]string{"Authorization": sess1token}, Code: http.StatusOK, Path: "/", Delay: 100 * time.Millisecond},
 		{Headers: map[string]string{"Authorization": sess1token}, Code: http.StatusTooManyRequests, Path: "/"},
-		{Headers: map[string]string{"Authorization": sess2token}, Code: http.StatusOK, Path: "/"},
+		{Headers: map[string]string{"Authorization": sess2token}, Code: http.StatusOK, Path: "/", Delay: 100 * time.Millisecond},
 		{Headers: map[string]string{"Authorization": sess2token}, Code: http.StatusTooManyRequests, Path: "/"},
 	}...)
 }


### PR DESCRIPTION
Added a 100 millisecond delay to let the sentinel token be set in redis for each token in order to stop test failing.