### PR TITLE
coprocess: fix tests to match the new dispatcher arguments

### DIFF
--- a/coprocess_test_helpers.go
+++ b/coprocess_test_helpers.go
@@ -17,15 +17,11 @@ static int TestMessageLength(struct CoProcessMessage* object) {
 	return object->length;
 }
 
-static struct CoProcessMessage* TestDispatchHook(struct CoProcessMessage* object) {
-	struct CoProcessMessage* outputObject = malloc(sizeof *outputObject);
-
-	outputObject->p_data = object->p_data;
-	outputObject->length = object->length;
-
-	applyTestHooks(outputObject);
-
-	return outputObject;
+static void TestDispatchHook(struct CoProcessMessage* object, struct CoProcessMessage* newObject) {
+	newObject->p_data = object->p_data;
+	newObject->length = object->length;
+	applyTestHooks(newObject);
+	return;
 };
 
 */
@@ -51,10 +47,11 @@ type TestDispatcher struct {
 
 /* Basic CoProcessDispatcher functions */
 
-func (d *TestDispatcher) Dispatch(objectPtr unsafe.Pointer) unsafe.Pointer {
+func (d *TestDispatcher) Dispatch(objectPtr unsafe.Pointer, newObjectPtr unsafe.Pointer) error {
 	object := (*C.struct_CoProcessMessage)(objectPtr)
-	newObjectPtr := C.TestDispatchHook(object)
-	return unsafe.Pointer(newObjectPtr)
+	newObject := (*C.struct_CoProcessMessage)(newObjectPtr)
+	C.TestDispatchHook(object, newObject)
+	return nil
 }
 
 func (d *TestDispatcher) DispatchEvent(eventJSON []byte) {


### PR DESCRIPTION
The dispatcher arguments changed a bit in #1886 so I've updated the tests to cover this.
I've found that we don't actually call `go build -test 'coprocess'` in our current CI configuration file (we do run Python and gRPC tests) but the fix is useful for development tasks.