### PR TITLE
fix regression on rate calculations

### DIFF
--- a/cli/lint/schema.go
+++ b/cli/lint/schema.go
@@ -224,6 +224,9 @@ const confSchema = `{
 	"drl_notification_frequency": {
 		"type": "integer"
 	},
+	"drl_threshold": {
+		"type": "number"
+	},
 	"enable_analytics": {
 		"type": "boolean"
 	},

--- a/session_manager.go
+++ b/session_manager.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"net/http"
 	"time"
 
@@ -253,7 +252,6 @@ func (l *SessionLimiter) ForwardMessage(r *http.Request, currentSession *user.Se
 	}
 
 	if enableQ {
-		fmt.Println("===========>")
 		if globalConf.LegacyEnableAllowanceCountdown {
 			currentSession.Allowance--
 		}

--- a/session_manager.go
+++ b/session_manager.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
@@ -219,7 +220,18 @@ func (l *SessionLimiter) ForwardMessage(r *http.Request, currentSession *user.Se
 			if DRLManager.Servers != nil {
 				n = float64(DRLManager.Servers.Count())
 			}
-			rate := apiLimit.Rate / apiLimit.Per
+			var rate float64
+			if apiLimit == nil {
+				rate = currentSession.Rate
+				if currentSession.Per != 0 {
+					rate /= currentSession.Per
+				}
+			} else {
+				rate = apiLimit.Rate
+				if apiLimit.Per != 0 {
+					rate /= apiLimit.Per
+				}
+			}
 			c := globalConf.DRLThreshold
 			if c == 0 {
 				// defaults to 5
@@ -241,6 +253,7 @@ func (l *SessionLimiter) ForwardMessage(r *http.Request, currentSession *user.Se
 	}
 
 	if enableQ {
+		fmt.Println("===========>")
 		if globalConf.LegacyEnableAllowanceCountdown {
 			currentSession.Allowance--
 		}


### PR DESCRIPTION
There are cases where apiLimit was nil resulting into tests to panic

This handles nil apiLimit and avoid division by zero