### PR TITLE
Basic auth now can extract credentials from body

### DIFF
--- a/api_loader.go
+++ b/api_loader.go
@@ -353,7 +353,7 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 			logger.Info("Checking security policy: OAuth")
 		}
 
-		if mwAppendEnabled(&authArray, &BasicAuthKeyIsValid{baseMid, cache.New(60*time.Second, 60*time.Minute)}) {
+		if mwAppendEnabled(&authArray, &BasicAuthKeyIsValid{baseMid, cache.New(60*time.Second, 60*time.Minute), nil, nil}) {
 			logger.Info("Checking security policy: Basic")
 		}
 

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -341,8 +341,11 @@ type APIDefinition struct {
 	Auth         Auth `bson:"auth" json:"auth"`
 	UseBasicAuth bool `bson:"use_basic_auth" json:"use_basic_auth"`
 	BasicAuth    struct {
-		DisableCaching bool `bson:"disable_caching" json:"disable_caching"`
-		CacheTTL       int  `bson:"cache_ttl" json:"cache_ttl"`
+		DisableCaching     bool   `bson:"disable_caching" json:"disable_caching"`
+		CacheTTL           int    `bson:"cache_ttl" json:"cache_ttl"`
+		ExtractFromBody    bool   `bson:"extract_from_body" json:"extract_from_body"`
+		BodyUserRegexp     string `bson:"body_user_regexp" json:"body_user_regexp"`
+		BodyPasswordRegexp string `bson:"body_password_regexp" json:"body_password_regexp"`
 	} `bson:"basic_auth" json:"basic_auth"`
 	UseMutualTLSAuth           bool                 `bson:"use_mutual_tls_auth" json:"use_mutual_tls_auth"`
 	ClientCertificates         []string             `bson:"client_certificates" json:"client_certificates"`

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -97,7 +98,7 @@ func initTestMain(m *testing.M) int {
 	if err := config.WriteDefault("", &globalConf); err != nil {
 		panic(err)
 	}
-	globalConf.Storage.Database = 1
+	globalConf.Storage.Database = rand.Intn(15)
 	var err error
 	globalConf.AppPath, err = ioutil.TempDir("", "tyk-test-")
 	if err != nil {

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -1429,11 +1429,13 @@ func TestRateLimitForAPIAndRateLimitAndQuotaCheck(t *testing.T) {
 		s.Rate = 1
 		s.Per = 60
 	})
+	defer FallbackKeySesionManager.RemoveSession(sess1token, false)
 
 	sess2token := createSession(func(s *user.SessionState) {
 		s.Rate = 1
 		s.Per = 60
 	})
+	defer FallbackKeySesionManager.RemoveSession(sess2token, false)
 
 	ts.Run(t, []test.TestCase{
 		{Headers: map[string]string{"Authorization": sess1token}, Code: http.StatusOK, Path: "/", Delay: 100 * time.Millisecond},

--- a/multiauth_test.go
+++ b/multiauth_test.go
@@ -78,7 +78,7 @@ func getMultiAuthStandardAndBasicAuthChain(spec *APISpec) http.Handler {
 	chain := alice.New(mwList(
 		&IPWhiteListMiddleware{baseMid},
 		&IPBlackListMiddleware{BaseMiddleware: baseMid},
-		&BasicAuthKeyIsValid{baseMid, cache.New(60*time.Second, 60*time.Minute)},
+		&BasicAuthKeyIsValid{baseMid, cache.New(60*time.Second, 60*time.Minute), nil, nil},
 		&AuthKey{baseMid},
 		&VersionCheck{BaseMiddleware: baseMid},
 		&KeyExpired{baseMid},

--- a/mw_basic_auth_test.go
+++ b/mw_basic_auth_test.go
@@ -59,6 +59,41 @@ func TestBasicAuth(t *testing.T) {
 	}...)
 }
 
+func TestBasicAuthFromBody(t *testing.T) {
+	ts := newTykTestServer()
+	defer ts.Close()
+
+	session := createStandardSession()
+	session.BasicAuthData.Password = "password"
+	session.AccessRights = map[string]user.AccessDefinition{"test": {APIID: "test", Versions: []string{"v1"}}}
+	session.OrgID = "default"
+
+	buildAndLoadAPI(func(spec *APISpec) {
+		spec.UseBasicAuth = true
+		spec.BasicAuth.ExtractFromBody = true
+		spec.BasicAuth.BodyUserRegexp = `<User>(.*)</User>`
+		spec.BasicAuth.BodyPasswordRegexp = `<Password>(.*)</Password>`
+		spec.UseKeylessAccess = false
+		spec.Proxy.ListenPath = "/"
+		spec.OrgID = "default"
+	})
+
+	validPassword := `<User>user</User><Password>password</Password>`
+	wrongPassword := `<User>user</User><Password>wrong</Password>`
+	withoutPassword := `<User>user</User>`
+	malformed := `<User>User>`
+
+	ts.Run(t, []test.TestCase{
+		// Create base auth based key
+		{Method: "POST", Path: "/tyk/keys/defaultuser", Data: session, AdminAuth: true, Code: 200},
+		{Method: "POST", Path: "/", Code: 400, BodyMatch: `Body do not contain username`},
+		{Method: "POST", Path: "/", Data: validPassword, Code: 200},
+		{Method: "POST", Path: "/", Data: wrongPassword, Code: 401},
+		{Method: "POST", Path: "/", Data: withoutPassword, Code: 400, BodyMatch: `Body do not contain password`},
+		{Method: "GET", Path: "/", Data: malformed, Code: 400, BodyMatch: `Body do not contain username`},
+	}...)
+}
+
 func TestBasicAuthLegacyWithHashFunc(t *testing.T) {
 	globalConf := config.Global()
 


### PR DESCRIPTION
You can specify regexps for username and body.
Regexp should contain one match group, which points to either username or password.

Example:
```
"basic_auth": {
    "extract_from_body": true,
    "body_user_regexp": "<User>(.*)</User>",
    "body_password_regexp": "<Password>(.*)</Password>"
}
```

Fix https://github.com/TykTechnologies/tyk/issues/1855