### PR TITLE
Copy arguments to RedisCluster.GetMultiKey

### DIFF
--- a/gateway/mw_request_signing_test.go
+++ b/gateway/mw_request_signing_test.go
@@ -19,7 +19,7 @@ var algoList = [4]string{"hmac-sha1", "hmac-sha256", "hmac-sha384", "hmac-sha512
 
 func getMiddlewareChain(spec *APISpec) http.Handler {
 	remote, _ := url.Parse(TestHttpAny)
-	proxy := TykNewSingleHostReverseProxy(remote, spec)
+	proxy := TykNewSingleHostReverseProxy(remote, spec, nil)
 	proxyHandler := ProxyHandler(proxy, spec)
 	baseMid := BaseMiddleware{Spec: spec, Proxy: proxy}
 	chain := alice.New(mwList(

--- a/storage/redis_cluster.go
+++ b/storage/redis_cluster.go
@@ -359,10 +359,11 @@ func (r *RedisCluster) GetKey(keyName string) (string, error) {
 }
 
 // GetMultiKey gets multiple keys from the database
-func (r *RedisCluster) GetMultiKey(keyNames []string) ([]string, error) {
+func (r *RedisCluster) GetMultiKey(keys []string) ([]string, error) {
 	r.ensureConnection()
 	cluster := r.singleton()
-
+	keyNames := make([]string, len(keys))
+	copy(keyNames, keys)
 	for index, val := range keyNames {
 		keyNames[index] = r.fixKey(val)
 	}

--- a/storage/redis_cluster_test.go
+++ b/storage/redis_cluster_test.go
@@ -3,8 +3,6 @@ package storage
 import "testing"
 
 func TestRedisClusterGetMultiKey(t *testing.T) {
-	t.Skip()
-
 	keys := []string{"first", "second"}
 	r := RedisCluster{KeyPrefix: "test-cluster"}
 	for _, v := range keys {
@@ -19,7 +17,7 @@ func TestRedisClusterGetMultiKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	v, err := r.GetMultiKey(keys)
+	v, err := r.GetMultiKey([]string{"first", "second"})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The method was modifying original slice, this results into bugs if caller
fails to pay attention.

The test was Skipped, after enabling it it was failing because of the
above assumptions.
