### PR TITLE
[FIX] attempt to load go-plugins from non-versioned paths causes panic

### DIFF
--- a/gateway/res_handler_go_plugin.go
+++ b/gateway/res_handler_go_plugin.go
@@ -55,6 +55,7 @@ func (h *ResponseGoPluginMiddleware) Init(c interface{}, spec *APISpec) error {
 			"versionedMwPath": h.Path,
 		})
 	}
+
 	if h.ResHandler, err = goplugin.GetResponseHandler(h.Path, h.SymbolName); err != nil {
 		h.logger.WithError(err).Error("Could not load Go-plugin")
 		return err


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Enable Tyk to load plugin bundles that contain plugins compatible with tyk-gateway <=v4.1

Let's say that my plugin name is `super-authorization-plugin`. The solution I devised is:
- build a plugin for v4.0.9 named `super-authorization-plugin.so`
- build a plugin for v4.2.4 named `super-authorization-plugin_v4.2.4_linux_amd64.so`
- put both plugins in the same bundle with a manifest that looks as follows:
  ```json
  {
    "file_list": [
      "super-authorization-plugin_v4.0.9_linux_amd64.so",
      "super-authorization-plugin.so"
    ],
    "custom_middleware": {
      "auth_check": {
        "name": "DojoTykEnvoyAuthorize",
        "path": "super-authorization-plugin.so"
      },
      "driver": "goplugin"
    }
  }
  ```
- **when tyk v4.0.9 tries to load the plugin, it will find `super-authorization-plugin.so` and load it correctly**
- **when tyk v4.2.4 tries to load the plugin, it will find `super-authorization-plugin_v4.0.9_linux_amd64.so` load it correctly**, if it doesn't find it, it'll fall-back to `super-authorization-plugin.so`


## Related Issue
#4447 

## Motivation and Context

Update gateways with a high number of api-definitions using go-plugins from v4.0.x to >=v4.1.x causes down time. Because v4.0 doesn't support bundles containing multiple versions of the same plugin built for different gateway versions, and >=v4.1 is not able to load the correct plugin when a bundle contains plugins compatible with v4.0.

## How This Has Been Tested
Installed tyk-hybrid-gateway using helm on a GKE cluster, changing the container image to one built from this PR.


## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
