### PR TITLE
TT-968 enabled h2c by default, the handler is h2c by default

### DIFF
--- a/gateway/proxy_muxer.go
+++ b/gateway/proxy_muxer.go
@@ -402,17 +402,13 @@ func (m *proxyMux) serve() {
 			}
 			var h http.Handler
 			h = &handleWrapper{p.router}
-
-			if p.protocol == "h2c" {
-				// wrapping handler in h2c. This ensures all features including tracing work
-				// in h2c services.
-				h2s := &http2.Server{}
-				h = &h2cWrapper{
-					w: h.(*handleWrapper),
-					h: h2c.NewHandler(p.router, h2s),
-				}
+			// by default enabling h2c by wrapping handler in h2c. This ensures all features including tracing work
+			// in h2c services.
+			h2s := &http2.Server{}
+			h = &h2cWrapper{
+				w: h.(*handleWrapper),
+				h: h2c.NewHandler(h, h2s),
 			}
-
 			addr := config.Global().ListenAddress + ":" + strconv.Itoa(p.port)
 			p.httpServer = &http.Server{
 				Addr:         addr,
@@ -420,7 +416,6 @@ func (m *proxyMux) serve() {
 				WriteTimeout: writeTimeout,
 				Handler:      h,
 			}
-
 			if config.Global().CloseConnections {
 				p.httpServer.SetKeepAlivesEnabled(false)
 			}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
By default set the HTTP handler to be h2c and remove the condition where the handler was h2c only when the target url is h2c. In this way users that need to use h2c for rest apis doesn't need to set a custom port. For grpc over h2c will be still required to set a custom port due that it needs the `listen_path` to be: `/` but this is not the case of rest apis.

## Related Issue
https://tyktech.atlassian.net/browse/TT-968

## Motivation and Context
fix https://tyktech.atlassian.net/browse/TT-968

## How This Has Been Tested
- Run gw in http mode and dashboard
 **Phase 1**
- Created Rest api A without custom port
- consume api A via postman, and via curl (Eg: curl -v --http2-prior-knowledge http://tyk-gateway:8080/keyless/uuid)
- Created Rest api B with custom port
- consume api B via postman and curl

**Phase 2**
- Created and configured grpc service
- Consume grpc service via grpcurl (Eg: grpcurl -plaintext -proto helloworld.proto -d '{"name": "sredny"}' tyk-gateway:12345 helloworld.Greeter/SayHello)

## Screenshots (if appropriate)

Screenshots showing the response calling the Rest and gRPC service
![Captura de Pantalla 2021-02-22 a la(s) 1 14 15 p  m](https://user-images.githubusercontent.com/4504205/108751352-178d6100-7510-11eb-8f33-9a369054ad32.png)
![Captura de Pantalla 2021-02-22 a la(s) 1 15 31 p  m](https://user-images.githubusercontent.com/4504205/108751355-18be8e00-7510-11eb-841c-46301a46d6ff.png)


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [ ] `go vet`
