### PR TITLE
[TT-107] Handle client certificate for custom domains in regex format

### DIFF
--- a/gateway/cert.go
+++ b/gateway/cert.go
@@ -390,21 +390,17 @@ func getTLSConfigForClient(baseConfig *tls.Config, listenPort int) func(hello *t
 			}
 		}
 
-		matches := false
+		newConfig.ClientAuth = tls.NoClientCert
+
 		for key, clientAuth := range domainRequireCert {
 			req := http.Request{Host: hello.ServerName, URL: &url.URL{}}
 			if mux.NewRouter().Host(key).Match(&req, &mux.RouteMatch{}) {
 				newConfig.ClientAuth = clientAuth
-				matches = true
 				break
 			}
 		}
 
-		if !matches {
-			newConfig.ClientAuth = tls.NoClientCert
-		}
-
-		if newConfig.ClientAuth == 0 {
+		if newConfig.ClientAuth == tls.NoClientCert {
 			newConfig.ClientAuth = domainRequireCert[""]
 		}
 


### PR DESCRIPTION
For custom domains routing, `gorilla` has its own type of regex. While handling client certificate with custom domain, we should use the same regex to make it work properly.

Fixes https://github.com/TykTechnologies/tyk/issues/3100