### PR TITLE
[TT-6585] Remove OAS mock response conversions

### DIFF
--- a/apidef/oas/middleware_test.go
+++ b/apidef/oas/middleware_test.go
@@ -82,18 +82,6 @@ func TestExtendedPaths(t *testing.T) {
 	})
 }
 
-func TestMockResponse(t *testing.T) {
-	var emptyMockResponse MockResponse
-
-	var convertedMockResponse apidef.MockResponseMeta
-	emptyMockResponse.ExtractTo(&convertedMockResponse)
-
-	var resultMockResponse MockResponse
-	resultMockResponse.Fill(convertedMockResponse)
-
-	assert.Equal(t, emptyMockResponse, resultMockResponse)
-}
-
 func TestTransformRequestBody(t *testing.T) {
 
 	t.Run("empty", func(t *testing.T) {


### PR DESCRIPTION
As a new mocking functionality will be implemented, the previous implementation should be removed.