### PR TITLE
[TT-4803] Revert plugin compiler build script changes.

### DIFF
--- a/ci/images/plugin-compiler/data/build.sh
+++ b/ci/images/plugin-compiler/data/build.sh
@@ -1,15 +1,10 @@
 #!/bin/bash
 set -xe
 
-CURRENTVERS=$(perl -n -e'/v(\d+).(\d+).(\d+)/'' && print "v$1\.$2\.$3"' $TYK_GW_PATH/gateway/version.go)
 plugin_name=$1
 plugin_id=$2
-# GOOS and GOARCH can be send to override the name of the plugin
-GOOS=$3
-GOARCH=$4
-CGOENABLED=0
 
-  PLUGIN_BUILD_PATH="/go/src/plugin_${plugin_name%.*}$plugin_id"
+PLUGIN_BUILD_PATH="/go/src/plugin_${plugin_name%.*}$plugin_id"
 
 function usage() {
     cat <<EOF
@@ -20,24 +15,9 @@ To build a plugin:
 EOF
 }
 
-# if params were not send, then attempt to get them from env vars
-if [[ $GOOS == "" ]] && [[ $GOARCH == "" ]]; then
-  GOOS=$(go env GOOS)
-  GOARCH=$(go env GOARCH)
-fi
-
 if [ -z "$plugin_name" ]; then
     usage
     exit 1
-fi
-
-# if arch and os present then update the name of file with those params
-if [[ $GOOS != "" ]] && [[ $GOARCH != "" ]]; then
-  plugin_name="${plugin_name%.*}_${CURRENTVERS}_${GOOS}_${GOARCH}.so"
-fi
-
-if [[ $GOOS != "linux" ]];then
-    CGOENABLED=1
 fi
 
 mkdir -p $PLUGIN_BUILD_PATH
@@ -73,5 +53,5 @@ rm -rf $TYK_GW_PATH/vendor
 
 rm /go/src/modules.txt
 
-GO111MODULE=off CGO_ENABLED=$CGOENABLED GOOS=$GOOS GOARCH=$GOARCH  go build -buildmode=plugin -o $plugin_name \
+GO111MODULE=off go build -buildmode=plugin -o $plugin_name \
     && mv $plugin_name $PLUGIN_SOURCE_PATH


### PR DESCRIPTION
## Description
Revert the changes inherited from https://github.com/TykTechnologies/tyk/pull/3873
The file was synced earlier by a sync automation run, and was causing smoke tests to fail.