### PR TITLE
[TT-1284] Load gateway health check to control port

### DIFF
--- a/gateway/proxy_muxer.go
+++ b/gateway/proxy_muxer.go
@@ -362,12 +362,7 @@ func (m *proxyMux) swap(new *proxyMux) {
 			}
 		}
 	}
-	p := m.getProxy(config.Global().ListenPort)
-	if p != nil && p.router != nil {
-		// All APIs processed, now we can healthcheck
-		// Add a root message to check all is OK
-		p.router.HandleFunc("/"+config.Global().HealthCheckEndpointName, liveCheckHandler)
-	}
+
 	m.serve()
 }
 

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -413,6 +413,8 @@ func loadControlAPIEndpoints(muxer *mux.Router) {
 		}
 	}
 
+	muxer.HandleFunc("/"+config.Global().HealthCheckEndpointName, liveCheckHandler)
+
 	r := mux.NewRouter()
 	muxer.PathPrefix("/tyk/").Handler(http.StripPrefix("/tyk",
 		stripSlashes(checkIsAPIOwner(controlAPICheckClientCertificate("/gateway/client", InstrumentationMW(r)))),

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -831,7 +831,7 @@ func firstVals(vals map[string][]string) map[string]string {
 }
 
 type TestConfig struct {
-	sepatateControlAPI bool
+	SeparateControlAPI bool
 	Delay              time.Duration
 	HotReload          bool
 	overrideDefaults   bool
@@ -854,7 +854,7 @@ func (s *Test) Start() {
 	globalConf := config.Global()
 	globalConf.ListenPort, _ = strconv.Atoi(port)
 
-	if s.config.sepatateControlAPI {
+	if s.config.SeparateControlAPI {
 		l, _ := net.Listen("tcp", "127.0.0.1:0")
 
 		_, port, _ = net.SplitHostPort(l.Addr().String())
@@ -888,7 +888,7 @@ func (s *Test) Start() {
 		RequestBuilder: func(tc *test.TestCase) (*http.Request, error) {
 			tc.BaseURL = s.URL
 			if tc.ControlRequest {
-				if s.config.sepatateControlAPI {
+				if s.config.SeparateControlAPI {
 					tc.BaseURL = scheme + controlProxy().listener.Addr().String()
 				} else if s.GlobalConfig.ControlAPIHostname != "" {
 					tc.Domain = s.GlobalConfig.ControlAPIHostname
@@ -920,7 +920,7 @@ func (s *Test) Close() {
 		s.cacnel()
 	}
 	defaultProxyMux.swap(&proxyMux{})
-	if s.config.sepatateControlAPI {
+	if s.config.SeparateControlAPI {
 		globalConf := config.Global()
 		globalConf.ControlAPIPort = 0
 		config.SetGlobal(globalConf)


### PR DESCRIPTION
With this PR, health check will be loaded to:
- control port, if `control_api_port` is set in `tyk.conf`
- listen port, if `control_api_port` is not set in `tyk.conf`

(Briefly it will be loaded in the same level with control api, only difference it will not require any authorization)

For example, you don't set `control_api_port` and you want to listen control api from `listen_port`. Although user sets listen path of one of apis to `/`, health check will be triggered when you call its endpoint e.g.`tyk-gateway:8181/hello`

Fixes https://github.com/TykTechnologies/tyk-operator/issues/205