### PR TITLE
Merging to release-5-lts: [TT-8395] cacheTimeout adjustments for consistency (#4919)

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -538,13 +538,14 @@ type ServiceDiscoveryConfiguration struct {
 	PortDataPath        string `bson:"port_data_path" json:"port_data_path"`
 	TargetPath          string `bson:"target_path" json:"target_path"`
 	UseTargetList       bool   `bson:"use_target_list" json:"use_target_list"`
+	CacheDisabled       bool   `bson:"cache_disabled" json:"cache_disabled"`
 	CacheTimeout        int64  `bson:"cache_timeout" json:"cache_timeout"`
 	EndpointReturnsList bool   `bson:"endpoint_returns_list" json:"endpoint_returns_list"`
 }
 
 // CacheOptions returns the timeout value in effect, and a bool if cache is enabled.
 func (sd *ServiceDiscoveryConfiguration) CacheOptions() (int64, bool) {
-	return sd.CacheTimeout, sd.UseDiscoveryService && sd.CacheTimeout > 0
+	return sd.CacheTimeout, !sd.CacheDisabled
 }
 
 type OIDProviderConfig struct {
@@ -695,11 +696,13 @@ type AnalyticsPluginConfig struct {
 
 type UptimeTests struct {
 	CheckList []HostCheckObject `bson:"check_list" json:"check_list"`
-	Config    struct {
-		ExpireUptimeAnalyticsAfter int64                         `bson:"expire_utime_after" json:"expire_utime_after"` // must have an expireAt TTL index set (http://docs.mongodb.org/manual/tutorial/expire-data/)
-		ServiceDiscovery           ServiceDiscoveryConfiguration `bson:"service_discovery" json:"service_discovery"`
-		RecheckWait                int                           `bson:"recheck_wait" json:"recheck_wait"`
-	} `bson:"config" json:"config"`
+	Config    UptimeTestsConfig `bson:"config" json:"config"`
+}
+
+type UptimeTestsConfig struct {
+	ExpireUptimeAnalyticsAfter int64                         `bson:"expire_utime_after" json:"expire_utime_after"` // must have an expireAt TTL index set (http://docs.mongodb.org/manual/tutorial/expire-data/)
+	ServiceDiscovery           ServiceDiscoveryConfiguration `bson:"service_discovery" json:"service_discovery"`
+	RecheckWait                int                           `bson:"recheck_wait" json:"recheck_wait"`
 }
 
 type AuthConfig struct {

--- a/apidef/migration.go
+++ b/apidef/migration.go
@@ -400,6 +400,8 @@ func (a *APIDefinition) SetDisabledFlags() {
 	a.CustomMiddlewareBundleDisabled = true
 	a.CustomMiddleware.IdExtractor.Disabled = true
 	a.ConfigDataDisabled = true
+	a.Proxy.ServiceDiscovery.CacheDisabled = true
+	a.UptimeTests.Config.ServiceDiscovery.CacheDisabled = true
 
 	for i := 0; i < len(a.CustomMiddleware.Pre); i++ {
 		a.CustomMiddleware.Pre[i].Disabled = true

--- a/apidef/migration_test.go
+++ b/apidef/migration_test.go
@@ -638,6 +638,18 @@ func TestSetDisabledFlags(t *testing.T) {
 		DomainDisabled:                 true,
 		CustomMiddlewareBundleDisabled: true,
 		ConfigDataDisabled:             true,
+		Proxy: ProxyConfig{
+			ServiceDiscovery: ServiceDiscoveryConfiguration{
+				CacheDisabled: true,
+			},
+		},
+		UptimeTests: UptimeTests{
+			Config: UptimeTestsConfig{
+				ServiceDiscovery: ServiceDiscoveryConfiguration{
+					CacheDisabled: true,
+				},
+			},
+		},
 		VersionData: VersionData{
 			Versions: map[string]VersionInfo{
 				"": {

--- a/apidef/oas/schema/x-tyk-gateway.md
+++ b/apidef/oas/schema/x-tyk-gateway.md
@@ -193,8 +193,17 @@ Tyk classic API definition: `service_discovery.use_target_list`.
 **Field: `cacheTimeout` (`int`)**
 CacheTimeout is the timeout of a cache value when a new data is loaded from a discovery service.
 Setting it too low will cause Tyk to call the SD service too often, setting it too high could mean that failures are not recovered from quickly enough.
+Deprecated: The field is deprecated, usage needs to be updated to configure caching.
 
 Tyk classic API definition: `service_discovery.cache_timeout`.
+
+**Field: `cache` ([ServiceDiscoveryCache](#servicediscoverycache))**
+Cache holds cache related flags.
+
+Tyk classic API definition:
+
+- `service_discovery.cache_disabled`
+- `service_discovery.cache_timeout`
 
 **Field: `targetPath` (`string`)**
 TargetPath is to set a target path to append to the discovered endpoint, since many SD services only provide host and port data. It is important to be able to target a specific resource on that host.
@@ -206,6 +215,19 @@ Tyk classic API definition: `service_discovery.target_path`.
 EndpointReturnsList is set `true` when the response type is a list instead of an object.
 
 Tyk classic API definition: `service_discovery.endpoint_returns_list`.
+
+
+### **ServiceDiscoveryCache**
+
+**Field: `enabled` (`boolean`)**
+Enabled turns service discovery cache on or off.
+
+Tyk classic API definition: `service_discovery.cache_disabled`.
+
+**Field: `timeout` (`int`)**
+Timeout is the TTL for a cached object in seconds.
+
+Tyk classic API definition: `service_discovery.cache_timeout`.
 
 
 ### **Test**

--- a/apidef/oas/upstream_test.go
+++ b/apidef/oas/upstream_test.go
@@ -8,6 +8,92 @@ import (
 	"github.com/TykTechnologies/tyk/apidef"
 )
 
+func TestCacheOptions(t *testing.T) {
+	t.Parallel()
+
+	emptyCache := &ServiceDiscoveryCache{}
+	enabledCache := &ServiceDiscoveryCache{
+		Enabled: true,
+		Timeout: 123,
+	}
+
+	var disabled bool
+	enabled := !disabled
+
+	testcases := []struct {
+		title   string
+		obj     *ServiceDiscovery
+		timeout int64
+		enabled bool
+	}{
+		{
+			"new",
+			&ServiceDiscovery{
+				Enabled: true,
+				Cache:   enabledCache,
+			},
+			123,
+			enabled,
+		},
+		{
+			"new and old",
+			&ServiceDiscovery{
+				Enabled:      true,
+				CacheTimeout: 10,
+				Cache:        enabledCache,
+			},
+			123,
+			enabled,
+		},
+		{
+			// This test case is particular to the behaviour of
+			// timeouts; if the new cache config value is set but
+			// is empty, we use that for the config. In practice,
+			// removing cache options on encoding with omitempty
+			// ensures that we rarely hit this case.
+			"new disabled and old",
+			&ServiceDiscovery{
+				Enabled:      true,
+				CacheTimeout: 10,
+				Cache:        emptyCache,
+			},
+			0,
+			disabled,
+		},
+		{
+			"new nil and old",
+			&ServiceDiscovery{
+				Enabled:      true,
+				CacheTimeout: 10,
+			},
+			10,
+			enabled,
+		},
+		{
+			"empty",
+			&ServiceDiscovery{
+				Enabled: true,
+			},
+			0,
+			disabled,
+		},
+		{
+			"nothing",
+			&ServiceDiscovery{},
+			0,
+			disabled,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.title, func(t *testing.T) {
+			timeout, ok := tc.obj.CacheOptions()
+			assert.Equal(t, tc.timeout, timeout)
+			assert.Equal(t, tc.enabled, ok)
+		})
+	}
+}
+
 func TestUpstream(t *testing.T) {
 	var emptyUpstream Upstream
 


### PR DESCRIPTION
[TT-8395] cacheTimeout adjustments for consistency (#4919)

Changed:

- Added Cache options to ServiceDiscovery in OAS,
- Deprecate old `cacheTimeout` value,
- Add a CacheDisabled to apidef (only had cacheTimeout)

Related issue: https://tyktech.atlassian.net/browse/TT-8395

Co-authored-by: Tit Petric <tit@tyk.io>

[TT-8395]: https://tyktech.atlassian.net/browse/TT-8395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ