### PR TITLE
Merging to release-5.1: TT-9352 on merging headers, check that they are assigned back (#5271)

### DIFF
--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -580,7 +580,7 @@ func (h *CustomMiddlewareResponseHook) HandleResponse(rw http.ResponseWriter, re
 	// check if we have changes in headers
 	if !areMapsEqual(object.Response.Headers, retObject.Response.Headers) {
 		// as we have changes we need to synchronize them
-		syncHeadersAndMultiValueHeaders(retObject.Response.Headers, retObject.Response.MultivalueHeaders)
+		retObject.Response.MultivalueHeaders = syncHeadersAndMultiValueHeaders(retObject.Response.Headers, retObject.Response.MultivalueHeaders)
 	}
 
 	// Set headers:


### PR DESCRIPTION
TT-9352 on merging headers, check that they are assigned back (#5271)

<!-- Provide a general summary of your changes in the Title above -->

## Description

after merging the headers we want to assign them back to the response

## Related Issue

https://tyktech.atlassian.net/browse/TT-9352

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

- Create an api that uses a python middleware
- create a middleware that appends a new header, like this one:


```
from tyk.decorators import *
from gateway import TykGateway as tyk
import json

@Hook
def MyResponseHook(request, response, session, metadata, spec):
    response_body = str(response.body)
    changed = response_body.upper().encode('utf-8')
    response.raw_body = changed
    response.headers["python-qa"] = "qa-test"

    return response, session, metadata, spec
```

- Consume the api
- Your should receive the header in the response

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why