### PR TITLE
Fix internal api usage as target

### DIFF
--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -552,7 +552,7 @@ func (d *DummyProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if d.SH.Spec.target.Scheme == "tyk" {
 		if targetAPI := fuzzyFindAPI(d.SH.Spec.target.Host); targetAPI != nil {
-			if h, found := apisHandlesByID.Load(d.SH.Spec.APIID); found {
+			if h, found := apisHandlesByID.Load(targetAPI.APIID); found {
 				if d.SH.Spec.Proxy.StripListenPath {
 					r.URL.Path = d.SH.Spec.StripListenPath(r, r.URL.Path)
 					r.URL.RawPath = d.SH.Spec.StripListenPath(r, r.URL.RawPath)


### PR DESCRIPTION
The problem was that it was always calling the same api's handler and enters endless loop. It should call the target apis handler, so needs to search `apisHandlesByID` with target api id. 

Fixes https://github.com/TykTechnologies/tyk/issues/3080