### PR TITLE
Remove dead code from storage

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -37,10 +37,7 @@ type Handler interface {
 	DeleteAllKeys() bool
 	DeleteRawKey(string) bool
 	Connect() bool
-	GetKeysAndValues() map[string]string
 	GetKeysAndValuesWithFilter(string) map[string]string
-	DeleteKeys([]string) bool
-	Decrement(string)
 	IncrememntWithExpire(string, int64) int64
 	SetRollingWindow(key string, per int64, val string, pipeline bool) (int, []interface{})
 	GetRollingWindow(key string, per int64, pipeline bool) (int, []interface{})


### PR DESCRIPTION
This removes unused code in RedisCluster struct
Also removes methods from storage.Handler interface that are not used

Methods removed from storage,Handler are

-  GetKeysAndValues
- DeleteKeys
- Decrement

Their respective implementation in RedisCluster were removed as well

I came across this while investigating alterative implementation for
storage.Handler to allow replacing redis with an in im memory cache
