### PR TITLE
Expose url scheme to plugins

### DIFF
--- a/coprocess.go
+++ b/coprocess.go
@@ -77,7 +77,10 @@ func (c *CoProcessor) ObjectFromRequest(r *http.Request) *coprocess.Object {
 	if host != "" {
 		headers["Host"] = host
 	}
-
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
 	miniRequestObject := &coprocess.MiniRequestObject{
 		Headers:        headers,
 		SetHeaders:     map[string]string{},
@@ -92,7 +95,7 @@ func (c *CoProcessor) ObjectFromRequest(r *http.Request) *coprocess.Object {
 		},
 		Method:     r.Method,
 		RequestUri: r.RequestURI,
-		Scheme:     r.URL.Scheme,
+		Scheme:     scheme,
 	}
 
 	if r.Body != nil {

--- a/mw_js_plugin.go
+++ b/mw_js_plugin.go
@@ -109,6 +109,10 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 		}
 		headers.Set("Host", host)
 	}
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
 
 	requestData := MiniRequestObject{
 		Headers:        headers,
@@ -122,7 +126,7 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 		DeleteParams:   []string{},
 		Method:         r.Method,
 		RequestURI:     r.RequestURI,
-		Scheme:         r.URL.Scheme,
+		Scheme:         scheme,
 	}
 
 	requestAsJson, err := json.Marshal(requestData)

--- a/mw_js_plugin_test.go
+++ b/mw_js_plugin_test.go
@@ -320,7 +320,6 @@ func TestJSVMRequestScheme(t *testing.T) {
 		Pre:                 true,
 	}
 	req := httptest.NewRequest("GET", "/foo", nil)
-	req.URL.Scheme = "http"
 	jsvm := JSVM{}
 	jsvm.Init(nil, logrus.NewEntry(log))
 

--- a/mw_virtual_endpoint.go
+++ b/mw_virtual_endpoint.go
@@ -31,6 +31,7 @@ type RequestObject struct {
 	Body    string
 	URL     string
 	Params  map[string][]string
+	Scheme  string
 }
 
 type ResponseObject struct {
@@ -136,10 +137,15 @@ func (d *VirtualEndpoint) ServeHTTPForCache(w http.ResponseWriter, r *http.Reque
 	}
 	defer r.Body.Close()
 
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
 	requestData := RequestObject{
 		Headers: r.Header,
 		Body:    string(originalBody),
 		URL:     r.URL.Path,
+		Scheme:  scheme,
 	}
 
 	// We need to copy the body _back_ for the decode


### PR DESCRIPTION
Fixes #1516 

Use checking r.TLS to either pass `http` or `https` to `Scheme` field in request objects passed to plugins.

@ilijabojanovic It's actually easily testable this time