### PR TITLE
When CGO is disabled only build an API compat stub, enables arm64 builds

### DIFF
--- a/bin/dist_build.sh
+++ b/bin/dist_build.sh
@@ -58,7 +58,9 @@ do
 done
 
 echo "Building Tyk binaries"
-gox -osarch="linux/amd64 linux/386" -tags 'coprocess' -cgo
+gox -osarch="linux/amd64 linux/386" -cgo
+# Build arm64 without CGO (no Python plugins), an improved cross-compilation toolkit is needed for that
+gox -osarch="linux/arm64"
 
 TEMPLATEDIR=${ARCHTGZDIRS[i386]}
 echo "Prepping TGZ Dirs"

--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -1,7 +1,6 @@
 package gateway
 
 import (
-	"C"
 	"bytes"
 	"encoding/json"
 	"net/url"

--- a/gateway/coprocess_python.go
+++ b/gateway/coprocess_python.go
@@ -1,3 +1,5 @@
+// +build cgo
+
 package gateway
 
 import (

--- a/gateway/coprocess_python_stub.go
+++ b/gateway/coprocess_python_stub.go
@@ -1,0 +1,15 @@
+// +build !cgo
+
+// This only builds when CGO isn't enabled so that we don't attempt to do it on unsuiable environments,
+// since CGO is required for Python plugins. Yet, we have to maintain symbol compatibility for the main package.
+package gateway
+
+import (
+	"errors"
+
+	"github.com/TykTechnologies/tyk/coprocess"
+)
+
+func NewPythonDispatcher() (dispatcher coprocess.Dispatcher, err error) {
+	return nil, errors.New("python support not compiled")
+}


### PR DESCRIPTION
Cross-compiling CGO requires a complete GCC tool chain along with libc. This is a bit more difficult with arm/aarch64 when the build host is x86. We don't currently set up such an environment.

This PR makes sure we can still cross-compile aarch64 (arm64) with CGO disabled. In order to make this work the Python coprocess dispatcher is stubbed to maintain API compatibility.