### PR TITLE
[TT-6743] Add the skeleton for external OAuth middleware

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -92,13 +92,14 @@ const (
 
 	Self = "self"
 
-	AuthTokenType = "authToken"
-	JWTType       = "jwt"
-	HMACType      = "hmac"
-	BasicType     = "basic"
-	CoprocessType = "coprocess"
-	OAuthType     = "oauth"
-	OIDCType      = "oidc"
+	AuthTokenType     = "authToken"
+	JWTType           = "jwt"
+	HMACType          = "hmac"
+	BasicType         = "basic"
+	CoprocessType     = "coprocess"
+	OAuthType         = "oauth"
+	ExternalOAuthType = "externalOAuth"
+	OIDCType          = "oidc"
 )
 
 var (
@@ -539,6 +540,7 @@ type APIDefinition struct {
 	OrgID               string        `bson:"org_id" json:"org_id"`
 	UseKeylessAccess    bool          `bson:"use_keyless" json:"use_keyless"`
 	UseOauth2           bool          `bson:"use_oauth2" json:"use_oauth2"`
+	ExternalOAuth       ExternalOAuth `bson:"external_oauth" json:"external_oauth"`
 	UseOpenID           bool          `bson:"use_openid" json:"use_openid"`
 	OpenIDOptions       OpenIDOptions `bson:"openid_options" json:"openid_options"`
 	Oauth2Meta          struct {
@@ -1270,3 +1272,21 @@ var Template = template.New("").Funcs(map[string]interface{}{
 		return string(xmlValue), err
 	},
 })
+
+type ExternalOAuth struct {
+	Enabled   bool       `bson:"enabled" json:"enabled"`
+	Providers []Provider `bson:"providers" json:"providers"`
+}
+
+type Provider struct {
+	JWT           JWTValidation `bson:"jwt" json:"jwt"`
+	Introspection Introspection `bson:"introspection" json:"introspection"`
+}
+
+type JWTValidation struct {
+	Enabled bool `bson:"enabled" json:"enabled"`
+}
+
+type Introspection struct {
+	Enabled bool `bson:"enabled" json:"enabled"`
+}

--- a/apidef/schema.go
+++ b/apidef/schema.go
@@ -192,6 +192,9 @@ const Schema = `{
         "oauth_meta": {
             "type":["object", "null"]
         },
+		"external_oauth": {
+            "type":["object", "null"]
+        },
         "cache_options": {
             "type":["object", "null"]
         },

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -340,6 +340,10 @@ func (gw *Gateway) processSpec(spec *APISpec, apisByListen map[string]int,
 			logger.Info("Checking security policy: OAuth")
 		}
 
+		if gw.mwAppendEnabled(&authArray, &ExternalOAuthMiddleware{baseMid}) {
+			logger.Info("Checking security policy: External OAuth")
+		}
+
 		if gw.mwAppendEnabled(&authArray, &BasicAuthKeyIsValid{baseMid, nil, nil}) {
 			logger.Info("Checking security policy: Basic")
 		}

--- a/gateway/mw_external_oauth.go
+++ b/gateway/mw_external_oauth.go
@@ -1,0 +1,96 @@
+package gateway
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/user"
+)
+
+type ExternalOAuthMiddleware struct {
+	BaseMiddleware
+}
+
+func (k *ExternalOAuthMiddleware) Name() string {
+	return "ExternalOAuth"
+}
+
+func (k *ExternalOAuthMiddleware) EnabledForSpec() bool {
+	return k.Spec.ExternalOAuth.Enabled
+}
+
+// getAuthType overrides BaseMiddleware.getAuthType.
+func (k *ExternalOAuthMiddleware) getAuthType() string {
+	return apidef.ExternalOAuthType
+}
+
+func (k *ExternalOAuthMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
+	if ctxGetRequestStatus(r) == StatusOkAndIgnore {
+		return nil, http.StatusOK
+	}
+
+	token, _ := k.getAuthToken(k.getAuthType(), r)
+	if token == "" {
+		return errors.New("authorization field missing"), http.StatusBadRequest
+	}
+
+	token = stripBearer(token)
+
+	var (
+		valid      bool
+		err        error
+		identifier string
+	)
+
+	if len(k.Spec.ExternalOAuth.Providers) == 0 {
+		return errors.New("there should be at least one provider configured"), http.StatusNotFound
+	}
+
+	// Just the first one will be used, later there can be multiple providers supported
+	provider := k.Spec.ExternalOAuth.Providers[0]
+
+	if provider.JWT.Enabled {
+		valid, identifier, err = k.jwt(token)
+	} else if provider.Introspection.Enabled {
+		valid, identifier, err = k.introspection(token)
+	} else {
+		return errors.New("access token validation method is not specified"), http.StatusInternalServerError
+	}
+
+	if err != nil {
+		return errors.New("error happened during the access token validation"), http.StatusInternalServerError
+	}
+
+	if !valid {
+		return errors.New("access token is not valid"), http.StatusUnauthorized
+	}
+
+	var virtualSession user.SessionState
+	virtualSession, exists := k.CheckSessionAndIdentityForValidKey(identifier, r)
+	if !exists {
+		virtualSession = k.generateVirtualSessionFor(r, identifier)
+	}
+
+	ctxSetSession(r, &virtualSession, false, k.Gw.GetConfig().HashKeys)
+
+	// Request is valid, carry on
+	return nil, http.StatusOK
+}
+
+// jwt makes access token validation without making a network call and validates access token locally.
+// The access token should be JWT type.
+func (k *ExternalOAuthMiddleware) jwt(accessToken string) (bool, string, error) {
+	return false, "", errors.New("jwt validation not implemented yet")
+}
+
+// introspection makes an introspection request to third-party provider to check whether the access token is valid or not.
+// The access token can be both JWT and opaque type.
+func (k *ExternalOAuthMiddleware) introspection(accessToken string) (bool, string, error) {
+	return false, "", errors.New("introspection not implemented yet")
+}
+
+// generateVirtualSessionFor generates a virtual session for the given access token by using its identifier.
+func (k *ExternalOAuthMiddleware) generateVirtualSessionFor(r *http.Request, identifier string) user.SessionState {
+	return user.SessionState{}
+}


### PR DESCRIPTION
This PR adds the skeleton for the external OAuth middleware. The functionalities are:
- jwt validation
- introspection
- creating a virtual session for the validated access tokens and setting to context.