### PR TITLE
ctx: inject API definition when using Go plugins

### DIFF
--- a/ctx/ctx.go
+++ b/ctx/ctx.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/TykTechnologies/tyk/apidef"
+
 	"github.com/TykTechnologies/tyk/storage"
 	"github.com/TykTechnologies/tyk/user"
 )
@@ -29,6 +31,7 @@ const (
 	ThrottleLevelLimit
 	Trace
 	CheckLoopLimits
+	Definition
 )
 
 func setContext(r *http.Request, ctx context.Context) {
@@ -76,4 +79,17 @@ func GetSession(r *http.Request) *user.SessionState {
 
 func SetSession(r *http.Request, s *user.SessionState, token string, scheduleUpdate bool) {
 	ctxSetSession(r, s, token, scheduleUpdate)
+}
+
+func SetDefinition(r *http.Request, s *apidef.APIDefinition) {
+	ctx := r.Context()
+	ctx = context.WithValue(ctx, Definition, s)
+	setContext(r, ctx)
+}
+
+func GetDefinition(r *http.Request) *apidef.APIDefinition {
+	if v := r.Context().Value(Definition); v != nil {
+		return v.(*apidef.APIDefinition)
+	}
+	return nil
 }

--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/TykTechnologies/tyk/ctx"
 	"github.com/TykTechnologies/tyk/goplugin"
 )
 
@@ -134,6 +135,10 @@ func (m *GoPluginMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reque
 
 	// call Go-plugin function
 	t1 := time.Now()
+
+	// Inject definition into request context:
+	ctx.SetDefinition(r, m.Spec.APIDefinition)
+
 	m.handler(rw, r)
 
 	// calculate latency


### PR DESCRIPTION
This is a potential solution for allowing API definition access from Go plugins:
```go
package main

import (
	"fmt"
	"net/http"

	"github.com/TykTechnologies/tyk/ctx"
)

func main() {}

func MyCustomPlugin(w http.ResponseWriter, r *http.Request) {
	fmt.Println("MyCustomPlugin is called")
	apidef := ctx.GetDefinition(r)
	fmt.Println("apidef=", apidef)
}

```