### PR TITLE
RPMs can be signed via the agent

### DIFF
--- a/bin/dist_build.sh
+++ b/bin/dist_build.sh
@@ -12,7 +12,7 @@ echo "Set version number"
 
 if [ $BUILDPKGS == "1" ]; then
     echo "Importing signing key"
-    gpg --list-keys | grep -w $SIGNKEY && echo "Key exists" || gpg --import $BUILDTOOLSDIR/build_key.key
+    gpg --list-keys | grep -w $SIGNKEY && echo "Key exists" || gpg --batch --import $BUILDTOOLSDIR/build_key.key
 fi
 
 echo "Prepare the release directories"

--- a/bin/dist_build.sh
+++ b/bin/dist_build.sh
@@ -154,5 +154,5 @@ do
 
     rpmName="$PKGNAME-$VERSION-1.${arch/amd64/x86_64}.rpm"
     echo "Signing $arch RPM"
-    $BUILDTOOLSDIR/rpm-sign.exp $rpmName
+    $BUILDTOOLSDIR/rpm-sign.sh $rpmName
 done


### PR DESCRIPTION
This will enable us to use the official go 1.12 base image rather than having to setup go by hand on jessie.