### PR TITLE
[TT-1680] [TT-1681] Fix content type detection when charset used

### DIFF
--- a/gateway/handler_error.go
+++ b/gateway/handler_error.go
@@ -102,9 +102,10 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 
 	if writeResponse {
 		var templateExtension string
-		var contentType string
+		contentType := r.Header.Get(headers.ContentType)
+		contentType = strings.Split(contentType, ";")[0]
 
-		switch r.Header.Get(headers.ContentType) {
+		switch contentType {
 		case headers.ApplicationXML:
 			templateExtension = "xml"
 			contentType = headers.ApplicationXML

--- a/gateway/handler_error_test.go
+++ b/gateway/handler_error_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"io/ioutil"
 	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"

--- a/gateway/handler_error_test.go
+++ b/gateway/handler_error_test.go
@@ -34,21 +34,26 @@ func TestHandleError_text_xml(t *testing.T) {
 	ts := StartTest()
 	defer ts.Close()
 
-	// Simulate 500 error
-	h := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		panic("I should fail!")
-	}))
-	defer h.Close()
-
 	BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/"
-		spec.Proxy.TargetURL = h.URL
+		spec.Proxy.TargetURL = "http://localhost:66666"
 	})
 	ts.Run(t, test.TestCase{
 		Path: "/",
 		Code: http.StatusInternalServerError,
 		Headers: map[string]string{
 			headers.ContentType: headers.TextXML,
+		},
+		BodyMatchFunc: func(b []byte) bool {
+			return strings.TrimSpace(expect) == string(bytes.TrimSpace(b))
+		},
+	})
+
+	ts.Run(t, test.TestCase{
+		Path: "/",
+		Code: http.StatusInternalServerError,
+		Headers: map[string]string{
+			headers.ContentType: headers.TextXML + "; charset=UTF-8",
 		},
 		BodyMatchFunc: func(b []byte) bool {
 			return strings.TrimSpace(expect) == string(bytes.TrimSpace(b))


### PR DESCRIPTION
Now only first part of the header value is used to detect content type.
E.g. we just split by ";"

Also re-factored test, and now instead of having http server causing panic (and messing with logs) it just has target url which points to non existing port.

https://tyktech.atlassian.net/browse/TT-1680
https://tyktech.atlassian.net/browse/TT-1681

## Motivation and Context
SOAP clients send the data with charset included.

## How This Has Been Tested
Added unit test, also easy to replicate just by sending content type with charset via curl.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [x] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [x] `go vet`
