### PR TITLE
Fix formatting of complex error messages

### DIFF
--- a/gateway/handler_error.go
+++ b/gateway/handler_error.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"bytes"
 	"encoding/base64"
+	"html/template"
 	"net/http"
 	"runtime/pprof"
 	"strconv"
@@ -21,7 +22,7 @@ const (
 
 // APIError is generic error object returned if there is something wrong with the request
 type APIError struct {
-	Message string
+	Message template.HTML
 }
 
 // ErrorHandler is invoked whenever there is an issue with a proxied request, most middleware will invoke
@@ -79,7 +80,7 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 
 		// Need to return the correct error code!
 		w.WriteHeader(errCode)
-		apiError := APIError{errMsg}
+		apiError := APIError{template.HTML(template.JSEscapeString(errMsg))}
 		tmpl.Execute(w, &apiError)
 	}
 

--- a/gateway/mw_validate_json_test.go
+++ b/gateway/mw_validate_json_test.go
@@ -23,7 +23,11 @@ var testJsonSchema = `{
             "description": "Age in years",
             "type": "integer",
             "minimum": 0
-        }
+        },
+		"objs":{
+			"enum":["a","b","c"],
+			"type":"string"
+		}
     },
     "required": ["firstName", "lastName"]
 }`
@@ -56,6 +60,7 @@ func TestValidateJSONSchema(t *testing.T) {
 		{Method: "POST", Path: "/v", Data: `[]`, BodyMatch: `Expected: object, given: array`, Code: http.StatusUnprocessableEntity},
 		{Method: "POST", Path: "/v", Data: `not_json`, Code: http.StatusBadRequest},
 		{Method: "POST", Path: "/v", Data: `{"age":23, "firstName": "Harry", "lastName": "Potter"}`, Code: http.StatusOK},
+		{Method: "POST", Path: "/v", Data: `{"age":23, "firstName": "Harry", "lastName": "Potter", "objs": "d"}`, Code: http.StatusUnprocessableEntity, BodyMatch: "objs: objs must be one of the following: \\\"a\\\", \\\"b\\\", \\\"c\\\""},
 	}...)
 }
 


### PR DESCRIPTION
It was using html/template package for rendering JSON files
which was causing HTML based escaping, instead of JS based.
For example quotes was escaped as `&#34;` instead of `\"`

Fix https://github.com/TykTechnologies/tyk/issues/2448
