### PR TITLE
Add RedisSentinel client option enabled by master_name parameter

### DIFF
--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -38,6 +38,9 @@
             "null"
           ]
         },
+        "master_name": {
+          "type": "string"
+        },
         "optimisation_max_active": {
           "type": "integer"
         },

--- a/config/config.go
+++ b/config/config.go
@@ -82,6 +82,7 @@ type StorageOptionsConf struct {
 	Port                  int               `json:"port"`
 	Hosts                 map[string]string `json:"hosts"` // Deprecated: Addrs instead.
 	Addrs                 []string          `json:"addrs"`
+	MasterName            string            `json:"master_name"`
 	Username              string            `json:"username"`
 	Password              string            `json:"password"`
 	Database              int               `json:"database"`


### PR DESCRIPTION
This PR adds Redis Sentinel client option enabled by if `master_name` isn't empty.

Fixes https://github.com/TykTechnologies/tyk/issues/2769