### PR TITLE
[TT-6795] [TT-6941] add omitempty to SubscriptionType

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -790,7 +790,7 @@ const (
 
 type GraphQLProxyConfig struct {
 	AuthHeaders      map[string]string `bson:"auth_headers" json:"auth_headers"`
-	SubscriptionType SubscriptionType  `bson:"subscription_type" json:"subscription_type"`
+	SubscriptionType SubscriptionType  `bson:"subscription_type" json:"subscription_type,omitempty"`
 }
 
 type GraphQLSubgraphConfig struct {
@@ -812,7 +812,7 @@ type GraphQLSubgraphEntity struct {
 	URL              string            `bson:"url" json:"url"`
 	SDL              string            `bson:"sdl" json:"sdl"`
 	Headers          map[string]string `bson:"headers" json:"headers"`
-	SubscriptionType SubscriptionType  `bson:"subscription_type" json:"subscription_type"`
+	SubscriptionType SubscriptionType  `bson:"subscription_type" json:"subscription_type,omitempty"`
 }
 
 type GraphQLEngineConfig struct {
@@ -860,7 +860,7 @@ type GraphQLEngineDataSourceConfigGraphQL struct {
 	URL              string            `bson:"url" json:"url"`
 	Method           string            `bson:"method" json:"method"`
 	Headers          map[string]string `bson:"headers" json:"headers"`
-	SubscriptionType SubscriptionType  `bson:"subscription_type" json:"subscription_type"`
+	SubscriptionType SubscriptionType  `bson:"subscription_type" json:"subscription_type,omitempty"`
 }
 
 type GraphQLEngineDataSourceConfigKafka struct {


### PR DESCRIPTION
This PR adds `omitempty` to the new `subscription_type` fields in API definition

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring or add test (improvements in base code or adds test coverage to functionality)