### PR TITLE
Merging to release-4: Move copyHeader to be included in analytics (#4666)

### DIFF
--- a/gateway/mw_redis_cache.go
+++ b/gateway/mw_redis_cache.go
@@ -233,17 +233,18 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 		newRes.Header.Del(h)
 	}
 
-	copyHeader(w.Header(), newRes.Header, m.Gw.GetConfig().IgnoreCanonicalMIMEHeaderKey)
 	session := ctxGetSession(r)
 
 	// Only add ratelimit data to keyed sessions
 	if session != nil {
 		quotaMax, quotaRemaining, _, quotaRenews := session.GetQuotaLimitByAPIID(m.Spec.APIID)
-		w.Header().Set(header.XRateLimitLimit, strconv.Itoa(int(quotaMax)))
-		w.Header().Set(header.XRateLimitRemaining, strconv.Itoa(int(quotaRemaining)))
-		w.Header().Set(header.XRateLimitReset, strconv.Itoa(int(quotaRenews)))
+		newRes.Header.Set(header.XRateLimitLimit, strconv.Itoa(int(quotaMax)))
+		newRes.Header.Set(header.XRateLimitRemaining, strconv.Itoa(int(quotaRemaining)))
+		newRes.Header.Set(header.XRateLimitReset, strconv.Itoa(int(quotaRenews)))
 	}
-	w.Header().Set(cachedResponseHeader, "1")
+	newRes.Header.Set(cachedResponseHeader, "1")
+
+	copyHeader(w.Header(), newRes.Header, m.Gw.GetConfig().IgnoreCanonicalMIMEHeaderKey)
 
 	if reqEtag := r.Header.Get("If-None-Match"); reqEtag != "" {
 		if respEtag := newRes.Header.Get("Etag"); respEtag != "" {


### PR DESCRIPTION
Move copyHeader to be included in analytics (#4666)

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->
On analytics hit, cache headers have been written directly to the
ResponseWriter headers. This PR changes this behaviour, so that the
analytics request also logs the X-Tyk-Cached-Response value.

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

https://tyktech.atlassian.net/browse/TT-7390

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why

Co-authored-by: Tit Petric <tit@tyk.io>