### PR TITLE
Merging to release-5-lts: move adapter helper functions to proper util files (TT-7999) (#4792)

### DIFF
--- a/apidef/adapter/engine_v2_utils.go
+++ b/apidef/adapter/engine_v2_utils.go
@@ -1,0 +1,137 @@
+package adapter
+
+import (
+	"errors"
+	"net/http"
+	neturl "net/url"
+	"sort"
+	"strings"
+
+	graphqlDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/graphql_datasource"
+	restDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/rest_datasource"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/plan"
+
+	"github.com/TykTechnologies/tyk/apidef"
+)
+
+type createGraphQLDataSourceFactoryParams struct {
+	graphqlConfig             apidef.GraphQLEngineDataSourceConfigGraphQL
+	subscriptionClientFactory graphqlDataSource.GraphQLSubscriptionClientFactory
+	httpClient                *http.Client
+	streamingClient           *http.Client
+}
+
+func graphqlDataSourceConfiguration(url string, method string, headers map[string]string, subscriptionType apidef.SubscriptionType) graphqlDataSource.Configuration {
+	dataSourceHeaders := make(map[string]string)
+	for name, value := range headers {
+		dataSourceHeaders[name] = value
+	}
+
+	if strings.HasPrefix(url, "tyk://") {
+		url = strings.ReplaceAll(url, "tyk://", "http://")
+		dataSourceHeaders[apidef.TykInternalApiHeader] = "true"
+	}
+
+	cfg := graphqlDataSource.Configuration{
+		Fetch: graphqlDataSource.FetchConfiguration{
+			URL:    url,
+			Method: method,
+			Header: convertApiDefinitionHeadersToHttpHeaders(dataSourceHeaders),
+		},
+		Subscription: graphqlDataSource.SubscriptionConfiguration{
+			URL:    url,
+			UseSSE: subscriptionType == apidef.GQLSubscriptionSSE,
+		},
+	}
+
+	return cfg
+}
+
+func createArgumentConfigurationsForArgumentNames(argumentNames ...string) plan.ArgumentsConfigurations {
+	argConfs := plan.ArgumentsConfigurations{}
+	for _, argName := range argumentNames {
+		argConf := plan.ArgumentConfiguration{
+			Name:       argName,
+			SourceType: plan.FieldArgumentSource,
+		}
+
+		argConfs = append(argConfs, argConf)
+	}
+
+	return argConfs
+}
+
+func extractURLQueryParamsForEngineV2(url string, providedApiDefQueries []apidef.QueryVariable) (urlWithoutParams string, engineV2Queries []restDataSource.QueryConfiguration, err error) {
+	urlParts := strings.Split(url, "?")
+	urlWithoutParams = urlParts[0]
+
+	queryPart := ""
+	if len(urlParts) == 2 {
+		queryPart = urlParts[1]
+	}
+	// Parse only query part as URL could contain templating {{.argument.id}} which should not be escaped
+	values, err := neturl.ParseQuery(queryPart)
+	if err != nil {
+		return "", nil, err
+	}
+
+	engineV2Queries = make([]restDataSource.QueryConfiguration, 0)
+	appendURLQueryParamsToEngineV2Queries(&engineV2Queries, values)
+	appendApiDefQueriesConfigToEngineV2Queries(&engineV2Queries, providedApiDefQueries)
+
+	if len(engineV2Queries) == 0 {
+		return urlWithoutParams, nil, nil
+	}
+
+	return urlWithoutParams, engineV2Queries, nil
+}
+
+func appendURLQueryParamsToEngineV2Queries(engineV2Queries *[]restDataSource.QueryConfiguration, queryValues neturl.Values) {
+	for queryKey, queryValue := range queryValues {
+		*engineV2Queries = append(*engineV2Queries, restDataSource.QueryConfiguration{
+			Name:  queryKey,
+			Value: strings.Join(queryValue, ","),
+		})
+	}
+
+	sort.Slice(*engineV2Queries, func(i, j int) bool {
+		return (*engineV2Queries)[i].Name < (*engineV2Queries)[j].Name
+	})
+}
+
+func appendApiDefQueriesConfigToEngineV2Queries(engineV2Queries *[]restDataSource.QueryConfiguration, apiDefQueries []apidef.QueryVariable) {
+	if len(apiDefQueries) == 0 {
+		return
+	}
+
+	for _, apiDefQueryVar := range apiDefQueries {
+		engineV2Query := restDataSource.QueryConfiguration{
+			Name:  apiDefQueryVar.Name,
+			Value: apiDefQueryVar.Value,
+		}
+
+		*engineV2Queries = append(*engineV2Queries, engineV2Query)
+	}
+}
+
+func createGraphQLDataSourceFactory(params createGraphQLDataSourceFactoryParams) (*graphqlDataSource.Factory, error) {
+	factory := &graphqlDataSource.Factory{
+		HTTPClient:      params.httpClient,
+		StreamingClient: params.streamingClient,
+	}
+
+	wsProtocol := graphqlDataSourceWebSocketProtocol(params.graphqlConfig.SubscriptionType)
+	graphqlSubscriptionClient := params.subscriptionClientFactory.NewSubscriptionClient(
+		params.httpClient,
+		params.streamingClient,
+		nil,
+		graphqlDataSource.WithWSSubProtocol(wsProtocol),
+	)
+
+	subscriptionClient, ok := graphqlSubscriptionClient.(*graphqlDataSource.SubscriptionClient)
+	if !ok {
+		return nil, errors.New("incorrect SubscriptionClient has been created")
+	}
+	factory.SubscriptionClient = subscriptionClient
+	return factory, nil
+}

--- a/apidef/adapter/engine_v2_utils_test.go
+++ b/apidef/adapter/engine_v2_utils_test.go
@@ -1,0 +1,282 @@
+package adapter
+
+import (
+	"net/http"
+	neturl "net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	graphqlDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/graphql_datasource"
+	restDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/rest_datasource"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/plan"
+
+	"github.com/TykTechnologies/tyk/apidef"
+)
+
+func TestGraphqlDataSourceConfiguration(t *testing.T) {
+	type testInput struct {
+		url              string
+		method           string
+		headers          map[string]string
+		subscriptionType apidef.SubscriptionType
+	}
+
+	t.Run("with internal data source url and sse", func(t *testing.T) {
+		internalDataSource := testInput{
+			url:    "tyk://data-source.fake",
+			method: http.MethodGet,
+			headers: map[string]string{
+				"Authorization": "token",
+				"X-Tyk-Key":     "value",
+			},
+			subscriptionType: apidef.GQLSubscriptionSSE,
+		}
+
+		expectedGraphqlDataSourceConfiguration := graphqlDataSource.Configuration{
+			Fetch: graphqlDataSource.FetchConfiguration{
+				URL:    "http://data-source.fake",
+				Method: http.MethodGet,
+				Header: http.Header{
+					"Authorization": {"token"},
+					http.CanonicalHeaderKey(apidef.TykInternalApiHeader): {"true"},
+					"X-Tyk-Key": {"value"},
+				},
+			},
+			Subscription: graphqlDataSource.SubscriptionConfiguration{
+				URL:           "http://data-source.fake",
+				UseSSE:        true,
+				SSEMethodPost: false,
+			},
+		}
+
+		actualGraphqlDataSourceConfiguration := graphqlDataSourceConfiguration(
+			internalDataSource.url,
+			internalDataSource.method,
+			internalDataSource.headers,
+			internalDataSource.subscriptionType,
+		)
+
+		assert.Equal(t, expectedGraphqlDataSourceConfiguration, actualGraphqlDataSourceConfiguration)
+	})
+
+	t.Run("with external data source url and no sse", func(t *testing.T) {
+		externalDataSource := testInput{
+			url:    "http://data-source.fake",
+			method: http.MethodGet,
+			headers: map[string]string{
+				"Authorization": "token",
+				"X-Tyk-Key":     "value",
+			},
+			subscriptionType: apidef.GQLSubscriptionTransportWS,
+		}
+
+		expectedGraphqlDataSourceConfiguration := graphqlDataSource.Configuration{
+			Fetch: graphqlDataSource.FetchConfiguration{
+				URL:    "http://data-source.fake",
+				Method: http.MethodGet,
+				Header: http.Header{
+					"Authorization": {"token"},
+					"X-Tyk-Key":     {"value"},
+				},
+			},
+			Subscription: graphqlDataSource.SubscriptionConfiguration{
+				URL:           "http://data-source.fake",
+				UseSSE:        false,
+				SSEMethodPost: false,
+			},
+		}
+
+		actualGraphqlDataSourceConfiguration := graphqlDataSourceConfiguration(
+			externalDataSource.url,
+			externalDataSource.method,
+			externalDataSource.headers,
+			externalDataSource.subscriptionType,
+		)
+
+		assert.Equal(t, expectedGraphqlDataSourceConfiguration, actualGraphqlDataSourceConfiguration)
+	})
+
+}
+
+func TestCreateArgumentConfigurationsForArgumentNames(t *testing.T) {
+	expectedArgumentConfigurations := plan.ArgumentsConfigurations{
+		{
+			Name:       "argument1",
+			SourceType: plan.FieldArgumentSource,
+		},
+		{
+			Name:       "argument2",
+			SourceType: plan.FieldArgumentSource,
+		},
+	}
+
+	actualArgumentConfigurations := createArgumentConfigurationsForArgumentNames("argument1", "argument2")
+	assert.Equal(t, expectedArgumentConfigurations, actualArgumentConfigurations)
+}
+
+func TestExtractURLQueryParamsForEngineV2(t *testing.T) {
+	type expectedOutput struct {
+		urlWithoutParams string
+		engineV2Queries  []restDataSource.QueryConfiguration
+		err              error
+	}
+
+	providedApiDefQueries := []apidef.QueryVariable{
+		{
+			Name:  "providedQueryName1",
+			Value: "providedQueryValue1",
+		},
+		{
+			Name:  "providedQueryName2",
+			Value: "providedQueryValue2",
+		},
+	}
+
+	t.Run("without query params in url", func(t *testing.T) {
+		inputUrl := "http://rest-data-source.fake"
+		expected := expectedOutput{
+			urlWithoutParams: "http://rest-data-source.fake",
+			engineV2Queries: []restDataSource.QueryConfiguration{
+				{
+					Name:  "providedQueryName1",
+					Value: "providedQueryValue1",
+				},
+				{
+					Name:  "providedQueryName2",
+					Value: "providedQueryValue2",
+				},
+			},
+			err: nil,
+		}
+		actualUrlWithoutParams, actualEngineV2Queries, actualErr := extractURLQueryParamsForEngineV2(inputUrl, providedApiDefQueries)
+		assert.Equal(t, expected.urlWithoutParams, actualUrlWithoutParams)
+		assert.Equal(t, expected.engineV2Queries, actualEngineV2Queries)
+		assert.Equal(t, expected.err, actualErr)
+	})
+
+	t.Run("with query params in url", func(t *testing.T) {
+		inputUrl := "http://rest-data-source.fake?urlParam=urlParamValue"
+		expected := expectedOutput{
+			urlWithoutParams: "http://rest-data-source.fake",
+			engineV2Queries: []restDataSource.QueryConfiguration{
+				{
+					Name:  "urlParam",
+					Value: "urlParamValue",
+				},
+				{
+					Name:  "providedQueryName1",
+					Value: "providedQueryValue1",
+				},
+				{
+					Name:  "providedQueryName2",
+					Value: "providedQueryValue2",
+				},
+			},
+			err: nil,
+		}
+		actualUrlWithoutParams, actualEngineV2Queries, actualErr := extractURLQueryParamsForEngineV2(inputUrl, providedApiDefQueries)
+		assert.Equal(t, expected.urlWithoutParams, actualUrlWithoutParams)
+		assert.Equal(t, expected.engineV2Queries, actualEngineV2Queries)
+		assert.Equal(t, expected.err, actualErr)
+	})
+}
+
+func TestAppendURLQueryParamsToEngineV2Queries(t *testing.T) {
+	existingEngineV2Queries := &[]restDataSource.QueryConfiguration{
+		{
+			Name:  "existingName",
+			Value: "existingValue",
+		},
+	}
+
+	queryValues := neturl.Values{
+		"newKey1": {"newKey1Value1"},
+		"newKey2": {"newKey2Value1", "newKey2Value2"},
+	}
+
+	expectedEngineV2Queries := &[]restDataSource.QueryConfiguration{
+		{
+			Name:  "existingName",
+			Value: "existingValue",
+		},
+		{
+			Name:  "newKey1",
+			Value: "newKey1Value1",
+		},
+		{
+			Name:  "newKey2",
+			Value: "newKey2Value1,newKey2Value2",
+		},
+	}
+
+	appendURLQueryParamsToEngineV2Queries(existingEngineV2Queries, queryValues)
+	assert.Equal(t, expectedEngineV2Queries, existingEngineV2Queries)
+}
+
+func TestAppendApiDefQueriesConfigToEngineV2Queries(t *testing.T) {
+	existingEngineV2Queries := &[]restDataSource.QueryConfiguration{
+		{
+			Name:  "existingName",
+			Value: "existingValue",
+		},
+	}
+
+	apiDefQueryVariables := []apidef.QueryVariable{
+		{
+			Name:  "newName1",
+			Value: "newValue2",
+		},
+		{
+			Name:  "newName2",
+			Value: "newValue2",
+		},
+	}
+
+	expectedEngineV2Queries := &[]restDataSource.QueryConfiguration{
+		{
+			Name:  "existingName",
+			Value: "existingValue",
+		},
+		{
+			Name:  "newName1",
+			Value: "newValue2",
+		},
+		{
+			Name:  "newName2",
+			Value: "newValue2",
+		},
+	}
+
+	appendApiDefQueriesConfigToEngineV2Queries(existingEngineV2Queries, apiDefQueryVariables)
+	assert.Equal(t, expectedEngineV2Queries, existingEngineV2Queries)
+}
+
+func TestCreateGraphQLDataSourceFactory(t *testing.T) {
+	inputParams := createGraphQLDataSourceFactoryParams{
+		graphqlConfig: apidef.GraphQLEngineDataSourceConfigGraphQL{
+			SubscriptionType: apidef.GQLSubscriptionSSE,
+		},
+		subscriptionClientFactory: &MockSubscriptionClientFactory{},
+		httpClient: &http.Client{
+			Timeout: 0,
+		},
+		streamingClient: &http.Client{
+			Timeout: 1,
+		},
+	}
+
+	expectedGraphQLDataSourceFactory := &graphqlDataSource.Factory{
+		HTTPClient: &http.Client{
+			Timeout: 0,
+		},
+		StreamingClient: &http.Client{
+			Timeout: 1,
+		},
+		SubscriptionClient: mockSubscriptionClient,
+	}
+
+	actualGraphQLDataSourceFactory, err := createGraphQLDataSourceFactory(inputParams)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedGraphQLDataSourceFactory, actualGraphQLDataSourceFactory)
+}

--- a/apidef/adapter/graphql_config_adapter.go
+++ b/apidef/adapter/graphql_config_adapter.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	neturl "net/url"
-	"sort"
 	"strings"
 
 	graphqlDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/graphql_datasource"
@@ -72,11 +70,11 @@ func (g *GraphQLConfigAdapter) EngineConfigV2() (*graphql.EngineV2Configuration,
 		return nil, ErrUnsupportedGraphQLConfigVersion
 	}
 
-	if g.isProxyOnlyAPIDefinition() {
+	if isProxyOnlyAPIDefinition(g.apiDefinition) {
 		return g.createV2ConfigForProxyOnlyExecutionMode()
 	}
 
-	if g.isSupergraphAPIDefinition() {
+	if isSupergraphAPIDefinition(g.apiDefinition) {
 		return g.createV2ConfigForSupergraphExecutionMode()
 	}
 
@@ -95,7 +93,7 @@ func (g *GraphQLConfigAdapter) createV2ConfigForProxyOnlyExecutionMode() (*graph
 	upstreamConfig := graphql.ProxyUpstreamConfig{
 		URL:              url,
 		StaticHeaders:    staticHeaders,
-		SubscriptionType: g.graphqlSubscriptionType(g.apiDefinition.GraphQL.Proxy.SubscriptionType),
+		SubscriptionType: graphqlSubscriptionType(g.apiDefinition.GraphQL.Proxy.SubscriptionType),
 	}
 
 	if g.schema == nil {
@@ -159,7 +157,9 @@ func (g *GraphQLConfigAdapter) createV2ConfigForSupergraphExecutionMode() (*grap
 }
 
 func (g *GraphQLConfigAdapter) createV2ConfigForEngineExecutionMode() (*graphql.EngineV2Configuration, error) {
-	if err := g.parseSchema(); err != nil {
+	var err error
+	g.schema, err = parseSchema(g.apiDefinition.GraphQL.Schema)
+	if err != nil {
 		return nil, err
 	}
 
@@ -176,28 +176,6 @@ func (g *GraphQLConfigAdapter) createV2ConfigForEngineExecutionMode() (*graphql.
 	conf.SetDataSources(datsSources)
 
 	return &conf, nil
-}
-
-func (g *GraphQLConfigAdapter) parseSchema() (err error) {
-	if g.schema != nil {
-		return nil
-	}
-
-	g.schema, err = graphql.NewSchemaFromString(g.apiDefinition.GraphQL.Schema)
-	if err != nil {
-		return err
-	}
-
-	normalizationResult, err := g.schema.Normalize()
-	if err != nil {
-		return err
-	}
-
-	if !normalizationResult.Successful && normalizationResult.Errors != nil {
-		return normalizationResult.Errors
-	}
-
-	return nil
 }
 
 func (g *GraphQLConfigAdapter) engineConfigV2FieldConfigs() (planFieldConfigs plan.FieldConfigurations) {
@@ -246,7 +224,7 @@ func (g *GraphQLConfigAdapter) engineConfigV2DataSources() (planDataSources []pl
 				Client: g.getHttpClient(),
 			}
 
-			urlWithoutQueryParams, queryConfigs, err := g.extractURLQueryParamsForEngineV2(restConfig.URL, restConfig.Query)
+			urlWithoutQueryParams, queryConfigs, err := extractURLQueryParamsForEngineV2(restConfig.URL, restConfig.Query)
 			if err != nil {
 				return nil, err
 			}
@@ -257,7 +235,7 @@ func (g *GraphQLConfigAdapter) engineConfigV2DataSources() (planDataSources []pl
 					Method: restConfig.Method,
 					Body:   restConfig.Body,
 					Query:  queryConfigs,
-					Header: g.convertHeadersToHttpHeaders(restConfig.Headers),
+					Header: convertApiDefinitionHeadersToHttpHeaders(restConfig.Headers),
 				},
 			})
 
@@ -268,12 +246,17 @@ func (g *GraphQLConfigAdapter) engineConfigV2DataSources() (planDataSources []pl
 				return nil, err
 			}
 
-			planDataSource.Factory, err = g.createGraphQLDataSourceFactory(graphqlConfig)
+			planDataSource.Factory, err = createGraphQLDataSourceFactory(createGraphQLDataSourceFactoryParams{
+				graphqlConfig:             graphqlConfig,
+				subscriptionClientFactory: g.subscriptionClientFactory,
+				httpClient:                g.getHttpClient(),
+				streamingClient:           g.getStreamingClient(),
+			})
 			if err != nil {
 				return nil, err
 			}
 
-			planDataSource.Custom = graphqlDataSource.ConfigJson(g.graphqlDataSourceConfiguration(
+			planDataSource.Custom = graphqlDataSource.ConfigJson(graphqlDataSourceConfiguration(
 				graphqlConfig.URL,
 				graphqlConfig.Method,
 				graphqlConfig.Headers,
@@ -320,8 +303,8 @@ func (g *GraphQLConfigAdapter) subgraphDataSourceConfigs() []graphqlDataSource.C
 		if len(apiDefSubgraphConf.SDL) == 0 {
 			continue
 		}
-		hdr := g.removeDuplicateHeaders(apiDefSubgraphConf.Headers, g.apiDefinition.GraphQL.Supergraph.GlobalHeaders)
-		conf := g.graphqlDataSourceConfiguration(
+		hdr := removeDuplicateApiDefinitionHeaders(apiDefSubgraphConf.Headers, g.apiDefinition.GraphQL.Supergraph.GlobalHeaders)
+		conf := graphqlDataSourceConfiguration(
 			apiDefSubgraphConf.URL,
 			http.MethodPost,
 			hdr,
@@ -337,32 +320,6 @@ func (g *GraphQLConfigAdapter) subgraphDataSourceConfigs() []graphqlDataSource.C
 	return confs
 }
 
-func (g *GraphQLConfigAdapter) graphqlDataSourceConfiguration(url string, method string, headers map[string]string, subscriptionType apidef.SubscriptionType) graphqlDataSource.Configuration {
-	dataSourceHeaders := make(map[string]string)
-	for name, value := range headers {
-		dataSourceHeaders[name] = value
-	}
-
-	if strings.HasPrefix(url, "tyk://") {
-		url = strings.ReplaceAll(url, "tyk://", "http://")
-		dataSourceHeaders[apidef.TykInternalApiHeader] = "true"
-	}
-
-	cfg := graphqlDataSource.Configuration{
-		Fetch: graphqlDataSource.FetchConfiguration{
-			URL:    url,
-			Method: method,
-			Header: g.convertHeadersToHttpHeaders(dataSourceHeaders),
-		},
-		Subscription: graphqlDataSource.SubscriptionConfiguration{
-			URL:    url,
-			UseSSE: subscriptionType == apidef.GQLSubscriptionSSE,
-		},
-	}
-
-	return cfg
-}
-
 func (g *GraphQLConfigAdapter) engineConfigV2Arguments(fieldConfs *plan.FieldConfigurations, generatedArgs map[graphql.TypeFieldLookupKey]graphql.TypeFieldArguments) {
 	for i := range *fieldConfs {
 		if len(generatedArgs) == 0 {
@@ -375,7 +332,7 @@ func (g *GraphQLConfigAdapter) engineConfigV2Arguments(fieldConfs *plan.FieldCon
 			continue
 		}
 
-		(*fieldConfs)[i].Arguments = g.createArgumentConfigurationsForArgumentNames(currentArgs.ArgumentNames)
+		(*fieldConfs)[i].Arguments = createArgumentConfigurationsForArgumentNames(currentArgs.ArgumentNames...)
 		delete(generatedArgs, lookupKey)
 	}
 
@@ -383,105 +340,9 @@ func (g *GraphQLConfigAdapter) engineConfigV2Arguments(fieldConfs *plan.FieldCon
 		*fieldConfs = append(*fieldConfs, plan.FieldConfiguration{
 			TypeName:  genArgs.TypeName,
 			FieldName: genArgs.FieldName,
-			Arguments: g.createArgumentConfigurationsForArgumentNames(genArgs.ArgumentNames),
+			Arguments: createArgumentConfigurationsForArgumentNames(genArgs.ArgumentNames...),
 		})
 	}
-}
-
-func (g *GraphQLConfigAdapter) createArgumentConfigurationsForArgumentNames(argumentNames []string) plan.ArgumentsConfigurations {
-	argConfs := plan.ArgumentsConfigurations{}
-	for _, argName := range argumentNames {
-		argConf := plan.ArgumentConfiguration{
-			Name:       argName,
-			SourceType: plan.FieldArgumentSource,
-		}
-
-		argConfs = append(argConfs, argConf)
-	}
-
-	return argConfs
-}
-
-func (g *GraphQLConfigAdapter) extractURLQueryParamsForEngineV2(url string, providedApiDefQueries []apidef.QueryVariable) (urlWithoutParams string, engineV2Queries []restDataSource.QueryConfiguration, err error) {
-	urlParts := strings.Split(url, "?")
-	urlWithoutParams = urlParts[0]
-
-	queryPart := ""
-	if len(urlParts) == 2 {
-		queryPart = urlParts[1]
-	}
-	// Parse only query part as URL could contain templating {{.argument.id}} which should not be escaped
-	values, err := neturl.ParseQuery(queryPart)
-	if err != nil {
-		return "", nil, err
-	}
-
-	engineV2Queries = make([]restDataSource.QueryConfiguration, 0)
-	g.convertURLQueryParamsIntoEngineV2Queries(&engineV2Queries, values)
-	g.convertApiDefQueriesConfigIntoEngineV2Queries(&engineV2Queries, providedApiDefQueries)
-
-	if len(engineV2Queries) == 0 {
-		return urlWithoutParams, nil, nil
-	}
-
-	return urlWithoutParams, engineV2Queries, nil
-}
-
-func (g *GraphQLConfigAdapter) convertURLQueryParamsIntoEngineV2Queries(engineV2Queries *[]restDataSource.QueryConfiguration, queryValues neturl.Values) {
-	for queryKey, queryValue := range queryValues {
-		*engineV2Queries = append(*engineV2Queries, restDataSource.QueryConfiguration{
-			Name:  queryKey,
-			Value: strings.Join(queryValue, ","),
-		})
-	}
-
-	sort.Slice(*engineV2Queries, func(i, j int) bool {
-		return (*engineV2Queries)[i].Name < (*engineV2Queries)[j].Name
-	})
-}
-
-func (g *GraphQLConfigAdapter) convertApiDefQueriesConfigIntoEngineV2Queries(engineV2Queries *[]restDataSource.QueryConfiguration, apiDefQueries []apidef.QueryVariable) {
-	if len(apiDefQueries) == 0 {
-		return
-	}
-
-	for _, apiDefQueryVar := range apiDefQueries {
-		engineV2Query := restDataSource.QueryConfiguration{
-			Name:  apiDefQueryVar.Name,
-			Value: apiDefQueryVar.Value,
-		}
-
-		*engineV2Queries = append(*engineV2Queries, engineV2Query)
-	}
-}
-
-func (g *GraphQLConfigAdapter) convertHeadersToHttpHeaders(apiDefHeaders map[string]string) http.Header {
-	if len(apiDefHeaders) == 0 {
-		return nil
-	}
-
-	engineV2Headers := make(http.Header)
-	for apiDefHeaderKey, apiDefHeaderValue := range apiDefHeaders {
-		engineV2Headers.Add(apiDefHeaderKey, apiDefHeaderValue)
-	}
-
-	return engineV2Headers
-}
-
-func (g *GraphQLConfigAdapter) removeDuplicateHeaders(headers ...map[string]string) map[string]string {
-	hdr := make(map[string]string)
-	// headers priority depends on the order of arguments
-	for _, header := range headers {
-		for k, v := range header {
-			keyCanonical := http.CanonicalHeaderKey(k)
-			if _, ok := hdr[keyCanonical]; ok {
-				// skip because header is present
-				continue
-			}
-			hdr[keyCanonical] = v
-		}
-	}
-	return hdr
 }
 
 func (g *GraphQLConfigAdapter) determineChildNodes(planDataSources []plan.DataSourceConfiguration) error {
@@ -507,15 +368,6 @@ func (g *GraphQLConfigAdapter) determineChildNodes(planDataSources []plan.DataSo
 	return nil
 }
 
-func (g *GraphQLConfigAdapter) isSupergraphAPIDefinition() bool {
-	return g.apiDefinition.GraphQL.Enabled && g.apiDefinition.GraphQL.ExecutionMode == apidef.GraphQLExecutionModeSupergraph
-}
-
-func (g *GraphQLConfigAdapter) isProxyOnlyAPIDefinition() bool {
-	return g.apiDefinition.GraphQL.Enabled &&
-		(g.apiDefinition.GraphQL.ExecutionMode == apidef.GraphQLExecutionModeProxyOnly || g.apiDefinition.GraphQL.ExecutionMode == apidef.GraphQLExecutionModeSubgraph)
-}
-
 func (g *GraphQLConfigAdapter) getHttpClient() *http.Client {
 	if g.httpClient == nil {
 		g.httpClient = httpclient.DefaultNetHttpClient
@@ -531,47 +383,4 @@ func (g *GraphQLConfigAdapter) getStreamingClient() *http.Client {
 	}
 
 	return g.streamingClient
-}
-
-func (g *GraphQLConfigAdapter) createGraphQLDataSourceFactory(graphqlConfig apidef.GraphQLEngineDataSourceConfigGraphQL) (*graphqlDataSource.Factory, error) {
-	factory := &graphqlDataSource.Factory{
-		HTTPClient:      g.getHttpClient(),
-		StreamingClient: g.getStreamingClient(),
-	}
-
-	wsProtocol := g.graphqlDataSourceWebSocketProtocol(graphqlConfig.SubscriptionType)
-	graphqlSubscriptionClient := g.subscriptionClientFactory.NewSubscriptionClient(
-		g.getHttpClient(),
-		g.getStreamingClient(),
-		nil,
-		graphqlDataSource.WithWSSubProtocol(wsProtocol),
-	)
-
-	subscriptionClient, ok := graphqlSubscriptionClient.(*graphqlDataSource.SubscriptionClient)
-	if !ok {
-		return nil, errors.New("incorrect SubscriptionClient has been created")
-	}
-	factory.SubscriptionClient = subscriptionClient
-	return factory, nil
-}
-
-func (g *GraphQLConfigAdapter) graphqlDataSourceWebSocketProtocol(subscriptionType apidef.SubscriptionType) string {
-	wsProtocol := graphqlDataSource.ProtocolGraphQLWS
-	if subscriptionType == apidef.GQLSubscriptionTransportWS {
-		wsProtocol = graphqlDataSource.ProtocolGraphQLTWS
-	}
-	return wsProtocol
-}
-
-func (g *GraphQLConfigAdapter) graphqlSubscriptionType(subscriptionType apidef.SubscriptionType) graphql.SubscriptionType {
-	switch subscriptionType {
-	case apidef.GQLSubscriptionWS:
-		return graphql.SubscriptionTypeGraphQLWS
-	case apidef.GQLSubscriptionTransportWS:
-		return graphql.SubscriptionTypeGraphQLTransportWS
-	case apidef.GQLSubscriptionSSE:
-		return graphql.SubscriptionTypeSSE
-	default:
-		return graphql.SubscriptionTypeUnknown
-	}
 }

--- a/apidef/adapter/graphql_config_adapter_test.go
+++ b/apidef/adapter/graphql_config_adapter_test.go
@@ -14,7 +14,7 @@ import (
 	kafkaDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/kafka_datasource"
 	restDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/rest_datasource"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/plan"
-	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
+
 	"github.com/TykTechnologies/tyk/apidef"
 )
 
@@ -494,7 +494,10 @@ func TestGraphQLConfigAdapter_engineConfigV2FieldConfigs(t *testing.T) {
 	}
 
 	adapter := NewGraphQLConfigAdapter(apiDef)
-	require.NoError(t, adapter.parseSchema())
+
+	var err error
+	adapter.schema, err = parseSchema(gqlConfig.Schema)
+	require.NoError(t, err)
 
 	actualFieldCfgs := adapter.engineConfigV2FieldConfigs()
 	assert.ElementsMatch(t, expectedFieldCfgs, actualFieldCfgs)
@@ -816,64 +819,15 @@ func TestGraphQLConfigAdapter_engineConfigV2DataSources(t *testing.T) {
 		WithStreamingClient(streamingClient),
 		withGraphQLSubscriptionClientFactory(&MockSubscriptionClientFactory{}),
 	)
-	require.NoError(t, adapter.parseSchema())
+
+	var err error
+	adapter.schema, err = parseSchema(gqlConfig.Schema)
+	require.NoError(t, err)
 
 	actualDataSources, err := adapter.engineConfigV2DataSources()
 	assert.NoError(t, err)
 	assert.Equal(t, expectedDataSources, actualDataSources)
 	//assert.ElementsMatch(t, expectedDataSources, actualDataSources)
-}
-
-func TestGraphQLConfigAdapter_GraphqlDataSourceWebSocketProtocol(t *testing.T) {
-	run := func(subscriptionType apidef.SubscriptionType, expectedWebSocketProtocol string) func(t *testing.T) {
-		return func(t *testing.T) {
-			adapter := NewGraphQLConfigAdapter(nil)
-			actualProtocol := adapter.graphqlDataSourceWebSocketProtocol(subscriptionType)
-			assert.Equal(t, expectedWebSocketProtocol, actualProtocol)
-		}
-	}
-
-	t.Run("should return 'graphql-ws' for undefined subscription type",
-		run(apidef.GQLSubscriptionUndefined, graphqlDataSource.ProtocolGraphQLWS),
-	)
-
-	t.Run("should return 'graphql-ws' for graphql-ws subscription type",
-		run(apidef.GQLSubscriptionWS, graphqlDataSource.ProtocolGraphQLWS),
-	)
-
-	t.Run("should return 'graphql-ws' for sse subscription type as websocket protocol is irrelevant in that case",
-		run(apidef.GQLSubscriptionSSE, graphqlDataSource.ProtocolGraphQLWS),
-	)
-
-	t.Run("should return 'graphql-transport-ws' for graphql-transport-ws subscription type",
-		run(apidef.GQLSubscriptionTransportWS, graphqlDataSource.ProtocolGraphQLTWS),
-	)
-}
-
-func TestGraphQLConfigAdapter_GraphqlSubscriptionType(t *testing.T) {
-	run := func(subscriptionType apidef.SubscriptionType, expectedGraphQLSubscriptionType graphql.SubscriptionType) func(t *testing.T) {
-		return func(t *testing.T) {
-			adapter := NewGraphQLConfigAdapter(nil)
-			actualSubscriptionType := adapter.graphqlSubscriptionType(subscriptionType)
-			assert.Equal(t, expectedGraphQLSubscriptionType, actualSubscriptionType)
-		}
-	}
-
-	t.Run("should return 'Unknown' for undefined subscription type",
-		run(apidef.GQLSubscriptionUndefined, graphql.SubscriptionTypeUnknown),
-	)
-
-	t.Run("should return 'SSE' for sse subscription type as websocket protocol is irrelevant in that case",
-		run(apidef.GQLSubscriptionSSE, graphql.SubscriptionTypeSSE),
-	)
-
-	t.Run("should return 'GraphQLWS' for graphql-ws subscription type",
-		run(apidef.GQLSubscriptionWS, graphql.SubscriptionTypeGraphQLWS),
-	)
-
-	t.Run("should return 'GraphQLTransportWS' for graphql-transport-ws subscription type",
-		run(apidef.GQLSubscriptionTransportWS, graphql.SubscriptionTypeGraphQLTransportWS),
-	)
 }
 
 var mockSubscriptionClient = &graphqlDataSource.SubscriptionClient{}

--- a/apidef/adapter/utils.go
+++ b/apidef/adapter/utils.go
@@ -1,0 +1,87 @@
+package adapter
+
+import (
+	"net/http"
+
+	graphqlDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/graphql_datasource"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
+
+	"github.com/TykTechnologies/tyk/apidef"
+)
+
+func parseSchema(schemaAsString string) (parsedSchema *graphql.Schema, err error) {
+	parsedSchema, err = graphql.NewSchemaFromString(schemaAsString)
+	if err != nil {
+		return nil, err
+	}
+
+	normalizationResult, err := parsedSchema.Normalize()
+	if err != nil {
+		return nil, err
+	}
+
+	if !normalizationResult.Successful && normalizationResult.Errors != nil {
+		return nil, normalizationResult.Errors
+	}
+
+	return parsedSchema, nil
+}
+
+func isSupergraphAPIDefinition(apiDefinition *apidef.APIDefinition) bool {
+	return apiDefinition.GraphQL.Enabled && apiDefinition.GraphQL.ExecutionMode == apidef.GraphQLExecutionModeSupergraph
+}
+
+func isProxyOnlyAPIDefinition(apiDefinition *apidef.APIDefinition) bool {
+	return apiDefinition.GraphQL.Enabled &&
+		(apiDefinition.GraphQL.ExecutionMode == apidef.GraphQLExecutionModeProxyOnly || apiDefinition.GraphQL.ExecutionMode == apidef.GraphQLExecutionModeSubgraph)
+}
+
+func graphqlDataSourceWebSocketProtocol(subscriptionType apidef.SubscriptionType) string {
+	wsProtocol := graphqlDataSource.ProtocolGraphQLWS
+	if subscriptionType == apidef.GQLSubscriptionTransportWS {
+		wsProtocol = graphqlDataSource.ProtocolGraphQLTWS
+	}
+	return wsProtocol
+}
+
+func graphqlSubscriptionType(subscriptionType apidef.SubscriptionType) graphql.SubscriptionType {
+	switch subscriptionType {
+	case apidef.GQLSubscriptionWS:
+		return graphql.SubscriptionTypeGraphQLWS
+	case apidef.GQLSubscriptionTransportWS:
+		return graphql.SubscriptionTypeGraphQLTransportWS
+	case apidef.GQLSubscriptionSSE:
+		return graphql.SubscriptionTypeSSE
+	default:
+		return graphql.SubscriptionTypeUnknown
+	}
+}
+
+func convertApiDefinitionHeadersToHttpHeaders(apiDefHeaders map[string]string) http.Header {
+	if len(apiDefHeaders) == 0 {
+		return nil
+	}
+
+	engineV2Headers := make(http.Header)
+	for apiDefHeaderKey, apiDefHeaderValue := range apiDefHeaders {
+		engineV2Headers.Add(apiDefHeaderKey, apiDefHeaderValue)
+	}
+
+	return engineV2Headers
+}
+
+func removeDuplicateApiDefinitionHeaders(headers ...map[string]string) map[string]string {
+	hdr := make(map[string]string)
+	// headers priority depends on the order of arguments
+	for _, header := range headers {
+		for k, v := range header {
+			keyCanonical := http.CanonicalHeaderKey(k)
+			if _, ok := hdr[keyCanonical]; ok {
+				// skip because header is present
+				continue
+			}
+			hdr[keyCanonical] = v
+		}
+	}
+	return hdr
+}

--- a/apidef/adapter/utils_test.go
+++ b/apidef/adapter/utils_test.go
@@ -1,0 +1,227 @@
+package adapter
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	graphqlDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/graphql_datasource"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
+
+	"github.com/TykTechnologies/tyk/apidef"
+)
+
+func TestParseSchema(t *testing.T) {
+	inputSchema := `
+		type Query {
+			hello: String!
+		}`
+
+	// We are pretty confident that the schema parsing works, as it is tested in the library already.
+	// We just want to make sure that there is no weird error happening.
+	parsedSchema, err := parseSchema(inputSchema)
+	assert.NotNil(t, parsedSchema)
+	assert.NoError(t, err)
+}
+
+func TestIsSupergraphAPIDefinition(t *testing.T) {
+	type testInput struct {
+		graphQLEnabled bool
+		executionModes []apidef.GraphQLExecutionMode
+		expectedResult bool
+	}
+	run := func(input testInput) func(t *testing.T) {
+		return func(t *testing.T) {
+			for _, executionMode := range input.executionModes {
+				apiDef := &apidef.APIDefinition{
+					GraphQL: apidef.GraphQLConfig{
+						Enabled:       input.graphQLEnabled,
+						ExecutionMode: executionMode,
+					},
+				}
+				assert.Equal(t, input.expectedResult, isSupergraphAPIDefinition(apiDef))
+			}
+		}
+	}
+
+	t.Run("false if graphql is disabled", run(
+		testInput{
+			graphQLEnabled: false,
+			executionModes: []apidef.GraphQLExecutionMode{
+				apidef.GraphQLExecutionModeSupergraph,
+				apidef.GraphQLExecutionModeProxyOnly,
+				apidef.GraphQLExecutionModeExecutionEngine,
+				apidef.GraphQLExecutionModeSubgraph,
+			},
+			expectedResult: false,
+		},
+	))
+
+	t.Run("false if execution mode is not supergraph", run(
+		testInput{
+			graphQLEnabled: true,
+			executionModes: []apidef.GraphQLExecutionMode{
+				apidef.GraphQLExecutionModeProxyOnly,
+				apidef.GraphQLExecutionModeExecutionEngine,
+				apidef.GraphQLExecutionModeSubgraph,
+			},
+			expectedResult: false,
+		},
+	))
+
+	t.Run("true if graphql is enabled and execution mode is supergraph", run(
+		testInput{
+			graphQLEnabled: true,
+			executionModes: []apidef.GraphQLExecutionMode{
+				apidef.GraphQLExecutionModeSupergraph,
+			},
+			expectedResult: true,
+		},
+	))
+}
+
+func TestIsProxyOnlyAPIDefinition(t *testing.T) {
+	type testInput struct {
+		graphQLEnabled bool
+		executionModes []apidef.GraphQLExecutionMode
+		expectedResult bool
+	}
+	run := func(input testInput) func(t *testing.T) {
+		return func(t *testing.T) {
+			for _, executionMode := range input.executionModes {
+				apiDef := &apidef.APIDefinition{
+					GraphQL: apidef.GraphQLConfig{
+						Enabled:       input.graphQLEnabled,
+						ExecutionMode: executionMode,
+					},
+				}
+				assert.Equal(t, input.expectedResult, isProxyOnlyAPIDefinition(apiDef))
+			}
+		}
+	}
+
+	t.Run("false if graphql is disabled", run(
+		testInput{
+			graphQLEnabled: false,
+			executionModes: []apidef.GraphQLExecutionMode{
+				apidef.GraphQLExecutionModeProxyOnly,
+				apidef.GraphQLExecutionModeExecutionEngine,
+				apidef.GraphQLExecutionModeSubgraph,
+				apidef.GraphQLExecutionModeSupergraph,
+			},
+			expectedResult: false,
+		},
+	))
+
+	t.Run("false if execution mode is not proxyOnly or subgraph", run(
+		testInput{
+			graphQLEnabled: true,
+			executionModes: []apidef.GraphQLExecutionMode{
+				apidef.GraphQLExecutionModeExecutionEngine,
+				apidef.GraphQLExecutionModeSupergraph,
+			},
+			expectedResult: false,
+		},
+	))
+
+	t.Run("true if graphql is enabled and execution mode is proxyOnly", run(
+		testInput{
+			graphQLEnabled: true,
+			executionModes: []apidef.GraphQLExecutionMode{
+				apidef.GraphQLExecutionModeProxyOnly,
+				apidef.GraphQLExecutionModeSubgraph,
+			},
+			expectedResult: true,
+		},
+	))
+}
+
+func TestGraphqlDataSourceWebSocketProtocol(t *testing.T) {
+	run := func(subscriptionType apidef.SubscriptionType, expectedWebSocketProtocol string) func(t *testing.T) {
+		return func(t *testing.T) {
+			actualProtocol := graphqlDataSourceWebSocketProtocol(subscriptionType)
+			assert.Equal(t, expectedWebSocketProtocol, actualProtocol)
+		}
+	}
+
+	t.Run("should return 'graphql-ws' for undefined subscription type",
+		run(apidef.GQLSubscriptionUndefined, graphqlDataSource.ProtocolGraphQLWS),
+	)
+
+	t.Run("should return 'graphql-ws' for graphql-ws subscription type",
+		run(apidef.GQLSubscriptionWS, graphqlDataSource.ProtocolGraphQLWS),
+	)
+
+	t.Run("should return 'graphql-ws' for sse subscription type as websocket protocol is irrelevant in that case",
+		run(apidef.GQLSubscriptionSSE, graphqlDataSource.ProtocolGraphQLWS),
+	)
+
+	t.Run("should return 'graphql-transport-ws' for graphql-transport-ws subscription type",
+		run(apidef.GQLSubscriptionTransportWS, graphqlDataSource.ProtocolGraphQLTWS),
+	)
+}
+
+func TestGraphqlSubscriptionType(t *testing.T) {
+	run := func(subscriptionType apidef.SubscriptionType, expectedGraphQLSubscriptionType graphql.SubscriptionType) func(t *testing.T) {
+		return func(t *testing.T) {
+			actualSubscriptionType := graphqlSubscriptionType(subscriptionType)
+			assert.Equal(t, expectedGraphQLSubscriptionType, actualSubscriptionType)
+		}
+	}
+
+	t.Run("should return 'Unknown' for undefined subscription type",
+		run(apidef.GQLSubscriptionUndefined, graphql.SubscriptionTypeUnknown),
+	)
+
+	t.Run("should return 'SSE' for sse subscription type as websocket protocol is irrelevant in that case",
+		run(apidef.GQLSubscriptionSSE, graphql.SubscriptionTypeSSE),
+	)
+
+	t.Run("should return 'GraphQLWS' for graphql-ws subscription type",
+		run(apidef.GQLSubscriptionWS, graphql.SubscriptionTypeGraphQLWS),
+	)
+
+	t.Run("should return 'GraphQLTransportWS' for graphql-transport-ws subscription type",
+		run(apidef.GQLSubscriptionTransportWS, graphql.SubscriptionTypeGraphQLTransportWS),
+	)
+}
+
+func TestConvertApiDefinitionHeadersToHttpHeaders(t *testing.T) {
+	t.Run("should return nil for empty input", func(t *testing.T) {
+		assert.Nil(t, convertApiDefinitionHeadersToHttpHeaders(nil))
+	})
+
+	t.Run("should successfully convert API Definition header to Http Headers", func(t *testing.T) {
+		apiDefinitionHeaders := map[string]string{
+			"Authorization": "token",
+			"X-Tyk-Key":     "value",
+		}
+
+		expectedHttpHeaders := http.Header{
+			"Authorization": {"token"},
+			"X-Tyk-Key":     {"value"},
+		}
+
+		actualHttpHeaders := convertApiDefinitionHeadersToHttpHeaders(apiDefinitionHeaders)
+		assert.Equal(t, expectedHttpHeaders, actualHttpHeaders)
+	})
+}
+
+func TestRemoveDuplicateApiDefinitionHeaders(t *testing.T) {
+	apiDefinitionHeadersFirstArgument := map[string]string{
+		"duplicate-header": "value",
+	}
+	apiDefinitionHeadersSecondArgument := map[string]string{
+		"Duplicate-Header":     "value",
+		"Non-Duplicate-Header": "another_value",
+	}
+
+	expectedDeduplicatedHeaders := map[string]string{
+		"Duplicate-Header":     "value",
+		"Non-Duplicate-Header": "another_value",
+	}
+
+	actualDeduplicatedHeaders := removeDuplicateApiDefinitionHeaders(apiDefinitionHeadersFirstArgument, apiDefinitionHeadersSecondArgument)
+	assert.Equal(t, expectedDeduplicatedHeaders, actualDeduplicatedHeaders)
+}


### PR DESCRIPTION
move adapter helper functions to proper util files (TT-7999) (#4792)

This PR moves helper functions from the GraphQL adapter to some proper
util files. It also adds some missing tests for those helper functions.

*Please note, that the remaining functions inside the adapter will be
refactored in the next step.*

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [x] Refactoring or add test (improvements in base code or adds test
coverage to functionality)