### PR TITLE
Merging to release-5-lts: [TT-7808] In proxy-only mode, GraphQL query return errors from upstream (#5049)

### DIFF
--- a/apidef/adapter/asyncapi_test.go
+++ b/apidef/adapter/asyncapi_test.go
@@ -321,7 +321,10 @@ const expectedGraphqlConfig = `{
     },
     "proxy": {
         "auth_headers": {},
-        "request_headers": null
+        "request_headers": null,
+        "use_response_extensions": {
+            "on_error_forwarding": false
+        }
     },
     "subgraph": {
         "sdl": ""

--- a/apidef/adapter/openapi_test.go
+++ b/apidef/adapter/openapi_test.go
@@ -1,0 +1,343 @@
+package adapter
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/buger/jsonparser"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/apidef"
+)
+
+const petstoreExpandedOpenAPI3 = `openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: apiteam@swagger.io
+    url: http://swagger.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: http://petstore.swagger.io/api
+paths:
+  /pets:
+    get:
+      description: |
+        Returns all pets from the system that the user has access to
+        Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+
+        Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+      operationId: findPets
+      parameters:
+        - name: tags
+          in: query
+          description: tags to filter by
+          required: false
+          style: form
+          schema:
+            type: array
+            items:
+              type: string
+        - name: limit
+          in: query
+          description: maximum number of results to return
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      description: Creates a new pet in the store. Duplicates are allowed
+      operationId: addPet
+      requestBody:
+        description: Pet to add to the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewPet'
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: find pet by id
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to fetch
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      description: deletes a single pet based on the ID supplied
+      operationId: deletePet
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '204':
+          description: pet deleted
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Pet:
+      allOf:
+        - $ref: '#/components/schemas/NewPet'
+        - type: object
+          required:
+            - id
+          properties:
+            id:
+              type: integer
+              format: int64
+
+    NewPet:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        tag:
+          type: string
+
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string`
+
+const expectedOpenAPIGraphQLSchema = "schema {\n    query: Query\n    mutation: Mutation\n}\n\ntype Query {\n    \"Returns a user based on a single ID, if the user does not have access to the pet\"\n    findPetById(id: Int!): Pet\n    \"\"\"\n    Returns all pets from the system that the user has access to\n    Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.\n\n    Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.\n    \"\"\"\n    findPets(limit: Int, tags: [String]): [Pet]\n}\n\ntype Mutation {\n    \"Creates a new pet in the store. Duplicates are allowed\"\n    addPet(newPetInput: NewPetInput!): Pet\n    \"deletes a single pet based on the ID supplied\"\n    deletePet(id: Int!): String\n}\n\ninput NewPetInput {\n    name: String!\n    tag: String\n}\n\ntype Pet {\n    id: Int!\n    name: String!\n    tag: String\n}"
+
+const expectedOpenAPIGraphQLConfig = `{
+    "enabled": true,
+    "execution_mode": "executionEngine",
+    "version": "2",
+    "schema": "schema {\n    query: Query\n    mutation: Mutation\n}\n\ntype Query {\n    \"Returns a user based on a single ID, if the user does not have access to the pet\"\n    findPetById(id: Int!): Pet\n    \"\"\"\n    Returns all pets from the system that the user has access to\n    Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.\n\n    Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.\n    \"\"\"\n    findPets(limit: Int, tags: [String]): [Pet]\n}\n\ntype Mutation {\n    \"Creates a new pet in the store. Duplicates are allowed\"\n    addPet(newPetInput: NewPetInput!): Pet\n    \"deletes a single pet based on the ID supplied\"\n    deletePet(id: Int!): String\n}\n\ninput NewPetInput {\n    name: String!\n    tag: String\n}\n\ntype Pet {\n    id: Int!\n    name: String!\n    tag: String\n}",
+    "type_field_configurations": null,
+    "playground": {
+        "enabled": false,
+        "path": ""
+    },
+    "engine": {
+        "field_configs": [
+            {
+                "type_name": "Mutation",
+                "field_name": "addPet",
+                "disable_default_mapping": true,
+                "path": [
+                    "addPet"
+                ]
+            },
+            {
+                "type_name": "Mutation",
+                "field_name": "deletePet",
+                "disable_default_mapping": true,
+                "path": [
+                    "deletePet"
+                ]
+            },
+            {
+                "type_name": "Query",
+                "field_name": "findPetById",
+                "disable_default_mapping": true,
+                "path": [
+                    "findPetById"
+                ]
+            },
+            {
+                "type_name": "Query",
+                "field_name": "findPets",
+                "disable_default_mapping": true,
+                "path": [
+                    "findPets"
+                ]
+            }
+        ],
+        "data_sources": [
+            {
+                "kind": "REST",
+                "name": "addPet",
+                "internal": false,
+                "root_fields": [
+                    {
+                        "type": "Mutation",
+                        "fields": [
+                            "addPet"
+                        ]
+                    }
+                ],
+                "config": {
+                    "url": "http://petstore.swagger.io/api/pets",
+                    "method": "POST",
+                    "headers": {},
+                    "query": [],
+                    "body": "{{ .arguments.newPetInput }}"
+                }
+            },
+            {
+                "kind": "REST",
+                "name": "deletePet",
+                "internal": false,
+                "root_fields": [
+                    {
+                        "type": "Mutation",
+                        "fields": [
+                            "deletePet"
+                        ]
+                    }
+                ],
+                "config": {
+                    "url": "http://petstore.swagger.io/api/pets/{{.arguments.id}}",
+                    "method": "DELETE",
+                    "headers": {},
+                    "query": [],
+                    "body": ""
+                }
+            },
+            {
+                "kind": "REST",
+                "name": "findPetById",
+                "internal": false,
+                "root_fields": [
+                    {
+                        "type": "Query",
+                        "fields": [
+                            "findPetById"
+                        ]
+                    }
+                ],
+                "config": {
+                    "url": "http://petstore.swagger.io/api/pets/{{.arguments.id}}",
+                    "method": "GET",
+                    "headers": {},
+                    "query": [],
+                    "body": ""
+                }
+            },
+            {
+                "kind": "REST",
+                "name": "findPets",
+                "internal": false,
+                "root_fields": [
+                    {
+                        "type": "Query",
+                        "fields": [
+                            "findPets"
+                        ]
+                    }
+                ],
+                "config": {
+                    "url": "http://petstore.swagger.io/api/pets?limit={{.arguments.limit}}\u0026tags={{.arguments.tags}}",
+                    "method": "GET",
+                    "headers": {},
+                    "query": [],
+                    "body": ""
+                }
+            }
+        ]
+    },
+    "proxy": {
+        "auth_headers": {},
+        "request_headers": null,
+        "use_response_extensions": {
+            "on_error_forwarding": false
+        }
+    },
+    "subgraph": {
+        "sdl": ""
+    },
+    "supergraph": {
+        "subgraphs": null,
+        "merged_sdl": "",
+        "global_headers": null,
+        "disable_query_batching": false
+    }
+}`
+
+func TestGraphQLConfigAdapter_OpenAPI(t *testing.T) {
+	adapter := NewOpenAPIAdapter("my-org-id", []byte(petstoreExpandedOpenAPI3))
+
+	actualApiDefinition, err := adapter.Import()
+	require.NoError(t, err)
+
+	require.Equal(t, "Swagger Petstore", actualApiDefinition.Name)
+	require.True(t, actualApiDefinition.GraphQL.Enabled)
+	require.True(t, actualApiDefinition.Active)
+	require.Equal(t, apidef.GraphQLExecutionModeExecutionEngine, actualApiDefinition.GraphQL.ExecutionMode)
+	require.Equal(t, expectedOpenAPIGraphQLSchema, actualApiDefinition.GraphQL.Schema)
+
+	data, err := json.Marshal(actualApiDefinition)
+	require.NoError(t, err)
+
+	actualGraphqlConfig, _, _, err := jsonparser.Get(data, "graphql")
+	require.NoError(t, err)
+
+	dst := bytes.NewBuffer(nil)
+	err = json.Indent(dst, actualGraphqlConfig, "", "    ")
+	require.NoError(t, err)
+	require.Equal(t, expectedOpenAPIGraphQLConfig, dst.String())
+}

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -748,10 +748,15 @@ const (
 	GraphQLConfigVersion2    GraphQLConfigVersion = "2"
 )
 
+type GraphQLResponseExtensions struct {
+	OnErrorForwarding bool `bson:"on_error_forwarding" json:"on_error_forwarding"`
+}
+
 type GraphQLProxyConfig struct {
-	AuthHeaders      map[string]string `bson:"auth_headers" json:"auth_headers"`
-	SubscriptionType SubscriptionType  `bson:"subscription_type" json:"subscription_type,omitempty"`
-	RequestHeaders   map[string]string `bson:"request_headers" json:"request_headers"`
+	AuthHeaders           map[string]string         `bson:"auth_headers" json:"auth_headers"`
+	SubscriptionType      SubscriptionType          `bson:"subscription_type" json:"subscription_type,omitempty"`
+	RequestHeaders        map[string]string         `bson:"request_headers" json:"request_headers"`
+	UseResponseExtensions GraphQLResponseExtensions `bson:"use_response_extensions" json:"use_response_extensions"`
 }
 
 type GraphQLSubgraphConfig struct {

--- a/gateway/mw_graphql_test.go
+++ b/gateway/mw_graphql_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/buger/jsonparser"
+
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -286,6 +288,34 @@ func TestGraphQLMiddleware_EngineMode(t *testing.T) {
 				},
 			}...)
 
+		})
+
+		t.Run("proxy-only return errors from upstream", func(t *testing.T) {
+			g.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+				spec.UseKeylessAccess = true
+				spec.GraphQL.Enabled = true
+				spec.GraphQL.ExecutionMode = apidef.GraphQLExecutionModeProxyOnly
+				spec.GraphQL.Version = apidef.GraphQLConfigVersion2
+				spec.GraphQL.Schema = gqlProxyUpstreamSchema
+				spec.GraphQL.Proxy.UseResponseExtensions.OnErrorForwarding = true
+				spec.Proxy.ListenPath = "/"
+				spec.Proxy.TargetURL = testGraphQLProxyUpstreamError
+			})
+
+			request := gql.Request{
+				Query: `{ hello(name: "World") httpMethod }`,
+			}
+			_, _ = g.Run(t, test.TestCase{
+				Data:   request,
+				Method: http.MethodPost,
+				Code:   http.StatusInternalServerError,
+				BodyMatchFunc: func(i []byte) bool {
+					value, _, _, err := jsonparser.Get(i, "errors", "[0]", "extensions", "error")
+					if err != nil {
+						return false
+					}
+					return string(value) == "Something went wrong"
+				}})
 		})
 
 		t.Run("subgraph", func(t *testing.T) {

--- a/gateway/mw_graphql_transport.go
+++ b/gateway/mw_graphql_transport.go
@@ -1,7 +1,9 @@
 package gateway
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"net/http"
 
 	"github.com/TykTechnologies/tyk/apidef"
@@ -81,6 +83,26 @@ func (g *GraphQLEngineTransport) handleProxyOnly(proxyOnlyCtx *GraphQLProxyOnlyC
 		return nil, err
 	}
 
+	if response.StatusCode >= http.StatusBadRequest {
+		// In proxy-only mode, we keep the upstream error message to
+		// insert into the library's error message.
+		body, err := io.ReadAll(response.Body)
+		if err != nil {
+			return nil, err
+		}
+		defer func() {
+			_ = response.Body.Close()
+		}()
+		// graphql-go-tools uses response.body to resolve the upstream response.
+		// It's not possible to re-use io.ReadCloser. Because of that, we keep the
+		// original error message for later use.
+		// See TT-7808
+		reusableBody, err := newNopCloserBuffer(io.NopCloser(bytes.NewReader(body)))
+		if err != nil {
+			return nil, err
+		}
+		response.Body = reusableBody
+	}
 	proxyOnlyCtx.upstreamResponse = response
 	return response, err
 }

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -28,6 +28,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/buger/jsonparser"
+
 	"github.com/gorilla/websocket"
 	"github.com/jensneuse/abstractlogger"
 
@@ -1040,6 +1042,32 @@ func (p *ReverseProxy) handleGraphQLEngineWebsocketUpgrade(roundTripper *TykRoun
 	return nil, true, nil
 }
 
+func returnErrorsFromUpstream(proxyOnlyCtx *GraphQLProxyOnlyContext, resultWriter *graphql.EngineResultWriter) error {
+	body, ok := proxyOnlyCtx.upstreamResponse.Body.(*nopCloserBuffer)
+	if !ok {
+		// Response body already read by graphql-go-tools, and it's not re-readable. Quit silently.
+		return nil
+	}
+	_, err := body.Seek(0, io.SeekStart)
+	if err != nil {
+		return err
+	}
+
+	responseBody, err := io.ReadAll(body)
+	if err != nil {
+		return err
+	}
+	// graphql-go-tools error message format: {"errors": [...]}
+	// Insert the upstream error into the first error message.
+	result, err := jsonparser.Set(resultWriter.Bytes(), responseBody, "errors", "[0]", "extensions")
+	if err != nil {
+		return err
+	}
+	resultWriter.Reset()
+	_, err = resultWriter.Write(result)
+	return err
+}
+
 func (p *ReverseProxy) handoverRequestToGraphQLExecutionEngine(roundTripper *TykRoundTripper, gqlRequest *graphql.Request, outreq *http.Request) (res *http.Response, hijacked bool, err error) {
 	p.TykAPISpec.GraphQLExecutor.Client.Transport = NewGraphQLEngineTransport(DetermineGraphQLEngineTransportType(p.TykAPISpec), roundTripper)
 
@@ -1115,6 +1143,12 @@ func (p *ReverseProxy) handoverRequestToGraphQLExecutionEngine(roundTripper *Tyk
 			if proxyOnlyCtx.upstreamResponse != nil {
 				header = proxyOnlyCtx.upstreamResponse.Header
 				httpStatus = proxyOnlyCtx.upstreamResponse.StatusCode
+				if p.TykAPISpec.GraphQL.Proxy.UseResponseExtensions.OnErrorForwarding && httpStatus >= http.StatusBadRequest {
+					err = returnErrorsFromUpstream(proxyOnlyCtx, &resultWriter)
+					if err != nil {
+						return
+					}
+				}
 			}
 		}
 

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -398,13 +398,14 @@ func ProxyHandler(p *ReverseProxy, apiSpec *APISpec) http.Handler {
 }
 
 const (
-	handlerPathGraphQLProxyUpstream  = "/graphql-proxy-upstream"
-	handlerPathRestDataSource        = "/rest-data-source"
-	handlerPathGraphQLDataSource     = "/graphql-data-source"
-	handlerPathHeadersRestDataSource = "/rest-headers-data-source"
-	handlerSubgraphAccounts          = "/subgraph-accounts"
-	handlerSubgraphAccountsModified  = "/subgraph-accounts-modified"
-	handlerSubgraphReviews           = "/subgraph-reviews"
+	handlerPathGraphQLProxyUpstream      = "/graphql-proxy-upstream"
+	handlerPathGraphQLProxyUpstreamError = "/graphql-proxy-upstream-error"
+	handlerPathRestDataSource            = "/rest-data-source"
+	handlerPathGraphQLDataSource         = "/graphql-data-source"
+	handlerPathHeadersRestDataSource     = "/rest-headers-data-source"
+	handlerSubgraphAccounts              = "/subgraph-accounts"
+	handlerSubgraphAccountsModified      = "/subgraph-accounts-modified"
+	handlerSubgraphReviews               = "/subgraph-reviews"
 
 	// We need a static port so that the urls can be used in static
 	// test data, and to prevent the requests from being randomized
@@ -412,20 +413,21 @@ const (
 	testHttpListen = "127.0.0.1:16500"
 	// Accepts any http requests on /, only allows GET on /get, etc.
 	// All return a JSON with request info.
-	TestHttpAny                  = "http://" + testHttpListen
-	TestHttpGet                  = TestHttpAny + "/get"
-	testHttpPost                 = TestHttpAny + "/post"
-	testGraphQLProxyUpstream     = TestHttpAny + handlerPathGraphQLProxyUpstream
-	testGraphQLDataSource        = TestHttpAny + handlerPathGraphQLDataSource
-	testRESTDataSource           = TestHttpAny + handlerPathRestDataSource
-	testRESTHeadersDataSource    = TestHttpAny + handlerPathHeadersRestDataSource
-	testSubgraphAccounts         = TestHttpAny + handlerSubgraphAccounts
-	testSubgraphAccountsModified = TestHttpAny + handlerSubgraphAccountsModified
-	testSubgraphReviews          = TestHttpAny + handlerSubgraphReviews
-	testHttpJWK                  = TestHttpAny + "/jwk.json"
-	testHttpJWKLegacy            = TestHttpAny + "/jwk-legacy.json"
-	testHttpBundles              = TestHttpAny + "/bundles/"
-	testReloadGroup              = TestHttpAny + "/groupReload"
+	TestHttpAny                   = "http://" + testHttpListen
+	TestHttpGet                   = TestHttpAny + "/get"
+	testHttpPost                  = TestHttpAny + "/post"
+	testGraphQLProxyUpstream      = TestHttpAny + handlerPathGraphQLProxyUpstream
+	testGraphQLProxyUpstreamError = TestHttpAny + handlerPathGraphQLProxyUpstreamError
+	testGraphQLDataSource         = TestHttpAny + handlerPathGraphQLDataSource
+	testRESTDataSource            = TestHttpAny + handlerPathRestDataSource
+	testRESTHeadersDataSource     = TestHttpAny + handlerPathHeadersRestDataSource
+	testSubgraphAccounts          = TestHttpAny + handlerSubgraphAccounts
+	testSubgraphAccountsModified  = TestHttpAny + handlerSubgraphAccountsModified
+	testSubgraphReviews           = TestHttpAny + handlerSubgraphReviews
+	testHttpJWK                   = TestHttpAny + "/jwk.json"
+	testHttpJWKLegacy             = TestHttpAny + "/jwk-legacy.json"
+	testHttpBundles               = TestHttpAny + "/bundles/"
+	testReloadGroup               = TestHttpAny + "/groupReload"
 
 	// Nothing should be listening on port 16501 - useful for
 	// testing TCP and HTTP failures.
@@ -511,6 +513,7 @@ func (s *Test) testHttpHandler(gw *Gateway) *mux.Router {
 	r.HandleFunc("/post", handleMethod("POST"))
 
 	r.HandleFunc(handlerPathGraphQLProxyUpstream, graphqlProxyUpstreamHandler)
+	r.HandleFunc(handlerPathGraphQLProxyUpstreamError, graphqlProxyUpstreamHandlerError)
 	r.HandleFunc(handlerPathGraphQLDataSource, graphqlDataSourceHandler)
 	r.HandleFunc(handlerPathRestDataSource, restDataSourceHandler)
 	r.HandleFunc(handlerPathHeadersRestDataSource, restHeadersDataSourceHandler)
@@ -554,6 +557,11 @@ func chunkedResponseHandler(w http.ResponseWriter, r *http.Request) {
 
 	_, _ = w.Write([]byte(`chunked response`))
 	f.Flush()
+}
+
+func graphqlProxyUpstreamHandlerError(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusInternalServerError)
+	_, _ = w.Write([]byte(`{"error": "Something went wrong"}`))
 }
 
 func graphqlProxyUpstreamHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
[TT-7808] In proxy-only mode, GraphQL query return errors from upstream (#5049)

PR for [TT-7808](https://tyktech.atlassian.net/browse/TT-7808)

We pass the upstream headers and status codes to the client in
proxy-only mode. This is an existing feature. With this PR, we start
attaching the upstream's error messages to the response.

For example, say that a GraphQL service returns the following,
non-standard error message with HTTP 401 status code:

```json
{"message": "Unauthorized"}
```

We return the following error message with HTTP 401 message to the
client:

```json
{
    "errors": [
        {
            "message": "unable to resolve",
            "locations": [
                {
                    "line": 2,
                    "column": 5
                }
            ]
        }
    ],
    "data": null
}
```

It was not possible to reach out to the original error message from
upstream. With this PR, we started returning the following error message
with HTTP 401 status code:

```json
{
    "errors": [
        {
            "message": "unable to resolve",
            "locations": [
                {
                    "line": 2,
                    "column": 5
                }
            ],
            "extensions": {
                "message": "Unauthorized"
            }
        }
    ],
    "data": null
}
```

A new configuration item has been added to the API
definition(`graphql.proxy.return_errors_from_upstream`). This solution
is only valid for proxy-only mode and we only keep the original response
if upstream returns an error(status code >= 400).



[TT-7808]:
https://tyktech.atlassian.net/browse/TT-7808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ