### PR TITLE
[TT-7970] Fix ID extractor config change which broke backwards compatibility

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -468,23 +468,23 @@ type MiddlewareDefinition struct {
 // IDExtractorConfig specifies the configuration for ID extractor
 type IDExtractorConfig struct {
 	// HeaderName is the header name to extract ID from.
-	HeaderName string `bson:"header_name" json:"header_name"`
+	HeaderName string `mapstructure:"header_name" bson:"header_name" json:"header_name"`
 	// FormParamName is the form parameter name to extract ID from.
-	FormParamName string `bson:"param_name" json:"param_name"`
+	FormParamName string `mapstructure:"param_name" bson:"param_name" json:"param_name"`
 	// RegexExpression is the regular expression to match ID.
-	RegexExpression string `bson:"regex_expression" json:"regex_expression"`
+	RegexExpression string `mapstructure:"regex_expression" bson:"regex_expression" json:"regex_expression"`
 	// RegexMatchIndex is the index from which ID to be extracted after a match.
-	RegexMatchIndex int `bson:"regex_match_index" json:"regex_match_index"`
+	RegexMatchIndex int `mapstructure:"regex_match_index" bson:"regex_match_index" json:"regex_match_index"`
 	// XPathExp is the xpath expression to match ID.
-	XPathExpression string `bson:"xpath_expression" json:"xpath_expression"`
+	XPathExpression string `mapstructure:"xpath_expression" bson:"xpath_expression" json:"xpath_expression"`
 }
 
 type MiddlewareIdExtractor struct {
-	Disabled        bool              `bson:"disabled" json:"disabled"`
-	ExtractFrom     IdExtractorSource `bson:"extract_from" json:"extract_from"`
-	ExtractWith     IdExtractorType   `bson:"extract_with" json:"extract_with"`
-	ExtractorConfig IDExtractorConfig `bson:"extractor_config" json:"extractor_config"`
-	Extractor       IDExtractor       `bson:"-" json:"-"`
+	Disabled        bool                   `bson:"disabled" json:"disabled"`
+	ExtractFrom     IdExtractorSource      `bson:"extract_from" json:"extract_from"`
+	ExtractWith     IdExtractorType        `bson:"extract_with" json:"extract_with"`
+	ExtractorConfig map[string]interface{} `bson:"extractor_config" json:"extractor_config"`
+	Extractor       IDExtractor            `bson:"-" json:"-"`
 }
 
 type MiddlewareSection struct {
@@ -1279,7 +1279,7 @@ func DummyAPI() APIDefinition {
 			PostKeyAuth: []MiddlewareDefinition{},
 			AuthCheck:   MiddlewareDefinition{},
 			IdExtractor: MiddlewareIdExtractor{
-				ExtractorConfig: IDExtractorConfig{},
+				ExtractorConfig: map[string]interface{}{},
 			},
 		},
 		Proxy: ProxyConfig{

--- a/coprocess/grpc/coprocess_grpc_test.go
+++ b/coprocess/grpc/coprocess_grpc_test.go
@@ -294,8 +294,8 @@ func loadTestGRPCAPIs(s *gateway.Test) {
 			IdExtractor: apidef.MiddlewareIdExtractor{
 				ExtractFrom: apidef.HeaderSource,
 				ExtractWith: apidef.ValueExtractor,
-				ExtractorConfig: apidef.IDExtractorConfig{
-					HeaderName: "Authorization",
+				ExtractorConfig: map[string]interface{}{
+					"header_name": "Authorization",
 				},
 			},
 		}
@@ -327,12 +327,10 @@ func loadTestGRPCAPIs(s *gateway.Test) {
 				Name: "testAuthHook1",
 			},
 			IdExtractor: apidef.MiddlewareIdExtractor{
-				Disabled:    false,
-				ExtractFrom: apidef.HeaderSource,
-				ExtractWith: apidef.ValueExtractor,
-				ExtractorConfig: apidef.IDExtractorConfig{
-					HeaderName: "Authorization",
-				},
+				Disabled:        false,
+				ExtractFrom:     apidef.HeaderSource,
+				ExtractWith:     apidef.ValueExtractor,
+				ExtractorConfig: map[string]interface{}{"header_name": "Authorization"},
 			},
 		}
 	}, func(spec *gateway.APISpec) {
@@ -363,12 +361,10 @@ func loadTestGRPCAPIs(s *gateway.Test) {
 				Name: "testAuthHook1",
 			},
 			IdExtractor: apidef.MiddlewareIdExtractor{
-				Disabled:    true,
-				ExtractFrom: apidef.HeaderSource,
-				ExtractWith: apidef.ValueExtractor,
-				ExtractorConfig: apidef.IDExtractorConfig{
-					HeaderName: "Authorization",
-				},
+				Disabled:        true,
+				ExtractFrom:     apidef.HeaderSource,
+				ExtractWith:     apidef.ValueExtractor,
+				ExtractorConfig: map[string]interface{}{"header_name": "Authorization"},
 			},
 		}
 	},

--- a/gateway/coprocess_id_extractor_test.go
+++ b/gateway/coprocess_id_extractor_test.go
@@ -41,7 +41,7 @@ func (ts *Test) createSpecTestFrom(tb testing.TB, def *apidef.APIDefinition) *AP
 }
 
 func (ts *Test) prepareExtractor(tb testing.TB, extractorSource apidef.IdExtractorSource, extractorType apidef.IdExtractorType,
-	config apidef.IDExtractorConfig, disabled bool) (IdExtractor, *APISpec) {
+	config map[string]interface{}, disabled bool) (IdExtractor, *APISpec) {
 	tb.Helper()
 	def := &apidef.APIDefinition{
 		OrgID: MockOrgID,
@@ -108,7 +108,9 @@ func TestValueExtractor(t *testing.T) {
 	testSessionID := ts.GenerateSessionID(extractorValueInput)
 
 	t.Run("HeaderSource", func(t *testing.T) {
-		extractor, spec := ts.prepareExtractor(t, apidef.HeaderSource, apidef.ValueExtractor, apidef.IDExtractorConfig{HeaderName: extractorHeaderName}, false)
+		extractor, spec := ts.prepareExtractor(t, apidef.HeaderSource, apidef.ValueExtractor, map[string]interface{}{
+			"header_name": extractorHeaderName,
+		}, false)
 
 		r := prepareHeaderExtractorRequest(nil)
 		sessionID, overrides := extractor.ExtractAndCheck(r)
@@ -133,7 +135,9 @@ func TestValueExtractor(t *testing.T) {
 	})
 
 	t.Run("FormSource", func(t *testing.T) {
-		extractor, spec := ts.prepareExtractor(t, apidef.FormSource, apidef.ValueExtractor, apidef.IDExtractorConfig{FormParamName: extractorParamName}, false)
+		extractor, spec := ts.prepareExtractor(t, apidef.FormSource, apidef.ValueExtractor, map[string]interface{}{
+			"param_name": extractorParamName,
+		}, false)
 
 		r := prepareExtractorFormRequest(nil)
 		sessionID, overrides := extractor.ExtractAndCheck(r)
@@ -166,10 +170,10 @@ func TestRegexExtractor(t *testing.T) {
 
 	t.Run("HeaderSource", func(t *testing.T) {
 		extractor, spec := ts.prepareExtractor(t, apidef.HeaderSource, apidef.RegexExtractor,
-			apidef.IDExtractorConfig{
-				HeaderName:      extractorHeaderName,
-				RegexExpression: extractorRegexExpr,
-				RegexMatchIndex: extractorRegexMatchIndex,
+			map[string]interface{}{
+				"regex_expression":  extractorRegexExpr,
+				"regex_match_index": extractorRegexMatchIndex,
+				"header_name":       extractorHeaderName,
 			}, false)
 
 		r := prepareHeaderExtractorRequest(nil)
@@ -196,9 +200,9 @@ func TestRegexExtractor(t *testing.T) {
 
 	t.Run("BodySource", func(t *testing.T) {
 		extractor, spec := ts.prepareExtractor(t, apidef.BodySource, apidef.RegexExtractor,
-			apidef.IDExtractorConfig{
-				RegexExpression: extractorRegexExpr,
-				RegexMatchIndex: extractorRegexMatchIndex,
+			map[string]interface{}{
+				"regex_expression":  extractorRegexExpr,
+				"regex_match_index": extractorRegexMatchIndex,
 			}, false)
 
 		r := prepareBodyExtractorRequest("")
@@ -225,10 +229,10 @@ func TestRegexExtractor(t *testing.T) {
 
 	t.Run("FormSource", func(t *testing.T) {
 		extractor, spec := ts.prepareExtractor(t, apidef.FormSource, apidef.RegexExtractor,
-			apidef.IDExtractorConfig{
-				RegexExpression: extractorRegexExpr,
-				RegexMatchIndex: extractorRegexMatchIndex,
-				FormParamName:   extractorParamName,
+			map[string]interface{}{
+				"regex_expression":  extractorRegexExpr,
+				"regex_match_index": extractorRegexMatchIndex,
+				"param_name":        extractorParamName,
 			}, false)
 
 		r := prepareExtractorFormRequest(nil)
@@ -262,9 +266,9 @@ func TestXPathExtractor(t *testing.T) {
 
 	t.Run("HeaderSource", func(t *testing.T) {
 		extractor, spec := ts.prepareExtractor(t, apidef.HeaderSource, apidef.XPathExtractor,
-			apidef.IDExtractorConfig{
-				XPathExpression: extractorXPathExpr,
-				HeaderName:      extractorHeaderName,
+			map[string]interface{}{
+				"xpath_expression": extractorXPathExpr,
+				"header_name":      extractorHeaderName,
 			}, false)
 
 		r := prepareHeaderExtractorRequest(nil)
@@ -291,8 +295,8 @@ func TestXPathExtractor(t *testing.T) {
 
 	t.Run("BodySource", func(t *testing.T) {
 		extractor, spec := ts.prepareExtractor(t, apidef.BodySource, apidef.XPathExtractor,
-			apidef.IDExtractorConfig{
-				XPathExpression: extractorXPathExpr,
+			map[string]interface{}{
+				"xpath_expression": extractorXPathExpr,
 			}, false)
 
 		r := prepareBodyExtractorRequest("")
@@ -319,9 +323,9 @@ func TestXPathExtractor(t *testing.T) {
 
 	t.Run("FormSource", func(t *testing.T) {
 		extractor, spec := ts.prepareExtractor(t, apidef.FormSource, apidef.XPathExtractor,
-			apidef.IDExtractorConfig{
-				XPathExpression: extractorXPathExpr,
-				FormParamName:   extractorParamName,
+			map[string]interface{}{
+				"xpath_expression": extractorXPathExpr,
+				"param_name":       extractorParamName,
 			}, false)
 
 		r := prepareExtractorFormRequest(nil)
@@ -354,8 +358,8 @@ func BenchmarkValueExtractor(b *testing.B) {
 		ts := StartTest(nil)
 		defer ts.Close()
 		extractor, _ := ts.prepareExtractor(b, apidef.HeaderSource, apidef.ValueExtractor,
-			apidef.IDExtractorConfig{
-				HeaderName: extractorHeaderName,
+			map[string]interface{}{
+				"header_name": extractorHeaderName,
 			}, false)
 		headers := map[string]string{extractorHeaderName: extractorValueInput}
 		for i := 0; i < b.N; i++ {
@@ -369,8 +373,8 @@ func BenchmarkValueExtractor(b *testing.B) {
 		ts := StartTest(nil)
 		defer ts.Close()
 		extractor, _ := ts.prepareExtractor(b, apidef.FormSource, apidef.ValueExtractor,
-			apidef.IDExtractorConfig{
-				FormParamName: extractorParamName,
+			map[string]interface{}{
+				"param_name": extractorParamName,
 			}, false)
 		params := map[string]string{extractorParamName: extractorValueInput}
 		for i := 0; i < b.N; i++ {
@@ -388,10 +392,10 @@ func BenchmarkRegexExtractor(b *testing.B) {
 
 		headerName := "testheader"
 		extractor, _ := ts.prepareExtractor(b, apidef.HeaderSource, apidef.RegexExtractor,
-			apidef.IDExtractorConfig{
-				RegexExpression: extractorRegexExpr,
-				RegexMatchIndex: extractorRegexMatchIndex,
-				HeaderName:      headerName,
+			map[string]interface{}{
+				"regex_expression":  extractorRegexExpr,
+				"regex_match_index": extractorRegexMatchIndex,
+				"header_name":       headerName,
 			}, false)
 		headers := map[string]string{extractorHeaderName: extractorRegexInput}
 		for i := 0; i < b.N; i++ {
@@ -405,9 +409,9 @@ func BenchmarkRegexExtractor(b *testing.B) {
 		defer ts.Close()
 
 		extractor, _ := ts.prepareExtractor(b, apidef.BodySource, apidef.RegexExtractor,
-			apidef.IDExtractorConfig{
-				RegexExpression: extractorRegexExpr,
-				RegexMatchIndex: extractorRegexMatchIndex,
+			map[string]interface{}{
+				"regex_expression":  extractorRegexExpr,
+				"regex_match_index": extractorRegexMatchIndex,
 			}, false)
 		for i := 0; i < b.N; i++ {
 			r := prepareBodyExtractorRequest(extractorRegexInput)
@@ -420,10 +424,10 @@ func BenchmarkRegexExtractor(b *testing.B) {
 		defer ts.Close()
 
 		extractor, _ := ts.prepareExtractor(b, apidef.FormSource, apidef.RegexExtractor,
-			apidef.IDExtractorConfig{
-				RegexExpression: extractorRegexExpr,
-				RegexMatchIndex: extractorRegexMatchIndex,
-				FormParamName:   extractorParamName,
+			map[string]interface{}{
+				"regex_expression":  extractorRegexExpr,
+				"regex_match_index": extractorRegexMatchIndex,
+				"param_name":        extractorParamName,
 			}, false)
 		params := map[string]string{extractorParamName: extractorRegexInput}
 		for i := 0; i < b.N; i++ {
@@ -439,11 +443,10 @@ func BenchmarkXPathExtractor(b *testing.B) {
 		ts := StartTest(nil)
 		defer ts.Close()
 
-		extractor, _ := ts.prepareExtractor(b, apidef.HeaderSource, apidef.XPathExtractor,
-			apidef.IDExtractorConfig{
-				XPathExpression: extractorXPathExpr,
-				HeaderName:      extractorHeaderName,
-			}, false)
+		extractor, _ := ts.prepareExtractor(b, apidef.HeaderSource, apidef.XPathExtractor, map[string]interface{}{
+			"xpath_expression": extractorXPathExpr,
+			"header_name":      extractorHeaderName,
+		}, false)
 		headers := map[string]string{extractorHeaderName: extractorXPathInput}
 		for i := 0; i < b.N; i++ {
 			r := prepareHeaderExtractorRequest(headers)
@@ -455,8 +458,9 @@ func BenchmarkXPathExtractor(b *testing.B) {
 		ts := StartTest(nil)
 		defer ts.Close()
 
-		extractor, _ := ts.prepareExtractor(b, apidef.BodySource, apidef.XPathExtractor,
-			apidef.IDExtractorConfig{XPathExpression: extractorXPathExpr}, false)
+		extractor, _ := ts.prepareExtractor(b, apidef.BodySource, apidef.XPathExtractor, map[string]interface{}{
+			"xpath_expression": extractorXPathExpr,
+		}, false)
 		for i := 0; i < b.N; i++ {
 			r := prepareBodyExtractorRequest(extractorXPathInput)
 			extractor.ExtractAndCheck(r)
@@ -467,9 +471,9 @@ func BenchmarkXPathExtractor(b *testing.B) {
 		ts := StartTest(nil)
 		defer ts.Close()
 
-		extractor, _ := ts.prepareExtractor(b, apidef.FormSource, apidef.XPathExtractor, apidef.IDExtractorConfig{
-			XPathExpression: extractorXPathExpr,
-			FormParamName:   extractorParamName,
+		extractor, _ := ts.prepareExtractor(b, apidef.FormSource, apidef.XPathExtractor, map[string]interface{}{
+			"xpath_expression": extractorXPathExpr,
+			"param_name":       extractorParamName,
 		}, false)
 		params := map[string]string{extractorParamName: extractorXPathInput}
 		for i := 0; i < b.N; i++ {
@@ -482,8 +486,8 @@ func BenchmarkXPathExtractor(b *testing.B) {
 func TestIDExtractorDisabled(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()
-	extractor, _ := ts.prepareExtractor(t, apidef.HeaderSource, apidef.ValueExtractor, apidef.IDExtractorConfig{
-		HeaderName: extractorHeaderName,
+	extractor, _ := ts.prepareExtractor(t, apidef.HeaderSource, apidef.ValueExtractor, map[string]interface{}{
+		"header_name": extractorHeaderName,
 	}, true)
 	assert.Nil(t, extractor)
 }


### PR DESCRIPTION
https://tyktech.atlassian.net/browse/TT-7970

https://github.com/TykTechnologies/tyk/pull/4755 broke backwards compatibility for ID extractor config. This PR fixes it.