### PR TITLE
Fix API definition upgrade from 2.7 to 2.9

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -226,7 +226,7 @@ type ExtendedPathsSet struct {
 	TrackEndpoints          []TrackEndpointMeta   `bson:"track_endpoints" json:"track_endpoints,omitempty"`
 	DoNotTrackEndpoints     []TrackEndpointMeta   `bson:"do_not_track_endpoints" json:"do_not_track_endpoints,omitempty"`
 	ValidateJSON            []ValidatePathMeta    `bson:"validate_json" json:"validate_json,omitempty"`
-	Internal                []InternalMeta        `bson:"internal" json:"internal"`
+	Internal                []InternalMeta        `bson:"internal" json:"internal,omitempty"`
 }
 
 type VersionInfo struct {


### PR DESCRIPTION
It should not add "intenal" record to JSON payload if its empty

Fix https://github.com/TykTechnologies/tyk-analytics/issues/1463