### PR TITLE
Add new config flag to enable distributed tracing

### DIFF
--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -1120,6 +1120,9 @@
         },
         "license_key": {
           "type": "string"
+        },
+        "enable_distributed_tracing": {
+          "type": "boolean"
         }
       }
     },

--- a/config/config.go
+++ b/config/config.go
@@ -491,6 +491,8 @@ type NewRelicConfig struct {
 	AppName string `json:"app_name"`
 	// New Relic License key
 	LicenseKey string `json:"license_key"`
+	// Enable distributed tracing
+	EnableDistributedTracing bool `json:"enable_distributed_tracing"`
 }
 
 type Tracer struct {

--- a/gateway/newrelic.go
+++ b/gateway/newrelic.go
@@ -13,15 +13,21 @@ import (
 
 // SetupNewRelic creates new newrelic.Application instance
 func (gw *Gateway) SetupNewRelic() (app newrelic.Application) {
-	var err error
+	var (
+		err      error
+		gwConfig = gw.GetConfig()
+	)
+
 	logger := log.WithFields(logrus.Fields{"prefix": "newrelic"})
 
 	logger.Info("Initializing NewRelic...")
 
-	cfg := newrelic.NewConfig(gw.GetConfig().NewRelic.AppName, gw.GetConfig().NewRelic.LicenseKey)
-	if gw.GetConfig().NewRelic.AppName != "" {
+	cfg := newrelic.NewConfig(gwConfig.NewRelic.AppName, gwConfig.NewRelic.LicenseKey)
+	if gwConfig.NewRelic.AppName != "" {
 		cfg.Enabled = true
 	}
+	cfg.DistributedTracer.Enabled = gwConfig.NewRelic.EnableDistributedTracing
+
 	cfg.Logger = &newRelicLogger{logger}
 
 	if app, err = newrelic.NewApplication(cfg); err != nil {


### PR DESCRIPTION
Adds `enable_distributed_tracing` (boolean) under the new relic configuration, update usage.

https://tyktech.atlassian.net/browse/TT-4209