### PR TITLE
add proxy config to gql apidef (TT-1935)

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -914,6 +914,9 @@ func DummyAPI() APIDefinition {
 		ExecutionMode:    GraphQLExecutionModeProxyOnly,
 		Version:          GraphQLConfigVersion2,
 		LastSchemaUpdate: nil,
+		Proxy: GraphQLProxyConfig{
+			AuthHeaders: map[string]string{},
+		},
 	}
 
 	return APIDefinition{

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -6,6 +6,7 @@ import (
 	"encoding/xml"
 	"net/http"
 	"text/template"
+	"time"
 
 	"github.com/jensneuse/graphql-go-tools/pkg/execution/datasource"
 
@@ -14,9 +15,8 @@ import (
 	"github.com/lonelycode/osin"
 	"gopkg.in/mgo.v2/bson"
 
-	"time"
-
 	"github.com/TykTechnologies/gojsonschema"
+
 	"github.com/TykTechnologies/tyk/regexp"
 )
 
@@ -556,6 +556,8 @@ type GraphQLConfig struct {
 	GraphQLPlayground GraphQLPlayground `bson:"playground" json:"playground"`
 	// Engine holds the configuration for engine v2 and upwards.
 	Engine GraphQLEngineConfig `bson:"engine" json:"engine"`
+	// Proxy holds the configuration for a proxy only api.
+	Proxy GraphQLProxyConfig `bson:"proxy" json:"proxy"`
 }
 
 type GraphQLConfigVersion string
@@ -565,6 +567,10 @@ const (
 	GraphQLConfigVersion1    GraphQLConfigVersion = "1"
 	GraphQLConfigVersion2    GraphQLConfigVersion = "2"
 )
+
+type GraphQLProxyConfig struct {
+	AuthHeaders map[string]string `bson:"auth_headers" json:"auth_headers"`
+}
 
 type GraphQLEngineConfig struct {
 	FieldConfigs []GraphQLFieldConfig      `bson:"field_configs" json:"field_configs"`

--- a/apidef/schema.go
+++ b/apidef/schema.go
@@ -521,7 +521,7 @@ const Schema = `{
                             }
                         },
                         "data_sources": {
-                            "type": ["object", "null"],
+                            "type": ["array", "null"],
                             "properties": {
                                 "kind": {
                                     "type": "string",

--- a/apidef/schema.go
+++ b/apidef/schema.go
@@ -439,6 +439,9 @@ const Schema = `{
                 "enabled": {
                     "type": "boolean"
                 },
+				"version": {
+                    "type": "string"
+                },
                 "execution_mode": {
                     "type": "string",
                     "enum": [
@@ -496,6 +499,72 @@ const Schema = `{
                         "type_name",
                         "field_name"
                     ]
+                },
+				"engine": {
+                    "type": ["object", "null"],
+                    "properties": {
+                        "field_configs": {
+                            "type": ["array", "null"],
+                            "properties": {
+                                "type_name": {
+                                    "type": "string"
+                                },
+                                "field_name": {
+                                    "type": "string"
+                                },
+                                "disable_default_mapping": {
+                                    "type": "boolean"
+                                },
+                                "path": {
+                                    "type": ["array", "null"]
+                                }
+                            }
+                        },
+                        "data_sources": {
+                            "type": ["object", "null"],
+                            "properties": {
+                                "kind": {
+                                    "type": "string",
+                                    "enum": [
+                                        "REST",
+                                        "GraphQL",
+                                        ""
+                                    ]
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "internal": {
+                                    "type": "boolean"
+                                },
+                                "root_fields": {
+                                    "type": ["array", "null"],
+                                    "properties": {
+                                        "type": {
+                                            "type": "string"
+                                        },
+                                        "fields": {
+                                            "type": ["array", "null"]
+                                        }
+                                    }
+                                },
+                                "config": {
+                                    "type": ["object", "null"]
+                                }
+                            },
+                            "required": [
+                                "kind"
+                            ]
+                        }
+                    }
+                },
+				"proxy": {
+                    "type": ["object", "null"],
+                    "properties": {
+                        "auth_headers": {
+                            "type": ["object", "null"]
+                        }
+                    }
                 },
                 "playground": {
                     "type": ["object", "null"],


### PR DESCRIPTION
This PR adds the ability to save auth headers for proxy-only GraphQL APIs.
It also adds some missing JSON Schema definitions for the v2 config.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)
