### PR TITLE
[TT-9218] HostUptimeChecker: Handle multiple Close invocations

### DIFF
--- a/gateway/host_checker.go
+++ b/gateway/host_checker.go
@@ -402,8 +402,8 @@ func eraseSyncMap(m *sync.Map) {
 }
 
 func (h *HostUptimeChecker) Stop() {
-	wasClosed := atomic.SwapInt32(&h.isClosed, CLOSED)
-	if wasClosed == 0 {
+	was := atomic.SwapInt32(&h.isClosed, CLOSED)
+	if was == OPEN {
 		eraseSyncMap(h.samples)
 
 		log.Info("[HOST CHECKER] Stopping poller")

--- a/gateway/host_checker_manager.go
+++ b/gateway/host_checker_manager.go
@@ -216,9 +216,7 @@ func (hc *HostCheckerManager) StartPoller(ctx context.Context) {
 
 func (hc *HostCheckerManager) StopPoller() {
 	hc.checkerMu.Lock()
-	if hc.checker != nil {
-		hc.checker.Stop()
-	}
+	hc.checker.Stop()
 	hc.checkerMu.Unlock()
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

HostUptimeChecker .Close is invoked from two places, the HostUptimeCheckerManager and the HostUptimeChecker itself, from the inner loop after the context it has gets cancelled.

The change adds an int32 value and uses the atomic package in order to run the HostUptimeChecker shutdown steps only once. The change should be 1.13+ compatible, so it applies to [4-lts, 5-lts, 5.1, master], some backporting required for 4-lts due to differences.

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

https://tyktech.atlassian.net/browse/TT-9218

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
