### PR TITLE
Fix request signing middleware

### DIFF
--- a/gateway/mw_http_signature_validation.go
+++ b/gateway/mw_http_signature_validation.go
@@ -158,7 +158,13 @@ func (hm *HTTPSignatureValidationMiddleware) ProcessRequest(w http.ResponseWrite
 		}
 	} else {
 		// Create a signed string with the secret
-		encodedSignature := generateHMACEncodedSignature(signatureString, secret, fieldValues.Algorthm)
+		encodedSignature, err := generateHMACEncodedSignature(signatureString, secret, fieldValues.Algorthm)
+		if err != nil {
+			logger.WithFields(logrus.Fields{
+				"error": err,
+			}).Error("Failed to validate signature")
+			return hm.authorizationError(r)
+		}
 
 		// Compare
 		matchPass = encodedSignature == fieldValues.Signature
@@ -437,7 +443,11 @@ func generateHMACSignatureStringFromRequest(r *http.Request, headers []string, p
 	return signatureString, nil
 }
 
-func generateHMACEncodedSignature(signatureString, secret string, algorithm string) string {
+func generateHMACEncodedSignature(signatureString, secret string, algorithm string) (string, error) {
+	if secret == "" {
+		return "", errors.New("Hmac secret is empty")
+	}
+
 	key := []byte(secret)
 
 	var hashFunction func() hash.Hash
@@ -456,7 +466,7 @@ func generateHMACEncodedSignature(signatureString, secret string, algorithm stri
 	h := hmac.New(hashFunction, key)
 	h.Write([]byte(signatureString))
 	encodedString := base64.StdEncoding.EncodeToString(h.Sum(nil))
-	return url.QueryEscape(encodedString)
+	return url.QueryEscape(encodedString), nil
 }
 
 func validateRSAEncodedSignature(signatureString string, publicKey *rsa.PublicKey, algorithm string, signature string) (bool, error) {

--- a/gateway/mw_http_signature_validation.go
+++ b/gateway/mw_http_signature_validation.go
@@ -73,7 +73,7 @@ func (hm *HTTPSignatureValidationMiddleware) ProcessRequest(w http.ResponseWrite
 	}
 
 	// Generate a signature string
-	signatureString, err := generateHMACSignatureStringFromRequest(r, fieldValues.Headers)
+	signatureString, err := generateHMACSignatureStringFromRequest(r, fieldValues.Headers, r.URL.Path)
 
 	if err != nil {
 		logger.WithError(err).WithField("signature_string", signatureString).Error("Signature string generation failed")
@@ -412,12 +412,12 @@ func getFieldValues(authHeader string) (*HMACFieldValues, error) {
 }
 
 // "Signature keyId="9876",algorithm="hmac-sha1",headers="x-test x-test-2",signature="queryEscape(base64(sig))"")
-func generateHMACSignatureStringFromRequest(r *http.Request, headers []string) (string, error) {
+func generateHMACSignatureStringFromRequest(r *http.Request, headers []string, path string) (string, error) {
 	signatureString := ""
 	for i, header := range headers {
 		loweredHeader := strings.TrimSpace(strings.ToLower(header))
 		if loweredHeader == "(request-target)" {
-			requestHeaderField := "(request-target): " + strings.ToLower(r.Method) + " " + r.URL.Path
+			requestHeaderField := "(request-target): " + strings.ToLower(r.Method) + " " + path
 			signatureString += requestHeaderField
 		} else {
 			// exception for dates and .Net oddness

--- a/gateway/mw_request_signing.go
+++ b/gateway/mw_request_signing.go
@@ -101,7 +101,12 @@ func (s *RequestSigning) ProcessRequest(w http.ResponseWriter, r *http.Request, 
 	}
 
 	headers := generateHeaderList(r, s.Spec.RequestSigning.HeaderList)
-	signatureString, err := generateHMACSignatureStringFromRequest(r, headers)
+
+	path := r.URL.Path
+	if s.Spec.Proxy.StripListenPath {
+		path = s.Spec.StripListenPath(r, r.URL.Path)
+	}
+	signatureString, err := generateHMACSignatureStringFromRequest(r, headers, path)
 	if err != nil {
 		log.Error(err)
 		return err, http.StatusInternalServerError

--- a/gateway/mw_request_signing_test.go
+++ b/gateway/mw_request_signing_test.go
@@ -10,11 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/justinas/alice"
-
 	"github.com/TykTechnologies/tyk/apidef"
-
+	"github.com/TykTechnologies/tyk/test"
 	"github.com/TykTechnologies/tyk/user"
+	"github.com/justinas/alice"
 )
 
 var algoList = [4]string{"hmac-sha1", "hmac-sha256", "hmac-sha384", "hmac-sha512"}
@@ -43,8 +42,6 @@ func generateSession(algo, data string) string {
 			s.HmacSecret = data
 			s.HMACEnabled = true
 		}
-
-		s.AccessRights = map[string]user.AccessDefinition{"protected": {APIID: "protected", Versions: []string{"v1"}}}
 	})
 
 	return sessionKey
@@ -93,6 +90,42 @@ func TestHMACRequestSigning(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("Empty secret", func(t *testing.T) {
+		algo := "hmac-sha256"
+		secret := ""
+
+		sessionKey := generateSession(algo, secret)
+		specs := generateSpec(algo, secret, sessionKey, nil)
+
+		recorder := httptest.NewRecorder()
+		chain := getMiddlewareChain(specs[0])
+
+		req := TestReq(t, "get", "/test/get", nil)
+		chain.ServeHTTP(recorder, req)
+
+		if recorder.Code != 500 {
+			t.Error("Expected status code 500 got ", recorder.Code)
+		}
+	})
+
+	t.Run("Invalid secret", func(t *testing.T) {
+		algo := "hmac-sha256"
+		secret := "12345"
+
+		sessionKey := generateSession(algo, secret)
+		specs := generateSpec(algo, "789", sessionKey, nil)
+
+		recorder := httptest.NewRecorder()
+		chain := getMiddlewareChain(specs[0])
+
+		req := TestReq(t, "get", "/test/get", nil)
+		chain.ServeHTTP(recorder, req)
+
+		if recorder.Code != 400 {
+			t.Error("Expected status code 400 got ", recorder.Code)
+		}
+	})
 
 	t.Run("Valid Custom headerList", func(t *testing.T) {
 		algo := "hmac-sha1"
@@ -219,6 +252,36 @@ func TestRSARequestSigning(t *testing.T) {
 
 		if recorder.Code != 200 {
 			t.Error("RSA request signing failed with error:", recorder.Body.String())
+		}
+	})
+
+	t.Run("Invalid certificate id", func(t *testing.T) {
+		algo := "rsa-sha256"
+		sessionKey := generateSession(algo, pubCertId)
+		specs := generateSpec(algo, "12345", sessionKey, nil)
+
+		req := TestReq(t, "get", "/test/get", nil)
+		recorder := httptest.NewRecorder()
+		chain := getMiddlewareChain(specs[0])
+		chain.ServeHTTP(recorder, req)
+
+		if recorder.Code != 500 {
+			t.Error("Expected status code 500 got ", recorder.Code)
+		}
+	})
+
+	t.Run("empty certificate id", func(t *testing.T) {
+		algo := "rsa-sha256"
+		sessionKey := generateSession(algo, pubCertId)
+		specs := generateSpec(algo, "", sessionKey, nil)
+
+		req := TestReq(t, "get", "/test/get", nil)
+		recorder := httptest.NewRecorder()
+		chain := getMiddlewareChain(specs[0])
+		chain.ServeHTTP(recorder, req)
+
+		if recorder.Code != 500 {
+			t.Error("Expected status code 500 got ", recorder.Code)
 		}
 	})
 
@@ -356,4 +419,84 @@ func TestStripListenPath(t *testing.T) {
 			t.Error("Expected status code 400 got ", recorder.Code)
 		}
 	})
+}
+
+func TestWithURLRewrite(t *testing.T) {
+	ts := StartTest()
+	defer ts.Close()
+
+	algo := "hmac-sha256"
+	secret := "12345"
+
+	sessionKey := CreateSession(func(session *user.SessionState) {
+		session.EnableHTTPSignatureValidation = true
+		session.HmacSecret = secret
+	})
+
+	apis := BuildAndLoadAPI(func(spec *APISpec) {
+		spec.APIID = "protected"
+		spec.Proxy.ListenPath = "/protected"
+		spec.EnableSignatureChecking = true
+	}, func(spec *APISpec) {
+		spec.APIID = "test"
+		spec.Proxy.ListenPath = "/test"
+		spec.Proxy.StripListenPath = true
+		spec.RequestSigning.Secret = secret
+		spec.RequestSigning.KeyId = sessionKey
+		spec.RequestSigning.Algorithm = algo
+	})
+
+	t.Run("looping", func(t *testing.T) {
+		version := apis[1].VersionData.Versions["v1"]
+		version.UseExtendedPaths = true
+		version.ExtendedPaths.URLRewrite = []apidef.URLRewriteMeta{
+			{
+				Path:         "get",
+				Method:       "GET",
+				MatchPattern: "get",
+				RewriteTo:    "tyk://protected/get",
+			},
+			{
+				Path:         "self",
+				Method:       "GET",
+				MatchPattern: "self",
+				RewriteTo:    "tyk://protected/test/get",
+			},
+		}
+
+		apis[1].VersionData.Versions["v1"] = version
+
+		ts.Run(t, []test.TestCase{
+			{Path: "/test/get", Method: http.MethodGet, Code: http.StatusOK},
+			// ensure listen path is not stripped in case url rewrite
+			{Path: "/test/self", Method: http.MethodGet, Code: http.StatusOK},
+		}...)
+	})
+
+	t.Run("external", func(t *testing.T) {
+		version := apis[1].VersionData.Versions["v1"]
+		version.UseExtendedPaths = true
+		version.ExtendedPaths.URLRewrite = []apidef.URLRewriteMeta{
+			{
+				Path:         "get",
+				Method:       "GET",
+				MatchPattern: "get",
+				RewriteTo:    ts.URL + "/protected/get",
+			},
+			{
+				Path:         "self",
+				Method:       "GET",
+				MatchPattern: "self",
+				RewriteTo:    ts.URL + "/protected/test/get",
+			},
+		}
+
+		apis[1].VersionData.Versions["v1"] = version
+		ts.Run(t, []test.TestCase{
+			{Path: "/test/get", Method: http.MethodGet, Code: http.StatusOK},
+			// ensure listen path is not stripped in case url rewrite
+			{Path: "/test/self", Method: http.MethodGet, Code: http.StatusOK},
+		}...)
+	})
+
 }


### PR DESCRIPTION
Fixes #2779 

1. Handle case of url-rewrite and strip listen path while generating signature string
2. Adds additional checks for input
3. Added more test cases