### PR TITLE
inherit throttle values from policy

### DIFF
--- a/gateway/api.go
+++ b/gateway/api.go
@@ -1876,8 +1876,8 @@ func handleDeleteOAuthClient(keyName, apiID string) (interface{}, int) {
 		return apiError("OAuth Client ID not found"), http.StatusNotFound
 	}
 
-	if apiSpec.OAuthManager != nil{
-		err := apiSpec.OAuthManager.OsinServer.Storage.DeleteClient(storageID,apiSpec.OrgID, true)
+	if apiSpec.OAuthManager != nil {
+		err := apiSpec.OAuthManager.OsinServer.Storage.DeleteClient(storageID, apiSpec.OrgID, true)
 		if err != nil {
 			return apiError("Delete failed"), http.StatusInternalServerError
 		}

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -430,10 +430,12 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 
 					if policy.ThrottleInterval > ar.Limit.ThrottleInterval {
 						ar.Limit.ThrottleInterval = policy.ThrottleInterval
+						session.ThrottleInterval = policy.ThrottleInterval
 					}
 
 					if policy.ThrottleRetryLimit > ar.Limit.ThrottleRetryLimit {
 						ar.Limit.ThrottleRetryLimit = policy.ThrottleRetryLimit
+						session.ThrottleRetryLimit = policy.ThrottleRetryLimit
 					}
 				}
 

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -540,12 +540,17 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 			}, nil,
 		},
 		{
-			"Throttle retry limit from policy", []string{"throttle1"},
-			"", func(t *testing.T, s *user.SessionState) {
+			name:     "Throttle retry limit from policy",
+			policies: []string{"throttle1"},
+			errMatch:"",
+			sessMatch: func(t *testing.T, s *user.SessionState) {
 				if s.ThrottleRetryLimit != 99 {
 					t.Fatalf("Throttle interval should be 9 inherited from policy")
 				}
-			}, nil,
+			},
+			session: nil,
+		},
+		{
 			name:     "inherit quota and rate from partitioned policies",
 			policies: []string{"quota1", "rate3"},
 			sessMatch: func(t *testing.T, s *user.SessionState) {

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -245,11 +245,11 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 				},
 			}},
 		},
-		"throttle1":{
-			ID: "throttle1",
-			ThrottleRetryLimit:99,
-			ThrottleInterval:9,
-			AccessRights: map[string]user.AccessDefinition{"a": {}},
+		"throttle1": {
+			ID:                 "throttle1",
+			ThrottleRetryLimit: 99,
+			ThrottleInterval:   9,
+			AccessRights:       map[string]user.AccessDefinition{"a": {}},
 		},
 	}
 	policiesMu.RUnlock()
@@ -524,10 +524,10 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 		{
 			"Throttle retry limit from policy", []string{"throttle1"},
 			"", func(t *testing.T, s *user.SessionState) {
-			if s.ThrottleRetryLimit != 99 {
-				t.Fatalf("Throttle interval should be 9 inherited from policy")
-			}
-		}, nil,
+				if s.ThrottleRetryLimit != 99 {
+					t.Fatalf("Throttle interval should be 9 inherited from policy")
+				}
+			}, nil,
 		},
 	}
 

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -245,6 +245,12 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 				},
 			}},
 		},
+		"throttle1":{
+			ID: "throttle1",
+			ThrottleRetryLimit:99,
+			ThrottleInterval:9,
+			AccessRights: map[string]user.AccessDefinition{"a": {}},
+		},
 	}
 	policiesMu.RUnlock()
 	bmid := &BaseMiddleware{Spec: &APISpec{
@@ -506,6 +512,22 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 
 				assert.Equal(t, want, s.AccessRights)
 			},
+		},
+		{
+			"Throttle interval from policy", []string{"throttle1"},
+			"", func(t *testing.T, s *user.SessionState) {
+				if s.ThrottleInterval != 9 {
+					t.Fatalf("Throttle interval should be 9 inherited from policy")
+				}
+			}, nil,
+		},
+		{
+			"Throttle retry limit from policy", []string{"throttle1"},
+			"", func(t *testing.T, s *user.SessionState) {
+			if s.ThrottleRetryLimit != 99 {
+				t.Fatalf("Throttle interval should be 9 inherited from policy")
+			}
+		}, nil,
 		},
 	}
 

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -542,7 +542,7 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 		{
 			name:     "Throttle retry limit from policy",
 			policies: []string{"throttle1"},
-			errMatch:"",
+			errMatch: "",
 			sessMatch: func(t *testing.T, s *user.SessionState) {
 				if s.ThrottleRetryLimit != 99 {
 					t.Fatalf("Throttle interval should be 9 inherited from policy")


### PR DESCRIPTION
In order to give a fix to https://github.com/TykTechnologies/tyk-analytics/issues/1774 was added logic to inherit the throttle values from policy