### PR TITLE
[TT-9207] Fix high quota policy is not respected

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -463,8 +463,7 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 					if greaterThanInt64(policy.QuotaMax, ar.Limit.QuotaMax) {
 
 						ar.Limit.QuotaMax = policy.QuotaMax
-						//if partition for quota is set the we must use this value in the global information of the key
-						if greaterThanInt64(policy.QuotaMax, session.QuotaMax) || policy.Partitions.Quota {
+						if greaterThanInt64(policy.QuotaMax, session.QuotaMax) {
 							session.QuotaMax = policy.QuotaMax
 						}
 					}

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -119,6 +119,11 @@ func (s *Test) TestPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesD
 			AccessRights: map[string]user.AccessDefinition{"b": {}},
 			Partitions:   user.PolicyPartitions{Quota: true},
 		},
+		"quota5": {
+			QuotaMax:     4,
+			Partitions:   user.PolicyPartitions{Quota: true},
+			AccessRights: map[string]user.AccessDefinition{"b": {}},
+		},
 		"unlimited-rate": {
 			Partitions:   user.PolicyPartitions{RateLimit: true},
 			AccessRights: map[string]user.AccessDefinition{"a": {}},
@@ -519,6 +524,12 @@ func (s *Test) TestPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesD
 				if s.QuotaMax != 3 {
 					t.Fatalf("Should pick bigger value")
 				}
+			}, nil,
+		},
+		{
+			"QuotaParts with acl", []string{"quota5", "quota4"},
+			"", func(t *testing.T, s *user.SessionState) {
+				assert.Equal(t, int64(4), s.QuotaMax)
 			}, nil,
 		},
 		{


### PR DESCRIPTION
While applying the policies which has quota and ACL partition, the second one applied to get precedence. However, it should get the greater value no matter the applying order.