### PR TITLE
[TT-3972] Optimizing CI flows

### DIFF
--- a/bin/ci-tests.sh
+++ b/bin/ci-tests.sh
@@ -2,46 +2,33 @@
 
 TEST_TIMEOUT=15m
 
-# print a command and execute it
-show() {
-	echo "$@" >&2
-	eval "$@"
-}
-
-fatal() {
-	echo "$@" >&2
-	exit 1
-}
-
 PKGS="$(go list ./...)"
 
 export PKG_PATH=${GOPATH}/src/github.com/TykTechnologies/tyk
 
+# exit on non-zero exit from go test/vet
+set -e
+
+# run go vet overall to fail early on violations
+echo "Running go vet"
+go vet ./...
+
 # build Go-plugin used in tests
-go build -o ./test/goplugins/goplugins.so -buildmode=plugin ./test/goplugins || fatal "building Go-plugin failed"
+echo "Building go plugin"
+go build -o ./test/goplugins/goplugins.so -buildmode=plugin ./test/goplugins
 
 for pkg in ${PKGS}; do
     tags=""
-
-    # TODO: Remove skipRace variable after solving race conditions in tests.
-    skipRace=false
-    if [[ ${pkg} == *"grpc" ]]; then
-        skipRace=true
-    elif [[ ${pkg} == *"goplugin" ]]; then
-        skipRace=true
+    if [[ ${pkg} == *"goplugin" ]]; then
         tags="-tags 'goplugin'"
     fi
 
-    race="-race"
-
-    if [[ ${skipRace} = true ]]; then
-        race=""
-    fi
     coveragefile=`echo "$pkg" | awk -F/ '{print $NF}'`
-    show go test ${race} -timeout ${TEST_TIMEOUT} -v -coverprofile=${coveragefile}.cov ${pkg} ${tags} || fatal "Test Failed"
-    show go vet ${tags} ${pkg} || fatal "go vet errored"
+
+    echo go test -race -count=1 -timeout ${TEST_TIMEOUT} -failfast -v -coverprofile=${coveragefile}.cov ${pkg} ${tags}
+    go test -race -count=1 -timeout ${TEST_TIMEOUT} -failfast -v -coverprofile=${coveragefile}.cov ${pkg} ${tags}
 done
 
 # run rpc tests separately
 rpc_tests='SyncAPISpecsRPC|OrgSessionWithRPCDown'
-show go test -timeout ${TEST_TIMEOUT} -v -coverprofile=gateway-rpc.cov github.com/TykTechnologies/tyk/gateway -p 1 -run '"'${rpc_tests}'"' || fatal "Test Failed"
+go test -count=1 -timeout ${TEST_TIMEOUT} -v -coverprofile=gateway-rpc.cov github.com/TykTechnologies/tyk/gateway -p 1 -run '"'${rpc_tests}'"'

--- a/bin/ci-tests.sh
+++ b/bin/ci-tests.sh
@@ -4,6 +4,12 @@ TEST_TIMEOUT=15m
 
 PKGS="$(go list ./...)"
 
+# Support passing custom flags (-json, etc.)
+OPTS="$@"
+if [[ -z "$OPTS" ]]; then
+	OPTS="-race -count=1 -failfast -v"
+fi
+
 export PKG_PATH=${GOPATH}/src/github.com/TykTechnologies/tyk
 
 # exit on non-zero exit from go test/vet
@@ -25,8 +31,8 @@ for pkg in ${PKGS}; do
 
     coveragefile=`echo "$pkg" | awk -F/ '{print $NF}'`
 
-    echo go test -race -count=1 -timeout ${TEST_TIMEOUT} -failfast -v -coverprofile=${coveragefile}.cov ${pkg} ${tags}
-    go test -race -count=1 -timeout ${TEST_TIMEOUT} -failfast -v -coverprofile=${coveragefile}.cov ${pkg} ${tags}
+    echo go test ${OPTS} -timeout ${TEST_TIMEOUT} -coverprofile=${coveragefile}.cov ${pkg} ${tags}
+    go test ${OPTS} -timeout ${TEST_TIMEOUT} -coverprofile=${coveragefile}.cov ${pkg} ${tags}
 done
 
 # run rpc tests separately

--- a/bin/ci-tests.sh
+++ b/bin/ci-tests.sh
@@ -15,10 +15,6 @@ export PKG_PATH=${GOPATH}/src/github.com/TykTechnologies/tyk
 # exit on non-zero exit from go test/vet
 set -e
 
-# run go vet overall to fail early on violations
-echo "Running go vet"
-go vet ./...
-
 # build Go-plugin used in tests
 echo "Building go plugin"
 go build -o ./test/goplugins/goplugins.so -buildmode=plugin ./test/goplugins


### PR DESCRIPTION
## Description

Improving the state of bin/ci-test.sh to facilitate local testing better.

# Related Issue

#4035 

## Motivation and Context

Clean up ci-test.sh code, remove go vet (duplicated with golangci-lint), adjust default flags to failfast.

## How This Has Been Tested

Loop 100x.

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/233360/168028450-109e2142-5ec2-4a70-8c94-49957d4f332b.png)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [ ] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
