### PR TITLE
[ TT-7872] feat: Add Preview Environments to Pull Requests — Uffizzi Integration

### DIFF
--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -1,0 +1,104 @@
+name: Build PR Image
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed, review_requested]
+
+jobs:
+
+  build-tyk:
+    name: Build and push `Tyk`
+    runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+    if: ${{ github.event.action != 'closed' }}
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          buildkitd-flags: --debug
+
+      - name: Generate UUID image name
+        id: uuid
+        run: echo "UUID_WORKER=$(uuidgen)" >> $GITHUB_ENV
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: registry.uffizzi.com/${{ env.UUID_WORKER }}
+          tags: type=raw,value=60d
+      
+      - name: Build and Push Image to registry.uffizzi.com - Uffizzi's ephemeral Registry
+        uses: docker/build-push-action@v3
+        with:
+          context: ./
+          file: ./Dockerfile.uffizzi
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha, mode=max
+
+  render-compose-file:
+    name: Render Docker Compose File
+    # Pass output of this workflow to another triggered by `workflow_run` event.
+    runs-on: ubuntu-latest
+    needs:
+      - build-tyk
+    outputs:
+      compose-file-cache-key: ${{ steps.hash.outputs.hash }}
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+      - name: Render Compose File
+        run: |
+          TYK_IMAGE=${{ needs.build-tyk.outputs.tags }}
+          export TYK_IMAGE
+          export UFFIZZI_URL=\$UFFIZZI_URL
+          GHA_ACTOR=${{github.actor}}
+          GHA_REPO=${{github.event.repository.name}}
+          GHA_BRANCH=${{github.head_ref}}
+          export GHA_ACTOR GHA_REPO GHA_BRANCH
+          # Render simple template from environment variables.
+          envsubst < docker-compose.uffizzi.yml > docker-compose.rendered.yml
+          cat docker-compose.rendered.yml
+      - name: Upload Rendered Compose File as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: docker-compose.rendered.yml
+          retention-days: 2
+      - name: Serialize PR Event to File
+        run: |
+          cat << EOF > event.json
+          ${{ toJSON(github.event) }}
+
+          EOF
+      - name: Upload PR Event as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: event.json
+          retention-days: 2
+
+  delete-preview:
+    name: Call for Preview Deletion
+    runs-on: ubuntu-latest
+    if: ${{ github.event.action == 'closed' }}
+    steps:
+      # If this PR is closing, we will not render a compose file nor pass it to the next workflow.
+      - name: Serialize PR Event to File
+        run: |
+          cat << EOF > event.json
+          ${{ toJSON(github.event) }}
+
+          EOF
+      - name: Upload PR Event as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: event.json
+          retention-days: 2

--- a/.github/workflows/uffizzi-preview.yml
+++ b/.github/workflows/uffizzi-preview.yml
@@ -1,0 +1,87 @@
+name: Deploy Uffizzi Preview
+
+on:
+  workflow_run:
+    workflows:
+      - "Build PR Image"
+    types:
+      - completed
+
+jobs:
+  cache-compose-file:
+    name: Cache Compose File
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    outputs:
+      compose-file-cache-key: ${{ env.HASH }}
+      pr-number: ${{ env.PR_NUMBER }}
+    steps:
+      - name: 'Download artifacts'
+        # Fetch output (zip archive) from the workflow run that triggered this workflow.
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "preview-spec"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/preview-spec.zip`, Buffer.from(download.data));
+
+      - name: 'Unzip artifact'
+        run: unzip preview-spec.zip
+      - name: Read Event into ENV
+        run: |
+          echo 'EVENT_JSON<<EOF' >> $GITHUB_ENV
+          cat event.json >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+      - name: Hash Rendered Compose File
+        id: hash
+        # If the previous workflow was triggered by a PR close event, we will not have a compose file artifact.
+        if: ${{ fromJSON(env.EVENT_JSON).action != 'closed' }}
+        run: echo "HASH=$(md5sum docker-compose.rendered.yml | awk '{ print $1 }')" >> $GITHUB_ENV
+      - name: Cache Rendered Compose File
+        if: ${{ fromJSON(env.EVENT_JSON).action != 'closed' }}
+        uses: actions/cache@v3
+        with:
+          path: docker-compose.rendered.yml
+          key: ${{ env.HASH }}
+
+      - name: Read PR Number From Event Object
+        id: pr
+        run: echo "PR_NUMBER=${{ fromJSON(env.EVENT_JSON).number }}" >> $GITHUB_ENV
+      - name: DEBUG - Print Job Outputs
+        if: ${{ runner.debug }}
+        run: |
+          echo "PR number: ${{ env.PR_NUMBER }}"
+          echo "Compose file hash: ${{ env.HASH }}"
+          cat event.json
+
+  deploy-uffizzi-preview:
+    name: Use Remote Workflow to Preview on Uffizzi
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    needs:
+      - cache-compose-file
+    uses: UffizziCloud/preview-action/.github/workflows/reusable.yaml@v2
+    with:
+      # If this workflow was triggered by a PR close event, cache-key will be an empty string
+      # and this reusable workflow will delete the preview deployment.
+      compose-file-cache-key: ${{ needs.cache-compose-file.outputs.compose-file-cache-key }}
+      compose-file-cache-path: docker-compose.rendered.yml
+      server: https://app.uffizzi.com
+      pr-number: ${{ needs.cache-compose-file.outputs.pr-number }}
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write

--- a/Dockerfile.uffizzi
+++ b/Dockerfile.uffizzi
@@ -1,0 +1,72 @@
+FROM debian:bullseye as assets
+
+# This Dockerfile facilitates bleeding edge development docker image builds
+# directly from source. To build a development image, run `make docker`.
+# If you need to tweak the environment for testing, you can override the
+# `GO_VERSION` and `PYTHON_VERSION` as docker build arguments.
+
+ARG GO_VERSION=1.16
+ARG PYTHON_VERSION=3.7.13
+
+WORKDIR /assets
+
+RUN	apt update && apt install wget -y && \
+ 	wget -q https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && \
+	wget -q https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.xz
+
+FROM debian:bullseye
+
+ARG GO_VERSION=1.16
+ARG PYTHON_VERSION=3.7.13
+
+COPY --from=assets /assets/ /tmp/
+WORKDIR /tmp
+
+# Install Go
+
+ENV PATH=$PATH:/usr/local/go/bin
+
+RUN	tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz && \
+	go version
+
+# Build essentials
+
+RUN apt update && apt install build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev curl wget libbz2-dev -y
+
+# Install $PYTHON_VERSION
+
+## This just installs whatever is is bullseye, makes docker build (fast/small)-(er)
+RUN	apt install python3 -y
+
+# This runs python code slower, but the process finishes quicker
+RUN	tar -xf Python-${PYTHON_VERSION}.tar.xz && ls -la && \
+	cd Python-${PYTHON_VERSION}/ && \
+	./configure --enable-shared && make build_all && \
+	make altinstall && \
+	ldconfig $PWD
+
+## This runs python code faster, but is expensive to build and runs regression tests
+# RUN	tar -xf Python-${PYTHON_VERSION}.tar.xz && ls -la && \
+#	cd Python-${PYTHON_VERSION}/ && \
+#	./configure --enable-shared --enable-optimizations && make -j 2 && \
+#	make altinstall && \
+#	ldconfig $PWD
+
+# Clean up build assets
+RUN find /tmp -type f -delete
+
+# Build gateway
+RUN mkdir /opt/tyk-gateway
+WORKDIR /opt/tyk-gateway
+ADD . /opt/tyk-gateway
+
+RUN make build && go clean -modcache
+
+COPY tyk.conf.uffizzi tyk.conf
+
+RUN echo "Tyk: $(/opt/tyk-gateway/tyk --version 2>&1)" && \
+	echo "Go: $(go version)" && \
+	echo "Python: $(python3 --version)"
+
+ENTRYPOINT ["/opt/tyk-gateway/tyk"]
+CMD [ "--conf=/opt/tyk-gateway/tyk.conf" ]

--- a/docker-compose.uffizzi.yml
+++ b/docker-compose.uffizzi.yml
@@ -1,0 +1,87 @@
+version: '3.9'
+
+x-uffizzi:
+  ingress:
+    service: tyk-dashboard
+    port: 3000
+
+services:
+  
+  tyk-dashboard:
+    image: tykio/tyk-dashboard:v4.3
+    environment:
+      - TYK_DB_STORAGE_MAIN_TYPE=postgres
+      - TYK_DB_STORAGE_MAIN_CONNECTIONSTRING=user=postgres password=password database='tyk_analytics' host=localhost port=5432
+      - TYK_DB_LISTENPORT=3000
+      - TYK_DB_ADMINSECRET=12345
+      - TYK_DB_TYKAPI_HOST=http://localhost
+      - TYK_DB_TYKAPI_PORT=8080
+      - TYK_DB_TYKAPI_SECRET=352d20ee67be67f6340b4c0605b044b7
+      - TYK_DB_NODESECRET=352d20ee67be67f6340b4c0605b044b7
+      - TYK_DB_REDISHOST=127.0.0.1
+      - TYK_DB_REDISPORT=6379
+      - TYK_DB_REDISPASSWORD=
+      - TYK_DB_ENABLECLUSTER=false
+      - TYK_DB_REDISDATABASE=0
+      - TYK_DB_ENABLEHASHEDKEYSLISTING=true
+      - TYK_DB_ENABLEUPDATEKEYBYHASH=true
+      - TYK_DB_ENABLEAGGREGATELOOKUPS=true
+      - TYK_DB_MONGOURL=mongodb://admin:password@localhost:27017/tyk_analytics?authSource=admin
+      - TYK_DB_MONGOUSESSL=false
+    ports:
+      - "3000:3000"
+    deploy:
+      resources:
+        limits:
+          memory: 2000M  
+
+  tyk-gateway:
+    image: "${TYK_IMAGE}"
+    ports:
+      - "8080:8080"
+    environment:
+      - TYK_GW_LISTENPORT=8080
+      - TYK_GW_SECRET=352d20ee67be67f6340b4c0605b044b7
+      - TYK_GW_NODESECRET=352d20ee67be67f6340b4c0605b044b7  
+      - TYK_GW_ENABLEHASHEDKEYSLISTING=true
+      - TYK_GW_USEREDISLOG=true
+    deploy:
+      resources:
+        limits:
+          memory: 2000M  
+
+  tyk-redis:
+    image: redis
+    ports:
+      - "6379:6379"
+    deploy:
+      resources:
+        limits:
+          memory: 500M    
+
+  tyk-postgres:
+    image: postgres:latest
+    container_name: tyk-postgres
+    environment:
+      - POSTGRES_DB=tyk_analytics
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=password
+      - PGDATA=/tmp
+    ports:
+      - "5432:5432" 
+    deploy:
+      resources:
+        limits:
+          memory: 500M   
+  
+  tyk-mongo:
+    image: mongo:4.0.25
+    ports:
+      - "27019:27019"
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=admin
+      - MONGO_INITDB_ROOT_PASSWORD=password   
+    deploy:
+      resources:
+        limits:
+          memory: 1000M

--- a/tyk.conf.uffizzi
+++ b/tyk.conf.uffizzi
@@ -1,0 +1,54 @@
+{
+  "listen_address": "",
+  "listen_port": 8080,
+  "secret": "352d20ee67be67f6340b4c0605b044b7",
+  "node_secret": "352d20ee67be67f6340b4c0605b044b7",
+  "template_path": "/opt/tyk-gateway/templates",
+  "use_db_app_configs": false,
+  "app_path": "/opt/tyk-gateway/apps",
+  "middleware_path": "/opt/tyk-gateway/middleware",
+  "storage": {
+    "type": "redis",
+    "host": "localhost",
+    "port": 6379,
+    "username": "",
+    "password": "",
+    "database": 0,
+    "timeout":15,
+    "optimisation_max_idle": 2000,
+    "optimisation_max_active": 4000
+  },
+  "http_server_options": {
+    "enable_http2": true,
+    "enable_websockets": true
+  },
+  "use_db_app_configs": true,
+  "db_app_conf_options": {
+        "connection_string": "http://localhost:3000",
+        "node_is_segmented": false,
+        "tags": null
+  },
+  "disable_dashboard_zeroconf": false,
+  "app_path": "/opt/tyk-gateway/apps",
+  "middleware_path": "/opt/tyk-gateway/middleware",
+  "enable_analytics": false,
+  "analytics_config": {
+    "type": "",
+    "ignored_ips": []
+  },
+  "dns_cache": {
+    "enabled": false,
+    "ttl": 3600,
+    "check_interval": 60
+  },
+  "allow_master_keys": false,
+  "allow_insecure_configs": true,
+  "policies": {
+    "policy_source": "file"
+  },
+  "hash_keys": true,
+  "hash_key_function": "murmur64",
+  "suppress_redis_signal_reload": false,
+  "force_global_session_lifetime": false,
+  "max_idle_connections_per_host": 500
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

This PR is adding support for preview environments for PR events (opened, sync'ed, reopened, etc) on Tyk, powered by [Uffizzi](https://www.uffizzi.com/).

This PR uses two GHA workflows — `uffizzi-build.yml` and `uffizzi-preview.yml` — to build and provision preview environments. This PR uses `Dockerfile.uffizzi`, which is based on `Dockerfile` in the source to build `Tyk-gateway` from source, ensuring changes are reflected in the preview environment. 

The `docker-compose.uffizzi.yml` defines `Tyk-gateway` container, which is built from source. It also contains `postgres`, `redis` and `mongodb` for storage operations of `Tyk,` and `Tyk-dashboard`, to act as an interface into `Tyk-gateway`.

Once a PR event is triggered — PR opened, PR synced, review requested — the build workflow `(uffizzi-build.yml)` will build the containers defined in the `docker-compose.uffizzi.yml` file, and the preview workflow `(uffizzi-preview.yml)` will either spin up a new preview or update an existing preview. The previews are ephemeral — so they live for only as long as needed. A comment is posted on the PR containing the URL of the preview environment, allowing contributors and maintainers to easily navigate to the preview. 

Clicking the link posted on the comment will take the user to the preview. The preview landing screen is the `sign-in` screen of `Tyk`. In this PoC, to sign-in, the `license key` must be entered. Post that, users will be prompted to create their org. Once that is done successfully, they'll be viewing `Tyk dashboard` and can use this to interact with `Tyk-gateway`.

## Related Issue
<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->
#4688 

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
Uffizzi is purpose-built for the task of previewing PRs and it integrates with existing workflow to deploy preview environments in the background without any manual steps for maintainers or contributors. It will add another layer of testing on top of `Tyk's` current testing stack, thus also cutting down on the time and effort it'd take to ensure proper coverage. 

The motivation behind this change is to enable `Tyk` to build, iterate and ship faster and with more confidence.

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

To test this:
- I opened [this PR](https://github.com/ShrutiC-git/tyk/pull/4) against the `default` branch in my fork of `tyk`
- Opening the PR triggered the `Build PR Image` action defined by `uffizzi-build.yml` → on completion of which the `Deploy Preview` action defined by `uffizzi-preview.yml` was triggered.
- On successful completion of the `Deploy Preview action`, [this comment](https://github.com/ShrutiC-git/tyk/pull/4#issuecomment-1412182853) was posted on the PR. 
- The comment took me to [this preview environment](https://app.uffizzi.com/github.com/ShrutiC-git/tyk/pull/4).
- Visiting the preview environment, I signed in using the `license key` I had created for testing the PoC. 
- I then created my organization and was successfully logged into `Tyk-dashboard` and interacted with the gateway by creating APIs, adding keys and policies, checking `gateway logs`, etc.

The preview environment linked in this PR is up already, and on a subsequent visit to this particular preview environment, the following credentials can be used to access the preview of `Tyk`

> email/username: test@test.test
password: password

------------------------------------------------------

If there is anything that needs to be changed on this PR to make `Tyk gateway` previews more efficient or any other feedback/concerns, please do let me know! Looking at the docs, I understand, this is a very extensive project with a very wide range of configuration options and it can be used it in so many ways - so cool! 

Let me know how this proposal looks and how can I make the PR more intuitive and useful for the community! cc @alephnull 

PS: _We use this 2-step workflow for open-source projects, to allow open-source projects to have previews for contributions from forks. [Here](https://www.uffizzi.com/preview-environments-guide/github-actions-two-stage-workflow) is a more in-depth read into why we use a two-stage workflow._

-------------------------------------------------------------

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [X] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why

cc @waveywaves