### PR TITLE
Handle nil map in body transform

### DIFF
--- a/res_handler_transform.go
+++ b/res_handler_transform.go
@@ -116,13 +116,15 @@ func (h *ResponseTransformMiddleware) HandleResponse(rw http.ResponseWriter, res
 		}
 	}
 
-	if h.Spec.EnableContextVars {
-		bodyData["_tyk_context"] = ctxGetData(req)
-	}
+	if bodyData != nil {
+		if h.Spec.EnableContextVars {
+			bodyData["_tyk_context"] = ctxGetData(req)
+		}
 
-	if tmeta.TemplateData.EnableSession {
-		session := ctxGetSession(req)
-		bodyData["_tyk_meta"] = session.MetaData
+		if tmeta.TemplateData.EnableSession {
+			session := ctxGetSession(req)
+			bodyData["_tyk_meta"] = session.MetaData
+		}
 	}
 
 	// Apply to template


### PR DESCRIPTION
This is a potential fix for #2016.

This fix makes sure that we don't write to the `nil` map that's initialized by `mxj.NewMapXml` when passing an invalid XML input.

We don't throw any HTTP errors from this middleware, if we decide to do that we should modify the lines that handle the request body.