### PR TITLE
Add Secure Headers to Oauth token endpoint

### DIFF
--- a/gateway/oauth_manager.go
+++ b/gateway/oauth_manager.go
@@ -219,6 +219,17 @@ func (o *OAuthHandlers) HandleAccessRequest(w http.ResponseWriter, r *http.Reque
 
 	o.notifyClientOfNewOauth(newNotification)
 
+	// Setting OWASP Secure Headers
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("X-XSS-Protection", "1; mode=block")
+	w.Header().Set("X-Frame-Options", "DENY")
+	w.Header().Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
+
+	// Avoid Caching of tokens
+	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+	w.Header().Set("Pragma", "no-cache")
+	w.Header().Set("Expires", "0")
+
 	w.WriteHeader(http.StatusOK)
 	w.Write(msg)
 }

--- a/gateway/oauth_manager_test.go
+++ b/gateway/oauth_manager_test.go
@@ -1051,3 +1051,40 @@ func TestClientRefreshRequestDouble(t *testing.T) {
 		})
 	})
 }
+
+func TestTokenEndpointHeaders(t *testing.T) {
+	ts := StartTest()
+	defer ts.Close()
+
+	spec := loadTestOAuthSpec()
+	createTestOAuthClient(spec, authClientID)
+
+	param := make(url.Values)
+	param.Set("grant_type", "client_credentials")
+	param.Set("redirect_uri", authRedirectUri)
+	param.Set("client_id", authClientID)
+
+	headers := map[string]string{
+		"Content-Type":  "application/x-www-form-urlencoded",
+		"Authorization": "Basic MTIzNDphYWJiY2NkZA==",
+	}
+
+	securityAndCacheHeaders := map[string]string{
+		"X-Content-Type-Options":    "nosniff",
+		"X-XSS-Protection":          "1; mode=block",
+		"X-Frame-Options":           "DENY",
+		"Strict-Transport-Security": "max-age=63072000; includeSubDomains",
+		"Cache-Control":             "no-cache, no-store, must-revalidate",
+		"Pragma":                    "no-cache",
+		"Expires":                   "0",
+	}
+
+	ts.Run(t, test.TestCase{
+		Path:         "/APIID/oauth/token/",
+		Data:         param.Encode(),
+		Headers:      headers,
+		Method:       http.MethodPost,
+		Code:         http.StatusOK,
+		HeadersMatch: securityAndCacheHeaders,
+	})
+}


### PR DESCRIPTION
Added below headers in `/oauth/token` response
```
 "X-Content-Type-Options"    
 "X-XSS-Protection"          
 "X-Frame-Options"        
 "Strict-Transport-Security"
 "Cache-Control"
 "Pragma"
 "Expires"
```