### PR TITLE
Improve query depth limit error with details

### DIFF
--- a/gateway/handler_error.go
+++ b/gateway/handler_error.go
@@ -143,7 +143,7 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 		// If error is not customized write error in default way
 		if errMsg != errCustomBodyResponse.Error() {
 			w.WriteHeader(errCode)
-			apiError := APIError{template.HTML(template.JSEscapeString(errMsg))}
+			apiError := APIError{template.HTML(errMsg)}
 			tmpl.Execute(w, &apiError)
 		}
 	}

--- a/gateway/mw_rate_limiting.go
+++ b/gateway/mw_rate_limiting.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -89,7 +90,7 @@ func (k *RateLimitAndQuotaCheck) ProcessRequest(w http.ResponseWriter, r *http.R
 
 		if complexityRes.Depth > session.MaxQueryDepth {
 			k.Logger().Debugf("Complexity of the request is higher than the allowed limit '%d'", session.MaxQueryDepth)
-			return errors.New("depth limit exceeded"), http.StatusForbidden
+			return errors.New(fmt.Sprintf(`query depth limit exceeded - current: %d > max: %d`, complexityRes.Depth, session.MaxQueryDepth)), http.StatusForbidden
 		}
 	}
 


### PR DESCRIPTION
- In the webinar, it is talked that adding max and current depths to the response: https://www.youtube.com/watch?v=9nF_piFQ-D8

- I removed `template.JSEscapeString`, it was making `>` unreadable. Can removing it break something else ?

Example error response:

```
{
    "error": "query depth limit exceeded - current: 3 > max: 2"
}
```