### PR TITLE
[TT-8512] Stop traffic when JSVM fails

### DIFF
--- a/gateway/mw_js_plugin.go
+++ b/gateway/mw_js_plugin.go
@@ -208,7 +208,7 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 	case returnRaw = <-ret:
 		if err := <-errRet; err != nil {
 			logger.WithError(err).Error("Failed to run JS middleware")
-			return nil, http.StatusOK
+			return errors.New(http.StatusText(http.StatusInternalServerError)), http.StatusInternalServerError
 		}
 		t.Stop()
 	case <-t.C:
@@ -219,7 +219,7 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 			// that panics.
 			panic("stop")
 		}
-		return nil, http.StatusOK
+		return errors.New(http.StatusText(http.StatusInternalServerError)), http.StatusInternalServerError
 	}
 	returnDataStr, _ := returnRaw.ToString()
 
@@ -227,7 +227,7 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 	newRequestData := VMReturnObject{}
 	if err := json.Unmarshal([]byte(returnDataStr), &newRequestData); err != nil {
 		logger.WithError(err).Error("Failed to decode middleware request data on return from VM. Returned data: ", returnDataStr)
-		return nil, http.StatusOK
+		return errors.New(http.StatusText(http.StatusInternalServerError)), http.StatusInternalServerError
 	}
 
 	// Reconstruct the request parts


### PR DESCRIPTION
This PR makes JSVM return `500` when an error happens. Currently, when it fails, it continues to run the middleware chain.