### PR TITLE
[TT-9410] Fix `track_404_logs` flag when control port is different than listen port

### DIFF
--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -735,6 +735,7 @@ func (gw *Gateway) loadHTTPService(spec *APISpec, apisByListen map[string]int, g
 	router := muxer.router(port, spec.Protocol, gwConfig)
 	if router == nil {
 		router = mux.NewRouter()
+		router.NotFoundHandler = http.HandlerFunc(muxer.handle404)
 		muxer.setRouter(port, spec.Protocol, router, gwConfig)
 	}
 

--- a/gateway/api_loader_test.go
+++ b/gateway/api_loader_test.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"path"
@@ -10,6 +11,10 @@ import (
 
 	"github.com/TykTechnologies/storage/persistent/model"
 	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/config"
+	logger "github.com/TykTechnologies/tyk/log"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/writer"
 
 	"github.com/stretchr/testify/assert"
 
@@ -425,4 +430,42 @@ func TestAllApisAreMTLS(t *testing.T) {
 	if result != expected {
 		t.Errorf("Expected AllApisAreMTLS to return %v, but got %v", expected, result)
 	}
+}
+
+func TestHandle404Called(t *testing.T) {
+	conf := func(globalConf *config.Config) {
+		globalConf.Track404Logs = true
+	}
+	ts := StartTest(conf, TestConfig {
+		SeparateControlAPI: true,
+	})
+	defer ts.Close()
+
+	// Need to load at least 1 api definition for the 404 handler to register
+	apiDefs := BuildAPI(func(spec *APISpec) {
+		spec.Name = "internal"
+		spec.APIID = "test"
+		spec.Proxy.ListenPath = "/dummy"
+	})
+
+	ts.Gw.LoadAPI(apiDefs...)
+
+	buf := &bytes.Buffer{}
+
+	log := logger.Get()
+	log.AddHook(&writer.Hook { // Send info and debug logs to stdout
+		Writer: buf,
+		LogLevels: []logrus.Level{
+			logrus.ErrorLevel,
+		},
+	})
+
+	// Note: "404 page not found" is the default 404 error response, which would show up if proxyMuxer.handle404 isn't 
+	// registered as the 404 handler
+	_, _ = ts.Run(t, test.TestCase{Path: "/i-do-not-exist/", BodyNotMatch: "404 page not found", Code: http.StatusNotFound})
+
+	loggerOut := buf.String()
+
+	assert.Contains(t, loggerOut, `msg="Not Found"`)
+	assert.Contains(t, loggerOut, `GET /i-do-not-exist/`)
 }

--- a/gateway/api_loader_test.go
+++ b/gateway/api_loader_test.go
@@ -453,7 +453,7 @@ func TestHandle404Called(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	log := logger.Get()
-	log.AddHook(&writer.Hook { // Send info and debug logs to stdout
+	log.AddHook(&writer.Hook { // Capture error logs
 		Writer: buf,
 		LogLevels: []logrus.Level{
 			logrus.ErrorLevel,


### PR DESCRIPTION
## Description

More details are on the [issue](https://github.com/TykTechnologies/tyk/issues/5131), but the jest is: when the control port is different than the listen port, the `track_404_logs` config flag does not work. This is because the 404 handler is not attached when we have to create a new router to accommodate a different port.

## Related Issue

- Closes https://github.com/TykTechnologies/tyk/issues/5131

## Motivation and Context

It makes `track_404_logs` work even if the control port is different than the listen port.

## How This Has Been Tested

- Tested using the same reproduction steps on the issue; that is spinning up a gateway instance with separate control and listen ports, and enabling `track_404_logs`, and making sure a request to the listen port that does not have a matching API definition results in a log line.
- Added a test that configures a gateway with that config, and with a separate control port, then makes a request to it asserting that we do indeed get an error log for the 404 (Is this good enough? I tried to be as non-intrusive in that part as I can, but I'm not super familiar with golang to know if this is a good enough test setup).

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [x] I ensured that the documentation is up to date
- [ ] ~I explained why this PR updates go.mod in detail with reasoning why it's required~
- [ ] ~I would like a code coverage CI quality gate exception and have explained why~
