### PR TITLE
Feature revoke oauth tokens

### DIFF
--- a/gateway/api.go
+++ b/gateway/api.go
@@ -1722,6 +1722,24 @@ func rotateOauthClientHandler(w http.ResponseWriter, r *http.Request) {
 	doJSONWrite(w, code, obj)
 }
 
+func getApisForOauthApp(w http.ResponseWriter, r *http.Request){
+	apis := []string{}
+	appID := mux.Vars(r)["appID"]
+
+	apisMu.RLock()
+	for apiId,api := range apisByID {
+		if api.UseOauth2 {
+			_, err := api.OAuthManager.OsinServer.Storage.GetClient(appID)
+			if err == nil {
+				apis = append(apis, apiId)
+			}
+		}
+	}
+	apisMu.RUnlock()
+
+	doJSONWrite(w, http.StatusOK, apis)
+}
+
 func oAuthClientHandler(w http.ResponseWriter, r *http.Request) {
 	apiID := mux.Vars(r)["apiID"]
 	keyName := mux.Vars(r)["keyName"]

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -1722,12 +1722,12 @@ func rotateOauthClientHandler(w http.ResponseWriter, r *http.Request) {
 	doJSONWrite(w, code, obj)
 }
 
-func getApisForOauthApp(w http.ResponseWriter, r *http.Request){
+func getApisForOauthApp(w http.ResponseWriter, r *http.Request) {
 	apis := []string{}
 	appID := mux.Vars(r)["appID"]
 
 	apisMu.RLock()
-	for apiId,api := range apisByID {
+	for apiId, api := range apisByID {
 		if api.UseOauth2 {
 			_, err := api.OAuthManager.OsinServer.Storage.GetClient(appID)
 			if err == nil {

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -1883,7 +1883,7 @@ func handleDeleteOAuthClient(keyName, apiID string) (interface{}, int) {
 const oAuthNotPropagatedErr = "OAuth client list isn't available or hasn't been propagated yet."
 const oAuthClientNotFound = "OAuth client not found"
 
-func getApiClients(apiID string)([]ExtendedOsinClientInterface, apiStatusMessage, int){
+func getApiClients(apiID string) ([]ExtendedOsinClientInterface, apiStatusMessage, int) {
 	filterID := prefixClient
 	apiSpec := getApiSpec(apiID)
 	if apiSpec == nil {
@@ -1927,7 +1927,7 @@ func getOauthClients(apiID string) (interface{}, int) {
 	clientData, _, apiStatusCode := getApiClients(apiID)
 
 	if apiStatusCode != 200 {
-		return clientData,apiStatusCode
+		return clientData, apiStatusCode
 	}
 
 	clients := []NewClientRequest{}
@@ -2084,13 +2084,13 @@ func RevokeAllTokensHandler(w http.ResponseWriter, r *http.Request) {
 	clientId := r.PostFormValue("client_id")
 	clientSecret := r.PostFormValue("client_secret")
 
-	if clientId == "" || clientSecret  == ""{
+	if clientId == "" || clientSecret == "" {
 		doJSONWrite(w, http.StatusBadRequest, apiError("client_id and client_secret are required"))
 		return
 	}
 
 	apis := getApisForOauthClientId(clientId)
-	log.Info("apis:",apis)
+	log.Info("apis:", apis)
 
 	if len(apis) == 0 {
 		doJSONWrite(w, http.StatusNotFound, apiError("oauth client doesnt have any api related"))

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -2047,6 +2047,12 @@ func RevokeTokenHandler(w http.ResponseWriter, r *http.Request){
 		return
 	}
 
+	/*x := RedisOsinStorageInterface{
+		orgID:"",
+		sessionManager:GlobalSessionManager,
+		store: getGlobalStorageHandler("", false),
+	}*/
+
 	RevokeToken(apiSpec.OAuthManager.OsinServer.Storage, token, tokenTypeHint)
 	w.WriteHeader(200)
 }
@@ -2087,6 +2093,14 @@ func RevokeAllTokensHandler(w http.ResponseWriter, r *http.Request){
 		doJSONWrite(w, http.StatusNotFound, apiError(oAuthNotPropagatedErr))
 		return
 	}
+
+	/*
+	x := RedisOsinStorageInterface{
+		orgID:"",
+		sessionManager:GlobalSessionManager,
+		store: getGlobalStorageHandler("", false),
+	}
+	*/
 
 	status := RevokeAllTokens(apiSpec.OAuthManager.OsinServer.Storage, clientId, clientSecret)
 	w.WriteHeader(status)

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -1882,6 +1882,7 @@ func handleDeleteOAuthClient(keyName, apiID string) (interface{}, int) {
 
 const oAuthNotPropagatedErr = "OAuth client list isn't available or hasn't been propagated yet."
 const oAuthClientNotFound = "OAuth client not found"
+
 // List Clients
 func getOauthClients(apiID string) (interface{}, int) {
 	filterID := prefixClient
@@ -2010,7 +2011,7 @@ func invalidateCacheHandler(w http.ResponseWriter, r *http.Request) {
 	doJSONWrite(w, http.StatusOK, apiOk("cache invalidated"))
 }
 
-func RevokeTokenHandler(w http.ResponseWriter, r *http.Request){
+func RevokeTokenHandler(w http.ResponseWriter, r *http.Request) {
 	err := r.ParseForm()
 
 	if err != nil {
@@ -2032,7 +2033,7 @@ func RevokeTokenHandler(w http.ResponseWriter, r *http.Request){
 	w.WriteHeader(200)
 }
 
-func GetStorageForApi(apiID string)(ExtendedOsinStorageInterface,int, error){
+func GetStorageForApi(apiID string) (ExtendedOsinStorageInterface, int, error) {
 	apiSpec := getApiSpec(apiID)
 	if apiSpec == nil {
 		log.WithFields(logrus.Fields{
@@ -2059,7 +2060,7 @@ func GetStorageForApi(apiID string)(ExtendedOsinStorageInterface,int, error){
 	return apiSpec.OAuthManager.OsinServer.Storage, http.StatusOK, nil
 }
 
-func RevokeAllTokensHandler(w http.ResponseWriter, r *http.Request){
+func RevokeAllTokensHandler(w http.ResponseWriter, r *http.Request) {
 	err := r.ParseForm()
 
 	if err != nil {

--- a/gateway/health_check.go
+++ b/gateway/health_check.go
@@ -93,9 +93,13 @@ func initHealthCheck(ctx context.Context) {
 	}(ctx)
 }
 
-func gatherHealthChecks() {
+type SafeHealthCheck struct{
+	info map[string]HealthCheckItem
+	mux sync.Mutex
+}
 
-	allInfos := make(map[string]HealthCheckItem, 3)
+func gatherHealthChecks() {
+	allInfos := SafeHealthCheck{info:make(map[string]HealthCheckItem, 3)}
 
 	redisStore := storage.RedisCluster{KeyPrefix: "livenesscheck-"}
 
@@ -120,7 +124,9 @@ func gatherHealthChecks() {
 			checkItem.Status = Fail
 		}
 
-		allInfos["redis"] = checkItem
+		allInfos.mux.Lock()
+		allInfos.info["redis"] = checkItem
+		allInfos.mux.Unlock()
 	}()
 
 	if config.Global().UseDBAppConfigs {
@@ -147,7 +153,10 @@ func gatherHealthChecks() {
 			}
 
 			checkItem.ComponentType = System
-			allInfos["dashboard"] = checkItem
+
+			allInfos.mux.Lock()
+			allInfos.info["dashboard"] = checkItem
+			allInfos.mux.Unlock()
 		}()
 	}
 
@@ -173,13 +182,17 @@ func gatherHealthChecks() {
 
 			checkItem.ComponentType = System
 
-			allInfos["rpc"] = checkItem
+			allInfos.mux.Lock()
+			allInfos.info["rpc"] = checkItem
+			allInfos.mux.Unlock()
 		}()
 	}
 
 	wg.Wait()
 
-	setCurrentHealthCheckInfo(allInfos)
+	allInfos.mux.Lock()
+	setCurrentHealthCheckInfo(allInfos.info)
+	allInfos.mux.Unlock()
 }
 
 func liveCheckHandler(w http.ResponseWriter, r *http.Request) {

--- a/gateway/health_check.go
+++ b/gateway/health_check.go
@@ -93,13 +93,13 @@ func initHealthCheck(ctx context.Context) {
 	}(ctx)
 }
 
-type SafeHealthCheck struct{
+type SafeHealthCheck struct {
 	info map[string]HealthCheckItem
-	mux sync.Mutex
+	mux  sync.Mutex
 }
 
 func gatherHealthChecks() {
-	allInfos := SafeHealthCheck{info:make(map[string]HealthCheckItem, 3)}
+	allInfos := SafeHealthCheck{info: make(map[string]HealthCheckItem, 3)}
 
 	redisStore := storage.RedisCluster{KeyPrefix: "livenesscheck-"}
 

--- a/gateway/oauth_manager.go
+++ b/gateway/oauth_manager.go
@@ -189,7 +189,6 @@ func (o *OAuthHandlers) HandleAccessRequest(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-
 	// Ping endpoint with o_auth key and auth_key
 	authCode := r.FormValue("code")
 	oldRefreshToken := r.FormValue("refresh_token")
@@ -225,9 +224,8 @@ func (o *OAuthHandlers) HandleAccessRequest(w http.ResponseWriter, r *http.Reque
 	w.Write(msg)
 }
 
-
-const(
-	accessToken = "access_token"
+const (
+	accessToken  = "access_token"
 	refreshToken = "refresh_token"
 )
 
@@ -240,14 +238,14 @@ func (o *OAuthHandlers) HandleRevokeToken(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	token:= r.PostFormValue("token")
+	token := r.PostFormValue("token")
 	tokenTypeHint := r.PostFormValue("token_type_hint")
 
 	RevokeToken(o.Manager.OsinServer.Storage, token, tokenTypeHint)
 	w.WriteHeader(200)
 }
 
-func RevokeToken(storage ExtendedOsinStorageInterface, token, tokenTypeHint string){
+func RevokeToken(storage ExtendedOsinStorageInterface, token, tokenTypeHint string) {
 	switch tokenTypeHint {
 	case accessToken:
 		storage.RemoveAccess(token)
@@ -267,9 +265,9 @@ func (o *OAuthHandlers) HandleRevokeAllTokens(w http.ResponseWriter, r *http.Req
 	}
 
 	clientId := r.PostFormValue("client_id")
-	secret := r.PostFormValue("secret")
+	secret := r.PostFormValue("client_secret")
 
-	if clientId == "" || secret == ""{
+	if clientId == "" || secret == "" {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -285,7 +283,7 @@ func RevokeAllTokens(storage ExtendedOsinStorageInterface, clientId, clientSecre
 		return http.StatusNotFound
 	}
 
-	if client.GetSecret() != clientSecret{
+	if client.GetSecret() != clientSecret {
 		return http.StatusForbidden
 	}
 
@@ -742,7 +740,7 @@ func (r *RedisOsinStorageInterface) GetClientTokens(id string) ([]OAuthClientTok
 
 	// convert sorted set data and scores into reply struct
 	tokensData := make([]OAuthClientToken, len(tokens))
-	for i := range tokens{
+	for i := range tokens {
 		tokensData[i] = OAuthClientToken{
 			Token:   tokens[i],
 			Expires: int64(scores[i]), // we store expire timestamp as a score
@@ -819,7 +817,7 @@ func (r *RedisOsinStorageInterface) SaveAuthorize(authData *osin.AuthorizeData) 
 	key := prefixAuth + authData.Code
 	log.Debug("Saving auth code: ", key)
 
-	log.Info("////save key: ", key," with value:", string(authDataJSON))
+	log.Info("////save key: ", key, " with value:", string(authDataJSON))
 	r.store.SetKey(key, string(authDataJSON), int64(authData.ExpiresIn))
 
 	return nil
@@ -1001,7 +999,7 @@ func (r *RedisOsinStorageInterface) LoadRefresh(token string) (*osin.AccessData,
 func (r *RedisOsinStorageInterface) RemoveRefresh(token string) error {
 	log.Debug("FOR REFRESH TO DELETE: ", token)
 	key := prefixRefresh + token
-	log.Debug("is going to remove refresh token with key:",key)
+	log.Debug("is going to remove refresh token with key:", key)
 	r.store.DeleteKey(key)
 	return nil
 }

--- a/gateway/oauth_manager.go
+++ b/gateway/oauth_manager.go
@@ -289,18 +289,14 @@ func RevokeAllTokens(storage ExtendedOsinStorageInterface, clientId, clientSecre
 		return http.StatusForbidden
 	}
 
-	//its only access?
 	clientTokens, err := storage.GetClientTokens(clientId)
 	if err != nil {
 		return http.StatusBadRequest
 	}
 
 	for _, token := range clientTokens {
-
 		access, err := storage.LoadAccess(token.Token)
-		log.Debug("loading acces with token:", token.Token)
 		if err == nil {
-			log.Debug("uno no dio error: ", access)
 			storage.RemoveAccess(access.AccessToken)
 			storage.RemoveRefresh(access.RefreshToken)
 		}

--- a/gateway/oauth_manager.go
+++ b/gateway/oauth_manager.go
@@ -571,7 +571,7 @@ func (r *RedisOsinStorageInterface) GetClient(id string) (osin.Client, error) {
 
 	clientJSON, err := r.store.GetKey(key)
 	if err != nil {
-		log.Errorf("Failure retreiving client ID key %q: %v", key, err)
+		log.Errorf("Failure retrieving client ID key %q: %v", key, err)
 		return nil, err
 	}
 

--- a/gateway/oauth_manager.go
+++ b/gateway/oauth_manager.go
@@ -177,7 +177,6 @@ func (o *OAuthHandlers) HandleAuthorizePassthrough(w http.ResponseWriter, r *htt
 // OAuth tokens without revealing tokens before they are requested).
 func (o *OAuthHandlers) HandleAccessRequest(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set(headers.ContentType, headers.ApplicationJSON)
-	log.Info("aqui")
 	// Handle response
 	resp := o.Manager.HandleAccess(r)
 	msg := o.generateOAuthOutputFromOsinResponse(resp)
@@ -817,7 +816,6 @@ func (r *RedisOsinStorageInterface) SaveAuthorize(authData *osin.AuthorizeData) 
 	key := prefixAuth + authData.Code
 	log.Debug("Saving auth code: ", key)
 
-	log.Info("////save key: ", key, " with value:", string(authDataJSON))
 	r.store.SetKey(key, string(authDataJSON), int64(authData.ExpiresIn))
 
 	return nil
@@ -964,7 +962,6 @@ func (r *RedisOsinStorageInterface) LoadAccess(token string) (*osin.AccessData, 
 func (r *RedisOsinStorageInterface) RemoveAccess(token string) error {
 	key := prefixAccess + storage.HashKey(token)
 
-	log.Debug("going to revoke access with key:", key)
 	r.store.DeleteKey(key)
 
 	// remove the access token from central storage too
@@ -997,9 +994,8 @@ func (r *RedisOsinStorageInterface) LoadRefresh(token string) (*osin.AccessData,
 
 // RemoveRefresh will remove a refresh token from redis
 func (r *RedisOsinStorageInterface) RemoveRefresh(token string) error {
-	log.Debug("FOR REFRESH TO DELETE: ", token)
+	log.Debug("is going to revoke refresh token: ", token)
 	key := prefixRefresh + token
-	log.Debug("is going to remove refresh token with key:", key)
 	r.store.DeleteKey(key)
 	return nil
 }

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -810,19 +810,19 @@ func (r *RPCStorageHandler) ProcessKeySpaceChanges(keys []string) {
 		splitKeys := strings.Split(key, ":")
 		if len(splitKeys) > 1 && splitKeys[1] == "resetQuota" {
 			keysToReset[splitKeys[0]] = true
-		}else if len(splitKeys) > 3 {
-			if  splitKeys[3] == "oAuthRevokeToken" || splitKeys[3] == "oAuthRevokeAccessToken"|| splitKeys[3] == "oAuthRevokeRefreshToken"{
+		} else if len(splitKeys) > 3 {
+			if splitKeys[3] == "oAuthRevokeToken" || splitKeys[3] == "oAuthRevokeAccessToken" || splitKeys[3] == "oAuthRevokeRefreshToken" {
 				TokensToBeRevoked[splitKeys[0]] = key
-			}else if splitKeys[3] == "oAuthRevokeAllTokens" {
+			} else if splitKeys[3] == "oAuthRevokeAllTokens" {
 				oauthClientToBeRevoked[splitKeys[0]] = key
 			}
 		}
 	}
 
 	//remove all token's client
-	for clientId, key := range oauthClientToBeRevoked{
+	for clientId, key := range oauthClientToBeRevoked {
 		//key formed as = clientId:clientSecret:apiId:oAuthRevokeAllTokens
-		splitKeys := strings.Split(key,":")
+		splitKeys := strings.Split(key, ":")
 		clientSecret := splitKeys[1]
 		apiId := splitKeys[3]
 
@@ -830,22 +830,22 @@ func (r *RPCStorageHandler) ProcessKeySpaceChanges(keys []string) {
 		if err != nil {
 			continue
 		}
-		clientTokens, err :=storage.GetClientTokens(clientId)
+		clientTokens, err := storage.GetClientTokens(clientId)
 		if err != nil {
-			for _, token := range clientTokens{
+			for _, token := range clientTokens {
 				key := token.Token
 				SessionCache.Delete(key)
 				RPCGlobalCache.Delete(r.KeyPrefix + key)
 			}
 		}
 
-		RevokeAllTokens(storage,clientId,clientSecret)
+		RevokeAllTokens(storage, clientId, clientSecret)
 	}
 
 	//single and specific tokens
-	for token, key := range TokensToBeRevoked{
+	for token, key := range TokensToBeRevoked {
 		//key formed as: token:apiId:tokenActionTypeHint
-		splitKeys := strings.Split(key,":")
+		splitKeys := strings.Split(key, ":")
 		apiId := splitKeys[1]
 		tokenActionTypeHint := splitKeys[2]
 
@@ -855,13 +855,13 @@ func (r *RPCStorageHandler) ProcessKeySpaceChanges(keys []string) {
 		}
 
 		var tokenTypeHint string
-		switch tokenActionTypeHint{
-			case "oAuthRevokeAccessToken":
-				tokenTypeHint = "access_token"
-			case "oAuthRevokeRefreshToken":
-				tokenTypeHint = "refresh_token"
+		switch tokenActionTypeHint {
+		case "oAuthRevokeAccessToken":
+			tokenTypeHint = "access_token"
+		case "oAuthRevokeRefreshToken":
+			tokenTypeHint = "refresh_token"
 		}
-		RevokeToken(storage,token,tokenTypeHint)
+		RevokeToken(storage, token, tokenTypeHint)
 		SessionCache.Delete(token)
 		RPCGlobalCache.Delete(r.KeyPrefix + token)
 	}

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -806,7 +806,6 @@ func (r *RPCStorageHandler) ProcessKeySpaceChanges(keys []string) {
 	TokensToBeRevoked := map[string]string{}
 
 	for _, key := range keys {
-		log.Debug("un cambio de keys:", key)
 		splitKeys := strings.Split(key, ":")
 		if len(splitKeys) > 1 && splitKeys[1] == "resetQuota" {
 			keysToReset[splitKeys[0]] = true

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -811,13 +811,15 @@ func (r *RPCStorageHandler) ProcessKeySpaceChanges(keys []string) {
 		if len(splitKeys) > 1 && splitKeys[1] == "resetQuota" {
 			keysToReset[splitKeys[0]] = true
 		}else if len(splitKeys) > 3 {
-			if splitKeys[3] == "oAuthRevokeAllTokens" || splitKeys[3] == "oAuthRevokeToken" || splitKeys[3] == "oAuthRevokeAccessToken"{
+			if  splitKeys[3] == "oAuthRevokeToken" || splitKeys[3] == "oAuthRevokeAccessToken"|| splitKeys[3] == "oAuthRevokeRefreshToken"{
 				TokensToBeRevoked[splitKeys[0]] = key
+			}else if splitKeys[3] == "oAuthRevokeAllTokens" {
+				oauthClientToBeRevoked[splitKeys[0]] = key
 			}
 		}
 	}
 
-	//all tokens client
+	//remove all token's client
 	for clientId, key := range oauthClientToBeRevoked{
 		//key formed as = clientId:clientSecret:apiId:oAuthRevokeAllTokens
 		splitKeys := strings.Split(key,":")

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -809,10 +809,12 @@ func (r *RPCStorageHandler) ProcessKeySpaceChanges(keys []string) {
 		splitKeys := strings.Split(key, ":")
 		if len(splitKeys) > 1 && splitKeys[1] == "resetQuota" {
 			keysToReset[splitKeys[0]] = true
-		} else if len(splitKeys) > 3 {
-			if splitKeys[3] == "oAuthRevokeToken" || splitKeys[3] == "oAuthRevokeAccessToken" || splitKeys[3] == "oAuthRevokeRefreshToken" {
+		} else if len(splitKeys) > 2 {
+			log.Info("uno de revocar tokens:", key)
+			action := splitKeys[len(splitKeys)-1]
+			if action == "oAuthRevokeToken" || action == "oAuthRevokeAccessToken" || action == "oAuthRevokeRefreshToken" {
 				TokensToBeRevoked[splitKeys[0]] = key
-			} else if splitKeys[3] == "oAuthRevokeAllTokens" {
+			} else if action == "oAuthRevokeAllTokens" {
 				oauthClientToBeRevoked[splitKeys[0]] = key
 			}
 		}
@@ -843,6 +845,7 @@ func (r *RPCStorageHandler) ProcessKeySpaceChanges(keys []string) {
 
 	//single and specific tokens
 	for token, key := range TokensToBeRevoked {
+		log.Info("revoke single token:", token)
 		//key formed as: token:apiId:tokenActionTypeHint
 		splitKeys := strings.Split(key, ":")
 		apiId := splitKeys[1]

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -825,9 +825,9 @@ func (r *RPCStorageHandler) ProcessKeySpaceChanges(keys []string) {
 		splitKeys := strings.Split(key, ":")
 		apiId := splitKeys[1]
 		tokenActionTypeHint := splitKeys[2]
-		hashedKey := strings.Contains(token,"#hashed")
+		hashedKey := strings.Contains(token, "#hashed")
 
-		if !hashedKey{
+		if !hashedKey {
 			storage, _, err := GetStorageForApi(apiId)
 			if err != nil {
 				continue
@@ -840,8 +840,8 @@ func (r *RPCStorageHandler) ProcessKeySpaceChanges(keys []string) {
 				tokenTypeHint = "refresh_token"
 			}
 			RevokeToken(storage, token, tokenTypeHint)
-		}else{
-			token = strings.Split(token,"#")[0]
+		} else {
+			token = strings.Split(token, "#")[0]
 			handleDeleteHashedKey(token, apiId, false)
 		}
 		SessionCache.Delete(token)

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -445,7 +445,7 @@ func loadControlAPIEndpoints(muxer *mux.Router) {
 		r.HandleFunc("/oauth/clients/{apiID}/{keyName:[^/]*}/rotate", rotateOauthClientHandler).Methods("PUT")
 		r.HandleFunc("/oauth/refresh/{keyName}", invalidateOauthRefresh).Methods("DELETE")
 		r.HandleFunc("/cache/{apiID}", invalidateCacheHandler).Methods("DELETE")
-		r.HandleFunc("/oauth/revoke",  RevokeTokenHandler).Methods("POST")
+		r.HandleFunc("/oauth/revoke", RevokeTokenHandler).Methods("POST")
 		r.HandleFunc("/oauth/revoke_all", RevokeAllTokensHandler).Methods("POST")
 
 	} else {
@@ -523,8 +523,8 @@ func addOAuthHandlers(spec *APISpec, muxer *mux.Router) *OAuthManager {
 	muxer.Handle(apiAuthorizePath, checkIsAPIOwner(allowMethods(oauthHandlers.HandleGenerateAuthCodeData, "POST")))
 	muxer.HandleFunc(clientAuthPath, allowMethods(oauthHandlers.HandleAuthorizePassthrough, "GET", "POST"))
 	muxer.HandleFunc(clientAccessPath, addSecureAndCacheHeaders(allowMethods(oauthHandlers.HandleAccessRequest, "GET", "POST")))
-	muxer.HandleFunc(revokeToken,oauthHandlers.HandleRevokeToken)
-	muxer.HandleFunc(revokeAllTokens,oauthHandlers.HandleRevokeAllTokens)
+	muxer.HandleFunc(revokeToken, oauthHandlers.HandleRevokeToken)
+	muxer.HandleFunc(revokeAllTokens, oauthHandlers.HandleRevokeAllTokens)
 	return &oauthManager
 }
 

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -510,6 +510,7 @@ func addOAuthHandlers(spec *APISpec, muxer *mux.Router) *OAuthManager {
 	serverConfig.RedirectUriSeparator = config.Global().OauthRedirectUriSeparator
 
 	prefix := generateOAuthPrefix(spec.APIID)
+	log.Info("prefix for oatuh redis:", prefix)
 	storageManager := getGlobalStorageHandler(prefix, false)
 	storageManager.Connect()
 	osinStorage := &RedisOsinStorageInterface{storageManager, GlobalSessionManager, spec.OrgID}

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -468,6 +468,7 @@ func loadControlAPIEndpoints(muxer *mux.Router) {
 		r.HandleFunc("/oauth/clients/create", createOauthClient).Methods("POST")
 		r.HandleFunc("/oauth/clients/{apiID}/{keyName:[^/]*}", oAuthClientHandler).Methods("PUT")
 		r.HandleFunc("/oauth/clients/{apiID}/{keyName:[^/]*}/rotate", rotateOauthClientHandler).Methods("PUT")
+		r.HandleFunc("/oauth/clients/apis/{appID}", getApisForOauthApp).Methods("GET")
 		r.HandleFunc("/oauth/refresh/{keyName}", invalidateOauthRefresh).Methods("DELETE")
 		r.HandleFunc("/cache/{apiID}", invalidateCacheHandler).Methods("DELETE")
 		r.HandleFunc("/oauth/revoke", RevokeTokenHandler).Methods("POST")

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -491,6 +491,8 @@ func addOAuthHandlers(spec *APISpec, muxer *mux.Router) *OAuthManager {
 	apiAuthorizePath := spec.Proxy.ListenPath + "tyk/oauth/authorize-client{_:/?}"
 	clientAuthPath := spec.Proxy.ListenPath + "oauth/authorize{_:/?}"
 	clientAccessPath := spec.Proxy.ListenPath + "oauth/token{_:/?}"
+	revokeToken := spec.Proxy.ListenPath + "oauth/revoke"
+	revokeAllTokens := spec.Proxy.ListenPath + "oauth/revoke_all"
 
 	serverConfig := osin.NewServerConfig()
 
@@ -517,7 +519,8 @@ func addOAuthHandlers(spec *APISpec, muxer *mux.Router) *OAuthManager {
 	muxer.Handle(apiAuthorizePath, checkIsAPIOwner(allowMethods(oauthHandlers.HandleGenerateAuthCodeData, "POST")))
 	muxer.HandleFunc(clientAuthPath, allowMethods(oauthHandlers.HandleAuthorizePassthrough, "GET", "POST"))
 	muxer.HandleFunc(clientAccessPath, addSecureAndCacheHeaders(allowMethods(oauthHandlers.HandleAccessRequest, "GET", "POST")))
-
+	muxer.HandleFunc(revokeToken,oauthHandlers.HandleRevokeToken)
+	muxer.HandleFunc(revokeAllTokens,oauthHandlers.HandleRevokeAllTokens)
 	return &oauthManager
 }
 

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -445,6 +445,9 @@ func loadControlAPIEndpoints(muxer *mux.Router) {
 		r.HandleFunc("/oauth/clients/{apiID}/{keyName:[^/]*}/rotate", rotateOauthClientHandler).Methods("PUT")
 		r.HandleFunc("/oauth/refresh/{keyName}", invalidateOauthRefresh).Methods("DELETE")
 		r.HandleFunc("/cache/{apiID}", invalidateCacheHandler).Methods("DELETE")
+		r.HandleFunc("/oauth/revoke",  RevokeTokenHandler).Methods("POST")
+		r.HandleFunc("/oauth/revoke_all", RevokeAllTokensHandler).Methods("POST")
+
 	} else {
 		mainLog.Info("Node is slaved, REST API minimised")
 	}

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -146,22 +146,22 @@ func getApiSpec(apiID string) *APISpec {
 	return spec
 }
 
-func getApisForOauthClientId(oauthClientId string) []string{
-	apis:= []string{}
+func getApisForOauthClientId(oauthClientId string) []string {
+	apis := []string{}
 	apisIdsCopy := []string{}
 
 	//generate a copy only with ids so we do not attempt to lock twice
 	apisMu.RLock()
-	for apiId,_ := range apisByID{
+	for apiId, _ := range apisByID {
 		apisIdsCopy = append(apisIdsCopy, apiId)
 	}
 	apisMu.RUnlock()
 
-	for index := range apisIdsCopy{
-		clientsData,_, status := getApiClients(apisIdsCopy[index])
+	for index := range apisIdsCopy {
+		clientsData, _, status := getApiClients(apisIdsCopy[index])
 		if status == http.StatusOK {
-			for _,client := range clientsData{
-				if client.GetId() == oauthClientId{
+			for _, client := range clientsData {
+				if client.GetId() == oauthClientId {
 					apis = append(apis, apisIdsCopy[index])
 				}
 			}

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -146,6 +146,31 @@ func getApiSpec(apiID string) *APISpec {
 	return spec
 }
 
+func getApisForOauthClientId(oauthClientId string) []string{
+	apis:= []string{}
+	apisIdsCopy := []string{}
+
+	//generate a copy only with ids so we do not attempt to lock twice
+	apisMu.RLock()
+	for apiId,_ := range apisByID{
+		apisIdsCopy = append(apisIdsCopy, apiId)
+	}
+	apisMu.RUnlock()
+
+	for index := range apisIdsCopy{
+		clientsData,_, status := getApiClients(apisIdsCopy[index])
+		if status == http.StatusOK {
+			for _,client := range clientsData{
+				if client.GetId() == oauthClientId{
+					apis = append(apis, apisIdsCopy[index])
+				}
+			}
+		}
+	}
+
+	return apis
+}
+
 func apisByIDLen() int {
 	apisMu.RLock()
 	defer apisMu.RUnlock()

--- a/rpc/rpc_client.go
+++ b/rpc/rpc_client.go
@@ -286,7 +286,6 @@ func GroupLogin() bool {
 
 	if ok == false {
 		Log.Error("RPC Login incorrect")
-		Log.Error("the group used is: ", config.GroupID)
 		rpcEmergencyMode = true
 		go reAttemptLogin(errors.New("Login incorrect"))
 		return false

--- a/rpc/rpc_client.go
+++ b/rpc/rpc_client.go
@@ -286,6 +286,7 @@ func GroupLogin() bool {
 
 	if ok == false {
 		Log.Error("RPC Login incorrect")
+		Log.Error("the group used is: ", config.GroupID)
 		rpcEmergencyMode = true
 		go reAttemptLogin(errors.New("Login incorrect"))
 		return false

--- a/storage/redis_cluster.go
+++ b/storage/redis_cluster.go
@@ -369,8 +369,7 @@ func (r *RedisCluster) GetKey(keyName string) (string, error) {
 	if err := r.up(); err != nil {
 		return "", err
 	}
-	// log.Debug("[STORE] Getting WAS: ", keyName)
-	// log.Debug("[STORE] Getting: ", r.fixKey(keyName))
+
 	cluster := r.singleton()
 
 	value, err := cluster.Get(r.fixKey(keyName)).Result()


### PR DESCRIPTION
Added endpoints to allow users to revoke access and refresh tokens, the endpoints are exposed in 2 levels: dashboard access (its already connected using another endpoint) and exposed directly via api as `OAuthHandler`  (this one is compliant of https://tools.ietf.org/html/rfc7009)

To be specific, the endpoints added are for:

- revoke single token, describing the token and token_type_hint
- revoke all the tokens related to one oauth client, for this the user must provide: apiId, clientSecret and clientID

**Revoke single token**
Method: POST
Path: /{api-id}/oauth/revoke
Content type: application/x-www-form-urlencoded
Body:

- token: string | required
- token_type_hint: string | optional | accepted values = {access_token, refresh_token}

**Revoke all tokens**
Method: POST
Path: /{api-id}/oauth/revoke_all
Content type: application/x-www-form-urlencoded
Body:

- client_id : ID of Oauth client
- client_secret: Secret of Oauth client, used to check the veracity of the request

Related to: https://github.com/TykTechnologies/product/issues/264