### PR TITLE
Add more descriptive message for key failure

### DIFF
--- a/gateway/server.go
+++ b/gateway/server.go
@@ -427,7 +427,7 @@ func checkIsAPIOwner(next http.Handler) http.Handler {
 			// Error
 			mainLog.Warning("Attempted administrative access with invalid or missing key!")
 
-			doJSONWrite(w, http.StatusForbidden, apiError("Forbidden"))
+			doJSONWrite(w, http.StatusForbidden, apiError("Attempted administrative access with invalid or missing key!"))
 			return
 		}
 		next.ServeHTTP(w, r)


### PR DESCRIPTION
I realized this while fixing a bug in an integration test. 