### PR TITLE
Make sure there can only be one Access-Control-Allow-Origin header in HTTP response

### DIFF
--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -343,6 +343,10 @@ func singleJoiningSlash(a, b string, disableStripSlash bool) string {
 }
 
 func copyHeader(dst, src http.Header) {
+	if val := dst.Get(http.CanonicalHeaderKey("Access-Control-Allow-Origin")); len(val) > 0 {
+		src.Del("Access-Control-Allow-Origin")
+	}
+
 	for k, vv := range src {
 		for _, v := range vv {
 			dst.Add(k, v)

--- a/reverse_proxy_test.go
+++ b/reverse_proxy_test.go
@@ -22,6 +22,41 @@ import (
 	"github.com/TykTechnologies/tyk/request"
 )
 
+func TestCopyHeader_NoDuplicateCORSHeaders(t *testing.T) {
+
+	makeHeaders := func(withCORS bool) http.Header {
+
+		var h = http.Header{}
+
+		h.Set("Vary", "Origin")
+		h.Set("Location", "https://tyk.io")
+
+		if withCORS {
+			h.Set("Access-Control-Allow-Origin", "tyk.io")
+		}
+
+		return h
+	}
+
+	tests := []struct {
+		src, dst http.Header
+	}{
+		{makeHeaders(true), makeHeaders(false)},
+		{makeHeaders(true), makeHeaders(true)},
+		{makeHeaders(false), makeHeaders(true)},
+	}
+
+	for _, v := range tests {
+		copyHeader(v.dst, v.src)
+
+		val := v.dst["Access-Control-Allow-Origin"]
+		if n := len(val); n != 1 {
+			t.Fatalf("%s found %d times", "Access-Control-Allow-Origin", n)
+		}
+	}
+
+}
+
 func TestReverseProxyRetainHost(t *testing.T) {
 	target, _ := url.Parse("http://target-host.com/targetpath")
 	cases := []struct {


### PR DESCRIPTION
 Fixes https://github.com/TykTechnologies/tyk/issues/2199

Also see https://www.w3.org/TR/cors/#resource-sharing-check

The value of `Access-Control-Allow-Origin` in the proxy target's header takes precedence