### PR TITLE
fix depth limits for graphql introspection queries (TT-3314)

### DIFF
--- a/gateway/mw_graphql_complexity_test.go
+++ b/gateway/mw_graphql_complexity_test.go
@@ -213,7 +213,7 @@ func TestGraphQLComplexityMiddleware_DepthLimitExceeded(t *testing.T) {
 		{
 			name:          "should allow silent introspection query and ignore depth limit",
 			operationName: "",
-			query:         gqlCountriesTypeIntrospectionQuery,
+			query:         gqlCountriesSilentTypeIntrospectionQuery,
 			accessDef: &user.AccessDefinition{
 				Limit:             user.APILimit{MaxQueryDepth: 1},
 				FieldAccessRights: []user.FieldAccessDefinition{},

--- a/gateway/mw_graphql_complexity_test.go
+++ b/gateway/mw_graphql_complexity_test.go
@@ -60,14 +60,16 @@ func TestGraphQLComplexityMiddleware_DepthLimitExceeded(t *testing.T) {
 	}`
 
 	cases := []struct {
-		name      string
-		query     string
-		accessDef *user.AccessDefinition
-		result    ComplexityFailReason
+		name          string
+		operationName string
+		query         string
+		accessDef     *user.AccessDefinition
+		result        ComplexityFailReason
 	}{
 		{
-			name:  "should use global limit and exceed when no per field rights",
-			query: countriesQuery,
+			name:          "should use global limit and exceed when no per field rights",
+			operationName: "TestQuery",
+			query:         countriesQuery,
 			accessDef: &user.AccessDefinition{
 				Limit:             user.APILimit{MaxQueryDepth: 3},
 				FieldAccessRights: []user.FieldAccessDefinition{},
@@ -75,8 +77,9 @@ func TestGraphQLComplexityMiddleware_DepthLimitExceeded(t *testing.T) {
 			result: ComplexityFailReasonDepthLimitExceeded,
 		},
 		{
-			name:  "should respect unlimited specific field depth limit and not exceed",
-			query: countriesQuery,
+			name:          "should respect unlimited specific field depth limit and not exceed",
+			operationName: "TestQuery",
+			query:         countriesQuery,
 			accessDef: &user.AccessDefinition{
 				Limit: user.APILimit{MaxQueryDepth: 3},
 				FieldAccessRights: []user.FieldAccessDefinition{
@@ -89,8 +92,9 @@ func TestGraphQLComplexityMiddleware_DepthLimitExceeded(t *testing.T) {
 			result: ComplexityFailReasonNone,
 		},
 		{
-			name:  "should respect higher specific field depth limit and not exceed",
-			query: countriesQuery,
+			name:          "should respect higher specific field depth limit and not exceed",
+			operationName: "TestQuery",
+			query:         countriesQuery,
 			accessDef: &user.AccessDefinition{
 				Limit: user.APILimit{MaxQueryDepth: 3},
 				FieldAccessRights: []user.FieldAccessDefinition{
@@ -103,8 +107,9 @@ func TestGraphQLComplexityMiddleware_DepthLimitExceeded(t *testing.T) {
 			result: ComplexityFailReasonNone,
 		},
 		{
-			name:  "should respect lower specific field depth limit and exceed",
-			query: countriesQuery,
+			name:          "should respect lower specific field depth limit and exceed",
+			operationName: "TestQuery",
+			query:         countriesQuery,
 			accessDef: &user.AccessDefinition{
 				Limit: user.APILimit{MaxQueryDepth: 100},
 				FieldAccessRights: []user.FieldAccessDefinition{
@@ -117,8 +122,9 @@ func TestGraphQLComplexityMiddleware_DepthLimitExceeded(t *testing.T) {
 			result: ComplexityFailReasonDepthLimitExceeded,
 		},
 		{
-			name:  "should respect specific field depth limits and not exceed",
-			query: countriesContinentsQuery,
+			name:          "should respect specific field depth limits and not exceed",
+			operationName: "TestQuery",
+			query:         countriesContinentsQuery,
 			accessDef: &user.AccessDefinition{
 				Limit: user.APILimit{MaxQueryDepth: 1},
 				FieldAccessRights: []user.FieldAccessDefinition{
@@ -135,8 +141,9 @@ func TestGraphQLComplexityMiddleware_DepthLimitExceeded(t *testing.T) {
 			result: ComplexityFailReasonNone,
 		},
 		{
-			name:  "should fallback to global limit when continents limits is not specified",
-			query: countriesContinentsQuery,
+			name:          "should fallback to global limit when continents limits is not specified",
+			operationName: "TestQuery",
+			query:         countriesContinentsQuery,
 			accessDef: &user.AccessDefinition{
 				Limit: user.APILimit{MaxQueryDepth: 1},
 				FieldAccessRights: []user.FieldAccessDefinition{
@@ -149,8 +156,9 @@ func TestGraphQLComplexityMiddleware_DepthLimitExceeded(t *testing.T) {
 			result: ComplexityFailReasonDepthLimitExceeded,
 		},
 		{
-			name:  "should fallback to global limit when countries limits is not specified",
-			query: countriesContinentsQuery,
+			name:          "should fallback to global limit when countries limits is not specified",
+			operationName: "TestQuery",
+			query:         countriesContinentsQuery,
 			accessDef: &user.AccessDefinition{
 				Limit: user.APILimit{MaxQueryDepth: 1},
 				FieldAccessRights: []user.FieldAccessDefinition{
@@ -162,12 +170,72 @@ func TestGraphQLComplexityMiddleware_DepthLimitExceeded(t *testing.T) {
 			},
 			result: ComplexityFailReasonDepthLimitExceeded,
 		},
+		{
+			name:          "should allow schema introspection query and ignore depth limit",
+			operationName: "IntrospectionQuery",
+			query:         gqlIntrospectionQuery,
+			accessDef: &user.AccessDefinition{
+				Limit:             user.APILimit{MaxQueryDepth: 1},
+				FieldAccessRights: []user.FieldAccessDefinition{},
+			},
+			result: ComplexityFailReasonNone,
+		},
+		{
+			name:          "should disallow schema introspection query and apply depth-limit with other non-introspection fields",
+			operationName: "IntrospectionQuery",
+			query:         gqlSchemaIntrospectionQueryWithMultipleFields,
+			accessDef: &user.AccessDefinition{
+				Limit:             user.APILimit{MaxQueryDepth: 1},
+				FieldAccessRights: []user.FieldAccessDefinition{},
+			},
+			result: ComplexityFailReasonDepthLimitExceeded,
+		},
+		{
+			name:          "should allow type introspection query and ignore depth limit",
+			operationName: "IntrospectionQuery",
+			query:         gqlCountriesTypeIntrospectionQuery,
+			accessDef: &user.AccessDefinition{
+				Limit:             user.APILimit{MaxQueryDepth: 1},
+				FieldAccessRights: []user.FieldAccessDefinition{},
+			},
+			result: ComplexityFailReasonNone,
+		},
+		{
+			name:          "should disallow type introspection query and apply depth-limit with other non-introspection fields",
+			operationName: "IntrospectionQuery",
+			query:         gqlCountriesTypeIntrospectionQueryWithMultipleFields,
+			accessDef: &user.AccessDefinition{
+				Limit:             user.APILimit{MaxQueryDepth: 1},
+				FieldAccessRights: []user.FieldAccessDefinition{},
+			},
+			result: ComplexityFailReasonDepthLimitExceeded,
+		},
+		{
+			name:          "should allow silent introspection query and ignore depth limit",
+			operationName: "",
+			query:         gqlCountriesTypeIntrospectionQuery,
+			accessDef: &user.AccessDefinition{
+				Limit:             user.APILimit{MaxQueryDepth: 1},
+				FieldAccessRights: []user.FieldAccessDefinition{},
+			},
+			result: ComplexityFailReasonNone,
+		},
+		{
+			name:          "should return error when complexity fails because of internal reasons",
+			operationName: "TestQuery",
+			query:         gqlInvalidCountriesQuery,
+			accessDef: &user.AccessDefinition{
+				Limit:             user.APILimit{MaxQueryDepth: 1},
+				FieldAccessRights: []user.FieldAccessDefinition{},
+			},
+			result: ComplexityFailReasonInternalError,
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			req := &graphql.Request{
-				OperationName: "TestQuery",
+				OperationName: tc.operationName,
 				Variables:     nil,
 				Query:         tc.query,
 			}
@@ -262,3 +330,73 @@ func TestGraphQLComplexityMiddleware_ProcessRequest_GraphqlLimits(t *testing.T) 
 		})
 	}
 }
+
+const gqlSchemaIntrospectionQueryWithMultipleFields = `query IntrospectionQuery {
+  countries {
+    name
+    continent {
+      code
+      name
+      countries {
+        code
+      }
+    }
+  }
+  __schema {
+    queryType {
+      name
+    }
+  }
+}`
+
+const gqlCountriesTypeIntrospectionQuery = `query IntrospectionQuery {
+  __type(name:"Country") {
+    name
+    fields {
+      name
+      type {
+        kind
+      }
+    }
+  }
+}`
+
+const gqlCountriesSilentTypeIntrospectionQuery = `{
+  __type(name:"Country") {
+    name
+    fields {
+      name
+      type {
+        kind
+      }
+    }
+  }
+}`
+
+const gqlCountriesTypeIntrospectionQueryWithMultipleFields = `query IntrospectionQuery {
+  countries {
+    name
+    continent {
+      code
+      name
+      countries {
+        code
+      }
+    }
+  }
+  __type(name:"Country") {
+    name
+  }
+}`
+
+const gqlInvalidCountriesQuery = `{
+  countries {
+    name
+    continent {
+      code
+      name
+      countries {
+        code
+      }
+    }
+}`

--- a/go.mod
+++ b/go.mod
@@ -97,6 +97,6 @@ require (
 	rsc.io/letsencrypt v0.0.2
 )
 
-replace github.com/jensneuse/graphql-go-tools => github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220117135208-c085bfdb3cf3
+replace github.com/jensneuse/graphql-go-tools => github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220119122148-1d614c799cd9
 
 //replace github.com/jensneuse/graphql-go-tools => ../graphql-go-tools

--- a/go.mod
+++ b/go.mod
@@ -97,6 +97,6 @@ require (
 	rsc.io/letsencrypt v0.0.2
 )
 
-replace github.com/jensneuse/graphql-go-tools => github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20211213120648-56cd4003725b
+replace github.com/jensneuse/graphql-go-tools => github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220117135208-c085bfdb3cf3
 
 //replace github.com/jensneuse/graphql-go-tools => ../graphql-go-tools

--- a/go.mod
+++ b/go.mod
@@ -97,6 +97,6 @@ require (
 	rsc.io/letsencrypt v0.0.2
 )
 
-replace github.com/jensneuse/graphql-go-tools => github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220119122148-1d614c799cd9
+replace github.com/jensneuse/graphql-go-tools => github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220119145137-4e314b1ec0e1
 
 //replace github.com/jensneuse/graphql-go-tools => ../graphql-go-tools

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/TykTechnologies/gorpc v0.0.0-20190515174534-b9c10befc5f4 h1:hTjM5Uubg
 github.com/TykTechnologies/gorpc v0.0.0-20190515174534-b9c10befc5f4/go.mod h1:vqhQRhIHefD4jdFo55j+m0vD5NMjx2liq/ubnshQpaY=
 github.com/TykTechnologies/goverify v0.0.0-20160822133757-7ccc57452ade h1:tFUV86NDnfMY4Au+EJHGJx0Rton8xdOLEh1aT+j6XBk=
 github.com/TykTechnologies/goverify v0.0.0-20160822133757-7ccc57452ade/go.mod h1:mkS8jKcz8otdfEXhJs1QQ/DKoIY1NFFsRPKS0RwQENI=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220117135208-c085bfdb3cf3 h1:cuiaVgTCbCM5XFmjkMPoPHEBFnYI+JVo3LE/rT74h3k=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220117135208-c085bfdb3cf3/go.mod h1:LBH1NWaQi0EnxGuJhWzhSZPpgtLkELZu+Hr8KH/Wn1E=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220119122148-1d614c799cd9 h1:iunJ544UzUY+TaUuc6J+87N/oL5a0a0xcnGHRXzZgrQ=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220119122148-1d614c799cd9/go.mod h1:LBH1NWaQi0EnxGuJhWzhSZPpgtLkELZu+Hr8KH/Wn1E=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c h1:j6fd0Fz1R4oSWOmcooGjrdahqrML+btQ+PfEJw8SzbA=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c/go.mod h1:GnHUbsQx+ysI10osPhUdTmsxcE7ef64cVp38Fdyd7e0=
 github.com/TykTechnologies/murmur3 v0.0.0-20180602122059-1915e687e465 h1:A2gBjoX8aF0G3GHEpHyj2f0ixuPkCgcGqmPdKHSkW+0=

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/TykTechnologies/gorpc v0.0.0-20190515174534-b9c10befc5f4 h1:hTjM5Uubg
 github.com/TykTechnologies/gorpc v0.0.0-20190515174534-b9c10befc5f4/go.mod h1:vqhQRhIHefD4jdFo55j+m0vD5NMjx2liq/ubnshQpaY=
 github.com/TykTechnologies/goverify v0.0.0-20160822133757-7ccc57452ade h1:tFUV86NDnfMY4Au+EJHGJx0Rton8xdOLEh1aT+j6XBk=
 github.com/TykTechnologies/goverify v0.0.0-20160822133757-7ccc57452ade/go.mod h1:mkS8jKcz8otdfEXhJs1QQ/DKoIY1NFFsRPKS0RwQENI=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220119122148-1d614c799cd9 h1:iunJ544UzUY+TaUuc6J+87N/oL5a0a0xcnGHRXzZgrQ=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220119122148-1d614c799cd9/go.mod h1:LBH1NWaQi0EnxGuJhWzhSZPpgtLkELZu+Hr8KH/Wn1E=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220119145137-4e314b1ec0e1 h1:MDIX1xjWv+aU7YH4hGBYYX2duUoaN0BZd8BNtfNwHmA=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220119145137-4e314b1ec0e1/go.mod h1:Zlt/B6ixQqmyBTu6HB2uWNOgCM8vIJ5G458pQARFlAk=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c h1:j6fd0Fz1R4oSWOmcooGjrdahqrML+btQ+PfEJw8SzbA=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c/go.mod h1:GnHUbsQx+ysI10osPhUdTmsxcE7ef64cVp38Fdyd7e0=
 github.com/TykTechnologies/murmur3 v0.0.0-20180602122059-1915e687e465 h1:A2gBjoX8aF0G3GHEpHyj2f0ixuPkCgcGqmPdKHSkW+0=
@@ -195,6 +195,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/TykTechnologies/gorpc v0.0.0-20190515174534-b9c10befc5f4 h1:hTjM5Uubg
 github.com/TykTechnologies/gorpc v0.0.0-20190515174534-b9c10befc5f4/go.mod h1:vqhQRhIHefD4jdFo55j+m0vD5NMjx2liq/ubnshQpaY=
 github.com/TykTechnologies/goverify v0.0.0-20160822133757-7ccc57452ade h1:tFUV86NDnfMY4Au+EJHGJx0Rton8xdOLEh1aT+j6XBk=
 github.com/TykTechnologies/goverify v0.0.0-20160822133757-7ccc57452ade/go.mod h1:mkS8jKcz8otdfEXhJs1QQ/DKoIY1NFFsRPKS0RwQENI=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20211213120648-56cd4003725b h1:Fcrmoqkp3i/AzXl2JCQ4y0kxXyC9boa6EMwSv6WoQVk=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20211213120648-56cd4003725b/go.mod h1:LBH1NWaQi0EnxGuJhWzhSZPpgtLkELZu+Hr8KH/Wn1E=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220117135208-c085bfdb3cf3 h1:cuiaVgTCbCM5XFmjkMPoPHEBFnYI+JVo3LE/rT74h3k=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220117135208-c085bfdb3cf3/go.mod h1:LBH1NWaQi0EnxGuJhWzhSZPpgtLkELZu+Hr8KH/Wn1E=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c h1:j6fd0Fz1R4oSWOmcooGjrdahqrML+btQ+PfEJw8SzbA=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c/go.mod h1:GnHUbsQx+ysI10osPhUdTmsxcE7ef64cVp38Fdyd7e0=
 github.com/TykTechnologies/murmur3 v0.0.0-20180602122059-1915e687e465 h1:A2gBjoX8aF0G3GHEpHyj2f0ixuPkCgcGqmPdKHSkW+0=


### PR DESCRIPTION
This PR will fix the case, that introspection queries are not being executed when the depth limit is in-place.