### PR TITLE
mw_js_plugin: extend ReturnOverrides HTTP code check to allow redirects

### DIFF
--- a/gateway/mw_js_plugin.go
+++ b/gateway/mw_js_plugin.go
@@ -255,8 +255,7 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 		return errors.New(newRequestData.Request.ReturnOverrides.ResponseError), newRequestData.Request.ReturnOverrides.ResponseCode
 	}
 
-	if newRequestData.Request.ReturnOverrides.ResponseCode != 0 && newRequestData.Request.ReturnOverrides.ResponseCode < http.StatusMultipleChoices {
-
+	if newRequestData.Request.ReturnOverrides.ResponseCode != 0 {
 		responseObject := VMResponseObject{
 			Response: ResponseObject{
 				Body:    newRequestData.Request.ReturnOverrides.ResponseError,


### PR DESCRIPTION
Fix for #2429, with this patch the following code is able to trigger a redirect:
```js
var sampleMiddleware = new TykJS.TykMiddleware.NewMiddleware({});

sampleMiddleware.NewProcessRequest(function(request, session, spec) {
  console.log("sampleMiddleware is called")
  request.ReturnOverrides.ResponseCode = 301
  request.ReturnOverrides.ResponseHeaders = {
    "Location": "http://anotherurl.com/"
  }
  return sampleMiddleware.ReturnData(request, session.meta_data);
});
```