### PR TITLE
Fix: nil panic for groupResetHandler in tests

### DIFF
--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -425,7 +425,7 @@ const (
 	NonCanonicalHeaderKey = "X-CertificateOuid"
 )
 
-func (s *Test) testHttpHandler() *mux.Router {
+func (s *Test) testHttpHandler(gw *Gateway) *mux.Router {
 	var upgrader = websocket.Upgrader{
 		ReadBufferSize:  1024,
 		WriteBufferSize: 1024,
@@ -513,7 +513,7 @@ func (s *Test) testHttpHandler() *mux.Router {
 		gz.Close()
 	})
 	r.HandleFunc("/chunked", chunkedEncodingHandler)
-	r.HandleFunc("/groupReload", s.Gw.groupResetHandler)
+	r.HandleFunc("/groupReload", gw.groupResetHandler)
 	r.HandleFunc("/bundles/{rest:.*}", s.BundleHandleFunc)
 	r.HandleFunc("/errors/{status}", func(w http.ResponseWriter, r *http.Request) {
 		statusCode, _ := strconv.Atoi(mux.Vars(r)["status"])
@@ -984,7 +984,6 @@ func (s *Test) start(genConf func(globalConf *config.Config)) *Gateway {
 		RequestBuilder: func(tc *test.TestCase) (*http.Request, error) {
 			tc.BaseURL = s.URL
 			if tc.ControlRequest {
-
 				if s.config.SeparateControlAPI {
 					tc.BaseURL = scheme + s.controlProxy().listener.Addr().String()
 				} else if s.GlobalConfig.ControlAPIHostname != "" {
@@ -1066,7 +1065,7 @@ func (s *Test) newGateway(genConf func(globalConf *config.Config)) *Gateway {
 		genConf(&gwConfig)
 	}
 
-	s.TestServerRouter = s.testHttpHandler()
+	s.TestServerRouter = s.testHttpHandler(gw)
 
 	skip := gwConfig.HttpServerOptions.SkipURLCleaning
 	s.TestServerRouter.SkipClean(skip)


### PR DESCRIPTION
When refactoring gateway object scope in testutilities to be explicit, testHttpHandler registered a route on (*Gateway)(nil), resulting in a panic. This fix explicitly passes a gateway object.

# TT-5252

TestReloadLoop_group is flaky, but it was panicking due some testutil rewrites, which ended up with a (*Gateway)(nil) value. I've resolved the panic, but the flakyness is still there:

```
$ gotest -run=TestReloadLoop_group -count=100 -v . | egrep -e '(PASS|FAIL):' | sort | uniq -c
     42 --- FAIL: TestReloadLoop_group (0.02s)
     58 --- PASS: TestReloadLoop_group (0.02s)
```

This is a marked flaky tests, starting work TBD next sprint(s)