### PR TITLE
[TT-9401] remove ruby dev from plugin compiler

### DIFF
--- a/ci/images/plugin-compiler/Dockerfile
+++ b/ci/images/plugin-compiler/Dockerfile
@@ -13,7 +13,7 @@ ENV PLUGIN_SOURCE_PATH=/plugin-source
 
 RUN mkdir -p $TYK_GW_PATH $PLUGIN_SOURCE_PATH
 
-RUN apt-get remove -y --allow-remove-essential --auto-remove mercurial \
+RUN apt-get remove -y --allow-remove-essential --auto-remove mercurial ruby-dev \
 	&& rm /usr/bin/passwd && rm /usr/sbin/adduser
 
 ADD go.mod go.sum $TYK_GW_PATH


### PR DESCRIPTION
Related issue : https://tyktech.atlassian.net/browse/TT-9401

Remove ruby-dev added in golang cross https://github.com/TykTechnologies/golang-cross/blob/master/Dockerfile#L48