### PR TITLE
move adapter helper functions to proper util files (TT-7999)

### DIFF
--- a/apidef/adapter/engine_v2_utils.go
+++ b/apidef/adapter/engine_v2_utils.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	graphqlDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/graphql_datasource"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/plan"
 
 	"github.com/TykTechnologies/tyk/apidef"
 )
@@ -32,4 +33,18 @@ func graphqlDataSourceConfiguration(url string, method string, headers map[strin
 	}
 
 	return cfg
+}
+
+func createArgumentConfigurationsForArgumentNames(argumentNames ...string) plan.ArgumentsConfigurations {
+	argConfs := plan.ArgumentsConfigurations{}
+	for _, argName := range argumentNames {
+		argConf := plan.ArgumentConfiguration{
+			Name:       argName,
+			SourceType: plan.FieldArgumentSource,
+		}
+
+		argConfs = append(argConfs, argConf)
+	}
+
+	return argConfs
 }

--- a/apidef/adapter/engine_v2_utils.go
+++ b/apidef/adapter/engine_v2_utils.go
@@ -1,0 +1,35 @@
+package adapter
+
+import (
+	"strings"
+
+	graphqlDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/graphql_datasource"
+
+	"github.com/TykTechnologies/tyk/apidef"
+)
+
+func graphqlDataSourceConfiguration(url string, method string, headers map[string]string, subscriptionType apidef.SubscriptionType) graphqlDataSource.Configuration {
+	dataSourceHeaders := make(map[string]string)
+	for name, value := range headers {
+		dataSourceHeaders[name] = value
+	}
+
+	if strings.HasPrefix(url, "tyk://") {
+		url = strings.ReplaceAll(url, "tyk://", "http://")
+		dataSourceHeaders[apidef.TykInternalApiHeader] = "true"
+	}
+
+	cfg := graphqlDataSource.Configuration{
+		Fetch: graphqlDataSource.FetchConfiguration{
+			URL:    url,
+			Method: method,
+			Header: convertApiDefinitionHeadersToHttpHeaders(dataSourceHeaders),
+		},
+		Subscription: graphqlDataSource.SubscriptionConfiguration{
+			URL:    url,
+			UseSSE: subscriptionType == apidef.GQLSubscriptionSSE,
+		},
+	}
+
+	return cfg
+}

--- a/apidef/adapter/engine_v2_utils_test.go
+++ b/apidef/adapter/engine_v2_utils_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	graphqlDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/graphql_datasource"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/plan"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/TykTechnologies/tyk/apidef"
@@ -93,4 +94,20 @@ func TestGraphqlDataSourceConfiguration(t *testing.T) {
 		assert.Equal(t, expectedGraphqlDataSourceConfiguration, actualGraphqlDataSourceConfiguration)
 	})
 
+}
+
+func TestCreateArgumentConfigurationsForArgumentNames(t *testing.T) {
+	expectedArgumentConfigurations := plan.ArgumentsConfigurations{
+		{
+			Name:       "argument1",
+			SourceType: plan.FieldArgumentSource,
+		},
+		{
+			Name:       "argument2",
+			SourceType: plan.FieldArgumentSource,
+		},
+	}
+
+	actualArgumentConfigurations := createArgumentConfigurationsForArgumentNames("argument1", "argument2")
+	assert.Equal(t, expectedArgumentConfigurations, actualArgumentConfigurations)
 }

--- a/apidef/adapter/engine_v2_utils_test.go
+++ b/apidef/adapter/engine_v2_utils_test.go
@@ -1,0 +1,96 @@
+package adapter
+
+import (
+	"net/http"
+	"testing"
+
+	graphqlDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/graphql_datasource"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk/apidef"
+)
+
+func TestGraphqlDataSourceConfiguration(t *testing.T) {
+	type testInput struct {
+		url              string
+		method           string
+		headers          map[string]string
+		subscriptionType apidef.SubscriptionType
+	}
+
+	t.Run("with internal data source url and sse", func(t *testing.T) {
+		internalDataSource := testInput{
+			url:    "tyk://data-source.fake",
+			method: http.MethodGet,
+			headers: map[string]string{
+				"Authorization": "token",
+				"X-Tyk-Key":     "value",
+			},
+			subscriptionType: apidef.GQLSubscriptionSSE,
+		}
+
+		expectedGraphqlDataSourceConfiguration := graphqlDataSource.Configuration{
+			Fetch: graphqlDataSource.FetchConfiguration{
+				URL:    "http://data-source.fake",
+				Method: http.MethodGet,
+				Header: http.Header{
+					"Authorization": {"token"},
+					http.CanonicalHeaderKey(apidef.TykInternalApiHeader): {"true"},
+					"X-Tyk-Key": {"value"},
+				},
+			},
+			Subscription: graphqlDataSource.SubscriptionConfiguration{
+				URL:           "http://data-source.fake",
+				UseSSE:        true,
+				SSEMethodPost: false,
+			},
+		}
+
+		actualGraphqlDataSourceConfiguration := graphqlDataSourceConfiguration(
+			internalDataSource.url,
+			internalDataSource.method,
+			internalDataSource.headers,
+			internalDataSource.subscriptionType,
+		)
+
+		assert.Equal(t, expectedGraphqlDataSourceConfiguration, actualGraphqlDataSourceConfiguration)
+	})
+
+	t.Run("with external data source url and no sse", func(t *testing.T) {
+		externalDataSource := testInput{
+			url:    "http://data-source.fake",
+			method: http.MethodGet,
+			headers: map[string]string{
+				"Authorization": "token",
+				"X-Tyk-Key":     "value",
+			},
+			subscriptionType: apidef.GQLSubscriptionTransportWS,
+		}
+
+		expectedGraphqlDataSourceConfiguration := graphqlDataSource.Configuration{
+			Fetch: graphqlDataSource.FetchConfiguration{
+				URL:    "http://data-source.fake",
+				Method: http.MethodGet,
+				Header: http.Header{
+					"Authorization": {"token"},
+					"X-Tyk-Key":     {"value"},
+				},
+			},
+			Subscription: graphqlDataSource.SubscriptionConfiguration{
+				URL:           "http://data-source.fake",
+				UseSSE:        false,
+				SSEMethodPost: false,
+			},
+		}
+
+		actualGraphqlDataSourceConfiguration := graphqlDataSourceConfiguration(
+			externalDataSource.url,
+			externalDataSource.method,
+			externalDataSource.headers,
+			externalDataSource.subscriptionType,
+		)
+
+		assert.Equal(t, expectedGraphqlDataSourceConfiguration, actualGraphqlDataSourceConfiguration)
+	})
+
+}

--- a/apidef/adapter/engine_v2_utils_test.go
+++ b/apidef/adapter/engine_v2_utils_test.go
@@ -5,10 +5,11 @@ import (
 	neturl "net/url"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	graphqlDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/graphql_datasource"
 	restDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/rest_datasource"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/plan"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/TykTechnologies/tyk/apidef"
 )

--- a/apidef/adapter/engine_v2_utils_test.go
+++ b/apidef/adapter/engine_v2_utils_test.go
@@ -114,6 +114,73 @@ func TestCreateArgumentConfigurationsForArgumentNames(t *testing.T) {
 	assert.Equal(t, expectedArgumentConfigurations, actualArgumentConfigurations)
 }
 
+func TestExtractURLQueryParamsForEngineV2(t *testing.T) {
+	type expectedOutput struct {
+		urlWithoutParams string
+		engineV2Queries  []restDataSource.QueryConfiguration
+		err              error
+	}
+
+	providedApiDefQueries := []apidef.QueryVariable{
+		{
+			Name:  "providedQueryName1",
+			Value: "providedQueryValue1",
+		},
+		{
+			Name:  "providedQueryName2",
+			Value: "providedQueryValue2",
+		},
+	}
+
+	t.Run("without query params in url", func(t *testing.T) {
+		inputUrl := "http://rest-data-source.fake"
+		expected := expectedOutput{
+			urlWithoutParams: "http://rest-data-source.fake",
+			engineV2Queries: []restDataSource.QueryConfiguration{
+				{
+					Name:  "providedQueryName1",
+					Value: "providedQueryValue1",
+				},
+				{
+					Name:  "providedQueryName2",
+					Value: "providedQueryValue2",
+				},
+			},
+			err: nil,
+		}
+		actualUrlWithoutParams, actualEngineV2Queries, actualErr := extractURLQueryParamsForEngineV2(inputUrl, providedApiDefQueries)
+		assert.Equal(t, expected.urlWithoutParams, actualUrlWithoutParams)
+		assert.Equal(t, expected.engineV2Queries, actualEngineV2Queries)
+		assert.Equal(t, expected.err, actualErr)
+	})
+
+	t.Run("with query params in url", func(t *testing.T) {
+		inputUrl := "http://rest-data-source.fake?urlParam=urlParamValue"
+		expected := expectedOutput{
+			urlWithoutParams: "http://rest-data-source.fake",
+			engineV2Queries: []restDataSource.QueryConfiguration{
+				{
+					Name:  "urlParam",
+					Value: "urlParamValue",
+				},
+				{
+					Name:  "providedQueryName1",
+					Value: "providedQueryValue1",
+				},
+				{
+					Name:  "providedQueryName2",
+					Value: "providedQueryValue2",
+				},
+			},
+			err: nil,
+		}
+		actualUrlWithoutParams, actualEngineV2Queries, actualErr := extractURLQueryParamsForEngineV2(inputUrl, providedApiDefQueries)
+		assert.Equal(t, expected.urlWithoutParams, actualUrlWithoutParams)
+		assert.Equal(t, expected.engineV2Queries, actualEngineV2Queries)
+		assert.Equal(t, expected.err, actualErr)
+	})
+}
+
 func TestAppendURLQueryParamsToEngineV2Queries(t *testing.T) {
 	existingEngineV2Queries := &[]restDataSource.QueryConfiguration{
 		{

--- a/apidef/adapter/engine_v2_utils_test.go
+++ b/apidef/adapter/engine_v2_utils_test.go
@@ -2,9 +2,11 @@ package adapter
 
 import (
 	"net/http"
+	neturl "net/url"
 	"testing"
 
 	graphqlDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/graphql_datasource"
+	restDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/rest_datasource"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/plan"
 	"github.com/stretchr/testify/assert"
 
@@ -110,4 +112,74 @@ func TestCreateArgumentConfigurationsForArgumentNames(t *testing.T) {
 
 	actualArgumentConfigurations := createArgumentConfigurationsForArgumentNames("argument1", "argument2")
 	assert.Equal(t, expectedArgumentConfigurations, actualArgumentConfigurations)
+}
+
+func TestAppendURLQueryParamsToEngineV2Queries(t *testing.T) {
+	existingEngineV2Queries := &[]restDataSource.QueryConfiguration{
+		{
+			Name:  "existingName",
+			Value: "existingValue",
+		},
+	}
+
+	queryValues := neturl.Values{
+		"newKey1": {"newKey1Value1"},
+		"newKey2": {"newKey2Value1", "newKey2Value2"},
+	}
+
+	expectedEngineV2Queries := &[]restDataSource.QueryConfiguration{
+		{
+			Name:  "existingName",
+			Value: "existingValue",
+		},
+		{
+			Name:  "newKey1",
+			Value: "newKey1Value1",
+		},
+		{
+			Name:  "newKey2",
+			Value: "newKey2Value1,newKey2Value2",
+		},
+	}
+
+	appendURLQueryParamsToEngineV2Queries(existingEngineV2Queries, queryValues)
+	assert.Equal(t, expectedEngineV2Queries, existingEngineV2Queries)
+}
+
+func TestAppendApiDefQueriesConfigToEngineV2Queries(t *testing.T) {
+	existingEngineV2Queries := &[]restDataSource.QueryConfiguration{
+		{
+			Name:  "existingName",
+			Value: "existingValue",
+		},
+	}
+
+	apiDefQueryVariables := []apidef.QueryVariable{
+		{
+			Name:  "newName1",
+			Value: "newValue2",
+		},
+		{
+			Name:  "newName2",
+			Value: "newValue2",
+		},
+	}
+
+	expectedEngineV2Queries := &[]restDataSource.QueryConfiguration{
+		{
+			Name:  "existingName",
+			Value: "existingValue",
+		},
+		{
+			Name:  "newName1",
+			Value: "newValue2",
+		},
+		{
+			Name:  "newName2",
+			Value: "newValue2",
+		},
+	}
+
+	appendApiDefQueriesConfigToEngineV2Queries(existingEngineV2Queries, apiDefQueryVariables)
+	assert.Equal(t, expectedEngineV2Queries, existingEngineV2Queries)
 }

--- a/apidef/adapter/engine_v2_utils_test.go
+++ b/apidef/adapter/engine_v2_utils_test.go
@@ -250,3 +250,32 @@ func TestAppendApiDefQueriesConfigToEngineV2Queries(t *testing.T) {
 	appendApiDefQueriesConfigToEngineV2Queries(existingEngineV2Queries, apiDefQueryVariables)
 	assert.Equal(t, expectedEngineV2Queries, existingEngineV2Queries)
 }
+
+func TestCreateGraphQLDataSourceFactory(t *testing.T) {
+	inputParams := createGraphQLDataSourceFactoryParams{
+		graphqlConfig: apidef.GraphQLEngineDataSourceConfigGraphQL{
+			SubscriptionType: apidef.GQLSubscriptionSSE,
+		},
+		subscriptionClientFactory: &MockSubscriptionClientFactory{},
+		httpClient: &http.Client{
+			Timeout: 0,
+		},
+		streamingClient: &http.Client{
+			Timeout: 1,
+		},
+	}
+
+	expectedGraphQLDataSourceFactory := &graphqlDataSource.Factory{
+		HTTPClient: &http.Client{
+			Timeout: 0,
+		},
+		StreamingClient: &http.Client{
+			Timeout: 1,
+		},
+		SubscriptionClient: mockSubscriptionClient,
+	}
+
+	actualGraphQLDataSourceFactory, err := createGraphQLDataSourceFactory(inputParams)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedGraphQLDataSourceFactory, actualGraphQLDataSourceFactory)
+}

--- a/apidef/adapter/graphql_config_adapter.go
+++ b/apidef/adapter/graphql_config_adapter.go
@@ -253,7 +253,7 @@ func (g *GraphQLConfigAdapter) engineConfigV2DataSources() (planDataSources []pl
 				return nil, err
 			}
 
-			planDataSource.Custom = graphqlDataSource.ConfigJson(g.graphqlDataSourceConfiguration(
+			planDataSource.Custom = graphqlDataSource.ConfigJson(graphqlDataSourceConfiguration(
 				graphqlConfig.URL,
 				graphqlConfig.Method,
 				graphqlConfig.Headers,
@@ -301,7 +301,7 @@ func (g *GraphQLConfigAdapter) subgraphDataSourceConfigs() []graphqlDataSource.C
 			continue
 		}
 		hdr := removeDuplicateApiDefinitionHeaders(apiDefSubgraphConf.Headers, g.apiDefinition.GraphQL.Supergraph.GlobalHeaders)
-		conf := g.graphqlDataSourceConfiguration(
+		conf := graphqlDataSourceConfiguration(
 			apiDefSubgraphConf.URL,
 			http.MethodPost,
 			hdr,
@@ -315,32 +315,6 @@ func (g *GraphQLConfigAdapter) subgraphDataSourceConfigs() []graphqlDataSource.C
 	}
 
 	return confs
-}
-
-func (g *GraphQLConfigAdapter) graphqlDataSourceConfiguration(url string, method string, headers map[string]string, subscriptionType apidef.SubscriptionType) graphqlDataSource.Configuration {
-	dataSourceHeaders := make(map[string]string)
-	for name, value := range headers {
-		dataSourceHeaders[name] = value
-	}
-
-	if strings.HasPrefix(url, "tyk://") {
-		url = strings.ReplaceAll(url, "tyk://", "http://")
-		dataSourceHeaders[apidef.TykInternalApiHeader] = "true"
-	}
-
-	cfg := graphqlDataSource.Configuration{
-		Fetch: graphqlDataSource.FetchConfiguration{
-			URL:    url,
-			Method: method,
-			Header: convertApiDefinitionHeadersToHttpHeaders(dataSourceHeaders),
-		},
-		Subscription: graphqlDataSource.SubscriptionConfiguration{
-			URL:    url,
-			UseSSE: subscriptionType == apidef.GQLSubscriptionSSE,
-		},
-	}
-
-	return cfg
 }
 
 func (g *GraphQLConfigAdapter) engineConfigV2Arguments(fieldConfs *plan.FieldConfigurations, generatedArgs map[graphql.TypeFieldLookupKey]graphql.TypeFieldArguments) {

--- a/apidef/adapter/graphql_config_adapter.go
+++ b/apidef/adapter/graphql_config_adapter.go
@@ -159,7 +159,9 @@ func (g *GraphQLConfigAdapter) createV2ConfigForSupergraphExecutionMode() (*grap
 }
 
 func (g *GraphQLConfigAdapter) createV2ConfigForEngineExecutionMode() (*graphql.EngineV2Configuration, error) {
-	if err := g.parseSchema(); err != nil {
+	var err error
+	g.schema, err = parseSchema(g.apiDefinition.GraphQL.Schema)
+	if err != nil {
 		return nil, err
 	}
 
@@ -176,28 +178,6 @@ func (g *GraphQLConfigAdapter) createV2ConfigForEngineExecutionMode() (*graphql.
 	conf.SetDataSources(datsSources)
 
 	return &conf, nil
-}
-
-func (g *GraphQLConfigAdapter) parseSchema() (err error) {
-	if g.schema != nil {
-		return nil
-	}
-
-	g.schema, err = graphql.NewSchemaFromString(g.apiDefinition.GraphQL.Schema)
-	if err != nil {
-		return err
-	}
-
-	normalizationResult, err := g.schema.Normalize()
-	if err != nil {
-		return err
-	}
-
-	if !normalizationResult.Successful && normalizationResult.Errors != nil {
-		return normalizationResult.Errors
-	}
-
-	return nil
 }
 
 func (g *GraphQLConfigAdapter) engineConfigV2FieldConfigs() (planFieldConfigs plan.FieldConfigurations) {

--- a/apidef/adapter/graphql_config_adapter.go
+++ b/apidef/adapter/graphql_config_adapter.go
@@ -329,7 +329,7 @@ func (g *GraphQLConfigAdapter) engineConfigV2Arguments(fieldConfs *plan.FieldCon
 			continue
 		}
 
-		(*fieldConfs)[i].Arguments = g.createArgumentConfigurationsForArgumentNames(currentArgs.ArgumentNames)
+		(*fieldConfs)[i].Arguments = createArgumentConfigurationsForArgumentNames(currentArgs.ArgumentNames...)
 		delete(generatedArgs, lookupKey)
 	}
 
@@ -337,23 +337,9 @@ func (g *GraphQLConfigAdapter) engineConfigV2Arguments(fieldConfs *plan.FieldCon
 		*fieldConfs = append(*fieldConfs, plan.FieldConfiguration{
 			TypeName:  genArgs.TypeName,
 			FieldName: genArgs.FieldName,
-			Arguments: g.createArgumentConfigurationsForArgumentNames(genArgs.ArgumentNames),
+			Arguments: createArgumentConfigurationsForArgumentNames(genArgs.ArgumentNames...),
 		})
 	}
-}
-
-func (g *GraphQLConfigAdapter) createArgumentConfigurationsForArgumentNames(argumentNames []string) plan.ArgumentsConfigurations {
-	argConfs := plan.ArgumentsConfigurations{}
-	for _, argName := range argumentNames {
-		argConf := plan.ArgumentConfiguration{
-			Name:       argName,
-			SourceType: plan.FieldArgumentSource,
-		}
-
-		argConfs = append(argConfs, argConf)
-	}
-
-	return argConfs
 }
 
 func (g *GraphQLConfigAdapter) extractURLQueryParamsForEngineV2(url string, providedApiDefQueries []apidef.QueryVariable) (urlWithoutParams string, engineV2Queries []restDataSource.QueryConfiguration, err error) {

--- a/apidef/adapter/graphql_config_adapter.go
+++ b/apidef/adapter/graphql_config_adapter.go
@@ -320,7 +320,7 @@ func (g *GraphQLConfigAdapter) subgraphDataSourceConfigs() []graphqlDataSource.C
 		if len(apiDefSubgraphConf.SDL) == 0 {
 			continue
 		}
-		hdr := g.removeDuplicateHeaders(apiDefSubgraphConf.Headers, g.apiDefinition.GraphQL.Supergraph.GlobalHeaders)
+		hdr := removeDuplicateApiDefinitionHeaders(apiDefSubgraphConf.Headers, g.apiDefinition.GraphQL.Supergraph.GlobalHeaders)
 		conf := g.graphqlDataSourceConfiguration(
 			apiDefSubgraphConf.URL,
 			http.MethodPost,
@@ -453,22 +453,6 @@ func (g *GraphQLConfigAdapter) convertApiDefQueriesConfigIntoEngineV2Queries(eng
 
 		*engineV2Queries = append(*engineV2Queries, engineV2Query)
 	}
-}
-
-func (g *GraphQLConfigAdapter) removeDuplicateHeaders(headers ...map[string]string) map[string]string {
-	hdr := make(map[string]string)
-	// headers priority depends on the order of arguments
-	for _, header := range headers {
-		for k, v := range header {
-			keyCanonical := http.CanonicalHeaderKey(k)
-			if _, ok := hdr[keyCanonical]; ok {
-				// skip because header is present
-				continue
-			}
-			hdr[keyCanonical] = v
-		}
-	}
-	return hdr
 }
 
 func (g *GraphQLConfigAdapter) determineChildNodes(planDataSources []plan.DataSourceConfiguration) error {

--- a/apidef/adapter/graphql_config_adapter.go
+++ b/apidef/adapter/graphql_config_adapter.go
@@ -72,11 +72,11 @@ func (g *GraphQLConfigAdapter) EngineConfigV2() (*graphql.EngineV2Configuration,
 		return nil, ErrUnsupportedGraphQLConfigVersion
 	}
 
-	if g.isProxyOnlyAPIDefinition() {
+	if isProxyOnlyAPIDefinition(g.apiDefinition) {
 		return g.createV2ConfigForProxyOnlyExecutionMode()
 	}
 
-	if g.isSupergraphAPIDefinition() {
+	if isSupergraphAPIDefinition(g.apiDefinition) {
 		return g.createV2ConfigForSupergraphExecutionMode()
 	}
 
@@ -476,15 +476,6 @@ func (g *GraphQLConfigAdapter) determineChildNodes(planDataSources []plan.DataSo
 		}
 	}
 	return nil
-}
-
-func (g *GraphQLConfigAdapter) isSupergraphAPIDefinition() bool {
-	return g.apiDefinition.GraphQL.Enabled && g.apiDefinition.GraphQL.ExecutionMode == apidef.GraphQLExecutionModeSupergraph
-}
-
-func (g *GraphQLConfigAdapter) isProxyOnlyAPIDefinition() bool {
-	return g.apiDefinition.GraphQL.Enabled &&
-		(g.apiDefinition.GraphQL.ExecutionMode == apidef.GraphQLExecutionModeProxyOnly || g.apiDefinition.GraphQL.ExecutionMode == apidef.GraphQLExecutionModeSubgraph)
 }
 
 func (g *GraphQLConfigAdapter) getHttpClient() *http.Client {

--- a/apidef/adapter/graphql_config_adapter.go
+++ b/apidef/adapter/graphql_config_adapter.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	neturl "net/url"
 	"strings"
 
 	graphqlDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/graphql_datasource"
@@ -225,7 +224,7 @@ func (g *GraphQLConfigAdapter) engineConfigV2DataSources() (planDataSources []pl
 				Client: g.getHttpClient(),
 			}
 
-			urlWithoutQueryParams, queryConfigs, err := g.extractURLQueryParamsForEngineV2(restConfig.URL, restConfig.Query)
+			urlWithoutQueryParams, queryConfigs, err := extractURLQueryParamsForEngineV2(restConfig.URL, restConfig.Query)
 			if err != nil {
 				return nil, err
 			}
@@ -339,31 +338,6 @@ func (g *GraphQLConfigAdapter) engineConfigV2Arguments(fieldConfs *plan.FieldCon
 			Arguments: createArgumentConfigurationsForArgumentNames(genArgs.ArgumentNames...),
 		})
 	}
-}
-
-func (g *GraphQLConfigAdapter) extractURLQueryParamsForEngineV2(url string, providedApiDefQueries []apidef.QueryVariable) (urlWithoutParams string, engineV2Queries []restDataSource.QueryConfiguration, err error) {
-	urlParts := strings.Split(url, "?")
-	urlWithoutParams = urlParts[0]
-
-	queryPart := ""
-	if len(urlParts) == 2 {
-		queryPart = urlParts[1]
-	}
-	// Parse only query part as URL could contain templating {{.argument.id}} which should not be escaped
-	values, err := neturl.ParseQuery(queryPart)
-	if err != nil {
-		return "", nil, err
-	}
-
-	engineV2Queries = make([]restDataSource.QueryConfiguration, 0)
-	appendURLQueryParamsToEngineV2Queries(&engineV2Queries, values)
-	appendApiDefQueriesConfigToEngineV2Queries(&engineV2Queries, providedApiDefQueries)
-
-	if len(engineV2Queries) == 0 {
-		return urlWithoutParams, nil, nil
-	}
-
-	return urlWithoutParams, engineV2Queries, nil
 }
 
 func (g *GraphQLConfigAdapter) determineChildNodes(planDataSources []plan.DataSourceConfiguration) error {

--- a/apidef/adapter/graphql_config_adapter.go
+++ b/apidef/adapter/graphql_config_adapter.go
@@ -257,7 +257,7 @@ func (g *GraphQLConfigAdapter) engineConfigV2DataSources() (planDataSources []pl
 					Method: restConfig.Method,
 					Body:   restConfig.Body,
 					Query:  queryConfigs,
-					Header: g.convertHeadersToHttpHeaders(restConfig.Headers),
+					Header: convertApiDefinitionHeadersToHttpHeaders(restConfig.Headers),
 				},
 			})
 
@@ -352,7 +352,7 @@ func (g *GraphQLConfigAdapter) graphqlDataSourceConfiguration(url string, method
 		Fetch: graphqlDataSource.FetchConfiguration{
 			URL:    url,
 			Method: method,
-			Header: g.convertHeadersToHttpHeaders(dataSourceHeaders),
+			Header: convertApiDefinitionHeadersToHttpHeaders(dataSourceHeaders),
 		},
 		Subscription: graphqlDataSource.SubscriptionConfiguration{
 			URL:    url,
@@ -453,19 +453,6 @@ func (g *GraphQLConfigAdapter) convertApiDefQueriesConfigIntoEngineV2Queries(eng
 
 		*engineV2Queries = append(*engineV2Queries, engineV2Query)
 	}
-}
-
-func (g *GraphQLConfigAdapter) convertHeadersToHttpHeaders(apiDefHeaders map[string]string) http.Header {
-	if len(apiDefHeaders) == 0 {
-		return nil
-	}
-
-	engineV2Headers := make(http.Header)
-	for apiDefHeaderKey, apiDefHeaderValue := range apiDefHeaders {
-		engineV2Headers.Add(apiDefHeaderKey, apiDefHeaderValue)
-	}
-
-	return engineV2Headers
 }
 
 func (g *GraphQLConfigAdapter) removeDuplicateHeaders(headers ...map[string]string) map[string]string {

--- a/apidef/adapter/graphql_config_adapter.go
+++ b/apidef/adapter/graphql_config_adapter.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net/http"
 	neturl "net/url"
-	"sort"
 	"strings"
 
 	graphqlDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/graphql_datasource"
@@ -357,42 +356,14 @@ func (g *GraphQLConfigAdapter) extractURLQueryParamsForEngineV2(url string, prov
 	}
 
 	engineV2Queries = make([]restDataSource.QueryConfiguration, 0)
-	g.convertURLQueryParamsIntoEngineV2Queries(&engineV2Queries, values)
-	g.convertApiDefQueriesConfigIntoEngineV2Queries(&engineV2Queries, providedApiDefQueries)
+	appendURLQueryParamsToEngineV2Queries(&engineV2Queries, values)
+	appendApiDefQueriesConfigToEngineV2Queries(&engineV2Queries, providedApiDefQueries)
 
 	if len(engineV2Queries) == 0 {
 		return urlWithoutParams, nil, nil
 	}
 
 	return urlWithoutParams, engineV2Queries, nil
-}
-
-func (g *GraphQLConfigAdapter) convertURLQueryParamsIntoEngineV2Queries(engineV2Queries *[]restDataSource.QueryConfiguration, queryValues neturl.Values) {
-	for queryKey, queryValue := range queryValues {
-		*engineV2Queries = append(*engineV2Queries, restDataSource.QueryConfiguration{
-			Name:  queryKey,
-			Value: strings.Join(queryValue, ","),
-		})
-	}
-
-	sort.Slice(*engineV2Queries, func(i, j int) bool {
-		return (*engineV2Queries)[i].Name < (*engineV2Queries)[j].Name
-	})
-}
-
-func (g *GraphQLConfigAdapter) convertApiDefQueriesConfigIntoEngineV2Queries(engineV2Queries *[]restDataSource.QueryConfiguration, apiDefQueries []apidef.QueryVariable) {
-	if len(apiDefQueries) == 0 {
-		return
-	}
-
-	for _, apiDefQueryVar := range apiDefQueries {
-		engineV2Query := restDataSource.QueryConfiguration{
-			Name:  apiDefQueryVar.Name,
-			Value: apiDefQueryVar.Value,
-		}
-
-		*engineV2Queries = append(*engineV2Queries, engineV2Query)
-	}
 }
 
 func (g *GraphQLConfigAdapter) determineChildNodes(planDataSources []plan.DataSourceConfiguration) error {

--- a/apidef/adapter/graphql_config_adapter.go
+++ b/apidef/adapter/graphql_config_adapter.go
@@ -501,7 +501,7 @@ func (g *GraphQLConfigAdapter) createGraphQLDataSourceFactory(graphqlConfig apid
 		StreamingClient: g.getStreamingClient(),
 	}
 
-	wsProtocol := g.graphqlDataSourceWebSocketProtocol(graphqlConfig.SubscriptionType)
+	wsProtocol := graphqlDataSourceWebSocketProtocol(graphqlConfig.SubscriptionType)
 	graphqlSubscriptionClient := g.subscriptionClientFactory.NewSubscriptionClient(
 		g.getHttpClient(),
 		g.getStreamingClient(),
@@ -515,12 +515,4 @@ func (g *GraphQLConfigAdapter) createGraphQLDataSourceFactory(graphqlConfig apid
 	}
 	factory.SubscriptionClient = subscriptionClient
 	return factory, nil
-}
-
-func (g *GraphQLConfigAdapter) graphqlDataSourceWebSocketProtocol(subscriptionType apidef.SubscriptionType) string {
-	wsProtocol := graphqlDataSource.ProtocolGraphQLWS
-	if subscriptionType == apidef.GQLSubscriptionTransportWS {
-		wsProtocol = graphqlDataSource.ProtocolGraphQLTWS
-	}
-	return wsProtocol
 }

--- a/apidef/adapter/graphql_config_adapter.go
+++ b/apidef/adapter/graphql_config_adapter.go
@@ -95,7 +95,7 @@ func (g *GraphQLConfigAdapter) createV2ConfigForProxyOnlyExecutionMode() (*graph
 	upstreamConfig := graphql.ProxyUpstreamConfig{
 		URL:              url,
 		StaticHeaders:    staticHeaders,
-		SubscriptionType: g.graphqlSubscriptionType(g.apiDefinition.GraphQL.Proxy.SubscriptionType),
+		SubscriptionType: graphqlSubscriptionType(g.apiDefinition.GraphQL.Proxy.SubscriptionType),
 	}
 
 	if g.schema == nil {
@@ -523,17 +523,4 @@ func (g *GraphQLConfigAdapter) graphqlDataSourceWebSocketProtocol(subscriptionTy
 		wsProtocol = graphqlDataSource.ProtocolGraphQLTWS
 	}
 	return wsProtocol
-}
-
-func (g *GraphQLConfigAdapter) graphqlSubscriptionType(subscriptionType apidef.SubscriptionType) graphql.SubscriptionType {
-	switch subscriptionType {
-	case apidef.GQLSubscriptionWS:
-		return graphql.SubscriptionTypeGraphQLWS
-	case apidef.GQLSubscriptionTransportWS:
-		return graphql.SubscriptionTypeGraphQLTransportWS
-	case apidef.GQLSubscriptionSSE:
-		return graphql.SubscriptionTypeSSE
-	default:
-		return graphql.SubscriptionTypeUnknown
-	}
 }

--- a/apidef/adapter/graphql_config_adapter_test.go
+++ b/apidef/adapter/graphql_config_adapter_test.go
@@ -494,7 +494,10 @@ func TestGraphQLConfigAdapter_engineConfigV2FieldConfigs(t *testing.T) {
 	}
 
 	adapter := NewGraphQLConfigAdapter(apiDef)
-	require.NoError(t, adapter.parseSchema())
+
+	var err error
+	adapter.schema, err = parseSchema(gqlConfig.Schema)
+	require.NoError(t, err)
 
 	actualFieldCfgs := adapter.engineConfigV2FieldConfigs()
 	assert.ElementsMatch(t, expectedFieldCfgs, actualFieldCfgs)
@@ -816,7 +819,10 @@ func TestGraphQLConfigAdapter_engineConfigV2DataSources(t *testing.T) {
 		WithStreamingClient(streamingClient),
 		withGraphQLSubscriptionClientFactory(&MockSubscriptionClientFactory{}),
 	)
-	require.NoError(t, adapter.parseSchema())
+
+	var err error
+	adapter.schema, err = parseSchema(gqlConfig.Schema)
+	require.NoError(t, err)
 
 	actualDataSources, err := adapter.engineConfigV2DataSources()
 	assert.NoError(t, err)

--- a/apidef/adapter/graphql_config_adapter_test.go
+++ b/apidef/adapter/graphql_config_adapter_test.go
@@ -14,7 +14,7 @@ import (
 	kafkaDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/kafka_datasource"
 	restDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/rest_datasource"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/plan"
-	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
+
 	"github.com/TykTechnologies/tyk/apidef"
 )
 
@@ -847,32 +847,6 @@ func TestGraphQLConfigAdapter_GraphqlDataSourceWebSocketProtocol(t *testing.T) {
 
 	t.Run("should return 'graphql-transport-ws' for graphql-transport-ws subscription type",
 		run(apidef.GQLSubscriptionTransportWS, graphqlDataSource.ProtocolGraphQLTWS),
-	)
-}
-
-func TestGraphQLConfigAdapter_GraphqlSubscriptionType(t *testing.T) {
-	run := func(subscriptionType apidef.SubscriptionType, expectedGraphQLSubscriptionType graphql.SubscriptionType) func(t *testing.T) {
-		return func(t *testing.T) {
-			adapter := NewGraphQLConfigAdapter(nil)
-			actualSubscriptionType := adapter.graphqlSubscriptionType(subscriptionType)
-			assert.Equal(t, expectedGraphQLSubscriptionType, actualSubscriptionType)
-		}
-	}
-
-	t.Run("should return 'Unknown' for undefined subscription type",
-		run(apidef.GQLSubscriptionUndefined, graphql.SubscriptionTypeUnknown),
-	)
-
-	t.Run("should return 'SSE' for sse subscription type as websocket protocol is irrelevant in that case",
-		run(apidef.GQLSubscriptionSSE, graphql.SubscriptionTypeSSE),
-	)
-
-	t.Run("should return 'GraphQLWS' for graphql-ws subscription type",
-		run(apidef.GQLSubscriptionWS, graphql.SubscriptionTypeGraphQLWS),
-	)
-
-	t.Run("should return 'GraphQLTransportWS' for graphql-transport-ws subscription type",
-		run(apidef.GQLSubscriptionTransportWS, graphql.SubscriptionTypeGraphQLTransportWS),
 	)
 }
 

--- a/apidef/adapter/graphql_config_adapter_test.go
+++ b/apidef/adapter/graphql_config_adapter_test.go
@@ -824,32 +824,6 @@ func TestGraphQLConfigAdapter_engineConfigV2DataSources(t *testing.T) {
 	//assert.ElementsMatch(t, expectedDataSources, actualDataSources)
 }
 
-func TestGraphQLConfigAdapter_GraphqlDataSourceWebSocketProtocol(t *testing.T) {
-	run := func(subscriptionType apidef.SubscriptionType, expectedWebSocketProtocol string) func(t *testing.T) {
-		return func(t *testing.T) {
-			adapter := NewGraphQLConfigAdapter(nil)
-			actualProtocol := adapter.graphqlDataSourceWebSocketProtocol(subscriptionType)
-			assert.Equal(t, expectedWebSocketProtocol, actualProtocol)
-		}
-	}
-
-	t.Run("should return 'graphql-ws' for undefined subscription type",
-		run(apidef.GQLSubscriptionUndefined, graphqlDataSource.ProtocolGraphQLWS),
-	)
-
-	t.Run("should return 'graphql-ws' for graphql-ws subscription type",
-		run(apidef.GQLSubscriptionWS, graphqlDataSource.ProtocolGraphQLWS),
-	)
-
-	t.Run("should return 'graphql-ws' for sse subscription type as websocket protocol is irrelevant in that case",
-		run(apidef.GQLSubscriptionSSE, graphqlDataSource.ProtocolGraphQLWS),
-	)
-
-	t.Run("should return 'graphql-transport-ws' for graphql-transport-ws subscription type",
-		run(apidef.GQLSubscriptionTransportWS, graphqlDataSource.ProtocolGraphQLTWS),
-	)
-}
-
 var mockSubscriptionClient = &graphqlDataSource.SubscriptionClient{}
 
 type MockSubscriptionClientFactory struct{}

--- a/apidef/adapter/utils.go
+++ b/apidef/adapter/utils.go
@@ -2,7 +2,18 @@ package adapter
 
 import (
 	"net/http"
+
+	"github.com/TykTechnologies/tyk/apidef"
 )
+
+func isSupergraphAPIDefinition(apiDefinition *apidef.APIDefinition) bool {
+	return apiDefinition.GraphQL.Enabled && apiDefinition.GraphQL.ExecutionMode == apidef.GraphQLExecutionModeSupergraph
+}
+
+func isProxyOnlyAPIDefinition(apiDefinition *apidef.APIDefinition) bool {
+	return apiDefinition.GraphQL.Enabled &&
+		(apiDefinition.GraphQL.ExecutionMode == apidef.GraphQLExecutionModeProxyOnly || apiDefinition.GraphQL.ExecutionMode == apidef.GraphQLExecutionModeSubgraph)
+}
 
 func convertApiDefinitionHeadersToHttpHeaders(apiDefHeaders map[string]string) http.Header {
 	if len(apiDefHeaders) == 0 {

--- a/apidef/adapter/utils.go
+++ b/apidef/adapter/utils.go
@@ -9,6 +9,24 @@ import (
 	"github.com/TykTechnologies/tyk/apidef"
 )
 
+func parseSchema(schemaAsString string) (parsedSchema *graphql.Schema, err error) {
+	parsedSchema, err = graphql.NewSchemaFromString(schemaAsString)
+	if err != nil {
+		return nil, err
+	}
+
+	normalizationResult, err := parsedSchema.Normalize()
+	if err != nil {
+		return nil, err
+	}
+
+	if !normalizationResult.Successful && normalizationResult.Errors != nil {
+		return nil, normalizationResult.Errors
+	}
+
+	return parsedSchema, nil
+}
+
 func isSupergraphAPIDefinition(apiDefinition *apidef.APIDefinition) bool {
 	return apiDefinition.GraphQL.Enabled && apiDefinition.GraphQL.ExecutionMode == apidef.GraphQLExecutionModeSupergraph
 }

--- a/apidef/adapter/utils.go
+++ b/apidef/adapter/utils.go
@@ -3,6 +3,8 @@ package adapter
 import (
 	"net/http"
 
+	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
+
 	"github.com/TykTechnologies/tyk/apidef"
 )
 
@@ -13,6 +15,19 @@ func isSupergraphAPIDefinition(apiDefinition *apidef.APIDefinition) bool {
 func isProxyOnlyAPIDefinition(apiDefinition *apidef.APIDefinition) bool {
 	return apiDefinition.GraphQL.Enabled &&
 		(apiDefinition.GraphQL.ExecutionMode == apidef.GraphQLExecutionModeProxyOnly || apiDefinition.GraphQL.ExecutionMode == apidef.GraphQLExecutionModeSubgraph)
+}
+
+func graphqlSubscriptionType(subscriptionType apidef.SubscriptionType) graphql.SubscriptionType {
+	switch subscriptionType {
+	case apidef.GQLSubscriptionWS:
+		return graphql.SubscriptionTypeGraphQLWS
+	case apidef.GQLSubscriptionTransportWS:
+		return graphql.SubscriptionTypeGraphQLTransportWS
+	case apidef.GQLSubscriptionSSE:
+		return graphql.SubscriptionTypeSSE
+	default:
+		return graphql.SubscriptionTypeUnknown
+	}
 }
 
 func convertApiDefinitionHeadersToHttpHeaders(apiDefHeaders map[string]string) http.Header {

--- a/apidef/adapter/utils.go
+++ b/apidef/adapter/utils.go
@@ -16,3 +16,19 @@ func convertApiDefinitionHeadersToHttpHeaders(apiDefHeaders map[string]string) h
 
 	return engineV2Headers
 }
+
+func removeDuplicateApiDefinitionHeaders(headers ...map[string]string) map[string]string {
+	hdr := make(map[string]string)
+	// headers priority depends on the order of arguments
+	for _, header := range headers {
+		for k, v := range header {
+			keyCanonical := http.CanonicalHeaderKey(k)
+			if _, ok := hdr[keyCanonical]; ok {
+				// skip because header is present
+				continue
+			}
+			hdr[keyCanonical] = v
+		}
+	}
+	return hdr
+}

--- a/apidef/adapter/utils.go
+++ b/apidef/adapter/utils.go
@@ -1,0 +1,18 @@
+package adapter
+
+import (
+	"net/http"
+)
+
+func convertApiDefinitionHeadersToHttpHeaders(apiDefHeaders map[string]string) http.Header {
+	if len(apiDefHeaders) == 0 {
+		return nil
+	}
+
+	engineV2Headers := make(http.Header)
+	for apiDefHeaderKey, apiDefHeaderValue := range apiDefHeaders {
+		engineV2Headers.Add(apiDefHeaderKey, apiDefHeaderValue)
+	}
+
+	return engineV2Headers
+}

--- a/apidef/adapter/utils.go
+++ b/apidef/adapter/utils.go
@@ -3,6 +3,7 @@ package adapter
 import (
 	"net/http"
 
+	graphqlDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/graphql_datasource"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
 
 	"github.com/TykTechnologies/tyk/apidef"
@@ -15,6 +16,14 @@ func isSupergraphAPIDefinition(apiDefinition *apidef.APIDefinition) bool {
 func isProxyOnlyAPIDefinition(apiDefinition *apidef.APIDefinition) bool {
 	return apiDefinition.GraphQL.Enabled &&
 		(apiDefinition.GraphQL.ExecutionMode == apidef.GraphQLExecutionModeProxyOnly || apiDefinition.GraphQL.ExecutionMode == apidef.GraphQLExecutionModeSubgraph)
+}
+
+func graphqlDataSourceWebSocketProtocol(subscriptionType apidef.SubscriptionType) string {
+	wsProtocol := graphqlDataSource.ProtocolGraphQLWS
+	if subscriptionType == apidef.GQLSubscriptionTransportWS {
+		wsProtocol = graphqlDataSource.ProtocolGraphQLTWS
+	}
+	return wsProtocol
 }
 
 func graphqlSubscriptionType(subscriptionType apidef.SubscriptionType) graphql.SubscriptionType {

--- a/apidef/adapter/utils_test.go
+++ b/apidef/adapter/utils_test.go
@@ -1,0 +1,29 @@
+package adapter
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConvertApiDefinitionHeadersToHttpHeaders(t *testing.T) {
+	t.Run("should return nil for empty input", func(t *testing.T) {
+		assert.Nil(t, convertApiDefinitionHeadersToHttpHeaders(nil))
+	})
+
+	t.Run("should successfully convert API Definition header to Http Headers", func(t *testing.T) {
+		apiDefinitionHeaders := map[string]string{
+			"Authorization": "token",
+			"X-Tyk-Key":     "value",
+		}
+
+		expectedHttpHeaders := http.Header{
+			"Authorization": {"token"},
+			"X-Tyk-Key":     {"value"},
+		}
+
+		actualHttpHeaders := convertApiDefinitionHeadersToHttpHeaders(apiDefinitionHeaders)
+		assert.Equal(t, expectedHttpHeaders, actualHttpHeaders)
+	})
+}

--- a/apidef/adapter/utils_test.go
+++ b/apidef/adapter/utils_test.go
@@ -4,9 +4,10 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	graphqlDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/graphql_datasource"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/TykTechnologies/tyk/apidef"
 )

--- a/apidef/adapter/utils_test.go
+++ b/apidef/adapter/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"testing"
 
+	graphqlDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/graphql_datasource"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
 	"github.com/stretchr/testify/assert"
 
@@ -120,6 +121,31 @@ func TestIsProxyOnlyAPIDefinition(t *testing.T) {
 			expectedResult: true,
 		},
 	))
+}
+
+func TestGraphqlDataSourceWebSocketProtocol(t *testing.T) {
+	run := func(subscriptionType apidef.SubscriptionType, expectedWebSocketProtocol string) func(t *testing.T) {
+		return func(t *testing.T) {
+			actualProtocol := graphqlDataSourceWebSocketProtocol(subscriptionType)
+			assert.Equal(t, expectedWebSocketProtocol, actualProtocol)
+		}
+	}
+
+	t.Run("should return 'graphql-ws' for undefined subscription type",
+		run(apidef.GQLSubscriptionUndefined, graphqlDataSource.ProtocolGraphQLWS),
+	)
+
+	t.Run("should return 'graphql-ws' for graphql-ws subscription type",
+		run(apidef.GQLSubscriptionWS, graphqlDataSource.ProtocolGraphQLWS),
+	)
+
+	t.Run("should return 'graphql-ws' for sse subscription type as websocket protocol is irrelevant in that case",
+		run(apidef.GQLSubscriptionSSE, graphqlDataSource.ProtocolGraphQLWS),
+	)
+
+	t.Run("should return 'graphql-transport-ws' for graphql-transport-ws subscription type",
+		run(apidef.GQLSubscriptionTransportWS, graphqlDataSource.ProtocolGraphQLTWS),
+	)
 }
 
 func TestGraphqlSubscriptionType(t *testing.T) {

--- a/apidef/adapter/utils_test.go
+++ b/apidef/adapter/utils_test.go
@@ -27,3 +27,21 @@ func TestConvertApiDefinitionHeadersToHttpHeaders(t *testing.T) {
 		assert.Equal(t, expectedHttpHeaders, actualHttpHeaders)
 	})
 }
+
+func TestRemoveDuplicateApiDefinitionHeaders(t *testing.T) {
+	apiDefinitionHeadersFirstArgument := map[string]string{
+		"duplicate-header": "value",
+	}
+	apiDefinitionHeadersSecondArgument := map[string]string{
+		"Duplicate-Header":     "value",
+		"Non-Duplicate-Header": "another_value",
+	}
+
+	expectedDeduplicatedHeaders := map[string]string{
+		"Duplicate-Header":     "value",
+		"Non-Duplicate-Header": "another_value",
+	}
+
+	actualDeduplicatedHeaders := removeDuplicateApiDefinitionHeaders(apiDefinitionHeadersFirstArgument, apiDefinitionHeadersSecondArgument)
+	assert.Equal(t, expectedDeduplicatedHeaders, actualDeduplicatedHeaders)
+}

--- a/apidef/adapter/utils_test.go
+++ b/apidef/adapter/utils_test.go
@@ -11,6 +11,19 @@ import (
 	"github.com/TykTechnologies/tyk/apidef"
 )
 
+func TestParseSchema(t *testing.T) {
+	inputSchema := `
+		type Query {
+			hello: String!
+		}`
+
+	// We are pretty confident that the schema parsing works, as it is tested in the library already.
+	// We just want to make sure that there is no weird error happening.
+	parsedSchema, err := parseSchema(inputSchema)
+	assert.NotNil(t, parsedSchema)
+	assert.NoError(t, err)
+}
+
 func TestIsSupergraphAPIDefinition(t *testing.T) {
 	type testInput struct {
 		graphQLEnabled bool

--- a/apidef/adapter/utils_test.go
+++ b/apidef/adapter/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/TykTechnologies/tyk/apidef"
@@ -119,6 +120,31 @@ func TestIsProxyOnlyAPIDefinition(t *testing.T) {
 			expectedResult: true,
 		},
 	))
+}
+
+func TestGraphqlSubscriptionType(t *testing.T) {
+	run := func(subscriptionType apidef.SubscriptionType, expectedGraphQLSubscriptionType graphql.SubscriptionType) func(t *testing.T) {
+		return func(t *testing.T) {
+			actualSubscriptionType := graphqlSubscriptionType(subscriptionType)
+			assert.Equal(t, expectedGraphQLSubscriptionType, actualSubscriptionType)
+		}
+	}
+
+	t.Run("should return 'Unknown' for undefined subscription type",
+		run(apidef.GQLSubscriptionUndefined, graphql.SubscriptionTypeUnknown),
+	)
+
+	t.Run("should return 'SSE' for sse subscription type as websocket protocol is irrelevant in that case",
+		run(apidef.GQLSubscriptionSSE, graphql.SubscriptionTypeSSE),
+	)
+
+	t.Run("should return 'GraphQLWS' for graphql-ws subscription type",
+		run(apidef.GQLSubscriptionWS, graphql.SubscriptionTypeGraphQLWS),
+	)
+
+	t.Run("should return 'GraphQLTransportWS' for graphql-transport-ws subscription type",
+		run(apidef.GQLSubscriptionTransportWS, graphql.SubscriptionTypeGraphQLTransportWS),
+	)
 }
 
 func TestConvertApiDefinitionHeadersToHttpHeaders(t *testing.T) {

--- a/apidef/adapter/utils_test.go
+++ b/apidef/adapter/utils_test.go
@@ -5,7 +5,121 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk/apidef"
 )
+
+func TestIsSupergraphAPIDefinition(t *testing.T) {
+	type testInput struct {
+		graphQLEnabled bool
+		executionModes []apidef.GraphQLExecutionMode
+		expectedResult bool
+	}
+	run := func(input testInput) func(t *testing.T) {
+		return func(t *testing.T) {
+			for _, executionMode := range input.executionModes {
+				apiDef := &apidef.APIDefinition{
+					GraphQL: apidef.GraphQLConfig{
+						Enabled:       input.graphQLEnabled,
+						ExecutionMode: executionMode,
+					},
+				}
+				assert.Equal(t, input.expectedResult, isSupergraphAPIDefinition(apiDef))
+			}
+		}
+	}
+
+	t.Run("false if graphql is disabled", run(
+		testInput{
+			graphQLEnabled: false,
+			executionModes: []apidef.GraphQLExecutionMode{
+				apidef.GraphQLExecutionModeSupergraph,
+				apidef.GraphQLExecutionModeProxyOnly,
+				apidef.GraphQLExecutionModeExecutionEngine,
+				apidef.GraphQLExecutionModeSubgraph,
+			},
+			expectedResult: false,
+		},
+	))
+
+	t.Run("false if execution mode is not supergraph", run(
+		testInput{
+			graphQLEnabled: true,
+			executionModes: []apidef.GraphQLExecutionMode{
+				apidef.GraphQLExecutionModeProxyOnly,
+				apidef.GraphQLExecutionModeExecutionEngine,
+				apidef.GraphQLExecutionModeSubgraph,
+			},
+			expectedResult: false,
+		},
+	))
+
+	t.Run("true if graphql is enabled and execution mode is supergraph", run(
+		testInput{
+			graphQLEnabled: true,
+			executionModes: []apidef.GraphQLExecutionMode{
+				apidef.GraphQLExecutionModeSupergraph,
+			},
+			expectedResult: true,
+		},
+	))
+}
+
+func TestIsProxyOnlyAPIDefinition(t *testing.T) {
+	type testInput struct {
+		graphQLEnabled bool
+		executionModes []apidef.GraphQLExecutionMode
+		expectedResult bool
+	}
+	run := func(input testInput) func(t *testing.T) {
+		return func(t *testing.T) {
+			for _, executionMode := range input.executionModes {
+				apiDef := &apidef.APIDefinition{
+					GraphQL: apidef.GraphQLConfig{
+						Enabled:       input.graphQLEnabled,
+						ExecutionMode: executionMode,
+					},
+				}
+				assert.Equal(t, input.expectedResult, isProxyOnlyAPIDefinition(apiDef))
+			}
+		}
+	}
+
+	t.Run("false if graphql is disabled", run(
+		testInput{
+			graphQLEnabled: false,
+			executionModes: []apidef.GraphQLExecutionMode{
+				apidef.GraphQLExecutionModeProxyOnly,
+				apidef.GraphQLExecutionModeExecutionEngine,
+				apidef.GraphQLExecutionModeSubgraph,
+				apidef.GraphQLExecutionModeSupergraph,
+			},
+			expectedResult: false,
+		},
+	))
+
+	t.Run("false if execution mode is not proxyOnly or subgraph", run(
+		testInput{
+			graphQLEnabled: true,
+			executionModes: []apidef.GraphQLExecutionMode{
+				apidef.GraphQLExecutionModeExecutionEngine,
+				apidef.GraphQLExecutionModeSupergraph,
+			},
+			expectedResult: false,
+		},
+	))
+
+	t.Run("true if graphql is enabled and execution mode is proxyOnly", run(
+		testInput{
+			graphQLEnabled: true,
+			executionModes: []apidef.GraphQLExecutionMode{
+				apidef.GraphQLExecutionModeProxyOnly,
+				apidef.GraphQLExecutionModeSubgraph,
+			},
+			expectedResult: true,
+		},
+	))
+}
 
 func TestConvertApiDefinitionHeadersToHttpHeaders(t *testing.T) {
 	t.Run("should return nil for empty input", func(t *testing.T) {


### PR DESCRIPTION
This PR moves helper functions from the GraphQL adapter to some proper util files. It also adds some missing tests for those helper functions.

*Please note, that the remaining functions inside the adapter will be refactored in the next step.*

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring or add test (improvements in base code or adds test coverage to functionality)