### PR TITLE
Adding a Dockerfile that lets you build from Source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# Start from the latest golang base image
+FROM golang:1.13 as builder
+
+# Set the Current Working Directory inside the container
+WORKDIR /app
+
+# Copy go mod and sum files
+COPY go.mod go.sum ./
+
+# Download all dependencies. Dependencies will be cached if the go.mod and go.sum files are not changed
+RUN go mod download
+
+# Copy the source from the current directory to the Working Directory inside the container
+COPY . .
+
+# Build the Go app
+RUN CGO_ENABLED=0 go build -o tyk .
+
+######## Start a new stage from scratch #######
+FROM debian:buster-slim
+
+RUN apt-get update \
+ && apt-get upgrade -y \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && apt-get autoremove -y \
+ && rm -rf /root/.cache
+
+RUN mkdir -p /opt/tyk-gateway
+WORKDIR /opt/tyk-gateway
+
+# Copy the Pre-built binary file from the previous stage
+COPY --from=builder /app/tyk /opt/tyk-gateway/tyk
+
+## Copy everything else
+COPY templates /opt/tyk-gateway/templates
+COPY coprocess /opt/tyk-gateway/coprocess
+COPY tyk.conf /opt/tyk-gateway/tyk.conf
+
+ENTRYPOINT ["./tyk"]
+
+CMD ["--conf=tyk.conf"]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ simple and does one thing well - protecting your API from unauthorised access.
 
 All the documentation can be found at http://tyk.io/docs/.
 
+### Docker
+
+You can build the Dockerfile from source:
+
+```bash
+docker build -t my-repo/tyk-gateway:v1 .
+```
+
 ### License
 
 Tyk is released under the MPL v2.0; please see [LICENSE.md](LICENSE.md) for a full version of the license.


### PR DESCRIPTION
Adds a new Dockerfile that lets you build Tyk from Source.
Final size: 145 Mb

**Purposes:**

1) This can replace the main package-based official image because it will replace the dependency on packages.  This will allow us to easily build ci/cd pipelines based off commits to master without needing to generate packages for every commit.

2) Allows developers to locally build Docker images based off their forks & modifications for any test purposes