### PR TITLE
Added new Debugging API

### DIFF
--- a/api.go
+++ b/api.go
@@ -1742,3 +1742,11 @@ func ctxSetLoopLimit(r *http.Request, limit int) {
 		setCtxValue(r, LoopLevelLimit, limit)
 	}
 }
+
+func ctxTraceEnabled(r *http.Request) bool {
+	return r.Context().Value(Trace) != nil
+}
+
+func ctxSetTrace(r *http.Request) {
+	setCtxValue(r, Trace, true)
+}

--- a/api_definition_test.go
+++ b/api_definition_test.go
@@ -22,7 +22,7 @@ import (
 func createDefinitionFromString(defStr string) *APISpec {
 	loader := APIDefinitionLoader{}
 	def := loader.ParseDefinition(strings.NewReader(defStr))
-	spec := loader.MakeSpec(def)
+	spec := loader.MakeSpec(def, nil)
 	return spec
 }
 

--- a/api_loader.go
+++ b/api_loader.go
@@ -46,30 +46,21 @@ func prepareStorage() (storage.RedisCluster, storage.RedisCluster, storage.Redis
 	return redisStore, redisOrgStore, healthStore, &rpcAuthStore, &rpcOrgStore
 }
 
-func skipSpecBecauseInvalid(spec *APISpec) bool {
+func skipSpecBecauseInvalid(spec *APISpec, logger *logrus.Entry) bool {
 
 	if spec.Proxy.ListenPath == "" {
-		mainLog.WithFields(logrus.Fields{
-			"org_id": spec.OrgID,
-			"api_id": spec.APIID,
-		}).Error("Listen path is empty, skipping API ID: ", spec.APIID)
+		logger.Error("Listen path is empty")
 		return true
 	}
 
 	if strings.Contains(spec.Proxy.ListenPath, " ") {
-		mainLog.WithFields(logrus.Fields{
-			"org_id": spec.OrgID,
-			"api_id": spec.APIID,
-		}).Error("Listen path contains spaces, is invalid, skipping API ID: ", spec.APIID)
+		logger.Error("Listen path contains spaces, is invalid")
 		return true
 	}
 
 	_, err := url.Parse(spec.Proxy.TargetURL)
 	if err != nil {
-		mainLog.WithFields(logrus.Fields{
-			"org_id": spec.OrgID,
-			"api_id": spec.APIID,
-		}).Error("couldn't parse target URL: ", err)
+		logger.Error("couldn't parse target URL: ", err)
 		return true
 	}
 
@@ -102,19 +93,22 @@ func countApisByListenHash(specs []*APISpec) map[string]int {
 
 func processSpec(spec *APISpec, apisByListen map[string]int,
 	redisStore, redisOrgStore, healthStore, rpcAuthStore, rpcOrgStore storage.Handler,
-	subrouter *mux.Router) *ChainObject {
+	subrouter *mux.Router, logger *logrus.Entry) *ChainObject {
 
 	var chainDef ChainObject
 	chainDef.Subrouter = subrouter
 
-	var coprocessLog = log.WithFields(logrus.Fields{
-		"prefix":   "coprocess",
+	logger = logger.WithFields(logrus.Fields{
+		"org_id":   spec.OrgID,
+		"api_id":   spec.APIID,
 		"api_name": spec.Name,
 	})
 
-	mainLog.WithFields(logrus.Fields{
-		"api_name": spec.Name,
-	}).Info("Loading API")
+	var coprocessLog = logger.WithFields(logrus.Fields{
+		"prefix": "coprocess",
+	})
+
+	logger.Info("Loading API")
 
 	if len(spec.TagHeaders) > 0 {
 		// Ensure all headers marked for tagging are lowercase
@@ -126,10 +120,8 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 		spec.TagHeaders = lowerCaseHeaders
 	}
 
-	if skipSpecBecauseInvalid(spec) {
-		mainLog.WithFields(logrus.Fields{
-			"api_name": spec.Name,
-		}).Warning("Skipped!")
+	if skipSpecBecauseInvalid(spec, logger) {
+		logger.Warning("Spec not valid, skipped!")
 		chainDef.Skip = true
 		return &chainDef
 	}
@@ -156,10 +148,7 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 		}
 	}
 	if pathModified {
-		mainLog.WithFields(logrus.Fields{
-			"org_id": spec.OrgID,
-			"api_id": spec.APIID,
-		}).Error("Listen path collision, changed to ", spec.Proxy.ListenPath)
+		logger.Error("Listen path collision, changed to ", spec.Proxy.ListenPath)
 	}
 
 	// Set up LB targets:
@@ -205,9 +194,7 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 	var prefix string
 	if spec.CustomMiddlewareBundle != "" {
 		if err := loadBundle(spec); err != nil {
-			mainLog.WithFields(logrus.Fields{
-				"api_name": spec.Name,
-			}).Error("Couldn't load bundle")
+			logger.Error("Couldn't load bundle")
 		}
 		tykBundlePath := filepath.Join(config.Global().MiddlewarePath, "bundles")
 		bundleNameHash := md5.New()
@@ -216,9 +203,7 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 		prefix = filepath.Join(tykBundlePath, bundlePath)
 	}
 
-	mainLog.WithFields(logrus.Fields{
-		"api_name": spec.Name,
-	}).Debug("Loading Middleware")
+	logger.Debug("Initializing API")
 	var mwPaths []string
 	mwPaths, mwAuthCheckFunc, mwPreFuncs, mwPostFuncs, mwPostAuthCheckFuncs, mwDriver = loadCustomMiddleware(spec)
 
@@ -231,12 +216,12 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 	}
 
 	if spec.UseOauth2 {
-		log.Debug("Loading OAuth Manager")
+		logger.Debug("Loading OAuth Manager")
 		oauthManager := addOAuthHandlers(spec, subrouter)
-		log.Debug("-- Added OAuth Handlers")
+		logger.Debug("-- Added OAuth Handlers")
 
 		spec.OAuthManager = oauthManager
-		log.Debug("Done loading OAuth Manager")
+		logger.Debug("Done loading OAuth Manager")
 	}
 
 	enableVersionOverrides := false
@@ -252,9 +237,7 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 
 	var proxy ReturningHttpHandler
 	if enableVersionOverrides {
-		mainLog.WithFields(logrus.Fields{
-			"api_name": spec.Name,
-		}).Info("Multi target enabled")
+		logger.Info("Multi target enabled")
 		proxy = NewMultiTargetProxy(spec)
 	} else {
 		proxy = TykNewSingleHostReverseProxy(spec.target, spec)
@@ -263,7 +246,8 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 	// Create the response processors
 	createResponseMiddlewareChain(spec)
 
-	baseMid := BaseMiddleware{spec, proxy}
+	baseMid := BaseMiddleware{Spec: spec, Proxy: proxy, logger: logger}
+
 	for _, v := range baseMid.Spec.VersionData.Versions {
 		if len(v.ExtendedPaths.CircuitBreaker) > 0 {
 			baseMid.Spec.CircuitBreakerEnabled = true
@@ -281,9 +265,7 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 
 	if spec.UseKeylessAccess {
 		chainDef.Open = true
-		mainLog.WithFields(logrus.Fields{
-			"api_name": spec.Name,
-		}).Info("Checking security policy: Open")
+		logger.Info("Checking security policy: Open")
 
 		// Add pre-process MW
 		chainArray := []alice.Constructor{}
@@ -361,23 +343,23 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 
 		// Select the keying method to use for setting session states
 		if mwAppendEnabled(&authArray, &Oauth2KeyExists{baseMid}) {
-			mainLog.WithField("api_name", spec.Name).Info("Checking security policy: OAuth")
+			logger.Info("Checking security policy: OAuth")
 		}
 
 		if mwAppendEnabled(&authArray, &BasicAuthKeyIsValid{baseMid, cache.New(60*time.Second, 60*time.Minute)}) {
-			mainLog.WithField("api_name", spec.Name).Info("Checking security policy: Basic")
+			logger.Info("Checking security policy: Basic")
 		}
 
 		if mwAppendEnabled(&authArray, &HMACMiddleware{BaseMiddleware: baseMid}) {
-			mainLog.WithField("api_name", spec.Name).Info("Checking security policy: HMAC")
+			logger.Info("Checking security policy: HMAC")
 		}
 
 		if mwAppendEnabled(&authArray, &JWTMiddleware{baseMid}) {
-			mainLog.WithField("api_name", spec.Name).Info("Checking security policy: JWT")
+			logger.Info("Checking security policy: JWT")
 		}
 
 		if mwAppendEnabled(&authArray, &OpenIDMW{BaseMiddleware: baseMid}) {
-			mainLog.WithField("api_name", spec.Name).Info("Checking security policy: OpenID")
+			logger.Info("Checking security policy: OpenID")
 		}
 
 		coprocessAuth := EnableCoProcess && mwDriver != apidef.OttoDriver && spec.EnableCoProcessAuth
@@ -393,13 +375,13 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 
 		if ottoAuth {
 
-			mainLog.Info("----> Checking security policy: JS Plugin")
+			logger.Info("----> Checking security policy: JS Plugin")
 
 			authArray = append(authArray, createDynamicMiddleware(mwAuthCheckFunc.Name, true, false, baseMid))
 		}
 
 		if spec.UseStandardAuth || len(authArray) == 0 {
-			mainLog.WithField("api_name", spec.Name).Info("Checking security policy: Token")
+			logger.Info("Checking security policy: Token")
 			authArray = append(authArray, createMiddleware(&AuthKey{baseMid}))
 		}
 
@@ -436,12 +418,8 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 			}
 		}
 
-		mainLog.WithField("api_name", spec.Name).Debug("Custom middleware completed processing")
-
 		// Use createMiddleware(&ModifiedMiddleware{baseMid})  to run custom middleware
 		chain = alice.New(chainArray...).Then(&DummyProxyHandler{SH: SuccessHandler{baseMid}})
-
-		log.Debug("Chain completed")
 
 		var simpleArray []alice.Constructor
 		mwAppendEnabled(&simpleArray, &IPWhiteListMiddleware{baseMid})
@@ -454,28 +432,24 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 
 		rateLimitPath := spec.Proxy.ListenPath + "tyk/rate-limits/"
 
-		mainLog.WithField("api_name", spec.Name).Debug("Rate limit endpoint is: ", rateLimitPath)
+		logger.Debug("Rate limit endpoint is: ", rateLimitPath)
 
 		chainDef.RateLimitPath = rateLimitPath
 		chainDef.RateLimitChain = alice.New(simpleArray...).
 			Then(http.HandlerFunc(userRatesCheck))
 	}
 
-	mainLog.WithField("api_name", spec.Name).Debug("Setting Listen Path: ", spec.Proxy.ListenPath)
+	logger.Debug("Setting Listen Path: ", spec.Proxy.ListenPath)
 
 	chainDef.ThisHandler = chain
 	chainDef.ListenOn = spec.Proxy.ListenPath + "{rest:.*}"
 
-	if config.Global().UseRedisLog {
-		log.WithFields(logrus.Fields{
-			"prefix":      "gateway",
-			"user_ip":     "--",
-			"server_name": "--",
-			"user_id":     "--",
-			"org_id":      spec.OrgID,
-			"api_id":      spec.APIID,
-		}).Info("Loaded: ", spec.Name)
-	}
+	logger.WithFields(logrus.Fields{
+		"prefix":      "gateway",
+		"user_ip":     "--",
+		"server_name": "--",
+		"user_id":     "--",
+	}).Info("API Loaded")
 
 	return &chainDef
 }
@@ -507,7 +481,7 @@ type DummyProxyHandler struct {
 func (d *DummyProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if found, err := isLoop(r); found {
 		if err != nil {
-			handler := ErrorHandler{d.SH.Base()}
+			handler := ErrorHandler{*d.SH.Base()}
 			handler.HandleError(w, r, err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -617,7 +591,8 @@ func loadApps(specs []*APISpec, muxer *mux.Router) {
 				subrouter = muxer
 			}
 
-			chainObj := processSpec(spec, apisByListen, redisStore, redisOrgStore, healthStore, rpcAuthStore, rpcOrgStore, subrouter)
+			chainObj := processSpec(spec, apisByListen, redisStore, redisOrgStore, healthStore, rpcAuthStore, rpcOrgStore, subrouter, logrus.NewEntry(log))
+
 			chainObj.Index = i
 			chainChannel <- chainObj
 			apisMu.Lock()

--- a/coprocess.go
+++ b/coprocess.go
@@ -222,9 +222,9 @@ func (m *CoProcessMiddleware) EnabledForSpec() bool {
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
-	log.WithFields(logrus.Fields{
-		"prefix": "coprocess",
-	}).Debug("CoProcess Request, HookType: ", m.HookType)
+	logger := m.Logger()
+
+	logger.Debug("CoProcess Request, HookType: ", m.HookType)
 
 	if !EnableCoProcess {
 		return nil, 200
@@ -260,9 +260,7 @@ func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 
 	returnObject, err := coProcessor.Dispatch(object)
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "coprocess",
-		}).WithError(err).Error("Dispatch error")
+		logger.WithError(err).Error("Dispatch error")
 		if m.HookType == coprocess.HookType_CustomKeyCheck {
 			return errors.New("Key not authorised"), 403
 		} else {
@@ -289,9 +287,7 @@ func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 
 	// The CP middleware indicates this is a bad auth:
 	if returnObject.Request.ReturnOverrides.ResponseCode > 400 {
-
-		logEntry := getLogEntryForRequest(r, token, nil)
-		logEntry.Info("Attempted access with invalid key.")
+		logEntry.WithField("key", obfuscateKey(token)).Info("Attempted access with invalid key")
 
 		// Fire Authfailed Event
 		AuthFailed(m, r, token)

--- a/coprocess.go
+++ b/coprocess.go
@@ -287,7 +287,7 @@ func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 
 	// The CP middleware indicates this is a bad auth:
 	if returnObject.Request.ReturnOverrides.ResponseCode > 400 {
-		logEntry.WithField("key", obfuscateKey(token)).Info("Attempted access with invalid key")
+		logger.WithField("key", obfuscateKey(token)).Info("Attempted access with invalid key")
 
 		// Fire Authfailed Event
 		AuthFailed(m, r, token)

--- a/coprocess_id_extractor.go
+++ b/coprocess_id_extractor.go
@@ -75,7 +75,7 @@ func (e *BaseExtractor) ExtractBody(r *http.Request) (string, error) {
 
 // Error is a helper for logging the extractor errors. It always returns HTTP 400 (so we don't expose any details).
 func (e *BaseExtractor) Error(r *http.Request, err error, message string) (returnOverrides ReturnOverrides) {
-	logEntry := getLogEntryForRequest(r, "", nil)
+	logEntry := getLogEntryForRequest(e.BaseMid.Logger(), r, "", nil)
 	logEntry.Info("Extractor error: ", message, ", ", err)
 
 	return ReturnOverrides{

--- a/coprocess_id_extractor_test.go
+++ b/coprocess_id_extractor_test.go
@@ -28,7 +28,7 @@ const (
 
 func createSpecTestFrom(t testing.TB, def *apidef.APIDefinition) *APISpec {
 	loader := APIDefinitionLoader{}
-	spec := loader.MakeSpec(def)
+	spec := loader.MakeSpec(def, nil)
 	tname := t.Name()
 	redisStore := storage.RedisCluster{KeyPrefix: tname + "-apikey."}
 	healthStore := storage.RedisCluster{KeyPrefix: tname + "-apihealth."}

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -1380,7 +1380,7 @@ func TestTracing(t *testing.T) {
 		{Method: "POST", Path: "/tyk/debug", Data: `{}`, AdminAuth: true, Code: 400, BodyMatch: "Spec field is missing"},
 		{Method: "POST", Path: "/tyk/debug", Data: `{"Spec": {}}`, AdminAuth: true, Code: 400, BodyMatch: "Request field is missing"},
 		{Method: "POST", Path: "/tyk/debug", Data: `{"Spec": {}, "Request": {}}`, AdminAuth: true, Code: 400, BodyMatch: "Spec not valid, skipped!"},
-		{Method: "POST", Path: "/tyk/debug", Data: traceRequest{Spec: spec.APIDefinition, Request: &traceHttpRequest{Method: "GET", Path: "/"}}, AdminAuth: true, Code: 200, BodyMatch: `"code":401`},
-		{Method: "POST", Path: "/tyk/debug", Data: traceRequest{Spec: spec.APIDefinition, Request: &traceHttpRequest{Path: "/", Headers: authHeaders}}, AdminAuth: true, Code: 200, BodyMatch: `"code":200`},
+		{Method: "POST", Path: "/tyk/debug", Data: traceRequest{Spec: spec.APIDefinition, Request: &traceHttpRequest{Method: "GET", Path: "/"}}, AdminAuth: true, Code: 200, BodyMatch: `401 Unauthorized`},
+		{Method: "POST", Path: "/tyk/debug", Data: traceRequest{Spec: spec.APIDefinition, Request: &traceHttpRequest{Path: "/", Headers: authHeaders}}, AdminAuth: true, Code: 200, BodyMatch: `200 OK`},
 	}...)
 }

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -1375,12 +1375,12 @@ func TestTracing(t *testing.T) {
 	authHeaders := map[string][]string{"Authorization": {keyID}}
 
 	ts.Run(t, []test.TestCase{
-		{Method: "GET", Path: "/tyk/trace", AdminAuth: true, Code: 405},
-		{Method: "POST", Path: "/tyk/trace", AdminAuth: true, Code: 400, BodyMatch: "Request malformed"},
-		{Method: "POST", Path: "/tyk/trace", Data: `{}`, AdminAuth: true, Code: 400, BodyMatch: "Spec field is missing"},
-		{Method: "POST", Path: "/tyk/trace", Data: `{"Spec": {}}`, AdminAuth: true, Code: 400, BodyMatch: "Request field is missing"},
-		{Method: "POST", Path: "/tyk/trace", Data: `{"Spec": {}, "Request": {}}`, AdminAuth: true, Code: 400, BodyMatch: "Spec not valid, skipped!"},
-		{Method: "POST", Path: "/tyk/trace", Data: traceRequest{Spec: spec.APIDefinition, Request: &traceHttpRequest{Method: "GET", Path: "/"}}, AdminAuth: true, Code: 200, BodyMatch: `"code":401`},
-		{Method: "POST", Path: "/tyk/trace", Data: traceRequest{Spec: spec.APIDefinition, Request: &traceHttpRequest{Path: "/", Headers: authHeaders}}, AdminAuth: true, Code: 200, BodyMatch: `"code":200`},
+		{Method: "GET", Path: "/tyk/debug", AdminAuth: true, Code: 405},
+		{Method: "POST", Path: "/tyk/debug", AdminAuth: true, Code: 400, BodyMatch: "Request malformed"},
+		{Method: "POST", Path: "/tyk/debug", Data: `{}`, AdminAuth: true, Code: 400, BodyMatch: "Spec field is missing"},
+		{Method: "POST", Path: "/tyk/debug", Data: `{"Spec": {}}`, AdminAuth: true, Code: 400, BodyMatch: "Request field is missing"},
+		{Method: "POST", Path: "/tyk/debug", Data: `{"Spec": {}, "Request": {}}`, AdminAuth: true, Code: 400, BodyMatch: "Spec not valid, skipped!"},
+		{Method: "POST", Path: "/tyk/debug", Data: traceRequest{Spec: spec.APIDefinition, Request: &traceHttpRequest{Method: "GET", Path: "/"}}, AdminAuth: true, Code: 200, BodyMatch: `"code":401`},
+		{Method: "POST", Path: "/tyk/debug", Data: traceRequest{Spec: spec.APIDefinition, Request: &traceHttpRequest{Path: "/", Headers: authHeaders}}, AdminAuth: true, Code: 200, BodyMatch: `"code":200`},
 	}...)
 }

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -987,29 +987,6 @@ func TestWebsocketsUpstreamUpgradeRequest(t *testing.T) {
 	})
 }
 
-func TestConcurrencyReloads(t *testing.T) {
-	var wg sync.WaitGroup
-
-	ts := newTykTestServer()
-	defer ts.Close()
-
-	buildAndLoadAPI()
-
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func() {
-			ts.Run(t, test.TestCase{Path: "/sample", Code: 200})
-			wg.Done()
-		}()
-	}
-
-	for j := 0; j < 5; j++ {
-		buildAndLoadAPI()
-	}
-
-	wg.Wait()
-}
-
 func TestWebsocketsSeveralOpenClose(t *testing.T) {
 	globalConf := config.Global()
 	globalConf.HttpServerOptions.EnableWebSockets = true

--- a/handler_success.go
+++ b/handler_success.go
@@ -36,6 +36,7 @@ const (
 	OrigRequestURL
 	LoopLevel
 	LoopLevelLimit
+	Trace
 )
 
 var SessionCache = cache.New(10*time.Second, 5*time.Second)

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -24,11 +24,10 @@ import (
 	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
 	"github.com/miekg/dns"
 	"github.com/satori/go.uuid"
-
-	"github.com/gorilla/mux"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"

--- a/log_helpers.go
+++ b/log_helpers.go
@@ -24,7 +24,11 @@ func obfuscateKey(keyName string) string {
 	return "--"
 }
 
-func getLogEntryForRequest(r *http.Request, key string, data map[string]interface{}) *logrus.Entry {
+func getLogEntryForRequest(logger *logrus.Entry, r *http.Request, key string, data map[string]interface{}) *logrus.Entry {
+	if logger == nil {
+		logger = logrus.NewEntry(log)
+	}
+
 	// populate http request fields
 	fields := logrus.Fields{
 		"path":   r.URL.Path,
@@ -34,17 +38,17 @@ func getLogEntryForRequest(r *http.Request, key string, data map[string]interfac
 	if key != "" {
 		fields["key"] = key
 		if !config.Global().EnableKeyLogging {
-			fields["key"] = logHiddenValue
+			fields["key"] = obfuscateKey(key)
 		}
 	}
 	// add to log additional fields if any passed
 	for key, val := range data {
 		fields[key] = val
 	}
-	return log.WithFields(fields)
+	return logger.WithFields(fields)
 }
 
-func getExplicitLogEntryForRequest(path string, IP string, key string, data map[string]interface{}) *logrus.Entry {
+func getExplicitLogEntryForRequest(logger *logrus.Entry, path string, IP string, key string, data map[string]interface{}) *logrus.Entry {
 	// populate http request fields
 	fields := logrus.Fields{
 		"path":   path,
@@ -61,5 +65,5 @@ func getExplicitLogEntryForRequest(path string, IP string, key string, data map[
 	for key, val := range data {
 		fields[key] = val
 	}
-	return log.WithFields(fields)
+	return logger.WithFields(fields)
 }

--- a/log_helpers_test.go
+++ b/log_helpers_test.go
@@ -74,7 +74,7 @@ func TestGetLogEntryForRequest(t *testing.T) {
 			Result: logrus.WithFields(logrus.Fields{
 				"path":   "/test",
 				"origin": "127.0.0.1",
-				"key":    logHiddenValue,
+				"key":    obfuscateKey("abs"),
 			}),
 		},
 		// enable_key_logging is not set, key is not passed, no additional data field
@@ -97,7 +97,7 @@ func TestGetLogEntryForRequest(t *testing.T) {
 				"origin": "127.0.0.1",
 				"a":      1,
 				"b":      "test",
-				"key":    logHiddenValue,
+				"key":    obfuscateKey("abc"),
 			}),
 		},
 		// enable_key_logging is not set, key is not passed, additional data fields are passed
@@ -117,7 +117,7 @@ func TestGetLogEntryForRequest(t *testing.T) {
 	for _, test := range testData {
 		globalConf.EnableKeyLogging = test.EnableKeyLogging
 		config.SetGlobal(globalConf)
-		logEntry := getLogEntryForRequest(testReq, test.Key, test.Data)
+		logEntry := getLogEntryForRequest(nil, testReq, test.Key, test.Data)
 		if logEntry.Data["path"] != test.Result.Data["path"] {
 			t.Error("Expected 'path':", test.Result.Data["path"], "Got:", logEntry.Data["path"])
 		}

--- a/looping_test.go
+++ b/looping_test.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"encoding/json"
+	"sync"
 	"testing"
 
 	"github.com/TykTechnologies/tyk/test"
@@ -128,24 +129,24 @@ func TestLooping(t *testing.T) {
 }
 
 func TestConcurrencyReloads(t *testing.T) {
-    var wg sync.WaitGroup
+	var wg sync.WaitGroup
 
-    ts := newTykTestServer()
-    defer ts.Close()
+	ts := newTykTestServer()
+	defer ts.Close()
 
-    buildAndLoadAPI()
+	buildAndLoadAPI()
 
-    for i := 0; i < 10; i++ {
-        wg.Add(1)
-        go func() {
-            ts.Run(t, test.TestCase{Path: "/sample", Code: 200})
-            wg.Done()
-        }()
-    }
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			ts.Run(t, test.TestCase{Path: "/sample", Code: 200})
+			wg.Done()
+		}()
+	}
 
-    for j := 0; j < 5; j++ {
-        buildAndLoadAPI()
-    }
+	for j := 0; j < 5; j++ {
+		buildAndLoadAPI()
+	}
 
-    wg.Wait()
+	wg.Wait()
 }

--- a/looping_test.go
+++ b/looping_test.go
@@ -126,3 +126,26 @@ func TestLooping(t *testing.T) {
 		}...)
 	})
 }
+
+func TestConcurrencyReloads(t *testing.T) {
+    var wg sync.WaitGroup
+
+    ts := newTykTestServer()
+    defer ts.Close()
+
+    buildAndLoadAPI()
+
+    for i := 0; i < 10; i++ {
+        wg.Add(1)
+        go func() {
+            ts.Run(t, test.TestCase{Path: "/sample", Code: 200})
+            wg.Done()
+        }()
+    }
+
+    for j := 0; j < 5; j++ {
+        buildAndLoadAPI()
+    }
+
+    wg.Wait()
+}

--- a/main.go
+++ b/main.go
@@ -381,6 +381,8 @@ func loadAPIEndpoints(muxer *mux.Router) {
 		mainLog.Info("Node is slaved, REST API minimised")
 	}
 
+	r.HandleFunc("/trace", traceHandler).Methods("POST")
+
 	r.HandleFunc("/keys", keyHandler).Methods("POST", "PUT", "GET", "DELETE")
 	r.HandleFunc("/keys/{keyName:[^/]*}", keyHandler).Methods("POST", "PUT", "GET", "DELETE")
 	r.HandleFunc("/certs", certHandler).Methods("POST", "GET")
@@ -593,7 +595,7 @@ func doReload() {
 
 	// Initialize/reset the JSVM
 	if config.Global().EnableJSVM {
-		GlobalEventsJSVM.Init(nil)
+		GlobalEventsJSVM.Init(nil, logrus.NewEntry(log))
 	}
 
 	// Load the API Policies

--- a/main.go
+++ b/main.go
@@ -381,7 +381,7 @@ func loadAPIEndpoints(muxer *mux.Router) {
 		mainLog.Info("Node is slaved, REST API minimised")
 	}
 
-	r.HandleFunc("/trace", traceHandler).Methods("POST")
+	r.HandleFunc("/debug", traceHandler).Methods("POST")
 
 	r.HandleFunc("/keys", keyHandler).Methods("POST", "PUT", "GET", "DELETE")
 	r.HandleFunc("/keys/{keyName:[^/]*}", keyHandler).Methods("POST", "PUT", "GET", "DELETE")

--- a/middleware.go
+++ b/middleware.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -144,15 +143,11 @@ type BaseMiddleware struct {
 	Spec   *APISpec
 	Proxy  ReturningHttpHandler
 	logger *logrus.Entry
-	mu     sync.Mutex
 }
 
 func (t BaseMiddleware) Base() *BaseMiddleware { return &t }
 
 func (t BaseMiddleware) Logger() (logger *logrus.Entry) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
 	if t.logger == nil {
 		t.logger = logrus.NewEntry(log)
 	}
@@ -161,21 +156,11 @@ func (t BaseMiddleware) Logger() (logger *logrus.Entry) {
 }
 
 func (t *BaseMiddleware) SetName(name string) {
-	logger := t.Logger()
-
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	t.logger = logger.WithField("mw", name)
+	t.logger = t.Logger().WithField("mw", name)
 }
 
 func (t *BaseMiddleware) SetRequestLogger(r *http.Request) {
-	logger := t.Logger()
-
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	t.logger = getLogEntryForRequest(logger, r, ctxGetAuthToken(r), nil)
+	t.logger = getLogEntryForRequest(t.Logger(), r, ctxGetAuthToken(r), nil)
 }
 
 func (t BaseMiddleware) Init() {}

--- a/middleware.go
+++ b/middleware.go
@@ -144,14 +144,14 @@ type BaseMiddleware struct {
 	Spec   *APISpec
 	Proxy  ReturningHttpHandler
 	logger *logrus.Entry
-	mu     sync.RWMutex
+	mu     sync.Mutex
 }
 
 func (t BaseMiddleware) Base() *BaseMiddleware { return &t }
 
 func (t BaseMiddleware) Logger() (logger *logrus.Entry) {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
+	t.mu.Lock()
+	defer t.mu.Unlock()
 
 	if t.logger == nil {
 		t.logger = logrus.NewEntry(log)
@@ -161,6 +161,9 @@ func (t BaseMiddleware) Logger() (logger *logrus.Entry) {
 }
 
 func (t *BaseMiddleware) SetName(name string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
 	t.logger = t.Logger().WithField("mw", name)
 }
 

--- a/middleware.go
+++ b/middleware.go
@@ -165,10 +165,12 @@ func (t *BaseMiddleware) SetName(name string) {
 }
 
 func (t *BaseMiddleware) SetRequestLogger(r *http.Request) {
+	logger := t.Logger()
+
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	t.logger = getLogEntryForRequest(t.Logger(), r, ctxGetAuthToken(r), nil)
+	t.logger = getLogEntryForRequest(logger, r, ctxGetAuthToken(r), nil)
 }
 
 func (t BaseMiddleware) Init() {}

--- a/middleware.go
+++ b/middleware.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/gocraft/health"
 	"github.com/justinas/alice"
 	newrelic "github.com/newrelic/go-agent"
@@ -25,7 +26,10 @@ var GlobalRate = ratecounter.NewRateCounter(1 * time.Second)
 
 type TykMiddleware interface {
 	Init()
-	Base() BaseMiddleware
+	Base() *BaseMiddleware
+	SetName(string)
+	SetRequestLogger(*http.Request)
+	Logger() *logrus.Entry
 	Config() (interface{}, error)
 	ProcessRequest(w http.ResponseWriter, r *http.Request, conf interface{}) (error, int) // Handles request
 	EnabledForSpec() bool
@@ -47,15 +51,19 @@ func createDynamicMiddleware(name string, isPre, useSession bool, baseMid BaseMi
 func createMiddleware(mw TykMiddleware) func(http.Handler) http.Handler {
 	// construct a new instance
 	mw.Init()
+	mw.SetName(mw.Name())
+	mw.Logger().Debug("Init")
 
 	// Pull the configuration
 	mwConf, err := mw.Config()
 	if err != nil {
-		log.Fatal("[Middleware] Configuration load failed")
+		mw.Logger().Fatal("[Middleware] Configuration load failed")
 	}
 
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mw.SetRequestLogger(r)
+
 			if config.Global().NewRelic.AppName != "" {
 				if txn, ok := w.(newrelic.Transaction); ok {
 					defer newrelic.StartSegment(txn, mw.Name()).End()
@@ -75,6 +83,7 @@ func createMiddleware(mw TykMiddleware) func(http.Handler) http.Handler {
 			job.EventKv("executed", meta)
 			job.EventKv(eventName, meta)
 			startTime := time.Now()
+			mw.Logger().WithField("ts", startTime.UnixNano()).Debug("Started")
 
 			if mw.Base().Spec.CORS.OptionsPassthrough && r.Method == "OPTIONS" {
 				h.ServeHTTP(w, r)
@@ -82,16 +91,23 @@ func createMiddleware(mw TykMiddleware) func(http.Handler) http.Handler {
 			}
 			err, errCode := mw.ProcessRequest(w, r, mwConf)
 			if err != nil {
-
-				handler := ErrorHandler{mw.Base()}
+				handler := ErrorHandler{*mw.Base()}
 				handler.HandleError(w, r, err.Error(), errCode)
 
 				meta["error"] = err.Error()
 
-				job.TimingKv("exec_time", time.Since(startTime).Nanoseconds(), meta)
-				job.TimingKv(eventName+".exec_time", time.Since(startTime).Nanoseconds(), meta)
+				finishTime := time.Since(startTime)
+				job.TimingKv("exec_time", finishTime.Nanoseconds(), meta)
+				job.TimingKv(eventName+".exec_time", finishTime.Nanoseconds(), meta)
+
+				mw.Logger().WithError(err).WithField("code", errCode).WithField("ns", finishTime.Nanoseconds()).Debug("Finished")
 				return
 			}
+
+			finishTime := time.Since(startTime)
+			job.TimingKv("exec_time", finishTime.Nanoseconds(), meta)
+			job.TimingKv(eventName+".exec_time", finishTime.Nanoseconds(), meta)
+			mw.Logger().WithField("code", errCode).WithField("ns", finishTime.Nanoseconds()).Debug("Finished")
 
 			// Special code, bypasses all other execution
 			if errCode != mwStatusRespond {
@@ -101,9 +117,6 @@ func createMiddleware(mw TykMiddleware) func(http.Handler) http.Handler {
 			} else {
 				mw.Base().UpdateRequestSession(r)
 			}
-
-			job.TimingKv("exec_time", time.Since(startTime).Nanoseconds(), meta)
-			job.TimingKv(eventName+".exec_time", time.Since(startTime).Nanoseconds(), meta)
 		})
 	}
 }
@@ -127,11 +140,28 @@ func mwList(mws ...TykMiddleware) []alice.Constructor {
 // BaseMiddleware wraps up the ApiSpec and Proxy objects to be included in a
 // middleware handler, this can probably be handled better.
 type BaseMiddleware struct {
-	Spec  *APISpec
-	Proxy ReturningHttpHandler
+	Spec   *APISpec
+	Proxy  ReturningHttpHandler
+	logger *logrus.Entry
 }
 
-func (t BaseMiddleware) Base() BaseMiddleware { return t }
+func (t BaseMiddleware) Base() *BaseMiddleware { return &t }
+
+func (t BaseMiddleware) Logger() (logger *logrus.Entry) {
+	if t.logger == nil {
+		t.logger = logrus.NewEntry(log)
+	}
+
+	return t.logger
+}
+
+func (t *BaseMiddleware) SetName(name string) {
+	t.logger = t.Logger().WithField("mw", name)
+}
+
+func (t *BaseMiddleware) SetRequestLogger(r *http.Request) {
+	t.logger = getLogEntryForRequest(t.Logger(), r, ctxGetAuthToken(r), nil)
+}
 
 func (t BaseMiddleware) Init() {}
 func (t BaseMiddleware) EnabledForSpec() bool {
@@ -147,7 +177,7 @@ func (t BaseMiddleware) OrgSession(key string) (user.SessionState, bool) {
 	if found && t.Spec.GlobalConfig.EnforceOrgDataAge {
 		// If exists, assume it has been authorized and pass on
 		// We cache org expiry data
-		log.Debug("Setting data expiry: ", session.OrgID)
+		t.Logger().Debug("Setting data expiry: ", session.OrgID)
 		go t.SetOrgExpiry(session.OrgID, session.DataExpires)
 	}
 
@@ -160,11 +190,11 @@ func (t BaseMiddleware) SetOrgExpiry(orgid string, expiry int64) {
 }
 
 func (t BaseMiddleware) OrgSessionExpiry(orgid string) int64 {
-	log.Debug("Checking: ", orgid)
+	t.Logger().Debug("Checking: ", orgid)
 	cachedVal, found := ExpiryCache.Get(orgid)
 	if !found {
 		go t.OrgSession(orgid)
-		log.Debug("no cached entry found, returning 7 days")
+		t.Logger().Debug("no cached entry found, returning 7 days")
 		return 604800
 	}
 
@@ -185,7 +215,7 @@ func (t BaseMiddleware) UpdateRequestSession(r *http.Request) bool {
 
 	lifetime := session.Lifetime(t.Spec.SessionLifetime)
 	if err := t.Spec.SessionManager.UpdateSession(token, session, lifetime, false); err != nil {
-		log.WithError(err).Error("Can't update session")
+		t.Logger().WithError(err).Error("Can't update session")
 		return false
 	}
 
@@ -213,14 +243,14 @@ func (t BaseMiddleware) ApplyPolicies(key string, session *user.SessionState) er
 		policiesMu.RUnlock()
 		if !ok {
 			err := fmt.Errorf("policy not found: %q", polID)
-			log.Error(err)
+			t.Logger().Error(err)
 			return err
 		}
 		// Check ownership, policy org owner must be the same as API,
 		// otherwise youcould overwrite a session key with a policy from a different org!
 		if t.Spec != nil && policy.OrgID != t.Spec.OrgID {
 			err := fmt.Errorf("attempting to apply policy from different organisation to key, skipping")
-			log.Error(err)
+			t.Logger().Error(err)
 			return err
 		}
 
@@ -229,7 +259,7 @@ func (t BaseMiddleware) ApplyPolicies(key string, session *user.SessionState) er
 			if policy.Partitions.Quota {
 				if didQuota {
 					err := fmt.Errorf("cannot apply multiple quota policies")
-					log.Error(err)
+					t.Logger().Error(err)
 					return err
 				}
 				didQuota = true
@@ -241,7 +271,7 @@ func (t BaseMiddleware) ApplyPolicies(key string, session *user.SessionState) er
 			if policy.Partitions.RateLimit {
 				if didRateLimit {
 					err := fmt.Errorf("cannot apply multiple rate limit policies")
-					log.Error(err)
+					t.Logger().Error(err)
 					return err
 				}
 				didRateLimit = true
@@ -270,7 +300,7 @@ func (t BaseMiddleware) ApplyPolicies(key string, session *user.SessionState) er
 		} else {
 			if len(policies) > 1 {
 				err := fmt.Errorf("cannot apply multiple policies if any are non-partitioned")
-				log.Error(err)
+				t.Logger().Error(err)
 				return err
 			}
 			// This is not a partitioned policy, apply everything
@@ -329,7 +359,7 @@ func (t BaseMiddleware) CheckSessionAndIdentityForValidKey(key string, r *http.R
 	}
 
 	// Try and get the session from the session store
-	log.Debug("Querying local cache")
+	t.Logger().Debug("Querying local cache")
 	cacheKey := key
 	if t.Spec.GlobalConfig.HashKeys {
 		cacheKey = storage.HashStr(key)
@@ -339,17 +369,17 @@ func (t BaseMiddleware) CheckSessionAndIdentityForValidKey(key string, r *http.R
 	if !t.Spec.GlobalConfig.LocalSessionCache.DisableCacheSessionState {
 		cachedVal, found := SessionCache.Get(cacheKey)
 		if found {
-			log.Debug("--> Key found in local cache")
+			t.Logger().Debug("--> Key found in local cache")
 			session := cachedVal.(user.SessionState)
 			if err := t.ApplyPolicies(key, &session); err != nil {
-				log.Error(err)
+				t.Logger().Error(err)
 			}
 			return session, true
 		}
 	}
 
 	// Check session store
-	log.Debug("Querying keystore")
+	t.Logger().Debug("Querying keystore")
 	session, found := t.Spec.SessionManager.SessionDetail(key, false)
 	if found {
 		session.SetKeyHash(cacheKey)
@@ -361,19 +391,19 @@ func (t BaseMiddleware) CheckSessionAndIdentityForValidKey(key string, r *http.R
 
 		// Check for a policy, if there is a policy, pull it and overwrite the session values
 		if err := t.ApplyPolicies(key, &session); err != nil {
-			log.Error(err)
+			t.Logger().Error(err)
 		}
-		log.Debug("--> Got key")
+		t.Logger().Debug("Got key")
 		return session, true
 	}
 
-	log.Debug("Querying authstore")
+	t.Logger().Debug("Querying authstore")
 	// 2. If not there, get it from the AuthorizationHandler
 	session, found = t.Spec.AuthManager.KeyAuthorised(key)
 	if found {
 		session.SetKeyHash(cacheKey)
 		// If not in Session, and got it from AuthHandler, create a session with a new TTL
-		log.Info("Recreating session for key: ", key)
+		t.Logger().Info("Recreating session for key: ", key)
 
 		// cache it
 		if !t.Spec.GlobalConfig.LocalSessionCache.DisableCacheSessionState {
@@ -382,10 +412,10 @@ func (t BaseMiddleware) CheckSessionAndIdentityForValidKey(key string, r *http.R
 
 		// Check for a policy, if there is a policy, pull it and overwrite the session values
 		if err := t.ApplyPolicies(key, &session); err != nil {
-			log.Error(err)
+			t.Logger().Error(err)
 		}
 
-		log.Debug("Lifetime is: ", session.Lifetime(t.Spec.SessionLifetime))
+		t.Logger().Debug("Lifetime is: ", session.Lifetime(t.Spec.SessionLifetime))
 		ctxScheduleSessionUpdate(r)
 	}
 

--- a/middleware.go
+++ b/middleware.go
@@ -165,12 +165,10 @@ func (t *BaseMiddleware) SetName(name string) {
 }
 
 func (t *BaseMiddleware) SetRequestLogger(r *http.Request) {
-	logger := t.Logger()
-
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	t.logger = getLogEntryForRequest(logger, r, ctxGetAuthToken(r), nil)
+	t.logger = getLogEntryForRequest(t.logger, r, ctxGetAuthToken(r), nil)
 }
 
 func (t BaseMiddleware) Init() {}

--- a/middleware.go
+++ b/middleware.go
@@ -161,17 +161,21 @@ func (t BaseMiddleware) Logger() (logger *logrus.Entry) {
 }
 
 func (t *BaseMiddleware) SetName(name string) {
+	logger := t.Logger()
+
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	t.logger = t.Logger().WithField("mw", name)
+	t.logger = logger.WithField("mw", name)
 }
 
 func (t *BaseMiddleware) SetRequestLogger(r *http.Request) {
+	logger := t.Logger()
+
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	t.logger = getLogEntryForRequest(t.logger, r, ctxGetAuthToken(r), nil)
+	t.logger = getLogEntryForRequest(logger, r, ctxGetAuthToken(r), nil)
 }
 
 func (t BaseMiddleware) Init() {}

--- a/multiauth_test.go
+++ b/multiauth_test.go
@@ -74,7 +74,7 @@ func getMultiAuthStandardAndBasicAuthChain(spec *APISpec) http.Handler {
 	remote, _ := url.Parse(testHttpAny)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
 	proxyHandler := ProxyHandler(proxy, spec)
-	baseMid := BaseMiddleware{spec, proxy}
+	baseMid := BaseMiddleware{Spec: spec, Proxy: proxy}
 	chain := alice.New(mwList(
 		&IPWhiteListMiddleware{baseMid},
 		&IPBlackListMiddleware{BaseMiddleware: baseMid},

--- a/mw_access_rights.go
+++ b/mw_access_rights.go
@@ -25,21 +25,13 @@ func (a *AccessRightsCheck) ProcessRequest(w http.ResponseWriter, r *http.Reques
 		}
 	}
 	session := ctxGetSession(r)
-	token := ctxGetAuthToken(r)
 
 	// If there's nothing in our profile, we let them through to the next phase
 	if len(session.AccessRights) > 0 {
 		// Otherwise, run auth checks
 		versionList, apiExists := session.AccessRights[a.Spec.APIID]
 		if !apiExists {
-			logEntry := getLogEntryForRequest(
-				r,
-				token,
-				map[string]interface{}{
-					"api_found": false,
-				},
-			)
-			logEntry.Info("Attempted access to unauthorised API.")
+			a.Logger().Info("Attempted access to unauthorised API")
 
 			return errors.New("Access to this API has been disallowed"), http.StatusForbidden
 		}
@@ -59,17 +51,7 @@ func (a *AccessRightsCheck) ProcessRequest(w http.ResponseWriter, r *http.Reques
 		}
 
 		if !found {
-			// Not found? Bounce
-			logEntry := getLogEntryForRequest(
-				r,
-				token,
-				map[string]interface{}{
-					"api_found":     true,
-					"version_found": false,
-				},
-			)
-			logEntry.Info("Attempted access to unauthorised API version.")
-
+			a.Logger().Info("Attempted access to unauthorised API version.")
 			return errors.New("Access to this API has been disallowed"), http.StatusForbidden
 		}
 	}

--- a/mw_api_rate_limit.go
+++ b/mw_api_rate_limit.go
@@ -44,8 +44,7 @@ func (k *RateLimitForAPI) EnabledForSpec() bool {
 }
 
 func (k *RateLimitForAPI) handleRateLimitFailure(r *http.Request, token string) (error, int) {
-	logEntry := getLogEntryForRequest(r, token, nil)
-	logEntry.Info("API rate limit exceeded.")
+	k.Logger().WithField("key", obfuscateKey(token)).Info("API rate limit exceeded.")
 
 	// Fire a rate limit exceeded event
 	k.FireEvent(EventRateLimitExceeded, EventKeyFailureMeta{

--- a/mw_api_rate_limit_test.go
+++ b/mw_api_rate_limit_test.go
@@ -32,7 +32,7 @@ func getRLOpenChain(spec *APISpec) http.Handler {
 	remote, _ := url.Parse(spec.Proxy.TargetURL)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
 	proxyHandler := ProxyHandler(proxy, spec)
-	baseMid := BaseMiddleware{spec, proxy}
+	baseMid := BaseMiddleware{Spec: spec, Proxy: proxy}
 	chain := alice.New(mwList(
 		&IPWhiteListMiddleware{baseMid},
 		&IPBlackListMiddleware{BaseMiddleware: baseMid},
@@ -46,7 +46,7 @@ func getGlobalRLAuthKeyChain(spec *APISpec) http.Handler {
 	remote, _ := url.Parse(spec.Proxy.TargetURL)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
 	proxyHandler := ProxyHandler(proxy, spec)
-	baseMid := BaseMiddleware{spec, proxy}
+	baseMid := BaseMiddleware{Spec: spec, Proxy: proxy}
 	chain := alice.New(mwList(
 		&IPWhiteListMiddleware{baseMid},
 		&IPBlackListMiddleware{BaseMiddleware: baseMid},

--- a/mw_auth_key.go
+++ b/mw_auth_key.go
@@ -75,8 +75,7 @@ func (k *AuthKey) ProcessRequest(w http.ResponseWriter, r *http.Request, _ inter
 
 	if key == "" {
 		// No header value, fail
-		logEntry := getLogEntryForRequest(r, "", nil)
-		logEntry.Info("Attempted access with malformed header, no auth header found.")
+		k.Logger().Info("Attempted access with malformed header, no auth header found.")
 
 		return errors.New("Authorization field missing"), http.StatusUnauthorized
 	}
@@ -87,8 +86,7 @@ func (k *AuthKey) ProcessRequest(w http.ResponseWriter, r *http.Request, _ inter
 	// Check if API key valid
 	session, keyExists := k.CheckSessionAndIdentityForValidKey(key, r)
 	if !keyExists {
-		logEntry := getLogEntryForRequest(r, key, nil)
-		logEntry.Info("Attempted access with non-existent key.")
+		k.Logger().WithField("key", obfuscateKey(key)).Info("Attempted access with non-existent key.")
 
 		// Fire Authfailed Event
 		AuthFailed(k, r, key)

--- a/mw_auth_key_test.go
+++ b/mw_auth_key_test.go
@@ -125,7 +125,7 @@ func getAuthKeyChain(spec *APISpec) http.Handler {
 	remote, _ := url.Parse(spec.Proxy.TargetURL)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
 	proxyHandler := ProxyHandler(proxy, spec)
-	baseMid := BaseMiddleware{spec, proxy}
+	baseMid := BaseMiddleware{Spec: spec, Proxy: proxy}
 	chain := alice.New(mwList(
 		&IPWhiteListMiddleware{baseMid},
 		&IPBlackListMiddleware{BaseMiddleware: baseMid},

--- a/mw_hmac_test.go
+++ b/mw_hmac_test.go
@@ -59,7 +59,7 @@ func getHMACAuthChain(spec *APISpec) http.Handler {
 	remote, _ := url.Parse(testHttpAny)
 	proxy := TykNewSingleHostReverseProxy(remote, spec)
 	proxyHandler := ProxyHandler(proxy, spec)
-	baseMid := BaseMiddleware{spec, proxy}
+	baseMid := BaseMiddleware{Spec: spec, Proxy: proxy}
 	chain := alice.New(mwList(
 		&IPWhiteListMiddleware{baseMid},
 		&IPBlackListMiddleware{BaseMiddleware: baseMid},

--- a/mw_js_plugin_test.go
+++ b/mw_js_plugin_test.go
@@ -23,11 +23,12 @@ import (
 
 func TestJSVMLogs(t *testing.T) {
 	var buf bytes.Buffer
+	log := logrus.New()
+	log.Out = &buf
+	log.Formatter = new(prefixed.TextFormatter)
+
 	jsvm := JSVM{}
-	jsvm.Init(nil)
-	jsvm.Log = logrus.New()
-	jsvm.Log.Out = &buf
-	jsvm.Log.Formatter = new(prefixed.TextFormatter)
+	jsvm.Init(nil, logrus.NewEntry(log))
 
 	jsvm.RawLog = logrus.New()
 	jsvm.RawLog.Out = &buf
@@ -81,7 +82,7 @@ func TestJSVMBody(t *testing.T) {
 	body := "foô \uffff \u0000 \xff bàr"
 	req := httptest.NewRequest("GET", "/foo", strings.NewReader(body))
 	jsvm := JSVM{}
-	jsvm.Init(nil)
+	jsvm.Init(nil, logrus.NewEntry(log))
 
 	const js = `
 var leakMid = new TykJS.TykMiddleware.NewMiddleware({})
@@ -117,7 +118,7 @@ func TestJSVMProcessTimeout(t *testing.T) {
 	}
 	req := httptest.NewRequest("GET", "/foo", strings.NewReader("body"))
 	jsvm := JSVM{}
-	jsvm.Init(nil)
+	jsvm.Init(nil, logrus.NewEntry(log))
 	jsvm.Timeout = time.Millisecond
 
 	// this js plugin just loops forever, keeping Otto at 100% CPU
@@ -160,12 +161,12 @@ testJSVMData.NewProcessRequest(function(request, session, spec) {
 	return testJSVMData.ReturnData(request, {})
 });`
 	dynMid := &DynamicMiddleware{
-		BaseMiddleware:      BaseMiddleware{spec, nil},
+		BaseMiddleware:      BaseMiddleware{Spec: spec, Proxy: nil},
 		MiddlewareClassName: "testJSVMData",
 		Pre:                 true,
 	}
 	jsvm := JSVM{}
-	jsvm.Init(nil)
+	jsvm.Init(nil, logrus.NewEntry(log))
 	if _, err := jsvm.VM.Run(js); err != nil {
 		t.Fatalf("failed to set up js plugin: %v", err)
 	}
@@ -196,12 +197,12 @@ testJSVMData.NewProcessRequest(function(request, session, config) {
 	return testJSVMData.ReturnData(request, {})
 });`
 	dynMid := &DynamicMiddleware{
-		BaseMiddleware:      BaseMiddleware{spec, nil},
+		BaseMiddleware:      BaseMiddleware{Spec: spec, Proxy: nil},
 		MiddlewareClassName: "testJSVMData",
 		Pre:                 true,
 	}
 	jsvm := JSVM{}
-	jsvm.Init(nil)
+	jsvm.Init(nil, logrus.NewEntry(log))
 	if _, err := jsvm.VM.Run(js); err != nil {
 		t.Fatalf("failed to set up js plugin: %v", err)
 	}
@@ -242,12 +243,12 @@ testJSVMData.NewProcessRequest(function(request, session, config) {
 	return testJSVMData.ReturnData(request, {})
 });`
 	dynMid := &DynamicMiddleware{
-		BaseMiddleware:      BaseMiddleware{spec, nil},
+		BaseMiddleware:      BaseMiddleware{Spec: spec, Proxy: nil},
 		MiddlewareClassName: "testJSVMData",
 		Pre:                 true,
 	}
 	jsvm := JSVM{}
-	jsvm.Init(nil)
+	jsvm.Init(nil, logrus.NewEntry(log))
 	if _, err := jsvm.VM.Run(js); err != nil {
 		t.Fatalf("failed to set up js plugin: %v", err)
 	}
@@ -276,7 +277,7 @@ testJSVMCore.NewProcessRequest(function(request, session, config) {
 	return testJSVMCore.ReturnData(request, {})
 });`
 	dynMid := &DynamicMiddleware{
-		BaseMiddleware:      BaseMiddleware{spec, nil},
+		BaseMiddleware:      BaseMiddleware{Spec: spec, Proxy: nil},
 		MiddlewareClassName: "testJSVMCore",
 		Pre:                 true,
 	}
@@ -296,7 +297,7 @@ testJSVMCore.NewProcessRequest(function(request, session, config) {
 		config.SetGlobal(globalConf)
 	}()
 	jsvm := JSVM{}
-	jsvm.Init(nil)
+	jsvm.Init(nil, logrus.NewEntry(log))
 	if _, err := jsvm.VM.Run(js); err != nil {
 		t.Fatalf("failed to set up js plugin: %v", err)
 	}
@@ -321,7 +322,7 @@ func TestJSVMRequestScheme(t *testing.T) {
 	req := httptest.NewRequest("GET", "/foo", nil)
 	req.URL.Scheme = "http"
 	jsvm := JSVM{}
-	jsvm.Init(nil)
+	jsvm.Init(nil, logrus.NewEntry(log))
 
 	const js = `
 var leakMid = new TykJS.TykMiddleware.NewMiddleware({})
@@ -419,7 +420,7 @@ func TestTykMakeHTTPRequest(t *testing.T) {
 
 func TestJSVMBase64(t *testing.T) {
 	jsvm := JSVM{}
-	jsvm.Init(nil)
+	jsvm.Init(nil, logrus.NewEntry(log))
 
 	inputString := "teststring"
 	inputB64 := "dGVzdHN0cmluZw=="

--- a/mw_modify_headers.go
+++ b/mw_modify_headers.go
@@ -32,12 +32,13 @@ func (t *TransformHeaders) ProcessRequest(w http.ResponseWriter, r *http.Request
 
 	// Manage global headers first - remove
 	for _, gdKey := range vInfo.GlobalHeadersRemove {
-		log.Debug("Removing: ", gdKey)
+		t.Logger().Debug("Removing: ", gdKey)
 		r.Header.Del(gdKey)
 	}
 
 	// Add
 	for nKey, nVal := range vInfo.GlobalHeaders {
+		t.Logger().Debug("Adding: ", nKey)
 		r.Header.Set(nKey, replaceTykVariables(r, nVal, false))
 	}
 

--- a/mw_organization_activity_test.go
+++ b/mw_organization_activity_test.go
@@ -1,3 +1,5 @@
+// +build !race
+
 package main
 
 import (

--- a/mw_organization_activity_test.go
+++ b/mw_organization_activity_test.go
@@ -129,7 +129,7 @@ func TestProcessRequestOffThreadQuotaLimit(t *testing.T) {
 		map[string]interface{}{
 			"quota_max":          10,
 			"quota_remaining":    10,
-			"quota_renewal_rate": 3,
+			"quota_renewal_rate": 2,
 		},
 	)
 
@@ -144,7 +144,7 @@ func TestProcessRequestOffThreadQuotaLimit(t *testing.T) {
 		// some of next request should fail with 403 as it is out of quota
 		failed := false
 		i := 0
-		for i = 0; i < 10; i++ {
+		for i = 0; i < 11; i++ {
 			res, _ := ts.Run(t, test.TestCase{})
 			res.Body.Close()
 			if res.StatusCode == http.StatusForbidden {
@@ -163,7 +163,7 @@ func TestProcessRequestOffThreadQuotaLimit(t *testing.T) {
 
 		// next 10 requests should be OK again
 		ok := false
-		for i = 0; i < 10; i++ {
+		for i = 0; i < 9; i++ {
 			res, _ := ts.Run(t, test.TestCase{})
 			res.Body.Close()
 			if res.StatusCode == http.StatusOK {

--- a/mw_rate_limiting.go
+++ b/mw_rate_limiting.go
@@ -25,7 +25,7 @@ func (k *RateLimitAndQuotaCheck) EnabledForSpec() bool {
 }
 
 func (k *RateLimitAndQuotaCheck) handleRateLimitFailure(r *http.Request, token string) (error, int) {
-	logEntry := getLogEntryForRequest(r, token, nil)
+	logEntry := getLogEntryForRequest(k.Logger(), r, token, nil)
 	logEntry.Info("Key rate limit exceeded.")
 
 	// Fire a rate limit exceeded event
@@ -43,7 +43,7 @@ func (k *RateLimitAndQuotaCheck) handleRateLimitFailure(r *http.Request, token s
 }
 
 func (k *RateLimitAndQuotaCheck) handleQuotaFailure(r *http.Request, token string) (error, int) {
-	logEntry := getLogEntryForRequest(r, token, nil)
+	logEntry := getLogEntryForRequest(k.Logger(), r, token, nil)
 	logEntry.Info("Key quota limit exceeded.")
 
 	// Fire a quota exceeded event

--- a/mw_rate_limiting.go
+++ b/mw_rate_limiting.go
@@ -25,8 +25,7 @@ func (k *RateLimitAndQuotaCheck) EnabledForSpec() bool {
 }
 
 func (k *RateLimitAndQuotaCheck) handleRateLimitFailure(r *http.Request, token string) (error, int) {
-	logEntry := getLogEntryForRequest(k.Logger(), r, token, nil)
-	logEntry.Info("Key rate limit exceeded.")
+	k.Logger().WithField("key", obfuscateKey(token)).Info("Key rate limit exceeded.")
 
 	// Fire a rate limit exceeded event
 	k.FireEvent(EventRateLimitExceeded, EventKeyFailureMeta{
@@ -43,8 +42,7 @@ func (k *RateLimitAndQuotaCheck) handleRateLimitFailure(r *http.Request, token s
 }
 
 func (k *RateLimitAndQuotaCheck) handleQuotaFailure(r *http.Request, token string) (error, int) {
-	logEntry := getLogEntryForRequest(k.Logger(), r, token, nil)
-	logEntry.Info("Key quota limit exceeded.")
+	k.Logger().WithField("key", obfuscateKey(token)).Info("Key quota limit exceeded.")
 
 	// Fire a quota exceeded event
 	k.FireEvent(EventQuotaExceeded, EventKeyFailureMeta{

--- a/mw_transform.go
+++ b/mw_transform.go
@@ -45,16 +45,7 @@ func (t *TransformMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 	}
 	err := transformBody(r, meta.(*TransformSpec), t.Spec.EnableContextVars)
 	if err != nil {
-		logEntry := getLogEntryForRequest(
-			r,
-			"",
-			map[string]interface{}{
-				"prefix":      "inbound-transform",
-				"server_name": t.Spec.Proxy.TargetURL,
-				"api_id":      t.Spec.APIID,
-			},
-		)
-		logEntry.Error(err)
+		t.Logger().WithError(err).Error("Body transform failure")
 	}
 	return nil, http.StatusOK
 }

--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -270,7 +270,7 @@ func TykNewSingleHostReverseProxy(target *url.URL, spec *APISpec) *ReverseProxy 
 		TykAPISpec:    spec,
 		FlushInterval: time.Duration(spec.GlobalConfig.HttpServerOptions.FlushInterval) * time.Millisecond,
 	}
-	proxy.ErrorHandler.BaseMiddleware = BaseMiddleware{spec, proxy}
+	proxy.ErrorHandler.BaseMiddleware = BaseMiddleware{Spec: spec, Proxy: proxy}
 	return proxy
 }
 

--- a/tracing.go
+++ b/tracing.go
@@ -51,7 +51,6 @@ type traceHttpResponse struct {
 	Body    string      `json:"body"`
 }
 
-
 // swagger:operation POST /trace trace trace
 //
 // Tracing request

--- a/tracing.go
+++ b/tracing.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/gorilla/mux"
+
+	"github.com/TykTechnologies/tyk/apidef"
+)
+
+type traceHttpRequest struct {
+	Method  string      `json:"method"`
+	Path    string      `json:"path"`
+	Body    string      `json:"body"`
+	Headers http.Header `json:"headers"`
+}
+
+func (tr *traceHttpRequest) toRequest() *http.Request {
+	r := httptest.NewRequest(tr.Method, tr.Path, strings.NewReader(tr.Body))
+	r.Header = tr.Headers
+	ctxSetTrace(r)
+
+	return r
+}
+
+// Tracing HTTP request
+//
+// swagger:model
+type traceRequest struct {
+	Request *traceHttpRequest     `json:"request"`
+	Spec    *apidef.APIDefinition `json:"spec"`
+}
+
+// Tracing HTTP response
+//
+// swagger:model
+type traceResponse struct {
+	Message  string             `json:"message"`
+	Response *traceHttpResponse `json:"response"`
+	Logs     string             `json:"logs"`
+}
+
+type traceHttpResponse struct {
+	Code    int         `json:"code"`
+	Headers http.Header `json:"headers"`
+	Body    string      `json:"body"`
+}
+
+
+// swagger:operation POST /trace trace trace
+//
+// Tracing request
+// Used to test API definition by sending sample request,
+// and analysisng output of both response and logs
+//
+//---
+// requestBody:
+//   content:
+//     application/json:
+//       schema:
+//         "$ref": "#/definitions/traceRequest"
+//       examples:
+//         request:
+//           method: GET
+//           path: /get
+//           headers:
+//              Authorization: key
+//         spec:
+//           api_name: "Test"
+// responses:
+//   200:
+//     description: Success tracing request
+//     schema:
+//       "$ref": "#/definitions/traceResponse"
+//     examples:
+//       message: "ok"
+//       response:
+//         code: 200
+//         headers:
+//           Header: value
+//         body: body-value
+//       logs: {...}\n{...}
+func traceHandler(w http.ResponseWriter, r *http.Request) {
+	var traceReq traceRequest
+	if err := json.NewDecoder(r.Body).Decode(&traceReq); err != nil {
+		log.Error("Couldn't decode trace request: ", err)
+
+		doJSONWrite(w, http.StatusBadRequest, apiError("Request malformed"))
+		return
+	}
+
+	if traceReq.Spec == nil {
+		log.Error("Spec field is missing")
+		doJSONWrite(w, http.StatusBadRequest, apiError("Spec field is missing"))
+		return
+	}
+
+	if traceReq.Request == nil {
+		log.Error("Request field is missing")
+		doJSONWrite(w, http.StatusBadRequest, apiError("Request field is missing"))
+		return
+	}
+
+	var logStorage bytes.Buffer
+	logger := logrus.New()
+	logger.Formatter = &logrus.JSONFormatter{}
+	logger.Level = logrus.DebugLevel
+	logger.Out = &logStorage
+
+	redisStore, redisOrgStore, healthStore, rpcAuthStore, rpcOrgStore := prepareStorage()
+	subrouter := mux.NewRouter()
+
+	loader := &APIDefinitionLoader{}
+	spec := loader.MakeSpec(traceReq.Spec, logrus.NewEntry(logger))
+
+	chainObj := processSpec(spec, nil, redisStore, redisOrgStore, healthStore, rpcAuthStore, rpcOrgStore, subrouter, logrus.NewEntry(logger))
+
+	if chainObj.ThisHandler == nil {
+		doJSONWrite(w, http.StatusBadRequest, traceResponse{Message: "error", Logs: logStorage.String()})
+		return
+	}
+
+	wr := httptest.NewRecorder()
+	chainObj.ThisHandler.ServeHTTP(wr, traceReq.Request.toRequest())
+
+	traceHttpResp := traceHttpResponse{Code: wr.Code, Body: wr.Body.String(), Headers: wr.HeaderMap}
+
+	log.Error(logStorage.String())
+
+	doJSONWrite(w, http.StatusOK, traceResponse{Message: "ok", Response: &traceHttpResp, Logs: logStorage.String()})
+}


### PR DESCRIPTION
Added new Tracing API, which allows you to debug API definition, by sending sample request to it.

As input, Tracing API require sample request object, and direct API definition.
This means that tracing API can be used even without creating API. Or for example, you can test API changes without saving them.

Example request:
```
POST /tyk/trace
{
    "request": {
        "method": "GET",
        "path": "/get",
        "headers": {
            "Header": ["Value"]
        }
    },
    "spec": {
        ...valid API definition...
    }
}
```

As output, it gives you response object, and gateway logs as JSON multi-line string.

Example output:
```
{
    "message": "ok"
    "response": "<raw-http-response-dump>",
    "logs": "{...}\n{...}"
}
```

Logging itself now way more structured, and prepared for easy parsing. Based on the logs you can see:
* API loading process: which middleware was loaded or not, issues during parsing and etc.
* Middleware logs: order of running, elapsed time, individual MW logs

Example of log output:

```
{"level":"debug","msg":"Default JSVM timeout used: 5s","prefix":"jsvm","time":"2018-09-05T17:49:19+03:00"}
{"api_id":"test","api_name":"","level":"info","msg":"Loading API","org_id":"","time":"2018-09-05T17:49:19+03:00"}
{"api_id":"test","api_name":"","level":"debug","msg":"Initializing API","org_id":"","time":"2018-09-05T17:49:19+03:00"}
{"api_id":"test","api_name":"","level":"debug","msg":"Init","mw":"RateCheckMW","org_id":"","time":"2018-09-05T17:49:19+03:00"}
{"api_id":"test","api_name":"","level":"debug","msg":"Init","mw":"VersionCheck","org_id":"","time":"2018-09-05T17:49:19+03:00"}
{"api_id":"test","api_name":"","level":"info","msg":"Checking security policy: Token","org_id":"","time":"2018-09-05T17:49:19+03:00"}
{"api_id":"test","api_name":"","level":"debug","msg":"Init","mw":"AuthKey","org_id":"","time":"2018-09-05T17:49:19+03:00"}
{"api_id":"test","api_name":"","level":"debug","msg":"Init","mw":"KeyExpired","org_id":"","time":"2018-09-05T17:49:19+03:00"}
{"api_id":"test","api_name":"","level":"debug","msg":"Init","mw":"AccessRightsCheck","org_id":"","time":"2018-09-05T17:49:19+03:00"}
{"api_id":"test","api_name":"","level":"debug","msg":"Init","mw":"RateLimitAndQuotaCheck","org_id":"","time":"2018-09-05T17:49:19+03:00"}
{"api_id":"test","api_name":"","level":"debug","msg":"Init","mw":"GranularAccessMiddleware","org_id":"","time":"2018-09-05T17:49:19+03:00"}
{"api_id":"test","api_name":"","level":"debug","msg":"Init","mw":"VersionCheck","org_id":"","time":"2018-09-05T17:49:19+03:00"}
{"api_id":"test","api_name":"","level":"debug","msg":"Init","mw":"KeyExpired","org_id":"","time":"2018-09-05T17:49:19+03:00"}
{"api_id":"test","api_name":"","level":"debug","msg":"Init","mw":"AccessRightsCheck","org_id":"","time":"2018-09-05T17:49:19+03:00"}
{"api_id":"test","api_name":"","level":"debug","msg":"Rate limit endpoint is: /sampletyk/rate-limits/","org_id":"","time":"2018-09-05T17:49:19+03:00"}
{"api_id":"test","api_name":"","level":"debug","msg":"Setting Listen Path: /sample","org_id":"","time":"2018-09-05T17:49:19+03:00"}
{"api_id":"test","api_name":"","level":"info","msg":"API Loaded","org_id":"","prefix":"gateway","server_name":"--","time":"2018-09-05T17:49:19+03:00","user_id":"--","user_ip":"--"}
{"api_id":"test","api_name":"","level":"debug","msg":"Started","mw":"RateCheckMW","org_id":"","origin":"192.0.2.1","path":"/","time":"2018-09-05T17:49:19+03:00","ts":1536158959332155740}
{"api_id":"test","api_name":"","code":200,"level":"debug","msg":"Finished","mw":"RateCheckMW","ns":27925,"org_id":"","origin":"192.0.2.1","path":"/","time":"2018-09-05T17:49:19+03:00"}
{"api_id":"test","api_name":"","level":"debug","msg":"Started","mw":"VersionCheck","org_id":"","origin":"192.0.2.1","path":"/","time":"2018-09-05T17:49:19+03:00","ts":1536158959332214289}
{"api_id":"test","api_name":"","code":200,"level":"debug","msg":"Finished","mw":"VersionCheck","ns":23042,"org_id":"","origin":"192.0.2.1","path":"/","time":"2018-09-05T17:49:19+03:00"}
{"api_id":"test","api_name":"","level":"debug","msg":"Started","mw":"AuthKey","org_id":"","origin":"192.0.2.1","path":"/","time":"2018-09-05T17:49:19+03:00","ts":1536158959332264989}
{"api_id":"test","api_name":"","level":"debug","msg":"Querying local cache","mw":"AuthKey","org_id":"","origin":"192.0.2.1","path":"/","time":"2018-09-05T17:49:19+03:00"}
{"api_id":"test","api_name":"","level":"debug","msg":"Querying keystore","mw":"AuthKey","org_id":"","origin":"192.0.2.1","path":"/","time":"2018-09-05T17:49:19+03:00"}
{"api_id":"test","api_name":"","level":"debug","msg":"Got key","mw":"AuthKey","org_id":"","origin":"192.0.2.1","path":"/","time":"2018-09-05T17:49:19+03:00"}
{"api_id":"test","api_name":"","code":200,"level":"debug","msg":"Finished","mw":"AuthKey","ns":1149266,"org_id":"","origin":"192.0.2.1","path":"/","time":"2018-09-05T17:49:19+03:00"}
{"api_id":"test","api_name":"","key":"****ecf1","level":"debug","msg":"Started","mw":"KeyExpired","org_id":"","origin":"192.0.2.1","path":"/","time":"2018-09-05T17:49:19+03:00","ts":1536158959333468462}
{"api_id":"test","api_name":"","code":200,"key":"****ecf1","level":"debug","msg":"Finished","mw":"KeyExpired","ns":23915,"org_id":"","origin":"192.0.2.1","path":"/","time":"2018-09-05T17:49:19+03:00"}
{"api_id":"test","api_name":"","key":"****ecf1","level":"debug","msg":"Started","mw":"AccessRightsCheck","org_id":"","origin":"192.0.2.1","path":"/","time":"2018-09-05T17:49:19+03:00","ts":1536158959333521672}
{"api_id":"test","api_name":"","code":200,"key":"****ecf1","level":"debug","msg":"Finished","mw":"AccessRightsCheck","ns":18849,"org_id":"","origin":"192.0.2.1","path":"/","time":"2018-09-05T17:49:19+03:00"}
{"api_id":"test","api_name":"","key":"****ecf1","level":"debug","msg":"Started","mw":"RateLimitAndQuotaCheck","org_id":"","origin":"192.0.2.1","path":"/","time":"2018-09-05T17:49:19+03:00","ts":1536158959333632612}
{"api_id":"test","api_name":"","code":200,"key":"****ecf1","level":"debug","msg":"Finished","mw":"RateLimitAndQuotaCheck","ns":42329,"org_id":"","origin":"192.0.2.1","path":"/","time":"2018-09-05T17:49:19+03:00"}
{"api_id":"test","api_name":"","key":"****ecf1","level":"debug","msg":"Started","mw":"GranularAccessMiddleware","org_id":"","origin":"192.0.2.1","path":"/","time":"2018-09-05T17:49:19+03:00","ts":1536158959333706674}
{"api_id":"test","api_name":"","code":200,"key":"****ecf1","level":"debug","msg":"Finished","mw":"GranularAccessMiddleware","ns":17514,"org_id":"","origin":"192.0.2.1","path":"/","time":"2018-09-05T17:49:19+03:00"}
```

Such detailed logs, accessed progmatically, allow some exciting cases like debugging VirtualEndpoint code, and seeing all JS parsing issues, or JS logging data, directly from Dashboard UI.

This API also allow you to test authentification as well. To do so, you just need to create key for the API, or JWT token, and provide authentification header to tracing API. So you can test full API cycle, include access rights and etc.

If your API is protected, and you do not provide token to Tracing API, you will get unauthorized error.