### PR TITLE
[TT-6587] Handle mock response listen path matching

### DIFF
--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -416,7 +416,17 @@ func (a APIDefinitionLoader) MakeSpec(def *nestedApiDefinition, logger *logrus.E
 		spec.OAS = *def.OAS
 	}
 
-	spec.OASRouter, err = gorillamux.NewRouter(&spec.OAS.T)
+	serverURL := spec.Proxy.ListenPath
+	if spec.Proxy.StripListenPath {
+		serverURL = "/"
+	}
+
+	oasSpec := spec.OAS.T
+	oasSpec.Servers = openapi3.Servers{
+		{URL: serverURL},
+	}
+
+	spec.OASRouter, err = gorillamux.NewRouter(&oasSpec)
 	if err != nil {
 		log.WithError(err).Error("Could not create OAS router")
 	}

--- a/gateway/mock_response.go
+++ b/gateway/mock_response.go
@@ -20,8 +20,8 @@ const acceptCode = "X-Tyk-Accept-Example-Code"
 const acceptExampleName = "X-Tyk-Accept-Example-Name"
 
 func (p *ReverseProxy) mockResponse(r *http.Request) (*http.Response, error) {
-	route, _, _ := p.TykAPISpec.OASRouter.FindRoute(r)
-	if route == nil {
+	route, _, err := p.TykAPISpec.OASRouter.FindRoute(r)
+	if route == nil || err != nil {
 		return nil, nil
 	}
 
@@ -36,7 +36,6 @@ func (p *ReverseProxy) mockResponse(r *http.Request) (*http.Response, error) {
 	var contentType string
 	var body []byte
 	var headers map[string]string
-	var err error
 
 	tykExampleRespOp := p.TykAPISpec.OAS.GetTykExtension().Middleware.Operations[route.Operation.OperationID].MockResponse
 

--- a/gateway/mock_response_test.go
+++ b/gateway/mock_response_test.go
@@ -102,21 +102,30 @@ func TestMockResponse(t *testing.T) {
 	t.Run("from OAS", func(t *testing.T) {
 		mockResponse.FromOASExamples.Enabled = true
 		api := BuildAPI(func(spec *APISpec) {
-			spec.Proxy.ListenPath = "/"
+			spec.Proxy.ListenPath = "/listen-path/"
+			spec.Proxy.StripListenPath = false
 			spec.IsOAS = true
 			spec.OAS = oasDoc
 		})[0]
 
 		g.Gw.LoadAPI(api)
 
-		_, _ = g.Run(t, test.TestCase{Path: "/get", BodyMatch: "Furkan", Code: http.StatusOK})
-		_, _ = g.Run(t, test.TestCase{Path: "/elma", BodyMatch: "/elma", Code: http.StatusOK})
+		_, _ = g.Run(t, test.TestCase{Path: "/listen-path/get", BodyMatch: "Furkan", Code: http.StatusOK})
+		_, _ = g.Run(t, test.TestCase{Path: "/listen-path/elma", BodyMatch: "/elma", Code: http.StatusOK})
+
+		t.Run("strip listen path", func(t *testing.T) {
+			api.Proxy.StripListenPath = true
+			g.Gw.LoadAPI(api)
+
+			_, _ = g.Run(t, test.TestCase{Path: "/listen-path/get", BodyMatch: "Furkan", Code: http.StatusOK})
+			_, _ = g.Run(t, test.TestCase{Path: "/listen-path/elma", BodyMatch: "/elma", Code: http.StatusOK})
+		})
 
 		t.Run("not found", func(t *testing.T) {
 			mockResponse.FromOASExamples.ContentType = "application/xml"
 			g.Gw.LoadAPI(api)
 
-			_, _ = g.Run(t, test.TestCase{Path: "/get", BodyMatch: "mock: there is no example response for the content type: application/xml"})
+			_, _ = g.Run(t, test.TestCase{Path: "/listen-path/get", BodyMatch: "mock: there is no example response for the content type: application/xml"})
 		})
 	})
 }


### PR DESCRIPTION
This PR fixes path matching when there is listen path in a mock response API.