### PR TITLE
[TD-1869] Explicitly support Amazon Linux/2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         include:
           - golang_cross: 1.16-el7
             goreleaser: 'ci/goreleaser/goreleaser-el7.yml'
-            rpmvers: 'el/7'
+            rpmvers: 'el/7 amazon/2'
             debvers: 'ubuntu/xenial ubuntu/bionic debian/jessie'
           - golang_cross: 1.16
             goreleaser: 'ci/goreleaser/goreleaser.yml'
@@ -250,7 +250,7 @@ jobs:
       ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
 
   upgrade-deb:
-    if: startsWith(github.ref, 'refs/tags') && !github.event.pull_request.draft
+    if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     needs: goreleaser
     strategy:
@@ -318,6 +318,7 @@ jobs:
         distro:
           - ubi7/ubi
           - ubi8/ubi
+          - amazonlinux:2
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Though the [documentation](https://tyk.io/docs/tyk-on-prem/installation/redhat-rhel-centos/gateway/#supported-distributions) claimed Amazon Linux 2 support, we never actually pushed packages to this distro.

This PR does so and adds an upgrade test for al/2. This will have to be ported to release-5.0.2.