### PR TITLE
Use redis client  api to set expiration of keys

### DIFF
--- a/storage/redis_cluster.go
+++ b/storage/redis_cluster.go
@@ -456,20 +456,11 @@ func (r *RedisCluster) SetKey(keyName, session string, timeout int64) error {
 	//log.Debug("[STORE] Setting key: ", r.fixKey(keyName))
 
 	r.ensureConnection()
-	err := r.singleton().Set(r.fixKey(keyName), session, 0).Err()
+	err := r.singleton().Set(r.fixKey(keyName), session, time.Duration(timeout)*time.Second).Err()
 	if err != nil {
 		log.Error("Error trying to set value: ", err)
 		return err
 	}
-
-	if timeout > 0 {
-		err := r.singleton().Expire(r.fixKey(keyName), time.Duration(timeout)*time.Second).Err()
-		if err != nil {
-			log.Error("Error trying to set expiry:", err)
-			return err
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
This avoid making 2 calls to set key and expiration since redis client
api for set is

```
Set(key string, value interface{}, expiration time.Duration) *StatusCmd
```

This allows us to directly set the expiration. If timeout is 0
then expiration will be 0