### PR TITLE
Nopclose request body for internal calls

### DIFF
--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -686,6 +686,8 @@ func (rt *TykRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 
 		rt.logger.WithField("looping_url", "tyk://"+r.Host).Debug("Executing request on internal route")
 		recorder := httptest.NewRecorder()
+
+		nopCloseRequestBody(r)
 		handler.ServeHTTP(recorder, r)
 		return recorder.Result(), nil
 	}


### PR DESCRIPTION
Remove the body copying logic from GraphQL middleware and put nopclose on internal api call of graphql apis.

Fixes https://github.com/TykTechnologies/tyk/issues/3145