### PR TITLE
TT-1781: Fix malformed analytics on proxying error

### DIFF
--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -1321,7 +1321,7 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 	}
 
 	if err != nil {
-
+		setContext(logreq, outreq.Context())
 		token := ctxGetAuthToken(req)
 
 		var alias string

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -1193,6 +1193,7 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 		outreq.Body = nil // Issue 16036: nil Body for http.Transport retries
 	}
 	outreq = outreq.WithContext(reqCtx)
+	setContext(logreq, outreq.Context())
 
 	outreq.Header = cloneHeader(req.Header)
 	if trace.IsEnabled() {
@@ -1321,7 +1322,6 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 	}
 
 	if err != nil {
-		setContext(logreq, outreq.Context())
 		token := ctxGetAuthToken(req)
 
 		var alias string


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
We currently use `logreq` in our reverse proxy for error analytics. The problem is that we [empty](https://github.com/TykTechnologies/tyk/blob/master/gateway/reverse_proxy.go#L1182) the `logreq`context and we never fill it again. So whenever the proxying has an error ( context canceled, incorrect host, CB triggered, timeout, etc), the analytics data are malformed since it doesn't contain anything in its context and some data is extracted from there, like the[ APIKey used ](https://github.com/TykTechnologies/tyk/blob/master/gateway/handler_error.go#L218).

This PR simply copies the `outreq` context to the `logreq` in its last setting point https://github.com/TykTechnologies/tyk/blob/master/gateway/reverse_proxy.go#L1195

There's a lot of room of improvement here (removing `logreq` and using `outreq` for everything, for example) but it's out of scope of this PR.

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
