### PR TITLE
Fix TT-1311

### DIFF
--- a/certs/go.mod
+++ b/certs/go.mod
@@ -5,4 +5,5 @@ go 1.12
 require (
 	github.com/pmylund/go-cache v2.1.0+incompatible
 	github.com/sirupsen/logrus v1.4.2
+	github.com/stretchr/testify v1.2.2
 )

--- a/certs/go.sum
+++ b/certs/go.sum
@@ -1,12 +1,17 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmylund/go-cache v2.1.0+incompatible h1:n+7K51jLz6a3sCvff3BppuCAkixuDHuJ/C57Vw/XjTE=
 github.com/pmylund/go-cache v2.1.0+incompatible/go.mod h1:hmz95dGvINpbRZGsqPcd7B5xXY5+EKb5PpGhQY3NTHk=
+github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/certs/manager.go
+++ b/certs/manager.go
@@ -468,6 +468,11 @@ func (c *CertificateManager) ListAllIds(prefix string) (out []string) {
 			out = append(out, strings.TrimPrefix(key, "raw-"))
 		}
 	} else {
+		// If list is not exists, but migrated record exists, it means it just empty
+		if _, err := c.storage.GetKey(indexKey + "-migrated"); err == nil {
+			return out
+		}
+
 		keys := c.storage.GetKeys("raw-" + prefix + "*")
 		for _, key := range keys {
 			if prefix != "" {
@@ -476,6 +481,8 @@ func (c *CertificateManager) ListAllIds(prefix string) (out []string) {
 			out = append(out, strings.TrimPrefix(key, "raw-"))
 		}
 	}
+	c.storage.SetKey(indexKey+"-migrated", "1", 0)
+
 	return out
 }
 

--- a/certs/manager_test.go
+++ b/certs/manager_test.go
@@ -292,8 +292,19 @@ func TestStorageIndex(t *testing.T) {
 	if len(storage.indexList) != 0 {
 		t.Error("Storage index list should have 0 certificates and indexes after creation")
 	}
+	if _, err := storage.GetKey("orgid-1-index-migrated"); err == nil {
+		t.Error("There should not be migration done")
+	}
+
+	m.ListAllIds("orgid-1")
+	if _, err := storage.GetKey("orgid-1-index-migrated"); err != nil {
+		t.Error("Migrated flag should be set after first listing", err)
+	}
+	// Set recound outside of collection. It should not be visible if migration was applied.
+	storage.data["raw-raw-orgid-1dummy"] = "test"
 
 	certID, _ := m.Add(storageCert, "orgid-1")
+
 	if len(storage.indexList["orgid-1-index"]) != 1 {
 		t.Error("Storage index list should have 1 certificates after adding a certificate")
 	}

--- a/gateway/rpc_storage_handler_test.go
+++ b/gateway/rpc_storage_handler_test.go
@@ -131,7 +131,7 @@ func TestProcessKeySpaceChangesForOauth(t *testing.T) {
 			}
 
 			stringEvent := buildStringEvent(tc.Event, token, myApi.APIID)
-			rpcListener.ProcessKeySpaceChanges([]string{stringEvent})
+			rpcListener.ProcessKeySpaceChanges([]string{stringEvent}, "")
 			found, err := getKeyFromStore(token)
 			if err == nil {
 				t.Error(" key not removed. event:", stringEvent, " found:", found)


### PR DESCRIPTION
Fixed slow certificate endpoint for orgs who have no certs.

The main root cause of the issue, is that initially when we implemented certificates we added a performance issue because it uses the Redis Scan command to list certs, and it is a slow blocking operation. After we realized that on the cloud it is very slow, we added a fix, so no we maintain a special collection with “certificate ids”, to make it fit into Redis model from the performance point. Together with this change we also added a “auto” migration for such users, so if you do not have this “special” redis collection, it will create it for you and will perform an initial “slow” scan to fill it.  For users who have no certificates, it can’t find such a “special” collection, and it tries to perform this migration. It can’t find any certificate and does not create this record.

Redis collection gets removed if there are no records.
So I added a new key, saying that migration is done.

https://tyktech.atlassian.net/browse/TT-1131

## Motivation and Context
Some pages on legacy cloud became unusable for users who have no certificates. 

## Screenshots (if appropriate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [x] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [x] `go vet`
