### PR TITLE
count requests even when expired is set to -1 =  never renew

### DIFF
--- a/storage/redis_cluster.go
+++ b/storage/redis_cluster.go
@@ -543,7 +543,7 @@ func (r *RedisCluster) IncrememntWithExpire(keyName string, expire int64) int64 
 		log.Debug("Incremented key: ", fixedKey, ", val is: ", val)
 	}
 
-	if val == 1 && expire != 0 {
+	if val == 1 && expire > 0 {
 		log.Debug("--> Setting Expire")
 		r.singleton().Expire(fixedKey, time.Duration(expire)*time.Second)
 	}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
When we created a key and apply an API, then set a limited quota and never renew it wasn't counting the requests after the first one. It was because we were removing automatically the key from redis as the expiration was -1 =. never renew. If we don't apply that expire to -1 then we will have a record in redis for quota. For some reason, quota renew to never started to be -1 I started to see this behavior since this PR https://github.com/TykTechnologies/tyk/pull/3068 so, have it in consideration

## Related Issue
https://github.com/TykTechnologies/tyk/issues/3061

## Motivation and Context
Give solution to https://github.com/TykTechnologies/tyk/issues/3061

## How This Has Been Tested
- Create a key and apply a policy with a limited quota and renew= never renew. 
- Use the key, we should see that quota-remaining is decreased for each request that we made
- Create another key, but this time apply an API and set a limited quota and renew= never renew
- Use the key, we see as well that quota remaining is being decreased

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [x] `go vet`
