### PR TITLE
Added option to set custom signature header

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -514,12 +514,13 @@ type BundleManifest struct {
 }
 
 type RequestSigningMeta struct {
-	IsEnabled     bool     `bson:"is_enabled" json:"is_enabled"`
-	Secret        string   `bson:"secret" json:"secret"`
-	KeyId         string   `bson:"key_id" json:"key_id"`
-	Algorithm     string   `bson:"algorithm" json:"algorithm"`
-	HeaderList    []string `bson:"header_list" json:"header_list"`
-	CertificateId string   `bson:"certificate_id" json:"certificate_id"`
+	IsEnabled             bool     `bson:"is_enabled" json:"is_enabled"`
+	Secret                string   `bson:"secret" json:"secret"`
+	KeyId                 string   `bson:"key_id" json:"key_id"`
+	Algorithm             string   `bson:"algorithm" json:"algorithm"`
+	HeaderList            []string `bson:"header_list" json:"header_list"`
+	CertificateId         string   `bson:"certificate_id" json:"certificate_id"`
+	CustomSignatureHeader string   `bson:"custom_signature_header" json:"custom_signature_header"`
 }
 
 // Clean will URL encode map[string]struct variables for saving

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -514,13 +514,13 @@ type BundleManifest struct {
 }
 
 type RequestSigningMeta struct {
-	IsEnabled             bool     `bson:"is_enabled" json:"is_enabled"`
-	Secret                string   `bson:"secret" json:"secret"`
-	KeyId                 string   `bson:"key_id" json:"key_id"`
-	Algorithm             string   `bson:"algorithm" json:"algorithm"`
-	HeaderList            []string `bson:"header_list" json:"header_list"`
-	CertificateId         string   `bson:"certificate_id" json:"certificate_id"`
-	CustomSignatureHeader string   `bson:"custom_signature_header" json:"custom_signature_header"`
+	IsEnabled       bool     `bson:"is_enabled" json:"is_enabled"`
+	Secret          string   `bson:"secret" json:"secret"`
+	KeyId           string   `bson:"key_id" json:"key_id"`
+	Algorithm       string   `bson:"algorithm" json:"algorithm"`
+	HeaderList      []string `bson:"header_list" json:"header_list"`
+	CertificateId   string   `bson:"certificate_id" json:"certificate_id"`
+	SignatureHeader string   `bson:"signature_header" json:"signature_header"`
 }
 
 // Clean will URL encode map[string]struct variables for saving

--- a/gateway/mw_request_signing.go
+++ b/gateway/mw_request_signing.go
@@ -142,8 +142,13 @@ func (s *RequestSigning) ProcessRequest(w http.ResponseWriter, r *http.Request, 
 	//Append signature
 	authHeader += "signature=\"" + encodedSignature + "\""
 
-	r.Header.Set("Authorization", authHeader)
-	log.Debug("Setting Authorization headers as =", authHeader)
+	if s.Spec.RequestSigning.CustomSignatureHeader != "" {
+		r.Header.Set(s.Spec.RequestSigning.CustomSignatureHeader, authHeader)
+		log.Debugf("Setting %s headers as =%s", s.Spec.RequestSigning.CustomSignatureHeader, authHeader)
+	} else {
+		r.Header.Set("Authorization", authHeader)
+		log.Debug("Setting Authorization headers as =", authHeader)
+	}
 
 	return nil, http.StatusOK
 }

--- a/gateway/mw_request_signing.go
+++ b/gateway/mw_request_signing.go
@@ -142,9 +142,9 @@ func (s *RequestSigning) ProcessRequest(w http.ResponseWriter, r *http.Request, 
 	//Append signature
 	authHeader += "signature=\"" + encodedSignature + "\""
 
-	if s.Spec.RequestSigning.CustomSignatureHeader != "" {
-		r.Header.Set(s.Spec.RequestSigning.CustomSignatureHeader, authHeader)
-		log.Debugf("Setting %s headers as =%s", s.Spec.RequestSigning.CustomSignatureHeader, authHeader)
+	if s.Spec.RequestSigning.SignatureHeader != "" {
+		r.Header.Set(s.Spec.RequestSigning.SignatureHeader, authHeader)
+		log.Debugf("Setting %s headers as =%s", s.Spec.RequestSigning.SignatureHeader, authHeader)
 	} else {
 		r.Header.Set("Authorization", authHeader)
 		log.Debug("Setting Authorization headers as =", authHeader)

--- a/gateway/mw_request_signing_test.go
+++ b/gateway/mw_request_signing_test.go
@@ -178,7 +178,7 @@ func TestHMACRequestSigning(t *testing.T) {
 			AuthHeaderName: "something",
 		}
 
-		api.RequestSigning.CustomSignatureHeader = "something"
+		api.RequestSigning.SignatureHeader = "something"
 
 		recorder := httptest.NewRecorder()
 		chain := getMiddlewareChain(api)
@@ -306,7 +306,7 @@ func TestRSARequestSigning(t *testing.T) {
 			AuthHeaderName: "something",
 		}
 
-		api.RequestSigning.CustomSignatureHeader = "something"
+		api.RequestSigning.SignatureHeader = "something"
 
 		req := TestReq(t, "get", "/test/get", nil)
 

--- a/gateway/mw_request_signing_test.go
+++ b/gateway/mw_request_signing_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/justinas/alice"
 
+	"github.com/TykTechnologies/tyk/apidef"
+
 	"github.com/TykTechnologies/tyk/user"
 )
 
@@ -163,6 +165,31 @@ func TestHMACRequestSigning(t *testing.T) {
 			t.Error("Expected status code 400 got ", recorder.Code)
 		}
 	})
+
+	t.Run("Custom Signature header", func(t *testing.T) {
+		algo := "hmac-sha256"
+
+		sessionKey := generateSession(algo, secret)
+		specs := generateSpec(algo, secret, sessionKey, nil)
+		api := specs[0]
+
+		api.AuthConfigs = make(map[string]apidef.AuthConfig)
+		api.AuthConfigs["hmac"] = apidef.AuthConfig{
+			AuthHeaderName: "something",
+		}
+
+		api.RequestSigning.CustomSignatureHeader = "something"
+
+		recorder := httptest.NewRecorder()
+		chain := getMiddlewareChain(api)
+
+		req := TestReq(t, "get", "/test/get", nil)
+		chain.ServeHTTP(recorder, req)
+
+		if recorder.Code != 200 {
+			t.Error("HMAC request signing failed with error:", recorder.Body.String())
+		}
+	})
 }
 
 func TestRSARequestSigning(t *testing.T) {
@@ -255,6 +282,31 @@ func TestRSARequestSigning(t *testing.T) {
 
 		sessionKey := generateSession(algo, pubCertId)
 		specs := generateSpec(algo, privCertId, sessionKey, headerList)
+
+		req := TestReq(t, "get", "/test/get", nil)
+
+		recorder := httptest.NewRecorder()
+		chain := getMiddlewareChain(specs[0])
+		chain.ServeHTTP(recorder, req)
+
+		if recorder.Code != 200 {
+			t.Error("RSA request signing failed with error ", recorder.Body.String())
+		}
+	})
+
+	t.Run("Custom Signature header", func(t *testing.T) {
+		algo := "rsa-sha256"
+
+		sessionKey := generateSession(algo, pubCertId)
+		specs := generateSpec(algo, privCertId, sessionKey, nil)
+
+		api := specs[0]
+		api.AuthConfigs = make(map[string]apidef.AuthConfig)
+		api.AuthConfigs["hmac"] = apidef.AuthConfig{
+			AuthHeaderName: "something",
+		}
+
+		api.RequestSigning.CustomSignatureHeader = "something"
 
 		req := TestReq(t, "get", "/test/get", nil)
 


### PR DESCRIPTION
Fixes #2849 

Added new config option `signature_header` in request signing middleware. If set, instead of setting Authorization header, it's value will be used for setting signature header.