### PR TITLE
[TT-936] support error templates for text/xml

### DIFF
--- a/gateway/handler_error.go
+++ b/gateway/handler_error.go
@@ -107,6 +107,9 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 		case headers.ApplicationXML:
 			templateExtension = "xml"
 			contentType = headers.ApplicationXML
+		case headers.TextXML:
+			templateExtension = "xml"
+			contentType = headers.TextXML
 		default:
 			templateExtension = "json"
 			contentType = headers.ApplicationJSON

--- a/gateway/handler_error_test.go
+++ b/gateway/handler_error_test.go
@@ -1,0 +1,53 @@
+package gateway
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/headers"
+	"github.com/TykTechnologies/tyk/test"
+)
+
+func TestHandleError_text_xml(t *testing.T) {
+	file := filepath.Join(config.Global().TemplatePath, "error_500.xml")
+	xml := `<error>
+	<code>500</code>
+	<message>{{.Message}}</message>
+</error>`
+	err := ioutil.WriteFile(file, []byte(xml), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(file)
+	expect := `
+<error>
+	<code>500</code>
+	<message>There was a problem proxying the request</message>
+</error>
+	`
+	ts := StartTest()
+	defer ts.Close()
+	h := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	h.Close()
+	BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/"
+		spec.Proxy.TargetURL = ts.URL
+	})
+	ts.Run(t, test.TestCase{
+		Path: "/",
+		Code: http.StatusInternalServerError,
+		Headers: map[string]string{
+			headers.ContentType: headers.TextXML,
+		},
+		BodyMatchFunc: func(b []byte) bool {
+			return strings.TrimSpace(expect) == string(bytes.TrimSpace(b))
+		},
+	})
+}

--- a/headers/headers.go
+++ b/headers/headers.go
@@ -20,6 +20,7 @@ const (
 	TykHookshot     = "Tyk-Hookshot"
 	ApplicationJSON = "application/json"
 	ApplicationXML  = "application/xml"
+	TextXML         = "text/xml"
 )
 
 const (


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
Tyk supports custom templates for rendering errors. We support content type `application/json` and `application/xml` however there are two `xml` content types `application/xml` and `text/xml`. 

When making a request with `text/xml` tyke will render the default `application/json` template because it fails to acknowlege `text/xml`

## Description
<!-- Describe your changes in detail -->
This makes tyk identify `text/xml`  and use `.xml` extension to search for error templates.

## Related Issue

https://tyktech.atlassian.net/browse/TT-936?atlOrigin=eyJpIjoiNDk3ODI0MTNjYjhlNGRjZGEzMjAwNGYzZGY0MmZkNDIiLCJwIjoiaiJ9

## Motivation and Context

This ensures we render `xml` error templates for `text/xml` requests.

## How This Has Been Tested
Unit test included 

```shell
go test -v -run TestHandleError_text_xml ./gateway/
```

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
