### PR TITLE
[TT-8694] Support CoProcess as a base identity provider in multi-auth

### DIFF
--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -493,7 +493,11 @@ func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 		}
 
 		returnedSession.KeyID = sessionID
-		ctxSetSession(r, returnedSession, true, m.Gw.GetConfig().HashKeys)
+
+		switch m.Spec.BaseIdentityProvidedBy {
+		case apidef.CustomAuth, apidef.UnsetAuth:
+			ctxSetSession(r, returnedSession, true, m.Gw.GetConfig().HashKeys)
+		}
 	}
 
 	return nil, http.StatusOK


### PR DESCRIPTION
This PR implements the support of using CoProcess as a base identity provider in multi-auth. 
The `base_identity_provided_by` should be set as `custom_auth` and inside the plugin `token` meta should be set to define id of the new session to be used as a base identity.