### PR TITLE
Fix CheckSpecMatchesStatus func breaking url rewrite

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -1008,10 +1008,6 @@ func (a *APISpec) CheckSpecMatchesStatus(r *http.Request, rxPaths []URLSpec, mod
 		matchPath = r.URL.Path
 	}
 
-	if a.Proxy.ListenPath != "/" {
-		matchPath = strings.TrimPrefix(matchPath, a.Proxy.ListenPath)
-	}
-
 	if !strings.HasPrefix(matchPath, "/") {
 		matchPath = "/" + matchPath
 	}


### PR DESCRIPTION
When `listen_path` matches with url rewrite endpoint, url rewriting doesn't work. This PR fixes the problem.

Fixes #2143