### PR TITLE
[TT-6568] Ability to turn off introspection for a graph

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -372,6 +372,10 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 					accessRights.Limit.QuotaRenews = r.Limit.QuotaRenews
 				}
 
+				if r, ok := session.AccessRights[apiID]; ok {
+					accessRights.DisableIntrospection = r.DisableIntrospection
+				}
+
 				// overwrite session access right for this API
 				rights[apiID] = accessRights
 
@@ -392,6 +396,7 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 
 					// Merge ACLs for the same API
 					if r, ok := rights[k]; ok {
+						r.DisableIntrospection = v.DisableIntrospection
 						r.Versions = appendIfMissing(rights[k].Versions, v.Versions...)
 
 						for _, u := range v.AllowedURLs {

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -373,7 +373,10 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 				}
 
 				if r, ok := session.AccessRights[apiID]; ok {
-					accessRights.DisableIntrospection = r.DisableIntrospection
+					// If GQL introspection is disabled, keep that configuration.
+					if r.DisableIntrospection {
+						accessRights.DisableIntrospection = r.DisableIntrospection
+					}
 				}
 
 				// overwrite session access right for this API
@@ -396,7 +399,10 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 
 					// Merge ACLs for the same API
 					if r, ok := rights[k]; ok {
-						r.DisableIntrospection = v.DisableIntrospection
+						// If GQL introspection is disabled, keep that configuration.
+						if v.DisableIntrospection {
+							r.DisableIntrospection = v.DisableIntrospection
+						}
 						r.Versions = appendIfMissing(rights[k].Versions, v.Versions...)
 
 						for _, u := range v.AllowedURLs {

--- a/gateway/mw_graphql_granular_access.go
+++ b/gateway/mw_graphql_granular_access.go
@@ -52,7 +52,6 @@ func (m *GraphQLGranularAccessMiddleware) ProcessRequest(w http.ResponseWriter, 
 		return nil, http.StatusOK
 	}
 
-	var isIntrospection bool
 	isIntrospection, err := gqlRequest.IsIntrospectionQuery()
 	if err != nil {
 		return err, http.StatusInternalServerError

--- a/gateway/policy.go
+++ b/gateway/policy.go
@@ -18,25 +18,27 @@ import (
 )
 
 type DBAccessDefinition struct {
-	APIName           string                       `json:"apiname"`
-	APIID             string                       `json:"apiid"`
-	Versions          []string                     `json:"versions"`
-	AllowedURLs       []user.AccessSpec            `bson:"allowed_urls" json:"allowed_urls"` // mapped string MUST be a valid regex
-	RestrictedTypes   []graphql.Type               `json:"restricted_types"`
-	AllowedTypes      []graphql.Type               `json:"allowed_types"`
-	FieldAccessRights []user.FieldAccessDefinition `json:"field_access_rights"`
-	Limit             *user.APILimit               `json:"limit"`
+	APIName              string                       `json:"apiname"`
+	APIID                string                       `json:"apiid"`
+	Versions             []string                     `json:"versions"`
+	AllowedURLs          []user.AccessSpec            `bson:"allowed_urls" json:"allowed_urls"` // mapped string MUST be a valid regex
+	RestrictedTypes      []graphql.Type               `json:"restricted_types"`
+	AllowedTypes         []graphql.Type               `json:"allowed_types"`
+	DisableIntrospection bool                         `json:"disable_introspection"`
+	FieldAccessRights    []user.FieldAccessDefinition `json:"field_access_rights"`
+	Limit                *user.APILimit               `json:"limit"`
 }
 
 func (d *DBAccessDefinition) ToRegularAD() user.AccessDefinition {
 	ad := user.AccessDefinition{
-		APIName:           d.APIName,
-		APIID:             d.APIID,
-		Versions:          d.Versions,
-		AllowedURLs:       d.AllowedURLs,
-		RestrictedTypes:   d.RestrictedTypes,
-		AllowedTypes:      d.AllowedTypes,
-		FieldAccessRights: d.FieldAccessRights,
+		APIName:              d.APIName,
+		APIID:                d.APIID,
+		Versions:             d.Versions,
+		AllowedURLs:          d.AllowedURLs,
+		RestrictedTypes:      d.RestrictedTypes,
+		AllowedTypes:         d.AllowedTypes,
+		DisableIntrospection: d.DisableIntrospection,
+		FieldAccessRights:    d.FieldAccessRights,
 	}
 
 	if d.Limit != nil {

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -322,6 +322,20 @@ func (s *Test) TestPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesD
 					},
 				}},
 		},
+		"introspection-disabled": {
+			ID: "introspection_disabled",
+			AccessRights: map[string]user.AccessDefinition{
+				"a": {
+					DisableIntrospection: true,
+				}},
+		},
+		"introspection-enabled": {
+			ID: "introspection_enabled",
+			AccessRights: map[string]user.AccessDefinition{
+				"a": {
+					DisableIntrospection: false,
+				}},
+		},
 		"field-level-depth-limit1": {
 			ID: "field-level-depth-limit1",
 			AccessRights: map[string]user.AccessDefinition{
@@ -706,6 +720,20 @@ func (s *Test) TestPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesD
 							{Name: "Person", Fields: []string{"name"}},
 						},
 						Limit: user.APILimit{},
+					},
+				}
+
+				assert.Equal(t, want, s.AccessRights)
+			},
+		},
+		{
+			name:     "If GQL introspection is disabled, it remains disabled after merging",
+			policies: []string{"introspection-disabled", "introspection-enabled"},
+			sessMatch: func(t *testing.T, s *user.SessionState) {
+				want := map[string]user.AccessDefinition{
+					"a": {
+						DisableIntrospection: true, // If GQL introspection is disabled, it remains disabled after merging.
+						Limit:                user.APILimit{},
 					},
 				}
 

--- a/gateway/session_manager.go
+++ b/gateway/session_manager.go
@@ -339,6 +339,7 @@ func GetAccessDefinitionByAPIIDOrSession(currentSession *user.SessionState, api 
 			accessDef.FieldAccessRights = rights.FieldAccessRights
 			accessDef.RestrictedTypes = rights.RestrictedTypes
 			accessDef.AllowedTypes = rights.AllowedTypes
+			accessDef.DisableIntrospection = rights.DisableIntrospection
 			allowanceScope = rights.AllowanceScope
 		}
 	}

--- a/user/session.go
+++ b/user/session.go
@@ -56,14 +56,15 @@ type APILimit struct {
 // in the gateway/policy.go:19
 // TODO: is it possible to share fields?
 type AccessDefinition struct {
-	APIName           string                  `json:"api_name" msg:"api_name"`
-	APIID             string                  `json:"api_id" msg:"api_id"`
-	Versions          []string                `json:"versions" msg:"versions"`
-	AllowedURLs       []AccessSpec            `bson:"allowed_urls" json:"allowed_urls" msg:"allowed_urls"` // mapped string MUST be a valid regex
-	RestrictedTypes   []graphql.Type          `json:"restricted_types" msg:"restricted_types"`
-	AllowedTypes      []graphql.Type          `json:"allowed_types" msg:"allowed_types"`
-	Limit             APILimit                `json:"limit" msg:"limit"`
-	FieldAccessRights []FieldAccessDefinition `json:"field_access_rights" msg:"field_access_rights"`
+	APIName              string                  `json:"api_name" msg:"api_name"`
+	APIID                string                  `json:"api_id" msg:"api_id"`
+	Versions             []string                `json:"versions" msg:"versions"`
+	AllowedURLs          []AccessSpec            `bson:"allowed_urls" json:"allowed_urls" msg:"allowed_urls"` // mapped string MUST be a valid regex
+	RestrictedTypes      []graphql.Type          `json:"restricted_types" msg:"restricted_types"`
+	AllowedTypes         []graphql.Type          `json:"allowed_types" msg:"allowed_types"`
+	Limit                APILimit                `json:"limit" msg:"limit"`
+	FieldAccessRights    []FieldAccessDefinition `json:"field_access_rights" msg:"field_access_rights"`
+	DisableIntrospection bool                    `json:"disable_introspection" msg:"disable_introspection"`
 
 	AllowanceScope string `json:"allowance_scope" msg:"allowance_scope"`
 }


### PR DESCRIPTION
PR for [TT-6568](https://tyktech.atlassian.net/jira/software/c/projects/TT/boards/26?modal=detail&selectedIssue=TT-6568)

I added a new field called `DisableIntrospection` to `AccessDefinition` struct. It's false by default because GQL introspection is enabled by default now. 

API Managers can disable introspection by using keys and policies. Debug endpoint works as expected. 

- If the API is open(keyless), we can still run introspection queries. 
- If the API requires an authentication token, the debug endpoint obeys the access definition rules as expected. So if `disable_introspection=true` for a token, users cannot run introspection queries with debug endpoint.

We need to update `AccessDefiniton` struct and related `.graphql` files in **tyk-analytics** and **portal** repositories after merging this PR.