### PR TITLE
TT-345 make circuit breaker configurable to when to use the half-open-state

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -152,7 +152,7 @@ type CircuitBreakerMeta struct {
 	ThresholdPercent     float64 `bson:"threshold_percent" json:"threshold_percent"`
 	Samples              int64   `bson:"samples" json:"samples"`
 	ReturnToServiceAfter int     `bson:"return_to_service_after" json:"return_to_service_after"`
-	EnableHalfOpenState  bool    `bson:"enable_half_open_state" json:"enable_half_open_state"`
+	DisableHalfOpenState  bool    `bson:"disable_half_open_state" json:"disable_half_open_state"`
 }
 
 type StringRegexMap struct {

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -152,6 +152,7 @@ type CircuitBreakerMeta struct {
 	ThresholdPercent     float64 `bson:"threshold_percent" json:"threshold_percent"`
 	Samples              int64   `bson:"samples" json:"samples"`
 	ReturnToServiceAfter int     `bson:"return_to_service_after" json:"return_to_service_after"`
+	EnableHalfOpenState  bool    `bson:"enable_half_open_state" json:"enable_half_open_state"`
 }
 
 type StringRegexMap struct {

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -152,7 +152,7 @@ type CircuitBreakerMeta struct {
 	ThresholdPercent     float64 `bson:"threshold_percent" json:"threshold_percent"`
 	Samples              int64   `bson:"samples" json:"samples"`
 	ReturnToServiceAfter int     `bson:"return_to_service_after" json:"return_to_service_after"`
-	DisableHalfOpenState  bool    `bson:"disable_half_open_state" json:"disable_half_open_state"`
+	DisableHalfOpenState bool    `bson:"disable_half_open_state" json:"disable_half_open_state"`
 }
 
 type StringRegexMap struct {

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -753,7 +753,7 @@ func (a APIDefinitionLoader) compileCircuitBreakerPathSpec(paths []apidef.Circui
 		newSpec.CircuitBreaker.CB = circuit.NewRateBreaker(stringSpec.ThresholdPercent, stringSpec.Samples)
 
 		// override backoff algorithm when is not desired to recheck the upstream before the ReturnToServiceAfter happens
-		if !stringSpec.EnableHalfOpenState {
+		if stringSpec.DisableHalfOpenState {
 			newSpec.CircuitBreaker.CB.BackOff = &backoff.StopBackOff{}
 		}
 

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/cenk/backoff"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -17,6 +16,8 @@ import (
 	"sync/atomic"
 	"text/template"
 	"time"
+
+	"github.com/cenk/backoff"
 
 	sprig "gopkg.in/Masterminds/sprig.v2"
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
added flag at path-api-level to know when to use halfOpenState in circuit breaker. If not gonna use it, then override the backoff algorithm and use the StopBackoff algorithm

## Related Issue
https://tyktech.atlassian.net/browse/TT-345

## Motivation and Context
Give solution to https://tyktech.atlassian.net/browse/TT-345 and provide a mechanism when the circuit-breaker should not attempt requests to the upstream before the `ReturnToServiceAfter` happens

## How This Has Been Tested
- Ran dumb application with endpoint that everytime returned 500 status code
- Hit the endpoint via GW until the circuit breaker is tripped
- The config for the circuit breaker for this api path looks like:
```
"circuit_breakers" : [ 
                        {
                            "path" : "/err-500",
                            "method" : "GET",
                            "threshold_percent" : 1.0,
                            "samples" : NumberLong(1),
                            "return_to_service_after" : 60,
                            "disable_half_open_state" : false
                        }
                    ],
```
it mean that for the 5xx status code the circuit breaker should be tripped.

- Tested with `disable_half_open_state` in `true` and `false`, if false then the algorithm will be the exponential backoff therefore we will see some requests to the upstream in the meantime, if true then we should not see any request to the upstream until the 60 seconds configured in `return_to_service_after` happens

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [ ] `go vet`
