### PR TITLE
[TT-3154] Fix stripping listen path when it contains regexp

### DIFF
--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -1269,6 +1269,11 @@ func TestStripListenPath(t *testing.T) {
 	assert.Equal(t, "/", stripListenPath("/listen/", "/listen/", nil))
 	assert.Equal(t, "/", stripListenPath("/listen", "/listen", nil))
 	assert.Equal(t, "/", stripListenPath("listen/", "", nil))
+
+	assert.Equal(t, "/get", stripListenPath("/{_:.*}/post/", "/listen/post/get"))
+	assert.Equal(t, "/get", stripListenPath("/{_:.*}/", "/listen/get"))
+	assert.Equal(t, "/get", stripListenPath("/pre/{_:.*}/", "/pre/listen/get"))
+	assert.Equal(t, "/", stripListenPath("/{_:.*}", "/listen"))
 }
 
 func TestAPISpec_SanitizeProxyPaths(t *testing.T) {

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -1262,13 +1262,13 @@ func TestAPIExpiration(t *testing.T) {
 }
 
 func TestStripListenPath(t *testing.T) {
-	assert.Equal(t, "/get", stripListenPath("/listen", "/listen/get", nil))
-	assert.Equal(t, "/get", stripListenPath("/listen/", "/listen/get", nil))
-	assert.Equal(t, "/get", stripListenPath("listen", "listen/get", nil))
-	assert.Equal(t, "/get", stripListenPath("listen/", "listen/get", nil))
-	assert.Equal(t, "/", stripListenPath("/listen/", "/listen/", nil))
-	assert.Equal(t, "/", stripListenPath("/listen", "/listen", nil))
-	assert.Equal(t, "/", stripListenPath("listen/", "", nil))
+	assert.Equal(t, "/get", stripListenPath("/listen", "/listen/get"))
+	assert.Equal(t, "/get", stripListenPath("/listen/", "/listen/get"))
+	assert.Equal(t, "/get", stripListenPath("listen", "listen/get"))
+	assert.Equal(t, "/get", stripListenPath("listen/", "listen/get"))
+	assert.Equal(t, "/", stripListenPath("/listen/", "/listen/"))
+	assert.Equal(t, "/", stripListenPath("/listen", "/listen"))
+	assert.Equal(t, "/", stripListenPath("listen/", ""))
 
 	assert.Equal(t, "/get", stripListenPath("/{_:.*}/post/", "/listen/post/get"))
 	assert.Equal(t, "/get", stripListenPath("/{_:.*}/", "/listen/get"))

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -1693,44 +1693,6 @@ func TestBrokenClients(t *testing.T) {
 	})
 }
 
-func TestStripRegex(t *testing.T) {
-	sample := []struct {
-		strip  string
-		path   string
-		expect string
-		vars   map[string]string
-	}{
-		{
-			strip:  "/base",
-			path:   "/base/path",
-			expect: "/path",
-			vars:   map[string]string{},
-		},
-		{
-			strip:  "/base/{key}",
-			path:   "/base/path/path",
-			expect: "/path",
-			vars: map[string]string{
-				"key": "path",
-			},
-		},
-		{
-			strip:  "/taihoe-test/{test:[\\w\\d]+}/id/",
-			path:   "/taihoe-test/asdas234234dad/id/v1/get",
-			expect: "/v1/get",
-			vars: map[string]string{
-				"test": "asdas234234dad",
-			},
-		},
-	}
-	for _, v := range sample {
-		got := stripListenPath(v.strip, v.path, v.vars)
-		if got != v.expect {
-			t.Errorf("expected %s got %s", v.expect, got)
-		}
-	}
-}
-
 func TestCache_singleErrorResponse(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("{}"))


### PR DESCRIPTION
We already had old code which stripped regexp https://github.com/TykTechnologies/tyk/pull/2466/files
But it worked only if you define a named variable inside it.
Current logic changed to use more simple algorithm from this PR https://github.com/TykTechnologies/tyk/pull/2277/files

## Related Issue
https://github.com/TykTechnologies/tyk/pull/2466/files
https://github.com/TykTechnologies/tyk/pull/2277/files



## How This Has Been Tested
Added unit tests

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [x] `go vet`
