### PR TITLE
[TT-716] Handle HostDown check when host checker manager isn't initialized

### DIFF
--- a/gateway/host_checker_manager_test.go
+++ b/gateway/host_checker_manager_test.go
@@ -33,8 +33,8 @@ func TestHostCheckerManagerInit(t *testing.T) {
 func TestAmIPolling(t *testing.T) {
 	hc := HostCheckerManager{}
 
-	pooling := hc.AmIPolling()
-	if pooling {
+	polling := hc.AmIPolling()
+	if polling {
 		t.Error("HostCheckerManager storage not configured, it should have failed.")
 	}
 
@@ -51,9 +51,9 @@ func TestAmIPolling(t *testing.T) {
 	hc2 := HostCheckerManager{}
 	hc2.Init(redisStorage)
 
-	pooling = hc.AmIPolling()
-	poolingHc2 := hc2.AmIPolling()
-	if !pooling && poolingHc2 {
+	polling = hc.AmIPolling()
+	pollingHc2 := hc2.AmIPolling()
+	if !polling && pollingHc2 {
 		t.Error("HostCheckerManager storage configured, it shouldn't have failed.")
 	}
 

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -149,6 +149,10 @@ func nextTarget(targetData *apidef.HostList, spec *APISpec) (string, error) {
 			if !spec.Proxy.CheckHostAgainstUptimeTests {
 				return host, nil // we don't care if it's up
 			}
+			// As checked by HostCheckerManager.AmIPolling
+			if GlobalHostChecker.store == nil {
+				return host, nil
+			}
 			if !GlobalHostChecker.HostDown(host) {
 				return host, nil // we do care and it's up
 			}


### PR DESCRIPTION
Workaround for TT-716, using the same check that's performed by `HostCheckerManager.AmIPolling` but excluding any additional behavior.
From the logic that's implemented in `server.go` we don't expect the host checker to be initialized when `disable_management_poller` is set to `true`.
Disabling `check_host_against_uptime_tests` could be a config-level workaround for the issue as well.