### PR TITLE
Respect tags coming from key level

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -400,7 +400,6 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 
 	// set tags
 	if len(tags) > 0 {
-		session.Tags = make([]string, 0, len(tags))
 		for tag := range tags {
 			session.Tags = append(session.Tags, tag)
 		}


### PR DESCRIPTION
When a policy with a tag is applied to a key, it doesn't respect key's tag. This PR fixes the bug if in FE,
https://github.com/TykTechnologies/tyk-analytics-ui/issues/1082 should be fixed for this PR to work properly.

Fixes #1671  