### PR TITLE
Fix oauth client update failure

### DIFF
--- a/gateway/api.go
+++ b/gateway/api.go
@@ -1562,9 +1562,6 @@ func updateOauthClient(keyName, apiID string, r *http.Request) (interface{}, int
 			return apiError("Policy access rights doesn't contain API this OAuth client belongs to"),
 				http.StatusBadRequest
 		}
-		if len(policy.AccessRights) != 1 {
-			return apiError("Policy access rights should contain only one API"), http.StatusBadRequest
-		}
 	}
 
 	// get existing version of oauth-client


### PR DESCRIPTION
Fixes #2594 

Allow oauth client policy to contain more than one API