### PR TITLE
[TT-7958] Rename Tyk native to Tyk classic

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -113,9 +113,9 @@ const (
 )
 
 var (
-	ErrAPIMigrated                = errors.New("the supplied API definition is in Tyk native format, please use OAS format for this API")
-	ErrAPINotMigrated             = errors.New("the supplied API definition is in OAS format, please use the Tyk native format for this API")
-	ErrOASGetForOldAPI            = errors.New("the requested API definition is in Tyk native format, please use old api endpoint")
+	ErrAPIMigrated                = errors.New("the supplied API definition is in Tyk classic format, please use OAS format for this API")
+	ErrAPINotMigrated             = errors.New("the supplied API definition is in OAS format, please use the Tyk classic format for this API")
+	ErrOASGetForOldAPI            = errors.New("the requested API definition is in Tyk classic format, please use old api endpoint")
 	ErrImportWithTykExtension     = errors.New("the import payload should not contain x-tyk-api-gateway")
 	ErrPayloadWithoutTykExtension = errors.New("the payload should contain x-tyk-api-gateway")
 	ErrAPINotFound                = errors.New("API not found")

--- a/apidef/oas/authentication.go
+++ b/apidef/oas/authentication.go
@@ -13,12 +13,12 @@ import (
 type Authentication struct {
 	// Enabled makes the API protected when one of the authentication modes is enabled.
 	//
-	// Tyk native API definition: `!use_keyless`.
+	// Tyk classic API definition: `!use_keyless`.
 	Enabled bool `bson:"enabled" json:"enabled"` // required
 
 	// StripAuthorizationData ensures that any security tokens used for accessing APIs are stripped and not leaked to the upstream.
 	//
-	// Tyk native API definition: `strip_auth_data`.
+	// Tyk classic API definition: `strip_auth_data`.
 	StripAuthorizationData bool `bson:"stripAuthorizationData,omitempty" json:"stripAuthorizationData,omitempty"`
 
 	// BaseIdentityProvider enables multi authentication mechanism and provides the session object that determines rate limits, ACL rules and quotas.
@@ -31,22 +31,22 @@ type Authentication struct {
 	// - `oidc_user`,
 	// - `oauth_key`.
 	//
-	// Tyk native API definition: `base_identity_provided_by`.
+	// Tyk classic API definition: `base_identity_provided_by`.
 	BaseIdentityProvider apidef.AuthTypeEnum `bson:"baseIdentityProvider,omitempty" json:"baseIdentityProvider,omitempty"`
 
 	// HMAC contains the configurations related to HMAC authentication mode.
 	//
-	// Tyk native API definition: `auth_configs["hmac"]`
+	// Tyk classic API definition: `auth_configs["hmac"]`
 	HMAC *HMAC `bson:"hmac,omitempty" json:"hmac,omitempty"`
 
 	// OIDC contains the configurations related to OIDC authentication mode.
 	//
-	// Tyk native API definition: `auth_configs["oidc"]`
+	// Tyk classic API definition: `auth_configs["oidc"]`
 	OIDC *OIDC `bson:"oidc,omitempty" json:"oidc,omitempty"`
 
 	// Custom contains the configurations related to Custom authentication mode.
 	//
-	// Tyk native API definition: `auth_configs["coprocess"]`
+	// Tyk classic API definition: `auth_configs["coprocess"]`
 	Custom *CustomPluginAuthentication `bson:"custom,omitempty" json:"custom,omitempty"`
 
 	// SecuritySchemes contains security schemes definitions.
@@ -233,21 +233,21 @@ func (ss SecuritySchemes) GetBaseIdentityProvider() (res apidef.AuthTypeEnum) {
 
 // AuthSources defines authentication source configuration: headers, cookies and query parameters.
 //
-// Tyk native API definition: `auth_configs{}`.
+// Tyk classic API definition: `auth_configs{}`.
 type AuthSources struct {
 	// Header contains configurations for the header value auth source, it is enabled by default.
 	//
-	// Tyk native API definition: `auth_configs[x].header`
+	// Tyk classic API definition: `auth_configs[x].header`
 	Header *AuthSource `bson:"header,omitempty" json:"header,omitempty"`
 
 	// Cookie contains configurations for the cookie value auth source.
 	//
-	// Tyk native API definition: `auth_configs[x].cookie`
+	// Tyk classic API definition: `auth_configs[x].cookie`
 	Cookie *AuthSource `bson:"cookie,omitempty" json:"cookie,omitempty"`
 
 	// Query contains configurations for the query parameters auth source.
 	//
-	// Tyk native API definition: `auth_configs[x].query`
+	// Tyk classic API definition: `auth_configs[x].query`
 	Query *AuthSource `bson:"query,omitempty" json:"query,omitempty"`
 }
 
@@ -306,10 +306,10 @@ func (as *AuthSources) ExtractTo(authConfig *apidef.AuthConfig) {
 // AuthSource defines an authentication source.
 type AuthSource struct {
 	// Enabled enables the auth source.
-	// Tyk native API definition: `auth_configs[X].use_param/use_cookie`
+	// Tyk classic API definition: `auth_configs[X].use_param/use_cookie`
 	Enabled bool `bson:"enabled" json:"enabled"` // required
 	// Name is the name of the auth source.
-	// Tyk native API definition: `auth_configs[X].param_name/cookie_name`
+	// Tyk classic API definition: `auth_configs[X].param_name/cookie_name`
 	Name string `bson:"name,omitempty" json:"name,omitempty"`
 }
 
@@ -417,7 +417,7 @@ type ScopeToPolicy struct {
 // HMAC holds the configuration for the HMAC authentication mode.
 type HMAC struct {
 	// Enabled enables the HMAC authentication mode.
-	// Tyk native API definition: `enable_signature_checking`
+	// Tyk classic API definition: `enable_signature_checking`
 	Enabled bool `bson:"enabled" json:"enabled"` // required
 
 	// AuthSources contains authentication token source configuration (header, cookie, query).
@@ -432,12 +432,12 @@ type HMAC struct {
 	//
 	// and reads the value from algorithm header.
 	//
-	// Tyk native API definition: `hmac_allowed_algorithms`
+	// Tyk classic API definition: `hmac_allowed_algorithms`
 	AllowedAlgorithms []string `bson:"allowedAlgorithms,omitempty" json:"allowedAlgorithms,omitempty"`
 
 	// AllowedClockSkew is the amount of milliseconds that will be tolerated for clock skew. It is used against replay attacks.
 	// The default value is `0`, which deactivates clock skew checks.
-	// Tyk native API definition: `hmac_allowed_clock_skew`
+	// Tyk classic API definition: `hmac_allowed_clock_skew`
 	AllowedClockSkew float64 `bson:"allowedClockSkew,omitempty" json:"allowedClockSkew,omitempty"`
 }
 
@@ -472,7 +472,7 @@ func (h *HMAC) ExtractTo(api *apidef.APIDefinition) {
 type OIDC struct {
 	// Enabled enables the OIDC authentication mode.
 	//
-	// Tyk native API definition: `use_openid`
+	// Tyk classic API definition: `use_openid`
 	Enabled bool `bson:"enabled" json:"enabled"` // required
 
 	// AuthSources contains authentication token source configuration (header, cookie, query).
@@ -480,12 +480,12 @@ type OIDC struct {
 
 	// SegregateByClientId is a boolean flag. If set to `true, the policies will be applied to a combination of Client ID and User ID.
 	//
-	// Tyk native API definition: `openid_options.segregate_by_client`.
+	// Tyk classic API definition: `openid_options.segregate_by_client`.
 	SegregateByClientId bool `bson:"segregateByClientId,omitempty" json:"segregateByClientId,omitempty"`
 
 	// Providers contains a list of authorised providers and their Client IDs, and matched policies.
 	//
-	// Tyk native API definition: `openid_options.providers`.
+	// Tyk classic API definition: `openid_options.providers`.
 	Providers []Provider `bson:"providers,omitempty" json:"providers,omitempty"`
 
 	// Scopes contains the defined scope claims.
@@ -583,11 +583,11 @@ type ClientToPolicy struct {
 type CustomPluginAuthentication struct {
 	// Enabled enables the CustomPluginAuthentication authentication mode.
 	//
-	// Tyk native API definition: `enable_coprocess_auth`/`use_go_plugin_auth`.
+	// Tyk classic API definition: `enable_coprocess_auth`/`use_go_plugin_auth`.
 	Enabled bool `bson:"enabled" json:"enabled"` // required
 
 	// Config contains configuration related to custom authentication plugin.
-	// Tyk native API definition: `custom_middleware.auth_check`.
+	// Tyk classic API definition: `custom_middleware.auth_check`.
 	Config *AuthenticationPlugin `bson:"config,omitempty" json:"config,omitempty"`
 
 	// Authentication token sources (header, cookie, query).

--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -42,27 +42,27 @@ type Global struct {
 	PluginConfig *PluginConfig `bson:"pluginConfig,omitempty" json:"pluginConfig,omitempty"`
 
 	// CORS contains the configuration related to cross origin resource sharing.
-	// Tyk native API definition: `CORS`.
+	// Tyk classic API definition: `CORS`.
 	CORS *CORS `bson:"cors,omitempty" json:"cors,omitempty"`
 
 	// PrePlugin contains configuration related to custom pre-authentication plugin.
-	// Tyk native API definition: `custom_middleware.pre`.
+	// Tyk classic API definition: `custom_middleware.pre`.
 	PrePlugin *PrePlugin `bson:"prePlugin,omitempty" json:"prePlugin,omitempty"`
 
 	// PostAuthenticationPlugin contains configuration related to custom post authentication plugin.
-	// Tyk native API definition: `custom_middleware.post_key_auth`.
+	// Tyk classic API definition: `custom_middleware.post_key_auth`.
 	PostAuthenticationPlugin *PostAuthenticationPlugin `bson:"postAuthenticationPlugin,omitempty" json:"postAuthenticationPlugin,omitempty"`
 
 	// PostPlugin contains configuration related to custom post plugin.
-	// Tyk native API definition: `custom_middleware.post`.
+	// Tyk classic API definition: `custom_middleware.post`.
 	PostPlugin *PostPlugin `bson:"postPlugin,omitempty" json:"postPlugin,omitempty"`
 
 	// ResponsePlugin contains configuration related to custom post plugin.
-	// Tyk native API definition: `custom_middleware.response`.
+	// Tyk classic API definition: `custom_middleware.response`.
 	ResponsePlugin *ResponsePlugin `bson:"responsePlugin,omitempty" json:"responsePlugin,omitempty"`
 
 	// Cache contains the configurations related to caching.
-	// Tyk native API definition: `cache_options`.
+	// Tyk classic API definition: `cache_options`.
 	Cache *Cache `bson:"cache,omitempty" json:"cache,omitempty"`
 }
 
@@ -174,7 +174,7 @@ type PluginConfig struct {
 	// - `grpc`,
 	// - `goplugin`.
 	//
-	// Tyk native API definition: `custom_middleware.driver`.
+	// Tyk classic API definition: `custom_middleware.driver`.
 	Driver apidef.MiddlewareDriver `bson:"driver,omitempty" json:"driver,omitempty"`
 
 	// Bundle configures custom plugin bundles.
@@ -231,28 +231,28 @@ func (p *PluginBundle) ExtractTo(api *apidef.APIDefinition) {
 type CORS struct {
 	// Enabled is a boolean flag, if set to `true`, this option enables CORS processing.
 	//
-	// Tyk native API definition: `CORS.enable`.
+	// Tyk classic API definition: `CORS.enable`.
 	Enabled bool `bson:"enabled" json:"enabled"` // required
 
 	// MaxAge indicates how long (in seconds) the results of a preflight request can be cached. The default is 0 which stands for no max age.
 	//
-	// Tyk native API definition: `CORS.max_age`.
+	// Tyk classic API definition: `CORS.max_age`.
 	MaxAge int `bson:"maxAge,omitempty" json:"maxAge,omitempty"`
 
 	// AllowCredentials indicates whether the request can include user credentials like cookies,
 	// HTTP authentication or client side SSL certificates.
 	//
-	// Tyk native API definition: `CORS.allow_credentials`.
+	// Tyk classic API definition: `CORS.allow_credentials`.
 	AllowCredentials bool `bson:"allowCredentials,omitempty" json:"allowCredentials,omitempty"`
 
 	// ExposedHeaders indicates which headers are safe to expose to the API of a CORS API specification.
 	//
-	// Tyk native API definition: `CORS.exposed_headers`.
+	// Tyk classic API definition: `CORS.exposed_headers`.
 	ExposedHeaders []string `bson:"exposedHeaders,omitempty" json:"exposedHeaders,omitempty"`
 
 	// AllowedHeaders holds a list of non simple headers the client is allowed to use with cross-domain requests.
 	//
-	// Tyk native API definition: `CORS.allowed_headers`.
+	// Tyk classic API definition: `CORS.allowed_headers`.
 	AllowedHeaders []string `bson:"allowedHeaders,omitempty" json:"allowedHeaders,omitempty"`
 
 	// OptionsPassthrough is a boolean flag. If set to `true`, it will proxy the CORS OPTIONS pre-flight
@@ -262,22 +262,22 @@ type CORS struct {
 	//
 	// If your service handles CORS natively, then enable this option.
 	//
-	// Tyk native API definition: `CORS.options_passthrough`.
+	// Tyk classic API definition: `CORS.options_passthrough`.
 	OptionsPassthrough bool `bson:"optionsPassthrough,omitempty" json:"optionsPassthrough,omitempty"`
 
 	// Debug is a boolean flag, If set to `true`, this option produces log files for the CORS middleware.
 	//
-	// Tyk native API definition: `CORS.debug`.
+	// Tyk classic API definition: `CORS.debug`.
 	Debug bool `bson:"debug,omitempty" json:"debug,omitempty"`
 
 	// AllowedOrigins holds a list of origin domains to allow access from. Wildcards are also supported, e.g. `http://*.foo.com`
 	//
-	// Tyk native API definition: `CORS.allowed_origins`.
+	// Tyk classic API definition: `CORS.allowed_origins`.
 	AllowedOrigins []string `bson:"allowedOrigins,omitempty" json:"allowedOrigins,omitempty"`
 
 	// AllowedMethods holds a list of methods to allow access via.
 	//
-	// Tyk native API definition: `CORS.allowed_methods`.
+	// Tyk classic API definition: `CORS.allowed_methods`.
 	AllowedMethods []string `bson:"allowedMethods,omitempty" json:"allowedMethods,omitempty"`
 }
 
@@ -312,38 +312,38 @@ type Cache struct {
 	// Enabled turns global cache middleware on or off. It is still possible to enable caching on a per-path basis
 	// by explicitly setting the endpoint cache middleware.
 	//
-	// Tyk native API definition: `cache_options.enable_cache`
+	// Tyk classic API definition: `cache_options.enable_cache`
 	Enabled bool `bson:"enabled" json:"enabled"` // required
 
 	// Timeout is the TTL for a cached object in seconds.
 	//
-	// Tyk native API definition: `cache_options.cache_timeout`
+	// Tyk classic API definition: `cache_options.cache_timeout`
 	Timeout int64 `bson:"timeout,omitempty" json:"timeout,omitempty"`
 
 	// CacheAllSafeRequests caches responses to (`GET`, `HEAD`, `OPTIONS`) requests overrides per-path cache settings in versions,
 	// applies across versions.
 	//
-	// Tyk native API definition: `cache_options.cache_all_safe_requests`
+	// Tyk classic API definition: `cache_options.cache_all_safe_requests`
 	CacheAllSafeRequests bool `bson:"cacheAllSafeRequests,omitempty" json:"cacheAllSafeRequests,omitempty"`
 
 	// CacheResponseCodes is an array of response codes which are safe to cache e.g. `404`.
 	//
-	// Tyk native API definition: `cache_options.cache_response_codes`
+	// Tyk classic API definition: `cache_options.cache_response_codes`
 	CacheResponseCodes []int `bson:"cacheResponseCodes,omitempty" json:"cacheResponseCodes,omitempty"`
 
 	// CacheByHeaders allows header values to be used as part of the cache key.
 	//
-	// Tyk native API definition: `cache_options.cache_by_headers`
+	// Tyk classic API definition: `cache_options.cache_by_headers`
 	CacheByHeaders []string `bson:"cacheByHeaders,omitempty" json:"cacheByHeaders,omitempty"`
 
 	// EnableUpstreamCacheControl instructs Tyk Cache to respect upstream cache control headers.
 	//
-	// Tyk native API definition: `cache_options.enable_upstream_cache_control`
+	// Tyk classic API definition: `cache_options.enable_upstream_cache_control`
 	EnableUpstreamCacheControl bool `bson:"enableUpstreamCacheControl,omitempty" json:"enableUpstreamCacheControl,omitempty"`
 
 	// ControlTTLHeaderName is the response header which tells Tyk how long it is safe to cache the response for.
 	//
-	// Tyk native API definition: `cache_options.cache_control_ttl_header`
+	// Tyk classic API definition: `cache_options.cache_control_ttl_header`
 	ControlTTLHeaderName string `bson:"controlTTLHeaderName,omitempty" json:"controlTTLHeaderName,omitempty"`
 }
 

--- a/apidef/oas/root.go
+++ b/apidef/oas/root.go
@@ -50,16 +50,16 @@ func (x *XTykAPIGateway) ExtractTo(api *apidef.APIDefinition) {
 // Info contains the main metadata about the API definition.
 type Info struct {
 	// ID is the unique ID of the API.
-	// Tyk native API definition: `api_id`
+	// Tyk classic API definition: `api_id`
 	ID string `bson:"id" json:"id,omitempty"`
 	// DBID is the unique database ID of the API.
-	// Tyk native API definition: `id`
+	// Tyk classic API definition: `id`
 	DBID apidef.ObjectId `bson:"dbId" json:"dbId,omitempty"`
 	// OrgID is the ID of the organisation which the API belongs to.
-	// Tyk native API definition: `org_id`
+	// Tyk classic API definition: `org_id`
 	OrgID string `bson:"orgId" json:"orgId,omitempty"`
 	// Name is the name of the API.
-	// Tyk native API definition: `name`
+	// Tyk classic API definition: `name`
 	Name string `bson:"name" json:"name"` // required
 	// Expiration date.
 	Expiration string `bson:"expiration,omitempty" json:"expiration,omitempty"`
@@ -112,10 +112,10 @@ func (i *Info) ExtractTo(api *apidef.APIDefinition) {
 // State holds configuration about API definition states (active, internal).
 type State struct {
 	// Active enables the API.
-	// Tyk native API definition: `active`
+	// Tyk classic API definition: `active`
 	Active bool `bson:"active" json:"active"` // required
 	// Internal makes the API accessible only internally.
-	// Tyk native API definition: `internal`
+	// Tyk classic API definition: `internal`
 	Internal bool `bson:"internal,omitempty" json:"internal,omitempty"`
 }
 
@@ -133,7 +133,7 @@ func (s *State) ExtractTo(api *apidef.APIDefinition) {
 
 // Versioning holds configuration for API versioning.
 //
-// Tyk native API definition: `version_data`.
+// Tyk classic API definition: `version_data`.
 type Versioning struct {
 	// Enabled is a boolean flag, if set to `true` it will enable versioning of an API.
 	Enabled bool `bson:"enabled" json:"enabled"` // required

--- a/apidef/oas/root_test.go
+++ b/apidef/oas/root_test.go
@@ -68,7 +68,7 @@ func TestXTykAPIGateway(t *testing.T) {
 	})
 
 	t.Run("filled old", func(t *testing.T) {
-		t.SkipNow() // when we don't need to skip this, it means OAS and Tyk native API definition match
+		t.SkipNow() // when we don't need to skip this, it means OAS and Tyk classic API definition match
 		initialAPI := apidef.APIDefinition{}
 		Fill(t, &initialAPI, 0)
 

--- a/apidef/oas/schema/x-tyk-gateway.md
+++ b/apidef/oas/schema/x-tyk-gateway.md
@@ -21,22 +21,22 @@ Middleware contains the configurations related to the proxy middleware.
 **Field: `id` (`string`)**
 ID is the unique ID of the API.
 
-Tyk native API definition: `api_id`.
+Tyk classic API definition: `api_id`.
 
 **Field: `dbId` (`object`)**
 DBID is the unique database ID of the API.
 
-Tyk native API definition: `id`.
+Tyk classic API definition: `id`.
 
 **Field: `orgId` (`string`)**
 OrgID is the ID of the organisation which the API belongs to.
 
-Tyk native API definition: `org_id`.
+Tyk classic API definition: `org_id`.
 
 **Field: `name` (`string`)**
 Name is the name of the API.
 
-Tyk native API definition: `name`.
+Tyk classic API definition: `name`.
 
 **Field: `expiration` (`string`)**
 Expiration date.
@@ -53,12 +53,12 @@ Versioning holds configuration for API versioning.
 **Field: `active` (`boolean`)**
 Active enables the API.
 
-Tyk native API definition: `active`.
+Tyk classic API definition: `active`.
 
 **Field: `internal` (`boolean`)**
 Internal makes the API accessible only internally.
 
-Tyk native API definition: `internal`.
+Tyk classic API definition: `internal`.
 
 
 ### **Versioning**
@@ -103,12 +103,12 @@ ID is the API ID for the version set in Name.
 **Field: `url` (`string`)**
 URL defines the target URL that the request should be proxied to.
 
-Tyk native API definition: `proxy.target_url`.
+Tyk classic API definition: `proxy.target_url`.
 
 **Field: `serviceDiscovery` ([ServiceDiscovery](#servicediscovery))**
 ServiceDiscovery contains the configuration related to Service Discovery.
 
-Tyk native API definition: `proxy.service_discovery`.
+Tyk classic API definition: `proxy.service_discovery`.
 
 **Field: `test` ([Test](#test))**
 Test contains the configuration related to uptime tests.
@@ -125,12 +125,12 @@ CertificatePinning contains the configuration related to certificate pinning.
 **Field: `enabled` (`boolean`)**
 Enabled enables Service Discovery.
 
-Tyk native API definition: `service_discovery.use_discovery_service`.
+Tyk classic API definition: `service_discovery.use_discovery_service`.
 
 **Field: `queryEndpoint` (`string`)**
 QueryEndpoint is the endpoint to call, this would usually be Consul, etcd or Eureka K/V store.
 
-Tyk native API definition: `service_discovery.query_endpoint`.
+Tyk classic API definition: `service_discovery.query_endpoint`.
 
 **Field: `dataPath` (`string`)**
 DataPath is the namespace of the data path - where exactly in your service response the namespace can be found.
@@ -152,7 +152,7 @@ For example, if your service responds with:
 
 then your namespace would be `node.value`.
 
-Tyk native API definition: `service_discovery.data_path`.
+Tyk classic API definition: `service_discovery.data_path`.
 
 **Field: `useNestedQuery` (`boolean`)**
 UseNestedQuery enables using a combination of `dataPath` and `parentDataPath`.
@@ -173,39 +173,39 @@ It is necessary when the data lives within this string-encoded JSON object.
 ```
 
 
-Tyk native API definition: `service_discovery.use_nested_query`.
+Tyk classic API definition: `service_discovery.use_nested_query`.
 
 **Field: `parentDataPath` (`string`)**
 ParentDataPath is the namespace of the where to find the nested value, if `useNestedQuery` is `true`. In the above example, it would be `node.value`. You would change the `dataPath` setting to be `hostname`, since this is where the host name data resides in the JSON string. Tyk automatically assumes that `dataPath` in this case is in a string-encoded JSON object and will try to deserialize it.
 
-Tyk native API definition: `service_discovery.parent_data_path`.
+Tyk classic API definition: `service_discovery.parent_data_path`.
 
 **Field: `portDataPath` (`string`)**
 PortDataPath is the port of the data path. In the above nested example, we can see that there is a separate `port` value for the service in the nested JSON. In this case, you can set the `portDataPath` value and Tyk will treat `dataPath` as the hostname and zip them together (this assumes that the hostname element does not end in a slash or resource identifier such as `/widgets/`). In the above example, the `portDataPath` would be `port`.
 
-Tyk native API definition: `service_discovery.port_data_path`.
+Tyk classic API definition: `service_discovery.port_data_path`.
 
 **Field: `useTargetList` (`boolean`)**
 UseTargetList should be set to `true`, if you are using load balancing. Tyk will treat the data path as a list and inject it into the target list of your API definition.
 
-Tyk native API definition: `service_discovery.use_target_list`.
+Tyk classic API definition: `service_discovery.use_target_list`.
 
 **Field: `cacheTimeout` (`int`)**
 CacheTimeout is the timeout of a cache value when a new data is loaded from a discovery service.
 Setting it too low will cause Tyk to call the SD service too often, setting it too high could mean that failures are not recovered from quickly enough.
 
-Tyk native API definition: `service_discovery.cache_timeout`.
+Tyk classic API definition: `service_discovery.cache_timeout`.
 
 **Field: `targetPath` (`string`)**
 TargetPath is to set a target path to append to the discovered endpoint, since many SD services only provide host and port data. It is important to be able to target a specific resource on that host.
 Setting this value will enable that.
 
-Tyk native API definition: `service_discovery.target_path`.
+Tyk classic API definition: `service_discovery.target_path`.
 
 **Field: `endpointReturnsList` (`boolean`)**
 EndpointReturnsList is set `true` when the response type is a list instead of an object.
 
-Tyk native API definition: `service_discovery.endpoint_returns_list`.
+Tyk classic API definition: `service_discovery.endpoint_returns_list`.
 
 
 ### **Test**
@@ -213,7 +213,7 @@ Tyk native API definition: `service_discovery.endpoint_returns_list`.
 **Field: `serviceDiscovery` ([ServiceDiscovery](#servicediscovery))**
 ServiceDiscovery contains the configuration related to test Service Discovery.
 
-Tyk native API definition: `proxy.service_discovery`.
+Tyk classic API definition: `proxy.service_discovery`.
 
 
 ### **MutualTLS**
@@ -221,12 +221,12 @@ Tyk native API definition: `proxy.service_discovery`.
 **Field: `enabled` (`boolean`)**
 Enabled enables/disables upstream mutual TLS auth for the API.
 
-Tyk native API definition: `upstream_certificates_disabled`.
+Tyk classic API definition: `upstream_certificates_disabled`.
 
 **Field: `domainToCertificateMapping` (`[]`[DomainToCertificate](#domaintocertificate))**
 DomainToCertificates maintains the mapping of domain to certificate.
 
-Tyk native API definition: `upstream_certificates`.
+Tyk classic API definition: `upstream_certificates`.
 
 
 ### **DomainToCertificate**
@@ -243,12 +243,12 @@ Certificate contains the certificate mapped to the domain.
 **Field: `enabled` (`boolean`)**
 Enabled is a boolean flag, if set to `true`, it enables certificate pinning for the API.
 
-Tyk native API definition: `certificate_pinning_disabled`.
+Tyk classic API definition: `certificate_pinning_disabled`.
 
 **Field: `domainToPublicKeysMapping` (`[]`[PinnedPublicKey](#pinnedpublickey))**
 DomainToPublicKeysMapping maintains the mapping of domain to pinned public keys.
 
-Tyk native API definition: `pinned_public_keys`.
+Tyk classic API definition: `pinned_public_keys`.
 
 
 ### **PinnedPublicKey**
@@ -268,7 +268,7 @@ ListenPath represents the path to listen on. Any requests coming into the host, 
 **Field: `slug` (`string`)**
 Slug is the Tyk Cloud equivalent of listen path.
 
-Tyk native API definition: `slug`.
+Tyk classic API definition: `slug`.
 
 **Field: `authentication` ([Authentication](#authentication))**
 Authentication contains the configurations related to authentication to the API.
@@ -282,7 +282,7 @@ GatewayTags contains segment tags to configure which GWs your APIs connect to.
 **Field: `customDomain` ([Domain](#domain))**
 CustomDomain is the domain to bind this API to.
 
-Tyk native API definition: `domain`.
+Tyk classic API definition: `domain`.
 
 
 ### **ListenPath**
@@ -290,12 +290,12 @@ Tyk native API definition: `domain`.
 **Field: `value` (`string`)**
 Value is the value of the listen path e.g. `/api/` or `/` or `/httpbin/`.
 
-Tyk native API definition: `proxy.listen_path`.
+Tyk classic API definition: `proxy.listen_path`.
 
 **Field: `strip` (`boolean`)**
 Strip removes the inbound listen path in the outgoing request. e.g. `http://acme.com/httpbin/get` where `httpbin`is the listen path. The `httpbin` listen path which is used to identify the API loaded in Tyk is removed, and the outbound request would be `http://httpbin.org/get`.
 
-Tyk native API definition: `proxy.strip_listen_path`.
+Tyk classic API definition: `proxy.strip_listen_path`.
 
 
 ### **Authentication**
@@ -303,12 +303,12 @@ Tyk native API definition: `proxy.strip_listen_path`.
 **Field: `enabled` (`boolean`)**
 Enabled makes the API protected when one of the authentication modes is enabled.
 
-Tyk native API definition: `!use_keyless`.
+Tyk classic API definition: `!use_keyless`.
 
 **Field: `stripAuthorizationData` (`boolean`)**
 StripAuthorizationData ensures that any security tokens used for accessing APIs are stripped and not leaked to the upstream.
 
-Tyk native API definition: `strip_auth_data`.
+Tyk classic API definition: `strip_auth_data`.
 
 **Field: `baseIdentityProvider` (`object`)**
 BaseIdentityProvider enables multi authentication mechanism and provides the session object that determines rate limits, ACL rules and quotas.
@@ -322,22 +322,22 @@ It should be set to one of the following:
 - `oauth_key`.
 
 
-Tyk native API definition: `base_identity_provided_by`.
+Tyk classic API definition: `base_identity_provided_by`.
 
 **Field: `hmac` ([HMAC](#hmac))**
 HMAC contains the configurations related to HMAC authentication mode.
 
-Tyk native API definition: `auth_configs["hmac"]`.
+Tyk classic API definition: `auth_configs["hmac"]`.
 
 **Field: `oidc` ([OIDC](#oidc))**
 OIDC contains the configurations related to OIDC authentication mode.
 
-Tyk native API definition: `auth_configs["oidc"]`.
+Tyk classic API definition: `auth_configs["oidc"]`.
 
 **Field: `custom` ([CustomPluginAuthentication](#custompluginauthentication))**
 Custom contains the configurations related to Custom authentication mode.
 
-Tyk native API definition: `auth_configs["coprocess"]`.
+Tyk classic API definition: `auth_configs["coprocess"]`.
 
 **Field: `securitySchemes` (`map[string]any`)**
 SecuritySchemes contains security schemes definitions.
@@ -348,22 +348,22 @@ SecuritySchemes contains security schemes definitions.
 **Field: `enabled` (`boolean`)**
 Enabled enables the HMAC authentication mode.
 
-Tyk native API definition: `enable_signature_checking`.
+Tyk classic API definition: `enable_signature_checking`.
 
 **Field: `header` ([AuthSource](#authsource))**
 Header contains configurations for the header value auth source, it is enabled by default.
 
-Tyk native API definition: `auth_configs[x].header`.
+Tyk classic API definition: `auth_configs[x].header`.
 
 **Field: `cookie` ([AuthSource](#authsource))**
 Cookie contains configurations for the cookie value auth source.
 
-Tyk native API definition: `auth_configs[x].cookie`.
+Tyk classic API definition: `auth_configs[x].cookie`.
 
 **Field: `query` ([AuthSource](#authsource))**
 Query contains configurations for the query parameters auth source.
 
-Tyk native API definition: `auth_configs[x].query`.
+Tyk classic API definition: `auth_configs[x].query`.
 
 **Field: `allowedAlgorithms` (`[]string`)**
 AllowedAlgorithms is the array of HMAC algorithms which are allowed. Tyk supports the following HMAC algorithms:
@@ -375,13 +375,13 @@ AllowedAlgorithms is the array of HMAC algorithms which are allowed. Tyk support
 
 and reads the value from algorithm header.
 
-Tyk native API definition: `hmac_allowed_algorithms`.
+Tyk classic API definition: `hmac_allowed_algorithms`.
 
 **Field: `allowedClockSkew` (`double`)**
 AllowedClockSkew is the amount of milliseconds that will be tolerated for clock skew. It is used against replay attacks.
 The default value is `0`, which deactivates clock skew checks.
 
-Tyk native API definition: `hmac_allowed_clock_skew`.
+Tyk classic API definition: `hmac_allowed_clock_skew`.
 
 
 ### **AuthSources**
@@ -389,17 +389,17 @@ Tyk native API definition: `hmac_allowed_clock_skew`.
 **Field: `header` ([AuthSource](#authsource))**
 Header contains configurations for the header value auth source, it is enabled by default.
 
-Tyk native API definition: `auth_configs[x].header`.
+Tyk classic API definition: `auth_configs[x].header`.
 
 **Field: `cookie` ([AuthSource](#authsource))**
 Cookie contains configurations for the cookie value auth source.
 
-Tyk native API definition: `auth_configs[x].cookie`.
+Tyk classic API definition: `auth_configs[x].cookie`.
 
 **Field: `query` ([AuthSource](#authsource))**
 Query contains configurations for the query parameters auth source.
 
-Tyk native API definition: `auth_configs[x].query`.
+Tyk classic API definition: `auth_configs[x].query`.
 
 
 ### **AuthSource**
@@ -407,12 +407,12 @@ Tyk native API definition: `auth_configs[x].query`.
 **Field: `enabled` (`boolean`)**
 Enabled enables the auth source.
 
-Tyk native API definition: `auth_configs[X].use_param/use_cookie`.
+Tyk classic API definition: `auth_configs[X].use_param/use_cookie`.
 
 **Field: `name` (`string`)**
 Name is the name of the auth source.
 
-Tyk native API definition: `auth_configs[X].param_name/cookie_name`.
+Tyk classic API definition: `auth_configs[X].param_name/cookie_name`.
 
 
 ### **OIDC**
@@ -420,32 +420,32 @@ Tyk native API definition: `auth_configs[X].param_name/cookie_name`.
 **Field: `enabled` (`boolean`)**
 Enabled enables the OIDC authentication mode.
 
-Tyk native API definition: `use_openid`.
+Tyk classic API definition: `use_openid`.
 
 **Field: `header` ([AuthSource](#authsource))**
 Header contains configurations for the header value auth source, it is enabled by default.
 
-Tyk native API definition: `auth_configs[x].header`.
+Tyk classic API definition: `auth_configs[x].header`.
 
 **Field: `cookie` ([AuthSource](#authsource))**
 Cookie contains configurations for the cookie value auth source.
 
-Tyk native API definition: `auth_configs[x].cookie`.
+Tyk classic API definition: `auth_configs[x].cookie`.
 
 **Field: `query` ([AuthSource](#authsource))**
 Query contains configurations for the query parameters auth source.
 
-Tyk native API definition: `auth_configs[x].query`.
+Tyk classic API definition: `auth_configs[x].query`.
 
 **Field: `segregateByClientId` (`boolean`)**
 SegregateByClientId is a boolean flag. If set to `true, the policies will be applied to a combination of Client ID and User ID.
 
-Tyk native API definition: `openid_options.segregate_by_client`.
+Tyk classic API definition: `openid_options.segregate_by_client`.
 
 **Field: `providers` (`[]`[Provider](#provider))**
 Providers contains a list of authorised providers and their Client IDs, and matched policies.
 
-Tyk native API definition: `openid_options.providers`.
+Tyk classic API definition: `openid_options.providers`.
 
 **Field: `scopes` ([Scopes](#scopes))**
 Scopes contains the defined scope claims.
@@ -492,27 +492,27 @@ PolicyID contains the Policy ID.
 **Field: `enabled` (`boolean`)**
 Enabled enables the CustomPluginAuthentication authentication mode.
 
-Tyk native API definition: `enable_coprocess_auth`/`use_go_plugin_auth`.
+Tyk classic API definition: `enable_coprocess_auth`/`use_go_plugin_auth`.
 
 **Field: `config` ([AuthenticationPlugin](#authenticationplugin))**
 Config contains configuration related to custom authentication plugin.
 
-Tyk native API definition: `custom_middleware.auth_check`.
+Tyk classic API definition: `custom_middleware.auth_check`.
 
 **Field: `header` ([AuthSource](#authsource))**
 Header contains configurations for the header value auth source, it is enabled by default.
 
-Tyk native API definition: `auth_configs[x].header`.
+Tyk classic API definition: `auth_configs[x].header`.
 
 **Field: `cookie` ([AuthSource](#authsource))**
 Cookie contains configurations for the cookie value auth source.
 
-Tyk native API definition: `auth_configs[x].cookie`.
+Tyk classic API definition: `auth_configs[x].cookie`.
 
 **Field: `query` ([AuthSource](#authsource))**
 Query contains configurations for the query parameters auth source.
 
-Tyk native API definition: `auth_configs[x].query`.
+Tyk classic API definition: `auth_configs[x].query`.
 
 
 ### **AuthenticationPlugin**
@@ -574,32 +574,32 @@ PluginConfig contains the configuration related custom plugin bundles/driver.
 **Field: `cors` ([CORS](#cors))**
 CORS contains the configuration related to cross origin resource sharing.
 
-Tyk native API definition: `CORS`.
+Tyk classic API definition: `CORS`.
 
 **Field: `prePlugin` ([PrePlugin](#preplugin))**
 PrePlugin contains configuration related to custom pre-authentication plugin.
 
-Tyk native API definition: `custom_middleware.pre`.
+Tyk classic API definition: `custom_middleware.pre`.
 
 **Field: `postAuthenticationPlugin` ([PostAuthenticationPlugin](#postauthenticationplugin))**
 PostAuthenticationPlugin contains configuration related to custom post authentication plugin.
 
-Tyk native API definition: `custom_middleware.post_key_auth`.
+Tyk classic API definition: `custom_middleware.post_key_auth`.
 
 **Field: `postPlugin` ([PostPlugin](#postplugin))**
 PostPlugin contains configuration related to custom post plugin.
 
-Tyk native API definition: `custom_middleware.post`.
+Tyk classic API definition: `custom_middleware.post`.
 
 **Field: `responsePlugin` ([ResponsePlugin](#responseplugin))**
 ResponsePlugin contains configuration related to custom post plugin.
 
-Tyk native API definition: `custom_middleware.response`.
+Tyk classic API definition: `custom_middleware.response`.
 
 **Field: `cache` ([Cache](#cache))**
 Cache contains the configurations related to caching.
 
-Tyk native API definition: `cache_options`.
+Tyk classic API definition: `cache_options`.
 
 
 ### **PluginConfig**
@@ -615,7 +615,7 @@ It's value should be set to one of the following:
 - `goplugin`.
 
 
-Tyk native API definition: `custom_middleware.driver`.
+Tyk classic API definition: `custom_middleware.driver`.
 
 **Field: `bundle` ([PluginBundle](#pluginbundle))**
 Bundle configures custom plugin bundles.
@@ -625,6 +625,7 @@ Bundle configures custom plugin bundles.
 
 **Field: `enabled` (`boolean`)**
 Enabled enables the custom plugin bundles.
+
 Tyk classic API definition: `custom_middleware_bundle_disabled`.
 
 **Field: `path` (`string`)**
@@ -637,48 +638,48 @@ Path will be suffixed to `bundle_base_url` in gateway config.
 **Field: `enabled` (`boolean`)**
 Enabled is a boolean flag, if set to `true`, this option enables CORS processing.
 
-Tyk native API definition: `CORS.enable`.
+Tyk classic API definition: `CORS.enable`.
 
 **Field: `maxAge` (`int`)**
 MaxAge indicates how long (in seconds) the results of a preflight request can be cached. The default is 0 which stands for no max age.
 
-Tyk native API definition: `CORS.max_age`.
+Tyk classic API definition: `CORS.max_age`.
 
 **Field: `allowCredentials` (`boolean`)**
 AllowCredentials indicates whether the request can include user credentials like cookies, HTTP authentication or client side SSL certificates.
 
-Tyk native API definition: `CORS.allow_credentials`.
+Tyk classic API definition: `CORS.allow_credentials`.
 
 **Field: `exposedHeaders` (`[]string`)**
 ExposedHeaders indicates which headers are safe to expose to the API of a CORS API specification.
 
-Tyk native API definition: `CORS.exposed_headers`.
+Tyk classic API definition: `CORS.exposed_headers`.
 
 **Field: `allowedHeaders` (`[]string`)**
 AllowedHeaders holds a list of non simple headers the client is allowed to use with cross-domain requests.
 
-Tyk native API definition: `CORS.allowed_headers`.
+Tyk classic API definition: `CORS.allowed_headers`.
 
 **Field: `optionsPassthrough` (`boolean`)**
 OptionsPassthrough is a boolean flag. If set to `true`, it will proxy the CORS OPTIONS pre-flight request directly to upstream, without authentication and any CORS checks. This means that pre-flight requests generated by web-clients such as SwaggerUI or the Tyk Portal documentation system will be able to test the API using trial keys.
 If your service handles CORS natively, then enable this option.
 
-Tyk native API definition: `CORS.options_passthrough`.
+Tyk classic API definition: `CORS.options_passthrough`.
 
 **Field: `debug` (`boolean`)**
 Debug is a boolean flag, If set to `true`, this option produces log files for the CORS middleware.
 
-Tyk native API definition: `CORS.debug`.
+Tyk classic API definition: `CORS.debug`.
 
 **Field: `allowedOrigins` (`[]string`)**
 AllowedOrigins holds a list of origin domains to allow access from. Wildcards are also supported, e.g. `http://*.foo.com`.
 
-Tyk native API definition: `CORS.allowed_origins`.
+Tyk classic API definition: `CORS.allowed_origins`.
 
 **Field: `allowedMethods` (`[]string`)**
 AllowedMethods holds a list of methods to allow access via.
 
-Tyk native API definition: `CORS.allowed_methods`.
+Tyk classic API definition: `CORS.allowed_methods`.
 
 
 ### **PrePlugin**
@@ -733,37 +734,37 @@ The plugins would be executed in the order of configuration in the list.
 **Field: `enabled` (`boolean`)**
 Enabled turns global cache middleware on or off. It is still possible to enable caching on a per-path basis by explicitly setting the endpoint cache middleware.
 
-Tyk native API definition: `cache_options.enable_cache`.
+Tyk classic API definition: `cache_options.enable_cache`.
 
 **Field: `timeout` (`int`)**
 Timeout is the TTL for a cached object in seconds.
 
-Tyk native API definition: `cache_options.cache_timeout`.
+Tyk classic API definition: `cache_options.cache_timeout`.
 
 **Field: `cacheAllSafeRequests` (`boolean`)**
 CacheAllSafeRequests caches responses to (`GET`, `HEAD`, `OPTIONS`) requests overrides per-path cache settings in versions, applies across versions.
 
-Tyk native API definition: `cache_options.cache_all_safe_requests`.
+Tyk classic API definition: `cache_options.cache_all_safe_requests`.
 
 **Field: `cacheResponseCodes` (`[]int`)**
 CacheResponseCodes is an array of response codes which are safe to cache e.g. `404`.
 
-Tyk native API definition: `cache_options.cache_response_codes`.
+Tyk classic API definition: `cache_options.cache_response_codes`.
 
 **Field: `cacheByHeaders` (`[]string`)**
 CacheByHeaders allows header values to be used as part of the cache key.
 
-Tyk native API definition: `cache_options.cache_by_headers`.
+Tyk classic API definition: `cache_options.cache_by_headers`.
 
 **Field: `enableUpstreamCacheControl` (`boolean`)**
 EnableUpstreamCacheControl instructs Tyk Cache to respect upstream cache control headers.
 
-Tyk native API definition: `cache_options.enable_upstream_cache_control`.
+Tyk classic API definition: `cache_options.enable_upstream_cache_control`.
 
 **Field: `controlTTLHeaderName` (`string`)**
 ControlTTLHeaderName is the response header which tells Tyk how long it is safe to cache the response for.
 
-Tyk native API definition: `cache_options.cache_control_ttl_header`.
+Tyk classic API definition: `cache_options.cache_control_ttl_header`.
 
 
 ### **Operation**

--- a/apidef/oas/security.go
+++ b/apidef/oas/security.go
@@ -26,7 +26,7 @@ const (
 type Token struct {
 	// Enabled enables the token based authentication mode.
 	//
-	// Tyk native API definition: `auth_configs["authToken"].use_standard_auth`
+	// Tyk classic API definition: `auth_configs["authToken"].use_standard_auth`
 	Enabled bool `bson:"enabled" json:"enabled"` // required
 
 	// AuthSources contains the configuration for authentication sources.
@@ -34,12 +34,12 @@ type Token struct {
 
 	// EnableClientCertificate allows to create dynamic keys based on certificates.
 	//
-	// Tyk native API definition: `auth_configs["authToken"].use_certificate`
+	// Tyk classic API definition: `auth_configs["authToken"].use_certificate`
 	EnableClientCertificate bool `bson:"enableClientCertificate,omitempty" json:"enableClientCertificate,omitempty"`
 
 	// Signature holds the configuration for verifying the signature of the token.
 	//
-	// Tyk native API definition: `auth_configs["authToken"].use_certificate`
+	// Tyk classic API definition: `auth_configs["authToken"].use_certificate`
 	Signature *Signature `bson:"signatureValidation,omitempty" json:"signatureValidation,omitempty"`
 }
 
@@ -202,14 +202,14 @@ func (s *OAS) extractJWTTo(api *apidef.APIDefinition, name string) {
 // Basic type holds configuration values related to http basic authentication.
 type Basic struct {
 	// Enabled enables the basic authentication mode.
-	// Tyk native API definition: `use_basic_auth`
+	// Tyk classic API definition: `use_basic_auth`
 	Enabled     bool `bson:"enabled" json:"enabled"` // required
 	AuthSources `bson:",inline" json:",inline"`
 	// DisableCaching disables the caching of basic authentication key.
-	// Tyk native API definition: `basic_auth.disable_caching`
+	// Tyk classic API definition: `basic_auth.disable_caching`
 	DisableCaching bool `bson:"disableCaching,omitempty" json:"disableCaching,omitempty"`
 	// CacheTTL is the TTL for a cached basic authentication key in seconds.
-	// Tyk native API definition: `basic_auth.cache_ttl`
+	// Tyk classic API definition: `basic_auth.cache_ttl`
 	CacheTTL int `bson:"cacheTTL,omitempty" json:"cacheTTL,omitempty"`
 	// ExtractCredentialsFromBody helps to extract username and password from body. In some cases, like dealing with SOAP,
 	// user credentials can be passed via request body.
@@ -291,13 +291,13 @@ func (s *OAS) extractBasicTo(api *apidef.APIDefinition, name string) {
 // ExtractCredentialsFromBody configures extracting credentials from the request body.
 type ExtractCredentialsFromBody struct {
 	// Enabled enables extracting credentials from body.
-	// Tyk native API definition: `basic_auth.extract_from_body`
+	// Tyk classic API definition: `basic_auth.extract_from_body`
 	Enabled bool `bson:"enabled" json:"enabled"` // required
 	// UserRegexp is the regex for username e.g. `<User>(.*)</User>`.
-	// Tyk native API definition: `basic_auth.userRegexp`
+	// Tyk classic API definition: `basic_auth.userRegexp`
 	UserRegexp string `bson:"userRegexp,omitempty" json:"userRegexp,omitempty"`
 	// PasswordRegexp is the regex for password e.g. `<Password>(.*)</Password>`.
-	// Tyk native API definition: `basic_auth.passwordRegexp`
+	// Tyk classic API definition: `basic_auth.passwordRegexp`
 	PasswordRegexp string `bson:"passwordRegexp,omitempty" json:"passwordRegexp,omitempty"`
 }
 

--- a/apidef/oas/server.go
+++ b/apidef/oas/server.go
@@ -11,7 +11,7 @@ type Server struct {
 	ListenPath ListenPath `bson:"listenPath" json:"listenPath"` // required
 
 	// Slug is the Tyk Cloud equivalent of listen path.
-	// Tyk native API definition: `slug`
+	// Tyk classic API definition: `slug`
 	Slug string `bson:"slug,omitempty" json:"slug,omitempty"`
 
 	// Authentication contains the configurations related to authentication to the API.
@@ -25,7 +25,7 @@ type Server struct {
 
 	// CustomDomain is the domain to bind this API to.
 	//
-	// Tyk native API definition: `domain`
+	// Tyk classic API definition: `domain`
 	CustomDomain *Domain `bson:"customDomain,omitempty" json:"customDomain,omitempty"`
 }
 
@@ -81,12 +81,12 @@ func (s *Server) ExtractTo(api *apidef.APIDefinition) {
 // ListenPath represents the path the server should listen on.
 type ListenPath struct {
 	// Value is the value of the listen path e.g. `/api/` or `/` or `/httpbin/`.
-	// Tyk native API definition: `proxy.listen_path`
+	// Tyk classic API definition: `proxy.listen_path`
 	Value string `bson:"value" json:"value"` // required
 	// Strip removes the inbound listen path in the outgoing request. e.g. `http://acme.com/httpbin/get` where `httpbin`
 	// is the listen path. The `httpbin` listen path which is used to identify the API loaded in Tyk is removed,
 	// and the outbound request would be `http://httpbin.org/get`.
-	// Tyk native API definition: `proxy.strip_listen_path`
+	// Tyk classic API definition: `proxy.strip_listen_path`
 	Strip bool `bson:"strip,omitempty" json:"strip,omitempty"`
 }
 

--- a/apidef/oas/upstream.go
+++ b/apidef/oas/upstream.go
@@ -10,11 +10,11 @@ import (
 // Upstream holds configuration for an upstream server.
 type Upstream struct {
 	// URL defines the target URL that the request should be proxied to.
-	// Tyk native API definition: `proxy.target_url`
+	// Tyk classic API definition: `proxy.target_url`
 	URL string `bson:"url" json:"url"` // required
 
 	// ServiceDiscovery contains the configuration related to Service Discovery.
-	// Tyk native API definition: `proxy.service_discovery`
+	// Tyk classic API definition: `proxy.service_discovery`
 	ServiceDiscovery *ServiceDiscovery `bson:"serviceDiscovery,omitempty" json:"serviceDiscovery,omitempty"`
 
 	// Test contains the configuration related to uptime tests.
@@ -93,11 +93,11 @@ func (u *Upstream) ExtractTo(api *apidef.APIDefinition) {
 type ServiceDiscovery struct {
 	// Enabled enables Service Discovery.
 	//
-	// Tyk native API definition: `service_discovery.use_discovery_service`
+	// Tyk classic API definition: `service_discovery.use_discovery_service`
 	Enabled bool `bson:"enabled" json:"enabled"` // required
 
 	// QueryEndpoint is the endpoint to call, this would usually be Consul, etcd or Eureka K/V store.
-	// Tyk native API definition: `service_discovery.query_endpoint`
+	// Tyk classic API definition: `service_discovery.query_endpoint`
 	QueryEndpoint string `bson:"queryEndpoint,omitempty" json:"queryEndpoint,omitempty"`
 
 	// DataPath is the namespace of the data path - where exactly in your service response the namespace can be found.
@@ -117,7 +117,7 @@ type ServiceDiscovery struct {
 	//
 	// then your namespace would be `node.value`.
 	//
-	// Tyk native API definition: `service_discovery.data_path`
+	// Tyk classic API definition: `service_discovery.data_path`
 	DataPath string `bson:"dataPath,omitempty" json:"dataPath,omitempty"`
 
 	// UseNestedQuery enables using a combination of `dataPath` and `parentDataPath`.
@@ -135,7 +135,7 @@ type ServiceDiscovery struct {
 	// }
 	// ```
 	//
-	// Tyk native API definition: `service_discovery.use_nested_query`
+	// Tyk classic API definition: `service_discovery.use_nested_query`
 	UseNestedQuery bool `bson:"useNestedQuery,omitempty" json:"useNestedQuery,omitempty"`
 
 	// ParentDataPath is the namespace of the where to find the nested
@@ -146,7 +146,7 @@ type ServiceDiscovery struct {
 	// `dataPath` in this case is in a string-encoded JSON object and
 	// will try to deserialize it.
 	//
-	// Tyk native API definition: `service_discovery.parent_data_path`
+	// Tyk classic API definition: `service_discovery.parent_data_path`
 	ParentDataPath string `bson:"parentDataPath,omitempty" json:"parentDataPath,omitempty"`
 
 	// PortDataPath is the port of the data path. In the above nested example, we can see that there is a separate `port` value
@@ -154,32 +154,32 @@ type ServiceDiscovery struct {
 	// the hostname and zip them together (this assumes that the hostname element does not end in a slash or resource identifier
 	// such as `/widgets/`). In the above example, the `portDataPath` would be `port`.
 	//
-	// Tyk native API definition: `service_discovery.port_data_path`
+	// Tyk classic API definition: `service_discovery.port_data_path`
 	PortDataPath string `bson:"portDataPath,omitempty" json:"portDataPath,omitempty"`
 
 	// UseTargetList should be set to `true`, if you are using load balancing. Tyk will treat the data path as a list and
 	// inject it into the target list of your API definition.
 	//
-	// Tyk native API definition: `service_discovery.use_target_list`
+	// Tyk classic API definition: `service_discovery.use_target_list`
 	UseTargetList bool `bson:"useTargetList,omitempty" json:"useTargetList,omitempty"`
 
 	// CacheTimeout is the timeout of a cache value when a new data is loaded from a discovery service.
 	// Setting it too low will cause Tyk to call the SD service too often, setting it too high could mean that
 	// failures are not recovered from quickly enough.
 	//
-	// Tyk native API definition: `service_discovery.cache_timeout`
+	// Tyk classic API definition: `service_discovery.cache_timeout`
 	CacheTimeout int64 `bson:"cacheTimeout,omitempty" json:"cacheTimeout,omitempty"`
 
 	// TargetPath is to set a target path to append to the discovered endpoint, since many SD services
 	// only provide host and port data. It is important to be able to target a specific resource on that host.
 	// Setting this value will enable that.
 	//
-	// Tyk native API definition: `service_discovery.target_path`
+	// Tyk classic API definition: `service_discovery.target_path`
 	TargetPath string `bson:"targetPath,omitempty" json:"targetPath,omitempty"`
 
 	// EndpointReturnsList is set `true` when the response type is a list instead of an object.
 	//
-	// Tyk native API definition: `service_discovery.endpoint_returns_list`
+	// Tyk classic API definition: `service_discovery.endpoint_returns_list`
 	EndpointReturnsList bool `bson:"endpointReturnsList,omitempty" json:"endpointReturnsList,omitempty"`
 }
 
@@ -214,7 +214,7 @@ func (sd *ServiceDiscovery) ExtractTo(serviceDiscovery *apidef.ServiceDiscoveryC
 // Test holds the test configuration for service discovery.
 type Test struct {
 	// ServiceDiscovery contains the configuration related to test Service Discovery.
-	// Tyk native API definition: `proxy.service_discovery`
+	// Tyk classic API definition: `proxy.service_discovery`
 	ServiceDiscovery *ServiceDiscovery `bson:"serviceDiscovery,omitempty" json:"serviceDiscovery,omitempty"`
 }
 
@@ -240,11 +240,11 @@ func (t *Test) ExtractTo(uptimeTests *apidef.UptimeTests) {
 // MutualTLS holds configuration related to mTLS on APIs, domain to certificate mappings.
 type MutualTLS struct {
 	// Enabled enables/disables upstream mutual TLS auth for the API.
-	// Tyk native API definition: `upstream_certificates_disabled`
+	// Tyk classic API definition: `upstream_certificates_disabled`
 	Enabled bool `bson:"enabled" json:"enabled"`
 
 	// DomainToCertificates maintains the mapping of domain to certificate.
-	// Tyk native API definition: `upstream_certificates`
+	// Tyk classic API definition: `upstream_certificates`
 	DomainToCertificates []DomainToCertificate `bson:"domainToCertificateMapping" json:"domainToCertificateMapping"`
 }
 
@@ -330,12 +330,12 @@ func (ppk PinnedPublicKeys) ExtractTo(publicKeys map[string]string) {
 type CertificatePinning struct {
 	// Enabled is a boolean flag, if set to `true`, it enables certificate pinning for the API.
 	//
-	// Tyk native API definition: `certificate_pinning_disabled`
+	// Tyk classic API definition: `certificate_pinning_disabled`
 	Enabled bool `bson:"enabled" json:"enabled"`
 
 	// DomainToPublicKeysMapping maintains the mapping of domain to pinned public keys.
 	//
-	// Tyk native API definition: `pinned_public_keys`
+	// Tyk classic API definition: `pinned_public_keys`
 	DomainToPublicKeysMapping PinnedPublicKeys `bson:"domainToPublicKeysMapping" json:"domainToPublicKeysMapping"`
 }
 

--- a/apidef/oas/xtyk_doc.go
+++ b/apidef/oas/xtyk_doc.go
@@ -336,12 +336,12 @@ func cleanDocs(docs ...*ast.CommentGroup) string {
 				s.WriteString("\n")
 			}
 
-			// Prepend empty line if line starts with `Tyk native API definition`
-			if strings.HasPrefix(lineComment, "Tyk native API definition") {
+			// Prepend empty line if line starts with `Tyk classic API definition`
+			if strings.HasPrefix(lineComment, "Tyk classic API definition") {
 				s.WriteString("\n")
 			}
 
-			// Append dot after Tyk native API definition, consistency.
+			// Append dot after Tyk classic API definition, consistency.
 			if lineComment == "" && lastCh == "`" {
 				s.WriteString(".\n")
 				lastCh = ""


### PR DESCRIPTION
Team agreed upon naming Tyk API definition to be Tyk Classic API definition.
Renaming for consistency.