### PR TITLE
Use TrimPrefix to strip listen path

### DIFF
--- a/gateway/handler_success.go
+++ b/gateway/handler_success.go
@@ -349,8 +349,8 @@ func (s *SuccessHandler) ServeHTTPWithCache(w http.ResponseWriter, r *http.Reque
 
 	// Make sure we get the correct target URL
 	if s.Spec.Proxy.StripListenPath {
-		r.URL.Path = strings.Replace(r.URL.Path, s.Spec.Proxy.ListenPath, "", 1)
-		r.URL.RawPath = strings.Replace(r.URL.RawPath, s.Spec.Proxy.ListenPath, "", 1)
+		r.URL.Path = strings.TrimPrefix(r.URL.Path, s.Spec.Proxy.ListenPath)
+		r.URL.RawPath = strings.TrimPrefix(r.URL.RawPath, s.Spec.Proxy.ListenPath)
 	}
 
 	t1 := time.Now()


### PR DESCRIPTION
Fixes #2313 
Same as #2211 Missed this case

`strings.Replace()` method was used to strip the `listen_path`.
So when URL rewrite plugin was used to call an endpoint that contained `listen_path` anywhere in it's path, it was getting removed.

To fix this I replaced `strings.Replace()` with `strings.TrimPrefix()`