### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/apidef/notifications.go
+++ b/apidef/notifications.go
@@ -3,7 +3,7 @@ package apidef
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"time"
@@ -79,7 +79,7 @@ func (n NotificationsManager) SendRequest(wait bool, count int, notification int
 		return
 	}
 	defer resp.Body.Close()
-	_, err = ioutil.ReadAll(resp.Body)
+	_, err = io.ReadAll(resp.Body)
 	if err != nil {
 		log.Error("Request failed, trying again in 10s. Error was: ", err)
 		count++

--- a/apidef/oas/import_test.go
+++ b/apidef/oas/import_test.go
@@ -2,7 +2,7 @@ package oas_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path"
 	"runtime"
 	"sort"
@@ -27,7 +27,7 @@ func findTestPath(filename string) string {
 // - Asserts expected routes for validateRequest.
 func TestImportValidateRequest(t *testing.T) {
 	// Load petstore
-	oasContents, err := ioutil.ReadFile(findTestPath("testdata/petstore-no-responses.json"))
+	oasContents, err := os.ReadFile(findTestPath("testdata/petstore-no-responses.json"))
 	assert.NoError(t, err)
 	assert.NotNil(t, oasContents)
 

--- a/apidef/oas/xtyk_doc_test.go
+++ b/apidef/oas/xtyk_doc_test.go
@@ -5,7 +5,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
+	"os"
 	"path"
 	"testing"
 
@@ -30,7 +30,7 @@ func TestExtractDocFromXTyk(t *testing.T) {
 	if *dumpXTykDoc {
 		filename := path.Join("schema", xTykDocPath)
 		t.Logf("Writing out: %s", filename)
-		err = ioutil.WriteFile(filename, []byte(xTykDocToMarkdown(fInfo)), 0666)
+		err = os.WriteFile(filename, []byte(xTykDocToMarkdown(fInfo)), 0666)
 		assert.NoError(t, err)
 	} else {
 		t.Log("Skipping writing out x-tyk-gateway.md docs")

--- a/certs/manager.go
+++ b/certs/manager.go
@@ -12,7 +12,7 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"errors"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -415,7 +415,7 @@ func (c *certificateManager) List(certIDs []string, mode CertificateType) (out [
 		// fallback to file
 		if err != nil {
 			// Try read from file
-			rawCert, err = ioutil.ReadFile(id)
+			rawCert, err = os.ReadFile(id)
 			if err != nil {
 				c.logger.Warn("Can't retrieve certificate:", id, err)
 				out = append(out, nil)
@@ -464,7 +464,7 @@ func (c *certificateManager) ListPublicKeys(keyIDs []string) (out []string) {
 			}
 			rawKey = []byte(val)
 		} else {
-			rawKey, err = ioutil.ReadFile(id)
+			rawKey, err = os.ReadFile(id)
 			if err != nil {
 				c.logger.Error("Error while reading public key from file:", id, err)
 				out = append(out, "")
@@ -501,7 +501,7 @@ func (c *certificateManager) ListRawPublicKey(keyID string) (out interface{}) {
 		}
 		rawKey = []byte(val)
 	} else {
-		rawKey, err = ioutil.ReadFile(keyID)
+		rawKey, err = os.ReadFile(keyID)
 		if err != nil {
 			c.logger.Error("Error while reading public key from file:", keyID, err)
 			return nil

--- a/certs/manager_test.go
+++ b/certs/manager_test.go
@@ -9,7 +9,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"errors"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -303,7 +302,7 @@ func TestAddCertificate(t *testing.T) {
 
 func TestCertificateStorage(t *testing.T) {
 	m := newManager()
-	dir, _ := ioutil.TempDir("", "certs")
+	dir, _ := os.MkdirTemp("", "certs")
 
 	defer func() {
 		os.RemoveAll(dir)
@@ -311,7 +310,7 @@ func TestCertificateStorage(t *testing.T) {
 
 	certPem, _ := genCertificateFromCommonName("file", false)
 	certPath := filepath.Join(dir, "cert.pem")
-	ioutil.WriteFile(certPath, certPem, 0666)
+	os.WriteFile(certPath, certPem, 0666)
 
 	privateCertPEM, keyCertPEM := genCertificateFromCommonName("private", false)
 	privateCertID, _ := m.Add(append(privateCertPEM, keyCertPEM...), "")

--- a/cli/bundler/bundler.go
+++ b/cli/bundler/bundler.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/TykTechnologies/goverify"
@@ -78,7 +77,7 @@ func (b *Bundler) Build(ctx *kingpin.ParseContext) error {
 	bundleBuf := new(bytes.Buffer)
 	for _, file := range manifest.FileList {
 		var data []byte
-		data, err = ioutil.ReadFile(file)
+		data, err = os.ReadFile(file)
 		if err != nil {
 			break
 		}
@@ -125,7 +124,7 @@ func (b *Bundler) Build(ctx *kingpin.ParseContext) error {
 			break
 		}
 		var data []byte
-		data, err = ioutil.ReadFile(file)
+		data, err = os.ReadFile(file)
 		if err != nil {
 			break
 		}
@@ -141,7 +140,7 @@ func (b *Bundler) Build(ctx *kingpin.ParseContext) error {
 	newManifest, err := zipWriter.Create(defaultManifestPath)
 	_, err = newManifest.Write(manifestData)
 	zipWriter.Close()
-	err = ioutil.WriteFile(bundlePath, buf.Bytes(), defaultBundlePerm)
+	err = os.WriteFile(bundlePath, buf.Bytes(), defaultBundlePerm)
 	if err != nil {
 		return err
 	}
@@ -192,7 +191,7 @@ func (b *Bundler) validateManifest(manifest *apidef.BundleManifest) (err error) 
 }
 
 func (b *Bundler) loadManifest(path string) (manifest *apidef.BundleManifest, err error) {
-	rawManifest, err := ioutil.ReadFile(path)
+	rawManifest, err := os.ReadFile(path)
 	if err != nil {
 		return manifest, errManifestLoad
 	}

--- a/cli/bundler/bundler_test.go
+++ b/cli/bundler/bundler_test.go
@@ -4,7 +4,6 @@ import (
 	"archive/zip"
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -54,7 +53,7 @@ func writeManifestFile(t testing.TB, manifest interface{}, filename string) *str
 		manifestString := manifest.(string)
 		data = []byte(manifestString)
 	}
-	ioutil.WriteFile(filename, data, 0600)
+	os.WriteFile(filename, data, 0600)
 	if err != nil {
 		t.Fatalf("Couldn't write manifest file: %s", err.Error())
 	}
@@ -132,7 +131,7 @@ func TestBuild(t *testing.T) {
 	// Build a simple bundle:
 	t.Run("Simple bundle build", func(t *testing.T) {
 		ctx := &kingpin.ParseContext{}
-		err := ioutil.WriteFile("middleware.py", []byte(""), 0600)
+		err := os.WriteFile("middleware.py", []byte(""), 0600)
 		if err != nil {
 			t.Fatalf("Couldn't write middleware.py: %s", err.Error())
 		}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -4,7 +4,6 @@ package cli
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
@@ -76,7 +75,7 @@ func Init(version string, confPaths []string) {
 	// Linter:
 	lintCmd := app.Command("lint", "Runs a linter on Tyk configuration file")
 	lintCmd.Action(func(c *kingpin.ParseContext) error {
-		confSchema, err := ioutil.ReadFile("cli/linter/schema.json")
+		confSchema, err := os.ReadFile("cli/linter/schema.json")
 		if err != nil {
 			return err
 		}

--- a/cli/linter/linter_test.go
+++ b/cli/linter/linter_test.go
@@ -2,7 +2,6 @@ package linter
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -108,7 +107,7 @@ func allContains(got, want []string) bool {
 func TestLint(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			f, err := ioutil.TempFile("", "tyk-lint")
+			f, err := os.CreateTemp("", "tyk-lint")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -117,7 +116,7 @@ func TestLint(t *testing.T) {
 			}
 			f.Close()
 
-			confSchema, err := ioutil.ReadFile("cli/linter/schema.json")
+			confSchema, err := os.ReadFile("cli/linter/schema.json")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -1168,7 +1167,7 @@ func WriteConf(path string, conf *Config) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(path, bs, 0644)
+	return os.WriteFile(path, bs, 0644)
 }
 
 // writeDefault will set conf to the default config and write it to disk

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,7 +3,6 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -82,7 +81,7 @@ func TestDefaultValueAndWriteDefaultConf(t *testing.T) {
 }
 
 func TestConfigFiles(t *testing.T) {
-	dir, err := ioutil.TempDir("", "tyk")
+	dir, err := os.MkdirTemp("", "tyk")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,7 +96,7 @@ func TestConfigFiles(t *testing.T) {
 	if conf.ListenPort != 8080 {
 		t.Fatalf("Expected ListenPort to be set to its default")
 	}
-	bs, _ := ioutil.ReadFile(path1)
+	bs, _ := os.ReadFile(path1)
 	if !strings.Contains(string(bs), "8080") {
 		t.Fatalf("Expected 8080 to be in the written conf file")
 	}
@@ -141,7 +140,7 @@ func TestConfigFiles(t *testing.T) {
 
 	// path1 exists but is invalid
 	os.Remove(path2)
-	ioutil.WriteFile(path1, []byte("{"), 0644)
+	os.WriteFile(path1, []byte("{"), 0644)
 	if err := Load(paths, conf); err == nil {
 		t.Fatalf("Load with an invalid config did not error")
 	}
@@ -152,7 +151,7 @@ func TestConfig_GetEventTriggers(t *testing.T) {
 	assert := func(t *testing.T, config string, expected string) {
 		conf := &Config{}
 
-		f, err := ioutil.TempFile("", "tyk.conf")
+		f, err := os.CreateTemp("", "tyk.conf")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -194,7 +193,7 @@ func TestConfig_GetEventTriggers(t *testing.T) {
 }
 
 func TestLoad_tracing(t *testing.T) {
-	dir, err := ioutil.TempDir("", "tyk")
+	dir, err := os.MkdirTemp("", "tyk")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -212,7 +211,7 @@ func TestLoad_tracing(t *testing.T) {
 					filepath.Dir(f),
 					"expect."+filepath.Base(f),
 				)
-				expect, err := ioutil.ReadFile(o)
+				expect, err := os.ReadFile(o)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -269,7 +268,7 @@ func TestLoad_tracing(t *testing.T) {
 					filepath.Dir(v.file),
 					"expect."+filepath.Base(v.file),
 				)
-				expect, err := ioutil.ReadFile(o)
+				expect, err := os.ReadFile(o)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/coprocess/grpc/coprocess_grpc_test.go
+++ b/coprocess/grpc/coprocess_grpc_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"mime/multipart"
 	"net"
@@ -502,7 +502,7 @@ func TestGRPCDispatch(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Request failed: %s", err.Error())
 		}
-		data, err := ioutil.ReadAll(res.Body)
+		data, err := io.ReadAll(res.Body)
 		if err != nil {
 			t.Fatalf("Couldn't read response body: %s", err.Error())
 		}

--- a/dlpython/main.go
+++ b/dlpython/main.go
@@ -11,7 +11,6 @@ import "C"
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -57,7 +56,7 @@ func FindPythonConfig(customVersion string) (selectedVersion string, err error) 
 		if !strings.HasSuffix(p, "/bin") {
 			continue
 		}
-		files, err := ioutil.ReadDir(p)
+		files, err := os.ReadDir(p)
 		if err != nil {
 			continue
 		}

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -33,7 +33,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -441,8 +440,8 @@ func (gw *Gateway) handleAddOrUpdate(keyName string, r *http.Request, isHashed b
 	// decode payload
 	newSession := &user.SessionState{}
 
-	contents, _ := ioutil.ReadAll(r.Body)
-	r.Body = ioutil.NopCloser(bytes.NewReader(contents))
+	contents, _ := io.ReadAll(r.Body)
+	r.Body = io.NopCloser(bytes.NewReader(contents))
 
 	if err := json.Unmarshal(contents, newSession); err != nil {
 		log.Error("Couldn't decode new session object: ", err)
@@ -940,7 +939,7 @@ func (gw *Gateway) handleAddOrUpdatePolicy(polID string, r *http.Request) (inter
 		return apiError("Marshalling failed"), http.StatusInternalServerError
 	}
 
-	if err := ioutil.WriteFile(polFilePath, asByte, 0644); err != nil {
+	if err := os.WriteFile(polFilePath, asByte, 0644); err != nil {
 		log.Error("Failed to create file! - ", err)
 		return apiError("Failed to create file!"), http.StatusInternalServerError
 	}
@@ -1267,7 +1266,7 @@ func (gw *Gateway) writeToFile(fs afero.Fs, newDef interface{}, filename string)
 		return errors.New("marshalling failed"), http.StatusInternalServerError
 	}
 
-	if err := ioutil.WriteFile(defFilePath, asByte, 0644); err != nil {
+	if err := os.WriteFile(defFilePath, asByte, 0644); err != nil {
 		log.Infof("EL file path: %v", defFilePath)
 		log.Error("Failed to create file! - ", err)
 		return errors.New("file object creation failed, write error"), http.StatusInternalServerError
@@ -1513,7 +1512,7 @@ func (gw *Gateway) apiOASPatchHandler(w http.ResponseWriter, r *http.Request) {
 	tykExtensionConfigParams := oas.GetTykExtensionConfigParams(r)
 
 	if oasObj.GetTykExtension() != nil && tykExtensionConfigParams == nil {
-		r.Body = ioutil.NopCloser(bytes.NewReader(reqBodyInBytes))
+		r.Body = io.NopCloser(bytes.NewReader(reqBodyInBytes))
 		obj, code := gw.handleUpdateApi(apiID, r, afero.NewOsFs(), true)
 		doJSONWrite(w, code, obj)
 		return
@@ -1551,7 +1550,7 @@ func (gw *Gateway) apiOASPatchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	r.Body = ioutil.NopCloser(bytes.NewReader(oasAPIInBytes))
+	r.Body = io.NopCloser(bytes.NewReader(oasAPIInBytes))
 
 	log.Debugf("PATCHing API: %q", apiID)
 	obj, code := gw.handleUpdateApi(apiID, r, afero.NewOsFs(), true)
@@ -3005,7 +3004,7 @@ func (gw *Gateway) validateOAS(next http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 
-		r.Body = ioutil.NopCloser(bytes.NewReader(reqBodyInBytes))
+		r.Body = io.NopCloser(bytes.NewReader(reqBodyInBytes))
 		next.ServeHTTP(w, r)
 	}
 }
@@ -3048,7 +3047,7 @@ func (gw *Gateway) makeImportedOASTykAPI(next http.HandlerFunc) http.HandlerFunc
 			return
 		}
 
-		r.Body = ioutil.NopCloser(bytes.NewReader(apiInBytes))
+		r.Body = io.NopCloser(bytes.NewReader(apiInBytes))
 		next.ServeHTTP(w, r)
 	}
 }
@@ -3414,7 +3413,7 @@ func invalidateTokens(prevClient ExtendedOsinClientInterface, updatedClient OAut
 
 func extractOASObjFromReq(reqBody io.Reader) ([]byte, *oas.OAS, error) {
 	var oasObj oas.OAS
-	reqBodyInBytes, err := ioutil.ReadAll(reqBody)
+	reqBodyInBytes, err := io.ReadAll(reqBody)
 	if err != nil {
 		return nil, nil, ErrRequestMalformed
 	}

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -511,13 +510,13 @@ func (a APIDefinitionLoader) FromDashboardService(endpoint string) ([]*APISpec, 
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusForbidden {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		a.Gw.reLogin()
 		return nil, fmt.Errorf("login failure, Response was: %v", string(body))
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		a.Gw.reLogin()
 		return nil, fmt.Errorf("dashboard API error, response was: %v", string(body))
 	}
@@ -525,7 +524,7 @@ func (a APIDefinitionLoader) FromDashboardService(endpoint string) ([]*APISpec, 
 	// Extract tagged APIs#
 	list := &nestedApiDefinitionList{}
 	if err := json.NewDecoder(resp.Body).Decode(&list); err != nil {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("failed to decode body: %v body was: %v", err, string(body))
 	}
 

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -1276,7 +1276,7 @@ func TestAPIDefinitionLoader(t *testing.T) {
 	})
 
 	t.Run("loadBlobTemplate", func(t *testing.T) {
-		templateInBytes, _ := ioutil.ReadFile(testTemplatePath)
+		templateInBytes, _ := os.ReadFile(testTemplatePath)
 		tempBase64 := base64.StdEncoding.EncodeToString(templateInBytes)
 
 		temp, err := l.loadBlobTemplate(tempBase64)

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -3,7 +3,7 @@ package gateway
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"net/http"
 	"net/url"
 	"path"
@@ -826,7 +826,7 @@ var playgroundTemplate *template.Template
 
 func (gw *Gateway) readGraphqlPlaygroundTemplate() {
 	playgroundPath := filepath.Join(gw.GetConfig().TemplatePath, "playground")
-	files, err := ioutil.ReadDir(playgroundPath)
+	files, err := os.ReadDir(playgroundPath)
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "playground",

--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -3552,7 +3551,7 @@ func testGetOASAPI(t *testing.T, d *Test, id, name, title string) (oasDoc openap
 	resp, _ := d.Run(t, test.TestCase{AdminAuth: true, Method: http.MethodGet, Path: getPath,
 		BodyMatch: bodyMatch, Code: http.StatusOK})
 
-	respInBytes, _ := ioutil.ReadAll(resp.Body)
+	respInBytes, _ := io.ReadAll(resp.Body)
 	_ = json.Unmarshal(respInBytes, &oasDoc)
 
 	return oasDoc
@@ -3567,7 +3566,7 @@ func testGetOldAPI(t *testing.T, d *Test, id, name string) (oldAPI apidef.APIDef
 	resp, _ := d.Run(t, test.TestCase{AdminAuth: true, Method: http.MethodGet, Path: getPath,
 		BodyMatch: bodyMatch, BodyNotMatch: "components", Code: http.StatusOK})
 
-	respInBytes, _ := ioutil.ReadAll(resp.Body)
+	respInBytes, _ := io.ReadAll(resp.Body)
 	_ = json.Unmarshal(respInBytes, &oldAPI)
 
 	return oldAPI
@@ -3591,7 +3590,7 @@ func testImportOAS(t *testing.T, ts *Test, testCase test.TestCase) string {
 	testCase.Method = http.MethodPost
 	resp, _ := ts.Run(t, testCase)
 
-	respInBytes, _ := ioutil.ReadAll(resp.Body)
+	respInBytes, _ := io.ReadAll(resp.Body)
 	_ = json.Unmarshal(respInBytes, &importResp)
 
 	ts.Gw.DoReload()

--- a/gateway/batch_requests.go
+++ b/gateway/batch_requests.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -69,7 +69,7 @@ func (b *BatchRequestHandler) doRequest(req *http.Request, relURL string) BatchR
 	}
 
 	defer resp.Body.Close()
-	content, err := ioutil.ReadAll(resp.Body)
+	content, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Warning("Body read failure! ", err)
 		return BatchReplyUnit{}

--- a/gateway/batch_requests_test.go
+++ b/gateway/batch_requests_test.go
@@ -5,7 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -61,7 +61,7 @@ func TestBatch(t *testing.T) {
 
 	resp, _ := ts.Do(test.TestCase{Method: "POST", Path: "/v1/tyk/batch/", Data: testBatchRequest})
 	if resp != nil {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		defer resp.Body.Close()
 
 		var batchResponse []map[string]json.RawMessage

--- a/gateway/cert.go
+++ b/gateway/cert.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -514,7 +514,7 @@ func (gw *Gateway) certHandler(w http.ResponseWriter, r *http.Request) {
 
 	switch r.Method {
 	case "POST":
-		content, err := ioutil.ReadAll(r.Body)
+		content, err := io.ReadAll(r.Body)
 		if err != nil {
 			doJSONWrite(w, 405, apiError("Malformed request body"))
 			return

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -46,7 +45,7 @@ func TestGatewayTLS(t *testing.T) {
 	// Configure server
 	serverCertPem, serverPrivPem, combinedPEM, _ := crypto.GenServerCertificate()
 
-	dir, _ := ioutil.TempDir("", "certs")
+	dir, _ := os.MkdirTemp("", "certs")
 	defer os.RemoveAll(dir)
 
 	client := GetTLSClient(nil, nil)
@@ -69,13 +68,13 @@ func TestGatewayTLS(t *testing.T) {
 	t.Run("Legacy TLS certificate path", func(t *testing.T) {
 
 		certFilePath := filepath.Join(dir, "server.crt")
-		err := ioutil.WriteFile(certFilePath, serverCertPem, 0666)
+		err := os.WriteFile(certFilePath, serverCertPem, 0666)
 		if err != nil {
 			t.Error("writing serverCertPem")
 		}
 
 		certKeyPath := filepath.Join(dir, "server.key")
-		err = ioutil.WriteFile(certKeyPath, serverPrivPem, 0666)
+		err = os.WriteFile(certKeyPath, serverPrivPem, 0666)
 		if err != nil {
 			t.Error("writing serverPrivPem")
 		}
@@ -104,7 +103,7 @@ func TestGatewayTLS(t *testing.T) {
 
 	t.Run("File certificate path", func(t *testing.T) {
 		certPath := filepath.Join(dir, "server.pem")
-		err := ioutil.WriteFile(certPath, combinedPEM, 0666)
+		err := os.WriteFile(certPath, combinedPEM, 0666)
 		if err != nil {
 			t.Error("could not write server.pem file")
 		}
@@ -160,7 +159,7 @@ func TestGatewayTLS(t *testing.T) {
 func TestGatewayControlAPIMutualTLS(t *testing.T) {
 	// Configure server
 	serverCertPem, _, combinedPEM, _ := crypto.GenServerCertificate()
-	dir, _ := ioutil.TempDir("", "certs")
+	dir, _ := os.MkdirTemp("", "certs")
 
 	defer func() {
 		os.RemoveAll(dir)

--- a/gateway/coprocess_bundle.go
+++ b/gateway/coprocess_bundle.go
@@ -17,7 +17,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -162,7 +161,7 @@ func (g *HTTPBundleGetter) Get() ([]byte, error) {
 	}
 
 	defer resp.Body.Close()
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 // Get mocks an HTTP(S) GET request.

--- a/gateway/coprocess_id_extractor.go
+++ b/gateway/coprocess_id_extractor.go
@@ -4,7 +4,7 @@ import (
 	"crypto/md5"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -67,7 +67,7 @@ func (e *BaseExtractor) ExtractForm(r *http.Request, paramName string) (formValu
 
 // ExtractBody is used when BodySource is specified.
 func (e *BaseExtractor) ExtractBody(r *http.Request) (string, error) {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return "", err
 	}

--- a/gateway/coprocess_python.go
+++ b/gateway/coprocess_python.go
@@ -5,7 +5,6 @@ package gateway
 
 import (
 	"C"
-	"io/ioutil"
 	"path/filepath"
 	"runtime"
 	"unsafe"
@@ -261,7 +260,7 @@ func PythonSetEnv(pythonPaths ...string) {
 func getBundlePaths(conf config.Config) []string {
 	bundlePath := filepath.Join(conf.MiddlewarePath, "bundles")
 	directories := make([]string, 0)
-	bundles, _ := ioutil.ReadDir(bundlePath)
+	bundles, _ := os.ReadDir(bundlePath)
 	for _, f := range bundles {
 		if f.IsDir() {
 			fullPath := filepath.Join(bundlePath, f.Name())

--- a/gateway/event_handler_webhooks.go
+++ b/gateway/event_handler_webhooks.go
@@ -6,7 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -244,7 +244,7 @@ func (w *WebHookHandler) HandleEvent(em config.EventMessage) {
 	} else {
 		defer resp.Body.Close()
 		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-			content, err := ioutil.ReadAll(resp.Body)
+			content, err := io.ReadAll(resp.Body)
 			if err == nil {
 				log.WithFields(logrus.Fields{
 					"prefix":       "webhooks",

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -336,7 +336,7 @@ func TestQuota(t *testing.T) {
 		}
 
 		var data map[string]string
-		body, _ := ioutil.ReadAll(r.Body)
+		body, _ := io.ReadAll(r.Body)
 		json.Unmarshal(body, &data)
 
 		if data["event"] != "QuotaExceeded" || data["message"] != "Key Quota Limit Exceeded" || data["key"] != keyID {

--- a/gateway/grpc_test.go
+++ b/gateway/grpc_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -84,7 +84,7 @@ func TestHTTP2_h2C(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer w.Body.Close()
-	b, err := ioutil.ReadAll(w.Body)
+	b, err := io.ReadAll(w.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -462,7 +462,7 @@ func TestGRPC_TokenBasedAuthentication(t *testing.T) {
 	}...)
 
 	// Read key
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	var resMap map[string]string
 	err := json.Unmarshal(body, &resMap)
 	if err != nil {
@@ -781,7 +781,7 @@ func TestGRPC_Stream_TokenBasedAuthentication(t *testing.T) {
 	}
 
 	// Read key
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Error("Fail reading body from create key request")
 	}

--- a/gateway/handler_error.go
+++ b/gateway/handler_error.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"html/template"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"runtime/pprof"
 	"strconv"
@@ -208,7 +207,7 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 
 			rsp := io.MultiWriter(w, &log)
 			tmplExecutor.Execute(rsp, &apiError)
-			response.Body = ioutil.NopCloser(&log)
+			response.Body = io.NopCloser(&log)
 		}
 	}
 

--- a/gateway/handler_error_test.go
+++ b/gateway/handler_error_test.go
@@ -2,7 +2,6 @@ package gateway
 
 import (
 	"bytes"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -20,7 +19,7 @@ func (s *Test) TestHandleError_text_xml(t *testing.T) {
 	<code>500</code>
 	<message>{{.Message}}</message>
 </error>`
-	err := ioutil.WriteFile(file, []byte(xml), 0600)
+	err := os.WriteFile(file, []byte(xml), 0600)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/gateway/handler_success.go
+++ b/gateway/handler_success.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"runtime/pprof"
 	"strconv"
@@ -173,7 +172,7 @@ func (s *SuccessHandler) RecordHit(r *http.Request, timing analytics.Latency, co
 			// mw_redis_cache instead? is there a reason not
 			// to include that in the analytics?
 			if responseCopy != nil {
-				contents, err := ioutil.ReadAll(responseCopy.Body)
+				contents, err := io.ReadAll(responseCopy.Body)
 				if err != nil {
 					log.Error("Couldn't read response body", err)
 				}
@@ -183,7 +182,7 @@ func (s *SuccessHandler) RecordHit(r *http.Request, timing analytics.Latency, co
 				// Get the wire format representation
 				var wireFormatRes bytes.Buffer
 				responseCopy.Write(&wireFormatRes)
-				responseCopy.Body = ioutil.NopCloser(bytes.NewBuffer(contents))
+				responseCopy.Body = io.NopCloser(bytes.NewBuffer(contents))
 				rawResponse = base64.StdEncoding.EncodeToString(wireFormatRes.Bytes())
 			}
 		}

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"time"
@@ -932,11 +931,11 @@ func parseForm(r *http.Request) {
 	// application/x-www-form-urlencoded
 	if r.Header.Get("Content-Type") == "application/x-www-form-urlencoded" && r.Form == nil {
 		var b bytes.Buffer
-		r.Body = ioutil.NopCloser(io.TeeReader(r.Body, &b))
+		r.Body = io.NopCloser(io.TeeReader(r.Body, &b))
 
 		r.ParseForm()
 
-		r.Body = ioutil.NopCloser(&b)
+		r.Body = io.NopCloser(&b)
 		return
 	}
 

--- a/gateway/middleware_test.go
+++ b/gateway/middleware_test.go
@@ -3,7 +3,7 @@ package gateway
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -318,7 +318,7 @@ func TestSessionLimiter_RedisQuotaExceeded_PerAPI(t *testing.T) {
 		_, _ = g.Run(t, test.TestCase{Path: fmt.Sprintf("/%s/", apiID), Headers: headers, Code: http.StatusOK})
 
 		resp, _ := g.Run(t, test.TestCase{Path: "/tyk/keys/" + key, AdminAuth: true, Code: http.StatusOK})
-		bodyInBytes, _ := ioutil.ReadAll(resp.Body)
+		bodyInBytes, _ := io.ReadAll(resp.Body)
 		var session user.SessionState
 		_ = json.Unmarshal(bodyInBytes, &session)
 

--- a/gateway/mw_basic_auth.go
+++ b/gateway/mw_basic_auth.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -124,8 +124,8 @@ func (k *BasicAuthKeyIsValid) basicAuthHeaderCredentials(w http.ResponseWriter, 
 }
 
 func (k *BasicAuthKeyIsValid) basicAuthBodyCredentials(w http.ResponseWriter, r *http.Request) (username, password string, err error, code int) {
-	body, _ := ioutil.ReadAll(r.Body)
-	r.Body = ioutil.NopCloser(bytes.NewReader(body))
+	body, _ := io.ReadAll(r.Body)
+	r.Body = io.NopCloser(bytes.NewReader(body))
 
 	userMatch := k.bodyUserRegexp.FindAllSubmatch(body, 1)
 	if len(userMatch) == 0 {

--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -79,7 +79,7 @@ func (w *customResponseWriter) getHttpResponse(r *http.Request) *http.Response {
 		ContentLength: w.dataLength,
 	}
 	if w.copyData {
-		httpResponse.Body = ioutil.NopCloser(bytes.NewReader(w.data))
+		httpResponse.Body = io.NopCloser(bytes.NewReader(w.data))
 	}
 
 	return httpResponse

--- a/gateway/mw_graphql_transport_test.go
+++ b/gateway/mw_graphql_transport_test.go
@@ -3,7 +3,7 @@ package gateway
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -82,7 +82,7 @@ func TestGraphQLEngineTransport_RoundTrip(t *testing.T) {
 				}
 			}
 
-			bodyBytes, err := ioutil.ReadAll(r.Body)
+			bodyBytes, err := io.ReadAll(r.Body)
 			require.NoError(t, err)
 			assert.Equal(t, expectations.body, string(bodyBytes))
 
@@ -140,7 +140,7 @@ func TestGraphQLEngineTransport_RoundTrip(t *testing.T) {
 			}
 		}
 
-		transportResponseBodyBytes, err := ioutil.ReadAll(transportResponse.Body)
+		transportResponseBodyBytes, err := io.ReadAll(transportResponse.Body)
 		require.NoError(t, err)
 		assert.Equal(t, response.body, string(transportResponseBodyBytes))
 	})
@@ -187,7 +187,7 @@ func TestGraphQLEngineTransport_RoundTrip(t *testing.T) {
 			}
 		}
 
-		transportResponseBodyBytes, err := ioutil.ReadAll(transportResponse.Body)
+		transportResponseBodyBytes, err := io.ReadAll(transportResponse.Body)
 		require.NoError(t, err)
 		assert.Equal(t, response.body, string(transportResponseBodyBytes))
 	})
@@ -234,7 +234,7 @@ func TestGraphQLEngineTransport_RoundTrip(t *testing.T) {
 			}
 		}
 
-		transportResponseBodyBytes, err := ioutil.ReadAll(transportResponse.Body)
+		transportResponseBodyBytes, err := io.ReadAll(transportResponse.Body)
 		require.NoError(t, err)
 		assert.Equal(t, response.body, string(transportResponseBodyBytes))
 	})

--- a/gateway/mw_js_plugin.go
+++ b/gateway/mw_js_plugin.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -118,7 +118,7 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 	logger := d.Logger()
 
 	// Create the proxy object
-	originalBody, err := ioutil.ReadAll(r.Body)
+	originalBody, err := io.ReadAll(r.Body)
 	if err != nil {
 		logger.WithError(err).Error("Failed to read request body")
 		return nil, http.StatusOK
@@ -233,10 +233,10 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 	// Reconstruct the request parts
 	if newRequestData.Request.IgnoreBody {
 		r.ContentLength = int64(len(originalBody))
-		r.Body = ioutil.NopCloser(bytes.NewReader(originalBody))
+		r.Body = io.NopCloser(bytes.NewReader(originalBody))
 	} else {
 		r.ContentLength = int64(len(newRequestData.Request.Body))
-		r.Body = ioutil.NopCloser(bytes.NewReader(newRequestData.Request.Body))
+		r.Body = io.NopCloser(bytes.NewReader(newRequestData.Request.Body))
 	}
 
 	// make sure request's body can be re-read again
@@ -575,7 +575,7 @@ func (j *JSVM) LoadTykJSApi() {
 			return otto.Value{}
 		}
 
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		bodyStr := string(body)
 		tykResp := TykJSHttpResponse{
 			Code:        resp.StatusCode,

--- a/gateway/mw_js_plugin_test.go
+++ b/gateway/mw_js_plugin_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -185,11 +185,11 @@ leakMid.NewProcessRequest(function(request, session) {
 
 	want := body + " appended"
 
-	newBodyInBytes, _ := ioutil.ReadAll(req.Body)
+	newBodyInBytes, _ := io.ReadAll(req.Body)
 	assert.Equal(t, want, string(newBodyInBytes))
 
 	t.Run("check request body is re-readable", func(t *testing.T) {
-		newBodyInBytes, _ = ioutil.ReadAll(req.Body)
+		newBodyInBytes, _ = io.ReadAll(req.Body)
 		assert.Equal(t, want, string(newBodyInBytes))
 	})
 }
@@ -496,7 +496,7 @@ testJSVMCore.NewProcessRequest(function(request, session, config) {
 		MiddlewareClassName: "testJSVMCore",
 		Pre:                 true,
 	}
-	tfile, err := ioutil.TempFile("", "tykjs")
+	tfile, err := os.CreateTemp("", "tykjs")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -558,7 +558,7 @@ leakMid.NewProcessRequest(function(request, session) {
 	dynMid.Spec.JSVM = jsvm
 	dynMid.ProcessRequest(nil, req, nil)
 
-	bs, err := ioutil.ReadAll(req.Body)
+	bs, err := io.ReadAll(req.Body)
 	if err != nil {
 		t.Fatalf("failed to read final body: %v", err)
 	}

--- a/gateway/mw_redis_cache.go
+++ b/gateway/mw_redis_cache.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"hash"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -104,7 +103,7 @@ func readBody(req *http.Request) (bodyBytes []byte, err error) {
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.ReadAll(req.Body)
+	return io.ReadAll(req.Body)
 }
 
 func isBodyHashRequired(request *http.Request) bool {

--- a/gateway/mw_transform.go
+++ b/gateway/mw_transform.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/clbanning/mxj"
@@ -52,7 +51,7 @@ func (t *TransformMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 }
 
 func transformBody(r *http.Request, tmeta *TransformSpec, t *TransformMiddleware) error {
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	defer r.Body.Close()
 
 	// Put into an interface:

--- a/gateway/mw_transform_test.go
+++ b/gateway/mw_transform_test.go
@@ -2,7 +2,7 @@ package gateway
 
 import (
 	"encoding/base64"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -47,7 +47,7 @@ func TestTransformNonAscii(t *testing.T) {
 	if err := transformBody(r, tmeta, &transform); err != nil {
 		t.Fatalf("wanted nil error, got %v", err)
 	}
-	gotBs, err := ioutil.ReadAll(r.Body)
+	gotBs, err := io.ReadAll(r.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,7 +154,7 @@ func TestTransformJSONMarshalXMLInput(t *testing.T) {
 	if err := transformBody(r, tmeta, &transform); err != nil {
 		t.Fatalf("wanted nil error, got %v", err)
 	}
-	gotBs, err := ioutil.ReadAll(r.Body)
+	gotBs, err := io.ReadAll(r.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -181,7 +181,7 @@ func TestTransformJSONMarshalJSONInput(t *testing.T) {
 	if err := transformBody(r, tmeta, &transform); err != nil {
 		t.Fatalf("wanted nil error, got %v", err)
 	}
-	gotBs, err := ioutil.ReadAll(r.Body)
+	gotBs, err := io.ReadAll(r.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -220,7 +220,7 @@ func TestTransformJSONMarshalJSONArrayInput(t *testing.T) {
 	if err := transformBody(r, tmeta, &transform); err != nil {
 		t.Fatalf("wanted nil error, got %v", err)
 	}
-	gotBs, err := ioutil.ReadAll(r.Body)
+	gotBs, err := io.ReadAll(r.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -266,7 +266,7 @@ func TestTransformXMLMarshal(t *testing.T) {
 		if err := transformBody(r, tmeta, &transform); err != nil {
 			t.Fatalf("wanted nil error, got %v", err)
 		}
-		gotBs, err := ioutil.ReadAll(r.Body)
+		gotBs, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/gateway/mw_url_rewrite.go
+++ b/gateway/mw_url_rewrite.go
@@ -2,7 +2,7 @@ package gateway
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/textproto"
 	"net/url"
@@ -673,7 +673,7 @@ func checkContextTrigger(r *http.Request, options map[string]apidef.StringRegexM
 
 func checkPayload(r *http.Request, options apidef.StringRegexMap, triggernum int) bool {
 	contextData := ctxGetData(r)
-	bodyBytes, _ := ioutil.ReadAll(r.Body)
+	bodyBytes, _ := io.ReadAll(r.Body)
 
 	matched, matches := options.FindAllStringSubmatch(string(bodyBytes), -1)
 

--- a/gateway/mw_validate_json.go
+++ b/gateway/mw_validate_json.go
@@ -3,7 +3,7 @@ package gateway
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/TykTechnologies/gojsonschema"
@@ -49,7 +49,7 @@ func (k *ValidateJSON) ProcessRequest(w http.ResponseWriter, r *http.Request, _ 
 	}
 
 	// Load input body into gojsonschema
-	bodyBytes, err := ioutil.ReadAll(r.Body)
+	bodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {
 		return err, http.StatusBadRequest
 	}

--- a/gateway/mw_virtual_endpoint.go
+++ b/gateway/mw_virtual_endpoint.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -130,7 +129,7 @@ func (d *VirtualEndpoint) ServeHTTPForCache(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Create the proxy object
-	originalBody, err := ioutil.ReadAll(r.Body)
+	originalBody, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read request body: %w", err)
 	}
@@ -148,7 +147,7 @@ func (d *VirtualEndpoint) ServeHTTPForCache(w http.ResponseWriter, r *http.Reque
 	}
 
 	// We need to copy the body _back_ for the decode
-	r.Body = ioutil.NopCloser(bytes.NewReader(originalBody))
+	r.Body = io.NopCloser(bytes.NewReader(originalBody))
 	parseForm(r)
 	requestData.Params = r.Form
 

--- a/gateway/policy.go
+++ b/gateway/policy.go
@@ -3,7 +3,7 @@ package gateway
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -134,7 +134,7 @@ func (gw *Gateway) LoadPoliciesFromDashboard(endpoint, secret string, allowExpli
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		log.Error("Policy request login failure, Response was: ", string(body))
 		gw.reLogin()
 		return nil

--- a/gateway/proxy_muxer_test.go
+++ b/gateway/proxy_muxer_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -340,7 +339,7 @@ func TestHTTP_custom_ports(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer w.Body.Close()
-	b, err := ioutil.ReadAll(w.Body)
+	b, err := io.ReadAll(w.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/gateway/redis_signal_handle_config.go
+++ b/gateway/redis_signal_handle_config.go
@@ -2,7 +2,6 @@ package gateway
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"syscall"
 	"time"
@@ -28,7 +27,7 @@ func (gw *Gateway) backupConfiguration() error {
 	now := time.Now()
 	asStr := now.Format("Mon-Jan-_2-15-04-05-2006")
 	fName := asStr + ".tyk.conf"
-	return ioutil.WriteFile(fName, oldConfig, 0644)
+	return os.WriteFile(fName, oldConfig, 0644)
 }
 
 func writeNewConfiguration(payload ConfigPayload) error {
@@ -36,7 +35,7 @@ func writeNewConfiguration(payload ConfigPayload) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(confPaths[0], newConfig, 0644)
+	return os.WriteFile(confPaths[0], newConfig, 0644)
 }
 
 func (gw *Gateway) handleNewConfiguration(payload string) {

--- a/gateway/res_handler_transform.go
+++ b/gateway/res_handler_transform.go
@@ -6,7 +6,6 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 
@@ -42,7 +41,7 @@ func respBodyReader(req *http.Request, resp *http.Response) io.ReadCloser {
 		reader, err := gzip.NewReader(resp.Body)
 		if err != nil {
 			log.Error("Body decompression error:", err)
-			return ioutil.NopCloser(bytes.NewReader(nil))
+			return io.NopCloser(bytes.NewReader(nil))
 		}
 
 		// represents unknown length
@@ -97,7 +96,7 @@ func (h *ResponseTransformMiddleware) HandleResponse(rw http.ResponseWriter, res
 	tmeta := meta.(*TransformSpec)
 
 	respBody := respBodyReader(req, res)
-	body, _ := ioutil.ReadAll(respBody)
+	body, _ := io.ReadAll(respBody)
 	defer respBody.Close()
 
 	// Put into an interface:
@@ -164,7 +163,7 @@ func (h *ResponseTransformMiddleware) HandleResponse(rw http.ResponseWriter, res
 
 	res.ContentLength = int64(bodyBuffer.Len())
 	res.Header.Set("Content-Length", strconv.Itoa(bodyBuffer.Len()))
-	res.Body = ioutil.NopCloser(&bodyBuffer)
+	res.Body = io.NopCloser(&bodyBuffer)
 
 	return nil
 }

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -1482,8 +1481,8 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 			*bodyBuffer2 = bodyBuffer
 
 			// Create new ReadClosers so we can split output
-			res.Body = ioutil.NopCloser(&bodyBuffer)
-			inres.Body = ioutil.NopCloser(bodyBuffer2)
+			res.Body = io.NopCloser(&bodyBuffer)
+			inres.Body = io.NopCloser(bodyBuffer2)
 		}
 	}
 
@@ -1687,7 +1686,7 @@ func (p *ReverseProxy) handleUpgradeResponse(rw http.ResponseWriter, req *http.R
 	go spc.copyFromBackend(errc)
 	<-errc
 
-	res.Body = ioutil.NopCloser(strings.NewReader(""))
+	res.Body = io.NopCloser(strings.NewReader(""))
 
 	return nil
 }

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -420,7 +419,7 @@ func TestCircuitBreakerEvents(t *testing.T) {
 
 	// Establish a simple HTTP server that takes webhook input and passes the event to above channel:
 	webHookServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		rawBody, err := ioutil.ReadAll(r.Body)
+		rawBody, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -785,14 +784,14 @@ func TestNopCloseRequestBody(t *testing.T) {
 		t.Error("Request's body was not replaced with nopCloser")
 	} else {
 		// try to read body 1st time
-		if data, err := ioutil.ReadAll(body); err != nil {
+		if data, err := io.ReadAll(body); err != nil {
 			t.Error("1st read, error while reading body:", err)
 		} else if !bytes.Equal(data, []byte("abcxyz")) { // compare with expected data
 			t.Error("1st read, body's data is not as expectd")
 		}
 
 		// try to read body again without closing
-		if data, err := ioutil.ReadAll(body); err != nil {
+		if data, err := io.ReadAll(body); err != nil {
 			t.Error("2nd read, error while reading body:", err)
 		} else if !bytes.Equal(data, []byte("abcxyz")) { // compare with expected data
 			t.Error("2nd read, body's data is not as expectd")
@@ -800,7 +799,7 @@ func TestNopCloseRequestBody(t *testing.T) {
 
 		// close body and try to read "closed" one
 		body.Close()
-		if data, err := ioutil.ReadAll(body); err != nil {
+		if data, err := io.ReadAll(body); err != nil {
 			t.Error("3rd read, error while reading body:", err)
 		} else if !bytes.Equal(data, []byte("abcxyz")) { // compare with expected data
 			t.Error("3rd read, body's data is not as expectd")
@@ -824,20 +823,20 @@ func TestNopCloseResponseBody(t *testing.T) {
 
 	// try to pass not nil body and check that it was replaced with nopCloser
 	resp = &http.Response{}
-	resp.Body = ioutil.NopCloser(strings.NewReader("abcxyz"))
+	resp.Body = io.NopCloser(strings.NewReader("abcxyz"))
 	nopCloseResponseBody(resp)
 	if body, ok := resp.Body.(*nopCloserBuffer); !ok {
 		t.Error("Response's body was not replaced with nopCloser")
 	} else {
 		// try to read body 1st time
-		if data, err := ioutil.ReadAll(body); err != nil {
+		if data, err := io.ReadAll(body); err != nil {
 			t.Error("1st read, error while reading body:", err)
 		} else if !bytes.Equal(data, []byte("abcxyz")) { // compare with expected data
 			t.Error("1st read, body's data is not as expectd")
 		}
 
 		// try to read body again without closing
-		if data, err := ioutil.ReadAll(body); err != nil {
+		if data, err := io.ReadAll(body); err != nil {
 			t.Error("2nd read, error while reading body:", err)
 		} else if !bytes.Equal(data, []byte("abcxyz")) { // compare with expected data
 			t.Error("2nd read, body's data is not as expectd")
@@ -845,7 +844,7 @@ func TestNopCloseResponseBody(t *testing.T) {
 
 		// close body and try to read "closed" one
 		body.Close()
-		if data, err := ioutil.ReadAll(body); err != nil {
+		if data, err := io.ReadAll(body); err != nil {
 			t.Error("3rd read, error while reading body:", err)
 		} else if !bytes.Equal(data, []byte("abcxyz")) { // compare with expected data
 			t.Error("3rd read, body's data is not as expectd")
@@ -1504,8 +1503,8 @@ func BenchmarkCopyRequestResponse(b *testing.B) {
 	req := &http.Request{}
 	res := &http.Response{}
 	for i := 0; i < b.N; i++ {
-		req.Body = ioutil.NopCloser(strings.NewReader(str))
-		res.Body = ioutil.NopCloser(strings.NewReader(str))
+		req.Body = io.NopCloser(strings.NewReader(str))
+		res.Body = io.NopCloser(strings.NewReader(str))
 		for j := 0; j < 10; j++ {
 			req, _ = copyRequest(req)
 			res, _ = copyResponse(res)

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
-	"io/ioutil"
+	"io"
 	stdlog "log"
 	"log/syslog"
 	"net"
@@ -1166,9 +1166,9 @@ func (gw *Gateway) initialiseSystem() error {
 		// `go test` without TYK_LOGLEVEL set defaults to no log
 		// output
 		log.SetLevel(logrus.ErrorLevel)
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 		gorpc.SetErrorLogger(func(string, ...interface{}) {})
-		stdlog.SetOutput(ioutil.Discard)
+		stdlog.SetOutput(io.Discard)
 	} else if *cli.DebugMode {
 		log.Level = logrus.DebugLevel
 		mainLog.Debug("Enabling debug-level output")
@@ -1293,11 +1293,11 @@ func writePIDFile(file string) error {
 		return err
 	}
 	pid := strconv.Itoa(os.Getpid())
-	return ioutil.WriteFile(file, []byte(pid), 0600)
+	return os.WriteFile(file, []byte(pid), 0600)
 }
 
 func readPIDFromFile(file string) (int, error) {
-	b, err := ioutil.ReadFile(file)
+	b, err := os.ReadFile(file)
 	if err != nil {
 		return 0, err
 	}

--- a/gateway/service_discovery.go
+++ b/gateway/service_discovery.go
@@ -1,7 +1,7 @@
 package gateway
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -52,7 +52,7 @@ func (s *ServiceDiscovery) getServiceData(name string) (string, error) {
 	}
 
 	defer resp.Body.Close()
-	contents, err := ioutil.ReadAll(resp.Body)
+	contents, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"net/http"
@@ -58,7 +57,7 @@ var (
 	discardMuxer = mux.NewRouter()
 
 	// Used to store the test bundles:
-	testMiddlewarePath, _ = ioutil.TempDir("", "tyk-middleware-path")
+	testMiddlewarePath, _ = os.MkdirTemp("", "tyk-middleware-path")
 
 	defaultTestConfig config.Config
 	EnableTestDNSMock = false
@@ -299,7 +298,7 @@ func (s *Test) RegisterJSFileMiddleware(apiid string, files map[string]string) {
 	}
 
 	for file, content := range files {
-		err = ioutil.WriteFile(gwConfig.MiddlewarePath+"/"+apiid+"/"+file, []byte(content), 0755)
+		err = os.WriteFile(gwConfig.MiddlewarePath+"/"+apiid+"/"+file, []byte(content), 0755)
 		if err != nil {
 			log.WithError(err).Error("writing in file")
 		}
@@ -471,7 +470,7 @@ func (s *Test) testHttpHandler(gw *Gateway) *mux.Router {
 		}
 		r.URL.Opaque = r.URL.RawPath
 		w.Header().Set("X-Tyk-Test", "1")
-		body, _ := ioutil.ReadAll(r.Body)
+		body, _ := io.ReadAll(r.Body)
 
 		err := json.NewEncoder(w).Encode(TestHttpResponse{
 			Method:  r.Method,
@@ -1084,7 +1083,7 @@ func (s *Test) newGateway(genConf func(globalConf *config.Config)) *Gateway {
 
 	var err error
 	gwConfig.Storage.Database = rand.Intn(15)
-	gwConfig.AppPath, err = ioutil.TempDir("", "tyk-test-")
+	gwConfig.AppPath, err = os.MkdirTemp("", "tyk-test-")
 
 	if err != nil {
 		panic(err)
@@ -1700,7 +1699,7 @@ func BuildAPI(apiGens ...func(spec *APISpec)) (specs []*APISpec) {
 func (gw *Gateway) LoadAPI(specs ...*APISpec) (out []*APISpec) {
 	gwConf := gw.GetConfig()
 	oldPath := gwConf.AppPath
-	gwConf.AppPath, _ = ioutil.TempDir("", "apps")
+	gwConf.AppPath, _ = os.MkdirTemp("", "apps")
 	gw.SetConfig(gwConf, true)
 	defer func() {
 		globalConf := gw.GetConfig()
@@ -1721,7 +1720,7 @@ func (gw *Gateway) LoadAPI(specs ...*APISpec) (out []*APISpec) {
 		}
 
 		specFilePath := filepath.Join(gwConf.AppPath, spec.APIID+strconv.Itoa(i)+".json")
-		if err := ioutil.WriteFile(specFilePath, specBytes, 0644); err != nil {
+		if err := os.WriteFile(specFilePath, specBytes, 0644); err != nil {
 			panic(err)
 		}
 
@@ -1732,7 +1731,7 @@ func (gw *Gateway) LoadAPI(specs ...*APISpec) (out []*APISpec) {
 		}
 
 		oasSpecFilePath := filepath.Join(gwConf.AppPath, spec.APIID+strconv.Itoa(i)+"-oas.json")
-		if err := ioutil.WriteFile(oasSpecFilePath, oasSpecBytes, 0644); err != nil {
+		if err := os.WriteFile(oasSpecFilePath, oasSpecBytes, 0644); err != nil {
 			panic(err)
 		}
 	}

--- a/gateway/tracing_test.go
+++ b/gateway/tracing_test.go
@@ -1,7 +1,7 @@
 package gateway
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -18,7 +18,7 @@ func TestTraceHttpRequest_toRequest(t *testing.T) {
 	tr := &traceHttpRequest{Path: "", Method: http.MethodPost, Body: body, Headers: header}
 
 	request, err := tr.toRequest(ts.Gw.GetConfig().IgnoreCanonicalMIMEHeaderKey)
-	bodyInBytes, _ := ioutil.ReadAll(request.Body)
+	bodyInBytes, _ := io.ReadAll(request.Body)
 
 	assert.NoError(t, err)
 	assert.Equal(t, http.MethodPost, request.Method)

--- a/test/goplugins/test_goplugin.go
+++ b/test/goplugins/test_goplugin.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/buger/jsonparser"
@@ -103,7 +103,7 @@ func MyPluginResponse(rw http.ResponseWriter, res *http.Response, req *http.Requ
 
 	buf.Write([]byte(`{"message":"response injected message"}`))
 
-	res.Body = ioutil.NopCloser(&buf)
+	res.Body = io.NopCloser(&buf)
 
 	apiDefinition := ctx.GetDefinition(req)
 	if apiDefinition == nil {

--- a/test/http.go
+++ b/test/http.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -47,8 +46,8 @@ type TestCase struct {
 }
 
 func AssertResponse(resp *http.Response, tc *TestCase) error {
-	body, _ := ioutil.ReadAll(resp.Body)
-	resp.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body = io.NopCloser(bytes.NewBuffer(body))
 	defer resp.Body.Close()
 
 	if tc.Code != 0 && resp.StatusCode != tc.Code {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->
"io/ioutil" has been deprecated since Go 1.19: As of Go 1.16
## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
