### PR TITLE
release API spec resources when reload APIs

### DIFF
--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -692,6 +692,12 @@ func loadApps(specs []*APISpec) {
 
 	// Swap in the new register
 	apisMu.Lock()
+
+	// release current specs resources before overwriting map
+	for _, curSpec := range apisByID {
+		curSpec.Release()
+	}
+
 	apisByID = tmpSpecRegister
 	apisMu.Unlock()
 

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -828,7 +828,6 @@ func TestReloadGoroutineLeakWithAsyncWrites(t *testing.T) {
 }
 
 func TestReloadGoroutineLeakWithCircuitBreaker(t *testing.T) {
-	t.Skip("gernest: proxying has changed need to rethink about how to test this")
 	ts := StartTest()
 	defer ts.Close()
 


### PR DESCRIPTION
this PR just brings back this change: https://github.com/TykTechnologies/tyk/pull/2256/files#diff-ad28d87199f22b3b034c7fc355476a6dR672

also, we need re-enable this test if we want to make sure no leaks happening (connected with CB logic): https://github.com/TykTechnologies/tyk/blob/master/gateway/gateway_test.go#L831