### PR TITLE
[TT-3965] Move versioning constants to apidef package

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -81,6 +81,11 @@ const (
 	// TykInternalApiHeader - flags request as internal api looping request
 	TykInternalApiHeader = "x-tyk-internal"
 
+	HeaderLocation       = "header"
+	URLParamLocation     = "url-param"
+	URLLocation          = "url"
+	ExpirationTimeFormat = "2006-01-02 15:04"
+
 	Self = "self"
 )
 

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -48,14 +48,6 @@ const (
 	RPCStorageEngine  apidef.StorageEngineCode = "rpc"
 )
 
-// Constants used by the version check middleware
-const (
-	headerLocation    = "header"
-	urlParamLocation  = "url-param"
-	urlLocation       = "url"
-	expiredTimeFormat = "2006-01-02 15:04"
-)
-
 // URLStatus is a custom enum type to avoid collisions
 type URLStatus int
 
@@ -276,7 +268,7 @@ func (a APIDefinitionLoader) MakeSpec(def *apidef.APIDefinition, logger *logrus.
 			continue
 		}
 		// calculate the time
-		if t, err := time.Parse(expiredTimeFormat, ver.Expires); err != nil {
+		if t, err := time.Parse(apidef.ExpirationTimeFormat, ver.Expires); err != nil {
 			logger.WithError(err).WithField("Expires", ver.Expires).Error("Could not parse expiry date for API")
 		} else {
 			ver.ExpiresTs = t
@@ -1312,7 +1304,7 @@ func (a *APISpec) getVersionFromRequest(r *http.Request) string {
 	defer ctxSetVersionName(r, &vName)
 
 	switch a.VersionDefinition.Location {
-	case headerLocation:
+	case apidef.HeaderLocation:
 		vName = r.Header.Get(a.VersionDefinition.Key)
 		if a.VersionDefinition.StripVersioningData {
 			log.Debug("Stripping version from header: ", vName)
@@ -1320,7 +1312,7 @@ func (a *APISpec) getVersionFromRequest(r *http.Request) string {
 		}
 
 		return vName
-	case urlParamLocation:
+	case apidef.URLParamLocation:
 		vName = r.URL.Query().Get(a.VersionDefinition.Key)
 		if a.VersionDefinition.StripVersioningData {
 			log.Debug("Stripping version from query: ", vName)
@@ -1330,7 +1322,7 @@ func (a *APISpec) getVersionFromRequest(r *http.Request) string {
 		}
 
 		return vName
-	case urlLocation:
+	case apidef.URLLocation:
 		uPath := a.StripListenPath(r, r.URL.Path)
 		uPath = strings.TrimPrefix(uPath, "/"+a.Slug)
 

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -755,7 +755,7 @@ func (ts *Test) testPrepareDefaultVersion() string {
 		v2 := apidef.VersionInfo{Name: "v2"}
 		v2.Paths.WhiteList = []string{"/bar"}
 
-		spec.VersionDefinition.Location = urlParamLocation
+		spec.VersionDefinition.Location = apidef.URLParamLocation
 		spec.VersionDefinition.Key = "v"
 		spec.VersionData.NotVersioned = false
 
@@ -790,7 +790,7 @@ func TestGetVersionFromRequest(t *testing.T) {
 		api := ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.VersionData.NotVersioned = false
-			spec.VersionDefinition.Location = headerLocation
+			spec.VersionDefinition.Location = apidef.HeaderLocation
 			spec.VersionDefinition.Key = "X-API-Version"
 			spec.VersionData.Versions["v1"] = versionInfo
 		})[0]
@@ -817,7 +817,7 @@ func TestGetVersionFromRequest(t *testing.T) {
 		api := ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.VersionData.NotVersioned = false
-			spec.VersionDefinition.Location = urlParamLocation
+			spec.VersionDefinition.Location = apidef.URLParamLocation
 			spec.VersionDefinition.Key = "version"
 			spec.VersionData.Versions["v2"] = versionInfo
 		})[0]
@@ -842,7 +842,7 @@ func TestGetVersionFromRequest(t *testing.T) {
 		api := ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.VersionData.NotVersioned = false
-			spec.VersionDefinition.Location = urlLocation
+			spec.VersionDefinition.Location = apidef.URLLocation
 			spec.VersionData.Versions["v3"] = versionInfo
 		})[0]
 
@@ -874,7 +874,7 @@ func BenchmarkGetVersionFromRequest(b *testing.B) {
 		ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.VersionData.NotVersioned = false
-			spec.VersionDefinition.Location = headerLocation
+			spec.VersionDefinition.Location = apidef.HeaderLocation
 			spec.VersionDefinition.Key = "X-API-Version"
 			spec.VersionData.Versions["v1"] = versionInfo
 		})
@@ -894,7 +894,7 @@ func BenchmarkGetVersionFromRequest(b *testing.B) {
 		ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.VersionData.NotVersioned = false
-			spec.VersionDefinition.Location = urlParamLocation
+			spec.VersionDefinition.Location = apidef.URLParamLocation
 			spec.VersionDefinition.Key = "version"
 			spec.VersionData.Versions["v2"] = versionInfo
 		})
@@ -912,7 +912,7 @@ func BenchmarkGetVersionFromRequest(b *testing.B) {
 		ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
 			spec.VersionData.NotVersioned = false
-			spec.VersionDefinition.Location = urlLocation
+			spec.VersionDefinition.Location = apidef.URLLocation
 			spec.VersionData.Versions["v3"] = versionInfo
 		})
 

--- a/gateway/mw_version_check_test.go
+++ b/gateway/mw_version_check_test.go
@@ -208,7 +208,7 @@ func TestNewVersioning(t *testing.T) {
 		a.VersionDefinition.Enabled = true
 		a.VersionDefinition.Name = baseVersionName
 		a.VersionDefinition.Default = apidef.Self
-		a.VersionDefinition.Location = urlParamLocation
+		a.VersionDefinition.Location = apidef.URLParamLocation
 		a.VersionDefinition.Key = "version"
 		a.VersionDefinition.Versions = []apidef.VersionMap{
 			{
@@ -320,7 +320,7 @@ func TestVersioning_StripPath(t *testing.T) {
 			"Default": {},
 			"v1":      {},
 		}
-		spec.VersionDefinition.Location = urlLocation
+		spec.VersionDefinition.Location = apidef.URLLocation
 		spec.VersionDefinition.Key = versionKey
 		spec.VersionDefinition.StripPath = false
 	})[0]
@@ -341,7 +341,7 @@ func TestOldVersioning_Expires(t *testing.T) {
 	nextYear := time.Now().AddDate(1, 0, 1)
 
 	vInfo := apidef.VersionInfo{
-		Expires: nextYear.Format(expiredTimeFormat),
+		Expires: nextYear.Format(apidef.ExpirationTimeFormat),
 	}
 
 	api := func() *APISpec {
@@ -349,7 +349,7 @@ func TestOldVersioning_Expires(t *testing.T) {
 			spec.Proxy.ListenPath = "/"
 			spec.VersionData.NotVersioned = true
 			spec.VersionData.DefaultVersion = "Default"
-			spec.VersionDefinition.Location = urlParamLocation
+			spec.VersionDefinition.Location = apidef.URLParamLocation
 			spec.VersionDefinition.Key = "version"
 			spec.VersionData.Versions = map[string]apidef.VersionInfo{
 				"Default": vInfo,
@@ -373,7 +373,7 @@ func TestOldVersioning_Expires(t *testing.T) {
 		})
 
 		t.Run("expired", func(t *testing.T) {
-			vInfo.Expires = expiredTimeFormat
+			vInfo.Expires = apidef.ExpirationTimeFormat
 			expiredAPI := api()
 			expiredAPI.VersionData.Versions["Default"] = vInfo
 
@@ -386,7 +386,7 @@ func TestOldVersioning_Expires(t *testing.T) {
 			t.Run("not expired", func(t *testing.T) {
 				versionedNotExpired := api()
 				versionedNotExpired.VersionData.NotVersioned = false
-				vInfo.Expires = nextYear.Format(expiredTimeFormat)
+				vInfo.Expires = nextYear.Format(apidef.ExpirationTimeFormat)
 				versionedNotExpired.VersionData.Versions["Default"] = vInfo
 
 				check(t, versionedNotExpired, test.TestCase{Code: http.StatusOK}, false)
@@ -395,7 +395,7 @@ func TestOldVersioning_Expires(t *testing.T) {
 			t.Run("expired", func(t *testing.T) {
 				versionedExpired := api()
 				versionedExpired.VersionData.NotVersioned = false
-				vInfo.Expires = expiredTimeFormat
+				vInfo.Expires = apidef.ExpirationTimeFormat
 				versionedExpired.VersionData.Versions["Default"] = vInfo
 
 				check(t, versionedExpired, test.TestCase{Code: http.StatusForbidden}, true)
@@ -406,7 +406,7 @@ func TestOldVersioning_Expires(t *testing.T) {
 			t.Run("not expired", func(t *testing.T) {
 				versionedNotExpired := api()
 				versionedNotExpired.VersionData.NotVersioned = false
-				vInfo.Expires = nextYear.Format(expiredTimeFormat)
+				vInfo.Expires = nextYear.Format(apidef.ExpirationTimeFormat)
 				versionedNotExpired.VersionData.Versions["v1"] = vInfo
 				versionedNotExpired.VersionData.Versions["Default"] = vInfo
 
@@ -416,7 +416,7 @@ func TestOldVersioning_Expires(t *testing.T) {
 			t.Run("expired", func(t *testing.T) {
 				versionedExpired := api()
 				versionedExpired.VersionData.NotVersioned = false
-				vInfo.Expires = expiredTimeFormat
+				vInfo.Expires = apidef.ExpirationTimeFormat
 				versionedExpired.VersionData.Versions["v1"] = vInfo
 				versionedExpired.VersionData.Versions["Default"] = vInfo
 


### PR DESCRIPTION
The versioning constants should be inside `apidef` package so that the dashboard can import them.