### PR TITLE
declared idForScope

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -338,6 +338,7 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 					return err
 				}
 
+				idForScope := apiID
 				// check if we already have limit on API level specified when policy was created
 				if accessRights.Limit == nil || *accessRights.Limit == (user.APILimit{}) {
 					// limit was not specified on API level so we will populate it from policy
@@ -357,8 +358,8 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 					accessRights.Limit.QuotaRenews = r.Limit.QuotaRenews
 				}
 
-				accessRights.AllowanceScope = apiID
-				accessRights.Limit.SetBy = apiID
+				accessRights.AllowanceScope = idForScope
+				accessRights.Limit.SetBy = idForScope
 
 				// overwrite session access right for this API
 				rights[apiID] = accessRights


### PR DESCRIPTION
Fix https://github.com/TykTechnologies/tyk/issues/3002

For some reason, we were setting a value to `idForScope` but the variables wasnt defined, and also some logic was missing to use later the variable (set it as `AllowanceScope` and `Limit.SetBy`)