### PR TITLE
[TT-1924] Fix issue with non-plugin paths

### DIFF
--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -93,7 +93,6 @@ func (m *GoPluginMiddleware) Name() string {
 }
 
 func (m *GoPluginMiddleware) EnabledForSpec() bool {
-
 	// global go plugins
 	if m.Path != "" && m.SymbolName != "" {
 		m.loadPlugin()
@@ -133,25 +132,22 @@ func (m *GoPluginMiddleware) loadPlugin() bool {
 	return true
 }
 
-func (m *GoPluginMiddleware) goPluginConfigFromRequest(r *http.Request) {
-
+func (m *GoPluginMiddleware) goPluginFromRequest(r *http.Request) (*GoPluginMiddleware, bool) {
 	version, _ := m.Spec.Version(r)
 	versionPaths := m.Spec.RxPaths[version.Name]
 
 	found, perPathPerMethodGoPlugin := m.Spec.CheckSpecMatchesStatus(r, versionPaths, GoPlugin)
-	if found {
-		m.handler = perPathPerMethodGoPlugin.(*GoPluginMiddleware).handler
-		m.Meta = perPathPerMethodGoPlugin.(*GoPluginMiddleware).Meta
-		m.Path = perPathPerMethodGoPlugin.(*GoPluginMiddleware).Path
-		m.SymbolName = perPathPerMethodGoPlugin.(*GoPluginMiddleware).SymbolName
-		m.logger = perPathPerMethodGoPlugin.(*GoPluginMiddleware).logger
-	}
+	return perPathPerMethodGoPlugin.(*GoPluginMiddleware), found
 }
 func (m *GoPluginMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, conf interface{}) (err error, respCode int) {
-
-	// is there a go plugin per path - we copy the handler etc from the urlspec if we find one
+	// if a Go plugin is found for this path, override the base handler and logger:
+	logger := m.logger
+	handler := m.handler
 	if !m.APILevel {
-		m.goPluginConfigFromRequest(r)
+		if pluginMw, found := m.goPluginFromRequest(r); found {
+			logger = pluginMw.logger
+			handler = pluginMw.handler
+		}
 	}
 
 	// make sure tyk recover in case Go-plugin function panics
@@ -159,7 +155,7 @@ func (m *GoPluginMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reque
 		if e := recover(); e != nil {
 			err = fmt.Errorf("%v", e)
 			respCode = http.StatusInternalServerError
-			m.logger.WithError(err).Error("Recovered from panic while running Go-plugin middleware func")
+			logger.WithError(err).Error("Recovered from panic while running Go-plugin middleware func")
 		}
 	}()
 
@@ -180,18 +176,18 @@ func (m *GoPluginMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reque
 	// Inject definition into request context:
 	ctx.SetDefinition(r, m.Spec.APIDefinition)
 
-	m.handler(rw, r)
+	handler(w, r)
 
 	// calculate latency
 	ms := DurationToMillisecond(time.Since(t1))
-	m.logger.WithField("ms", ms).Debug("Go-plugin request processing took")
+	logger.WithField("ms", ms).Debug("Go-plugin request processing took")
 
 	// check if response was sent
 	if rw.responseSent {
 		// check if response code was an error one
 		switch {
 		case rw.statusCodeSent == http.StatusForbidden:
-			m.logger.WithError(err).Error("Authentication error in Go-plugin middleware func")
+			logger.WithError(err).Error("Authentication error in Go-plugin middleware func")
 			m.Base().FireEvent(EventAuthFailure, EventKeyFailureMeta{
 				EventMetaDefault: EventMetaDefault{Message: "Auth Failure", OriginatingRequest: EncodeRequestToEvent(r)},
 				Path:             r.URL.Path,
@@ -203,7 +199,7 @@ func (m *GoPluginMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reque
 			// base middleware will report this error to analytics if needed
 			respCode = rw.statusCodeSent
 			err = fmt.Errorf("plugin function sent error response code: %d", rw.statusCodeSent)
-			m.logger.WithError(err).Error("Failed to process request with Go-plugin middleware func")
+			logger.WithError(err).Error("Failed to process request with Go-plugin middleware func")
 		default:
 			// record 2XX to analytics
 			m.successHandler.RecordHit(r, Latency{Total: int64(ms)}, rw.statusCodeSent, rw.getHttpResponse(r))


### PR DESCRIPTION
When using an API with plugin-enabled paths, requests fail when calling paths that don't reference any plugins.

## Description
The current logic look as follows:
```golang
func (m *GoPluginMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, conf interface{}) (err error, respCode int) {
	// is there a go plugin per path - we copy the handler etc from the urlspec if we find one
	if !m.APILevel {
		m.goPluginConfigFromRequest(r)
	}
	...
	m.handler(rw, r)
```
In this context, the `GoPluginMiddleware` is enabled for the whole API so when you send a request to a path that doesn't use any plugin's function name, `m.handler` is still called, resulting in `panic`. This only occurs during a fresh gateway start.
The proposed solution is to ignore the Go middleware when `m.goPluginConfigFromRequest` reports that no path matches:
```golang
func (m *GoPluginMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, conf interface{}) (err error, respCode int) {
	// is there a go plugin per path - we copy the handler etc from the urlspec if we find one
	if !m.APILevel {
		m.goPluginConfigFromRequest(r)
		// if no handler is available, skip this middleware call:
		if m.handler == nil {
			return
		}
	}
	...
	m.handler(rw, r)
```

## Related Issue
TT-1924


## How This Has Been Tested
Manually tested in `master` using the following steps:
1. Prepare a Go plugin with the following code:

```golang
package main

import (
	"net/http"
)

func MyPluginFunction(rw http.ResponseWriter, r *http.Request) {
	r.Header.Add("plugin-function", "MyPluginFunction")
}

func main() {}

```
2. Build the plugin (we assume that the output is called `plugin.so`):
```
$ go build -buildmode=plugin
```
2. Configure an API with plugin-enabled paths (Go plugins) and reference the above plugin:
```json
    "version_data": {
        "not_versioned": true,
        "default_version": "",
        "versions": {
            "Default": {
                "name": "Default",
                "expires": "",
                "paths": {
                    "ignored": [],
                    "white_list": [],
                    "black_list": []
                },
                "use_extended_paths": true,
                "extended_paths": {
                    "go_plugin": [
                        {
                            "path": "/headers",
                            "method": "GET",
                            "plugin_path": "myplugin.so",
                            "func_name": "MyPluginFunction"
                        }
                    ]
                },
                "global_headers": {},
                "global_headers_remove": [],
                "global_response_headers": {},
                "global_response_headers_remove": [],
                "ignore_endpoint_case": false,
                "global_size_limit": 0,
                "override_target": ""
            }
        }
    },
```
3. Build the gateway with Go plugin tags:
```
$ go build -tags 'goplugin'
```
4. Start the gateway and hit the non-plugin path first, the `curl` output should look like:
```
% curl http://localhost:8080/quickstart/get
curl: (52) Empty reply from server
```
The gateway log will contain a panic:
```
2021/09/01 21:12:54 http: panic serving [::1]:64015: runtime error: invalid memory address or nil pointer dereference
goroutine 131 [running]:
net/http.(*conn).serve.func1(0x14000270000)
	/usr/local/go/src/net/http/server.go:1824 +0x108
panic(0x10539dda0, 0x106110eb0)
	/usr/local/go/src/runtime/panic.go:971 +0x3f4
github.com/sirupsen/logrus.(*Entry).WithFields(0x0, 0x14000588f08, 0x104fb31eb)
	/Users/matias/go/pkg/mod/github.com/sirupsen/logrus@v1.4.2/entry.go:116 +0x28
github.com/sirupsen/logrus.(*Entry).WithField(...)
	/Users/matias/go/pkg/mod/github.com/sirupsen/logrus@v1.4.2/entry.go:111
github.com/sirupsen/logrus.(*Entry).WithError(...)
	/Users/matias/go/pkg/mod/github.com/sirupsen/logrus@v1.4.2/entry.go:101
github.com/TykTechnologies/tyk/gateway.(*GoPluginMiddleware).ProcessRequest.func1(0x14000589838, 0x14000589848, 0x140000dd400)
	/Users/matias/go/src/github.com/TykTechnologies/tyk/gateway/mw_go_plugin.go:162 +0x188
panic(0x10539dda0, 0x106110eb0)
```
5. Now hit the plugin-enabled path:
```
% curl http://localhost:8080/quickstart/headers
{
  "headers": {
    "Accept": "*/*", 
    "Accept-Encoding": "gzip", 
    "Host": "httpbin.org", 
    "Plugin-Id": "MyPluginPerPathFoo", 
    "User-Agent": "curl/7.64.1", 
    "X-Amzn-Trace-Id": "Root=1-6130894e-0a8c96f15629da963e24bb00"
  }
}
```
`curl` output looks as expected now.
6. Now hit the non-plugin path again:
```
% curl http://localhost:8080/quickstart/get
{
  "args": {}, 
  "headers": {
    "Accept": "*/*", 
    "Accept-Encoding": "gzip", 
    "Host": "httpbin.org", 
    "User-Agent": "curl/7.64.1", 
    "X-Amzn-Trace-Id": "Root=1-6130896d-06e63f0b396f9d906ff1f591"
  }, 
  "origin": "::1, 181.123.252.74", 
  "url": "http://httpbin.org/get"
}
```

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [ ] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
