### PR TITLE
accept oauth credentials as json on /token endpoint

### DIFF
--- a/gateway/oauth_manager.go
+++ b/gateway/oauth_manager.go
@@ -262,7 +262,8 @@ func (o *OAuthManager) HandleAuthorisation(r *http.Request, complete bool, sessi
 }
 
 // JSONToFormValues if r has header Content-Type set to application/json this
-// will decode json as map[string]string and adds the key/value pairs in r.Form.
+// will decode request body as json to map[string]string and adds the key/value
+// pairs in r.Form.
 func JSONToFormValues(r *http.Request) error {
 	if r.Header.Get("Content-Type") == "application/json" {
 		var o map[string]string

--- a/gateway/oauth_manager.go
+++ b/gateway/oauth_manager.go
@@ -261,7 +261,7 @@ func (o *OAuthManager) HandleAuthorisation(r *http.Request, complete bool, sessi
 	return resp
 }
 
-// JSONToFormValues if r has heaert Content-Type set to application/json this
+// JSONToFormValues if r has header Content-Type set to application/json this
 // will decode json as map[string]string and adds the key/value pairs in r.Form.
 func JSONToFormValues(r *http.Request) error {
 	if r.Header.Get("Content-Type") == "application/json" {

--- a/gateway/oauth_manager.go
+++ b/gateway/oauth_manager.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"math"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/lonelycode/osin"
@@ -260,9 +261,44 @@ func (o *OAuthManager) HandleAuthorisation(r *http.Request, complete bool, sessi
 	return resp
 }
 
+// JSONToFormValues if r has heaert Content-Type set to application/json this
+// will decode json as map[string]string and adds the key/value pairs in r.Form.
+func JSONToFormValues(r *http.Request) error {
+	if r.Header.Get("Content-Type") == "application/json" {
+		var o map[string]string
+		// we don't want to mess with the original body so we are going to work with a
+		// copy.
+		body, err := r.GetBody()
+		if err != nil {
+			return err
+		}
+		err = json.NewDecoder(body).Decode(&o)
+		if err != nil {
+			return err
+		}
+		if len(o) > 0 {
+			if r.Form == nil {
+				r.Form = make(url.Values)
+			}
+			for k, v := range o {
+				r.Form.Set(k, v)
+			}
+		}
+
+	}
+	return nil
+}
+
 // HandleAccess wraps an access request with osin's primitives
 func (o *OAuthManager) HandleAccess(r *http.Request) *osin.Response {
 	resp := o.OsinServer.NewResponse()
+	// we are intentionally ignoring errors, because this is called again by
+	// osin.We are only doing this to ensure r.From is properly initialized incase
+	// r.ParseForm was success
+	r.ParseForm()
+	if err := JSONToFormValues(r); err != nil {
+		log.Errorf("trying to set url values decoded from json body :%v", err)
+	}
 	var username string
 	if ar := o.OsinServer.HandleAccessRequest(resp, r); ar != nil {
 

--- a/gateway/oauth_manager_test.go
+++ b/gateway/oauth_manager_test.go
@@ -1117,19 +1117,6 @@ func TestJSONToFormValues(t *testing.T) {
 		}
 	})
 
-	t.Run("no application/json header", func(ts *testing.T) {
-		err := JSONToFormValues(r)
-		if err != nil {
-			ts.Fatal(err)
-		}
-		for k, v := range o {
-			g := r.Form.Get(k)
-			if g == v {
-				ts.Errorf("expected %s not to be set", v)
-			}
-		}
-	})
-
 	t.Run("with application/json header", func(ts *testing.T) {
 		r.Header.Set("Content-Type", "application/json")
 		err := JSONToFormValues(r)

--- a/gateway/oauth_manager_test.go
+++ b/gateway/oauth_manager_test.go
@@ -5,6 +5,7 @@ package gateway
 */
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/url"
 	"reflect"
@@ -1086,5 +1087,60 @@ func TestTokenEndpointHeaders(t *testing.T) {
 		Method:       http.MethodPost,
 		Code:         http.StatusOK,
 		HeadersMatch: securityAndCacheHeaders,
+	})
+}
+
+func TestJSONToFormValues(t *testing.T) {
+	o := map[string]string{
+		"username":      "test@test.com",
+		"password":      "12345678",
+		"scope":         "client",
+		"client_id":     "test-client-id",
+		"client_secret": "test-client-secret",
+		"grant_type":    "password",
+	}
+	b, _ := json.Marshal(o)
+	r, err := http.NewRequest(http.MethodPost, "/token", bytes.NewReader(b))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Run("no application/json header", func(ts *testing.T) {
+		err := JSONToFormValues(r)
+		if err != nil {
+			ts.Fatal(err)
+		}
+		for k, v := range o {
+			g := r.Form.Get(k)
+			if g == v {
+				ts.Errorf("expected %s not to be set", v)
+			}
+		}
+	})
+
+	t.Run("no application/json header", func(ts *testing.T) {
+		err := JSONToFormValues(r)
+		if err != nil {
+			ts.Fatal(err)
+		}
+		for k, v := range o {
+			g := r.Form.Get(k)
+			if g == v {
+				ts.Errorf("expected %s not to be set", v)
+			}
+		}
+	})
+
+	t.Run("with application/json header", func(ts *testing.T) {
+		r.Header.Set("Content-Type", "application/json")
+		err := JSONToFormValues(r)
+		if err != nil {
+			ts.Fatal(err)
+		}
+		for k, v := range o {
+			g := r.Form.Get(k)
+			if g != v {
+				ts.Errorf("expected %s got %s", v, g)
+			}
+		}
 	})
 }


### PR DESCRIPTION
When Content-Type header is set to application/json . This will decode
and adds them to r.Form to be used by osin

closes #2375
