### PR TITLE
[TT-1611] Make request body re-readable after dynamic middleware

### DIFF
--- a/gateway/mw_js_plugin.go
+++ b/gateway/mw_js_plugin.go
@@ -231,6 +231,9 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 		r.Body = ioutil.NopCloser(bytes.NewReader(newRequestData.Request.Body))
 	}
 
+	// make sure request's body can be re-read again
+	nopCloseRequestBody(r)
+
 	r.URL, err = url.Parse(newRequestData.Request.URL)
 	if err != nil {
 		return nil, http.StatusOK

--- a/gateway/mw_js_plugin_test.go
+++ b/gateway/mw_js_plugin_test.go
@@ -102,15 +102,15 @@ leakMid.NewProcessRequest(function(request, session) {
 	dynMid.Spec.JSVM = jsvm
 	dynMid.ProcessRequest(nil, req, nil)
 
-	bs, err := ioutil.ReadAll(req.Body)
-	if err != nil {
-		t.Fatalf("failed to read final body: %v", err)
-	}
 	want := body + " appended"
-	if got := string(bs); want != got {
-		t.Fatalf("JS plugin broke non-UTF8 body %q into %q",
-			want, got)
-	}
+
+	newBodyInBytes, _ := ioutil.ReadAll(req.Body)
+	assert.Equal(t, want, string(newBodyInBytes))
+
+	t.Run("check request body is re-readable", func(t *testing.T) {
+		newBodyInBytes, _ = ioutil.ReadAll(req.Body)
+		assert.Equal(t, want, string(newBodyInBytes))
+	})
 }
 
 func TestJSVMSessionMetadataUpdate(t *testing.T) {


### PR DESCRIPTION
The request body is reconstructed after dynamic middleware. However, it is forgotten to be made re-readable so it causes log-browser to show empty request body. This PR calls the function `nopCloseRequestBody` which makes request body re-readable and also added a test. I checked that the test fails without the fix.