### PR TITLE
JWT scope-policy mapping support added

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -351,6 +351,7 @@ type APIDefinition struct {
 	JWTExpiresAtValidationSkew uint64               `bson:"jwt_expires_at_validation_skew" json:"jwt_expires_at_validation_skew"`
 	JWTNotBeforeValidationSkew uint64               `bson:"jwt_not_before_validation_skew" json:"jwt_not_before_validation_skew"`
 	JWTSkipKid                 bool                 `bson:"jwt_skip_kid" json:"jwt_skip_kid"`
+	JWTScopeToPolicyMapping    map[string]string    `bson:"jwt_scope_to_policy_mapping" json:"jwt_scope_to_policy_mapping"`
 	NotificationsDetails       NotificationsManager `bson:"notifications" json:"notifications"`
 	EnableSignatureChecking    bool                 `bson:"enable_signature_checking" json:"enable_signature_checking"`
 	HmacAllowedClockSkew       float64              `bson:"hmac_allowed_clock_skew" json:"hmac_allowed_clock_skew"`

--- a/middleware.go
+++ b/middleware.go
@@ -425,6 +425,7 @@ func (t BaseMiddleware) CheckSessionAndIdentityForValidKey(key string, r *http.R
 			session := cachedVal.(user.SessionState)
 			if err := t.ApplyPolicies(key, &session); err != nil {
 				t.Logger().Error(err)
+				return session, false
 			}
 			return session, true
 		}
@@ -444,6 +445,7 @@ func (t BaseMiddleware) CheckSessionAndIdentityForValidKey(key string, r *http.R
 		// Check for a policy, if there is a policy, pull it and overwrite the session values
 		if err := t.ApplyPolicies(key, &session); err != nil {
 			t.Logger().Error(err)
+			return session, false
 		}
 		t.Logger().Debug("Got key")
 		return session, true
@@ -465,6 +467,7 @@ func (t BaseMiddleware) CheckSessionAndIdentityForValidKey(key string, r *http.R
 		// Check for a policy, if there is a policy, pull it and overwrite the session values
 		if err := t.ApplyPolicies(key, &session); err != nil {
 			t.Logger().Error(err)
+			return session, false
 		}
 
 		t.Logger().Debug("Lifetime is: ", session.Lifetime(t.Spec.SessionLifetime))

--- a/mw_jwt.go
+++ b/mw_jwt.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
-	cache "github.com/pmylund/go-cache"
+	"github.com/pmylund/go-cache"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/user"
@@ -244,6 +244,16 @@ func (k *JWTMiddleware) getUserIdFromClaim(claims jwt.MapClaims) (string, error)
 	return "", errors.New(message)
 }
 
+func (k *JWTMiddleware) getScopeFromClaim(claims jwt.MapClaims) []string {
+	// get claim "scope" and turn it into slice of strings
+	if scope, found := claims["scope"].(string); found {
+		return strings.Split(scope, " ") // by standard is space separated list of values
+	}
+
+	// claim "scope" is optional so return nothing if it is not present
+	return nil
+}
+
 // processCentralisedJWT Will check a JWT token centrally against the secret stored in the API Definition.
 func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token) (error, int) {
 	k.Logger().Debug("JWT authority is centralised")
@@ -278,6 +288,36 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 		newSession, err := generateSessionFromPolicy(basePolicyID,
 			k.Spec.OrgID,
 			true)
+
+		// apply policies from scope if scope-to-policy mapping is specified for this API
+		if k.Spec.JWTScopeToPolicyMapping != nil {
+			if scope := k.getScopeFromClaim(claims); scope != nil {
+				polIDs := []string{
+					basePolicyID, // add base policy as a first one
+				}
+
+				// add all policies matched from scope-policy mapping
+				policiesToApply := map[string]bool{}
+				for _, scopeItem := range scope {
+					if policyID, ok := k.Spec.JWTScopeToPolicyMapping[scopeItem]; ok {
+						policiesToApply[policyID] = true
+					}
+				}
+				for id := range policiesToApply {
+					polIDs = append(polIDs, id)
+				}
+
+				newSession.SetPolicies(polIDs...)
+
+				// multiple policies assigned to a key, check if it is applicable
+				if err := k.ApplyPolicies(sessionID, &newSession); err != nil {
+					k.reportLoginFailure(baseFieldData, r)
+					k.Logger().WithError(err).Error("Could not several policies from scope-claim mapping to JWT to session")
+					return errors.New("Key not authorized: could not apply several policies"), http.StatusForbidden
+				}
+			}
+		}
+
 		if err != nil {
 			k.reportLoginFailure(baseFieldData, r)
 			k.Logger().Error("Could not find a valid policy to apply to this token!")
@@ -575,7 +615,10 @@ func generateSessionFromPolicy(policyID, orgID string, enforceOrg bool) (user.Se
 	session.Per = policy.Per
 	session.QuotaMax = policy.QuotaMax
 	session.QuotaRenewalRate = policy.QuotaRenewalRate
-	session.AccessRights = policy.AccessRights
+	session.AccessRights = make(map[string]user.AccessDefinition)
+	for apiID, access := range policy.AccessRights {
+		session.AccessRights[apiID] = access
+	}
 	session.HMACEnabled = policy.HMACEnabled
 	session.IsInactive = policy.IsInactive
 	session.Tags = policy.Tags

--- a/test/http.go
+++ b/test/http.go
@@ -21,6 +21,7 @@ type TestCase struct {
 	Cookies         []*http.Cookie    `json:",omitempty"`
 	Delay           time.Duration     `json:",omitempty"`
 	BodyMatch       string            `json:",omitempty"`
+	BodyMatchFunc   func([]byte) bool `json:",omitempty"`
 	BodyNotMatch    string            `json:",omitempty"`
 	HeadersMatch    map[string]string `json:",omitempty"`
 	HeadersNotMatch map[string]string `json:",omitempty"`
@@ -47,6 +48,10 @@ func AssertResponse(resp *http.Response, tc TestCase) error {
 
 	if tc.BodyNotMatch != "" && bytes.Contains(body, []byte(tc.BodyNotMatch)) {
 		return fmt.Errorf("Response body should not contain `%s`. %s", tc.BodyNotMatch, string(body))
+	}
+
+	if tc.BodyMatchFunc != nil && !tc.BodyMatchFunc(body) {
+		return fmt.Errorf("Response body did not pass BodyMatchFunc: %s", string(body))
 	}
 
 	for k, v := range tc.HeadersMatch {


### PR DESCRIPTION
added changes for https://github.com/TykTechnologies/tyk/issues/1834


for JWT middle-ware:
1. There is a new field `jwt_scope_to_policy_mapping ` in API definition (payload in endpoint to create API as well) - which is just mapping scope-to-policy_id
2. If this field is present then session key associated with the given JWT will be assigned to several policies using provided mapping
3. base-policy JWT claim logic still works for backward compatibility
4. policies mapped to JWT scope should follow recently implemented rules around `per_api` partitions flag - they shouldn't have the same API id in ACL and might specify limit on API level per API in ACL

for open ID middle-ware:
- it will come in next commit, I am going to post more notes (or maybe we should have it as another PR)