### PR TITLE
Merging to release-4-lts: [TT-7124] Fix pointer error (#4291)

### DIFF
--- a/gateway/server.go
+++ b/gateway/server.go
@@ -1011,11 +1011,6 @@ func (gw *Gateway) setupLogger() {
 		}
 
 		hook, err := logrus_sentry.NewSentryHook(gwConfig.SentryCode, logLevel)
-<<<<<<< HEAD
-		hook.Timeout = 0
-=======
->>>>>>> 1beafa06... [TT-7124] Fix pointer error (#4291)
-
 		if err == nil {
 			hook.Timeout = 0
 			log.Hooks.Add(hook)

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -1011,9 +1011,13 @@ func (gw *Gateway) setupLogger() {
 		}
 
 		hook, err := logrus_sentry.NewSentryHook(gwConfig.SentryCode, logLevel)
+<<<<<<< HEAD
 		hook.Timeout = 0
+=======
+>>>>>>> 1beafa06... [TT-7124] Fix pointer error (#4291)
 
 		if err == nil {
+			hook.Timeout = 0
 			log.Hooks.Add(hook)
 			rawLog.Hooks.Add(hook)
 		}


### PR DESCRIPTION
[TT-7124] Fix pointer error (#4291)

`logrus_sentry.NewSentryHook` returns a pointer to a `SentryHook`.
Simply passing a malformed DSN will result in `SentryHook` being `nil`
which we then call `hook.Timeout` resulting in a pointer dereference
error

[TT-7124]: https://tyktech.atlassian.net/browse/TT-7124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ