### PR TITLE
Separate migration tests

### DIFF
--- a/apidef/migration_test.go
+++ b/apidef/migration_test.go
@@ -7,166 +7,204 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAPIDefinition_MigrateVersioning(t *testing.T) {
-	const (
-		dbID       = "apiID"
-		apiID      = "apiID"
-		listenPath = "listenPath"
-		baseTarget = "base.com"
-		v1Target   = "v1.com"
-		v2Target   = "v2.com"
-		v1         = "v1"
-		v2         = "v2"
-		exp1       = "exp1"
-		exp2       = "exp2"
-	)
+const (
+	dbID       = "dbID"
+	apiID      = "apiID"
+	listenPath = "listenPath"
+	baseTarget = "base.com"
+	v1Target   = "v1.com"
+	v2Target   = "v2.com"
+	v1         = "v1"
+	v2         = "v2"
+	exp1       = "exp1"
+	exp2       = "exp2"
+	key        = "version"
+)
 
-	old := func() APIDefinition {
-		return APIDefinition{
-			Id:     dbID,
-			APIID:  apiID,
-			Active: true,
-			Proxy:  ProxyConfig{TargetURL: baseTarget, ListenPath: listenPath},
-			VersionDefinition: VersionDefinition{
-				Location:  "url",
-				Key:       "version",
-				StripPath: true,
-			},
-			VersionData: VersionData{
-				NotVersioned:   false,
-				DefaultVersion: v1,
-				Versions: map[string]VersionInfo{
-					v1: {
-						Expires: exp1,
-					},
-					v2: {
-						Expires: exp2,
-					},
+var testV1ExtendedPaths = ExtendedPathsSet{
+	WhiteList: []EndPointMeta{
+		{Method: http.MethodGet, Path: "/get1"},
+	},
+}
+
+var testV2ExtendedPaths = ExtendedPathsSet{
+	WhiteList: []EndPointMeta{
+		{Method: http.MethodGet, Path: "/get2"},
+	},
+}
+
+func oldTestAPI() APIDefinition {
+	return APIDefinition{
+		Id:     dbID,
+		APIID:  apiID,
+		Active: true,
+		Proxy:  ProxyConfig{TargetURL: baseTarget, ListenPath: listenPath},
+		VersionDefinition: VersionDefinition{
+			Location:  URLLocation,
+			Key:       key,
+			StripPath: true,
+		},
+		VersionData: VersionData{
+			NotVersioned:   false,
+			DefaultVersion: v1,
+			Versions: map[string]VersionInfo{
+				v1: {
+					Expires:          exp1,
+					UseExtendedPaths: true,
+					ExtendedPaths:    testV1ExtendedPaths,
+				},
+				v2: {
+					Expires:          exp2,
+					UseExtendedPaths: true,
+					ExtendedPaths:    testV2ExtendedPaths,
 				},
 			},
-		}
+		},
 	}
+}
 
-	base := old()
+func TestAPIDefinition_MigrateVersioning(t *testing.T) {
+	base := oldTestAPI()
 	versions, err := base.MigrateVersioning()
 	assert.NoError(t, err)
 
 	expectedBase := base
 	expectedBase.Expiration = exp1
-	expectedBase.VersionData.NotVersioned = true
-	expectedBase.VersionData.DefaultVersion = ""
-	expectedBase.VersionData.Versions = map[string]VersionInfo{
-		"": {
-			Name:           "",
-			Expires:        "",
-			OverrideTarget: "",
+	expectedBase.VersionData = VersionData{
+		NotVersioned: true,
+		Versions: map[string]VersionInfo{
+			"": {
+				UseExtendedPaths: true,
+				ExtendedPaths:    testV1ExtendedPaths,
+			},
 		},
 	}
-
-	expectedBase.VersionDefinition.Enabled = true
-	expectedBase.VersionDefinition.Name = v1
-	expectedBase.VersionDefinition.Default = Self
-	expectedBase.VersionDefinition.Versions = map[string]string{
-		v2: versions[0].APIID,
+	expectedBase.VersionDefinition = VersionDefinition{
+		Enabled:             true,
+		Name:                v1,
+		Default:             Self,
+		Location:            URLLocation,
+		Key:                 key,
+		StripVersioningData: true,
+		Versions: map[string]string{
+			v2: versions[0].APIID,
+		},
 	}
 
 	assert.Equal(t, expectedBase, base)
 
-	expectedVersion := old()
+	expectedVersion := oldTestAPI()
 	expectedVersion.Id = ""
-	expectedVersion.APIID = ""
+	expectedVersion.APIID = versions[0].APIID
 	expectedVersion.Name += "-" + v2
 	expectedVersion.Internal = true
 	expectedVersion.Expiration = exp2
 	expectedVersion.Proxy.ListenPath += "-" + v2 + "/"
 	expectedVersion.VersionDefinition = VersionDefinition{}
-	expectedVersion.VersionData.NotVersioned = true
-	expectedVersion.VersionData.DefaultVersion = ""
-	expectedVersion.VersionData.Versions = map[string]VersionInfo{
-		"": {},
+	expectedVersion.VersionData = VersionData{
+		NotVersioned: true,
+		Versions: map[string]VersionInfo{
+			"": {
+				UseExtendedPaths: true,
+				ExtendedPaths:    testV2ExtendedPaths,
+			},
+		},
 	}
 
 	assert.Len(t, versions, 1)
-	expectedVersion.APIID = versions[0].APIID
 	assert.Equal(t, expectedVersion, versions[0])
+}
 
-	t.Run("override target", func(t *testing.T) {
-		t.Run("base", func(t *testing.T) {
-			overrideTargetBase := old()
-			vInfo := overrideTargetBase.VersionData.Versions[v1]
-			vInfo.OverrideTarget = v1Target
-			overrideTargetBase.VersionData.Versions[v1] = vInfo
+func TestAPIDefinition_MigrateVersioning_Disabled(t *testing.T) {
+	base := oldTestAPI()
+	base.VersionData.NotVersioned = true
 
-			versions, err = overrideTargetBase.MigrateVersioning()
-			assert.NoError(t, err)
+	t.Run("multiple versions", func(t *testing.T) {
+		_, err := base.MigrateVersioning()
+		assert.EqualError(t, err, "not migratable - if not versioned, there should be just one version info in versions map")
+	})
 
-			expectedBase.Proxy.TargetURL = v1Target
+	delete(base.VersionData.Versions, v2)
 
-			expectedBase.VersionDefinition.Versions[v2] = versions[0].APIID
-			assert.Equal(t, expectedBase, overrideTargetBase)
+	t.Run("one version", func(t *testing.T) {
+		versions, err := base.MigrateVersioning()
+		assert.NoError(t, err)
+		assert.Nil(t, versions)
 
-			assert.Len(t, versions, 1)
-			expectedVersion.APIID = versions[0].APIID
-			assert.Equal(t, expectedVersion, versions[0])
-		})
+		expectedBaseDefinition := VersionDefinition{
+			Location:            URLLocation,
+			Key:                 key,
+			StripVersioningData: true,
+		}
 
-		t.Run("version", func(t *testing.T) {
-			overrideTargetBase := old()
-			vInfo := overrideTargetBase.VersionData.Versions[v2]
-			vInfo.OverrideTarget = v2Target
-			overrideTargetBase.VersionData.Versions[v2] = vInfo
+		assert.Equal(t, expectedBaseDefinition, base.VersionDefinition)
 
-			versions, err = overrideTargetBase.MigrateVersioning()
-			assert.NoError(t, err)
+		expectedBaseData := VersionData{
+			NotVersioned: true,
+			Versions: map[string]VersionInfo{
+				"": {
+					UseExtendedPaths: true,
+					ExtendedPaths:    testV1ExtendedPaths,
+				},
+			},
+		}
 
-			expectedBase.Proxy.TargetURL = baseTarget
-			expectedBase.VersionDefinition.Versions[v2] = versions[0].APIID
+		assert.Equal(t, expectedBaseData, base.VersionData)
+	})
+}
 
-			assert.Equal(t, expectedBase, overrideTargetBase)
+func TestAPIDefinition_MigrateVersioning_Expires(t *testing.T) {
+	t.Run("version enabled", func(t *testing.T) {
+		base := oldTestAPI()
+		versions, err := base.MigrateVersioning()
+		assert.NoError(t, err)
 
-			expectedVersion.Proxy.TargetURL = v2Target
-			assert.Len(t, versions, 1)
-			expectedVersion.APIID = versions[0].APIID
-			assert.Equal(t, expectedVersion, versions[0])
-		})
+		assert.Equal(t, base.Expiration, exp1)
+		assert.Equal(t, versions[0].Expiration, exp2)
 	})
 
 	t.Run("version disabled", func(t *testing.T) {
-		versionDisabledBase := old()
-		versionDisabledBase.VersionData.NotVersioned = true
+		base := oldTestAPI()
+		delete(base.VersionData.Versions, v2)
+		base.VersionData.NotVersioned = true
+		versions, err := base.MigrateVersioning()
+		assert.NoError(t, err)
+		assert.Empty(t, versions)
 
-		t.Run("multiple versions", func(t *testing.T) {
-			versions, err = versionDisabledBase.MigrateVersioning()
-			assert.EqualError(t, err, "not migratable - if not versioned, there should be just one version info in versions map")
-		})
+		assert.Equal(t, base.Expiration, "")
+		assert.Equal(t, base.VersionData.Versions[""].Expires, "")
+	})
+}
 
-		delete(versionDisabledBase.VersionData.Versions, v2)
+func TestAPIDefinition_MigrateVersioning_OverrideTarget(t *testing.T) {
+	t.Run("base", func(t *testing.T) {
+		base := oldTestAPI()
+		vInfo := base.VersionData.Versions[v1]
+		vInfo.OverrideTarget = v1Target
+		base.VersionData.Versions[v1] = vInfo
 
-		t.Run("one version", func(t *testing.T) {
-			versions, err = versionDisabledBase.MigrateVersioning()
-			assert.NoError(t, err)
-			assert.Nil(t, versions)
+		versions, err := base.MigrateVersioning()
+		assert.NoError(t, err)
 
-			expectedBase.Expiration = ""
-			expectedBase.VersionDefinition.Enabled = false
-			expectedBase.VersionDefinition.Name = ""
-			expectedBase.VersionDefinition.Default = ""
-			expectedBase.VersionDefinition.Versions = nil
+		assert.Equal(t, v1Target, base.Proxy.TargetURL)
+		assert.Equal(t, baseTarget, versions[0].Proxy.TargetURL)
+	})
 
-			assert.Len(t, expectedBase.VersionData.Versions, 1)
-			assert.Contains(t, expectedBase.VersionData.Versions, "")
+	t.Run("version", func(t *testing.T) {
+		base := oldTestAPI()
+		vInfo := base.VersionData.Versions[v2]
+		vInfo.OverrideTarget = v2Target
+		base.VersionData.Versions[v2] = vInfo
 
-			assert.Equal(t, expectedBase, versionDisabledBase)
-		})
+		versions, err := base.MigrateVersioning()
+		assert.NoError(t, err)
+
+		assert.Equal(t, baseTarget, base.Proxy.TargetURL)
+		assert.Equal(t, v2Target, versions[0].Proxy.TargetURL)
 	})
 }
 
 func TestAPIDefinition_MigrateVersioning_StripPath(t *testing.T) {
-	const (
-		v1 = "v1"
-		v2 = "v2"
-	)
-
 	old := func() APIDefinition {
 		return APIDefinition{
 			VersionDefinition: VersionDefinition{


### PR DESCRIPTION
This PR separates migration tests for code readability