### PR TITLE
Strip Authorization from cookie when enabled

### DIFF
--- a/mw_strip_auth.go
+++ b/mw_strip_auth.go
@@ -3,6 +3,7 @@ package main
 import (
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/Sirupsen/logrus"
 )
@@ -70,4 +71,23 @@ func (sa *StripAuth) stripFromHeaders(r *http.Request) {
 	}
 
 	r.Header.Del(authHeaderName)
+
+	// Strip Authorization from Cookie Header
+	cookieName := "Cookie"
+	if config.CookieName != "" {
+		cookieName = config.CookieName
+	}
+
+	cookieValue := r.Header.Get(cookieName)
+
+	cookies := strings.Split(r.Header.Get(cookieName), ";")
+	for i, c := range cookies {
+		if strings.HasPrefix(c, authHeaderName) {
+			cookies = append(cookies[:i], cookies[i+1:]...)
+			cookieValue = strings.Join(cookies, ";")
+			r.Header.Set(cookieName, cookieValue)
+			break
+		}
+
+	}
 }


### PR DESCRIPTION
When user wants to strip authorization from headers, it wasn't stripped from cookies.
This PR enables removing authorization from cookies too.

Example after this PR:

```
curl http://localhost:8181/trial/get --cookie 'Authorization=eyJvcmciOiI1YzM0YWNmYWJjYTgyYTA5Nzk5MWEwNDkiLCJpZCI6ImRjMTNiOGU0NWMzYzQzZjJhZTdlNDlmYWU4ZjI1YmU4IiwiaCI6Im11cm11cjY0In0='
{
  "args": {}, 
  "headers": {
    "Accept": "*/*", 
    "Accept-Encoding": "gzip", 
    "Connection": "close", 
    "Cookie": "", 
    "Host": "httpbin.org", 
    "User-Agent": "curl/7.54.0"
  }, 
  "origin": "::1, 88.241.39.30", 
  "url": "http://httpbin.org/get"
}
```
Fixes #2047 