### PR TITLE
[TT-4163]  Implement new api expiration feature

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -480,6 +480,8 @@ type Scopes struct {
 type APIDefinition struct {
 	Id                  ObjectId      `bson:"_id,omitempty" json:"id,omitempty" gorm:"primaryKey;column:_id"`
 	Name                string        `bson:"name" json:"name"`
+	Expiration          string        `bson:"expiration" json:"expiration"`
+	ExpirationTs        time.Time     `bson:"-" json:"-"`
 	Slug                string        `bson:"slug" json:"slug"`
 	ListenPort          int           `bson:"listen_port" json:"listen_port"`
 	Protocol            string        `bson:"protocol" json:"protocol"`

--- a/apidef/schema.go
+++ b/apidef/schema.go
@@ -24,6 +24,9 @@ const Schema = `{
         "api_id": {
             "type": "string"
         },
+		"expiration": {
+            "type": "string"
+        },
         "enable_ip_whitelisting": {
             "type": "boolean"
         },

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -263,13 +263,15 @@ func (a APIDefinitionLoader) MakeSpec(def *apidef.APIDefinition, logger *logrus.
 		logger = logrus.NewEntry(log)
 	}
 
-	if t, err := time.Parse(expiredTimeFormat, def.Expiration); err != nil {
+	// new expiration feature
+	if t, err := time.Parse(apidef.ExpirationTimeFormat, def.Expiration); err != nil {
 		logger.WithError(err).WithField("name", def.Name).WithField("Expiration", def.Expiration).
 			Error("Could not parse expiration date for API")
 	} else {
 		def.ExpirationTs = t
 	}
 
+	// Deprecated
 	// parse version expiration time stamps
 	for key, ver := range def.VersionData.Versions {
 		if ver.Expires == "" || ver.Expires == "-1" {

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -87,6 +87,7 @@ const (
 	VersionDoesNotExist            RequestStatus = "This API version does not seem to exist"
 	VersionWhiteListStatusNotFound RequestStatus = "WhiteListStatus for path not found"
 	VersionExpired                 RequestStatus = "Api Version has expired, please check documentation or contact administrator"
+	APIExpired                     RequestStatus = "API has expired, please check documentation or contact administrator"
 	EndPointNotAllowed             RequestStatus = "Requested endpoint is forbidden"
 	StatusOkAndIgnore              RequestStatus = "Everything OK, passing and not filtering"
 	StatusOk                       RequestStatus = "Everything OK, passing"
@@ -260,6 +261,13 @@ func (a APIDefinitionLoader) MakeSpec(def *apidef.APIDefinition, logger *logrus.
 
 	if logger == nil {
 		logger = logrus.NewEntry(log)
+	}
+
+	if t, err := time.Parse(expiredTimeFormat, def.Expiration); err != nil {
+		logger.WithError(err).WithField("name", def.Name).WithField("Expiration", def.Expiration).
+			Error("Could not parse expiration date for API")
+	} else {
+		def.ExpirationTs = t
 	}
 
 	// parse version expiration time stamps
@@ -1370,7 +1378,9 @@ func (a *APISpec) RequestValid(r *http.Request) (bool, RequestStatus) {
 		return false, VersionWhiteListStatusNotFound
 	}
 
-	if !a.VersionData.NotVersioned && versionInfo.Expired() {
+	if a.VersionData.NotVersioned && a.Expired() {
+		return false, APIExpired
+	} else if !a.VersionData.NotVersioned && versionInfo.Expired() { // Deprecated
 		return false, VersionExpired
 	}
 
@@ -1387,6 +1397,21 @@ func (a *APISpec) RequestValid(r *http.Request) (bool, RequestStatus) {
 	default:
 		return true, StatusOk
 	}
+}
+
+func (a *APISpec) Expired() bool {
+	// Never expires
+	if a.Expiration == "" || a.Expiration == "-1" {
+		return false
+	}
+
+	// otherwise use parsed timestamp
+	if a.ExpirationTs.IsZero() {
+		log.Error("Could not parse expiration date, disallow")
+		return true
+	}
+
+	return time.Since(a.ExpirationTs) >= 0
 }
 
 // Version attempts to extract the version data from a request, depending on where it is stored in the

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
@@ -1036,4 +1037,38 @@ func TestAPIDefinitionLoader_Template(t *testing.T) {
 
 		executeAndAssert(t, temp)
 	})
+}
+
+func TestAPIExpiration(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	api := BuildAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/"
+		spec.UseKeylessAccess = true
+		spec.VersionData.NotVersioned = true
+		spec.VersionDefinition.Enabled = true
+	})[0]
+
+	for _, versioned := range []bool{false, true} {
+		api.VersionDefinition.Enabled = versioned
+
+		t.Run(fmt.Sprintf("versioning=%v", versioned), func(t *testing.T) {
+			t.Run("not expired", func(t *testing.T) {
+				api.Expiration = time.Now().Format(expiredTimeFormat)
+				ts.Gw.LoadAPI(api)
+				resp, _ := ts.Run(t, test.TestCase{Code: http.StatusOK})
+
+				assert.NotEmpty(t, resp.Header.Get(XTykAPIExpires))
+			})
+
+			t.Run("expired", func(t *testing.T) {
+				api.Expiration = expiredTimeFormat
+				ts.Gw.LoadAPI(api)
+				resp, _ := ts.Run(t, test.TestCase{Code: http.StatusForbidden})
+
+				assert.Empty(t, resp.Header.Get(XTykAPIExpires))
+			})
+		})
+	}
 }

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -1055,7 +1055,7 @@ func TestAPIExpiration(t *testing.T) {
 
 		t.Run(fmt.Sprintf("versioning=%v", versioned), func(t *testing.T) {
 			t.Run("not expired", func(t *testing.T) {
-				api.Expiration = time.Now().Format(expiredTimeFormat)
+				api.Expiration = time.Now().AddDate(1, 0, 0).Format(apidef.ExpirationTimeFormat)
 				ts.Gw.LoadAPI(api)
 				resp, _ := ts.Run(t, test.TestCase{Code: http.StatusOK})
 
@@ -1063,7 +1063,7 @@ func TestAPIExpiration(t *testing.T) {
 			})
 
 			t.Run("expired", func(t *testing.T) {
-				api.Expiration = expiredTimeFormat
+				api.Expiration = apidef.ExpirationTimeFormat
 				ts.Gw.LoadAPI(api)
 				resp, _ := ts.Run(t, test.TestCase{Code: http.StatusForbidden})
 

--- a/gateway/mw_version_check.go
+++ b/gateway/mw_version_check.go
@@ -84,7 +84,9 @@ func (v *VersionCheck) ProcessRequest(w http.ResponseWriter, r *http.Request, _ 
 		return nil, mwStatusRespond
 	}
 
-	if expTime := versionInfo.ExpiryTime(); !expTime.IsZero() {
+	if !v.Spec.ExpirationTs.IsZero() {
+		w.Header().Set(XTykAPIExpires, v.Spec.ExpirationTs.Format(time.RFC1123))
+	} else if expTime := versionInfo.ExpiryTime(); !expTime.IsZero() { // Deprecated
 		w.Header().Set(XTykAPIExpires, expTime.Format(time.RFC1123))
 	}
 


### PR DESCRIPTION
This PR implements new expiration feature. It adds a flag named `expiration` to api definition. Previous expiration feature works only when versioning is enabled. However, this one will work no matter new versioning is enabled or not.