### PR TITLE
Support URL rewrites based on request context

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -139,11 +139,12 @@ type StringRegexMap struct {
 }
 
 type RoutingTriggerOptions struct {
-	HeaderMatches      map[string]StringRegexMap `bson:"header_matches" json:"header_matches"`
-	QueryValMatches    map[string]StringRegexMap `bson:"query_val_matches" json:"query_val_matches"`
-	PathPartMatches    map[string]StringRegexMap `bson:"path_part_matches" json:"path_part_matches"`
-	SessionMetaMatches map[string]StringRegexMap `bson:"session_meta_matches" json:"session_meta_matches"`
-	PayloadMatches     StringRegexMap            `bson:"payload_matches" json:"payload_matches"`
+	HeaderMatches         map[string]StringRegexMap `bson:"header_matches" json:"header_matches"`
+	QueryValMatches       map[string]StringRegexMap `bson:"query_val_matches" json:"query_val_matches"`
+	PathPartMatches       map[string]StringRegexMap `bson:"path_part_matches" json:"path_part_matches"`
+	SessionMetaMatches    map[string]StringRegexMap `bson:"session_meta_matches" json:"session_meta_matches"`
+	RequestContextMatches map[string]StringRegexMap `bson:"request_context_matches" json:"request_context_matches"`
+	PayloadMatches        StringRegexMap            `bson:"payload_matches" json:"payload_matches"`
 }
 
 type RoutingTrigger struct {

--- a/mw_url_rewrite_test.go
+++ b/mw_url_rewrite_test.go
@@ -713,6 +713,33 @@ func TestRewriterTriggers(t *testing.T) {
 		},
 		func() TestDef {
 			r, _ := http.NewRequest("GET", "/test/foo/rewrite", nil)
+			hOpt := apidef.StringRegexMap{MatchPattern: "bar"}
+			hOpt.Init()
+
+			ctxSetData(r, map[string]interface{}{
+				"rewrite": "bar-baz",
+			})
+
+			return TestDef{
+				"Request context",
+				"/test/foo/rewrite", "/change/to/me/ignore",
+				"/test/foo/rewrite", "/change/to/me/bar",
+				[]apidef.RoutingTrigger{
+					{
+						On: apidef.Any,
+						Options: apidef.RoutingTriggerOptions{
+							RequestContextMatches: map[string]apidef.StringRegexMap{
+								"rewrite": hOpt,
+							},
+						},
+						RewriteTo: "/change/to/me/$tyk_context.trigger-0-rewrite",
+					},
+				},
+				r,
+			}
+		},
+		func() TestDef {
+			r, _ := http.NewRequest("GET", "/test/foo/rewrite", nil)
 			hOpt := apidef.StringRegexMap{MatchPattern: "foo"}
 			hOpt.Init()
 


### PR DESCRIPTION
Similar to key meta. We should reflect it on UI. 

New key in Routing trigger options is `request_context_matches`. 

Fix https://github.com/TykTechnologies/tyk/issues/2032