### PR TITLE
Fix metadata property type of session object in swagger.yml

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -2793,8 +2793,7 @@ components:
           type: string
           x-go-name: LastUpdated
         meta_data:
-          additionalProperties:
-            type: object
+          additionalProperties: {}
           type: object
           x-go-name: MetaData
         monitor:


### PR DESCRIPTION
# Fix for TykTechnologies#3876 wrong type for Metadata

## Description
The Metadata in the swagger.yml has the wrong type: TykTechnologies#3876

The generated value/type from the current object is map[string]map[string]interface, while it should be of type map[string]interface.

## Related Issue
TykTechnologies#3876