### PR TITLE
[TT-7393] Add public function to directly access the Redis Universal Client

### DIFF
--- a/storage/redis_cluster.go
+++ b/storage/redis_cluster.go
@@ -138,6 +138,10 @@ func (r *RedisCluster) singleton() redis.UniversalClient {
 	return r.RedisController.singleton(r.IsCache, r.IsAnalytics)
 }
 
+func (r *RedisCluster) GetUniversalClient() redis.UniversalClient {
+	return r.singleton()
+}
+
 func (r *RedisCluster) hashKey(in string) string {
 
 	if !r.HashKeys {


### PR DESCRIPTION
## Description

Expose direct access to the underlying Redis Universal Client via `GetUniversalClient`

## Related Issue

https://github.com/TykTechnologies/tyk/issues/4545

## Motivation and Context

This is needed for plugin developers (in some cases) to issue commands that are not supported by the storage abstraction layer or have otherwise had their behavior changed. For example, it is not possible to issue a `SETEX` command. Similarly, the `MGET` command behaves differently and doesn't work in cases where some keys are expected to be missing.

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
