### PR TITLE
[TT-8290] Fix policy acl-ratelimit partition combination

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -530,9 +530,7 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 					ar.Limit.QuotaRenews = r.Limit.QuotaRenews
 				}
 
-				if !usePartitions || policy.Partitions.Acl {
-					rights[k] = ar
-				}
+				rights[k] = ar
 			}
 
 			// Master policy case
@@ -608,6 +606,11 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 
 	// If some APIs had only ACL partitions, inherit rest from session level
 	for k, v := range rights {
+		if !didACL[k] {
+			delete(rights, k)
+			continue
+		}
+
 		if !didRateLimit[k] {
 			v.Limit.Rate = session.Rate
 			v.Limit.Per = session.Per

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -134,6 +134,21 @@ func (s *Test) TestPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesD
 			Rate:       4,
 			Per:        4,
 		},
+		"rate-for-a": {
+			Partitions:   user.PolicyPartitions{RateLimit: true},
+			AccessRights: map[string]user.AccessDefinition{"a": {}},
+			Rate:         4,
+		},
+		"rate-for-b": {
+			Partitions:   user.PolicyPartitions{RateLimit: true},
+			AccessRights: map[string]user.AccessDefinition{"b": {}},
+			Rate:         2,
+		},
+		"rate-for-a-b": {
+			Partitions:   user.PolicyPartitions{RateLimit: true},
+			AccessRights: map[string]user.AccessDefinition{"a": {}, "b": {}},
+			Rate:         4,
+		},
 		"acl1": {
 			Partitions:   user.PolicyPartitions{Acl: true},
 			AccessRights: map[string]user.AccessDefinition{"a": {}},
@@ -144,6 +159,10 @@ func (s *Test) TestPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesD
 		},
 		"acl3": {
 			AccessRights: map[string]user.AccessDefinition{"c": {}},
+		},
+		"acl-for-a-b": {
+			Partitions:   user.PolicyPartitions{Acl: true},
+			AccessRights: map[string]user.AccessDefinition{"a": {}, "b": {}},
 		},
 		"unlimitedComplexity": {
 			Partitions:    user.PolicyPartitions{Complexity: true},
@@ -569,6 +588,23 @@ func (s *Test) TestPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesD
 			"AclPart", []string{"acl1", "acl2"},
 			"", func(t *testing.T, s *user.SessionState) {
 				want := map[string]user.AccessDefinition{"a": {Limit: user.APILimit{}}, "b": {Limit: user.APILimit{}}}
+				assert.Equal(t, want, s.AccessRights)
+			}, nil,
+		},
+		{
+			"Acl for a and rate for a,b", []string{"acl1", "rate-for-a-b"},
+			"", func(t *testing.T, s *user.SessionState) {
+				want := map[string]user.AccessDefinition{"a": {Limit: user.APILimit{Rate: 4}}}
+				assert.Equal(t, want, s.AccessRights)
+			}, nil,
+		},
+		{
+			"Acl for a,b and individual rate for a,b", []string{"acl-for-a-b", "rate-for-a", "rate-for-b"},
+			"", func(t *testing.T, s *user.SessionState) {
+				want := map[string]user.AccessDefinition{
+					"a": {Limit: user.APILimit{Rate: 4}},
+					"b": {Limit: user.APILimit{Rate: 2}},
+				}
 				assert.Equal(t, want, s.AccessRights)
 			}, nil,
 		},


### PR DESCRIPTION
The rate and acl(access rights) partitioned policies merging for a key doesn't work correctly. This PR fixes it and adds a test case for it.