### PR TITLE
Update python version to 3.9 on CI test setup

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ${{ matrix.platform }}
     
     steps:
-    - name: Set up Python 3.7
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.9
 
     - name: Fix private module deps
       env:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-            python-version: '3.5'
+            python-version: '3.9'
 
       - name: Install Dependencies and basic hygiene test
         id: hygiene

--- a/dlpython/main_test.go
+++ b/dlpython/main_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-var testVersion = "3.5"
+var testVersion = "3.9"
 
 func init() {
 	if versionOverride := os.Getenv("PYTHON_VERSION"); versionOverride != "" {


### PR DESCRIPTION
## Description
Update EOL python 3.5 to 3.9

## Related Issue
https://tyktech.atlassian.net/browse/TT-5956?focusedCommentId=25705

## Motivation and Context
Update python versions due to end of life support 3.5 (2020 RIP) to 3.9 (Oct 2025)

## How This Has Been Tested
Tests itself are on the current pipeline, we'll see if pass or fails
