### PR TITLE
Backport plugin aliasing fix for 2.-

### DIFF
--- a/images/plugin-compiler/Dockerfile
+++ b/images/plugin-compiler/Dockerfile
@@ -6,8 +6,13 @@ LABEL io.tyk.vendor="Tyk" \
 ENV GOPATH=/go
 ARG TYK_GW_TAG
 ENV TYK_GW_PATH=${GOPATH}/src/github.com/TykTechnologies/tyk
+# This directory will contain the plugin source and will be
+# mounted from the host box by the user using docker volumes
+ENV PLUGIN_SOURCE_PATH=/plugin-source
+# This is the temporary path where the plugin will be built
+ENV PLUGIN_BUILD_PATH=/go/src/plugin-build
 
-RUN mkdir -p /go/src/plugin-build $TYK_GW_PATH
+RUN mkdir -p $TYK_GW_PATH $PLUGIN_SOURCE_PATH $PLUGIN_BUILD_PATH
 COPY data/build.sh /build.sh
 RUN chmod +x /build.sh
 

--- a/images/plugin-compiler/data/build.sh
+++ b/images/plugin-compiler/data/build.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 
 set -xe
-# This directory will contain the plugin source and will be
-# mounted from the host box by the user using docker volumes
-PLUGIN_BUILD_PATH=/go/src/plugin-build
 
 plugin_name=$1
+plugin_path=$(date +%s)-$plugin_name
 
 function usage() {
     cat <<EOF
@@ -21,8 +19,10 @@ if [ -z "$plugin_name" ]; then
 fi
 
 # Handle if plugin has own vendor folder, and ignore error if not
+yes | cp -r $PLUGIN_SOURCE_PATH/* $PLUGIN_BUILD_PATH || true
 yes | cp -r $PLUGIN_BUILD_PATH/vendor $GOPATH/src || true \
         && rm -rf $PLUGIN_BUILD_PATH/vendor
 
-cd $PLUGIN_BUILD_PATH && \
-    go build -buildmode=plugin -o $plugin_name
+cd $PLUGIN_BUILD_PATH \
+    && go build -buildmode=plugin -ldflags "-pluginpath=$plugin_path" -o $plugin_name \
+    && mv $plugin_name $PLUGIN_SOURCE_PATH


### PR DESCRIPTION
## Description
Backport fix in related issue to release-2.9. This should be merged to `release-2.9` _only_.

## Related Issue
#3195 

## How This Has Been Tested
Test log:
```shellsession
% docker build -t tykio/tyk-plugin-compiler:v2.9.4.2-rc1 --build-arg=TYK_GW_TAG=v2.9.4.2 .
Sending build context to Docker daemon  13.31kB
Step 1/13 : FROM tykio/tyk-build-env:latest
 ---> c9b1f747cb9f
Step 2/13 : LABEL io.tyk.vendor="Tyk"       version="1.0"       description="Image for plugin development"
 ---> Using cache
 ---> f6493e851359
Step 3/13 : ENV GOPATH=/go
 ---> Using cache
 ---> deb7d97c0378
Step 4/13 : ARG TYK_GW_TAG
 ---> Using cache
 ---> e9c212fa6ba8
Step 5/13 : ENV TYK_GW_PATH=${GOPATH}/src/github.com/TykTechnologies/tyk
 ---> Using cache
 ---> a56bdbad1827
Step 6/13 : ENV PLUGIN_SOURCE_PATH=/plugin-source
 ---> Running in 301b6fcc2795
Removing intermediate container 301b6fcc2795
 ---> 2c3c0e504664
Step 7/13 : ENV PLUGIN_BUILD_PATH=/go/src/plugin-build
 ---> Running in c98d4cc267cb
Removing intermediate container c98d4cc267cb
 ---> 88bd728172e2
Step 8/13 : RUN mkdir -p $TYK_GW_PATH $PLUGIN_SOURCE_PATH $PLUGIN_BUILD_PATH
 ---> Running in edc7d9ced030
Removing intermediate container edc7d9ced030
 ---> c0b926bb6513
Step 9/13 : COPY data/build.sh /build.sh
 ---> 60110952600b
Step 10/13 : RUN chmod +x /build.sh
 ---> Running in 7b1dcb1685b2
Removing intermediate container 7b1dcb1685b2
 ---> 29bbe91bb775
Step 11/13 : RUN curl -sL "https://api.github.com/repos/TykTechnologies/tyk/tarball/${TYK_GW_TAG}" |     tar -C $TYK_GW_PATH --strip-components=1 -xzf -
 ---> Running in 86129ef00dc1
Removing intermediate container 86129ef00dc1
 ---> 45336045395a
Step 12/13 : RUN yes | cp -r $TYK_GW_PATH/vendor $GOPATH/src && rm -rf $TYK_GW_PATH/vendor
 ---> Running in 97f0f1315306
Removing intermediate container 97f0f1315306
 ---> 4737e34efc59
Step 13/13 : ENTRYPOINT ["/build.sh"]
 ---> Running in 78aaef8caea8
Removing intermediate container 78aaef8caea8
 ---> 392e56b2004d
Successfully built 392e56b2004d
Successfully tagged tykio/tyk-plugin-compiler:v2.9.4.2-rc1
% docker run --rm -v $(pwd):/plugin-source tykio/tyk-plugin-compiler:v2.9.4.2-rc1 p1.so
+ plugin_name=p1.so
++ date +%s
+ plugin_path=1594372397-p1.so
+ '[' -z p1.so ']'
+ yes
+ cp -r /plugin-source/apps /plugin-source/foo-plugin.go /plugin-source/plugins /plugin-source/plugins.yml /plugin-source/pre-post.json /plugin-source/tyk.conf /go/src/plugin-build
+ yes
+ cp -r /go/src/plugin-build/vendor /go/src
cp: cannot stat '/go/src/plugin-build/vendor': No such file or directory
+ true
+ rm -rf /go/src/plugin-build/vendor
+ cd /go/src/plugin-build
+ go build -buildmode=plugin -ldflags -pluginpath=1594372397-p1.so -o p1.so
+ mv p1.so /plugin-source
% docker run --rm -v $(pwd):/plugin-source tykio/tyk-plugin-compiler:v2.9.4.2-rc1 p2.so
+ plugin_name=p2.so
++ date +%s
+ plugin_path=1594372407-p2.so
+ '[' -z p2.so ']'
+ yes
+ cp -r /plugin-source/apps /plugin-source/foo-plugin.go /plugin-source/p1.so /plugin-source/plugins /plugin-source/plugins.yml /plugin-source/pre-post.json /plugin-source/tyk.conf /go/src/plugin-build
+ yes
+ cp -r /go/src/plugin-build/vendor /go/src
cp: cannot stat '/go/src/plugin-build/vendor': No such file or directory
+ true
+ rm -rf /go/src/plugin-build/vendor
+ cd /go/src/plugin-build
+ go build -buildmode=plugin -ldflags -pluginpath=1594372407-p2.so -o p2.so
+ mv p2.so /plugin-source
% mv *.so plugins                                                                      
% docker-compose -f plugins.yml up
Creating network "test_default" with the default driver
Creating test_redis_1 ... done
Creating test_tyk-gateway_1 ... done
Attaching to test_redis_1, test_tyk-gateway_1
redis_1        | 1:C 10 Jul 2020 09:13:50.434 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
redis_1        | 1:C 10 Jul 2020 09:13:50.434 # Redis version=5.0.6, bits=64, commit=00000000, modified=0, pid=1, just started
redis_1        | 1:C 10 Jul 2020 09:13:50.434 # Warning: no config file specified, using the default config. In order to specify a config file use redis-server /path/to/redis.conf
tyk-gateway_1  | **************************************************************************************************************
tyk-gateway_1  | *                                           WARNING                                                          *
tyk-gateway_1  | **               USING GATEWAY SECRET IN TYK.CONF BECAUSE NO ENV VARIABLE SET                               **
tyk-gateway_1  | *                                REFER TO IMAGE README FOR MORE INFO                                         *
tyk-gateway_1  | **************************************************************************************************************
tyk-gateway_1  | 
redis_1        | 1:M 10 Jul 2020 09:13:50.435 * Running mode=standalone, port=6379.
redis_1        | 1:M 10 Jul 2020 09:13:50.435 # Server initialized
redis_1        | 1:M 10 Jul 2020 09:13:50.435 # WARNING overcommit_memory is set to 0! Background save may fail under low memory condition. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
redis_1        | 1:M 10 Jul 2020 09:13:50.435 # WARNING you have Transparent Huge Pages (THP) support enabled in your kernel. This will create latency and memory usage issues with Redis. To fix this issue run the command 'echo never > /sys/kernel/mm/transparent_hugepage/enabled' as root, and add it to your /etc/rc.local in order to retain the setting after a reboot. Redis must be restarted after THP is disabled.
redis_1        | 1:M 10 Jul 2020 09:13:50.435 * Ready to accept connections
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="Tyk API Gateway v2.9.4.2" prefix=main
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="--> [REDIS] Creating single-node client"
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="Rich plugins are disabled" prefix=coprocess
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="PIDFile location set to: /var/run/tyk/tyk-gateway.pid" prefix=main
tyk-gateway_1  | time="Jul 10 09:13:51" level=warning msg="The control_api_port should be changed for production" prefix=main
tyk-gateway_1  | time="Jul 10 09:13:51" level=warning msg="Insecure configuration allowed: allow_insecure_configs: true" prefix=checkup
tyk-gateway_1  | time="Jul 10 09:13:51" level=warning msg="Health Checker is deprecated and not recommended" prefix=checkup
tyk-gateway_1  | time="Jul 10 09:13:51" level=warning msg="Default secret `352d20ee67be67f6340b4c0605b044b7` should be changed for production." prefix=checkup
tyk-gateway_1  | time="Jul 10 09:13:51" level=warning msg="Default node_secret `352d20ee67be67f6340b4c0605b044b7` should be changed for production." prefix=checkup
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="Starting Poller" prefix=host-check-mgr
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="Redis connection pools are ready after number of retires" currRetry=0
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="Redis connection pools are ready" prefix=main
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="Initialising Tyk REST API Endpoints" prefix=main
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="--> Standard listener (http)" port=":8080" prefix=main
tyk-gateway_1  | time="Jul 10 09:13:51" level=warning msg="Starting HTTP server on:[::]:8080" prefix=main
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="Initialising distributed rate limiter" prefix=main
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="Tyk Gateway started (v2.9.4.2)" prefix=main
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="--> Listening on address: (open interface)" prefix=main
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="--> Listening on port: 8080" prefix=main
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="--> PID: 9" prefix=main
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="Loading policies" prefix=main
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="Loading API Specification from /opt/tyk-gateway/apps/post.json"
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="Starting gateway rate limiter notifications..."
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="Loading API Specification from /opt/tyk-gateway/apps/pre.json"
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="Detected 2 APIs" prefix=main
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="Loading API configurations." prefix=main
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="Tracking hostname" api_name="Post test" domain="(no host)" prefix=main
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="Tracking hostname" api_name="Pre test" domain="(no host)" prefix=main
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="Initialising Tyk REST API Endpoints" prefix=main
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="API bind on custom port:0" prefix=main
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="Initializing HealthChecker"
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="--> [REDIS] Creating single-node client"
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="Checking security policy: Open" api_id= api_name="Post test" org_id=
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="API Loaded" api_id= api_name="Post test" org_id= prefix=gateway server_name=-- user_id=-- user_ip=--
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="API bind on custom port:0" prefix=main
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="Initializing HealthChecker"
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="Checking security policy: Open" api_id= api_name="Pre test" org_id=
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="API Loaded" api_id= api_name="Pre test" org_id= prefix=gateway server_name=-- user_id=-- user_ip=--
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="Loading uptime tests..." prefix=host-check-mgr
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="Initialised API Definitions" prefix=main
tyk-gateway_1  | time="Jul 10 09:13:51" level=info msg="API reload complete" prefix=main
^CGracefully stopping... (press Ctrl+C again to force)
```

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [ ] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
