### PR TITLE
[TT-4785] Bump logrus, use logrus.TextFormatter (security)

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	prefixed "github.com/x-cray/logrus-prefixed-formatter"
 )
 
 var (
@@ -20,15 +19,16 @@ var (
 // example:   `{"foo": {"bar": "baz"}}`
 // flattened: `foo.bar: baz`
 func LoadTranslations(thing map[string]interface{}) {
-	formatter := new(prefixed.TextFormatter)
+	formatter := new(logrus.TextFormatter)
 	formatter.TimestampFormat = `Jan 02 15:04:05`
 	formatter.FullTimestamp = true
+
 	log.Formatter = &TranslationFormatter{formatter}
 	translations, _ = Flatten(thing)
 }
 
 type TranslationFormatter struct {
-	*prefixed.TextFormatter
+	*logrus.TextFormatter
 }
 
 func (t *TranslationFormatter) Format(entry *logrus.Entry) ([]byte, error) {
@@ -47,7 +47,7 @@ func (f *RawFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 }
 
 func init() {
-	formatter := new(prefixed.TextFormatter)
+	formatter := new(logrus.TextFormatter)
 	formatter.TimestampFormat = `Jan 02 15:04:05`
 	formatter.FullTimestamp = true
 

--- a/log/log.go
+++ b/log/log.go
@@ -22,6 +22,7 @@ func LoadTranslations(thing map[string]interface{}) {
 	formatter := new(logrus.TextFormatter)
 	formatter.TimestampFormat = `Jan 02 15:04:05`
 	formatter.FullTimestamp = true
+	formatter.DisableColors = true
 
 	log.Formatter = &TranslationFormatter{formatter}
 	translations, _ = Flatten(thing)
@@ -50,6 +51,7 @@ func init() {
 	formatter := new(logrus.TextFormatter)
 	formatter.TimestampFormat = `Jan 02 15:04:05`
 	formatter.FullTimestamp = true
+	formatter.DisableColors = true
 
 	log.Formatter = formatter
 	rawLog.Formatter = new(RawFormatter)

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -1,0 +1,19 @@
+package log_test
+
+import (
+	"testing"
+
+	logger "github.com/TykTechnologies/tyk/log"
+	"github.com/sirupsen/logrus"
+)
+
+func TestLogQuoting(t *testing.T) {
+	log := logger.Get()
+	log.Warnf("%s", "\rhello\n")
+	log.Warnf("%v", "\rhello\n")
+	log.Warnf("%q", "\rhello\n")
+
+	log.WithFields(logrus.Fields{
+		"text": "\rhello\n",
+	}).Info("hey")
+}

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -16,4 +16,12 @@ func TestLogQuoting(t *testing.T) {
 	log.WithFields(logrus.Fields{
 		"text": "\rhello\n",
 	}).Info("hey")
+
+	rawLog := logger.GetRaw()
+	rawLog.Info("\rhello\n")
+
+	logger.LoadTranslations(map[string]interface{}{
+		"foo": "bar",
+	})
+	log.WithField("code", "foo").Info("foo")
 }


### PR DESCRIPTION
The change adresses possible log overwrite issues with our logger - the standard logrus logger actually doesn't have this security issue, even without adding `ForceQuote` on fields. There's no way to enable it on the prefixed logger.

## Description

This change updates logrus to the current stable version, as well as removes the insecure package x-cray/logrus-prefixed-formatter. The change has been visually verified to resolve the possible security issue:

Before:

```
=== RUN   TestLogQuoting
hello07 09:45:55]  WARN 

hello07 09:45:55]  WARN 

[Mar 07 09:45:55]  WARN "\rhello\n"
```

After:

```
=== RUN   TestLogQuoting
time="Mar 08 12:44:45" level=warning msg="\rhello\n"
time="Mar 08 12:44:45" level=warning msg="\rhello\n"
time="Mar 08 12:44:45" level=warning msg="\"\\rhello\\n\""
time="Mar 08 12:44:45" level=info msg=hey text="\rhello\n"
--- PASS: TestLogQuoting (0.00s)
```

The test has been added to inspect this output, but doesn't actually test anything.

## Motivation and Context

This solves several if not all possible log escape issues, where a malicious actor could overwrite log entries.

## How This Has Been Tested

`make build` and `go test`.

## Screenshots (if appropriate)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [x] My change requires a change to the documentation.
  - [x] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [x] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [x] `go vet`

## Possible documentation update

In case people rely on the behaviour of the current prefixed textformatter, the usage patters will change due to the significantly different output here.