### PR TITLE
[TT-4161] Implement strip_path migrator to strip_versioning_data

### DIFF
--- a/apidef/migration.go
+++ b/apidef/migration.go
@@ -49,6 +49,12 @@ func (a *APIDefinition) MigrateVersioning() (versions []APIDefinition, err error
 		a.VersionDefinition.Name = a.VersionData.DefaultVersion
 	}
 
+	if a.VersionDefinition.Location == URLLocation {
+		a.VersionDefinition.StripVersioningData = a.VersionDefinition.StripPath
+	}
+
+	a.VersionDefinition.StripPath = false
+
 	defaultVersionInfo := a.VersionData.Versions[a.VersionData.DefaultVersion]
 
 	if defaultVersionInfo.OverrideTarget != "" {


### PR DESCRIPTION
This PR implements a migrate function from `strip_path` to `strip_versioning_data`. It adds migration tests and also checks whether current users are affected with migration.