### PR TITLE
Fix/update pmylund go cache

### DIFF
--- a/dnscache/storage.go
+++ b/dnscache/storage.go
@@ -6,7 +6,7 @@ import (
 
 	"fmt"
 
-	cache "github.com/pmylund/go-cache"
+	"github.com/patrickmn/go-cache"
 	"github.com/sirupsen/logrus"
 )
 

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -1256,12 +1256,12 @@ func (s *Test) Close() {
 		log.Error("could not remove apis")
 	}
 
-	s.Gw.SessionCache = nil
-	s.Gw.ExpiryCache = nil
-	s.Gw.UtilCache = nil
-	s.Gw.ServiceCache = nil
-	s.Gw.RPCGlobalCache = nil
-	s.Gw.RPCCertCache = nil
+	s.Gw.SessionCache.Close()
+	s.Gw.ExpiryCache.Close()
+	s.Gw.UtilCache.Close()
+	s.Gw.ServiceCache.Close()
+	s.Gw.RPCGlobalCache.Close()
+	s.Gw.RPCCertCache.Close()
 
 	runtime.GC()
 }

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -1255,6 +1255,15 @@ func (s *Test) Close() {
 	if err != nil {
 		log.Error("could not remove apis")
 	}
+
+	s.Gw.SessionCache = nil
+	s.Gw.ExpiryCache = nil
+	s.Gw.UtilCache = nil
+	s.Gw.ServiceCache = nil
+	s.Gw.RPCGlobalCache = nil
+	s.Gw.RPCCertCache = nil
+
+	runtime.GC()
 }
 
 // RemoveApis clean all the apis from a living gw

--- a/gateway/testutil_test.go
+++ b/gateway/testutil_test.go
@@ -13,7 +13,6 @@ func TestStartTestLeaks(t *testing.T) {
 	ts.Close()
 
 	tick := func() {
-		runtime.GC()
 		time.Sleep(time.Second)
 		t.Logf("Tick with %d goroutines", runtime.NumGoroutine())
 	}

--- a/gateway/testutil_test.go
+++ b/gateway/testutil_test.go
@@ -1,0 +1,22 @@
+package gateway
+
+import (
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestStartTestLeaks(t *testing.T) {
+	t.Logf("Started with %d goroutines", runtime.NumGoroutine())
+
+	ts := StartTest(nil)
+	ts.Close()
+
+	tick := func() {
+		runtime.GC()
+		time.Sleep(time.Second)
+		t.Logf("Tick with %d goroutines", runtime.NumGoroutine())
+	}
+
+	tick()
+}

--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,7 @@ require (
 require (
 	github.com/TykTechnologies/kin-openapi v0.90.0
 	github.com/TykTechnologies/opentelemetry v0.0.11
-	github.com/patrickmn/go-cache v2.1.0+incompatible
+	github.com/patrickmn/go-cache v2.1.1-0.20191004192108-46f407853014+incompatible
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,7 @@ require (
 require (
 	github.com/TykTechnologies/kin-openapi v0.90.0
 	github.com/TykTechnologies/opentelemetry v0.0.11
-	github.com/patrickmn/go-cache v2.1.1-0.20191004192108-46f407853014+incompatible
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,6 @@ require (
 	github.com/oschwald/maxminddb-golang v1.5.0
 	github.com/paulbellamy/ratecounter v0.2.0
 	github.com/pires/go-proxyproto v0.0.0-20190615163442-2c19fd512994
-	github.com/pmylund/go-cache v2.1.0+incompatible
 	github.com/robertkrimen/otto v0.0.0-20180617131154-15f95af6e78d
 	github.com/rs/cors v1.7.0
 	github.com/sirupsen/logrus v1.9.3
@@ -82,6 +81,7 @@ require (
 require (
 	github.com/TykTechnologies/kin-openapi v0.90.0
 	github.com/TykTechnologies/opentelemetry v0.0.11
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -782,8 +782,8 @@ github.com/oschwald/maxminddb-golang v1.5.0/go.mod h1:3jhIUymTJ5VREKyIhWm66LJiQt
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
-github.com/patrickmn/go-cache v2.1.1-0.20191004192108-46f407853014+incompatible h1:IWzUvJ72xMjmrjR9q3H1PF+jwdN0uNQiR2t1BLNalyo=
-github.com/patrickmn/go-cache v2.1.1-0.20191004192108-46f407853014+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/paulbellamy/ratecounter v0.2.0 h1:2L/RhJq+HA8gBQImDXtLPrDXK5qAj6ozWVK/zFXVJGs=
 github.com/paulbellamy/ratecounter v0.2.0/go.mod h1:Hfx1hDpSGoqxkVVpBi/IlYD7kChlfo5C6hzIHwPqfFE=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/go.sum
+++ b/go.sum
@@ -782,6 +782,8 @@ github.com/oschwald/maxminddb-golang v1.5.0/go.mod h1:3jhIUymTJ5VREKyIhWm66LJiQt
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/paulbellamy/ratecounter v0.2.0 h1:2L/RhJq+HA8gBQImDXtLPrDXK5qAj6ozWVK/zFXVJGs=
 github.com/paulbellamy/ratecounter v0.2.0/go.mod h1:Hfx1hDpSGoqxkVVpBi/IlYD7kChlfo5C6hzIHwPqfFE=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -807,8 +809,6 @@ github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZ
 github.com/pkg/term v0.0.0-20180730021639-bffc007b7fd5/go.mod h1:eCbImbZ95eXtAUIbLAuAVnBnwf83mjf6QIVH8SHYwqQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/pmylund/go-cache v2.1.0+incompatible h1:n+7K51jLz6a3sCvff3BppuCAkixuDHuJ/C57Vw/XjTE=
-github.com/pmylund/go-cache v2.1.0+incompatible/go.mod h1:hmz95dGvINpbRZGsqPcd7B5xXY5+EKb5PpGhQY3NTHk=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=

--- a/go.sum
+++ b/go.sum
@@ -782,8 +782,8 @@ github.com/oschwald/maxminddb-golang v1.5.0/go.mod h1:3jhIUymTJ5VREKyIhWm66LJiQt
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
-github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
-github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
+github.com/patrickmn/go-cache v2.1.1-0.20191004192108-46f407853014+incompatible h1:IWzUvJ72xMjmrjR9q3H1PF+jwdN0uNQiR2t1BLNalyo=
+github.com/patrickmn/go-cache v2.1.1-0.20191004192108-46f407853014+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/paulbellamy/ratecounter v0.2.0 h1:2L/RhJq+HA8gBQImDXtLPrDXK5qAj6ozWVK/zFXVJGs=
 github.com/paulbellamy/ratecounter v0.2.0/go.mod h1:Hfx1hDpSGoqxkVVpBi/IlYD7kChlfo5C6hzIHwPqfFE=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -3,7 +3,7 @@ package cache
 import (
 	"time"
 
-	"github.com/pmylund/go-cache"
+	"github.com/patrickmn/go-cache"
 )
 
 // DefaultExpiration is a helper value that uses the repository defaults.

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"sync"
 	"time"
 
 	"github.com/patrickmn/go-cache"
@@ -16,6 +17,7 @@ type Repository interface {
 	Delete(string)
 	Count() int
 	Flush()
+	Close()
 }
 
 // New creates a new cache instance.
@@ -33,6 +35,8 @@ func New(defaultExpiration, cleanupInterval int64) Repository {
 }
 
 type repository struct {
+	mu sync.RWMutex
+
 	// Default expiration interval, in seconds.
 	defaultExpiration int64
 
@@ -45,6 +49,12 @@ type repository struct {
 
 // Get retrieves a cache item by key.
 func (r *repository) Get(key string) (interface{}, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.cache == nil {
+		return nil, false
+	}
+
 	return r.cache.Get(key)
 }
 
@@ -54,20 +64,59 @@ func (r *repository) Set(key string, value interface{}, timeout int64) {
 	if timeout <= 0 {
 		timeout = r.defaultExpiration
 	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.cache == nil {
+		return
+	}
+
 	r.cache.Set(key, value, time.Duration(timeout)*time.Second)
 }
 
 // Delete cache item by key.
 func (r *repository) Delete(key string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.cache == nil {
+		return
+	}
+
 	r.cache.Delete(key)
 }
 
 // Count returns number of items in the cache.
 func (r *repository) Count() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if r.cache == nil {
+		return 0
+	}
+
 	return r.cache.ItemCount()
 }
 
 // Flush flushes all the items from the cache.
 func (r *repository) Flush() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.cache == nil {
+		return
+	}
+
 	r.cache.Flush()
+}
+
+// Close shuts down the underlying cache safely
+func (r *repository) Close() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.cache != nil {
+		r.cache.Flush()
+		r.cache = nil
+	}
 }

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -31,4 +31,6 @@ func TestCache(t *testing.T) {
 	cache.Set("key", "value", 1)
 	cache.Flush()
 	assert.Equal(t, 0, cache.Count())
+
+	cache.Close()
 }

--- a/regexp/cache.go
+++ b/regexp/cache.go
@@ -4,7 +4,7 @@ import (
 	"regexp"
 	"time"
 
-	gocache "github.com/pmylund/go-cache"
+	gocache "github.com/patrickmn/go-cache"
 )
 
 const (


### PR DESCRIPTION
Testing change: This PR slightly improves the leaky goroutines behaviour around StartTest/Test.Close. Each test function that invokes startTest may leak several goroutines, one for each of the caches. If not clearing the caches and invoking the garbage collector, leaks accumulate.

Tested with 

Test before: 16 -> 24 -> 31 goroutines
Test after: 16 -> 18 -> 19

- update import paths for pmylund/go-cache, renamed to patrickmn/go-cache on github (same repo),
- add test case to verify goroutine leaks for StartTest() / .Close(),
- add explicit clear caches to nil and GC invocation in Test.Close(),
- add a Close() and mutex to internal/cache (fix race in tests)

The dependency is not bumped, last release is october 2017 and we are already on latest.
