### PR TITLE
TT-311 wait for redis connection to be available

### DIFF
--- a/gateway/cert.go
+++ b/gateway/cert.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"github.com/TykTechnologies/tyk/storage"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -288,6 +289,15 @@ func (gw *Gateway) getTLSConfigForClient(baseConfig *tls.Config, listenPort int)
 		certNameMap[certData.Name] = &cert
 	}
 
+	if len(gwConfig.HttpServerOptions.SSLCertificates) > 0 {
+		// ensure that we are connected to redis
+		for {
+			if storage.Connected() {
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
 	for _, cert := range gw.CertificateManager.List(gwConfig.HttpServerOptions.SSLCertificates, certs.CertificatePrivate) {
 		if cert != nil {
 			serverCerts = append(serverCerts, *cert)

--- a/gateway/proxy_muxer.go
+++ b/gateway/proxy_muxer.go
@@ -480,6 +480,7 @@ func (m *proxyMux) generateListener(listenPort int, protocol string, gw *Gateway
 
 		tlsConfig.GetConfigForClient = gw.getTLSConfigForClient(&tlsConfig, listenPort)
 		l, err = tls.Listen("tcp", targetPort, &tlsConfig)
+
 	default:
 		mainLog.WithField("port", targetPort).Infof("--> Standard listener (%s)", protocol)
 		l, err = net.Listen("tcp", targetPort)

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -583,7 +583,7 @@ func (gw *Gateway) loadControlAPIEndpoints(muxer *mux.Router) {
 		r.HandleFunc("/apis/{apiID}", gw.apiHandler).Methods("GET", "POST", "PUT", "DELETE")
 		r.HandleFunc("/health", gw.healthCheckhandler).Methods("GET")
 		r.HandleFunc("/policies", gw.polHandler).Methods("GET", "POST", "PUT", "DELETE")
-		r.HandleFunc("/policies/{polID}",gw.polHandler).Methods("GET", "POST", "PUT", "DELETE")
+		r.HandleFunc("/policies/{polID}", gw.polHandler).Methods("GET", "POST", "PUT", "DELETE")
 		r.HandleFunc("/oauth/clients/create", gw.createOauthClient).Methods("POST")
 		r.HandleFunc("/oauth/clients/{apiID}/{keyName:[^/]*}", gw.oAuthClientHandler).Methods("PUT")
 		r.HandleFunc("/oauth/clients/{apiID}/{keyName:[^/]*}/rotate", gw.rotateOauthClientHandler).Methods("PUT")


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Make the GW wait for redis to be connected to read the certificate. Currently it doesnt wait, so it fails reading the certificate when is a cert id

## Related Issue
https://tyktech.atlassian.net/browse/TT-311

## Motivation and Context
Give solution to https://tyktech.atlassian.net/browse/TT-311

## How This Has Been Tested
- Run GW and dashboard
- Register a cert via cert manager in dashboard and copy the id
- edit the gw config file to use ssl: `http_server_options.use_ssl: true` and `http_server_options.ssl_certificates: ["your_cert_id"]`
- shutdown and start the gw
- Update the config file of dashboard to point to a https gw
- Any traffic from dashboard to gw should be successful (you can try listing keys )
## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [ ] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
