### PR TITLE
[TT-4141] Add auto-generated api ids to newly created APIs in migration

### DIFF
--- a/apidef/migration.go
+++ b/apidef/migration.go
@@ -5,6 +5,8 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+
+	uuid "github.com/satori/go.uuid"
 )
 
 func (a *APIDefinition) MigrateVersioning() (versions []APIDefinition, err error) {
@@ -13,18 +15,27 @@ func (a *APIDefinition) MigrateVersioning() (versions []APIDefinition, err error
 	}
 
 	if a.VersionData.NotVersioned && len(a.VersionData.Versions) > 1 {
-		return nil, errors.New("not migratable - if not versioned, there should be 1 version info in versions map")
+		return nil, errors.New("not migratable - if not versioned, there should be just one version info in versions map")
 	}
 
 	if !a.VersionData.NotVersioned {
+		if _, ok := a.VersionData.Versions[a.VersionData.DefaultVersion]; !ok {
+			return nil, errors.New("not migratable - if versioned, default version should match one of the versions")
+		}
+
 		for vName, vInfo := range a.VersionData.Versions {
 			if a.VersionData.DefaultVersion == vName {
 				continue
 			}
 
 			newAPI := *a
-			newAPI.APIID = ""
+
+			newID := uuid.NewV4()
+			apiID := strings.Replace(newID.String(), "-", "", -1)
+
+			newAPI.APIID = apiID
 			newAPI.Id = ""
+			newAPI.Name += "-" + url.QueryEscape(vName)
 			newAPI.Internal = true
 			newAPI.VersionDefinition = VersionDefinition{}
 			newAPI.VersionData.NotVersioned = true
@@ -32,11 +43,17 @@ func (a *APIDefinition) MigrateVersioning() (versions []APIDefinition, err error
 
 			if vInfo.OverrideTarget != "" {
 				newAPI.Proxy.TargetURL = vInfo.OverrideTarget
+				vInfo.OverrideTarget = ""
 			}
 
 			newAPI.Proxy.ListenPath = strings.TrimSuffix(newAPI.Proxy.ListenPath, "/") + "-" + url.QueryEscape(vName) + "/"
 
 			newAPI.Expiration = vInfo.Expires
+			vInfo.Expires = ""
+
+			newAPI.VersionData.Versions = map[string]VersionInfo{
+				"": vInfo,
+			}
 
 			versions = append(versions, newAPI)
 			delete(a.VersionData.Versions, vName)
@@ -45,7 +62,7 @@ func (a *APIDefinition) MigrateVersioning() (versions []APIDefinition, err error
 				a.VersionDefinition.Versions = make(map[string]string)
 			}
 
-			a.VersionDefinition.Versions[vName] = ""
+			a.VersionDefinition.Versions[vName] = newAPI.APIID
 		}
 	}
 

--- a/apidef/migration_test.go
+++ b/apidef/migration_test.go
@@ -67,7 +67,7 @@ func TestAPIDefinition_MigrateVersioning(t *testing.T) {
 	expectedBase.VersionDefinition.Name = v1
 	expectedBase.VersionDefinition.Default = Self
 	expectedBase.VersionDefinition.Versions = map[string]string{
-		v2: "",
+		v2: versions[0].APIID,
 	}
 
 	assert.Equal(t, expectedBase, base)
@@ -75,6 +75,7 @@ func TestAPIDefinition_MigrateVersioning(t *testing.T) {
 	expectedVersion := old()
 	expectedVersion.Id = ""
 	expectedVersion.APIID = ""
+	expectedVersion.Name += "-" + v2
 	expectedVersion.Internal = true
 	expectedVersion.Expiration = exp2
 	expectedVersion.Proxy.ListenPath += "-" + v2 + "/"
@@ -86,6 +87,7 @@ func TestAPIDefinition_MigrateVersioning(t *testing.T) {
 	}
 
 	assert.Len(t, versions, 1)
+	expectedVersion.APIID = versions[0].APIID
 	assert.Equal(t, expectedVersion, versions[0])
 
 	t.Run("override target", func(t *testing.T) {
@@ -100,9 +102,11 @@ func TestAPIDefinition_MigrateVersioning(t *testing.T) {
 
 			expectedBase.Proxy.TargetURL = v1Target
 
+			expectedBase.VersionDefinition.Versions[v2] = versions[0].APIID
 			assert.Equal(t, expectedBase, overrideTargetBase)
 
 			assert.Len(t, versions, 1)
+			expectedVersion.APIID = versions[0].APIID
 			assert.Equal(t, expectedVersion, versions[0])
 		})
 
@@ -116,11 +120,13 @@ func TestAPIDefinition_MigrateVersioning(t *testing.T) {
 			assert.NoError(t, err)
 
 			expectedBase.Proxy.TargetURL = baseTarget
+			expectedBase.VersionDefinition.Versions[v2] = versions[0].APIID
 
 			assert.Equal(t, expectedBase, overrideTargetBase)
 
 			expectedVersion.Proxy.TargetURL = v2Target
 			assert.Len(t, versions, 1)
+			expectedVersion.APIID = versions[0].APIID
 			assert.Equal(t, expectedVersion, versions[0])
 		})
 	})
@@ -131,7 +137,7 @@ func TestAPIDefinition_MigrateVersioning(t *testing.T) {
 
 		t.Run("multiple versions", func(t *testing.T) {
 			versions, err = versionDisabledBase.MigrateVersioning()
-			assert.EqualError(t, err, "not migratable - if not versioned, there should be 1 version info in versions map")
+			assert.EqualError(t, err, "not migratable - if not versioned, there should be just one version info in versions map")
 		})
 
 		delete(versionDisabledBase.VersionData.Versions, v2)

--- a/gateway/mw_version_check_test.go
+++ b/gateway/mw_version_check_test.go
@@ -326,11 +326,7 @@ func TestOldVersioning_StripPath(t *testing.T) {
 			versions, err := api.MigrateVersioning()
 			assert.NoError(t, err)
 
-			const subVersionID = "subVersionID"
-			api.VersionDefinition.Versions["v1"] = subVersionID
-			versions[0].APIID = subVersionID
 			ts.Gw.LoadAPI(api, &APISpec{APIDefinition: &versions[0]})
-
 			_, _ = ts.Run(t, tc)
 		})
 	}
@@ -394,10 +390,6 @@ func TestOldVersioning_Expires(t *testing.T) {
 
 			apis := []*APISpec{api}
 			if len(versions) > 0 {
-				const subVersionID = "subVersionID"
-				api.VersionDefinition.Versions["v1"] = subVersionID
-				versions[0].APIID = subVersionID
-
 				apis = append(apis, &APISpec{APIDefinition: &versions[0]})
 			}
 


### PR DESCRIPTION
This PR auto-generates sub-version API ids in migration.