### PR TITLE
[TT-6159] coprocess: add tests for Tyk cgo API and expose GW RedisController for CP functionality

### DIFF
--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -260,6 +260,10 @@ func (gw *Gateway) CoProcessInit() {
 		}
 	}
 
+	// Make the current RedisController globally available
+	// cgo doesn't know about GW objects so this needs
+	// to be exposed this way:
+	cgoRedisController = gw.RedisController
 }
 
 // EnabledForSpec checks if this middleware should be enabled for a given API.

--- a/gateway/coprocess_api_test.go
+++ b/gateway/coprocess_api_test.go
@@ -1,0 +1,15 @@
+package gateway
+
+import (
+	"testing"
+)
+
+func TestCgoTykStoreGetData(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+	cgoTykStoreData("testkey", "testvalue", 5)
+	retVal := cgoTykGetData("testkey")
+	if retVal != "testvalue" {
+		t.Fatal("couldn't get Redis key")
+	}
+}


### PR DESCRIPTION
## Description
After GW refactor the way Redis is initialized/handled changed and broke the functionality of the Tyk cgo API. This API is documented [here](https://tyk.io/docs/plugins/supported-languages/rich-plugins/python/tyk-python-api-methods/) and it basically allows a developer to interact with Redis from a Python plugin.

Constraints:
- I’ve added tests to cover this functionality, they’re standard Go tests (using cgo of course).
- cgo in tests isn’t allowed so I implemented wrapper functions for both calls (cgoTykGetData and cgoTykStoreData).
- Have added a global cgoRedisController, I know we now try to isolate GW structure for every GW object but cgo doesn’t know about structures or methods associated with it.
- We can’t modify/improve exported cgo functions (TykStoreData and TykGetData), these functions can only receive and return C objects.

## Related Issue
TT-6159

## Motivation and Context
-

## How This Has Been Tested
Manually tested.
Added automatic tests in this PR -previously missing-.

## Screenshots (if appropriate)
-

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [x] `go vet`
