### PR TITLE
Reuse client for heartbeat.

### DIFF
--- a/dashboard_register.go
+++ b/dashboard_register.go
@@ -36,6 +36,8 @@ type HTTPDashboardHandler struct {
 	heartBeatStopSentinel bool
 }
 
+var hbClient *http.Client
+
 func initialiseClient(timeout time.Duration) *http.Client {
 	client := &http.Client{}
 	if config.Global().HttpServerOptions.UseSSL {
@@ -167,9 +169,10 @@ func (h *HTTPDashboardHandler) sendHeartBeat() error {
 	req := h.newRequest(h.HeartBeatEndpoint)
 	req.Header.Set("x-tyk-nodeid", NodeID)
 	req.Header.Set("x-tyk-nonce", ServiceNonce)
-	c := initialiseClient(5 * time.Second)
-
-	resp, err := c.Do(req)
+	if hbClient == nil {
+		hbClient = initialiseClient(5 * time.Second)
+	}
+	resp, err := hbClient.Do(req)
 	if err != nil || resp.StatusCode != 200 {
 		return errors.New("dashboard is down? Heartbeat is failing")
 	}


### PR DESCRIPTION
Fixes #1951 
This prevents the issue with spawning a new open socket for each gateway to dashboard heartbeat that is observed in TLS connections when the default transport is overidden.

From Go client.go:

```
// The Client's Transport typically has internal state (cached TCP
// connections), so Clients should be reused instead of created as
// needed. Clients are safe for concurrent use by multiple goroutines.
```

Since we are doing the same operation constantly it makes more sense to create a single client and reuse the connection for the dashboard heartbeat.