### PR TITLE
Allow oAuth token override metadata if using key_rules

### DIFF
--- a/gateway/oauth_manager.go
+++ b/gateway/oauth_manager.go
@@ -827,7 +827,16 @@ func (r *RedisOsinStorageInterface) SaveAccess(accessData *osin.AccessData) erro
 
 	c, ok := accessData.Client.(*OAuthClient)
 	if ok && c.MetaData != nil {
-		newSession.MetaData = c.MetaData.(map[string]interface{})
+		if newSession.MetaData == nil {
+			newSession.MetaData = make(map[string]interface{})
+		}
+
+		// Allow session inherit and *override* client values
+		for k, v := range c.MetaData.(map[string]interface{}) {
+			if _, found := newSession.MetaData[k]; !found {
+				newSession.MetaData[k] = v
+			}
+		}
 	}
 
 	// Use the default session expiry here as this is OAuth

--- a/gateway/oauth_manager_test.go
+++ b/gateway/oauth_manager_test.go
@@ -46,6 +46,18 @@ const keyRules = `{
 	"quota_renewal_rate": 300
 }`
 
+const keyRulesWithMetadata = `{
+	"last_check": 1402492859,
+	"org_id": "53ac07777cbb8c2d53000002",
+	"rate": 1,
+	"per": 1,
+	"quota_max": -1,
+	"quota_renews": 1399567002,
+	"quota_remaining": 10,
+	"quota_renewal_rate": 300,
+	"meta_data": {"key": "meta", "foo": "keybar"}
+}`
+
 func buildTestOAuthSpec(apiGens ...func(spec *APISpec)) *APISpec {
 	return BuildAPI(func(spec *APISpec) {
 		spec.APIID = "999999"
@@ -127,6 +139,7 @@ func createTestOAuthClient(spec *APISpec, clientID string) {
 		ClientSecret:      authClientSecret,
 		ClientRedirectURI: redirectURI,
 		PolicyID:          pID,
+		MetaData:          map[string]interface{}{"foo": "bar", "client": "meta"},
 	}
 	spec.OAuthManager.OsinServer.Storage.SetClient(testClient.ClientID, &testClient, false)
 }
@@ -386,6 +399,54 @@ func TestAPIClientAuthorizeToken(t *testing.T) {
 			BodyMatch: `{"access_token":".*","expires_in":3600,"redirect_to":"http://client.oauth.com` +
 				`#access_token=.*=&expires_in=3600&token_type=bearer","token_type":"bearer"}`,
 		})
+	})
+
+	t.Run("Client authorize token request with metadata", func(t *testing.T) {
+		param := make(url.Values)
+		param.Set("response_type", "token")
+		param.Set("redirect_uri", authRedirectUri)
+		param.Set("client_id", authClientID)
+		param.Set("key_rules", keyRulesWithMetadata)
+
+		headers := map[string]string{
+			"Content-Type": "application/x-www-form-urlencoded",
+		}
+
+		resp, err := ts.Run(t, test.TestCase{
+			Path:      "/APIID/tyk/oauth/authorize-client/",
+			AdminAuth: true,
+			Data:      param.Encode(),
+			Headers:   headers,
+			Method:    http.MethodPost,
+			Code:      http.StatusOK,
+			BodyMatch: `{"access_token":".*","expires_in":3600,"redirect_to":"http://client.oauth.com` +
+				`#access_token=.*=&expires_in=3600&token_type=bearer","token_type":"bearer"}`,
+		})
+		if err != nil {
+			t.Error(err)
+		}
+		asData := make(map[string]interface{})
+		if err := json.NewDecoder(resp.Body).Decode(&asData); err != nil {
+			t.Fatal("Decode failed:", err)
+		}
+		token, ok := asData["access_token"].(string)
+		if !ok {
+			t.Fatal("No access token found")
+		}
+		session, ok := spec.AuthManager.KeyAuthorised(token)
+		if !ok {
+			t.Error("Key was not created (Can't find it)!")
+		}
+		if session.MetaData == nil {
+			t.Fatal("Session metadata is nil")
+		}
+		if len(session.MetaData) != 3 {
+			t.Fatal("Unexpected session metadata length", session.MetaData)
+		}
+
+		if !reflect.DeepEqual(session.MetaData, map[string]interface{}{"foo": "keybar", "client": "meta", "key": "meta"}) {
+			t.Fatal("Metadata not match:", session.MetaData)
+		}
 	})
 }
 


### PR DESCRIPTION
Now token inherits and overrides client metadata
Fix https://github.com/TykTechnologies/tyk/issues/2724

Added instead of https://github.com/TykTechnologies/tyk/pull/2885