### PR TITLE
[TT-8959/TT-9611] Add timeout to endpoint level cache config

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -155,6 +155,7 @@ type CacheMeta struct {
 	Path                   string `bson:"path" json:"path"`
 	CacheKeyRegex          string `bson:"cache_key_regex" json:"cache_key_regex"`
 	CacheOnlyResponseCodes []int  `bson:"cache_response_codes" json:"cache_response_codes"`
+	Timeout                int64  `bson:"timeout" json:"timeout"`
 }
 
 type RequestInputType string

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -166,6 +166,7 @@ type EndPointCacheMeta struct {
 	Method                 string
 	CacheKeyRegex          string
 	CacheOnlyResponseCodes []int
+	Timeout                int64
 }
 
 type TransformSpec struct {
@@ -805,6 +806,7 @@ func (a APIDefinitionLoader) compileCachedPathSpec(oldpaths []string, newpaths [
 		newSpec.CacheConfig.Method = spec.Method
 		newSpec.CacheConfig.CacheKeyRegex = spec.CacheKeyRegex
 		newSpec.CacheConfig.CacheOnlyResponseCodes = spec.CacheOnlyResponseCodes
+		newSpec.CacheConfig.Timeout = spec.Timeout
 		// Extend with method actions
 		urlSpec = append(urlSpec, newSpec)
 	}

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -1298,6 +1298,52 @@ func TestOldCachePlugin(t *testing.T) {
 	})
 }
 
+func TestAdvanceCacheTimeoutPerEndpoint(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+	cache := storage.RedisCluster{KeyPrefix: "cache-", RedisController: ts.Gw.RedisController}
+	defer cache.DeleteScanMatch("*")
+
+	extendedPaths := apidef.ExtendedPathsSet{
+		AdvanceCacheConfig: []apidef.CacheMeta{
+			{
+				Method: http.MethodGet,
+				Path:   "/my-cached-endpoint",
+			},
+		},
+	}
+
+	api := BuildAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/"
+		spec.CacheOptions = apidef.CacheOptions{
+			CacheTimeout: 0,
+			EnableCache:  true,
+		}
+
+		UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+			v.ExtendedPaths = extendedPaths
+		})
+	})[0]
+
+	ts.Gw.LoadAPI(api)
+
+	headerCache := map[string]string{"x-tyk-cached-response": "1"}
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{Method: http.MethodGet, Path: "/my-cached-endpoint", HeadersNotMatch: headerCache, Delay: 10 * time.Millisecond},
+		{Method: http.MethodGet, Path: "/my-cached-endpoint", HeadersNotMatch: headerCache},
+	}...)
+
+	// endpoint level cache timeout should override
+	extendedPaths.AdvanceCacheConfig[0].Timeout = 120
+	ts.Gw.LoadAPI(api)
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{Method: http.MethodGet, Path: "/my-cached-endpoint", HeadersNotMatch: headerCache, Delay: 10 * time.Millisecond},
+		{Method: http.MethodGet, Path: "/my-cached-endpoint", HeadersMatch: headerCache},
+	}...)
+}
+
 func TestWebsocketsSeveralOpenClose(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()

--- a/gateway/mw_redis_cache.go
+++ b/gateway/mw_redis_cache.go
@@ -146,6 +146,7 @@ func (m *RedisCacheMiddleware) decodePayload(payload string) (string, string, er
 type cacheOptions struct {
 	key                    string
 	cacheOnlyResponseCodes []int
+	timeout                int64
 }
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
@@ -193,14 +194,23 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 	}
 
 	cacheOnlyResponseCodes := m.Spec.CacheOptions.CacheOnlyResponseCodes
-	// override api main CacheOnlyResponseCodes by endpoint specific if provided
-	if cacheMeta != nil && len(cacheMeta.CacheOnlyResponseCodes) > 0 {
-		cacheOnlyResponseCodes = cacheMeta.CacheOnlyResponseCodes
+	timeout := m.Spec.CacheOptions.CacheTimeout
+	if cacheMeta != nil {
+		// override api level CacheOnlyResponseCodes by endpoint level if provided
+		if len(cacheMeta.CacheOnlyResponseCodes) > 0 {
+			cacheOnlyResponseCodes = cacheMeta.CacheOnlyResponseCodes
+		}
+
+		// override api level Timout by endpoint level if provided
+		if cacheMeta.Timeout > 0 {
+			timeout = cacheMeta.Timeout
+		}
 	}
 
 	ctxSetCacheOptions(r, &cacheOptions{
 		key:                    key,
 		cacheOnlyResponseCodes: cacheOnlyResponseCodes,
+		timeout:                timeout,
 	})
 
 	retBlob, err = m.store.GetKey(key)

--- a/gateway/res_cache.go
+++ b/gateway/res_cache.go
@@ -76,7 +76,7 @@ func (m *ResponseCacheMiddleware) HandleResponse(w http.ResponseWriter, res *htt
 	}
 
 	cacheThisRequest := true
-	cacheTTL := m.Spec.CacheOptions.CacheTimeout
+	cacheTTL := options.timeout
 
 	// make sure the status codes match if specified
 	if len(options.cacheOnlyResponseCodes) > 0 {


### PR DESCRIPTION
This PR adds a new param `timeout` to `advance_cache_config` so that `APIDefinition.CacheOptions.CacheTimeout` is overriden by endpoint level `extended_paths.advance_cache_config[x].timeout` if endpoint level is greater than `0`.