### PR TITLE
[TT-376] Import swagger paths in old whitelist format + track endpoint

### DIFF
--- a/apidef/importer/importer_test.go
+++ b/apidef/importer/importer_test.go
@@ -3,6 +3,8 @@ package importer
 import (
 	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestToAPIDefinition_Swagger(t *testing.T) {
@@ -37,10 +39,10 @@ func TestToAPIDefinition_Swagger(t *testing.T) {
 		t.Fatal("Version could not be found")
 	}
 
-	if len(v.ExtendedPaths.TrackEndpoints) != 3 {
-		t.Fatalf("Expected 3 endpoints, found %v\n", len(v.ExtendedPaths.TrackEndpoints))
-	}
+	assert.Len(t, v.ExtendedPaths.WhiteList, 2)
 
+	assert.Len(t, v.ExtendedPaths.WhiteList[0].MethodActions, 2)
+	assert.Len(t, v.ExtendedPaths.WhiteList[1].MethodActions, 1)
 }
 
 var petstoreJSON string = `{

--- a/apidef/importer/importer_test.go
+++ b/apidef/importer/importer_test.go
@@ -39,10 +39,10 @@ func TestToAPIDefinition_Swagger(t *testing.T) {
 		t.Fatal("Version could not be found")
 	}
 
+	assert.Len(t, v.ExtendedPaths.TrackEndpoints, 3)
 	assert.Len(t, v.ExtendedPaths.WhiteList, 2)
 
-	assert.Len(t, v.ExtendedPaths.WhiteList[0].MethodActions, 2)
-	assert.Len(t, v.ExtendedPaths.WhiteList[1].MethodActions, 1)
+	assert.Equal(t, len(v.ExtendedPaths.WhiteList[0].MethodActions)+len(v.ExtendedPaths.WhiteList[1].MethodActions), 3)
 }
 
 var petstoreJSON string = `{

--- a/apidef/importer/swagger.go
+++ b/apidef/importer/swagger.go
@@ -93,9 +93,13 @@ func (s *SwaggerAST) ConvertIntoApiVersion(asMock bool) (apidef.VersionInfo, err
 		return versionInfo, errors.New("no paths defined in swagger file")
 	}
 	for pathName, pathSpec := range s.Paths {
-		newEndpointMeta := apidef.EndPointMeta{
+		whitelistMeta := apidef.EndPointMeta{
 			Path:          pathName,
 			MethodActions: map[string]apidef.EndpointMethodMeta{},
+		}
+
+		trackMeta := apidef.TrackEndpointMeta{
+			Path: pathName,
 		}
 
 		// We just want the paths here, no mocks
@@ -115,12 +119,16 @@ func (s *SwaggerAST) ConvertIntoApiVersion(asMock bool) (apidef.VersionInfo, err
 				continue
 			}
 
-			newEndpointMeta.MethodActions[methodName] = apidef.EndpointMethodMeta{
+			whitelistMeta.MethodActions[methodName] = apidef.EndpointMethodMeta{
 				Action: apidef.NoAction,
 				Code:   http.StatusOK,
 			}
+
+			trackMeta.Method = methodName
+			versionInfo.ExtendedPaths.TrackEndpoints = append(versionInfo.ExtendedPaths.TrackEndpoints, trackMeta)
 		}
-		versionInfo.ExtendedPaths.WhiteList = append(versionInfo.ExtendedPaths.WhiteList, newEndpointMeta)
+
+		versionInfo.ExtendedPaths.WhiteList = append(versionInfo.ExtendedPaths.WhiteList, whitelistMeta)
 	}
 
 	return versionInfo, nil


### PR DESCRIPTION
This PR adds track endpoint as another default plugin for imported swagger documentation paths along with whitelist plugin. Note that this PR uses old whitelist configuration. The new configuration will be released with version 5 and in that version the import functionality will have more features and for that reason the new import functionality will be implemented separately. This is for old APIs before OAS features.