### PR TITLE
[TT-221] Move query depth logic to SessionLimiter

### DIFF
--- a/gateway/mw_api_rate_limit.go
+++ b/gateway/mw_api_rate_limit.go
@@ -74,7 +74,7 @@ func (k *RateLimitForAPI) ProcessRequest(w http.ResponseWriter, r *http.Request,
 		true,
 		false,
 		&k.Spec.GlobalConfig,
-		k.Spec.APIID,
+		k.Spec,
 		false,
 	)
 

--- a/gateway/mw_organisation_activity.go
+++ b/gateway/mw_organisation_activity.go
@@ -110,7 +110,7 @@ func (k *OrganizationMonitor) ProcessRequestLive(r *http.Request, orgSession use
 		orgSession.Per > 0 && orgSession.Rate > 0,
 		true,
 		&k.Spec.GlobalConfig,
-		k.Spec.APIID,
+		k.Spec,
 		false,
 	)
 
@@ -241,7 +241,7 @@ func (k *OrganizationMonitor) AllowAccessNext(
 		session.Per > 0 && session.Rate > 0,
 		true,
 		&k.Spec.GlobalConfig,
-		k.Spec.APIID,
+		k.Spec,
 		false,
 	)
 

--- a/gateway/mw_rate_limiting_test.go
+++ b/gateway/mw_rate_limiting_test.go
@@ -4,6 +4,9 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/jensneuse/graphql-go-tools/pkg/graphql"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/TykTechnologies/tyk/headers"
 	"github.com/TykTechnologies/tyk/test"
 	"github.com/TykTechnologies/tyk/user"
@@ -101,4 +104,47 @@ func TestNeverRenewQuota(t *testing.T) {
 		{Headers: authHeader, Code: http.StatusForbidden},
 	}...)
 
+}
+
+func TestDepthLimit(t *testing.T) {
+	g := StartTest()
+	defer g.Close()
+
+	spec := BuildAndLoadAPI(func(spec *APISpec) {
+		spec.UseKeylessAccess = false
+		spec.Proxy.ListenPath = "/"
+		spec.GraphQL.Enabled = true
+	})[0]
+
+	session, key := g.CreateSession(func(s *user.SessionState) {
+		s.MaxQueryDepth = -1
+		s.AccessRights = map[string]user.AccessDefinition{
+			spec.APIID: {
+				APIID:   spec.APIID,
+				APIName: spec.Name,
+				Limit: &user.APILimit{
+					MaxQueryDepth: 1,
+				},
+			},
+		}
+	})
+
+	authHeader := map[string]string{
+		headers.Authorization: key,
+	}
+
+	request := graphql.Request{
+		OperationName: "Query",
+		Variables:     nil,
+		Query:         "query Query { people { name } }",
+	}
+
+	t.Run("Per API", func(t *testing.T) {
+		assert.Equal(t, -1, session.MaxQueryDepth)
+
+		// Although session.MaxQueryDepth is unlimited, it will be ignored because per API level depth value is set.
+		_, _ = g.Run(t, []test.TestCase{
+			{Headers: authHeader, Data: request, BodyMatch: "depth limit exceeded", Code: http.StatusForbidden},
+		}...)
+	})
 }

--- a/gateway/session_manager.go
+++ b/gateway/session_manager.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/jensneuse/graphql-go-tools/pkg/graphql"
+
 	"github.com/TykTechnologies/leakybucket"
 	"github.com/TykTechnologies/leakybucket/memorycache"
 	"github.com/TykTechnologies/tyk/config"
@@ -92,6 +94,8 @@ const (
 	sessionFailNone sessionFailReason = iota
 	sessionFailRateLimit
 	sessionFailQuota
+	sessionFailDepthLimit
+	sessionFailInternalServerError
 )
 
 func (l *SessionLimiter) limitSentinel(currentSession *user.SessionState, key string, rateScope string, store storage.Handler,
@@ -177,13 +181,14 @@ func (sfr sessionFailReason) String() string {
 // sessionFailReason if session limits have been exceeded.
 // Key values to manage rate are Rate and Per, e.g. Rate of 10 messages
 // Per 10 seconds
-func (l *SessionLimiter) ForwardMessage(r *http.Request, currentSession *user.SessionState, key string, store storage.Handler, enableRL, enableQ bool, globalConf *config.Config, apiID string, dryRun bool) sessionFailReason {
+func (l *SessionLimiter) ForwardMessage(r *http.Request, currentSession *user.SessionState, key string, store storage.Handler, enableRL, enableQ bool, globalConf *config.Config, api *APISpec, dryRun bool) sessionFailReason {
 	// check for limit on API level (set to session by ApplyPolicies)
 	var apiLimit *user.APILimit
 	var allowanceScope string
+
 	if len(currentSession.AccessRights) > 0 {
-		if rights, ok := currentSession.AccessRights[apiID]; !ok {
-			log.WithField("apiID", apiID).Debug("[RATE] unexpected apiID")
+		if rights, ok := currentSession.AccessRights[api.APIID]; !ok {
+			log.WithField("apiID", api.APIID).Debug("[RATE] unexpected apiID")
 			return sessionFailRateLimit
 		} else {
 			apiLimit = rights.Limit
@@ -200,6 +205,14 @@ func (l *SessionLimiter) ForwardMessage(r *http.Request, currentSession *user.Se
 			Per:                currentSession.Per,
 			ThrottleInterval:   currentSession.ThrottleInterval,
 			ThrottleRetryLimit: currentSession.ThrottleRetryLimit,
+			MaxQueryDepth:      currentSession.MaxQueryDepth,
+		}
+	}
+
+	// If MaxQueryDepth is -1 or 0, it means unlimited and no need for depth limiting.
+	if api.GraphQL.Enabled && apiLimit.MaxQueryDepth > 0 {
+		if failReason := l.DepthLimitExceeded(r, apiLimit, api.GraphQLExecutor.Schema); failReason != sessionFailNone {
+			return failReason
 		}
 	}
 
@@ -255,6 +268,23 @@ func (l *SessionLimiter) ForwardMessage(r *http.Request, currentSession *user.Se
 
 	return sessionFailNone
 
+}
+
+func (l *SessionLimiter) DepthLimitExceeded(r *http.Request, apiLimit *user.APILimit, schema *graphql.Schema) sessionFailReason {
+	gqlRequest := ctxGetGraphQLRequest(r)
+
+	complexityRes, err := gqlRequest.CalculateComplexity(graphql.DefaultComplexityCalculator, schema)
+	if err != nil {
+		log.Errorf("Error while calculating complexity of GraphQL request: '%s'", err)
+		return sessionFailInternalServerError
+	}
+
+	if complexityRes.Depth > apiLimit.MaxQueryDepth {
+		log.Debugf("Complexity of the request is higher than the allowed limit '%d'", apiLimit.MaxQueryDepth)
+		return sessionFailDepthLimit
+	}
+
+	return sessionFailNone
 }
 
 func (l *SessionLimiter) RedisQuotaExceeded(r *http.Request, currentSession *user.SessionState, scope string, limit *user.APILimit, store storage.Handler) bool {


### PR DESCRIPTION
When per API limit is applied, session global limit values should be ignored. However, it is not working like that for query depth limit. This PR moves the depth limit check inside `ForwardMessage` function to be able to benefit this piece: https://github.com/TykTechnologies/tyk/blob/fafaba25989f2569f4aa02482a338b3210747767/gateway/session_manager.go#L189-L197

Fixes https://tyktech.atlassian.net/browse/TT-221