### PR TITLE
[TT-4201] Implement separated mock response feature

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -166,11 +166,23 @@ type EndpointMethodMeta struct {
 	Headers map[string]string    `bson:"headers" json:"headers"`
 }
 
+type MockResponseMeta struct {
+	Disabled   bool              `bson:"disabled" json:"disabled"`
+	Path       string            `bson:"path" json:"path"`
+	Method     string            `bson:"method" json:"method"`
+	IgnoreCase bool              `bson:"ignore_case" json:"ignore_case"`
+	Code       int               `bson:"code" json:"code"`
+	Body       string            `bson:"body" json:"body"`
+	Headers    map[string]string `bson:"headers" json:"headers"`
+}
+
 type EndPointMeta struct {
-	Disabled      bool                          `bson:"disabled" json:"disabled"`
-	Path          string                        `bson:"path" json:"path"`
-	IgnoreCase    bool                          `bson:"ignore_case" json:"ignore_case"`
-	MethodActions map[string]EndpointMethodMeta `bson:"method_actions" json:"method_actions"`
+	Disabled   bool   `bson:"disabled" json:"disabled"`
+	Path       string `bson:"path" json:"path"`
+	Method     string `bson:"method" json:"method"`
+	IgnoreCase bool   `bson:"ignore_case" json:"ignore_case"`
+	// Deprecated. Use Method instead.
+	MethodActions map[string]EndpointMethodMeta `bson:"method_actions,omitempty" json:"method_actions,omitempty"`
 }
 
 type CacheMeta struct {
@@ -307,6 +319,7 @@ type ExtendedPathsSet struct {
 	Ignored                 []EndPointMeta        `bson:"ignored" json:"ignored,omitempty"`
 	WhiteList               []EndPointMeta        `bson:"white_list" json:"white_list,omitempty"`
 	BlackList               []EndPointMeta        `bson:"black_list" json:"black_list,omitempty"`
+	MockResponse            []MockResponseMeta    `bson:"mock_response" json:"mock_response,omitempty"`
 	Cached                  []string              `bson:"cache" json:"cache,omitempty"`
 	AdvanceCacheConfig      []CacheMeta           `bson:"advance_cache_config" json:"advance_cache_config,omitempty"`
 	Transform               []TemplateMeta        `bson:"transform" json:"transform,omitempty"`


### PR DESCRIPTION
This PR implements separated Mock Response feature. It was living inside `whitelist/blacklist/ignored` as `method_actions` but it can be a separate one from them. Also, `whitelist/blacklist/ignored` enabling/disabling or ignore case feature were working per path basis as we add all methods inside `method_actions`. Right now, you can work with them per `path+method` basis.