### PR TITLE
Fix ReturnOverrides test

### DIFF
--- a/gateway/coprocess_bundle_test.go
+++ b/gateway/coprocess_bundle_test.go
@@ -148,7 +148,7 @@ from tyk.decorators import *
 from gateway import TykGateway as tyk
 
 @Hook
-def MyRequestHook(request, response, session, metadata, spec):
+def MyRequestHook(request, session, spec):
 	request.object.return_overrides.headers['X-Foo'] = 'Bar'
 	request.object.return_overrides.response_code = int(request.object.params["status"])
 


### PR DESCRIPTION
I've inspected #2840 which also includes some `gofmt` and `goimports` fixes however in 2.10 branch this is ok.
Have included only the `coproces_bundle_test.go` change.