### PR TITLE
Fix go vet warning

### DIFF
--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -814,7 +814,6 @@ func BuildAndLoadAPI(apiGens ...func(spec *APISpec)) (specs []*APISpec) {
 
 func CloneAPI(a *APISpec) *APISpec {
 	new := &APISpec{}
-	*new = *a
 	new.APIDefinition = &apidef.APIDefinition{}
 	*new.APIDefinition = *a.APIDefinition
 


### PR DESCRIPTION
Avoid copying internal structures except apidef 