### PR TITLE
[TT-6022] Kafka data source should subscribe to multiple topics

### DIFF
--- a/apidef/adapter/graphql_config_adapter.go
+++ b/apidef/adapter/graphql_config_adapter.go
@@ -256,7 +256,7 @@ func (g *GraphQLConfigAdapter) engineConfigV2DataSources() (planDataSources []pl
 			planDataSource.Custom = kafkaDataSource.ConfigJSON(kafkaDataSource.Configuration{
 				Subscription: kafkaDataSource.SubscriptionConfiguration{
 					BrokerAddresses:      kafkaConfig.BrokerAddresses,
-					Topic:                kafkaConfig.Topic,
+					Topics:               kafkaConfig.Topics,
 					GroupID:              kafkaConfig.GroupID,
 					ClientID:             kafkaConfig.ClientID,
 					KafkaVersion:         kafkaConfig.KafkaVersion,

--- a/apidef/adapter/graphql_config_adapter_test.go
+++ b/apidef/adapter/graphql_config_adapter_test.go
@@ -718,7 +718,7 @@ func TestGraphQLConfigAdapter_engineConfigV2DataSources(t *testing.T) {
 			Custom: kafkaDataSource.ConfigJSON(kafkaDataSource.Configuration{
 				Subscription: kafkaDataSource.SubscriptionConfiguration{
 					BrokerAddresses:      []string{"localhost:9092"},
-					Topic:                "test.topic",
+					Topics:               []string{"test.topic"},
 					GroupID:              "test.consumer.group",
 					ClientID:             "test.client.id",
 					KafkaVersion:         "V2_8_0_0",
@@ -744,7 +744,7 @@ func TestGraphQLConfigAdapter_engineConfigV2DataSources(t *testing.T) {
 			Custom: kafkaDataSource.ConfigJSON(kafkaDataSource.Configuration{
 				Subscription: kafkaDataSource.SubscriptionConfiguration{
 					BrokerAddresses:      []string{"localhost:9092"},
-					Topic:                "test.topic.{{.arguments.name}}",
+					Topics:               []string{"test.topic.{{.arguments.name}}"},
 					GroupID:              "test.consumer.group",
 					ClientID:             "test.client.id",
 					KafkaVersion:         "V2_8_0_0",
@@ -1001,7 +1001,7 @@ var graphqlEngineV2ConfigJson = `{
 				}],
 				"config": {
 					"broker_addresses": ["localhost:9092"],
-					"topic": "test.topic",
+					"topics": ["test.topic"],
 					"group_id": "test.consumer.group",
 					"client_id": "test.client.id",
 					"kafka_version": "V2_8_0_0",
@@ -1027,7 +1027,7 @@ var graphqlEngineV2ConfigJson = `{
 				}],
 				"config": {
 					"broker_addresses": ["localhost:9092"],
-					"topic": "test.topic.{{.arguments.name}}",
+					"topics": ["test.topic.{{.arguments.name}}"],
 					"group_id": "test.consumer.group",
 					"client_id": "test.client.id",
 					"kafka_version": "V2_8_0_0",

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -840,7 +840,7 @@ type GraphQLEngineDataSourceConfigGraphQL struct {
 
 type GraphQLEngineDataSourceConfigKafka struct {
 	BrokerAddresses      []string              `bson:"broker_addresses" json:"broker_addresses"`
-	Topic                string                `bson:"topic" json:"topic"`
+	Topics               []string              `bson:"topics" json:"topics"`
 	GroupID              string                `bson:"group_id" json:"group_id"`
 	ClientID             string                `bson:"client_id" json:"client_id"`
 	KafkaVersion         string                `bson:"kafka_version" json:"kafka_version"`

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/TykTechnologies/gojsonschema v0.0.0-20170222154038-dcb3e4bb7990
 	github.com/TykTechnologies/gorpc v0.0.0-20190515174534-b9c10befc5f4
 	github.com/TykTechnologies/goverify v0.0.0-20160822133757-7ccc57452ade
-	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220718102023-6b39855ccacf
+	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220811105404-ca0a95f795bd
 	github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c
 	github.com/TykTechnologies/murmur3 v0.0.0-20180602122059-1915e687e465
 	github.com/TykTechnologies/openid2go v0.0.0-20200312160651-00c254a52b19

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/TykTechnologies/gojsonschema v0.0.0-20170222154038-dcb3e4bb7990
 	github.com/TykTechnologies/gorpc v0.0.0-20190515174534-b9c10befc5f4
 	github.com/TykTechnologies/goverify v0.0.0-20160822133757-7ccc57452ade
-	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220811105404-ca0a95f795bd
+	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220811124354-8d1f142966f8
 	github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c
 	github.com/TykTechnologies/murmur3 v0.0.0-20180602122059-1915e687e465
 	github.com/TykTechnologies/openid2go v0.0.0-20200312160651-00c254a52b19

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ github.com/TykTechnologies/gorpc v0.0.0-20190515174534-b9c10befc5f4 h1:hTjM5Uubg
 github.com/TykTechnologies/gorpc v0.0.0-20190515174534-b9c10befc5f4/go.mod h1:vqhQRhIHefD4jdFo55j+m0vD5NMjx2liq/ubnshQpaY=
 github.com/TykTechnologies/goverify v0.0.0-20160822133757-7ccc57452ade h1:tFUV86NDnfMY4Au+EJHGJx0Rton8xdOLEh1aT+j6XBk=
 github.com/TykTechnologies/goverify v0.0.0-20160822133757-7ccc57452ade/go.mod h1:mkS8jKcz8otdfEXhJs1QQ/DKoIY1NFFsRPKS0RwQENI=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220811105404-ca0a95f795bd h1:7RBykR1bLWi2FTQTm2hUt7ZJmrZbJcbyAsQOw49UoxA=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220811105404-ca0a95f795bd/go.mod h1:Cxpyt1EQHf8bRqAfZStqbgHif8YWngLga7tpnHRSRwU=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220811124354-8d1f142966f8 h1:CA59ssz4bwLkd7pzkDpZOnlMzzraq/TEbJ6xvQpSPCc=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220811124354-8d1f142966f8/go.mod h1:Cxpyt1EQHf8bRqAfZStqbgHif8YWngLga7tpnHRSRwU=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c h1:j6fd0Fz1R4oSWOmcooGjrdahqrML+btQ+PfEJw8SzbA=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c/go.mod h1:GnHUbsQx+ysI10osPhUdTmsxcE7ef64cVp38Fdyd7e0=
 github.com/TykTechnologies/logrus v0.0.0-20161201171239-55ff0f4b9b3d h1:SJdPn00x2EBwMDZxX018yUn4p6SV5CYXMss/b1lT//0=

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ github.com/TykTechnologies/gorpc v0.0.0-20190515174534-b9c10befc5f4 h1:hTjM5Uubg
 github.com/TykTechnologies/gorpc v0.0.0-20190515174534-b9c10befc5f4/go.mod h1:vqhQRhIHefD4jdFo55j+m0vD5NMjx2liq/ubnshQpaY=
 github.com/TykTechnologies/goverify v0.0.0-20160822133757-7ccc57452ade h1:tFUV86NDnfMY4Au+EJHGJx0Rton8xdOLEh1aT+j6XBk=
 github.com/TykTechnologies/goverify v0.0.0-20160822133757-7ccc57452ade/go.mod h1:mkS8jKcz8otdfEXhJs1QQ/DKoIY1NFFsRPKS0RwQENI=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220718102023-6b39855ccacf h1:Vrk4c5ftlyKs5ETQb22eSnsL6S3FtqsbP7/qGmiZyqE=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220718102023-6b39855ccacf/go.mod h1:Cxpyt1EQHf8bRqAfZStqbgHif8YWngLga7tpnHRSRwU=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220811105404-ca0a95f795bd h1:7RBykR1bLWi2FTQTm2hUt7ZJmrZbJcbyAsQOw49UoxA=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20220811105404-ca0a95f795bd/go.mod h1:Cxpyt1EQHf8bRqAfZStqbgHif8YWngLga7tpnHRSRwU=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c h1:j6fd0Fz1R4oSWOmcooGjrdahqrML+btQ+PfEJw8SzbA=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c/go.mod h1:GnHUbsQx+ysI10osPhUdTmsxcE7ef64cVp38Fdyd7e0=
 github.com/TykTechnologies/logrus v0.0.0-20161201171239-55ff0f4b9b3d h1:SJdPn00x2EBwMDZxX018yUn4p6SV5CYXMss/b1lT//0=


### PR DESCRIPTION
This PR updates the GraphQL config adapter and graphql-go-tools commit hash. 

See [TT-6022](https://tyktech.atlassian.net/jira/software/c/projects/TT/boards/26?modal=detail&selectedIssue=TT-6022) for details.

[changelog]
internal: Updating graphql-go-tools commit hash.
internal: Update GraphQL config adapter to support multiple Kafka topics.


