### PR TITLE
get rid of env engine

### DIFF
--- a/gateway/mw_url_rewrite.go
+++ b/gateway/mw_url_rewrite.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/textproto"
 	"net/url"
-	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -25,7 +24,6 @@ const (
 	contextLabel     = "$tyk_context."
 	consulLabel      = "$secret_consul."
 	vaultLabel       = "$secret_vault."
-	envLabel         = "$secret_env."
 	secretsConfLabel = "$secret_conf."
 	triggerKeyPrefix = "trigger"
 	triggerKeySep    = "-"
@@ -208,12 +206,6 @@ func replaceTykVariables(r *http.Request, in string, escape bool) string {
 		in = replaceVariables(in, vars, contextData, secretsConfLabel, escape)
 	}
 
-	if strings.Contains(in, envLabel) {
-		contextData := ctxGetData(r)
-		vars := envValueMatch.FindAllString(in, -1)
-		in = replaceVariables(in, vars, contextData, envLabel, escape)
-	}
-
 	if strings.Contains(in, vaultLabel) {
 		contextData := ctxGetData(r)
 		vars := vaultMatch.FindAllString(in, -1)
@@ -269,16 +261,6 @@ func replaceVariables(in string, vars []string, vals map[string]interface{}, lab
 
 			val, ok := secrets[key]
 			if !ok || val == "" {
-				in = emptyStringFn(key, in, v)
-				continue
-			}
-
-			in = strings.Replace(in, v, val, -1)
-
-		case envLabel:
-
-			val := os.Getenv(fmt.Sprintf("TYK_SECRET_%s", strings.ToUpper(key)))
-			if val == "" {
 				in = emptyStringFn(key, in, v)
 				continue
 			}

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -1072,12 +1072,6 @@ func kvStore(value string) (string, error) {
 		return val, nil
 	}
 
-	if strings.HasPrefix(value, "env://") {
-		key := strings.TrimPrefix(value, "env://")
-		log.Debugf("Retrieving %s from environment", key)
-		return os.Getenv(fmt.Sprintf("TYK_SECRET_%s", strings.ToUpper(key))), nil
-	}
-
 	if strings.HasPrefix(value, "consul://") {
 		key := strings.TrimPrefix(value, "consul://")
 		log.Debugf("Retrieving %s from consul", key)


### PR DESCRIPTION
Drop the Env KV engine

## Description
Currently we allow all env values. We already have an implementation for this that reads values
with their prefixes as `TYK_SECRET`. We are going to stick with that.

## Related Issue

## Motivation and Context

Simplicity and security

## How This Has Been Tested

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [x] My change requires a change to the documentation.
  - [x] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [] `go vet`
