### PR TITLE
Adding packer to tyk-build-env

### DIFF
--- a/images/build-env/Dockerfile
+++ b/images/build-env/Dockerfile
@@ -1,9 +1,10 @@
 FROM golang:1.12
 LABEL io.tyk.vendor="Tyk" \
-      version="1.1" \
+      version="1.3" \
       description="Base image for builds"
 
 ENV GOPATH=/
+ENV PACKER_VERSION="1.5.4"
 
 RUN apt-get update && apt-get dist-upgrade -y && \
     apt-get install -y ca-certificates \
@@ -24,5 +25,7 @@ RUN apt-get update && apt-get dist-upgrade -y && \
 RUN luarocks install lua-cjson
 RUN pip3 install grpcio protobuf
 RUN mkdir -p $GOPATH ~/rpmbuild/SOURCES ~/rpmbuild/SPECS
-RUN go get github.com/mitchellh/gox
+RUN go get github.com/mitchellh/gox 
 RUN gem install fpm rake package_cloud
+RUN curl https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip \
+        -o /tmp/packer.zip && cd /usr/local/bin && unzip /tmp/packer.zip


### PR DESCRIPTION
Also noted that build pipelines were using wrong version of tyk-build-env. New version `1.3` pushed and tagged as `latest`. All pipelines should now be using latest tag.