### PR TITLE
Add global option to ignore endpoint case

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -244,6 +244,7 @@ type VersionInfo struct {
 	ExtendedPaths       ExtendedPathsSet  `bson:"extended_paths" json:"extended_paths"`
 	GlobalHeaders       map[string]string `bson:"global_headers" json:"global_headers"`
 	GlobalHeadersRemove []string          `bson:"global_headers_remove" json:"global_headers_remove"`
+	IgnoreEndpointCase  bool              `bson:"ignore_endpoint_case" json:"ignore_endpoint_case"`
 	GlobalSizeLimit     int64             `bson:"global_size_limit" json:"global_size_limit"`
 	OverrideTarget      string            `bson:"override_target" json:"override_target"`
 }

--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -236,6 +236,9 @@
         }
       }
     },
+    "ignore_endpoint_case": {
+      "type": "boolean"
+    },
     "db_app_conf_options": {
       "type": ["object", "null"],
       "additionalProperties": false,

--- a/config/config.go
+++ b/config/config.go
@@ -421,6 +421,7 @@ type Config struct {
 	TykJSPath                string          `json:"tyk_js_path"`
 	MiddlewarePath           string          `json:"middleware_path"`
 	CoProcessOptions         CoProcessConfig `json:"coprocess_options"`
+	IgnoreEndpointCase       bool            `json:"ignore_endpoint_case"`
 
 	// Monitoring, Logging & Profiling
 	LogLevel                string         `json:"log_level"`

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -525,7 +525,7 @@ func (a APIDefinitionLoader) generateRegex(stringSpec string, newSpec *URLSpec, 
 	apiLangIDsRegex := regexp.MustCompile(`{([^}]*)}`)
 	asRegexStr := apiLangIDsRegex.ReplaceAllString(stringSpec, `([^/]*)`)
 	// Case insensitive match
-	if newSpec.IgnoreCase {
+	if newSpec.IgnoreCase || config.Global().IgnoreEndpointCase {
 		asRegexStr = "(?i)" + asRegexStr
 	}
 	asRegex, _ := regexp.Compile(asRegexStr)

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -547,13 +547,13 @@ func (a APIDefinitionLoader) compilePathSpec(paths []string, specType URLStatus)
 	return urlSpec
 }
 
-func (a APIDefinitionLoader) compileExtendedPathSpec(paths []apidef.EndPointMeta, specType URLStatus) []URLSpec {
+func (a APIDefinitionLoader) compileExtendedPathSpec(ignoreEndpointCase bool, paths []apidef.EndPointMeta, specType URLStatus) []URLSpec {
 	// transform an extended configuration URL into an array of URLSpecs
 	// This way we can iterate the whole array once, on match we break with status
 	urlSpec := []URLSpec{}
 
 	for _, stringSpec := range paths {
-		newSpec := URLSpec{IgnoreCase: stringSpec.IgnoreCase}
+		newSpec := URLSpec{IgnoreCase: stringSpec.IgnoreCase || ignoreEndpointCase}
 		a.generateRegex(stringSpec.Path, &newSpec, specType)
 
 		// Extend with method actions
@@ -908,9 +908,9 @@ func (a APIDefinitionLoader) compileInternalPathspathSpec(paths []apidef.Interna
 func (a APIDefinitionLoader) getExtendedPathSpecs(apiVersionDef apidef.VersionInfo, apiSpec *APISpec) ([]URLSpec, bool) {
 	// TODO: New compiler here, needs to put data into a different structure
 
-	ignoredPaths := a.compileExtendedPathSpec(apiVersionDef.ExtendedPaths.Ignored, Ignored)
-	blackListPaths := a.compileExtendedPathSpec(apiVersionDef.ExtendedPaths.BlackList, BlackList)
-	whiteListPaths := a.compileExtendedPathSpec(apiVersionDef.ExtendedPaths.WhiteList, WhiteList)
+	ignoredPaths := a.compileExtendedPathSpec(apiVersionDef.IgnoreEndpointCase, apiVersionDef.ExtendedPaths.Ignored, Ignored)
+	blackListPaths := a.compileExtendedPathSpec(apiVersionDef.IgnoreEndpointCase, apiVersionDef.ExtendedPaths.BlackList, BlackList)
+	whiteListPaths := a.compileExtendedPathSpec(apiVersionDef.IgnoreEndpointCase, apiVersionDef.ExtendedPaths.WhiteList, WhiteList)
 	cachedPaths := a.compileCachedPathSpec(apiVersionDef.ExtendedPaths.Cached, apiVersionDef.ExtendedPaths.AdvanceCacheConfig)
 	transformPaths := a.compileTransformPathSpec(apiVersionDef.ExtendedPaths.Transform, Transformed)
 	transformResponsePaths := a.compileTransformPathSpec(apiVersionDef.ExtendedPaths.TransformResponse, TransformedResponse)

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -393,6 +393,43 @@ func TestIgnored(t *testing.T) {
 				{Path: "/Bar", Code: http.StatusOK},
 			}...)
 		})
+
+		t.Run("ignore-case in api level", func(t *testing.T) {
+			globalConf := config.Global()
+			globalConf.IgnoreEndpointCase = false
+			config.SetGlobal(globalConf)
+
+			v := spec.VersionData.Versions["v1"]
+			v.IgnoreEndpointCase = true
+			spec.VersionData.Versions["v1"] = v
+
+			LoadAPI(spec)
+
+			_, _ = ts.Run(t, []test.TestCase{
+				{Path: "/foo", Code: http.StatusOK},
+				{Path: "/Foo", Code: http.StatusOK},
+				{Path: "/bar", Code: http.StatusOK},
+				{Path: "/Bar", Code: http.StatusOK},
+			}...)
+		})
+
+		// Check whether everything returns normal
+		globalConf := config.Global()
+		globalConf.IgnoreEndpointCase = false
+		config.SetGlobal(globalConf)
+
+		v := spec.VersionData.Versions["v1"]
+		v.IgnoreEndpointCase = false
+		spec.VersionData.Versions["v1"] = v
+
+		LoadAPI(spec)
+
+		_, _ = ts.Run(t, []test.TestCase{
+			{Path: "/foo", Code: http.StatusUnauthorized},
+			{Path: "/Foo", Code: http.StatusOK},
+			{Path: "/bar", Code: http.StatusOK},
+			{Path: "/Bar", Code: http.StatusOK},
+		}...)
 	})
 }
 


### PR DESCRIPTION
This PR adds new config parameter `ignore_endpoint_case`. If it is `true`, all endpoint matches will work by ignoring case no matter what is set for the `ignore_endpoint_case` value in API level and the endpoint `ignore_case` value. On UI, maybe we should disable it when the global one is true.  

Also, it adds new API level parameter `ignore_enpoint_case`. If it is `true`, all endpoint matches for the API will work by ignoring case no matter what is set for the endpoint `ignore_case` value.

Fixes #2897 