### PR TITLE
coprocess: extend ReturnOverrides headers usage (fixes #2282)

### DIFF
--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -293,6 +293,10 @@ func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 	if returnObject.Request.ReturnOverrides.ResponseCode > 400 {
 		logger.WithField("key", obfuscateKey(token)).Info("Attempted access with invalid key")
 
+		for h, v := range returnObject.Request.ReturnOverrides.Headers {
+			w.Header().Set(h, v)
+		}
+
 		// Fire Authfailed Event
 		AuthFailed(m, r, token)
 


### PR DESCRIPTION
Fixes #2282.

This was a case we didn't cover while building this feature.

It was available in different `ReturnOverrides` scenarios.