### PR TITLE
[TT-5562] Add SASL options to Kafka data source

### DIFF
--- a/apidef/adapter/graphql_config_adapter.go
+++ b/apidef/adapter/graphql_config_adapter.go
@@ -263,6 +263,7 @@ func (g *GraphQLConfigAdapter) engineConfigV2DataSources() (planDataSources []pl
 					StartConsumingLatest: kafkaConfig.StartConsumingLatest,
 					BalanceStrategy:      kafkaConfig.BalanceStrategy,
 					IsolationLevel:       kafkaConfig.IsolationLevel,
+					SASL:                 kafkaConfig.SASL,
 				},
 			})
 		}

--- a/apidef/adapter/graphql_config_adapter_test.go
+++ b/apidef/adapter/graphql_config_adapter_test.go
@@ -725,6 +725,11 @@ func TestGraphQLConfigAdapter_engineConfigV2DataSources(t *testing.T) {
 					StartConsumingLatest: true,
 					BalanceStrategy:      kafkaDataSource.BalanceStrategySticky,
 					IsolationLevel:       kafkaDataSource.IsolationLevelReadCommitted,
+					SASL: kafkaDataSource.SASL{
+						Enable:   true,
+						User:     "admin",
+						Password: "admin-secret",
+					},
 				},
 			}),
 		},
@@ -746,6 +751,11 @@ func TestGraphQLConfigAdapter_engineConfigV2DataSources(t *testing.T) {
 					StartConsumingLatest: true,
 					BalanceStrategy:      kafkaDataSource.BalanceStrategySticky,
 					IsolationLevel:       kafkaDataSource.IsolationLevelReadCommitted,
+					SASL: kafkaDataSource.SASL{
+						Enable:   true,
+						User:     "admin",
+						Password: "admin-secret",
+					},
 				},
 			}),
 		},
@@ -997,7 +1007,12 @@ var graphqlEngineV2ConfigJson = `{
 					"kafka_version": "V2_8_0_0",
 					"start_consuming_latest": true,
 					"balance_strategy": "BalanceStrategySticky",
-					"isolation_level": "ReadCommitted"
+					"isolation_level": "ReadCommitted",
+					"sasl": {
+						"enable": true,
+						"user": "admin",
+						"password": "admin-secret"
+					}
 				}
 			},
 			{
@@ -1018,7 +1033,12 @@ var graphqlEngineV2ConfigJson = `{
 					"kafka_version": "V2_8_0_0",
 					"start_consuming_latest": true,
 					"balance_strategy": "BalanceStrategySticky",
-					"isolation_level": "ReadCommitted"
+					"isolation_level": "ReadCommitted",
+					"sasl": {
+						"enable": true,
+						"user": "admin",
+						"password": "admin-secret"
+					}
 				}
 			}
 		]

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -14,6 +14,7 @@ import (
 
 	uuid "github.com/satori/go.uuid"
 
+	"github.com/jensneuse/graphql-go-tools/pkg/engine/datasource/kafka_datasource"
 	"github.com/jensneuse/graphql-go-tools/pkg/execution/datasource"
 
 	"github.com/clbanning/mxj"
@@ -819,14 +820,15 @@ type GraphQLEngineDataSourceConfigGraphQL struct {
 }
 
 type GraphQLEngineDataSourceConfigKafka struct {
-	BrokerAddr           string `bson:"broker_addr" json:"broker_addr"`
-	Topic                string `bson:"topic" json:"topic"`
-	GroupID              string `bson:"group_id" json:"group_id"`
-	ClientID             string `bson:"client_id" json:"client_id"`
-	KafkaVersion         string `bson:"kafka_version" json:"kafka_version"`
-	StartConsumingLatest bool   `json:"start_consuming_latest"`
-	BalanceStrategy      string `json:"balance_strategy"`
-	IsolationLevel       string `json:"isolation_level"`
+	BrokerAddr           string                `bson:"broker_addr" json:"broker_addr"`
+	Topic                string                `bson:"topic" json:"topic"`
+	GroupID              string                `bson:"group_id" json:"group_id"`
+	ClientID             string                `bson:"client_id" json:"client_id"`
+	KafkaVersion         string                `bson:"kafka_version" json:"kafka_version"`
+	StartConsumingLatest bool                  `json:"start_consuming_latest"`
+	BalanceStrategy      string                `json:"balance_strategy"`
+	IsolationLevel       string                `json:"isolation_level"`
+	SASL                 kafka_datasource.SASL `json:"sasl"`
 }
 
 type QueryVariable struct {


### PR DESCRIPTION
This PR adds SASL(Simple Authentication and Security Layer) options to the Kafka data source. See [TT-5562](https://tyktech.atlassian.net/jira/software/c/projects/TT/boards/26?modal=detail&selectedIssue=TT-5562).