### PR TITLE
 Add key update test for policies not enforcing acl case

### DIFF
--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -307,7 +307,7 @@ func TestKeyHandler_UpdateKey(t *testing.T) {
 		}...)
 
 		sessionState, found := FallbackKeySesionManager.SessionDetail(key, false)
-		if !found && sessionState.AccessRights[testAPIID].APIID != testAPIID && len(sessionState.ApplyPolicies) != 2 {
+		if !found || sessionState.AccessRights[testAPIID].APIID != testAPIID || len(sessionState.ApplyPolicies) != 2 {
 			t.Fatal("Adding policy to the list failed")
 		}
 	})
@@ -322,7 +322,7 @@ func TestKeyHandler_UpdateKey(t *testing.T) {
 		}...)
 
 		sessionState, found := FallbackKeySesionManager.SessionDetail(key, false)
-		if !found && sessionState.AccessRights[testAPIID].APIID != testAPIID && len(sessionState.ApplyPolicies) != 0 {
+		if !found || sessionState.AccessRights[testAPIID].APIID != testAPIID || len(sessionState.ApplyPolicies) != 0 {
 			t.Fatal("Removing policy from the list failed")
 		}
 	})

--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -271,57 +271,60 @@ func TestKeyHandler(t *testing.T) {
 }
 
 func TestKeyHandler_UpdateKey(t *testing.T) {
+	const testAPIID = "testAPIID"
+
 	ts := StartTest()
 	defer ts.Close()
 
 	BuildAndLoadAPI(func(spec *APISpec) {
-		spec.Name = "test"
+		spec.APIID = testAPIID
 		spec.UseKeylessAccess = false
 		spec.Auth.UseParam = true
 	})
 
-	accessRights := map[string]user.AccessDefinition{"test": {
-		APIID: "test", Versions: []string{"v1"},
-	}}
-
 	pID := CreatePolicy(func(p *user.Policy) {
-		p.AccessRights = accessRights
-		p.Partitions.Acl = true
-	})
-
-	pID2 := CreatePolicy(func(p *user.Policy) {
-		p.AccessRights = accessRights
 		p.Partitions.RateLimit = true
 	})
 
-	pID3 := CreatePolicy(func(p *user.Policy) {
-		p.AccessRights = accessRights
+	pID2 := CreatePolicy(func(p *user.Policy) {
 		p.Partitions.Quota = true
 	})
 
 	session, key := ts.CreateSession(func(s *user.SessionState) {
-		s.ApplyPolicies = []string{pID, pID2}
-		s.AccessRights = accessRights
+		s.ApplyPolicies = []string{pID}
+		s.AccessRights = map[string]user.AccessDefinition{testAPIID: {
+			APIID: testAPIID, Versions: []string{"v1"},
+		}}
 	})
 
-	t.Run("Add policy", func(t *testing.T) {
-		session.ApplyPolicies = append(session.ApplyPolicies, pID3)
+	t.Run("Add policy not enforcing acl", func(t *testing.T) {
+		session.ApplyPolicies = append(session.ApplyPolicies, pID2)
 		sessionData, _ := json.Marshal(session)
 		path := fmt.Sprintf("/tyk/keys/%s", key)
 
 		_, _ = ts.Run(t, []test.TestCase{
 			{Method: http.MethodPut, Path: path, Data: sessionData, AdminAuth: true, Code: 200},
 		}...)
+
+		sessionState, found := FallbackKeySesionManager.SessionDetail(key, false)
+		if !found && sessionState.AccessRights[testAPIID].APIID != testAPIID && len(sessionState.ApplyPolicies) != 2 {
+			t.Fatal("Adding policy to the list failed")
+		}
 	})
 
-	t.Run("Remove policy", func(t *testing.T) {
-		session.ApplyPolicies = []string{pID}
+	t.Run("Remove policy not enforcing acl", func(t *testing.T) {
+		session.ApplyPolicies = []string{}
 		sessionData, _ := json.Marshal(session)
 		path := fmt.Sprintf("/tyk/keys/%s", key)
 
 		_, _ = ts.Run(t, []test.TestCase{
 			{Method: http.MethodPut, Path: path, Data: sessionData, AdminAuth: true, Code: 200},
 		}...)
+
+		sessionState, found := FallbackKeySesionManager.SessionDetail(key, false)
+		if !found && sessionState.AccessRights[testAPIID].APIID != testAPIID && len(sessionState.ApplyPolicies) != 0 {
+			t.Fatal("Removing policy from the list failed")
+		}
 	})
 }
 

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -655,10 +655,9 @@ func (s *Test) CreateSession(sGen ...func(s *user.SessionState)) (*user.SessionS
 	keySuccess := apiModifyKeySuccess{}
 	err = json.NewDecoder(resp.Body).Decode(&keySuccess)
 	if err != nil {
-		log.Fatal("Error while serializing session:", err)
+		log.Fatal("Error while decoding session response:", err)
 		return nil, ""
 	}
-	resp.Body.Close()
 
 	return session, keySuccess.Key
 }

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -356,7 +356,7 @@ func withAuth(r *http.Request) *http.Request {
 	return r
 }
 
-// TODO: replace with /tyk/keys/create call
+// Deprecated: Use Test.CreateSession instead.
 func CreateSession(sGen ...func(s *user.SessionState)) string {
 	key := generateToken("", "")
 	session := CreateStandardSession()
@@ -634,32 +634,33 @@ func (s *Test) RunExt(t testing.TB, testCases ...test.TestCase) {
 	}
 }
 
-func (s *Test) createSession(sGen ...func(s *user.SessionState)) string {
+func (s *Test) CreateSession(sGen ...func(s *user.SessionState)) (*user.SessionState, string) {
 	session := CreateStandardSession()
 	if len(sGen) > 0 {
 		sGen[0](session)
 	}
 
 	resp, err := s.Do(test.TestCase{
-		Method: "POST",
-		Path:   "/tyk/keys/create",
-		Data:   session,
+		Method:    http.MethodPost,
+		Path:      "/tyk/keys/create",
+		Data:      session,
+		AdminAuth: true,
 	})
 
 	if err != nil {
 		log.Fatal("Error while creating session:", err)
-		return ""
+		return nil, ""
 	}
 
-	respJSON := apiModifyKeySuccess{}
-	err = json.NewDecoder(resp.Body).Decode(&respJSON)
+	keySuccess := apiModifyKeySuccess{}
+	err = json.NewDecoder(resp.Body).Decode(&keySuccess)
 	if err != nil {
 		log.Fatal("Error while serializing session:", err)
-		return ""
+		return nil, ""
 	}
 	resp.Body.Close()
 
-	return respJSON.Key
+	return session, keySuccess.Key
 }
 
 func StartTest(config ...TestConfig) Test {


### PR DESCRIPTION
This PR adds test for the case in which applied policies to key doesn't enforce ACL.

Also, this test deprecates `CreateSession` test util function. Tests should use `Test.CreateSession` function instead after this PR.