### PR TITLE
add json schema for graphql

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -527,35 +527,35 @@ type RequestSigningMeta struct {
 	SignatureHeader string   `bson:"signature_header" json:"signature_header"`
 }
 
-// GraphQLConfig is the root config object for GraphQL middlewares
+// GraphQLConfig is the root config object for GraphQL middlewares.
 type GraphQLConfig struct {
-	// Enabled indicates if GraphQL should be enabled
+	// Enabled indicates if GraphQL should be enabled.
 	Enabled bool `bson:"enabled" json:"enabled"`
-	// GraphQLAPI is the API specific configuration
+	// GraphQLAPI is the API specific configuration.
 	GraphQLAPI GraphQLAPI `bson:"api" json:"api"`
-	// GraphQLPlayground is the Playground specific configuration
+	// GraphQLPlayground is the Playground specific configuration.
 	GraphQLPlayground GraphQLPlayground `bson:"playground" json:"playground"`
 }
 
-// GraphQLAPI is the configuration for the GraphQL Middleware
+// GraphQLAPI is the configuration for the GraphQL Middleware.
 type GraphQLAPI struct {
-	// Endpoint is, combined with the base path, the route which the GraphQL Middleware reacts to
+	// Endpoint is, combined with the base path, the route which the GraphQL Middleware reacts to.
 	Endpoint string `bson:"endpoint" json:"endpoint"`
-	// Schema is the GraphQL Schema exposed by the GraphQL API/Upstream/Engine
+	// Schema is the GraphQL Schema exposed by the GraphQL API/Upstream/Engine.
 	Schema string `bson:"schema" json:"schema"`
-	// Execution defines the mode and configuration in which the GraphQL middleware should operate
+	// Execution defines the mode and configuration in which the GraphQL middleware should operate.
 	Execution GraphQLExecution `bson:"execution" json:"execution"`
 }
 
-// GraphQLExecution defines the GraphQL Execution Mode as well as its configuration
+// GraphQLExecution defines the GraphQL Execution Mode as well as its configuration.
 type GraphQLExecution struct {
-	// Mode is the mode in which the Middleware should operate
+	// Mode is the mode in which the Middleware should operate.
 	Mode GraphQLExecutionMode `bson:"mode" json:"mode"`
-	// Validation defines the behaviour regarding GraphQL request validation
+	// Validation defines the behaviour regarding GraphQL request validation.
 	Validation GraphQLExecutionValidation `bson:"validation" json:"validation"`
 }
 
-// GraphQLExecutionMode is the mode in which the GraphQL Middleware should operate
+// GraphQLExecutionMode is the mode in which the GraphQL Middleware should operate.
 type GraphQLExecutionMode string
 
 const (
@@ -568,7 +568,7 @@ const (
 	GraphQLExecutionModeExecutionEngine GraphQLExecutionMode = "executionEngine"
 )
 
-// GraphQLExecutionValidation is the config for operation validation
+// GraphQLExecutionValidation is the config for operation validation.
 type GraphQLExecutionValidation struct {
 	// Enabled indicates if the validation should be enabled.
 	Enabled bool `bson:"enabled" json:"enabled"`
@@ -576,7 +576,7 @@ type GraphQLExecutionValidation struct {
 	OnFail GraphQLValidationBehavior `bson:"on_fail" json:"on_fail"`
 }
 
-// GraphQLValidationBehavior represents an enum for the configurable validation behavior
+// GraphQLValidationBehavior represents an enum for the configurable validation behavior.
 type GraphQLValidationBehavior string
 
 const (
@@ -588,7 +588,7 @@ const (
 	GraphQLValidationBehaviorErrorObject GraphQLValidationBehavior = "useErrorObject"
 )
 
-// GraphQLPlayground represents the configuration for the public playground which will be hosted alongside the api
+// GraphQLPlayground represents the configuration for the public playground which will be hosted alongside the api.
 type GraphQLPlayground struct {
 	// Enabled indicates if the playground should be enabled.
 	Enabled bool `bson:"enabled" json:"enabled"`

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -231,70 +231,6 @@ type ExtendedPathsSet struct {
 	Internal                []InternalMeta        `bson:"internal" json:"internal,omitempty"`
 }
 
-// GraphQLConfig is the root config object for GraphQL Middlewares
-type GraphQLConfig struct {
-	// BasePath is the base path for the GraphQL API, Subscriptions Endpoint as well as the GraphQLPlayground
-	BasePath   string            `bson:"base_path" json:"base_path"`
-	// GraphQLApi is the API specific configuration
-	GraphQLApi        GraphQLApi        `bson:"graphql_api" json:"graphql_api"`
-	// GraphQLPlayground is the Playground specific configuration
-	GraphQLPlayground GraphQLPlayground `bson:"playground" json:"playground"`
-}
-
-// GraphQLApi is the configuration for the GraphQL Middleware
-type GraphQLApi struct {
-	// Endpoint is, combined with the base path, the route which the GraphQL Middleware reacts to
-	Endpoint      string               `bson:"endpoint" json:"endpoint"`
-	// Schema is the GraphQL Schema exposed by the GraphQL API/Upstream/Engine
-	Schema        string               `bson:"schema" json:"schema"`
-	// Subscriptions is the configuration regarding websocket subscriptions
-	Subscriptions GraphQLSubscriptions `bson:"subscriptions" json:"subscriptions"`
-	// Execution defines the mode and configuration in which the GraphQL middleware should operate
-	Execution     GraphQLExecution `bson:"execution" json:"execution"`
-}
-
-// GraphQLSubscriptions is the configuration for websocket based GraphQL Subscriptions
-type GraphQLSubscriptions struct {
-	// Enabled defines if Subscriptions should be accepted
-	Enabled                               bool   `bson:"enabled" json:"enabled"`
-	// Endpoint is, combined with the base path, the route on which websocket upgrade requests will be accepted
-	Endpoint                              string `bson:"endpoint" json:"endpoint"`
-	// SecureWebsocketProtocolHeaderVariable is the SecWebsocketProtocolHeader variable expected by the websocket client
-	SecureWebsocketProtocolHeaderVariable string `bson:"secure_websocket_protocol_header_variable" json:"secure_websocket_protocol_header_variable"`
-}
-
-// GraphQLExecution defines the GraphQL Execution Mode as well as its configuration
-type GraphQLExecution struct {
-	// Mode is the mode in which the Middleware should operate
-	Mode       GraphQLExecutionMode       `bson:"mode" json:"mode"`
-	// Validation defines the behaviour regarding GraphQL request validation
-	Validation GraphQLExecutionValidation `bson:"validation" json:"validation"`
-	// Config is the GraphQLExecutionMode specific configuration object
-	Config     json.RawMessage            `bson:"config" json:"config"`
-}
-
-// GraphQLExecutionMode is the mode in which the GraphQL Middleware should operate
-type GraphQLExecutionMode int
-
-const (
-	// GraphQLExecutionModeProxyOnly is the mode in which the GraphQL Middleware doesn't evaluate the GraphQL request
-	// In other terms, the GraphQL Middleware will not act as a GraphQL server in itself.
-	// The GraphQL Middleware will (optionally) validate the request and leave the execution up to the upstream.
-	GraphQLExecutionModeProxyOnly GraphQLExecutionMode = iota + 1
-	// GraphQLExecutionModeExecutionEngine is the mode in which the GraphQL Middleware will evaluate every request.
-	// This means the Middleware will act as a independent GraphQL service which might delegate partial execution to upstreams.
-	GraphQLExecutionModeExecutionEngine
-)
-
-type GraphQLExecutionValidation struct {
-	Enabled bool `bson:"enabled" json:"enabled"`
-}
-
-type GraphQLPlayground struct {
-	Enabled bool   `bson:"enabled" json:"enabled"`
-	Path    string `bson:"path" json:"path"`
-}
-
 type VersionInfo struct {
 	Name      string    `bson:"name" json:"name"`
 	Expires   string    `bson:"expires" json:"expires"`
@@ -311,7 +247,6 @@ type VersionInfo struct {
 	IgnoreEndpointCase  bool              `bson:"ignore_endpoint_case" json:"ignore_endpoint_case"`
 	GlobalSizeLimit     int64             `bson:"global_size_limit" json:"global_size_limit"`
 	OverrideTarget      string            `bson:"override_target" json:"override_target"`
-	GraphQL             GraphQLConfig     `bson:"graphql" json:"graphql"`
 }
 
 type AuthProviderMeta struct {
@@ -547,6 +482,7 @@ type APIDefinition struct {
 	GlobalRateLimit         GlobalRateLimit        `bson:"global_rate_limit" json:"global_rate_limit"`
 	StripAuthData           bool                   `bson:"strip_auth_data" json:"strip_auth_data"`
 	EnableDetailedRecording bool                   `bson:"enable_detailed_recording" json:"enable_detailed_recording"`
+	GraphQL                 GraphQLConfig          `bson:"graphql" json:"graphql"`
 }
 
 type AuthConfig struct {
@@ -589,6 +525,75 @@ type RequestSigningMeta struct {
 	HeaderList      []string `bson:"header_list" json:"header_list"`
 	CertificateId   string   `bson:"certificate_id" json:"certificate_id"`
 	SignatureHeader string   `bson:"signature_header" json:"signature_header"`
+}
+
+// GraphQLConfig is the root config object for GraphQL middlewares
+type GraphQLConfig struct {
+	// Enabled indicates if GraphQL should be enabled
+	Enabled bool `bson:"enabled" json:"enabled"`
+	// GraphQLApi is the API specific configuration
+	GraphQLApi GraphQLApi `bson:"api" json:"api"`
+	// GraphQLPlayground is the Playground specific configuration
+	GraphQLPlayground GraphQLPlayground `bson:"playground" json:"playground"`
+}
+
+// GraphQLApi is the configuration for the GraphQL Middleware
+type GraphQLApi struct {
+	// Endpoint is, combined with the base path, the route which the GraphQL Middleware reacts to
+	Endpoint string `bson:"endpoint" json:"endpoint"`
+	// Schema is the GraphQL Schema exposed by the GraphQL API/Upstream/Engine
+	Schema string `bson:"schema" json:"schema"`
+	// Execution defines the mode and configuration in which the GraphQL middleware should operate
+	Execution GraphQLExecution `bson:"execution" json:"execution"`
+}
+
+// GraphQLExecution defines the GraphQL Execution Mode as well as its configuration
+type GraphQLExecution struct {
+	// Mode is the mode in which the Middleware should operate
+	Mode GraphQLExecutionMode `bson:"mode" json:"mode"`
+	// Validation defines the behaviour regarding GraphQL request validation
+	Validation GraphQLExecutionValidation `bson:"validation" json:"validation"`
+}
+
+// GraphQLExecutionMode is the mode in which the GraphQL Middleware should operate
+type GraphQLExecutionMode string
+
+const (
+	// GraphQLExecutionModeProxyOnly is the mode in which the GraphQL Middleware doesn't evaluate the GraphQL request
+	// In other terms, the GraphQL Middleware will not act as a GraphQL server in itself.
+	// The GraphQL Middleware will (optionally) validate the request and leave the execution up to the upstream.
+	GraphQLExecutionModeProxyOnly GraphQLExecutionMode = "proxyOnly"
+	// GraphQLExecutionModeExecutionEngine is the mode in which the GraphQL Middleware will evaluate every request.
+	// This means the Middleware will act as a independent GraphQL service which might delegate partial execution to upstreams.
+	GraphQLExecutionModeExecutionEngine GraphQLExecutionMode = "executionEngine"
+)
+
+// GraphQLExecutionValidation is the config for operation validation
+type GraphQLExecutionValidation struct {
+	// Enabled indicates if the validation should be enabled.
+	Enabled bool `bson:"enabled" json:"enabled"`
+	// OnFail determines the gateway behavior when a validation fails.
+	OnFail GraphQLValidationBehavior `bson:"on_fail" json:"on_fail"`
+}
+
+// GraphQLValidationBehavior represents an enum for the configurable validation behavior
+type GraphQLValidationBehavior string
+
+const (
+	// GraphQLValidationBehaviorStatusCode400 represents the behavior that the response will be a 400 Bad Request
+	// on a failing operation validation.
+	GraphQLValidationBehaviorStatusCode400 GraphQLValidationBehavior = "httpStatusCode400"
+	// GraphQLValidationBehaviorErrorObject represents the behavior that the response will contain a graphql error
+	// object with the paths on which the validation failed.
+	GraphQLValidationBehaviorErrorObject GraphQLValidationBehavior = "useErrorObject"
+)
+
+// GraphQLPlayground represents the configuration for the public playground which will be hosted alongside the api
+type GraphQLPlayground struct {
+	// Enabled indicates if the playground should be enabled.
+	Enabled bool `bson:"enabled" json:"enabled"`
+	// Path sets the path on which the playground will be hosted if enabled.
+	Path string `bson:"path" json:"path"`
 }
 
 // Clean will URL encode map[string]struct variables for saving
@@ -849,6 +854,18 @@ func DummyAPI() APIDefinition {
 		},
 	}
 
+	graphql := GraphQLConfig{
+		Enabled: false,
+		GraphQLApi: GraphQLApi{
+			Execution: GraphQLExecution{
+				Mode: GraphQLExecutionModeProxyOnly,
+				Validation: GraphQLExecutionValidation{
+					OnFail: GraphQLValidationBehaviorStatusCode400,
+				},
+			},
+		},
+	}
+
 	return APIDefinition{
 		VersionData:             versionData,
 		ConfigData:              map[string]interface{}{},
@@ -870,7 +887,8 @@ func DummyAPI() APIDefinition {
 				ExtractorConfig: map[string]interface{}{},
 			},
 		},
-		Tags: []string{},
+		Tags:    []string{},
+		GraphQL: graphql,
 	}
 }
 

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -531,14 +531,14 @@ type RequestSigningMeta struct {
 type GraphQLConfig struct {
 	// Enabled indicates if GraphQL should be enabled
 	Enabled bool `bson:"enabled" json:"enabled"`
-	// GraphQLApi is the API specific configuration
-	GraphQLApi GraphQLApi `bson:"api" json:"api"`
+	// GraphQLAPI is the API specific configuration
+	GraphQLAPI GraphQLAPI `bson:"api" json:"api"`
 	// GraphQLPlayground is the Playground specific configuration
 	GraphQLPlayground GraphQLPlayground `bson:"playground" json:"playground"`
 }
 
-// GraphQLApi is the configuration for the GraphQL Middleware
-type GraphQLApi struct {
+// GraphQLAPI is the configuration for the GraphQL Middleware
+type GraphQLAPI struct {
 	// Endpoint is, combined with the base path, the route which the GraphQL Middleware reacts to
 	Endpoint string `bson:"endpoint" json:"endpoint"`
 	// Schema is the GraphQL Schema exposed by the GraphQL API/Upstream/Engine
@@ -856,7 +856,7 @@ func DummyAPI() APIDefinition {
 
 	graphql := GraphQLConfig{
 		Enabled: false,
-		GraphQLApi: GraphQLApi{
+		GraphQLAPI: GraphQLAPI{
 			Execution: GraphQLExecution{
 				Mode: GraphQLExecutionModeProxyOnly,
 				Validation: GraphQLExecutionValidation{

--- a/apidef/schema.go
+++ b/apidef/schema.go
@@ -431,8 +431,11 @@ const Schema = `{
         ]
         },
         "graphql": {
-            "type": ["object", "null"],
+            "type": "object",
             "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
                 "api": {
                     "type": "object",
                     "properties": {
@@ -494,8 +497,7 @@ const Schema = `{
                 }
             },
             "required": [
-                "api", 
-                "playground"
+                "enabled"
             ]
         }
     }

--- a/apidef/schema.go
+++ b/apidef/schema.go
@@ -500,7 +500,7 @@ const Schema = `{
                 "enabled"
             ]
         }
-    }
+    },
     "required": [
         "auth",
         "name",

--- a/apidef/schema.go
+++ b/apidef/schema.go
@@ -431,7 +431,7 @@ const Schema = `{
         ]
         },
         "graphql": {
-            "type": "object",
+            "type": ["object", “null“],
             "properties": {
                 "enabled": {
                     "type": "boolean"

--- a/apidef/schema.go
+++ b/apidef/schema.go
@@ -429,8 +429,76 @@ const Schema = `{
         "required": [
             "is_enabled"
         ]
+        },
+        "graphql": {
+            "type": ["object", "null"],
+            "properties": {
+                "api": {
+                    "type": "object",
+                    "properties": {
+                        "endpoint": {
+                            "type": "string"
+                        },
+                        "schema": {
+                            "type": "string"
+                        },
+                        "execution": {
+                            "type": "object",
+                            "properties": {
+                                "mode": {
+                                    "type": "string",
+                                    "enum": ["proxyOnly"]
+                                },
+                                "validation": {
+                                    "type": "object",
+                                    "properties": {
+                                        "enabled": {
+                                            "type": "boolean"
+                                        },
+                                        "on_fail": {
+                                            "type": "string",
+                                            "enum": ["httpStatusCode400", "useErrorObject"]
+                                        }
+                                    },
+                                    "required": [
+                                        "enabled", 
+                                        "on_fail"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "mode", 
+                                "validation"
+                            ]
+                        } 
+                    },
+                    "required": [
+                        "endpoint", 
+                        "schema", 
+                        "execution"
+                    ]
+                },
+                "playground": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "path": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "enabled"
+                    ]
+                }
+            },
+            "required": [
+                "api", 
+                "playground"
+            ]
         }
-    },
+    }
     "required": [
         "auth",
         "name",

--- a/gateway/mw_graphql.go
+++ b/gateway/mw_graphql.go
@@ -13,13 +13,7 @@ func (m *GraphQLMiddleware) Name() string {
 }
 
 func (m *GraphQLMiddleware) EnabledForSpec() bool {
-	for _, versionData := range m.Spec.VersionData.Versions {
-		if versionData.GraphQL.GraphQLApi.Schema != "" {
-			return true
-		}
-	}
-
-	return false
+	return m.Spec.GraphQL.Enabled
 }
 
 func (m *GraphQLMiddleware) Init() {


### PR DESCRIPTION
This pr adds the json schema for graphql in its initial form.

It includes:
- configuration of graphql endpoint
- configuration of validation
- configuration of playground
- configuration of execution (proxyOnly as for now) 