### PR TITLE
(perf) optimising stripping bearer token

### DIFF
--- a/gateway/mw_auth_key.go
+++ b/gateway/mw_auth_key.go
@@ -159,9 +159,10 @@ func (k *AuthKey) validateSignature(r *http.Request, key string) (error, int) {
 }
 
 func stripBearer(token string) string {
-	token = strings.Replace(token, "Bearer", "", 1)
-	token = strings.Replace(token, "bearer", "", 1)
-	return strings.TrimSpace(token)
+	if len(token) > 6 && strings.ToUpper(token[0:7]) == "BEARER " {
+		return token[7:]
+	}
+	return token
 }
 
 func AuthFailed(m TykMiddleware, r *http.Request, token string) {

--- a/gateway/mw_auth_key_test.go
+++ b/gateway/mw_auth_key_test.go
@@ -409,3 +409,34 @@ const multiAuthDef = `{
 		"target_url": "` + testHttpAny + `"
 	}
 }`
+
+func TestStripBearer(t *testing.T) {
+	var bearerTests = []struct {
+		in  string
+		out string
+	}{
+		{"Bearer abc", "abc"},
+		{"bearer abc", "abc"},
+		{"bEaReR abc", "abc"},
+		{"Bearer: abc", "Bearer: abc"}, // invalid
+		{"Basic abc", "Basic abc"},
+		{"abc", "abc"},
+	}
+
+	for _, tt := range bearerTests {
+		t.Run(tt.in, func(t *testing.T) {
+			out := stripBearer(tt.in)
+			if out != tt.out {
+				t.Errorf("got %q, want %q", out, tt.out)
+			}
+		})
+	}
+}
+
+func BenchmarkStripBearer(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_ = stripBearer("Bearer abcdefghijklmnopqrstuvwxyz12345678910")
+	}
+}

--- a/gateway/mw_jwt_test.go
+++ b/gateway/mw_jwt_test.go
@@ -387,7 +387,7 @@ func TestJWTSessionRSABearerInvalid(t *testing.T) {
 		ts.Run(t, test.TestCase{
 			Headers:   authHeaders,
 			Code:      http.StatusForbidden,
-			BodyMatch: "Key not authorized:illegal base64 data at input byte 0",
+			BodyMatch: "Key not authorized:illegal base64 data at input byte 6",
 		})
 	})
 }
@@ -402,7 +402,7 @@ func TestJWTSessionRSABearerInvalidTwoBears(t *testing.T) {
 
 	t.Run("Request with Bearer bearer", func(t *testing.T) {
 		ts.Run(t, test.TestCase{
-			Headers: authHeaders1, Code: http.StatusOK, //todo: fix code since it should be http.StatusForbidden
+			Headers: authHeaders1, Code: http.StatusForbidden,
 		})
 	})
 
@@ -410,7 +410,7 @@ func TestJWTSessionRSABearerInvalidTwoBears(t *testing.T) {
 
 	t.Run("Request with bearer Bearer", func(t *testing.T) {
 		ts.Run(t, test.TestCase{
-			Headers: authHeaders2, Code: http.StatusOK, //todo: fix code since it should be http.StatusForbidden
+			Headers: authHeaders2, Code: http.StatusForbidden,
 		})
 	})
 }


### PR DESCRIPTION
Should speed up JWT & Auth Token a little bit.

```
benchcmp old.txt new.txt
benchmark                  old ns/op     new ns/op     delta
BenchmarkStripBearer-4     165           38.4          -76.73%

benchmark                  old allocs     new allocs     delta
BenchmarkStripBearer-4     2              1              -50.00%

benchmark                  old bytes     new bytes     delta
BenchmarkStripBearer-4     96            8             -91.67%
```