### PR TITLE
Merging to release-5-lts: [TT-8693] Support JSVM as a base identity provider in multi-auth (#4952)

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -73,6 +73,7 @@ const (
 	// For multi-type auth
 	AuthTypeNone  AuthTypeEnum = ""
 	AuthToken     AuthTypeEnum = "auth_token"
+	CustomAuth    AuthTypeEnum = "custom_auth"
 	HMACKey       AuthTypeEnum = "hmac_key"
 	BasicAuthUser AuthTypeEnum = "basic_auth_user"
 	JWTClaim      AuthTypeEnum = "jwt_claim"

--- a/gateway/mw_js_plugin.go
+++ b/gateway/mw_js_plugin.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/TykTechnologies/tyk/apidef"
+
 	"github.com/robertkrimen/otto"
 	_ "github.com/robertkrimen/otto/underscore"
 
@@ -300,7 +302,11 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 
 	if d.Auth {
 		newRequestData.Session.KeyID = newRequestData.AuthValue
-		ctxSetSession(r, &newRequestData.Session, true, d.Gw.GetConfig().HashKeys)
+
+		switch d.Spec.BaseIdentityProvidedBy {
+		case apidef.CustomAuth, apidef.UnsetAuth:
+			ctxSetSession(r, &newRequestData.Session, true, d.Gw.GetConfig().HashKeys)
+		}
 	}
 
 	return nil, http.StatusOK

--- a/gateway/mw_js_plugin_test.go
+++ b/gateway/mw_js_plugin_test.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -168,6 +169,94 @@ testJSVMMiddleware.NewProcessRequest(function(request, session) {
 	if updatedSession.MetaData["removed"] != nil {
 		t.Fatal("Failed to update session metadata for removed")
 	}
+}
+
+func TestJSVM_MultiAuthentication(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	const (
+		apiID          = "my-api-id"
+		sessionMetaKey = "sessionMetaKey"
+
+		customAuthSessionMetaValue = "customAuthSessionMetaValue"
+		customAuthSessionID        = "customAuthSessionID"
+		customAuthSessionRate      = 100
+
+		authTokenSessionMetaValue = "authTokenSessionMetaValue"
+		authTokenSessionRate      = 200
+	)
+
+	var js = fmt.Sprintf(`
+var testJSVMMiddleware = new TykJS.TykMiddleware.NewMiddleware({});
+
+testJSVMMiddleware.NewProcessRequest(function(request, session) {
+		var thisSession = {
+			"rate": %d,
+			"per": 1,
+			"quota_max": -1,	
+			"access_rights": {},
+			"meta_data": {"%s": "%s"}
+		};
+
+	return {Request:request, Session:thisSession, AuthValue:"%s"}
+});`, customAuthSessionRate, sessionMetaKey, customAuthSessionMetaValue, customAuthSessionID)
+
+	ts.RegisterJSFileMiddleware(apiID, map[string]string{
+		"auth.js": js,
+	})
+
+	api := BuildAPI(func(spec *APISpec) {
+		spec.APIID = apiID
+		spec.Proxy.ListenPath = "/"
+		spec.UseKeylessAccess = false
+		spec.EnableCoProcessAuth = true
+		spec.CustomMiddleware.Driver = apidef.OttoDriver
+		spec.CustomMiddleware.AuthCheck.Name = "testJSVMMiddleware"
+		spec.CustomMiddleware.AuthCheck.Path = ts.Gw.GetConfig().MiddlewarePath + "/my-api-id/auth.js"
+		spec.UseStandardAuth = true
+		spec.BaseIdentityProvidedBy = apidef.AuthToken
+		spec.ResponseProcessors = []apidef.ResponseProcessor{{Name: "header_injector"}}
+		spec.VersionData.Versions["v1"] = apidef.VersionInfo{
+			GlobalResponseHeaders: map[string]string{
+				sessionMetaKey: "$tyk_meta." + sessionMetaKey,
+			},
+		}
+	})[0]
+
+	_, authTokenSessionID := ts.CreateSession(func(s *user.SessionState) {
+		s.Rate = authTokenSessionRate
+		s.MetaData = map[string]interface{}{
+			sessionMetaKey: authTokenSessionMetaValue,
+		}
+		s.AccessRights = map[string]user.AccessDefinition{apiID: {
+			APIID: apiID, Versions: []string{"v1"},
+		}}
+	})
+
+	check := func(t *testing.T, baseIdentityProvidedBy apidef.AuthTypeEnum, keyName string, headerVal string, rate int) {
+		t.Helper()
+
+		api.BaseIdentityProvidedBy = baseIdentityProvidedBy
+		ts.Gw.LoadAPI(api)
+
+		_, _ = ts.Run(t, []test.TestCase{
+			{Headers: map[string]string{"Authorization": authTokenSessionID},
+				HeadersMatch: map[string]string{sessionMetaKey: headerVal}, Code: http.StatusOK},
+		}...)
+
+		retSession, found := ts.Gw.GlobalSessionManager.SessionDetail(api.OrgID, keyName, false)
+		assert.Equal(t, float64(rate), retSession.Rate)
+		assert.True(t, found)
+	}
+
+	t.Run("custom base identity", func(t *testing.T) {
+		check(t, apidef.CustomAuth, customAuthSessionID, customAuthSessionMetaValue, customAuthSessionRate)
+	})
+
+	t.Run("auth token base identity", func(t *testing.T) {
+		check(t, apidef.AuthToken, authTokenSessionID, authTokenSessionMetaValue, authTokenSessionRate)
+	})
 }
 
 func TestJSVMProcessTimeout(t *testing.T) {


### PR DESCRIPTION
[TT-8693] Support JSVM as a base identity provider in multi-auth (#4952)

This PR implements the support of using JSVM as a base identity provider
in multi-auth.
The `base_identity_provided_by` should be set as `custom_auth` and
inside javascript code the return object should set `AuthValue` to
define id of the new session to be used as a base identity.