### PR TITLE
[TT-5665] Allow list for field based permissions implement for allowing fields

### DIFF
--- a/gateway/mw_graphql_granular_access.go
+++ b/gateway/mw_graphql_granular_access.go
@@ -93,9 +93,10 @@ func (g *GraphqlGranularAccessChecker) validateFieldRestrictions(gqlRequest *gra
 func (g *GraphqlGranularAccessChecker) CheckGraphqlRequestFieldAllowance(gqlRequest *graphql.Request, accessDef *user.AccessDefinition, schema *graphql.Schema) GraphqlGranularAccessResult {
 	if accessDef.EnableAllow {
 		if len(accessDef.AllowedTypes) == 0 {
+			// Allow list feature is enabled but the list is empty.
 			var errors graphql.RequestErrors = []graphql.RequestError{
 				{
-					Message: fmt.Sprintf("there are no allowed types"),
+					Message: fmt.Sprintf("the allow list is empty"),
 				},
 			}
 			return GraphqlGranularAccessResult{
@@ -114,7 +115,7 @@ func (g *GraphqlGranularAccessChecker) CheckGraphqlRequestFieldAllowance(gqlRequ
 	}
 
 	if len(accessDef.RestrictedTypes) == 0 {
-		// There is no restricted types. Every field is allowed to access.
+		// There are no restricted types. Every field is allowed access.
 		return GraphqlGranularAccessResult{failReason: GranularAccessFailReasonNone}
 	}
 	fieldRestrictionList := graphql.FieldRestrictionList{

--- a/gateway/mw_graphql_granular_access.go
+++ b/gateway/mw_graphql_granular_access.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
@@ -77,45 +78,48 @@ type GraphqlGranularAccessResult struct {
 
 type GraphqlGranularAccessChecker struct{}
 
-func (g *GraphqlGranularAccessChecker) validateFieldRestrictions(gqlRequest *graphql.Request, restrictedFieldsList graphql.FieldRestrictionList, schema *graphql.Schema) *GraphqlGranularAccessResult {
-	result, err := gqlRequest.ValidateFieldRestrictions(schema, restrictedFieldsList, graphql.DefaultFieldsValidator{})
+func (g *GraphqlGranularAccessChecker) validateFieldRestrictions(gqlRequest *graphql.Request, fieldRestrictionList graphql.FieldRestrictionList, schema *graphql.Schema) GraphqlGranularAccessResult {
+	result, err := gqlRequest.ValidateFieldRestrictions(schema, fieldRestrictionList, graphql.DefaultFieldsValidator{})
 	if err != nil {
-		return &GraphqlGranularAccessResult{failReason: GranularAccessFailReasonInternalError, internalErr: err}
+		return GraphqlGranularAccessResult{failReason: GranularAccessFailReasonInternalError, internalErr: err}
 	}
 
 	if !result.Valid || (result.Errors != nil && result.Errors.Count() > 0) {
-		return &GraphqlGranularAccessResult{failReason: GranularAccessFailReasonValidationError, validationResult: &result}
+		return GraphqlGranularAccessResult{failReason: GranularAccessFailReasonValidationError, validationResult: &result}
 	}
-	return nil
+	return GraphqlGranularAccessResult{failReason: GranularAccessFailReasonNone}
 }
 
 func (g *GraphqlGranularAccessChecker) CheckGraphqlRequestFieldAllowance(gqlRequest *graphql.Request, accessDef *user.AccessDefinition, schema *graphql.Schema) GraphqlGranularAccessResult {
-	if len(accessDef.RestrictedTypes) == 0 && len(accessDef.AllowedTypes) == 0 {
-		return GraphqlGranularAccessResult{failReason: GranularAccessFailReasonNone}
-	}
-
-	var restrictedFieldsLists []graphql.FieldRestrictionList
-
-	if len(accessDef.RestrictedTypes) != 0 {
-		restrictedFieldsLists = append(restrictedFieldsLists, graphql.FieldRestrictionList{
-			Kind:  graphql.BlockList,
-			Types: accessDef.RestrictedTypes,
-		})
-	}
-
-	if len(accessDef.AllowedTypes) != 0 {
-		restrictedFieldsLists = append(restrictedFieldsLists, graphql.FieldRestrictionList{
+	if accessDef.EnableAllow {
+		if len(accessDef.AllowedTypes) == 0 {
+			var errors graphql.RequestErrors = []graphql.RequestError{
+				{
+					Message: fmt.Sprintf("there are no allowed types"),
+				},
+			}
+			return GraphqlGranularAccessResult{
+				failReason: GranularAccessFailReasonValidationError,
+				validationResult: &graphql.RequestFieldsValidationResult{
+					Valid:  false,
+					Errors: errors,
+				},
+			}
+		}
+		fieldRestrictionList := graphql.FieldRestrictionList{
 			Kind:  graphql.AllowList,
 			Types: accessDef.AllowedTypes,
-		})
-	}
-
-	for _, restrictedFieldsList := range restrictedFieldsLists {
-		result := g.validateFieldRestrictions(gqlRequest, restrictedFieldsList, schema)
-		if result != nil {
-			return *result
 		}
+		return g.validateFieldRestrictions(gqlRequest, fieldRestrictionList, schema)
 	}
 
-	return GraphqlGranularAccessResult{failReason: GranularAccessFailReasonNone}
+	if len(accessDef.RestrictedTypes) == 0 {
+		// There is no restricted types. Every field is allowed to access.
+		return GraphqlGranularAccessResult{failReason: GranularAccessFailReasonNone}
+	}
+	fieldRestrictionList := graphql.FieldRestrictionList{
+		Kind:  graphql.BlockList,
+		Types: accessDef.RestrictedTypes,
+	}
+	return g.validateFieldRestrictions(gqlRequest, fieldRestrictionList, schema)
 }

--- a/gateway/mw_graphql_granular_access.go
+++ b/gateway/mw_graphql_granular_access.go
@@ -1,7 +1,6 @@
 package gateway
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
@@ -96,7 +95,7 @@ func (g *GraphqlGranularAccessChecker) CheckGraphqlRequestFieldAllowance(gqlRequ
 			// Allow list feature is enabled but the list is empty.
 			var errors graphql.RequestErrors = []graphql.RequestError{
 				{
-					Message: fmt.Sprintf("the allow list is empty"),
+					Message: "the allow list is empty",
 				},
 			}
 			return GraphqlGranularAccessResult{

--- a/gateway/mw_graphql_granular_access_test.go
+++ b/gateway/mw_graphql_granular_access_test.go
@@ -272,7 +272,7 @@ func TestGraphQL_AllowedTypes_Empty_List(t *testing.T) {
 				Data:    restrictedQuery,
 				Headers: authHeaderWithDirectKey,
 				BodyMatchFunc: func(bytes []byte) bool {
-					return assert.Contains(t, string(bytes), `{"errors":[{"message":"there are no allowed types"}]}`)
+					return assert.Contains(t, string(bytes), `{"errors":[{"message":"the allow list is empty"}]}`)
 				},
 				Code: http.StatusBadRequest,
 			},
@@ -292,7 +292,7 @@ func TestGraphQL_AllowedTypes_Empty_List(t *testing.T) {
 				Data:    restrictedQuery,
 				Headers: authHeaderWithPolicyAppliedKey,
 				BodyMatchFunc: func(bytes []byte) bool {
-					return assert.Contains(t, string(bytes), `{"errors":[{"message":"there are no allowed types"}]}`)
+					return assert.Contains(t, string(bytes), `{"errors":[{"message":"the allow list is empty"}]}`)
 				},
 				Code: http.StatusBadRequest,
 			},

--- a/gateway/mw_graphql_granular_access_test.go
+++ b/gateway/mw_graphql_granular_access_test.go
@@ -124,9 +124,8 @@ func TestGraphQL_AllowedTypes(t *testing.T) {
 	_, directKey := g.CreateSession(func(s *user.SessionState) {
 		s.AccessRights = map[string]user.AccessDefinition{
 			api.APIID: {
-				APIID:       api.APIID,
-				APIName:     api.Name,
-				EnableAllow: true,
+				APIID:   api.APIID,
+				APIName: api.Name,
 				AllowedTypes: []graphql.Type{
 					{
 						Name:   "Country",
@@ -144,9 +143,8 @@ func TestGraphQL_AllowedTypes(t *testing.T) {
 	pID := g.CreatePolicy(func(p *user.Policy) {
 		p.AccessRights = map[string]user.AccessDefinition{
 			api.APIID: {
-				APIID:       api.APIID,
-				APIName:     api.Name,
-				EnableAllow: true,
+				APIID:   api.APIID,
+				APIName: api.Name,
 				AllowedTypes: []graphql.Type{
 					{
 						Name:   "Country",
@@ -220,87 +218,6 @@ func TestGraphQL_AllowedTypes(t *testing.T) {
 	})
 }
 
-func TestGraphQL_AllowedTypes_Empty_List(t *testing.T) {
-	g := StartTest(nil)
-	defer g.Close()
-
-	api := g.Gw.BuildAndLoadAPI(func(spec *APISpec) {
-		spec.Proxy.ListenPath = "/"
-		spec.UseKeylessAccess = false
-		spec.GraphQL.Enabled = true
-	})[0]
-
-	_, directKey := g.CreateSession(func(s *user.SessionState) {
-		s.AccessRights = map[string]user.AccessDefinition{
-			api.APIID: {
-				APIID:       api.APIID,
-				APIName:     api.Name,
-				EnableAllow: true,
-			},
-		}
-	})
-
-	pID := g.CreatePolicy(func(p *user.Policy) {
-		p.AccessRights = map[string]user.AccessDefinition{
-			api.APIID: {
-				APIID:       api.APIID,
-				APIName:     api.Name,
-				EnableAllow: true,
-			},
-		}
-	})
-
-	_, policyAppliedKey := g.CreateSession(func(s *user.SessionState) {
-		s.ApplyPolicies = []string{pID}
-	})
-
-	allowedQuery := graphql.Request{
-		Query: "query Query { countries { code } }",
-	}
-
-	restrictedQuery := graphql.Request{
-		Query: "query Query { countries { name } }",
-	}
-
-	t.Run("Direct key", func(t *testing.T) {
-		authHeaderWithDirectKey := map[string]string{
-			headers.Authorization: directKey,
-		}
-
-		_, _ = g.Run(t, []test.TestCase{
-			{
-				Data:    restrictedQuery,
-				Headers: authHeaderWithDirectKey,
-				BodyMatchFunc: func(bytes []byte) bool {
-					return assert.Contains(t, string(bytes), `{"errors":[{"message":"the allow list is empty"}]}`)
-				},
-				Code: http.StatusBadRequest,
-			},
-			{Data: allowedQuery, Headers: authHeaderWithDirectKey, Code: http.StatusBadRequest},
-		}...)
-	})
-
-	t.Run("Policy applied key", func(t *testing.T) {
-		test.Flaky(t) // TODO: TT-5220
-
-		authHeaderWithPolicyAppliedKey := map[string]string{
-			headers.Authorization: policyAppliedKey,
-		}
-
-		_, _ = g.Run(t, []test.TestCase{
-			{
-				Data:    restrictedQuery,
-				Headers: authHeaderWithPolicyAppliedKey,
-				BodyMatchFunc: func(bytes []byte) bool {
-					return assert.Contains(t, string(bytes), `{"errors":[{"message":"the allow list is empty"}]}`)
-				},
-				Code: http.StatusBadRequest,
-			},
-			{Data: allowedQuery, Headers: authHeaderWithPolicyAppliedKey, Code: http.StatusBadRequest},
-		}...)
-	})
-}
-
 func TestGraphQL_AllowedTypes_Override_RestrictedTypes(t *testing.T) {
 	g := StartTest(nil)
 	defer g.Close()
@@ -314,9 +231,8 @@ func TestGraphQL_AllowedTypes_Override_RestrictedTypes(t *testing.T) {
 	_, directKey := g.CreateSession(func(s *user.SessionState) {
 		s.AccessRights = map[string]user.AccessDefinition{
 			api.APIID: {
-				APIID:       api.APIID,
-				APIName:     api.Name,
-				EnableAllow: true,
+				APIID:   api.APIID,
+				APIName: api.Name,
 				AllowedTypes: []graphql.Type{
 					{
 						Name:   "Country",
@@ -340,9 +256,8 @@ func TestGraphQL_AllowedTypes_Override_RestrictedTypes(t *testing.T) {
 	pID := g.CreatePolicy(func(p *user.Policy) {
 		p.AccessRights = map[string]user.AccessDefinition{
 			api.APIID: {
-				APIID:       api.APIID,
-				APIName:     api.Name,
-				EnableAllow: true,
+				APIID:   api.APIID,
+				APIName: api.Name,
 				AllowedTypes: []graphql.Type{
 					{
 						Name:   "Country",

--- a/user/session.go
+++ b/user/session.go
@@ -62,6 +62,7 @@ type AccessDefinition struct {
 	AllowedURLs       []AccessSpec            `bson:"allowed_urls" json:"allowed_urls" msg:"allowed_urls"` // mapped string MUST be a valid regex
 	RestrictedTypes   []graphql.Type          `json:"restricted_types" msg:"restricted_types"`
 	AllowedTypes      []graphql.Type          `json:"allowed_types" msg:"allowed_types"`
+	EnableAllow       bool                    `json:"enable_allow" msg:"enable_allow"`
 	Limit             APILimit                `json:"limit" msg:"limit"`
 	FieldAccessRights []FieldAccessDefinition `json:"field_access_rights" msg:"field_access_rights"`
 

--- a/user/session.go
+++ b/user/session.go
@@ -62,7 +62,6 @@ type AccessDefinition struct {
 	AllowedURLs       []AccessSpec            `bson:"allowed_urls" json:"allowed_urls" msg:"allowed_urls"` // mapped string MUST be a valid regex
 	RestrictedTypes   []graphql.Type          `json:"restricted_types" msg:"restricted_types"`
 	AllowedTypes      []graphql.Type          `json:"allowed_types" msg:"allowed_types"`
-	EnableAllow       bool                    `json:"enable_allow" msg:"enable_allow"`
 	Limit             APILimit                `json:"limit" msg:"limit"`
 	FieldAccessRights []FieldAccessDefinition `json:"field_access_rights" msg:"field_access_rights"`
 


### PR DESCRIPTION
This PR implements [TT-5665](https://tyktech.atlassian.net/browse/TT-5665). 

- Added a new field to `AccessDefinition` called `EnableAllow`
- Added integration tests for allow list feature.
- If the user sets `EnableAllow` true, the restricted fields feature is disabled. Only the fields in the allow list can be accessible.
- If the allow list is enabled but the list is empty, it returns `{"errors":[{"message":"the allow list is empty"}]}`
- Tried to reduce duplicated code in the tests but significantly reduced the code's readability. So I reverted those changes. 

`Policy applied key` test in `TestGraphQL_RestrictedTypes` marked as flaky. Because the test cases were based on the same code, I didn't remove that mark from my tests.