### PR TITLE
[TT-7126] add authority headers

### DIFF
--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -270,6 +270,9 @@
         "coprocess_grpc_server": {
           "type": "string"
         },
+        "grpc_authority": {
+          "type": "string"
+        },
         "enable_coprocess": {
           "type": "boolean"
         },

--- a/config/config.go
+++ b/config/config.go
@@ -234,7 +234,7 @@ type DnsCacheConfig struct {
 	TTL int64 `json:"ttl"`
 
 	CheckInterval int64 `json:"-" ignored:"true"`
-	//controls cache cleanup interval. By convention this shouldn't be exposed to a config or env_variable_setup
+	// controls cache cleanup interval. By convention this shouldn't be exposed to a config or env_variable_setup
 
 	// A strategy which will be used when a DNS query will reply with more than 1 IP Address per single host.
 	// As a DNS query response IP Addresses can have a changing order depending on DNS server balancing strategy (eg: round robin, geographically dependent origin-ip ordering, etc) this option allows you to not to limit the connection to the first host in a cached response list or prevent response caching.
@@ -453,6 +453,9 @@ type CoProcessConfig struct {
 
 	// Maximum message which can be sent to gRPC server
 	GRPCSendMaxSize int `json:"grpc_send_max_size"`
+
+	// Authority used in GRPC connection
+	GRPCAuthority string `json:"grpc_authority"`
 
 	// Sets the path to built-in Tyk modules. This will be part of the Python module lookup path. The value used here is the default one for most installations.
 	PythonPathPrefix string `json:"python_path_prefix"`

--- a/coprocess/grpc/coprocess_grpc_test.go
+++ b/coprocess/grpc/coprocess_grpc_test.go
@@ -31,6 +31,7 @@ const (
 	grpcListenAddr  = ":9999"
 	grpcListenPath  = "tcp://127.0.0.1:9999"
 	grpcTestMaxSize = 100000000
+	grpcAuthority   = "localhost"
 
 	testHeaderName  = "Testheader"
 	testHeaderValue = "testvalue"
@@ -155,7 +156,6 @@ func newTestGRPCServer() (s *grpc.Server) {
 }
 
 func loadTestGRPCAPIs(s *gateway.Test) {
-
 	s.Gw.BuildAndLoadAPI(func(spec *gateway.APISpec) {
 		spec.APIID = "1"
 		spec.OrgID = gateway.MockOrgID
@@ -455,6 +455,7 @@ func startTykWithGRPC() (*gateway.Test, *grpc.Server) {
 		CoProcessGRPCServer: grpcListenPath,
 		GRPCRecvMaxSize:     grpcTestMaxSize,
 		GRPCSendMaxSize:     grpcTestMaxSize,
+		GRPCAuthority:       grpcAuthority,
 	}
 	ts := gateway.StartTest(nil, gateway.TestConfig{
 		CoprocessConfig:   cfg,

--- a/gateway/coprocess_grpc.go
+++ b/gateway/coprocess_grpc.go
@@ -57,7 +57,6 @@ func (d *GRPCDispatcher) DispatchEvent(eventJSON []byte) {
 	}
 
 	_, err := grpcClient.DispatchEvent(context.Background(), eventObject)
-
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "coprocess",
@@ -89,10 +88,13 @@ func (gw *Gateway) NewGRPCDispatcher() (coprocess.Dispatcher, error) {
 	if gw.GetConfig().CoProcessOptions.CoProcessGRPCServer == "" {
 		return nil, errors.New("No gRPC URL is set")
 	}
+	authority := gw.GetConfig().CoProcessOptions.GRPCAuthority
+
 	var err error
 	grpcConnection, err = grpc.Dial("",
 		gw.grpcCallOpts(),
 		grpc.WithInsecure(),
+		grpc.WithAuthority(authority),
 		grpc.WithDialer(gw.dialer),
 	)
 


### PR DESCRIPTION
https://tyktech.atlassian.net/browse/TT-7126

Closes #4221 #3082 

Additional changes:

- added config schema for new `grpc_authority` config option (pass linter tests)