### PR TITLE
res_handler_transform: make sure bodyData is available on XML errors

### DIFF
--- a/res_handler_transform.go
+++ b/res_handler_transform.go
@@ -95,9 +95,13 @@ func (h *ResponseTransformMiddleware) HandleResponse(rw http.ResponseWriter, res
 		mxj.XmlCharsetReader = WrappedCharsetReader
 		var err error
 
-		bodyData, err = mxj.NewMapXml(body) // unmarshal
+		xmlMap, err := mxj.NewMapXml(body) // unmarshal
 		if err != nil {
 			logger.WithError(err).Error("Error unmarshalling XML")
+			break
+		}
+		for k, v := range xmlMap {
+			bodyData[k] = v
 		}
 	default: // apidef.RequestJSON
 		if len(body) == 0 {


### PR DESCRIPTION
For #2016.

I was able to reproduce using the instructions described in the ticket. The issue occurs at this point:

```go
	bodyData := make(map[string]interface{})
	switch tmeta.TemplateData.Input {
	case apidef.RequestXML:
		if len(body) == 0 {
			body = []byte("<_/>")
		}

		mxj.XmlCharsetReader = WrappedCharsetReader
		var err error

		bodyData, err := mxj.NewMapXml(body)
		if err != nil {
			logger.WithError(err).Error("Error unmarshalling XML")
		}
```

When `mxj.NewMapXml` returns an error, `bodyData` is not properly set and further references to it fail (like setting context vars using `bodyData["_tyk_context"] = ctxGetData(req)`).

This approach avoids replacing `bodyData`.