### PR TITLE
Merging to release-5-lts: [TT-8711] Fix upstream mTLS when protocol=tcp/tls (#5033)

### DIFF
--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -1433,3 +1433,64 @@ func TestCipherSuites(t *testing.T) {
 		_, _ = ts.Run(t, test.TestCase{Client: client, Path: "/", ErrorMatch: "tls: handshake failure"})
 	})
 }
+
+func TestUpstreamCertificates_WithProtocolTCP(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	cert, key, _, _ := certs.GenCertificate(&x509.Certificate{}, false)
+	certificate, _ := tls.X509KeyPair(cert, key)
+
+	upstreamCert, _, combinedUpstreamCertPEM, _ := certs.GenServerCertificate()
+
+	certPool := x509.NewCertPool()
+	certPool.AppendCertsFromPEM(upstreamCert)
+
+	serverTLSConfig := &tls.Config{Certificates: []tls.Certificate{certificate}, ClientCAs: certPool, ClientAuth: tls.RequireAndVerifyClientCert}
+	ls, err := tls.Listen("tcp", "127.0.0.1:8003", serverTLSConfig)
+	assert.NoError(t, err)
+	defer ls.Close()
+
+	go listenProxyProto(ls)
+
+	certID, err := ts.Gw.CertificateManager.Add(combinedUpstreamCertPEM, "")
+
+	ts.EnablePort(6001, "tcp")
+	api := ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/"
+		spec.Protocol = "tcp"
+		spec.ListenPort = 6001
+		spec.Proxy.TargetURL = "tls://127.0.0.1:8003"
+		spec.Proxy.Transport.SSLInsecureSkipVerify = true
+		spec.UpstreamCertificates = map[string]string{
+			"*": certID,
+		}
+	})[0]
+
+	t.Run("enabled", func(t *testing.T) {
+		client, err := net.Dial("tcp", "127.0.0.1:6001")
+		assert.NoError(t, err)
+		defer client.Close()
+
+		_, _ = client.Write([]byte("ping"))
+		received := make([]byte, 4)
+		_, err = client.Read(received)
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("pong"), received)
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		api.UpstreamCertificates = nil
+		ts.Gw.LoadAPI(api)
+
+		client, err := net.Dial("tcp", "127.0.0.1:6001")
+		assert.NoError(t, err)
+		defer client.Close()
+
+		_, _ = client.Write([]byte("ping"))
+		received := make([]byte, 4)
+		n, err := client.Read(received)
+		assert.Error(t, err)
+		assert.Equal(t, 0, n)
+	})
+}

--- a/gateway/mw_graphql.go
+++ b/gateway/mw_graphql.go
@@ -73,11 +73,11 @@ func (m *GraphQLMiddleware) Init() {
 	if needsGraphQLExecutionEngine(m.Spec) {
 		absLogger := abstractlogger.NewLogrusLogger(log, absLoggerLevel(log.Level))
 		m.Spec.GraphQLExecutor.Client = &http.Client{
-			Transport: &http.Transport{TLSClientConfig: tlsClientConfig(m.Spec)},
+			Transport: &http.Transport{TLSClientConfig: tlsClientConfig(m.Spec, nil)},
 		}
 		m.Spec.GraphQLExecutor.StreamingClient = &http.Client{
 			Timeout:   0,
-			Transport: &http.Transport{TLSClientConfig: tlsClientConfig(m.Spec)},
+			Transport: &http.Transport{TLSClientConfig: tlsClientConfig(m.Spec, nil)},
 		}
 
 		if m.Spec.GraphQL.Version == apidef.GraphQLConfigVersionNone || m.Spec.GraphQL.Version == apidef.GraphQLConfigVersion1 {

--- a/gateway/proxy_muxer.go
+++ b/gateway/proxy_muxer.go
@@ -192,7 +192,7 @@ func (m *proxyMux) addTCPService(spec *APISpec, modifier *tcp.Modifier, gw *Gate
 	if p := m.getProxy(spec.ListenPort, conf); p != nil {
 		p.tcpProxy.AddDomainHandler(hostname, spec.Proxy.TargetURL, modifier)
 	} else {
-		tlsConfig := tlsClientConfig(spec)
+		tlsConfig := tlsClientConfig(spec, gw)
 
 		p = &proxy{
 			port:             spec.ListenPort,

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -580,8 +580,28 @@ func proxyFromAPI(api *APISpec) func(*http.Request) (*url.URL, error) {
 	}
 }
 
-func tlsClientConfig(s *APISpec) *tls.Config {
+func tlsClientConfig(s *APISpec, gw *Gateway) *tls.Config {
 	config := &tls.Config{}
+
+	if s.Protocol == "tls" || s.Protocol == "tcp" {
+		targetURL, err := url.Parse(s.Proxy.TargetURL)
+		if err != nil {
+			targetURL, err = url.Parse("tcp://" + s.Proxy.TargetURL)
+			if err != nil {
+				mainLog.WithError(err).Error("Error parsing target URL")
+			}
+		}
+
+		if targetURL != nil {
+			var tlsCertificates []tls.Certificate
+			if cert := gw.getUpstreamCertificate(targetURL.Host, s); cert != nil {
+				mainLog.Debug("Found upstream mutual TLS certificate")
+				tlsCertificates = []tls.Certificate{*cert}
+			}
+
+			config.Certificates = tlsCertificates
+		}
+	}
 
 	if s.GlobalConfig.ProxySSLInsecureSkipVerify {
 		config.InsecureSkipVerify = true

--- a/tcp/tcp.go
+++ b/tcp/tcp.go
@@ -95,6 +95,7 @@ func (p *Proxy) Swap(new *Proxy) {
 	defer p.Unlock()
 
 	p.muxer = new.muxer
+	p.TLSConfigTarget = new.TLSConfigTarget
 }
 
 func (p *Proxy) RemoveDomainHandler(domain string) {


### PR DESCRIPTION
[TT-8711] Fix upstream mTLS when protocol=tcp/tls (#5033)

This PR adds the missing upstream certificate configuration for tcp/tls
APIs.

[TT-8711]: https://tyktech.atlassian.net/browse/TT-8711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ