### PR TITLE
Fix/inject dialer conf to storage

### DIFF
--- a/storage/redis_cluster.go
+++ b/storage/redis_cluster.go
@@ -38,63 +38,7 @@ type RedisCluster struct {
 }
 
 func NewRedisClusterPool(isCache, isAnalytics bool, conf config.Config) redis.UniversalClient {
-	// redisSingletonMu is locked and we know the singleton is nil
-	cfg := conf.Storage
-	if isCache && conf.EnableSeperateCacheStore {
-		cfg = conf.CacheStorage
-	} else if isAnalytics && conf.EnableAnalytics && conf.EnableSeperateAnalyticsStore {
-		cfg = conf.AnalyticsStorage
-	}
-	log.Debug("Creating new Redis connection pool")
-
-	// poolSize applies per cluster node and not for the whole cluster.
-	poolSize := 500
-	if cfg.MaxActive > 0 {
-		poolSize = cfg.MaxActive
-	}
-
-	timeout := 5 * time.Second
-
-	if cfg.Timeout > 0 {
-		timeout = time.Duration(cfg.Timeout) * time.Second
-	}
-
-	var tlsConfig *tls.Config
-
-	if cfg.UseSSL {
-		tlsConfig = &tls.Config{
-			InsecureSkipVerify: cfg.SSLInsecureSkipVerify,
-		}
-	}
-
-	var client redis.UniversalClient
-	opts := &redis.UniversalOptions{
-		Addrs:            getRedisAddrs(cfg),
-		MasterName:       cfg.MasterName,
-		SentinelPassword: cfg.SentinelPassword,
-		Username:         cfg.Username,
-		Password:         cfg.Password,
-		DB:               cfg.Database,
-		DialTimeout:      timeout,
-		ReadTimeout:      timeout,
-		WriteTimeout:     timeout,
-		IdleTimeout:      240 * timeout,
-		PoolSize:         poolSize,
-		TLSConfig:        tlsConfig,
-	}
-
-	if opts.MasterName != "" {
-		log.Info("--> [REDIS] Creating sentinel-backed failover client")
-		client = redis.NewFailoverClient(opts.Failover())
-	} else if cfg.EnableCluster {
-		log.Info("--> [REDIS] Creating cluster client")
-		client = redis.NewClusterClient(opts.Cluster())
-	} else {
-		log.Info("--> [REDIS] Creating single-node client")
-		client = redis.NewClient(opts.Simple())
-	}
-
-	return client
+	return NewRedisClusterPoolWithOptions(isCache, isAnalytics, conf, nil)
 }
 
 func NewRedisClusterPoolWithOptions(isCache, isAnalytics bool, conf config.Config, cb func(*redis.UniversalOptions)) redis.UniversalClient {
@@ -144,7 +88,9 @@ func NewRedisClusterPoolWithOptions(isCache, isAnalytics bool, conf config.Confi
 	}
 
 	// Patch default config with test config;
-	cb(opts)
+	if cb != nil {
+		cb(opts)
+	}
 
 	if opts.MasterName != "" {
 		log.Info("--> [REDIS] Creating sentinel-backed failover client")


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->

- Copy `NewRedisClusterPool` to `NewRedisClusterPoolWithOptions`, add new parameter to allow modifying redis options,
- Extend `RedisController` with a new `SetConstructor` method - defaulting to `NewRedisClusterPool`;
- Hook in testutil.go / newGateway function to set the redis dialer in the redis.UniversalOptions;
- Don't create *Test in HMAC test utilities functions, two *Test instances contribute/enable flaky tests;

## Related Issue
<!-- This project only accepts pull requests related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->

https://tyktech.atlassian.net/browse/TT-3973
https://tyktech.atlassian.net/browse/TT-5228

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

This fixes most `TestHMAC*` tests. I've only had failures in TestHMACAuthSessionPass and TestHMACAuthSessionSHA512Pass after the first commit, and they happened rarely. Hopefully we can get a complete fix together along with #4176. 

Second commit fixes the remaining flakyness for TestHmac*Pass; two *Test instances have been alive during a test, and the tests don't like that. No sir.

## How This Has Been Tested
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of
the code, etc. -->

```
$ gotest -run='TestHMACAuth.+Pass' -count=100 .
ok  	github.com/TykTechnologies/tyk/gateway	22.040s
$ gotest -run='TestHMAC.+' -count=100 .
ok  	github.com/TykTechnologies/tyk/gateway	93.279s
$ gotest -run='TestHMAC.+' -count=100 -race .
ok  	github.com/TykTechnologies/tyk/gateway	323.257s
```

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/233360/179261663-039dc67a-2fff-426b-a7f0-1bd4a0e20b24.png)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [ ] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
