### PR TITLE
Merging to release-5-lts: [TT-7661] reload all APIs having a plugin defined in API definition (#4731)

### DIFF
--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -318,8 +318,10 @@ func (a APIDefinitionLoader) MakeSpec(def *nestedApiDefinition, logger *logrus.E
 	// Unique API content ID, to check if we already have if it changed from previous sync
 	spec.Checksum = base64.URLEncoding.EncodeToString(sha256hash[:])
 
-	if currSpec := a.Gw.getApiSpec(def.APIID); currSpec != nil && currSpec.Checksum == spec.Checksum {
-		return a.Gw.getApiSpec(def.APIID)
+	spec.APIDefinition = def.APIDefinition
+
+	if currSpec := a.Gw.getApiSpec(def.APIID); !shouldReloadSpec(currSpec, spec) {
+		return currSpec
 	}
 
 	if logger == nil {
@@ -350,8 +352,6 @@ func (a APIDefinitionLoader) MakeSpec(def *nestedApiDefinition, logger *logrus.E
 			def.VersionData.Versions[key] = ver
 		}
 	}
-
-	spec.APIDefinition = def.APIDefinition
 
 	// We'll push the default HealthChecker:
 	spec.Health = &DefaultHealthChecker{

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -740,7 +740,7 @@ func (gw *Gateway) loadHTTPService(spec *APISpec, apisByListen map[string]int, g
 
 	var chainObj *ChainObject
 
-	if curSpec := gw.getApiSpec(spec.APIID); curSpec != nil && curSpec.Checksum == spec.Checksum {
+	if curSpec := gw.getApiSpec(spec.APIID); !shouldReloadSpec(curSpec, spec) {
 		if chain, found := gw.apisHandlesByID.Load(spec.APIID); found {
 			chainObj = chain.(*ChainObject)
 		}
@@ -919,7 +919,7 @@ func (gw *Gateway) loadApps(specs []*APISpec) {
 				spec.Proxy.ListenPath = converted
 			}
 
-			if currSpec := gw.getApiSpec(spec.APIID); currSpec != nil && spec.Checksum == currSpec.Checksum {
+			if currSpec := gw.getApiSpec(spec.APIID); !shouldReloadSpec(currSpec, spec) {
 				tmpSpecRegister[spec.APIID] = currSpec
 			} else {
 				tmpSpecRegister[spec.APIID] = spec

--- a/gateway/util_test.go
+++ b/gateway/util_test.go
@@ -236,3 +236,217 @@ func Test_getAPIURL(t *testing.T) {
 		})
 	}
 }
+
+func Test_shouldReloadSpec(t *testing.T) {
+	t.Parallel()
+	t.Run("empty curr spec", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, shouldReloadSpec(nil, &APISpec{}))
+	})
+
+	t.Run("checksum mismatch", func(t *testing.T) {
+		t.Parallel()
+		existingSpec, newSpec := &APISpec{Checksum: "1"}, &APISpec{Checksum: "2"}
+		assert.True(t, shouldReloadSpec(existingSpec, newSpec))
+	})
+
+	type testCase struct {
+		name string
+		spec *APISpec
+		want bool
+	}
+
+	assertionHelper := func(t *testing.T, tcs []testCase) {
+		t.Helper()
+		for i := 0; i < len(tcs); i++ {
+			tc := tcs[i]
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				if got := shouldReloadSpec(&APISpec{}, tc.spec); got != tc.want {
+					t.Errorf("shouldReloadSpec() = %v, want %v", got, tc.want)
+				}
+			})
+		}
+	}
+
+	t.Run("virtual endpoint", func(t *testing.T) {
+		t.Parallel()
+		tcs := []testCase{
+			{
+				name: "disabled",
+				spec: &APISpec{APIDefinition: &apidef.APIDefinition{
+					VersionData: apidef.VersionData{
+						Versions: map[string]apidef.VersionInfo{
+							"": {
+								ExtendedPaths: apidef.ExtendedPathsSet{
+									Virtual: []apidef.VirtualMeta{
+										{
+											Disabled: false,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				},
+				want: true,
+			},
+			{
+				name: "enabled",
+				spec: &APISpec{APIDefinition: &apidef.APIDefinition{
+					VersionData: apidef.VersionData{
+						Versions: map[string]apidef.VersionInfo{
+							"": {
+								ExtendedPaths: apidef.ExtendedPathsSet{
+									Virtual: []apidef.VirtualMeta{
+										{
+											Disabled: true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				},
+				want: false,
+			},
+		}
+
+		assertionHelper(t, tcs)
+	})
+
+	t.Run("driver", func(t *testing.T) {
+		t.Parallel()
+		tcs := []testCase{
+			{
+				name: "grpc",
+				spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddleware: apidef.MiddlewareSection{
+							Driver: apidef.GrpcDriver,
+							Pre: []apidef.MiddlewareDefinition{
+								{
+									Disabled: false,
+									Name:     "funcName",
+								},
+							},
+						},
+					},
+				},
+				want: false,
+			},
+			{
+				name: "goplugin",
+				spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddleware: apidef.MiddlewareSection{
+							Driver: apidef.GoPluginDriver,
+							Pre: []apidef.MiddlewareDefinition{
+								{
+									Disabled: false,
+									Name:     "funcName",
+								},
+							},
+						},
+					},
+				},
+				want: true,
+			},
+		}
+
+		assertionHelper(t, tcs)
+	})
+
+	t.Run("mw enabled", func(t *testing.T) {
+		t.Parallel()
+		tcs := []testCase{
+			{
+				name: "auth",
+				spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddleware: apidef.MiddlewareSection{
+							AuthCheck: apidef.MiddlewareDefinition{
+								Disabled: false,
+								Name:     "auth",
+								Path:     "path",
+							},
+						},
+					},
+				},
+				want: true,
+			},
+			{
+				name: "pre",
+				spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddleware: apidef.MiddlewareSection{
+							Pre: []apidef.MiddlewareDefinition{
+								{
+									Disabled: false,
+									Name:     "pre",
+									Path:     "path",
+								},
+							},
+						},
+					},
+				},
+				want: true,
+			},
+			{
+				name: "postKeyAuth",
+				spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddleware: apidef.MiddlewareSection{
+							PostKeyAuth: []apidef.MiddlewareDefinition{
+								{
+									Disabled: false,
+									Name:     "postAuth",
+									Path:     "path",
+								},
+							},
+						},
+					},
+				},
+				want: true,
+			},
+			{
+				name: "post",
+				spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddleware: apidef.MiddlewareSection{
+							Post: []apidef.MiddlewareDefinition{
+								{
+									Disabled: false,
+									Name:     "post",
+									Path:     "path",
+								},
+							},
+						},
+					},
+				},
+				want: true,
+			},
+			{
+				name: "response",
+				spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddleware: apidef.MiddlewareSection{
+							Response: []apidef.MiddlewareDefinition{
+								{
+									Disabled: false,
+									Name:     "response",
+									Path:     "path",
+								},
+							},
+						},
+					},
+				},
+				want: true,
+			},
+		}
+
+		assertionHelper(t, tcs)
+	})
+}

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -1,0 +1,14 @@
+package middleware
+
+import "github.com/TykTechnologies/tyk/apidef"
+
+// Enabled returns whether middlewares are enabled or not.
+func Enabled(defs ...apidef.MiddlewareDefinition) bool {
+	for _, def := range defs {
+		if !def.Disabled && def.Name != "" {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -1,0 +1,62 @@
+package middleware
+
+import (
+	"testing"
+
+	"github.com/TykTechnologies/tyk/apidef"
+)
+
+func TestEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		mws  []apidef.MiddlewareDefinition
+		want bool
+	}{
+		{
+			name: "disabled",
+			mws: []apidef.MiddlewareDefinition{
+				{
+					Disabled: true,
+					Name:     "mwFunc",
+					Path:     "path",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "enabled with empty name and path",
+			mws: []apidef.MiddlewareDefinition{
+				{
+					Disabled: false,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "enabled with empty name and path",
+			mws: []apidef.MiddlewareDefinition{
+				{
+					Disabled: false,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "enabled",
+			mws: []apidef.MiddlewareDefinition{
+				{
+					Disabled: false,
+					Name:     "mwFunc",
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Enabled(tt.mws...); got != tt.want {
+				t.Errorf("Enabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
[TT-7661] reload all APIs having a plugin defined in API definition (#4731)

<!-- Provide a general summary of your changes in the Title above -->

## Description
Currently APIs are not reloaded unless API definition checksum isn't
changed.
However this could lead to API not reloading when custom middlewares are
used, since when plugin shared objects or js files etc changes doesn't
make the checksum change.
As a solution to this, we can reload all APIs which have custom
middleware enabled.
Also gRPC plugins need not be reloaded unless there's a change in API
definition, so that should be skipped.
<!-- Describe your changes in detail -->

## Related Issue
https://tyktech.atlassian.net/browse/TT-7661


## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why

[TT-7661]: https://tyktech.atlassian.net/browse/TT-7661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ