### PR TITLE
Iterate auth configs map in alphabetical order in auth source validation

### DIFF
--- a/apidef/validator.go
+++ b/apidef/validator.go
@@ -100,9 +100,11 @@ var ErrAllAuthSourcesDisabled = "all auth sources are disabled for %s, at least 
 type RuleAtLeastEnableOneAuthSource struct{}
 
 func (r *RuleAtLeastEnableOneAuthSource) Validate(apiDef *APIDefinition, validationResult *ValidationResult) {
-	var authConfigs []string
+	authConfigs := make([]string, len(apiDef.AuthConfigs))
+	i := 0
 	for name := range apiDef.AuthConfigs {
-		authConfigs = append(authConfigs, name)
+		authConfigs[i] = name
+		i++
 	}
 
 	sort.Strings(authConfigs)

--- a/apidef/validator.go
+++ b/apidef/validator.go
@@ -3,6 +3,7 @@ package apidef
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -99,10 +100,18 @@ var ErrAllAuthSourcesDisabled = "all auth sources are disabled for %s, at least 
 type RuleAtLeastEnableOneAuthSource struct{}
 
 func (r *RuleAtLeastEnableOneAuthSource) Validate(apiDef *APIDefinition, validationResult *ValidationResult) {
-	for k, authConfig := range apiDef.AuthConfigs {
-		if shouldValidateAuthSource(k, apiDef) && !(authConfig.UseParam || authConfig.UseCookie || !authConfig.DisableHeader) {
+	var authConfigs []string
+	for name := range apiDef.AuthConfigs {
+		authConfigs = append(authConfigs, name)
+	}
+
+	sort.Strings(authConfigs)
+
+	for _, name := range authConfigs {
+		if shouldValidateAuthSource(name, apiDef) &&
+			!(apiDef.AuthConfigs[name].UseParam || apiDef.AuthConfigs[name].UseCookie || !apiDef.AuthConfigs[name].DisableHeader) {
 			validationResult.IsValid = false
-			validationResult.AppendError(fmt.Errorf(ErrAllAuthSourcesDisabled, k))
+			validationResult.AppendError(fmt.Errorf(ErrAllAuthSourcesDisabled, name))
 		}
 	}
 


### PR DESCRIPTION
The `RuleAtLeastEnableOneAuthSource` validator iterates through `auth_configs` map and generates errors in different order everytime. It causes random test failures. This PR makes sure that the map is put on slice, sorted and iterated in alphabetical order.