### PR TITLE
[TT-9060] Improvement: Restructure dockerfile to take advantage of caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,12 +56,13 @@ RUN	apt install python3 -y
 RUN find /tmp -type f -delete
 
 # Build gateway
-
 RUN mkdir /opt/tyk-gateway
 WORKDIR /opt/tyk-gateway
+ADD go.mod go.sum /opt/tyk-gateway
+RUN go mod download
 ADD . /opt/tyk-gateway
 
-RUN go mod download && make build && go clean -modcache
+RUN make build
 
 COPY tyk.conf.example tyk.conf
 

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ mongo-shell:
 .PHONY: docker docker-std
 
 docker:
-	docker build --platform ${BUILD_PLATFORM} --no-cache --rm -t internal/tyk-gateway --squash .
+	docker build --platform ${BUILD_PLATFORM} --rm -t internal/tyk-gateway --squash .
 
 docker-std: build
 	docker build --platform ${BUILD_PLATFORM} --no-cache -t internal/tyk-gateway:std -f ci/Dockerfile.std .


### PR DESCRIPTION
Change removes the `--no-cache` option for docker build. The Dockerfile is modified so that `go mod download` gets cached in it's own layer. Only if the contents of go.sum or go.mod are modified, that layer will be rebuilt.