### PR TITLE
Merging to release-5.1: [TT-9401/TT-9400/TT-9441] Fix reported CVEs on dockerhub (#5310)

### DIFF
--- a/ci/images/plugin-compiler/Dockerfile
+++ b/ci/images/plugin-compiler/Dockerfile
@@ -13,7 +13,7 @@ ENV PLUGIN_SOURCE_PATH=/plugin-source
 
 RUN mkdir -p $TYK_GW_PATH $PLUGIN_SOURCE_PATH
 
-RUN apt-get remove -y --allow-remove-essential --auto-remove mercurial \
+RUN apt-get remove -y --allow-remove-essential --auto-remove mercurial ruby-dev python3.9 \
 	&& rm /usr/bin/passwd && rm /usr/sbin/adduser
 
 ADD go.mod go.sum $TYK_GW_PATH


### PR DESCRIPTION
[TT-9401/TT-9400/TT-9441] Fix reported CVEs on dockerhub (#5310)

Related issues: https://tyktech.atlassian.net/browse/TT-9401,
https://tyktech.atlassian.net/browse/TT-9400,
https://tyktech.atlassian.net/browse/TT-9441

Remove ruby-dev added in golang cross
https://github.com/TykTechnologies/golang-cross/blob/master/Dockerfile#L48

Remove python3 preinstalled in debian - plugin compiler doesn't require
it.


![image](https://github.com/TykTechnologies/tyk/assets/8171046/639709ef-a448-4ec7-b7ff-7cd1421450a7)