### PR TITLE
[TT-4869] Implement base of paths and operations

### DIFF
--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -10,8 +10,8 @@ import (
 
 type Middleware struct {
 	// Global contains the configurations related to the global middleware.
-	Global *Global `bson:"global,omitempty" json:"global,omitempty"`
-	Paths  Paths   `bson:"paths,omitempty" json:"paths,omitempty"`
+	Global     *Global    `bson:"global,omitempty" json:"global,omitempty"`
+	Operations Operations `bson:"operations,omitempty" json:"operations,omitempty"`
 }
 
 func (m *Middleware) Fill(api apidef.APIDefinition) {
@@ -23,31 +23,11 @@ func (m *Middleware) Fill(api apidef.APIDefinition) {
 	if ShouldOmit(m.Global) {
 		m.Global = nil
 	}
-
-	if m.Paths == nil {
-		m.Paths = make(Paths)
-	}
-
-	m.Paths.Fill(api.VersionData.Versions[""].ExtendedPaths)
-	if ShouldOmit(m.Paths) {
-		m.Paths = nil
-	}
 }
 
 func (m *Middleware) ExtractTo(api *apidef.APIDefinition) {
 	if m.Global != nil {
 		m.Global.ExtractTo(api)
-	}
-
-	if m.Paths != nil {
-		var ep apidef.ExtendedPathsSet
-		m.Paths.ExtractTo(&ep)
-		base := apidef.VersionInfo{UseExtendedPaths: true, ExtendedPaths: ep}
-		if api.VersionData.Versions == nil {
-			api.VersionData.Versions = make(map[string]apidef.VersionInfo)
-		}
-
-		api.VersionData.Versions[""] = base
 	}
 }
 
@@ -420,14 +400,6 @@ func (p *Path) getMethod(name string) *Plugins {
 		return p.Get
 	}
 }
-
-type AllowanceType int
-
-const (
-	allow                AllowanceType = 0
-	block                AllowanceType = 1
-	ignoreAuthentication AllowanceType = 2
-)
 
 type Plugins struct {
 	Allow                *Allowance `bson:"allow,omitempty" json:"allow,omitempty"`

--- a/apidef/oas/oas.go
+++ b/apidef/oas/oas.go
@@ -21,6 +21,7 @@ func (s *OAS) Fill(api apidef.APIDefinition) {
 	}
 
 	xTykAPIGateway.Fill(api)
+	s.fillPathsAndOperations(api.VersionData.Versions[""].ExtendedPaths)
 	s.fillSecurity(api)
 
 	if ShouldOmit(xTykAPIGateway) {
@@ -41,6 +42,16 @@ func (s *OAS) ExtractTo(api *apidef.APIDefinition) {
 
 	if s.GetTykExtension() != nil {
 		s.GetTykExtension().ExtractTo(api)
+	}
+
+	var ep apidef.ExtendedPathsSet
+	s.extractPathsAndOperations(&ep)
+
+	api.VersionData.Versions = map[string]apidef.VersionInfo{
+		"": {
+			UseExtendedPaths: true,
+			ExtendedPaths:    ep,
+		},
 	}
 }
 
@@ -188,4 +199,20 @@ func (s *OAS) getTykSecurityScheme(name string) interface{} {
 	}
 
 	return securitySchemes[name]
+}
+
+func (s *OAS) getTykMiddleware() (middleware *Middleware) {
+	if s.GetTykExtension() != nil {
+		middleware = s.GetTykExtension().Middleware
+	}
+
+	return
+}
+
+func (s *OAS) getTykOperations() (operations Operations) {
+	if s.getTykMiddleware() != nil {
+		operations = s.getTykMiddleware().Operations
+	}
+
+	return
 }

--- a/apidef/oas/oas.go
+++ b/apidef/oas/oas.go
@@ -8,6 +8,7 @@ import (
 )
 
 const ExtensionTykAPIGateway = "x-tyk-api-gateway"
+const Main = ""
 
 type OAS struct {
 	openapi3.T
@@ -21,7 +22,7 @@ func (s *OAS) Fill(api apidef.APIDefinition) {
 	}
 
 	xTykAPIGateway.Fill(api)
-	s.fillPathsAndOperations(api.VersionData.Versions[""].ExtendedPaths)
+	s.fillPathsAndOperations(api.VersionData.Versions[Main].ExtendedPaths)
 	s.fillSecurity(api)
 
 	if ShouldOmit(xTykAPIGateway) {
@@ -48,7 +49,7 @@ func (s *OAS) ExtractTo(api *apidef.APIDefinition) {
 	s.extractPathsAndOperations(&ep)
 
 	api.VersionData.Versions = map[string]apidef.VersionInfo{
-		"": {
+		Main: {
 			UseExtendedPaths: true,
 			ExtendedPaths:    ep,
 		},

--- a/apidef/oas/operation.go
+++ b/apidef/oas/operation.go
@@ -44,12 +44,14 @@ func (s *OAS) extractPathsAndOperations(ep *apidef.ExtendedPathsSet) {
 	}
 
 	for id, tykOp := range tykOperations {
+	found:
 		for path, pathItem := range s.Paths {
 			for method, operation := range pathItem.Operations() {
 				if id == operation.OperationID {
 					tykOp.extractAllowanceTo(ep, path, method, allow)
 					tykOp.extractAllowanceTo(ep, path, method, block)
 					tykOp.extractAllowanceTo(ep, path, method, ignoreAuthentication)
+					break found
 				}
 			}
 		}

--- a/apidef/oas/operation.go
+++ b/apidef/oas/operation.go
@@ -67,23 +67,11 @@ func (s *OAS) fillAllowance(endpointMetas []apidef.EndPointMeta, typ AllowanceTy
 
 		switch typ {
 		case block:
-			if operation.Block == nil {
-				operation.Block = &Allowance{}
-			}
-
-			allowance = operation.Block
+			allowance = newAllowance(&operation.Block)
 		case ignoreAuthentication:
-			if operation.IgnoreAuthentication == nil {
-				operation.IgnoreAuthentication = &Allowance{}
-			}
-
-			allowance = operation.IgnoreAuthentication
+			allowance = newAllowance(&operation.IgnoreAuthentication)
 		default:
-			if operation.Allow == nil {
-				operation.Allow = &Allowance{}
-			}
-
-			allowance = operation.Allow
+			allowance = newAllowance(&operation.Allow)
 		}
 
 		allowance.Fill(em)
@@ -91,6 +79,14 @@ func (s *OAS) fillAllowance(endpointMetas []apidef.EndPointMeta, typ AllowanceTy
 			allowance = nil
 		}
 	}
+}
+
+func newAllowance(prev **Allowance) *Allowance {
+	if *prev == nil {
+		*prev = &Allowance{}
+	}
+
+	return *prev
 }
 
 func (o *Operation) extractAllowanceTo(ep *apidef.ExtendedPathsSet, path string, method string, typ AllowanceType) {

--- a/apidef/oas/operation.go
+++ b/apidef/oas/operation.go
@@ -1,0 +1,157 @@
+package oas
+
+import (
+	"strings"
+
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+type Operations map[string]*Operation
+
+type Operation struct {
+	Allow                *Allowance `bson:"allow,omitempty" json:"allow,omitempty"`
+	Block                *Allowance `bson:"block,omitempty" json:"block,omitempty"`
+	IgnoreAuthentication *Allowance `bson:"ignoreAuthentication,omitempty" json:"ignoreAuthentication,omitempty"`
+}
+
+const (
+	allow                AllowanceType = 0
+	block                AllowanceType = 1
+	ignoreAuthentication AllowanceType = 2
+)
+
+type AllowanceType int
+
+func (s *OAS) fillPathsAndOperations(ep apidef.ExtendedPathsSet) {
+	if s.Paths == nil {
+		s.Paths = make(openapi3.Paths)
+	}
+
+	s.fillAllowance(ep.WhiteList, allow)
+	s.fillAllowance(ep.BlackList, block)
+	s.fillAllowance(ep.Ignored, ignoreAuthentication)
+
+	if len(s.Paths) == 0 {
+		s.Paths = nil
+	}
+}
+
+func (s *OAS) extractPathsAndOperations(ep *apidef.ExtendedPathsSet) {
+	tykOperations := s.getTykOperations()
+	if len(tykOperations) == 0 {
+		return
+	}
+
+	for id, tykOp := range tykOperations {
+		for path, pathItem := range s.Paths {
+			for method, operation := range pathItem.Operations() {
+				if id == operation.OperationID {
+					tykOp.extractAllowanceTo(ep, path, method, allow)
+					tykOp.extractAllowanceTo(ep, path, method, block)
+					tykOp.extractAllowanceTo(ep, path, method, ignoreAuthentication)
+				}
+			}
+		}
+	}
+}
+
+func (s *OAS) fillAllowance(endpointMetas []apidef.EndPointMeta, typ AllowanceType) {
+	for _, em := range endpointMetas {
+		operationID := s.getOperationID(em.Path, em.Method)
+		operation := s.GetTykExtension().getOperation(operationID)
+
+		var allowance *Allowance
+
+		switch typ {
+		case block:
+			if operation.Block == nil {
+				operation.Block = &Allowance{}
+			}
+
+			allowance = operation.Block
+		case ignoreAuthentication:
+			if operation.IgnoreAuthentication == nil {
+				operation.IgnoreAuthentication = &Allowance{}
+			}
+
+			allowance = operation.IgnoreAuthentication
+		default:
+			if operation.Allow == nil {
+				operation.Allow = &Allowance{}
+			}
+
+			allowance = operation.Allow
+		}
+
+		allowance.Fill(em)
+		if ShouldOmit(allowance) {
+			allowance = nil
+		}
+	}
+}
+
+func (o *Operation) extractAllowanceTo(ep *apidef.ExtendedPathsSet, path string, method string, typ AllowanceType) {
+	allowance := o.Allow
+	endpointMetas := &ep.WhiteList
+
+	switch typ {
+	case block:
+		allowance = o.Block
+		endpointMetas = &ep.BlackList
+	case ignoreAuthentication:
+		allowance = o.IgnoreAuthentication
+		endpointMetas = &ep.Ignored
+	}
+
+	if allowance == nil {
+		return
+	}
+
+	endpointMeta := apidef.EndPointMeta{Path: path, Method: method}
+	allowance.ExtractTo(&endpointMeta)
+	*endpointMetas = append(*endpointMetas, endpointMeta)
+}
+
+func (s *OAS) getOperationID(path, method string) (operationID string) {
+	operationID = strings.TrimPrefix(path, "/") + method
+
+	if s.Paths[path] == nil {
+		s.Paths[path] = &openapi3.PathItem{}
+	}
+
+	p := s.Paths[path]
+	operation := p.GetOperation(method)
+	if operation == nil {
+		p.SetOperation(method, &openapi3.Operation{OperationID: operationID})
+		return operationID
+	}
+
+	if operation.OperationID == "" {
+		operation.OperationID = operationID
+	} else {
+		operationID = operation.OperationID
+	}
+
+	return
+}
+
+func (x *XTykAPIGateway) getOperation(operationID string) *Operation {
+	if x.Middleware == nil {
+		x.Middleware = &Middleware{}
+	}
+
+	middleware := x.Middleware
+
+	if middleware.Operations == nil {
+		middleware.Operations = make(Operations)
+	}
+
+	operations := middleware.Operations
+
+	if operations[operationID] == nil {
+		operations[operationID] = &Operation{}
+	}
+
+	return operations[operationID]
+}

--- a/apidef/oas/operation_test.go
+++ b/apidef/oas/operation_test.go
@@ -1,0 +1,66 @@
+package oas
+
+import (
+	"testing"
+
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOAS_PathsAndOperations(t *testing.T) {
+	const operationId = "userGET"
+	const existingOperationId = "userPOST"
+
+	var oas OAS
+	oas.Paths = openapi3.Paths{
+		"/user": {
+			Get: &openapi3.Operation{
+				OperationID: operationId,
+			},
+		},
+	}
+
+	xTykAPIGateway := &XTykAPIGateway{
+		Middleware: &Middleware{
+			Operations: Operations{
+				operationId: {
+					Allow: &Allowance{
+						Enabled: true,
+					},
+				},
+			},
+		},
+	}
+
+	oas.SetTykExtension(xTykAPIGateway)
+
+	var ep apidef.ExtendedPathsSet
+	oas.extractPathsAndOperations(&ep)
+
+	var convertedOAS OAS
+	convertedOAS.Paths = openapi3.Paths{
+		"/user": {
+			Post: &openapi3.Operation{
+				OperationID: existingOperationId,
+			},
+		},
+	}
+	convertedOAS.SetTykExtension(&XTykAPIGateway{Middleware: &Middleware{Operations: Operations{}}})
+	convertedOAS.fillPathsAndOperations(ep)
+
+	assert.Equal(t, oas.getTykOperations(), convertedOAS.getTykOperations())
+
+	expCombinedPaths := openapi3.Paths{
+		"/user": {
+			Post: &openapi3.Operation{
+				OperationID: existingOperationId,
+			},
+			Get: &openapi3.Operation{
+				OperationID: operationId,
+			},
+		},
+	}
+
+	assert.Equal(t, expCombinedPaths, convertedOAS.Paths)
+}


### PR DESCRIPTION
This PR implements `operationId` usage to match plugins for path and methods. See the example Tyk OAS doc:
```
{
  "components": {},
  "info": null,
  "openapi": "",
  "paths": {
    "/user": {
      "get": {
        "operationId": "userGET",
        "responses": null
      },
      "post": {
        "operationId": "userPOST",
        "responses": null
      }
    }
  },
  "x-tyk-api-gateway": {
    "info": {
      "name": "",
      "state": {
        "active": false
      }
    },
    "upstream": {
      "url": ""
    },
    "server": {
      "listenPath": {
        "value": ""
      }
    },
    "middleware": {
      "operations": {
        "userGET": {
          "allow": {
            "enabled": true
          }
        }
      }
    }
  }
}
```