### PR TITLE
Circuit breaker improvement

### DIFF
--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -726,7 +726,7 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 		begin := time.Now()
 		res, err = roundTripper.RoundTrip(outreq)
 		upstreamLatency = time.Since(begin)
-		if err != nil || res.StatusCode == http.StatusInternalServerError {
+		if err != nil || res.StatusCode/100 == 5 {
 			breakerConf.CB.Fail()
 		} else {
 			breakerConf.CB.Success()

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -345,6 +346,38 @@ func TestWrappedServeHTTP(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	req, _ := http.NewRequest(http.MethodGet, "/", nil)
 	proxy.WrappedServeHTTP(recorder, req, false)
+}
+
+func TestCircuitBreaker5xxs(t *testing.T) {
+	ts := StartTest()
+	defer ts.Close()
+
+	t.Run("Extended Paths", func(t *testing.T) {
+		BuildAndLoadAPI(func(spec *APISpec) {
+			UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+				json.Unmarshal([]byte(`[
+					{
+						"path": "error",
+						"method": "GET",
+						"threshold_percent": 0.1,
+						"samples": 3,
+						"return_to_service_after": 6000
+					}
+  			 	]`), &v.ExtendedPaths.CircuitBreaker)
+			})
+			spec.Proxy.ListenPath = "/"
+			spec.CircuitBreakerEnabled = true
+		})
+
+		ts.Run(t, []test.TestCase{
+			{Path: "/errors/500", Code: http.StatusInternalServerError},
+			{Path: "/errors/501", Code: http.StatusNotImplemented},
+			{Path: "/errors/502", Code: http.StatusBadGateway},
+			{Path: "/errors/500", Code: http.StatusServiceUnavailable},
+			{Path: "/errors/501", Code: http.StatusServiceUnavailable},
+			{Path: "/errors/502", Code: http.StatusServiceUnavailable},
+		}...)
+	})
 }
 
 func TestSingleJoiningSlash(t *testing.T) {

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -365,6 +365,7 @@ func testHttpHandler() *mux.Router {
 	// use gorilla's mux as it allows to cancel URI cleaning
 	// (it is not configurable in standard http mux)
 	r := mux.NewRouter()
+
 	r.HandleFunc("/get", handleMethod("GET"))
 	r.HandleFunc("/post", handleMethod("POST"))
 	r.HandleFunc("/ws", wsHandler)
@@ -379,6 +380,10 @@ func testHttpHandler() *mux.Router {
 		gz.Close()
 	})
 	r.HandleFunc("/bundles/{rest:.*}", bundleHandleFunc)
+	r.HandleFunc("/errors/{status}", func(w http.ResponseWriter, r *http.Request) {
+		statusCode, _ := strconv.Atoi(mux.Vars(r)["status"])
+		httpError(w, statusCode)
+	})
 	r.HandleFunc("/{rest:.*}", handleMethod(""))
 
 	return r


### PR DESCRIPTION
Tyk's Circuit Breaker only works for 500 errors. This is pretty limiting. e.g. the breaker will not trip for failed upstreams.

This PR fixes that in order to break the circuit for any 5XX errors or if RoundTrip returns an error.