### PR TITLE
[TT-4141] Set base as Default when there is no default is selected

### DIFF
--- a/apidef/migration.go
+++ b/apidef/migration.go
@@ -29,8 +29,8 @@ func (a *APIDefinition) MigrateVersioning() (versions []APIDefinition, err error
 	var found bool
 	if baseVInfo, found = a.VersionData.Versions[base]; !found {
 		a.VersionDefinition.Default = ""
-
-		if baseVInfo, found = a.VersionData.Versions["Default"]; !found {
+		base = "Default"
+		if baseVInfo, found = a.VersionData.Versions[base]; !found {
 			var sortedVersionNames []string
 			for vName := range a.VersionData.Versions {
 				sortedVersionNames = append(sortedVersionNames, vName)

--- a/apidef/migration_test.go
+++ b/apidef/migration_test.go
@@ -8,17 +8,18 @@ import (
 )
 
 const (
-	dbID       = "dbID"
-	apiID      = "apiID"
-	listenPath = "listenPath"
-	baseTarget = "base.com"
-	v1Target   = "v1.com"
-	v2Target   = "v2.com"
-	v1         = "v1"
-	v2         = "v2"
-	exp1       = "exp1"
-	exp2       = "exp2"
-	key        = "version"
+	dbID        = "dbID"
+	apiID       = "apiID"
+	listenPath  = "listenPath"
+	baseTarget  = "base.com"
+	baseAPIName = "base-api"
+	v1Target    = "v1.com"
+	v2Target    = "v2.com"
+	v1          = "v1"
+	v2          = "v2"
+	exp1        = "exp1"
+	exp2        = "exp2"
+	key         = "version"
 )
 
 var testV1ExtendedPaths = ExtendedPathsSet{
@@ -37,6 +38,7 @@ func oldTestAPI() APIDefinition {
 	return APIDefinition{
 		Id:     dbID,
 		APIID:  apiID,
+		Name:   baseAPIName,
 		Active: true,
 		Proxy:  ProxyConfig{TargetURL: baseTarget, ListenPath: listenPath},
 		VersionDefinition: VersionDefinition{
@@ -211,6 +213,9 @@ func TestAPIDefinition_MigrateVersioning_DefaultEmpty(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.Equal(t, expectedBaseData, base.VersionData)
+
+		assert.Len(t, versions, 1)
+		assert.Contains(t, versions[0].Name, baseAPIName+"-Alpha")
 	})
 }
 


### PR DESCRIPTION
This PR sets forgotten setting base API name while selecting `Default` as base when there is no `DefaultVersion` is set.