### PR TITLE
If rate is -1 or 0 skip rate limiting

### DIFF
--- a/gateway/session_manager.go
+++ b/gateway/session_manager.go
@@ -217,7 +217,8 @@ func (l *SessionLimiter) ForwardMessage(r *http.Request, currentSession *user.Se
 		}
 	}
 
-	if enableRL {
+	// If rate is -1 or 0, it means unlimited and no need for rate limiting.
+	if enableRL && apiLimit.Rate > 0 {
 		rateScope := ""
 		if allowanceScope != "" {
 			rateScope = allowanceScope + "-"


### PR DESCRIPTION
Redis RL doesn't care -1 and 0 values. So, I decided to skip rate limiting for `-1` and `0` values. This will also improve performance very effectively. It should be merged to master, 2.10 and 2.9 branches.

Fixes https://github.com/TykTechnologies/tyk-analytics/issues/1719