### PR TITLE
[TT-3965] Implement new versioning system

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -338,6 +338,7 @@ type VersionInfo struct {
 	IgnoreEndpointCase          bool              `bson:"ignore_endpoint_case" json:"ignore_endpoint_case"`
 	GlobalSizeLimit             int64             `bson:"global_size_limit" json:"global_size_limit"`
 	OverrideTarget              string            `bson:"override_target" json:"override_target"`
+	APIID                       string            `bson:"api_id" json:"api_id"`
 }
 
 type AuthProviderMeta struct {

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -304,6 +304,8 @@ func (gw *Gateway) processSpec(spec *APISpec, apisByListen map[string]int,
 		logger.Info("Checking security policy: Open")
 	}
 
+	gw.mwAppendEnabled(&chainArray, &VersionCheck{BaseMiddleware: baseMid})
+
 	for _, obj := range mwPreFuncs {
 		if mwDriver == apidef.GoPluginDriver {
 			gw.mwAppendEnabled(
@@ -323,7 +325,6 @@ func (gw *Gateway) processSpec(spec *APISpec, apisByListen map[string]int,
 		}
 	}
 
-	gw.mwAppendEnabled(&chainArray, &VersionCheck{BaseMiddleware: baseMid})
 	gw.mwAppendEnabled(&chainArray, &RateCheckMW{BaseMiddleware: baseMid})
 	gw.mwAppendEnabled(&chainArray, &IPWhiteListMiddleware{BaseMiddleware: baseMid})
 	gw.mwAppendEnabled(&chainArray, &IPBlackListMiddleware{BaseMiddleware: baseMid})
@@ -576,7 +577,7 @@ func (d *DummyProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if d.SH.Spec.target.Scheme == "tyk" {
-		handler, found := d.Gw.findInternalHttpHandlerByNameOrID(d.SH.Spec.target.Host)
+		handler, _, found := d.Gw.findInternalHttpHandlerByNameOrID(d.SH.Spec.target.Host)
 		if !found {
 			handler := ErrorHandler{*d.SH.Base()}
 			handler.HandleError(w, r, "Couldn't detect target", http.StatusInternalServerError, true)
@@ -591,18 +592,18 @@ func (d *DummyProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	d.SH.ServeHTTP(w, r)
 }
 
-func (gw *Gateway) findInternalHttpHandlerByNameOrID(apiNameOrID string) (handler http.Handler, ok bool) {
-	targetAPI := gw.fuzzyFindAPI(apiNameOrID)
+func (gw *Gateway) findInternalHttpHandlerByNameOrID(apiNameOrID string) (handler http.Handler, targetAPI *APISpec, ok bool) {
+	targetAPI = gw.fuzzyFindAPI(apiNameOrID)
 	if targetAPI == nil {
-		return nil, false
+		return
 	}
 
 	h, found := gw.apisHandlesByID.Load(targetAPI.APIID)
 	if !found {
-		return nil, false
+		return nil, nil, false
 	}
 
-	return h.(http.Handler), true
+	return h.(http.Handler), targetAPI, true
 }
 
 func sanitizeProxyPaths(apiSpec *APISpec, request *http.Request) {

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -767,7 +767,7 @@ func (rt *TykRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 			r.Header.Del(apidef.TykInternalApiHeader)
 		}
 
-		handler, found := rt.Gw.findInternalHttpHandlerByNameOrID(r.Host)
+		handler, _, found := rt.Gw.findInternalHttpHandlerByNameOrID(r.Host)
 		if !found {
 			rt.logger.WithField("looping_url", "tyk://"+r.Host).Error("Couldn't detect target")
 			return nil, errors.New("handler could")


### PR DESCRIPTION
This PR implements new versioning system. To the version abject, it adds a new `api_id` field. When `api_id` is set and that api version is called, it automatically routes to versioned API.