### PR TITLE
inherit rate values on rate partition policy

### DIFF
--- a/gateway/api.go
+++ b/gateway/api.go
@@ -1876,8 +1876,8 @@ func handleDeleteOAuthClient(keyName, apiID string) (interface{}, int) {
 		return apiError("OAuth Client ID not found"), http.StatusNotFound
 	}
 
-	if apiSpec.OAuthManager != nil{
-		err := apiSpec.OAuthManager.OsinServer.Storage.DeleteClient(storageID,apiSpec.OrgID, true)
+	if apiSpec.OAuthManager != nil {
+		err := apiSpec.OAuthManager.OsinServer.Storage.DeleteClient(storageID, apiSpec.OrgID, true)
 		if err != nil {
 			return apiError("Delete failed"), http.StatusInternalServerError
 		}

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -424,12 +424,12 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 
 					if ar.Limit.Rate != -1 && policy.Rate > ar.Limit.Rate {
 						ar.Limit.Rate = policy.Rate
-						session.Rate = policy.Rate
+						//session.Rate = policy.Rate
 					}
 
 					if policy.Per > ar.Limit.Per {
 						ar.Limit.Per = policy.Per
-						session.Per = policy.Per
+						//session.Per = policy.Per
 					}
 
 					if policy.ThrottleInterval > ar.Limit.ThrottleInterval {

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -424,12 +424,12 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 
 					if ar.Limit.Rate != -1 && policy.Rate > ar.Limit.Rate {
 						ar.Limit.Rate = policy.Rate
-						//session.Rate = policy.Rate
+						session.Rate = policy.Rate
 					}
 
 					if policy.Per > ar.Limit.Per {
 						ar.Limit.Per = policy.Per
-						//session.Per = policy.Per
+						session.Per = policy.Per
 					}
 
 					if policy.ThrottleInterval > ar.Limit.ThrottleInterval {

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -410,10 +410,12 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 					// -1 is special "unlimited" case
 					if ar.Limit.QuotaMax != -1 && policy.QuotaMax > ar.Limit.QuotaMax {
 						ar.Limit.QuotaMax = policy.QuotaMax
+						session.QuotaMax = policy.QuotaMax
 					}
 
 					if policy.QuotaRenewalRate > ar.Limit.QuotaRenewalRate {
 						ar.Limit.QuotaRenewalRate = policy.QuotaRenewalRate
+						session.QuotaRenewalRate = policy.QuotaRenewalRate
 					}
 				}
 
@@ -422,10 +424,12 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 
 					if ar.Limit.Rate != -1 && policy.Rate > ar.Limit.Rate {
 						ar.Limit.Rate = policy.Rate
+						session.Rate = policy.Rate
 					}
 
 					if policy.Per > ar.Limit.Per {
 						ar.Limit.Per = policy.Per
+						session.Per = policy.Per
 					}
 
 					if policy.ThrottleInterval > ar.Limit.ThrottleInterval {

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -527,6 +527,21 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 				}
 			},
 		},
+		{
+			name:     "inherit quota and rate from partitioned policies applied in different order",
+			policies: []string{"rate3", "quota1"},
+			sessMatch: func(t *testing.T, s *user.SessionState) {
+				if s.QuotaMax != 2 {
+					t.Fatalf("quota should be the same as quota policy")
+				}
+				if s.Rate != 4 {
+					t.Fatalf("rate should be the same as rate policy")
+				}
+				if s.Per != 4 {
+					t.Fatalf("Rate per seconds should be the same as rate policy")
+				}
+			},
+		},
 	}
 
 	return bmid, tests

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -111,6 +111,11 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 			Partitions: user.PolicyPartitions{RateLimit: true},
 			Rate:       4,
 		},
+		"rate3": {
+			Partitions: user.PolicyPartitions{RateLimit: true},
+			Rate:       4,
+			Per:        4,
+		},
 		"acl1": {
 			Partitions:   user.PolicyPartitions{Acl: true},
 			AccessRights: map[string]user.AccessDefinition{"a": {}},
@@ -505,6 +510,21 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 				}
 
 				assert.Equal(t, want, s.AccessRights)
+			},
+		},
+		{
+			name:      "inherit quota and rate from partitioned policies",
+			policies:  []string{"quota1", "rate3"},
+			sessMatch: func(t *testing.T, s *user.SessionState) {
+				if s.QuotaMax != 2 {
+					t.Fatalf("quota should be the same as quota policy")
+				}
+				if s.Rate != 4 {
+					t.Fatalf("rate should be the same as rate policy")
+				}
+				if s.Per != 4 {
+					t.Fatalf("Rate per seconds should be the same as rate policy")
+				}
 			},
 		},
 	}

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -513,8 +513,8 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 			},
 		},
 		{
-			name:      "inherit quota and rate from partitioned policies",
-			policies:  []string{"quota1", "rate3"},
+			name:     "inherit quota and rate from partitioned policies",
+			policies: []string{"quota1", "rate3"},
 			sessMatch: func(t *testing.T, s *user.SessionState) {
 				if s.QuotaMax != 2 {
 					t.Fatalf("quota should be the same as quota policy")


### PR DESCRIPTION
when a policy for rates partition is applied, set the correct values in key values, this aso fix the inheritance of values when more than one partition policy is applied 

Related to: https://github.com/TykTechnologies/tyk-analytics/issues/1748