### PR TITLE
[TT-2867] Fix ResetQuota calling inside handleDeleteKey function

### DIFF
--- a/gateway/api.go
+++ b/gateway/api.go
@@ -634,17 +634,17 @@ func handleAddKey(keyName, hashedName, sessionString, apiID string) {
 	}).Info("Updated hashed key in slave storage.")
 }
 
-func handleDeleteKey(keyName, apiID string, resetQuota bool) (interface{}, int) {
-	orgID := ""
-	if spec := getApiSpec(apiID); spec != nil {
-		orgID = spec.OrgID
+func handleDeleteKey(keyName, orgID, apiID string, resetQuota bool) (interface{}, int) {
+	session, ok := GlobalSessionManager.SessionDetail(orgID, keyName, false)
+	if !ok {
+		return apiError("There is no such key found"), http.StatusNotFound
 	}
 
 	if apiID == "-1" {
 		// Go through ALL managed API's and delete the key
 		apisMu.RLock()
 		removed := GlobalSessionManager.RemoveSession(orgID, keyName, false)
-		GlobalSessionManager.ResetQuota(keyName, &user.SessionState{}, false)
+		GlobalSessionManager.ResetQuota(keyName, &session, false)
 
 		apisMu.RUnlock()
 
@@ -676,7 +676,7 @@ func handleDeleteKey(keyName, apiID string, resetQuota bool) (interface{}, int) 
 	}
 
 	if resetQuota {
-		GlobalSessionManager.ResetQuota(keyName, &user.SessionState{}, false)
+		GlobalSessionManager.ResetQuota(keyName, &session, false)
 	}
 
 	statusObj := apiModifyKeySuccess{
@@ -701,8 +701,8 @@ func handleDeleteKey(keyName, apiID string, resetQuota bool) (interface{}, int) 
 }
 
 // handleDeleteHashedKeyWithLogs is a wrapper for handleDeleteHashedKey with logs
-func handleDeleteHashedKeyWithLogs(keyName, apiID string, resetQuota bool) (interface{}, int) {
-	res, code := handleDeleteHashedKey(keyName, apiID, resetQuota)
+func handleDeleteHashedKeyWithLogs(keyName, orgID, apiID string, resetQuota bool) (interface{}, int) {
+	res, code := handleDeleteHashedKey(keyName, orgID, apiID, resetQuota)
 
 	if code != http.StatusOK {
 		log.WithFields(logrus.Fields{
@@ -721,10 +721,11 @@ func handleDeleteHashedKeyWithLogs(keyName, apiID string, resetQuota bool) (inte
 	return res, code
 }
 
-func handleDeleteHashedKey(keyName, apiID string, resetQuota bool) (interface{}, int) {
-	orgID := ""
-	if spec := getApiSpec(apiID); spec != nil {
-		orgID = spec.OrgID
+func handleDeleteHashedKey(keyName, orgID, apiID string, resetQuota bool) (interface{}, int) {
+
+	session, ok := GlobalSessionManager.SessionDetail(orgID, keyName, true)
+	if !ok {
+		return apiError("There is no such key found"), http.StatusNotFound
 	}
 
 	if apiID == "-1" {
@@ -745,7 +746,7 @@ func handleDeleteHashedKey(keyName, apiID string, resetQuota bool) (interface{},
 	}
 
 	if resetQuota {
-		GlobalSessionManager.ResetQuota(keyName, &user.SessionState{}, true)
+		GlobalSessionManager.ResetQuota(keyName, &session, true)
 	}
 
 	statusObj := apiModifyKeySuccess{
@@ -972,16 +973,16 @@ func keyHandler(w http.ResponseWriter, r *http.Request) {
 	case http.MethodDelete:
 		// Remove a key
 		if !isHashed {
-			obj, code = handleDeleteKey(keyName, apiID, true)
+			obj, code = handleDeleteKey(keyName, orgID, apiID, true)
 		} else {
-			obj, code = handleDeleteHashedKeyWithLogs(keyName, apiID, true)
+			obj, code = handleDeleteHashedKeyWithLogs(keyName, orgID, apiID, true)
 		}
 		if code != http.StatusOK && hashKeyFunction != "" {
 			// try to use legacy key format
 			if !isHashed {
-				obj, code = handleDeleteKey(origKeyName, apiID, true)
+				obj, code = handleDeleteKey(origKeyName, orgID, apiID, true)
 			} else {
-				obj, code = handleDeleteHashedKeyWithLogs(origKeyName, apiID, true)
+				obj, code = handleDeleteHashedKeyWithLogs(origKeyName, orgID, apiID, true)
 			}
 		}
 	}

--- a/gateway/middleware_test.go
+++ b/gateway/middleware_test.go
@@ -112,6 +112,8 @@ func TestBaseMiddleware_getAuthType(t *testing.T) {
 func TestSessionLimiter_RedisQuotaExceeded_PerAPI(t *testing.T) {
 	g := StartTest()
 	defer g.Close()
+	GlobalSessionManager.Store().DeleteAllKeys()
+	defer GlobalSessionManager.Store().DeleteAllKeys()
 
 	apis := BuildAPI(func(spec *APISpec) {
 		spec.APIID = "api1"

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -859,7 +859,7 @@ func (r *RPCStorageHandler) ProcessKeySpaceChanges(keys []string, orgId string) 
 			RevokeToken(storage, token, tokenTypeHint)
 		} else {
 			token = strings.Split(token, "#")[0]
-			handleDeleteHashedKey(token, apiId, false)
+			handleDeleteHashedKey(token, orgId, apiId, false)
 		}
 		SessionCache.Delete(token)
 		RPCGlobalCache.Delete(r.KeyPrefix + token)
@@ -873,7 +873,7 @@ func (r *RPCStorageHandler) ProcessKeySpaceChanges(keys []string, orgId string) 
 			if len(splitKeys) > 1 && splitKeys[1] == "hashed" {
 				key = splitKeys[0]
 				log.Info("--> removing cached (hashed) key: ", splitKeys[0])
-				handleDeleteHashedKey(splitKeys[0], "", resetQuota)
+				handleDeleteHashedKey(splitKeys[0], orgId, "", resetQuota)
 				getSessionAndCreate(splitKeys[0], r)
 			} else {
 				log.Info("--> removing cached key: ", key)
@@ -881,7 +881,7 @@ func (r *RPCStorageHandler) ProcessKeySpaceChanges(keys []string, orgId string) 
 				if storage.TokenOrg(key) == "" {
 					key = generateToken(orgId, key)
 				}
-				handleDeleteKey(key, "-1", resetQuota)
+				handleDeleteKey(key, orgId, "-1", resetQuota)
 				getSessionAndCreate(splitKeys[0], r)
 			}
 			SessionCache.Delete(key)

--- a/gateway/rpc_storage_handler_test.go
+++ b/gateway/rpc_storage_handler_test.go
@@ -152,6 +152,9 @@ func TestProcessKeySpaceChanges_ResetQuota(t *testing.T) {
 		HashKeys:         false,
 	}
 
+	GlobalSessionManager.Store().DeleteAllKeys()
+	defer GlobalSessionManager.Store().DeleteAllKeys()
+
 	g := StartTest()
 	defer g.Close()
 

--- a/gateway/rpc_storage_handler_test.go
+++ b/gateway/rpc_storage_handler_test.go
@@ -127,11 +127,10 @@ func TestProcessKeySpaceChangesForOauth(t *testing.T) {
 			} else {
 				getKeyFromStore = GlobalSessionManager.Store().GetKey
 				GlobalSessionManager.Store().DeleteAllKeys()
-				GlobalSessionManager.Store().SetKey(token, token, 100)
-				_, err := GlobalSessionManager.Store().GetKey(token)
-				if err != nil {
-					t.Fatal("Key should be pre-loaded in store previously so the test can perform the revoke action.")
-				}
+				err := GlobalSessionManager.Store().SetRawKey(token, token, 100)
+				assert.NoError(t, err)
+				_, err = GlobalSessionManager.Store().GetRawKey(token)
+				assert.NoError(t, err)
 			}
 
 			stringEvent := buildStringEvent(tc.Event, token, myApi.APIID)

--- a/gateway/rpc_storage_handler_test.go
+++ b/gateway/rpc_storage_handler_test.go
@@ -2,10 +2,14 @@ package gateway
 
 import (
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/headers"
 	"github.com/TykTechnologies/tyk/storage"
+	"github.com/TykTechnologies/tyk/test"
+	"github.com/TykTechnologies/tyk/user"
 	"github.com/lonelycode/osin"
 	"github.com/stretchr/testify/assert"
 )
@@ -140,4 +144,60 @@ func TestProcessKeySpaceChangesForOauth(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestProcessKeySpaceChanges_ResetQuota(t *testing.T) {
+	rpcListener := RPCStorageHandler{
+		KeyPrefix:        "rpc.listener.",
+		SuppressRegister: true,
+		HashKeys:         false,
+	}
+
+	g := StartTest()
+	defer g.Close()
+
+	api := BuildAndLoadAPI(func(spec *APISpec) {
+		spec.UseKeylessAccess = false
+		spec.Proxy.ListenPath = "/api"
+	})[0]
+
+	session, key := g.CreateSession(func(s *user.SessionState) {
+		s.AccessRights = map[string]user.AccessDefinition{api.APIID: {
+			APIID: api.APIID,
+			Limit: &user.APILimit{
+				QuotaMax: 30,
+			},
+		}}
+	})
+
+	auth := map[string]string{
+		headers.Authorization: key,
+	}
+
+	// Call 3 times
+	_, _ = g.Run(t, []test.TestCase{
+		{Path: "/api", Headers: auth, Code: http.StatusOK},
+		{Path: "/api", Headers: auth, Code: http.StatusOK},
+		{Path: "/api", Headers: auth, Code: http.StatusOK},
+	}...)
+
+	// AllowanceScope is api id.
+	quotaKey := QuotaKeyPrefix + api.APIID + "-" + key
+	quotaCounter, err := GlobalSessionManager.Store().GetRawKey(quotaKey)
+	assert.NoError(t, err)
+	assert.Equal(t, "3", quotaCounter)
+
+	rpcListener.ProcessKeySpaceChanges([]string{key + ":resetQuota", key}, api.OrgID)
+
+	// mock of key reload in mdcb environment
+	err = GlobalSessionManager.UpdateSession(key, session, 0, false)
+	assert.NoError(t, err)
+
+	// Call 1 time
+	_, _ = g.Run(t, test.TestCase{Path: "/api", Headers: auth, Code: http.StatusOK})
+
+	// ProcessKeySpaceChanges should reset the quota counter, it should be 1 instead of 4.
+	quotaCounter, err = GlobalSessionManager.Store().GetRawKey(quotaKey)
+	assert.NoError(t, err)
+	assert.Equal(t, "1", quotaCounter)
 }


### PR DESCRIPTION
The session given to `ResetQuota` is empty. So, it prevents calling allowance scoped quota counters to remain same.