### PR TITLE
Intersect restricted types when two policies are applied on same key

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -402,16 +402,10 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 						}
 
 						for _, t := range v.RestrictedTypes {
-							found := false
 							for ri, rt := range r.RestrictedTypes {
 								if t.Name == rt.Name {
-									found = true
-									r.RestrictedTypes[ri].Fields = append(rt.Fields, t.Fields...)
+									r.RestrictedTypes[ri].Fields = intersection(rt.Fields, t.Fields)
 								}
-							}
-
-							if !found {
-								r.RestrictedTypes = append(r.RestrictedTypes, v.RestrictedTypes...)
 							}
 						}
 

--- a/gateway/util.go
+++ b/gateway/util.go
@@ -19,6 +19,23 @@ func appendIfMissing(slice []string, newSlice ...string) []string {
 	return slice
 }
 
+// intersection gets intersection of the given two slices.
+func intersection(a []string, b []string) (inter []string) {
+	m := make(map[string]bool)
+
+	for _, item := range a {
+		m[item] = true
+	}
+
+	for _, item := range b {
+		if _, ok := m[item]; ok {
+			inter = append(inter, item)
+		}
+	}
+
+	return
+}
+
 // contains checks whether the given slice contains the given item.
 func contains(s []string, i string) bool {
 	for _, a := range s {


### PR DESCRIPTION
This PR changes logic of restricted types merging when two policies are applied on same key. 
 
Let's say:
- pol1 restrics [ a b c ] 
- pol2 restrics [ c d e]

intersection: [ c ]

Only c will be restricted. [ a b d e ] will be accessible.

Fixes https://github.com/TykTechnologies/tyk/issues/3166