### PR TITLE
Deprecate event_trigers_defunct, use event_triggers_defunct,

### DIFF
--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -328,6 +328,12 @@
         "null"
       ]
     },
+    "event_triggers_defunct": {
+      "type": [
+        "array",
+        "null"
+      ]
+    },
     "experimental_process_org_off_thread": {
       "type": "boolean"
     },

--- a/config/config.go
+++ b/config/config.go
@@ -285,7 +285,8 @@ type Config struct {
 	CoProcessOptions                  CoProcessConfig                       `json:"coprocess_options"`
 	HideGeneratorHeader               bool                                  `json:"hide_generator_header"`
 	EventHandlers                     apidef.EventHandlerMetaConfig         `json:"event_handlers"`
-	EventTriggers                     map[apidef.TykEvent][]TykEventHandler `json:"event_trigers_defunct"`
+	EventTriggers                     map[apidef.TykEvent][]TykEventHandler `json:"event_trigers_defunct"`  // Deprecated: Config.GetEventTriggers instead.
+	EventTriggersDefunct              map[apidef.TykEvent][]TykEventHandler `json:"event_triggers_defunct"` // Deprecated: Config.GetEventTriggers instead.
 	PIDFileLocation                   string                                `json:"pid_file_location"`
 	AllowInsecureConfigs              bool                                  `json:"allow_insecure_configs"`
 	PublicKeyPath                     string                                `json:"public_key_path"`
@@ -317,6 +318,25 @@ type Config struct {
 	DisableRegexpCache                bool                                  `json:"disable_regexp_cache"`
 	RegexpCacheExpire                 int32                                 `json:"regexp_cache_expire"`
 	HealthCheckEndpointName           string                                `json:"health_check_endpoint_name"`
+}
+
+// GetEventTriggers returns event triggers. There was a typo in the json tag.
+// To maintain backward compatibility, this solution is chosen.
+func (c Config) GetEventTriggers() map[apidef.TykEvent][]TykEventHandler {
+	if c.EventTriggersDefunct == nil {
+		return c.EventTriggers
+	}
+
+	if c.EventTriggers != nil {
+		log.Info("Both event_trigers_defunct and event_triggers_defunct are configured in the config," +
+			" event_triggers_defunct will be used.")
+	}
+
+	return c.EventTriggersDefunct
+}
+
+func (c *Config) SetEventTriggers(eventTriggers map[apidef.TykEvent][]TykEventHandler) {
+	c.EventTriggersDefunct = eventTriggers
 }
 
 type CertData struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -8,6 +8,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/TykTechnologies/tyk/apidef"
 )
 
 func TestDefaultValueAndWriteDefaultConf(t *testing.T) {
@@ -135,4 +137,50 @@ func TestConfigFiles(t *testing.T) {
 	if err := Load(paths, conf); err == nil {
 		t.Fatalf("Load with an invalid config did not error")
 	}
+}
+
+func TestConfig_GetEventTriggers(t *testing.T) {
+
+	assert := func(t *testing.T, config string, expected string) {
+		conf := &Config{}
+
+		f, err := ioutil.TempFile("", "tyk.conf")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer f.Close()
+
+		_, err = f.Write([]byte(config))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		paths := []string{f.Name()}
+
+		if err := Load(paths, conf); err != nil {
+			t.Fatal(err)
+		}
+
+		triggers := conf.GetEventTriggers()
+
+		if _, ok := triggers[apidef.TykEvent(expected)]; !ok || len(triggers) != 1 {
+			t.Fatal("Config is not loaded correctly")
+		}
+	}
+
+	t.Run("Deprecated configuration", func(t *testing.T) {
+		deprecated := `{"event_trigers_defunct": {"deprecated": []}}`
+		assert(t, deprecated, "deprecated")
+	})
+
+	t.Run("Current configuration", func(t *testing.T) {
+		current := `{"event_triggers_defunct": {"current": []}}`
+		assert(t, current, "current")
+	})
+
+	t.Run("Both configured", func(t *testing.T) {
+		both := `{"event_trigers_defunct": {"deprecated": []}, "event_triggers_defunct": {"current": []}}`
+		assert(t, both, "current")
+	})
+
 }

--- a/event_system.go
+++ b/event_system.go
@@ -154,7 +154,7 @@ func (s *APISpec) FireEvent(name apidef.TykEvent, meta interface{}) {
 }
 
 func FireSystemEvent(name apidef.TykEvent, meta interface{}) {
-	fireEvent(name, meta, config.Global().EventTriggers)
+	fireEvent(name, meta, config.Global().GetEventTriggers())
 }
 
 // LogMessageEventHandler is a sample Event Handler
@@ -212,5 +212,5 @@ func initGenericEventHandlers(conf *config.Config) {
 
 		}
 	}
-	conf.EventTriggers = handlers
+	conf.SetEventTriggers(handlers)
 }

--- a/event_system_test.go
+++ b/event_system_test.go
@@ -140,7 +140,7 @@ func TestLogMessageEventHandler(t *testing.T) {
 func TestInitGenericEventHandlers(t *testing.T) {
 	conf := prepareEventsConf()
 	initGenericEventHandlers(conf)
-	triggers := conf.EventTriggers
+	triggers := conf.GetEventTriggers()
 	if len(triggers) != 2 {
 		t.Fatal("EventTriggers length doesn't match")
 	}


### PR DESCRIPTION
This PR deprecates `event_trigers_defunct`, the current version will be `event_triggers_defunct`.

It maintain backward compatibility.

#Fixes #2228 