### PR TITLE
Add global response headers adding and removing

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -240,13 +240,15 @@ type VersionInfo struct {
 		WhiteList []string `bson:"white_list" json:"white_list"`
 		BlackList []string `bson:"black_list" json:"black_list"`
 	} `bson:"paths" json:"paths"`
-	UseExtendedPaths    bool              `bson:"use_extended_paths" json:"use_extended_paths"`
-	ExtendedPaths       ExtendedPathsSet  `bson:"extended_paths" json:"extended_paths"`
-	GlobalHeaders       map[string]string `bson:"global_headers" json:"global_headers"`
-	GlobalHeadersRemove []string          `bson:"global_headers_remove" json:"global_headers_remove"`
-	IgnoreEndpointCase  bool              `bson:"ignore_endpoint_case" json:"ignore_endpoint_case"`
-	GlobalSizeLimit     int64             `bson:"global_size_limit" json:"global_size_limit"`
-	OverrideTarget      string            `bson:"override_target" json:"override_target"`
+	UseExtendedPaths            bool              `bson:"use_extended_paths" json:"use_extended_paths"`
+	ExtendedPaths               ExtendedPathsSet  `bson:"extended_paths" json:"extended_paths"`
+	GlobalHeaders               map[string]string `bson:"global_headers" json:"global_headers"`
+	GlobalHeadersRemove         []string          `bson:"global_headers_remove" json:"global_headers_remove"`
+	GlobalResponseHeaders       map[string]string `bson:"global_response_headers" json:"global_response_headers"`
+	GlobalResponseHeadersRemove []string          `bson:"global_response_headers_remove" json:"global_response_headers_remove"`
+	IgnoreEndpointCase          bool              `bson:"ignore_endpoint_case" json:"ignore_endpoint_case"`
+	GlobalSizeLimit             int64             `bson:"global_size_limit" json:"global_size_limit"`
+	OverrideTarget              string            `bson:"override_target" json:"override_target"`
 }
 
 type AuthProviderMeta struct {

--- a/gateway/res_handler_header_injector_test.go
+++ b/gateway/res_handler_header_injector_test.go
@@ -103,3 +103,36 @@ func BenchmarkResponseHeaderInjection(b *testing.B) {
 		}...)
 	}
 }
+
+func TestGlobalResponseHeaders(t *testing.T) {
+	ts := StartTest()
+	defer ts.Close()
+
+	spec := BuildAPI(func(spec *APISpec) {
+		spec.UseKeylessAccess = true
+		spec.Proxy.ListenPath = "/"
+
+		spec.ResponseProcessors = []apidef.ResponseProcessor{{Name: "header_injector"}}
+	})[0]
+	LoadAPI(spec)
+
+	addedHeaders := map[string]string{"X-Tyk-Test": "1"}
+	removedHeaders := map[string]string{}
+
+	_, _ = ts.Run(t, test.TestCase{HeadersMatch: addedHeaders, HeadersNotMatch: removedHeaders})
+
+	// Add and remove global response headers
+	UpdateAPIVersion(spec, "Default", func(v *apidef.VersionInfo) {
+		v.UseExtendedPaths = true
+		v.GlobalResponseHeaders = map[string]string{
+			"global-header": "global-value",
+		}
+		v.GlobalResponseHeadersRemove = []string{"X-Tyk-Test"}
+	})
+	LoadAPI(spec)
+
+	addedHeaders = map[string]string{"global-header": "global-value"}
+	removedHeaders = map[string]string{"X-Tyk-Test": "1"}
+
+	_, _ = ts.Run(t, test.TestCase{HeadersMatch: addedHeaders, HeadersNotMatch: removedHeaders})
+}


### PR DESCRIPTION
This PR adds new way of adding and removing response global headers in versions level.
```
"versions": {
        "Default": {                
          "global_response_headers": {},
          "global_response_headers_remove": [],       
        }
      }
```

`response_processor` will continue to be the other way. This feature doesn't break it.


Gateway change for: https://github.com/TykTechnologies/tyk/issues/2453