### PR TITLE
[TT-9586] Prevent panic in setHasMock func

### DIFF
--- a/apidef/oas/oas.go
+++ b/apidef/oas/oas.go
@@ -283,7 +283,8 @@ func (s *OAS) getTykSecurityScheme(name string) interface{} {
 	return securitySchemes[name]
 }
 
-func (s *OAS) getTykMiddleware() (middleware *Middleware) {
+// GetTykMiddleware returns middleware section from XTykAPIGateway.
+func (s *OAS) GetTykMiddleware() (middleware *Middleware) {
 	if s.GetTykExtension() != nil {
 		middleware = s.GetTykExtension().Middleware
 	}
@@ -292,8 +293,8 @@ func (s *OAS) getTykMiddleware() (middleware *Middleware) {
 }
 
 func (s *OAS) getTykOperations() (operations Operations) {
-	if s.getTykMiddleware() != nil {
-		operations = s.getTykMiddleware().Operations
+	if s.GetTykMiddleware() != nil {
+		operations = s.GetTykMiddleware().Operations
 	}
 
 	return

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -1728,7 +1728,7 @@ func (a *APISpec) setHasMock() {
 		return
 	}
 
-	middleware := a.OAS.GetTykExtension().Middleware
+	middleware := a.OAS.GetTykMiddleware()
 	if middleware == nil {
 		a.HasMock = false
 		return


### PR DESCRIPTION
This PR fixes a panic case inside `APISpec.setHasMock` func.