### PR TITLE
Merging to release-5.1: [TT-9586] Prevent panic in setHasMock func (#5361)

### DIFF
--- a/apidef/oas/oas.go
+++ b/apidef/oas/oas.go
@@ -267,7 +267,8 @@ func (s *OAS) getTykSecurityScheme(name string) interface{} {
 	return securitySchemes[name]
 }
 
-func (s *OAS) getTykMiddleware() (middleware *Middleware) {
+// GetTykMiddleware returns middleware section from XTykAPIGateway.
+func (s *OAS) GetTykMiddleware() (middleware *Middleware) {
 	if s.GetTykExtension() != nil {
 		middleware = s.GetTykExtension().Middleware
 	}
@@ -276,8 +277,8 @@ func (s *OAS) getTykMiddleware() (middleware *Middleware) {
 }
 
 func (s *OAS) getTykOperations() (operations Operations) {
-	if s.getTykMiddleware() != nil {
-		operations = s.getTykMiddleware().Operations
+	if s.GetTykMiddleware() != nil {
+		operations = s.GetTykMiddleware().Operations
 	}
 
 	return

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -1728,7 +1728,7 @@ func (a *APISpec) setHasMock() {
 		return
 	}
 
-	middleware := a.OAS.GetTykExtension().Middleware
+	middleware := a.OAS.GetTykMiddleware()
 	if middleware == nil {
 		a.HasMock = false
 		return

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -17,6 +17,8 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/TykTechnologies/tyk/apidef/oas"
+
 	"github.com/TykTechnologies/storage/persistent/model"
 	"github.com/TykTechnologies/tyk/rpc"
 
@@ -1539,6 +1541,7 @@ func Test_LoadAPIsFromRPC(t *testing.T) {
 	})
 }
 
+<<<<<<< HEAD
 func TestAPISpec_isListeningOnPort(t *testing.T) {
 	s := APISpec{APIDefinition: &apidef.APIDefinition{}}
 	cfg := &config.Config{}
@@ -1548,4 +1551,45 @@ func TestAPISpec_isListeningOnPort(t *testing.T) {
 
 	s.ListenPort = 8000
 	assert.True(t, s.isListeningOnPort(8000, cfg))
+=======
+func TestAPISpec_setHasMock(t *testing.T) {
+	s := APISpec{APIDefinition: &apidef.APIDefinition{}}
+
+	s.setHasMock()
+	assert.False(t, s.HasMock)
+
+	s.IsOAS = true
+	s.setHasMock()
+	assert.False(t, s.HasMock)
+
+	s.OAS = oas.OAS{}
+	s.setHasMock()
+	assert.False(t, s.HasMock)
+
+	xTyk := &oas.XTykAPIGateway{}
+	s.OAS.SetTykExtension(xTyk)
+	s.setHasMock()
+	assert.False(t, s.HasMock)
+
+	middleware := &oas.Middleware{}
+	xTyk.Middleware = middleware
+	s.setHasMock()
+	assert.False(t, s.HasMock)
+
+	op := &oas.Operation{}
+	middleware.Operations = oas.Operations{
+		"my-operation": op,
+	}
+	s.setHasMock()
+	assert.False(t, s.HasMock)
+
+	mock := &oas.MockResponse{}
+	op.MockResponse = mock
+	s.setHasMock()
+	assert.False(t, s.HasMock)
+
+	mock.Enabled = true
+	s.setHasMock()
+	assert.True(t, s.HasMock)
+>>>>>>> 8a2b4c14... [TT-9586] Prevent panic in setHasMock func (#5361)
 }

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -1541,7 +1541,6 @@ func Test_LoadAPIsFromRPC(t *testing.T) {
 	})
 }
 
-<<<<<<< HEAD
 func TestAPISpec_isListeningOnPort(t *testing.T) {
 	s := APISpec{APIDefinition: &apidef.APIDefinition{}}
 	cfg := &config.Config{}
@@ -1551,7 +1550,8 @@ func TestAPISpec_isListeningOnPort(t *testing.T) {
 
 	s.ListenPort = 8000
 	assert.True(t, s.isListeningOnPort(8000, cfg))
-=======
+}
+
 func TestAPISpec_setHasMock(t *testing.T) {
 	s := APISpec{APIDefinition: &apidef.APIDefinition{}}
 
@@ -1591,5 +1591,4 @@ func TestAPISpec_setHasMock(t *testing.T) {
 	mock.Enabled = true
 	s.setHasMock()
 	assert.True(t, s.HasMock)
->>>>>>> 8a2b4c14... [TT-9586] Prevent panic in setHasMock func (#5361)
 }


### PR DESCRIPTION
[TT-9586] Prevent panic in setHasMock func (#5361)

This PR fixes a panic case inside `APISpec.setHasMock` func.

[TT-9586]: https://tyktech.atlassian.net/browse/TT-9586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ