### PR TITLE
storage: avoid MGET call when no keys are specified

### DIFF
--- a/storage/redis_cluster.go
+++ b/storage/redis_cluster.go
@@ -364,6 +364,9 @@ func (r *RedisCluster) GetKeysAndValuesWithFilter(filter string) map[string]stri
 	}
 
 	keys, _ := redis.Strings(sessionsInterface, err)
+	if len(keys) == 0 {
+		return nil
+	}
 	valueObj, err := r.singleton().Do("MGET", sessionsInterface.([]interface{})...)
 	values, err := redis.Strings(valueObj, err)
 	if err != nil {


### PR DESCRIPTION
Fixes #2155 

`GetKeysAndValuesWithFilter` lists keys and runs `MGET`(https://redis.io/commands/mget) using these keys. This patch avoids the `MGET` call when the list is empty.

This method is only called by the `oauth_manager.go` code.