### PR TITLE
[TT-1475] respect ignored paths in CoProcessMiddleware

### DIFF
--- a/coprocess/grpc/coprocess_grpc_test.go
+++ b/coprocess/grpc/coprocess_grpc_test.go
@@ -235,6 +235,54 @@ func loadTestGRPCAPIs() {
 				Driver: apidef.GrpcDriver,
 			}
 		},
+		func(spec *gateway.APISpec) {
+			spec.APIID = "ignore_plugin"
+			spec.OrgID = gateway.MockOrgID
+			spec.Auth = apidef.AuthConfig{
+				AuthHeaderName: "authorization",
+			}
+			spec.UseKeylessAccess = false
+			spec.EnableCoProcessAuth = true
+			spec.VersionData = struct {
+				NotVersioned   bool                          `bson:"not_versioned" json:"not_versioned"`
+				DefaultVersion string                        `bson:"default_version" json:"default_version"`
+				Versions       map[string]apidef.VersionInfo `bson:"versions" json:"versions"`
+			}{
+				DefaultVersion: "v1",
+				Versions: map[string]apidef.VersionInfo{
+					"v1": {
+						Name:             "v1",
+						UseExtendedPaths: true,
+						ExtendedPaths: apidef.ExtendedPathsSet{
+							Ignored: []apidef.EndPointMeta{
+								{
+									Path:       "/anything",
+									IgnoreCase: true,
+									MethodActions: map[string]apidef.EndpointMethodMeta{
+										http.MethodGet: {
+											Action: apidef.NoAction,
+											Code:   http.StatusOK,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			spec.Proxy.ListenPath = "/grpc-test-api-ignore/"
+			spec.Proxy.StripListenPath = true
+			spec.CustomMiddleware = apidef.MiddlewareSection{
+				Driver: apidef.GrpcDriver,
+				IdExtractor: apidef.MiddlewareIdExtractor{
+					ExtractFrom: apidef.HeaderSource,
+					ExtractWith: apidef.ValueExtractor,
+					ExtractorConfig: map[string]interface{}{
+						"header_name": "Authorization",
+					},
+				},
+			}
+		},
 	)
 }
 
@@ -408,4 +456,44 @@ func randStringBytes(n int) string {
 	}
 
 	return string(b)
+}
+
+func TestGRPCIgnore(t *testing.T) {
+	ts, grpcServer := startTykWithGRPC()
+	defer ts.Close()
+	defer grpcServer.Stop()
+
+	path := "/grpc-test-api-ignore/"
+
+	// no header
+	ts.Run(t, test.TestCase{
+		Path:   path + "something",
+		Method: http.MethodGet,
+		Code:   http.StatusBadRequest,
+		BodyMatchFunc: func(b []byte) bool {
+			return bytes.Contains(b, []byte("Authorization field missing"))
+		},
+	})
+
+	ts.Run(t, test.TestCase{
+		Path:   path + "anything",
+		Method: http.MethodGet,
+		Code:   http.StatusOK,
+	})
+
+	// bad header
+	headers := map[string]string{"authorization": "bad"}
+	ts.Run(t, test.TestCase{
+		Path:    path + "something",
+		Method:  http.MethodGet,
+		Code:    http.StatusForbidden,
+		Headers: headers,
+	})
+
+	ts.Run(t, test.TestCase{
+		Path:    path + "anything",
+		Method:  http.MethodGet,
+		Code:    http.StatusOK,
+		Headers: headers,
+	})
 }

--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -294,10 +294,12 @@ func (m *CoProcessMiddleware) EnabledForSpec() bool {
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
+	if ctxGetRequestStatus(r) == StatusOkAndIgnore {
+		return nil, http.StatusOK
+	}
 	logger := m.Logger()
 	logger.Debug("CoProcess Request, HookType: ", m.HookType)
 	originalURL := r.URL
-
 	authToken, _ := m.getAuthToken(coprocessType, r)
 
 	var extractor IdExtractor

--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -294,9 +294,12 @@ func (m *CoProcessMiddleware) EnabledForSpec() bool {
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
-	if ctxGetRequestStatus(r) == StatusOkAndIgnore {
-		return nil, http.StatusOK
+	if m.HookType == coprocess.HookType_CustomKeyCheck {
+		if ctxGetRequestStatus(r) == StatusOkAndIgnore {
+			return nil, http.StatusOK
+		}
 	}
+
 	logger := m.Logger()
 	logger.Debug("CoProcess Request, HookType: ", m.HookType)
 	originalURL := r.URL


### PR DESCRIPTION
This adds a check before we process request with coprocess middleware to ensure we skip the middleware when we have 
`StatusOkAndIgnore` set in context.

## Related Issue
fixes #3383

## Motivation and Context
If you have coprocess set and ignore extended paths. Then the ignored extended paths won't be respected.


## How This Has Been Tested
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of
the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [x] `go vet`
