### PR TITLE
Override max quota on partitioned quota policy set

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -409,7 +409,7 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 					// -1 is special "unlimited" case
 					if ar.Limit.QuotaMax != -1 && policy.QuotaMax > ar.Limit.QuotaMax {
 						ar.Limit.QuotaMax = policy.QuotaMax
-						session.QuotaMax = policy.QuotaMax
+						//session.QuotaMax = policy.QuotaMax
 					}
 
 					if policy.QuotaRenewalRate > ar.Limit.QuotaRenewalRate {

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -410,6 +410,7 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 					// -1 is special "unlimited" case
 					if ar.Limit.QuotaMax != -1 && policy.QuotaMax > ar.Limit.QuotaMax {
 						ar.Limit.QuotaMax = policy.QuotaMax
+						session.QuotaMax = policy.QuotaMax
 					}
 
 					if policy.QuotaRenewalRate > ar.Limit.QuotaRenewalRate {
@@ -447,6 +448,7 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 
 			// Master policy case
 			if len(policy.AccessRights) == 0 {
+				log.Info("entra aqui al master")
 				if !usePartitions || policy.Partitions.RateLimit {
 					session.Rate = policy.Rate
 					session.Per = policy.Per
@@ -458,6 +460,8 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 					session.QuotaMax = policy.QuotaMax
 					session.QuotaRenewalRate = policy.QuotaRenewalRate
 				}
+			}else{
+				log.Info("policy access rights:", policy.AccessRights)
 			}
 
 			if !session.HMACEnabled {

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -448,7 +448,6 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 
 			// Master policy case
 			if len(policy.AccessRights) == 0 {
-				log.Info("entra aqui al master")
 				if !usePartitions || policy.Partitions.RateLimit {
 					session.Rate = policy.Rate
 					session.Per = policy.Per
@@ -460,8 +459,6 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 					session.QuotaMax = policy.QuotaMax
 					session.QuotaRenewalRate = policy.QuotaRenewalRate
 				}
-			}else{
-				log.Info("policy access rights:", policy.AccessRights)
 			}
 
 			if !session.HMACEnabled {

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -409,7 +409,7 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 					// -1 is special "unlimited" case
 					if ar.Limit.QuotaMax != -1 && policy.QuotaMax > ar.Limit.QuotaMax {
 						ar.Limit.QuotaMax = policy.QuotaMax
-						//session.QuotaMax = policy.QuotaMax
+						session.QuotaMax = policy.QuotaMax
 					}
 
 					if policy.QuotaRenewalRate > ar.Limit.QuotaRenewalRate {
@@ -443,7 +443,6 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 				}
 
 				rights[k] = *ar
-				log.Info("set rights en la posicion:", k, " el valor: ", *ar)
 			}
 
 			// Master policy case

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -369,7 +369,6 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 			}
 		} else {
 			usePartitions := policy.Partitions.Quota || policy.Partitions.RateLimit || policy.Partitions.Acl
-
 			for k, v := range policy.AccessRights {
 				ar := &v
 
@@ -444,6 +443,7 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 				}
 
 				rights[k] = *ar
+				log.Info("set rights en la posicion:", k, " el valor: ", *ar)
 			}
 
 			// Master policy case

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -103,6 +103,11 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 			Partitions: user.PolicyPartitions{Quota: true},
 			QuotaMax:   3,
 		},
+		"quota3": {
+			QuotaMax:                      3,
+			AccessRights: 				   map[string]user.AccessDefinition{"a": {}},
+			Partitions:                    user.PolicyPartitions{Quota:true},
+		},
 		"rate1": {
 			Partitions: user.PolicyPartitions{RateLimit: true},
 			Rate:       3,
@@ -357,6 +362,14 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 					t.Fatalf("Should pick bigger value")
 				}
 			}, nil,
+		},
+		{
+			"QuotaPart with access rights", []string{"quota3"},
+			"", func(t *testing.T, s *user.SessionState) {
+			if s.QuotaMax != 3 {
+				t.Fatalf("Should pick bigger value")
+			}
+		}, nil,
 		},
 		{
 			"RatePart", []string{"rate1"},

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -367,7 +367,7 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 			"QuotaPart with access rights", []string{"quota3"},
 			"", func(t *testing.T, s *user.SessionState) {
 				if s.QuotaMax != 3 {
-					t.Fatalf("Should pick bigger value")
+					t.Fatalf("quota should be the same as policy quota")
 				}
 			}, nil,
 		},

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -104,9 +104,9 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 			QuotaMax:   3,
 		},
 		"quota3": {
-			QuotaMax:                      3,
-			AccessRights: 				   map[string]user.AccessDefinition{"a": {}},
-			Partitions:                    user.PolicyPartitions{Quota:true},
+			QuotaMax:     3,
+			AccessRights: map[string]user.AccessDefinition{"a": {}},
+			Partitions:   user.PolicyPartitions{Quota: true},
 		},
 		"rate1": {
 			Partitions: user.PolicyPartitions{RateLimit: true},
@@ -366,10 +366,10 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 		{
 			"QuotaPart with access rights", []string{"quota3"},
 			"", func(t *testing.T, s *user.SessionState) {
-			if s.QuotaMax != 3 {
-				t.Fatalf("Should pick bigger value")
-			}
-		}, nil,
+				if s.QuotaMax != 3 {
+					t.Fatalf("Should pick bigger value")
+				}
+			}, nil,
 		},
 		{
 			"RatePart", []string{"rate1"},


### PR DESCRIPTION
When a partitioned quota policy is set, then override the global max quota with the policy value
Added portion of code in tests to validate this condition

Related to: https://github.com/TykTechnologies/tyk-analytics/issues/1772