### PR TITLE
Circuit breaker improvement

### DIFF
--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -726,7 +726,7 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 		begin := time.Now()
 		res, err = roundTripper.RoundTrip(outreq)
 		upstreamLatency = time.Since(begin)
-		if err != nil || res.StatusCode == http.StatusInternalServerError {
+		if err != nil || res.StatusCode/100 == 5 || res.StatusCode/100 == 4{
 			breakerConf.CB.Fail()
 		} else {
 			breakerConf.CB.Success()

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -362,8 +362,8 @@ func TestCircuitBreaker5xxs(t *testing.T){
                             "threshold_percent": 0.1,
                             "samples": 3,
                             "return_to_service_after": 6000
-				}]`), &v.ExtendedPaths.CircuitBreaker)
-
+					}
+  			 ]`), &v.ExtendedPaths.CircuitBreaker)
 			})
 			spec.Proxy.ListenPath = "/"
 
@@ -395,7 +395,8 @@ func TestCircuitBreaker4xxs(t *testing.T){
                             "threshold_percent": 0.1,
                             "samples": 3,
                             "return_to_service_after": 6000
-				}]`), &v.ExtendedPaths.CircuitBreaker)
+					}
+				]`), &v.ExtendedPaths.CircuitBreaker)
 
 			})
 			spec.Proxy.ListenPath = "/"

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -362,9 +362,17 @@ func testHttpHandler() *mux.Router {
 		}
 	}
 
+	handleMethodError := func(method string) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			statusCode, _ := strconv.Atoi(mux.Vars(r)["status"])
+			httpError(w,statusCode)
+		}
+	}
+
 	// use gorilla's mux as it allows to cancel URI cleaning
 	// (it is not configurable in standard http mux)
 	r := mux.NewRouter()
+
 	r.HandleFunc("/get", handleMethod("GET"))
 	r.HandleFunc("/post", handleMethod("POST"))
 	r.HandleFunc("/ws", wsHandler)
@@ -379,6 +387,8 @@ func testHttpHandler() *mux.Router {
 		gz.Close()
 	})
 	r.HandleFunc("/bundles/{rest:.*}", bundleHandleFunc)
+	r.HandleFunc("/error/{status}",handleMethodError("GET"))
+
 	r.HandleFunc("/{rest:.*}", handleMethod(""))
 
 	return r

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -362,13 +362,6 @@ func testHttpHandler() *mux.Router {
 		}
 	}
 
-	handleMethodError := func(method string) http.HandlerFunc {
-		return func(w http.ResponseWriter, r *http.Request) {
-			statusCode, _ := strconv.Atoi(mux.Vars(r)["status"])
-			httpError(w,statusCode)
-		}
-	}
-
 	// use gorilla's mux as it allows to cancel URI cleaning
 	// (it is not configurable in standard http mux)
 	r := mux.NewRouter()
@@ -387,8 +380,10 @@ func testHttpHandler() *mux.Router {
 		gz.Close()
 	})
 	r.HandleFunc("/bundles/{rest:.*}", bundleHandleFunc)
-	r.HandleFunc("/error/{status}",handleMethodError("GET"))
-
+	r.HandleFunc("/error/{status}", func(w http.ResponseWriter, r *http.Request) {
+			statusCode, _ := strconv.Atoi(mux.Vars(r)["status"])
+			httpError(w,statusCode)
+	})
 	r.HandleFunc("/{rest:.*}", handleMethod(""))
 
 	return r


### PR DESCRIPTION
Tyk's Circuit Breaker only works for 500 errors. This is pretty limiting. e.g. the breaker will not trip for failed upstreams.

This PR fixes that in an order to break the circuit for any 5XX errors, 4XX errors or if RoundTrip returns an error.