### PR TITLE
TT-3361 - Disable enable_health_checks for release-4

### DIFF
--- a/images/hybrid/tyk/tyk.conf.example
+++ b/images/hybrid/tyk/tyk.conf.example
@@ -27,7 +27,7 @@
     "ignored_ips": []
   },
   "health_check": {
-    "enable_health_checks": true,
+    "enable_health_checks": false,
     "health_check_value_timeouts": 60
   },
   "optimisations_use_async_session_write": true,

--- a/install/data/tyk.standalone.conf
+++ b/install/data/tyk.standalone.conf
@@ -27,7 +27,7 @@
     "ignored_ips": []
   },
   "health_check": {
-    "enable_health_checks": true,
+    "enable_health_checks": false,
     "health_check_value_timeouts": 60
   },
   "optimisations_use_async_session_write": true,


### PR DESCRIPTION
## Description
enable_health_checks is a deprecated feature that causes performance issues.  This PR disables the setting.

## Related Issue
https://tyktech.atlassian.net/browse/TT-3361

## Motivation and Context
This disables the deprecated health_checks feature because of performance problems.

## How This Has Been Tested
Only supplied/default configuration files have been changed and the perf benefits of disabling it are easy to measure.

## Screenshots (if appropriate)
N/A

## Types of changes
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
- [X ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [ ] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
