### PR TITLE
Added support of WSDL import

### DIFF
--- a/apidef/importer/importer.go
+++ b/apidef/importer/importer.go
@@ -27,7 +27,7 @@ func GetImporterForSource(source APIImporterSource) (APIImporter, error) {
 	case SwaggerSource:
 		return &SwaggerAST{}, nil
 	case WSDLSource:
-		return &WSDL{}, nil
+		return &WSDLDef{}, nil
 	default:
 		return nil, errors.New("source not matched, failing")
 	}

--- a/apidef/importer/importer.go
+++ b/apidef/importer/importer.go
@@ -26,6 +26,8 @@ func GetImporterForSource(source APIImporterSource) (APIImporter, error) {
 		return &BluePrintAST{}, nil
 	case SwaggerSource:
 		return &SwaggerAST{}, nil
+	case WSDLSource:
+		return &WSDL{}, nil
 	default:
 		return nil, errors.New("source not matched, failing")
 	}

--- a/apidef/importer/wsdl.go
+++ b/apidef/importer/wsdl.go
@@ -3,11 +3,12 @@ package importer
 import (
 	"encoding/xml"
 	"errors"
-	"github.com/TykTechnologies/tyk/apidef"
-	uuid "github.com/satori/go.uuid"
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/TykTechnologies/tyk/apidef"
+	uuid "github.com/satori/go.uuid"
 )
 
 const WSDLSource APIImporterSource = "wsdl"

--- a/apidef/importer/wsdl.go
+++ b/apidef/importer/wsdl.go
@@ -1,0 +1,227 @@
+package importer
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	NS_WSDL   = "http://schemas.xmlsoap.org/wsdl/"
+	NS_SOAP   = "http://schemas.xmlsoap.org/wsdl/soap/"
+	NS_SOAP12 = "http://schemas.xmlsoap.org/wsdl/soap12/"
+	NS_HTTP   = "http://schemas.xmlsoap.org/wsdl/http/"
+)
+
+type WSDL struct {
+	Services []*WSDLService `xml:"http://schemas.xmlsoap.org/wsdl/ service"`
+	Bindings []*WSDLBinding `xml:"http://schemas.xmlsoap.org/wsdl/ binding"`
+}
+
+type WSDLService struct {
+	Name  string      `xml:"name,attr"`
+	Ports []*WSDLPort `xml:"http://schemas.xmlsoap.org/wsdl/ port"`
+}
+
+type WSDLPort struct {
+	Name    string      `xml:"name,attr"`
+	Binding string      `xml:"binding,attr"`
+	Address WSDLAddress `xml:"address"`
+}
+
+type WSDLAddress struct {
+	Location string `xml:"location,attr"`
+}
+
+type WSDLBinding struct {
+	Name       string           `xml:"name,attr"`
+	Operations []*WSDLOperation `xml:"http://schemas.xmlsoap.org/wsdl/ operation"`
+	Protocol   string
+	Method     string
+}
+
+type WSDLOperation struct {
+	Name string `xml:"name,attr"`
+	Meta OperationMeta
+}
+
+type OperationMeta struct {
+	SoapAction string
+	Endpoint   string
+}
+
+func (b *WSDLBinding) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	//Get value of name attribute
+	for _, attr := range start.Attr {
+		if attr.Name.Local == "name" {
+			b.Name = attr.Value
+			break
+		}
+	}
+
+	if b.Name == "" {
+		return errors.New("Binding name is empty. Malformed wsdl")
+	}
+
+	fmt.Println("Parsing binding:", b.Name)
+
+	//Fetch protocol specific data
+	//If soap/soap12 is used, set Method to POST
+	//If http is used, get value of verb attribute
+	//If any other protocol is used, then skip
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			fmt.Println("d.Token returned err")
+			return err
+		}
+
+		switch t := tok.(type) {
+		case xml.StartElement:
+			{
+				fmt.Println("Found startElement")
+				switch t.Name.Local {
+				case "binding":
+					{
+						fmt.Print("Found binding elementi of ")
+						switch t.Name.Space {
+						case NS_SOAP, NS_SOAP12:
+							{
+								fmt.Println("soap/sopa12 protocol")
+								if t.Name.Space == NS_SOAP {
+									b.Protocol = "soap"
+								} else {
+									b.Protocol = "soap12"
+								}
+
+								var transport string
+								for _, attr := range t.Attr {
+									if attr.Name.Local == "transport" {
+										transport = attr.Value
+										break
+									}
+								}
+								parts := strings.Split(transport, "/")
+								if parts[len(parts)-1] == "http" {
+									b.Method = "POST"
+								}
+							}
+						case NS_HTTP:
+							{
+								fmt.Println("http protocol")
+								b.Protocol = "http"
+								for _, attr := range t.Attr {
+									if attr.Name.Local == "verb" {
+										b.Method = attr.Value
+										break
+									}
+								}
+
+							}
+						default:
+							{
+								//Unsportted binding protocol is used
+								fmt.Println("Unsupported binding protocol is used:", t.Name.Space, ":", t.Name.Local)
+								return nil
+							}
+						}
+					}
+				case "operation":
+					{
+						if t.Name.Space == NS_WSDL && b.Method != "" {
+							op := new(WSDLOperation)
+							if err := d.DecodeElement(op, &t); err != nil {
+								return err
+							}
+							b.Operations = append(b.Operations, op)
+						}
+					}
+				default:
+					{
+						if err := d.Skip(); err != nil {
+							return err
+						}
+					}
+				}
+			}
+		case xml.EndElement:
+			{
+				fmt.Println("Found endElement")
+				if t.Name.Space == NS_WSDL && t.Name.Local == "binding" {
+					return nil
+				}
+			}
+		}
+	}
+}
+
+func (op *WSDLOperation) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	for _, attr := range start.Attr {
+		if attr.Name.Local == "name" {
+			op.Name = attr.Value
+			break
+		}
+	}
+
+	if op.Name == "" {
+		return errors.New("Operation name is empty. Malformed wsdl")
+	}
+
+	fmt.Println("Parsing operation", op.Name)
+
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			return err
+		}
+
+		switch t := tok.(type) {
+		case xml.StartElement:
+			{
+				fmt.Println("Found startElement")
+				if t.Name.Local == "operation" {
+					switch t.Name.Space {
+					case NS_SOAP, NS_SOAP12:
+						{
+							for _, attr := range t.Attr {
+								if attr.Name.Local == "soapAction" {
+									op.Meta.SoapAction = attr.Value
+									break
+								}
+							}
+						}
+					case NS_HTTP:
+						{
+							for _, attr := range t.Attr {
+								if attr.Name.Local == "location" {
+									op.Meta.Endpoint = attr.Value
+									break
+								}
+							}
+						}
+					default:
+						{
+							fmt.Println("Unsupported protocol. Skipping")
+							return nil
+						}
+					}
+
+				} else {
+					if err := d.Skip(); err != nil {
+						return err
+					}
+				}
+			}
+		case xml.EndElement:
+			{
+				fmt.Println("Found EndElement")
+
+				if t.Name.Space == NS_WSDL && t.Name.Local == "operation" {
+					return nil
+				}
+			}
+		}
+
+	}
+}

--- a/apidef/importer/wsdl_test.go
+++ b/apidef/importer/wsdl_test.go
@@ -7,14 +7,22 @@ import (
 
 type testWSDLInput struct {
 	wsdlDefinition string
+	isInvalidInput bool
 	data           []testWSDLData
 }
 
 type testWSDLData struct {
 	servicePortNameMapping map[string]string
-	method                 string
 	noOfEndpoints          int
+	endpoints              []endpointData
 	returnErr              bool
+}
+
+type endpointData struct {
+	method       string
+	path         string
+	matchPattern string
+	rewritePath  string
 }
 
 var testData = []testWSDLInput{
@@ -23,27 +31,171 @@ var testData = []testWSDLInput{
 		data: []testWSDLData{
 			{
 				servicePortNameMapping: map[string]string{"HolidayService2": "HolidayService2Soap"},
-				method:                 "POST",
 				noOfEndpoints:          6,
-				returnErr:              false,
+				endpoints: []endpointData{
+					{
+						path:         "HolidayService2/GetHolidaysForDateRange",
+						method:       "POST",
+						matchPattern: "HolidayService2/GetHolidaysForDateRange",
+						rewritePath:  "http://www.holidaywebservice.com/HolidayService_v2/HolidayService2.asmx",
+					},
+					{
+						path:         "HolidayService2/GetCountriesAvailable",
+						method:       "POST",
+						matchPattern: "HolidayService2/GetCountriesAvailable",
+						rewritePath:  "http://www.holidaywebservice.com/HolidayService_v2/HolidayService2.asmx",
+					},
+					{
+						path:         "HolidayService2/GetHolidaysAvailable",
+						method:       "POST",
+						matchPattern: "HolidayService2/GetHolidaysAvailable",
+						rewritePath:  "http://www.holidaywebservice.com/HolidayService_v2/HolidayService2.asmx",
+					},
+					{
+						path:         "HolidayService2/GetHolidaysForMonth",
+						method:       "POST",
+						matchPattern: "HolidayService2/GetHolidaysForMonth",
+						rewritePath:  "http://www.holidaywebservice.com/HolidayService_v2/HolidayService2.asmx",
+					},
+					{
+						path:         "HolidayService2/GetHolidaysForYear",
+						method:       "POST",
+						matchPattern: "HolidayService2/GetHolidaysForYear",
+						rewritePath:  "http://www.holidaywebservice.com/HolidayService_v2/HolidayService2.asmx",
+					},
+					{
+						path:         "HolidayService2/GetHolidayDate",
+						method:       "POST",
+						matchPattern: "HolidayService2/GetHolidayDate",
+						rewritePath:  "http://www.holidaywebservice.com/HolidayService_v2/HolidayService2.asmx",
+					},
+				},
 			},
 			{
 				servicePortNameMapping: map[string]string{"HolidayService2": "HolidayService2HttpGet"},
-				method:                 "GET",
 				noOfEndpoints:          6,
-				returnErr:              false,
+				endpoints: []endpointData{
+					{
+						path:         "HolidayService2/GetHolidaysForDateRange",
+						method:       "GET",
+						matchPattern: "(/GetHolidaysForDateRange.*)",
+						rewritePath:  "http://www.holidaywebservice.com/HolidayService_v2/HolidayService2.asmx$1",
+					},
+					{
+						path:         "HolidayService2/GetCountriesAvailable",
+						method:       "GET",
+						matchPattern: "(/GetCountriesAvailable.*)",
+						rewritePath:  "http://www.holidaywebservice.com/HolidayService_v2/HolidayService2.asmx$1",
+					},
+					{
+						path:         "HolidayService2/GetHolidaysAvailable",
+						method:       "GET",
+						matchPattern: "(/GetHolidaysAvailable.*)",
+						rewritePath:  "http://www.holidaywebservice.com/HolidayService_v2/HolidayService2.asmx$1",
+					},
+					{
+						path:         "HolidayService2/GetHolidaysForMonth",
+						method:       "GET",
+						matchPattern: "(/GetHolidaysForMonth.*)",
+						rewritePath:  "http://www.holidaywebservice.com/HolidayService_v2/HolidayService2.asmx$1",
+					},
+					{
+						path:         "HolidayService2/GetHolidaysForYear",
+						method:       "GET",
+						matchPattern: "(/GetHolidaysForYear.*)",
+						rewritePath:  "http://www.holidaywebservice.com/HolidayService_v2/HolidayService2.asmx$1",
+					},
+					{
+						path:         "HolidayService2/GetHolidayDate",
+						method:       "GET",
+						matchPattern: "(/GetHolidayDate.*)",
+						rewritePath:  "http://www.holidaywebservice.com/HolidayService_v2/HolidayService2.asmx$1",
+					},
+				},
 			},
 			{
 				servicePortNameMapping: map[string]string{"HolidayService2": "HolidayService2HttpPost"},
-				method:                 "POST",
 				noOfEndpoints:          6,
-				returnErr:              false,
+				endpoints: []endpointData{
+					{
+						path:         "HolidayService2/GetHolidaysForDateRange",
+						method:       "POST",
+						matchPattern: "(/GetHolidaysForDateRange.*)",
+						rewritePath:  "http://www.holidaywebservice.com/HolidayService_v2/HolidayService2.asmx$1",
+					},
+					{
+						path:         "HolidayService2/GetCountriesAvailable",
+						method:       "POST",
+						matchPattern: "(/GetCountriesAvailable.*)",
+						rewritePath:  "http://www.holidaywebservice.com/HolidayService_v2/HolidayService2.asmx$1",
+					},
+					{
+						path:         "HolidayService2/GetHolidaysAvailable",
+						method:       "POST",
+						matchPattern: "(/GetHolidaysAvailable.*)",
+						rewritePath:  "http://www.holidaywebservice.com/HolidayService_v2/HolidayService2.asmx$1",
+					},
+					{
+						path:         "HolidayService2/GetHolidaysForMonth",
+						method:       "POST",
+						matchPattern: "(/GetHolidaysForMonth.*)",
+						rewritePath:  "http://www.holidaywebservice.com/HolidayService_v2/HolidayService2.asmx$1",
+					},
+					{
+						path:         "HolidayService2/GetHolidaysForYear",
+						method:       "POST",
+						matchPattern: "(/GetHolidaysForYear.*)",
+						rewritePath:  "http://www.holidaywebservice.com/HolidayService_v2/HolidayService2.asmx$1",
+					},
+					{
+						path:         "HolidayService2/GetHolidayDate",
+						method:       "POST",
+						matchPattern: "(/GetHolidayDate.*)",
+						rewritePath:  "http://www.holidaywebservice.com/HolidayService_v2/HolidayService2.asmx$1",
+					},
+				},
 			},
 			{
 				servicePortNameMapping: map[string]string{"HolidayService2": ""},
-				method:                 "POST",
 				noOfEndpoints:          6,
-				returnErr:              false,
+				endpoints: []endpointData{
+					{
+						path:         "HolidayService2/GetHolidaysForDateRange",
+						method:       "POST",
+						matchPattern: "HolidayService2/GetHolidaysForDateRange",
+						rewritePath:  "http://www.holidaywebservice.com/HolidayService_v2/HolidayService2.asmx",
+					},
+					{
+						path:         "HolidayService2/GetCountriesAvailable",
+						method:       "POST",
+						matchPattern: "HolidayService2/GetCountriesAvailable",
+						rewritePath:  "http://www.holidaywebservice.com/HolidayService_v2/HolidayService2.asmx",
+					},
+					{
+						path:         "HolidayService2/GetHolidaysAvailable",
+						method:       "POST",
+						matchPattern: "HolidayService2/GetHolidaysAvailable",
+						rewritePath:  "http://www.holidaywebservice.com/HolidayService_v2/HolidayService2.asmx",
+					},
+					{
+						path:         "HolidayService2/GetHolidaysForMonth",
+						method:       "POST",
+						matchPattern: "HolidayService2/GetHolidaysForMonth",
+						rewritePath:  "http://www.holidaywebservice.com/HolidayService_v2/HolidayService2.asmx",
+					},
+					{
+						path:         "HolidayService2/GetHolidaysForYear",
+						method:       "POST",
+						matchPattern: "HolidayService2/GetHolidaysForYear",
+						rewritePath:  "http://www.holidaywebservice.com/HolidayService_v2/HolidayService2.asmx",
+					},
+					{
+						path:         "HolidayService2/GetHolidayDate",
+						method:       "POST",
+						matchPattern: "HolidayService2/GetHolidayDate",
+						rewritePath:  "http://www.holidaywebservice.com/HolidayService_v2/HolidayService2.asmx",
+					},
+				},
 			},
 			{
 				//invalid portName is provided
@@ -64,27 +216,42 @@ var testData = []testWSDLInput{
 			},
 		},
 	},
+	{
+		//Invalid input
+		wsdlDefinition: "<ghfsdfjadhfkadf>",
+		isInvalidInput: true,
+	},
+	{
+		//Invalid input
+		wsdlDefinition: wsdl_2_0_example,
+		isInvalidInput: true,
+	},
 }
 
 func TestToAPIDefinition_WSDL(t *testing.T) {
 	for _, input := range testData {
-		wsdl_imp := &WSDL{}
-
-		buff := bytes.NewBufferString(holidayService)
+		wsdl_imp := &WSDLDef{}
+		buff := bytes.NewBufferString(input.wsdlDefinition)
 
 		err := wsdl_imp.LoadFrom(buff)
 		if err != nil {
-			t.Fatal(err)
+			if input.isInvalidInput {
+				continue
+			} else {
+				t.Fatal(err)
+			}
 		}
 
 		for _, data := range input.data {
 			wsdl_imp.SetServicePortMapping(data.servicePortNameMapping)
 			def, err := wsdl_imp.ToAPIDefinition("testOrg", "http://test.com", false)
 
-			if err != nil && !data.returnErr {
-				t.Fatal(err)
-			} else {
-				return
+			if err != nil {
+				if !data.returnErr {
+					t.Fatal(err)
+				} else {
+					continue
+				}
 			}
 
 			if def.VersionData.NotVersioned {
@@ -104,12 +271,25 @@ func TestToAPIDefinition_WSDL(t *testing.T) {
 				t.Fatalf("Expected %v endpoints, found %v\n", data.noOfEndpoints, len(v.ExtendedPaths.TrackEndpoints))
 			}
 
-			for _, v := range v.ExtendedPaths.TrackEndpoints {
-				if v.Method != data.method {
-					t.Fatalf("Invalid endpoint method")
+			for _, endpoint := range data.endpoints {
+				for _, rewriteData := range v.ExtendedPaths.URLRewrite {
+
+					if rewriteData.Path == endpoint.path {
+						if rewriteData.Method != endpoint.method {
+							t.Fatalf("Invalid endpoint method. Expected %s found %s", endpoint.method, rewriteData.Method)
+						}
+
+						if rewriteData.MatchPattern != endpoint.matchPattern {
+							t.Fatalf("Invalid matchPattern. Expected %s found %s", endpoint.matchPattern, rewriteData.MatchPattern)
+						}
+
+						if rewriteData.RewriteTo != endpoint.rewritePath {
+							t.Fatalf("Invalid rewrite path. Expected %s found %s", endpoint.rewritePath, rewriteData.RewriteTo)
+						}
+					}
+
 				}
 			}
-
 		}
 	}
 }
@@ -808,4 +988,68 @@ var smtpExample string = `<?xml version="1.0"?>
     </types>
 </definitions>
 
+`
+
+var wsdl_2_0_example = `
+<?xml version = "1.0" encoding = "utf-8" ?>
+<description
+    xmlns = "http://www.w3.org/ns/wsdl"
+    targetNamespace = "http://yoursite.com/MyService"
+    xmlns:tns = "http://yoursite.com/MyService"
+    xmlns:stns = "http://yoursite.com/MyService/schema"
+    xmlns:wsoap = "http://www.w3.org/ns/wsdl/soap"
+    xmlns:soap = "http://www.w3.org/2003/05/soap-envelope"
+    xmlns:wsdlx = "http://www.w3.org/ns/wsdl-extensions">
+ 
+    <documentation>
+        This document describes my Service. You can find additional information in
+        the following web page: http://yoursite.com/MyService/help.html
+    </documentation>
+ 
+    <types>
+        <xs:schema
+        xmlns:xs = "http://www.w3.org/2001/XMLSchema"
+        targetNamespace = "http://yoursite.com/MyService/schema"
+        xmlns = "http://yoursite.com/MyService/schema" >
+            <xs:element name = "checkServiceStatus" type="tCheckServiceStatus" />
+            <xs:complexType name = "tCheckServiceStatus" >
+                <xs:sequence>
+                    <xs:element name = "checkDate" type = "xs:date" />
+                    <xs:element name = "serviceName" type = "xs:string" />
+                </xs:sequence>
+            </xs:complexType>
+            <xs:element name = " checkServiceStatusResponse" type = "xs:double" />
+            <xs:element name = "dataError" type = "xs:string" />
+        </xs:schema>
+    </types>
+ 
+    <interface name = "myServiceInterface">
+        <fault name = "dataFault" element = "stns:dataError" />
+        <operation name = "checkServiceStatusOp"
+            pattern = "http://www.w3.org/ns/wsdl/in-out"
+            style= " http://www.w3.org/ns/wsdl/style/iri"
+            wsdlx:safe = "true">
+            <input messageLabel = "In" element = "stns:checkServiceStatus" />
+            <output messageLabel = "Out" element = "stns:checkServiceStatusResponse"/>
+            <outfault messageLabel = "Out" ref = "tns:dataFault" />
+        </operation>
+    </interface>
+ 
+    <binding name = "myServiceInterfaceSOAPBinding" 
+          interface = "tns:myServiceInterface"
+          type = "http://www.w3.org/ns/wsdl/soap"
+          wsoap:protocol = "http://www.w3.org/2003/05/soap/bindings/HTTP/">
+        <operation ref = "tns:checkServiceStatusOp" 
+      wsoap:mep = "http://www.w3.org/2003/05/soap/mep/soap-response"/>
+        <fault ref = "tns:dataFault" 
+      wsoap:code = "soap:Sender"/>
+    </binding>
+ 
+    <service name = "myService" 
+       interface = "tns:myServiceInterface">
+        <endpoint name = "myServiceEndpoint" 
+               binding = "tns:myServiceInterfaceSOAPBinding"
+               address = "http://yoursite.com/MyService"/>
+    </service>
+</description>
 `

--- a/apidef/importer/wsdl_test.go
+++ b/apidef/importer/wsdl_test.go
@@ -1,0 +1,811 @@
+package importer
+
+import (
+	"bytes"
+	"testing"
+)
+
+type testWSDLInput struct {
+	wsdlDefinition string
+	data           []testWSDLData
+}
+
+type testWSDLData struct {
+	servicePortNameMapping map[string]string
+	method                 string
+	noOfEndpoints          int
+	returnErr              bool
+}
+
+var testData = []testWSDLInput{
+	{
+		wsdlDefinition: holidayService,
+		data: []testWSDLData{
+			{
+				servicePortNameMapping: map[string]string{"HolidayService2": "HolidayService2Soap"},
+				method:                 "POST",
+				noOfEndpoints:          6,
+				returnErr:              false,
+			},
+			{
+				servicePortNameMapping: map[string]string{"HolidayService2": "HolidayService2HttpGet"},
+				method:                 "GET",
+				noOfEndpoints:          6,
+				returnErr:              false,
+			},
+			{
+				servicePortNameMapping: map[string]string{"HolidayService2": "HolidayService2HttpPost"},
+				method:                 "POST",
+				noOfEndpoints:          6,
+				returnErr:              false,
+			},
+			{
+				servicePortNameMapping: map[string]string{"HolidayService2": ""},
+				method:                 "POST",
+				noOfEndpoints:          6,
+				returnErr:              false,
+			},
+			{
+				//invalid portName is provided
+				//should throw an error
+				servicePortNameMapping: map[string]string{"HolidayService2": "something"},
+				returnErr:              true,
+			},
+		},
+	},
+	{
+		//smtp protocol is not supported
+		//should throw error
+		wsdlDefinition: smtpExample,
+		data: []testWSDLData{
+			{
+				servicePortNameMapping: map[string]string{"StockQuoteService": "StockQuotePort"},
+				returnErr:              true,
+			},
+		},
+	},
+}
+
+func TestToAPIDefinition_WSDL(t *testing.T) {
+	for _, input := range testData {
+		wsdl_imp := &WSDL{}
+
+		buff := bytes.NewBufferString(holidayService)
+
+		err := wsdl_imp.LoadFrom(buff)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, data := range input.data {
+			wsdl_imp.SetServicePortMapping(data.servicePortNameMapping)
+			def, err := wsdl_imp.ToAPIDefinition("testOrg", "http://test.com", false)
+
+			if err != nil && !data.returnErr {
+				t.Fatal(err)
+			} else {
+				return
+			}
+
+			if def.VersionData.NotVersioned {
+				t.Fatal("WSDL import must always be versioned")
+			}
+
+			if len(def.VersionData.Versions) > 1 {
+				t.Fatal("There should only be one version")
+			}
+
+			v, ok := def.VersionData.Versions["1.0.0"]
+			if !ok {
+				t.Fatal("Version could not be found")
+			}
+
+			if len(v.ExtendedPaths.TrackEndpoints) != data.noOfEndpoints {
+				t.Fatalf("Expected %v endpoints, found %v\n", data.noOfEndpoints, len(v.ExtendedPaths.TrackEndpoints))
+			}
+
+			for _, v := range v.ExtendedPaths.TrackEndpoints {
+				if v.Method != data.method {
+					t.Fatalf("Invalid endpoint method")
+				}
+			}
+
+		}
+	}
+}
+
+var holidayService string = `
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:tm="http://microsoft.com/wsdl/mime/textMatching/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:tns="http://www.holidaywebservice.com/HolidayService_v2/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:s="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" targetNamespace="http://www.holidaywebservice.com/HolidayService_v2/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+  <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Web service that calculates holiday dates. (Version 2.0.1)</wsdl:documentation>
+  <wsdl:types>
+    <s:schema elementFormDefault="qualified" targetNamespace="http://www.holidaywebservice.com/HolidayService_v2/">
+      <s:element name="GetCountriesAvailable">
+        <s:complexType/>
+      </s:element>
+      <s:element name="GetCountriesAvailableResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="GetCountriesAvailableResult" type="tns:ArrayOfCountryCode"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="ArrayOfCountryCode">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="CountryCode" nillable="true" type="tns:CountryCode"/>
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="CountryCode">
+        <s:complexContent mixed="false">
+          <s:extension base="tns:CodeDescriptionBase"/>
+        </s:complexContent>
+      </s:complexType>
+      <s:complexType name="CodeDescriptionBase" abstract="true">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Code" type="s:string"/>
+          <s:element minOccurs="0" maxOccurs="1" name="Description" type="s:string"/>
+        </s:sequence>
+      </s:complexType>
+      <s:element name="GetHolidaysAvailable">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="1" maxOccurs="1" name="countryCode" type="tns:Country"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:simpleType name="Country">
+        <s:restriction base="s:string">
+          <s:enumeration value="Canada"/>
+          <s:enumeration value="GreatBritain"/>
+          <s:enumeration value="IrelandNorthern"/>
+          <s:enumeration value="IrelandRepublicOf"/>
+          <s:enumeration value="Scotland"/>
+          <s:enumeration value="UnitedStates"/>
+        </s:restriction>
+      </s:simpleType>
+      <s:element name="GetHolidaysAvailableResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="GetHolidaysAvailableResult" type="tns:ArrayOfHolidayCode"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="ArrayOfHolidayCode">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="HolidayCode" nillable="true" type="tns:HolidayCode"/>
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="HolidayCode">
+        <s:complexContent mixed="false">
+          <s:extension base="tns:CodeDescriptionBase"/>
+        </s:complexContent>
+      </s:complexType>
+      <s:element name="GetHolidayDate">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="1" maxOccurs="1" name="countryCode" type="tns:Country"/>
+            <s:element minOccurs="0" maxOccurs="1" name="holidayCode" type="s:string"/>
+            <s:element minOccurs="1" maxOccurs="1" name="year" type="s:int"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="GetHolidayDateResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="1" maxOccurs="1" name="GetHolidayDateResult" type="s:dateTime"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="GetHolidaysForDateRange">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="1" maxOccurs="1" name="countryCode" type="tns:Country"/>
+            <s:element minOccurs="1" maxOccurs="1" name="startDate" type="s:dateTime"/>
+            <s:element minOccurs="1" maxOccurs="1" name="endDate" type="s:dateTime"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="GetHolidaysForDateRangeResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="GetHolidaysForDateRangeResult" type="tns:ArrayOfHoliday"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="ArrayOfHoliday">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="Holiday" nillable="true" type="tns:Holiday"/>
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="Holiday">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Country" type="tns:Country"/>
+          <s:element minOccurs="0" maxOccurs="1" name="HolidayCode" type="s:string"/>
+          <s:element minOccurs="0" maxOccurs="1" name="Descriptor" type="s:string"/>
+          <s:element minOccurs="1" maxOccurs="1" name="HolidayType" type="tns:HolidayType"/>
+          <s:element minOccurs="1" maxOccurs="1" name="DateType" type="tns:HolidayDateType"/>
+          <s:element minOccurs="1" maxOccurs="1" name="BankHoliday" type="tns:BankHoliday"/>
+          <s:element minOccurs="1" maxOccurs="1" name="Date" type="s:dateTime"/>
+          <s:element minOccurs="0" maxOccurs="1" name="RelatedHolidayCode" type="s:string"/>
+          <s:element minOccurs="0" maxOccurs="1" name="ApplicableRegions" type="tns:ArrayOfRegionCode"/>
+        </s:sequence>
+      </s:complexType>
+      <s:simpleType name="HolidayType">
+        <s:restriction base="s:string">
+          <s:enumeration value="Notable"/>
+          <s:enumeration value="Religious"/>
+          <s:enumeration value="NotableReligious"/>
+          <s:enumeration value="Other"/>
+        </s:restriction>
+      </s:simpleType>
+      <s:simpleType name="HolidayDateType">
+        <s:restriction base="s:string">
+          <s:enumeration value="Observed"/>
+          <s:enumeration value="Actual"/>
+          <s:enumeration value="ObservedActual"/>
+        </s:restriction>
+      </s:simpleType>
+      <s:simpleType name="BankHoliday">
+        <s:restriction base="s:string">
+          <s:enumeration value="Recognized"/>
+          <s:enumeration value="NotRecognized"/>
+        </s:restriction>
+      </s:simpleType>
+      <s:complexType name="ArrayOfRegionCode">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="RegionCode" nillable="true" type="tns:RegionCode"/>
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="RegionCode">
+        <s:complexContent mixed="false">
+          <s:extension base="tns:CodeDescriptionBase"/>
+        </s:complexContent>
+      </s:complexType>
+      <s:element name="GetHolidaysForYear">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="1" maxOccurs="1" name="countryCode" type="tns:Country"/>
+            <s:element minOccurs="1" maxOccurs="1" name="year" type="s:int"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="GetHolidaysForYearResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="GetHolidaysForYearResult" type="tns:ArrayOfHoliday"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="GetHolidaysForMonth">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="1" maxOccurs="1" name="countryCode" type="tns:Country"/>
+            <s:element minOccurs="1" maxOccurs="1" name="year" type="s:int"/>
+            <s:element minOccurs="1" maxOccurs="1" name="month" type="s:int"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="GetHolidaysForMonthResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="GetHolidaysForMonthResult" type="tns:ArrayOfHoliday"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="ArrayOfCountryCode" nillable="true" type="tns:ArrayOfCountryCode"/>
+      <s:element name="ArrayOfHolidayCode" nillable="true" type="tns:ArrayOfHolidayCode"/>
+      <s:element name="dateTime" type="s:dateTime"/>
+      <s:element name="ArrayOfHoliday" nillable="true" type="tns:ArrayOfHoliday"/>
+    </s:schema>
+  </wsdl:types>
+  <wsdl:message name="GetCountriesAvailableSoapIn">
+    <wsdl:part name="parameters" element="tns:GetCountriesAvailable"/>
+  </wsdl:message>
+  <wsdl:message name="GetCountriesAvailableSoapOut">
+    <wsdl:part name="parameters" element="tns:GetCountriesAvailableResponse"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidaysAvailableSoapIn">
+    <wsdl:part name="parameters" element="tns:GetHolidaysAvailable"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidaysAvailableSoapOut">
+    <wsdl:part name="parameters" element="tns:GetHolidaysAvailableResponse"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidayDateSoapIn">
+    <wsdl:part name="parameters" element="tns:GetHolidayDate"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidayDateSoapOut">
+    <wsdl:part name="parameters" element="tns:GetHolidayDateResponse"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidaysForDateRangeSoapIn">
+    <wsdl:part name="parameters" element="tns:GetHolidaysForDateRange"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidaysForDateRangeSoapOut">
+    <wsdl:part name="parameters" element="tns:GetHolidaysForDateRangeResponse"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidaysForYearSoapIn">
+    <wsdl:part name="parameters" element="tns:GetHolidaysForYear"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidaysForYearSoapOut">
+    <wsdl:part name="parameters" element="tns:GetHolidaysForYearResponse"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidaysForMonthSoapIn">
+    <wsdl:part name="parameters" element="tns:GetHolidaysForMonth"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidaysForMonthSoapOut">
+    <wsdl:part name="parameters" element="tns:GetHolidaysForMonthResponse"/>
+  </wsdl:message>
+  <wsdl:message name="GetCountriesAvailableHttpGetIn"/>
+  <wsdl:message name="GetCountriesAvailableHttpGetOut">
+    <wsdl:part name="Body" element="tns:ArrayOfCountryCode"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidaysAvailableHttpGetIn">
+    <wsdl:part name="countryCode" type="s:string"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidaysAvailableHttpGetOut">
+    <wsdl:part name="Body" element="tns:ArrayOfHolidayCode"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidayDateHttpGetIn">
+    <wsdl:part name="countryCode" type="s:string"/>
+    <wsdl:part name="holidayCode" type="s:string"/>
+    <wsdl:part name="year" type="s:string"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidayDateHttpGetOut">
+    <wsdl:part name="Body" element="tns:dateTime"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidaysForDateRangeHttpGetIn">
+    <wsdl:part name="countryCode" type="s:string"/>
+    <wsdl:part name="startDate" type="s:string"/>
+    <wsdl:part name="endDate" type="s:string"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidaysForDateRangeHttpGetOut">
+    <wsdl:part name="Body" element="tns:ArrayOfHoliday"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidaysForYearHttpGetIn">
+    <wsdl:part name="countryCode" type="s:string"/>
+    <wsdl:part name="year" type="s:string"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidaysForYearHttpGetOut">
+    <wsdl:part name="Body" element="tns:ArrayOfHoliday"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidaysForMonthHttpGetIn">
+    <wsdl:part name="countryCode" type="s:string"/>
+    <wsdl:part name="year" type="s:string"/>
+    <wsdl:part name="month" type="s:string"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidaysForMonthHttpGetOut">
+    <wsdl:part name="Body" element="tns:ArrayOfHoliday"/>
+  </wsdl:message>
+  <wsdl:message name="GetCountriesAvailableHttpPostIn"/>
+  <wsdl:message name="GetCountriesAvailableHttpPostOut">
+    <wsdl:part name="Body" element="tns:ArrayOfCountryCode"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidaysAvailableHttpPostIn">
+    <wsdl:part name="countryCode" type="s:string"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidaysAvailableHttpPostOut">
+    <wsdl:part name="Body" element="tns:ArrayOfHolidayCode"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidayDateHttpPostIn">
+    <wsdl:part name="countryCode" type="s:string"/>
+    <wsdl:part name="holidayCode" type="s:string"/>
+    <wsdl:part name="year" type="s:string"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidayDateHttpPostOut">
+    <wsdl:part name="Body" element="tns:dateTime"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidaysForDateRangeHttpPostIn">
+    <wsdl:part name="countryCode" type="s:string"/>
+    <wsdl:part name="startDate" type="s:string"/>
+    <wsdl:part name="endDate" type="s:string"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidaysForDateRangeHttpPostOut">
+    <wsdl:part name="Body" element="tns:ArrayOfHoliday"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidaysForYearHttpPostIn">
+    <wsdl:part name="countryCode" type="s:string"/>
+    <wsdl:part name="year" type="s:string"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidaysForYearHttpPostOut">
+    <wsdl:part name="Body" element="tns:ArrayOfHoliday"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidaysForMonthHttpPostIn">
+    <wsdl:part name="countryCode" type="s:string"/>
+    <wsdl:part name="year" type="s:string"/>
+    <wsdl:part name="month" type="s:string"/>
+  </wsdl:message>
+  <wsdl:message name="GetHolidaysForMonthHttpPostOut">
+    <wsdl:part name="Body" element="tns:ArrayOfHoliday"/>
+  </wsdl:message>
+  <wsdl:portType name="HolidayService2Soap">
+    <wsdl:operation name="GetCountriesAvailable">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Get the available countries.</wsdl:documentation>
+      <wsdl:input message="tns:GetCountriesAvailableSoapIn"/>
+      <wsdl:output message="tns:GetCountriesAvailableSoapOut"/>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidaysAvailable">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Get the available holidays for a specified country.</wsdl:documentation>
+      <wsdl:input message="tns:GetHolidaysAvailableSoapIn"/>
+      <wsdl:output message="tns:GetHolidaysAvailableSoapOut"/>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidayDate">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Get the date of a specific holiday.</wsdl:documentation>
+      <wsdl:input message="tns:GetHolidayDateSoapIn"/>
+      <wsdl:output message="tns:GetHolidayDateSoapOut"/>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidaysForDateRange">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Get the holidays for a date range.</wsdl:documentation>
+      <wsdl:input message="tns:GetHolidaysForDateRangeSoapIn"/>
+      <wsdl:output message="tns:GetHolidaysForDateRangeSoapOut"/>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidaysForYear">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Get the holidays for an entire year.</wsdl:documentation>
+      <wsdl:input message="tns:GetHolidaysForYearSoapIn"/>
+      <wsdl:output message="tns:GetHolidaysForYearSoapOut"/>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidaysForMonth">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Get the holidays for a specific month.</wsdl:documentation>
+      <wsdl:input message="tns:GetHolidaysForMonthSoapIn"/>
+      <wsdl:output message="tns:GetHolidaysForMonthSoapOut"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:portType name="HolidayService2HttpGet">
+    <wsdl:operation name="GetCountriesAvailable">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Get the available countries.</wsdl:documentation>
+      <wsdl:input message="tns:GetCountriesAvailableHttpGetIn"/>
+      <wsdl:output message="tns:GetCountriesAvailableHttpGetOut"/>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidaysAvailable">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Get the available holidays for a specified country.</wsdl:documentation>
+      <wsdl:input message="tns:GetHolidaysAvailableHttpGetIn"/>
+      <wsdl:output message="tns:GetHolidaysAvailableHttpGetOut"/>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidayDate">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Get the date of a specific holiday.</wsdl:documentation>
+      <wsdl:input message="tns:GetHolidayDateHttpGetIn"/>
+      <wsdl:output message="tns:GetHolidayDateHttpGetOut"/>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidaysForDateRange">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Get the holidays for a date range.</wsdl:documentation>
+      <wsdl:input message="tns:GetHolidaysForDateRangeHttpGetIn"/>
+      <wsdl:output message="tns:GetHolidaysForDateRangeHttpGetOut"/>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidaysForYear">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Get the holidays for an entire year.</wsdl:documentation>
+      <wsdl:input message="tns:GetHolidaysForYearHttpGetIn"/>
+      <wsdl:output message="tns:GetHolidaysForYearHttpGetOut"/>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidaysForMonth">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Get the holidays for a specific month.</wsdl:documentation>
+      <wsdl:input message="tns:GetHolidaysForMonthHttpGetIn"/>
+      <wsdl:output message="tns:GetHolidaysForMonthHttpGetOut"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:portType name="HolidayService2HttpPost">
+    <wsdl:operation name="GetCountriesAvailable">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Get the available countries.</wsdl:documentation>
+      <wsdl:input message="tns:GetCountriesAvailableHttpPostIn"/>
+      <wsdl:output message="tns:GetCountriesAvailableHttpPostOut"/>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidaysAvailable">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Get the available holidays for a specified country.</wsdl:documentation>
+      <wsdl:input message="tns:GetHolidaysAvailableHttpPostIn"/>
+      <wsdl:output message="tns:GetHolidaysAvailableHttpPostOut"/>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidayDate">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Get the date of a specific holiday.</wsdl:documentation>
+      <wsdl:input message="tns:GetHolidayDateHttpPostIn"/>
+      <wsdl:output message="tns:GetHolidayDateHttpPostOut"/>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidaysForDateRange">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Get the holidays for a date range.</wsdl:documentation>
+      <wsdl:input message="tns:GetHolidaysForDateRangeHttpPostIn"/>
+      <wsdl:output message="tns:GetHolidaysForDateRangeHttpPostOut"/>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidaysForYear">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Get the holidays for an entire year.</wsdl:documentation>
+      <wsdl:input message="tns:GetHolidaysForYearHttpPostIn"/>
+      <wsdl:output message="tns:GetHolidaysForYearHttpPostOut"/>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidaysForMonth">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Get the holidays for a specific month.</wsdl:documentation>
+      <wsdl:input message="tns:GetHolidaysForMonthHttpPostIn"/>
+      <wsdl:output message="tns:GetHolidaysForMonthHttpPostOut"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="HolidayService2Soap" type="tns:HolidayService2Soap">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="GetCountriesAvailable">
+      <soap:operation soapAction="http://www.holidaywebservice.com/HolidayService_v2/GetCountriesAvailable" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidaysAvailable">
+      <soap:operation soapAction="http://www.holidaywebservice.com/HolidayService_v2/GetHolidaysAvailable" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidayDate">
+      <soap:operation soapAction="http://www.holidaywebservice.com/HolidayService_v2/GetHolidayDate" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidaysForDateRange">
+      <soap:operation soapAction="http://www.holidaywebservice.com/HolidayService_v2/GetHolidaysForDateRange" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidaysForYear">
+      <soap:operation soapAction="http://www.holidaywebservice.com/HolidayService_v2/GetHolidaysForYear" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidaysForMonth">
+      <soap:operation soapAction="http://www.holidaywebservice.com/HolidayService_v2/GetHolidaysForMonth" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="HolidayService2Soap12" type="tns:HolidayService2Soap">
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="GetCountriesAvailable">
+      <soap12:operation soapAction="http://www.holidaywebservice.com/HolidayService_v2/GetCountriesAvailable" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidaysAvailable">
+      <soap12:operation soapAction="http://www.holidaywebservice.com/HolidayService_v2/GetHolidaysAvailable" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidayDate">
+      <soap12:operation soapAction="http://www.holidaywebservice.com/HolidayService_v2/GetHolidayDate" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidaysForDateRange">
+      <soap12:operation soapAction="http://www.holidaywebservice.com/HolidayService_v2/GetHolidaysForDateRange" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidaysForYear">
+      <soap12:operation soapAction="http://www.holidaywebservice.com/HolidayService_v2/GetHolidaysForYear" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidaysForMonth">
+      <soap12:operation soapAction="http://www.holidaywebservice.com/HolidayService_v2/GetHolidaysForMonth" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="HolidayService2HttpGet" type="tns:HolidayService2HttpGet">
+    <http:binding verb="GET"/>
+    <wsdl:operation name="GetCountriesAvailable">
+      <http:operation location="/GetCountriesAvailable"/>
+      <wsdl:input>
+        <http:urlEncoded/>
+      </wsdl:input>
+      <wsdl:output>
+        <mime:mimeXml part="Body"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidaysAvailable">
+      <http:operation location="/GetHolidaysAvailable"/>
+      <wsdl:input>
+        <http:urlEncoded/>
+      </wsdl:input>
+      <wsdl:output>
+        <mime:mimeXml part="Body"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidayDate">
+      <http:operation location="/GetHolidayDate"/>
+      <wsdl:input>
+        <http:urlEncoded/>
+      </wsdl:input>
+      <wsdl:output>
+        <mime:mimeXml part="Body"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidaysForDateRange">
+      <http:operation location="/GetHolidaysForDateRange"/>
+      <wsdl:input>
+        <http:urlEncoded/>
+      </wsdl:input>
+      <wsdl:output>
+        <mime:mimeXml part="Body"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidaysForYear">
+      <http:operation location="/GetHolidaysForYear"/>
+      <wsdl:input>
+        <http:urlEncoded/>
+      </wsdl:input>
+      <wsdl:output>
+        <mime:mimeXml part="Body"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidaysForMonth">
+      <http:operation location="/GetHolidaysForMonth"/>
+      <wsdl:input>
+        <http:urlEncoded/>
+      </wsdl:input>
+      <wsdl:output>
+        <mime:mimeXml part="Body"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="HolidayService2HttpPost" type="tns:HolidayService2HttpPost">
+    <http:binding verb="POST"/>
+    <wsdl:operation name="GetCountriesAvailable">
+      <http:operation location="/GetCountriesAvailable"/>
+      <wsdl:input>
+        <mime:content type="application/x-www-form-urlencoded"/>
+      </wsdl:input>
+      <wsdl:output>
+        <mime:mimeXml part="Body"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidaysAvailable">
+      <http:operation location="/GetHolidaysAvailable"/>
+      <wsdl:input>
+        <mime:content type="application/x-www-form-urlencoded"/>
+      </wsdl:input>
+      <wsdl:output>
+        <mime:mimeXml part="Body"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidayDate">
+      <http:operation location="/GetHolidayDate"/>
+      <wsdl:input>
+        <mime:content type="application/x-www-form-urlencoded"/>
+      </wsdl:input>
+      <wsdl:output>
+        <mime:mimeXml part="Body"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidaysForDateRange">
+      <http:operation location="/GetHolidaysForDateRange"/>
+      <wsdl:input>
+        <mime:content type="application/x-www-form-urlencoded"/>
+      </wsdl:input>
+      <wsdl:output>
+        <mime:mimeXml part="Body"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidaysForYear">
+      <http:operation location="/GetHolidaysForYear"/>
+      <wsdl:input>
+        <mime:content type="application/x-www-form-urlencoded"/>
+      </wsdl:input>
+      <wsdl:output>
+        <mime:mimeXml part="Body"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="GetHolidaysForMonth">
+      <http:operation location="/GetHolidaysForMonth"/>
+      <wsdl:input>
+        <mime:content type="application/x-www-form-urlencoded"/>
+      </wsdl:input>
+      <wsdl:output>
+        <mime:mimeXml part="Body"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="HolidayService2">
+    <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Web service that calculates holiday dates. (Version 2.0.1)</wsdl:documentation>
+    <wsdl:port name="HolidayService2Soap" binding="tns:HolidayService2Soap">
+      <soap:address location="http://www.holidaywebservice.com/HolidayService_v2/HolidayService2.asmx"/>
+    </wsdl:port>
+    <wsdl:port name="HolidayService2Soap12" binding="tns:HolidayService2Soap12">
+      <soap12:address location="http://www.holidaywebservice.com/HolidayService_v2/HolidayService2.asmx"/>
+    </wsdl:port>
+    <wsdl:port name="HolidayService2HttpGet" binding="tns:HolidayService2HttpGet">
+      <http:address location="http://www.holidaywebservice.com/HolidayService_v2/HolidayService2.asmx"/>
+    </wsdl:port>
+    <wsdl:port name="HolidayService2HttpPost" binding="tns:HolidayService2HttpPost">
+      <http:address location="http://www.holidaywebservice.com/HolidayService_v2/HolidayService2.asmx"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>
+`
+
+var smtpExample string = `<?xml version="1.0"?>
+<definitions name="StockQuote"
+          targetNamespace="http://example.com/stockquote.wsdl"
+          xmlns:tns="http://example.com/stockquote.wsdl"
+          xmlns:xsd1="http://example.com/stockquote.xsd"
+          xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+          xmlns="http://schemas.xmlsoap.org/wsdl/">
+
+    <message name="SubscribeToQuotes">
+        <part name="body" element="xsd1:SubscribeToQuotes"/>
+        <part name="subscribeheader" element="xsd1:SubscriptionHeader"/>
+    </message>
+
+    <portType name="StockQuotePortType">
+        <operation name="SubscribeToQuotes">
+           <input message="tns:SubscribeToQuotes"/>
+        </operation>
+    </portType>
+
+    <binding name="StockQuoteSoap" type="tns:StockQuotePortType">
+        <soap:binding style="document" transport="http://example.com/smtp"/>
+        <operation name="SubscribeToQuotes">
+           <input message="tns:SubscribeToQuotes">
+               <soap:body parts="body" use="literal"/>
+               <soap:header message="tns:SubscribeToQuotes" part="subscribeheader" use="literal"/>
+           </input>
+        </operation>
+    </binding>
+
+    <service name="StockQuoteService">
+        <port name="StockQuotePort" binding="tns:StockQuoteSoap">
+           <soap:address location="mailto:subscribe@example.com"/>
+        </port>
+    </service>
+
+    <types>
+        <schema targetNamespace="http://example.com/stockquote.xsd"
+               xmlns="http://www.w3.org/2000/10/XMLSchema">
+           <element name="SubscribeToQuotes">
+               <complexType>
+                   <all>
+                       <element name="tickerSymbol" type="string"/>
+                   </all>
+               </complexType>
+           </element>
+           <element name="SubscriptionHeader" type="uriReference"/>
+        </schema>
+    </types>
+</definitions>
+
+`

--- a/cli/importer/importer.go
+++ b/cli/importer/importer.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	cmdName = "import"
-	cmdDesc = "Imports a BluePrint/Swagger file"
+	cmdDesc = "Imports a BluePrint/Swagger/WSDL file"
 )
 
 var (
@@ -30,6 +30,8 @@ type Importer struct {
 	input          *string
 	swaggerMode    *bool
 	bluePrintMode  *bool
+	wsdlMode       *bool
+	portNames      *string
 	createAPI      *bool
 	orgID          *string
 	upstreamTarget *string
@@ -45,9 +47,11 @@ func init() {
 // AddTo initializes an importer object.
 func AddTo(app *kingpin.Application) {
 	cmd := app.Command(cmdName, cmdDesc)
-	imp.input = cmd.Arg("input file", "e.g. blueprint.json, swagger.json, etc.").String()
+	imp.input = cmd.Arg("input file", "e.g. blueprint.json, swagger.json, service.wsdl etc.").String()
 	imp.swaggerMode = cmd.Flag("swagger", "Use Swagger mode").Bool()
 	imp.bluePrintMode = cmd.Flag("blueprint", "Use BluePrint mode").Bool()
+	imp.wsdlMode = cmd.Flag("wsdl", "Use WSDL mode").Bool()
+	imp.portNames = cmd.Flag("port-names", "Specify port name of each service in the WSDL file. Input format is comma separated list of serviceName:portName").String()
 	imp.createAPI = cmd.Flag("create-api", "Creates a new API definition from the blueprint").Bool()
 	imp.orgID = cmd.Flag("org-id", "assign the API Definition to this org_id (required with create-api").String()
 	imp.upstreamTarget = cmd.Flag("upstream-target", "set the upstream target for the definition").PlaceHolder("URL").String()
@@ -71,12 +75,54 @@ func (i *Importer) Import(ctx *kingpin.ParseContext) (err error) {
 			log.Fatal(err)
 			os.Exit(1)
 		}
+	} else if *i.wsdlMode {
+		err = i.handleWSDLMode()
+		if err != nil {
+			log.Fatal(err)
+			os.Exit(1)
+		}
 	} else {
 		log.Fatal(errUnknownMode)
 		os.Exit(1)
 	}
 	os.Exit(0)
 	return nil
+}
+
+func (i *Importer) validateInput() error {
+
+	if *i.createAPI {
+		if *i.upstreamTarget == "" || *i.orgID == "" {
+			return fmt.Errorf("No upstream target or org ID defined, these are both required")
+		}
+	} else {
+		if *i.forAPI == "" {
+			return fmt.Errorf("If adding to an API, the path to the definition must be listed")
+		}
+
+		if *i.asVersion == "" {
+			return fmt.Errorf("No version defined for this import operation, please set an import ID using the --as-version flag")
+		}
+	}
+
+	return nil
+}
+
+func (i *Importer) processPortNames() map[string]string {
+	p := make(map[string]string)
+
+	if *i.portNames == "" {
+		return p
+	}
+
+	pairs := strings.Split(*i.portNames, ",")
+
+	for _, v := range pairs {
+		components := strings.Split(v, ":")
+		p[components[0]] = components[1]
+	}
+
+	return p
 }
 
 func (i *Importer) handleBluePrintMode() error {
@@ -186,6 +232,52 @@ func (i *Importer) handleSwaggerMode() error {
 	return nil
 }
 
+func (i *Importer) handleWSDLMode() error {
+	var def *apidef.APIDefinition
+
+	//Process Input
+	if err := i.validateInput(); err != nil {
+		return err
+	}
+	serviceportMapping := i.processPortNames()
+
+	//Load WSDL file
+	w, err := i.wsdlLoadFile(*i.input)
+	if err != nil {
+		return fmt.Errorf("File load error: %v", err)
+	}
+
+	w.SetServicePortMapping(serviceportMapping)
+
+	if *i.createAPI {
+		//Create new API
+		def, err = w.ToAPIDefinition(*i.orgID, *i.upstreamTarget, *i.asMock)
+		if err != nil {
+			return fmt.Errorf("Failed to create API Defintition from file")
+		}
+	} else {
+		//Add into existing API
+		def, err = i.apiDefLoadFile(*i.forAPI)
+		if err != nil {
+			return fmt.Errorf("failed to load and decode file data for API Definition: %v", err)
+		}
+
+		versionData, err := w.ConvertIntoApiVersion(*i.asMock)
+		if err != nil {
+			return fmt.Errorf("Conversion into API Def failed: %v", err)
+		}
+
+		if err := w.InsertIntoAPIDefinitionAsVersion(versionData, def, *i.asVersion); err != nil {
+			return fmt.Errorf("Insertion failed: %v", err)
+		}
+
+	}
+
+	i.printDef(def)
+
+	return nil
+}
+
 func (i *Importer) printDef(def *apidef.APIDefinition) {
 	asJSON, err := json.MarshalIndent(def, "", "    ")
 	if err != nil {
@@ -213,6 +305,24 @@ func (i *Importer) swaggerLoadFile(path string) (*importer.SwaggerAST, error) {
 	}
 
 	return swagger.(*importer.SwaggerAST), nil
+}
+
+func (i *Importer) wsdlLoadFile(path string) (*importer.WSDL, error) {
+	wsdl, err := importer.GetImporterForSource(importer.WSDLSource)
+	if err != nil {
+		return nil, err
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	if err := wsdl.LoadFrom(f); err != nil {
+		return nil, err
+	}
+
+	return wsdl.(*importer.WSDL), nil
 }
 
 func (i *Importer) bluePrintLoadFile(path string) (*importer.BluePrintAST, error) {

--- a/cli/importer/importer.go
+++ b/cli/importer/importer.go
@@ -307,7 +307,7 @@ func (i *Importer) swaggerLoadFile(path string) (*importer.SwaggerAST, error) {
 	return swagger.(*importer.SwaggerAST), nil
 }
 
-func (i *Importer) wsdlLoadFile(path string) (*importer.WSDL, error) {
+func (i *Importer) wsdlLoadFile(path string) (*importer.WSDLDef, error) {
 	wsdl, err := importer.GetImporterForSource(importer.WSDLSource)
 	if err != nil {
 		return nil, err
@@ -322,7 +322,7 @@ func (i *Importer) wsdlLoadFile(path string) (*importer.WSDL, error) {
 		return nil, err
 	}
 
-	return wsdl.(*importer.WSDL), nil
+	return wsdl.(*importer.WSDLDef), nil
 }
 
 func (i *Importer) bluePrintLoadFile(path string) (*importer.BluePrintAST, error) {

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -11,8 +11,9 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-
+	"path/filepath"
 	"runtime"
+	"strconv"
 
 	"strings"
 	"sync"


### PR DESCRIPTION
User can now import WSDL file to create API definition. 
[#Reference](https://github.com/TykTechnologies/tyk-analytics/issues/1160)

**Supported features:**
1. WSDL file with multiple services
2. SOAP/SOAP12 binding
3. HTTP binding

**Generated API Definition will be as follows:**
1. API `name` is same as that of the service name. If WSDL contains multiple services, then the name of the first service in the file will be used.

2. `listen-path` of the API will be 

> "/service name/"

   If WSDL contains multiple services, then the name of the first service in the file will be used.

3. For each supported operation, an endpoint will be created. Endpoint will have the path

> /service_name/end_path

In case of **SOAP/SOAP12** binding, _end_path_ will be operation name.
In case of **HTTP** binding, _end_path_ will be value of `location` attribute of the operation. 

4. Each endpoint will use url-rewrite middleware to direct the request to the upstream. This was necessary to support multiple services

If service has multiple Ports type, name of the Port needs to be specified. If Port name is not provided then first Port of the service is used.

https://github.com/TykTechnologies/tyk/issues/2255