### PR TITLE
Return error If scope is enabled but no match in jwt

### DIFF
--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -456,6 +456,11 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 			mappedPolIDs := mapScopeToPolicies(k.Spec.JWTScopeToPolicyMapping, scope)
 
 			polIDs = append(polIDs, mappedPolIDs...)
+			if len(polIDs) == 0 {
+				k.reportLoginFailure(baseFieldData, r)
+				k.Logger().Error("no matching policy found in scope claim")
+				return errors.New("key not authorized: no matching policy found in scope claim"), http.StatusForbidden
+			}
 
 			// check if we need to update session
 			if !updateSession {


### PR DESCRIPTION
The behavior is like that:
If `Use Scope Claim` is enabled, but it has 0 matches, it will fail. However, if JWT doesn't contain a scope claim, it will use default policy.

In terms of fallback to default policy, It behaves exactly same with `Policy Field Name`. I made them consistent.

Fixes https://github.com/TykTechnologies/tyk/issues/3003