### PR TITLE
Fix plugin building

### DIFF
--- a/bin/dist_build.sh
+++ b/bin/dist_build.sh
@@ -41,7 +41,6 @@ cd $ORGDIR
 cd $cliDIR
 git checkout master
 git pull
-go get -v ./...
 gox -osarch="linux/arm64 linux/amd64 linux/386"
 
 echo "Copying CLI Build files"

--- a/bin/dist_build.sh
+++ b/bin/dist_build.sh
@@ -50,6 +50,9 @@ mv tyk-cli_linux_* $cliTmpDir/
 echo "Starting Tyk build"
 cd $SOURCEBINPATH
 
+echo "Moving vendor dir to GOPATH"
+mv vendor ${GOPATH}/src/
+
 echo "Blitzing TGZ dirs"
 for arch in ${!ARCHTGZDIRS[@]}
 do

--- a/bin/dist_build.sh
+++ b/bin/dist_build.sh
@@ -51,7 +51,7 @@ echo "Starting Tyk build"
 cd $SOURCEBINPATH
 
 echo "Moving vendor dir to GOPATH"
-mv vendor ${GOPATH}/src/
+yes | cp -r vendor ${GOPATH}/src/ && rm -rf vendor
 
 echo "Blitzing TGZ dirs"
 for arch in ${!ARCHTGZDIRS[@]}

--- a/bin/dist_build.sh
+++ b/bin/dist_build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-: ${ORGDIR:="/src/github.com/TykTechnologies"}
+: ${ORGDIR:="/go/src/github.com/TykTechnologies"}
 : ${SOURCEBINPATH:="${ORGDIR}/tyk"}
 : ${SIGNKEY:="729EA673"}
 : ${BUILDPKGS:="1"}

--- a/bin/dist_push.sh
+++ b/bin/dist_push.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-: ${ORGDIR:="/src/github.com/TykTechnologies"}
+: ${ORGDIR:="/go/src/github.com/TykTechnologies"}
 : ${SOURCEBINPATH:="${ORGDIR}/tyk"}
 : ${DEBVERS:="ubuntu/trusty ubuntu/xenial ubuntu/bionic debian/jessie debian/stretch debian/buster"}
-: ${RPMVERS:="el/6 el/7"}
+: ${RPMVERS:="el/6 el/7 el/8"}
 : ${PKGNAME:="tyk-gateway"}
 
 echo "Set version number"

--- a/images/plugin-compiler/Dockerfile
+++ b/images/plugin-compiler/Dockerfile
@@ -3,6 +3,7 @@ LABEL io.tyk.vendor="Tyk" \
       version="1.0" \
       description="Image for plugin development"
 
+ENV GOPATH=/go
 ARG TYK_GW_TAG
 ENV TYK_GW_PATH=${GOPATH}/src/github.com/TykTechnologies/tyk
 
@@ -11,7 +12,8 @@ COPY data/build.sh /build.sh
 RUN chmod +x /build.sh
 
 RUN curl -sL "https://api.github.com/repos/TykTechnologies/tyk/tarball/${TYK_GW_TAG}" | \
-    tar -C $TYK_GW_PATH --strip-components=1 -xzf -
+    tar -C $TYK_GW_PATH --strip-components=1 -xzf - 
+RUN yes | cp -r $TYK_GW_PATH/vendor $GOPATH/src && rm -rf $TYK_GW_PATH/vendor
 
 ENTRYPOINT ["/build.sh"]
 

--- a/images/plugin-compiler/data/build.sh
+++ b/images/plugin-compiler/data/build.sh
@@ -21,12 +21,8 @@ if [ -z "$plugin_name" ]; then
 fi
 
 # Handle if plugin has own vendor folder, and ignore error if not
-yes | cp -r $PLUGIN_BUILD_PATH/vendor $GOPATH/src || true
-rm -rf $PLUGIN_BUILD_PATH/vendor
-
-# Move GW vendor folder to GOPATH (same step should be made during building main binaries)
-yes | cp -r $TYK_GW_PATH/vendor $GOPATH/src
-rm -rf $TYK_GW_PATH/vendor
+yes | cp -r $PLUGIN_BUILD_PATH/vendor $GOPATH/src || true \
+        && rm -rf $PLUGIN_BUILD_PATH/vendor
 
 cd $PLUGIN_BUILD_PATH && \
     go build -buildmode=plugin -o $plugin_name


### PR DESCRIPTION
After the suggestion of keeping vendor'd code in `$GOPATH/src/vendor`, basically this PR boils down to setting GOPATH in the Dockerfile. This was the omission that took me a long time to figure out.

This has been tested end-to-end using the unstable pipeline. The commit that was tested is `dac95f7e04de2ebf63cfc15f555650153233c6dc`. Additionally, to make this reproducible, modules are not fetched and it is assumed that everything required is vendor'd. This should help reproducibility a good deal.