### PR TITLE
[TT-162] Fix JSVM session metadata usage

### DIFF
--- a/gateway/looping_test.go
+++ b/gateway/looping_test.go
@@ -198,7 +198,7 @@ func TestLooping(t *testing.T) {
                 }
                 return TykJsResponse(resp, session.meta_data)
             }
-        `, "POST", "/virt", true)
+        `, "POST", "/virt", true, true)
 
 		ts.Run(t, []test.TestCase{
 			{Method: "POST", Path: "/virt", Data: postAction, BodyMatch: `"Url":"/post_action`},

--- a/gateway/mw_virtual_endpoint.go
+++ b/gateway/mw_virtual_endpoint.go
@@ -43,7 +43,7 @@ type ResponseObject struct {
 
 type VMResponseObject struct {
 	Response    ResponseObject
-	SessionMeta map[string]string
+	SessionMeta map[string]interface{}
 }
 
 // DynamicMiddleware is a generic middleware that will execute JS code before continuing
@@ -226,7 +226,7 @@ func (d *VirtualEndpoint) ServeHTTPForCache(w http.ResponseWriter, r *http.Reque
 
 	// Save the sesison data (if modified)
 	if vmeta.UseSession {
-		newMeta := mapStrsToIfaces(newResponseData.SessionMeta)
+		newMeta := newResponseData.SessionMeta
 		if !reflect.DeepEqual(session.GetMetaData(), newMeta) {
 			session.SetMetaData(newMeta)
 			ctxSetSession(r, session, "", true)


### PR DESCRIPTION
Fix for #3218.

## Description
When `use_session` is enabled, the `SessionMeta` object is expected to contain a content with the following structure:
```json
{"tyk_developer_id":"5f1937ad4ea4611eefb8ede6","tyk_key_request_fields":{},"tyk_user_fields":{}}
```
Because we were previously using `map[string]string`, the key request and user fields break the unmarshalling step.
Using `map[string]interface{}` fixes the issue.

## Related Issue
#3218.


## How This Has Been Tested
Steps described in #3218.

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
