### PR TITLE
Merging to release-5-lts: [TT-9062] Improvement: Enable rolling profiling of gateway (#5061)

### DIFF
--- a/gateway/server.go
+++ b/gateway/server.go
@@ -1566,17 +1566,24 @@ func Start() {
 		gw.reloadURLStructure(func() {})
 	}, &configs)
 
+	unix := time.Now().Unix()
+
+	var (
+		memprofile = fmt.Sprintf("tyk.%d.mprof", unix)
+		cpuprofile = fmt.Sprintf("tyk.%d.prof", unix)
+	)
+
 	if *cli.MemProfile {
 		mainLog.Debug("Memory profiling active")
 		var err error
-		if memProfFile, err = os.Create("tyk.mprof"); err != nil {
+		if memProfFile, err = os.Create(memprofile); err != nil {
 			panic(err)
 		}
 		defer memProfFile.Close()
 	}
 	if *cli.CPUProfile {
 		mainLog.Info("Cpu profiling active")
-		cpuProfFile, err := os.Create("tyk.prof")
+		cpuProfFile, err := os.Create(cpuprofile)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
[TT-9062] Improvement: Enable rolling profiling of gateway (#5061)

PR contains a behaviour change when using `--memprofile` or
`--cpuprofile` options.

Before: `tyk.mprof` and `tyk.prof` would be written out.
After: `tyk.<unixtime>.mprof` and `tyk.<unixtime>.prof` would be written
out.

This enables continous collection of memory and cpu profiles without
overwriting.

After running `./tyk --memprofile --cpuprofile` two times, you'd have
two profiles.

```
# ls ./tyk* -la
-rwxr-xr-x 1 root root 61226168 May 25 16:31 ./tyk
-rw-r--r-- 1 root root        0 May 25 16:32 ./tyk.1685025153.mprof
-rw-r--r-- 1 root root     2093 May 25 16:32 ./tyk.1685025153.prof
-rw-r--r-- 1 root root        0 May 25 16:33 ./tyk.1685025183.mprof
-rw-r--r-- 1 root root     2443 May 25 16:33 ./tyk.1685025183.prof
```

Co-authored-by: Tit Petric <tit@tyk.io>

[TT-9062]: https://tyktech.atlassian.net/browse/TT-9062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ