### PR TITLE
make strings.Contains args order less suspicious

### DIFF
--- a/cli/bundler/bundler_test.go
+++ b/cli/bundler/bundler_test.go
@@ -82,7 +82,7 @@ func TestBuild(t *testing.T) {
 		filename := writeManifestFile(t, "{", defaultManifestPath)
 		bundler.manifestPath = filename
 		err = bundler.Build(ctx)
-		if !strings.Contains("unexpected end of JSON input", err.Error()) {
+		if !strings.Contains(err.Error(), "unexpected end of JSON input") {
 			t.Fatalf("Expected JSON error, got: %s", err.Error())
 		}
 		filename = writeManifestFile(t, &apidef.BundleManifest{


### PR DESCRIPTION
The old code looked suspicious and was fragile.
It would fail if error messages were not totally the same.
Swapped the arguments order to fix that.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>
