### PR TITLE
[TT-7127] Fix invalid memory address or nil pointer dereference in Golang Virtual Endpoints

### DIFF
--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -175,10 +175,12 @@ func (m *GoPluginMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reque
 	// if a Go plugin is found for this path, override the base handler and logger:
 	logger := m.logger
 	handler := m.handler
+	successHandler := m.successHandler
 	if !m.APILevel {
 		if pluginMw, found := m.goPluginFromRequest(r); found {
 			logger = pluginMw.logger
 			handler = pluginMw.handler
+			successHandler = &SuccessHandler{BaseMiddleware: m.BaseMiddleware}
 		}
 	}
 	if handler == nil {
@@ -236,7 +238,7 @@ func (m *GoPluginMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reque
 			logger.WithError(err).Error("Failed to process request with Go-plugin middleware func")
 		default:
 			// record 2XX to analytics
-			m.successHandler.RecordHit(r, analytics.Latency{Total: int64(ms)}, rw.statusCodeSent, rw.getHttpResponse(r))
+			successHandler.RecordHit(r, analytics.Latency{Total: int64(ms)}, rw.statusCodeSent, rw.getHttpResponse(r))
 
 			// no need to continue passing this request down to reverse proxy
 			respCode = mwStatusRespond


### PR DESCRIPTION
```
[Jul 20 14:23:42] DEBUG Started api_id=1 api_name=Tyk Test API mw=GoPluginMiddleware: : org_id=default origin=172.17.0.1 path=/tyk-api-test/foo ts=1658327022041894229
[Jul 20 14:23:42] DEBUG Go-plugin request processing took ms=0.010736 mwPath=123321/plugin.so mwSymbolName=GoPluginFoo
[Jul 20 14:23:42] ERROR Recovered from panic while running Go-plugin middleware func error=runtime error: invalid memory address or nil pointer dereference mwPath=123321/plugin.so mwSymbolName=GoPluginFoo
[Jul 20 14:23:42] DEBUG Finished api_id=1 api_name=Tyk Test API code=500 error=runtime error: invalid memory address or nil pointer dereference mw=GoPluginMiddleware: : ns=95692 org_id=default origin=172.17.0.1 path=/tyk-api-test/foo
```

Signed-off-by: Chenyang Yan <memory.yancy@gmail.com>

<!-- Provide a general summary of your changes in the Title above -->

## Description

Fix invalid memory address or nil pointer dereference in Golang Virtual Endpoints

## Related Issue

#4197 

## How This Has Been Tested

See log message and do not produce panic error