### PR TITLE
Bringing auto build plugin-compiler on release-3 branches

### DIFF
--- a/.github/workflows/plugin-compiler.yml
+++ b/.github/workflows/plugin-compiler.yml
@@ -1,0 +1,27 @@
+# Build and push plugin-compiler
+
+name: Plugin compiler
+
+on:
+  push:
+    tags:
+      - v*
+      
+jobs:
+  build-env:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: checkout tyk
+        uses: actions/checkout@v2
+
+      - name: push to github registry
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: tykio/tyk-plugin-compiler
+          path: images/plugin-compiler
+          tag_with_ref: true
+          add_git_labels: true
+          build_args: TYK_GW_TAG=${{ github.ref }}


### PR DESCRIPTION
## Description
Porting from master. This PR should be merged to all release branches:
  release-3-lts
  release-3.0.2
  release-3.0.3
  release-3.1
  release-3.1.0
  release-3.1.1
  release-3.1.2

## Related Issue
Reported on Slack.

## Motivation and Context
The workflow needs to exist on the branches from where releases are made.

## How This Has Been Tested
The identical workflow has been on master for a while.

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [ ] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
