### PR TITLE
Fix global testMiddlewarePath writing out to /tmp

### DIFF
--- a/gateway/coprocess_bundle_test.go
+++ b/gateway/coprocess_bundle_test.go
@@ -18,11 +18,9 @@ import (
 	"github.com/TykTechnologies/tyk/test"
 )
 
-var (
-	testBundlesPath = filepath.Join(testMiddlewarePath, "bundles")
-)
+var pkgPath string
 
-func pkgPath() string {
+func init() {
 	_, filename, _, _ := runtime.Caller(0)
 	return filepath.Dir(filename) + "./.."
 }
@@ -58,6 +56,7 @@ func TestBundleLoader(t *testing.T) {
 	})
 
 	t.Run("Existing bundle with auth check", func(t *testing.T) {
+		testBundlesPath := filepath.Join(ts.Gw.GetConfig().MiddlewarePath, "bundles")
 		specs := ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 			spec.CustomMiddlewareBundle = bundleID
 		})

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -1715,6 +1715,7 @@ func BuildAPI(apiGens ...func(spec *APISpec)) (specs []*APISpec) {
 }
 
 func (gw *Gateway) LoadAPI(specs ...*APISpec) (out []*APISpec) {
+	var err error
 	gwConf := gw.GetConfig()
 	oldPath := gwConf.AppPath
 	gwConf.AppPath, err = ioutil.TempDir("", "apps")

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -1084,10 +1084,10 @@ func (s *Test) newGateway(genConf func(globalConf *config.Config)) *Gateway {
 	var err error
 	gwConfig.Storage.Database = mathRand.Intn(15)
 	gwConfig.AppPath, err = ioutil.TempDir("", "tyk-test-")
-
 	if err != nil {
 		panic(err)
 	}
+
 	gwConfig.EnableAnalytics = true
 	gwConfig.AnalyticsConfig.EnableGeoIP = true
 
@@ -1107,7 +1107,11 @@ func (s *Test) newGateway(genConf func(globalConf *config.Config)) *Gateway {
 	gwConfig.BundleBaseURL = testHttpBundles
 
 	// Used to store the test bundles:
-	testMiddlewarePath, _ := ioutil.TempDir("", "tyk-middleware-path")
+	testMiddlewarePath, err := ioutil.TempDir("", "tyk-middleware-path")
+	if err != nil {
+		panic(err)
+	}
+
 	gwConfig.MiddlewarePath = testMiddlewarePath
 
 	// force ipv4 for now, to work around the docker bug affecting
@@ -1713,7 +1717,10 @@ func BuildAPI(apiGens ...func(spec *APISpec)) (specs []*APISpec) {
 func (gw *Gateway) LoadAPI(specs ...*APISpec) (out []*APISpec) {
 	gwConf := gw.GetConfig()
 	oldPath := gwConf.AppPath
-	gwConf.AppPath, _ = ioutil.TempDir("", "apps")
+	gwConf.AppPath, err = ioutil.TempDir("", "apps")
+	if err != nil {
+		panic(err)
+	}
 	gw.SetConfig(gwConf, true)
 	defer func() {
 		globalConf := gw.GetConfig()

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -59,9 +59,6 @@ var (
 	// to register to, but never used
 	discardMuxer = mux.NewRouter()
 
-	// Used to store the test bundles:
-	testMiddlewarePath, _ = ioutil.TempDir("", "tyk-middleware-path")
-
 	defaultTestConfig config.Config
 	EnableTestDNSMock = false
 	MockHandle        *test.DnsMockHandle
@@ -1108,6 +1105,9 @@ func (s *Test) newGateway(genConf func(globalConf *config.Config)) *Gateway {
 	gwConfig.CoProcessOptions.EnableCoProcess = true
 	gwConfig.EnableBundleDownloader = true
 	gwConfig.BundleBaseURL = testHttpBundles
+
+	// Used to store the test bundles:
+	testMiddlewarePath, _ := ioutil.TempDir("", "tyk-middleware-path")
 	gwConfig.MiddlewarePath = testMiddlewarePath
 
 	// force ipv4 for now, to work around the docker bug affecting


### PR DESCRIPTION
Fixes tests code to not write out a testMiddlewarePath to /tmp on gateway start.

Intended for: master, LTS, 5.3