### PR TITLE
Disable TCP analytics

### DIFF
--- a/gateway/proxy_muxer.go
+++ b/gateway/proxy_muxer.go
@@ -180,7 +180,7 @@ func (m *proxyMux) addTCPService(spec *APISpec, modifier *tcp.Modifier) {
 				DialTLS:         dialWithServiceDiscovery(spec, customDialTLSCheck(spec, tlsConfig)),
 				Dial:            dialWithServiceDiscovery(spec, net.Dial),
 				TLSConfigTarget: tlsConfig,
-				SyncStats:       recordTCPHit(spec.APIID, spec.DoNotTrack),
+				// SyncStats:       recordTCPHit(spec.APIID, spec.DoNotTrack),
 			},
 		}
 		p.tcpProxy.AddDomainHandler(hostname, spec.Proxy.TargetURL, modifier)

--- a/tcp/tcp_test.go
+++ b/tcp/tcp_test.go
@@ -55,6 +55,7 @@ func TestProxyModifier(t *testing.T) {
 	})
 }
 func TestProxySyncStats(t *testing.T) {
+	t.Skip()
 	// Echoing
 	upstream := test.TcpMock(false, func(in []byte, err error) (out []byte) {
 		return in


### PR DESCRIPTION
Unfortunately, we do not have to do it right.
So the decision is to temporarily disable them until the next releases.

Fix https://github.com/TykTechnologies/tyk-pump/issues/210
Fix https://github.com/TykTechnologies/tyk-sink/issues/89