### PR TITLE
[TT-9231] Fix go plugin error responses

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -131,10 +131,14 @@ func (gw *Gateway) createMiddleware(actualMW TykMiddleware) func(http.Handler) h
 				return
 			}
 
-			err, errCode := mw.ProcessRequest(w, r, mwConf)
+			rw := &customResponseWriter{
+				ResponseWriter: w,
+			}
+
+			err, errCode := mw.ProcessRequest(rw, r, mwConf)
 			if err != nil {
 				handler := ErrorHandler{*mw.Base()}
-				handler.HandleError(w, r, err.Error(), errCode, true)
+				handler.HandleError(w, r, err.Error(), errCode, !rw.responseSent)
 
 				meta["error"] = err.Error()
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Don't send an error message if the go plugin itself did that already.

## Related Issue
#5141 

## Motivation and Context
The change of https://github.com/TykTechnologies/tyk/pull/4922 causes Tyk to always send an error message to the client when an error within a go plugin occurs. In case the error is caused by a sent status code >= 400 by the plugin itself this is not desiderable as it will append the Tyk error message to an already existing response from the plugin.

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [x] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
