### PR TITLE
[TT-2932] fix upgrades for gw from 3.0.6

### DIFF
--- a/bin/dist_build.sh
+++ b/bin/dist_build.sh
@@ -121,7 +121,7 @@ FPMCOMMON=(
     --before-install $TEMPLATEDIR/install/before_install.sh
     --after-install $TEMPLATEDIR/install/post_install.sh
     --after-remove $TEMPLATEDIR/install/post_remove.sh
-    --after-upgrade $TEMPLATEDIR/install/posttrans.sh
+    --posttrans $TEMPLATEDIR/install/posttrans.sh
 )
 
 cd $BUILDDIR

--- a/bin/dist_build.sh
+++ b/bin/dist_build.sh
@@ -121,7 +121,7 @@ FPMCOMMON=(
     --before-install $TEMPLATEDIR/install/before_install.sh
     --after-install $TEMPLATEDIR/install/post_install.sh
     --after-remove $TEMPLATEDIR/install/post_remove.sh
-    --before-upgrade $TEMPLATEDIR/install/backup.sh
+    --rpm-pretrans $TEMPLATEDIR/install/backup.sh
     --rpm-posttrans $TEMPLATEDIR/install/posttrans.sh
 )
 

--- a/bin/dist_build.sh
+++ b/bin/dist_build.sh
@@ -121,11 +121,7 @@ FPMCOMMON=(
     --before-install $TEMPLATEDIR/install/before_install.sh
     --after-install $TEMPLATEDIR/install/post_install.sh
     --after-remove $TEMPLATEDIR/install/post_remove.sh
-)
-[ -z $PKGCONFLICTS ] || FPMCOMMON+=( --conflicts $PKGCONFLICTS )
-FPMRPM=(
-    --before-upgrade $TEMPLATEDIR/install/post_remove.sh
-    --after-upgrade $TEMPLATEDIR/install/post_install.sh
+    --after-upgrade $TEMPLATEDIR/install/posttrans.sh
 )
 
 cd $BUILDDIR

--- a/bin/dist_build.sh
+++ b/bin/dist_build.sh
@@ -121,7 +121,7 @@ FPMCOMMON=(
     --before-install $TEMPLATEDIR/install/before_install.sh
     --after-install $TEMPLATEDIR/install/post_install.sh
     --after-remove $TEMPLATEDIR/install/post_remove.sh
-    --posttrans $TEMPLATEDIR/install/posttrans.sh
+    --rpm-posttrans $TEMPLATEDIR/install/posttrans.sh
 )
 
 cd $BUILDDIR

--- a/bin/dist_build.sh
+++ b/bin/dist_build.sh
@@ -121,6 +121,7 @@ FPMCOMMON=(
     --before-install $TEMPLATEDIR/install/before_install.sh
     --after-install $TEMPLATEDIR/install/post_install.sh
     --after-remove $TEMPLATEDIR/install/post_remove.sh
+    --before-upgrade $TEMPLATEDIR/install/backup.sh
     --rpm-posttrans $TEMPLATEDIR/install/posttrans.sh
 )
 

--- a/bin/dist_push.sh
+++ b/bin/dist_push.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 : ${ORGDIR:="/go/src/github.com/TykTechnologies"}
 : ${SOURCEBINPATH:="${ORGDIR}/tyk"}
-: ${DEBVERS:="ubuntu/trusty ubuntu/xenial ubuntu/bionic debian/jessie debian/stretch debian/buster"}
-: ${RPMVERS:="el/6 el/7 el/8"}
+: ${DEBVERS:="ubuntu/xenial ubuntu/bionic debian/jessie debian/stretch debian/buster"}
+: ${RPMVERS:="el/7 el/8"}
 : ${PKGNAME:="tyk-gateway"}
 
 echo "Set version number"

--- a/install/backup.sh
+++ b/install/backup.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+SERVICE_NAME=tyk-gateway
+
+mkdir -p /tmp/tyk-backups
+
+if command -V systemctl >/dev/null 2>&1; then
+    cp /lib/systemd/system/${SERVICE_NAME}.service /tmp/tyk-backups
+    echo Backed up systemd service file
+    fi
+fi

--- a/install/backup.sh
+++ b/install/backup.sh
@@ -7,5 +7,4 @@ mkdir -p /tmp/tyk-backups
 if command -V systemctl >/dev/null 2>&1; then
     cp /lib/systemd/system/${SERVICE_NAME}.service /tmp/tyk-backups
     echo Backed up systemd service file
-    fi
 fi

--- a/install/posttrans.sh
+++ b/install/posttrans.sh
@@ -5,5 +5,6 @@ SERVICE_NAME=tyk-gateway
 if command -V systemctl >/dev/null 2>&1; then
     if [ ! -f /lib/systemd/system/${SERVICE_NAME}.service ]; then
 	cp /opt/${SERVICE_NAME}/install/${SERVICE_NAME}.service /lib/systemd/system/${SERVICE_NAME}.service
+	echo Restored systemd service file
     fi
 fi

--- a/install/posttrans.sh
+++ b/install/posttrans.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-SERVICE_NAME=tyk-dashboard
+SERVICE_NAME=tyk-gateway
 
 if command -V systemctl >/dev/null 2>&1; then
     if [ ! -f /lib/systemd/system/${SERVICE_NAME}.service ]; then

--- a/install/posttrans.sh
+++ b/install/posttrans.sh
@@ -4,7 +4,7 @@ SERVICE_NAME=tyk-gateway
 
 if command -V systemctl >/dev/null 2>&1; then
     if [ ! -f /lib/systemd/system/${SERVICE_NAME}.service ]; then
-	cp /opt/${SERVICE_NAME}/install/${SERVICE_NAME}.service /lib/systemd/system/${SERVICE_NAME}.service
+	cp /tmp/tyk-backups/${SERVICE_NAME}.service /lib/systemd/system/${SERVICE_NAME}.service
 	echo Restored systemd service file
     fi
 fi

--- a/install/posttrans.sh
+++ b/install/posttrans.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+SERVICE_NAME=tyk-dashboard
+
+if command -V systemctl >/dev/null 2>&1; then
+    if [ ! -f /lib/systemd/system/${SERVICE_NAME}.service ]; then
+	cp /opt/${SERVICE_NAME}/install/${SERVICE_NAME}.service /lib/systemd/system/${SERVICE_NAME}.service
+    fi
+fi


### PR DESCRIPTION
This is an alternate strategy to https://github.com/TykTechnologies/tyk-analytics/pull/2386

## Description
With this PR, we fallback to the old Buddy pipeline release process for 3.0.x releases. This PR will need to be applied to release-3.0.7 and release-3-lts.

## Related Issue
https://tyktech.atlassian.net/browse/TT-2932

## Motivation and Context
We backup and restore the systemd service file using rpm specific triggers. Since goreleaser and xenial are in opposition, using fpm can allow for LTS releases to continue supporting xenial _and_ work-around the upgrade bug.

While this works there are a lot of scripts that run at various points and it is not easy for a person without context to understand what is going on here. This is not good for LTS branches which prioritise stability.

## How This Has Been Tested
Tested locally using `tyk-gateway-3.0.7~273.3268ac0` from tyk-gateway-unstable repo. Upgraded from 3.0.6 from tyk-gateway repo.