### PR TITLE
on update key, dont update the creation date

### DIFF
--- a/gateway/api.go
+++ b/gateway/api.go
@@ -344,6 +344,8 @@ func handleAddOrUpdate(keyName string, r *http.Request, isHashed bool) (interfac
 			return apiError("Key is not found"), http.StatusNotFound
 		}
 
+		//remain the creation date
+		newSession.DateCreated = originalKey.DateCreated
 		// don't change fields related to quota and rate limiting if was passed as "suppress_reset=1"
 		if suppressReset {
 			// save existing quota_renews and last_updated if suppress_reset was passed


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
on update key, set the creation date of original key

## Related Issue
https://github.com/TykTechnologies/tyk-analytics/issues/1869

## Motivation and Context
Give solution to https://github.com/TykTechnologies/tyk-analytics/issues/1869

## How This Has Been Tested
- Create key
- Update key and now the create date should be the same as the beggining. Not zero date

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [x] `go vet`
