### PR TITLE
[TT-6588] Move oas preparation to MakeSpec function

### DIFF
--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -285,7 +285,7 @@ type APIDefinitionLoader struct {
 
 // MakeSpec will generate a flattened URLSpec from and APIDefinitions' VersionInfo data. paths are
 // keyed to the Api version name, which is determined during routing to speed up lookups
-func (a APIDefinitionLoader) MakeSpec(def *apidef.APIDefinition, logger *logrus.Entry) *APISpec {
+func (a APIDefinitionLoader) MakeSpec(def nestedApiDefinition, logger *logrus.Entry) *APISpec {
 	spec := &APISpec{}
 
 	if logger == nil {
@@ -317,7 +317,7 @@ func (a APIDefinitionLoader) MakeSpec(def *apidef.APIDefinition, logger *logrus.
 		}
 	}
 
-	spec.APIDefinition = def
+	spec.APIDefinition = def.APIDefinition
 
 	// We'll push the default HealthChecker:
 	spec.Health = &DefaultHealthChecker{
@@ -387,6 +387,15 @@ func (a APIDefinitionLoader) MakeSpec(def *apidef.APIDefinition, logger *logrus.
 		}
 		spec.RxPaths[v.Name] = pathSpecs
 		spec.WhiteListEnabled[v.Name] = whiteListSpecs
+	}
+
+	if spec.IsOAS && def.OAS != nil {
+		loader := openapi3.NewLoader()
+		if err := loader.ResolveRefsIn(&def.OAS.T, nil); err != nil {
+			log.WithError(err).Errorf("Dashboard loaded API's OAS reference resolve failed: %s", def.APIID)
+		}
+
+		spec.OAS = *def.OAS
 	}
 
 	return spec
@@ -489,17 +498,7 @@ func (a APIDefinitionLoader) FromDashboardService(endpoint string) ([]*APISpec, 
 	// Process
 	var specs []*APISpec
 	for _, def := range apiDefs {
-		spec := a.MakeSpec(def.APIDefinition, nil)
-
-		if spec.IsOAS {
-			loader := openapi3.NewLoader()
-			if err := loader.ResolveRefsIn(&def.OAS.T, nil); err != nil {
-				log.WithError(err).Errorf("Dashboard loaded API's OAS reference resolve failed: %s", def.APIID)
-			}
-
-			spec.OAS = *def.OAS
-		}
-
+		spec := a.MakeSpec(def, nil)
 		specs = append(specs, spec)
 	}
 
@@ -577,16 +576,7 @@ func (a APIDefinitionLoader) processRPCDefinitions(apiCollection string, gw *Gat
 			def.Proxy.ListenPath = newListenPath
 		}
 
-		spec := a.MakeSpec(def.APIDefinition, nil)
-		if spec.IsOAS {
-			loader := openapi3.NewLoader()
-			if err := loader.ResolveRefsIn(&def.OAS.T, nil); err != nil {
-				log.WithError(err).Errorf("RPC loaded API's OAS reference resolve failed: %s", def.APIID)
-			}
-
-			spec.OAS = *def.OAS
-		}
-
+		spec := a.MakeSpec(def, nil)
 		specs = append(specs, spec)
 	}
 
@@ -632,17 +622,17 @@ func (a APIDefinitionLoader) FromDir(dir string) []*APISpec {
 		}
 
 		def := a.ParseDefinition(f)
-		spec := a.MakeSpec(&def, nil)
-
-		_, _ = f.Seek(0, io.SeekStart)
-		_ = f.Close()
-
+		nestDef := nestedApiDefinition{APIDefinition: &def}
 		loader := openapi3.NewLoader()
 		oasDoc, err := loader.LoadFromFile(a.GetOASFilepath(path))
 		if err == nil {
-			spec.OAS.T = *oasDoc
-			_ = f.Close()
+			nestDef.OAS = &oas.OAS{T: *oasDoc}
 		}
+
+		spec := a.MakeSpec(nestDef, nil)
+
+		_, _ = f.Seek(0, io.SeekStart)
+		_ = f.Close()
 
 		specs = append(specs, spec)
 	}

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -285,7 +285,7 @@ type APIDefinitionLoader struct {
 
 // MakeSpec will generate a flattened URLSpec from and APIDefinitions' VersionInfo data. paths are
 // keyed to the Api version name, which is determined during routing to speed up lookups
-func (a APIDefinitionLoader) MakeSpec(def nestedApiDefinition, logger *logrus.Entry) *APISpec {
+func (a APIDefinitionLoader) MakeSpec(def *nestedApiDefinition, logger *logrus.Entry) *APISpec {
 	spec := &APISpec{}
 
 	if logger == nil {
@@ -498,7 +498,7 @@ func (a APIDefinitionLoader) FromDashboardService(endpoint string) ([]*APISpec, 
 	// Process
 	var specs []*APISpec
 	for _, def := range apiDefs {
-		spec := a.MakeSpec(def, nil)
+		spec := a.MakeSpec(&def, nil)
 		specs = append(specs, spec)
 	}
 
@@ -576,7 +576,7 @@ func (a APIDefinitionLoader) processRPCDefinitions(apiCollection string, gw *Gat
 			def.Proxy.ListenPath = newListenPath
 		}
 
-		spec := a.MakeSpec(def, nil)
+		spec := a.MakeSpec(&def, nil)
 		specs = append(specs, spec)
 	}
 
@@ -629,7 +629,7 @@ func (a APIDefinitionLoader) FromDir(dir string) []*APISpec {
 			nestDef.OAS = &oas.OAS{T: *oasDoc}
 		}
 
-		spec := a.MakeSpec(nestDef, nil)
+		spec := a.MakeSpec(&nestDef, nil)
 
 		_, _ = f.Seek(0, io.SeekStart)
 		_ = f.Close()

--- a/gateway/coprocess_id_extractor_test.go
+++ b/gateway/coprocess_id_extractor_test.go
@@ -28,7 +28,7 @@ const (
 
 func (ts *Test) createSpecTestFrom(t testing.TB, def *apidef.APIDefinition) *APISpec {
 	loader := APIDefinitionLoader{Gw: ts.Gw}
-	spec := loader.MakeSpec(def, nil)
+	spec := loader.MakeSpec(nestedApiDefinition{APIDefinition: def}, nil)
 	tname := t.Name()
 	redisStore := &storage.RedisCluster{KeyPrefix: tname + "-apikey.", RedisController: ts.Gw.RedisController}
 	healthStore := &storage.RedisCluster{KeyPrefix: tname + "-apihealth.", RedisController: ts.Gw.RedisController}

--- a/gateway/coprocess_id_extractor_test.go
+++ b/gateway/coprocess_id_extractor_test.go
@@ -28,7 +28,7 @@ const (
 
 func (ts *Test) createSpecTestFrom(t testing.TB, def *apidef.APIDefinition) *APISpec {
 	loader := APIDefinitionLoader{Gw: ts.Gw}
-	spec := loader.MakeSpec(nestedApiDefinition{APIDefinition: def}, nil)
+	spec := loader.MakeSpec(&nestedApiDefinition{APIDefinition: def}, nil)
 	tname := t.Name()
 	redisStore := &storage.RedisCluster{KeyPrefix: tname + "-apikey.", RedisController: ts.Gw.RedisController}
 	healthStore := &storage.RedisCluster{KeyPrefix: tname + "-apihealth.", RedisController: ts.Gw.RedisController}

--- a/gateway/rpc_backup_handlers.go
+++ b/gateway/rpc_backup_handlers.go
@@ -49,7 +49,7 @@ func (gw *Gateway) LoadDefinitionsFromRPCBackup() ([]*APISpec, error) {
 
 	apiListAsString := decrypt([]byte(secret), cryptoText)
 
-	a := APIDefinitionLoader{gw}
+	a := APIDefinitionLoader{Gw: gw}
 	return a.processRPCDefinitions(apiListAsString, gw)
 }
 

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/TykTechnologies/tyk/test"
 	"html/template"
 	"io/ioutil"
 	stdlog "log"
@@ -20,6 +19,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/TykTechnologies/tyk/test"
 
 	"sync/atomic"
 	textTemplate "text/template"
@@ -438,7 +439,7 @@ func (gw *Gateway) buildDashboardConnStr(resource string) string {
 }
 
 func (gw *Gateway) syncAPISpecs() (int, error) {
-	loader := APIDefinitionLoader{gw}
+	loader := APIDefinitionLoader{Gw: gw}
 
 	var s []*APISpec
 	if gw.GetConfig().UseDBAppConfigs {

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -881,7 +881,7 @@ func TestReq(t testing.TB, method, urlStr string, body interface{}) *http.Reques
 func (gw *Gateway) CreateDefinitionFromString(defStr string) *APISpec {
 	loader := APIDefinitionLoader{Gw: gw}
 	def := loader.ParseDefinition(strings.NewReader(defStr))
-	spec := loader.MakeSpec(nestedApiDefinition{APIDefinition: &def}, nil)
+	spec := loader.MakeSpec(&nestedApiDefinition{APIDefinition: &def}, nil)
 	return spec
 }
 

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -881,7 +881,7 @@ func TestReq(t testing.TB, method, urlStr string, body interface{}) *http.Reques
 func (gw *Gateway) CreateDefinitionFromString(defStr string) *APISpec {
 	loader := APIDefinitionLoader{Gw: gw}
 	def := loader.ParseDefinition(strings.NewReader(defStr))
-	spec := loader.MakeSpec(&def, nil)
+	spec := loader.MakeSpec(nestedApiDefinition{APIDefinition: &def}, nil)
 	return spec
 }
 

--- a/gateway/tracing.go
+++ b/gateway/tracing.go
@@ -112,8 +112,8 @@ func (gw *Gateway) traceHandler(w http.ResponseWriter, r *http.Request) {
 	gs := gw.prepareStorage()
 	subrouter := mux.NewRouter()
 
-	loader := &APIDefinitionLoader{gw}
-	spec := loader.MakeSpec(traceReq.Spec, logrus.NewEntry(logger))
+	loader := &APIDefinitionLoader{Gw: gw}
+	spec := loader.MakeSpec(nestedApiDefinition{APIDefinition: traceReq.Spec}, logrus.NewEntry(logger))
 
 	chainObj := gw.processSpec(spec, nil, &gs, subrouter, logrus.NewEntry(logger))
 	spec.middlewareChain = chainObj

--- a/gateway/tracing.go
+++ b/gateway/tracing.go
@@ -113,7 +113,7 @@ func (gw *Gateway) traceHandler(w http.ResponseWriter, r *http.Request) {
 	subrouter := mux.NewRouter()
 
 	loader := &APIDefinitionLoader{Gw: gw}
-	spec := loader.MakeSpec(nestedApiDefinition{APIDefinition: traceReq.Spec}, logrus.NewEntry(logger))
+	spec := loader.MakeSpec(&nestedApiDefinition{APIDefinition: traceReq.Spec}, logrus.NewEntry(logger))
 
 	chainObj := gw.processSpec(spec, nil, &gs, subrouter, logrus.NewEntry(logger))
 	spec.middlewareChain = chainObj


### PR DESCRIPTION
Move repeating code to common `MakeSpec` function.