### PR TITLE
Merging to release-4-lts: [TT-7959] Add option to skip ClientCA announcement during mTLS (#4762)

### DIFF
--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -557,6 +557,9 @@
         "override_defaults": {
           "type": "boolean"
         },
+        "skip_client_ca_announcement": {
+          "type": "boolean"
+        },
         "read_timeout": {
           "type": "integer"
         },

--- a/config/config.go
+++ b/config/config.go
@@ -384,6 +384,11 @@ type HttpServerOptionsConfig struct {
 	// Maximum TLS version.
 	MaxVersion uint16 `json:"max_version"`
 
+	// When mTLS enabled, this option allows to skip client CA announcement in the TLS handshake.
+	// This option is useful when you have a lot of ClientCAs and you want to reduce the handshake overhead, as some clients can hit TLS handshake limits.
+	// This option does not give any hints to the client, on which certificate to pick (but this is very rare situation when it is required)
+	SkipClientCAAnnouncement bool `json:"skip_client_ca_announcement"`
+
 	// Set this to the number of seconds that Tyk uses to flush content from the proxied upstream connection to the open downstream connection.
 	// This option needed be set for streaming protocols like Server Side Events, or gRPC streaming.
 	FlushInterval int `json:"flush_interval"`

--- a/gateway/cert.go
+++ b/gateway/cert.go
@@ -272,6 +272,30 @@ var tlsConfigCache = cache.New(60*time.Second, 60*time.Minute)
 
 var tlsConfigMu sync.Mutex
 
+func getClientValidator(helloInfo *tls.ClientHelloInfo, certPool *x509.CertPool) func([][]byte, [][]*x509.Certificate) error {
+	return func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+		if len(rawCerts) == 0 {
+			return errors.New("x509: missing client certificate")
+		}
+
+		cert, certErr := x509.ParseCertificate(rawCerts[0])
+		if certErr != nil {
+			return certErr
+		}
+
+		opts := x509.VerifyOptions{
+			Roots:         certPool,
+			CurrentTime:   time.Now(),
+			Intermediates: x509.NewCertPool(),
+			KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		}
+
+		_, err := cert.Verify(opts)
+
+		return err
+	}
+}
+
 func (gw *Gateway) getTLSConfigForClient(baseConfig *tls.Config, listenPort int) func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
 	gwConfig := gw.GetConfig()
 	// Supporting legacy certificate configuration
@@ -438,8 +462,17 @@ func (gw *Gateway) getTLSConfigForClient(baseConfig *tls.Config, listenPort int)
 			newConfig.ClientAuth = domainRequireCert[""]
 		}
 
+		if gwConfig.HttpServerOptions.SkipClientCAAnnouncement {
+			if newConfig.ClientAuth == tls.RequireAndVerifyClientCert {
+				newConfig.VerifyPeerCertificate = getClientValidator(hello, newConfig.ClientCAs)
+			}
+			newConfig.ClientCAs = x509.NewCertPool()
+			newConfig.ClientAuth = tls.RequestClientCert
+		}
+
 		// Cache the config
 		tlsConfigCache.Set(hello.ServerName+listenPortStr, newConfig, cache.DefaultExpiration)
+
 		return newConfig, nil
 	}
 }

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -1235,8 +1235,7 @@ func (s *Test) RunExt(t testing.TB, testCases ...test.TestCase) {
 	}
 }
 
-func GetTLSClient(cert *tls.Certificate, caCert []byte) *http.Client {
-	// Setup HTTPS client
+func GetTLSConfig(cert *tls.Certificate, caCert []byte) *tls.Config {
 	tlsConfig := &tls.Config{}
 
 	if cert != nil {
@@ -1251,6 +1250,13 @@ func GetTLSClient(cert *tls.Certificate, caCert []byte) *http.Client {
 	} else {
 		tlsConfig.InsecureSkipVerify = true
 	}
+
+	return tlsConfig
+}
+
+func GetTLSClient(cert *tls.Certificate, caCert []byte) *http.Client {
+	// Setup HTTPS client
+	tlsConfig := GetTLSConfig(cert, caCert)
 
 	transport := &http.Transport{TLSClientConfig: tlsConfig}
 


### PR DESCRIPTION
[TT-7959] Add option to skip ClientCA announcement during mTLS (#4762)

At the moment we announce ClientCA to the client, which is a default Go
way to do mTLS, and it also gives client a hint which certificate to
use, if it has many.

However if you have a lot of certificates in ClientCA, like 100, it can
overflow TLS handshake buffer of some clients (for example default JVM
buffer is 32kb).

This PR adds an option
`http_server_options.skip_client_ca_announcement`, which stops
announcing ClientCAs during handshake. However, if you just pass empty
ClientCA, and at the same time set TLS mode to
`RequireAndVerifyClientCert` it will error, because non empty ClientCA
required for default mTLS verification, which is built in to Go TLS
library. Which means that we have to "disable" default client cert
validation by setting TLS mode to `RequestClientCert`, and implement our
"own" verification. Thankfully Go provides TLS hook
`VerifyPeerCertificate` where you can add custom validation. It does not
have access to client hello message, and other dynamic variables, so it
needs to use a closure (this way is recommended by Go team). Inside this
check duplicate exactly the same code which Go TLS library has, but
instead of depending on `config.ClientCA` it use certificate pool passed
via closure.

mTLS unit test now runs 2 times, with and without clientCA announcement.

I was afraid to make new way "default" because mTLS is weird, and better
have a lot of options to tune it.

But despite new config variable is added, this PR still can count as
bugfix.

## Motivation and Context

We have a client who is hitting overflow issue, without a way to
overcome it. And number of used certificates only will grow.


## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why

---------

Co-authored-by: jeff <jeffy.mathew100@gmail.com>