### PR TITLE
add json tag to skip (un)marshalling for MatchRegexp

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -171,7 +171,7 @@ type URLRewriteMeta struct {
 	MatchPattern string           `bson:"match_pattern" json:"match_pattern"`
 	RewriteTo    string           `bson:"rewrite_to" json:"rewrite_to"`
 	Triggers     []RoutingTrigger `bson:"triggers" json:"triggers"`
-	MatchRegexp  *regexp.Regexp
+	MatchRegexp  *regexp.Regexp   `json:"-"`
 }
 
 type VirtualMeta struct {


### PR DESCRIPTION
`MatchRegexp` is meant to be an internal value used for caching the regexp of `match_pattern` not controlled by the user