### PR TITLE
per API partitions option added

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -204,6 +204,9 @@ func (t BaseMiddleware) UpdateRequestSession(r *http.Request) bool {
 // will overwrite the session state to use the policy values.
 func (t BaseMiddleware) ApplyPolicies(key string, session *user.SessionState) error {
 	rights := session.AccessRights
+	if rights == nil {
+		rights = make(map[string]user.AccessDefinition)
+	}
 	tags := make(map[string]bool)
 	didQuota, didRateLimit, didACL := false, false, false
 	didPerAPI := make(map[string]bool)
@@ -225,69 +228,82 @@ func (t BaseMiddleware) ApplyPolicies(key string, session *user.SessionState) er
 			return err
 		}
 
-		if policy.Partitions.Quota || policy.Partitions.RateLimit || policy.Partitions.Acl {
-			// This is a partitioned policy, only apply what is active
-			if policy.Partitions.PerAPI {
-				// new logic when you can specify quota or rate in more than one policy but for different APIs
-				// this new option will be applied to session ONLY when policy.Partitions.Acl == true
-				// as this is where we merging access rights from all policies into session
-				for apiID, accessRights := range policy.AccessRights {
-					if didPerAPI[apiID] {
-						err := fmt.Errorf("cannot apply multiple policies for API: %s", apiID)
-						log.Error(err)
-						return err
-					}
-					didPerAPI[apiID] = true
+		if policy.Partitions.PerAPI &&
+			(policy.Partitions.Quota || policy.Partitions.RateLimit || policy.Partitions.Acl) {
+			err := fmt.Errorf("cannot apply policy %s which has per_api and any of partitions set", policy.ID)
+			log.Error(err)
+			return err
+		}
 
-					// check if we already have limit on API level specified when policy was created
-					if accessRights.Limit != nil {
-						continue
-					}
+		if policy.Partitions.PerAPI {
+			// new logic when you can specify quota or rate in more than one policy but for different APIs
+			if didQuota || didRateLimit || didACL { // no other partitions allowed
+				err := fmt.Errorf("cannot apply multiple policies when some have per_api set and some are partitioned")
+				log.Error(err)
+				return err
+			}
+			for apiID, accessRights := range policy.AccessRights {
+				// check if limit was already set for this API by other policy assigned to key
+				if didPerAPI[apiID] {
+					err := fmt.Errorf("cannot apply multiple policies for API: %s", apiID)
+					log.Error(err)
+					return err
+				}
 
+				// check if we already have limit on API level specified when policy was created
+				if accessRights.Limit == nil {
 					// limit was not specified on API level so we will populate it from policy
-					apiLimitFromPolicy := &user.APILimit{
-						QuotaMax:    -1,
-						SetByPolicy: true,
+					accessRights.Limit = &user.APILimit{
+						QuotaMax:         policy.QuotaMax,
+						QuotaRenewalRate: policy.QuotaRenewalRate,
+						Rate:             policy.Rate,
+						Per:              policy.Per,
+						SetByPolicy:      true,
 					}
-					if policy.Partitions.Quota {
-						apiLimitFromPolicy.QuotaMax = policy.QuotaMax
-						apiLimitFromPolicy.QuotaRenewalRate = policy.QuotaRenewalRate
-					}
-					if policy.Partitions.RateLimit {
-						apiLimitFromPolicy.Rate = policy.Rate
-						apiLimitFromPolicy.Per = policy.Per
-					}
-					accessRights.Limit = apiLimitFromPolicy
-					policy.AccessRights[apiID] = accessRights
-				}
-			} else {
-				// legacy logic when you can specify quota or rate only in no more than one policy
-				if policy.Partitions.Quota {
-					if didQuota {
-						err := fmt.Errorf("cannot apply multiple quota policies")
-						log.Error(err)
-						return err
-					}
-					didQuota = true
-					// Quotas
-					session.QuotaMax = policy.QuotaMax
-					session.QuotaRenewalRate = policy.QuotaRenewalRate
 				}
 
-				if policy.Partitions.RateLimit {
-					if didRateLimit {
-						err := fmt.Errorf("cannot apply multiple rate limit policies")
-						log.Error(err)
-						return err
-					}
-					didRateLimit = true
-					// Rate limiting
-					session.Allowance = policy.Rate // This is a legacy thing, merely to make sure output is consistent. Needs to be purged
-					session.Rate = policy.Rate
-					session.Per = policy.Per
-					if policy.LastUpdated != "" {
-						session.LastUpdated = policy.LastUpdated
-					}
+				// adjust policy access right with limit on API level
+				policy.AccessRights[apiID] = accessRights
+
+				// overwrite session access right for this API
+				rights[apiID] = accessRights
+
+				// identify that limit for that API is set (to allow set it only once)
+				didPerAPI[apiID] = true
+			}
+		} else if policy.Partitions.Quota || policy.Partitions.RateLimit || policy.Partitions.Acl {
+			// This is a partitioned policy, only apply what is active
+			// legacy logic when you can specify quota or rate only in no more than one policy
+			if len(didPerAPI) > 0 { // no policies with per_api set allowed
+				err := fmt.Errorf("cannot apply multiple policies when some are partitioned and some have per_api set")
+				log.Error(err)
+				return err
+			}
+			if policy.Partitions.Quota {
+				if didQuota {
+					err := fmt.Errorf("cannot apply multiple quota policies")
+					log.Error(err)
+					return err
+				}
+				didQuota = true
+				// Quotas
+				session.QuotaMax = policy.QuotaMax
+				session.QuotaRenewalRate = policy.QuotaRenewalRate
+			}
+
+			if policy.Partitions.RateLimit {
+				if didRateLimit {
+					err := fmt.Errorf("cannot apply multiple rate limit policies")
+					log.Error(err)
+					return err
+				}
+				didRateLimit = true
+				// Rate limiting
+				session.Allowance = policy.Rate // This is a legacy thing, merely to make sure output is consistent. Needs to be purged
+				session.Rate = policy.Rate
+				session.Per = policy.Per
+				if policy.LastUpdated != "" {
+					session.LastUpdated = policy.LastUpdated
 				}
 			}
 
@@ -303,7 +319,6 @@ func (t BaseMiddleware) ApplyPolicies(key string, session *user.SessionState) er
 				}
 				session.HMACEnabled = policy.HMACEnabled
 			}
-
 		} else {
 			if len(policies) > 1 {
 				err := fmt.Errorf("cannot apply multiple policies if any are non-partitioned")

--- a/mw_api_rate_limit.go
+++ b/mw_api_rate_limit.go
@@ -70,6 +70,7 @@ func (k *RateLimitForAPI) ProcessRequest(w http.ResponseWriter, r *http.Request,
 		true,
 		false,
 		&k.Spec.GlobalConfig,
+		k.Spec.APIID,
 	)
 
 	if reason == sessionFailRateLimit {

--- a/mw_organisation_activity.go
+++ b/mw_organisation_activity.go
@@ -106,6 +106,7 @@ func (k *OrganizationMonitor) ProcessRequestLive(r *http.Request, orgSession use
 		orgSession.Per > 0 && orgSession.Rate > 0,
 		true,
 		&k.Spec.GlobalConfig,
+		k.Spec.APIID,
 	)
 
 	sessionLifeTime := orgSession.Lifetime(k.Spec.SessionLifetime)
@@ -235,6 +236,7 @@ func (k *OrganizationMonitor) AllowAccessNext(
 		session.Per > 0 && session.Rate > 0,
 		true,
 		&k.Spec.GlobalConfig,
+		k.Spec.APIID,
 	)
 
 	sessionLifeTime := session.Lifetime(k.Spec.SessionLifetime)

--- a/mw_rate_limiting.go
+++ b/mw_rate_limiting.go
@@ -74,6 +74,7 @@ func (k *RateLimitAndQuotaCheck) ProcessRequest(w http.ResponseWriter, r *http.R
 		!k.Spec.DisableRateLimit,
 		!k.Spec.DisableQuota,
 		&k.Spec.GlobalConfig,
+		k.Spec.APIID,
 	)
 
 	switch reason {

--- a/policy.go
+++ b/policy.go
@@ -17,7 +17,8 @@ type DBAccessDefinition struct {
 	APIName     string            `json:"apiname"`
 	APIID       string            `json:"apiid"`
 	Versions    []string          `json:"versions"`
-	AllowedURLs []user.AccessSpec `bson:"allowed_urls"  json:"allowed_urls"` // mapped string MUST be a valid regex
+	AllowedURLs []user.AccessSpec `bson:"allowed_urls" json:"allowed_urls"` // mapped string MUST be a valid regex
+	Limit       *user.APILimit    `json:"limit"`
 }
 
 func (d *DBAccessDefinition) ToRegularAD() user.AccessDefinition {
@@ -26,6 +27,7 @@ func (d *DBAccessDefinition) ToRegularAD() user.AccessDefinition {
 		APIID:       d.APIID,
 		Versions:    d.Versions,
 		AllowedURLs: d.AllowedURLs,
+		Limit:       d.Limit,
 	}
 }
 

--- a/user/policy.go
+++ b/user/policy.go
@@ -24,4 +24,5 @@ type PolicyPartitions struct {
 	Quota     bool `bson:"quota" json:"quota"`
 	RateLimit bool `bson:"rate_limit" json:"rate_limit"`
 	Acl       bool `bson:"acl" json:"acl"`
+	PerAPI    bool `bson:"per_api" json:"per_api"`
 }

--- a/user/session.go
+++ b/user/session.go
@@ -20,12 +20,24 @@ type AccessSpec struct {
 	Methods []string `json:"methods" msg:"methods"`
 }
 
+// APILimit stores quota and rate limit on ACL level (per API)
+type APILimit struct {
+	Rate             float64 `json:"rate" msg:"rate"`
+	Per              float64 `json:"per" msg:"per"`
+	QuotaMax         int64   `json:"quota_max" msg:"quota_max"`
+	QuotaRenews      int64   `json:"quota_renews" msg:"quota_renews"`
+	QuotaRemaining   int64   `json:"quota_remaining" msg:"quota_remaining"`
+	QuotaRenewalRate int64   `json:"quota_renewal_rate" msg:"quota_renewal_rate"`
+	SetByPolicy      bool    `json:"set_by_policy" msg:"set_by_policy"`
+}
+
 // AccessDefinition defines which versions of an API a key has access to
 type AccessDefinition struct {
 	APIName     string       `json:"api_name" msg:"api_name"`
 	APIID       string       `json:"api_id" msg:"api_id"`
 	Versions    []string     `json:"versions" msg:"versions"`
-	AllowedURLs []AccessSpec `bson:"allowed_urls"  json:"allowed_urls" msg:"allowed_urls"` // mapped string MUST be a valid regex
+	AllowedURLs []AccessSpec `bson:"allowed_urls" json:"allowed_urls" msg:"allowed_urls"` // mapped string MUST be a valid regex
+	Limit       *APILimit    `json:"limit" msg:"limit"`
 }
 
 // SessionState objects represent a current API session, mainly used for rate limiting.


### PR DESCRIPTION
Added changes for https://github.com/TykTechnologies/tyk/issues/1783

While looking at this feature I tried to follow ideas:
- legacy should continue working without any tricks
- we should be able to use the same concept of partitioned policies but with one more edge case when we can specify quota and rate limit in more than one partitioned policy if they have different APIs in ACL
- we should be able specify quota and rate limit on API level (ACL item) explicitly when we create policy 

The idea is to introduce new option "Per API" in partitions section when we create policy. If this option is unchecked - everything should work as before.

Also, there is one condition - that new option "Per API" comes to play only when another partition option "Enforce access control" (aka ACL) is checked as this is what tells our logic to merge access rights from different policies into one array in key session when several (partitioned) policies attached to key. Imho it is weird, maybe can be fixed on UI level.

Also, I've introduced quota and rate limit on API level (field `limit`) in `AccessDefinition` because:
- we need to be able to specify quota and rate limit per ACL item when we create policy
- we need to store quota and rate limit per ACL policy even if it was not specified per ACL item but just on policy level - so all ACL items kind of inherit quota and rate from policy and overwrite it if it was specified explicitly while policy was created
- when quota and rate on ACL item level inherited from policy `AccessDefinition.Limit` gets new field `SetByPolicy` to true - for informative/debug purposes so we know from where that limit on API level has come from

If we have limits on API level we add API ID to storage keys (leaky bucket and other rate limits keys or keys to store quota for key or org session).

If we don't have limit specified on API level quota and rate limit should work as they were working before that change.

if we try to assign several policies with the same API in ACL it should error.

Please note - I didn't include unit tests intentionally (however I've got some) because:
- I rewrote this logic several times while exploring different options to implement this feature so unit test were through away thing every time
- I am kind of got stuck with the way we test rate limits and quotas (as I receive false positives time to time)