### PR TITLE
goplugin loader loads plugin without the prefix v

### DIFF
--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -120,6 +120,10 @@ func (m *GoPluginMiddleware) EnabledForSpec() bool {
 	return false
 }
 
+// loadPlugin loads the plugin file from m.Path, it will try with:
+// m.path which can be {plugin_name}.so
+// if the file doesn't exist then it will try converting it to the tyk version aware format: {plugin_name}_{tyk_version}_{os}_{arch}.so
+// later if the file still doesn't exist then it will try again but ensuring that the version contains the prefix 'v'
 func (m *GoPluginMiddleware) loadPlugin() bool {
 	m.logger = log.WithFields(logrus.Fields{
 		"mwPath":       m.Path,
@@ -136,7 +140,13 @@ func (m *GoPluginMiddleware) loadPlugin() bool {
 
 	if !FileExist(m.Path) {
 		// if the exact name doesn't exist then try to load it using tyk version
-		m.Path = m.goPluginFromTykVersion(VERSION)
+		m.Path = m.getPluginNameFromTykVersion(VERSION)
+
+		prefixedVersion := getPrefixedVersion(VERSION)
+		if !FileExist(m.Path) && VERSION != prefixedVersion {
+			// if they file doesn't exist yet, then lets try with version in the format: v.x.x
+			m.Path = m.getPluginNameFromTykVersion(prefixedVersion)
+		}
 	}
 
 	if m.handler, err = goplugin.GetHandler(m.Path, m.SymbolName); err != nil {
@@ -236,10 +246,10 @@ func (m *GoPluginMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reque
 	return
 }
 
-// goPluginFromTykVersion builds a name of plugin based on tyk version
+// getPluginNameFromTykVersion builds a name of plugin based on tyk version
 // os and architecture. The structure of the plugin name looks like:
 // {plugin-dir}/{plugin-name}_{GW-version}_{OS}_{arch}.so
-func (m *GoPluginMiddleware) goPluginFromTykVersion(version string) string {
+func (m *GoPluginMiddleware) getPluginNameFromTykVersion(version string) string {
 	if m.Path == "" {
 		return ""
 	}
@@ -255,7 +265,6 @@ func (m *GoPluginMiddleware) goPluginFromTykVersion(version string) string {
 	if len(vs) > 0 {
 		version = vs[0]
 	}
-	version = EnsureSemanticVersioning(version)
 
 	newPluginName := strings.Join([]string{pluginName, version, os, architecture}, "_")
 	newPluginPath := pluginDir + "/" + newPluginName + ".so"
@@ -263,8 +272,8 @@ func (m *GoPluginMiddleware) goPluginFromTykVersion(version string) string {
 	return newPluginPath
 }
 
-// EnsureSemanticVersioning receives a version and check that it has the prefix 'v' otherwise, it adds it
-func EnsureSemanticVersioning(version string) string {
+// getPrefixedVersion receives a version and check that it has the prefix 'v' otherwise, it adds it
+func getPrefixedVersion(version string) string {
 	if !strings.HasPrefix(version, "v") {
 		version = "v" + version
 	}

--- a/gateway/mw_go_plugin_test.go
+++ b/gateway/mw_go_plugin_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGoPluginFromTykVersion(t *testing.T) {
+func TestGetGoPluginNameFromTykVersion(t *testing.T) {
 	t.Parallel()
 
 	m := GoPluginMiddleware{
@@ -32,12 +32,28 @@ func TestGoPluginFromTykVersion(t *testing.T) {
 	// plugin with clean version in filename (no -rc16).
 	expectVersion := "v4.1.0"
 
-	for _, version := range []string{expectVersion, expectVersion + "-rc16", "4.1.0"} {
+	versions := []struct {
+		version, expectedVersion string
+	}{
+		{
+			version:         expectVersion,
+			expectedVersion: expectVersion,
+		},
+		{
+			version:         expectVersion + "-rc16",
+			expectedVersion: expectVersion,
+		},
+		{
+			version:         "4.1.0",
+			expectedVersion: "4.1.0",
+		},
+	}
+	for _, version := range versions {
 		testcases = append(testcases, []testCase{
-			{version, "plugin.so", fmt.Sprintf("./plugin_%v_%v_%v.so", expectVersion, goos, goarch)},
-			{version, "/some/path/plugin.so", fmt.Sprintf("/some/path/plugin_%v_%v_%v.so", expectVersion, goos, goarch)},
-			{version, "/some/path/plugin", fmt.Sprintf("/some/path/plugin_%v_%v_%v.so", expectVersion, goos, goarch)},
-			{version, "./plugin.so", fmt.Sprintf("./plugin_%v_%v_%v.so", expectVersion, goos, goarch)},
+			{version.version, "plugin.so", fmt.Sprintf("./plugin_%v_%v_%v.so", version.expectedVersion, goos, goarch)},
+			{version.version, "/some/path/plugin.so", fmt.Sprintf("/some/path/plugin_%v_%v_%v.so", version.expectedVersion, goos, goarch)},
+			{version.version, "/some/path/plugin", fmt.Sprintf("/some/path/plugin_%v_%v_%v.so", version.expectedVersion, goos, goarch)},
+			{version.version, "./plugin.so", fmt.Sprintf("./plugin_%v_%v_%v.so", version.expectedVersion, goos, goarch)},
 		}...)
 	}
 
@@ -46,14 +62,14 @@ func TestGoPluginFromTykVersion(t *testing.T) {
 			t.Parallel()
 
 			m.Path = tc.userDefinedName
-			newPluginPath := m.goPluginFromTykVersion(tc.version)
+			newPluginPath := m.getPluginNameFromTykVersion(tc.version)
 			assert.Equal(t, tc.inferredName, newPluginPath)
 		})
 	}
 }
 
-func TestEnsureSemanticVersioning(t *testing.T) {
-	version := EnsureSemanticVersioning("v4.1.0")
+func TestGetPrefixedVersion(t *testing.T) {
+	version := getPrefixedVersion("v4.1.0")
 	expectedVersion := "v4.1.0"
 	assert.Equal(t, expectedVersion, version)
 
@@ -74,7 +90,7 @@ func TestEnsureSemanticVersioning(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			version := EnsureSemanticVersioning(tc.version)
+			version := getPrefixedVersion(tc.version)
 			assert.Equal(t, tc.expectedVersion, version)
 		})
 	}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Plugin loader for goPlugins now load them even if they do not have the prefix V in the gw version in the name of file.

## Related Issue

https://tyktech.atlassian.net/browse/TT-6668

## Motivation and Context

Give solution to https://tyktech.atlassian.net/browse/TT-6668

## How This Has Been Tested

- ran tests
- run env with go plugins bundler enabled and disabled
- created an api with plugin
- compiled the plugin
- the plugin is loaded

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
