### PR TITLE
add comprehensive check on whether to enable size limit check

### DIFF
--- a/gateway/mw_request_size_limit.go
+++ b/gateway/mw_request_size_limit.go
@@ -21,6 +21,19 @@ func (t *RequestSizeLimitMiddleware) Name() string {
 }
 
 func (t *RequestSizeLimitMiddleware) EnabledForSpec() bool {
+	if t.Spec.VersionData.NotVersioned {
+
+		var vInfo apidef.VersionInfo
+
+		for _, v := range t.Spec.VersionData.Versions {
+			// Use the first version
+			vInfo = v
+			break
+		}
+
+		return vInfo.GlobalSizeLimit > 0
+	}
+
 	for _, version := range t.Spec.VersionData.Versions {
 		if len(version.ExtendedPaths.SizeLimit) > 0 {
 			return true


### PR DESCRIPTION
Fixes https://github.com/TykTechnologies/tyk/issues/2887

Currently if the spec is not versioned, the size limit middleware doesn't kick in. As versioned apis don’t make use of “global_size_limit” but “size_limit” for different paths and methods