### PR TITLE
Service Discovery - use cache timeout at the API level before looking at the global configs

### DIFF
--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -189,7 +189,9 @@ func TykNewSingleHostReverseProxy(target *url.URL, spec *APISpec) *ReverseProxy 
 		if ServiceCache == nil {
 			log.Debug("[PROXY] Service cache initialising")
 			expiry := 120
-			if spec.GlobalConfig.ServiceDiscovery.DefaultCacheTimeout > 0 {
+			if spec.Proxy.ServiceDiscovery.CacheTimeout > 0 {
+				expiry = int(spec.Proxy.ServiceDiscovery.CacheTimeout)
+			} else if spec.GlobalConfig.ServiceDiscovery.DefaultCacheTimeout > 0 {
 				expiry = spec.GlobalConfig.ServiceDiscovery.DefaultCacheTimeout
 			}
 			ServiceCache = cache.New(time.Duration(expiry)*time.Second, 15*time.Second)


### PR DESCRIPTION
Service Discovery - Uses the cache timeout at the API level before looking at the global one in the context of ServiceDiscovery