### PR TITLE
on bind to slugs=true then add a path separator on oauth paths

### DIFF
--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -442,7 +442,7 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 		mwAppendEnabled(&simpleArray, &KeyExpired{baseMid})
 		mwAppendEnabled(&simpleArray, &AccessRightsCheck{baseMid})
 
-		rateLimitPath := spec.Proxy.ListenPath + "/tyk/rate-limits/"
+		rateLimitPath := spec.Proxy.ListenPath + "tyk/rate-limits/"
 
 		logger.Debug("Rate limit endpoint is: ", rateLimitPath)
 

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -442,7 +442,7 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 		mwAppendEnabled(&simpleArray, &KeyExpired{baseMid})
 		mwAppendEnabled(&simpleArray, &AccessRightsCheck{baseMid})
 
-		rateLimitPath := spec.Proxy.ListenPath + "tyk/rate-limits/"
+		rateLimitPath := spec.Proxy.ListenPath + "/tyk/rate-limits/"
 
 		logger.Debug("Rate limit endpoint is: ", rateLimitPath)
 

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -493,7 +493,7 @@ func generateOAuthPrefix(apiID string) string {
 func addOAuthHandlers(spec *APISpec, muxer *mux.Router) *OAuthManager {
 	var pathSeparator string
 	if !strings.HasSuffix(spec.Proxy.ListenPath, "/") {
-		pathSeparator = ""
+		pathSeparator = "/"
 	}
 
 	apiAuthorizePath := spec.Proxy.ListenPath + pathSeparator + "tyk/oauth/authorize-client{_:/?}"

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -493,7 +493,7 @@ func generateOAuthPrefix(apiID string) string {
 func addOAuthHandlers(spec *APISpec, muxer *mux.Router) *OAuthManager {
 	var pathSeparator string
 	if !strings.HasSuffix(spec.Proxy.ListenPath, "/") {
-		pathSeparator = "/"
+		pathSeparator = ""
 	}
 
 	apiAuthorizePath := spec.Proxy.ListenPath + pathSeparator + "tyk/oauth/authorize-client{_:/?}"

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -491,11 +491,16 @@ func generateOAuthPrefix(apiID string) string {
 
 // Create API-specific OAuth handlers and respective auth servers
 func addOAuthHandlers(spec *APISpec, muxer *mux.Router) *OAuthManager {
-	apiAuthorizePath := spec.Proxy.ListenPath + "tyk/oauth/authorize-client{_:/?}"
-	clientAuthPath := spec.Proxy.ListenPath + "oauth/authorize{_:/?}"
-	clientAccessPath := spec.Proxy.ListenPath + "oauth/token{_:/?}"
-	revokeToken := spec.Proxy.ListenPath + "oauth/revoke"
-	revokeAllTokens := spec.Proxy.ListenPath + "oauth/revoke_all"
+	var pathSeparator string
+	if config.Global().SlaveOptions.BindToSlugsInsteadOfListenPaths {
+		pathSeparator = "/"
+	}
+
+	apiAuthorizePath := spec.Proxy.ListenPath + pathSeparator + "tyk/oauth/authorize-client{_:/?}"
+	clientAuthPath := spec.Proxy.ListenPath + pathSeparator + "oauth/authorize{_:/?}"
+	clientAccessPath := spec.Proxy.ListenPath + pathSeparator + "oauth/token{_:/?}"
+	revokeToken := spec.Proxy.ListenPath + pathSeparator + "oauth/revoke"
+	revokeAllTokens := spec.Proxy.ListenPath + pathSeparator + "oauth/revoke_all"
 
 	serverConfig := osin.NewServerConfig()
 

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -492,7 +492,7 @@ func generateOAuthPrefix(apiID string) string {
 // Create API-specific OAuth handlers and respective auth servers
 func addOAuthHandlers(spec *APISpec, muxer *mux.Router) *OAuthManager {
 	var pathSeparator string
-	if config.Global().SlaveOptions.BindToSlugsInsteadOfListenPaths {
+	if !strings.HasSuffix(spec.Proxy.ListenPath, "/") {
 		pathSeparator = "/"
 	}
 


### PR DESCRIPTION
Behaviour of `/{yourapi}/oauth/token` change depending of the value of `slave_options.bind_to_slugs`

## Description
On bind to slugs we are not setting a slash at the end of the route, then, in `addOAuthHandlers` we concatenate a route to that path without adding a separator between slug and `oauthPath`, so, was added that slash depending of the value of `slave_options.bind_to_slugs` otherwise we would need to hit the route `/{yourapi}oauth/token` to have the same result (current behaviour). Other Oauth routes were affected by this same behaviour, so was added the separator as well. Now, we need to be able to revoke tokens issued locally, currently we revoke tokens issued from dashboard/master GW, this change will be done in a different PR

## Related Issue
https://github.com/TykTechnologies/tyk-analytics/issues/1842

## Motivation and Context
Solves https://github.com/TykTechnologies/tyk-analytics/issues/1842 so in slave GW we are allowed to issue oauth tokens no matter what is the value of `bind_to_slugs`

## How This Has Been Tested
- Created an API (from dashboard)
- Created an Oauth Client (from dashboard)
- Run Slave gateway
- Request a token with `slave_options.bind_to_slugs=true`
- Request a token with `slave_options.bind_to_slugs=false`

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [ ] `go vet`
