### PR TITLE
update graphql-go-tools (TT-1895)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -97,6 +97,6 @@ require (
 	rsc.io/letsencrypt v0.0.2
 )
 
-replace github.com/jensneuse/graphql-go-tools => github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20210310152233-6ff6aba4c612
+replace github.com/jensneuse/graphql-go-tools => github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20210324124248-3397d6fea435
 
 //replace github.com/jensneuse/graphql-go-tools => ../graphql-go-tools

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/TykTechnologies/gorpc v0.0.0-20190515174534-b9c10befc5f4 h1:hTjM5Uubg
 github.com/TykTechnologies/gorpc v0.0.0-20190515174534-b9c10befc5f4/go.mod h1:vqhQRhIHefD4jdFo55j+m0vD5NMjx2liq/ubnshQpaY=
 github.com/TykTechnologies/goverify v0.0.0-20160822133757-7ccc57452ade h1:tFUV86NDnfMY4Au+EJHGJx0Rton8xdOLEh1aT+j6XBk=
 github.com/TykTechnologies/goverify v0.0.0-20160822133757-7ccc57452ade/go.mod h1:mkS8jKcz8otdfEXhJs1QQ/DKoIY1NFFsRPKS0RwQENI=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20210310152233-6ff6aba4c612 h1:ZDHFzEdO90/mZ+DNyz2dscuolPF5+Ao1nN9xOda5c2s=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20210310152233-6ff6aba4c612/go.mod h1:zm0OEQyZ8F2jzX1Rqm6lOjt6u8hCPW86YOjGvPMpVe0=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20210324124248-3397d6fea435 h1:HvfrXk8uLX9YbTxb1MYMkENvTbJmCukPdNt+jjTWPkA=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20210324124248-3397d6fea435/go.mod h1:zm0OEQyZ8F2jzX1Rqm6lOjt6u8hCPW86YOjGvPMpVe0=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c h1:j6fd0Fz1R4oSWOmcooGjrdahqrML+btQ+PfEJw8SzbA=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c/go.mod h1:GnHUbsQx+ysI10osPhUdTmsxcE7ef64cVp38Fdyd7e0=
 github.com/TykTechnologies/murmur3 v0.0.0-20180602122059-1915e687e465 h1:A2gBjoX8aF0G3GHEpHyj2f0ixuPkCgcGqmPdKHSkW+0=


### PR DESCRIPTION
update graphql-go-tools which includes the following bugfix: https://github.com/TykTechnologies/graphql-go-tools/pull/107