### PR TITLE
Do not spam logs if oauth2 is used and oauth_on_keychange_url not

### DIFF
--- a/apidef/notifications.go
+++ b/apidef/notifications.go
@@ -19,6 +19,10 @@ type NotificationsManager struct {
 
 // SendRequest sends the requested package (as a POST) to the defined
 func (n NotificationsManager) SendRequest(wait bool, count int, notification interface{}) {
+	if n.OAuthKeyChangeURL == "" {
+		return
+	}
+
 	if wait {
 		if count < 3 {
 			time.Sleep(10 * time.Second)


### PR DESCRIPTION
We have lot of this spamming on Sentry