### PR TITLE
Log when page not found

### DIFF
--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -683,6 +683,7 @@ func loadApps(specs []*APISpec) {
 
 	muxer := &proxyMux{}
 	router := mux.NewRouter()
+	router.NotFoundHandler = http.HandlerFunc(muxer.handle404)
 	loadAPIEndpoints(router)
 	muxer.setRouter(port, "", router)
 

--- a/gateway/proxy_muxer.go
+++ b/gateway/proxy_muxer.go
@@ -148,6 +148,14 @@ func (m *proxyMux) setRouter(port int, protocol string, router *mux.Router) {
 	}
 }
 
+func (m *proxyMux) handle404(w http.ResponseWriter, r *http.Request) {
+	requestMeta := fmt.Sprintf("%s %s %s", r.Method, r.URL.Path, r.Proto)
+	log.WithField("request", requestMeta).Error("404 page not found")
+
+	w.WriteHeader(http.StatusNotFound)
+	fmt.Fprintf(w, "404 page not found")
+}
+
 func (m *proxyMux) addTCPService(spec *APISpec, modifier *tcp.Modifier) {
 	hostname := spec.GlobalConfig.HostName
 	if spec.GlobalConfig.EnableCustomDomains {

--- a/gateway/proxy_muxer.go
+++ b/gateway/proxy_muxer.go
@@ -15,8 +15,8 @@ import (
 	"github.com/TykTechnologies/again"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/tcp"
-	proxyproto "github.com/pires/go-proxyproto"
-	cache "github.com/pmylund/go-cache"
+	"github.com/pires/go-proxyproto"
+	"github.com/pmylund/go-cache"
 
 	"golang.org/x/net/http2"
 
@@ -150,10 +150,10 @@ func (m *proxyMux) setRouter(port int, protocol string, router *mux.Router) {
 
 func (m *proxyMux) handle404(w http.ResponseWriter, r *http.Request) {
 	requestMeta := fmt.Sprintf("%s %s %s", r.Method, r.URL.Path, r.Proto)
-	log.WithField("request", requestMeta).Error("404 page not found")
+	log.WithField("request", requestMeta).Error(http.StatusText(http.StatusNotFound))
 
 	w.WriteHeader(http.StatusNotFound)
-	fmt.Fprintf(w, "404 page not found")
+	_, _ = fmt.Fprint(w, http.StatusText(http.StatusNotFound))
 }
 
 func (m *proxyMux) addTCPService(spec *APISpec, modifier *tcp.Modifier) {

--- a/gateway/proxy_muxer_test.go
+++ b/gateway/proxy_muxer_test.go
@@ -303,6 +303,6 @@ func TestHandle404(t *testing.T) {
 
 	_, _ = g.Run(t, []test.TestCase{
 		{Path: "/existing", Code: http.StatusOK},
-		{Path: "/nonexisting", Code: http.StatusNotFound, BodyMatch: "404 page not found"},
+		{Path: "/nonexisting", Code: http.StatusNotFound, BodyMatch: http.StatusText(http.StatusNotFound)},
 	}...)
 }

--- a/gateway/proxy_muxer_test.go
+++ b/gateway/proxy_muxer_test.go
@@ -12,6 +12,8 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/TykTechnologies/tyk/test"
+
 	"github.com/TykTechnologies/tyk/config"
 )
 
@@ -288,4 +290,19 @@ func TestHTTP_custom_ports(t *testing.T) {
 	if bs != echo {
 		t.Errorf("expected %s to %s", echo, bs)
 	}
+}
+
+func TestHandle404(t *testing.T) {
+	g := StartTest()
+	defer g.Close()
+
+	BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/existing"
+		spec.UseKeylessAccess = true
+	})
+
+	_, _ = g.Run(t, []test.TestCase{
+		{Path: "/existing", Code: http.StatusOK},
+		{Path: "/nonexisting", Code: http.StatusNotFound, BodyMatch: "404 page not found"},
+	}...)
 }


### PR DESCRIPTION
Example log:

``` 
time="Jan 13 16:07:06" level=error msg="404 page not found" request="GET /non-existing-api/get HTTP/1.1" 
```

Fixes https://github.com/TykTechnologies/tyk/issues/2468