### PR TITLE
Merging to release-4.3: TT-7248 Added backoff algorithm to pull the plugin bundles.  (#4513)

### DIFF
--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -539,11 +539,7 @@ func (a APIDefinitionLoader) FromDashboardService(endpoint string) ([]*APISpec, 
 	apiDefs := list.filter(gwConfig.DBAppConfOptions.NodeIsSegmented, gwConfig.DBAppConfOptions.Tags...)
 
 	// Process
-	var specs []*APISpec
-	for _, def := range apiDefs {
-		spec := a.MakeSpec(&def, nil)
-		specs = append(specs, spec)
-	}
+	specs := a.prepareSpecs(apiDefs, gwConfig, false)
 
 	// Set the nonce
 	a.Gw.ServiceNonceMutex.Lock()
@@ -605,25 +601,34 @@ func (a APIDefinitionLoader) processRPCDefinitions(apiCollection string, gw *Gat
 	// Extract tagged entries only
 	apiDefs := list.filter(gwConfig.DBAppConfOptions.NodeIsSegmented, gwConfig.DBAppConfOptions.Tags...)
 
+	specs := a.prepareSpecs(apiDefs, gwConfig, true)
+
+	return specs, nil
+}
+
+func (a APIDefinitionLoader) prepareSpecs(apiDefs []nestedApiDefinition, gwConfig config.Config, fromRPC bool) []*APISpec {
 	var specs []*APISpec
+
 	for _, def := range apiDefs {
-		def.DecodeFromDB()
+		if fromRPC {
+			def.DecodeFromDB()
 
-		if gwConfig.SlaveOptions.BindToSlugsInsteadOfListenPaths {
-			newListenPath := "/" + def.Slug //+ "/"
-			log.Warning("Binding to ",
-				newListenPath,
-				" instead of ",
-				def.Proxy.ListenPath)
+			if gwConfig.SlaveOptions.BindToSlugsInsteadOfListenPaths {
+				newListenPath := "/" + def.Slug //+ "/"
+				log.Warning("Binding to ",
+					newListenPath,
+					" instead of ",
+					def.Proxy.ListenPath)
 
-			def.Proxy.ListenPath = newListenPath
+				def.Proxy.ListenPath = newListenPath
+			}
 		}
 
 		spec := a.MakeSpec(&def, nil)
 		specs = append(specs, spec)
 	}
 
-	return specs, nil
+	return specs
 }
 
 func (a APIDefinitionLoader) ParseDefinition(r io.Reader) (api apidef.APIDefinition) {

--- a/gateway/coprocess_bundle_test.go
+++ b/gateway/coprocess_bundle_test.go
@@ -4,10 +4,14 @@ import (
 	"crypto/md5"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/test"
@@ -241,4 +245,56 @@ func TestResponseOverride(t *testing.T) {
 	t.Run("JSVM", func(t *testing.T) {
 		testOverride(t, ts.RegisterBundle("jsvm_override", overrideResponseJSVM))
 	})
+}
+
+func TestPullBundle(t *testing.T) {
+
+	testCases := []struct {
+		name             string
+		expectedAttempts int
+		shouldErr        bool
+	}{
+		{
+			name:             "bundle downloaded at first attempt",
+			expectedAttempts: 1,
+			shouldErr:        false,
+		},
+		{
+			// failed the 2 first times
+			name:             "bundle downloaded at third attempt",
+			expectedAttempts: 3,
+			shouldErr:        false,
+		},
+		{
+			// should try 5 times, afterwards it will fail
+			name:             "bundle download failed",
+			expectedAttempts: 5,
+			shouldErr:        true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			attempts := 0
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				attempts++
+				if tc.expectedAttempts > attempts || tc.shouldErr {
+					// simulate file not found, so it will throw err
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer ts.Close()
+
+			getter := &HTTPBundleGetter{
+				URL:                ts.URL,
+				InsecureSkipVerify: false,
+			}
+			_, err := pullBundle(getter, 0)
+
+			didErr := err != nil
+			assert.Equal(t, tc.expectedAttempts, attempts)
+			assert.Equal(t, tc.shouldErr, didErr)
+		})
+	}
 }


### PR DESCRIPTION
TT-7248 Added backoff algorithm to pull the plugin bundles.  (#4513)

<!-- Provide a general summary of your changes in the Title above -->

## Description

Currently if the gateway cannot pull a plugin bundle then it just throw
error and continue processing the next api definition. In this PR was
introduced a new behavior, the gateway will attempt to download the
bundle, of it fails then it will try until 4 more times, the timeframe
between one attempt and the other is defined by an exponential backoff
described
[here](https://pkg.go.dev/github.com/cenkalti/backoff#NewExponentialBackOff)

~~Now when an API will load a bundle, it's processed async so the
loading of the other apis is not blocked by this one.~~

## Related Issue

https://tyktech.atlassian.net/browse/TT-7248

## Motivation and Context

Provide a better response when downloading the bundles fails for
external causes

## How This Has Been Tested

- Added unit test for backoff algorithm
- in Dash+GW setup: created apis, one of them with bundle
plugin...finally check that all the apis are reachable

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why