### PR TITLE
[TT-8728] OAS - Minor issues with imported Tyk API definition

### DIFF
--- a/apidef/adapter/openapi.go
+++ b/apidef/adapter/openapi.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"path"
 
 	"github.com/getkin/kin-openapi/openapi3"
 
@@ -75,6 +76,7 @@ func (o *openAPI) prepareGraphQLEngineConfig() error {
 				}
 				parsedEndpoint.Scheme = server.Scheme
 				parsedEndpoint.Host = server.Host
+				parsedEndpoint.Path = path.Join(server.Path, parsedEndpoint.Path)
 
 				query := parsedEndpoint.Query()
 				for _, parameter := range operation.Parameters {
@@ -96,9 +98,10 @@ func (o *openAPI) prepareGraphQLEngineConfig() error {
 				}
 
 				fieldConfig := apidef.GraphQLFieldConfig{
-					TypeName:  graphqlType,
-					FieldName: fieldName,
-					Path:      []string{fieldName},
+					TypeName:              graphqlType,
+					FieldName:             fieldName,
+					DisableDefaultMapping: true, // See TT-TT-8728
+					Path:                  []string{fieldName},
 				}
 				o.apiDefinition.GraphQL.Engine.FieldConfigs = append(o.apiDefinition.GraphQL.Engine.FieldConfigs, fieldConfig)
 

--- a/apidef/adapter/openapi_test.go
+++ b/apidef/adapter/openapi_test.go
@@ -187,7 +187,7 @@ const expectedOpenAPIGraphQLConfig = `{
             {
                 "type_name": "Mutation",
                 "field_name": "addPet",
-                "disable_default_mapping": false,
+                "disable_default_mapping": true,
                 "path": [
                     "addPet"
                 ]
@@ -195,7 +195,7 @@ const expectedOpenAPIGraphQLConfig = `{
             {
                 "type_name": "Mutation",
                 "field_name": "deletePet",
-                "disable_default_mapping": false,
+                "disable_default_mapping": true,
                 "path": [
                     "deletePet"
                 ]
@@ -203,7 +203,7 @@ const expectedOpenAPIGraphQLConfig = `{
             {
                 "type_name": "Query",
                 "field_name": "findPetById",
-                "disable_default_mapping": false,
+                "disable_default_mapping": true,
                 "path": [
                     "findPetById"
                 ]
@@ -211,7 +211,7 @@ const expectedOpenAPIGraphQLConfig = `{
             {
                 "type_name": "Query",
                 "field_name": "findPets",
-                "disable_default_mapping": false,
+                "disable_default_mapping": true,
                 "path": [
                     "findPets"
                 ]
@@ -231,7 +231,7 @@ const expectedOpenAPIGraphQLConfig = `{
                     }
                 ],
                 "config": {
-                    "url": "http://petstore.swagger.io/pets",
+                    "url": "http://petstore.swagger.io/api/pets",
                     "method": "POST",
                     "headers": {},
                     "query": [],
@@ -251,7 +251,7 @@ const expectedOpenAPIGraphQLConfig = `{
                     }
                 ],
                 "config": {
-                    "url": "http://petstore.swagger.io/pets/{{.arguments.id}}",
+                    "url": "http://petstore.swagger.io/api/pets/{{.arguments.id}}",
                     "method": "DELETE",
                     "headers": {},
                     "query": [],
@@ -271,7 +271,7 @@ const expectedOpenAPIGraphQLConfig = `{
                     }
                 ],
                 "config": {
-                    "url": "http://petstore.swagger.io/pets/{{.arguments.id}}",
+                    "url": "http://petstore.swagger.io/api/pets/{{.arguments.id}}",
                     "method": "GET",
                     "headers": {},
                     "query": [],
@@ -291,7 +291,7 @@ const expectedOpenAPIGraphQLConfig = `{
                     }
                 ],
                 "config": {
-                    "url": "http://petstore.swagger.io/pets?limit={{.arguments.limit}}\u0026tags={{.arguments.tags}}",
+                    "url": "http://petstore.swagger.io/api/pets?limit={{.arguments.limit}}\u0026tags={{.arguments.tags}}",
                     "method": "GET",
                     "headers": {},
                     "query": [],


### PR DESCRIPTION
PR for [TT-8728](https://tyktech.atlassian.net/jira/software/c/projects/TT/boards/26?modal=detail&selectedIssue=TT-8728)

This PR includes the fixes for the following:

- Field mapping for REST data sources should be disabled by default (that’s the standard behavior for UDG APIs). Otherwise, the imported UDG API’s data sources don’t work.
- Data source URLs are not correctly created from the OAS spec.

[TT-8728]: https://tyktech.atlassian.net/browse/TT-8728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ