### PR TITLE
Release 27/custom signature validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ notifications:
 
 env:
   global:
-    - TYK_LOGLEVEL=info
+    - TYK_LOGLEVEL=panic
 
 addons:
   apt:
@@ -21,11 +21,10 @@ addons:
 
 matrix:
   include:
-    - go: 1.9.x
-      env: LATEST_GO=true # run linters and report coverage
     - go: 1.10.x
       env: LATEST_GO=true # run linters and report coverage
-
+    - go: 1.11.x
+      env: LATEST_GO=true # run linters and report coverage
 
 services:
   - redis-server

--- a/analytics.go
+++ b/analytics.go
@@ -7,8 +7,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/oschwald/maxminddb-golang"
-	"gopkg.in/vmihailenco/msgpack.v2"
+	maxminddb "github.com/oschwald/maxminddb-golang"
+	msgpack "gopkg.in/vmihailenco/msgpack.v2"
 
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/regexp"

--- a/api.go
+++ b/api.go
@@ -333,7 +333,7 @@ func handleGetDetail(sessionKey, apiID string, byHash bool) (interface{}, int) {
 		log.WithFields(logrus.Fields{
 			"prefix": "api",
 			"key":    obfuscateKey(sessionKey),
-			"error": err,
+			"error":  err,
 			"status": "ok",
 		}).Info("Can't retrieve key quota")
 	}

--- a/api.go
+++ b/api.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/gorilla/mux"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/TykTechnologies/tyk/apidef"

--- a/api_definition.go
+++ b/api_definition.go
@@ -17,7 +17,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/rubyist/circuitbreaker"
+	circuit "github.com/rubyist/circuitbreaker"
 
 	"github.com/TykTechnologies/gojsonschema"
 	"github.com/TykTechnologies/tyk/apidef"

--- a/api_loader.go
+++ b/api_loader.go
@@ -14,7 +14,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/gorilla/mux"
 	"github.com/justinas/alice"
-	"github.com/pmylund/go-cache"
+	cache "github.com/pmylund/go-cache"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"

--- a/api_test.go
+++ b/api_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/garyburd/redigo/redis"
 	"github.com/gorilla/mux"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 
 	"fmt"
 

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -433,12 +433,22 @@ type APIDefinition struct {
 }
 
 type Auth struct {
-	UseParam       bool   `mapstructure:"use_param" bson:"use_param" json:"use_param"`
-	ParamName      string `mapstructure:"param_name" bson:"param_name" json:"param_name"`
-	UseCookie      bool   `mapstructure:"use_cookie" bson:"use_cookie" json:"use_cookie"`
-	CookieName     string `mapstructure:"cookie_name" bson:"cookie_name" json:"cookie_name"`
-	AuthHeaderName string `mapstructure:"auth_header_name" bson:"auth_header_name" json:"auth_header_name"`
-	UseCertificate bool   `mapstructure:"use_certificate" bson:"use_certificate" json:"use_certificate"`
+	UseParam          bool               `mapstructure:"use_param" bson:"use_param" json:"use_param"`
+	ParamName         string             `mapstructure:"param_name" bson:"param_name" json:"param_name"`
+	UseCookie         bool               `mapstructure:"use_cookie" bson:"use_cookie" json:"use_cookie"`
+	CookieName        string             `mapstructure:"cookie_name" bson:"cookie_name" json:"cookie_name"`
+	AuthHeaderName    string             `mapstructure:"auth_header_name" bson:"auth_header_name" json:"auth_header_name"`
+	UseCertificate    bool               `mapstructure:"use_certificate" bson:"use_certificate" json:"use_certificate"`
+	ValidateSignature *ValidateSignature `mapstructure:"validate_signature" bson:"validate_signature" json:"validate_signature,omitempty"`
+}
+
+type ValidateSignature struct {
+	Mode             string `mapstructure:"mode" bson:"mode" json:"mode"`
+	SignatureKey     string `mapstructure:"signature_key" bson:"signature_key" json:"signature_key"`
+	SessionMetaKey   string `mapstructure:"session_meta_key" bson:"session_meta_key" json:"session_meta_key"`
+	AllowedClockSkew int64  `mapstructure:"allowed_clock_skew" bson:"allowed_clock_skew" json:"allowed_clock_skew"`
+	ErrorCode        int    `mapstructure:"error_code" bson:"error_code" json:"error_code"`
+	ErrorMessage     string `mapstructure:"error_message" bson:"error_message" json:"error_message"`
 }
 
 type GlobalRateLimit struct {
@@ -666,16 +676,16 @@ func DummyAPI() APIDefinition {
 	}
 
 	return APIDefinition{
-		VersionData:             versionData,
-		ConfigData:              map[string]interface{}{},
-		AllowedIPs:              []string{},
-		PinnedPublicKeys:        map[string]string{},
-		ResponseProcessors:      []ResponseProcessor{},
-		ClientCertificates:      []string{},
-		BlacklistedIPs:          []string{},
-		TagHeaders:              []string{},
-		UpstreamCertificates:    map[string]string{},
-		HmacAllowedAlgorithms:   []string{},
+		VersionData:           versionData,
+		ConfigData:            map[string]interface{}{},
+		AllowedIPs:            []string{},
+		PinnedPublicKeys:      map[string]string{},
+		ResponseProcessors:    []ResponseProcessor{},
+		ClientCertificates:    []string{},
+		BlacklistedIPs:        []string{},
+		TagHeaders:            []string{},
+		UpstreamCertificates:  map[string]string{},
+		HmacAllowedAlgorithms: []string{},
 		CustomMiddleware: MiddlewareSection{
 			Post:        []MiddlewareDefinition{},
 			Pre:         []MiddlewareDefinition{},

--- a/apidef/importer/swagger.go
+++ b/apidef/importer/swagger.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 
 	"github.com/TykTechnologies/tyk/apidef"
 )

--- a/auth_manager.go
+++ b/auth_manager.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/storage"

--- a/certs/manager.go
+++ b/certs/manager.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/pmylund/go-cache"
+	cache "github.com/pmylund/go-cache"
 )
 
 // StorageHandler is a standard interface to a storage backend,

--- a/coprocess_helpers.go
+++ b/coprocess_helpers.go
@@ -88,11 +88,11 @@ func TykSessionState(session *coprocess.SessionState) *user.SessionState {
 		MetaData:                metadata,
 		Monitor:                 monitor,
 		EnableDetailedRecording: session.EnableDetailedRecording,
-		Tags:                session.Tags,
-		Alias:               session.Alias,
-		LastUpdated:         session.LastUpdated,
-		IdExtractorDeadline: session.IdExtractorDeadline,
-		SessionLifetime:     session.SessionLifetime,
+		Tags:                    session.Tags,
+		Alias:                   session.Alias,
+		LastUpdated:             session.LastUpdated,
+		IdExtractorDeadline:     session.IdExtractorDeadline,
+		SessionLifetime:         session.SessionLifetime,
 	}
 }
 
@@ -174,11 +174,11 @@ func ProtoSessionState(session *user.SessionState) *coprocess.SessionState {
 		Monitor:                 monitor,
 		Metadata:                metadata,
 		EnableDetailedRecording: session.EnableDetailedRecording,
-		Tags:                session.Tags,
-		Alias:               session.Alias,
-		LastUpdated:         session.LastUpdated,
-		IdExtractorDeadline: session.IdExtractorDeadline,
-		SessionLifetime:     session.SessionLifetime,
+		Tags:                    session.Tags,
+		Alias:                   session.Alias,
+		LastUpdated:             session.LastUpdated,
+		IdExtractorDeadline:     session.IdExtractorDeadline,
+		SessionLifetime:         session.SessionLifetime,
 	}
 }
 

--- a/coprocess_id_extractor.go
+++ b/coprocess_id_extractor.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/mitchellh/mapstructure"
-	"gopkg.in/xmlpath.v2"
+	xmlpath "gopkg.in/xmlpath.v2"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/regexp"

--- a/event_system.go
+++ b/event_system.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/rubyist/circuitbreaker"
+	circuit "github.com/rubyist/circuitbreaker"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/garyburd/redigo/redis"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
-	"gopkg.in/vmihailenco/msgpack.v2"
+	msgpack "gopkg.in/vmihailenco/msgpack.v2"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/cli"

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -1356,8 +1356,8 @@ func TestRateLimitForAPIAndRateLimitAndQuotaCheck(t *testing.T) {
 
 	ts.Run(t, []test.TestCase{
 		{Headers: map[string]string{"Authorization": sess1token}, Code: http.StatusOK, Path: "/"},
-		{Headers: map[string]string{"Authorization": sess1token}, Code: http.StatusTooManyRequests, Path: "/"},
+		{Headers: map[string]string{"Authorization": sess1token}, Code: http.StatusTooManyRequests, Delay: 100, Path: "/"},
 		{Headers: map[string]string{"Authorization": sess2token}, Code: http.StatusOK, Path: "/"},
-		{Headers: map[string]string{"Authorization": sess2token}, Code: http.StatusTooManyRequests, Path: "/"},
+		{Headers: map[string]string{"Authorization": sess2token}, Code: http.StatusTooManyRequests, Delay: 100, Path: "/"},
 	}...)
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -26,7 +26,7 @@ import (
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/gorilla/websocket"
 	"github.com/miekg/dns"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 
 	"github.com/gorilla/mux"
 

--- a/host_checker_manager.go
+++ b/host_checker_manager.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/satori/go.uuid"
-	"gopkg.in/vmihailenco/msgpack.v2"
+	uuid "github.com/satori/go.uuid"
+	msgpack "gopkg.in/vmihailenco/msgpack.v2"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"

--- a/log/log.go
+++ b/log/log.go
@@ -30,6 +30,8 @@ func Get() *logrus.Logger {
 		log.Level = logrus.WarnLevel
 	case "debug":
 		log.Level = logrus.DebugLevel
+	case "panic":
+		log.Level = logrus.PanicLevel
 	default:
 		log.Level = logrus.InfoLevel
 	}

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/newrelic/go-agent"
+	newrelic "github.com/newrelic/go-agent"
 
 	"github.com/TykTechnologies/tyk/checkup"
 
@@ -33,9 +33,9 @@ import (
 	"github.com/justinas/alice"
 	"github.com/lonelycode/gorpc"
 	"github.com/lonelycode/osin"
-	"github.com/netbrain/goautosocket"
+	gas "github.com/netbrain/goautosocket"
 	"github.com/rs/cors"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"rsc.io/letsencrypt"
 
 	"github.com/TykTechnologies/goagain"

--- a/multiauth_test.go
+++ b/multiauth_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/justinas/alice"
 	"github.com/lonelycode/go-uuid/uuid"
-	"github.com/pmylund/go-cache"
+	cache "github.com/pmylund/go-cache"
 
 	"github.com/TykTechnologies/tyk/user"
 )

--- a/mw_api_rate_limit_test.go
+++ b/mw_api_rate_limit_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/justinas/alice"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 
 	"github.com/TykTechnologies/tyk/user"
 )

--- a/mw_basic_auth.go
+++ b/mw_basic_auth.go
@@ -7,13 +7,15 @@ import (
 	"strings"
 	"time"
 
+	cache "github.com/pmylund/go-cache"
+
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/storage"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/pmylund/go-cache"
-	"github.com/TykTechnologies/murmur3"
 	"golang.org/x/crypto/bcrypt"
+
+	"github.com/TykTechnologies/murmur3"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/user"

--- a/mw_context_vars.go
+++ b/mw_context_vars.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 
 	"github.com/TykTechnologies/tyk/request"
 )

--- a/mw_jwt.go
+++ b/mw_jwt.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 	cache "github.com/pmylund/go-cache"
 
 	"github.com/TykTechnologies/tyk/apidef"

--- a/mw_jwt_test.go
+++ b/mw_jwt_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/lonelycode/go-uuid/uuid"
 
 	"github.com/TykTechnologies/tyk/test"

--- a/mw_openid.go
+++ b/mw_openid.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 
 	"github.com/TykTechnologies/openid2go/openid"
 	"github.com/TykTechnologies/tyk/apidef"

--- a/mw_openid.go
+++ b/mw_openid.go
@@ -200,7 +200,7 @@ func (k *OpenIDMW) ProcessRequest(w http.ResponseWriter, r *http.Request, _ inte
 	// apply new policy to session if any and update session
 	session.SetPolicies(policyID)
 	if err := k.ApplyPolicies(sessionID, &session); err != nil {
-	    log.WithError(err).Error("Could not apply new policy from OIDC client to session")
+		log.WithError(err).Error("Could not apply new policy from OIDC client to session")
 		return errors.New("Key not authorized: could not apply new policy"), http.StatusForbidden
 	}
 

--- a/mw_organization_activity_test.go
+++ b/mw_organization_activity_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/test"

--- a/newrelic.go
+++ b/newrelic.go
@@ -7,7 +7,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/gocraft/health"
 	"github.com/gorilla/mux"
-	"github.com/newrelic/go-agent"
+	newrelic "github.com/newrelic/go-agent"
 	"github.com/newrelic/go-agent/_integrations/nrgorilla/v1"
 
 	"github.com/TykTechnologies/tyk/config"

--- a/oauth_manager.go
+++ b/oauth_manager.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	osin "github.com/lonelycode/osin"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"golang.org/x/crypto/bcrypt"
 
 	"strconv"

--- a/oauth_manager_test.go
+++ b/oauth_manager_test.go
@@ -17,9 +17,8 @@ import (
 
 	"time"
 
-	"github.com/satori/go.uuid"
-
 	"github.com/lonelycode/osin"
+	uuid "github.com/satori/go.uuid"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"

--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/pmylund/go-cache"
+	cache "github.com/pmylund/go-cache"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"

--- a/rpc_analytics_purger.go
+++ b/rpc_analytics_purger.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
-	"gopkg.in/vmihailenco/msgpack.v2"
+	msgpack "gopkg.in/vmihailenco/msgpack.v2"
 
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/storage"

--- a/rpc_storage_handler.go
+++ b/rpc_storage_handler.go
@@ -14,7 +14,7 @@ import (
 	"github.com/garyburd/redigo/redis"
 	"github.com/lonelycode/gorpc"
 	cache "github.com/pmylund/go-cache"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/storage"

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -8,8 +8,9 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/TykTechnologies/tyk/cli"
 	"github.com/lonelycode/gorpc"
+
+	"github.com/TykTechnologies/tyk/cli"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/test"
 )

--- a/signature_validator/hash.go
+++ b/signature_validator/hash.go
@@ -1,0 +1,36 @@
+package signature_validator
+
+import (
+	"crypto/md5"
+	"crypto/sha256"
+	"strconv"
+)
+
+type Hasher interface {
+	Name() string
+	Hash(token string, sharedSecret string, timeStamp int64) []byte
+}
+
+type MasherySha256Sum struct{}
+
+func (m MasherySha256Sum) Name() string {
+	return "MasherySha256"
+}
+
+func (m MasherySha256Sum) Hash(token string, sharedSecret string, timeStamp int64) []byte {
+	signature := sha256.Sum256([]byte(token + sharedSecret + strconv.FormatInt(timeStamp, 10)))
+
+	return signature[:]
+}
+
+type MasheryMd5sum struct{}
+
+func (m MasheryMd5sum) Name() string {
+	return "MasheryMd5"
+}
+
+func (m MasheryMd5sum) Hash(token string, sharedSecret string, timeStamp int64) []byte {
+	signature := md5.Sum([]byte(token + sharedSecret + strconv.FormatInt(timeStamp, 10)))
+
+	return signature[:]
+}

--- a/signature_validator/hash_test.go
+++ b/signature_validator/hash_test.go
@@ -1,0 +1,34 @@
+package signature_validator
+
+import (
+	"encoding/hex"
+	"testing"
+	"time"
+)
+
+const (
+	token        = "5bcef48a3f03d311ff27d156630baf849e3b438b8a48fec99239d5c9"
+	sharedSecret = "foobar"
+	now          = 1546259837
+)
+
+func TestMasherySha256Sum_Hash(t *testing.T) {
+	expected := "fce2e80253cd438b666341176f34bde499116b63719e2482dae6965518ffd316"
+
+	hasher := MasherySha256Sum{}
+	hashed := hex.EncodeToString(hasher.Hash(token, sharedSecret, now))
+
+	if hashed != expected {
+		t.Fatalf("expected %s, got %s", expected, hashed)
+	}
+}
+
+func BenchmarkMasherySha256Sum_Hash(b *testing.B) {
+
+	b.ReportAllocs()
+
+	for n := 0; n < b.N; n++ {
+		hasher := MasherySha256Sum{}
+		hasher.Hash(token, sharedSecret, time.Now().Unix())
+	}
+}

--- a/signature_validator/validate.go
+++ b/signature_validator/validate.go
@@ -1,0 +1,53 @@
+package signature_validator
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type Validator interface {
+	Init(hasherName string) error
+	Validate(attempt, actual string, allowedClockSkew int64) error
+}
+
+type SignatureValidator struct {
+	h Hasher
+}
+
+func (v *SignatureValidator) Init(hasherName string) error {
+	switch hasherName {
+	case "MasherySha256":
+		v.h = MasherySha256Sum{}
+	case "MasheryMd5":
+		v.h = MasheryMd5sum{}
+	default:
+		return errors.New(fmt.Sprintf("unsupported hasher type (%s)", hasherName))
+	}
+
+	return nil
+}
+
+func (v SignatureValidator) Validate(signatureAttempt, apiKey, sharedSecret string, allowedClockSkew int64) error {
+	signatureAttemptHex, _ := hex.DecodeString(signatureAttempt)
+
+	now := time.Now().Unix()
+	for i := int64(0); i <= allowedClockSkew; i++ {
+		if bytes.Equal(v.h.Hash(apiKey, sharedSecret, now+i), signatureAttemptHex) {
+			return nil
+		}
+
+		if i == int64(0) {
+			continue
+		}
+
+		if bytes.Equal(v.h.Hash(apiKey, sharedSecret, now-i), signatureAttemptHex) {
+			return nil
+		}
+	}
+
+	return errors.New("signature is not valid")
+}

--- a/signature_validator/validate_test.go
+++ b/signature_validator/validate_test.go
@@ -1,0 +1,75 @@
+package signature_validator
+
+import (
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+func TestValidateSignature_Init(t *testing.T) {
+
+	type tt = struct {
+		In    string
+		Error error
+	}
+
+	suite := []tt{
+		{"", errors.New("empty string in init")},
+		{"SomeJunk", errors.New("non existent")},
+		{"MasherySha256", nil},
+		{"MasheryMd5", nil},
+	}
+
+	for _, s := range suite {
+
+		validator := SignatureValidator{}
+		err := validator.Init(s.In)
+
+		if err != nil && s.Error == nil {
+			t.Errorf("expected success, got error %s", err.Error())
+			t.FailNow()
+		}
+
+		if err == nil && s.Error != nil {
+			t.Errorf("expected error (%s), got success", s.Error.Error())
+			t.FailNow()
+		}
+	}
+}
+
+func TestValidateSignature_Validate(t *testing.T) {
+	type tt struct {
+		SignatureAttempt string
+		Error            error
+	}
+
+	allowedClockSkew := int64(100)
+
+	suite := []tt{
+		{SignatureAttempt: "", Error: errors.New("should not pass with missing signature")},
+		{SignatureAttempt: "abcde", Error: errors.New("should not pass with incorrect signature")},
+		{SignatureAttempt: hex.EncodeToString(MasherySha256Sum{}.Hash(token, sharedSecret, time.Now().Unix()-101)), Error: errors.New("clock too slow")},
+		{SignatureAttempt: hex.EncodeToString(MasherySha256Sum{}.Hash(token, sharedSecret, time.Now().Unix()+101)), Error: errors.New("clock too fast")},
+		{SignatureAttempt: hex.EncodeToString(MasherySha256Sum{}.Hash(token, sharedSecret, time.Now().Unix())), Error: nil},
+		{SignatureAttempt: hex.EncodeToString(MasherySha256Sum{}.Hash(token, sharedSecret, time.Now().Unix()+99)), Error: nil},
+		{SignatureAttempt: hex.EncodeToString(MasherySha256Sum{}.Hash(token, sharedSecret, time.Now().Unix()-99)), Error: nil},
+	}
+
+	validator := SignatureValidator{}
+	_ = validator.Init("MasherySha256")
+
+	for _, s := range suite {
+		err := validator.Validate(s.SignatureAttempt, token, sharedSecret, allowedClockSkew)
+		if err != nil && s.Error == nil {
+			t.Errorf("expected valid, got error %s", err.Error())
+			t.FailNow()
+		}
+
+		if err == nil && s.Error != nil {
+			t.Errorf("expected error (%s), got valid", s.Error.Error())
+			t.FailNow()
+		}
+	}
+}

--- a/storage/redis_cluster.go
+++ b/storage/redis_cluster.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/garyburd/redigo/redis"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 
 	"github.com/TykTechnologies/redigocluster/rediscluster"
 	"github.com/TykTechnologies/tyk/config"

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/buger/jsonparser"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 
 	"github.com/TykTechnologies/murmur3"
 	"github.com/TykTechnologies/tyk/config"


### PR DESCRIPTION
#2045

Allows optional addition of `validate_signature` field to
`apidefintion.auth` object.

Currently supports mashery signature validation modes `MasherySha256`
and `MasheryMd5`.

In order to test, add something like the following to auth field of api definition. Declarative syntax, in that signature validation logic is only enabled based upon the presence of the validate_signature object.

```json
"validate_signature": {
  "mode": "MasherySha256",
  "signature_header_key": "x-Signature",
  "session_meta_key": "secret",
  "allowed_clock_skew": 30,
  "error_code": 403,
  "error_message": "your signature is invalid"
}
```

Ensure to add a shared secret to the token meta.

Benchmarks:

```
BenchmarkMasherySha256Sum_Hash-4          500000              2094 ns/op
208 B/op          4 allocs/op
```