### PR TITLE
Add support for `sha256`, `sha384` and `sha512` hmac signatures

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -358,6 +358,7 @@ type APIDefinition struct {
 	NotificationsDetails       NotificationsManager `bson:"notifications" json:"notifications"`
 	EnableSignatureChecking    bool                 `bson:"enable_signature_checking" json:"enable_signature_checking"`
 	HmacAllowedClockSkew       float64              `bson:"hmac_allowed_clock_skew" json:"hmac_allowed_clock_skew"`
+	HmacAllowedAlgorithms      []string             `bson:"hmac_allowed_algorithms" json:"hmac_allowed_algorithms"`
 	BaseIdentityProvidedBy     AuthTypeEnum         `bson:"base_identity_provided_by" json:"base_identity_provided_by"`
 	VersionDefinition          struct {
 		Location  string `bson:"location" json:"location"`
@@ -678,6 +679,7 @@ func DummyAPI() APIDefinition {
 		TagHeaders:              []string{},
 		UpstreamCertificates:    map[string]string{},
 		JWTScopeToPolicyMapping: map[string]string{},
+		HmacAllowedAlgorithms:   []string{},
 		CustomMiddleware: MiddlewareSection{
 			Post:        []MiddlewareDefinition{},
 			Pre:         []MiddlewareDefinition{},

--- a/apidef/schema.go
+++ b/apidef/schema.go
@@ -194,6 +194,9 @@ const Schema = `{
         "hmac_allowed_clock_skew": {
             "type": "number"
         },
+        "hmac_allowed_algorithms": {
+            "type": ["array", "null"]
+        },
         "dont_set_quota_on_create": {
             "type": "boolean"
             },

--- a/mw_hmac.go
+++ b/mw_hmac.go
@@ -77,6 +77,12 @@ func (hm *HMACMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request,
 
 	if len(hm.Spec.HmacAllowedAlgorithms) > 0 {
 		algorithmAllowed := false
+		for _, alg := range hm.Spec.HmacAllowedAlgorithms {
+			if alg == fieldValues.Algorthm {
+				algorithmAllowed = true
+				break
+			}
+		}
 		if !algorithmAllowed {
 			logger.WithError(err).WithField("algorithm", fieldValues.Algorthm).Error("Algorithm not supported")
 			return hm.authorizationError(r)

--- a/mw_hmac.go
+++ b/mw_hmac.go
@@ -75,6 +75,14 @@ func (hm *HMACMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request,
 		return hm.authorizationError(r)
 	}
 
+	if len(hm.Spec.HmacAllowedAlgorithms) > 0 {
+		algorithmAllowed := false
+		if !algorithmAllowed {
+			logger.WithError(err).WithField("algorithm", fieldValues.Algorthm).Error("Algorithm not supported")
+			return hm.authorizationError(r)
+		}
+	}
+
 	// Create a signed string with the secret
 	encodedSignature := generateEncodedSignature(signatureString, secret, fieldValues.Algorthm)
 

--- a/mw_hmac_test.go
+++ b/mw_hmac_test.go
@@ -184,6 +184,7 @@ func TestHMACAuthSessionSHA512Pass(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	req.Header.Set("Authorization", fmt.Sprintf("Signature keyId=\"%s\",algorithm=\"hmac-sha512\",signature=\"%s\"", sessionKey, encodedString))
 
+	spec.HmacAllowedAlgorithms = []string{"hmac-sha512"}
 	chain := getHMACAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
 

--- a/mw_hmac_test.go
+++ b/mw_hmac_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"crypto/hmac"
 	"crypto/sha1"
+	"crypto/sha512"
 	"encoding/base64"
 	"fmt"
+	"hash"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -98,7 +100,7 @@ func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
 	}
 }
 
-func testPrepareHMACAuthSessionPass(tb testing.TB, eventWG *sync.WaitGroup, withHeader bool, isBench bool) (string, *APISpec, *http.Request, string) {
+func testPrepareHMACAuthSessionPass(tb testing.TB, hashFn func() hash.Hash, eventWG *sync.WaitGroup, withHeader bool, isBench bool) (string, *APISpec, *http.Request, string) {
 	spec := createSpecTest(tb, hmacAuthDef)
 	session := createHMACAuthSession()
 
@@ -142,7 +144,7 @@ func testPrepareHMACAuthSessionPass(tb testing.TB, eventWG *sync.WaitGroup, with
 
 	// Encode it
 	key := []byte(session.HmacSecret)
-	h := hmac.New(sha1.New, key)
+	h := hmac.New(hashFn, key)
 	h.Write([]byte(signatureString))
 
 	sigString := base64.StdEncoding.EncodeToString(h.Sum(nil))
@@ -155,10 +157,32 @@ func TestHMACAuthSessionPass(t *testing.T) {
 	// Should not receive an AuthFailure event
 	var eventWG sync.WaitGroup
 	eventWG.Add(1)
-	encodedString, spec, req, sessionKey := testPrepareHMACAuthSessionPass(t, &eventWG, false, false)
+	encodedString, spec, req, sessionKey := testPrepareHMACAuthSessionPass(t, sha1.New, &eventWG, false, false)
 
 	recorder := httptest.NewRecorder()
 	req.Header.Set("Authorization", fmt.Sprintf("Signature keyId=\"%s\",algorithm=\"hmac-sha1\",signature=\"%s\"", sessionKey, encodedString))
+
+	chain := getHMACAuthChain(spec)
+	chain.ServeHTTP(recorder, req)
+
+	if recorder.Code != 200 {
+		t.Error("Initial request failed with non-200 code, should have gone through!: \n", recorder.Code, recorder.Body.String())
+	}
+
+	// Check we did not get our AuthFailure event
+	if !waitTimeout(&eventWG, 20*time.Millisecond) {
+		t.Error("Request should not have generated an AuthFailure event!: \n")
+	}
+}
+
+func TestHMACAuthSessionSHA512Pass(t *testing.T) {
+	// Should not receive an AuthFailure event
+	var eventWG sync.WaitGroup
+	eventWG.Add(1)
+	encodedString, spec, req, sessionKey := testPrepareHMACAuthSessionPass(t, sha512.New, &eventWG, false, false)
+
+	recorder := httptest.NewRecorder()
+	req.Header.Set("Authorization", fmt.Sprintf("Signature keyId=\"%s\",algorithm=\"hmac-sha512\",signature=\"%s\"", sessionKey, encodedString))
 
 	chain := getHMACAuthChain(spec)
 	chain.ServeHTTP(recorder, req)
@@ -178,7 +202,7 @@ func BenchmarkHMACAuthSessionPass(b *testing.B) {
 
 	var eventWG sync.WaitGroup
 	eventWG.Add(b.N)
-	encodedString, spec, req, sessionKey := testPrepareHMACAuthSessionPass(b, &eventWG, false, true)
+	encodedString, spec, req, sessionKey := testPrepareHMACAuthSessionPass(b, sha1.New, &eventWG, false, true)
 
 	recorder := httptest.NewRecorder()
 	req.Header.Set("Authorization", fmt.Sprintf("Signature keyId=\"%s\",algorithm=\"hmac-sha1\",signature=\"%s\"", sessionKey, encodedString))
@@ -405,7 +429,7 @@ func TestHMACAuthSessionPassWithHeaderField(t *testing.T) {
 	// Should not receive an AuthFailure event
 	var eventWG sync.WaitGroup
 	eventWG.Add(1)
-	encodedString, spec, req, sessionKey := testPrepareHMACAuthSessionPass(t, &eventWG, true, false)
+	encodedString, spec, req, sessionKey := testPrepareHMACAuthSessionPass(t, sha1.New, &eventWG, true, false)
 
 	recorder := httptest.NewRecorder()
 	req.Header.Set("Authorization", fmt.Sprintf("Signature keyId=\"%s\",algorithm=\"hmac-sha1\",headers=\"(request-target) date x-test-1 x-test-2\",signature=\"%s\"", sessionKey, encodedString))
@@ -428,7 +452,7 @@ func BenchmarkHMACAuthSessionPassWithHeaderField(b *testing.B) {
 
 	var eventWG sync.WaitGroup
 	eventWG.Add(b.N)
-	encodedString, spec, req, sessionKey := testPrepareHMACAuthSessionPass(b, &eventWG, true, true)
+	encodedString, spec, req, sessionKey := testPrepareHMACAuthSessionPass(b, sha1.New, &eventWG, true, true)
 
 	recorder := httptest.NewRecorder()
 	req.Header.Set("Authorization", fmt.Sprintf("Signature keyId=\"%s\",algorithm=\"hmac-sha1\",headers=\"(request-target) date x-test-1 x-test-2\",signature=\"%s\"", sessionKey, encodedString))


### PR DESCRIPTION
Now HMAC middleware will actually read Algorithm header value, and based on its value will pick the hashing algorithm. You can also whitelist allowed hashing algorithms by setting new string array API definition variable`hmac_allowed_algorithms` to smth like: ["hmac-sha512"]. Accepted values: "hmac-sha1", "hmac-sha256", "hmac-sha384", "hmac-sha512".

Fix https://github.com/TykTechnologies/tyk/issues/2066