### PR TITLE
gateway: allow proxy on internal APIs (#2619)

### DIFF
--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -532,9 +532,25 @@ func (d *DummyProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		ctxIncLoopLevel(r, loopLevelLimit)
 		handler.ServeHTTP(w, r)
-	} else {
-		d.SH.ServeHTTP(w, r)
+		return
 	}
+
+	if d.SH.Spec.target.Scheme == "tyk" {
+		if targetAPI := fuzzyFindAPI(d.SH.Spec.target.Host); targetAPI != nil {
+			if targetAPI.middlewareChain != nil {
+				if d.SH.Spec.Proxy.StripListenPath {
+					r.URL.Path = d.SH.Spec.StripListenPath(r, r.URL.Path)
+					r.URL.RawPath = d.SH.Spec.StripListenPath(r, r.URL.RawPath)
+				}
+				targetAPI.middlewareChain.ThisHandler.ServeHTTP(w, r)
+				return
+			}
+		}
+		handler := ErrorHandler{*d.SH.Base()}
+		handler.HandleError(w, r, "Couldn't detect target", http.StatusInternalServerError, true)
+		return
+	}
+	d.SH.ServeHTTP(w, r)
 }
 
 func loadGlobalApps() {


### PR DESCRIPTION
After inspecting different versions I didn't really find this functionality, seems the code from #1859 didn't include this. I've reused some of its logic in order to achieve what's expected in #2619.
Suggestions are welcome.