### PR TITLE
Merging to release-5.1: [TT-2598] rewrite host only when newURL host is not empty. (#5092)

### DIFF
--- a/gateway/mw_url_rewrite.go
+++ b/gateway/mw_url_rewrite.go
@@ -431,23 +431,39 @@ func (m *URLRewriteMiddleware) EnabledForSpec() bool {
 	return false
 }
 
-func (m *URLRewriteMiddleware) CheckHostRewrite(oldPath, newTarget string, r *http.Request) {
+func (m *URLRewriteMiddleware) CheckHostRewrite(oldPath, newTarget string, r *http.Request) error {
 	oldAsURL, errParseOld := url.Parse(oldPath)
 	if errParseOld != nil {
-		log.WithError(errParseOld).WithField("url", oldPath).Error("could not parse")
-		return
+		return errParseOld
 	}
 
 	newAsURL, errParseNew := url.Parse(newTarget)
 	if errParseNew != nil {
-		log.WithError(errParseNew).WithField("url", newTarget).Error("could not parse")
-		return
+		return errParseNew
 	}
 
-	if newAsURL.Scheme != LoopScheme && oldAsURL.Host != newAsURL.Host {
+	if shouldRewriteHost(oldAsURL, newAsURL) {
 		log.Debug("Detected a host rewrite in pattern!")
 		setCtxValue(r, ctx.RetainHost, true)
 	}
+
+	return nil
+}
+
+func shouldRewriteHost(oldURL, newURL *url.URL) bool {
+	if newURL.Scheme == "" {
+		return false
+	}
+
+	if newURL.Scheme == LoopScheme {
+		return false
+	}
+
+	if oldURL.Host == newURL.Host {
+		return false
+	}
+
+	return true
 }
 
 const LoopScheme = "tyk"
@@ -495,7 +511,9 @@ func (m *URLRewriteMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 		})
 	}
 
-	m.CheckHostRewrite(oldPath, p, r)
+	if err = m.CheckHostRewrite(oldPath, p, r); err != nil {
+		log.WithError(err).WithField("from", oldPath).WithField("to", p).Error("Checking Host rewrite: error parsing URL")
+	}
 
 	newURL, err := url.Parse(p)
 	if err != nil {


### PR DESCRIPTION
[TT-2598] rewrite host only when newURL host is not empty. (#5092)

<!-- Provide a general summary of your changes in the Title above -->

## Description
Currently Proxying error happens in `ReverseProxy.director` in
https://github.com/TykTechnologies/tyk/blob/b3415a1a2deb864c3932dc7d86e99de3680fea7c/gateway/reverse_proxy.go#L256.
This is triggered with `ctx.RetainHost` which is updated from
`URLRewriteMiddleware.CheckHostRewrite()`, it doesn't check whether the
new URL has a scheme specified causing this issue.
https://github.com/TykTechnologies/tyk/blob/b3415a1a2deb864c3932dc7d86e99de3680fea7c/gateway/mw_url_rewrite.go#L447.
This PR fixes it.

## Related Issue
https://tyktech.atlassian.net/browse/TT-2598

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why

[TT-2598]: https://tyktech.atlassian.net/browse/TT-2598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ