### PR TITLE
releng: add test infra for goplugins

### DIFF
--- a/images/README.md
+++ b/images/README.md
@@ -1,25 +1,9 @@
-# build-env
-
-Docker environment used to build official images.
-
-This used be here but now lives at the repo attached to
-[tyk-build-env](https://hub.docker.com/r/tykio/tyk-build-env)
-
 # plugin-compiler
 
-The usecase is that you have a plugin (probably Go) that you require
-to be built.
-
-Navigate to where your plugin is and build using a docker volume to
-mount your code into the image. Since the vendor directory needs to be
-identical between the gateway build and the plugin build, this means
-that you should pull the version of this image corresponding to the
-gateway version you are using.
-
-This also implies that if your plugin has vendored modules that are
-[also used by Tyk
+Does not support go modules. If your plugin has vendored modules that
+are [also used by Tyk
 gateway](https://github.com/TykTechnologies/tyk/tree/master/vendor)
-then your module will be overridden by the version that Tyk uses. 
+then your module will be overridden by the version that Tyk uses.
 
 ``` shell
 cd ${GOPATH}/src/tyk-plugin
@@ -29,6 +13,35 @@ docker run -v `pwd`:/go/src/plugin-build plugin-build pre
 You will find a `pre.so` in the current directory which is the file
 that goes into the API definition
 
+## Testing the image
+
+```shell
+% ./test.zsh v2.9.5
+....
+```
+Look for `msg="API Loaded" api_id= api_name="Goplugin test"` in the output. Test that the plugin is working correctly by,
+
+```shell
+% curl http://localhost:8080/goplugin/headers
+{
+  "headers": {
+    "Accept": "*/*", 
+    "Accept-Encoding": "gzip", 
+    "Foo": "Bar", 
+    "Host": "httpbin.org", 
+    "User-Agent": "curl/7.68.0", 
+    "X-Amzn-Trace-Id": "Root=1-606f4317-18581ac0164b5496739a5b32"
+  }
+}
+```
+
+The `Foo: Bar` header indicates all is well. Can be tested with `jq` like:
+
+``` shell
+% curl http://localhost:8080/goplugin/headers | jq '.headers.Foo == "Bar"'
+true
+```
+
 ## Building the image
 
 This will build the image that will be used in the plugin build
@@ -37,8 +50,7 @@ step. This section is for only for informational purposes.
 In the root of the repo:
 
 ``` shell
-docker build --build-arg TYK_GW_TAG=v2.8.4 -t tyk-plugin-build-2.8.4 .
+docker build --build-arg TYK_GW_TAG=v2.8.4 -t tykio/tyk-plugin-compiler:v2.8.4 -f images/plugin-compiler/Dockerfile .
 ```
 
-TYK_GW_TAG refers to the _tag_ in github corresponding to a released
-version.
+`TYK_GW_TAG` can be any github ref.

--- a/images/README.md
+++ b/images/README.md
@@ -1,22 +1,28 @@
 # plugin-compiler
 
-Does not support go modules. If your plugin has vendored modules that
-are [also used by Tyk
+~~Does not support go modules. If your plugin has vendored modules that
+are [also used by tyk
 gateway](https://github.com/TykTechnologies/tyk/tree/master/vendor)
-then your module will be overridden by the version that Tyk uses.
+then your module will be overridden by the version that Tyk uses.~~
+
+Since 3.2, tyk has started using go.mod and thus your vendor'd code will no longer be overridden by tyk's versions.
+
+## Using the image
+Assuming that you are in the plugin source directory and that you want to build a plugin for v3.0.4 of the the gateway,
 
 ``` shell
-cd ${GOPATH}/src/tyk-plugin
-docker run -v `pwd`:/go/src/plugin-build plugin-build pre
+% docker run --rm -v `pwd`:/plugin-source tykio/tyk-plugin-compiler:v3.0.4 testplugin.so
 ```
 
-You will find a `pre.so` in the current directory which is the file
-that goes into the API definition
+You will find a `testplugin.so` in the current directory which is the file that goes into the API definition
 
 ## Testing the image
 
 ```shell
-% ./test.zsh v2.9.5
+% export tag=v2.9.5
+% rm -v testplugin/*.so
+% docker run --rm -v `pwd`/testplugin:/plugin-source tykio/tyk-plugin-compiler:${tag} testplugin.so
+% docker-compose -f test.yml up
 ....
 ```
 Look for `msg="API Loaded" api_id= api_name="Goplugin test"` in the output. Test that the plugin is working correctly by,

--- a/images/plugin-compiler/test.yml
+++ b/images/plugin-compiler/test.yml
@@ -1,0 +1,14 @@
+version: "3"
+services:
+  redis:
+    image: redis
+
+  gw:
+    image: tykio/tyk-gateway:${tag}
+    volumes:
+      - ./testplugin/testplugin.so:/opt/tyk-gateway/middleware/testplugin.so
+      - ./testplugin/apidef.json:/opt/tyk-gateway/apps/testplugin.json
+    ports:
+      - "8080:8080"
+    environment:
+      - TYK_LOGLEVEL=debug

--- a/images/plugin-compiler/test.zsh
+++ b/images/plugin-compiler/test.zsh
@@ -21,5 +21,5 @@ TRAPINT() {
 export tag=$1
 
 rm -v testplugin/*.so
-podman run --rm -v `pwd`/testplugin:/plugin-source tykio/tyk-plugin-compiler:${tag} testplugin.so
+docker run --rm -v `pwd`/testplugin:/plugin-source tykio/tyk-plugin-compiler:${tag} testplugin.so
 docker-compose -f test.yml up

--- a/images/plugin-compiler/test.zsh
+++ b/images/plugin-compiler/test.zsh
@@ -1,0 +1,25 @@
+#!/usr/bin/env zsh
+
+function usage {
+    local progname=$1
+    cat <<EOF
+Usage:
+$progname <tag>
+
+Builds the plugin in testplugin using the supplied tag and tests it in the corresponding gw image.
+Requires docker compose.
+EOF
+    exit 1
+}
+
+TRAPINT() {
+    print Tearing down test env
+    docker-compose -f test.yml down
+}
+
+[[ -z $1 ]] && usage $0
+export tag=$1
+
+rm -v testplugin/*.so
+podman run --rm -v `pwd`/testplugin:/plugin-source tykio/tyk-plugin-compiler:${tag} testplugin.so
+docker-compose -f test.yml up

--- a/images/plugin-compiler/testplugin/apidef.json
+++ b/images/plugin-compiler/testplugin/apidef.json
@@ -1,0 +1,77 @@
+{
+    "name": "Goplugin test",
+    "slug": "goplugin",
+    "use_go_plugin_auth": false,
+    "use_keyless": true,
+    "use_oauth2": false,
+    "use_openid": false,
+    "openid_options": {
+	"providers": [],
+	"segregate_by_client": false
+    },
+    "version_data": {
+        "not_versioned": true,
+        "versions": {
+            "Default": {
+                "name": "Default",
+                "expires": "3000-01-02 15:04",
+                "use_extended_paths": true,
+                "extended_paths": {
+                    "ignored": [],
+                    "white_list": [],
+                    "black_list": []
+                }
+            }
+        }
+    },
+    "proxy": {
+	"preserve_host_header": false,
+	"listen_path": "/goplugin/",
+	"target_url": "http://httpbin.org/",
+	"strip_listen_path": true,
+	"enable_load_balancing": false,
+	"target_list": [],
+	"check_host_against_uptime_tests": false,
+	"service_discovery": {
+	    "use_discovery_service": false,
+	    "query_endpoint": "",
+	    "use_nested_query": false,
+	    "parent_data_path": "",
+	    "data_path": "",
+	    "port_data_path": "",
+	    "target_path": "",
+	    "use_target_list": false,
+	    "cache_timeout": 0,
+	    "endpoint_returns_list": false
+	}
+    },
+    "auth": {
+	"use_param": false,
+	"param_name": "",
+	"use_cookie": false,
+	"cookie_name": "",
+	"auth_header_name": "Authorization",
+	"use_certificate": false
+    },
+    "custom_middleware": {
+	"pre": [],
+	"post": [
+	 {
+	    "name": "AddFooBarHeader",
+	    "path": "/opt/tyk-gateway/middleware/testplugin.so",
+	    "require_session": false
+	}
+	],
+	"post_key_auth": [],
+	"auth_check": {},
+	"response": [],
+	"driver": "goplugin",
+	"id_extractor": {
+	    "extract_from": "",
+	    "extract_with": "",
+	    "extractor_config": {}
+	}
+    },
+    "custom_middleware_bundle": "",
+    "strip_auth_data": false
+}

--- a/images/plugin-compiler/testplugin/main.go
+++ b/images/plugin-compiler/testplugin/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"net/http"
+)
+
+// AddFooBarHeader adds custom "Foo: Bar" header to the request
+//nolint:deadcode
+func AddFooBarHeader(rw http.ResponseWriter, r *http.Request) {
+	r.Header.Add("Foo", "Bar")
+}
+
+func main() {}


### PR DESCRIPTION
Fetches things from Hub, suitable for testing -rc tags.

## Motivation and Context
Goplugins depend on many things being in alignment.

## How This Has Been Tested
Requires a functional docker-compose.

Run it as
```shell
% ./test.zsh v2.9.5
....
```

Look for `msg="API Loaded" api_id= api_name="Goplugin test"` in the output. Control-C will stop everything.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
