### PR TITLE
[TT-2324] trim whitespace and compare cookiename with custom cookie config

### DIFF
--- a/gateway/mw_strip_auth.go
+++ b/gateway/mw_strip_auth.go
@@ -89,7 +89,7 @@ func (sa *StripAuth) stripFromHeaders(r *http.Request, config *apidef.AuthConfig
 
 	cookies := strings.Split(cookieValue, ";")
 	for i, c := range cookies {
-		if strings.HasPrefix(c, cookieName) {
+		if strings.HasPrefix(strings.TrimSpace(c), cookieName) {
 			cookies = append(cookies[:i], cookies[i+1:]...)
 			cookieValue = strings.Join(cookies, ";")
 			r.Header.Set("Cookie", cookieValue)

--- a/gateway/mw_strip_auth_test.go
+++ b/gateway/mw_strip_auth_test.go
@@ -90,6 +90,8 @@ func TestStripAuth_stripFromHeaders(t *testing.T) {
 			authTokenType: {CookieName: key},
 		}
 		stripFromCookieTest(t, req, key, sa, "Dummy=DUMMY;NonDefaultName=AUTHORIZATION;Dummy2=DUMMY2", "Dummy=DUMMY;Dummy2=DUMMY2")
+		// whitespace between cookies
+		stripFromCookieTest(t, req, key, sa, "Dummy=DUMMY; NonDefaultName=AUTHORIZATION; Dummy2=DUMMY2", "Dummy=DUMMY; Dummy2=DUMMY2")
 	})
 }
 


### PR DESCRIPTION
while comparing for custom cookie name, a white space added after separator `;` would cause cookie not be stripped. This PR adds logic to fix that 