### PR TITLE
Fix gRPC message size parameter

### DIFF
--- a/gateway/coprocess_grpc.go
+++ b/gateway/coprocess_grpc.go
@@ -80,7 +80,7 @@ func grpcCallOpts() grpc.DialOption {
 		opts = append(opts, grpc.MaxCallRecvMsgSize(recvSize))
 	}
 	if sendSize > 0 {
-		opts = append(opts, grpc.MaxCallRecvMsgSize(sendSize))
+		opts = append(opts, grpc.MaxCallSendMsgSize(sendSize))
 	}
 	return grpc.WithDefaultCallOptions(opts...)
 }


### PR DESCRIPTION
Spotted this typo while reviewing #2204.
```diff
diff --git a/gateway/coprocess_grpc.go b/gateway/coprocess_grpc.go
index 7b7a5598..9313a610 100644
--- a/gateway/coprocess_grpc.go
+++ b/gateway/coprocess_grpc.go
@@ -80,7 +80,7 @@ func grpcCallOpts() grpc.DialOption {
                opts = append(opts, grpc.MaxCallRecvMsgSize(recvSize))
        }
        if sendSize > 0 {
-               opts = append(opts, grpc.MaxCallRecvMsgSize(sendSize))
+               opts = append(opts, grpc.MaxCallSendMsgSize(sendSize))
        }
        return grpc.WithDefaultCallOptions(opts...)
 }
```