### PR TITLE
[TT-8959/TT-9612] Add endpoint level cache timeout OAS conversion

### DIFF
--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -830,6 +830,9 @@ type CachePlugin struct {
 
 	// CacheResponseCodes contains a list of valid response codes for responses that are okay to add to the cache.
 	CacheResponseCodes []int `bson:"cacheResponseCodes,omitempty" json:"cacheResponseCodes,omitempty"`
+
+	// Timeout is the TTL for the endpoint level caching in seconds. 0 means no caching.
+	Timeout int64 `bson:"timeout,omitempty" json:"timeout,omitempty"`
 }
 
 // Fill fills *CachePlugin from apidef.CacheMeta.
@@ -837,6 +840,7 @@ func (a *CachePlugin) Fill(cm apidef.CacheMeta) {
 	a.Enabled = !cm.Disabled
 	a.CacheByRegex = cm.CacheKeyRegex
 	a.CacheResponseCodes = cm.CacheOnlyResponseCodes
+	a.Timeout = cm.Timeout
 }
 
 // ExtractTo extracts *CachePlugin values to *apidef.CacheMeta.
@@ -844,6 +848,7 @@ func (a *CachePlugin) ExtractTo(cm *apidef.CacheMeta) {
 	cm.Disabled = !a.Enabled
 	cm.CacheKeyRegex = a.CacheByRegex
 	cm.CacheOnlyResponseCodes = a.CacheResponseCodes
+	cm.Timeout = a.Timeout
 }
 
 // EnforceTimeout holds the configuration for enforcing request timeouts.

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -579,7 +579,8 @@
         },
         "timeout": {
           "type": "integer",
-          "format": "int64"
+          "format": "int64",
+          "minimum": 0
         }
       },
       "required": [

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -576,6 +576,10 @@
               "type": "integer"
             }
           ]
+        },
+        "timeout": {
+          "type": "integer",
+          "format": "int64"
         }
       },
       "required": [

--- a/apidef/oas/schema/x-tyk-gateway.md
+++ b/apidef/oas/schema/x-tyk-gateway.md
@@ -925,6 +925,9 @@ Example value: `\"id\":[^,]*` (quoted json value).
 **Field: `cacheResponseCodes` (`[]int`)**
 CacheResponseCodes contains a list of valid response codes for responses that are okay to add to the cache.
 
+**Field: `timeout` (`int`)**
+Timeout is the TTL for the endpoint level caching in seconds. 0 means no caching.
+
 
 ### **EnforceTimeout**
 


### PR DESCRIPTION
This PR:
- adds OAS conversion for endpoint level `timeout`
- adds GoDoc
- adds `timeout` to the schema `apidef/oas/schema/x-tyk-api-gateway.json`