### PR TITLE
[TT-3965] Return same error when default version info is not found in new versi…

### DIFF
--- a/gateway/mw_version_check.go
+++ b/gateway/mw_version_check.go
@@ -43,6 +43,10 @@ func (v *VersionCheck) ProcessRequest(w http.ResponseWriter, r *http.Request, _ 
 	}
 
 	if v.Spec.VersionDefinition.Enabled && targetVersion != apidef.Self && targetVersion != v.Spec.VersionDefinition.Name {
+		if targetVersion == "" {
+			return errors.New(string(VersionNotFound)), http.StatusForbidden
+		}
+
 		subVersionID := v.Spec.VersionDefinition.Versions[targetVersion]
 		handler, _, found := v.Gw.findInternalHttpHandlerByNameOrID(subVersionID)
 		if !found {


### PR DESCRIPTION
This PR makes sure that when default version info is not found the old versioning and new versioning are returning same errors and to make sure that it adds a detailed test with before/after migration.