### PR TITLE
Make oauth error status code configurable

### DIFF
--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -668,6 +668,9 @@
     "oauth_token_expired_retain_period": {
       "type": "integer"
     },
+    "oauth_error_status_code": {
+      "type": "integer"
+    },
     "optimisations_use_async_session_write": {
       "type": "boolean"
     },

--- a/config/config.go
+++ b/config/config.go
@@ -385,6 +385,7 @@ type Config struct {
 	OauthTokenExpire              int32                `json:"oauth_token_expire"`
 	OauthTokenExpiredRetainPeriod int32                `json:"oauth_token_expired_retain_period"`
 	OauthRedirectUriSeparator     string               `json:"oauth_redirect_uri_separator"`
+	OauthErrorStatusCode          int                  `json:"oauth_error_status_code"`
 	EnableKeyLogging              bool                 `json:"enable_key_logging"`
 
 	// Proxy analytics configuration

--- a/gateway/oauth_manager_test.go
+++ b/gateway/oauth_manager_test.go
@@ -323,7 +323,7 @@ func TestAuthCodeRedirectInvalidMultipleURL(t *testing.T) {
 			Data:    param.Encode(),
 			Headers: headers,
 			Method:  http.MethodPost,
-			Code:    http.StatusBadRequest,
+			Code:    http.StatusForbidden,
 		})
 	})
 }
@@ -955,7 +955,7 @@ func TestOAuthAPIRefreshInvalidate(t *testing.T) {
 			Data:    param.Encode(),
 			Headers: headers,
 			Method:  http.MethodPost,
-			Code:    http.StatusBadRequest,
+			Code:    http.StatusForbidden,
 		})
 	})
 }
@@ -1092,7 +1092,7 @@ func TestTokenEndpointHeaders(t *testing.T) {
 			Path:         "/APIID/oauth/token/",
 			Data:         param.Encode(),
 			Method:       http.MethodPost,
-			Code:         http.StatusBadRequest,
+			Code:         http.StatusForbidden,
 			HeadersMatch: securityAndCacheHeaders,
 		}}...)
 }

--- a/gateway/oauth_manager_test.go
+++ b/gateway/oauth_manager_test.go
@@ -323,7 +323,7 @@ func TestAuthCodeRedirectInvalidMultipleURL(t *testing.T) {
 			Data:    param.Encode(),
 			Headers: headers,
 			Method:  http.MethodPost,
-			Code:    http.StatusForbidden,
+			Code:    http.StatusBadRequest,
 		})
 	})
 }
@@ -955,7 +955,7 @@ func TestOAuthAPIRefreshInvalidate(t *testing.T) {
 			Data:    param.Encode(),
 			Headers: headers,
 			Method:  http.MethodPost,
-			Code:    http.StatusForbidden,
+			Code:    http.StatusBadRequest,
 		})
 	})
 }
@@ -1092,7 +1092,7 @@ func TestTokenEndpointHeaders(t *testing.T) {
 			Path:         "/APIID/oauth/token/",
 			Data:         param.Encode(),
 			Method:       http.MethodPost,
-			Code:         http.StatusForbidden,
+			Code:         http.StatusBadRequest,
 			HeadersMatch: securityAndCacheHeaders,
 		}}...)
 }

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -485,7 +485,13 @@ func addOAuthHandlers(spec *APISpec, muxer *mux.Router) *OAuthManager {
 	clientAccessPath := spec.Proxy.ListenPath + "oauth/token{_:/?}"
 
 	serverConfig := osin.NewServerConfig()
-	serverConfig.ErrorStatusCode = http.StatusForbidden
+
+	if config.Global().OauthErrorStatusCode != 0 {
+		serverConfig.ErrorStatusCode = config.Global().OauthErrorStatusCode
+	} else {
+		serverConfig.ErrorStatusCode = http.StatusBadRequest
+	}
+
 	serverConfig.AllowedAccessTypes = spec.Oauth2Meta.AllowedAccessTypes
 	serverConfig.AllowedAuthorizeTypes = spec.Oauth2Meta.AllowedAuthorizeTypes
 	serverConfig.RedirectUriSeparator = config.Global().OauthRedirectUriSeparator

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -489,7 +489,7 @@ func addOAuthHandlers(spec *APISpec, muxer *mux.Router) *OAuthManager {
 	if config.Global().OauthErrorStatusCode != 0 {
 		serverConfig.ErrorStatusCode = config.Global().OauthErrorStatusCode
 	} else {
-		serverConfig.ErrorStatusCode = http.StatusBadRequest
+		serverConfig.ErrorStatusCode = http.StatusForbidden
 	}
 
 	serverConfig.AllowedAccessTypes = spec.Oauth2Meta.AllowedAccessTypes


### PR DESCRIPTION
This PR 
- makes oauth error status code configurable by adding a new config variable `oauth_error_status_code`
- changes default value from `403` to `400` as mentioned in the issue.

Fixes https://github.com/TykTechnologies/tyk/issues/2381