### PR TITLE
Add Host field to AnalyticsRecord

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -19,6 +19,7 @@ import (
 // AnalyticsRecord encodes the details of a request
 type AnalyticsRecord struct {
 	Method        string
+	Host          string
 	Path          string // HTTP path, can be overriden by "track path" plugin
 	RawPath       string // Original HTTP path
 	ContentLength int64

--- a/handler_error.go
+++ b/handler_error.go
@@ -132,8 +132,14 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 			trackedPath = p
 		}
 
+		host := r.URL.Host
+		if host == "" && e.Spec.target != nil {
+			host = e.Spec.target.Host
+		}
+
 		record := AnalyticsRecord{
 			r.Method,
+			host,
 			trackedPath,
 			r.URL.Path,
 			r.ContentLength,

--- a/handler_success.go
+++ b/handler_success.go
@@ -10,11 +10,10 @@ import (
 	"strings"
 	"time"
 
-	cache "github.com/pmylund/go-cache"
-
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/request"
 	"github.com/TykTechnologies/tyk/user"
+	cache "github.com/pmylund/go-cache"
 )
 
 // Enums for keys to be stored in a session context - this is how gorilla expects
@@ -208,8 +207,14 @@ func (s *SuccessHandler) RecordHit(r *http.Request, timing int64, code int, resp
 			trackedPath = p
 		}
 
+		host := r.URL.Host
+		if host == "" && s.Spec.target != nil {
+			host = s.Spec.target.Host
+		}
+
 		record := AnalyticsRecord{
 			r.Method,
+			host,
 			trackedPath,
 			r.URL.Path,
 			r.ContentLength,


### PR DESCRIPTION
This PR adds `Host` field to `AnalyticsRecord `.

Fixes #2183 