### PR TITLE
TT-6162 on setting session lifetime, consider the sessionlifetime set at api level

### DIFF
--- a/gateway/api.go
+++ b/gateway/api.go
@@ -245,12 +245,48 @@ func (gw *Gateway) applyPoliciesAndSave(keyName string, session *user.SessionSta
 		return err
 	}
 
-	lifetime := session.Lifetime(spec.GetSessionLifetimeRespectsKeyExpiration(), spec.SessionLifetime, gw.GetConfig().ForceGlobalSessionLifetime, gw.GetConfig().GlobalSessionLifetime)
+	// calculate lifetime considering access rights
+	lifetime := gw.ApplyLifetime(session, spec)
 	if err := gw.GlobalSessionManager.UpdateSession(keyName, session, lifetime, isHashed); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func (gw *Gateway) GetApiSpecsFromAccessRights(sess *user.SessionState) []*APISpec {
+	var apis []*APISpec
+	if sess != nil && len(sess.AccessRights) > 0 {
+		for apiID := range sess.AccessRights {
+			spec := gw.getApiSpec(apiID)
+			if spec != nil {
+				apis = append(apis, spec)
+			}
+		}
+	}
+
+	return apis
+}
+
+// ApplyLifetime calculates the lifetime for the key. It considers the access rights and the bigger lifetime will be used
+func (gw *Gateway) ApplyLifetime(sess *user.SessionState, specs ...*APISpec) int64 {
+	var lifetime int64
+
+	if len(sess.AccessRights) > 0 {
+		specs = gw.GetApiSpecsFromAccessRights(sess)
+	}
+
+	for _, spec := range specs {
+		if spec != nil {
+			sessionLifeTime := sess.Lifetime(spec.GetSessionLifetimeRespectsKeyExpiration(), spec.SessionLifetime, gw.GetConfig().ForceGlobalSessionLifetime, gw.GetConfig().GlobalSessionLifetime)
+			// uses the greater lifetime
+			if sessionLifeTime > lifetime {
+				lifetime = sessionLifeTime
+			}
+		}
+	}
+
+	return lifetime
 }
 
 func resetAPILimits(accessRights map[string]user.AccessDefinition) {
@@ -274,7 +310,6 @@ func (gw *Gateway) doAddOrUpdate(keyName string, newSession *user.SessionState, 
 		// reset API-level limit to empty APILimit if any has a zero-value
 		resetAPILimits(newSession.AccessRights)
 		// We have a specific list of access rules, only add / update those
-
 		for apiId := range newSession.AccessRights {
 			apiSpec := gw.getApiSpec(apiId)
 			if apiSpec == nil {
@@ -315,13 +350,13 @@ func (gw *Gateway) doAddOrUpdate(keyName string, newSession *user.SessionState, 
 		log.Warning("No API Access Rights set, adding key to ALL.")
 		gw.apisMu.RLock()
 		defer gw.apisMu.RUnlock()
+
 		for _, spec := range gw.apisByID {
 			if !dontReset {
 				gw.GlobalSessionManager.ResetQuota(keyName, newSession, isHashed)
 				newSession.QuotaRenews = time.Now().Unix() + newSession.QuotaRenewalRate
 			}
 			gw.checkAndApplyTrialPeriod(keyName, newSession, isHashed)
-
 			// apply polices (if any) and save key
 			if err := gw.applyPoliciesAndSave(keyName, newSession, spec, isHashed); err != nil {
 				return err
@@ -672,7 +707,7 @@ func (gw *Gateway) handleGetAllKeys(filter string) (interface{}, int) {
 	return sessionsObj, http.StatusOK
 }
 
-func (gw *Gateway) handleAddKey(keyName, hashedName, sessionString, apiID string, orgId string) {
+func (gw *Gateway) handleAddKey(keyName, hashedName, sessionString, orgId string) {
 	sess := &user.SessionState{}
 	json.Unmarshal([]byte(sessionString), sess)
 	sess.LastUpdated = strconv.Itoa(int(time.Now().Unix()))
@@ -681,11 +716,10 @@ func (gw *Gateway) handleAddKey(keyName, hashedName, sessionString, apiID string
 		return
 	}
 
-	lifetime := GetSessionLifetime(sess, gw)
+	lifetime := gw.ApplyLifetime(sess, nil)
 
 	var err error
 	if gw.GetConfig().HashKeys {
-
 		err = gw.GlobalSessionManager.UpdateSession(hashedName, sess, lifetime, true)
 	} else {
 		err = gw.GlobalSessionManager.UpdateSession(keyName, sess, lifetime, false)
@@ -1874,7 +1908,6 @@ func (gw *Gateway) createKeyHandler(w http.ResponseWriter, r *http.Request) {
 					gw.GlobalSessionManager.ResetQuota(newKey, newSession, false)
 					newSession.QuotaRenews = time.Now().Unix() + newSession.QuotaRenewalRate
 				}
-				// apply polices (if any) and save key
 				if err := gw.applyPoliciesAndSave(newKey, newSession, spec, false); err != nil {
 					doJSONWrite(w, http.StatusInternalServerError, apiError("Failed to create key - "+err.Error()))
 					return
@@ -3270,22 +3303,4 @@ func updateOASServers(spec *APISpec, conf config.Config, apiDef *apidef.APIDefin
 
 	newAPIURL := getAPIURL(*apiDef, conf)
 	oasObj.UpdateServers(newAPIURL, oldAPIURL)
-}
-
-// GetSessionLifetime defines the TTL of the key
-func GetSessionLifetime(sess *user.SessionState, gw *Gateway) int64 {
-	var lifetime int64
-	if sess != nil && len(sess.AccessRights) > 0 {
-		for apiID := range sess.AccessRights {
-			spec := gw.getApiSpec(apiID)
-			if spec != nil {
-				sessionLifeTime := sess.Lifetime(spec.GetSessionLifetimeRespectsKeyExpiration(), spec.SessionLifetime, gw.GetConfig().ForceGlobalSessionLifetime, gw.GetConfig().GlobalSessionLifetime)
-				// uses the greater lifetime
-				if sessionLifeTime > lifetime {
-					lifetime = sessionLifeTime
-				}
-			}
-		}
-	}
-	return lifetime
 }

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -707,7 +707,7 @@ func (gw *Gateway) handleGetAllKeys(filter string) (interface{}, int) {
 	return sessionsObj, http.StatusOK
 }
 
-func (gw *Gateway) handleAddKey(keyName, hashedName, sessionString, orgId string) {
+func (gw *Gateway) handleAddKey(keyName, sessionString, orgId string) {
 	sess := &user.SessionState{}
 	json.Unmarshal([]byte(sessionString), sess)
 	sess.LastUpdated = strconv.Itoa(int(time.Now().Unix()))
@@ -717,13 +717,7 @@ func (gw *Gateway) handleAddKey(keyName, hashedName, sessionString, orgId string
 	}
 
 	lifetime := gw.ApplyLifetime(sess, nil)
-
-	var err error
-	if gw.GetConfig().HashKeys {
-		err = gw.GlobalSessionManager.UpdateSession(hashedName, sess, lifetime, true)
-	} else {
-		err = gw.GlobalSessionManager.UpdateSession(keyName, sess, lifetime, false)
-	}
+	err := gw.GlobalSessionManager.UpdateSession(keyName, sess, lifetime, gw.GetConfig().HashKeys)
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "api",

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -3276,7 +3276,7 @@ func updateOASServers(spec *APISpec, conf config.Config, apiDef *apidef.APIDefin
 func GetSessionLifetime(sess *user.SessionState, gw *Gateway) int64 {
 	var lifetime int64
 	if sess != nil && len(sess.AccessRights) > 0 {
-		for apiID, _ := range sess.AccessRights {
+		for apiID := range sess.AccessRights {
 			spec := gw.getApiSpec(apiID)
 			if spec != nil {
 				sessionLifeTime := sess.Lifetime(spec.GetSessionLifetimeRespectsKeyExpiration(), spec.SessionLifetime, gw.GetConfig().ForceGlobalSessionLifetime, gw.GetConfig().GlobalSessionLifetime)

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -254,6 +254,7 @@ func (gw *Gateway) applyPoliciesAndSave(keyName string, session *user.SessionSta
 	return nil
 }
 
+// GetApiSpecsFromAccessRights from the session.AccessRights returns the collection of api specs
 func (gw *Gateway) GetApiSpecsFromAccessRights(sess *user.SessionState) []*APISpec {
 	var apis []*APISpec
 	if sess != nil && len(sess.AccessRights) > 0 {
@@ -1872,6 +1873,7 @@ func (gw *Gateway) createKeyHandler(w http.ResponseWriter, r *http.Request) {
 				sessionManager := gw.GlobalSessionManager
 				newSession.QuotaRenews = time.Now().Unix() + newSession.QuotaRenewalRate
 				sessionManager.ResetQuota(newKey, newSession, false)
+				// apply polices (if any) and save key
 				err := sessionManager.UpdateSession(newKey, newSession, -1, false)
 				if err != nil {
 					doJSONWrite(w, http.StatusInternalServerError, apiError("Failed to create key - "+err.Error()))

--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -3094,7 +3094,7 @@ func testImportOAS(t *testing.T, ts *Test, testCase test.TestCase) string {
 	return importResp.Key
 }
 
-func TestGetSessionLifetime(t *testing.T) {
+func TestApplyLifetime(t *testing.T) {
 
 	ts := StartTest(nil)
 	defer ts.Close()
@@ -3163,12 +3163,19 @@ func TestGetSessionLifetime(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:             "Session without access rights",
+			expectedLifetime: 0,
+			getTestSession: func() user.SessionState {
+				return user.SessionState{}
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			session := tc.getTestSession()
-			assert.Equal(t, tc.expectedLifetime, GetSessionLifetime(&session, ts.Gw))
+			assert.Equal(t, tc.expectedLifetime, ts.Gw.ApplyLifetime(&session, nil))
 		})
 	}
 }

--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -3093,3 +3093,82 @@ func testImportOAS(t *testing.T, ts *Test, testCase test.TestCase) string {
 
 	return importResp.Key
 }
+
+func TestGetSessionLifetime(t *testing.T) {
+
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	ts.Gw.BuildAndLoadAPI(
+		func(spec *APISpec) {
+			spec.APIID = "api1"
+		},
+		func(spec *APISpec) {
+			spec.APIID = "api2"
+			spec.SessionLifetime = 1000
+		},
+		func(spec *APISpec) {
+			spec.APIID = "api3"
+			spec.SessionLifetime = 999
+		},
+	)
+
+	testCases := []struct {
+		name             string
+		expectedLifetime int64
+		getTestSession   func() user.SessionState
+	}{
+		{
+			name:             "single api without session lifetime set",
+			expectedLifetime: 0,
+			getTestSession: func() user.SessionState {
+				return user.SessionState{
+					AccessRights: map[string]user.AccessDefinition{
+						"api1": {
+							APIID: "api1", Versions: []string{"v1"},
+						},
+					},
+				}
+			},
+		},
+		{
+			name:             "many apis, one of them with session lifetime set",
+			expectedLifetime: 1000,
+			getTestSession: func() user.SessionState {
+				return user.SessionState{
+					AccessRights: map[string]user.AccessDefinition{
+						"api1": {
+							APIID: "api1", Versions: []string{"v1"},
+						},
+						"api2": {
+							APIID: "api2", Versions: []string{"v1"},
+						},
+					},
+				}
+			},
+		},
+		{
+			name:             "many apis with session lifetime set, greater should be used",
+			expectedLifetime: 1000,
+			getTestSession: func() user.SessionState {
+				return user.SessionState{
+					AccessRights: map[string]user.AccessDefinition{
+						"api2": {
+							APIID: "api2", Versions: []string{"v1"},
+						},
+						"api3": {
+							APIID: "api3", Versions: []string{"v1"},
+						},
+					},
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			session := tc.getTestSession()
+			assert.Equal(t, tc.expectedLifetime, GetSessionLifetime(&session, ts.Gw))
+		})
+	}
+}

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -841,7 +841,7 @@ func (gw *Gateway) getSessionAndCreate(keyName string, r *RPCStorageHandler, isH
 	if err != nil {
 		log.Error("Key not found in master - skipping")
 	} else {
-		gw.handleAddKey(keyName, hashedKeyName, sessionString, "-1", orgId)
+		gw.handleAddKey(keyName, hashedKeyName, sessionString, orgId)
 	}
 }
 

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -831,17 +831,17 @@ func (r *RPCStorageHandler) CheckForKeyspaceChanges(orgId string) {
 
 func (gw *Gateway) getSessionAndCreate(keyName string, r *RPCStorageHandler, isHashed bool, orgId string) {
 
-	hashedKeyName := keyName
+	key := keyName
 	// avoid double hashing
 	if !isHashed {
-		hashedKeyName = storage.HashKey(keyName, gw.GetConfig().HashKeys)
+		key = storage.HashKey(keyName, gw.GetConfig().HashKeys)
 	}
 
-	sessionString, err := r.GetRawKey("apikey-" + hashedKeyName)
+	sessionString, err := r.GetRawKey("apikey-" + key)
 	if err != nil {
 		log.Error("Key not found in master - skipping")
 	} else {
-		gw.handleAddKey(keyName, hashedKeyName, sessionString, orgId)
+		gw.handleAddKey(key, sessionString, orgId)
 	}
 }
 


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->

## Description
In the handler of adding a new key (used by worker gateways in a MDCB environment) then consider that some apis has the session lifetime set at api level, in those cases we should use this value. If we're in the situation where a key has multiple access rights, and each api has defined different session lifetimes then the bigger one will be used.

**UPDATE**
While developing I found out a situation in which we were not consistent in the behavior of the lifetime calculation, it happens on-premise that if you have 2 apis with different session lifetime set then when you create a key and apply those 2 apis then any of the lifetimes is set (sometimes the biggest one, sometimes the smallest one). Why does this happens? it happens because while applying policies we always overwritte the sessionLifetime, so the lifetime of the last api deifnition processed will be the one saved. How to replicate this? follow the next instructions:

- Create 2 apis with SessionLifetime set, use a different one for each Api. (api A and api B)
- Go and create a key, applying apis: first select the api A and then the api B
- Check the TTL set.
- Go and create a new key but applying api B first and then api A
- Check the TTL set. it's different than the first api key.

As a user I would expect to have always the same TTL set no matter how did I selected the APIS. So, if we leave this in this way we would end up to have different behaviors in the worker nodes and controller nodes, while worker nodes will always set the bigger TTL, the controller node will just choose any of the sessionLifetimes configured. In this PR I took care over those situations and normalized how it's calculated (it should be the same in any environment and always choose the bigger one.)

## Related Issue
https://tyktech.atlassian.net/browse/TT-6162

## Motivation and Context
Give solution to https://tyktech.atlassian.net/browse/TT-6162 and be consistent in MDCB environments

## How This Has Been Tested
- Tested manually running an MDCB environment: created an api with session lifetime different than zero.
- Then created a key via dashboard for that API
- Then check in the worker node, when the key is synchronized that the TTL is different than zero and consistent with the value set via api def.
- Also added unit test

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
