### PR TITLE
on update key, if the expiry sent is a past time,use original expiry

### DIFF
--- a/gateway/api.go
+++ b/gateway/api.go
@@ -371,6 +371,11 @@ func handleAddOrUpdate(keyName string, r *http.Request, isHashed bool) (interfac
 		keyName = generateToken(newSession.OrgID, keyName)
 	}
 
+	//set the original expiry if the content in payload is a past time
+	if time.Now().After(time.Unix(newSession.Expires, 0)) && newSession.Expires > 1 {
+		newSession.Expires = originalKey.Expires
+	}
+
 	// Update our session object (create it)
 	if newSession.BasicAuthData.Password != "" {
 		// If we are using a basic auth user, then we need to make the keyname explicit against the OrgId in order to differentiate it


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->

## Description
When updating a key, if the `expires` sent is a past date then use the original expires field. As this is taking us to a situation where updating a key is getting expired inmediatly due that FE is sending: `2592000` that corresponds to ` Sat, 31 Jan 1970 00:00:00 GMT`

## Related Issue
https://github.com/TykTechnologies/tyk/issues/3038

## Motivation and Context
Give solution to https://github.com/TykTechnologies/tyk/issues/3038 so we can move forward and work in https://github.com/TykTechnologies/tyk/issues/3009

## How This Has Been Tested
- Create policy that set a expires different than: `key never expires`

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
