### PR TITLE
plugin-compiler: use a dynamic package path

### DIFF
--- a/images/plugin-compiler/data/build.sh
+++ b/images/plugin-compiler/data/build.sh
@@ -3,6 +3,7 @@
 set -xe
 
 plugin_name=$1
+plugin_path=$(date +%s)-$plugin_name
 
 function usage() {
     cat <<EOF
@@ -23,5 +24,5 @@ yes | cp -r $PLUGIN_BUILD_PATH/vendor $GOPATH/src || true \
         && rm -rf $PLUGIN_BUILD_PATH/vendor
 
 cd $PLUGIN_BUILD_PATH \
-    && go build -buildmode=plugin -o $plugin_name \
+    && go build -buildmode=plugin -ldflags "-pluginpath=$plugin_path" -o $plugin_name \
     && mv $plugin_name $PLUGIN_SOURCE_PATH


### PR DESCRIPTION
Workaround for #3195.

To test this without having to rebuild the `tyk-plugin-compiler` image, the `build.sh` can be replaced on runtime using the volume flag:
```
$ docker run --rm -v `pwd`/build.sh:/build.sh -v `pwd`:/plugin-source tykio/tyk-plugin-compiler:v2.9.4.2 plugin1.so
``` 
With this fix, the scenario described in the original ticket will perform as expected, allowing the usage of multiple Docker-built Go plugins.