### PR TITLE
[TT-1702] Add missing test all APIs mTLS but control API unaffected

### DIFF
--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -1608,6 +1608,17 @@ func TestStaticMTLSAPI(t *testing.T) {
 		return ts, clientCertID, clientCert
 	}
 
+	t.Run("control API is not affected", func(t *testing.T) {
+		ts, _, _ := setup()
+		defer ts.Close()
+
+		tlsConfig := &tls.Config{InsecureSkipVerify: true}
+		transport := &http.Transport{TLSClientConfig: tlsConfig}
+		_, _ = ts.Run(t, test.TestCase{
+			AdminAuth: true, Path: "/tyk/apis/oas", Code: http.StatusOK, Client: &http.Client{Transport: transport},
+		})
+	})
+
 	t.Run("valid client cert", func(t *testing.T) {
 		ts, _, clientCert := setup()
 		defer ts.Close()


### PR DESCRIPTION
This adds the missing test for the PR: https://github.com/TykTechnologies/tyk/pull/5018