### PR TITLE
Fix APIDefinition JWTIdentityBaseField bson/json key inconsisitency i…

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -372,7 +372,7 @@ type APIDefinition struct {
 	EnableCoProcessAuth        bool                 `bson:"enable_coprocess_auth" json:"enable_coprocess_auth"`
 	JWTSigningMethod           string               `bson:"jwt_signing_method" json:"jwt_signing_method"`
 	JWTSource                  string               `bson:"jwt_source" json:"jwt_source"`
-	JWTIdentityBaseField       string               `bson:"jwt_identit_base_field" json:"jwt_identity_base_field"`
+	JWTIdentityBaseField       string               `bson:"jwt_identity_base_field" json:"jwt_identity_base_field"`
 	JWTClientIDBaseField       string               `bson:"jwt_client_base_field" json:"jwt_client_base_field"`
 	JWTPolicyFieldName         string               `bson:"jwt_policy_field_name" json:"jwt_policy_field_name"`
 	JWTDefaultPolicies         []string             `bson:"jwt_default_policies" json:"jwt_default_policies"`


### PR DESCRIPTION
When I tried to create app definition by dumping MongoDB, I found the JWT identity base field doesn't match between MongoDB (jwt_identit_base_field) and JSON (jwt_identity_base_field) file. After reviewing other field definition, I think this should be a typo issue.