### PR TITLE
Merging to release-4.3: [TT-7450] Safely erase a sync.Map value (#4588)

### DIFF
--- a/gateway/host_checker.go
+++ b/gateway/host_checker.go
@@ -392,12 +392,21 @@ func (h *HostUptimeChecker) Start(ctx context.Context) {
 	log.Debug("[HOST CHECKER] Host reporter started...")
 }
 
+// eraseSyncMap uses native sync.Map functions to clear the map
+// without needing to unsafely modify the value to nil.
+func eraseSyncMap(m *sync.Map) {
+	m.Range(func(k, _ interface{}) bool {
+		m.Delete(k)
+		return true
+	})
+}
+
 func (h *HostUptimeChecker) Stop() {
 	if !h.getStopLoop() {
 		h.setStopLoop(true)
-		h.muStopLoop.Lock()
-		h.samples = new(sync.Map)
-		h.muStopLoop.Unlock()
+
+		eraseSyncMap(h.samples)
+
 		log.Info("[HOST CHECKER] Stopping poller")
 		h.pool.Close()
 	}


### PR DESCRIPTION
[TT-7450] Safely erase a sync.Map value (#4588)

<!-- Provide a general summary of your changes in the Title above -->

## Description

Accessing a sync.Map value is safe over the provided functions. Setting
a *sync.Map value to nil is unsafe.

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->
https://tyktech.atlassian.net/browse/TT-7450

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why

Co-authored-by: Tit Petric <tit@tyk.io>

[TT-7450]: https://tyktech.atlassian.net/browse/TT-7450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ