### PR TITLE
Add AuthConfigs field to APISpec

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -366,8 +366,9 @@ type APIDefinition struct {
 		AllowedAuthorizeTypes  []osin.AuthorizeRequestType `bson:"allowed_authorize_types" json:"allowed_authorize_types"`
 		AuthorizeLoginRedirect string                      `bson:"auth_login_redirect" json:"auth_login_redirect"`
 	} `bson:"oauth_meta" json:"oauth_meta"`
-	Auth         Auth `bson:"auth" json:"auth"`
-	UseBasicAuth bool `bson:"use_basic_auth" json:"use_basic_auth"`
+	Auth         AuthConfig            `bson:"auth" json:"auth"` // Deprecated: Use AuthConfigs instead.
+	AuthConfigs  map[string]AuthConfig `bson:"auth_configs" json:"auth_configs"`
+	UseBasicAuth bool                  `bson:"use_basic_auth" json:"use_basic_auth"`
 	BasicAuth    struct {
 		DisableCaching     bool   `bson:"disable_caching" json:"disable_caching"`
 		CacheTTL           int    `bson:"cache_ttl" json:"cache_ttl"`
@@ -478,7 +479,7 @@ type APIDefinition struct {
 	StripAuthData     bool                   `bson:"strip_auth_data" json:"strip_auth_data"`
 }
 
-type Auth struct {
+type AuthConfig struct {
 	UseParam          bool            `mapstructure:"use_param" bson:"use_param" json:"use_param"`
 	ParamName         string          `mapstructure:"param_name" bson:"param_name" json:"param_name"`
 	UseCookie         bool            `mapstructure:"use_cookie" bson:"use_cookie" json:"use_cookie"`

--- a/apidef/schema.go
+++ b/apidef/schema.go
@@ -245,6 +245,9 @@ const Schema = `{
                 "auth_header_name"
             ]
         },
+		"auth_configs":{
+			"type": ["object", "null"]
+		},
         "definition": {
             "type": ["object", "null"],
             "id": "http://jsonschema.net/definition",

--- a/coprocess/grpc/coprocess_grpc_test.go
+++ b/coprocess/grpc/coprocess_grpc_test.go
@@ -124,7 +124,7 @@ func loadTestGRPCAPIs() {
 	gateway.BuildAndLoadAPI(func(spec *gateway.APISpec) {
 		spec.APIID = "1"
 		spec.OrgID = gateway.MockOrgID
-		spec.Auth = apidef.Auth{
+		spec.Auth = apidef.AuthConfig{
 			AuthHeaderName: "authorization",
 		}
 		spec.UseKeylessAccess = false
@@ -151,7 +151,7 @@ func loadTestGRPCAPIs() {
 	}, func(spec *gateway.APISpec) {
 		spec.APIID = "2"
 		spec.OrgID = gateway.MockOrgID
-		spec.Auth = apidef.Auth{
+		spec.Auth = apidef.AuthConfig{
 			AuthHeaderName: "authorization",
 		}
 		spec.UseKeylessAccess = true
@@ -178,7 +178,7 @@ func loadTestGRPCAPIs() {
 	}, func(spec *gateway.APISpec) {
 		spec.APIID = "3"
 		spec.OrgID = "default"
-		spec.Auth = apidef.Auth{
+		spec.Auth = apidef.AuthConfig{
 			AuthHeaderName: "authorization",
 		}
 		spec.UseKeylessAccess = false
@@ -206,7 +206,7 @@ func loadTestGRPCAPIs() {
 		func(spec *gateway.APISpec) {
 			spec.APIID = "4"
 			spec.OrgID = "default"
-			spec.Auth = apidef.Auth{
+			spec.Auth = apidef.AuthConfig{
 				AuthHeaderName: "authorization",
 			}
 			spec.UseKeylessAccess = false

--- a/gateway/analytics.go
+++ b/gateway/analytics.go
@@ -8,8 +8,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/oschwald/maxminddb-golang"
-	"gopkg.in/vmihailenco/msgpack.v2"
+	maxminddb "github.com/oschwald/maxminddb-golang"
+	msgpack "gopkg.in/vmihailenco/msgpack.v2"
 
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/regexp"

--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -373,7 +373,7 @@ func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 	if m.Spec.EnableCoProcessAuth && m.HookType == coprocess.HookType_CustomKeyCheck {
 		// The CP middleware didn't setup a session:
 		if returnObject.Session == nil || token == "" {
-			authHeaderValue := r.Header.Get(m.Spec.Auth.AuthHeaderName)
+			authHeaderValue,_ := getAuthToken(m, r)
 			AuthFailed(m, r, authHeaderValue)
 			return errors.New("Key not authorised"), 403
 		}

--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -373,7 +373,7 @@ func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 	if m.Spec.EnableCoProcessAuth && m.HookType == coprocess.HookType_CustomKeyCheck {
 		// The CP middleware didn't setup a session:
 		if returnObject.Session == nil || token == "" {
-			authHeaderValue,_ := getAuthToken(m, r)
+			authHeaderValue, _ := m.getAuthToken(m.getAuthType(), r)
 			AuthFailed(m, r, authHeaderValue)
 			return errors.New("Key not authorised"), 403
 		}
@@ -411,6 +411,11 @@ func (h *CustomMiddlewareResponseHook) Init(mwDef interface{}, spec *APISpec) er
 		MiddlewareDriver: spec.CustomMiddleware.Driver,
 	}
 	return nil
+}
+
+// getAuthType overrides BaseMiddleware.getAuthType.
+func (m *CoProcessMiddleware) getAuthType() string {
+	return "coprocess"
 }
 
 func (h *CustomMiddlewareResponseHook) Name() string {

--- a/gateway/middleware_test.go
+++ b/gateway/middleware_test.go
@@ -1,11 +1,15 @@
 package gateway
 
 import (
+	"net/http"
 	"testing"
+
+	"github.com/TykTechnologies/tyk/apidef"
+	cache "github.com/pmylund/go-cache"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/user"
-	cache "github.com/pmylund/go-cache"
 )
 
 type mockStore struct {
@@ -43,4 +47,54 @@ func TestBaseMiddleware_OrgSessionExpiry(t *testing.T) {
 	if got != sess.DataExpires {
 		t.Errorf("expected %d got %d", sess.DataExpires, got)
 	}
+}
+
+func TestBaseMiddleware_getAuthType(t *testing.T) {
+	spec := &APISpec{APIDefinition: &apidef.APIDefinition{}}
+	spec.AuthConfigs = map[string]apidef.AuthConfig{
+		"authToken": {AuthHeaderName: "h1"},
+		"basic":     {AuthHeaderName: "h2"},
+		"coprocess": {AuthHeaderName: "h3"},
+		"hmac":      {AuthHeaderName: "h4"},
+		"jwt":       {AuthHeaderName: "h5"},
+		"oauth":     {AuthHeaderName: "h6"},
+	}
+
+	baseMid := BaseMiddleware{Spec: spec}
+
+	r, _ := http.NewRequest(http.MethodGet, "", nil)
+	r.Header.Set("h1", "t1")
+	r.Header.Set("h2", "t2")
+	r.Header.Set("h3", "t3")
+	r.Header.Set("h4", "t4")
+	r.Header.Set("h5", "t5")
+	r.Header.Set("h6", "t6")
+
+	authKey := &AuthKey{BaseMiddleware: baseMid}
+	basic := &BasicAuthKeyIsValid{BaseMiddleware: baseMid}
+	coprocess := &CoProcessMiddleware{BaseMiddleware: baseMid}
+	hmac := &HTTPSignatureValidationMiddleware{BaseMiddleware: baseMid}
+	jwt := &JWTMiddleware{BaseMiddleware: baseMid}
+	oauth := &Oauth2KeyExists{BaseMiddleware: baseMid}
+
+	// test getAuthType
+	assert.Equal(t, "authToken", authKey.getAuthType())
+	assert.Equal(t, "basic", basic.getAuthType())
+	assert.Equal(t, "coprocess", coprocess.getAuthType())
+	assert.Equal(t, "hmac", hmac.getAuthType())
+	assert.Equal(t, "jwt", jwt.getAuthType())
+	assert.Equal(t, "oauth", oauth.getAuthType())
+
+	// test getAuthToken
+	getToken := func(authType string, getAuthToken func(authType string, r *http.Request) (string, apidef.AuthConfig)) string {
+		token, _ := getAuthToken(authType, r)
+		return token
+	}
+
+	assert.Equal(t, "t1", getToken(authKey.getAuthType(), authKey.getAuthToken))
+	assert.Equal(t, "t2", getToken(basic.getAuthType(), basic.getAuthToken))
+	assert.Equal(t, "t3", getToken(coprocess.getAuthType(), coprocess.getAuthToken))
+	assert.Equal(t, "t4", getToken(hmac.getAuthType(), hmac.getAuthToken))
+	assert.Equal(t, "t5", getToken(jwt.getAuthType(), jwt.getAuthToken))
+	assert.Equal(t, "t6", getToken(oauth.getAuthType(), oauth.getAuthToken))
 }

--- a/gateway/multiauth_test.go
+++ b/gateway/multiauth_test.go
@@ -23,8 +23,8 @@ const multiAuthDev = `{
 	"use_standard_auth": true,
 	"base_identity_provided_by": "auth_token",
 	"auth_configs": {
-		"BasicAuthKeyIsValid": {"auth_header_name": "Authorization"},
-		"AuthKey": {"auth_header_name": "x-standard-auth"}
+		"basic": {"auth_header_name": "Authorization"},
+		"authToken": {"auth_header_name": "x-standard-auth"}
 	},
 	"version_data": {
 		"not_versioned": true,

--- a/gateway/multiauth_test.go
+++ b/gateway/multiauth_test.go
@@ -22,7 +22,10 @@ const multiAuthDev = `{
 	"use_basic_auth": true,
 	"use_standard_auth": true,
 	"base_identity_provided_by": "auth_token",
-	"auth": {"auth_header_name": "x-standard-auth"},
+	"auth_configs": {
+		"BasicAuthKeyIsValid": {"auth_header_name": "Authorization"},
+		"AuthKey": {"auth_header_name": "x-standard-auth"}
+	},
 	"version_data": {
 		"not_versioned": true,
 		"versions": {

--- a/gateway/mw_auth_key.go
+++ b/gateway/mw_auth_key.go
@@ -45,12 +45,18 @@ func (k *AuthKey) ProcessRequest(w http.ResponseWriter, r *http.Request, _ inter
 
 	config := k.Spec.Auth
 
-	key := r.Header.Get(config.AuthHeaderName)
+	authHeaderName := config.AuthHeaderName
+	key := r.Header.Get(authHeaderName)
+	customHeaderValue := getAuthHeaderValue(k, r)
+	if key == "" && customHeaderValue != "" {
+		key = customHeaderValue
+		authHeaderName = getAuthHeaderName(k)
+	}
 
 	paramName := config.ParamName
 	if config.UseParam || paramName != "" {
 		if paramName == "" {
-			paramName = config.AuthHeaderName
+			paramName = authHeaderName
 		}
 
 		paramValue := r.URL.Query().Get(paramName)
@@ -64,7 +70,7 @@ func (k *AuthKey) ProcessRequest(w http.ResponseWriter, r *http.Request, _ inter
 	cookieName := config.CookieName
 	if config.UseCookie || cookieName != "" {
 		if cookieName == "" {
-			cookieName = config.AuthHeaderName
+			cookieName = authHeaderName
 		}
 
 		authCookie, err := r.Cookie(cookieName)

--- a/gateway/mw_basic_auth.go
+++ b/gateway/mw_basic_auth.go
@@ -79,8 +79,13 @@ func (k *BasicAuthKeyIsValid) requestForBasicAuth(w http.ResponseWriter, msg str
 	return errors.New(msg), http.StatusUnauthorized
 }
 
+// getAuthType overrides BaseMiddleware.getAuthType.
+func (k *BasicAuthKeyIsValid) getAuthType() string {
+	return "basic"
+}
+
 func (k *BasicAuthKeyIsValid) basicAuthHeaderCredentials(w http.ResponseWriter, r *http.Request) (username, password string, err error, code int) {
-	token, _ := getAuthToken(k, r)
+	token, _ := k.getAuthToken(k.getAuthType(), r)
 	logger := k.Logger().WithField("key", obfuscateKey(token))
 	if token == "" {
 		// No header value, fail

--- a/gateway/mw_basic_auth.go
+++ b/gateway/mw_basic_auth.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	cache "github.com/pmylund/go-cache"
+	"github.com/pmylund/go-cache"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/sync/singleflight"
@@ -80,7 +80,7 @@ func (k *BasicAuthKeyIsValid) requestForBasicAuth(w http.ResponseWriter, msg str
 }
 
 func (k *BasicAuthKeyIsValid) basicAuthHeaderCredentials(w http.ResponseWriter, r *http.Request) (username, password string, err error, code int) {
-	token := r.Header.Get(headers.Authorization)
+	token := getAuthHeaderValue(k, r)
 	logger := k.Logger().WithField("key", obfuscateKey(token))
 	if token == "" {
 		// No header value, fail

--- a/gateway/mw_basic_auth.go
+++ b/gateway/mw_basic_auth.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pmylund/go-cache"
+	cache "github.com/pmylund/go-cache"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/sync/singleflight"
@@ -80,7 +80,7 @@ func (k *BasicAuthKeyIsValid) requestForBasicAuth(w http.ResponseWriter, msg str
 }
 
 func (k *BasicAuthKeyIsValid) basicAuthHeaderCredentials(w http.ResponseWriter, r *http.Request) (username, password string, err error, code int) {
-	token := getAuthHeaderValue(k, r)
+	token, _ := getAuthToken(k, r)
 	logger := k.Logger().WithField("key", obfuscateKey(token))
 	if token == "" {
 		// No header value, fail

--- a/gateway/mw_http_signature_validation.go
+++ b/gateway/mw_http_signature_validation.go
@@ -21,7 +21,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/TykTechnologies/tyk/apidef"
-	"github.com/TykTechnologies/tyk/headers"
 	"github.com/TykTechnologies/tyk/regexp"
 	"github.com/TykTechnologies/tyk/user"
 )
@@ -52,7 +51,7 @@ func (hm *HTTPSignatureValidationMiddleware) ProcessRequest(w http.ResponseWrite
 		return nil, http.StatusOK
 	}
 
-	token := r.Header.Get("Authorization")
+	token := getAuthHeaderValue(hm, r)
 	if token == "" {
 		return hm.authorizationError(r)
 	}
@@ -234,7 +233,7 @@ func (hm *HTTPSignatureValidationMiddleware) setContextVars(r *http.Request, tok
 func (hm *HTTPSignatureValidationMiddleware) authorizationError(r *http.Request) (error, int) {
 	hm.Logger().Info("Authorization field missing or malformed")
 
-	AuthFailed(hm, r, r.Header.Get(headers.Authorization))
+	AuthFailed(hm, r, getAuthHeaderValue(hm, r))
 
 	return errors.New("Authorization field missing, malformed or invalid"), http.StatusBadRequest
 }
@@ -314,7 +313,7 @@ func getDateHeader(r *http.Request) (string, string) {
 	auxHeaderVal := r.Header.Get(altHeaderSpec)
 	// Prefer aux if present
 	if auxHeaderVal != "" {
-		token := r.Header.Get(headers.Authorization)
+		token := getAuthHeaderValue(&HMACMiddleware{}, r)
 		log.WithFields(logrus.Fields{
 			"prefix":      "hmac",
 			"auth_header": token,

--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -6,12 +6,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/TykTechnologies/tyk/headers"
 	"net/http"
 	"strings"
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
-	cache "github.com/pmylund/go-cache"
+	"github.com/dgrijalva/jwt-go"
+	"github.com/pmylund/go-cache"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/user"
@@ -514,6 +515,36 @@ func (k *JWTMiddleware) processOneToOneTokenMap(r *http.Request, token *jwt.Toke
 	return nil, http.StatusOK
 }
 
+func getAuthHeaderName(middleware interface{}) (authHeaderName string) {
+	switch middleware.(type) {
+	case *JWTMiddleware:
+		authHeaderName = headers.AuthJWT
+	case *AuthKey:
+		authHeaderName = headers.AuthKey
+	case *HMACMiddleware:
+		authHeaderName = headers.AuthHMAC
+	case *Oauth2KeyExists:
+		authHeaderName = headers.AuthOAuth2
+	case *BasicAuthKeyIsValid:
+		authHeaderName = headers.AuthBasic
+	default:
+		authHeaderName = headers.AuthDefault
+	}
+
+	return
+}
+
+func getAuthHeaderValue(middleware interface{}, r *http.Request) (headerValue string) {
+	customHeaderName := getAuthHeaderName(middleware)
+
+	if headerValue = r.Header.Get(customHeaderName); headerValue != "" {
+		return
+	}
+
+	headerValue = r.Header.Get(headers.AuthDefault)
+	return
+}
+
 func (k *JWTMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	if ctxGetRequestStatus(r) == StatusOkAndIgnore {
 		return nil, http.StatusOK
@@ -523,15 +554,21 @@ func (k *JWTMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _
 	config := k.Spec.Auth
 	var tykId string
 
-	// Get the token
-	rawJWT := r.Header.Get(config.AuthHeaderName)
+	authHeaderName := config.AuthHeaderName
+	rawJWT := r.Header.Get(authHeaderName)
+	customHeaderValue := getAuthHeaderValue(k, r)
+	if rawJWT == "" && customHeaderValue != "" {
+		rawJWT = customHeaderValue
+		authHeaderName = getAuthHeaderName(k)
+	}
+
 	if config.UseParam {
 		// Set hte header name
-		rawJWT = r.URL.Query().Get(config.AuthHeaderName)
+		rawJWT = r.URL.Query().Get(authHeaderName)
 	}
 
 	if config.UseCookie {
-		authCookie, err := r.Cookie(config.AuthHeaderName)
+		authCookie, err := r.Cookie(authHeaderName)
 		if err != nil {
 			rawJWT = ""
 		} else {
@@ -543,7 +580,7 @@ func (k *JWTMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _
 		// No header value, fail
 		logger.Info("Attempted access with malformed header, no JWT auth header found.")
 
-		log.Debug("Looked in: ", config.AuthHeaderName)
+		log.Debug("Looked in: ", authHeaderName)
 		log.Debug("Raw data was: ", rawJWT)
 		log.Debug("Headers are: ", r.Header)
 

--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
-	"github.com/pmylund/go-cache"
+	jwt "github.com/dgrijalva/jwt-go"
+	cache "github.com/pmylund/go-cache"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/user"
@@ -514,6 +514,11 @@ func (k *JWTMiddleware) processOneToOneTokenMap(r *http.Request, token *jwt.Toke
 	return nil, http.StatusOK
 }
 
+// getAuthType overrides BaseMiddleware.getAuthType.
+func (k *JWTMiddleware) getAuthType() string {
+	return "jwt"
+}
+
 func (k *JWTMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	if ctxGetRequestStatus(r) == StatusOkAndIgnore {
 		return nil, http.StatusOK
@@ -522,7 +527,7 @@ func (k *JWTMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _
 	logger := k.Logger()
 	var tykId string
 
-	rawJWT, config := getAuthToken(k, r)
+	rawJWT, config := k.getAuthToken(k.getAuthType(), r)
 
 	if rawJWT == "" {
 		// No header value, fail

--- a/gateway/mw_oauth2_key_exists.go
+++ b/gateway/mw_oauth2_key_exists.go
@@ -27,6 +27,11 @@ func (k *Oauth2KeyExists) EnabledForSpec() bool {
 	return k.Spec.UseOauth2
 }
 
+// getAuthType overrides BaseMiddleware.getAuthType.
+func (k *Oauth2KeyExists) getAuthType() string {
+	return "oauth"
+}
+
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	if ctxGetRequestStatus(r) == StatusOkAndIgnore {
@@ -35,7 +40,7 @@ func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request,
 
 	logger := k.Logger()
 	// We're using OAuth, start checking for access keys
-	token, _ := getAuthToken(k, r)
+	token, _ := k.getAuthToken(k.getAuthType(), r)
 	parts := strings.Split(token, " ")
 
 	if len(parts) < 2 {

--- a/gateway/mw_oauth2_key_exists.go
+++ b/gateway/mw_oauth2_key_exists.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/TykTechnologies/tyk/apidef"
-	"github.com/TykTechnologies/tyk/headers"
 )
 
 const (
@@ -36,7 +35,7 @@ func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request,
 
 	logger := k.Logger()
 	// We're using OAuth, start checking for access keys
-	token := r.Header.Get(headers.Authorization)
+	token := getAuthHeaderValue(k, r)
 	parts := strings.Split(token, " ")
 
 	if len(parts) < 2 {

--- a/gateway/mw_oauth2_key_exists.go
+++ b/gateway/mw_oauth2_key_exists.go
@@ -35,7 +35,7 @@ func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request,
 
 	logger := k.Logger()
 	// We're using OAuth, start checking for access keys
-	token := getAuthHeaderValue(k, r)
+	token, _ := getAuthToken(k, r)
 	parts := strings.Split(token, " ")
 
 	if len(parts) < 2 {

--- a/gateway/mw_request_signing.go
+++ b/gateway/mw_request_signing.go
@@ -101,7 +101,7 @@ func (s *RequestSigning) ProcessRequest(w http.ResponseWriter, r *http.Request, 
 	}
 
 	headers := generateHeaderList(r, s.Spec.RequestSigning.HeaderList)
-	signatureString, err := generateHMACSignatureStringFromRequest(s, r, headers)
+	signatureString, err := generateHMACSignatureStringFromRequest(r, headers)
 	if err != nil {
 		log.Error(err)
 		return err, http.StatusInternalServerError

--- a/gateway/mw_request_signing.go
+++ b/gateway/mw_request_signing.go
@@ -101,8 +101,7 @@ func (s *RequestSigning) ProcessRequest(w http.ResponseWriter, r *http.Request, 
 	}
 
 	headers := generateHeaderList(r, s.Spec.RequestSigning.HeaderList)
-
-	signatureString, err := generateSignatureStringFromRequest(r, headers)
+	signatureString, err := generateHMACSignatureStringFromRequest(s, r, headers)
 	if err != nil {
 		log.Error(err)
 		return err, http.StatusInternalServerError

--- a/gateway/mw_strip_auth_test.go
+++ b/gateway/mw_strip_auth_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 type TestAuth struct {
-	apidef.Auth
+	apidef.AuthConfig
 	HeaderKey  string
 	QueryParam string
 }
@@ -30,9 +30,9 @@ func randStringBytes(n int) string {
 
 func testPrepareStripAuthStripFromHeaders() ([]string, []TestAuth) {
 	testCases := []TestAuth{
-		{Auth: apidef.Auth{AuthHeaderName: "Authorization"}, HeaderKey: "Authorization"},
-		{Auth: apidef.Auth{AuthHeaderName: ""}, HeaderKey: "Authorization"},
-		{Auth: apidef.Auth{AuthHeaderName: "MyAuth"}, HeaderKey: "MyAuth"},
+		{AuthConfig: apidef.AuthConfig{AuthHeaderName: "Authorization"}, HeaderKey: "Authorization"},
+		{AuthConfig: apidef.AuthConfig{AuthHeaderName: ""}, HeaderKey: "Authorization"},
+		{AuthConfig: apidef.AuthConfig{AuthHeaderName: "MyAuth"}, HeaderKey: "MyAuth"},
 	}
 
 	miscHeaders := []string{
@@ -53,7 +53,7 @@ func TestStripAuth_stripFromHeaders(t *testing.T) {
 
 			sa := StripAuth{}
 			sa.Spec = &APISpec{APIDefinition: &apidef.APIDefinition{}}
-			sa.Spec.Auth = tc.Auth
+			sa.Spec.Auth = tc.AuthConfig
 
 			req, err := http.NewRequest("GET", "http://example.com", nil)
 			if err != nil {
@@ -92,7 +92,7 @@ func TestStripAuth_stripFromHeaders(t *testing.T) {
 		}
 		sa := StripAuth{}
 		sa.Spec = &APISpec{APIDefinition: &apidef.APIDefinition{}}
-		sa.Spec.Auth = apidef.Auth{}
+		sa.Spec.Auth = apidef.AuthConfig{}
 		key := "Cookie"
 		stripFromCookieTest(t, req, key, sa, "Authorization=AUTHORIZATION", "")
 		stripFromCookieTest(t, req, key, sa, "Authorization=AUTHORIZATION;Dummy=DUMMY", "Dummy=DUMMY")
@@ -100,7 +100,7 @@ func TestStripAuth_stripFromHeaders(t *testing.T) {
 		stripFromCookieTest(t, req, key, sa, "Dummy=DUMMY;Authorization=AUTHORIZATION;Dummy2=DUMMY2", "Dummy=DUMMY;Dummy2=DUMMY2")
 
 		key = "NonDefaultName"
-		sa.Spec.Auth = apidef.Auth{CookieName: key}
+		sa.Spec.Auth = apidef.AuthConfig{CookieName: key}
 		stripFromCookieTest(t, req, key, sa, "Dummy=DUMMY;Authorization=AUTHORIZATION;Dummy2=DUMMY2", "Dummy=DUMMY;Dummy2=DUMMY2")
 	})
 }
@@ -125,7 +125,7 @@ func BenchmarkStripAuth_stripFromHeaders(b *testing.B) {
 		for _, tc := range testCases {
 			sa := StripAuth{}
 			sa.Spec = &APISpec{APIDefinition: &apidef.APIDefinition{}}
-			sa.Spec.Auth = tc.Auth
+			sa.Spec.Auth = tc.AuthConfig
 
 			req, err := http.NewRequest("GET", "http://example.com", nil)
 			if err != nil {
@@ -150,13 +150,13 @@ func BenchmarkStripAuth_stripFromHeaders(b *testing.B) {
 func testPrepareStripAuthStripFromParams() ([]string, []TestAuth) {
 	testCases := []TestAuth{
 		// ParamName set, use it
-		{Auth: apidef.Auth{UseParam: true, ParamName: "password1"}, QueryParam: "password1"},
+		{AuthConfig: apidef.AuthConfig{UseParam: true, ParamName: "password1"}, QueryParam: "password1"},
 		// ParamName not set, use AuthHeaderName
-		{Auth: apidef.Auth{UseParam: true, ParamName: "", AuthHeaderName: "auth1"}, QueryParam: "auth1"},
+		{AuthConfig: apidef.AuthConfig{UseParam: true, ParamName: "", AuthHeaderName: "auth1"}, QueryParam: "auth1"},
 		// ParamName takes precedence over AuthHeaderName
-		{Auth: apidef.Auth{UseParam: true, ParamName: "auth2", AuthHeaderName: "auth3"}, QueryParam: "auth2"},
+		{AuthConfig: apidef.AuthConfig{UseParam: true, ParamName: "auth2", AuthHeaderName: "auth3"}, QueryParam: "auth2"},
 		// Both not set, use Authorization
-		{Auth: apidef.Auth{UseParam: true, ParamName: "", AuthHeaderName: ""}, QueryParam: "Authorization"},
+		{AuthConfig: apidef.AuthConfig{UseParam: true, ParamName: "", AuthHeaderName: ""}, QueryParam: "Authorization"},
 	}
 
 	miscQueryStrings := []string{
@@ -177,7 +177,7 @@ func TestStripAuth_stripFromParams(t *testing.T) {
 
 			sa := StripAuth{}
 			sa.Spec = &APISpec{APIDefinition: &apidef.APIDefinition{}}
-			sa.Spec.Auth = tc.Auth
+			sa.Spec.Auth = tc.AuthConfig
 
 			rawUrl := "http://example.com/abc"
 
@@ -220,7 +220,7 @@ func BenchmarkStripAuth_stripFromParams(b *testing.B) {
 		for _, tc := range testCases {
 			sa := StripAuth{}
 			sa.Spec = &APISpec{APIDefinition: &apidef.APIDefinition{}}
-			sa.Spec.Auth = tc.Auth
+			sa.Spec.Auth = tc.AuthConfig
 
 			req, err := http.NewRequest("GET", "http://example.com/abc", nil)
 			if err != nil {

--- a/gateway/oauth_manager_test.go
+++ b/gateway/oauth_manager_test.go
@@ -50,7 +50,7 @@ func buildTestOAuthSpec(apiGens ...func(spec *APISpec)) *APISpec {
 	return BuildAPI(func(spec *APISpec) {
 		spec.APIID = "999999"
 		spec.OrgID = "default"
-		spec.Auth = apidef.Auth{
+		spec.Auth = apidef.AuthConfig{
 			AuthHeaderName: "authorization",
 		}
 		spec.UseKeylessAccess = false

--- a/headers/headers.go
+++ b/headers/headers.go
@@ -17,6 +17,15 @@ const (
 )
 
 const (
+	AuthJWT     = "Auth-JWT"
+	AuthKey     = "Auth-Key"
+	AuthHMAC    = "Auth-HMAC"
+	AuthOAuth2  = "Auth-OAuth2"
+	AuthBasic   = "Auth-Basic"
+	AuthDefault = "Authorization"
+)
+
+const (
 	TykHookshot     = "Tyk-Hookshot"
 	ApplicationJSON = "application/json"
 	ApplicationXML  = "application/xml"

--- a/headers/headers.go
+++ b/headers/headers.go
@@ -17,15 +17,6 @@ const (
 )
 
 const (
-	AuthJWT     = "Auth-JWT"
-	AuthKey     = "Auth-Key"
-	AuthHMAC    = "Auth-HMAC"
-	AuthOAuth2  = "Auth-OAuth2"
-	AuthBasic   = "Auth-Basic"
-	AuthDefault = "Authorization"
-)
-
-const (
 	TykHookshot     = "Tyk-Hookshot"
 	ApplicationJSON = "application/json"
 	ApplicationXML  = "application/xml"


### PR DESCRIPTION
Fixes #2580 

This PR adds a new field 

`AuthConfigs  map[string]AuthConfig` 

to `APISpec`. The idea is to have special auth configuration for authentication types needing Auth token. 

Right now the following middlewares need Auth token, please let me know if I miss something:

- `JWTMiddleware` -> `jwt`
- `AuthKey` -> `authToken`
- `HTTPSignatureValidationMiddleware` -> `hmac`
- `Oauth2KeyExists` -> `oauth`
- `BasicAuthKeyIsValid` -> `basic`
- `CoProcessMiddleware` -> `coprocess`

Example configuration:

```
"auth_configs": {
	"basic": {"auth_header_name": "My-Basic-Auth-Key"},
	"authToken": {"auth_header_name": "My-Auth-Key"}
},
```