### PR TITLE
[TD-1965]: Fix failing upgrade tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,7 +295,6 @@ jobs:
           docker run --rm test-${{ matrix.distro }}-${{ matrix.arch }}
 
   upgrade-rpm:
-    if: startsWith(github.ref, 'refs/tags') && !github.event.pull_request.draft
     needs: goreleaser
     runs-on: ubuntu-latest
     strategy:
@@ -320,7 +319,7 @@ jobs:
         run: |
           echo 'FROM registry.access.redhat.com/${{ matrix.distro }}
           COPY tyk-gateway*.x86_64.rpm /tyk-gateway.rpm
-          RUN yum install -y curl
+          RUN yum install --allowerasing  -y curl
           RUN curl -fsSL https://packagecloud.io/install/repositories/tyk/tyk-gateway/script.rpm.sh | bash && yum install -y tyk-gateway-3.0.8-1
           RUN curl https://keyserver.tyk.io/tyk.io.rpm.signing.key.2020 -o tyk-gateway.key && rpm --import tyk-gateway.key
           RUN rpm --checksig tyk-gateway.rpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,6 +236,9 @@ jobs:
       ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
 
   upgrade-deb:
+    services:
+      httpbin.org:
+        image: kennethreitz/httpbin
     if: startsWith(github.ref, 'refs/tags') && !github.event.pull_request.draft
     runs-on: ubuntu-latest
     needs: goreleaser
@@ -292,9 +295,12 @@ jobs:
 
       - name: Test the built container image with api functionality test.
         run: |
-          docker run --rm test-${{ matrix.distro }}-${{ matrix.arch }}
+          docker run --network ${{ job.container.network }} --rm test-${{ matrix.distro }}-${{ matrix.arch }}
 
   upgrade-rpm:
+    services:
+      httpbin.org:
+        image: kennethreitz/httpbin
     if: startsWith(github.ref, 'refs/tags') && !github.event.pull_request.draft
     needs: goreleaser
     runs-on: ubuntu-latest
@@ -344,7 +350,7 @@ jobs:
 
       - name: Test the built container image with api functionality test.
         run: |
-          docker run --rm test-${{ matrix.distro }}
+          docker run --network ${{ job.container.network }} --rm test-${{ matrix.distro }}
 
   smoke-tests:
     if: startsWith(github.ref, 'refs/tags') && !github.event.pull_request.draft

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,6 +239,7 @@ jobs:
     services:
       httpbin.org:
         image: kennethreitz/httpbin
+    if: startsWith(github.ref, 'refs/tags') && !github.event.pull_request.draft
     runs-on: ubuntu-latest
     needs: goreleaser
     strategy:
@@ -300,6 +301,7 @@ jobs:
     services:
       httpbin.org:
         image: kennethreitz/httpbin
+    if: startsWith(github.ref, 'refs/tags') && !github.event.pull_request.draft
     needs: goreleaser
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,7 +239,6 @@ jobs:
     services:
       httpbin.org:
         image: kennethreitz/httpbin
-    if: startsWith(github.ref, 'refs/tags') && !github.event.pull_request.draft
     runs-on: ubuntu-latest
     needs: goreleaser
     strategy:
@@ -301,7 +300,6 @@ jobs:
     services:
       httpbin.org:
         image: kennethreitz/httpbin
-    if: startsWith(github.ref, 'refs/tags') && !github.event.pull_request.draft
     needs: goreleaser
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,6 +295,7 @@ jobs:
           docker run --rm test-${{ matrix.distro }}-${{ matrix.arch }}
 
   upgrade-rpm:
+    if: startsWith(github.ref, 'refs/tags') && !github.event.pull_request.draft
     needs: goreleaser
     runs-on: ubuntu-latest
     strategy:

--- a/ci/tests/api-functionality/api_test.sh
+++ b/ci/tests/api-functionality/api_test.sh
@@ -3,6 +3,6 @@
 set -exo pipefail
 
 #Just print the response for verbosity before testing the output
-curl -s --retry 5 --retry-delay 10 -XGET -H "Accept: application/json" "http://localhost:8080/smoke-test-api/?arg=test"
-curl -s --retry 5 --retry-delay 10 -XGET -H "Accept: application/json" "http://localhost:8080/smoke-test-api/?arg=test"| jq -e '.args.arg == "test"'
+curl -s --retry 5 --retry-delay 10 --retry-connrefused -XGET -H "Accept: application/json" "http://localhost:8080/smoke-test-api/?arg=test"
+curl -s --retry 5 --retry-delay 10 --retry-connrefused -XGET -H "Accept: application/json" "http://localhost:8080/smoke-test-api/?arg=test"| jq -e '.args.arg == "test"'
 

--- a/ci/tests/api-functionality/api_test.sh
+++ b/ci/tests/api-functionality/api_test.sh
@@ -3,6 +3,6 @@
 set -exo pipefail
 
 #Just print the response for verbosity before testing the output
-curl -s -XGET -H "Accept: application/json" "http://localhost:8080/smoke-test-api/?arg=test"
-curl -s -XGET -H "Accept: application/json" "http://localhost:8080/smoke-test-api/?arg=test"| jq -e '.args.arg == "test"'
+curl -s --retry 5 --retry-delay 10 -XGET -H "Accept: application/json" "http://localhost:8080/smoke-test-api/?arg=test"
+curl -s --retry 5 --retry-delay 10 -XGET -H "Accept: application/json" "http://localhost:8080/smoke-test-api/?arg=test"| jq -e '.args.arg == "test"'
 


### PR DESCRIPTION
This fixes:
- The curl issue in ubi9(curl-minimal vs curl) - We'll now forcefully replace curl-minimal with curl on ubi9 test.

- Inconsistent failures of httpbin - Adds a httpbin service container, that will be used instead of calling httpbin.org directly. Also updates the api test script to retry the curl invocations.