### PR TITLE
[TT-8298] Fixing bug of empty APIName and APIID in access_rights

### DIFF
--- a/gateway/policy.go
+++ b/gateway/policy.go
@@ -18,8 +18,8 @@ import (
 )
 
 type DBAccessDefinition struct {
-	APIName              string                       `json:"apiname"`
-	APIID                string                       `json:"apiid"`
+	APIName              string                       `json:"api_name"`
+	APIID                string                       `json:"api_id"`
 	Versions             []string                     `json:"versions"`
 	AllowedURLs          []user.AccessSpec            `bson:"allowed_urls" json:"allowed_urls"` // mapped string MUST be a valid regex
 	RestrictedTypes      []graphql.Type               `json:"restricted_types"`


### PR DESCRIPTION
The tag of APIName and APIID was wrong because of which API was returning empty string

<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
Fixing the json tag for `DBAccessDefinition` struct

## Related Issue

https://github.com/TykTechnologies/tyk/issues/4350 

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

Ran the go tests and tested the fix manually 

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
