### PR TITLE
[TT-5263] Fix flaky goplugin tests

### DIFF
--- a/bin/ci-tests.sh
+++ b/bin/ci-tests.sh
@@ -17,7 +17,7 @@ set -e
 
 # build Go-plugin used in tests
 echo "Building go plugin"
-go build -o ./test/goplugins/goplugins.so -buildmode=plugin ./test/goplugins
+go build -race -o ./test/goplugins/goplugins.so -buildmode=plugin ./test/goplugins
 
 for pkg in ${PKGS}; do
     tags=""

--- a/bin/ci-tests.sh
+++ b/bin/ci-tests.sh
@@ -28,7 +28,7 @@ for pkg in ${PKGS}; do
     coveragefile=`echo "$pkg" | awk -F/ '{print $NF}'`
 
     echo go test ${OPTS} -timeout ${TEST_TIMEOUT} -coverprofile=${coveragefile}.cov ${pkg} ${tags}
-    TYK_LOGELEVEL=debug go test ${OPTS} -timeout ${TEST_TIMEOUT} -coverprofile=${coveragefile}.cov ${pkg} ${tags}
+    go test ${OPTS} -timeout ${TEST_TIMEOUT} -coverprofile=${coveragefile}.cov ${pkg} ${tags}
 done
 
 # run rpc tests separately

--- a/bin/ci-tests.sh
+++ b/bin/ci-tests.sh
@@ -28,7 +28,7 @@ for pkg in ${PKGS}; do
     coveragefile=`echo "$pkg" | awk -F/ '{print $NF}'`
 
     echo go test ${OPTS} -timeout ${TEST_TIMEOUT} -coverprofile=${coveragefile}.cov ${pkg} ${tags}
-    go test ${OPTS} -timeout ${TEST_TIMEOUT} -coverprofile=${coveragefile}.cov ${pkg} ${tags}
+    TYK_LOGELEVEL=debug go test ${OPTS} -timeout ${TEST_TIMEOUT} -coverprofile=${coveragefile}.cov ${pkg} ${tags}
 done
 
 # run rpc tests separately

--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -135,7 +135,7 @@ func (m *GoPluginMiddleware) loadPlugin() bool {
 	// try to load plugin
 	var err error
 
-	newPath, err := goplugin.GetPluginFileNameToLoad(m.Path, VERSION)
+	newPath, err := goplugin.GetPluginFileNameToLoad(goplugin.FileSystemStorage{}, m.Path, VERSION)
 	if err != nil {
 		m.logger.WithError(err).Error("plugin file not found")
 		return false

--- a/gateway/res_handler_go_plugin.go
+++ b/gateway/res_handler_go_plugin.go
@@ -41,7 +41,7 @@ func (h *ResponseGoPluginMiddleware) Init(c interface{}, spec *APISpec) error {
 		return nil
 	}
 
-	newPath, err := goplugin.GetPluginFileNameToLoad(h.Path, VERSION)
+	newPath, err := goplugin.GetPluginFileNameToLoad(goplugin.FileSystemStorage{}, h.Path, VERSION)
 	if err != nil {
 		h.logger.WithError(err).Error("Could not load Go-plugin. File was not found")
 		return err

--- a/goplugin/file_loader.go
+++ b/goplugin/file_loader.go
@@ -9,15 +9,15 @@ import (
 
 var log = logger.Get()
 
-// Storage interface so we can test which plugin should be loaded
-type Storage interface {
-	FileExist(string) bool
+// interface so we can test which plugin should be loaded
+type storage interface {
+	fileExist(string) bool
 }
 
 // FileSystemStorage implements storage interface, it uses the filesystem as store
 type FileSystemStorage struct{}
 
-func (FileSystemStorage) FileExist(path string) bool {
+func (FileSystemStorage) fileExist(path string) bool {
 	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
 		log.Warningf("plugin file %v doesn't exist", path)
 		return false

--- a/goplugin/file_loader.go
+++ b/goplugin/file_loader.go
@@ -9,10 +9,6 @@ import (
 
 var log = logger.Get()
 
-func init() {
-	PluginStorage = FileSystemStorage{}
-}
-
 // Storage interface so we can test which plugin should be loaded
 type Storage interface {
 	FileExist(string) bool

--- a/goplugin/file_loader.go
+++ b/goplugin/file_loader.go
@@ -10,18 +10,18 @@ import (
 var log = logger.Get()
 
 func init() {
-	pluginStorage = FileSystemStorage{}
+	PluginStorage = FileSystemStorage{}
 }
 
-// interface so we can test which plugin should be loaded
-type storage interface {
-	fileExist(string) bool
+// Storage interface so we can test which plugin should be loaded
+type Storage interface {
+	FileExist(string) bool
 }
 
 // FileSystemStorage implements storage interface, it uses the filesystem as store
 type FileSystemStorage struct{}
 
-func (FileSystemStorage) fileExist(path string) bool {
+func (FileSystemStorage) FileExist(path string) bool {
 	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
 		log.Warningf("plugin file %v doesn't exist", path)
 		return false

--- a/goplugin/file_loader_test.go
+++ b/goplugin/file_loader_test.go
@@ -39,7 +39,7 @@ func TestFileExist(t *testing.T) {
 				defer os.Remove(f.Name())
 			}
 
-			fileFound := storage.FileExist(tc.fileName)
+			fileFound := storage.fileExist(tc.fileName)
 
 			assert.Equal(t, tc.fileFound, fileFound)
 		})

--- a/goplugin/file_loader_test.go
+++ b/goplugin/file_loader_test.go
@@ -39,7 +39,7 @@ func TestFileExist(t *testing.T) {
 				defer os.Remove(f.Name())
 			}
 
-			fileFound := storage.fileExist(tc.fileName)
+			fileFound := storage.FileExist(tc.fileName)
 
 			assert.Equal(t, tc.fileFound, fileFound)
 		})

--- a/goplugin/mw_go_plugin_test.go
+++ b/goplugin/mw_go_plugin_test.go
@@ -21,7 +21,6 @@ import (
 
 // run go build -buildmode=plugin -o goplugins.so in ./test/goplugins directory prior to running tests
 func TestGoPluginMWs(t *testing.T) {
-	test.Flaky(t) // TODO: TT-5263
 
 	ts := gateway.StartTest(nil)
 	defer ts.Close()
@@ -102,7 +101,6 @@ func TestGoPluginMWs(t *testing.T) {
 }
 
 func TestGoPluginResponseHook(t *testing.T) {
-	test.Flaky(t) // TODO: TT-5263
 
 	ts := gateway.StartTest(nil)
 	defer ts.Close()
@@ -145,7 +143,6 @@ func TestGoPluginResponseHook(t *testing.T) {
 }
 
 func TestGoPluginPerPathSingleFile(t *testing.T) {
-	test.Flaky(t) // TODO: TT-5263
 
 	ts := gateway.StartTest(nil)
 	defer ts.Close()
@@ -222,7 +219,6 @@ func TestGoPluginPerPathSingleFile(t *testing.T) {
 }
 
 func TestGoPluginAPIandPerPath(t *testing.T) {
-	test.Flaky(t) // TODO: TT-5263
 
 	ts := gateway.StartTest(nil)
 	defer ts.Close()

--- a/goplugin/mw_go_plugin_test.go
+++ b/goplugin/mw_go_plugin_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/gateway"
-	"github.com/TykTechnologies/tyk/goplugin"
 	"github.com/TykTechnologies/tyk/test"
 )
 
@@ -26,7 +25,6 @@ func TestGoPluginMWs(t *testing.T) {
 	ts := gateway.StartTest(nil)
 	defer ts.Close()
 
-	goplugin.PluginStorage = goplugin.FileSystemStorage{}
 	ts.Gw.BuildAndLoadAPI(func(spec *gateway.APISpec) {
 		spec.APIID = "plugin_api"
 		spec.Proxy.ListenPath = "/goplugin"

--- a/goplugin/mw_go_plugin_test.go
+++ b/goplugin/mw_go_plugin_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/gateway"
+	"github.com/TykTechnologies/tyk/goplugin"
 	"github.com/TykTechnologies/tyk/test"
 )
 
@@ -25,6 +26,7 @@ func TestGoPluginMWs(t *testing.T) {
 	ts := gateway.StartTest(nil)
 	defer ts.Close()
 
+	goplugin.PluginStorage = goplugin.FileSystemStorage{}
 	ts.Gw.BuildAndLoadAPI(func(spec *gateway.APISpec) {
 		spec.APIID = "plugin_api"
 		spec.Proxy.ListenPath = "/goplugin"

--- a/goplugin/plugin_name_builder.go
+++ b/goplugin/plugin_name_builder.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 )
 
-// pluginStorage defaults to FileSystemStorage
-var pluginStorage storage
+// PluginStorage defaults to FileSystemStorage
+var PluginStorage Storage
 
 // GetPluginFileNameToLoad check which file to load based on name, tyk version, os and architecture
 // but it also takes care of returning the name of the file that exists
@@ -18,7 +18,7 @@ func GetPluginFileNameToLoad(path string, version string) (string, error) {
 	newNamingFormat := getPluginNameFromTykVersion(prefixedGwVersion, path)
 
 	// 1. attempt to load a plugin that follow the new standard
-	if pluginStorage.fileExist(newNamingFormat) {
+	if PluginStorage.FileExist(newNamingFormat) {
 		return newNamingFormat, nil
 	}
 
@@ -26,13 +26,13 @@ func GetPluginFileNameToLoad(path string, version string) (string, error) {
 	if !strings.HasPrefix(version, "v") {
 		newNamingFormat = getPluginNameFromTykVersion(version, path)
 
-		if pluginStorage.fileExist(newNamingFormat) {
+		if PluginStorage.FileExist(newNamingFormat) {
 			return newNamingFormat, nil
 		}
 	}
 
 	// 3. attempt to load the exact name provided
-	if !pluginStorage.fileExist(path) {
+	if !PluginStorage.FileExist(path) {
 		return "", errors.New("plugin file not found")
 	}
 

--- a/goplugin/plugin_name_builder.go
+++ b/goplugin/plugin_name_builder.go
@@ -9,13 +9,13 @@ import (
 
 // GetPluginFileNameToLoad check which file to load based on name, tyk version, os and architecture
 // but it also takes care of returning the name of the file that exists
-func GetPluginFileNameToLoad(pluginStorage Storage, path string, version string) (string, error) {
+func GetPluginFileNameToLoad(pluginStorage storage, path string, version string) (string, error) {
 
 	prefixedGwVersion := getPrefixedVersion(version)
 	newNamingFormat := getPluginNameFromTykVersion(prefixedGwVersion, path)
 
 	// 1. attempt to load a plugin that follow the new standard
-	if pluginStorage.FileExist(newNamingFormat) {
+	if pluginStorage.fileExist(newNamingFormat) {
 		return newNamingFormat, nil
 	}
 
@@ -23,13 +23,13 @@ func GetPluginFileNameToLoad(pluginStorage Storage, path string, version string)
 	if !strings.HasPrefix(version, "v") {
 		newNamingFormat = getPluginNameFromTykVersion(version, path)
 
-		if pluginStorage.FileExist(newNamingFormat) {
+		if pluginStorage.fileExist(newNamingFormat) {
 			return newNamingFormat, nil
 		}
 	}
 
 	// 3. attempt to load the exact name provided
-	if !pluginStorage.FileExist(path) {
+	if !pluginStorage.fileExist(path) {
 		return "", errors.New("plugin file not found")
 	}
 

--- a/goplugin/plugin_name_builder.go
+++ b/goplugin/plugin_name_builder.go
@@ -7,18 +7,15 @@ import (
 	"strings"
 )
 
-// PluginStorage defaults to FileSystemStorage
-var PluginStorage Storage
-
 // GetPluginFileNameToLoad check which file to load based on name, tyk version, os and architecture
 // but it also takes care of returning the name of the file that exists
-func GetPluginFileNameToLoad(path string, version string) (string, error) {
+func GetPluginFileNameToLoad(pluginStorage Storage, path string, version string) (string, error) {
 
 	prefixedGwVersion := getPrefixedVersion(version)
 	newNamingFormat := getPluginNameFromTykVersion(prefixedGwVersion, path)
 
 	// 1. attempt to load a plugin that follow the new standard
-	if PluginStorage.FileExist(newNamingFormat) {
+	if pluginStorage.FileExist(newNamingFormat) {
 		return newNamingFormat, nil
 	}
 
@@ -26,13 +23,13 @@ func GetPluginFileNameToLoad(path string, version string) (string, error) {
 	if !strings.HasPrefix(version, "v") {
 		newNamingFormat = getPluginNameFromTykVersion(version, path)
 
-		if PluginStorage.FileExist(newNamingFormat) {
+		if pluginStorage.FileExist(newNamingFormat) {
 			return newNamingFormat, nil
 		}
 	}
 
 	// 3. attempt to load the exact name provided
-	if !PluginStorage.FileExist(path) {
+	if !pluginStorage.FileExist(path) {
 		return "", errors.New("plugin file not found")
 	}
 

--- a/goplugin/plugin_name_builder_test.go
+++ b/goplugin/plugin_name_builder_test.go
@@ -15,7 +15,7 @@ type MockStorage struct {
 	files []string
 }
 
-func (ms MockStorage) FileExist(path string) bool {
+func (ms MockStorage) fileExist(path string) bool {
 	for _, v := range ms.files {
 		// clean path as some of them has ./ as prefix
 		path := strings.TrimPrefix(path, "./")

--- a/goplugin/plugin_name_builder_test.go
+++ b/goplugin/plugin_name_builder_test.go
@@ -15,7 +15,7 @@ type MockStorage struct {
 	files []string
 }
 
-func (ms MockStorage) fileExist(path string) bool {
+func (ms MockStorage) FileExist(path string) bool {
 	for _, v := range ms.files {
 		// clean path as some of them has ./ as prefix
 		path := strings.TrimPrefix(path, "./")
@@ -73,11 +73,11 @@ func TestGetPluginFileNameToLoad(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			pluginStorage = MockStorage{
+			PluginStorage = MockStorage{
 				files: testCase.files,
 			}
 			defer func() {
-				pluginStorage = FileSystemStorage{}
+				PluginStorage = FileSystemStorage{}
 			}()
 
 			filenameToLoad, _ := GetPluginFileNameToLoad(testCase.pluginName, testCase.version)

--- a/goplugin/plugin_name_builder_test.go
+++ b/goplugin/plugin_name_builder_test.go
@@ -73,14 +73,7 @@ func TestGetPluginFileNameToLoad(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			PluginStorage = MockStorage{
-				files: testCase.files,
-			}
-			defer func() {
-				PluginStorage = FileSystemStorage{}
-			}()
-
-			filenameToLoad, _ := GetPluginFileNameToLoad(testCase.pluginName, testCase.version)
+			filenameToLoad, _ := GetPluginFileNameToLoad(MockStorage{files: testCase.files}, testCase.pluginName, testCase.version)
 			assert.Equal(t, testCase.expectedFileName, filenameToLoad)
 		})
 	}

--- a/goplugin/plugin_name_builder_test.go
+++ b/goplugin/plugin_name_builder_test.go
@@ -76,6 +76,9 @@ func TestGetPluginFileNameToLoad(t *testing.T) {
 			pluginStorage = MockStorage{
 				files: testCase.files,
 			}
+			defer func() {
+				pluginStorage = FileSystemStorage{}
+			}()
 
 			filenameToLoad, _ := GetPluginFileNameToLoad(testCase.pluginName, testCase.version)
 			assert.Equal(t, testCase.expectedFileName, filenameToLoad)

--- a/goplugin/plugin_name_builder_test.go
+++ b/goplugin/plugin_name_builder_test.go
@@ -73,7 +73,8 @@ func TestGetPluginFileNameToLoad(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			filenameToLoad, _ := GetPluginFileNameToLoad(MockStorage{files: testCase.files}, testCase.pluginName, testCase.version)
+			filenameToLoad, err := GetPluginFileNameToLoad(MockStorage{files: testCase.files}, testCase.pluginName, testCase.version)
+			assert.NoError(t, err)
 			assert.Equal(t, testCase.expectedFileName, filenameToLoad)
 		})
 	}


### PR DESCRIPTION
goplugin tests were flaky due to two reasons. 
1.`var pluginStorage storage` was a global variable and it was set to `MockFileSystemStorage` which caused other tests depending on actual filesystem to fail.
2. CI tests are run with `-race` flag, but the goplugins are not build with `-race` flag, hence causing error `plugin build with different version` of go. 

This PR fixes these two cases. 