### PR TITLE
Check complexity of a request if higher than depth limit in key

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -302,7 +302,7 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 		session.MetaData = make(map[string]interface{})
 	}
 
-	didQuota, didRateLimit, didACL := make(map[string]bool), make(map[string]bool), make(map[string]bool)
+	didQuota, didRateLimit, didACL, didComplexity := make(map[string]bool), make(map[string]bool), make(map[string]bool), make(map[string]bool)
 	policies := session.PolicyIDs()
 
 	for _, polID := range policies {
@@ -323,7 +323,7 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 		}
 
 		if policy.Partitions.PerAPI &&
-			(policy.Partitions.Quota || policy.Partitions.RateLimit || policy.Partitions.Acl) {
+			(policy.Partitions.Quota || policy.Partitions.RateLimit || policy.Partitions.Acl || policy.Partitions.Complexity) {
 			err := fmt.Errorf("cannot apply policy %s which has per_api and any of partitions set", policy.ID)
 			log.Error(err)
 			return err
@@ -332,7 +332,7 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 		if policy.Partitions.PerAPI {
 			for apiID, accessRights := range policy.AccessRights {
 				// new logic when you can specify quota or rate in more than one policy but for different APIs
-				if didQuota[apiID] || didRateLimit[apiID] || didACL[apiID] { // no other partitions allowed
+				if didQuota[apiID] || didRateLimit[apiID] || didACL[apiID] || didComplexity[apiID] { // no other partitions allowed
 					err := fmt.Errorf("cannot apply multiple policies when some have per_api set and some are partitioned")
 					log.Error(err)
 					return err
@@ -348,6 +348,7 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 						Per:                policy.Per,
 						ThrottleInterval:   policy.ThrottleInterval,
 						ThrottleRetryLimit: policy.ThrottleRetryLimit,
+						MaxQueryDepth:      policy.MaxQueryDepth,
 					}
 				}
 
@@ -366,9 +367,10 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 				didACL[apiID] = true
 				didQuota[apiID] = true
 				didRateLimit[apiID] = true
+				didComplexity[apiID] = true
 			}
 		} else {
-			usePartitions := policy.Partitions.Quota || policy.Partitions.RateLimit || policy.Partitions.Acl
+			usePartitions := policy.Partitions.Quota || policy.Partitions.RateLimit || policy.Partitions.Acl || policy.Partitions.Complexity
 
 			for k, v := range policy.AccessRights {
 				ar := &v
@@ -437,6 +439,13 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 					}
 				}
 
+				if !usePartitions || policy.Partitions.Complexity {
+					didComplexity[k] = true
+					if ar.Limit.MaxQueryDepth != -1 && policy.MaxQueryDepth > ar.Limit.MaxQueryDepth {
+						ar.Limit.MaxQueryDepth = policy.MaxQueryDepth
+					}
+				}
+
 				// Respect existing QuotaRenews
 				if r, ok := session.AccessRights[k]; ok && r.Limit != nil {
 					ar.Limit.QuotaRenews = r.Limit.QuotaRenews
@@ -452,6 +461,10 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 					session.Per = policy.Per
 					session.ThrottleInterval = policy.ThrottleInterval
 					session.ThrottleRetryLimit = policy.ThrottleRetryLimit
+				}
+
+				if !usePartitions || policy.Partitions.Complexity {
+					session.MaxQueryDepth = policy.MaxQueryDepth
 				}
 
 				if !usePartitions || policy.Partitions.Quota {
@@ -510,6 +523,10 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 			v.Limit.ThrottleRetryLimit = session.ThrottleRetryLimit
 		}
 
+		if !didComplexity[k] {
+			v.Limit.MaxQueryDepth = session.MaxQueryDepth
+		}
+
 		if !didQuota[k] {
 			v.Limit.QuotaMax = session.QuotaMax
 			v.Limit.QuotaRenewalRate = session.QuotaRenewalRate
@@ -529,7 +546,7 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 	}
 
 	// If we have policies defining rules for one single API, update session root vars (legacy)
-	if len(didQuota) == 1 && len(didRateLimit) == 1 {
+	if len(didQuota) == 1 && len(didRateLimit) == 1 && len(didComplexity) == 1 {
 		for _, v := range rights {
 			if len(didRateLimit) == 1 {
 				session.Rate = v.Limit.Rate
@@ -540,6 +557,10 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 				session.QuotaMax = v.Limit.QuotaMax
 				session.QuotaRenews = v.Limit.QuotaRenews
 				session.QuotaRenewalRate = v.Limit.QuotaRenewalRate
+			}
+
+			if len(didComplexity) == 1 {
+				session.MaxQueryDepth = v.Limit.MaxQueryDepth
 			}
 		}
 	}

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -38,6 +38,8 @@ const coprocessType = "coprocess"
 const oauthType = "oauth"
 const oidcType = "oidc"
 
+const disabledQueryDepth = -1
+
 var (
 	GlobalRate            = ratecounter.NewRateCounter(1 * time.Second)
 	orgSessionExpiryCache singleflight.Group
@@ -441,7 +443,7 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 
 				if !usePartitions || policy.Partitions.Complexity {
 					didComplexity[k] = true
-					if ar.Limit.MaxQueryDepth != -1 && policy.MaxQueryDepth > ar.Limit.MaxQueryDepth {
+					if ar.Limit.MaxQueryDepth != disabledQueryDepth && policy.MaxQueryDepth > ar.Limit.MaxQueryDepth {
 						ar.Limit.MaxQueryDepth = policy.MaxQueryDepth
 					}
 				}

--- a/gateway/mw_graphql.go
+++ b/gateway/mw_graphql.go
@@ -70,7 +70,7 @@ func (m *GraphQLMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 		return errors.New("there was a problem proxying the request"), http.StatusInternalServerError
 	}
 
-	if session.MaxQueryDepth != -1 && complexityRes.Depth > session.MaxQueryDepth {
+	if session.MaxQueryDepth != disabledQueryDepth && complexityRes.Depth > session.MaxQueryDepth {
 		m.Logger().Errorf("Complexity of the request is higher than the allowed limit '%d'", session.MaxQueryDepth)
 		return errors.New("depth limit exceeded"), http.StatusForbidden
 	}

--- a/gateway/mw_graphql.go
+++ b/gateway/mw_graphql.go
@@ -59,5 +59,21 @@ func (m *GraphQLMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 		return errCustomBodyResponse, http.StatusBadRequest
 	}
 
+	session := ctxGetSession(r)
+	if session == nil {
+		return nil, http.StatusOK
+	}
+
+	complexityRes, err := gqlRequest.CalculateComplexity(gql.DefaultComplexityCalculator, m.Schema)
+	if err != nil {
+		m.Logger().Errorf("Error while calculating complexity of GraphQL request: '%s'", err)
+		return errors.New("there was a problem proxying the request"), http.StatusInternalServerError
+	}
+
+	if session.MaxQueryDepth != -1 && complexityRes.Depth > session.MaxQueryDepth {
+		m.Logger().Errorf("Complexity of the request is higher than the allowed limit '%d'", session.MaxQueryDepth)
+		return errors.New("depth limit exceeded"), http.StatusForbidden
+	}
+
 	return nil, http.StatusOK
 }

--- a/gateway/mw_graphql_test.go
+++ b/gateway/mw_graphql_test.go
@@ -4,6 +4,9 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/TykTechnologies/tyk/headers"
+	"github.com/TykTechnologies/tyk/user"
+
 	gql "github.com/jensneuse/graphql-go-tools/pkg/graphql"
 
 	"github.com/TykTechnologies/tyk/test"
@@ -26,7 +29,7 @@ func TestGraphQL(t *testing.T) {
 		_, _ = g.Run(t, test.TestCase{BodyMatch: "there was a problem proxying the request", Code: http.StatusInternalServerError})
 	})
 
-	spec.GraphQL.GraphQLAPI.Schema = "schema { query: Query } type Query { hello: String }"
+	spec.GraphQL.GraphQLAPI.Schema = "schema { query: Query } type Query { hello: word } type word { numOfLetters: Int }"
 	LoadAPI(spec)
 
 	t.Run("Empty request shouldn't be unmarshalled", func(t *testing.T) {
@@ -45,13 +48,68 @@ func TestGraphQL(t *testing.T) {
 		_, _ = g.Run(t, test.TestCase{Data: request, Code: http.StatusBadRequest})
 	})
 
+	spec.UseKeylessAccess = false
+	LoadAPI(spec)
+
+	pID := CreatePolicy(func(p *user.Policy) {
+		p.MaxQueryDepth = 1
+		p.AccessRights = map[string]user.AccessDefinition{
+			spec.APIID: {
+				APIID:   spec.APIID,
+				APIName: spec.Name,
+			},
+		}
+	})
+
+	policyAppliedSession, policyAppliedKey := g.CreateSession(func(s *user.SessionState) {
+		s.ApplyPolicies = []string{pID}
+	})
+
+	directSession, directKey := g.CreateSession(func(s *user.SessionState) {
+		s.MaxQueryDepth = 1
+		s.AccessRights = map[string]user.AccessDefinition{
+			spec.APIID: {
+				APIID:   spec.APIID,
+				APIName: spec.Name,
+			},
+		}
+	})
+
+	authHeaderWithDirectKey := map[string]string{
+		headers.Authorization: directKey,
+	}
+
+	authHeaderWithPolicyAppliedKey := map[string]string{
+		headers.Authorization: policyAppliedKey,
+	}
+
+	t.Run("Depth limit exceeded", func(t *testing.T) {
+		request := gql.Request{
+			OperationName: "Hello",
+			Variables:     nil,
+			Query:         "query Hello { hello { numOfLetters } }",
+		}
+
+		if directSession.MaxQueryDepth != 1 || policyAppliedSession.MaxQueryDepth != 1 {
+			t.Fatal("MaxQueryDepth couldn't be applied to key")
+		}
+
+		_, _ = g.Run(t, []test.TestCase{
+			{Headers: authHeaderWithDirectKey, Data: request, BodyMatch: "depth limit exceeded", Code: http.StatusForbidden},
+			{Headers: authHeaderWithPolicyAppliedKey, Data: request, BodyMatch: "depth limit exceeded", Code: http.StatusForbidden},
+		}...)
+	})
+
 	t.Run("Valid query should successfully work", func(t *testing.T) {
 		request := gql.Request{
 			OperationName: "Hello",
 			Variables:     nil,
-			Query:         "query Hello { hello }",
+			Query:         "query Hello { hello { numOfLetters } }",
 		}
 
-		_, _ = g.Run(t, test.TestCase{Data: request, BodyMatch: "hello", Code: http.StatusOK})
+		directSession.MaxQueryDepth = 2
+		_ = GlobalSessionManager.UpdateSession(directKey, directSession, 0, false)
+
+		_, _ = g.Run(t, test.TestCase{Headers: authHeaderWithDirectKey, Data: request, BodyMatch: "hello", Code: http.StatusOK})
 	})
 }

--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -715,6 +715,7 @@ func generateSessionFromPolicy(policyID, orgID string, enforceOrg bool) (user.Se
 	session.Per = policy.Per
 	session.ThrottleInterval = policy.ThrottleInterval
 	session.ThrottleRetryLimit = policy.ThrottleRetryLimit
+	session.MaxQueryDepth = policy.MaxQueryDepth
 	session.QuotaMax = policy.QuotaMax
 	session.QuotaRenewalRate = policy.QuotaRenewalRate
 	session.AccessRights = make(map[string]user.AccessDefinition)

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -122,6 +122,14 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 		"acl3": {
 			AccessRights: map[string]user.AccessDefinition{"c": {}},
 		},
+		"complexity1": {
+			Partitions:    user.PolicyPartitions{Complexity: true},
+			MaxQueryDepth: 2,
+		},
+		"complexity2": {
+			Partitions:    user.PolicyPartitions{Complexity: true},
+			MaxQueryDepth: 3,
+		},
 		"per_api_and_partitions": {
 			ID: "per_api_and_partitions",
 			Partitions: user.PolicyPartitions{
@@ -370,6 +378,22 @@ func testPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesData) {
 			"RateParts", []string{"rate1", "rate2"},
 			"", func(t *testing.T, s *user.SessionState) {
 				if s.Rate != 4 {
+					t.Fatalf("Should pick bigger value")
+				}
+			}, nil,
+		},
+		{
+			"ComplexityPart", []string{"complexity1"},
+			"", func(t *testing.T, s *user.SessionState) {
+				if s.MaxQueryDepth != 2 {
+					t.Fatalf("want MaxQueryDepth to be 2")
+				}
+			}, nil,
+		},
+		{
+			"ComplexityParts", []string{"complexity1", "complexity2"},
+			"", func(t *testing.T, s *user.SessionState) {
+				if s.MaxQueryDepth != 3 {
 					t.Fatalf("Should pick bigger value")
 				}
 			}, nil,

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -789,7 +789,9 @@ func (s *Test) CreateSession(sGen ...func(s *user.SessionState)) (*user.SessionS
 		return nil, ""
 	}
 
-	return session, keySuccess.Key
+	createdSession, _ := GlobalSessionManager.SessionDetail(session.OrgID, keySuccess.Key, false)
+
+	return &createdSession, keySuccess.Key
 }
 
 func StartTest(config ...TestConfig) *Test {

--- a/user/policy.go
+++ b/user/policy.go
@@ -16,6 +16,7 @@ type Policy struct {
 	QuotaRenewalRate              int64                            `bson:"quota_renewal_rate" json:"quota_renewal_rate"`
 	ThrottleInterval              float64                          `bson:"throttle_interval" json:"throttle_interval"`
 	ThrottleRetryLimit            int                              `bson:"throttle_retry_limit" json:"throttle_retry_limit"`
+	MaxQueryDepth                 int                              `bson:"max_query_depth" json:"max_query_depth"`
 	AccessRights                  map[string]AccessDefinition      `bson:"access_rights" json:"access_rights"`
 	HMACEnabled                   bool                             `bson:"hmac_enabled" json:"hmac_enabled"`
 	EnableHTTPSignatureValidation bool                             `json:"enable_http_signature_validation" msg:"enable_http_signature_validation"`
@@ -30,8 +31,9 @@ type Policy struct {
 }
 
 type PolicyPartitions struct {
-	Quota     bool `bson:"quota" json:"quota"`
-	RateLimit bool `bson:"rate_limit" json:"rate_limit"`
-	Acl       bool `bson:"acl" json:"acl"`
-	PerAPI    bool `bson:"per_api" json:"per_api"`
+	Quota      bool `bson:"quota" json:"quota"`
+	RateLimit  bool `bson:"rate_limit" json:"rate_limit"`
+	Complexity bool `bson:"complexity" json:"complexity"`
+	Acl        bool `bson:"acl" json:"acl"`
+	PerAPI     bool `bson:"per_api" json:"per_api"`
 }

--- a/user/session.go
+++ b/user/session.go
@@ -30,6 +30,7 @@ type APILimit struct {
 	Per                float64 `json:"per" msg:"per"`
 	ThrottleInterval   float64 `json:"throttle_interval" msg:"throttle_interval"`
 	ThrottleRetryLimit int     `json:"throttle_retry_limit" msg:"throttle_retry_limit"`
+	MaxQueryDepth      int     `json:"max_query_depth" msg:"max_query_depth"`
 	QuotaMax           int64   `json:"quota_max" msg:"quota_max"`
 	QuotaRenews        int64   `json:"quota_renews" msg:"quota_renews"`
 	QuotaRemaining     int64   `json:"quota_remaining" msg:"quota_remaining"`
@@ -59,6 +60,7 @@ type SessionState struct {
 	Per                float64                     `json:"per" msg:"per"`
 	ThrottleInterval   float64                     `json:"throttle_interval" msg:"throttle_interval"`
 	ThrottleRetryLimit int                         `json:"throttle_retry_limit" msg:"throttle_retry_limit"`
+	MaxQueryDepth      int                         `json:"max_query_depth" msg:"max_query_depth"`
 	DateCreated        time.Time                   `json:"date_created" msg:"date_created"`
 	Expires            int64                       `json:"expires" msg:"expires"`
 	QuotaMax           int64                       `json:"quota_max" msg:"quota_max"`


### PR DESCRIPTION
This PR adds a new partition `complexity` and a new session and policy field `max_query_depth`.

Fixes https://github.com/TykTechnologies/product/issues/300