### PR TITLE
[TT-730] Fix uptime check on non-polling slave nodes

### DIFF
--- a/gateway/host_checker_manager.go
+++ b/gateway/host_checker_manager.go
@@ -307,9 +307,17 @@ func (hc *HostCheckerManager) HostDown(urlStr string) bool {
 	log.WithFields(logrus.Fields{
 		"prefix": "host-check-mgr",
 	}).Debug("Key is: ", PoolerHostSentinelKeyPrefix+u.Host)
-	_, ok := hc.unhealthyHostList.Load(PoolerHostSentinelKeyPrefix + u.Host)
+
+	key := PoolerHostSentinelKeyPrefix + u.Host
+	// If the node doesn't perform any uptime checks, query the storage:
+	if hc.store != nil && !hc.pollerStarted {
+		v, _ := hc.store.GetKey(key)
+		return v == "1"
+	}
+	_, ok := hc.unhealthyHostList.Load(key)
 	// Found a key, the host is down
 	return ok
+
 }
 
 func (hc *HostCheckerManager) PrepareTrackingHost(checkObject apidef.HostCheckObject, apiID string) (HostData, error) {


### PR DESCRIPTION
Potential fix for TT-730.

**How to test?**

1) Setup an MDCB environment with one master GW and two slave GWs.
`tyk.conf` (slave GW #1, listening on 8081)
```json
{
    "listen_address": "",
    "listen_port": 8081,
    "secret": "352d20ee67be67f6340b4c0605b044b7",
    "node_secret": "abcdef",
    "template_path": "./templates",
    "tyk_js_path": "./js/tyk.js",
    "middleware_path": "./middleware",
    "log_level": "info",
    "policies": {
        "policy_source": "rpc",
        "policy_record_name": "tyk_policies",
        "allow_explicit_policy_id_": true
    },
    "use_db_app_configs": false,
    "db_app_conf_options": {
        "node_is_segmented": false,
        "tags": ["qa"]
    },
    "disable_dashboard_zeroconf": false,
    "app_path": "./test_apps/",
    "storage": {
        "type": "redis",
        "host": "yyy",
        "port": 6379,
        "hosts": null,
        "username": "",
        "password": "",
        "database": 0,
        "optimisation_max_idle": 100,
        "optimisation_max_active": 0,
        "enable_cluster": false
    },
    "enable_separate_cache_store": false,
    "cache_storage": {
        "type": "redis",
        "host": "",
        "port": 0,
        "hosts": {
            "localhost": "6380"
        },
        "username": "",
        "password": "",
        "database": 0,
        "optimisation_max_idle": 3000,
        "optimisation_max_active": 5000,
        "enable_cluster": false
    },
    "enable_analytics": false,
    "analytics_config": {
        "type": "rpc",
        "ignored_ips": [],
        "enable_detailed_recording": true,
        "enable_geo_ip": false,
        "geo_ip_db_path": "./GeoLite2-City.mmdb",
        "normalise_urls": {
            "enabled": true,
            "normalise_uuids": true,
            "normalise_numbers": true,
            "custom_patterns": []
        }
    },
    "health_check": {
        "enable_health_checks": false,
        "health_check_value_timeouts": 0
    },
    "optimisations_use_async_session_write": true,
    "allow_master_keys": true,
    "hash_keys": true,
    "hash_key_function": "murmur64",
    "enable_hashed_keys_listing": true,
    "suppress_redis_signal_reload": false,
    "suppress_default_org_store": false,
    "use_redis_log": true,
    "sentry_code": "",
    "use_sentry": false,
    "use_syslog": false,
    "use_graylog": false,
    "use_logstash": false,
    "graylog_network_addr": "",
    "logstash_network_addr": "",
    "syslog_transport": "",
    "logstash_transport": "",
    "syslog_network_addr": "",
    "enforce_org_data_age": true,
    "enforce_org_data_detail_logging": false,
    "enforce_org_quotas": true,
    "experimental_process_org_off_thread": false,
    "enable_non_transactional_rate_limiter": true,
    "enable_sentinel_rate_limiter": false,
    "management_node": false,
    "Monitor": {
        "enable_trigger_monitors": false,
        "configuration": {
            "method": "",
            "target_path": "",
            "template_path": "",
            "header_map": null,
            "event_timeout": 0
        },
        "global_trigger_limit": 0,
        "monitor_user_keys": false,
        "monitor_org_keys": false
    },
    "oauth_refresh_token_expire": 0,
    "oauth_token_expire": 0,
    "oauth_redirect_uri_separator": ";",
    "slave_options": {
        "use_rpc": true,
        "connection_string": "localhost:9090",
        "rpc_key": "5fd922984ea46102adc5b609",
        "api_key": "a11cfb1d3e8f41776dcf6728e359a62f",
        "enable_rpc_cache": false,
        "bind_to_slugs": false,
        "disable_keyspace_sync": false,
        "group_id": ""
    },
    "disable_virtual_path_blobs": false,
    "local_session_cache": {
        "disable_cached_session_state": true,
        "cached_session_timeout": 0,
        "cached_session_eviction": 0
    },
    "http_server_options": {
        "override_defaults": false,
        "read_timeout": 0,
        "write_timeout": 0,
        "use_ssl": false,
        "use_ssl_le": false,
        "enable_websockets": true,
        "certificates": [
            {
                "cert_file": "/etc/ssl/certs/server.crt",
                "key_file": "/etc/ssl/certs/server.key"
            }
        ],
        "server_name": "",
        "min_version": 0,
        "flush_interval": 0
    },
    "service_discovery": {
        "default_cache_timeout": 0
    },
    "close_connections": true,
    "auth_override": {
        "force_auth_provider": true,
        "auth_provider": {
            "name": "",
            "storage_engine": "rpc",
            "meta": null
        },
        "force_session_provider": false,
        "session_provider": {
            "name": "",
            "storage_engine": "",
            "meta": null
        }
    },
    "uptime_tests": {
        "disable": false,
        "config": {
            "failure_trigger_sample_size": 1,
            "time_wait": 5,
            "checker_pool_size": 5,
            "enable_uptime_analytics": true
        }
    },
    "hostname": "",
    "enable_api_segregation": false,
    "control_api_hostname": "",
    "enable_custom_domains": true,
    "enable_jsvm": true,
    "hide_generator_header": false,
    "event_handlers": {
        "events": {}
    },
    "event_trigers_defunct": {},
    "pid_file_location": "./tyk-gateway.pid",
    "allow_insecure_configs": true,
    "close_idle_connections": false,
    "allow_remote_config": true,
    "enable_bundle_downloader": false,
    "disable_ports_whitelist": true,
    "tracing": {
        "enabled": false,
        "name": "",
        "options": null
    },
    "enable_http_profiler": false
}
```

For slave GW #2, use the same configuration but change `listen_port` to 8082.

2) Start the Dashboard, Sync and all the GWs.
3) Create an API with the following settings:
```json
    "uptime_tests": {
      "check_list": [
        {
          "body": "",
          "headers": {},
          "method": "GET",
          "url": "http://localhost:8000/"
        },
        {
          "body": "",
          "headers": {},
          "method": "GET",
          "url": "http://localhost:8001/"
        }
      ],
    "proxy": {
      "check_host_against_uptime_tests": true,
      "target_list": [
        "http://localhost:8000",
        "http://localhost:8001"
      ],
      "strip_listen_path": true,
      "enable_load_balancing": true,
      "listen_path": "/quickstart/",
      "disable_strip_slash": true
    },
```
4) Make sure that both `localhost:8000` and `localhost:8001` are up and hit `http://localhost:8081/quickstart/` (slave GW 1) and `http://localhost:8082/quickstart/` (slave GW 2) multiple times. So far all the requests should work and you should see rotating "hello from server1" and "hello from server2" messages.
5) Stop the test server on `localhost:8001` and repeat 4)
6) The host that's polling will stop trying to communicate with `localhost:8001`, the other host will still send requests to it and report `proxy error` messages.

**Note:** For test serves I'm using the following Python snippets:
**Test sever 1 (listening on 8000)**
```python
#!/usr/bin/env python3

import http.server as SimpleHTTPServer
import socketserver as SocketServer
import logging

PORT = 8000

class GetHandler(
        SimpleHTTPServer.SimpleHTTPRequestHandler
        ):

    def do_GET(self):
        logging.error(self.headers)
        content = f"hello from server1:8000\n"
        encoded_content = content.encode("utf8")
        self.send_response(200)
        self.send_header("Content-type", "text/html")
        self.end_headers()
        self.wfile.write(encoded_content)

Handler = GetHandler
httpd = SocketServer.TCPServer(("", PORT), Handler)

httpd.serve_forever()
```

**Test server 2 (listening on 8001)**
```python
#!/usr/bin/env python3

import http.server as SimpleHTTPServer
import socketserver as SocketServer
import logging

PORT = 8001

class GetHandler(
        SimpleHTTPServer.SimpleHTTPRequestHandler
        ):

    def do_GET(self):
        logging.error(self.headers)
        content = f"hello from server2:8001\n"
        encoded_content = content.encode("utf8")
        self.send_response(200)
        self.send_header("Content-type", "text/html")
        self.end_headers()
        self.wfile.write(encoded_content)

Handler = GetHandler
httpd = SocketServer.TCPServer(("", PORT), Handler)

httpd.serve_forever()
```