### PR TITLE
Merging to release-4.3: TT-7351 changed precedence on how plugins are picked (#4576)

### DIFF
--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -117,10 +117,10 @@ func (m *GoPluginMiddleware) EnabledForSpec() bool {
 	return false
 }
 
-// loadPlugin loads the plugin file from m.Path, it will try with:
-// m.path which can be {plugin_name}.so
-// if the file doesn't exist then it will try converting it to the tyk version aware format: {plugin_name}_{tyk_version}_{os}_{arch}.so
-// later if the file still doesn't exist then it will try again but ensuring that the version contains the prefix 'v'
+// loadPlugin loads the plugin file from m.Path, it will try
+//converting it to the tyk version aware format: {plugin_name}_{tyk_version}_{os}_{arch}.so
+// if the file doesn't exist then it will again but with a gw version that is not prefixed by 'v'
+// later, it will try with m.path which can be {plugin_name}.so
 func (m *GoPluginMiddleware) loadPlugin() bool {
 	m.logger = log.WithFields(logrus.Fields{
 		"mwPath":       m.Path,
@@ -135,7 +135,11 @@ func (m *GoPluginMiddleware) loadPlugin() bool {
 	// try to load plugin
 	var err error
 
-	newPath := goplugin.GetPluginFileNameToLoad(m.Path, VERSION)
+	newPath, err := goplugin.GetPluginFileNameToLoad(m.Path, VERSION)
+	if err != nil {
+		m.logger.WithError(err).Error("plugin file not found")
+		return false
+	}
 	if m.Path != newPath {
 		m.Path = newPath
 	}

--- a/gateway/mw_go_plugin_test.go
+++ b/gateway/mw_go_plugin_test.go
@@ -1,0 +1,18 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestLoadPlugin test the function to load a middleware goplugin
+// ToDo: find out how to successfully load a plugin for testing
+func TestLoadPlugin(t *testing.T) {
+	plugin := GoPluginMiddleware{
+		Path: "/any-fake-path",
+	}
+
+	pluginLoaded := plugin.loadPlugin()
+	assert.Equal(t, false, pluginLoaded)
+}

--- a/gateway/res_handler_go_plugin.go
+++ b/gateway/res_handler_go_plugin.go
@@ -41,13 +41,16 @@ func (h *ResponseGoPluginMiddleware) Init(c interface{}, spec *APISpec) error {
 		return nil
 	}
 
-	newPath := goplugin.GetPluginFileNameToLoad(h.Path, VERSION)
+	newPath, err := goplugin.GetPluginFileNameToLoad(h.Path, VERSION)
+	if err != nil {
+		h.logger.WithError(err).Error("Could not load Go-plugin. File was not found")
+		return err
+	}
 	if h.Path != newPath {
 		h.Path = newPath
 	}
 
 	// try to load plugin
-	var err error
 	if h.ResHandler, err = goplugin.GetResponseHandler(h.Path, h.SymbolName); err != nil {
 		h.logger.WithError(err).Error("Could not load Go-plugin")
 		return err

--- a/gateway/res_handler_go_plugin_test.go
+++ b/gateway/res_handler_go_plugin_test.go
@@ -1,0 +1,23 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk/apidef"
+)
+
+func TestResponseGoPluginMiddlewareInit(t *testing.T) {
+	plugin := ResponseGoPluginMiddleware{
+		Path: "/any-fake-path",
+	}
+
+	middlewareDefinition := apidef.MiddlewareDefinition{
+		Path: "any-path",
+		Name: "fake middleware definition name",
+	}
+	err := plugin.Init(middlewareDefinition, &APISpec{})
+
+	assert.Error(t, err)
+}

--- a/goplugin/plugin_name_builder.go
+++ b/goplugin/plugin_name_builder.go
@@ -1,6 +1,7 @@
 package goplugin
 
 import (
+	"errors"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -11,21 +12,31 @@ var pluginStorage storage
 
 // GetPluginFileNameToLoad check which file to load based on name, tyk version, os and architecture
 // but it also takes care of returning the name of the file that exists
-func GetPluginFileNameToLoad(path string, version string) string {
-	if !pluginStorage.fileExist(path) {
-		// if the exact name doesn't exist then try to load it using tyk version
-		newPath := getPluginNameFromTykVersion(version, path)
+func GetPluginFileNameToLoad(path string, version string) (string, error) {
 
-		prefixedVersion := getPrefixedVersion(version)
+	prefixedGwVersion := getPrefixedVersion(version)
+	newNamingFormat := getPluginNameFromTykVersion(prefixedGwVersion, path)
 
-		if !pluginStorage.fileExist(newPath) && version != prefixedVersion {
-			// if the file doesn't exist yet, then lets try with version in the format: v.x.x.x
-			newPath = getPluginNameFromTykVersion(prefixedVersion, path)
-		}
-		path = newPath
+	// 1. attempt to load a plugin that follow the new standard
+	if pluginStorage.fileExist(newNamingFormat) {
+		return newNamingFormat, nil
 	}
 
-	return path
+	// 2. attempt to load a plugin that follows the new standard but gw version is not prefixed
+	if !strings.HasPrefix(version, "v") {
+		newNamingFormat = getPluginNameFromTykVersion(version, path)
+
+		if pluginStorage.fileExist(newNamingFormat) {
+			return newNamingFormat, nil
+		}
+	}
+
+	// 3. attempt to load the exact name provided
+	if !pluginStorage.fileExist(path) {
+		return "", errors.New("plugin file not found")
+	}
+
+	return path, nil
 }
 
 // getPluginNameFromTykVersion builds a name of plugin based on tyk version

--- a/goplugin/plugin_name_builder_test.go
+++ b/goplugin/plugin_name_builder_test.go
@@ -43,7 +43,7 @@ func TestGetPluginFileNameToLoad(t *testing.T) {
 		{
 			name:             "base name file exist",
 			pluginName:       "myplugin.so",
-			files:            []string{"myplugin.so", "myplugin_v4.1.0_" + OSandArch + ".so", "myplugin_v4.1.0_linux_amd64.so", "myplugin", "anything-else"},
+			files:            []string{"myplugin.so", "myplugin", "anything-else"},
 			expectedFileName: "myplugin.so",
 			version:          gwVersion,
 		},
@@ -58,7 +58,7 @@ func TestGetPluginFileNameToLoad(t *testing.T) {
 			// in some point we had an issue where name loaded didn't contain prefix v. So we keep it for backward compatibility
 			name:             "exist plugin file that follows new formatting but gw version without prefix v",
 			pluginName:       "myplugin.so",
-			files:            []string{"myplugin_4.1.0_" + OSandArch + ".so", "myplugin_v4.1.0_" + OSandArch + ".so", "myplugin_v4.1.0_linux_amd64.so", "myplugin", "anything-else"},
+			files:            []string{"myplugin_4.1.0_" + OSandArch + ".so", "myplugin", "anything-else", "myplugin.so"},
 			expectedFileName: "./myplugin_4.1.0_" + OSandArch + ".so",
 			version:          gwVersionWithoutPrefix,
 		},
@@ -77,7 +77,7 @@ func TestGetPluginFileNameToLoad(t *testing.T) {
 				files: testCase.files,
 			}
 
-			filenameToLoad := GetPluginFileNameToLoad(testCase.pluginName, testCase.version)
+			filenameToLoad, _ := GetPluginFileNameToLoad(testCase.pluginName, testCase.version)
 			assert.Equal(t, testCase.expectedFileName, filenameToLoad)
 		})
 	}


### PR DESCRIPTION
TT-7351 changed precedence on how plugins are picked (#4576)

<!-- Provide a general summary of your changes in the Title above -->

## Description

Changed precedence on how goplugins are picked to be loaded. It used to
be:

1. exact name provided by user
2. new naming convention with unprefixed gw version
3. new naming convention

Now it was modified to be:

1. New naming convention
2. New naminf convention with unprefixed gw version
3. exact name provided by user

In this way it will always attempt to load a compatible plugin and will
avoid crashes when is found a file that is not intended to be used by
that version of gw

## Related Issue

https://tyktech.atlassian.net/browse/TT-7351

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

- Added unit tests
- Manual testing. In a single directory have 3 plugins files which name
is: `myplugin.so`,
`myplugin_v4.3.0_darwin_amd64.so`,`myplugin_4.3.0_darwin_amd64.so`
- Create an api that uses a goplugin which name is `myplugin.so`
- The plugin `myplugin_v4.3.0_darwin_amd64.so` should be picked
- Remove the file `myplugin_v4.3.0_darwin_amd64.so` (if you use bundles
then remove any local cache, check the directory set in the gw config
`middleware_path`+bundles)
- Restart the gateway , the file `myplugin_4.3.0_darwin_amd64.so` should
be loaded
- Remove the file `myplugin_4.3.0_darwin_amd64.so` and restart the
gateway
- The file `myplugin.so` should be loaded

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why

Co-authored-by: Tomas Buchaillot <tombuchaillot89@gmail.com>