### PR TITLE
[TT-4228] Fix strip listen path which removes forwarding slash in path

### DIFF
--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -1534,10 +1534,14 @@ func (a *APISpec) SanitizeProxyPaths(r *http.Request) {
 		return
 	}
 
+	log.Debug("Stripping proxy listen path: ", a.Proxy.ListenPath)
+
 	r.URL.Path = a.StripListenPath(r, r.URL.Path)
 	if r.URL.RawPath != "" {
 		r.URL.RawPath = a.StripListenPath(r, r.URL.RawPath)
 	}
+
+	log.Debug("Upstream path is: ", r.URL.Path)
 }
 
 type RoundRobin struct {

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -1529,6 +1529,17 @@ func (a *APISpec) StripListenPath(r *http.Request, path string) string {
 	return stripListenPath(a.Proxy.ListenPath, path, mux.Vars(r))
 }
 
+func (a *APISpec) SanitizeProxyPaths(r *http.Request) {
+	if !a.Proxy.StripListenPath {
+		return
+	}
+
+	r.URL.Path = a.StripListenPath(r, r.URL.Path)
+	if r.URL.RawPath != "" {
+		r.URL.RawPath = a.StripListenPath(r, r.URL.RawPath)
+	}
+}
+
 type RoundRobin struct {
 	pos uint32
 }
@@ -1544,15 +1555,25 @@ func (r *RoundRobin) WithLen(len int) int {
 
 var listenPathVarsRE = regexp.MustCompile(`{[^:]+(:[^}]+)?}`)
 
-func stripListenPath(listenPath, path string, muxVars map[string]string) string {
+func stripListenPath(listenPath, path string, muxVars map[string]string) (res string) {
+	defer func() {
+		if !strings.HasPrefix(res, "/") {
+			res = "/" + res
+		}
+	}()
+
 	if !strings.Contains(listenPath, "{") {
-		return strings.TrimPrefix(path, listenPath)
+		res = strings.TrimPrefix(path, listenPath)
+		return
 	}
+
 	lp := listenPathVarsRE.ReplaceAllStringFunc(listenPath, func(match string) string {
 		match = strings.TrimLeft(match, "{")
 		match = strings.TrimRight(match, "}")
 		aliasVar := strings.Split(match, ":")[0]
 		return muxVars[aliasVar]
 	})
-	return strings.TrimPrefix(path, lp)
+
+	res = strings.TrimPrefix(path, lp)
+	return
 }

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -584,7 +584,7 @@ func (d *DummyProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		sanitizeProxyPaths(d.SH.Spec, r)
+		d.SH.Spec.SanitizeProxyPaths(r)
 		handler.ServeHTTP(w, r)
 		return
 	}
@@ -604,15 +604,6 @@ func (gw *Gateway) findInternalHttpHandlerByNameOrID(apiNameOrID string) (handle
 	}
 
 	return h.(http.Handler), targetAPI, true
-}
-
-func sanitizeProxyPaths(apiSpec *APISpec, request *http.Request) {
-	if !apiSpec.Proxy.StripListenPath {
-		return
-	}
-
-	request.URL.Path = apiSpec.StripListenPath(request, request.URL.Path)
-	request.URL.RawPath = apiSpec.StripListenPath(request, request.URL.RawPath)
 }
 
 func (gw *Gateway) loadGlobalApps() {

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -2035,7 +2035,7 @@ func TestStripRegex(t *testing.T) {
 		{
 			strip:  "/taihoe-test/{test:[\\w\\d]+}/id/",
 			path:   "/taihoe-test/asdas234234dad/id/v1/get",
-			expect: "v1/get",
+			expect: "/v1/get",
 			vars: map[string]string{
 				"test": "asdas234234dad",
 			},

--- a/gateway/handler_error.go
+++ b/gateway/handler_error.go
@@ -228,12 +228,6 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 			r.URL.Path = e.Spec.StripListenPath(r, r.URL.Path)
 		}
 
-		// This is an odd bugfix, will need further testing
-		r.URL.Path = "/" + r.URL.Path
-		if strings.HasPrefix(r.URL.Path, "//") {
-			r.URL.Path = strings.TrimPrefix(r.URL.Path, "/")
-		}
-
 		oauthClientID := ""
 		session := ctxGetSession(r)
 		tags := make([]string, 0, estimateTagsCapacity(session, e.Spec))

--- a/gateway/handler_success.go
+++ b/gateway/handler_success.go
@@ -305,12 +305,7 @@ func (s *SuccessHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) *http
 	defer s.Base().UpdateRequestSession(r)
 
 	// Make sure we get the correct target URL
-	if s.Spec.Proxy.StripListenPath {
-		log.Debug("Stripping: ", s.Spec.Proxy.ListenPath)
-		r.URL.Path = s.Spec.StripListenPath(r, r.URL.Path)
-		r.URL.RawPath = s.Spec.StripListenPath(r, r.URL.RawPath)
-		log.Debug("Upstream Path is: ", r.URL.Path)
-	}
+	s.Spec.SanitizeProxyPaths(r)
 
 	addVersionHeader(w, r, s.Spec.GlobalConfig)
 
@@ -337,10 +332,7 @@ func (s *SuccessHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) *http
 func (s *SuccessHandler) ServeHTTPWithCache(w http.ResponseWriter, r *http.Request) ProxyResponse {
 
 	// Make sure we get the correct target URL
-	if s.Spec.Proxy.StripListenPath {
-		r.URL.Path = s.Spec.StripListenPath(r, r.URL.Path)
-		r.URL.RawPath = s.Spec.StripListenPath(r, r.URL.RawPath)
-	}
+	s.Spec.SanitizeProxyPaths(r)
 
 	t1 := time.Now()
 	inRes := s.Proxy.ServeHTTPForCache(w, r)

--- a/gateway/mw_request_signing.go
+++ b/gateway/mw_request_signing.go
@@ -83,9 +83,6 @@ func (s *RequestSigning) getRequestPath(r *http.Request) string {
 	} else {
 		if s.Spec.Proxy.StripListenPath {
 			path = s.Spec.StripListenPath(r, path)
-			if !strings.HasPrefix(path, "/") {
-				path = "/" + path
-			}
 		}
 	}
 

--- a/gateway/mw_request_signing_test.go
+++ b/gateway/mw_request_signing_test.go
@@ -414,7 +414,7 @@ func TestRSARequestSigning(t *testing.T) {
 	})
 }
 
-func TestStripListenPath(t *testing.T) {
+func TestAPISpec_StripListenPath(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()
 

--- a/gateway/mw_version_check.go
+++ b/gateway/mw_version_check.go
@@ -49,7 +49,7 @@ func (v *VersionCheck) ProcessRequest(w http.ResponseWriter, r *http.Request, _ 
 			return errors.New(string(VersionDoesNotExist)), http.StatusNotFound
 		}
 
-		sanitizeProxyPaths(v.Spec, r)
+		v.Spec.SanitizeProxyPaths(r)
 
 		handler.ServeHTTP(w, r)
 		return nil, mwStatusRespond


### PR DESCRIPTION
Strip listen path removes forwarding slash in endpoint if listen path has a trailing slash like:
`listen_path` -> `/listen/`
`path` -> `/listen/get`
stripping result: `get`

It should respect the forwarding slash in the endpoint and the result should be `/get`