### PR TITLE
added response body on revoke tokens. Implemented better error messages

### DIFF
--- a/gateway/api.go
+++ b/gateway/api.go
@@ -2116,7 +2116,7 @@ func RevokeTokenHandler(w http.ResponseWriter, r *http.Request) {
 			RevokeToken(storage, token, tokenTypeHint)
 		}
 	}
-	doJSONWrite(w, http.StatusOK, "token revoked successfully")
+	doJSONWrite(w, http.StatusOK, apiOk("token revoked successfully"))
 }
 
 func GetStorageForApi(apiID string) (ExtendedOsinStorageInterface, int, error) {
@@ -2182,7 +2182,7 @@ func RevokeAllTokensHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	doJSONWrite(w, http.StatusOK, "tokens revoked successfully")
+	doJSONWrite(w, http.StatusOK, apiOk("tokens revoked successfully"))
 }
 
 // TODO: Don't modify http.Request values in-place. We must right now

--- a/gateway/oauth_manager.go
+++ b/gateway/oauth_manager.go
@@ -246,7 +246,7 @@ func (o *OAuthHandlers) HandleRevokeToken(w http.ResponseWriter, r *http.Request
 	}
 
 	RevokeToken(o.Manager.OsinServer.Storage, token, tokenTypeHint)
-	doJSONWrite(w, http.StatusOK, "token revoked successfully")
+	doJSONWrite(w, http.StatusOK, apiOk("token revoked successfully"))
 }
 
 func RevokeToken(storage ExtendedOsinStorageInterface, token, tokenTypeHint string) {
@@ -287,7 +287,7 @@ func (o *OAuthHandlers) HandleRevokeAllTokens(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	doJSONWrite(w, http.StatusOK, "tokens revoked successfully")
+	doJSONWrite(w, http.StatusOK, apiOk("tokens revoked successfully"))
 }
 
 func RevokeAllTokens(storage ExtendedOsinStorageInterface, clientId, clientSecret string) (int, error) {

--- a/gateway/oauth_manager.go
+++ b/gateway/oauth_manager.go
@@ -233,15 +233,20 @@ const (
 func (o *OAuthHandlers) HandleRevokeToken(w http.ResponseWriter, r *http.Request) {
 	err := r.ParseForm()
 	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
+		doJSONWrite(w, http.StatusBadRequest, apiError("error parsing form. Form malformed"))
 		return
 	}
 
 	token := r.PostFormValue("token")
 	tokenTypeHint := r.PostFormValue("token_type_hint")
 
+	if token == "" {
+		doJSONWrite(w, http.StatusBadRequest, apiError(oauthTokenEmpty))
+		return
+	}
+
 	RevokeToken(o.Manager.OsinServer.Storage, token, tokenTypeHint)
-	w.WriteHeader(200)
+	doJSONWrite(w, http.StatusOK, "token revoked successfully")
 }
 
 func RevokeToken(storage ExtendedOsinStorageInterface, token, tokenTypeHint string) {
@@ -259,36 +264,46 @@ func RevokeToken(storage ExtendedOsinStorageInterface, token, tokenTypeHint stri
 func (o *OAuthHandlers) HandleRevokeAllTokens(w http.ResponseWriter, r *http.Request) {
 	err := r.ParseForm()
 	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
+		doJSONWrite(w, http.StatusBadRequest, apiError("error parsing form. Form malformed"))
 		return
 	}
 
 	clientId := r.PostFormValue("client_id")
 	secret := r.PostFormValue("client_secret")
 
-	if clientId == "" || secret == "" {
-		w.WriteHeader(http.StatusBadRequest)
+	if clientId == "" {
+		doJSONWrite(w, http.StatusUnauthorized, apiError(oauthClientIdEmpty))
 		return
 	}
 
-	status := RevokeAllTokens(o.Manager.OsinServer.Storage, clientId, secret)
-	w.WriteHeader(status)
+	if secret == "" {
+		doJSONWrite(w, http.StatusUnauthorized, apiError(oauthClientSecretEmpty))
+		return
+	}
+
+	status, err := RevokeAllTokens(o.Manager.OsinServer.Storage, clientId, secret)
+	if err != nil {
+		doJSONWrite(w, status, apiError(err.Error()))
+		return
+	}
+
+	doJSONWrite(w, http.StatusOK, "tokens revoked successfully")
 }
 
-func RevokeAllTokens(storage ExtendedOsinStorageInterface, clientId, clientSecret string) int {
+func RevokeAllTokens(storage ExtendedOsinStorageInterface, clientId, clientSecret string) (int, error) {
 	client, err := storage.GetClient(clientId)
 	log.Debug("Revoke all tokens")
 	if err != nil {
-		return http.StatusNotFound
+		return http.StatusNotFound, errors.New("error getting oauth client")
 	}
 
 	if client.GetSecret() != clientSecret {
-		return http.StatusForbidden
+		return http.StatusUnauthorized, errors.New(oauthClientSecretWrong)
 	}
 
 	clientTokens, err := storage.GetClientTokens(clientId)
 	if err != nil {
-		return http.StatusBadRequest
+		return http.StatusBadRequest, errors.New("cannot retrieve client tokens")
 	}
 
 	for _, token := range clientTokens {
@@ -299,7 +314,7 @@ func RevokeAllTokens(storage ExtendedOsinStorageInterface, clientId, clientSecre
 		}
 	}
 
-	return http.StatusOK
+	return http.StatusOK, nil
 }
 
 // OAuthManager handles and wraps osin OAuth2 functions to handle authorise and access requests


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
added response body on revoke tokens endpoints. Validated fields that cannot be empty: client_secret, client_id, token. Be aware that api endpoints are developed according to RFC 7009, and note: _invalid tokens do not cause an error response since the client cannot handle such an error in a reasonable way.  Moreover, the purpose of the revocation request, invalidating the particular token, is already achieved._

## Related Issue
API response no descriptive

## Motivation and Context
Response on API endpoints is not descriptive and users doesn't know what is wrong

## How This Has Been Tested
- Hit each endpoint by separated

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
