### PR TITLE
nested gql datasource config

### DIFF
--- a/apidef/adapter/gqlengineadapter/adapter_udg.go
+++ b/apidef/adapter/gqlengineadapter/adapter_udg.go
@@ -172,31 +172,6 @@ func (u *UniversalDataGraph) engineConfigV2DataSources() (planDataSources []plan
 	return planDataSources, err
 }
 
-func generateRestDataSourceFromGraphql(config apidef.GraphQLEngineDataSourceConfigGraphQL) (json.RawMessage, error) {
-	type reqStruct struct {
-		Query     string          `json:"query"`
-		Variables json.RawMessage `json:"variables"`
-	}
-
-	req := reqStruct{
-		Query:     config.Operation,
-		Variables: config.Variables,
-	}
-	body, err := json.Marshal(req)
-	if err != nil {
-		return nil, err
-	}
-	customMessage := restDataSource.ConfigJSON(restDataSource.Configuration{
-		Fetch: restDataSource.FetchConfiguration{
-			URL:    config.URL,
-			Method: config.Method,
-			Body:   string(body),
-			Header: convertApiDefinitionHeadersToHttpHeaders(config.Headers),
-		},
-	})
-	return customMessage, nil
-}
-
 func (u *UniversalDataGraph) engineConfigV2Arguments(fieldConfs *plan.FieldConfigurations, generatedArgs map[graphql.TypeFieldLookupKey]graphql.TypeFieldArguments) {
 	for i := range *fieldConfs {
 		if len(generatedArgs) == 0 {

--- a/apidef/adapter/gqlengineadapter/adapter_udg_test.go
+++ b/apidef/adapter/gqlengineadapter/adapter_udg_test.go
@@ -399,6 +399,29 @@ func TestUniversalDataGraph_engineConfigV2DataSources(t *testing.T) {
 		{
 			RootNodes: []plan.TypeField{
 				{
+					TypeName:   "Nested",
+					FieldNames: []string{"nestedGql"},
+				},
+			},
+			ChildNodes: nil,
+			Factory: &restDataSource.Factory{
+				Client: httpClient,
+			},
+			Custom: restDataSource.ConfigJSON(restDataSource.Configuration{
+				Fetch: restDataSource.FetchConfiguration{
+					URL:    "https://graphql.example.com",
+					Method: "POST",
+					Header: http.Header{
+						"Auth": []string{"123"},
+					},
+					Query: nil,
+					Body:  `{"operationName":"","variables":"","query":"{ fromNested }"}`,
+				},
+			}),
+		},
+		{
+			RootNodes: []plan.TypeField{
+				{
 					TypeName:   "Subscription",
 					FieldNames: []string{"foobar"},
 				},
@@ -497,6 +520,7 @@ type WithChildren implements IDType {
 type Nested {
   id: ID!
   name: String!
+  nestedGql: String!
 }
 type MultiRoot1 {
   id: ID!
@@ -677,6 +701,23 @@ var graphqlEngineV2ConfigJson = `{
 					"headers": {
 						"Auth": "123"
 					}
+				}
+			},
+			{
+				"kind": "GraphQL",
+				"internal": false,
+				"root_fields": [
+					{ "type": "Nested", "fields": ["nestedGql"] }
+				],
+				"config": {
+					"url": "https://graphql.example.com",
+					"method": "POST",
+					"headers": {
+						"Auth": "123"
+					},
+					"has_operation": true,
+					"operation": "{ fromNested }",
+					"variables": ""
 				}
 			},
 			{

--- a/apidef/adapter/gqlengineadapter/utils.go
+++ b/apidef/adapter/gqlengineadapter/utils.go
@@ -1,12 +1,19 @@
 package gqlengineadapter
 
 import (
+	"encoding/json"
+	"errors"
 	"net/http"
 
 	graphqlDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/graphql_datasource"
+	restDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/rest_datasource"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
 
 	"github.com/TykTechnologies/tyk/apidef"
+)
+
+var (
+	ErrGraphQLConfigIsMissingOperation = errors.New("graphql data source config is missing an operation")
 )
 
 func parseSchema(schemaAsString string) (parsedSchema *graphql.Schema, err error) {
@@ -75,4 +82,27 @@ func removeDuplicateApiDefinitionHeaders(headers ...map[string]string) map[strin
 		}
 	}
 	return hdr
+}
+
+func generateRestDataSourceFromGraphql(config apidef.GraphQLEngineDataSourceConfigGraphQL) (json.RawMessage, error) {
+	if !config.HasOperation {
+		return nil, ErrGraphQLConfigIsMissingOperation
+	}
+	req := graphql.Request{
+		Query:     config.Operation,
+		Variables: config.Variables,
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	customMessage := restDataSource.ConfigJSON(restDataSource.Configuration{
+		Fetch: restDataSource.FetchConfiguration{
+			URL:    config.URL,
+			Method: config.Method,
+			Body:   string(body),
+			Header: convertApiDefinitionHeadersToHttpHeaders(config.Headers),
+		},
+	})
+	return customMessage, nil
 }

--- a/apidef/adapter/gqlengineadapter/utils_test.go
+++ b/apidef/adapter/gqlengineadapter/utils_test.go
@@ -6,8 +6,9 @@ import (
 	"net/http"
 	"testing"
 
-	restDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/rest_datasource"
 	"github.com/stretchr/testify/assert"
+
+	restDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/rest_datasource"
 
 	graphqlDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/graphql_datasource"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"

--- a/apidef/adapter/gqlengineadapter/utils_test.go
+++ b/apidef/adapter/gqlengineadapter/utils_test.go
@@ -2,9 +2,11 @@ package gqlengineadapter
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
 
+	restDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/rest_datasource"
 	"github.com/stretchr/testify/assert"
 
 	graphqlDataSource "github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/graphql_datasource"
@@ -113,6 +115,53 @@ func TestRemoveDuplicateApiDefinitionHeaders(t *testing.T) {
 
 	actualDeduplicatedHeaders := removeDuplicateApiDefinitionHeaders(apiDefinitionHeadersFirstArgument, apiDefinitionHeadersSecondArgument)
 	assert.Equal(t, expectedDeduplicatedHeaders, actualDeduplicatedHeaders)
+}
+
+func TestGenerateRestDataSourceFromGraphql(t *testing.T) {
+	t.Run("should return error if generation is not possible", func(t *testing.T) {
+		gqlConfig := apidef.GraphQLEngineDataSourceConfigGraphQL{
+			URL:              "http://local.fake",
+			Method:           http.MethodPost,
+			Headers:          nil,
+			SubscriptionType: "",
+			HasOperation:     false,
+			Operation:        "{ invalidOperation }",
+			Variables:        nil,
+		}
+
+		restEngineConfig, err := generateRestDataSourceFromGraphql(gqlConfig)
+		assert.Equal(t, err, ErrGraphQLConfigIsMissingOperation)
+		assert.Nil(t, restEngineConfig)
+	})
+
+	t.Run("should convert GraphQL Data Source config to REST engine config", func(t *testing.T) {
+		gqlConfig := apidef.GraphQLEngineDataSourceConfigGraphQL{
+			URL:    "http://local.fake",
+			Method: http.MethodPost,
+			Headers: map[string]string{
+				"x-header": "header-value",
+			},
+			SubscriptionType: "",
+			HasOperation:     true,
+			Operation:        "mutation MyOp { myOperation }",
+			Variables:        json.RawMessage(`{"var":"val"}`),
+		}
+
+		expectedRestEngineConfig := restDataSource.ConfigJSON(restDataSource.Configuration{
+			Fetch: restDataSource.FetchConfiguration{
+				URL:    "http://local.fake",
+				Method: http.MethodPost,
+				Body:   `{"operationName":"","variables":{"var":"val"},"query":"mutation MyOp { myOperation }"}`,
+				Header: http.Header{
+					"X-Header": []string{"header-value"},
+				},
+			},
+		})
+
+		actualRestEngineConfig, err := generateRestDataSourceFromGraphql(gqlConfig)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedRestEngineConfig, actualRestEngineConfig)
+	})
 }
 
 var mockSubscriptionClient = &graphqlDataSource.SubscriptionClient{}

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -822,6 +822,9 @@ type GraphQLEngineDataSourceConfigGraphQL struct {
 	Method           string            `bson:"method" json:"method"`
 	Headers          map[string]string `bson:"headers" json:"headers"`
 	SubscriptionType SubscriptionType  `bson:"subscription_type" json:"subscription_type,omitempty"`
+	HasOperation     bool              `bson:"has_operation" json:"has_operation"`
+	Operation        string            `bson:"operation" json:"operation"`
+	Variables        json.RawMessage   `bson:"variables" json:"variables"`
 }
 
 type GraphQLEngineDataSourceConfigKafka struct {


### PR DESCRIPTION
This PR adds new fields to the API definition for GraphQL Data sources, so that they can be used as nested data sources.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

