### PR TITLE
Escape unicode while generating redirect_to url for oauth

### DIFF
--- a/gateway/oauth_manager.go
+++ b/gateway/oauth_manager.go
@@ -114,11 +114,14 @@ func (o *OAuthHandlers) generateOAuthOutputFromOsinResponse(osinResponse *osin.R
 		osinResponse.Output["redirect_to"] = redirect
 	}
 
-	respData, err := json.Marshal(&osinResponse.Output)
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	encoder.SetEscapeHTML(false)
+	err = encoder.Encode(&osinResponse.Output)
 	if err != nil {
 		return nil
 	}
-	return respData
+	return buffer.Bytes()
 }
 
 func (o *OAuthHandlers) notifyClientOfNewOauth(notification NewOAuthNotification) {

--- a/gateway/oauth_manager_test.go
+++ b/gateway/oauth_manager_test.go
@@ -378,14 +378,15 @@ func TestAPIClientAuthorizeToken(t *testing.T) {
 			"Content-Type": "application/x-www-form-urlencoded",
 		}
 
-		ts.Run(t, test.TestCase{
+		_, _ = ts.Run(t, test.TestCase{
 			Path:      "/APIID/tyk/oauth/authorize-client/",
 			AdminAuth: true,
 			Data:      param.Encode(),
 			Headers:   headers,
 			Method:    http.MethodPost,
 			Code:      http.StatusOK,
-			BodyMatch: `"access_token"`,
+			BodyMatch: `{"access_token":".*","expires_in":3600,"redirect_to":"http://client.oauth.com` +
+				`#access_token=.*=&expires_in=3600&token_type=bearer","token_type":"bearer"}`,
 		})
 	})
 }


### PR DESCRIPTION
- Fixes https://github.com/TykTechnologies/tyk/issues/2679