### PR TITLE
TT-3973: Patch flaky test for test hmac auth session key missing

### DIFF
--- a/dnscache/dnscache_test.go
+++ b/dnscache/dnscache_test.go
@@ -1,0 +1,51 @@
+package dnscache
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/TykTechnologies/tyk/test"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(InitTestMain(context.Background(), m))
+}
+
+var (
+	dnsMock *test.DnsMockHandle
+)
+
+func InitTestMain(ctx context.Context, m *testing.M) int {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	if err := setUp(ctx); err != nil {
+		logger.WithError(err).Error()
+	}
+	defer func() {
+		if err := tearDown(); err != nil {
+			logger.WithError(err).Error()
+		}
+	}()
+
+	return m.Run()
+}
+
+func setUp(ctx context.Context) (err error) {
+	dnsMock, err = test.InitDNSMock(etcHostsMap, etcHostsErrorMap)
+	if err != nil {
+		return fmt.Errorf("Error in dns mock init: %w", err)
+	}
+
+	return nil
+}
+
+func tearDown() error {
+	if err := dnsMock.Shutdown(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/dnscache/manager_test.go
+++ b/dnscache/manager_test.go
@@ -11,14 +11,14 @@ import (
 )
 
 func TestWrapDialerDialContextFunc(t *testing.T) {
-	tearDownTestStorageFetchItem := setupTestStorageFetchItem(&configTestStorageFetchItem{t, etcHostsMap, etcHostsErrorMap})
-	defer tearDownTestStorageFetchItem()
+	t.Parallel()
 
 	expectedHost := "orig-host.com"
 	expectedSingleIpHost := "single.orig-host.com"
 	hostWithPort := expectedHost + ":8078"
 	singleIpHostWithPort := expectedSingleIpHost + ":8078"
-	dialerContext, cancel := context.WithCancel(context.TODO())
+
+	dialerContext, cancel := context.WithCancel(context.Background())
 	cancel() //Manually disable connection establishment
 
 	cases := []struct {

--- a/dnscache/storage.go
+++ b/dnscache/storage.go
@@ -17,12 +17,14 @@ type DnsCacheItem struct {
 
 // DnsCacheStorage is an in-memory cache of auto-purged dns query ip responses
 type DnsCacheStorage struct {
-	cache *cache.Cache
+	cache      *cache.Cache
+	LookupHost func(string) ([]string, error)
 }
 
 func NewDnsCacheStorage(expiration, checkInterval time.Duration) *DnsCacheStorage {
-	storage := DnsCacheStorage{cache.New(expiration, checkInterval)}
-	return &storage
+	return &DnsCacheStorage{
+		cache: cache.New(expiration, checkInterval),
+	}
 }
 
 // Items returns map of non expired dns cache items
@@ -89,5 +91,8 @@ func (dc *DnsCacheStorage) Clear() {
 }
 
 func (dc *DnsCacheStorage) resolveDNSRecord(host string) ([]string, error) {
+	if dc.LookupHost != nil {
+		return dc.LookupHost(host)
+	}
 	return net.LookupHost(host)
 }

--- a/dnscache/storage_test.go
+++ b/dnscache/storage_test.go
@@ -235,6 +235,8 @@ func TestStorageRecordExpiration(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			dnsCache := NewDnsCacheStorage(time.Duration(expiration)*time.Millisecond, time.Duration(tc.checkInterval)*time.Millisecond)
 
 			for _, r := range tc.records {

--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -1653,17 +1653,11 @@ func TestApiLoaderLongestPathFirst(t *testing.T) {
 
 	var testCases []test.TestCase
 
-	client := test.NewClient(
-		test.WithTransport(
-			test.NewTransport(test.WithLocalDialer()),
-		),
-	)
-
 	for hp := range inputs {
 		testCases = append(testCases, test.TestCase{
 			Path:      "/" + hp.path,
 			Domain:    hp.host,
-			Client:    client,
+			Client:    test.NewClientLocal(),
 			Code:      200,
 			BodyMatch: `"Url":"/` + hp.path + `"`,
 		})

--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -1653,10 +1653,17 @@ func TestApiLoaderLongestPathFirst(t *testing.T) {
 
 	var testCases []test.TestCase
 
+	client := test.NewClient(
+		test.WithTransport(
+			test.NewTransport(test.WithLocalDialer()),
+		),
+	)
+
 	for hp := range inputs {
 		testCases = append(testCases, test.TestCase{
 			Path:      "/" + hp.path,
 			Domain:    hp.host,
+			Client:    client,
 			Code:      200,
 			BodyMatch: `"Url":"/` + hp.path + `"`,
 		})

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -768,7 +768,7 @@ func TestUpstreamMutualTLS(t *testing.T) {
 			ts.Gw.LoadAPI(api)
 
 			// Giving a different value to proxy host, it should not interfere upstream certificate matching
-			_, _ = ts.Run(t, test.TestCase{Domain: proxyHost, Code: http.StatusOK})
+			_, _ = ts.Run(t, test.TestCase{Domain: proxyHost, Code: http.StatusOK, Client: test.NewClientLocal()})
 		})
 
 		t.Run("PreserveHostHeader=true", func(t *testing.T) {
@@ -776,7 +776,7 @@ func TestUpstreamMutualTLS(t *testing.T) {
 			ts.Gw.LoadAPI(api)
 
 			// Giving a different value to proxy host, it should not interfere upstream certificate matching
-			_, _ = ts.Run(t, test.TestCase{Domain: proxyHost, Code: http.StatusOK})
+			_, _ = ts.Run(t, test.TestCase{Domain: proxyHost, Code: http.StatusOK, Client: test.NewClientLocal()})
 		})
 	})
 }

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -1103,6 +1103,8 @@ func TestCustomDomain(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()
 
+	localClient := test.NewClientLocal()
+
 	t.Run("With custom domain support", func(t *testing.T) {
 		globalConf := ts.Gw.GetConfig()
 		globalConf.EnableCustomDomains = true
@@ -1121,10 +1123,11 @@ func TestCustomDomain(t *testing.T) {
 		)
 
 		ts.Run(t, []test.TestCase{
-			{Code: 200, Path: "/with_domain", Domain: "host1"},
-			{Code: 404, Path: "/with_domain"},
-			{Code: 200, Path: "/without_domain"},
-			{Code: 200, Path: "/tyk/keys", AdminAuth: true},
+			{Client: localClient, Code: 200, Path: "/with_domain", Domain: "host1"},
+			{Client: localClient, Code: 404, Path: "/with_domain"},
+			{Client: localClient, Code: 200, Path: "/without_domain"},
+			{Client: localClient, Code: 200, Path: "/without_domain", Domain: "bogus"},
+			{Client: localClient, Code: 200, Path: "/tyk/keys", AdminAuth: true},
 		}...)
 	})
 
@@ -1142,10 +1145,10 @@ func TestCustomDomain(t *testing.T) {
 		)
 
 		ts.Run(t, []test.TestCase{
-			{Code: 200, Path: "/with_domain", Domain: "host1"},
-			{Code: 200, Path: "/with_domain"},
-			{Code: 200, Path: "/without_domain"},
-			{Code: 200, Path: "/tyk/keys", AdminAuth: true},
+			{Client: localClient, Code: 200, Path: "/with_domain", Domain: "host1"},
+			{Client: localClient, Code: 200, Path: "/with_domain"},
+			{Client: localClient, Code: 200, Path: "/without_domain"},
+			{Client: localClient, Code: 200, Path: "/tyk/keys", AdminAuth: true},
 		}...)
 	})
 }
@@ -2157,16 +2160,4 @@ func TestOverrideErrors(t *testing.T) {
 		assert(message4, code2, e, i)
 	})
 
-}
-
-func TestMultiGatewayEnv(t *testing.T) {
-	t.Skip() //skipping it for now
-	for i := 0; i < 1000; i++ {
-		t.Logf("Creando gateway N %v", i)
-		ts := StartTest(nil)
-		// time.Sleep(20*time.Second)
-		ts.Close()
-	}
-	t.Log("...sleeping")
-	time.Sleep(1 * time.Minute)
 }

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -366,7 +366,7 @@ func (gw *Gateway) setupGlobals() {
 
 	// Load all the files that have the "error" prefix.
 	//	gwConfig.TemplatePath = "/Users/sredny/go/src/github.com/TykTechnologies/tyk/templates"
-	templatesDir := filepath.Join(gwConfig.TemplatePath, "error*")
+	templatesDir := filepath.Join(gwConfig.TemplatePath, "error.*")
 	gw.templates = template.Must(template.ParseGlob(templatesDir))
 	gw.templatesRaw = textTemplate.Must(textTemplate.ParseGlob(templatesDir))
 	gw.CoProcessInit()

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -228,6 +228,7 @@ func NewGateway(config config.Config, ctx context.Context, cancelFn context.Canc
 	gw.TestBundles = map[string]map[string]string{}
 
 	gw.RedisController = storage.NewRedisController()
+	gw.RedisController.SetContext(ctx)
 
 	return &gw
 }

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -219,7 +219,7 @@ func InitTestMain(ctx context.Context, m *testing.M) int {
 			panic(errMock)
 		}
 
-		defer MockHandle.ShutdownDnsMock()
+		defer MockHandle.Shutdown()
 	}
 
 	exitCode := m.Run()

--- a/storage/redis_cluster.go
+++ b/storage/redis_cluster.go
@@ -669,6 +669,8 @@ func (r *RedisCluster) StartPubSubHandler(channel string, callback func(interfac
 	pubsub := client.Subscribe(r.RedisController.ctx, channel)
 	defer pubsub.Close()
 
+	log.Debug("Starting pubsub with ctx", r.RedisController.ctx)
+
 	for {
 		msg, err := pubsub.Receive(r.RedisController.ctx)
 		if err != nil {

--- a/storage/redis_controller.go
+++ b/storage/redis_controller.go
@@ -26,6 +26,11 @@ func NewRedisController() *RedisController {
 	}
 }
 
+// SetContext to ensure cancellation on pubsub
+func (rc *RedisController) SetContext(ctx context.Context) {
+	rc.ctx = ctx
+}
+
 // DisableRedis very handy when testsing it allows to dynamically enable/disable talking with
 // redisW
 func (rc *RedisController) DisableRedis(setRedisDown bool) {

--- a/test/dns.go
+++ b/test/dns.go
@@ -153,7 +153,9 @@ type DnsMockHandle struct {
 	id         string
 	mockServer *dns.Server
 
-	Resolver   *net.Resolver
+	Resolver *net.Resolver
+	Dialer   *net.Dialer
+
 	Shutdown   func() error
 	LookupHost func(string) ([]string, error)
 }
@@ -250,6 +252,10 @@ func InitDNSMock(domainsMap map[string][]string, domainsErrorMap map[string]int)
 			dialer := net.Dialer{}
 			return dialer.DialContext(ctx, network, mockServer.PacketConn.LocalAddr().String())
 		},
+	}
+
+	handle.Dialer = &net.Dialer{
+		Resolver: handle.Resolver,
 	}
 
 	handle.Shutdown = func() error {

--- a/test/http_client.go
+++ b/test/http_client.go
@@ -1,0 +1,83 @@
+package test
+
+import (
+	"context"
+	"net"
+	"net/http"
+)
+
+type (
+	// Options for populating a http.Client
+	ClientOption func(*http.Client)
+
+	// Options for populating a http.Transport
+	TransportOption func(*http.Transport)
+
+	// DialContext function signature
+	DialContext func(ctx context.Context, network, addr string) (net.Conn, error)
+)
+
+// NewClient creates a http.Client with options
+func NewClient(opts ...ClientOption) *http.Client {
+	client := &http.Client{}
+	applyClientOptions(client, opts...)
+	return client
+}
+
+func applyClientOptions(c *http.Client, opts ...ClientOption) {
+	for _, v := range opts {
+		v(c)
+	}
+}
+
+// NewClientLocal returns a http.Client that can connect
+// only to localhost. See: `WithLocalDialer`.
+func NewClientLocal(opts ...ClientOption) *http.Client {
+	client := NewClient(
+		WithTransport(
+			NewTransport(WithLocalDialer()),
+		),
+	)
+	applyClientOptions(client, opts...)
+	return client
+}
+
+// WithTransport sets a http.RoundTripper to a http.Client
+func WithTransport(transport http.RoundTripper) ClientOption {
+	return ClientOption(func(c *http.Client) {
+		c.Transport = transport
+	})
+}
+
+// NewTransport creates a http.Transport with options
+func NewTransport(opts ...TransportOption) *http.Transport {
+	transport := &http.Transport{}
+	for _, v := range opts {
+		v(transport)
+	}
+	return transport
+}
+
+// WithDialer sets transport.DialContext
+func WithDialer(dialer DialContext) TransportOption {
+	return TransportOption(func(transport *http.Transport) {
+		transport.DialContext = dialer
+	})
+}
+
+// WithLocalDialer sets a http.Transport DialContext,
+// which only connects to 127.0.0.1.
+func WithLocalDialer() TransportOption {
+	return TransportOption(func(transport *http.Transport) {
+		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			host, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, err
+			}
+			host = "127.0.0.1"
+
+			dialer := net.Dialer{}
+			return dialer.DialContext(ctx, network, net.JoinHostPort(host, port))
+		}
+	})
+}


### PR DESCRIPTION
Pass cancellation context to RedisController, to exit pubSubLoop without referencing net.DefaultResolver (data race, globals)