### PR TITLE
Fix webhook

### DIFF
--- a/gateway/event_handler_webhooks.go
+++ b/gateway/event_handler_webhooks.go
@@ -228,15 +228,24 @@ func (w *WebHookHandler) HandleEvent(em config.EventMessage) {
 		}).Error("Webhook request failed: ", err)
 	} else {
 		defer resp.Body.Close()
-		content, err := ioutil.ReadAll(resp.Body)
-		if err == nil {
-			log.WithFields(logrus.Fields{
-				"prefix": "webhooks",
-			}).Debug(string(content))
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			content, err := ioutil.ReadAll(resp.Body)
+			if err == nil {
+				log.WithFields(logrus.Fields{
+					"prefix":       "webhooks",
+					"responseCode": resp.StatusCode,
+				}).Debug(string(content))
+			} else {
+				log.WithFields(logrus.Fields{
+					"prefix": "webhooks",
+				}).Error(err)
+			}
+
 		} else {
 			log.WithFields(logrus.Fields{
-				"prefix": "webhooks",
-			}).Error(err)
+				"prefix":       "webhooks",
+				"responseCode": resp.StatusCode,
+			}).Error("Request to webhook failed")
 		}
 	}
 

--- a/gateway/event_handler_webhooks.go
+++ b/gateway/event_handler_webhooks.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 
@@ -218,7 +219,9 @@ func (w *WebHookHandler) HandleEvent(em config.EventMessage) {
 		return
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	cli := &http.Client{Timeout: 30 * time.Second}
+
+	resp, err := cli.Do(req)
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "webhooks",

--- a/gateway/event_handler_webhooks.go
+++ b/gateway/event_handler_webhooks.go
@@ -182,6 +182,7 @@ func (w *WebHookHandler) BuildRequest(reqBody string) (*http.Request, error) {
 	}
 
 	req.Header.Set("User-Agent", "Tyk-Hookshot")
+	req.Header.Set("Content-Type", "application/json")
 
 	for key, val := range w.conf.HeaderList {
 		req.Header.Set(key, val)

--- a/gateway/event_handler_webhooks_test.go
+++ b/gateway/event_handler_webhooks_test.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -218,4 +219,47 @@ func TestNewCustomTemplate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWebhookContentTypeHeader(t *testing.T) {
+	globalConf := config.Global()
+	templatePath := globalConf.TemplatePath
+
+	tests := []struct {
+		Name                string
+		TemplatePath        string
+		InputHeaders        map[string]string
+		ExpectedContentType string
+	}{
+		{"MissingTemplatePath", "", nil, "application/json"},
+		{"MissingTemplatePath/CustomHeaders", "", map[string]string{"Content-Type": "application/xml"}, "application/xml"},
+		{"InvalidTemplatePath", "randomPath", nil, "application/json"},
+		{"InvalidTemplatePath/CustomHeaders", "randomPath", map[string]string{"Content-Type": "application/xml"}, "application/xml"},
+		{"CustomTemplate", filepath.Join(templatePath, "breaker_webhook.json"), nil, ""},
+		{"CustomTemplate/CustomHeaders", filepath.Join(templatePath, "breaker_webhook.json"), map[string]string{"Content-Type": "application/json"}, "application/json"},
+	}
+
+	for _, ts := range tests {
+		t.Run(ts.Name, func(t *testing.T) {
+			conf := config.WebHookHandlerConf{
+				TemplatePath: ts.TemplatePath,
+				HeaderList:   ts.InputHeaders,
+			}
+
+			hook := &WebHookHandler{}
+			if err := hook.Init(conf); err != nil {
+				t.Fatal("Webhook Init failed with err ", err)
+			}
+
+			req, err := hook.BuildRequest("")
+			if err != nil {
+				t.Fatal("Failed to build request with error ", err)
+			}
+
+			if req.Header.Get("Content-Type") != ts.ExpectedContentType {
+				t.Fatalf("Expect Content-Type %s. Got %s", ts.ExpectedContentType, req.Header.Get("Content-Type"))
+			}
+		})
+	}
+
 }

--- a/gateway/event_handler_webhooks_test.go
+++ b/gateway/event_handler_webhooks_test.go
@@ -96,6 +96,10 @@ func TestBuildRequest(t *testing.T) {
 	if got := req.Header.Get("User-Agent"); got != "Tyk-Hookshot" {
 		t.Error("Header User Agent is not correct!")
 	}
+
+	if got := req.Header.Get("Content-Type"); got != "application/json" {
+		t.Error("Header Content-Type is not correct!")
+	}
 }
 
 func TestCreateBody(t *testing.T) {


### PR DESCRIPTION
1. Added Timeout to HTTP client used for sending a request to webhook
2. Added new flag `useDefaultTemplate` in WebHookHandler
3. Set Content-Type header to "application/json" if default template is used.
4. Handle unsuccessful response code

 Fixes #2371 