### PR TITLE
templates: fix field name (#2709)

### DIFF
--- a/templates/default_webhook.json
+++ b/templates/default_webhook.json
@@ -22,7 +22,7 @@
 {
     "event": "{{.Type}}",
     "message": "{{.Meta.Message}}",
-    "org": "{{.Meta.Org}}",
+    "org": "{{.Meta.OrgID}}",
     "key": "{{.Meta.Key}}",
     "trigger_limit": "{{.Meta.TriggerLimit}}"
 }

--- a/templates/monitor_template.json
+++ b/templates/monitor_template.json
@@ -1,7 +1,7 @@
 {
     "event": "{{.Type}}",
     "message": "{{.Meta.Message}}",
-    "org": "{{.Meta.Org}}",
+    "org": "{{.Meta.OrgID}}",
     "key": "{{.Meta.Key}}",
     "trigger_limit": "{{.Meta.TriggerLimit}}"
 }


### PR DESCRIPTION
Fixes #2709 

The data structure for this event is as follows (`gateway/event_system.go`):
```go
type EventTriggerExceededMeta struct {
	EventMetaDefault
	OrgID           string `json:"org_id"`
	Key             string `json:"key"`
	TriggerLimit    int64  `json:"trigger_limit"`
	UsagePercentage int64  `json:"usage_percentage"`
}
```