### PR TITLE
[TT-5962] [TT-5704] Updating graphql-go-tools commit hash.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/TykTechnologies/gojsonschema v0.0.0-20170222154038-dcb3e4bb7990
 	github.com/TykTechnologies/gorpc v0.0.0-20190515174534-b9c10befc5f4
 	github.com/TykTechnologies/goverify v0.0.0-20160822133757-7ccc57452ade
-	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220707111424-ab42a8d48fa7
+	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220718102023-6b39855ccacf
 	github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c
 	github.com/TykTechnologies/murmur3 v0.0.0-20180602122059-1915e687e465
 	github.com/TykTechnologies/openid2go v0.0.0-20200312160651-00c254a52b19

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ github.com/TykTechnologies/gorpc v0.0.0-20190515174534-b9c10befc5f4 h1:hTjM5Uubg
 github.com/TykTechnologies/gorpc v0.0.0-20190515174534-b9c10befc5f4/go.mod h1:vqhQRhIHefD4jdFo55j+m0vD5NMjx2liq/ubnshQpaY=
 github.com/TykTechnologies/goverify v0.0.0-20160822133757-7ccc57452ade h1:tFUV86NDnfMY4Au+EJHGJx0Rton8xdOLEh1aT+j6XBk=
 github.com/TykTechnologies/goverify v0.0.0-20160822133757-7ccc57452ade/go.mod h1:mkS8jKcz8otdfEXhJs1QQ/DKoIY1NFFsRPKS0RwQENI=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220707111424-ab42a8d48fa7 h1:FdtyXeKDpK75n8xTSLrQ+daP4G3Xkj9jpdIfmtATHVI=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220707111424-ab42a8d48fa7/go.mod h1:Cxpyt1EQHf8bRqAfZStqbgHif8YWngLga7tpnHRSRwU=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220718102023-6b39855ccacf h1:Vrk4c5ftlyKs5ETQb22eSnsL6S3FtqsbP7/qGmiZyqE=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220718102023-6b39855ccacf/go.mod h1:Cxpyt1EQHf8bRqAfZStqbgHif8YWngLga7tpnHRSRwU=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c h1:j6fd0Fz1R4oSWOmcooGjrdahqrML+btQ+PfEJw8SzbA=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c/go.mod h1:GnHUbsQx+ysI10osPhUdTmsxcE7ef64cVp38Fdyd7e0=
 github.com/TykTechnologies/logrus v0.0.0-20161201171239-55ff0f4b9b3d h1:SJdPn00x2EBwMDZxX018yUn4p6SV5CYXMss/b1lT//0=


### PR DESCRIPTION
[TT-5962] [TT-5704]
[changelog]
internal: Updating graphql-go-tools commit hash.




[TT-5962]: https://tyktech.atlassian.net/browse/TT-5962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TT-5704]: https://tyktech.atlassian.net/browse/TT-5704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ