### PR TITLE
include empty values for graphql api execution mode in json schema

### DIFF
--- a/apidef/api_definition_test.go
+++ b/apidef/api_definition_test.go
@@ -22,3 +22,23 @@ func TestSchema(t *testing.T) {
 		}
 	}
 }
+
+func TestSchemaGraphqlConfig(t *testing.T) {
+	schemaLoader := schema.NewBytesLoader([]byte(Schema))
+
+	spec := DummyAPI()
+	spec.GraphQL.ExecutionMode = ""
+
+	goLoader := schema.NewGoLoader(spec)
+
+	result, err := schema.Validate(schemaLoader, goLoader)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !result.Valid() {
+		for _, err := range result.Errors() {
+			t.Error(err)
+		}
+	}
+}

--- a/apidef/schema.go
+++ b/apidef/schema.go
@@ -437,12 +437,11 @@ const Schema = `{
 					"type": "boolean"
 				},
 				"execution_mode": {
-					"type": ["string", "null"],
+					"type": "string",
 					"enum": [
 						"proxyOnly",
 						"executionEngine",
-						"",
-						null
+						""
 					]
 				},
 				"schema": {

--- a/apidef/schema.go
+++ b/apidef/schema.go
@@ -437,10 +437,12 @@ const Schema = `{
 					"type": "boolean"
 				},
 				"execution_mode": {
-					"type": "string",
+					"type": ["string", "null"],
 					"enum": [
 						"proxyOnly",
-						"executionEngine"
+						"executionEngine",
+						"",
+						null
 					]
 				},
 				"schema": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Allow execution mode enum values to be null or empty

## Related Issue
https://github.com/TykTechnologies/tyk/pull/3123