### PR TITLE
Custom signature validation

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -445,19 +445,20 @@ type APIDefinition struct {
 }
 
 type Auth struct {
-	UseParam          bool               `mapstructure:"use_param" bson:"use_param" json:"use_param"`
-	ParamName         string             `mapstructure:"param_name" bson:"param_name" json:"param_name"`
-	UseCookie         bool               `mapstructure:"use_cookie" bson:"use_cookie" json:"use_cookie"`
-	CookieName        string             `mapstructure:"cookie_name" bson:"cookie_name" json:"cookie_name"`
-	AuthHeaderName    string             `mapstructure:"auth_header_name" bson:"auth_header_name" json:"auth_header_name"`
-	UseCertificate    bool               `mapstructure:"use_certificate" bson:"use_certificate" json:"use_certificate"`
-	ValidateSignature *ValidateSignature `mapstructure:"validate_signature" bson:"validate_signature" json:"validate_signature,omitempty"`
+	UseParam          bool            `mapstructure:"use_param" bson:"use_param" json:"use_param"`
+	ParamName         string          `mapstructure:"param_name" bson:"param_name" json:"param_name"`
+	UseCookie         bool            `mapstructure:"use_cookie" bson:"use_cookie" json:"use_cookie"`
+	CookieName        string          `mapstructure:"cookie_name" bson:"cookie_name" json:"cookie_name"`
+	AuthHeaderName    string          `mapstructure:"auth_header_name" bson:"auth_header_name" json:"auth_header_name"`
+	UseCertificate    bool            `mapstructure:"use_certificate" bson:"use_certificate" json:"use_certificate"`
+	ValidateSignature bool            `mapstructure:"validate_signature" bson:"validate_signature" json:"validate_signature"`
+	Signature         SignatureConfig `mapstructure:"signature" bson:"signature" json:"signature,omitempty"`
 }
 
-type ValidateSignature struct {
-	Mode             string `mapstructure:"mode" bson:"mode" json:"mode"`
-	SignatureKey     string `mapstructure:"signature_key" bson:"signature_key" json:"signature_key"`
-	SessionMetaKey   string `mapstructure:"session_meta_key" bson:"session_meta_key" json:"session_meta_key"`
+type SignatureConfig struct {
+	Algorithm        string `mapstructure:"algorithm" bson:"algorithm" json:"algorithm"`
+	Header           string `mapstructure:"header" bson:"header" json:"header"`
+	Secret           string `mapstructure:"secret" bson:"secret" json:"secret"`
 	AllowedClockSkew int64  `mapstructure:"allowed_clock_skew" bson:"allowed_clock_skew" json:"allowed_clock_skew"`
 	ErrorCode        int    `mapstructure:"error_code" bson:"error_code" json:"error_code"`
 	ErrorMessage     string `mapstructure:"error_message" bson:"error_message" json:"error_message"`

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -445,12 +445,22 @@ type APIDefinition struct {
 }
 
 type Auth struct {
-	UseParam       bool   `mapstructure:"use_param" bson:"use_param" json:"use_param"`
-	ParamName      string `mapstructure:"param_name" bson:"param_name" json:"param_name"`
-	UseCookie      bool   `mapstructure:"use_cookie" bson:"use_cookie" json:"use_cookie"`
-	CookieName     string `mapstructure:"cookie_name" bson:"cookie_name" json:"cookie_name"`
-	AuthHeaderName string `mapstructure:"auth_header_name" bson:"auth_header_name" json:"auth_header_name"`
-	UseCertificate bool   `mapstructure:"use_certificate" bson:"use_certificate" json:"use_certificate"`
+	UseParam          bool               `mapstructure:"use_param" bson:"use_param" json:"use_param"`
+	ParamName         string             `mapstructure:"param_name" bson:"param_name" json:"param_name"`
+	UseCookie         bool               `mapstructure:"use_cookie" bson:"use_cookie" json:"use_cookie"`
+	CookieName        string             `mapstructure:"cookie_name" bson:"cookie_name" json:"cookie_name"`
+	AuthHeaderName    string             `mapstructure:"auth_header_name" bson:"auth_header_name" json:"auth_header_name"`
+	UseCertificate    bool               `mapstructure:"use_certificate" bson:"use_certificate" json:"use_certificate"`
+	ValidateSignature *ValidateSignature `mapstructure:"validate_signature" bson:"validate_signature" json:"validate_signature,omitempty"`
+}
+
+type ValidateSignature struct {
+	Mode             string `mapstructure:"mode" bson:"mode" json:"mode"`
+	SignatureKey     string `mapstructure:"signature_key" bson:"signature_key" json:"signature_key"`
+	SessionMetaKey   string `mapstructure:"session_meta_key" bson:"session_meta_key" json:"session_meta_key"`
+	AllowedClockSkew int64  `mapstructure:"allowed_clock_skew" bson:"allowed_clock_skew" json:"allowed_clock_skew"`
+	ErrorCode        int    `mapstructure:"error_code" bson:"error_code" json:"error_code"`
+	ErrorMessage     string `mapstructure:"error_message" bson:"error_message" json:"error_message"`
 }
 
 type GlobalRateLimit struct {

--- a/mw_auth_key.go
+++ b/mw_auth_key.go
@@ -134,7 +134,7 @@ func (k *AuthKey) validateSignature(r *http.Request, key string) (error, int) {
 	validator := signature_validator.SignatureValidator{}
 	if err := validator.Init(config.Signature.Algorithm); err != nil {
 		logger.WithError(err).Info("Invalid signature verification algorithm")
-		return errors.New(errorMessage), errorCode
+		return errors.New("internal server error"), http.StatusInternalServerError
 	}
 
 	signature := r.Header.Get(config.Signature.Header)

--- a/mw_auth_key.go
+++ b/mw_auth_key.go
@@ -2,12 +2,19 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/certs"
 	"github.com/TykTechnologies/tyk/request"
+	"github.com/TykTechnologies/tyk/signature_validator"
+)
+
+const (
+	defaultErrorCode    = http.StatusForbidden
+	defaultErrorMessage = "Not Authorized"
 )
 
 // KeyExists will check if the key being used to access the API is in the request data,
@@ -95,6 +102,66 @@ func (k *AuthKey) ProcessRequest(w http.ResponseWriter, r *http.Request, _ inter
 		reportHealthValue(k.Spec, KeyFailure, "1")
 
 		return errors.New("Access to this API has been disallowed"), http.StatusForbidden
+	}
+
+	if config.ValidateSignature != nil {
+		if config.ValidateSignature.SignatureKey == "" {
+			err := errors.New("signature_header_key not set")
+			log.WithError(err).Error("misconfigured api definition")
+			return errors.New("internal server error"), http.StatusInternalServerError
+		}
+
+		if config.ValidateSignature.SessionMetaKey == "" {
+			err := errors.New("auth.validate_signature.session_meta_key not set")
+			log.WithError(err).Error("misconfigured api definition")
+			return errors.New("internal server error"), http.StatusInternalServerError
+		}
+
+		if config.ValidateSignature.Mode == "" {
+			err := errors.New("auth.validate_signature.mode not set")
+			log.WithError(err).Error("misconfigured api definition")
+			return errors.New("internal server error"), http.StatusInternalServerError
+		}
+
+		errorCode := defaultErrorCode
+		if config.ValidateSignature.ErrorCode != 0 {
+			errorCode = config.ValidateSignature.ErrorCode
+		}
+
+		errorMessage := defaultErrorMessage
+		if config.ValidateSignature.ErrorMessage != "" {
+			errorMessage = config.ValidateSignature.ErrorMessage
+		}
+
+		validator := signature_validator.SignatureValidator{}
+
+		if err := validator.Init(config.ValidateSignature.Mode); err != nil {
+			log.WithError(err).Error("misconfigured api definition")
+			return errors.New("internal server error"), http.StatusInternalServerError
+		}
+
+		signatureAttempt := r.Header.Get(config.ValidateSignature.SignatureKey)
+		if signatureAttempt == "" {
+			return errors.New(errorMessage), errorCode
+		}
+
+		sharedSecretIf, ok := session.MetaData[config.ValidateSignature.SessionMetaKey]
+		if !ok {
+			err := errors.New(fmt.Sprintf("session token does not contain shared secret in metadata[%s]", config.ValidateSignature.SessionMetaKey))
+			log.WithError(err).Error("misconfigured api definition")
+			return errors.New("internal server error"), http.StatusInternalServerError
+		}
+
+		sharedSecret, ok := sharedSecretIf.(string)
+		if !ok {
+			err := errors.New("key metadata config error, shared secret not string")
+			log.WithError(err).Error("misconfigured session token")
+			return errors.New("internal server error"), http.StatusInternalServerError
+		}
+
+		if err := validator.Validate(signatureAttempt, key, sharedSecret, config.ValidateSignature.AllowedClockSkew); err != nil {
+			return errors.New(errorMessage), errorCode
+		}
 	}
 
 	// Set session state on context, we will need it later

--- a/signature_validator/hash.go
+++ b/signature_validator/hash.go
@@ -14,7 +14,7 @@ type Hasher interface {
 type MasherySha256Sum struct{}
 
 func (m MasherySha256Sum) Name() string {
-	return "MasherySha256"
+	return "MasherySHA256"
 }
 
 func (m MasherySha256Sum) Hash(token string, sharedSecret string, timeStamp int64) []byte {
@@ -26,7 +26,7 @@ func (m MasherySha256Sum) Hash(token string, sharedSecret string, timeStamp int6
 type MasheryMd5sum struct{}
 
 func (m MasheryMd5sum) Name() string {
-	return "MasheryMd5"
+	return "MasheryMD5"
 }
 
 func (m MasheryMd5sum) Hash(token string, sharedSecret string, timeStamp int64) []byte {

--- a/signature_validator/hash.go
+++ b/signature_validator/hash.go
@@ -1,0 +1,36 @@
+package signature_validator
+
+import (
+	"crypto/md5"
+	"crypto/sha256"
+	"strconv"
+)
+
+type Hasher interface {
+	Name() string
+	Hash(token string, sharedSecret string, timeStamp int64) []byte
+}
+
+type MasherySha256Sum struct{}
+
+func (m MasherySha256Sum) Name() string {
+	return "MasherySha256"
+}
+
+func (m MasherySha256Sum) Hash(token string, sharedSecret string, timeStamp int64) []byte {
+	signature := sha256.Sum256([]byte(token + sharedSecret + strconv.FormatInt(timeStamp, 10)))
+
+	return signature[:]
+}
+
+type MasheryMd5sum struct{}
+
+func (m MasheryMd5sum) Name() string {
+	return "MasheryMd5"
+}
+
+func (m MasheryMd5sum) Hash(token string, sharedSecret string, timeStamp int64) []byte {
+	signature := md5.Sum([]byte(token + sharedSecret + strconv.FormatInt(timeStamp, 10)))
+
+	return signature[:]
+}

--- a/signature_validator/hash_test.go
+++ b/signature_validator/hash_test.go
@@ -1,0 +1,34 @@
+package signature_validator
+
+import (
+	"encoding/hex"
+	"testing"
+	"time"
+)
+
+const (
+	token        = "5bcef48a3f03d311ff27d156630baf849e3b438b8a48fec99239d5c9"
+	sharedSecret = "foobar"
+	now          = 1546259837
+)
+
+func TestMasherySha256Sum_Hash(t *testing.T) {
+	expected := "fce2e80253cd438b666341176f34bde499116b63719e2482dae6965518ffd316"
+
+	hasher := MasherySha256Sum{}
+	hashed := hex.EncodeToString(hasher.Hash(token, sharedSecret, now))
+
+	if hashed != expected {
+		t.Fatalf("expected %s, got %s", expected, hashed)
+	}
+}
+
+func BenchmarkMasherySha256Sum_Hash(b *testing.B) {
+
+	b.ReportAllocs()
+
+	for n := 0; n < b.N; n++ {
+		hasher := MasherySha256Sum{}
+		hasher.Hash(token, sharedSecret, time.Now().Unix())
+	}
+}

--- a/signature_validator/validate.go
+++ b/signature_validator/validate.go
@@ -1,0 +1,53 @@
+package signature_validator
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type Validator interface {
+	Init(hasherName string) error
+	Validate(attempt, actual string, allowedClockSkew int64) error
+}
+
+type SignatureValidator struct {
+	h Hasher
+}
+
+func (v *SignatureValidator) Init(hasherName string) error {
+	switch hasherName {
+	case "MasherySha256":
+		v.h = MasherySha256Sum{}
+	case "MasheryMd5":
+		v.h = MasheryMd5sum{}
+	default:
+		return errors.New(fmt.Sprintf("unsupported hasher type (%s)", hasherName))
+	}
+
+	return nil
+}
+
+func (v SignatureValidator) Validate(signatureAttempt, apiKey, sharedSecret string, allowedClockSkew int64) error {
+	signatureAttemptHex, _ := hex.DecodeString(signatureAttempt)
+
+	now := time.Now().Unix()
+	for i := int64(0); i <= allowedClockSkew; i++ {
+		if bytes.Equal(v.h.Hash(apiKey, sharedSecret, now+i), signatureAttemptHex) {
+			return nil
+		}
+
+		if i == int64(0) {
+			continue
+		}
+
+		if bytes.Equal(v.h.Hash(apiKey, sharedSecret, now-i), signatureAttemptHex) {
+			return nil
+		}
+	}
+
+	return errors.New("signature is not valid")
+}

--- a/signature_validator/validate_test.go
+++ b/signature_validator/validate_test.go
@@ -18,8 +18,8 @@ func TestValidateSignature_Init(t *testing.T) {
 	suite := []tt{
 		{"", errors.New("empty string in init")},
 		{"SomeJunk", errors.New("non existent")},
-		{"MasherySha256", nil},
-		{"MasheryMd5", nil},
+		{"MasherySHA256", nil},
+		{"MasheryMD5", nil},
 	}
 
 	for _, s := range suite {
@@ -58,7 +58,7 @@ func TestValidateSignature_Validate(t *testing.T) {
 	}
 
 	validator := SignatureValidator{}
-	_ = validator.Init("MasherySha256")
+	_ = validator.Init("MasherySHA256")
 
 	for _, s := range suite {
 		err := validator.Validate(s.SignatureAttempt, token, sharedSecret, allowedClockSkew)

--- a/signature_validator/validate_test.go
+++ b/signature_validator/validate_test.go
@@ -1,0 +1,75 @@
+package signature_validator
+
+import (
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+func TestValidateSignature_Init(t *testing.T) {
+
+	type tt = struct {
+		In    string
+		Error error
+	}
+
+	suite := []tt{
+		{"", errors.New("empty string in init")},
+		{"SomeJunk", errors.New("non existent")},
+		{"MasherySha256", nil},
+		{"MasheryMd5", nil},
+	}
+
+	for _, s := range suite {
+
+		validator := SignatureValidator{}
+		err := validator.Init(s.In)
+
+		if err != nil && s.Error == nil {
+			t.Errorf("expected success, got error %s", err.Error())
+			t.FailNow()
+		}
+
+		if err == nil && s.Error != nil {
+			t.Errorf("expected error (%s), got success", s.Error.Error())
+			t.FailNow()
+		}
+	}
+}
+
+func TestValidateSignature_Validate(t *testing.T) {
+	type tt struct {
+		SignatureAttempt string
+		Error            error
+	}
+
+	allowedClockSkew := int64(100)
+
+	suite := []tt{
+		{SignatureAttempt: "", Error: errors.New("should not pass with missing signature")},
+		{SignatureAttempt: "abcde", Error: errors.New("should not pass with incorrect signature")},
+		{SignatureAttempt: hex.EncodeToString(MasherySha256Sum{}.Hash(token, sharedSecret, time.Now().Unix()-101)), Error: errors.New("clock too slow")},
+		{SignatureAttempt: hex.EncodeToString(MasherySha256Sum{}.Hash(token, sharedSecret, time.Now().Unix()+101)), Error: errors.New("clock too fast")},
+		{SignatureAttempt: hex.EncodeToString(MasherySha256Sum{}.Hash(token, sharedSecret, time.Now().Unix())), Error: nil},
+		{SignatureAttempt: hex.EncodeToString(MasherySha256Sum{}.Hash(token, sharedSecret, time.Now().Unix()+99)), Error: nil},
+		{SignatureAttempt: hex.EncodeToString(MasherySha256Sum{}.Hash(token, sharedSecret, time.Now().Unix()-99)), Error: nil},
+	}
+
+	validator := SignatureValidator{}
+	_ = validator.Init("MasherySha256")
+
+	for _, s := range suite {
+		err := validator.Validate(s.SignatureAttempt, token, sharedSecret, allowedClockSkew)
+		if err != nil && s.Error == nil {
+			t.Errorf("expected valid, got error %s", err.Error())
+			t.FailNow()
+		}
+
+		if err == nil && s.Error != nil {
+			t.Errorf("expected error (%s), got valid", s.Error.Error())
+			t.FailNow()
+		}
+	}
+}


### PR DESCRIPTION
#2045

`auth` section now has new `validate_signature` boolean field, and `signature` section for configuring signature flow.

Currently supports mashery signature validation modes `MasherySHA256`
and `MasheryMD5`.

```json
"auth": {
  "validate_signature": true,
  "signature": {
    "algorithm": "MasherySHA256",
    "header": "X-Signature",
    "secret": "secret",
    "allowed_clock_skew": 2
  }
}
```

"secret" field can hold dynamic values from meta or context, for example: "$tyk_meta.signature_secret".

Additionally, you can override error code and message using:
```
  "error_code": 403,
  "error_message": "your signature is invalid"
```

Benchmarks:

```
BenchmarkMasherySha256Sum_Hash-4          500000              2094 ns/op
208 B/op          4 allocs/op
```