### PR TITLE
Merging to release-5-lts: [TT-9060] Improvement: Restructure dockerfile to take advantage of caching (#5060)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye as assets
+FROM debian:bullseye AS assets
 
 # This Dockerfile facilitates bleeding edge development docker image builds
 # directly from source. To build a development image, run `make docker`.
@@ -62,11 +62,7 @@ ADD go.mod go.sum /opt/tyk-gateway
 RUN go mod download
 ADD . /opt/tyk-gateway
 
-<<<<<<< HEAD
-RUN make build && go clean -modcache
-=======
 RUN make build
->>>>>>> 76a00611... [TT-9060] Improvement: Restructure dockerfile to take advantage of caching (#5060)
 
 COPY tyk.conf.example tyk.conf
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,12 +56,17 @@ RUN	apt install python3 -y
 RUN find /tmp -type f -delete
 
 # Build gateway
-
 RUN mkdir /opt/tyk-gateway
 WORKDIR /opt/tyk-gateway
+ADD go.mod go.sum /opt/tyk-gateway
+RUN go mod download
 ADD . /opt/tyk-gateway
 
+<<<<<<< HEAD
 RUN make build && go clean -modcache
+=======
+RUN make build
+>>>>>>> 76a00611... [TT-9060] Improvement: Restructure dockerfile to take advantage of caching (#5060)
 
 COPY tyk.conf.example tyk.conf
 

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ mongo-shell:
 .PHONY: docker docker-std
 
 docker:
-	docker build --platform ${BUILD_PLATFORM} --no-cache --rm -t internal/tyk-gateway --squash .
+	docker build --platform ${BUILD_PLATFORM} --rm -t internal/tyk-gateway --squash .
 
 docker-std: build
 	docker build --platform ${BUILD_PLATFORM} --no-cache -t internal/tyk-gateway:std -f ci/Dockerfile.std .


### PR DESCRIPTION
[TT-9060] Improvement: Restructure dockerfile to take advantage of caching (#5060)

Change removes the `--no-cache` option for docker build. The Dockerfile
is modified so that `go mod download` gets cached in it's own layer.
Only if the contents of go.sum or go.mod are modified, that layer will
be rebuilt.

Co-authored-by: Tit Petric <tit@tyk.io>

[TT-9060]: https://tyktech.atlassian.net/browse/TT-9060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ