### PR TITLE
TT-3980 if control api not requires mutual tls then not ask for cert

### DIFF
--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -1003,7 +1003,8 @@ func (gw *Gateway) loadApps(specs []*APISpec) {
 
 	mainLog.Info("Initialised API Definitions")
 
-	controlApiIsConfigured := gw.GetConfig().ControlAPIPort != 0 || gw.GetConfig().ControlAPIHostname != ""
+	gwListenPort := gw.GetConfig().ListenPort
+	controlApiIsConfigured := (gw.GetConfig().ControlAPIPort != 0 && gw.GetConfig().ControlAPIPort != gwListenPort) || gw.GetConfig().ControlAPIHostname != ""
 	if gw.allApisAreMTLS() && !gw.GetConfig().Security.ControlAPIUseMutualTLS && !controlApiIsConfigured {
 		mainLog.Warning("All APIs are protected with mTLS, except for the control API. " +
 			"We recommend configuring the control API port or control hostname to ensure consistent security measures")

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -1005,7 +1005,8 @@ func (gw *Gateway) loadApps(specs []*APISpec) {
 
 	controlApiIsConfigured := gw.GetConfig().ControlAPIPort != 0 || gw.GetConfig().ControlAPIHostname != ""
 	if gw.AllApisAreMTLS() && !gw.GetConfig().Security.ControlAPIUseMutualTLS && !controlApiIsConfigured {
-		mainLog.Warning("All APIs are protected with mTLS, except for the control API. We recommend configuring the control API port or control hostname to ensure consistent security measures")
+		mainLog.Warning("All APIs are protected with mTLS, except for the control API. " +
+			"We recommend configuring the control API port or control hostname to ensure consistent security measures")
 	}
 }
 

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -1004,13 +1004,13 @@ func (gw *Gateway) loadApps(specs []*APISpec) {
 	mainLog.Info("Initialised API Definitions")
 
 	controlApiIsConfigured := gw.GetConfig().ControlAPIPort != 0 || gw.GetConfig().ControlAPIHostname != ""
-	if gw.AllApisAreMTLS() && !gw.GetConfig().Security.ControlAPIUseMutualTLS && !controlApiIsConfigured {
+	if gw.allApisAreMTLS() && !gw.GetConfig().Security.ControlAPIUseMutualTLS && !controlApiIsConfigured {
 		mainLog.Warning("All APIs are protected with mTLS, except for the control API. " +
 			"We recommend configuring the control API port or control hostname to ensure consistent security measures")
 	}
 }
 
-func (gw *Gateway) AllApisAreMTLS() bool {
+func (gw *Gateway) allApisAreMTLS() bool {
 	for _, api := range gw.apisByID {
 		if !api.UseMutualTLSAuth && api.Active {
 			return false

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -1012,6 +1012,8 @@ func (gw *Gateway) loadApps(specs []*APISpec) {
 }
 
 func (gw *Gateway) allApisAreMTLS() bool {
+	gw.apisMu.RLock()
+	defer gw.apisMu.RUnlock()
 	for _, api := range gw.apisByID {
 		if !api.UseMutualTLSAuth && api.Active {
 			return false

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -1003,4 +1003,18 @@ func (gw *Gateway) loadApps(specs []*APISpec) {
 
 	mainLog.Info("Initialised API Definitions")
 
+	controlApiIsConfigured := gw.GetConfig().ControlAPIPort != 0 || gw.GetConfig().ControlAPIHostname != ""
+	if gw.AllApisAreMTLS() && !gw.GetConfig().Security.ControlAPIUseMutualTLS && !controlApiIsConfigured {
+		mainLog.Warning("All APIs are protected with mTLS, except for the control API. We recommend configuring the control API port or control hostname to ensure consistent security measures")
+	}
+}
+
+func (gw *Gateway) AllApisAreMTLS() bool {
+	for _, api := range gw.apisByID {
+		if !api.UseMutualTLSAuth && api.Active {
+			return false
+		}
+	}
+
+	return true
 }

--- a/gateway/api_loader_test.go
+++ b/gateway/api_loader_test.go
@@ -408,7 +408,7 @@ func TestAllApisAreMTLS(t *testing.T) {
 	gw.apisByID[spec2.APIID] = spec2
 	gw.apisByID[spec3.APIID] = spec3
 
-	result := gw.AllApisAreMTLS()
+	result := gw.allApisAreMTLS()
 
 	expected := true
 	if result != expected {
@@ -419,7 +419,7 @@ func TestAllApisAreMTLS(t *testing.T) {
 	spec3.UseMutualTLSAuth = false
 
 	// Call the method again
-	result = gw.AllApisAreMTLS()
+	result = gw.allApisAreMTLS()
 
 	expected = false
 	if result != expected {

--- a/gateway/api_loader_test.go
+++ b/gateway/api_loader_test.go
@@ -2,13 +2,14 @@ package gateway
 
 import (
 	"fmt"
-	"github.com/TykTechnologies/storage/persistent/model"
-	"github.com/TykTechnologies/tyk/apidef"
 	"net/http"
 	"path"
 	_ "path"
 	"sync/atomic"
 	"testing"
+
+	"github.com/TykTechnologies/storage/persistent/model"
+	"github.com/TykTechnologies/tyk/apidef"
 
 	"github.com/stretchr/testify/assert"
 
@@ -419,7 +420,7 @@ func TestAllApisAreMTLS(t *testing.T) {
 
 	// Call the method again
 	result = gw.AllApisAreMTLS()
-	
+
 	expected = false
 	if result != expected {
 		t.Errorf("Expected AllApisAreMTLS to return %v, but got %v", expected, result)

--- a/gateway/api_loader_test.go
+++ b/gateway/api_loader_test.go
@@ -2,13 +2,13 @@ package gateway
 
 import (
 	"fmt"
+	"github.com/TykTechnologies/storage/persistent/model"
+	"github.com/TykTechnologies/tyk/apidef"
 	"net/http"
 	"path"
 	_ "path"
 	"sync/atomic"
 	"testing"
-
-	"github.com/TykTechnologies/storage/persistent/model"
 
 	"github.com/stretchr/testify/assert"
 
@@ -371,4 +371,57 @@ func TestTykRateLimitsStatusOfAPI(t *testing.T) {
 		quotaMax, quotaRemaining, rate, per)
 
 	_, _ = g.Run(t, test.TestCase{Path: "/my-api/tyk/rate-limits/", Headers: authHeader, BodyMatch: bodyMatch, Code: http.StatusOK})
+}
+
+func TestAllApisAreMTLS(t *testing.T) {
+	// Create a new instance of the Gateway
+	gw := &Gateway{
+		apisByID: make(map[string]*APISpec),
+	}
+
+	// Define API specs
+	spec1 := &APISpec{
+		APIDefinition: &apidef.APIDefinition{
+			UseMutualTLSAuth: true,
+			Active:           true,
+			APIID:            "api1",
+		},
+	}
+	spec2 := &APISpec{
+		APIDefinition: &apidef.APIDefinition{
+			UseMutualTLSAuth: true,
+			Active:           true,
+			APIID:            "api2",
+		},
+	}
+	spec3 := &APISpec{
+		APIDefinition: &apidef.APIDefinition{
+			UseMutualTLSAuth: true,
+			Active:           true,
+			APIID:            "api3",
+		},
+	}
+
+	// Add API specs to the gateway
+	gw.apisByID[spec1.APIID] = spec1
+	gw.apisByID[spec2.APIID] = spec2
+	gw.apisByID[spec3.APIID] = spec3
+
+	result := gw.AllApisAreMTLS()
+
+	expected := true
+	if result != expected {
+		t.Errorf("Expected AllApisAreMTLS to return %v, but got %v", expected, result)
+	}
+
+	// Change one API to not use mutual TLS authentication
+	spec3.UseMutualTLSAuth = false
+
+	// Call the method again
+	result = gw.AllApisAreMTLS()
+	
+	expected = false
+	if result != expected {
+		t.Errorf("Expected AllApisAreMTLS to return %v, but got %v", expected, result)
+	}
 }

--- a/gateway/cert.go
+++ b/gateway/cert.go
@@ -374,17 +374,17 @@ func (gw *Gateway) getTLSConfigForClient(baseConfig *tls.Config, listenPort int)
 		fmt.Printf("\nControl api hostname: %v\n", gwConfig.ControlAPIHostname)
 		fmt.Printf("\nhello server name: %v\n", hello.ServerName)
 		domainRequireCert := map[string]tls.ClientAuthType{}
-		if isControlAPI && gwConfig.Security.ControlAPIUseMutualTLS {
-			newConfig.ClientAuth = tls.RequireAndVerifyClientCert
-			newConfig.ClientCAs = gw.CertificateManager.CertPool(gwConfig.Security.Certificates.ControlAPI)
 
-			tlsConfigCache.Set(hello.ServerName, newConfig, cache.DefaultExpiration)
+		if isControlAPI {
+			if gwConfig.Security.ControlAPIUseMutualTLS {
+				newConfig.ClientAuth = tls.RequireAndVerifyClientCert
+				newConfig.ClientCAs = gw.CertificateManager.CertPool(gwConfig.Security.Certificates.ControlAPI)
 
-			fmt.Printf("\n==========1=============\n")
-			fmt.Printf("\n%+v\n", newConfig)
-			return newConfig, nil
-		} else if isControlAPI {
-			// is control api but not mutual tls is required
+				tlsConfigCache.Set(hello.ServerName, newConfig, cache.DefaultExpiration)
+				return newConfig, nil
+			}
+
+			// Control API without mutual TLS
 			domainRequireCert[hello.ServerName] = -1
 		}
 

--- a/gateway/cert.go
+++ b/gateway/cert.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -304,17 +303,6 @@ func getClientValidator(helloInfo *tls.ClientHelloInfo, certPool *x509.CertPool)
 
 		return err
 	}
-}
-
-func (gw *Gateway) AllApisAreMTLS() bool {
-	for _, api := range gw.apisByID {
-		fmt.Printf("\nname: %v active: %v mtls: %v\n", api.Name, api.Active, api.UseMutualTLSAuth)
-		if !api.UseMutualTLSAuth && api.Active {
-			return false
-		}
-	}
-
-	return true
 }
 
 func (gw *Gateway) getTLSConfigForClient(baseConfig *tls.Config, listenPort int) func(hello *tls.ClientHelloInfo) (*tls.Config, error) {

--- a/gateway/cert.go
+++ b/gateway/cert.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -370,6 +371,8 @@ func (gw *Gateway) getTLSConfigForClient(baseConfig *tls.Config, listenPort int)
 		isControlAPI := (listenPort != 0 && gwConfig.ControlAPIPort == listenPort) || (gwConfig.ControlAPIHostname == hello.ServerName)
 		domainRequireCert := map[string]tls.ClientAuthType{}
 
+		fmt.Println("api hostname: " + gwConfig.ControlAPIHostname)
+		fmt.Println(gwConfig.ControlAPIHostname == hello.ServerName)
 		if isControlAPI {
 			if gwConfig.Security.ControlAPIUseMutualTLS {
 				newConfig.ClientAuth = tls.RequireAndVerifyClientCert
@@ -379,6 +382,7 @@ func (gw *Gateway) getTLSConfigForClient(baseConfig *tls.Config, listenPort int)
 				return newConfig, nil
 			}
 
+			fmt.Println("era controlllll========")
 			// Control API without mutual TLS
 			domainRequireCert[hello.ServerName] = -1
 		}

--- a/gateway/cert.go
+++ b/gateway/cert.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -369,10 +368,6 @@ func (gw *Gateway) getTLSConfigForClient(baseConfig *tls.Config, listenPort int)
 		}
 
 		isControlAPI := (listenPort != 0 && gwConfig.ControlAPIPort == listenPort) || (gwConfig.ControlAPIHostname == hello.ServerName)
-		fmt.Printf("\n Listen port: %v \n", listenPort)
-		fmt.Printf("\nControl api port: %v\n", gwConfig.ControlAPIPort)
-		fmt.Printf("\nControl api hostname: %v\n", gwConfig.ControlAPIHostname)
-		fmt.Printf("\nhello server name: %v\n", hello.ServerName)
 		domainRequireCert := map[string]tls.ClientAuthType{}
 
 		if isControlAPI {
@@ -404,12 +399,10 @@ func (gw *Gateway) getTLSConfigForClient(baseConfig *tls.Config, listenPort int)
 		for _, spec := range gw.apiSpecs {
 			switch {
 			case spec.UseMutualTLSAuth:
-				// si el dominio es el mismo q control api, entonces si puede pedirlo
 				if domainRequireCert[spec.Domain] == 0 {
 					// Require verification only if there is a single known domain for TLS auth, otherwise use previous value
 					domainRequireCert[spec.Domain] = tls.RequireAndVerifyClientCert
 				} else if domainRequireCert[spec.Domain] != tls.RequireAndVerifyClientCert {
-					fmt.Println(domainRequireCert[spec.Domain])
 					// If we have another API on this domain, which is not mutual tls enabled, just ask for cert
 					domainRequireCert[spec.Domain] = tls.RequestClientCert
 				}

--- a/gateway/cert.go
+++ b/gateway/cert.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -371,8 +370,6 @@ func (gw *Gateway) getTLSConfigForClient(baseConfig *tls.Config, listenPort int)
 		isControlAPI := (listenPort != 0 && gwConfig.ControlAPIPort == listenPort) || (gwConfig.ControlAPIHostname == hello.ServerName)
 		domainRequireCert := map[string]tls.ClientAuthType{}
 
-		fmt.Println("api hostname: " + gwConfig.ControlAPIHostname)
-		fmt.Println(gwConfig.ControlAPIHostname == hello.ServerName)
 		if isControlAPI {
 			if gwConfig.Security.ControlAPIUseMutualTLS {
 				newConfig.ClientAuth = tls.RequireAndVerifyClientCert
@@ -382,7 +379,6 @@ func (gw *Gateway) getTLSConfigForClient(baseConfig *tls.Config, listenPort int)
 				return newConfig, nil
 			}
 
-			fmt.Println("era controlllll========")
 			// Control API without mutual TLS
 			domainRequireCert[hello.ServerName] = -1
 		}

--- a/gateway/cert.go
+++ b/gateway/cert.go
@@ -370,7 +370,7 @@ func (gw *Gateway) getTLSConfigForClient(baseConfig *tls.Config, listenPort int)
 		// not ControlAPIHostname has been configured or the hostName is the same in the hello handshake
 		isControlHostName := gwConfig.ControlAPIHostname == "" || (gwConfig.ControlAPIHostname == hello.ServerName)
 		// target port is the same where control api lives
-		isControlPort := gwConfig.ControlAPIPort == 0 || (gwConfig.ControlAPIPort == listenPort && listenPort != 0)
+		isControlPort := (gwConfig.ControlAPIPort == 0 && listenPort == gwConfig.ListenPort) || (gwConfig.ControlAPIPort == listenPort && listenPort != 0)
 		isControlAPI := isControlHostName && isControlPort
 
 		if isControlAPI && gwConfig.Security.ControlAPIUseMutualTLS {
@@ -496,6 +496,7 @@ func (gw *Gateway) getTLSConfigForClient(baseConfig *tls.Config, listenPort int)
 		}
 
 		if newConfig.ClientAuth == tls.RequireAndVerifyClientCert && isControlAPI && !gwConfig.Security.ControlAPIUseMutualTLS {
+
 			newConfig.ClientAuth = tls.RequestClientCert
 		}
 

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -357,9 +357,9 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 		globalConf.HttpServerOptions.UseSSL = true
 		globalConf.HttpServerOptions.SSLCertificates = []string{certID}
 		globalConf.HttpServerOptions.SkipClientCAAnnouncement = skipCAAnnounce
-
 		globalConf.ControlAPIPort = 1212
 	}
+
 	ts := StartTest(conf)
 	defer ts.Close()
 
@@ -775,9 +775,6 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 
 	t.Run("Multiple APIs, mutual on empty", func(t *testing.T) {
 		testSameDomain := func(t *testing.T, domain string) {
-			gc := ts.Gw.GetConfig()
-			gc.Security.ControlAPIUseMutualTLS = true
-			ts.Gw.SetConfig(gc, true)
 
 			clientCertID, _ := ts.Gw.CertificateManager.Add(clientCertPem, "")
 			defer ts.Gw.CertificateManager.Delete(clientCertID, "")
@@ -814,7 +811,6 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 						Path:       "/with_mutual",
 						Client:     clientWithoutCert,
 						ErrorMatch: badcertErr,
-						//BodyMatch: `"error": "` + certNotMatchErr,
 					})
 				}
 
@@ -844,12 +840,7 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 						Path:       "/with_mutual",
 						Client:     client,
 						ErrorMatch: badcertErr,
-						//BodyMatch: `"error": "` + certNotMatchErr,
-						//Code: 200,
 					})
-
-					//					bb, _ := ioutil.ReadAll(res.Body)
-					//					t.Log(string(bb))
 				}
 			})
 

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -357,7 +357,7 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 		globalConf.HttpServerOptions.SSLCertificates = []string{certID}
 		globalConf.HttpServerOptions.SkipClientCAAnnouncement = skipCAAnnounce
 
-		globalConf.ControlAPIHostname = "api.hostname"
+		globalConf.ControlAPIPort = 1212
 	}
 	ts := StartTest(conf)
 	defer ts.Close()
@@ -813,7 +813,7 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 						Path:       "/with_mutual",
 						Client:     clientWithoutCert,
 						ErrorMatch: badcertErr,
-						//	BodyMatch: `"error": "` + certNotMatchErr,
+						//BodyMatch: `"error": "` + certNotMatchErr,
 					})
 				}
 

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -480,13 +480,16 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 
 				certNotAllowedErr := `Certificate with SHA256 ` + certs.HexSHA256(clientCert.Certificate[0]) + ` not allowed`
 
-				_, _ = ts.Run(t, test.TestCase{
-					Path:      "/with_mutual",
-					Client:    client,
-					Domain:    domain,
+				res, _ := ts.Run(t, test.TestCase{
+					Path:   "/with_mutual",
+					Client: client,
+					//	Domain:    domain,
 					Code:      403,
 					BodyMatch: `"error": "` + certNotAllowedErr,
 				})
+				//				t.Logf(res.StatusCode)
+				t.Logf("\n+++++++++ %d +++++++\n", res.StatusCode)
+
 			})
 
 			t.Run("Client certificate match", func(t *testing.T) {

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -359,7 +359,6 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 		globalConf.HttpServerOptions.SkipClientCAAnnouncement = skipCAAnnounce
 		globalConf.ControlAPIPort = 1212
 	}
-
 	ts := StartTest(conf)
 	defer ts.Close()
 
@@ -775,7 +774,6 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 
 	t.Run("Multiple APIs, mutual on empty", func(t *testing.T) {
 		testSameDomain := func(t *testing.T, domain string) {
-
 			clientCertID, _ := ts.Gw.CertificateManager.Add(clientCertPem, "")
 			defer ts.Gw.CertificateManager.Delete(clientCertID, "")
 
@@ -806,7 +804,6 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 						BodyMatch: `"error": "` + certNotMatchErr,
 					})
 				} else {
-
 					_, _ = ts.Run(t, test.TestCase{
 						Path:       "/with_mutual",
 						Client:     clientWithoutCert,
@@ -864,7 +861,6 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 			testSameDomain(t, "localhost")
 		})
 	})
-
 }
 
 func TestUpstreamMutualTLS(t *testing.T) {

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -293,6 +293,7 @@ func TestAPIMutualTLS(t *testing.T) {
 }
 
 func TestMutualTLSApisControlPortNotMTLS(t *testing.T) {
+	t.Skip()
 	// crear una api q es mtls, consumir control: 403
 	// crear una api q es mtls, setear control port, consumir control: 200
 	serverCertPem, _, combinedPEM, _ := certs.GenServerCertificate()

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -480,7 +480,7 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 
 				certNotAllowedErr := `Certificate with SHA256 ` + certs.HexSHA256(clientCert.Certificate[0]) + ` not allowed`
 
-				_, _ := ts.Run(t, test.TestCase{
+				_, _ = ts.Run(t, test.TestCase{
 					Path:      "/with_mutual",
 					Client:    client,
 					Domain:    domain,

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -292,6 +292,59 @@ func TestAPIMutualTLS(t *testing.T) {
 	})
 }
 
+func TestMutualTLSApisControlPortNotMTLS(t *testing.T) {
+	// crear una api q es mtls, consumir control: 403
+	// crear una api q es mtls, setear control port, consumir control: 200
+	serverCertPem, _, combinedPEM, _ := certs.GenServerCertificate()
+	certID, _, _ := certs.GetCertIDAndChainPEM(combinedPEM, "")
+	clientCertPem, _, _, clientCert := certs.GenCertificate(&x509.Certificate{}, false)
+
+	conf := func(globalConf *config.Config) {
+		globalConf.EnableCustomDomains = true
+		globalConf.HttpServerOptions.UseSSL = true
+		globalConf.HttpServerOptions.SSLCertificates = []string{certID}
+
+		globalConf.ControlAPIHostname = "api.hostname"
+	}
+	ts := StartTest(conf)
+	defer ts.Close()
+
+	certID, err := ts.Gw.CertificateManager.Add(combinedPEM, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ts.Gw.CertificateManager.Delete(certID, "")
+	ts.ReloadGatewayProxy()
+
+	clientCertID, _ := ts.Gw.CertificateManager.Add(clientCertPem, "")
+	defer ts.Gw.CertificateManager.Delete(clientCertID, "")
+
+	loadAPIS := func(certs ...string) {
+		ts.Gw.BuildAndLoadAPI(
+			func(spec *APISpec) {
+				spec.Proxy.ListenPath = "/with_mutual"
+				spec.UseMutualTLSAuth = true
+				spec.ClientCertificates = certs
+			},
+		)
+	}
+
+	t.Run("scenario 1", func(t *testing.T) {
+		loadAPIS(clientCertID)
+
+		client := GetTLSClient(&clientCert, serverCertPem)
+
+		_, _ = ts.Run(t, test.TestCase{
+			Path:   "/with_mutual",
+			Domain: "",
+			Client: client,
+			Code:   200,
+		})
+
+		// hit control and should be 403
+	})
+}
+
 func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 	t.Helper()
 

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -303,6 +303,8 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 		globalConf.HttpServerOptions.UseSSL = true
 		globalConf.HttpServerOptions.SSLCertificates = []string{certID}
 		globalConf.HttpServerOptions.SkipClientCAAnnouncement = skipCAAnnounce
+
+		globalConf.ControlAPIHostname = "api.hostname"
 	}
 	ts := StartTest(conf)
 	defer ts.Close()
@@ -317,7 +319,7 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 	// Initialize client certificates
 	clientCertPem, _, _, clientCert := certs.GenCertificate(&x509.Certificate{}, false)
 	clientCertPem2, _, _, clientCert2 := certs.GenCertificate(&x509.Certificate{}, false)
-
+	fmt.Println(clientCert2)
 	t.Run("acceptable CAs from server", func(t *testing.T) {
 		tlsConfig := GetTLSConfig(&clientCert, serverCertPem)
 		tlsConfig.GetClientCertificate = func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
@@ -430,201 +432,200 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 			})
 		})
 	})
+	/*
+			t.Run("Multiple APIs on same domain", func(t *testing.T) {
+				testSameDomain := func(t *testing.T, domain string) {
+					clientCertID, _ := ts.Gw.CertificateManager.Add(clientCertPem, "")
+					defer ts.Gw.CertificateManager.Delete(clientCertID, "")
 
-	t.Run("Multiple APIs on same domain", func(t *testing.T) {
-		testSameDomain := func(t *testing.T, domain string) {
-			clientCertID, _ := ts.Gw.CertificateManager.Add(clientCertPem, "")
-			defer ts.Gw.CertificateManager.Delete(clientCertID, "")
+					loadAPIS := func(certs ...string) {
+						ts.Gw.BuildAndLoadAPI(
+							func(spec *APISpec) {
+								spec.Proxy.ListenPath = "/without_mutual"
+								spec.Domain = domain
+							},
+							func(spec *APISpec) {
+								spec.Proxy.ListenPath = "/with_mutual"
+								spec.UseMutualTLSAuth = true
+								spec.ClientCertificates = certs
+								spec.Domain = domain
+							},
+						)
+					}
 
-			loadAPIS := func(certs ...string) {
-				ts.Gw.BuildAndLoadAPI(
-					func(spec *APISpec) {
-						spec.Proxy.ListenPath = "/without_mutual"
-						spec.Domain = domain
-					},
-					func(spec *APISpec) {
-						spec.Proxy.ListenPath = "/with_mutual"
-						spec.UseMutualTLSAuth = true
-						spec.ClientCertificates = certs
-						spec.Domain = domain
-					},
-				)
-			}
+					t.Run("Without certificate", func(t *testing.T) {
+						clientWithoutCert := GetTLSClient(nil, nil)
 
-			t.Run("Without certificate", func(t *testing.T) {
-				clientWithoutCert := GetTLSClient(nil, nil)
+						loadAPIS()
 
-				loadAPIS()
+						_, _ = ts.Run(t, []test.TestCase{
+							{
+								Path:      "/with_mutual",
+								Client:    clientWithoutCert,
+								Domain:    domain,
+								Code:      403,
+								BodyMatch: `"error": "` + certNotMatchErr,
+							},
+							{
+								Path:   "/without_mutual",
+								Client: clientWithoutCert,
+								Domain: domain,
+								Code:   200,
+							},
+						}...)
+					})
 
-				_, _ = ts.Run(t, []test.TestCase{
-					{
-						Path:      "/with_mutual",
-						Client:    clientWithoutCert,
-						Domain:    domain,
-						Code:      403,
-						BodyMatch: `"error": "` + certNotMatchErr,
-					},
-					{
-						Path:   "/without_mutual",
-						Client: clientWithoutCert,
-						Domain: domain,
-						Code:   200,
-					},
-				}...)
-			})
+					t.Run("Client certificate not match", func(t *testing.T) {
+						client := GetTLSClient(&clientCert, serverCertPem)
 
-			t.Run("Client certificate not match", func(t *testing.T) {
-				client := GetTLSClient(&clientCert, serverCertPem)
+						loadAPIS()
 
-				loadAPIS()
+						certNotAllowedErr := `Certificate with SHA256 ` + certs.HexSHA256(clientCert.Certificate[0]) + ` not allowed`
 
-				certNotAllowedErr := `Certificate with SHA256 ` + certs.HexSHA256(clientCert.Certificate[0]) + ` not allowed`
+						_, _ = ts.Run(t, test.TestCase{
+							Path:      "/with_mutual",
+							Client:    client,
+							Domain:    domain,
+							Code:      403,
+							BodyMatch: `"error": "` + certNotAllowedErr,
+						})
+					})
 
-				_, _ = ts.Run(t, test.TestCase{
-					Path:      "/with_mutual",
-					Client:    client,
-					Domain:    domain,
-					Code:      403,
-					BodyMatch: `"error": "` + certNotAllowedErr,
-				})
+					t.Run("Client certificate match", func(t *testing.T) {
+						loadAPIS(clientCertID)
+						client := GetTLSClient(&clientCert, serverCertPem)
 
-			})
-
-			t.Run("Client certificate match", func(t *testing.T) {
-				loadAPIS(clientCertID)
-				client := GetTLSClient(&clientCert, serverCertPem)
-
-				_, _ = ts.Run(t, test.TestCase{
-					Path:   "/with_mutual",
-					Domain: domain,
-					Client: client,
-					Code:   200,
-				})
-			})
-		}
-
-		t.Run("Empty domain", func(t *testing.T) {
-			testSameDomain(t, "")
-		})
-
-		t.Run("Custom domain", func(t *testing.T) {
-			testSameDomain(t, "localhost")
-		})
-	})
-
-	t.Run("Multiple APIs with Mutual TLS on the same domain", func(t *testing.T) {
-		testSameDomain := func(t *testing.T, domain string) {
-			clientCertID, _ := ts.Gw.CertificateManager.Add(clientCertPem, "")
-			defer ts.Gw.CertificateManager.Delete(clientCertID, "")
-
-			clientCertID2, _ := ts.Gw.CertificateManager.Add(clientCertPem2, "")
-			defer ts.Gw.CertificateManager.Delete(clientCertID2, "")
-
-			loadAPIS := func(certs []string, certs2 []string) {
-				ts.Gw.BuildAndLoadAPI(
-					func(spec *APISpec) {
-						spec.Proxy.ListenPath = "/with_mutual"
-						spec.UseMutualTLSAuth = true
-						spec.ClientCertificates = certs
-						spec.Domain = domain
-					},
-					func(spec *APISpec) {
-						spec.Proxy.ListenPath = "/with_mutual_2"
-						spec.UseMutualTLSAuth = true
-						spec.ClientCertificates = certs2
-						spec.Domain = domain
-					},
-				)
-			}
-
-			t.Run("Without certificate", func(t *testing.T) {
-				clientWithoutCert := GetTLSClient(nil, nil)
-
-				loadAPIS([]string{}, []string{})
-
-				_, _ = ts.Run(t, []test.TestCase{
-					{
-						Path:       "/with_mutual",
-						Client:     clientWithoutCert,
-						Domain:     domain,
-						ErrorMatch: badcertErr,
-					},
-					{
-						Path:       "/with_mutual_2",
-						Client:     clientWithoutCert,
-						Domain:     domain,
-						ErrorMatch: badcertErr,
-					},
-				}...)
-			})
-
-			t.Run("Client certificate not match", func(t *testing.T) {
-				client := GetTLSClient(&clientCert, serverCertPem)
-
-				loadAPIS([]string{}, []string{})
-
-				_, _ = ts.Run(t, test.TestCase{
-					Path:       "/with_mutual",
-					Client:     client,
-					Domain:     domain,
-					ErrorMatch: badcertErr,
-				})
-
-				_, _ = ts.Run(t, test.TestCase{
-					Path:       "/with_mutual_2",
-					Client:     client,
-					Domain:     domain,
-					ErrorMatch: badcertErr,
-				})
-			})
-
-			t.Run("Client certificate match", func(t *testing.T) {
-				loadAPIS([]string{clientCertID}, []string{clientCertID2})
-				client := GetTLSClient(&clientCert, serverCertPem)
-				client2 := GetTLSClient(&clientCert2, serverCertPem)
-
-				_, _ = ts.Run(t,
-					[]test.TestCase{
-						{
+						_, _ = ts.Run(t, test.TestCase{
 							Path:   "/with_mutual",
 							Domain: domain,
 							Client: client,
 							Code:   200,
-						},
-						{
-							Path:      "/with_mutual_2",
-							Domain:    domain,
-							Client:    client,
-							Code:      403,
-							BodyMatch: `"error": "` + `Certificate with SHA256 ` + certs.HexSHA256(clientCert.Certificate[0]) + ` not allowed`,
-						},
-						{
-							Path:   "/with_mutual_2",
-							Domain: domain,
-							Client: client2,
-							Code:   200,
-						},
-						{
-							Path:      "/with_mutual",
-							Domain:    domain,
-							Client:    client2,
-							Code:      403,
-							BodyMatch: `"error": "` + `Certificate with SHA256 ` + certs.HexSHA256(clientCert2.Certificate[0]) + ` not allowed`,
-						},
-					}...,
-				)
+						})
+					})
+				}
+
+				t.Run("Empty domain", func(t *testing.T) {
+					testSameDomain(t, "")
+				})
+
+				t.Run("Custom domain", func(t *testing.T) {
+					testSameDomain(t, "localhost")
+				})
 			})
-		}
 
-		t.Run("Empty domain", func(t *testing.T) {
-			testSameDomain(t, "")
+		t.Run("Multiple APIs with Mutual TLS on the same domain", func(t *testing.T) {
+			testSameDomain := func(t *testing.T, domain string) {
+				clientCertID, _ := ts.Gw.CertificateManager.Add(clientCertPem, "")
+				defer ts.Gw.CertificateManager.Delete(clientCertID, "")
+
+				clientCertID2, _ := ts.Gw.CertificateManager.Add(clientCertPem2, "")
+				defer ts.Gw.CertificateManager.Delete(clientCertID2, "")
+
+				loadAPIS := func(certs []string, certs2 []string) {
+					ts.Gw.BuildAndLoadAPI(
+						func(spec *APISpec) {
+							spec.Proxy.ListenPath = "/with_mutual"
+							spec.UseMutualTLSAuth = true
+							spec.ClientCertificates = certs
+							spec.Domain = domain
+						},
+						func(spec *APISpec) {
+							spec.Proxy.ListenPath = "/with_mutual_2"
+							spec.UseMutualTLSAuth = true
+							spec.ClientCertificates = certs2
+							spec.Domain = domain
+						},
+					)
+				}
+
+				t.Run("Without certificate", func(t *testing.T) {
+					clientWithoutCert := GetTLSClient(nil, nil)
+
+					loadAPIS([]string{}, []string{})
+
+					_, _ = ts.Run(t, []test.TestCase{
+						{
+							Path:       "/with_mutual",
+							Client:     clientWithoutCert,
+							Domain:     domain,
+							ErrorMatch: badcertErr,
+						},
+						{
+							Path:       "/with_mutual_2",
+							Client:     clientWithoutCert,
+							Domain:     domain,
+							ErrorMatch: badcertErr,
+						},
+					}...)
+				})
+
+				t.Run("Client certificate not match", func(t *testing.T) {
+					client := GetTLSClient(&clientCert, serverCertPem)
+
+					loadAPIS([]string{}, []string{})
+
+					_, _ = ts.Run(t, test.TestCase{
+						Path:       "/with_mutual",
+						Client:     client,
+						Domain:     domain,
+						ErrorMatch: badcertErr,
+					})
+
+					_, _ = ts.Run(t, test.TestCase{
+						Path:       "/with_mutual_2",
+						Client:     client,
+						Domain:     domain,
+						ErrorMatch: badcertErr,
+					})
+				})
+
+				t.Run("Client certificate match", func(t *testing.T) {
+					loadAPIS([]string{clientCertID}, []string{clientCertID2})
+					client := GetTLSClient(&clientCert, serverCertPem)
+					client2 := GetTLSClient(&clientCert2, serverCertPem)
+
+					_, _ = ts.Run(t,
+						[]test.TestCase{
+							{
+								Path:   "/with_mutual",
+								Domain: domain,
+								Client: client,
+								Code:   200,
+							},
+							{
+								Path:      "/with_mutual_2",
+								Domain:    domain,
+								Client:    client,
+								Code:      403,
+								BodyMatch: `"error": "` + `Certificate with SHA256 ` + certs.HexSHA256(clientCert.Certificate[0]) + ` not allowed`,
+							},
+							{
+								Path:   "/with_mutual_2",
+								Domain: domain,
+								Client: client2,
+								Code:   200,
+							},
+							{
+								Path:      "/with_mutual",
+								Domain:    domain,
+								Client:    client2,
+								Code:      403,
+								BodyMatch: `"error": "` + `Certificate with SHA256 ` + certs.HexSHA256(clientCert2.Certificate[0]) + ` not allowed`,
+							},
+						}...,
+					)
+				})
+			}
+
+			t.Run("Empty domain", func(t *testing.T) {
+				testSameDomain(t, "")
+			})
+
+			t.Run("Custom domain", func(t *testing.T) {
+				testSameDomain(t, "localhost")
+			})
 		})
-
-		t.Run("Custom domain", func(t *testing.T) {
-			testSameDomain(t, "localhost")
-		})
-	})
-
+	*/
 	t.Run("Multiple APIs, mutual on custom", func(t *testing.T) {
 		testSameDomain := func(t *testing.T, domain string) {
 			clientCertID, _ := ts.Gw.CertificateManager.Add(clientCertPem, "")
@@ -721,6 +722,10 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 
 	t.Run("Multiple APIs, mutual on empty", func(t *testing.T) {
 		testSameDomain := func(t *testing.T, domain string) {
+			gc := ts.Gw.GetConfig()
+			gc.Security.ControlAPIUseMutualTLS = true
+			ts.Gw.SetConfig(gc, true)
+
 			clientCertID, _ := ts.Gw.CertificateManager.Add(clientCertPem, "")
 			defer ts.Gw.CertificateManager.Delete(clientCertID, "")
 
@@ -751,10 +756,12 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 						BodyMatch: `"error": "` + certNotMatchErr,
 					})
 				} else {
+
 					_, _ = ts.Run(t, test.TestCase{
 						Path:       "/with_mutual",
 						Client:     clientWithoutCert,
 						ErrorMatch: badcertErr,
+						//	BodyMatch: `"error": "` + certNotMatchErr,
 					})
 				}
 
@@ -784,7 +791,12 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 						Path:       "/with_mutual",
 						Client:     client,
 						ErrorMatch: badcertErr,
+						//BodyMatch: `"error": "` + certNotMatchErr,
+						//Code: 200,
 					})
+
+					//					bb, _ := ioutil.ReadAll(res.Body)
+					//					t.Log(string(bb))
 				}
 			})
 
@@ -808,6 +820,7 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 			testSameDomain(t, "localhost")
 		})
 	})
+
 }
 
 func TestUpstreamMutualTLS(t *testing.T) {

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -480,15 +480,13 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 
 				certNotAllowedErr := `Certificate with SHA256 ` + certs.HexSHA256(clientCert.Certificate[0]) + ` not allowed`
 
-				res, _ := ts.Run(t, test.TestCase{
-					Path:   "/with_mutual",
-					Client: client,
-					//	Domain:    domain,
+				_, _ := ts.Run(t, test.TestCase{
+					Path:      "/with_mutual",
+					Client:    client,
+					Domain:    domain,
 					Code:      403,
 					BodyMatch: `"error": "` + certNotAllowedErr,
 				})
-				//				t.Logf(res.StatusCode)
-				t.Logf("\n+++++++++ %d +++++++\n", res.StatusCode)
 
 			})
 

--- a/gateway/proxy_muxer.go
+++ b/gateway/proxy_muxer.go
@@ -494,7 +494,6 @@ func (m *proxyMux) generateListener(listenPort int, protocol string, gw *Gateway
 			tlsConfig.NextProtos = append(tlsConfig.NextProtos, http2.NextProtoTLS)
 		}
 
-		fmt.Println("========jeeee-------------")
 		tlsConfig.GetConfigForClient = gw.getTLSConfigForClient(&tlsConfig, listenPort)
 		l, err = tls.Listen("tcp", targetPort, &tlsConfig)
 

--- a/gateway/proxy_muxer.go
+++ b/gateway/proxy_muxer.go
@@ -494,6 +494,7 @@ func (m *proxyMux) generateListener(listenPort int, protocol string, gw *Gateway
 			tlsConfig.NextProtos = append(tlsConfig.NextProtos, http2.NextProtoTLS)
 		}
 
+		fmt.Println("========jeeee-------------")
 		tlsConfig.GetConfigForClient = gw.getTLSConfigForClient(&tlsConfig, listenPort)
 		l, err = tls.Listen("tcp", targetPort, &tlsConfig)
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

When the control API is not protected with mTLS then we should not ask for a cert even if all the apis regstered have mtls as authorization mechanism.

## Related Issue
[ JIRA ticket](https://tyktech.atlassian.net/browse/TT-3980)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
