### PR TITLE
[TT-9528] Remove OldApiDefinition

### DIFF
--- a/apidef/oas/old_oas.go
+++ b/apidef/oas/old_oas.go
@@ -1,20 +1,13 @@
 package oas
 
 import (
-	openapifork "github.com/TykTechnologies/kin-openapi/openapi3"
-	"github.com/TykTechnologies/tyk/apidef"
-
 	"github.com/getkin/kin-openapi/openapi3"
+
+	openapifork "github.com/TykTechnologies/kin-openapi/openapi3"
 )
 
 type OldOAS struct {
 	openapifork.T
-}
-
-// OldApiDefinition is used to query APIs with old OAS structure.
-type OldApiDefinition struct {
-	apidef.APIDefinition `bson:"api_definition,inline" json:"api_definition,inline"`
-	OAS                  *OldOAS `bson:"oas,omitempty" json:"oas,omitempty"`
 }
 
 // ConvertToNewerOAS converts a deprecated OldOAS object to the newer OAS representation.


### PR DESCRIPTION
`OldApiDefinition` is specific to dashboard and MDCB, it is not related to the gw because it has database related functions.