### PR TITLE
git checkout . after fix vendor in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,7 @@ jobs:
           rm -rf vendor
           mkdir -p /go/src/github.com/TykTechnologies/tyk
           cp -r ./* /go/src/github.com/TykTechnologies/tyk
+          git checkout .
 
       - uses: goreleaser/goreleaser-action@v2
         with:


### PR DESCRIPTION
go release throws dirty git state after `go mod tidy`
https://github.com/TykTechnologies/tyk/runs/4787073278?check_suite_focus=true