### PR TITLE
Override oauth errors with global config

### DIFF
--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -528,7 +528,7 @@
       "type": "string",
       "format": "path"
     },
-    "tyk_errors": {
+    "override_errors": {
       "type": ["object", "null"],
       "additionalProperties": false,
       "properties": {

--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -528,6 +528,18 @@
       "type": "string",
       "format": "path"
     },
+    "tyk_errors": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "code": {
+          "type": "integer"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
     "monitor": {
       "type": ["object", "null"],
       "additionalProperties": false,

--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -528,7 +528,7 @@
       "type": "string",
       "format": "path"
     },
-    "override_errors": {
+    "override_messages": {
       "type": ["object", "null"],
       "additionalProperties": false,
       "properties": {

--- a/config/config.go
+++ b/config/config.go
@@ -465,11 +465,9 @@ type Config struct {
 	// Secrets are key-value pairs that can be accessed in the dashboard via "secrets://"
 	Secrets map[string]string `json:"secrets"`
 
-	// TykErrors is used to override returned API error codes and messages.
-	TykErrors map[TykErrorType]TykError `bson:"tyk_errors" json:"tyk_errors"`
+	// OverrideErrors is used to override returned API error codes and messages.
+	OverrideErrors map[string]TykError `bson:"override_errors" json:"override_errors"`
 }
-
-type TykErrorType string
 
 type TykError struct {
 	Message string `json:"message"`

--- a/config/config.go
+++ b/config/config.go
@@ -465,8 +465,8 @@ type Config struct {
 	// Secrets are key-value pairs that can be accessed in the dashboard via "secrets://"
 	Secrets map[string]string `json:"secrets"`
 
-	// OverrideErrors is used to override returned API error codes and messages.
-	OverrideErrors map[string]TykError `bson:"override_errors" json:"override_errors"`
+	// OverrideMessages is used to override returned API error codes and messages.
+	OverrideMessages map[string]TykError `bson:"override_messages" json:"override_messages"`
 }
 
 type TykError struct {

--- a/config/config.go
+++ b/config/config.go
@@ -464,6 +464,16 @@ type Config struct {
 
 	// Secrets are key-value pairs that can be accessed in the dashboard via "secrets://"
 	Secrets map[string]string `json:"secrets"`
+
+	// TykErrors is used to override returned API error codes and messages.
+	TykErrors map[TykErrorType]TykError `bson:"tyk_errors" json:"tyk_errors"`
+}
+
+type TykErrorType string
+
+type TykError struct {
+	Message string `json:"message"`
+	Code    int    `json:"code"`
 }
 
 // VaultConfig is used to configure the creation of a client

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -2117,11 +2117,11 @@ func TestOverrideErrors(t *testing.T) {
 			Message: message1,
 			Code:    code1,
 		},
-		ErrOAuthBearerTokenMalformed: {
+		ErrOAuthAuthorizationFieldMalformed: {
 			Message: message2,
 			Code:    code2,
 		},
-		ErrOAuthKeyNotAuthorised: {
+		ErrOAuthKeyNotFound: {
 			Message: message3,
 			Code:    code3,
 		},
@@ -2133,7 +2133,7 @@ func TestOverrideErrors(t *testing.T) {
 			Message: message5,
 			Code:    code5,
 		},
-		ErrAuthNonExistentKey: {
+		ErrAuthKeyNotFound: {
 			Message: message6,
 			Code:    code6,
 		},
@@ -2145,10 +2145,10 @@ func TestOverrideErrors(t *testing.T) {
 	e, i := errorAndStatusCode(ErrOAuthAuthorizationFieldMissing)
 	assert(message1, code1, e, i)
 
-	e, i = errorAndStatusCode(ErrOAuthBearerTokenMalformed)
+	e, i = errorAndStatusCode(ErrOAuthAuthorizationFieldMalformed)
 	assert(message2, code2, e, i)
 
-	e, i = errorAndStatusCode(ErrOAuthKeyNotAuthorised)
+	e, i = errorAndStatusCode(ErrOAuthKeyNotFound)
 	assert(message3, code3, e, i)
 
 	e, i = errorAndStatusCode(ErrOAuthClientDeleted)
@@ -2157,7 +2157,7 @@ func TestOverrideErrors(t *testing.T) {
 	e, i = errorAndStatusCode(ErrAuthAuthorizationFieldMissing)
 	assert(message5, code5, e, i)
 
-	e, i = errorAndStatusCode(ErrAuthNonExistentKey)
+	e, i = errorAndStatusCode(ErrAuthKeyNotFound)
 	assert(message6, code6, e, i)
 
 	t.Run("Partial override", func(t *testing.T) {
@@ -2165,7 +2165,7 @@ func TestOverrideErrors(t *testing.T) {
 			ErrOAuthAuthorizationFieldMissing: {
 				Code: code4,
 			},
-			ErrOAuthBearerTokenMalformed: {
+			ErrOAuthAuthorizationFieldMalformed: {
 				Message: message4,
 			},
 		}
@@ -2176,7 +2176,7 @@ func TestOverrideErrors(t *testing.T) {
 		e, i := errorAndStatusCode(ErrOAuthAuthorizationFieldMissing)
 		assert(message1, code4, e, i)
 
-		e, i = errorAndStatusCode(ErrOAuthBearerTokenMalformed)
+		e, i = errorAndStatusCode(ErrOAuthAuthorizationFieldMalformed)
 		assert(message4, code2, e, i)
 
 	})

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -2112,7 +2112,7 @@ func TestOverrideErrors(t *testing.T) {
 	const code6 = 6
 
 	globalConf := config.Global()
-	globalConf.OverrideErrors = map[string]config.TykError{
+	globalConf.OverrideMessages = map[string]config.TykError{
 		ErrOAuthAuthorizationFieldMissing: {
 			Message: message1,
 			Code:    code1,
@@ -2161,7 +2161,7 @@ func TestOverrideErrors(t *testing.T) {
 	assert(message6, code6, e, i)
 
 	t.Run("Partial override", func(t *testing.T) {
-		globalConf.OverrideErrors = map[string]config.TykError{
+		globalConf.OverrideMessages = map[string]config.TykError{
 			ErrOAuthAuthorizationFieldMissing: {
 				Code: code4,
 			},

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -2091,7 +2091,7 @@ func TestCache_singleErrorResponse(t *testing.T) {
 	)
 }
 
-func TestOverrideTykErrors(t *testing.T) {
+func TestOverrideErrors(t *testing.T) {
 	assert := func(expectedError string, expectedCode int, actualError error, actualCode int) {
 		if !(expectedError == actualError.Error() && expectedCode == actualCode) {
 			t.Fatal("Override failed")
@@ -2106,48 +2106,66 @@ func TestOverrideTykErrors(t *testing.T) {
 	const code3 = 3
 	const message4 = "Message4"
 	const code4 = 4
+	const message5 = "Message5"
+	const code5 = 5
+	const message6 = "Message6"
+	const code6 = 6
 
 	globalConf := config.Global()
-	globalConf.TykErrors = map[config.TykErrorType]config.TykError{
-		OAuthAuthorizationFieldMissing: {
+	globalConf.OverrideErrors = map[string]config.TykError{
+		ErrOAuthAuthorizationFieldMissing: {
 			Message: message1,
 			Code:    code1,
 		},
-		OAuthBearerTokenMalformed: {
+		ErrOAuthBearerTokenMalformed: {
 			Message: message2,
 			Code:    code2,
 		},
-		OAuthKeyNotAuthorised: {
+		ErrOAuthKeyNotAuthorised: {
 			Message: message3,
 			Code:    code3,
 		},
-		OAuthClientDeleted: {
+		ErrOAuthClientDeleted: {
 			Message: message4,
 			Code:    code4,
+		},
+		ErrAuthAuthorizationFieldMissing: {
+			Message: message5,
+			Code:    code5,
+		},
+		ErrAuthNonExistentKey: {
+			Message: message6,
+			Code:    code6,
 		},
 	}
 	config.SetGlobal(globalConf)
 
 	overrideTykErrors()
 
-	e, i := errorAndStatusCode(OAuthAuthorizationFieldMissing)
+	e, i := errorAndStatusCode(ErrOAuthAuthorizationFieldMissing)
 	assert(message1, code1, e, i)
 
-	e, i = errorAndStatusCode(OAuthBearerTokenMalformed)
+	e, i = errorAndStatusCode(ErrOAuthBearerTokenMalformed)
 	assert(message2, code2, e, i)
 
-	e, i = errorAndStatusCode(OAuthKeyNotAuthorised)
+	e, i = errorAndStatusCode(ErrOAuthKeyNotAuthorised)
 	assert(message3, code3, e, i)
 
-	e, i = errorAndStatusCode(OAuthClientDeleted)
+	e, i = errorAndStatusCode(ErrOAuthClientDeleted)
 	assert(message4, code4, e, i)
 
+	e, i = errorAndStatusCode(ErrAuthAuthorizationFieldMissing)
+	assert(message5, code5, e, i)
+
+	e, i = errorAndStatusCode(ErrAuthNonExistentKey)
+	assert(message6, code6, e, i)
+
 	t.Run("Partial override", func(t *testing.T) {
-		globalConf.TykErrors = map[config.TykErrorType]config.TykError{
-			OAuthAuthorizationFieldMissing: {
+		globalConf.OverrideErrors = map[string]config.TykError{
+			ErrOAuthAuthorizationFieldMissing: {
 				Code: code4,
 			},
-			OAuthBearerTokenMalformed: {
+			ErrOAuthBearerTokenMalformed: {
 				Message: message4,
 			},
 		}
@@ -2155,10 +2173,10 @@ func TestOverrideTykErrors(t *testing.T) {
 
 		overrideTykErrors()
 
-		e, i := errorAndStatusCode(OAuthAuthorizationFieldMissing)
+		e, i := errorAndStatusCode(ErrOAuthAuthorizationFieldMissing)
 		assert(message1, code4, e, i)
 
-		e, i = errorAndStatusCode(OAuthBearerTokenMalformed)
+		e, i = errorAndStatusCode(ErrOAuthBearerTokenMalformed)
 		assert(message4, code2, e, i)
 
 	})

--- a/gateway/handler_error.go
+++ b/gateway/handler_error.go
@@ -31,7 +31,7 @@ func errorAndStatusCode(errType string) (error, int) {
 }
 
 func overrideTykErrors() {
-	for id, err := range config.Global().OverrideErrors {
+	for id, err := range config.Global().OverrideMessages {
 
 		overridenErr := TykErrors[id]
 

--- a/gateway/handler_error.go
+++ b/gateway/handler_error.go
@@ -23,39 +23,15 @@ const (
 	defaultContentType    = headers.ApplicationJSON
 )
 
-const (
-	OAuthAuthorizationFieldMissing config.TykErrorType = "oauth.auth_field_missing"
-	OAuthBearerTokenMalformed      config.TykErrorType = "oauth.bearer_token_malformed"
-	OAuthKeyNotAuthorised          config.TykErrorType = "oauth.key_not_authorised"
-	OAuthClientDeleted             config.TykErrorType = "oauth.client_deleted"
-)
+var TykErrors = make(map[string]config.TykError)
 
-var TykErrors = map[config.TykErrorType]config.TykError{
-	OAuthAuthorizationFieldMissing: {
-		Message: "Authorization field missing",
-		Code:    http.StatusBadRequest,
-	},
-	OAuthBearerTokenMalformed: {
-		Message: "Bearer token malformed",
-		Code:    http.StatusBadRequest,
-	},
-	OAuthKeyNotAuthorised: {
-		Message: "Key not authorised",
-		Code:    http.StatusForbidden,
-	},
-	OAuthClientDeleted: {
-		Message: "Key not authorised. OAuth client access was revoked",
-		Code:    http.StatusForbidden,
-	},
-}
-
-func errorAndStatusCode(errType config.TykErrorType) (error, int) {
+func errorAndStatusCode(errType string) (error, int) {
 	err := TykErrors[errType]
 	return errors.New(err.Message), err.Code
 }
 
 func overrideTykErrors() {
-	for id, err := range config.Global().TykErrors {
+	for id, err := range config.Global().OverrideErrors {
 
 		overridenErr := TykErrors[id]
 

--- a/gateway/mw_auth_key.go
+++ b/gateway/mw_auth_key.go
@@ -20,7 +20,7 @@ const (
 
 const (
 	ErrAuthAuthorizationFieldMissing = "auth.auth_field_missing"
-	ErrAuthNonExistentKey            = "auth.nonexistent_key"
+	ErrAuthKeyNotFound               = "auth.key_not_found"
 )
 
 func init() {
@@ -29,7 +29,7 @@ func init() {
 		Code:    http.StatusUnauthorized,
 	}
 
-	TykErrors[ErrAuthNonExistentKey] = config.TykError{
+	TykErrors[ErrAuthKeyNotFound] = config.TykError{
 		Message: "Access to this API has been disallowed",
 		Code:    http.StatusForbidden,
 	}
@@ -95,7 +95,7 @@ func (k *AuthKey) ProcessRequest(w http.ResponseWriter, r *http.Request, _ inter
 		// Report in health check
 		reportHealthValue(k.Spec, KeyFailure, "1")
 
-		return errorAndStatusCode(ErrAuthNonExistentKey)
+		return errorAndStatusCode(ErrAuthKeyNotFound)
 	}
 
 	// Set session state on context, we will need it later

--- a/gateway/mw_auth_key.go
+++ b/gateway/mw_auth_key.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/TykTechnologies/tyk/config"
+
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/certs"
 	"github.com/TykTechnologies/tyk/request"
@@ -15,6 +17,23 @@ const (
 	defaultSignatureErrorCode    = http.StatusUnauthorized
 	defaultSignatureErrorMessage = "Request signature verification failed"
 )
+
+const (
+	ErrAuthAuthorizationFieldMissing = "auth.auth_field_missing"
+	ErrAuthNonExistentKey            = "auth.nonexistent_key"
+)
+
+func init() {
+	TykErrors[ErrAuthAuthorizationFieldMissing] = config.TykError{
+		Message: "Authorization field missing",
+		Code:    http.StatusUnauthorized,
+	}
+
+	TykErrors[ErrAuthNonExistentKey] = config.TykError{
+		Message: "Access to this API has been disallowed",
+		Code:    http.StatusForbidden,
+	}
+}
 
 // KeyExists will check if the key being used to access the API is in the request data,
 // and then if the key is in the storage engine
@@ -59,7 +78,7 @@ func (k *AuthKey) ProcessRequest(w http.ResponseWriter, r *http.Request, _ inter
 		// No header value, fail
 		k.Logger().Info("Attempted access with malformed header, no auth header found.")
 
-		return errors.New("Authorization field missing"), http.StatusUnauthorized
+		return errorAndStatusCode(ErrAuthAuthorizationFieldMissing)
 	}
 
 	// Ignore Bearer prefix on token if it exists
@@ -76,7 +95,7 @@ func (k *AuthKey) ProcessRequest(w http.ResponseWriter, r *http.Request, _ inter
 		// Report in health check
 		reportHealthValue(k.Spec, KeyFailure, "1")
 
-		return errors.New("Access to this API has been disallowed"), http.StatusForbidden
+		return errorAndStatusCode(ErrAuthNonExistentKey)
 	}
 
 	// Set session state on context, we will need it later

--- a/gateway/mw_oauth2_key_exists.go
+++ b/gateway/mw_oauth2_key_exists.go
@@ -5,12 +5,43 @@ import (
 	"strings"
 	"time"
 
+	"github.com/TykTechnologies/tyk/config"
+
 	"github.com/TykTechnologies/tyk/apidef"
 )
 
 const (
 	checkOAuthClientDeletedInetrval = 1 * time.Second
 )
+
+const (
+	ErrOAuthAuthorizationFieldMissing = "oauth.auth_field_missing"
+	ErrOAuthBearerTokenMalformed      = "oauth.bearer_token_malformed"
+	ErrOAuthKeyNotAuthorised          = "oauth.key_not_authorised"
+	ErrOAuthClientDeleted             = "oauth.client_deleted"
+)
+
+func init() {
+	TykErrors[ErrOAuthAuthorizationFieldMissing] = config.TykError{
+		Message: "Authorization field missing",
+		Code:    http.StatusBadRequest,
+	}
+
+	TykErrors[ErrOAuthBearerTokenMalformed] = config.TykError{
+		Message: "Bearer token malformed",
+		Code:    http.StatusBadRequest,
+	}
+
+	TykErrors[ErrOAuthKeyNotAuthorised] = config.TykError{
+		Message: "Key not authorised",
+		Code:    http.StatusForbidden,
+	}
+
+	TykErrors[ErrOAuthClientDeleted] = config.TykError{
+		Message: "Key not authorised. OAuth client access was revoked",
+		Code:    http.StatusForbidden,
+	}
+}
 
 // Oauth2KeyExists will check if the key being used to access the API is in the request data,
 // and then if the key is in the storage engine
@@ -45,13 +76,13 @@ func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request,
 	if len(parts) < 2 {
 		logger.Info("Attempted access with malformed header, no auth header found.")
 
-		return errorAndStatusCode(OAuthAuthorizationFieldMissing)
+		return errorAndStatusCode(ErrOAuthAuthorizationFieldMissing)
 	}
 
 	if strings.ToLower(parts[0]) != "bearer" {
 		logger.Info("Bearer token malformed")
 
-		return errorAndStatusCode(OAuthBearerTokenMalformed)
+		return errorAndStatusCode(ErrOAuthBearerTokenMalformed)
 	}
 
 	accessToken := parts[1]
@@ -67,7 +98,7 @@ func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request,
 		// Report in health check
 		reportHealthValue(k.Spec, KeyFailure, "-1")
 
-		return errorAndStatusCode(OAuthKeyNotAuthorised)
+		return errorAndStatusCode(ErrOAuthKeyNotAuthorised)
 	}
 
 	// Make sure OAuth-client is still present
@@ -89,7 +120,7 @@ func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request,
 	}
 	if oauthClientDeleted {
 		logger.WithField("oauthClientID", session.OauthClientID).Warning("Attempted access for deleted OAuth client.")
-		return errorAndStatusCode(OAuthClientDeleted)
+		return errorAndStatusCode(ErrOAuthClientDeleted)
 	}
 
 	// Set session state on context, we will need it later

--- a/gateway/mw_oauth2_key_exists.go
+++ b/gateway/mw_oauth2_key_exists.go
@@ -15,10 +15,10 @@ const (
 )
 
 const (
-	ErrOAuthAuthorizationFieldMissing = "oauth.auth_field_missing"
-	ErrOAuthBearerTokenMalformed      = "oauth.bearer_token_malformed"
-	ErrOAuthKeyNotAuthorised          = "oauth.key_not_authorised"
-	ErrOAuthClientDeleted             = "oauth.client_deleted"
+	ErrOAuthAuthorizationFieldMissing   = "oauth.auth_field_missing"
+	ErrOAuthAuthorizationFieldMalformed = "oauth.auth_field_malformed"
+	ErrOAuthKeyNotFound                 = "oauth.key_not_found"
+	ErrOAuthClientDeleted               = "oauth.client_deleted"
 )
 
 func init() {
@@ -27,12 +27,12 @@ func init() {
 		Code:    http.StatusBadRequest,
 	}
 
-	TykErrors[ErrOAuthBearerTokenMalformed] = config.TykError{
+	TykErrors[ErrOAuthAuthorizationFieldMalformed] = config.TykError{
 		Message: "Bearer token malformed",
 		Code:    http.StatusBadRequest,
 	}
 
-	TykErrors[ErrOAuthKeyNotAuthorised] = config.TykError{
+	TykErrors[ErrOAuthKeyNotFound] = config.TykError{
 		Message: "Key not authorised",
 		Code:    http.StatusForbidden,
 	}
@@ -82,7 +82,7 @@ func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request,
 	if strings.ToLower(parts[0]) != "bearer" {
 		logger.Info("Bearer token malformed")
 
-		return errorAndStatusCode(ErrOAuthBearerTokenMalformed)
+		return errorAndStatusCode(ErrOAuthAuthorizationFieldMalformed)
 	}
 
 	accessToken := parts[1]
@@ -98,7 +98,7 @@ func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request,
 		// Report in health check
 		reportHealthValue(k.Spec, KeyFailure, "-1")
 
-		return errorAndStatusCode(ErrOAuthKeyNotAuthorised)
+		return errorAndStatusCode(ErrOAuthKeyNotFound)
 	}
 
 	// Make sure OAuth-client is still present

--- a/gateway/mw_oauth2_key_exists.go
+++ b/gateway/mw_oauth2_key_exists.go
@@ -1,7 +1,6 @@
 package gateway
 
 import (
-	"errors"
 	"net/http"
 	"strings"
 	"time"
@@ -46,13 +45,13 @@ func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request,
 	if len(parts) < 2 {
 		logger.Info("Attempted access with malformed header, no auth header found.")
 
-		return errors.New("Authorization field missing"), http.StatusBadRequest
+		return errorAndStatusCode(OAuthAuthorizationFieldMissing)
 	}
 
 	if strings.ToLower(parts[0]) != "bearer" {
 		logger.Info("Bearer token malformed")
 
-		return errors.New("Bearer token malformed"), http.StatusBadRequest
+		return errorAndStatusCode(OAuthBearerTokenMalformed)
 	}
 
 	accessToken := parts[1]
@@ -68,7 +67,7 @@ func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request,
 		// Report in health check
 		reportHealthValue(k.Spec, KeyFailure, "-1")
 
-		return errors.New("Key not authorised"), http.StatusForbidden
+		return errorAndStatusCode(OAuthKeyNotAuthorised)
 	}
 
 	// Make sure OAuth-client is still present
@@ -90,7 +89,7 @@ func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request,
 	}
 	if oauthClientDeleted {
 		logger.WithField("oauthClientID", session.OauthClientID).Warning("Attempted access for deleted OAuth client.")
-		return errors.New("Key not authorised. OAuth client access was revoked"), http.StatusForbidden
+		return errorAndStatusCode(OAuthClientDeleted)
 	}
 
 	// Set session state on context, we will need it later

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -932,6 +932,8 @@ func initialiseSystem(ctx context.Context) error {
 		config.SetGlobal(globalConf)
 	}
 
+	overrideTykErrors()
+
 	if os.Getenv("TYK_LOGLEVEL") == "" && !*cli.DebugMode {
 		level := strings.ToLower(config.Global().LogLevel)
 		switch level {


### PR DESCRIPTION
This PR defines a new config variable: `override_messages` to override error messages and codes. Example usage:
```
"override_messages": {
        "oauth.auth_field_missing" : {
            "code": 401,
            "message": "Token is not authorised"
        }
    }
```
The following are the configurable errors for now:
```
"auth.auth_field_missing"
"auth.key_not_found"

"oauth.auth_field_missing"
"oauth.auth_field_malformed"
"oauth.key_not_found"
"oauth.client_deleted"
```

Also, it is possible to override only error code or only error message. Like this:
 ```
"override_messages": {
        "oauth.auth_field_missing" : {
            "code": 401,
        }
    }
```
Fixes https://github.com/TykTechnologies/tyk/issues/2900