### PR TITLE
Remove the false deprecation warning on the hard-sync limiters (non DRL)

### DIFF
--- a/checkup/checkup.go
+++ b/checkup/checkup.go
@@ -26,7 +26,6 @@ const (
 )
 
 func Run(c *config.Config) {
-	legacyRateLimiters(c)
 	allowInsecureConfigs(c)
 	healthCheck(c)
 	sessionLifetimeCheck(c)
@@ -35,16 +34,6 @@ func Run(c *config.Config) {
 	cpus()
 	defaultSecrets(c)
 	defaultAnalytics(c)
-}
-
-func legacyRateLimiters(c *config.Config) {
-	if c.ManagementNode {
-		return
-	}
-
-	if c.EnableSentinelRateLimiter || c.EnableRedisRollingLimiter {
-		log.Warning("SentinelRateLimiter & RedisRollingLimiter are deprecated")
-	}
 }
 
 func allowInsecureConfigs(c *config.Config) {


### PR DESCRIPTION
The non-DRL rate limits have been flagged as "deprecated" and "legacy".  This is a mis-classification.  They are indeed less performant as a tradeoff of being more accurate than the DRL rate limitor.

They are "legacy" by virtue of existing before the DRL (more performant/less acurrate) limiter, but certainly not "deprecated"

TT-7034