### PR TITLE
Spelling correction for keyspace log warning

### DIFF
--- a/rpc_storage_handler.go
+++ b/rpc_storage_handler.go
@@ -979,7 +979,7 @@ func (r *RPCStorageHandler) CheckForKeyspaceChanges(orgId string) {
 				r.CheckForKeyspaceChanges(orgId)
 			}
 		}
-		log.Warning("Keysapce warning: ", err)
+		log.Warning("Keyspace warning: ", err)
 		return
 	}
 


### PR DESCRIPTION
Keysapce -> Keyspace