### PR TITLE
Bug/2195 fix looping issue

### DIFF
--- a/api_definition.go
+++ b/api_definition.go
@@ -1022,10 +1022,17 @@ func (a *APISpec) URLAllowedAndIgnored(r *http.Request, rxPaths []URLSpec, white
 
 // CheckSpecMatchesStatus checks if a url spec has a specific status
 func (a *APISpec) CheckSpecMatchesStatus(r *http.Request, rxPaths []URLSpec, mode URLStatus) (bool, interface{}) {
-	matchPath := ctxGetUrlRewritePath(r)
-	method := ctxGetRequestMethod(r)
-	if matchPath == "" {
+	var matchPath, method string
+
+	if mode == TransformedJQResponse || mode == HeaderInjectedResponse || mode == TransformedResponse {
+		matchPath = ctxGetUrlRewritePath(r)
+		method = ctxGetRequestMethod(r)
+		if matchPath == "" {
+			matchPath = r.URL.Path
+		}
+	} else {
 		matchPath = r.URL.Path
+		method = r.Method
 	}
 
 	if a.Proxy.ListenPath != "/" {

--- a/api_definition.go
+++ b/api_definition.go
@@ -1024,6 +1024,8 @@ func (a *APISpec) URLAllowedAndIgnored(r *http.Request, rxPaths []URLSpec, white
 func (a *APISpec) CheckSpecMatchesStatus(r *http.Request, rxPaths []URLSpec, mode URLStatus) (bool, interface{}) {
 	var matchPath, method string
 
+	//If url-rewrite middleware was used, call response middleware of original path and not of rewritten path
+	// context variable UrlRewritePath is set by rewrite middleware
 	if mode == TransformedJQResponse || mode == HeaderInjectedResponse || mode == TransformedResponse {
 		matchPath = ctxGetUrlRewritePath(r)
 		method = ctxGetRequestMethod(r)

--- a/looping_test.go
+++ b/looping_test.go
@@ -88,6 +88,46 @@ func TestLooping(t *testing.T) {
 		}...)
 	})
 
+	t.Run("Test multiple url rewrites", func(t *testing.T) {
+		buildAndLoadAPI(func(spec *APISpec) {
+			version := spec.VersionData.Versions["v1"]
+			json.Unmarshal([]byte(`{
+                "use_extended_paths": true,
+                "extended_paths": {
+			"internal": [{
+                        	"path": "/hidden_path",
+                        	"method": "GET"
+                    	}],
+			"url_rewrites": [{
+                        	"path": "/test",
+                        	"match_pattern": "/test",
+                        	"method": "GET",
+				"rewrite_to":"tyk://self/hidden_path_1"
+                    	},{
+                        	"path": "/hidden_path_1",
+                        	"match_pattern": "/hidden_path_1",
+                        	"method": "GET",
+				"rewrite_to":"tyk://self/hidden_path_2"
+                    	},{
+                        	"path": "/hidden_path_2",
+                        	"match_pattern": "/hidden_path_2",
+                        	"method": "GET",
+				"rewrite_to":"/upstream"
+		    	}]
+                }
+            }`), &version)
+
+			spec.VersionData.Versions["v1"] = version
+			spec.Proxy.ListenPath = "/"
+		})
+
+		//addHeaders := map[string]string{"X-Test": "test", "X-Internal": "test"}
+
+		ts.Run(t, []test.TestCase{
+			{Method: "GET", Path: "/test", BodyMatch: `"Url":"/upstream"`},
+		}...)
+	})
+
 	t.Run("Loop to another API", func(t *testing.T) {
 		buildAndLoadAPI(func(spec *APISpec) {
 			spec.APIID = "testid"


### PR DESCRIPTION
Fixes #2195

Every middleware call CheckSpecMathesStatus() to check if middlewares are set for the path.

In case of url-rewrite, path set in ctxGetUrlRewritePath was used, which stores value of original path before url-write. That variable was used to run response middleware of the original path and not of the rewritten path

But in case of looping feature, we want to run request middlewares of the rewritten path as well. So I changed the code to use ctxGetUrlRewritePath only in case of response middleware and use r.url.Path otherwise.

