### PR TITLE
[TT-7323] log only when file close errors out.

### DIFF
--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -677,7 +677,9 @@ func (a APIDefinitionLoader) loadDefFromFilePath(filePath string) (*APISpec, err
 	f, err := os.Open(filePath)
 	defer func() {
 		err = f.Close()
-		log.Error("error while closing file ", filePath)
+		if err != nil {
+			log.WithError(err).Error("error while closing file ", filePath)
+		}
 	}()
 
 	if err != nil {


### PR DESCRIPTION
[changelog]
internal: log only when file close errors out.

<!-- Provide a general summary of your changes in the Title above -->

## Description

Log only when file close errors out.

## Related Issue
https://tyktech.atlassian.net/browse/TT-7323