### PR TITLE
Add access to regexp capturing group Inside URL rewriter

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -540,6 +540,14 @@ func (s *StringRegexMap) Check(value string) string {
 	return s.matchRegex.FindString(value)
 }
 
+func (s *StringRegexMap) FindStringSubmatch(value string) []string {
+	return s.matchRegex.FindStringSubmatch(value)
+}
+
+func (s *StringRegexMap) FindAllStringSubmatch(value string, n int) [][]string {
+	return s.matchRegex.FindAllStringSubmatch(value, n)
+}
+
 func (s *StringRegexMap) Init() error {
 	var err error
 	if s.matchRegex, err = regexp.Compile(s.MatchPattern); err != nil {

--- a/regexp/cache_regexp_str_ret_slice_str.go
+++ b/regexp/cache_regexp_str_ret_slice_str.go
@@ -1,0 +1,45 @@
+package regexp
+
+import (
+	"regexp"
+	"time"
+)
+
+type regexpStrRetSliceStrCache struct {
+	*cache
+}
+
+func newRegexpStrRetSliceStrCache(ttl time.Duration, isEnabled bool) *regexpStrRetSliceStrCache {
+	return &regexpStrRetSliceStrCache{
+		cache: newCache(
+			ttl,
+			isEnabled,
+		),
+	}
+}
+
+func (c *regexpStrRetSliceStrCache) do(r *regexp.Regexp, s string, noCacheFn func(s string) []string) []string {
+	// return if cache is not enabled
+	if !c.enabled() {
+		return noCacheFn(s)
+	}
+
+	// generate key, check key size
+	key := r.String() + s
+	if len(key) > maxKeySize {
+		return noCacheFn(s)
+	}
+
+	// cache hit
+	if res, found := c.getStrSlice(key); found {
+		return res
+	}
+
+	// cache miss, add to cache if value is not too big
+	res := noCacheFn(s)
+	if len(res) <= maxValueSize {
+		c.add(key, res)
+	}
+
+	return res
+}

--- a/regexp/regexp.go
+++ b/regexp/regexp.go
@@ -18,6 +18,7 @@ var (
 	replaceAllStringCache        = newRegexpStrStrRetStrCache(defaultCacheItemTTL, true)
 	replaceAllLiteralStringCache = newRegexpStrStrRetStrCache(defaultCacheItemTTL, true)
 	replaceAllStringFuncCache    = newRegexpStrFuncRetStrCache(defaultCacheItemTTL, true)
+	findStringSubmatchCache      = newRegexpStrRetSliceStrCache(defaultCacheItemTTL, true)
 	findAllStringCache           = newRegexpStrIntRetSliceStrCache(defaultCacheItemTTL, true)
 	findAllStringSubmatchCache   = newRegexpStrIntRetSliceSliceStrCache(defaultCacheItemTTL, true)
 )
@@ -41,6 +42,7 @@ func ResetCache(ttl time.Duration, isEnabled bool) {
 	replaceAllStringCache.reset(ttl, isEnabled)
 	replaceAllLiteralStringCache.reset(ttl, isEnabled)
 	replaceAllStringFuncCache.reset(ttl, isEnabled)
+	findStringSubmatchCache.reset(ttl, isEnabled)
 	findAllStringCache.reset(ttl, isEnabled)
 	findAllStringSubmatchCache.reset(ttl, isEnabled)
 }
@@ -320,8 +322,7 @@ func (re *Regexp) FindStringSubmatch(s string) []string {
 	if re.Regexp == nil {
 		return []string{}
 	}
-	// TODO: add cache for FindStringSubmatch
-	return re.Regexp.FindStringSubmatch(s)
+	return findStringSubmatchCache.do(re.Regexp, s, re.Regexp.FindStringSubmatch)
 }
 
 // FindStringSubmatchIndex is the same as regexp.Regexp.FindStringSubmatchIndex but returns cached result instead.

--- a/regexp/regexp_test.go
+++ b/regexp/regexp_test.go
@@ -567,3 +567,47 @@ func BenchmarkRegexpFindAllStringSubmatch(b *testing.B) {
 
 	b.Log(res)
 }
+
+func TestFindStringSubmatch(t *testing.T) {
+	ResetCache(defaultCacheItemTTL, true)
+
+	// 1st miss
+	rx := MustCompile("abc(\\w)")
+	res := rx.FindStringSubmatch("qweabcxyzabc123abcz")
+	expectedRes := []string{"abcx", "x"}
+
+	if !reflect.DeepEqual(res, expectedRes) {
+		t.Error("Expected :", expectedRes, " Got:", res)
+	}
+	// 2nd hit
+	res2 := rx.FindStringSubmatch("qweabcxyzabc123abcz")
+	if !reflect.DeepEqual(res2, expectedRes) {
+		t.Error("Expected :", expectedRes, " Got:", res2)
+	}
+}
+
+func TestTestFindStringSubmatchRegexpNotSet(t *testing.T) {
+	ResetCache(defaultCacheItemTTL, true)
+
+	rx := &Regexp{}
+
+	res := rx.FindStringSubmatch("qweabcxyzabc123abcz")
+	if len(res) > 0 {
+		t.Error("Expected 0 length slice returned. Got:", res)
+	}
+}
+
+func BenchmarkRegexpFindStringSubmatch(b *testing.B) {
+	b.ReportAllocs()
+
+	ResetCache(defaultCacheItemTTL, true)
+
+	rx := MustCompile("abc(\\w)")
+	var res []string
+
+	for i := 0; i < b.N; i++ {
+		res = rx.FindStringSubmatch("qweabcxyzabc123abcz")
+	}
+
+	b.Log(res)
+}


### PR DESCRIPTION
- add additional level  for $tyc_context trigger keys
- $tyk_context.trigger-{n}-{name}-{i}-{groupNum}  holds group value

Fixes https://github.com/TykTechnologies/tyk/issues/1833