### PR TITLE
Log error when control api router is missing

### DIFF
--- a/gateway/server.go
+++ b/gateway/server.go
@@ -388,9 +388,12 @@ func loadAPIEndpoints(muxer *mux.Router) {
 	}
 
 	if muxer == nil {
-		muxer = defaultProxyMux.router(config.Global().ControlAPIPort, "")
+		cp := config.Global().ControlAPIPort
+		muxer = defaultProxyMux.router(cp, "")
 		if muxer == nil {
-			log.Error("Can't find control API router")
+			if cp != 0 {
+				log.Error("Can't find control API router")
+			}
 			return
 		}
 	}


### PR DESCRIPTION
This change refactor logic for missing control router.

When  ControlAPIPort is set(not zero) If we can't find its router while
calling loadAPIEndpoints then it results in an error

Fixes #2534