### PR TITLE
Load go plugins that contains the prefix V (#4444)

### DIFF
--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -135,7 +135,18 @@ func (m *GoPluginMiddleware) loadPlugin() bool {
 
 	if !FileExist(m.Path) {
 		// if the exact name doesn't exist then try to load it using tyk version
+<<<<<<< HEAD
 		m.Path = m.goPluginFromTykVersion(VERSION)
+=======
+		newPath := m.getPluginNameFromTykVersion(VERSION)
+
+		prefixedVersion := getPrefixedVersion(VERSION)
+		if !FileExist(newPath) && VERSION != prefixedVersion {
+			// if the file doesn't exist yet, then lets try with version in the format: v.x.x.x
+			newPath = m.getPluginNameFromTykVersion(prefixedVersion)
+		}
+		m.Path = newPath
+>>>>>>> cf54fe53... Load go plugins that contains the prefix V (#4444)
 	}
 
 	if m.handler, err = goplugin.GetHandler(m.Path, m.SymbolName); err != nil {

--- a/gateway/util.go
+++ b/gateway/util.go
@@ -117,6 +117,7 @@ func greaterThanInt(first, second int) bool {
 
 func FileExist(filepath string) bool {
 	if _, err := os.Stat(filepath); errors.Is(err, os.ErrNotExist) {
+		log.Warningf("plugin file %v doesn't exist", filepath)
 		return false
 	}
 	return true


### PR DESCRIPTION
* the plugin path was modified multiple times, ending up in a nonsense path and not loading the plugin

(cherry picked from commit cf54fe538d59c059df4e858f0faa1a7535ba970b)

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
