### PR TITLE
key creation endpoint fixed

### DIFF
--- a/api.go
+++ b/api.go
@@ -988,6 +988,11 @@ func createKeyHandler(w http.ResponseWriter, r *http.Request) {
 
 	if len(newSession.AccessRights) > 0 {
 		for apiID := range newSession.AccessRights {
+			// reset API-level limit to nil if it has a zero-value
+			if access := newSession.AccessRights[apiID]; access.Limit != nil && *access.Limit == (user.APILimit{}) {
+				access.Limit = nil
+				newSession.AccessRights[apiID] = access
+			}
 			apiSpec := getApiSpec(apiID)
 			if apiSpec != nil {
 				checkAndApplyTrialPeriod(newKey, apiID, newSession)


### PR DESCRIPTION
added changes for https://github.com/TykTechnologies/tyk/issues/1986#event-1982918250

the problem was that our UI passes API-level limit with zero value:
<img width="366" alt="screen shot 2018-11-26 at 3 21 35 pm" src="https://user-images.githubusercontent.com/33698537/49044707-9615bf80-f19c-11e8-9012-1134b6569bdf.png">

So backend was picking up that zero value and used it for rate/quota limits. A non-nil API level limit acts as a trigger to apply limits on API level - added special check to reset api limit to nil if it is not nil but has zero-value struct in it.