### PR TITLE
[TT-1264] Go response plugins

### DIFF
--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -240,6 +240,7 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 		fixFuncPath(prefix, mwPreFuncs)
 		fixFuncPath(prefix, mwPostFuncs)
 		fixFuncPath(prefix, mwPostAuthCheckFuncs)
+		//TODO: add bundle support go go response hook i.e. fixFuncPath(prefix,mwResponseFuncs)
 		// TODO: add mwResponseFuncs here when Golang response custom MW support implemented
 	}
 

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -240,8 +240,7 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 		fixFuncPath(prefix, mwPreFuncs)
 		fixFuncPath(prefix, mwPostFuncs)
 		fixFuncPath(prefix, mwPostAuthCheckFuncs)
-		//TODO: add bundle support go go response hook i.e. fixFuncPath(prefix,mwResponseFuncs)
-		// TODO: add mwResponseFuncs here when Golang response custom MW support implemented
+		fixFuncPath(prefix, mwResponseFuncs)
 	}
 
 	if spec.GraphQL.GraphQLPlayground.Enabled {

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -812,7 +812,11 @@ func responseProcessorByName(name string) TykResponseHandler {
 		return &HeaderTransform{}
 	case "custom_mw_res_hook":
 		return &CustomMiddlewareResponseHook{}
+	case "go_plugin_res_hook":
+		return &ResponseGoPluginMiddleware{}
+
 	}
+
 	return nil
 }
 

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -812,7 +812,7 @@ func responseProcessorByName(name string) TykResponseHandler {
 		return &HeaderTransform{}
 	case "custom_mw_res_hook":
 		return &CustomMiddlewareResponseHook{}
-	case "go_plugin_res_hook":
+	case "goplugin_res_hook":
 		return &ResponseGoPluginMiddleware{}
 
 	}

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -800,6 +800,11 @@ type TykResponseHandler interface {
 	HandleError(http.ResponseWriter, *http.Request)
 }
 
+type TykGoPluginResponseHandler interface {
+	TykResponseHandler
+	HandleGoPluginResponse(http.ResponseWriter, *http.Response, *http.Request) error
+}
+
 func responseProcessorByName(name string) TykResponseHandler {
 	switch name {
 	case "header_injector":

--- a/gateway/oauth_manager.go
+++ b/gateway/oauth_manager.go
@@ -6,13 +6,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/TykTechnologies/tyk/request"
-	"github.com/sirupsen/logrus"
 	"math"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/TykTechnologies/tyk/request"
+	"github.com/sirupsen/logrus"
 
 	"github.com/lonelycode/osin"
 	uuid "github.com/satori/go.uuid"

--- a/gateway/res_handler_go_plugin.go
+++ b/gateway/res_handler_go_plugin.go
@@ -1,0 +1,112 @@
+package gateway
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/TykTechnologies/tyk/goplugin"
+	"github.com/TykTechnologies/tyk/user"
+	"github.com/sirupsen/logrus"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+type ResponseGoPluginMiddleware struct {
+	Path       string // path to .so file
+	SymbolName string // function symbol to look up
+	logger     *logrus.Entry
+	Spec       *APISpec
+	ResHandler func(rw http.ResponseWriter, res *http.Response, req *http.Request, ses *user.SessionState)
+}
+
+func (ResponseGoPluginMiddleware) Name() string {
+	return "ResponseGoPluginMiddleware"
+}
+
+func (h *ResponseGoPluginMiddleware) Init(c interface{}, spec *APISpec) error {
+
+	h.logger = log.WithFields(logrus.Fields{
+		"mwPath":       h.Path,
+		"mwSymbolName": h.SymbolName,
+	})
+
+	if h.ResHandler != nil {
+		h.logger.Info("Go-plugin middleware is already initialized")
+		// noop
+		return nil
+	}
+
+	// try to load plugin
+	var err error
+	if h.ResHandler, err = goplugin.GetResponseHandler(h.Path, h.SymbolName); err != nil {
+		h.logger.WithError(err).Error("Could not load Go-plugin")
+		return err
+	}
+
+	return nil
+}
+
+func (h *ResponseGoPluginMiddleware) HandleError(rw http.ResponseWriter, req *http.Request) {
+}
+
+func (h *ResponseGoPluginMiddleware) HandleResponse(w http.ResponseWriter, res *http.Response, req *http.Request, ses *user.SessionState) error {
+	// make sure tyk recover in case Go-plugin function panics
+	defer func() {
+		if e := recover(); e != nil {
+			err := fmt.Errorf("%v", e)
+			w.WriteHeader(http.StatusInternalServerError)
+			h.logger.WithError(err).Error("Recovered from panic while running Go-plugin middleware func")
+		}
+	}()
+
+	// make sure response body can be re-read again
+	nopCloseResponseBody(res)
+
+	// decompress body if needed before handing to plugin
+	respBody := respBodyReader(req, res)
+	defer respBody.Close()
+
+	res.Body = respBody
+
+	// wrap ResponseWriter to check if response was sent
+	rw := &customResponseWriter{
+		ResponseWriter: w,
+		copyData:       recordDetail(req, h.Spec),
+	}
+
+	// call Go-plugin function
+	t1 := time.Now()
+
+	h.ResHandler(rw, res, req, ses)
+
+	// calculate latency
+	ms := DurationToMillisecond(time.Since(t1))
+	h.logger.WithField("ms", ms).Debug("Go-plugin response processing took")
+
+	// check if response was sent
+	if rw.responseSent {
+		// check if response code was an error one
+		switch {
+		case rw.statusCodeSent >= http.StatusBadRequest:
+			// base middleware will report this error to analytics if needed
+			w.WriteHeader(rw.statusCodeSent)
+			err := fmt.Errorf("plugin function sent error response code: %d", rw.statusCodeSent)
+			h.logger.WithError(err).Error("Returned error code while processing response with Go-plugin middleware func")
+
+		}
+	} else {
+		w.WriteHeader(http.StatusOK)
+	}
+
+	var bodyBuffer bytes.Buffer
+
+	// Re-compress if original upstream response was compressed
+	encoding := res.Header.Get("Content-Encoding")
+	bodyBuffer = compressBuffer(bodyBuffer, encoding)
+
+	res.ContentLength = int64(bodyBuffer.Len())
+	res.Header.Set("Content-Length", strconv.Itoa(bodyBuffer.Len()))
+	res.Body = ioutil.NopCloser(&bodyBuffer)
+	return nil
+}

--- a/gateway/res_handler_go_plugin.go
+++ b/gateway/res_handler_go_plugin.go
@@ -2,12 +2,13 @@ package gateway
 
 import (
 	"fmt"
+	"net/http"
+	"time"
+
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/goplugin"
 	"github.com/TykTechnologies/tyk/user"
 	"github.com/sirupsen/logrus"
-	"net/http"
-	"time"
 )
 
 type ResponseGoPluginMiddleware struct {

--- a/gateway/res_handler_go_plugin.go
+++ b/gateway/res_handler_go_plugin.go
@@ -15,7 +15,7 @@ type ResponseGoPluginMiddleware struct {
 	SymbolName string // function symbol to look up
 	logger     *logrus.Entry
 	Spec       *APISpec
-	ResHandler func(rw http.ResponseWriter, res *http.Response, req *http.Request, ses *user.SessionState)
+	ResHandler func(rw http.ResponseWriter, res *http.Response, req *http.Request)
 }
 
 func (ResponseGoPluginMiddleware) Name() string {
@@ -50,9 +50,14 @@ func (h *ResponseGoPluginMiddleware) Init(c interface{}, spec *APISpec) error {
 }
 
 func (h *ResponseGoPluginMiddleware) HandleError(rw http.ResponseWriter, req *http.Request) {
+	//noop
 }
 
 func (h *ResponseGoPluginMiddleware) HandleResponse(w http.ResponseWriter, res *http.Response, req *http.Request, ses *user.SessionState) error {
+	return nil
+}
+
+func (h *ResponseGoPluginMiddleware) HandleGoPluginResponse(w http.ResponseWriter, res *http.Response, req *http.Request) error {
 	// make sure tyk recover in case Go-plugin function panics
 	defer func() {
 		if e := recover(); e != nil {
@@ -72,7 +77,7 @@ func (h *ResponseGoPluginMiddleware) HandleResponse(w http.ResponseWriter, res *
 	// call Go-plugin function
 	t1 := time.Now()
 
-	h.ResHandler(rw, res, req, ses)
+	h.ResHandler(rw, res, req)
 
 	// calculate latency
 	ms := DurationToMillisecond(time.Since(t1))

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -655,12 +655,20 @@ func createResponseMiddlewareChain(spec *APISpec, responseFuncs []apidef.Middlew
 	}
 
 	for _, mw := range responseFuncs {
-		processor := responseProcessorByName("custom_mw_res_hook")
+		var processor TykResponseHandler
+		//is it goplugin or other middleware
+		if strings.HasSuffix(mw.Path, ".so") {
+			processor = responseProcessorByName("goplugin_res_hook")
+		} else {
+			processor = responseProcessorByName("custom_mw_res_hook")
+		}
+
 		// TODO: perhaps error when plugin support is disabled?
 		if processor == nil {
 			mainLog.Error("Couldn't find custom middleware processor")
 			return
 		}
+
 		if err := processor.Init(mw, spec); err != nil {
 			mainLog.Debug("Failed to init processor: ", err)
 		}

--- a/goplugin/goplugin.go
+++ b/goplugin/goplugin.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"net/http"
 	"plugin"
+
+	"github.com/TykTechnologies/tyk/user"
 )
 
 func GetHandler(path string, symbol string) (http.HandlerFunc, error) {
@@ -28,4 +30,26 @@ func GetHandler(path string, symbol string) (http.HandlerFunc, error) {
 	}
 
 	return pluginHandler, nil
+}
+
+func GetResponseHandler(path string, symbol string) (func(rw http.ResponseWriter, res *http.Response, req *http.Request, ses *user.SessionState), error) {
+	// try to load plugin
+	loadedPlugin, err := plugin.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// try to lookup function symbol
+	funcSymbol, err := loadedPlugin.Lookup(symbol)
+	if err != nil {
+		return nil, err
+	}
+
+	// try to cast symbol to real func
+	respPluginHandler, ok := funcSymbol.(func(rw http.ResponseWriter, res *http.Response, req *http.Request, ses *user.SessionState))
+	if !ok {
+		return nil, errors.New("could not cast function symbol to TykResponseHandler")
+	}
+
+	return respPluginHandler, nil
 }

--- a/goplugin/goplugin.go
+++ b/goplugin/goplugin.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"net/http"
 	"plugin"
-
-	"github.com/TykTechnologies/tyk/user"
 )
 
 func GetHandler(path string, symbol string) (http.HandlerFunc, error) {
@@ -32,7 +30,7 @@ func GetHandler(path string, symbol string) (http.HandlerFunc, error) {
 	return pluginHandler, nil
 }
 
-func GetResponseHandler(path string, symbol string) (func(rw http.ResponseWriter, res *http.Response, req *http.Request, ses *user.SessionState), error) {
+func GetResponseHandler(path string, symbol string) (func(rw http.ResponseWriter, res *http.Response, req *http.Request), error) {
 	// try to load plugin
 	loadedPlugin, err := plugin.Open(path)
 	if err != nil {
@@ -46,7 +44,7 @@ func GetResponseHandler(path string, symbol string) (func(rw http.ResponseWriter
 	}
 
 	// try to cast symbol to real func
-	respPluginHandler, ok := funcSymbol.(func(rw http.ResponseWriter, res *http.Response, req *http.Request, ses *user.SessionState))
+	respPluginHandler, ok := funcSymbol.(func(rw http.ResponseWriter, res *http.Response, req *http.Request))
 	if !ok {
 		return nil, errors.New("could not cast function symbol to TykResponseHandler")
 	}

--- a/goplugin/mw_go_plugin_test.go
+++ b/goplugin/mw_go_plugin_test.go
@@ -20,6 +20,8 @@ func TestMain(m *testing.M) {
 
 // TestGoPluginMWs tests all possible Go-plugin MWs ("pre", "auth_check", "post_key_auth" and "post")
 // Please see ./test/goplugins/test_goplugin.go for plugin implementation details
+
+// run go build -buildmode=plugin -o goplugins.so in ./test/goplugins directory prior to running tests
 func TestGoPluginMWs(t *testing.T) {
 	ts := gateway.StartTest()
 	defer ts.Close()
@@ -35,31 +37,25 @@ func TestGoPluginMWs(t *testing.T) {
 			Pre: []apidef.MiddlewareDefinition{
 				{
 					Name: "MyPluginPre",
-					Path: "../test/goplugins/test_goplugin.go",
+					Path: "../test/goplugins/goplugins.so",
 				},
 			},
 			AuthCheck: apidef.MiddlewareDefinition{
 				Name: "MyPluginAuthCheck",
-				Path: "../test/goplugins/test_goplugin.go",
+				Path: "../test/goplugins/goplugins.so",
 			},
 			PostKeyAuth: []apidef.MiddlewareDefinition{
 				{
 					Name: "MyPluginPostKeyAuth",
-					Path: "../test/goplugins/test_goplugin.go",
+					Path: "../test/goplugins/goplugins.so",
 				},
 			},
 			Post: []apidef.MiddlewareDefinition{
 				{
 					Name: "MyPluginPost",
-					Path: "../test/goplugins/test_goplugin.go",
+					Path: "../test/goplugins/goplugins.so",
 				},
 			},
-			//Response: []apidef.MiddlewareDefinition{
-			//	{
-			//		Name: "MyPluginResponse",
-			//		Path: "../test/goplugins/test_goplugin.go",
-			//	},
-			//},
 		}
 	})
 
@@ -85,10 +81,9 @@ func TestGoPluginMWs(t *testing.T) {
 				Headers: map[string]string{"Authorization": "abc"},
 				Code:    http.StatusOK,
 				HeadersMatch: map[string]string{
-					"X-Initial-URI":    "/goplugin/plugin_hit",
-					"X-Auth-Result":    "OK",
-					"X-Session-Alias":  "abc-session",
-					"X-Response-Added": "resp-added",
+					"X-Initial-URI":   "/goplugin/plugin_hit",
+					"X-Auth-Result":   "OK",
+					"X-Session-Alias": "abc-session",
 				},
 				BodyMatch: `"message":"post message"`,
 			},
@@ -98,6 +93,44 @@ func TestGoPluginMWs(t *testing.T) {
 				AdminAuth: true,
 				Code:      http.StatusOK,
 				BodyMatch: `"action":"deleted"`},
+		}...)
+	})
+}
+
+func TestGoPluginResponseHook(t *testing.T) {
+	ts := gateway.StartTest()
+	defer ts.Close()
+
+	gateway.BuildAndLoadAPI(func(spec *gateway.APISpec) {
+		spec.APIID = "plugin_api"
+		spec.Proxy.ListenPath = "/goplugin"
+		spec.UseKeylessAccess = true
+		spec.UseStandardAuth = false
+		spec.UseGoPluginAuth = false
+		spec.CustomMiddleware = apidef.MiddlewareSection{
+			Driver: apidef.GoPluginDriver,
+			Response: []apidef.MiddlewareDefinition{
+				{
+					Name: "MyPluginResponse",
+					Path: "../test/goplugins/goplugins.so",
+				},
+			},
+		}
+	})
+
+	time.Sleep(1 * time.Second)
+
+	t.Run("Run Go-plugin all middle-wares", func(t *testing.T) {
+		ts.Run(t, []test.TestCase{
+			{
+				Path:    "/goplugin/plugin_hit",
+				Headers: map[string]string{"Authorization": "abc"},
+				Code:    http.StatusOK,
+				HeadersMatch: map[string]string{
+					"X-Response-Added": "resp-added",
+				},
+				BodyMatch: `{"message":"response injected message"}`,
+			},
 		}...)
 	})
 }

--- a/goplugin/mw_go_plugin_test.go
+++ b/goplugin/mw_go_plugin_test.go
@@ -19,7 +19,7 @@ func TestMain(m *testing.M) {
 }
 
 // TestGoPluginMWs tests all possible Go-plugin MWs ("pre", "auth_check", "post_key_auth" and "post")
-// Please see ./test/goplugins/test_goplugins.go for plugin implementation details
+// Please see ./test/goplugins/test_goplugin.go for plugin implementation details
 func TestGoPluginMWs(t *testing.T) {
 	ts := gateway.StartTest()
 	defer ts.Close()
@@ -35,25 +35,31 @@ func TestGoPluginMWs(t *testing.T) {
 			Pre: []apidef.MiddlewareDefinition{
 				{
 					Name: "MyPluginPre",
-					Path: "../test/goplugins/goplugins.so",
+					Path: "../test/goplugins/test_goplugin.go",
 				},
 			},
 			AuthCheck: apidef.MiddlewareDefinition{
 				Name: "MyPluginAuthCheck",
-				Path: "../test/goplugins/goplugins.so",
+				Path: "../test/goplugins/test_goplugin.go",
 			},
 			PostKeyAuth: []apidef.MiddlewareDefinition{
 				{
 					Name: "MyPluginPostKeyAuth",
-					Path: "../test/goplugins/goplugins.so",
+					Path: "../test/goplugins/test_goplugin.go",
 				},
 			},
 			Post: []apidef.MiddlewareDefinition{
 				{
 					Name: "MyPluginPost",
-					Path: "../test/goplugins/goplugins.so",
+					Path: "../test/goplugins/test_goplugin.go",
 				},
 			},
+			//Response: []apidef.MiddlewareDefinition{
+			//	{
+			//		Name: "MyPluginResponse",
+			//		Path: "../test/goplugins/test_goplugin.go",
+			//	},
+			//},
 		}
 	})
 
@@ -79,9 +85,10 @@ func TestGoPluginMWs(t *testing.T) {
 				Headers: map[string]string{"Authorization": "abc"},
 				Code:    http.StatusOK,
 				HeadersMatch: map[string]string{
-					"X-Initial-URI":   "/goplugin/plugin_hit",
-					"X-Auth-Result":   "OK",
-					"X-Session-Alias": "abc-session",
+					"X-Initial-URI":    "/goplugin/plugin_hit",
+					"X-Auth-Result":    "OK",
+					"X-Session-Alias":  "abc-session",
+					"X-Response-Added": "resp-added",
 				},
 				BodyMatch: `"message":"post message"`,
 			},

--- a/goplugin/no_goplugin.go
+++ b/goplugin/no_goplugin.go
@@ -4,9 +4,14 @@ package goplugin
 
 import (
 	"fmt"
+	"github.com/TykTechnologies/tyk/user"
 	"net/http"
 )
 
 func GetHandler(path string, symbol string) (http.HandlerFunc, error) {
 	return nil, fmt.Errorf("goplugin.GetHandler is disabled, please disable build flag 'nogoplugin'")
+}
+
+func GetResponseHandler(path string, symbol string) (func(rw http.ResponseWriter, res *http.Response, req *http.Request, ses *user.SessionState), error) {
+	return nil, fmt.Errorf("goplugin.GetResponseHandler is disabled, please disable build flag 'nogoplugin'")
 }

--- a/goplugin/no_goplugin.go
+++ b/goplugin/no_goplugin.go
@@ -4,7 +4,6 @@ package goplugin
 
 import (
 	"fmt"
-	"github.com/TykTechnologies/tyk/user"
 	"net/http"
 )
 
@@ -12,6 +11,6 @@ func GetHandler(path string, symbol string) (http.HandlerFunc, error) {
 	return nil, fmt.Errorf("goplugin.GetHandler is disabled, please disable build flag 'nogoplugin'")
 }
 
-func GetResponseHandler(path string, symbol string) (func(rw http.ResponseWriter, res *http.Response, req *http.Request, ses *user.SessionState), error) {
+func GetResponseHandler(path string, symbol string) (func(rw http.ResponseWriter, res *http.Response, req *http.Request), error) {
 	return nil, fmt.Errorf("goplugin.GetResponseHandler is disabled, please disable build flag 'nogoplugin'")
 }

--- a/test/goplugins/test_goplugin.go
+++ b/test/goplugins/test_goplugin.go
@@ -76,7 +76,7 @@ func MyPluginPost(rw http.ResponseWriter, r *http.Request) {
 }
 
 // MyPluginResponse intercepts response from upstream which we can then manipulate
-func MyPluginResponse(rw http.ResponseWriter, res *http.Response, req *http.Request, ses *user.SessionState) {
+func MyPluginResponse(rw http.ResponseWriter, res *http.Response, req *http.Request) {
 
 	res.Header.Add("X-Response-Added", "resp-added")
 


### PR DESCRIPTION
## Description

Go plugins in Tyk kick ass. However we are missing a way to hook into the return round trip. This PR solves this by providing a response hook for Go plugins 🎉 

## Related Issue
<!-- This project only accepts pull requests related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->

## Motivation and Context

Completes the current picture for hook in points for native go plugin support. The most performant and convenient way to extend Tyk Gateway functionality.

## How This Has Been Tested

Unit tests included.

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [x] My change requires a change to the documentation.
  - [x] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [x] I have updated the documentation accordingly.
- [ x] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [] When updating library version must provide reason/explanation for this update.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`

Docs [WIP]:

### Loading a Golang response plugin

Now we need to instruct Tyk to load this shared library for an API so it will start processing traffic as part of the middleware chain. To do so we will need to edit our API spec using the raw JSON editor in the Tyk Dashboard or directly in the JSON file (in the case of the Community Edition). This change needs to be done for the `"custom_middleware"` field and it should look like this:

```{.json}
"custom_middleware": {
  "pre": [],
  "post_key_auth": [],
  "auth_check": {},
  "post": [],
  "response": [
    {
      "name": "MyResponsePlugin",
      "path": "<path>/resplugin.so"
    }
  ],
  "driver": "goplugin"
}
```

Here we have:

* `"driver"` - Set this to `goplugin` (no value created for this plugin) which says to Tyk that this custom middleware is a Golang native plugin.
* `"post"` - This is the hook name. We use middleware with hook type `response` because we want this custom middleware to process the request on its return leg of a round trip.
* `post.name` - is your function name from the go plugin project.
* `post.path` - is the full or relative (to the Tyk binary) path to `.so` file with plugin implementation (make sure Tyk has read access to this file)

### Response plugin method signature

To write a response plugin in Go you need it to have a method signature like in the example below. You can then access  and modify any part of the request, response and session (i.e. API key state) from the plugins.

```
package main

import (
	"bytes"
	"encoding/json"
	"io/ioutil"
	"net/http"

	"github.com/TykTechnologies/tyk/user"
)

// MyPluginResponse intercepts response from upstream 
func MyPluginResponse(rw http.ResponseWriter, res *http.Response, req *http.Request) {
        // add a header to our response object
	res.Header.Add("X-Response-Added", "resp-added")

        // overwrite our response body
	var buf bytes.Buffer
	buf.Write([]byte(`{"message":"Hi! I'm a response plugin"}`))
	res.Body = ioutil.NopCloser(&buf)

}

func main() {}
```



