### PR TITLE
Make JSVM the default driver

### DIFF
--- a/api_loader.go
+++ b/api_loader.go
@@ -220,9 +220,10 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 		"api_name": spec.Name,
 	}).Debug("Loading Middleware")
 	var mwPaths []string
+
 	mwPaths, mwAuthCheckFunc, mwPreFuncs, mwPostFuncs, mwPostAuthCheckFuncs, mwDriver = loadCustomMiddleware(spec)
 
-	if spec.CustomMiddleware.Driver == apidef.OttoDriver {
+	if mwDriver == apidef.OttoDriver {
 		spec.JSVM.LoadJSPaths(mwPaths, prefix)
 	}
 

--- a/coprocess_bundle.go
+++ b/coprocess_bundle.go
@@ -97,7 +97,8 @@ func (b *Bundle) Verify() error {
 func (b *Bundle) AddToSpec() {
 	b.Spec.CustomMiddleware = b.Manifest.CustomMiddleware
 
-	if GlobalDispatcher != nil {
+	// Call HandleMiddlewareCache only when using rich plugins:
+	if GlobalDispatcher != nil && b.Spec.CustomMiddleware.Driver != apidef.OttoDriver {
 		GlobalDispatcher.HandleMiddlewareCache(&b.Manifest, b.Path)
 	}
 }


### PR DESCRIPTION
This is a regression described in #1887, affecting `2.7` and current `master`, in addition this PR makes sure that:
- When loading JSVM plugins, bundled or not, they aren't processed by a rich plugin dispatcher (but JSVM loads it).

I've tried the following scenarios:
- JSVM plugin stored in `middleware` and specified directly in the API definition as we suggest in our [doc](https://tyk.io/docs/customise-tyk/plugins/javascript-middleware/install-middleware/tyk-ce/), driver explicitly set, using the following block:
```json
    "custom_middleware": {
        "driver": "otto",
        "pre": [
            {
                "name": "sampleMiddleware",
                "path": "middleware/sampleMiddleware.js"
            }
        ]
    }
```
- JSVM plugin stored in `middleware` and specified directly in the API definition as we suggest in our [doc](https://tyk.io/docs/customise-tyk/plugins/javascript-middleware/install-middleware/tyk-ce/), not explicitly setting the driver to `otto`:
```json
    "custom_middleware": {
        "pre": [
            {
                "name": "sampleMiddleware",
                "path": "middleware/sampleMiddleware.js"
            }
        ]
    }
```
- Bundled JSVM plugin, specifying the driver `otto` (see attachment) 
[jsvm-bundle.zip](https://github.com/TykTechnologies/tyk/files/2330679/jsvm-bundle.zip).

- Bundled Python plugin, specifying the driver `python` (see attachment)
[python-bundle.zip](https://github.com/TykTechnologies/tyk/files/2330676/python-bundle.zip).