### PR TITLE
remove deprecated optimisations_use_async_session_write (TT-580)

### DIFF
--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -716,15 +716,6 @@
     "oauth_error_status_code": {
       "type": "integer"
     },
-    "optimisations_use_async_session_write": {
-      "type": "boolean"
-    },
-    "session_update_pool_size": {
-      "type": "integer"
-    },
-    "session_update_buffer_size": {
-      "type": "integer"
-    },
     "pid_file_location": {
       "type": "string"
     },

--- a/config/config.go
+++ b/config/config.go
@@ -324,7 +324,6 @@ type Config struct {
 	HttpServerOptions         HttpServerOptionsConfig `json:"http_server_options"`
 	ReloadWaitTime            int                     `bson:"reload_wait_time" json:"reload_wait_time"`
 	VersionHeader             string                  `json:"version_header"`
-	UseAsyncSessionWrite      bool                    `json:"optimisations_use_async_session_write"`
 	SuppressRedisSignalReload bool                    `json:"suppress_redis_signal_reload"`
 
 	// Gateway Security Policies

--- a/config/config.go
+++ b/config/config.go
@@ -454,8 +454,6 @@ type Config struct {
 	EventTriggersDefunct map[apidef.TykEvent][]TykEventHandler `json:"event_triggers_defunct"` // Deprecated: Config.GetEventTriggers instead.
 
 	// TODO: These config options are not documented - What do they do?
-	SessionUpdatePoolSize          int   `json:"session_update_pool_size"`
-	SessionUpdateBufferSize        int   `json:"session_update_buffer_size"`
 	SupressDefaultOrgStore         bool  `json:"suppress_default_org_store"`
 	LegacyEnableAllowanceCountdown bool  `bson:"legacy_enable_allowance_countdown" json:"legacy_enable_allowance_countdown"`
 	GlobalSessionLifetime          int64 `bson:"global_session_lifetime" json:"global_session_lifetime"`

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -953,33 +953,6 @@ func TestListenPathTykPrefix(t *testing.T) {
 	})
 }
 
-func TestReloadGoroutineLeakWithAsyncWrites(t *testing.T) {
-	ts := StartTest()
-	defer ts.Close()
-
-	globalConf := config.Global()
-	globalConf.UseAsyncSessionWrite = true
-	globalConf.EnableJSVM = false
-	config.SetGlobal(globalConf)
-	defer ResetTestConfig()
-
-	specs := BuildAndLoadAPI(func(spec *APISpec) {
-		spec.Proxy.ListenPath = "/"
-	})
-
-	before := runtime.NumGoroutine()
-
-	LoadAPI(specs...) // just doing DoReload() doesn't load anything as BuildAndLoadAPI cleans up folder with API specs
-
-	time.Sleep(100 * time.Millisecond)
-
-	after := runtime.NumGoroutine()
-
-	if before < after {
-		t.Errorf("Goroutine leak, was: %d, after reload: %d", before, after)
-	}
-}
-
 func TestReloadGoroutineLeakWithCircuitBreaker(t *testing.T) {
 	ts := StartTest()
 	defer ts.Close()

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -1295,15 +1295,6 @@ func Start() {
 		analytics.Stop()
 	}
 
-	// if using async session writes stop workers
-	if config.Global().UseAsyncSessionWrite {
-		DefaultOrgStore.Stop()
-		for i := range apiSpecs {
-			apiSpecs[i].StopSessionManagerPool()
-		}
-
-	}
-
 	// write pprof profiles
 	writeProfiles()
 

--- a/install/data/tyk.self_contained.conf
+++ b/install/data/tyk.self_contained.conf
@@ -34,7 +34,6 @@
     "enabled": false,
     "ttl": 3600
   },
-  "optimisations_use_async_session_write": true,
   "allow_master_keys": false,
   "policies": {
     "policy_source": "file",

--- a/install/data/tyk.with_dash.conf
+++ b/install/data/tyk.with_dash.conf
@@ -44,7 +44,6 @@
     "enabled": false,
     "ttl": 3600
   },
-  "optimisations_use_async_session_write": true,
   "allow_master_keys": false,
   "policies": {
     "policy_source": "service",

--- a/tyk.conf.example
+++ b/tyk.conf.example
@@ -26,7 +26,6 @@
     "ttl": 3600,
     "check_interval": 60
   },
-  "optimisations_use_async_session_write": true,
   "allow_master_keys": false,
   "policies": {
     "policy_source": "file"


### PR DESCRIPTION
This PR removes the deprecated `optimisations_use_async_session_write` config flag and its functionality.

## Related Issue
https://tyktech.atlassian.net/browse/TT-580

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring or add test (improvements in base code or adds test coverage to functionality)