### PR TITLE
[TT-6332] Fix chunked response logging

### DIFF
--- a/gateway/analytics.go
+++ b/gateway/analytics.go
@@ -53,6 +53,10 @@ type RedisAnalyticsHandler struct {
 	Gw                          *Gateway `json:"-"`
 	mu                          sync.Mutex
 	analyticsSerializer         serializer.AnalyticsSerializer
+
+	// testing purposes
+	mockEnabled   bool
+	mockRecordHit func(record *analytics.AnalyticsRecord)
 }
 
 func (r *RedisAnalyticsHandler) Init() {
@@ -110,6 +114,11 @@ func (r *RedisAnalyticsHandler) Flush() {
 
 // RecordHit will store an analytics.Record in Redis
 func (r *RedisAnalyticsHandler) RecordHit(record *analytics.AnalyticsRecord) error {
+	if r.mockEnabled {
+		r.mockRecordHit(record)
+		return nil
+	}
+
 	// check if we should stop sending records 1st
 	if atomic.LoadUint32(&r.shouldStop) > 0 {
 		return nil

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -1711,12 +1711,6 @@ func copyRequest(r *http.Request) *http.Request {
 }
 
 func copyResponse(r *http.Response) *http.Response {
-	// for the case of streaming for which Content-Length might be unset = -1.
-
-	if r.ContentLength == -1 {
-		return r
-	}
-
 	// If the response is 101 Switching Protocols then the body will contain a
 	// `*http.readWriteCloserBody` which cannot be copied (see stdlib documentation).
 	// In this case we want to return immediately to avoid a silent crash.


### PR DESCRIPTION
The `Transfer-Encoding: chunked` case has `Content-Length: -1`.  In `nopCloseResponseBoy` function we return immediately when it is `-1` . So, it consumes the response body and can't read again. This PR removes the `-1` check to make the response body re-readable to fix the logging issue on the Log Browser for chunked responses.