### PR TITLE
Change redis client logic and deprecate hosts with addrs in redis conf

### DIFF
--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -32,6 +32,12 @@
             "null"
           ]
         },
+        "addrs": {
+          "type": [
+            "array",
+            "null"
+          ]
+        },
         "optimisation_max_active": {
           "type": "integer"
         },
@@ -1030,8 +1036,8 @@
     "enable_http_profiler": {
       "type": "boolean"
     },
-    "ssl_force_common_name_check":{
-	    "type":"boolean"
+    "ssl_force_common_name_check": {
+      "type": "boolean"
     }
   }
 }

--- a/config/config.go
+++ b/config/config.go
@@ -80,7 +80,8 @@ type StorageOptionsConf struct {
 	Type                  string            `json:"type"`
 	Host                  string            `json:"host"`
 	Port                  int               `json:"port"`
-	Hosts                 map[string]string `json:"hosts"`
+	Hosts                 map[string]string `json:"hosts"` // Deprecated: Addrs instead.
+	Addrs                 []string          `json:"addrs"`
 	Username              string            `json:"username"`
 	Password              string            `json:"password"`
 	Database              int               `json:"database"`


### PR DESCRIPTION
This PR deprecates `hosts` field in redis configuration. Instead `addrs` is defined. Example:
```
"addrs": [
"localhost:30001",
"localhost:30002",
"localhost:30003"
],
```

Also, this PR changes the redis client definition logic. The old version was defining cluster client if given address number is more than one. Otherwise, it was defining a simple redis client.
With this PR, if `enable_cluster` is `true`, the client will be automatically defined as cluster client no matter number of given addresses in config.

Fixes #2742