### PR TITLE
[TT-4141] Write override_target to target_url

### DIFF
--- a/apidef/migration.go
+++ b/apidef/migration.go
@@ -28,10 +28,10 @@ func (a *APIDefinition) MigrateVersioning() (versions []APIDefinition, err error
 		newAPI.VersionData.DefaultVersion = ""
 
 		if vInfo.OverrideTarget != "" {
-			newAPI.Proxy.ListenPath = vInfo.OverrideTarget
-		} else { // listen path of each version should be unique
-			newAPI.Proxy.ListenPath = strings.TrimSuffix(newAPI.Proxy.ListenPath, "/") + "-" + url.QueryEscape(vName) + "/"
+			newAPI.Proxy.TargetURL = vInfo.OverrideTarget
 		}
+
+		newAPI.Proxy.ListenPath = strings.TrimSuffix(newAPI.Proxy.ListenPath, "/") + "-" + url.QueryEscape(vName) + "/"
 
 		newAPI.Expiration = vInfo.Expires
 
@@ -60,7 +60,7 @@ func (a *APIDefinition) MigrateVersioning() (versions []APIDefinition, err error
 	defaultVersionInfo := a.VersionData.Versions[a.VersionData.DefaultVersion]
 
 	if defaultVersionInfo.OverrideTarget != "" {
-		a.Proxy.ListenPath = defaultVersionInfo.OverrideTarget
+		a.Proxy.TargetURL = defaultVersionInfo.OverrideTarget
 		defaultVersionInfo.OverrideTarget = ""
 	}
 

--- a/apidef/migration_test.go
+++ b/apidef/migration_test.go
@@ -11,6 +11,7 @@ func TestAPIDefinition_MigrateVersioning(t *testing.T) {
 		dbID       = "apiID"
 		apiID      = "apiID"
 		listenPath = "listenPath"
+		baseTarget = "base.com"
 		v1Target   = "v1.com"
 		v2Target   = "v2.com"
 		v1         = "v1"
@@ -24,7 +25,7 @@ func TestAPIDefinition_MigrateVersioning(t *testing.T) {
 			Id:     dbID,
 			APIID:  apiID,
 			Active: true,
-			Proxy:  ProxyConfig{ListenPath: listenPath},
+			Proxy:  ProxyConfig{TargetURL: baseTarget, ListenPath: listenPath},
 			VersionDefinition: VersionDefinition{
 				Location:  "url",
 				Key:       "version",
@@ -95,7 +96,7 @@ func TestAPIDefinition_MigrateVersioning(t *testing.T) {
 			versions, err = overrideTargetBase.MigrateVersioning()
 			assert.NoError(t, err)
 
-			expectedBase.Proxy.ListenPath = v1Target
+			expectedBase.Proxy.TargetURL = v1Target
 
 			assert.Equal(t, expectedBase, overrideTargetBase)
 
@@ -112,11 +113,11 @@ func TestAPIDefinition_MigrateVersioning(t *testing.T) {
 			versions, err = overrideTargetBase.MigrateVersioning()
 			assert.NoError(t, err)
 
-			expectedBase.Proxy.ListenPath = listenPath
+			expectedBase.Proxy.TargetURL = baseTarget
 
 			assert.Equal(t, expectedBase, overrideTargetBase)
 
-			expectedVersion.Proxy.ListenPath = v2Target
+			expectedVersion.Proxy.TargetURL = v2Target
 			assert.Len(t, versions, 1)
 			assert.Equal(t, expectedVersion, versions[0])
 		})


### PR DESCRIPTION
This PR fixes an implementation mistake that `override_target` is written to `listen_path` instead of `target_url` in versioning migration.