### PR TITLE
Do not support feature/ branches for go.mod update in tyk-analytics

### DIFF
--- a/.github/workflows/update-tyk-analytics.yml
+++ b/.github/workflows/update-tyk-analytics.yml
@@ -8,7 +8,6 @@ on:
       - master
       - release-**
       - integration/**
-      - feature/**
 
 jobs:
   sync:


### PR DESCRIPTION
It does not appear to be used much and the errors on Slack are annoying.

This means that if you have a branch feature/something in this repo, the corresponding feature/something branch in tyk-analytics will _not_ have its go mod updated. 