### PR TITLE
Add matrix job for go1.15, go1.15-el7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,15 @@ env:
   
 jobs:
   goreleaser:
+    name: '${{ matrix.golang_cross }}'
     runs-on: ubuntu-latest
-
-    container: tykio/golang-cross:1.15.15
+    strategy:
+      fail-fast: false
+      matrix:
+        golang_cross: [1.15,1.15-el7]
+    container: 'tykio/golang-cross:${{ matrix.golang_cross }}'
+    env:
+      GOLANG_CROSS: ${{ matrix.golang_cross }}
 
     outputs:
       tag: ${{ steps.targets.outputs.tag }}
@@ -373,6 +379,10 @@ jobs:
       - smoke-tests
       - goreleaser
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        golang_cross: [1.15, 1.15-el7]
 
     steps:
       - uses: actions/download-artifact@v2
@@ -393,6 +403,8 @@ jobs:
         with:
           repo: tyk/${{ needs.goreleaser.outputs.pc }}
           dir: dist
+          rpmvers: ${{ matrix.golang_cross == '1.15-el7' && 'el/7' || 'el/8' }}
+          debvers: ${{ matrix.golang_cross == '1.15-el7' && "ubuntu/xenial debian/stretch" || "ubuntu/bionic ubuntu/focal debian/jessie" }}
 
       - name: Tell release channel
         if: always()

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -225,6 +225,7 @@ nfpms:
     maintainer: "Tyk <info@tyk.io>"
     description: Tyk API Gateway
     package_name: tyk-gateway
+    file_name_template: "{{ .PackageName }}-{{.Env.GOLANG_CROSS}}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
     builds:
 
       - std-linux


### PR DESCRIPTION
- Add matrix job for go1.15, go1.15-el7
- Remove darwin support
- Update filename format to have golang cross version in package name
- Provide target os versions on package cloud action