### PR TITLE
Go Plugin compiler auto build on release-2.9

### DIFF
--- a/.github/workflows/plugin-compiler.yml
+++ b/.github/workflows/plugin-compiler.yml
@@ -1,0 +1,28 @@
+name: Go plugin compiler
+
+on:
+  push:
+    branches:
+      - as/auto-build-pc
+    tags:
+      - v2.9*
+
+jobs:
+  compiler:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: tykio/tyk-plugin-compiler
+          tag_with_ref: true
+          push: ${{ startsWith(github.ref, 'refs/tags/') }}
+          path: images/plugin-compiler
+          build_args: TYK_GW_TAG=${{ github.event.release.tag_name }}
+          add_git_labels: true

--- a/images/README.md
+++ b/images/README.md
@@ -37,13 +37,19 @@ that goes into the API definition
 
 ## Building the image
 
+The image is built automatically by [Github
+Action](https://github.com/TykTechnologies/tyk/actions?query=workflow%3A%22Go+plugin+compiler).
+There was a [change in paths in
+v2.9.4.1](https://tyk.io/docs/plugins/supported-languages/golang/).
+
 This will build the image that will be used in the plugin build
 step. This section is for only for informational purposes.
 
-In the root of the repo:
+In this directory of the repo:
 
 ``` shell
-docker build --build-arg TYK_GW_TAG=v2.8.4 -t tyk-plugin-build-2.8.4 .
+% docker build --build-arg TYK_GW_TAG=v2.8.4 -t tykio/tyk-plugin-compiler:v2.8.4 plugin-compiler
+% docker push tykio/tyk-plugin-compiler:v2.8.4
 ```
 
 TYK_GW_TAG refers to the _tag_ in github corresponding to a released


### PR DESCRIPTION
Automation exists on master and release-3* branches. This will add it for release-2.9 too.