### PR TITLE
[TT-926] fix security vulnerability that exposes key in the log when …

### DIFF
--- a/gateway/auth_manager.go
+++ b/gateway/auth_manager.go
@@ -53,8 +53,12 @@ func (b *DefaultSessionManager) Store() storage.Handler {
 
 func (b *DefaultSessionManager) ResetQuota(keyName string, session *user.SessionState, isHashed bool) {
 	origKeyName := keyName
+	//is the key hashed? no, then do we want to hash the key? no, then we need to obfuscate the key
 	if !isHashed {
 		keyName = storage.HashKey(keyName, b.Gw.GetConfig().HashKeys)
+	}
+	if !b.Gw.GetConfig().HashKeys && !b.Gw.GetConfig().EnableKeyLogging {
+		keyName = b.Gw.obfuscateKey(origKeyName)
 	}
 
 	rawKey := QuotaKeyPrefix + keyName
@@ -82,7 +86,6 @@ func (b *DefaultSessionManager) clearCacheForKey(keyName string, hashed bool) {
 	if !hashed {
 		cacheKey = storage.HashKey(keyName, b.Gw.GetConfig().HashKeys)
 	}
-
 	// Delete gateway's cache immediately
 	b.Gw.SessionCache.Delete(cacheKey)
 


### PR DESCRIPTION
This pull requesrt fixes this [vulnerbaility](https://tyktech.atlassian.net/browse/TT-926).

The problem involved the HashKey function in [storage.go](https://github.com/TykTechnologies/tyk/blob/76a00611f33e150b1b6145264909baeefa1cbd4f/storage/storage.go#L170). It returns the key without hashing if "hash_keys" is set to false in the tyk.conf file. Now I've added a conditional that obfuscates the key if "hash_keys" and "enable_key_logging" are set to false. 

