### PR TITLE
[TT-2949] add validation for allowedIPs and blacklisted IPs when enabled

### DIFF
--- a/apidef/validator.go
+++ b/apidef/validator.go
@@ -139,7 +139,7 @@ func shouldValidateAuthSource(authType string, apiDef *APIDefinition) bool {
 	return false
 }
 
-var ErrInvalidIPCIDR = "invalid IP/CIDR %s"
+var ErrInvalidIPCIDR = "invalid IP/CIDR %q"
 
 type RuleValidateIPList struct{}
 
@@ -162,8 +162,12 @@ func (r *RuleValidateIPList) Validate(apiDef *APIDefinition, validationResult *V
 func (r *RuleValidateIPList) validateIPAddr(ips []string) []error {
 	var errs []error
 	for _, ip := range ips {
-		_, _, err := net.ParseCIDR(ip)
-		if err == nil {
+		if strings.Count(ip, "/") == 1 {
+			_, _, err := net.ParseCIDR(ip)
+			if err != nil {
+				errs = append(errs, fmt.Errorf(ErrInvalidIPCIDR, ip))
+			}
+
 			continue
 		}
 

--- a/apidef/validator_test.go
+++ b/apidef/validator_test.go
@@ -217,3 +217,96 @@ func TestRuleAtLeastEnableOneAuthConfig_Validate(t *testing.T) {
 		},
 	))
 }
+
+func TestRuleValidateIPList_Validate(t *testing.T) {
+	ruleSet := ValidationRuleSet{
+		&RuleValidateIPList{},
+	}
+
+	t.Run("valid IP and CIDR", runValidationTest(
+		&APIDefinition{
+			EnableIpWhiteListing: true,
+			AllowedIPs: []string{
+				"192.168.0.10",
+				"192.168.2.1/24",
+			},
+			EnableIpBlacklisting: true,
+			BlacklistedIPs: []string{
+				"192.168.0.20",
+				"192.168.3.1/24",
+			},
+		},
+		ruleSet,
+		ValidationResult{
+			IsValid: true,
+			Errors:  nil,
+		},
+	))
+
+	t.Run("invalid IP and CIDR", runValidationTest(
+		&APIDefinition{
+			EnableIpWhiteListing: true,
+			AllowedIPs: []string{
+				"bob",
+				"192.168.2.1/24",
+			},
+			EnableIpBlacklisting: true,
+			BlacklistedIPs: []string{
+				"blah",
+				"192.168.3.1/24",
+			},
+		},
+		ruleSet,
+		ValidationResult{
+			IsValid: false,
+			Errors: []error{
+				fmt.Errorf(ErrInvalidIPCIDR, "bob"),
+				fmt.Errorf(ErrInvalidIPCIDR, "blah"),
+			},
+		},
+	))
+
+	t.Run("do not validate allowed IPs when whitelisting not enabled", runValidationTest(
+		&APIDefinition{
+			EnableIpWhiteListing: false,
+			AllowedIPs: []string{
+				"bob",
+				"192.168.2.1/24",
+			},
+			EnableIpBlacklisting: true,
+			BlacklistedIPs: []string{
+				"blah",
+				"192.168.3.1/24",
+			},
+		},
+		ruleSet,
+		ValidationResult{
+			IsValid: false,
+			Errors: []error{
+				fmt.Errorf(ErrInvalidIPCIDR, "blah"),
+			},
+		},
+	))
+
+	t.Run("do not validate blacklist when not enabled", runValidationTest(
+		&APIDefinition{
+			EnableIpWhiteListing: true,
+			AllowedIPs: []string{
+				"bob",
+				"192.168.2.1/24",
+			},
+			EnableIpBlacklisting: false,
+			BlacklistedIPs: []string{
+				"blah",
+				"192.168.3.1/24",
+			},
+		},
+		ruleSet,
+		ValidationResult{
+			IsValid: false,
+			Errors: []error{
+				fmt.Errorf(ErrInvalidIPCIDR, "bob"),
+			},
+		},
+	))
+}

--- a/apidef/validator_test.go
+++ b/apidef/validator_test.go
@@ -243,6 +243,27 @@ func TestRuleValidateIPList_Validate(t *testing.T) {
 		},
 	))
 
+	t.Run("invalid CIDR", runValidationTest(
+		&APIDefinition{
+			EnableIpWhiteListing: true,
+			AllowedIPs: []string{
+				"192.168.2.1/bob",
+			},
+			EnableIpBlacklisting: true,
+			BlacklistedIPs: []string{
+				"192.168.3.1/blah",
+			},
+		},
+		ruleSet,
+		ValidationResult{
+			IsValid: false,
+			Errors: []error{
+				fmt.Errorf(ErrInvalidIPCIDR, "192.168.2.1/bob"),
+				fmt.Errorf(ErrInvalidIPCIDR, "192.168.3.1/blah"),
+			},
+		},
+	))
+
 	t.Run("invalid IP and CIDR", runValidationTest(
 		&APIDefinition{
 			EnableIpWhiteListing: true,

--- a/gateway/mw_ip_blacklist.go
+++ b/gateway/mw_ip_blacklist.go
@@ -40,8 +40,7 @@ func (i *IPBlackListMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Re
 		}
 
 		// We parse the IP to manage IPv4 and IPv6 easily
-		if blockedIP.Equal(remoteIP) {
-
+		if blockedIP != nil && remoteIP != nil && blockedIP.Equal(remoteIP) {
 			return i.handleError(r, remoteIP.String())
 		}
 	}

--- a/gateway/mw_ip_blacklist.go
+++ b/gateway/mw_ip_blacklist.go
@@ -40,7 +40,7 @@ func (i *IPBlackListMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Re
 		}
 
 		// We parse the IP to manage IPv4 and IPv6 easily
-		if blockedIP != nil && remoteIP != nil && blockedIP.Equal(remoteIP) {
+		if blockedIP.Equal(remoteIP) {
 			return i.handleError(r, remoteIP.String())
 		}
 	}

--- a/gateway/mw_ip_blacklist_test.go
+++ b/gateway/mw_ip_blacklist_test.go
@@ -4,23 +4,26 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/TykTechnologies/tyk/header"
 )
 
 var testBlackListIPData = []struct {
-	remote, forwarded string
-	wantCode          int
+	remote, forwarded, xRealIP string
+	wantCode                   int
 }{
-	{"127.0.0.1:80", "", http.StatusForbidden},         // remote exact match
-	{"127.0.0.2:80", "", http.StatusForbidden},         // remote CIDR match
-	{"10.0.0.1:80", "", http.StatusOK},                 // no match
-	{"10.0.0.1:80", "127.0.0.1", http.StatusForbidden}, // forwarded exact match
-	{"10.0.0.1:80", "127.0.0.2", http.StatusForbidden}, // forwarded CIDR match
+	{"127.0.0.1:80", "", "", http.StatusForbidden},         // remote exact match
+	{"127.0.0.2:80", "", "", http.StatusForbidden},         // remote CIDR match
+	{"10.0.0.1:80", "", "", http.StatusOK},                 // no match
+	{"10.0.0.1:80", "127.0.0.1", "", http.StatusForbidden}, // forwarded exact match
+	{"10.0.0.1:80", "127.0.0.2", "", http.StatusForbidden}, // forwarded CIDR match
+	{"10.0.0.1:80", "", "bob", http.StatusOK},              // no match
 }
 
 func testPrepareIPBlacklistMiddleware() *APISpec {
 	return BuildAPI(func(spec *APISpec) {
 		spec.EnableIpBlacklisting = true
-		spec.BlacklistedIPs = []string{"127.0.0.1", "127.0.0.1/24"}
+		spec.BlacklistedIPs = []string{"127.0.0.1", "127.0.0.1/24", "bob"}
 	})[0]
 }
 
@@ -33,6 +36,10 @@ func TestIPBlacklistMiddleware(t *testing.T) {
 		req.RemoteAddr = tc.remote
 		if tc.forwarded != "" {
 			req.Header.Set("X-Forwarded-For", tc.forwarded)
+		}
+
+		if tc.xRealIP != "" {
+			req.Header.Set(header.XRealIP, tc.xRealIP)
 		}
 
 		mw := &IPBlackListMiddleware{}
@@ -62,6 +69,11 @@ func BenchmarkIPBlacklistMiddleware(b *testing.B) {
 			if tc.forwarded != "" {
 				req.Header.Set("X-Forwarded-For", tc.forwarded)
 			}
+
+			if tc.xRealIP != "" {
+				req.Header.Set(header.XRealIP, tc.xRealIP)
+			}
+
 			_, code := mw.ProcessRequest(rec, req, nil)
 			if code != tc.wantCode {
 				b.Errorf("[%d] Response code %d should be %d\n%q %q", ti,

--- a/gateway/mw_ip_whitelist.go
+++ b/gateway/mw_ip_whitelist.go
@@ -40,7 +40,7 @@ func (i *IPWhiteListMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Re
 		}
 
 		// We parse the IP to manage IPv4 and IPv6 easily
-		if allowedIP.Equal(remoteIP) {
+		if allowedIP != nil && remoteIP != nil && allowedIP.Equal(remoteIP) {
 			// matched, pass through
 			return nil, http.StatusOK
 		}

--- a/gateway/mw_ip_whitelist.go
+++ b/gateway/mw_ip_whitelist.go
@@ -40,7 +40,7 @@ func (i *IPWhiteListMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Re
 		}
 
 		// We parse the IP to manage IPv4 and IPv6 easily
-		if allowedIP != nil && remoteIP != nil && allowedIP.Equal(remoteIP) {
+		if allowedIP.Equal(remoteIP) {
 			// matched, pass through
 			return nil, http.StatusOK
 		}

--- a/gateway/mw_ip_whitelist_test.go
+++ b/gateway/mw_ip_whitelist_test.go
@@ -4,23 +4,26 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/TykTechnologies/tyk/header"
 )
 
 var testWhiteListIPData = []struct {
-	remote, forwarded string
-	wantCode          int
+	remote, forwarded, xRealIP string
+	wantCode                   int
 }{
-	{"127.0.0.1:80", "", http.StatusOK},         // remote exact match
-	{"127.0.0.2:80", "", http.StatusOK},         // remote CIDR match
-	{"10.0.0.1:80", "", http.StatusForbidden},   // no match
-	{"10.0.0.1:80", "127.0.0.1", http.StatusOK}, // forwarded exact match
-	{"10.0.0.1:80", "127.0.0.2", http.StatusOK}, // forwarded CIDR match
+	{"127.0.0.1:80", "", "", http.StatusOK},          // remote exact match
+	{"127.0.0.2:80", "", "", http.StatusOK},          // remote CIDR match
+	{"10.0.0.1:80", "", "", http.StatusForbidden},    // no match
+	{"10.0.0.1:80", "127.0.0.1", "", http.StatusOK},  // forwarded exact match
+	{"10.0.0.1:80", "127.0.0.2", "", http.StatusOK},  // forwarded CIDR match
+	{"10.0.0.1:80", "", "bob", http.StatusForbidden}, // no match
 }
 
 func testPrepareIPMiddlewarePass() *APISpec {
 	return BuildAPI(func(spec *APISpec) {
 		spec.EnableIpWhiteListing = true
-		spec.AllowedIPs = []string{"127.0.0.1", "127.0.0.1/24"}
+		spec.AllowedIPs = []string{"127.0.0.1", "127.0.0.1/24", "bob"}
 	})[0]
 }
 
@@ -35,13 +38,17 @@ func TestIPMiddlewarePass(t *testing.T) {
 			req.Header.Set("X-Forwarded-For", tc.forwarded)
 		}
 
+		if tc.xRealIP != "" {
+			req.Header.Set(header.XRealIP, tc.xRealIP)
+		}
+
 		mw := &IPWhiteListMiddleware{}
 		mw.Spec = spec
 		_, code := mw.ProcessRequest(rec, req, nil)
 
 		if code != tc.wantCode {
-			t.Errorf("[%d] Response code %d should be %d\n%q %q", ti,
-				code, tc.wantCode, tc.remote, tc.forwarded)
+			t.Errorf("[%d] Response code %d should be %d\n%q %q %q", ti,
+				code, tc.wantCode, tc.remote, tc.forwarded, tc.xRealIP)
 		}
 	}
 }
@@ -62,11 +69,15 @@ func BenchmarkIPMiddlewarePass(b *testing.B) {
 				req.Header.Set("X-Forwarded-For", tc.forwarded)
 			}
 
+			if tc.xRealIP != "" {
+				req.Header.Set(header.XRealIP, tc.xRealIP)
+			}
+
 			_, code := mw.ProcessRequest(rec, req, nil)
 
 			if code != tc.wantCode {
-				b.Errorf("[%d] Response code %d should be %d\n%q %q", ti,
-					code, tc.wantCode, tc.remote, tc.forwarded)
+				b.Errorf("[%d] Response code %d should be %d\n%q %q %q", ti,
+					code, tc.wantCode, tc.remote, tc.forwarded, tc.xRealIP)
 			}
 		}
 	}

--- a/request/real_ip.go
+++ b/request/real_ip.go
@@ -15,18 +15,21 @@ func RealIP(r *http.Request) string {
 		return contextIp.(string)
 	}
 
-	if realIP := r.Header.Get(header.XRealIP); realIP != "" {
-		return realIP
+	if realIPVal := r.Header.Get(header.XRealIP); realIPVal != "" {
+		if realIP := net.ParseIP(realIPVal); realIP != nil {
+			return realIP.String()
+		}
 	}
 
 	if fw := r.Header.Get(header.XForwardFor); fw != "" {
 		// X-Forwarded-For has no port
 		if i := strings.IndexByte(fw, ','); i >= 0 {
-
-			return fw[:i]
+			fw = fw[:i]
 		}
 
-		return fw
+		if fwIP := net.ParseIP(fw); fwIP != nil {
+			return fwIP.String()
+		}
 	}
 
 	// From net/http.Request.RemoteAddr:

--- a/request/real_ip_test.go
+++ b/request/real_ip_test.go
@@ -17,6 +17,8 @@ var ipHeaderTests = []struct {
 	{remoteAddr: "10.0.1.4:8080", key: "X-Forwarded-For", value: "10.0.0.2", expected: "10.0.0.2", comment: "X-Forwarded-For (single)"},
 	{remoteAddr: "10.0.1.4:8080", key: "X-Forwarded-For", value: "10.0.0.3, 10.0.0.2, 10.0.0.1", expected: "10.0.0.3", comment: "X-Forwarded-For (multiple)"},
 	{remoteAddr: "10.0.1.4:8080", expected: "10.0.1.4", comment: "RemoteAddr"},
+	{remoteAddr: "10.0.1.4:8080", key: "X-Forwarded-For", value: "bob", expected: "10.0.1.4", comment: "invalid X-Forwarded-For"},
+	{remoteAddr: "10.0.1.4:8080", key: "X-Real-IP", value: "bob", expected: "10.0.1.4", comment: "invalid X-Real-IP"},
 }
 
 func TestRealIP(t *testing.T) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
https://tyktech.atlassian.net/browse/TT-2949
This is caused when `allowedIP` and `requestIP` are `nil`. 
https://pkg.go.dev/net#IP.Equal reports true when both are nil.

https://go.dev/play/p/LuTGi2_fVza - The issue can be seen here

