### PR TITLE
[TT-7971] Share VERSION internally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 temp/
 testapps/
 
+/build
+/build_tools
+
 /vendor
 
 /*.conf

--- a/.gitignore
+++ b/.gitignore
@@ -3,20 +3,9 @@
 .vagrant/
 .vscode/
 temp/
-/middleware/bundles
-/middleware/e1d21f942ec746ed416ab97fe1bf07e8/
-/middleware/e1d21f942ec746ed416ab97fe1bf07e8_IGNORED/
 testapps/
 
 /vendor
-
-/utils/release_live.sh
-/utils/release_rc.sh
-/utils/build_hybrid.sh
-/utils/cloud_release.sh
-
-build_tools/
-build/
 
 /*.conf
 /*.json
@@ -45,8 +34,6 @@ petstore.json
 *.log
 !testdata/*.mmdb
 *.pid
-coprocess_gen_test.go
-session_state_gen_test.go
 __pycache__/
 tyk.test
 tyk-gateway.pid

--- a/ci/goreleaser/goreleaser-el7.yml
+++ b/ci/goreleaser/goreleaser-el7.yml
@@ -26,8 +26,8 @@ builds:
     ldflags:
       - -X github.com/TykTechnologies/tyk/internal/build.VERSION={{.Version}}
         -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
-        -X github.com/TykTechnologies/tyk/internal/build.buildDate={{.Date}}
-        -X github.com/TykTechnologies/tyk/internal/build.builtBy=goreleaser
+        -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
+        -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
     env:
       - CC=aarch64-linux-gnu-gcc
     goos:
@@ -148,6 +148,7 @@ dockers:
     - config
     - coprocess
     - ctx
+    - internal
     - dlpython
     - dnscache
     - gateway

--- a/ci/goreleaser/goreleaser-el7.yml
+++ b/ci/goreleaser/goreleaser-el7.yml
@@ -12,9 +12,9 @@ builds:
       - -tags=goplugin
     ldflags:
       - -X github.com/TykTechnologies/tyk/internal/build.VERSION={{.Version}}
-      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
-      - -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
-      - -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
+        -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
+        -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
+        -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
     goos:
       - linux
     goarch:
@@ -25,9 +25,9 @@ builds:
       - -tags=goplugin
     ldflags:
       - -X github.com/TykTechnologies/tyk/internal/build.VERSION={{.Version}}
-      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
-      - -X github.com/TykTechnologies/tyk/internal/build.buildDate={{.Date}}
-      - -X github.com/TykTechnologies/tyk/internal/build.builtBy=goreleaser
+        -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
+        -X github.com/TykTechnologies/tyk/internal/build.buildDate={{.Date}}
+        -X github.com/TykTechnologies/tyk/internal/build.builtBy=goreleaser
     env:
       - CC=aarch64-linux-gnu-gcc
     goos:

--- a/ci/goreleaser/goreleaser-el7.yml
+++ b/ci/goreleaser/goreleaser-el7.yml
@@ -11,7 +11,10 @@ builds:
     flags:
       - -tags=goplugin
     ldflags:
-      - -X github.com/TykTechnologies/tyk/gateway.VERSION={{.Version}} -X github.com/TykTechnologies/tyk/gateway.Commit={{.FullCommit}} -X github.com/TykTechnologies/tyk/gateway.buildDate={{.Date}} -X github.com/TykTechnologies/tyk/gateway.builtBy=goreleaser
+      - -X github.com/TykTechnologies/tyk/internal/build.VERSION={{.Version}}
+      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
     goos:
       - linux
     goarch:
@@ -21,7 +24,10 @@ builds:
     flags:
       - -tags=goplugin
     ldflags:
-      - -X github.com/TykTechnologies/tyk/gateway.VERSION={{.Version}} -X github.com/TykTechnologies/tyk/gateway.Commit={{.FullCommit}} -X github.com/TykTechnologies/tyk/gateway.buildDate={{.Date}} -X github.com/TykTechnologies/tyk/gateway.builtBy=goreleaser
+      - -X github.com/TykTechnologies/tyk/internal/build.VERSION={{.Version}}
+      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
+      - -X github.com/TykTechnologies/tyk/internal/build.buildDate={{.Date}}
+      - -X github.com/TykTechnologies/tyk/internal/build.builtBy=goreleaser
     env:
       - CC=aarch64-linux-gnu-gcc
     goos:

--- a/ci/goreleaser/goreleaser.yml
+++ b/ci/goreleaser/goreleaser.yml
@@ -10,7 +10,10 @@ builds:
     flags:
       - -tags=goplugin
     ldflags:
-      - -X github.com/TykTechnologies/tyk/gateway.VERSION={{.Version}} -X github.com/TykTechnologies/tyk/gateway.Commit={{.FullCommit}} -X github.com/TykTechnologies/tyk/gateway.buildDate={{.Date}} -X github.com/TykTechnologies/tyk/gateway.builtBy=goreleaser
+      - -X github.com/TykTechnologies/tyk/internal/build.VERSION={{.Version}}
+      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
     goos:
       - linux
     goarch:
@@ -20,7 +23,10 @@ builds:
     flags:
       - -tags=goplugin
     ldflags:
-      - -X github.com/TykTechnologies/tyk/gateway.VERSION={{.Version}} -X github.com/TykTechnologies/tyk/gateway.Commit={{.FullCommit}} -X github.com/TykTechnologies/tyk/gateway.buildDate={{.Date}} -X github.com/TykTechnologies/tyk/gateway.builtBy=goreleaser
+      - -X github.com/TykTechnologies/tyk/internal/build.VERSION={{.Version}}
+      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
     env:
       - CC=aarch64-linux-gnu-gcc
     goos:

--- a/ci/goreleaser/goreleaser.yml
+++ b/ci/goreleaser/goreleaser.yml
@@ -155,6 +155,7 @@ dockers:
     - config
     - coprocess
     - ctx
+    - internal
     - dlpython
     - dnscache
     - gateway

--- a/ci/goreleaser/goreleaser.yml
+++ b/ci/goreleaser/goreleaser.yml
@@ -11,9 +11,9 @@ builds:
       - -tags=goplugin
     ldflags:
       - -X github.com/TykTechnologies/tyk/internal/build.VERSION={{.Version}}
-      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
-      - -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
-      - -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
+        -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
+        -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
+        -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
     goos:
       - linux
     goarch:
@@ -24,9 +24,9 @@ builds:
       - -tags=goplugin
     ldflags:
       - -X github.com/TykTechnologies/tyk/internal/build.VERSION={{.Version}}
-      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
-      - -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
-      - -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
+        -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
+        -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
+        -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
     env:
       - CC=aarch64-linux-gnu-gcc
     goos:

--- a/ci/images/plugin-compiler/data/build.sh
+++ b/ci/images/plugin-compiler/data/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -xe
 
-CURRENTVERS=$(perl -n -e'/v(\d+).(\d+).(\d+)/'' && print "v$1\.$2\.$3"' $TYK_GW_PATH/gateway/version.go)
+CURRENTVERS=$(perl -n -e'/v(\d+).(\d+).(\d+)/'' && print "v$1\.$2\.$3"' $TYK_GW_PATH/internal/build/version.go)
 plugin_name=$1
 plugin_id=$2
 # GOOS and GOARCH can be send to override the name of the plugin

--- a/ci/tests/plugin-compiler/test.sh
+++ b/ci/tests/plugin-compiler/test.sh
@@ -29,7 +29,7 @@ docker run --rm -v `pwd`/testplugin:/plugin-source tykio/tyk-plugin-compiler:${t
 # This ensures correct paths when running by hand
 TYK_GW_PATH=$(readlink -f $(dirname $(readlink -f $0))/../../..)
 # Get version from source code (will not include rc tags - same as ci/images/plugin-compiler build.sh)
-TYK_GW_VERSION=$(perl -n -e'/v(\d+).(\d+).(\d+)/'' && print "v$1\.$2\.$3"' $TYK_GW_PATH/gateway/version.go)
+TYK_GW_VERSION=$(perl -n -e'/v(\d+).(\d+).(\d+)/'' && print "v$1\.$2\.$3"' $TYK_GW_PATH/internal/build/version.go)
 
 # if params were not sent, then attempt to get them from env vars
 if [[ $GOOS == "" ]] && [[ $GOARCH == "" ]]; then

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -13,6 +13,7 @@ import (
 	"github.com/TykTechnologies/tyk/cli/importer"
 	"github.com/TykTechnologies/tyk/cli/linter"
 	"github.com/TykTechnologies/tyk/cli/plugin"
+	"github.com/TykTechnologies/tyk/internal/build"
 	logger "github.com/TykTechnologies/tyk/log"
 )
 
@@ -105,6 +106,13 @@ func Init(version string, confPaths []string) {
 
 	// Add plugin commands:
 	plugin.AddTo(app)
+
+	// Print gateway version
+	versionCmd := app.Command("version", "Print tyk version")
+	versionCmd.Action(func(*kingpin.ParseContext) error {
+		fmt.Println(build.VERSION)
+		return nil
+	})
 }
 
 // Parse parses the command-line arguments.

--- a/gateway/health_check.go
+++ b/gateway/health_check.go
@@ -8,11 +8,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/TykTechnologies/tyk/rpc"
-
 	"github.com/sirupsen/logrus"
 
 	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/internal/build"
+	"github.com/TykTechnologies/tyk/rpc"
 	"github.com/TykTechnologies/tyk/storage"
 )
 
@@ -196,7 +196,7 @@ func (gw *Gateway) liveCheckHandler(w http.ResponseWriter, r *http.Request) {
 
 	res := HealthCheckResponse{
 		Status:      Pass,
-		Version:     VERSION,
+		Version:     build.VERSION,
 		Description: "Tyk GW",
 		Details:     checks,
 	}

--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -7,13 +7,13 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/TykTechnologies/tyk-pump/analytics"
-	"github.com/TykTechnologies/tyk/apidef"
-
 	"github.com/sirupsen/logrus"
 
+	"github.com/TykTechnologies/tyk-pump/analytics"
+	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/ctx"
 	"github.com/TykTechnologies/tyk/goplugin"
+	"github.com/TykTechnologies/tyk/internal/build"
 	"github.com/TykTechnologies/tyk/request"
 )
 
@@ -135,7 +135,7 @@ func (m *GoPluginMiddleware) loadPlugin() bool {
 	// try to load plugin
 	var err error
 
-	newPath, err := goplugin.GetPluginFileNameToLoad(goplugin.FileSystemStorage{}, m.Path, VERSION)
+	newPath, err := goplugin.GetPluginFileNameToLoad(goplugin.FileSystemStorage{}, m.Path, build.VERSION)
 	if err != nil {
 		m.logger.WithError(err).Error("plugin file not found")
 		return false

--- a/gateway/res_handler_go_plugin.go
+++ b/gateway/res_handler_go_plugin.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/ctx"
 	"github.com/TykTechnologies/tyk/goplugin"
+	"github.com/TykTechnologies/tyk/internal/build"
 	"github.com/TykTechnologies/tyk/user"
 )
 
@@ -41,7 +42,7 @@ func (h *ResponseGoPluginMiddleware) Init(c interface{}, spec *APISpec) error {
 		return nil
 	}
 
-	newPath, err := goplugin.GetPluginFileNameToLoad(goplugin.FileSystemStorage{}, h.Path, VERSION)
+	newPath, err := goplugin.GetPluginFileNameToLoad(goplugin.FileSystemStorage{}, h.Path, build.VERSION)
 	if err != nil {
 		h.logger.WithError(err).Error("Could not load Go-plugin. File was not found")
 		return err

--- a/gateway/res_handler_header_injector_test.go
+++ b/gateway/res_handler_header_injector_test.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/TykTechnologies/tyk/apidef"

--- a/gateway/res_handler_header_injector_test.go
+++ b/gateway/res_handler_header_injector_test.go
@@ -2,7 +2,6 @@ package gateway
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/TykTechnologies/tyk/apidef"
@@ -89,7 +88,7 @@ func TestResponseHeaderInjection(t *testing.T) {
 		"X-Tyk-Test": "1",
 	}
 
-	userAgent := fmt.Sprintf("\"User-Agent\":\"Tyk/%v\"", VERSION)
+	userAgent := "\"User-Agent\":\"Tyk/1.0.0\""
 
 	_, _ = ts.Run(t, []test.TestCase{
 		// Create base auth based key
@@ -125,7 +124,7 @@ func BenchmarkResponseHeaderInjection(b *testing.B) {
 		"X-Tyk-Test": "1",
 	}
 
-	userAgent := fmt.Sprintf("\"User-Agent\":\"Tyk/%v\"", VERSION)
+	userAgent := "\"User-Agent\":\"Tyk/1.0.0\""
 
 	for i := 0; i < b.N; i++ {
 		_, _ = ts.Run(b, []test.TestCase{

--- a/gateway/res_handler_header_injector_test.go
+++ b/gateway/res_handler_header_injector_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/internal/build"
 	"github.com/TykTechnologies/tyk/test"
 )
 
@@ -88,7 +89,7 @@ func TestResponseHeaderInjection(t *testing.T) {
 		"X-Tyk-Test": "1",
 	}
 
-	userAgent := "\"User-Agent\":\"Tyk/1.0.0\""
+	userAgent := fmt.Sprintf("\"User-Agent\":\"Tyk/%s\"", build.VERSION)
 
 	_, _ = ts.Run(t, []test.TestCase{
 		// Create base auth based key
@@ -124,7 +125,7 @@ func BenchmarkResponseHeaderInjection(b *testing.B) {
 		"X-Tyk-Test": "1",
 	}
 
-	userAgent := "\"User-Agent\":\"Tyk/1.0.0\""
+	userAgent := fmt.Sprintf("\"User-Agent\":\"Tyk/%s\"", build.VERSION)
 
 	for i := 0; i < b.N; i++ {
 		_, _ = ts.Run(b, []test.TestCase{

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -46,12 +46,13 @@ import (
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/ctx"
 	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/internal/build"
 	"github.com/TykTechnologies/tyk/regexp"
 	"github.com/TykTechnologies/tyk/trace"
 	"github.com/TykTechnologies/tyk/user"
 )
 
-var defaultUserAgent = "Tyk/" + VERSION
+var defaultUserAgent = "Tyk/" + build.VERSION
 
 var corsHeaders = []string{
 	"Access-Control-Allow-Origin",

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -54,6 +54,7 @@ import (
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/dnscache"
 	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/internal/build"
 	logger "github.com/TykTechnologies/tyk/log"
 	"github.com/TykTechnologies/tyk/regexp"
 	"github.com/TykTechnologies/tyk/rpc"
@@ -345,7 +346,7 @@ func (gw *Gateway) setupGlobals() {
 
 	versionStore := storage.RedisCluster{KeyPrefix: "version-check-", RedisController: gw.RedisController}
 	versionStore.Connect()
-	err := versionStore.SetKey("gateway", VERSION, 0)
+	err := versionStore.SetKey("gateway", build.VERSION, 0)
 
 	if err != nil {
 		mainLog.WithError(err).Error("Could not set version in versionStore")
@@ -1176,7 +1177,7 @@ func (gw *Gateway) initialiseSystem() error {
 		mainLog.Debug("No configuration file defined, will try to use default (tyk.conf)")
 	}
 
-	mainLog.Infof("Tyk API Gateway %s", VERSION)
+	mainLog.Infof("Tyk API Gateway %s", build.VERSION)
 
 	if !gw.isRunningTests() {
 		gwConfig := config.Config{}
@@ -1506,7 +1507,7 @@ func Start() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	cli.Init(VERSION, confPaths)
+	cli.Init(build.VERSION, confPaths)
 	cli.Parse()
 	// Stop gateway process if not running in "start" mode:
 	if !cli.DefaultMode {
@@ -1777,7 +1778,7 @@ func (gw *Gateway) startServer() {
 	// at this point NodeID is ready to use by DRL
 	gw.drlOnce.Do(gw.startDRL)
 
-	mainLog.Infof("Tyk Gateway started (%s)", VERSION)
+	mainLog.Infof("Tyk Gateway started (%s)", build.VERSION)
 	address := gw.GetConfig().ListenAddress
 	if gw.GetConfig().ListenAddress == "" {
 		address = "(open interface)"

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -43,6 +43,7 @@ import (
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/cli"
 	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/internal/build"
 	"github.com/TykTechnologies/tyk/storage"
 	_ "github.com/TykTechnologies/tyk/templates" // Don't delete
 	"github.com/TykTechnologies/tyk/test"
@@ -1129,7 +1130,7 @@ func (s *Test) newGateway(genConf func(globalConf *config.Config)) *Gateway {
 	defaultTestConfig = gwConfig
 	gw.SetConfig(gwConfig)
 
-	cli.Init(VERSION, confPaths)
+	cli.Init(build.VERSION, confPaths)
 
 	err = gw.initialiseSystem()
 	if err != nil {

--- a/gateway/version.go
+++ b/gateway/version.go
@@ -1,4 +1,0 @@
-package gateway
-
-var VERSION = "v4.3.0"
-var builtBy, Commit, buildDate string

--- a/internal/build/README.md
+++ b/internal/build/README.md
@@ -1,0 +1,13 @@
+# Build package
+
+This package contains values that are injected by goreleaser at build
+time. The main used value in gateway is `VERSION`, notably by goplugins,
+as well as by the gateway itself, providing build information.
+
+This enables:
+
+```
+import "github.com/TykTechnologies/tyk/internal/build"
+
+// use build.VERSION
+```

--- a/internal/build/version.go
+++ b/internal/build/version.go
@@ -1,0 +1,16 @@
+package build
+
+// These values are injected at build-time by CI/goreleaser.
+
+var (
+	// VERSION contains the tagged gateway version. It may contain a `rc` suffix,
+	// which may be delimited with `-rc` or any other suffix. Follows Semver+Tag.
+	VERSION = "v4.3.0"
+
+	// BuiltBy contains the environment name from the build (goreleaser).
+	BuiltBy string
+	// BuildDate is the date the build was made at.
+	BuildDate string
+	// Commit is the commit hash for the build source.
+	Commit string
+)

--- a/smoke-tests/plugin-aliasing/test.sh
+++ b/smoke-tests/plugin-aliasing/test.sh
@@ -29,7 +29,7 @@ docker run --rm -v `pwd`/helloworld-plugin:/plugin-source tykio/tyk-plugin-compi
 # This ensures correct paths when running by hand
 TYK_GW_PATH=$(readlink -f $(dirname $(readlink -f $0))/../../..)
 # Get version from source code (will not include rc tags - same as ci/images/plugin-compiler build.sh)
-TYK_GW_VERSION=$(perl -n -e'/v(\d+).(\d+).(\d+)/'' && print "v$1\.$2\.$3"' ./../../gateway/version.go)
+TYK_GW_VERSION=$(perl -n -e'/v(\d+).(\d+).(\d+)/'' && print "v$1\.$2\.$3"' ./../../internal/build/version.go)
 
 # if params were not sent, then attempt to get them from env vars
 if [[ $GOOS == "" ]] && [[ $GOARCH == "" ]]; then


### PR DESCRIPTION
As VERSION is injected into gateway.VERSION, it can't be shared via packages. `goplugin` can't use VERSION, causing an import diamond-dependency problem that cannot be resolved and the API must pass version info over it's API.

The expected API changes are:

- cli/ package, cli.Init (currently passed version)
- plugins, also currently passed version somewhere
- gateway.VERSION (it remains compatible just not the source of the info anymore)

The PR changes this to:

- create internal/build package with VERSION,
- fixes goreleaser to inject values into `internal/runtime.VERSION`
- update code using VERSION currently

How was this tested:

```
$ go build -ldflags="-X github.com/TykTechnologies/tyk/internal/build.VERSION=1.2.3" . && ./tyk --version
1.2.3
```

https://tyktech.atlassian.net/browse/TT-7971