### PR TITLE
Request signing middleware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ install:
   - go get github.com/go-swagger/go-swagger/cmd/swagger
 
 script:
+  - pip3 install setuptools
   - sudo pip3 install google
   - sudo pip3 install protobuf
     ### Needed to convert the swagger 2.0 file to openapi 3.0

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -499,7 +499,7 @@ type BundleManifest struct {
 
 type RequestSigningMeta struct {
 	IsEnabled bool   `bson:"is_enabled" json:"is_enabled"`
-	Key       string `bson:"key" json:"key"`
+	Secret    string `bson:"secret" json:"secret"`
 	KeyId     string `bson:"key_id", json:"key_id"`
 	Algorithm string `bson:"algorithm", json:"algorithm"`
 }

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -500,8 +500,8 @@ type BundleManifest struct {
 type RequestSigningMeta struct {
 	IsEnabled bool   `bson:"is_enabled" json:"is_enabled"`
 	Secret    string `bson:"secret" json:"secret"`
-	KeyId     string `bson:"key_id", json:"key_id"`
-	Algorithm string `bson:"algorithm", json:"algorithm"`
+	KeyId     string `bson:"key_id" json:"key_id"`
+	Algorithm string `bson:"algorithm" json:"algorithm"`
 }
 
 // Clean will URL encode map[string]struct variables for saving

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -386,6 +386,7 @@ type APIDefinition struct {
 	EnableSignatureChecking    bool                 `bson:"enable_signature_checking" json:"enable_signature_checking"`
 	HmacAllowedClockSkew       float64              `bson:"hmac_allowed_clock_skew" json:"hmac_allowed_clock_skew"`
 	HmacAllowedAlgorithms      []string             `bson:"hmac_allowed_algorithms" json:"hmac_allowed_algorithms"`
+	RequestSigning             RequestSigningMeta   `bson:"request_signing" json:"request_signing"`
 	BaseIdentityProvidedBy     AuthTypeEnum         `bson:"base_identity_provided_by" json:"base_identity_provided_by"`
 	VersionDefinition          struct {
 		Location  string `bson:"location" json:"location"`
@@ -494,6 +495,13 @@ type BundleManifest struct {
 	CustomMiddleware MiddlewareSection `bson:"custom_middleware" json:"custom_middleware"`
 	Checksum         string            `bson:"checksum" json:"checksum"`
 	Signature        string            `bson:"signature" json:"signature"`
+}
+
+type RequestSigningMeta struct {
+	IsEnabled bool   `bson:"is_enabled" json:"is_enabled"`
+	Key       string `bson:"key" json:"key"`
+	KeyId     string `bson:"key_id", json:"key_id"`
+	Algorithm string `bson:"algorithm", json:"algorithm"`
 }
 
 // Clean will URL encode map[string]struct variables for saving

--- a/apidef/schema.go
+++ b/apidef/schema.go
@@ -394,6 +394,26 @@ const Schema = `{
                     "type": "number"
                 }
             }
+        },
+	"request_signing": {
+          "type": ["object", "null"],
+           "properties": {
+                "is_enabled": {
+                    "type": "boolean"
+                },
+                "key": {
+                    "type": "string"
+                },
+		"key_id": {
+                    "type": "string"
+                },
+		"algorithm": {
+                    "type": "string"
+                }
+            },
+	    "required": [
+	    	"is_enabled"
+	    ]
         }
     },
     "required": [

--- a/apidef/schema.go
+++ b/apidef/schema.go
@@ -401,7 +401,7 @@ const Schema = `{
                 "is_enabled": {
                     "type": "boolean"
                 },
-                "key": {
+                "secret": {
                     "type": "string"
                 },
 		"key_id": {

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -396,6 +396,7 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 	mwAppendEnabled(&chainArray, &TransformMethod{BaseMiddleware: baseMid})
 	mwAppendEnabled(&chainArray, &RedisCacheMiddleware{BaseMiddleware: baseMid, CacheStore: &cacheStore})
 	mwAppendEnabled(&chainArray, &VirtualEndpoint{BaseMiddleware: baseMid})
+	mwAppendEnabled(&chainArray, &RequestSigning{BaseMiddleware: baseMid})
 
 	for _, obj := range mwPostFuncs {
 		if mwDriver == apidef.GoPluginDriver {

--- a/gateway/mw_hmac.go
+++ b/gateway/mw_hmac.go
@@ -61,7 +61,7 @@ func (hm *HMACMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request,
 	}
 
 	// Generate a signature string
-	signatureString, err := generateHMACSignatureStringFromRequest(r, fieldValues)
+	signatureString, err := generateHMACSignatureStringFromRequest(r, fieldValues.Headers)
 	if err != nil {
 		logger.WithError(err).WithField("signature_string", signatureString).Error("Signature string generation failed")
 		return hm.authorizationError(r)
@@ -296,9 +296,9 @@ func getFieldValues(authHeader string) (*HMACFieldValues, error) {
 
 // "Signature keyId="9876",algorithm="hmac-sha1",headers="x-test x-test-2",signature="queryEscape(base64(sig))"")
 
-func generateHMACSignatureStringFromRequest(r *http.Request, fieldValues *HMACFieldValues) (string, error) {
+func generateHMACSignatureStringFromRequest(r *http.Request, headers []string) (string, error) {
 	signatureString := ""
-	for i, header := range fieldValues.Headers {
+	for i, header := range headers {
 		loweredHeader := strings.TrimSpace(strings.ToLower(header))
 		if loweredHeader == "(request-target)" {
 			requestHeaderField := "(request-target): " + strings.ToLower(r.Method) + " " + r.URL.Path
@@ -313,7 +313,7 @@ func generateHMACSignatureStringFromRequest(r *http.Request, fieldValues *HMACFi
 			signatureString += headerField
 		}
 
-		if i != len(fieldValues.Headers)-1 {
+		if i != len(headers)-1 {
 			signatureString += "\n"
 		}
 	}

--- a/gateway/mw_request_signing.go
+++ b/gateway/mw_request_signing.go
@@ -1,0 +1,98 @@
+package gateway
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type RequestSigning struct {
+	BaseMiddleware
+}
+
+func (s *RequestSigning) Name() string {
+	return "RequestSigning"
+}
+
+func (s *RequestSigning) EnabledForSpec() bool {
+	return s.Spec.RequestSigning.IsEnabled
+}
+
+var supportedAlgorithms = []string{"hmac-sha1", "hmac-sha256", "hmac-sha384", "hmac-sha512"}
+
+func generateHeaderList(r *http.Request) []string {
+	headers := make([]string, len(r.Header)+1)
+
+	headers[0] = "(request-target)"
+	i := 1
+
+	for k := range r.Header {
+		loweredCaseHeader := strings.ToLower(k)
+		headers[i] = strings.TrimSpace(loweredCaseHeader)
+		i++
+	}
+
+	//Date header is must as per Signing HTTP Messages Draft
+	if r.Header.Get("date") == "" {
+		refDate := "Mon, 02 Jan 2006 15:04:05 MST"
+		tim := time.Now().Format(refDate)
+
+		r.Header.Set("date", tim)
+		headers = append(headers, "date")
+	}
+
+	return headers
+}
+
+func (s *RequestSigning) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
+	if s.Spec.RequestSigning.Key == "" || s.Spec.RequestSigning.KeyId == "" || s.Spec.RequestSigning.Algorithm == "" {
+		log.Error("Fields required for signing the request are missing")
+		return errors.New("Fields required for signing the request are missing"), http.StatusInternalServerError
+	}
+
+	var algoList []string
+	if len(s.Spec.HmacAllowedAlgorithms) > 0 {
+		algoList = s.Spec.HmacAllowedAlgorithms
+	} else {
+		algoList = supportedAlgorithms
+	}
+
+	algorithmAllowed := false
+	for _, alg := range algoList {
+		if alg == s.Spec.RequestSigning.Algorithm {
+			algorithmAllowed = true
+			break
+		}
+	}
+	if !algorithmAllowed {
+		log.WithField("algorithm", s.Spec.RequestSigning.Algorithm).Error("Algorithm not supported")
+		return errors.New("Request signing Algorithm is not supported"), http.StatusInternalServerError
+	}
+
+	headers := generateHeaderList(r)
+	signatureString, err := generateHMACSignatureStringFromRequest(r, headers)
+	if err != nil {
+		log.Error(err)
+		return err, http.StatusInternalServerError
+	}
+
+	strHeaders := strings.Join(headers, " ")
+	encodedSignature := generateEncodedSignature(signatureString, s.Spec.RequestSigning.Key, s.Spec.RequestSigning.Algorithm)
+
+	//Generate Authorization header
+	authHeader := "Signature "
+	//Append keyId
+	authHeader += "keyId=\"" + s.Spec.RequestSigning.KeyId + "\","
+	//Append algorithm
+	authHeader += "algorithm=\"" + s.Spec.RequestSigning.Algorithm + "\","
+	//Append Headers
+	authHeader += "headers=\"" + strHeaders + "\","
+	//Append signature
+	authHeader += "signature=\"" + encodedSignature + "\""
+
+	r.Header.Set("Authorization", authHeader)
+	log.Debug("Setting Authorization headers as =", authHeader)
+
+	return nil, http.StatusOK
+}

--- a/gateway/mw_request_signing.go
+++ b/gateway/mw_request_signing.go
@@ -46,7 +46,7 @@ func generateHeaderList(r *http.Request) []string {
 }
 
 func (s *RequestSigning) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
-	if s.Spec.RequestSigning.Key == "" || s.Spec.RequestSigning.KeyId == "" || s.Spec.RequestSigning.Algorithm == "" {
+	if s.Spec.RequestSigning.Secret == "" || s.Spec.RequestSigning.KeyId == "" || s.Spec.RequestSigning.Algorithm == "" {
 		log.Error("Fields required for signing the request are missing")
 		return errors.New("Fields required for signing the request are missing"), http.StatusInternalServerError
 	}
@@ -78,7 +78,7 @@ func (s *RequestSigning) ProcessRequest(w http.ResponseWriter, r *http.Request, 
 	}
 
 	strHeaders := strings.Join(headers, " ")
-	encodedSignature := generateEncodedSignature(signatureString, s.Spec.RequestSigning.Key, s.Spec.RequestSigning.Algorithm)
+	encodedSignature := generateEncodedSignature(signatureString, s.Spec.RequestSigning.Secret, s.Spec.RequestSigning.Algorithm)
 
 	//Generate Authorization header
 	authHeader := "Signature "

--- a/gateway/mw_request_signing_test.go
+++ b/gateway/mw_request_signing_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/TykTechnologies/tyk/user"
 )
 
-var algoList = []string{"hmac-sha1", "hmac-sha256", "hmac-sha384", "hmac-sha512"}
+var algoList = [4]string{"hmac-sha1", "hmac-sha256", "hmac-sha384", "hmac-sha512"}
 
 func generateSpec(algo string) {
 	sessionKey := CreateSession(func(s *user.SessionState) {

--- a/gateway/mw_request_signing_test.go
+++ b/gateway/mw_request_signing_test.go
@@ -1,0 +1,94 @@
+package gateway
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/TykTechnologies/tyk/test"
+	"github.com/TykTechnologies/tyk/user"
+)
+
+var algoList = []string{"hmac-sha1", "hmac-sha256", "hmac-sha384", "hmac-sha512"}
+
+func generateSpec(algo string) {
+	sessionKey := CreateSession(func(s *user.SessionState) {
+		s.HMACEnabled = true
+		s.HmacSecret = "9879879878787878"
+
+		s.AccessRights = map[string]user.AccessDefinition{"protected": {APIID: "protected", Versions: []string{"v1"}}}
+
+	})
+
+	BuildAndLoadAPI(func(spec *APISpec) {
+		spec.APIID = "protected"
+		spec.Name = "protected api"
+		spec.Proxy.ListenPath = "/something"
+		spec.EnableSignatureChecking = true
+		spec.Auth.AuthHeaderName = "authorization"
+		spec.HmacAllowedClockSkew = 5000
+		spec.UseKeylessAccess = false
+		spec.UseBasicAuth = false
+		spec.UseOauth2 = false
+
+		version := spec.VersionData.Versions["v1"]
+		version.UseExtendedPaths = true
+		spec.VersionData.Versions["v1"] = version
+	}, func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/test"
+		spec.RequestSigning.IsEnabled = true
+		spec.RequestSigning.KeyId = sessionKey
+		spec.RequestSigning.Key = "9879879878787878"
+		spec.RequestSigning.Algorithm = algo
+
+		version := spec.VersionData.Versions["v1"]
+		json.Unmarshal([]byte(`{
+                "use_extended_paths": true,
+                "extended_paths": {
+                    "url_rewrites": [{
+                        "path": "/by_name",
+                        "match_pattern": "/by_name(.*)",
+                        "method": "GET",
+                        "rewrite_to": "tyk://protected api/get"
+                    }]
+                }
+            }`), &version)
+
+		spec.VersionData.Versions["v1"] = version
+	})
+
+}
+
+func TestRequestSigning(t *testing.T) {
+	ts := StartTest()
+	defer ts.Close()
+
+	for _, algo := range algoList {
+		name := "Test with " + algo
+		t.Run(name, func(t *testing.T) {
+
+			generateSpec(algo)
+
+			ts.Run(t, []test.TestCase{
+				{Path: "/test/by_name", Code: 200},
+			}...)
+		})
+	}
+
+	t.Run("Invalid algorithm", func(t *testing.T) {
+		generateSpec("random")
+
+		ts.Run(t, []test.TestCase{
+			{Path: "/test/by_name", Code: 500},
+		}...)
+	})
+
+	t.Run("Invalid Date field", func(t *testing.T) {
+		generateSpec("hmac-sha1")
+
+		headers := map[string]string{"date": "Mon, 02 Jan 2006 15:04:05 GMT"}
+
+		ts.Run(t, []test.TestCase{
+			{Path: "/test/by_name", Headers: headers, Code: 400},
+		}...)
+	})
+}

--- a/gateway/mw_request_signing_test.go
+++ b/gateway/mw_request_signing_test.go
@@ -37,7 +37,7 @@ func generateSpec(algo string) {
 		spec.Proxy.ListenPath = "/test"
 		spec.RequestSigning.IsEnabled = true
 		spec.RequestSigning.KeyId = sessionKey
-		spec.RequestSigning.Key = "9879879878787878"
+		spec.RequestSigning.Secret = "9879879878787878"
 		spec.RequestSigning.Algorithm = algo
 
 		version := spec.VersionData.Versions["v1"]


### PR DESCRIPTION
The feature is implemented using [Draft 10](https://tools.ietf.org/html/draft-cavage-http-signatures-10)

`(request-target)` and all the headers of the request will be used for generating signature string. 
If request doesn't contain `Date` header, middleware will add one as it is required according to above draft.

A new config option `request_signing` is added in API Definition to enable/disable request signing. It has following format

```json
"request_signing": {
  "is_enabled": true,
  "key": "xxxx",
  "key_id": "1",
  "algorithm": "hmac-sha256"
}
```
Following algorithms are supported:
1. `hmac-sha1`
2. `hmac-sha256`
3. `hmac-sha384`
4. `hmac-sha512`

Fixes #2234 
