### PR TITLE
filter by orgId on search apis for oauthClients

### DIFF
--- a/gateway/api.go
+++ b/gateway/api.go
@@ -2004,7 +2004,7 @@ func getApisForOauthClientId(oauthClientId string, orgId string) []string {
 			}
 		}
 	}
-	log.Info("apis for that client:", apis)
+
 	return apis
 }
 

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -160,10 +160,11 @@ func getSpecForOrg(orgID string) *APISpec {
 func getApisIdsForOrg(orgID string) []string {
 	result := []string{}
 
+	showAll := orgID == ""
 	apisMu.RLock()
 	defer apisMu.RUnlock()
 	for _, v := range apisByID {
-		if v.OrgID == orgID {
+		if v.OrgID == orgID || showAll {
 			result = append(result, v.APIID)
 		}
 	}
@@ -1738,15 +1739,15 @@ func rotateOauthClientHandler(w http.ResponseWriter, r *http.Request) {
 func getApisForOauthApp(w http.ResponseWriter, r *http.Request) {
 	apis := []string{}
 	appID := mux.Vars(r)["appID"]
-	orgID := mux.Vars(r)["orgID"]
+	orgID := r.FormValue("orgID")
 
 	//get all organization apis
 	apisIds := getApisIdsForOrg(orgID)
 
 	for index := range apisIds {
 		if api := getApiSpec(apisIds[index]); api != nil {
-			if api.UseOauth2{
-				clients,_, code := getApiClients(apisIds[index])
+			if api.UseOauth2 {
+				clients, _, code := getApiClients(apisIds[index])
 				if code == http.StatusOK {
 					for _, client := range clients {
 						if client.GetId() == appID {

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -442,7 +442,7 @@ func loadControlAPIEndpoints(muxer *mux.Router) {
 		r.HandleFunc("/oauth/clients/create", createOauthClient).Methods("POST")
 		r.HandleFunc("/oauth/clients/{apiID}/{keyName:[^/]*}", oAuthClientHandler).Methods("PUT")
 		r.HandleFunc("/oauth/clients/{apiID}/{keyName:[^/]*}/rotate", rotateOauthClientHandler).Methods("PUT")
-		r.HandleFunc("/oauth/clients/apis/{orgID}/{appID}", getApisForOauthApp).Methods("GET")
+		r.HandleFunc("/oauth/clients/apis/{appID}", getApisForOauthApp).Queries("orgID", "{[0-9]*?}").Methods("GET")
 		r.HandleFunc("/oauth/refresh/{keyName}", invalidateOauthRefresh).Methods("DELETE")
 		r.HandleFunc("/cache/{apiID}", invalidateCacheHandler).Methods("DELETE")
 		r.HandleFunc("/oauth/revoke", RevokeTokenHandler).Methods("POST")

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -442,7 +442,7 @@ func loadControlAPIEndpoints(muxer *mux.Router) {
 		r.HandleFunc("/oauth/clients/create", createOauthClient).Methods("POST")
 		r.HandleFunc("/oauth/clients/{apiID}/{keyName:[^/]*}", oAuthClientHandler).Methods("PUT")
 		r.HandleFunc("/oauth/clients/{apiID}/{keyName:[^/]*}/rotate", rotateOauthClientHandler).Methods("PUT")
-		r.HandleFunc("/oauth/clients/apis/{appID}", getApisForOauthApp).Methods("GET")
+		r.HandleFunc("/oauth/clients/apis/{orgID}/{appID}", getApisForOauthApp).Methods("GET")
 		r.HandleFunc("/oauth/refresh/{keyName}", invalidateOauthRefresh).Methods("DELETE")
 		r.HandleFunc("/cache/{apiID}", invalidateCacheHandler).Methods("DELETE")
 		r.HandleFunc("/oauth/revoke", RevokeTokenHandler).Methods("POST")

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -145,31 +145,6 @@ func getApiSpec(apiID string) *APISpec {
 	return spec
 }
 
-func getApisForOauthClientId(oauthClientId string) []string {
-	apis := []string{}
-	apisIdsCopy := []string{}
-
-	//generate a copy only with ids so we do not attempt to lock twice
-	apisMu.RLock()
-	for apiId := range apisByID {
-		apisIdsCopy = append(apisIdsCopy, apiId)
-	}
-	apisMu.RUnlock()
-
-	for index := range apisIdsCopy {
-		clientsData, _, status := getApiClients(apisIdsCopy[index])
-		if status == http.StatusOK {
-			for _, client := range clientsData {
-				if client.GetId() == oauthClientId {
-					apis = append(apis, apisIdsCopy[index])
-				}
-			}
-		}
-	}
-
-	return apis
-}
-
 func apisByIDLen() int {
 	apisMu.RLock()
 	defer apisMu.RUnlock()
@@ -535,7 +510,6 @@ func addOAuthHandlers(spec *APISpec, muxer *mux.Router) *OAuthManager {
 	serverConfig.RedirectUriSeparator = config.Global().OauthRedirectUriSeparator
 
 	prefix := generateOAuthPrefix(spec.APIID)
-	log.Info("prefix for oatuh redis:", prefix)
 	storageManager := getGlobalStorageHandler(prefix, false)
 	storageManager.Connect()
 	osinStorage := &RedisOsinStorageInterface{storageManager, GlobalSessionManager, spec.OrgID}


### PR DESCRIPTION
When looking for the apis that uses certain oauthClient then first we filter by OrgId to make the search faster.

Related to: https://github.com/TykTechnologies/tyk-analytics/issues/1817