### PR TITLE
[TT-6400] Field based permissions whitelisting - Define better struct for RestrictedTypes

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -407,6 +407,14 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 							}
 						}
 
+						for _, t := range v.AllowedTypes {
+							for ri, rt := range r.AllowedTypes {
+								if t.Name == rt.Name {
+									r.AllowedTypes[ri].Fields = intersection(rt.Fields, t.Fields)
+								}
+							}
+						}
+
 						mergeFieldLimits := func(res *user.FieldLimits, new user.FieldLimits) {
 							if greaterThanInt(new.MaxQueryDepth, res.MaxQueryDepth) {
 								res.MaxQueryDepth = new.MaxQueryDepth

--- a/gateway/policy.go
+++ b/gateway/policy.go
@@ -23,6 +23,7 @@ type DBAccessDefinition struct {
 	Versions          []string                     `json:"versions"`
 	AllowedURLs       []user.AccessSpec            `bson:"allowed_urls" json:"allowed_urls"` // mapped string MUST be a valid regex
 	RestrictedTypes   []graphql.Type               `json:"restricted_types"`
+	AllowedTypes      []graphql.Type               `json:"allowed_types"`
 	FieldAccessRights []user.FieldAccessDefinition `json:"field_access_rights"`
 	Limit             *user.APILimit               `json:"limit"`
 }
@@ -34,6 +35,7 @@ func (d *DBAccessDefinition) ToRegularAD() user.AccessDefinition {
 		Versions:          d.Versions,
 		AllowedURLs:       d.AllowedURLs,
 		RestrictedTypes:   d.RestrictedTypes,
+		AllowedTypes:      d.AllowedTypes,
 		FieldAccessRights: d.FieldAccessRights,
 	}
 

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -302,6 +302,26 @@ func (s *Test) TestPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesD
 					},
 				}},
 		},
+		"allowed-types1": {
+			ID: "allowed_types_1",
+			AccessRights: map[string]user.AccessDefinition{
+				"a": {
+					AllowedTypes: []graphql.Type{
+						{Name: "Country", Fields: []string{"code", "name"}},
+						{Name: "Person", Fields: []string{"name", "height"}},
+					},
+				}},
+		},
+		"allowed-types2": {
+			ID: "allowed_types_2",
+			AccessRights: map[string]user.AccessDefinition{
+				"a": {
+					AllowedTypes: []graphql.Type{
+						{Name: "Country", Fields: []string{"code", "phone"}},
+						{Name: "Person", Fields: []string{"name", "mass"}},
+					},
+				}},
+		},
 		"field-level-depth-limit1": {
 			ID: "field-level-depth-limit1",
 			AccessRights: map[string]user.AccessDefinition{
@@ -665,6 +685,23 @@ func (s *Test) TestPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesD
 				want := map[string]user.AccessDefinition{
 					"a": { // It should get intersection of restricted types.
 						RestrictedTypes: []graphql.Type{
+							{Name: "Country", Fields: []string{"code"}},
+							{Name: "Person", Fields: []string{"name"}},
+						},
+						Limit: user.APILimit{},
+					},
+				}
+
+				assert.Equal(t, want, s.AccessRights)
+			},
+		},
+		{
+			name:     "Merge allowed fields for the same GraphQL API",
+			policies: []string{"allowed-types1", "allowed-types2"},
+			sessMatch: func(t *testing.T, s *user.SessionState) {
+				want := map[string]user.AccessDefinition{
+					"a": { // It should get intersection of restricted types.
+						AllowedTypes: []graphql.Type{
 							{Name: "Country", Fields: []string{"code"}},
 							{Name: "Person", Fields: []string{"name"}},
 						},

--- a/gateway/session_manager.go
+++ b/gateway/session_manager.go
@@ -338,6 +338,7 @@ func GetAccessDefinitionByAPIIDOrSession(currentSession *user.SessionState, api 
 			accessDef.Limit = rights.Limit
 			accessDef.FieldAccessRights = rights.FieldAccessRights
 			accessDef.RestrictedTypes = rights.RestrictedTypes
+			accessDef.AllowedTypes = rights.AllowedTypes
 			allowanceScope = rights.AllowanceScope
 		}
 	}

--- a/user/session.go
+++ b/user/session.go
@@ -61,6 +61,7 @@ type AccessDefinition struct {
 	Versions          []string                `json:"versions" msg:"versions"`
 	AllowedURLs       []AccessSpec            `bson:"allowed_urls" json:"allowed_urls" msg:"allowed_urls"` // mapped string MUST be a valid regex
 	RestrictedTypes   []graphql.Type          `json:"restricted_types" msg:"restricted_types"`
+	AllowedTypes      []graphql.Type          `json:"allowed_types" msg:"allowed_types"`
 	Limit             APILimit                `json:"limit" msg:"limit"`
 	FieldAccessRights []FieldAccessDefinition `json:"field_access_rights" msg:"field_access_rights"`
 


### PR DESCRIPTION
I dropped [the first implementation](https://github.com/TykTechnologies/tyk/commit/25327c3fd6ab0590b12c3e9493fa40b4a1231b51) to prevent breaking the current API and GUI. I realized that tyk-analytics has the same `RestrictedTypes` field in various structs and business logic.

See the following:

https://github.com/TykTechnologies/tyk-analytics/blob/master/dashboard/api_admin_methods.go#L242
https://github.com/TykTechnologies/tyk-analytics/blob/6afe1ee6f5fcd3a3582287bf080a1d64fcf54b25/graphql/types.graphql#L7

This PR only(for [TT-6400](https://tyktech.atlassian.net/browse/TT-6400)) adds a new field called `AllowedFields` and has no impact on the API. I'm going to implement the actual business logic after merging this one. I plan to add a field named `enableAllowList` and modify the business logic in `CheckGraphqlRequestFieldAllowance` in `mw_graphql_granular_access.go` file. Then, probably we need to add a similar business logic to tyk-analytics but I'm not very familiar with that codebase. 

Related tickets on Jira:

https://tyktech.atlassian.net/browse/TT-5665
https://tyktech.atlassian.net/browse/TT-6110
