### PR TITLE
on Apply policies, check the highest value for each field, without considering relation with another field 

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -407,41 +407,63 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 
 				if !usePartitions || policy.Partitions.Quota {
 					didQuota[k] = true
+					quotaMaxWasSetInSession := false
 
 					// -1 is special "unlimited" case
 					if ar.Limit.QuotaMax != -1 && policy.QuotaMax > ar.Limit.QuotaMax {
 						ar.Limit.QuotaMax = policy.QuotaMax
-						session.QuotaMax = policy.QuotaMax
+						if policy.QuotaMax > session.QuotaMax {
+							session.QuotaMax = policy.QuotaMax
+							quotaMaxWasSetInSession = true
+						}
 					}
 
 					if policy.QuotaRenewalRate > ar.Limit.QuotaRenewalRate {
 						ar.Limit.QuotaRenewalRate = policy.QuotaRenewalRate
+					}
+
+					if quotaMaxWasSetInSession {
 						session.QuotaRenewalRate = policy.QuotaRenewalRate
 					}
 				}
 
 				if !usePartitions || policy.Partitions.RateLimit {
 					didRateLimit[k] = true
+					rateWasSetInSession := false
+					throttleWasSetInSession := false
 
 					if ar.Limit.Rate != -1 && policy.Rate > ar.Limit.Rate {
 						ar.Limit.Rate = policy.Rate
-						session.Rate = policy.Rate
+						if policy.Rate > session.Rate {
+							session.Rate = policy.Rate
+							rateWasSetInSession = true
+						}
 					}
 
 					if policy.Per > ar.Limit.Per {
 						ar.Limit.Per = policy.Per
-						session.Per = policy.Per
-					}
-
-					if policy.ThrottleInterval > ar.Limit.ThrottleInterval {
-						ar.Limit.ThrottleInterval = policy.ThrottleInterval
-						session.ThrottleInterval = policy.ThrottleInterval
+						if rateWasSetInSession {
+							session.Per = policy.Per
+						}
 					}
 
 					if policy.ThrottleRetryLimit > ar.Limit.ThrottleRetryLimit {
 						ar.Limit.ThrottleRetryLimit = policy.ThrottleRetryLimit
-						session.ThrottleRetryLimit = policy.ThrottleRetryLimit
+
+						if policy.ThrottleRetryLimit > session.ThrottleRetryLimit{
+							session.ThrottleRetryLimit = policy.ThrottleRetryLimit
+							throttleWasSetInSession = true
+						}
 					}
+
+					if policy.ThrottleInterval > ar.Limit.ThrottleInterval {
+						ar.Limit.ThrottleInterval = policy.ThrottleInterval
+					}
+
+					if throttleWasSetInSession {
+						session.ThrottleInterval = policy.ThrottleInterval
+					}
+
 				}
 
 				// Respect existing QuotaRenews

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -407,42 +407,36 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 
 				if !usePartitions || policy.Partitions.Quota {
 					didQuota[k] = true
-					quotaMaxWasSetInSession := false
 
 					// -1 is special "unlimited" case
 					if ar.Limit.QuotaMax != -1 && policy.QuotaMax > ar.Limit.QuotaMax {
 						ar.Limit.QuotaMax = policy.QuotaMax
 						if policy.QuotaMax > session.QuotaMax {
 							session.QuotaMax = policy.QuotaMax
-							quotaMaxWasSetInSession = true
 						}
 					}
 
 					if policy.QuotaRenewalRate > ar.Limit.QuotaRenewalRate {
 						ar.Limit.QuotaRenewalRate = policy.QuotaRenewalRate
-					}
-
-					if quotaMaxWasSetInSession {
-						session.QuotaRenewalRate = policy.QuotaRenewalRate
+						if policy.QuotaRenewalRate > session.QuotaRenewalRate {
+							session.QuotaRenewalRate = policy.QuotaRenewalRate
+						}
 					}
 				}
 
 				if !usePartitions || policy.Partitions.RateLimit {
 					didRateLimit[k] = true
-					rateWasSetInSession := false
-					throttleWasSetInSession := false
 
 					if ar.Limit.Rate != -1 && policy.Rate > ar.Limit.Rate {
 						ar.Limit.Rate = policy.Rate
 						if policy.Rate > session.Rate {
 							session.Rate = policy.Rate
-							rateWasSetInSession = true
 						}
 					}
 
 					if policy.Per > ar.Limit.Per {
 						ar.Limit.Per = policy.Per
-						if rateWasSetInSession {
+						if policy.Per > session.Per {
 							session.Per = policy.Per
 						}
 					}
@@ -452,18 +446,15 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 
 						if policy.ThrottleRetryLimit > session.ThrottleRetryLimit {
 							session.ThrottleRetryLimit = policy.ThrottleRetryLimit
-							throttleWasSetInSession = true
 						}
 					}
 
 					if policy.ThrottleInterval > ar.Limit.ThrottleInterval {
 						ar.Limit.ThrottleInterval = policy.ThrottleInterval
+						if policy.ThrottleInterval > session.ThrottleInterval {
+							session.ThrottleInterval = policy.ThrottleInterval
+						}
 					}
-
-					if throttleWasSetInSession {
-						session.ThrottleInterval = policy.ThrottleInterval
-					}
-
 				}
 
 				// Respect existing QuotaRenews

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -407,7 +407,6 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 
 				if !usePartitions || policy.Partitions.Quota {
 					didQuota[k] = true
-					quotaMaxWasSetInSession := false
 
 					// -1 is special "unlimited" case
 					if ar.Limit.QuotaMax != -1 && policy.QuotaMax > ar.Limit.QuotaMax {
@@ -427,8 +426,6 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 
 				if !usePartitions || policy.Partitions.RateLimit {
 					didRateLimit[k] = true
-					rateWasSetInSession := false
-					throttleWasSetInSession := false
 
 					if ar.Limit.Rate != -1 && policy.Rate > ar.Limit.Rate {
 						ar.Limit.Rate = policy.Rate
@@ -446,7 +443,6 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 
 					if policy.ThrottleRetryLimit > ar.Limit.ThrottleRetryLimit {
 						ar.Limit.ThrottleRetryLimit = policy.ThrottleRetryLimit
-
 						if policy.ThrottleRetryLimit > session.ThrottleRetryLimit {
 							session.ThrottleRetryLimit = policy.ThrottleRetryLimit
 						}
@@ -458,7 +454,6 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 							session.ThrottleInterval = policy.ThrottleInterval
 						}
 					}
-
 				}
 
 				// Respect existing QuotaRenews

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -450,7 +450,7 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 					if policy.ThrottleRetryLimit > ar.Limit.ThrottleRetryLimit {
 						ar.Limit.ThrottleRetryLimit = policy.ThrottleRetryLimit
 
-						if policy.ThrottleRetryLimit > session.ThrottleRetryLimit{
+						if policy.ThrottleRetryLimit > session.ThrottleRetryLimit {
 							session.ThrottleRetryLimit = policy.ThrottleRetryLimit
 							throttleWasSetInSession = true
 						}


### PR DESCRIPTION
always select the biggest value, it doesn't matter if it have any relation with another value, Eg: rate with per,  throttle_interval with throttle_retry_limit, quota_max with quota_renewal_rate, and so on. now they are chosen independently

related to: https://github.com/TykTechnologies/tyk-analytics/issues/1814