### PR TITLE
Ensure that version used my plugin loader has the correct syntax

### DIFF
--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -255,9 +255,17 @@ func (m *GoPluginMiddleware) goPluginFromTykVersion(version string) string {
 	if len(vs) > 0 {
 		version = vs[0]
 	}
+	version = EnsureSemanticVersioning(version)
 
 	newPluginName := strings.Join([]string{pluginName, version, os, architecture}, "_")
 	newPluginPath := pluginDir + "/" + newPluginName + ".so"
 
 	return newPluginPath
+}
+
+func EnsureSemanticVersioning(version string) string {
+	if !strings.HasPrefix(version, "v") {
+		version = "v" + version
+	}
+	return version
 }

--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -263,6 +263,7 @@ func (m *GoPluginMiddleware) goPluginFromTykVersion(version string) string {
 	return newPluginPath
 }
 
+// EnsureSemanticVersioning receives a version and check that it has the prefix 'v' otherwise, it adds it
 func EnsureSemanticVersioning(version string) string {
 	if !strings.HasPrefix(version, "v") {
 		version = "v" + version


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

When reading the version we need to ensure that it contains the prefix "v". It happens that goreleaser strips the prefix, so we have different behaviors when building the app locally vs the container built by goreleaser. For more details: [documentation](https://goreleaser.com/customization/templates/?h=variables#fn:version-prefix) 

## Related Issue

https://tyktech.atlassian.net/browse/TT-6668

## Motivation and Context

Problem details: https://tyktech.atlassian.net/browse/TT-6668

## How This Has Been Tested

- Run the next steps while building the app locally and also running the gw using an RC image.

- Create an api via dashboard with a goplugin enabled. The plugin file doesn't really have to exist, as we need to check is the file that attempts to load. In order to do so, I edited the apidefinition in the raw editor and added:

```
"custom_middleware": {
      "pre": [
          {
            "name": "AddFooBarHeader",
            "path": "anypath/plugin.so"
        }
    ],
      "driver": "goplugin",
     // the other stuffs
}
```
- Run the gw and check the name of the plugin that is attempting to load...the version section should be in the format: vx.x.x

In my local I get the next log line, which shows me that the plugin loader is targeting the correct file:

```
ERROR Could not load Go-plugin error=plugin.Open("anypath/plugin_v4.1.0_darwin_amd64.so"): realpath failed mwPath=anypath/plugin.so mwSymbolName=AddFooBarHeader
```

To use docker containers I generated the image `tykio/tyk-gateway:v4.3.0-rc5` that contain the changes in this branch, however I encourage you to create your own image.

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
