### PR TITLE
Fix blog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ All the documentation for Tyk Gateway and other OSS-related topics can be found 
 ## Community
 * [Tyk Community Board](https://community.tyk.io/) - Technical support from the Tyk Community
 * [Write a GitHub Issue](https://github.com/TykTechnologies/tyk/issues/new/choose) - Feature requests & bug reports welcome
-* [Technical blog](https://tyk.io/api-expertise/blog/) - Tyk announcements and updates
+* [Technical blog](https://tyk.io/blog/) - Tyk announcements and updates
 * [Newsletters ](https://pages.tyk.io/newsletter)- Subscribe to our GraphQL & API newsletters
 * If you are using Tyk give us a star ⭐️
 


### PR DESCRIPTION
## Description

Readme link to the blog page was broken

## Related Issue

## Motivation and Context

To have fixed Readme links 😉

## How This Has Been Tested

Manually tested

## Types of changes


- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

- [x ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
