### PR TITLE
[TT-960] Add allowance scope in case no pol in key and per api

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -350,7 +350,7 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 				}
 
 				idForScope := apiID
-				// check if we already have limit on API level specified when policy was created
+				// check if we don't have limit on API level specified when policy was created
 				if accessRights.Limit == nil || *accessRights.Limit == (user.APILimit{}) {
 					// limit was not specified on API level so we will populate it from policy
 					idForScope = policy.ID
@@ -570,6 +570,17 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 	session.Tags = []string{}
 	for tag := range tags {
 		session.Tags = append(session.Tags, tag)
+	}
+
+	if len(policies) == 0 {
+		accessRights := session.GetAccessRights()
+		for apiID, accessRight := range accessRights {
+			// check if the api in the session has per api limit
+			if accessRight.Limit != nil && *accessRight.Limit != (user.APILimit{}) {
+				accessRight.AllowanceScope = apiID
+				session.AccessRights[apiID] = accessRight
+			}
+		}
 	}
 
 	distinctACL := map[string]bool{}

--- a/gateway/middleware_test.go
+++ b/gateway/middleware_test.go
@@ -1,10 +1,15 @@
 package gateway
 
 import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
 	"net/http"
 	"testing"
 
 	"github.com/TykTechnologies/tyk/apidef"
+	headers2 "github.com/TykTechnologies/tyk/headers"
+	"github.com/TykTechnologies/tyk/test"
 	cache "github.com/pmylund/go-cache"
 	"github.com/stretchr/testify/assert"
 
@@ -102,4 +107,89 @@ func TestBaseMiddleware_getAuthType(t *testing.T) {
 	assert.Equal(t, "t5", getToken(jwt.getAuthType(), jwt.getAuthToken))
 	assert.Equal(t, "t6", getToken(oauth.getAuthType(), oauth.getAuthToken))
 	assert.Equal(t, "t7", getToken(oidc.getAuthType(), oidc.getAuthToken))
+}
+
+func TestSessionLimiter_RedisQuotaExceeded_PerAPI(t *testing.T) {
+	g := StartTest()
+	defer g.Close()
+
+	apis := BuildAPI(func(spec *APISpec) {
+		spec.APIID = "api1"
+		spec.UseKeylessAccess = false
+		spec.Proxy.ListenPath = "/api1/"
+	}, func(spec *APISpec) {
+		spec.APIID = "api2"
+		spec.UseKeylessAccess = false
+		spec.Proxy.ListenPath = "/api2/"
+	}, func(spec *APISpec) {
+		spec.APIID = "api3"
+		spec.UseKeylessAccess = false
+		spec.Proxy.ListenPath = "/api3/"
+	})
+
+	LoadAPI(apis...)
+
+	const globalQuotaMax int64 = 25
+
+	session, key := g.CreateSession(func(s *user.SessionState) {
+		s.AccessRights = map[string]user.AccessDefinition{
+			apis[0].APIID: {
+				APIID: apis[0].APIID,
+				Limit: &user.APILimit{
+					QuotaMax: 10,
+				},
+			},
+			apis[1].APIID: {
+				APIID: apis[1].APIID,
+				Limit: &user.APILimit{
+					QuotaMax: 2,
+				},
+			},
+			apis[2].APIID: {
+				APIID: apis[2].APIID,
+			},
+		}
+		s.QuotaMax = globalQuotaMax
+		s.QuotaRemaining = globalQuotaMax
+	})
+
+	headers := map[string]string{
+		headers2.Authorization: key,
+	}
+
+	// Check allowance scope is equal to api id because per api is enabled for api1 and api2
+	assert.Equal(t, session.AccessRights[apis[0].APIID].AllowanceScope, apis[0].APIID)
+	assert.Equal(t, session.AccessRights[apis[1].APIID].AllowanceScope, apis[1].APIID)
+
+	// Check allowcance scope is equal to "" because per api is not enabled for api3
+	assert.Equal(t, session.AccessRights[apis[2].APIID].AllowanceScope, "")
+
+	sendReqAndCheckQuota := func(t *testing.T, apiID string, expectedQuotaRemaining int64, perAPI bool) {
+		_, _ = g.Run(t, test.TestCase{Path: fmt.Sprintf("/%s/", apiID), Headers: headers, Code: http.StatusOK})
+
+		resp, _ := g.Run(t, test.TestCase{Path: "/tyk/keys/" + key, AdminAuth: true, Code: http.StatusOK})
+		bodyInBytes, _ := ioutil.ReadAll(resp.Body)
+		var session user.SessionState
+		_ = json.Unmarshal(bodyInBytes, &session)
+
+		if perAPI {
+			assert.Equal(t, expectedQuotaRemaining, session.AccessRights[apiID].Limit.QuotaRemaining)
+			assert.Equal(t, globalQuotaMax, session.QuotaRemaining) // global quota should remain same
+		} else {
+			assert.Equal(t, expectedQuotaRemaining, session.QuotaRemaining) // if not per api, fallback to global
+		}
+	}
+
+	// for api1 - per api
+	sendReqAndCheckQuota(t, apis[0].APIID, 9, true)
+	sendReqAndCheckQuota(t, apis[0].APIID, 8, true)
+	sendReqAndCheckQuota(t, apis[0].APIID, 7, true)
+
+	// for api2 - per api
+	sendReqAndCheckQuota(t, apis[1].APIID, 1, true)
+	sendReqAndCheckQuota(t, apis[1].APIID, 0, true)
+
+	// for api3 - global
+	sendReqAndCheckQuota(t, apis[2].APIID, 24, false)
+	sendReqAndCheckQuota(t, apis[2].APIID, 23, false)
 }


### PR DESCRIPTION
The problem is that when you add two APIs to a key without policy, they are using same redis key for quota. In policy case, it uses allowance scope and for each API, it stores in different redis key. 

This is how we generate redis key:
https://github.com/TykTechnologies/tyk/blob/047733bd92e150c110be0d3afa8c2a4106ea3699/gateway/session_manager.go#L257

Briefly, when two APIs key without policy and per api enabled `quotaScope` is `""`, that is the issue.