### PR TITLE
[TD-922] Fix plugin  build script for plugin compiler image.

### DIFF
--- a/ci/images/plugin-compiler/data/build.sh
+++ b/ci/images/plugin-compiler/data/build.sh
@@ -64,7 +64,7 @@ yes | cp -rf $PLUGIN_BUILD_PATH/vendor/* $GOPATH/src || true \
 # First we need to find which deps GW already has, remove this folders, and after copy fresh versions from GW
 
 # github.com and rest of packages have different nesting levels, so have to handle it separately
-ls -d $TYK_GW_PATH/vendor/github.com/*/* | sed "s|$TYK_GW_PATH/vendor|$GOPATH/src|g" | xargs -d '\n' rm -rf
+ls -d $TYK_GW_PATH/vendor/github.com/*/* | sed "s|$TYK_GW_PATH/vendor|$GOPATH/src|g" | grep -v "TykTechnologies/tyk" | xargs -d '\n' rm -rf
 ls -d $TYK_GW_PATH/vendor/*/* | sed "s|$TYK_GW_PATH/vendor|$GOPATH/src|g" | grep -v github | xargs -d '\n' rm -rf
 
 # Copy GW dependencies
@@ -73,5 +73,5 @@ rm -rf $TYK_GW_PATH/vendor
 
 rm /go/src/modules.txt
 
-GO111MODULE=off CGO_ENABLE=$CGO_ENABLE GOOS=$GOOS GOARCH=$GOARCH  go build -buildmode=plugin -o $plugin_name \
+GO111MODULE=off CGO_ENABLED=$CGOENABLED GOOS=$GOOS GOARCH=$GOARCH  go build -buildmode=plugin -o $plugin_name \
     && mv $plugin_name $PLUGIN_SOURCE_PATH


### PR DESCRIPTION
## Description
Fixes the issue in this release workflow(https://github.com/TykTechnologies/tyk/runs/5467433097?check_suite_focus=true#step:3:261)

There's a new module dependency for the gateway that's internal
to the tyk gateway repo. (`github.com/TykTechnologies/tyk/certs`).
This causes the entire gateway source to be deleted in the build
script step where old dependecies are deleted so that they could be
replaced with fresh dependencies vendored in the GW source directory
of the plugin compiler image. This fixes that issue by filtering
the tyk repo from the delete list.

* Also fixes a variable naming issue(CGOENABLED)
