### PR TITLE
[TT-4035] Release 4.0 plugin compiler workaround

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,6 +21,7 @@ builds:
 
     flags:
       - -tags=goplugin
+      - -trimpath
     ldflags:
       - -X gateway.VERSION={{.Version}} -X gateway.commit={{.FullCommit}} -X gateway.buildDate={{.Date}} -X gateway.builtBy=goreleaser
     goos:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -197,6 +197,7 @@ dockers:
     - "--label=org.opencontainers.image.title=tyk-plugin-compiler"
     - "--label=org.opencontainers.image.revision={{.FullCommit}}"
     - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--build-arg=GW_VERSION={{ .Tag }}"
   goarch: amd64
   goos: linux
   dockerfile: images/plugin-compiler/Dockerfile

--- a/images/plugin-compiler/Dockerfile
+++ b/images/plugin-compiler/Dockerfile
@@ -3,12 +3,14 @@
 FROM golang:1.15-buster
 LABEL description="Image for plugin development"
 
-ENV TYK_GW_PATH=/go/src/github.com/TykTechnologies/tyk
+ARG GW_VERSION
+WORKDIR /__w/tyk/
+RUN git clone --depth 1 --branch $GW_VERSION  https://github.com/TykTechnologies/tyk
 # This directory will contain the plugin source and will be
 # mounted from the host box by the user using docker volumes
 ENV PLUGIN_SOURCE_PATH=/plugin-source
 
-RUN mkdir -p $TYK_GW_PATH $PLUGIN_SOURCE_PATH
+RUN mkdir -p  $PLUGIN_SOURCE_PATH
 COPY images/plugin-compiler/data/build.sh /build.sh
 # COPY ./ $TYK_GW_PATH/
 # RUN cd $TYK_GW_PATH && go mod tidy && go mod vendor

--- a/images/plugin-compiler/Dockerfile
+++ b/images/plugin-compiler/Dockerfile
@@ -4,8 +4,8 @@ FROM golang:1.15-buster
 LABEL description="Image for plugin development"
 
 ARG GW_VERSION
-WORKDIR /__w/tyk/
-RUN git clone --depth 1 --branch $GW_VERSION  https://github.com/TykTechnologies/tyk
+#WORKDIR /__w/tyk/
+#RUN git clone --depth 1 --branch $GW_VERSION  https://github.com/TykTechnologies/tyk
 # This directory will contain the plugin source and will be
 # mounted from the host box by the user using docker volumes
 ENV PLUGIN_SOURCE_PATH=/plugin-source

--- a/images/plugin-compiler/data/build.sh
+++ b/images/plugin-compiler/data/build.sh
@@ -32,7 +32,7 @@ if [ ! -f go.mod ]; then
 fi
 
 # replace gw with local version
-echo "replace github.com/TykTechnologies/tyk => /__w/tyk/tyk" >> go.mod
+#echo "replace github.com/TykTechnologies/tyk => /__w/tyk/tyk" >> go.mod
 
 # Ensure that GW package versions have priorities
 
@@ -46,5 +46,5 @@ echo "replace github.com/TykTechnologies/tyk => /__w/tyk/tyk" >> go.mod
 # Copy GW dependencies
 # yes | cp -rf /tmp/vendor/* $PLUGIN_BUILD_PATH/vendor
 
-go build -buildmode=plugin -o $plugin_name \
+go build -trimpath -buildmode=plugin -o $plugin_name \
     && mv $plugin_name $PLUGIN_SOURCE_PATH

--- a/images/plugin-compiler/data/build.sh
+++ b/images/plugin-compiler/data/build.sh
@@ -31,9 +31,8 @@ if [ ! -f go.mod ]; then
     exit 1
 fi
 
-# if plugin has go.mod
-#[ -f go.mod ] && [ ! -d vendor ] && go mod vendor
-#rm go.mod
+# replace gw with local version
+echo "replace github.com/TykTechnologies/tyk => /__w/tyk/tyk" >> go.mod
 
 # Ensure that GW package versions have priorities
 

--- a/images/plugin-compiler/data/build.sh
+++ b/images/plugin-compiler/data/build.sh
@@ -32,8 +32,8 @@ if [ ! -f go.mod ]; then
 fi
 
 # if plugin has go.mod
-[ -f go.mod ] && [ ! -d vendor ] && go mod vendor
-rm go.mod
+#[ -f go.mod ] && [ ! -d vendor ] && go mod vendor
+#rm go.mod
 
 # Ensure that GW package versions have priorities
 


### PR DESCRIPTION
This PR intends to fix - `plugin.Open("plugin"): plugin was built with a different version of package` for gw dependencies. 
This issue won't occur locally if a replace directive is used in go.mod to replace the gw dependency with a local copy.

Since the gw is built in our release pipeline in github actions workspace directory `__w/tyk/tyk`, we can clone the corresponding gw version into `__w/tyk/tyk` and use a replace directive for gw while building the plugin and it'll be fixed. 

Related issue - https://github.com/golang/go/issues/31354

