### PR TITLE
Merging to release-4: [TT-6137] Update graphql-go-tools commit hash (#4606)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/TykTechnologies/gojsonschema v0.0.0-20170222154038-dcb3e4bb7990
 	github.com/TykTechnologies/gorpc v0.0.0-20190515174534-b9c10befc5f4
 	github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708
-	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20221207092329-acdd20d63048
+	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230102111920-7ea949545272
 	github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c
 	github.com/TykTechnologies/murmur3 v0.0.0-20180602122059-1915e687e465
 	github.com/TykTechnologies/openid2go v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/TykTechnologies/gorpc v0.0.0-20190515174534-b9c10befc5f4/go.mod h1:vq
 github.com/TykTechnologies/goverify v0.0.0-20160822133757-7ccc57452ade/go.mod h1:mkS8jKcz8otdfEXhJs1QQ/DKoIY1NFFsRPKS0RwQENI=
 github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708 h1:cmXjlMzcexhc/Cg+QB/c2CPUVs1ux9xn6162qaf/LC4=
 github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708/go.mod h1:mkS8jKcz8otdfEXhJs1QQ/DKoIY1NFFsRPKS0RwQENI=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20221207092329-acdd20d63048 h1:p1otsVyn6x69u7hstadFoqqzf0E0V6DJBcd5hsAedoE=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20221207092329-acdd20d63048/go.mod h1:rs6RZamoJmz5oL5nOyQdzCdo87BzJyrSrug3r3ZHrFc=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230102111920-7ea949545272 h1:0q25dD2GQEAIzU8Kr5wGZazqTyGPwfI8R4SxWMP1+uw=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230102111920-7ea949545272/go.mod h1:rs6RZamoJmz5oL5nOyQdzCdo87BzJyrSrug3r3ZHrFc=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c h1:j6fd0Fz1R4oSWOmcooGjrdahqrML+btQ+PfEJw8SzbA=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c/go.mod h1:GnHUbsQx+ysI10osPhUdTmsxcE7ef64cVp38Fdyd7e0=
 github.com/TykTechnologies/murmur3 v0.0.0-20180602122059-1915e687e465 h1:A2gBjoX8aF0G3GHEpHyj2f0ixuPkCgcGqmPdKHSkW+0=


### PR DESCRIPTION
[TT-6137] Update graphql-go-tools commit hash (#4606)

[changelog]
internal: Updated graphql-go-tools commit hash.

[TT-6137]: https://tyktech.atlassian.net/browse/TT-6137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ