### PR TITLE
[TT-8708] Fix client mTLS when protocol=tls

### DIFF
--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -1803,3 +1803,12 @@ func (s *APISpec) hasVirtualEndpoint() bool {
 
 	return false
 }
+
+// isListeningOnPort checks whether the API listens on the given port.
+func (s *APISpec) isListeningOnPort(port int, gwConfig *config.Config) bool {
+	if s.ListenPort == 0 {
+		return gwConfig.ListenPort == port
+	}
+
+	return s.ListenPort == port
+}

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -15,6 +15,8 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/TykTechnologies/tyk/config"
+
 	"github.com/stretchr/testify/assert"
 
 	redis "github.com/go-redis/redis/v8"
@@ -1423,4 +1425,15 @@ func TestAPISpec_GetSessionLifetimeRespectsKeyExpiration(t *testing.T) {
 		a.SessionLifetimeRespectsKeyExpiration = true
 		assert.True(t, a.GetSessionLifetimeRespectsKeyExpiration())
 	})
+}
+
+func TestAPISpec_isListeningOnPort(t *testing.T) {
+	s := APISpec{APIDefinition: &apidef.APIDefinition{}}
+	cfg := &config.Config{}
+
+	cfg.ListenPort = 7000
+	assert.True(t, s.isListeningOnPort(7000, cfg))
+
+	s.ListenPort = 8000
+	assert.True(t, s.isListeningOnPort(8000, cfg))
 }

--- a/gateway/cert.go
+++ b/gateway/cert.go
@@ -392,6 +392,11 @@ func (gw *Gateway) getTLSConfigForClient(baseConfig *tls.Config, listenPort int)
 		}
 
 		for _, spec := range gw.apiSpecs {
+			// eliminate APIs which are not in the current port
+			if !spec.isListeningOnPort(listenPort, &gwConfig) {
+				continue
+			}
+
 			switch {
 			case spec.UseMutualTLSAuth:
 				if domainRequireCert[spec.Domain] == 0 {


### PR DESCRIPTION
This PR fixes client certificates are not respected when API protocol is set as `tls`. It happens because APIs which are not in the called port interfering and manipulating while setting certificate requirements.