### PR TITLE
[TT-1246] Ensure api's and policies are reloaded when redis is connected

### DIFF
--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -451,7 +451,7 @@ func (a APIDefinitionLoader) FromRPC(orgId string) ([]*APISpec, error) {
 
 	if rpc.LoadCount() > 0 {
 		if err := saveRPCDefinitionsBackup(apiCollection); err != nil {
-			return nil, err
+			log.Error(err)
 		}
 	}
 

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -432,7 +432,6 @@ func (a APIDefinitionLoader) FromRPC(orgId string) ([]*APISpec, error) {
 	if rpc.IsEmergencyMode() {
 		return LoadDefinitionsFromRPCBackup()
 	}
-
 	store := RPCStorageHandler{}
 	if !store.Connect() {
 		return nil, errors.New("Can't connect RPC layer")

--- a/gateway/policy.go
+++ b/gateway/policy.go
@@ -185,7 +185,7 @@ func LoadPoliciesFromRPC(orgId string) (map[string]user.Policy, error) {
 	}
 
 	if err := saveRPCPoliciesBackup(rpcPolicies); err != nil {
-		return nil, err
+		log.Error(err)
 	}
 
 	return policies, nil

--- a/gateway/rpc_backup_handlers.go
+++ b/gateway/rpc_backup_handlers.go
@@ -44,11 +44,11 @@ func LoadDefinitionsFromRPCBackup() ([]*APISpec, error) {
 
 	secret := rightPad2Len(config.Global().Secret, "=", 32)
 	cryptoText, err := store.GetKey(checkKey)
-	apiListAsString := decrypt([]byte(secret), cryptoText)
-
 	if err != nil {
 		return nil, errors.New("[RPC] --> Failed to get node backup (" + checkKey + "): " + err.Error())
 	}
+
+	apiListAsString := decrypt([]byte(secret), cryptoText)
 
 	a := APIDefinitionLoader{}
 	return a.processRPCDefinitions(apiListAsString)

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"errors"
 	"strconv"
 	"strings"
 	"time"
@@ -184,7 +185,7 @@ func (r *RPCStorageHandler) GetRawKey(keyName string) (string, error) {
 				"keyName": keyName,
 			},
 		)
-		if r.IsAccessError(err) {
+		if r.IsRetriableError(err) {
 			if rpc.Login() {
 				return r.GetRawKey(keyName)
 			}
@@ -227,7 +228,7 @@ func (r *RPCStorageHandler) GetExp(keyName string) (int64, error) {
 				"fixedKeyName": r.fixKey(keyName),
 			},
 		)
-		if r.IsAccessError(err) {
+		if r.IsRetriableError(err) {
 			if rpc.Login() {
 				return r.GetExp(keyName)
 			}
@@ -264,7 +265,7 @@ func (r *RPCStorageHandler) SetKey(keyName, session string, timeout int64) error
 			},
 		)
 
-		if r.IsAccessError(err) {
+		if r.IsRetriableError(err) {
 			if rpc.Login() {
 				return r.SetKey(keyName, session, timeout)
 			}
@@ -298,7 +299,7 @@ func (r *RPCStorageHandler) Decrement(keyName string) {
 			},
 		)
 	}
-	if r.IsAccessError(err) {
+	if r.IsRetriableError(err) {
 		if rpc.Login() {
 			r.Decrement(keyName)
 			return
@@ -325,7 +326,7 @@ func (r *RPCStorageHandler) IncrememntWithExpire(keyName string, expire int64) i
 			},
 		)
 	}
-	if r.IsAccessError(err) {
+	if r.IsRetriableError(err) {
 		if rpc.Login() {
 			return r.IncrememntWithExpire(keyName, expire)
 		}
@@ -363,7 +364,7 @@ func (r *RPCStorageHandler) GetKeysAndValuesWithFilter(filter string) map[string
 			},
 		)
 
-		if r.IsAccessError(err) {
+		if r.IsRetriableError(err) {
 			if rpc.Login() {
 				return r.GetKeysAndValuesWithFilter(filter)
 			}
@@ -390,7 +391,7 @@ func (r *RPCStorageHandler) GetKeysAndValues() map[string]string {
 	if err != nil {
 		rpc.EmitErrorEvent(rpc.FuncClientSingletonCall, "GetKeysAndValues", err)
 
-		if r.IsAccessError(err) {
+		if r.IsRetriableError(err) {
 			if rpc.Login() {
 				return r.GetKeysAndValues()
 			}
@@ -425,7 +426,7 @@ func (r *RPCStorageHandler) DeleteKey(keyName string) bool {
 			},
 		)
 
-		if r.IsAccessError(err) {
+		if r.IsRetriableError(err) {
 			if rpc.Login() {
 				return r.DeleteKey(keyName)
 			}
@@ -453,7 +454,7 @@ func (r *RPCStorageHandler) DeleteRawKey(keyName string) bool {
 			},
 		)
 
-		if r.IsAccessError(err) {
+		if r.IsRetriableError(err) {
 			if rpc.Login() {
 				return r.DeleteRawKey(keyName)
 			}
@@ -484,7 +485,7 @@ func (r *RPCStorageHandler) DeleteKeys(keys []string) bool {
 				},
 			)
 
-			if r.IsAccessError(err) {
+			if r.IsRetriableError(err) {
 				if rpc.Login() {
 					return r.DeleteKeys(keys)
 				}
@@ -530,7 +531,7 @@ func (r *RPCStorageHandler) AppendToSet(keyName, value string) {
 			},
 		)
 	}
-	if r.IsAccessError(err) {
+	if r.IsRetriableError(err) {
 		if rpc.Login() {
 			r.AppendToSet(keyName, value)
 		}
@@ -558,7 +559,7 @@ func (r *RPCStorageHandler) SetRollingWindow(keyName string, per int64, val stri
 			},
 		)
 
-		if r.IsAccessError(err) {
+		if r.IsRetriableError(err) {
 			if rpc.Login() {
 				return r.SetRollingWindow(keyName, per, val, false)
 			}
@@ -595,9 +596,9 @@ func (r RPCStorageHandler) RemoveFromSet(keyName, value string) {
 	log.Error("RPCStorageHandler.RemoveFromSet - Not implemented")
 }
 
-func (r RPCStorageHandler) IsAccessError(err error) bool {
+func (r RPCStorageHandler) IsRetriableError(err error) bool {
 	if err != nil {
-		return err.Error() == "Access Denied"
+		return err.Error() == "Access Denied" || errors.Is(err, rpc.ErrRPCIsDown)
 	}
 	return false
 }
@@ -621,7 +622,7 @@ func (r *RPCStorageHandler) GetApiDefinitions(orgId string, tags []string) strin
 			},
 		)
 
-		if r.IsAccessError(err) {
+		if r.IsRetriableError(err) {
 			if rpc.Login() {
 				return r.GetApiDefinitions(orgId, tags)
 			}
@@ -651,7 +652,7 @@ func (r *RPCStorageHandler) GetPolicies(orgId string) string {
 			},
 		)
 
-		if r.IsAccessError(err) {
+		if r.IsRetriableError(err) {
 			if rpc.Login() {
 				return r.GetPolicies(orgId)
 			}
@@ -679,7 +680,7 @@ func (r *RPCStorageHandler) CheckForReload(orgId string) {
 				"orgId": orgId,
 			},
 		)
-		if r.IsAccessError(err) {
+		if r.IsRetriableError(err) {
 			log.Warning("[RPC STORE] CheckReload: Not logged in")
 			if rpc.Login() {
 				r.CheckForReload(orgId)
@@ -723,7 +724,7 @@ func (r *RPCStorageHandler) StartRPCKeepaliveWatcher() {
 				"prefix": "RPC Conn Mgr",
 			}).Warning("Can't connect to RPC layer")
 
-			if r.IsAccessError(err) {
+			if r.IsRetriableError(err) {
 				if rpc.Login() {
 					continue
 				}
@@ -770,7 +771,7 @@ func (r *RPCStorageHandler) CheckForKeyspaceChanges(orgId string) {
 			err,
 			reqData,
 		)
-		if r.IsAccessError(err) {
+		if r.IsRetriableError(err) {
 			if rpc.Login() {
 				r.CheckForKeyspaceChanges(orgId)
 			}

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -1,7 +1,6 @@
 package gateway
 
 import (
-	"errors"
 	"strconv"
 	"strings"
 	"time"
@@ -598,7 +597,7 @@ func (r RPCStorageHandler) RemoveFromSet(keyName, value string) {
 
 func (r RPCStorageHandler) IsRetriableError(err error) bool {
 	if err != nil {
-		return err.Error() == "Access Denied" || errors.Is(err, rpc.ErrRPCIsDown)
+		return err.Error() == "Access Denied"
 	}
 	return false
 }

--- a/gateway/rpc_test.go
+++ b/gateway/rpc_test.go
@@ -164,26 +164,6 @@ func TestSyncAPISpecsRPCFailure_CheckGlobals(t *testing.T) {
 	}
 }
 
-// Our RPC layer too racy, but not harmul, mostly global variables like RPCIsClientConnected
-func TestSyncAPISpecsRPCFailure(t *testing.T) {
-	// Test RPC
-	dispatcher := gorpc.NewDispatcher()
-	dispatcher.AddFunc("GetApiDefinitions", func(clientAddr string, dr *apidef.DefRequest) (string, error) {
-		return "malformed json", nil
-	})
-	dispatcher.AddFunc("Login", func(clientAddr, userKey string) bool {
-		return true
-	})
-
-	rpc := startRPCMock(dispatcher)
-	defer stopRPCMock(rpc)
-
-	count, _ := syncAPISpecs()
-	if count != 0 {
-		t.Error("Should return empty value for malformed rpc response", apiSpecs)
-	}
-}
-
 func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 	// Test RPC
 	dispatcher := gorpc.NewDispatcher()

--- a/gateway/rpc_test.go
+++ b/gateway/rpc_test.go
@@ -225,8 +225,7 @@ func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 
 		// Wait for backup to load
 		time.Sleep(100 * time.Millisecond)
-		ReloadTestCase.Tick()
-		time.Sleep(100 * time.Millisecond)
+		DoReload()
 
 		cachedAuth := map[string]string{"Authorization": "test"}
 		notCachedAuth := map[string]string{"Authorization": "nope1"}

--- a/gateway/rpc_test.go
+++ b/gateway/rpc_test.go
@@ -362,7 +362,7 @@ func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 	})
 }
 
-func TestSyncAPISpecsRPCSuccess_redis_failure(t *testing.T) {
+func TestSyncAPISpecsRPC_redis_failure(t *testing.T) {
 	dispatcher := gorpc.NewDispatcher()
 	dispatcher.AddFunc("GetApiDefinitions", func(clientAddr string, dr *apidef.DefRequest) (string, error) {
 		return jsonMarshalString(BuildAPI(func(spec *APISpec) {

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -1247,7 +1247,9 @@ func Start() {
 		defer trace.Close()
 	}
 	start(ctx)
-	go storage.ConnectToRedis(ctx)
+	go storage.ConnectToRedis(ctx, func() {
+		reloadURLStructure(func() {})
+	})
 
 	if *cli.MemProfile {
 		mainLog.Debug("Memory profiling active")
@@ -1455,6 +1457,6 @@ func startServer() {
 	mainLog.Info("--> Listening on port: ", config.Global().ListenPort)
 	mainLog.Info("--> PID: ", hostDetails.PID)
 	if !rpc.IsEmergencyMode() {
-		DoReload()
+		reloadURLStructure(func() {})
 	}
 }

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -1457,6 +1457,6 @@ func startServer() {
 	mainLog.Info("--> Listening on port: ", config.Global().ListenPort)
 	mainLog.Info("--> PID: ", hostDetails.PID)
 	if !rpc.IsEmergencyMode() {
-		reloadURLStructure(func() {})
+		DoReload()
 	}
 }

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -61,6 +61,8 @@ var (
 
 	// ReloadTestCase use this when in any test for gateway reloads
 	ReloadTestCase = NewReloadMachinery()
+	// OnConnect this is a callback which is called whenever we transition redis Disconnected to connected
+	OnConnect func()
 )
 
 // ReloadMachinery is a helper struct to use when writing tests that do manual
@@ -290,7 +292,11 @@ func InitTestMain(ctx context.Context, m *testing.M, genConf ...func(globalConf 
 	if analytics.GeoIPDB == nil {
 		panic("GeoIPDB was not initialized")
 	}
-	go storage.ConnectToRedis(ctx, nil)
+	go storage.ConnectToRedis(ctx, func() {
+		if OnConnect != nil {
+			OnConnect()
+		}
+	})
 	for {
 		if storage.Connected() {
 			break

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -928,6 +928,7 @@ func (s *Test) Close() {
 }
 
 func (s *Test) Run(t testing.TB, testCases ...test.TestCase) (*http.Response, error) {
+	t.Helper()
 	return s.testRunner.Run(t, testCases...)
 }
 

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -290,7 +290,7 @@ func InitTestMain(ctx context.Context, m *testing.M, genConf ...func(globalConf 
 	if analytics.GeoIPDB == nil {
 		panic("GeoIPDB was not initialized")
 	}
-	go storage.ConnectToRedis(ctx)
+	go storage.ConnectToRedis(ctx, nil)
 	for {
 		if storage.Connected() {
 			break

--- a/rpc/rpc_client.go
+++ b/rpc/rpc_client.go
@@ -438,9 +438,6 @@ func recoverOp(fn func() error) func() error {
 }
 
 func FuncClientSingleton(funcName string, request interface{}) (interface{}, error) {
-	if !values.ClientIsConnected() {
-		return nil, ErrRPCIsDown
-	}
 	return funcClientSingleton.CallTimeout(funcName, request, GlobalRPCCallTimeout)
 }
 

--- a/rpc/rpc_client.go
+++ b/rpc/rpc_client.go
@@ -294,12 +294,7 @@ func Connect(connConfig Config, suppressRegister bool, dispatcherFuncs map[strin
 		register()
 		go checkDisconnect()
 	}
-	return backoff.Retry(func() error {
-		if !values.ClientIsConnected() {
-			return ErrRPCIsDown
-		}
-		return nil
-	}, backoff.NewExponentialBackOff()) == nil
+	return true
 }
 
 // Login tries to login to the rpc sever. Returns true if it succeeds and false

--- a/rpc/rpc_client.go
+++ b/rpc/rpc_client.go
@@ -449,7 +449,7 @@ func FuncClientSingleton(funcName string, request interface{}) (result interface
 		result, err = funcClientSingleton.CallTimeout(funcName, request, GlobalRPCCallTimeout)
 		return nil
 	}, backoff.WithMaxRetries(
-		backoff.NewExponentialBackOff(), 2,
+		backoff.NewExponentialBackOff(), 1,
 	))
 	if be != nil {
 		err = be

--- a/rpc/rpc_client.go
+++ b/rpc/rpc_client.go
@@ -449,7 +449,7 @@ func FuncClientSingleton(funcName string, request interface{}) (result interface
 		result, err = funcClientSingleton.CallTimeout(funcName, request, GlobalRPCCallTimeout)
 		return nil
 	}, backoff.WithMaxRetries(
-		backoff.NewExponentialBackOff(), 1,
+		backoff.NewConstantBackOff(10*time.Millisecond), 3,
 	))
 	if be != nil {
 		err = be

--- a/storage/redis_cluster.go
+++ b/storage/redis_cluster.go
@@ -132,12 +132,6 @@ func ConnectToRedis(ctx context.Context, onConnect func()) {
 		ok = true
 	}
 	redisUp.Store(ok)
-	if ok {
-		// we are connected to Redis
-		if onConnect != nil {
-			onConnect()
-		}
-	}
 	for {
 		select {
 		case <-ctx.Done():

--- a/storage/redis_cluster.go
+++ b/storage/redis_cluster.go
@@ -38,19 +38,20 @@ var ctx = context.Background()
 // redisW
 func DisableRedis(ok bool) {
 	if ok {
+		// we make sure to set that redis is down
 		redisUp.Store(false)
 		disableRedis.Store(true)
 		return
 	}
-	redisUp.Store(true)
 	disableRedis.Store(false)
 }
 
 func shouldConnect() bool {
+	ok := true
 	if v := disableRedis.Load(); v != nil {
-		return !v.(bool)
+		ok = !v.(bool)
 	}
-	return true
+	return ok
 }
 
 // Connected returns true if we are connected to redis
@@ -142,6 +143,7 @@ func ConnectToRedis(ctx context.Context, onConnect func()) {
 			}
 			conn := Connected()
 			ok := connectCluster(c...)
+
 			redisUp.Store(ok)
 			if !conn && ok {
 				// Here we are transitioning from DISCONNECTED to CONNECTED state

--- a/test/http.go
+++ b/test/http.go
@@ -227,6 +227,7 @@ type HTTPTestRunner struct {
 }
 
 func (r HTTPTestRunner) Run(t testing.TB, testCases ...TestCase) (*http.Response, error) {
+	t.Helper()
 	var lastResponse *http.Response
 	var lastError error
 


### PR DESCRIPTION
When deploying tyk in slaved GW we the error returned from failing to save backups from redis were causing the gw to fail to load API's and policies.

## Description
In this PR

- we only log the error from failed backup saves, and proceeed to load api's and policies because the rpc calls are not dependent on redis.
- We queue a reload whenever the connection to redis is established. This is not done everytime, when initialing the reload loop we don't need to queue a reload since a reload would have been queued already. In the next connection loop tick when we determine a connection was established then we queue a reload.

## Related Issue
https://tyksupport.zendesk.com/agent/tickets/11686

## Motivation and Context
We need to manually trigger a reload for tyk to load api's when it started without redis.

## How This Has Been Tested
- manually

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [ ] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
