### PR TITLE
Fix concurrent map usage when cloning session

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/miekg/dns v1.0.14
 	github.com/mitchellh/mapstructure v1.2.2
 	github.com/newrelic/go-agent v2.13.0+incompatible
-	github.com/nsf/jsondiff v0.0.0-20210303162244-6ea32392771e // indirect
+	github.com/nsf/jsondiff v0.0.0-20210303162244-6ea32392771e
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/openzipkin/zipkin-go v0.2.2
 	github.com/oschwald/maxminddb-golang v1.5.0

--- a/user/session.go
+++ b/user/session.go
@@ -123,6 +123,9 @@ func NewSessionState() *SessionState {
 
 // Clone  returns a fresh copy of s
 func (s *SessionState) Clone() SessionState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	return SessionState{
 		LastCheck:                     s.LastCheck,
 		Allowance:                     s.Allowance,


### PR DESCRIPTION
In order to allow concurrent session object usage, we clone it before use.
However clone operation itself is not thread safe.
Situation becomes especially visible when `local_session_cache.disable_cached_session_state` set to false, e.g. when in-memory cache used a lot.

Fix #3567

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [ ] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
