### PR TITLE
[TT-3913] Implement basic plugin's oas conversions

### DIFF
--- a/apidef/api_definition_test.go
+++ b/apidef/api_definition_test.go
@@ -1,8 +1,9 @@
 package apidef
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	schema "github.com/xeipuuv/gojsonschema"
 )

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -160,6 +160,7 @@ type EndpointMethodMeta struct {
 }
 
 type EndPointMeta struct {
+	Disabled      bool                          `bson:"disabled" json:"disabled"`
 	Path          string                        `bson:"path" json:"path"`
 	IgnoreCase    bool                          `bson:"ignore_case" json:"ignore_case"`
 	MethodActions map[string]EndpointMethodMeta `bson:"method_actions" json:"method_actions"`

--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -1,12 +1,17 @@
 package oas
 
 import (
+	"net/http"
+	"sort"
+	"strings"
+
 	"github.com/TykTechnologies/tyk/apidef"
 )
 
 type Middleware struct {
 	// Global contains the configurations related to the global middleware.
 	Global *Global `bson:"global,omitempty" json:"global,omitempty"`
+	Paths  Paths   `bson:"paths,omitempty" json:"paths,omitempty"`
 }
 
 func (m *Middleware) Fill(api apidef.APIDefinition) {
@@ -18,11 +23,31 @@ func (m *Middleware) Fill(api apidef.APIDefinition) {
 	if ShouldOmit(m.Global) {
 		m.Global = nil
 	}
+
+	if m.Paths == nil {
+		m.Paths = make(Paths)
+	}
+
+	m.Paths.Fill(api.VersionData.Versions["Default"].ExtendedPaths)
+	if ShouldOmit(m.Paths) {
+		m.Paths = nil
+	}
 }
 
 func (m *Middleware) ExtractTo(api *apidef.APIDefinition) {
 	if m.Global != nil {
 		m.Global.ExtractTo(api)
+	}
+
+	if m.Paths != nil {
+		var ep apidef.ExtendedPathsSet
+		m.Paths.ExtractTo(&ep)
+		defaultVersion := apidef.VersionInfo{UseExtendedPaths: true, ExtendedPaths: ep}
+		versions := map[string]apidef.VersionInfo{
+			"Default": defaultVersion,
+		}
+
+		api.VersionData.Versions = versions
 	}
 }
 
@@ -145,4 +170,262 @@ func (c *Cache) ExtractTo(cache *apidef.CacheOptions) {
 	cache.CacheByHeaders = c.CacheByHeaders
 	cache.EnableUpstreamCacheControl = c.EnableUpstreamCacheControl
 	cache.CacheControlTTLHeader = c.ControlTTLHeaderName
+}
+
+type Paths map[string]*Path
+
+func (ps Paths) Fill(ep apidef.ExtendedPathsSet) {
+	ps.fillAllowance(ep, allow)
+	ps.fillAllowance(ep, block)
+	ps.fillAllowance(ep, ignoreAuthentication)
+}
+
+func (ps Paths) fillAllowance(ep apidef.ExtendedPathsSet, typ AllowanceType) {
+	endpointMetas := ep.WhiteList
+
+	switch typ {
+	case block:
+		endpointMetas = ep.BlackList
+	case ignoreAuthentication:
+		endpointMetas = ep.Ignored
+	}
+
+	for _, em := range endpointMetas {
+		for method := range em.MethodActions {
+			if _, ok := ps[em.Path]; !ok {
+				ps[em.Path] = &Path{}
+			}
+
+			plugins := ps[em.Path].getMethod(method)
+			plugins.fillAllowance(em, typ)
+		}
+	}
+}
+
+func (ps Paths) ExtractTo(ep *apidef.ExtendedPathsSet) {
+	var paths []string
+	for path := range ps {
+		paths = append(paths, path)
+	}
+
+	sort.Strings(paths)
+
+	for _, path := range paths {
+		ps[path].ExtractTo(ep, path)
+	}
+}
+
+type Path struct {
+	Delete  *Plugins `bson:"delete,omitempty" json:"delete,omitempty"`
+	Get     *Plugins `bson:"get,omitempty" json:"get,omitempty"`
+	Head    *Plugins `bson:"head,omitempty" json:"head,omitempty"`
+	Options *Plugins `bson:"options,omitempty" json:"options,omitempty"`
+	Patch   *Plugins `bson:"patch,omitempty" json:"patch,omitempty"`
+	Post    *Plugins `bson:"post,omitempty" json:"post,omitempty"`
+	Put     *Plugins `bson:"put,omitempty" json:"put,omitempty"`
+	Trace   *Plugins `bson:"trace,omitempty" json:"trace,omitempty"`
+	Connect *Plugins `bson:"connect,omitempty" json:"connect,omitempty"`
+}
+
+func (p *Path) ExtractTo(ep *apidef.ExtendedPathsSet, path string) {
+	if p.Get != nil {
+		p.Get.ExtractTo(ep, path, http.MethodGet)
+	}
+
+	if p.Post != nil {
+		p.Post.ExtractTo(ep, path, http.MethodPost)
+	}
+
+	if p.Put != nil {
+		p.Put.ExtractTo(ep, path, http.MethodPut)
+	}
+
+	if p.Delete != nil {
+		p.Delete.ExtractTo(ep, path, http.MethodDelete)
+	}
+
+	if p.Head != nil {
+		p.Head.ExtractTo(ep, path, http.MethodHead)
+	}
+
+	if p.Options != nil {
+		p.Options.ExtractTo(ep, path, http.MethodOptions)
+	}
+
+	if p.Trace != nil {
+		p.Trace.ExtractTo(ep, path, http.MethodTrace)
+	}
+
+	if p.Patch != nil {
+		p.Patch.ExtractTo(ep, path, http.MethodPatch)
+	}
+
+	if p.Connect != nil {
+		p.Connect.ExtractTo(ep, path, http.MethodConnect)
+	}
+}
+
+func (p *Path) getMethod(name string) *Plugins {
+	switch {
+	case strings.EqualFold(http.MethodGet, name):
+		if p.Get == nil {
+			p.Get = &Plugins{}
+		}
+
+		return p.Get
+	case strings.EqualFold(http.MethodPost, name):
+		if p.Post == nil {
+			p.Post = &Plugins{}
+		}
+
+		return p.Post
+	case strings.EqualFold(http.MethodPut, name):
+		if p.Put == nil {
+			p.Put = &Plugins{}
+		}
+
+		return p.Put
+	case strings.EqualFold(http.MethodDelete, name):
+		if p.Delete == nil {
+			p.Delete = &Plugins{}
+		}
+
+		return p.Delete
+	case strings.EqualFold(http.MethodHead, name):
+		if p.Head == nil {
+			p.Head = &Plugins{}
+		}
+
+		return p.Head
+	case strings.EqualFold(http.MethodOptions, name):
+		if p.Options == nil {
+			p.Options = &Plugins{}
+		}
+
+		return p.Options
+	case strings.EqualFold(http.MethodTrace, name):
+		if p.Trace == nil {
+			p.Trace = &Plugins{}
+		}
+
+		return p.Trace
+	case strings.EqualFold(http.MethodPatch, name):
+		if p.Patch == nil {
+			p.Patch = &Plugins{}
+		}
+
+		return p.Patch
+	case strings.EqualFold(http.MethodConnect, name):
+		if p.Connect == nil {
+			p.Connect = &Plugins{}
+		}
+
+		return p.Connect
+	default:
+		if p.Get == nil {
+			p.Get = &Plugins{}
+		}
+
+		return p.Get
+	}
+}
+
+type AllowanceType int
+
+const (
+	allow                AllowanceType = 0
+	block                AllowanceType = 1
+	ignoreAuthentication AllowanceType = 2
+)
+
+type Plugins struct {
+	Allow                *Allowance `bson:"allow,omitempty" json:"allow,omitempty"`
+	Block                *Allowance `bson:"block,omitempty" json:"block,omitempty"`
+	IgnoreAuthentication *Allowance `bson:"ignoreAuthentication,omitempty" json:"ignoreAuthentication,omitempty"`
+}
+
+func (p *Plugins) fillAllowance(endpointMeta apidef.EndPointMeta, typ AllowanceType) {
+	var allowance *Allowance
+
+	switch typ {
+	case block:
+		if p.Block == nil {
+			p.Block = &Allowance{}
+		}
+
+		allowance = p.Block
+	case ignoreAuthentication:
+		if p.IgnoreAuthentication == nil {
+			p.IgnoreAuthentication = &Allowance{}
+		}
+
+		allowance = p.IgnoreAuthentication
+	default:
+		if p.Allow == nil {
+			p.Allow = &Allowance{}
+		}
+
+		allowance = p.Allow
+	}
+
+	allowance.Fill(endpointMeta)
+	if ShouldOmit(allowance) {
+		allowance = nil
+	}
+}
+
+func (p *Plugins) ExtractTo(ep *apidef.ExtendedPathsSet, path string, method string) {
+	p.extractAllowance(ep, path, method, allow)
+	p.extractAllowance(ep, path, method, block)
+	p.extractAllowance(ep, path, method, ignoreAuthentication)
+}
+
+func (p *Plugins) extractAllowance(ep *apidef.ExtendedPathsSet, path string, method string, typ AllowanceType) {
+	allowance := p.Allow
+	endpointMetas := &ep.WhiteList
+
+	switch typ {
+	case block:
+		allowance = p.Block
+		endpointMetas = &ep.BlackList
+	case ignoreAuthentication:
+		allowance = p.IgnoreAuthentication
+		endpointMetas = &ep.Ignored
+	}
+
+	if allowance != nil {
+		newPath := true
+		for i, em := range *endpointMetas {
+			if path == em.Path {
+				(*endpointMetas)[i].MethodActions[method] = apidef.EndpointMethodMeta{Action: apidef.NoAction}
+				newPath = false
+				break
+			}
+		}
+
+		if newPath {
+			methodActions := map[string]apidef.EndpointMethodMeta{
+				method: {Action: apidef.NoAction},
+			}
+
+			endpointMeta := apidef.EndPointMeta{Path: path, MethodActions: methodActions}
+			allowance.ExtractTo(&endpointMeta)
+			*endpointMetas = append(*endpointMetas, endpointMeta)
+		}
+	}
+}
+
+type Allowance struct {
+	Enabled    bool `bson:"enabled" json:"enabled"`
+	IgnoreCase bool `bson:"ignoreCase,omitempty" json:"ignoreCase,omitempty"`
+}
+
+func (a *Allowance) Fill(endpointMeta apidef.EndPointMeta) {
+	a.Enabled = !endpointMeta.Disabled
+	a.IgnoreCase = endpointMeta.IgnoreCase
+}
+
+func (a *Allowance) ExtractTo(endpointMeta *apidef.EndPointMeta) {
+	endpointMeta.Disabled = !a.Enabled
+	endpointMeta.IgnoreCase = a.IgnoreCase
 }

--- a/apidef/oas/middleware_test.go
+++ b/apidef/oas/middleware_test.go
@@ -54,3 +54,30 @@ func TestCache(t *testing.T) {
 
 	assert.Equal(t, emptyCache, resultCache)
 }
+
+func TestExtendedPaths(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		paths := make(Paths)
+
+		var convertedEP apidef.ExtendedPathsSet
+		paths.ExtractTo(&convertedEP)
+
+		resultPaths := make(Paths)
+		resultPaths.Fill(convertedEP)
+
+		assert.Equal(t, paths, resultPaths)
+	})
+
+	t.Run("filled", func(t *testing.T) {
+		paths := make(Paths)
+		Fill(t, &paths, 0)
+
+		var convertedEP apidef.ExtendedPathsSet
+		paths.ExtractTo(&convertedEP)
+
+		resultPaths := make(Paths)
+		resultPaths.Fill(convertedEP)
+
+		assert.Equal(t, paths, resultPaths)
+	})
+}


### PR DESCRIPTION
This PR implements basic plugin(`whitelist`, `blacklist`, `ignore`)'s OAS conversions and the base for plugin system.

```
paths: 
      /pets:
        GET:
          plugins:
            allow:
              enabled: true
              ignoreCase: false
            block:
              enabled: false
              ignoreCase: false
            ignoreAuthentication:
              enabled: false
              ignoreCase: false
```