### PR TITLE
Fix python dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,7 @@ env:
 addons:
   apt:
     packages:
-    - python3.5
     - python3-pip
-    - python3.5-dev
     - libluajit-5.1-dev
 
 matrix:
@@ -42,9 +40,7 @@ script:
   - curl -sL https://deb.nodesource.com/setup_11.x | sudo -E bash -
   - sudo -E apt-get -yq --no-install-suggests --no-install-recommends $(travis_apt_get_options) install nodejs
   - sudo npm install -g api-spec-converter --unsafe-perm=true --allow-root
-  - go build -tags 'coprocess python'
   - go build -tags 'coprocess lua'
-  - go build -tags 'coprocess grpc'
   - ./bin/ci-test.sh
   - if [[ $LATEST_GO ]]; then goveralls -coverprofile=<(gocovmerge *.cov); fi
   - ./bin/ci-benchmark.sh

--- a/dlpython/main.go
+++ b/dlpython/main.go
@@ -52,6 +52,9 @@ func FindPythonConfig(customVersion string) (selectedVersion string, err error) 
 	pythonConfigBinaries := map[float64]string{}
 
 	for _, p := range strings.Split(paths, ":") {
+		if !strings.HasSuffix(p, "/bin") {
+			continue
+		}
 		files, err := ioutil.ReadDir(p)
 		if err != nil {
 			continue
@@ -128,6 +131,7 @@ func FindPythonConfig(customVersion string) (selectedVersion string, err error) 
 func getLibraryPathFromCfg() error {
 	out, err := exec.Command(pythonConfigPath, "--ldflags").Output()
 	if err != nil {
+		logger.Errorf("Error while executing command for python config path: %s", pythonConfigPath)
 		return err
 	}
 	outString := string(out)

--- a/gateway/coprocess_python.go
+++ b/gateway/coprocess_python.go
@@ -152,7 +152,8 @@ func (d *PythonDispatcher) HandleMiddlewareCache(b *apidef.BundleManifest, baseP
 func PythonInit() error {
 	ver, err := python.FindPythonConfig(config.Global().CoProcessOptions.PythonVersion)
 	if err != nil {
-		return fmt.Errorf("Python version '%s' doesn't exist", ver)
+		log.WithError(err).Errorf("Python version '%s' doesn't exist", ver)
+		return fmt.Errorf("python version '%s' doesn't exist", ver)
 	}
 	err = python.Init()
 	if err != nil {


### PR DESCRIPTION
`FindPythonConfig` file may have been finding a non-binary python config. And, it was failing on execution. This PR filters the paths with `/bin` folder.

Now, in the CI, it will find `/usr/bin/python3.5-config` and execute it.

Fixes #2634