### PR TITLE
use context to manage rate limit notification loop

### DIFF
--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -587,9 +587,9 @@ func (s *Test) Start() {
 
 	setupPortsWhitelist()
 
-	startServer()
 	ctx, cancel := context.WithCancel(context.Background())
 	s.cacnel = cancel
+	startServer(ctx)
 	setupGlobals(ctx)
 	// Set up a default org manager so we can traverse non-live paths
 	if !config.Global().SupressDefaultOrgStore {


### PR DESCRIPTION
The goroutine was running forever with no way of terminating.

This change uses context.Context to ensure that the goroutine is
cancellable
