### PR TITLE
[TT-7514] Drop empty customDomain in migration

### DIFF
--- a/apidef/migration.go
+++ b/apidef/migration.go
@@ -225,6 +225,7 @@ func (a *APIDefinition) Migrate() (versions []APIDefinition, err error) {
 	a.migrateCertificatePinning()
 	a.migrateGatewayTags()
 	a.migrateAuthenticationPlugin()
+	a.migrateCustomDomain()
 
 	versions, err = a.MigrateVersioning()
 	if err != nil {
@@ -268,6 +269,12 @@ func (a *APIDefinition) migrateGatewayTags() {
 func (a *APIDefinition) migrateAuthenticationPlugin() {
 	if reflect.DeepEqual(a.CustomMiddleware.AuthCheck, MiddlewareDefinition{}) {
 		a.CustomMiddleware.AuthCheck.Disabled = true
+	}
+}
+
+func (a *APIDefinition) migrateCustomDomain() {
+	if !a.DomainDisabled && a.Domain == "" {
+		a.DomainDisabled = true
 	}
 }
 

--- a/apidef/oas/oas_test.go
+++ b/apidef/oas/oas_test.go
@@ -602,4 +602,8 @@ func TestMigrateAndFillOAS_DropEmpties(t *testing.T) {
 	t.Run("authenticationPlugin", func(t *testing.T) {
 		assert.Nil(t, baseAPI.OAS.GetTykExtension().Middleware)
 	})
+
+	t.Run("customDomain", func(t *testing.T) {
+		assert.Nil(t, baseAPI.OAS.GetTykExtension().Server.CustomDomain)
+	})
 }

--- a/apidef/oas/server.go
+++ b/apidef/oas/server.go
@@ -51,8 +51,13 @@ func (s *Server) Fill(api apidef.APIDefinition) {
 		s.GatewayTags = nil
 	}
 
-	if s.CustomDomain != nil {
-		s.CustomDomain.Fill(api)
+	if s.CustomDomain == nil {
+		s.CustomDomain = &Domain{}
+	}
+
+	s.CustomDomain.Fill(api)
+	if ShouldOmit(s.CustomDomain) {
+		s.CustomDomain = nil
 	}
 }
 


### PR DESCRIPTION
- There was a bug in `customDomain` conversions
- After migration, this PR drop empty `customDomain`