### PR TITLE
[TT-9186] [plugin-tests] Add --platform to goreleaser plugincompiler

### DIFF
--- a/ci/goreleaser/goreleaser-5.0.yml
+++ b/ci/goreleaser/goreleaser-5.0.yml
@@ -126,6 +126,7 @@ dockers:
       - tykio/tyk-plugin-compiler:{{ .Tag }}
       - tykio/tyk-plugin-compiler:v{{ .Major }}.{{ .Minor }}{{.Prerelease}}
     build_flag_templates:
+      - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title=tyk-plugin-compiler"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"

--- a/ci/goreleaser/goreleaser-el7.yml
+++ b/ci/goreleaser/goreleaser-el7.yml
@@ -118,6 +118,7 @@ dockers:
       - tykio/tyk-plugin-compiler:{{ .Tag }}-el7
       - tykio/tyk-plugin-compiler:v{{ .Major }}.{{ .Minor }}{{.Prerelease}}-el7
     build_flag_templates:
+      - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title=tyk-plugin-compiler"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"


### PR DESCRIPTION
plugin-compiler is a cross compile env that should run in linux/amd64 to produce arm64 binaries