### PR TITLE
Exclude listen path prefix from url when matching plugins

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -977,6 +977,10 @@ func (a *APISpec) CheckSpecMatchesStatus(r *http.Request, rxPaths []URLSpec, mod
 	if !strings.HasPrefix(matchPath, "/") {
 		matchPath = "/" + matchPath
 	}
+	if a.Proxy.ListenPath != "/" {
+		matchPath = strings.TrimPrefix(matchPath, a.Proxy.ListenPath)
+	}
+
 	// Check if ignored
 	for _, v := range rxPaths {
 		if mode != v.Status {


### PR DESCRIPTION
Issue was happening because ListenPath was included into request URL

Fix https://github.com/TykTechnologies/tyk/issues/2067