### PR TITLE
http status code 504 for upstream service timeout

### DIFF
--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -669,7 +669,7 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 		}).Error("http: proxy error: ", err)
 
 		if strings.Contains(err.Error(), "timeout awaiting response headers") {
-			p.ErrorHandler.HandleError(rw, logreq, "Upstream service reached hard timeout.", 408)
+			p.ErrorHandler.HandleError(rw, logreq, "Upstream service reached hard timeout.", http.StatusGatewayTimeout)
 
 			if p.TykAPISpec.Proxy.ServiceDiscovery.UseDiscoveryService {
 				if ServiceCache != nil {


### PR DESCRIPTION
resolves #1975

When `Enforced Timeout` plugin is enabled, the gateway response status
code indicates a client error `408 Request Timeout`.

In fact, there is nothing wrong with the client request and this is
misleading.

The correct http status code for this is `504 - Gateway Timeout`.

> The server was acting as a gateway or proxy and did not receive a
timely response from the upstream server.
