### PR TITLE
Cache failed OrgKey expiration attempts

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -193,6 +193,8 @@ func (t BaseMiddleware) OrgSessionExpiry(orgid string) int64 {
 	t.Logger().Debug("Checking: ", orgid)
 	cachedVal, found := ExpiryCache.Get(orgid)
 	if !found {
+		// Cache failed attempt
+		t.SetOrgExpiry(orgid, 604800)
 		go t.OrgSession(orgid)
 		t.Logger().Debug("no cached entry found, returning 7 days")
 		return 604800

--- a/signature_validator/validate.go
+++ b/signature_validator/validate.go
@@ -32,9 +32,6 @@ func (v *SignatureValidator) Init(hasherName string) error {
 
 func (v SignatureValidator) Validate(signature, key, secret string, allowedClockSkew int64) error {
 	signatureBytes, _ := hex.DecodeString(signature)
-
-	fmt.Println("Validating:", signature, key, secret)
-
 	now := time.Now().Unix()
 	for i := int64(0); i <= allowedClockSkew; i++ {
 		if bytes.Equal(v.h.Hash(key, secret, now+i), signatureBytes) {


### PR DESCRIPTION
At the moment it expects that OrgKey exists, and if not, it asks for an Org key on every request.

Fix #2184