### PR TITLE
on delete client, check that the apiSpec have defined an oauth manager

### DIFF
--- a/gateway/api.go
+++ b/gateway/api.go
@@ -1877,25 +1877,29 @@ func handleDeleteOAuthClient(keyName, apiID string) (interface{}, int) {
 		return apiError("OAuth Client ID not found"), http.StatusNotFound
 	}
 
-	err := apiSpec.OAuthManager.OsinServer.Storage.DeleteClient(storageID, apiSpec.OrgID, true)
-	if err != nil {
-		return apiError("Delete failed"), http.StatusInternalServerError
+	if apiSpec.OAuthManager != nil{
+		err := apiSpec.OAuthManager.OsinServer.Storage.DeleteClient(storageID,apiSpec.OrgID, true)
+		if err != nil {
+			return apiError("Delete failed"), http.StatusInternalServerError
+		}
+
+		statusObj := apiModifyKeySuccess{
+			Key:    keyName,
+			Status: "ok",
+			Action: "deleted",
+		}
+
+		log.WithFields(logrus.Fields{
+			"prefix": "api",
+			"apiID":  apiID,
+			"status": "ok",
+			"client": keyName,
+		}).Info("Deleted OAuth client")
+
+		return statusObj, http.StatusOK
 	}
 
-	statusObj := apiModifyKeySuccess{
-		Key:    keyName,
-		Status: "ok",
-		Action: "deleted",
-	}
-
-	log.WithFields(logrus.Fields{
-		"prefix": "api",
-		"apiID":  apiID,
-		"status": "ok",
-		"client": keyName,
-	}).Info("Deleted OAuth client")
-
-	return statusObj, http.StatusOK
+	return apiError("OAuth Client ID not found"), http.StatusNotFound
 }
 
 const oAuthNotPropagatedErr = "OAuth client list isn't available or hasn't been propagated yet."


### PR DESCRIPTION
as reported in https://github.com/TykTechnologies/tyk/issues/2940 on delete oauth client first we must check that the ApiSpec have a valid oauthManager loaded, in order to do so was added a validation to check that `apiSpec.OAuthManager` is not null