### PR TITLE
Merging to release-4-lts: [TT-8693] Support JSVM as a base identity provider in multi-auth (#4952)

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -66,6 +66,7 @@ const (
 
 	// For multi-type auth
 	AuthToken     AuthTypeEnum = "auth_token"
+	CustomAuth    AuthTypeEnum = "custom_auth"
 	HMACKey       AuthTypeEnum = "hmac_key"
 	BasicAuthUser AuthTypeEnum = "basic_auth_user"
 	JWTClaim      AuthTypeEnum = "jwt_claim"

--- a/gateway/mw_js_plugin.go
+++ b/gateway/mw_js_plugin.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/TykTechnologies/tyk/apidef"
+
 	"github.com/robertkrimen/otto"
 	_ "github.com/robertkrimen/otto/underscore"
 
@@ -298,7 +300,11 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 
 	if d.Auth {
 		newRequestData.Session.KeyID = newRequestData.AuthValue
-		ctxSetSession(r, &newRequestData.Session, true, d.Gw.GetConfig().HashKeys)
+
+		switch d.Spec.BaseIdentityProvidedBy {
+		case apidef.CustomAuth, apidef.UnsetAuth:
+			ctxSetSession(r, &newRequestData.Session, true, d.Gw.GetConfig().HashKeys)
+		}
 	}
 
 	return nil, http.StatusOK


### PR DESCRIPTION
[TT-8693] Support JSVM as a base identity provider in multi-auth (#4952)

This PR implements the support of using JSVM as a base identity provider
in multi-auth.
The `base_identity_provided_by` should be set as `custom_auth` and
inside javascript code the return object should set `AuthValue` to
define id of the new session to be used as a base identity.