### PR TITLE
[TT-2162] Add missing session lifetime function test

### DIFF
--- a/user/session.go
+++ b/user/session.go
@@ -229,12 +229,15 @@ func (s *SessionState) Lifetime(fallback int64, forceGlobalSessionLifetime bool,
 	if forceGlobalSessionLifetime {
 		return globalSessionLifetime
 	}
+
 	if s.SessionLifetime > 0 {
 		return s.SessionLifetime
 	}
+
 	if fallback > 0 {
 		return fallback
 	}
+
 	return 0
 }
 

--- a/user/session_test.go
+++ b/user/session_test.go
@@ -1,0 +1,36 @@
+package user
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSessionState_Lifetime(t *testing.T) {
+	s := SessionState{}
+
+	t.Run("forceGlobal=false", func(t *testing.T) {
+		s.SessionLifetime = 1
+		assert.Equal(t, int64(1), s.Lifetime(2, false, 3))
+
+		s.SessionLifetime = 0
+		assert.Equal(t, int64(2), s.Lifetime(2, false, 3))
+
+		s.SessionLifetime = 0
+		assert.Equal(t, int64(0), s.Lifetime(0, false, 3))
+
+		s.SessionLifetime = 0
+		assert.Equal(t, int64(0), s.Lifetime(-1, false, 3))
+	})
+
+	t.Run("forceGlobal=true", func(t *testing.T) {
+		s.SessionLifetime = 1
+		assert.Equal(t, int64(3), s.Lifetime(2, true, 3))
+
+		s.SessionLifetime = 0
+		assert.Equal(t, int64(3), s.Lifetime(2, true, 3))
+
+		s.SessionLifetime = 0
+		assert.Equal(t, int64(3), s.Lifetime(0, true, 3))
+	})
+}


### PR DESCRIPTION
This PR adds test for  `SessionState.Lifetime()` and makes sure that the fix that will be added for `TT-2162` doesn't break existing functionality. `SessionState.Lifetime()` coverage is `100%` with this one.