### PR TITLE
Fix multiple plugins stopped working after URL rewrite

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -974,6 +974,9 @@ func (a *APISpec) URLAllowedAndIgnored(r *http.Request, rxPaths []URLSpec, white
 // CheckSpecMatchesStatus checks if a url spec has a specific status
 func (a *APISpec) CheckSpecMatchesStatus(r *http.Request, rxPaths []URLSpec, mode URLStatus) (bool, interface{}) {
 	matchPath := r.URL.Path
+	if origURL := ctxGetOrigRequestURL(r); origURL != nil {
+		matchPath = origURL.Path
+	}
 	if !strings.HasPrefix(matchPath, "/") {
 		matchPath = "/" + matchPath
 	}


### PR DESCRIPTION
It just checkes for original URL in call cases. 

Fix https://github.com/TykTechnologies/tyk/issues/2064
