### PR TITLE
Add https case when processing tcp requests

### DIFF
--- a/tcp/tcp.go
+++ b/tcp/tcp.go
@@ -224,14 +224,14 @@ func (p *Proxy) handleConn(conn net.Conn) error {
 		} else {
 			rconn, err = net.Dial("tcp", u.Host)
 		}
-	case "tls":
+	case "tls", "https":
 		if p.DialTLS != nil {
 			rconn, err = p.DialTLS("tcp", u.Host)
 		} else {
 			rconn, err = tls.Dial("tcp", u.Host, p.TLSConfigTarget)
 		}
 	default:
-		err = errors.New("Unsupported protocol. Should be empty, `tcp` or `tls`")
+		err = errors.New("Unsupported protocol. Should be empty, `tcp`, `tls` or `https`)
 	}
 	if err != nil {
 		conn.Close()


### PR DESCRIPTION
This will unblock basic grpc proxying for the gateway.


## Description
Widen check to allow https traffic through when TLS api configured
## Related Issue


## Motivation and Context

Allows secured gRPC traffic through the gateway which is currently not possible without breaking the gRPC spec


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [ ] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
