### PR TITLE
Guarantee tyk wont start when linter runs

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -80,7 +80,7 @@ func Init(version string, confPaths []string) {
 		}
 		if len(lines) == 0 {
 			fmt.Printf("found no issues in %s\n", path)
-			return nil
+			os.Exit(0)
 		}
 		fmt.Printf("issues found in %s:\n", path)
 		for _, line := range lines {


### PR DESCRIPTION
Addresses one of issues in #1880 
I couldnt consistently reproduce the behaviour but sometime when `tyk lint` is run tyk process will start up afterwards. This is not the advertised behaviour of the linter currently - so this change guarantees exit.

We can change behaviour by attaching flags to the command at a future time.