### PR TITLE
Merging to release-5-lts: [TT-926] fix security vulnerability that exposes key in the log  (#5080)

### DIFF
--- a/gateway/auth_manager.go
+++ b/gateway/auth_manager.go
@@ -34,6 +34,13 @@ type DefaultSessionManager struct {
 	Gw    *Gateway `json:"-"`
 }
 
+func (b *DefaultSessionManager) ResetQuotaObfuscateKey(keyName string) string {
+	if !b.Gw.GetConfig().HashKeys && !b.Gw.GetConfig().EnableKeyLogging {
+		return b.Gw.obfuscateKey(keyName)
+	}
+	return keyName
+}
+
 func (b *DefaultSessionManager) Init(store storage.Handler) {
 	b.store = store
 	b.store.Connect()
@@ -53,6 +60,7 @@ func (b *DefaultSessionManager) Store() storage.Handler {
 
 func (b *DefaultSessionManager) ResetQuota(keyName string, session *user.SessionState, isHashed bool) {
 	origKeyName := keyName
+
 	if !isHashed {
 		keyName = storage.HashKey(keyName, b.Gw.GetConfig().HashKeys)
 	}
@@ -61,7 +69,7 @@ func (b *DefaultSessionManager) ResetQuota(keyName string, session *user.Session
 	log.WithFields(logrus.Fields{
 		"prefix":      "auth-mgr",
 		"inbound-key": b.Gw.obfuscateKey(origKeyName),
-		"key":         rawKey,
+		"key":         b.ResetQuotaObfuscateKey(keyName),
 	}).Info("Reset quota for key.")
 
 	rateLimiterSentinelKey := RateLimitKeyPrefix + keyName + ".BLOCKED"
@@ -82,7 +90,6 @@ func (b *DefaultSessionManager) clearCacheForKey(keyName string, hashed bool) {
 	if !hashed {
 		cacheKey = storage.HashKey(keyName, b.Gw.GetConfig().HashKeys)
 	}
-
 	// Delete gateway's cache immediately
 	b.Gw.SessionCache.Delete(cacheKey)
 

--- a/gateway/auth_manager_test.go
+++ b/gateway/auth_manager_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/TykTechnologies/tyk/certs"
 	"github.com/TykTechnologies/tyk/config"
 
@@ -244,4 +246,40 @@ func TestHashKeyFunctionChanged(t *testing.T) {
 		testChangeHashFunc(t, nil, client, http.StatusForbidden)
 	})
 
+}
+
+func TestResetQuotaObfuscate(t *testing.T) {
+
+	t.Run("Obfuscate key", func(t *testing.T) {
+		conf := func(globalConf *config.Config) {
+			globalConf.HashKeys = false
+			globalConf.EnableKeyLogging = false
+		}
+
+		ts := StartTest(conf)
+		sessionManager := DefaultSessionManager{Gw: ts.Gw}
+		t.Cleanup(func() {
+			ts.Close()
+		})
+
+		actual := sessionManager.ResetQuotaObfuscateKey("481408ygjkbs")
+
+		assert.Equal(t, "****jkbs", actual)
+	})
+	t.Run("Does not Obfuscate key", func(t *testing.T) {
+		conf := func(globalConf *config.Config) {
+			globalConf.HashKeys = true
+			globalConf.EnableKeyLogging = true
+		}
+
+		ts := StartTest(conf)
+		sessionManager := DefaultSessionManager{Gw: ts.Gw}
+		t.Cleanup(func() {
+			ts.Close()
+		})
+
+		actual := sessionManager.ResetQuotaObfuscateKey("481408ygjkbs")
+
+		assert.Equal(t, "481408ygjkbs", actual)
+	})
 }


### PR DESCRIPTION
[TT-926] fix security vulnerability that exposes key in the log  (#5080)

<!-- Provide a general summary of your changes in the Title above -->

## Description


The problem involved the HashKey function in
[storage.go](https://github.com/TykTechnologies/tyk/blob/76a00611f33e150b1b6145264909baeefa1cbd4f/storage/storage.go#L170).
It returns the key without hashing if "hash_keys" is set to false in the
tyk.conf file. Now a conditional has been added that obfuscates the key
if "hash_keys" and "enable_key_logging" are set to false.

## Related Issue

[View issue here](https://tyktech.atlassian.net/browse/TT-926)

## Motivation and Context

This issue is a low level security vulnerability.

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why

[TT-926]: https://tyktech.atlassian.net/browse/TT-926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ