### PR TITLE
Add some documentation and tests for goplugins

### DIFF
--- a/images/plugin-compiler/README.md
+++ b/images/plugin-compiler/README.md
@@ -1,0 +1,28 @@
+# Tyk Plugin compiler
+
+## Building a plugin
+Navigate to where your plugin is and build using a docker volume to
+mount your code into the image. Since the vendor directory needs to be
+identical between the gateway build and the plugin build, this means
+that you should pull the version of this image corresponding to the
+gateway version you are using.
+
+This also implies that if your plugin has vendored modules that are
+also used by Tyk gateway then your module will be overridden by the
+version that Tyk uses.
+
+```shellsession
+% docker run -v `pwd`:/plugin-source tykio/tyk-plugin-compiler:v2.9.4.2 myplugin.so
+```
+
+You will find a myplugin.so in the current directory which is the file
+that goes into the API definition
+
+## Plugin aliasing
+Due to the way that `dl_open(3)` works, the filename needs to change
+for `libdl` to recognise that the plugin has been updated. Else, the
+cached value from `ld.so.cache` will be used.
+
+## Hot reloading
+Using `/tyk/reload/group` will _not_ update the plugin if you have
+compiled a fresh version and used the same pathname.

--- a/images/plugin-compiler/README.md
+++ b/images/plugin-compiler/README.md
@@ -29,3 +29,5 @@ more details.
 ## Hot reloading
 Using `/tyk/reload/group` will _not_ update the plugin if you have
 compiled a fresh version and used the same pathname.
+
+To reload a plugin, you will have to restart the gateway process.

--- a/images/plugin-compiler/README.md
+++ b/images/plugin-compiler/README.md
@@ -19,9 +19,12 @@ You will find a myplugin.so in the current directory which is the file
 that goes into the API definition
 
 ## Plugin aliasing
-Due to the way that `dl_open(3)` works, the filename needs to change
-for `libdl` to recognise that the plugin has been updated. Else, the
-cached value from `ld.so.cache` will be used.
+Plugins are loaded via `dl_open(3)` and the shared library cache,
+`ld.so.cache` will be used. Therefore,even if a plugin's content
+changes but the filename does not, the cached plugin will be used.
+
+See the manpages for `dl_open(3)` and `ld.so(8)` on your platform for
+more details.
 
 ## Hot reloading
 Using `/tyk/reload/group` will _not_ update the plugin if you have

--- a/images/plugin-compiler/test/Makefile
+++ b/images/plugin-compiler/test/Makefile
@@ -1,0 +1,19 @@
+TPC ?= $(shell git tag | tail -1)
+
+docker-compose = GW_VERSION=$(TPC) docker-compose -f plugins.yml -p tpc
+
+.PHONY: check-header clean
+
+check-header: plugin.so
+	@curl -s -X POST http://localhost:8080/postplugin | jq -e 'if .headers.Foo != "Bar" then false else true end'
+	@echo Found header Foo=Bar 
+
+plugin.so:	foo-plugin.go plugins.yml
+	docker run --rm -v $$PWD:/plugin-source tykio/tyk-plugin-compiler:$(TPC) $@
+	cp $@ plugins/
+	@echo Built plugin for $(TPC), bringing up compose env
+	$(docker-compose) up --detach && sleep 2
+
+clean:
+	rm -fv *.so
+	$(docker-compose) down

--- a/images/plugin-compiler/test/README.md
+++ b/images/plugin-compiler/test/README.md
@@ -1,0 +1,63 @@
+# Testing the plugin compiler
+
+## Build the plugin
+`TPC_VERSION` (Tyk Plugin Compiler version) should correspond to the version you want to use.
+
+``` shellsession
+% make TPC_VERSION=v2.9.4.2-rc1
+docker run --rm -v $PWD:/plugin-source tykio/tyk-plugin-compiler:v2.9.4.2-rc1 plugin.so
++ plugin_name=plugin.so
+++ date +%s
++ plugin_path=1594377968-plugin.so
++ '[' -z plugin.so ']'
++ yes
++ cp -r /plugin-source/#README.md# /plugin-source/Makefile /plugin-source/apps /plugin-source/foo-plugin.go /plugin-source/plugins /plugin-source/plugins.yml /plugin-source/pre-post.json /plugin-source/tyk.conf /go/src/plugin-build
++ yes
++ cp -r /go/src/plugin-build/vendor /go/src
+cp: cannot stat '/go/src/plugin-build/vendor': No such file or directory
++ true
++ rm -rf /go/src/plugin-build/vendor
++ cd /go/src/plugin-build
++ go build -buildmode=plugin -ldflags -pluginpath=1594377968-plugin.so -o plugin.so
++ mv plugin.so /plugin-source
+```
+
+## Define an API
+Place this in the `apps` sub-directory. This is mounted to
+`/opt/tyk-gateway/apps`. A sample definition is provided.
+
+## Run gateway with plugins
+Move the plugins into a directory called `plugins`. This will be
+mounted to `/opt/tyk-gateway/middleware` in the gateway container. A
+minimal `tyk.conf` is provided. Set the gateway version to use and
+bring the gateway and redis up with
+
+``` shellsession
+% GW_VERSION=v2.9.4.2 docker-compose -f plugins.yml up
+```
+
+## See if the plugin works
+
+``` shellsession
+% curl -X POST http://localhost:8080/postplugin
+{
+  "args": {}, 
+  "data": "", 
+  "files": {}, 
+  "form": {}, 
+  "headers": {
+    "Accept": "*/*", 
+    "Accept-Encoding": "gzip", 
+    "Content-Length": "0", 
+    "Foo": "Bar", 
+    "Host": "httpbin.org", 
+    "User-Agent": "curl/7.68.0", 
+    "X-Amzn-Trace-Id": "Root=1-5f08545c-2f91e5c4388bff04f25f1467"
+  }, 
+  "json": null, 
+  "origin": "172.26.0.1, 106.51.77.191", 
+  "url": "http://httpbin.org/post"
+}
+```
+
+Note the header `Foo`.

--- a/images/plugin-compiler/test/apps/post.json
+++ b/images/plugin-compiler/test/apps/post.json
@@ -1,0 +1,50 @@
+{
+    "name": "Post test",
+    "use_keyless": true,
+    "active": true,
+    "proxy": {
+        "listen_path": "/postplugin",
+        "target_url": "http://httpbin.org/post",
+        "strip_listen_path": true
+    },
+    "version_data": {
+        "not_versioned": true,
+        "default_version": "",
+        "versions": {
+            "Default": {
+                "name": "Default",
+                "expires": "",
+                "paths": {
+                    "ignored": [],
+                    "white_list": [],
+                    "black_list": []
+                },
+                "use_extended_paths": true,
+                "global_headers": {},
+                "global_headers_remove": [],
+                "global_response_headers": null,
+                "global_response_headers_remove": null,
+                "ignore_endpoint_case": false,
+                "global_size_limit": 0,
+                "override_target": "",
+                "extended_paths": {
+                    "track_endpoints": [
+                        {
+                            "path": "",
+                            "method": "GET"
+                        }
+                    ]
+                }
+            }
+        }
+    },
+    "custom_middleware": {
+        "post": [
+            {
+                "name": "AddFooBarHeader",
+                "path": "/opt/tyk-gateway/middleware/plugin.so"
+            }
+        ],
+        "driver": "goplugin"
+    }
+}

--- a/images/plugin-compiler/test/foo-plugin.go
+++ b/images/plugin-compiler/test/foo-plugin.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"net/http"
+)
+
+// AddFooBarHeader adds custom "Foo: Bar" header to the request
+func AddFooBarHeader(rw http.ResponseWriter, r *http.Request) {
+	r.Header.Add("Foo", "Bar")
+}
+
+func main() {}

--- a/images/plugin-compiler/test/foo-plugin.go
+++ b/images/plugin-compiler/test/foo-plugin.go
@@ -5,6 +5,7 @@ import (
 )
 
 // AddFooBarHeader adds custom "Foo: Bar" header to the request
+// nolint
 func AddFooBarHeader(rw http.ResponseWriter, r *http.Request) {
 	r.Header.Add("Foo", "Bar")
 }

--- a/images/plugin-compiler/test/plugins.yml
+++ b/images/plugin-compiler/test/plugins.yml
@@ -1,0 +1,17 @@
+version: '3'
+services:
+    tyk-gateway:
+        environment:
+          - TYK_LOGLEVEL=debug
+        image: tykio/tyk-gateway:${GW_VERSION}
+        ports:
+            - "8080:8080"
+        volumes:
+            - ${PWD}/apps:/opt/tyk-gateway/apps
+            - ${PWD}/tyk.conf:/opt/tyk-gateway/tyk.conf
+            - ${PWD}/plugins:/opt/tyk-gateway/middleware
+        depends_on:
+            - redis
+              
+    redis:
+        image: redis

--- a/images/plugin-compiler/test/tyk.conf
+++ b/images/plugin-compiler/test/tyk.conf
@@ -1,0 +1,42 @@
+{
+  "listen_port": 8080,
+  "secret": "352d20ee67be67f6340b4c0605b044b7",
+  "node_secret": "352d20ee67be67f6340b4c0605b044b7",
+  "template_path": "/opt/tyk-gateway/templates",
+  "tyk_js_path": "/opt/tyk-gateway/js/tyk.js",
+  "middleware_path": "/opt/tyk-gateway/middleware",
+  "app_path": "/opt/tyk-gateway/apps/",
+  "storage": {
+    "type": "redis",
+    "host": "redis",
+    "port": 6379,
+    "username": "",
+    "password": "",
+    "database": 0,
+    "optimisation_max_idle": 2000,
+    "optimisation_max_active": 4000
+  },
+  "health_check": {
+    "enable_health_checks": true,
+    "health_check_value_timeouts": 60
+  },
+  "optimisations_use_async_session_write": true,
+  "enable_non_transactional_rate_limiter": true,
+  "enable_sentinel_rate_limiter": false,
+  "allow_master_keys": false,
+  "hash_keys": true,
+  "close_connections": false,
+  "http_server_options": {
+    "enable_websockets": true
+  },
+  "allow_insecure_configs": true,
+  "coprocess_options": {
+    "enable_coprocess": false,
+    "coprocess_grpc_server": ""
+  },
+  "enable_bundle_downloader": true,
+  "bundle_base_url": "",
+  "global_session_lifetime": 100,
+  "force_global_session_lifetime": false,
+  "max_idle_connections_per_host": 500
+}


### PR DESCRIPTION
Uses docker-compose

## Description
A Makefile and some documentation to test goplugins. This is for gateway versions _after_ 2.9.4.1 as prior versions exposed `plugin-build` and will probably not work.

## Related Issue
#3195 

## Motivation and Context
Testing goplugins is cumbersome as it requires a bit of setup and the commands are long and easy to mess up.

## How This Has Been Tested
By hand.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [x] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
