### PR TITLE
add subscription type cfg for proxy-only and fix federation cfg gen

### DIFF
--- a/apidef/adapter/graphql_config_adapter.go
+++ b/apidef/adapter/graphql_config_adapter.go
@@ -40,13 +40,6 @@ func WithStreamingClient(streamingClient *http.Client) GraphQLConfigAdapterOptio
 	}
 }
 
-// Use this option function to set a dummy SubscriptionClient for testing.
-/*func withDummySubscriptionClient(subscriptionClient *graphqlDataSource.SubscriptionClient) GraphQLConfigAdapterOption {
-	return func(adapter *GraphQLConfigAdapter) {
-		adapter.dummySubscriptionClient = subscriptionClient
-	}
-}*/
-
 func withGraphQLSubscriptionClientFactory(factory graphqlDataSource.GraphQLSubscriptionClientFactory) GraphQLConfigAdapterOption {
 	return func(adapter *GraphQLConfigAdapter) {
 		adapter.subscriptionClientFactory = factory

--- a/apidef/adapter/graphql_config_adapter.go
+++ b/apidef/adapter/graphql_config_adapter.go
@@ -41,9 +41,15 @@ func WithStreamingClient(streamingClient *http.Client) GraphQLConfigAdapterOptio
 }
 
 // Use this option function to set a dummy SubscriptionClient for testing.
-func withDummySubscriptionClient(subscriptionClient *graphqlDataSource.SubscriptionClient) GraphQLConfigAdapterOption {
+/*func withDummySubscriptionClient(subscriptionClient *graphqlDataSource.SubscriptionClient) GraphQLConfigAdapterOption {
 	return func(adapter *GraphQLConfigAdapter) {
 		adapter.dummySubscriptionClient = subscriptionClient
+	}
+}*/
+
+func withGraphQLSubscriptionClientFactory(factory graphqlDataSource.GraphQLSubscriptionClientFactory) GraphQLConfigAdapterOption {
+	return func(adapter *GraphQLConfigAdapter) {
+		adapter.subscriptionClientFactory = factory
 	}
 }
 
@@ -53,12 +59,14 @@ type GraphQLConfigAdapter struct {
 	streamingClient *http.Client
 	schema          *graphql.Schema
 
-	// For testing purposes
-	dummySubscriptionClient *graphqlDataSource.SubscriptionClient
+	subscriptionClientFactory graphqlDataSource.GraphQLSubscriptionClientFactory
 }
 
 func NewGraphQLConfigAdapter(apiDefinition *apidef.APIDefinition, options ...GraphQLConfigAdapterOption) GraphQLConfigAdapter {
-	adapter := GraphQLConfigAdapter{apiDefinition: apiDefinition}
+	adapter := GraphQLConfigAdapter{
+		apiDefinition:             apiDefinition,
+		subscriptionClientFactory: &graphqlDataSource.DefaultSubscriptionClientFactory{},
+	}
 	for _, option := range options {
 		option(&adapter)
 	}
@@ -95,8 +103,9 @@ func (g *GraphQLConfigAdapter) createV2ConfigForProxyOnlyExecutionMode() (*graph
 	}
 
 	upstreamConfig := graphql.ProxyUpstreamConfig{
-		URL:           url,
-		StaticHeaders: staticHeaders,
+		URL:              url,
+		StaticHeaders:    staticHeaders,
+		SubscriptionType: g.graphqlSubscriptionType(g.apiDefinition.GraphQL.Proxy.SubscriptionType),
 	}
 
 	if g.schema == nil {
@@ -112,6 +121,8 @@ func (g *GraphQLConfigAdapter) createV2ConfigForProxyOnlyExecutionMode() (*graph
 		upstreamConfig,
 		graphqlDataSource.NewBatchFactory(),
 		graphql.WithProxyHttpClient(g.httpClient),
+		graphql.WithProxyStreamingClient(g.streamingClient),
+		graphql.WithProxySubscriptionClientFactory(g.subscriptionClientFactory),
 	).EngineV2Configuration()
 
 	return &v2Config, err
@@ -121,12 +132,20 @@ func (g *GraphQLConfigAdapter) createV2ConfigForSupergraphExecutionMode() (*grap
 	dataSourceConfs := g.subgraphDataSourceConfigs()
 	var federationConfigV2Factory *graphql.FederationEngineConfigFactory
 	if g.apiDefinition.GraphQL.Supergraph.DisableQueryBatching {
-		federationConfigV2Factory = graphql.NewFederationEngineConfigFactory(dataSourceConfs, nil, graphql.WithFederationHttpClient(g.getHttpClient()))
+		federationConfigV2Factory = graphql.NewFederationEngineConfigFactory(
+			dataSourceConfs,
+			nil,
+			graphql.WithFederationHttpClient(g.getHttpClient()),
+			graphql.WithFederationStreamingClient(g.getStreamingClient()),
+			graphql.WithFederationSubscriptionClientFactory(g.subscriptionClientFactory),
+		)
 	} else {
 		federationConfigV2Factory = graphql.NewFederationEngineConfigFactory(
 			dataSourceConfs,
 			graphqlDataSource.NewBatchFactory(),
 			graphql.WithFederationHttpClient(g.getHttpClient()),
+			graphql.WithFederationStreamingClient(g.getStreamingClient()),
+			graphql.WithFederationSubscriptionClientFactory(g.subscriptionClientFactory),
 		)
 	}
 
@@ -256,7 +275,11 @@ func (g *GraphQLConfigAdapter) engineConfigV2DataSources() (planDataSources []pl
 				return nil, err
 			}
 
-			planDataSource.Factory = g.createGraphQLDataSourceFactory(graphqlConfig)
+			planDataSource.Factory, err = g.createGraphQLDataSourceFactory(graphqlConfig)
+			if err != nil {
+				return nil, err
+			}
+
 			planDataSource.Custom = graphqlDataSource.ConfigJson(g.graphqlDataSourceConfiguration(
 				graphqlConfig.URL,
 				graphqlConfig.Method,
@@ -517,27 +540,26 @@ func (g *GraphQLConfigAdapter) getStreamingClient() *http.Client {
 	return g.streamingClient
 }
 
-func (g *GraphQLConfigAdapter) createGraphQLDataSourceFactory(graphqlConfig apidef.GraphQLEngineDataSourceConfigGraphQL) *graphqlDataSource.Factory {
+func (g *GraphQLConfigAdapter) createGraphQLDataSourceFactory(graphqlConfig apidef.GraphQLEngineDataSourceConfigGraphQL) (*graphqlDataSource.Factory, error) {
 	factory := &graphqlDataSource.Factory{
 		HTTPClient:      g.getHttpClient(),
 		StreamingClient: g.getStreamingClient(),
 	}
 
-	// We can set a dummy SubscriptionClient for testing to not overcomplicate stuff.
-	// SubscriptionClient itself is tested already in library.
-	if g.dummySubscriptionClient != nil {
-		factory.SubscriptionClient = g.dummySubscriptionClient
-		return factory
-	}
-
 	wsProtocol := g.graphqlDataSourceWebSocketProtocol(graphqlConfig.SubscriptionType)
-	factory.SubscriptionClient = graphqlDataSource.NewGraphQLSubscriptionClient(
+	graphqlSubscriptionClient := g.subscriptionClientFactory.NewSubscriptionClient(
 		g.getHttpClient(),
 		g.getStreamingClient(),
 		nil,
 		graphqlDataSource.WithWSSubProtocol(wsProtocol),
 	)
-	return factory
+
+	subscriptionClient, ok := graphqlSubscriptionClient.(*graphqlDataSource.SubscriptionClient)
+	if !ok {
+		return nil, errors.New("incorrect SubscriptionClient has been created")
+	}
+	factory.SubscriptionClient = subscriptionClient
+	return factory, nil
 }
 
 func (g *GraphQLConfigAdapter) graphqlDataSourceWebSocketProtocol(subscriptionType apidef.SubscriptionType) string {
@@ -546,4 +568,17 @@ func (g *GraphQLConfigAdapter) graphqlDataSourceWebSocketProtocol(subscriptionTy
 		wsProtocol = graphqlDataSource.ProtocolGraphQLTWS
 	}
 	return wsProtocol
+}
+
+func (g *GraphQLConfigAdapter) graphqlSubscriptionType(subscriptionType apidef.SubscriptionType) graphql.SubscriptionType {
+	switch subscriptionType {
+	case apidef.GQLSubscriptionWS:
+		return graphql.SubscriptionTypeGraphQLWS
+	case apidef.GQLSubscriptionTransportWS:
+		return graphql.SubscriptionTypeGraphQLTransportWS
+	case apidef.GQLSubscriptionSSE:
+		return graphql.SubscriptionTypeSSE
+	default:
+		return graphql.SubscriptionTypeUnknown
+	}
 }

--- a/apidef/adapter/graphql_config_adapter_test.go
+++ b/apidef/adapter/graphql_config_adapter_test.go
@@ -1,18 +1,20 @@
 package adapter
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	graphqlDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/graphql_datasource"
 	kafkaDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/kafka_datasource"
 	restDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/rest_datasource"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/plan"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
+	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
 	"github.com/TykTechnologies/tyk/apidef"
 )
 
@@ -29,7 +31,12 @@ func TestGraphQLConfigAdapter_EngineConfigV2(t *testing.T) {
 		}
 
 		httpClient := &http.Client{}
-		adapter := NewGraphQLConfigAdapter(apiDef, WithHttpClient(httpClient))
+		streamingClient := &http.Client{}
+		adapter := NewGraphQLConfigAdapter(apiDef,
+			WithHttpClient(httpClient),
+			WithStreamingClient(streamingClient),
+			withGraphQLSubscriptionClientFactory(&MockSubscriptionClientFactory{}),
+		)
 
 		engineV2Config, err := adapter.EngineConfigV2()
 		assert.NoError(t, err)
@@ -43,8 +50,10 @@ func TestGraphQLConfigAdapter_EngineConfigV2(t *testing.T) {
 			},
 			ChildNodes: []plan.TypeField{},
 			Factory: &graphqlDataSource.Factory{
-				BatchFactory: graphqlDataSource.NewBatchFactory(),
-				HTTPClient:   httpClient,
+				BatchFactory:       graphqlDataSource.NewBatchFactory(),
+				HTTPClient:         httpClient,
+				StreamingClient:    streamingClient,
+				SubscriptionClient: mockSubscriptionClient,
 			},
 			Custom: graphqlDataSource.ConfigJson(graphqlDataSource.Configuration{
 				Fetch: graphqlDataSource.FetchConfiguration{
@@ -54,7 +63,8 @@ func TestGraphQLConfigAdapter_EngineConfigV2(t *testing.T) {
 					},
 				},
 				Subscription: graphqlDataSource.SubscriptionConfiguration{
-					URL: "http://localhost:8080",
+					URL:    "http://localhost:8080",
+					UseSSE: true,
 				},
 			}),
 		}
@@ -86,7 +96,13 @@ func TestGraphQLConfigAdapter_EngineConfigV2(t *testing.T) {
 		}
 
 		httpClient := &http.Client{}
-		adapter := NewGraphQLConfigAdapter(apiDef, WithHttpClient(httpClient))
+		streamingClient := &http.Client{}
+		adapter := NewGraphQLConfigAdapter(
+			apiDef,
+			WithHttpClient(httpClient),
+			WithStreamingClient(streamingClient),
+			withGraphQLSubscriptionClientFactory(&MockSubscriptionClientFactory{}),
+		)
 
 		engineV2Config, err := adapter.EngineConfigV2()
 		assert.NoError(t, err)
@@ -100,8 +116,10 @@ func TestGraphQLConfigAdapter_EngineConfigV2(t *testing.T) {
 			},
 			ChildNodes: []plan.TypeField{},
 			Factory: &graphqlDataSource.Factory{
-				BatchFactory: graphqlDataSource.NewBatchFactory(),
-				HTTPClient:   httpClient,
+				BatchFactory:       graphqlDataSource.NewBatchFactory(),
+				HTTPClient:         httpClient,
+				StreamingClient:    streamingClient,
+				SubscriptionClient: mockSubscriptionClient,
 			},
 			Custom: graphqlDataSource.ConfigJson(graphqlDataSource.Configuration{
 				Fetch: graphqlDataSource.FetchConfiguration{
@@ -112,7 +130,8 @@ func TestGraphQLConfigAdapter_EngineConfigV2(t *testing.T) {
 					},
 				},
 				Subscription: graphqlDataSource.SubscriptionConfiguration{
-					URL: "http://api-name",
+					URL:    "http://api-name",
+					UseSSE: true,
 				},
 			}),
 		}
@@ -171,7 +190,13 @@ func TestGraphQLConfigAdapter_EngineConfigV2(t *testing.T) {
 		apiDef.GraphQL.Supergraph.DisableQueryBatching = true
 
 		httpClient := &http.Client{}
-		adapter := NewGraphQLConfigAdapter(apiDef, WithHttpClient(httpClient))
+		streamingClient := &http.Client{}
+		adapter := NewGraphQLConfigAdapter(
+			apiDef,
+			WithHttpClient(httpClient),
+			WithStreamingClient(streamingClient),
+			withGraphQLSubscriptionClientFactory(&MockSubscriptionClientFactory{}),
+		)
 
 		v2Config, err := adapter.EngineConfigV2()
 		assert.NoError(t, err)
@@ -193,7 +218,9 @@ func TestGraphQLConfigAdapter_EngineConfigV2(t *testing.T) {
 				},
 			},
 			Factory: &graphqlDataSource.Factory{
-				HTTPClient: httpClient,
+				HTTPClient:         httpClient,
+				StreamingClient:    streamingClient,
+				SubscriptionClient: mockSubscriptionClient,
 			},
 			Custom: graphqlDataSource.ConfigJson(graphqlDataSource.Configuration{
 				Fetch: graphqlDataSource.FetchConfiguration{
@@ -232,7 +259,13 @@ func TestGraphQLConfigAdapter_EngineConfigV2(t *testing.T) {
 		}
 
 		httpClient := &http.Client{}
-		adapter := NewGraphQLConfigAdapter(apiDef, WithHttpClient(httpClient))
+		streamingClient := &http.Client{}
+		adapter := NewGraphQLConfigAdapter(
+			apiDef,
+			WithHttpClient(httpClient),
+			WithStreamingClient(streamingClient),
+			withGraphQLSubscriptionClientFactory(&MockSubscriptionClientFactory{}),
+		)
 
 		engineV2Config, err := adapter.EngineConfigV2()
 		assert.NoError(t, err)
@@ -255,8 +288,10 @@ func TestGraphQLConfigAdapter_EngineConfigV2(t *testing.T) {
 				},
 			},
 			Factory: &graphqlDataSource.Factory{
-				BatchFactory: graphqlDataSource.NewBatchFactory(),
-				HTTPClient:   httpClient,
+				BatchFactory:       graphqlDataSource.NewBatchFactory(),
+				HTTPClient:         httpClient,
+				StreamingClient:    streamingClient,
+				SubscriptionClient: mockSubscriptionClient,
 			},
 			Custom: graphqlDataSource.ConfigJson(graphqlDataSource.Configuration{
 				Fetch: graphqlDataSource.FetchConfiguration{
@@ -266,7 +301,8 @@ func TestGraphQLConfigAdapter_EngineConfigV2(t *testing.T) {
 					},
 				},
 				Subscription: graphqlDataSource.SubscriptionConfiguration{
-					URL: "http://localhost:8080",
+					URL:    "http://localhost:8080",
+					UseSSE: false,
 				},
 			}),
 		}
@@ -472,12 +508,6 @@ func TestGraphQLConfigAdapter_engineConfigV2FieldConfigs(t *testing.T) {
 func TestGraphQLConfigAdapter_engineConfigV2DataSources(t *testing.T) {
 	httpClient := &http.Client{}
 	streamingClient := &http.Client{}
-	dummySubscriptionClient := graphqlDataSource.NewGraphQLSubscriptionClient(
-		httpClient,
-		streamingClient,
-		nil,
-		graphqlDataSource.WithWSSubProtocol(graphqlDataSource.ProtocolGraphQLWS),
-	)
 
 	expectedDataSources := []plan.DataSourceConfiguration{
 		{
@@ -526,7 +556,7 @@ func TestGraphQLConfigAdapter_engineConfigV2DataSources(t *testing.T) {
 			Factory: &graphqlDataSource.Factory{
 				HTTPClient:         httpClient,
 				StreamingClient:    streamingClient,
-				SubscriptionClient: dummySubscriptionClient,
+				SubscriptionClient: mockSubscriptionClient,
 			},
 			Custom: graphqlDataSource.ConfigJson(graphqlDataSource.Configuration{
 				Fetch: graphqlDataSource.FetchConfiguration{
@@ -608,7 +638,7 @@ func TestGraphQLConfigAdapter_engineConfigV2DataSources(t *testing.T) {
 			Factory: &graphqlDataSource.Factory{
 				HTTPClient:         httpClient,
 				StreamingClient:    streamingClient,
-				SubscriptionClient: dummySubscriptionClient,
+				SubscriptionClient: mockSubscriptionClient,
 			},
 			Custom: graphqlDataSource.ConfigJson(graphqlDataSource.Configuration{
 				Fetch: graphqlDataSource.FetchConfiguration{
@@ -709,7 +739,7 @@ func TestGraphQLConfigAdapter_engineConfigV2DataSources(t *testing.T) {
 			Factory: &graphqlDataSource.Factory{
 				HTTPClient:         httpClient,
 				StreamingClient:    streamingClient,
-				SubscriptionClient: dummySubscriptionClient,
+				SubscriptionClient: mockSubscriptionClient,
 			},
 			Custom: graphqlDataSource.ConfigJson(graphqlDataSource.Configuration{
 				Fetch: graphqlDataSource.FetchConfiguration{
@@ -789,7 +819,7 @@ func TestGraphQLConfigAdapter_engineConfigV2DataSources(t *testing.T) {
 	adapter := NewGraphQLConfigAdapter(
 		apiDef, WithHttpClient(httpClient),
 		WithStreamingClient(streamingClient),
-		withDummySubscriptionClient(dummySubscriptionClient),
+		withGraphQLSubscriptionClientFactory(&MockSubscriptionClientFactory{}),
 	)
 	require.NoError(t, adapter.parseSchema())
 
@@ -823,6 +853,40 @@ func TestGraphQLConfigAdapter_GraphqlDataSourceWebSocketProtocol(t *testing.T) {
 	t.Run("should return 'graphql-transport-ws' for graphql-transport-ws subscription type",
 		run(apidef.GQLSubscriptionTransportWS, graphqlDataSource.ProtocolGraphQLTWS),
 	)
+}
+
+func TestGraphQLConfigAdapter_GraphqlSubscriptionType(t *testing.T) {
+	run := func(subscriptionType apidef.SubscriptionType, expectedGraphQLSubscriptionType graphql.SubscriptionType) func(t *testing.T) {
+		return func(t *testing.T) {
+			adapter := NewGraphQLConfigAdapter(nil)
+			actualSubscriptionType := adapter.graphqlSubscriptionType(subscriptionType)
+			assert.Equal(t, expectedGraphQLSubscriptionType, actualSubscriptionType)
+		}
+	}
+
+	t.Run("should return 'Unknown' for undefined subscription type",
+		run(apidef.GQLSubscriptionUndefined, graphql.SubscriptionTypeUnknown),
+	)
+
+	t.Run("should return 'SSE' for sse subscription type as websocket protocol is irrelevant in that case",
+		run(apidef.GQLSubscriptionSSE, graphql.SubscriptionTypeSSE),
+	)
+
+	t.Run("should return 'GraphQLWS' for graphql-ws subscription type",
+		run(apidef.GQLSubscriptionWS, graphql.SubscriptionTypeGraphQLWS),
+	)
+
+	t.Run("should return 'GraphQLTransportWS' for graphql-transport-ws subscription type",
+		run(apidef.GQLSubscriptionTransportWS, graphql.SubscriptionTypeGraphQLTransportWS),
+	)
+}
+
+var mockSubscriptionClient = &graphqlDataSource.SubscriptionClient{}
+
+type MockSubscriptionClientFactory struct{}
+
+func (m *MockSubscriptionClientFactory) NewSubscriptionClient(httpClient, streamingClient *http.Client, engineCtx context.Context, options ...graphqlDataSource.Options) graphqlDataSource.GraphQLSubscriptionClient {
+	return mockSubscriptionClient
 }
 
 const graphqlEngineV1ConfigJson = `{
@@ -1161,7 +1225,8 @@ var graphqlProxyOnlyConfig = `{
 	"proxy": {
 		"auth_headers": {
 			"Authorization": "123abc"
-		}
+		},
+		"subscription_type": "sse"
 	},
 	"engine": {
 		"field_configs": [],
@@ -1191,7 +1256,8 @@ var graphqlSubgraphConfig = `{
 		"data_sources": []
 	},
 	"subgraph": {
-		"sdl": ` + strconv.Quote(federationAccountsServiceSDL) + `
+		"sdl": ` + strconv.Quote(federationAccountsServiceSDL) + `,
+		"subscription_type": "graphql-transport-ws"
 	},
 	"playground": {}
 }`

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -781,7 +781,8 @@ const (
 )
 
 type GraphQLProxyConfig struct {
-	AuthHeaders map[string]string `bson:"auth_headers" json:"auth_headers"`
+	AuthHeaders      map[string]string `bson:"auth_headers" json:"auth_headers"`
+	SubscriptionType SubscriptionType  `bson:"subscription_type" json:"subscription_type"`
 }
 
 type GraphQLSubgraphConfig struct {

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -27,19 +27,22 @@ import (
 
 	"github.com/TykTechnologies/tyk/apidef/oas"
 
-	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/resolve"
 	"github.com/cenk/backoff"
+
+	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/resolve"
 
 	"github.com/Masterminds/sprig/v3"
 
 	circuit "github.com/TykTechnologies/circuitbreaker"
-	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
+
+	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
 
 	"github.com/TykTechnologies/gojsonschema"
 
 	"github.com/TykTechnologies/tyk-pump/analytics"
+
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/header"
@@ -218,8 +221,9 @@ type APISpec struct {
 			BeforeFetchHook resolve.BeforeFetchHook
 			AfterFetchHook  resolve.AfterFetchHook
 		}
-		Client *http.Client
-		Schema *graphql.Schema
+		Client          *http.Client
+		StreamingClient *http.Client
+		Schema          *graphql.Schema
 	} `json:"-"`
 
 	hasMock   bool

--- a/gateway/mw_graphql.go
+++ b/gateway/mw_graphql.go
@@ -75,6 +75,10 @@ func (m *GraphQLMiddleware) Init() {
 		m.Spec.GraphQLExecutor.Client = &http.Client{
 			Transport: &http.Transport{TLSClientConfig: tlsClientConfig(m.Spec)},
 		}
+		m.Spec.GraphQLExecutor.StreamingClient = &http.Client{
+			Timeout:   0,
+			Transport: &http.Transport{TLSClientConfig: tlsClientConfig(m.Spec)},
+		}
 
 		if m.Spec.GraphQL.Version == apidef.GraphQLConfigVersionNone || m.Spec.GraphQL.Version == apidef.GraphQLConfigVersion1 {
 			m.initGraphQLEngineV1(absLogger)
@@ -163,6 +167,7 @@ func (m *GraphQLMiddleware) initGraphQLEngineV1(logger *abstractlogger.LogrusLog
 func (m *GraphQLMiddleware) initGraphQLEngineV2(logger *abstractlogger.LogrusLogger) {
 	configAdapter := adapter.NewGraphQLConfigAdapter(m.Spec.APIDefinition,
 		adapter.WithHttpClient(m.Spec.GraphQLExecutor.Client),
+		adapter.WithStreamingClient(m.Spec.GraphQLExecutor.StreamingClient),
 		adapter.WithSchema(m.Spec.GraphQLExecutor.Schema),
 	)
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/TykTechnologies/gojsonschema v0.0.0-20170222154038-dcb3e4bb7990
 	github.com/TykTechnologies/gorpc v0.0.0-20190515174534-b9c10befc5f4
 	github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708
-	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20221025081929-fca0a9e1387e
+	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20221026084245-1fc4f5ca74bb
 	github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c
 	github.com/TykTechnologies/murmur3 v0.0.0-20180602122059-1915e687e465
 	github.com/TykTechnologies/openid2go v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/TykTechnologies/gorpc v0.0.0-20190515174534-b9c10befc5f4/go.mod h1:vq
 github.com/TykTechnologies/goverify v0.0.0-20160822133757-7ccc57452ade/go.mod h1:mkS8jKcz8otdfEXhJs1QQ/DKoIY1NFFsRPKS0RwQENI=
 github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708 h1:cmXjlMzcexhc/Cg+QB/c2CPUVs1ux9xn6162qaf/LC4=
 github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708/go.mod h1:mkS8jKcz8otdfEXhJs1QQ/DKoIY1NFFsRPKS0RwQENI=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20221025081929-fca0a9e1387e h1:OIIFo+2MWNXKBJAdbq+teQ1sw0WWs2hkuOOs02mtZ2s=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20221025081929-fca0a9e1387e/go.mod h1:rs6RZamoJmz5oL5nOyQdzCdo87BzJyrSrug3r3ZHrFc=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20221026084245-1fc4f5ca74bb h1:w7NGYV5amb+A7IY5HYldS+O2D9WWV31193DT3L9k8G4=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20221026084245-1fc4f5ca74bb/go.mod h1:rs6RZamoJmz5oL5nOyQdzCdo87BzJyrSrug3r3ZHrFc=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c h1:j6fd0Fz1R4oSWOmcooGjrdahqrML+btQ+PfEJw8SzbA=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c/go.mod h1:GnHUbsQx+ysI10osPhUdTmsxcE7ef64cVp38Fdyd7e0=
 github.com/TykTechnologies/murmur3 v0.0.0-20180602122059-1915e687e465 h1:A2gBjoX8aF0G3GHEpHyj2f0ixuPkCgcGqmPdKHSkW+0=


### PR DESCRIPTION
This PR adds a configuration option for setting the subscription type on proxy-only APIs.
It also fixes an issue with federation APIs.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)
