### PR TITLE
Fix swagger inconsistencies

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -1,9 +1,9 @@
 openapi: 3.0.0
 info:
   title: Tyk Gateway API
-  version: 2.8.0
+  version: 3.2.0
   description: |-
-    The Tyk Gateway REST API is the primary means for integrating your application with the Tyk API Gateway system. This API is very small, and has no granular permissions system. It is intended to be used purely for internal automation and integration.
+    The Tyk Gateway API is the primary means for integrating your application with the Tyk API Gateway system. This API is very small, and has no granular permissions system. It is intended to be used purely for internal automation and integration.
 
     **Warning: Under no circumstances should outside parties be granted access to this API.**
 
@@ -16,9 +16,9 @@ info:
     * OAuth client creation (only when not using the Dashboard)
 
 
-    In order to use the REST API, you'll need to set the `secret` parameter in your tyk.conf file.
+    In order to use the Gateway API, you'll need to set the `secret` parameter in your tyk.conf file.
 
-    The shared secret you set should then be sent along as a header with each REST API Request in order for it to be successful:
+    The shared secret you set should then be sent along as a header with each Gateway API Request in order for it to be successful:
 
     ```
     x-tyk-authorization: <your-secret>
@@ -32,82 +32,6 @@ tags:
   - name: Keys
     description: |-
       All keys that are used to access services via Tyk correspond to a session object that informs Tyk about the context of this particular token, like access rules and rate/quota allowance.
-      
-      <h3>Hashed Keys Environment</h3>
-      
-      Listing tokens is only possible if you set `enable_hashed_keys_listing` to `true`. See [Using Hashed Keys Environment Endpoints](https://tyk.io/docs/security/#a-name-key-hashing-a-key-hashing) section for more details.
-      
-      - endpoints `POST /tyk/keys/create`, `POST /tyk/keys` and `POST /tyk/keys/{keyName}` return `"key_hash"` for future use.
-      - endpoint `GET /tyk/keys` retrieves all (or per API) key hashes. You can disable this endpoint by using the `tyk.conf` setting `enable_hashed_keys_listing` (set to false by default).
-      - endpoint `GET /tyk/keys/{keyName}` is able to get a key by its hash. You need to provide the key hash as a `keyName`. 
-      and call it with the optional query parameter `hashed=true`. So the format is `GET /tyk/keys/{keyName}?hashed=true"`.
-      - The same optional parameter is available for the `DELETE /tyk/keys/{keyName}?hashed=true` endpoint.
-      
-      <h3>Example: Import Existing Keys into Tyk</h3>
-      
-
-
-      You can use the `PUT /tyk/keys/{KEY_ID}` endpoint as defined below to import existing keys into Tyk.
-      
-      This example uses standard `authorization` header authentication, and assumes that the Dashboard is located at `127.0.0.1:8080` and the Tyk secret is `352d20ee67be67f6340b4c0605b044b7` - update these as necessary to match your environment.
-      
-      To import a key called `abc`, save the JSON contents as `token.json` (see example below), then run the following Curl command.
-      
-      ```
-      curl http://127.0.0.1:8080/tyk/keys/abc -H 'x-tyk-authorization: 352d20ee67be67f6340b4c0605b044b7' -H 'Content-Type: application/json'  -d @token.json
-      ```
-      
-      The following request will fail as the key doesn't exist.
-      
-      ```
-      curl http://127.0.0.1:8080/quickstart/headers -H 'Authorization. invalid123'
-      ```
-      
-      But this request will now work, using the imported key.
-      
-      ```
-      curl http://127.0.0.1:8080/quickstart/headers -H 'Authorization: abc'
-      ```
-      
-      <h4>Example token.json file<h4>
-      
-      ```
-      {
-        "allowance": 1000,
-        "rate": 1000,
-        "per": 60,
-        "expires": -1,
-        "quota_max": -1,
-        "quota_renews": 1406121006,
-        "quota_remaining": 0,
-        "quota_renewal_rate": 60,
-        "access_rights": {
-          "3": {
-            "api_name": "Tyk Test API",
-            "api_id": "3"
-          }
-        },
-        "org_id": "53ac07777cbb8c2d53000002",
-        "basic_auth_data": {
-          "password": "",
-          "hash_type": ""
-        },
-        "hmac_enabled": false,
-        "hmac_string": "",
-        "is_inactive": false,
-        "apply_policy_id": "",
-        "apply_policies": [
-          "59672779fa4387000129507d",
-          "53222349fa4387004324324e",
-          "543534s9fa4387004324324d"
-          ],
-        "monitor": {
-          "trigger_limits": []
-        }
-      }
-      ```
-
-      Additionally see <a href="https://tyk.io/docs/tyk-rest-api/token-session-object-details/">key session object data format</a>.
   - name: OAuth
     description: |-
       Manage OAuth clients, and manage their tokens
@@ -289,7 +213,7 @@ tags:
       
       * `cache_options.cache_all_safe_requests`: Set this to `true` if you want all *safe* requests (GET, HEAD, OPTIONS) to be cached. This is a blanket setting for APIs where caching is required but you don't want to set individual paths up in the definition.
       
-      * `cache_options.enable_upstream_cache_control`: Set this to `true` if you want your application to control the cache options for Tyk (TTL and whether to cache or not). See [Caching](/docs/reduce-latency/caching/) for more details.
+      * `cache_options.enable_upstream_cache_control`: Set this to `true` if you want your application to control the cache options for Tyk (TTL and whether to cache or not). See [Caching](/docs/basic-config-and-security/reduce-latency/caching/) for more details.
       
       * `response_processors`: Response processors need to be specifically defined so they are loaded on API creation, otherwise the middleware will not fire. In order to have the two main response middleware components fire, the following configuration object should be supplied.
       
@@ -321,7 +245,7 @@ tags:
 
       These methods only work on a single API node. If updating a cluster, it is important to ensure that all nodes are updated before initiating a reload.
 paths:
-  /tyk/apis:
+  '/tyk/apis':
     get:
       description: |-
         List APIs
@@ -580,7 +504,7 @@ paths:
               schema:
                 type: string
               example: "Hello Tiki"
-  /tyk/keys:
+  '/tyk/keys':
     get:
       summary: List Keys
       description: You can retrieve all the keys in your Tyk instance. Returns an array of Key IDs.
@@ -668,12 +592,118 @@ paths:
                 per: 5
                 org_id: 53ac07777cbb8c2d53000002
     put:
-      summary: Update Key or Add custom Key
+      summary: Update Key
       description: |-
         You can also manually add keys to Tyk using your own key-generation algorithm. It is recommended if using this approach to ensure that the OrgID being used in the API Definition and the key data is blank so that Tyk does not try to prepend or manage the key in any way.
       tags:
         - Keys
       operationId: updateKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SessionState"
+            example:
+              quota_max: 60
+              quota_renews: 1406121006
+              quota_renewal_rate: 60
+              allowance: 100
+              rate: 100
+              per: 5
+              org_id: 53ac07777cbb8c2d53000002
+      parameters:
+        - description: |-
+            Adding the suppress_reset parameter and setting it to 1, will cause Tyk not to reset the quota limit that is in the current live quota manager. By default Tyk will reset the quota in the live quota manager (initialising it) when adding a key. Adding the `suppress_reset` flag to the URL parameters will avoid this behaviour.
+          name: suppress_reset
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: ["1"]
+      responses:
+        '200':
+          description: Key updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/apiModifyKeySuccess'
+              example:
+                action: updated
+                status: ok
+        '400':
+          description: No or incorrect Key ID specified
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/apiStatusMessage'
+              example:
+                message: Key ID not specified
+                status: error         
+    post:
+      summary: Create Custom Key / Import Key
+      description: |-
+        You can use the `POST /tyk/keys/{KEY_ID}` endpoint as defined below to import existing keys into Tyk.
+
+        This example uses standard `authorization` header authentication, and assumes that the Gateway is located at `127.0.0.1:8080` and the Tyk secret is `352d20ee67be67f6340b4c0605b044b7` - update these as necessary to match your environment.
+
+        To import a key called `mycustomkey`, save the JSON contents as `token.json` (see example below), then run the following Curl command.
+
+        ```
+        curl http://127.0.0.1:8080/tyk/keys/mycustomkey -H 'x-tyk-authorization: 352d20ee67be67f6340b4c0605b044b7' -H 'Content-Type: application/json'  -d @token.json
+        ```
+
+        The following request will fail as the key doesn't exist.
+
+        ```
+        curl http://127.0.0.1:8080/quickstart/headers -H 'Authorization. invalid123'
+        ```
+
+        But this request will now work, using the imported key.
+
+        ```
+        curl http://127.0.0.1:8080/quickstart/headers -H 'Authorization: mycustomkey'
+        ```
+
+        <h4>Example token.json file<h4>
+
+        ```
+        {
+          "allowance": 1000,
+          "rate": 1000,
+          "per": 60,
+          "expires": -1,
+          "quota_max": -1,
+          "quota_renews": 1406121006,
+          "quota_remaining": 0,
+          "quota_renewal_rate": 60,
+          "access_rights": {
+            "3": {
+              "api_name": "Tyk Test API",
+              "api_id": "3"
+            }
+          },
+          "org_id": "53ac07777cbb8c2d53000002",
+          "basic_auth_data": {
+            "password": "",
+            "hash_type": ""
+          },
+          "hmac_enabled": false,
+          "hmac_string": "",
+          "is_inactive": false,
+          "apply_policy_id": "",
+          "apply_policies": [
+            "59672779fa4387000129507d",
+            "53222349fa4387004324324e",
+            "543534s9fa4387004324324d"
+            ],
+          "monitor": {
+            "trigger_limits": []
+          }
+        }
+        ```
+      tags:
+        - Keys
+      operationId: createCustomKey
       requestBody:
         content:
           application/json:
@@ -731,13 +761,13 @@ paths:
               example:
                 action: Key deleted
                 status: ok
-  /tyk/oauth/clients/create:
+  '/tyk/oauth/clients/create':
     post:
       summary: Create new OAuth client
       description: Any OAuth keys must be generated with the help of a client ID. These need to be pre-registered with Tyk before they can be used (in a similar vein to how you would register your app with Twitter before attempting to ask user permissions using their API).
         <br/><br/>
         <h3>Creating OAuth clients with Access to Multiple APIs</h3>
-        New from Tyk Gateway 2.6.0 is the ability to create OAuth clients with access to more than one API. If you provide the api_id it works the same as in previous releases. If you don¿ït provide the api_id the request uses policy access rights and enumerates APIs from their setting in the newly created OAuth-client.
+        New from Tyk Gateway 2.6.0 is the ability to create OAuth clients with access to more than one API. If you provide the api_id it works the same as in previous releases. If you don't provide the api_id the request uses policy access rights and enumerates APIs from their setting in the newly created OAuth-client.
 
 
       tags:
@@ -764,6 +794,28 @@ paths:
                 api_id: id
                 policy_id: policy
   '/tyk/oauth/clients/{apiID}':
+    put:
+      summary: Update OAuth metadata and Policy ID
+      description: Allows you to update the metadata and Policy ID for an OAuth client.
+      tags:
+        - OAuth
+      operationId: updateoAuthClient
+      parameters:
+        - description: The API ID
+          name: apiID
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OAuth client metadata updated
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/NewClientRequest'  
     get:
       summary: List oAuth clients
       description: OAuth Clients are organised by API ID, and therefore are queried as such.
@@ -883,6 +935,66 @@ paths:
               example:
                 - "tok1"
                 - "tok2"
+  '/tyk/oauth/revoke':
+    post:
+      description: revoke a single token
+      summary: revoke token
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                token: 
+                  description: token to be revoked
+                  type: string
+                client_id: 
+                  description: id of oauth client
+                  type: string
+                token_type_hint: 
+                  description: type of token to be revoked, if sent then the accepted values are access_token and refresh_token. String value and optional, of not provided then it will attempt to remove access and refresh tokens that matchs
+                  type: string
+            example:
+              token: eyJvcmciOiI1ZTIwOTFjNGQ0YWVmY2U2MGMwNGZiOTIiLCJpZCI6ImJlMjlhYjVkODc1OTRhZDJhYTBhNjAwNzFlNzE1ZmQxIiwiaCI6Im11cm11cjY0In0=
+              client_id: 411f0800957c4a3e81fe181141dbc22a
+      tags:
+        - OAuth
+      operationId: revokeSingleToken
+      responses:
+        '200':
+          description: Succesful response
+  '/tyk/oauth/revoke_all':
+    post:
+      description: revoke all the tokens for a given oauth client
+      summary: revoke all client's tokens
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                client_id: 
+                  description: id of oauth client
+                  type: string
+                client_secret: 
+                  description: oauth client secret to ensure that its a valid operation
+                  type: string
+            example:
+              client_id: 411f0800957c4a3e81fe181141dbc22a
+              client_secret: N2Y0YjgzMjctMTEwNi00YWExLWJjM2MtYjg1NWZhM2M1NmNj
+      tags:
+        - OAuth
+      operationId: revokeAllTokens
+      responses:
+        '200':
+          description: Succesful response
+        '400':
+          description: Bad request, form malformed or client secret and client id doesn't match
+        '404':
+          description: oauth client doesn't have any api related
+                
   '/tyk/oauth/refresh/{keyName}':
     delete:
       summary: Invalidate OAuth refresh token
@@ -951,11 +1063,11 @@ paths:
               example:
                 code: MWY0ZDRkMzktOTYwNi00NDRiLTk2YmQtOWQxOGQ3Mjc5Yzdk
                 redirect_to: 'http://client-app.com/oauth-redirect/?code=MWY0ZDRkMzktOTYwNi00NDRiLTk2YmQtOWQxOGQ3Mjc5Yzdk'
-  /tyk/org/keys:
+  '/tyk/org/keys':
     get:
       summary: List Organisation Keys
       description: |-
-        You can now set rate limits at the organisation level by using the following fields - allowance and rate. These are the number of allowed requests for the specified per value, and need to be set to the same value. If you don¿ït want to have organisation level rate limiting, set ¿írate¿ì or ¿íper¿ì to zero, or don¿ït add them to your request.
+        You can now set rate limits at the organisation level by using the following fields - allowance and rate. These are the number of allowed requests for the specified per value, and need to be set to the same value. If you don't want to have organisation level rate limiting, set 'rate' or 'per' to zero, or don't add them to your request.
       tags:
         - Organisation Quotas
       operationId: listOrgKeys
@@ -975,6 +1087,27 @@ paths:
                 keys:
                   - "key1"
                   - "key2"
+  '/tyk/org/keys/{keyID}':
+    parameters:
+      - description: The Key ID
+        name: keyID
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Get an Organisation Key
+      description: Get session info about specified orgnanisation key. Should return up to date rate limit and quota usage numbers.
+      tags:
+        - Organisation Quotas
+      operationId: getOrgKey
+      responses:
+        '200':
+          description: Key object
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionState'
     post:
       summary: Create an organisation key
       description: |-
@@ -1006,33 +1139,12 @@ paths:
                 action: created
                 key: '{...KEY JSON definition...}'
                 status: ok
-  '/tyk/orgs/keys/{keyID}':
-    parameters:
-      - description: The Key ID
-        name: keyID
-        in: path
-        required: true
-        schema:
-          type: string
-    get:
-      summary: Get an Organisation Key
-      description: Get session info about specified orgnanisation key. Should return up to date rate limit and quota usage numbers.
-      tags:
-        - Organisation Quotas
-      operationId: getOrgKey
-      responses:
-        '200':
-          description: Key object
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SessionState'
     put:
       summary: Update Organisation Key
       description: |-
         This work similar to Keys API except that Key ID is always equals Organisation ID
 
-        For Gateway v2.6.0 onwards, you can now set rate limits at the organisation level by using the following fields - allowance and rate. These are the number of allowed requests for the specified per value, and need to be set to the same value. If you don¿ït want to have organisation level rate limiting, set `rate` or `per` to zero, or don¿ït add them to your request.
+        For Gateway v2.6.0 onwards, you can now set rate limits at the organisation level by using the following fields - allowance and rate. These are the number of allowed requests for the specified per value, and need to be set to the same value. If you don't want to have organisation level rate limiting, set `rate` or `per` to zero, or don't add them to your request.
       tags:
         - Organisation Quotas
       operationId: updateOrgKey
@@ -1084,7 +1196,7 @@ paths:
               example:
                 action: Key deleted
                 status: ok
-  /{listen_path}/tyk/batch:
+  '/{listen_path}/tyk/batch':
     parameters:
       - name: listen_path
         in: path


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
 - Sync tyk-docs swagger.yml
 - Rename REST API to Gateway API
 - Remove Hashed Keys Environment from keys description
 - Modify PUT /tyk/keys/{keyID} summary
 - Add POST /tyk/keys/{keyID}
 - Rename GET /tyk/orgs/keys/{keyID} to GET /tyk/org/keys/{keyID}

## Related Issue
<!-- This project only accepts pull requests related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->
[Tyk docs PR](https://github.com/TykTechnologies/tyk-docs/pull/1764)

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
swagger.yml in Tyk repo differs from swagger.yml in [tyk-docs](https://github.com/TykTechnologies/tyk-docs/blob/master/tyk-docs/static/others/gateway-swagger.yaml)
This PR intends to sync these two swagger files


