### PR TITLE
Move OpenID JWT scope settings to root level

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -305,10 +305,8 @@ type ServiceDiscoveryConfiguration struct {
 }
 
 type OIDProviderConfig struct {
-	Issuer               string            `bson:"issuer" json:"issuer"`
-	ClientIDs            map[string]string `bson:"client_ids" json:"client_ids"`
-	ScopeFieldName       string            `bson:"scope_field_name" json:"scope_field_name"`
-	ScopeToPolicyMapping map[string]string `bson:"scope_to_policy_mapping" json:"scope_to_policy_mapping"`
+	Issuer    string            `bson:"issuer" json:"issuer"`
+	ClientIDs map[string]string `bson:"client_ids" json:"client_ids"`
 }
 
 type OpenIDOptions struct {
@@ -355,6 +353,7 @@ type APIDefinition struct {
 	JWTNotBeforeValidationSkew uint64               `bson:"jwt_not_before_validation_skew" json:"jwt_not_before_validation_skew"`
 	JWTSkipKid                 bool                 `bson:"jwt_skip_kid" json:"jwt_skip_kid"`
 	JWTScopeToPolicyMapping    map[string]string    `bson:"jwt_scope_to_policy_mapping" json:"jwt_scope_to_policy_mapping"`
+	JWTScopeClaimName          string               `bson:"jwt_scope_claim_name" json:"jwt_scope_claim_name"`
 	NotificationsDetails       NotificationsManager `bson:"notifications" json:"notifications"`
 	EnableSignatureChecking    bool                 `bson:"enable_signature_checking" json:"enable_signature_checking"`
 	HmacAllowedClockSkew       float64              `bson:"hmac_allowed_clock_skew" json:"hmac_allowed_clock_skew"`

--- a/apidef/schema.go
+++ b/apidef/schema.go
@@ -105,6 +105,9 @@ const Schema = `{
         "jwt_scope_to_policy_mapping": {
             "type": ["object", "null"]
         },
+        "jwt_scope_claim_name": {
+            "type": "string"
+        },
         "use_keyless": {
             "type": "boolean"
         },

--- a/mw_jwt.go
+++ b/mw_jwt.go
@@ -307,8 +307,13 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 			true)
 
 		// apply policies from scope if scope-to-policy mapping is specified for this API
-		if k.Spec.JWTScopeToPolicyMapping != nil {
-			if scope := getScopeFromClaim(claims, "scope"); scope != nil {
+		if len(k.Spec.JWTScopeToPolicyMapping) != 0 {
+			scopeClaimName := k.Spec.JWTScopeClaimName
+			if scopeClaimName == "" {
+				scopeClaimName = "scope"
+			}
+
+			if scope := getScopeFromClaim(claims, scopeClaimName); scope != nil {
 				polIDs := []string{
 					basePolicyID, // add base policy as a first one
 				}


### PR DESCRIPTION
The main intent that it probably will be too complex, especially from UI point of view. Lets start with defining same mapping for all clients. As a bonus, all fields shared with JWT middleware.

Also, JWT middleware scope name made configurable using `JWTScopeClaimName`

Plus empty map check now use: `len` instead of nil, to support empty maps.

Updates https://github.com/TykTechnologies/tyk/pull/1943 and https://github.com/TykTechnologies/tyk/issues/1834