### PR TITLE
Merging to release-5.1: [TT-9206] Fix high rate policy is not respected (#5170)

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -482,8 +482,7 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 
 					if greaterThanFloat64(policy.Rate, ar.Limit.Rate) {
 						ar.Limit.Rate = policy.Rate
-						//if policy.Partitions.RateLimit then we must set this value in the global data of the key
-						if greaterThanFloat64(policy.Rate, session.Rate) || policy.Partitions.RateLimit {
+						if greaterThanFloat64(policy.Rate, session.Rate) {
 							session.Rate = policy.Rate
 						}
 					}

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -137,6 +137,16 @@ func (s *Test) TestPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesD
 			Rate:       4,
 			Per:        4,
 		},
+		"rate4": {
+			Partitions:   user.PolicyPartitions{RateLimit: true},
+			Rate:         8,
+			AccessRights: map[string]user.AccessDefinition{"a": {}},
+		},
+		"rate5": {
+			Partitions:   user.PolicyPartitions{RateLimit: true},
+			Rate:         10,
+			AccessRights: map[string]user.AccessDefinition{"a": {}},
+		},
 		"rate-for-a": {
 			Partitions:   user.PolicyPartitions{RateLimit: true},
 			AccessRights: map[string]user.AccessDefinition{"a": {}},
@@ -553,6 +563,12 @@ func (s *Test) TestPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesD
 				if s.Rate != 4 {
 					t.Fatalf("Should pick bigger value")
 				}
+			}, nil,
+		},
+		{
+			"RateParts with acl", []string{"rate5", "rate4"},
+			"", func(t *testing.T, s *user.SessionState) {
+				assert.Equal(t, float64(10), s.Rate)
 			}, nil,
 		},
 		{


### PR DESCRIPTION
[TT-9206] Fix high rate policy is not respected (#5170)

While applying the policies which has rate limit and ACL partition, the
second one applied to get precedence. However, it should get the greater
value no matter the applying order.

[TT-9206]: https://tyktech.atlassian.net/browse/TT-9206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ