### PR TITLE
implement determining child fields in GraphQLConfigAdapter

### DIFF
--- a/apidef/graphql_config_adapter.go
+++ b/apidef/graphql_config_adapter.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/jensneuse/graphql-go-tools/pkg/ast"
+	"github.com/jensneuse/graphql-go-tools/pkg/astparser"
 	"github.com/jensneuse/graphql-go-tools/pkg/engine/datasource/graphql_datasource"
 	"github.com/jensneuse/graphql-go-tools/pkg/engine/datasource/httpclient"
 	"github.com/jensneuse/graphql-go-tools/pkg/engine/datasource/rest_datasource"
@@ -127,9 +129,121 @@ func (g *GraphQLConfigAdapter) engineConfigV2DataSources() (planDataSources []pl
 		planDataSources = append(planDataSources, planDataSource)
 	}
 
-	return planDataSources, nil
+	err = g.determineChildNodes(&planDataSources)
+	return planDataSources, err
 }
 
 func (g *GraphQLConfigAdapter) SetHttpClient(httpClient *http.Client) {
 	g.httpClient = httpClient
+}
+
+func (g *GraphQLConfigAdapter) determineChildNodes(planDataSources *[]plan.DataSourceConfiguration) error {
+	schema, report := astparser.ParseGraphqlDocumentString(g.config.Schema)
+	if report.HasErrors() {
+		return report
+	}
+	for i := range *planDataSources {
+		for j := range (*planDataSources)[i].RootNodes {
+			typeName := (*planDataSources)[i].RootNodes[j].TypeName
+			for k := range (*planDataSources)[i].RootNodes[j].FieldNames {
+				fieldName := (*planDataSources)[i].RootNodes[j].FieldNames[k]
+				children := g.findFieldChildren(typeName, fieldName, &schema, *planDataSources)
+				(*planDataSources)[i].ChildNodes = append((*planDataSources)[i].ChildNodes, children...)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *GraphQLConfigAdapter) findFieldChildren(typeName, fieldName string, schema *ast.Document, dataSources []plan.DataSourceConfiguration) []plan.TypeField {
+	node, exists := schema.Index.FirstNodeByNameStr(typeName)
+	if !exists {
+		return nil
+	}
+	var fields []int
+	switch node.Kind {
+	case ast.NodeKindObjectTypeDefinition:
+		fields = schema.ObjectTypeDefinitions[node.Ref].FieldsDefinition.Refs
+	case ast.NodeKindInterfaceTypeDefinition:
+		fields = schema.InterfaceTypeDefinitions[node.Ref].FieldsDefinition.Refs
+	default:
+		return nil
+	}
+	if len(fields) == 0 {
+		return nil
+	}
+	for _, ref := range fields {
+		if fieldName == schema.FieldDefinitionNameString(ref) {
+			fieldTypeName := schema.FieldDefinitionTypeNode(ref).NameString(schema)
+			childNodes := []plan.TypeField{}
+			g.findNestedFieldChildren(fieldTypeName, schema, dataSources, &childNodes)
+			return childNodes
+		}
+	}
+
+	return nil
+}
+
+func (g *GraphQLConfigAdapter) findNestedFieldChildren(typeName string, schema *ast.Document, dataSources []plan.DataSourceConfiguration, childNodes *[]plan.TypeField) {
+	node, exists := schema.Index.FirstNodeByNameStr(typeName)
+	if !exists {
+		return
+	}
+	var fields []int
+	switch node.Kind {
+	case ast.NodeKindObjectTypeDefinition:
+		fields = schema.ObjectTypeDefinitions[node.Ref].FieldsDefinition.Refs
+	case ast.NodeKindInterfaceTypeDefinition:
+		fields = schema.InterfaceTypeDefinitions[node.Ref].FieldsDefinition.Refs
+	default:
+		return
+	}
+	if len(fields) == 0 {
+		return
+	}
+	for _, ref := range fields {
+		fieldName := schema.FieldDefinitionNameString(ref)
+		if g.isRootField(typeName, fieldName, dataSources) {
+			continue
+		}
+		g.putChildNode(childNodes, typeName, fieldName)
+		fieldTypeName := schema.FieldDefinitionTypeNode(ref).NameString(schema)
+		g.findNestedFieldChildren(fieldTypeName, schema, dataSources, childNodes)
+	}
+	return
+}
+
+func (g *GraphQLConfigAdapter) isRootField(typeName, fieldName string, dataSources []plan.DataSourceConfiguration) bool {
+	for i := range dataSources {
+		for j := range dataSources[i].RootNodes {
+			if typeName != dataSources[i].RootNodes[j].TypeName {
+				continue
+			}
+			for k := range dataSources[i].RootNodes[j].FieldNames {
+				if fieldName == dataSources[i].RootNodes[j].FieldNames[k] {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func (g *GraphQLConfigAdapter) putChildNode(nodes *[]plan.TypeField, typeName, fieldName string) {
+	for i := range *nodes {
+		if typeName != (*nodes)[i].TypeName {
+			continue
+		}
+		for j := range (*nodes)[i].FieldNames {
+			if fieldName == (*nodes)[i].FieldNames[j] {
+				return
+			}
+		}
+		(*nodes)[i].FieldNames = append((*nodes)[i].FieldNames, fieldName)
+		return
+	}
+	*nodes = append(*nodes, plan.TypeField{
+		TypeName:   typeName,
+		FieldNames: []string{fieldName},
+	})
 }


### PR DESCRIPTION
This PR adds the functionality to determine the child nodes for the V2GraphQLEngineConfiguration.
The algorithm traverses from all root fields in the data sources and collects all non-root fields as children.
If children are of type "interface" or "object" they get traversed recursively, depth-first.
The algorithm can be further improved by allowing overlapping child fields. This makes sense, e.g. for GraphQL federation, where multiple microservices return the same field on a type but is not a requirement for now.