### PR TITLE
Added new `health_check_endpoint_name` option

### DIFF
--- a/api_loader.go
+++ b/api_loader.go
@@ -626,7 +626,7 @@ func loadApps(specs []*APISpec, muxer *mux.Router) {
 
 	// All APIs processed, now we can healthcheck
 	// Add a root message to check all is OK
-	muxer.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
+	muxer.HandleFunc("/"+config.Global().HealthCheckEndpointName, func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "Hello Tiki")
 	})
 

--- a/cli/lint/schema.go
+++ b/cli/lint/schema.go
@@ -755,6 +755,9 @@ const confSchema = `{
 	},
 	"proxy_ssl_disable_renegotiation": {
 		"type": "boolean"
+	},
+	"health_check_endpoint_name": {
+		"type": "string"
 	}
 }
 }`

--- a/config/config.go
+++ b/config/config.go
@@ -294,6 +294,7 @@ type Config struct {
 	MinTokenLength                    int                                   `json:"min_token_length"`
 	DisableRegexpCache                bool                                  `json:"disable_regexp_cache"`
 	RegexpCacheExpire                 int32                                 `json:"regexp_cache_expire"`
+	HealthCheckEndpointName           string                                `json:"health_check_endpoint_name"`
 }
 
 type CertData struct {

--- a/main.go
+++ b/main.go
@@ -879,6 +879,10 @@ func afterConfSetup(conf *config.Config) {
 	rpc.GlobalRPCCallTimeout = time.Second * time.Duration(conf.SlaveOptions.CallTimeout)
 	initGenericEventHandlers(conf)
 	regexp.ResetCache(time.Second*time.Duration(conf.RegexpCacheExpire), !conf.DisableRegexpCache)
+
+	if conf.HealthCheckEndpointName == "" {
+		conf.HealthCheckEndpointName = "hello"
+	}
 }
 
 var hostDetails struct {
@@ -1350,7 +1354,7 @@ func listen(listener, controlListener net.Listener, err error) {
 	mainLog.Info("--> Listening on port: ", config.Global().ListenPort)
 	mainLog.Info("--> PID: ", hostDetails.PID)
 
-	mainRouter.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
+	mainRouter.HandleFunc("/"+config.Global().HealthCheckEndpointName, func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "Hello Tiki")
 	})
 


### PR DESCRIPTION
Now default "/hello" endpoint for both global and API level can be renamed using new "health_check_endpoint_name" string variable.

Fix https://github.com/TykTechnologies/tyk/issues/1981

