### PR TITLE
[TT-5328] Add BalanceStrategy and IsolationLevel to Kafka config adapter

### DIFF
--- a/apidef/adapter/graphql_config_adapter.go
+++ b/apidef/adapter/graphql_config_adapter.go
@@ -261,6 +261,8 @@ func (g *GraphQLConfigAdapter) engineConfigV2DataSources() (planDataSources []pl
 					ClientID:             kafkaConfig.ClientID,
 					KafkaVersion:         kafkaConfig.KafkaVersion,
 					StartConsumingLatest: kafkaConfig.StartConsumingLatest,
+					BalanceStrategy:      kafkaConfig.BalanceStrategy,
+					IsolationLevel:       kafkaConfig.IsolationLevel,
 				},
 			})
 		}

--- a/apidef/adapter/graphql_config_adapter_test.go
+++ b/apidef/adapter/graphql_config_adapter_test.go
@@ -723,6 +723,8 @@ func TestGraphQLConfigAdapter_engineConfigV2DataSources(t *testing.T) {
 					ClientID:             "test.client.id",
 					KafkaVersion:         "V2_8_0_0",
 					StartConsumingLatest: true,
+					BalanceStrategy:      kafkaDataSource.BalanceStrategySticky,
+					IsolationLevel:       kafkaDataSource.IsolationLevelReadCommitted,
 				},
 			}),
 		},
@@ -742,6 +744,8 @@ func TestGraphQLConfigAdapter_engineConfigV2DataSources(t *testing.T) {
 					ClientID:             "test.client.id",
 					KafkaVersion:         "V2_8_0_0",
 					StartConsumingLatest: true,
+					BalanceStrategy:      kafkaDataSource.BalanceStrategySticky,
+					IsolationLevel:       kafkaDataSource.IsolationLevelReadCommitted,
 				},
 			}),
 		},
@@ -991,7 +995,9 @@ var graphqlEngineV2ConfigJson = `{
 					"group_id": "test.consumer.group",
 					"client_id": "test.client.id",
 					"kafka_version": "V2_8_0_0",
-					"start_consuming_latest": true
+					"start_consuming_latest": true,
+					"balance_strategy": "BalanceStrategySticky",
+					"isolation_level": "ReadCommitted"
 				}
 			},
 			{
@@ -1010,7 +1016,9 @@ var graphqlEngineV2ConfigJson = `{
 					"group_id": "test.consumer.group",
 					"client_id": "test.client.id",
 					"kafka_version": "V2_8_0_0",
-					"start_consuming_latest": true
+					"start_consuming_latest": true,
+					"balance_strategy": "BalanceStrategySticky",
+					"isolation_level": "ReadCommitted"
 				}
 			}
 		]

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -817,6 +817,8 @@ type GraphQLEngineDataSourceConfigKafka struct {
 	ClientID             string `bson:"client_id" json:"client_id"`
 	KafkaVersion         string `bson:"kafka_version" json:"kafka_version"`
 	StartConsumingLatest bool   `json:"start_consuming_latest"`
+	BalanceStrategy      string `json:"balance_strategy"`
+	IsolationLevel       string `json:"isolation_level"`
 }
 
 type QueryVariable struct {


### PR DESCRIPTION
I added `BalanceStrategy` and `IsolationLevel` configuration options to the Kafka config adapter in this PR.