### PR TITLE
[TT-1280] Fallback to HTTP scheme when using H2C URLs in LB target list

### DIFF
--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -131,11 +131,14 @@ func EnsureTransport(host, protocol string) string {
 	if err != nil {
 		return host
 	}
-	if u.Scheme == "" {
+	switch u.Scheme {
+	case "":
 		if protocol == "" {
 			protocol = "http"
 		}
 		u.Scheme = protocol
+	case "h2c":
+		u.Scheme = "http"
 	}
 	return u.String()
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Potential fix for #3426.

During my investigation I've compared the request flow under two scenarios:

a) H2C enabled API with a single target URL using the `h2c` scheme.
b) H2C enabled API with multiple target URLs using the `h2c` scheme.

If we inspect the behavior of scenario a), we see the following debug output:
```
[Dec 13 20:53:21] DEBUG Started proxy
[Dec 13 20:53:21] DEBUG Stripping: /
[Dec 13 20:53:21] DEBUG Upstream Path is: protobuf.Math/Max
[Dec 13 20:53:21] DEBUG Started api_id=3 api_name=Tyk Test API mw=ReverseProxy org_id=default ts=1607903601070072000
[Dec 13 20:53:21] DEBUG Setting timeout for outbound request to: 10
[Dec 13 20:53:21] DEBUG Creating new transport api_id=3 api_name=Tyk Test API mw=ReverseProxy org_id=default
[Dec 13 20:53:21] DEBUG Upstream request URL: protobuf.Math/Max api_id=3 api_name=Tyk Test API mw=ReverseProxy org_id=default
[Dec 13 20:53:21] DEBUG Outbound request URL: http://127.0.0.1:8000/protobuf.Math/Max api_id=3 api_name=Tyk Test API mw=ReverseProxy org_id=default
[Dec 13 20:53:23] DEBUG Finished api_id=3 api_name=Tyk Test API mw=ReverseProxy ns=2036399759 org_id=default
[Dec 13 20:53:23] DEBUG Upstream request took (ms): 2036.507924
[Dec 13 20:53:23] DEBUG Done proxy
```
An important step that we observe here is that based on the upstream request URL that contains the gRPC method, etc., we end up calling the appropriate URL using the `http` scheme. This behavior isn't reflected when using multiple LB targets:

```
[Dec 13 20:53:58] DEBUG Started proxy
[Dec 13 20:53:58] DEBUG Stripping: /
[Dec 13 20:53:58] DEBUG Upstream Path is: protobuf.Math/Max
[Dec 13 20:53:58] DEBUG Started api_id=3 api_name=Tyk Test API mw=ReverseProxy org_id=default ts=1607903638188350000
[Dec 13 20:53:58] DEBUG Setting timeout for outbound request to: 10
[Dec 13 20:53:58] DEBUG Creating new transport api_id=3 api_name=Tyk Test API mw=ReverseProxy org_id=default
[Dec 13 20:53:58] DEBUG Upstream request URL: protobuf.Math/Max api_id=3 api_name=Tyk Test API mw=ReverseProxy org_id=default
[Dec 13 20:53:58] DEBUG PROXY: [LOAD BALANCING] Load balancer enabled, getting upstream target
[Dec 13 20:53:58] DEBUG Outbound request URL: h2c://127.0.0.1:8000/protobuf.Math/Max api_id=3 api_name=Tyk Test API mw=ReverseProxy org_id=default
[Dec 13 20:53:58] ERROR proxy: http: proxy error: http2: unsupported scheme api_id=3 api_name=Tyk Test API mw=ReverseProxy org_id=default server_name=127.0.0.1:8000 user_id=-- user_ip=::1 user_name=
[Dec 13 20:53:58] DEBUG Finished api_id=3 api_name=Tyk Test API mw=ReverseProxy ns=304815 org_id=default
[Dec 13 20:53:58] DEBUG Upstream request took (ms): 0.323972
[Dec 13 20:53:58] DEBUG Done proxy
```
We can observe that the proxy tries to use `h2c` scheme. As a workaround this patch modifies the scheme when `EnsureTransport` is called. Note that `EnsureTransport` is only called when the LB is enabled:
```golang
func EnsureTransport(host, protocol string) string {
	host = strings.TrimSpace(host)
	protocol = strings.TrimSpace(protocol)
	u, err := url.Parse(host)
	if err != nil {
		return host
	}
	if u.Scheme == "" {
		if protocol == "" {
			protocol = "http"
		}
		u.Scheme = protocol
	}
	return u.String()
}
```
I've also verified that the transport is properly set under both scenarios, e.g. the following gets applied in both, when using H2C, no matter if it's single target or multiple target (this is correct):
```golang
	if config.Global().ProxyEnableHttp2 {
		http2.ConfigureTransport(transport)
	}

	if p.TykAPISpec.Protocol == "h2c" {
		h2t := &http2.Transport{
			// kind of a hack, but for plaintext/H2C requests, pretend to dial TLS
			DialTLS: func(network, addr string, _ *tls.Config) (net.Conn, error) {
				return net.Dial(network, addr)
			},
			AllowHTTP: true,
		}
		return &TykRoundTripper{transport, h2t, p.logger}
	}
```
So far the issue seems to be related only to the `scheme` and setting it in a proper way fixes the scenario b):

```golang
func EnsureTransport(host, protocol string) string {
	host = strings.TrimSpace(host)
	protocol = strings.TrimSpace(protocol)
	u, err := url.Parse(host)
	if err != nil {
		return host
	}
	switch u.Scheme {
	case "":
		if protocol == "" {
			protocol = "http"
		}
		u.Scheme = protocol

	case "h2c":
		u.Scheme = "http"
	}
	return u.String()
}
```

When the fix is applied, the request flow looks as follows:

**First request goes to target 1 (127.0.0.1:8000):**
```
[Dec 13 21:05:13] DEBUG Started proxy
[Dec 13 21:05:13] DEBUG Stripping: /
[Dec 13 21:05:13] DEBUG Upstream Path is: protobuf.Math/Max
[Dec 13 21:05:13] DEBUG Started api_id=3 api_name=Tyk Test API mw=ReverseProxy org_id=default ts=1607904313274074000
[Dec 13 21:05:13] DEBUG Setting timeout for outbound request to: 10
[Dec 13 21:05:13] DEBUG Creating new transport api_id=3 api_name=Tyk Test API mw=ReverseProxy org_id=default
[Dec 13 21:05:13] DEBUG Upstream request URL: protobuf.Math/Max api_id=3 api_name=Tyk Test API mw=ReverseProxy org_id=default
[Dec 13 21:05:13] DEBUG PROXY: [LOAD BALANCING] Load balancer enabled, getting upstream target
[Dec 13 21:05:13] DEBUG Outbound request URL: http://127.0.0.1:8000/protobuf.Math/Max api_id=3 api_name=Tyk Test API mw=ReverseProxy org_id=default
[Dec 13 21:05:15] DEBUG Finished api_id=3 api_name=Tyk Test API mw=ReverseProxy ns=2025671107 org_id=default
[Dec 13 21:05:15] DEBUG Upstream request took (ms): 2025.738936
[Dec 13 21:05:15] DEBUG Done proxy
```
**Second request goes to target 2 (127.0.0.1:8001):**
```
[Dec 13 21:05:22] DEBUG Started proxy
[Dec 13 21:05:22] DEBUG Stripping: /
[Dec 13 21:05:22] DEBUG Upstream Path is: protobuf.Math/Max
[Dec 13 21:05:22] DEBUG Started api_id=3 api_name=Tyk Test API mw=ReverseProxy org_id=default ts=1607904322842541000
[Dec 13 21:05:22] DEBUG Upstream request URL: protobuf.Math/Max api_id=3 api_name=Tyk Test API mw=ReverseProxy org_id=default
[Dec 13 21:05:22] DEBUG PROXY: [LOAD BALANCING] Load balancer enabled, getting upstream target
[Dec 13 21:05:22] DEBUG Outbound request URL: http://127.0.0.1:8001/protobuf.Math/Max api_id=3 api_name=Tyk Test API mw=ReverseProxy org_id=default
[Dec 13 21:05:24] DEBUG HOST CHECKER: Host list reset
[Dec 13 21:05:24] DEBUG Finished api_id=3 api_name=Tyk Test API mw=ReverseProxy ns=2025650752 org_id=default
[Dec 13 21:05:24] DEBUG Upstream request took (ms): 2025.798319
[Dec 13 21:05:24] DEBUG Done proxy
```

## Related Issue
#3426
## How This Has Been Tested
Test instructions in #3426. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)
