### PR TITLE
fix failing assert in test

### DIFF
--- a/gateway/mw_jwt_test.go
+++ b/gateway/mw_jwt_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"sort"
 	"testing"
 	"time"
 
@@ -1056,9 +1057,10 @@ func TestJWTScopeToPolicyMapping(t *testing.T) {
 				BodyMatchFunc: func(data []byte) bool {
 					sessionData := user.SessionState{}
 					json.Unmarshal(data, &sessionData)
-
-					assert.Equal(t, sessionData.ApplyPolicies, []string{p1ID, p2ID})
-
+					expect := []string{p1ID, p2ID}
+					sort.Strings(sessionData.ApplyPolicies)
+					sort.Strings(expect)
+					assert.Equal(t, sessionData.ApplyPolicies, expect)
 					return true
 				},
 			},


### PR DESCRIPTION
This sorts string slice before assert. The test was randomly failing,
with correct values but just in a different order.

This ensures the slices are in the same order before doing assertion
