### PR TITLE
ignore ValidatePathMeta.Schema from datastore

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -323,7 +323,7 @@ type ValidatePathMeta struct {
 	Disabled    bool                    `bson:"disabled" json:"disabled"`
 	Path        string                  `bson:"path" json:"path"`
 	Method      string                  `bson:"method" json:"method"`
-	Schema      map[string]interface{}  `bson:"schema" json:"schema"`
+	Schema      map[string]interface{}  `bson:"-" json:"-"`
 	SchemaB64   string                  `bson:"schema_b64" json:"schema_b64,omitempty"`
 	SchemaCache gojsonschema.JSONLoader `bson:"-" json:"-"`
 	// Allows override of default 422 Unprocessible Entity response code for validation errors.

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -323,7 +323,7 @@ type ValidatePathMeta struct {
 	Disabled    bool                    `bson:"disabled" json:"disabled"`
 	Path        string                  `bson:"path" json:"path"`
 	Method      string                  `bson:"method" json:"method"`
-	Schema      map[string]interface{}  `bson:"-" json:"-"`
+	Schema      map[string]interface{}  `bson:"-" json:"schema"`
 	SchemaB64   string                  `bson:"schema_b64" json:"schema_b64,omitempty"`
 	SchemaCache gojsonschema.JSONLoader `bson:"-" json:"-"`
 	// Allows override of default 422 Unprocessible Entity response code for validation errors.

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -324,7 +324,7 @@ type ValidatePathMeta struct {
 	Path        string                  `bson:"path" json:"path"`
 	Method      string                  `bson:"method" json:"method"`
 	Schema      map[string]interface{}  `bson:"-" json:"schema"`
-	SchemaB64   string                  `bson:"schema_b64" json:"schema_b64,omitempty"`
+	SchemaB64   string                  `bson:"schema_b64" json:"-"`
 	SchemaCache gojsonschema.JSONLoader `bson:"-" json:"-"`
 	// Allows override of default 422 Unprocessible Entity response code for validation errors.
 	ErrorResponseCode int `bson:"error_response_code" json:"error_response_code"`


### PR DESCRIPTION
`ValidatePathMeta.Schema64` will be considered over `ValidatePathMeta.Schema`

## Related Issue
https://tyktech.atlassian.net/browse/TT-5547

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

