### PR TITLE
[TT-7129] Fix setting global_size_limit not enabling RequestSizeLimitMiddleware

### DIFF
--- a/gateway/mw_request_size_limit.go
+++ b/gateway/mw_request_size_limit.go
@@ -11,7 +11,9 @@ import (
 	"github.com/TykTechnologies/tyk/headers"
 )
 
-// TransformMiddleware is a middleware that will apply a template to a request body to transform it's contents ready for an upstream API
+// RequestSizeLimitMiddleware is a middleware that will enforce a limit on the request body size. The request has
+// already been copied to memory when this middleware is called. Therefore, this middleware can't protect the gateway
+// itself from large requests.
 type RequestSizeLimitMiddleware struct {
 	BaseMiddleware
 }
@@ -22,7 +24,8 @@ func (t *RequestSizeLimitMiddleware) Name() string {
 
 func (t *RequestSizeLimitMiddleware) EnabledForSpec() bool {
 	for _, version := range t.Spec.VersionData.Versions {
-		if len(version.ExtendedPaths.SizeLimit) > 0 {
+		if len(version.ExtendedPaths.SizeLimit) > 0 ||
+			version.GlobalSizeLimit > 0 {
 			return true
 		}
 	}

--- a/gateway/mw_request_size_limit_test.go
+++ b/gateway/mw_request_size_limit_test.go
@@ -1,0 +1,25 @@
+package gateway
+
+import (
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/test"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestRequestSizeLimitGlobalSizeLimit(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+			v.GlobalSizeLimit = 1024
+		})
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{Method: "POST", Path: "/sample/", Data: strings.Repeat("a", 1024), Code: http.StatusOK},
+		{Method: "POST", Path: "/sample/", Data: strings.Repeat("a", 1025), Code: http.StatusBadRequest},
+	}...)
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Fix `EnabledForSpec` in `RequestSizeLimitMiddleware` for API global limits without size limits in `extended_paths`.

## Related Issue
https://github.com/TykTechnologies/tyk/issues/3977

## Motivation and Context
Makes the `RequestSizeLimitMiddleware` usable when only API global limits are specified.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [x] `go vet`
