### PR TITLE
make consistent how policies are applied so order doesnt matter

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -407,41 +407,63 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 
 				if !usePartitions || policy.Partitions.Quota {
 					didQuota[k] = true
+					quotaMaxWasSetInSession := false
 
 					// -1 is special "unlimited" case
 					if ar.Limit.QuotaMax != -1 && policy.QuotaMax > ar.Limit.QuotaMax {
 						ar.Limit.QuotaMax = policy.QuotaMax
-						session.QuotaMax = policy.QuotaMax
+						if policy.QuotaMax > session.QuotaMax {
+							session.QuotaMax = policy.QuotaMax
+							quotaMaxWasSetInSession = true
+						}
 					}
 
 					if policy.QuotaRenewalRate > ar.Limit.QuotaRenewalRate {
 						ar.Limit.QuotaRenewalRate = policy.QuotaRenewalRate
+					}
+
+					if quotaMaxWasSetInSession {
 						session.QuotaRenewalRate = policy.QuotaRenewalRate
 					}
 				}
 
 				if !usePartitions || policy.Partitions.RateLimit {
 					didRateLimit[k] = true
+					rateWasSetInSession := false
+					throttleWasSetInSession := false
 
 					if ar.Limit.Rate != -1 && policy.Rate > ar.Limit.Rate {
 						ar.Limit.Rate = policy.Rate
-						session.Rate = policy.Rate
+						if policy.Rate > session.Rate {
+							session.Rate = policy.Rate
+							rateWasSetInSession = true
+						}
 					}
 
 					if policy.Per > ar.Limit.Per {
 						ar.Limit.Per = policy.Per
-						session.Per = policy.Per
-					}
-
-					if policy.ThrottleInterval > ar.Limit.ThrottleInterval {
-						ar.Limit.ThrottleInterval = policy.ThrottleInterval
-						session.ThrottleInterval = policy.ThrottleInterval
+						if rateWasSetInSession {
+							session.Per = policy.Per
+						}
 					}
 
 					if policy.ThrottleRetryLimit > ar.Limit.ThrottleRetryLimit {
 						ar.Limit.ThrottleRetryLimit = policy.ThrottleRetryLimit
-						session.ThrottleRetryLimit = policy.ThrottleRetryLimit
+
+						if policy.ThrottleRetryLimit > session.ThrottleRetryLimit{
+							session.ThrottleRetryLimit = policy.ThrottleRetryLimit
+							throttleWasSetInSession = true
+						}
 					}
+
+					if policy.ThrottleInterval > ar.Limit.ThrottleInterval {
+						ar.Limit.ThrottleInterval = policy.ThrottleInterval
+					}
+
+					if throttleWasSetInSession {
+						session.ThrottleInterval = policy.ThrottleInterval
+					}
+
 				}
 
 				// Respect existing QuotaRenews

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -450,7 +450,7 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 					if policy.ThrottleRetryLimit > ar.Limit.ThrottleRetryLimit {
 						ar.Limit.ThrottleRetryLimit = policy.ThrottleRetryLimit
 
-						if policy.ThrottleRetryLimit > session.ThrottleRetryLimit{
+						if policy.ThrottleRetryLimit > session.ThrottleRetryLimit {
 							session.ThrottleRetryLimit = policy.ThrottleRetryLimit
 							throttleWasSetInSession = true
 						}


### PR DESCRIPTION
As the order of policies should not matter when they are applied on a key, then we now take the greatest value of the limit (rate, quota, throttling).

This fix https://github.com/TykTechnologies/tyk-analytics/issues/1814