### PR TITLE
only call MakeSpec() on api reload if API has changed based on SHA256…

### DIFF
--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -217,6 +217,13 @@ func (s *APISpec) Release() {
 		}
 	}
 
+	if s.JSVM.VM != nil {
+		s.JSVM.VM.Interrupt = make(chan func(), 1)
+		s.JSVM.VM.Interrupt <- func() {
+			panic("stopping VM due to API reload")
+		}
+	}
+
 	// cancel execution contexts
 	if s.GraphQLExecutor.CancelV2 != nil {
 		s.GraphQLExecutor.CancelV2()

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -823,7 +823,7 @@ func (gw *Gateway) loadApps(specs []*APISpec) {
 	for _, spec := range specs {
 		func() {
 			defer func() {
-				// recover from panic if one occured. Set err to nil otherwise.
+				// recover from panic if one occurred. Set err to nil otherwise.
 				if err := recover(); err != nil {
 					log.Errorf("Panic while loading an API: %v, panic: %v, stacktrace: %v", spec.APIDefinition, err, string(debug.Stack()))
 				}
@@ -865,6 +865,13 @@ func (gw *Gateway) loadApps(specs []*APISpec) {
 	// release current specs resources before overwriting map
 	for _, curSpec := range gw.apisByID {
 		curSpec.Release()
+	}
+
+	// check for deleted APIs and remove from gw.apisByIDHash
+	for apiId, _ := range gw.apisByIDHash {
+		if _, ok := tmpSpecRegister[apiId]; !ok {
+			delete(gw.apisByIDHash, apiId)
+		}
 	}
 
 	gw.apisByID = tmpSpecRegister

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -875,6 +875,14 @@ func (gw *Gateway) loadApps(specs []*APISpec) {
 	}
 
 	gw.apisByID = tmpSpecRegister
+
+	// ensure handles are deleted from sync map to ensure
+	// they're removed by GC
+	gw.apisHandlesByID.Range(func(key, value interface{}) bool {
+		gw.apisHandlesByID.Delete(key)
+		return true
+	})
+
 	gw.apisHandlesByID = tmpSpecHandles
 
 	gw.apisMu.Unlock()

--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -157,6 +157,10 @@ func (m *GoPluginMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reque
 
 	// make sure tyk recover in case Go-plugin function panics
 	defer func() {
+		// clear API definition from req context to
+		// allow GC to remove it if connections are
+		// "keep alive" and API def has changed and reloaded
+		setCtxValue(r, ctx.Definition, nil)
 		if e := recover(); e != nil {
 			err = fmt.Errorf("%v", e)
 			respCode = http.StatusInternalServerError

--- a/gateway/res_handler_go_plugin.go
+++ b/gateway/res_handler_go_plugin.go
@@ -67,6 +67,10 @@ func (h *ResponseGoPluginMiddleware) HandleResponse(w http.ResponseWriter, res *
 func (h *ResponseGoPluginMiddleware) HandleGoPluginResponse(w http.ResponseWriter, res *http.Response, req *http.Request) error {
 	// make sure tyk recover in case Go-plugin function panics
 	defer func() {
+		// clear API definition from req context to
+		// allow GC to remove it if connections are
+		// "keep alive" and API def has changed and reloaded
+		setCtxValue(req, ctx.Definition, nil)
 		if e := recover(); e != nil {
 			err := fmt.Errorf("%v", e)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -82,6 +82,11 @@ var (
 
 const appName = "tyk-gateway"
 
+type apiHash struct {
+	hash   [32]byte
+	apidef *APISpec
+}
+
 type Gateway struct {
 	DefaultProxyMux *proxyMux
 	config          atomic.Value
@@ -133,6 +138,7 @@ type Gateway struct {
 	apisMu          sync.RWMutex
 	apiSpecs        []*APISpec
 	apisByID        map[string]*APISpec
+	apisByIDHash    map[string]apiHash
 	apisHandlesByID *sync.Map
 
 	policiesMu   sync.RWMutex
@@ -217,6 +223,7 @@ func NewGateway(config config.Config, ctx context.Context, cancelFn context.Canc
 	gw.UtilCache = cache.New(time.Hour, 10*time.Minute)
 
 	gw.apisByID = map[string]*APISpec{}
+	gw.apisByIDHash = map[string]apiHash{}
 	gw.apisHandlesByID = new(sync.Map)
 
 	gw.policiesByID = map[string]user.Policy{}

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -896,7 +896,7 @@ func TestReq(t testing.TB, method, urlStr string, body interface{}) *http.Reques
 
 func (gw *Gateway) CreateDefinitionFromString(defStr string) *APISpec {
 	loader := APIDefinitionLoader{Gw: gw}
-	def := loader.ParseDefinition(strings.NewReader(defStr))
+	def := loader.ParseDefinition([]byte(defStr))
 	spec := loader.MakeSpec(&def, nil)
 	return spec
 }


### PR DESCRIPTION
… of API def - to resolve OOM issue with hot API reload with JSVM enabled

Relates to this issue
#4214 oom-jsvm-hot-reload

## Description
Tyk runs out of memory when performing hot api reload with JSVM enabled


## How This Has Been Tested
Testing details within the related issue

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [ ] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
