### PR TITLE
[TD-983]: Revert sync automation

### DIFF
--- a/ci/goreleaser/goreleaser-el7.yml
+++ b/ci/goreleaser/goreleaser-el7.yml
@@ -158,7 +158,6 @@ dockers:
   extra_files:
     - ci/images/plugin-compiler
     - go.mod
-    - analytics
     - apidef
     - certs
     - checkup

--- a/ci/goreleaser/goreleaser.yml
+++ b/ci/goreleaser/goreleaser.yml
@@ -194,7 +194,6 @@ dockers:
   extra_files:
     - ci/images/plugin-compiler
     - go.mod
-    - analytics
     - apidef
     - certs
     - checkup


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

The corresponding code changes for this config change are not merged to the release-4-lts branch, so
needs to be reverted.
These changes were made in the PR #3981 and was copied over by the automation to release-4-lts branch.
The changes to goreleaser be  added to the templates and then generated from there.
