### PR TITLE
[TT-1258] Fix JWKs compatibility with previous TYk versions

### DIFF
--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"bytes"
 	"crypto/md5"
 	"crypto/x509"
 	"encoding/base64"
@@ -43,6 +44,21 @@ func (k *JWTMiddleware) EnabledForSpec() bool {
 
 var JWKCache *cache.Cache
 
+type JWK struct {
+	Alg string   `json:"alg"`
+	Kty string   `json:"kty"`
+	Use string   `json:"use"`
+	X5c []string `json:"x5c"`
+	N   string   `json:"n"`
+	E   string   `json:"e"`
+	KID string   `json:"kid"`
+	X5t string   `json:"x5t"`
+}
+
+type JWKs struct {
+	Keys []JWK `json:"keys"`
+}
+
 func parseJWK(buf []byte) (*jose.JSONWebKeySet, error) {
 	var j jose.JSONWebKeySet
 	err := json.Unmarshal(buf, &j)
@@ -52,11 +68,65 @@ func parseJWK(buf []byte) (*jose.JSONWebKeySet, error) {
 	return &j, nil
 }
 
+func (k *JWTMiddleware) legacyGetSecretFromURL(url, kid, keyType string) (interface{}, error) {
+	// Implement a cache
+	if JWKCache == nil {
+		JWKCache = cache.New(240*time.Second, 30*time.Second)
+	}
+
+	var jwkSet JWKs
+	cachedJWK, found := JWKCache.Get("legacy-" + k.Spec.APIID)
+	if !found {
+		resp, err := http.Get(url)
+		if err != nil {
+			k.Logger().WithError(err).Error("Failed to get resource URL")
+			return nil, err
+		}
+		defer resp.Body.Close()
+
+		// Decode it
+		if err := json.NewDecoder(resp.Body).Decode(&jwkSet); err != nil {
+			k.Logger().WithError(err).Error("Failed to decode body JWK")
+			return nil, err
+		}
+
+		JWKCache.Set("legacy-" + k.Spec.APIID, jwkSet, cache.DefaultExpiration)
+	} else {
+		jwkSet = cachedJWK.(JWKs)
+	}
+
+	for _, val := range jwkSet.Keys {
+		if val.KID != kid || strings.ToLower(val.Kty) != strings.ToLower(keyType) {
+			continue
+		}
+		if len(val.X5c) > 0 {
+			// Use the first cert only
+			decodedCert, err := base64.StdEncoding.DecodeString(val.X5c[0])
+			if !bytes.Contains(decodedCert, []byte("-----")) {
+				return nil, errors.New("No legacy public keys found")
+			}
+			if err != nil {
+				return nil, err
+			}
+			return ParseRSAPublicKey(decodedCert)
+		}
+		return nil, errors.New("no certificates in JWK")
+	}
+
+	return nil, errors.New("No matching KID could be found")
+}
+
 func (k *JWTMiddleware) getSecretFromURL(url, kid, keyType string) (interface{}, error) {
 	// Implement a cache
 	if JWKCache == nil {
 		k.Logger().Debug("Creating JWK Cache")
 		JWKCache = cache.New(240*time.Second, 30*time.Second)
+	}
+
+	if key, err := k.legacyGetSecretFromURL(url, kid, keyType); err == nil {
+		return key, nil
+	} else {
+		k.Logger().WithError(err).Info("Legacy JWK qery")
 	}
 
 	var jwkSet *jose.JSONWebKeySet

--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -123,12 +123,6 @@ func (k *JWTMiddleware) getSecretFromURL(url, kid, keyType string) (interface{},
 		JWKCache = cache.New(240*time.Second, 30*time.Second)
 	}
 
-	if key, err := k.legacyGetSecretFromURL(url, kid, keyType); err == nil {
-		return key, nil
-	} else {
-		k.Logger().WithError(err).Info("Legacy JWK query")
-	}
-
 	var jwkSet *jose.JSONWebKeySet
 
 	cachedJWK, found := JWKCache.Get(k.Spec.APIID)
@@ -147,7 +141,13 @@ func (k *JWTMiddleware) getSecretFromURL(url, kid, keyType string) (interface{},
 			return nil, err
 		}
 		if jwkSet, err = parseJWK(buf); err != nil {
-			k.Logger().WithError(err).Error("Failed to decode body JWK")
+			k.Logger().WithError(err).Error("Failed to decode body JWK. Trying x5c PEM fallback.")
+			
+			key, legacyError := k.legacyGetSecretFromURL(url, kid, keyType)
+			if legacyError == nil {
+				return key, nil
+			}
+
 			return nil, err
 		}
 

--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -141,7 +141,7 @@ func (k *JWTMiddleware) getSecretFromURL(url, kid, keyType string) (interface{},
 			return nil, err
 		}
 		if jwkSet, err = parseJWK(buf); err != nil {
-			k.Logger().WithError(err).Error("Failed to decode body JWK. Trying x5c PEM fallback.")
+			k.Logger().WithError(err).Info("Failed to decode JWKs body. Trying x5c PEM fallback.")
 
 			key, legacyError := k.legacyGetSecretFromURL(url, kid, keyType)
 			if legacyError == nil {

--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -90,7 +90,7 @@ func (k *JWTMiddleware) legacyGetSecretFromURL(url, kid, keyType string) (interf
 			return nil, err
 		}
 
-		JWKCache.Set("legacy-" + k.Spec.APIID, jwkSet, cache.DefaultExpiration)
+		JWKCache.Set("legacy-"+k.Spec.APIID, jwkSet, cache.DefaultExpiration)
 	} else {
 		jwkSet = cachedJWK.(JWKs)
 	}
@@ -142,7 +142,7 @@ func (k *JWTMiddleware) getSecretFromURL(url, kid, keyType string) (interface{},
 		}
 		if jwkSet, err = parseJWK(buf); err != nil {
 			k.Logger().WithError(err).Error("Failed to decode body JWK. Trying x5c PEM fallback.")
-			
+
 			key, legacyError := k.legacyGetSecretFromURL(url, kid, keyType)
 			if legacyError == nil {
 				return key, nil

--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -126,7 +126,7 @@ func (k *JWTMiddleware) getSecretFromURL(url, kid, keyType string) (interface{},
 	if key, err := k.legacyGetSecretFromURL(url, kid, keyType); err == nil {
 		return key, nil
 	} else {
-		k.Logger().WithError(err).Info("Legacy JWK qery")
+		k.Logger().WithError(err).Info("Legacy JWK query")
 	}
 
 	var jwkSet *jose.JSONWebKeySet

--- a/gateway/mw_jwt_test.go
+++ b/gateway/mw_jwt_test.go
@@ -1402,14 +1402,14 @@ func TestJWTSessionRSAWithEncodedJWK(t *testing.T) {
 			JWKCache.Flush()
 		}
 	}
-	// t.Run("Direct JWK URL", func(t *testing.T) {
-	// 	spec.JWTSource = testHttpJWK
-	// 	LoadAPI(spec)
-	// 	flush()
-	// 	ts.Run(t, test.TestCase{
-	// 		Headers: authHeaders, Code: http.StatusOK,
-	// 	})
-	// })
+	t.Run("Direct JWK URL", func(t *testing.T) {
+		spec.JWTSource = testHttpJWK
+		LoadAPI(spec)
+		flush()
+		ts.Run(t, test.TestCase{
+			Headers: authHeaders, Code: http.StatusOK,
+		})
+	})
 	t.Run("Direct JWK URL with legacy jwk", func(t *testing.T) {
 		spec.JWTSource = testHttpJWKLegacy
 		LoadAPI(spec)

--- a/gateway/mw_jwt_test.go
+++ b/gateway/mw_jwt_test.go
@@ -1402,20 +1402,20 @@ func TestJWTSessionRSAWithEncodedJWK(t *testing.T) {
 			JWKCache.Flush()
 		}
 	}
-	t.Run("Direct JWK URL", func(t *testing.T) {
-		spec.JWTSource = testHttpJWK
-		LoadAPI(spec)
-		flush()
-		ts.Run(t, test.TestCase{
-			Headers: authHeaders, Code: http.StatusOK,
-		})
-	})
-	t.Run("Direct JWK URL with bad jwk", func(t *testing.T) {
+	// t.Run("Direct JWK URL", func(t *testing.T) {
+	// 	spec.JWTSource = testHttpJWK
+	// 	LoadAPI(spec)
+	// 	flush()
+	// 	ts.Run(t, test.TestCase{
+	// 		Headers: authHeaders, Code: http.StatusOK,
+	// 	})
+	// })
+	t.Run("Direct JWK URL with legacy jwk", func(t *testing.T) {
 		spec.JWTSource = testHttpJWKLegacy
 		LoadAPI(spec)
 		flush()
 		ts.Run(t, test.TestCase{
-			Headers: authHeaders, Code: http.StatusForbidden,
+			Headers: authHeaders, Code: http.StatusOK,
 		})
 	})
 	t.Run("Base64", func(t *testing.T) {
@@ -1426,12 +1426,12 @@ func TestJWTSessionRSAWithEncodedJWK(t *testing.T) {
 			Headers: authHeaders, Code: http.StatusOK,
 		})
 	})
-	t.Run("Base64 bad jwk", func(t *testing.T) {
+	t.Run("Base64 legacy jwk", func(t *testing.T) {
 		spec.JWTSource = base64.StdEncoding.EncodeToString([]byte(testHttpJWKLegacy))
 		LoadAPI(spec)
 		flush()
 		ts.Run(t, test.TestCase{
-			Headers: authHeaders, Code: http.StatusForbidden,
+			Headers: authHeaders, Code: http.StatusOK,
 		})
 	})
 }


### PR DESCRIPTION
Support public key in PEM format is found in x5c (old way)

Fix https://tyktech.atlassian.net/browse/TT-1258

## Motivation and Context
In 3.0.2 we broke clients who used Tyk specific non-RFC compatible JWKs

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [x] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
