### PR TITLE
Rename certs package as cert for the Go convention

### DIFF
--- a/cert/helpers.go
+++ b/cert/helpers.go
@@ -1,4 +1,4 @@
-package certs
+package cert
 
 import (
 	"bytes"

--- a/cert/manager.go
+++ b/cert/manager.go
@@ -1,4 +1,4 @@
-package certs
+package cert
 
 import (
 	"bytes"

--- a/cert/manager_test.go
+++ b/cert/manager_test.go
@@ -1,4 +1,4 @@
-package certs
+package cert
 
 import (
 	"bytes"

--- a/ci/goreleaser/goreleaser-el7.yml
+++ b/ci/goreleaser/goreleaser-el7.yml
@@ -136,7 +136,7 @@ dockers:
     - ci/images/plugin-compiler
     - go.mod
     - apidef
-    - certs
+    - cert
     - checkup
     - cli
     - config

--- a/ci/goreleaser/goreleaser.yml
+++ b/ci/goreleaser/goreleaser.yml
@@ -144,7 +144,7 @@ dockers:
     - ci/images/plugin-compiler
     - go.mod
     - apidef
-    - certs
+    - cert
     - checkup
     - cli
     - config

--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/TykTechnologies/tyk/cert"
+
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/go-redis/redis/v8"
 	uuid "github.com/satori/go.uuid"
@@ -28,7 +30,6 @@ import (
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/apidef/oas"
-	"github.com/TykTechnologies/tyk/certs"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/storage"
 	"github.com/TykTechnologies/tyk/test"
@@ -696,12 +697,12 @@ func TestUpdateKeyWithCert(t *testing.T) {
 
 	t.Run("Update key with valid cert", func(t *testing.T) {
 		// create cert
-		clientCertPem, _, _, _ := certs.GenCertificate(&x509.Certificate{}, false)
+		clientCertPem, _, _, _ := cert.GenCertificate(&x509.Certificate{}, false)
 		certID, _ := ts.Gw.CertificateManager.Add(clientCertPem, "")
 		defer ts.Gw.CertificateManager.Delete(certID, "")
 
 		// new valid cert
-		newClientCertPem, _, _, _ := certs.GenCertificate(&x509.Certificate{}, false)
+		newClientCertPem, _, _, _ := cert.GenCertificate(&x509.Certificate{}, false)
 		newCertID, _ := ts.Gw.CertificateManager.Add(newClientCertPem, "")
 		defer ts.Gw.CertificateManager.Delete(newCertID, "")
 
@@ -724,7 +725,7 @@ func TestUpdateKeyWithCert(t *testing.T) {
 	})
 
 	t.Run("Update key with empty cert", func(t *testing.T) {
-		clientCertPem, _, _, _ := certs.GenCertificate(&x509.Certificate{}, false)
+		clientCertPem, _, _, _ := cert.GenCertificate(&x509.Certificate{}, false)
 		certID, _ := ts.Gw.CertificateManager.Add(clientCertPem, "")
 
 		// create session base and set cert
@@ -747,7 +748,7 @@ func TestUpdateKeyWithCert(t *testing.T) {
 	})
 
 	t.Run("Update key with invalid cert", func(t *testing.T) {
-		clientCertPem, _, _, _ := certs.GenCertificate(&x509.Certificate{}, false)
+		clientCertPem, _, _, _ := cert.GenCertificate(&x509.Certificate{}, false)
 		certID, _ := ts.Gw.CertificateManager.Add(clientCertPem, "")
 
 		// create session base and set cert

--- a/gateway/auth_manager_test.go
+++ b/gateway/auth_manager_test.go
@@ -5,7 +5,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/TykTechnologies/tyk/certs"
+	"github.com/TykTechnologies/tyk/cert"
+
 	"github.com/TykTechnologies/tyk/config"
 
 	"github.com/TykTechnologies/tyk/header"
@@ -121,8 +122,8 @@ func TestHashKeyFunctionChanged(t *testing.T) {
 	orgId := "default"
 
 	//We generate the combinedPEM and get its serverCertID
-	_, _, combinedPEM, _ := certs.GenServerCertificate()
-	serverCertID, _, _ := certs.GetCertIDAndChainPEM(combinedPEM, "")
+	_, _, combinedPEM, _ := cert.GenServerCertificate()
+	serverCertID, _, _ := cert.GetCertIDAndChainPEM(combinedPEM, "")
 
 	client := GetTLSClient(nil, nil)
 	conf := func(globalConf *config.Config) {
@@ -141,7 +142,7 @@ func TestHashKeyFunctionChanged(t *testing.T) {
 	//We reload the gw proxy so it uses the added server certificate
 	ts.ReloadGatewayProxy()
 
-	clientPEM, _, _, clientCert := certs.GenCertificate(&x509.Certificate{}, false)
+	clientPEM, _, _, clientCert := cert.GenCertificate(&x509.Certificate{}, false)
 	clientCertID, err := ts.Gw.CertificateManager.Add(clientPEM, orgId)
 	if err != nil {
 		t.Fatal("certificate should be added to cert manager")

--- a/gateway/batch_requests_test.go
+++ b/gateway/batch_requests_test.go
@@ -13,7 +13,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/TykTechnologies/tyk/certs"
+	"github.com/TykTechnologies/tyk/cert"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/test"
@@ -125,7 +125,7 @@ func TestVirtualEndpointBatch(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()
 
-	_, _, combinedClientPEM, clientCert := certs.GenCertificate(&x509.Certificate{}, false)
+	_, _, combinedClientPEM, clientCert := cert.GenCertificate(&x509.Certificate{}, false)
 	clientCert.Leaf, _ = x509.ParseCertificate(clientCert.Certificate[0])
 	upstream := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 	}))

--- a/gateway/grpc_test.go
+++ b/gateway/grpc_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/TykTechnologies/tyk/certs"
+	"github.com/TykTechnologies/tyk/cert"
 
 	"github.com/TykTechnologies/tyk/config"
 
@@ -143,9 +143,9 @@ func TestHTTP2_TLS(t *testing.T) {
 	expected := "HTTP/2.0"
 
 	// Certificates
-	_, _, _, clientCert := certs.GenCertificate(&x509.Certificate{}, false)
-	serverCertPem, _, combinedPEM, _ := certs.GenServerCertificate()
-	certID, _, _ := certs.GetCertIDAndChainPEM(combinedPEM, "")
+	_, _, _, clientCert := cert.GenCertificate(&x509.Certificate{}, false)
+	serverCertPem, _, combinedPEM, _ := cert.GenServerCertificate()
+	certID, _, _ := cert.GetCertIDAndChainPEM(combinedPEM, "")
 
 	// Upstream server supporting HTTP/2
 	upstream := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -196,9 +196,9 @@ func TestHTTP2_TLS(t *testing.T) {
 func TestTLSTyk_H2cUpstream(t *testing.T) {
 
 	// Certificates
-	_, _, _, clientCert := certs.GenCertificate(&x509.Certificate{}, false)
-	serverCertPem, _, combinedPEM, _ := certs.GenServerCertificate()
-	certID, _, _ := certs.GetCertIDAndChainPEM(combinedPEM, "")
+	_, _, _, clientCert := cert.GenCertificate(&x509.Certificate{}, false)
+	serverCertPem, _, combinedPEM, _ := cert.GenServerCertificate()
+	certID, _, _ := cert.GetCertIDAndChainPEM(combinedPEM, "")
 
 	var port = 6666
 	// run Tyk in HTTPS
@@ -253,8 +253,8 @@ func TestTLSTyk_H2cUpstream(t *testing.T) {
 
 func TestGRPC_TLS(t *testing.T) {
 
-	_, _, combinedPEM, _ := certs.GenServerCertificate()
-	certID, _, _ := certs.GetCertIDAndChainPEM(combinedPEM, "")
+	_, _, combinedPEM, _ := cert.GenServerCertificate()
+	certID, _, _ := cert.GetCertIDAndChainPEM(combinedPEM, "")
 
 	// gRPC server
 	target, s := startGRPCServer(t, nil, setupHelloSVC)
@@ -301,11 +301,11 @@ func TestGRPC_MutualTLS(t *testing.T) {
 	// Mutual Authentication for both downstream-tyk and tyk-upstream
 
 	//generate certificates
-	_, _, combinedClientPEM, clientCert := certs.GenCertificate(&x509.Certificate{}, false)
+	_, _, combinedClientPEM, clientCert := cert.GenCertificate(&x509.Certificate{}, false)
 	clientCert.Leaf, _ = x509.ParseCertificate(clientCert.Certificate[0])
-	serverCertPem, _, combinedPEM, _ := certs.GenServerCertificate()
+	serverCertPem, _, combinedPEM, _ := cert.GenServerCertificate()
 	// we can know the certId before add it to cert manager
-	certID, _, _ := certs.GetCertIDAndChainPEM(combinedPEM, "")
+	certID, _, _ := cert.GetCertIDAndChainPEM(combinedPEM, "")
 
 	// Tyk
 	conf := func(globalConf *config.Config) {
@@ -357,8 +357,8 @@ func TestGRPC_MutualTLS(t *testing.T) {
 
 func TestGRPC_BasicAuthentication(t *testing.T) {
 
-	_, _, combinedPEM, _ := certs.GenServerCertificate()
-	certID, _, _ := certs.GetCertIDAndChainPEM(combinedPEM, "")
+	_, _, combinedPEM, _ := cert.GenServerCertificate()
+	certID, _, _ := cert.GetCertIDAndChainPEM(combinedPEM, "")
 
 	// gRPC server
 	target, s := startGRPCServer(t, nil, setupHelloSVC)
@@ -416,8 +416,8 @@ func TestGRPC_BasicAuthentication(t *testing.T) {
 
 func TestGRPC_TokenBasedAuthentication(t *testing.T) {
 
-	_, _, combinedPEM, _ := certs.GenServerCertificate()
-	certID, _, _ := certs.GetCertIDAndChainPEM(combinedPEM, "")
+	_, _, combinedPEM, _ := cert.GenServerCertificate()
+	certID, _, _ := cert.GetCertIDAndChainPEM(combinedPEM, "")
 
 	// gRPC server
 	target, s := startGRPCServer(t, nil, setupHelloSVC)
@@ -524,7 +524,7 @@ func openListener(t *testing.T) net.Listener {
 }
 
 func grpcServerCreds(t *testing.T, clientCert *x509.Certificate) []grpc.ServerOption {
-	cert, key, _, _ := certs.GenCertificate(&x509.Certificate{}, false)
+	cert, key, _, _ := cert.GenCertificate(&x509.Certificate{}, false)
 	certificate, _ := tls.X509KeyPair(cert, key)
 
 	pool := x509.NewCertPool()
@@ -672,8 +672,8 @@ func (*loginCredsOrToken) RequireTransportSecurity() bool {
 func TestGRPC_Stream_MutualTLS(t *testing.T) {
 	// Mutual Authentication for both downstream-tyk and tyk-upstream
 
-	serverCertPem, _, combinedPEM, _ := certs.GenServerCertificate()
-	serverCertID, _, _ := certs.GetCertIDAndChainPEM(serverCertPem, "")
+	serverCertPem, _, combinedPEM, _ := cert.GenServerCertificate()
+	serverCertID, _, _ := cert.GetCertIDAndChainPEM(serverCertPem, "")
 
 	// Tyk
 	conf := func(globalConf *config.Config) {
@@ -686,7 +686,7 @@ func TestGRPC_Stream_MutualTLS(t *testing.T) {
 	ts := StartTest(conf)
 	defer ts.Close()
 
-	_, _, combinedClientPEM, clientCert := certs.GenCertificate(&x509.Certificate{}, false)
+	_, _, combinedClientPEM, clientCert := cert.GenCertificate(&x509.Certificate{}, false)
 	certID, _ := ts.Gw.CertificateManager.Add(combinedPEM, "") // For tyk to know downstream
 	defer ts.Gw.CertificateManager.Delete(certID, "")
 	clientCert.Leaf, _ = x509.ParseCertificate(clientCert.Certificate[0])
@@ -726,8 +726,8 @@ func TestGRPC_Stream_MutualTLS(t *testing.T) {
 
 func TestGRPC_Stream_TokenBasedAuthentication(t *testing.T) {
 
-	_, _, combinedPEM, _ := certs.GenServerCertificate()
-	serverCertID, _, _ := certs.GetCertIDAndChainPEM(combinedPEM, "")
+	_, _, combinedPEM, _ := cert.GenServerCertificate()
+	serverCertID, _, _ := cert.GetCertIDAndChainPEM(combinedPEM, "")
 
 	// gRPC server
 	target, s := startGRPCServer(t, nil, setupStreamSVC)
@@ -802,8 +802,8 @@ func TestGRPC_Stream_TokenBasedAuthentication(t *testing.T) {
 
 func TestGRPC_Stream_BasicAuthentication(t *testing.T) {
 
-	_, _, combinedPEM, _ := certs.GenServerCertificate()
-	serverCertID, _, _ := certs.GetCertIDAndChainPEM(combinedPEM, "")
+	_, _, combinedPEM, _ := cert.GenServerCertificate()
+	serverCertID, _, _ := cert.GetCertIDAndChainPEM(combinedPEM, "")
 
 	// gRPC server
 	target, s := startGRPCServer(t, nil, setupStreamSVC)

--- a/gateway/mw_auth_key.go
+++ b/gateway/mw_auth_key.go
@@ -5,7 +5,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/TykTechnologies/tyk/certs"
+	"github.com/TykTechnologies/tyk/cert"
+
 	"github.com/TykTechnologies/tyk/storage"
 
 	"github.com/TykTechnologies/tyk/user"
@@ -96,7 +97,7 @@ func (k *AuthKey) ProcessRequest(_ http.ResponseWriter, r *http.Request, _ inter
 		key = stripBearer(key)
 	} else if authConfig.UseCertificate && key == "" && r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
 		log.Debug("Trying to find key by client certificate")
-		certHash = k.Spec.OrgID + certs.HexSHA256(r.TLS.PeerCertificates[0].Raw)
+		certHash = k.Spec.OrgID + cert.HexSHA256(r.TLS.PeerCertificates[0].Raw)
 		key = k.Gw.generateToken(k.Spec.OrgID, certHash)
 	} else {
 		k.Logger().Info("Attempted access with malformed header, no auth header found.")

--- a/gateway/mw_http_signature_validation_test.go
+++ b/gateway/mw_http_signature_validation_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/TykTechnologies/tyk/certs"
+	"github.com/TykTechnologies/tyk/cert"
 
 	"github.com/justinas/alice"
 	"github.com/lonelycode/go-uuid/uuid"
@@ -707,7 +707,7 @@ func TestRSAAuthSessionPass(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()
 
-	_, _, _, serverCert := certs.GenServerCertificate()
+	_, _, _, serverCert := cert.GenServerCertificate()
 	privateKey := serverCert.PrivateKey.(*rsa.PrivateKey)
 	x509Cert, _ := x509.ParseCertificate(serverCert.Certificate[0])
 	pubDer, _ := x509.MarshalPKIXPublicKey(x509Cert.PublicKey)
@@ -742,7 +742,7 @@ func BenchmarkRSAAuthSessionPass(b *testing.B) {
 	ts := StartTest(nil)
 	defer ts.Close()
 
-	_, _, _, serverCert := certs.GenServerCertificate()
+	_, _, _, serverCert := cert.GenServerCertificate()
 	privateKey := serverCert.PrivateKey.(*rsa.PrivateKey)
 	x509Cert, _ := x509.ParseCertificate(serverCert.Certificate[0])
 	pubDer, _ := x509.MarshalPKIXPublicKey(x509Cert.PublicKey)
@@ -771,7 +771,7 @@ func TestRSAAuthSessionKeyMissing(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()
 
-	_, _, _, serverCert := certs.GenServerCertificate()
+	_, _, _, serverCert := cert.GenServerCertificate()
 	privateKey := serverCert.PrivateKey.(*rsa.PrivateKey)
 	x509Cert, _ := x509.ParseCertificate(serverCert.Certificate[0])
 	pubDer, _ := x509.MarshalPKIXPublicKey(x509Cert.PublicKey)

--- a/gateway/mw_request_signing.go
+++ b/gateway/mw_request_signing.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/TykTechnologies/tyk/certs"
+	"github.com/TykTechnologies/tyk/cert"
 )
 
 type RequestSigning struct {
@@ -133,7 +133,7 @@ func (s *RequestSigning) ProcessRequest(w http.ResponseWriter, r *http.Request, 
 			return errors.New("CertificateID is empty"), http.StatusInternalServerError
 		}
 
-		certList := s.Gw.CertificateManager.List([]string{s.Spec.RequestSigning.CertificateId}, certs.CertificatePrivate)
+		certList := s.Gw.CertificateManager.List([]string{s.Spec.RequestSigning.CertificateId}, cert.CertificatePrivate)
 		if len(certList) == 0 || certList[0] == nil {
 			log.Error("Certificate not found")
 			return errors.New("Certificate not found"), http.StatusInternalServerError

--- a/gateway/mw_request_signing_test.go
+++ b/gateway/mw_request_signing_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/TykTechnologies/tyk/certs"
+	"github.com/TykTechnologies/tyk/cert"
 
 	"github.com/stretchr/testify/assert"
 
@@ -260,7 +260,7 @@ func TestRSARequestSigning(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()
 
-	_, _, combinedPem, cert := certs.GenServerCertificate()
+	_, _, combinedPem, cert := cert.GenServerCertificate()
 	privCertId, _ := ts.Gw.CertificateManager.Add(combinedPem, "")
 	defer ts.Gw.CertificateManager.Delete(privCertId, "")
 

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/TykTechnologies/tyk/cert"
+
 	"github.com/TykTechnologies/tyk/test"
 
 	"sync/atomic"
@@ -46,7 +48,6 @@ import (
 	"rsc.io/letsencrypt"
 
 	"github.com/TykTechnologies/tyk/apidef"
-	"github.com/TykTechnologies/tyk/certs"
 	"github.com/TykTechnologies/tyk/checkup"
 	"github.com/TykTechnologies/tyk/cli"
 	"github.com/TykTechnologies/tyk/config"
@@ -106,7 +107,7 @@ type Gateway struct {
 	MonitoringHandler    config.TykEventHandler
 	RPCListener          RPCStorageHandler
 	DashService          DashboardServiceSender
-	CertificateManager   *certs.CertificateManager
+	CertificateManager   *cert.CertificateManager
 	GlobalHostChecker    HostCheckerManager
 	HostCheckTicker      chan struct{}
 	HostCheckerClient    *http.Client
@@ -406,14 +407,14 @@ func (gw *Gateway) setupGlobals() {
 	}
 
 	storeCert := &storage.RedisCluster{KeyPrefix: "cert-", HashKeys: false, RedisController: gw.RedisController}
-	gw.CertificateManager = certs.NewCertificateManager(storeCert, certificateSecret, log, !gw.GetConfig().Cloud)
+	gw.CertificateManager = cert.NewCertificateManager(storeCert, certificateSecret, log, !gw.GetConfig().Cloud)
 	if gw.GetConfig().SlaveOptions.UseRPC {
 		rpcStore := &RPCStorageHandler{
 			KeyPrefix: "cert-",
 			HashKeys:  false,
 			Gw:        gw,
 		}
-		gw.CertificateManager = certs.NewSlaveCertManager(storeCert, rpcStore, certificateSecret, log, !gw.GetConfig().Cloud)
+		gw.CertificateManager = cert.NewSlaveCertManager(storeCert, rpcStore, certificateSecret, log, !gw.GetConfig().Cloud)
 	}
 
 	if gw.GetConfig().NewRelic.AppName != "" {


### PR DESCRIPTION
We should not use plural package names like `certs` as a Go convention. This PR renames the` certs` package to be `cert`.

- https://rakyll.org/style-packages/