### PR TITLE
update graphql-go-tools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/TykTechnologies/gojsonschema v0.0.0-20170222154038-dcb3e4bb7990
 	github.com/TykTechnologies/gorpc v0.0.0-20210624160652-fe65bda0ccb9
 	github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708
-	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230615115010-d5563fa7a90b
+	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230616114116-b4495dbf28d7
 	github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c
 	github.com/TykTechnologies/murmur3 v0.0.0-20230310161213-aad17efd5632
 	github.com/TykTechnologies/openid2go v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/TykTechnologies/gorpc v0.0.0-20210624160652-fe65bda0ccb9/go.mod h1:v6
 github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708 h1:cmXjlMzcexhc/Cg+QB/c2CPUVs1ux9xn6162qaf/LC4=
 github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708/go.mod h1:mkS8jKcz8otdfEXhJs1QQ/DKoIY1NFFsRPKS0RwQENI=
 github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230320143102-7a16078ce517/go.mod h1:ZiFZcrue3+n2mHH+KLHRipbYVULkgy3Myko5S7IIs74=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230615115010-d5563fa7a90b h1:sJpPrmx03R7Hvocu8ORn9sAv4h8H4+lh+jMDJpSbG1A=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230615115010-d5563fa7a90b/go.mod h1:Fjaf4vD/lBTjBdwG+eCd+VhQzKNZBRw+9nygH4IUHlA=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230616114116-b4495dbf28d7 h1:RjsYV7L2tdaLH/Jt7PcN/dSoWbSfbRMag3fxWKYgGpQ=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230616114116-b4495dbf28d7/go.mod h1:Fjaf4vD/lBTjBdwG+eCd+VhQzKNZBRw+9nygH4IUHlA=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c h1:j6fd0Fz1R4oSWOmcooGjrdahqrML+btQ+PfEJw8SzbA=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c/go.mod h1:GnHUbsQx+ysI10osPhUdTmsxcE7ef64cVp38Fdyd7e0=
 github.com/TykTechnologies/murmur3 v0.0.0-20230310161213-aad17efd5632 h1:T5NWziFusj8au5nxAqMMh/bZyX9CAyYnBkaMSsfH6BA=


### PR DESCRIPTION
This PR updates `graphql-go-tools` to latest `master`.
