### PR TITLE
[TT-9143] Fix flay TestVirtualEndpointDisabled

### DIFF
--- a/gateway/mw_virtual_endpoint_test.go
+++ b/gateway/mw_virtual_endpoint_test.go
@@ -241,17 +241,16 @@ func TestVirtualEndpointDisabled(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()
 
-	ts.testPrepareVirtualEndpoint(virtTestJS, "GET", "/virt1",
-		proxyOnErrorDisabled, keylessAuthEnabled, cacheEnabled, true)
+	ts.testPrepareVirtualEndpoint(virtTestJS, "GET", "/virt2",
+		proxyOnErrorDisabled, keylessAuthEnabled, false, true)
 
 	_, _ = ts.Run(t,
 		test.TestCase{
-			Path:         "/virt1",
+			Path:         "/virt2",
 			BodyNotMatch: "foobar",
 			HeadersNotMatch: map[string]string{
-				cachedResponseHeader: "1",
-				"data-foo":           "x",
-				"data-bar-y":         "3",
+				"data-foo":   "x",
+				"data-bar-y": "3",
 			},
 		},
 	)


### PR DESCRIPTION
disable cache in TestVirtualEndpointDisabled since it's not what being tested.

<!-- Provide a general summary of your changes in the Title above -->

## Description
TestVirtualEndpointDisabled is asserting on cachedResponse headers, also enabling cache mw. 

This is causing since previous tests are run with the same endpoint too. 

This PR does the following
- change test API endpoint 
- disable cache mw.
- do not assert for cache response header

## Related Issue

https://tyktech.atlassian.net/browse/TT-9143

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested
```
go test -failfast -count=100 -race -timeout=60m  -cover -v github.com/TykTechnologies/tyk/gateway  -run=^TestVirtualEndpointDisabled$
```

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
