### PR TITLE
change way how we detect that we are connected to rpc for healtCheck

### DIFF
--- a/gateway/health_check.go
+++ b/gateway/health_check.go
@@ -175,7 +175,7 @@ func gatherHealthChecks() {
 				Time:          time.Now().Format(time.RFC3339),
 			}
 
-			if !rpc.GroupLogin() {
+			if !rpc.Login() {
 				checkItem.Output = "Could not connect to RPC"
 				checkItem.Status = Fail
 			}

--- a/gateway/health_check.go
+++ b/gateway/health_check.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"github.com/TykTechnologies/tyk/rpc"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -173,9 +174,7 @@ func gatherHealthChecks() {
 				Time:          time.Now().Format(time.RFC3339),
 			}
 
-			rpcStore := RPCStorageHandler{KeyPrefix: "livenesscheck-"}
-
-			if !rpcStore.Connect() {
+			if !rpc.GroupLogin() {
 				checkItem.Output = "Could not connect to RPC"
 				checkItem.Status = Fail
 			}

--- a/gateway/health_check.go
+++ b/gateway/health_check.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/TykTechnologies/tyk/rpc"
 	"net/http"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/TykTechnologies/tyk/rpc"
 
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/storage"

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -721,7 +721,7 @@ func (r *RPCStorageHandler) StartRPCKeepaliveWatcher() {
 		if err := r.SetKey("0000", "0000", 10); err != nil {
 			log.WithError(err).WithFields(logrus.Fields{
 				"prefix": "RPC Conn Mgr",
-			}).Info("Can't connect to RPC layer")
+			}).Warning("Can't connect to RPC layer")
 
 			if r.IsAccessError(err) {
 				if rpc.Login() {


### PR DESCRIPTION

## Description
Changed condition on how we check that we are connected to RPC, before we used the `Connect` method of RPC but it contains certain conditions that doesn't match with the expected result, then, as we constantly check if we can login to the group, then its a good criteria to use this value to check the status of rpc.

## Related Issue
https://github.com/TykTechnologies/tyk/issues/3008

## Motivation and Context
Give solution to https://github.com/TykTechnologies/tyk/issues/3008

## How This Has Been Tested
- Run MDCB setup
- Stop Sink
- Check health status for the slave GW pointing to http://tyk-gateway:8182/hello
- Check logs and ensure that we are printing a Warning log giving information that we are not connected to RPC

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [ ] `go vet`
