### PR TITLE
Get gateway src from github in plugin compiler

### DIFF
--- a/ci/goreleaser/goreleaser.yml
+++ b/ci/goreleaser/goreleaser.yml
@@ -136,6 +136,7 @@ dockers:
     - "--label=org.opencontainers.image.version={{.Version}}"
     - "--build-arg=TYK_GW_TAG={{ .Tag }}"
     - "--build-arg=GOLANG_CROSS={{ .Env.GOLANG_CROSS }}"
+    - "--build-arg=GITHUB_SHA={{ .Env.GITHUB_SHA }}"
   goarch: amd64
   goos: linux
   dockerfile: ci/images/plugin-compiler/Dockerfile

--- a/ci/images/plugin-compiler/Dockerfile
+++ b/ci/images/plugin-compiler/Dockerfile
@@ -19,8 +19,7 @@ RUN chmod +x /build.sh
 RUN  apt-get remove -y --allow-remove-essential --auto-remove mercurial \
 	&& rm /usr/bin/passwd && rm /usr/sbin/adduser
 
-
-COPY . $TYK_GW_PATH
+RUN curl -L -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/TykTechnologies/tyk/tarball/$GITUHB_SHA --output - | tar --strip-components 1 -C $TYK_GW_PATH -xzf -
 RUN cd $TYK_GW_PATH
 
 ENTRYPOINT ["/build.sh"]


### PR DESCRIPTION
Update plugin compiler docker image to get the gateway source directly from github (using the tarballs api)