### PR TITLE
[TT-640] Add detailed mode for certificate listing API

### DIFF
--- a/certs/manager.go
+++ b/certs/manager.go
@@ -247,8 +247,8 @@ type CertificateBasics struct {
 	ID        string    `json:"id"`
 	IssuerCN  string    `json:"issuer_cn"`
 	SubjectCN string    `json:"subject_cn"`
-	NotBefore time.Time `json:"not_before,omitempty"`
-	NotAfter  time.Time `json:"not_after,omitempty"`
+	NotBefore time.Time `json:"not_before"`
+	NotAfter  time.Time `json:"not_after"`
 }
 
 func ExtractCertificateBasics(cert *tls.Certificate, certID string) *CertificateBasics {

--- a/certs/manager.go
+++ b/certs/manager.go
@@ -243,6 +243,24 @@ func isCertCanBeListed(cert *tls.Certificate, mode CertificateType) bool {
 	return true
 }
 
+type CertificateBasics struct {
+	ID        string    `json:"id"`
+	IssuerCN  string    `json:"issuer_cn"`
+	SubjectCN string    `json:"subject_cn"`
+	NotBefore time.Time `json:"not_before,omitempty"`
+	NotAfter  time.Time `json:"not_after,omitempty"`
+}
+
+func ExtractCertificateBasics(cert *tls.Certificate, certID string) *CertificateBasics {
+	return &CertificateBasics{
+		ID:        certID,
+		IssuerCN:  cert.Leaf.Issuer.CommonName,
+		SubjectCN: cert.Leaf.Subject.CommonName,
+		NotAfter:  cert.Leaf.NotAfter,
+		NotBefore: cert.Leaf.NotBefore,
+	}
+}
+
 type CertificateMeta struct {
 	ID            string    `json:"id"`
 	Fingerprint   string    `json:"fingerprint"`

--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -593,12 +593,12 @@ func TestUpdateKeyWithCert(t *testing.T) {
 
 	t.Run("Update key with valid cert", func(t *testing.T) {
 		// create cert
-		clientCertPem, _, _, _ := certs.GenCertificate(&x509.Certificate{})
+		clientCertPem, _, _, _ := certs.GenCertificate(&x509.Certificate{}, false)
 		certID, _ := ts.Gw.CertificateManager.Add(clientCertPem, "")
 		defer ts.Gw.CertificateManager.Delete(certID, "")
 
 		// new valid cert
-		newClientCertPem, _, _, _ := certs.GenCertificate(&x509.Certificate{})
+		newClientCertPem, _, _, _ := certs.GenCertificate(&x509.Certificate{}, false)
 		newCertID, _ := ts.Gw.CertificateManager.Add(newClientCertPem, "")
 		defer ts.Gw.CertificateManager.Delete(newCertID, "")
 
@@ -621,7 +621,7 @@ func TestUpdateKeyWithCert(t *testing.T) {
 	})
 
 	t.Run("Update key with empty cert", func(t *testing.T) {
-		clientCertPem, _, _, _ := certs.GenCertificate(&x509.Certificate{})
+		clientCertPem, _, _, _ := certs.GenCertificate(&x509.Certificate{}, false)
 		certID, _ := ts.Gw.CertificateManager.Add(clientCertPem, "")
 
 		// create session base and set cert
@@ -644,7 +644,7 @@ func TestUpdateKeyWithCert(t *testing.T) {
 	})
 
 	t.Run("Update key with invalid cert", func(t *testing.T) {
-		clientCertPem, _, _, _ := certs.GenCertificate(&x509.Certificate{})
+		clientCertPem, _, _, _ := certs.GenCertificate(&x509.Certificate{}, false)
 		certID, _ := ts.Gw.CertificateManager.Add(clientCertPem, "")
 
 		// create session base and set cert

--- a/gateway/auth_manager_test.go
+++ b/gateway/auth_manager_test.go
@@ -144,7 +144,7 @@ func TestHashKeyFunctionChanged(t *testing.T) {
 	//We reload the gw proxy so it uses the added server certificate
 	ts.ReloadGatewayProxy()
 
-	clientPEM, _, _, clientCert := certs.GenCertificate(&x509.Certificate{})
+	clientPEM, _, _, clientCert := certs.GenCertificate(&x509.Certificate{}, false)
 	clientCertID, err := ts.Gw.CertificateManager.Add(clientPEM, orgId)
 	if err != nil {
 		t.Fatal("certificate should be added to cert manager")

--- a/gateway/batch_requests_test.go
+++ b/gateway/batch_requests_test.go
@@ -126,7 +126,7 @@ func TestVirtualEndpointBatch(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()
 
-	_, _, combinedClientPEM, clientCert := certs.GenCertificate(&x509.Certificate{})
+	_, _, combinedClientPEM, clientCert := certs.GenCertificate(&x509.Certificate{}, false)
 	clientCert.Leaf, _ = x509.ParseCertificate(clientCert.Certificate[0])
 	upstream := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 	}))

--- a/gateway/cert.go
+++ b/gateway/cert.go
@@ -454,18 +454,19 @@ func (gw *Gateway) certHandler(w http.ResponseWriter, r *http.Request) {
 	case "GET":
 		if certID == "" {
 			orgID := r.URL.Query().Get("org_id")
-
-			certIDs := gw.CertificateManager.ListAllIds(orgID)
 			mode := r.URL.Query().Get("mode")
+			certIDs := gw.CertificateManager.ListAllIds(orgID)
 			if mode == ListDetailed {
 				var certificateBasics = make([]*certs.CertificateBasics, len(certIDs))
 				certificates := gw.CertificateManager.List(certIDs, certs.CertificateAny)
 				for ci, certificate := range certificates {
 					certificateBasics[ci] = certs.ExtractCertificateBasics(certificate, certIDs[ci])
 				}
+
 				doJSONWrite(w, http.StatusOK, &APIAllCertificateBasics{Certs: certificateBasics})
 				return
 			}
+
 			doJSONWrite(w, http.StatusOK, &APIAllCertificates{certIDs})
 			return
 		}

--- a/gateway/cert_go1.10_test.go
+++ b/gateway/cert_go1.10_test.go
@@ -163,7 +163,7 @@ func TestPublicKeyPinning(t *testing.T) {
 		_, _, _, serverCert := certs.GenCertificate(&x509.Certificate{
 			EmailAddresses: []string{"test@test.com"},
 			Subject:        pkix.Name{CommonName: "localhost"},
-		})
+		}, false)
 		serverPubID, err := ts.Gw.uploadCertPublicKey(serverCert)
 		if err != nil {
 			t.Error(err)
@@ -182,7 +182,7 @@ func TestPublicKeyPinning(t *testing.T) {
 		// start proxy
 		_, _, _, proxyCert := certs.GenCertificate(&x509.Certificate{
 			Subject: pkix.Name{CommonName: "local1.host"},
-		})
+		}, false)
 		proxyPubID, err := ts.Gw.uploadCertPublicKey(proxyCert)
 		if err != nil {
 			t.Error(err)

--- a/gateway/grpc_test.go
+++ b/gateway/grpc_test.go
@@ -143,7 +143,7 @@ func TestHTTP2_TLS(t *testing.T) {
 	expected := "HTTP/2.0"
 
 	// Certificates
-	_, _, _, clientCert := certs.GenCertificate(&x509.Certificate{})
+	_, _, _, clientCert := certs.GenCertificate(&x509.Certificate{}, false)
 	serverCertPem, _, combinedPEM, _ := certs.GenServerCertificate()
 	certID, _, _ := certs.GetCertIDAndChainPEM(combinedPEM, "")
 
@@ -196,7 +196,7 @@ func TestHTTP2_TLS(t *testing.T) {
 func TestTLSTyk_H2cUpstream(t *testing.T) {
 
 	// Certificates
-	_, _, _, clientCert := certs.GenCertificate(&x509.Certificate{})
+	_, _, _, clientCert := certs.GenCertificate(&x509.Certificate{}, false)
 	serverCertPem, _, combinedPEM, _ := certs.GenServerCertificate()
 	certID, _, _ := certs.GetCertIDAndChainPEM(combinedPEM, "")
 
@@ -301,7 +301,7 @@ func TestGRPC_MutualTLS(t *testing.T) {
 	// Mutual Authentication for both downstream-tyk and tyk-upstream
 
 	//generate certificates
-	_, _, combinedClientPEM, clientCert := certs.GenCertificate(&x509.Certificate{})
+	_, _, combinedClientPEM, clientCert := certs.GenCertificate(&x509.Certificate{}, false)
 	clientCert.Leaf, _ = x509.ParseCertificate(clientCert.Certificate[0])
 	serverCertPem, _, combinedPEM, _ := certs.GenServerCertificate()
 	// we can know the certId before add it to cert manager
@@ -522,7 +522,7 @@ func openListener(t *testing.T) net.Listener {
 }
 
 func grpcServerCreds(t *testing.T, clientCert *x509.Certificate) []grpc.ServerOption {
-	cert, key, _, _ := certs.GenCertificate(&x509.Certificate{})
+	cert, key, _, _ := certs.GenCertificate(&x509.Certificate{}, false)
 	certificate, _ := tls.X509KeyPair(cert, key)
 
 	pool := x509.NewCertPool()
@@ -684,7 +684,7 @@ func TestGRPC_Stream_MutualTLS(t *testing.T) {
 	ts := StartTest(conf)
 	defer ts.Close()
 
-	_, _, combinedClientPEM, clientCert := certs.GenCertificate(&x509.Certificate{})
+	_, _, combinedClientPEM, clientCert := certs.GenCertificate(&x509.Certificate{}, false)
 	certID, _ := ts.Gw.CertificateManager.Add(combinedPEM, "") // For tyk to know downstream
 	defer ts.Gw.CertificateManager.Delete(certID, "")
 	clientCert.Leaf, _ = x509.ParseCertificate(clientCert.Certificate[0])


### PR DESCRIPTION
This PR intends to add detailed mode for certificate listing API to return additional details are returned. A query parameter `mode` is added to the API `GET /certs`, when `mode=detailed`, additional details  `issuer.commonName`,  `subject.commonName`, `not_before`, `not_after` are returned