### PR TITLE
Merging to release-4: [TT-7323] log only when file close errors out. (#4517)

### DIFF
--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -677,7 +677,9 @@ func (a APIDefinitionLoader) loadDefFromFilePath(filePath string) (*APISpec, err
 	f, err := os.Open(filePath)
 	defer func() {
 		err = f.Close()
-		log.Error("error while closing file ", filePath)
+		if err != nil {
+			log.WithError(err).Error("error while closing file ", filePath)
+		}
 	}()
 
 	if err != nil {


### PR DESCRIPTION
[TT-7323] log only when file close errors out. (#4517)

[changelog]
internal: log only when file close errors out.

<!-- Provide a general summary of your changes in the Title above -->

## Description

Log only when file close errors out.

## Related Issue
https://tyktech.atlassian.net/browse/TT-7323

[TT-7323]: https://tyktech.atlassian.net/browse/TT-7323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ