### PR TITLE
Remove unnecessary if statement and move variable to required place

### DIFF
--- a/gateway/mw_access_rights.go
+++ b/gateway/mw_access_rights.go
@@ -22,12 +22,6 @@ func (a *AccessRightsCheck) ProcessRequest(w http.ResponseWriter, r *http.Reques
 		return nil, http.StatusOK
 	}
 
-	accessingVersion := a.Spec.getVersionFromRequest(r)
-	if accessingVersion == "" {
-		if a.Spec.VersionData.DefaultVersion != "" {
-			accessingVersion = a.Spec.VersionData.DefaultVersion
-		}
-	}
 	session := ctxGetSession(r)
 
 	// If there's nothing in our profile, we let them through to the next phase
@@ -45,8 +39,13 @@ func (a *AccessRightsCheck) ProcessRequest(w http.ResponseWriter, r *http.Reques
 			// Not versioned, no point checking version access rights
 			found = true
 		} else {
+			targetVersion := a.Spec.getVersionFromRequest(r)
+			if targetVersion == "" {
+				targetVersion = a.Spec.VersionData.DefaultVersion
+			}
+
 			for _, vInfo := range versionList.Versions {
-				if vInfo == accessingVersion {
+				if vInfo == targetVersion {
 					found = true
 					break
 				}


### PR DESCRIPTION
`if a.Spec.VersionData.DefaultVersion != ""`  check is unnecessary. If it is empty `accessingVersion` still be empty, if not it will be overridden anyway. Also, the variable is just used in just `else` block so it is moved there.