### PR TITLE
Merging to release-5-lts: [TT-6024] Return error when GoPlugin handler is nil (#4922)

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -133,12 +133,8 @@ func (gw *Gateway) createMiddleware(actualMW TykMiddleware) func(http.Handler) h
 
 			err, errCode := mw.ProcessRequest(w, r, mwConf)
 			if err != nil {
-				// GoPluginMiddleware are expected to send response in case of error
-				// but we still want to record error
-				_, isGoPlugin := actualMW.(*GoPluginMiddleware)
-
 				handler := ErrorHandler{*mw.Base()}
-				handler.HandleError(w, r, err.Error(), errCode, !isGoPlugin)
+				handler.HandleError(w, r, err.Error(), errCode, true)
 
 				meta["error"] = err.Error()
 

--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -181,9 +182,14 @@ func (m *GoPluginMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reque
 		if pluginMw, found := m.goPluginFromRequest(r); found {
 			logger = pluginMw.logger
 			handler = pluginMw.handler
+		} else {
+			return nil, http.StatusOK // next middleware
 		}
 	}
+
 	if handler == nil {
+		respCode = http.StatusInternalServerError
+		err = errors.New(http.StatusText(respCode))
 		return
 	}
 


### PR DESCRIPTION
[TT-6024] Return error when GoPlugin handler is nil (#4922)

When GoPlugin load fails during API load, its handler is set as `nil`.
The gateway should stop and return error when the API is called instead
of skipping to other middlewares.

Fixes https://github.com/TykTechnologies/tyk/issues/4469

[TT-6024]: https://tyktech.atlassian.net/browse/TT-6024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ