### PR TITLE
Fix memory leak

### DIFF
--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -517,15 +517,15 @@ func (d *DummyProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		var handler http.Handler
 		if r.URL.Hostname() == "self" {
-			if d.SH.Spec.middlewareChain != nil {
-				handler = d.SH.Spec.middlewareChain.ThisHandler
+			if h, found := apisHandlesByID[d.SH.Spec.APIID]; found {
+				handler = h
 			}
 		} else {
 			ctxSetVersionInfo(r, nil)
 
 			if targetAPI := fuzzyFindAPI(r.URL.Hostname()); targetAPI != nil {
-				if targetAPI.middlewareChain != nil {
-					handler = targetAPI.middlewareChain.ThisHandler
+				if h, found := apisHandlesByID[targetAPI.APIID]; found {
+					handler = h
 				}
 			} else {
 				handler := ErrorHandler{*d.SH.Base()}
@@ -551,12 +551,12 @@ func (d *DummyProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if d.SH.Spec.target.Scheme == "tyk" {
 		if targetAPI := fuzzyFindAPI(d.SH.Spec.target.Host); targetAPI != nil {
-			if targetAPI.middlewareChain != nil {
+			if h, found := apisHandlesByID[d.SH.Spec.APIID]; found {
 				if d.SH.Spec.Proxy.StripListenPath {
 					r.URL.Path = d.SH.Spec.StripListenPath(r, r.URL.Path)
 					r.URL.RawPath = d.SH.Spec.StripListenPath(r, r.URL.RawPath)
 				}
-				targetAPI.middlewareChain.ThisHandler.ServeHTTP(w, r)
+				h.ServeHTTP(w, r)
 				return
 			}
 		}
@@ -604,7 +604,7 @@ func fuzzyFindAPI(search string) *APISpec {
 	return nil
 }
 
-func loadHTTPService(spec *APISpec, apisByListen map[string]int, gs *generalStores, muxer *proxyMux) {
+func loadHTTPService(spec *APISpec, apisByListen map[string]int, gs *generalStores, muxer *proxyMux) http.Handler {
 	port := config.Global().ListenPort
 	if spec.ListenPort != 0 {
 		port = spec.ListenPort
@@ -626,12 +626,9 @@ func loadHTTPService(spec *APISpec, apisByListen map[string]int, gs *generalStor
 	}
 
 	chainObj := processSpec(spec, apisByListen, gs, router, logrus.NewEntry(log))
-	apisMu.Lock()
-	spec.middlewareChain = chainObj
-	apisMu.Unlock()
 
 	if chainObj.Skip {
-		return
+		return chainObj.ThisHandler
 	}
 
 	if !chainObj.Open {
@@ -639,6 +636,8 @@ func loadHTTPService(spec *APISpec, apisByListen map[string]int, gs *generalStor
 	}
 
 	router.Handle(chainObj.ListenOn, chainObj.ThisHandler)
+
+	return chainObj.ThisHandler
 }
 
 func loadTCPService(spec *APISpec, gs *generalStores, muxer *proxyMux) {
@@ -680,6 +679,7 @@ func loadApps(specs []*APISpec) {
 	mainLog.Info("Loading API configurations.")
 
 	tmpSpecRegister := make(map[string]*APISpec)
+	tmpSpecHandles := make(map[string]http.Handler)
 
 	// sort by listen path from longer to shorter, so that /foo
 	// doesn't break /foo-bar
@@ -727,7 +727,7 @@ func loadApps(specs []*APISpec) {
 					mainLog.Infof("Intialized tracer  api_name=%q", spec.Name)
 				}
 			}
-			loadHTTPService(spec, apisByListen, &gs, muxer)
+			tmpSpecHandles[spec.APIID] = loadHTTPService(spec, apisByListen, &gs, muxer)
 		case "tcp", "tls":
 			loadTCPService(spec, &gs, muxer)
 		}
@@ -744,6 +744,8 @@ func loadApps(specs []*APISpec) {
 	}
 
 	apisByID = tmpSpecRegister
+	apisHandlesByID = tmpSpecHandles
+
 	apisMu.Unlock()
 
 	mainLog.Debug("Checker host list")

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -70,9 +70,10 @@ var (
 	CertificateManager   *certs.CertificateManager
 	NewRelicApplication  newrelic.Application
 
-	apisMu   sync.RWMutex
-	apiSpecs []*APISpec
-	apisByID = map[string]*APISpec{}
+	apisMu          sync.RWMutex
+	apiSpecs        []*APISpec
+	apisByID        = map[string]*APISpec{}
+	apisHandlesByID = map[string]http.Handler{}
 
 	keyGen DefaultKeyGenerator
 

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -73,7 +73,7 @@ var (
 	apisMu          sync.RWMutex
 	apiSpecs        []*APISpec
 	apisByID        = map[string]*APISpec{}
-	apisHandlesByID = map[string]http.Handler{}
+	apisHandlesByID = new(sync.Map)
 
 	keyGen DefaultKeyGenerator
 


### PR DESCRIPTION
We stored HTTP handler inside API definition, which probably introduced some circular dependency, confusing the GC.
Handler access itself was needed for the looping, so even if API not loaded to the router (internal), it still could be accessed.

Now handler access moved to the map, where key is API id.
And map is updated in the same maneer as apisByID