### PR TITLE
[TT-1606] Separated analytics storage

### DIFF
--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -329,6 +329,12 @@
     "enable_analytics": {
       "type": "boolean"
     },
+    "enable_separate_analytics_store": {
+      "type": "boolean"
+    },
+    "analytics_storage": {
+      "$ref": "#/definitions/StorageOptions"
+    },
     "enable_api_segregation": {
       "type": "boolean"
     },

--- a/config/config.go
+++ b/config/config.go
@@ -403,8 +403,10 @@ type Config struct {
 	SSLForceCommonNameCheck       bool                 `json:"ssl_force_common_name_check"`
 
 	// Proxy analytics configuration
-	EnableAnalytics bool                  `json:"enable_analytics"`
-	AnalyticsConfig AnalyticsConfigConfig `json:"analytics_config"`
+	EnableAnalytics              bool                  `json:"enable_analytics"`
+	AnalyticsConfig              AnalyticsConfigConfig `json:"analytics_config"`
+	EnableSeperateAnalyticsStore bool                  `json:"enable_separate_analytics_store"`
+	AnalyticsStorage             StorageOptionsConf    `json:"analytics_storage"`
 
 	LivenessCheck LivenessCheckConfig `json:"liveness_check"`
 	// Cache

--- a/gateway/analytics.go
+++ b/gateway/analytics.go
@@ -199,7 +199,7 @@ func (r *RedisAnalyticsHandler) Init(globalConf config.Config) {
 	}
 
 	analytics.Store.Connect()
-
+	fmt.Println("storee:", analytics.Store)
 	ps := config.Global().AnalyticsConfig.PoolSize
 	recordsBufferSize := config.Global().AnalyticsConfig.RecordsBufferSize
 	r.workerBufferSize = recordsBufferSize / uint64(ps)

--- a/gateway/analytics.go
+++ b/gateway/analytics.go
@@ -199,7 +199,6 @@ func (r *RedisAnalyticsHandler) Init(globalConf config.Config) {
 	}
 
 	analytics.Store.Connect()
-	fmt.Println("storee:", analytics.Store)
 	ps := config.Global().AnalyticsConfig.PoolSize
 	recordsBufferSize := config.Global().AnalyticsConfig.RecordsBufferSize
 	r.workerBufferSize = recordsBufferSize / uint64(ps)

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -177,7 +177,7 @@ func setupGlobals(ctx context.Context) {
 		if config.Global().ManagementNode {
 			mainLog.Warn("Running Uptime checks in a management node.")
 		}
-		healthCheckStore := storage.RedisCluster{KeyPrefix: "host-checker:"}
+		healthCheckStore := storage.RedisCluster{KeyPrefix: "host-checker:", IsAnalytics: true}
 		InitHostCheckManager(ctx, &healthCheckStore)
 	}
 
@@ -196,7 +196,7 @@ func setupGlobals(ctx context.Context) {
 		config.SetGlobal(globalConf)
 		mainLog.Debug("Setting up analytics DB connection")
 
-		analyticsStore := storage.RedisCluster{KeyPrefix: "analytics-"}
+		analyticsStore := storage.RedisCluster{KeyPrefix: "analytics-", IsAnalytics: true}
 		analytics.Store = &analyticsStore
 		analytics.Init(globalConf)
 
@@ -204,7 +204,7 @@ func setupGlobals(ctx context.Context) {
 			mainLog.Debug("Using RPC cache purge")
 
 			rpcPurgeOnce.Do(func() {
-				store := storage.RedisCluster{KeyPrefix: "analytics-"}
+				store := storage.RedisCluster{KeyPrefix: "analytics-", IsAnalytics: true}
 				purger := rpc.Purger{
 					Store: &store,
 				}

--- a/storage/redis_cluster.go
+++ b/storage/redis_cluster.go
@@ -149,7 +149,7 @@ func ConnectToRedis(ctx context.Context, onConnect func()) {
 	tick := time.NewTicker(time.Second)
 	defer tick.Stop()
 	c := []RedisCluster{
-		{}, {IsCache: true},{IsAnalytics: true},
+		{}, {IsCache: true}, {IsAnalytics: true},
 	}
 	var ok bool
 	for _, v := range c {

--- a/storage/redis_cluster.go
+++ b/storage/redis_cluster.go
@@ -149,10 +149,7 @@ func ConnectToRedis(ctx context.Context, onConnect func()) {
 	tick := time.NewTicker(time.Second)
 	defer tick.Stop()
 	c := []RedisCluster{
-		{}, {IsCache: true},
-	}
-	if config.Global().EnableAnalytics {
-		c = append(c, RedisCluster{IsAnalytics: true})
+		{}, {IsCache: true},{IsAnalytics: true},
 	}
 	var ok bool
 	for _, v := range c {

--- a/storage/redis_cluster.go
+++ b/storage/redis_cluster.go
@@ -29,6 +29,8 @@ var ErrRedisIsDown = errors.New("storage: Redis is either down or was not config
 
 var singlePool atomic.Value
 var singleCachePool atomic.Value
+var singleAnalyticsPool atomic.Value
+
 var redisUp atomic.Value
 
 var disableRedis atomic.Value
@@ -80,9 +82,16 @@ func WaitConnect(ctx context.Context) bool {
 	}
 }
 
-func singleton(cache bool) redis.UniversalClient {
+func singleton(cache, analytics bool) redis.UniversalClient {
 	if cache {
 		v := singleCachePool.Load()
+		if v != nil {
+			return v.(redis.UniversalClient)
+		}
+		return nil
+	}
+	if analytics {
+		v := singleAnalyticsPool.Load()
 		if v != nil {
 			return v.(redis.UniversalClient)
 		}
@@ -95,15 +104,18 @@ func singleton(cache bool) redis.UniversalClient {
 	return nil
 }
 
-func connectSingleton(cache bool) bool {
-	d := singleton(cache) == nil
+func connectSingleton(cache, analytics bool) bool {
+	d := singleton(cache, analytics) == nil
 	if d {
 		log.Debug("Connecting to redis cluster")
 		if cache {
-			singleCachePool.Store(NewRedisClusterPool(cache))
+			singleCachePool.Store(NewRedisClusterPool(cache, analytics))
+			return true
+		} else if analytics {
+			singleAnalyticsPool.Store(NewRedisClusterPool(cache, analytics))
 			return true
 		}
-		singlePool.Store(NewRedisClusterPool(cache))
+		singlePool.Store(NewRedisClusterPool(cache, analytics))
 		return true
 	}
 	return true
@@ -111,13 +123,14 @@ func connectSingleton(cache bool) bool {
 
 // RedisCluster is a storage manager that uses the redis database.
 type RedisCluster struct {
-	KeyPrefix string
-	HashKeys  bool
-	IsCache   bool
+	KeyPrefix   string
+	HashKeys    bool
+	IsCache     bool
+	IsAnalytics bool
 }
 
 func clusterConnectionIsOpen(cluster *RedisCluster) bool {
-	c := singleton(cluster.IsCache)
+	c := singleton(cluster.IsCache, cluster.IsAnalytics)
 	testKey := "redis-test-" + uuid.NewV4().String()
 	if err := c.Set(ctx, testKey, "test", time.Second).Err(); err != nil {
 		return false
@@ -138,9 +151,12 @@ func ConnectToRedis(ctx context.Context, onConnect func()) {
 	c := []RedisCluster{
 		{}, {IsCache: true},
 	}
+	if config.Global().EnableAnalytics {
+		c = append(c, RedisCluster{IsAnalytics: true})
+	}
 	var ok bool
 	for _, v := range c {
-		if !connectSingleton(v.IsCache) {
+		if !connectSingleton(v.IsCache, v.IsAnalytics) {
 			break
 		}
 		if !clusterConnectionIsOpen(&v) {
@@ -182,19 +198,20 @@ func connectCluster(v ...RedisCluster) bool {
 }
 
 func establishConnection(v *RedisCluster) bool {
-	if !connectSingleton(v.IsCache) {
+	if !connectSingleton(v.IsCache, v.IsAnalytics) {
 		return false
 	}
 	return clusterConnectionIsOpen(v)
 }
 
-func NewRedisClusterPool(isCache bool) redis.UniversalClient {
+func NewRedisClusterPool(isCache, isAnalytics bool) redis.UniversalClient {
 	// redisSingletonMu is locked and we know the singleton is nil
 	cfg := config.Global().Storage
 	if isCache && config.Global().EnableSeperateCacheStore {
 		cfg = config.Global().CacheStorage
+	} else if isAnalytics && config.Global().EnableAnalytics && config.Global().EnableSeperateAnalyticsStore {
+		cfg = config.Global().AnalyticsStorage
 	}
-
 	log.Debug("Creating new Redis connection pool")
 
 	// poolSize applies per cluster node and not for the whole cluster.
@@ -272,7 +289,7 @@ func (r *RedisCluster) Connect() bool {
 }
 
 func (r *RedisCluster) singleton() redis.UniversalClient {
-	return singleton(r.IsCache)
+	return singleton(r.IsCache, r.IsAnalytics)
 }
 
 func (r *RedisCluster) hashKey(in string) string {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
Added configuration options `enable_separate_analytics_store` and `analytics_store` to have a separated analytics storage.
Codewise, it works in the same way as `cache_storage` and `enable_separate_cache`.

**DOCS WIP**

## Related Issue
<!-- This project only accepts pull requests related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->
https://tyktech.atlassian.net/browse/TT-1606

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
If Redis runs out of memory during a high workload (where analytics would probably have a big part on it), it will make the entire Tyk cluster unable to continue functioning.
To minimize the impact in those situations, the idea is to add an option to have a separated Redis / Redis cluster for analytics.


## How This Has Been Tested
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of
the code, etc. -->
- Checked if the whole analytics flow (gw - request - pump receive the record) is still working without any modification.
- Checked if we set `enable_separate_analytics_store:true` and configure `analytics_store` to another Redis, everything should work on the gateway side but the pump shouldn't process anything. If we change the pump config to this new Redis, it should purge all the records.

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [x] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
