### PR TITLE
retain body for requests 

### DIFF
--- a/coprocess_id_extractor.go
+++ b/coprocess_id_extractor.go
@@ -50,7 +50,7 @@ func (e *BaseExtractor) ExtractHeader(r *http.Request) (headerValue string, err 
 
 // ExtractForm is used when a FormSource is specified.
 func (e *BaseExtractor) ExtractForm(r *http.Request, paramName string) (formValue string, err error) {
-	r.ParseForm()
+	parseForm(r)
 
 	if paramName == "" {
 		return "", errors.New("no form param name set")

--- a/middleware.go
+++ b/middleware.go
@@ -538,7 +538,8 @@ func parseForm(r *http.Request) {
 		r.ParseForm()
 
 		r.Body = ioutil.NopCloser(&b)
-	} else {
-		r.ParseForm()
+		return
 	}
+
+	r.ParseForm()
 }

--- a/middleware.go
+++ b/middleware.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"strconv"
 	"time"
@@ -522,4 +525,20 @@ func handleResponseChain(chain []TykResponseHandler, rw http.ResponseWriter, res
 		}
 	}
 	return nil
+}
+
+func parseForm(r *http.Request) {
+	// https://golang.org/pkg/net/http/#Request.ParseForm
+	// ParseForm drains the request body for a request with Content-Type of
+	// application/x-www-form-urlencoded
+	if r.Header.Get("Content-Type") == "application/x-www-form-urlencoded" {
+		var b bytes.Buffer
+		r.Body = ioutil.NopCloser(io.TeeReader(r.Body, &b))
+
+		r.ParseForm()
+
+		r.Body = ioutil.NopCloser(&b)
+	} else {
+		r.ParseForm()
+	}
 }

--- a/mw_context_vars.go
+++ b/mw_context_vars.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"bytes"
-	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -27,19 +24,7 @@ func (m *MiddlewareContextVars) EnabledForSpec() bool {
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (m *MiddlewareContextVars) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 
-	// https://golang.org/pkg/net/http/#Request.ParseForm
-	// ParseForm drains the request body for a request with Content-Type of
-	// application/x-www-form-urlencoded
-	if r.Header.Get("Content-Type") == "application/x-www-form-urlencoded" {
-		var b bytes.Buffer
-		r.Body = ioutil.NopCloser(io.TeeReader(r.Body, &b))
-
-		r.ParseForm()
-
-		r.Body = ioutil.NopCloser(&b)
-	} else {
-		r.ParseForm()
-	}
+	parseForm(r)
 
 	contextDataObject := map[string]interface{}{
 		"request_data": r.Form, // Form params (map[string][]string)

--- a/mw_rate_check.go
+++ b/mw_rate_check.go
@@ -1,6 +1,8 @@
 package main
 
-import "net/http"
+import (
+	"net/http"
+)
 
 type RateCheckMW struct {
 	BaseMiddleware

--- a/mw_virtual_endpoint.go
+++ b/mw_virtual_endpoint.go
@@ -150,7 +150,7 @@ func (d *VirtualEndpoint) ServeHTTPForCache(w http.ResponseWriter, r *http.Reque
 
 	// We need to copy the body _back_ for the decode
 	r.Body = ioutil.NopCloser(bytes.NewReader(originalBody))
-	r.ParseForm()
+	parseForm(r)
 	requestData.Params = r.Form
 
 	requestAsJson, err := json.Marshal(requestData)


### PR DESCRIPTION
Fixes https://github.com/TykTechnologies/tyk/issues/2169

This PR makes sure to retain request body for requests with Content-Type of `application/x-www-form-urlencoded` as it is drained by ParseForm which is called in the `URLRewrite` middleware. 

https://golang.org/pkg/net/http/#Request.ParseForm says

```
For POST, PUT, and PATCH requests, it also parses the request body as a
form and puts the results into both r.PostForm and r.Form. 
Request body parameters take precedence over URL query string values in r.Form.

For other HTTP methods, or when the Content-Type is not application/x-www-form-urlencoded, 
the request Body is not read, and r.PostForm is initialized to a non-nil, empty value.

``` 

To verify, you can swap the request a bit by using `application/json` instead of 
`application/x-www-form-urlencoded` as the content-type, you will notice the request does not fail

```sh
curl -X POST \
    http://localhost:9000/XXXXXXXX/my/1.0/oauth/token/ \
    -H 'accept: application/json' \
    -H 'authorization: Basic xxxxxxxx' \
    -H 'cache-control: no-cache' \
    -d '{"grant_type":"client_credentials","scope":"execute"}' \
-H 'content-type: application/json'

```

cc @bitsofinfo 