### PR TITLE
update graphql-go-tools (TT-7807)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/TykTechnologies/gojsonschema v0.0.0-20170222154038-dcb3e4bb7990
 	github.com/TykTechnologies/gorpc v0.0.0-20190515174534-b9c10befc5f4
 	github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708
-	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230104075326-2b137b928bce
+	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230412132247-218da3d7039e
 	github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c
 	github.com/TykTechnologies/murmur3 v0.0.0-20180602122059-1915e687e465
 	github.com/TykTechnologies/openid2go v0.0.0-20200312160651-00c254a52b19

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/TykTechnologies/gorpc v0.0.0-20190515174534-b9c10befc5f4 h1:hTjM5Uubg
 github.com/TykTechnologies/gorpc v0.0.0-20190515174534-b9c10befc5f4/go.mod h1:vqhQRhIHefD4jdFo55j+m0vD5NMjx2liq/ubnshQpaY=
 github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708 h1:cmXjlMzcexhc/Cg+QB/c2CPUVs1ux9xn6162qaf/LC4=
 github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708/go.mod h1:mkS8jKcz8otdfEXhJs1QQ/DKoIY1NFFsRPKS0RwQENI=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230104075326-2b137b928bce h1:rnr0tosWmeyufU6TutgFr2HkwRno0tUzugiqjFNSoJk=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230104075326-2b137b928bce/go.mod h1:s8pb1jSB+T5OomqIH3w0FAcH7aY7q/fcAeYps9s+pNg=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230412132247-218da3d7039e h1:hn/nH/7XbvVpTm3rn/Bqt8SwYDkx+sGpFmuPSNvlgEo=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230412132247-218da3d7039e/go.mod h1:s8pb1jSB+T5OomqIH3w0FAcH7aY7q/fcAeYps9s+pNg=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c h1:j6fd0Fz1R4oSWOmcooGjrdahqrML+btQ+PfEJw8SzbA=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c/go.mod h1:GnHUbsQx+ysI10osPhUdTmsxcE7ef64cVp38Fdyd7e0=
 github.com/TykTechnologies/murmur3 v0.0.0-20180602122059-1915e687e465 h1:A2gBjoX8aF0G3GHEpHyj2f0ixuPkCgcGqmPdKHSkW+0=


### PR DESCRIPTION
update `graphql-go-tools` on branch `release-4-lts` to latest branch `tyk-release-4-lts`