### PR TITLE
Merging to release-5.1: Do not return keyID when basic auth key is created with hash_keys=true. (#5199)

### DIFF
--- a/gateway/api.go
+++ b/gateway/api.go
@@ -516,7 +516,7 @@ func (gw *Gateway) handleAddOrUpdate(keyName string, r *http.Request, isHashed b
 	}
 
 	// Update our session object (create it)
-	if newSession.BasicAuthData.Password != "" {
+	if newSession.IsBasicAuth() {
 		// If we are using a basic auth user, then we need to make the keyname explicit against the OrgId in order to differentiate it
 		// Only if it's NEW
 		switch r.Method {
@@ -532,7 +532,7 @@ func (gw *Gateway) handleAddOrUpdate(keyName string, r *http.Request, isHashed b
 				gw.setBasicAuthSessionPassword(newSession)
 			}
 		}
-	} else if originalKey.BasicAuthData.Password != "" {
+	} else if originalKey.IsBasicAuth() {
 		// preserve basic auth data
 		newSession.BasicAuthData.Hash = originalKey.BasicAuthData.Hash
 		newSession.BasicAuthData.Password = originalKey.BasicAuthData.Password
@@ -579,6 +579,10 @@ func (gw *Gateway) handleAddOrUpdate(keyName string, r *http.Request, isHashed b
 
 	// add key hash for newly created key
 	if gw.GetConfig().HashKeys && r.Method == http.MethodPost {
+		if newSession.IsBasicAuth() {
+			response.Key = ""
+		}
+
 		if isHashed {
 			response.KeyHash = keyName
 		} else {
@@ -674,7 +678,7 @@ func (gw *Gateway) handleGetDetail(sessionKey, apiID, orgID string, byHash bool)
 	}
 
 	// If it's a basic auth key and a valid Base64 string, use it as the key ID:
-	if session.BasicAuthData.Password != "" {
+	if session.IsBasicAuth() {
 		if storage.TokenOrg(sessionKey) != "" {
 			session.KeyID = sessionKey
 		}

--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -1142,9 +1142,15 @@ func (ts *Test) testHashFuncAndBAHelper(t *testing.T) {
 
 	_, _ = ts.Run(t, []test.TestCase{
 		{
-			Method:    http.MethodPost,
-			Path:      "/tyk/keys/defaultuser",
-			Data:      session,
+			Method: http.MethodPost,
+			Path:   "/tyk/keys/defaultuser",
+			Data:   session,
+			BodyMatchFunc: func(resp []byte) bool {
+				keyResp := apiModifyKeySuccess{}
+				err := json.Unmarshal(resp, &keyResp)
+				assert.NoError(t, err)
+				return keyResp.Key == "" && keyResp.KeyHash != ""
+			},
 			AdminAuth: true,
 			Code:      200,
 		},

--- a/user/session.go
+++ b/user/session.go
@@ -328,3 +328,8 @@ func (s *SessionState) GetQuotaLimitByAPIID(apiID string) (int64, int64, int64, 
 
 	return s.QuotaMax, s.QuotaRemaining, s.QuotaRenewalRate, s.QuotaRenews
 }
+
+// IsBasicAuth returns whether the key is basic auth or not.
+func (s *SessionState) IsBasicAuth() bool {
+	return s.BasicAuthData.Password != ""
+}


### PR DESCRIPTION
Do not return keyID when basic auth key is created with hash_keys=true. (#5199)

<!-- Provide a general summary of your changes in the Title above -->

## Description

Do not return keyID when basic auth key is created with hash_keys=true.

## Related Issue
https://tyktech.atlassian.net/browse/TT-9220
Refer https://tyktech.atlassian.net/browse/TT-8586 for more details

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why