### PR TITLE
Merging to release-4-lts: [TT-8708] Fix client mTLS when protocol=tls (#5038)

### DIFF
--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -1502,3 +1502,12 @@ func (s *APISpec) hasVirtualEndpoint() bool {
 
 	return false
 }
+
+// isListeningOnPort checks whether the API listens on the given port.
+func (s *APISpec) isListeningOnPort(port int, gwConfig *config.Config) bool {
+	if s.ListenPort == 0 {
+		return gwConfig.ListenPort == port
+	}
+
+	return s.ListenPort == port
+}

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -14,6 +14,8 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/TykTechnologies/tyk/config"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/TykTechnologies/tyk/apidef"
@@ -998,4 +1000,15 @@ func TestAPISpec_SanitizeProxyPaths(t *testing.T) {
 		assert.Equal(t, "/get", r.URL.Path)
 		assert.Equal(t, "", r.URL.RawPath)
 	})
+}
+
+func TestAPISpec_isListeningOnPort(t *testing.T) {
+	s := APISpec{APIDefinition: &apidef.APIDefinition{}}
+	cfg := &config.Config{}
+
+	cfg.ListenPort = 7000
+	assert.True(t, s.isListeningOnPort(7000, cfg))
+
+	s.ListenPort = 8000
+	assert.True(t, s.isListeningOnPort(8000, cfg))
 }

--- a/gateway/cert.go
+++ b/gateway/cert.go
@@ -384,6 +384,11 @@ func (gw *Gateway) getTLSConfigForClient(baseConfig *tls.Config, listenPort int)
 		}
 
 		for _, spec := range gw.apiSpecs {
+			// eliminate APIs which are not in the current port
+			if !spec.isListeningOnPort(listenPort, &gwConfig) {
+				continue
+			}
+
 			switch {
 			case spec.UseMutualTLSAuth:
 				if domainRequireCert[spec.Domain] == 0 {

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -1321,6 +1321,7 @@ func TestUpstreamCertificates_WithProtocolTCP(t *testing.T) {
 	go listenProxyProto(ls)
 
 	certID, err := ts.Gw.CertificateManager.Add(combinedUpstreamCertPEM, "")
+	defer ts.Gw.CertificateManager.Delete(certID, "")
 
 	ts.EnablePort(6001, "tcp")
 	api := ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
@@ -1359,5 +1360,75 @@ func TestUpstreamCertificates_WithProtocolTCP(t *testing.T) {
 		n, err := client.Read(received)
 		assert.Error(t, err)
 		assert.Equal(t, 0, n)
+	})
+}
+
+func TestClientCertificates_WithProtocolTLS(t *testing.T) {
+	const (
+		upstreamAddr    = "127.0.0.1:8005"
+		proxyListenPort = 6005
+	)
+
+	// upstream
+	upstream, err := net.Listen("tcp", upstreamAddr)
+	assert.NoError(t, err)
+	defer upstream.Close()
+
+	go listenProxyProto(upstream)
+
+	// tyk
+	_, _, tykServerCombinedPEM, _ := certs.GenServerCertificate()
+	serverCertID, _, _ := certs.GetCertIDAndChainPEM(tykServerCombinedPEM, "")
+
+	ts := StartTest(func(globalConf *config.Config) {
+		globalConf.HttpServerOptions.UseSSL = false
+		globalConf.HttpServerOptions.SSLCertificates = []string{serverCertID}
+	})
+	defer ts.Close()
+
+	_, _ = ts.Gw.CertificateManager.Add(tykServerCombinedPEM, "")
+	defer ts.Gw.CertificateManager.Delete(serverCertID, "")
+
+	cert, key, combinedClientCertPEM, _ := certs.GenServerCertificate()
+	clientCertificate, err := tls.X509KeyPair(cert, key)
+	assert.NoError(t, err)
+
+	clientCertificateID, err := ts.Gw.CertificateManager.Add(combinedClientCertPEM, "")
+	defer ts.Gw.CertificateManager.Delete(clientCertificateID, "")
+
+	ts.EnablePort(proxyListenPort, "tls")
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/"
+		spec.Protocol = "tls"
+		spec.ListenPort = proxyListenPort
+		spec.Proxy.TargetURL = "tcp://" + upstreamAddr
+		spec.UseMutualTLSAuth = true
+		spec.UseMutualTLSAuth = true
+		spec.ClientCertificates = []string{clientCertificateID}
+	}, func(spec *APISpec) {
+		spec.Name = "another-api-on-control-port" // required to cover the case where there is another API in a different port.
+	})
+
+	apiAddr := fmt.Sprintf(":%d", proxyListenPort)
+	mTLSConfig := &tls.Config{InsecureSkipVerify: true}
+
+	// client
+	t.Run("bad certificate", func(t *testing.T) {
+		_, err := tls.Dial("tcp", apiAddr, mTLSConfig)
+		assert.Contains(t, err.Error(), badcertErr)
+	})
+
+	t.Run("correct certificate", func(t *testing.T) {
+		mTLSConfig.Certificates = append(mTLSConfig.Certificates, clientCertificate)
+
+		client, err := tls.Dial("tcp", apiAddr, mTLSConfig)
+		assert.NoError(t, err)
+		defer client.Close()
+
+		_, _ = client.Write([]byte("ping"))
+		received := make([]byte, 4)
+		_, err = client.Read(received)
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("pong"), received)
 	})
 }


### PR DESCRIPTION
[TT-8708] Fix client mTLS when protocol=tls (#5038)

This PR fixes client certificates are not respected when API protocol is
set as `tls`. It happens because APIs which are not in the called port
interfering and manipulating while setting certificate requirements.

[TT-8708]: https://tyktech.atlassian.net/browse/TT-8708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ