### PR TITLE
Fix mixed TLS auth

### DIFF
--- a/gateway/cert.go
+++ b/gateway/cert.go
@@ -8,11 +8,13 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/TykTechnologies/tyk/certs"
 	"github.com/TykTechnologies/tyk/config"
 
 	"github.com/gorilla/mux"
+	cache "github.com/pmylund/go-cache"
 )
 
 type APICertificateStatusMessage struct {
@@ -261,8 +263,9 @@ func dummyGetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
 	return nil, nil
 }
 
-func getTLSConfigForClient(baseConfig *tls.Config, listenPort int) func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+var tlsConfigCache = cache.New(60*time.Second, 60*time.Minute)
 
+func getTLSConfigForClient(baseConfig *tls.Config, listenPort int) func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
 	// Supporting legacy certificate configuration
 	serverCerts := []tls.Certificate{}
 	certNameMap := map[string]*tls.Certificate{}
@@ -291,6 +294,10 @@ func getTLSConfigForClient(baseConfig *tls.Config, listenPort int) func(hello *t
 	}
 
 	return func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+		if config, found := tlsConfigCache.Get(hello.ServerName); found {
+			return config.(*tls.Config), nil
+		}
+
 		newConfig := baseConfig.Clone()
 
 		isControlAPI := (listenPort != 0 && config.Global().ControlAPIPort == listenPort) || (config.Global().ControlAPIHostname == hello.ServerName)
@@ -299,14 +306,47 @@ func getTLSConfigForClient(baseConfig *tls.Config, listenPort int) func(hello *t
 			newConfig.ClientAuth = tls.RequireAndVerifyClientCert
 			newConfig.ClientCAs = CertificateManager.CertPool(config.Global().Security.Certificates.ControlAPI)
 
+			tlsConfigCache.Set(hello.ServerName, newConfig, cache.DefaultExpiration)
 			return newConfig, nil
 		}
 
 		apisMu.RLock()
 		defer apisMu.RUnlock()
 
-		// Dynamically add API specific certificates
+		newConfig.ClientCAs = x509.NewCertPool()
+
+		domainRequireCert := map[string]tls.ClientAuthType{}
 		for _, spec := range apiSpecs {
+			// If there are multiple APIs on the same domain, and not all of them use mutual TLS auth
+			if domainRequireCert[spec.Domain] != 0 && !spec.UseMutualTLSAuth {
+				domainRequireCert[spec.Domain] = tls.RequestClientCert
+			}
+
+			if spec.UseMutualTLSAuth {
+				// Require verification only if there is a single known domain for TLS auth, otherwise use previous value
+				if domainRequireCert[spec.Domain] == 0 {
+					domainRequireCert[spec.Domain] = tls.RequireAndVerifyClientCert
+				}
+
+				// If current domain match or empty, whitelist client certificates
+				if spec.Domain == "" || spec.Domain == hello.ServerName {
+					certIDs := append(spec.ClientCertificates, config.Global().Security.Certificates.API...)
+
+					for _, cert := range CertificateManager.List(certIDs, certs.CertificatePublic) {
+						if cert != nil {
+							newConfig.ClientCAs.AddCert(cert.Leaf)
+						}
+					}
+				}
+			}
+
+			// Dynamic certificate check required, falling back to HTTP level check
+			// TODO: Change to VerifyPeerCertificate hook instead, when possible
+			if spec.Auth.UseCertificate && domainRequireCert[spec.Domain] < tls.RequestClientCert {
+				domainRequireCert[spec.Domain] = tls.RequestClientCert
+			}
+
+			// Dynamically add API specific certificates
 			if len(spec.Certificates) != 0 {
 				for _, cert := range CertificateManager.List(spec.Certificates, certs.CertificatePrivate) {
 					if cert == nil {
@@ -326,33 +366,11 @@ func getTLSConfigForClient(baseConfig *tls.Config, listenPort int) func(hello *t
 			}
 		}
 
-		for _, spec := range apiSpecs {
-			// If there is mutual TLS already found, in previous loop cycle
-			// And if there is another API on the same domain, we have a conflict
-			// We can't uniquely identify by domain API anymore
-			// So we going just ask certificate and fallback to HTTP level check
-			if newConfig.ClientAuth == tls.RequireAndVerifyClientCert && spec.Domain != "" && spec.Domain == hello.ServerName {
-				newConfig.ClientAuth = tls.RequestClientCert
-				break
-			}
-			if spec.UseMutualTLSAuth && spec.Domain != "" && spec.Domain == hello.ServerName {
-				newConfig.ClientAuth = tls.RequireAndVerifyClientCert
-				certIDs := append(spec.ClientCertificates, config.Global().Security.Certificates.API...)
-				newConfig.ClientCAs = CertificateManager.CertPool(certIDs)
-			}
-		}
+		newConfig.ClientAuth = domainRequireCert[hello.ServerName]
 
-		// No mutual tls APIs with matched domain found
-		// Check if one of APIs without domain, require asking client cert
-		if newConfig.ClientAuth == tls.NoClientCert {
-			for _, spec := range apiSpecs {
-				if spec.Auth.UseCertificate || (spec.Domain == "" && spec.UseMutualTLSAuth) {
-					newConfig.ClientAuth = tls.RequestClientCert
-					break
-				}
-			}
-		}
+		log.Error("ASDASDASD:", domainRequireCert)
 
+		tlsConfigCache.Set(hello.ServerName, newConfig, cache.DefaultExpiration)
 		return newConfig, nil
 	}
 }

--- a/gateway/cert.go
+++ b/gateway/cert.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -293,8 +294,10 @@ func getTLSConfigForClient(baseConfig *tls.Config, listenPort int) func(hello *t
 		baseConfig.NameToCertificate[name] = cert
 	}
 
+	listenPortStr := strconv.Itoa(listenPort)
+
 	return func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
-		if config, found := tlsConfigCache.Get(hello.ServerName); found {
+		if config, found := tlsConfigCache.Get(hello.ServerName + listenPortStr); found {
 			return config.(*tls.Config), nil
 		}
 
@@ -368,9 +371,7 @@ func getTLSConfigForClient(baseConfig *tls.Config, listenPort int) func(hello *t
 
 		newConfig.ClientAuth = domainRequireCert[hello.ServerName]
 
-		log.Error("ASDASDASD:", domainRequireCert)
-
-		tlsConfigCache.Set(hello.ServerName, newConfig, cache.DefaultExpiration)
+		tlsConfigCache.Set(hello.ServerName+listenPortStr, newConfig, cache.DefaultExpiration)
 		return newConfig, nil
 	}
 }

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -319,6 +319,9 @@ func syncAPISpecs() (int, error) {
 		filter = append(filter, v)
 	}
 	apiSpecs = filter
+
+	tlsConfigCache.Flush()
+
 	return len(apiSpecs), nil
 }
 


### PR DESCRIPTION
Fixed issue when both APIs have the same domain and mutual TLS enabled.
Added a lot of tests to cover new cases.

Additionally added caching layer, which should significantly speed up TLS handshake, when there are a lot of APIs or certificates used.

Fix https://github.com/TykTechnologies/tyk/issues/2625