### PR TITLE
Fix RedisCluster.GetMultiKey

### DIFF
--- a/storage/redis_cluster.go
+++ b/storage/redis_cluster.go
@@ -250,8 +250,12 @@ func (r *RedisCluster) GetMultiKey(keyNames []string) ([]string, error) {
 		log.WithError(err).Debug("Error trying to get value")
 		return nil, ErrKeyNotFound
 	}
-
-	return value, nil
+	for _, v := range value {
+		if v != "" {
+			return value, nil
+		}
+	}
+	return nil, ErrKeyNotFound
 }
 
 func (r *RedisCluster) GetKeyTTL(keyName string) (ttl int64, err error) {

--- a/storage/redis_cluster_test.go
+++ b/storage/redis_cluster_test.go
@@ -1,0 +1,27 @@
+package storage
+
+import "testing"
+
+func TestRedisClusterGetMultiKey(t *testing.T) {
+	keys := []string{"first", "second"}
+	r := RedisCluster{KeyPrefix: "test-cluster"}
+	for _, v := range keys {
+		r.DeleteKey(v)
+	}
+	_, err := r.GetMultiKey(keys)
+	if err != ErrKeyNotFound {
+		t.Errorf("expected %v got %v", ErrKeyNotFound, err)
+	}
+	err = r.SetKey(keys[0], keys[0], 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v, err := r.GetMultiKey(keys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v[0] != keys[0] {
+		t.Errorf("expected %s got %s", keys[0], v[0])
+	}
+}


### PR DESCRIPTION
This method was not returning any error for the case of missing keys.

calling with `[]string{"1", "2"}` keys that dont exists resulted into
`[]string{"", ""} , nil` .

This changes adds additional check to ensure if no value retuned we get
`nil, ErrKeyNotFound`

Fixes #2490