### PR TITLE
Merging to release-4-lts: [TT-6024] Return error when GoPlugin handler is nil (#4922)

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -140,12 +140,8 @@ func (gw *Gateway) createMiddleware(actualMW TykMiddleware) func(http.Handler) h
 
 			err, errCode := mw.ProcessRequest(w, r, mwConf)
 			if err != nil {
-				// GoPluginMiddleware are expected to send response in case of error
-				// but we still want to record error
-				_, isGoPlugin := actualMW.(*GoPluginMiddleware)
-
 				handler := ErrorHandler{*mw.Base()}
-				handler.HandleError(w, r, err.Error(), errCode, !isGoPlugin)
+				handler.HandleError(w, r, err.Error(), errCode, true)
 
 				meta["error"] = err.Error()
 

--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -162,9 +163,14 @@ func (m *GoPluginMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reque
 		if pluginMw, found := m.goPluginFromRequest(r); found {
 			logger = pluginMw.logger
 			handler = pluginMw.handler
+		} else {
+			return nil, http.StatusOK // next middleware
 		}
 	}
+
 	if handler == nil {
+		respCode = http.StatusInternalServerError
+		err = errors.New(http.StatusText(respCode))
 		return
 
 	}

--- a/goplugin/mw_go_plugin_test.go
+++ b/goplugin/mw_go_plugin_test.go
@@ -273,3 +273,46 @@ func TestGoPluginAPIandPerPath(t *testing.T) {
 		}...)
 	})
 }
+
+func TestGoPluginMiddleware_ProcessRequest_ShouldFailWhenNotLoaded(t *testing.T) {
+	ts := gateway.StartTest(nil)
+	defer ts.Close()
+
+	api := ts.Gw.BuildAndLoadAPI(func(spec *gateway.APISpec) {
+		spec.Proxy.ListenPath = "/"
+		spec.UseKeylessAccess = false
+		spec.CustomPluginAuthEnabled = true
+		spec.CustomMiddleware.Driver = apidef.GoPluginDriver
+		spec.CustomMiddleware.AuthCheck.Name = "my-auth"
+		spec.CustomMiddleware.AuthCheck.Path = "auth.so"
+	})[0]
+
+	_, _ = ts.Run(t, test.TestCase{
+		Path: "/get", Code: http.StatusInternalServerError, BodyMatch: http.StatusText(http.StatusInternalServerError),
+	})
+
+	t.Run("path level", func(t *testing.T) {
+		api.CustomPluginAuthEnabled = false
+		api.UseKeylessAccess = true
+
+		v := api.VersionData.Versions["v1"]
+		v.UseExtendedPaths = true
+		v.ExtendedPaths = apidef.ExtendedPathsSet{
+			GoPlugin: []apidef.GoPluginMeta{
+				apidef.GoPluginMeta{
+					Path:       "/my-plugin",
+					Method:     http.MethodGet,
+					PluginPath: "non-existing.so",
+					SymbolName: "NonExistingPlugin",
+				},
+			},
+		}
+		api.VersionData.Versions["v1"] = v
+		ts.Gw.LoadAPI(api)
+
+		_, _ = ts.Run(t, []test.TestCase{
+			{Path: "/get", Code: http.StatusOK},
+			{Path: "/my-plugin", Code: http.StatusInternalServerError, BodyMatch: http.StatusText(http.StatusInternalServerError)},
+		}...)
+	})
+}


### PR DESCRIPTION
[TT-6024] Return error when GoPlugin handler is nil (#4922)

When GoPlugin load fails during API load, its handler is set as `nil`.
The gateway should stop and return error when the API is called instead
of skipping to other middlewares.

Fixes https://github.com/TykTechnologies/tyk/issues/4469