### PR TITLE
allow polices to be loaded from dash irrespective of where APIs are loaded from

### DIFF
--- a/gateway/server.go
+++ b/gateway/server.go
@@ -1188,7 +1188,7 @@ func dashboardServiceInit() {
 }
 
 func handleDashboardRegistration() {
-	if !config.Global().UseDBAppConfigs {
+	if !config.Global().UseDBAppConfigs && config.Global().Policies.PolicySource != "service" {
 		return
 	}
 


### PR DESCRIPTION
Right now, if APIs are loaded from the filesystem, policies cannot be loaded from the dash.

How to replicate:

- set `policies.policy_source: "service"` and `use_db_app_config: false`
- APIs will be loaded from files while policies won't be loaded from the dashboard.

Fixes https://github.com/TykTechnologies/tyk/issues/2545