### PR TITLE
Merging to release-4-lts: [TT-8512] Stop traffic when JSVM fails (#5048)

### DIFF
--- a/gateway/mw_js_plugin.go
+++ b/gateway/mw_js_plugin.go
@@ -206,7 +206,7 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 	case returnRaw = <-ret:
 		if err := <-errRet; err != nil {
 			logger.WithError(err).Error("Failed to run JS middleware")
-			return nil, http.StatusOK
+			return errors.New(http.StatusText(http.StatusInternalServerError)), http.StatusInternalServerError
 		}
 		t.Stop()
 	case <-t.C:
@@ -217,7 +217,7 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 			// that panics.
 			panic("stop")
 		}
-		return nil, http.StatusOK
+		return errors.New(http.StatusText(http.StatusInternalServerError)), http.StatusInternalServerError
 	}
 	returnDataStr, _ := returnRaw.ToString()
 
@@ -225,7 +225,7 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 	newRequestData := VMReturnObject{}
 	if err := json.Unmarshal([]byte(returnDataStr), &newRequestData); err != nil {
 		logger.WithError(err).Error("Failed to decode middleware request data on return from VM. Returned data: ", returnDataStr)
-		return nil, http.StatusOK
+		return errors.New(http.StatusText(http.StatusInternalServerError)), http.StatusInternalServerError
 	}
 
 	// Reconstruct the request parts


### PR DESCRIPTION
[TT-8512] Stop traffic when JSVM fails (#5048)

This PR makes JSVM return `500` when an error happens. Currently, when
it fails, it continues to run the middleware chain.

[TT-8512]: https://tyktech.atlassian.net/browse/TT-8512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ