### PR TITLE
[TT-4249] Add disable flag for enforced timeout plugin

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -222,9 +222,10 @@ type HeaderInjectionMeta struct {
 }
 
 type HardTimeoutMeta struct {
-	Path    string `bson:"path" json:"path"`
-	Method  string `bson:"method" json:"method"`
-	TimeOut int    `bson:"timeout" json:"timeout"`
+	Disabled bool   `bson:"disabled" json:"disabled"`
+	Path     string `bson:"path" json:"path"`
+	Method   string `bson:"method" json:"method"`
+	TimeOut  int    `bson:"timeout" json:"timeout"`
 }
 
 type TrackEndpointMeta struct {

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -808,6 +808,10 @@ func (a APIDefinitionLoader) compileTimeoutPathSpec(paths []apidef.HardTimeoutMe
 	urlSpec := []URLSpec{}
 
 	for _, stringSpec := range paths {
+		if stringSpec.Disabled {
+			continue
+		}
+
 		newSpec := URLSpec{}
 		a.generateRegex(stringSpec.Path, &newSpec, stat, conf)
 		// Extend with method actions


### PR DESCRIPTION
This PR adds `disable` flag for enforced timeout plugin to be able to switch on/off it.