### PR TITLE
Merging to release-4.0.14: TT-9177 obsfuscate key on log (#5152)

### DIFF
--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -894,7 +894,11 @@ func (r *RPCStorageHandler) ProcessKeySpaceChanges(keys []string, orgId string) 
 				_, status = r.Gw.handleDeleteHashedKey(splitKeys[0], orgId, "", resetQuota)
 				r.Gw.getSessionAndCreate(splitKeys[0], r, true, orgId)
 			} else {
+<<<<<<< HEAD
 				log.Debug("--> removing cached key: ", r.Gw.obfuscateKey(key))
+=======
+				log.Info("--> removing cached key: ", r.Gw.obfuscateKey(key))
+>>>>>>> 56d57566... TT-9177 obsfuscate key on log (#5152)
 				// in case it's an username (basic auth) then generate the token
 				if storage.TokenOrg(key) == "" {
 					key = r.Gw.generateToken(orgId, key)

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -894,11 +894,7 @@ func (r *RPCStorageHandler) ProcessKeySpaceChanges(keys []string, orgId string) 
 				_, status = r.Gw.handleDeleteHashedKey(splitKeys[0], orgId, "", resetQuota)
 				r.Gw.getSessionAndCreate(splitKeys[0], r, true, orgId)
 			} else {
-<<<<<<< HEAD
-				log.Debug("--> removing cached key: ", r.Gw.obfuscateKey(key))
-=======
 				log.Info("--> removing cached key: ", r.Gw.obfuscateKey(key))
->>>>>>> 56d57566... TT-9177 obsfuscate key on log (#5152)
 				// in case it's an username (basic auth) then generate the token
 				if storage.TokenOrg(key) == "" {
 					key = r.Gw.generateToken(orgId, key)

--- a/storage/redis_cluster.go
+++ b/storage/redis_cluster.go
@@ -591,11 +591,6 @@ func (r *RedisCluster) DeleteKey(keyName string) bool {
 		log.Debug(err)
 		return false
 	}
-<<<<<<< HEAD
-	log.Debug("DEL Key was: ", obfuscateKey(keyName))
-	log.Debug("DEL Key became: ", obfuscateKey(r.fixKey(keyName)))
-=======
->>>>>>> 56d57566... TT-9177 obsfuscate key on log (#5152)
 
 	singleton, err := r.singleton()
 	if err != nil {

--- a/storage/redis_cluster.go
+++ b/storage/redis_cluster.go
@@ -591,8 +591,11 @@ func (r *RedisCluster) DeleteKey(keyName string) bool {
 		log.Debug(err)
 		return false
 	}
+<<<<<<< HEAD
 	log.Debug("DEL Key was: ", obfuscateKey(keyName))
 	log.Debug("DEL Key became: ", obfuscateKey(r.fixKey(keyName)))
+=======
+>>>>>>> 56d57566... TT-9177 obsfuscate key on log (#5152)
 
 	singleton, err := r.singleton()
 	if err != nil {


### PR DESCRIPTION
TT-9177 obsfuscate key on log (#5152)

<!-- Provide a general summary of your changes in the Title above -->

## Description

Obsfuscated the keys on logging, if someone would like to see the whole
key printed in the logs then they should enable `enable_key_logging` in
the configuration of the gateways

## Related Issue

https://tyktech.atlassian.net/browse/TT-9177

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

Manually tested running an MDCB env

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why

Co-authored-by: Zaid Albirawi <zaid@tyk.io>