### PR TITLE
Improved debugging

### DIFF
--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -251,9 +251,9 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 	var proxy ReturningHttpHandler
 	if enableVersionOverrides {
 		logger.Info("Multi target enabled")
-		proxy = NewMultiTargetProxy(spec)
+		proxy = NewMultiTargetProxy(spec, logger)
 	} else {
-		proxy = TykNewSingleHostReverseProxy(spec.target, spec)
+		proxy = TykNewSingleHostReverseProxy(spec.target, spec, logger)
 	}
 
 	// Create the response processors, pass all the loaded custom middleware response functions:

--- a/gateway/distributed_rate_limiter.go
+++ b/gateway/distributed_rate_limiter.go
@@ -88,7 +88,7 @@ func onServerStatusReceivedHandler(payload string) {
 		return
 	}
 
-	log.Debug("Received DRL data: ", serverData)
+	// log.Debug("Received DRL data: ", serverData)
 
 	if DRLManager.Ready {
 		if err := DRLManager.AddOrUpdateServer(serverData); err != nil {
@@ -97,7 +97,7 @@ func onServerStatusReceivedHandler(payload string) {
 				Debug("AddOrUpdateServer error. Seems like you running multiple segmented Tyk groups in same Redis.")
 			return
 		}
-		log.Debug(DRLManager.Report())
+		// log.Debug(DRLManager.Report())
 	} else {
 		log.Warning("DRL not ready, skipping this notification")
 	}

--- a/gateway/host_checker_test.go
+++ b/gateway/host_checker_test.go
@@ -208,7 +208,7 @@ func TestReverseProxyAllDown(t *testing.T) {
 	eventWG.Wait()
 
 	remote, _ := url.Parse(TestHttpAny)
-	proxy := TykNewSingleHostReverseProxy(remote, spec)
+	proxy := TykNewSingleHostReverseProxy(remote, spec, nil)
 
 	req := TestReq(t, "GET", "/", nil)
 	rec := httptest.NewRecorder()

--- a/gateway/multi_target_proxy_handler.go
+++ b/gateway/multi_target_proxy_handler.go
@@ -40,11 +40,11 @@ func (m *MultiTargetProxy) CopyResponse(dst io.Writer, src io.Reader) {
 	m.defaultProxy.CopyResponse(dst, src)
 }
 
-func NewMultiTargetProxy(spec *APISpec) *MultiTargetProxy {
+func NewMultiTargetProxy(spec *APISpec, logger *logrus.Entry) *MultiTargetProxy {
 	m := &MultiTargetProxy{}
 	m.versionProxies = make(map[string]*ReverseProxy)
 	m.specReference = spec
-	m.defaultProxy = TykNewSingleHostReverseProxy(spec.target, spec)
+	m.defaultProxy = TykNewSingleHostReverseProxy(spec.target, spec, logger)
 
 	for vname, vdata := range spec.VersionData.Versions {
 		if vdata.OverrideTarget == "" {
@@ -69,7 +69,7 @@ func NewMultiTargetProxy(spec *APISpec) *MultiTargetProxy {
 				"prefix": "multi-target",
 			}).Error("Couldn't parse version target URL in MultiTarget: ", err)
 		}
-		m.versionProxies[vname] = TykNewSingleHostReverseProxy(remote, spec)
+		m.versionProxies[vname] = TykNewSingleHostReverseProxy(remote, spec, logger)
 	}
 	return m
 }

--- a/gateway/multiauth_test.go
+++ b/gateway/multiauth_test.go
@@ -74,7 +74,7 @@ func createMultiBasicAuthSession(isBench bool) *user.SessionState {
 
 func getMultiAuthStandardAndBasicAuthChain(spec *APISpec) http.Handler {
 	remote, _ := url.Parse(TestHttpAny)
-	proxy := TykNewSingleHostReverseProxy(remote, spec)
+	proxy := TykNewSingleHostReverseProxy(remote, spec, nil)
 	proxyHandler := ProxyHandler(proxy, spec)
 	baseMid := BaseMiddleware{Spec: spec, Proxy: proxy}
 	chain := alice.New(mwList(

--- a/gateway/mw_api_rate_limit_test.go
+++ b/gateway/mw_api_rate_limit_test.go
@@ -32,7 +32,7 @@ func createRLSession() *user.SessionState {
 
 func getRLOpenChain(spec *APISpec) http.Handler {
 	remote, _ := url.Parse(spec.Proxy.TargetURL)
-	proxy := TykNewSingleHostReverseProxy(remote, spec)
+	proxy := TykNewSingleHostReverseProxy(remote, spec, nil)
 	proxyHandler := ProxyHandler(proxy, spec)
 	baseMid := BaseMiddleware{Spec: spec, Proxy: proxy}
 	chain := alice.New(mwList(
@@ -46,7 +46,7 @@ func getRLOpenChain(spec *APISpec) http.Handler {
 
 func getGlobalRLAuthKeyChain(spec *APISpec) http.Handler {
 	remote, _ := url.Parse(spec.Proxy.TargetURL)
-	proxy := TykNewSingleHostReverseProxy(remote, spec)
+	proxy := TykNewSingleHostReverseProxy(remote, spec, nil)
 	proxyHandler := ProxyHandler(proxy, spec)
 	baseMid := BaseMiddleware{Spec: spec, Proxy: proxy}
 	chain := alice.New(mwList(

--- a/gateway/mw_auth_key_test.go
+++ b/gateway/mw_auth_key_test.go
@@ -198,7 +198,7 @@ func createAuthKeyAuthSession(isBench bool) *user.SessionState {
 
 func getAuthKeyChain(spec *APISpec) http.Handler {
 	remote, _ := url.Parse(spec.Proxy.TargetURL)
-	proxy := TykNewSingleHostReverseProxy(remote, spec)
+	proxy := TykNewSingleHostReverseProxy(remote, spec, nil)
 	proxyHandler := ProxyHandler(proxy, spec)
 	baseMid := BaseMiddleware{Spec: spec, Proxy: proxy}
 	chain := alice.New(mwList(

--- a/gateway/mw_http_signature_validation_test.go
+++ b/gateway/mw_http_signature_validation_test.go
@@ -80,7 +80,7 @@ func createRSAAuthSession(pubCertId string) *user.SessionState {
 
 func getHMACAuthChain(spec *APISpec) http.Handler {
 	remote, _ := url.Parse(TestHttpAny)
-	proxy := TykNewSingleHostReverseProxy(remote, spec)
+	proxy := TykNewSingleHostReverseProxy(remote, spec, nil)
 	proxyHandler := ProxyHandler(proxy, spec)
 	baseMid := BaseMiddleware{Spec: spec, Proxy: proxy}
 	chain := alice.New(mwList(

--- a/gateway/redis_signals.go
+++ b/gateway/redis_signals.go
@@ -193,7 +193,7 @@ func (r *RedisNotifier) Notify(notif interface{}) bool {
 		return false
 	}
 
-	pubSubLog.Debug("Sending notification", notif)
+	// pubSubLog.Debug("Sending notification", notif)
 
 	if err := r.store.Publish(r.channel, string(toSend)); err != nil {
 

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -573,6 +573,10 @@ func httpTransport(timeOut float64, rw http.ResponseWriter, req *http.Request, p
 	if proxyURL, _ := transport.Proxy(req); proxyURL != nil {
 		p.logger.Debug("Detected proxy: " + proxyURL.String())
 		transport.TLSClientConfig.VerifyPeerCertificate = verifyPeerCertificatePinnedCheck(p.TykAPISpec, transport.TLSClientConfig)
+
+		if transport.TLSClientConfig.VerifyPeerCertificate != nil {
+			p.logger.Debug("Certificate pinning check is enabled")
+		}
 	} else {
 		transport.DialTLS = customDialTLSCheck(p.TykAPISpec, transport.TLSClientConfig)
 	}

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -182,7 +182,7 @@ var (
 // the target request will be for /base/dir. This version modifies the
 // stdlib version by also setting the host to the target, this allows
 // us to work with heroku and other such providers
-func TykNewSingleHostReverseProxy(target *url.URL, spec *APISpec) *ReverseProxy {
+func TykNewSingleHostReverseProxy(target *url.URL, spec *APISpec, logger *logrus.Entry) *ReverseProxy {
 	onceStartAllHostsDown.Do(func() {
 		handler := func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "all hosts are down", http.StatusServiceUnavailable)
@@ -296,10 +296,17 @@ func TykNewSingleHostReverseProxy(target *url.URL, spec *APISpec) *ReverseProxy 
 		}
 	}
 
+	if logger == nil {
+		logger = logrus.NewEntry(log)
+	}
+
+	logger = logger.WithField("mw", "ReverseProxy")
+
 	proxy := &ReverseProxy{
 		Director:      director,
 		TykAPISpec:    spec,
 		FlushInterval: time.Duration(spec.GlobalConfig.HttpServerOptions.FlushInterval) * time.Millisecond,
+		logger:        logger,
 		sp: sync.Pool{
 			New: func() interface{} {
 				buffer := make([]byte, 32*1024)
@@ -338,7 +345,8 @@ type ReverseProxy struct {
 	TykAPISpec   *APISpec
 	ErrorHandler ErrorHandler
 
-	sp sync.Pool
+	logger *logrus.Entry
+	sp     sync.Pool
 }
 
 func defaultTransport(dialerTimeout float64) *http.Transport {
@@ -424,7 +432,13 @@ var hopHeaders = []string{
 }
 
 func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) ProxyResponse {
+	startTime := time.Now()
+	p.logger.WithField("ts", startTime.UnixNano()).Debug("Started")
+
 	resp := p.WrappedServeHTTP(rw, req, recordDetail(req, p.TykAPISpec))
+
+	finishTime := time.Since(startTime)
+	p.logger.WithField("ns", finishTime.Nanoseconds()).Debug("Finished")
 
 	// make response body to be nopCloser and re-readable before serve it through chain of middlewares
 	nopCloseResponseBody(resp.Response)
@@ -433,8 +447,15 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) Prox
 }
 
 func (p *ReverseProxy) ServeHTTPForCache(rw http.ResponseWriter, req *http.Request) ProxyResponse {
+	startTime := time.Now()
+	p.logger.WithField("ts", startTime.UnixNano()).Debug("Started")
+
 	resp := p.WrappedServeHTTP(rw, req, true)
 	nopCloseResponseBody(resp.Response)
+
+	finishTime := time.Since(startTime)
+	p.logger.WithField("ns", finishTime.Nanoseconds()).Debug("Finished")
+
 	return resp
 }
 
@@ -447,7 +468,7 @@ func (p *ReverseProxy) CheckHardTimeoutEnforced(spec *APISpec, req *http.Request
 	found, meta := spec.CheckSpecMatchesStatus(req, versionPaths, HardTimeout)
 	if found {
 		intMeta := meta.(*int)
-		log.Debug("HARD TIMEOUT ENFORCED: ", *intMeta)
+		p.logger.Debug("HARD TIMEOUT ENFORCED: ", *intMeta)
 		return true, float64(*intMeta)
 	}
 
@@ -484,7 +505,7 @@ func (p *ReverseProxy) CheckCircuitBreakerEnforced(spec *APISpec, req *http.Requ
 	found, meta := spec.CheckSpecMatchesStatus(req, versionPaths, CircuitBreaker)
 	if found {
 		exMeta := meta.(*ExtendedCircuitBreakerMeta)
-		log.Debug("CB Enforced for path: ", *exMeta)
+		p.logger.Debug("CB Enforced for path: ", *exMeta)
 		return true, exMeta
 	}
 
@@ -550,6 +571,7 @@ func httpTransport(timeOut float64, rw http.ResponseWriter, req *http.Request, p
 	// When request routed through the proxy `DialTLS` is not used, and only VerifyPeerCertificate is supported
 	// The reason behind two separate checks is that `DialTLS` supports specifying public keys per hostname, and `VerifyPeerCertificate` only global ones, e.g. `*`
 	if proxyURL, _ := transport.Proxy(req); proxyURL != nil {
+		p.logger.Debug("Detected proxy: " + proxyURL.String())
 		transport.TLSClientConfig.VerifyPeerCertificate = verifyPeerCertificatePinnedCheck(p.TykAPISpec, transport.TLSClientConfig)
 	} else {
 		transport.DialTLS = customDialTLSCheck(p.TykAPISpec, transport.TLSClientConfig)
@@ -589,7 +611,7 @@ func httpTransport(timeOut float64, rw http.ResponseWriter, req *http.Request, p
 	return transport
 }
 
-func setCommonNameVerifyPeerCertificate(spec *APISpec, tlsConfig *tls.Config, hostName string) {
+func (p *ReverseProxy) setCommonNameVerifyPeerCertificate(tlsConfig *tls.Config, hostName string) {
 	tlsConfig.InsecureSkipVerify = true
 
 	// if verifyPeerCertificate was set previously, make sure it is also executed
@@ -598,6 +620,7 @@ func setCommonNameVerifyPeerCertificate(spec *APISpec, tlsConfig *tls.Config, ho
 		if prevFunc != nil {
 			err := prevFunc(rawCerts, verifiedChains)
 			if err != nil {
+				p.logger.Error("Failed to verify server certificate: " + err.Error())
 				return err
 			}
 		}
@@ -612,7 +635,7 @@ func setCommonNameVerifyPeerCertificate(spec *APISpec, tlsConfig *tls.Config, ho
 			certs[i] = cert
 		}
 
-		if !spec.Proxy.Transport.SSLInsecureSkipVerify && !config.Global().ProxySSLInsecureSkipVerify {
+		if !p.TykAPISpec.Proxy.Transport.SSLInsecureSkipVerify && !config.Global().ProxySSLInsecureSkipVerify {
 			opts := x509.VerifyOptions{
 				Roots:         tlsConfig.RootCAs,
 				CurrentTime:   time.Now(),
@@ -628,6 +651,7 @@ func setCommonNameVerifyPeerCertificate(spec *APISpec, tlsConfig *tls.Config, ho
 			}
 			_, err := certs[0].Verify(opts)
 			if err != nil {
+				p.logger.Error("Failed to verify server certificate: " + err.Error())
 				return err
 			}
 		}
@@ -660,6 +684,8 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 			_, timeout := p.CheckHardTimeoutEnforced(p.TykAPISpec, req)
 			p.TykAPISpec.HTTPTransport = httpTransport(timeout, rw, req, p)
 			p.TykAPISpec.HTTPTransportCreated = time.Now()
+
+			p.logger.Debug("Creating new HTTP transport")
 		}
 
 		roundTripper = p.TykAPISpec.HTTPTransport
@@ -676,6 +702,8 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 			_, timeout := p.CheckHardTimeoutEnforced(p.TykAPISpec, req)
 			p.TykAPISpec.WSTransport = httpTransport(timeout, rw, req, p)
 			p.TykAPISpec.WSTransportCreated = time.Now()
+
+			p.logger.Debug("Creating new WS transport")
 		}
 
 		// overwrite transport's ResponseWriter from previous upgrade request
@@ -713,11 +741,11 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 	setContext(outreq, context.Background())
 	setContext(logreq, context.Background())
 
-	log.Debug("UPSTREAM REQUEST URL: ", req.URL)
+	p.logger.Debug("Upstream request URL: ", req.URL)
 
 	// We need to double set the context for the outbound request to reprocess the target
 	if p.TykAPISpec.URLRewriteEnabled && req.Context().Value(ctx.RetainHost) == true {
-		log.Debug("Detected host rewrite, notifying director")
+		p.logger.Debug("Detected host rewrite, notifying director")
 		setCtxValue(outreq, ctx.RetainHost, true)
 	}
 
@@ -734,7 +762,7 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 	p.Director(outreq)
 	outreq.Close = false
 
-	log.Debug("Outbound Request: ", outreq.URL.String())
+	p.logger.Debug("Outbound request URL: ", outreq.URL.String())
 
 	// Do not modify outbound request headers if they are WS
 	if !outReqIsWebsocket {
@@ -774,6 +802,7 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 	// set up TLS certificates for upstream if needed
 	var tlsCertificates []tls.Certificate
 	if cert := getUpstreamCertificate(outreq.Host, p.TykAPISpec); cert != nil {
+		p.logger.Debug("Found upstream mutual TLS certificate")
 		tlsCertificates = []tls.Certificate{*cert}
 	}
 
@@ -796,10 +825,13 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 			httpTransport = roundTripper.(*http.Transport)
 		}
 
+		p.logger.Debug("Using forced SSL CN check")
+
 		if proxyURL, _ := httpTransport.Proxy(req); proxyURL != nil {
+			p.logger.Debug("Detected proxy: " + proxyURL.String())
 			tlsConfig := httpTransport.TLSClientConfig
 			host, _, _ := net.SplitHostPort(outreq.Host)
-			setCommonNameVerifyPeerCertificate(p.TykAPISpec, tlsConfig, host)
+			p.setCommonNameVerifyPeerCertificate(tlsConfig, host)
 		}
 
 	}
@@ -810,11 +842,11 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 	var upstreamLatency time.Duration
 	if breakerEnforced {
 		if !breakerConf.CB.Ready() {
-			log.Debug("ON REQUEST: Circuit Breaker is in OPEN state")
+			p.logger.Debug("ON REQUEST: Circuit Breaker is in OPEN state")
 			p.ErrorHandler.HandleError(rw, logreq, "Service temporarily unavailable.", 503, true)
 			return ProxyResponse{}
 		}
-		log.Debug("ON REQUEST: Circuit Breaker is in CLOSED or HALF-OPEN state")
+		p.logger.Debug("ON REQUEST: Circuit Breaker is in CLOSED or HALF-OPEN state")
 		begin := time.Now()
 		res, err = roundTripper.RoundTrip(outreq)
 		upstreamLatency = time.Since(begin)
@@ -838,7 +870,7 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 			alias = session.Alias
 		}
 
-		log.WithFields(logrus.Fields{
+		p.logger.WithFields(logrus.Fields{
 			"prefix":      "proxy",
 			"user_ip":     addrs,
 			"server_name": outreq.Host,
@@ -853,7 +885,7 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 
 			if p.TykAPISpec.Proxy.ServiceDiscovery.UseDiscoveryService {
 				if ServiceCache != nil {
-					log.Debug("[PROXY] [SERVICE DISCOVERY] Upstream host failed, refreshing host list")
+					p.logger.Debug("[PROXY] [SERVICE DISCOVERY] Upstream host failed, refreshing host list")
 					ServiceCache.Delete(p.TykAPISpec.APIID)
 				}
 			}
@@ -894,7 +926,7 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 	}
 
 	if err != nil {
-		log.Error("Response chain failed! ", err)
+		p.logger.Error("Response chain failed! ", err)
 	}
 
 	inres := new(http.Response)
@@ -1017,7 +1049,7 @@ func (p *ReverseProxy) copyBuffer(dst io.Writer, src io.Reader) (int64, error) {
 	for {
 		nr, rerr := src.Read(*buf)
 		if rerr != nil && rerr != io.EOF && rerr != context.Canceled {
-			log.WithFields(logrus.Fields{
+			p.logger.WithFields(logrus.Fields{
 				"prefix": "proxy",
 				"org_id": p.TykAPISpec.OrgID,
 				"api_id": p.TykAPISpec.APIID,

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -101,7 +101,7 @@ func TestReverseProxyRetainHost(t *testing.T) {
 				setCtxValue(req, ctx.RetainHost, true)
 			}
 
-			proxy := TykNewSingleHostReverseProxy(target, spec)
+			proxy := TykNewSingleHostReverseProxy(target, spec, nil)
 			proxy.Director(req)
 
 			if got := req.URL.String(); got != tc.wantURL {
@@ -285,7 +285,7 @@ func TestReverseProxyDnsCache(t *testing.T) {
 			}
 
 			Url, _ := url.Parse(tc.URL)
-			proxy := TykNewSingleHostReverseProxy(Url, spec)
+			proxy := TykNewSingleHostReverseProxy(Url, spec, nil)
 			recorder := httptest.NewRecorder()
 			proxy.WrappedServeHTTP(recorder, req, false)
 
@@ -343,7 +343,7 @@ func testNewWrappedServeHTTP() *ReverseProxy {
 		EnforcedTimeoutEnabled: true,
 		CircuitBreakerEnabled:  true,
 	}
-	return TykNewSingleHostReverseProxy(target, spec)
+	return TykNewSingleHostReverseProxy(target, spec, nil)
 }
 
 func TestWrappedServeHTTP(t *testing.T) {

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -153,8 +153,8 @@ func (r *RPCStorageHandler) cleanKey(keyName string) string {
 // GetKey will retrieve a key from the database
 func (r *RPCStorageHandler) GetKey(keyName string) (string, error) {
 	start := time.Now() // get current time
-	log.Debug("[STORE] Getting WAS: ", keyName)
-	log.Debug("[STORE] Getting: ", r.fixKey(keyName))
+	//	log.Debug("[STORE] Getting WAS: ", keyName)
+	//  log.Debug("[STORE] Getting: ", r.fixKey(keyName))
 
 	value, err := r.GetRawKey(r.fixKey(keyName))
 

--- a/gateway/tracing.go
+++ b/gateway/tracing.go
@@ -117,7 +117,8 @@ func traceHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	wr := httptest.NewRecorder()
-	chainObj.ThisHandler.ServeHTTP(wr, traceReq.Request.toRequest())
+	tr := traceReq.Request.toRequest()
+	chainObj.ThisHandler.ServeHTTP(wr, tr)
 
 	var response string
 	if dump, err := httputil.DumpResponse(wr.Result(), true); err == nil {
@@ -126,5 +127,14 @@ func traceHandler(w http.ResponseWriter, r *http.Request) {
 		response = err.Error()
 	}
 
-	doJSONWrite(w, http.StatusOK, traceResponse{Message: "ok", Response: response, Logs: logStorage.String()})
+	var request string
+	if dump, err := httputil.DumpRequest(tr, true); err == nil {
+		request = string(dump)
+	} else {
+		request = err.Error()
+	}
+
+	requestDump := "====== Request ======\n" + request + "\n====== Response ======\n" + response
+
+	doJSONWrite(w, http.StatusOK, traceResponse{Message: "ok", Response: requestDump, Logs: logStorage.String()})
 }

--- a/storage/redis_cluster.go
+++ b/storage/redis_cluster.go
@@ -309,8 +309,8 @@ func (r *RedisCluster) ensureConnection() {
 // GetKey will retrieve a key from the database
 func (r *RedisCluster) GetKey(keyName string) (string, error) {
 	r.ensureConnection()
-	log.Debug("[STORE] Getting WAS: ", keyName)
-	log.Debug("[STORE] Getting: ", r.fixKey(keyName))
+	// log.Debug("[STORE] Getting WAS: ", keyName)
+	// log.Debug("[STORE] Getting: ", r.fixKey(keyName))
 	cluster := r.singleton()
 
 	value, err := cluster.Get(r.fixKey(keyName)).Result()
@@ -394,7 +394,7 @@ func (r *RedisCluster) GetRawKey(keyName string) (string, error) {
 }
 
 func (r *RedisCluster) GetExp(keyName string) (int64, error) {
-	log.Debug("Getting exp for key: ", r.fixKey(keyName))
+	//	log.Debug("Getting exp for key: ", r.fixKey(keyName))
 	r.ensureConnection()
 
 	value, err := r.singleton().TTL(r.fixKey(keyName)).Result()
@@ -415,8 +415,8 @@ func (r *RedisCluster) SetExp(keyName string, timeout int64) error {
 
 // SetKey will create (or update) a key value in the store
 func (r *RedisCluster) SetKey(keyName, session string, timeout int64) error {
-	log.Debug("[STORE] SET Raw key is: ", keyName)
-	log.Debug("[STORE] Setting key: ", r.fixKey(keyName))
+	//log.Debug("[STORE] SET Raw key is: ", keyName)
+	//log.Debug("[STORE] Setting key: ", r.fixKey(keyName))
 
 	r.ensureConnection()
 	err := r.singleton().Set(r.fixKey(keyName), session, 0).Err()
@@ -449,7 +449,7 @@ func (r *RedisCluster) SetRawKey(keyName, session string, timeout int64) error {
 // Decrement will decrement a key in redis
 func (r *RedisCluster) Decrement(keyName string) {
 	keyName = r.fixKey(keyName)
-	log.Debug("Decrementing key: ", keyName)
+	// log.Debug("Decrementing key: ", keyName)
 	r.ensureConnection()
 	err := r.singleton().Decr(keyName).Err()
 	if err != nil {
@@ -459,12 +459,13 @@ func (r *RedisCluster) Decrement(keyName string) {
 
 // IncrementWithExpire will increment a key in redis
 func (r *RedisCluster) IncrememntWithExpire(keyName string, expire int64) int64 {
-	log.Debug("Incrementing raw key: ", keyName)
+	// log.Debug("Incrementing raw key: ", keyName)
 	r.ensureConnection()
 
 	// This function uses a raw key, so we shouldn't call fixKey
 	fixedKey := keyName
 	val, err := r.singleton().Incr(fixedKey).Result()
+
 	if err != nil {
 		log.Error("Error trying to increment value:", err)
 	} else {


### PR DESCRIPTION
Tyk debugger now shows both request and response data. So you can actually see how headers are added or body is transformed. It looks in-dash like this:
```
====== Request ======
GET / HTTP/1.1
Host: example.com
A: b


====== Response ======
HTTP/1.1 500 Internal Server Error
Connection: close
Content-Type: application/json
X-Generator: tyk.io

{
    "error": "There was a problem proxying the request"
} 
```

Additionally, all reverse proxy logs are shown in tracer as well, and you can see how much proxying took, is it used a certificate or pinning and etc. 

Additionally, from debug output removed annoying DRL logs and raw level redis calls, which was polluting the logs.  