### PR TITLE
Merging to release-5.1: [TT-7808] In proxy-only mode, GraphQL query return errors from upstream (#5049)

### DIFF
--- a/apidef/adapter/asyncapi_test.go
+++ b/apidef/adapter/asyncapi_test.go
@@ -321,7 +321,10 @@ const expectedGraphqlConfig = `{
     },
     "proxy": {
         "auth_headers": {},
-        "request_headers": null
+        "request_headers": null,
+        "use_response_extensions": {
+            "on_error_forwarding": false
+        }
     },
     "subgraph": {
         "sdl": ""

--- a/apidef/adapter/openapi_test.go
+++ b/apidef/adapter/openapi_test.go
@@ -302,7 +302,10 @@ const expectedOpenAPIGraphQLConfig = `{
     },
     "proxy": {
         "auth_headers": {},
-        "request_headers": null
+        "request_headers": null,
+        "use_response_extensions": {
+            "on_error_forwarding": false
+        }
     },
     "subgraph": {
         "sdl": ""

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -748,10 +748,15 @@ const (
 	GraphQLConfigVersion2    GraphQLConfigVersion = "2"
 )
 
+type GraphQLResponseExtensions struct {
+	OnErrorForwarding bool `bson:"on_error_forwarding" json:"on_error_forwarding"`
+}
+
 type GraphQLProxyConfig struct {
-	AuthHeaders      map[string]string `bson:"auth_headers" json:"auth_headers"`
-	SubscriptionType SubscriptionType  `bson:"subscription_type" json:"subscription_type,omitempty"`
-	RequestHeaders   map[string]string `bson:"request_headers" json:"request_headers"`
+	AuthHeaders           map[string]string         `bson:"auth_headers" json:"auth_headers"`
+	SubscriptionType      SubscriptionType          `bson:"subscription_type" json:"subscription_type,omitempty"`
+	RequestHeaders        map[string]string         `bson:"request_headers" json:"request_headers"`
+	UseResponseExtensions GraphQLResponseExtensions `bson:"use_response_extensions" json:"use_response_extensions"`
 }
 
 type GraphQLSubgraphConfig struct {

--- a/gateway/mw_graphql_test.go
+++ b/gateway/mw_graphql_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/buger/jsonparser"
+
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -286,6 +288,34 @@ func TestGraphQLMiddleware_EngineMode(t *testing.T) {
 				},
 			}...)
 
+		})
+
+		t.Run("proxy-only return errors from upstream", func(t *testing.T) {
+			g.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+				spec.UseKeylessAccess = true
+				spec.GraphQL.Enabled = true
+				spec.GraphQL.ExecutionMode = apidef.GraphQLExecutionModeProxyOnly
+				spec.GraphQL.Version = apidef.GraphQLConfigVersion2
+				spec.GraphQL.Schema = gqlProxyUpstreamSchema
+				spec.GraphQL.Proxy.UseResponseExtensions.OnErrorForwarding = true
+				spec.Proxy.ListenPath = "/"
+				spec.Proxy.TargetURL = testGraphQLProxyUpstreamError
+			})
+
+			request := gql.Request{
+				Query: `{ hello(name: "World") httpMethod }`,
+			}
+			_, _ = g.Run(t, test.TestCase{
+				Data:   request,
+				Method: http.MethodPost,
+				Code:   http.StatusInternalServerError,
+				BodyMatchFunc: func(i []byte) bool {
+					value, _, _, err := jsonparser.Get(i, "errors", "[0]", "extensions", "error")
+					if err != nil {
+						return false
+					}
+					return string(value) == "Something went wrong"
+				}})
 		})
 
 		t.Run("subgraph", func(t *testing.T) {

--- a/gateway/mw_graphql_transport.go
+++ b/gateway/mw_graphql_transport.go
@@ -1,7 +1,9 @@
 package gateway
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"net/http"
 
 	"github.com/TykTechnologies/tyk/apidef"
@@ -81,6 +83,26 @@ func (g *GraphQLEngineTransport) handleProxyOnly(proxyOnlyCtx *GraphQLProxyOnlyC
 		return nil, err
 	}
 
+	if response.StatusCode >= http.StatusBadRequest {
+		// In proxy-only mode, we keep the upstream error message to
+		// insert into the library's error message.
+		body, err := io.ReadAll(response.Body)
+		if err != nil {
+			return nil, err
+		}
+		defer func() {
+			_ = response.Body.Close()
+		}()
+		// graphql-go-tools uses response.body to resolve the upstream response.
+		// It's not possible to re-use io.ReadCloser. Because of that, we keep the
+		// original error message for later use.
+		// See TT-7808
+		reusableBody, err := newNopCloserBuffer(io.NopCloser(bytes.NewReader(body)))
+		if err != nil {
+			return nil, err
+		}
+		response.Body = reusableBody
+	}
 	proxyOnlyCtx.upstreamResponse = response
 	return response, err
 }

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -28,6 +28,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/buger/jsonparser"
+
 	"github.com/gorilla/websocket"
 	"github.com/jensneuse/abstractlogger"
 
@@ -1020,6 +1022,32 @@ func (p *ReverseProxy) handleGraphQLEngineWebsocketUpgrade(roundTripper *TykRoun
 	return nil, true, nil
 }
 
+func returnErrorsFromUpstream(proxyOnlyCtx *GraphQLProxyOnlyContext, resultWriter *graphql.EngineResultWriter) error {
+	body, ok := proxyOnlyCtx.upstreamResponse.Body.(*nopCloserBuffer)
+	if !ok {
+		// Response body already read by graphql-go-tools, and it's not re-readable. Quit silently.
+		return nil
+	}
+	_, err := body.Seek(0, io.SeekStart)
+	if err != nil {
+		return err
+	}
+
+	responseBody, err := io.ReadAll(body)
+	if err != nil {
+		return err
+	}
+	// graphql-go-tools error message format: {"errors": [...]}
+	// Insert the upstream error into the first error message.
+	result, err := jsonparser.Set(resultWriter.Bytes(), responseBody, "errors", "[0]", "extensions")
+	if err != nil {
+		return err
+	}
+	resultWriter.Reset()
+	_, err = resultWriter.Write(result)
+	return err
+}
+
 func (p *ReverseProxy) handoverRequestToGraphQLExecutionEngine(roundTripper *TykRoundTripper, gqlRequest *graphql.Request, outreq *http.Request) (res *http.Response, hijacked bool, err error) {
 	p.TykAPISpec.GraphQLExecutor.Client.Transport = NewGraphQLEngineTransport(DetermineGraphQLEngineTransportType(p.TykAPISpec), roundTripper)
 
@@ -1095,6 +1123,12 @@ func (p *ReverseProxy) handoverRequestToGraphQLExecutionEngine(roundTripper *Tyk
 			if proxyOnlyCtx.upstreamResponse != nil {
 				header = proxyOnlyCtx.upstreamResponse.Header
 				httpStatus = proxyOnlyCtx.upstreamResponse.StatusCode
+				if p.TykAPISpec.GraphQL.Proxy.UseResponseExtensions.OnErrorForwarding && httpStatus >= http.StatusBadRequest {
+					err = returnErrorsFromUpstream(proxyOnlyCtx, &resultWriter)
+					if err != nil {
+						return
+					}
+				}
 			}
 		}
 

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -398,13 +398,14 @@ func ProxyHandler(p *ReverseProxy, apiSpec *APISpec) http.Handler {
 }
 
 const (
-	handlerPathGraphQLProxyUpstream  = "/graphql-proxy-upstream"
-	handlerPathRestDataSource        = "/rest-data-source"
-	handlerPathGraphQLDataSource     = "/graphql-data-source"
-	handlerPathHeadersRestDataSource = "/rest-headers-data-source"
-	handlerSubgraphAccounts          = "/subgraph-accounts"
-	handlerSubgraphAccountsModified  = "/subgraph-accounts-modified"
-	handlerSubgraphReviews           = "/subgraph-reviews"
+	handlerPathGraphQLProxyUpstream      = "/graphql-proxy-upstream"
+	handlerPathGraphQLProxyUpstreamError = "/graphql-proxy-upstream-error"
+	handlerPathRestDataSource            = "/rest-data-source"
+	handlerPathGraphQLDataSource         = "/graphql-data-source"
+	handlerPathHeadersRestDataSource     = "/rest-headers-data-source"
+	handlerSubgraphAccounts              = "/subgraph-accounts"
+	handlerSubgraphAccountsModified      = "/subgraph-accounts-modified"
+	handlerSubgraphReviews               = "/subgraph-reviews"
 
 	// We need a static port so that the urls can be used in static
 	// test data, and to prevent the requests from being randomized
@@ -412,20 +413,21 @@ const (
 	testHttpListen = "127.0.0.1:16500"
 	// Accepts any http requests on /, only allows GET on /get, etc.
 	// All return a JSON with request info.
-	TestHttpAny                  = "http://" + testHttpListen
-	TestHttpGet                  = TestHttpAny + "/get"
-	testHttpPost                 = TestHttpAny + "/post"
-	testGraphQLProxyUpstream     = TestHttpAny + handlerPathGraphQLProxyUpstream
-	testGraphQLDataSource        = TestHttpAny + handlerPathGraphQLDataSource
-	testRESTDataSource           = TestHttpAny + handlerPathRestDataSource
-	testRESTHeadersDataSource    = TestHttpAny + handlerPathHeadersRestDataSource
-	testSubgraphAccounts         = TestHttpAny + handlerSubgraphAccounts
-	testSubgraphAccountsModified = TestHttpAny + handlerSubgraphAccountsModified
-	testSubgraphReviews          = TestHttpAny + handlerSubgraphReviews
-	testHttpJWK                  = TestHttpAny + "/jwk.json"
-	testHttpJWKLegacy            = TestHttpAny + "/jwk-legacy.json"
-	testHttpBundles              = TestHttpAny + "/bundles/"
-	testReloadGroup              = TestHttpAny + "/groupReload"
+	TestHttpAny                   = "http://" + testHttpListen
+	TestHttpGet                   = TestHttpAny + "/get"
+	testHttpPost                  = TestHttpAny + "/post"
+	testGraphQLProxyUpstream      = TestHttpAny + handlerPathGraphQLProxyUpstream
+	testGraphQLProxyUpstreamError = TestHttpAny + handlerPathGraphQLProxyUpstreamError
+	testGraphQLDataSource         = TestHttpAny + handlerPathGraphQLDataSource
+	testRESTDataSource            = TestHttpAny + handlerPathRestDataSource
+	testRESTHeadersDataSource     = TestHttpAny + handlerPathHeadersRestDataSource
+	testSubgraphAccounts          = TestHttpAny + handlerSubgraphAccounts
+	testSubgraphAccountsModified  = TestHttpAny + handlerSubgraphAccountsModified
+	testSubgraphReviews           = TestHttpAny + handlerSubgraphReviews
+	testHttpJWK                   = TestHttpAny + "/jwk.json"
+	testHttpJWKLegacy             = TestHttpAny + "/jwk-legacy.json"
+	testHttpBundles               = TestHttpAny + "/bundles/"
+	testReloadGroup               = TestHttpAny + "/groupReload"
 
 	// Nothing should be listening on port 16501 - useful for
 	// testing TCP and HTTP failures.
@@ -511,6 +513,7 @@ func (s *Test) testHttpHandler(gw *Gateway) *mux.Router {
 	r.HandleFunc("/post", handleMethod("POST"))
 
 	r.HandleFunc(handlerPathGraphQLProxyUpstream, graphqlProxyUpstreamHandler)
+	r.HandleFunc(handlerPathGraphQLProxyUpstreamError, graphqlProxyUpstreamHandlerError)
 	r.HandleFunc(handlerPathGraphQLDataSource, graphqlDataSourceHandler)
 	r.HandleFunc(handlerPathRestDataSource, restDataSourceHandler)
 	r.HandleFunc(handlerPathHeadersRestDataSource, restHeadersDataSourceHandler)
@@ -554,6 +557,11 @@ func chunkedResponseHandler(w http.ResponseWriter, r *http.Request) {
 
 	_, _ = w.Write([]byte(`chunked response`))
 	f.Flush()
+}
+
+func graphqlProxyUpstreamHandlerError(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusInternalServerError)
+	_, _ = w.Write([]byte(`{"error": "Something went wrong"}`))
 }
 
 func graphqlProxyUpstreamHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
[TT-7808] In proxy-only mode, GraphQL query return errors from upstream (#5049)

PR for [TT-7808](https://tyktech.atlassian.net/browse/TT-7808)

We pass the upstream headers and status codes to the client in
proxy-only mode. This is an existing feature. With this PR, we start
attaching the upstream's error messages to the response.

For example, say that a GraphQL service returns the following,
non-standard error message with HTTP 401 status code:

```json
{"message": "Unauthorized"}
```

We return the following error message with HTTP 401 message to the
client:

```json
{
    "errors": [
        {
            "message": "unable to resolve",
            "locations": [
                {
                    "line": 2,
                    "column": 5
                }
            ]
        }
    ],
    "data": null
}
```

It was not possible to reach out to the original error message from
upstream. With this PR, we started returning the following error message
with HTTP 401 status code:

```json
{
    "errors": [
        {
            "message": "unable to resolve",
            "locations": [
                {
                    "line": 2,
                    "column": 5
                }
            ],
            "extensions": {
                "message": "Unauthorized"
            }
        }
    ],
    "data": null
}
```

A new configuration item has been added to the API
definition(`graphql.proxy.return_errors_from_upstream`). This solution
is only valid for proxy-only mode and we only keep the original response
if upstream returns an error(status code >= 400).



[TT-7808]:
https://tyktech.atlassian.net/browse/TT-7808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ