### PR TITLE
On quota or rate set as partitioned policy, set the values in key data

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -406,10 +406,11 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 
 				if !usePartitions || policy.Partitions.Quota {
 					didQuota[k] = true
-
 					if greaterThanInt64(policy.QuotaMax, ar.Limit.QuotaMax) {
+
 						ar.Limit.QuotaMax = policy.QuotaMax
-						if greaterThanInt64(policy.QuotaMax, session.QuotaMax) {
+						//if partition for quota is set the we must use this value in the global information of the key
+						if greaterThanInt64(policy.QuotaMax, session.QuotaMax) || policy.Partitions.Quota {
 							session.QuotaMax = policy.QuotaMax
 						}
 					}
@@ -427,7 +428,8 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 
 					if greaterThanFloat64(policy.Rate, ar.Limit.Rate) {
 						ar.Limit.Rate = policy.Rate
-						if greaterThanFloat64(policy.Rate, session.Rate) {
+						//if policy.Partitions.RateLimit then we must set this value in the global data of the key
+						if greaterThanFloat64(policy.Rate, session.Rate) || policy.Partitions.RateLimit {
 							session.Rate = policy.Rate
 						}
 					}

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -410,7 +410,7 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 
 						ar.Limit.QuotaMax = policy.QuotaMax
 						//if partition for quota is set the we must use this value in the global information of the key
-						if greaterThanInt64(policy.QuotaMax, session.QuotaMax) /*|| policy.Partitions.Quota*/ {
+						if greaterThanInt64(policy.QuotaMax, session.QuotaMax) || policy.Partitions.Quota {
 							session.QuotaMax = policy.QuotaMax
 						}
 					}
@@ -429,7 +429,7 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 					if greaterThanFloat64(policy.Rate, ar.Limit.Rate) {
 						ar.Limit.Rate = policy.Rate
 						//if policy.Partitions.RateLimit then we must set this value in the global data of the key
-						if greaterThanFloat64(policy.Rate, session.Rate) /*|| policy.Partitions.RateLimit*/ {
+						if greaterThanFloat64(policy.Rate, session.Rate) || policy.Partitions.RateLimit {
 							session.Rate = policy.Rate
 						}
 					}

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -410,7 +410,7 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 
 						ar.Limit.QuotaMax = policy.QuotaMax
 						//if partition for quota is set the we must use this value in the global information of the key
-						if greaterThanInt64(policy.QuotaMax, session.QuotaMax) || policy.Partitions.Quota {
+						if greaterThanInt64(policy.QuotaMax, session.QuotaMax) /*|| policy.Partitions.Quota*/ {
 							session.QuotaMax = policy.QuotaMax
 						}
 					}
@@ -429,7 +429,7 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 					if greaterThanFloat64(policy.Rate, ar.Limit.Rate) {
 						ar.Limit.Rate = policy.Rate
 						//if policy.Partitions.RateLimit then we must set this value in the global data of the key
-						if greaterThanFloat64(policy.Rate, session.Rate) || policy.Partitions.RateLimit {
+						if greaterThanFloat64(policy.Rate, session.Rate) /*|| policy.Partitions.RateLimit*/ {
 							session.Rate = policy.Rate
 						}
 					}


### PR DESCRIPTION
…l data of the key

<!-- Provide a general summary of your changes in the Title above -->

## Description
if we apply a policy that has partitioned quota or rate then those values will be enforced and set in the global fields of a key. Before, as an example (it applies for rate and quota) if `session.QuotaMax` was -1 and `policy.QuotaMax`any other value then in the key we were not setting this value in the global scope of the key and -1 was set instead, and that is not correct at all as if we have a policy with infinite quota and another with partitioned quota, the partitioned quota should be set.

## Related Issue
https://github.com/TykTechnologies/tyk-analytics/issues/1748 some changes were applied to this same function `ApplyPolicies`, specifically the places where the function `greaterThanInt64` is used is were changed in some way the logic. 

## Motivation and Context
give solution to https://github.com/TykTechnologies/tyk-analytics/issues/1748

## How This Has Been Tested
- Create a policy P1 with quota partitioned
- Create a policy P2 with rate partitioned
- Created key applying the policies P1 and P2
- The key returned, in the global fields for Quota and rate should have the values set in P1 and P2

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [x] `go vet`
