### PR TITLE
Increased timeout for dashboard API loading

### DIFF
--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -346,7 +346,7 @@ func (a APIDefinitionLoader) FromDashboardService(endpoint, secret string) ([]*A
 
 	newRequest.Header.Set(headers.XTykNonce, ServiceNonce)
 
-	c := initialiseClient(120 * time.Second)
+	c := initialiseClient()
 	resp, err := c.Do(newRequest)
 	if err != nil {
 		return nil, err

--- a/gateway/dashboard_register.go
+++ b/gateway/dashboard_register.go
@@ -43,10 +43,10 @@ type HTTPDashboardHandler struct {
 
 var dashClient *http.Client
 
-func initialiseClient(timeout time.Duration) *http.Client {
+func initialiseClient() *http.Client {
 	if dashClient == nil {
 		dashClient = &http.Client{
-			Timeout: timeout,
+			Timeout: 30 * time.Second,
 		}
 
 		if config.Global().HttpServerOptions.UseSSL {
@@ -122,7 +122,7 @@ func (h *HTTPDashboardHandler) NotifyDashboardOfEvent(event interface{}) error {
 	req.Header.Set(headers.XTykNodeID, GetNodeID())
 	req.Header.Set(headers.XTykNonce, ServiceNonce)
 
-	c := initialiseClient(5 * time.Second)
+	c := initialiseClient()
 
 	resp, err := c.Do(req)
 	if err != nil {
@@ -151,7 +151,7 @@ func (h *HTTPDashboardHandler) NotifyDashboardOfEvent(event interface{}) error {
 func (h *HTTPDashboardHandler) Register() error {
 	dashLog.Info("Registering gateway node with Dashboard")
 	req := h.newRequest(h.RegistrationEndpoint)
-	c := initialiseClient(5 * time.Second)
+	c := initialiseClient()
 	resp, err := c.Do(req)
 
 	if err != nil {
@@ -193,7 +193,7 @@ func (h *HTTPDashboardHandler) StartBeating() error {
 
 	req := h.newRequest(h.HeartBeatEndpoint)
 
-	client := initialiseClient(5 * time.Second)
+	client := initialiseClient()
 
 	for !h.heartBeatStopSentinel {
 		if err := h.sendHeartBeat(req, client); err != nil {
@@ -252,7 +252,7 @@ func (h *HTTPDashboardHandler) DeRegister() error {
 	req.Header.Set(headers.XTykNodeID, GetNodeID())
 	req.Header.Set(headers.XTykNonce, ServiceNonce)
 
-	c := initialiseClient(5 * time.Second)
+	c := initialiseClient()
 	resp, err := c.Do(req)
 
 	if err != nil {

--- a/gateway/policy.go
+++ b/gateway/policy.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"time"
 
 	"github.com/TykTechnologies/tyk/rpc"
 
@@ -84,7 +83,7 @@ func LoadPoliciesFromDashboard(endpoint, secret string, allowExplicit bool) map[
 	log.WithFields(logrus.Fields{
 		"prefix": "policy",
 	}).Info("Mutex lock acquired... calling")
-	c := initialiseClient(10 * time.Second)
+	c := initialiseClient()
 
 	log.WithFields(logrus.Fields{
 		"prefix": "policy",


### PR DESCRIPTION
In 2.9.2 we started caching dashboard http client, but because of it timeout started be set to fixed 5 seconds (because first initializeClient call cache the client). Now Timeout is just set to one 30 second value, for all API calls.