### PR TITLE
[TD-1991]: Fix goreleaser issue on tag push

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.19.x]
+        go-version: [1.16.x]
         platform: [ubuntu-latest]
         arch: [amd64]
         node-version: [15.x]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,10 +120,14 @@ jobs:
           mkdir -p /go/src/github.com/TykTechnologies/tyk
           cp -r ./* /go/src/github.com/TykTechnologies/tyk
 
+      - name: Set whether goreleaser snapshot or not.
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        run: echo "GRFLAGS=--snapshot" >> $GITHUB_ENV
+
       - uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --clean -f ${{ matrix.goreleaser }}
+          args: release --clean ${{ env.GRFLAGS }} -f ${{ matrix.goreleaser }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CGO_ENABLED: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
       - uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --clean -f ${{ matrix.goreleaser }} ${{ !startsWith(github.ref, 'refs/tags/') && ' --snapshot' }}
+          args: release --clean -f ${{ matrix.goreleaser }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CGO_ENABLED: 1


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Fix goreleaser error on tag push due to an improper conditional.
Also fix api-tests and ui-tests changes for 1.19.x pulled in by sync-automation

## Related Issue
TD-1991