### PR TITLE
[TT-1542] Add fallback hash key functions to catch function changes

### DIFF
--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -433,6 +433,22 @@
         "sha256"
       ]
     },
+    "hash_key_function_fallback": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string",
+        "enum": [
+          "",
+          "murmur32",
+          "murmur64",
+          "murmur128",
+          "sha256"
+        ]
+      }
+    },
     "health_check": {
       "type": [
         "object",

--- a/config/config.go
+++ b/config/config.go
@@ -331,6 +331,7 @@ type Config struct {
 	// Gateway Security Policies
 	HashKeys                bool           `json:"hash_keys"`
 	HashKeyFunction         string         `json:"hash_key_function"`
+	HashKeyFunctionFallback []string       `json:"hash_key_function_fallback"`
 	EnableHashedKeysListing bool           `json:"enable_hashed_keys_listing"`
 	MinTokenLength          int            `json:"min_token_length"`
 	EnableAPISegregation    bool           `json:"enable_api_segregation"`

--- a/gateway/auth_manager.go
+++ b/gateway/auth_manager.go
@@ -139,13 +139,13 @@ func (b *DefaultSessionManager) SessionDetail(orgID string, keyName string, hash
 	} else {
 		if storage.TokenOrg(keyName) != orgID {
 			// try to get legacy and new format key at once
+			toSearchList := []string{generateToken(orgID, keyName), keyName}
+			for _, fallback := range config.Global().HashKeyFunctionFallback {
+				toSearchList = append(toSearchList, generateToken(orgID, keyName, fallback))
+			}
+
 			var jsonKeyValList []string
-			jsonKeyValList, err = b.store.GetMultiKey(
-				[]string{
-					generateToken(orgID, keyName),
-					keyName,
-				},
-			)
+			jsonKeyValList, err = b.store.GetMultiKey(toSearchList)
 
 			// pick the 1st non empty from the returned list
 			for _, val := range jsonKeyValList {

--- a/gateway/auth_manager.go
+++ b/gateway/auth_manager.go
@@ -186,10 +186,15 @@ func (b *DefaultSessionManager) Sessions(filter string) []string {
 
 type DefaultKeyGenerator struct{}
 
-func generateToken(orgID, keyID string) string {
+func generateToken(orgID, keyID string, customHashKeyFunction ...string) string {
 	keyID = strings.TrimPrefix(keyID, orgID)
-	token, err := storage.GenerateToken(orgID, keyID, config.Global().HashKeyFunction)
+	hashKeyFunction := config.Global().HashKeyFunction
 
+	if len(customHashKeyFunction) > 0 {
+		hashKeyFunction = customHashKeyFunction[0]
+	}
+
+	token, err := storage.GenerateToken(orgID, keyID, hashKeyFunction)
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "auth-mgr",

--- a/gateway/auth_manager_test.go
+++ b/gateway/auth_manager_test.go
@@ -1,8 +1,13 @@
 package gateway
 
 import (
+	"crypto/x509"
 	"net/http"
 	"testing"
+
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/certs"
+	"github.com/TykTechnologies/tyk/headers"
 
 	"github.com/TykTechnologies/tyk/storage"
 
@@ -100,5 +105,109 @@ func TestAuthenticationAfterUpdateKey(t *testing.T) {
 
 	t.Run("HashKeys=true", func(t *testing.T) {
 		assert(true)
+	})
+}
+
+func TestHashKeyFunctionChanged(t *testing.T) {
+	_, _, combinedPEM, _ := genServerCertificate()
+	serverCertID, _ := CertificateManager.Add(combinedPEM, "")
+	defer CertificateManager.Delete(serverCertID, "")
+
+	_, _, _, clientCert := genCertificate(&x509.Certificate{})
+	clientCertID := certs.HexSHA256(clientCert.Certificate[0])
+	client := GetTLSClient(nil, nil)
+
+	globalConf := config.Global()
+	globalConf.HttpServerOptions.UseSSL = true
+	globalConf.HttpServerOptions.SSLCertificates = []string{serverCertID}
+	globalConf.HashKeys = true
+	globalConf.HashKeyFunction = "murmur64"
+	globalConf.LocalSessionCache.DisableCacheSessionState = true
+	config.SetGlobal(globalConf)
+
+	defer ResetTestConfig()
+
+	g := StartTest()
+	defer g.Close()
+
+	api := BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/"
+		spec.UseKeylessAccess = false
+		spec.AuthConfigs = map[string]apidef.AuthConfig{
+			authTokenType: {UseCertificate: true},
+		}
+	})[0]
+
+	globalConf = config.Global()
+
+	testChangeHashFunc := func(t *testing.T, authHeader map[string]string, client *http.Client, failCode int) {
+		_, _ = g.Run(t, test.TestCase{Headers: authHeader, Client: client, Code: http.StatusOK})
+
+		globalConf.HashKeyFunction = "sha256"
+		config.SetGlobal(globalConf)
+
+		_, _ = g.Run(t, test.TestCase{Headers: authHeader, Client: client, Code: failCode})
+
+		globalConf.HashKeyFunctionFallback = []string{"murmur64"}
+		config.SetGlobal(globalConf)
+
+		_, _ = g.Run(t, test.TestCase{Headers: authHeader, Client: client, Code: http.StatusOK})
+
+		// Reset
+		globalConf.HashKeyFunction = "murmur64"
+		globalConf.HashKeyFunctionFallback = nil
+		config.SetGlobal(globalConf)
+	}
+
+	t.Run("custom key", func(t *testing.T) {
+		const customKey = "custom-key"
+
+		session := CreateStandardSession()
+		session.AccessRights = map[string]user.AccessDefinition{"test": {
+			APIID: "test", Versions: []string{"v1"},
+		}}
+
+		_, _ = g.Run(t, test.TestCase{AdminAuth: true, Method: http.MethodPost, Path: "/tyk/keys/" + customKey,
+			Data: session, Client: client, Code: http.StatusOK})
+
+		testChangeHashFunc(t, map[string]string{headers.Authorization: customKey}, client, http.StatusForbidden)
+	})
+
+	t.Run("basic auth key", func(t *testing.T) {
+		api.UseBasicAuth = true
+		LoadAPI(api)
+		globalConf = config.Global()
+
+		session := CreateStandardSession()
+		session.BasicAuthData.Password = "password"
+		session.AccessRights = map[string]user.AccessDefinition{"test": {
+			APIID: "test", Versions: []string{"v1"},
+		}}
+
+		_, _ = g.Run(t, test.TestCase{AdminAuth: true, Method: http.MethodPost, Path: "/tyk/keys/user",
+			Data: session, Client: client, Code: http.StatusOK})
+
+		authHeader := map[string]string{"Authorization": genAuthHeader("user", "password")}
+
+		testChangeHashFunc(t, authHeader, client, http.StatusUnauthorized)
+
+		api.UseBasicAuth = false
+		LoadAPI(api)
+		globalConf = config.Global()
+	})
+
+	t.Run("client certificate", func(t *testing.T) {
+		session := CreateStandardSession()
+		session.Certificate = clientCertID
+		session.BasicAuthData.Password = "password"
+		session.AccessRights = map[string]user.AccessDefinition{"test": {
+			APIID: "test", Versions: []string{"v1"},
+		}}
+
+		_, _ = g.Run(t, test.TestCase{AdminAuth: true, Method: http.MethodPost, Path: "/tyk/keys/create",
+			Data: session, Client: client, Code: http.StatusOK})
+
+		client = GetTLSClient(&clientCert, nil)
+		testChangeHashFunc(t, nil, client, http.StatusForbidden)
 	})
 }

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -982,40 +982,6 @@ func TestKeyWithCertificateTLS(t *testing.T) {
 
 		_, _ = ts.Run(t, test.TestCase{Code: http.StatusOK, Path: "/test1", Domain: "host2", Client: client})
 	})
-
-	t.Run("Hash key function changed", func(t *testing.T) {
-
-		BuildAndLoadAPI(func(spec *APISpec) {
-			spec.Proxy.ListenPath = "/"
-			spec.UseKeylessAccess = false
-			spec.AuthConfigs = map[string]apidef.AuthConfig{
-				authTokenType: {UseCertificate: true},
-			}
-		})
-
-		_, _, _, clientCert := genCertificate(&x509.Certificate{})
-		clientCertID := certs.HexSHA256(clientCert.Certificate[0])
-		client := GetTLSClient(&clientCert, nil)
-
-		_, _ = ts.CreateSession(func(s *user.SessionState) {
-			s.Certificate = clientCertID
-			s.SetAccessRights(map[string]user.AccessDefinition{"test": {
-				APIID: "test", Versions: []string{"v1"},
-			}})
-		})
-
-		_, _ = ts.Run(t, test.TestCase{Path: "/", Client: client, Code: http.StatusOK})
-
-		globalConf.HashKeyFunction = "sha256"
-		config.SetGlobal(globalConf)
-
-		_, _ = ts.Run(t, test.TestCase{Path: "/", Client: client, Code: http.StatusForbidden})
-
-		globalConf.HashKeyFunctionFallback = []string{"murmur64"}
-		config.SetGlobal(globalConf)
-
-		_, _ = ts.Run(t, test.TestCase{Path: "/", Client: client, Code: http.StatusOK})
-	})
 }
 
 func TestAPICertificate(t *testing.T) {

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -982,6 +982,40 @@ func TestKeyWithCertificateTLS(t *testing.T) {
 
 		_, _ = ts.Run(t, test.TestCase{Code: http.StatusOK, Path: "/test1", Domain: "host2", Client: client})
 	})
+
+	t.Run("Hash key function changed", func(t *testing.T) {
+
+		BuildAndLoadAPI(func(spec *APISpec) {
+			spec.Proxy.ListenPath = "/"
+			spec.UseKeylessAccess = false
+			spec.AuthConfigs = map[string]apidef.AuthConfig{
+				authTokenType: {UseCertificate: true},
+			}
+		})
+
+		_, _, _, clientCert := genCertificate(&x509.Certificate{})
+		clientCertID := certs.HexSHA256(clientCert.Certificate[0])
+		client := GetTLSClient(&clientCert, nil)
+
+		_, _ = ts.CreateSession(func(s *user.SessionState) {
+			s.Certificate = clientCertID
+			s.SetAccessRights(map[string]user.AccessDefinition{"test": {
+				APIID: "test", Versions: []string{"v1"},
+			}})
+		})
+
+		_, _ = ts.Run(t, test.TestCase{Path: "/", Client: client, Code: http.StatusOK})
+
+		globalConf.HashKeyFunction = "sha256"
+		config.SetGlobal(globalConf)
+
+		_, _ = ts.Run(t, test.TestCase{Path: "/", Client: client, Code: http.StatusForbidden})
+
+		globalConf.HashKeyFunctionFallback = []string{"murmur64"}
+		config.SetGlobal(globalConf)
+
+		_, _ = ts.Run(t, test.TestCase{Path: "/", Client: client, Code: http.StatusOK})
+	})
 }
 
 func TestAPICertificate(t *testing.T) {

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -18,7 +18,7 @@ import (
 	"github.com/justinas/alice"
 	newrelic "github.com/newrelic/go-agent"
 	"github.com/paulbellamy/ratecounter"
-	cache "github.com/pmylund/go-cache"
+	"github.com/pmylund/go-cache"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/singleflight"
 
@@ -652,9 +652,11 @@ func (t BaseMiddleware) CheckSessionAndIdentityForValidKey(originalKey *string, 
 
 	// Try and get the session from the session store
 	t.Logger().Debug("Querying local cache")
+	keyHash := key
 	cacheKey := key
 	if t.Spec.GlobalConfig.HashKeys {
-		cacheKey = storage.HashStr(key)
+		keyHash = storage.HashStr(key)
+		cacheKey = storage.HashStr(key, storage.HashMurmur64) // always hash cache keys with murmur64 to prevent collisions
 	}
 
 	// Check in-memory cache
@@ -675,7 +677,7 @@ func (t BaseMiddleware) CheckSessionAndIdentityForValidKey(originalKey *string, 
 	t.Logger().Debug("Querying keystore")
 	session, found := GlobalSessionManager.SessionDetail(t.Spec.OrgID, key, false)
 	if found {
-		session.SetKeyHash(cacheKey)
+		session.SetKeyHash(keyHash)
 		// If exists, assume it has been authorized and pass on
 		// cache it
 		clone := session.Clone()
@@ -704,7 +706,7 @@ func (t BaseMiddleware) CheckSessionAndIdentityForValidKey(originalKey *string, 
 		// update value of originalKey, as for custom-keys it might get updated (the key is generated again using alias)
 		*originalKey = key
 
-		session.SetKeyHash(cacheKey)
+		session.SetKeyHash(keyHash)
 		// If not in Session, and got it from AuthHandler, create a session with a new TTL
 		t.Logger().Info("Recreating session for key: ", obfuscateKey(key))
 

--- a/gateway/mw_auth_key.go
+++ b/gateway/mw_auth_key.go
@@ -5,10 +5,11 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/TykTechnologies/tyk/certs"
+
 	"github.com/TykTechnologies/tyk/user"
 
 	"github.com/TykTechnologies/tyk/apidef"
-	"github.com/TykTechnologies/tyk/certs"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/request"
 	"github.com/TykTechnologies/tyk/signature_validator"
@@ -74,23 +75,17 @@ func (k *AuthKey) ProcessRequest(w http.ResponseWriter, r *http.Request, _ inter
 	var session user.SessionState
 	if key != "" {
 		key = stripBearer(key)
-		session, keyExists = k.CheckSessionAndIdentityForValidKey(&key, r)
 	} else if authConfig.UseCertificate && key == "" && r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
-		functionsToTryInOrder := []string{config.Global().HashKeyFunction}
-		for _, nextFunction := range append(functionsToTryInOrder, config.Global().HashKeyFunctionFallback...) {
-			log.Debugf("Trying to find key by client certificate with hash function: %s", nextFunction)
+		log.Debug("Trying to find key by client certificate")
 
-			key = generateToken(k.Spec.OrgID, certs.HexSHA256(r.TLS.PeerCertificates[0].Raw), nextFunction)
-			if session, keyExists = k.CheckSessionAndIdentityForValidKey(&key, r); keyExists {
-				break
-			}
-		}
+		key = certs.HexSHA256(r.TLS.PeerCertificates[0].Raw)
 	} else {
 		k.Logger().Info("Attempted access with malformed header, no auth header found.")
 
 		return errorAndStatusCode(ErrAuthAuthorizationFieldMissing)
 	}
 
+	session, keyExists = k.CheckSessionAndIdentityForValidKey(&key, r)
 	if !keyExists {
 		k.Logger().WithField("key", obfuscateKey(key)).Info("Attempted access with non-existent key.")
 

--- a/gateway/mw_auth_key.go
+++ b/gateway/mw_auth_key.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/TykTechnologies/tyk/user"
+
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/certs"
 	"github.com/TykTechnologies/tyk/config"
@@ -66,25 +68,29 @@ func (k *AuthKey) ProcessRequest(w http.ResponseWriter, r *http.Request, _ inter
 		return nil, http.StatusOK
 	}
 
-	key, config := k.getAuthToken(k.getAuthType(), r)
+	key, authConfig := k.getAuthToken(k.getAuthType(), r)
 
-	// If key not provided in header or cookie and client certificate is provided, try to find certificate based key
-	if config.UseCertificate && key == "" && r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
-		key = generateToken(k.Spec.OrgID, certs.HexSHA256(r.TLS.PeerCertificates[0].Raw))
-	}
+	keyExists := false
+	var session user.SessionState
+	if key != "" {
+		key = stripBearer(key)
+		session, keyExists = k.CheckSessionAndIdentityForValidKey(&key, r)
+	} else if authConfig.UseCertificate && key == "" && r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
+		functionsToTryInOrder := []string{config.Global().HashKeyFunction}
+		for _, nextFunction := range append(functionsToTryInOrder, config.Global().HashKeyFunctionFallback...) {
+			log.Debugf("Trying to find key by client certificate with hash function: %s", nextFunction)
 
-	if key == "" {
-		// No header value, fail
+			key = generateToken(k.Spec.OrgID, certs.HexSHA256(r.TLS.PeerCertificates[0].Raw), nextFunction)
+			if session, keyExists = k.CheckSessionAndIdentityForValidKey(&key, r); keyExists {
+				break
+			}
+		}
+	} else {
 		k.Logger().Info("Attempted access with malformed header, no auth header found.")
 
 		return errorAndStatusCode(ErrAuthAuthorizationFieldMissing)
 	}
 
-	// Ignore Bearer prefix on token if it exists
-	key = stripBearer(key)
-
-	// Check if API key valid
-	session, keyExists := k.CheckSessionAndIdentityForValidKey(&key, r)
 	if !keyExists {
 		k.Logger().WithField("key", obfuscateKey(key)).Info("Attempted access with non-existent key.")
 

--- a/gateway/mw_basic_auth.go
+++ b/gateway/mw_basic_auth.go
@@ -178,7 +178,7 @@ func (k *BasicAuthKeyIsValid) ProcessRequest(w http.ResponseWriter, r *http.Requ
 	}
 
 	// Check if API key valid
-	keyName := generateToken(k.Spec.OrgID, username)
+	keyName := username
 	logger := k.Logger().WithField("key", obfuscateKey(keyName))
 	session, keyExists := k.CheckSessionAndIdentityForValidKey(&keyName, r)
 	if !keyExists {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -144,8 +144,15 @@ func hashFunction(algorithm string) (hash.Hash, error) {
 	}
 }
 
-func HashStr(in string) string {
-	h, _ := hashFunction(TokenHashAlgo(in))
+func HashStr(in string, withAlg ...string) string {
+	var algo string
+	if len(withAlg) > 0 && withAlg[0] != "" {
+		algo = withAlg[0]
+	} else {
+		algo = TokenHashAlgo(in)
+	}
+
+	h, _ := hashFunction(algo)
 	h.Write([]byte(in))
 	return hex.EncodeToString(h.Sum(nil))
 }


### PR DESCRIPTION
Added new `hash_key_function_fallback` array option to specify list of hash function which Gateway needs to check if key with default hash key function not found. 

This functionality needed only if you change default hashing algorithm, but your token information does not hold information about hashing function like custom keys, certificates, or basic auth tokens.