### PR TITLE
Loop to another API

### DIFF
--- a/api.go
+++ b/api.go
@@ -1909,6 +1909,24 @@ func ctxGetUrlRewritePath(r *http.Request) string {
 	return ""
 }
 
+func ctxSetCheckLoopLimits(r *http.Request, b bool) {
+	setCtxValue(r, CheckLoopLimits, b)
+}
+
+// Should we check Rate limits and Quotas?
+func ctxCheckLimits(r *http.Request) bool {
+	// If looping disabled, allow all
+	if !ctxLoopingEnabled(r) {
+		return true
+	}
+
+	if v := r.Context().Value(CheckLoopLimits); v != nil {
+		return v.(bool)
+	}
+
+	return false
+}
+
 func ctxSetRequestMethod(r *http.Request, path string) {
 	setCtxValue(r, RequestMethod, path)
 }
@@ -1928,6 +1946,10 @@ func ctxGetDefaultVersion(r *http.Request) bool {
 
 func ctxSetDefaultVersion(r *http.Request) {
 	setCtxValue(r, VersionDefault, true)
+}
+
+func ctxLoopingEnabled(r *http.Request) bool {
+	return ctxLoopLevel(r) > 0
 }
 
 func ctxLoopLevel(r *http.Request) int {

--- a/api_loader.go
+++ b/api_loader.go
@@ -127,6 +127,11 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 		return &chainDef
 	}
 
+	// Expose API only to looping
+	if spec.Internal {
+		chainDef.Skip = true
+	}
+
 	pathModified := false
 	for {
 		hash := generateDomainPath(spec.Domain, spec.Proxy.ListenPath)
@@ -509,6 +514,7 @@ func (d *DummyProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		// No need to handle errors, in all error cases limit will be set to 0
 		loopLevelLimit, _ := strconv.Atoi(r.URL.Query().Get("loop_limit"))
+		ctxSetCheckLoopLimits(r, r.URL.Query().Get("check_limits") == "true")
 
 		if origURL := ctxGetOrigRequestURL(r); origURL != nil {
 			r.URL.Host = origURL.Host

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -119,6 +119,11 @@ type TrackEndpointMeta struct {
 	Method string `bson:"method" json:"method"`
 }
 
+type InternalMeta struct {
+	Path   string `bson:"path" json:"path"`
+	Method string `bson:"method" json:"method"`
+}
+
 type RequestSizeMeta struct {
 	Path      string `bson:"path" json:"path"`
 	Method    string `bson:"method" json:"method"`
@@ -208,6 +213,7 @@ type ExtendedPathsSet struct {
 	TrackEndpoints          []TrackEndpointMeta   `bson:"track_endpoints" json:"track_endpoints,omitempty"`
 	DoNotTrackEndpoints     []TrackEndpointMeta   `bson:"do_not_track_endpoints" json:"do_not_track_endpoints,omitempty"`
 	ValidateJSON            []ValidatePathMeta    `bson:"validate_json" json:"validate_json,omitempty"`
+	Internal                []InternalMeta        `bson:"internal" json:"internal"`
 }
 
 type VersionInfo struct {
@@ -403,6 +409,7 @@ type APIDefinition struct {
 	CacheOptions              CacheOptions           `bson:"cache_options" json:"cache_options"`
 	SessionLifetime           int64                  `bson:"session_lifetime" json:"session_lifetime"`
 	Active                    bool                   `bson:"active" json:"active"`
+	Internal                  bool                   `bson:"internal" json:"internal"`
 	AuthProvider              AuthProviderMeta       `bson:"auth_provider" json:"auth_provider"`
 	SessionProvider           SessionProviderMeta    `bson:"session_provider" json:"session_provider"`
 	EventHandlers             EventHandlerMetaConfig `bson:"event_handlers" json:"event_handlers"`
@@ -621,6 +628,7 @@ func DummyAPI() APIDefinition {
 	}
 	methodTransformMeta := MethodTransformMeta{Path: "path", Method: "method", ToMethod: "tomethod"}
 	trackEndpointMeta := TrackEndpointMeta{Path: "path", Method: "method"}
+	internalMeta := InternalMeta{Path: "path", Method: "method"}
 	validatePathMeta := ValidatePathMeta{Path: "path", Method: "method", Schema: map[string]interface{}{}, SchemaB64: ""}
 	paths := struct {
 		Ignored   []string `bson:"ignored" json:"ignored"`
@@ -654,6 +662,7 @@ func DummyAPI() APIDefinition {
 			MethodTransforms:        []MethodTransformMeta{methodTransformMeta},
 			TrackEndpoints:          []TrackEndpointMeta{trackEndpointMeta},
 			DoNotTrackEndpoints:     []TrackEndpointMeta{trackEndpointMeta},
+			Internal:                []InternalMeta{internalMeta},
 			ValidateJSON:            []ValidatePathMeta{validatePathMeta},
 		},
 	}

--- a/apidef/schema.go
+++ b/apidef/schema.go
@@ -218,8 +218,10 @@ const Schema = `{
             "type": "boolean"
         },
         "active": {
-            "type": "boolean",
-            "id": "http://jsonschema.net/active"
+            "type": "boolean"
+        },
+        "internal": {
+            "type": "boolean"
         },
         "auth": {
             "type": ["object", "null"],

--- a/handler_success.go
+++ b/handler_success.go
@@ -39,6 +39,7 @@ const (
 	ThrottleLevel
 	ThrottleLevelLimit
 	Trace
+	CheckLoopLimits
 )
 
 var (

--- a/looping_test.go
+++ b/looping_test.go
@@ -4,27 +4,27 @@
 package main
 
 import (
-    "encoding/json"
-    "sync"
-    "testing"
+	"encoding/json"
+	"sync"
+	"testing"
 
-    "github.com/TykTechnologies/tyk/test"
-    "github.com/TykTechnologies/tyk/user"
+	"github.com/TykTechnologies/tyk/test"
+	"github.com/TykTechnologies/tyk/user"
 )
 
 func TestLooping(t *testing.T) {
-    ts := newTykTestServer()
-    defer ts.Close()
+	ts := newTykTestServer()
+	defer ts.Close()
 
-    postAction := `<operation action="https://example.com/post_action">data</operation>`
-    getAction := `<operation action="https://example.com/get_action">data</operation>`
+	postAction := `<operation action="https://example.com/post_action">data</operation>`
+	getAction := `<operation action="https://example.com/get_action">data</operation>`
 
-    t.Run("Using advanced URL rewrite", func(t *testing.T) {
-        // We defined internnal advanced rewrite based on body data
-        // which rewrites to internal paths (marked as blacklist so they protected from outside world)
-        buildAndLoadAPI(func(spec *APISpec) {
-            version := spec.VersionData.Versions["v1"]
-            json.Unmarshal([]byte(`{
+	t.Run("Using advanced URL rewrite", func(t *testing.T) {
+		// We defined internnal advanced rewrite based on body data
+		// which rewrites to internal paths (marked as blacklist so they protected from outside world)
+		buildAndLoadAPI(func(spec *APISpec) {
+			version := spec.VersionData.Versions["v1"]
+			json.Unmarshal([]byte(`{
                 "use_extended_paths": true,
                 "extended_paths": {
                     "internal": [{
@@ -67,38 +67,38 @@ func TestLooping(t *testing.T) {
                 }
             }`), &version)
 
-            spec.VersionData.Versions["v1"] = version
+			spec.VersionData.Versions["v1"] = version
 
-            spec.Proxy.ListenPath = "/"
-        })
+			spec.Proxy.ListenPath = "/"
+		})
 
-        ts.Run(t, []test.TestCase{
-            {Method: "POST", Path: "/xml", Data: postAction, BodyMatch: `"Url":"/post_action`},
+		ts.Run(t, []test.TestCase{
+			{Method: "POST", Path: "/xml", Data: postAction, BodyMatch: `"Url":"/post_action`},
 
-            // Should retain original query params
-            {Method: "POST", Path: "/xml?a=b", Data: getAction, BodyMatch: `"Url":"/get_action`},
+			// Should retain original query params
+			{Method: "POST", Path: "/xml?a=b", Data: getAction, BodyMatch: `"Url":"/get_action`},
 
-            // Should rewrite http method, if loop rewrite param passed
-            {Method: "POST", Path: "/xml", Data: getAction, BodyMatch: `"Method":"GET"`},
+			// Should rewrite http method, if loop rewrite param passed
+			{Method: "POST", Path: "/xml", Data: getAction, BodyMatch: `"Method":"GET"`},
 
-            // Internal endpoint can be accessed only via looping
-            {Method: "GET", Path: "/get_action", Code: 403},
+			// Internal endpoint can be accessed only via looping
+			{Method: "GET", Path: "/get_action", Code: 403},
 
-            {Method: "POST", Path: "/get_action", Code: 403},
-        }...)
-    })
+			{Method: "POST", Path: "/get_action", Code: 403},
+		}...)
+	})
 
-    t.Run("Loop to another API", func(t *testing.T) {
-        buildAndLoadAPI(func(spec *APISpec) {
-            spec.APIID = "testid"
-            spec.Name = "hidden api"
-            spec.Proxy.ListenPath = "/somesecret"
-            spec.Internal = true
-        }, func(spec *APISpec) {
-            spec.Proxy.ListenPath = "/test"
+	t.Run("Loop to another API", func(t *testing.T) {
+		buildAndLoadAPI(func(spec *APISpec) {
+			spec.APIID = "testid"
+			spec.Name = "hidden api"
+			spec.Proxy.ListenPath = "/somesecret"
+			spec.Internal = true
+		}, func(spec *APISpec) {
+			spec.Proxy.ListenPath = "/test"
 
-            version := spec.VersionData.Versions["v1"]
-            json.Unmarshal([]byte(`{
+			version := spec.VersionData.Versions["v1"]
+			json.Unmarshal([]byte(`{
                 "use_extended_paths": true,
                 "extended_paths": {
                     "url_rewrites": [{
@@ -120,19 +120,19 @@ func TestLooping(t *testing.T) {
                 }
             }`), &version)
 
-            spec.VersionData.Versions["v1"] = version
-        })
+			spec.VersionData.Versions["v1"] = version
+		})
 
-        ts.Run(t, []test.TestCase{
-            {Path: "/somesecret", Code: 404},
-            {Path: "/test/by_name", Code: 200},
-            {Path: "/test/by_id", Code: 200},
-            {Path: "/test/wrong", Code: 500},
-        }...)
-    })
+		ts.Run(t, []test.TestCase{
+			{Path: "/somesecret", Code: 404},
+			{Path: "/test/by_name", Code: 200},
+			{Path: "/test/by_id", Code: 200},
+			{Path: "/test/wrong", Code: 500},
+		}...)
+	})
 
-    t.Run("VirtualEndpoint or plugins", func(t *testing.T) {
-        testPrepareVirtualEndpoint(`
+	t.Run("VirtualEndpoint or plugins", func(t *testing.T) {
+		testPrepareVirtualEndpoint(`
             function testVirtData(request, session, config) {
                 var loopLocation = "/default"
 
@@ -152,21 +152,21 @@ func TestLooping(t *testing.T) {
             }
         `, "POST", "/virt", true)
 
-        ts.Run(t, []test.TestCase{
-            {Method: "POST", Path: "/virt", Data: postAction, BodyMatch: `"Url":"/post_action`},
+		ts.Run(t, []test.TestCase{
+			{Method: "POST", Path: "/virt", Data: postAction, BodyMatch: `"Url":"/post_action`},
 
-            // Should retain original query params
-            {Method: "POST", Path: "/virt?a=b", Data: getAction, BodyMatch: `"Url":"/get_action`},
+			// Should retain original query params
+			{Method: "POST", Path: "/virt?a=b", Data: getAction, BodyMatch: `"Url":"/get_action`},
 
-            // Should rewrite http method, if loop rewrite param passed
-            {Method: "POST", Path: "/virt", Data: getAction, BodyMatch: `"Method":"GET"`},
-        }...)
-    })
+			// Should rewrite http method, if loop rewrite param passed
+			{Method: "POST", Path: "/virt", Data: getAction, BodyMatch: `"Method":"GET"`},
+		}...)
+	})
 
-    t.Run("Loop limit", func(t *testing.T) {
-        buildAndLoadAPI(func(spec *APISpec) {
-            version := spec.VersionData.Versions["v1"]
-            json.Unmarshal([]byte(`{
+	t.Run("Loop limit", func(t *testing.T) {
+		buildAndLoadAPI(func(spec *APISpec) {
+			version := spec.VersionData.Versions["v1"]
+			json.Unmarshal([]byte(`{
                 "use_extended_paths": true,
                 "extended_paths": {
                     "url_rewrites": [{
@@ -178,19 +178,19 @@ func TestLooping(t *testing.T) {
                 }
             }`), &version)
 
-            spec.VersionData.Versions["v1"] = version
-            spec.Proxy.ListenPath = "/"
-        })
+			spec.VersionData.Versions["v1"] = version
+			spec.Proxy.ListenPath = "/"
+		})
 
-        ts.Run(t, []test.TestCase{
-            {Method: "GET", Path: "/recursion", Code: 500, BodyMatch: "Loop level too deep. Found more than 2 loops in single request"},
-        }...)
-    })
+		ts.Run(t, []test.TestCase{
+			{Method: "GET", Path: "/recursion", Code: 500, BodyMatch: "Loop level too deep. Found more than 2 loops in single request"},
+		}...)
+	})
 
-    t.Run("Quota and rate limit calculation", func(t *testing.T) {
-        buildAndLoadAPI(func(spec *APISpec) {
-            version := spec.VersionData.Versions["v1"]
-            json.Unmarshal([]byte(`{
+	t.Run("Quota and rate limit calculation", func(t *testing.T) {
+		buildAndLoadAPI(func(spec *APISpec) {
+			version := spec.VersionData.Versions["v1"]
+			json.Unmarshal([]byte(`{
                 "use_extended_paths": true,
                 "extended_paths": {
                     "url_rewrites": [{
@@ -202,42 +202,42 @@ func TestLooping(t *testing.T) {
                 }
             }`), &version)
 
-            spec.VersionData.Versions["v1"] = version
-            spec.Proxy.ListenPath = "/"
-            spec.UseKeylessAccess = false
-        })
+			spec.VersionData.Versions["v1"] = version
+			spec.Proxy.ListenPath = "/"
+			spec.UseKeylessAccess = false
+		})
 
-        keyID := createSession(func(s *user.SessionState) {
-            s.QuotaMax = 2
-        })
+		keyID := createSession(func(s *user.SessionState) {
+			s.QuotaMax = 2
+		})
 
-        authHeaders := map[string]string{"authorization": keyID}
+		authHeaders := map[string]string{"authorization": keyID}
 
-        ts.Run(t, []test.TestCase{
-            {Method: "GET", Path: "/recursion", Headers: authHeaders, BodyNotMatch: "Quota exceeded"},
-        }...)
-    })
+		ts.Run(t, []test.TestCase{
+			{Method: "GET", Path: "/recursion", Headers: authHeaders, BodyNotMatch: "Quota exceeded"},
+		}...)
+	})
 }
 
 func TestConcurrencyReloads(t *testing.T) {
-    var wg sync.WaitGroup
+	var wg sync.WaitGroup
 
-    ts := newTykTestServer()
-    defer ts.Close()
+	ts := newTykTestServer()
+	defer ts.Close()
 
-    buildAndLoadAPI()
+	buildAndLoadAPI()
 
-    for i := 0; i < 10; i++ {
-        wg.Add(1)
-        go func() {
-            ts.Run(t, test.TestCase{Path: "/sample", Code: 200})
-            wg.Done()
-        }()
-    }
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			ts.Run(t, test.TestCase{Path: "/sample", Code: 200})
+			wg.Done()
+		}()
+	}
 
-    for j := 0; j < 5; j++ {
-        buildAndLoadAPI()
-    }
+	for j := 0; j < 5; j++ {
+		buildAndLoadAPI()
+	}
 
-    wg.Wait()
+	wg.Wait()
 }

--- a/looping_test.go
+++ b/looping_test.go
@@ -74,8 +74,8 @@ func TestLooping(t *testing.T) {
 
     t.Run("Loop to another API", func(t *testing.T) {
         buildAndLoadAPI(func(spec *APISpec) {
-            spec.APIID = "test_api"
-            spec.Name = "hidden_api"
+            spec.APIID = "testid"
+            spec.Name = "hidden api"
             spec.Proxy.ListenPath = "/somesecret"
         }, func(spec *APISpec) {
             spec.Proxy.ListenPath = "/"
@@ -88,12 +88,12 @@ func TestLooping(t *testing.T) {
                         "path": "/by_name",
                         "match_pattern": "/by_name(.*)",
                         "method": "GET",
-                        "rewrite_to": "tyk://hidden_api/get"
+                        "rewrite_to": "tyk://hidden api/get"
                     },{
                         "path": "/by_id",
                         "match_pattern": "/by_id(.*)",
                         "method": "GET",
-                        "rewrite_to": "tyk://test_api/get"
+                        "rewrite_to": "tyk://testid/get"
                     },{
                         "path": "/wrong",
                         "match_pattern": "/wrong(.*)",

--- a/looping_test.go
+++ b/looping_test.go
@@ -4,27 +4,27 @@
 package main
 
 import (
-	"encoding/json"
-	"sync"
-	"testing"
+    "encoding/json"
+    "sync"
+    "testing"
 
-	"github.com/TykTechnologies/tyk/test"
-	"github.com/TykTechnologies/tyk/user"
+    "github.com/TykTechnologies/tyk/test"
+    "github.com/TykTechnologies/tyk/user"
 )
 
 func TestLooping(t *testing.T) {
-	ts := newTykTestServer()
-	defer ts.Close()
+    ts := newTykTestServer()
+    defer ts.Close()
 
-	postAction := `<operation action="https://example.com/post_action">data</operation>`
-	getAction := `<operation action="https://example.com/get_action">data</operation>`
+    postAction := `<operation action="https://example.com/post_action">data</operation>`
+    getAction := `<operation action="https://example.com/get_action">data</operation>`
 
-	t.Run("Using advanced URL rewrite", func(t *testing.T) {
-		// We defined internnal advanced rewrite based on body data
-		// which rewrites to internal paths (marked as blacklist so they protected from outside world)
-		buildAndLoadAPI(func(spec *APISpec) {
-			version := spec.VersionData.Versions["v1"]
-			json.Unmarshal([]byte(`{
+    t.Run("Using advanced URL rewrite", func(t *testing.T) {
+        // We defined internnal advanced rewrite based on body data
+        // which rewrites to internal paths (marked as blacklist so they protected from outside world)
+        buildAndLoadAPI(func(spec *APISpec) {
+            version := spec.VersionData.Versions["v1"]
+            json.Unmarshal([]byte(`{
                 "use_extended_paths": true,
                 "extended_paths": {
                     "url_rewrites": [{
@@ -56,24 +56,65 @@ func TestLooping(t *testing.T) {
                 }
             }`), &version)
 
-			spec.VersionData.Versions["v1"] = version
+            spec.VersionData.Versions["v1"] = version
 
-			spec.Proxy.ListenPath = "/"
-		})
+            spec.Proxy.ListenPath = "/"
+        })
 
-		ts.Run(t, []test.TestCase{
-			{Method: "POST", Path: "/xml", Data: postAction, BodyMatch: `"Url":"/post_action`},
+        ts.Run(t, []test.TestCase{
+            {Method: "POST", Path: "/xml", Data: postAction, BodyMatch: `"Url":"/post_action`},
 
-			// Should retain original query params
-			{Method: "POST", Path: "/xml?a=b", Data: getAction, BodyMatch: `"Url":"/get_action`},
+            // Should retain original query params
+            {Method: "POST", Path: "/xml?a=b", Data: getAction, BodyMatch: `"Url":"/get_action`},
 
-			// Should rewrite http method, if loop rewrite param passed
-			{Method: "POST", Path: "/xml", Data: getAction, BodyMatch: `"Method":"GET"`},
-		}...)
-	})
+            // Should rewrite http method, if loop rewrite param passed
+            {Method: "POST", Path: "/xml", Data: getAction, BodyMatch: `"Method":"GET"`},
+        }...)
+    })
 
-	t.Run("VirtualEndpoint or plugins", func(t *testing.T) {
-		testPrepareVirtualEndpoint(`
+    t.Run("Loop to another API", func(t *testing.T) {
+        buildAndLoadAPI(func(spec *APISpec) {
+            spec.APIID = "test_api"
+            spec.Name = "hidden_api"
+            spec.Proxy.ListenPath = "/somesecret"
+        }, func(spec *APISpec) {
+            spec.Proxy.ListenPath = "/"
+
+            version := spec.VersionData.Versions["v1"]
+            json.Unmarshal([]byte(`{
+                "use_extended_paths": true,
+                "extended_paths": {
+                    "url_rewrites": [{
+                        "path": "/by_name",
+                        "match_pattern": "/by_name(.*)",
+                        "method": "GET",
+                        "rewrite_to": "tyk://hidden_api/get"
+                    },{
+                        "path": "/by_id",
+                        "match_pattern": "/by_id(.*)",
+                        "method": "GET",
+                        "rewrite_to": "tyk://test_api/get"
+                    },{
+                        "path": "/wrong",
+                        "match_pattern": "/wrong(.*)",
+                        "method": "GET",
+                        "rewrite_to": "tyk://wrong/get"
+                    }]
+                }
+            }`), &version)
+
+            spec.VersionData.Versions["v1"] = version
+        })
+
+        ts.Run(t, []test.TestCase{
+            {Path: "/by_name", Code: 200},
+            {Path: "/by_id", Code: 200},
+            {Path: "/wrong", Code: 500},
+        }...)
+    })
+
+    t.Run("VirtualEndpoint or plugins", func(t *testing.T) {
+        testPrepareVirtualEndpoint(`
             function testVirtData(request, session, config) {
                 var loopLocation = "/default"
 
@@ -93,21 +134,21 @@ func TestLooping(t *testing.T) {
             }
         `, "POST", "/virt", true)
 
-		ts.Run(t, []test.TestCase{
-			{Method: "POST", Path: "/virt", Data: postAction, BodyMatch: `"Url":"/post_action`},
+        ts.Run(t, []test.TestCase{
+            {Method: "POST", Path: "/virt", Data: postAction, BodyMatch: `"Url":"/post_action`},
 
-			// Should retain original query params
-			{Method: "POST", Path: "/virt?a=b", Data: getAction, BodyMatch: `"Url":"/get_action`},
+            // Should retain original query params
+            {Method: "POST", Path: "/virt?a=b", Data: getAction, BodyMatch: `"Url":"/get_action`},
 
-			// Should rewrite http method, if loop rewrite param passed
-			{Method: "POST", Path: "/virt", Data: getAction, BodyMatch: `"Method":"GET"`},
-		}...)
-	})
+            // Should rewrite http method, if loop rewrite param passed
+            {Method: "POST", Path: "/virt", Data: getAction, BodyMatch: `"Method":"GET"`},
+        }...)
+    })
 
-	t.Run("Loop limit", func(t *testing.T) {
-		buildAndLoadAPI(func(spec *APISpec) {
-			version := spec.VersionData.Versions["v1"]
-			json.Unmarshal([]byte(`{
+    t.Run("Loop limit", func(t *testing.T) {
+        buildAndLoadAPI(func(spec *APISpec) {
+            version := spec.VersionData.Versions["v1"]
+            json.Unmarshal([]byte(`{
                 "use_extended_paths": true,
                 "extended_paths": {
                     "url_rewrites": [{
@@ -119,19 +160,19 @@ func TestLooping(t *testing.T) {
                 }
             }`), &version)
 
-			spec.VersionData.Versions["v1"] = version
-			spec.Proxy.ListenPath = "/"
-		})
+            spec.VersionData.Versions["v1"] = version
+            spec.Proxy.ListenPath = "/"
+        })
 
-		ts.Run(t, []test.TestCase{
-			{Method: "GET", Path: "/recursion", Code: 500, BodyMatch: "Loop level too deep. Found more than 2 loops in single request"},
-		}...)
-	})
+        ts.Run(t, []test.TestCase{
+            {Method: "GET", Path: "/recursion", Code: 500, BodyMatch: "Loop level too deep. Found more than 2 loops in single request"},
+        }...)
+    })
 
-	t.Run("Quota and rate limit calculation", func(t *testing.T) {
-		buildAndLoadAPI(func(spec *APISpec) {
-			version := spec.VersionData.Versions["v1"]
-			json.Unmarshal([]byte(`{
+    t.Run("Quota and rate limit calculation", func(t *testing.T) {
+        buildAndLoadAPI(func(spec *APISpec) {
+            version := spec.VersionData.Versions["v1"]
+            json.Unmarshal([]byte(`{
                 "use_extended_paths": true,
                 "extended_paths": {
                     "url_rewrites": [{
@@ -143,42 +184,42 @@ func TestLooping(t *testing.T) {
                 }
             }`), &version)
 
-			spec.VersionData.Versions["v1"] = version
-			spec.Proxy.ListenPath = "/"
-			spec.UseKeylessAccess = false
-		})
+            spec.VersionData.Versions["v1"] = version
+            spec.Proxy.ListenPath = "/"
+            spec.UseKeylessAccess = false
+        })
 
-		keyID := createSession(func(s *user.SessionState) {
-			s.QuotaMax = 2
-		})
+        keyID := createSession(func(s *user.SessionState) {
+            s.QuotaMax = 2
+        })
 
-		authHeaders := map[string]string{"authorization": keyID}
+        authHeaders := map[string]string{"authorization": keyID}
 
-		ts.Run(t, []test.TestCase{
-			{Method: "GET", Path: "/recursion", Headers: authHeaders, BodyNotMatch: "Quota exceeded"},
-		}...)
-	})
+        ts.Run(t, []test.TestCase{
+            {Method: "GET", Path: "/recursion", Headers: authHeaders, BodyNotMatch: "Quota exceeded"},
+        }...)
+    })
 }
 
 func TestConcurrencyReloads(t *testing.T) {
-	var wg sync.WaitGroup
+    var wg sync.WaitGroup
 
-	ts := newTykTestServer()
-	defer ts.Close()
+    ts := newTykTestServer()
+    defer ts.Close()
 
-	buildAndLoadAPI()
+    buildAndLoadAPI()
 
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func() {
-			ts.Run(t, test.TestCase{Path: "/sample", Code: 200})
-			wg.Done()
-		}()
-	}
+    for i := 0; i < 10; i++ {
+        wg.Add(1)
+        go func() {
+            ts.Run(t, test.TestCase{Path: "/sample", Code: 200})
+            wg.Done()
+        }()
+    }
 
-	for j := 0; j < 5; j++ {
-		buildAndLoadAPI()
-	}
+    for j := 0; j < 5; j++ {
+        buildAndLoadAPI()
+    }
 
-	wg.Wait()
+    wg.Wait()
 }

--- a/mw_api_rate_limit.go
+++ b/mw_api_rate_limit.go
@@ -63,7 +63,7 @@ func (k *RateLimitForAPI) handleRateLimitFailure(r *http.Request, token string) 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (k *RateLimitForAPI) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	// Skip rate limiting and quotas for looping
-	if ctxLoopLevel(r) > 0 {
+	if !ctxCheckLimits(r) {
 		return nil, http.StatusOK
 	}
 

--- a/mw_organisation_activity.go
+++ b/mw_organisation_activity.go
@@ -52,7 +52,7 @@ func (k *OrganizationMonitor) setOrgHasNoSession(val bool) {
 
 func (k *OrganizationMonitor) ProcessRequest(w http.ResponseWriter, r *http.Request, conf interface{}) (error, int) {
 	// Skip rate limiting and quotas for looping
-	if ctxLoopLevel(r) > 0 {
+	if !ctxCheckLimits(r) {
 		return nil, http.StatusOK
 	}
 

--- a/mw_rate_limiting.go
+++ b/mw_rate_limiting.go
@@ -62,7 +62,7 @@ func (k *RateLimitAndQuotaCheck) handleQuotaFailure(r *http.Request, token strin
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (k *RateLimitAndQuotaCheck) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	// Skip rate limiting and quotas for looping
-	if ctxLoopLevel(r) > 0 {
+	if !ctxCheckLimits(r) {
 		return nil, http.StatusOK
 	}
 


### PR DESCRIPTION
Allow specifying APIID, ID, or Name as a loop target.

For example "tyk://my api/"

Fix https://github.com/TykTechnologies/tyk/issues/2120

Part of https://github.com/TykTechnologies/product/issues/86

Additionally added support for marking API and Endpoint internal, "internal" boolean field for API, and new plugin:
```
             "extended_paths": {
                    "internal": [{
                        "path": "/get_action",
                        "method": "GET"
                    },{
                        "path": "/post_action",
                        "method": "POST"
                    }]
             }
```

Also added "check_limits" flag, which enables quota/rate tracking, which you can add to URL like this: `tyk://<api>/get?check_limits=true`