### PR TITLE
TT-2798: supergraph global headers

### DIFF
--- a/apidef/adapter/graphql_config_adapter.go
+++ b/apidef/adapter/graphql_config_adapter.go
@@ -213,7 +213,7 @@ func (g *GraphQLConfigAdapter) supergraphDataSourceConfigs() []graphqlDataSource
 			Fetch: graphqlDataSource.FetchConfiguration{
 				URL:    apiDefSubgraphConf.URL,
 				Method: http.MethodPost,
-				Header: nil,
+				Header: g.convertHttpHeadersToEngineV2Headers(g.config.Supergraph.GlobalHeaders),
 			},
 			Federation: graphqlDataSource.FederationConfiguration{
 				Enabled:    true,

--- a/apidef/adapter/graphql_config_adapter_test.go
+++ b/apidef/adapter/graphql_config_adapter_test.go
@@ -57,7 +57,10 @@ func TestGraphQLConfigAdapter_supergraphDataSourceConfigs(t *testing.T) {
 			Fetch: graphqlDataSource.FetchConfiguration{
 				URL:    "http://accounts.service",
 				Method: http.MethodPost,
-				Header: nil,
+				Header: http.Header{
+					"header1": []string{"value1"},
+					"header2": []string{"value2"},
+				},
 			},
 			Federation: graphqlDataSource.FederationConfiguration{
 				Enabled:    true,
@@ -68,7 +71,10 @@ func TestGraphQLConfigAdapter_supergraphDataSourceConfigs(t *testing.T) {
 			Fetch: graphqlDataSource.FetchConfiguration{
 				URL:    "http://products.service",
 				Method: http.MethodPost,
-				Header: nil,
+				Header: http.Header{
+					"header1": []string{"value1"},
+					"header2": []string{"value2"},
+				},
 			},
 			Federation: graphqlDataSource.FederationConfiguration{
 				Enabled:    true,
@@ -79,7 +85,10 @@ func TestGraphQLConfigAdapter_supergraphDataSourceConfigs(t *testing.T) {
 			Fetch: graphqlDataSource.FetchConfiguration{
 				URL:    "http://reviews.service",
 				Method: http.MethodPost,
-				Header: nil,
+				Header: http.Header{
+					"header1": []string{"value1"},
+					"header2": []string{"value2"},
+				},
 			},
 			Federation: graphqlDataSource.FederationConfiguration{
 				Enabled:    true,
@@ -441,6 +450,10 @@ var graphqlEngineV2SupergraphConfigJson = `{
 				"sdl": ` + strconv.Quote(federationReviewsServiceSDL) + `
 			}
 		],
+		"global_headers": {
+			"header1": "value1",
+			"header2": "value2"
+		},
 		"merged_sdl": "` + federationMergedSDL + `"
 	},
 	"playground": {}

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -664,9 +664,10 @@ type GraphQLSubgraphConfig struct {
 
 type GraphQLSupergraphConfig struct {
 	// UpdatedAt contains the date and time of the last update of a supergraph API.
-	UpdatedAt *time.Time              `bson:"updated_at" json:"updated_at,omitempty"`
-	Subgraphs []GraphQLSubgraphEntity `bson:"subgraphs" json:"subgraphs"`
-	MergedSDL string                  `bson:"merged_sdl" json:"merged_sdl"`
+	UpdatedAt     *time.Time              `bson:"updated_at" json:"updated_at,omitempty"`
+	Subgraphs     []GraphQLSubgraphEntity `bson:"subgraphs" json:"subgraphs"`
+	MergedSDL     string                  `bson:"merged_sdl" json:"merged_sdl"`
+	GlobalHeaders map[string]string       `bson:"global_headers" json:"global_headers"`
 }
 
 type GraphQLSubgraphEntity struct {

--- a/apidef/schema.go
+++ b/apidef/schema.go
@@ -600,6 +600,9 @@ const Schema = `{
                                 }
                             }
                         },
+                        "global_headers": {
+                            "type": ["object", "null"]
+                        },
                         "merged_sdl": {
                             "type": "string"
                         }


### PR DESCRIPTION
implements global headers in a federated supergraph.

## Description
Storing the global headers in API definition

## Motivation and Context
https://tyktech.atlassian.net/browse/TT-2798

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

