### PR TITLE
enabled api to reset cache in slaved gw

### DIFF
--- a/gateway/server.go
+++ b/gateway/server.go
@@ -444,7 +444,6 @@ func loadControlAPIEndpoints(muxer *mux.Router) {
 		r.HandleFunc("/oauth/clients/{apiID}/{keyName:[^/]*}/rotate", rotateOauthClientHandler).Methods("PUT")
 		r.HandleFunc("/oauth/clients/apis/{appID}", getApisForOauthApp).Queries("orgID", "{[0-9]*?}").Methods("GET")
 		r.HandleFunc("/oauth/refresh/{keyName}", invalidateOauthRefresh).Methods("DELETE")
-		r.HandleFunc("/cache/{apiID}", invalidateCacheHandler).Methods("DELETE")
 		r.HandleFunc("/oauth/revoke", RevokeTokenHandler).Methods("POST")
 		r.HandleFunc("/oauth/revoke_all", RevokeAllTokensHandler).Methods("POST")
 
@@ -453,7 +452,7 @@ func loadControlAPIEndpoints(muxer *mux.Router) {
 	}
 
 	r.HandleFunc("/debug", traceHandler).Methods("POST")
-
+	r.HandleFunc("/cache/{apiID}", invalidateCacheHandler).Methods("DELETE")
 	r.HandleFunc("/keys", keyHandler).Methods("POST", "PUT", "GET", "DELETE")
 	r.HandleFunc("/keys/preview", previewKeyHandler).Methods("POST")
 	r.HandleFunc("/keys/{keyName:[^/]*}", keyHandler).Methods("POST", "PUT", "GET", "DELETE")


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Added ability to invalidate cache of API in slaved GW

## Related Issue
https://github.com/TykTechnologies/tyk/issues/3033

## Motivation and Context
Provide a mechanism to invalidate cache in slaved Gateway via API. Provide a solution for https://github.com/TykTechnologies/tyk/issues/3033

## How This Has Been Tested
- Created API
- Hit API in Slave GW and in the first response the header `X-Tyk-Cached-Response` is not present
- Hit again the API and same endpoint and now `X-Tyk-Cached-Response` is present.
- Hit GW API to remove cache: `DELETE /tyk/cache/{API_ID}`
- Hit again our API in the same endpoint and the cache header is not present

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [ ] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [x] `go vet`
