### PR TITLE
Make maximum gRPC message size configurable

### DIFF
--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -257,6 +257,12 @@
         },
         "python_version": {
           "type": "string"
+        },
+        "grpc_recv_max_size": {
+          "type": "integer"
+        },
+        "grpc_send_max_size": {
+          "type": "integer"
         }
       }
     },

--- a/config/config.go
+++ b/config/config.go
@@ -214,6 +214,8 @@ type ServiceDiscoveryConf struct {
 type CoProcessConfig struct {
 	EnableCoProcess     bool   `json:"enable_coprocess"`
 	CoProcessGRPCServer string `json:"coprocess_grpc_server"`
+	GRPCRecvMaxSize     int    `json:"grpc_recv_max_size"`
+	GRPCSendMaxSize     int    `json:"grpc_send_max_size"`
 	PythonPathPrefix    string `json:"python_path_prefix"`
 	PythonVersion       string `json:"python_version"`
 }

--- a/coprocess/grpc/coprocess_grpc_test.go
+++ b/coprocess/grpc/coprocess_grpc_test.go
@@ -353,12 +353,23 @@ func TestGRPCDispatch(t *testing.T) {
 		})
 	})
 
-	t.Run("Post Hook with long message", func(t *testing.T) {
+	t.Run("Post Hook with allowed message length", func(t *testing.T) {
 		s := randStringBytes(20000000)
 		ts.Run(t, test.TestCase{
 			Path:    "/grpc-test-api-3/",
 			Method:  http.MethodGet,
 			Code:    http.StatusOK,
+			Headers: headers,
+			Data:    s,
+		})
+	})
+
+	t.Run("Post Hook with with unallowed message length", func(t *testing.T) {
+		s := randStringBytes(150000000)
+		ts.Run(t, test.TestCase{
+			Path:    "/grpc-test-api-3/",
+			Method:  http.MethodGet,
+			Code:    http.StatusInternalServerError,
 			Headers: headers,
 			Data:    s,
 		})

--- a/coprocess/grpc/coprocess_grpc_test.go
+++ b/coprocess/grpc/coprocess_grpc_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io/ioutil"
+	"math/rand"
 	"mime/multipart"
 	"net"
 	"net/http"
@@ -396,4 +397,16 @@ func BenchmarkGRPCDispatch(b *testing.B) {
 			})
 		}
 	})
+}
+
+const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func randStringBytes(n int) string {
+	b := make([]byte, n)
+
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+
+	return string(b)
 }

--- a/gateway/coprocess_grpc.go
+++ b/gateway/coprocess_grpc.go
@@ -72,13 +72,29 @@ func (d *GRPCDispatcher) Reload() {}
 // HandleMiddlewareCache isn't used by gRPC.
 func (d *GRPCDispatcher) HandleMiddlewareCache(b *apidef.BundleManifest, basePath string) {}
 
+func grpcCallOpts() grpc.DialOption {
+	recvSize := config.Global().CoProcessOptions.GRPCRecvMaxSize
+	sendSize := config.Global().CoProcessOptions.GRPCSendMaxSize
+	if recvSize > 0 && sendSize > 0 {
+		return grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(recvSize),
+			grpc.MaxCallSendMsgSize(sendSize),
+		)
+	}
+	return grpc.WithDefaultCallOptions()
+}
+
 // NewGRPCDispatcher wraps all the actions needed for this CP.
 func NewGRPCDispatcher() (coprocess.Dispatcher, error) {
 	if config.Global().CoProcessOptions.CoProcessGRPCServer == "" {
 		return nil, errors.New("No gRPC URL is set")
 	}
 	var err error
-	grpcConnection, err = grpc.Dial("", grpc.WithInsecure(), grpc.WithDialer(dialer))
+	grpcConnection, err = grpc.Dial("",
+		grpcCallOpts(),
+		grpc.WithInsecure(),
+		grpc.WithDialer(dialer),
+	)
 	grpcClient = coprocess.NewDispatcherClient(grpcConnection)
 
 	if err != nil {

--- a/gateway/coprocess_grpc.go
+++ b/gateway/coprocess_grpc.go
@@ -75,13 +75,14 @@ func (d *GRPCDispatcher) HandleMiddlewareCache(b *apidef.BundleManifest, basePat
 func grpcCallOpts() grpc.DialOption {
 	recvSize := config.Global().CoProcessOptions.GRPCRecvMaxSize
 	sendSize := config.Global().CoProcessOptions.GRPCSendMaxSize
-	if recvSize > 0 && sendSize > 0 {
-		return grpc.WithDefaultCallOptions(
-			grpc.MaxCallRecvMsgSize(recvSize),
-			grpc.MaxCallSendMsgSize(sendSize),
-		)
+	var opts []grpc.CallOption
+	if recvSize > 0 {
+		opts = append(opts, grpc.MaxCallRecvMsgSize(recvSize))
 	}
-	return grpc.WithDefaultCallOptions()
+	if sendSize > 0 {
+		opts = append(opts, grpc.MaxCallRecvMsgSize(sendSize))
+	}
+	return grpc.WithDefaultCallOptions(opts...)
 }
 
 // NewGRPCDispatcher wraps all the actions needed for this CP.

--- a/gateway/mw_strip_auth_test.go
+++ b/gateway/mw_strip_auth_test.go
@@ -2,7 +2,6 @@ package gateway
 
 import (
 	"fmt"
-	"math/rand"
 	"net/http"
 	"net/url"
 	"testing"
@@ -14,18 +13,6 @@ type TestAuth struct {
 	apidef.AuthConfig
 	HeaderKey  string
 	QueryParam string
-}
-
-const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-
-func randStringBytes(n int) string {
-	b := make([]byte, n)
-
-	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
-	}
-
-	return string(b)
 }
 
 func testPrepareStripAuthStripFromHeaders() ([]string, []TestAuth) {

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -985,3 +985,14 @@ YGivtXBGXk1hlVYlje1RB+W6RQuDAegI5h8vl8pYJS9JQH0wjatsDaE=
 `
 
 const jwtSecret = "9879879878787878"
+const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func randStringBytes(n int) string {
+	b := make([]byte, n)
+
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+
+	return string(b)
+}


### PR DESCRIPTION
Potential fix for #2203 

This introduces two new parameters in `tyk.conf`:
```json
{
  "grpc_recv_max_size": 100000,
  "grpc_send_max_size": 100000
}
```
When no parameter is set (and both parameters equal `0`), we call `WithDefaultCallOptions` so default values are used.
The value is a number of bytes.