### PR TITLE
API limit remaining quota fixed

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -292,6 +292,16 @@ func (t BaseMiddleware) ApplyPolicies(key string, session *user.SessionState) er
 					}
 				}
 
+				// respect current quota remaining and quota renews (on API limit level)
+				var limitQuotaRemaining int64
+				var limitQuotaRenews int64
+				if currAccessRight, ok := rights[apiID]; ok && currAccessRight.Limit != nil {
+					limitQuotaRemaining = currAccessRight.Limit.QuotaRemaining
+					limitQuotaRenews = currAccessRight.Limit.QuotaRenews
+				}
+				accessRights.Limit.QuotaRemaining = limitQuotaRemaining
+				accessRights.Limit.QuotaRenews = limitQuotaRenews
+
 				// overwrite session access right for this API
 				rights[apiID] = accessRights
 


### PR DESCRIPTION
added changes for https://github.com/TykTechnologies/tyk-analytics/issues/987

The problem with quota-remaining is that it it never makes to storage, we schedule session update in storage only when new renewal period starts, so we have to populate "remaining quota" counters directly from counters in redis when key gets requested via API.

Also, added some tests for quota on API limit, something we should have done initially.