### PR TITLE
Fix when order of APIs breaks mutual TLS

### DIFF
--- a/gateway/cert.go
+++ b/gateway/cert.go
@@ -320,15 +320,15 @@ func getTLSConfigForClient(baseConfig *tls.Config, listenPort int) func(hello *t
 
 		domainRequireCert := map[string]tls.ClientAuthType{}
 		for _, spec := range apiSpecs {
-			// If there are multiple APIs on the same domain, and not all of them use mutual TLS auth
-			if domainRequireCert[spec.Domain] != 0 && !spec.UseMutualTLSAuth {
-				domainRequireCert[spec.Domain] = tls.RequestClientCert
-			}
 
-			if spec.UseMutualTLSAuth {
-				// Require verification only if there is a single known domain for TLS auth, otherwise use previous value
+			switch {
+			case spec.UseMutualTLSAuth:
 				if domainRequireCert[spec.Domain] == 0 {
+					// Require verification only if there is a single known domain for TLS auth, otherwise use previous value
 					domainRequireCert[spec.Domain] = tls.RequireAndVerifyClientCert
+				} else if domainRequireCert[spec.Domain] != tls.RequireAndVerifyClientCert {
+					// If we have another API on this domain, which is not mutual tls enabled, just ask for cert
+					domainRequireCert[spec.Domain] = tls.RequestClientCert
 				}
 
 				// If current domain match or empty, whitelist client certificates
@@ -341,12 +341,19 @@ func getTLSConfigForClient(baseConfig *tls.Config, listenPort int) func(hello *t
 						}
 					}
 				}
-			}
-
-			// Dynamic certificate check required, falling back to HTTP level check
-			// TODO: Change to VerifyPeerCertificate hook instead, when possible
-			if spec.Auth.UseCertificate && domainRequireCert[spec.Domain] < tls.RequestClientCert {
-				domainRequireCert[spec.Domain] = tls.RequestClientCert
+			case spec.Auth.UseCertificate:
+				// Dynamic certificate check required, falling back to HTTP level check
+				// TODO: Change to VerifyPeerCertificate hook instead, when possible
+				if domainRequireCert[spec.Domain] < tls.RequestClientCert {
+					domainRequireCert[spec.Domain] = tls.RequestClientCert
+				}
+			default:
+				// For APIs which do not use certificates, indicate that there is API for such domain already
+				if domainRequireCert[spec.Domain] == 0 {
+					domainRequireCert[spec.Domain] = -1
+				} else {
+					domainRequireCert[spec.Domain] = tls.RequestClientCert
+				}
 			}
 
 			// Dynamically add API specific certificates
@@ -368,6 +375,8 @@ func getTLSConfigForClient(baseConfig *tls.Config, listenPort int) func(hello *t
 				}
 			}
 		}
+
+		log.Error("AAAAAAAA!!!!!", domainRequireCert)
 
 		newConfig.ClientAuth = domainRequireCert[hello.ServerName]
 

--- a/gateway/cert.go
+++ b/gateway/cert.go
@@ -376,8 +376,6 @@ func getTLSConfigForClient(baseConfig *tls.Config, listenPort int) func(hello *t
 			}
 		}
 
-		log.Error("AAAAAAAA!!!!!", domainRequireCert)
-
 		newConfig.ClientAuth = domainRequireCert[hello.ServerName]
 
 		tlsConfigCache.Set(hello.ServerName+listenPortStr, newConfig, cache.DefaultExpiration)

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -341,13 +341,13 @@ func TestAPIMutualTLS(t *testing.T) {
 			loadAPIS := func(certs ...string) {
 				BuildAndLoadAPI(
 					func(spec *APISpec) {
-						spec.Proxy.ListenPath = "/with_mutual"
-						spec.UseMutualTLSAuth = true
-						spec.ClientCertificates = certs
+						spec.Proxy.ListenPath = "/without_mutual"
 						spec.Domain = domain
 					},
 					func(spec *APISpec) {
-						spec.Proxy.ListenPath = "/without_mutual"
+						spec.Proxy.ListenPath = "/with_mutual"
+						spec.UseMutualTLSAuth = true
+						spec.ClientCertificates = certs
 						spec.Domain = domain
 					},
 				)


### PR DESCRIPTION
Now order of APIs does not matter.

Fix https://github.com/TykTechnologies/tyk/issues/2625