### PR TITLE
Fix rich plugins and JSON validation usage

### DIFF
--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -175,6 +175,7 @@ func (c *CoProcessor) BuildObject(req *http.Request, res *http.Response) (*copro
 func (c *CoProcessor) ObjectPostProcess(object *coprocess.Object, r *http.Request) (err error) {
 	r.ContentLength = int64(len(object.Request.RawBody))
 	r.Body = ioutil.NopCloser(bytes.NewReader(object.Request.RawBody))
+	nopCloseRequestBody(r)
 
 	for _, dh := range object.Request.DeleteHeaders {
 		r.Header.Del(dh)


### PR DESCRIPTION
Fix for #2913.

Makes use of the `nopCloseRequestBody` helper.