### PR TITLE
[TT-2332] modify auth token fetch to rely only on UseParam or UseCookie

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -767,7 +767,7 @@ func (b BaseMiddleware) getAuthToken(authType string, r *http.Request) (string, 
 	}
 
 	paramName := config.ParamName
-	if config.UseParam || paramName != "" {
+	if config.UseParam {
 		if paramName == "" {
 			paramName = defaultName
 		}
@@ -781,7 +781,7 @@ func (b BaseMiddleware) getAuthToken(authType string, r *http.Request) (string, 
 	}
 
 	cookieName := config.CookieName
-	if config.UseCookie || cookieName != "" {
+	if config.UseCookie {
 		if cookieName == "" {
 			cookieName = defaultName
 		}

--- a/gateway/mw_auth_key_test.go
+++ b/gateway/mw_auth_key_test.go
@@ -542,6 +542,8 @@ const multiAuthDef = `{
 	"auth": {
 		"auth_header_name": "authorization",
 		"param_name": "token",
+		"use_param": true,
+		"use_cookie": true,
 		"cookie_name": "oreo"
 	},
 	"version_data": {


### PR DESCRIPTION
https://tyktech.atlassian.net/browse/TT-2332
fix 
`authConfig.authToken.useCookie` is ignored when `cookieName` is not empty
`authConfig.authToken.useParam` is ignored when `paramName` is not empty