### PR TITLE
[TT-3621] Use session.Certificate to search whether certificate existing

### DIFF
--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/TykTechnologies/tyk/headers"
+
 	"github.com/TykTechnologies/tyk/user"
 
 	"github.com/TykTechnologies/tyk/apidef"
@@ -850,6 +852,7 @@ func TestKeyWithCertificateTLS(t *testing.T) {
 	conf := func(globalConf *config.Config) {
 		globalConf.HttpServerOptions.UseSSL = true
 		globalConf.EnableCustomDomains = true
+		globalConf.HashKeyFunction = ""
 		globalConf.HttpServerOptions.SSLCertificates = []string{serverCertID}
 		globalConf.HealthCheckEndpointName = "hello"
 	}
@@ -963,14 +966,14 @@ func TestKeyWithCertificateTLS(t *testing.T) {
 				t.Fatal("Should create key based on certificate")
 			}
 
-			_, key = ts.CreateSession(func(s *user.SessionState) {
+			_, secondKey := ts.CreateSession(func(s *user.SessionState) {
 				s.Certificate = clientCertID
 				s.AccessRights = map[string]user.AccessDefinition{"test": {
 					APIID: "test", Versions: []string{"v1"},
 				}}
 			})
 
-			if key != "" {
+			if secondKey != "" {
 				t.Fatal("Should not allow create key based on the same certificate")
 			}
 
@@ -978,6 +981,17 @@ func TestKeyWithCertificateTLS(t *testing.T) {
 
 			// Domain is not set, but we still pass it, it should still work
 			ts.Run(t, test.TestCase{Path: "/test1", Code: 200, Domain: "localhost", Client: client})
+
+			// key should also work without cert
+			header := map[string]string{
+				headers.Authorization: key,
+			}
+			client := &http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+				},
+			}
+			ts.Run(t, test.TestCase{Path: "/test1", Headers: header, Code: http.StatusOK, Domain: "localhost", Client: client})
 		})
 	})
 

--- a/gateway/mw_auth_key.go
+++ b/gateway/mw_auth_key.go
@@ -115,27 +115,11 @@ func (k *AuthKey) ProcessRequest(_ http.ResponseWriter, r *http.Request, _ inter
 	}
 
 	if authConfig.UseCertificate {
-		certID := session.OrgID + certHash
-		_, err := k.Gw.CertificateManager.GetRaw(certID)
-		if err != nil {
-			// Try alternative approach:
-			id, err := storage.TokenID(session.KeyID)
-			if err != nil {
-				log.Error(err)
-				return k.reportInvalidKey(key, r, MsgNonExistentCert, ErrAuthCertNotFound)
-			}
-
-			certID = session.OrgID + id
-			_, err = k.Gw.CertificateManager.GetRaw(certID)
-			if err != nil {
-				return k.reportInvalidKey(key, r, MsgNonExistentCert, ErrAuthCertNotFound)
-			}
-		}
-
-		if session.Certificate != certID {
-			return k.reportInvalidKey(key, r, MsgInvalidKey, ErrAuthKeyIsInvalid)
+		if _, err := k.Gw.CertificateManager.GetRaw(session.Certificate); err != nil {
+			return k.reportInvalidKey(key, r, MsgNonExistentCert, ErrAuthCertNotFound)
 		}
 	}
+
 	// Set session state on context, we will need it later
 	switch k.Spec.BaseIdentityProvidedBy {
 	case apidef.AuthToken, apidef.UnsetAuth:


### PR DESCRIPTION
I think it is not necessary to build cert id from scratch again. We already have that in session. The problems occur while rebuilding it.