### PR TITLE
api_id is not required if policy_id passed, unit-tests added

### DIFF
--- a/cli/lint/schema.go
+++ b/cli/lint/schema.go
@@ -382,6 +382,9 @@ const confSchema = `{
 			"use_ssl_le": {
 				"type": "boolean"
 			},
+			"enable_http2": {
+				"type": "boolean"
+			},
 			"write_timeout": {
 				"type": "integer"
 			},
@@ -538,6 +541,9 @@ const confSchema = `{
 	},
 	"proxy_default_timeout": {
 		"type": "integer"
+	},
+	"proxy_enable_http2": {
+		"type": "boolean"
 	},
 	"proxy_ssl_insecure_skip_verify": {
 		"type": "boolean"


### PR DESCRIPTION
added a couple of changes for https://github.com/TykTechnologies/product/issues/19

When we create oauth client - one of `api_id` or `policy_id` are expected in payload (but not both).
If `policy_id` is provided we pick needed API ID from policy's ACL.

Also, I've extended unit-test coverage a little bit.