### PR TITLE
import oas

### DIFF
--- a/gateway/server.go
+++ b/gateway/server.go
@@ -619,6 +619,7 @@ func (gw *Gateway) loadControlAPIEndpoints(muxer *mux.Router) {
 		r.HandleFunc("/apis/oas/{apiID}", gw.apiHandler).Methods(http.MethodDelete)
 		r.HandleFunc("/apis/oas/{apiID}", gw.validateOAS(gw.apiOASPatchHandler)).Methods(http.MethodPatch)
 		r.HandleFunc("/apis/oas/{apiID}/export", gw.apiOASExportHandler).Methods("GET")
+		r.HandleFunc("/import/oas", gw.validateOAS(gw.makeImportedOASTykAPI(gw.apiOASPostHandler))).Methods(http.MethodPost)
 		r.HandleFunc("/health", gw.healthCheckhandler).Methods("GET")
 		r.HandleFunc("/policies", gw.polHandler).Methods("GET", "POST", "PUT", "DELETE")
 		r.HandleFunc("/policies/{polID}", gw.polHandler).Methods("GET", "POST", "PUT", "DELETE")


### PR DESCRIPTION
Create new API definitions with OAS without x-tyk-gateway.
The developer is starting with their own OAS definition that they would like to expose via Tyk (New)

## Related Issue
https://tyktech.atlassian.net/browse/TT-5411


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

