### PR TITLE
Improve error logs for JWT and remove double call to obfuscateKey fun…

### DIFF
--- a/gateway/log_helpers.go
+++ b/gateway/log_helpers.go
@@ -36,10 +36,7 @@ func getLogEntryForRequest(logger *logrus.Entry, r *http.Request, key string, da
 	}
 	// add key to log if configured to do so
 	if key != "" {
-		fields["key"] = key
-		if !config.Global().EnableKeyLogging {
-			fields["key"] = obfuscateKey(key)
-		}
+		fields["key"] = obfuscateKey(key)
 	}
 	// add to log additional fields if any passed
 	for key, val := range data {

--- a/gateway/mw_jwt_test.go
+++ b/gateway/mw_jwt_test.go
@@ -1999,3 +1999,46 @@ func TestJWTExpOverride(t *testing.T) {
 	})
 
 }
+
+func TestPolicyOfANotherOrgJWTHMAC(t *testing.T) {
+	const apiID = "testapid"
+	const identitySource = "user_id"
+	const policyFieldName = "policy_id"
+
+	ts := StartTest()
+	defer ts.Close()
+
+	// OrgID: "default",
+	policyOfOrgDefault := CreatePolicy(func(p *user.Policy) {
+		p.AccessRights = map[string]user.AccessDefinition{
+			apiID: {},
+		}
+	})
+
+	// OrgID: "NotDefault"
+	spec := BuildAPI(func(spec *APISpec) {
+		spec.APIID = apiID
+		spec.OrgID = "NotDefault"
+		spec.UseKeylessAccess = false
+		spec.EnableJWT = true
+		spec.JWTSigningMethod = RSASign
+		spec.JWTSource = base64.StdEncoding.EncodeToString([]byte(jwtRSAPubKey))
+		spec.JWTIdentityBaseField = identitySource
+		spec.Proxy.ListenPath = "/"
+	})[0]
+
+	t.Run("Policy field name empty", func(t *testing.T) {
+		jwtToken := CreateJWKToken(func(t *jwt.Token) {
+			t.Claims.(jwt.MapClaims)[identitySource] = "dummy"
+			t.Claims.(jwt.MapClaims)[policyFieldName] = policyOfOrgDefault
+		})
+
+		authHeaders := map[string]string{"authorization": jwtToken}
+
+		// Default
+		LoadAPI(spec)
+		_, _ = ts.Run(t, test.TestCase{
+			Headers: authHeaders, Code: http.StatusForbidden,
+		})
+	})
+}


### PR DESCRIPTION
1. Improve error logs for jwt
2. Remove double call to obfuscateKey function. We were checking twice the same thing.

## Description
Added fields to the error messages to make it easier to debug (when not running from source and adding ad hoc debug messages on our own)

## Related Issue
A user opened #3042 so I thought this PR could have helped him.

## Motivation and Context
Help the user that was using Tyk CE #3042

## How This Has Been Tested
Added a test for the user's use case - test when the org id of the requested api is not matching a policy of the policy that was found in the gateway.

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [ ] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
- [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [X] I have added tests
- [ ] All new and existing tests passed.
- [X] Check your code additions will not fail linting checks:
  - [X] `go fmt`
  - [X] `go vet`
