### PR TITLE
Move auth type constants to apidef package

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -89,6 +89,12 @@ const (
 	Self = "self"
 
 	AuthTokenType = "authToken"
+	JWTType       = "jwt"
+	HMACType      = "hmac"
+	BasicType     = "basic"
+	CoprocessType = "coprocess"
+	OAuthType     = "oauth"
+	OIDCType      = "oidc"
 )
 
 type ObjectId bson.ObjectId

--- a/gateway/auth_manager_test.go
+++ b/gateway/auth_manager_test.go
@@ -154,7 +154,7 @@ func TestHashKeyFunctionChanged(t *testing.T) {
 		spec.Proxy.ListenPath = "/"
 		spec.UseKeylessAccess = false
 		spec.AuthConfigs = map[string]apidef.AuthConfig{
-			authTokenType: {UseCertificate: false},
+			apidef.AuthTokenType: {UseCertificate: false},
 		}
 	})[0]
 
@@ -196,7 +196,7 @@ func TestHashKeyFunctionChanged(t *testing.T) {
 	t.Run("basic auth key", func(t *testing.T) {
 		api.UseBasicAuth = true
 		api.AuthConfigs = map[string]apidef.AuthConfig{
-			authTokenType: {UseCertificate: true},
+			apidef.AuthTokenType: {UseCertificate: true},
 		}
 		ts.Gw.LoadAPI(api)
 		globalConf = ts.Gw.GetConfig()
@@ -222,7 +222,7 @@ func TestHashKeyFunctionChanged(t *testing.T) {
 	t.Run("client certificate", func(t *testing.T) {
 		api.UseBasicAuth = false
 		api.AuthConfigs = map[string]apidef.AuthConfig{
-			authTokenType: {UseCertificate: true},
+			apidef.AuthTokenType: {UseCertificate: true},
 		}
 		ts.Gw.LoadAPI(api)
 		session := CreateStandardSession()

--- a/gateway/cert.go
+++ b/gateway/cert.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/TykTechnologies/tyk/apidef"
+
 	"github.com/TykTechnologies/tyk/certs"
 	"github.com/TykTechnologies/tyk/config"
 
@@ -377,7 +379,7 @@ func (gw *Gateway) getTLSConfigForClient(baseConfig *tls.Config, listenPort int)
 						}
 					}
 				}
-			case spec.AuthConfigs[authTokenType].UseCertificate:
+			case spec.AuthConfigs[apidef.AuthTokenType].UseCertificate:
 				// Dynamic certificate check required, falling back to HTTP level check
 				// TODO: Change to VerifyPeerCertificate hook instead, when possible
 				if domainRequireCert[spec.Domain] < tls.RequestClientCert {

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -862,7 +862,7 @@ func TestKeyWithCertificateTLS(t *testing.T) {
 			spec.UseKeylessAccess = false
 			spec.BaseIdentityProvidedBy = apidef.AuthToken
 			spec.AuthConfigs = map[string]apidef.AuthConfig{
-				authTokenType: {UseCertificate: true},
+				apidef.AuthTokenType: {UseCertificate: true},
 			}
 			spec.Proxy.ListenPath = "/"
 			spec.OrgID = orgId
@@ -918,7 +918,7 @@ func TestKeyWithCertificateTLS(t *testing.T) {
 				spec.UseKeylessAccess = false
 				spec.BaseIdentityProvidedBy = apidef.AuthToken
 				spec.AuthConfigs = map[string]apidef.AuthConfig{
-					authTokenType: {UseCertificate: true},
+					apidef.AuthTokenType: {UseCertificate: true},
 				}
 				spec.Proxy.ListenPath = "/test1"
 				spec.OrgID = orgId
@@ -994,7 +994,7 @@ func TestKeyWithCertificateTLS(t *testing.T) {
 				spec.UseKeylessAccess = false
 				spec.BaseIdentityProvidedBy = apidef.AuthToken
 				spec.AuthConfigs = map[string]apidef.AuthConfig{
-					authTokenType: {UseCertificate: true},
+					apidef.AuthTokenType: {UseCertificate: true},
 				}
 				spec.Proxy.ListenPath = "/test1"
 				spec.OrgID = orgId
@@ -1033,7 +1033,7 @@ func TestKeyWithCertificateTLS(t *testing.T) {
 			spec.UseKeylessAccess = false
 			spec.BaseIdentityProvidedBy = apidef.AuthToken
 			spec.AuthConfigs = map[string]apidef.AuthConfig{
-				authTokenType: {UseCertificate: true},
+				apidef.AuthTokenType: {UseCertificate: true},
 			}
 			spec.Proxy.ListenPath = "/"
 			spec.OrgID = orgId
@@ -1070,7 +1070,7 @@ func TestKeyWithCertificateTLS(t *testing.T) {
 			spec.UseKeylessAccess = false
 			spec.BaseIdentityProvidedBy = apidef.AuthToken
 			spec.AuthConfigs = map[string]apidef.AuthConfig{
-				authTokenType: {UseCertificate: true},
+				apidef.AuthTokenType: {UseCertificate: true},
 			}
 			spec.Proxy.ListenPath = "/"
 			spec.OrgID = orgId

--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -310,7 +310,7 @@ func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 	logger := m.Logger()
 	logger.Debug("CoProcess Request, HookType: ", m.HookType)
 	originalURL := r.URL
-	authToken, _ := m.getAuthToken(coprocessType, r)
+	authToken, _ := m.getAuthToken(apidef.CoprocessType, r)
 
 	var extractor IdExtractor
 	if m.Spec.EnableCoProcessAuth && m.Spec.CustomMiddleware.IdExtractor.Extractor != nil {
@@ -521,7 +521,7 @@ func (h *CustomMiddlewareResponseHook) Init(mwDef interface{}, spec *APISpec) er
 
 // getAuthType overrides BaseMiddleware.getAuthType.
 func (m *CoProcessMiddleware) getAuthType() string {
-	return coprocessType
+	return apidef.CoprocessType
 }
 
 func (h *CustomMiddlewareResponseHook) Name() string {

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -1931,7 +1931,7 @@ func TestTracing(t *testing.T) {
 
 	t.Run("Custom auth header", func(t *testing.T) {
 		spec.AuthConfigs = map[string]apidef.AuthConfig{
-			authTokenType: {
+			apidef.AuthTokenType: {
 				AuthHeaderName: "Custom-Auth-Header",
 			},
 		}

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -31,14 +31,6 @@ import (
 
 const mwStatusRespond = 666
 
-const authTokenType = "authToken"
-const jwtType = "jwt"
-const hmacType = "hmac"
-const basicType = "basic"
-const coprocessType = "coprocess"
-const oauthType = "oauth"
-const oidcType = "oidc"
-
 var (
 	GlobalRate            = ratecounter.NewRateCounter(1 * time.Second)
 	orgSessionExpiryCache singleflight.Group
@@ -754,7 +746,7 @@ func (b BaseMiddleware) getAuthType() string {
 func (b BaseMiddleware) getAuthToken(authType string, r *http.Request) (string, apidef.AuthConfig) {
 	config, ok := b.Base().Spec.AuthConfigs[authType]
 	// Auth is deprecated. To maintain backward compatibility authToken and jwt cases are added.
-	if !ok && (authType == authTokenType || authType == jwtType) {
+	if !ok && (authType == apidef.AuthTokenType || authType == apidef.JWTType) {
 		config = b.Base().Spec.Auth
 	}
 

--- a/gateway/middleware_test.go
+++ b/gateway/middleware_test.go
@@ -93,13 +93,13 @@ func TestBaseMiddleware_getAuthType(t *testing.T) {
 	oidc := &OpenIDMW{BaseMiddleware: baseMid}
 
 	// test getAuthType
-	assert.Equal(t, authTokenType, authKey.getAuthType())
-	assert.Equal(t, basicType, basic.getAuthType())
-	assert.Equal(t, coprocessType, coprocess.getAuthType())
-	assert.Equal(t, hmacType, hmac.getAuthType())
-	assert.Equal(t, jwtType, jwt.getAuthType())
-	assert.Equal(t, oauthType, oauth.getAuthType())
-	assert.Equal(t, oidcType, oidc.getAuthType())
+	assert.Equal(t, apidef.AuthTokenType, authKey.getAuthType())
+	assert.Equal(t, apidef.BasicType, basic.getAuthType())
+	assert.Equal(t, apidef.CoprocessType, coprocess.getAuthType())
+	assert.Equal(t, apidef.HMACType, hmac.getAuthType())
+	assert.Equal(t, apidef.JWTType, jwt.getAuthType())
+	assert.Equal(t, apidef.OAuthType, oauth.getAuthType())
+	assert.Equal(t, apidef.OIDCType, oidc.getAuthType())
 
 	// test getAuthToken
 	getToken := func(authType string, getAuthToken func(authType string, r *http.Request) (string, apidef.AuthConfig)) string {

--- a/gateway/mw_auth_key.go
+++ b/gateway/mw_auth_key.go
@@ -78,7 +78,7 @@ func (k *AuthKey) setContextVars(r *http.Request, token string) {
 
 // getAuthType overrides BaseMiddleware.getAuthType.
 func (k *AuthKey) getAuthType() string {
-	return authTokenType
+	return apidef.AuthTokenType
 }
 
 func (k *AuthKey) ProcessRequest(_ http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {

--- a/gateway/mw_auth_key_test.go
+++ b/gateway/mw_auth_key_test.go
@@ -110,7 +110,7 @@ func TestSignatureValidation(t *testing.T) {
 		spec.UseKeylessAccess = false
 		spec.Proxy.ListenPath = "/"
 		spec.AuthConfigs = map[string]apidef.AuthConfig{
-			authTokenType: {
+			apidef.AuthTokenType: {
 				ValidateSignature: true,
 				UseParam:          true,
 				ParamName:         "api_key",
@@ -184,9 +184,9 @@ func TestSignatureValidation(t *testing.T) {
 	})
 
 	t.Run("Dynamic signature", func(t *testing.T) {
-		authConfig := api.AuthConfigs[authTokenType]
+		authConfig := api.AuthConfigs[apidef.AuthTokenType]
 		authConfig.Signature.Secret = "$tyk_meta.signature_secret"
-		api.AuthConfigs[authTokenType] = authConfig
+		api.AuthConfigs[apidef.AuthTokenType] = authConfig
 		ts.Gw.LoadAPI(api)
 
 		key := CreateSession(ts.Gw, func(s *user.SessionState) {
@@ -220,9 +220,9 @@ func TestSignatureValidation(t *testing.T) {
 	})
 
 	t.Run("Dynamic signature with custom key", func(t *testing.T) {
-		authConfig := api.AuthConfigs[authTokenType]
+		authConfig := api.AuthConfigs[apidef.AuthTokenType]
 		authConfig.Signature.Secret = "$tyk_meta.signature_secret"
-		api.AuthConfigs[authTokenType] = authConfig
+		api.AuthConfigs[apidef.AuthTokenType] = authConfig
 		ts.Gw.LoadAPI(api)
 
 		customKey := "c8zj99aze7hdvtaqh4qvcck7"

--- a/gateway/mw_basic_auth.go
+++ b/gateway/mw_basic_auth.go
@@ -80,7 +80,7 @@ func (k *BasicAuthKeyIsValid) requestForBasicAuth(w http.ResponseWriter, msg str
 
 // getAuthType overrides BaseMiddleware.getAuthType.
 func (k *BasicAuthKeyIsValid) getAuthType() string {
-	return basicType
+	return apidef.BasicType
 }
 
 func (k *BasicAuthKeyIsValid) basicAuthHeaderCredentials(w http.ResponseWriter, r *http.Request) (username, password string, err error, code int) {

--- a/gateway/mw_http_signature_validation.go
+++ b/gateway/mw_http_signature_validation.go
@@ -48,7 +48,7 @@ func (hm *HTTPSignatureValidationMiddleware) Init() {
 
 // getAuthType overrides BaseMiddleware.getAuthType.
 func (hm *HTTPSignatureValidationMiddleware) getAuthType() string {
-	return hmacType
+	return apidef.HMACType
 }
 
 func (hm *HTTPSignatureValidationMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {

--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -694,7 +694,7 @@ func (k *JWTMiddleware) processOneToOneTokenMap(r *http.Request, token *jwt.Toke
 
 // getAuthType overrides BaseMiddleware.getAuthType.
 func (k *JWTMiddleware) getAuthType() string {
-	return jwtType
+	return apidef.JWTType
 }
 
 func (k *JWTMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {

--- a/gateway/mw_oauth2_key_exists.go
+++ b/gateway/mw_oauth2_key_exists.go
@@ -59,7 +59,7 @@ func (k *Oauth2KeyExists) EnabledForSpec() bool {
 
 // getAuthType overrides BaseMiddleware.getAuthType.
 func (k *Oauth2KeyExists) getAuthType() string {
-	return oauthType
+	return apidef.OAuthType
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail

--- a/gateway/mw_openid.go
+++ b/gateway/mw_openid.go
@@ -92,7 +92,7 @@ func (k *OpenIDMW) dummyErrorHandler(e error, w http.ResponseWriter, r *http.Req
 }
 
 func (k *OpenIDMW) getAuthType() string {
-	return oidcType
+	return apidef.OIDCType
 }
 
 func (k *OpenIDMW) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {

--- a/gateway/mw_strip_auth.go
+++ b/gateway/mw_strip_auth.go
@@ -41,7 +41,7 @@ func (sa *StripAuth) ProcessRequest(w http.ResponseWriter, r *http.Request, _ in
 
 	// For backward compatibility
 	if len(sa.Spec.AuthConfigs) == 0 {
-		strip(authTokenType, &sa.Spec.Auth)
+		strip(apidef.AuthTokenType, &sa.Spec.Auth)
 	}
 
 	return nil, http.StatusOK

--- a/gateway/mw_strip_auth_test.go
+++ b/gateway/mw_strip_auth_test.go
@@ -87,7 +87,7 @@ func TestStripAuth_stripFromHeaders(t *testing.T) {
 
 		key = "NonDefaultName"
 		sa.Spec.AuthConfigs = map[string]apidef.AuthConfig{
-			authTokenType: {CookieName: key},
+			apidef.AuthTokenType: {CookieName: key},
 		}
 		stripFromCookieTest(t, req, key, sa, "Dummy=DUMMY;NonDefaultName=AUTHORIZATION;Dummy2=DUMMY2", "Dummy=DUMMY;Dummy2=DUMMY2")
 		// whitespace between cookies
@@ -97,7 +97,7 @@ func TestStripAuth_stripFromHeaders(t *testing.T) {
 
 func stripFromCookieTest(t *testing.T, req *http.Request, key string, sa StripAuth, value string, expected string) {
 	req.Header.Set("Cookie", value)
-	config := sa.Spec.AuthConfigs[authTokenType]
+	config := sa.Spec.AuthConfigs[apidef.AuthTokenType]
 	sa.stripFromHeaders(req, &config)
 
 	actual := req.Header.Get("Cookie")


### PR DESCRIPTION
The auth type constants should be accessible by every package without cyclic dependency issues.