### PR TITLE
TT-94 Fix developer quotas/rates in multi-key portal

### DIFF
--- a/gateway/session_manager.go
+++ b/gateway/session_manager.go
@@ -121,6 +121,14 @@ func (l *SessionLimiter) limitRedis(currentSession *user.SessionState, key strin
 	rateLimiterKey := RateLimitKeyPrefix + rateScope + currentSession.GetKeyHash()
 	rateLimiterSentinelKey := RateLimitKeyPrefix + rateScope + currentSession.GetKeyHash() + ".BLOCKED"
 
+	md := currentSession.GetMetaData()
+	if md != nil {
+		if _, ok := md[keyDataDeveloperID]; ok {
+			rateLimiterKey = RateLimitKeyPrefix + rateScope + md[keyDataDeveloperID].(string)
+			rateLimiterSentinelKey = RateLimitKeyPrefix + rateScope + md[keyDataDeveloperID].(string) + ".BLOCKED"
+		}
+	}
+
 	if l.doRollingWindowWrite(key, rateLimiterKey, rateLimiterSentinelKey, currentSession, store, globalConf, apiLimit, dryRun) {
 		return true
 	}
@@ -138,6 +146,13 @@ func (l *SessionLimiter) limitDRL(currentSession *user.SessionState, key string,
 	bucketKey := key + ":" + rateScope + currentSession.LastUpdated
 	currRate := apiLimit.Rate
 	per := apiLimit.Per
+
+	md := currentSession.GetMetaData()
+	if md != nil {
+		if _, ok := md[keyDataDeveloperID]; ok {
+			bucketKey = md[keyDataDeveloperID].(string) + ":" + rateScope + currentSession.LastUpdated
+		}
+	}
 
 	// DRL will always overflow with more servers on low rates
 	rate := uint(currRate * float64(DRLManager.RequestTokenValue))
@@ -343,6 +358,12 @@ func (l *SessionLimiter) RedisQuotaExceeded(r *http.Request, currentSession *use
 	}
 
 	rawKey := QuotaKeyPrefix + quotaScope + currentSession.GetKeyHash()
+	md := currentSession.GetMetaData()
+	if md != nil {
+		if _, ok := md[keyDataDeveloperID]; ok {
+			rawKey = QuotaKeyPrefix + quotaScope + md[keyDataDeveloperID].(string)
+		}
+	}
 	quotaRenewalRate := limit.QuotaRenewalRate
 	quotaRenews := limit.QuotaRenews
 	quotaMax := limit.QuotaMax


### PR DESCRIPTION
When developer issued multiple keys for the same API, it should be treated as a single "key" in terms of quota/rate.

## Description
At the moment it is easy abuse the portal, and overcome the limit just by creating another key.

## How This Has Been Tested
No unit tests added yet

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [ ] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
