### PR TITLE
Move old strip path code to one place and deprecate strip_path

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -329,7 +329,7 @@ type VersionDefinition struct {
 	Default             string       `bson:"default" json:"default"`
 	Location            string       `bson:"location" json:"location"`
 	Key                 string       `bson:"key" json:"key"`
-	StripPath           bool         `bson:"strip_path" json:"strip_path"`
+	StripPath           bool         `bson:"strip_path" json:"strip_path"` // Deprecated. Use StripVersioningData instead.
 	StripVersioningData bool         `bson:"strip_versioning_data" json:"strip_versioning_data"`
 	Versions            []VersionMap `bson:"versions" json:"versions"`
 }

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -1337,7 +1337,7 @@ func (a *APISpec) getVersionFromRequest(r *http.Request) string {
 		// First non-empty part of the path is the version ID
 		for _, part := range strings.Split(uPath, "/") {
 			if part != "" {
-				if a.VersionDefinition.StripVersioningData {
+				if a.VersionDefinition.StripVersioningData || a.VersionDefinition.StripPath {
 					log.Debug("Stripping version from url: ", part)
 
 					r.URL.Path = strings.Replace(r.URL.Path, part+"/", "", 1)

--- a/gateway/handler_success.go
+++ b/gateway/handler_success.go
@@ -304,16 +304,6 @@ func (s *SuccessHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) *http
 	log.Debug("Started proxy")
 	defer s.Base().UpdateRequestSession(r)
 
-	versionDef := s.Spec.VersionDefinition
-	if !s.Spec.VersionData.NotVersioned && versionDef.Location == "url" && versionDef.StripPath {
-		part := s.Spec.getVersionFromRequest(r)
-
-		log.Debug("Stripping version from url: ", part)
-
-		r.URL.Path = strings.Replace(r.URL.Path, part+"/", "", 1)
-		r.URL.RawPath = strings.Replace(r.URL.RawPath, part+"/", "", 1)
-	}
-
 	// Make sure we get the correct target URL
 	if s.Spec.Proxy.StripListenPath {
 		log.Debug("Stripping: ", s.Spec.Proxy.ListenPath)
@@ -345,16 +335,6 @@ func (s *SuccessHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) *http
 // final destination, this is invoked by the ProxyHandler or right at the start of a request chain if the URL
 // Spec states the path is Ignored Itwill also return a response object for the cache
 func (s *SuccessHandler) ServeHTTPWithCache(w http.ResponseWriter, r *http.Request) ProxyResponse {
-
-	versionDef := s.Spec.VersionDefinition
-	if !s.Spec.VersionData.NotVersioned && versionDef.Location == "url" && versionDef.StripPath {
-		part := s.Spec.getVersionFromRequest(r)
-
-		log.Debug("Stripping version from URL: ", part)
-
-		r.URL.Path = strings.Replace(r.URL.Path, part+"/", "", 1)
-		r.URL.RawPath = strings.Replace(r.URL.RawPath, part+"/", "", 1)
-	}
 
 	// Make sure we get the correct target URL
 	if s.Spec.Proxy.StripListenPath {


### PR DESCRIPTION
This PR removes old strip path handling to one place and get rid of redundancy. The tests are already existing, this change should not break tests.