### PR TITLE
don't use Request.GetBody

### DIFF
--- a/gateway/oauth_manager.go
+++ b/gateway/oauth_manager.go
@@ -257,13 +257,7 @@ func (o *OAuthManager) HandleAuthorisation(r *http.Request, complete bool, sessi
 func JSONToFormValues(r *http.Request) error {
 	if r.Header.Get("Content-Type") == "application/json" {
 		var o map[string]string
-		// we don't want to mess with the original body so we are going to work with a
-		// copy.
-		body, err := r.GetBody()
-		if err != nil {
-			return err
-		}
-		err = json.NewDecoder(body).Decode(&o)
+		err := json.NewDecoder(r.Body).Decode(&o)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Decode json directly from r.Body because r.GetBody is nil

The tests missed this because they used `http.NewRequest` which sets `r.GetBody`.
 
Fixes #2375
Fixes #2398
