### PR TITLE
TT-4091 - OAS Caching Paths support

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -186,6 +186,7 @@ type EndPointMeta struct {
 }
 
 type CacheMeta struct {
+	Disabled               bool   `bson:"disabled" json:"disabled"`
 	Method                 string `bson:"method" json:"method"`
 	Path                   string `bson:"path" json:"path"`
 	CacheKeyRegex          string `bson:"cache_key_regex" json:"cache_key_regex"`

--- a/apidef/migration.go
+++ b/apidef/migration.go
@@ -201,19 +201,21 @@ func (a *APIDefinition) Migrate() (versions []APIDefinition, err error) {
 	}
 
 	a.MigrateEndpointMeta()
+	a.MigrateCachePlugin()
 	for i := 0; i < len(versions); i++ {
 		versions[i].MigrateEndpointMeta()
+		a.MigrateCachePlugin()
 	}
 
 	return versions, nil
 }
 
-func (a *APIDefinition) MigrateCachePlugin() (err error) {
+func (a *APIDefinition) MigrateCachePlugin() {
 	vInfo := a.VersionData.Versions[""]
 	list := vInfo.ExtendedPaths.Cached
 
 	if vInfo.UseExtendedPaths && len(list) > 0 {
-		var advCacheMethods = []CacheMeta{}
+		var advCacheMethods []CacheMeta
 		for _, cache := range list {
 			newGetMethodCache := CacheMeta{
 				Path:   cache,
@@ -236,6 +238,4 @@ func (a *APIDefinition) MigrateCachePlugin() (err error) {
 	}
 
 	a.VersionData.Versions[""] = vInfo
-
-	return nil
 }

--- a/apidef/migration.go
+++ b/apidef/migration.go
@@ -2,6 +2,7 @@ package apidef
 
 import (
 	"errors"
+	"net/http"
 	"net/url"
 	"sort"
 	"strings"
@@ -214,11 +215,22 @@ func (a *APIDefinition) MigrateCachePlugin() (err error) {
 	if vInfo.UseExtendedPaths && len(list) > 0 {
 		var advCacheMethods = []CacheMeta{}
 		for _, cache := range list {
-			newCache := CacheMeta{
+			newGetMethodCache := CacheMeta{
 				Path:     cache,
 				Disabled: false,
+				Method:   http.MethodGet,
 			}
-			advCacheMethods = append(advCacheMethods, newCache)
+			newHeadMethodCache := CacheMeta{
+				Path:     cache,
+				Disabled: false,
+				Method:   http.MethodHead,
+			}
+			newOptionsMethodCache := CacheMeta{
+				Path:     cache,
+				Disabled: false,
+				Method:   http.MethodOptions,
+			}
+			advCacheMethods = append(advCacheMethods, newGetMethodCache, newHeadMethodCache, newOptionsMethodCache)
 		}
 		vInfo.ExtendedPaths.AdvanceCacheConfig = advCacheMethods
 	}

--- a/apidef/migration.go
+++ b/apidef/migration.go
@@ -216,24 +216,25 @@ func (a *APIDefinition) MigrateCachePlugin() (err error) {
 		var advCacheMethods = []CacheMeta{}
 		for _, cache := range list {
 			newGetMethodCache := CacheMeta{
-				Path:     cache,
-				Disabled: false,
-				Method:   http.MethodGet,
+				Path:   cache,
+				Method: http.MethodGet,
 			}
 			newHeadMethodCache := CacheMeta{
-				Path:     cache,
-				Disabled: false,
-				Method:   http.MethodHead,
+				Path:   cache,
+				Method: http.MethodHead,
 			}
 			newOptionsMethodCache := CacheMeta{
-				Path:     cache,
-				Disabled: false,
-				Method:   http.MethodOptions,
+				Path:   cache,
+				Method: http.MethodOptions,
 			}
 			advCacheMethods = append(advCacheMethods, newGetMethodCache, newHeadMethodCache, newOptionsMethodCache)
 		}
+
 		vInfo.ExtendedPaths.AdvanceCacheConfig = advCacheMethods
+		// reset cache to empty
+		vInfo.ExtendedPaths.Cached = nil
 	}
+
 	a.VersionData.Versions[""] = vInfo
 
 	return nil

--- a/apidef/migration_test.go
+++ b/apidef/migration_test.go
@@ -324,7 +324,7 @@ func TestAPIDefinition_MigrateEndpointMeta(t *testing.T) {
 }
 
 func TestAPIDefinition_MigrateCache(t *testing.T) {
-	name := "Default"
+	name := ""
 
 	versionInfo := VersionInfo{
 		Name:             name,
@@ -357,8 +357,22 @@ func TestAPIDefinition_MigrateCache(t *testing.T) {
 		path1 := defaultVersionInfo.ExtendedPaths.AdvanceCacheConfig[0]
 		path1Cache := defaultVersionInfo.ExtendedPaths.Cached[0]
 
+		expectedCachedDefault := []string{"test"}
+		cacheItem := CacheMeta{
+			Method:        "",
+			Disabled:      false,
+			Path:          "test",
+			CacheKeyRegex: "",
+		}
+		expectedAdvCacheMethods := []CacheMeta{
+			cacheItem,
+		}
+
 		assert.Equal(t, len(defaultVersionInfo.ExtendedPaths.AdvanceCacheConfig), len(defaultVersionInfo.ExtendedPaths.Cached))
 		assert.Equal(t, path1.Path, path1Cache)
+
+		assert.Equal(t, expectedCachedDefault, defaultVersionInfo.ExtendedPaths.Cached)
+		assert.Equal(t, expectedAdvCacheMethods, defaultVersionInfo.ExtendedPaths.AdvanceCacheConfig)
 	}
 
 	t.Run("check migration of old data to new", func(t *testing.T) {

--- a/apidef/migration_test.go
+++ b/apidef/migration_test.go
@@ -323,37 +323,23 @@ func TestAPIDefinition_MigrateEndpointMeta(t *testing.T) {
 	assert.Equal(t, expectedMockResponse, api.VersionData.Versions[""].ExtendedPaths.MockResponse)
 }
 
-func TestAPIDefinition_MigrateCache(t *testing.T) {
-
+func TestAPIDefinition_MigrateCachePlugin(t *testing.T) {
 	versionInfo := VersionInfo{
-		Name:             "",
 		UseExtendedPaths: true,
 		ExtendedPaths: ExtendedPathsSet{
 			Cached: []string{"test"},
 		},
 	}
 
-	old := func() APIDefinition {
-		return APIDefinition{
-			VersionDefinition: VersionDefinition{
-				Location: URLLocation,
+	old := APIDefinition{
+		VersionData: VersionData{
+			Versions: map[string]VersionInfo{
+				"": versionInfo,
 			},
-			VersionData: VersionData{
-				NotVersioned:   false,
-				DefaultVersion: "",
-				Versions: map[string]VersionInfo{
-					"": versionInfo,
-				},
-			},
-		}
+		},
 	}
 
-	base := old()
-
-	err := base.MigrateCachePlugin()
-	assert.NoError(t, err)
-
-	defaultVersionInfo := base.VersionData.Versions[base.VersionData.DefaultVersion]
+	old.MigrateCachePlugin()
 
 	cacheItemGet := CacheMeta{
 		Method:        http.MethodGet,
@@ -372,7 +358,6 @@ func TestAPIDefinition_MigrateCache(t *testing.T) {
 		cacheItemOptions,
 	}
 
-	assert.Empty(t, defaultVersionInfo.ExtendedPaths.Cached)
-	assert.Equal(t, expectedAdvCacheMethods, defaultVersionInfo.ExtendedPaths.AdvanceCacheConfig)
-
+	assert.Empty(t, old.VersionData.Versions[""].ExtendedPaths.Cached)
+	assert.Equal(t, expectedAdvCacheMethods, old.VersionData.Versions[""].ExtendedPaths.AdvanceCacheConfig)
 }

--- a/apidef/migration_test.go
+++ b/apidef/migration_test.go
@@ -358,17 +358,34 @@ func TestAPIDefinition_MigrateCache(t *testing.T) {
 		path1Cache := defaultVersionInfo.ExtendedPaths.Cached[0]
 
 		expectedCachedDefault := []string{"test"}
-		cacheItem := CacheMeta{
-			Method:        "",
+		cacheItemGet := CacheMeta{
+			Method:        http.MethodGet,
 			Disabled:      false,
 			Path:          "test",
 			CacheKeyRegex: "",
 		}
+		cacheItemHead := CacheMeta{
+
+			Disabled:      false,
+			Path:          "test",
+			CacheKeyRegex: "",
+			Method:        http.MethodHead,
+		}
+		cacheItemOptions := CacheMeta{
+			Disabled:      false,
+			Path:          "test",
+			CacheKeyRegex: "",
+			Method:        http.MethodOptions,
+		}
 		expectedAdvCacheMethods := []CacheMeta{
-			cacheItem,
+			cacheItemGet,
+			cacheItemHead,
+			cacheItemOptions,
 		}
 
-		assert.Equal(t, len(defaultVersionInfo.ExtendedPaths.AdvanceCacheConfig), len(defaultVersionInfo.ExtendedPaths.Cached))
+		// for every cache item we have to have 3 new AdvanceCacheConfig items
+		// since we do support caching only for safe methods GET, OPTIONS and HEAD
+		assert.Equal(t, len(defaultVersionInfo.ExtendedPaths.AdvanceCacheConfig), len(defaultVersionInfo.ExtendedPaths.Cached)*3)
 		assert.Equal(t, path1.Path, path1Cache)
 
 		assert.Equal(t, expectedCachedDefault, defaultVersionInfo.ExtendedPaths.Cached)

--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -180,6 +180,7 @@ func (ps Paths) Fill(ep apidef.ExtendedPathsSet) {
 	ps.fillAllowance(ep.Ignored, ignoreAuthentication)
 	ps.fillMockResponse(ep.MockResponse)
 	ps.fillMethodTransform(ep.MethodTransforms)
+	ps.fillCache(ep)
 }
 
 func (ps Paths) fillAllowance(endpointMetas []apidef.EndPointMeta, typ AllowanceType) {
@@ -398,6 +399,7 @@ type Plugins struct {
 	// MockResponse allows you to mock responses for an API endpoint.
 	MockResponse    *MockResponse    `bson:"mockResponse,omitempty" json:"mockResponse,omitempty"`
 	MethodTransform *MethodTransform `bson:"methodTransform,omitempty" json:"methodTransform,omitempty"`
+	Cache           *CacheMiddleware `bson:"cache,omitempty" json:"cache,omitempty"`
 }
 
 func (p *Plugins) ExtractTo(ep *apidef.ExtendedPathsSet, path string, method string) {
@@ -406,6 +408,7 @@ func (p *Plugins) ExtractTo(ep *apidef.ExtendedPathsSet, path string, method str
 	p.extractAllowanceTo(ep, path, method, ignoreAuthentication)
 	p.extractMockResponseTo(ep, path, method)
 	p.extractMethodTransformTo(ep, path, method)
+	p.extractCacheTo(ep, path, method)
 }
 
 func (p *Plugins) extractAllowanceTo(ep *apidef.ExtendedPathsSet, path string, method string, typ AllowanceType) {
@@ -526,4 +529,76 @@ func (mt *MethodTransform) Fill(meta apidef.MethodTransformMeta) {
 func (mt *MethodTransform) ExtractTo(meta *apidef.MethodTransformMeta) {
 	meta.Disabled = !mt.Enabled
 	meta.ToMethod = mt.ToMethod
+}
+func (ps Paths) fillCache(ep apidef.ExtendedPathsSet) {
+	advanceCacheConfig := &ep.AdvanceCacheConfig
+
+	for _, advCache := range *advanceCacheConfig {
+		if ps[advCache.Path] != nil {
+			plugins := ps[advCache.Path].getMethod(advCache.Method)
+			plugins.fillCache(advCache)
+
+		}
+	}
+}
+
+func (p *Plugins) fillCache(cacheMeta apidef.CacheMeta) {
+	if p.Cache == nil {
+		p.Cache = &CacheMiddleware{}
+	}
+	p.Cache.Fill(cacheMeta)
+}
+
+func (p *Plugins) extractCacheTo(ep *apidef.ExtendedPathsSet, path string, method string) {
+	advanceCacheConfig := ep.AdvanceCacheConfig
+	if advanceCacheConfig == nil {
+		advanceCacheConfig = []apidef.CacheMeta{}
+		newCache := apidef.CacheMeta{}
+		newCache.CacheOnlyResponseCodes = p.Cache.CacheResponseCodes
+		newCache.Disabled = !p.Cache.Enabled
+		newCache.CacheKeyRegex = p.Cache.CacheByRegex
+		newCache.Method = method
+		newCache.Path = path
+
+		advanceCacheConfig = append(advanceCacheConfig, newCache)
+		ep.AdvanceCacheConfig = advanceCacheConfig
+		return
+	}
+
+	founded := false
+	for _, advCache := range advanceCacheConfig {
+		if path == advCache.Path && method == advCache.Method && !founded {
+			founded = true
+			break
+		}
+	}
+	if !founded {
+		newCache := apidef.CacheMeta{}
+		newCache.CacheOnlyResponseCodes = p.Cache.CacheResponseCodes
+		newCache.Disabled = !p.Cache.Enabled
+		newCache.CacheKeyRegex = p.Cache.CacheByRegex
+		newCache.Method = method
+		newCache.Path = path
+
+		advanceCacheConfig = append(advanceCacheConfig, newCache)
+		ep.AdvanceCacheConfig = advanceCacheConfig
+	}
+}
+
+type CacheMiddleware struct {
+	Enabled            bool   `bson:"enabled" json:"enabled"`
+	CacheByRegex       string `bson:"cacheByRegex,omitempty" json:"cacheByRegex,omitempty"`
+	CacheResponseCodes []int  `bson:"cacheResponseCodes,omitempty" json:"cacheResponseCodes,omitempty"`
+}
+
+func (a *CacheMiddleware) Fill(cm apidef.CacheMeta) {
+	a.Enabled = !cm.Disabled
+	a.CacheByRegex = cm.CacheKeyRegex
+	a.CacheResponseCodes = cm.CacheOnlyResponseCodes
+}
+
+func (a *CacheMiddleware) ExtractTo(endpointMeta *apidef.CacheMeta) {
+	endpointMeta.Disabled = !a.Enabled
+	endpointMeta.CacheKeyRegex = a.CacheByRegex
+	endpointMeta.CacheOnlyResponseCodes = a.CacheResponseCodes
 }

--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -555,11 +555,8 @@ func (p *Plugins) extractCacheTo(ep *apidef.ExtendedPathsSet, path string, metho
 	}
 
 	newCacheMeta := apidef.CacheMeta{
-		CacheOnlyResponseCodes: p.Cache.CacheResponseCodes,
-		Disabled:               !p.Cache.Enabled,
-		CacheKeyRegex:          p.Cache.CacheByRegex,
-		Method:                 method,
-		Path:                   path,
+		Method: method,
+		Path:   path,
 	}
 	p.Cache.ExtractTo(&newCacheMeta)
 	ep.AdvanceCacheConfig = append(ep.AdvanceCacheConfig, newCacheMeta)

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -682,6 +682,7 @@ func (a APIDefinitionLoader) compileCachedPathSpec(oldpaths []string, newpaths [
 		if spec.Disabled {
 			continue
 		}
+
 		newSpec := URLSpec{}
 		a.generateRegex(spec.Path, &newSpec, Cached, conf)
 		newSpec.CacheConfig.Method = spec.Method

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -679,6 +679,9 @@ func (a APIDefinitionLoader) compileCachedPathSpec(oldpaths []string, newpaths [
 	}
 
 	for _, spec := range newpaths {
+		if spec.Disabled {
+			continue
+		}
 		newSpec := URLSpec{}
 		a.generateRegex(spec.Path, &newSpec, Cached, conf)
 		newSpec.CacheConfig.Method = spec.Method

--- a/gateway/mw_version_check_test.go
+++ b/gateway/mw_version_check_test.go
@@ -490,8 +490,8 @@ func TestOldCache(t *testing.T) {
 		})[0]
 	}
 
-	check := func(t *testing.T, response string) {
-
+	check := func(t *testing.T, api *APISpec, response string) {
+		ts.Gw.LoadAPI(api)
 		_, _ = ts.Run(t, []test.TestCase{
 			{Path: "/test", BodyMatch: "default", Code: http.StatusOK},
 			{Path: "/anything", BodyMatch: response, Code: http.StatusOK},
@@ -499,14 +499,13 @@ func TestOldCache(t *testing.T) {
 
 	}
 
-	ts.Gw.LoadAPI(api())
-	check(t, response)
+	check(t, api(), response)
 
 	t.Run("migration", func(t *testing.T) {
 		response = "updated"
 		err := api().MigrateCachePlugin()
 		assert.NoError(t, err)
 
-		check(t, response)
+		check(t, api(), response)
 	})
 }

--- a/gateway/mw_version_check_test.go
+++ b/gateway/mw_version_check_test.go
@@ -2,7 +2,6 @@ package gateway
 
 import (
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -454,58 +453,5 @@ func TestOldVersioning_Expires(t *testing.T) {
 				check(t, versionedExpired, test.TestCase{Path: "/?version=v1", Code: http.StatusForbidden}, true)
 			})
 		})
-	})
-}
-
-func TestOldCache(t *testing.T) {
-	ts := StartTest(nil)
-	defer ts.Close()
-	var response = "default"
-
-	vInfo := apidef.VersionInfo{
-		ExtendedPaths: apidef.ExtendedPathsSet{
-			Cached: []string{
-				"/test",
-			},
-		},
-		UseExtendedPaths: true,
-	}
-
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(response))
-	}))
-
-	api := func() *APISpec {
-		return BuildAPI(func(spec *APISpec) {
-			spec.Proxy.ListenPath = "/"
-			spec.Proxy.TargetURL = upstream.URL
-			spec.VersionDefinition.Location = apidef.URLParamLocation
-			spec.VersionData.Versions = map[string]apidef.VersionInfo{
-				"Default": vInfo,
-			}
-			spec.CacheOptions = apidef.CacheOptions{
-				CacheTimeout: 120,
-				EnableCache:  true,
-			}
-		})[0]
-	}
-
-	check := func(t *testing.T, api *APISpec, response string) {
-		ts.Gw.LoadAPI(api)
-		_, _ = ts.Run(t, []test.TestCase{
-			{Path: "/test", BodyMatch: "default", Code: http.StatusOK},
-			{Path: "/anything", BodyMatch: response, Code: http.StatusOK},
-		}...)
-
-	}
-
-	check(t, api(), response)
-
-	t.Run("migration", func(t *testing.T) {
-		response = "updated"
-		err := api().MigrateCachePlugin()
-		assert.NoError(t, err)
-
-		check(t, api(), response)
 	})
 }


### PR DESCRIPTION
This PR:
- Adds `disabled` flag to cache plugin
- Implements migration from old cache string array to new advanced cache config
- Implements OAS conversion for advanced cache config