### PR TITLE
Use context.Context to manage uptime tests loops

### DIFF
--- a/gateway/server.go
+++ b/gateway/server.go
@@ -171,7 +171,7 @@ func setupGlobals(ctx context.Context) {
 
 	// Initialise our Host Checker
 	healthCheckStore := storage.RedisCluster{KeyPrefix: "host-checker:"}
-	InitHostCheckManager(&healthCheckStore)
+	InitHostCheckManager(ctx, &healthCheckStore)
 
 	redisStore := storage.RedisCluster{KeyPrefix: "apikey-", HashKeys: config.Global().HashKeys}
 	FallbackKeySesionManager.Init(&redisStore)


### PR DESCRIPTION
Since we use context.Context already, this change refactors all
long running loops in uptime test feature accept
context.Context and stop when the context is cancelled
