### PR TITLE
Fire event on authentication failure

### DIFF
--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -3,13 +3,14 @@ package gateway
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
 	"github.com/TykTechnologies/tyk/ctx"
 	"github.com/TykTechnologies/tyk/goplugin"
 	"github.com/TykTechnologies/tyk/request"
 	"github.com/sirupsen/logrus"
-	"io/ioutil"
-	"net/http"
-	"time"
 )
 
 // customResponseWriter is a wrapper around standard http.ResponseWriter

--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -151,10 +151,12 @@ func (m *GoPluginMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reque
 		if rw.statusCodeSent >= http.StatusForbidden {
 
 			m.logger.WithError(err).Error("Authentication error in Go-plugin middleware func")
-
-			m.Base().FireEvent(EventAuthFailure, EventMetaDefault {
-				EventMetaDefault: EventMetaDefault{Message: "Auth Failure", OriginatingRequest: EncodeRequestToEvent(r)},
-			})
+			m.Base().FireEvent(EventAuthFailure, EventKeyFailureMeta{
+		                EventMetaDefault: EventMetaDefault{Message: "Auth Failure", OriginatingRequest: EncodeRequestToEvent(r)},
+		                Path: r.URL.Path,
+		                Origin: request.RealIP(r),
+		                Key: "n/a",
+	                })
 			respCode = rw.statusCodeSent
 			err = fmt.Errorf("plugin function sent auth failed response code: %d", rw.statusCodeSent)
 

--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -148,7 +148,15 @@ func (m *GoPluginMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reque
 	// check if response was sent
 	if rw.responseSent {
 		// check if response code was an error one
-		if rw.statusCodeSent >= http.StatusBadRequest {
+		if rw.statusCodeSent >= http.StatusForbidden {
+
+			m.logger.WithError(err).Error("Authentication error in Go-plugin middleware func")
+
+			m.Base().FireEvent(EventAuthFailure, EventMetaDefault {
+				EventMetaDefault: EventMetaDefault{Message: "Auth Failure", OriginatingRequest: EncodeRequestToEvent(r)},
+			})
+
+		} else if rw.statusCodeSent >= http.StatusBadRequest {
 			// base middleware will report this error to analytics if needed
 			respCode = rw.statusCodeSent
 			err = fmt.Errorf("plugin function sent error response code: %d", rw.statusCodeSent)

--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -6,9 +6,8 @@ import (
 	"io/ioutil"
 	"net/http"
 	"time"
-
 	"github.com/sirupsen/logrus"
-
+        "github.com/TykTechnologies/tyk/request"
 	"github.com/TykTechnologies/tyk/ctx"
 	"github.com/TykTechnologies/tyk/goplugin"
 )

--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -3,13 +3,13 @@ package gateway
 import (
 	"bytes"
 	"fmt"
+	"github.com/TykTechnologies/tyk/ctx"
+	"github.com/TykTechnologies/tyk/goplugin"
+	"github.com/TykTechnologies/tyk/request"
+	"github.com/sirupsen/logrus"
 	"io/ioutil"
 	"net/http"
 	"time"
-	"github.com/sirupsen/logrus"
-        "github.com/TykTechnologies/tyk/request"
-	"github.com/TykTechnologies/tyk/ctx"
-	"github.com/TykTechnologies/tyk/goplugin"
 )
 
 // customResponseWriter is a wrapper around standard http.ResponseWriter
@@ -151,11 +151,11 @@ func (m *GoPluginMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reque
 
 			m.logger.WithError(err).Error("Authentication error in Go-plugin middleware func")
 			m.Base().FireEvent(EventAuthFailure, EventKeyFailureMeta{
-		                EventMetaDefault: EventMetaDefault{Message: "Auth Failure", OriginatingRequest: EncodeRequestToEvent(r)},
-		                Path: r.URL.Path,
-		                Origin: request.RealIP(r),
-		                Key: "n/a",
-	                })
+				EventMetaDefault: EventMetaDefault{Message: "Auth Failure", OriginatingRequest: EncodeRequestToEvent(r)},
+				Path:             r.URL.Path,
+				Origin:           request.RealIP(r),
+				Key:              "n/a",
+			})
 			respCode = rw.statusCodeSent
 			err = fmt.Errorf("plugin function sent auth failed response code: %d", rw.statusCodeSent)
 

--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -155,6 +155,8 @@ func (m *GoPluginMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reque
 			m.Base().FireEvent(EventAuthFailure, EventMetaDefault {
 				EventMetaDefault: EventMetaDefault{Message: "Auth Failure", OriginatingRequest: EncodeRequestToEvent(r)},
 			})
+			respCode = rw.statusCodeSent
+			err = fmt.Errorf("plugin function sent auth failed response code: %d", rw.statusCodeSent)
 
 		} else if rw.statusCodeSent >= http.StatusBadRequest {
 			// base middleware will report this error to analytics if needed


### PR DESCRIPTION
When Custom Go plugin returns 403 StatusForbidden, fire an event indicating Auth failure.