### PR TITLE
Merging to release-5.1: [TT-1702] Add missing test all APIs mTLS but control API unaffected (#5299)

### DIFF
--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -1608,6 +1608,17 @@ func TestStaticMTLSAPI(t *testing.T) {
 		return ts, clientCertID, clientCert
 	}
 
+	t.Run("control API is not affected", func(t *testing.T) {
+		ts, _, _ := setup()
+		defer ts.Close()
+
+		tlsConfig := &tls.Config{InsecureSkipVerify: true}
+		transport := &http.Transport{TLSClientConfig: tlsConfig}
+		_, _ = ts.Run(t, test.TestCase{
+			AdminAuth: true, Path: "/tyk/apis/oas", Code: http.StatusOK, Client: &http.Client{Transport: transport},
+		})
+	})
+
 	t.Run("valid client cert", func(t *testing.T) {
 		ts, _, clientCert := setup()
 		defer ts.Close()


### PR DESCRIPTION
[TT-1702] Add missing test all APIs mTLS but control API unaffected (#5299)

This adds the missing test for the PR:
https://github.com/TykTechnologies/tyk/pull/5018

[TT-1702]: https://tyktech.atlassian.net/browse/TT-1702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ