### PR TITLE
Decouple policy loading from implementation

### DIFF
--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -40,8 +40,11 @@ func TestLoadPoliciesFromDashboardReLogin(t *testing.T) {
 
 	allowExplicitPolicyID := config.Global().Policies.AllowExplicitPolicyID
 
-	policyMap := LoadPoliciesFromDashboard(ts.URL, "", allowExplicitPolicyID)
+	policyMap, err := LoadPoliciesFromDashboard(ts.URL, "", allowExplicitPolicyID)
 
+	if err == nil {
+		t.Error("Should be nil because got back 403 from Dashboard")
+	}
 	if policyMap != nil {
 		t.Error("Should be nil because got back 403 from Dashboard")
 	}

--- a/gateway/rpc_test.go
+++ b/gateway/rpc_test.go
@@ -316,7 +316,7 @@ func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 			t.Error("Should fetch latest specs", count)
 		}
 
-		if count, _ := syncPolicies(); count != 2 {
+		if count, _ := syncPolicies(defaultPolicyLoader); count != 2 {
 			t.Error("Should fetch latest policies", count)
 		}
 	})


### PR DESCRIPTION
This defines PolicyLoader interface which is used to load policies into
the gateway

Default implementation is provided by BasePolicyLoader.

Tests for BasePolicyLoader will be provided in a separate PR.

Related https://github.com/TykTechnologies/tyk/pull/2604
