### PR TITLE
Merging to release-4: [TT-5132] Set LastUpdated field in org session update (#4646)

### DIFF
--- a/gateway/api.go
+++ b/gateway/api.go
@@ -1780,6 +1780,7 @@ func (gw *Gateway) handleOrgAddOrUpdate(orgID string, r *http.Request) (interfac
 		gw.DefaultQuotaStore.RemoveSession(orgID, rawKey, false)
 	}
 
+	newSession.LastUpdated = strconv.Itoa(int(time.Now().Unix()))
 	err := sessionManager.UpdateSession(orgID, newSession, 0, false)
 	if err != nil {
 		return apiError("Error writing to key store " + err.Error()), http.StatusInternalServerError


### PR DESCRIPTION
[TT-5132] Set LastUpdated field in org session update (#4646)

The `last_updated` field is important while doing rate-limiting
operations. Any update or create operation for org session should set
last update time.

[TT-5132]: https://tyktech.atlassian.net/browse/TT-5132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ