### PR TITLE
[TD-1429] headers renamed for 5.0 only

### DIFF
--- a/ci/goreleaser/goreleaser-el7.yml
+++ b/ci/goreleaser/goreleaser-el7.yml
@@ -146,7 +146,7 @@ dockers:
     - dnscache
     - gateway
     - goplugin
-    - header
+    - headers
     - log
     - regexp
     - request

--- a/ci/goreleaser/goreleaser.yml
+++ b/ci/goreleaser/goreleaser.yml
@@ -153,7 +153,7 @@ dockers:
     - dnscache
     - gateway
     - goplugin
-    - header
+    - headers
     - log
     - regexp
     - request


### PR DESCRIPTION
https://github.com/TykTechnologies/tyk/pull/4567 should never have been merged to release-4.x branches as the rename was for 5.0.

This PR fixes the problem for 4.3.2 and the problem exists in release-4.3 as well.