### PR TITLE
Merging to release-4-lts: [TT-7661] reload all APIs having a plugin defined in API definition (#4731)

### DIFF
--- a/ci/goreleaser/goreleaser-el7.yml
+++ b/ci/goreleaser/goreleaser-el7.yml
@@ -182,6 +182,7 @@ dockers:
     - testdata
     - trace
     - user
+    - internal
 
 
 checksum:

--- a/ci/goreleaser/goreleaser.yml
+++ b/ci/goreleaser/goreleaser.yml
@@ -218,6 +218,7 @@ dockers:
     - testdata
     - trace
     - user
+    - internal
 
 
 docker_manifests:

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -276,7 +276,7 @@ func (a APIDefinitionLoader) MakeSpec(def *apidef.APIDefinition, logger *logrus.
 	// Unique API content ID, to check if we already have if it changed from previous sync
 	spec.Checksum = base64.URLEncoding.EncodeToString(sha256hash[:])
 
-	spec.APIDefinition = def.APIDefinition
+	spec.APIDefinition = def
 
 	if currSpec := a.Gw.getApiSpec(def.APIID); !shouldReloadSpec(currSpec, spec) {
 		return currSpec
@@ -300,11 +300,6 @@ func (a APIDefinitionLoader) MakeSpec(def *apidef.APIDefinition, logger *logrus.
 		}
 	}
 
-<<<<<<< HEAD
-	spec.APIDefinition = def
-
-=======
->>>>>>> bea03b12... [TT-7661] reload all APIs having a plugin defined in API definition (#4731)
 	// We'll push the default HealthChecker:
 	spec.Health = &DefaultHealthChecker{
 		Gw:    a.Gw,

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -276,8 +276,10 @@ func (a APIDefinitionLoader) MakeSpec(def *apidef.APIDefinition, logger *logrus.
 	// Unique API content ID, to check if we already have if it changed from previous sync
 	spec.Checksum = base64.URLEncoding.EncodeToString(sha256hash[:])
 
-	if currSpec := a.Gw.getApiSpec(def.APIID); currSpec != nil && currSpec.Checksum == spec.Checksum {
-		return a.Gw.getApiSpec(def.APIID)
+	spec.APIDefinition = def.APIDefinition
+
+	if currSpec := a.Gw.getApiSpec(def.APIID); !shouldReloadSpec(currSpec, spec) {
+		return currSpec
 	}
 
 	if logger == nil {
@@ -298,8 +300,11 @@ func (a APIDefinitionLoader) MakeSpec(def *apidef.APIDefinition, logger *logrus.
 		}
 	}
 
+<<<<<<< HEAD
 	spec.APIDefinition = def
 
+=======
+>>>>>>> bea03b12... [TT-7661] reload all APIs having a plugin defined in API definition (#4731)
 	// We'll push the default HealthChecker:
 	spec.Health = &DefaultHealthChecker{
 		Gw:    a.Gw,

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -722,7 +722,7 @@ func (gw *Gateway) loadHTTPService(spec *APISpec, apisByListen map[string]int, g
 
 	var chainObj *ChainObject
 
-	if curSpec := gw.getApiSpec(spec.APIID); curSpec != nil && curSpec.Checksum == spec.Checksum {
+	if curSpec := gw.getApiSpec(spec.APIID); !shouldReloadSpec(curSpec, spec) {
 		if chain, found := gw.apisHandlesByID.Load(spec.APIID); found {
 			chainObj = chain.(*ChainObject)
 		}
@@ -900,7 +900,7 @@ func (gw *Gateway) loadApps(specs []*APISpec) {
 				spec.Proxy.ListenPath = converted
 			}
 
-			if currSpec := gw.getApiSpec(spec.APIID); currSpec != nil && spec.Checksum == currSpec.Checksum {
+			if currSpec := gw.getApiSpec(spec.APIID); !shouldReloadSpec(currSpec, spec) {
 				tmpSpecRegister[spec.APIID] = currSpec
 			} else {
 				tmpSpecRegister[spec.APIID] = spec

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/TykTechnologies/tyk/certs"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/test"
+	"github.com/stretchr/testify/assert"
 )
 
 const (

--- a/gateway/util.go
+++ b/gateway/util.go
@@ -1,8 +1,18 @@
 package gateway
 
 import (
+<<<<<<< HEAD
 	"errors"
 	"os"
+=======
+	"net"
+	"net/url"
+	"strconv"
+
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/internal/middleware"
+>>>>>>> bea03b12... [TT-7661] reload all APIs having a plugin defined in API definition (#4731)
 )
 
 // appendIfMissing ensures dest slice is unique with new items.
@@ -114,4 +124,44 @@ func FileExist(filepath string) bool {
 		return false
 	}
 	return true
+}
+
+func shouldReloadSpec(existingSpec, newSpec *APISpec) bool {
+	if existingSpec == nil {
+		return true
+	}
+
+	if existingSpec.Checksum != newSpec.Checksum {
+		return true
+	}
+
+	if newSpec.hasVirtualEndpoint() {
+		return true
+	}
+
+	if newSpec.CustomMiddleware.Driver == apidef.GrpcDriver {
+		return false
+	}
+
+	if middleware.Enabled(newSpec.CustomMiddleware.AuthCheck) {
+		return true
+	}
+
+	if middleware.Enabled(newSpec.CustomMiddleware.Pre...) {
+		return true
+	}
+
+	if middleware.Enabled(newSpec.CustomMiddleware.PostKeyAuth...) {
+		return true
+	}
+
+	if middleware.Enabled(newSpec.CustomMiddleware.Post...) {
+		return true
+	}
+
+	if middleware.Enabled(newSpec.CustomMiddleware.Response...) {
+		return true
+	}
+
+	return false
 }

--- a/gateway/util.go
+++ b/gateway/util.go
@@ -1,18 +1,11 @@
 package gateway
 
 import (
-<<<<<<< HEAD
 	"errors"
 	"os"
-=======
-	"net"
-	"net/url"
-	"strconv"
 
 	"github.com/TykTechnologies/tyk/apidef"
-	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/internal/middleware"
->>>>>>> bea03b12... [TT-7661] reload all APIs having a plugin defined in API definition (#4731)
 )
 
 // appendIfMissing ensures dest slice is unique with new items.

--- a/gateway/util_test.go
+++ b/gateway/util_test.go
@@ -25,3 +25,428 @@ func TestAppendIfMissingUniqueness(t *testing.T) {
 
 	assert.Equal(t, want, after)
 }
+<<<<<<< HEAD
+=======
+
+func Test_getAPIURL(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		apiDef   apidef.APIDefinition
+		gwConfig config.Config
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "https enabled with api domain",
+			args: args{
+				apiDef: apidef.APIDefinition{
+					Domain: "example.com",
+					Proxy: apidef.ProxyConfig{
+						ListenPath: "/api",
+					},
+				},
+				gwConfig: config.Config{
+					HttpServerOptions: config.HttpServerOptionsConfig{
+						UseSSL: true,
+					},
+				},
+			},
+			want: "https://example.com/api",
+		},
+
+		{
+			name: "https disabled with api domain",
+			args: args{
+				apiDef: apidef.APIDefinition{
+					Domain: "example.com",
+					Proxy: apidef.ProxyConfig{
+						ListenPath: "/api",
+					},
+				},
+				gwConfig: config.Config{},
+			},
+			want: "http://example.com/api",
+		},
+
+		{
+			name: "https disabled without api domain",
+			args: args{
+				apiDef: apidef.APIDefinition{
+					Proxy: apidef.ProxyConfig{
+						ListenPath: "/api",
+					},
+				},
+				gwConfig: config.Config{
+					ListenAddress: "127.0.0.1",
+					ListenPort:    8080,
+				},
+			},
+			want: "http://127.0.0.1:8080/api",
+		},
+
+		{
+			name: "https enabled and configured listen address and port 443",
+			args: args{
+				apiDef: apidef.APIDefinition{
+					Proxy: apidef.ProxyConfig{
+						ListenPath: "/api",
+					},
+				},
+				gwConfig: config.Config{
+					ListenAddress: "10.0.0.1",
+					ListenPort:    443,
+					HttpServerOptions: config.HttpServerOptionsConfig{
+						UseSSL: true,
+					},
+				},
+			},
+			want: "https://10.0.0.1/api",
+		},
+
+		{
+			name: "without api domain and configured listen address",
+			args: args{
+				apiDef: apidef.APIDefinition{
+					Proxy: apidef.ProxyConfig{
+						ListenPath: "/api",
+					},
+				},
+				gwConfig: config.Config{
+					ListenAddress: "10.0.0.1",
+					ListenPort:    8080,
+					HttpServerOptions: config.HttpServerOptionsConfig{
+						UseSSL: true,
+					},
+				},
+			},
+			want: "https://10.0.0.1:8080/api",
+		},
+
+		{
+			name: "configured listen address with 80 port",
+			args: args{
+				apiDef: apidef.APIDefinition{
+					Proxy: apidef.ProxyConfig{
+						ListenPath: "/api",
+					},
+				},
+				gwConfig: config.Config{
+					ListenAddress: "10.0.0.1",
+					ListenPort:    80,
+				},
+			},
+			want: "http://10.0.0.1/api",
+		},
+
+		{
+			name: "without api domain and no configured listen address",
+			args: args{
+				apiDef: apidef.APIDefinition{
+					Proxy: apidef.ProxyConfig{
+						ListenPath: "/api",
+					},
+				},
+				gwConfig: config.Config{
+					ListenPort: 8080,
+					HttpServerOptions: config.HttpServerOptionsConfig{
+						UseSSL: true,
+					},
+				},
+			},
+			want: "https://127.0.0.1:8080/api",
+		},
+
+		{
+			name: "no configured listen address with 80 port",
+			args: args{
+				apiDef: apidef.APIDefinition{
+					Proxy: apidef.ProxyConfig{
+						ListenPath: "/api",
+					},
+				},
+				gwConfig: config.Config{
+					ListenPort: 80,
+				},
+			},
+			want: "http://127.0.0.1/api",
+		},
+
+		{
+			name: "gw hostname non 80 port",
+			args: args{
+				apiDef: apidef.APIDefinition{
+					Proxy: apidef.ProxyConfig{
+						ListenPath: "/api",
+					},
+				},
+				gwConfig: config.Config{
+					ListenAddress: "127.0.0.1",
+					ListenPort:    8080,
+					HostName:      "example-host.org",
+				},
+			},
+			want: "http://example-host.org:8080/api",
+		},
+
+		{
+			name: "gw hostname with port 80",
+			args: args{
+				apiDef: apidef.APIDefinition{
+					Proxy: apidef.ProxyConfig{
+						ListenPath: "/api",
+					},
+				},
+				gwConfig: config.Config{
+					ListenAddress: "127.0.0.1",
+					ListenPort:    80,
+					HostName:      "example-host.org",
+				},
+			},
+			want: "http://example-host.org/api",
+		},
+
+		{
+			name: "https enabled gw hostname with port 443",
+			args: args{
+				apiDef: apidef.APIDefinition{
+					Proxy: apidef.ProxyConfig{
+						ListenPath: "/api",
+					},
+				},
+				gwConfig: config.Config{
+					ListenAddress: "127.0.0.1",
+					ListenPort:    443,
+					HostName:      "example-host.org",
+					HttpServerOptions: config.HttpServerOptionsConfig{
+						UseSSL: true,
+					},
+				},
+			},
+
+			want: "https://example-host.org/api",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, getAPIURL(tt.args.apiDef, tt.args.gwConfig), "getAPIURL(%v, %v)", tt.args.apiDef, tt.args.gwConfig)
+		})
+	}
+}
+
+func Test_shouldReloadSpec(t *testing.T) {
+	t.Parallel()
+	t.Run("empty curr spec", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, shouldReloadSpec(nil, &APISpec{}))
+	})
+
+	t.Run("checksum mismatch", func(t *testing.T) {
+		t.Parallel()
+		existingSpec, newSpec := &APISpec{Checksum: "1"}, &APISpec{Checksum: "2"}
+		assert.True(t, shouldReloadSpec(existingSpec, newSpec))
+	})
+
+	type testCase struct {
+		name string
+		spec *APISpec
+		want bool
+	}
+
+	assertionHelper := func(t *testing.T, tcs []testCase) {
+		t.Helper()
+		for i := 0; i < len(tcs); i++ {
+			tc := tcs[i]
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				if got := shouldReloadSpec(&APISpec{}, tc.spec); got != tc.want {
+					t.Errorf("shouldReloadSpec() = %v, want %v", got, tc.want)
+				}
+			})
+		}
+	}
+
+	t.Run("virtual endpoint", func(t *testing.T) {
+		t.Parallel()
+		tcs := []testCase{
+			{
+				name: "disabled",
+				spec: &APISpec{APIDefinition: &apidef.APIDefinition{
+					VersionData: apidef.VersionData{
+						Versions: map[string]apidef.VersionInfo{
+							"": {
+								ExtendedPaths: apidef.ExtendedPathsSet{
+									Virtual: []apidef.VirtualMeta{
+										{
+											Disabled: false,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				},
+				want: true,
+			},
+			{
+				name: "enabled",
+				spec: &APISpec{APIDefinition: &apidef.APIDefinition{
+					VersionData: apidef.VersionData{
+						Versions: map[string]apidef.VersionInfo{
+							"": {
+								ExtendedPaths: apidef.ExtendedPathsSet{
+									Virtual: []apidef.VirtualMeta{
+										{
+											Disabled: true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				},
+				want: false,
+			},
+		}
+
+		assertionHelper(t, tcs)
+	})
+
+	t.Run("driver", func(t *testing.T) {
+		t.Parallel()
+		tcs := []testCase{
+			{
+				name: "grpc",
+				spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddleware: apidef.MiddlewareSection{
+							Driver: apidef.GrpcDriver,
+							Pre: []apidef.MiddlewareDefinition{
+								{
+									Disabled: false,
+									Name:     "funcName",
+								},
+							},
+						},
+					},
+				},
+				want: false,
+			},
+			{
+				name: "goplugin",
+				spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddleware: apidef.MiddlewareSection{
+							Driver: apidef.GoPluginDriver,
+							Pre: []apidef.MiddlewareDefinition{
+								{
+									Disabled: false,
+									Name:     "funcName",
+								},
+							},
+						},
+					},
+				},
+				want: true,
+			},
+		}
+
+		assertionHelper(t, tcs)
+	})
+
+	t.Run("mw enabled", func(t *testing.T) {
+		t.Parallel()
+		tcs := []testCase{
+			{
+				name: "auth",
+				spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddleware: apidef.MiddlewareSection{
+							AuthCheck: apidef.MiddlewareDefinition{
+								Disabled: false,
+								Name:     "auth",
+								Path:     "path",
+							},
+						},
+					},
+				},
+				want: true,
+			},
+			{
+				name: "pre",
+				spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddleware: apidef.MiddlewareSection{
+							Pre: []apidef.MiddlewareDefinition{
+								{
+									Disabled: false,
+									Name:     "pre",
+									Path:     "path",
+								},
+							},
+						},
+					},
+				},
+				want: true,
+			},
+			{
+				name: "postKeyAuth",
+				spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddleware: apidef.MiddlewareSection{
+							PostKeyAuth: []apidef.MiddlewareDefinition{
+								{
+									Disabled: false,
+									Name:     "postAuth",
+									Path:     "path",
+								},
+							},
+						},
+					},
+				},
+				want: true,
+			},
+			{
+				name: "post",
+				spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddleware: apidef.MiddlewareSection{
+							Post: []apidef.MiddlewareDefinition{
+								{
+									Disabled: false,
+									Name:     "post",
+									Path:     "path",
+								},
+							},
+						},
+					},
+				},
+				want: true,
+			},
+			{
+				name: "response",
+				spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddleware: apidef.MiddlewareSection{
+							Response: []apidef.MiddlewareDefinition{
+								{
+									Disabled: false,
+									Name:     "response",
+									Path:     "path",
+								},
+							},
+						},
+					},
+				},
+				want: true,
+			},
+		}
+
+		assertionHelper(t, tcs)
+	})
+}
+>>>>>>> bea03b12... [TT-7661] reload all APIs having a plugin defined in API definition (#4731)

--- a/gateway/util_test.go
+++ b/gateway/util_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,216 +25,6 @@ func TestAppendIfMissingUniqueness(t *testing.T) {
 	want = append(want, "B", "D", "E", "F")
 
 	assert.Equal(t, want, after)
-}
-<<<<<<< HEAD
-=======
-
-func Test_getAPIURL(t *testing.T) {
-	t.Parallel()
-	type args struct {
-		apiDef   apidef.APIDefinition
-		gwConfig config.Config
-	}
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
-		{
-			name: "https enabled with api domain",
-			args: args{
-				apiDef: apidef.APIDefinition{
-					Domain: "example.com",
-					Proxy: apidef.ProxyConfig{
-						ListenPath: "/api",
-					},
-				},
-				gwConfig: config.Config{
-					HttpServerOptions: config.HttpServerOptionsConfig{
-						UseSSL: true,
-					},
-				},
-			},
-			want: "https://example.com/api",
-		},
-
-		{
-			name: "https disabled with api domain",
-			args: args{
-				apiDef: apidef.APIDefinition{
-					Domain: "example.com",
-					Proxy: apidef.ProxyConfig{
-						ListenPath: "/api",
-					},
-				},
-				gwConfig: config.Config{},
-			},
-			want: "http://example.com/api",
-		},
-
-		{
-			name: "https disabled without api domain",
-			args: args{
-				apiDef: apidef.APIDefinition{
-					Proxy: apidef.ProxyConfig{
-						ListenPath: "/api",
-					},
-				},
-				gwConfig: config.Config{
-					ListenAddress: "127.0.0.1",
-					ListenPort:    8080,
-				},
-			},
-			want: "http://127.0.0.1:8080/api",
-		},
-
-		{
-			name: "https enabled and configured listen address and port 443",
-			args: args{
-				apiDef: apidef.APIDefinition{
-					Proxy: apidef.ProxyConfig{
-						ListenPath: "/api",
-					},
-				},
-				gwConfig: config.Config{
-					ListenAddress: "10.0.0.1",
-					ListenPort:    443,
-					HttpServerOptions: config.HttpServerOptionsConfig{
-						UseSSL: true,
-					},
-				},
-			},
-			want: "https://10.0.0.1/api",
-		},
-
-		{
-			name: "without api domain and configured listen address",
-			args: args{
-				apiDef: apidef.APIDefinition{
-					Proxy: apidef.ProxyConfig{
-						ListenPath: "/api",
-					},
-				},
-				gwConfig: config.Config{
-					ListenAddress: "10.0.0.1",
-					ListenPort:    8080,
-					HttpServerOptions: config.HttpServerOptionsConfig{
-						UseSSL: true,
-					},
-				},
-			},
-			want: "https://10.0.0.1:8080/api",
-		},
-
-		{
-			name: "configured listen address with 80 port",
-			args: args{
-				apiDef: apidef.APIDefinition{
-					Proxy: apidef.ProxyConfig{
-						ListenPath: "/api",
-					},
-				},
-				gwConfig: config.Config{
-					ListenAddress: "10.0.0.1",
-					ListenPort:    80,
-				},
-			},
-			want: "http://10.0.0.1/api",
-		},
-
-		{
-			name: "without api domain and no configured listen address",
-			args: args{
-				apiDef: apidef.APIDefinition{
-					Proxy: apidef.ProxyConfig{
-						ListenPath: "/api",
-					},
-				},
-				gwConfig: config.Config{
-					ListenPort: 8080,
-					HttpServerOptions: config.HttpServerOptionsConfig{
-						UseSSL: true,
-					},
-				},
-			},
-			want: "https://127.0.0.1:8080/api",
-		},
-
-		{
-			name: "no configured listen address with 80 port",
-			args: args{
-				apiDef: apidef.APIDefinition{
-					Proxy: apidef.ProxyConfig{
-						ListenPath: "/api",
-					},
-				},
-				gwConfig: config.Config{
-					ListenPort: 80,
-				},
-			},
-			want: "http://127.0.0.1/api",
-		},
-
-		{
-			name: "gw hostname non 80 port",
-			args: args{
-				apiDef: apidef.APIDefinition{
-					Proxy: apidef.ProxyConfig{
-						ListenPath: "/api",
-					},
-				},
-				gwConfig: config.Config{
-					ListenAddress: "127.0.0.1",
-					ListenPort:    8080,
-					HostName:      "example-host.org",
-				},
-			},
-			want: "http://example-host.org:8080/api",
-		},
-
-		{
-			name: "gw hostname with port 80",
-			args: args{
-				apiDef: apidef.APIDefinition{
-					Proxy: apidef.ProxyConfig{
-						ListenPath: "/api",
-					},
-				},
-				gwConfig: config.Config{
-					ListenAddress: "127.0.0.1",
-					ListenPort:    80,
-					HostName:      "example-host.org",
-				},
-			},
-			want: "http://example-host.org/api",
-		},
-
-		{
-			name: "https enabled gw hostname with port 443",
-			args: args{
-				apiDef: apidef.APIDefinition{
-					Proxy: apidef.ProxyConfig{
-						ListenPath: "/api",
-					},
-				},
-				gwConfig: config.Config{
-					ListenAddress: "127.0.0.1",
-					ListenPort:    443,
-					HostName:      "example-host.org",
-					HttpServerOptions: config.HttpServerOptionsConfig{
-						UseSSL: true,
-					},
-				},
-			},
-
-			want: "https://example-host.org/api",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, getAPIURL(tt.args.apiDef, tt.args.gwConfig), "getAPIURL(%v, %v)", tt.args.apiDef, tt.args.gwConfig)
-		})
-	}
 }
 
 func Test_shouldReloadSpec(t *testing.T) {
@@ -270,45 +61,27 @@ func Test_shouldReloadSpec(t *testing.T) {
 
 	t.Run("virtual endpoint", func(t *testing.T) {
 		t.Parallel()
-		tcs := []testCase{
-			{
-				name: "disabled",
-				spec: &APISpec{APIDefinition: &apidef.APIDefinition{
-					VersionData: apidef.VersionData{
-						Versions: map[string]apidef.VersionInfo{
-							"": {
-								ExtendedPaths: apidef.ExtendedPathsSet{
-									Virtual: []apidef.VirtualMeta{
-										{
-											Disabled: false,
-										},
-									},
-								},
-							},
+		virtualEndpointAPIDef := &apidef.APIDefinition{}
+		virtualEndpointAPIDef.VersionData.Versions = map[string]apidef.VersionInfo{
+			"": {
+				ExtendedPaths: apidef.ExtendedPathsSet{
+					Virtual: []apidef.VirtualMeta{
+						{
+							ResponseFunctionName: "respFuncName",
 						},
 					},
 				},
-				},
+			},
+		}
+		tcs := []testCase{
+			{
+				name: "with virutal endpoint",
+				spec: &APISpec{APIDefinition: virtualEndpointAPIDef},
 				want: true,
 			},
 			{
-				name: "enabled",
-				spec: &APISpec{APIDefinition: &apidef.APIDefinition{
-					VersionData: apidef.VersionData{
-						Versions: map[string]apidef.VersionInfo{
-							"": {
-								ExtendedPaths: apidef.ExtendedPathsSet{
-									Virtual: []apidef.VirtualMeta{
-										{
-											Disabled: true,
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				},
+				name: "without virutal endpoint",
+				spec: &APISpec{APIDefinition: &apidef.APIDefinition{}},
 				want: false,
 			},
 		}
@@ -327,8 +100,7 @@ func Test_shouldReloadSpec(t *testing.T) {
 							Driver: apidef.GrpcDriver,
 							Pre: []apidef.MiddlewareDefinition{
 								{
-									Disabled: false,
-									Name:     "funcName",
+									Name: "funcName",
 								},
 							},
 						},
@@ -344,8 +116,7 @@ func Test_shouldReloadSpec(t *testing.T) {
 							Driver: apidef.GoPluginDriver,
 							Pre: []apidef.MiddlewareDefinition{
 								{
-									Disabled: false,
-									Name:     "funcName",
+									Name: "funcName",
 								},
 							},
 						},
@@ -367,9 +138,8 @@ func Test_shouldReloadSpec(t *testing.T) {
 					APIDefinition: &apidef.APIDefinition{
 						CustomMiddleware: apidef.MiddlewareSection{
 							AuthCheck: apidef.MiddlewareDefinition{
-								Disabled: false,
-								Name:     "auth",
-								Path:     "path",
+								Name: "auth",
+								Path: "path",
 							},
 						},
 					},
@@ -383,9 +153,8 @@ func Test_shouldReloadSpec(t *testing.T) {
 						CustomMiddleware: apidef.MiddlewareSection{
 							Pre: []apidef.MiddlewareDefinition{
 								{
-									Disabled: false,
-									Name:     "pre",
-									Path:     "path",
+									Name: "pre",
+									Path: "path",
 								},
 							},
 						},
@@ -400,9 +169,8 @@ func Test_shouldReloadSpec(t *testing.T) {
 						CustomMiddleware: apidef.MiddlewareSection{
 							PostKeyAuth: []apidef.MiddlewareDefinition{
 								{
-									Disabled: false,
-									Name:     "postAuth",
-									Path:     "path",
+									Name: "postAuth",
+									Path: "path",
 								},
 							},
 						},
@@ -417,9 +185,8 @@ func Test_shouldReloadSpec(t *testing.T) {
 						CustomMiddleware: apidef.MiddlewareSection{
 							Post: []apidef.MiddlewareDefinition{
 								{
-									Disabled: false,
-									Name:     "post",
-									Path:     "path",
+									Name: "post",
+									Path: "path",
 								},
 							},
 						},
@@ -434,9 +201,8 @@ func Test_shouldReloadSpec(t *testing.T) {
 						CustomMiddleware: apidef.MiddlewareSection{
 							Response: []apidef.MiddlewareDefinition{
 								{
-									Disabled: false,
-									Name:     "response",
-									Path:     "path",
+									Name: "response",
+									Path: "path",
 								},
 							},
 						},
@@ -449,4 +215,3 @@ func Test_shouldReloadSpec(t *testing.T) {
 		assertionHelper(t, tcs)
 	})
 }
->>>>>>> bea03b12... [TT-7661] reload all APIs having a plugin defined in API definition (#4731)

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -1,0 +1,14 @@
+package middleware
+
+import "github.com/TykTechnologies/tyk/apidef"
+
+// Enabled returns whether middlewares are enabled or not.
+func Enabled(defs ...apidef.MiddlewareDefinition) bool {
+	for _, def := range defs {
+		if !def.Disabled && def.Name != "" {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -5,7 +5,7 @@ import "github.com/TykTechnologies/tyk/apidef"
 // Enabled returns whether middlewares are enabled or not.
 func Enabled(defs ...apidef.MiddlewareDefinition) bool {
 	for _, def := range defs {
-		if !def.Disabled && def.Name != "" {
+		if def.Name != "" {
 			return true
 		}
 	}

--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -13,31 +13,9 @@ func TestEnabled(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "disabled",
+			name: "empty name and path",
 			mws: []apidef.MiddlewareDefinition{
-				{
-					Disabled: true,
-					Name:     "mwFunc",
-					Path:     "path",
-				},
-			},
-			want: false,
-		},
-		{
-			name: "enabled with empty name and path",
-			mws: []apidef.MiddlewareDefinition{
-				{
-					Disabled: false,
-				},
-			},
-			want: false,
-		},
-		{
-			name: "enabled with empty name and path",
-			mws: []apidef.MiddlewareDefinition{
-				{
-					Disabled: false,
-				},
+				{},
 			},
 			want: false,
 		},
@@ -45,8 +23,7 @@ func TestEnabled(t *testing.T) {
 			name: "enabled",
 			mws: []apidef.MiddlewareDefinition{
 				{
-					Disabled: false,
-					Name:     "mwFunc",
+					Name: "mwFunc",
 				},
 			},
 			want: true,

--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -1,0 +1,62 @@
+package middleware
+
+import (
+	"testing"
+
+	"github.com/TykTechnologies/tyk/apidef"
+)
+
+func TestEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		mws  []apidef.MiddlewareDefinition
+		want bool
+	}{
+		{
+			name: "disabled",
+			mws: []apidef.MiddlewareDefinition{
+				{
+					Disabled: true,
+					Name:     "mwFunc",
+					Path:     "path",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "enabled with empty name and path",
+			mws: []apidef.MiddlewareDefinition{
+				{
+					Disabled: false,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "enabled with empty name and path",
+			mws: []apidef.MiddlewareDefinition{
+				{
+					Disabled: false,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "enabled",
+			mws: []apidef.MiddlewareDefinition{
+				{
+					Disabled: false,
+					Name:     "mwFunc",
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Enabled(tt.mws...); got != tt.want {
+				t.Errorf("Enabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
[TT-7661] reload all APIs having a plugin defined in API definition (#4731)

<!-- Provide a general summary of your changes in the Title above -->

## Description
Currently APIs are not reloaded unless API definition checksum isn't
changed.
However this could lead to API not reloading when custom middlewares are
used, since when plugin shared objects or js files etc changes doesn't
make the checksum change.
As a solution to this, we can reload all APIs which have custom
middleware enabled.
Also gRPC plugins need not be reloaded unless there's a change in API
definition, so that should be skipped.
<!-- Describe your changes in detail -->

## Related Issue
https://tyktech.atlassian.net/browse/TT-7661


## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why

[TT-7661]: https://tyktech.atlassian.net/browse/TT-7661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ