### PR TITLE
Decouple API spec loading from implementation

### DIFF
--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -238,7 +238,7 @@ func (s *APISpec) validateHTTP() error {
 	return nil
 }
 
-// APIDefinitionLoader implements SpecLoader that can load specs from diffrent
+// APIDefinitionLoader implements SpecLoader that can load specs from different
 // sources.
 type APIDefinitionLoader struct{}
 

--- a/gateway/rpc_backup_handlers.go
+++ b/gateway/rpc_backup_handlers.go
@@ -50,8 +50,7 @@ func LoadDefinitionsFromRPCBackup() ([]*APISpec, error) {
 		return nil, errors.New("[RPC] --> Failed to get node backup (" + checkKey + "): " + err.Error())
 	}
 
-	a := APIDefinitionLoader{}
-	return a.processRPCDefinitions(apiListAsString)
+	return defaultAPISpecLoader.processRPCDefinitions(apiListAsString)
 }
 
 func saveRPCDefinitionsBackup(list string) error {

--- a/gateway/rpc_test.go
+++ b/gateway/rpc_test.go
@@ -194,7 +194,7 @@ func TestSyncAPISpecsRPCFailure(t *testing.T) {
 	rpc := startRPCMock(dispatcher)
 	defer stopRPCMock(rpc)
 
-	count, _ := syncAPISpecs()
+	count, _ := syncAPISpecs(defaultAPISpecLoader)
 	if count != 0 {
 		t.Error("Should return empty value for malformed rpc response", apiSpecs)
 	}
@@ -239,7 +239,7 @@ func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 			{Path: "/sample", Headers: authHeaders, Code: 200},
 		}...)
 
-		count, _ := syncAPISpecs()
+		count, _ := syncAPISpecs(defaultAPISpecLoader)
 		if count != 1 {
 			t.Error("Should return array with one spec", apiSpecs)
 		}
@@ -312,7 +312,7 @@ func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 			{Path: "/sample", Headers: notCachedAuth, Code: 200},
 		}...)
 
-		if count, _ := syncAPISpecs(); count != 2 {
+		if count, _ := syncAPISpecs(defaultAPISpecLoader); count != 2 {
 			t.Error("Should fetch latest specs", count)
 		}
 


### PR DESCRIPTION
This commit introduces SpecLoader interface. Which is used to load api
specs used by the gateway.

This also updates APIDefinitionLoader to implement SpecLoader interface.
By moving implementation details outside syncAPISpecs it is possible
to load api spec from any source without affecting the gateway syncing
logic.

Some use case for this change,

- Cleaner tests, we can now rigorously test APIDefinitionLoader implementation
without relying on loading the whole gateway. There are lots of flaky tests
at the moment(tests that sometimes pass/ sometime fails).

- Good for the future of service mesh. It ill be possible now to have distributed/ replicated
api spec store for HA deployments

It was also a lesson for me to know more about the gateway. I will be documenting the implementation
in future Pull Requests.