### PR TITLE
[TT-342] Add redis sentinel password parameter

### DIFF
--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -41,6 +41,9 @@
         "master_name": {
           "type": "string"
         },
+        "sentinel_password": {
+          "type": "string"
+        },
         "optimisation_max_active": {
           "type": "integer"
         },

--- a/config/config.go
+++ b/config/config.go
@@ -83,6 +83,7 @@ type StorageOptionsConf struct {
 	Hosts                 map[string]string `json:"hosts"` // Deprecated: Addrs instead.
 	Addrs                 []string          `json:"addrs"`
 	MasterName            string            `json:"master_name"`
+	SentinelPassword      string            `json:"sentinel_password"`
 	Username              string            `json:"username"`
 	Password              string            `json:"password"`
 	Database              int               `json:"database"`

--- a/storage/redis_cluster.go
+++ b/storage/redis_cluster.go
@@ -185,16 +185,18 @@ func NewRedisClusterPool(isCache bool) redis.UniversalClient {
 
 	var client redis.UniversalClient
 	opts := &redis.UniversalOptions{
-		Addrs:        getRedisAddrs(cfg),
-		MasterName:   cfg.MasterName,
-		Password:     cfg.Password,
-		DB:           cfg.Database,
-		DialTimeout:  timeout,
-		ReadTimeout:  timeout,
-		WriteTimeout: timeout,
-		IdleTimeout:  240 * timeout,
-		PoolSize:     poolSize,
-		TLSConfig:    tlsConfig,
+		Addrs:            getRedisAddrs(cfg),
+		MasterName:       cfg.MasterName,
+		SentinelPassword: cfg.SentinelPassword,
+		Username:         cfg.Username,
+		Password:         cfg.Password,
+		DB:               cfg.Database,
+		DialTimeout:      timeout,
+		ReadTimeout:      timeout,
+		WriteTimeout:     timeout,
+		IdleTimeout:      240 * timeout,
+		PoolSize:         poolSize,
+		TLSConfig:        tlsConfig,
 	}
 
 	if opts.MasterName != "" {


### PR DESCRIPTION
- Adds new global config parameter `sentinel_password` for sentinel clients.
- Adds missing `Username` and `SentinelPassword` in Redis client configuration.