### PR TITLE
[TT-880] Send unique gw session id in node registration request

### DIFF
--- a/gateway/dashboard_register.go
+++ b/gateway/dashboard_register.go
@@ -161,6 +161,9 @@ func (h *HTTPDashboardHandler) Register() error {
 		dashLog.Errorf("Request failed with error %v; retrying in 5s", err)
 		time.Sleep(time.Second * 5)
 		return h.Register()
+	} else if resp.StatusCode == http.StatusConflict {
+		dashLog.Debug("Node is already registered")
+		return nil
 	} else if resp != nil && resp.StatusCode != 200 {
 		dashLog.Errorf("Response failed with code %d; retrying in 5s", resp.StatusCode)
 		time.Sleep(time.Second * 5)
@@ -227,6 +230,7 @@ func (h *HTTPDashboardHandler) newRequest(endpoint string) *http.Request {
 	}
 	req.Header.Set("authorization", h.Secret)
 	req.Header.Set(headers.XTykHostname, hostDetails.Hostname)
+	req.Header.Set(headers.XTykSessionID, SessionID)
 	return req
 }
 

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -87,6 +87,9 @@ var (
 	muNodeID sync.Mutex // guards NodeID
 	NodeID   string
 
+	// SessionID is the unique session id which is used while connecting to dashboard to prevent multiple node allocation.
+	SessionID string
+
 	runningTestsMu sync.RWMutex
 	testMode       bool
 
@@ -1254,6 +1257,8 @@ func Start() {
 	}
 
 	SetNodeID("solo-" + uuid.NewV4().String())
+
+	SessionID = uuid.NewV4().String()
 
 	if err := initialiseSystem(ctx); err != nil {
 		mainLog.Fatalf("Error initialising system: %v", err)

--- a/headers/headers.go
+++ b/headers/headers.go
@@ -34,6 +34,7 @@ const (
 	XXSSProtection      = "X-XSS-Protection"
 	XFrameOptions       = "X-Frame-Options"
 	XTykNodeID          = "x-tyk-nodeid"
+	XTykSessionID       = "x-tyk-session-id"
 	XTykNonce           = "x-tyk-nonce"
 	XTykHostname        = "x-tyk-hostname"
 	XGenerator          = "X-Generator"


### PR DESCRIPTION
The idea is to send unique session id from gateway to prevent multiple node id allocation for one gateway.

Works with: https://github.com/TykTechnologies/tyk-analytics/pull/2331