### PR TITLE
[TT-6150] Revert "[TT-3904] fix chunked body logging (#3861)"

### DIFF
--- a/gateway/mw_redis_cache_test.go
+++ b/gateway/mw_redis_cache_test.go
@@ -65,20 +65,6 @@ func TestRedisCacheMiddleware_WithCompressedResponse(t *testing.T) {
 			{Path: path, Code: 200, BodyMatch: "This is a compressed response"},
 		}...)
 	})
-
-	t.Run("with chunked gzip response body and dynamic redis", func(t *testing.T) {
-		createAPI(true)
-		ts.Gw.RedisController.DisableRedis(true)
-		_, _ = ts.Run(t, []test.TestCase{
-			{Path: "/chunked", Code: http.StatusOK, BodyMatch: "Mars"},
-			{Path: "/chunked", Code: http.StatusOK, BodyMatch: "Mars"},
-		}...)
-		ts.Gw.RedisController.DisableRedis(false)
-		_, _ = ts.Run(t, []test.TestCase{
-			{Path: "/chunked", Code: http.StatusOK, BodyMatch: "Mars"},
-			{Path: "/chunked", Code: http.StatusOK, BodyMatch: "Mars"},
-		}...)
-	})
 }
 
 func Test_isSafeMethod(t *testing.T) {

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -1122,8 +1122,6 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 
 	// Do this before we make a shallow copy
 	session := ctxGetSession(req)
-	// mantain the body
-	copyRequest(req)
 
 	outreq := new(http.Request)
 	logreq := new(http.Request)
@@ -1702,9 +1700,7 @@ func copyBody(body io.ReadCloser) io.ReadCloser {
 }
 
 func copyRequest(r *http.Request) *http.Request {
-	if r.ContentLength == -1 &&
-		// for unknown length, if request is not gRPC we assume it's chunked transfer encoding
-		IsGrpcStreaming(r) {
+	if r.ContentLength == -1 {
 		return r
 	}
 
@@ -1770,7 +1766,5 @@ func (p *ReverseProxy) IsUpgrade(req *http.Request) (bool, string) {
 
 // IsGrpcStreaming  determines wether a request represents a grpc streaming req
 func IsGrpcStreaming(r *http.Request) bool {
-	return r.ContentLength == -1 &&
-		// gRPC over HTTP/2 requests content-type should begin with "application/grpc"
-		strings.HasPrefix(r.Header.Get(headers.ContentType), "application/grpc")
+	return r.ContentLength == -1 && r.Header.Get(headers.ContentType) == "application/grpc"
 }

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -512,7 +512,6 @@ func (s *Test) testHttpHandler(gw *Gateway) *mux.Router {
 		json.NewEncoder(gz).Encode(response)
 		gz.Close()
 	})
-	r.HandleFunc("/chunked", chunkedEncodingHandler)
 	r.HandleFunc("/groupReload", gw.groupResetHandler)
 	r.HandleFunc("/bundles/{rest:.*}", s.BundleHandleFunc)
 	r.HandleFunc("/errors/{status}", func(w http.ResponseWriter, r *http.Request) {
@@ -681,23 +680,6 @@ func subgraphReviewsHandler(w http.ResponseWriter, r *http.Request) {
 				]
 			}
 		}`))
-}
-
-func chunkedEncodingHandler(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case http.MethodPost, http.MethodGet:
-	default:
-		http.Error(w, `{ "error": "request method not allowed"}`, http.StatusBadRequest)
-		return
-	}
-	if f, ok := w.(http.Flusher); ok {
-		_, _ = w.Write([]byte(`{"data":{"country":{`))
-		f.Flush()
-		_, _ = w.Write([]byte(`"code":"M","name":"Mars"}}}`))
-		f.Flush()
-		return
-	}
-	http.Error(w, `{ "error": "response writer does not implement flusher"}`, http.StatusInternalServerError)
 }
 
 const jwkTestJson = `{


### PR DESCRIPTION
Reasons to revert:
- It causes another bug
- The test is wrong
- No need to copy the request
- Handling response body re-read is not correct
