### PR TITLE
Merging to release-4-lts: [TT-6419] Querying for __typename in any graph causes a 502 error (#4501)

### DIFF
--- a/gateway/mw_graphql_test.go
+++ b/gateway/mw_graphql_test.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -204,6 +205,31 @@ func TestGraphQLMiddleware_EngineMode(t *testing.T) {
 				{Data: countries1, BodyMatch: `"There was a problem proxying the request`, Code: http.StatusInternalServerError},
 			}...)
 		})
+	})
+
+	t.Run("Inspect __typename without hitting the upstream", func(t *testing.T) {
+		// See TT-6419
+		g := StartTest(nil)
+		defer g.Close()
+
+		g.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+			spec.UseKeylessAccess = true
+			spec.Proxy.ListenPath = "/"
+			spec.GraphQL.Enabled = true
+			spec.GraphQL.ExecutionMode = apidef.GraphQLExecutionModeExecutionEngine
+			spec.GraphQL.Version = apidef.GraphQLConfigVersion2
+		})
+
+		request := gql.Request{
+			Variables: nil,
+			Query:     "query { __typename }",
+		}
+
+		expectedBody := []byte(`{"data":{"__typename":"Query"}}`)
+		_, _ = g.Run(t, test.TestCase{Data: request, BodyMatchFunc: func(body []byte) bool {
+			return bytes.Equal(expectedBody, body)
+		},
+			Code: http.StatusOK})
 	})
 
 	t.Run("graphql engine v2", func(t *testing.T) {

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -1037,8 +1037,15 @@ func (p *ReverseProxy) handoverRequestToGraphQLExecutionEngine(roundTripper *Tyk
 
 		if isProxyOnly {
 			proxyOnlyCtx := reqCtx.(*GraphQLProxyOnlyContext)
-			header = proxyOnlyCtx.upstreamResponse.Header
-			httpStatus = proxyOnlyCtx.upstreamResponse.StatusCode
+			// There is a case in the proxy-only mode where the request can be handled
+			// by the library without calling the upstream.
+			// This is a valid query for proxy-only mode: query { __typename }
+			// In this case, upstreamResponse is nil.
+			// See TT-6419 for further info.
+			if proxyOnlyCtx.upstreamResponse != nil {
+				header = proxyOnlyCtx.upstreamResponse.Header
+				httpStatus = proxyOnlyCtx.upstreamResponse.StatusCode
+			}
 		}
 
 		res = resultWriter.AsHTTPResponse(httpStatus, header)


### PR DESCRIPTION
[TT-6419] Querying for __typename in any graph causes a 502 error (#4501)

This PR fixes an edge case in proxy-only mode. When you run the
following query:

```graphql
query { __typename }
```

The GW panics and returns 502 for the request because the recent version
of graphql-go-tools can handle this query without hitting the upstream.
It maintains the type names internally.

See https://github.com/TykTechnologies/graphql-go-tools/pull/323 for
further info.