### PR TITLE
do not configure upstreamURL form servers if it's already present 

### DIFF
--- a/apidef/oas/default.go
+++ b/apidef/oas/default.go
@@ -81,7 +81,7 @@ func (s *OAS) BuildDefaultTykExtension(overRideValues TykExtensionConfigParams) 
 
 	if overRideValues.UpstreamURL != "" {
 		upstreamURL = overRideValues.UpstreamURL
-	} else {
+	} else if xTykAPIGateway.Upstream.URL == "" {
 		if len(s.Servers) == 0 {
 			return errEmptyServersObject
 		}
@@ -89,11 +89,13 @@ func (s *OAS) BuildDefaultTykExtension(overRideValues TykExtensionConfigParams) 
 		upstreamURL = s.Servers[0].URL
 	}
 
-	if err := getURLFormatErr(overRideValues.UpstreamURL != "", upstreamURL); err != nil {
-		return err
-	}
+	if upstreamURL != "" {
+		if err := getURLFormatErr(overRideValues.UpstreamURL != "", upstreamURL); err != nil {
+			return err
+		}
 
-	xTykAPIGateway.Upstream.URL = upstreamURL
+		xTykAPIGateway.Upstream.URL = upstreamURL
+	}
 
 	if overRideValues.Authentication != nil {
 		err := s.importAuthentication(*overRideValues.Authentication)

--- a/apidef/oas/default_test.go
+++ b/apidef/oas/default_test.go
@@ -913,6 +913,50 @@ func TestOAS_BuildDefaultTykExtension(t *testing.T) {
 
 	})
 
+	t.Run("do not configure upstream URL with servers when upstream URL params is not provided and "+
+		"upstream URL in x-tyk in not empty", func(t *testing.T) {
+		oasDef := OAS{
+			T: openapi3.T{
+				Info: &openapi3.Info{
+					Title: "OAS API",
+				},
+				Servers: openapi3.Servers{
+					{
+						URL: "https://example-org.com/api",
+					},
+				},
+			},
+		}
+
+		existingTykExtension := XTykAPIGateway{
+			Info: Info{
+				Name: "New OAS API",
+			},
+			Server: Server{
+				ListenPath: ListenPath{
+					Value: "/listen-api",
+				},
+			},
+			Upstream: Upstream{
+				URL: "https://upstream.org/api",
+			},
+		}
+
+		oasDef.SetTykExtension(&existingTykExtension)
+
+		newListenPath := "/new-listen-api"
+
+		expectedTykExtension := existingTykExtension
+		expectedTykExtension.Server.ListenPath.Value = newListenPath
+		expectedTykExtension.Info.State.Active = true
+
+		err := oasDef.BuildDefaultTykExtension(TykExtensionConfigParams{
+			ListenPath: newListenPath,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, expectedTykExtension, *oasDef.GetTykExtension())
+	})
+
 }
 
 func TestGetTykExtensionConfigParams(t *testing.T) {


### PR DESCRIPTION
do not configure upstreamURL form servers if it's already present in x-tyk-gw
[changelog]
internal: skip configuring upstreamURL from servers if it's already present in x-tyk-api-gw
