### PR TITLE
Prepend apiid to path 

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -277,6 +277,10 @@ func (r *RedisAnalyticsHandler) recordWorker() {
 			if !strings.HasPrefix(record.RawPath, "/") {
 				record.RawPath = "/" + record.RawPath
 			}
+			//if tracking path prepend apiid for grouping in aggregate queries
+			if record.TrackPath {
+				record.Path = record.APIID + record.Path
+			}
 
 			if encoded, err := msgpack.Marshal(record); err != nil {
 				log.WithError(err).Error("Error encoding analytics data")

--- a/analytics.go
+++ b/analytics.go
@@ -277,7 +277,7 @@ func (r *RedisAnalyticsHandler) recordWorker() {
 			if !strings.HasPrefix(record.RawPath, "/") {
 				record.RawPath = "/" + record.RawPath
 			}
-			//if tracking path prepend apiid for grouping in aggregate queries
+			//if tracking path prepend b64 of json containing apiid and api name for grouping in aggregate queries
 			if record.TrackPath {
 				record.Path = record.APIID + record.Path
 			}


### PR DESCRIPTION
Fixes #860

This make endpoints in aggregate become namespaced by apiid and path so endpoint popularity graphs will be fixed.

i.e. When record has `trackPath=true` record.path becomes apiid/path

First path element before forward slash will always be apiid in aggregate collections.

