### PR TITLE
Add support for whitelisting ports

### DIFF
--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -706,6 +706,9 @@
         }
       }
     },
+    "enable_ports_whitelist": {
+      "type": "boolean"
+    },
     "ports_whitelist": {
       "type": [
         "object",

--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -706,7 +706,7 @@
         }
       }
     },
-    "enable_ports_whitelist": {
+    "disable_ports_whitelist": {
       "type": "boolean"
     },
     "ports_whitelist": {

--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -58,6 +58,32 @@
           "type": "string"
         }
       }
+    },
+    "PortWhiteList": {
+      "type": [
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "ranges": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "from": {
+              "type": "integer"
+            },
+            "to": {
+              "type": "integer"
+            }
+          }
+        },
+        "ports": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        }
+      }
     }
   },
   "properties": {
@@ -680,22 +706,24 @@
         }
       }
     },
-    "disabled_ports": {
+    "ports_whitelist": {
       "type": [
-        "array",
+        "object",
         "null"
       ],
-      "items": {
-        "type": [
-          "object"
-        ],
-        "properties": {
-          "protocol": {
-            "type": "string"
-          },
-          "port": {
-            "type": "number"
-          }
+      "additionalProperties": false,
+      "properties": {
+        "http": {
+          "$ref": "#/definitions/PortWhiteList"
+        },
+        "https": {
+          "$ref": "#/definitions/PortWhiteList"
+        },
+        "tcp": {
+          "$ref": "#/definitions/PortWhiteList"
+        },
+        "tls": {
+          "$ref": "#/definitions/PortWhiteList"
         }
       }
     },

--- a/config/config.go
+++ b/config/config.go
@@ -266,15 +266,15 @@ type PortWhiteList struct {
 	Ports  []int       `json:"ports,omitempty"`
 }
 
-// Ok returns true if port is acceptable from the PortWhiteList.
-func (p PortWhiteList) Ok(port int) bool {
+// Match returns true if port is acceptable from the PortWhiteList.
+func (p PortWhiteList) Match(port int) bool {
 	for _, v := range p.Ports {
 		if port == v {
 			return true
 		}
 	}
 	for _, r := range p.Ranges {
-		if r.Ok(port) {
+		if r.Match(port) {
 			return true
 		}
 	}
@@ -287,8 +287,8 @@ type PortRange struct {
 	To   int `json:"to"`
 }
 
-// Ok returns true if port is within the range
-func (r PortRange) Ok(port int) bool {
+// Match returns true if port is within the range
+func (r PortRange) Match(port int) bool {
 	return r.From <= port && r.To >= port
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -325,7 +325,7 @@ type Config struct {
 	EnableAPISegregation    bool           `json:"enable_api_segregation"`
 	TemplatePath            string         `json:"template_path"`
 	Policies                PoliciesConfig `json:"policies"`
-	EnablePortWhiteList     bool           `json:"enable_ports_whitelist"`
+	DisablePortWhiteList    bool           `json:"disable_ports_whitelist"`
 	// Defines the ports that will be available for the api services to bind to.
 	// This is a map of protocol to PortWhiteList. This allows per protocol
 	// configurations.

--- a/config/config.go
+++ b/config/config.go
@@ -325,6 +325,7 @@ type Config struct {
 	EnableAPISegregation    bool           `json:"enable_api_segregation"`
 	TemplatePath            string         `json:"template_path"`
 	Policies                PoliciesConfig `json:"policies"`
+	EnablePortWhiteList     bool           `json:"enable_ports_whitelist"`
 	// Defines the ports that will be available for the api services to bind to.
 	// This is a map of protocol to PortWhiteList. This allows per protocol
 	// configurations.

--- a/config/config.go
+++ b/config/config.go
@@ -260,6 +260,38 @@ type ServicePort struct {
 	Port     int    `json:"port"`
 }
 
+// PortWhiteList defines ports that will be allowed by the gateway.
+type PortWhiteList struct {
+	Ranges []PortRange `json:"ranges,omitempty"`
+	Ports  []int       `json:"ports,omitempty"`
+}
+
+// Ok returns true if port is acceptable from the PortWhiteList.
+func (p PortWhiteList) Ok(port int) bool {
+	for _, v := range p.Ports {
+		if port == v {
+			return true
+		}
+	}
+	for _, r := range p.Ranges {
+		if r.Ok(port) {
+			return true
+		}
+	}
+	return false
+}
+
+// PortRange defines a range of ports inclusively.
+type PortRange struct {
+	From int `json:"from"`
+	To   int `json:"to"`
+}
+
+// Ok returns true if port is within the range
+func (r PortRange) Ok(port int) bool {
+	return r.From <= port && r.To >= port
+}
+
 // Config is the configuration object used by tyk to set up various parameters.
 type Config struct {
 	// OriginalPath is the path to the config file that was read. If
@@ -293,7 +325,10 @@ type Config struct {
 	EnableAPISegregation    bool           `json:"enable_api_segregation"`
 	TemplatePath            string         `json:"template_path"`
 	Policies                PoliciesConfig `json:"policies"`
-	DisabledPorts           []ServicePort  `json:"disabled_ports"`
+	// Defines the ports that will be available for the api services to bind to.
+	// This is a map of protocol to PortWhiteList. This allows per protocol
+	// configurations.
+	PortWhiteList map[string]PortWhiteList `json:"ports_whitelist"`
 
 	// CE Configurations
 	AppPath string `json:"app_path"`

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -844,6 +844,9 @@ func TestProxyProtocol(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	EnablePort(p, "tcp")
+	defer ResetTestConfig()
+
 	proxyAddr := rp.Addr().String()
 	rp.Close()
 	BuildAndLoadAPI(func(spec *APISpec) {

--- a/gateway/proxy_muxer.go
+++ b/gateway/proxy_muxer.go
@@ -309,7 +309,7 @@ func (m *proxyMux) swap(new *proxyMux) {
 				ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 				curP.httpServer.Shutdown(ctx)
 				cancel()
-			} else {
+			} else if curP.listener != nil {
 				curP.listener.Close()
 			}
 			m.again.Delete(target(listenAddress, curP.port))

--- a/gateway/proxy_muxer.go
+++ b/gateway/proxy_muxer.go
@@ -405,6 +405,9 @@ func target(listenAddress string, listenPort int) string {
 }
 
 func CheckPortWhiteList(cfg config.Config, listenPort int, protocol string) error {
+	if !cfg.EnablePortWhiteList {
+		return nil
+	}
 	if protocol == "" || protocol == "http" || protocol == "https" {
 		if listenPort == cfg.ListenPort || listenPort == cfg.ControlAPIPort {
 			return nil

--- a/gateway/proxy_muxer.go
+++ b/gateway/proxy_muxer.go
@@ -413,7 +413,7 @@ func CheckPortWhiteList(cfg config.Config, listenPort int, protocol string) erro
 	w := cfg.PortWhiteList
 	if w != nil {
 		if ls, ok := w[protocol]; ok {
-			if ls.Ok(listenPort) {
+			if ls.Match(listenPort) {
 				return nil
 			}
 		}

--- a/gateway/proxy_muxer.go
+++ b/gateway/proxy_muxer.go
@@ -405,9 +405,8 @@ func target(listenAddress string, listenPort int) string {
 }
 
 func CheckPortWhiteList(cfg config.Config, listenPort int, protocol string) error {
-	gwPort := cfg.ListenPort
 	if protocol == "" || protocol == "http" || protocol == "https" {
-		if listenPort == gwPort {
+		if listenPort == cfg.ListenPort || listenPort == cfg.ControlAPIPort {
 			return nil
 		}
 	}

--- a/gateway/proxy_muxer_test.go
+++ b/gateway/proxy_muxer_test.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"reflect"
 	"strconv"
 	"sync/atomic"
@@ -89,6 +88,8 @@ func TestTCPDial_with_service_discovery(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	EnablePort(p, "tcp")
+	defer ResetTestConfig()
 	address := rp.Addr().String()
 	rp.Close()
 	BuildAndLoadAPI(func(spec *APISpec) {
@@ -215,31 +216,4 @@ func TestCheckPortWhiteList(t *testing.T) {
 			}
 		})
 	}
-	m := map[string]config.PortWhiteList{
-		"http": config.PortWhiteList{
-			Ranges: []config.PortRange{
-				{
-					From: 8000,
-					To:   9000,
-				},
-			},
-		},
-		"tcp": config.PortWhiteList{
-			Ranges: []config.PortRange{
-				{
-					From: 7001,
-					To:   7900,
-				},
-			},
-		},
-		"tls": config.PortWhiteList{
-			Ports: []int{6000, 6015},
-		},
-	}
-	e := json.NewEncoder(os.Stdout)
-	e.SetIndent("", "  ")
-	e.Encode(map[string]interface{}{
-		"ports_whitelist": m,
-	})
-	t.Error("yay")
 }

--- a/gateway/proxy_muxer_test.go
+++ b/gateway/proxy_muxer_test.go
@@ -145,9 +145,8 @@ func TestCheckPortWhiteList(t *testing.T) {
 		fail     bool
 		wls      map[string]config.PortWhiteList
 	}{
-		{"gw port empty protocol", "", base.ListenPort, false, nil},
-		{"gw port http protocol", "http", base.ListenPort, false, nil},
-		{"gw port https protocol", "https", base.ListenPort, false, nil},
+		{"gw port empty protocol", "", base.ListenPort, true, nil},
+		{"gw port http protocol", "http", base.ListenPort, false, base.PortWhiteList},
 		{"unknown tls", "tls", base.ListenPort, true, nil},
 		{"unknown tcp", "tls", base.ListenPort, true, nil},
 		{"whitelisted tcp", "tcp", base.ListenPort, false, map[string]config.PortWhiteList{
@@ -201,17 +200,16 @@ func TestCheckPortWhiteList(t *testing.T) {
 			},
 		}},
 	}
-	for _, tt := range cases {
+	for i, tt := range cases {
 		t.Run(tt.name, func(ts *testing.T) {
-			base.PortWhiteList = tt.wls
-			err := CheckPortWhiteList(base, tt.port, tt.protocol)
+			err := CheckPortWhiteList(tt.wls, tt.port, tt.protocol)
 			if tt.fail {
 				if err == nil {
 					ts.Error("expected an error got nil")
 				}
 			} else {
 				if err != nil {
-					ts.Errorf("expected an nil got %v", err)
+					ts.Errorf("%d: expected an nil got %v", i, err)
 				}
 			}
 		})

--- a/gateway/proxy_muxer_test.go
+++ b/gateway/proxy_muxer_test.go
@@ -146,7 +146,11 @@ func TestCheckPortWhiteList(t *testing.T) {
 		wls      map[string]config.PortWhiteList
 	}{
 		{"gw port empty protocol", "", base.ListenPort, true, nil},
-		{"gw port http protocol", "http", base.ListenPort, false, base.PortWhiteList},
+		{"gw port http protocol", "http", base.ListenPort, false, map[string]config.PortWhiteList{
+			"http": config.PortWhiteList{
+				Ports: []int{base.ListenPort},
+			},
+		}},
 		{"unknown tls", "tls", base.ListenPort, true, nil},
 		{"unknown tcp", "tls", base.ListenPort, true, nil},
 		{"whitelisted tcp", "tcp", base.ListenPort, false, map[string]config.PortWhiteList{

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -940,27 +940,6 @@ func initialiseSystem(ctx context.Context) error {
 	if config.Global().HttpServerOptions.UseLE_SSL {
 		go StartPeriodicStateBackup(&LE_MANAGER)
 	}
-	// setup listen and control ports as whitelisted
-	globalConf = config.Global()
-	w := globalConf.PortWhiteList
-	if w == nil {
-		w = make(map[string]config.PortWhiteList)
-	}
-	protocol := "http"
-	if globalConf.HttpServerOptions.UseSSL {
-		protocol = "https"
-	}
-	ls := config.PortWhiteList{}
-	if v, ok := w[protocol]; ok {
-		ls = v
-	}
-	ls.Ports = append(ls.Ports, globalConf.ListenPort)
-	if globalConf.ControlAPIPort != 0 {
-		ls.Ports = append(ls.Ports, globalConf.ControlAPIPort)
-	}
-	w[protocol] = ls
-	globalConf.PortWhiteList = w
-	config.SetGlobal(globalConf)
 	return nil
 }
 
@@ -1237,6 +1216,29 @@ func startDRL() {
 }
 
 func startServer() {
+	{
+		// setup listen and control ports as whitelisted
+		globalConf := config.Global()
+		w := globalConf.PortWhiteList
+		if w == nil {
+			w = make(map[string]config.PortWhiteList)
+		}
+		protocol := "http"
+		if globalConf.HttpServerOptions.UseSSL {
+			protocol = "https"
+		}
+		ls := config.PortWhiteList{}
+		if v, ok := w[protocol]; ok {
+			ls = v
+		}
+		ls.Ports = append(ls.Ports, globalConf.ListenPort)
+		if globalConf.ControlAPIPort != 0 {
+			ls.Ports = append(ls.Ports, globalConf.ControlAPIPort)
+		}
+		w[protocol] = ls
+		globalConf.PortWhiteList = w
+		config.SetGlobal(globalConf)
+	}
 	// Ensure that Control listener and default http listener running on first start
 	muxer := &proxyMux{}
 

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -940,7 +940,27 @@ func initialiseSystem(ctx context.Context) error {
 	if config.Global().HttpServerOptions.UseLE_SSL {
 		go StartPeriodicStateBackup(&LE_MANAGER)
 	}
-
+	// setup listen and control ports as whitelisted
+	globalConf = config.Global()
+	w := globalConf.PortWhiteList
+	if w == nil {
+		w = make(map[string]config.PortWhiteList)
+	}
+	protocol := "http"
+	if globalConf.HttpServerOptions.UseSSL {
+		protocol = "https"
+	}
+	ls := config.PortWhiteList{}
+	if v, ok := w[protocol]; ok {
+		ls = v
+	}
+	ls.Ports = append(ls.Ports, globalConf.ListenPort)
+	if globalConf.ControlAPIPort != 0 {
+		ls.Ports = append(ls.Ports, globalConf.ControlAPIPort)
+	}
+	w[protocol] = ls
+	globalConf.PortWhiteList = w
+	config.SetGlobal(globalConf)
 	return nil
 }
 

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -589,6 +589,8 @@ func (s *Test) Start() {
 	globalConf.CoProcessOptions = s.config.CoprocessConfig
 	config.SetGlobal(globalConf)
 
+	setupPortsWhitelist()
+
 	startServer()
 	ctx, cancel := context.WithCancel(context.Background())
 	s.cacnel = cancel
@@ -858,6 +860,7 @@ func (p *httpProxyHandler) handleHTTP(w http.ResponseWriter, req *http.Request) 
 }
 
 func (p *httpProxyHandler) Stop() error {
+	ResetTestConfig()
 	return p.server.Close()
 }
 

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -237,6 +237,28 @@ func controlProxy() *proxy {
 	return mainProxy()
 }
 
+func EnablePort(port int, protocol string) {
+	c := config.Global()
+	if c.PortWhiteList == nil {
+		c.PortWhiteList = map[string]config.PortWhiteList{
+			protocol: config.PortWhiteList{
+				Ports: []int{port},
+			},
+		}
+	} else {
+		m, ok := c.PortWhiteList[protocol]
+		if !ok {
+			m = config.PortWhiteList{
+				Ports: []int{port},
+			}
+		} else {
+			m.Ports = append(m.Ports, port)
+		}
+		c.PortWhiteList[protocol] = m
+	}
+	config.SetGlobal(c)
+}
+
 func getMainRouter(m *proxyMux) *mux.Router {
 	var protocol string
 	if config.Global().HttpServerOptions.UseSSL {


### PR DESCRIPTION
Add support for whitelisting ports

This change introduces `ports_whitelist` configuration option to `tyk.conf`, which
defines which ports should the gateway allow services to be bind to.

example configuration is like this

```json
{
  "ports_whitelist": {
    "http": {
      "ranges": [
        {
          "from": 8000,
          "to": 9000
        }
      ]
    },
    "tcp": {
      "ranges": [
        {
          "from": 7001,
          "to": 7900
        }
      ]
    },
    "tls": {
      "ports": [
        6000,
        6015
      ]
    }
  }
}
```

You define the protocol `http`, `https`, `tcp` or `tls` which maps to an object 
with schema

```json
{
    "type": [
        "object"
    ],
    "additionalProperties": false,
    "properties": {
        "ranges": {
            "type": "array",
            "items": {
                "type": "object",
                "additionalProperties": false,
                "properties": {
                    "from": {
                        "type": "integer"
                    },
                    "to": {
                        "type": "integer"
                    }
                }
            }
        }
    },
    "ports": {
        "type": "array",
        "items": {
            "type": "integer"
        }
    }
}
```


# Defining specific ports

You can  configure a specific port to be available like this.

```json
{
    "ports_whitelist": {
        "http": {
            "ports": [
                8089,
                8090
            ]
        }
    }
}
```

This configuration tells the gateway to allow `http` services only on port `8089`
and `8090`

# Defining port ranges

port ranges is the boundary of allowed ports inclusively. This helps to avoid 
tedious specifying each possible ports.

Example

```json
{
    "ports_whitelist": {
        "http": {
            "ranges": [
                {
                    "from": 8000,
                    "to": 9000
                }
            ]
        }
    }
}
```

This configures the gateway to allow any port withing `8000` `...` `9000`
boundary inclusively meaning `8000` ,`8050`, `9000` will all be allowed.

# Precedence

Ports defined in `ports` property takes precedence over `ranges`. This means if
a port is allowed inside `ports` property no further checks will be done to see if
its within range.

Fixes #2529