### PR TITLE
[TT-7399] Add possibility to add oAuth client tags to session tags

### DIFF
--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -607,6 +607,11 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 							session.Tags = append(session.Tags, tag.(string))
 						}
 					}
+					
+					policies, ok := data["policies"].(string)
+					if ok {
+						session["policies"] = policies
+					}
 				}
 			}
 		} else {

--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -609,10 +609,10 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 						}
 						updateSession = true
 					}
-					
-					policies, ok := data["policies"].(string)
+
+					policies, ok := data["policies"].([]interface{})
 					if ok {
-						session["policies"] = policies
+						session.MetaData["policies"] = policies
 						updateSession = true
 					}
 				}

--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -595,27 +595,8 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 			if userData != nil {
 				data, ok := userData.(map[string]interface{})
 				if ok {
-					developerID, keyFound := data["tyk_developer_id"].(string)
-					if keyFound {
-						session.MetaData["tyk_developer_id"] = developerID
-						updateSession = true
-					}
+					updateSession = session.TagsFromMetadata(data)
 
-					// pteam-<id>, porg-<id>
-					clientTags, ok := data["tags"].([]interface{})
-					if ok {
-						for _, tag := range clientTags {
-							strTag, _ := tag.(string)
-							session.Tags = append(session.Tags, strTag)
-						}
-						updateSession = true
-					}
-
-					policies, ok := data["policies"].([]interface{})
-					if ok {
-						session.MetaData["policies"] = policies
-						updateSession = true
-					}
 					if err := k.ApplyPolicies(&session); err != nil {
 						return errors.New("failed to apply policies in session metadata: " + err.Error()), http.StatusInternalServerError
 					}

--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -599,6 +599,12 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 					if keyFound {
 						session.MetaData["tyk_developer_id"] = developerID
 					}
+					
+					// pteam-<id>, porg-<id>
+					clientTags, keyFound := data["tags"].([]string)
+					if keyFound {
+						session.Tags = append(session.Tags, clientTags...)
+					}
 				}
 			}
 		} else {

--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -598,6 +598,7 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 					developerID, keyFound := data["tyk_developer_id"].(string)
 					if keyFound {
 						session.MetaData["tyk_developer_id"] = developerID
+						updateSession = true
 					}
 
 					// pteam-<id>, porg-<id>
@@ -606,11 +607,13 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 						for _, tag := range clientTags {
 							session.Tags = append(session.Tags, tag.(string))
 						}
+						updateSession = true
 					}
 					
 					policies, ok := data["policies"].(string)
 					if ok {
 						session["policies"] = policies
+						updateSession = true
 					}
 				}
 			}

--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -605,7 +605,8 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 					clientTags, ok := data["tags"].([]interface{})
 					if ok {
 						for _, tag := range clientTags {
-							session.Tags = append(session.Tags, tag.(string))
+							strTag, _ := tag.(string)
+							session.Tags = append(session.Tags, strTag)
 						}
 						updateSession = true
 					}

--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -616,6 +616,9 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 						session.MetaData["policies"] = policies
 						updateSession = true
 					}
+					if err := k.ApplyPolicies(&session); err != nil {
+						return errors.New("failed to create key: " + err.Error()), http.StatusInternalServerError
+					}
 				}
 			}
 		} else {

--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -599,11 +599,13 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 					if keyFound {
 						session.MetaData["tyk_developer_id"] = developerID
 					}
-					
+
 					// pteam-<id>, porg-<id>
-					clientTags, keyFound := data["tags"].([]string)
-					if keyFound {
-						session.Tags = append(session.Tags, clientTags...)
+					clientTags, ok := data["tags"].([]interface{})
+					if ok {
+						for _, tag := range clientTags {
+							session.Tags = append(session.Tags, tag.(string))
+						}
 					}
 				}
 			}

--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -617,7 +617,7 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 						updateSession = true
 					}
 					if err := k.ApplyPolicies(&session); err != nil {
-						return errors.New("failed to create key: " + err.Error()), http.StatusInternalServerError
+						return errors.New("failed to apply policies in session metadata: " + err.Error()), http.StatusInternalServerError
 					}
 				}
 			}

--- a/user/session_tags.go
+++ b/user/session_tags.go
@@ -12,7 +12,10 @@ func (s *SessionState) TagsFromMetadata(data map[string]interface{}) (updateSess
 	clientTags, ok := data["tags"].([]interface{})
 	if ok {
 		for _, tag := range clientTags {
-			strTag, _ := tag.(string)
+			strTag, err := tag.(string)
+			if err {
+				continue
+			}
 			s.Tags = append(s.Tags, strTag)
 		}
 		updateSession = true

--- a/user/session_tags.go
+++ b/user/session_tags.go
@@ -1,0 +1,28 @@
+package user
+
+// TagsFromMetadata updates the session state with the tags from the metadata.
+func (s *SessionState) TagsFromMetadata(data map[string]interface{}) (updateSession bool) {
+	developerID, keyFound := data["tyk_developer_id"].(string)
+	if keyFound {
+		s.MetaData["tyk_developer_id"] = developerID
+		updateSession = true
+	}
+
+	// pteam-<id>, porg-<id>
+	clientTags, ok := data["tags"].([]interface{})
+	if ok {
+		for _, tag := range clientTags {
+			strTag, _ := tag.(string)
+			s.Tags = append(s.Tags, strTag)
+		}
+		updateSession = true
+	}
+
+	policies, ok := data["policies"].([]interface{})
+	if ok {
+		s.MetaData["policies"] = policies
+		updateSession = true
+	}
+
+	return
+}

--- a/user/session_tags.go
+++ b/user/session_tags.go
@@ -12,8 +12,8 @@ func (s *SessionState) TagsFromMetadata(data map[string]interface{}) (updateSess
 	clientTags, ok := data["tags"].([]interface{})
 	if ok {
 		for _, tag := range clientTags {
-			strTag, err := tag.(string)
-			if err {
+			strTag, ok := tag.(string)
+			if !ok {
 				continue
 			}
 			s.Tags = append(s.Tags, strTag)

--- a/user/session_tags_test.go
+++ b/user/session_tags_test.go
@@ -1,0 +1,38 @@
+package user
+
+import (
+	"testing"
+)
+
+func TestSessionState_TagsFromMetadata(t *testing.T) {
+	tests := []struct {
+		name              string
+		session           *SessionState
+		data              map[string]interface{}
+		wantUpdateSession bool
+	}{
+		{
+			name: "all-values",
+			session: &SessionState{
+				MetaData: map[string]interface{}{
+					"tyk_developer_id": "123",
+					"policies":         []interface{}{"[]"},
+					"tags":             []interface{}{"pteam-123", "porg-123"},
+				},
+			},
+			data: map[string]interface{}{
+				"tyk_developer_id": "456",
+				"policies":         []interface{}{"[]"},
+				"tags":             []interface{}{"pteam-456", "porg-456"},
+			},
+			wantUpdateSession: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotUpdateSession := tt.session.TagsFromMetadata(tt.data); gotUpdateSession != tt.wantUpdateSession {
+				t.Errorf("SessionState.TagsFromMetadata() = %v, want %v", gotUpdateSession, tt.wantUpdateSession)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This can allow generating custom analytics dimensions, because each tag generate own dimension. 

For example as a Portal, it can create oAuth clients which contain "tags" string array inside oAuth client object, which contains values like: `["portal-team-<teamId>", "portal-org-<orgId>", "portal-dev-<devId>"]`. For each of those tags pump will generate a separate analytics dimension.

JIRA: https://tyktech.atlassian.net/browse/TT-7399

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
