### PR TITLE
[TT-1607] Fix SSE when web sockets are enabled

### DIFF
--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -1652,11 +1652,6 @@ func (p *ReverseProxy) IsUpgrade(req *http.Request) (bool, string) {
 		return false, ""
 	}
 
-	EncodeAccept := strings.ToLower(strings.TrimSpace(req.Header.Get(headers.Accept)))
-	if EncodeAccept == "text/event-stream" {
-		return true, ""
-	}
-
 	connection := strings.ToLower(strings.TrimSpace(req.Header.Get(headers.Connection)))
 	if connection != "upgrade" {
 		return false, ""

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -12,9 +12,12 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"text/template"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/jensneuse/graphql-go-tools/pkg/execution/datasource"
 	"github.com/jensneuse/graphql-go-tools/pkg/graphql"
@@ -1196,4 +1199,74 @@ func TestReverseProxyWebSocketCancelation(t *testing.T) {
 			close(triggerCancelCh)
 		}
 	}
+}
+
+func TestSSE(t *testing.T) {
+	// send and receive should be in order
+	var wg sync.WaitGroup
+
+	sseServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Connection", "keep-alive")
+
+		flusher, _ := w.(http.Flusher)
+		for i := 0; i < 5; i++ {
+			wg.Wait()
+			fmt.Fprintf(w, "data: %d\n", i)
+			flusher.Flush()
+			wg.Add(1)
+		}
+	}))
+
+	conf := func(globalConf *config.Config) {
+		globalConf.HttpServerOptions.EnableWebSockets = false
+	}
+	ts := StartTest(conf)
+	defer ts.Close()
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Proxy.TargetURL = sseServer.URL
+		spec.Proxy.ListenPath = "/"
+	})
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL, nil)
+	req.Header.Set("Accept", "text/event-stream")
+
+	client := http.Client{}
+
+	stream := func(enableWebSockets bool) {
+		globalConf := ts.Gw.GetConfig()
+		globalConf.HttpServerOptions.EnableWebSockets = enableWebSockets
+		ts.Gw.SetConfig(globalConf)
+
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+
+		reader := bufio.NewReader(res.Body)
+		defer res.Body.Close()
+
+		i := 0
+		for {
+			line, err := reader.ReadBytes('\n')
+			if err != nil && err != io.EOF {
+				t.Fatal(err)
+			}
+
+			if len(line) == 0 {
+				break
+			}
+
+			assert.Equal(t, fmt.Sprintf("data: %v\n", i), string(line))
+			i++
+			wg.Done()
+		}
+	}
+
+	t.Run("websockets disabled", func(t *testing.T) {
+		stream(false)
+	})
+
+	t.Run("websockets enabled", func(t *testing.T) {
+		stream(true)
+	})
 }


### PR DESCRIPTION
This PR fixes the SSE when `enable_websockets` is `true`. The problem is inside [IsUpgrade](https://github.com/TykTechnologies/tyk/blob/8ba3c49443a1d3dc2568c425a824fb7e3cb625b7/gateway/reverse_proxy.go#L1650) function, when websockets are enabled that function returns `true` and it tries to behave the response as upgrade response and it enters [handleUpgradeResponse](https://github.com/TykTechnologies/tyk/blob/master/gateway/reverse_proxy.go#L1226). If the reason of adding `"text/event-stream"` check inside `IsUpgrade` function is to consume incoming data immediately, I believe it does that [here](https://github.com/TykTechnologies/tyk/blob/master/gateway/reverse_proxy.go#L1356).

The problem was happened because of missing test, so this PR adds a test including websockets is enabled/disabled cases.

Fixes https://github.com/TykTechnologies/tyk/issues/3214
Fixes https://github.com/TykTechnologies/tyk/issues/3256