### PR TITLE
Make testdata and templates a dependency

### DIFF
--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -28,15 +28,19 @@ import (
 	"github.com/go-redis/redis"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
-	uuid "github.com/satori/go.uuid"
+
 	"golang.org/x/net/context"
 
 	"github.com/TykTechnologies/tyk/apidef"
+
 	"github.com/TykTechnologies/tyk/cli"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/storage"
+	_ "github.com/TykTechnologies/tyk/templates" // Don't delete
 	"github.com/TykTechnologies/tyk/test"
+	_ "github.com/TykTechnologies/tyk/testdata" // Don't delete
 	"github.com/TykTechnologies/tyk/user"
+	uuid "github.com/satori/go.uuid"
 )
 
 var (

--- a/templates/doc.go
+++ b/templates/doc.go
@@ -1,0 +1,3 @@
+package templates
+
+// To be able to vendor this package, it should be Go package so this file is created.

--- a/testdata/doc.go
+++ b/testdata/doc.go
@@ -1,0 +1,3 @@
+package testdata
+
+// To be able to vendor this package, it should be Go package so this file is created.


### PR DESCRIPTION
In dashboard, when `go mod vendor` is run, it removes `testdata` and `templates` although they are a dependency in runtime and cause failure in tests. This PR makes them a dependency in compile time and will provide that they will be vendored in the dashboard.