### PR TITLE
fix json tag for policies loaded from the dashboard 

### DIFF
--- a/gateway/policy.go
+++ b/gateway/policy.go
@@ -16,7 +16,7 @@ import (
 )
 
 type DBAccessDefinition struct {
-	APIName     string            `json:"apiname"`
+	APIName     string            `json:"api_name"`
 	APIID       string            `json:"apiid"`
 	Versions    []string          `json:"versions"`
 	AllowedURLs []user.AccessSpec `bson:"allowed_urls" json:"allowed_urls"` // mapped string MUST be a valid regex


### PR DESCRIPTION
Fixes https://github.com/TykTechnologies/tyk-analytics/issues/1308

When fetching the list of policies from the DB, the json key is `api_name` not `apiname`. `apiname` is the bson key though