### PR TITLE
[TT-657] Move CORS handler from chain to middleware to cover oauth2 endpoints

### DIFF
--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -105,6 +105,8 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 
 	var chainDef ChainObject
 
+	handleCORS(subrouter, spec)
+
 	logger = logger.WithFields(logrus.Fields{
 		"org_id":   spec.OrgID,
 		"api_id":   spec.APIID,
@@ -294,8 +296,6 @@ func processSpec(spec *APISpec, apisByListen map[string]int,
 		chainDef.Open = true
 		logger.Info("Checking security policy: Open")
 	}
-
-	handleCORS(&chainArray, spec)
 
 	for _, obj := range mwPreFuncs {
 		if mwDriver == apidef.GoPluginDriver {

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -40,7 +40,6 @@ import (
 	"github.com/evalphobia/logrus_sentry"
 	graylogHook "github.com/gemnasium/logrus-graylog-hook"
 	"github.com/gorilla/mux"
-	"github.com/justinas/alice"
 	"github.com/lonelycode/osin"
 	newrelic "github.com/newrelic/go-agent"
 	"github.com/rs/cors"
@@ -670,7 +669,7 @@ func createResponseMiddlewareChain(spec *APISpec, responseFuncs []apidef.Middlew
 	spec.ResponseChain = responseChain
 }
 
-func handleCORS(chain *[]alice.Constructor, spec *APISpec) {
+func handleCORS(router *mux.Router, spec *APISpec) {
 
 	if spec.CORS.Enable {
 		mainLog.Debug("CORS ENABLED")
@@ -685,7 +684,7 @@ func handleCORS(chain *[]alice.Constructor, spec *APISpec) {
 			Debug:              spec.CORS.Debug,
 		})
 
-		*chain = append(*chain, c.Handler)
+		router.Use(c.Handler)
 	}
 }
 


### PR DESCRIPTION
The reason for the move is that the oauth2 handlers don't have a chain in front of it but CORS is in the chain and it is the reason of why oauth endpoints don't support CORS. This PR moves it to routers middleware level to cover all endpoints in an API router.