### PR TITLE
Fix plugin build script

### DIFF
--- a/ci/images/plugin-compiler/data/build.sh
+++ b/ci/images/plugin-compiler/data/build.sh
@@ -63,9 +63,10 @@ yes | cp -rf $PLUGIN_BUILD_PATH/vendor/* $GOPATH/src || true \
 # We can't just copy Tyk dependencies on top of plugin dependencies, since different package versions have different file structures
 # First we need to find which deps GW already has, remove this folders, and after copy fresh versions from GW
 
-# github.com and rest of packages have different nesting levels, so have to handle it separately
-ls -d $TYK_GW_PATH/vendor/github.com/*/* | sed "s|$TYK_GW_PATH/vendor|$GOPATH/src|g" | xargs -d '\n' rm -rf
-ls -d $TYK_GW_PATH/vendor/*/* | sed "s|$TYK_GW_PATH/vendor|$GOPATH/src|g" | grep -v github | xargs -d '\n' rm -rf
+# github.com and rest of packages have different nesting levels, so have to handle it separately - also exlude the tyk repo so that
+# it doesn't get deleted if we have any deps internal to the tyk module
+find "$TYK_GW_PATH/vendor/github.com" -mindepth 2 -maxdepth 2  -type d -not -path "$TYK_GW_PATH/vendor/github.com/TykTechnologies/tyk" | sed "s|$TYK_GW_PATH/vendor|$GOPATH/src|g" | xargs rm -rf
+find "$TYK_GW_PATH/vendor" -mindepth 2 -maxdepth 2  -type d -not -path "$TYK_GW_PATH/vendor/github.com/*"| sed "s|$TYK_GW_PATH/vendor|$GOPATH/src|g" | xargs rm -rf
 
 # Copy GW dependencies
 yes | cp -rf $TYK_GW_PATH/vendor/* $GOPATH/src

--- a/ci/tests/plugin-compiler/test.sh
+++ b/ci/tests/plugin-compiler/test.sh
@@ -25,6 +25,7 @@ trap "$compose down" EXIT
 
 rm -fv testplugin/*.so || true
 docker run --rm -v `pwd`/testplugin:/plugin-source tykio/tyk-plugin-compiler:${tag} testplugin.so
+mv testplugin/testplugin*.so testplugin/testplugin.so
 $compose up -d
 sleep 2 # Wait for init
 curl -vvv http://localhost:8080/goplugin/headers


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Update plugin compiler smoke tests to align with  the new changes in plugin compiler  build where the plugin name has version and platform info in the name, 
Also fix the plugin compiler build script - there seems to be an issue when there's an internal dependency in the `go.mod` file(eg: `github.com/TykTechnologies/tyk/certs`) - it causes the build to fail as it causes the the source tree to be deleted while building the plugin.