### PR TITLE
Improve tcp verbosity, don't log closed connection used errs

### DIFF
--- a/tcp/tcp_test.go
+++ b/tcp/tcp_test.go
@@ -206,13 +206,15 @@ func testRunner(t *testing.T, proxy *Proxy, hostname string, useSSL bool, testCa
 		tlsConfig.BuildNameToCertificate()
 		proxyLn, err = tls.Listen("tcp", ":0", tlsConfig)
 
-		if err != nil {
-			t.Fatalf(err.Error())
-			return
-		}
 	} else {
-		proxyLn, _ = net.Listen("tcp", ":0")
+		proxyLn, err = net.Listen("tcp", ":0")
 	}
+
+	if err != nil {
+		t.Fatalf(err.Error())
+		return
+	}
+
 	defer proxyLn.Close()
 
 	go proxy.Serve(proxyLn)

--- a/test/tcp.go
+++ b/test/tcp.go
@@ -93,6 +93,7 @@ func (r TCPTestRunner) Run(t testing.TB, testCases ...TCPTestCase) error {
 
 func TcpMock(useSSL bool, cb func(in []byte, err error) (out []byte)) net.Listener {
 	var l net.Listener
+	var err error
 
 	if useSSL {
 		tlsConfig := &tls.Config{
@@ -101,9 +102,14 @@ func TcpMock(useSSL bool, cb func(in []byte, err error) (out []byte)) net.Listen
 			MaxVersion:         tls.VersionTLS12,
 		}
 		tlsConfig.BuildNameToCertificate()
-		l, _ = tls.Listen("tcp", ":0", tlsConfig)
+		l, err = tls.Listen("tcp", ":0", tlsConfig)
 	} else {
-		l, _ = net.Listen("tcp", ":0")
+		l, err = net.Listen("tcp", ":0")
+	}
+
+	// Panic, as we don't return err
+	if err != nil {
+		panic(err)
 	}
 
 	go func() {

--- a/test/tcp.go
+++ b/test/tcp.go
@@ -111,6 +111,11 @@ func TcpMock(useSSL bool, cb func(in []byte, err error) (out []byte)) net.Listen
 			// Listen for an incoming connection.
 			conn, err := l.Accept()
 			if err != nil {
+				// Fixed in go 1.16 with net.ErrClosed
+				if IsSocketClosed(err) {
+					return
+				}
+
 				log.Println("Mock Accept error", err.Error())
 				return
 			}
@@ -161,4 +166,11 @@ func Cert(domain string) tls.Certificate {
 	tlscert, _ := tls.X509KeyPair(cert.Bytes(), key.Bytes())
 
 	return tlscert
+}
+
+// IsSocketClosed returns true if err is a result of reading from closed network
+// connection
+func IsSocketClosed(err error) bool {
+	// Fixed in go 1.16 with net.ErrClosed
+	return strings.Contains(err.Error(), "use of closed network connection")
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->

As the connection is closed, net.Listener.Accept will return an untyped error for go <1.16, and will return net.ErrClosed for go>=1.16; there is a pre-existing check for connection closed which wasn't used in the code path, nor implemented in the mock. This commit brings down the verbosity when running tests.

Other changes:

- honor the same err closed message in tcp mock,
- fix tcp mock (twice?) error swallowing with net.Listen,
- checking io.EOF with errors.Is

## Related Issue
<!-- This project only accepts pull requests related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

There's a very very very rare test failure in the tcp test (`-count 1000` only sometimes triggers it). The first step in determining if it's a fault of tests or package code is to handle errors and decrease irrelevant output. This PR does that. The minor code improvements don't modify functionality, but reasonably decrease unnecessary and irrelevant log output, and possibly handle some error states which were previously unhandled.

## How This Has Been Tested
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of
the code, etc. -->

I've verified the changes are functional by running the following test case several times.

```
TYK_LOGLEVEL=debug go test -count=1000 -v ./tcp/...
...
ok  	github.com/TykTechnologies/tyk/tcp	95.230s
```

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [ ] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
