### PR TITLE
Parse bundle download URL and allow optional insecure TLS for it

### DIFF
--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -278,6 +278,9 @@
     "enable_bundle_downloader": {
       "type": "boolean"
     },
+    "bundle_insecure_skip_verify": {
+      "type": "boolean"
+    },
     "enable_custom_domains": {
       "type": "boolean"
     },

--- a/config/config.go
+++ b/config/config.go
@@ -412,14 +412,15 @@ type Config struct {
 	CacheStorage             StorageOptionsConf    `json:"cache_storage"`
 
 	// Middleware/Plugin Configuration
-	EnableBundleDownloader  bool            `bson:"enable_bundle_downloader" json:"enable_bundle_downloader"`
-	BundleBaseURL           string          `bson:"bundle_base_url" json:"bundle_base_url"`
-	EnableJSVM              bool            `json:"enable_jsvm"`
-	JSVMTimeout             int             `json:"jsvm_timeout"`
-	DisableVirtualPathBlobs bool            `json:"disable_virtual_path_blobs"`
-	TykJSPath               string          `json:"tyk_js_path"`
-	MiddlewarePath          string          `json:"middleware_path"`
-	CoProcessOptions        CoProcessConfig `json:"coprocess_options"`
+	EnableBundleDownloader   bool            `bson:"enable_bundle_downloader" json:"enable_bundle_downloader"`
+	BundleBaseURL            string          `bson:"bundle_base_url" json:"bundle_base_url"`
+	BundleInsecureSkipVerify bool            `bson:"bundle_insecure_skip_verify" json:"bundle_insecure_skip_verify"`
+	EnableJSVM               bool            `json:"enable_jsvm"`
+	JSVMTimeout              int             `json:"jsvm_timeout"`
+	DisableVirtualPathBlobs  bool            `json:"disable_virtual_path_blobs"`
+	TykJSPath                string          `json:"tyk_js_path"`
+	MiddlewarePath           string          `json:"middleware_path"`
+	CoProcessOptions         CoProcessConfig `json:"coprocess_options"`
 
 	// Monitoring, Logging & Profiling
 	LogLevel                string         `json:"log_level"`

--- a/gateway/coprocess_bundle_test.go
+++ b/gateway/coprocess_bundle_test.go
@@ -80,6 +80,54 @@ func TestBundleLoader(t *testing.T) {
 	})
 }
 
+func TestBundleFetcher(t *testing.T) {
+	bundleID := "testbundle"
+
+	t.Run("Simple bundle base URL", func(t *testing.T) {
+		globalConf := config.Global()
+		globalConf.BundleBaseURL = "mock://somepath"
+		globalConf.BundleInsecureSkipVerify = false
+		config.SetGlobal(globalConf)
+		specs := BuildAndLoadAPI(func(spec *APISpec) {
+			spec.CustomMiddlewareBundle = bundleID
+		})
+		spec := specs[0]
+		bundle, err := fetchBundle(spec)
+		if err != nil {
+			t.Fatalf("Couldn't fetch bundle: %s", err.Error())
+		}
+
+		if string(bundle.Data) != "bundle" {
+			t.Errorf("Wrong bundle data: %s", bundle.Data)
+		}
+		if bundle.Name != bundleID {
+			t.Errorf("Wrong bundle name: %s", bundle.Name)
+		}
+	})
+
+	t.Run("Bundle base URL with querystring", func(t *testing.T) {
+		globalConf := config.Global()
+		globalConf.BundleBaseURL = "mock://somepath?api_key=supersecret"
+		globalConf.BundleInsecureSkipVerify = true
+		config.SetGlobal(globalConf)
+		specs := BuildAndLoadAPI(func(spec *APISpec) {
+			spec.CustomMiddlewareBundle = bundleID
+		})
+		spec := specs[0]
+		bundle, err := fetchBundle(spec)
+		if err != nil {
+			t.Fatalf("Couldn't fetch bundle: %s", err.Error())
+		}
+
+		if string(bundle.Data) != "bundle-insecure" {
+			t.Errorf("Wrong bundle data: %s", bundle.Data)
+		}
+		if bundle.Name != bundleID {
+			t.Errorf("Wrong bundle name: %s", bundle.Name)
+		}
+	})
+}
+
 var overrideResponsePython = map[string]string{
 	"manifest.json": `
 		{

--- a/gateway/coprocess_bundle_test.go
+++ b/gateway/coprocess_bundle_test.go
@@ -82,6 +82,7 @@ func TestBundleLoader(t *testing.T) {
 
 func TestBundleFetcher(t *testing.T) {
 	bundleID := "testbundle"
+	defer ResetTestConfig()
 
 	t.Run("Simple bundle base URL", func(t *testing.T) {
 		globalConf := config.Global()


### PR DESCRIPTION
Bundle fetcher now parses the bundle base URL and joins the bundle ID to its path component instead of simple string concatenation. Resulting URL is then rendered from the parsed structure. This ensures correct URL will be constructed if the base contains e.g. query string parameters.

This also adds a "bundle_insecure_skip_verify" config option to enable downloading from e.g. test sources that might not have a trusted certificate. Disabled by default.

Addresses #2874