### PR TITLE
[TT-7415] check if schema/example/examples is configured in OAS before enabling mockResponse.

### DIFF
--- a/apidef/oas/operation.go
+++ b/apidef/oas/operation.go
@@ -539,7 +539,21 @@ type FromOASExamples struct {
 }
 
 func (m *MockResponse) shouldImport(operation *openapi3.Operation) bool {
-	return len(operation.Responses) > 0
+	for _, response := range operation.Responses {
+		for _, content := range response.Value.Content {
+			if content.Example != nil || content.Schema != nil {
+				return true
+			}
+
+			for _, example := range content.Examples {
+				if example.Value != nil {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
 }
 
 // Import populates *MockResponse with enabled argument for FromOASExamples.


### PR DESCRIPTION


[changelog]
internal: check if schema/example/examples is configured in OAS before enabling mockResponse.

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

## Related Issue
https://tyktech.atlassian.net/browse/TT-7415