### PR TITLE
 fix plugins

### DIFF
--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -176,9 +176,9 @@ func (c *CoProcessor) ObjectPostProcess(object *coprocess.Object, r *http.Reques
 	r.ContentLength = int64(len(object.Request.RawBody))
 	r.Body = ioutil.NopCloser(bytes.NewReader(object.Request.RawBody))
 	nopCloseRequestBody(r)
-	
+
 	logger := c.Middleware.Logger()
-	
+
 	for _, dh := range object.Request.DeleteHeaders {
 		r.Header.Del(dh)
 	}

--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -172,7 +172,7 @@ func (c *CoProcessor) BuildObject(req *http.Request, res *http.Response) (*copro
 }
 
 // ObjectPostProcess does CoProcessObject post-processing (adding/removing headers or params, etc.).
-func (c *CoProcessor) ObjectPostProcess(object *coprocess.Object, r *http.Request) (err error) {
+func (c *CoProcessor) ObjectPostProcess(object *coprocess.Object, r *http.Request, origURL string, origMethod string) (err error) {
 	r.ContentLength = int64(len(object.Request.RawBody))
 	r.Body = ioutil.NopCloser(bytes.NewReader(object.Request.RawBody))
 	nopCloseRequestBody(r)
@@ -194,11 +194,29 @@ func (c *CoProcessor) ObjectPostProcess(object *coprocess.Object, r *http.Reques
 		values.Set(p, v)
 	}
 
-	r.URL, err = url.ParseRequestURI(object.Request.Url)
+	parsedURL, err := url.ParseRequestURI(object.Request.Url)
 	if err != nil {
 		return
 	}
+
+	rewriteURL := ctxGetURLRewriteTarget(r)
+	if rewriteURL != nil {
+		ctxSetURLRewriteTarget(r, parsedURL)
+		r.URL, _ = url.ParseRequestURI(origURL)
+	} else {
+		r.URL = parsedURL
+	}
+
+	transformMethod := ctxGetTransformRequestMethod(r)
+	if transformMethod != "" {
+		ctxSetTransformRequestMethod(r, object.Request.Method)
+		r.Method = origMethod
+	} else {
+		r.Method = object.Request.Method
+	}
+
 	r.URL.RawQuery = values.Encode()
+
 	return
 }
 
@@ -300,6 +318,19 @@ func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 		return errors.New("Middleware error"), 500
 	}
 
+	var origURL string
+	if rewriteUrl := ctxGetURLRewriteTarget(r); rewriteUrl != nil {
+		origURL = object.Request.Url
+		object.Request.Url = rewriteUrl.String()
+		object.Request.RequestUri = rewriteUrl.RequestURI()
+	}
+
+	var origMethod string
+	if transformMethod := ctxGetTransformRequestMethod(r); transformMethod != "" {
+		origMethod = r.Method
+		object.Request.Method = transformMethod
+	}
+
 	t1 := time.Now()
 	returnObject, err := coProcessor.Dispatch(object)
 	ms := DurationToMillisecond(time.Since(t1))
@@ -315,7 +346,7 @@ func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 
 	m.logger.WithField("ms", ms).Debug("gRPC request processing took")
 
-	err = coProcessor.ObjectPostProcess(returnObject, r)
+	err = coProcessor.ObjectPostProcess(returnObject, r, origURL, origMethod)
 	if err != nil {
 		// Restore original URL object so that it can be used by ErrorHandler:
 		r.URL = originalURL

--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -177,7 +177,7 @@ func (c *CoProcessor) ObjectPostProcess(object *coprocess.Object, r *http.Reques
 	r.Body = ioutil.NopCloser(bytes.NewReader(object.Request.RawBody))
 	nopCloseRequestBody(r)
 	
-	logger := m.Middleware.Logger()
+	logger := c.Middleware.Logger()
 	
 	for _, dh := range object.Request.DeleteHeaders {
 		r.Header.Del(dh)

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -151,7 +151,7 @@ func getApisForOauthClientId(oauthClientId string) []string {
 
 	//generate a copy only with ids so we do not attempt to lock twice
 	apisMu.RLock()
-	for apiId, _ := range apisByID {
+	for apiId := range apisByID {
 		apisIdsCopy = append(apisIdsCopy, apiId)
 	}
 	apisMu.RUnlock()


### PR DESCRIPTION
Fixes #2922 

In 2.8.x URL Rewrite/Method transform middleware directly modified http.Request object.
This behavior was changed in 2.9.x(https://github.com/TykTechnologies/tyk/pull/2301/files) 
http.Request is now transformed at the end of middleware chain. Because of this Post hook did not received modified values.

Fixed the code by passing URLRewrite/Method Transform info to Post hook of the plugin.