### PR TITLE
Merging to release-4-lts: [TT-6965] Only set useSignature to true when bundleVerifier is not nil (#4572)

### DIFF
--- a/gateway/coprocess_bundle.go
+++ b/gateway/coprocess_bundle.go
@@ -47,7 +47,7 @@ func (b *Bundle) Verify() error {
 	}).Info("----> Verifying bundle: ", b.Spec.CustomMiddlewareBundle)
 
 	var useSignature bool
-	var bundleVerifier goverify.Verifier
+	bundleVerifier := b.Gw.NotificationVerifier
 
 	// Perform signature verification if a public key path is set:
 	if b.Gw.GetConfig().PublicKeyPath != "" {
@@ -55,14 +55,13 @@ func (b *Bundle) Verify() error {
 			// Error: A public key is set, but the bundle isn't signed.
 			return errors.New("Bundle isn't signed")
 		}
-		if b.Gw.NotificationVerifier == nil {
+		if bundleVerifier == nil {
 			var err error
 			bundleVerifier, err = goverify.LoadPublicKeyFromFile(b.Gw.GetConfig().PublicKeyPath)
 			if err != nil {
 				return err
 			}
 		}
-
 		useSignature = true
 	}
 
@@ -96,9 +95,7 @@ func (b *Bundle) Verify() error {
 		if err := bundleVerifier.Verify(bundleData.Bytes(), signed); err != nil {
 			return err
 		}
-
 	}
-
 	return nil
 }
 

--- a/gateway/coprocess_bundle_test.go
+++ b/gateway/coprocess_bundle_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/test"
 )
@@ -298,6 +299,65 @@ func TestPullBundle(t *testing.T) {
 			didErr := err != nil
 			assert.Equal(t, tc.expectedAttempts, attempts)
 			assert.Equal(t, tc.shouldErr, didErr)
+		})
+	}
+}
+
+func TestBundle_Verify(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		bundle  Bundle
+		wantErr bool
+	}{
+		{
+			name: "bundle with invalid public key path",
+			bundle: Bundle{
+				Name: "test",
+				Data: []byte("test"),
+				Path: "/test/test.zip",
+				Spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddlewareBundle: "test-mw-bundle",
+					},
+				},
+				Manifest: apidef.BundleManifest{
+					Signature: "test-signature",
+				},
+				Gw: &Gateway{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "bundle without signature",
+			bundle: Bundle{
+				Name: "test",
+				Data: []byte("test"),
+				Path: "/test/test.zip",
+				Spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddlewareBundle: "test-mw-bundle",
+					},
+				},
+				Manifest: apidef.BundleManifest{
+					Signature: "",
+				},
+				Gw: &Gateway{},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := tt.bundle
+
+			globalConf := config.Config{}
+			globalConf.PublicKeyPath = "test"
+			b.Gw.SetConfig(globalConf)
+
+			if err := b.Verify(); (err != nil) != tt.wantErr {
+				t.Errorf("Bundle.Verify() error = %v, wantErr %v", err, tt.wantErr)
+			}
 		})
 	}
 }


### PR DESCRIPTION
[TT-6965] Only set useSignature to true when bundleVerifier is not nil (#4572)

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->
Making sure that bundleVerifier is never nil to avoid panics.
## Related Issue

https://tyktech.atlassian.net/browse/TT-6965?atlOrigin=eyJpIjoiODNjYzkyZjgzNWFhNGViZjgzYzYzMjc3Y2U0MTNlOTQiLCJwIjoiaiJ9
<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested
It can be a little bit tricky to unit test this, so this PR has been
tested by creating a local Docker image of the current branch and
embedding it in a Tyk Demo instance. Follow these steps to test it
locally:

1. Modify `tyk/Dockerfile` in line 39, remove `RUN apt install python3
-y` and add this:
```
RUN apt update && apt install python3 python3-dev python3-pip -y
RUN pip3 install 'protobuf==3.20.0'
RUN pip3 install grpcio
```
2. (Only for M1 users) Go to Makefile and modify the line 103 from
`docker build --no-cache --rm -t internal/tyk-gateway --squash .` to
```
docker build --platform linux/x86_64 --no-cache --rm -t internal/tyk-gateway --squash .
``` 
This is required to make it work on M1 Macs.
3. Run `make docker` within Tyk directory
4. Go to Tyk Demo directory and modify all `tykio/tyk-gateway`
coincidences (including the tag) to `internal/tyk-gateway:latest`. In
that way, we’ll be using the local gateway image with the changes we
made.
List of files to modify:
     - scripts/add-gateway.sh
     - deployments/mdcb/docker-compose.yml
     - deployments/tyk/docker-compose.yml
     - deployments/tyk2/docker-compose.yml
5. Go to `scripts/common.sh `and modify
`gateway_image_tag=$(get_service_image_tag "tyk-gateway")` to
`gateway_image_tag=v4.3.0` . We are doing this because the local image
does not have a tag (well, the tag is “latest”, we could modify this
when creating the local image).
6. Run `./up.sh`. A _"Tyk Demo bootstrap completed"_ after finishing is
expected.
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


[TT-6965]:
https://tyktech.atlassian.net/browse/TT-6965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[TT-6965]: https://tyktech.atlassian.net/browse/TT-6965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TT-6965]: https://tyktech.atlassian.net/browse/TT-6965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ