### PR TITLE
Merging to release-5-lts: TT-3980 if control api not requires mutual tls then not ask for cert (#5018)

### DIFF
--- a/gateway/api_loader_test.go
+++ b/gateway/api_loader_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/TykTechnologies/storage/persistent/model"
+	"github.com/TykTechnologies/tyk/apidef"
 
 	"github.com/stretchr/testify/assert"
 
@@ -371,4 +372,57 @@ func TestTykRateLimitsStatusOfAPI(t *testing.T) {
 		quotaMax, quotaRemaining, rate, per)
 
 	_, _ = g.Run(t, test.TestCase{Path: "/my-api/tyk/rate-limits/", Headers: authHeader, BodyMatch: bodyMatch, Code: http.StatusOK})
+}
+
+func TestAllApisAreMTLS(t *testing.T) {
+	// Create a new instance of the Gateway
+	gw := &Gateway{
+		apisByID: make(map[string]*APISpec),
+	}
+
+	// Define API specs
+	spec1 := &APISpec{
+		APIDefinition: &apidef.APIDefinition{
+			UseMutualTLSAuth: true,
+			Active:           true,
+			APIID:            "api1",
+		},
+	}
+	spec2 := &APISpec{
+		APIDefinition: &apidef.APIDefinition{
+			UseMutualTLSAuth: true,
+			Active:           true,
+			APIID:            "api2",
+		},
+	}
+	spec3 := &APISpec{
+		APIDefinition: &apidef.APIDefinition{
+			UseMutualTLSAuth: true,
+			Active:           true,
+			APIID:            "api3",
+		},
+	}
+
+	// Add API specs to the gateway
+	gw.apisByID[spec1.APIID] = spec1
+	gw.apisByID[spec2.APIID] = spec2
+	gw.apisByID[spec3.APIID] = spec3
+
+	result := gw.allApisAreMTLS()
+
+	expected := true
+	if result != expected {
+		t.Errorf("Expected AllApisAreMTLS to return %v, but got %v", expected, result)
+	}
+
+	// Change one API to not use mutual TLS authentication
+	spec3.UseMutualTLSAuth = false
+
+	// Call the method again
+	result = gw.allApisAreMTLS()
+
+	expected = false
+	if result != expected {
+		t.Errorf("Expected AllApisAreMTLS to return %v, but got %v", expected, result)
+	}
 }

--- a/gateway/cert.go
+++ b/gateway/cert.go
@@ -367,7 +367,11 @@ func (gw *Gateway) getTLSConfigForClient(baseConfig *tls.Config, listenPort int)
 			newConfig.NameToCertificate[name] = cert
 		}
 
-		isControlAPI := (listenPort != 0 && gwConfig.ControlAPIPort == listenPort) || (gwConfig.ControlAPIHostname == hello.ServerName)
+		// not ControlAPIHostname has been configured or the hostName is the same in the hello handshake
+		isControlHostName := gwConfig.ControlAPIHostname == "" || (gwConfig.ControlAPIHostname == hello.ServerName)
+		// target port is the same where control api lives
+		isControlPort := (gwConfig.ControlAPIPort == 0 && listenPort == gwConfig.ListenPort) || (gwConfig.ControlAPIPort == listenPort && listenPort != 0)
+		isControlAPI := isControlHostName && isControlPort
 
 		if isControlAPI && gwConfig.Security.ControlAPIUseMutualTLS {
 			newConfig.ClientAuth = tls.RequireAndVerifyClientCert
@@ -488,6 +492,11 @@ func (gw *Gateway) getTLSConfigForClient(baseConfig *tls.Config, listenPort int)
 				newConfig.VerifyPeerCertificate = getClientValidator(hello, newConfig.ClientCAs)
 			}
 			newConfig.ClientCAs = x509.NewCertPool()
+			newConfig.ClientAuth = tls.RequestClientCert
+		}
+
+		if newConfig.ClientAuth == tls.RequireAndVerifyClientCert && isControlAPI && !gwConfig.Security.ControlAPIUseMutualTLS {
+
 			newConfig.ClientAuth = tls.RequestClientCert
 		}
 

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -303,6 +303,7 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 		globalConf.HttpServerOptions.UseSSL = true
 		globalConf.HttpServerOptions.SSLCertificates = []string{certID}
 		globalConf.HttpServerOptions.SkipClientCAAnnouncement = skipCAAnnounce
+		globalConf.ControlAPIPort = 1212
 	}
 	ts := StartTest(conf)
 	defer ts.Close()
@@ -317,7 +318,6 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 	// Initialize client certificates
 	clientCertPem, _, _, clientCert := certs.GenCertificate(&x509.Certificate{}, false)
 	clientCertPem2, _, _, clientCert2 := certs.GenCertificate(&x509.Certificate{}, false)
-
 	t.Run("acceptable CAs from server", func(t *testing.T) {
 		tlsConfig := GetTLSConfig(&clientCert, serverCertPem)
 		tlsConfig.GetClientCertificate = func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {


### PR DESCRIPTION
TT-3980 if control api not requires mutual tls then not ask for cert (#5018)

<!-- Provide a general summary of your changes in the Title above -->

## Description

When the control API is not protected with mTLS then we should not ask
for a cert even if all the apis regstered have mtls as authorization
mechanism.

## Related Issue
[ JIRA ticket](https://tyktech.atlassian.net/browse/TT-3980)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why