### PR TITLE
[WIP] feature/2873 JWT Auth to support ECDSA signing algorithms.

### DIFF
--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -576,13 +576,21 @@ func (k *JWTMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _
 			return nil, err
 		}
 
-		if k.Spec.JWTSigningMethod == RSASign {
+		switch k.Spec.JWTSigningMethod {
+		case RSASign:
 			asRSA, err := jwt.ParseRSAPublicKeyFromPEM(val)
 			if err != nil {
 				logger.WithError(err).Error("Failed to decode JWT to RSA type")
 				return nil, err
 			}
 			return asRSA, nil
+		case ECDSASign:
+			asEcdsa, err := jwt.ParseECPublicKeyFromPEM(val)
+			if err != nil {
+				logger.WithError(err).Error("Failed to decode JWT to ECDSA type")
+				return nil, err
+			}
+			return asEcdsa, nil
 		}
 
 		return val, nil


### PR DESCRIPTION
fixes #2873

Allows JWT auth to support ECDSA signing algorithm.

## To test:

Private Key: `openssl ecparam -genkey -name prime256v1 -noout -out private.pem`
Public Key: `openssl ec -in private.pem -pubout -out public.pem`

## dependency: 

* UI - Tyk Dashboard UI api definition to support ecdsa signing algorithm
in addition to rsa & hmac
* Requires documentation