### PR TITLE
Oauth clients and certificates listing optimization

### DIFF
--- a/certs/manager.go
+++ b/certs/manager.go
@@ -30,6 +30,10 @@ type StorageHandler interface {
 	GetKeys(string) []string
 	DeleteKey(string) bool
 	DeleteScanMatch(string) bool
+	GetListRange(string, int64, int64) ([]string, error)
+	RemoveFromList(string, string) error
+	AppendToSet(string, string)
+	Exists(string) (bool, error)
 }
 
 type CertificateManager struct {
@@ -368,12 +372,22 @@ func (c *CertificateManager) ListRawPublicKey(keyID string) (out interface{}) {
 }
 
 func (c *CertificateManager) ListAllIds(prefix string) (out []string) {
-	keys := c.storage.GetKeys("raw-" + prefix + "*")
-
-	for _, key := range keys {
-		out = append(out, strings.TrimPrefix(key, "raw-"))
+	indexKey := prefix + "-index"
+	exists, _ := c.storage.Exists(indexKey)
+	if exists && prefix != "" {
+		keys, _ := c.storage.GetListRange(indexKey, 0, -1)
+		for _, key := range keys {
+			out = append(out, strings.TrimPrefix(key, "raw-"))
+		}
+	} else {
+		keys := c.storage.GetKeys("raw-" + prefix + "*")
+		for _, key := range keys {
+			if prefix != "" {
+				c.storage.AppendToSet(indexKey, key)
+			}
+			out = append(out, strings.TrimPrefix(key, "raw-"))
+		}
 	}
-
 	return out
 }
 
@@ -488,10 +502,19 @@ func (c *CertificateManager) Add(certData []byte, orgID string) (string, error) 
 		return "", err
 	}
 
+	if orgID != "" {
+		c.storage.AppendToSet(orgID+"-index", "raw-"+certID)
+	}
+
 	return certID, nil
 }
 
-func (c *CertificateManager) Delete(certID string) {
+func (c *CertificateManager) Delete(certID string, orgID string) {
+
+	if orgID != "" {
+		c.storage.RemoveFromList(orgID+"-index", "raw-"+certID)
+	}
+
 	c.storage.DeleteKey("raw-" + certID)
 	c.cache.Delete(certID)
 }

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -1478,7 +1478,7 @@ func createOauthClient(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		err := apiSpec.OAuthManager.OsinServer.Storage.SetClient(storageID, &newClient, true)
+		err := apiSpec.OAuthManager.OsinServer.Storage.SetClient(storageID, apiSpec.OrgID, &newClient, true)
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "api",
@@ -1522,7 +1522,7 @@ func createOauthClient(w http.ResponseWriter, r *http.Request) {
 			// set oauth client if it is oauth API
 			if apiSpec.UseOauth2 {
 				oauth2 = true
-				err := apiSpec.OAuthManager.OsinServer.Storage.SetClient(storageID, &newClient, true)
+				err := apiSpec.OAuthManager.OsinServer.Storage.SetClient(storageID, apiSpec.OrgID, &newClient, true)
 				if err != nil {
 					log.WithFields(logrus.Fields{
 						"prefix": "api",
@@ -1615,7 +1615,7 @@ func updateOauthClient(keyName, apiID string, r *http.Request) (interface{}, int
 		Description:       updateClientData.Description,       // update
 	}
 
-	err = apiSpec.OAuthManager.OsinServer.Storage.SetClient(storageID, &updatedClient, true)
+	err = apiSpec.OAuthManager.OsinServer.Storage.SetClient(storageID, apiSpec.OrgID, &updatedClient, true)
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "api",
@@ -1883,7 +1883,7 @@ func handleDeleteOAuthClient(keyName, apiID string) (interface{}, int) {
 	}
 
 	if apiSpec.OAuthManager != nil {
-		err := apiSpec.OAuthManager.OsinServer.Storage.DeleteClient(storageID, true)
+		err := apiSpec.OAuthManager.OsinServer.Storage.DeleteClient(storageID, apiSpec.OrgID, true)
 		if err != nil {
 			return apiError("Delete failed"), http.StatusInternalServerError
 		}
@@ -1927,7 +1927,7 @@ func getApiClients(apiID string) ([]ExtendedOsinClientInterface, apiStatusMessag
 
 	clientData := []ExtendedOsinClientInterface{}
 	if apiSpec.UseOauth2 {
-		clientData, err = apiSpec.OAuthManager.OsinServer.Storage.GetClients(filterID, true)
+		clientData, err := apiSpec.OAuthManager.OsinServer.Storage.GetClients(filterID, apiSpec.OrgID, true)
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "api",

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -1927,7 +1927,7 @@ func getApiClients(apiID string) ([]ExtendedOsinClientInterface, apiStatusMessag
 
 	clientData := []ExtendedOsinClientInterface{}
 	if apiSpec.UseOauth2 {
-		clientData, err := apiSpec.OAuthManager.OsinServer.Storage.GetClients(filterID, apiSpec.OrgID, true)
+		clientData, err = apiSpec.OAuthManager.OsinServer.Storage.GetClients(filterID, apiSpec.OrgID, true)
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "api",

--- a/gateway/batch_requests_test.go
+++ b/gateway/batch_requests_test.go
@@ -133,7 +133,7 @@ func TestVirtualEndpointBatch(t *testing.T) {
 	defer upstream.Close()
 
 	clientCertID, _ := CertificateManager.Add(combinedClientPEM, "")
-	defer CertificateManager.Delete(clientCertID)
+	defer CertificateManager.Delete(clientCertID, "")
 
 	virtBatchTest = strings.Replace(virtBatchTest, "{upstream_URL}", upstream.URL, 2)
 	defer upstream.Close()

--- a/gateway/cert.go
+++ b/gateway/cert.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -452,7 +453,11 @@ func certHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	case "DELETE":
-		CertificateManager.Delete(certID)
+		orgID := r.URL.Query().Get("org_id")
+		if orgID == "" && len(certID) >= sha256.Size*2 {
+			orgID = certID[:len(certID)-sha256.Size*2]
+		}
+		CertificateManager.Delete(certID, orgID)
 		doJSONWrite(w, http.StatusOK, &apiStatusMessage{"ok", "removed"})
 	}
 }

--- a/gateway/cert_go1.10_test.go
+++ b/gateway/cert_go1.10_test.go
@@ -41,7 +41,7 @@ func TestPublicKeyPinning(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	defer CertificateManager.Delete(pubID)
+	defer CertificateManager.Delete(pubID, "")
 
 	upstream := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 	}))
@@ -138,7 +138,7 @@ func TestPublicKeyPinning(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		defer CertificateManager.Delete(serverPubID)
+		defer CertificateManager.Delete(serverPubID, "")
 
 		upstream := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		}))
@@ -158,7 +158,7 @@ func TestPublicKeyPinning(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		defer CertificateManager.Delete(proxyPubID)
+		defer CertificateManager.Delete(proxyPubID, "")
 
 		proxy := initProxy("http", &tls.Config{
 			Certificates: []tls.Certificate{proxyCert},

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -148,7 +148,7 @@ func TestGatewayTLS(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer CertificateManager.Delete(certID)
+		defer CertificateManager.Delete(certID, "")
 
 		globalConf := config.Global()
 		globalConf.HttpServerOptions.SSLCertificates = []string{certID}
@@ -195,7 +195,7 @@ func TestGatewayControlAPIMutualTLS(t *testing.T) {
 
 	t.Run("Separate domain", func(t *testing.T) {
 		certID, _ := CertificateManager.Add(combinedPEM, "")
-		defer CertificateManager.Delete(certID)
+		defer CertificateManager.Delete(certID, "")
 
 		globalConf := config.Global()
 		globalConf.ControlAPIHostname = "localhost"
@@ -226,7 +226,7 @@ func TestGatewayControlAPIMutualTLS(t *testing.T) {
 		}...)
 
 		clientCertID, _ := CertificateManager.Add(clientCertPem, "")
-		defer CertificateManager.Delete(clientCertID)
+		defer CertificateManager.Delete(clientCertID, "")
 
 		globalConf = config.Global()
 		globalConf.Security.Certificates.ControlAPI = []string{clientCertID}
@@ -243,7 +243,7 @@ func TestAPIMutualTLS(t *testing.T) {
 	// Configure server
 	serverCertPem, _, combinedPEM, _ := genServerCertificate()
 	certID, _ := CertificateManager.Add(combinedPEM, "")
-	defer CertificateManager.Delete(certID)
+	defer CertificateManager.Delete(certID, "")
 
 	globalConf := config.Global()
 	globalConf.EnableCustomDomains = true
@@ -303,7 +303,7 @@ func TestAPIMutualTLS(t *testing.T) {
 				Code: 200, Client: client, Domain: "localhost",
 			})
 
-			CertificateManager.Delete(clientCertID)
+			CertificateManager.Delete(clientCertID, "")
 			CertificateManager.FlushCache()
 			tlsConfigCache.Flush()
 
@@ -318,7 +318,7 @@ func TestAPIMutualTLS(t *testing.T) {
 
 			clientCertPem2, _, _, _ := genCertificate(&x509.Certificate{})
 			clientCertID2, _ := CertificateManager.Add(clientCertPem2, "")
-			defer CertificateManager.Delete(clientCertID2)
+			defer CertificateManager.Delete(clientCertID2, "")
 
 			BuildAndLoadAPI(func(spec *APISpec) {
 				spec.Domain = "localhost"
@@ -336,7 +336,7 @@ func TestAPIMutualTLS(t *testing.T) {
 	t.Run("Multiple APIs on same domain", func(t *testing.T) {
 		testSameDomain := func(t *testing.T, domain string) {
 			clientCertID, _ := CertificateManager.Add(clientCertPem, "")
-			defer CertificateManager.Delete(clientCertID)
+			defer CertificateManager.Delete(clientCertID, "")
 
 			loadAPIS := func(certs ...string) {
 				BuildAndLoadAPI(
@@ -416,10 +416,10 @@ func TestAPIMutualTLS(t *testing.T) {
 	t.Run("Multiple APIs with Mutual TLS on the same domain", func(t *testing.T) {
 		testSameDomain := func(t *testing.T, domain string) {
 			clientCertID, _ := CertificateManager.Add(clientCertPem, "")
-			defer CertificateManager.Delete(clientCertID)
+			defer CertificateManager.Delete(clientCertID, "")
 
 			clientCertID2, _ := CertificateManager.Add(clientCertPem2, "")
-			defer CertificateManager.Delete(clientCertID2)
+			defer CertificateManager.Delete(clientCertID2, "")
 
 			loadAPIS := func(certs []string, certs2 []string) {
 				BuildAndLoadAPI(
@@ -529,7 +529,7 @@ func TestAPIMutualTLS(t *testing.T) {
 	t.Run("Multiple APIs, mutual on custom", func(t *testing.T) {
 		testSameDomain := func(t *testing.T, domain string) {
 			clientCertID, _ := CertificateManager.Add(clientCertPem, "")
-			defer CertificateManager.Delete(clientCertID)
+			defer CertificateManager.Delete(clientCertID, "")
 
 			loadAPIS := func(certs ...string) {
 				BuildAndLoadAPI(
@@ -623,7 +623,7 @@ func TestAPIMutualTLS(t *testing.T) {
 	t.Run("Multiple APIs, mutual on empty", func(t *testing.T) {
 		testSameDomain := func(t *testing.T, domain string) {
 			clientCertID, _ := CertificateManager.Add(clientCertPem, "")
-			defer CertificateManager.Delete(clientCertID)
+			defer CertificateManager.Delete(clientCertID, "")
 
 			loadAPIS := func(certs ...string) {
 				BuildAndLoadAPI(
@@ -753,7 +753,7 @@ func TestUpstreamMutualTLS(t *testing.T) {
 		defer ts.Close()
 
 		clientCertID, _ := CertificateManager.Add(combinedClientPEM, "")
-		defer CertificateManager.Delete(clientCertID)
+		defer CertificateManager.Delete(clientCertID, "")
 
 		pool.AddCert(clientCert.Leaf)
 
@@ -823,7 +823,7 @@ func TestSSLForceCommonName(t *testing.T) {
 func TestKeyWithCertificateTLS(t *testing.T) {
 	_, _, combinedPEM, _ := genServerCertificate()
 	serverCertID, _ := CertificateManager.Add(combinedPEM, "")
-	defer CertificateManager.Delete(serverCertID)
+	defer CertificateManager.Delete(serverCertID, "")
 
 	globalConf := config.Global()
 	globalConf.HttpServerOptions.UseSSL = true
@@ -945,7 +945,7 @@ func TestKeyWithCertificateTLS(t *testing.T) {
 func TestAPICertificate(t *testing.T) {
 	_, _, combinedPEM, _ := genServerCertificate()
 	serverCertID, _ := CertificateManager.Add(combinedPEM, "")
-	defer CertificateManager.Delete(serverCertID)
+	defer CertificateManager.Delete(serverCertID, "")
 
 	globalConf := config.Global()
 	globalConf.HttpServerOptions.UseSSL = true
@@ -1039,7 +1039,7 @@ func TestCipherSuites(t *testing.T) {
 	//configure server so we can useSSL and utilize the logic, but skip verification in the clients
 	_, _, combinedPEM, _ := genServerCertificate()
 	serverCertID, _ := CertificateManager.Add(combinedPEM, "")
-	defer CertificateManager.Delete(serverCertID)
+	defer CertificateManager.Delete(serverCertID, "")
 
 	globalConf := config.Global()
 	globalConf.HttpServerOptions.UseSSL = true

--- a/gateway/grpc_test.go
+++ b/gateway/grpc_test.go
@@ -34,7 +34,7 @@ func TestHTTP2_TLS(t *testing.T) {
 	_, _, _, clientCert := genCertificate(&x509.Certificate{})
 	serverCertPem, _, combinedPEM, _ := genServerCertificate()
 	certID, _ := CertificateManager.Add(combinedPEM, "")
-	defer CertificateManager.Delete(certID)
+	defer CertificateManager.Delete(certID, "")
 
 	// Upstream server supporting HTTP/2
 	upstream := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -82,7 +82,7 @@ func TestGRPC_TLS(t *testing.T) {
 
 	_, _, combinedPEM, _ := genServerCertificate()
 	certID, _ := CertificateManager.Add(combinedPEM, "")
-	defer CertificateManager.Delete(certID)
+	defer CertificateManager.Delete(certID, "")
 
 	// gRPC server
 	s := startGRPCServer(t, nil)
@@ -131,10 +131,10 @@ func TestGRPC_MutualTLS(t *testing.T) {
 	serverCertPem, _, combinedPEM, _ := genServerCertificate()
 
 	certID, _ := CertificateManager.Add(combinedPEM, "") // For tyk to know downstream
-	defer CertificateManager.Delete(certID)
+	defer CertificateManager.Delete(certID, "")
 
 	clientCertID, _ := CertificateManager.Add(combinedClientPEM, "") // For upstream to know tyk
-	defer CertificateManager.Delete(clientCertID)
+	defer CertificateManager.Delete(clientCertID, "")
 
 	// Protected gRPC server
 	s := startGRPCServer(t, clientCert.Leaf)
@@ -181,7 +181,7 @@ func TestGRPC_BasicAuthentication(t *testing.T) {
 	defer ResetTestConfig()
 	_, _, combinedPEM, _ := genServerCertificate()
 	certID, _ := CertificateManager.Add(combinedPEM, "")
-	defer CertificateManager.Delete(certID)
+	defer CertificateManager.Delete(certID, "")
 
 	// gRPC server
 	s := startGRPCServer(t, nil)
@@ -238,7 +238,7 @@ func TestGRPC_TokenBasedAuthentication(t *testing.T) {
 	defer ResetTestConfig()
 	_, _, combinedPEM, _ := genServerCertificate()
 	certID, _ := CertificateManager.Add(combinedPEM, "")
-	defer CertificateManager.Delete(certID)
+	defer CertificateManager.Delete(certID, "")
 
 	// gRPC server
 	s := startGRPCServer(t, nil)

--- a/gateway/ldap_auth_handler.go
+++ b/gateway/ldap_auth_handler.go
@@ -229,3 +229,18 @@ func (l LDAPStorageHandler) RemoveSortedSetRange(keyName, scoreFrom, scoreTo str
 	log.Error("Not implemented")
 	return nil
 }
+
+func (l LDAPStorageHandler) RemoveFromList(keyName, value string) error {
+	log.Error("Not implemented")
+	return nil
+}
+
+func (l *LDAPStorageHandler) GetListRange(keyName string, from, to int64) ([]string, error) {
+	log.Error("Not implemented")
+	return nil, nil
+}
+
+func (l LDAPStorageHandler) Exists(keyName string) (bool, error) {
+	log.Error("Not implemented")
+	return false, nil
+}

--- a/gateway/mw_http_signature_validation_test.go
+++ b/gateway/mw_http_signature_validation_test.go
@@ -647,7 +647,7 @@ func TestRSAAuthSessionPass(t *testing.T) {
 	pubDer, _ := x509.MarshalPKIXPublicKey(x509Cert.PublicKey)
 	pubPem := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDer})
 	pubID, _ := CertificateManager.Add(pubPem, "")
-	defer CertificateManager.Delete(pubID)
+	defer CertificateManager.Delete(pubID, "")
 
 	// Should not receive an AuthFailure event
 	var eventWG sync.WaitGroup
@@ -679,7 +679,7 @@ func BenchmarkRSAAuthSessionPass(b *testing.B) {
 	pubDer, _ := x509.MarshalPKIXPublicKey(x509Cert.PublicKey)
 	pubPem := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDer})
 	pubID, _ := CertificateManager.Add(pubPem, "")
-	defer CertificateManager.Delete(pubID)
+	defer CertificateManager.Delete(pubID, "")
 
 	var eventWG sync.WaitGroup
 	eventWG.Add(b.N)
@@ -705,7 +705,7 @@ func TestRSAAuthSessionKeyMissing(t *testing.T) {
 	pubDer, _ := x509.MarshalPKIXPublicKey(x509Cert.PublicKey)
 	pubPem := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDer})
 	pubID, _ := CertificateManager.Add(pubPem, "")
-	defer CertificateManager.Delete(pubID)
+	defer CertificateManager.Delete(pubID, "")
 
 	spec := LoadSampleAPI(hmacAuthDef)
 

--- a/gateway/mw_request_signing_test.go
+++ b/gateway/mw_request_signing_test.go
@@ -231,13 +231,13 @@ func TestRSARequestSigning(t *testing.T) {
 
 	_, _, combinedPem, cert := genServerCertificate()
 	privCertId, _ := CertificateManager.Add(combinedPem, "")
-	defer CertificateManager.Delete(privCertId)
+	defer CertificateManager.Delete(privCertId, "")
 
 	x509Cert, _ := x509.ParseCertificate(cert.Certificate[0])
 	pubDer, _ := x509.MarshalPKIXPublicKey(x509Cert.PublicKey)
 	pubPem := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDer})
 	pubCertId, _ := CertificateManager.Add(pubPem, "")
-	defer CertificateManager.Delete(pubCertId)
+	defer CertificateManager.Delete(pubCertId, "")
 
 	name := "Test with rsa-sha256"
 	t.Run(name, func(t *testing.T) {

--- a/gateway/oauth_manager.go
+++ b/gateway/oauth_manager.go
@@ -474,13 +474,13 @@ func (o *OAuthManager) HandleAccess(r *http.Request) *osin.Response {
 // These enums fix the prefix to use when storing various OAuth keys and data, since we
 // delegate everything to the osin framework
 const (
-	prefixAuth      = "oauth-authorize."
-	prefixClient    = "oauth-clientid."
-	prefixAccess    = "oauth-access."
-	prefixRefresh   = "oauth-refresh."
-	prefixClientset = "oauth-clientset."
-
-	prefixClientTokens = "oauth-client-tokens."
+	prefixAuth            = "oauth-authorize."
+	prefixClient          = "oauth-clientid."
+	prefixAccess          = "oauth-access."
+	prefixRefresh         = "oauth-refresh."
+	prefixClientset       = "oauth-clientset."
+	prefixClientIndexList = "oauth-client-index."
+	prefixClientTokens    = "oauth-client-tokens."
 )
 
 // swagger:model
@@ -498,7 +498,7 @@ type ExtendedOsinStorageInterface interface {
 	osin.Storage
 
 	// Create OAuth clients
-	SetClient(id string, client osin.Client, ignorePrefix bool) error
+	SetClient(id string, orgID string, client osin.Client, ignorePrefix bool) error
 
 	// Custom getter to handle prefixing issues in Redis
 	GetClientNoPrefix(id string) (osin.Client, error)
@@ -511,9 +511,9 @@ type ExtendedOsinStorageInterface interface {
 	// Custom getter to handle prefixing issues in Redis
 	GetExtendedClientNoPrefix(id string) (ExtendedOsinClientInterface, error)
 
-	GetClients(filter string, ignorePrefix bool) ([]ExtendedOsinClientInterface, error)
+	GetClients(filter string, orgID string, ignorePrefix bool) ([]ExtendedOsinClientInterface, error)
 
-	DeleteClient(id string, ignorePrefix bool) error
+	DeleteClient(id string, orgID string, ignorePrefix bool) error
 
 	// GetUser retrieves a Basic Access user token type from the key store
 	GetUser(string) (*user.SessionState, error)
@@ -624,15 +624,39 @@ func (r *RedisOsinStorageInterface) GetExtendedClientNoPrefix(id string) (Extend
 }
 
 // GetClients will retrieve a list of clients for a prefix
-func (r *RedisOsinStorageInterface) GetClients(filter string, ignorePrefix bool) ([]ExtendedOsinClientInterface, error) {
+func (r *RedisOsinStorageInterface) GetClients(filter string, orgID string, ignorePrefix bool) ([]ExtendedOsinClientInterface, error) {
 	key := prefixClient + filter
 	if ignorePrefix {
 		key = filter
 	}
 
+	indexKey := prefixClientIndexList + orgID
+
 	var clientJSON map[string]string
 	if !config.Global().Storage.EnableCluster {
-		clientJSON = r.store.GetKeysAndValuesWithFilter(key)
+		exists, _ := r.store.Exists(indexKey)
+		if exists {
+			keys, err := r.store.GetListRange(indexKey, 0, -1)
+			if err != nil {
+				log.Error("Couldn't get OAuth client index list: ", err)
+				return nil, err
+			}
+			keyVals, err := r.store.GetMultiKey(keys)
+			if err != nil {
+				log.Error("Couldn't get OAuth client index list values: ", err)
+				return nil, err
+			}
+
+			clientJSON = make(map[string]string)
+			for i, key := range keys {
+				clientJSON[key] = keyVals[i]
+			}
+		} else {
+			clientJSON = r.store.GetKeysAndValuesWithFilter(key)
+			for key := range clientJSON {
+				r.store.AppendToSet(indexKey, key)
+			}
+		}
 	} else {
 		keyForSet := prefixClientset + prefixClient // Org ID
 		var err error
@@ -749,7 +773,7 @@ func (r *RedisOsinStorageInterface) GetClientTokens(id string) ([]OAuthClientTok
 }
 
 // SetClient creates client data
-func (r *RedisOsinStorageInterface) SetClient(id string, client osin.Client, ignorePrefix bool) error {
+func (r *RedisOsinStorageInterface) SetClient(id string, orgID string, client osin.Client, ignorePrefix bool) error {
 	clientDataJSON, err := json.Marshal(client)
 
 	if err != nil {
@@ -771,6 +795,19 @@ func (r *RedisOsinStorageInterface) SetClient(id string, client osin.Client, ign
 
 	keyForSet := prefixClientset + prefixClient // Org ID
 
+	indexKey := prefixClientIndexList + orgID
+	//check if the indexKey exists
+	exists, err := r.store.Exists(indexKey)
+	if err != nil {
+		return err
+	}
+	// if it exists, delete it to avoid duplicity in the client index list
+	if exists {
+		r.store.RemoveFromList(indexKey, key)
+	}
+	// append to oauth client index list
+	r.store.AppendToSet(indexKey, key)
+
 	// In set, there is no option for update so the existing client should be removed before adding new one.
 	set, _ := r.store.GetSet(keyForSet)
 	for _, v := range set {
@@ -784,7 +821,7 @@ func (r *RedisOsinStorageInterface) SetClient(id string, client osin.Client, ign
 }
 
 // DeleteClient Removes a client from the system
-func (r *RedisOsinStorageInterface) DeleteClient(id string, ignorePrefix bool) error {
+func (r *RedisOsinStorageInterface) DeleteClient(id string, orgID string, ignorePrefix bool) error {
 	key := prefixClient + id
 	if ignorePrefix {
 		key = id
@@ -799,6 +836,10 @@ func (r *RedisOsinStorageInterface) DeleteClient(id string, ignorePrefix bool) e
 	}
 
 	r.store.DeleteKey(key)
+
+	indexKey := prefixClientIndexList + orgID
+	// delete from oauth client
+	r.store.RemoveFromList(indexKey, key)
 
 	// delete list of tokens for this client
 	r.store.DeleteKey(prefixClientTokens + id)

--- a/gateway/oauth_manager_test.go
+++ b/gateway/oauth_manager_test.go
@@ -141,7 +141,7 @@ func createTestOAuthClient(spec *APISpec, clientID string) {
 		PolicyID:          pID,
 		MetaData:          map[string]interface{}{"foo": "bar", "client": "meta"},
 	}
-	spec.OAuthManager.OsinServer.Storage.SetClient(testClient.ClientID, &testClient, false)
+	spec.OAuthManager.OsinServer.Storage.SetClient(testClient.ClientID, "org-id-1", &testClient, false)
 }
 
 func TestOauthMultipleAPIs(t *testing.T) {
@@ -153,12 +153,14 @@ func TestOauthMultipleAPIs(t *testing.T) {
 		spec.UseOauth2 = true
 		spec.UseKeylessAccess = false
 		spec.Proxy.ListenPath = "/api1/"
+		spec.OrgID = "org-id-1"
 	})
 	spec2 := buildTestOAuthSpec(func(spec *APISpec) {
 		spec.APIID = "oauth2_copy"
 		spec.UseKeylessAccess = false
 		spec.UseOauth2 = true
 		spec.Proxy.ListenPath = "/api2/"
+		spec.OrgID = "org-id-2"
 	})
 
 	apis := LoadAPI(spec, spec2)
@@ -182,8 +184,8 @@ func TestOauthMultipleAPIs(t *testing.T) {
 		ClientRedirectURI: authRedirectUri,
 		PolicyID:          pID,
 	}
-	spec.OAuthManager.OsinServer.Storage.SetClient(testClient.ClientID, &testClient, false)
-	spec2.OAuthManager.OsinServer.Storage.SetClient(testClient.ClientID, &testClient, false)
+	spec.OAuthManager.OsinServer.Storage.SetClient(testClient.ClientID, spec.OrgID, &testClient, false)
+	spec2.OAuthManager.OsinServer.Storage.SetClient(testClient.ClientID, spec2.OrgID, &testClient, false)
 
 	param := make(url.Values)
 	param.Set("response_type", "token")

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -904,3 +904,18 @@ func (r *RPCStorageHandler) RemoveSortedSetRange(keyName, scoreFrom, scoreTo str
 	log.Error("RPCStorageHandler.RemoveSortedSetRange - Not implemented")
 	return nil
 }
+
+func (r *RPCStorageHandler) RemoveFromList(keyName, value string) error {
+	log.Error("Not implemented")
+	return nil
+}
+
+func (r *RPCStorageHandler) GetListRange(keyName string, from, to int64) ([]string, error) {
+	log.Error("Not implemented")
+	return nil, nil
+}
+
+func (r *RPCStorageHandler) Exists(keyName string) (bool, error) {
+	log.Error("Not implemented")
+	return false, nil
+}

--- a/storage/redis_cluster.go
+++ b/storage/redis_cluster.go
@@ -882,6 +882,60 @@ func (r *RedisCluster) AppendToSet(keyName, value string) {
 	}
 }
 
+//Exists check if keyName exists
+func (r *RedisCluster) Exists(keyName string) (bool, error) {
+	fixedKey := r.fixKey(keyName)
+	log.WithField("keyName", fixedKey).Debug("Checking if exists")
+
+	exists, err := r.singleton().Exists(fixedKey).Result()
+	if err != nil {
+		log.Error("Error trying to check if key exists: ", err)
+		return false, err
+	}
+	if exists == 1 {
+		return true, nil
+	}
+	return false, nil
+}
+
+// RemoveFromList delete an value from a list idetinfied with the keyName
+func (r *RedisCluster) RemoveFromList(keyName, value string) error {
+	fixedKey := r.fixKey(keyName)
+	logEntry := logrus.Fields{
+		"keyName":  keyName,
+		"fixedKey": fixedKey,
+		"value":    value,
+	}
+	log.WithFields(logEntry).Debug("Removing value from list")
+
+	if err := r.singleton().LRem(fixedKey, 0, value).Err(); err != nil {
+		log.WithFields(logEntry).WithError(err).Error("LREM command failed")
+		return err
+	}
+
+	return nil
+}
+
+// GetListRange gets range of elements of list identified by keyName
+func (r *RedisCluster) GetListRange(keyName string, from, to int64) ([]string, error) {
+	fixedKey := r.fixKey(keyName)
+	logEntry := logrus.Fields{
+		"keyName":  keyName,
+		"fixedKey": fixedKey,
+		"from":     from,
+		"to":       to,
+	}
+	log.WithFields(logEntry).Debug("Getting list range")
+
+	elements, err := r.singleton().LRange(fixedKey, from, to).Result()
+	if err != nil {
+		log.WithFields(logEntry).WithError(err).Error("LRANGE command failed")
+		return nil, err
+	}
+
+	return elements, nil
+}
+
 func (r *RedisCluster) AppendToSetPipelined(key string, values []string) {
 	if len(values) == 0 {
 		return

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -46,7 +46,6 @@ type Handler interface {
 	GetRollingWindow(key string, per int64, pipeline bool) (int, []interface{})
 	GetSet(string) (map[string]string, error)
 	AddToSet(string, string)
-	AppendToSet(string, string)
 	AppendToSetPipelined(string, []string)
 	GetAndDeleteSet(string) []interface{}
 	RemoveFromSet(string, string)
@@ -55,6 +54,10 @@ type Handler interface {
 	AddToSortedSet(string, string, float64)
 	GetSortedSetRange(string, string, string) ([]string, []float64, error)
 	RemoveSortedSetRange(string, string, string) error
+	GetListRange(string, int64, int64) ([]string, error)
+	RemoveFromList(string, string) error
+	AppendToSet(string, string)
+	Exists(string) (bool, error)
 }
 
 const defaultHashAlgorithm = "murmur64"


### PR DESCRIPTION
The idea behind this PR is solve the slow loading of oauth clients and certificates lists.

This is caused because we scan all the redis keys looking for the certificates / oauth clients.

This PR solves this creating an index list per org (for certificates) and per API (for oauth clients) where the keys are going to be migrated.

The behavior expected is the first time we load the list, it's going to be like it is now but all the keys are going to be migrated for that certs list / oauth client (if they already exists). In the second load, it's going to be faster,  since it get the keys from the list. 