### PR TITLE
[TD-1413]: Add triggering of release workflow on tag push.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,10 @@ name: Release
 
 on:
   pull_request:
+  push:
     branches:
       - master
       - release-**
-      - integration/**
-      - feature/**
-      - perf/**
     tags:
       - 'v*'
 


### PR DESCRIPTION

## Description
This seemed to have been mistakenly removed as part of an earlier PR, reverting.
