### PR TITLE
Fix non-cgo build

### DIFF
--- a/gateway/coprocess_python_stub.go
+++ b/gateway/coprocess_python_stub.go
@@ -7,9 +7,10 @@ package gateway
 import (
 	"errors"
 
+	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/coprocess"
 )
 
-func NewPythonDispatcher() (dispatcher coprocess.Dispatcher, err error) {
+func NewPythonDispatcher(conf config.Config) (dispatcher coprocess.Dispatcher, err error) {
 	return nil, errors.New("python support not compiled")
 }

--- a/gateway/coprocess_python_stub.go
+++ b/gateway/coprocess_python_stub.go
@@ -7,9 +7,12 @@ package gateway
 import (
 	"errors"
 
+	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/coprocess"
 )
+
+var GatewayFireSystemEvent func(name apidef.TykEvent, meta interface{})
 
 func NewPythonDispatcher(conf config.Config) (dispatcher coprocess.Dispatcher, err error) {
 	return nil, errors.New("python support not compiled")


### PR DESCRIPTION
Coprocess stub was not updated

These changes were missed during latest MDCB framework. 
Can be replicated on non-cgo envs, but locally on mac can be replicated using `GOOS=linux go build `