### PR TITLE
[TT-1954] Add the errCode (http status code) to error view model

### DIFF
--- a/gateway/handler_error.go
+++ b/gateway/handler_error.go
@@ -82,6 +82,7 @@ func overrideTykErrors() {
 
 // APIError is generic error object returned if there is something wrong with the request
 type APIError struct {
+	Status  int
 	Message template.HTML
 }
 
@@ -140,7 +141,7 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 
 		// Need to return the correct error code!
 		w.WriteHeader(errCode)
-		apiError := APIError{template.HTML(template.JSEscapeString(errMsg))}
+		apiError := APIError{Status: errCode, Message: template.HTML(template.JSEscapeString(errMsg))}
 		tmpl.Execute(w, &apiError)
 	}
 


### PR DESCRIPTION
I would like to render the http status code in the error response body. And i mean; why not? :-)

*Before* submitting a pull request, please make sure the following is done...

1. Fork the repo and create your branch from the **latest** `master`.
2. If you've added code that should be tested, add tests!
3. If you've changed APIs, describe what needs to be updated in the documentation.
4. Ensure the test suite passes (`go test`).
5. Make sure your code lints (`go fmt && go vet`).