### PR TITLE
[TT-5034] UDG header pass through breaks when the header is not a string

### DIFF
--- a/gateway/mw_graphql_test.go
+++ b/gateway/mw_graphql_test.go
@@ -7,15 +7,16 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/buger/jsonparser"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	gql "github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/header"
 	"github.com/TykTechnologies/tyk/test"
 	"github.com/TykTechnologies/tyk/user"
-	"github.com/buger/jsonparser"
-	"github.com/gorilla/websocket"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // Note: here we test only validation behaviour and do not expect real graphql responses here


### PR DESCRIPTION
This PR improves UDG/GraphQL-related error handling in Tyk GW. See [TT-5034](https://tyktech.atlassian.net/jira/software/c/projects/TT/boards/26?modal=detail&selectedIssue=TT-5034) on Jira for details.

Basically, I wrapped the error message returned by `p.TykAPISpec.GraphQLExecutor.EngineV2.Execute` method to check its type in `WrappedServeHTTP` method. This way, we can inform the user about the underlying problem when something goes wrong in GQL execution. 

Previously, it was hiding the actual error message from the user. It can be quite challenging to debug the underlying problem for cloud customers: 

```json
{
    "error": "There was a problem proxying the request"
}
```


Current error message:

```json
{
    "error": "GraphQL execution error: Value is array, but can\'t find closing \']\' symbol"
}
```

I preferred using Zaid's sample in the integration test.

See the comments section on Jira for details: https://tyktech.atlassian.net/browse/TT-5034?focusedCommentId=29704

By the way, there is nothing changed GQL-specific error handling. For example, if I send a malformed GQL query it returns the validation error as expected:

```json
{
    "errors": [
        {
            "message": "unexpected token - got: RBRACE want one of: [EOF LBRACE COMMENT STRING BLOCKSTRING IDENT]",
            "locations": [
                {
                    "line": 10,
                    "column": 1
                }
            ]
        }
    ]
}
```