### PR TITLE
Load go plugins that contains the prefix V (#4444)

### DIFF
--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -135,7 +135,18 @@ func (m *GoPluginMiddleware) loadPlugin() bool {
 
 	if !FileExist(m.Path) {
 		// if the exact name doesn't exist then try to load it using tyk version
+<<<<<<< HEAD
 		m.Path = m.goPluginFromTykVersion(VERSION)
+=======
+		newPath := m.getPluginNameFromTykVersion(VERSION)
+
+		prefixedVersion := getPrefixedVersion(VERSION)
+		if !FileExist(newPath) && VERSION != prefixedVersion {
+			// if the file doesn't exist yet, then lets try with version in the format: v.x.x.x
+			newPath = m.getPluginNameFromTykVersion(prefixedVersion)
+		}
+		m.Path = newPath
+>>>>>>> cf54fe53... Load go plugins that contains the prefix V (#4444)
 	}
 
 	if m.handler, err = goplugin.GetHandler(m.Path, m.SymbolName); err != nil {

--- a/gateway/util.go
+++ b/gateway/util.go
@@ -117,6 +117,7 @@ func greaterThanInt(first, second int) bool {
 
 func FileExist(filepath string) bool {
 	if _, err := os.Stat(filepath); errors.Is(err, os.ErrNotExist) {
+		log.Warningf("plugin file %v doesn't exist", filepath)
 		return false
 	}
 	return true


### PR DESCRIPTION
Load go plugins that contains the prefix V (#4444)

* the plugin path was modified multiple times, ending up in a nonsense path and not loading the plugin