### PR TITLE
Load go plugins that contains the prefix V

### DIFF
--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -139,14 +139,16 @@ func (m *GoPluginMiddleware) loadPlugin() bool {
 	var err error
 
 	if !FileExist(m.Path) {
+		newPath := m.Path
 		// if the exact name doesn't exist then try to load it using tyk version
-		m.Path = m.getPluginNameFromTykVersion(VERSION)
+		newPath = m.getPluginNameFromTykVersion(VERSION)
 
 		prefixedVersion := getPrefixedVersion(VERSION)
-		if !FileExist(m.Path) && VERSION != prefixedVersion {
-			// if they file doesn't exist yet, then lets try with version in the format: v.x.x
-			m.Path = m.getPluginNameFromTykVersion(prefixedVersion)
+		if !FileExist(newPath) && VERSION != prefixedVersion {
+			// if the file doesn't exist yet, then lets try with version in the format: v.x.x.x
+			newPath = m.getPluginNameFromTykVersion(prefixedVersion)
 		}
+		m.Path = newPath
 	}
 
 	defer func() {

--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -139,9 +139,8 @@ func (m *GoPluginMiddleware) loadPlugin() bool {
 	var err error
 
 	if !FileExist(m.Path) {
-		newPath := m.Path
 		// if the exact name doesn't exist then try to load it using tyk version
-		newPath = m.getPluginNameFromTykVersion(VERSION)
+		newPath := m.getPluginNameFromTykVersion(VERSION)
 
 		prefixedVersion := getPrefixedVersion(VERSION)
 		if !FileExist(newPath) && VERSION != prefixedVersion {

--- a/gateway/util.go
+++ b/gateway/util.go
@@ -117,6 +117,7 @@ func greaterThanInt(first, second int) bool {
 
 func FileExist(filepath string) bool {
 	if _, err := os.Stat(filepath); errors.Is(err, os.ErrNotExist) {
+		log.Warningf("plugin file %v doesn't exist", filepath)
 		return false
 	}
 	return true


### PR DESCRIPTION

## Description

The plugin path was modified multiple times, ending up in a nonsensepath and not loading the plugin.

## Related Issue
https://tyktech.atlassian.net/browse/TT-6668

## Motivation and Context

Fix https://tyktech.atlassian.net/browse/TT-6668?focusedCommentId=30359

## How This Has Been Tested

- Load plugin with prefix
- Load plugin without prefix
- Load plugin with plain name

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
