### PR TITLE
Don't print host name in debugging

### DIFF
--- a/gateway/tracing.go
+++ b/gateway/tracing.go
@@ -23,6 +23,8 @@ type traceHttpRequest struct {
 
 func (tr *traceHttpRequest) toRequest() *http.Request {
 	r := httptest.NewRequest(tr.Method, tr.Path, strings.NewReader(tr.Body))
+	// It sets example.com by default. Setting it to empty will not show a value because it is not necessary.
+	r.Host = ""
 	r.Header = tr.Headers
 	ctxSetTrace(r)
 


### PR DESCRIPTION
Test server was printing Host as `example.com`. This PR makes it empty and it doesn't prints anything when it is empty.

Fixes https://github.com/TykTechnologies/tyk/issues/2775