### PR TITLE
[TT-4277] Not force default version before migration

### DIFF
--- a/apidef/migration.go
+++ b/apidef/migration.go
@@ -19,16 +19,36 @@ func (a *APIDefinition) MigrateVersioning() (versions []APIDefinition, err error
 		return nil, errors.New("not migratable - if not versioned, there should be just one version info in versions map")
 	}
 
-	if !a.VersionData.NotVersioned {
-		if _, ok := a.VersionData.Versions[a.VersionData.DefaultVersion]; !ok {
-			return nil, errors.New("not migratable - if versioned, default version should match one of the versions")
+	a.VersionDefinition.Enabled = !a.VersionData.NotVersioned
+	if a.VersionDefinition.Enabled {
+		a.VersionDefinition.Default = Self
+	}
+
+	base := a.VersionData.DefaultVersion
+	var baseVInfo VersionInfo
+	var found bool
+	if baseVInfo, found = a.VersionData.Versions[base]; !found {
+		a.VersionDefinition.Default = ""
+
+		var sortedVersionNames []string
+		for vName := range a.VersionData.Versions {
+			sortedVersionNames = append(sortedVersionNames, vName)
 		}
 
-		for vName, vInfo := range a.VersionData.Versions {
-			if a.VersionData.DefaultVersion == vName {
-				continue
-			}
+		sort.Strings(sortedVersionNames)
+		if len(sortedVersionNames) > 0 {
+			base = sortedVersionNames[0]
+		}
 
+		baseVInfo = a.VersionData.Versions[base]
+	}
+
+	delete(a.VersionData.Versions, base)
+
+	if a.VersionDefinition.Enabled {
+		a.VersionDefinition.Name = base
+
+		for vName, vInfo := range a.VersionData.Versions {
 			newAPI := *a
 
 			newID := uuid.NewV4()
@@ -38,72 +58,62 @@ func (a *APIDefinition) MigrateVersioning() (versions []APIDefinition, err error
 			newAPI.Id = ""
 			newAPI.Name += "-" + url.QueryEscape(vName)
 			newAPI.Internal = true
+			newAPI.Proxy.ListenPath = strings.TrimSuffix(newAPI.Proxy.ListenPath, "/") + "-" + url.QueryEscape(vName) + "/"
 			newAPI.VersionDefinition = VersionDefinition{}
-			newAPI.VersionData.NotVersioned = true
-			newAPI.VersionData.DefaultVersion = ""
 
+			// Version API Expires migration
+			newAPI.Expiration = vInfo.Expires
+			vInfo.Expires = ""
+
+			// Version API OverrideTarget migration
 			if vInfo.OverrideTarget != "" {
 				newAPI.Proxy.TargetURL = vInfo.OverrideTarget
 				vInfo.OverrideTarget = ""
 			}
 
-			newAPI.Proxy.ListenPath = strings.TrimSuffix(newAPI.Proxy.ListenPath, "/") + "-" + url.QueryEscape(vName) + "/"
-
-			newAPI.Expiration = vInfo.Expires
-			vInfo.Expires = ""
-
-			newAPI.VersionData.Versions = map[string]VersionInfo{
-				"": vInfo,
+			newAPI.VersionData = VersionData{
+				NotVersioned: true,
+				Versions: map[string]VersionInfo{
+					"": vInfo,
+				},
 			}
-
-			versions = append(versions, newAPI)
-			delete(a.VersionData.Versions, vName)
 
 			if a.VersionDefinition.Versions == nil {
 				a.VersionDefinition.Versions = make(map[string]string)
 			}
 
 			a.VersionDefinition.Versions[vName] = newAPI.APIID
+
+			versions = append(versions, newAPI)
 		}
 	}
 
-	a.VersionDefinition.Enabled = !a.VersionData.NotVersioned
-	if a.VersionDefinition.Enabled {
-		a.VersionDefinition.Default = Self
-		a.VersionDefinition.Name = a.VersionData.DefaultVersion
-	}
-
+	// Base API StripPath migration
 	if a.VersionDefinition.Location == URLLocation {
 		a.VersionDefinition.StripVersioningData = a.VersionDefinition.StripPath
 	}
 
 	a.VersionDefinition.StripPath = false
 
-	defaultVersionInfo := a.VersionData.Versions[a.VersionData.DefaultVersion]
-	if a.VersionData.NotVersioned {
-		for _, v := range a.VersionData.Versions {
-			defaultVersionInfo = v
-			a.VersionData.Versions = map[string]VersionInfo{}
-			break
-		}
+	// Base API Expires migration
+	if a.VersionDefinition.Enabled {
+		a.Expiration = baseVInfo.Expires
 	}
 
-	if defaultVersionInfo.OverrideTarget != "" {
-		a.Proxy.TargetURL = defaultVersionInfo.OverrideTarget
-		defaultVersionInfo.OverrideTarget = ""
+	baseVInfo.Expires = ""
+
+	// Base API OverrideTarget migration
+	if baseVInfo.OverrideTarget != "" {
+		a.Proxy.TargetURL = baseVInfo.OverrideTarget
+		baseVInfo.OverrideTarget = ""
 	}
 
-	if !a.VersionData.NotVersioned {
-		a.Expiration = defaultVersionInfo.Expires
+	a.VersionData = VersionData{
+		NotVersioned: true,
+		Versions: map[string]VersionInfo{
+			"": baseVInfo,
+		},
 	}
-
-	defaultVersionInfo.Expires = ""
-
-	a.VersionData.Versions[""] = defaultVersionInfo
-	delete(a.VersionData.Versions, a.VersionData.DefaultVersion)
-
-	a.VersionData.DefaultVersion = ""
-	a.VersionData.NotVersioned = true
 
 	return
 }

--- a/apidef/migration.go
+++ b/apidef/migration.go
@@ -30,17 +30,19 @@ func (a *APIDefinition) MigrateVersioning() (versions []APIDefinition, err error
 	if baseVInfo, found = a.VersionData.Versions[base]; !found {
 		a.VersionDefinition.Default = ""
 
-		var sortedVersionNames []string
-		for vName := range a.VersionData.Versions {
-			sortedVersionNames = append(sortedVersionNames, vName)
-		}
+		if baseVInfo, found = a.VersionData.Versions["Default"]; !found {
+			var sortedVersionNames []string
+			for vName := range a.VersionData.Versions {
+				sortedVersionNames = append(sortedVersionNames, vName)
+			}
 
-		sort.Strings(sortedVersionNames)
-		if len(sortedVersionNames) > 0 {
-			base = sortedVersionNames[0]
-		}
+			sort.Strings(sortedVersionNames)
+			if len(sortedVersionNames) > 0 {
+				base = sortedVersionNames[0]
+			}
 
-		baseVInfo = a.VersionData.Versions[base]
+			baseVInfo = a.VersionData.Versions[base]
+		}
 	}
 
 	delete(a.VersionData.Versions, base)

--- a/apidef/migration_test.go
+++ b/apidef/migration_test.go
@@ -198,6 +198,20 @@ func TestAPIDefinition_MigrateVersioning_DefaultEmpty(t *testing.T) {
 		},
 	}
 	assert.Equal(t, expectedV2Data, versions[0].VersionData)
+
+	t.Run("Default", func(t *testing.T) {
+		base = oldTestAPI()
+		base.VersionData.DefaultVersion = ""
+		base.VersionData.Versions["Default"] = base.VersionData.Versions[v1]
+		base.VersionData.Versions["Alpha"] = base.VersionData.Versions[v2]
+		delete(base.VersionData.Versions, v1)
+		delete(base.VersionData.Versions, v2)
+
+		versions, err = base.MigrateVersioning()
+		assert.NoError(t, err)
+
+		assert.Equal(t, expectedBaseData, base.VersionData)
+	})
 }
 
 func TestAPIDefinition_MigrateVersioning_Expires(t *testing.T) {


### PR DESCRIPTION
This PR is letting user to migrate a versioning enabled API which doesn't select a default.