### PR TITLE
fix opentracing headers propagation

### DIFF
--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -685,11 +685,11 @@ func loadApps(specs []*APISpec) {
 		case "", "http", "https":
 			if shouldTrace {
 				// opentracing works only with http services.
-				err := trace.AddTracer(spec.Name)
+				err := trace.AddTracer("", spec.Name)
 				if err != nil {
-					mainLog.Errorf("Failed to initialize tracer for %s error:%v", spec.Name, err)
+					mainLog.Errorf("Failed to initialize tracer for %q error:%v", spec.Name, err)
 				} else {
-					mainLog.Infof("Intialized opentracer  api=%s", spec.Name)
+					mainLog.Infof("Intialized tracer  api_name=%q", spec.Name)
 				}
 			}
 			loadHTTPService(spec, apisByListen, &gs, muxer)

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -673,6 +673,7 @@ func loadApps(specs []*APISpec) {
 		muxer.setRouter(globalConf.ControlAPIPort, "", router)
 	}
 	gs := prepareStorage()
+	shouldTrace := trace.IsEnabled()
 	for _, spec := range specs {
 		if spec.ListenPort != spec.GlobalConfig.ListenPort {
 			mainLog.Info("API bind on custom port:", spec.ListenPort)
@@ -682,6 +683,15 @@ func loadApps(specs []*APISpec) {
 
 		switch spec.Protocol {
 		case "", "http", "https":
+			if shouldTrace {
+				// opentracing works only with http services.
+				err := trace.AddTracer(spec.Name)
+				if err != nil {
+					mainLog.Errorf("Failed to initialize tracer for %s error:%v", spec.Name, err)
+				} else {
+					mainLog.Infof("Intialized opentracer  api=%s", spec.Name)
+				}
+			}
 			loadHTTPService(spec, apisByListen, &gs, muxer)
 		case "tcp", "tls":
 			loadTCPService(spec, &gs, muxer)

--- a/gateway/api_loader_test.go
+++ b/gateway/api_loader_test.go
@@ -1,0 +1,38 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/TykTechnologies/tyk/trace"
+)
+
+func TestOpenTracing(t *testing.T) {
+	ts := StartTest()
+	defer ts.Close()
+	trace.SetupTracing("test", nil)
+	defer trace.Close()
+
+	t.Run("ensure the manager is enabled", func(ts *testing.T) {
+		if !trace.IsEnabled() {
+			ts.Error("expected tracing manager should be enabled")
+		}
+	})
+
+	t.Run("ensure services are initialized", func(ts *testing.T) {
+		var s string
+		trace.SetInit(func(name string, service string, opts map[string]interface{}, logger trace.Logger) (trace.Tracer, error) {
+			s = service
+			return trace.NoopTracer{}, nil
+		})
+		name := "trace"
+		BuildAndLoadAPI(
+			func(spec *APISpec) {
+				spec.Name = name
+				spec.UseOauth2 = true
+			},
+		)
+		if name != s {
+			ts.Errorf("expected %s got %s", name, s)
+		}
+	})
+}

--- a/trace/manager.go
+++ b/trace/manager.go
@@ -88,6 +88,7 @@ func Close() error {
 	for _, v := range s {
 		services.Delete(v)
 	}
+	Disable()
 	return nil
 }
 

--- a/trace/manager.go
+++ b/trace/manager.go
@@ -14,9 +14,17 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 )
 
+// ErrManagerDisabled is returned when trying to use global trace manager when
+// it is disabled.
 var ErrManagerDisabled = errors.New("trace: trace is diabled")
+
+// This stores a map of opentracer configurations.
 var manager = &sync.Map{}
+
+// This stores a map of service name to  initialized Tracer implementation.
 var services = &sync.Map{}
+
+// Stores status of tracing.
 var enabled atomic.Value
 var logger Logger = StdLogger{}
 var initializer = Init

--- a/trace/manager.go
+++ b/trace/manager.go
@@ -73,7 +73,7 @@ func (o *OpenTracer) Get(service string) Tracer {
 	o.mu.RUnlock()
 	if !ok {
 		if o.log != nil {
-			o.log.Info(service, "not found")
+			o.log.Infof("[trace] Failed to get tracer for %q error: not found", service)
 		}
 		return NoopTracer{}
 	}

--- a/trace/manager.go
+++ b/trace/manager.go
@@ -18,7 +18,6 @@ var ErrManagerDisabled = errors.New("trace: trace is diabled")
 var manager = &sync.Map{}
 var services = &sync.Map{}
 var enabled atomic.Value
-var mu sync.RWMutex
 var logger Logger = StdLogger{}
 var initializer = Init
 

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -8,6 +8,9 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 )
 
+// InitFunc this is a function for initializing a Tracer
+type InitFunc func(name string, service string, opts map[string]interface{}, logger Logger) (Tracer, error)
+
 type Tracer interface {
 	Name() string
 	opentracing.Tracer


### PR DESCRIPTION
Fixes #2655

For some reason the changes which was calling `trace.AddTracer` were lost and as a result, traces for api's were never initialised.

This change ensures that we call `trace.AddTracer` for all http api's.