### PR TITLE
SSL Force Common Name Check

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -430,10 +430,11 @@ type APIDefinition struct {
 		CheckHostAgainstUptimeTests bool                          `bson:"check_host_against_uptime_tests" json:"check_host_against_uptime_tests"`
 		ServiceDiscovery            ServiceDiscoveryConfiguration `bson:"service_discovery" json:"service_discovery"`
 		Transport                   struct {
-			SSLInsecureSkipVerify bool     `bson:"ssl_insecure_skip_verify" json:"ssl_insecure_skip_verify"`
-			SSLCipherSuites       []string `bson:"ssl_ciphers" json:"ssl_ciphers"`
-			SSLMinVersion         uint16   `bson:"ssl_min_version" json:"ssl_min_version"`
-			ProxyURL              string   `bson:"proxy_url" json:"proxy_url"`
+			SSLInsecureSkipVerify   bool     `bson:"ssl_insecure_skip_verify" json:"ssl_insecure_skip_verify"`
+			SSLCipherSuites         []string `bson:"ssl_ciphers" json:"ssl_ciphers"`
+			SSLMinVersion           uint16   `bson:"ssl_min_version" json:"ssl_min_version"`
+			SSLForceCommonNameCheck bool     `json:"ssl_force_common_name_check"`
+			ProxyURL                string   `bson:"proxy_url" json:"proxy_url"`
 		} `bson:"transport" json:"transport"`
 	} `bson:"proxy" json:"proxy"`
 	DisableRateLimit          bool                   `bson:"disable_rate_limit" json:"disable_rate_limit"`

--- a/apidef/schema.go
+++ b/apidef/schema.go
@@ -51,9 +51,9 @@ const Schema = `{
         "use_standard_auth": {
             "type": "boolean"
         },
-		"use_go_plugin_auth": {
-			"type": "boolean"
-		},
+        "use_go_plugin_auth": {
+            "type": "boolean"
+        },
         "enable_coprocess_auth": {
             "type": "boolean"
         },
@@ -75,7 +75,7 @@ const Schema = `{
         "jwt_policy_field_name": {
             "type": "string"
         },
-		"jwt_default_policies": {
+        "jwt_default_policies": {
             "type": ["array", "null"]
         },
         "jwt_signing_method": {
@@ -319,6 +319,9 @@ const Schema = `{
                         },
                         "proxy_url": {
                             "type": "string"
+                        },
+                        "ssl_force_common_name_check": {
+                            "type": "boolean"
                         }
                     }
                 }
@@ -404,7 +407,7 @@ const Schema = `{
                 }
             }
         },
-	"request_signing": {
+    "request_signing": {
           "type": ["object", "null"],
            "properties": {
                 "is_enabled": {
@@ -413,16 +416,16 @@ const Schema = `{
                 "secret": {
                     "type": "string"
                 },
-		"key_id": {
+        "key_id": {
                     "type": "string"
                 },
-		"algorithm": {
+        "algorithm": {
                     "type": "string"
                 }
             },
-	    "required": [
-	    	"is_enabled"
-	    ]
+        "required": [
+            "is_enabled"
+        ]
         }
     },
     "required": [

--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -1017,6 +1017,9 @@
     },
     "enable_http_profiler": {
       "type": "boolean"
+    },
+    "ssl_force_common_name_check":{
+	    "type":"boolean"
     }
   }
 }

--- a/config/config.go
+++ b/config/config.go
@@ -386,6 +386,7 @@ type Config struct {
 	OauthTokenExpiredRetainPeriod int32                `json:"oauth_token_expired_retain_period"`
 	OauthRedirectUriSeparator     string               `json:"oauth_redirect_uri_separator"`
 	EnableKeyLogging              bool                 `json:"enable_key_logging"`
+	SSLForceCommonNameCheck       bool                 `json:"ssl_force_common_name_check"`
 
 	// Proxy analytics configuration
 	EnableAnalytics bool                  `json:"enable_analytics"`

--- a/gateway/batch_requests.go
+++ b/gateway/batch_requests.go
@@ -49,7 +49,7 @@ func (b *BatchRequestHandler) doRequest(req *http.Request, relURL string) BatchR
 
 	tr.TLSClientConfig.InsecureSkipVerify = config.Global().ProxySSLInsecureSkipVerify
 
-	tr.DialTLS = dialTLSPinnedCheck(b.API, tr.TLSClientConfig)
+	tr.DialTLS = customDialTLSCheck(b.API, tr.TLSClientConfig)
 
 	tr.Proxy = proxyFromAPI(b.API)
 

--- a/gateway/cert.go
+++ b/gateway/cert.go
@@ -132,8 +132,58 @@ func verifyPeerCertificatePinnedCheck(spec *APISpec, tlsConfig *tls.Config) func
 	}
 }
 
-func dialTLSPinnedCheck(spec *APISpec, tc *tls.Config) func(network, addr string) (net.Conn, error) {
-	if (spec == nil || len(spec.PinnedPublicKeys) == 0) && len(config.Global().Security.PinnedPublicKeys) == 0 {
+func validatePublicKeys(host string, conn *tls.Conn, spec *APISpec) bool {
+	certLog.Debug("Checking certificate public key for host:", host)
+
+	whitelist := getPinnedPublicKeys(host, spec)
+	if len(whitelist) == 0 {
+		return true
+	}
+
+	isValid := false
+
+	state := conn.ConnectionState()
+	for _, peercert := range state.PeerCertificates {
+		der, err := x509.MarshalPKIXPublicKey(peercert.PublicKey)
+		if err != nil {
+			continue
+		}
+		fingerprint := certs.HexSHA256(der)
+
+		for _, w := range whitelist {
+			if w == fingerprint {
+				isValid = true
+				break
+			}
+		}
+	}
+
+	return isValid
+}
+
+func validateCommonName(host string, conn *tls.Conn) error {
+	certLog.Debug("Checking certificate CommonName for host :", host)
+
+	state := conn.ConnectionState()
+	if state.PeerCertificates[0].Subject.CommonName != host {
+		return errors.New("certificate had CN " + state.PeerCertificates[0].Subject.CommonName + "expected " + host)
+	}
+
+	return nil
+}
+
+func customDialTLSCheck(spec *APISpec, tc *tls.Config) func(network, addr string) (net.Conn, error) {
+	var checkPinnedKeys, checkCommonName bool
+
+	if (spec != nil && len(spec.PinnedPublicKeys) != 0) || len(config.Global().Security.PinnedPublicKeys) != 0 {
+		checkPinnedKeys = true
+	}
+
+	if (spec != nil && spec.Proxy.Transport.SSLForceCommonNameCheck) || config.Global().SSLForceCommonNameCheck {
+		checkCommonName = true
+	}
+
+	if !checkCommonName && !checkPinnedKeys {
 		return nil
 	}
 
@@ -147,29 +197,22 @@ func dialTLSPinnedCheck(spec *APISpec, tc *tls.Config) func(network, addr string
 		}
 
 		host, _, _ := net.SplitHostPort(addr)
-		whitelist := getPinnedPublicKeys(host, spec)
-		if len(whitelist) == 0 {
-			return c, nil
+
+		if checkPinnedKeys {
+			isValid := validatePublicKeys(host, c, spec)
+			if !isValid {
+				return nil, errors.New("https://" + host + " certificate public key pinning error. Public keys do not match.")
+			}
 		}
 
-		certLog.Debug("Checking certificate public key for host:", host)
-
-		state := c.ConnectionState()
-		for _, peercert := range state.PeerCertificates {
-			der, err := x509.MarshalPKIXPublicKey(peercert.PublicKey)
+		if checkCommonName {
+			err := validateCommonName(host, c)
 			if err != nil {
-				continue
-			}
-			fingerprint := certs.HexSHA256(der)
-
-			for _, w := range whitelist {
-				if w == fingerprint {
-					return c, nil
-				}
+				return nil, err
 			}
 		}
 
-		return nil, errors.New("https://" + host + " certificate public key pinning error. Public keys do not match.")
+		return c, nil
 	}
 }
 

--- a/gateway/cert_go1.10_test.go
+++ b/gateway/cert_go1.10_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+
 	//	"net"
 	"net/http"
 	"net/http/httptest"
@@ -151,7 +152,7 @@ func TestPublicKeyPinning(t *testing.T) {
 
 		// start proxy
 		_, _, _, proxyCert := genCertificate(&x509.Certificate{
-			Subject: pkix.Name{CommonName: "localhost"},
+			Subject: pkix.Name{CommonName: "local1.host"},
 		})
 		proxyPubID, err := uploadCertPublicKey(proxyCert)
 		if err != nil {
@@ -159,7 +160,7 @@ func TestPublicKeyPinning(t *testing.T) {
 		}
 		defer CertificateManager.Delete(proxyPubID)
 
-		proxy := initProxy("https", &tls.Config{
+		proxy := initProxy("http", &tls.Config{
 			Certificates: []tls.Certificate{proxyCert},
 		})
 		defer proxy.Stop()
@@ -175,7 +176,7 @@ func TestPublicKeyPinning(t *testing.T) {
 
 		pubKeys := fmt.Sprintf("%s,%s", serverPubID, proxyPubID)
 		upstream.URL = strings.Replace(upstream.URL, "127.0.0.1", "localhost", 1)
-		proxy.URL = strings.Replace(proxy.URL, "127.0.0.1", "localhost", 1)
+		proxy.URL = strings.Replace(proxy.URL, "127.0.0.1", "local1.host", 1)
 
 		BuildAndLoadAPI([]func(spec *APISpec){func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/valid"

--- a/gateway/cert_go1.10_test.go
+++ b/gateway/cert_go1.10_test.go
@@ -5,9 +5,14 @@ package gateway
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
+	"fmt"
+	//	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/TykTechnologies/tyk/certs"
@@ -15,17 +20,27 @@ import (
 	"github.com/TykTechnologies/tyk/test"
 )
 
-func TestPublicKeyPinning(t *testing.T) {
-	_, _, _, serverCert := genServerCertificate()
+func uploadCertPublicKey(serverCert tls.Certificate) (string, error) {
 	x509Cert, _ := x509.ParseCertificate(serverCert.Certificate[0])
 	pubDer, _ := x509.MarshalPKIXPublicKey(x509Cert.PublicKey)
 	pubPem := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDer})
 	pubID, _ := CertificateManager.Add(pubPem, "")
-	defer CertificateManager.Delete(pubID)
 
 	if pubID != certs.HexSHA256(pubDer) {
-		t.Error("Certmanager returned wrong pub key fingerprint:", certs.HexSHA256(pubDer), pubID)
+		errStr := fmt.Sprintf("certmanager returned wrong pub key fingerprint: %s %s", certs.HexSHA256(pubDer), pubID)
+		return "", errors.New(errStr)
 	}
+
+	return pubID, nil
+}
+
+func TestPublicKeyPinning(t *testing.T) {
+	_, _, _, serverCert := genServerCertificate()
+	pubID, err := uploadCertPublicKey(serverCert)
+	if err != nil {
+		t.Error(err)
+	}
+	defer CertificateManager.Delete(pubID)
 
 	upstream := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 	}))
@@ -110,6 +125,75 @@ func TestPublicKeyPinning(t *testing.T) {
 		})
 
 		ts.Run(t, test.TestCase{Code: 500})
+	})
+
+	t.Run("Enable Common Name check", func(t *testing.T) {
+		// start upstream server
+		_, _, _, serverCert := genCertificate(&x509.Certificate{
+			EmailAddresses: []string{"test@test.com"},
+			Subject:        pkix.Name{CommonName: "localhost"},
+		})
+		serverPubID, err := uploadCertPublicKey(serverCert)
+		if err != nil {
+			t.Error(err)
+		}
+		defer CertificateManager.Delete(serverPubID)
+
+		upstream := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		}))
+		upstream.TLS = &tls.Config{
+			InsecureSkipVerify: true,
+			Certificates:       []tls.Certificate{serverCert},
+		}
+
+		upstream.StartTLS()
+		defer upstream.Close()
+
+		// start proxy
+		_, _, _, proxyCert := genCertificate(&x509.Certificate{
+			Subject: pkix.Name{CommonName: "localhost"},
+		})
+		proxyPubID, err := uploadCertPublicKey(proxyCert)
+		if err != nil {
+			t.Error(err)
+		}
+		defer CertificateManager.Delete(proxyPubID)
+
+		proxy := initProxy("https", &tls.Config{
+			Certificates: []tls.Certificate{proxyCert},
+		})
+		defer proxy.Stop()
+
+		globalConf := config.Global()
+		globalConf.SSLForceCommonNameCheck = true
+		globalConf.ProxySSLInsecureSkipVerify = true
+		config.SetGlobal(globalConf)
+		defer ResetTestConfig()
+
+		ts := StartTest()
+		defer ts.Close()
+
+		pubKeys := fmt.Sprintf("%s,%s", serverPubID, proxyPubID)
+		upstream.URL = strings.Replace(upstream.URL, "127.0.0.1", "localhost", 1)
+		proxy.URL = strings.Replace(proxy.URL, "127.0.0.1", "localhost", 1)
+
+		BuildAndLoadAPI([]func(spec *APISpec){func(spec *APISpec) {
+			spec.Proxy.ListenPath = "/valid"
+			spec.Proxy.TargetURL = upstream.URL
+			spec.Proxy.Transport.ProxyURL = proxy.URL
+			spec.PinnedPublicKeys = map[string]string{"*": pubKeys}
+		},
+			func(spec *APISpec) {
+				spec.Proxy.ListenPath = "/invalid"
+				spec.Proxy.TargetURL = upstream.URL
+				spec.Proxy.Transport.ProxyURL = proxy.URL
+				spec.PinnedPublicKeys = map[string]string{"*": "wrong"}
+			}}...)
+
+		ts.Run(t, []test.TestCase{
+			{Code: 200, Path: "/valid"},
+			{Code: 500, Path: "/invalid"},
+		}...)
 	})
 }
 

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
 	"io/ioutil"
@@ -15,6 +16,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -445,6 +447,56 @@ func TestUpstreamMutualTLS(t *testing.T) {
 		})
 
 		// Should pass with valid upstream certificate
+		ts.Run(t, test.TestCase{Code: 200})
+	})
+
+}
+
+func TestSSLForceCommonName(t *testing.T) {
+	upstream := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	}))
+
+	// generate certificate Common Name as valid hostname and SAN as non-empty value
+	_, _, _, cert := genCertificate(&x509.Certificate{
+		EmailAddresses: []string{"test@test.com"},
+		Subject:        pkix.Name{CommonName: "host1.local"},
+	})
+
+	upstream.TLS = &tls.Config{
+		Certificates: []tls.Certificate{cert},
+	}
+
+	upstream.StartTLS()
+	defer upstream.Close()
+
+	// test case to ensure that Golang doesn't check against CommonName if SAN is non empty
+	t.Run("Force Common Name Check is Disabled", func(t *testing.T) {
+		ts := StartTest()
+		defer ts.Close()
+
+		targetURL := strings.Replace(upstream.URL, "127.0.0.1", "localhost", 1)
+		BuildAndLoadAPI(func(spec *APISpec) {
+			spec.Proxy.ListenPath = "/"
+			spec.Proxy.TargetURL = targetURL
+		})
+		ts.Run(t, test.TestCase{Code: 500, BodyMatch: "There was a problem proxying the request"})
+	})
+
+	t.Run("Force Common Name Check is Enabled", func(t *testing.T) {
+		globalConf := config.Global()
+		globalConf.SSLForceCommonNameCheck = true
+		config.SetGlobal(globalConf)
+		defer ResetTestConfig()
+
+		ts := StartTest()
+		defer ts.Close()
+
+		targetURL := strings.Replace(upstream.URL, "127.0.0.1", "host1.local", 1)
+		BuildAndLoadAPI(func(spec *APISpec) {
+			spec.Proxy.ListenPath = "/"
+			spec.Proxy.TargetURL = targetURL
+		})
+
 		ts.Run(t, test.TestCase{Code: 200})
 	})
 }

--- a/gateway/mw_js_plugin.go
+++ b/gateway/mw_js_plugin.go
@@ -504,7 +504,7 @@ func (j *JSVM) LoadTykJSApi() {
 			tr.TLSClientConfig.InsecureSkipVerify = true
 		}
 
-		tr.DialTLS = dialTLSPinnedCheck(j.Spec, tr.TLSClientConfig)
+		tr.DialTLS = customDialTLSCheck(j.Spec, tr.TLSClientConfig)
 
 		tr.Proxy = proxyFromAPI(j.Spec)
 

--- a/gateway/proxy_muxer.go
+++ b/gateway/proxy_muxer.go
@@ -166,7 +166,7 @@ func (m *proxyMux) addTCPService(spec *APISpec, modifier *tcp.Modifier) {
 			protocol:         spec.Protocol,
 			useProxyProtocol: spec.EnableProxyProtocol,
 			tcpProxy: &tcp.Proxy{
-				DialTLS:         dialWithServiceDiscovery(spec, dialTLSPinnedCheck(spec, tlsConfig)),
+				DialTLS:         dialWithServiceDiscovery(spec, customDialTLSCheck(spec, tlsConfig)),
 				Dial:            dialWithServiceDiscovery(spec, net.Dial),
 				TLSConfigTarget: tlsConfig,
 				SyncStats:       recordTCPHit(spec.APIID, spec.DoNotTrack),

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -526,7 +526,7 @@ func httpTransport(timeOut float64, rw http.ResponseWriter, req *http.Request, p
 	if proxyURL, _ := transport.Proxy(req); proxyURL != nil {
 		transport.TLSClientConfig.VerifyPeerCertificate = verifyPeerCertificatePinnedCheck(p.TykAPISpec, transport.TLSClientConfig)
 	} else {
-		transport.DialTLS = dialTLSPinnedCheck(p.TykAPISpec, transport.TLSClientConfig)
+		transport.DialTLS = customDialTLSCheck(p.TykAPISpec, transport.TLSClientConfig)
 	}
 
 	if p.TykAPISpec.GlobalConfig.ProxySSLMinVersion > 0 {

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -773,17 +773,9 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 		}
 
 		if proxyURL, _ := httpTransport.Proxy(req); proxyURL != nil {
-			var tlsConfig *tls.Config
-
-			tlsConfig = httpTransport.TLSClientConfig
+			tlsConfig := httpTransport.TLSClientConfig
 			host, _, _ := net.SplitHostPort(outreq.Host)
 			setCommonNameVerifyPeerCertificate(p.TykAPISpec, tlsConfig, host)
-
-			if outReqIsWebsocket {
-				roundTripper.(*WSDialer).Transport = httpTransport
-			} else {
-				roundTripper = httpTransport
-			}
 		}
 
 	}


### PR DESCRIPTION
Added new option in gateway configuration `ssl_force_common_name_check`.

If an SSL certificate has non-empty SAN, it is used for validating hostname, ignoring Common Name field of Certificate.(This is recommended, as most client have dropped support of CN)

But if a user has legacy certificate and wants to enforce check against Common Name, he can enable `ssl_force_common_name_check`
