### PR TITLE
Handle plugin vendor'd code

### DIFF
--- a/bin/dist_build.sh
+++ b/bin/dist_build.sh
@@ -50,7 +50,7 @@ echo "Starting Tyk build"
 cd $SOURCEBINPATH
 
 echo "Moving vendor dir to GOPATH"
-yes | cp -r vendor ${GOPATH}/src/ && rm -rf vendor
+mv vendor ${GOPATH}/src/
 
 echo "Blitzing TGZ dirs"
 for arch in ${!ARCHTGZDIRS[@]}

--- a/bin/dist_build.sh
+++ b/bin/dist_build.sh
@@ -50,7 +50,7 @@ echo "Starting Tyk build"
 cd $SOURCEBINPATH
 
 echo "Moving vendor dir to GOPATH"
-mv vendor ${GOPATH}/src/
+yes | cp -r vendor ${GOPATH}/src/ && rm -rf vendor
 
 echo "Blitzing TGZ dirs"
 for arch in ${!ARCHTGZDIRS[@]}

--- a/images/plugin-compiler/Dockerfile
+++ b/images/plugin-compiler/Dockerfile
@@ -3,11 +3,16 @@ LABEL io.tyk.vendor="Tyk" \
       version="1.0" \
       description="Image for plugin development"
 
-ENV GOPATH=/go
 ARG TYK_GW_TAG
+ENV GOPATH=/go
 ENV TYK_GW_PATH=${GOPATH}/src/github.com/TykTechnologies/tyk
+# This directory will contain the plugin source and will be
+# mounted from the host box by the user using docker volumes
+ENV PLUGIN_SOURCE_PATH=/plugin-source
+# This is the temporary path where the plugin will be built
+ENV PLUGIN_BUILD_PATH=/go/src/plugin-build
 
-RUN mkdir -p /go/src/plugin-build $TYK_GW_PATH
+RUN mkdir -p $TYK_GW_PATH $PLUGIN_SOURCE_PATH $PLUGIN_BUILD_PATH
 COPY data/build.sh /build.sh
 RUN chmod +x /build.sh
 

--- a/images/plugin-compiler/data/build.sh
+++ b/images/plugin-compiler/data/build.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
 set -xe
-# This directory will contain the plugin source and will be
-# mounted from the host box by the user using docker volumes
-PLUGIN_BUILD_PATH=/go/src/plugin-build
 
 plugin_name=$1
 
@@ -21,8 +18,10 @@ if [ -z "$plugin_name" ]; then
 fi
 
 # Handle if plugin has own vendor folder, and ignore error if not
+yes | cp -r $PLUGIN_SOURCE_PATH/* $PLUGIN_BUILD_PATH || true
 yes | cp -r $PLUGIN_BUILD_PATH/vendor $GOPATH/src || true \
         && rm -rf $PLUGIN_BUILD_PATH/vendor
 
-cd $PLUGIN_BUILD_PATH && \
-    go build -buildmode=plugin -o $plugin_name
+cd $PLUGIN_BUILD_PATH \
+    && go build -buildmode=plugin -o $plugin_name \
+    && mv $plugin_name $PLUGIN_SOURCE_PATH


### PR DESCRIPTION
- moved all env var definitions to Dockerfile
- Use /plugin-code ($PLUGIN_SOURCE_PATH) as a staging area
- $PLUGIN_BUILD_PATH is where the code is built

Needs an update to the docs for the source path.
Tested locally.