### PR TITLE
Merging to release-5.1: TT-9013 Fix RPCStorageHandler init when loading policies from RPC (#5059)

### DIFF
--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -545,14 +545,9 @@ func (a APIDefinitionLoader) FromDashboardService(endpoint string) ([]*APISpec, 
 }
 
 // FromCloud will connect and download ApiDefintions from a Mongo DB instance.
-func (a APIDefinitionLoader) FromRPC(orgId string, gw *Gateway) ([]*APISpec, error) {
+func (a APIDefinitionLoader) FromRPC(store RPCDataLoader, orgId string, gw *Gateway) ([]*APISpec, error) {
 	if rpc.IsEmergencyMode() {
 		return gw.LoadDefinitionsFromRPCBackup()
-	}
-
-	store := RPCStorageHandler{
-		DoReload: gw.DoReload,
-		Gw:       a.Gw,
 	}
 
 	if !store.Connect() {

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -15,13 +15,9 @@ import (
 	"text/template"
 	"time"
 
-<<<<<<< HEAD
-=======
 	"github.com/TykTechnologies/storage/persistent/model"
-	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/rpc"
 
->>>>>>> 3b6aa955... TT-9013 Fix RPCStorageHandler init when loading policies from RPC (#5059)
 	"github.com/stretchr/testify/assert"
 
 	redis "github.com/go-redis/redis/v8"
@@ -1431,19 +1427,6 @@ func TestAPISpec_GetSessionLifetimeRespectsKeyExpiration(t *testing.T) {
 		assert.True(t, a.GetSessionLifetimeRespectsKeyExpiration())
 	})
 }
-<<<<<<< HEAD
-=======
-
-func TestAPISpec_isListeningOnPort(t *testing.T) {
-	s := APISpec{APIDefinition: &apidef.APIDefinition{}}
-	cfg := &config.Config{}
-
-	cfg.ListenPort = 7000
-	assert.True(t, s.isListeningOnPort(7000, cfg))
-
-	s.ListenPort = 8000
-	assert.True(t, s.isListeningOnPort(8000, cfg))
-}
 
 func Test_LoadAPIsFromRPC(t *testing.T) {
 	ts := StartTest(nil)
@@ -1494,4 +1477,3 @@ func Test_LoadAPIsFromRPC(t *testing.T) {
 		assert.Equal(t, 1, len(apisMap), "expected 0 APIs to be loaded from RPC backup")
 	})
 }
->>>>>>> 3b6aa955... TT-9013 Fix RPCStorageHandler init when loading policies from RPC (#5059)

--- a/gateway/policy.go
+++ b/gateway/policy.go
@@ -201,12 +201,11 @@ func parsePoliciesFromRPC(list string, allowExplicit bool) (map[string]user.Poli
 	return policies, nil
 }
 
-func (gw *Gateway) LoadPoliciesFromRPC(orgId string, allowExplicit bool) (map[string]user.Policy, error) {
+func (gw *Gateway) LoadPoliciesFromRPC(store RPCDataLoader, orgId string, allowExplicit bool) (map[string]user.Policy, error) {
 	if rpc.IsEmergencyMode() {
 		return gw.LoadPoliciesFromRPCBackup()
 	}
 
-	store := &RPCStorageHandler{Gw: gw}
 	if !store.Connect() {
 		return nil, errors.New("Policies backup: Failed connecting to database")
 	}

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/rpc"
 	"github.com/TykTechnologies/tyk/test"
 	"github.com/TykTechnologies/tyk/user"
 
@@ -1550,4 +1551,74 @@ func TestParsePoliciesFromRPC(t *testing.T) {
 		})
 	}
 
+}
+
+type RPCDataLoaderMock struct {
+	ShouldConnect bool
+	Policies      []user.Policy
+	Apis          []nestedApiDefinition
+}
+
+func (s *RPCDataLoaderMock) Connect() bool {
+	return s.ShouldConnect
+}
+
+func (s *RPCDataLoaderMock) GetApiDefinitions(orgId string, tags []string) string {
+	apiList, err := json.Marshal(s.Apis)
+	if err != nil {
+		return ""
+	}
+	return string(apiList)
+}
+func (s *RPCDataLoaderMock) GetPolicies(orgId string) string {
+	policyList, err := json.Marshal(s.Policies)
+	if err != nil {
+		return ""
+	}
+	return string(policyList)
+}
+
+func Test_LoadPoliciesFromRPC(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+	objectID := model.NewObjectID()
+
+	t.Run("load policies from RPC - success", func(t *testing.T) {
+		mockedStorage := &RPCDataLoaderMock{
+			ShouldConnect: true,
+			Policies: []user.Policy{
+				{MID: objectID, ID: "", OrgID: "org1"},
+			},
+		}
+
+		polMap, err := ts.Gw.LoadPoliciesFromRPC(mockedStorage, "org1", true)
+
+		assert.NoError(t, err, "error loading policies from RPC:", err)
+		assert.Equal(t, 1, len(polMap), "expected 0 policies to be loaded from RPC")
+	})
+
+	t.Run("load policies from RPC - success - then fail", func(t *testing.T) {
+		mockedStorage := &RPCDataLoaderMock{
+			ShouldConnect: true,
+			Policies: []user.Policy{
+				{MID: objectID, ID: "", OrgID: "org1"},
+			},
+		}
+		// we load the Policies from RPC successfully - it should store the Policies in the backup
+		polMap, err := ts.Gw.LoadPoliciesFromRPC(mockedStorage, "org1", true)
+
+		assert.NoError(t, err, "error loading policies from RPC:", err)
+		assert.Equal(t, 1, len(polMap), "expected 0 policies to be loaded from RPC")
+
+		// we now simulate a failure to connect to RPC
+		mockedStorage.ShouldConnect = false
+		rpc.SetEmergencyMode(t, true)
+		defer rpc.ResetEmergencyMode()
+
+		// we now try to load the Policies again, and expect it to load the Policies from the backup
+		polMap, err = ts.Gw.LoadPoliciesFromRPC(mockedStorage, "org1", true)
+
+		assert.NoError(t, err, "error loading policies from RPC:", err)
+		assert.Equal(t, 1, len(polMap), "expected 0 policies to be loaded from RPC")
+	})
 }

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -110,6 +110,12 @@ type RPCStorageHandler struct {
 	Gw               *Gateway `json:"-"`
 }
 
+type RPCDataLoader interface {
+	Connect() bool
+	GetApiDefinitions(orgId string, tags []string) string
+	GetPolicies(orgId string) string
+}
+
 // Connect will establish a connection to the RPC
 func (r *RPCStorageHandler) Connect() bool {
 	slaveOptions := r.Gw.GetConfig().SlaveOptions

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -473,8 +473,12 @@ func (gw *Gateway) syncAPISpecs() (int, error) {
 	} else if gw.GetConfig().SlaveOptions.UseRPC {
 		mainLog.Debug("Using RPC Configuration")
 
+		dataLoader := &RPCStorageHandler{
+			Gw:       gw,
+			DoReload: gw.DoReload,
+		}
 		var err error
-		s, err = loader.FromRPC(gw.GetConfig().SlaveOptions.RPCKey, gw)
+		s, err = loader.FromRPC(dataLoader, gw.GetConfig().SlaveOptions.RPCKey, gw)
 		if err != nil {
 			return 0, err
 		}
@@ -531,7 +535,11 @@ func (gw *Gateway) syncPolicies() (count int, err error) {
 		pols = gw.LoadPoliciesFromDashboard(connStr, gw.GetConfig().NodeSecret, gw.GetConfig().Policies.AllowExplicitPolicyID)
 	case "rpc":
 		mainLog.Debug("Using Policies from RPC")
-		pols, err = gw.LoadPoliciesFromRPC(gw.GetConfig().SlaveOptions.RPCKey, gw.GetConfig().Policies.AllowExplicitPolicyID)
+		dataLoader := &RPCStorageHandler{
+			Gw:       gw,
+			DoReload: gw.DoReload,
+		}
+		pols, err = gw.LoadPoliciesFromRPC(dataLoader, gw.GetConfig().SlaveOptions.RPCKey, gw.GetConfig().Policies.AllowExplicitPolicyID)
 	default:
 		//if policy path defined we want to allow use of the REST API
 		if gw.GetConfig().Policies.PolicyPath != "" {

--- a/rpc/rpc_client.go
+++ b/rpc/rpc_client.go
@@ -535,5 +535,11 @@ func ForceConnected(t *testing.T) {
 
 // SetEmergencyMode used in tests to force emergency mode
 func SetEmergencyMode(t *testing.T, value bool) {
+	t.Helper()
 	values.SetEmergencyMode(value)
+}
+
+func SetLoadCounts(t *testing.T, value int) {
+	t.Helper()
+	values.SetLoadCounts(value)
 }


### PR DESCRIPTION
TT-9013 Fix RPCStorageHandler init when loading policies from RPC (#5059)

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->
This PR adds a `DoReload` func to the RPCStorageHandler used in the
policy loading layer. This was causing an empty
`emergencyModeLoadedCallback` func on rpc layer, which in the end,
didn't allow the data being load from Redis on MDCB failure

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->
https://tyktech.atlassian.net/browse/TT-9013
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
https://tyktech.atlassian.net/browse/TT-9013
## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->
Added unit tests + tested manually.


## Screenshots (if appropriate)

![image](https://github.com/TykTechnologies/tyk/assets/25751713/ff5d5c73-78e4-4969-ada5-435ceab1c5f4)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why