### PR TITLE
fix bug of request.Body will be setted to empty if call parseForm twice

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -532,7 +532,7 @@ func parseForm(r *http.Request) {
 	// https://golang.org/pkg/net/http/#Request.ParseForm
 	// ParseForm drains the request body for a request with Content-Type of
 	// application/x-www-form-urlencoded
-	if r.Header.Get("Content-Type") == "application/x-www-form-urlencoded" {
+	if r.Header.Get("Content-Type") == "application/x-www-form-urlencoded" && r.Form == nil {
 		var b bytes.Buffer
 		r.Body = ioutil.NopCloser(io.TeeReader(r.Body, &b))
 


### PR DESCRIPTION
PR #2182  fix the problem

```go
		var b bytes.Buffer
		r.Body = ioutil.NopCloser(io.TeeReader(r.Body, &b))

		r.ParseForm()

		r.Body = ioutil.NopCloser(&b)

```

But when call the `parseForm` twice at different locations, the `request.Body` will be set to empty.

Because the `r.ParseForm()` will not read the body again(the second time, `r.From` and `r.PostForm` are not `nil`)

so the `io.TeeReader` will not write the body into `var b bytes.Buffer`,  and  `r.Body = ioutil.NopCloser(&b)`, the body will be empty