### PR TITLE
handle properly the value scope_allowance on keys 

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -338,6 +338,7 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 					return err
 				}
 
+				resourceForScope := apiID
 				// check if we already have limit on API level specified when policy was created
 				if accessRights.Limit == nil || *accessRights.Limit == (user.APILimit{}) {
 					// limit was not specified on API level so we will populate it from policy
@@ -349,15 +350,18 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 						ThrottleInterval:   policy.ThrottleInterval,
 						ThrottleRetryLimit: policy.ThrottleRetryLimit,
 					}
+				} else {
+					accessRights.AllowanceScope = policy.ID
+					accessRights.Limit.SetBy = policy.ID
+					resourceForScope = policy.ID
 				}
+				accessRights.AllowanceScope = resourceForScope
+				accessRights.Limit.SetBy = resourceForScope
 
 				// respect current quota renews (on API limit level)
 				if r, ok := session.AccessRights[apiID]; ok && r.Limit != nil {
 					accessRights.Limit.QuotaRenews = r.Limit.QuotaRenews
 				}
-
-				accessRights.AllowanceScope = apiID
-				accessRights.Limit.SetBy = apiID
 
 				// overwrite session access right for this API
 				rights[apiID] = accessRights

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -355,6 +355,7 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 					accessRights.Limit.SetBy = policy.ID
 					resourceForScope = policy.ID
 				}
+				log.Info("set: ", resourceForScope)
 				accessRights.AllowanceScope = resourceForScope
 				accessRights.Limit.SetBy = resourceForScope
 

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -355,7 +355,6 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 					accessRights.Limit.SetBy = policy.ID
 					resourceForScope = policy.ID
 				}
-				log.Info("set: ", resourceForScope)
 				accessRights.AllowanceScope = resourceForScope
 				accessRights.Limit.SetBy = resourceForScope
 

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -338,7 +338,7 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 					return err
 				}
 
-				resourceForScope := apiID
+				idForScope := apiID
 				// check if we already have limit on API level specified when policy was created
 				if accessRights.Limit == nil || *accessRights.Limit == (user.APILimit{}) {
 					// limit was not specified on API level so we will populate it from policy
@@ -351,12 +351,10 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 						ThrottleRetryLimit: policy.ThrottleRetryLimit,
 					}
 				} else {
-					accessRights.AllowanceScope = policy.ID
-					accessRights.Limit.SetBy = policy.ID
-					resourceForScope = policy.ID
+					idForScope = policy.ID
 				}
-				accessRights.AllowanceScope = resourceForScope
-				accessRights.Limit.SetBy = resourceForScope
+				accessRights.AllowanceScope = idForScope
+				accessRights.Limit.SetBy = idForScope
 
 				// respect current quota renews (on API limit level)
 				if r, ok := session.AccessRights[apiID]; ok && r.Limit != nil {

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -471,7 +471,7 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 							Rate:             20,
 							Per:              1,
 						},
-						AllowanceScope: "d",
+						AllowanceScope: "per_api_and_no_other_partitions",
 					},
 					"c": {
 						Limit: &user.APILimit{
@@ -479,7 +479,7 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 							Rate:     2000,
 							Per:      60,
 						},
-						AllowanceScope: "c",
+						AllowanceScope: "per_api_and_no_other_partitions",
 					},
 				}
 

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -486,7 +486,7 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 							Rate:     300,
 							Per:      1,
 						},
-						AllowanceScope: "per_api_with_limit_set_from_policy",
+						AllowanceScope: "d",
 					},
 					"d": {
 						Limit: &user.APILimit{
@@ -495,7 +495,7 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 							Rate:             200,
 							Per:              10,
 						},
-						AllowanceScope: "e",
+						AllowanceScope: "per_api_with_limit_set_from_policy",
 					},
 				}
 

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -234,6 +234,32 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 				"e": {},
 			},
 		},
+		"two_apis_with_limit_set_from_policy_for_one_of_them": {
+			ID:       "two_apis_with_limit_set_from_policy_for_one_of_them",
+			QuotaMax: -1,
+			Rate:     1000,
+			Per:      60,
+			Partitions: user.PolicyPartitions{
+				PerAPI:    true,
+				Quota:     false,
+				RateLimit: false,
+				Acl:       false,
+			},
+			AccessRights: map[string]user.AccessDefinition{
+				"a": {
+					APIID: "api_a",
+					Limit: &user.APILimit{
+						QuotaMax:         5000,
+						QuotaRenewalRate: 3600,
+						Rate:             200,
+						Per:              10,
+					},
+				},
+				"b": {
+					APIID: "api_b",
+				},
+			},
+		},
 		"per-path1": {
 			ID: "per_path_1",
 			AccessRights: map[string]user.AccessDefinition{"a": {
@@ -552,6 +578,33 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 				}
 				if s.Per != 4 {
 					t.Fatalf("Rate per seconds should be the same as rate policy")
+				}
+			},
+		},
+		{
+			name:     "Allowance scope on key for two apis with limits set to one of them from policy",
+			policies: []string{"two_apis_with_limit_set_from_policy_for_one_of_them"},
+			sessMatch: func(t *testing.T, s *user.SessionState) {
+				if s.AccessRights["a"].Limit == nil {
+					t.Fatalf("limit for api a cannot be null")
+				} else {
+					if s.AccessRights["a"].Limit.SetBy != "two_apis_with_limit_set_from_policy_for_one_of_them" {
+						t.Fatalf("the value of limit.setBy should be the same as policy ID")
+					}
+					if s.AccessRights["a"].AllowanceScope != "two_apis_with_limit_set_from_policy_for_one_of_them" {
+						t.Fatalf("the value of AllowanceScope should be the same as policy ID")
+					}
+				}
+
+				if s.AccessRights["b"].Limit == nil {
+					t.Fatalf("limit for api b cannot be null")
+				} else {
+					if s.AccessRights["b"].Limit.SetBy != s.AccessRights["b"].APIID {
+						t.Fatalf("the value of limit.setBy should be the same as API ID")
+					}
+					if s.AccessRights["b"].AllowanceScope != s.AccessRights["b"].APIID {
+						t.Fatalf("the value of AllowanceScope should be the same as API ID")
+					}
 				}
 			},
 		},

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -246,7 +246,7 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 				Acl:       false,
 			},
 			AccessRights: map[string]user.AccessDefinition{
-				"a": {
+				"api_a": {
 					APIID: "api_a",
 					Limit: &user.APILimit{
 						QuotaMax:         5000,
@@ -255,7 +255,7 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 						Per:              10,
 					},
 				},
-				"b": {
+				"api_b": {
 					APIID: "api_b",
 				},
 			},
@@ -585,24 +585,24 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 			name:     "Allowance scope on key for two apis with limits set to one of them from policy",
 			policies: []string{"two_apis_with_limit_set_from_policy_for_one_of_them"},
 			sessMatch: func(t *testing.T, s *user.SessionState) {
-				if s.AccessRights["a"].Limit == nil {
+				if s.AccessRights["api_a"].Limit == nil {
 					t.Fatalf("limit for api a cannot be null")
 				} else {
-					if s.AccessRights["a"].Limit.SetBy != "two_apis_with_limit_set_from_policy_for_one_of_them" {
+					if s.AccessRights["api_a"].Limit.SetBy != "two_apis_with_limit_set_from_policy_for_one_of_them" {
 						t.Fatalf("the value of limit.setBy should be the same as policy ID")
 					}
-					if s.AccessRights["a"].AllowanceScope != "two_apis_with_limit_set_from_policy_for_one_of_them" {
+					if s.AccessRights["api_a"].AllowanceScope != "two_apis_with_limit_set_from_policy_for_one_of_them" {
 						t.Fatalf("the value of AllowanceScope should be the same as policy ID")
 					}
 				}
 
-				if s.AccessRights["b"].Limit == nil {
+				if s.AccessRights["api_b"].Limit == nil {
 					t.Fatalf("limit for api b cannot be null")
 				} else {
-					if s.AccessRights["b"].Limit.SetBy != s.AccessRights["b"].APIID {
+					if s.AccessRights["api_b"].Limit.SetBy != s.AccessRights["api_b"].APIID {
 						t.Fatalf("the value of limit.setBy should be the same as API ID")
 					}
-					if s.AccessRights["b"].AllowanceScope != s.AccessRights["b"].APIID {
+					if s.AccessRights["api_b"].AllowanceScope != s.AccessRights["api_b"].APIID {
 						t.Fatalf("the value of AllowanceScope should be the same as API ID")
 					}
 				}

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -495,7 +495,7 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 							Rate:             200,
 							Per:              10,
 						},
-						AllowanceScope: "per_api_with_limit_set_from_policy",
+						AllowanceScope: "e",
 					},
 				}
 

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -234,32 +234,6 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 				"e": {},
 			},
 		},
-		"two_apis_with_limit_set_from_policy_for_one_of_them": {
-			ID:       "two_apis_with_limit_set_from_policy_for_one_of_them",
-			QuotaMax: -1,
-			Rate:     1000,
-			Per:      60,
-			Partitions: user.PolicyPartitions{
-				PerAPI:    true,
-				Quota:     false,
-				RateLimit: false,
-				Acl:       false,
-			},
-			AccessRights: map[string]user.AccessDefinition{
-				"api_a": {
-					APIID: "api_a",
-					Limit: &user.APILimit{
-						QuotaMax:         5000,
-						QuotaRenewalRate: 3600,
-						Rate:             200,
-						Per:              10,
-					},
-				},
-				"api_b": {
-					APIID: "api_b",
-				},
-			},
-		},
 		"per-path1": {
 			ID: "per_path_1",
 			AccessRights: map[string]user.AccessDefinition{"a": {
@@ -578,33 +552,6 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 				}
 				if s.Per != 4 {
 					t.Fatalf("Rate per seconds should be the same as rate policy")
-				}
-			},
-		},
-		{
-			name:     "Allowance scope on key for two apis with limits set to one of them from policy",
-			policies: []string{"two_apis_with_limit_set_from_policy_for_one_of_them"},
-			sessMatch: func(t *testing.T, s *user.SessionState) {
-				if s.AccessRights["api_a"].Limit == nil {
-					t.Fatalf("limit for api a cannot be null")
-				} else {
-					if s.AccessRights["api_a"].Limit.SetBy != "two_apis_with_limit_set_from_policy_for_one_of_them" {
-						t.Fatalf("the value of limit.setBy should be the same as policy ID")
-					}
-					if s.AccessRights["api_a"].AllowanceScope != "two_apis_with_limit_set_from_policy_for_one_of_them" {
-						t.Fatalf("the value of AllowanceScope should be the same as policy ID")
-					}
-				}
-
-				if s.AccessRights["api_b"].Limit == nil {
-					t.Fatalf("limit for api b cannot be null")
-				} else {
-					if s.AccessRights["api_b"].Limit.SetBy != s.AccessRights["api_b"].APIID {
-						t.Fatalf("the value of limit.setBy should be the same as API ID")
-					}
-					if s.AccessRights["api_b"].AllowanceScope != s.AccessRights["api_b"].APIID {
-						t.Fatalf("the value of AllowanceScope should be the same as API ID")
-					}
 				}
 			},
 		},

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -486,7 +486,7 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 							Rate:     300,
 							Per:      1,
 						},
-						AllowanceScope: "d",
+						AllowanceScope: "e",
 					},
 					"d": {
 						Limit: &user.APILimit{

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -512,7 +512,7 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 							Rate:     300,
 							Per:      1,
 						},
-						AllowanceScope: "e",
+						AllowanceScope: "per_api_with_limit_set_from_policy",
 					},
 					"d": {
 						Limit: &user.APILimit{
@@ -521,7 +521,7 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 							Rate:             200,
 							Per:              10,
 						},
-						AllowanceScope: "d",
+						AllowanceScope: "per_api_with_limit_set_from_policy",
 					},
 				}
 


### PR DESCRIPTION
This PR was created in order to give a fix to https://github.com/TykTechnologies/tyk-analytics/issues/1698 and set the proper allowance_scope when is applied a policy with limits set for one api (but 2 apis are in accessRights array) and set policy_Id as `AllowanceScope = policyID` as well as `Limit.SetBy = resourceForScope`. Was added a test as well.