### PR TITLE
Bug/2211 fix strip path

### DIFF
--- a/handler_success.go
+++ b/handler_success.go
@@ -309,8 +309,8 @@ func (s *SuccessHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) *http
 	// Make sure we get the correct target URL
 	if s.Spec.Proxy.StripListenPath {
 		log.Debug("Stripping: ", s.Spec.Proxy.ListenPath)
-		r.URL.Path = strings.Replace(r.URL.Path, s.Spec.Proxy.ListenPath, "", 1)
-		r.URL.RawPath = strings.Replace(r.URL.RawPath, s.Spec.Proxy.ListenPath, "", 1)
+		r.URL.Path = strings.TrimPrefix(r.URL.Path, s.Spec.Proxy.ListenPath)
+		r.URL.RawPath = strings.TrimPrefix(r.URL.RawPath, s.Spec.Proxy.ListenPath)
 		log.Debug("Upstream Path is: ", r.URL.Path)
 	}
 


### PR DESCRIPTION
Fixes #2211 

Previously, strings.Replace() method was used to strip the `listen_path`.
So when URL rewrite plugin was used to call an endpoint that contained `listen_path` anywhere in it's path,  it was getting removed.

To fix this I replaced  `strings.Replace()` with `strings.TrimPrefix()`