### PR TITLE
Merging to release-5-lts: [TT-8694] Support CoProcess as a base identity provider in multi-auth (#4954)

### DIFF
--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -493,7 +493,11 @@ func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 		}
 
 		returnedSession.KeyID = sessionID
-		ctxSetSession(r, returnedSession, true, m.Gw.GetConfig().HashKeys)
+
+		switch m.Spec.BaseIdentityProvidedBy {
+		case apidef.CustomAuth, apidef.UnsetAuth:
+			ctxSetSession(r, returnedSession, true, m.Gw.GetConfig().HashKeys)
+		}
 	}
 
 	return nil, http.StatusOK


### PR DESCRIPTION
[TT-8694] Support CoProcess as a base identity provider in multi-auth (#4954)

This PR implements the support of using CoProcess as a base identity
provider in multi-auth.
The `base_identity_provided_by` should be set as `custom_auth` and
inside the plugin `token` meta should be set to define id of the new
session to be used as a base identity.

[TT-8694]: https://tyktech.atlassian.net/browse/TT-8694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ