### PR TITLE
Fix host checker

### DIFF
--- a/host_checker_manager.go
+++ b/host_checker_manager.go
@@ -211,7 +211,7 @@ func (hc *HostCheckerManager) OnHostDown(report HostHealthReport) {
 	log.WithFields(logrus.Fields{
 		"prefix": "host-check-mgr",
 	}).Debug("Update key: ", hc.getHostKey(report))
-	hc.store.SetKey(hc.getHostKey(report), "1", int64(hc.checker.checkTimeout+1))
+	hc.store.SetKey(hc.getHostKey(report), "1", int64(hc.checker.checkTimeout*hc.checker.sampleTriggerLimit))
 
 	spec := getApiSpec(report.MetaData[UnHealthyHostMetaDataAPIKey])
 	if spec == nil {

--- a/host_checker_test.go
+++ b/host_checker_test.go
@@ -149,7 +149,7 @@ func TestHostChecker(t *testing.T) {
 	}
 
 	redisStore := GlobalHostChecker.store.(storage.RedisCluster)
-	if ttl, _ := redisStore.GetKeyTTL(PoolerHostSentinelKeyPrefix + testHttpFailure); int(ttl) != GlobalHostChecker.checker.checkTimeout+1 {
+	if ttl, _ := redisStore.GetKeyTTL(PoolerHostSentinelKeyPrefix + testHttpFailure); int(ttl) != GlobalHostChecker.checker.checkTimeout*GlobalHostChecker.checker.sampleTriggerLimit {
 		t.Error("HostDown expiration key should be checkTimeout + 1", ttl)
 	}
 	GlobalHostChecker.checkerMu.Unlock()


### PR DESCRIPTION
Current implementation has multiple flaws. 
At the moment first HostDown event happens after a number of specified tries, and if the host is still down, the next HostDown event will happen after the same number of tries. So if `time_wait` is 10s, and `failure_trigger_sample_size` 2, it means 20 seconds between events. At the same time we set redis expiration key for "host down" key, to `time_wait` + 1, which means key will be expired 9 seconds before second HostDown event. This PR fix it by setting expiration time to `time_wait` * `failure_trigger_sample_size`

Another issue is how host considered to be up. At the moment on first succesful attempt we just enabled the host, however if upstream is unstable, having single healthy attempt does not mean that it is recovered. This change makes Host UP logic work exactly like Host Down and now consider number of tries. 

Fix https://github.com/TykTechnologies/tyk/issues/2036