### PR TITLE
[TT-304] fix blocking slave gateway when mdcb is down

### DIFF
--- a/rpc/rpc_client.go
+++ b/rpc/rpc_client.go
@@ -46,6 +46,9 @@ var (
 	rpcConnectMu sync.Mutex
 )
 
+// ErrRPCIsDown this is returned when we can't reach rpc server.
+var ErrRPCIsDown = errors.New("RPCStorageHandler: rpc is either down or ws not configured")
+
 // rpc.Login is callend may places we only need one in flight at a time.
 var loginFlight singleflight.Group
 
@@ -271,16 +274,14 @@ func Connect(connConfig Config, suppressRegister bool, dispatcherFuncs map[strin
 		funcClientSingleton = dispatcher.NewFuncClient(clientSingleton)
 	}
 
-	if !Login() {
-		return false
-	}
+	go Login()
 
 	if !suppressRegister {
 		register()
 		go checkDisconnect()
 	}
 
-	return true
+	return clientIsConnected
 }
 
 // Login tries to login to the rpc sever. Returns true if it succeeds and false
@@ -424,6 +425,9 @@ func recoverOp(fn func() error) func() error {
 }
 
 func FuncClientSingleton(funcName string, request interface{}) (interface{}, error) {
+	if !clientIsConnected {
+		return nil, ErrRPCIsDown
+	}
 	return funcClientSingleton.CallTimeout(funcName, request, GlobalRPCCallTimeout)
 }
 


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
We were calling Login inside rpc.Connect.

The Login call blocks and uses exponential backoff for retries.

We are now calling this in a separate goroutine.

## Related Issue
<!-- This project only accepts pull requests related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
When stating slave gateway and mdcb is down, the startup blocks and the rest of the gw becomes unresponsive.

## How This Has Been Tested
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of
the code, etc. -->
- start dashboard
- start slave gw before starting mdcb

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [ ] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
