### PR TITLE
added TestRebuildResponseHeaders

### DIFF
--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -560,10 +560,7 @@ func (h *CustomMiddlewareResponseHook) HandleResponse(rw http.ResponseWriter, re
 		return errors.New("Middleware error")
 	}
 
-	// Clear all response headers before populating from coprocess response object:
-	for k := range res.Header {
-		delete(res.Header, k)
-	}
+	h.SetResponseHeaders(res, retObject)
 	// Set headers:
 	ignoreCanonical := h.mw.Gw.GetConfig().IgnoreCanonicalMIMEHeaderKey
 	for k, v := range retObject.Response.Headers {
@@ -576,6 +573,20 @@ func (h *CustomMiddlewareResponseHook) HandleResponse(rw http.ResponseWriter, re
 
 	res.StatusCode = int(retObject.Response.StatusCode)
 	return nil
+}
+
+// SetResponseHeaders cleans the headers from the upstream and populate them again after the mw call
+// as some mws modify the headers
+func (h *CustomMiddlewareResponseHook) SetResponseHeaders(res *http.Response, retObject *coprocess.Object) {
+	// Clear all response headers before populating from coprocess response object:
+	for k := range res.Header {
+		delete(res.Header, k)
+	}
+	// Set headers:
+	ignoreCanonical := h.Gw.GetConfig().IgnoreCanonicalMIMEHeaderKey
+	for k, v := range retObject.Response.Headers {
+		setCustomHeader(res.Header, k, v, ignoreCanonical)
+	}
 }
 
 func (c *CoProcessor) Dispatch(object *coprocess.Object) (*coprocess.Object, error) {

--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -560,7 +560,7 @@ func (h *CustomMiddlewareResponseHook) HandleResponse(rw http.ResponseWriter, re
 		return errors.New("Middleware error")
 	}
 
-	h.SetResponseHeaders(res, retObject)
+	h.RebuildResponseHeaders(res, retObject)
 	// Set headers:
 	ignoreCanonical := h.mw.Gw.GetConfig().IgnoreCanonicalMIMEHeaderKey
 	for k, v := range retObject.Response.Headers {
@@ -575,9 +575,9 @@ func (h *CustomMiddlewareResponseHook) HandleResponse(rw http.ResponseWriter, re
 	return nil
 }
 
-// SetResponseHeaders cleans the headers from the upstream and populate them again after the mw call
+// RebuildResponseHeaders cleans the headers from the upstream and populate them again after the mw call
 // as some mws modify the headers
-func (h *CustomMiddlewareResponseHook) SetResponseHeaders(res *http.Response, retObject *coprocess.Object) {
+func (h *CustomMiddlewareResponseHook) RebuildResponseHeaders(res *http.Response, retObject *coprocess.Object) {
 	// Clear all response headers before populating from coprocess response object:
 	for k := range res.Header {
 		delete(res.Header, k)

--- a/gateway/coprocess_test.go
+++ b/gateway/coprocess_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestRebuildResponseHeaders(t *testing.T) {
 	ts := StartTest(nil)
+	defer ts.Close()
 	h := CustomMiddlewareResponseHook{
 		mw: nil,
 		Gw: ts.Gw,

--- a/gateway/coprocess_test.go
+++ b/gateway/coprocess_test.go
@@ -1,0 +1,90 @@
+package gateway
+
+import (
+	"github.com/TykTechnologies/tyk/coprocess"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+)
+
+func TestSetResponseHeaders(t *testing.T) {
+	ts := StartTest(nil)
+	h := CustomMiddlewareResponseHook{
+		mw: nil,
+		Gw: ts.Gw,
+	}
+
+	persistedHeaderKey := "persisted-header"
+	removedHeaderKey := "removed-header"
+	testCases := []struct {
+		name                               string
+		initialResponseHeaders             map[string]string
+		responseHeadersFromCoprocessPlugin map[string]string
+		expectedFinalResponseHeaders       map[string]string
+	}{
+		{
+			name: "header removed by coprocess plugin",
+			initialResponseHeaders: map[string]string{
+				persistedHeaderKey: "1",
+				removedHeaderKey:   "1",
+			},
+			responseHeadersFromCoprocessPlugin: map[string]string{
+				persistedHeaderKey: "1",
+			},
+			expectedFinalResponseHeaders: map[string]string{
+				persistedHeaderKey: "1",
+			},
+		},
+		{
+			name: "headers are not modified in coprocess plugin",
+			initialResponseHeaders: map[string]string{
+				persistedHeaderKey: "1",
+			},
+			responseHeadersFromCoprocessPlugin: map[string]string{
+				persistedHeaderKey: "1",
+			},
+			expectedFinalResponseHeaders: map[string]string{
+				persistedHeaderKey: "1",
+			},
+		},
+		{
+			name: "a header is added by the coprocess plugin",
+			initialResponseHeaders: map[string]string{
+				persistedHeaderKey: "1",
+			},
+			responseHeadersFromCoprocessPlugin: map[string]string{
+				persistedHeaderKey: "1",
+				"new-added-header": "1",
+			},
+			expectedFinalResponseHeaders: map[string]string{
+				persistedHeaderKey: "1",
+				"new-added-header": "1",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			upstreamRes := http.Response{Header: http.Header{}}
+
+			// build the initial object
+			for headerName, headerValue := range tc.initialResponseHeaders {
+				upstreamRes.Header.Add(headerName, headerValue)
+			}
+
+			ret := coprocess.Object{
+				Response: &coprocess.ResponseObject{},
+			}
+			ret.Response.Headers = tc.responseHeadersFromCoprocessPlugin
+
+			h.SetResponseHeaders(&upstreamRes, &ret)
+
+			assert.Equal(t, len(tc.expectedFinalResponseHeaders), len(upstreamRes.Header))
+
+			for headerName, expectedHeaderValue := range tc.expectedFinalResponseHeaders {
+				currentHeaderValue := upstreamRes.Header.Get(headerName)
+				assert.Equal(t, expectedHeaderValue, currentHeaderValue)
+			}
+		})
+	}
+}

--- a/gateway/coprocess_test.go
+++ b/gateway/coprocess_test.go
@@ -77,7 +77,7 @@ func TestRebuildResponseHeaders(t *testing.T) {
 			}
 			ret.Response.Headers = tc.responseHeadersFromCoprocessPlugin
 
-			h.SetResponseHeaders(&upstreamRes, &ret)
+			h.RebuildResponseHeaders(&upstreamRes, &ret)
 
 			assert.Equal(t, len(tc.expectedFinalResponseHeaders), len(upstreamRes.Header))
 

--- a/gateway/coprocess_test.go
+++ b/gateway/coprocess_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestSetResponseHeaders(t *testing.T) {
+func TestRebuildResponseHeaders(t *testing.T) {
 	ts := StartTest(nil)
 	h := CustomMiddlewareResponseHook{
 		mw: nil,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Added test to TestRebuildResponseHeaders which is a function called by coprocess to set headers after dispatching the plugin call

## Related Issue
https://tyktech.atlassian.net/browse/TT-6093

## Motivation and Context
Give solution to https://tyktech.atlassian.net/browse/TT-6093

## How This Has Been Tested
- Ran manual test as ticket
- Ran unit test

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
