### PR TITLE
[TT-7489/TT-7490]add migration for response body transform.

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -111,8 +111,6 @@ const (
 	OAuthType         = "oauth"
 	ExternalOAuthType = "externalOAuth"
 	OIDCType          = "oidc"
-
-	ResponseProcessorResponseBodyTransform = "response_body_transform"
 )
 
 var (

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -111,6 +111,8 @@ const (
 	OAuthType         = "oauth"
 	ExternalOAuthType = "externalOAuth"
 	OIDCType          = "oidc"
+
+	ResponseProcessorResponseBodyTransform = "response_body_transform"
 )
 
 var (

--- a/apidef/migration.go
+++ b/apidef/migration.go
@@ -11,6 +11,10 @@ import (
 	"github.com/TykTechnologies/tyk/internal/uuid"
 )
 
+const (
+	ResponseProcessorResponseBodyTransform = "response_body_transform"
+)
+
 var (
 	ErrMigrationNewVersioningEnabled = errors.New("not migratable - new versioning is already enabled")
 )

--- a/apidef/migration.go
+++ b/apidef/migration.go
@@ -448,7 +448,7 @@ func (a *APIDefinition) migrateScopeToPolicy() {
 func (a *APIDefinition) migrateResponseProcessors() {
 	var responseProcessors []ResponseProcessor
 	for i := range a.ResponseProcessors {
-		if a.ResponseProcessors[i].Name == "response_body_transform" {
+		if a.ResponseProcessors[i].Name == ResponseProcessorResponseBodyTransform {
 			continue
 		}
 		responseProcessors = append(responseProcessors, a.ResponseProcessors[i])

--- a/apidef/migration.go
+++ b/apidef/migration.go
@@ -233,6 +233,7 @@ func (a *APIDefinition) Migrate() (versions []APIDefinition, err error) {
 	a.migrateIDExtractor()
 	a.migrateCustomDomain()
 	a.migrateScopeToPolicy()
+	a.migrateResponseProcessors()
 
 	versions, err = a.MigrateVersioning()
 	if err != nil {
@@ -442,4 +443,16 @@ func (a *APIDefinition) migrateScopeToPolicy() {
 	}
 
 	a.Scopes.JWT = scopeClaim
+}
+
+func (a *APIDefinition) migrateResponseProcessors() {
+	var responseProcessors []ResponseProcessor
+	for i := range a.ResponseProcessors {
+		if a.ResponseProcessors[i].Name == "response_body_transform" {
+			continue
+		}
+		responseProcessors = append(responseProcessors, a.ResponseProcessors[i])
+	}
+
+	a.ResponseProcessors = responseProcessors
 }

--- a/apidef/migration_test.go
+++ b/apidef/migration_test.go
@@ -121,7 +121,7 @@ func oldTestAPI() APIDefinition {
 			},
 		},
 		ResponseProcessors: []ResponseProcessor{
-			{Name: "response_body_transform"},
+			{Name: ResponseProcessorResponseBodyTransform},
 		},
 	}
 }

--- a/apidef/migration_test.go
+++ b/apidef/migration_test.go
@@ -26,11 +26,31 @@ var testV1ExtendedPaths = ExtendedPathsSet{
 	WhiteList: []EndPointMeta{
 		{Method: http.MethodGet, Path: "/get1"},
 	},
+	TransformResponse: []TemplateMeta{
+		{
+			Method: http.MethodGet, Path: "/transform1",
+			TemplateData: TemplateData{
+				EnableSession:  true,
+				Mode:           UseBlob,
+				TemplateSource: `{"http_method":"{{.Method}}"}`,
+				Input:          RequestJSON,
+			}},
+	},
 }
 
 var testV2ExtendedPaths = ExtendedPathsSet{
 	WhiteList: []EndPointMeta{
 		{Method: http.MethodGet, Path: "/get2"},
+	},
+	TransformResponse: []TemplateMeta{
+		{
+			Method: http.MethodGet, Path: "/transform2",
+			TemplateData: TemplateData{
+				EnableSession:  true,
+				Mode:           UseBlob,
+				TemplateSource: `{"http_method":"{{.Method}}"}`,
+				Input:          RequestJSON,
+			}},
 	},
 }
 
@@ -99,6 +119,9 @@ func oldTestAPI() APIDefinition {
 				UseCookie:      true,
 				CookieName:     "Authorization",
 			},
+		},
+		ResponseProcessors: []ResponseProcessor{
+			{Name: "response_body_transform"},
 		},
 	}
 }
@@ -730,4 +753,12 @@ func TestAPIDefinition_migrateScopeToPolicy(t *testing.T) {
 		check(t, apiDef.JWTScopeClaimName, apiDef.JWTScopeToPolicyMapping, apiDef.Scopes.OIDC)
 	})
 
+}
+
+func TestAPIDefinition_migrateResponseProcessors(t *testing.T) {
+	base := oldTestAPI()
+	_, err := base.Migrate()
+	assert.NoError(t, err)
+
+	assert.Empty(t, base.ResponseProcessors)
 }

--- a/gateway/res_handler_transform_test.go
+++ b/gateway/res_handler_transform_test.go
@@ -26,7 +26,7 @@ func TestTransformResponseWithURLRewrite(t *testing.T) {
 		RewriteTo:    "get",
 	}
 
-	responseProcessorConf := []apidef.ResponseProcessor{{Name: "response_body_transform"}}
+	responseProcessorConf := []apidef.ResponseProcessor{{Name: apidef.ResponseProcessorResponseBodyTransform}}
 
 	t.Run("Transform without rewrite", func(t *testing.T) {
 		ts := StartTest(nil)
@@ -99,7 +99,7 @@ func TestTransformResponse_ContextVars(t *testing.T) {
 		},
 	}
 
-	responseProcessorConf := []apidef.ResponseProcessor{{Name: "response_body_transform"}}
+	responseProcessorConf := []apidef.ResponseProcessor{{Name: apidef.ResponseProcessorResponseBodyTransform}}
 
 	// When Context Vars are disabled
 	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
@@ -143,7 +143,7 @@ func TestTransformResponse_WithCache(t *testing.T) {
 			TemplateSource: base64.StdEncoding.EncodeToString([]byte(`{"foo":"{{._tyk_context.headers_Foo}}"}`)),
 		},
 	}
-	responseProcessorConf := []apidef.ResponseProcessor{{Name: "response_body_transform"}}
+	responseProcessorConf := []apidef.ResponseProcessor{{Name: apidef.ResponseProcessorResponseBodyTransform}}
 
 	createAPI := func(withCache bool) {
 		ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {

--- a/gateway/res_handler_transform_test.go
+++ b/gateway/res_handler_transform_test.go
@@ -26,15 +26,12 @@ func TestTransformResponseWithURLRewrite(t *testing.T) {
 		RewriteTo:    "get",
 	}
 
-	responseProcessorConf := []apidef.ResponseProcessor{{Name: apidef.ResponseProcessorResponseBodyTransform}}
-
 	t.Run("Transform without rewrite", func(t *testing.T) {
 		ts := StartTest(nil)
 		defer ts.Close()
 
 		ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
-			spec.ResponseProcessors = responseProcessorConf
 			UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
 				v.ExtendedPaths.TransformResponse = []apidef.TemplateMeta{transformResponseConf}
 			})
@@ -51,7 +48,6 @@ func TestTransformResponseWithURLRewrite(t *testing.T) {
 
 		ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
-			spec.ResponseProcessors = responseProcessorConf
 
 			UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
 				v.ExtendedPaths.TransformResponse = []apidef.TemplateMeta{transformResponseConf}
@@ -70,7 +66,6 @@ func TestTransformResponseWithURLRewrite(t *testing.T) {
 
 		ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 			spec.Proxy.ListenPath = "/"
-			spec.ResponseProcessors = responseProcessorConf
 
 			transformResponseConf.Path = "abc"
 
@@ -99,12 +94,9 @@ func TestTransformResponse_ContextVars(t *testing.T) {
 		},
 	}
 
-	responseProcessorConf := []apidef.ResponseProcessor{{Name: apidef.ResponseProcessorResponseBodyTransform}}
-
 	// When Context Vars are disabled
 	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/"
-		spec.ResponseProcessors = responseProcessorConf
 		UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
 			v.ExtendedPaths.TransformResponse = []apidef.TemplateMeta{transformResponseConf}
 		})
@@ -118,7 +110,6 @@ func TestTransformResponse_ContextVars(t *testing.T) {
 	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/"
 		spec.EnableContextVars = true
-		spec.ResponseProcessors = responseProcessorConf
 		UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
 			v.ExtendedPaths.TransformResponse = []apidef.TemplateMeta{transformResponseConf}
 		})
@@ -143,7 +134,6 @@ func TestTransformResponse_WithCache(t *testing.T) {
 			TemplateSource: base64.StdEncoding.EncodeToString([]byte(`{"foo":"{{._tyk_context.headers_Foo}}"}`)),
 		},
 	}
-	responseProcessorConf := []apidef.ResponseProcessor{{Name: apidef.ResponseProcessorResponseBodyTransform}}
 
 	createAPI := func(withCache bool) {
 		ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
@@ -151,7 +141,6 @@ func TestTransformResponse_WithCache(t *testing.T) {
 			spec.CacheOptions.CacheTimeout = 60
 			spec.EnableContextVars = true
 			spec.CacheOptions.EnableCache = withCache
-			spec.ResponseProcessors = responseProcessorConf
 			UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
 				v.ExtendedPaths.TransformResponse = []apidef.TemplateMeta{transformResponseConf}
 				v.ExtendedPaths.Cached = []string{path}


### PR DESCRIPTION
## Description
Response body transform middleware can now work without `response_body_transform` response processor configured. 
Removing `response_body_transform` from response processors for consistency.
<!-- Describe your changes in detail -->

## Related Issue
https://tyktech.atlassian.net/browse/TT-7490

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
