### PR TITLE
[TT-437]  Add test cases for white/blacklist endpoint including listen path

### DIFF
--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -115,7 +115,7 @@ func TestWhitelist(t *testing.T) {
 	t.Run("Simple Paths", func(t *testing.T) {
 		BuildAndLoadAPI(func(spec *APISpec) {
 			UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
-				v.Paths.WhiteList = []string{"/simple", "/regex/{id}/test"}
+				v.Paths.WhiteList = []string{"/simple", "pathWithoutSlash", "/regex/{id}/test"}
 				v.UseExtendedPaths = false
 			})
 
@@ -125,6 +125,7 @@ func TestWhitelist(t *testing.T) {
 		ts.Run(t, []test.TestCase{
 			// Should mock path
 			{Path: "/simple", Code: http.StatusOK},
+			{Path: "/pathWithoutSlash", Code: http.StatusOK},
 			{Path: "/regex/123/test", Code: http.StatusOK},
 			{Path: "/regex/123/differ", Code: http.StatusForbidden},
 			{Path: "/", Code: http.StatusForbidden},
@@ -172,6 +173,32 @@ func TestWhitelist(t *testing.T) {
 			{Path: "/Foo", Code: http.StatusOK},
 			{Path: "/bar", Code: http.StatusOK},
 			{Path: "/Bar", Code: http.StatusForbidden},
+		}...)
+	})
+
+	t.Run("Listen path matches", func(t *testing.T) {
+		BuildAndLoadAPI(func(spec *APISpec) {
+			UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+				v.Paths.WhiteList = []string{"/fruits/fruit"}
+				v.UseExtendedPaths = false
+			})
+
+			spec.Proxy.ListenPath = "/fruits/"
+		}, func(spec *APISpec) {
+			UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+				v.Paths.WhiteList = []string{"/vegetable$"}
+				v.UseExtendedPaths = false
+			})
+
+			spec.Proxy.ListenPath = "/vegetables/"
+		})
+
+		_, _ = ts.Run(t, []test.TestCase{
+			{Path: "/fruits/fruit", Code: http.StatusOK},
+			{Path: "/fruits/count", Code: http.StatusForbidden},
+
+			{Path: "/vegetables/vegetable", Code: http.StatusOK},
+			{Path: "/vegetables/count", Code: http.StatusForbidden},
 		}...)
 	})
 }
@@ -243,6 +270,32 @@ func TestBlacklist(t *testing.T) {
 			{Path: "/Foo", Code: http.StatusForbidden},
 			{Path: "/bar", Code: http.StatusForbidden},
 			{Path: "/Bar", Code: http.StatusOK},
+		}...)
+	})
+
+	t.Run("Listen path matches", func(t *testing.T) {
+		BuildAndLoadAPI(func(spec *APISpec) {
+			UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+				v.Paths.BlackList = []string{"/fruits/fruit"}
+				v.UseExtendedPaths = false
+			})
+
+			spec.Proxy.ListenPath = "/fruits/"
+		}, func(spec *APISpec) {
+			UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+				v.Paths.BlackList = []string{"/vegetable$"}
+				v.UseExtendedPaths = false
+			})
+
+			spec.Proxy.ListenPath = "/vegetables/"
+		})
+
+		_, _ = ts.Run(t, []test.TestCase{
+			{Path: "/fruits/fruit", Code: http.StatusForbidden},
+			{Path: "/fruits/count", Code: http.StatusOK},
+
+			{Path: "/vegetables/vegetable", Code: http.StatusForbidden},
+			{Path: "/vegetables/count", Code: http.StatusOK},
 		}...)
 	})
 }


### PR DESCRIPTION
The issue described in https://tyktech.atlassian.net/browse/TT-437 is not valid. To handle that situation `$` can be used.
This PR adds that test case.