### PR TITLE
[TT-8527] Remove redundant code and increase maintainability in open api async api importers

### DIFF
--- a/apidef/adapter/asyncapi.go
+++ b/apidef/adapter/asyncapi.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
-	"sort"
 	"strings"
 
 	"github.com/buger/jsonparser"
@@ -96,45 +95,20 @@ func encodeKafkaDataSourceConfig(cfg kafka_datasource.GraphQLSubscriptionOptions
 	return json.Marshal(localConfig)
 }
 
-func ImportAsyncAPIDocument(input []byte) (apidef.APIDefinition, error) {
-	def := apidef.DummyAPI()
-
-	parsed, err := asyncapi.ParseAsyncAPIDocument(input)
+func (a *asyncAPI) prepareGraphQLEngineConfig() error {
+	serverConfig, err := prepareKafkaDataSourceConfig(a.document)
 	if err != nil {
-		return def, err
+		return err
 	}
 
-	report := operationreport.Report{}
-	doc := asyncapi.ImportParsedAsyncAPIDocument(parsed, &report)
-	if report.HasErrors() {
-		return def, report
-	}
-
-	w := &bytes.Buffer{}
-	err = astprinter.PrintIndent(doc, nil, []byte("  "), w)
-	if err != nil {
-		return def, err
-	}
-
-	def.Name = fmt.Sprintf("%s - %s", parsed.Info.Title, parsed.Info.Version)
-	def.GraphQL.Enabled = true
-	def.Active = true
-	def.GraphQL.ExecutionMode = apidef.GraphQLExecutionModeExecutionEngine
-	def.GraphQL.Schema = w.String()
-
-	serverConfig, err := prepareKafkaDataSourceConfig(parsed)
-	if err != nil {
-		return def, err
-	}
-
-	for channelName, channelItem := range parsed.Channels {
+	for channelName, channelItem := range a.document.Channels {
 		channelName = processArgumentSection(channelName)
 		fieldConfig := apidef.GraphQLFieldConfig{
 			TypeName:  "Subscription",
 			FieldName: channelItem.OperationID,
 			Path:      []string{channelItem.OperationID},
 		}
-		def.GraphQL.Engine.FieldConfigs = append(def.GraphQL.Engine.FieldConfigs, fieldConfig)
+		a.apiDefinition.GraphQL.Engine.FieldConfigs = append(a.apiDefinition.GraphQL.Engine.FieldConfigs, fieldConfig)
 		rootFields := []apidef.GraphQLTypeFields{
 			{
 				Type: "Subscription",
@@ -155,7 +129,7 @@ func ImportAsyncAPIDocument(input []byte) (apidef.APIDefinition, error) {
 			for _, cfg := range serverConfig {
 				marshalConfig, err := encodeKafkaDataSourceConfig(cfg, channelName)
 				if err != nil {
-					return def, err
+					return err
 				}
 				dataSourceConfig.Config = marshalConfig
 				break
@@ -165,7 +139,7 @@ func ImportAsyncAPIDocument(input []byte) (apidef.APIDefinition, error) {
 				if cfg, ok := serverConfig[server]; ok {
 					encodedConfig, err := encodeKafkaDataSourceConfig(cfg, channelName)
 					if err != nil {
-						return def, err
+						return err
 					}
 					dataSourceConfig.Config = encodedConfig
 					break
@@ -173,20 +147,56 @@ func ImportAsyncAPIDocument(input []byte) (apidef.APIDefinition, error) {
 			}
 		}
 
-		def.GraphQL.Engine.DataSources = append(def.GraphQL.Engine.DataSources, dataSourceConfig)
+		a.apiDefinition.GraphQL.Engine.DataSources = append(a.apiDefinition.GraphQL.Engine.DataSources, dataSourceConfig)
+	}
+
+	return nil
+}
+
+func (a *asyncAPI) Import() (*apidef.APIDefinition, error) {
+	if err := a.prepareGraphQLEngineConfig(); err != nil {
+		return nil, err
 	}
 
 	// We iterate over the maps to create a new API definition. This leads to the random placement of
 	// items in various arrays in the resulting JSON document. In order to test the AsyncAPI converter
 	// with fixtures and prevent randomness, we sort various data structures here.
+	sortFieldConfigsByName(a.apiDefinition)
+	sortDataSourcesByName(a.apiDefinition)
 
-	sort.Slice(def.GraphQL.Engine.FieldConfigs, func(i, j int) bool {
-		return def.GraphQL.Engine.FieldConfigs[i].FieldName < def.GraphQL.Engine.FieldConfigs[j].FieldName
-	})
+	document := asyncapi.ImportParsedAsyncAPIDocument(a.document, a.report)
+	if a.report.HasErrors() {
+		return nil, a.report
+	}
 
-	sort.Slice(def.GraphQL.Engine.DataSources, func(i, j int) bool {
-		return def.GraphQL.Engine.DataSources[i].Name < def.GraphQL.Engine.DataSources[j].Name
-	})
+	w := &bytes.Buffer{}
+	err := astprinter.PrintIndent(document, nil, []byte("  "), w)
+	if err != nil {
+		return nil, err
+	}
+	a.apiDefinition.GraphQL.Schema = w.String()
 
-	return def, nil
+	return a.apiDefinition, nil
 }
+
+type asyncAPI struct {
+	report        *operationreport.Report
+	apiDefinition *apidef.APIDefinition
+	document      *asyncapi.AsyncAPI
+}
+
+func NewAsyncAPIAdapter(orgId string, input []byte) (ImportAdapter, error) {
+	document, err := asyncapi.ParseAsyncAPIDocument(input)
+	if err != nil {
+		return nil, err
+	}
+
+	apiDefinition := newApiDefinition(document.Info.Title, orgId)
+	return &asyncAPI{
+		report:        &operationreport.Report{},
+		apiDefinition: apiDefinition,
+		document:      document,
+	}, nil
+}
+
+var _ ImportAdapter = (*asyncAPI)(nil)

--- a/apidef/adapter/asyncapi_test.go
+++ b/apidef/adapter/asyncapi_test.go
@@ -335,8 +335,7 @@ const expectedGraphqlConfig = `{
 }`
 
 func TestGraphQLConfigAdapter_AsyncAPI(t *testing.T) {
-	importer, err := NewAsyncAPIAdapter("my-org-id", []byte(streetlightsKafkaAsyncAPI))
-	require.NoError(t, err)
+	importer := NewAsyncAPIAdapter("my-org-id", []byte(streetlightsKafkaAsyncAPI))
 
 	actualApiDefinition, err := importer.Import()
 	require.NoError(t, err)

--- a/apidef/adapter/asyncapi_test.go
+++ b/apidef/adapter/asyncapi_test.go
@@ -335,10 +335,13 @@ const expectedGraphqlConfig = `{
 }`
 
 func TestGraphQLConfigAdapter_AsyncAPI(t *testing.T) {
-	actualApiDefinition, err := ImportAsyncAPIDocument([]byte(streetlightsKafkaAsyncAPI))
+	importer, err := NewAsyncAPIAdapter("my-org-id", []byte(streetlightsKafkaAsyncAPI))
 	require.NoError(t, err)
 
-	require.Equal(t, "Streetlights Kafka API - 1.0.0", actualApiDefinition.Name)
+	actualApiDefinition, err := importer.Import()
+	require.NoError(t, err)
+
+	require.Equal(t, "Streetlights Kafka API", actualApiDefinition.Name)
 	require.True(t, actualApiDefinition.GraphQL.Enabled)
 	require.True(t, actualApiDefinition.Active)
 	require.Equal(t, apidef.GraphQLExecutionModeExecutionEngine, actualApiDefinition.GraphQL.ExecutionMode)

--- a/apidef/adapter/import_adapter.go
+++ b/apidef/adapter/import_adapter.go
@@ -1,0 +1,7 @@
+package adapter
+
+import "github.com/TykTechnologies/tyk/apidef"
+
+type ImportAdapter interface {
+	Import() (*apidef.APIDefinition, error)
+}

--- a/apidef/adapter/openapi_test.go
+++ b/apidef/adapter/openapi_test.go
@@ -301,7 +301,7 @@ const expectedOpenAPIGraphQLConfig = `{
         ]
     },
     "proxy": {
-        "auth_headers": null,
+        "auth_headers": {},
         "request_headers": null
     },
     "subgraph": {
@@ -316,7 +316,10 @@ const expectedOpenAPIGraphQLConfig = `{
 }`
 
 func TestGraphQLConfigAdapter_OpenAPI(t *testing.T) {
-	actualApiDefinition, err := ImportOpenAPIDocument("my-org-id", []byte(petstoreExpandedOpenAPI3))
+	adapter, err := NewOpenAPIAdapter("my-org-id", []byte(petstoreExpandedOpenAPI3))
+	require.NoError(t, err)
+
+	actualApiDefinition, err := adapter.Import()
 	require.NoError(t, err)
 
 	require.Equal(t, "Swagger Petstore", actualApiDefinition.Name)

--- a/apidef/adapter/openapi_test.go
+++ b/apidef/adapter/openapi_test.go
@@ -316,8 +316,7 @@ const expectedOpenAPIGraphQLConfig = `{
 }`
 
 func TestGraphQLConfigAdapter_OpenAPI(t *testing.T) {
-	adapter, err := NewOpenAPIAdapter("my-org-id", []byte(petstoreExpandedOpenAPI3))
-	require.NoError(t, err)
+	adapter := NewOpenAPIAdapter("my-org-id", []byte(petstoreExpandedOpenAPI3))
 
 	actualApiDefinition, err := adapter.Import()
 	require.NoError(t, err)

--- a/apidef/adapter/utils.go
+++ b/apidef/adapter/utils.go
@@ -2,6 +2,8 @@ package adapter
 
 import (
 	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/internal/uuid"
+	"sort"
 )
 
 type GraphQLEngineAdapterType int
@@ -40,4 +42,49 @@ func graphqlEngineAdapterTypeFromApiDefinition(apiDefinition *apidef.APIDefiniti
 	}
 
 	return GraphQLEngineAdapterTypeUnknown
+}
+
+func newApiDefinition(name, orgId string) *apidef.APIDefinition {
+	return &apidef.APIDefinition{
+		Name:   name,
+		Active: true,
+		OrgID:  orgId,
+		APIID:  uuid.NewHex(),
+		GraphQL: apidef.GraphQLConfig{
+			Enabled:       true,
+			Version:       apidef.GraphQLConfigVersion2,
+			ExecutionMode: apidef.GraphQLExecutionModeExecutionEngine,
+			Proxy: apidef.GraphQLProxyConfig{
+				AuthHeaders: make(map[string]string),
+			},
+		},
+		VersionDefinition: apidef.VersionDefinition{
+			Enabled:  false,
+			Location: "header",
+		},
+		VersionData: apidef.VersionData{
+			NotVersioned: true,
+			Versions: map[string]apidef.VersionInfo{
+				"Default": {
+					Name:             "Default",
+					UseExtendedPaths: true,
+				},
+			},
+		},
+		Proxy: apidef.ProxyConfig{
+			StripListenPath: true,
+		},
+	}
+}
+
+func sortFieldConfigsByName(apiDefinition *apidef.APIDefinition) {
+	sort.Slice(apiDefinition.GraphQL.Engine.FieldConfigs, func(i, j int) bool {
+		return apiDefinition.GraphQL.Engine.FieldConfigs[i].FieldName < apiDefinition.GraphQL.Engine.FieldConfigs[j].FieldName
+	})
+}
+
+func sortDataSourcesByName(apiDefinition *apidef.APIDefinition) {
+	sort.Slice(apiDefinition.GraphQL.Engine.DataSources, func(i, j int) bool {
+		return apiDefinition.GraphQL.Engine.DataSources[i].Name < apiDefinition.GraphQL.Engine.DataSources[j].Name
+	})
 }


### PR DESCRIPTION
This PR adds an interface called `ImportAdapter`. `asyncapi` and `openapi` types implement that interface. 

```golang
type ImportAdapter interface {
	Import() (*apidef.APIDefinition, error)
}
```

Sample usage:

```golang
importer := NewAsyncAPIAdapter("my-org-id", []byte(streetlightsKafkaAsyncAPI))
apiDef, err := importer.Import()
if err != nil {
   // Handle this error
}
```