### PR TITLE
[TT-3154] Add extra test case to path regex match

### DIFF
--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -1314,6 +1314,8 @@ func TestStripListenPath(t *testing.T) {
 	assert.Equal(t, "/get", stripListenPath("/{_:.*}/", "/listen/get"))
 	assert.Equal(t, "/get", stripListenPath("/pre/{_:.*}/", "/pre/listen/get"))
 	assert.Equal(t, "/", stripListenPath("/{_:.*}", "/listen"))
+	assert.Equal(t, "/get", stripListenPath("/{myPattern:foo|bar}", "/foo/get"))
+	assert.Equal(t, "/anything/get", stripListenPath("/{myPattern:foo|bar}", "/anything/get"))
 }
 
 func TestAPISpec_SanitizeProxyPaths(t *testing.T) {


### PR DESCRIPTION
There is no such a bug actually. The testing of the feature is not valid. Gorilla's regex feature works like this `{name:pattern}`.

So instead of setting listen path `/{foo|bar|baz}/`. Please try `/{myPattern:foo|bar}` or you can omit name like this `/{_:foo|bar}`.

This PR adds a test case for that to clarify the gorilla regex path usage.