### PR TITLE
Fix error response template escapes

### DIFF
--- a/gateway/mw_validate_json_test.go
+++ b/gateway/mw_validate_json_test.go
@@ -25,9 +25,13 @@ var testJsonSchema = `{
             "type": "integer",
             "minimum": 0
         },
-		"objs":{
-			"enum":["a","b","c"],
-			"type":"string"
+		"objs": {
+			"enum": ["a", "b", "c"],
+			"type": "string"
+		},
+		"regex": {
+			"type": "string",
+			"pattern": "^[a-z]+[0-9]+$"
 		}
     },
     "required": ["firstName", "lastName"]
@@ -61,9 +65,11 @@ func TestValidateJSONSchema(t *testing.T) {
 		{Method: http.MethodPost, Path: "/without_validation", Data: "{not_valid}", Code: http.StatusOK},
 		{Method: http.MethodPost, Path: "/v", Data: `{"age":23}`, BodyMatch: `firstName: firstName is required; lastName: lastName is required`, Code: http.StatusUnprocessableEntity},
 		{Method: http.MethodPost, Path: "/v", Data: `[]`, BodyMatch: `Expected: object, given: array`, Code: http.StatusUnprocessableEntity},
-		{Method: http.MethodPost, Path: "/v", Data: `not_json`, Code: http.StatusBadRequest},
+		{Method: http.MethodPost, Path: "/v", Data: `not_json`, Code: http.StatusBadRequest, BodyMatch: `JSON parsing error: invalid character 'o' in literal null \(expecting 'u'\)`},
 		{Method: http.MethodPost, Path: "/v", Data: `{"age":23, "firstName": "Harry", "lastName": "Potter"}`, Code: http.StatusOK},
 		{Method: http.MethodPost, Path: "/v", Data: `{"age":23, "firstName": "Harry", "lastName": "Potter", "objs": "d"}`, Code: http.StatusUnprocessableEntity, BodyMatch: `objs: objs must be one of the following: \\"a\\", \\"b\\", \\"c\\"`},
+		{Method: http.MethodPost, Path: "/v", Data: `{"age":23, "firstName": "dummy", "lastName": "dummy", "regex": "d1"}`, Code: http.StatusOK},
+		{Method: http.MethodPost, Path: "/v", Data: `{"age":23, "firstName": "dummy", "lastName": "dummy", "regex": "D1"}`, Code: http.StatusUnprocessableEntity, BodyMatch: `regex: Does not match pattern '\^\[a-z\]\+\[0-9\]\+\$'`},
 	}...)
 
 	t.Run("disabled", func(t *testing.T) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Fix symbol escapes in error response to be proper for the used format.

## Related Issue
https://github.com/TykTechnologies/tyk/issues/4363

## Motivation and Context
This bug seems to only actually affect the `validate_json` middleware as it seems to be the only one to report error messages with special characters like quotes. But this issue is present for any error messages sent to a client with special characters. This PR changes the escape strategy to use the escaping from the XML and JSON encoding packages.

## How This Has Been Tested
Ran tests for `handle_error.go` and `mw_validate_json.go`. Added another test case for ` mw_validate_json.go`.

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [x] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
