### PR TITLE
Fix trace request builder func

### DIFF
--- a/gateway/tracing_test.go
+++ b/gateway/tracing_test.go
@@ -1,0 +1,26 @@
+package gateway
+
+import (
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTraceHttpRequest_toRequest(t *testing.T) {
+	const body = `{"foo":"bar"}`
+	header := http.Header{}
+	header.Add("key", "value")
+	tr := &traceHttpRequest{Path: "", Method: http.MethodPost, Body: body, Headers: header}
+
+	request, err := tr.toRequest()
+	bodyInBytes, _ := ioutil.ReadAll(request.Body)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.MethodPost, request.Method)
+	assert.Equal(t, "", request.URL.Host)
+	assert.Equal(t, "", request.URL.Path)
+	assert.Equal(t, header, request.Header)
+	assert.Equal(t, string(bodyInBytes), body)
+}


### PR DESCRIPTION
When `tr.Path` was empty, it was giving error. So I change `httptest.NewRequest()` to `http.NewRequest()`.

Fixes https://github.com/TykTechnologies/tyk-analytics/issues/2031