### PR TITLE
use redis local store to save tokens in nodes {do not merge}

### DIFF
--- a/gateway/api.go
+++ b/gateway/api.go
@@ -2187,12 +2187,19 @@ func RevokeAllTokensHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	tokens := []string{}
 	for _, apiId := range apis {
 		storage, _, err := GetStorageForApi(apiId)
 		if err == nil {
-			RevokeAllTokens(storage, clientId, clientSecret)
+			_, tokens, _ = RevokeAllTokens(storage, clientId, clientSecret)
 		}
 	}
+
+	n := Notification{
+		Command: KeySpaceUpdateNotification,
+		Payload: strings.Join(tokens, ","),
+	}
+	MainNotifier.Notify(n)
 
 	doJSONWrite(w, http.StatusOK, apiOk("tokens revoked successfully"))
 }

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -2191,7 +2191,8 @@ func RevokeAllTokensHandler(w http.ResponseWriter, r *http.Request) {
 	for _, apiId := range apis {
 		storage, _, err := GetStorageForApi(apiId)
 		if err == nil {
-			_, tokens, _ = RevokeAllTokens(storage, clientId, clientSecret)
+			_, tokensRevoked, _ := RevokeAllTokens(storage, clientId, clientSecret)
+			tokens = append(tokens, tokensRevoked...)
 		}
 	}
 

--- a/gateway/auth_manager.go
+++ b/gateway/auth_manager.go
@@ -295,6 +295,8 @@ func (b *DefaultSessionManager) SessionDetail(orgID string, keyName string, hash
 					keyName,
 				},
 			)
+
+			log.Debug("err;", err.Error(), "  keyname:", keyName)
 			// pick the 1st non empty from the returned list
 			for _, val := range jsonKeyValList {
 				if val != "" {

--- a/gateway/auth_manager.go
+++ b/gateway/auth_manager.go
@@ -296,7 +296,6 @@ func (b *DefaultSessionManager) SessionDetail(orgID string, keyName string, hash
 				},
 			)
 
-			log.Debug("err;", err.Error(), "  keyname:", keyName)
 			// pick the 1st non empty from the returned list
 			for _, val := range jsonKeyValList {
 				if val != "" {

--- a/gateway/oauth_manager.go
+++ b/gateway/oauth_manager.go
@@ -307,8 +307,7 @@ func RevokeAllTokens(storage ExtendedOsinStorageInterface, clientId, clientSecre
 		return http.StatusBadRequest, resp, errors.New("cannot retrieve client tokens")
 	}
 
-	log.Debug("Tokens found:", len(clientTokens))
-
+	log.Debug("Tokens found to be revoked:", len(clientTokens))
 	for _, token := range clientTokens {
 		access, err := storage.LoadAccess(token.Token)
 		if err == nil {
@@ -909,7 +908,6 @@ func (r *RedisOsinStorageInterface) LoadAuthorize(code string) (*osin.AuthorizeD
 func (r *RedisOsinStorageInterface) RemoveAuthorize(code string) error {
 	key := prefixAuth + code
 	r.store.DeleteKey(key)
-
 	return nil
 }
 

--- a/gateway/oauth_manager.go
+++ b/gateway/oauth_manager.go
@@ -281,11 +281,17 @@ func (o *OAuthHandlers) HandleRevokeAllTokens(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	status, _, err := RevokeAllTokens(o.Manager.OsinServer.Storage, clientId, secret)
+	status, tokens, err := RevokeAllTokens(o.Manager.OsinServer.Storage, clientId, secret)
 	if err != nil {
 		doJSONWrite(w, status, apiError(err.Error()))
 		return
 	}
+
+	n := Notification{
+		Command: KeySpaceUpdateNotification,
+		Payload: strings.Join(tokens, ","),
+	}
+	MainNotifier.Notify(n)
 
 	doJSONWrite(w, http.StatusOK, apiOk("tokens revoked successfully"))
 }

--- a/gateway/oauth_manager.go
+++ b/gateway/oauth_manager.go
@@ -281,7 +281,7 @@ func (o *OAuthHandlers) HandleRevokeAllTokens(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	status, err := RevokeAllTokens(o.Manager.OsinServer.Storage, clientId, secret)
+	status, _, err := RevokeAllTokens(o.Manager.OsinServer.Storage, clientId, secret)
 	if err != nil {
 		doJSONWrite(w, status, apiError(err.Error()))
 		return
@@ -290,31 +290,37 @@ func (o *OAuthHandlers) HandleRevokeAllTokens(w http.ResponseWriter, r *http.Req
 	doJSONWrite(w, http.StatusOK, apiOk("tokens revoked successfully"))
 }
 
-func RevokeAllTokens(storage ExtendedOsinStorageInterface, clientId, clientSecret string) (int, error) {
+func RevokeAllTokens(storage ExtendedOsinStorageInterface, clientId, clientSecret string) (int, []string, error) {
+	resp := []string{}
 	client, err := storage.GetClient(clientId)
 	log.Debug("Revoke all tokens")
 	if err != nil {
-		return http.StatusNotFound, errors.New("error getting oauth client")
+		return http.StatusNotFound, resp, errors.New("error getting oauth client")
 	}
 
 	if client.GetSecret() != clientSecret {
-		return http.StatusUnauthorized, errors.New(oauthClientSecretWrong)
+		return http.StatusUnauthorized, resp, errors.New(oauthClientSecretWrong)
 	}
 
 	clientTokens, err := storage.GetClientTokens(clientId)
 	if err != nil {
-		return http.StatusBadRequest, errors.New("cannot retrieve client tokens")
+		return http.StatusBadRequest, resp, errors.New("cannot retrieve client tokens")
 	}
+
+	log.Debug("Tokens found:", len(clientTokens))
 
 	for _, token := range clientTokens {
 		access, err := storage.LoadAccess(token.Token)
 		if err == nil {
+			resp = append(resp, access.AccessToken)
 			storage.RemoveAccess(access.AccessToken)
 			storage.RemoveRefresh(access.RefreshToken)
+		} else {
+			log.Debug("error loading access:", err.Error())
 		}
 	}
 
-	return http.StatusOK, nil
+	return http.StatusOK, resp, nil
 }
 
 // OAuthManager handles and wraps osin OAuth2 functions to handle authorise and access requests
@@ -567,6 +573,7 @@ func TykOsinNewServer(config *osin.ServerConfig, storage ExtendedOsinStorageInte
 type RedisOsinStorageInterface struct {
 	store          storage.Handler
 	sessionManager SessionHandler
+	redisStore     storage.Handler
 	orgID          string
 }
 
@@ -759,7 +766,7 @@ func (r *RedisOsinStorageInterface) GetClientTokens(id string) ([]OAuthClientTok
 
 	log.Info("Getting client tokens sorted list:", key)
 
-	tokens, scores, err := r.store.GetSortedSetRange(key, startScore, "+inf")
+	tokens, scores, err := r.redisStore.GetSortedSetRange(key, startScore, "+inf")
 	if err != nil {
 		return nil, err
 	}
@@ -767,7 +774,7 @@ func (r *RedisOsinStorageInterface) GetClientTokens(id string) ([]OAuthClientTok
 	// clean up expired tokens in sorted set (remove all tokens with score up to current timestamp minus retention)
 	if config.Global().OauthTokenExpiredRetainPeriod > 0 {
 		cleanupStartScore := strconv.FormatInt(nowTs-int64(config.Global().OauthTokenExpiredRetainPeriod), 10)
-		go r.store.RemoveSortedSetRange(key, "-inf", cleanupStartScore)
+		go r.redisStore.RemoveSortedSetRange(key, "-inf", cleanupStartScore)
 	}
 
 	if len(tokens) == 0 {
@@ -841,9 +848,9 @@ func (r *RedisOsinStorageInterface) DeleteClient(id string, orgID string, ignore
 
 	// Get the raw vals:
 	clientJSON, err := r.store.GetKey(key)
+	keyForSet := prefixClientset + prefixClient // Org ID
 	if err == nil {
 		log.Debug("Removing from set")
-		keyForSet := prefixClientset + prefixClient // Org ID
 		r.store.RemoveFromSet(keyForSet, clientJSON)
 	}
 
@@ -855,6 +862,11 @@ func (r *RedisOsinStorageInterface) DeleteClient(id string, orgID string, ignore
 
 	// delete list of tokens for this client
 	r.store.DeleteKey(prefixClientTokens + id)
+	if config.Global().SlaveOptions.UseRPC {
+		r.redisStore.RemoveFromList(indexKey, key)
+		r.redisStore.DeleteKey(prefixClientTokens + id)
+		r.redisStore.RemoveFromSet(keyForSet, clientJSON)
+	}
 
 	return nil
 }
@@ -897,6 +909,7 @@ func (r *RedisOsinStorageInterface) LoadAuthorize(code string) (*osin.AuthorizeD
 func (r *RedisOsinStorageInterface) RemoveAuthorize(code string) error {
 	key := prefixAuth + code
 	r.store.DeleteKey(key)
+
 	return nil
 }
 
@@ -919,7 +932,7 @@ func (r *RedisOsinStorageInterface) SaveAccess(accessData *osin.AccessData) erro
 	// add code to list of tokens for this client
 	sortedListKey := prefixClientTokens + accessData.Client.GetId()
 	log.Debug("Adding ACCESS key to sorted list: ", sortedListKey)
-	r.store.AddToSortedSet(
+	r.redisStore.AddToSortedSet(
 		sortedListKey,
 		storage.HashKey(accessData.AccessToken),
 		float64(accessData.CreatedAt.Unix()+int64(accessData.ExpiresIn)), // set score as token expire timestamp
@@ -1028,7 +1041,7 @@ func (r *RedisOsinStorageInterface) RemoveAccess(token string) error {
 		//remove from set oauth.client-tokens
 		log.Info("removing token from oauth client tokens list")
 		limit := strconv.FormatFloat(float64(access.ExpireAt().Unix()), 'f', 0, 64)
-		r.store.RemoveSortedSetRange(key, limit, limit)
+		r.redisStore.RemoveSortedSetRange(key, limit, limit)
 	} else {
 		log.Warning("Cannot load access token:", token)
 	}

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -807,6 +807,7 @@ func (r *RPCStorageHandler) ProcessKeySpaceChanges(keys []string) {
 	oauthTokenKeys := map[string]bool{}
 
 	for _, key := range keys {
+		log.Debug("recevived:", key)
 		splitKeys := strings.Split(key, ":")
 		if len(splitKeys) > 1 && splitKeys[1] == "resetQuota" {
 			keysToReset[splitKeys[0]] = true
@@ -830,7 +831,8 @@ func (r *RPCStorageHandler) ProcessKeySpaceChanges(keys []string) {
 		if err != nil {
 			continue
 		}
-		RevokeAllTokens(storage, clientId, clientSecret)
+		_, tokens, _ := RevokeAllTokens(storage, clientId, clientSecret)
+		keys = append(keys, tokens...)
 	}
 
 	//single and specific tokens

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -807,7 +807,6 @@ func (r *RPCStorageHandler) ProcessKeySpaceChanges(keys []string) {
 	oauthTokenKeys := map[string]bool{}
 
 	for _, key := range keys {
-		log.Debug("recevived:", key)
 		splitKeys := strings.Split(key, ":")
 		if len(splitKeys) > 1 && splitKeys[1] == "resetQuota" {
 			keysToReset[splitKeys[0]] = true

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -517,7 +517,7 @@ func addOAuthHandlers(spec *APISpec, muxer *mux.Router) *OAuthManager {
 	prefix := generateOAuthPrefix(spec.APIID)
 	storageManager := getGlobalStorageHandler(prefix, false)
 	storageManager.Connect()
-	osinStorage := &RedisOsinStorageInterface{storageManager, GlobalSessionManager, spec.OrgID}
+	osinStorage := &RedisOsinStorageInterface{storageManager, GlobalSessionManager, &storage.RedisCluster{KeyPrefix: prefix, HashKeys: false}, spec.OrgID}
 
 	osinServer := TykOsinNewServer(serverConfig, osinStorage)
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Replicate tokens between MDCB cluster, so revoke tokens works in MDCB properly. Basically they were not communicating about actions performed: revoke access token, revoke refresh token, revoke all oauth client tokens

## Related Issue
https://github.com/TykTechnologies/tyk/issues/3025

## Motivation and Context
Provide stable feature for revoke tokens

## How This Has Been Tested
- on MDCB setup with 2 slaves nodes
- client credential flow and auth token flow
- Issuing tokens in slaves and master GW
- revoke single tokens, revoke all tokens, revoke all tokens from dashboard

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [x] `go vet`
