### PR TITLE
Don't skip the irrelevant middlewares with key when ignore plugin is …

### DIFF
--- a/ctx/ctx.go
+++ b/ctx/ctx.go
@@ -32,6 +32,7 @@ const (
 	Trace
 	CheckLoopLimits
 	Definition
+	RequestStatus
 )
 
 func setContext(r *http.Request, ctx context.Context) {

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -2194,3 +2194,14 @@ func ctxTraceEnabled(r *http.Request) bool {
 func ctxSetTrace(r *http.Request) {
 	setCtxValue(r, ctx.Trace, true)
 }
+
+func ctxSetRequestStatus(r *http.Request, stat RequestStatus) {
+	setCtxValue(r, ctx.RequestStatus, stat)
+}
+
+func ctxGetRequestStatus(r *http.Request) (stat RequestStatus) {
+	if v := r.Context().Value(ctx.RequestStatus); v != nil {
+		stat = v.(RequestStatus)
+	}
+	return
+}

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -303,12 +303,12 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 		}
 	}
 
+	mwAppendEnabled(&chainArray, &VersionCheck{BaseMiddleware: baseMid})
 	mwAppendEnabled(&chainArray, &RateCheckMW{BaseMiddleware: baseMid})
 	mwAppendEnabled(&chainArray, &IPWhiteListMiddleware{BaseMiddleware: baseMid})
 	mwAppendEnabled(&chainArray, &IPBlackListMiddleware{BaseMiddleware: baseMid})
 	mwAppendEnabled(&chainArray, &CertificateCheckMW{BaseMiddleware: baseMid})
 	mwAppendEnabled(&chainArray, &OrganizationMonitor{BaseMiddleware: baseMid})
-	mwAppendEnabled(&chainArray, &VersionCheck{BaseMiddleware: baseMid})
 	mwAppendEnabled(&chainArray, &RequestSizeLimitMiddleware{baseMid})
 	mwAppendEnabled(&chainArray, &MiddlewareContextVars{BaseMiddleware: baseMid})
 	mwAppendEnabled(&chainArray, &TrackEndpointMiddleware{baseMid})

--- a/gateway/mw_access_rights.go
+++ b/gateway/mw_access_rights.go
@@ -18,6 +18,10 @@ func (a *AccessRightsCheck) Name() string {
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (a *AccessRightsCheck) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
+	if ctxGetRequestStatus(r) == StatusOkAndIgnore {
+		return nil, http.StatusOK
+	}
+
 	accessingVersion := a.Spec.getVersionFromRequest(r)
 	if accessingVersion == "" {
 		if a.Spec.VersionData.DefaultVersion != "" {

--- a/gateway/mw_auth_key.go
+++ b/gateway/mw_auth_key.go
@@ -39,6 +39,10 @@ func (k *AuthKey) setContextVars(r *http.Request, token string) {
 }
 
 func (k *AuthKey) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
+	if ctxGetRequestStatus(r) == StatusOkAndIgnore {
+		return nil, http.StatusOK
+	}
+
 	config := k.Spec.Auth
 
 	key := r.Header.Get(config.AuthHeaderName)

--- a/gateway/mw_basic_auth.go
+++ b/gateway/mw_basic_auth.go
@@ -153,6 +153,10 @@ func (k *BasicAuthKeyIsValid) basicAuthBodyCredentials(w http.ResponseWriter, r 
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (k *BasicAuthKeyIsValid) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
+	if ctxGetRequestStatus(r) == StatusOkAndIgnore {
+		return nil, http.StatusOK
+	}
+
 	username, password, err, code := k.basicAuthHeaderCredentials(w, r)
 	token := r.Header.Get(headers.Authorization)
 	if err != nil {

--- a/gateway/mw_certificate_check.go
+++ b/gateway/mw_certificate_check.go
@@ -18,6 +18,10 @@ func (m *CertificateCheckMW) EnabledForSpec() bool {
 }
 
 func (m *CertificateCheckMW) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
+	if ctxGetRequestStatus(r) == StatusOkAndIgnore {
+		return nil, http.StatusOK
+	}
+
 	if m.Spec.UseMutualTLSAuth {
 		certIDs := append(m.Spec.ClientCertificates, m.Spec.GlobalConfig.Security.Certificates.API...)
 

--- a/gateway/mw_granular_access.go
+++ b/gateway/mw_granular_access.go
@@ -18,6 +18,10 @@ func (m *GranularAccessMiddleware) Name() string {
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (m *GranularAccessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
+	if ctxGetRequestStatus(r) == StatusOkAndIgnore {
+		return nil, http.StatusOK
+	}
+
 	logger := m.Logger()
 	session := ctxGetSession(r)
 

--- a/gateway/mw_hmac.go
+++ b/gateway/mw_hmac.go
@@ -46,6 +46,10 @@ func (hm *HMACMiddleware) Init() {
 }
 
 func (hm *HMACMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
+	if ctxGetRequestStatus(r) == StatusOkAndIgnore {
+		return nil, http.StatusOK
+	}
+
 	token := r.Header.Get("Authorization")
 	if token == "" {
 		return hm.authorizationError(r)

--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -515,6 +515,10 @@ func (k *JWTMiddleware) processOneToOneTokenMap(r *http.Request, token *jwt.Toke
 }
 
 func (k *JWTMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
+	if ctxGetRequestStatus(r) == StatusOkAndIgnore {
+		return nil, http.StatusOK
+	}
+
 	logger := k.Logger()
 	config := k.Spec.Auth
 	var tykId string

--- a/gateway/mw_key_expired_check.go
+++ b/gateway/mw_key_expired_check.go
@@ -18,6 +18,10 @@ func (k *KeyExpired) Name() string {
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (k *KeyExpired) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
+	if ctxGetRequestStatus(r) == StatusOkAndIgnore {
+		return nil, http.StatusOK
+	}
+
 	logger := k.Logger()
 	session := ctxGetSession(r)
 	if session == nil {

--- a/gateway/mw_oauth2_key_exists.go
+++ b/gateway/mw_oauth2_key_exists.go
@@ -30,6 +30,10 @@ func (k *Oauth2KeyExists) EnabledForSpec() bool {
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
+	if ctxGetRequestStatus(r) == StatusOkAndIgnore {
+		return nil, http.StatusOK
+	}
+
 	logger := k.Logger()
 	// We're using OAuth, start checking for access keys
 	token := r.Header.Get(headers.Authorization)

--- a/gateway/mw_openid.go
+++ b/gateway/mw_openid.go
@@ -92,6 +92,10 @@ func (k *OpenIDMW) dummyErrorHandler(e error, w http.ResponseWriter, r *http.Req
 }
 
 func (k *OpenIDMW) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
+	if ctxGetRequestStatus(r) == StatusOkAndIgnore {
+		return nil, http.StatusOK
+	}
+
 	logger := k.Logger()
 	// 1. Validate the JWT
 	ouser, token, halt := openid.AuthenticateOIDWithUser(k.providerConfiguration, w, r)

--- a/gateway/mw_rate_limiting.go
+++ b/gateway/mw_rate_limiting.go
@@ -61,6 +61,10 @@ func (k *RateLimitAndQuotaCheck) handleQuotaFailure(r *http.Request, token strin
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (k *RateLimitAndQuotaCheck) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
+	if ctxGetRequestStatus(r) == StatusOkAndIgnore {
+		return nil, http.StatusOK
+	}
+
 	// Skip rate limiting and quotas for looping
 	if !ctxCheckLimits(r) {
 		return nil, http.StatusOK

--- a/gateway/mw_version_check.go
+++ b/gateway/mw_version_check.go
@@ -64,8 +64,7 @@ func (v *VersionCheck) ProcessRequest(w http.ResponseWriter, r *http.Request, _ 
 	}
 
 	if stat == StatusOkAndIgnore {
-		v.sh.ServeHTTP(w, r)
-		return nil, mwStatusRespond
+		ctxSetRequestStatus(r, stat)
 	}
 
 	return nil, http.StatusOK


### PR DESCRIPTION
Save `RequestStatus` to context and add check for `Ignore` to skip in middlewares requiring auth header.

Fixes #2579 