### PR TITLE
[TT-8526]: removed childnodes in rest datasource

### DIFF
--- a/apidef/adapter/graphql_config_adapter.go
+++ b/apidef/adapter/graphql_config_adapter.go
@@ -486,6 +486,9 @@ func (g *GraphQLConfigAdapter) removeDuplicateHeaders(headers ...map[string]stri
 
 func (g *GraphQLConfigAdapter) determineChildNodes(planDataSources []plan.DataSourceConfiguration) error {
 	for i := range planDataSources {
+		if _, ok := planDataSources[i].Factory.(*restDataSource.Factory); ok {
+			continue
+		}
 		for j := range planDataSources[i].RootNodes {
 			typeName := planDataSources[i].RootNodes[j].TypeName
 			for k := range planDataSources[i].RootNodes[j].FieldNames {

--- a/apidef/adapter/graphql_config_adapter_test.go
+++ b/apidef/adapter/graphql_config_adapter_test.go
@@ -574,12 +574,6 @@ func TestGraphQLConfigAdapter_engineConfigV2DataSources(t *testing.T) {
 					FieldNames: []string{"withChildren"},
 				},
 			},
-			ChildNodes: []plan.TypeField{
-				{
-					TypeName:   "WithChildren",
-					FieldNames: []string{"id", "name", "__typename"},
-				},
-			},
 			Factory: &restDataSource.Factory{
 				Client: httpClient,
 			},
@@ -595,12 +589,6 @@ func TestGraphQLConfigAdapter_engineConfigV2DataSources(t *testing.T) {
 				{
 					TypeName:   "WithChildren",
 					FieldNames: []string{"nested"},
-				},
-			},
-			ChildNodes: []plan.TypeField{
-				{
-					TypeName:   "Nested",
-					FieldNames: []string{"id", "name", "__typename"},
 				},
 			},
 			Factory: &restDataSource.Factory{


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->
In the graphql go tools, childnodes are not needed in the rest
datasource and are causing an issue with the paths generated by the
planners in the engine, this change fixes that.

[TT-8526](https://tyktech.atlassian.net/browse/TT-8526)
## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


[TT-8526]: https://tyktech.atlassian.net/browse/TT-8526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ