### PR TITLE
coprocess: fix double free on dispatch errors (#1933)

### DIFF
--- a/coprocess_native.go
+++ b/coprocess_native.go
@@ -59,8 +59,6 @@ func (c *CoProcessor) Dispatch(object *coprocess.Object) (*coprocess.Object, err
 
 	// Call the dispatcher (objectPtr is freed during this call):
 	if err = GlobalDispatcher.Dispatch(unsafe.Pointer(objectPtr), unsafe.Pointer(newObjectPtr)); err != nil {
-		C.free(unsafe.Pointer(newObjectPtr.p_data))
-		C.free(unsafe.Pointer(newObjectPtr))
 		return nil, err
 	}
 	newObjectBytes := C.GoBytes(newObjectPtr.p_data, newObjectPtr.length)


### PR DESCRIPTION
After debugging this with the bundle that's provided in #1933, I've found that the object is already freed in [coprocess_python.go](https://github.com/TykTechnologies/tyk/blob/master/coprocess_python.go#L140), when a dispatch error occurs.
Dispatch errors are rare, in the scenario described in #1933 it occurs because the dependencies were missing during the test.