### PR TITLE
 Remove deprecated api auth field from requireds

### DIFF
--- a/apidef/schema.go
+++ b/apidef/schema.go
@@ -515,7 +515,6 @@ const Schema = `{
 		}
     },
     "required": [
-        "auth",
         "name",
         "proxy",
         "version_data"


### PR DESCRIPTION
`auth` field had been deprecated with `auth_configs`