### PR TITLE
[TT-3970] Override with deprecated auth when jwt or auth token is enabled

### DIFF
--- a/apidef/api_definition_test.go
+++ b/apidef/api_definition_test.go
@@ -1,8 +1,9 @@
 package apidef
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	schema "github.com/xeipuuv/gojsonschema"
 )
@@ -110,4 +111,26 @@ func TestSchemaGraphqlConfig(t *testing.T) {
 			t.Error(err)
 		}
 	}
+}
+
+func TestAPIDefinition_DecodeFromDB_AuthDeprecation(t *testing.T) {
+	const authHeader = "authorization"
+
+	spec := DummyAPI()
+	spec.Auth = AuthConfig{AuthHeaderName: authHeader}
+	spec.UseStandardAuth = true
+	spec.DecodeFromDB()
+
+	assert.Equal(t, spec.AuthConfigs, map[string]AuthConfig{
+		"authToken": spec.Auth,
+	})
+
+	spec.EnableJWT = true
+	spec.DecodeFromDB()
+
+	assert.Equal(t, spec.AuthConfigs, map[string]AuthConfig{
+		"authToken": spec.Auth,
+		"jwt":       spec.Auth,
+	})
+
 }

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -874,20 +874,20 @@ func (a *APIDefinition) DecodeFromDB() {
 	}
 
 	// Auth is deprecated so this code tries to maintain backward compatibility
-	makeCompatible := func(authType string) {
+	makeCompatible := func(authType string, enabled bool) {
 		if a.AuthConfigs == nil {
 			a.AuthConfigs = make(map[string]AuthConfig)
 		}
 
 		_, ok := a.AuthConfigs[authType]
 
-		if !ok {
+		if !ok && enabled {
 			a.AuthConfigs[authType] = a.Auth
 		}
 	}
 
-	makeCompatible("authToken")
-	makeCompatible("jwt")
+	makeCompatible("authToken", a.UseStandardAuth)
+	makeCompatible("jwt", a.EnableJWT)
 	// JWTScopeToPolicyMapping and JWTScopeClaimName are deprecated and following code ensures backward compatibility
 	if !a.UseOpenID && a.JWTScopeClaimName != "" && a.Scopes.JWT.ScopeClaimName == "" {
 		a.Scopes.JWT.ScopeToPolicy = a.JWTScopeToPolicyMapping


### PR DESCRIPTION
This is an old hidden bug appeared with OAS.