### PR TITLE
Get key endpoint should return `key_hash`, if hashing is enabled

### DIFF
--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -421,6 +421,7 @@ func testHashKeyHandlerHelper(t *testing.T, expectedHashSize int) {
 				Data:      string(withAccessJSON),
 				AdminAuth: true,
 				Code:      200,
+				BodyMatch: fmt.Sprintf(`"key_hash":"%s"`, myKeyHash),
 			},
 			// get one key by hash value with specifying hashed=true (no API specified)
 			{
@@ -429,6 +430,7 @@ func testHashKeyHandlerHelper(t *testing.T, expectedHashSize int) {
 				Data:      string(withAccessJSON),
 				AdminAuth: true,
 				Code:      200,
+				BodyMatch: fmt.Sprintf(`"key_hash":"%s"`, myKeyHash),
 			},
 			// get one key by hash value with specifying hashed=true (API specified)
 			{
@@ -437,6 +439,7 @@ func testHashKeyHandlerHelper(t *testing.T, expectedHashSize int) {
 				Data:      string(withAccessJSON),
 				AdminAuth: true,
 				Code:      200,
+				BodyMatch: fmt.Sprintf(`"key_hash":"%s"`, myKeyHash),
 			},
 			// get one key by hash value without specifying hashed=true
 			{
@@ -687,11 +690,12 @@ func TestHashKeyHandlerHashingDisabled(t *testing.T) {
 			},
 			// get one key by key name
 			{
-				Method:    "GET",
-				Path:      "/tyk/keys/" + myKey,
-				Data:      string(withAccessJSON),
-				AdminAuth: true,
-				Code:      200,
+				Method:       "GET",
+				Path:         "/tyk/keys/" + myKey,
+				Data:         string(withAccessJSON),
+				AdminAuth:    true,
+				Code:         200,
+				BodyNotMatch: fmt.Sprintf(`"key_hash":"%s"`, myKeyHash),
 			},
 			// get one key by hash value with specifying hashed=true (no API specified)
 			{

--- a/gateway/mw_js_plugin.go
+++ b/gateway/mw_js_plugin.go
@@ -544,7 +544,8 @@ func (j *JSVM) LoadTykJSApi() {
 		apiId := call.Argument(1).String()
 
 		obj, _ := handleGetDetail(apiKey, apiId, false)
-		bs, _ := json.Marshal(obj)
+		resp := obj.(apiGetKeyResponse)
+		bs, _ := json.Marshal(resp.Session)
 
 		returnVal, err := j.VM.ToValue(string(bs))
 		if err != nil {

--- a/gateway/mw_jwt_test.go
+++ b/gateway/mw_jwt_test.go
@@ -1011,10 +1011,15 @@ func TestJWTScopeToPolicyMapping(t *testing.T) {
 						p2ID:         true,
 					}
 
-					resp := map[string]interface{}{}
+					resp := struct {
+						Session map[string]interface{}
+						KeyHash string
+					}{}
+
+					//resp := map[string]interface{}{}
 					json.Unmarshal(body, &resp)
 					realResp := map[interface{}]bool{}
-					for _, val := range resp["apply_policies"].([]interface{}) {
+					for _, val := range resp.Session["apply_policies"].([]interface{}) {
 						realResp[val] = true
 					}
 

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -577,11 +577,14 @@ func TestApplyPoliciesQuotaAPILimit(t *testing.T) {
 			AdminAuth: true,
 			Code:      http.StatusOK,
 			BodyMatchFunc: func(data []byte) bool {
-				sessionData := user.SessionState{}
-				if err := json.Unmarshal(data, &sessionData); err != nil {
+				response := apiGetKeyResponse{}
+
+				if err := json.Unmarshal(data, &response); err != nil {
 					t.Log(err.Error())
 					return false
 				}
+
+				sessionData := response.Session
 				api1Limit := sessionData.AccessRights["api1"].Limit
 				if api1Limit == nil {
 					t.Log("api1 limit is not set")
@@ -654,11 +657,14 @@ func TestApplyPoliciesQuotaAPILimit(t *testing.T) {
 			AdminAuth: true,
 			Code:      http.StatusOK,
 			BodyMatchFunc: func(data []byte) bool {
-				sessionData := user.SessionState{}
-				if err := json.Unmarshal(data, &sessionData); err != nil {
+				response := apiGetKeyResponse{}
+
+				if err := json.Unmarshal(data, &response); err != nil {
 					t.Log(err.Error())
 					return false
 				}
+				sessionData := response.Session
+
 				api1Limit := sessionData.AccessRights["api1"].Limit
 				if api1Limit == nil {
 					t.Error("api1 limit is not set")
@@ -752,11 +758,13 @@ func TestPerAPIPolicyUpdate(t *testing.T) {
 			AdminAuth: true,
 			Code:      http.StatusOK,
 			BodyMatchFunc: func(data []byte) bool {
-				sessionData := user.SessionState{}
-				if err := json.Unmarshal(data, &sessionData); err != nil {
+				response := apiGetKeyResponse{}
+
+				if err := json.Unmarshal(data, &response); err != nil {
 					t.Log(err.Error())
 					return false
 				}
+				sessionData := response.Session
 
 				if len(sessionData.AccessRights) != 2 {
 					t.Fatalf("expected 2 entries in AccessRights found %d", len(sessionData.AccessRights))
@@ -803,11 +811,14 @@ func TestPerAPIPolicyUpdate(t *testing.T) {
 			AdminAuth: true,
 			Code:      http.StatusOK,
 			BodyMatchFunc: func(data []byte) bool {
-				sessionData := user.SessionState{}
-				if err := json.Unmarshal(data, &sessionData); err != nil {
+				response := apiGetKeyResponse{}
+
+				if err := json.Unmarshal(data, &response); err != nil {
 					t.Log(err.Error())
 					return false
 				}
+
+				sessionData := response.Session
 
 				if len(sessionData.AccessRights) != 1 {
 					t.Fatalf("expected only 1 entry in AccessRights found %d", len(sessionData.AccessRights))


### PR DESCRIPTION
Fixes [tyk-analytics-ui/issues/1118](https://github.com/TykTechnologies/tyk-analytics-ui/issues/1118)

The response of get key endpoint is modified to 

```
{                                                                       
   Session user.SessionState                                                    
   KeyHash string                                                          
 } 
```