### PR TITLE
[TT-4141] Make migrated version APIs internal by default

### DIFF
--- a/apidef/migration.go
+++ b/apidef/migration.go
@@ -25,6 +25,7 @@ func (a *APIDefinition) MigrateVersioning() (versions []APIDefinition, err error
 			newAPI := *a
 			newAPI.APIID = ""
 			newAPI.Id = ""
+			newAPI.Internal = true
 			newAPI.VersionDefinition = VersionDefinition{}
 			newAPI.VersionData.NotVersioned = true
 			newAPI.VersionData.DefaultVersion = ""

--- a/apidef/migration_test.go
+++ b/apidef/migration_test.go
@@ -75,6 +75,7 @@ func TestAPIDefinition_MigrateVersioning(t *testing.T) {
 	expectedVersion := old()
 	expectedVersion.Id = ""
 	expectedVersion.APIID = ""
+	expectedVersion.Internal = true
 	expectedVersion.Expiration = exp2
 	expectedVersion.Proxy.ListenPath += "-" + v2 + "/"
 	expectedVersion.VersionDefinition = VersionDefinition{}


### PR DESCRIPTION
When we migrate old APIs and create versioned APIs for each version, we should set versions internal by default. They should not be accessible via their own listen paths unless user makes them external.