### PR TITLE
Allow running without Redis, without printing errors

### DIFF
--- a/gateway/health_check.go
+++ b/gateway/health_check.go
@@ -76,6 +76,10 @@ func (gw *Gateway) gatherHealthChecks() {
 	go func() {
 		defer wg.Done()
 
+		if !gw.RedisController.Enabled() {
+			return
+		}
+
 		var checkItem = apidef.HealthCheckItem{
 			Status:        apidef.Pass,
 			ComponentType: apidef.Datastore,

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -340,7 +340,8 @@ func (gw *Gateway) setupGlobals() {
 	}
 
 	if gwConfig.EnableAnalytics && gwConfig.Storage.Type != "redis" {
-		mainLog.Fatal("Analytics requires Redis Storage backend, please enable Redis in the tyk.conf file.")
+		mainLog.Warn("Analytics requires Redis Storage backend, please enable Redis in the tyk.conf file.")
+		gwConfig.EnableAnalytics = false
 	}
 
 	// Initialise HostCheckerManager only if uptime tests are enabled.
@@ -1214,7 +1215,7 @@ func (gw *Gateway) initialiseSystem() error {
 	}
 
 	if gwConfig.Storage.Type != "redis" {
-		mainLog.Fatal("Redis connection details not set, please ensure that the storage type is set to Redis and that the connection parameters are correct.")
+		mainLog.Warn("Redis connection details not set, starting in dbless mode, features like analytics and rate limits going to be disabled")
 	}
 
 	// suply rpc client globals to join it main loging and instrumentation sub systems
@@ -1271,6 +1272,10 @@ func (gw *Gateway) initialiseSystem() error {
 		if gwConfig.Policies.PolicyRecordName == "" {
 			gwConfig.Policies.PolicyRecordName = config.DefaultDashPolicyRecordName
 		}
+	}
+
+	if gwConfig.Storage.Type != "redis" {
+		gw.RedisController.DisableRedis(true)
 	}
 
 	gw.SetConfig(gwConfig)

--- a/storage/redis_controller.go
+++ b/storage/redis_controller.go
@@ -51,7 +51,7 @@ func (rc *RedisController) DisableRedis(setRedisDown bool) {
 	rc.reconnect <- struct{}{}
 }
 
-func (rc *RedisController) enabled() bool {
+func (rc *RedisController) Enabled() bool {
 	ok := true
 	if v := rc.disableRedis.Load(); v != nil {
 		ok = !v.(bool)
@@ -193,7 +193,7 @@ func (rc *RedisController) statusCheck(ctx context.Context, conf *config.Config,
 			return
 		case <-tick.C:
 			//if we disabled redis - we don't want to check anything
-			if !rc.enabled() {
+			if !rc.Enabled() {
 				continue
 			}
 


### PR DESCRIPTION
Tyk already supports running without Redis, because it support Redis failure handling, and reconnection mechanism.

What this PR adds is allow set TYK_GW_STORAGE_TYPE to empty value (actually anything non "redis"), disable auto-reconnects, and turns on fallback mode. It also makes it not print error messages every 10 seconds.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
