### PR TITLE
Make linter generic to be able to use in other projects

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -73,7 +73,7 @@ func Init(version string, confPaths []string) {
 	// Linter:
 	lintCmd := app.Command("lint", "Runs a linter on Tyk configuration file")
 	lintCmd.Action(func(c *kingpin.ParseContext) error {
-		path, lines, err := lint.Run(confPaths)
+		path, lines, err := lint.Run(lint.ConfSchema, confPaths)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)

--- a/cli/lint/lint.go
+++ b/cli/lint/lint.go
@@ -14,13 +14,13 @@ import (
 // Run will lint the configuration file. It will return the path to the
 // config file that was checked, a list of warnings and an error, if any
 // happened.
-func Run(paths []string) (string, []string, error) {
+func Run(schm string, paths []string) (string, []string, error) {
 	addFormats(&schema.FormatCheckers)
 	var conf config.Config
 	if err := config.Load(paths, &conf); err != nil {
 		return "", nil, err
 	}
-	schemaLoader := schema.NewBytesLoader([]byte(confSchema))
+	schemaLoader := schema.NewBytesLoader([]byte(schm))
 
 	var orig map[string]interface{}
 	f, err := os.Open(conf.OriginalPath)

--- a/cli/lint/lint_test.go
+++ b/cli/lint/lint_test.go
@@ -116,7 +116,7 @@ func TestLint(t *testing.T) {
 				t.Fatal(err)
 			}
 			f.Close()
-			_, got, err := Run([]string{f.Name()})
+			_, got, err := Run(ConfSchema, []string{f.Name()})
 			if err != nil {
 				got = []string{err.Error()}
 			}

--- a/cli/lint/schema.go
+++ b/cli/lint/schema.go
@@ -1,6 +1,6 @@
 package lint
 
-const confSchema = `{
+const ConfSchema = `{
 "$schema": "http://json-schema.org/draft-04/schema#",
 "type": "object",
 "additionalProperties": false,


### PR DESCRIPTION
I will implement linter for `tyk-analytics`. I want to use `Run` function. So, I made it generic.