### PR TITLE
improve log processed & listening on domain/path

### DIFF
--- a/api_loader.go
+++ b/api_loader.go
@@ -24,6 +24,7 @@ import (
 )
 
 type ChainObject struct {
+	Domain         string
 	ListenOn       string
 	ThisHandler    http.Handler
 	RateLimitChain http.Handler
@@ -444,6 +445,7 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 
 	chainDef.ThisHandler = chain
 	chainDef.ListenOn = spec.Proxy.ListenPath + "{rest:.*}"
+	chainDef.Domain = spec.Domain
 
 	logger.WithFields(logrus.Fields{
 		"prefix":      "gateway",
@@ -618,7 +620,7 @@ func loadApps(specs []*APISpec, muxer *mux.Router) {
 			chainObj.Subrouter.Handle(chainObj.RateLimitPath, chainObj.RateLimitChain)
 		}
 
-		mainLog.Info("Processed and listening on: ", chainObj.ListenOn)
+		mainLog.Infof("Processed and listening on: %s%s", chainObj.Domain, chainObj.ListenOn)
 		chainObj.Subrouter.Handle(chainObj.ListenOn, chainObj.ThisHandler)
 	}
 


### PR DESCRIPTION
When listening on custom domain rather than using listen paths e.g.`foo.com`. The gateway starts, and displays the following log message:

```
[Sep 12 16:05:13]  INFO main: Processed and listening on: /{rest:.*}
```
 
This makes it impossible to see what APIs are loaded.
By adding the `Domain` property to the chain object, we can now provide better logs:

```
[Sep 12 16:08:02]  INFO main: Processed and listening on: foo.com/{rest:.*}
```
