### PR TITLE
Add JWTDefaultPolicies field and default policy feature

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -373,6 +373,7 @@ type APIDefinition struct {
 	JWTIdentityBaseField       string               `bson:"jwt_identit_base_field" json:"jwt_identity_base_field"`
 	JWTClientIDBaseField       string               `bson:"jwt_client_base_field" json:"jwt_client_base_field"`
 	JWTPolicyFieldName         string               `bson:"jwt_policy_field_name" json:"jwt_policy_field_name"`
+	JWTDefaultPolicies         []string             `bson:"jwt_default_policies" json:"jwt_default_policies"`
 	JWTIssuedAtValidationSkew  uint64               `bson:"jwt_issued_at_validation_skew" json:"jwt_issued_at_validation_skew"`
 	JWTExpiresAtValidationSkew uint64               `bson:"jwt_expires_at_validation_skew" json:"jwt_expires_at_validation_skew"`
 	JWTNotBeforeValidationSkew uint64               `bson:"jwt_not_before_validation_skew" json:"jwt_not_before_validation_skew"`

--- a/apidef/schema.go
+++ b/apidef/schema.go
@@ -75,6 +75,9 @@ const Schema = `{
         "jwt_policy_field_name": {
             "type": "string"
         },
+		"jwt_default_policies": {
+            "type": ["array", "null"]
+        },
         "jwt_signing_method": {
             "type": "string"
         },

--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -206,6 +206,10 @@ func (k *JWTMiddleware) getBasePolicyID(r *http.Request, claims jwt.MapClaims) (
 		return pols[0], true
 	}
 
+	if len(k.Spec.JWTDefaultPolicies) > 0 {
+		return k.Spec.JWTDefaultPolicies[0], true
+	}
+
 	return "", false
 }
 
@@ -290,22 +294,40 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 
 	k.Logger().Debug("JWT Temporary session ID is: ", sessionID)
 
+	contains := func(s []string, e string) bool {
+		for _, a := range s {
+			if a == e {
+				return true
+			}
+		}
+		return false
+	}
+
 	session, exists := k.CheckSessionAndIdentityForValidKey(sessionID, r)
 	if !exists {
 		// Create it
 		k.Logger().Debug("Key does not exist, creating")
-		session = user.SessionState{}
 
 		// We need a base policy as a template, either get it from the token itself OR a proxy client ID within Tyk
 		basePolicyID, foundPolicy := k.getBasePolicyID(r, claims)
 		if !foundPolicy {
 			k.reportLoginFailure(baseFieldData, r)
-			return errors.New("Key not authorized: no matching policy found"), http.StatusForbidden
+			return errors.New("key not authorized: no matching policy found"), http.StatusForbidden
 		}
 
-		newSession, err := generateSessionFromPolicy(basePolicyID,
+		session, err = generateSessionFromPolicy(basePolicyID,
 			k.Spec.OrgID,
 			true)
+
+		for _, pol := range k.Spec.JWTDefaultPolicies {
+			if !contains(session.ApplyPolicies, pol) {
+				session.ApplyPolicies = append(session.ApplyPolicies, pol)
+			}
+		}
+
+		if err := k.ApplyPolicies(&session); err != nil {
+			return errors.New("failed to create key: " + err.Error()), http.StatusInternalServerError
+		}
 
 		// apply policies from scope if scope-to-policy mapping is specified for this API
 		if len(k.Spec.JWTScopeToPolicyMapping) != 0 {
@@ -323,13 +345,13 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 				mappedPolIDs := mapScopeToPolicies(k.Spec.JWTScopeToPolicyMapping, scope)
 
 				polIDs = append(polIDs, mappedPolIDs...)
-				newSession.SetPolicies(polIDs...)
+				session.SetPolicies(polIDs...)
 
 				// multiple policies assigned to a key, check if it is applicable
-				if err := k.ApplyPolicies(&newSession); err != nil {
+				if err := k.ApplyPolicies(&session); err != nil {
 					k.reportLoginFailure(baseFieldData, r)
 					k.Logger().WithError(err).Error("Could not several policies from scope-claim mapping to JWT to session")
-					return errors.New("Key not authorized: could not apply several policies"), http.StatusForbidden
+					return errors.New("key not authorized: could not apply several policies"), http.StatusForbidden
 				}
 			}
 		}
@@ -337,29 +359,28 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 		if err != nil {
 			k.reportLoginFailure(baseFieldData, r)
 			k.Logger().Error("Could not find a valid policy to apply to this token!")
-			return errors.New("Key not authorized: no matching policy"), http.StatusForbidden
+			return errors.New("key not authorized: no matching policy"), http.StatusForbidden
 		}
 
 		//override session expiry with JWT if longer lived
 		if f, ok := claims["exp"].(float64); ok {
-			if int64(f)-newSession.Expires > 0 {
-				newSession.Expires = int64(f)
+			if int64(f)-session.Expires > 0 {
+				session.Expires = int64(f)
 			}
 		}
 
-		session = newSession
 		session.MetaData = map[string]interface{}{"TykJWTSessionID": sessionID}
 		session.Alias = baseFieldData
 
 		// Update the session in the session manager in case it gets called again
-		k.Logger().Debug("Policy applied to key")
 		updateSession = true
-	} else if k.Spec.JWTPolicyFieldName != "" {
+		k.Logger().Debug("Policy applied to key")
+	} else {
 		// extract policy ID from JWT token
-		policyID, foundPolicy := k.getPolicyIDFromToken(claims)
+		policyID, foundPolicy := k.getBasePolicyID(r, claims)
 		if !foundPolicy {
 			k.reportLoginFailure(baseFieldData, r)
-			return errors.New("key not authorized: no matching policy claim found"), http.StatusForbidden
+			return errors.New("key not authorized: no matching policy found"), http.StatusForbidden
 		}
 		// check if we received a valid policy ID in claim
 		policiesMu.RLock()
@@ -367,7 +388,7 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 		policiesMu.RUnlock()
 		if !ok {
 			k.reportLoginFailure(baseFieldData, r)
-			k.Logger().Error("Policy ID found in token is invalid!")
+			k.Logger().Error("Policy ID found is invalid!")
 			return errors.New("key not authorized: no matching policy"), http.StatusForbidden
 		}
 		// check if token for this session was switched to another valid policy
@@ -378,30 +399,50 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 			return errors.New("key not authorized: no matching policy found"), http.StatusForbidden
 		}
 
+		// check a policy is removed/added from/to default policies
+		defaultPolicyListChanged := false
+
+		for _, pol := range session.PolicyIDs() {
+			if !contains(k.Spec.JWTDefaultPolicies, pol) && policyID != pol {
+				defaultPolicyListChanged = true
+			}
+		}
+
+		for _, defPol := range k.Spec.JWTDefaultPolicies {
+			if !contains(session.PolicyIDs(), defPol) {
+				defaultPolicyListChanged = true
+			}
+		}
+
+		if !contains(pols, policyID) || defaultPolicyListChanged {
+			if policy.OrgID != k.Spec.OrgID {
+				k.reportLoginFailure(baseFieldData, r)
+				k.Logger().Error("Policy ID found is invalid (wrong ownership)!")
+				return errors.New("key not authorized: no matching policy"), http.StatusForbidden
+			}
+			// apply new policy to session and update session
+			updateSession = true
+			session.SetPolicies(policyID)
+
+			for _, pol := range k.Spec.JWTDefaultPolicies {
+				if !contains(session.ApplyPolicies, pol) {
+					session.ApplyPolicies = append(session.ApplyPolicies, pol)
+				}
+			}
+
+			if err := k.ApplyPolicies(&session); err != nil {
+				k.reportLoginFailure(baseFieldData, r)
+				k.Logger().WithError(err).Error("Could not apply new policy to session")
+				return errors.New("key not authorized: could not apply new policy"), http.StatusForbidden
+			}
+		}
+
 		//override session expiry with JWT if longer lived
 		if f, ok := claims["exp"].(float64); ok {
 			if int64(f)-session.Expires > 0 {
 				session.Expires = int64(f)
 				updateSession = true
 			}
-		}
-
-		if pols[0] != policyID { // switch session to new policy and update session storage and cache
-			// check ownership before updating session
-			if policy.OrgID != k.Spec.OrgID {
-				k.reportLoginFailure(baseFieldData, r)
-				k.Logger().Error("Policy ID found in token is invalid (wrong ownership)!")
-				return errors.New("Key not authorized: no matching policy"), http.StatusForbidden
-			}
-			// apply new policy to session and update session
-			session.SetPolicies(policyID)
-			if err := k.ApplyPolicies(&session); err != nil {
-				k.reportLoginFailure(baseFieldData, r)
-				k.Logger().WithError(err).Error("Could not apply new policy from JWT to session")
-				return errors.New("Key not authorized: could not apply new policy"), http.StatusForbidden
-			}
-
-			updateSession = true
 		}
 	}
 


### PR DESCRIPTION
This PR adds `JWTDefaultPolicies` to api definition. This means in `JWT` authentication, a user can apply some default policies not having conflict to the session created by `JWT` authentication.

Note: Error messages start with lowercase. I refactored the messages in the related part. There should be a big refactor to make error messages compatible with Go conventions.

Fixes #2009 