### PR TITLE
Merging to release-5-lts: [TT-9364] Fix formatting float64 to string in tyk_context variables (#5280)

### DIFF
--- a/gateway/mw_url_rewrite.go
+++ b/gateway/mw_url_rewrite.go
@@ -340,7 +340,7 @@ func valToStr(v interface{}) string {
 	case string:
 		s = x
 	case float64:
-		s = strconv.FormatFloat(x, 'f', -1, 32)
+		s = strconv.FormatFloat(x, 'f', -1, 64)
 	case int64:
 		s = strconv.FormatInt(x, 10)
 	case []string:

--- a/gateway/mw_url_rewrite_test.go
+++ b/gateway/mw_url_rewrite_test.go
@@ -1241,14 +1241,15 @@ func TestURLRewriteCaseSensitivity(t *testing.T) {
 func TestValToStr(t *testing.T) {
 
 	example := []interface{}{
-		"abc",      // string
-		int64(456), // int64
-		12.22,      // float
-		"abc,def",  // string url encode
+		"abc",              // string
+		int64(456),         // int64
+		12.22,              // float
+		float64(123452342), // float64
+		"abc,def",          // string url encode
 	}
 
 	str := valToStr(example)
-	expected := "abc,456,12.22,abc%2Cdef"
+	expected := "abc,456,12.22,123452342,abc%2Cdef"
 
 	if str != expected {
 		t.Errorf("expected (%s) got (%s)", expected, str)


### PR DESCRIPTION
[TT-9364] Fix formatting float64 to string in tyk_context variables (#5280)

`32` bit size rounds and distorts `float64` value.

Fixes https://github.com/TykTechnologies/tyk/issues/5134

[TT-9364]: https://tyktech.atlassian.net/browse/TT-9364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ