### PR TITLE
TT-2356 Caching default expiration time if org is not found

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -30,8 +30,8 @@ import (
 )
 
 const (
-	mwStatusRespond         = 666
-	defaultOrgSessionExpiry = int64(604800)
+	mwStatusRespond                = 666
+	DEFAULT_ORG_SESSION_EXPIRATION = int64(604800)
 )
 
 var (
@@ -268,8 +268,8 @@ func (t BaseMiddleware) OrgSessionExpiry(orgid string) int64 {
 	if err != nil {
 
 		t.Logger().Debug("no cached entry found, returning 7 days")
-		t.SetOrgExpiry(orgid, defaultOrgSessionExpiry)
-		return defaultOrgSessionExpiry
+		t.SetOrgExpiry(orgid, DEFAULT_ORG_SESSION_EXPIRATION)
+		return DEFAULT_ORG_SESSION_EXPIRATION
 	}
 
 	return id.(int64)

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -29,7 +29,10 @@ import (
 	"github.com/TykTechnologies/tyk/user"
 )
 
-const mwStatusRespond = 666
+const (
+	mwStatusRespond         = 666
+	defaultOrgSessionExpiry = int64(604800)
+)
 
 var (
 	GlobalRate            = ratecounter.NewRateCounter(1 * time.Second)
@@ -232,7 +235,8 @@ func (t BaseMiddleware) OrgSession(orgID string) (user.SessionState, bool) {
 	if found && t.Spec.GlobalConfig.EnforceOrgDataAge {
 		// If exists, assume it has been authorized and pass on
 		// We cache org expiry data
-		t.Logger().Debug("Setting data expiry: ", session.OrgID)
+		t.Logger().Debug("Setting data expiry: ", orgID)
+
 		t.Gw.ExpiryCache.Set(session.OrgID, session.DataExpires, cache.DefaultExpiration)
 	}
 
@@ -253,16 +257,21 @@ func (t BaseMiddleware) OrgSessionExpiry(orgid string) int64 {
 		if found {
 			return cachedVal, nil
 		}
+
 		s, found := t.OrgSession(orgid)
 		if found && t.Spec.GlobalConfig.EnforceOrgDataAge {
 			return s.DataExpires, nil
 		}
+
 		return 0, errors.New("missing session")
 	})
 	if err != nil {
+
 		t.Logger().Debug("no cached entry found, returning 7 days")
-		return int64(604800)
+		t.SetOrgExpiry(orgid, defaultOrgSessionExpiry)
+		return defaultOrgSessionExpiry
 	}
+
 	return id.(int64)
 }
 

--- a/gateway/middleware_test.go
+++ b/gateway/middleware_test.go
@@ -19,6 +19,7 @@ import (
 
 type mockStore struct {
 	SessionHandler
+	DetailNotFound bool
 }
 
 var sess = user.SessionState{
@@ -26,8 +27,8 @@ var sess = user.SessionState{
 	DataExpires: 110,
 }
 
-func (mockStore) SessionDetail(orgID string, keyName string, hashed bool) (user.SessionState, bool) {
-	return sess.Clone(), true
+func (m mockStore) SessionDetail(orgID string, keyName string, hashed bool) (user.SessionState, bool) {
+	return sess.Clone(), !m.DetailNotFound
 }
 
 func TestBaseMiddleware_OrgSessionExpiry(t *testing.T) {
@@ -48,14 +49,18 @@ func TestBaseMiddleware_OrgSessionExpiry(t *testing.T) {
 	ts.Gw.ExpiryCache.Set(sess.OrgID, v, cache.DefaultExpiration)
 
 	got := m.OrgSessionExpiry(sess.OrgID)
-	if got != v {
-		t.Errorf("expected %d got %d", v, got)
-	}
+	assert.Equal(t, v, got)
 	ts.Gw.ExpiryCache.Delete(sess.OrgID)
+
 	got = m.OrgSessionExpiry(sess.OrgID)
-	if got != sess.DataExpires {
-		t.Errorf("expected %d got %d", sess.DataExpires, got)
-	}
+	assert.Equal(t, sess.DataExpires, got)
+	ts.Gw.ExpiryCache.Delete(sess.OrgID)
+
+	m.Spec.OrgSessionManager = mockStore{DetailNotFound: true}
+	noOrgSess := "nonexistent_org"
+	got = m.OrgSessionExpiry(noOrgSess)
+	assert.Equal(t, defaultOrgSessionExpiry, got)
+
 }
 
 func TestBaseMiddleware_getAuthType(t *testing.T) {

--- a/gateway/middleware_test.go
+++ b/gateway/middleware_test.go
@@ -19,6 +19,7 @@ import (
 
 type mockStore struct {
 	SessionHandler
+	//DetailNotFound is used to make mocked SessionDetail return (x,false), as if it don't find the session in the mocked storage.
 	DetailNotFound bool
 }
 
@@ -59,7 +60,7 @@ func TestBaseMiddleware_OrgSessionExpiry(t *testing.T) {
 	m.Spec.OrgSessionManager = mockStore{DetailNotFound: true}
 	noOrgSess := "nonexistent_org"
 	got = m.OrgSessionExpiry(noOrgSess)
-	assert.Equal(t, defaultOrgSessionExpiry, got)
+	assert.Equal(t, DEFAULT_ORG_SESSION_EXPIRATION, got)
 
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
In MDCB environments, the edge gateways goes to MDCB on each request to look for the orgKey. This is scenario is happening even if orgKey is not set - it doesn't exist.

This happens because on each recordHit (succes/error),  we try to get the expiration of the org session https://github.com/TykTechnologies/tyk/blob/009b52b0e7b093e133f3065cbc9c5123fea26bf3/gateway/handler_success.go#L240 - and this checks the cache first, then it goes ,thru MDCB and if it's not found, it returns a 7 days default time https://github.com/TykTechnologies/tyk/blob/009b52b0e7b093e133f3065cbc9c5123fea26bf3/gateway/middleware.go#L248.

So this PR address this problem, adding the org with the default value to `ExpiryCache`  if the org was not found. 
This cache has a default 10min expiration time, so if we add an orgKey - it should be found in the next 10 minutes and updated accordingly.


## Related Issue
<!-- This project only accepts pull requests related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->
https://tyktech.atlassian.net/browse/TT-2356
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
https://tyktech.atlassian.net/browse/TT-2356
## How This Has Been Tested
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of
the code, etc. -->
Added unit test
## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [ ] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
