### PR TITLE
Merging to release-5.1: fix issue when scope contains spaces (TT-6455) (#5084)

### DIFF
--- a/gateway/mw_jwt_test.go
+++ b/gateway/mw_jwt_test.go
@@ -1294,6 +1294,18 @@ func TestGetScopeFromClaim(t *testing.T) {
 			expectedClaims: []string{"foo", "bar", "baz"},
 			name:           "nested slice strings",
 		},
+		{
+			jwt:            `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMiwic2NvcGUiOlsiZm9vIGJhciIsImJheiJdfQ.XYJ5gEHQhKxLMhXrYsQ7prZ98bty9UPa7LXvF5N4IPM`,
+			key:            "scope",
+			expectedClaims: []string{"foo bar", "baz"},
+			name:           "slice strings with spaced values",
+		},
+		{
+			jwt:            `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMiwic2NvcGUiOlsiZm9vIGJhciIsImJheiIsWyJoZWxsbyB3b3JsZCIsIm9uZSJdXX0.A6Yc-WEZSGtOy8hBMsMrvRXNNKSDO7OLMdznoYERKWk`,
+			key:            "scope",
+			expectedClaims: []string{"foo bar", "baz", "hello world", "one"},
+			name:           "nested slice strings with spaced values",
+		},
 	}
 
 	pubKey := []byte(`mysecret`)


### PR DESCRIPTION
fix issue when scope contains spaces (TT-6455) (#5084)

This PR fixes an issue when a scope contains a space inside an array:

Example:
```
{
  "claim": ["nospace", "with space"]
}
```

This will now be parsed to:
```
["nospace", "with space"]
```

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)