### PR TITLE
Fixes Redis being initialised by event handlers before storing global config

### DIFF
--- a/main.go
+++ b/main.go
@@ -827,10 +827,13 @@ func initialiseSystem() error {
 		if err := config.Load(confPaths, &globalConf); err != nil {
 			return err
 		}
-		afterConfSetup(&globalConf)
 		if globalConf.PIDFileLocation == "" {
 			globalConf.PIDFileLocation = "/var/run/tyk/tyk-gateway.pid"
 		}
+		// It's necessary to set global conf before and after calling afterConfSetup as global conf
+		// is being used by dependencies of the even handler init and then conf is modified again.
+		config.SetGlobal(globalConf)
+		afterConfSetup(&globalConf)
 		config.SetGlobal(globalConf)
 	}
 


### PR DESCRIPTION
Without global config stored Redis is unable to correctly initialize. This regression happens when event handlers such as webhooks are present in the configuration.

Fix https://github.com/TykTechnologies/tyk/issues/2170