### PR TITLE
Add support for dynamic API certificates

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -425,6 +425,7 @@ type APIDefinition struct {
 		Debug              bool     `bson:"debug" json:"debug"`
 	} `bson:"CORS" json:"CORS"`
 	Domain            string                 `bson:"domain" json:"domain"`
+	Certificates      []string               `bson:"certificates" json:"certificates"`
 	DoNotTrack        bool                   `bson:"do_not_track" json:"do_not_track"`
 	Tags              []string               `bson:"tags" json:"tags"`
 	EnableContextVars bool                   `bson:"enable_context_vars" json:"enable_context_vars"`

--- a/apidef/schema.go
+++ b/apidef/schema.go
@@ -265,6 +265,9 @@ const Schema = `{
         "domain": {
             "type": "string"
         },
+        "certificates": {
+            "type": ["array", "null"]
+        },
         "check_host_against_uptime_tests": {
             "type": "boolean"
         },


### PR DESCRIPTION
Added new API definition field: `certificates`, which is a string array.

You just need to specify a list of Certificate IDs, and Tyk will dynamically load this certificates, without process restart. 

Fix https://github.com/TykTechnologies/tyk/issues/2030