### PR TITLE
[TT-2162] Feature respect key expiration

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -568,65 +568,66 @@ type APIDefinition struct {
 	// CertificatePinningDisabled disables public key pinning
 	CertificatePinningDisabled bool `bson:"certificate_pinning_disabled" json:"certificate_pinning_disabled"`
 
-	EnableJWT                  bool                   `bson:"enable_jwt" json:"enable_jwt"`
-	UseStandardAuth            bool                   `bson:"use_standard_auth" json:"use_standard_auth"`
-	UseGoPluginAuth            bool                   `bson:"use_go_plugin_auth" json:"use_go_plugin_auth"`
-	EnableCoProcessAuth        bool                   `bson:"enable_coprocess_auth" json:"enable_coprocess_auth"`
-	JWTSigningMethod           string                 `bson:"jwt_signing_method" json:"jwt_signing_method"`
-	JWTSource                  string                 `bson:"jwt_source" json:"jwt_source"`
-	JWTIdentityBaseField       string                 `bson:"jwt_identit_base_field" json:"jwt_identity_base_field"`
-	JWTClientIDBaseField       string                 `bson:"jwt_client_base_field" json:"jwt_client_base_field"`
-	JWTPolicyFieldName         string                 `bson:"jwt_policy_field_name" json:"jwt_policy_field_name"`
-	JWTDefaultPolicies         []string               `bson:"jwt_default_policies" json:"jwt_default_policies"`
-	JWTIssuedAtValidationSkew  uint64                 `bson:"jwt_issued_at_validation_skew" json:"jwt_issued_at_validation_skew"`
-	JWTExpiresAtValidationSkew uint64                 `bson:"jwt_expires_at_validation_skew" json:"jwt_expires_at_validation_skew"`
-	JWTNotBeforeValidationSkew uint64                 `bson:"jwt_not_before_validation_skew" json:"jwt_not_before_validation_skew"`
-	JWTSkipKid                 bool                   `bson:"jwt_skip_kid" json:"jwt_skip_kid"`
-	Scopes                     Scopes                 `bson:"scopes" json:"scopes"`
-	JWTScopeToPolicyMapping    map[string]string      `bson:"jwt_scope_to_policy_mapping" json:"jwt_scope_to_policy_mapping"` // Deprecated: use Scopes.JWT.ScopeToPolicy or Scopes.OIDC.ScopeToPolicy
-	JWTScopeClaimName          string                 `bson:"jwt_scope_claim_name" json:"jwt_scope_claim_name"`               // Deprecated: use Scopes.JWT.ScopeClaimName or Scopes.OIDC.ScopeClaimName
-	NotificationsDetails       NotificationsManager   `bson:"notifications" json:"notifications"`
-	EnableSignatureChecking    bool                   `bson:"enable_signature_checking" json:"enable_signature_checking"`
-	HmacAllowedClockSkew       float64                `bson:"hmac_allowed_clock_skew" json:"hmac_allowed_clock_skew"`
-	HmacAllowedAlgorithms      []string               `bson:"hmac_allowed_algorithms" json:"hmac_allowed_algorithms"`
-	RequestSigning             RequestSigningMeta     `bson:"request_signing" json:"request_signing"`
-	BaseIdentityProvidedBy     AuthTypeEnum           `bson:"base_identity_provided_by" json:"base_identity_provided_by"`
-	VersionDefinition          VersionDefinition      `bson:"definition" json:"definition"`
-	VersionData                VersionData            `bson:"version_data" json:"version_data"` // Deprecated. Use VersionDefinition instead.
-	UptimeTests                UptimeTests            `bson:"uptime_tests" json:"uptime_tests"`
-	Proxy                      ProxyConfig            `bson:"proxy" json:"proxy"`
-	DisableRateLimit           bool                   `bson:"disable_rate_limit" json:"disable_rate_limit"`
-	DisableQuota               bool                   `bson:"disable_quota" json:"disable_quota"`
-	CustomMiddleware           MiddlewareSection      `bson:"custom_middleware" json:"custom_middleware"`
-	CustomMiddlewareBundle     string                 `bson:"custom_middleware_bundle" json:"custom_middleware_bundle"`
-	CacheOptions               CacheOptions           `bson:"cache_options" json:"cache_options"`
-	SessionLifetime            int64                  `bson:"session_lifetime" json:"session_lifetime"`
-	Active                     bool                   `bson:"active" json:"active"`
-	Internal                   bool                   `bson:"internal" json:"internal"`
-	AuthProvider               AuthProviderMeta       `bson:"auth_provider" json:"auth_provider"`
-	SessionProvider            SessionProviderMeta    `bson:"session_provider" json:"session_provider"`
-	EventHandlers              EventHandlerMetaConfig `bson:"event_handlers" json:"event_handlers"`
-	EnableBatchRequestSupport  bool                   `bson:"enable_batch_request_support" json:"enable_batch_request_support"`
-	EnableIpWhiteListing       bool                   `mapstructure:"enable_ip_whitelisting" bson:"enable_ip_whitelisting" json:"enable_ip_whitelisting"`
-	AllowedIPs                 []string               `mapstructure:"allowed_ips" bson:"allowed_ips" json:"allowed_ips"`
-	EnableIpBlacklisting       bool                   `mapstructure:"enable_ip_blacklisting" bson:"enable_ip_blacklisting" json:"enable_ip_blacklisting"`
-	BlacklistedIPs             []string               `mapstructure:"blacklisted_ips" bson:"blacklisted_ips" json:"blacklisted_ips"`
-	DontSetQuotasOnCreate      bool                   `mapstructure:"dont_set_quota_on_create" bson:"dont_set_quota_on_create" json:"dont_set_quota_on_create"`
-	ExpireAnalyticsAfter       int64                  `mapstructure:"expire_analytics_after" bson:"expire_analytics_after" json:"expire_analytics_after"` // must have an expireAt TTL index set (http://docs.mongodb.org/manual/tutorial/expire-data/)
-	ResponseProcessors         []ResponseProcessor    `bson:"response_processors" json:"response_processors"`
-	CORS                       CORSConfig             `bson:"CORS" json:"CORS"`
-	Domain                     string                 `bson:"domain" json:"domain"`
-	DomainDisabled             bool                   `bson:"domain_disabled" json:"domain_disabled"`
-	Certificates               []string               `bson:"certificates" json:"certificates"`
-	DoNotTrack                 bool                   `bson:"do_not_track" json:"do_not_track"`
-	EnableContextVars          bool                   `bson:"enable_context_vars" json:"enable_context_vars"`
-	ConfigData                 map[string]interface{} `bson:"config_data" json:"config_data"`
-	TagHeaders                 []string               `bson:"tag_headers" json:"tag_headers"`
-	GlobalRateLimit            GlobalRateLimit        `bson:"global_rate_limit" json:"global_rate_limit"`
-	StripAuthData              bool                   `bson:"strip_auth_data" json:"strip_auth_data"`
-	EnableDetailedRecording    bool                   `bson:"enable_detailed_recording" json:"enable_detailed_recording"`
-	GraphQL                    GraphQLConfig          `bson:"graphql" json:"graphql"`
-	AnalyticsPlugin            AnalyticsPluginConfig  `bson:"analytics_plugin" json:"analytics_plugin"`
+	EnableJWT                            bool                   `bson:"enable_jwt" json:"enable_jwt"`
+	UseStandardAuth                      bool                   `bson:"use_standard_auth" json:"use_standard_auth"`
+	UseGoPluginAuth                      bool                   `bson:"use_go_plugin_auth" json:"use_go_plugin_auth"`
+	EnableCoProcessAuth                  bool                   `bson:"enable_coprocess_auth" json:"enable_coprocess_auth"`
+	JWTSigningMethod                     string                 `bson:"jwt_signing_method" json:"jwt_signing_method"`
+	JWTSource                            string                 `bson:"jwt_source" json:"jwt_source"`
+	JWTIdentityBaseField                 string                 `bson:"jwt_identit_base_field" json:"jwt_identity_base_field"`
+	JWTClientIDBaseField                 string                 `bson:"jwt_client_base_field" json:"jwt_client_base_field"`
+	JWTPolicyFieldName                   string                 `bson:"jwt_policy_field_name" json:"jwt_policy_field_name"`
+	JWTDefaultPolicies                   []string               `bson:"jwt_default_policies" json:"jwt_default_policies"`
+	JWTIssuedAtValidationSkew            uint64                 `bson:"jwt_issued_at_validation_skew" json:"jwt_issued_at_validation_skew"`
+	JWTExpiresAtValidationSkew           uint64                 `bson:"jwt_expires_at_validation_skew" json:"jwt_expires_at_validation_skew"`
+	JWTNotBeforeValidationSkew           uint64                 `bson:"jwt_not_before_validation_skew" json:"jwt_not_before_validation_skew"`
+	JWTSkipKid                           bool                   `bson:"jwt_skip_kid" json:"jwt_skip_kid"`
+	Scopes                               Scopes                 `bson:"scopes" json:"scopes"`
+	JWTScopeToPolicyMapping              map[string]string      `bson:"jwt_scope_to_policy_mapping" json:"jwt_scope_to_policy_mapping"` // Deprecated: use Scopes.JWT.ScopeToPolicy or Scopes.OIDC.ScopeToPolicy
+	JWTScopeClaimName                    string                 `bson:"jwt_scope_claim_name" json:"jwt_scope_claim_name"`               // Deprecated: use Scopes.JWT.ScopeClaimName or Scopes.OIDC.ScopeClaimName
+	NotificationsDetails                 NotificationsManager   `bson:"notifications" json:"notifications"`
+	EnableSignatureChecking              bool                   `bson:"enable_signature_checking" json:"enable_signature_checking"`
+	HmacAllowedClockSkew                 float64                `bson:"hmac_allowed_clock_skew" json:"hmac_allowed_clock_skew"`
+	HmacAllowedAlgorithms                []string               `bson:"hmac_allowed_algorithms" json:"hmac_allowed_algorithms"`
+	RequestSigning                       RequestSigningMeta     `bson:"request_signing" json:"request_signing"`
+	BaseIdentityProvidedBy               AuthTypeEnum           `bson:"base_identity_provided_by" json:"base_identity_provided_by"`
+	VersionDefinition                    VersionDefinition      `bson:"definition" json:"definition"`
+	VersionData                          VersionData            `bson:"version_data" json:"version_data"` // Deprecated. Use VersionDefinition instead.
+	UptimeTests                          UptimeTests            `bson:"uptime_tests" json:"uptime_tests"`
+	Proxy                                ProxyConfig            `bson:"proxy" json:"proxy"`
+	DisableRateLimit                     bool                   `bson:"disable_rate_limit" json:"disable_rate_limit"`
+	DisableQuota                         bool                   `bson:"disable_quota" json:"disable_quota"`
+	CustomMiddleware                     MiddlewareSection      `bson:"custom_middleware" json:"custom_middleware"`
+	CustomMiddlewareBundle               string                 `bson:"custom_middleware_bundle" json:"custom_middleware_bundle"`
+	CacheOptions                         CacheOptions           `bson:"cache_options" json:"cache_options"`
+	SessionLifetimeRespectsKeyExpiration bool                   `bson:"session_lifetime_respects_key_expiration" json:"session_lifetime_respects_key_expiration"`
+	SessionLifetime                      int64                  `bson:"session_lifetime" json:"session_lifetime"`
+	Active                               bool                   `bson:"active" json:"active"`
+	Internal                             bool                   `bson:"internal" json:"internal"`
+	AuthProvider                         AuthProviderMeta       `bson:"auth_provider" json:"auth_provider"`
+	SessionProvider                      SessionProviderMeta    `bson:"session_provider" json:"session_provider"`
+	EventHandlers                        EventHandlerMetaConfig `bson:"event_handlers" json:"event_handlers"`
+	EnableBatchRequestSupport            bool                   `bson:"enable_batch_request_support" json:"enable_batch_request_support"`
+	EnableIpWhiteListing                 bool                   `mapstructure:"enable_ip_whitelisting" bson:"enable_ip_whitelisting" json:"enable_ip_whitelisting"`
+	AllowedIPs                           []string               `mapstructure:"allowed_ips" bson:"allowed_ips" json:"allowed_ips"`
+	EnableIpBlacklisting                 bool                   `mapstructure:"enable_ip_blacklisting" bson:"enable_ip_blacklisting" json:"enable_ip_blacklisting"`
+	BlacklistedIPs                       []string               `mapstructure:"blacklisted_ips" bson:"blacklisted_ips" json:"blacklisted_ips"`
+	DontSetQuotasOnCreate                bool                   `mapstructure:"dont_set_quota_on_create" bson:"dont_set_quota_on_create" json:"dont_set_quota_on_create"`
+	ExpireAnalyticsAfter                 int64                  `mapstructure:"expire_analytics_after" bson:"expire_analytics_after" json:"expire_analytics_after"` // must have an expireAt TTL index set (http://docs.mongodb.org/manual/tutorial/expire-data/)
+	ResponseProcessors                   []ResponseProcessor    `bson:"response_processors" json:"response_processors"`
+	CORS                                 CORSConfig             `bson:"CORS" json:"CORS"`
+	Domain                               string                 `bson:"domain" json:"domain"`
+	DomainDisabled                       bool                   `bson:"domain_disabled" json:"domain_disabled"`
+	Certificates                         []string               `bson:"certificates" json:"certificates"`
+	DoNotTrack                           bool                   `bson:"do_not_track" json:"do_not_track"`
+	EnableContextVars                    bool                   `bson:"enable_context_vars" json:"enable_context_vars"`
+	ConfigData                           map[string]interface{} `bson:"config_data" json:"config_data"`
+	TagHeaders                           []string               `bson:"tag_headers" json:"tag_headers"`
+	GlobalRateLimit                      GlobalRateLimit        `bson:"global_rate_limit" json:"global_rate_limit"`
+	StripAuthData                        bool                   `bson:"strip_auth_data" json:"strip_auth_data"`
+	EnableDetailedRecording              bool                   `bson:"enable_detailed_recording" json:"enable_detailed_recording"`
+	GraphQL                              GraphQLConfig          `bson:"graphql" json:"graphql"`
+	AnalyticsPlugin                      AnalyticsPluginConfig  `bson:"analytics_plugin" json:"analytics_plugin"`
 
 	// Gateway segment tags
 	TagsDisabled bool     `bson:"tags_disabled" json:"tags_disabled"`

--- a/apidef/schema.go
+++ b/apidef/schema.go
@@ -256,6 +256,9 @@ const Schema = `{
                 }
             }
         },
+        "session_lifetime_respects_key_expiration": {
+            "type": "boolean"
+        },
         "session_lifetime": {
             "type": "number"
         },

--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -423,6 +423,9 @@
     "global_session_lifetime": {
       "type": "integer"
     },
+    "session_lifetime_respects_key_expiration": {
+      "type": "boolean"
+    },
     "graylog_network_addr": {
       "type": "string"
     },

--- a/config/config.go
+++ b/config/config.go
@@ -952,6 +952,8 @@ type Config struct {
 
 	// Enable global API token expiration. Can be needed if all your APIs using JWT or oAuth 2.0 auth methods with dynamically generated keys.
 	ForceGlobalSessionLifetime bool `bson:"force_global_session_lifetime" json:"force_global_session_lifetime"`
+	// SessionLifetimeRespectsKeyExpiration respects the key expiration time when the session lifetime is less than the key expiration. That is, Redis waits the key expiration for physical removal.
+	SessionLifetimeRespectsKeyExpiration bool `bson:"session_lifetime_respects_key_expiration" json:"session_lifetime_respects_key_expiration"`
 	// global session lifetime, in seconds.
 	GlobalSessionLifetime int64 `bson:"global_session_lifetime" json:"global_session_lifetime"`
 

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -245,7 +245,7 @@ func (gw *Gateway) applyPoliciesAndSave(keyName string, session *user.SessionSta
 		return err
 	}
 
-	lifetime := session.Lifetime(spec.SessionLifetime, gw.GetConfig().ForceGlobalSessionLifetime, gw.GetConfig().GlobalSessionLifetime)
+	lifetime := session.Lifetime(spec.GetSessionLifetimeRespectsKeyExpiration(), spec.SessionLifetime, gw.GetConfig().ForceGlobalSessionLifetime, gw.GetConfig().GlobalSessionLifetime)
 	if err := gw.GlobalSessionManager.UpdateSession(keyName, session, lifetime, isHashed); err != nil {
 		return err
 	}

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -217,6 +217,16 @@ type APISpec struct {
 	} `json:"-"`
 }
 
+// GetSessionLifetimeRespectsKeyExpiration returns a boolean to tell whether session lifetime should respect to key expiration or not.
+// The global config takes the precedence. If the global one is `true`, value of the one in api level doesn't matter.
+func (a *APISpec) GetSessionLifetimeRespectsKeyExpiration() bool {
+	if a.GlobalConfig.SessionLifetimeRespectsKeyExpiration {
+		return true
+	}
+
+	return a.SessionLifetimeRespectsKeyExpiration
+}
+
 // Release releases all resources associated with API spec
 func (s *APISpec) Release() {
 	// release circuit breaker resources

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -1386,3 +1386,25 @@ func TestEnforcedTimeout(t *testing.T) {
 		})
 	})
 }
+
+func TestAPISpec_GetSessionLifetimeRespectsKeyExpiration(t *testing.T) {
+	a := APISpec{APIDefinition: &apidef.APIDefinition{}}
+
+	t.Run("GetSessionLifetimeRespectsKeyExpiration=false", func(t *testing.T) {
+		a.GlobalConfig.SessionLifetimeRespectsKeyExpiration = false
+		a.SessionLifetimeRespectsKeyExpiration = false
+		assert.False(t, a.GetSessionLifetimeRespectsKeyExpiration())
+
+		a.SessionLifetimeRespectsKeyExpiration = true
+		assert.True(t, a.GetSessionLifetimeRespectsKeyExpiration())
+	})
+
+	t.Run("GetSessionLifetimeRespectsKeyExpiration=true", func(t *testing.T) {
+		a.GlobalConfig.SessionLifetimeRespectsKeyExpiration = true
+		a.SessionLifetimeRespectsKeyExpiration = false
+		assert.True(t, a.GetSessionLifetimeRespectsKeyExpiration())
+
+		a.SessionLifetimeRespectsKeyExpiration = true
+		assert.True(t, a.GetSessionLifetimeRespectsKeyExpiration())
+	})
+}

--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -1192,6 +1192,54 @@ func TestKeyHandler_HashingDisabled(t *testing.T) {
 	})
 }
 
+func TestSessionLifetimeRespectsKeyExpiration(t *testing.T) {
+	const respectingAPI = "respectingAPI"
+	const overridingAPI = "overridingAPI"
+
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	t.Run("override session lifetime with api level", func(t *testing.T) {
+		ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+			spec.APIID = overridingAPI
+			spec.UseKeylessAccess = false
+			spec.SessionLifetime = 1
+			spec.SessionLifetimeRespectsKeyExpiration = false
+		})
+
+		_, toBeOverriddenKey := ts.CreateSession(func(s *user.SessionState) {
+			s.AccessRights = map[string]user.AccessDefinition{overridingAPI: {
+				APIID: overridingAPI,
+			}}
+		})
+
+		_, _ = ts.Run(t, []test.TestCase{
+			{AdminAuth: true, Path: "/tyk/keys/" + toBeOverriddenKey, Code: http.StatusOK, Delay: time.Second},
+			{AdminAuth: true, Path: "/tyk/keys/" + toBeOverriddenKey, Code: http.StatusNotFound},
+		}...)
+	})
+
+	t.Run("respect key expiration", func(t *testing.T) {
+		ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+			spec.APIID = respectingAPI
+			spec.UseKeylessAccess = false
+			spec.SessionLifetime = 1
+			spec.SessionLifetimeRespectsKeyExpiration = true
+		})
+
+		_, toBeRespectedKey := ts.CreateSession(func(s *user.SessionState) {
+			s.AccessRights = map[string]user.AccessDefinition{respectingAPI: {
+				APIID: respectingAPI,
+			}}
+		})
+
+		_, _ = ts.Run(t, []test.TestCase{
+			{AdminAuth: true, Path: "/tyk/keys/" + toBeRespectedKey, Code: http.StatusOK, Delay: time.Second},
+			{AdminAuth: true, Path: "/tyk/keys/" + toBeRespectedKey, Code: http.StatusOK},
+		}...)
+	})
+}
+
 func TestInvalidateCache(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -278,7 +278,7 @@ func (t BaseMiddleware) UpdateRequestSession(r *http.Request) bool {
 		return false
 	}
 
-	lifetime := session.Lifetime(t.Spec.SessionLifetime, t.Gw.GetConfig().ForceGlobalSessionLifetime, t.Gw.GetConfig().GlobalSessionLifetime)
+	lifetime := session.Lifetime(t.Spec.GetSessionLifetimeRespectsKeyExpiration(), t.Spec.SessionLifetime, t.Gw.GetConfig().ForceGlobalSessionLifetime, t.Gw.GetConfig().GlobalSessionLifetime)
 	if err := t.Gw.GlobalSessionManager.UpdateSession(token, session, lifetime, false); err != nil {
 		t.Logger().WithError(err).Error("Can't update session")
 		return false
@@ -724,7 +724,7 @@ func (t BaseMiddleware) CheckSessionAndIdentityForValidKey(originalKey string, r
 			return session, false
 		}
 
-		t.Logger().Debug("Lifetime is: ", session.Lifetime(t.Spec.SessionLifetime, t.Gw.GetConfig().ForceGlobalSessionLifetime, t.Gw.GetConfig().GlobalSessionLifetime))
+		t.Logger().Debug("Lifetime is: ", session.Lifetime(t.Spec.GetSessionLifetimeRespectsKeyExpiration(), t.Spec.SessionLifetime, t.Gw.GetConfig().ForceGlobalSessionLifetime, t.Gw.GetConfig().GlobalSessionLifetime))
 		ctxScheduleSessionUpdate(r)
 		return session, found
 	}

--- a/gateway/mw_organisation_activity.go
+++ b/gateway/mw_organisation_activity.go
@@ -115,7 +115,7 @@ func (k *OrganizationMonitor) ProcessRequestLive(r *http.Request, orgSession *us
 		false,
 	)
 
-	sessionLifeTime := orgSession.Lifetime(k.Spec.SessionLifetime, k.Gw.GetConfig().ForceGlobalSessionLifetime, k.Gw.GetConfig().GlobalSessionLifetime)
+	sessionLifeTime := orgSession.Lifetime(k.Spec.GetSessionLifetimeRespectsKeyExpiration(), k.Spec.SessionLifetime, k.Gw.GetConfig().ForceGlobalSessionLifetime, k.Gw.GetConfig().GlobalSessionLifetime)
 
 	if err := k.Spec.OrgSessionManager.UpdateSession(k.Spec.OrgID, orgSession, sessionLifeTime, false); err == nil {
 		// update in-app cache if needed
@@ -246,7 +246,7 @@ func (k *OrganizationMonitor) AllowAccessNext(
 		false,
 	)
 
-	sessionLifeTime := session.Lifetime(k.Spec.SessionLifetime, k.Gw.GetConfig().ForceGlobalSessionLifetime, k.Gw.GetConfig().GlobalSessionLifetime)
+	sessionLifeTime := session.Lifetime(k.Spec.GetSessionLifetimeRespectsKeyExpiration(), k.Spec.SessionLifetime, k.Gw.GetConfig().ForceGlobalSessionLifetime, k.Gw.GetConfig().GlobalSessionLifetime)
 
 	if err := k.Spec.OrgSessionManager.UpdateSession(k.Spec.OrgID, session, sessionLifeTime, false); err == nil {
 		// update in-app cache if needed

--- a/gateway/oauth_manager.go
+++ b/gateway/oauth_manager.go
@@ -485,7 +485,7 @@ func (o *OAuthManager) HandleAccess(r *http.Request) *osin.Response {
 			keyName := o.Gw.generateToken(o.API.OrgID, username)
 
 			log.Debug("Updating user:", keyName)
-			err := o.Gw.GlobalSessionManager.UpdateSession(keyName, session, session.Lifetime(o.API.SessionLifetime, o.Gw.GetConfig().ForceGlobalSessionLifetime, o.Gw.GetConfig().GlobalSessionLifetime), false)
+			err := o.Gw.GlobalSessionManager.UpdateSession(keyName, session, session.Lifetime(o.API.GetSessionLifetimeRespectsKeyExpiration(), o.API.SessionLifetime, o.Gw.GetConfig().ForceGlobalSessionLifetime, o.Gw.GetConfig().GlobalSessionLifetime), false)
 			if err != nil {
 				log.Error(err)
 			}

--- a/user/session.go
+++ b/user/session.go
@@ -237,20 +237,50 @@ func (s *SessionState) KeyHashEmpty() bool {
 	return s.keyHash == ""
 }
 
-func (s *SessionState) Lifetime(fallback int64, forceGlobalSessionLifetime bool, globalSessionLifetime int64) int64 {
+// Lifetime returns the lifetime of a session. Global session lifetime has always precedence. Then, the session lifetime value
+// in the key level takes precedence. However, if key `respectKeyExpiration` is `true`, when the key expiration has longer than
+// the session lifetime, the key expiration is returned. It means even if the session lifetime finishes, it waits for the key expiration
+// for physical removal.
+func (s *SessionState) Lifetime(respectKeyExpiration bool, fallback int64, forceGlobalSessionLifetime bool, globalSessionLifetime int64) int64 {
 	if forceGlobalSessionLifetime {
 		return globalSessionLifetime
 	}
 
 	if s.SessionLifetime > 0 {
-		return s.SessionLifetime
+		return calculateLifetime(respectKeyExpiration, s.Expires, s.SessionLifetime)
 	}
 
 	if fallback > 0 {
-		return fallback
+		return calculateLifetime(respectKeyExpiration, s.Expires, fallback)
 	}
 
 	return 0
+}
+
+// calculateLifetime calculates the lifetime of a session. It also sets the value to the key expiration in case of the key expiration
+// value is respected and `lifetime` < `expiration`.
+func calculateLifetime(respectExpiration bool, expiration, lifetime int64) int64 {
+	if lifetime < 0 {
+		lifetime = 0
+	}
+
+	if expiration < 0 {
+		expiration = 0
+	}
+
+	if !respectExpiration {
+		return lifetime
+	}
+
+	if expiration == 0 || lifetime == 0 {
+		return 0
+	}
+
+	if expiration > lifetime {
+		return expiration
+	}
+
+	return lifetime
 }
 
 // PolicyIDs returns the IDs of all the policies applied to this

--- a/user/session_test.go
+++ b/user/session_test.go
@@ -19,27 +19,80 @@ func TestSessionState_Lifetime(t *testing.T) {
 	s := SessionState{}
 
 	t.Run("forceGlobal=false", func(t *testing.T) {
-		s.SessionLifetime = 1
-		assert.Equal(t, int64(1), s.Lifetime(2, false, 3))
+		t.Run("respectExpiration=false", func(t *testing.T) {
+			s.SessionLifetime = 1
+			s.Expires = 5
+			assert.Equal(t, int64(1), s.Lifetime(false, 2, false, 3))
 
-		s.SessionLifetime = 0
-		assert.Equal(t, int64(2), s.Lifetime(2, false, 3))
+			s.SessionLifetime = 0
+			assert.Equal(t, int64(2), s.Lifetime(false, 2, false, 3))
 
-		s.SessionLifetime = 0
-		assert.Equal(t, int64(0), s.Lifetime(0, false, 3))
+			s.SessionLifetime = 0
+			assert.Equal(t, int64(0), s.Lifetime(false, 0, false, 3))
 
-		s.SessionLifetime = 0
-		assert.Equal(t, int64(0), s.Lifetime(-1, false, 3))
+			s.SessionLifetime = 0
+			assert.Equal(t, int64(0), s.Lifetime(false, -1, false, 3))
+		})
+
+		t.Run("respectExpiration=true", func(t *testing.T) {
+			s.SessionLifetime = 1
+			s.Expires = 5
+			assert.Equal(t, int64(5), s.Lifetime(true, 2, false, 3))
+
+			s.SessionLifetime = 0
+			assert.Equal(t, int64(5), s.Lifetime(true, 2, false, 3))
+
+			s.SessionLifetime = 0
+			assert.Equal(t, int64(0), s.Lifetime(true, 0, false, 3))
+
+			s.SessionLifetime = 0
+			assert.Equal(t, int64(0), s.Lifetime(true, -1, false, 3))
+		})
 	})
 
 	t.Run("forceGlobal=true", func(t *testing.T) {
-		s.SessionLifetime = 1
-		assert.Equal(t, int64(3), s.Lifetime(2, true, 3))
+		t.Run("respectExpiration=false", func(t *testing.T) {
+			s.SessionLifetime = 1
+			assert.Equal(t, int64(3), s.Lifetime(false, 2, true, 3))
 
-		s.SessionLifetime = 0
-		assert.Equal(t, int64(3), s.Lifetime(2, true, 3))
+			s.SessionLifetime = 0
+			assert.Equal(t, int64(3), s.Lifetime(false, 2, true, 3))
 
-		s.SessionLifetime = 0
-		assert.Equal(t, int64(3), s.Lifetime(0, true, 3))
+			s.SessionLifetime = 0
+			assert.Equal(t, int64(3), s.Lifetime(false, 0, true, 3))
+		})
+
+		t.Run("respectExpiration=true", func(t *testing.T) {
+			s.SessionLifetime = 1
+			assert.Equal(t, int64(3), s.Lifetime(true, 2, true, 3))
+
+			s.SessionLifetime = 0
+			assert.Equal(t, int64(3), s.Lifetime(true, 2, true, 3))
+
+			s.SessionLifetime = 0
+			assert.Equal(t, int64(3), s.Lifetime(true, 0, true, 3))
+		})
+	})
+}
+
+func Test_calculateLifetime(t *testing.T) {
+	t.Run("respectExpiration=false", func(t *testing.T) {
+		assert.Equal(t, int64(3), calculateLifetime(false, 2, 3))
+		assert.Equal(t, int64(2), calculateLifetime(false, 2, 2))
+		assert.Equal(t, int64(1), calculateLifetime(false, 2, 1))
+		assert.Equal(t, int64(0), calculateLifetime(false, 2, 0))
+		assert.Equal(t, int64(0), calculateLifetime(false, 2, -1))
+		assert.Equal(t, int64(1), calculateLifetime(false, 0, 1))
+		assert.Equal(t, int64(1), calculateLifetime(false, -1, 1))
+	})
+
+	t.Run("respectExpiration=true", func(t *testing.T) {
+		assert.Equal(t, int64(3), calculateLifetime(true, 2, 3))
+		assert.Equal(t, int64(2), calculateLifetime(true, 2, 2))
+		assert.Equal(t, int64(2), calculateLifetime(true, 2, 1))
+		assert.Equal(t, int64(0), calculateLifetime(true, 2, 0))
+		assert.Equal(t, int64(0), calculateLifetime(true, 2, -1))
+		assert.Equal(t, int64(0), calculateLifetime(true, 0, 1))
+		assert.Equal(t, int64(0), calculateLifetime(true, -1, 1))
 	})
 }


### PR DESCRIPTION
This PR defines new fields inside API definition and global config named `session_lifetime_respects_key_expiration`. 

When it is: 
`false`: It will not respect expiration date which is bigger than session lifetime and the key will be physically removed.
`true`: It will respect the expiration which is set in the key level and the key will not be physically removed until expiration time finishes.

if global `session_lifetime_respects_key_expiration` is `true` api level will be ignored