### PR TITLE
Fix Python memory issues

### DIFF
--- a/coprocess/lua/binding.h
+++ b/coprocess/lua/binding.h
@@ -8,7 +8,7 @@
 
 static void LuaInit();
 
-static void LuaDispatchHook(struct CoProcessMessage*, struct CoProcessMessage*);
+static int LuaDispatchHook(struct CoProcessMessage*, struct CoProcessMessage*);
 static void LuaDispatchEvent(char*);
 
 void LoadCachedMiddleware(void*);

--- a/coprocess/lua/binding.h
+++ b/coprocess/lua/binding.h
@@ -8,7 +8,7 @@
 
 static void LuaInit();
 
-static struct CoProcessMessage* LuaDispatchHook(struct CoProcessMessage*);
+static void LuaDispatchHook(struct CoProcessMessage*, struct CoProcessMessage*);
 static void LuaDispatchEvent(char*);
 
 void LoadCachedMiddleware(void*);

--- a/coprocess/native_dispatcher.go
+++ b/coprocess/native_dispatcher.go
@@ -27,7 +27,7 @@ const (
 // Dispatcher defines a basic interface for the CP dispatcher, check PythonDispatcher for reference.
 type Dispatcher interface {
 	// Dispatch takes and returns a pointer to a CoProcessMessage struct, see coprocess/api.h for details. This is used by CP bindings.
-	Dispatch(unsafe.Pointer) unsafe.Pointer
+	Dispatch(unsafe.Pointer, unsafe.Pointer)
 
 	// DispatchEvent takes an event JSON, as bytes. Doesn't return.
 	DispatchEvent([]byte)

--- a/coprocess/native_dispatcher.go
+++ b/coprocess/native_dispatcher.go
@@ -27,7 +27,7 @@ const (
 // Dispatcher defines a basic interface for the CP dispatcher, check PythonDispatcher for reference.
 type Dispatcher interface {
 	// Dispatch takes and returns a pointer to a CoProcessMessage struct, see coprocess/api.h for details. This is used by CP bindings.
-	Dispatch(unsafe.Pointer, unsafe.Pointer)
+	Dispatch(unsafe.Pointer, unsafe.Pointer) error
 
 	// DispatchEvent takes an event JSON, as bytes. Doesn't return.
 	DispatchEvent([]byte)

--- a/coprocess/python/binding.h
+++ b/coprocess/python/binding.h
@@ -9,7 +9,7 @@ static int Python_LoadDispatcher();
 static int Python_NewDispatcher(char*);
 static void Python_ReloadDispatcher();
 
-static void Python_DispatchHook(struct CoProcessMessage*, struct CoProcessMessage*);
+static int Python_DispatchHook(struct CoProcessMessage*, struct CoProcessMessage*);
 static void Python_DispatchEvent(char*);
 
 #endif

--- a/coprocess/python/binding.h
+++ b/coprocess/python/binding.h
@@ -9,7 +9,7 @@ static int Python_LoadDispatcher();
 static int Python_NewDispatcher(char*);
 static void Python_ReloadDispatcher();
 
-static struct CoProcessMessage* Python_DispatchHook(struct CoProcessMessage*);
+static void Python_DispatchHook(struct CoProcessMessage*, struct CoProcessMessage*);
 static void Python_DispatchEvent(char*);
 
 #endif

--- a/coprocess_lua.go
+++ b/coprocess_lua.go
@@ -25,10 +25,7 @@ static void LoadMiddlewareIntoState(lua_State* L, char* middleware_name, char* m
 	luaL_dostring(L, middleware_contents);
 }
 
-static struct CoProcessMessage* LuaDispatchHook(struct CoProcessMessage* object) {
-
-	struct CoProcessMessage* outputObject = malloc(sizeof *outputObject);
-
+static void LuaDispatchHook(struct CoProcessMessage* object, struct CoProcessMessage* outputObject) {
 	lua_State *L = luaL_newstate();
 
 	luaL_openlibs(L);
@@ -52,7 +49,7 @@ static struct CoProcessMessage* LuaDispatchHook(struct CoProcessMessage* object)
 	outputObject->p_data = (void*)output;
 	outputObject->length = lua_output_length;
 
-	return outputObject;
+	return;
 }
 
 static void LuaDispatchEvent(char* event_json) {
@@ -107,10 +104,10 @@ type LuaDispatcher struct {
 }
 
 // Dispatch takes a CoProcessMessage and sends it to the CP.
-func (d *LuaDispatcher) Dispatch(objectPtr unsafe.Pointer) unsafe.Pointer {
+func (d *LuaDispatcher) Dispatch(objectPtr unsafe.Pointer, newObjectPtr unsafe.Pointer) {
 	object := (*C.struct_CoProcessMessage)(objectPtr)
-	newObjectPtr := C.LuaDispatchHook(object)
-	return unsafe.Pointer(newObjectPtr)
+	newObject := (*C.struct_CoProcessMessage)(newObjectPtr)
+	C.LuaDispatchHook(object, newObject)
 }
 
 // Reload will perform a middleware reload when a hot reload is triggered.

--- a/coprocess_native.go
+++ b/coprocess_native.go
@@ -50,20 +50,15 @@ func (c *CoProcessor) Dispatch(object *coprocess.Object) (*coprocess.Object, err
 	objectMsgStr := string(objectMsg)
 
 	CObjectStr := C.CString(objectMsgStr)
-	defer C.free(unsafe.Pointer(CObjectStr))
 
 	objectPtr := (*C.struct_CoProcessMessage)(C.malloc(C.size_t(unsafe.Sizeof(C.struct_CoProcessMessage{}))))
 	objectPtr.p_data = unsafe.Pointer(CObjectStr)
 	objectPtr.length = C.int(len(objectMsg))
-	defer C.free(unsafe.Pointer(objectPtr))
 
-	newObjectPtr := (*C.struct_CoProcessMessage)(GlobalDispatcher.Dispatch(unsafe.Pointer(objectPtr)))
-	defer C.free(unsafe.Pointer(newObjectPtr))
+	newObjectPtr := (*C.struct_CoProcessMessage)(C.malloc(C.size_t(unsafe.Sizeof(C.struct_CoProcessMessage{}))))
 
-	if newObjectPtr == nil {
-		return nil, errors.New("Dispatch error")
-	}
-
+	// Call the dispatcher (objectPtr is freed during this call):
+	GlobalDispatcher.Dispatch(unsafe.Pointer(objectPtr), unsafe.Pointer(newObjectPtr))
 	newObjectBytes := C.GoBytes(newObjectPtr.p_data, newObjectPtr.length)
 
 	newObject := &coprocess.Object{}
@@ -77,6 +72,10 @@ func (c *CoProcessor) Dispatch(object *coprocess.Object) (*coprocess.Object, err
 	if err != nil {
 		return nil, err
 	}
+
+	// Free the returned object memory:
+	C.free(unsafe.Pointer(newObjectPtr.p_data))
+	C.free(unsafe.Pointer(newObjectPtr))
 
 	return newObject, nil
 }

--- a/coprocess_native.go
+++ b/coprocess_native.go
@@ -58,7 +58,11 @@ func (c *CoProcessor) Dispatch(object *coprocess.Object) (*coprocess.Object, err
 	newObjectPtr := (*C.struct_CoProcessMessage)(C.malloc(C.size_t(unsafe.Sizeof(C.struct_CoProcessMessage{}))))
 
 	// Call the dispatcher (objectPtr is freed during this call):
-	GlobalDispatcher.Dispatch(unsafe.Pointer(objectPtr), unsafe.Pointer(newObjectPtr))
+	if err = GlobalDispatcher.Dispatch(unsafe.Pointer(objectPtr), unsafe.Pointer(newObjectPtr)); err != nil {
+		C.free(unsafe.Pointer(newObjectPtr.p_data))
+		C.free(unsafe.Pointer(newObjectPtr))
+		return nil, err
+	}
 	newObjectBytes := C.GoBytes(newObjectPtr.p_data, newObjectPtr.length)
 
 	newObject := &coprocess.Object{}

--- a/coprocess_python.go
+++ b/coprocess_python.go
@@ -36,7 +36,7 @@ static int Python_Init() {
 
 
 static int Python_LoadDispatcher() {
-	PyObject *module_name = PyUnicode_FromString( dispatcher_module_name );
+	PyObject* module_name = PyUnicode_FromString( dispatcher_module_name );
 	dispatcher_module = PyImport_Import( module_name );
 
 	if( dispatcher_module == NULL ) {
@@ -63,7 +63,7 @@ static int Python_LoadDispatcher() {
 
 static void Python_ReloadDispatcher() {
 	gilState = PyGILState_Ensure();
-	PyObject *hook_name = PyUnicode_FromString(dispatcher_reload);
+	PyObject* hook_name = PyUnicode_FromString(dispatcher_reload);
 	if( dispatcher_reload_hook == NULL ) {
 		dispatcher_reload_hook = PyObject_GetAttr(dispatcher, hook_name);
 	};
@@ -124,21 +124,28 @@ static void Python_SetEnv(char* python_path) {
 	setenv("PYTHONPATH", python_path, 1 );
 }
 
-static struct CoProcessMessage* Python_DispatchHook(struct CoProcessMessage* object) {
-	struct CoProcessMessage* outputObject = malloc(sizeof *outputObject);
-
+static void Python_DispatchHook(struct CoProcessMessage* object, struct CoProcessMessage* new_object) {
 	if (object->p_data == NULL) {
-		return outputObject;
+		free(object);
+		return;
 	}
 
 	gilState = PyGILState_Ensure();
-	PyObject *args = PyTuple_Pack( 1, PyBytes_FromStringAndSize(object->p_data, object->length) );
+	PyObject* input = PyBytes_FromStringAndSize(object->p_data, object->length);
+	PyObject* args = PyTuple_Pack( 1, input );
 
-	PyObject *result = PyObject_CallObject( dispatcher_hook, args );
+	PyObject* result = PyObject_CallObject( dispatcher_hook, args );
+
+	free(object->p_data);
+	free(object);
+
+	Py_DECREF(input);
+	Py_DECREF(args);
+
 	if( result == NULL ) {
 		PyErr_Print();
 		PyGILState_Release(gilState);
-		return NULL;
+		return;
 	}
 	PyObject* new_object_msg_item = PyTuple_GetItem( result, 0 );
 	char* output = PyBytes_AsString(new_object_msg_item);
@@ -146,17 +153,23 @@ static struct CoProcessMessage* Python_DispatchHook(struct CoProcessMessage* obj
 	PyObject* new_object_msg_length = PyTuple_GetItem( result, 1 );
 	int msg_length = PyLong_AsLong(new_object_msg_length);
 
-	outputObject->p_data = (void*)output;
-	outputObject->length = msg_length;
+	// Copy the message in order to avoid accessing the result PyObject internal buffer:
+	char* output_copy = malloc(msg_length);
+	memcpy(output_copy, output, msg_length);
+
+	Py_DECREF(result);
+
+	new_object->p_data= (void*)output_copy;
+	new_object->length = msg_length;
 
 	PyGILState_Release(gilState);
-	return outputObject;
+	return;
 }
 
 static void Python_DispatchEvent(char* event_json) {
 	gilState = PyGILState_Ensure();
-	PyObject *args = PyTuple_Pack( 1, PyUnicode_FromString(event_json) );
-	PyObject *result = PyObject_CallObject( dispatch_event, args );
+	PyObject* args = PyTuple_Pack( 1, PyUnicode_FromString(event_json) );
+	PyObject* result = PyObject_CallObject( dispatch_event, args );
 	PyGILState_Release(gilState);
 }
 
@@ -192,10 +205,11 @@ type PythonDispatcher struct {
 }
 
 // Dispatch takes a CoProcessMessage and sends it to the CP.
-func (d *PythonDispatcher) Dispatch(objectPtr unsafe.Pointer) unsafe.Pointer {
+func (d *PythonDispatcher) Dispatch(objectPtr unsafe.Pointer, newObjectPtr unsafe.Pointer) {
 	object := (*C.struct_CoProcessMessage)(objectPtr)
-	newObjectPtr := C.Python_DispatchHook(object)
-	return unsafe.Pointer(newObjectPtr)
+	newObject := (*C.struct_CoProcessMessage)(newObjectPtr)
+	// TODO: restore error result
+	C.Python_DispatchHook(object, newObject)
 }
 
 // DispatchEvent dispatches a Tyk event.


### PR DESCRIPTION
Related to #1228.

Added Python refcount macros. Modified the C.free calls to avoid any GC issues.

Python_DispatchHook uses memcpy to avoid accessing the internal buffer of the resulting PyObject.
