### PR TITLE
[TT-7420] Change mock response headers from map to array

### DIFF
--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -696,7 +696,9 @@ func (a *Allowance) Import(enabled bool) {
 
 // Header holds a header name and value pair.
 type Header struct {
-	Name  string `bson:"name" json:"name"`
+	// Name is the name of the header.
+	Name string `bson:"name" json:"name"`
+	// Value is the value of the header.
 	Value string `bson:"value" json:"value"`
 }
 

--- a/apidef/oas/operation.go
+++ b/apidef/oas/operation.go
@@ -541,7 +541,7 @@ type MockResponse struct {
 	// Body is the HTTP response body that will be returned.
 	Body string `bson:"body,omitempty" json:"body,omitempty"`
 	// Headers are the HTTP response headers that will be returned.
-	Headers map[string]string `bson:"headers,omitempty" json:"headers,omitempty"`
+	Headers []Header `bson:"headers,omitempty" json:"headers,omitempty"`
 	// FromOASExamples is the configuration to extract a mock response from OAS documentation.
 	FromOASExamples *FromOASExamples `bson:"fromOASExamples,omitempty" json:"fromOASExamples,omitempty"`
 }

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -546,7 +546,12 @@
           "type": "string"
         },
         "headers": {
-          "type": "object"
+          "type": "array",
+          "items": [
+            {
+              "$ref": "#/definitions/X-Tyk-Header"
+            }
+          ]
         },
         "fromOASExamples": {
           "properties": {
@@ -1186,6 +1191,21 @@
           "type": "boolean"
         }
       }
+    },
+    "X-Tyk-Header": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ]
     }
   }
 }

--- a/apidef/oas/schema/x-tyk-gateway.md
+++ b/apidef/oas/schema/x-tyk-gateway.md
@@ -873,11 +873,20 @@ Code is the HTTP response code that will be returned.
 **Field: `body` (`string`)**
 Body is the HTTP response body that will be returned.
 
-**Field: `headers` (`string`)**
+**Field: `headers` (`[]`[Header](#header))**
 Headers are the HTTP response headers that will be returned.
 
 **Field: `fromOASExamples` ([FromOASExamples](#fromoasexamples))**
 FromOASExamples is the configuration to extract a mock response from OAS documentation.
+
+
+### **Header**
+
+**Field: `name` (`string`)**
+Name is the name of the header.
+
+**Field: `value` (`string`)**
+Value is the value of the header.
 
 
 ### **FromOASExamples**

--- a/gateway/mock_response_test.go
+++ b/gateway/mock_response_test.go
@@ -25,8 +25,11 @@ func TestMockResponse(t *testing.T) {
 		Enabled: true,
 		Code:    http.StatusTeapot,
 		Body:    body,
-		Headers: map[string]string{
-			headerKey: headerValue,
+		Headers: []oas.Header{
+			{
+				Name:  headerKey,
+				Value: headerValue,
+			},
 		},
 		FromOASExamples: &oas.FromOASExamples{},
 	}
@@ -134,8 +137,11 @@ func TestMockResponse(t *testing.T) {
 func Test_mockFromConfig(t *testing.T) {
 	const body = "my-mock-response-body"
 
-	expectedHeaders := map[string]string{
-		"key": "value",
+	expectedHeaders := []oas.Header{
+		{
+			Name:  "key",
+			Value: "value",
+		},
 	}
 
 	tykMockRespOp := &oas.MockResponse{
@@ -258,9 +264,9 @@ func Test_mockFromOAS(t *testing.T) {
 			assert.Equal(t, "application/json", contentType)
 			assert.Equal(t, `"Furkan"`, string(body))
 
-			expectedHeaders := map[string]string{
-				"Test-header-1": "test-header-value-1",
-				"Test-header-2": "test-header-value-2",
+			expectedHeaders := []oas.Header{
+				{Name: "Test-header-1", Value: "test-header-value-1"},
+				{Name: "Test-header-2", Value: "test-header-value-2"},
 			}
 			assert.Equal(t, expectedHeaders, headers)
 		})


### PR DESCRIPTION
We don't use maps for key values but arrays.