### PR TITLE
[TT-1574] Multiple analytics keys

### DIFF
--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -159,10 +159,10 @@
           "type": "integer"
         },
         "records_buffer_size": {
-          "type": "boolean"
+          "type": "integer"
         },
         "enable_multiple_analytics_keys": {
-          "type": "integer"
+          "type": "boolean"
         },
         "storage_expiration_time": {
           "type": "integer"

--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -159,6 +159,9 @@
           "type": "integer"
         },
         "records_buffer_size": {
+          "type": "boolean"
+        },
+        "enable_multiple_analytics_keys": {
           "type": "integer"
         },
         "storage_expiration_time": {

--- a/config/config.go
+++ b/config/config.go
@@ -110,16 +110,17 @@ type NormaliseURLPatterns struct {
 }
 
 type AnalyticsConfigConfig struct {
-	Type                    string              `json:"type"`
-	IgnoredIPs              []string            `json:"ignored_ips"`
-	EnableDetailedRecording bool                `json:"enable_detailed_recording"`
-	EnableGeoIP             bool                `json:"enable_geo_ip"`
-	GeoIPDBLocation         string              `json:"geo_ip_db_path"`
-	NormaliseUrls           NormalisedURLConfig `json:"normalise_urls"`
-	PoolSize                int                 `json:"pool_size"`
-	RecordsBufferSize       uint64              `json:"records_buffer_size"`
-	StorageExpirationTime   int                 `json:"storage_expiration_time"`
-	ignoredIPsCompiled      map[string]bool
+	Type                        string              `json:"type"`
+	IgnoredIPs                  []string            `json:"ignored_ips"`
+	EnableDetailedRecording     bool                `json:"enable_detailed_recording"`
+	EnableGeoIP                 bool                `json:"enable_geo_ip"`
+	GeoIPDBLocation             string              `json:"geo_ip_db_path"`
+	NormaliseUrls               NormalisedURLConfig `json:"normalise_urls"`
+	PoolSize                    int                 `json:"pool_size"`
+	RecordsBufferSize           uint64              `json:"records_buffer_size"`
+	StorageExpirationTime       int                 `json:"storage_expiration_time"`
+	ignoredIPsCompiled          map[string]bool
+	EnableMultipleAnalyticsKeys bool `json:"enable_multiple_analytics_keys"`
 }
 
 type HealthCheckConfig struct {

--- a/gateway/analytics.go
+++ b/gateway/analytics.go
@@ -256,7 +256,7 @@ func (r *RedisAnalyticsHandler) recordWorker() {
 		analyticKey := analyticsKeyName
 		if r.enableMultipleAnalyticsKeys {
 			suffix := rand.Intn(10)
-			analyticKey += "_" + fmt.Sprint(suffix)
+			analyticKey = fmt.Sprintf("%v_%v", analyticKey, suffix)
 		}
 		readyToSend := false
 		select {

--- a/gateway/analytics.go
+++ b/gateway/analytics.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"fmt"
+	"math/rand"
 	"net"
 	"strings"
 	"sync"
@@ -178,13 +179,14 @@ func (a *AnalyticsRecord) SetExpiry(expiresInSeconds int64) {
 // RedisAnalyticsHandler will record analytics data to a redis back end
 // as defined in the Config object
 type RedisAnalyticsHandler struct {
-	Store            storage.AnalyticsHandler
-	GeoIPDB          *maxminddb.Reader
-	globalConf       config.Config
-	recordsChan      chan *AnalyticsRecord
-	workerBufferSize uint64
-	shouldStop       uint32
-	poolWg           sync.WaitGroup
+	Store                       storage.AnalyticsHandler
+	GeoIPDB                     *maxminddb.Reader
+	globalConf                  config.Config
+	recordsChan                 chan *AnalyticsRecord
+	workerBufferSize            uint64
+	shouldStop                  uint32
+	poolWg                      sync.WaitGroup
+	enableMultipleAnalyticsKeys bool
 }
 
 func (r *RedisAnalyticsHandler) Init(globalConf config.Config) {
@@ -204,7 +206,7 @@ func (r *RedisAnalyticsHandler) Init(globalConf config.Config) {
 	recordsBufferSize := config.Global().AnalyticsConfig.RecordsBufferSize
 	r.workerBufferSize = recordsBufferSize / uint64(ps)
 	log.WithField("workerBufferSize", r.workerBufferSize).Debug("Analytics pool worker buffer size")
-
+	r.enableMultipleAnalyticsKeys = config.Global().AnalyticsConfig.EnableMultipleAnalyticsKeys
 	r.recordsChan = make(chan *AnalyticsRecord, recordsBufferSize)
 
 	// start worker pool
@@ -246,10 +248,16 @@ func (r *RedisAnalyticsHandler) recordWorker() {
 	// this is buffer to send one pipelined command to redis
 	// use r.recordsBufferSize as cap to reduce slice re-allocations
 	recordsBuffer := make([][]byte, 0, r.workerBufferSize)
+	rand.Seed(time.Now().Unix())
 
 	// read records from channel and process
 	lastSentTs := time.Now()
 	for {
+		analyticKey := analyticsKeyName
+		if r.enableMultipleAnalyticsKeys {
+			suffix := rand.Intn(10)
+			analyticKey += "_" + fmt.Sprint(suffix)
+		}
 		readyToSend := false
 		select {
 
@@ -257,7 +265,7 @@ func (r *RedisAnalyticsHandler) recordWorker() {
 			// check if channel was closed and it is time to exit from worker
 			if !ok {
 				// send what is left in buffer
-				r.Store.AppendToSetPipelined(analyticsKeyName, recordsBuffer)
+				r.Store.AppendToSetPipelined(analyticKey, recordsBuffer)
 				return
 			}
 
@@ -312,7 +320,7 @@ func (r *RedisAnalyticsHandler) recordWorker() {
 
 		// send data to Redis and reset buffer
 		if len(recordsBuffer) > 0 && (readyToSend || time.Since(lastSentTs) >= recordsBufferForcedFlushInterval) {
-			r.Store.AppendToSetPipelined(analyticsKeyName, recordsBuffer)
+			r.Store.AppendToSetPipelined(analyticKey, recordsBuffer)
 			recordsBuffer = recordsBuffer[:0]
 			lastSentTs = time.Now()
 		}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
This PR adds the config option `analytics_config.enable_multiple_analytics_keys`. This option will make the gateway write to 10 analytics keys instead of one.

In each recordWorker loop, it will random a number between 0 and 9 and it will be added as a suffix to our analytic key. In this way, we're going to write 10 analytic keys instead of one. In the case of Redis cluster config is enabled, it will distribute the keys depending on each shard keyspace.

This allows us to:
- Loss fewer analytics records if a pump fails since it will only lose the records from one of the keys.
- If Redis cluster is enabled, read the analytics across multiple nodes.
- 
Docs: https://github.com/TykTechnologies/tyk-docs/pull/1573
**NOTE: This feature will work with pump v1.2.1 +**
## Related Issue
<!-- This project only accepts pull requests related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->
https://tyktech.atlassian.net/browse/TT-1574

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Reduce Redis overload and have a better analytics distribution across the cluster. Also to have better fault tolerance in the pump.

## How This Has Been Tested
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of
the code, etc. -->
- Set enable_multiple_analytics_keys:true in the pump and analytics_config.enable_multiple_analytics_keys:true in the gateway.
- Using redis cluster (https://github.com/Grokzen/docker-redis-cluster) or/and standalone Redis.
- Setup any pump (CSV and dummy in my tests).
- Send 100 requests to a gw API.
- Your pumps should process 100 analytics records.
If you keep sending requests and turn off the pump, you should see in Redis multiple analytics keys with the following format: tyk-system-analytics_X where X goes from 0 to 9. And each key should have different records inside.
## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [X] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [X] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] Check your code additions will not fail linting checks:
  - [X] `go fmt -s`
  - [X] `go vet`
