### PR TITLE
add graphql federation support (TT-1689)

### DIFF
--- a/apidef/adapter/graphql_config_adapter.go
+++ b/apidef/adapter/graphql_config_adapter.go
@@ -10,6 +10,7 @@ import (
 	restDataSource "github.com/jensneuse/graphql-go-tools/pkg/engine/datasource/rest_datasource"
 	"github.com/jensneuse/graphql-go-tools/pkg/engine/plan"
 	"github.com/jensneuse/graphql-go-tools/pkg/graphql"
+	"github.com/jensneuse/graphql-go-tools/pkg/graphql/federation"
 
 	"github.com/TykTechnologies/tyk/apidef"
 )
@@ -50,6 +51,35 @@ func (g *GraphQLConfigAdapter) EngineConfigV2() (*graphql.EngineV2Configuration,
 		return nil, ErrUnsupportedGraphQLConfigVersion
 	}
 
+	if g.isSupergraphAPIDefinition() {
+		return g.createV2ConfigForSupergraphExecutionMode()
+	}
+
+	return g.createV2ConfigForEngineExecutionMode()
+}
+
+func (g *GraphQLConfigAdapter) createV2ConfigForSupergraphExecutionMode() (*graphql.EngineV2Configuration, error) {
+	client := g.httpClient
+	if client == nil {
+		client = httpclient.DefaultNetHttpClient
+	}
+
+	dataSourceConfs := g.supergraphDataSourceConfigs()
+	federationConfigV2Factory := federation.NewEngineConfigV2Factory(client, dataSourceConfs...)
+	err := federationConfigV2Factory.SetMergedSchemaFromString(g.config.Supergraph.MergedSDL)
+	if err != nil {
+		return nil, err
+	}
+
+	conf, err := federationConfigV2Factory.EngineV2Configuration()
+	if err != nil {
+		return nil, err
+	}
+
+	return &conf, nil
+}
+
+func (g *GraphQLConfigAdapter) createV2ConfigForEngineExecutionMode() (*graphql.EngineV2Configuration, error) {
 	if err := g.parseSchema(); err != nil {
 		return nil, err
 	}
@@ -177,6 +207,35 @@ func (g *GraphQLConfigAdapter) engineConfigV2DataSources() (planDataSources []pl
 	return planDataSources, err
 }
 
+func (g *GraphQLConfigAdapter) supergraphDataSourceConfigs() []graphqlDataSource.Configuration {
+	confs := make([]graphqlDataSource.Configuration, 0)
+	if len(g.config.Supergraph.Subgraphs) == 0 {
+		return confs
+	}
+
+	for _, apiDefSubgraphConf := range g.config.Supergraph.Subgraphs {
+		if len(apiDefSubgraphConf.SDL) == 0 {
+			continue
+		}
+
+		conf := graphqlDataSource.Configuration{
+			Fetch: graphqlDataSource.FetchConfiguration{
+				URL:    apiDefSubgraphConf.URL,
+				Method: http.MethodPost,
+				Header: nil,
+			},
+			Federation: graphqlDataSource.FederationConfiguration{
+				Enabled:    true,
+				ServiceSDL: apiDefSubgraphConf.SDL,
+			},
+		}
+
+		confs = append(confs, conf)
+	}
+
+	return confs
+}
+
 func (g *GraphQLConfigAdapter) engineConfigV2Arguments(fieldConfs *plan.FieldConfigurations, generatedArgs map[graphql.TypeFieldLookupKey]graphql.TypeFieldArguments) {
 	for i := range *fieldConfs {
 		if len(generatedArgs) == 0 {
@@ -268,4 +327,8 @@ func (g *GraphQLConfigAdapter) determineChildNodes(planDataSources []plan.DataSo
 		}
 	}
 	return nil
+}
+
+func (g *GraphQLConfigAdapter) isSupergraphAPIDefinition() bool {
+	return g.config.Enabled && g.config.ExecutionMode == apidef.GraphQLExecutionModeSupergraph
 }

--- a/apidef/adapter/graphql_config_adapter_test.go
+++ b/apidef/adapter/graphql_config_adapter_test.go
@@ -33,8 +33,7 @@ func TestGraphQLConfigAdapter_EngineConfigV2(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(graphqlEngineV2SupergraphConfigJson), &gqlConfig))
 
 		httpClient := &http.Client{}
-		adapter := NewGraphQLConfigAdapter(gqlConfig)
-		adapter.SetHttpClient(httpClient)
+		adapter := NewGraphQLConfigAdapter(gqlConfig, WithHttpClient(httpClient))
 
 		_, err := adapter.EngineConfigV2()
 		assert.NoError(t, err)

--- a/apidef/adapter/graphql_config_adapter_test.go
+++ b/apidef/adapter/graphql_config_adapter_test.go
@@ -3,7 +3,7 @@ package adapter
 import (
 	"encoding/json"
 	"net/http"
-	"strings"
+	"strconv"
 	"testing"
 
 	graphqlDataSource "github.com/jensneuse/graphql-go-tools/pkg/engine/datasource/graphql_datasource"
@@ -62,7 +62,7 @@ func TestGraphQLConfigAdapter_supergraphDataSourceConfigs(t *testing.T) {
 			},
 			Federation: graphqlDataSource.FederationConfiguration{
 				Enabled:    true,
-				ServiceSDL: cleanEscapeCharacters(federationAccountsServiceSDL),
+				ServiceSDL: federationAccountsServiceSDL,
 			},
 		},
 		{
@@ -73,7 +73,7 @@ func TestGraphQLConfigAdapter_supergraphDataSourceConfigs(t *testing.T) {
 			},
 			Federation: graphqlDataSource.FederationConfiguration{
 				Enabled:    true,
-				ServiceSDL: cleanEscapeCharacters(federationProductsServiceSDL),
+				ServiceSDL: federationProductsServiceSDL,
 			},
 		},
 		{
@@ -84,7 +84,7 @@ func TestGraphQLConfigAdapter_supergraphDataSourceConfigs(t *testing.T) {
 			},
 			Federation: graphqlDataSource.FederationConfiguration{
 				Enabled:    true,
-				ServiceSDL: cleanEscapeCharacters(federationReviewsServiceSDL),
+				ServiceSDL: federationReviewsServiceSDL,
 			},
 		},
 	}
@@ -287,10 +287,6 @@ func TestGraphQLConfigAdapter_engineConfigV2DataSources(t *testing.T) {
 	assert.ElementsMatch(t, expectedDataSources, actualDataSources)
 }
 
-func cleanEscapeCharacters(input string) string {
-	return strings.ReplaceAll(input, "\\\"", "\"")
-}
-
 const graphqlEngineV1ConfigJson = `{
 	"enabled": true,
 	"execution_mode": "executionEngine",
@@ -408,11 +404,12 @@ const graphqlEngineV2ConfigJson = `{
 	"playground": {}
 }`
 
-const federationAccountsServiceSDL = "extend type Query {me: User} type User @key(fields: \\\"id\\\"){ id: ID! username: String!}"
-const federationProductsServiceSDL = "extend type Query {topProducts(first: Int = 5): [Product]} type Product @key(fields: \\\"upc\\\") {upc: String! name: String! price: Int!}"
-const federationReviewsServiceSDL = "type Review { body: String! author: User! @provides(fields: \\\"username\\\") product: Product! } extend type User @key(fields: \\\"id\\\") { id: ID! @external reviews: [Review] } extend type Product @key(fields: \\\"upc\\\") { upc: String! @external reviews: [Review] }"
+const federationAccountsServiceSDL = `extend type Query {me: User} type User @key(fields: "id"){ id: ID! username: String!}`
+const federationProductsServiceSDL = `extend type Query {topProducts(first: Int = 5): [Product]} type Product @key(fields: "upc") {upc: String! name: String! price: Int!}`
+const federationReviewsServiceSDL = `type Review { body: String! author: User! @provides(fields: "username") product: Product! } extend type User @key(fields: "id") { id: ID! @external reviews: [Review] } extend type Product @key(fields: "upc") { upc: String! @external reviews: [Review] }`
 const federationMergedSDL = `type Query { me: User topProducts(first: Int = 5): [Product] } type User { id: ID! username: String! reviews: [Review] } type Product { upc: String! name: String! price: Int! reviews: [Review] } type Review { body: String! author: User! product: Product! }`
-const graphqlEngineV2SupergraphConfigJson = `{
+
+var graphqlEngineV2SupergraphConfigJson = `{
 	"enabled": true,
 	"execution_mode": "supergraph",
 	"version": "2",
@@ -427,12 +424,12 @@ const graphqlEngineV2SupergraphConfigJson = `{
 			{
 				"api_id": "",
 				"url": "http://accounts.service",
-				"sdl": "` + federationAccountsServiceSDL + `"
+				"sdl": ` + strconv.Quote(federationAccountsServiceSDL) + `
 			},
 			{
 				"api_id": "",
 				"url": "http://products.service",
-				"sdl": "` + federationProductsServiceSDL + `"
+				"sdl": ` + strconv.Quote(federationProductsServiceSDL) + `
 			},
 			{
 				"api_id": "",
@@ -442,7 +439,7 @@ const graphqlEngineV2SupergraphConfigJson = `{
 			{
 				"api_id": "",
 				"url": "http://reviews.service",
-				"sdl": "` + federationReviewsServiceSDL + `"
+				"sdl": ` + strconv.Quote(federationReviewsServiceSDL) + `
 			}
 		],
 		"merged_sdl": "` + federationMergedSDL + `"

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/xml"
-
 	"net/http"
 	"text/template"
 	"time"
@@ -567,6 +566,10 @@ type GraphQLConfig struct {
 	Engine GraphQLEngineConfig `bson:"engine" json:"engine"`
 	// Proxy holds the configuration for a proxy only api.
 	Proxy GraphQLProxyConfig `bson:"proxy" json:"proxy"`
+	// Subgraph holds the configuration for a GraphQL federation subgraph.
+	Subgraph GraphQLSubgraphConfig `bson:"subgraph" json:"subgraph"`
+	// Supergraph holds the configuration for a GraphQL federation supergraph.
+	Supergraph GraphQLSupergraphConfig `bson:"supergraph" json:"supergraph"`
 }
 
 type GraphQLConfigVersion string
@@ -579,6 +582,21 @@ const (
 
 type GraphQLProxyConfig struct {
 	AuthHeaders map[string]string `bson:"auth_headers" json:"auth_headers"`
+}
+
+type GraphQLSubgraphConfig struct {
+	SDL string `bson:"sdl" json:"sdl"`
+}
+
+type GraphQLSupergraphConfig struct {
+	Subgraphs []GraphQLSubgraphEntity `bson:"subgraphs" json:"subgraphs"`
+	MergedSDL string                  `bson:"merged_sdl" json:"merged_sdl"`
+}
+
+type GraphQLSubgraphEntity struct {
+	APIID string `bson:"api_id" json:"api_id"`
+	URL   string `bson:"url" json:"url"`
+	SDL   string `bson:"sdl" json:"sdl"`
 }
 
 type GraphQLEngineConfig struct {
@@ -643,6 +661,11 @@ const (
 	// GraphQLExecutionModeExecutionEngine is the mode in which the GraphQL Middleware will evaluate every request.
 	// This means the Middleware will act as a independent GraphQL service which might delegate partial execution to upstreams.
 	GraphQLExecutionModeExecutionEngine GraphQLExecutionMode = "executionEngine"
+	// GraphQLExecutionModeSubgraph is the mode if the API is defined as a subgraph for usage in GraphQL federation.
+	// It will basically act the same as an API in proxyOnly mode but can be used in a supergraph.
+	GraphQLExecutionModeSubgraph GraphQLExecutionMode = "subgraph"
+	// GraphQLExecutionModeSupergraph is the mode where an API is able to use subgraphs to build a supergraph in GraphQL federation.
+	GraphQLExecutionModeSupergraph GraphQLExecutionMode = "supergraph"
 )
 
 // GraphQLPlayground represents the configuration for the public playground which will be hosted alongside the api.

--- a/apidef/schema.go
+++ b/apidef/schema.go
@@ -447,6 +447,8 @@ const Schema = `{
                     "enum": [
                         "proxyOnly",
                         "executionEngine",
+						"subgraph",
+						"supergraph",
                         ""
                     ]
                 },
@@ -563,6 +565,36 @@ const Schema = `{
                     "properties": {
                         "auth_headers": {
                             "type": ["object", "null"]
+                        }
+                    }
+                },
+                "subgraph": {
+                    "type": ["object", "null"],
+                    "properties": {
+                        "sdl": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "supergraph": {
+                    "type": ["object", "null"],
+                    "properties": {
+                        "subgraphs": {
+                            "type": ["array", "null"],
+                            "properties": {
+                                "api_id": {
+                                    "type": "string"
+                                },
+                                "url": {
+                                    "type": "string"
+                                },
+                                "sdl": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "merged_sdl": {
+                            "type": "string"
                         }
                     }
                 },

--- a/apidef/schema.go
+++ b/apidef/schema.go
@@ -439,7 +439,7 @@ const Schema = `{
                 "enabled": {
                     "type": "boolean"
                 },
-				"version": {
+                "version": {
                     "type": "string"
                 },
                 "execution_mode": {
@@ -447,8 +447,8 @@ const Schema = `{
                     "enum": [
                         "proxyOnly",
                         "executionEngine",
-						"subgraph",
-						"supergraph",
+                        "subgraph",
+                        "supergraph",
                         ""
                     ]
                 },
@@ -502,7 +502,7 @@ const Schema = `{
                         "field_name"
                     ]
                 },
-				"engine": {
+                "engine": {
                     "type": ["object", "null"],
                     "properties": {
                         "field_configs": {
@@ -560,7 +560,7 @@ const Schema = `{
                         }
                     }
                 },
-				"proxy": {
+                "proxy": {
                     "type": ["object", "null"],
                     "properties": {
                         "auth_headers": {

--- a/gateway/mw_graphql.go
+++ b/gateway/mw_graphql.go
@@ -61,7 +61,7 @@ func (m *GraphQLMiddleware) Init() {
 
 	m.Spec.GraphQLExecutor.Schema = schema
 
-	if m.needsExecutionEngine() {
+	if needsGraphQLExecutionEngine(m.Spec) {
 		absLogger := abstractlogger.NewLogrusLogger(log, absLoggerLevel(log.Level))
 		m.Spec.GraphQLExecutor.Client = &http.Client{Transport: &http.Transport{TLSClientConfig: tlsClientConfig(m.Spec)}}
 
@@ -244,11 +244,6 @@ func (m *GraphQLMiddleware) websocketUpgradeUsesGraphQLProtocol(r *http.Request)
 	return websocketProtocol == GraphQLWebSocketProtocol
 }
 
-func (m *GraphQLMiddleware) needsExecutionEngine() bool {
-	return m.Spec.GraphQL.ExecutionMode == apidef.GraphQLExecutionModeExecutionEngine ||
-		m.Spec.GraphQL.ExecutionMode == apidef.GraphQLExecutionModeSupergraph
-}
-
 func (m *GraphQLMiddleware) checkForUnsupportedUsage() error {
 	if m.isGraphQLConfigVersion1() && m.isSupergraphAPIDefinition() {
 		return errors.New("supergraph execution mode is not supported for graphql config version 1 - please use version 2")
@@ -296,6 +291,11 @@ func (m *GraphQLMiddleware) OnError(ctx resolve.HookContext, output []byte, sing
 				"single_flight": singleFlight,
 			},
 		).Debugf("%s (afterFetchHook.OnError): %s", ctx.CurrentPath, string(output))
+}
+
+func needsGraphQLExecutionEngine(apiSpec *APISpec) bool {
+	return apiSpec.GraphQL.ExecutionMode == apidef.GraphQLExecutionModeExecutionEngine ||
+		apiSpec.GraphQL.ExecutionMode == apidef.GraphQLExecutionModeSupergraph
 }
 
 func absLoggerLevel(level logrus.Level) abstractlogger.Level {

--- a/gateway/mw_graphql.go
+++ b/gateway/mw_graphql.go
@@ -61,7 +61,7 @@ func (m *GraphQLMiddleware) Init() {
 
 	m.Spec.GraphQLExecutor.Schema = schema
 
-	if m.Spec.GraphQL.ExecutionMode == apidef.GraphQLExecutionModeExecutionEngine {
+	if m.needsExecutionEngine() {
 		absLogger := abstractlogger.NewLogrusLogger(log, absLoggerLevel(log.Level))
 		m.Spec.GraphQLExecutor.Client = &http.Client{Transport: &http.Transport{TLSClientConfig: tlsClientConfig(m.Spec)}}
 
@@ -168,9 +168,18 @@ func (m *GraphQLMiddleware) initGraphQLEngineV2(logger *abstractlogger.LogrusLog
 	m.Spec.GraphQLExecutor.EngineV2 = engine
 	m.Spec.GraphQLExecutor.HooksV2.BeforeFetchHook = m
 	m.Spec.GraphQLExecutor.HooksV2.AfterFetchHook = m
+
+	if m.isSupergraphAPIDefinition() {
+		m.loadSupergraphMergedSDLAsSchema()
+	}
 }
 
 func (m *GraphQLMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
+	err := m.checkForUnsupportedUsage()
+	if err != nil {
+		m.Logger().WithError(err).Error("request could not be executed because of unsupported usage")
+		return errors.New("there was a problem proxying the request"), http.StatusInternalServerError
+	}
 
 	if m.Spec.GraphQLExecutor.Schema == nil {
 		m.Logger().Error("Schema is not created")
@@ -191,7 +200,7 @@ func (m *GraphQLMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 	}
 
 	var gqlRequest gql.Request
-	err := gql.UnmarshalRequest(r.Body, &gqlRequest)
+	err = gql.UnmarshalRequest(r.Body, &gqlRequest)
 	if err != nil {
 		m.Logger().Debugf("Error while unmarshalling GraphQL request: '%s'", err)
 		return err, http.StatusBadRequest
@@ -233,6 +242,31 @@ func (m *GraphQLMiddleware) writeGraphQLError(w http.ResponseWriter, errors gql.
 func (m *GraphQLMiddleware) websocketUpgradeUsesGraphQLProtocol(r *http.Request) bool {
 	websocketProtocol := r.Header.Get(headers.SecWebSocketProtocol)
 	return websocketProtocol == GraphQLWebSocketProtocol
+}
+
+func (m *GraphQLMiddleware) needsExecutionEngine() bool {
+	return m.Spec.GraphQL.ExecutionMode == apidef.GraphQLExecutionModeExecutionEngine ||
+		m.Spec.GraphQL.ExecutionMode == apidef.GraphQLExecutionModeSupergraph
+}
+
+func (m *GraphQLMiddleware) checkForUnsupportedUsage() error {
+	if m.isGraphQLConfigVersion1() && m.isSupergraphAPIDefinition() {
+		return errors.New("supergraph execution mode is not supported for graphql config version 1 - please use version 2")
+	}
+
+	return nil
+}
+
+func (m *GraphQLMiddleware) isGraphQLConfigVersion1() bool {
+	return m.Spec.GraphQL.Version == apidef.GraphQLConfigVersion1 || m.Spec.GraphQL.Version == apidef.GraphQLConfigVersionNone
+}
+
+func (m *GraphQLMiddleware) isSupergraphAPIDefinition() bool {
+	return m.Spec.GraphQL.ExecutionMode == apidef.GraphQLExecutionModeSupergraph
+}
+
+func (m *GraphQLMiddleware) loadSupergraphMergedSDLAsSchema() {
+	m.Spec.GraphQL.Schema = m.Spec.GraphQL.Supergraph.MergedSDL
 }
 
 func (m *GraphQLMiddleware) OnBeforeFetch(ctx resolve.HookContext, input []byte) {

--- a/gateway/mw_graphql_test.go
+++ b/gateway/mw_graphql_test.go
@@ -410,6 +410,21 @@ func TestGraphQLMiddleware_EngineMode(t *testing.T) {
 
 			_, _ = g.Run(t, test.TestCase{Data: request, BodyMatch: `{"kind":"OBJECT","name":"Country"`, Code: http.StatusOK})
 		})
+
+		t.Run("should return error when supergraph is used with v1", func(t *testing.T) {
+			BuildAndLoadAPI(func(spec *APISpec) {
+				spec.UseKeylessAccess = true
+				spec.Proxy.ListenPath = "/"
+				spec.GraphQL.Enabled = true
+				spec.GraphQL.ExecutionMode = apidef.GraphQLExecutionModeSupergraph
+			})
+
+			request := gql.Request{
+				Query: "query Query { countries { name } }",
+			}
+
+			_, _ = g.Run(t, test.TestCase{Data: request, BodyMatch: `there was a problem proxying the request`, Code: http.StatusInternalServerError})
+		})
 	})
 
 }

--- a/gateway/mw_graphql_test.go
+++ b/gateway/mw_graphql_test.go
@@ -209,7 +209,7 @@ func TestGraphQLMiddleware_EngineMode(t *testing.T) {
 
 				_, _ = g.Run(t, test.TestCase{
 					Data:      request,
-					BodyMatch: `\\"operationName\\":\\"\\",\\"variables\\":{\\"_representations\\":\[{\\"__typename\\":\\"User\\",\\"id\\":\\"1\\"}\]},\\"query\\":\\"query Subgraph\(\$_representations: \[_Any!\]!\) {.*_entities\(representations: \$_representations\) {.*\.\.\. on User {.*id.*username.*}.*}.*}\\"`,
+					BodyMatch: `variables.*_representations.*__typename.*User.*id.*1.*query Subgraph\(\$_representations: \[_Any!\]!\) {.*_entities\(representations: \$_representations\) {.*on User {.* id.* username.*}.*}.*}.*}`,
 					Code:      http.StatusOK,
 				})
 			})

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -816,7 +816,7 @@ func (p *ReverseProxy) handleGraphQL(roundTripper *TykRoundTripper, outreq *http
 		return
 	}
 
-	if p.TykAPISpec.GraphQL.ExecutionMode == apidef.GraphQLExecutionModeExecutionEngine {
+	if needsGraphQLExecutionEngine(p.TykAPISpec) {
 		return p.handoverRequestToGraphQLExecutionEngine(roundTripper, gqlRequest)
 	}
 

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/dgrijalva/jwt-go"
 	"github.com/go-redis/redis/v8"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
@@ -671,21 +671,21 @@ func subgraphAccountsHandler(w http.ResponseWriter, r *http.Request) {
 
 func subgraphReviewsHandler(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write([]byte(`{
-		"data": {
-		    "_entities": [
-			    {
-			        "reviews": [
-				      	{
-				        	"body": "A highly effective form of birth control."
-						},
-				    	{
-				    		"body": "Fedoras are one of the most fashionable hats around and can look great with a variety of outfits."
-				    	}
-					]
-			    }
-		    ]
-		}
-	  }`))
+			"data": {
+				"_entities": [
+					{
+						"reviews": [
+							{
+								"body": "A highly effective form of birth control."
+							},
+							{
+								"body": "Fedoras are one of the most fashionable hats around and can look great with a variety of outfits."
+							}
+						]
+					}
+				]
+			}
+		}`))
 }
 
 const jwkTestJson = `{

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -462,6 +462,8 @@ const (
 	handlerPathRestDataSource        = "/rest-data-source"
 	handlerPathGraphQLDataSource     = "/graphql-data-source"
 	handlerPathHeadersRestDataSource = "/rest-headers-data-source"
+	handlerSubgraphAccounts          = "/subgraph-accounts"
+	handlerSubgraphReviews           = "/subgraph-reviews"
 
 	// We need a static port so that the urls can be used in static
 	// test data, and to prevent the requests from being randomized
@@ -475,6 +477,8 @@ const (
 	testGraphQLDataSource     = TestHttpAny + handlerPathGraphQLDataSource
 	testRESTDataSource        = TestHttpAny + handlerPathRestDataSource
 	testRESTHeadersDataSource = TestHttpAny + handlerPathHeadersRestDataSource
+	testSubgraphAccounts      = TestHttpAny + handlerSubgraphAccounts
+	testSubgraphReviews       = TestHttpAny + handlerSubgraphReviews
 	testHttpJWK               = TestHttpAny + "/jwk.json"
 	testHttpJWKLegacy         = TestHttpAny + "/jwk-legacy.json"
 	testHttpBundles           = TestHttpAny + "/bundles/"
@@ -556,6 +560,8 @@ func testHttpHandler() *mux.Router {
 	r.HandleFunc(handlerPathGraphQLDataSource, graphqlDataSourceHandler)
 	r.HandleFunc(handlerPathRestDataSource, restDataSourceHandler)
 	r.HandleFunc(handlerPathHeadersRestDataSource, restHeadersDataSourceHandler)
+	r.HandleFunc(handlerSubgraphAccounts, subgraphAccountsHandler)
+	r.HandleFunc(handlerSubgraphReviews, subgraphReviewsHandler)
 
 	r.HandleFunc("/ws", wsHandler)
 	r.HandleFunc("/jwk.json", func(w http.ResponseWriter, r *http.Request) {
@@ -650,6 +656,36 @@ func restDataSourceHandler(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		]`))
+}
+
+func subgraphAccountsHandler(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write([]byte(`{
+		"data": {
+			"me": {
+				"id": "1",
+				"username": "tyk"
+			}
+		}
+	}`))
+}
+
+func subgraphReviewsHandler(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write([]byte(`{
+		"data": {
+		    "_entities": [
+			    {
+			        "reviews": [
+				      	{
+				        	"body": "A highly effective form of birth control."
+						},
+				    	{
+				    		"body": "Fedoras are one of the most fashionable hats around and can look great with a variety of outfits."
+				    	}
+					]
+			    }
+		    ]
+		}
+	  }`))
 }
 
 const jwkTestJson = `{

--- a/go.mod
+++ b/go.mod
@@ -100,4 +100,4 @@ require (
 
 replace github.com/jensneuse/graphql-go-tools => github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20210602073701-d05425e1bfd0
 
-replace github.com/jensneuse/graphql-go-tools => ../graphql-go-tools
+//replace github.com/jensneuse/graphql-go-tools => ../graphql-go-tools

--- a/go.mod
+++ b/go.mod
@@ -100,4 +100,4 @@ require (
 
 replace github.com/jensneuse/graphql-go-tools => github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20210602073701-d05425e1bfd0
 
-//replace github.com/jensneuse/graphql-go-tools => ../graphql-go-tools
+replace github.com/jensneuse/graphql-go-tools => ../graphql-go-tools


### PR DESCRIPTION
This PR adds support for GraphQL federation.
The API definition has been extended with a section for `supergraph` and `subgraph`. The execution mode can now also be set to `supergraph` (= `engine`) or `subgraph` (=`proxy-only`).

## Related Issue
https://tyktech.atlassian.net/browse/TT-1689


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)