### PR TITLE
Chunked quota limiter

### DIFF
--- a/cli/lint/schema.go
+++ b/cli/lint/schema.go
@@ -1,0 +1,778 @@
+package lint
+
+const confSchema = `{
+"$schema": "http://json-schema.org/draft-04/schema#",
+"type": "object",
+"additionalProperties": false,
+"definitions": {
+	"StorageOptions": {
+		"type": ["object", "null"],
+		"additionalProperties": false,
+		"properties": {
+			"database": {
+				"type": "integer"
+			},
+			"enable_cluster": {
+				"type": "boolean"
+			},
+			"use_ssl":{
+				"type": "boolean"
+			},
+			"ssl_insecure_skip_verify":{
+				"type": "boolean"
+			},
+			"host": {
+				"type": "string",
+				"format": "host-no-port"
+			},
+			"hosts": {
+				"type": ["array", "null"]
+			},
+			"optimisation_max_active": {
+				"type": "integer"
+			},
+			"optimisation_max_idle": {
+				"type": "integer"
+			},
+			"password": {
+				"type": "string"
+			},
+			"port": {
+				"type": "integer"
+			},
+			"type": {
+				"type": "string",
+				"enum": ["", "redis"]
+			},
+			"username": {
+				"type": "string"
+			}
+		}
+	}
+},
+"properties": {
+	"allow_insecure_configs": {
+		"type": "boolean"
+	},
+	"allow_master_keys": {
+		"type": "boolean"
+	},
+	"allow_remote_config": {
+		"type": "boolean"
+	},
+	"analytics_config": {
+		"type": ["object", "null"],
+		"additionalProperties": false,
+		"properties": {
+			"enable_detailed_recording": {
+				"type": "boolean"
+			},
+			"enable_geo_ip": {
+				"type": "boolean"
+			},
+			"geo_ip_db_path": {
+				"type": "string",
+				"format": "path"
+			},
+			"ignored_ips": {
+				"type": ["array", "null"]
+			},
+			"normalise_urls": {
+				"type": ["object", "null"],
+				"additionalProperties": false,
+				"properties": {
+					"custom_patterns": {
+						"type": ["array", "null"]
+					},
+					"enabled": {
+						"type": "boolean"
+					},
+					"normalise_numbers": {
+						"type": "boolean"
+					},
+					"normalise_uuids": {
+						"type": "boolean"
+					}
+				}
+			},
+			"pool_size": {
+				"type": "integer"
+			},
+			"records_buffer_size": {
+				"type": "integer"
+			},
+			"storage_expiration_time": {
+				"type": "integer"
+			},
+			"type": {
+				"type": "string"
+			}
+		}
+	},
+	"app_path": {
+		"type": "string",
+		"format": "path"
+	},
+	"auth_override": {
+		"type": ["object", "null"],
+		"additionalProperties": false,
+		"properties": {
+			"auth_provider": {
+				"type": ["object", "null"],
+				"additionalProperties": false,
+				"properties": {
+					"meta": {
+						"type": ["array", "null"]
+					},
+					"name": {
+						"type": "string"
+					},
+					"storage_engine": {
+						"type": "string"
+					}
+				}
+			},
+			"force_auth_provider": {
+				"type": "boolean"
+			},
+			"force_session_provider": {
+				"type": "boolean"
+			},
+			"session_provider": {
+				"type": ["object", "null"],
+				"additionalProperties": false,
+				"properties": {
+					"meta": {
+						"type": ["array", "null"]
+					},
+					"name": {
+						"type": "string"
+					},
+					"storage_engine": {
+						"type": "string"
+					}
+				}
+			}
+		}
+	},
+	"bundle_base_url": {
+		"type": "string"
+	},
+	"cache_storage": {
+		"$ref": "#/definitions/StorageOptions"
+	},
+	"close_connections": {
+		"type": "boolean"
+	},
+	"proxy_close_connections": {
+		"type": "boolean"
+	},
+	"close_idle_connections": {
+		"type": "boolean"
+	},
+	"control_api_hostname": {
+		"type": "string"
+	},
+	"control_api_port": {
+		"type": "integer"
+	},
+	"coprocess_options": {
+		"type": ["object", "null"],
+		"additionalProperties": false,
+		"properties": {
+			"coprocess_grpc_server": {
+				"type": "string"
+			},
+			"enable_coprocess": {
+				"type": "boolean"
+			},
+			"python_path_prefix": {
+				"type": "string"
+			}
+		}
+	},
+	"db_app_conf_options": {
+		"type": ["object", "null"],
+		"additionalProperties": false,
+		"properties": {
+			"connection_string": {
+				"type": "string"
+			},
+			"node_is_segmented": {
+				"type": "boolean"
+			},
+			"tags": {
+				"type": ["array", "null"],
+				"items": {
+					"type": "string"
+				}
+			}
+		}
+	},
+	"version_header":{
+		"type": "string"
+	},
+	"disable_dashboard_zeroconf": {
+		"type": "boolean"
+	},
+	"disable_virtual_path_blobs": {
+		"type": "boolean"
+	},
+	"drl_notification_frequency": {
+		"type": "integer"
+	},
+	"enable_analytics": {
+		"type": "boolean"
+	},
+	"enable_api_segregation": {
+		"type": "boolean"
+	},
+	"enable_bundle_downloader": {
+		"type": "boolean"
+	},
+	"enable_custom_domains": {
+		"type": "boolean"
+	},
+	"enable_jsvm": {
+		"type": "boolean"
+	},
+	"jsvm_timeout": {
+		"type": "integer"
+	},
+	"enable_non_transactional_rate_limiter": {
+		"type": "boolean"
+	},
+	"enable_redis_rolling_limiter": {
+		"type": "boolean"
+	},
+	"enable_sentinel_rate_limiter": {
+		"type": "boolean"
+	},
+	"enable_separate_cache_store": {
+		"type": "boolean"
+	},
+	"enforce_org_data_age": {
+		"type": "boolean"
+	},
+	"enforce_org_data_detail_logging": {
+		"type": "boolean"
+	},
+	"enforce_org_quotas": {
+		"type": "boolean"
+	},
+	"event_handlers": {
+		"type": ["object", "null"],
+		"additionalProperties": false,
+		"properties": {
+			"events": {
+				"type": ["object", "null"],
+				"additionalProperties": false
+			}
+		}
+	},
+	"event_trigers_defunct": {
+		"type": ["array", "null"]
+	},
+	"experimental_process_org_off_thread": {
+		"type": "boolean"
+	},
+	"force_global_session_lifetime": {
+		"type": "boolean"
+	},
+	"global_session_lifetime": {
+		"type": "integer"
+	},
+	"graylog_network_addr": {
+		"type": "string"
+	},
+	"hash_keys": {
+		"type": "boolean"
+	},
+	"hash_key_function": {
+		"type": "string",
+		"enum": ["", "murmur32", "murmur64", "murmur128", "sha256"]
+	},
+	"health_check": {
+		"type": ["object", "null"],
+		"additionalProperties": false,
+		"properties": {
+			"enable_health_checks": {
+				"type": "boolean"
+			},
+			"health_check_value_timeouts": {
+				"type": "integer"
+			}
+		}
+	},
+	"hide_generator_header": {
+		"type": "boolean"
+	},
+	"hostname": {
+		"type": "string"
+	},
+	"http_server_options": {
+		"type": ["object", "null"],
+		"additionalProperties": false,
+		"properties": {
+			"certificates": {
+				"type": ["array", "null"],
+				"items": {
+					"type": ["object", "null"],
+					"additionalProperties": false,
+					"properties": {
+						"domain_name": {
+							"type": "string"
+						},
+						"cert_file": {
+							"type": "string"
+						},
+						"key_file": {
+							"type": "string"
+						}
+					}
+				}
+			},
+			"enable_websockets": {
+				"type": "boolean"
+			},
+			"flush_interval": {
+				"type": "integer"
+			},
+			"min_version": {
+				"type": "integer"
+			},
+			"override_defaults": {
+				"type": "boolean"
+			},
+			"read_timeout": {
+				"type": "integer"
+			},
+			"server_name": {
+				"type": "string"
+			},
+			"skip_url_cleaning": {
+				"type": "boolean"
+			},
+			"skip_target_path_escaping": {
+				"type": "boolean"
+			},
+			"ssl_insecure_skip_verify": {
+				"type": "boolean"
+			},
+			"use_ssl": {
+				"type": "boolean"
+			},
+			"use_ssl_le": {
+				"type": "boolean"
+			},
+			"write_timeout": {
+				"type": "integer"
+			},
+			"ssl_certificates": {
+				"type": ["array", "null"],
+				"items": {
+					"type": "string"
+				}
+			},
+			"ssl_ciphers":{
+				"type": ["array", "null"],
+				"items": {
+					"type": "string"
+				}
+			}
+		}
+	},
+	"legacy_enable_allowance_countdown": {
+		"type": "boolean"
+	},
+	"listen_address": {
+		"type": "string",
+		"format": "host-no-port"
+	},
+	"listen_port": {
+		"type": "integer"
+	},
+	"local_session_cache": {
+		"type": ["object", "null"],
+		"additionalProperties": false,
+		"properties": {
+			"cached_session_eviction": {
+				"type": "integer"
+			},
+			"cached_session_timeout": {
+				"type": "integer"
+			},
+			"disable_cached_session_state": {
+				"type": "boolean"
+			}
+		}
+	},
+	"log_level": {
+		"type": "string",
+		"enum": ["", "debug", "info", "warn", "error"]
+	},
+	"logstash_network_addr": {
+		"type": "string"
+	},
+	"logstash_transport": {
+		"type": "string"
+	},
+	"management_node": {
+		"type": "boolean"
+	},
+	"max_idle_connections_per_host": {
+		"type": "integer"
+	},
+	"max_idle_connections": {
+		"type": "integer"
+	},
+	"max_conn_time": {
+		"type": "integer"
+	},
+	"middleware_path": {
+		"type": "string",
+		"format": "path"
+	},
+	"monitor": {
+		"type": ["object", "null"],
+		"additionalProperties": false,
+		"properties": {
+			"configuration": {
+				"type": ["object", "null"],
+				"additionalProperties": false,
+				"properties": {
+					"event_timeout": {
+						"type": "integer"
+					},
+					"header_map": {
+						"type": ["array", "null"]
+					},
+					"method": {
+						"type": "string"
+					},
+					"target_path": {
+						"type": "string"
+					},
+					"template_path": {
+						"type": "string",
+						"format": "path"
+					}
+				}
+			},
+			"enable_trigger_monitors": {
+				"type": "boolean"
+			},
+			"global_trigger_limit": {
+				"type": "integer"
+			},
+			"monitor_org_keys": {
+				"type": "boolean"
+			},
+			"monitor_user_keys": {
+				"type": "boolean"
+			}
+		}
+	},
+	"node_secret": {
+		"type": "string"
+	},
+	"oauth_redirect_uri_separator": {
+		"type": "string"
+	},
+	"oauth_refresh_token_expire": {
+		"type": "integer"
+	},
+	"oauth_token_expire": {
+		"type": "integer"
+	},
+	"oauth_token_expired_retain_period": {
+		"type": "integer"
+	},
+	"optimisations_use_async_session_write": {
+		"type": "boolean"
+	},
+	"session_update_pool_size":{
+		"type": "integer"
+	},
+	"session_update_buffer_size":{
+		"type": "integer"
+	},
+	"pid_file_location": {
+		"type": "string"
+	},
+	"policies": {
+		"type": ["object", "null"],
+		"additionalProperties": false,
+		"properties": {
+			"allow_explicit_policy_id": {
+				"type": "boolean"
+			},
+			"policy_connection_string": {
+				"type": "string"
+			},
+			"policy_record_name": {
+				"type": "string"
+			},
+			"policy_source": {
+				"type": "string",
+				"enum": ["", "service", "rpc"]
+			}
+		}
+	},
+	"proxy_default_timeout": {
+		"type": "integer"
+	},
+	"proxy_ssl_insecure_skip_verify": {
+		"type": "boolean"
+	},
+	"proxy_ssl_min_version": {
+		"type": "integer"
+	},
+	"proxy_ssl_ciphers": {
+		"type": ["array", "null"],
+		"items": {
+			"type": "string"
+		}
+	},
+	"public_key_path": {
+		"type": "string",
+		"format": "path"
+	},
+	"reload_wait_time": {
+		"type": "integer"
+	},
+	"secret": {
+		"type": "string"
+	},
+	"sentry_code": {
+		"type": "string"
+	},
+	"service_discovery": {
+		"type": ["object", "null"],
+		"additionalProperties": false,
+		"properties": {
+			"default_cache_timeout": {
+				"type": "integer"
+			}
+		}
+	},
+	"slave_options": {
+		"type": ["object", "null"],
+		"additionalProperties": false,
+		"properties": {
+			"api_key": {
+				"type": "string"
+			},
+			"bind_to_slugs": {
+				"type": "boolean"
+			},
+			"call_timeout": {
+				"type": "integer"
+			},
+			"connection_string": {
+				"type": "string"
+			},
+			"disable_keyspace_sync": {
+				"type": "boolean"
+			},
+			"enable_rpc_cache": {
+				"type": "boolean"
+			},
+			"group_id": {
+				"type": "string"
+			},
+			"ping_timeout": {
+				"type": "integer"
+			},
+			"rpc_key": {
+				"type": "string"
+			},
+			"ssl_insecure_skip_verify": {
+				"type": "boolean"
+			},
+			"use_rpc": {
+				"type": "boolean"
+			},
+			"use_ssl": {
+				"type": "boolean"
+			},
+			"rpc_pool_size": {
+				"type": "integer"
+			}
+		}
+	},
+	"statsd_connection_string": {
+		"type": "string"
+	},
+	"statsd_prefix": {
+		"type": "string"
+	},
+	"storage": {
+		"$ref": "#/definitions/StorageOptions"
+	},
+	"suppress_default_org_store": {
+		"type": "boolean"
+	},
+	"suppress_redis_signal_reload": {
+		"type": "boolean"
+	},
+	"syslog_network_addr": {
+		"type": "string"
+	},
+	"syslog_transport": {
+		"type": "string"
+	},
+	"template_path": {
+		"type": "string",
+		"format": "path"
+	},
+	"tyk_js_path": {
+		"type": "string",
+		"format": "path"
+	},
+	"uptime_tests": {
+		"type": ["object", "null"],
+		"additionalProperties": false,
+		"properties": {
+			"config": {
+				"type": ["object", "null"],
+				"additionalProperties": false,
+				"properties": {
+					"checker_pool_size": {
+						"type": "integer"
+					},
+					"enable_uptime_analytics": {
+						"type": "boolean"
+					},
+					"failure_trigger_sample_size": {
+						"type": "integer"
+					},
+					"time_wait": {
+						"type": "integer"
+					}
+				}
+			},
+			"disable": {
+				"type": "boolean"
+			}
+		}
+	},
+	"use_db_app_configs": {
+		"type": "boolean"
+	},
+	"use_graylog": {
+		"type": "boolean"
+	},
+	"use_logstash": {
+		"type": "boolean"
+	},
+	"use_redis_log": {
+		"type": "boolean"
+	},
+	"use_sentry": {
+		"type": "boolean"
+	},
+	"use_syslog": {
+		"type": "boolean"
+	},
+	"security": {
+		"type": ["object", "null"],
+		"additionalProperties": false,
+		"properties": {
+			"private_certificate_encoding_secret": {
+				"type": "string"
+			},
+			"control_api_use_mutual_tls": {
+				"type": "boolean"
+			},
+			"pinned_public_keys": {
+				"type": ["array", "null"],
+				"items": {
+					"type": "object"
+				}
+			},
+			"certificates": {
+				"type": ["object", "null"],
+				"additionalProperties": false,
+				"properties": {
+					"upstream": {
+						"type": ["object", "null"]
+					},
+					"apis": {
+						"type": ["array", "null"],
+						"items": {
+							"type": "string"
+						}
+					},
+					"control_api": {
+						"type": ["array", "null"],
+						"items": {
+							"type": "string"
+						}
+					},
+					"dashboard_api": {
+						"type": ["array", "null"],
+						"items": {
+							"type": "string"
+						}
+					},
+					"mdcb_api": {
+						"type": ["array", "null"],
+						"items": {
+							"type": "string"
+						}
+					}
+				}
+			}
+		}
+	},
+	"enable_key_logging": {
+		"type": "boolean"
+	},
+	"newrelic": {
+		"type": ["object", "null"],
+		"additionalProperties": false,
+		"properties": {
+			"app_name": {
+				"type": "string"
+			},
+			"license_key": {
+				"type": "string"
+			}
+		}
+	},
+	"enable_hashed_keys_listing": {
+		"type": "boolean"
+	},
+	"min_token_length": {
+		"type": "integer"
+	},
+	"disable_regexp_cache": {
+		"type": "boolean"
+	},
+	"regexp_cache_expire": {
+		"type": "integer"
+	},
+	"proxy_ssl_disable_renegotiation": {
+		"type": "boolean"
+	},
+	"chunked_quota": {
+		"type": ["object", "null"],
+		"additionalProperties": false,
+		"properties": {
+			"enable_chunked_quota": {
+				"type": "boolean"
+			},
+			"quota_chunk_size": {
+				"type": "integer"
+			},
+			"chunk_return_timeout": {
+				"type": "integer"
+			},
+			"chunk_return_part": {
+				"type": "integer"
+			}
+		}
+	}
+}
+}`

--- a/config/config.go
+++ b/config/config.go
@@ -252,6 +252,12 @@ type Tracer struct {
 	// for options required by supported tracer implementation.
 	Options map[string]interface{} `json:"options"`
 }
+type ChunkedQuotaConfig struct {
+	EnableChunkedQuota bool    `json:"enable_chunked_quota"`
+	ChunkSize          int64   `json:"quota_chunk_size"`
+	ChunkReturnTimeout uint64  `json:"chunk_return_timeout"`
+	ChunkReturnPart    float64 `json:"chunk_return_part"`
+}
 
 // Config is the configuration object used by tyk to set up various parameters.
 type Config struct {
@@ -399,8 +405,7 @@ type Config struct {
 	ForceGlobalSessionLifetime     bool  `bson:"force_global_session_lifetime" json:"force_global_session_lifetime"`
 	HideGeneratorHeader            bool  `json:"hide_generator_header"`
 
-	DistributedQuotaEnabled       bool  `json:"distributed_quota_enabled"`
-	DistributedQuotaSyncFrequency int32 `json:"distributed_quota_sync_frequency"`
+	ChunkedQuota ChunkedQuotaConfig `json:"chunked_quota"`
 }
 
 // GetEventTriggers returns event triggers. There was a typo in the json tag.

--- a/config/config.go
+++ b/config/config.go
@@ -398,6 +398,9 @@ type Config struct {
 	GlobalSessionLifetime          int64 `bson:"global_session_lifetime" json:"global_session_lifetime"`
 	ForceGlobalSessionLifetime     bool  `bson:"force_global_session_lifetime" json:"force_global_session_lifetime"`
 	HideGeneratorHeader            bool  `json:"hide_generator_header"`
+
+	DistributedQuotaEnabled       bool  `json:"distributed_quota_enabled"`
+	DistributedQuotaSyncFrequency int32 `json:"distributed_quota_sync_frequency"`
 }
 
 // GetEventTriggers returns event triggers. There was a typo in the json tag.

--- a/gateway/distributed_rate_limiter.go
+++ b/gateway/distributed_rate_limiter.go
@@ -96,6 +96,9 @@ func onServerStatusReceivedHandler(payload string) {
 				WithField("serverData", serverData).
 				Debug("AddOrUpdateServer error. Seems like you running multiple segmented Tyk groups in same Redis.")
 			return
+		} else if DQLManager != nil {
+			// notify distributed quota limiter about server data
+			DQLManager.CheckServerLoad(serverData.ID, serverData.LoadPerSec)
 		}
 		log.Debug(DRLManager.Report())
 	} else {

--- a/gateway/dql.go
+++ b/gateway/dql.go
@@ -85,7 +85,7 @@ func NewDQL(store storage.Handler) *DQL {
 
 func (d *DQL) getQuotaChannels(key string) *quotaChannels {
 	d.channelsMu.Lock()
-	d.channelsMu.Unlock()
+	defer d.channelsMu.Unlock()
 	ch, ok := d.channels[key]
 	if !ok {
 		return nil

--- a/gateway/dql.go
+++ b/gateway/dql.go
@@ -1,0 +1,268 @@
+package gateway
+
+import (
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+
+	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/storage"
+	"github.com/TykTechnologies/tyk/user"
+)
+
+const (
+	defaultQuotaChunkSize          = 100
+	defaultQuotaChunkReturnTimeout = 30
+	defaultQuotaChunkReturnPart    = 0.2
+
+	// we don't return chunk if less than that duration left until chunk expiration
+	quotaChunkReturnGracePeriod = -300 * time.Millisecond
+
+	quotaChunkRefundRequestInterval = 500 * time.Millisecond
+)
+
+// quota processing message
+type quotaProcessingMsg struct {
+	max         int64
+	renewalRate int64
+	replyCh     chan bool
+}
+
+type quotaChannels struct {
+	processingCh         chan *quotaProcessingMsg // this channel receives requests while serving traffic to check if quota exceeded
+	refundCh             chan bool                // this channel receives messages when some more busy server requests refund
+	refundRequestChannel chan bool                // this channel is to send requests to other servers when current is ran out of quota
+}
+
+type quotaChunkRefundRequest struct {
+	Key string
+}
+
+// DQL - Distributed Quota Limiter provides logic to use quotas distributed over several gateway instances
+type DQL struct {
+	thisServerID string
+
+	thisServerLessLoaded   bool
+	thisServerLessLoadedMu sync.Mutex
+
+	store              storage.Handler
+	chunkedQuotaConfig config.ChunkedQuotaConfig
+	chunkReturnTimeout time.Duration
+
+	channels   map[string]*quotaChannels // map of API key to set of related channels consumed by go-routine per key
+	channelsMu sync.Mutex
+}
+
+// NewDQL creates new instance of distributed quota limiter
+func NewDQL(store storage.Handler) *DQL {
+	chunkedQuotaConfig := config.Global().ChunkedQuota
+	if !chunkedQuotaConfig.EnableChunkedQuota {
+		log.Error("Could not create distributed quota limiter because it is not enabled in config")
+		return nil
+	}
+
+	// populate defaults if needed
+	if chunkedQuotaConfig.ChunkSize == 0 {
+		chunkedQuotaConfig.ChunkSize = defaultQuotaChunkSize
+	}
+	if chunkedQuotaConfig.ChunkReturnTimeout == 0 {
+		chunkedQuotaConfig.ChunkReturnTimeout = defaultQuotaChunkReturnTimeout
+	}
+	if chunkedQuotaConfig.ChunkReturnPart <= 0 || chunkedQuotaConfig.ChunkReturnPart > 1 {
+		chunkedQuotaConfig.ChunkReturnPart = defaultQuotaChunkReturnPart
+	}
+
+	return &DQL{
+		thisServerID:       DRLManager.ThisServerID,
+		store:              store,
+		chunkedQuotaConfig: chunkedQuotaConfig,
+		chunkReturnTimeout: time.Duration(chunkedQuotaConfig.ChunkReturnTimeout) * time.Second,
+		channels:           make(map[string]*quotaChannels),
+	}
+}
+
+func (d *DQL) getQuotaChannels(key string) *quotaChannels {
+	d.channelsMu.Lock()
+	d.channelsMu.Unlock()
+	ch, ok := d.channels[key]
+	if !ok {
+		return nil
+	}
+
+	return ch
+}
+
+// IncrementAndCheck increments quota counter for the given session and returns true if quota is exceeded
+func (d *DQL) IncrementAndCheck(session *user.SessionState) bool {
+	key := QuotaKeyPrefix + session.KeyHash()
+
+	// get key quota channels for the key
+	d.channelsMu.Lock()
+	ch, ok := d.channels[key] // one set of channels per API key
+	if !ok {
+		ch = &quotaChannels{
+			processingCh:         make(chan *quotaProcessingMsg, d.chunkedQuotaConfig.ChunkSize),
+			refundCh:             make(chan bool),
+			refundRequestChannel: make(chan bool),
+		}
+		d.channels[key] = ch
+		go d.quotaCounter(key, ch)                                   // one go routine per API key
+		go d.quotaChunkRefundRequester(key, ch.refundRequestChannel) // again one go routine per API key
+	}
+	d.channelsMu.Unlock()
+
+	// send message for quota processing
+	replyCh := make(chan bool)
+	ch.processingCh <- &quotaProcessingMsg{
+		max:         session.QuotaMax,
+		renewalRate: session.QuotaRenewalRate,
+		replyCh:     replyCh,
+	}
+
+	// here we block to receive result - if quota exceeded for that session key or not
+	return <-replyCh
+}
+
+func (d *DQL) quotaCounter(key string, ch *quotaChannels) {
+	var chunk int64
+	var chunkExpires time.Time
+	var chunkNeverExpires bool
+	var chunkTs time.Time
+	for {
+		select {
+		case msg := <-ch.processingCh:
+			// request new chunk if current chunk is 0 or expired
+			if chunk == 0 || (!chunkNeverExpires && time.Now().After(chunkExpires)) {
+				values, err := d.store.IncrementByWithExpire(key, d.chunkedQuotaConfig.ChunkSize, msg.renewalRate)
+				if err != nil {
+					log.WithError(err).Error("Could not request new quota chunk, just letting traffic go")
+					msg.replyCh <- false
+					continue
+				}
+				chunkTs = time.Now()
+				total := values[0]
+				if values[1] <= 0 { // no expiration
+					chunkNeverExpires = true
+				} else {
+					chunkNeverExpires = false
+					chunkExpires = chunkTs.Add(time.Duration(values[1]) * time.Second)
+				}
+				// check if we still need to allow some requests or reply that it was exceeded right away
+				if total >= msg.max {
+					if totalBefore := total - d.chunkedQuotaConfig.ChunkSize; totalBefore < msg.max {
+						chunk = msg.max - totalBefore
+					} else {
+						// current chunk exceeded and no new chunks available
+						chunk = 0
+						msg.replyCh <- true
+						// send request for refund to obtain some chunk maybe next time
+						ch.refundRequestChannel <- true
+						continue
+					}
+				} else {
+					// new quota chunk received
+					chunk = d.chunkedQuotaConfig.ChunkSize
+				}
+			}
+
+			// decrement and allow request to proceed
+			chunk--
+			msg.replyCh <- false
+		case <-ch.refundCh: // received signal to return part of chunk
+			// check if this server is the less loaded
+			if !d.canRefundOnRequest() {
+				log.Debug("This server is not the slowest one, don't return part of chunk")
+				continue
+			}
+			// refund part of current chunk if non zero and not expired and expiration is not too close
+			if chunk > 0 && (chunkNeverExpires || time.Now().Before(chunkExpires.Add(quotaChunkReturnGracePeriod))) {
+				returnPart := int64(float64(chunk) * d.chunkedQuotaConfig.ChunkReturnPart)
+				if _, err := d.store.IncrementByWithExpire(key, -1*returnPart, 0); err != nil {
+					log.WithError(err).Error("Could not return part of chunk")
+				} else {
+					chunk -= returnPart
+				}
+			}
+		case <-time.After(d.chunkReturnTimeout): // wait, if no traffic for specified period - return chunk
+			// return remain of current chunk if non zero and not expired and expiration is not too close
+			if chunk > 0 && (chunkNeverExpires || time.Now().Before(chunkExpires.Add(quotaChunkReturnGracePeriod))) {
+				if _, err := d.store.IncrementByWithExpire(key, -1*chunk, 0); err != nil {
+					log.WithError(err).Error("Could not return chunk on timeout")
+				} else {
+					chunk = 0
+				}
+			} else {
+				log.Debug("quota chunk was not returned")
+			}
+		}
+	}
+}
+
+func (d *DQL) quotaChunkRefundRequester(key string, ch chan bool) {
+	var lastSent time.Time
+	for range ch {
+		if time.Now().Before(lastSent.Add(quotaChunkRefundRequestInterval)) {
+			continue
+		}
+
+		request := quotaChunkRefundRequest{Key: key}
+		asJson, err := json.Marshal(request)
+		if err != nil {
+			log.WithError(err).Error("Failed to encode chunk refund request payload")
+			continue
+		}
+
+		MainNotifier.Notify(
+			Notification{
+				Command: DQLChunkRefundRequestNotification,
+				Payload: string(asJson),
+			},
+		)
+
+		lastSent = time.Now()
+	}
+}
+
+func (d *DQL) canRefundOnRequest() bool {
+	d.thisServerLessLoadedMu.Lock()
+	defer d.thisServerLessLoadedMu.Unlock()
+	return d.thisServerLessLoaded
+}
+
+func (d *DQL) CheckServerLoad(serverID string, loadPerSec int64) {
+	if serverID == d.thisServerID {
+		return
+	}
+
+	d.thisServerLessLoadedMu.Lock()
+	defer d.thisServerLessLoadedMu.Unlock()
+	d.thisServerLessLoaded = GlobalRate.Rate() < loadPerSec
+	if d.thisServerLessLoaded {
+		log.Debug("this server is the less loaded one, distributed quota limiter will use this server to refund chunks")
+	}
+}
+
+func onChunkRefundRequestReceivedHandler(payload string) {
+	request := quotaChunkRefundRequest{}
+	if err := json.Unmarshal([]byte(payload), &request); err != nil {
+		log.WithFields(logrus.Fields{
+			"prefix": "pub-sub",
+		}).WithError(err).Error("Failed unmarshal chunk refund request data")
+		return
+	}
+
+	log.Debug("Received quota chunk refund request: ", request)
+
+	// get channel by key and send request for refund
+	ch := DQLManager.getQuotaChannels(request.Key)
+	if ch == nil {
+		log.WithFields(logrus.Fields{
+			"prefix": "pub-sub",
+		}).Error("Failed to get refund channel for key to process chunk refund request data")
+		return
+	}
+
+	ch.refundCh <- true
+}

--- a/gateway/ldap_auth_handler.go
+++ b/gateway/ldap_auth_handler.go
@@ -154,9 +154,9 @@ func (l *LDAPStorageHandler) IncrememntWithExpire(keyName string, timeout int64)
 	return 999
 }
 
-func (l *LDAPStorageHandler) IncrementByWithExpire(keyName string, incBy int64, timeout int64) int64 {
+func (l *LDAPStorageHandler) IncrementByWithExpire(keyName string, incBy int64, timeout int64) ([]int64, error) {
 	l.notifyReadOnly()
-	return 999
+	return []int64{999, 999}, nil
 }
 
 func (l *LDAPStorageHandler) notifyReadOnly() bool {

--- a/gateway/ldap_auth_handler.go
+++ b/gateway/ldap_auth_handler.go
@@ -154,6 +154,11 @@ func (l *LDAPStorageHandler) IncrememntWithExpire(keyName string, timeout int64)
 	return 999
 }
 
+func (l *LDAPStorageHandler) IncrementByWithExpire(keyName string, incBy int64, timeout int64) int64 {
+	l.notifyReadOnly()
+	return 999
+}
+
 func (l *LDAPStorageHandler) notifyReadOnly() bool {
 	log.Warning("LDAP storage is READ ONLY")
 	return false

--- a/gateway/mw_rate_limiting.go
+++ b/gateway/mw_rate_limiting.go
@@ -8,7 +8,9 @@ import (
 	"github.com/TykTechnologies/tyk/request"
 )
 
-var sessionLimiter = SessionLimiter{}
+var sessionLimiter = SessionLimiter{
+	keyQuotas: map[string]keyQuota{},
+}
 var sessionMonitor = Monitor{}
 
 // RateLimitAndQuotaCheck will check the incomming request and key whether it is within it's quota and

--- a/gateway/mw_rate_limiting.go
+++ b/gateway/mw_rate_limiting.go
@@ -8,9 +8,7 @@ import (
 	"github.com/TykTechnologies/tyk/request"
 )
 
-var sessionLimiter = SessionLimiter{
-	keyQuotas: map[string]keyQuota{},
-}
+var sessionLimiter = SessionLimiter{}
 var sessionMonitor = Monitor{}
 
 // RateLimitAndQuotaCheck will check the incomming request and key whether it is within it's quota and

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -20,6 +20,7 @@ import (
 type InboundData struct {
 	KeyName      string
 	Value        string
+	IntValue     int64
 	SessionState string
 	Timeout      int64
 	Per          int64
@@ -113,6 +114,9 @@ var (
 		},
 		"Ping": func() bool {
 			return false
+		},
+		"IncrementByWithExpire": func(ibd *InboundData) ([]int64, error) {
+			return []int64{0, 0}, nil
 		},
 	}
 )
@@ -354,6 +358,40 @@ func (r *RPCStorageHandler) IncrememntWithExpire(keyName string, expire int64) i
 
 	return val.(int64)
 
+}
+
+// IncrementByWithExpire increments given key by value in Redis
+// and sets expiration if it is a new key
+func (r *RPCStorageHandler) IncrementByWithExpire(keyName string, incBy int64, expire int64) int64 {
+	ibd := InboundData{
+		KeyName:  keyName,
+		IntValue: incBy,
+		Expire:   expire,
+	}
+
+	val, err := rpc.FuncClientSingleton("IncrementByWithExpire", ibd)
+	if err != nil {
+		rpc.EmitErrorEventKv(
+			rpc.FuncClientSingletonCall,
+			"IncrementByWithExpire",
+			err,
+			map[string]string{
+				"keyName": keyName,
+			},
+		)
+	}
+	if r.IsAccessError(err) {
+		if rpc.Login() {
+			return r.IncrementByWithExpire(keyName, incBy, expire)
+		}
+	}
+
+	if val == nil {
+		log.Warning("RPC IncrementByWithExpire returned nil value, returning 0")
+		return 0
+	}
+
+	return val.(int64)
 }
 
 // GetKeys will return all keys according to the filter (filter is a prefix - e.g. tyk.keys.*)

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -362,7 +362,7 @@ func (r *RPCStorageHandler) IncrememntWithExpire(keyName string, expire int64) i
 
 // IncrementByWithExpire increments given key by value in Redis
 // and sets expiration if it is a new key
-func (r *RPCStorageHandler) IncrementByWithExpire(keyName string, incBy int64, expire int64) int64 {
+func (r *RPCStorageHandler) IncrementByWithExpire(keyName string, incBy int64, expire int64) ([]int64, error) {
 	ibd := InboundData{
 		KeyName:  keyName,
 		IntValue: incBy,
@@ -388,10 +388,10 @@ func (r *RPCStorageHandler) IncrementByWithExpire(keyName string, incBy int64, e
 
 	if val == nil {
 		log.Warning("RPC IncrementByWithExpire returned nil value, returning 0")
-		return 0
+		return nil, nil
 	}
 
-	return val.(int64)
+	return val.([]int64), err
 }
 
 // GetKeys will return all keys according to the filter (filter is a prefix - e.g. tyk.keys.*)

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -1088,6 +1088,9 @@ func Start() {
 
 	mainLog.Info("Stop signal received.")
 
+	// stop quota counters
+	sessionLimiter.stopCounters()
+
 	// stop analytics workers
 	if config.Global().EnableAnalytics && analytics.Store == nil {
 		analytics.Stop()

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -70,6 +70,7 @@ var (
 	DashService              DashboardServiceSender
 	CertificateManager       *certs.CertificateManager
 	NewRelicApplication      newrelic.Application
+	DQLManager               *DQL
 
 	apisMu   sync.RWMutex
 	apiSpecs []*APISpec
@@ -1088,9 +1089,6 @@ func Start() {
 
 	mainLog.Info("Stop signal received.")
 
-	// stop quota counters
-	sessionLimiter.stopCounters()
-
 	// stop analytics workers
 	if config.Global().EnableAnalytics && analytics.Store == nil {
 		analytics.Stop()
@@ -1245,6 +1243,7 @@ func handleDashboardRegistration() {
 }
 
 var drlOnce sync.Once
+var dqlOnce sync.Once
 
 func startDRL() {
 	switch {
@@ -1256,6 +1255,24 @@ func startDRL() {
 	mainLog.Info("Initialising distributed rate limiter")
 	setupDRL()
 	startRateLimitNotifications()
+}
+
+func startDQL() {
+	if config.Global().ManagementNode {
+		mainLog.Info("Management node, skip initialising distributed quota limiter")
+		return
+	}
+
+	if !config.Global().ChunkedQuota.EnableChunkedQuota {
+		mainLog.Info("Chunked quota is not enabled, skip initialising distributed quota limiter")
+		return
+	}
+
+	mainLog.Info("Initialising distributed quota limiter")
+	DQLManager = NewDQL(
+		getGlobalStorageHandler("dql-", false),
+	)
+	// TODO: start notifications ??
 }
 
 // mainHandler's only purpose is to allow mainRouter to be dynamically replaced
@@ -1411,6 +1428,9 @@ func listen(listener, controlListener net.Listener, err error) {
 
 	// at this point NodeID is ready to use by DRL
 	drlOnce.Do(startDRL)
+
+	// start distributed quote limiter
+	dqlOnce.Do(startDQL)
 
 	address := config.Global().ListenAddress
 	if config.Global().ListenAddress == "" {

--- a/gateway/session_manager.go
+++ b/gateway/session_manager.go
@@ -2,7 +2,6 @@ package gateway
 
 import (
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/TykTechnologies/leakybucket"
@@ -27,109 +26,12 @@ type PublicSession struct {
 const (
 	QuotaKeyPrefix     = "quota-"
 	RateLimitKeyPrefix = "rate-limit-"
-
-	quotaChanBufferSize = 256
 )
-
-type keyQuota struct {
-	key        string
-	session    *user.SessionState
-	isExceeded bool
-	reqChan    chan bool
-}
 
 // SessionLimiter is the rate limiter for the API, use ForwardMessage() to
 // check if a message should pass through or not
 type SessionLimiter struct {
 	bucketStore leakybucket.Storage
-
-	keyQuotas   map[string]keyQuota
-	keyQuotasMu sync.Mutex
-}
-
-func (l *SessionLimiter) getKeyQuota(key string, session *user.SessionState, store storage.Handler, globalConf *config.Config) keyQuota {
-	l.keyQuotasMu.Lock()
-	defer l.keyQuotasMu.Unlock()
-
-	// check if key quota counter is already running
-	if quota, ok := l.keyQuotas[key]; ok {
-		return quota
-	}
-
-	// create and start new key quota counter
-	quota := keyQuota{
-		key:     key,
-		session: session,
-		reqChan: make(chan bool, quotaChanBufferSize),
-	}
-	l.keyQuotas[key] = quota
-	syncEvery := time.Duration(session.QuotaRenewalRate*1000/int64(globalConf.DistributedQuotaSyncFrequency)) * time.Millisecond
-	go l.startCounter(quota, store, syncEvery)
-
-	return quota
-}
-
-func (l *SessionLimiter) setQuotaIsExceeded(key string, isExceeded bool) {
-	l.keyQuotasMu.Lock()
-	defer l.keyQuotasMu.Unlock()
-	if quota, ok := l.keyQuotas[key]; ok {
-		quota.isExceeded = isExceeded
-		l.keyQuotas[key] = quota
-	}
-}
-
-func (l *SessionLimiter) startCounter(quota keyQuota, store storage.Handler, syncEvery time.Duration) {
-	// initialize total counter with current value from centralized Redis storage
-	// by supplying 0 increment
-	totalCounter := store.IncrementByWithExpire(quota.key, 0, quota.session.QuotaRenewalRate)
-
-	// this var will be used to count requests per aggregation period
-	var localCounter int64
-
-	for {
-		select {
-		case _, ok := <-quota.reqChan:
-			// check if channel was closed and it is time to stop go-routine
-			if !ok {
-				return
-			}
-
-			// check if quota was exceeded
-			if totalCounter >= quota.session.QuotaMax {
-				l.setQuotaIsExceeded(quota.key, true)
-				localCounter = 0
-				continue
-			}
-
-			// increment last known total counter and local aggregated counter
-			totalCounter++
-			localCounter++
-
-			// update remaining
-			remaining := quota.session.QuotaMax - totalCounter
-			if remaining < 0 {
-				quota.session.QuotaRemaining = 0
-			} else {
-				quota.session.QuotaRemaining = remaining
-			}
-
-		case <-time.After(syncEvery):
-			// aggregation period is done
-			// overwrite totalCounter from centralized Redis storage
-			totalCounter = store.IncrementByWithExpire(quota.key, localCounter, quota.session.QuotaRenewalRate)
-			// reset
-			localCounter = 0
-			l.setQuotaIsExceeded(quota.key, false)
-		}
-	}
-}
-
-func (l *SessionLimiter) stopCounters() {
-	l.keyQuotasMu.Lock()
-	defer l.keyQuotasMu.Unlock()
-	for _, quota := range l.keyQuotas {
-		close(quota.reqChan)
-	}
 }
 
 func (l *SessionLimiter) doRollingWindowWrite(key, rateLimiterKey, rateLimiterSentinelKey string,
@@ -287,8 +189,8 @@ func (l *SessionLimiter) ForwardMessage(r *http.Request, currentSession *user.Se
 			currentSession.Allowance--
 		}
 
-		if globalConf.DistributedQuotaEnabled {
-			if l.DistributedRedisQuotaExceeded(currentSession, key, store, globalConf) {
+		if globalConf.ChunkedQuota.EnableChunkedQuota {
+			if l.ChunkedRedisQuotaExceeded(currentSession) {
 				return sessionFailQuota
 			}
 		} else if l.RedisQuotaExceeded(r, currentSession, key, store, apiID) {
@@ -392,21 +294,12 @@ func (l *SessionLimiter) RedisQuotaExceeded(r *http.Request, currentSession *use
 	return false
 }
 
-func (l *SessionLimiter) DistributedRedisQuotaExceeded(currentSession *user.SessionState, key string, store storage.Handler, globalConf *config.Config) bool {
+func (l *SessionLimiter) ChunkedRedisQuotaExceeded(currentSession *user.SessionState) bool {
 	// Are they unlimited?
 	if currentSession.QuotaMax == -1 {
 		// No quota set
 		return false
 	}
 
-	rawKey := QuotaKeyPrefix + currentSession.KeyHash()
-	quotaCounter := l.getKeyQuota(rawKey, currentSession, store, globalConf)
-
-	// count request if quota is not exceeded for the given key
-	if !quotaCounter.isExceeded {
-		quotaCounter.reqChan <- true
-		return false
-	}
-
-	return true
+	return DQLManager.IncrementAndCheck(currentSession)
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -53,7 +53,7 @@ type Handler interface {
 	AddToSortedSet(string, string, float64)
 	GetSortedSetRange(string, string, string) ([]string, []float64, error)
 	RemoveSortedSetRange(string, string, string) error
-	IncrementByWithExpire(string, int64, int64) int64
+	IncrementByWithExpire(string, int64, int64) ([]int64, error)
 }
 
 const defaultHashAlgorithm = "murmur64"

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -53,6 +53,7 @@ type Handler interface {
 	AddToSortedSet(string, string, float64)
 	GetSortedSetRange(string, string, string) ([]string, []float64, error)
 	RemoveSortedSetRange(string, string, string) error
+	IncrementByWithExpire(string, int64, int64) int64
 }
 
 const defaultHashAlgorithm = "murmur64"


### PR DESCRIPTION
added changes for https://github.com/TykTechnologies/tyk/issues/1761

Current implementation includes:

1. Key quota can be stored in local Redis or in Master DC if slave options are enabled - in both cases acts as central storage for quotas all gateways use - it is possible to have just on local gateway cluster sharing the same quotas in Redis or have several gateway groups in Slave DCs sharing quotas stored in Master DC over RPC calls
2. When we serve traffic with quota limiter we ask central storage for chunk of quota (based on new store method `IncrementByWithExpire` which is `INCRBY` + `EXPIRE` or `TTL` combination on Redis side), that chunk has ttl equal to quota renewal rate and then we decrement that quota chunk for all subsequent requests while serving traffic. The size of chunk is configurable.
3. When current chunk is done we ask for another one - thats how we don't speak to Redis within every request. The bonus is that chunks are issued for gateways based on their demands - how much traffic they serve
4. If gateway's traffic dropped - active chunk will be returned after some configurable timeout.
5. If current chunk is done and there are no more available (quota exceeded but renewal is not happened yet) the gateway which faces that situation issues special chunk refund  notification to other gateways in that group with hope that next try to get chunk will be successful
6. Any gateway can receive chunk refund notification from others in group and refund part of current chunk to central storage (percentage of that refund is configurable). This happens only if given gateway is the slowest one in group (it uses DRL notifications to understand that).

All this applies to how we calculate quotas per key basis - chunks are issued per keys, chunk expire or refund as well happens per key.

Issues I found during manual testing:

Current implementation `IncrementByWithExpire` can increment to value much higher than actual quota max for the given key, it is Ok for callers as they receive new value and ttl every time back and understand that situation (quota is exceeded, no more chunks available), but refund process will be screwed up - when we refund part of chunk it will be decremented from quota max + some extra.
As a solution we can supply `IncrementByWithExpire` with max value and inside we can simulate conditional update like as sequence of:
1. get current value
2. check if incrementing it by chunk size won't jump over passed max value
3. if it jumps over max value just set it to max value to identify that it is exceeded and make happy refunders - it will be correctly decremented from max and never jumps over max value in future
4. if current value + chunk size are still under max value just add it
5. all this needs to be done atomically
For atomicity we can do with `IncrementByWithExpire` two things:
- implement with optimistic locking using check-and-set i.e. Redis combination of `WATCH + GET + MULTI + SETEX/INCRBY + EXPIRE + EXEC` and then `TTL` to get current remain of key's ttl so this chunk will have it
- or Lua scripting

Another issue - this change needs to respect recent changes connected with quota limits on policy ACL API level. It can be easily done as it is just different key format picking quota max and renewal from acl item instead of key.

I will also add some sequence diagrams here.