### PR TITLE
set oas.ExternalDocs to nil if populated with zero values

### DIFF
--- a/apidef/oas/oas.go
+++ b/apidef/oas/oas.go
@@ -32,6 +32,11 @@ func (s *OAS) Fill(api apidef.APIDefinition) {
 	if ShouldOmit(s.Extensions) {
 		s.Extensions = nil
 	}
+
+	// set external docs to nil if populated with default values
+	if ShouldOmit(s.ExternalDocs) {
+		s.ExternalDocs = nil
+	}
 }
 
 func (s *OAS) ExtractTo(api *apidef.APIDefinition) {


### PR DESCRIPTION
[changelog]
added: set oas.ExternalDocs to nil if populated with zero values.
