### PR TITLE
Uptime tests poller group

### DIFF
--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -934,6 +934,9 @@
         },
         "disable": {
           "type": "boolean"
+        },
+        "poller_group": {
+          "type": "string"
         }
       }
     },

--- a/config/config.go
+++ b/config/config.go
@@ -210,10 +210,10 @@ type UptimeTestsConfigDetail struct {
 }
 
 type UptimeTestsConfig struct {
-	Disable bool                    `json:"disable"`
-	Config  UptimeTestsConfigDetail `json:"config"`
+	Disable     bool                    `json:"disable"`
+	PollerGroup string                  `json:"poller_group"`
+	Config      UptimeTestsConfigDetail `json:"config"`
 }
-
 type ServiceDiscoveryConf struct {
 	DefaultCacheTimeout int `json:"default_cache_timeout"`
 }

--- a/gateway/host_checker_manager.go
+++ b/gateway/host_checker_manager.go
@@ -144,12 +144,17 @@ func (hc *HostCheckerManager) AmIPolling() bool {
 		}).Error("No storage instance set for uptime tests! Disabling poller...")
 		return false
 	}
-	activeInstance, err := hc.store.GetKey(PollerCacheKey)
+	pollerCacheKey := PollerCacheKey
+	if config.Global().UptimeTests.PollerGroup != "" {
+		pollerCacheKey = pollerCacheKey + "." + config.Global().UptimeTests.PollerGroup
+	}
+
+	activeInstance, err := hc.store.GetKey(pollerCacheKey)
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "host-check-mgr",
 		}).Debug("No Primary instance found, assuming control")
-		hc.store.SetKey(PollerCacheKey, hc.Id, 15)
+		hc.store.SetKey(pollerCacheKey, hc.Id, 15)
 		return true
 	}
 
@@ -157,7 +162,7 @@ func (hc *HostCheckerManager) AmIPolling() bool {
 		log.WithFields(logrus.Fields{
 			"prefix": "host-check-mgr",
 		}).Debug("Primary instance set, I am master")
-		hc.store.SetKey(PollerCacheKey, hc.Id, 15) // Reset TTL
+		hc.store.SetKey(pollerCacheKey, hc.Id, 15) // Reset TTL
 		return true
 	}
 

--- a/gateway/host_checker_manager_test.go
+++ b/gateway/host_checker_manager_test.go
@@ -112,8 +112,8 @@ func TestCheckActivePollerLoop(t *testing.T) {
 
 	found := false
 
-	//Giving 5 retries to find the poller active key
-	for i := 0; i < 5; i++ {
+	//Giving 15 retries to find the poller active key
+	for i := 0; i < 15; i++ {
 		activeInstance, err := hc.store.GetKey(PollerCacheKey)
 		if activeInstance == hc.Id && err == nil {
 			found = true

--- a/gateway/host_checker_manager_test.go
+++ b/gateway/host_checker_manager_test.go
@@ -1,0 +1,200 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"testing"
+	"text/template"
+
+	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/storage"
+	uuid "github.com/satori/go.uuid"
+)
+
+func TestHostCheckerManagerInit(t *testing.T) {
+	ts := StartTest()
+	defer ts.Close()
+
+	hc := HostCheckerManager{}
+	redisStorage := &storage.RedisCluster{KeyPrefix: "host-checker:"}
+	hc.Init(redisStorage)
+
+	if hc.Id == "" {
+		t.Error("HostCheckerManager should create an Id on Init")
+	}
+	if hc.unhealthyHostList == nil {
+		t.Error("HostCheckerManager should initialize unhealthyHostList on Init")
+	}
+	if hc.resetsInitiated == nil {
+		t.Error("HostCheckerManager should initialize resetsInitiated on Init")
+	}
+}
+
+func TestAmIPolling(t *testing.T) {
+	hc := HostCheckerManager{}
+
+	polling := hc.AmIPolling()
+	if polling {
+		t.Error("HostCheckerManager storage not configured, it should have failed.")
+	}
+
+	//Testing if we had 2 active host checker managers, only 1 takes control of the uptimechecks
+	globalConf := config.Global()
+	globalConf.UptimeTests.PollerGroup = "TEST"
+	config.SetGlobal(globalConf)
+
+	ts := StartTest()
+	defer ts.Close()
+
+	redisStorage := &storage.RedisCluster{KeyPrefix: "host-checker:"}
+	hc.Init(redisStorage)
+	hc2 := HostCheckerManager{}
+	hc2.Init(redisStorage)
+
+	polling = hc.AmIPolling()
+	pollingHc2 := hc2.AmIPolling()
+	if !polling && pollingHc2 {
+		t.Error("HostCheckerManager storage configured, it shouldn't have failed.")
+	}
+
+	//Testing if the PollerCacheKey contains the poller_group
+	activeInstance, err := hc.store.GetKey("PollerActiveInstanceID.TEST")
+	if err != nil {
+		t.Error("PollerActiveInstanceID.TEST  should exist in redis.", activeInstance)
+	}
+	if activeInstance != hc.Id {
+		t.Error("PollerActiveInstanceID.TEST value should be hc.Id")
+	}
+
+	//Testing if the PollerCacheKey doesn't contains the poller_group by default
+	ResetTestConfig()
+	emptyRedis()
+	hc = HostCheckerManager{}
+
+	redisStorage = &storage.RedisCluster{KeyPrefix: "host-checker:"}
+	hc.Init(redisStorage)
+	hc.AmIPolling()
+
+	activeInstance, err = hc.store.GetKey("PollerActiveInstanceID")
+	if err != nil {
+		t.Error("PollerActiveInstanceID should exist in redis.", activeInstance)
+	}
+	if activeInstance != hc.Id {
+		t.Error("PollerActiveInstanceID value should be hc.Id")
+	}
+}
+
+func TestGenerateCheckerId(t *testing.T) {
+	hc := HostCheckerManager{}
+	hc.GenerateCheckerId()
+	if hc.Id == "" {
+		t.Error("HostCheckerManager should generate an Id on GenerateCheckerId")
+	}
+
+	uuid, _ := uuid.FromString(hc.Id)
+	if uuid.Version() != 4 {
+		t.Error("HostCheckerManager should generate an uuid.v4 id")
+	}
+}
+
+func TestCheckActivePollerLoop(t *testing.T) {
+	ts := StartTest()
+	defer ts.Close()
+	emptyRedis()
+
+	hc := &HostCheckerManager{}
+	redisStorage := &storage.RedisCluster{KeyPrefix: "host-checker:"}
+	hc.Init(redisStorage)
+	//defering the stop of the CheckActivePollerLoop
+	defer func(hc *HostCheckerManager) {
+		hc.stopLoop = true
+	}(hc)
+
+	ctx := context.Background()
+	go hc.CheckActivePollerLoop(ctx)
+
+	found := false
+
+	//Giving 5 retries to find the poller active key
+	for i := 0; i < 5; i++ {
+		activeInstance, err := hc.store.GetKey("PollerActiveInstanceID")
+		if activeInstance == hc.Id && err == nil {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Error("activeInstance should be hc.Id when the CheckActivePollerLoop is running")
+	}
+
+}
+
+func TestStartPoller(t *testing.T) {
+	hc := HostCheckerManager{}
+	ctx := context.Background()
+
+	hc.StartPoller(ctx)
+
+	if hc.checker == nil {
+		t.Error("StartPoller should have initialized the HostUptimeChecker")
+	}
+}
+
+func TestRecordUptimeAnalytics(t *testing.T) {
+	ts := StartTest()
+	defer ts.Close()
+	emptyRedis()
+
+	hc := &HostCheckerManager{}
+	redisStorage := &storage.RedisCluster{KeyPrefix: "host-checker:"}
+	hc.Init(redisStorage)
+
+	specTmpl := template.Must(template.New("spec").Parse(sampleUptimeTestAPI))
+
+	tmplData := struct {
+		Host1, Host2 string
+	}{
+		testHttpFailureAny,
+		testHttpFailureAny,
+	}
+
+	specBuf := &bytes.Buffer{}
+	specTmpl.ExecuteTemplate(specBuf, specTmpl.Name(), &tmplData)
+
+	spec := CreateDefinitionFromString(specBuf.String())
+	spec.UptimeTests.Config.ExpireUptimeAnalyticsAfter = 30
+	apisMu.Lock()
+	apisByID = map[string]*APISpec{spec.APIID: spec}
+	apisMu.Unlock()
+	defer func() {
+		apisMu.Lock()
+		apisByID = make(map[string]*APISpec)
+		apisMu.Unlock()
+	}()
+
+	hostData := HostData{
+		CheckURL: "/test",
+		Method:   http.MethodGet,
+	}
+	report := HostHealthReport{
+		HostData:     hostData,
+		ResponseCode: http.StatusOK,
+		Latency:      10.00,
+		IsTCPError:   false,
+	}
+	report.MetaData = make(map[string]string)
+	report.MetaData[UnHealthyHostMetaDataAPIKey] = spec.APIID
+
+	err := hc.RecordUptimeAnalytics(report)
+	if err != nil {
+		t.Error("RecordUptimeAnalytics shouldn't fail")
+	}
+
+	set, err := hc.store.Exists(UptimeAnalytics_KEYNAME)
+	if err != nil || !set {
+		t.Error("tyk-uptime-analytics should exist in redis.", err)
+	}
+
+}

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -152,6 +152,10 @@ func nextTarget(targetData *apidef.HostList, spec *APISpec) (string, error) {
 			if !spec.Proxy.CheckHostAgainstUptimeTests {
 				return host, nil // we don't care if it's up
 			}
+			// As checked by HostCheckerManager.AmIPolling
+			if GlobalHostChecker.store == nil {
+				return host, nil
+			}
 			if !GlobalHostChecker.HostDown(host) {
 				return host, nil // we do care and it's up
 			}

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -172,9 +172,14 @@ func setupGlobals(ctx context.Context) {
 		mainLog.Fatal("Analytics requires Redis Storage backend, please enable Redis in the tyk.conf file.")
 	}
 
-	// Initialise our Host Checker
-	healthCheckStore := storage.RedisCluster{KeyPrefix: "host-checker:"}
-	InitHostCheckManager(ctx, &healthCheckStore)
+	// Initialise HostCheckerManager only if uptime tests are enabled.
+	if !config.Global().UptimeTests.Disable {
+		if config.Global().ManagementNode {
+			mainLog.Warn("Running Uptime checks in a management node.")
+		}
+		healthCheckStore := storage.RedisCluster{KeyPrefix: "host-checker:"}
+		InitHostCheckManager(ctx, &healthCheckStore)
+	}
 
 	initHealthCheck(ctx)
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
Added new configuration for uptime tests: `poller_group` - string - Adds a postfix to the Poller Cache key. In that way, we can have different pollers for each group.

An example of a config with `poller_group`:
```
 "uptime_tests": {
        "disable": false,
        "poller_group":"external",
        "config": {
            "failure_trigger_sample_size": 1,
            "time_wait": 2,
            "checker_pool_size": 50,
            "enable_uptime_analytics": true
        }
    },
```

Modified `uptime_tests.disable` to be the trigger of the HostCheckerManager. If it is true, the gateway won't be able to become the Host checker manager.
Added some host checker manager unit tests.


## Related Issue
<!-- This project only accepts pull requests related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->
https://tyktech.atlassian.net/browse/TT-496


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
On sharded gateway environments, each shard / node should have their own Poller / Host checker to do the uptimetest of their APIs. For more context, please check https://tyktech.atlassian.net/browse/TT-496


## How This Has Been Tested
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of
the code, etc. -->
Tested with:
2 GWs: poller_group:"a" , db_app_conf_options.node_is_segmented:true and db_app_conf_options.tags:["test"]
1 GWs: poller_group:"b" , db_app_conf_options.node_is_segmented:true and db_app_conf_options.tags:["test-2"]
1 Pump running with uptime tests configured.

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [x] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [x] `go vet`
