### PR TITLE
Merging to release-4-lts: Override with deprecated auth when jwt or auth token is enabled (#3755)

### DIFF
--- a/apidef/api_definition_test.go
+++ b/apidef/api_definition_test.go
@@ -42,3 +42,25 @@ func TestSchemaGraphqlConfig(t *testing.T) {
 		}
 	}
 }
+
+func TestAPIDefinition_DecodeFromDB_AuthDeprecation(t *testing.T) {
+	const authHeader = "authorization"
+
+	spec := DummyAPI()
+	spec.Auth = AuthConfig{AuthHeaderName: authHeader}
+	spec.UseStandardAuth = true
+	spec.DecodeFromDB()
+
+	assert.Equal(t, spec.AuthConfigs, map[string]AuthConfig{
+		"authToken": spec.Auth,
+	})
+
+	spec.EnableJWT = true
+	spec.DecodeFromDB()
+
+	assert.Equal(t, spec.AuthConfigs, map[string]AuthConfig{
+		"authToken": spec.Auth,
+		"jwt":       spec.Auth,
+	})
+
+}

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -854,20 +854,20 @@ func (a *APIDefinition) DecodeFromDB() {
 	}
 
 	// Auth is deprecated so this code tries to maintain backward compatibility
-	makeCompatible := func(authType string) {
+	makeCompatible := func(authType string, enabled bool) {
 		if a.AuthConfigs == nil {
 			a.AuthConfigs = make(map[string]AuthConfig)
 		}
 
 		_, ok := a.AuthConfigs[authType]
 
-		if !ok {
+		if !ok && enabled {
 			a.AuthConfigs[authType] = a.Auth
 		}
 	}
 
-	makeCompatible("authToken")
-	makeCompatible("jwt")
+	makeCompatible("authToken", a.UseStandardAuth)
+	makeCompatible("jwt", a.EnableJWT)
 }
 
 // Expired returns true if this Version has expired


### PR DESCRIPTION
Override with deprecated auth when jwt or auth token is enabled (#3755)