### PR TITLE
[TT-7767] UDG data source config based on info parsed from OAS spec

### DIFF
--- a/apidef/adapter/openapi.go
+++ b/apidef/adapter/openapi.go
@@ -9,12 +9,13 @@ import (
 	"net/url"
 	"sort"
 
+	"github.com/getkin/kin-openapi/openapi3"
+
 	"github.com/TykTechnologies/graphql-go-tools/pkg/astprinter"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/openapi"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/operationreport"
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/internal/uuid"
-	"github.com/getkin/kin-openapi/openapi3"
 )
 
 const defaultRequestBodyMimeType = "application/json"

--- a/apidef/adapter/openapi.go
+++ b/apidef/adapter/openapi.go
@@ -1,0 +1,229 @@
+package adapter
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+
+	"github.com/TykTechnologies/graphql-go-tools/pkg/astprinter"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/openapi"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/operationreport"
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/internal/uuid"
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+const defaultRequestBodyMimeType = "application/json"
+
+type OpenAPI struct {
+	apiDefinition *apidef.APIDefinition
+	document      *openapi3.T
+}
+
+func extractRequestBody(mime string, operation *openapi3.Operation) (*openapi3.SchemaRef, error) {
+	mediaType := operation.RequestBody.Value.Content.Get(mime)
+	if mediaType == nil {
+		return nil, fmt.Errorf("no media found for mime type %s", mime)
+	}
+
+	if mediaType.Schema != nil {
+		return mediaType.Schema, nil
+	}
+	return nil, fmt.Errorf("no schema found for mime type %s", mime)
+}
+
+func newApiDefinition(document *openapi3.T, orgId string) *apidef.APIDefinition {
+	return &apidef.APIDefinition{
+		Name:   document.Info.Title,
+		Active: true,
+		OrgID:  orgId,
+		APIID:  uuid.NewHex(),
+		GraphQL: apidef.GraphQLConfig{
+			Enabled:       true,
+			Version:       apidef.GraphQLConfigVersion2,
+			ExecutionMode: apidef.GraphQLExecutionModeExecutionEngine,
+		},
+		VersionDefinition: apidef.VersionDefinition{
+			Enabled:  false,
+			Location: "header",
+		},
+		VersionData: apidef.VersionData{
+			NotVersioned: true,
+			Versions: map[string]apidef.VersionInfo{
+				"Default": {
+					Name:             "Default",
+					UseExtendedPaths: true,
+				},
+			},
+		},
+		Proxy: apidef.ProxyConfig{
+			StripListenPath: true,
+		},
+	}
+}
+
+func (o *OpenAPI) prepareGraphQLEngineConfig() error {
+	if o.document == nil {
+		return fmt.Errorf("document is nil")
+	}
+
+	if len(o.document.Servers) == 0 {
+		return errors.New("no server defined in OpenAPI spec")
+	}
+
+	graphqlTypes := map[string][]string{
+		"Query":    {http.MethodGet},
+		"Mutation": {http.MethodPost, http.MethodPut, http.MethodDelete},
+	}
+
+	// We only support one server definition and always pick the first one.
+	server, err := url.Parse(o.document.Servers[0].URL)
+	if err != nil {
+		return err
+	}
+
+	for rawEndpoint, pathItem := range o.document.Paths {
+		// Converts /pets/{id} to /pets/{{.arguments.id}}
+		endpoint := processArgumentSection(rawEndpoint)
+
+		for graphqlType, methods := range graphqlTypes {
+			for _, method := range methods {
+				operation := pathItem.GetOperation(method)
+				if operation == nil {
+					continue
+				}
+
+				parsedEndpoint, err := url.Parse(endpoint)
+				if err != nil {
+					return fmt.Errorf("failed to parse endpoint: %w", err)
+				}
+				parsedEndpoint.Scheme = server.Scheme
+				parsedEndpoint.Host = server.Host
+
+				query := parsedEndpoint.Query()
+				for _, parameter := range operation.Parameters {
+					if parameter.Value.In == "query" {
+						query.Add(parameter.Value.Name, fmt.Sprintf("{{.arguments.%s}}", parameter.Value.Name))
+					}
+				}
+				unescapedQuery, err := url.PathUnescape(query.Encode())
+				if err != nil {
+					return err
+				}
+				parsedEndpoint.RawQuery = unescapedQuery
+
+				fieldName := openapi.MakeFieldNameFromOperationID(operation.OperationID)
+				if fieldName == "" {
+					// If "operationId" is not defined by the user, try to make an operationId
+					// from endpoint's itself. The same technique is used by IBM/openapi-to-graphql tool.
+					fieldName = openapi.MakeFieldNameFromEndpoint(method, rawEndpoint)
+				}
+
+				fieldConfig := apidef.GraphQLFieldConfig{
+					TypeName:  graphqlType,
+					FieldName: fieldName,
+					Path:      []string{fieldName},
+				}
+				o.apiDefinition.GraphQL.Engine.FieldConfigs = append(o.apiDefinition.GraphQL.Engine.FieldConfigs, fieldConfig)
+
+				rootFields := []apidef.GraphQLTypeFields{
+					{
+						Type: graphqlType,
+						Fields: []string{
+							fieldName,
+						},
+					},
+				}
+				dataSourceConfig := apidef.GraphQLEngineDataSource{
+					Kind:       apidef.GraphQLEngineDataSourceKindREST,
+					Name:       fieldName,
+					RootFields: rootFields,
+				}
+
+				dataSourceURL, err := url.PathUnescape(parsedEndpoint.String())
+				if err != nil {
+					return err
+				}
+
+				restConfig := apidef.GraphQLEngineDataSourceConfigREST{
+					URL:     dataSourceURL,
+					Method:  method,
+					Headers: make(map[string]string),
+					Query:   []apidef.QueryVariable{},
+				}
+				if operation.RequestBody != nil {
+					inputTypeSchema, err := extractRequestBody(defaultRequestBodyMimeType, operation)
+					if err != nil {
+						return err
+					}
+					inputTypeName := openapi.MakeInputTypeName(inputTypeSchema.Ref)
+					restConfig.Body = fmt.Sprintf("{{ .arguments.%s }}", openapi.MakeParameterName(inputTypeName))
+				}
+
+				encodedRestConfig, err := json.Marshal(restConfig)
+				if err != nil {
+					return err
+				}
+
+				dataSourceConfig.Config = encodedRestConfig
+				o.apiDefinition.GraphQL.Engine.DataSources = append(o.apiDefinition.GraphQL.Engine.DataSources, dataSourceConfig)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (o *OpenAPI) sortFieldConfigsByName() {
+	sort.Slice(o.apiDefinition.GraphQL.Engine.FieldConfigs, func(i, j int) bool {
+		return o.apiDefinition.GraphQL.Engine.FieldConfigs[i].FieldName < o.apiDefinition.GraphQL.Engine.FieldConfigs[j].FieldName
+	})
+}
+
+func (o *OpenAPI) sortDataSourcesByName() {
+	sort.Slice(o.apiDefinition.GraphQL.Engine.DataSources, func(i, j int) bool {
+		return o.apiDefinition.GraphQL.Engine.DataSources[i].Name < o.apiDefinition.GraphQL.Engine.DataSources[j].Name
+	})
+}
+
+func ImportOpenAPIDocument(orgId string, input []byte) (*apidef.APIDefinition, error) {
+	report := operationreport.Report{}
+	document, err := openapi.ParseOpenAPIDocument(input)
+	if err != nil {
+		return nil, err
+	}
+
+	apiDefinition := newApiDefinition(document, orgId)
+
+	o := OpenAPI{
+		apiDefinition: apiDefinition,
+		document:      document,
+	}
+	if err = o.prepareGraphQLEngineConfig(); err != nil {
+		return nil, err
+	}
+
+	// We iterate over the maps to create a new API definition. This leads to the random placement of
+	// items in various arrays in the resulting JSON document. In order to test the OpenAPI converter
+	// with fixtures and prevent randomness, we sort various data structures here.
+	o.sortFieldConfigsByName()
+	o.sortDataSourcesByName()
+
+	graphqlDocument := openapi.ImportParsedOpenAPIv3Document(document, &report)
+	if report.HasErrors() {
+		return nil, report
+	}
+
+	w := &bytes.Buffer{}
+	err = astprinter.PrintIndent(graphqlDocument, nil, []byte("  "), w)
+	if err != nil {
+		return nil, err
+	}
+	apiDefinition.GraphQL.Schema = w.String()
+
+	return apiDefinition, nil
+}

--- a/apidef/adapter/openapi_test.go
+++ b/apidef/adapter/openapi_test.go
@@ -1,0 +1,337 @@
+package adapter
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/buger/jsonparser"
+	"github.com/stretchr/testify/require"
+)
+
+const petstoreExpandedOpenAPI3 = `openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: apiteam@swagger.io
+    url: http://swagger.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: http://petstore.swagger.io/api
+paths:
+  /pets:
+    get:
+      description: |
+        Returns all pets from the system that the user has access to
+        Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+
+        Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+      operationId: findPets
+      parameters:
+        - name: tags
+          in: query
+          description: tags to filter by
+          required: false
+          style: form
+          schema:
+            type: array
+            items:
+              type: string
+        - name: limit
+          in: query
+          description: maximum number of results to return
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      description: Creates a new pet in the store. Duplicates are allowed
+      operationId: addPet
+      requestBody:
+        description: Pet to add to the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewPet'
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: find pet by id
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to fetch
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      description: deletes a single pet based on the ID supplied
+      operationId: deletePet
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '204':
+          description: pet deleted
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Pet:
+      allOf:
+        - $ref: '#/components/schemas/NewPet'
+        - type: object
+          required:
+            - id
+          properties:
+            id:
+              type: integer
+              format: int64
+
+    NewPet:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        tag:
+          type: string
+
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string`
+
+const expectedOpenAPIGraphQLSchema = "schema {\n    query: Query\n    mutation: Mutation\n}\n\ntype Query {\n    \"Returns a user based on a single ID, if the user does not have access to the pet\"\n    findPetById(id: Int): Pet\n    \"\"\"\n    Returns all pets from the system that the user has access to\n    Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.\n\n    Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.\n    \"\"\"\n    findPets(limit: Int, tags: [String]): [Pet]\n}\n\ntype Mutation {\n    \"Creates a new pet in the store. Duplicates are allowed\"\n    addPet(newPetInput: NewPetInput): Pet\n    \"deletes a single pet based on the ID supplied\"\n    deletePet(id: Int): String\n}\n\ninput NewPetInput {\n    name: String\n    tag: String\n}\n\ntype Pet {\n    id: Int\n    name: String\n    tag: String\n}"
+
+const expectedOpenAPIGraphQLConfig = `{
+    "enabled": true,
+    "execution_mode": "executionEngine",
+    "version": "2",
+    "schema": "schema {\n    query: Query\n    mutation: Mutation\n}\n\ntype Query {\n    \"Returns a user based on a single ID, if the user does not have access to the pet\"\n    findPetById(id: Int): Pet\n    \"\"\"\n    Returns all pets from the system that the user has access to\n    Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.\n\n    Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.\n    \"\"\"\n    findPets(limit: Int, tags: [String]): [Pet]\n}\n\ntype Mutation {\n    \"Creates a new pet in the store. Duplicates are allowed\"\n    addPet(newPetInput: NewPetInput): Pet\n    \"deletes a single pet based on the ID supplied\"\n    deletePet(id: Int): String\n}\n\ninput NewPetInput {\n    name: String\n    tag: String\n}\n\ntype Pet {\n    id: Int\n    name: String\n    tag: String\n}",
+    "type_field_configurations": null,
+    "playground": {
+        "enabled": false,
+        "path": ""
+    },
+    "engine": {
+        "field_configs": [
+            {
+                "type_name": "Mutation",
+                "field_name": "addPet",
+                "disable_default_mapping": false,
+                "path": [
+                    "addPet"
+                ]
+            },
+            {
+                "type_name": "Mutation",
+                "field_name": "deletePet",
+                "disable_default_mapping": false,
+                "path": [
+                    "deletePet"
+                ]
+            },
+            {
+                "type_name": "Query",
+                "field_name": "findPetById",
+                "disable_default_mapping": false,
+                "path": [
+                    "findPetById"
+                ]
+            },
+            {
+                "type_name": "Query",
+                "field_name": "findPets",
+                "disable_default_mapping": false,
+                "path": [
+                    "findPets"
+                ]
+            }
+        ],
+        "data_sources": [
+            {
+                "kind": "REST",
+                "name": "addPet",
+                "internal": false,
+                "root_fields": [
+                    {
+                        "type": "Mutation",
+                        "fields": [
+                            "addPet"
+                        ]
+                    }
+                ],
+                "config": {
+                    "url": "http://petstore.swagger.io/pets",
+                    "method": "POST",
+                    "headers": {},
+                    "query": [],
+                    "body": "{{ .arguments.newPetInput }}"
+                }
+            },
+            {
+                "kind": "REST",
+                "name": "deletePet",
+                "internal": false,
+                "root_fields": [
+                    {
+                        "type": "Mutation",
+                        "fields": [
+                            "deletePet"
+                        ]
+                    }
+                ],
+                "config": {
+                    "url": "http://petstore.swagger.io/pets/{{.arguments.id}}",
+                    "method": "DELETE",
+                    "headers": {},
+                    "query": [],
+                    "body": ""
+                }
+            },
+            {
+                "kind": "REST",
+                "name": "findPetById",
+                "internal": false,
+                "root_fields": [
+                    {
+                        "type": "Query",
+                        "fields": [
+                            "findPetById"
+                        ]
+                    }
+                ],
+                "config": {
+                    "url": "http://petstore.swagger.io/pets/{{.arguments.id}}",
+                    "method": "GET",
+                    "headers": {},
+                    "query": [],
+                    "body": ""
+                }
+            },
+            {
+                "kind": "REST",
+                "name": "findPets",
+                "internal": false,
+                "root_fields": [
+                    {
+                        "type": "Query",
+                        "fields": [
+                            "findPets"
+                        ]
+                    }
+                ],
+                "config": {
+                    "url": "http://petstore.swagger.io/pets?limit={{.arguments.limit}}\u0026tags={{.arguments.tags}}",
+                    "method": "GET",
+                    "headers": {},
+                    "query": [],
+                    "body": ""
+                }
+            }
+        ]
+    },
+    "proxy": {
+        "auth_headers": null,
+        "request_headers": null
+    },
+    "subgraph": {
+        "sdl": ""
+    },
+    "supergraph": {
+        "subgraphs": null,
+        "merged_sdl": "",
+        "global_headers": null,
+        "disable_query_batching": false
+    }
+}`
+
+func TestGraphQLConfigAdapter_OpenAPI(t *testing.T) {
+	actualApiDefinition, err := ImportOpenAPIDocument("my-org-id", []byte(petstoreExpandedOpenAPI3))
+	require.NoError(t, err)
+
+	require.Equal(t, "Swagger Petstore", actualApiDefinition.Name)
+	require.True(t, actualApiDefinition.GraphQL.Enabled)
+	require.True(t, actualApiDefinition.Active)
+	require.Equal(t, apidef.GraphQLExecutionModeExecutionEngine, actualApiDefinition.GraphQL.ExecutionMode)
+	require.Equal(t, expectedOpenAPIGraphQLSchema, actualApiDefinition.GraphQL.Schema)
+
+	data, err := json.Marshal(actualApiDefinition)
+	require.NoError(t, err)
+
+	actualGraphqlConfig, _, _, err := jsonparser.Get(data, "graphql")
+	require.NoError(t, err)
+
+	dst := bytes.NewBuffer(nil)
+	err = json.Indent(dst, actualGraphqlConfig, "", "    ")
+	require.NoError(t, err)
+	require.Equal(t, expectedOpenAPIGraphQLConfig, dst.String())
+}

--- a/apidef/adapter/openapi_test.go
+++ b/apidef/adapter/openapi_test.go
@@ -5,9 +5,10 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/buger/jsonparser"
 	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/apidef"
 )
 
 const petstoreExpandedOpenAPI3 = `openapi: "3.0.0"

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/TykTechnologies/gojsonschema v0.0.0-20170222154038-dcb3e4bb7990
 	github.com/TykTechnologies/gorpc v0.0.0-20210624160652-fe65bda0ccb9
 	github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708
-	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230320143102-7a16078ce517
+	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230403092412-8921a0eef884
 	github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c
 	github.com/TykTechnologies/murmur3 v0.0.0-20230310161213-aad17efd5632
 	github.com/TykTechnologies/openid2go v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,9 @@ github.com/TykTechnologies/gorpc v0.0.0-20210624160652-fe65bda0ccb9 h1:fbxHiuw/2
 github.com/TykTechnologies/gorpc v0.0.0-20210624160652-fe65bda0ccb9/go.mod h1:v6v7Mlj08+EmEcXOfpuTxGt2qYU9yhqqtv4QF9Wf50E=
 github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708 h1:cmXjlMzcexhc/Cg+QB/c2CPUVs1ux9xn6162qaf/LC4=
 github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708/go.mod h1:mkS8jKcz8otdfEXhJs1QQ/DKoIY1NFFsRPKS0RwQENI=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230320143102-7a16078ce517 h1:EtNbr8wZPmSBtUKjE2S74bAYeJAJzW5CqJNewSz12sQ=
 github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230320143102-7a16078ce517/go.mod h1:ZiFZcrue3+n2mHH+KLHRipbYVULkgy3Myko5S7IIs74=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230403092412-8921a0eef884 h1:++85E/+PCBqxgT7uaXZ63N+1eeiGgWXoulh4NIQB/3M=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230403092412-8921a0eef884/go.mod h1:Fjaf4vD/lBTjBdwG+eCd+VhQzKNZBRw+9nygH4IUHlA=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c h1:j6fd0Fz1R4oSWOmcooGjrdahqrML+btQ+PfEJw8SzbA=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c/go.mod h1:GnHUbsQx+ysI10osPhUdTmsxcE7ef64cVp38Fdyd7e0=
 github.com/TykTechnologies/murmur3 v0.0.0-20230310161213-aad17efd5632 h1:T5NWziFusj8au5nxAqMMh/bZyX9CAyYnBkaMSsfH6BA=
@@ -281,8 +282,9 @@ github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LB
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
-github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
 github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
+github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/go-zookeeper/zk v1.0.2 h1:4mx0EYENAdX/B/rbunjlt5+4RTA/a9SMHBRuSKdGxPM=
 github.com/go-zookeeper/zk v1.0.2/go.mod h1:nOB03cncLtlp4t+UAkGSV+9beXP/akpekBwL+UX1Qcw=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee h1:s+21KNqlpePfkah2I+gwHF8xmJWRjooY+5248k6m4A0=


### PR DESCRIPTION
This PR adds `ImportOpenAPIDocument` method to the GraphQL config adapter. Basically, it takes an OpenAPI v3.0.0 document and produces an API definition for UDG.

* It doesn't support [versioning](https://tyk.io/docs/tyk-apis/tyk-gateway-api/api-definition-objects/versioning-endpoint/) yet.
* If a user has defined multiple servers in the `Servers` section, `ImportOpenAPIDocument` picks the first one to build a data source configuration. 

A sample can be found in `openapi_test.go` file. 