### PR TITLE
[TT-796] Trigger JSVM error when non-JS extension is used

### DIFF
--- a/gateway/mw_js_plugin.go
+++ b/gateway/mw_js_plugin.go
@@ -365,6 +365,11 @@ func (j *JSVM) LoadJSPaths(paths []string, prefix string) {
 		if prefix != "" {
 			mwPath = filepath.Join(prefix, mwPath)
 		}
+		extension := filepath.Ext(mwPath)
+		if !strings.Contains(extension, ".js") {
+			j.Log.Errorf("Unsupported extension '%s' (%s)", extension, mwPath)
+			continue
+		}
 		j.Log.Info("Loading JS File: ", mwPath)
 		f, err := os.Open(mwPath)
 		if err != nil {


### PR DESCRIPTION
Taken from #3365.

## Description

When a custom middleware block doesn't specify a driver, `jsvm` is picked as the default driver (this is expected behavior).

When a developer passes a native Go module path under this scenario, gateway CPU usage raises and the plugin fails to load, the reason is that JSVM tries to parse the native Go module. To mitigate this we added a simple extension check on #3365, this wasn't present in the release branch that reported this issue (2.9.4.3).

## Related Issue
#3365

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested
Manually tested using a native Go plugin with two types of custom middleware blocks:

- Valid scenario:
```json
{
    "name": "Tyk Test API",
    "api_id": "3",
    "org_id": "default",
    "definition": {
        "location": "",
        "key": ""
    },
    "use_keyless": true,
    "auth": {
        "auth_header_name": ""
    },
    "version_data": {
        "not_versioned": true,
        "versions": {
            "Default": {
                "name": "Default",
                "expires": "3000-01-02 15:04",
                "use_extended_paths": true,
                "extended_paths": {
                    "ignored": [],
                    "white_list": [],
                    "black_list": []
                }
            }
        }
    },
    "proxy": {
        "listen_path": "/quickstart/",
        "target_url": "http://httpbin.org/",
        "strip_listen_path": true
    },
    "custom_middleware": {
        "post": [
            {
              "name": "AddFooBarHeader",
              "path": "plugin/plugin.so"
            }
          ],
          "driver": "goplugin"
    },
    "do_not_track": true
}
```
- Invalid scenario:
```json
{
    "name": "Tyk Test API",
    "api_id": "3",
    "org_id": "default",
    "definition": {
        "location": "",
        "key": ""
    },
    "use_keyless": true,
    "auth": {
        "auth_header_name": ""
    },
    "version_data": {
        "not_versioned": true,
        "versions": {
            "Default": {
                "name": "Default",
                "expires": "3000-01-02 15:04",
                "use_extended_paths": true,
                "extended_paths": {
                    "ignored": [],
                    "white_list": [],
                    "black_list": []
                }
            }
        }
    },
    "proxy": {
        "listen_path": "/quickstart/",
        "target_url": "http://httpbin.org/",
        "strip_listen_path": true
    },
    "custom_middleware": {
        "post": [
            {
              "name": "AddFooBarHeader",
              "path": "plugin/plugin.so"
            }
          ],
          "driver": ""
    },
    "do_not_track": true
}
```

## Screenshots (if appropriate)
No screenshots

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [ ] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [x] `go vet`
