### PR TITLE
Update accessRights of Per API policy when API is deleted

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -277,6 +277,9 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 				log.Error(err)
 				return err
 			}
+
+			//Added this to ensure that if an API is deleted, it is removed from accessRights also.
+			newRights := make(map[string]user.AccessDefinition)
 			for apiID, accessRights := range policy.AccessRights {
 				// check if limit was already set for this API by other policy assigned to key
 				if didPerAPI[apiID] {
@@ -311,11 +314,12 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 				accessRights.Limit.QuotaRenews = limitQuotaRenews
 
 				// overwrite session access right for this API
-				rights[apiID] = accessRights
+				newRights[apiID] = accessRights
 
 				// identify that limit for that API is set (to allow set it only once)
 				didPerAPI[apiID] = true
 			}
+			rights = newRights
 		} else if policy.Partitions.Quota || policy.Partitions.RateLimit || policy.Partitions.Acl {
 			// This is a partitioned policy, only apply what is active
 			// legacy logic when you can specify quota or rate only in no more than one policy


### PR DESCRIPTION
Fixes [tyk-analytics/issues/1222](https://github.com/TykTechnologies/tyk-analytics/issues/1222)

`accessRights` are stored in a map. While applying Per API policy, previous instance of map was used and entries where updated. So if an API was deleted from policy, it's entry was not deleted from `accessRights`. 

The issue is resolved by creating new instance of map and adding entries to it.

