### PR TITLE
bugfix: Downgrade protobuf version for python 3.7

### DIFF
--- a/Dockerfile.std
+++ b/Dockerfile.std
@@ -15,7 +15,7 @@ RUN apt-get install -y python3-setuptools libpython3.7 python3.7-dev curl \
     && curl https://bootstrap.pypa.io/get-pip.py | python3 \
     && rm -rf /usr/include/* && rm /usr/lib/*-linux-gnu/*.a && rm /usr/lib/*-linux-gnu/*.o \
     && rm /usr/lib/python3.7/config-3.7m-*-linux-gnu/*.a \
-    && pip3 install --only-binary ":all:" grpcio protobuf \
+    && pip3 install --only-binary ":all:" grpcio protobuf==3.20.1 \
     && apt-get autoremove -y \
     && rm -rf /root/.cache \
     && rm -rf /var/lib/apt/lists/*

--- a/integration/smoke-tests/python-plugins/docker-compose.yml
+++ b/integration/smoke-tests/python-plugins/docker-compose.yml
@@ -4,6 +4,12 @@ services:
     image: redis
     ports:
       - "0.0.0.0:6379:6379"
+    healthcheck:
+      test: [ "CMD", "redis-cli", "--raw", "incr", "ping" ]
+      interval: 5s
+      retries: 10
+      start_period: 2s
+      timeout: 10s
 
   bundler:
     build:
@@ -20,3 +26,17 @@ services:
       - "0.0.0.0:8080:8080"
     environment:
       - TYK_LOGLEVEL=debug
+    healthcheck:
+      test: curl -s --fail http://localhost:8080/hello | grep -o '.*"status":"pass".*"status":"pass"'
+      interval: 5s
+      retries: 10
+      start_period: 2s
+      timeout: 10s
+  wait:
+    image: hello-world:linux
+    depends_on:
+        gw:
+            condition: service_healthy
+        redis:
+            condition: service_healthy
+      

--- a/integration/smoke-tests/python-plugins/test.sh
+++ b/integration/smoke-tests/python-plugins/test.sh
@@ -18,6 +18,5 @@ EOF
 export tag=$1
 
 docker-compose build && docker-compose up -d
-sleep 2 # Wait to start
 curl http://localhost:8080/pyplugin/headers | jq -e '.headers.Foo == "Bar"'
 docker-compose down


### PR DESCRIPTION
Protobuf version major update introduces breaking changes against python 3.7 we need to downgrade in order to fix GW container not starting.

More info: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates