### PR TITLE
[TT-7164] Move introspection call function to middleware

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -7,14 +7,10 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
-	"net/url"
 	"strings"
 	"text/template"
 	"time"
-
-	"github.com/golang-jwt/jwt/v4"
 
 	uuid "github.com/satori/go.uuid"
 
@@ -1329,35 +1325,4 @@ type Introspection struct {
 type IntrospectionCache struct {
 	Enabled bool  `bson:"enabled" json:"enabled"`
 	Timeout int64 `bson:"timeout" json:"timeout"`
-}
-
-func (i *Introspection) Call(accessToken string) (jwt.MapClaims, error) {
-	body := url.Values{}
-	body.Set("token", accessToken)
-	body.Set("client_id", i.ClientID)
-	body.Set("client_secret", i.ClientSecret)
-
-	res, err := http.Post(i.URL, "application/x-www-form-urlencoded", strings.NewReader(body.Encode()))
-	if err != nil {
-		return nil, fmt.Errorf("error happened during the introspection call: %s", err)
-	}
-
-	defer res.Body.Close()
-
-	bodyInBytes, err := io.ReadAll(res.Body)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't read the introspection call response: %s", err)
-	}
-
-	var claims jwt.MapClaims
-	err = json.Unmarshal(bodyInBytes, &claims)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't unmarshal the introspection call response: %s", err)
-	}
-
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("status does not indicate success: code: %d, body: %v", res.StatusCode, res.Body)
-	}
-
-	return claims, nil
 }


### PR DESCRIPTION
We decided that the `apidef` package should just include schema related logic. The introspection call should live inside the middleware.