### PR TITLE
consistent mw version order

### DIFF
--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -267,85 +267,37 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 	cacheStore.Connect()
 
 	var chain http.Handler
+	var chainArray []alice.Constructor
+	var authArray []alice.Constructor
 
 	if spec.UseKeylessAccess {
 		chainDef.Open = true
 		logger.Info("Checking security policy: Open")
+	}
 
-		// Add pre-process MW
-		chainArray := []alice.Constructor{}
-		handleCORS(&chainArray, spec)
+	handleCORS(&chainArray, spec)
 
-		for _, obj := range mwPreFuncs {
-			if mwDriver != apidef.OttoDriver {
+	for _, obj := range mwPreFuncs {
+		if mwDriver != apidef.OttoDriver {
 
-				coprocessLog.Debug("Registering coprocess middleware, hook name: ", obj.Name, "hook type: Pre", ", driver: ", mwDriver)
-				mwAppendEnabled(&chainArray, &CoProcessMiddleware{baseMid, coprocess.HookType_Pre, obj.Name, mwDriver})
-			} else {
-				chainArray = append(chainArray, createDynamicMiddleware(obj.Name, true, obj.RequireSession, baseMid))
-			}
+			coprocessLog.Debug("Registering coprocess middleware, hook name: ", obj.Name, "hook type: Pre", ", driver: ", mwDriver)
+			mwAppendEnabled(&chainArray, &CoProcessMiddleware{baseMid, coprocess.HookType_Pre, obj.Name, mwDriver})
+		} else {
+			chainArray = append(chainArray, createDynamicMiddleware(obj.Name, true, obj.RequireSession, baseMid))
 		}
+	}
 
-		mwAppendEnabled(&chainArray, &RateCheckMW{BaseMiddleware: baseMid})
-		mwAppendEnabled(&chainArray, &IPWhiteListMiddleware{BaseMiddleware: baseMid})
-		mwAppendEnabled(&chainArray, &IPBlackListMiddleware{BaseMiddleware: baseMid})
-		mwAppendEnabled(&chainArray, &CertificateCheckMW{BaseMiddleware: baseMid})
-		mwAppendEnabled(&chainArray, &OrganizationMonitor{BaseMiddleware: baseMid})
-		mwAppendEnabled(&chainArray, &RateLimitForAPI{BaseMiddleware: baseMid})
-		mwAppendEnabled(&chainArray, &ValidateJSON{BaseMiddleware: baseMid})
-		mwAppendEnabled(&chainArray, &MiddlewareContextVars{BaseMiddleware: baseMid})
-		mwAppendEnabled(&chainArray, &VersionCheck{BaseMiddleware: baseMid})
-		mwAppendEnabled(&chainArray, &RequestSizeLimitMiddleware{baseMid})
-		mwAppendEnabled(&chainArray, &TrackEndpointMiddleware{baseMid})
+	mwAppendEnabled(&chainArray, &RateCheckMW{BaseMiddleware: baseMid})
+	mwAppendEnabled(&chainArray, &IPWhiteListMiddleware{BaseMiddleware: baseMid})
+	mwAppendEnabled(&chainArray, &IPBlackListMiddleware{BaseMiddleware: baseMid})
+	mwAppendEnabled(&chainArray, &CertificateCheckMW{BaseMiddleware: baseMid})
+	mwAppendEnabled(&chainArray, &OrganizationMonitor{BaseMiddleware: baseMid})
+	mwAppendEnabled(&chainArray, &VersionCheck{BaseMiddleware: baseMid})
+	mwAppendEnabled(&chainArray, &RequestSizeLimitMiddleware{baseMid})
+	mwAppendEnabled(&chainArray, &MiddlewareContextVars{BaseMiddleware: baseMid})
+	mwAppendEnabled(&chainArray, &TrackEndpointMiddleware{baseMid})
 
-		mwAppendEnabled(&chainArray, &TransformMiddleware{baseMid})
-		mwAppendEnabled(&chainArray, &TransformJQMiddleware{baseMid})
-		mwAppendEnabled(&chainArray, &TransformHeaders{BaseMiddleware: baseMid})
-		mwAppendEnabled(&chainArray, &RedisCacheMiddleware{BaseMiddleware: baseMid, CacheStore: &cacheStore})
-		mwAppendEnabled(&chainArray, &VirtualEndpoint{BaseMiddleware: baseMid})
-		mwAppendEnabled(&chainArray, &URLRewriteMiddleware{BaseMiddleware: baseMid})
-		mwAppendEnabled(&chainArray, &TransformMethod{BaseMiddleware: baseMid})
-
-		for _, obj := range mwPostFuncs {
-			if mwDriver != apidef.OttoDriver {
-
-				coprocessLog.Debug("Registering coprocess middleware, hook name: ", obj.Name, "hook type: Post", ", driver: ", mwDriver)
-				mwAppendEnabled(&chainArray, &CoProcessMiddleware{baseMid, coprocess.HookType_Post, obj.Name, mwDriver})
-			} else {
-				chainArray = append(chainArray, createDynamicMiddleware(obj.Name, false, obj.RequireSession, baseMid))
-			}
-		}
-
-		// for KeyLessAccess we can't support rate limiting, versioning or access rules
-		chain = alice.New(chainArray...).Then(&DummyProxyHandler{SH: SuccessHandler{baseMid}})
-
-	} else {
-		var chainArray []alice.Constructor
-		var authArray []alice.Constructor
-
-		handleCORS(&chainArray, spec)
-
-		// Add pre-process MW
-		for _, obj := range mwPreFuncs {
-			if mwDriver != apidef.OttoDriver {
-
-				coprocessLog.Debug("Registering coprocess middleware, hook name: ", obj.Name, "hook type: Pre", ", driver: ", mwDriver)
-				mwAppendEnabled(&chainArray, &CoProcessMiddleware{baseMid, coprocess.HookType_Pre, obj.Name, mwDriver})
-			} else {
-				chainArray = append(chainArray, createDynamicMiddleware(obj.Name, true, obj.RequireSession, baseMid))
-			}
-		}
-
-		mwAppendEnabled(&chainArray, &RateCheckMW{BaseMiddleware: baseMid})
-		mwAppendEnabled(&chainArray, &IPWhiteListMiddleware{BaseMiddleware: baseMid})
-		mwAppendEnabled(&chainArray, &IPBlackListMiddleware{BaseMiddleware: baseMid})
-		mwAppendEnabled(&chainArray, &CertificateCheckMW{BaseMiddleware: baseMid})
-		mwAppendEnabled(&chainArray, &OrganizationMonitor{BaseMiddleware: baseMid})
-		mwAppendEnabled(&chainArray, &VersionCheck{BaseMiddleware: baseMid})
-		mwAppendEnabled(&chainArray, &RequestSizeLimitMiddleware{baseMid})
-		mwAppendEnabled(&chainArray, &MiddlewareContextVars{BaseMiddleware: baseMid})
-		mwAppendEnabled(&chainArray, &TrackEndpointMiddleware{baseMid})
-
+	if !spec.UseKeylessAccess {
 		// Select the keying method to use for setting session states
 		if mwAppendEnabled(&authArray, &Oauth2KeyExists{baseMid}) {
 			logger.Info("Checking security policy: OAuth")
@@ -379,7 +331,6 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 		}
 
 		if ottoAuth {
-
 			logger.Info("----> Checking security policy: JS Plugin")
 
 			authArray = append(authArray, createDynamicMiddleware(mwAuthCheckFunc.Name, true, false, baseMid))
@@ -393,7 +344,6 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 		chainArray = append(chainArray, authArray...)
 
 		for _, obj := range mwPostAuthCheckFuncs {
-
 			coprocessLog.Debug("Registering coprocess middleware, hook name: ", obj.Name, "hook type: Pre", ", driver: ", mwDriver)
 			mwAppendEnabled(&chainArray, &CoProcessMiddleware{baseMid, coprocess.HookType_PostKeyAuth, obj.Name, mwDriver})
 		}
@@ -401,31 +351,32 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 		mwAppendEnabled(&chainArray, &StripAuth{baseMid})
 		mwAppendEnabled(&chainArray, &KeyExpired{baseMid})
 		mwAppendEnabled(&chainArray, &AccessRightsCheck{baseMid})
-		mwAppendEnabled(&chainArray, &RateLimitAndQuotaCheck{baseMid})
-		mwAppendEnabled(&chainArray, &RateLimitForAPI{BaseMiddleware: baseMid})
 		mwAppendEnabled(&chainArray, &GranularAccessMiddleware{baseMid})
-		mwAppendEnabled(&chainArray, &ValidateJSON{BaseMiddleware: baseMid})
-		mwAppendEnabled(&chainArray, &TransformMiddleware{baseMid})
-		mwAppendEnabled(&chainArray, &TransformJQMiddleware{baseMid})
-		mwAppendEnabled(&chainArray, &TransformHeaders{BaseMiddleware: baseMid})
-		mwAppendEnabled(&chainArray, &URLRewriteMiddleware{BaseMiddleware: baseMid})
-		mwAppendEnabled(&chainArray, &RedisCacheMiddleware{BaseMiddleware: baseMid, CacheStore: &cacheStore})
-		mwAppendEnabled(&chainArray, &TransformMethod{BaseMiddleware: baseMid})
-		mwAppendEnabled(&chainArray, &VirtualEndpoint{BaseMiddleware: baseMid})
+		mwAppendEnabled(&chainArray, &RateLimitAndQuotaCheck{baseMid})
+	}
 
-		for _, obj := range mwPostFuncs {
-			if mwDriver != apidef.OttoDriver {
+	mwAppendEnabled(&chainArray, &RateLimitForAPI{BaseMiddleware: baseMid})
+	mwAppendEnabled(&chainArray, &ValidateJSON{BaseMiddleware: baseMid})
+	mwAppendEnabled(&chainArray, &TransformMiddleware{baseMid})
+	mwAppendEnabled(&chainArray, &TransformJQMiddleware{baseMid})
+	mwAppendEnabled(&chainArray, &TransformHeaders{BaseMiddleware: baseMid})
+	mwAppendEnabled(&chainArray, &URLRewriteMiddleware{BaseMiddleware: baseMid})
+	mwAppendEnabled(&chainArray, &RedisCacheMiddleware{BaseMiddleware: baseMid, CacheStore: &cacheStore})
+	mwAppendEnabled(&chainArray, &TransformMethod{BaseMiddleware: baseMid})
+	mwAppendEnabled(&chainArray, &VirtualEndpoint{BaseMiddleware: baseMid})
 
-				coprocessLog.Debug("Registering coprocess middleware, hook name: ", obj.Name, "hook type: Post", ", driver: ", mwDriver)
-				mwAppendEnabled(&chainArray, &CoProcessMiddleware{baseMid, coprocess.HookType_Post, obj.Name, mwDriver})
-			} else {
-				chainArray = append(chainArray, createDynamicMiddleware(obj.Name, false, obj.RequireSession, baseMid))
-			}
+	for _, obj := range mwPostFuncs {
+		if mwDriver != apidef.OttoDriver {
+			coprocessLog.Debug("Registering coprocess middleware, hook name: ", obj.Name, "hook type: Post", ", driver: ", mwDriver)
+			mwAppendEnabled(&chainArray, &CoProcessMiddleware{baseMid, coprocess.HookType_Post, obj.Name, mwDriver})
+		} else {
+			chainArray = append(chainArray, createDynamicMiddleware(obj.Name, false, obj.RequireSession, baseMid))
 		}
+	}
 
-		// Use createMiddleware(&ModifiedMiddleware{baseMid})  to run custom middleware
-		chain = alice.New(chainArray...).Then(&DummyProxyHandler{SH: SuccessHandler{baseMid}})
+	chain = alice.New(chainArray...).Then(&DummyProxyHandler{SH: SuccessHandler{baseMid}})
 
+	if !spec.UseKeylessAccess {
 		var simpleArray []alice.Constructor
 		mwAppendEnabled(&simpleArray, &IPWhiteListMiddleware{baseMid})
 		mwAppendEnabled(&simpleArray, &IPBlackListMiddleware{BaseMiddleware: baseMid})

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -361,8 +361,8 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 	mwAppendEnabled(&chainArray, &TransformJQMiddleware{baseMid})
 	mwAppendEnabled(&chainArray, &TransformHeaders{BaseMiddleware: baseMid})
 	mwAppendEnabled(&chainArray, &URLRewriteMiddleware{BaseMiddleware: baseMid})
-	mwAppendEnabled(&chainArray, &RedisCacheMiddleware{BaseMiddleware: baseMid, CacheStore: &cacheStore})
 	mwAppendEnabled(&chainArray, &TransformMethod{BaseMiddleware: baseMid})
+	mwAppendEnabled(&chainArray, &RedisCacheMiddleware{BaseMiddleware: baseMid, CacheStore: &cacheStore})
 	mwAppendEnabled(&chainArray, &VirtualEndpoint{BaseMiddleware: baseMid})
 
 	for _, obj := range mwPostFuncs {


### PR DESCRIPTION
- Consistent MW execution order - previously, the keyless APIs executed in a different order to protected APIs.
- Remove duplicate code - When creating new plugins - you no longer need to create it in 2 places
- Resolves #2317