### PR TITLE
Fix refcount management in dlpython

### DIFF
--- a/dlpython/helpers.go
+++ b/dlpython/helpers.go
@@ -139,7 +139,7 @@ func PyObjectGetAttr(o unsafe.Pointer, attr interface{}) (unsafe.Pointer, error)
 // PyBytesFromString wraps PyBytesFromString
 func PyBytesFromString(input []byte) (unsafe.Pointer, error) {
 	data := C.CBytes(input)
-	// defer C.free(unsafe.Pointer(data))
+	defer C.free(unsafe.Pointer(data))
 	ret := PyBytes_FromStringAndSize((*C.char)(data), C.long(len(input)))
 	if ret == nil {
 		return nil, errors.New("PyBytesFromString failed")
@@ -149,17 +149,31 @@ func PyBytesFromString(input []byte) (unsafe.Pointer, error) {
 
 // PyBytesAsString wraps PyBytes_AsString
 func PyBytesAsString(o unsafe.Pointer, l int) ([]byte, error) {
-	cstr := PyBytes_AsString(ToPyObject(o))
+	obj := ToPyObject(o)
+	cstr := PyBytes_AsString(obj)
 	if cstr == nil {
 		return nil, errors.New("PyBytes_AsString as string failed")
 	}
-	// defer C.free(unsafe.Pointer(cstr))
 	str := C.GoBytes(unsafe.Pointer(cstr), C.int(l))
-	return []byte(str), nil
+	b := []byte(str)
+	return b, nil
 }
 
 // PyLongAsLong wraps PyLong_AsLong
 func PyLongAsLong(o unsafe.Pointer) int {
 	l := PyLong_AsLong(ToPyObject(o))
 	return int(l)
+}
+
+func PyIncRef(o unsafe.Pointer) {
+	Py_IncRef(ToPyObject(o))
+}
+
+func PyDecRef(o unsafe.Pointer) {
+	Py_DecRef(ToPyObject(o))
+}
+
+func PyTupleClearFreeList() int {
+	sz := PyTuple_ClearFreeList()
+	return int(sz)
 }

--- a/gateway/coprocess_python.go
+++ b/gateway/coprocess_python.go
@@ -86,6 +86,8 @@ func (d *PythonDispatcher) Dispatch(object *coprocess.Object) (*coprocess.Object
 		pythonLock.Unlock()
 		return nil, err
 	}
+	python.PyDecRef(args)
+	python.PyDecRef(dispatchHookFunc)
 
 	newObjectPtr, err := python.PyTupleGetItem(result, 0)
 	if err != nil {
@@ -116,6 +118,7 @@ func (d *PythonDispatcher) Dispatch(object *coprocess.Object) (*coprocess.Object
 		pythonLock.Unlock()
 		return nil, err
 	}
+	python.PyDecRef(result)
 	pythonLock.Unlock()
 
 	newObject := &coprocess.Object{}


### PR DESCRIPTION
Fix for #2894, similar to #1886:

1. Implemented bindings for `Py_IncRef`, `Py_DecRef` and `PyTuple_ClearFreeList` (could be potentially used).
2. Corrected `free` call in `PyBytesFromString`.
3. Added refcount handlers in `coprocess_python.go`.

With this patch, GC object count looks better over time (using the middleware attached in #2894):

```
myhook called
29509
myhook called
29509
myhook called
29509
myhook called
29509
myhook called
29509
myhook called
29509
myhook called
29509
myhook called
29509
myhook called
29509
myhook called
29509
myhook called
29509
myhook called
29509
myhook called
29509
myhook called
29509
```

Under some scenarios, additional tweaks might be required (either on the plugin side or Tyk Python code side) to run the GC collection more often, etc.