### PR TITLE
Merging to release-5.1: [TT-8708] Fix client mTLS when protocol=tls (#5038)

### DIFF
--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -1803,3 +1803,12 @@ func (s *APISpec) hasVirtualEndpoint() bool {
 
 	return false
 }
+
+// isListeningOnPort checks whether the API listens on the given port.
+func (s *APISpec) isListeningOnPort(port int, gwConfig *config.Config) bool {
+	if s.ListenPort == 0 {
+		return gwConfig.ListenPort == port
+	}
+
+	return s.ListenPort == port
+}

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -15,6 +15,8 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/TykTechnologies/tyk/config"
+
 	"github.com/stretchr/testify/assert"
 
 	redis "github.com/go-redis/redis/v8"
@@ -1423,4 +1425,15 @@ func TestAPISpec_GetSessionLifetimeRespectsKeyExpiration(t *testing.T) {
 		a.SessionLifetimeRespectsKeyExpiration = true
 		assert.True(t, a.GetSessionLifetimeRespectsKeyExpiration())
 	})
+}
+
+func TestAPISpec_isListeningOnPort(t *testing.T) {
+	s := APISpec{APIDefinition: &apidef.APIDefinition{}}
+	cfg := &config.Config{}
+
+	cfg.ListenPort = 7000
+	assert.True(t, s.isListeningOnPort(7000, cfg))
+
+	s.ListenPort = 8000
+	assert.True(t, s.isListeningOnPort(8000, cfg))
 }

--- a/gateway/cert.go
+++ b/gateway/cert.go
@@ -396,6 +396,11 @@ func (gw *Gateway) getTLSConfigForClient(baseConfig *tls.Config, listenPort int)
 		}
 
 		for _, spec := range gw.apiSpecs {
+			// eliminate APIs which are not in the current port
+			if !spec.isListeningOnPort(listenPort, &gwConfig) {
+				continue
+			}
+
 			switch {
 			case spec.UseMutualTLSAuth:
 				if domainRequireCert[spec.Domain] == 0 {

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -1433,3 +1433,138 @@ func TestCipherSuites(t *testing.T) {
 		_, _ = ts.Run(t, test.TestCase{Client: client, Path: "/", ErrorMatch: "tls: handshake failure"})
 	})
 }
+<<<<<<< HEAD
+=======
+
+func TestUpstreamCertificates_WithProtocolTCP(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	cert, key, _, _ := certs.GenCertificate(&x509.Certificate{}, false)
+	certificate, _ := tls.X509KeyPair(cert, key)
+
+	upstreamCert, _, combinedUpstreamCertPEM, _ := certs.GenServerCertificate()
+
+	certPool := x509.NewCertPool()
+	certPool.AppendCertsFromPEM(upstreamCert)
+
+	serverTLSConfig := &tls.Config{Certificates: []tls.Certificate{certificate}, ClientCAs: certPool, ClientAuth: tls.RequireAndVerifyClientCert}
+	ls, err := tls.Listen("tcp", "127.0.0.1:8003", serverTLSConfig)
+	assert.NoError(t, err)
+	defer ls.Close()
+
+	go listenProxyProto(ls)
+
+	certID, err := ts.Gw.CertificateManager.Add(combinedUpstreamCertPEM, "")
+	defer ts.Gw.CertificateManager.Delete(certID, "")
+
+	ts.EnablePort(6001, "tcp")
+	api := ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/"
+		spec.Protocol = "tcp"
+		spec.ListenPort = 6001
+		spec.Proxy.TargetURL = "tls://127.0.0.1:8003"
+		spec.Proxy.Transport.SSLInsecureSkipVerify = true
+		spec.UpstreamCertificates = map[string]string{
+			"*": certID,
+		}
+	})[0]
+
+	t.Run("enabled", func(t *testing.T) {
+		client, err := net.Dial("tcp", "127.0.0.1:6001")
+		assert.NoError(t, err)
+		defer client.Close()
+
+		_, _ = client.Write([]byte("ping"))
+		received := make([]byte, 4)
+		_, err = client.Read(received)
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("pong"), received)
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		api.UpstreamCertificates = nil
+		ts.Gw.LoadAPI(api)
+
+		client, err := net.Dial("tcp", "127.0.0.1:6001")
+		assert.NoError(t, err)
+		defer client.Close()
+
+		_, _ = client.Write([]byte("ping"))
+		received := make([]byte, 4)
+		n, err := client.Read(received)
+		assert.Error(t, err)
+		assert.Equal(t, 0, n)
+	})
+}
+
+func TestClientCertificates_WithProtocolTLS(t *testing.T) {
+	const (
+		upstreamAddr    = "127.0.0.1:8005"
+		proxyListenPort = 6005
+	)
+
+	// upstream
+	upstream, err := net.Listen("tcp", upstreamAddr)
+	assert.NoError(t, err)
+	defer upstream.Close()
+
+	go listenProxyProto(upstream)
+
+	// tyk
+	_, _, tykServerCombinedPEM, _ := certs.GenServerCertificate()
+	serverCertID, _, _ := certs.GetCertIDAndChainPEM(tykServerCombinedPEM, "")
+
+	ts := StartTest(func(globalConf *config.Config) {
+		globalConf.HttpServerOptions.UseSSL = false
+		globalConf.HttpServerOptions.SSLCertificates = []string{serverCertID}
+	})
+	defer ts.Close()
+
+	_, _ = ts.Gw.CertificateManager.Add(tykServerCombinedPEM, "")
+	defer ts.Gw.CertificateManager.Delete(serverCertID, "")
+
+	cert, key, combinedClientCertPEM, _ := certs.GenServerCertificate()
+	clientCertificate, err := tls.X509KeyPair(cert, key)
+	assert.NoError(t, err)
+
+	clientCertificateID, err := ts.Gw.CertificateManager.Add(combinedClientCertPEM, "")
+	defer ts.Gw.CertificateManager.Delete(clientCertificateID, "")
+
+	ts.EnablePort(proxyListenPort, "tls")
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/"
+		spec.Protocol = "tls"
+		spec.ListenPort = proxyListenPort
+		spec.Proxy.TargetURL = "tcp://" + upstreamAddr
+		spec.UseMutualTLSAuth = true
+		spec.UseMutualTLSAuth = true
+		spec.ClientCertificates = []string{clientCertificateID}
+	}, func(spec *APISpec) {
+		spec.Name = "another-api-on-control-port" // required to cover the case where there is another API in a different port.
+	})
+
+	apiAddr := fmt.Sprintf(":%d", proxyListenPort)
+	mTLSConfig := &tls.Config{InsecureSkipVerify: true}
+
+	// client
+	t.Run("bad certificate", func(t *testing.T) {
+		_, err := tls.Dial("tcp", apiAddr, mTLSConfig)
+		assert.ErrorContains(t, err, badcertErr)
+	})
+
+	t.Run("correct certificate", func(t *testing.T) {
+		mTLSConfig.Certificates = append(mTLSConfig.Certificates, clientCertificate)
+
+		client, err := tls.Dial("tcp", apiAddr, mTLSConfig)
+		assert.NoError(t, err)
+		defer client.Close()
+
+		_, _ = client.Write([]byte("ping"))
+		received := make([]byte, 4)
+		_, err = client.Read(received)
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("pong"), received)
+	})
+}
+>>>>>>> 8e5284cd... [TT-8708] Fix client mTLS when protocol=tls (#5038)


### PR DESCRIPTION
[TT-8708] Fix client mTLS when protocol=tls (#5038)

This PR fixes client certificates are not respected when API protocol is
set as `tls`. It happens because APIs which are not in the called port
interfering and manipulating while setting certificate requirements.