### PR TITLE
Python session handlers (experimental, don't merge)

### DIFF
--- a/coprocess/python/tyk/gateway.py
+++ b/coprocess/python/tyk/gateway.py
@@ -1,10 +1,22 @@
+from session import TykSession
+
 import ctypes
+
 parent = ctypes.cdll.LoadLibrary(None)
 
 parent.TykGetData.argtypes = [ctypes.c_char_p]
 parent.TykGetData.restype = ctypes.c_char_p
 
 parent.TykStoreData.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_int]
+
+class tyk_get_session_ret(ctypes.Structure):
+    _fields_ = [
+        # ('session_buf', ctypes.c_char_p),
+        ('session_buf', ctypes.c_void_p),
+        ('buflen', ctypes.c_int)
+    ]
+
+parent.TykGetSession.restype = ctypes.POINTER(tyk_get_session_ret)
 
 class TykGateway():
     def log(message, level):
@@ -23,9 +35,33 @@ class TykGateway():
 
     def store_data(key, value, ttl):
         key_p = ctypes.c_char_p(bytes(key, "utf-8"))
-        value_p = ctypes.c_char_p(bytes(value, "utf-8"))
+        # value_p = ctypes.c_char_p(bytes(value, "utf-8"))
+        value_p = ctypes.c_char_p(value)
         ttl_int = ctypes.c_int(ttl)
         parent.TykStoreData(key_p, value_p, ttl_int)
+
+    def set_session(token, session, schedule_update):
+        raw_session = session.SerializeToString()
+        token_p = ctypes.c_char_p(bytes(token, "utf-8"))
+        raw_session_p = ctypes.c_char_p(raw_session)
+        parent.TykSetSession(token_p, raw_session_p, len(raw_session))
+
+    def get_session(spec, token):
+        token_p = ctypes.c_char_p(bytes(token, "utf-8"))
+        org_p = ctypes.c_char_p(bytes(spec['OrgID'], "utf-8"))
+        ret_ptr = parent.TykGetSession(org_p, token_p)
+        # Handle null pointer:
+        if not ret_ptr:
+            return None
+        ret = ret_ptr.contents
+        # Initialize a new PB session object:
+        session = TykSession()
+        raw_session = ctypes.string_at(ret.session_buf, ret.buflen)
+        session.ParseFromString(raw_session)
+        # Free memory that was allocated on the Go side:
+        parent.free(ret.session_buf)
+        parent.free(ret_ptr)
+        return session
 
     def trigger_event(name, payload):
         name_p = ctypes.c_char_p(bytes(name, "utf-8"))

--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -276,6 +276,16 @@ func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 	var returnOverrides ReturnOverrides
 	var sessionID string
 
+	/*
+		id, _ := m.getAuthToken(m.getAuthType(), r)
+		fmt.Println("id=", id)
+		prevSession, exists := m.CheckSessionAndIdentityForValidKey(id, r)
+		if exists {
+			ctxSetSession(r, &prevSession, id, true)
+			return nil, 200
+		}
+	*/
+
 	if m.HookType == coprocess.HookType_CustomKeyCheck && extractor != nil {
 		sessionID, returnOverrides = extractor.ExtractAndCheck(r)
 
@@ -398,7 +408,7 @@ func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 		}
 
 		if extractor == nil {
-			ctxSetSession(r, returnedSession, token, true)
+			ctxSetSession(r, returnedSession, token, false)
 		} else {
 			ctxSetSession(r, returnedSession, sessionID, true)
 		}

--- a/gateway/coprocess_api_c.go
+++ b/gateway/coprocess_api_c.go
@@ -1,0 +1,27 @@
+package gateway 
+
+/*
+#include <stdlib.h>
+
+typedef struct tyk_get_session_ret {
+	char* session_buf;
+	int buflen;
+} tyk_get_session_ret;
+
+struct tyk_get_session_ret* new_tyk_get_session_ret(char* session_buf, int buflen) {
+	struct tyk_get_session_ret* ret = malloc(sizeof(struct tyk_get_session_ret));
+	if(ret == NULL) {
+		return NULL;
+	}
+	ret->session_buf=session_buf;
+	ret->buflen=buflen;
+	return ret;
+};
+*/
+import "C"
+
+func tykGetSessionRet(data []byte) *C.tyk_get_session_ret {
+	sessionBuf := C.CBytes(data)
+	length := C.int(len(data))
+	return C.new_tyk_get_session_ret((*C.char)(sessionBuf), length)
+}


### PR DESCRIPTION
Sample code:
```python
from tyk.decorators import *
from gateway import TykGateway as tyk
from session import TykSession

tyk.log("middleware.py is loaded", "info")

@Hook
def authhook(request, session, metadata, spec):
  tyk.log("authhook is called", "info")
  token = request.get_header('Authorization')

  # Check if there's a session associated with this token:
  session = tyk.get_session(spec, token)
  if session:
    tyk.log("found a session for token {0}".format(token), "info")
    print("session=",session)
  else:
    tyk.log("no session found for token {0}".format(token), "error")

  # Perform the authentication:
  if token == '47a0c79c427728b3df4af62b9228c8ae':
    tyk.log("auth ok", "info")

    # If there was no session associated with this token, create one and return:
    if session == None:
      tyk.log("initializing a new session", "info")
      session = TykSession()
      session.rate = 1000.0
      session.per = 1.0
      session.metadata["user"] = "matias"
      metadata["token"] = token
      tyk.set_session(token, session, True)
      return request, session, metadata

    # The session already exists
    tyk.log("re-using previously created session", "info")
    # This is still required (for now):
    metadata["token"] = token
    return request, session, metadata

  # We reach this point if the auth fails:
  tyk.log("auth failed", "error")
  return request, session, metadata

```