### PR TITLE
[TT-6485] fix chaining external native API to internal OAS API.

### DIFF
--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -611,6 +611,7 @@ func (d *DummyProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		d.SH.Spec.SanitizeProxyPaths(r)
+		ctxSetVersionInfo(r, nil)
 		handler.ServeHTTP(w, r)
 		return
 	}

--- a/gateway/looping_test.go
+++ b/gateway/looping_test.go
@@ -6,6 +6,9 @@ package gateway
 
 import (
 	"encoding/json"
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/getkin/kin-openapi/openapi3"
 	"sync"
 	"testing"
 
@@ -266,6 +269,59 @@ func TestLooping(t *testing.T) {
 			{Method: "GET", Path: "/recursion", Headers: authHeaders, BodyNotMatch: "Quota exceeded"},
 		}...)
 	})
+
+	t.Run("loop external native def to internal OAS", func(t *testing.T) {
+		// Create internal OAS API
+		tykExtension := oas.XTykAPIGateway{
+			Info: oas.Info{
+				Name: "internal",
+				ID:   "internal-api",
+				State: oas.State{
+					Active:   false,
+					Internal: true,
+				},
+			},
+			Upstream: oas.Upstream{
+				URL: TestHttpAny,
+			},
+			Server: oas.Server{
+				ListenPath: oas.ListenPath{
+					Value: "/internal/",
+					Strip: false,
+				},
+			},
+		}
+
+		oasAPI := openapi3.T{
+			OpenAPI: "3.0.3",
+			Info: &openapi3.Info{
+				Title:   "oas doc",
+				Version: "1",
+			},
+			Paths: make(openapi3.Paths),
+		}
+
+		oasObj := oas.OAS{T: oasAPI}
+		oasObj.SetTykExtension(&tykExtension)
+
+		oasAPIDef := apidef.APIDefinition{}
+		oasObj.ExtractTo(&oasAPIDef)
+
+		ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+			spec.APIID = "external-api"
+			spec.Name = "external"
+			spec.Proxy.ListenPath = "/external/"
+			spec.Proxy.TargetURL = "tyk://internal/"
+		}, func(spec *APISpec) {
+			spec.APIDefinition = &oasAPIDef
+			spec.OAS = oasObj
+		})
+
+		_, _ = ts.Run(t, []test.TestCase{
+			{Path: "/external/", Code: 200},
+		}...)
+	})
+
 }
 
 func TestConcurrencyReloads(t *testing.T) {


### PR DESCRIPTION
[changelog]
fixed: chaining external native API def to internal OAS API def.
