### PR TITLE
Fix Body Transform with Validate JSON plugin

### DIFF
--- a/gateway/mw_transform.go
+++ b/gateway/mw_transform.go
@@ -72,6 +72,7 @@ func transformBody(r *http.Request, tmeta *TransformSpec, contextVars bool) erro
 		if len(body) == 0 {
 			body = []byte("{}")
 		}
+
 		var tempBody interface{}
 		if err := json.Unmarshal(body, &tempBody); err != nil {
 			return err
@@ -106,6 +107,7 @@ func transformBody(r *http.Request, tmeta *TransformSpec, contextVars bool) erro
 	}
 	r.Body = ioutil.NopCloser(&bodyBuffer)
 	r.ContentLength = int64(bodyBuffer.Len())
+	nopCloseRequestBody(r)
 
 	return nil
 }


### PR DESCRIPTION
We use special `nopCloser` wrapper for body, which is smart enough
to automatically rewind the body when it fully read.

When we set new body, we need wrap it to noCloser again.

Fix https://github.com/TykTechnologies/tyk/issues/2425