### PR TITLE
[TT-158]Fix panic on /tyk/health endpoint

### DIFF
--- a/gateway/api_healthcheck.go
+++ b/gateway/api_healthcheck.go
@@ -117,7 +117,7 @@ func (h *DefaultHealthChecker) ApiHealthValues() (HealthCheckValues, error) {
 	}
 	var runningTotal int
 	for _, v := range vals {
-		s := string(v.([]byte))
+		s := v.(string)
 		log.Debug("V is: ", s)
 		splitValues := strings.Split(s, ".")
 		if len(splitValues) > 1 {


### PR DESCRIPTION
We changed redis library, which return `string` instead of `[]byte`

<!-- Provide a general summary of your changes in the Title above -->

## Description

This changes type casting of value returned from redis call from `[]byte` which was expected from old redis client to `string` which is from the the new client.

## Related Issue
fixes #3222 

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested
- added api
- called the `/tyk/health` endpoint

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [ ] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
