### PR TITLE
fix panic for bad integer casting

### DIFF
--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -416,9 +416,9 @@ func (p *ReverseProxy) CheckHardTimeoutEnforced(spec *APISpec, req *http.Request
 	_, versionPaths, _, _ := spec.Version(req)
 	found, meta := spec.CheckSpecMatchesStatus(req, versionPaths, HardTimeout)
 	if found {
-		intMeta := meta.(*float64)
+		intMeta := meta.(*int)
 		log.Debug("HARD TIMEOUT ENFORCED: ", *intMeta)
-		return true, *intMeta
+		return true, float64(*intMeta)
 	}
 
 	return false, spec.GlobalConfig.ProxyDefaultTimeout


### PR DESCRIPTION
HardTimeout expects float64 result but  HardTimeoutMeta.Timeout is int

This  causes the panic  when calling spec.CheckSpecMatchesStatus  with
HardTimeout

Fixes #2420 