### PR TITLE
[TT-1461] Call letsencrypt.Manager.Watch once

### DIFF
--- a/gateway/le_helpers.go
+++ b/gateway/le_helpers.go
@@ -91,11 +91,13 @@ func onLESSLStatusReceivedHandler(payload string) {
 }
 
 func StartPeriodicStateBackup(ctx context.Context, m *letsencrypt.Manager) {
+	watch := m.Watch()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-m.Watch():
+		case <-watch:
 			if LE_FIRSTRUN {
 				log.Info("[SSL] State change detected, storing")
 				StoreLEState(m)


### PR DESCRIPTION
The `Watch` function is called again and again. This PR calls it once and gets the channel.