### PR TITLE
Fix oauth endpoint headers

### DIFF
--- a/gateway/api.go
+++ b/gateway/api.go
@@ -112,6 +112,22 @@ func (m MethodNotAllowedHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	doJSONWrite(w, http.StatusMethodNotAllowed, apiError("Method not supported"))
 }
 
+func addSecureAndCacheHeaders(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Setting OWASP Secure Headers
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-XSS-Protection", "1; mode=block")
+		w.Header().Set("X-Frame-Options", "DENY")
+		w.Header().Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
+
+		// Avoid Caching of tokens
+		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+		w.Header().Set("Pragma", "no-cache")
+		w.Header().Set("Expires", "0")
+		next(w, r)
+	}
+}
+
 func allowMethods(next http.HandlerFunc, methods ...string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		for _, method := range methods {

--- a/gateway/oauth_manager.go
+++ b/gateway/oauth_manager.go
@@ -221,17 +221,6 @@ func (o *OAuthHandlers) HandleAccessRequest(w http.ResponseWriter, r *http.Reque
 
 	o.notifyClientOfNewOauth(newNotification)
 
-	// Setting OWASP Secure Headers
-	w.Header().Set(headers.XContentTypeOptions, "nosniff")
-	w.Header().Set(headers.XXSSProtection, "1; mode=block")
-	w.Header().Set(headers.XFrameOptions, "DENY")
-	w.Header().Set(headers.StrictTransportSecurity, "max-age=63072000; includeSubDomains")
-
-	// Avoid Caching of tokens
-	w.Header().Set(headers.CacheControl, "no-cache, no-store, must-revalidate")
-	w.Header().Set(headers.Pragma, "no-cache")
-	w.Header().Set(headers.Expires, "0")
-
 	w.WriteHeader(http.StatusOK)
 	w.Write(msg)
 }

--- a/gateway/oauth_manager_test.go
+++ b/gateway/oauth_manager_test.go
@@ -1080,14 +1080,21 @@ func TestTokenEndpointHeaders(t *testing.T) {
 		"Expires":                   "0",
 	}
 
-	ts.Run(t, test.TestCase{
-		Path:         "/APIID/oauth/token/",
-		Data:         param.Encode(),
-		Headers:      headers,
-		Method:       http.MethodPost,
-		Code:         http.StatusOK,
-		HeadersMatch: securityAndCacheHeaders,
-	})
+	ts.Run(t, []test.TestCase{
+		{
+			Path:         "/APIID/oauth/token/",
+			Data:         param.Encode(),
+			Headers:      headers,
+			Method:       http.MethodPost,
+			Code:         http.StatusOK,
+			HeadersMatch: securityAndCacheHeaders,
+		}, { // Set security headers even if request fails
+			Path:         "/APIID/oauth/token/",
+			Data:         param.Encode(),
+			Method:       http.MethodPost,
+			Code:         http.StatusForbidden,
+			HeadersMatch: securityAndCacheHeaders,
+		}}...)
 }
 
 func TestJSONToFormValues(t *testing.T) {

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -464,7 +464,7 @@ func addOAuthHandlers(spec *APISpec, muxer *mux.Router) *OAuthManager {
 
 	muxer.Handle(apiAuthorizePath, checkIsAPIOwner(allowMethods(oauthHandlers.HandleGenerateAuthCodeData, "POST")))
 	muxer.HandleFunc(clientAuthPath, allowMethods(oauthHandlers.HandleAuthorizePassthrough, "GET", "POST"))
-	muxer.HandleFunc(clientAccessPath, allowMethods(oauthHandlers.HandleAccessRequest, "GET", "POST"))
+	muxer.HandleFunc(clientAccessPath, addSecureAndCacheHeaders(allowMethods(oauthHandlers.HandleAccessRequest, "GET", "POST")))
 
 	return &oauthManager
 }


### PR DESCRIPTION
Fixes #2423 

Add secure headers even if request to `/oauth/token` fails