### PR TITLE
[TT-7661] reload all APIs having a plugin defined in API definition

### DIFF
--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -318,7 +318,7 @@ func (a APIDefinitionLoader) MakeSpec(def *nestedApiDefinition, logger *logrus.E
 	// Unique API content ID, to check if we already have if it changed from previous sync
 	spec.Checksum = base64.URLEncoding.EncodeToString(sha256hash[:])
 
-	if currSpec := a.Gw.getApiSpec(def.APIID); currSpec != nil && currSpec.Checksum == spec.Checksum {
+	if currSpec := a.Gw.getApiSpec(def.APIID); !shouldReloadSpec(currSpec, spec) {
 		return a.Gw.getApiSpec(def.APIID)
 	}
 

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -318,6 +318,8 @@ func (a APIDefinitionLoader) MakeSpec(def *nestedApiDefinition, logger *logrus.E
 	// Unique API content ID, to check if we already have if it changed from previous sync
 	spec.Checksum = base64.URLEncoding.EncodeToString(sha256hash[:])
 
+	spec.APIDefinition = def.APIDefinition
+
 	if currSpec := a.Gw.getApiSpec(def.APIID); !shouldReloadSpec(currSpec, spec) {
 		return a.Gw.getApiSpec(def.APIID)
 	}
@@ -350,8 +352,6 @@ func (a APIDefinitionLoader) MakeSpec(def *nestedApiDefinition, logger *logrus.E
 			def.VersionData.Versions[key] = ver
 		}
 	}
-
-	spec.APIDefinition = def.APIDefinition
 
 	// We'll push the default HealthChecker:
 	spec.Health = &DefaultHealthChecker{

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -321,7 +321,7 @@ func (a APIDefinitionLoader) MakeSpec(def *nestedApiDefinition, logger *logrus.E
 	spec.APIDefinition = def.APIDefinition
 
 	if currSpec := a.Gw.getApiSpec(def.APIID); !shouldReloadSpec(currSpec, spec) {
-		return a.Gw.getApiSpec(def.APIID)
+		return currSpec
 	}
 
 	if logger == nil {

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -740,7 +740,7 @@ func (gw *Gateway) loadHTTPService(spec *APISpec, apisByListen map[string]int, g
 
 	var chainObj *ChainObject
 
-	if curSpec := gw.getApiSpec(spec.APIID); curSpec != nil && curSpec.Checksum == spec.Checksum {
+	if curSpec := gw.getApiSpec(spec.APIID); !shouldReloadSpec(curSpec, spec) {
 		if chain, found := gw.apisHandlesByID.Load(spec.APIID); found {
 			chainObj = chain.(*ChainObject)
 		}
@@ -919,7 +919,7 @@ func (gw *Gateway) loadApps(specs []*APISpec) {
 				spec.Proxy.ListenPath = converted
 			}
 
-			if currSpec := gw.getApiSpec(spec.APIID); currSpec != nil && spec.Checksum == currSpec.Checksum {
+			if currSpec := gw.getApiSpec(spec.APIID); !shouldReloadSpec(currSpec, spec) {
 				tmpSpecRegister[spec.APIID] = currSpec
 			} else {
 				tmpSpecRegister[spec.APIID] = spec

--- a/gateway/util.go
+++ b/gateway/util.go
@@ -150,8 +150,11 @@ func getAPIURL(apiDef apidef.APIDefinition, gwConfig config.Config) string {
 }
 
 func shouldReloadSpec(existingSpec, newSpec *APISpec) bool {
-	specChanged := existingSpec != nil && existingSpec.Checksum != newSpec.Checksum
-	if specChanged {
+	if existingSpec == nil {
+		return true
+	}
+
+	if existingSpec.Checksum != newSpec.Checksum {
 		return true
 	}
 
@@ -175,11 +178,8 @@ func shouldReloadSpec(existingSpec, newSpec *APISpec) bool {
 	}
 
 	customPlugin = mwsEnabled(newSpec.CustomMiddleware.Response)
-	if customPlugin {
-		return true
-	}
 
-	return false
+	return customPlugin
 }
 
 func mwsEnabled(mwDefs []apidef.MiddlewareDefinition) bool {

--- a/gateway/util.go
+++ b/gateway/util.go
@@ -163,6 +163,10 @@ func shouldReloadSpec(existingSpec, newSpec *APISpec) bool {
 		return true
 	}
 
+	if newSpec.CustomMiddleware.Driver == apidef.GrpcDriver {
+		return false
+	}
+
 	if middleware.Enabled(newSpec.CustomMiddleware.AuthCheck) {
 		return true
 	}

--- a/gateway/util.go
+++ b/gateway/util.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/internal/middleware"
 )
 
 // appendIfMissing ensures dest slice is unique with new items.
@@ -158,39 +159,29 @@ func shouldReloadSpec(existingSpec, newSpec *APISpec) bool {
 		return true
 	}
 
-	if mwEnabled(newSpec.CustomMiddleware.AuthCheck) {
+	if newSpec.hasVirtualEndpoint() {
 		return true
 	}
 
-	customPlugin := mwsEnabled(newSpec.CustomMiddleware.Pre)
-	if customPlugin {
+	if middleware.Enabled(newSpec.CustomMiddleware.AuthCheck) {
 		return true
 	}
 
-	customPlugin = mwsEnabled(newSpec.CustomMiddleware.PostKeyAuth)
-	if customPlugin {
+	if middleware.Enabled(newSpec.CustomMiddleware.Pre...) {
 		return true
 	}
 
-	customPlugin = mwsEnabled(newSpec.CustomMiddleware.Post)
-	if customPlugin {
+	if middleware.Enabled(newSpec.CustomMiddleware.PostKeyAuth...) {
 		return true
 	}
 
-	customPlugin = mwsEnabled(newSpec.CustomMiddleware.Response)
-
-	return customPlugin
-}
-
-func mwsEnabled(mwDefs []apidef.MiddlewareDefinition) bool {
-	for _, mwDef := range mwDefs {
-		if mwEnabled(mwDef) {
-			return true
-		}
+	if middleware.Enabled(newSpec.CustomMiddleware.Post...) {
+		return true
 	}
+
+	if middleware.Enabled(newSpec.CustomMiddleware.Response...) {
+		return true
+	}
+
 	return false
-}
-
-func mwEnabled(mwDef apidef.MiddlewareDefinition) bool {
-	return !mwDef.Disabled && mwDef.Path != "" && mwDef.Name != ""
 }

--- a/gateway/util_test.go
+++ b/gateway/util_test.go
@@ -236,3 +236,104 @@ func Test_getAPIURL(t *testing.T) {
 		})
 	}
 }
+
+func Test_shouldReloadSpec(t *testing.T) {
+	t.Run("checksum mismatch", func(t *testing.T) {
+		existingSpec, newSpec := &APISpec{Checksum: "1"}, &APISpec{Checksum: "2"}
+		assert.True(t, shouldReloadSpec(existingSpec, newSpec))
+	})
+
+	t.Run("mw enabled", func(t *testing.T) {
+		tcs := []struct {
+			spec         *APISpec
+			shouldReload bool
+		}{
+			{
+				spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddleware: apidef.MiddlewareSection{
+							AuthCheck: apidef.MiddlewareDefinition{
+								Disabled: false,
+								Name:     "auth",
+								Path:     "path",
+							},
+						},
+					},
+				},
+				shouldReload: true,
+			},
+			{
+				spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddleware: apidef.MiddlewareSection{
+							Pre: []apidef.MiddlewareDefinition{
+								{
+									Disabled: false,
+									Name:     "pre",
+									Path:     "path",
+								},
+							},
+						},
+					},
+				},
+				shouldReload: true,
+			},
+			{
+				spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddleware: apidef.MiddlewareSection{
+							Pre: []apidef.MiddlewareDefinition{
+								{
+									Disabled: false,
+									Name:     "postAuth",
+									Path:     "path",
+								},
+							},
+						},
+					},
+				},
+				shouldReload: true,
+			},
+			{
+				spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddleware: apidef.MiddlewareSection{
+							Pre: []apidef.MiddlewareDefinition{
+								{
+									Disabled: false,
+									Name:     "post",
+									Path:     "path",
+								},
+							},
+						},
+					},
+				},
+				shouldReload: true,
+			},
+			{
+				spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddleware: apidef.MiddlewareSection{
+							Pre: []apidef.MiddlewareDefinition{
+								{
+									Disabled: false,
+									Name:     "response",
+									Path:     "path",
+								},
+							},
+						},
+					},
+				},
+				shouldReload: true,
+			},
+			{
+				spec:         &APISpec{APIDefinition: &apidef.APIDefinition{}},
+				shouldReload: false,
+			},
+		}
+
+		for _, tc := range tcs {
+			assert.Equal(t, tc.shouldReload, shouldReloadSpec(nil, tc.spec))
+		}
+	})
+}

--- a/gateway/util_test.go
+++ b/gateway/util_test.go
@@ -238,6 +238,10 @@ func Test_getAPIURL(t *testing.T) {
 }
 
 func Test_shouldReloadSpec(t *testing.T) {
+	t.Run("empty curr spec", func(t *testing.T) {
+		assert.True(t, shouldReloadSpec(nil, &APISpec{}))
+	})
+
 	t.Run("checksum mismatch", func(t *testing.T) {
 		existingSpec, newSpec := &APISpec{Checksum: "1"}, &APISpec{Checksum: "2"}
 		assert.True(t, shouldReloadSpec(existingSpec, newSpec))
@@ -333,7 +337,7 @@ func Test_shouldReloadSpec(t *testing.T) {
 		}
 
 		for _, tc := range tcs {
-			assert.Equal(t, tc.shouldReload, shouldReloadSpec(nil, tc.spec))
+			assert.Equal(t, tc.shouldReload, shouldReloadSpec(&APISpec{}, tc.spec))
 		}
 	})
 }

--- a/gateway/util_test.go
+++ b/gateway/util_test.go
@@ -250,13 +250,29 @@ func Test_shouldReloadSpec(t *testing.T) {
 		assert.True(t, shouldReloadSpec(existingSpec, newSpec))
 	})
 
+	type testCase struct {
+		name string
+		spec *APISpec
+		want bool
+	}
+
+	assertionHelper := func(t *testing.T, tcs []testCase) {
+		t.Helper()
+		for _, tc := range tcs {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				func(spec *APISpec, want bool) {
+					if got := shouldReloadSpec(&APISpec{}, spec); got != want {
+						t.Errorf("shouldReloadSpec() = %v, want %v", got, want)
+					}
+				}(tc.spec, tc.want)
+			})
+		}
+	}
+
 	t.Run("virtual endpoint", func(t *testing.T) {
 		t.Parallel()
-		tcs := []struct {
-			name string
-			spec *APISpec
-			want bool
-		}{
+		tcs := []testCase{
 			{
 				name: "disabled",
 				spec: &APISpec{APIDefinition: &apidef.APIDefinition{
@@ -299,23 +315,12 @@ func Test_shouldReloadSpec(t *testing.T) {
 			},
 		}
 
-		for _, tc := range tcs {
-			t.Run(tc.name, func(t *testing.T) {
-				t.Parallel()
-				if got := shouldReloadSpec(&APISpec{}, tc.spec); got != tc.want {
-					t.Errorf("shouldReloadSpec() = %v, want %v", got, tc.want)
-				}
-			})
-		}
+		assertionHelper(t, tcs)
 	})
 
 	t.Run("driver", func(t *testing.T) {
 		t.Parallel()
-		tcs := []struct {
-			name string
-			spec *APISpec
-			want bool
-		}{
+		tcs := []testCase{
 			{
 				name: "grpc",
 				spec: &APISpec{
@@ -352,23 +357,12 @@ func Test_shouldReloadSpec(t *testing.T) {
 			},
 		}
 
-		for _, tc := range tcs {
-			t.Run(tc.name, func(t *testing.T) {
-				t.Parallel()
-				if got := shouldReloadSpec(&APISpec{}, tc.spec); got != tc.want {
-					t.Errorf("shouldReloadSpec() = %v, want %v", got, tc.want)
-				}
-			})
-		}
+		assertionHelper(t, tcs)
 	})
 
 	t.Run("mw enabled", func(t *testing.T) {
 		t.Parallel()
-		tcs := []struct {
-			name string
-			spec *APISpec
-			want bool
-		}{
+		tcs := []testCase{
 			{
 				name: "auth",
 				spec: &APISpec{
@@ -454,13 +448,6 @@ func Test_shouldReloadSpec(t *testing.T) {
 			},
 		}
 
-		for _, tc := range tcs {
-			t.Run(tc.name, func(t *testing.T) {
-				t.Parallel()
-				if got := shouldReloadSpec(&APISpec{}, tc.spec); got != tc.want {
-					t.Errorf("shouldReloadSpec() = %v, want %v", got, tc.want)
-				}
-			})
-		}
+		assertionHelper(t, tcs)
 	})
 }

--- a/gateway/util_test.go
+++ b/gateway/util_test.go
@@ -258,14 +258,13 @@ func Test_shouldReloadSpec(t *testing.T) {
 
 	assertionHelper := func(t *testing.T, tcs []testCase) {
 		t.Helper()
-		for _, tc := range tcs {
+		for i := 0; i < len(tcs); i++ {
+			tc := tcs[i]
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
-				func(spec *APISpec, want bool) {
-					if got := shouldReloadSpec(&APISpec{}, spec); got != want {
-						t.Errorf("shouldReloadSpec() = %v, want %v", got, want)
-					}
-				}(tc.spec, tc.want)
+				if got := shouldReloadSpec(&APISpec{}, tc.spec); got != tc.want {
+					t.Errorf("shouldReloadSpec() = %v, want %v", got, tc.want)
+				}
 			})
 		}
 	}

--- a/gateway/util_test.go
+++ b/gateway/util_test.go
@@ -247,6 +247,56 @@ func Test_shouldReloadSpec(t *testing.T) {
 		assert.True(t, shouldReloadSpec(existingSpec, newSpec))
 	})
 
+	t.Run("virtual endpoint", func(t *testing.T) {
+		tcs := []struct {
+			spec         *APISpec
+			shouldReload bool
+		}{
+			{
+				spec: &APISpec{APIDefinition: &apidef.APIDefinition{
+					VersionData: apidef.VersionData{
+						Versions: map[string]apidef.VersionInfo{
+							"": {
+								ExtendedPaths: apidef.ExtendedPathsSet{
+									Virtual: []apidef.VirtualMeta{
+										{
+											Disabled: false,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				},
+				shouldReload: true,
+			},
+			{
+				spec: &APISpec{APIDefinition: &apidef.APIDefinition{
+					VersionData: apidef.VersionData{
+						Versions: map[string]apidef.VersionInfo{
+							"": {
+								ExtendedPaths: apidef.ExtendedPathsSet{
+									Virtual: []apidef.VirtualMeta{
+										{
+											Disabled: true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				},
+				shouldReload: false,
+			},
+		}
+
+		for _, tc := range tcs {
+			assert.Equal(t, tc.shouldReload, shouldReloadSpec(&APISpec{}, tc.spec))
+		}
+	})
+
 	t.Run("mw enabled", func(t *testing.T) {
 		tcs := []struct {
 			spec         *APISpec

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -1,0 +1,14 @@
+package middleware
+
+import "github.com/TykTechnologies/tyk/apidef"
+
+func Enabled(defs ...apidef.MiddlewareDefinition) bool {
+	for _, def := range defs {
+		// gRPC coprocess won't return true since def.path would be empty.
+		if !def.Disabled && def.Path != "" && def.Name != "" {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -2,10 +2,10 @@ package middleware
 
 import "github.com/TykTechnologies/tyk/apidef"
 
+// Enabled returns whether middlewares are enabled or not.
 func Enabled(defs ...apidef.MiddlewareDefinition) bool {
 	for _, def := range defs {
-		// gRPC coprocess won't return true since def.path would be empty.
-		if !def.Disabled && def.Path != "" && def.Name != "" {
+		if !def.Disabled && def.Name != "" {
 			return true
 		}
 	}

--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -1,0 +1,63 @@
+package middleware
+
+import (
+	"testing"
+
+	"github.com/TykTechnologies/tyk/apidef"
+)
+
+func TestEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		mws  []apidef.MiddlewareDefinition
+		want bool
+	}{
+		{
+			name: "disabled",
+			mws: []apidef.MiddlewareDefinition{
+				{
+					Disabled: true,
+					Name:     "mwFunc",
+					Path:     "path",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "enabled with empty name and path",
+			mws: []apidef.MiddlewareDefinition{
+				{
+					Disabled: false,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "enabled with empty name and path",
+			mws: []apidef.MiddlewareDefinition{
+				{
+					Disabled: false,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "enabled",
+			mws: []apidef.MiddlewareDefinition{
+				{
+					Disabled: false,
+					Name:     "mwFunc",
+					Path:     "/path/to/plugin",
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Enabled(tt.mws...); got != tt.want {
+				t.Errorf("Enabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -47,7 +47,6 @@ func TestEnabled(t *testing.T) {
 				{
 					Disabled: false,
 					Name:     "mwFunc",
-					Path:     "/path/to/plugin",
 				},
 			},
 			want: true,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Currently APIs are not reloaded unless API definition checksum isn't changed. 
However this could lead to API not reloading when custom middlewares are used, since when plugin shared objects or js files etc changes doesn't make the checksum change.
As a solution to this, we can reload all APIs which have custom middleware enabled.
Also gRPC plugins need not be reloaded unless there's a change in API definition, so that should be skipped.
<!-- Describe your changes in detail -->

## Related Issue
https://tyktech.atlassian.net/browse/TT-7661


## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
