### PR TITLE
Add full XTykAPIGateway conversion test

### DIFF
--- a/apidef/oas/authentication.go
+++ b/apidef/oas/authentication.go
@@ -1,6 +1,8 @@
 package oas
 
 import (
+	"sort"
+
 	"github.com/lonelycode/osin"
 
 	"github.com/TykTechnologies/tyk/apidef"
@@ -432,6 +434,10 @@ func (s *Scopes) Fill(scopeClaim *apidef.ScopeClaim) {
 		s.ScopeToPolicyMapping = append(s.ScopeToPolicyMapping, ScopeToPolicy{Scope: scope, PolicyID: policyID})
 	}
 
+	sort.Slice(s.ScopeToPolicyMapping, func(i, j int) bool {
+		return s.ScopeToPolicyMapping[i].Scope < s.ScopeToPolicyMapping[j].PolicyID
+	})
+
 	if len(s.ScopeToPolicyMapping) == 0 {
 		s.ScopeToPolicyMapping = nil
 	}
@@ -671,6 +677,10 @@ func (o *OIDC) Fill(api apidef.APIDefinition) {
 		if len(mapping) == 0 {
 			mapping = nil
 		}
+
+		sort.Slice(mapping, func(i, j int) bool {
+			return mapping[i].ClientID < mapping[j].ClientID
+		})
 
 		o.Providers = append(o.Providers, Provider{Issuer: v.Issuer, ClientToPolicyMapping: mapping})
 	}

--- a/apidef/oas/root.go
+++ b/apidef/oas/root.go
@@ -44,8 +44,10 @@ func (x *XTykAPIGateway) ExtractTo(api *apidef.APIDefinition) {
 	// This is used to make API calls work before actual versioning implementation.
 	api.VersionData.DefaultVersion = "Default"
 	api.VersionData.NotVersioned = true
-	api.VersionData.Versions = map[string]apidef.VersionInfo{
-		"Default": {},
+	if len(api.VersionData.Versions) == 0 {
+		api.VersionData.Versions = map[string]apidef.VersionInfo{
+			"Default": {},
+		}
 	}
 }
 

--- a/apidef/oas/root_test.go
+++ b/apidef/oas/root_test.go
@@ -24,7 +24,20 @@ func TestXTykAPIGateway(t *testing.T) {
 		assert.Equal(t, emptyXTykAPIGateway, resultXTykAPIGateway)
 	})
 
-	t.Run("filled", func(t *testing.T) {
+	t.Run("filled OAS", func(t *testing.T) {
+		var xTykAPIGateway XTykAPIGateway
+		Fill(t, &xTykAPIGateway, 0)
+
+		var convertedAPI apidef.APIDefinition
+		xTykAPIGateway.ExtractTo(&convertedAPI)
+
+		var resultXTykAPIGateway XTykAPIGateway
+		resultXTykAPIGateway.Fill(convertedAPI)
+
+		assert.Equal(t, xTykAPIGateway, resultXTykAPIGateway)
+	})
+
+	t.Run("filled old", func(t *testing.T) {
 		t.SkipNow() // when we don't need to skip this, it means OAS and old API definition match
 		initialAPI := apidef.APIDefinition{}
 		Fill(t, &initialAPI, 0)
@@ -102,7 +115,6 @@ func Fill(t *testing.T, input interface{}, index int) {
 		if v.Type() == reflect.TypeOf(map[string]apidef.AuthConfig{}) {
 			v.Set(reflect.ValueOf(FillTestAuthConfigs(t, index)))
 		} else {
-
 			newMap := reflect.MakeMapWithSize(v.Type(), 0)
 			for i := 0; i < 3; i++ {
 				newKey := reflect.New(v.Type().Key()).Elem()

--- a/apidef/oas/upstream.go
+++ b/apidef/oas/upstream.go
@@ -24,6 +24,15 @@ func (u *Upstream) Fill(api apidef.APIDefinition) {
 	if ShouldOmit(u.ServiceDiscovery) {
 		u.ServiceDiscovery = nil
 	}
+
+	if u.Test == nil {
+		u.Test = &Test{}
+	}
+
+	u.Test.Fill(api.UptimeTests)
+	if ShouldOmit(u.Test) {
+		u.Test = nil
+	}
 }
 
 func (u *Upstream) ExtractTo(api *apidef.APIDefinition) {
@@ -31,6 +40,10 @@ func (u *Upstream) ExtractTo(api *apidef.APIDefinition) {
 
 	if u.ServiceDiscovery != nil {
 		u.ServiceDiscovery.ExtractTo(&api.Proxy.ServiceDiscovery)
+	}
+
+	if u.Test != nil {
+		u.Test.ExtractTo(&api.UptimeTests)
 	}
 }
 


### PR DESCRIPTION
Filling old API definition and converting to OAS and reconverting test is skipped because all conversions are not ready yet. However, the reverse of it is possible. We can fill OAS and convert it to old API definition and reconverting to OAS. This PR implements that test and fix bugs which cause the test to fail.