### PR TITLE
[TT-5369] Add customDomain to be configured with simple OAS

### DIFF
--- a/apidef/oas/default.go
+++ b/apidef/oas/default.go
@@ -17,8 +17,9 @@ var (
 )
 
 type TykExtensionConfigParams struct {
-	UpstreamURL string
-	ListenPath  string
+	UpstreamURL  string
+	ListenPath   string
+	CustomDomain string
 }
 
 func (s *OAS) BuildDefaultTykExtension(overRideValues TykExtensionConfigParams) error {
@@ -40,6 +41,10 @@ func (s *OAS) BuildDefaultTykExtension(overRideValues TykExtensionConfigParams) 
 		xTykAPIGateway.Server.ListenPath.Value = overRideValues.ListenPath
 	} else if xTykAPIGateway.Server.ListenPath.Value == "" {
 		xTykAPIGateway.Server.ListenPath.Value = "/"
+	}
+
+	if overRideValues.CustomDomain != "" {
+		xTykAPIGateway.Server.CustomDomain = overRideValues.CustomDomain
 	}
 
 	var upstreamURL string

--- a/apidef/oas/default_test.go
+++ b/apidef/oas/default_test.go
@@ -60,9 +60,11 @@ func TestOAS_BuildDefaultTykExtension(t *testing.T) {
 			},
 		}
 
+		customDomain := "custom-domain.org"
 		err := oasDef.BuildDefaultTykExtension(TykExtensionConfigParams{
-			ListenPath:  "/listen-api",
-			UpstreamURL: "https://example.org/api",
+			ListenPath:   "/listen-api",
+			UpstreamURL:  "https://example.org/api",
+			CustomDomain: customDomain,
 		})
 
 		assert.Nil(t, err)
@@ -72,6 +74,7 @@ func TestOAS_BuildDefaultTykExtension(t *testing.T) {
 				ListenPath: ListenPath{
 					Value: "/listen-api",
 				},
+				CustomDomain: customDomain,
 			},
 			Upstream: Upstream{
 				URL: "https://example.org/api",
@@ -159,14 +162,18 @@ func TestOAS_BuildDefaultTykExtension(t *testing.T) {
 				ListenPath: ListenPath{
 					Value: "/listen-api",
 				},
+				CustomDomain: "custom-domain.org",
 			},
 		}
 
 		oasDef.SetTykExtension(&existingTykExtension)
 
+		newCustomDomain := "new-custom-domain.org"
+
 		err := oasDef.BuildDefaultTykExtension(TykExtensionConfigParams{
-			ListenPath:  "/new-listen-api",
-			UpstreamURL: "https://example.org/api",
+			ListenPath:   "/new-listen-api",
+			UpstreamURL:  "https://example.org/api",
+			CustomDomain: newCustomDomain,
 		})
 
 		assert.Nil(t, err)
@@ -176,6 +183,7 @@ func TestOAS_BuildDefaultTykExtension(t *testing.T) {
 				ListenPath: ListenPath{
 					Value: "/new-listen-api",
 				},
+				CustomDomain: newCustomDomain,
 			},
 			Upstream: Upstream{
 				URL: "https://example.org/api",


### PR DESCRIPTION
[changelog]
added: customDomain can be configured with simple OAS + params