### PR TITLE
Fix quota calculation for Key API

### DIFF
--- a/api.go
+++ b/api.go
@@ -327,7 +327,7 @@ func handleGetDetail(sessionKey, apiID string, byHash bool) (interface{}, int) {
 		quotaKey = QuotaKeyPrefix + sessionKey
 	}
 
-	if usedQuota, err := sessionManager.Store().GetKey("apikey-" + quotaKey); err == nil {
+	if usedQuota, err := sessionManager.Store().GetRawKey(quotaKey); err == nil {
 		qInt, _ := strconv.Atoi(usedQuota)
 		remaining := session.QuotaMax - int64(qInt)
 

--- a/api.go
+++ b/api.go
@@ -327,7 +327,7 @@ func handleGetDetail(sessionKey, apiID string, byHash bool) (interface{}, int) {
 		quotaKey = QuotaKeyPrefix + sessionKey
 	}
 
-	if usedQuota, err := sessionManager.Store().GetKey(quotaKey); err == nil {
+	if usedQuota, err := sessionManager.Store().GetKey("apikey-" + quotaKey); err == nil {
 		qInt, _ := strconv.Atoi(usedQuota)
 		remaining := session.QuotaMax - int64(qInt)
 

--- a/api_test.go
+++ b/api_test.go
@@ -208,7 +208,7 @@ func TestKeyHandler(t *testing.T) {
 			},
 			{
 				Method: "GET",
-				Path:   "/sample/?key=wrong_key_id",
+				Path:   "/sample/?authorization=wrong_key_id",
 				Code:   403,
 			},
 			{

--- a/api_test.go
+++ b/api_test.go
@@ -133,7 +133,10 @@ func TestKeyHandler(t *testing.T) {
 	ts := newTykTestServer()
 	defer ts.Close()
 
-	buildAndLoadAPI()
+	buildAndLoadAPI(func(spec *APISpec) {
+		spec.UseKeylessAccess = false
+		spec.Auth.UseParam = true
+	})
 
 	// Access right not specified
 	masterKey := createStandardSession()
@@ -150,7 +153,7 @@ func TestKeyHandler(t *testing.T) {
 	policiesMu.Lock()
 	policiesByID["abc_policy"] = user.Policy{
 		Active:   true,
-		QuotaMax: 1234567890,
+		QuotaMax: 5,
 	}
 	policiesMu.Unlock()
 	withPolicy := createStandardSession()
@@ -204,11 +207,28 @@ func TestKeyHandler(t *testing.T) {
 				Code:      200,
 			},
 			{
+				Method: "GET",
+				Path:   "/sample/?key=wrong_key_id",
+				Code:   403,
+			},
+			{
+				Method: "GET",
+				Path:   "/sample/?authorization=my_key_id",
+				Code:   200,
+			},
+			{
 				Method:    "GET",
 				Path:      "/tyk/keys/my_key_id" + "?api_id=test",
 				AdminAuth: true,
 				Code:      200,
-				BodyMatch: `"quota_max":1234567890`,
+				BodyMatch: `"quota_max":5`,
+			},
+			{
+				Method:    "GET",
+				Path:      "/tyk/keys/my_key_id" + "?api_id=test",
+				AdminAuth: true,
+				Code:      200,
+				BodyMatch: `"quota_remaining":4`,
 			},
 		}...)
 	})

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -503,7 +503,7 @@ const sampleAPI = `{
     },
     "auth": {
         "auth_header_name": "authorization"
-    },
+	},
     "version_data": {
         "not_versioned": true,
         "versions": {


### PR DESCRIPTION
Fixes:
https://github.com/TykTechnologies/tyk/issues/1879

It was not using "quota-" prefix. 