### PR TITLE
TD-1991/Goreleaser error on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,10 +104,10 @@ jobs:
             *.txt.sig
             *.txt
 
-      - uses: goreleaser/goreleaser-action@v3
+      - uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --clean -f ${{ matrix.goreleaser }}
+          args: release --clean -f ${{ matrix.goreleaser }} ${{ !startsWith(github.ref, 'refs/tags/') && ' --snapshot' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CGO_ENABLED: 1


### PR DESCRIPTION
Goreleaser is failing when pushing a tag due to an error on an expression over the github workflow