### PR TITLE
Merging to release-5-lts: [TT-6024] Fix GoPlugin enable case (#4925)

### DIFF
--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -109,8 +109,10 @@ func (m *GoPluginMiddleware) EnabledForSpec() bool {
 
 	// per path go plugins
 	for _, version := range m.Spec.VersionData.Versions {
-		if len(version.ExtendedPaths.GoPlugin) > 0 {
-			return true
+		for _, p := range version.ExtendedPaths.GoPlugin {
+			if !p.Disabled {
+				return true
+			}
 		}
 	}
 

--- a/gateway/mw_go_plugin_test.go
+++ b/gateway/mw_go_plugin_test.go
@@ -37,10 +37,17 @@ func TestGoPluginMiddleware_EnabledForSpec(t *testing.T) {
 	})
 
 	t.Run("per path go plugin", func(t *testing.T) {
+		ep := apidef.ExtendedPathsSet{GoPlugin: make([]apidef.GoPluginMeta, 1)}
 		apiSpec.VersionData.Versions = map[string]apidef.VersionInfo{"v1": {
-			ExtendedPaths: apidef.ExtendedPathsSet{GoPlugin: make([]apidef.GoPluginMeta, 1)},
+			ExtendedPaths: ep,
 		}}
 
 		assert.True(t, gpm.EnabledForSpec())
+
+		t.Run("disabled", func(t *testing.T) {
+			ep.GoPlugin[0].Disabled = true
+
+			assert.False(t, gpm.EnabledForSpec())
+		})
 	})
 }


### PR DESCRIPTION
[TT-6024] Fix GoPlugin enable case (#4925)

`GoPluginMiddleware` in path level is enabled if there is one `disabled:
false` in the paths section.

[TT-6024]: https://tyktech.atlassian.net/browse/TT-6024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ