### PR TITLE
[TT-5192] Add StartConsumingLatest to GQL config adapter

### DIFF
--- a/apidef/adapter/graphql_config_adapter.go
+++ b/apidef/adapter/graphql_config_adapter.go
@@ -255,11 +255,12 @@ func (g *GraphQLConfigAdapter) engineConfigV2DataSources() (planDataSources []pl
 			planDataSource.Factory = &kafkaDataSource.Factory{}
 			planDataSource.Custom = kafkaDataSource.ConfigJSON(kafkaDataSource.Configuration{
 				Subscription: kafkaDataSource.SubscriptionConfiguration{
-					BrokerAddr:   kafkaConfig.BrokerAddr,
-					Topic:        kafkaConfig.Topic,
-					GroupID:      kafkaConfig.GroupID,
-					ClientID:     kafkaConfig.ClientID,
-					KafkaVersion: kafkaConfig.KafkaVersion,
+					BrokerAddr:           kafkaConfig.BrokerAddr,
+					Topic:                kafkaConfig.Topic,
+					GroupID:              kafkaConfig.GroupID,
+					ClientID:             kafkaConfig.ClientID,
+					KafkaVersion:         kafkaConfig.KafkaVersion,
+					StartConsumingLatest: kafkaConfig.StartConsumingLatest,
 				},
 			})
 		}

--- a/apidef/adapter/graphql_config_adapter_test.go
+++ b/apidef/adapter/graphql_config_adapter_test.go
@@ -6,14 +6,12 @@ import (
 	"strconv"
 	"testing"
 
-	kafkaDataSource "github.com/jensneuse/graphql-go-tools/pkg/engine/datasource/kafka_datasource"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	graphqlDataSource "github.com/jensneuse/graphql-go-tools/pkg/engine/datasource/graphql_datasource"
+	kafkaDataSource "github.com/jensneuse/graphql-go-tools/pkg/engine/datasource/kafka_datasource"
 	restDataSource "github.com/jensneuse/graphql-go-tools/pkg/engine/datasource/rest_datasource"
 	"github.com/jensneuse/graphql-go-tools/pkg/engine/plan"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/TykTechnologies/tyk/apidef"
 )
@@ -719,11 +717,12 @@ func TestGraphQLConfigAdapter_engineConfigV2DataSources(t *testing.T) {
 			Factory: &kafkaDataSource.Factory{},
 			Custom: kafkaDataSource.ConfigJSON(kafkaDataSource.Configuration{
 				Subscription: kafkaDataSource.SubscriptionConfiguration{
-					BrokerAddr:   "localhost:9092",
-					Topic:        "test.topic",
-					GroupID:      "test.consumer.group",
-					ClientID:     "test.client.id",
-					KafkaVersion: "V2_8_0_0",
+					BrokerAddr:           "localhost:9092",
+					Topic:                "test.topic",
+					GroupID:              "test.consumer.group",
+					ClientID:             "test.client.id",
+					KafkaVersion:         "V2_8_0_0",
+					StartConsumingLatest: true,
 				},
 			}),
 		},
@@ -737,11 +736,12 @@ func TestGraphQLConfigAdapter_engineConfigV2DataSources(t *testing.T) {
 			Factory: &kafkaDataSource.Factory{},
 			Custom: kafkaDataSource.ConfigJSON(kafkaDataSource.Configuration{
 				Subscription: kafkaDataSource.SubscriptionConfiguration{
-					BrokerAddr:   "localhost:9092",
-					Topic:        "test.topic.{{.arguments.name}}",
-					GroupID:      "test.consumer.group",
-					ClientID:     "test.client.id",
-					KafkaVersion: "V2_8_0_0",
+					BrokerAddr:           "localhost:9092",
+					Topic:                "test.topic.{{.arguments.name}}",
+					GroupID:              "test.consumer.group",
+					ClientID:             "test.client.id",
+					KafkaVersion:         "V2_8_0_0",
+					StartConsumingLatest: true,
 				},
 			}),
 		},
@@ -990,7 +990,8 @@ var graphqlEngineV2ConfigJson = `{
 					"topic": "test.topic",
 					"group_id": "test.consumer.group",
 					"client_id": "test.client.id",
-					"kafka_version": "V2_8_0_0"
+					"kafka_version": "V2_8_0_0",
+					"start_consuming_latest": true
 				}
 			},
 			{
@@ -1008,7 +1009,8 @@ var graphqlEngineV2ConfigJson = `{
 					"topic": "test.topic.{{.arguments.name}}",
 					"group_id": "test.consumer.group",
 					"client_id": "test.client.id",
-					"kafka_version": "V2_8_0_0"
+					"kafka_version": "V2_8_0_0",
+					"start_consuming_latest": true
 				}
 			}
 		]

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -801,11 +801,12 @@ type GraphQLEngineDataSourceConfigGraphQL struct {
 }
 
 type GraphQLEngineDataSourceConfigKafka struct {
-	BrokerAddr   string `bson:"broker_addr" json:"broker_addr"`
-	Topic        string `bson:"topic" json:"topic"`
-	GroupID      string `bson:"group_id" json:"group_id"`
-	ClientID     string `bson:"client_id" json:"client_id"`
-	KafkaVersion string `bson:"kafka_version" json:"kafka_version"`
+	BrokerAddr           string `bson:"broker_addr" json:"broker_addr"`
+	Topic                string `bson:"topic" json:"topic"`
+	GroupID              string `bson:"group_id" json:"group_id"`
+	ClientID             string `bson:"client_id" json:"client_id"`
+	KafkaVersion         string `bson:"kafka_version" json:"kafka_version"`
+	StartConsumingLatest bool   `json:"start_consuming_latest"`
 }
 
 type QueryVariable struct {


### PR DESCRIPTION
This PR adds `StartConsumingLatest` to `GraphQLEngineDataSourceConfigKafka` and updates tests. It's a boolean field to control offset alignment when the consumer is restarted.

Details: [TT-5192](https://tyktech.atlassian.net/jira/software/c/projects/TT/boards/26?modal=detail&selectedIssue=TT-5192)