### PR TITLE
Fix/dash connection leak

### DIFF
--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -281,7 +281,19 @@ func (a APIDefinitionLoader) MakeSpec(def *apidef.APIDefinition, logger *logrus.
 
 	// Create and init the virtual Machine
 	if config.Global().EnableJSVM {
-		spec.JSVM.Init(spec, logger)
+		_, _, _, _, _, _, mwDriver := loadCustomMiddleware(spec)
+		hasVirtualEndpoint := false
+
+		for _, version := range spec.VersionData.Versions {
+			if len(version.ExtendedPaths.Virtual) > 0 {
+				hasVirtualEndpoint = true
+				break
+			}
+		}
+
+		if mwDriver == apidef.OttoDriver || hasVirtualEndpoint {
+			spec.JSVM.Init(spec, logger)
+		}
 	}
 
 	// Set up Event Handlers

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -281,7 +281,7 @@ func (a APIDefinitionLoader) MakeSpec(def *apidef.APIDefinition, logger *logrus.
 
 	// Create and init the virtual Machine
 	if config.Global().EnableJSVM {
-		mwPaths, _, _, _, _, _, mwDriver := loadCustomMiddleware(spec)
+		mwPaths, _, _, _, _, _, _ := loadCustomMiddleware(spec)
 
 		hasVirtualEndpoint := false
 
@@ -292,7 +292,7 @@ func (a APIDefinitionLoader) MakeSpec(def *apidef.APIDefinition, logger *logrus.
 			}
 		}
 
-		if (len(mwPaths) > 0 && mwDriver == apidef.OttoDriver) || hasVirtualEndpoint {
+		if spec.CustomMiddlewareBundle != "" || len(mwPaths) > 0 || hasVirtualEndpoint {
 			spec.JSVM.Init(spec, logger)
 		}
 	}

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -281,7 +281,8 @@ func (a APIDefinitionLoader) MakeSpec(def *apidef.APIDefinition, logger *logrus.
 
 	// Create and init the virtual Machine
 	if config.Global().EnableJSVM {
-		_, _, _, _, _, _, mwDriver := loadCustomMiddleware(spec)
+		mwPaths, _, _, _, _, _, mwDriver := loadCustomMiddleware(spec)
+
 		hasVirtualEndpoint := false
 
 		for _, version := range spec.VersionData.Versions {
@@ -291,7 +292,7 @@ func (a APIDefinitionLoader) MakeSpec(def *apidef.APIDefinition, logger *logrus.
 			}
 		}
 
-		if mwDriver == apidef.OttoDriver || hasVirtualEndpoint {
+		if (len(mwPaths) > 0 && mwDriver == apidef.OttoDriver) || hasVirtualEndpoint {
 			spec.JSVM.Init(spec, logger)
 		}
 	}

--- a/gateway/dashboard_register.go
+++ b/gateway/dashboard_register.go
@@ -41,21 +41,25 @@ type HTTPDashboardHandler struct {
 	heartBeatStopSentinel bool
 }
 
-func initialiseClient(timeout time.Duration) *http.Client {
-	client := &http.Client{
-		Timeout: timeout,
-	}
+var dashClient *http.Client
 
-	if config.Global().HttpServerOptions.UseSSL {
-		// Setup HTTPS client
-		tlsConfig := &tls.Config{
-			InsecureSkipVerify: config.Global().HttpServerOptions.SSLInsecureSkipVerify,
+func initialiseClient(timeout time.Duration) *http.Client {
+	if dashClient == nil {
+		dashClient = &http.Client{
+			Timeout: timeout,
 		}
 
-		client.Transport = &http.Transport{TLSClientConfig: tlsConfig}
+		if config.Global().HttpServerOptions.UseSSL {
+			// Setup HTTPS client
+			tlsConfig := &tls.Config{
+				InsecureSkipVerify: config.Global().HttpServerOptions.SSLInsecureSkipVerify,
+			}
+
+			dashClient.Transport = &http.Transport{TLSClientConfig: tlsConfig}
+		}
 	}
 
-	return client
+	return dashClient
 }
 
 func reLogin() {


### PR DESCRIPTION
JSVM now initialized ONLY if API actually uses middleware or virtual endpoint. 
Additionally HTTP client which is used to communicate with the dashboard gets re-used for all connections. 

Fix https://github.com/TykTechnologies/tyk/issues/2752
Fix https://github.com/TykTechnologies/tyk/issues/2702