### PR TITLE
[TT-7696] Modify domainToPublicKeysMapping schema to accept null

### DIFF
--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -111,7 +111,7 @@
           "type": "boolean"
         },
         "domainToPublicKeysMapping": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": [
             {
               "$ref": "#/definitions/X-Tyk-PinnedPublicKeys"
@@ -794,7 +794,6 @@
       },
       "required": [
         "enabled",
-        "default",
         "location",
         "key",
         "versions"

--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -2136,7 +2136,6 @@ func TestHandleAddOASApi_AddVersionAtomically(t *testing.T) {
 	v2 := BuildAPI(func(a *APISpec) {
 		a.Name = "v2"
 		a.APIID = v2APIID
-		a.CertificatePinningDisabled = true
 		a.VersionDefinition.Location = ""
 		a.VersionDefinition.Key = ""
 
@@ -2264,7 +2263,6 @@ func TestHandleDeleteOASAPI_RemoveVersionAtomically(t *testing.T) {
 	v1 := BuildAPI(func(a *APISpec) {
 		a.Name = "v1"
 		a.APIID = "v1"
-		a.CertificatePinningDisabled = true
 		a.VersionDefinition.Location = ""
 		a.VersionDefinition.Key = ""
 
@@ -2275,7 +2273,6 @@ func TestHandleDeleteOASAPI_RemoveVersionAtomically(t *testing.T) {
 	v2 := BuildAPI(func(a *APISpec) {
 		a.Name = "v2"
 		a.APIID = "v2"
-		a.CertificatePinningDisabled = true
 		a.VersionDefinition.Location = ""
 		a.VersionDefinition.Key = ""
 
@@ -2286,7 +2283,6 @@ func TestHandleDeleteOASAPI_RemoveVersionAtomically(t *testing.T) {
 	baseAPI := BuildAPI(func(a *APISpec) {
 		a.Name = "base"
 		a.APIID = "base"
-		a.CertificatePinningDisabled = true
 		a.VersionDefinition.Versions = map[string]string{
 			v1VersionName: v1.APIID,
 			v2VersionName: v2.APIID,


### PR DESCRIPTION
The migration fails when `domainToPublicKeysMapping` comes as `null` because the schema doesn't accept it. There are two solutions:
1. Tagging `domainToPublicKeysMapping` as `domainToPublicKeysMapping` which drops when it is `null`
2. Modifying the schema to accept `null`

I went with the 2nd option because `domainToPublicKeysMapping` should be set, if `certificatePinning` is used.