### PR TITLE
Fix basic auth caching

### DIFF
--- a/api_loader.go
+++ b/api_loader.go
@@ -10,12 +10,10 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/gorilla/mux"
 	"github.com/justinas/alice"
-	cache "github.com/pmylund/go-cache"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
@@ -353,7 +351,7 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 			logger.Info("Checking security policy: OAuth")
 		}
 
-		if mwAppendEnabled(&authArray, &BasicAuthKeyIsValid{baseMid, cache.New(60*time.Second, 60*time.Minute), nil, nil}) {
+		if mwAppendEnabled(&authArray, &BasicAuthKeyIsValid{baseMid, nil, nil}) {
 			logger.Info("Checking security policy: Basic")
 		}
 

--- a/multiauth_test.go
+++ b/multiauth_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/justinas/alice"
 	"github.com/lonelycode/go-uuid/uuid"
-	cache "github.com/pmylund/go-cache"
 
 	"github.com/TykTechnologies/tyk/user"
 )
@@ -78,7 +77,7 @@ func getMultiAuthStandardAndBasicAuthChain(spec *APISpec) http.Handler {
 	chain := alice.New(mwList(
 		&IPWhiteListMiddleware{baseMid},
 		&IPBlackListMiddleware{BaseMiddleware: baseMid},
-		&BasicAuthKeyIsValid{baseMid, cache.New(60*time.Second, 60*time.Minute), nil, nil},
+		&BasicAuthKeyIsValid{baseMid, nil, nil},
 		&AuthKey{baseMid},
 		&VersionCheck{BaseMiddleware: baseMid},
 		&KeyExpired{baseMid},


### PR DESCRIPTION
Basic auth cache was initialized for every API on every API reload.
go-cache by itself consume quite lot of resources, when started in such amounts.

Fix https://github.com/TykTechnologies/tyk/issues/2238