### PR TITLE
Allow enable HTTP profiling via config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -308,6 +308,7 @@ type Config struct {
 	ProxyDefaultTimeout               float64                               `json:"proxy_default_timeout"`
 	ProxySSLDisableRenegotiation      bool                                  `json:"proxy_ssl_disable_renegotiation"`
 	LogLevel                          string                                `json:"log_level"`
+	HTTPProfile                       bool                                  `json:"enable_http_profiler"`
 	Security                          SecurityConfig                        `json:"security"`
 	EnableKeyLogging                  bool                                  `json:"enable_key_logging"`
 	NewRelic                          NewRelicConfig                        `json:"newrelic"`

--- a/main.go
+++ b/main.go
@@ -376,7 +376,7 @@ func loadAPIEndpoints(muxer *mux.Router) {
 		mainLog.Info("Control API hostname set: ", hostname)
 	}
 
-	if *cli.HTTPProfile {
+	if *cli.HTTPProfile || config.Global().HTTPProfile {
 		muxer.HandleFunc("/debug/pprof/profile", pprof_http.Profile)
 		muxer.HandleFunc("/debug/pprof/{_:.*}", pprof_http.Index)
 	}


### PR DESCRIPTION
Added `enable_http_profiler` config option