### PR TITLE
Add disable 404 logs config option

### DIFF
--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -785,6 +785,9 @@
     "use_logstash": {
       "type": "boolean"
     },
+    "disable_404_logs": {
+      "type": "boolean"
+    },
     "use_redis_log": {
       "type": "boolean"
     },

--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -785,7 +785,7 @@
     "use_logstash": {
       "type": "boolean"
     },
-    "disable_404_logs": {
+    "track_404_logs": {
       "type": "boolean"
     },
     "use_redis_log": {

--- a/config/config.go
+++ b/config/config.go
@@ -429,7 +429,7 @@ type Config struct {
 	UseSyslog               bool           `json:"use_syslog"`
 	UseGraylog              bool           `json:"use_graylog"`
 	UseLogstash             bool           `json:"use_logstash"`
-	Disable404Logs          bool           `json:"disable_404_logs"`
+	Track404Logs            bool           `json:"track_404_logs"`
 	GraylogNetworkAddr      string         `json:"graylog_network_addr"`
 	LogstashNetworkAddr     string         `json:"logstash_network_addr"`
 	SyslogTransport         string         `json:"syslog_transport"`

--- a/config/config.go
+++ b/config/config.go
@@ -429,6 +429,7 @@ type Config struct {
 	UseSyslog               bool           `json:"use_syslog"`
 	UseGraylog              bool           `json:"use_graylog"`
 	UseLogstash             bool           `json:"use_logstash"`
+	Disable404Logs          bool           `json:"disable_404_logs"`
 	GraylogNetworkAddr      string         `json:"graylog_network_addr"`
 	LogstashNetworkAddr     string         `json:"logstash_network_addr"`
 	SyslogTransport         string         `json:"syslog_transport"`
@@ -462,7 +463,6 @@ type Config struct {
 // VaultConfig is used to configure the creation of a client
 // This is a stripped down version of the Config struct in vault's API client
 type VaultConfig struct {
-
 	// Address is the address of the Vault server. This should be a complete
 	// URL such as "http://vault.example.com".
 	Address string `json:"address"`

--- a/gateway/proxy_muxer.go
+++ b/gateway/proxy_muxer.go
@@ -15,8 +15,8 @@ import (
 	"github.com/TykTechnologies/again"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/tcp"
-	proxyproto "github.com/pires/go-proxyproto"
-	cache "github.com/pmylund/go-cache"
+	"github.com/pires/go-proxyproto"
+	"github.com/pmylund/go-cache"
 
 	"golang.org/x/net/http2"
 
@@ -149,9 +149,10 @@ func (m *proxyMux) setRouter(port int, protocol string, router *mux.Router) {
 }
 
 func (m *proxyMux) handle404(w http.ResponseWriter, r *http.Request) {
-	if !config.Global().Disable404Logs {
+	if config.Global().Track404Logs {
 		requestMeta := fmt.Sprintf("%s %s %s", r.Method, r.URL.Path, r.Proto)
-		log.WithField("request", requestMeta).Error(http.StatusText(http.StatusNotFound))
+		log.WithField("request", requestMeta).WithField("origin", r.RemoteAddr).
+			Error(http.StatusText(http.StatusNotFound))
 	}
 
 	w.WriteHeader(http.StatusNotFound)

--- a/gateway/proxy_muxer.go
+++ b/gateway/proxy_muxer.go
@@ -15,8 +15,8 @@ import (
 	"github.com/TykTechnologies/again"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/tcp"
-	"github.com/pires/go-proxyproto"
-	"github.com/pmylund/go-cache"
+	proxyproto "github.com/pires/go-proxyproto"
+	cache "github.com/pmylund/go-cache"
 
 	"golang.org/x/net/http2"
 
@@ -149,8 +149,10 @@ func (m *proxyMux) setRouter(port int, protocol string, router *mux.Router) {
 }
 
 func (m *proxyMux) handle404(w http.ResponseWriter, r *http.Request) {
-	requestMeta := fmt.Sprintf("%s %s %s", r.Method, r.URL.Path, r.Proto)
-	log.WithField("request", requestMeta).Error(http.StatusText(http.StatusNotFound))
+	if !config.Global().Disable404Logs {
+		requestMeta := fmt.Sprintf("%s %s %s", r.Method, r.URL.Path, r.Proto)
+		log.WithField("request", requestMeta).Error(http.StatusText(http.StatusNotFound))
+	}
 
 	w.WriteHeader(http.StatusNotFound)
 	_, _ = fmt.Fprint(w, http.StatusText(http.StatusNotFound))


### PR DESCRIPTION
This PR adds a new config option `track_404_logs` to track `404` logs by setting `true`.

Related to https://github.com/TykTechnologies/tyk/issues/2468