### PR TITLE
Merging to release-5-lts: TT-9177 obsfuscate key on log (#5152)

### DIFF
--- a/gateway/api.go
+++ b/gateway/api.go
@@ -777,7 +777,7 @@ func (gw *Gateway) handleDeleteKey(keyName, orgID, apiID string, resetQuota bool
 
 		log.WithFields(logrus.Fields{
 			"prefix": "api",
-			"key":    keyName,
+			"key":    gw.obfuscateKey(keyName),
 			"status": "ok",
 		}).Info("Deleted key across all APIs.")
 
@@ -807,7 +807,7 @@ func (gw *Gateway) handleDeleteKey(keyName, orgID, apiID string, resetQuota bool
 
 	log.WithFields(logrus.Fields{
 		"prefix": "api",
-		"key":    keyName,
+		"key":    gw.obfuscateKey(keyName),
 		"status": "ok",
 	}).Info("Deleted key.")
 
@@ -828,7 +828,7 @@ func (gw *Gateway) handleDeleteHashedKeyWithLogs(keyName, orgID, apiID string, r
 
 	log.WithFields(logrus.Fields{
 		"prefix": "api",
-		"key":    keyName,
+		"key":    gw.obfuscateKey(keyName),
 		"status": "ok",
 	}).Info("Deleted hashed key across all APIs.")
 

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -171,7 +171,7 @@ func (r *RPCStorageHandler) hashKey(in string) string {
 func (r *RPCStorageHandler) fixKey(keyName string) string {
 	setKeyName := r.KeyPrefix + r.hashKey(keyName)
 
-	log.Debug("Input key was: ", setKeyName)
+	log.Debug("Input key was: ", r.Gw.obfuscateKey(setKeyName))
 
 	return setKeyName
 }
@@ -453,8 +453,8 @@ func (r *RPCStorageHandler) GetKeysAndValues() map[string]string {
 // DeleteKey will remove a key from the database
 func (r *RPCStorageHandler) DeleteKey(keyName string) bool {
 
-	log.Debug("DEL Key was: ", keyName)
-	log.Debug("DEL Key became: ", r.fixKey(keyName))
+	log.Debug("DEL Key was: ", r.Gw.obfuscateKey(keyName))
+	log.Debug("DEL Key became: ", r.Gw.obfuscateKey(r.fixKey(keyName)))
 	ok, err := rpc.FuncClientSingleton("DeleteKey", r.fixKey(keyName))
 	if err != nil {
 		rpc.EmitErrorEventKv(
@@ -1049,7 +1049,7 @@ func (r *RPCStorageHandler) ProcessKeySpaceChanges(keys []string, orgId string) 
 				key = splitKeys[0]
 				_, status = r.Gw.handleDeleteHashedKey(key, orgId, "", resetQuota)
 			} else {
-				log.Info("--> removing cached key: ", key)
+				log.Info("--> removing cached key: ", r.Gw.obfuscateKey(key))
 				// in case it's an username (basic auth) then generate the token
 				if storage.TokenOrg(key) == "" {
 					key = r.Gw.generateToken(orgId, key)

--- a/storage/redis_cluster.go
+++ b/storage/redis_cluster.go
@@ -584,8 +584,6 @@ func (r *RedisCluster) DeleteKey(keyName string) bool {
 		log.Debug(err)
 		return false
 	}
-	log.Debug("DEL Key was: ", keyName)
-	log.Debug("DEL Key became: ", r.fixKey(keyName))
 
 	singleton, err := r.singleton()
 	if err != nil {


### PR DESCRIPTION
TT-9177 obsfuscate key on log (#5152)

<!-- Provide a general summary of your changes in the Title above -->

## Description

Obsfuscated the keys on logging, if someone would like to see the whole
key printed in the logs then they should enable `enable_key_logging` in
the configuration of the gateways

## Related Issue

https://tyktech.atlassian.net/browse/TT-9177

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

Manually tested running an MDCB env

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why

Co-authored-by: Zaid Albirawi <zaid@tyk.io>