### PR TITLE
Check response hooks when validating bundle manifest files

### DIFF
--- a/cli/bundler/bundler.go
+++ b/cli/bundler/bundler.go
@@ -173,7 +173,7 @@ func (b *Bundler) validateManifest(manifest *apidef.BundleManifest) (err error) 
 	}
 
 	// The custom middleware block must specify at least one hook:
-	definedHooks := len(manifest.CustomMiddleware.Pre) + len(manifest.CustomMiddleware.Post) + len(manifest.CustomMiddleware.PostKeyAuth)
+	definedHooks := len(manifest.CustomMiddleware.Pre) + len(manifest.CustomMiddleware.Post) + len(manifest.CustomMiddleware.PostKeyAuth) + len(manifest.CustomMiddleware.Response)
 
 	// We should count the auth check middleware (single), if it's present:
 	if manifest.CustomMiddleware.AuthCheck.Name != "" {


### PR DESCRIPTION
Fix for #3095.

During my tests I was using the old `tyk-cli` tool which didn't perform this type of validation, this extends the current CLI tool to cover response hooks.