### PR TITLE
[TT-3807] Omit declared but empty slice, map and pointer fields from OAS api

### DIFF
--- a/apidef/oas/authentication.go
+++ b/apidef/oas/authentication.go
@@ -1,8 +1,6 @@
 package oas
 
 import (
-	"reflect"
-
 	"github.com/lonelycode/osin"
 
 	"github.com/TykTechnologies/tyk/apidef"
@@ -11,10 +9,10 @@ import (
 type Authentication struct {
 	// Enabled makes the API protected when one of the authentication modes is enabled.
 	// Old API Definition: `!use_keyless`
-	Enabled                bool                `bson:"enabled" json:"enabled"` // required
+	Enabled bool `bson:"enabled" json:"enabled"` // required
 	// StripAuthorizationData ensures that any security tokens used for accessing APIs are stripped and not leaked to the upstream.
 	// Old API Definition: `strip_auth_data`
-	StripAuthorizationData bool                `bson:"stripAuthorizationData,omitempty" json:"stripAuthorizationData,omitempty"`
+	StripAuthorizationData bool `bson:"stripAuthorizationData,omitempty" json:"stripAuthorizationData,omitempty"`
 	// BaseIdentityProvider enables multi authentication mechanism and provides the session object that determines rate limits, ACL rules and quotas.
 	// It should be set to one of the following:
 	// - `auth_token`
@@ -25,18 +23,18 @@ type Authentication struct {
 	// - `oauth_key`
 	//
 	// Old API Definition: `base_identity_provided_by`
-	BaseIdentityProvider   apidef.AuthTypeEnum `bson:"baseIdentityProvider,omitempty" json:"baseIdentityProvider,omitempty"`
+	BaseIdentityProvider apidef.AuthTypeEnum `bson:"baseIdentityProvider,omitempty" json:"baseIdentityProvider,omitempty"`
 	// Token contains the configurations related to standard token based authentication mode.
 	// Old API Definition: `auth_configs["authToken"]`
-	Token                  *Token              `bson:"token,omitempty" json:"token,omitempty"`
-	JWT                    *JWT                `bson:"jwt,omitempty" json:"jwt,omitempty"`
+	Token *Token `bson:"token,omitempty" json:"token,omitempty"`
+	JWT   *JWT   `bson:"jwt,omitempty" json:"jwt,omitempty"`
 	// Basic contains the configurations related to basic authentication mode.
 	// Old API Definition: `auth_configs["basic"]`
-	Basic                  *Basic              `bson:"basic,omitempty" json:"basic,omitempty"`
-	OAuth                  *OAuth              `bson:"oauth,omitempty" json:"oauth,omitempty"`
+	Basic *Basic `bson:"basic,omitempty" json:"basic,omitempty"`
+	OAuth *OAuth `bson:"oauth,omitempty" json:"oauth,omitempty"`
 	// HMAC contains the configurations related to HMAC authentication mode.
 	// Old API Definition: `auth_configs["hmac"]`
-	HMAC                   *HMAC               `bson:"hmac,omitempty" json:"hmac,omitempty"`
+	HMAC *HMAC `bson:"hmac,omitempty" json:"hmac,omitempty"`
 }
 
 func (a *Authentication) Fill(api apidef.APIDefinition) {
@@ -56,7 +54,7 @@ func (a *Authentication) Fill(api apidef.APIDefinition) {
 		a.Token.Fill(api.UseStandardAuth, authToken)
 	}
 
-	if reflect.DeepEqual(a.Token, &Token{}) {
+	if ShouldOmit(a.Token) {
 		a.Token = nil
 	}
 
@@ -68,7 +66,7 @@ func (a *Authentication) Fill(api apidef.APIDefinition) {
 		a.JWT.Fill(api)
 	}
 
-	if reflect.DeepEqual(a.JWT, &JWT{}) {
+	if ShouldOmit(a.JWT) {
 		a.JWT = nil
 	}
 
@@ -80,7 +78,7 @@ func (a *Authentication) Fill(api apidef.APIDefinition) {
 		a.Basic.Fill(api)
 	}
 
-	if reflect.DeepEqual(a.Basic, &Basic{}) {
+	if ShouldOmit(a.Basic) {
 		a.Basic = nil
 	}
 
@@ -92,7 +90,7 @@ func (a *Authentication) Fill(api apidef.APIDefinition) {
 		a.OAuth.Fill(api)
 	}
 
-	if reflect.DeepEqual(a.OAuth, &OAuth{}) {
+	if ShouldOmit(a.OAuth) {
 		a.OAuth = nil
 	}
 
@@ -104,7 +102,7 @@ func (a *Authentication) Fill(api apidef.APIDefinition) {
 		a.HMAC.Fill(api)
 	}
 
-	if reflect.DeepEqual(a.HMAC, &HMAC{}) {
+	if ShouldOmit(a.HMAC) {
 		a.HMAC = nil
 	}
 }
@@ -138,14 +136,14 @@ func (a *Authentication) ExtractTo(api *apidef.APIDefinition) {
 type Token struct {
 	// Enabled enables the token based authentication mode.
 	// Old API Definition: `api_id`
-	Enabled                 bool `bson:"enabled" json:"enabled"` // required
-	AuthSources             `bson:",inline" json:",inline"`
+	Enabled     bool `bson:"enabled" json:"enabled"` // required
+	AuthSources `bson:",inline" json:",inline"`
 	// EnableClientCertificate allows to create dynamic keys based on certificates.
 	// Old API Definition: `auth_configs["authToken"].use_certificate`
-	EnableClientCertificate bool       `bson:"enableClientCertificate,omitempty" json:"enableClientCertificate,omitempty"`
+	EnableClientCertificate bool `bson:"enableClientCertificate,omitempty" json:"enableClientCertificate,omitempty"`
 	//
 	// Old API Definition:
-	Signature               *Signature `bson:"signatureValidation,omitempty" json:"signatureValidation,omitempty"`
+	Signature *Signature `bson:"signatureValidation,omitempty" json:"signatureValidation,omitempty"`
 }
 
 func (t *Token) Fill(enabled bool, authToken apidef.AuthConfig) {
@@ -161,7 +159,7 @@ func (t *Token) Fill(enabled bool, authToken apidef.AuthConfig) {
 	}
 
 	t.Signature.Fill(authToken)
-	if (*t.Signature == Signature{}) {
+	if ShouldOmit(t.Signature) {
 		t.Signature = nil
 	}
 }
@@ -191,10 +189,10 @@ type AuthSources struct {
 	Header HeaderAuthSource `bson:"header" json:"header"` // required
 	// Cookie contains configurations of the cookie auth source.
 	// Old API Definition: `api_id`
-	Cookie *AuthSource      `bson:"cookie,omitempty" json:"cookie,omitempty"`
+	Cookie *AuthSource `bson:"cookie,omitempty" json:"cookie,omitempty"`
 	// Param contains configurations of the param auth source.
 	// Old API Definition: `api_id`
-	Param  *AuthSource      `bson:"param,omitempty" json:"param,omitempty"`
+	Param *AuthSource `bson:"param,omitempty" json:"param,omitempty"`
 }
 
 func (as *AuthSources) Fill(authConfig apidef.AuthConfig) {
@@ -207,7 +205,7 @@ func (as *AuthSources) Fill(authConfig apidef.AuthConfig) {
 	}
 
 	as.Param.Fill(authConfig.UseParam, authConfig.ParamName)
-	if (*as.Param == AuthSource{}) {
+	if ShouldOmit(as.Param) {
 		as.Param = nil
 	}
 
@@ -217,7 +215,7 @@ func (as *AuthSources) Fill(authConfig apidef.AuthConfig) {
 	}
 
 	as.Cookie.Fill(authConfig.UseCookie, authConfig.CookieName)
-	if (*as.Cookie == AuthSource{}) {
+	if ShouldOmit(as.Cookie) {
 		as.Cookie = nil
 	}
 }
@@ -246,10 +244,10 @@ type HeaderAuthSource struct {
 type AuthSource struct {
 	// Enabled enables the auth source.
 	// Old API Definition: `auth_configs[X].use_param/use_cookie`
-	Enabled bool   `bson:"enabled" json:"enabled"` // required
+	Enabled bool `bson:"enabled" json:"enabled"` // required
 	// Name is the name of the auth source.
 	// Old API Definition: `auth_configs[X].param_name/cookie_name`
-	Name    string `bson:"name,omitempty" json:"name,omitempty"`
+	Name string `bson:"name,omitempty" json:"name,omitempty"`
 }
 
 func (as *AuthSource) Fill(enabled bool, name string) {
@@ -358,14 +356,14 @@ func (j *JWT) ExtractTo(api *apidef.APIDefinition) {
 type Basic struct {
 	// Enabled enables the basic authentication mode.
 	// Old API Definition: `use_basic_auth`
-	Enabled                    bool `bson:"enabled" json:"enabled"` // required
-	AuthSources                `bson:",inline" json:",inline"`
+	Enabled     bool `bson:"enabled" json:"enabled"` // required
+	AuthSources `bson:",inline" json:",inline"`
 	// DisableCaching disables the caching of basic authentication key.
 	// Old API Definition: `basic_auth.disable_caching`
-	DisableCaching             bool                        `bson:"disableCaching,omitempty" json:"disableCaching,omitempty"`
+	DisableCaching bool `bson:"disableCaching,omitempty" json:"disableCaching,omitempty"`
 	// CacheTTL is the TTL for a cached basic authentication key in seconds.
 	// Old API Definition: `basic_auth.cache_ttl`
-	CacheTTL                   int                         `bson:"cacheTTL,omitempty" json:"cacheTTL,omitempty"`
+	CacheTTL int `bson:"cacheTTL,omitempty" json:"cacheTTL,omitempty"`
 	// ExtractCredentialsFromBody helps to extract username and password from body. In some cases, like dealing with SOAP,
 	// user credentials can be passed via request body.
 	ExtractCredentialsFromBody *ExtractCredentialsFromBody `bson:"extractCredentialsFromBody,omitempty" json:"extractCredentialsFromBody,omitempty"`
@@ -385,7 +383,7 @@ func (b *Basic) Fill(api apidef.APIDefinition) {
 
 	b.ExtractCredentialsFromBody.Fill(api)
 
-	if reflect.DeepEqual(b.ExtractCredentialsFromBody, &ExtractCredentialsFromBody{}) {
+	if ShouldOmit(b.ExtractCredentialsFromBody) {
 		b.ExtractCredentialsFromBody = nil
 	}
 }
@@ -413,10 +411,10 @@ func (b *Basic) ExtractTo(api *apidef.APIDefinition) {
 type ExtractCredentialsFromBody struct {
 	// Enabled enables extracting credentials from body.
 	// Old API Definition: `basic_auth.extract_from_body`
-	Enabled        bool   `bson:"enabled" json:"enabled"` // required
+	Enabled bool `bson:"enabled" json:"enabled"` // required
 	// UserRegexp is the regex for username e.g. `<User>(.*)</User>`.
 	// Old API Definition: `basic_auth.userRegexp`
-	UserRegexp     string `bson:"userRegexp,omitempty" json:"userRegexp,omitempty"`
+	UserRegexp string `bson:"userRegexp,omitempty" json:"userRegexp,omitempty"`
 	// PasswordRegexp is the regex for password e.g. `<Password>(.*)</Password>`.
 	// Old API Definition: `basic_auth.passwordRegexp`
 	PasswordRegexp string `bson:"passwordRegexp,omitempty" json:"passwordRegexp,omitempty"`
@@ -458,7 +456,7 @@ func (o *OAuth) Fill(api apidef.APIDefinition) {
 
 	o.Notifications.Fill(api.NotificationsDetails)
 
-	if reflect.DeepEqual(o.Notifications, &Notifications{}) {
+	if ShouldOmit(o.Notifications) {
 		o.Notifications = nil
 	}
 }
@@ -502,8 +500,8 @@ func (n *Notifications) ExtractTo(nm *apidef.NotificationsManager) {
 type HMAC struct {
 	// Enabled enables the HMAC authentication mode.
 	// Old API Definition: `enable_signature_checking`
-	Enabled           bool `bson:"enabled" json:"enabled"` // required
-	AuthSources       `bson:",inline" json:",inline"`
+	Enabled     bool `bson:"enabled" json:"enabled"` // required
+	AuthSources `bson:",inline" json:",inline"`
 	// AllowedAlgorithms is the array of HMAC algorithms which are allowed. Tyk supports the following HMAC algorithms:
 	// - `hmac-sha1`
 	// - `hmac-sha256`
@@ -516,7 +514,7 @@ type HMAC struct {
 	// AllowedClockSkew is the amount of milliseconds that will be tolerated for clock skew. It is used against replay attacks.
 	// The default value is `0`, which deactivates clock skew checks.
 	// Old API Definition: `hmac_allowed_clock_skew`
-	AllowedClockSkew  float64  `bson:"allowedClockSkew,omitempty" json:"allowedClockSkew,omitempty"`
+	AllowedClockSkew float64 `bson:"allowedClockSkew,omitempty" json:"allowedClockSkew,omitempty"`
 }
 
 func (h *HMAC) Fill(api apidef.APIDefinition) {

--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -1,8 +1,6 @@
 package oas
 
 import (
-	"reflect"
-
 	"github.com/TykTechnologies/tyk/apidef"
 )
 
@@ -17,7 +15,7 @@ func (m *Middleware) Fill(api apidef.APIDefinition) {
 	}
 
 	m.Global.Fill(api)
-	if reflect.DeepEqual(m.Global, &Global{}) {
+	if ShouldOmit(m.Global) {
 		m.Global = nil
 	}
 }
@@ -29,7 +27,7 @@ func (m *Middleware) ExtractTo(api *apidef.APIDefinition) {
 }
 
 type Global struct {
-	CORS  *CORS  `bson:"cors,omitempty" json:"cors,omitempty"`
+	CORS *CORS `bson:"cors,omitempty" json:"cors,omitempty"`
 	// Cache contains the configurations related to caching.
 	// Old API Definition: `cache_options`
 	Cache *Cache `bson:"cache,omitempty" json:"cache,omitempty"`
@@ -42,7 +40,7 @@ func (g *Global) Fill(api apidef.APIDefinition) {
 	}
 
 	g.CORS.Fill(api.CORS)
-	if reflect.DeepEqual(g.CORS, &CORS{}) {
+	if ShouldOmit(g.CORS) {
 		g.CORS = nil
 	}
 
@@ -52,7 +50,7 @@ func (g *Global) Fill(api apidef.APIDefinition) {
 	}
 
 	g.Cache.Fill(api.CacheOptions)
-	if reflect.DeepEqual(g.Cache, &Cache{}) {
+	if ShouldOmit(g.Cache) {
 		g.Cache = nil
 	}
 }
@@ -107,26 +105,26 @@ type Cache struct {
 	// Enabled turns global cache middleware on or off. It is still possible to enable caching on a per-path basis
 	// by explicitly setting the endpoint cache middleware.
 	// Old API Definition: `cache_options.enable_cache`
-	Enabled                    bool     `bson:"enabled" json:"enabled"` // required
+	Enabled bool `bson:"enabled" json:"enabled"` // required
 	// Timeout is the TTL for a cached object in seconds.
 	// Old API Definition: `cache_options.cache_timeout`
-	Timeout                    int64    `bson:"timeout,omitempty" json:"timeout,omitempty"`
+	Timeout int64 `bson:"timeout,omitempty" json:"timeout,omitempty"`
 	// CacheAllSafeRequests caches responses to (`GET`, `HEAD`, `OPTIONS`) requests overrides per-path cache settings in versions,
 	// applies across versions.
 	// Old API Definition: `cache_options.cache_all_safe_requests`
-	CacheAllSafeRequests       bool     `bson:"cacheAllSafeRequests,omitempty" json:"cacheAllSafeRequests,omitempty"`
+	CacheAllSafeRequests bool `bson:"cacheAllSafeRequests,omitempty" json:"cacheAllSafeRequests,omitempty"`
 	// CacheResponseCodes is an array of response codes which are safe to cache e.g. `404`.
 	// Old API Definition: `cache_options.cache_response_codes`
-	CacheResponseCodes         []int    `bson:"cacheResponseCodes,omitempty" json:"cacheResponseCodes,omitempty"`
+	CacheResponseCodes []int `bson:"cacheResponseCodes,omitempty" json:"cacheResponseCodes,omitempty"`
 	// CacheByHeaders allows header values to be used as part of the cache key.
 	// Old API Definition: `cache_options.cache_by_headers`
-	CacheByHeaders             []string `bson:"cacheByHeaders,omitempty" json:"cacheByHeaders,omitempty"`
+	CacheByHeaders []string `bson:"cacheByHeaders,omitempty" json:"cacheByHeaders,omitempty"`
 	// EnableUpstreamCacheControl instructs Tyk Cache to respect upstream cache control headers.
 	// Old API Definition: `cache_options.enable_upstream_cache_control`
-	EnableUpstreamCacheControl bool     `bson:"enableUpstreamCacheControl,omitempty" json:"enableUpstreamCacheControl,omitempty"`
+	EnableUpstreamCacheControl bool `bson:"enableUpstreamCacheControl,omitempty" json:"enableUpstreamCacheControl,omitempty"`
 	// ControlTTLHeaderName is the response header which tells Tyk how long it is safe to cache the response for.
 	// Old API Definition: `cache_options.cache_control_ttl_header`
-	ControlTTLHeaderName       string   `bson:"controlTTLHeaderName,omitempty" json:"controlTTLHeaderName,omitempty"`
+	ControlTTLHeaderName string `bson:"controlTTLHeaderName,omitempty" json:"controlTTLHeaderName,omitempty"`
 }
 
 func (c *Cache) Fill(cache apidef.CacheOptions) {

--- a/apidef/oas/oasutil.go
+++ b/apidef/oas/oasutil.go
@@ -1,0 +1,56 @@
+package oas
+
+import (
+	"math"
+	"reflect"
+)
+
+// ShouldOmit checks whether a field should be set to empty and omitted from OAS JSON.
+func ShouldOmit(i interface{}) bool {
+	return IsZero(reflect.ValueOf(i))
+}
+
+// IsZero is a customized implementation of reflect.Value.IsZero. The built-in function accepts slice, map and pointer fields
+// having 0 length as not zero. In OAS, we would like them to be counted as empty so we separated slice, map and pointer to
+// different cases.
+func IsZero(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return math.Float64bits(v.Float()) == 0
+	case reflect.Complex64, reflect.Complex128:
+		c := v.Complex()
+		return math.Float64bits(real(c)) == 0 && math.Float64bits(imag(c)) == 0
+	case reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			if !IsZero(v.Index(i)) {
+				return false
+			}
+		}
+		return true
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.UnsafePointer:
+		return v.IsNil()
+	case reflect.Ptr:
+		return v.IsNil() || IsZero(v.Elem())
+	case reflect.Slice, reflect.Map:
+		return v.Len() == 0
+	case reflect.String:
+		return v.Len() == 0
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			if !IsZero(v.Field(i)) {
+				return false
+			}
+		}
+		return true
+	default:
+		// This should never happens, but will act as a safeguard for
+		// later, as a default value doesn't makes sense here.
+		panic(&reflect.ValueError{"reflect.Value.IsZero", v.Kind()})
+	}
+}

--- a/apidef/oas/oasutil.go
+++ b/apidef/oas/oasutil.go
@@ -51,6 +51,6 @@ func IsZero(v reflect.Value) bool {
 	default:
 		// This should never happens, but will act as a safeguard for
 		// later, as a default value doesn't makes sense here.
-		panic(&reflect.ValueError{"reflect.Value.IsZero", v.Kind()})
+		panic(&reflect.ValueError{Method: "oas.IsZero", Kind: v.Kind()})
 	}
 }

--- a/apidef/oas/oasutil_test.go
+++ b/apidef/oas/oasutil_test.go
@@ -1,0 +1,34 @@
+package oas
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testStruct struct {
+	Bool      bool
+	Array     []string
+	Map       map[string]string
+	SubStruct *subStruct
+}
+
+type subStruct struct {
+	SubMap map[string]string
+}
+
+func TestShouldOmit(t *testing.T) {
+	v1 := testStruct{}
+	v2 := testStruct{Array: make([]string, 0), Map: make(map[string]string), SubStruct: &subStruct{}}
+	v3 := testStruct{Array: make([]string, 0), Map: make(map[string]string), SubStruct: &subStruct{SubMap: make(map[string]string)}}
+	v4 := testStruct{Bool: true}
+	v5 := testStruct{Array: []string{"a"}}
+	v6 := testStruct{Map: map[string]string{"a": "b"}}
+
+	assert.True(t, ShouldOmit(v1))
+	assert.True(t, ShouldOmit(v2))
+	assert.True(t, ShouldOmit(v3))
+	assert.False(t, ShouldOmit(v4))
+	assert.False(t, ShouldOmit(v5))
+	assert.False(t, ShouldOmit(v6))
+}

--- a/apidef/oas/root.go
+++ b/apidef/oas/root.go
@@ -8,11 +8,11 @@ const ExtensionTykAPIGateway = "x-tyk-api-gateway"
 
 type XTykAPIGateway struct {
 	// Info contains the main metadata about the API definition.
-	Info     Info     `bson:"info" json:"info"`         // required
+	Info Info `bson:"info" json:"info"` // required
 	// Upstream contains the configurations related to the upstream.
 	Upstream Upstream `bson:"upstream" json:"upstream"` // required
 	// Server contains the configurations related to the server.
-	Server     Server      `bson:"server" json:"server"` // required
+	Server Server `bson:"server" json:"server"` // required
 	// Middleware contains the configurations related to the proxy middleware.
 	Middleware *Middleware `bson:"middleware,omitempty" json:"middleware,omitempty"`
 }
@@ -27,7 +27,7 @@ func (x *XTykAPIGateway) Fill(api apidef.APIDefinition) {
 	}
 
 	x.Middleware.Fill(api)
-	if (*x.Middleware == Middleware{}) {
+	if ShouldOmit(x.Middleware) {
 		x.Middleware = nil
 	}
 }
@@ -55,13 +55,13 @@ type Info struct {
 	ID string `bson:"id" json:"id,omitempty"`
 	// DBID is the unique database ID of the API.
 	// Old API Definition: `id`
-	DBID  apidef.ObjectId `bson:"dbID" json:"dbID,omitempty"`
+	DBID apidef.ObjectId `bson:"dbID" json:"dbID,omitempty"`
 	// OrgID is the ID of the organisation which the API belongs to.
 	// Old API Definition: `org_id`
-	OrgID string          `bson:"orgID" json:"orgID,omitempty"`
+	OrgID string `bson:"orgID" json:"orgID,omitempty"`
 	// Name is the name of the API.
 	// Old API Definition: `name`
-	Name  string          `bson:"name" json:"name"` // required
+	Name string `bson:"name" json:"name"` // required
 	// State contains the configurations related to the state of the API.
 	State State `bson:"state" json:"state"` // required
 }
@@ -85,7 +85,7 @@ func (i *Info) ExtractTo(api *apidef.APIDefinition) {
 type State struct {
 	// Active enables the API.
 	// Old API Definition: `active`
-	Active   bool `bson:"active" json:"active"` // required
+	Active bool `bson:"active" json:"active"` // required
 	// Internal makes the API accessible only internally.
 	// Old API Definition: `internal`
 	Internal bool `bson:"internal,omitempty" json:"internal,omitempty"`

--- a/apidef/oas/server.go
+++ b/apidef/oas/server.go
@@ -5,10 +5,10 @@ import "github.com/TykTechnologies/tyk/apidef"
 type Server struct {
 	// ListenPath represents the path to listen on. Any requests coming into the host, on the port that Tyk is configured to run on,
 	// that match this path will have the rules defined in the API Definition applied.
-	ListenPath     ListenPath      `bson:"listenPath" json:"listenPath"` // required
+	ListenPath ListenPath `bson:"listenPath" json:"listenPath"` // required
 	// Slug is the Tyk Cloud equivalent of listen path.
 	// Old API Definition: `slug`
-	Slug           string          `bson:"slug,omitempty" json:"slug,omitempty"`
+	Slug string `bson:"slug,omitempty" json:"slug,omitempty"`
 	// Authentication contains the configurations related to authentication to the API.
 	Authentication *Authentication `bson:"authentication,omitempty" json:"authentication,omitempty"`
 }
@@ -22,7 +22,7 @@ func (s *Server) Fill(api apidef.APIDefinition) {
 	}
 
 	s.Authentication.Fill(api)
-	if (*s.Authentication == Authentication{}) {
+	if ShouldOmit(s.Authentication) {
 		s.Authentication = nil
 	}
 }
@@ -46,7 +46,7 @@ type ListenPath struct {
 	// is the listen path. The `httpbin` listen path which is used to identify the API loaded in Tyk is removed,
 	// and the outbound request would be `http://httpbin.org/get`.
 	// Old API Definition: `proxy.strip_listen_path`
-	Strip bool   `bson:"strip,omitempty" json:"strip,omitempty"`
+	Strip bool `bson:"strip,omitempty" json:"strip,omitempty"`
 }
 
 func (lp *ListenPath) Fill(api apidef.APIDefinition) {

--- a/apidef/oas/upstream.go
+++ b/apidef/oas/upstream.go
@@ -5,12 +5,12 @@ import "github.com/TykTechnologies/tyk/apidef"
 type Upstream struct {
 	// URL defines the target URL that the request should be proxied to.
 	// Old API Definition: `proxy.target_url`
-	URL              string            `bson:"url" json:"url"` // required
+	URL string `bson:"url" json:"url"` // required
 	// ServiceDiscovery contains the configuration related to Service Discovery.
 	// Old API Definition: `proxy.service_discovery`
 	ServiceDiscovery *ServiceDiscovery `bson:"serviceDiscovery,omitempty" json:"serviceDiscovery,omitempty"`
 	// Test contains the configuration related to uptime tests.
-	Test             *Test             `bson:"test,omitempty" json:"test,omitempty"`
+	Test *Test `bson:"test,omitempty" json:"test,omitempty"`
 }
 
 func (u *Upstream) Fill(api apidef.APIDefinition) {
@@ -21,7 +21,7 @@ func (u *Upstream) Fill(api apidef.APIDefinition) {
 	}
 
 	u.ServiceDiscovery.Fill(api.Proxy.ServiceDiscovery)
-	if (*u.ServiceDiscovery == ServiceDiscovery{}) {
+	if ShouldOmit(u.ServiceDiscovery) {
 		u.ServiceDiscovery = nil
 	}
 }
@@ -37,10 +37,10 @@ func (u *Upstream) ExtractTo(api *apidef.APIDefinition) {
 type ServiceDiscovery struct {
 	// Enabled enables Service Discovery.
 	// Old API Definition: `service_discovery.use_discovery_service`
-	Enabled             bool   `bson:"enabled" json:"enabled"` // required
+	Enabled bool `bson:"enabled" json:"enabled"` // required
 	// QueryEndpoint is the endpoint to call, this would usually be Consul, etcd or Eureka K/V store.
 	// Old API Definition: `service_discovery.query_endpoint`
-	QueryEndpoint       string `bson:"queryEndpoint,omitempty" json:"queryEndpoint,omitempty"`
+	QueryEndpoint string `bson:"queryEndpoint,omitempty" json:"queryEndpoint,omitempty"`
 	// DataPath is the namespace of the data path - where exactly in your service response the namespace can be found.
 	// For example, if your service responds with:
 	// ```
@@ -57,7 +57,7 @@ type ServiceDiscovery struct {
 	//
 	// then your namespace would be `node.value`.
 	// Old API Definition: `service_discovery.data_path`
-	DataPath            string `bson:"dataPath,omitempty" json:"dataPath,omitempty"`
+	DataPath string `bson:"dataPath,omitempty" json:"dataPath,omitempty"`
 	// UseNestedQuery enables using a combination of `dataPath` and `parentDataPath`.
 	// It is necessary when the data lives within this string-encoded JSON object.
 	// ```
@@ -72,36 +72,36 @@ type ServiceDiscovery struct {
 	// }
 	//```
 	// Old API Definition: `service_discovery.use_nested_query`
-	UseNestedQuery      bool   `bson:"useNestedQuery,omitempty" json:"useNestedQuery,omitempty"`
+	UseNestedQuery bool `bson:"useNestedQuery,omitempty" json:"useNestedQuery,omitempty"`
 	// ParentDataPath is the namespace of the where to find the nested value, if `useNestedQuery` is `true`.
 	// In the above example, it would be `node.value`. You would then change the `dataPath` setting to be `hostname`,
 	// since this is where the host name data resides in the JSON string.
 	// Tyk automatically assumes that `dataPath` in this case is in a string-encoded JSON object and will try to deserialize it.
 	// Old API Definition: `service_discovery.parent_data_path`
-	ParentDataPath      string `bson:"parentDataPath,omitempty" json:"parentDataPath,omitempty"`
+	ParentDataPath string `bson:"parentDataPath,omitempty" json:"parentDataPath,omitempty"`
 	// PortDataPath is the port of the data path. In the above nested example, we can see that there is a separate `port` value
 	// for the service in the nested JSON. In this case, you can set the `portDataPath` value and Tyk will treat `dataPath`
 	// as the hostname and zip them together (this assumes that the hostname element does not end in a slash or resource identifier
 	// such as `/widgets/`). In the above example, the `portDataPath` would be `port`.
 	// Old API Definition: `service_discovery.port_data_path`
-	PortDataPath        string `bson:"portDataPath,omitempty" json:"portDataPath,omitempty"`
+	PortDataPath string `bson:"portDataPath,omitempty" json:"portDataPath,omitempty"`
 	// UseTargetList should be set to `true`, if you are using load balancing. Tyk will treat the data path as a list and
 	// inject it into the target list of your API Definition.
 	// Old API Definition: `service_discovery.use_target_list`
-	UseTargetList       bool   `bson:"useTargetList,omitempty" json:"useTargetList,omitempty"`
+	UseTargetList bool `bson:"useTargetList,omitempty" json:"useTargetList,omitempty"`
 	// CacheTimeout is the timeout of a cache value when a new data is loaded from a discovery service.
 	// Setting it too low will cause Tyk to call the SD service too often, setting it too high could mean that
 	// failures are not recovered from quickly enough.
 	// Old API Definition: `service_discovery.cache_timeout`
-	CacheTimeout        int64  `bson:"cacheTimeout,omitempty" json:"cacheTimeout,omitempty"`
+	CacheTimeout int64 `bson:"cacheTimeout,omitempty" json:"cacheTimeout,omitempty"`
 	// TargetPath is to set a target path to append to the discovered endpoint, since many SD services
 	// only provide host and port data. It is important to be able to target a specific resource on that host.
 	// Setting this value will enable that.
 	// Old API Definition: `service_discovery.target_path`
-	TargetPath          string `bson:"targetPath,omitempty" json:"targetPath,omitempty"`
+	TargetPath string `bson:"targetPath,omitempty" json:"targetPath,omitempty"`
 	// EndpointReturnsList is set `true` when the response type is a list instead of an object.
 	// Old API Definition: `service_discovery.endpoint_returns_list`
-	EndpointReturnsList bool   `bson:"endpointReturnsList,omitempty" json:"endpointReturnsList,omitempty"`
+	EndpointReturnsList bool `bson:"endpointReturnsList,omitempty" json:"endpointReturnsList,omitempty"`
 }
 
 func (sd *ServiceDiscovery) Fill(serviceDiscovery apidef.ServiceDiscoveryConfiguration) {
@@ -142,7 +142,7 @@ func (t *Test) Fill(uptimeTests apidef.UptimeTests) {
 	}
 
 	t.ServiceDiscovery.Fill(uptimeTests.Config.ServiceDiscovery)
-	if (*t.ServiceDiscovery == ServiceDiscovery{}) {
+	if ShouldOmit(t.ServiceDiscovery) {
 		t.ServiceDiscovery = nil
 	}
 }


### PR DESCRIPTION
This PR fixes omitting of empty but declared slice, map and pointer cases in OAS structure. (`[]`, `{}`)

`json:"something, omitempty"` doesn't help in case of maps, arrays and objects because FE sends them declared but as empty. We would like to remove them as they don't have any value inside. We set them `nil` by manually checking with `shouldOmit` in the code.

I customized the built-int `reflect.Value.IsZero` as `IsZero`. The built-in function accepts slice, map and pointer fields having 0 length as not zero. In OAS, we would like them to be counted as empty so I separated slice, map and pointer to different cases.