### PR TITLE
new virtual endpoint param proxy_to_target_if_error added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ addons:
 matrix:
   include:
     - go: 1.10.x
-      env: LATEST_GO=true # run linters and report coverage
     - go: 1.11.x
       env: LATEST_GO=true # run linters and report coverage
 

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -168,6 +168,7 @@ type VirtualMeta struct {
 	Path                 string `bson:"path" json:"path"`
 	Method               string `bson:"method" json:"method"`
 	UseSession           bool   `bson:"use_session" json:"use_session"`
+	ProxyOnError         bool   `bson:"proxy_on_error" json:"proxy_on_error"`
 }
 
 type MethodTransformMeta struct {

--- a/looping_test.go
+++ b/looping_test.go
@@ -90,7 +90,7 @@ func TestLooping(t *testing.T) {
                 }
                 return TykJsResponse(resp, session.meta_data)
             }
-        `, "POST")
+        `, "POST", "/virt", true)
 
 		ts.Run(t, []test.TestCase{
 			{Method: "POST", Path: "/virt", Data: postAction, BodyMatch: `"Url":"/post_action`},

--- a/mw_redis_cache.go
+++ b/mw_redis_cache.go
@@ -143,7 +143,7 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 			log.Debug("This is a virtual function")
 			vp := VirtualEndpoint{BaseMiddleware: m.BaseMiddleware}
 			vp.Init()
-			reqVal = vp.ServeHTTPForCache(w, r)
+			reqVal = vp.ServeHTTPForCache(w, r, nil)
 		} else {
 			// This passes through and will write the value to the writer, but spit out a copy for the cache
 			log.Debug("Not virtual, passing")

--- a/mw_virtual_endpoint_test.go
+++ b/mw_virtual_endpoint_test.go
@@ -33,7 +33,7 @@ func testPrepareVirtualEndpoint(js string, method string, path string, proxyOnEr
 			FunctionSourceURI:    base64.StdEncoding.EncodeToString([]byte(js)),
 			Path:                 path,
 			Method:               method,
-			proxyOnError:         proxyOnError,
+			ProxyOnError:         proxyOnError,
 		}
 		v := spec.VersionData.Versions["v1"]
 		v.UseExtendedPaths = true

--- a/mw_virtual_endpoint_test.go
+++ b/mw_virtual_endpoint_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/base64"
+	"net/http"
 	"testing"
 
 	"github.com/TykTechnologies/tyk/apidef"
@@ -22,7 +23,7 @@ function testVirtData(request, session, config) {
 }
 `
 
-func testPrepareVirtualEndpoint(js string, method string) {
+func testPrepareVirtualEndpoint(js string, method string, path string, proxyOnError bool) {
 	buildAndLoadAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/"
 
@@ -30,8 +31,9 @@ func testPrepareVirtualEndpoint(js string, method string) {
 			ResponseFunctionName: "testVirtData",
 			FunctionSourceType:   "blob",
 			FunctionSourceURI:    base64.StdEncoding.EncodeToString([]byte(js)),
-			Path:                 "/virt",
+			Path:                 path,
 			Method:               method,
+			proxyOnError:         proxyOnError,
 		}
 		v := spec.VersionData.Versions["v1"]
 		v.UseExtendedPaths = true
@@ -59,7 +61,7 @@ func TestVirtualEndpoint(t *testing.T) {
 	ts := newTykTestServer()
 	defer ts.Close()
 
-	testPrepareVirtualEndpoint(virtTestJS, "GET")
+	testPrepareVirtualEndpoint(virtTestJS, "GET", "/virt", true)
 
 	ts.Run(t, test.TestCase{
 		Path:      "/virt",
@@ -72,13 +74,25 @@ func TestVirtualEndpoint(t *testing.T) {
 	})
 }
 
+func TestVirtualEndpoint500(t *testing.T) {
+	ts := newTykTestServer()
+	defer ts.Close()
+
+	testPrepareVirtualEndpoint("abc", "GET", "/abc", false)
+
+	ts.Run(t, test.TestCase{
+		Path: "/abc",
+		Code: http.StatusInternalServerError,
+	})
+}
+
 func BenchmarkVirtualEndpoint(b *testing.B) {
 	b.ReportAllocs()
 
 	ts := newTykTestServer()
 	defer ts.Close()
 
-	testPrepareVirtualEndpoint(virtTestJS, "GET")
+	testPrepareVirtualEndpoint(virtTestJS, "GET", "/virt", true)
 
 	for i := 0; i < b.N; i++ {
 		ts.Run(b, test.TestCase{


### PR DESCRIPTION
added changes for https://github.com/TykTechnologies/tyk/issues/1795

there is a new field in virtual endpoint meta - `proxy_to_target_if_error` that indicates what to do if JS func execution failed.

- if it is `true` we apply old logic allowing request to be proxies to upstream
- if it is `false` (default value) we reply with 500 and stop processing request

also added some code to fix bug in https://github.com/TykTechnologies/tyk/issues/1951 as it was blocking this fix