### PR TITLE
Use header functions to set headers in debugging

### DIFF
--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -1794,6 +1794,23 @@ func TestTracing(t *testing.T) {
 		{Method: "POST", Path: "/tyk/debug", Data: traceRequest{Spec: spec.APIDefinition, Request: &traceHttpRequest{Method: "GET", Path: "/"}}, AdminAuth: true, Code: 200, BodyMatch: `401 Unauthorized`},
 		{Method: "POST", Path: "/tyk/debug", Data: traceRequest{Spec: spec.APIDefinition, Request: &traceHttpRequest{Path: "/", Headers: authHeaders}}, AdminAuth: true, Code: 200, BodyMatch: `200 OK`},
 	}...)
+
+	t.Run("Custom auth header", func(t *testing.T) {
+		spec.AuthConfigs = map[string]apidef.AuthConfig{
+			authTokenType: {
+				AuthHeaderName: "Custom-Auth-Header",
+			},
+		}
+
+		customAuthHeaders := map[string][]string{"custom-auth-header": {keyID}}
+
+		_, _ = ts.Run(t, []test.TestCase{
+			{Method: http.MethodPost, Path: "/tyk/debug", Data: traceRequest{Spec: spec.APIDefinition,
+				Request: &traceHttpRequest{Path: "/", Headers: authHeaders}}, AdminAuth: true, Code: 200, BodyMatch: `401 Unauthorized`},
+			{Method: http.MethodPost, Path: "/tyk/debug", Data: traceRequest{Spec: spec.APIDefinition,
+				Request: &traceHttpRequest{Path: "/", Headers: customAuthHeaders}}, AdminAuth: true, Code: 200, BodyMatch: `200 OK`},
+		}...)
+	})
 }
 
 func TestBrokenClients(t *testing.T) {

--- a/gateway/tracing.go
+++ b/gateway/tracing.go
@@ -25,7 +25,13 @@ func (tr *traceHttpRequest) toRequest() *http.Request {
 	r := httptest.NewRequest(tr.Method, tr.Path, strings.NewReader(tr.Body))
 	// It sets example.com by default. Setting it to empty will not show a value because it is not necessary.
 	r.Host = ""
-	r.Header = tr.Headers
+
+	for key, values := range tr.Headers {
+		for _, v := range values {
+			r.Header.Add(key, v)
+		}
+	}
+
 	ctxSetTrace(r)
 
 	return r


### PR DESCRIPTION
`Header` `Get` and `Set` functions are canonicalizing the headers. So, we are trying to get values by `Get` but set directly to the header map and it causes inconsistency.

Fixes https://github.com/TykTechnologies/tyk-analytics/issues/1713