### PR TITLE
Merging to release-5.1: [TT-9205] Fix policy not overriding session values (#5013)

### DIFF
--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -167,6 +167,10 @@ func (s *Test) TestPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesD
 			AccessRights: map[string]user.AccessDefinition{"a": {}, "b": {}},
 			Rate:         4,
 		},
+		"rate-no-partition": {
+			AccessRights: map[string]user.AccessDefinition{"a": {}},
+			Rate:         12,
+		},
 		"acl1": {
 			Partitions:   user.PolicyPartitions{Acl: true},
 			AccessRights: map[string]user.AccessDefinition{"a": {}},
@@ -581,6 +585,18 @@ func (s *Test) TestPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesD
 			"", func(t *testing.T, s *user.SessionState) {
 				assert.Equal(t, float64(10), s.Rate)
 			}, nil,
+		},
+		{
+			"RateParts with acl respected by session", []string{"rate4", "rate5"},
+			"", func(t *testing.T, s *user.SessionState) {
+				assert.Equal(t, float64(10), s.Rate)
+			}, &user.SessionState{Rate: 20},
+		},
+		{
+			"Rate with no partition respected by session", []string{"rate-no-partition"},
+			"", func(t *testing.T, s *user.SessionState) {
+				assert.Equal(t, float64(12), s.Rate)
+			}, &user.SessionState{Rate: 20},
 		},
 		{
 			"ComplexityPart with unlimited", []string{"unlimitedComplexity"},


### PR DESCRIPTION
[TT-9205] Fix policy not overriding session values (#5013)