### PR TITLE
[TT-1702] APIs TLS settings should not affect Control API

### DIFF
--- a/gateway/cert.go
+++ b/gateway/cert.go
@@ -499,11 +499,6 @@ func (gw *Gateway) getTLSConfigForClient(baseConfig *tls.Config, listenPort int)
 			newConfig.ClientAuth = tls.RequestClientCert
 		}
 
-		if newConfig.ClientAuth == tls.RequireAndVerifyClientCert && isControlAPI && !gwConfig.Security.ControlAPIUseMutualTLS {
-
-			newConfig.ClientAuth = tls.RequestClientCert
-		}
-
 		// Cache the config
 		tlsConfigCache.Set(hello.ServerName+listenPortStr, newConfig, cache.DefaultExpiration)
 

--- a/gateway/cert.go
+++ b/gateway/cert.go
@@ -375,11 +375,13 @@ func (gw *Gateway) getTLSConfigForClient(baseConfig *tls.Config, listenPort int)
 		isControlPort := (gwConfig.ControlAPIPort == 0 && listenPort == gwConfig.ListenPort) || (gwConfig.ControlAPIPort == listenPort && listenPort != 0)
 		isControlAPI := isControlHostName && isControlPort
 
-		if isControlAPI && gwConfig.Security.ControlAPIUseMutualTLS {
-			newConfig.ClientAuth = tls.RequireAndVerifyClientCert
-			newConfig.ClientCAs = gw.CertificateManager.CertPool(gwConfig.Security.Certificates.ControlAPI)
+		if isControlAPI {
+			if gwConfig.Security.ControlAPIUseMutualTLS {
+				newConfig.ClientAuth = tls.RequireAndVerifyClientCert
+				newConfig.ClientCAs = gw.CertificateManager.CertPool(gwConfig.Security.Certificates.ControlAPI)
 
-			tlsConfigCache.Set(hello.ServerName, newConfig, cache.DefaultExpiration)
+				tlsConfigCache.Set(hello.ServerName, newConfig, cache.DefaultExpiration)
+			}
 			return newConfig, nil
 		}
 

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -1608,6 +1608,17 @@ func TestStaticMTLSAPI(t *testing.T) {
 		return ts, clientCertID, clientCert
 	}
 
+	t.Run("control API is not affected", func(t *testing.T) {
+		ts, _, _ := setup()
+		defer ts.Close()
+
+		tlsConfig := &tls.Config{InsecureSkipVerify: true}
+		transport := &http.Transport{TLSClientConfig: tlsConfig}
+		_, _ = ts.Run(t, test.TestCase{
+			AdminAuth: true, Path: "/tyk/apis/oas", Code: http.StatusOK, Client: &http.Client{Transport: transport},
+		})
+	})
+
 	t.Run("valid client cert", func(t *testing.T) {
 		ts, _, clientCert := setup()
 		defer ts.Close()


### PR DESCRIPTION
## Description
If all APIs are mTLS protected, then tls certificate requirement will be enabled for ControlAPI as well (since it share the same TLS handler)

Work in progress (needs tests)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [x] `go vet`
