### PR TITLE
[TT-6702] Remove version change actions from apidef

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -659,9 +659,6 @@ type APIDefinition struct {
 
 	// IsOAS is set to true when API has an OAS definition (created in OAS or migrated to OAS)
 	IsOAS bool `bson:"is_oas" json:"is_oas,omitempty"`
-
-	VersionChangeActions map[string]string `bson:"-" json:"-"`
-	ExistingAPI          *APIDefinition    `bson:"-" json:"-"`
 }
 
 type AnalyticsPluginConfig struct {


### PR DESCRIPTION
The `ExistingAPI` field caused `TestSQLMigrator` failed, so moving from here to `dashboard.ApiDefinition`.