### PR TITLE
when rpc in emergency mode then dont check org session in rpc

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -230,7 +230,7 @@ func (t BaseMiddleware) OrgSession(orgID string) (user.SessionState, bool) {
 	var session user.SessionState
 	var found bool
 
-	if !rpc.IsEmergencyMode(){
+	if !rpc.IsEmergencyMode() {
 		// Try and get the session from the session store
 		session, found = t.Spec.OrgSessionManager.SessionDetail(orgID, orgID, false)
 		if found && t.Spec.GlobalConfig.EnforceOrgDataAge {

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -231,18 +231,20 @@ func (t BaseMiddleware) OrgSession(orgID string) (user.SessionState, bool) {
 	var session user.SessionState
 	var found bool
 
-	if !rpc.IsEmergencyMode() {
-		// Try and get the session from the session store
-		session, found = t.Spec.OrgSessionManager.SessionDetail(orgID, orgID, false)
-		if found && t.Spec.GlobalConfig.EnforceOrgDataAge {
-			// If exists, assume it has been authorized and pass on
-			// We cache org expiry data
-			t.Logger().Debug("Setting data expiry: ", session.OrgID)
-			ExpiryCache.Set(session.OrgID, session.DataExpires, cache.DefaultExpiration)
-		}
-
-		session.SetKeyHash(storage.HashKey(orgID))
+	if rpc.IsEmergencyMode() {
+		return session, false
 	}
+
+	// Try and get the session from the session store
+	session, found = t.Spec.OrgSessionManager.SessionDetail(orgID, orgID, false)
+	if found && t.Spec.GlobalConfig.EnforceOrgDataAge {
+		// If exists, assume it has been authorized and pass on
+		// We cache org expiry data
+		t.Logger().Debug("Setting data expiry: ", session.OrgID)
+		ExpiryCache.Set(session.OrgID, session.DataExpires, cache.DefaultExpiration)
+	}
+
+	session.SetKeyHash(storage.HashKey(orgID))
 
 	return session, found
 }

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"github.com/TykTechnologies/tyk/rpc"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -226,16 +227,22 @@ func (t BaseMiddleware) Config() (interface{}, error) {
 }
 
 func (t BaseMiddleware) OrgSession(orgID string) (user.SessionState, bool) {
-	// Try and get the session from the session store
-	session, found := t.Spec.OrgSessionManager.SessionDetail(orgID, orgID, false)
-	if found && t.Spec.GlobalConfig.EnforceOrgDataAge {
-		// If exists, assume it has been authorized and pass on
-		// We cache org expiry data
-		t.Logger().Debug("Setting data expiry: ", session.OrgID)
-		ExpiryCache.Set(session.OrgID, session.DataExpires, cache.DefaultExpiration)
+	var session user.SessionState
+	var found bool
+
+	if !rpc.IsEmergencyMode(){
+		// Try and get the session from the session store
+		session, found = t.Spec.OrgSessionManager.SessionDetail(orgID, orgID, false)
+		if found && t.Spec.GlobalConfig.EnforceOrgDataAge {
+			// If exists, assume it has been authorized and pass on
+			// We cache org expiry data
+			t.Logger().Debug("Setting data expiry: ", session.OrgID)
+			ExpiryCache.Set(session.OrgID, session.DataExpires, cache.DefaultExpiration)
+		}
+
+		session.SetKeyHash(storage.HashKey(orgID))
 	}
 
-	session.SetKeyHash(storage.HashKey(orgID))
 	return session, found
 }
 

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/TykTechnologies/tyk/rpc"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/TykTechnologies/tyk/rpc"
 
 	"github.com/TykTechnologies/tyk/headers"
 

--- a/gateway/middleware_test.go
+++ b/gateway/middleware_test.go
@@ -78,8 +78,6 @@ func TestOrgSessionWithRPCDown(t *testing.T) {
 	if found {
 		t.Fatal("org  session should be null:")
 	}
-	stopRPCMock(nil)
-
 }
 
 func TestBaseMiddleware_getAuthType(t *testing.T) {

--- a/gateway/middleware_test.go
+++ b/gateway/middleware_test.go
@@ -1,12 +1,11 @@
 package gateway
 
 import (
-	"net/http"
-	"testing"
-
 	"github.com/TykTechnologies/tyk/apidef"
 	cache "github.com/pmylund/go-cache"
 	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
 
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/user"
@@ -47,6 +46,39 @@ func TestBaseMiddleware_OrgSessionExpiry(t *testing.T) {
 	if got != sess.DataExpires {
 		t.Errorf("expected %d got %d", sess.DataExpires, got)
 	}
+}
+
+func TestOrgSessionWithRPCDown(t *testing.T) {
+	ts := StartTest()
+	defer ts.Close()
+
+	//we need rpc down
+	globalConf := config.Global()
+	globalConf.SlaveOptions.ConnectionString = testHttpFailure
+	globalConf.SlaveOptions.UseRPC = true
+	globalConf.SlaveOptions.RPCKey = "test_org"
+	globalConf.SlaveOptions.APIKey = "test"
+	globalConf.Policies.PolicySource = "rpc"
+	config.SetGlobal(globalConf)
+
+	m := BaseMiddleware{
+		Spec: &APISpec{
+			GlobalConfig: config.Config{
+				EnforceOrgDataAge: true,
+			},
+			OrgSessionManager: mockStore{},
+		},
+		logger: mainLog,
+	}
+	// reload so we force to fall in emergency mode
+	DoReload()
+
+	_,found := m.OrgSession(sess.OrgID)
+	if found{
+		t.Fatal("org  session should be null:")
+	}
+	stopRPCMock(nil)
+
 }
 
 func TestBaseMiddleware_getAuthType(t *testing.T) {

--- a/gateway/middleware_test.go
+++ b/gateway/middleware_test.go
@@ -1,11 +1,12 @@
 package gateway
 
 import (
+	"net/http"
+	"testing"
+
 	"github.com/TykTechnologies/tyk/apidef"
 	cache "github.com/pmylund/go-cache"
 	"github.com/stretchr/testify/assert"
-	"net/http"
-	"testing"
 
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/user"

--- a/gateway/middleware_test.go
+++ b/gateway/middleware_test.go
@@ -73,8 +73,8 @@ func TestOrgSessionWithRPCDown(t *testing.T) {
 	// reload so we force to fall in emergency mode
 	DoReload()
 
-	_,found := m.OrgSession(sess.OrgID)
-	if found{
+	_, found := m.OrgSession(sess.OrgID)
+	if found {
 		t.Fatal("org  session should be null:")
 	}
 	stopRPCMock(nil)

--- a/rpc/rpc_client.go
+++ b/rpc/rpc_client.go
@@ -309,6 +309,7 @@ func loginBase() bool {
 			}
 		}
 		rpcLoginMu.Unlock()
+		return false
 	}
 	return true
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
When a slave gw has enabled analytics, and sink is down, then dont try to get org session from rpc

## Related Issue
https://github.com/TykTechnologies/tyk/issues/3162

## Motivation and Context
Give solution to https://github.com/TykTechnologies/tyk/issues/3162 also, fix how gw behaves when sink is down and do not affect the response time for the apis.

## How This Has Been Tested
- Setup MDCB environment and ensure that slaved gw have `enable_analytics` set to true
- Consume api in master and slaved gw
- Turn off sink
- Consume API in slaved gw, the time of response should be similar as step 2 (however, consider that it can take some seconds to change the state to emergency mode)
- Consume api in master (to ensure that nothing is broken now)
- Turn on again sink
- Consume api in slave

Some load test were performed using apache benchmark sending 10 request in parallel and 100 request in total (executing  `ab -n 100 -c 10 http://tyk-gateway:8182/1/` ), next are the results after the change:

1- **With Sink up&running:**
```
Requests per second:    13.91 [#/sec] (mean)
Time per request:       718.859 [ms] (mean) (this is for a batch of 10 requests)
Time per request:       71.886 [ms] (mean, across all concurrent requests) (per single request)
```
2- With Sink down:
```
Requests per second:    13.79 [#/sec] (mean)
Time per request:       725.245 [ms] (mean)
Time per request:       72.524 [ms] (mean, across all concurrent requests)
```

As we see, the number are almost the same. And just as a reference these are the numbers with sink down before make this change:

```
Requests per second:    0.97 [#/sec] (mean)
Time per request:       10302.129 [ms] (mean)
Time per request:       1030.213 [ms] (mean, across all concurrent requests)
```

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [x] `go vet`
