### PR TITLE
Optimize regexp key generation

### DIFF
--- a/regexp/cache_regexp_str_func_ret_str.go
+++ b/regexp/cache_regexp_str_func_ret_str.go
@@ -1,7 +1,6 @@
 package regexp
 
 import (
-	"fmt"
 	"regexp"
 	"time"
 )
@@ -25,14 +24,18 @@ func (c *regexpStrFuncRetStrCache) do(r *regexp.Regexp, src string, repl func(st
 		return noCacheFn(src, repl)
 	}
 
+	kb := keyBuilderPool.Get().(*keyBuilder)
+	defer keyBuilderPool.Put(kb)
+	kb.Reset()
+
 	// generate key, check key size
-	key := r.String() + src + fmt.Sprintf("%p", repl)
-	if len(key) > maxKeySize {
+	nsKey := kb.AppendString(r.String()).AppendString(src).Appendf("%p", repl).UnsafeKey()
+	if len(nsKey) > maxKeySize {
 		return noCacheFn(src, repl)
 	}
 
 	// cache hit
-	if res, found := c.getString(key); found {
+	if res, found := c.getString(nsKey); found {
 		return res
 	}
 
@@ -42,7 +45,7 @@ func (c *regexpStrFuncRetStrCache) do(r *regexp.Regexp, src string, repl func(st
 		return res
 	}
 
-	c.add(key, res)
+	c.add(kb.Key(), res)
 
 	return res
 }

--- a/regexp/cache_regexp_str_int_ret_slice_slice_str.go
+++ b/regexp/cache_regexp_str_int_ret_slice_slice_str.go
@@ -2,7 +2,6 @@ package regexp
 
 import (
 	"regexp"
-	"strconv"
 	"time"
 )
 
@@ -25,14 +24,18 @@ func (c *regexpStrIntRetSliceSliceStrCache) do(r *regexp.Regexp, s string, n int
 		return noCacheFn(s, n)
 	}
 
+	kb := keyBuilderPool.Get().(*keyBuilder)
+	defer keyBuilderPool.Put(kb)
+	kb.Reset()
+
 	// generate key, check key size
-	key := r.String() + s + strconv.Itoa(n)
-	if len(key) > maxKeySize {
+	nsKey := kb.AppendString(r.String()).AppendString(s).AppendInt(n).UnsafeKey()
+	if len(nsKey) > maxKeySize {
 		return noCacheFn(s, n)
 	}
 
 	// cache hit
-	if res, found := c.getStrSliceOfSlices(key); found {
+	if res, found := c.getStrSliceOfSlices(nsKey); found {
 		return res
 	}
 
@@ -42,7 +45,7 @@ func (c *regexpStrIntRetSliceSliceStrCache) do(r *regexp.Regexp, s string, n int
 		return res
 	}
 
-	c.add(key, res)
+	c.add(kb.Key(), res)
 
 	return res
 }

--- a/regexp/keybuilder.go
+++ b/regexp/keybuilder.go
@@ -1,0 +1,66 @@
+package regexp
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+	"unsafe"
+)
+
+var keyBuilderPool = sync.Pool{
+	New: func() interface{} { return new(keyBuilder) },
+}
+
+// Combine logic of strings.Builder and bytes.Buffer.
+// Allow to reuse builder with 0 allocs, as bytes.Buffer
+// and also allow to get 0 alloc string representation
+// as strings.Builder
+type keyBuilder struct {
+	buf []byte
+}
+
+// Reset resets the keyBuilder to be empty.
+func (kb *keyBuilder) Reset() *keyBuilder {
+	kb.buf = kb.buf[:0]
+	return kb
+}
+
+// Returns content of internal buffer, converted to string.
+// Safe for using as key for storing item, immutable
+func (kb *keyBuilder) Key() string {
+	return string(kb.buf)
+}
+
+// Returns string representation of internal buffer.
+// Mutable, sequential writes to keyBuilder will
+// also mutate returned representation.
+// Safe for lookups by key.
+// Should not be used as key for storing items.
+func (kb *keyBuilder) UnsafeKey() string {
+	return *(*string)(unsafe.Pointer(&kb.buf))
+}
+
+func (kb *keyBuilder) Write(p []byte) (int, error) {
+	kb.buf = append(kb.buf, p...)
+	return len(p), nil
+}
+
+func (kb *keyBuilder) AppendString(s string) *keyBuilder {
+	kb.buf = append(kb.buf, s...)
+	return kb
+}
+
+func (kb *keyBuilder) AppendBytes(b []byte) *keyBuilder {
+	kb.buf = append(kb.buf, b...)
+	return kb
+}
+
+func (kb *keyBuilder) Appendf(format string, a ...interface{}) *keyBuilder {
+	fmt.Fprintf(kb, format, a...)
+	return kb
+}
+
+func (kb *keyBuilder) AppendInt(n int) *keyBuilder {
+	kb.buf = strconv.AppendInt(kb.buf, int64(n), 10)
+	return kb
+}

--- a/regexp/keybuilder_test.go
+++ b/regexp/keybuilder_test.go
@@ -1,0 +1,103 @@
+package regexp
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestKeyImmutabilityReset(t *testing.T) {
+	kb := keyBuilder{}
+
+	kb.AppendString("aaa")
+	k := kb.Key()
+
+	kb.Reset()
+	if k != "aaa" {
+		t.Errorf("key should remains aaa, got %v", k)
+	}
+}
+
+func TestKeyImmutabilityChangeBuilderState(t *testing.T) {
+	kb := keyBuilder{}
+
+	kb.AppendString("aaa")
+	k := kb.Key()
+
+	kb.AppendString("bbb")
+	if k != "aaa" {
+		t.Errorf("key should remains aaa, got %v", k)
+	}
+}
+
+func TestAppendString(t *testing.T) {
+	kb := keyBuilder{}
+
+	kb.AppendString("aaa").AppendString("bbb")
+	nsKey := kb.UnsafeKey()
+	key := kb.Key()
+
+	if key != "aaabbb" || nsKey != "aaabbb" {
+		t.Errorf("expect to got aaabbb, got %v and %v", key, nsKey)
+	}
+}
+
+func TestAppendBytes(t *testing.T) {
+	kb := keyBuilder{}
+
+	kb.AppendString("aaa").AppendBytes([]byte("bbb"))
+	nsKey := kb.UnsafeKey()
+	key := kb.Key()
+
+	if key != "aaabbb" || nsKey != "aaabbb" {
+		t.Errorf("expect to got aaabbb, got %v and %v", key, nsKey)
+	}
+}
+
+func TestAppendInt(t *testing.T) {
+	kb := keyBuilder{}
+
+	kb.AppendString("aaa").AppendInt(123)
+	nsKey := kb.UnsafeKey()
+	key := kb.Key()
+
+	if key != "aaa123" || nsKey != "aaa123" {
+		t.Errorf("expect to got aaa123, got %v and %v", key, nsKey)
+	}
+}
+
+func TestWrite(t *testing.T) {
+	kb := keyBuilder{}
+
+	b := []byte("bbb")
+	n, err := kb.AppendString("aaa").Write(b)
+
+	if err != nil {
+		t.Errorf("Write should always pass without error, got %v", err)
+	}
+
+	if n != len(b) {
+		t.Errorf("Write should always return length of byte slice argument. Expected %v, got %v", len(b), n)
+	}
+
+	nsKey := kb.UnsafeKey()
+	key := kb.Key()
+
+	if key != "aaabbb" || nsKey != "aaabbb" {
+		t.Errorf("expect to got aaabbb, got %v and %v", key, nsKey)
+	}
+}
+
+func TestAppendf(t *testing.T) {
+	kb := keyBuilder{}
+
+	f := func(s string) string { return s }
+	expected := fmt.Sprintf("aaa%p", f)
+
+	kb.AppendString("aaa").Appendf("%p", f)
+	nsKey := kb.UnsafeKey()
+	key := kb.Key()
+
+	if key != expected || nsKey != expected {
+		t.Errorf("expect to got %v, got %v and %v", expected, key, nsKey)
+	}
+}

--- a/regexp/keybuilder_test.go
+++ b/regexp/keybuilder_test.go
@@ -5,71 +5,77 @@ import (
 	"testing"
 )
 
+var tStr1 = "aαa⏰𐌈"
+var tStr2 = "bβb⏳𐌏"
+
 func TestKeyImmutabilityReset(t *testing.T) {
 	kb := keyBuilder{}
 
-	kb.AppendString("aaa")
+	kb.AppendString(tStr1)
 	k := kb.Key()
 
 	kb.Reset()
-	if k != "aaa" {
-		t.Errorf("key should remains aaa, got %v", k)
+	if k != tStr1 {
+		t.Errorf("key should remains %v, got %v", tStr1, k)
 	}
 }
 
 func TestKeyImmutabilityChangeBuilderState(t *testing.T) {
 	kb := keyBuilder{}
 
-	kb.AppendString("aaa")
+	kb.AppendString(tStr1)
 	k := kb.Key()
 
-	kb.AppendString("bbb")
-	if k != "aaa" {
-		t.Errorf("key should remains aaa, got %v", k)
+	kb.AppendString(tStr2)
+	if k != tStr1 {
+		t.Errorf("key should remains %v, got %v", tStr1, k)
 	}
 }
 
 func TestAppendString(t *testing.T) {
 	kb := keyBuilder{}
 
-	kb.AppendString("aaa").AppendString("bbb")
+	kb.AppendString(tStr1).AppendString(tStr2)
 	nsKey := kb.UnsafeKey()
 	key := kb.Key()
 
-	if key != "aaabbb" || nsKey != "aaabbb" {
-		t.Errorf("expect to got aaabbb, got %v and %v", key, nsKey)
+	exp := tStr1 + tStr2
+	if key != exp || nsKey != exp {
+		t.Errorf("expect to got %v, got %v and %v", exp, key, nsKey)
 	}
 }
 
 func TestAppendBytes(t *testing.T) {
 	kb := keyBuilder{}
 
-	kb.AppendString("aaa").AppendBytes([]byte("bbb"))
+	kb.AppendString(tStr1).AppendBytes([]byte(tStr2))
 	nsKey := kb.UnsafeKey()
 	key := kb.Key()
 
-	if key != "aaabbb" || nsKey != "aaabbb" {
-		t.Errorf("expect to got aaabbb, got %v and %v", key, nsKey)
+	exp := tStr1 + tStr2
+	if key != exp || nsKey != exp {
+		t.Errorf("expect to got %v, got %v and %v", exp, key, nsKey)
 	}
 }
 
 func TestAppendInt(t *testing.T) {
 	kb := keyBuilder{}
 
-	kb.AppendString("aaa").AppendInt(123)
+	kb.AppendString(tStr1).AppendInt(123)
 	nsKey := kb.UnsafeKey()
 	key := kb.Key()
 
-	if key != "aaa123" || nsKey != "aaa123" {
-		t.Errorf("expect to got aaa123, got %v and %v", key, nsKey)
+	exp := tStr1 + "123"
+	if key != exp || nsKey != exp {
+		t.Errorf("expect to got %v, got %v and %v", exp, key, nsKey)
 	}
 }
 
 func TestWrite(t *testing.T) {
 	kb := keyBuilder{}
 
-	b := []byte("bbb")
-	n, err := kb.AppendString("aaa").Write(b)
+	b := []byte(tStr2)
+	n, err := kb.AppendString(tStr1).Write(b)
 
 	if err != nil {
 		t.Errorf("Write should always pass without error, got %v", err)
@@ -82,8 +88,9 @@ func TestWrite(t *testing.T) {
 	nsKey := kb.UnsafeKey()
 	key := kb.Key()
 
-	if key != "aaabbb" || nsKey != "aaabbb" {
-		t.Errorf("expect to got aaabbb, got %v and %v", key, nsKey)
+	exp := tStr1 + tStr2
+	if key != exp || nsKey != exp {
+		t.Errorf("expect to got %v, got %v and %v", exp, key, nsKey)
 	}
 }
 
@@ -91,13 +98,13 @@ func TestAppendf(t *testing.T) {
 	kb := keyBuilder{}
 
 	f := func(s string) string { return s }
-	expected := fmt.Sprintf("aaa%p", f)
 
-	kb.AppendString("aaa").Appendf("%p", f)
+	kb.AppendString(tStr1).Appendf("%p", f)
 	nsKey := kb.UnsafeKey()
 	key := kb.Key()
 
-	if key != expected || nsKey != expected {
-		t.Errorf("expect to got %v, got %v and %v", expected, key, nsKey)
+	exp := tStr1 + fmt.Sprintf("%p", f)
+	if key != exp || nsKey != exp {
+		t.Errorf("expect to got %v, got %v and %v", exp, key, nsKey)
 	}
 }


### PR DESCRIPTION
This pull request will introduce reusable keybuilder which reduce allocations in cached regexp
Resolve #1998 
Related to #1662 