### PR TITLE
merge/cf54fe538d59c059df4e858f0faa1a7535ba970b

### DIFF
--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -140,13 +140,14 @@ func (m *GoPluginMiddleware) loadPlugin() bool {
 
 	if !FileExist(m.Path) {
 		// if the exact name doesn't exist then try to load it using tyk version
-		m.Path = m.getPluginNameFromTykVersion(VERSION)
+		newPath := m.getPluginNameFromTykVersion(VERSION)
 
 		prefixedVersion := getPrefixedVersion(VERSION)
-		if !FileExist(m.Path) && VERSION != prefixedVersion {
-			// if they file doesn't exist yet, then lets try with version in the format: v.x.x
-			m.Path = m.getPluginNameFromTykVersion(prefixedVersion)
+		if !FileExist(newPath) && VERSION != prefixedVersion {
+			// if the file doesn't exist yet, then lets try with version in the format: v.x.x.x
+			newPath = m.getPluginNameFromTykVersion(prefixedVersion)
 		}
+		m.Path = newPath
 	}
 
 	defer func() {

--- a/gateway/util.go
+++ b/gateway/util.go
@@ -117,6 +117,7 @@ func greaterThanInt(first, second int) bool {
 
 func FileExist(filepath string) bool {
 	if _, err := os.Stat(filepath); errors.Is(err, os.ErrNotExist) {
+		log.Warningf("plugin file %v doesn't exist", filepath)
 		return false
 	}
 	return true


### PR DESCRIPTION
- TT-3361 - Disable enable_health_checks for master (#3728)
- Convert map to array for scope policy mapping (#3737)
- TT-3648 started to process oauth clients events (#3719)
- Handle GoPlugin conversion independent from AuthConfigs (#3745)
- Match upstream certificate with target url's host instead of request's host (#3746)
- TT-1799 - prevent show full error to API response (#3743)
- [TT-3880] Deprecate JWTScopeToPolicyMapping and JWTScopeToPolicyMapping (#3744)
- Add open id check for scope field deprecation (#3748)
- [TT-3881] Implement the base for OIDC OAS conversion (#3741)
- TT-1799 - improved API response error message (#3747)
- [TT-3965] Implement new versioning system (#3753)
- Implement basic plugin's oas conversions (#3752)
- Override with deprecated auth when jwt or auth token is enabled (#3755)
- Add full XTykAPIGateway conversion test (#3759)
- Add disabled option to WhiteList/BlackList/Ignore plugins (#3760)
- fix optional query params for udg (TT-3985) (#3762)
- [TT-640] Add detailed mode for certificate listing API (#3757)
- TT-3906 - additional logic in case of non existing cert (#3763)
- sort query params for engine v2 configuration (#3770)
- [TT-4027] document certs APIs (#3769)
- TT-3663 - Implemented client certificates support (#3756)
- Capitalize plugins path methods in OAS (#3773)
- trim whitespace and compare cookiename with custom cookie config (#3774)
- Remove unnecessary if statement and move variable to required place (#3775)
- Add strip path test when version location is url (#3777)
- [TT-4089] return extra names in certificate listing detailed mode (#3778)
- Add changes to new versioning (#3780)
- update graphql-go-tools (#3779)
- Implement new versioning migrator (#3781)
- Implement strip versioning data (#3782)
- Fix sorting in OAS Scopes (#3785)
- Move old strip path code to one place and deprecate strip_path (#3784)
- Add TestOldVersioning_Expires test (#3787)
- Move versioning constants to apidef package (#3790)
- [TT-3966] Implement oas conversion of new versioning mechanism (#3758)
- Implement strip_path migrator to strip_versioning_data (#3792)
- [TT-4163]  Implement new api expiration feature (#3789)
- Implement expires to expiration migration (#3796)
- Fix/tt 4144 fix path templating (#3797)
- Add standalone mock response test (#3800)
- Implement separated mock response feature (#3801)
- Write override_target to target_url (#3806)
- Implement mock response migration (#3805)
- Refactor allowance oas conversion (#3808)
- Delete oas/extensions.go (#3809)
- [TT-4204] Implement mock response oas conversion (#3812)
- move host details into gw struct (#3810)
- Remove FAIL statement from test names to ease FAIL keyword search in CI (#3819)
- pass down wrapped http response writer to plugin (#3803)
- [TT-4228] Fix strip listen path which removes forwarding slash in path (#3813)
- Add disabled flag to method transform (#3815)
- Implement method transform plugin OAS conversion (#3821)
- TD-664/Aws-cf-templates for release-4 (#3817)
- Add mock response doc (#3814)
- Make migrated version APIs internal by default (#3824)
- Add auto-generated api ids to newly created APIs in migration (#3825)
- TT-4091 - OAS Caching Paths support (#3807)
- Adding healthcheck info and lock into gw struct (#3828)
- Add GoDoc for method transform plugin (#3826)
- Separate migration tests (#3830)
- Clean gateway_test.go (#3829)
- [TT-4277] Not force default version before migration (#3832)
- Return same error when default version info is not found in new versioning (#3833)
- Add disable flag for enforced timeout plugin (#3827)
- Set base as Default when there is no default is selected (#3834)
- Reflect OAS contract change of MethodTransform to TransformRequestMethod (#3835)
- Implement expiration field OAS conversion (#3839)
- Implement enforce timeout OAS conversion (#3845)
- fix depth limits for graphql introspection queries (TT-3314) (#3850)
- fix field selection on interface types (#3859)
- [TT-376] Import swagger paths in old whitelist format + track endpoint (#3844)
- set session id when openid key doesnt exist.So quota and key is created (#3852)
- pass auth headers as query params for subscription operation (#3864)
- update graphql-go-tools (#3884)
- Add fixes for Python 3.8/3.9 (#3479)
- adding _OMITCONFIGFILE config (#3874)
- TT-1740 Adding fallback scenario for ctx Get Apidef and Session (#3875)
- Add name field to auth config (#3888)
- [TT-4583]migrate authconfig name (#3890)
- [TT-4147] remove APIID from bundle dest path (#3849)
- [TT-4569] optional header authconfig (#3886)
- update graphql-go-tools (#3899)
- Implement security scheme conversions (#3902)
- update sprig to v3 (#3897)
- cherry picked
- TT-97 Export certificates package (#3312)
- Fix go mod to include tyk/certs for release-4
- Fix some edge cases of OAS auth source conversions (#3912)
- [CI] Syncing release automation from master
- Add small adjustments to OAS security scheme conversions (#3914)
- Fix the case where multiple securitySchemes exist (#3922)
- [TT-4655] Federation crashes gateway during performance tests (#3910)
- update graphql-go-tools (#3926)
- Auto-enable auth-source in security scheme (#3924)
- Move auth type constants to apidef package (#3927)
- TD-876/release-4-cleanup (#3918)
- Iterate auth configs map in alphabetical order in auth source validation (#3928)
- Refactor jwt OAS conversion (#3934)
- Refactor basic auth OAS conversion (#3935)
- [TT-4758] Implement OAS oauth2 scheme conversion (#3936)
- [TT-4869] Implement base of paths and operations (#3940)
- Add TransformRequestMethod operation to OAS (#3941)
- Add Cache operation to OAS (#3942)
- Add EnforceTimeout operation to OAS (#3943)
- Refactor custom plugin OAS conversion (#3933)
- Refactor go plugin OAS conversion (#3951)
- Refactor oidc auth OAS conversion (#3950)
- internal: relocate and fix legacy scripts (#3952)
- update graphql-to-tools TT-4627 (#3962)
- Cleanup OAS authentication code (#3963)
- TT-4934 make ctx.SetSession backwards compatible (#3967)
- [TT-4838] Add ValidateOASObject method (#3945)
- Revert "[TT-4838] Add ValidateOASObject method (#3945)" (#3968)
- Fix HMAC OAS conversion (#3970)
- Implement OAS upstream certificates conversion (#3964)
- fix graphiql to use default theme (#3966)
- Implement OAS pinned public keys conversion (#3971)
- Fix upstream certificate OAS conversion (#3982)
- [TT-4838] ValidateOASObject method (#3973)
- [TT-4874] OAS schema endpoint (#3974)
- [TT-4870] OAS migrate regex path fragments (#3975)
- [CI] Syncing release automation from master
- Disallow loading TCP services on main gateway port (#3984)
- [TT-4271] Bump docker version and remove critical CVE dependencies (#3959)
- TT-5026 Initializing OrganizationMonitor with a valid gw pointer (#3987)
- set oas.ExternalDocs to nil if populated with zero values (#3989)
- Fix json tag of pinned public keys (#3990)
- TT-4994 Separated the RPC cache into 2 stores (#3983)
- Fix go.mod
- Remove redundancy in the schema test (#3992)
- [TT-5080] Fix DRL panic on gateway start (#3997)
- [TT-4994] Middleware: ensure that session with applied policies is returned. (#3993)
- Crrts should not be a go module
- Remove certs package from go.mod
- Fix: deduplicate versions and methods, fix incorrect policy test (#4002)
- Implement disabled field to validate json plugin (#4006)
- fix race condition in Test_loadOASSchema (#3980)
- when adding a new certificate check if exists by using the Exist method and not Get (#4003)
- exit CI when gofmt is not clean (#3946)
- [CI] Syncing release automation from master
- [TT-4793] request and res log obfuscation (#3981)
- [TT-4839] Add x-tyk-api-gateway-schema in OAS validator (#3996)
- [TT-5094] Implement validate request middleware in OAS (#4007)
- [TT-4815] Updating graphql-go-tools commit hash (#4008)
- Add validateRequest plugin schema (#4010)
- [TT-5107] exit on faulty go generate (#4000)
- [TT-5121] modify X-Tyk-Operations to have patternProperties for key (#4013)
- Backporting https://github.com/TykTechnologies/tyk/pull/4015 changes (#4018)
- [TT-5160] Update OAS servers object while api creation or addition (#4024)
- fix x-tyk-api-schema - securitySchemes, cors.enabled (#4031)
- [TT-1563] Add segment tags on oas api (#4030)
- [CI] Syncing release automation from master
- user: ensure that key_id is not present in Redis session object (#4032)
- [release-4] Updating graphql-go-tools commit hash [changelog] internal: Updating graphql-go-tools commit hash.
- [TT-5160] add default listenaddress, consider 80 port when configured in GetAPIURL (#4033)
- Add domain to OAS spec (#4025)
- [TT-5199] Updating graphql-go-tools commit hash (#4036)
- [CI] Syncing release automation from master
- [TT-5212] add BuildDefaultTykExtension to build tyk extension from simple OAS (#4039)
- cherry picked ce745192
- Initialize DefaultOrgStore in NewGateway func (#4048)
- [TT-5192] [TT-4816] [TT-5117] Update graphql-to-tools (#4046)
- [TT-5307] update jaeger-client-go (#4049)
- export API in OAS format (#4037)
- Fix resource leak in config.Load, close file handle (#4042)
- TT-3879 Bugfix allow_explicit_policy_id on edge gateways (#4052)
- [CI] Syncing release automation from master
- add customDomain to be configured with simple OAS (#4060)
- [TT-5371] OAS patch endpoint (#4062)
- [TT-5368] added endpoint DELETE /apis/oas/{apiID} (#4068)
- [TT-5450] update swagger (#4069)
- import oas (#4065)
- [TT-5375] Add is_oas flag to APIDefinition (#4067)
- [TT-5398] Implement OAS apiKey scheme import (#4063)
- [TT-5406, TT-5407] simple OAS middlewares (allowList, validateRequest) (#4064)
- update opeations OAS schema to have a string instead of string starting with / (#4076)
- Implement OAS jwt security scheme import (#4077)
- Implement OAS oauth security scheme import (#4080)
- [TT-5506] fix OAS servers in patch (#4083)
- Fix security scheme unmarshalling (#4084)
- import OAS, get apiID from query (#4075)
- do not configure upstreamURL form servers if it's already present in x-tyk-api-gw (#4089)
- Implement OAS basic security scheme import (#4081)
- Add authentication bool param to import oas endpoint (#4088)
- Fix import oas api params (#4090)
- swagger doc for import OAS (#4072)
- change validate request default error response code to 422 (#4096)
- [release-4] Updated graphql-go-tools commit hash
- TT-5376 HTTPServerOptions Certificate custom env decoder (#3716)
- Implement base identity provider precedence during OAS import (#4093)
- persist schema object during encodeForDB (#4095)
- ignore ValidatePathMeta.Schema from datastore (#4099)
- [TT-3972] Mark/skip problematic tests, resolve some root issues (#4035)
- Fix: revert pubsub.Channel back to pubsub.Message, context/timeout adjustments (#4079)
- Fix: nil panic for groupResetHandler in tests (#4086)
- Handle security scheme map conditions (#4100)
- add API ID if not provided while creating an API (#4101)
- enable OAS payload validation for OAS endpoints (#4106)
- [CI] Syncing release automation from master
- do not return error when api id is not provided while importing OAS (#4109)
- Change oas import path to be consistent (#4107)
- [TT-3154] Fix stripping listen path when it contains regexp (#4104)
- Prevent expiration parse error for old APIs (#4111)
- Return error when user imports payload with x-tyk-api-gateway (#4113)
- Return error if post/put oas doesn't include x-tyk-api-gateway (#4114)
- [TT-5577] strip listen path by default on OAS import (#4112)
- toggle custom domain (#4115)
- bugfix: fixing mTLS logic for APIs with same domain and different mTLS rules (#4097)
- Don't clear OAS paths to nil if empty (#4116)
- [TT-1666] fix: don't match /foobar with /foo routes (#4017)
- use OAS schema minor versions instead of patch. (#4117)
- Fix the panic when analytics plugin enabled (#4118)
- return when create/update request comes in dashboard mode. (#4121)
- Fix TestValidateRequest passing mistakenly (#4120)
- [TT-5279] Updated graphql-go-tools commit hash (#4124)
- Honor EnableTags when loading apis (#4123)
- Add extra test case to path regex match (#4125)
- block import API in dashboard mode. (#4131)
- Omit gateway tags if empty (#4127)
- python: avoid api_id reference on MiddlewareLoader
- adjust OAS contract onKeyChangeURL to onKeyChangeUrl to be in consistent with OAS namings. (#4133)
- Fix the oas schema of versioning (#4136)
- TT-5714 ConnectToRedis RedisController fixes (#4134)
- [TT-5746] change upstream mTLS contract. (#4137)
- Add missing session lifetime function test (#4141)
- update graphql go tools for TT-5563 (#4143)
- [TT-5747] update certificate pinning OAS contract (#4140)
- Update graphql go tools (#4145)
- Fix broken OAS paths and operations extraction (#4146)
- Add extra oas validation from getkin library (#4151)
- Make validate request working for OSS users (#4150)
- Resolve OAS reference loaded from dashboard (#4154)
- Validate just oas request body (#4155)
- [TT-5823] Log error instead of info when invalid api comes from dashboard (#4156)
- [TT-5396] Add ability to select basic authentication hashing function (#4070)
- [CI] Syncing release automation from master
- [TT-5880] Sanitize Release Versions (#4159)
- [TT-5396] default basicauth hash fix (#4162)
- auto extract xtyk oas doc (#4144)
- TT-5937 RPC analytics serialization bugfix (#4164)
- Refactor load of apis from dashboard (#4168)
- Load apis with OAS data from MDCB (#4169)
- [TT-5935] Add oas custom marshal function to handle SQL cases (#4171)
- kafka data source cherry pick and import path renaming (#4174)
- [TT-5316] Fix incorrect context value panic (#4153)
- fix token for gh action (#4177)
- [TT-6057] fix OAS validate request middleware error with strict hostname matching. (#4185)
- [TT-5962] [TT-5704] (#4190)
- Add flags to make session lifetime respects key expiration (#4119)
- Remove omitempty from 'enabled' fields in OAS (#4194)
- Respect custom error response code in validate request (#4200)
- [TT-3973] Fix/flaky hmac tests (#4199)
- Honor tags on loadRPC apidef load code paths (#4187)
- changing secrets.TYK_ANALYTICS_TOKEN for secrets.ORG_GH_TOKEN
- [TT-5262] add dialCtxFn in gw to test. (#4176)
- [CI] Syncing release automation from master
- [TT-2332] modify auth token fetch to rely only on UseParam or UseCookie (#3837)
- Add disabled flag to body transform endpoint plugin (#3831)
- [TT-4852] implement transform request body OAS contract. (#4210)
- Behave session.Expires as unix (#4212)
- [TT-1313] Implement additional circuit breaker events (#4158)
- [CI] Syncing release automation from master
- Omit path and body when they are empty (#4220)
- TT-6162 on setting session lifetime, consider the sessionlifetime set at api level (#4217)
- [TT-5187] Add Dockerfile, docker-compose.yml (#3988)
- [TT-3904] fix chunked body logging (#3861) (#4225)
- fix json marshalling for OAS extensions. (#4227)
- [TT-6022] Kafka data source should subscribe to multiple topics (#4233)
- Revert "[TT-3904] fix chunked body logging (#3861)" (#4238)
- Add compressed/chunked response tests (#4239)
- Fix chunked response logging (#4241)
- add api schema to error handler and success handler (#4243)
- Revert "add api schema to error handler and success handler (#4243)" (#4247)
- TT-5555 Adding omitempty json tag to new non-required fields (#4244)
- TT-5980 Add custom environment variable decoder for '.ports_whitelist' (#4166)
- Fix MutualTLS server side behaviour, fix TT-5249 flaky test, extend MutualTLS tests (#4237)
- added flag to pull oas data in apidef (#4207)
- TT-6290 on updated key signal do not pull the key if not exist locally (#4232)
- mw_js_plugin: trigger middleware error when JSVM isn't enabled (#4206)
- TT-2356 Caching default expiration time if org is not found (#4275)
- [TT-4083] upgrade go version (#4261)
- [TT-6400] Field based permissions whitelisting - Define better struct for RestrictedTypes (#4271)
- [TT-5665] Allow list for field based permissions implement for allowing fields (#4288)
- add api schema to analytics record (#4285)
- Remove OAS mock response conversions (#4301)
- Bump goverify module (#4226)
- TT-6407 Edge key quota reset bugfix (#4300)
- [TT-6588] Move oas preparation to MakeSpec function (#4302)
- use go embed instead of go bindata to embed static files. (#4286)
- [TT-6110] Updated graphql-go-tools commit hash (#4311)
- [TT-6568] Ability to turn off introspection for a graph (#4315)
- update graphql go tools (#4316)
- Implement OAS mock response (#4303)
- [TT-6093] Ensure headers are updated from response middleware (#4193)
- [TT-6658] Implement getting mock response from OAS (#4318)
- [TT-5852]added sub request id to request (#4313)
- Implement OAS schema extractor (#4320)
- [TT-6663] Extract mock response headers from OAS response doc (#4321)
- [TT-6635] Fix/jsvm memory usage (#4249)
- Add OAS mock response schema (#4324)
- Handle mock response listen path matching (#4328)
- Remove not necessary commented backup code (#4326)
- Add GoDoc for Mock Response (#4325)
- Add the skeleton for external OAuth middleware (#4344)
- [TT-6110] Updated graphql-go-tools commit hash (#4333)
- [TT-6669] Updated graphql-go-tools commit hash (#4342)
- [TT-6669] Use IsIntrospectionQueryStrict to check introspection queries (#4345)
- [TT-6697] External oauth jwt (#4347)
- Fix/tt 6168/investigate possible issue with batching requests to subgraphs in graph ql api federation setting (#4341)
- Implement external OAuth introspection (#4348)
- Implement external OAuth OAS conversions (#4352)
- TT-1799 - in case of error in signing method show proper error message (#3751)
- add configurations for new subscription protocols (#4351)
- fix chaining external native API to internal OAS API. (#4358)
- [TT-6737] [TT-6798] Updated graphql-go-tools commit hash (#4362)
- [TT-6502] working around memory allocations in restricted memory environments, rewriting nopCloser (#4299)
- Implement OAuth introspection redis cache (#4356)
- [TT-6933] Implement introspection cache OAS conversion (#4369)
- Add GoDoc for OAS OAuth introspection fields (#4370)
- add subscription type cfg for proxy-only and fix federation cfg gen (#4367)
- [TT-6575] feat: persisted queries (#4359)
- [TT-6927] Improving DX with make lint, add faillint, PR template update (#4314)
- [TT-5744] OAS docs updates (#4327)
- [TT-6927] Improvement/goimports local (#4329)
- [TT-6454] modify OAS servers methods. (#4373)
- change OAS AddServers signature to return error. (#4375)
- [TT-6919] Feature/introspection exp check (#4376)
- Check whether introspection has exp val (#4381)
- add omitempty to SubscriptionType (#4382)
- Add hidden version base id (#4383)
- Remove version change actions from apidef (#4386)
- Revert "change OAS AddServers signature to return error. (#4375)" (#4387)
- fix non-working single flight (#4402) (#4404)
- Convert Error log to Debug in JWT API while searching OAuth client (#4406) (#4410)
- Change swagger version to 4.3 (#4423)
- Change swagger version to 4.3.0 (#4426)
- Ensure that version used my plugin loader has the correct syntax (#4417) (#4427)
- Fix middleware order, enabling virtual endpoint caching and cache control from jsvm (#4397) (#4431)
- Fix the panic while loading Go-plugin (#4416) (#4435)
- Load go plugins that contains the prefix V (#4444)


[TT-3880]: https://tyktech.atlassian.net/browse/TT-3880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TT-3881]: https://tyktech.atlassian.net/browse/TT-3881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TT-3965]: https://tyktech.atlassian.net/browse/TT-3965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TT-640]: https://tyktech.atlassian.net/browse/TT-640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ