### PR TITLE
Use context.Context to manage purging loops

### DIFF
--- a/gateway/redis_analytics_purger.go
+++ b/gateway/redis_analytics_purger.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"context"
 	"time"
 
 	"github.com/TykTechnologies/tyk/config"
@@ -18,10 +19,16 @@ type RedisPurger struct {
 	Store storage.Handler
 }
 
-func (r RedisPurger) PurgeLoop(ticker <-chan time.Time) {
+func (r RedisPurger) PurgeLoop(ctx context.Context) {
+	tick := time.NewTicker(time.Second)
+	defer tick.Stop()
 	for {
-		<-ticker
-		r.PurgeCache()
+		select {
+		case <-ctx.Done():
+			return
+		case <-tick.C:
+			r.PurgeCache()
+		}
 	}
 }
 

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -149,8 +149,6 @@ func apisByIDLen() int {
 
 var redisPurgeOnce sync.Once
 var rpcPurgeOnce sync.Once
-var purgeTicker = time.Tick(time.Second)
-var rpcPurgeTicker = time.Tick(10 * time.Second)
 
 // Create all globals and init connection handlers
 func setupGlobals(ctx context.Context) {
@@ -193,7 +191,7 @@ func setupGlobals(ctx context.Context) {
 		redisPurgeOnce.Do(func() {
 			store := storage.RedisCluster{KeyPrefix: "analytics-"}
 			redisPurger := RedisPurger{Store: &store}
-			go redisPurger.PurgeLoop(purgeTicker)
+			go redisPurger.PurgeLoop(ctx)
 		})
 
 		if config.Global().AnalyticsConfig.Type == "rpc" {
@@ -205,7 +203,7 @@ func setupGlobals(ctx context.Context) {
 					Store: &store,
 				}
 				purger.Connect()
-				go purger.PurgeLoop(rpcPurgeTicker)
+				go purger.PurgeLoop(ctx)
 			})
 		}
 		go flushNetworkAnalytics(ctx)

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -96,8 +96,6 @@ func InitTestMain(ctx context.Context, m *testing.M, genConf ...func(globalConf 
 	globalConf.EnableBundleDownloader = true
 	globalConf.BundleBaseURL = testHttpBundles
 	globalConf.MiddlewarePath = testMiddlewarePath
-	purgeTicker = make(chan time.Time)
-	rpcPurgeTicker = make(chan time.Time)
 	// force ipv4 for now, to work around the docker bug affecting
 	// Go 1.8 and ealier
 	globalConf.ListenAddress = "127.0.0.1"

--- a/rpc/rpc_analytics_purger.go
+++ b/rpc/rpc_analytics_purger.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"context"
 	"encoding/json"
 	"time"
 
@@ -87,10 +88,15 @@ func (r *Purger) Connect() {
 
 // PurgeLoop starts the loop that will pull data out of the in-memory
 // store and into RPC.
-func (r Purger) PurgeLoop(ticker <-chan time.Time) {
+func (r Purger) PurgeLoop(ctx context.Context) {
+	tick := time.NewTicker(10 * time.Second)
 	for {
-		<-ticker
-		r.PurgeCache()
+		select {
+		case <-ctx.Done():
+			return
+		case <-tick.C:
+			r.PurgeCache()
+		}
 	}
 }
 


### PR DESCRIPTION
This  makes redis analytics purger and rpc analytics purger cancellable
