### PR TITLE
fix use of singleflight in  RedisCacheMiddleware

### DIFF
--- a/gateway/mw_redis_cache.go
+++ b/gateway/mw_redis_cache.go
@@ -180,7 +180,6 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 		log.Debug("Error creating checksum. Skipping cache check")
 		errCreatingChecksum = true
 	} else {
-		retBlob, err = m.CacheStore.GetKey(key)
 		v, sfErr, _ := m.singleFlight.Do(key, func() (interface{}, error) {
 			return m.CacheStore.GetKey(key)
 		})


### PR DESCRIPTION
`m.CacheStore.GetKey(key)` is called under singleFlight. This remove
duplicate call of `m.CacheStore.GetKey(key)`  which nullifies the purpose of singleflight.

