### PR TITLE
[TT-5822] Validate just oas request body

### DIFF
--- a/gateway/mw_oas_validate_request.go
+++ b/gateway/mw_oas_validate_request.go
@@ -69,7 +69,7 @@ func (k *ValidateRequest) ProcessRequest(w http.ResponseWriter, r *http.Request,
 		Route:      route,
 	}
 
-	err = openapi3filter.ValidateRequest(r.Context(), requestValidationInput)
+	err = openapi3filter.ValidateRequestBody(r.Context(), requestValidationInput, route.Operation.RequestBody.Value)
 	if err != nil {
 		return fmt.Errorf("request validation error: %v", err), http.StatusBadRequest
 	}


### PR DESCRIPTION
This is just for checking request body for `4.1` in future we will expand it with other request components.