### PR TITLE
fix parsing GraphQL queries before checking auth (TT-1402)

### DIFF
--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -420,8 +420,11 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 
 	mwAppendEnabled(&chainArray, &RateLimitForAPI{BaseMiddleware: baseMid})
 	mwAppendEnabled(&chainArray, &GraphQLMiddleware{BaseMiddleware: baseMid})
-	mwAppendEnabled(&chainArray, &GraphQLComplexityMiddleware{BaseMiddleware: baseMid})
-	mwAppendEnabled(&chainArray, &GraphQLGranularAccessMiddleware{BaseMiddleware: baseMid})
+	if !spec.UseKeylessAccess {
+		mwAppendEnabled(&chainArray, &GraphQLComplexityMiddleware{BaseMiddleware: baseMid})
+		mwAppendEnabled(&chainArray, &GraphQLGranularAccessMiddleware{BaseMiddleware: baseMid})
+	}
+
 	mwAppendEnabled(&chainArray, &ValidateJSON{BaseMiddleware: baseMid})
 	mwAppendEnabled(&chainArray, &TransformMiddleware{baseMid})
 	mwAppendEnabled(&chainArray, &TransformJQMiddleware{baseMid})

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -333,7 +333,6 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 	mwAppendEnabled(&chainArray, &RequestSizeLimitMiddleware{baseMid})
 	mwAppendEnabled(&chainArray, &MiddlewareContextVars{BaseMiddleware: baseMid})
 	mwAppendEnabled(&chainArray, &TrackEndpointMiddleware{baseMid})
-	mwAppendEnabled(&chainArray, &GraphQLMiddleware{BaseMiddleware: baseMid})
 
 	if !spec.UseKeylessAccess {
 		// Select the keying method to use for setting session states
@@ -420,6 +419,9 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 	}
 
 	mwAppendEnabled(&chainArray, &RateLimitForAPI{BaseMiddleware: baseMid})
+	mwAppendEnabled(&chainArray, &GraphQLMiddleware{BaseMiddleware: baseMid})
+	mwAppendEnabled(&chainArray, &GraphQLComplexityMiddleware{BaseMiddleware: baseMid})
+	mwAppendEnabled(&chainArray, &GraphQLGranularAccessMiddleware{BaseMiddleware: baseMid})
 	mwAppendEnabled(&chainArray, &ValidateJSON{BaseMiddleware: baseMid})
 	mwAppendEnabled(&chainArray, &TransformMiddleware{baseMid})
 	mwAppendEnabled(&chainArray, &TransformJQMiddleware{baseMid})

--- a/gateway/mw_granular_access.go
+++ b/gateway/mw_granular_access.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/TykTechnologies/tyk/headers"
-
 	"github.com/TykTechnologies/tyk/regexp"
 )
 
@@ -30,31 +28,6 @@ func (m *GranularAccessMiddleware) ProcessRequest(w http.ResponseWriter, r *http
 	sessionVersionData, foundAPI := session.GetAccessRightByAPIID(m.Spec.APIID)
 	if !foundAPI {
 		return nil, http.StatusOK
-	}
-
-	if m.Spec.GraphQL.Enabled {
-		if len(sessionVersionData.RestrictedTypes) == 0 {
-			return nil, http.StatusOK
-		}
-
-		gqlRequest := ctxGetGraphQLRequest(r)
-
-		result, err := gqlRequest.ValidateRestrictedFields(m.Spec.GraphQLExecutor.Schema, sessionVersionData.RestrictedTypes)
-		if err != nil {
-			m.Logger().Errorf("Error during GraphQL request restricted fields validation: '%s'", err)
-			return errors.New("there was a problem proxying the request"), http.StatusInternalServerError
-		}
-
-		if !result.Valid || (result.Errors != nil && result.Errors.Count() > 0) {
-			w.Header().Set(headers.ContentType, headers.ApplicationJSON)
-			w.WriteHeader(http.StatusBadRequest)
-			_, _ = result.Errors.WriteResponse(w)
-			m.Logger().Debugf("Error during GraphQL request restricted fields validation: '%s'", result.Errors)
-			return errCustomBodyResponse, http.StatusBadRequest
-		}
-
-		return nil, http.StatusOK
-
 	}
 
 	if len(sessionVersionData.AllowedURLs) == 0 {

--- a/gateway/mw_granular_access_test.go
+++ b/gateway/mw_granular_access_test.go
@@ -4,21 +4,18 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/jensneuse/graphql-go-tools/pkg/graphql"
-
 	"github.com/TykTechnologies/tyk/headers"
 	"github.com/TykTechnologies/tyk/test"
 	"github.com/TykTechnologies/tyk/user"
 )
 
-func TestGraphQL_RestrictedTypes(t *testing.T) {
+func TestGranularAccessMiddleware_ProcessRequest(t *testing.T) {
 	g := StartTest()
 	defer g.Close()
 
 	api := BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/"
 		spec.UseKeylessAccess = false
-		spec.GraphQL.Enabled = true
 	})[0]
 
 	_, directKey := g.CreateSession(func(s *user.SessionState) {
@@ -26,10 +23,10 @@ func TestGraphQL_RestrictedTypes(t *testing.T) {
 			api.APIID: {
 				APIID:   api.APIID,
 				APIName: api.Name,
-				RestrictedTypes: []graphql.Type{
+				AllowedURLs: []user.AccessSpec{
 					{
-						Name:   "Country",
-						Fields: []string{"code"},
+						URL:     "^/valid_path.*",
+						Methods: []string{"GET"},
 					},
 				},
 			},
@@ -41,10 +38,10 @@ func TestGraphQL_RestrictedTypes(t *testing.T) {
 			api.APIID: {
 				APIID:   api.APIID,
 				APIName: api.Name,
-				RestrictedTypes: []graphql.Type{
+				AllowedURLs: []user.AccessSpec{
 					{
-						Name:   "Country",
-						Fields: []string{"name"},
+						URL:     "^/valid_path.*",
+						Methods: []string{"GET"},
 					},
 				},
 			},
@@ -55,24 +52,44 @@ func TestGraphQL_RestrictedTypes(t *testing.T) {
 		s.ApplyPolicies = []string{pID}
 	})
 
-	q1 := graphql.Request{
-		Query: "query Query { countries { code } }",
-	}
-
-	q2 := graphql.Request{
-		Query: "query Query { countries { name } }",
-	}
-
 	t.Run("Direct key", func(t *testing.T) {
 		authHeaderWithDirectKey := map[string]string{
 			headers.Authorization: directKey,
 		}
 
-		_, _ = g.Run(t, []test.TestCase{
-			{Data: q1, Headers: authHeaderWithDirectKey,
-				BodyMatch: `{"errors":\[{"message":"field: code is restricted on type: Country","path":null}\]}`, Code: http.StatusBadRequest},
-			{Data: q2, Headers: authHeaderWithDirectKey, Code: http.StatusOK},
-		}...)
+		t.Run("should return 200 OK on allowed path with allowed method", func(t *testing.T) {
+			_, _ = g.Run(t, []test.TestCase{
+				{
+					Path:    "/valid_path",
+					Method:  http.MethodGet,
+					Code:    http.StatusOK,
+					Headers: authHeaderWithDirectKey,
+				},
+			}...)
+		})
+
+		t.Run("should return 403 Forbidden on allowed path with disallowed method", func(t *testing.T) {
+			_, _ = g.Run(t, []test.TestCase{
+				{
+					Path:    "/valid_path",
+					Method:  http.MethodPost,
+					Code:    http.StatusForbidden,
+					Headers: authHeaderWithDirectKey,
+				},
+			}...)
+		})
+
+		t.Run("should return 403 Forbidden on disallowed path with allowed method", func(t *testing.T) {
+			_, _ = g.Run(t, []test.TestCase{
+				{
+					Path:    "/invalid_path",
+					Method:  http.MethodGet,
+					Code:    http.StatusForbidden,
+					Headers: authHeaderWithDirectKey,
+				},
+			}...)
+		})
+
 	})
 
 	t.Run("Policy applied key", func(t *testing.T) {
@@ -80,10 +97,37 @@ func TestGraphQL_RestrictedTypes(t *testing.T) {
 			headers.Authorization: policyAppliedKey,
 		}
 
-		_, _ = g.Run(t, []test.TestCase{
-			{Data: q2, Headers: authHeaderWithPolicyAppliedKey,
-				BodyMatch: `{"errors":\[{"message":"field: name is restricted on type: Country","path":null}\]}`, Code: http.StatusBadRequest},
-			{Data: q1, Headers: authHeaderWithPolicyAppliedKey, Code: http.StatusOK},
-		}...)
+		t.Run("should return 200 OK on allowed path with allowed method", func(t *testing.T) {
+			_, _ = g.Run(t, []test.TestCase{
+				{
+					Path:    "/valid_path",
+					Method:  http.MethodGet,
+					Code:    http.StatusOK,
+					Headers: authHeaderWithPolicyAppliedKey,
+				},
+			}...)
+		})
+
+		t.Run("should return 403 Forbidden on allowed path with disallowed method", func(t *testing.T) {
+			_, _ = g.Run(t, []test.TestCase{
+				{
+					Path:    "/valid_path",
+					Method:  http.MethodPost,
+					Code:    http.StatusForbidden,
+					Headers: authHeaderWithPolicyAppliedKey,
+				},
+			}...)
+		})
+
+		t.Run("should return 403 Forbidden on disallowed path with allowed method", func(t *testing.T) {
+			_, _ = g.Run(t, []test.TestCase{
+				{
+					Path:    "/invalid_path",
+					Method:  http.MethodGet,
+					Code:    http.StatusForbidden,
+					Headers: authHeaderWithPolicyAppliedKey,
+				},
+			}...)
+		})
 	})
 }

--- a/gateway/mw_graphql_complexity.go
+++ b/gateway/mw_graphql_complexity.go
@@ -51,7 +51,7 @@ func (m *GraphQLComplexityMiddleware) ProcessRequest(w http.ResponseWriter, r *h
 
 func (m *GraphQLComplexityMiddleware) DepthLimitEnabled(accessDef *user.AccessDefinition) bool {
 	// There is a possibility that depth limit is disabled on field level too,
-	// but we continue with this because of the explanation above.
+	// but we could not determine this without analyzing actual requested fields.
 	if len(accessDef.FieldAccessRights) > 0 {
 		return true
 	}

--- a/gateway/mw_graphql_complexity.go
+++ b/gateway/mw_graphql_complexity.go
@@ -26,7 +26,7 @@ func (m *GraphQLComplexityMiddleware) Name() string {
 }
 
 func (m *GraphQLComplexityMiddleware) EnabledForSpec() bool {
-	return m.Spec.GraphQL.Enabled && !m.Spec.UseKeylessAccess
+	return m.Spec.GraphQL.Enabled
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail

--- a/gateway/mw_graphql_complexity.go
+++ b/gateway/mw_graphql_complexity.go
@@ -1,0 +1,109 @@
+package gateway
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/jensneuse/graphql-go-tools/pkg/graphql"
+
+	"github.com/TykTechnologies/tyk/user"
+)
+
+type ComplexityFailReason int
+
+const (
+	ComplexityFailReasonNone ComplexityFailReason = iota
+	ComplexityFailReasonInternalError
+	ComplexityFailReasonDepthLimitExceeded
+)
+
+type GraphQLComplexityMiddleware struct {
+	BaseMiddleware
+}
+
+func (m *GraphQLComplexityMiddleware) Name() string {
+	return "GraphQLComplexityMiddleware"
+}
+
+func (m *GraphQLComplexityMiddleware) EnabledForSpec() bool {
+	return m.Spec.GraphQL.Enabled && !m.Spec.UseKeylessAccess
+}
+
+// ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
+func (m *GraphQLComplexityMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
+	accessDef, _, err := GetAccessDefinitionByAPIIDOrSession(ctxGetSession(r), m.Spec)
+	if err != nil {
+		m.Logger().Debugf("Error while calculating GraphQL complexity: '%s'", err)
+		return m.handleComplexityFailReason(ComplexityFailReasonInternalError)
+	}
+
+	gqlRequest := ctxGetGraphQLRequest(r)
+
+	// If MaxQueryDepth is -1 or 0, it means unlimited and no need for depth limiting.
+	if m.DepthLimitEnabled(accessDef) {
+		if failReason := m.DepthLimitExceeded(gqlRequest, accessDef, m.Spec.GraphQLExecutor.Schema); failReason != ComplexityFailReasonNone {
+			return m.handleComplexityFailReason(failReason)
+		}
+	}
+
+	return nil, http.StatusOK
+}
+
+func (m *GraphQLComplexityMiddleware) DepthLimitEnabled(accessDef *user.AccessDefinition) bool {
+	// There is a possibility that depth limit is disabled on field level too,
+	// but we continue with this because of the explanation above.
+	if len(accessDef.FieldAccessRights) > 0 {
+		return true
+	}
+
+	return accessDef.Limit.MaxQueryDepth > 0
+}
+
+func (m *GraphQLComplexityMiddleware) DepthLimitExceeded(gqlRequest *graphql.Request, accessDef *user.AccessDefinition, schema *graphql.Schema) ComplexityFailReason {
+	complexityRes, err := gqlRequest.CalculateComplexity(graphql.DefaultComplexityCalculator, schema)
+	if err != nil {
+		log.Errorf("Error while calculating complexity of GraphQL request: '%s'", err)
+		return ComplexityFailReasonInternalError
+	}
+
+	// do per query depth check
+	if len(accessDef.FieldAccessRights) == 0 {
+		if complexityRes.Depth > accessDef.Limit.MaxQueryDepth {
+			log.Debugf("Complexity of the request is higher than the allowed limit '%d'", accessDef.Limit.MaxQueryDepth)
+			return ComplexityFailReasonDepthLimitExceeded
+		}
+		return ComplexityFailReasonNone
+	}
+
+	// do per query field depth check
+	for _, fieldAccessDef := range accessDef.FieldAccessRights {
+		for _, fieldComplexityRes := range complexityRes.PerRootField {
+			if fieldComplexityRes.TypeName != fieldAccessDef.TypeName {
+				continue
+			}
+			if fieldComplexityRes.FieldName != fieldAccessDef.FieldName {
+				continue
+			}
+
+			if greaterThanInt(fieldComplexityRes.Depth, fieldAccessDef.Limits.MaxQueryDepth) {
+				log.Debugf("Complexity of the field: %s.%s is higher than the allowed limit '%d'",
+					fieldAccessDef.TypeName, fieldAccessDef.FieldName, accessDef.Limit.MaxQueryDepth)
+
+				return ComplexityFailReasonDepthLimitExceeded
+			}
+		}
+	}
+
+	return ComplexityFailReasonNone
+}
+
+func (m *GraphQLComplexityMiddleware) handleComplexityFailReason(failReason ComplexityFailReason) (error, int) {
+	switch failReason {
+	case ComplexityFailReasonInternalError:
+		return errors.New("there was a problem proxying the request"), http.StatusInternalServerError
+	case ComplexityFailReasonDepthLimitExceeded:
+		return errors.New("depth limit exceeded"), http.StatusForbidden
+	}
+
+	return nil, http.StatusOK
+}

--- a/gateway/mw_graphql_complexity_test.go
+++ b/gateway/mw_graphql_complexity_test.go
@@ -1,0 +1,115 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/jensneuse/graphql-go-tools/pkg/graphql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/user"
+)
+
+func TestGraphQLComplexityMiddleware_DepthLimitEnabled(t *testing.T) {
+	m := GraphQLComplexityMiddleware{}
+
+	accessDefPerField := &user.AccessDefinition{
+		FieldAccessRights: []user.FieldAccessDefinition{
+			{TypeName: "Query", FieldName: "countries", Limits: user.FieldLimits{MaxQueryDepth: 0}},
+			{TypeName: "Query", FieldName: "continents", Limits: user.FieldLimits{MaxQueryDepth: -1}},
+			{TypeName: "Mutation", FieldName: "putCountry", Limits: user.FieldLimits{MaxQueryDepth: 2}},
+		},
+		Limit: &user.APILimit{
+			MaxQueryDepth: 0,
+		},
+	}
+
+	accessDefWithGlobal := &user.AccessDefinition{
+		Limit: &user.APILimit{
+			MaxQueryDepth: 2,
+		},
+	}
+
+	t.Run("Per field", func(t *testing.T) {
+		assert.True(t, m.DepthLimitEnabled(accessDefPerField))
+		accessDefPerField.FieldAccessRights = []user.FieldAccessDefinition{}
+		assert.False(t, m.DepthLimitEnabled(accessDefPerField))
+	})
+
+	t.Run("Global", func(t *testing.T) {
+		assert.True(t, m.DepthLimitEnabled(accessDefWithGlobal))
+		accessDefWithGlobal.Limit.MaxQueryDepth = 0
+		assert.False(t, m.DepthLimitEnabled(accessDefWithGlobal))
+	})
+}
+
+func TestGraphQLComplexityMiddleware_DepthLimitExceeded(t *testing.T) {
+	m := GraphQLComplexityMiddleware{}
+	countriesSchema, err := graphql.NewSchemaFromString(gqlCountriesSchema)
+	require.NoError(t, err)
+
+	req := &graphql.Request{
+		OperationName: "TestQuery",
+		Variables:     nil,
+		Query:         "query TestQuery { countries { code name continent { code name countries { code name } } } }",
+	}
+
+	accessDef := &user.AccessDefinition{
+		Limit: &user.APILimit{
+			MaxQueryDepth: 3,
+		},
+		FieldAccessRights: []user.FieldAccessDefinition{},
+	}
+
+	t.Run("should fallback to global limit and exceed", func(t *testing.T) {
+		failReason := m.DepthLimitExceeded(req, accessDef, countriesSchema)
+		assert.Equal(t, ComplexityFailReasonDepthLimitExceeded, failReason)
+	})
+
+	t.Run("should respect unlimited specific field depth limit and not exceed", func(t *testing.T) {
+		accessDef.FieldAccessRights = []user.FieldAccessDefinition{
+			{
+				TypeName:  "Query",
+				FieldName: "countries",
+				Limits: user.FieldLimits{
+					MaxQueryDepth: -1,
+				},
+			},
+		}
+
+		failReason := m.DepthLimitExceeded(req, accessDef, countriesSchema)
+		assert.Equal(t, ComplexityFailReasonNone, failReason)
+	})
+
+	t.Run("should respect higher specific field depth limit and not exceed", func(t *testing.T) {
+		accessDef.FieldAccessRights = []user.FieldAccessDefinition{
+			{
+				TypeName:  "Query",
+				FieldName: "countries",
+				Limits: user.FieldLimits{
+					MaxQueryDepth: 10,
+				},
+			},
+		}
+
+		failReason := m.DepthLimitExceeded(req, accessDef, countriesSchema)
+		assert.Equal(t, ComplexityFailReasonNone, failReason)
+	})
+
+	t.Run("should respect lower specific field depth limit and exceed", func(t *testing.T) {
+		accessDef.Limit.MaxQueryDepth = 100
+		accessDef.FieldAccessRights = []user.FieldAccessDefinition{
+			{
+				TypeName:  "Query",
+				FieldName: "countries",
+				Limits: user.FieldLimits{
+					MaxQueryDepth: 1,
+				},
+			},
+		}
+
+		failReason := m.DepthLimitExceeded(req, accessDef, countriesSchema)
+		assert.Equal(t, ComplexityFailReasonDepthLimitExceeded, failReason)
+	})
+
+}

--- a/gateway/mw_graphql_granular_access.go
+++ b/gateway/mw_graphql_granular_access.go
@@ -1,0 +1,56 @@
+package gateway
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/TykTechnologies/tyk/headers"
+)
+
+type GraphQLGranularAccessMiddleware struct {
+	BaseMiddleware
+}
+
+func (m *GraphQLGranularAccessMiddleware) Name() string {
+	return "GraphQLGranularAccessMiddleware"
+}
+
+func (m *GraphQLGranularAccessMiddleware) EnabledForSpec() bool {
+	return m.Spec.GraphQL.Enabled
+}
+
+// ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
+func (m *GraphQLGranularAccessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
+	if ctxGetRequestStatus(r) == StatusOkAndIgnore {
+		return nil, http.StatusOK
+	}
+
+	session := ctxGetSession(r)
+
+	sessionVersionData, foundAPI := session.GetAccessRightByAPIID(m.Spec.APIID)
+	if !foundAPI {
+		return nil, http.StatusOK
+	}
+
+	if len(sessionVersionData.RestrictedTypes) == 0 {
+		return nil, http.StatusOK
+	}
+
+	gqlRequest := ctxGetGraphQLRequest(r)
+
+	result, err := gqlRequest.ValidateRestrictedFields(m.Spec.GraphQLExecutor.Schema, sessionVersionData.RestrictedTypes)
+	if err != nil {
+		m.Logger().Errorf("Error during GraphQL request restricted fields validation: '%s'", err)
+		return errors.New("there was a problem proxying the request"), http.StatusInternalServerError
+	}
+
+	if !result.Valid || (result.Errors != nil && result.Errors.Count() > 0) {
+		w.Header().Set(headers.ContentType, headers.ApplicationJSON)
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = result.Errors.WriteResponse(w)
+		m.Logger().Debugf("Error during GraphQL request restricted fields validation: '%s'", result.Errors)
+		return errCustomBodyResponse, http.StatusBadRequest
+	}
+
+	return nil, http.StatusOK
+}

--- a/gateway/mw_graphql_granular_access.go
+++ b/gateway/mw_graphql_granular_access.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/jensneuse/graphql-go-tools/pkg/graphql"
+
 	"github.com/TykTechnologies/tyk/headers"
 )
 
@@ -38,7 +40,12 @@ func (m *GraphQLGranularAccessMiddleware) ProcessRequest(w http.ResponseWriter, 
 
 	gqlRequest := ctxGetGraphQLRequest(r)
 
-	result, err := gqlRequest.ValidateRestrictedFields(m.Spec.GraphQLExecutor.Schema, sessionVersionData.RestrictedTypes)
+	restrictedFieldsList := graphql.FieldRestrictionList{
+		Kind:  graphql.BlockList,
+		Types: sessionVersionData.RestrictedTypes,
+	}
+
+	result, err := gqlRequest.ValidateFieldRestrictions(m.Spec.GraphQLExecutor.Schema, restrictedFieldsList, graphql.DefaultFieldsValidator{})
 	if err != nil {
 		m.Logger().Errorf("Error during GraphQL request restricted fields validation: '%s'", err)
 		return errors.New("there was a problem proxying the request"), http.StatusInternalServerError

--- a/gateway/mw_graphql_granular_access.go
+++ b/gateway/mw_graphql_granular_access.go
@@ -16,7 +16,7 @@ func (m *GraphQLGranularAccessMiddleware) Name() string {
 }
 
 func (m *GraphQLGranularAccessMiddleware) EnabledForSpec() bool {
-	return m.Spec.GraphQL.Enabled && !m.Spec.UseKeylessAccess
+	return m.Spec.GraphQL.Enabled
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail

--- a/gateway/mw_graphql_granular_access.go
+++ b/gateway/mw_graphql_granular_access.go
@@ -16,7 +16,7 @@ func (m *GraphQLGranularAccessMiddleware) Name() string {
 }
 
 func (m *GraphQLGranularAccessMiddleware) EnabledForSpec() bool {
-	return m.Spec.GraphQL.Enabled
+	return m.Spec.GraphQL.Enabled && !m.Spec.UseKeylessAccess
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail

--- a/gateway/mw_graphql_granular_access_test.go
+++ b/gateway/mw_graphql_granular_access_test.go
@@ -1,0 +1,89 @@
+package gateway
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/jensneuse/graphql-go-tools/pkg/graphql"
+
+	"github.com/TykTechnologies/tyk/headers"
+	"github.com/TykTechnologies/tyk/test"
+	"github.com/TykTechnologies/tyk/user"
+)
+
+func TestGraphQL_RestrictedTypes(t *testing.T) {
+	g := StartTest()
+	defer g.Close()
+
+	api := BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/"
+		spec.UseKeylessAccess = false
+		spec.GraphQL.Enabled = true
+	})[0]
+
+	_, directKey := g.CreateSession(func(s *user.SessionState) {
+		s.AccessRights = map[string]user.AccessDefinition{
+			api.APIID: {
+				APIID:   api.APIID,
+				APIName: api.Name,
+				RestrictedTypes: []graphql.Type{
+					{
+						Name:   "Country",
+						Fields: []string{"code"},
+					},
+				},
+			},
+		}
+	})
+
+	pID := CreatePolicy(func(p *user.Policy) {
+		p.AccessRights = map[string]user.AccessDefinition{
+			api.APIID: {
+				APIID:   api.APIID,
+				APIName: api.Name,
+				RestrictedTypes: []graphql.Type{
+					{
+						Name:   "Country",
+						Fields: []string{"name"},
+					},
+				},
+			},
+		}
+	})
+
+	_, policyAppliedKey := g.CreateSession(func(s *user.SessionState) {
+		s.ApplyPolicies = []string{pID}
+	})
+
+	q1 := graphql.Request{
+		Query: "query Query { countries { code } }",
+	}
+
+	q2 := graphql.Request{
+		Query: "query Query { countries { name } }",
+	}
+
+	t.Run("Direct key", func(t *testing.T) {
+		authHeaderWithDirectKey := map[string]string{
+			headers.Authorization: directKey,
+		}
+
+		_, _ = g.Run(t, []test.TestCase{
+			{Data: q1, Headers: authHeaderWithDirectKey,
+				BodyMatch: `{"errors":\[{"message":"field: code is restricted on type: Country","path":null}\]}`, Code: http.StatusBadRequest},
+			{Data: q2, Headers: authHeaderWithDirectKey, Code: http.StatusOK},
+		}...)
+	})
+
+	t.Run("Policy applied key", func(t *testing.T) {
+		authHeaderWithPolicyAppliedKey := map[string]string{
+			headers.Authorization: policyAppliedKey,
+		}
+
+		_, _ = g.Run(t, []test.TestCase{
+			{Data: q2, Headers: authHeaderWithPolicyAppliedKey,
+				BodyMatch: `{"errors":\[{"message":"field: name is restricted on type: Country","path":null}\]}`, Code: http.StatusBadRequest},
+			{Data: q1, Headers: authHeaderWithPolicyAppliedKey, Code: http.StatusOK},
+		}...)
+	})
+}

--- a/gateway/mw_graphql_test.go
+++ b/gateway/mw_graphql_test.go
@@ -156,12 +156,12 @@ func TestGraphQLMiddleware_RequestValidation(t *testing.T) {
 			_, _ = g.Run(t, test.TestCase{Headers: authHeaderWithDirectKey, Data: request, BodyMatch: "hello", Code: http.StatusOK})
 		})
 
-		t.Run("Invalid query should return 401 when auth is failing", func(t *testing.T) {
+		t.Run("Invalid query should return 403 when auth is failing", func(t *testing.T) {
 			request.Query = "query Hello {"
-			directSession.MaxQueryDepth = 2
-			_ = GlobalSessionManager.UpdateSession("invalid key", directSession, 0, false)
-
-			_, _ = g.Run(t, test.TestCase{Headers: authHeaderWithDirectKey, Data: request, BodyMatch: "hello", Code: http.StatusUnauthorized})
+			authHeaderWithInvalidDirectKey := map[string]string{
+				headers.Authorization: "invalid key",
+			}
+			_, _ = g.Run(t, test.TestCase{Headers: authHeaderWithInvalidDirectKey, Data: request, BodyMatch: "", Code: http.StatusForbidden})
 		})
 	})
 }

--- a/gateway/mw_graphql_test.go
+++ b/gateway/mw_graphql_test.go
@@ -82,6 +82,7 @@ func TestGraphQLMiddleware_RequestValidation(t *testing.T) {
 
 	t.Run("with policies", func(t *testing.T) {
 		spec.UseKeylessAccess = false
+		spec.GraphQL.Schema = "schema { query: Query } type Query { hello: word } type word { numOfLetters: Int }"
 		LoadAPI(spec)
 
 		pID := CreatePolicy(func(p *user.Policy) {

--- a/gateway/mw_graphql_test.go
+++ b/gateway/mw_graphql_test.go
@@ -155,6 +155,14 @@ func TestGraphQLMiddleware_RequestValidation(t *testing.T) {
 
 			_, _ = g.Run(t, test.TestCase{Headers: authHeaderWithDirectKey, Data: request, BodyMatch: "hello", Code: http.StatusOK})
 		})
+
+		t.Run("Invalid query should return 401 when auth is failing", func(t *testing.T) {
+			request.Query = "query Hello {"
+			directSession.MaxQueryDepth = 2
+			_ = GlobalSessionManager.UpdateSession("invalid key", directSession, 0, false)
+
+			_, _ = g.Run(t, test.TestCase{Headers: authHeaderWithDirectKey, Data: request, BodyMatch: "hello", Code: http.StatusUnauthorized})
+		})
 	})
 }
 

--- a/gateway/mw_rate_limiting.go
+++ b/gateway/mw_rate_limiting.go
@@ -139,8 +139,6 @@ func (k *RateLimitAndQuotaCheck) ProcessRequest(w http.ResponseWriter, r *http.R
 
 	case sessionFailQuota:
 		return k.handleQuotaFailure(r, token)
-	case sessionFailDepthLimit:
-		return errors.New("depth limit exceeded"), http.StatusForbidden
 	case sessionFailInternalServerError:
 		return errors.New("there was a problem proxying the request"), http.StatusInternalServerError
 	default:

--- a/gateway/session_manager_test.go
+++ b/gateway/session_manager_test.go
@@ -3,118 +3,134 @@ package gateway
 import (
 	"testing"
 
-	"github.com/jensneuse/graphql-go-tools/pkg/graphql"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
+	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/user"
 )
 
-func TestSessionLimiter_DepthLimitEnabled(t *testing.T) {
-	l := SessionLimiter{}
-
-	accessDefPerField := &user.AccessDefinition{
-		FieldAccessRights: []user.FieldAccessDefinition{
-			{TypeName: "Query", FieldName: "countries", Limits: user.FieldLimits{MaxQueryDepth: 0}},
-			{TypeName: "Query", FieldName: "continents", Limits: user.FieldLimits{MaxQueryDepth: -1}},
-			{TypeName: "Mutation", FieldName: "putCountry", Limits: user.FieldLimits{MaxQueryDepth: 2}},
-		},
-		Limit: &user.APILimit{
-			MaxQueryDepth: 0,
+func TestGetAccessDefinitionByAPIIDOrSession(t *testing.T) {
+	api := &APISpec{
+		APIDefinition: &apidef.APIDefinition{
+			APIID: "api",
 		},
 	}
 
-	accessDefWithGlobal := &user.AccessDefinition{
-		Limit: &user.APILimit{
-			MaxQueryDepth: 2,
-		},
-	}
+	t.Run("should return error when api is missing in access rights", func(t *testing.T) {
+		sessionWithMissingAPI := &user.SessionState{
+			QuotaMax:           int64(1),
+			QuotaRenewalRate:   int64(1),
+			QuotaRenews:        int64(1),
+			Rate:               1.0,
+			Per:                1.0,
+			ThrottleInterval:   1.0,
+			ThrottleRetryLimit: 1.0,
+			MaxQueryDepth:      1.0,
+			AccessRights: map[string]user.AccessDefinition{
+				"another-api": {},
+			},
+		}
 
-	t.Run("graphqlEnabled", func(t *testing.T) {
-		assert.False(t, l.DepthLimitEnabled(false, accessDefWithGlobal))
-		assert.True(t, l.DepthLimitEnabled(true, accessDefWithGlobal))
+		accessDef, allowanceScope, err := GetAccessDefinitionByAPIIDOrSession(sessionWithMissingAPI, api)
+		assert.Nil(t, accessDef)
+		assert.Equal(t, "", allowanceScope)
+		assert.Error(t, err)
+		assert.Equal(t, "unexpected apiID", err.Error())
 	})
 
-	t.Run("Per field", func(t *testing.T) {
-		assert.True(t, l.DepthLimitEnabled(true, accessDefPerField))
-		accessDefPerField.FieldAccessRights = []user.FieldAccessDefinition{}
-		assert.False(t, l.DepthLimitEnabled(true, accessDefPerField))
-	})
-
-	t.Run("Global", func(t *testing.T) {
-		assert.True(t, l.DepthLimitEnabled(true, accessDefWithGlobal))
-		accessDefWithGlobal.Limit.MaxQueryDepth = 0
-		assert.False(t, l.DepthLimitEnabled(true, accessDefWithGlobal))
-	})
-}
-
-func TestSessionLimiter_DepthLimitExceeded(t *testing.T) {
-	l := SessionLimiter{}
-	countriesSchema, err := graphql.NewSchemaFromString(gqlCountriesSchema)
-	require.NoError(t, err)
-
-	req := &graphql.Request{
-		OperationName: "TestQuery",
-		Variables:     nil,
-		Query:         "query TestQuery { countries { code name continent { code name countries { code name } } } }",
-	}
-
-	accessDef := &user.AccessDefinition{
-		Limit: &user.APILimit{
-			MaxQueryDepth: 3,
-		},
-		FieldAccessRights: []user.FieldAccessDefinition{},
-	}
-
-	t.Run("should fallback to global limit and exceed", func(t *testing.T) {
-		failReason := l.DepthLimitExceeded(req, accessDef, countriesSchema)
-		assert.Equal(t, sessionFailDepthLimit, failReason)
-	})
-
-	t.Run("should respect unlimited specific field depth limit and not exceed", func(t *testing.T) {
-		accessDef.FieldAccessRights = []user.FieldAccessDefinition{
-			{
-				TypeName:  "Query",
-				FieldName: "countries",
-				Limits: user.FieldLimits{
-					MaxQueryDepth: -1,
+	t.Run("should return access definition from session when limits for api are not defined", func(t *testing.T) {
+		sessionWithoutAPILimits := &user.SessionState{
+			QuotaMax:           int64(1),
+			QuotaRenewalRate:   int64(1),
+			QuotaRenews:        int64(1),
+			Rate:               1.0,
+			Per:                1.0,
+			ThrottleInterval:   1.0,
+			ThrottleRetryLimit: 1.0,
+			MaxQueryDepth:      1.0,
+			AccessRights: map[string]user.AccessDefinition{
+				"api": {
+					Limit: nil,
 				},
 			},
 		}
 
-		failReason := l.DepthLimitExceeded(req, accessDef, countriesSchema)
-		assert.Equal(t, sessionFailNone, failReason)
+		accessDef, allowanceScope, err := GetAccessDefinitionByAPIIDOrSession(sessionWithoutAPILimits, api)
+		assert.Equal(t, &user.AccessDefinition{
+			Limit: &user.APILimit{
+				QuotaMax:           int64(1),
+				QuotaRenewalRate:   int64(1),
+				QuotaRenews:        int64(1),
+				Rate:               1.0,
+				Per:                1.0,
+				ThrottleInterval:   1.0,
+				ThrottleRetryLimit: 1.0,
+				MaxQueryDepth:      1.0,
+			},
+		}, accessDef)
+		assert.Equal(t, "", allowanceScope)
+		assert.NoError(t, err)
 	})
 
-	t.Run("should respect higher specific field depth limit and not exceed", func(t *testing.T) {
-		accessDef.FieldAccessRights = []user.FieldAccessDefinition{
-			{
-				TypeName:  "Query",
-				FieldName: "countries",
-				Limits: user.FieldLimits{
-					MaxQueryDepth: 10,
+	t.Run("should return access definition with api limits", func(t *testing.T) {
+		sessionWithAPILimits := &user.SessionState{
+			QuotaMax:           int64(1),
+			QuotaRenewalRate:   int64(1),
+			QuotaRenews:        int64(1),
+			Rate:               1.0,
+			Per:                1.0,
+			ThrottleInterval:   1.0,
+			ThrottleRetryLimit: 1.0,
+			MaxQueryDepth:      1.0,
+			AccessRights: map[string]user.AccessDefinition{
+				"api": {
+					AllowanceScope: "b",
+					FieldAccessRights: []user.FieldAccessDefinition{
+						{
+							TypeName:  "Query",
+							FieldName: "hello",
+							Limits: user.FieldLimits{
+								MaxQueryDepth: 2,
+							},
+						},
+					},
+					Limit: &user.APILimit{
+						QuotaMax:           int64(2),
+						QuotaRenewalRate:   int64(2),
+						QuotaRenews:        int64(2),
+						Rate:               2.0,
+						Per:                2.0,
+						ThrottleInterval:   2.0,
+						ThrottleRetryLimit: 2.0,
+						MaxQueryDepth:      2.0,
+					},
 				},
 			},
 		}
 
-		failReason := l.DepthLimitExceeded(req, accessDef, countriesSchema)
-		assert.Equal(t, sessionFailNone, failReason)
-	})
-
-	t.Run("should respect lower specific field depth limit and exceed", func(t *testing.T) {
-		accessDef.Limit.MaxQueryDepth = 100
-		accessDef.FieldAccessRights = []user.FieldAccessDefinition{
-			{
-				TypeName:  "Query",
-				FieldName: "countries",
-				Limits: user.FieldLimits{
-					MaxQueryDepth: 1,
+		accessDef, allowanceScope, err := GetAccessDefinitionByAPIIDOrSession(sessionWithAPILimits, api)
+		assert.Equal(t, &user.AccessDefinition{
+			FieldAccessRights: []user.FieldAccessDefinition{
+				{
+					TypeName:  "Query",
+					FieldName: "hello",
+					Limits: user.FieldLimits{
+						MaxQueryDepth: 2,
+					},
 				},
 			},
-		}
-
-		failReason := l.DepthLimitExceeded(req, accessDef, countriesSchema)
-		assert.Equal(t, sessionFailDepthLimit, failReason)
+			Limit: &user.APILimit{
+				QuotaMax:           int64(2),
+				QuotaRenewalRate:   int64(2),
+				QuotaRenews:        int64(2),
+				Rate:               2.0,
+				Per:                2.0,
+				ThrottleInterval:   2.0,
+				ThrottleRetryLimit: 2.0,
+				MaxQueryDepth:      2.0,
+			},
+		}, accessDef)
+		assert.Equal(t, "b", allowanceScope)
+		assert.NoError(t, err)
 	})
-
 }


### PR DESCRIPTION
This PR fixes an issue on which GraphQL queries are being parsed before checking auth. This results in unexpected HTTP responses.

Changes:
 - added failing test for the issue
 - moved GraphQL middleware after auth check
 - splitted API and GraphQL rate and quota checks as the GraphQL part needs the GraphQL middleware before
 - splitted API and GraphQL granular access as the GraphQL part needs the GraphQL middleware before
 - added missing tests for API granular access


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring or add test (improvements in base code or adds test coverage to functionality)
