### PR TITLE
[TT-6641] Convert Error log to Debug in JWT API while searching OAuth client

### DIFF
--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -367,9 +367,6 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 		return err, http.StatusForbidden
 	}
 
-	// Get the OAuth client ID if available:
-	oauthClientID := k.getOAuthClientIDFromClaim(claims)
-
 	// Generate a virtual token
 	data := []byte(baseFieldData)
 	keyID := fmt.Sprintf("%x", md5.Sum(data))
@@ -567,6 +564,8 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 		}
 	}
 
+	// Get the OAuth client ID if available:
+	oauthClientID := k.getOAuthClientIDFromClaim(claims)
 	session.OauthClientID = oauthClientID
 	if session.OauthClientID != "" {
 		// Initialize the OAuthManager if empty:
@@ -600,7 +599,7 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 				}
 			}
 		} else {
-			k.Logger().WithError(err).Error("Couldn't get OAuth client")
+			k.Logger().WithError(err).Debug("Couldn't get OAuth client")
 		}
 	}
 

--- a/gateway/oauth_manager.go
+++ b/gateway/oauth_manager.go
@@ -604,16 +604,16 @@ func (r *RedisOsinStorageInterface) Close() {}
 func (r *RedisOsinStorageInterface) GetClient(id string) (osin.Client, error) {
 	key := prefixClient + id
 
-	log.Info("Getting client ID:", id)
+	log.Debug("Getting client ID:", id)
 	clientJSON, err := r.store.GetKey(key)
 	if err != nil {
-		log.Errorf("Failure retrieving client ID key %q: %v", key, err)
+		log.Debugf("Failure retrieving client ID key %q: %v", key, err)
 		return nil, err
 	}
 
 	client := new(OAuthClient)
 	if err := json.Unmarshal([]byte(clientJSON), &client); err != nil {
-		log.Error("Couldn't unmarshal OAuth client object: ", err)
+		log.Debug("Couldn't unmarshal OAuth client object: ", err)
 	}
 	return client, nil
 }


### PR DESCRIPTION
JWT protected APIs are used in DCR flows. For that case, OAuth client id extracted from token payload is searched and set to session metadata as developer id. However, in normal flows without DCR `client_id`, `clientId`, `cid` make gateway JWT middleware to search for OAuth client. It cannot find and logs errors in console. This PR converts those logs to debug to clear confusion of users not considering OAuth client.