### PR TITLE
fix issue when scope contains spaces (TT-6455)

### DIFF
--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -527,7 +527,7 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 			scopeClaimName = "scope"
 		}
 
-		if scope := getScopeFromClaim(claims, scopeClaimName); scope != nil {
+		if scope := getScopeFromClaim(claims, scopeClaimName); len(scope) > 0 {
 			polIDs := []string{
 				basePolicyID, // add base policy as a first one
 			}

--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -289,9 +289,7 @@ func toScopeStringsSlice(v interface{}, scopeSlice *[]string, nested bool) []str
 	case string:
 		if !nested {
 			splitStringScopes := strings.Split(e, " ")
-			for _, scope := range splitStringScopes {
-				*scopeSlice = append(*scopeSlice, scope)
-			}
+			*scopeSlice = append(*scopeSlice, splitStringScopes...)
 		} else {
 			*scopeSlice = append(*scopeSlice, e)
 		}

--- a/gateway/mw_jwt_test.go
+++ b/gateway/mw_jwt_test.go
@@ -1294,6 +1294,18 @@ func TestGetScopeFromClaim(t *testing.T) {
 			expectedClaims: []string{"foo", "bar", "baz"},
 			name:           "nested slice strings",
 		},
+		{
+			jwt:            `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMiwic2NvcGUiOlsiZm9vIGJhciIsImJheiJdfQ.XYJ5gEHQhKxLMhXrYsQ7prZ98bty9UPa7LXvF5N4IPM`,
+			key:            "scope",
+			expectedClaims: []string{"foo bar", "baz"},
+			name:           "slice strings with spaced values",
+		},
+		{
+			jwt:            `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMiwic2NvcGUiOlsiZm9vIGJhciIsImJheiIsWyJoZWxsbyB3b3JsZCIsIm9uZSJdXX0.A6Yc-WEZSGtOy8hBMsMrvRXNNKSDO7OLMdznoYERKWk`,
+			key:            "scope",
+			expectedClaims: []string{"foo bar", "baz", "hello world", "one"},
+			name:           "nested slice strings with spaced values",
+		},
 	}
 
 	pubKey := []byte(`mysecret`)


### PR DESCRIPTION
This PR fixes an issue when a scope contains a space inside an array:

Example:
```
{
  "claim": ["nospace", "with space"]
}
```

This will now be parsed to:
```
["nospace", "with space"]
```

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

