### PR TITLE
analytics RecordHit fixed

### DIFF
--- a/handler_success.go
+++ b/handler_success.go
@@ -4,14 +4,13 @@ import (
 	"bytes"
 	"encoding/base64"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"runtime/pprof"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/pmylund/go-cache"
+	cache "github.com/pmylund/go-cache"
 
 	"github.com/TykTechnologies/tyk/request"
 
@@ -152,18 +151,10 @@ func (s *SuccessHandler) RecordHit(r *http.Request, timing int64, code int, resp
 			// mw_redis_cache instead? is there a reason not
 			// to include that in the analytics?
 			if responseCopy != nil {
-				// Make a copy of response body as Response.Write resets underlying buffer to 0 len
-				responseCopyBodyBuffer := new(bytes.Buffer)
-				recordBodyBuffer := new(bytes.Buffer)
-				io.Copy(responseCopyBodyBuffer, responseCopy.Body) // this resets responseCopy.Body buffer to 0 len
-				*recordBodyBuffer = *responseCopyBodyBuffer
-				responseCopy.Body = ioutil.NopCloser(recordBodyBuffer) // fix responseCopy.Body buffer after io.Copy
 				// Get the wire format representation
 				var wireFormatRes bytes.Buffer
-				responseCopy.Write(&wireFormatRes) // this resets responseCopy.Body buffer to 0 len again
+				responseCopy.Write(&wireFormatRes)
 				rawResponse = base64.StdEncoding.EncodeToString(wireFormatRes.Bytes())
-				// fix Body to be read again
-				responseCopy.Body = ioutil.NopCloser(responseCopyBodyBuffer) // fix responseCopy.Body buffer after responseCopy.Write
 			}
 		}
 

--- a/mw_redis_cache.go
+++ b/mw_redis_cache.go
@@ -231,6 +231,7 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 	if err != nil {
 		log.Error("Could not create response object: ", err)
 	}
+	nopCloseResponseBody(newRes)
 
 	defer newRes.Body.Close()
 	for _, h := range hopHeaders {
@@ -263,7 +264,7 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 
 	// Record analytics
 	if !m.Spec.DoNotTrack {
-		go m.sh.RecordHit(r, 0, newRes.StatusCode, nil)
+		go m.sh.RecordHit(r, 0, newRes.StatusCode, newRes)
 	}
 
 	// Stop any further execution

--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -371,7 +371,11 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) *htt
 }
 
 func (p *ReverseProxy) ServeHTTPForCache(rw http.ResponseWriter, req *http.Request) *http.Response {
-	return p.WrappedServeHTTP(rw, req, true)
+	resp := p.WrappedServeHTTP(rw, req, true)
+
+	nopCloseResponseBody(resp)
+
+	return resp
 }
 
 func (p *ReverseProxy) CheckHardTimeoutEnforced(spec *APISpec, req *http.Request) (bool, int) {
@@ -890,11 +894,8 @@ func (n nopCloser) Read(p []byte) (int, error) {
 	return num, err
 }
 
-// Close is a no-op Close plus moves position to the start just in case
+// Close is a no-op Close
 func (n nopCloser) Close() error {
-	// seek to the start if body ever called to be closed
-	n.Seek(0, io.SeekStart)
-
 	return nil
 }
 


### PR DESCRIPTION
added changes for https://github.com/TykTechnologies/tyk/issues/1996

Thus situation was happening when detailed analytics recording (copy of actual response in analytics record) is enabled.

The code in RecordHit was screwing up copyResponse.Body underlaying buffer by reseting its length to 0. So item put into cache had only headers without body and it was causing that error `http: proxy error during body copy: unexpected EOF` as we use reverse-proxy code to instantiate response from cache item value.
