### PR TITLE
[TT-7137] fixed issue with perist graphql and non empty listen path

### DIFF
--- a/gateway/mw_persist_graphql_operation.go
+++ b/gateway/mw_persist_graphql_operation.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -49,7 +50,8 @@ func (i *PersistGraphQLOperationMiddleware) ProcessRequest(w http.ResponseWriter
 	defer r.Body.Close()
 
 	replacers := make(map[string]int)
-	paths := strings.Split(mwSpec.Path, "/")
+	fullPath := fmt.Sprintf("%s/%s", strings.TrimRight(i.Spec.Proxy.ListenPath, "/"), strings.TrimLeft(mwSpec.Path, "/"))
+	paths := strings.Split(fullPath, "/")
 	for i, part := range paths {
 		if strings.HasPrefix(part, "{") && strings.HasSuffix(part, "}") {
 			key := "$path." + strings.Replace(part, "{", "", -1)

--- a/gateway/mw_persist_graphql_operation_test.go
+++ b/gateway/mw_persist_graphql_operation_test.go
@@ -25,6 +25,13 @@ query country($code: ID!){
   }
 }`
 
+const testGQLQueryCountryCode = `
+query country($countryCode: ID!){
+  country(code: $countryCode){
+    code
+  }
+}`
+
 const testQueryContinentCode = `
 query continent($code: ID!) {
   continent(code: $code){
@@ -223,6 +230,55 @@ func TestGraphqlPersist_Variables(t *testing.T) {
 			return q.Query == testQueryContinentCode && string(q.Variables) == `{"code":"AF"}`
 		}},
 	)
+	assert.NoError(t, err)
+}
+
+func TestGraphQLPersist_VariablesListenPath(t *testing.T) {
+	ts := StartTest(nil)
+	t.Cleanup(func() {
+		ts.Close()
+	})
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "rest-graph-listen-path"
+		spec.OrgID = "default"
+		spec.Proxy.ListenPath = "/test/"
+		spec.Proxy.TargetURL = TestHttpAny
+		spec.EnableContextVars = true
+		spec.VersionData.NotVersioned = false
+		spec.VersionData.Versions["Default"] = apidef.VersionInfo{
+			Name:             "Default",
+			Expires:          "3000-01-02 00:00",
+			UseExtendedPaths: true,
+			ExtendedPaths: apidef.ExtendedPathsSet{
+				PersistGraphQL: []apidef.PersistGraphQLMeta{
+					{
+						Path:      "/getCountryByCode/{countryCode}",
+						Method:    "GET",
+						Operation: testGQLQueryCountryCode,
+						Variables: map[string]interface{}{
+							"countryCode": "$path.countryCode",
+						},
+					},
+				},
+			},
+		}
+	})
+
+	_, err := ts.Run(t,
+		test.TestCase{Path: "/test/getCountryByCode/NG", Method: "GET", BodyMatchFunc: func(bytes []byte) bool {
+			var testResp TestHttpResponse
+			if err := json.Unmarshal(bytes, &testResp); err != nil {
+				return false
+			}
+			// Get query and variables
+			var q GraphQLRequest
+			if err := json.Unmarshal([]byte(testResp.Body), &q); err != nil {
+				return false
+			}
+			return q.Query == testGQLQueryCountryCode && string(q.Variables) == `{"countryCode":"NG"}`
+		}},
+	)
+
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->
Fixed an issue with the grapql persist middleware not working on apis where the listen path on the spec is not empty

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->
[TT-7137](https://tyktech.atlassian.net/browse/TT-7137)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
