### PR TITLE
Refactor loadAPIEndpoints to loadControlAPIEndpoints

### DIFF
--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -684,7 +684,7 @@ func loadApps(specs []*APISpec) {
 	muxer := &proxyMux{}
 	router := mux.NewRouter()
 	router.NotFoundHandler = http.HandlerFunc(muxer.handle404)
-	loadAPIEndpoints(router)
+	loadControlAPIEndpoints(router)
 	muxer.setRouter(port, "", router)
 
 	gs := prepareStorage()

--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -1302,7 +1302,7 @@ func BenchmarkApiReload(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		loadAPIEndpoints(nil)
+		loadControlAPIEndpoints(nil)
 		loadApps(specs)
 	}
 }

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -391,7 +391,8 @@ func controlAPICheckClientCertificate(certLevel string, next http.Handler) http.
 	})
 }
 
-func loadAPIEndpoints(muxer *mux.Router) {
+// loadControlAPIEndpoints loads the endpoints used for controlling the Gateway.
+func loadControlAPIEndpoints(muxer *mux.Router) {
 	hostname := config.Global().HostName
 	if config.Global().ControlAPIHostname != "" {
 		hostname = config.Global().ControlAPIHostname
@@ -1361,7 +1362,7 @@ func startServer() {
 	muxer := &proxyMux{}
 
 	router := mux.NewRouter()
-	loadAPIEndpoints(router)
+	loadControlAPIEndpoints(router)
 	muxer.setRouter(config.Global().ControlAPIPort, "", router)
 
 	if muxer.router(config.Global().ListenPort, "") == nil {

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -129,7 +129,7 @@ func InitTestMain(ctx context.Context, m *testing.M, genConf ...func(globalConf 
 	cli.Init(VERSION, confPaths)
 	initialiseSystem(ctx)
 	// Small part of start()
-	loadAPIEndpoints(mainRouter())
+	loadControlAPIEndpoints(mainRouter())
 	if analytics.GeoIPDB == nil {
 		panic("GeoIPDB was not initialized")
 	}


### PR DESCRIPTION
This PR renames `loadAPIEndpoints` func to `loadControlAPIEndpoints` to make the code more understandable. When you say just `API` it results in a confusion with user APIs.