### PR TITLE
[TT-6659] Implement OAS schema extractor

### DIFF
--- a/apidef/oas/example.go
+++ b/apidef/oas/example.go
@@ -1,0 +1,42 @@
+package oas
+
+import "github.com/getkin/kin-openapi/openapi3"
+
+func ExampleExtractor(schema *openapi3.SchemaRef) interface{} {
+	val := schema.Value
+	if val.Example != nil {
+		return val.Example
+	}
+
+	switch {
+	case val.Type == openapi3.TypeObject:
+		obj := make(map[string]interface{})
+		for name, prop := range schema.Value.Properties {
+			obj[name] = ExampleExtractor(prop)
+		}
+
+		return obj
+	case val.Type == openapi3.TypeArray:
+		items := ExampleExtractor(val.Items)
+		return []interface{}{items}
+	default:
+		if len(val.Enum) > 0 {
+			return val.Enum[0]
+		} else {
+			return emptyExampleVal(val)
+		}
+	}
+}
+
+func emptyExampleVal(schema *openapi3.Schema) interface{} {
+	switch schema.Type {
+	case openapi3.TypeString:
+		return "string"
+	case openapi3.TypeInteger, openapi3.TypeNumber:
+		return 0
+	case openapi3.TypeBoolean:
+		return true
+	default:
+		return nil
+	}
+}

--- a/apidef/oas/example_test.go
+++ b/apidef/oas/example_test.go
@@ -1,0 +1,166 @@
+package oas
+
+import (
+	"context"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_exampleExtractor(t *testing.T) {
+	cases := []struct {
+		name        string
+		schema      string
+		expectedRes interface{}
+	}{
+		{
+			"object",
+			`{
+				"type": "object",
+				"properties": {	
+				  "name": {
+					"type": "string",
+					"example": "bird"
+				  }
+				}
+			}`,
+			map[string]interface{}{
+				"name": "bird",
+			},
+		},
+		{
+			"object without properties",
+			`{
+				"type": "object"
+			}`,
+			map[string]interface{}{},
+		},
+		{
+			"object with example",
+			`{
+				"type": "object",
+				"properties": {	
+				  "name": {
+					"type": "string",
+					"example": "bird"
+				  }
+				},
+				"example": "duck"
+			}`,
+			"duck",
+		},
+		{
+			"boolean",
+			`{
+				"type": "boolean"
+			}`,
+			true,
+		},
+		{
+			"boolean with example",
+			`{
+				"type": "boolean",
+				"example": false	
+			}`,
+			false,
+		},
+		{
+			"string",
+			`{
+				"type": "string"
+			}`,
+			"string",
+		},
+		{
+			"string with just example",
+			`{
+				"type": "string",
+				"example": "bird"	
+			}`,
+			"bird",
+		},
+		{
+			"string with just enum",
+			`{
+				"type": "string",	
+				"enum": ["duck", "bird"]	
+			}`,
+			"duck",
+		},
+		{
+			"string with enum and example",
+			`{
+				"type": "string",
+				"example": "bird",
+				"enum": ["duck"]	
+			}`,
+			"bird",
+		},
+		{
+			"integer",
+			`{
+				"type": "integer"
+			}`,
+			0,
+		},
+		{
+			"integer with example",
+			`{
+				"type": "integer",
+				"example": 5	
+			}`, float64(5),
+		},
+		{
+			"number",
+			`{
+				"type": "number"
+			}`,
+			0,
+		},
+		{
+			"number with example",
+			`{
+				"type": "number",
+				"example": 5	
+			}`, float64(5),
+		},
+		{
+			"array",
+			`{
+				"type": "array",
+				"items": {
+					"type": "string",
+					"example": "bird"
+				}
+			}`,
+			[]interface{}{"bird"},
+		},
+		{
+			"array with example",
+			`{
+				"type": "array",
+				"items": {
+					"type": "string",
+					"example": "bird"
+				},
+				"example": "duck"
+			}`,
+			"duck",
+		},
+	}
+
+	for _, c := range cases {
+		schemaRef := &openapi3.SchemaRef{}
+		err := schemaRef.UnmarshalJSON([]byte(c.schema))
+		assert.NoError(t, err)
+
+		assert.NoError(t, schemaRef.Validate(context.Background()))
+
+		actualRes := ExampleExtractor(schemaRef)
+
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.expectedRes, actualRes)
+		})
+	}
+}

--- a/gateway/mock_response.go
+++ b/gateway/mock_response.go
@@ -140,9 +140,9 @@ func mockFromOAS(r *http.Request, operation *openapi3.Operation, fromOASExamples
 		}
 	}
 
-	/*if example == nil {
+	if example == nil {
 		example = oas.ExampleExtractor(media.Schema)
-	}*/
+	}
 
 	body, err := json.Marshal(example)
 	if err != nil {

--- a/gateway/mock_response_test.go
+++ b/gateway/mock_response_test.go
@@ -200,6 +200,19 @@ func Test_mockFromOAS(t *testing.T) {
 				},
 			},
 		},
+		"405": &openapi3.ResponseRef{
+			Value: &openapi3.Response{
+				Content: openapi3.Content{
+					"text": {
+						Schema: &openapi3.SchemaRef{
+							Value: &openapi3.Schema{
+								Example: 5,
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	t.Run("select by config", func(t *testing.T) {
@@ -268,6 +281,17 @@ func Test_mockFromOAS(t *testing.T) {
 			assert.Equal(t, http.StatusNotFound, code)
 			assert.Contains(t, []string{`"first-value"`, `"second-value"`}, string(body))
 		})
+	})
+
+	t.Run("extraction from schema", func(t *testing.T) {
+		fromOASExamples.ExampleName = ""
+		fromOASExamples.Code = http.StatusMethodNotAllowed
+		fromOASExamples.ContentType = "text"
+		code, _, body, _, err := mockFromOAS(&http.Request{}, operation, fromOASExamples)
+		assert.NoError(t, err)
+
+		assert.Equal(t, http.StatusMethodNotAllowed, code)
+		assert.Equal(t, "5", string(body))
 	})
 
 	t.Run("errors", func(t *testing.T) {


### PR DESCRIPTION
This PR implements the example extractor from OAS schemas when there is no `example` or `examples` provided in the response path.