### PR TITLE
moved RPC to rpc package

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -17,6 +17,8 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/TykTechnologies/tyk/rpc"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/rubyist/circuitbreaker"
 
@@ -341,11 +343,11 @@ func (a APIDefinitionLoader) FromDashboardService(endpoint, secret string) ([]*A
 
 // FromCloud will connect and download ApiDefintions from a Mongo DB instance.
 func (a APIDefinitionLoader) FromRPC(orgId string) []*APISpec {
-	if rpcEmergencyMode {
+	if rpc.IsRPCEmergencyMode() {
 		return LoadDefinitionsFromRPCBackup()
 	}
 
-	store := RPCStorageHandler{UserKey: config.Global().SlaveOptions.APIKey, Address: config.Global().SlaveOptions.ConnectionString}
+	store := rpc.RPCStorageHandler{SlaveOptions: config.Global().SlaveOptions}
 	if !store.Connect() {
 		return nil
 	}
@@ -361,7 +363,7 @@ func (a APIDefinitionLoader) FromRPC(orgId string) []*APISpec {
 
 	//store.Disconnect()
 
-	if rpcLoadCount > 0 {
+	if rpc.GetRPCLoadCount() > 0 {
 		saveRPCDefinitionsBackup(apiCollection)
 	}
 

--- a/api_loader.go
+++ b/api_loader.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/TykTechnologies/tyk/rpc"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/gorilla/mux"
 	"github.com/justinas/alice"
@@ -35,12 +37,12 @@ type ChainObject struct {
 	Subrouter      *mux.Router
 }
 
-func prepareStorage() (storage.RedisCluster, storage.RedisCluster, storage.RedisCluster, *RPCStorageHandler, *RPCStorageHandler) {
+func prepareStorage() (storage.RedisCluster, storage.RedisCluster, storage.RedisCluster, *rpc.RPCStorageHandler, *rpc.RPCStorageHandler) {
 	redisStore := storage.RedisCluster{KeyPrefix: "apikey-", HashKeys: config.Global().HashKeys}
 	redisOrgStore := storage.RedisCluster{KeyPrefix: "orgkey."}
 	healthStore := storage.RedisCluster{KeyPrefix: "apihealth."}
-	rpcAuthStore := RPCStorageHandler{KeyPrefix: "apikey-", HashKeys: config.Global().HashKeys, UserKey: config.Global().SlaveOptions.APIKey, Address: config.Global().SlaveOptions.ConnectionString}
-	rpcOrgStore := RPCStorageHandler{KeyPrefix: "orgkey.", UserKey: config.Global().SlaveOptions.APIKey, Address: config.Global().SlaveOptions.ConnectionString}
+	rpcAuthStore := rpc.RPCStorageHandler{KeyPrefix: "apikey-", HashKeys: config.Global().HashKeys, SlaveOptions: config.Global().SlaveOptions}
+	rpcOrgStore := rpc.RPCStorageHandler{KeyPrefix: "orgkey.", SlaveOptions: config.Global().SlaveOptions}
 
 	FallbackKeySesionManager.Init(&redisStore)
 

--- a/policy.go
+++ b/policy.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/TykTechnologies/tyk/rpc"
+
 	"github.com/Sirupsen/logrus"
 
 	"github.com/TykTechnologies/tyk/config"
@@ -157,11 +159,11 @@ func parsePoliciesFromRPC(list string) (map[string]user.Policy, error) {
 }
 
 func LoadPoliciesFromRPC(orgId string) map[string]user.Policy {
-	if rpcEmergencyMode {
+	if rpc.IsRPCEmergencyMode() {
 		return LoadPoliciesFromRPCBackup()
 	}
 
-	store := &RPCStorageHandler{UserKey: config.Global().SlaveOptions.APIKey, Address: config.Global().SlaveOptions.ConnectionString}
+	store := &rpc.RPCStorageHandler{SlaveOptions: config.Global().SlaveOptions}
 	if !store.Connect() {
 		return nil
 	}

--- a/redis_analytics_purger.go
+++ b/redis_analytics_purger.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"time"
+
+	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/storage"
+)
+
+// Purger is an interface that will define how the in-memory store will be purged
+// of analytics data to prevent it growing too large
+type Purger interface {
+	PurgeCache()
+	PurgeLoop(<-chan time.Time)
+}
+
+type RedisPurger struct {
+	Store storage.Handler
+}
+
+func (r RedisPurger) PurgeLoop(ticker <-chan time.Time) {
+	for {
+		<-ticker
+		r.PurgeCache()
+	}
+}
+
+func (r *RedisPurger) PurgeCache() {
+	expireAfter := config.Global().AnalyticsConfig.StorageExpirationTime
+	if expireAfter == 0 {
+		expireAfter = 60 // 1 minute
+	}
+
+	exp, _ := r.Store.GetExp(analyticsKeyName)
+	if exp <= 0 {
+		r.Store.SetExp(analyticsKeyName, int64(expireAfter))
+	}
+}

--- a/redis_signals.go
+++ b/redis_signals.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/TykTechnologies/tyk/rpc"
+
 	"github.com/garyburd/redigo/redis"
 
 	"github.com/TykTechnologies/goverify"
@@ -123,7 +125,7 @@ func handleKeySpaceEventCacheFlush(payload string) {
 			key = splitKeys[0]
 		}
 
-		RPCGlobalCache.Delete("apikey-" + key)
+		rpc.RPCGlobalCache.Delete("apikey-" + key)
 		SessionCache.Delete(key)
 	}
 }


### PR DESCRIPTION
Added changes to move RPC stack into new `rpc` package which will be reused in context of https://github.com/TykTechnologies/tyk-pump/issues/80

There is some callback business and new function setupRPC() to glue `rpc` package with globals in tyk.