### PR TITLE
Merging to release-5.1: [TT-8558] Do not stop applying polices when one of them non-existing (#5124)

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -320,6 +320,10 @@ func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 		if !ok {
 			err := fmt.Errorf("policy not found: %q", polID)
 			t.Logger().Error(err)
+			if len(policies) > 1 {
+				continue
+			}
+
 			return err
 		}
 		// Check ownership, policy org owner must be the same as API,

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -424,7 +424,7 @@ func (s *Test) TestPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesD
 		},
 		{
 			name:     "MultiNonPart",
-			policies: []string{"nonpart1", "nonpart2"},
+			policies: []string{"nonpart1", "nonpart2", "nonexistent"},
 			sessMatch: func(t *testing.T, s *user.SessionState) {
 				want := map[string]user.AccessDefinition{
 					"a": {


### PR DESCRIPTION
[TT-8558] Do not stop applying polices when one of them non-existing (#5124)

In multiple policies applied to a key case, if one of the policies is
not found, the other policies should continue to be applied so that
their APIs continues to work.

[TT-8558]: https://tyktech.atlassian.net/browse/TT-8558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ