### PR TITLE
Fix usage of the gateway code in the dasboard tests

### DIFF
--- a/gateway/health_check.go
+++ b/gateway/health_check.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -134,7 +135,12 @@ func gatherHealthChecks() {
 				Time:          time.Now().Format(time.RFC3339),
 			}
 
-			if err := DashService.Ping(); err != nil {
+			if DashService == nil {
+				err := errors.New("Dashboard service not initialized")
+				mainLog.WithField("liveness-check", true).Error(err)
+				checkItem.Output = err.Error()
+				checkItem.Status = Fail
+			} else if err := DashService.Ping(); err != nil {
 				mainLog.WithField("liveness-check", true).Error(err)
 				checkItem.Output = err.Error()
 				checkItem.Status = Fail


### PR DESCRIPTION
When the dashboard was using the gateway tests, it was causing the panic, since dashboard service in tests not always initialized.

Fix for https://github.com/TykTechnologies/tyk/issues/857