### PR TITLE
Fix cross-gateway notification validation

### DIFF
--- a/gateway/distributed_rate_limiter.go
+++ b/gateway/distributed_rate_limiter.go
@@ -83,7 +83,8 @@ func onServerStatusReceivedHandler(payload string) {
 	serverData := drl.Server{}
 	if err := json.Unmarshal([]byte(payload), &serverData); err != nil {
 		log.WithFields(logrus.Fields{
-			"prefix": "pub-sub",
+			"prefix":  "pub-sub",
+			"payload": string(payload),
 		}).Error("Failed unmarshal server data: ", err)
 		return
 	}

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -880,12 +880,18 @@ func TestManagementNodeRedisEvents(t *testing.T) {
 		msg := redis.Message{
 			Payload: `{"Command": "NoticeGatewayDRLNotification"}`,
 		}
+
+		callbackRun := false
 		shouldHandle := func(got NotificationCommand) {
+			callbackRun = true
 			if want := NoticeGatewayDRLNotification; got != want {
 				t.Fatalf("want %q, got %q", want, got)
 			}
 		}
 		handleRedisEvent(&msg, shouldHandle, nil)
+		if !callbackRun {
+			t.Fatalf("Should run callback")
+		}
 		globalConf.ManagementNode = true
 		config.SetGlobal(globalConf)
 		notHandle := func(got NotificationCommand) {
@@ -908,13 +914,18 @@ func TestManagementNodeRedisEvents(t *testing.T) {
 		payload, _ := json.Marshal(n)
 		msg.Payload = string(payload)
 
+		callbackRun := false
 		shouldHandle := func(got NotificationCommand) {
+			callbackRun = true
 			if want := NoticeGroupReload; got != want {
 				t.Fatalf("want %q, got %q", want, got)
 			}
 		}
 
 		handleRedisEvent(&msg, shouldHandle, nil)
+		if !callbackRun {
+			t.Fatalf("Should run callback")
+		}
 
 		n.Signature = "wrong"
 		payload, _ = json.Marshal(n)

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -875,21 +875,60 @@ func TestManagementNodeRedisEvents(t *testing.T) {
 	globalConf := config.Global()
 	globalConf.ManagementNode = false
 	config.SetGlobal(globalConf)
-	msg := redis.Message{
-		Payload: `{"Command": "NoticeGatewayDRLNotification"}`,
-	}
-	shouldHandle := func(got NotificationCommand) {
-		if want := NoticeGatewayDRLNotification; got != want {
-			t.Fatalf("want %q, got %q", want, got)
+
+	t.Run("Without signing:", func(t *testing.T) {
+		msg := redis.Message{
+			Payload: `{"Command": "NoticeGatewayDRLNotification"}`,
 		}
-	}
-	handleRedisEvent(&msg, shouldHandle, nil)
-	globalConf.ManagementNode = true
-	config.SetGlobal(globalConf)
-	notHandle := func(got NotificationCommand) {
-		t.Fatalf("should have not handled redis event")
-	}
-	handleRedisEvent(msg, notHandle, nil)
+		shouldHandle := func(got NotificationCommand) {
+			if want := NoticeGatewayDRLNotification; got != want {
+				t.Fatalf("want %q, got %q", want, got)
+			}
+		}
+		handleRedisEvent(&msg, shouldHandle, nil)
+		globalConf.ManagementNode = true
+		config.SetGlobal(globalConf)
+		notHandle := func(got NotificationCommand) {
+			t.Fatalf("should have not handled redis event")
+		}
+		handleRedisEvent(msg, notHandle, nil)
+	})
+
+	t.Run("With signature", func(t *testing.T) {
+		globalConf := config.Global()
+		globalConf.AllowInsecureConfigs = false
+		config.SetGlobal(globalConf)
+
+		n := Notification{
+			Command: NoticeGroupReload,
+			Payload: string("test"),
+		}
+		n.Sign()
+		msg := redis.Message{}
+		payload, _ := json.Marshal(n)
+		msg.Payload = string(payload)
+
+		shouldHandle := func(got NotificationCommand) {
+			if want := NoticeGroupReload; got != want {
+				t.Fatalf("want %q, got %q", want, got)
+			}
+		}
+
+		handleRedisEvent(&msg, shouldHandle, nil)
+
+		n.Signature = "wrong"
+		payload, _ = json.Marshal(n)
+		msg.Payload = string(payload)
+
+		valid := false
+		shouldFail := func(got NotificationCommand) {
+			valid = true
+		}
+		handleRedisEvent(&msg, shouldFail, nil)
+		if valid {
+			t.Fatalf("Should fail validation")
+		}
+	})
 }
 
 func TestListenPathTykPrefix(t *testing.T) {
@@ -1237,7 +1276,7 @@ func TestCacheWithAdvanceUrlRewrite(t *testing.T) {
 							On: "all",
 							Options: apidef.RoutingTriggerOptions{
 								HeaderMatches: map[string]apidef.StringRegexMap{
-									"rewritePath": apidef.StringRegexMap{
+									"rewritePath": {
 										MatchPattern: "newpath",
 									},
 								},

--- a/gateway/redis_signals.go
+++ b/gateway/redis_signals.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"crypto"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -41,11 +42,11 @@ type Notification struct {
 	Command       NotificationCommand `json:"command"`
 	Payload       string              `json:"payload"`
 	Signature     string              `json:"signature"`
-	SignatureAlgo string              `json:"algorithm"`
+	SignatureAlgo crypto.Hash         `json:"algorithm"`
 }
 
 func (n *Notification) Sign() {
-	n.SignatureAlgo = "secret-sha256"
+	n.SignatureAlgo = crypto.SHA256
 	hash := sha256.Sum256([]byte(string(n.Command) + n.Payload + config.Global().NodeSecret))
 	n.Signature = hex.EncodeToString(hash[:])
 }
@@ -146,7 +147,7 @@ func isPayloadSignatureValid(notification Notification) bool {
 	}
 
 	switch notification.SignatureAlgo {
-	case "secret-sha256":
+	case crypto.SHA256:
 		hash := sha256.Sum256([]byte(string(notification.Command) + notification.Payload + config.Global().NodeSecret))
 		expectedSignature := hex.EncodeToString(hash[:])
 

--- a/gateway/redis_signals.go
+++ b/gateway/redis_signals.go
@@ -1,7 +1,9 @@
 package gateway
 
 import (
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"strconv"
 	"strings"
@@ -36,9 +38,16 @@ const (
 
 // Notification is a type that encodes a message published to a pub sub channel (shared between implementations)
 type Notification struct {
-	Command   NotificationCommand `json:"command"`
-	Payload   string              `json:"payload"`
-	Signature string              `json:"signature"`
+	Command       NotificationCommand `json:"command"`
+	Payload       string              `json:"payload"`
+	Signature     string              `json:"signature"`
+	SignatureAlgo string              `json:"algorithm"`
+}
+
+func (n *Notification) Sign() {
+	n.SignatureAlgo = "secret-sha256"
+	hash := sha256.Sum256([]byte(string(n.Command) + n.Payload + config.Global().NodeSecret))
+	n.Signature = hex.EncodeToString(hash[:])
 }
 
 func startPubSubLoop() {
@@ -132,45 +141,51 @@ var redisInsecureWarn sync.Once
 var notificationVerifier goverify.Verifier
 
 func isPayloadSignatureValid(notification Notification) bool {
-
-	switch notification.Command {
-	case NoticeGatewayDRLNotification, NoticeGatewayLENotification:
-		// Gateway to gateway
+	if config.Global().AllowInsecureConfigs {
 		return true
 	}
 
-	if notification.Signature == "" && config.Global().AllowInsecureConfigs {
-		return true
-	}
+	switch notification.SignatureAlgo {
+	case "secret-sha256":
+		hash := sha256.Sum256([]byte(string(notification.Command) + notification.Payload + config.Global().NodeSecret))
+		expectedSignature := hex.EncodeToString(hash[:])
 
-	if config.Global().PublicKeyPath != "" && notificationVerifier == nil {
-		var err error
-
-		notificationVerifier, err = goverify.LoadPublicKeyFromFile(config.Global().PublicKeyPath)
-		if err != nil {
-
-			pubSubLog.Error("Notification signer: Failed loading private key from path: ", err)
+		if expectedSignature == notification.Signature {
+			return true
+		} else {
+			pubSubLog.Error("Notification signer: Failed verifying pub sub signature using node_secret: ")
 			return false
 		}
-	}
+	default:
+		if config.Global().PublicKeyPath != "" && notificationVerifier == nil {
+			var err error
 
-	if notificationVerifier != nil {
+			notificationVerifier, err = goverify.LoadPublicKeyFromFile(config.Global().PublicKeyPath)
+			if err != nil {
 
-		signed, err := base64.StdEncoding.DecodeString(notification.Signature)
-		if err != nil {
-
-			pubSubLog.Error("Failed to decode signature: ", err)
-			return false
+				pubSubLog.Error("Notification signer: Failed loading private key from path: ", err)
+				return false
+			}
 		}
 
-		if err := notificationVerifier.Verify([]byte(notification.Payload), signed); err != nil {
+		if notificationVerifier != nil {
 
-			pubSubLog.Error("Could not verify notification: ", err, ": ", notification)
+			signed, err := base64.StdEncoding.DecodeString(notification.Signature)
+			if err != nil {
 
-			return false
+				pubSubLog.Error("Failed to decode signature: ", err)
+				return false
+			}
+
+			if err := notificationVerifier.Verify([]byte(notification.Payload), signed); err != nil {
+
+				pubSubLog.Error("Could not verify notification: ", err, ": ", notification)
+
+				return false
+			}
+
+			return true
 		}
-
-		return true
 	}
 
 	return false
@@ -184,6 +199,9 @@ type RedisNotifier struct {
 
 // Notify will send a notification to a channel
 func (r *RedisNotifier) Notify(notif interface{}) bool {
+	if n, ok := notif.(Notification); ok {
+		n.Sign()
+	}
 
 	toSend, err := json.Marshal(notif)
 

--- a/gateway/redis_signals.go
+++ b/gateway/redis_signals.go
@@ -202,6 +202,7 @@ type RedisNotifier struct {
 func (r *RedisNotifier) Notify(notif interface{}) bool {
 	if n, ok := notif.(Notification); ok {
 		n.Sign()
+		notif = n
 	}
 
 	toSend, err := json.Marshal(notif)


### PR DESCRIPTION
Alternative approach to https://github.com/TykTechnologies/tyk/pull/2819 which does not require new config value.
Gateways now sign their messages using `node_secret` value.
Added new "SignatureAlgo" notification object field, and if it set to `sha256`, it generates SHA256(type+message+secret) hash, and validates it the same way.

Fix https://github.com/TykTechnologies/tyk/issues/2762