### PR TITLE
[Fix/TT-225] Not encode and reset RawQuery after JSVM if no change on query params

### DIFF
--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/url"
+	"reflect"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -187,13 +188,13 @@ func (c *CoProcessor) ObjectPostProcess(object *coprocess.Object, r *http.Reques
 		r.Header.Set(h, v)
 	}
 
-	values := r.URL.Query()
+	updatedValues := r.URL.Query()
 	for _, k := range object.Request.DeleteParams {
-		values.Del(k)
+		updatedValues.Del(k)
 	}
 
 	for p, v := range object.Request.AddParams {
-		values.Set(p, v)
+		updatedValues.Set(p, v)
 	}
 
 	parsedURL, err := url.ParseRequestURI(object.Request.Url)
@@ -222,7 +223,9 @@ func (c *CoProcessor) ObjectPostProcess(object *coprocess.Object, r *http.Reques
 		r.Method = object.Request.Method
 	}
 
-	r.URL.RawQuery = values.Encode()
+	if !reflect.DeepEqual(r.URL.Query(), updatedValues) {
+		r.URL.RawQuery = updatedValues.Encode()
+	}
 
 	return
 }

--- a/gateway/mw_js_plugin.go
+++ b/gateway/mw_js_plugin.go
@@ -51,6 +51,28 @@ type MiniRequestObject struct {
 	Scheme          string
 }
 
+func (mr *MiniRequestObject) ReconstructParams(r *http.Request) {
+	updatedValues := r.URL.Query()
+
+	for _, k := range mr.DeleteParams {
+		updatedValues.Del(k)
+	}
+
+	for p, v := range mr.AddParams {
+		updatedValues.Set(p, v)
+	}
+
+	for p, v := range mr.ExtendedParams {
+		for _, val := range v {
+			updatedValues.Add(p, val)
+		}
+	}
+
+	if !reflect.DeepEqual(r.URL.Query(), updatedValues) {
+		r.URL.RawQuery = updatedValues.Encode()
+	}
+}
+
 type VMReturnObject struct {
 	Request     MiniRequestObject
 	SessionMeta map[string]string
@@ -225,26 +247,7 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 	}
 
 	// Delete and set request parameters
-	values := r.URL.Query()
-	updatedValues := r.URL.Query()
-
-	for _, k := range newRequestData.Request.DeleteParams {
-		updatedValues.Del(k)
-	}
-
-	for p, v := range newRequestData.Request.AddParams {
-		updatedValues.Set(p, v)
-	}
-
-	for p, v := range newRequestData.Request.ExtendedParams {
-		for _, val := range v {
-			updatedValues.Add(p, val)
-		}
-	}
-
-	if !reflect.DeepEqual(values, updatedValues) {
-		r.URL.RawQuery = values.Encode()
-	}
+	newRequestData.Request.ReconstructParams(r)
 
 	// Save the session data (if modified)
 	if !d.Pre && d.UseSession {

--- a/gateway/mw_js_plugin_test.go
+++ b/gateway/mw_js_plugin_test.go
@@ -4,11 +4,15 @@ import (
 	"bytes"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"regexp"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/TykTechnologies/tyk/ctx"
 	"github.com/TykTechnologies/tyk/user"
@@ -592,5 +596,30 @@ post.NewProcessRequest(function(request, session) {
 			{Path: "/test", Code: 200, BodyMatch: `"Pre":"foobar"`},
 			{Path: "/test", Code: 200, BodyMatch: `"Post":"foobar"`},
 		}...)
+	})
+}
+
+func TestMiniRequestObject_ReconstructParams(t *testing.T) {
+	const exampleURL = "http://example.com/get?b=1&c=2&a=3"
+	r, _ := http.NewRequest(http.MethodGet, exampleURL, nil)
+	mr := MiniRequestObject{}
+
+	t.Run("Don't touch queries if no change on params", func(t *testing.T) {
+		mr.ReconstructParams(r)
+		assert.Equal(t, exampleURL, r.URL.String())
+	})
+
+	t.Run("Update params", func(t *testing.T) {
+		mr.AddParams = map[string]string{
+			"d": "4",
+		}
+		mr.DeleteParams = append(mr.DeleteHeaders, "b")
+		mr.ReconstructParams(r)
+
+		assert.Equal(t, url.Values{
+			"a": []string{"3"},
+			"c": []string{"2"},
+			"d": []string{"4"},
+		}, r.URL.Query())
 	})
 }


### PR DESCRIPTION
```
url, _ := url.Parse("http://example.com/get?c=1&a=2&b=3&e=4&d=5")
queries := url.Query()
url.RawQuery = queries.Encode()
fmt.Println(url) // http://example.com/get?a=2&b=3&c=1&d=5&e=4
```

As you see in the above example, `Encode()` function sorts by key. The reason why it does this becase `url.Values` is a `map` and setting order is not saved when you iterate. `Encode` function sorts to prevent random results.

The fix is that if there is no change on query params after JSVM, it doesn't make query parsing and encoding and continue with the existing `RawQuery` value.

Fixes https://tyktech.atlassian.net/browse/TT-225