### PR TITLE
Create testutil.go

### DIFF
--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -27,7 +27,7 @@ func createDefinitionFromString(defStr string) *APISpec {
 }
 
 func TestURLRewrites(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	t.Run("Extended Paths with url_rewrites", func(t *testing.T) {
@@ -81,7 +81,7 @@ func TestURLRewrites(t *testing.T) {
 }
 
 func TestWhitelist(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	t.Run("Extended Paths", func(t *testing.T) {
@@ -162,7 +162,7 @@ func TestWhitelist(t *testing.T) {
 }
 
 func TestBlacklist(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	t.Run("Extended Paths", func(t *testing.T) {
@@ -215,7 +215,7 @@ func TestBlacklist(t *testing.T) {
 }
 
 func TestConflictingPaths(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	BuildAndLoadAPI(func(spec *APISpec) {
@@ -243,7 +243,7 @@ func TestConflictingPaths(t *testing.T) {
 }
 
 func TestIgnored(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	t.Run("Extended Paths", func(t *testing.T) {
@@ -300,7 +300,7 @@ func TestIgnored(t *testing.T) {
 }
 
 func TestWhitelistMethodWithAdditionalMiddleware(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	t.Run("Extended Paths", func(t *testing.T) {
@@ -342,7 +342,7 @@ func TestWhitelistMethodWithAdditionalMiddleware(t *testing.T) {
 }
 
 func TestSyncAPISpecsDashboardSuccess(t *testing.T) {
-	// Mock Dashboard
+	// Test Dashboard
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/system/apis" {
 			w.Write([]byte(`{"Status": "OK", "Nonce": "1", "Message": [{"api_definition": {}}]}`))
@@ -453,7 +453,7 @@ func (ln *customListener) Close() error {
 }
 
 func TestDefaultVersion(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	key := testPrepareDefaultVersion()
@@ -471,7 +471,7 @@ func TestDefaultVersion(t *testing.T) {
 func BenchmarkDefaultVersion(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	key := testPrepareDefaultVersion()
@@ -520,7 +520,7 @@ func testPrepareDefaultVersion() string {
 }
 
 func TestGetVersionFromRequest(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	versionInfo := apidef.VersionInfo{}
@@ -576,7 +576,7 @@ func TestGetVersionFromRequest(t *testing.T) {
 
 func BenchmarkGetVersionFromRequest(b *testing.B) {
 	b.ReportAllocs()
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	versionInfo := apidef.VersionInfo{}
@@ -640,7 +640,7 @@ func BenchmarkGetVersionFromRequest(b *testing.B) {
 }
 
 func TestSyncAPISpecsDashboardJSONFailure(t *testing.T) {
-	// Mock Dashboard
+	// Test Dashboard
 	callNum := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/system/apis" {

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -27,12 +27,12 @@ func createDefinitionFromString(defStr string) *APISpec {
 }
 
 func TestURLRewrites(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	t.Run("Extended Paths with url_rewrites", func(t *testing.T) {
-		buildAndLoadAPI(func(spec *APISpec) {
-			updateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+		BuildAndLoadAPI(func(spec *APISpec) {
+			UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
 				json.Unmarshal([]byte(`[
 						{
                             "path": "/rewrite1",
@@ -81,12 +81,12 @@ func TestURLRewrites(t *testing.T) {
 }
 
 func TestWhitelist(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	t.Run("Extended Paths", func(t *testing.T) {
-		buildAndLoadAPI(func(spec *APISpec) {
-			updateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+		BuildAndLoadAPI(func(spec *APISpec) {
+			UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
 				json.Unmarshal([]byte(`[
 					{
 						"path": "/reply/{id}",
@@ -116,8 +116,8 @@ func TestWhitelist(t *testing.T) {
 	})
 
 	t.Run("Simple Paths", func(t *testing.T) {
-		buildAndLoadAPI(func(spec *APISpec) {
-			updateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+		BuildAndLoadAPI(func(spec *APISpec) {
+			UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
 				v.Paths.WhiteList = []string{"/simple", "/regex/{id}/test"}
 				v.UseExtendedPaths = false
 			})
@@ -135,8 +135,8 @@ func TestWhitelist(t *testing.T) {
 	})
 
 	t.Run("Test #1944", func(t *testing.T) {
-		buildAndLoadAPI(func(spec *APISpec) {
-			updateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+		BuildAndLoadAPI(func(spec *APISpec) {
+			UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
 				v.Paths.WhiteList = []string{"/foo/{fooId}$", "/foo/{fooId}/bar/{barId}$", "/baz/{bazId}"}
 				v.UseExtendedPaths = false
 			})
@@ -162,12 +162,12 @@ func TestWhitelist(t *testing.T) {
 }
 
 func TestBlacklist(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	t.Run("Extended Paths", func(t *testing.T) {
-		buildAndLoadAPI(func(spec *APISpec) {
-			updateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+		BuildAndLoadAPI(func(spec *APISpec) {
+			UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
 				json.Unmarshal([]byte(`[
 					{
 						"path": "/blacklist/literal",
@@ -194,8 +194,8 @@ func TestBlacklist(t *testing.T) {
 	})
 
 	t.Run("Simple Paths", func(t *testing.T) {
-		buildAndLoadAPI(func(spec *APISpec) {
-			updateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+		BuildAndLoadAPI(func(spec *APISpec) {
+			UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
 				v.Paths.BlackList = []string{"/blacklist/literal", "/blacklist/{id}/test"}
 				v.UseExtendedPaths = false
 			})
@@ -215,11 +215,11 @@ func TestBlacklist(t *testing.T) {
 }
 
 func TestConflictingPaths(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	buildAndLoadAPI(func(spec *APISpec) {
-		updateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+	BuildAndLoadAPI(func(spec *APISpec) {
+		UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
 			json.Unmarshal([]byte(`[
 				{
 					"path": "/metadata/{id}",
@@ -243,12 +243,12 @@ func TestConflictingPaths(t *testing.T) {
 }
 
 func TestIgnored(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	t.Run("Extended Paths", func(t *testing.T) {
-		buildAndLoadAPI(func(spec *APISpec) {
-			updateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+		BuildAndLoadAPI(func(spec *APISpec) {
+			UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
 				json.Unmarshal([]byte(`[
 					{
 						"path": "/ignored/literal",
@@ -277,8 +277,8 @@ func TestIgnored(t *testing.T) {
 	})
 
 	t.Run("Simple Paths", func(t *testing.T) {
-		buildAndLoadAPI(func(spec *APISpec) {
-			updateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+		BuildAndLoadAPI(func(spec *APISpec) {
+			UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
 				v.Paths.Ignored = []string{"/ignored/literal", "/ignored/{id}/test"}
 				v.UseExtendedPaths = false
 			})
@@ -300,15 +300,15 @@ func TestIgnored(t *testing.T) {
 }
 
 func TestWhitelistMethodWithAdditionalMiddleware(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	t.Run("Extended Paths", func(t *testing.T) {
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.UseKeylessAccess = true
 			spec.Proxy.ListenPath = "/"
 
-			updateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+			UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
 				v.UseExtendedPaths = true
 
 				json.Unmarshal([]byte(`[
@@ -453,7 +453,7 @@ func (ln *customListener) Close() error {
 }
 
 func TestDefaultVersion(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	key := testPrepareDefaultVersion()
@@ -471,7 +471,7 @@ func TestDefaultVersion(t *testing.T) {
 func BenchmarkDefaultVersion(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	key := testPrepareDefaultVersion()
@@ -492,7 +492,7 @@ func BenchmarkDefaultVersion(b *testing.B) {
 }
 
 func testPrepareDefaultVersion() string {
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		v1 := apidef.VersionInfo{Name: "v1"}
 		v1.Name = "v1"
 		v1.Paths.WhiteList = []string{"/foo"}
@@ -512,7 +512,7 @@ func testPrepareDefaultVersion() string {
 		spec.UseKeylessAccess = false
 	})
 
-	return createSession(func(s *user.SessionState) {
+	return CreateSession(func(s *user.SessionState) {
 		s.AccessRights = map[string]user.AccessDefinition{"test": {
 			APIID: "test", Versions: []string{"v1", "v2"},
 		}}
@@ -520,7 +520,7 @@ func testPrepareDefaultVersion() string {
 }
 
 func TestGetVersionFromRequest(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	versionInfo := apidef.VersionInfo{}
@@ -528,7 +528,7 @@ func TestGetVersionFromRequest(t *testing.T) {
 	versionInfo.Paths.BlackList = []string{"/bar"}
 
 	t.Run("Header location", func(t *testing.T) {
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.VersionData.NotVersioned = false
 			spec.VersionDefinition.Location = headerLocation
@@ -545,7 +545,7 @@ func TestGetVersionFromRequest(t *testing.T) {
 	})
 
 	t.Run("URL param location", func(t *testing.T) {
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.VersionData.NotVersioned = false
 			spec.VersionDefinition.Location = urlParamLocation
@@ -560,7 +560,7 @@ func TestGetVersionFromRequest(t *testing.T) {
 	})
 
 	t.Run("URL location", func(t *testing.T) {
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.VersionData.NotVersioned = false
 			spec.VersionDefinition.Location = urlLocation
@@ -576,7 +576,7 @@ func TestGetVersionFromRequest(t *testing.T) {
 
 func BenchmarkGetVersionFromRequest(b *testing.B) {
 	b.ReportAllocs()
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	versionInfo := apidef.VersionInfo{}
@@ -585,7 +585,7 @@ func BenchmarkGetVersionFromRequest(b *testing.B) {
 
 	b.Run("Header location", func(b *testing.B) {
 		b.ReportAllocs()
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.VersionData.NotVersioned = false
 			spec.VersionDefinition.Location = headerLocation
@@ -605,7 +605,7 @@ func BenchmarkGetVersionFromRequest(b *testing.B) {
 
 	b.Run("URL param location", func(b *testing.B) {
 		b.ReportAllocs()
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.VersionData.NotVersioned = false
 			spec.VersionDefinition.Location = urlParamLocation
@@ -623,7 +623,7 @@ func BenchmarkGetVersionFromRequest(b *testing.B) {
 
 	b.Run("URL location", func(b *testing.B) {
 		b.ReportAllocs()
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.VersionData.NotVersioned = false
 			spec.VersionDefinition.Location = urlLocation

--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -56,10 +56,10 @@ func TestHealthCheckEndpoint(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	buildAndLoadAPI()
+	BuildAndLoadAPI()
 
 	ts.Run(t, []test.TestCase{
 		{Path: "/tyk/health/?api_id=test", AdminAuth: true, Code: 200},
@@ -83,11 +83,11 @@ func TestApiHandlerPostDupPath(t *testing.T) {
 
 	t.Run("Sequentieal order", func(t *testing.T) {
 		// Load initial API
-		buildAndLoadAPI(
+		BuildAndLoadAPI(
 			func(spec *APISpec) { spec.APIID = "1" },
 		)
 
-		buildAndLoadAPI(
+		BuildAndLoadAPI(
 			func(spec *APISpec) { spec.APIID = "1" },
 			func(spec *APISpec) { spec.APIID = "2" },
 			func(spec *APISpec) { spec.APIID = "3" },
@@ -102,7 +102,7 @@ func TestApiHandlerPostDupPath(t *testing.T) {
 	})
 
 	t.Run("Should re-order", func(t *testing.T) {
-		buildAndLoadAPI(
+		BuildAndLoadAPI(
 			func(spec *APISpec) { spec.APIID = "2" },
 			func(spec *APISpec) { spec.APIID = "3" },
 		)
@@ -114,7 +114,7 @@ func TestApiHandlerPostDupPath(t *testing.T) {
 	})
 
 	t.Run("Restore original order", func(t *testing.T) {
-		buildAndLoadAPI(
+		BuildAndLoadAPI(
 			func(spec *APISpec) { spec.APIID = "1" },
 			func(spec *APISpec) { spec.APIID = "2" },
 			func(spec *APISpec) { spec.APIID = "3" },
@@ -130,20 +130,20 @@ func TestApiHandlerPostDupPath(t *testing.T) {
 }
 
 func TestKeyHandler(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.UseKeylessAccess = false
 		spec.Auth.UseParam = true
 	})
 
 	// Access right not specified
-	masterKey := createStandardSession()
+	masterKey := CreateStandardSession()
 	masterKeyJSON, _ := json.Marshal(masterKey)
 
 	// with access
-	withAccess := createStandardSession()
+	withAccess := CreateStandardSession()
 	withAccess.AccessRights = map[string]user.AccessDefinition{"test": {
 		APIID: "test", Versions: []string{"v1"},
 	}}
@@ -159,14 +159,14 @@ func TestKeyHandler(t *testing.T) {
 		}},
 	}
 	policiesMu.Unlock()
-	withPolicy := createStandardSession()
+	withPolicy := CreateStandardSession()
 	withPolicy.ApplyPolicies = []string{
 		"abc_policy",
 	}
 	withPolicyJSON, _ := json.Marshal(withPolicy)
 
 	// with invalid policy
-	withBadPolicy := createStandardSession()
+	withBadPolicy := CreateStandardSession()
 	withBadPolicy.AccessRights = map[string]user.AccessDefinition{"test": {
 		APIID: "test", Versions: []string{"v1"},
 	}}
@@ -233,7 +233,7 @@ func TestKeyHandler(t *testing.T) {
 		}...)
 	})
 
-	knownKey := createSession()
+	knownKey := CreateSession()
 
 	t.Run("Get key", func(t *testing.T) {
 		ts.Run(t, []test.TestCase{
@@ -315,7 +315,7 @@ func TestHashKeyHandlerLegacyWithHashFunc(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	// create session with legacy key format
@@ -359,12 +359,12 @@ func TestHashKeyHandlerLegacyWithHashFunc(t *testing.T) {
 }
 
 func testHashKeyHandlerHelper(t *testing.T, expectedHashSize int) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	buildAndLoadAPI()
+	BuildAndLoadAPI()
 
-	withAccess := createStandardSession()
+	withAccess := CreateStandardSession()
 	withAccess.AccessRights = map[string]user.AccessDefinition{"test": {
 		APIID: "test", Versions: []string{"v1"},
 	}}
@@ -485,7 +485,7 @@ func testHashKeyHandlerHelper(t *testing.T, expectedHashSize int) {
 }
 
 func testHashFuncAndBAHelper(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	session := testPrepareBasicAuth(false)
@@ -524,12 +524,12 @@ func TestHashKeyListingDisabled(t *testing.T) {
 
 	defer resetTestConfig()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	buildAndLoadAPI()
+	BuildAndLoadAPI()
 
-	withAccess := createStandardSession()
+	withAccess := CreateStandardSession()
 	withAccess.AccessRights = map[string]user.AccessDefinition{"test": {
 		APIID: "test", Versions: []string{"v1"},
 	}}
@@ -642,12 +642,12 @@ func TestHashKeyHandlerHashingDisabled(t *testing.T) {
 
 	defer resetTestConfig()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	buildAndLoadAPI()
+	BuildAndLoadAPI()
 
-	withAccess := createStandardSession()
+	withAccess := CreateStandardSession()
 	withAccess.AccessRights = map[string]user.AccessDefinition{"test": {
 		APIID: "test", Versions: []string{"v1"},
 	}}
@@ -722,10 +722,10 @@ func TestHashKeyHandlerHashingDisabled(t *testing.T) {
 }
 
 func TestInvalidateCache(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	buildAndLoadAPI()
+	BuildAndLoadAPI()
 
 	ts.Run(t, []test.TestCase{
 		{Method: "DELETE", Path: "/tyk/cache/test", AdminAuth: true, Code: 200},
@@ -734,10 +734,10 @@ func TestInvalidateCache(t *testing.T) {
 }
 
 func TestGetOAuthClients(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.UseOauth2 = true
 	})
 
@@ -758,10 +758,10 @@ func TestGetOAuthClients(t *testing.T) {
 }
 
 func TestCreateOAuthClient(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	buildAndLoadAPI(
+	BuildAndLoadAPI(
 		func(spec *APISpec) {
 			spec.UseOauth2 = true
 		},
@@ -771,7 +771,7 @@ func TestCreateOAuthClient(t *testing.T) {
 		},
 	)
 
-	createPolicy(func(p *user.Policy) {
+	CreatePolicy(func(p *user.Policy) {
 		p.ID = "p1"
 		p.AccessRights = map[string]user.AccessDefinition{
 			"test": {
@@ -779,7 +779,7 @@ func TestCreateOAuthClient(t *testing.T) {
 			},
 		}
 	})
-	createPolicy(func(p *user.Policy) {
+	CreatePolicy(func(p *user.Policy) {
 		p.ID = "p2"
 		p.AccessRights = map[string]user.AccessDefinition{
 			"test": {
@@ -972,7 +972,7 @@ func BenchmarkApiReload(b *testing.B) {
 	specs := make([]*APISpec, 100)
 
 	for i := 0; i < 100; i++ {
-		specs[i] = buildAndLoadAPI(func(spec *APISpec) {
+		specs[i] = BuildAndLoadAPI(func(spec *APISpec) {
 			spec.APIID = strconv.Itoa(i + 1)
 		})[0]
 	}
@@ -1044,16 +1044,16 @@ func TestApiLoaderLongestPathFirst(t *testing.T) {
 	var apis []*APISpec
 
 	for hp := range inputs {
-		apis = append(apis, buildAPI(func(spec *APISpec) {
+		apis = append(apis, BuildAPI(func(spec *APISpec) {
 			spec.APIID = uuid.NewV4().String()
 			spec.Domain = hp.host
 			spec.Proxy.ListenPath = "/" + hp.path
 		})[0])
 	}
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
-	loadAPI(apis...)
+	LoadAPI(apis...)
 
 	var testCases []test.TestCase
 

--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -56,7 +56,7 @@ func TestHealthCheckEndpoint(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	BuildAndLoadAPI()
@@ -130,7 +130,7 @@ func TestApiHandlerPostDupPath(t *testing.T) {
 }
 
 func TestKeyHandler(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	BuildAndLoadAPI(func(spec *APISpec) {
@@ -315,7 +315,7 @@ func TestHashKeyHandlerLegacyWithHashFunc(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	// create session with legacy key format
@@ -359,7 +359,7 @@ func TestHashKeyHandlerLegacyWithHashFunc(t *testing.T) {
 }
 
 func testHashKeyHandlerHelper(t *testing.T, expectedHashSize int) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	BuildAndLoadAPI()
@@ -485,7 +485,7 @@ func testHashKeyHandlerHelper(t *testing.T, expectedHashSize int) {
 }
 
 func testHashFuncAndBAHelper(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	session := testPrepareBasicAuth(false)
@@ -524,7 +524,7 @@ func TestHashKeyListingDisabled(t *testing.T) {
 
 	defer resetTestConfig()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	BuildAndLoadAPI()
@@ -642,7 +642,7 @@ func TestHashKeyHandlerHashingDisabled(t *testing.T) {
 
 	defer resetTestConfig()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	BuildAndLoadAPI()
@@ -722,7 +722,7 @@ func TestHashKeyHandlerHashingDisabled(t *testing.T) {
 }
 
 func TestInvalidateCache(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	BuildAndLoadAPI()
@@ -734,7 +734,7 @@ func TestInvalidateCache(t *testing.T) {
 }
 
 func TestGetOAuthClients(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	BuildAndLoadAPI(func(spec *APISpec) {
@@ -758,7 +758,7 @@ func TestGetOAuthClients(t *testing.T) {
 }
 
 func TestCreateOAuthClient(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	BuildAndLoadAPI(
@@ -1051,7 +1051,7 @@ func TestApiLoaderLongestPathFirst(t *testing.T) {
 		})[0])
 	}
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 	LoadAPI(apis...)
 

--- a/gateway/auth_manager_test.go
+++ b/gateway/auth_manager_test.go
@@ -17,15 +17,15 @@ func TestAuthenticationAfterDeleteKey(t *testing.T) {
 		globalConf.HashKeys = hashKeys
 		config.SetGlobal(globalConf)
 
-		ts := newTykTestServer()
+		ts := StartTest()
 		defer ts.Close()
 
-		api := buildAndLoadAPI(func(spec *APISpec) {
+		api := BuildAndLoadAPI(func(spec *APISpec) {
 			spec.UseKeylessAccess = false
 			spec.Proxy.ListenPath = "/"
 		})[0]
 
-		key := createSession(func(s *user.SessionState) {
+		key := CreateSession(func(s *user.SessionState) {
 			s.AccessRights = map[string]user.AccessDefinition{api.APIID: {
 				APIID: api.APIID,
 			}}
@@ -57,17 +57,17 @@ func TestAuthenticationAfterUpdateKey(t *testing.T) {
 		globalConf.HashKeys = hashKeys
 		config.SetGlobal(globalConf)
 
-		ts := newTykTestServer()
+		ts := StartTest()
 		defer ts.Close()
 
-		api := buildAndLoadAPI(func(spec *APISpec) {
+		api := BuildAndLoadAPI(func(spec *APISpec) {
 			spec.UseKeylessAccess = false
 			spec.Proxy.ListenPath = "/"
 		})[0]
 
 		key := generateToken("", "")
 
-		session := createStandardSession()
+		session := CreateStandardSession()
 		session.AccessRights = map[string]user.AccessDefinition{api.APIID: {
 			APIID: api.APIID,
 		}}

--- a/gateway/batch_requests_test.go
+++ b/gateway/batch_requests_test.go
@@ -24,7 +24,7 @@ const testBatchRequest = `{
 			"test-header-1": "test-1",
 			"test-header-2": "test-2"
 		},
-		"relative_url": "get/?param1=this"te
+		"relative_url": "get/?param1=this"
 	},
 	{
 		"method": "POST",

--- a/gateway/batch_requests_test.go
+++ b/gateway/batch_requests_test.go
@@ -24,7 +24,7 @@ const testBatchRequest = `{
 			"test-header-1": "test-1",
 			"test-header-2": "test-2"
 		},
-		"relative_url": "get/?param1=this"
+		"relative_url": "get/?param1=this"te
 	},
 	{
 		"method": "POST",
@@ -40,7 +40,7 @@ const testBatchRequest = `{
 }`
 
 func TestBatch(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	BuildAndLoadAPI(func(spec *APISpec) {
@@ -146,7 +146,7 @@ func TestVirtualEndpointBatch(t *testing.T) {
 
 	defer resetTestConfig()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	BuildAndLoadAPI(func(spec *APISpec) {

--- a/gateway/batch_requests_test.go
+++ b/gateway/batch_requests_test.go
@@ -40,10 +40,10 @@ const testBatchRequest = `{
 }`
 
 func TestBatch(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/v1/"
 		spec.EnableBatchRequestSupport = true
 	})
@@ -146,10 +146,10 @@ func TestVirtualEndpointBatch(t *testing.T) {
 
 	defer resetTestConfig()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/"
 		virtualMeta := apidef.VirtualMeta{
 			ResponseFunctionName: "batchTest",
@@ -158,7 +158,7 @@ func TestVirtualEndpointBatch(t *testing.T) {
 			Path:                 "/virt",
 			Method:               "GET",
 		}
-		updateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+		UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
 			v.UseExtendedPaths = true
 			v.ExtendedPaths = apidef.ExtendedPathsSet{
 				Virtual: []apidef.VirtualMeta{virtualMeta},

--- a/gateway/cert_go1.10_test.go
+++ b/gateway/cert_go1.10_test.go
@@ -44,10 +44,10 @@ func TestPublicKeyPinning(t *testing.T) {
 		config.SetGlobal(globalConf)
 		defer resetTestConfig()
 
-		ts := newTykTestServer()
+		ts := StartMock()
 		defer ts.Close()
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.PinnedPublicKeys = map[string]string{"127.0.0.1": pubID}
 			spec.Proxy.TargetURL = upstream.URL
@@ -57,10 +57,10 @@ func TestPublicKeyPinning(t *testing.T) {
 	})
 
 	t.Run("Pub key not match", func(t *testing.T) {
-		ts := newTykTestServer()
+		ts := StartMock()
 		defer ts.Close()
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.PinnedPublicKeys = map[string]string{"127.0.0.1": "wrong"}
 			spec.Proxy.TargetURL = upstream.URL
@@ -75,10 +75,10 @@ func TestPublicKeyPinning(t *testing.T) {
 		config.SetGlobal(globalConf)
 		defer resetTestConfig()
 
-		ts := newTykTestServer()
+		ts := StartMock()
 		defer ts.Close()
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.Proxy.TargetURL = upstream.URL
 		})
@@ -99,10 +99,10 @@ func TestPublicKeyPinning(t *testing.T) {
 
 		defer proxy.Stop()
 
-		ts := newTykTestServer()
+		ts := StartMock()
 		defer ts.Close()
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.Proxy.TargetURL = upstream.URL
 			spec.Proxy.Transport.ProxyURL = proxy.URL
@@ -126,14 +126,14 @@ func TestProxyTransport(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	//matching ciphers
 	t.Run("Global: Cipher match", func(t *testing.T) {
 		globalConf.ProxySSLCipherSuites = []string{"TLS_RSA_WITH_AES_128_CBC_SHA"}
 		config.SetGlobal(globalConf)
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.Proxy.TargetURL = upstream.URL
 		})
@@ -143,7 +143,7 @@ func TestProxyTransport(t *testing.T) {
 	t.Run("Global: Cipher not match", func(t *testing.T) {
 		globalConf.ProxySSLCipherSuites = []string{"TLS_RSA_WITH_RC4_128_SHA"}
 		config.SetGlobal(globalConf)
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.Proxy.TargetURL = upstream.URL
 		})
@@ -153,7 +153,7 @@ func TestProxyTransport(t *testing.T) {
 	t.Run("API: Cipher override", func(t *testing.T) {
 		globalConf.ProxySSLCipherSuites = []string{"TLS_RSA_WITH_RC4_128_SHA"}
 		config.SetGlobal(globalConf)
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.Proxy.TargetURL = upstream.URL
 			spec.Proxy.Transport.SSLCipherSuites = []string{"TLS_RSA_WITH_AES_128_CBC_SHA"}
@@ -165,7 +165,7 @@ func TestProxyTransport(t *testing.T) {
 	t.Run("API: MinTLS not match", func(t *testing.T) {
 		globalConf.ProxySSLMinVersion = 772
 		config.SetGlobal(globalConf)
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.Proxy.TargetURL = upstream.URL
 			spec.Proxy.Transport.SSLCipherSuites = []string{"TLS_RSA_WITH_AES_128_CBC_SHA"}
@@ -177,7 +177,7 @@ func TestProxyTransport(t *testing.T) {
 	t.Run("API: Invalid proxy", func(t *testing.T) {
 		globalConf.ProxySSLMinVersion = 771
 		config.SetGlobal(globalConf)
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.Proxy.TargetURL = upstream.URL
 			spec.Proxy.Transport.SSLCipherSuites = []string{"TLS_RSA_WITH_AES_128_CBC_SHA"}
@@ -198,7 +198,7 @@ func TestProxyTransport(t *testing.T) {
 		})
 		defer proxy.Stop()
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.Proxy.Transport.SSLCipherSuites = []string{"TLS_RSA_WITH_AES_128_CBC_SHA"}
 			spec.Proxy.Transport.ProxyURL = proxy.URL

--- a/gateway/cert_go1.10_test.go
+++ b/gateway/cert_go1.10_test.go
@@ -44,7 +44,7 @@ func TestPublicKeyPinning(t *testing.T) {
 		config.SetGlobal(globalConf)
 		defer resetTestConfig()
 
-		ts := StartMock()
+		ts := StartTest()
 		defer ts.Close()
 
 		BuildAndLoadAPI(func(spec *APISpec) {
@@ -57,7 +57,7 @@ func TestPublicKeyPinning(t *testing.T) {
 	})
 
 	t.Run("Pub key not match", func(t *testing.T) {
-		ts := StartMock()
+		ts := StartTest()
 		defer ts.Close()
 
 		BuildAndLoadAPI(func(spec *APISpec) {
@@ -75,7 +75,7 @@ func TestPublicKeyPinning(t *testing.T) {
 		config.SetGlobal(globalConf)
 		defer resetTestConfig()
 
-		ts := StartMock()
+		ts := StartTest()
 		defer ts.Close()
 
 		BuildAndLoadAPI(func(spec *APISpec) {
@@ -99,7 +99,7 @@ func TestPublicKeyPinning(t *testing.T) {
 
 		defer proxy.Stop()
 
-		ts := StartMock()
+		ts := StartTest()
 		defer ts.Close()
 
 		BuildAndLoadAPI(func(spec *APISpec) {
@@ -126,7 +126,7 @@ func TestProxyTransport(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	//matching ciphers

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -108,7 +108,7 @@ func TestGatewayTLS(t *testing.T) {
 		config.SetGlobal(globalConf)
 		defer resetTestConfig()
 
-		ts := StartMock()
+		ts := StartTest()
 		defer ts.Close()
 
 		BuildAndLoadAPI(func(spec *APISpec) {
@@ -135,7 +135,7 @@ func TestGatewayTLS(t *testing.T) {
 		config.SetGlobal(globalConf)
 		defer resetTestConfig()
 
-		ts := StartMock()
+		ts := StartTest()
 		defer ts.Close()
 
 		BuildAndLoadAPI(func(spec *APISpec) {
@@ -157,7 +157,7 @@ func TestGatewayTLS(t *testing.T) {
 		config.SetGlobal(globalConf)
 		defer resetTestConfig()
 
-		ts := StartMock()
+		ts := StartTest()
 		defer ts.Close()
 
 		BuildAndLoadAPI(func(spec *APISpec) {
@@ -182,7 +182,7 @@ func TestGatewayTLS(t *testing.T) {
 		config.SetGlobal(globalConf)
 		defer resetTestConfig()
 
-		ts := StartMock()
+		ts := StartTest()
 		defer ts.Close()
 
 		BuildAndLoadAPI(func(spec *APISpec) {
@@ -226,7 +226,7 @@ func TestGatewayControlAPIMutualTLS(t *testing.T) {
 		globalConf.HttpServerOptions.SSLCertificates = []string{certID}
 		config.SetGlobal(globalConf)
 
-		ts := StartMock()
+		ts := StartTest()
 		defer ts.Close()
 
 		defer func() {
@@ -277,7 +277,7 @@ func TestAPIMutualTLS(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	// Initialize client certificates
@@ -459,7 +459,7 @@ func TestUpstreamMutualTLS(t *testing.T) {
 		config.SetGlobal(globalConf)
 		defer resetTestConfig()
 
-		ts := StartMock()
+		ts := StartTest()
 		defer ts.Close()
 
 		clientCertID, _ := CertificateManager.Add(combinedClientPEM, "")
@@ -494,7 +494,7 @@ func TestKeyWithCertificateTLS(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	BuildAndLoadAPI(func(spec *APISpec) {
@@ -533,7 +533,7 @@ func TestAPICertificate(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{
@@ -567,7 +567,7 @@ func TestCertificateHandlerTLS(t *testing.T) {
 	clientPEM, _, _, clientCert := genCertificate(&x509.Certificate{})
 	clientCertID := certs.HexSHA256(clientCert.Certificate[0])
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	t.Run("List certificates, empty", func(t *testing.T) {
@@ -628,7 +628,7 @@ func TestCipherSuites(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	BuildAndLoadAPI(func(spec *APISpec) {
@@ -692,7 +692,7 @@ func TestHTTP2(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	BuildAndLoadAPI(func(spec *APISpec) {
@@ -737,7 +737,7 @@ func TestGRPC(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	BuildAndLoadAPI(func(spec *APISpec) {

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -108,10 +108,10 @@ func TestGatewayTLS(t *testing.T) {
 		config.SetGlobal(globalConf)
 		defer resetTestConfig()
 
-		ts := newTykTestServer()
+		ts := StartMock()
 		defer ts.Close()
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 		})
 
@@ -135,10 +135,10 @@ func TestGatewayTLS(t *testing.T) {
 		config.SetGlobal(globalConf)
 		defer resetTestConfig()
 
-		ts := newTykTestServer()
+		ts := StartMock()
 		defer ts.Close()
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 		})
 
@@ -157,10 +157,10 @@ func TestGatewayTLS(t *testing.T) {
 		config.SetGlobal(globalConf)
 		defer resetTestConfig()
 
-		ts := newTykTestServer()
+		ts := StartMock()
 		defer ts.Close()
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 		})
 
@@ -182,10 +182,10 @@ func TestGatewayTLS(t *testing.T) {
 		config.SetGlobal(globalConf)
 		defer resetTestConfig()
 
-		ts := newTykTestServer()
+		ts := StartMock()
 		defer ts.Close()
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 		})
 
@@ -226,7 +226,7 @@ func TestGatewayControlAPIMutualTLS(t *testing.T) {
 		globalConf.HttpServerOptions.SSLCertificates = []string{certID}
 		config.SetGlobal(globalConf)
 
-		ts := newTykTestServer()
+		ts := StartMock()
 		defer ts.Close()
 
 		defer func() {
@@ -277,7 +277,7 @@ func TestAPIMutualTLS(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	// Initialize client certificates
@@ -287,7 +287,7 @@ func TestAPIMutualTLS(t *testing.T) {
 		t.Run("API without mutual TLS", func(t *testing.T) {
 			client := getTLSClient(&clientCert, serverCertPem)
 
-			buildAndLoadAPI(func(spec *APISpec) {
+			BuildAndLoadAPI(func(spec *APISpec) {
 				spec.Domain = "localhost"
 				spec.Proxy.ListenPath = "/"
 			})
@@ -298,7 +298,7 @@ func TestAPIMutualTLS(t *testing.T) {
 		t.Run("MutualTLSCertificate not set", func(t *testing.T) {
 			client := getTLSClient(nil, nil)
 
-			buildAndLoadAPI(func(spec *APISpec) {
+			BuildAndLoadAPI(func(spec *APISpec) {
 				spec.Domain = "localhost"
 				spec.Proxy.ListenPath = "/"
 				spec.UseMutualTLSAuth = true
@@ -315,7 +315,7 @@ func TestAPIMutualTLS(t *testing.T) {
 			client := getTLSClient(&clientCert, serverCertPem)
 			clientCertID, _ := CertificateManager.Add(clientCertPem, "")
 
-			buildAndLoadAPI(func(spec *APISpec) {
+			BuildAndLoadAPI(func(spec *APISpec) {
 				spec.Domain = "localhost"
 				spec.Proxy.ListenPath = "/"
 				spec.UseMutualTLSAuth = true
@@ -342,7 +342,7 @@ func TestAPIMutualTLS(t *testing.T) {
 			clientCertID2, _ := CertificateManager.Add(clientCertPem2, "")
 			defer CertificateManager.Delete(clientCertID2)
 
-			buildAndLoadAPI(func(spec *APISpec) {
+			BuildAndLoadAPI(func(spec *APISpec) {
 				spec.Domain = "localhost"
 				spec.Proxy.ListenPath = "/"
 				spec.UseMutualTLSAuth = true
@@ -360,7 +360,7 @@ func TestAPIMutualTLS(t *testing.T) {
 		defer CertificateManager.Delete(clientCertID)
 
 		loadAPIS := func(certs ...string) {
-			buildAndLoadAPI(
+			BuildAndLoadAPI(
 				func(spec *APISpec) {
 					spec.Proxy.ListenPath = "/with_mutual"
 					spec.UseMutualTLSAuth = true
@@ -459,7 +459,7 @@ func TestUpstreamMutualTLS(t *testing.T) {
 		config.SetGlobal(globalConf)
 		defer resetTestConfig()
 
-		ts := newTykTestServer()
+		ts := StartMock()
 		defer ts.Close()
 
 		clientCertID, _ := CertificateManager.Add(combinedClientPEM, "")
@@ -467,7 +467,7 @@ func TestUpstreamMutualTLS(t *testing.T) {
 
 		pool.AddCert(clientCert.Leaf)
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.Proxy.TargetURL = upstream.URL
 			spec.UpstreamCertificates = map[string]string{
@@ -494,10 +494,10 @@ func TestKeyWithCertificateTLS(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.UseKeylessAccess = false
 		spec.BaseIdentityProvidedBy = apidef.AuthToken
 		spec.Auth.UseCertificate = true
@@ -511,7 +511,7 @@ func TestKeyWithCertificateTLS(t *testing.T) {
 	})
 
 	t.Run("Cert known", func(t *testing.T) {
-		createSession(func(s *user.SessionState) {
+		CreateSession(func(s *user.SessionState) {
 			s.Certificate = clientCertID
 			s.AccessRights = map[string]user.AccessDefinition{"test": {
 				APIID: "test", Versions: []string{"v1"},
@@ -533,7 +533,7 @@ func TestAPICertificate(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{
@@ -541,7 +541,7 @@ func TestAPICertificate(t *testing.T) {
 	}}}
 
 	t.Run("Cert set via API", func(t *testing.T) {
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Certificates = []string{serverCertID}
 			spec.UseKeylessAccess = true
 			spec.Proxy.ListenPath = "/"
@@ -551,7 +551,7 @@ func TestAPICertificate(t *testing.T) {
 	})
 
 	t.Run("Cert unknown", func(t *testing.T) {
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.UseKeylessAccess = true
 			spec.Proxy.ListenPath = "/"
 		})
@@ -567,7 +567,7 @@ func TestCertificateHandlerTLS(t *testing.T) {
 	clientPEM, _, _, clientCert := genCertificate(&x509.Certificate{})
 	clientCertID := certs.HexSHA256(clientCert.Certificate[0])
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	t.Run("List certificates, empty", func(t *testing.T) {
@@ -628,10 +628,10 @@ func TestCipherSuites(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/"
 	})
 
@@ -692,10 +692,10 @@ func TestHTTP2(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/"
 		spec.UseKeylessAccess = true
 		spec.Proxy.TargetURL = upstream.URL
@@ -737,10 +737,10 @@ func TestGRPC(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/"
 		spec.UseKeylessAccess = true
 		spec.Proxy.TargetURL = "https://localhost:50051"

--- a/gateway/coprocess_bundle_test.go
+++ b/gateway/coprocess_bundle_test.go
@@ -33,7 +33,7 @@ func TestBundleLoader(t *testing.T) {
 	bundleID := registerBundle("grpc_with_auth_check", grpcBundleWithAuthCheck)
 
 	t.Run("Nonexistent bundle", func(t *testing.T) {
-		specs := buildAndLoadAPI(func(spec *APISpec) {
+		specs := BuildAndLoadAPI(func(spec *APISpec) {
 			spec.CustomMiddlewareBundle = "nonexistent.zip"
 		})
 		err := loadBundle(specs[0])
@@ -43,7 +43,7 @@ func TestBundleLoader(t *testing.T) {
 	})
 
 	t.Run("Existing bundle with auth check", func(t *testing.T) {
-		specs := buildAndLoadAPI(func(spec *APISpec) {
+		specs := BuildAndLoadAPI(func(spec *APISpec) {
 			spec.CustomMiddlewareBundle = bundleID
 		})
 		spec := specs[0]

--- a/gateway/coprocess_grpc_test.go
+++ b/gateway/coprocess_grpc_test.go
@@ -204,7 +204,7 @@ func loadTestGRPCAPIs() {
 	})
 }
 
-func startTykWithGRPC() (*Mock, *grpc.Server) {
+func startTykWithGRPC() (*Test, *grpc.Server) {
 	// Setup the gRPC server:
 	listener, _ := net.Listen("tcp", grpcListenAddr)
 	grpcServer := newTestGRPCServer()
@@ -215,7 +215,7 @@ func startTykWithGRPC() (*Mock, *grpc.Server) {
 		EnableCoProcess:     true,
 		CoProcessGRPCServer: grpcListenPath,
 	}
-	ts := StartMock(MockConfig{coprocessConfig: cfg})
+	ts := StartTest(TestConfig{coprocessConfig: cfg})
 
 	// Load test APIs:
 	loadTestGRPCAPIs()

--- a/gateway/coprocess_grpc_test.go
+++ b/gateway/coprocess_grpc_test.go
@@ -120,7 +120,7 @@ func newTestGRPCServer() (s *grpc.Server) {
 }
 
 func loadTestGRPCAPIs() {
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.APIID = "1"
 		spec.OrgID = mockOrgID
 		spec.Auth = apidef.Auth{
@@ -215,7 +215,7 @@ func startTykWithGRPC() (*tykTestServer, *grpc.Server) {
 		EnableCoProcess:     true,
 		CoProcessGRPCServer: grpcListenPath,
 	}
-	ts := newTykTestServer(tykTestServerConfig{coprocessConfig: cfg})
+	ts := StartMock(tykTestServerConfig{coprocessConfig: cfg})
 
 	// Load test APIs:
 	loadTestGRPCAPIs()
@@ -227,7 +227,7 @@ func TestGRPCDispatch(t *testing.T) {
 	defer ts.Close()
 	defer grpcServer.Stop()
 
-	keyID := createSession(func(s *user.SessionState) {
+	keyID := CreateSession(func(s *user.SessionState) {
 		s.MetaData = map[string]interface{}{
 			"testkey":  map[string]interface{}{"nestedkey": "nestedvalue"},
 			"testkey2": "testvalue",
@@ -310,7 +310,7 @@ func BenchmarkGRPCDispatch(b *testing.B) {
 	defer ts.Close()
 	defer grpcServer.Stop()
 
-	keyID := createSession(func(s *user.SessionState) {})
+	keyID := CreateSession(func(s *user.SessionState) {})
 	headers := map[string]string{"authorization": keyID}
 
 	b.Run("Pre Hook with SetHeaders", func(b *testing.B) {

--- a/gateway/coprocess_grpc_test.go
+++ b/gateway/coprocess_grpc_test.go
@@ -204,7 +204,7 @@ func loadTestGRPCAPIs() {
 	})
 }
 
-func startTykWithGRPC() (*tykTestServer, *grpc.Server) {
+func startTykWithGRPC() (*Mock, *grpc.Server) {
 	// Setup the gRPC server:
 	listener, _ := net.Listen("tcp", grpcListenAddr)
 	grpcServer := newTestGRPCServer()
@@ -215,7 +215,7 @@ func startTykWithGRPC() (*tykTestServer, *grpc.Server) {
 		EnableCoProcess:     true,
 		CoProcessGRPCServer: grpcListenPath,
 	}
-	ts := StartMock(tykTestServerConfig{coprocessConfig: cfg})
+	ts := StartMock(MockConfig{coprocessConfig: cfg})
 
 	// Load test APIs:
 	loadTestGRPCAPIs()

--- a/gateway/coprocess_id_extractor_python_test.go
+++ b/gateway/coprocess_id_extractor_python_test.go
@@ -147,7 +147,7 @@ def MyAuthHook(request, session, metadata, spec):
 // Our `pythonBundleWithAuthCheck` plugin restrict more then 1 call
 // With ID extractor, it should run multiple times (because cache)
 func TestValueExtractorHeaderSource(t *testing.T) {
-	ts := StartMock(MockConfig{
+	ts := StartTest(TestConfig{
 		coprocessConfig: config.CoProcessConfig{
 			EnableCoProcess: true,
 		},

--- a/gateway/coprocess_id_extractor_python_test.go
+++ b/gateway/coprocess_id_extractor_python_test.go
@@ -147,7 +147,7 @@ def MyAuthHook(request, session, metadata, spec):
 // Our `pythonBundleWithAuthCheck` plugin restrict more then 1 call
 // With ID extractor, it should run multiple times (because cache)
 func TestValueExtractorHeaderSource(t *testing.T) {
-	ts := StartMock(tykTestServerConfig{
+	ts := StartMock(MockConfig{
 		coprocessConfig: config.CoProcessConfig{
 			EnableCoProcess: true,
 		},

--- a/gateway/coprocess_id_extractor_python_test.go
+++ b/gateway/coprocess_id_extractor_python_test.go
@@ -147,7 +147,7 @@ def MyAuthHook(request, session, metadata, spec):
 // Our `pythonBundleWithAuthCheck` plugin restrict more then 1 call
 // With ID extractor, it should run multiple times (because cache)
 func TestValueExtractorHeaderSource(t *testing.T) {
-	ts := newTykTestServer(tykTestServerConfig{
+	ts := StartMock(tykTestServerConfig{
 		coprocessConfig: config.CoProcessConfig{
 			EnableCoProcess: true,
 		},
@@ -155,7 +155,7 @@ func TestValueExtractorHeaderSource(t *testing.T) {
 	})
 	defer ts.Close()
 
-	spec := buildAPI(func(spec *APISpec) {
+	spec := BuildAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/"
 		spec.UseKeylessAccess = false
 		spec.EnableCoProcessAuth = true
@@ -165,7 +165,7 @@ func TestValueExtractorHeaderSource(t *testing.T) {
 		spec.CustomMiddlewareBundle = bundleID
 		spec.APIID = "api1"
 
-		loadAPI(spec)
+		LoadAPI(spec)
 		time.Sleep(1 * time.Second)
 
 		ts.Run(t, []test.TestCase{
@@ -179,7 +179,7 @@ func TestValueExtractorHeaderSource(t *testing.T) {
 		spec.CustomMiddlewareBundle = bundleID
 		spec.APIID = "api2"
 
-		loadAPI(spec)
+		LoadAPI(spec)
 		time.Sleep(1 * time.Second)
 
 		formHeaders := map[string]string{"Content-Type": "application/x-www-form-urlencoded"}
@@ -195,7 +195,7 @@ func TestValueExtractorHeaderSource(t *testing.T) {
 		spec.CustomMiddlewareBundle = bundleID
 		spec.APIID = "api3"
 
-		loadAPI(spec)
+		LoadAPI(spec)
 		time.Sleep(1 * time.Second)
 
 		ts.Run(t, []test.TestCase{

--- a/gateway/coprocess_python_test.go
+++ b/gateway/coprocess_python_test.go
@@ -131,7 +131,7 @@ def MyPreHook(request, session, metadata, spec):
 }
 
 func TestPythonBundles(t *testing.T) {
-	ts := newTykTestServer(tykTestServerConfig{
+	ts := StartMock(tykTestServerConfig{
 		coprocessConfig: config.CoProcessConfig{
 			EnableCoProcess: true,
 		}})
@@ -142,7 +142,7 @@ func TestPythonBundles(t *testing.T) {
 	preHookBundle := registerBundle("python_with_pre_hook", pythonBundleWithPreHook)
 
 	t.Run("Single-file bundle with authentication hook", func(t *testing.T) {
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/test-api/"
 			spec.UseKeylessAccess = false
 			spec.EnableCoProcessAuth = true
@@ -163,14 +163,14 @@ func TestPythonBundles(t *testing.T) {
 
 	t.Run("Single-file bundle with post hook", func(t *testing.T) {
 
-		keyID := createSession(func(s *user.SessionState) {
+		keyID := CreateSession(func(s *user.SessionState) {
 			s.MetaData = map[string]interface{}{
 				"testkey":   map[string]interface{}{"nestedkey": "nestedvalue"},
 				"stringkey": "testvalue",
 			}
 		})
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/test-api-2/"
 			spec.UseKeylessAccess = false
 			spec.EnableCoProcessAuth = false
@@ -188,7 +188,7 @@ func TestPythonBundles(t *testing.T) {
 	})
 
 	t.Run("Single-file bundle with pre hook and UTF-8/non-UTF-8 request data", func(t *testing.T) {
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/test-api-2/"
 			spec.UseKeylessAccess = true
 			spec.EnableCoProcessAuth = false

--- a/gateway/coprocess_python_test.go
+++ b/gateway/coprocess_python_test.go
@@ -131,7 +131,7 @@ def MyPreHook(request, session, metadata, spec):
 }
 
 func TestPythonBundles(t *testing.T) {
-	ts := StartMock(tykTestServerConfig{
+	ts := StartMock(MockConfig{
 		coprocessConfig: config.CoProcessConfig{
 			EnableCoProcess: true,
 		}})

--- a/gateway/coprocess_python_test.go
+++ b/gateway/coprocess_python_test.go
@@ -131,7 +131,7 @@ def MyPreHook(request, session, metadata, spec):
 }
 
 func TestPythonBundles(t *testing.T) {
-	ts := StartMock(MockConfig{
+	ts := StartTest(TestConfig{
 		coprocessConfig: config.CoProcessConfig{
 			EnableCoProcess: true,
 		}})

--- a/gateway/coprocess_test.go
+++ b/gateway/coprocess_test.go
@@ -141,7 +141,7 @@ func TestCoProcessMiddleware(t *testing.T) {
 
 	chain := buildCoProcessChain(spec, "hook_test", coprocess.HookType_Pre, apidef.MiddlewareDriver("python"))
 
-	session := createStandardSession()
+	session := CreateStandardSession()
 	spec.SessionManager.UpdateSession("abc", session, 60, false)
 
 	recorder := httptest.NewRecorder()
@@ -157,7 +157,7 @@ func TestCoProcessObjectPostProcess(t *testing.T) {
 
 	chain := buildCoProcessChain(spec, "hook_test_object_postprocess", coprocess.HookType_Pre, apidef.MiddlewareDriver("python"))
 
-	session := createStandardSession()
+	session := CreateStandardSession()
 	spec.SessionManager.UpdateSession("abc", session, 60, false)
 
 	recorder := httptest.NewRecorder()
@@ -211,7 +211,7 @@ func TestCoProcessAuth(t *testing.T) {
 
 	chain := buildCoProcessChain(spec, "hook_test_bad_auth", coprocess.HookType_CustomKeyCheck, apidef.MiddlewareDriver("python"))
 
-	session := createStandardSession()
+	session := CreateStandardSession()
 	spec.SessionManager.UpdateSession("abc", session, 60, false)
 
 	recorder := httptest.NewRecorder()
@@ -230,7 +230,7 @@ func TestCoProcessAuth(t *testing.T) {
 func TestCoProcessReturnOverrides(t *testing.T) {
 	spec := createSpecTest(t, basicCoProcessDef)
 	chain := buildCoProcessChain(spec, "hook_test_return_overrides", coprocess.HookType_Pre, apidef.MiddlewareDriver("python"))
-	session := createStandardSession()
+	session := CreateStandardSession()
 	spec.SessionManager.UpdateSession("abc", session, 60, false)
 
 	recorder := httptest.NewRecorder()
@@ -250,7 +250,7 @@ func TestCoProcessReturnOverrides(t *testing.T) {
 func TestCoProcessReturnOverridesErrorMessage(t *testing.T) {
 	spec := createSpecTest(t, basicCoProcessDef)
 	chain := buildCoProcessChain(spec, "hook_test_return_overrides_error", coprocess.HookType_Pre, apidef.MiddlewareDriver("python"))
-	session := createStandardSession()
+	session := CreateStandardSession()
 	spec.SessionManager.UpdateSession("abc", session, 60, false)
 
 	recorder := httptest.NewRecorder()

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -2,29 +2,28 @@ package gateway
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math/rand"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"path/filepath"
+
 	"runtime"
-	"strconv"
+
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
-	"github.com/gorilla/mux"
+
+
 	"github.com/gorilla/websocket"
 	msgpack "gopkg.in/vmihailenco/msgpack.v2"
+	"github.com/garyburd/redigo/redis"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/cli"
@@ -34,149 +33,15 @@ import (
 	"github.com/TykTechnologies/tyk/user"
 )
 
-func init() {
-	runningTests = true
-}
-
-var (
-	// to register to, but never used
-	discardMuxer = mux.NewRouter()
-
-	// to simulate time ticks for tests that do reloads
-	reloadTick = make(chan time.Time)
-
-	// Used to store the test bundles:
-	testMiddlewarePath, _ = ioutil.TempDir("", "tyk-middleware-path")
-
-	mockHandle *test.DnsMockHandle
-)
-
 const defaultListenPort = 8080
 const mockOrgID = "507f1f77bcf86cd799439011"
-
-var defaultTestConfig config.Config
-var testServerRouter *mux.Router
 
 func resetTestConfig() {
 	config.SetGlobal(defaultTestConfig)
 }
 
-// simulate reloads in the background, i.e. writes to
-// global variables that should not be accessed in a
-// racy way like the policies and api specs maps.
-func reloadSimulation() {
-	for {
-		policiesMu.Lock()
-		policiesByID["_"] = user.Policy{}
-		delete(policiesByID, "_")
-		policiesMu.Unlock()
-		apisMu.Lock()
-		old := apiSpecs
-		apiSpecs = append(apiSpecs, nil)
-		apiSpecs = old
-		apisByID["_"] = nil
-		delete(apisByID, "_")
-		apisMu.Unlock()
-		time.Sleep(5 * time.Millisecond)
-	}
-}
-
 func TestMain(m *testing.M) {
-	os.Exit(initTestMain(m))
-}
-
-func initTestMain(m *testing.M) int {
-	testServerRouter = testHttpHandler()
-	testServer := &http.Server{
-		Addr:           testHttpListen,
-		Handler:        testServerRouter,
-		ReadTimeout:    1 * time.Second,
-		WriteTimeout:   1 * time.Second,
-		MaxHeaderBytes: 1 << 20,
-	}
-
-	globalConf := config.Global()
-	if err := config.WriteDefault("", &globalConf); err != nil {
-		panic(err)
-	}
-	globalConf.Storage.Database = rand.Intn(15)
-	var err error
-	globalConf.AppPath, err = ioutil.TempDir("", "tyk-test-")
-	if err != nil {
-		panic(err)
-	}
-	globalConf.EnableAnalytics = true
-	globalConf.AnalyticsConfig.EnableGeoIP = true
-	globalConf.AnalyticsConfig.GeoIPDBLocation = filepath.Join("../testdata", "MaxMind-DB-test-ipv4-24.mmdb")
-	globalConf.EnableJSVM = true
-	globalConf.Monitor.EnableTriggerMonitors = true
-	globalConf.AnalyticsConfig.NormaliseUrls.Enabled = true
-	globalConf.AllowInsecureConfigs = true
-	// Enable coprocess and bundle downloader:
-	globalConf.CoProcessOptions.EnableCoProcess = true
-	globalConf.CoProcessOptions.PythonPathPrefix = "../"
-	globalConf.EnableBundleDownloader = true
-	globalConf.BundleBaseURL = testHttpBundles
-	globalConf.MiddlewarePath = testMiddlewarePath
-	purgeTicker = make(chan time.Time)
-	rpcPurgeTicker = make(chan time.Time)
-	// force ipv4 for now, to work around the docker bug affecting
-	// Go 1.8 and ealier
-	globalConf.ListenAddress = "127.0.0.1"
-
-	mockHandle, err = test.InitDNSMock(test.DomainsToAddresses, nil)
-	if err != nil {
-		panic(err)
-	}
-
-	defer func() {
-		testServer.Shutdown(context.Background())
-		mockHandle.ShutdownDnsMock()
-	}()
-
-	go func() {
-		err := testServer.ListenAndServe()
-		if err != nil {
-			log.Warn("testServer.ListenAndServe() err: ", err.Error())
-		}
-	}()
-
-	CoProcessInit()
-	afterConfSetup(&globalConf)
-	defaultTestConfig = globalConf
-	config.SetGlobal(globalConf)
-	if err := emptyRedis(); err != nil {
-		panic(err)
-	}
-	cli.Init(VERSION, confPaths)
-	initialiseSystem()
-	// Small part of start()
-	loadAPIEndpoints(mainRouter)
-	if analytics.GeoIPDB == nil {
-		panic("GeoIPDB was not initialized")
-	}
-	go startPubSubLoop()
-	go reloadLoop(reloadTick)
-	go reloadQueueLoop()
-	go reloadSimulation()
-	exitCode := m.Run()
-	os.RemoveAll(config.Global().AppPath)
-	return exitCode
-}
-
-func emptyRedis() error {
-	addr := config.Global().Storage.Host + ":" + strconv.Itoa(config.Global().Storage.Port)
-	c, err := redis.Dial("tcp", addr)
-	if err != nil {
-		return fmt.Errorf("could not connect to redis: %v", err)
-	}
-	defer c.Close()
-	dbName := strconv.Itoa(config.Global().Storage.Database)
-	if _, err := c.Do("SELECT", dbName); err != nil {
-		return err
-	}
-	_, err = c.Do("FLUSHDB")
-	return err
+	os.Exit(InitTestMain(m))
 }
 
 func createNonThrottledSession() *user.SessionState {
@@ -193,18 +58,20 @@ func createNonThrottledSession() *user.SessionState {
 	return session
 }
 
-func createStandardSession() *user.SessionState {
-	session := new(user.SessionState)
-	session.Rate = 10000
-	session.Allowance = session.Rate
-	session.LastCheck = time.Now().Unix()
-	session.Per = 60
-	session.Expires = -1
-	session.QuotaRenewalRate = 300 // 5 minutes
-	session.QuotaRenews = time.Now().Unix() + 20
-	session.QuotaRemaining = 10
-	session.QuotaMax = -1
-	return session
+func TestAA(t *testing.T){
+	ts := StartMock()
+
+	ts.Start()
+	defer ts.Close()
+
+	BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/"
+	})
+
+	ts.Run(t, []test.TestCase{
+		{Code: 200},
+	}...)
+
 }
 
 type tykErrorResponse struct {
@@ -259,16 +126,16 @@ func testReq(t testing.TB, method, urlStr string, body interface{}) *http.Reques
 }
 
 func TestParambasedAuth(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Auth.UseParam = true
 		spec.UseKeylessAccess = false
 		spec.Proxy.ListenPath = "/"
 	})
 
-	key := createSession(func(s *user.SessionState) {
+	key := CreateSession(func(s *user.SessionState) {
 		s.AccessRights = map[string]user.AccessDefinition{"test": {
 			APIID: "test", Versions: []string{"v1"},
 		}}
@@ -292,12 +159,12 @@ func TestParambasedAuth(t *testing.T) {
 }
 
 func TestStripPathWithURLRewrite(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 	defer resetTestConfig()
 
 	t.Run("rewrite URL containing listen path", func(t *testing.T) {
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			version := spec.VersionData.Versions["v1"]
 			json.Unmarshal([]byte(`{
                 "use_extended_paths": true,
@@ -323,7 +190,7 @@ func TestStripPathWithURLRewrite(t *testing.T) {
 }
 
 func TestSkipTargetPassEscapingOff(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 	defer resetTestConfig()
 
@@ -332,7 +199,7 @@ func TestSkipTargetPassEscapingOff(t *testing.T) {
 		globalConf.HttpServerOptions.SkipTargetPathEscaping = false
 		config.SetGlobal(globalConf)
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 		})
 
@@ -347,7 +214,7 @@ func TestSkipTargetPassEscapingOff(t *testing.T) {
 		globalConf.HttpServerOptions.SkipTargetPathEscaping = true
 		config.SetGlobal(globalConf)
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 		})
 
@@ -362,7 +229,7 @@ func TestSkipTargetPassEscapingOff(t *testing.T) {
 		globalConf.HttpServerOptions.SkipTargetPathEscaping = false
 		config.SetGlobal(globalConf)
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.StripListenPath = false
 			spec.Proxy.ListenPath = "/listen_me"
 			spec.Proxy.TargetURL = testHttpAny + "/sent_to_me"
@@ -379,7 +246,7 @@ func TestSkipTargetPassEscapingOff(t *testing.T) {
 		globalConf.HttpServerOptions.SkipTargetPathEscaping = true
 		config.SetGlobal(globalConf)
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.StripListenPath = false
 			spec.Proxy.ListenPath = "/listen_me"
 			spec.Proxy.TargetURL = testHttpAny + "/sent_to_me"
@@ -396,7 +263,7 @@ func TestSkipTargetPassEscapingOff(t *testing.T) {
 		globalConf.HttpServerOptions.SkipTargetPathEscaping = false
 		config.SetGlobal(globalConf)
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.StripListenPath = true
 			spec.Proxy.ListenPath = "/listen_me"
 			spec.Proxy.TargetURL = testHttpAny + "/sent_to_me"
@@ -413,7 +280,7 @@ func TestSkipTargetPassEscapingOff(t *testing.T) {
 		globalConf.HttpServerOptions.SkipTargetPathEscaping = true
 		config.SetGlobal(globalConf)
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.StripListenPath = true
 			spec.Proxy.ListenPath = "/listen_me"
 			spec.Proxy.TargetURL = testHttpAny + "/sent_to_me"
@@ -440,7 +307,7 @@ func TestSkipTargetPassEscapingOffWithSkipURLCleaningTrue(t *testing.T) {
 	testServerRouter.SkipClean(true)
 	defer testServerRouter.SkipClean(prevSkipClean)
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	t.Run("With escaping, default", func(t *testing.T) {
@@ -448,7 +315,7 @@ func TestSkipTargetPassEscapingOffWithSkipURLCleaningTrue(t *testing.T) {
 		globalConf.HttpServerOptions.SkipTargetPathEscaping = false
 		config.SetGlobal(globalConf)
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 		})
 
@@ -462,7 +329,7 @@ func TestSkipTargetPassEscapingOffWithSkipURLCleaningTrue(t *testing.T) {
 		globalConf.HttpServerOptions.SkipTargetPathEscaping = true
 		config.SetGlobal(globalConf)
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 		})
 
@@ -476,7 +343,7 @@ func TestSkipTargetPassEscapingOffWithSkipURLCleaningTrue(t *testing.T) {
 		globalConf.HttpServerOptions.SkipTargetPathEscaping = false
 		config.SetGlobal(globalConf)
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.StripListenPath = false
 			spec.Proxy.ListenPath = "/listen_me"
 			spec.Proxy.TargetURL = testHttpAny + "/sent_to_me"
@@ -494,7 +361,7 @@ func TestSkipTargetPassEscapingOffWithSkipURLCleaningTrue(t *testing.T) {
 		globalConf.HttpServerOptions.SkipTargetPathEscaping = true
 		config.SetGlobal(globalConf)
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.StripListenPath = false
 			spec.Proxy.ListenPath = "/listen_me"
 			spec.Proxy.TargetURL = testHttpAny + "/sent_to_me"
@@ -512,7 +379,7 @@ func TestSkipTargetPassEscapingOffWithSkipURLCleaningTrue(t *testing.T) {
 		globalConf.HttpServerOptions.SkipTargetPathEscaping = false
 		config.SetGlobal(globalConf)
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.StripListenPath = true
 			spec.Proxy.ListenPath = "/listen_me"
 			spec.Proxy.TargetURL = testHttpAny + "/sent_to_me"
@@ -530,7 +397,7 @@ func TestSkipTargetPassEscapingOffWithSkipURLCleaningTrue(t *testing.T) {
 		globalConf.HttpServerOptions.SkipTargetPathEscaping = true
 		config.SetGlobal(globalConf)
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.StripListenPath = true
 			spec.Proxy.ListenPath = "/listen_me"
 			spec.Proxy.TargetURL = testHttpAny + "/sent_to_me"
@@ -546,7 +413,7 @@ func TestSkipTargetPassEscapingOffWithSkipURLCleaningTrue(t *testing.T) {
 }
 
 func TestQuota(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	var keyID string
@@ -569,7 +436,7 @@ func TestQuota(t *testing.T) {
 	}))
 	defer webhook.Close()
 
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.UseKeylessAccess = false
 		spec.Proxy.ListenPath = "/"
 
@@ -607,7 +474,7 @@ func TestQuota(t *testing.T) {
 	})
 
 	// Create session with Quota = 2
-	keyID = createSession(func(s *user.SessionState) {
+	keyID = CreateSession(func(s *user.SessionState) {
 		s.QuotaMax = 2
 	})
 
@@ -629,12 +496,12 @@ func TestQuota(t *testing.T) {
 }
 
 func TestAnalytics(t *testing.T) {
-	ts := newTykTestServer(tykTestServerConfig{
+	ts := StartMock(tykTestServerConfig{
 		delay: 20 * time.Millisecond,
 	})
 	defer ts.Close()
 
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.UseKeylessAccess = false
 		spec.Proxy.ListenPath = "/"
 	})
@@ -666,7 +533,7 @@ func TestAnalytics(t *testing.T) {
 	})
 
 	t.Run("Log success", func(t *testing.T) {
-		key := createSession()
+		key := CreateSession()
 
 		authHeaders := map[string]string{
 			"authorization": key,
@@ -697,12 +564,12 @@ func TestAnalytics(t *testing.T) {
 		globalConf.AnalyticsConfig.EnableDetailedRecording = true
 		config.SetGlobal(globalConf)
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.UseKeylessAccess = false
 			spec.Proxy.ListenPath = "/"
 		})
 
-		key := createSession()
+		key := CreateSession()
 
 		authHeaders := map[string]string{
 			"authorization": key,
@@ -741,7 +608,7 @@ func TestAnalytics(t *testing.T) {
 		globalConf.AnalyticsConfig.EnableDetailedRecording = true
 		config.SetGlobal(globalConf)
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.UseKeylessAccess = false
 			spec.Proxy.ListenPath = "/"
 			spec.CacheOptions = apidef.CacheOptions{
@@ -751,7 +618,7 @@ func TestAnalytics(t *testing.T) {
 			}
 		})
 
-		key := createSession()
+		key := CreateSession()
 
 		authHeaders := map[string]string{
 			"authorization": key,
@@ -789,12 +656,12 @@ func TestAnalytics(t *testing.T) {
 
 func TestListener(t *testing.T) {
 	// Trick to get spec JSON, without loading API
-	// Specs will be reseted when we do `newTykTestServer`
-	specs := buildAndLoadAPI()
+	// Specs will be reseted when we do `StartMock`
+	specs := BuildAndLoadAPI()
 	specJSON, _ := json.Marshal(specs[0].APIDefinition)
 	listJSON := fmt.Sprintf("[%s]", string(specJSON))
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	tests := []test.TestCase{
@@ -834,7 +701,7 @@ func TestListener(t *testing.T) {
 
 // Admin api located on separate port
 func TestControlListener(t *testing.T) {
-	ts := newTykTestServer(tykTestServerConfig{
+	ts := StartMock(tykTestServerConfig{
 		sepatateControlAPI: true,
 	})
 	defer ts.Close()
@@ -858,7 +725,7 @@ func TestHttpPprof(t *testing.T) {
 	old := cli.HTTPProfile
 	defer func() { cli.HTTPProfile = old }()
 
-	ts := newTykTestServer(tykTestServerConfig{
+	ts := StartMock(tykTestServerConfig{
 		sepatateControlAPI: true,
 	})
 
@@ -902,10 +769,10 @@ func TestManagementNodeRedisEvents(t *testing.T) {
 }
 
 func TestListenPathTykPrefix(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/tyk-foo/"
 	})
 
@@ -916,7 +783,7 @@ func TestListenPathTykPrefix(t *testing.T) {
 }
 
 func TestReloadGoroutineLeakWithAsyncWrites(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	globalConf := config.Global()
@@ -925,13 +792,13 @@ func TestReloadGoroutineLeakWithAsyncWrites(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	specs := buildAndLoadAPI(func(spec *APISpec) {
+	specs := BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/"
 	})
 
 	before := runtime.NumGoroutine()
 
-	loadAPI(specs...) // just doing doReload() doesn't load anything as buildAndLoadAPI cleans up folder with API specs
+	LoadAPI(specs...) // just doing doReload() doesn't load anything as BuildAndLoadAPI cleans up folder with API specs
 
 	time.Sleep(100 * time.Millisecond)
 
@@ -943,7 +810,7 @@ func TestReloadGoroutineLeakWithAsyncWrites(t *testing.T) {
 }
 
 func TestReloadGoroutineLeakWithCircuitBreaker(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	globalConf := config.Global()
@@ -951,9 +818,9 @@ func TestReloadGoroutineLeakWithCircuitBreaker(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	specs := buildAndLoadAPI(func(spec *APISpec) {
+	specs := BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/"
-		updateAPIVersion(spec, "v1", func(version *apidef.VersionInfo) {
+		UpdateAPIVersion(spec, "v1", func(version *apidef.VersionInfo) {
 			version.ExtendedPaths = apidef.ExtendedPathsSet{
 				CircuitBreaker: []apidef.CircuitBreakerMeta{
 					{
@@ -970,7 +837,7 @@ func TestReloadGoroutineLeakWithCircuitBreaker(t *testing.T) {
 
 	before := runtime.NumGoroutine()
 
-	loadAPI(specs...) // just doing doReload() doesn't load anything as buildAndLoadAPI cleans up folder with API specs
+	LoadAPI(specs...) // just doing doReload() doesn't load anything as BuildAndLoadAPI cleans up folder with API specs
 
 	time.Sleep(100 * time.Millisecond)
 
@@ -982,10 +849,10 @@ func TestReloadGoroutineLeakWithCircuitBreaker(t *testing.T) {
 }
 
 func TestProxyUserAgent(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/"
 	})
 
@@ -1008,7 +875,7 @@ func TestSkipUrlCleaning(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1016,7 +883,7 @@ func TestSkipUrlCleaning(t *testing.T) {
 	}))
 	defer s.Close()
 
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/"
 		spec.Proxy.TargetURL = s.URL
 	})
@@ -1027,10 +894,10 @@ func TestSkipUrlCleaning(t *testing.T) {
 }
 
 func TestMultiTargetProxy(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.VersionData.NotVersioned = false
 		spec.VersionData.Versions = map[string]apidef.VersionInfo{
 			"vdef": {Name: "vdef"},
@@ -1063,7 +930,7 @@ func TestCustomDomain(t *testing.T) {
 		config.SetGlobal(globalConf)
 		defer resetTestConfig()
 
-		buildAndLoadAPI(
+		BuildAndLoadAPI(
 			func(spec *APISpec) {
 				spec.Domain = "localhost"
 			},
@@ -1074,7 +941,7 @@ func TestCustomDomain(t *testing.T) {
 	})
 
 	t.Run("Without custom domain support", func(t *testing.T) {
-		buildAndLoadAPI(
+		BuildAndLoadAPI(
 			func(spec *APISpec) {
 				spec.Domain = "localhost"
 			},
@@ -1086,7 +953,7 @@ func TestCustomDomain(t *testing.T) {
 }
 
 func TestHelloHealthcheck(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	t.Run("Without APIs", func(t *testing.T) {
@@ -1096,7 +963,7 @@ func TestHelloHealthcheck(t *testing.T) {
 	})
 
 	t.Run("With APIs", func(t *testing.T) {
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/sample"
 		})
 
@@ -1108,12 +975,12 @@ func TestHelloHealthcheck(t *testing.T) {
 }
 
 func TestCacheAllSafeRequests(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 	cache := storage.RedisCluster{KeyPrefix: "cache-"}
 	defer cache.DeleteScanMatch("*")
 
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.CacheOptions = apidef.CacheOptions{
 			CacheTimeout:         120,
 			EnableCache:          true,
@@ -1134,19 +1001,19 @@ func TestCacheAllSafeRequests(t *testing.T) {
 }
 
 func TestCachePostRequest(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 	cache := storage.RedisCluster{KeyPrefix: "cache-"}
 	defer cache.DeleteScanMatch("*")
 
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.CacheOptions = apidef.CacheOptions{
 			CacheTimeout:         120,
 			EnableCache:          true,
 			CacheAllSafeRequests: false,
 		}
 
-		updateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+		UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
 			json.Unmarshal([]byte(`[{
 						"method":"POST",
 						"path":"/",
@@ -1171,7 +1038,7 @@ func TestCachePostRequest(t *testing.T) {
 }
 
 func TestCacheEtag(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 	cache := storage.RedisCluster{KeyPrefix: "cache-"}
 	defer cache.DeleteScanMatch("*")
@@ -1181,7 +1048,7 @@ func TestCacheEtag(t *testing.T) {
 		w.Write([]byte("body"))
 	}))
 
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.CacheOptions = apidef.CacheOptions{
 			CacheTimeout:         120,
 			EnableCache:          true,
@@ -1210,10 +1077,10 @@ func TestWebsocketsUpstreamUpgradeRequest(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/"
 	})
 
@@ -1235,10 +1102,10 @@ func TestWebsocketsSeveralOpenClose(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/"
 	})
 
@@ -1333,10 +1200,10 @@ func TestWebsocketsAndHTTPEndpointMatch(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/"
 	})
 
@@ -1462,7 +1329,7 @@ func createTestUptream(t *testing.T, allowedConns int, readsPerConn int) net.Lis
 }
 
 func TestKeepAliveConns(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 	defer resetTestConfig()
 
@@ -1476,7 +1343,7 @@ func TestKeepAliveConns(t *testing.T) {
 		upstream := createTestUptream(t, 1, 3)
 		defer upstream.Close()
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.Proxy.TargetURL = "http://" + upstream.Addr().String()
 		})
@@ -1497,7 +1364,7 @@ func TestKeepAliveConns(t *testing.T) {
 		upstream := createTestUptream(t, 3, 1)
 		defer upstream.Close()
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.Proxy.TargetURL = "http://" + upstream.Addr().String()
 		})
@@ -1519,7 +1386,7 @@ func TestKeepAliveConns(t *testing.T) {
 		upstream := createTestUptream(t, 2, 2)
 		defer upstream.Close()
 
-		spec := buildAndLoadAPI(func(spec *APISpec) {
+		spec := BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.Proxy.TargetURL = "http://" + upstream.Addr().String()
 		})[0]
@@ -1549,10 +1416,10 @@ func TestRateLimitForAPIAndRateLimitAndQuotaCheck(t *testing.T) {
 
 	defer resetTestConfig()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.APIID += "_" + time.Now().String()
 		spec.UseKeylessAccess = false
 		spec.DisableRateLimit = false
@@ -1564,13 +1431,13 @@ func TestRateLimitForAPIAndRateLimitAndQuotaCheck(t *testing.T) {
 		spec.Proxy.ListenPath = "/"
 	})
 
-	sess1token := createSession(func(s *user.SessionState) {
+	sess1token := CreateSession(func(s *user.SessionState) {
 		s.Rate = 1
 		s.Per = 60
 	})
 	defer FallbackKeySesionManager.RemoveSession(sess1token, false)
 
-	sess2token := createSession(func(s *user.SessionState) {
+	sess2token := CreateSession(func(s *user.SessionState) {
 		s.Rate = 1
 		s.Per = 60
 	})
@@ -1585,15 +1452,15 @@ func TestRateLimitForAPIAndRateLimitAndQuotaCheck(t *testing.T) {
 }
 
 func TestTracing(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	prepareStorage()
-	spec := buildAPI(func(spec *APISpec) {
+	spec := BuildAPI(func(spec *APISpec) {
 		spec.UseKeylessAccess = false
 	})[0]
 
-	keyID := createSession(func(s *user.SessionState) {})
+	keyID := CreateSession(func(s *user.SessionState) {})
 	authHeaders := map[string][]string{"Authorization": {keyID}}
 
 	ts.Run(t, []test.TestCase{
@@ -1608,7 +1475,7 @@ func TestTracing(t *testing.T) {
 }
 
 func TestBrokenClients(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 	defer resetTestConfig()
 
@@ -1616,7 +1483,7 @@ func TestBrokenClients(t *testing.T) {
 	globalConf.ProxyDefaultTimeout = 1
 	config.SetGlobal(globalConf)
 
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.UseKeylessAccess = true
 		spec.Proxy.ListenPath = "/"
 		spec.EnforcedTimeoutEnabled = true

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -57,7 +57,7 @@ func createNonThrottledSession() *user.SessionState {
 }
 
 func TestAA(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 
 	ts.Start()
 	defer ts.Close()
@@ -124,7 +124,7 @@ func testReq(t testing.TB, method, urlStr string, body interface{}) *http.Reques
 }
 
 func TestParambasedAuth(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	BuildAndLoadAPI(func(spec *APISpec) {
@@ -157,7 +157,7 @@ func TestParambasedAuth(t *testing.T) {
 }
 
 func TestStripPathWithURLRewrite(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 	defer resetTestConfig()
 
@@ -188,7 +188,7 @@ func TestStripPathWithURLRewrite(t *testing.T) {
 }
 
 func TestSkipTargetPassEscapingOff(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 	defer resetTestConfig()
 
@@ -305,7 +305,7 @@ func TestSkipTargetPassEscapingOffWithSkipURLCleaningTrue(t *testing.T) {
 	testServerRouter.SkipClean(true)
 	defer testServerRouter.SkipClean(prevSkipClean)
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	t.Run("With escaping, default", func(t *testing.T) {
@@ -411,7 +411,7 @@ func TestSkipTargetPassEscapingOffWithSkipURLCleaningTrue(t *testing.T) {
 }
 
 func TestQuota(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	var keyID string
@@ -494,7 +494,7 @@ func TestQuota(t *testing.T) {
 }
 
 func TestAnalytics(t *testing.T) {
-	ts := StartMock(MockConfig{
+	ts := StartTest(TestConfig{
 		delay: 20 * time.Millisecond,
 	})
 	defer ts.Close()
@@ -654,12 +654,12 @@ func TestAnalytics(t *testing.T) {
 
 func TestListener(t *testing.T) {
 	// Trick to get spec JSON, without loading API
-	// Specs will be reseted when we do `StartMock`
+	// Specs will be reseted when we do `StartTest`
 	specs := BuildAndLoadAPI()
 	specJSON, _ := json.Marshal(specs[0].APIDefinition)
 	listJSON := fmt.Sprintf("[%s]", string(specJSON))
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	tests := []test.TestCase{
@@ -699,7 +699,7 @@ func TestListener(t *testing.T) {
 
 // Admin api located on separate port
 func TestControlListener(t *testing.T) {
-	ts := StartMock(MockConfig{
+	ts := StartTest(TestConfig{
 		sepatateControlAPI: true,
 	})
 	defer ts.Close()
@@ -723,7 +723,7 @@ func TestHttpPprof(t *testing.T) {
 	old := cli.HTTPProfile
 	defer func() { cli.HTTPProfile = old }()
 
-	ts := StartMock(MockConfig{
+	ts := StartTest(TestConfig{
 		sepatateControlAPI: true,
 	})
 
@@ -767,7 +767,7 @@ func TestManagementNodeRedisEvents(t *testing.T) {
 }
 
 func TestListenPathTykPrefix(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	BuildAndLoadAPI(func(spec *APISpec) {
@@ -781,7 +781,7 @@ func TestListenPathTykPrefix(t *testing.T) {
 }
 
 func TestReloadGoroutineLeakWithAsyncWrites(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	globalConf := config.Global()
@@ -808,7 +808,7 @@ func TestReloadGoroutineLeakWithAsyncWrites(t *testing.T) {
 }
 
 func TestReloadGoroutineLeakWithCircuitBreaker(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	globalConf := config.Global()
@@ -847,7 +847,7 @@ func TestReloadGoroutineLeakWithCircuitBreaker(t *testing.T) {
 }
 
 func TestProxyUserAgent(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	BuildAndLoadAPI(func(spec *APISpec) {
@@ -873,7 +873,7 @@ func TestSkipUrlCleaning(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -892,7 +892,7 @@ func TestSkipUrlCleaning(t *testing.T) {
 }
 
 func TestMultiTargetProxy(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	BuildAndLoadAPI(func(spec *APISpec) {
@@ -951,7 +951,7 @@ func TestCustomDomain(t *testing.T) {
 }
 
 func TestHelloHealthcheck(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	t.Run("Without APIs", func(t *testing.T) {
@@ -973,7 +973,7 @@ func TestHelloHealthcheck(t *testing.T) {
 }
 
 func TestCacheAllSafeRequests(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 	cache := storage.RedisCluster{KeyPrefix: "cache-"}
 	defer cache.DeleteScanMatch("*")
@@ -999,7 +999,7 @@ func TestCacheAllSafeRequests(t *testing.T) {
 }
 
 func TestCachePostRequest(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 	cache := storage.RedisCluster{KeyPrefix: "cache-"}
 	defer cache.DeleteScanMatch("*")
@@ -1036,7 +1036,7 @@ func TestCachePostRequest(t *testing.T) {
 }
 
 func TestCacheEtag(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 	cache := storage.RedisCluster{KeyPrefix: "cache-"}
 	defer cache.DeleteScanMatch("*")
@@ -1075,7 +1075,7 @@ func TestWebsocketsUpstreamUpgradeRequest(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	BuildAndLoadAPI(func(spec *APISpec) {
@@ -1100,7 +1100,7 @@ func TestWebsocketsSeveralOpenClose(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	BuildAndLoadAPI(func(spec *APISpec) {
@@ -1198,7 +1198,7 @@ func TestWebsocketsAndHTTPEndpointMatch(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	BuildAndLoadAPI(func(spec *APISpec) {
@@ -1327,7 +1327,7 @@ func createTestUptream(t *testing.T, allowedConns int, readsPerConn int) net.Lis
 }
 
 func TestKeepAliveConns(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 	defer resetTestConfig()
 
@@ -1414,7 +1414,7 @@ func TestRateLimitForAPIAndRateLimitAndQuotaCheck(t *testing.T) {
 
 	defer resetTestConfig()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	BuildAndLoadAPI(func(spec *APISpec) {
@@ -1450,7 +1450,7 @@ func TestRateLimitForAPIAndRateLimitAndQuotaCheck(t *testing.T) {
 }
 
 func TestTracing(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	prepareStorage()
@@ -1473,7 +1473,7 @@ func TestTracing(t *testing.T) {
 }
 
 func TestBrokenClients(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 	defer resetTestConfig()
 

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -19,11 +19,9 @@ import (
 	"testing"
 	"time"
 
-
-
+	"github.com/garyburd/redigo/redis"
 	"github.com/gorilla/websocket"
 	msgpack "gopkg.in/vmihailenco/msgpack.v2"
-	"github.com/garyburd/redigo/redis"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/cli"
@@ -58,7 +56,7 @@ func createNonThrottledSession() *user.SessionState {
 	return session
 }
 
-func TestAA(t *testing.T){
+func TestAA(t *testing.T) {
 	ts := StartMock()
 
 	ts.Start()
@@ -496,7 +494,7 @@ func TestQuota(t *testing.T) {
 }
 
 func TestAnalytics(t *testing.T) {
-	ts := StartMock(tykTestServerConfig{
+	ts := StartMock(MockConfig{
 		delay: 20 * time.Millisecond,
 	})
 	defer ts.Close()
@@ -701,7 +699,7 @@ func TestListener(t *testing.T) {
 
 // Admin api located on separate port
 func TestControlListener(t *testing.T) {
-	ts := StartMock(tykTestServerConfig{
+	ts := StartMock(MockConfig{
 		sepatateControlAPI: true,
 	})
 	defer ts.Close()
@@ -725,7 +723,7 @@ func TestHttpPprof(t *testing.T) {
 	old := cli.HTTPProfile
 	defer func() { cli.HTTPProfile = old }()
 
-	ts := StartMock(tykTestServerConfig{
+	ts := StartMock(MockConfig{
 		sepatateControlAPI: true,
 	})
 

--- a/gateway/looping_test.go
+++ b/gateway/looping_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestLooping(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	postAction := `<operation action="https://example.com/post_action">data</operation>`
@@ -22,7 +22,7 @@ func TestLooping(t *testing.T) {
 	t.Run("Using advanced URL rewrite", func(t *testing.T) {
 		// We defined internnal advanced rewrite based on body data
 		// which rewrites to internal paths (marked as blacklist so they protected from outside world)
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			version := spec.VersionData.Versions["v1"]
 			json.Unmarshal([]byte(`{
                 "use_extended_paths": true,
@@ -89,7 +89,7 @@ func TestLooping(t *testing.T) {
 	})
 
 	t.Run("Test multiple url rewrites", func(t *testing.T) {
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			version := spec.VersionData.Versions["v1"]
 			json.Unmarshal([]byte(`{
                 "use_extended_paths": true,
@@ -129,7 +129,7 @@ func TestLooping(t *testing.T) {
 	})
 
 	t.Run("Loop to another API", func(t *testing.T) {
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.APIID = "testid"
 			spec.Name = "hidden api"
 			spec.Proxy.ListenPath = "/somesecret"
@@ -212,7 +212,7 @@ func TestLooping(t *testing.T) {
 	})
 
 	t.Run("Loop limit", func(t *testing.T) {
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			version := spec.VersionData.Versions["v1"]
 			json.Unmarshal([]byte(`{
                 "use_extended_paths": true,
@@ -236,7 +236,7 @@ func TestLooping(t *testing.T) {
 	})
 
 	t.Run("Quota and rate limit calculation", func(t *testing.T) {
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			version := spec.VersionData.Versions["v1"]
 			json.Unmarshal([]byte(`{
                 "use_extended_paths": true,
@@ -255,7 +255,7 @@ func TestLooping(t *testing.T) {
 			spec.UseKeylessAccess = false
 		})
 
-		keyID := createSession(func(s *user.SessionState) {
+		keyID := CreateSession(func(s *user.SessionState) {
 			s.QuotaMax = 2
 		})
 
@@ -270,10 +270,10 @@ func TestLooping(t *testing.T) {
 func TestConcurrencyReloads(t *testing.T) {
 	var wg sync.WaitGroup
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	buildAndLoadAPI()
+	BuildAndLoadAPI()
 
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
@@ -284,7 +284,7 @@ func TestConcurrencyReloads(t *testing.T) {
 	}
 
 	for j := 0; j < 5; j++ {
-		buildAndLoadAPI()
+		BuildAndLoadAPI()
 	}
 
 	wg.Wait()

--- a/gateway/looping_test.go
+++ b/gateway/looping_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestLooping(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	postAction := `<operation action="https://example.com/post_action">data</operation>`
@@ -270,7 +270,7 @@ func TestLooping(t *testing.T) {
 func TestConcurrencyReloads(t *testing.T) {
 	var wg sync.WaitGroup
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	BuildAndLoadAPI()

--- a/gateway/mw_api_rate_limit_test.go
+++ b/gateway/mw_api_rate_limit_test.go
@@ -96,7 +96,7 @@ func requestThrottlingTest(limiter string, testLevel string) func(t *testing.T) 
 	return func(t *testing.T) {
 		defer resetTestConfig()
 
-		ts := newTykTestServer()
+		ts := StartMock()
 		defer ts.Close()
 
 		globalCfg := config.Global()
@@ -125,7 +125,7 @@ func requestThrottlingTest(limiter string, testLevel string) func(t *testing.T) 
 
 		for _, requestThrottlingEnabled := range []bool{false, true} {
 
-			spec := buildAndLoadAPI(func(spec *APISpec) {
+			spec := BuildAndLoadAPI(func(spec *APISpec) {
 				spec.Name = "test"
 				spec.APIID = "test"
 				spec.OrgID = "default"
@@ -133,7 +133,7 @@ func requestThrottlingTest(limiter string, testLevel string) func(t *testing.T) 
 				spec.Proxy.ListenPath = "/"
 			})[0]
 
-			policyID := createPolicy(func(p *user.Policy) {
+			policyID := CreatePolicy(func(p *user.Policy) {
 				p.OrgID = "default"
 
 				p.AccessRights = map[string]user.AccessDefinition{
@@ -169,7 +169,7 @@ func requestThrottlingTest(limiter string, testLevel string) func(t *testing.T) 
 				}
 			})
 
-			key := createSession(func(s *user.SessionState) {
+			key := CreateSession(func(s *user.SessionState) {
 				s.ApplyPolicies = []string{policyID}
 			})
 

--- a/gateway/mw_api_rate_limit_test.go
+++ b/gateway/mw_api_rate_limit_test.go
@@ -96,7 +96,7 @@ func requestThrottlingTest(limiter string, testLevel string) func(t *testing.T) 
 	return func(t *testing.T) {
 		defer resetTestConfig()
 
-		ts := StartMock()
+		ts := StartTest()
 		defer ts.Close()
 
 		globalCfg := config.Global()

--- a/gateway/mw_auth_key_test.go
+++ b/gateway/mw_auth_key_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestMurmur3CharBug(t *testing.T) {
 	defer resetTestConfig()
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	api := BuildAPI(func(spec *APISpec) {
@@ -105,7 +105,7 @@ func TestMurmur3CharBug(t *testing.T) {
 
 func TestSignatureValidation(t *testing.T) {
 	defer resetTestConfig()
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	api := BuildAPI(func(spec *APISpec) {

--- a/gateway/mw_auth_key_test.go
+++ b/gateway/mw_auth_key_test.go
@@ -20,10 +20,10 @@ import (
 
 func TestMurmur3CharBug(t *testing.T) {
 	defer resetTestConfig()
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	api := buildAPI(func(spec *APISpec) {
+	api := BuildAPI(func(spec *APISpec) {
 		spec.UseKeylessAccess = false
 		spec.Proxy.ListenPath = "/"
 	})[0]
@@ -37,9 +37,9 @@ func TestMurmur3CharBug(t *testing.T) {
 		globalConf.HashKeys = false
 		config.SetGlobal(globalConf)
 
-		loadAPI(api)
+		LoadAPI(api)
 
-		key := createSession()
+		key := CreateSession()
 
 		ts.Run(t, []test.TestCase{
 			genTestCase("wrong", 403),
@@ -54,9 +54,9 @@ func TestMurmur3CharBug(t *testing.T) {
 		globalConf.HashKeyFunction = ""
 		config.SetGlobal(globalConf)
 
-		loadAPI(api)
+		LoadAPI(api)
 
-		key := createSession()
+		key := CreateSession()
 
 		ts.Run(t, []test.TestCase{
 			genTestCase("wrong", 403),
@@ -72,9 +72,9 @@ func TestMurmur3CharBug(t *testing.T) {
 		globalConf.HashKeyFunction = "murmur32"
 		config.SetGlobal(globalConf)
 
-		loadAPI(api)
+		LoadAPI(api)
 
-		key := createSession()
+		key := CreateSession()
 
 		ts.Run(t, []test.TestCase{
 			genTestCase("wrong", 403),
@@ -90,9 +90,9 @@ func TestMurmur3CharBug(t *testing.T) {
 		globalConf.HashKeyFunction = "murmur64"
 		config.SetGlobal(globalConf)
 
-		loadAPI(api)
+		LoadAPI(api)
 
-		key := createSession()
+		key := CreateSession()
 
 		ts.Run(t, []test.TestCase{
 			genTestCase("wrong", 403),
@@ -105,10 +105,10 @@ func TestMurmur3CharBug(t *testing.T) {
 
 func TestSignatureValidation(t *testing.T) {
 	defer resetTestConfig()
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	api := buildAPI(func(spec *APISpec) {
+	api := BuildAPI(func(spec *APISpec) {
 		spec.UseKeylessAccess = false
 		spec.Proxy.ListenPath = "/"
 		spec.Auth.ValidateSignature = true
@@ -120,9 +120,9 @@ func TestSignatureValidation(t *testing.T) {
 
 	t.Run("Static signature", func(t *testing.T) {
 		api.Auth.Signature.Secret = "foobar"
-		loadAPI(api)
+		LoadAPI(api)
 
-		key := createSession()
+		key := CreateSession()
 		hasher := signature_validator.MasheryMd5sum{}
 		validHash := hasher.Hash(key, "foobar", time.Now().Unix())
 
@@ -149,9 +149,9 @@ func TestSignatureValidation(t *testing.T) {
 
 	t.Run("Dynamic signature", func(t *testing.T) {
 		api.Auth.Signature.Secret = "$tyk_meta.signature_secret"
-		loadAPI(api)
+		LoadAPI(api)
 
-		key := createSession(func(s *user.SessionState) {
+		key := CreateSession(func(s *user.SessionState) {
 			s.MetaData = map[string]interface{}{
 				"signature_secret": "foobar",
 			}

--- a/gateway/mw_basic_auth_test.go
+++ b/gateway/mw_basic_auth_test.go
@@ -38,7 +38,7 @@ func testPrepareBasicAuth(cacheDisabled bool) *user.SessionState {
 }
 
 func TestBasicAuth(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	session := testPrepareBasicAuth(false)
@@ -60,7 +60,7 @@ func TestBasicAuth(t *testing.T) {
 }
 
 func TestBasicAuthFromBody(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	session := CreateStandardSession()
@@ -105,7 +105,7 @@ func TestBasicAuthLegacyWithHashFunc(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	// create session with legacy key format
@@ -136,7 +136,7 @@ func TestBasicAuthCachedUserCollision(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	session := testPrepareBasicAuth(false)
@@ -168,7 +168,7 @@ func TestBasicAuthCachedUserCollision(t *testing.T) {
 }
 
 func TestBasicAuthCachedPasswordCollision(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	for _, useCache := range []bool{true, false} {
@@ -206,7 +206,7 @@ func TestBasicAuthCachedPasswordCollision(t *testing.T) {
 func BenchmarkBasicAuth(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	session := testPrepareBasicAuth(false)
@@ -239,7 +239,7 @@ func BenchmarkBasicAuth(b *testing.B) {
 func BenchmarkBasicAuth_CacheEnabled(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	session := testPrepareBasicAuth(false)
@@ -265,7 +265,7 @@ func BenchmarkBasicAuth_CacheEnabled(b *testing.B) {
 func BenchmarkBasicAuth_CacheDisabled(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	session := testPrepareBasicAuth(true)

--- a/gateway/mw_basic_auth_test.go
+++ b/gateway/mw_basic_auth_test.go
@@ -21,12 +21,12 @@ func genAuthHeader(username, password string) string {
 }
 
 func testPrepareBasicAuth(cacheDisabled bool) *user.SessionState {
-	session := createStandardSession()
+	session := CreateStandardSession()
 	session.BasicAuthData.Password = "password"
 	session.AccessRights = map[string]user.AccessDefinition{"test": {APIID: "test", Versions: []string{"v1"}}}
 	session.OrgID = "default"
 
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.UseBasicAuth = true
 		spec.BasicAuth.DisableCaching = cacheDisabled
 		spec.UseKeylessAccess = false
@@ -38,7 +38,7 @@ func testPrepareBasicAuth(cacheDisabled bool) *user.SessionState {
 }
 
 func TestBasicAuth(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	session := testPrepareBasicAuth(false)
@@ -60,15 +60,15 @@ func TestBasicAuth(t *testing.T) {
 }
 
 func TestBasicAuthFromBody(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	session := createStandardSession()
+	session := CreateStandardSession()
 	session.BasicAuthData.Password = "password"
 	session.AccessRights = map[string]user.AccessDefinition{"test": {APIID: "test", Versions: []string{"v1"}}}
 	session.OrgID = "default"
 
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.UseBasicAuth = true
 		spec.BasicAuth.ExtractFromBody = true
 		spec.BasicAuth.BodyUserRegexp = `<User>(.*)</User>`
@@ -105,7 +105,7 @@ func TestBasicAuthLegacyWithHashFunc(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	// create session with legacy key format
@@ -136,7 +136,7 @@ func TestBasicAuthCachedUserCollision(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	session := testPrepareBasicAuth(false)
@@ -168,7 +168,7 @@ func TestBasicAuthCachedUserCollision(t *testing.T) {
 }
 
 func TestBasicAuthCachedPasswordCollision(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	for _, useCache := range []bool{true, false} {
@@ -206,7 +206,7 @@ func TestBasicAuthCachedPasswordCollision(t *testing.T) {
 func BenchmarkBasicAuth(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	session := testPrepareBasicAuth(false)
@@ -239,7 +239,7 @@ func BenchmarkBasicAuth(b *testing.B) {
 func BenchmarkBasicAuth_CacheEnabled(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	session := testPrepareBasicAuth(false)
@@ -265,7 +265,7 @@ func BenchmarkBasicAuth_CacheEnabled(b *testing.B) {
 func BenchmarkBasicAuth_CacheDisabled(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	session := testPrepareBasicAuth(true)

--- a/gateway/mw_context_vars_test.go
+++ b/gateway/mw_context_vars_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func testPrepareContextVarsMiddleware() {
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/"
 		spec.EnableContextVars = true
 		spec.VersionData.Versions = map[string]apidef.VersionInfo{
@@ -32,7 +32,7 @@ func testPrepareContextVarsMiddleware() {
 }
 
 func TestContextVarsMiddleware(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	testPrepareContextVarsMiddleware()
@@ -48,7 +48,7 @@ func TestContextVarsMiddleware(t *testing.T) {
 func BenchmarkContextVarsMiddleware(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	testPrepareContextVarsMiddleware()

--- a/gateway/mw_context_vars_test.go
+++ b/gateway/mw_context_vars_test.go
@@ -32,7 +32,7 @@ func testPrepareContextVarsMiddleware() {
 }
 
 func TestContextVarsMiddleware(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	testPrepareContextVarsMiddleware()
@@ -48,7 +48,7 @@ func TestContextVarsMiddleware(t *testing.T) {
 func BenchmarkContextVarsMiddleware(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	testPrepareContextVarsMiddleware()

--- a/gateway/mw_ip_blacklist_test.go
+++ b/gateway/mw_ip_blacklist_test.go
@@ -18,7 +18,7 @@ var testBlackListIPData = []struct {
 }
 
 func testPrepareIPBlacklistMiddleware() *APISpec {
-	return buildAPI(func(spec *APISpec) {
+	return BuildAPI(func(spec *APISpec) {
 		spec.EnableIpBlacklisting = true
 		spec.BlacklistedIPs = []string{"127.0.0.1", "127.0.0.1/24"}
 	})[0]

--- a/gateway/mw_ip_whitelist_test.go
+++ b/gateway/mw_ip_whitelist_test.go
@@ -18,7 +18,7 @@ var testWhiteListIPData = []struct {
 }
 
 func testPrepareIPMiddlewarePass() *APISpec {
-	return buildAPI(func(spec *APISpec) {
+	return BuildAPI(func(spec *APISpec) {
 		spec.EnableIpWhiteListing = true
 		spec.AllowedIPs = []string{"127.0.0.1", "127.0.0.1/24"}
 	})[0]

--- a/gateway/mw_js_plugin_test.go
+++ b/gateway/mw_js_plugin_test.go
@@ -351,7 +351,7 @@ leakMid.NewProcessRequest(function(request, session) {
 }
 
 func TestTykMakeHTTPRequest(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	bundle := registerBundle("jsvm_make_http_request", map[string]string{
@@ -393,7 +393,7 @@ func TestTykMakeHTTPRequest(t *testing.T) {
 	`})
 
 	t.Run("Existing endpoint", func(t *testing.T) {
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/sample"
 			spec.ConfigData = map[string]interface{}{
 				"base_url": ts.URL,
@@ -407,7 +407,7 @@ func TestTykMakeHTTPRequest(t *testing.T) {
 	})
 
 	t.Run("Nonexistent endpoint", func(t *testing.T) {
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/sample"
 			spec.ConfigData = map[string]interface{}{
 				"base_url": ts.URL,
@@ -419,7 +419,7 @@ func TestTykMakeHTTPRequest(t *testing.T) {
 	})
 
 	t.Run("Endpoint with query", func(t *testing.T) {
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/sample"
 			spec.ConfigData = map[string]interface{}{
 				"base_url": ts.URL,
@@ -444,11 +444,11 @@ func TestTykMakeHTTPRequest(t *testing.T) {
 		testServerRouter.SkipClean(true)
 		defer testServerRouter.SkipClean(prevSkipClean)
 
-		ts := newTykTestServer()
+		ts := StartMock()
 		defer ts.Close()
 		defer resetTestConfig()
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/sample"
 			spec.ConfigData = map[string]interface{}{
 				"base_url": ts.URL,

--- a/gateway/mw_js_plugin_test.go
+++ b/gateway/mw_js_plugin_test.go
@@ -351,7 +351,7 @@ leakMid.NewProcessRequest(function(request, session) {
 }
 
 func TestTykMakeHTTPRequest(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	bundle := registerBundle("jsvm_make_http_request", map[string]string{
@@ -444,7 +444,7 @@ func TestTykMakeHTTPRequest(t *testing.T) {
 		testServerRouter.SkipClean(true)
 		defer testServerRouter.SkipClean(prevSkipClean)
 
-		ts := StartMock()
+		ts := StartTest()
 		defer ts.Close()
 		defer resetTestConfig()
 

--- a/gateway/mw_jwt_test.go
+++ b/gateway/mw_jwt_test.go
@@ -128,7 +128,7 @@ func prepareGenericJWTSession(testName string, method string, claimName string, 
 }
 
 func TestJWTSessionHMAC(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	//If we skip the check then the Id will be taken from SUB and the call will succeed
@@ -146,7 +146,7 @@ func TestJWTSessionHMAC(t *testing.T) {
 func BenchmarkJWTSessionHMAC(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	//If we skip the check then the Id will be taken from SUB and the call will succeed
@@ -163,7 +163,7 @@ func BenchmarkJWTSessionHMAC(b *testing.B) {
 
 func TestJWTHMACIdInSubClaim(t *testing.T) {
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	//Same as above
@@ -200,7 +200,7 @@ func TestJWTHMACIdInSubClaim(t *testing.T) {
 }
 
 func TestJWTRSAIdInSubClaim(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	_, jwtToken := prepareGenericJWTSession(t.Name(), RSASign, SUB, true)
@@ -231,7 +231,7 @@ func TestJWTRSAIdInSubClaim(t *testing.T) {
 }
 
 func TestJWTSessionRSA(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	//default values, keep backward compatibility
@@ -247,7 +247,7 @@ func TestJWTSessionRSA(t *testing.T) {
 func BenchmarkJWTSessionRSA(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	//default values, keep backward compatibility
@@ -262,7 +262,7 @@ func BenchmarkJWTSessionRSA(b *testing.B) {
 }
 
 func TestJWTSessionFailRSA_EmptyJWT(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	//default values, same as before (keeps backward compatibility)
@@ -277,7 +277,7 @@ func TestJWTSessionFailRSA_EmptyJWT(t *testing.T) {
 }
 
 func TestJWTSessionFailRSA_NoAuthHeader(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	//default values, same as before (keeps backward compatibility)
@@ -292,7 +292,7 @@ func TestJWTSessionFailRSA_NoAuthHeader(t *testing.T) {
 }
 
 func TestJWTSessionFailRSA_MalformedJWT(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	//default values, same as before (keeps backward compatibility)
@@ -309,7 +309,7 @@ func TestJWTSessionFailRSA_MalformedJWT(t *testing.T) {
 }
 
 func TestJWTSessionFailRSA_MalformedJWT_NOTRACK(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	//default values, same as before (keeps backward compatibility)
@@ -327,7 +327,7 @@ func TestJWTSessionFailRSA_MalformedJWT_NOTRACK(t *testing.T) {
 }
 
 func TestJWTSessionFailRSA_WrongJWT(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	//default values, same as before (keeps backward compatibility)
@@ -344,7 +344,7 @@ func TestJWTSessionFailRSA_WrongJWT(t *testing.T) {
 }
 
 func TestJWTSessionRSABearer(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	//default values, same as before (keeps backward compatibility)
@@ -361,7 +361,7 @@ func TestJWTSessionRSABearer(t *testing.T) {
 func BenchmarkJWTSessionRSABearer(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	//default values, same as before (keeps backward compatibility)
@@ -376,7 +376,7 @@ func BenchmarkJWTSessionRSABearer(b *testing.B) {
 }
 
 func TestJWTSessionRSABearerInvalid(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	//default values, same as before (keeps backward compatibility)
@@ -393,7 +393,7 @@ func TestJWTSessionRSABearerInvalid(t *testing.T) {
 }
 
 func TestJWTSessionRSABearerInvalidTwoBears(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	//default values, same as before (keeps backward compatibility)
@@ -464,7 +464,7 @@ func prepareJWTSessionRSAWithRawSourceOnWithClientID(isBench bool) string {
 }
 
 func TestJWTSessionRSAWithRawSourceOnWithClientID(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	jwtToken := prepareJWTSessionRSAWithRawSourceOnWithClientID(false)
@@ -480,7 +480,7 @@ func TestJWTSessionRSAWithRawSourceOnWithClientID(t *testing.T) {
 func BenchmarkJWTSessionRSAWithRawSourceOnWithClientID(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	jwtToken := prepareJWTSessionRSAWithRawSourceOnWithClientID(true)
@@ -520,7 +520,7 @@ func prepareJWTSessionRSAWithRawSource() string {
 }
 
 func TestJWTSessionRSAWithRawSource(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	jwtToken := prepareJWTSessionRSAWithRawSource()
@@ -536,7 +536,7 @@ func TestJWTSessionRSAWithRawSource(t *testing.T) {
 func BenchmarkJWTSessionRSAWithRawSource(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	jwtToken := prepareJWTSessionRSAWithRawSource()
@@ -555,7 +555,7 @@ func BenchmarkJWTSessionRSAWithRawSource(b *testing.B) {
 }
 
 func TestJWTSessionRSAWithRawSourceInvalidPolicyID(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	spec := BuildAPI(func(spec *APISpec) {
@@ -591,7 +591,7 @@ func TestJWTSessionRSAWithRawSourceInvalidPolicyID(t *testing.T) {
 }
 
 func TestJWTSessionExpiresAtValidationConfigs(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	pID := CreatePolicy()
@@ -666,7 +666,7 @@ func TestJWTSessionExpiresAtValidationConfigs(t *testing.T) {
 }
 
 func TestJWTSessionIssueAtValidationConfigs(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	pID := CreatePolicy()
@@ -755,7 +755,7 @@ func TestJWTSessionIssueAtValidationConfigs(t *testing.T) {
 }
 
 func TestJWTSessionNotBeforeValidationConfigs(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	pID := CreatePolicy()
@@ -823,7 +823,7 @@ func TestJWTSessionNotBeforeValidationConfigs(t *testing.T) {
 }
 
 func TestJWTExistingSessionRSAWithRawSourceInvalidPolicyID(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	spec := BuildAPI(func(spec *APISpec) {
@@ -875,7 +875,7 @@ func TestJWTExistingSessionRSAWithRawSourceInvalidPolicyID(t *testing.T) {
 }
 
 func TestJWTScopeToPolicyMapping(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	basePolicyID := CreatePolicy(func(p *user.Policy) {
@@ -1065,7 +1065,7 @@ func TestJWTScopeToPolicyMapping(t *testing.T) {
 }
 
 func TestJWTExistingSessionRSAWithRawSourcePolicyIDChanged(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	spec := BuildAPI(func(spec *APISpec) {
@@ -1168,7 +1168,7 @@ func prepareJWTSessionRSAWithJWK() string {
 }
 
 func TestJWTSessionRSAWithJWK(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	jwtToken := prepareJWTSessionRSAWithJWK()
@@ -1184,7 +1184,7 @@ func TestJWTSessionRSAWithJWK(t *testing.T) {
 func BenchmarkJWTSessionRSAWithJWK(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	jwtToken := prepareJWTSessionRSAWithJWK()
@@ -1227,7 +1227,7 @@ func prepareJWTSessionRSAWithEncodedJWK() (*APISpec, string) {
 }
 
 func TestJWTSessionRSAWithEncodedJWK(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	spec, jwtToken := prepareJWTSessionRSAWithEncodedJWK()
@@ -1256,7 +1256,7 @@ func TestJWTSessionRSAWithEncodedJWK(t *testing.T) {
 func BenchmarkJWTSessionRSAWithEncodedJWK(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	spec, jwtToken := prepareJWTSessionRSAWithEncodedJWK()
@@ -1278,7 +1278,7 @@ func BenchmarkJWTSessionRSAWithEncodedJWK(b *testing.B) {
 }
 
 func TestJWTHMACIdNewClaim(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	//If we skip the check then the Id will be taken from SUB and the call will succeed
@@ -1293,7 +1293,7 @@ func TestJWTHMACIdNewClaim(t *testing.T) {
 }
 
 func TestJWTRSAIdInClaimsWithBaseField(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	BuildAndLoadAPI(func(spec *APISpec) {
@@ -1390,7 +1390,7 @@ func TestJWTRSAIdInClaimsWithBaseField(t *testing.T) {
 }
 
 func TestJWTRSAIdInClaimsWithoutBaseField(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	BuildAndLoadAPI(func(spec *APISpec) {
@@ -1438,7 +1438,7 @@ func TestJWTRSAIdInClaimsWithoutBaseField(t *testing.T) {
 }
 
 func TestJWTECDSASign(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	//If we skip the check then the Id will be taken from SUB and the call will succeed
@@ -1453,7 +1453,7 @@ func TestJWTECDSASign(t *testing.T) {
 }
 
 func TestJWTUnknownSign(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	//If we skip the check then the Id will be taken from SUB and the call will succeed
@@ -1468,7 +1468,7 @@ func TestJWTUnknownSign(t *testing.T) {
 }
 
 func TestJWTRSAInvalidPublickKey(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	BuildAndLoadAPI(func(spec *APISpec) {
@@ -1517,7 +1517,7 @@ func createExpiringPolicy(pGen ...func(p *user.Policy)) string {
 }
 
 func TestJWTExpOverridesToken(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 	//create policy which sets keys to have expiry in one second
 	pID := createExpiringPolicy()

--- a/gateway/mw_jwt_test.go
+++ b/gateway/mw_jwt_test.go
@@ -17,39 +17,6 @@ import (
 	"github.com/TykTechnologies/tyk/user"
 )
 
-const jwtSecret = "9879879878787878"
-
-// openssl genrsa -out app.rsa
-const jwtRSAPrivKey = `
------BEGIN RSA PRIVATE KEY-----
-MIIEpQIBAAKCAQEAyqZ4rwKF8qCExS7kpY4cnJa/37FMkJNkalZ3OuslLB0oRL8T
-4c94kdF4aeNzSFkSe2n99IBI6Ssl79vbfMZb+t06L0Q94k+/P37x7+/RJZiff4y1
-VGjrnrnMI2iu9l4iBBRYzNmG6eblroEMMWlgk5tysHgxB59CSNIcD9gqk1hx4n/F
-gOmvKsfQgWHNlPSDTRcWGWGhB2/XgNVYG2pOlQxAPqLhBHeqGTXBbPfGF9cHzixp
-sPr6GtbzPwhsQ/8bPxoJ7hdfn+rzztks3d6+HWURcyNTLRe0mjXjjee9Z6+gZ+H+
-fS4pnP9tqT7IgU6ePUWTpjoiPtLexgsAa/ctjQIDAQABAoIBAECWvnBJRZgHQUn3
-oDiECup9wbnyMI0D7UVXObk1qSteP69pl1SpY6xWLyLQs7WjbhiXt7FuEc7/SaAh
-Wttx/W7/g8P85Bx1fmcmdsYakXaCJpPorQKyTibQ4ReIDfvIFN9n/MWNr0ptpVbx
-GonFJFrneK52IGplgCLllLwYEbnULYcJc6E25Ro8U2gQjF2r43PDa07YiDrmB/GV
-QQW4HTo+CA9rdK0bP8GpXgc0wpmBhx/t/YdnDg6qhzyUMk9As7JrAzYPjHO0cRun
-vhA/aG/mdMmRumY75nj7wB5U5DgstsN2ER75Pjr1xe1knftIyNm15AShCPfLaLGo
-dA2IpwECgYEA5E8h6ssa7QroCGwp/N0wSJW41hFYGygbOEg6yPWTJkqmMZVduD8X
-/KFqJK4LcIbFQuR28+hWJpHm/RF1AMRhbbWkAj6h02gv5izFwDiFKev5paky4Evg
-G8WfUOmSZ1D+fVxwaoG0OaRZpCovUTxYig3xrI659DMeKqpQ7e8l9ekCgYEA4zql
-l4P4Dn0ydr+TI/s4NHIQHkaLQAVk3OWwyKowijXd8LCtuZRA1NKSpqQ4ZXi0B17o
-9zzF5jEUjws3qWv4PKWdxJu3y+h/etsg7wxUeNizbY2ooUGeMbk0tWxJihbgaI7E
-XxLIT50F3Ky4EJ2cUL9GmJ+gLCw0KIaVbkiyYAUCgYEA0WyVHB76r/2VIkS1rzHm
-HG7ageKfAyoi7dmzsqsxM6q+EDWHJn8Zra8TAlp0O+AkClwvkUTJ4c9sJy9gODfr
-dwtrSnPRVW74oRbovo4Z+H5xHbi65mwzQsZggYP/u63cA3pL1Cbt/wH3CFN52/aS
-8PAhg7vYb1yEi3Z3jgoUtCECgYEAhSPX4u9waQzyhKG7lVmdlR1AVH0BGoIOl1/+
-NZWC23i0klLzd8lmM00uoHWYldwjoC38UuFJE5eudCIeeybITMC9sHWNO+z+xP2g
-TnDrDePrPkXCiLnp9ziNqb/JVyAQXTNJ3Gsk84EN7j9Fmna/IJDyzHq7XyaHaTdy
-VyxBWAECgYEA4jYS07bPx5UMhKiMJDqUmDfLNFD97XwPoJIkOdn6ezqeOSmlmo7t
-jxHLbCmsDOAsCU/0BlLXg9wMU7n5QKSlfTVGok/PU0rq2FUXQwyKGnellrqODwFQ
-YGivtXBGXk1hlVYlje1RB+W6RQuDAegI5h8vl8pYJS9JQH0wjatsDaE=
------END RSA PRIVATE KEY-----
-`
-
 // openssl rsa -in app.rsa -pubout > app.rsa.pub
 const jwtRSAPubKey = `
 -----BEGIN PUBLIC KEY-----
@@ -130,7 +97,7 @@ func prepareGenericJWTSession(testName string, method string, claimName string, 
 	case RSASign:
 		sessionFunc = createJWTSessionWithRSA
 
-		jwtToken = createJWKToken(func(t *jwt.Token) {
+		jwtToken = CreateJWKToken(func(t *jwt.Token) {
 			t.Claims.(jwt.MapClaims)["foo"] = "bar"
 			t.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour * 72).Unix()
 
@@ -143,7 +110,7 @@ func prepareGenericJWTSession(testName string, method string, claimName string, 
 		})
 	}
 
-	spec := buildAndLoadAPI(func(spec *APISpec) {
+	spec := BuildAndLoadAPI(func(spec *APISpec) {
 		spec.UseKeylessAccess = false
 		spec.JWTSigningMethod = method
 		spec.EnableJWT = true
@@ -161,7 +128,7 @@ func prepareGenericJWTSession(testName string, method string, claimName string, 
 }
 
 func TestJWTSessionHMAC(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	//If we skip the check then the Id will be taken from SUB and the call will succeed
@@ -179,7 +146,7 @@ func TestJWTSessionHMAC(t *testing.T) {
 func BenchmarkJWTSessionHMAC(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	//If we skip the check then the Id will be taken from SUB and the call will succeed
@@ -196,7 +163,7 @@ func BenchmarkJWTSessionHMAC(b *testing.B) {
 
 func TestJWTHMACIdInSubClaim(t *testing.T) {
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	//Same as above
@@ -233,7 +200,7 @@ func TestJWTHMACIdInSubClaim(t *testing.T) {
 }
 
 func TestJWTRSAIdInSubClaim(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	_, jwtToken := prepareGenericJWTSession(t.Name(), RSASign, SUB, true)
@@ -264,7 +231,7 @@ func TestJWTRSAIdInSubClaim(t *testing.T) {
 }
 
 func TestJWTSessionRSA(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	//default values, keep backward compatibility
@@ -280,7 +247,7 @@ func TestJWTSessionRSA(t *testing.T) {
 func BenchmarkJWTSessionRSA(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	//default values, keep backward compatibility
@@ -295,7 +262,7 @@ func BenchmarkJWTSessionRSA(b *testing.B) {
 }
 
 func TestJWTSessionFailRSA_EmptyJWT(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	//default values, same as before (keeps backward compatibility)
@@ -310,7 +277,7 @@ func TestJWTSessionFailRSA_EmptyJWT(t *testing.T) {
 }
 
 func TestJWTSessionFailRSA_NoAuthHeader(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	//default values, same as before (keeps backward compatibility)
@@ -325,7 +292,7 @@ func TestJWTSessionFailRSA_NoAuthHeader(t *testing.T) {
 }
 
 func TestJWTSessionFailRSA_MalformedJWT(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	//default values, same as before (keeps backward compatibility)
@@ -342,7 +309,7 @@ func TestJWTSessionFailRSA_MalformedJWT(t *testing.T) {
 }
 
 func TestJWTSessionFailRSA_MalformedJWT_NOTRACK(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	//default values, same as before (keeps backward compatibility)
@@ -360,7 +327,7 @@ func TestJWTSessionFailRSA_MalformedJWT_NOTRACK(t *testing.T) {
 }
 
 func TestJWTSessionFailRSA_WrongJWT(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	//default values, same as before (keeps backward compatibility)
@@ -377,7 +344,7 @@ func TestJWTSessionFailRSA_WrongJWT(t *testing.T) {
 }
 
 func TestJWTSessionRSABearer(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	//default values, same as before (keeps backward compatibility)
@@ -394,7 +361,7 @@ func TestJWTSessionRSABearer(t *testing.T) {
 func BenchmarkJWTSessionRSABearer(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	//default values, same as before (keeps backward compatibility)
@@ -409,7 +376,7 @@ func BenchmarkJWTSessionRSABearer(b *testing.B) {
 }
 
 func TestJWTSessionRSABearerInvalid(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	//default values, same as before (keeps backward compatibility)
@@ -426,7 +393,7 @@ func TestJWTSessionRSABearerInvalid(t *testing.T) {
 }
 
 func TestJWTSessionRSABearerInvalidTwoBears(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	//default values, same as before (keeps backward compatibility)
@@ -451,7 +418,7 @@ func TestJWTSessionRSABearerInvalidTwoBears(t *testing.T) {
 // JWTSessionRSAWithRawSourceOnWithClientID
 
 func prepareJWTSessionRSAWithRawSourceOnWithClientID(isBench bool) string {
-	spec := buildAndLoadAPI(func(spec *APISpec) {
+	spec := BuildAndLoadAPI(func(spec *APISpec) {
 		spec.APIID = "777888"
 		spec.OrgID = "default"
 		spec.UseKeylessAccess = false
@@ -463,7 +430,7 @@ func prepareJWTSessionRSAWithRawSourceOnWithClientID(isBench bool) string {
 		spec.Proxy.ListenPath = "/"
 	})[0]
 
-	policyID := createPolicy(func(p *user.Policy) {
+	policyID := CreatePolicy(func(p *user.Policy) {
 		p.OrgID = "default"
 		p.AccessRights = map[string]user.AccessDefinition{
 			spec.APIID: {
@@ -485,7 +452,7 @@ func prepareJWTSessionRSAWithRawSourceOnWithClientID(isBench bool) string {
 	spec.SessionManager.ResetQuota(tokenID, session, false)
 	spec.SessionManager.UpdateSession(tokenID, session, 60, false)
 
-	jwtToken := createJWKToken(func(t *jwt.Token) {
+	jwtToken := CreateJWKToken(func(t *jwt.Token) {
 		t.Header["kid"] = "12345"
 		t.Claims.(jwt.MapClaims)["foo"] = "bar"
 		t.Claims.(jwt.MapClaims)["user_id"] = "user"
@@ -497,7 +464,7 @@ func prepareJWTSessionRSAWithRawSourceOnWithClientID(isBench bool) string {
 }
 
 func TestJWTSessionRSAWithRawSourceOnWithClientID(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	jwtToken := prepareJWTSessionRSAWithRawSourceOnWithClientID(false)
@@ -513,7 +480,7 @@ func TestJWTSessionRSAWithRawSourceOnWithClientID(t *testing.T) {
 func BenchmarkJWTSessionRSAWithRawSourceOnWithClientID(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	jwtToken := prepareJWTSessionRSAWithRawSourceOnWithClientID(true)
@@ -529,7 +496,7 @@ func BenchmarkJWTSessionRSAWithRawSourceOnWithClientID(b *testing.B) {
 // JWTSessionRSAWithRawSource
 
 func prepareJWTSessionRSAWithRawSource() string {
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.UseKeylessAccess = false
 		spec.EnableJWT = true
 		spec.JWTSigningMethod = RSASign
@@ -539,9 +506,9 @@ func prepareJWTSessionRSAWithRawSource() string {
 		spec.Proxy.ListenPath = "/"
 	})
 
-	pID := createPolicy()
+	pID := CreatePolicy()
 
-	jwtToken := createJWKToken(func(t *jwt.Token) {
+	jwtToken := CreateJWKToken(func(t *jwt.Token) {
 		t.Header["kid"] = "12345"
 		t.Claims.(jwt.MapClaims)["foo"] = "bar"
 		t.Claims.(jwt.MapClaims)["user_id"] = "user"
@@ -553,7 +520,7 @@ func prepareJWTSessionRSAWithRawSource() string {
 }
 
 func TestJWTSessionRSAWithRawSource(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	jwtToken := prepareJWTSessionRSAWithRawSource()
@@ -569,7 +536,7 @@ func TestJWTSessionRSAWithRawSource(t *testing.T) {
 func BenchmarkJWTSessionRSAWithRawSource(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	jwtToken := prepareJWTSessionRSAWithRawSource()
@@ -588,10 +555,10 @@ func BenchmarkJWTSessionRSAWithRawSource(b *testing.B) {
 }
 
 func TestJWTSessionRSAWithRawSourceInvalidPolicyID(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	spec := buildAPI(func(spec *APISpec) {
+	spec := BuildAPI(func(spec *APISpec) {
 		spec.UseKeylessAccess = false
 		spec.EnableJWT = true
 		spec.JWTSigningMethod = RSASign
@@ -601,11 +568,11 @@ func TestJWTSessionRSAWithRawSourceInvalidPolicyID(t *testing.T) {
 		spec.Proxy.ListenPath = "/"
 	})[0]
 
-	loadAPI(spec)
+	LoadAPI(spec)
 
-	createPolicy()
+	CreatePolicy()
 
-	jwtToken := createJWKToken(func(t *jwt.Token) {
+	jwtToken := CreateJWKToken(func(t *jwt.Token) {
 		t.Header["kid"] = "12345"
 		t.Claims.(jwt.MapClaims)["foo"] = "bar"
 		t.Claims.(jwt.MapClaims)["user_id"] = "user"
@@ -624,12 +591,12 @@ func TestJWTSessionRSAWithRawSourceInvalidPolicyID(t *testing.T) {
 }
 
 func TestJWTSessionExpiresAtValidationConfigs(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	pID := createPolicy()
+	pID := CreatePolicy()
 	jwtAuthHeaderGen := func(skew time.Duration) map[string]string {
-		jwtToken := createJWKToken(func(t *jwt.Token) {
+		jwtToken := CreateJWKToken(func(t *jwt.Token) {
 			t.Claims.(jwt.MapClaims)["policy_id"] = pID
 			t.Claims.(jwt.MapClaims)["user_id"] = "user123"
 			t.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(skew).Unix()
@@ -638,7 +605,7 @@ func TestJWTSessionExpiresAtValidationConfigs(t *testing.T) {
 		return map[string]string{"authorization": jwtToken}
 	}
 
-	spec := buildAPI(func(spec *APISpec) {
+	spec := BuildAPI(func(spec *APISpec) {
 		spec.UseKeylessAccess = false
 		spec.EnableJWT = true
 		spec.JWTSigningMethod = RSASign
@@ -651,7 +618,7 @@ func TestJWTSessionExpiresAtValidationConfigs(t *testing.T) {
 	// This test is successful by definition
 	t.Run("Expiry_After_now--Valid_jwt", func(t *testing.T) {
 		spec.JWTExpiresAtValidationSkew = 0 //Default value
-		loadAPI(spec)
+		LoadAPI(spec)
 
 		ts.Run(t, test.TestCase{
 			Headers: jwtAuthHeaderGen(+time.Second), Code: http.StatusOK,
@@ -661,7 +628,7 @@ func TestJWTSessionExpiresAtValidationConfigs(t *testing.T) {
 	// This test is successful by definition, so it's true also with skew, but just to avoid confusion.
 	t.Run("Expiry_After_now-Add_skew--Valid_jwt", func(t *testing.T) {
 		spec.JWTExpiresAtValidationSkew = 1
-		loadAPI(spec)
+		LoadAPI(spec)
 
 		ts.Run(t, test.TestCase{
 			Headers: jwtAuthHeaderGen(+time.Second), Code: http.StatusOK,
@@ -670,7 +637,7 @@ func TestJWTSessionExpiresAtValidationConfigs(t *testing.T) {
 
 	t.Run("Expiry_Before_now--Invalid_jwt", func(t *testing.T) {
 		spec.JWTExpiresAtValidationSkew = 0 //Default value
-		loadAPI(spec)
+		LoadAPI(spec)
 
 		ts.Run(t, test.TestCase{
 			Headers:   jwtAuthHeaderGen(-time.Second),
@@ -681,7 +648,7 @@ func TestJWTSessionExpiresAtValidationConfigs(t *testing.T) {
 
 	t.Run("Expired_token-Before_now-Huge_skew--Valid_jwt", func(t *testing.T) {
 		spec.JWTExpiresAtValidationSkew = 1000 // This value doesn't matter since validation is disabled
-		loadAPI(spec)
+		LoadAPI(spec)
 
 		ts.Run(t, test.TestCase{
 			Headers: jwtAuthHeaderGen(-time.Second), Code: http.StatusOK,
@@ -690,7 +657,7 @@ func TestJWTSessionExpiresAtValidationConfigs(t *testing.T) {
 
 	t.Run("Expired_token-Before_now-Add_skew--Valid_jwt", func(t *testing.T) {
 		spec.JWTExpiresAtValidationSkew = 2
-		loadAPI(spec)
+		LoadAPI(spec)
 
 		ts.Run(t, test.TestCase{
 			Headers: jwtAuthHeaderGen(-time.Second), Code: http.StatusOK,
@@ -699,12 +666,12 @@ func TestJWTSessionExpiresAtValidationConfigs(t *testing.T) {
 }
 
 func TestJWTSessionIssueAtValidationConfigs(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	pID := createPolicy()
+	pID := CreatePolicy()
 	jwtAuthHeaderGen := func(skew time.Duration) map[string]string {
-		jwtToken := createJWKToken(func(t *jwt.Token) {
+		jwtToken := CreateJWKToken(func(t *jwt.Token) {
 			t.Claims.(jwt.MapClaims)["policy_id"] = pID
 			t.Claims.(jwt.MapClaims)["user_id"] = "user123"
 			t.Claims.(jwt.MapClaims)["iat"] = time.Now().Add(skew).Unix()
@@ -713,7 +680,7 @@ func TestJWTSessionIssueAtValidationConfigs(t *testing.T) {
 		return map[string]string{"authorization": jwtToken}
 	}
 
-	spec := buildAPI(func(spec *APISpec) {
+	spec := BuildAPI(func(spec *APISpec) {
 		spec.UseKeylessAccess = false
 		spec.EnableJWT = true
 		spec.JWTSigningMethod = "rsa"
@@ -727,7 +694,7 @@ func TestJWTSessionIssueAtValidationConfigs(t *testing.T) {
 	t.Run("IssuedAt_Before_now-no_skew--Valid_jwt", func(t *testing.T) {
 		spec.JWTIssuedAtValidationSkew = 0
 
-		loadAPI(spec)
+		LoadAPI(spec)
 
 		ts.Run(t, test.TestCase{
 			Headers: jwtAuthHeaderGen(-time.Second), Code: http.StatusOK,
@@ -737,7 +704,7 @@ func TestJWTSessionIssueAtValidationConfigs(t *testing.T) {
 	t.Run("Expiry_after_now--Invalid_jwt", func(t *testing.T) {
 		spec.JWTExpiresAtValidationSkew = 0 //Default value
 
-		loadAPI(spec)
+		LoadAPI(spec)
 
 		ts.Run(t, test.TestCase{
 			Headers: jwtAuthHeaderGen(-time.Second), Code: http.StatusOK,
@@ -747,7 +714,7 @@ func TestJWTSessionIssueAtValidationConfigs(t *testing.T) {
 	t.Run("IssueAt-After_now-no_skew--Invalid_jwt", func(t *testing.T) {
 		spec.JWTIssuedAtValidationSkew = 0
 
-		loadAPI(spec)
+		LoadAPI(spec)
 
 		ts.Run(t, test.TestCase{
 			Headers:   jwtAuthHeaderGen(+time.Minute),
@@ -758,7 +725,7 @@ func TestJWTSessionIssueAtValidationConfigs(t *testing.T) {
 
 	t.Run("IssueAt--After_now-Huge_skew--valid_jwt", func(t *testing.T) {
 		spec.JWTIssuedAtValidationSkew = 1000 // This value doesn't matter since validation is disabled
-		loadAPI(spec)
+		LoadAPI(spec)
 
 		ts.Run(t, test.TestCase{
 			Headers: jwtAuthHeaderGen(+time.Second),
@@ -769,7 +736,7 @@ func TestJWTSessionIssueAtValidationConfigs(t *testing.T) {
 	// True by definition
 	t.Run("IssueAt-Before_now-Add_skew--not_valid_jwt", func(t *testing.T) {
 		spec.JWTIssuedAtValidationSkew = 2 // 2 seconds
-		loadAPI(spec)
+		LoadAPI(spec)
 
 		ts.Run(t, test.TestCase{
 			Headers: jwtAuthHeaderGen(-3 * time.Second), Code: http.StatusOK,
@@ -779,7 +746,7 @@ func TestJWTSessionIssueAtValidationConfigs(t *testing.T) {
 	t.Run("IssueAt-After_now-Add_skew--Valid_jwt", func(t *testing.T) {
 		spec.JWTIssuedAtValidationSkew = 1
 
-		loadAPI(spec)
+		LoadAPI(spec)
 
 		ts.Run(t, test.TestCase{
 			Headers: jwtAuthHeaderGen(+time.Second), Code: http.StatusOK,
@@ -788,12 +755,12 @@ func TestJWTSessionIssueAtValidationConfigs(t *testing.T) {
 }
 
 func TestJWTSessionNotBeforeValidationConfigs(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	pID := createPolicy()
+	pID := CreatePolicy()
 	jwtAuthHeaderGen := func(skew time.Duration) map[string]string {
-		jwtToken := createJWKToken(func(t *jwt.Token) {
+		jwtToken := CreateJWKToken(func(t *jwt.Token) {
 			t.Claims.(jwt.MapClaims)["policy_id"] = pID
 			t.Claims.(jwt.MapClaims)["user_id"] = "user123"
 			t.Claims.(jwt.MapClaims)["nbf"] = time.Now().Add(skew).Unix()
@@ -801,7 +768,7 @@ func TestJWTSessionNotBeforeValidationConfigs(t *testing.T) {
 		return map[string]string{"authorization": jwtToken}
 	}
 
-	spec := buildAPI(func(spec *APISpec) {
+	spec := BuildAPI(func(spec *APISpec) {
 		spec.UseKeylessAccess = false
 		spec.EnableJWT = true
 		spec.Proxy.ListenPath = "/"
@@ -815,7 +782,7 @@ func TestJWTSessionNotBeforeValidationConfigs(t *testing.T) {
 	t.Run("NotBefore_Before_now-Valid_jwt", func(t *testing.T) {
 		spec.JWTNotBeforeValidationSkew = 0
 
-		loadAPI(spec)
+		LoadAPI(spec)
 
 		ts.Run(t, test.TestCase{
 			Headers: jwtAuthHeaderGen(-time.Second), Code: http.StatusOK,
@@ -825,7 +792,7 @@ func TestJWTSessionNotBeforeValidationConfigs(t *testing.T) {
 	t.Run("NotBefore_After_now--Invalid_jwt", func(t *testing.T) {
 		spec.JWTNotBeforeValidationSkew = 0 //Default value
 
-		loadAPI(spec)
+		LoadAPI(spec)
 
 		ts.Run(t, test.TestCase{
 			Headers:   jwtAuthHeaderGen(+time.Second),
@@ -837,7 +804,7 @@ func TestJWTSessionNotBeforeValidationConfigs(t *testing.T) {
 	t.Run("NotBefore_After_now-Add_skew--valid_jwt", func(t *testing.T) {
 		spec.JWTNotBeforeValidationSkew = 1
 
-		loadAPI(spec)
+		LoadAPI(spec)
 
 		ts.Run(t, test.TestCase{
 			Headers: jwtAuthHeaderGen(+time.Second), Code: http.StatusOK,
@@ -847,7 +814,7 @@ func TestJWTSessionNotBeforeValidationConfigs(t *testing.T) {
 	t.Run("NotBefore_After_now-Huge_skew--valid_jwt", func(t *testing.T) {
 		spec.JWTNotBeforeValidationSkew = 1000 // This value is so high that it's actually similar to disabling the claim.
 
-		loadAPI(spec)
+		LoadAPI(spec)
 
 		ts.Run(t, test.TestCase{
 			Headers: jwtAuthHeaderGen(+time.Second), Code: http.StatusOK,
@@ -856,10 +823,10 @@ func TestJWTSessionNotBeforeValidationConfigs(t *testing.T) {
 }
 
 func TestJWTExistingSessionRSAWithRawSourceInvalidPolicyID(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	spec := buildAPI(func(spec *APISpec) {
+	spec := BuildAPI(func(spec *APISpec) {
 		spec.UseKeylessAccess = false
 		spec.EnableJWT = true
 		spec.JWTSigningMethod = RSASign
@@ -869,11 +836,11 @@ func TestJWTExistingSessionRSAWithRawSourceInvalidPolicyID(t *testing.T) {
 		spec.Proxy.ListenPath = "/"
 	})[0]
 
-	loadAPI(spec)
+	LoadAPI(spec)
 
-	p1ID := createPolicy()
+	p1ID := CreatePolicy()
 
-	jwtToken := createJWKToken(func(t *jwt.Token) {
+	jwtToken := CreateJWKToken(func(t *jwt.Token) {
 		t.Header["kid"] = "12345"
 		t.Claims.(jwt.MapClaims)["foo"] = "bar"
 		t.Claims.(jwt.MapClaims)["user_id"] = "user"
@@ -889,7 +856,7 @@ func TestJWTExistingSessionRSAWithRawSourceInvalidPolicyID(t *testing.T) {
 	})
 
 	// put in JWT invalid policy ID and do request again
-	jwtTokenInvalidPolicy := createJWKToken(func(t *jwt.Token) {
+	jwtTokenInvalidPolicy := CreateJWKToken(func(t *jwt.Token) {
 		t.Header["kid"] = "12345"
 		t.Claims.(jwt.MapClaims)["foo"] = "bar"
 		t.Claims.(jwt.MapClaims)["user_id"] = "user"
@@ -908,10 +875,10 @@ func TestJWTExistingSessionRSAWithRawSourceInvalidPolicyID(t *testing.T) {
 }
 
 func TestJWTScopeToPolicyMapping(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	basePolicyID := createPolicy(func(p *user.Policy) {
+	basePolicyID := CreatePolicy(func(p *user.Policy) {
 		p.AccessRights = map[string]user.AccessDefinition{
 			"base-api": {
 				Limit: &user.APILimit{
@@ -926,7 +893,7 @@ func TestJWTScopeToPolicyMapping(t *testing.T) {
 		}
 	})
 
-	spec1 := buildAPI(func(spec *APISpec) {
+	spec1 := BuildAPI(func(spec *APISpec) {
 		spec.APIID = "api1"
 		spec.UseKeylessAccess = false
 		spec.EnableJWT = true
@@ -937,7 +904,7 @@ func TestJWTScopeToPolicyMapping(t *testing.T) {
 		spec.Proxy.ListenPath = "/api1"
 	})[0]
 
-	p1ID := createPolicy(func(p *user.Policy) {
+	p1ID := CreatePolicy(func(p *user.Policy) {
 		p.AccessRights = map[string]user.AccessDefinition{
 			spec1.APIID: {
 				Limit: &user.APILimit{
@@ -952,7 +919,7 @@ func TestJWTScopeToPolicyMapping(t *testing.T) {
 		}
 	})
 
-	spec2 := buildAPI(func(spec *APISpec) {
+	spec2 := BuildAPI(func(spec *APISpec) {
 		spec.APIID = "api2"
 		spec.UseKeylessAccess = false
 		spec.EnableJWT = true
@@ -963,7 +930,7 @@ func TestJWTScopeToPolicyMapping(t *testing.T) {
 		spec.Proxy.ListenPath = "/api2"
 	})[0]
 
-	p2ID := createPolicy(func(p *user.Policy) {
+	p2ID := CreatePolicy(func(p *user.Policy) {
 		p.AccessRights = map[string]user.AccessDefinition{
 			spec2.APIID: {
 				Limit: &user.APILimit{
@@ -978,7 +945,7 @@ func TestJWTScopeToPolicyMapping(t *testing.T) {
 		}
 	})
 
-	spec3 := buildAPI(func(spec *APISpec) {
+	spec3 := BuildAPI(func(spec *APISpec) {
 		spec.APIID = "api3"
 		spec.UseKeylessAccess = false
 		spec.EnableJWT = true
@@ -989,7 +956,7 @@ func TestJWTScopeToPolicyMapping(t *testing.T) {
 		spec.Proxy.ListenPath = "/api3"
 	})[0]
 
-	spec := buildAPI(func(spec *APISpec) {
+	spec := BuildAPI(func(spec *APISpec) {
 		spec.APIID = "base-api"
 		spec.UseKeylessAccess = false
 		spec.EnableJWT = true
@@ -1004,11 +971,11 @@ func TestJWTScopeToPolicyMapping(t *testing.T) {
 		}
 	})[0]
 
-	loadAPI(spec, spec1, spec2, spec3)
+	LoadAPI(spec, spec1, spec2, spec3)
 
 	userID := "user-" + uuid.New()
 
-	jwtToken := createJWKToken(func(t *jwt.Token) {
+	jwtToken := CreateJWKToken(func(t *jwt.Token) {
 		t.Header["kid"] = "12345"
 		t.Claims.(jwt.MapClaims)["foo"] = "bar"
 		t.Claims.(jwt.MapClaims)["user_id"] = userID
@@ -1098,10 +1065,10 @@ func TestJWTScopeToPolicyMapping(t *testing.T) {
 }
 
 func TestJWTExistingSessionRSAWithRawSourcePolicyIDChanged(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	spec := buildAPI(func(spec *APISpec) {
+	spec := BuildAPI(func(spec *APISpec) {
 		spec.UseKeylessAccess = false
 		spec.EnableJWT = true
 		spec.JWTSigningMethod = RSASign
@@ -1111,16 +1078,16 @@ func TestJWTExistingSessionRSAWithRawSourcePolicyIDChanged(t *testing.T) {
 		spec.Proxy.ListenPath = "/"
 	})[0]
 
-	loadAPI(spec)
+	LoadAPI(spec)
 
-	p1ID := createPolicy(func(p *user.Policy) {
+	p1ID := CreatePolicy(func(p *user.Policy) {
 		p.QuotaMax = 111
 	})
-	p2ID := createPolicy(func(p *user.Policy) {
+	p2ID := CreatePolicy(func(p *user.Policy) {
 		p.QuotaMax = 999
 	})
 
-	jwtToken := createJWKToken(func(t *jwt.Token) {
+	jwtToken := CreateJWKToken(func(t *jwt.Token) {
 		t.Header["kid"] = "12345"
 		t.Claims.(jwt.MapClaims)["foo"] = "bar"
 		t.Claims.(jwt.MapClaims)["user_id"] = "user"
@@ -1150,7 +1117,7 @@ func TestJWTExistingSessionRSAWithRawSourcePolicyIDChanged(t *testing.T) {
 	// check key/session quota
 
 	// put in JWT another valid policy ID and do request again
-	jwtTokenAnotherPolicy := createJWKToken(func(t *jwt.Token) {
+	jwtTokenAnotherPolicy := CreateJWKToken(func(t *jwt.Token) {
 		t.Header["kid"] = "12345"
 		t.Claims.(jwt.MapClaims)["foo"] = "bar"
 		t.Claims.(jwt.MapClaims)["user_id"] = "user"
@@ -1178,7 +1145,7 @@ func TestJWTExistingSessionRSAWithRawSourcePolicyIDChanged(t *testing.T) {
 // JWTSessionRSAWithJWK
 
 func prepareJWTSessionRSAWithJWK() string {
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.UseKeylessAccess = false
 		spec.EnableJWT = true
 		spec.JWTSigningMethod = RSASign
@@ -1188,8 +1155,8 @@ func prepareJWTSessionRSAWithJWK() string {
 		spec.Proxy.ListenPath = "/"
 	})
 
-	pID := createPolicy()
-	jwtToken := createJWKToken(func(t *jwt.Token) {
+	pID := CreatePolicy()
+	jwtToken := CreateJWKToken(func(t *jwt.Token) {
 		t.Header["kid"] = "12345"
 		t.Claims.(jwt.MapClaims)["foo"] = "bar"
 		t.Claims.(jwt.MapClaims)["user_id"] = "user"
@@ -1201,7 +1168,7 @@ func prepareJWTSessionRSAWithJWK() string {
 }
 
 func TestJWTSessionRSAWithJWK(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	jwtToken := prepareJWTSessionRSAWithJWK()
@@ -1217,7 +1184,7 @@ func TestJWTSessionRSAWithJWK(t *testing.T) {
 func BenchmarkJWTSessionRSAWithJWK(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	jwtToken := prepareJWTSessionRSAWithJWK()
@@ -1237,7 +1204,7 @@ func BenchmarkJWTSessionRSAWithJWK(b *testing.B) {
 // JWTSessionRSAWithEncodedJWK
 
 func prepareJWTSessionRSAWithEncodedJWK() (*APISpec, string) {
-	spec := buildAPI(func(spec *APISpec) {
+	spec := BuildAPI(func(spec *APISpec) {
 		spec.UseKeylessAccess = false
 		spec.EnableJWT = true
 		spec.JWTSigningMethod = RSASign
@@ -1246,8 +1213,8 @@ func prepareJWTSessionRSAWithEncodedJWK() (*APISpec, string) {
 		spec.Proxy.ListenPath = "/"
 	})[0]
 
-	pID := createPolicy()
-	jwtToken := createJWKToken(func(t *jwt.Token) {
+	pID := CreatePolicy()
+	jwtToken := CreateJWKToken(func(t *jwt.Token) {
 		t.Header["kid"] = "12345"
 		// Set some claims
 		t.Claims.(jwt.MapClaims)["foo"] = "bar"
@@ -1260,7 +1227,7 @@ func prepareJWTSessionRSAWithEncodedJWK() (*APISpec, string) {
 }
 
 func TestJWTSessionRSAWithEncodedJWK(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	spec, jwtToken := prepareJWTSessionRSAWithEncodedJWK()
@@ -1269,7 +1236,7 @@ func TestJWTSessionRSAWithEncodedJWK(t *testing.T) {
 
 	t.Run("Direct JWK URL", func(t *testing.T) {
 		spec.JWTSource = testHttpJWK
-		loadAPI(spec)
+		LoadAPI(spec)
 
 		ts.Run(t, test.TestCase{
 			Headers: authHeaders, Code: http.StatusOK,
@@ -1278,7 +1245,7 @@ func TestJWTSessionRSAWithEncodedJWK(t *testing.T) {
 
 	t.Run("Base64 JWK URL", func(t *testing.T) {
 		spec.JWTSource = base64.StdEncoding.EncodeToString([]byte(testHttpJWK))
-		loadAPI(spec)
+		LoadAPI(spec)
 
 		ts.Run(t, test.TestCase{
 			Headers: authHeaders, Code: http.StatusOK,
@@ -1289,13 +1256,13 @@ func TestJWTSessionRSAWithEncodedJWK(t *testing.T) {
 func BenchmarkJWTSessionRSAWithEncodedJWK(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	spec, jwtToken := prepareJWTSessionRSAWithEncodedJWK()
 	spec.JWTSource = base64.StdEncoding.EncodeToString([]byte(testHttpJWK))
 
-	loadAPI(spec)
+	LoadAPI(spec)
 
 	authHeaders := map[string]string{"authorization": jwtToken}
 
@@ -1311,7 +1278,7 @@ func BenchmarkJWTSessionRSAWithEncodedJWK(b *testing.B) {
 }
 
 func TestJWTHMACIdNewClaim(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	//If we skip the check then the Id will be taken from SUB and the call will succeed
@@ -1326,10 +1293,10 @@ func TestJWTHMACIdNewClaim(t *testing.T) {
 }
 
 func TestJWTRSAIdInClaimsWithBaseField(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.UseKeylessAccess = false
 		spec.EnableJWT = true
 		spec.JWTSigningMethod = RSASign
@@ -1339,10 +1306,10 @@ func TestJWTRSAIdInClaimsWithBaseField(t *testing.T) {
 		spec.Proxy.ListenPath = "/"
 	})
 
-	pID := createPolicy()
+	pID := CreatePolicy()
 
 	//First test - user id in the configured base field 'user_id'
-	jwtToken := createJWKToken(func(t *jwt.Token) {
+	jwtToken := CreateJWKToken(func(t *jwt.Token) {
 		t.Header["kid"] = "12345"
 		t.Claims.(jwt.MapClaims)["foo"] = "bar"
 		t.Claims.(jwt.MapClaims)["user_id"] = "user123@test.com"
@@ -1357,7 +1324,7 @@ func TestJWTRSAIdInClaimsWithBaseField(t *testing.T) {
 	})
 
 	//user-id claim configured but it's empty - returning an error
-	jwtToken = createJWKToken(func(t *jwt.Token) {
+	jwtToken = CreateJWKToken(func(t *jwt.Token) {
 		t.Header["kid"] = "12345"
 		t.Claims.(jwt.MapClaims)["foo"] = "bar"
 		t.Claims.(jwt.MapClaims)["user_id"] = ""
@@ -1374,7 +1341,7 @@ func TestJWTRSAIdInClaimsWithBaseField(t *testing.T) {
 	})
 
 	//user-id claim configured but not found fallback to sub
-	jwtToken = createJWKToken(func(t *jwt.Token) {
+	jwtToken = CreateJWKToken(func(t *jwt.Token) {
 		t.Header["kid"] = "12345"
 		t.Claims.(jwt.MapClaims)["foo"] = "bar"
 		t.Claims.(jwt.MapClaims)["sub"] = "user123@test.com"
@@ -1389,7 +1356,7 @@ func TestJWTRSAIdInClaimsWithBaseField(t *testing.T) {
 	})
 
 	//user-id claim not found fallback to sub that is empty
-	jwtToken = createJWKToken(func(t *jwt.Token) {
+	jwtToken = CreateJWKToken(func(t *jwt.Token) {
 		t.Header["kid"] = "12345"
 		t.Claims.(jwt.MapClaims)["foo"] = "bar"
 		t.Claims.(jwt.MapClaims)["sub"] = ""
@@ -1406,7 +1373,7 @@ func TestJWTRSAIdInClaimsWithBaseField(t *testing.T) {
 	})
 
 	//user-id and sub claims not found
-	jwtToken = createJWKToken(func(t *jwt.Token) {
+	jwtToken = CreateJWKToken(func(t *jwt.Token) {
 		t.Header["kid"] = "12345"
 		t.Claims.(jwt.MapClaims)["foo"] = "bar"
 		t.Claims.(jwt.MapClaims)["policy_id"] = pID
@@ -1423,10 +1390,10 @@ func TestJWTRSAIdInClaimsWithBaseField(t *testing.T) {
 }
 
 func TestJWTRSAIdInClaimsWithoutBaseField(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.UseKeylessAccess = false
 		spec.EnableJWT = true
 		spec.JWTSigningMethod = RSASign
@@ -1436,9 +1403,9 @@ func TestJWTRSAIdInClaimsWithoutBaseField(t *testing.T) {
 		spec.Proxy.ListenPath = "/"
 	})
 
-	pID := createPolicy()
+	pID := CreatePolicy()
 
-	jwtToken := createJWKToken(func(t *jwt.Token) {
+	jwtToken := CreateJWKToken(func(t *jwt.Token) {
 		t.Header["kid"] = "12345"
 		t.Claims.(jwt.MapClaims)["foo"] = "bar"
 		t.Claims.(jwt.MapClaims)["sub"] = "user123@test.com" //is ignored
@@ -1453,7 +1420,7 @@ func TestJWTRSAIdInClaimsWithoutBaseField(t *testing.T) {
 	})
 
 	//Id is not found since there's no sub claim and user_id has't been set in the api def (spec.JWTIdentityBaseField)
-	jwtToken = createJWKToken(func(t *jwt.Token) {
+	jwtToken = CreateJWKToken(func(t *jwt.Token) {
 		t.Header["kid"] = "12345"
 		t.Claims.(jwt.MapClaims)["foo"] = "bar"
 		t.Claims.(jwt.MapClaims)["user_id"] = "user123@test.com" //is ignored
@@ -1471,7 +1438,7 @@ func TestJWTRSAIdInClaimsWithoutBaseField(t *testing.T) {
 }
 
 func TestJWTECDSASign(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	//If we skip the check then the Id will be taken from SUB and the call will succeed
@@ -1486,7 +1453,7 @@ func TestJWTECDSASign(t *testing.T) {
 }
 
 func TestJWTUnknownSign(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	//If we skip the check then the Id will be taken from SUB and the call will succeed
@@ -1501,10 +1468,10 @@ func TestJWTUnknownSign(t *testing.T) {
 }
 
 func TestJWTRSAInvalidPublickKey(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.UseKeylessAccess = false
 		spec.EnableJWT = true
 		spec.JWTSigningMethod = RSASign
@@ -1513,9 +1480,9 @@ func TestJWTRSAInvalidPublickKey(t *testing.T) {
 		spec.Proxy.ListenPath = "/"
 	})
 
-	pID := createPolicy()
+	pID := CreatePolicy()
 
-	jwtToken := createJWKToken(func(t *jwt.Token) {
+	jwtToken := CreateJWKToken(func(t *jwt.Token) {
 		t.Header["kid"] = "12345"
 		t.Claims.(jwt.MapClaims)["foo"] = "bar"
 		t.Claims.(jwt.MapClaims)["sub"] = "user123@test.com" //is ignored
@@ -1534,7 +1501,7 @@ func TestJWTRSAInvalidPublickKey(t *testing.T) {
 
 func createExpiringPolicy(pGen ...func(p *user.Policy)) string {
 	pID := keyGen.GenerateAuthKey("")
-	pol := createStandardPolicy()
+	pol := CreateStandardPolicy()
 	pol.ID = pID
 	pol.KeyExpiresIn = 1
 
@@ -1550,12 +1517,12 @@ func createExpiringPolicy(pGen ...func(p *user.Policy)) string {
 }
 
 func TestJWTExpOverridesToken(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 	//create policy which sets keys to have expiry in one second
 	pID := createExpiringPolicy()
 
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.UseKeylessAccess = false
 		spec.EnableJWT = true
 		spec.JWTSigningMethod = RSASign
@@ -1564,7 +1531,7 @@ func TestJWTExpOverridesToken(t *testing.T) {
 		spec.Proxy.ListenPath = "/"
 	})
 
-	jwtToken := createJWKToken(func(t *jwt.Token) {
+	jwtToken := CreateJWKToken(func(t *jwt.Token) {
 		t.Claims.(jwt.MapClaims)["foo"] = "bar"
 		t.Claims.(jwt.MapClaims)["sub"] = "user123@test.com" //is ignored
 		t.Claims.(jwt.MapClaims)["policy_id"] = pID

--- a/gateway/mw_organization_activity_test.go
+++ b/gateway/mw_organization_activity_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/TykTechnologies/tyk/test"
 )
 
-func testPrepareProcessRequestQuotaLimit(tb testing.TB, ts Mock, data map[string]interface{}) {
+func testPrepareProcessRequestQuotaLimit(tb testing.TB, ts Test, data map[string]interface{}) {
 	// load API
 	orgID := "test-org-" + uuid.NewV4().String()
 	BuildAndLoadAPI(func(spec *APISpec) {
@@ -42,7 +42,7 @@ func TestProcessRequestLiveQuotaLimit(t *testing.T) {
 	config.SetGlobal(globalConf)
 
 	// run test server
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	// load API
@@ -91,7 +91,7 @@ func BenchmarkProcessRequestLiveQuotaLimit(b *testing.B) {
 	defer resetTestConfig()
 
 	// run test server
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	// load API
@@ -121,7 +121,7 @@ func TestProcessRequestOffThreadQuotaLimit(t *testing.T) {
 	defer resetTestConfig()
 
 	// run test server
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	// load API
@@ -193,7 +193,7 @@ func BenchmarkProcessRequestOffThreadQuotaLimit(b *testing.B) {
 	defer resetTestConfig()
 
 	// run test server
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	// load API
@@ -224,7 +224,7 @@ func TestProcessRequestLiveRedisRollingLimiter(t *testing.T) {
 	defer resetTestConfig()
 
 	// run test server
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	// load API
@@ -281,7 +281,7 @@ func BenchmarkProcessRequestLiveRedisRollingLimiter(b *testing.B) {
 	defer resetTestConfig()
 
 	// run test server
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	// load API
@@ -312,7 +312,7 @@ func TestProcessRequestOffThreadRedisRollingLimiter(t *testing.T) {
 	defer resetTestConfig()
 
 	// run test server
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	// load API
@@ -367,7 +367,7 @@ func BenchmarkProcessRequestOffThreadRedisRollingLimiter(b *testing.B) {
 	config.SetGlobal(globalConf)
 
 	// run test server
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	// load API

--- a/gateway/mw_organization_activity_test.go
+++ b/gateway/mw_organization_activity_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/TykTechnologies/tyk/test"
 )
 
-func testPrepareProcessRequestQuotaLimit(tb testing.TB, ts tykTestServer, data map[string]interface{}) {
+func testPrepareProcessRequestQuotaLimit(tb testing.TB, ts Mock, data map[string]interface{}) {
 	// load API
 	orgID := "test-org-" + uuid.NewV4().String()
 	BuildAndLoadAPI(func(spec *APISpec) {

--- a/gateway/mw_organization_activity_test.go
+++ b/gateway/mw_organization_activity_test.go
@@ -16,7 +16,7 @@ import (
 func testPrepareProcessRequestQuotaLimit(tb testing.TB, ts tykTestServer, data map[string]interface{}) {
 	// load API
 	orgID := "test-org-" + uuid.NewV4().String()
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.UseKeylessAccess = true
 		spec.OrgID = orgID
 		spec.Proxy.ListenPath = "/"
@@ -42,7 +42,7 @@ func TestProcessRequestLiveQuotaLimit(t *testing.T) {
 	config.SetGlobal(globalConf)
 
 	// run test server
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	// load API
@@ -91,7 +91,7 @@ func BenchmarkProcessRequestLiveQuotaLimit(b *testing.B) {
 	defer resetTestConfig()
 
 	// run test server
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	// load API
@@ -121,7 +121,7 @@ func TestProcessRequestOffThreadQuotaLimit(t *testing.T) {
 	defer resetTestConfig()
 
 	// run test server
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	// load API
@@ -193,7 +193,7 @@ func BenchmarkProcessRequestOffThreadQuotaLimit(b *testing.B) {
 	defer resetTestConfig()
 
 	// run test server
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	// load API
@@ -224,7 +224,7 @@ func TestProcessRequestLiveRedisRollingLimiter(t *testing.T) {
 	defer resetTestConfig()
 
 	// run test server
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	// load API
@@ -281,7 +281,7 @@ func BenchmarkProcessRequestLiveRedisRollingLimiter(b *testing.B) {
 	defer resetTestConfig()
 
 	// run test server
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	// load API
@@ -312,7 +312,7 @@ func TestProcessRequestOffThreadRedisRollingLimiter(t *testing.T) {
 	defer resetTestConfig()
 
 	// run test server
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	// load API
@@ -367,7 +367,7 @@ func BenchmarkProcessRequestOffThreadRedisRollingLimiter(b *testing.B) {
 	config.SetGlobal(globalConf)
 
 	// run test server
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	// load API

--- a/gateway/mw_transform_jq_test.go
+++ b/gateway/mw_transform_jq_test.go
@@ -10,10 +10,10 @@ import (
 )
 
 func testPrepareJQMiddleware() {
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/"
 		spec.EnableContextVars = true
-		updateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+		UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
 			v.UseExtendedPaths = true
 			v.ExtendedPaths.TransformJQ = []apidef.TransformJQMeta{{
 				Path:   "/jq",
@@ -25,7 +25,7 @@ func testPrepareJQMiddleware() {
 }
 
 func TestJQMiddleware(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	testPrepareJQMiddleware()
@@ -43,7 +43,7 @@ func TestJQMiddleware(t *testing.T) {
 func BenchmarkJQMiddleware(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	testPrepareJQMiddleware()

--- a/gateway/mw_transform_jq_test.go
+++ b/gateway/mw_transform_jq_test.go
@@ -25,7 +25,7 @@ func testPrepareJQMiddleware() {
 }
 
 func TestJQMiddleware(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	testPrepareJQMiddleware()
@@ -43,7 +43,7 @@ func TestJQMiddleware(t *testing.T) {
 func BenchmarkJQMiddleware(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	testPrepareJQMiddleware()

--- a/gateway/mw_validate_json_test.go
+++ b/gateway/mw_validate_json_test.go
@@ -29,8 +29,8 @@ var testJsonSchema = `{
 }`
 
 func testPrepareValidateJSONSchema() {
-	buildAndLoadAPI(func(spec *APISpec) {
-		updateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+	BuildAndLoadAPI(func(spec *APISpec) {
+		UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
 			json.Unmarshal([]byte(`[
 				{
 					"path": "/v",
@@ -45,7 +45,7 @@ func testPrepareValidateJSONSchema() {
 }
 
 func TestValidateJSONSchema(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	testPrepareValidateJSONSchema()
@@ -62,7 +62,7 @@ func TestValidateJSONSchema(t *testing.T) {
 func BenchmarkValidateJSONSchema(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	testPrepareValidateJSONSchema()

--- a/gateway/mw_validate_json_test.go
+++ b/gateway/mw_validate_json_test.go
@@ -45,7 +45,7 @@ func testPrepareValidateJSONSchema() {
 }
 
 func TestValidateJSONSchema(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	testPrepareValidateJSONSchema()
@@ -62,7 +62,7 @@ func TestValidateJSONSchema(t *testing.T) {
 func BenchmarkValidateJSONSchema(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	testPrepareValidateJSONSchema()

--- a/gateway/mw_version_check_test.go
+++ b/gateway/mw_version_check_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func testPrepareVersioning() (string, string) {
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.UseKeylessAccess = false
 		spec.VersionData.NotVersioned = false
 		spec.VersionDefinition.Location = "header"
@@ -60,13 +60,13 @@ func testPrepareVersioning() (string, string) {
 		}
 	})
 
-	keyWrongVersion := createSession(func(s *user.SessionState) {
+	keyWrongVersion := CreateSession(func(s *user.SessionState) {
 		s.AccessRights = map[string]user.AccessDefinition{"test": {
 			APIID: "test", Versions: []string{"v3"},
 		}}
 	})
 
-	keyKnownVersion := createSession(func(s *user.SessionState) {
+	keyKnownVersion := CreateSession(func(s *user.SessionState) {
 		s.AccessRights = map[string]user.AccessDefinition{"test": {
 			APIID: "test", Versions: []string{"v1", "v2", "expired"},
 		}}
@@ -76,7 +76,7 @@ func testPrepareVersioning() (string, string) {
 }
 
 func TestVersioning(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	keyWrongVersion, keyKnownVersion := testPrepareVersioning()
@@ -119,7 +119,7 @@ func TestVersioning(t *testing.T) {
 func BenchmarkVersioning(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	keyWrongVersion, keyKnownVersion := testPrepareVersioning()

--- a/gateway/mw_version_check_test.go
+++ b/gateway/mw_version_check_test.go
@@ -76,7 +76,7 @@ func testPrepareVersioning() (string, string) {
 }
 
 func TestVersioning(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	keyWrongVersion, keyKnownVersion := testPrepareVersioning()
@@ -119,7 +119,7 @@ func TestVersioning(t *testing.T) {
 func BenchmarkVersioning(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	keyWrongVersion, keyKnownVersion := testPrepareVersioning()

--- a/gateway/mw_virtual_endpoint_test.go
+++ b/gateway/mw_virtual_endpoint_test.go
@@ -24,7 +24,7 @@ function testVirtData(request, session, config) {
 `
 
 func testPrepareVirtualEndpoint(js string, method string, path string, proxyOnError bool) {
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/"
 
 		virtualMeta := apidef.VirtualMeta{
@@ -58,7 +58,7 @@ func testPrepareVirtualEndpoint(js string, method string, path string, proxyOnEr
 }
 
 func TestVirtualEndpoint(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	testPrepareVirtualEndpoint(virtTestJS, "GET", "/virt", true)
@@ -75,7 +75,7 @@ func TestVirtualEndpoint(t *testing.T) {
 }
 
 func TestVirtualEndpoint500(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	testPrepareVirtualEndpoint("abc", "GET", "/abc", false)
@@ -89,7 +89,7 @@ func TestVirtualEndpoint500(t *testing.T) {
 func BenchmarkVirtualEndpoint(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	testPrepareVirtualEndpoint(virtTestJS, "GET", "/virt", true)

--- a/gateway/mw_virtual_endpoint_test.go
+++ b/gateway/mw_virtual_endpoint_test.go
@@ -58,7 +58,7 @@ func testPrepareVirtualEndpoint(js string, method string, path string, proxyOnEr
 }
 
 func TestVirtualEndpoint(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	testPrepareVirtualEndpoint(virtTestJS, "GET", "/virt", true)
@@ -75,7 +75,7 @@ func TestVirtualEndpoint(t *testing.T) {
 }
 
 func TestVirtualEndpoint500(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	testPrepareVirtualEndpoint("abc", "GET", "/abc", false)
@@ -89,7 +89,7 @@ func TestVirtualEndpoint500(t *testing.T) {
 func BenchmarkVirtualEndpoint(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	testPrepareVirtualEndpoint(virtTestJS, "GET", "/virt", true)

--- a/gateway/oauth_manager_test.go
+++ b/gateway/oauth_manager_test.go
@@ -46,7 +46,7 @@ const keyRules = `{
 }`
 
 func loadTestOAuthSpec() *APISpec {
-	spec := buildAndLoadAPI(func(spec *APISpec) {
+	spec := BuildAndLoadAPI(func(spec *APISpec) {
 		spec.APIID = "999999"
 		spec.OrgID = "default"
 		spec.Auth = apidef.Auth{
@@ -124,7 +124,7 @@ func createTestOAuthClient(spec *APISpec, clientID string) {
 }
 
 func TestAuthCodeRedirect(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	spec := loadTestOAuthSpec()
@@ -165,7 +165,7 @@ func TestAuthCodeRedirectMultipleURL(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	spec := loadTestOAuthSpec()
@@ -206,7 +206,7 @@ func TestAuthCodeRedirectInvalidMultipleURL(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	spec := loadTestOAuthSpec()
@@ -234,7 +234,7 @@ func TestAuthCodeRedirectInvalidMultipleURL(t *testing.T) {
 }
 
 func TestAPIClientAuthorizeAuthCode(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	spec := loadTestOAuthSpec()
@@ -265,7 +265,7 @@ func TestAPIClientAuthorizeAuthCode(t *testing.T) {
 }
 
 func TestAPIClientAuthorizeToken(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	spec := loadTestOAuthSpec()
@@ -296,7 +296,7 @@ func TestAPIClientAuthorizeToken(t *testing.T) {
 }
 
 func TestDeleteOauthClient(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	spec := loadTestOAuthSpec()
@@ -389,7 +389,7 @@ func TestDeleteOauthClient(t *testing.T) {
 }
 
 func TestAPIClientAuthorizeTokenWithPolicy(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	spec := loadTestOAuthSpec()
@@ -489,7 +489,7 @@ func testGetClientTokens(t *testing.T, hashed bool) {
 
 	defer resetTestConfig()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	spec := loadTestOAuthSpec()
@@ -628,7 +628,7 @@ func getToken(t *testing.T, ts *tykTestServer) tokenData {
 }
 
 func TestOAuthClientCredsGrant(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	spec := loadTestOAuthSpec()
@@ -667,7 +667,7 @@ func TestOAuthClientCredsGrant(t *testing.T) {
 }
 
 func TestClientAccessRequest(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	spec := loadTestOAuthSpec()
@@ -699,7 +699,7 @@ func TestClientAccessRequest(t *testing.T) {
 }
 
 func TestOAuthAPIRefreshInvalidate(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	spec := loadTestOAuthSpec()
@@ -756,7 +756,7 @@ func TestOAuthAPIRefreshInvalidate(t *testing.T) {
 }
 
 func TestClientRefreshRequest(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	spec := loadTestOAuthSpec()
@@ -788,7 +788,7 @@ func TestClientRefreshRequest(t *testing.T) {
 }
 
 func TestClientRefreshRequestDouble(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	spec := loadTestOAuthSpec()

--- a/gateway/oauth_manager_test.go
+++ b/gateway/oauth_manager_test.go
@@ -124,7 +124,7 @@ func createTestOAuthClient(spec *APISpec, clientID string) {
 }
 
 func TestAuthCodeRedirect(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	spec := loadTestOAuthSpec()
@@ -165,7 +165,7 @@ func TestAuthCodeRedirectMultipleURL(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	spec := loadTestOAuthSpec()
@@ -206,7 +206,7 @@ func TestAuthCodeRedirectInvalidMultipleURL(t *testing.T) {
 	config.SetGlobal(globalConf)
 	defer resetTestConfig()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	spec := loadTestOAuthSpec()
@@ -234,7 +234,7 @@ func TestAuthCodeRedirectInvalidMultipleURL(t *testing.T) {
 }
 
 func TestAPIClientAuthorizeAuthCode(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	spec := loadTestOAuthSpec()
@@ -265,7 +265,7 @@ func TestAPIClientAuthorizeAuthCode(t *testing.T) {
 }
 
 func TestAPIClientAuthorizeToken(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	spec := loadTestOAuthSpec()
@@ -296,7 +296,7 @@ func TestAPIClientAuthorizeToken(t *testing.T) {
 }
 
 func TestDeleteOauthClient(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	spec := loadTestOAuthSpec()
@@ -389,7 +389,7 @@ func TestDeleteOauthClient(t *testing.T) {
 }
 
 func TestAPIClientAuthorizeTokenWithPolicy(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	spec := loadTestOAuthSpec()
@@ -440,7 +440,7 @@ func TestAPIClientAuthorizeTokenWithPolicy(t *testing.T) {
 	})
 }
 
-func getAuthCode(t *testing.T, ts *Mock) map[string]string {
+func getAuthCode(t *testing.T, ts *Test) map[string]string {
 	param := make(url.Values)
 	param.Set("response_type", "code")
 	param.Set("redirect_uri", authRedirectUri)
@@ -489,7 +489,7 @@ func testGetClientTokens(t *testing.T, hashed bool) {
 
 	defer resetTestConfig()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	spec := loadTestOAuthSpec()
@@ -596,7 +596,7 @@ type tokenData struct {
 	RefreshToken string `json:"refresh_token"`
 }
 
-func getToken(t *testing.T, ts *Mock) tokenData {
+func getToken(t *testing.T, ts *Test) tokenData {
 	authData := getAuthCode(t, ts)
 
 	param := make(url.Values)
@@ -628,7 +628,7 @@ func getToken(t *testing.T, ts *Mock) tokenData {
 }
 
 func TestOAuthClientCredsGrant(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	spec := loadTestOAuthSpec()
@@ -667,7 +667,7 @@ func TestOAuthClientCredsGrant(t *testing.T) {
 }
 
 func TestClientAccessRequest(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	spec := loadTestOAuthSpec()
@@ -699,7 +699,7 @@ func TestClientAccessRequest(t *testing.T) {
 }
 
 func TestOAuthAPIRefreshInvalidate(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	spec := loadTestOAuthSpec()
@@ -756,7 +756,7 @@ func TestOAuthAPIRefreshInvalidate(t *testing.T) {
 }
 
 func TestClientRefreshRequest(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	spec := loadTestOAuthSpec()
@@ -788,7 +788,7 @@ func TestClientRefreshRequest(t *testing.T) {
 }
 
 func TestClientRefreshRequestDouble(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	spec := loadTestOAuthSpec()

--- a/gateway/oauth_manager_test.go
+++ b/gateway/oauth_manager_test.go
@@ -440,7 +440,7 @@ func TestAPIClientAuthorizeTokenWithPolicy(t *testing.T) {
 	})
 }
 
-func getAuthCode(t *testing.T, ts *tykTestServer) map[string]string {
+func getAuthCode(t *testing.T, ts *Mock) map[string]string {
 	param := make(url.Values)
 	param.Set("response_type", "code")
 	param.Set("redirect_uri", authRedirectUri)
@@ -596,7 +596,7 @@ type tokenData struct {
 	RefreshToken string `json:"refresh_token"`
 }
 
-func getToken(t *testing.T, ts *tykTestServer) tokenData {
+func getToken(t *testing.T, ts *Mock) tokenData {
 	authData := getAuthCode(t, ts)
 
 	param := make(url.Values)

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -487,11 +487,11 @@ func TestApplyPoliciesQuotaAPILimit(t *testing.T) {
 	}
 	policiesMu.RUnlock()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	// load APIs
-	buildAndLoadAPI(
+	BuildAndLoadAPI(
 		func(spec *APISpec) {
 			spec.Name = "api 1"
 			spec.APIID = "api1"

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestLoadPoliciesFromDashboardReLogin(t *testing.T) {
-	// Mock Dashboard
+	// Test Dashboard
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(403)
 	}))
@@ -487,7 +487,7 @@ func TestApplyPoliciesQuotaAPILimit(t *testing.T) {
 	}
 	policiesMu.RUnlock()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	// load APIs

--- a/gateway/res_handler_header_injector_test.go
+++ b/gateway/res_handler_header_injector_test.go
@@ -10,11 +10,11 @@ import (
 )
 
 func testPrepareResponseHeaderInjection() {
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.UseKeylessAccess = true
 		spec.Proxy.ListenPath = "/"
 		spec.OrgID = "default"
-		updateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+		UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
 			v.UseExtendedPaths = true
 			json.Unmarshal([]byte(`[
 				{
@@ -61,7 +61,7 @@ func testPrepareResponseHeaderInjection() {
 }
 
 func TestResponseHeaderInjection(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	testPrepareResponseHeaderInjection()
@@ -83,7 +83,7 @@ func TestResponseHeaderInjection(t *testing.T) {
 func BenchmarkResponseHeaderInjection(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	testPrepareResponseHeaderInjection()

--- a/gateway/res_handler_header_injector_test.go
+++ b/gateway/res_handler_header_injector_test.go
@@ -18,21 +18,21 @@ func testPrepareResponseHeaderInjection() {
 			v.UseExtendedPaths = true
 			json.Unmarshal([]byte(`[
 				{
-					"delete_headers": ["X-Tyk-Mock"],
+					"delete_headers": ["X-Tyk-Test"],
 					"add_headers": {"X-Test": "test"},
 					"path": "/test-with-slash",
 					"method": "GET",
 					"act_on": false
 				},
 				{
-					"delete_headers": ["X-Tyk-Mock"],
+					"delete_headers": ["X-Tyk-Test"],
 					"add_headers": {"X-Test": "test"},
 					"path": "test-no-slash",
 					"method": "GET",
 					"act_on": false
 				},
 				{
-					"delete_headers": ["X-Tyk-Mock"],
+					"delete_headers": ["X-Tyk-Test"],
 					"add_headers": {"X-Test": "test"},
 					"path": "/rewrite-test",
 					"method": "GET",
@@ -61,13 +61,13 @@ func testPrepareResponseHeaderInjection() {
 }
 
 func TestResponseHeaderInjection(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	testPrepareResponseHeaderInjection()
 
 	addHeaders := map[string]string{"X-Test": "test"}
-	deleteHeaders := map[string]string{"X-Tyk-Mock": "1"}
+	deleteHeaders := map[string]string{"X-Tyk-Test": "1"}
 	userAgent := fmt.Sprintf("\"User-Agent\":\"Tyk/%v\"", VERSION)
 
 	ts.Run(t, []test.TestCase{
@@ -83,13 +83,13 @@ func TestResponseHeaderInjection(t *testing.T) {
 func BenchmarkResponseHeaderInjection(b *testing.B) {
 	b.ReportAllocs()
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	testPrepareResponseHeaderInjection()
 
 	addHeaders := map[string]string{"X-Test": "test"}
-	deleteHeaders := map[string]string{"X-Tyk-Mock": "1"}
+	deleteHeaders := map[string]string{"X-Tyk-Test": "1"}
 	userAgent := fmt.Sprintf("\"User-Agent\":\"Tyk/%v\"", VERSION)
 
 	for i := 0; i < b.N; i++ {

--- a/gateway/res_handler_transform_test.go
+++ b/gateway/res_handler_transform_test.go
@@ -28,13 +28,13 @@ func TestTransformResponseWithURLRewrite(t *testing.T) {
 	responseProcessorConf := []apidef.ResponseProcessor{{Name: "response_body_transform"}}
 
 	t.Run("Transform without rewrite", func(t *testing.T) {
-		ts := newTykTestServer()
+		ts := StartMock()
 		defer ts.Close()
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.ResponseProcessors = responseProcessorConf
-			updateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+			UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
 				v.ExtendedPaths.TransformResponse = []apidef.TemplateMeta{transformResponseConf}
 			})
 		})
@@ -45,14 +45,14 @@ func TestTransformResponseWithURLRewrite(t *testing.T) {
 	})
 
 	t.Run("Transform path equals rewrite to ", func(t *testing.T) {
-		ts := newTykTestServer()
+		ts := StartMock()
 		defer ts.Close()
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.ResponseProcessors = responseProcessorConf
 
-			updateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+			UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
 				v.ExtendedPaths.TransformResponse = []apidef.TemplateMeta{transformResponseConf}
 				v.ExtendedPaths.URLRewrite = []apidef.URLRewriteMeta{urlRewriteConf}
 			})
@@ -64,16 +64,16 @@ func TestTransformResponseWithURLRewrite(t *testing.T) {
 	})
 
 	t.Run("Transform path equals rewrite path", func(t *testing.T) {
-		ts := newTykTestServer()
+		ts := StartMock()
 		defer ts.Close()
 
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.ResponseProcessors = responseProcessorConf
 
 			transformResponseConf.Path = "abc"
 
-			updateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+			UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
 				v.ExtendedPaths.TransformResponse = []apidef.TemplateMeta{transformResponseConf}
 				v.ExtendedPaths.URLRewrite = []apidef.URLRewriteMeta{urlRewriteConf}
 			})
@@ -86,7 +86,7 @@ func TestTransformResponseWithURLRewrite(t *testing.T) {
 }
 
 func TestTransformResponse_ContextVars(t *testing.T) {
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	transformResponseConf := apidef.TemplateMeta{
@@ -101,10 +101,10 @@ func TestTransformResponse_ContextVars(t *testing.T) {
 	responseProcessorConf := []apidef.ResponseProcessor{{Name: "response_body_transform"}}
 
 	// When Context Vars are disabled
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/"
 		spec.ResponseProcessors = responseProcessorConf
-		updateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+		UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
 			v.ExtendedPaths.TransformResponse = []apidef.TemplateMeta{transformResponseConf}
 		})
 	})
@@ -114,11 +114,11 @@ func TestTransformResponse_ContextVars(t *testing.T) {
 	})
 
 	// When Context Vars are enabled
-	buildAndLoadAPI(func(spec *APISpec) {
+	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/"
 		spec.EnableContextVars = true
 		spec.ResponseProcessors = responseProcessorConf
-		updateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+		UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
 			v.ExtendedPaths.TransformResponse = []apidef.TemplateMeta{transformResponseConf}
 		})
 	})
@@ -131,7 +131,7 @@ func TestTransformResponse_ContextVars(t *testing.T) {
 func TestTransformResponse_WithCache(t *testing.T) {
 	const path = "/get"
 
-	ts := newTykTestServer()
+	ts := StartMock()
 	defer ts.Close()
 
 	transformResponseConf := apidef.TemplateMeta{
@@ -145,13 +145,13 @@ func TestTransformResponse_WithCache(t *testing.T) {
 	responseProcessorConf := []apidef.ResponseProcessor{{Name: "response_body_transform"}}
 
 	createAPI := func(withCache bool) {
-		buildAndLoadAPI(func(spec *APISpec) {
+		BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.CacheOptions.CacheTimeout = 60
 			spec.EnableContextVars = true
 			spec.CacheOptions.EnableCache = withCache
 			spec.ResponseProcessors = responseProcessorConf
-			updateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+			UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
 				v.ExtendedPaths.TransformResponse = []apidef.TemplateMeta{transformResponseConf}
 				v.ExtendedPaths.Cached = []string{path}
 			})

--- a/gateway/res_handler_transform_test.go
+++ b/gateway/res_handler_transform_test.go
@@ -28,7 +28,7 @@ func TestTransformResponseWithURLRewrite(t *testing.T) {
 	responseProcessorConf := []apidef.ResponseProcessor{{Name: "response_body_transform"}}
 
 	t.Run("Transform without rewrite", func(t *testing.T) {
-		ts := StartMock()
+		ts := StartTest()
 		defer ts.Close()
 
 		BuildAndLoadAPI(func(spec *APISpec) {
@@ -45,7 +45,7 @@ func TestTransformResponseWithURLRewrite(t *testing.T) {
 	})
 
 	t.Run("Transform path equals rewrite to ", func(t *testing.T) {
-		ts := StartMock()
+		ts := StartTest()
 		defer ts.Close()
 
 		BuildAndLoadAPI(func(spec *APISpec) {
@@ -64,7 +64,7 @@ func TestTransformResponseWithURLRewrite(t *testing.T) {
 	})
 
 	t.Run("Transform path equals rewrite path", func(t *testing.T) {
-		ts := StartMock()
+		ts := StartTest()
 		defer ts.Close()
 
 		BuildAndLoadAPI(func(spec *APISpec) {
@@ -86,7 +86,7 @@ func TestTransformResponseWithURLRewrite(t *testing.T) {
 }
 
 func TestTransformResponse_ContextVars(t *testing.T) {
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	transformResponseConf := apidef.TemplateMeta{
@@ -131,7 +131,7 @@ func TestTransformResponse_ContextVars(t *testing.T) {
 func TestTransformResponse_WithCache(t *testing.T) {
 	const path = "/get"
 
-	ts := StartMock()
+	ts := StartTest()
 	defer ts.Close()
 
 	transformResponseConf := apidef.TemplateMeta{

--- a/gateway/rpc_test.go
+++ b/gateway/rpc_test.go
@@ -117,7 +117,7 @@ const apiDefListTest2 = `[{
 }]`
 
 func TestSyncAPISpecsRPCFailure_CheckGlobals(t *testing.T) {
-	// Mock RPC
+	// Test RPC
 	callCount := 0
 	dispatcher := gorpc.NewDispatcher()
 	dispatcher.AddFunc("GetApiDefinitions", func(clientAddr string, dr *DefRequest) (string, error) {
@@ -178,7 +178,7 @@ func TestSyncAPISpecsRPCFailure_CheckGlobals(t *testing.T) {
 
 // Our RPC layer too racy, but not harmul, mostly global variables like RPCIsClientConnected
 func TestSyncAPISpecsRPCFailure(t *testing.T) {
-	// Mock RPC
+	// Test RPC
 	dispatcher := gorpc.NewDispatcher()
 	dispatcher.AddFunc("GetApiDefinitions", func(clientAddr string, dr *DefRequest) (string, error) {
 		return "malformed json", nil
@@ -197,7 +197,7 @@ func TestSyncAPISpecsRPCFailure(t *testing.T) {
 }
 
 func TestSyncAPISpecsRPCSuccess(t *testing.T) {
-	// Mock RPC
+	// Test RPC
 	dispatcher := gorpc.NewDispatcher()
 	dispatcher.AddFunc("GetApiDefinitions", func(clientAddr string, dr *DefRequest) (string, error) {
 		return jsonMarshalString(BuildAPI(func(spec *APISpec) {
@@ -217,7 +217,7 @@ func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 	t.Run("RPC is live", func(t *testing.T) {
 		rpc := startRPCMock(dispatcher)
 		defer stopRPCMock(rpc)
-		ts := StartMock()
+		ts := StartTest()
 		defer ts.Close()
 
 		apiBackup, _ := LoadDefinitionsFromRPCBackup()
@@ -252,7 +252,7 @@ func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 		config.SetGlobal(globalConf)
 
 		// RPC layer is down
-		ts := StartMock()
+		ts := StartTest()
 		defer ts.Close()
 
 		// Wait for backup to load
@@ -296,7 +296,7 @@ func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 		// Back to live
 		rpc := startRPCMock(dispatcher)
 		defer stopRPCMock(rpc)
-		ts := StartMock()
+		ts := StartTest()
 		defer ts.Close()
 
 		time.Sleep(100 * time.Millisecond)
@@ -319,7 +319,7 @@ func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 
 	t.Run("RPC is back, live reload", func(t *testing.T) {
 		rpc := startRPCMock(dispatcher)
-		ts := StartMock()
+		ts := StartTest()
 		defer ts.Close()
 
 		time.Sleep(100 * time.Millisecond)

--- a/gateway/rpc_test.go
+++ b/gateway/rpc_test.go
@@ -200,7 +200,7 @@ func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 	// Mock RPC
 	dispatcher := gorpc.NewDispatcher()
 	dispatcher.AddFunc("GetApiDefinitions", func(clientAddr string, dr *DefRequest) (string, error) {
-		return jsonMarshalString(buildAPI(func(spec *APISpec) {
+		return jsonMarshalString(BuildAPI(func(spec *APISpec) {
 			spec.UseKeylessAccess = false
 		})), nil
 	})
@@ -211,13 +211,13 @@ func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 		return true
 	})
 	dispatcher.AddFunc("GetKey", func(clientAddr, key string) (string, error) {
-		return jsonMarshalString(createStandardSession()), nil
+		return jsonMarshalString(CreateStandardSession()), nil
 	})
 
 	t.Run("RPC is live", func(t *testing.T) {
 		rpc := startRPCMock(dispatcher)
 		defer stopRPCMock(rpc)
-		ts := newTykTestServer()
+		ts := StartMock()
 		defer ts.Close()
 
 		apiBackup, _ := LoadDefinitionsFromRPCBackup()
@@ -252,7 +252,7 @@ func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 		config.SetGlobal(globalConf)
 
 		// RPC layer is down
-		ts := newTykTestServer()
+		ts := StartMock()
 		defer ts.Close()
 
 		// Wait for backup to load
@@ -279,7 +279,7 @@ func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 
 		dispatcher := gorpc.NewDispatcher()
 		dispatcher.AddFunc("GetApiDefinitions", func(clientAddr string, dr *DefRequest) (string, error) {
-			return jsonMarshalString(buildAPI(
+			return jsonMarshalString(BuildAPI(
 				func(spec *APISpec) { spec.UseKeylessAccess = false },
 				func(spec *APISpec) { spec.UseKeylessAccess = false },
 			)), nil
@@ -291,12 +291,12 @@ func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 			return true
 		})
 		dispatcher.AddFunc("GetKey", func(clientAddr, key string) (string, error) {
-			return jsonMarshalString(createStandardSession()), nil
+			return jsonMarshalString(CreateStandardSession()), nil
 		})
 		// Back to live
 		rpc := startRPCMock(dispatcher)
 		defer stopRPCMock(rpc)
-		ts := newTykTestServer()
+		ts := StartMock()
 		defer ts.Close()
 
 		time.Sleep(100 * time.Millisecond)
@@ -319,7 +319,7 @@ func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 
 	t.Run("RPC is back, live reload", func(t *testing.T) {
 		rpc := startRPCMock(dispatcher)
-		ts := newTykTestServer()
+		ts := StartMock()
 		defer ts.Close()
 
 		time.Sleep(100 * time.Millisecond)

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -21,12 +21,12 @@ import (
 
 	"golang.org/x/net/http2"
 
-	newrelic "github.com/newrelic/go-agent"
+	"github.com/newrelic/go-agent"
 
 	"github.com/TykTechnologies/tyk/checkup"
 
 	"github.com/Sirupsen/logrus"
-	logrus_syslog "github.com/Sirupsen/logrus/hooks/syslog"
+	"github.com/Sirupsen/logrus/hooks/syslog"
 	logstashHook "github.com/bshuster-repo/logrus-logstash-hook"
 	"github.com/evalphobia/logrus_sentry"
 	"github.com/facebookgo/pidfile"
@@ -35,11 +35,11 @@ import (
 	"github.com/justinas/alice"
 	"github.com/lonelycode/osin"
 	"github.com/rs/cors"
-	uuid "github.com/satori/go.uuid"
+	"github.com/satori/go.uuid"
 	"rsc.io/letsencrypt"
 
 	"github.com/TykTechnologies/goagain"
-	gas "github.com/TykTechnologies/goautosocket"
+	"github.com/TykTechnologies/goautosocket"
 	"github.com/TykTechnologies/gorpc"
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/certs"

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -21,12 +21,12 @@ import (
 
 	"golang.org/x/net/http2"
 
-	"github.com/newrelic/go-agent"
+	newrelic "github.com/newrelic/go-agent"
 
 	"github.com/TykTechnologies/tyk/checkup"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/Sirupsen/logrus/hooks/syslog"
+	logrus_syslog "github.com/Sirupsen/logrus/hooks/syslog"
 	logstashHook "github.com/bshuster-repo/logrus-logstash-hook"
 	"github.com/evalphobia/logrus_sentry"
 	"github.com/facebookgo/pidfile"
@@ -35,11 +35,11 @@ import (
 	"github.com/justinas/alice"
 	"github.com/lonelycode/osin"
 	"github.com/rs/cors"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"rsc.io/letsencrypt"
 
 	"github.com/TykTechnologies/goagain"
-	"github.com/TykTechnologies/goautosocket"
+	gas "github.com/TykTechnologies/goautosocket"
 	"github.com/TykTechnologies/gorpc"
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/certs"

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-
 	"golang.org/x/net/context"
 
 	"io"

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -449,7 +449,7 @@ type Mock struct {
 	URL string
 
 	testRunner   *test.HTTPTestRunner
-	globalConfig config.Config
+	GlobalConfig config.Config
 	config       MockConfig
 }
 
@@ -488,10 +488,10 @@ func (s *Mock) Start() {
 		listen(s.ln, s.cln, fmt.Errorf("Without goagain"))
 	}
 
-	s.globalConfig = globalConf
+	s.GlobalConfig = globalConf
 
 	scheme := "http://"
-	if s.globalConfig.HttpServerOptions.UseSSL {
+	if s.GlobalConfig.HttpServerOptions.UseSSL {
 		scheme = "https://"
 	}
 	s.URL = scheme + s.ln.Addr().String()
@@ -502,8 +502,8 @@ func (s *Mock) Start() {
 			if tc.ControlRequest {
 				if s.config.sepatateControlAPI {
 					tc.BaseURL = scheme + s.cln.Addr().String()
-				} else if s.globalConfig.ControlAPIHostname != "" {
-					tc.Domain = s.globalConfig.ControlAPIHostname
+				} else if s.GlobalConfig.ControlAPIHostname != "" {
+					tc.Domain = s.GlobalConfig.ControlAPIHostname
 				}
 			}
 			r, err := test.NewRequest(tc)

--- a/test/http.go
+++ b/test/http.go
@@ -97,7 +97,7 @@ func AssertResponse(resp *http.Response, tc *TestCase) error {
 	return nil
 }
 
-func reqBodyReader(body interface{}) io.Reader {
+func ReqBodyReader(body interface{}) io.Reader {
 	switch x := body.(type) {
 	case []byte:
 		return bytes.NewReader(x)
@@ -142,12 +142,12 @@ func NewRequest(tc *TestCase) (req *http.Request, err error) {
 		uri = strings.Replace(uri, "[::]", tc.Domain, 1)
 		uri = strings.Replace(uri, "127.0.0.1", tc.Domain, 1)
 
-		req, err = http.NewRequest(tc.Method, uri, reqBodyReader(tc.Data))
+		req, err = http.NewRequest(tc.Method, uri, ReqBodyReader(tc.Data))
 		if err != nil {
 			return
 		}
 	} else {
-		req = httptest.NewRequest(tc.Method, uri, reqBodyReader(tc.Data))
+		req = httptest.NewRequest(tc.Method, uri, ReqBodyReader(tc.Data))
 	}
 
 	for k, v := range tc.Headers {


### PR DESCRIPTION
This PR creates `testutil.go`. The purpose is to be able to import test functions in other projects.

For example, in dashboard, this PR provides us to write the following test:

```go
func TestAPIContext_RevokeDeveloperKey(t *testing.T) {
	g := gateway.StartTest()
	defer g.Close()

	Tyk.(*TykApi).Port = strconv.Itoa(g.GlobalConfig.ListenPort)
	sessionID, _ := UserSessions.CreateAPISession(&testUser)

	ts := newTykTestServer(tykTestServerConfig{accessKey: sessionID})
	defer ts.Close()

	api := gateway.BuildAndLoadAPI(func(spec *gateway.APISpec) {
		spec.Proxy.ListenPath = "/"
		spec.UseKeylessAccess = false
	})[0]

	key := gateway.CreateSession(func(s *user.SessionState) {
		s.AccessRights = map[string]user.AccessDefinition{api.APIID: {
			APIID: api.APIID,
		}}
	})

	developer := createSampleDeveloper(func(developer *PortalDeveloper) {
		developer.OrgId = testOrg.Id.Hex()
		developer.ApiKeys = map[string]string{
			api.APIID: key,
		}
	})

	authHeaders := map[string]string{
		"authorization": key,
	}

	g.Run(t, test.TestCase{Path: "/", Headers: authHeaders, Code: http.StatusOK})

	headers := map[string]string{"authorization": testUser.AccessKey}
	revokePath := fmt.Sprintf("/api/portal/developers/key/%s/%s/%s", api.APIID, key, developer.Id.Hex())

	_, _ = ts.Run(t, []test.TestCase{
		{Method: http.MethodDelete, Headers: headers, Path: revokePath, Code: http.StatusOK, BodyMatch: "User key revoked"},
	}...)

	g.Run(t, test.TestCase{Path: "/", Headers: authHeaders, Code: http.StatusForbidden})
}
```