### PR TITLE
PoC - DO NOT MERGE: native golang plugins

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -68,6 +68,7 @@ const (
 	RequestTracked
 	RequestNotTracked
 	ValidateJSONRequest
+	PrePluginRequest
 )
 
 // RequestStatus is a custom type to avoid collisions
@@ -99,6 +100,7 @@ const (
 	StatusRequesTracked            RequestStatus = "Request Tracked"
 	StatusRequestNotTracked        RequestStatus = "Request Not Tracked"
 	StatusValidateJSON             RequestStatus = "Validate JSON"
+	StatusPrePlugin                RequestStatus = "Custom Pre Plugin"
 )
 
 // URLSpec represents a flattened specification for URLs, used to check if a proxy URL
@@ -123,6 +125,7 @@ type URLSpec struct {
 	TrackEndpoint             apidef.TrackEndpointMeta
 	DoNotTrackEndpoint        apidef.TrackEndpointMeta
 	ValidatePathMeta          apidef.ValidatePathMeta
+	PrePlugin                 apidef.PrePluginMeta
 }
 
 type TransformSpec struct {
@@ -785,6 +788,20 @@ func (a APIDefinitionLoader) compileValidateJSONPathspathSpec(paths []apidef.Val
 	return urlSpec
 }
 
+func (a APIDefinitionLoader) compilePrePluginPathSpec(paths []apidef.PrePluginMeta, stat URLStatus) []URLSpec {
+	urlSpec := []URLSpec{}
+
+	for _, stringSpec := range paths {
+		newSpec := URLSpec{}
+		a.generateRegex(stringSpec.Path, &newSpec, stat)
+		newSpec.PrePlugin = stringSpec
+
+		urlSpec = append(urlSpec, newSpec)
+	}
+
+	return urlSpec
+}
+
 func (a APIDefinitionLoader) compileUnTrackedEndpointPathspathSpec(paths []apidef.TrackEndpointMeta, stat URLStatus) []URLSpec {
 	urlSpec := []URLSpec{}
 
@@ -821,6 +838,7 @@ func (a APIDefinitionLoader) getExtendedPathSpecs(apiVersionDef apidef.VersionIn
 	trackedPaths := a.compileTrackedEndpointPathspathSpec(apiVersionDef.ExtendedPaths.TrackEndpoints, RequestTracked)
 	unTrackedPaths := a.compileUnTrackedEndpointPathspathSpec(apiVersionDef.ExtendedPaths.DoNotTrackEndpoints, RequestNotTracked)
 	validateJSON := a.compileValidateJSONPathspathSpec(apiVersionDef.ExtendedPaths.ValidateJSON, ValidateJSONRequest)
+	prePlugin := a.compilePrePluginPathSpec(apiVersionDef.ExtendedPaths.PrePlugin, PrePluginRequest)
 
 	combinedPath := []URLSpec{}
 	combinedPath = append(combinedPath, ignoredPaths...)
@@ -842,6 +860,7 @@ func (a APIDefinitionLoader) getExtendedPathSpecs(apiVersionDef apidef.VersionIn
 	combinedPath = append(combinedPath, trackedPaths...)
 	combinedPath = append(combinedPath, unTrackedPaths...)
 	combinedPath = append(combinedPath, validateJSON...)
+	combinedPath = append(combinedPath, prePlugin...)
 
 	return combinedPath, len(whiteListPaths) > 0
 }
@@ -898,6 +917,8 @@ func (a *APISpec) getURLStatus(stat URLStatus) RequestStatus {
 		return StatusRequestNotTracked
 	case ValidateJSONRequest:
 		return StatusValidateJSON
+	case PrePluginRequest:
+		return StatusPrePlugin
 
 	default:
 		log.Error("URL Status was not one of Ignored, Blacklist or WhiteList! Blocking.")
@@ -1068,6 +1089,10 @@ func (a *APISpec) CheckSpecMatchesStatus(r *http.Request, rxPaths []URLSpec, mod
 		case ValidateJSONRequest:
 			if r.Method == v.ValidatePathMeta.Method {
 				return true, &v.ValidatePathMeta
+			}
+		case PrePluginRequest:
+			if r.Method == v.PrePlugin.Method {
+				return true, &v.PrePlugin
 			}
 		}
 	}

--- a/api_loader.go
+++ b/api_loader.go
@@ -295,6 +295,8 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 		mwAppendEnabled(&chainArray, &RequestSizeLimitMiddleware{baseMid})
 		mwAppendEnabled(&chainArray, &TrackEndpointMiddleware{baseMid})
 
+		mwAppendEnabled(&chainArray, &PrePlugin{BaseMiddleware: baseMid})
+
 		mwAppendEnabled(&chainArray, &TransformMiddleware{baseMid})
 		mwAppendEnabled(&chainArray, &TransformJQMiddleware{baseMid})
 		mwAppendEnabled(&chainArray, &TransformHeaders{BaseMiddleware: baseMid})
@@ -342,6 +344,8 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 		mwAppendEnabled(&chainArray, &RequestSizeLimitMiddleware{baseMid})
 		mwAppendEnabled(&chainArray, &MiddlewareContextVars{BaseMiddleware: baseMid})
 		mwAppendEnabled(&chainArray, &TrackEndpointMiddleware{baseMid})
+
+		mwAppendEnabled(&chainArray, &PrePlugin{BaseMiddleware: baseMid})
 
 		// Select the keying method to use for setting session states
 		if mwAppendEnabled(&authArray, &Oauth2KeyExists{baseMid}) {

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -7,6 +7,8 @@ import (
 	"github.com/lonelycode/osin"
 	"gopkg.in/mgo.v2/bson"
 
+	"github.com/TykTechnologies/tyk/plugin"
+
 	"time"
 
 	"github.com/TykTechnologies/gojsonschema"
@@ -188,6 +190,15 @@ type ValidatePathMeta struct {
 	ErrorResponseCode int `bson:"error_response_code" json:"error_response_code"`
 }
 
+type PrePluginMeta struct {
+	Path   string `bson:"path" json:"path"`
+	Method string `bson:"method" json:"method"`
+	// location of plugin so file
+	Plugin   string `bson:"plugin" json:"plugin"`
+	Fn       string `bson:"fn" json:"fn"`
+	Executor plugin.Executor
+}
+
 type ExtendedPathsSet struct {
 	Ignored                 []EndPointMeta        `bson:"ignored" json:"ignored,omitempty"`
 	WhiteList               []EndPointMeta        `bson:"white_list" json:"white_list,omitempty"`
@@ -208,6 +219,7 @@ type ExtendedPathsSet struct {
 	TrackEndpoints          []TrackEndpointMeta   `bson:"track_endpoints" json:"track_endpoints,omitempty"`
 	DoNotTrackEndpoints     []TrackEndpointMeta   `bson:"do_not_track_endpoints" json:"do_not_track_endpoints,omitempty"`
 	ValidateJSON            []ValidatePathMeta    `bson:"validate_json" json:"validate_json,omitempty"`
+	PrePlugin               []PrePluginMeta       `bson:"pre_plugin" json:"pre_plugin"`
 }
 
 type VersionInfo struct {

--- a/apps/foo.json
+++ b/apps/foo.json
@@ -1,0 +1,42 @@
+{
+  "name": "Foo",
+  "api_id": "foo",
+  "org_id": "default",
+  "definition": {
+    "location": "",
+    "key": ""
+  },
+  "use_keyless": true,
+  "auth": {
+    "auth_header_name": ""
+  },
+  "version_data": {
+    "not_versioned": true,
+    "versions": {
+      "Default": {
+        "name": "Default",
+        "expires": "3000-01-02 15:04",
+        "use_extended_paths": true,
+        "extended_paths": {
+          "ignored": [],
+          "white_list": [],
+          "black_list": [],
+          "pre_plugin": [
+            {
+              "path": "get",
+              "method": "GET",
+              "plugin": "./plugin/foo/foo.so",
+              "fn": "Fooer"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "proxy": {
+    "listen_path": "/foo/",
+    "target_url": "http://httpbin.org/",
+    "strip_listen_path": true
+  },
+  "do_not_track": true
+}

--- a/mw_pre_plugin.go
+++ b/mw_pre_plugin.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"net/http"
+	"plugin"
+
+	"github.com/pkg/errors"
+
+	"github.com/TykTechnologies/tyk/apidef"
+	nativePlugin "github.com/TykTechnologies/tyk/plugin"
+)
+
+// TransformMiddleware is a middleware that will apply a template to a request body to transform it's contents ready for an upstream API
+type PrePlugin struct {
+	BaseMiddleware
+	Executor nativePlugin.Executor
+}
+
+func (t *PrePlugin) Name() string {
+	return "PrePlugin"
+}
+
+func (t *PrePlugin) EnabledForSpec() bool {
+	for _, version := range t.Spec.VersionData.Versions {
+		if len(version.ExtendedPaths.PrePlugin) == 0 {
+			return false
+		}
+
+		for _, p := range version.ExtendedPaths.PrePlugin {
+			plug, err := plugin.Open(p.Plugin)
+			if err != nil {
+				log.WithError(err).Fatal("unable to open plugin")
+			}
+
+			pluginSymbol, err := plug.Lookup(p.Fn)
+			if err != nil {
+				log.WithError(err).Fatal("unable to lookup plugin")
+			}
+
+			executor, ok := pluginSymbol.(nativePlugin.Executor)
+			if !ok {
+				log.WithError(err).Fatal("plugin symbol not of executor type")
+			}
+
+			t.Executor = executor
+		}
+
+		return true
+	}
+	return false
+}
+
+// ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
+func (t *PrePlugin) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
+
+	_, versionPaths, _, _ := t.Spec.Version(r)
+	found, meta := t.Spec.CheckSpecMatchesStatus(r, versionPaths, PrePluginRequest)
+	if !found {
+		return nil, http.StatusOK
+	}
+
+	_, ok := meta.(*apidef.PrePluginMeta)
+	if !ok {
+		return errors.New("not of type PrePluginMeta"), http.StatusInternalServerError
+	}
+
+	if err := t.Executor.Do(r); err != nil {
+		return errors.Wrap(err, "unable to execute function"), http.StatusInternalServerError
+	}
+
+	return nil, http.StatusOK
+}

--- a/plugin/foo/foo.go
+++ b/plugin/foo/foo.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"net/http"
+)
+
+type Foo struct{}
+
+// Do sets `Foo: Bar` on a request header
+func (f Foo) Do(r *http.Request) error {
+	r.Header.Set("Foo", "Bar")
+
+	return nil
+}
+
+var Fooer Foo

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -1,0 +1,7 @@
+package plugin
+
+import "net/http"
+
+type Executor interface {
+	Do(r *http.Request) error
+}


### PR DESCRIPTION
This example implements a native pre-plugin

1. build out your custom middleware e.g. `plugin/foo/foo.go`
2. compile custom middleware into Shared Object e.g. `go build -buildmode=plugin -o plugin/foo/foo.so plugin/foo/foo.go`
3. configure API definition e.g. `apps/foo.json`
4. Hot reload / restart gateway & test:

```
curl http://localhost:8080/foo/get
{
  "args": {},
  "headers": {
    "Accept": "*/*",
    "Accept-Encoding": "gzip",
    "Connection": "close",
    "Foo": "Bar",                           <----------- Injected into request
    "Host": "httpbin.org",
    "User-Agent": "curl/7.61.0"
  },
  "origin": "::1, 5.70.19.189",
  "url": "http://httpbin.org/get"
}
```