### PR TITLE
Read log browser response body if compressed

### DIFF
--- a/handler_success.go
+++ b/handler_success.go
@@ -193,6 +193,8 @@ func (s *SuccessHandler) RecordHit(r *http.Request, timing int64, code int, resp
 			// mw_redis_cache instead? is there a reason not
 			// to include that in the analytics?
 			if responseCopy != nil {
+				responseCopy.Body = respBodyReader(r, responseCopy)
+
 				// Get the wire format representation
 				var wireFormatRes bytes.Buffer
 				responseCopy.Write(&wireFormatRes)

--- a/res_handler_transform.go
+++ b/res_handler_transform.go
@@ -39,6 +39,8 @@ func respBodyReader(req *http.Request, resp *http.Response) io.ReadCloser {
 			log.Error("Body decompression error:", err)
 			return ioutil.NopCloser(bytes.NewReader(nil))
 		}
+		resp.ContentLength = 0 // represents unknown length
+		defer reader.Close()
 		return reader
 	case "deflate":
 		return flate.NewReader(resp.Body)

--- a/res_handler_transform.go
+++ b/res_handler_transform.go
@@ -39,10 +39,15 @@ func respBodyReader(req *http.Request, resp *http.Response) io.ReadCloser {
 			log.Error("Body decompression error:", err)
 			return ioutil.NopCloser(bytes.NewReader(nil))
 		}
-		resp.ContentLength = 0 // represents unknown length
-		defer reader.Close()
+
+		// represents unknown length
+		resp.ContentLength = 0
+
 		return reader
 	case "deflate":
+		// represents unknown length
+		resp.ContentLength = 0
+
 		return flate.NewReader(resp.Body)
 	}
 


### PR DESCRIPTION
Fixes https://github.com/TykTechnologies/tyk-analytics/issues/1215

The solution is to read compressed body.