### PR TITLE
add dns caching support for wss:tls connection

### DIFF
--- a/mw_api_rate_limit_test.go
+++ b/mw_api_rate_limit_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 	"time"
 
+	uuid "github.com/satori/go.uuid"
+
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/test"
-	uuid "github.com/satori/go.uuid"
 
 	"github.com/justinas/alice"
 

--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -314,10 +314,7 @@ func defaultTransport(dialerTimeout int) *http.Transport {
 		KeepAlive: 30 * time.Second,
 		DualStack: true,
 	}
-	dialContextFunc := dialer.DialContext
-	if dnsCacheManager.IsCacheEnabled() {
-		dialContextFunc = dnsCacheManager.WrapDialer(dialer)
-	}
+	dialContextFunc := dnsCacheManager.WrapDialer(dialer)
 
 	return &http.Transport{
 		DialContext:           dialContextFunc,


### PR DESCRIPTION
- Add dns caching for wss proxying by using raw tls updage from native cacheable net.Conn
- Use more "collision prone" ips in dns caching tests in reverse_proxy_test.go 
