### PR TITLE
[TT-8959] Add configurable cache timeouts per endpoint

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -155,6 +155,7 @@ type CacheMeta struct {
 	Path                   string `bson:"path" json:"path"`
 	CacheKeyRegex          string `bson:"cache_key_regex" json:"cache_key_regex"`
 	CacheOnlyResponseCodes []int  `bson:"cache_response_codes" json:"cache_response_codes"`
+	Timeout                int64  `bson:"timeout" json:"timeout"`
 }
 
 type RequestInputType string

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -166,6 +166,7 @@ type EndPointCacheMeta struct {
 	Method                 string
 	CacheKeyRegex          string
 	CacheOnlyResponseCodes []int
+	Timeout                int64
 }
 
 type TransformSpec struct {

--- a/gateway/mw_redis_cache.go
+++ b/gateway/mw_redis_cache.go
@@ -143,6 +143,7 @@ func (m *RedisCacheMiddleware) decodePayload(payload string) (string, string, er
 type cacheOptions struct {
 	key                    string
 	cacheOnlyResponseCodes []int
+	timeout                int64
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
@@ -198,6 +199,7 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 	ctxSetCacheOptions(r, &cacheOptions{
 		key:                    key,
 		cacheOnlyResponseCodes: cacheOnlyResponseCodes,
+		timeout:                cacheMeta.Timeout,
 	})
 
 	retBlob, err = m.store.GetKey(key)

--- a/gateway/res_cache.go
+++ b/gateway/res_cache.go
@@ -77,6 +77,9 @@ func (m *ResponseCacheMiddleware) HandleResponse(w http.ResponseWriter, res *htt
 
 	cacheThisRequest := true
 	cacheTTL := m.spec.CacheOptions.CacheTimeout
+	if options.timeout != 0 {
+		cacheTTL = options.timeout
+	}
 
 	// make sure the status codes match if specified
 	if len(options.cacheOnlyResponseCodes) > 0 {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Currently the only way to have endpoints have unique timeout values is to self inject upstream control. This offers a simple alternative that is OOTB.


## Related Issue

(https://tyktech.atlassian.net/browse/TT-8959)

## Motivation and Context

Enterprise users currently have to hack granular timeouts with upstream control headers, which can lead to other issues with competing logic in the gateway.


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
