### PR TITLE
Merging to release-5-lts: [TT-6024] Cover GoPluginMiddleware.EnabledForSpec()  with test (#4921)

### DIFF
--- a/gateway/mw_go_plugin_test.go
+++ b/gateway/mw_go_plugin_test.go
@@ -3,6 +3,8 @@ package gateway
 import (
 	"testing"
 
+	"github.com/TykTechnologies/tyk/apidef"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,4 +17,30 @@ func TestLoadPlugin(t *testing.T) {
 
 	pluginLoaded := plugin.loadPlugin()
 	assert.Equal(t, false, pluginLoaded)
+}
+
+func TestGoPluginMiddleware_EnabledForSpec(t *testing.T) {
+	gpm := GoPluginMiddleware{}
+	apiSpec := &APISpec{APIDefinition: &apidef.APIDefinition{}}
+	gpm.Spec = apiSpec
+
+	assert.False(t, gpm.EnabledForSpec())
+
+	t.Run("global go plugin", func(t *testing.T) {
+		gpm.Path = "plugin.so"
+		gpm.SymbolName = "name"
+
+		assert.True(t, gpm.EnabledForSpec())
+
+		gpm.Path = ""
+		gpm.SymbolName = ""
+	})
+
+	t.Run("per path go plugin", func(t *testing.T) {
+		apiSpec.VersionData.Versions = map[string]apidef.VersionInfo{"v1": {
+			ExtendedPaths: apidef.ExtendedPathsSet{GoPlugin: make([]apidef.GoPluginMeta, 1)},
+		}}
+
+		assert.True(t, gpm.EnabledForSpec())
+	})
 }


### PR DESCRIPTION
[TT-6024] Cover GoPluginMiddleware.EnabledForSpec()  with test (#4921)

This PR covers `GoPluginMiddleware.EnabledForSpec()` with a test.

[TT-6024]: https://tyktech.atlassian.net/browse/TT-6024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ