### PR TITLE
[TT-9257] Update graphql-go-tools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/TykTechnologies/gojsonschema v0.0.0-20170222154038-dcb3e4bb7990
 	github.com/TykTechnologies/gorpc v0.0.0-20210624160652-fe65bda0ccb9
 	github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708
-	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230629083404-7adc3c0fdfac
+	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230807142628-f787e7ab594e
 	github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c
 	github.com/TykTechnologies/murmur3 v0.0.0-20230310161213-aad17efd5632
 	github.com/TykTechnologies/openid2go v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/TykTechnologies/gorpc v0.0.0-20210624160652-fe65bda0ccb9/go.mod h1:v6
 github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708 h1:cmXjlMzcexhc/Cg+QB/c2CPUVs1ux9xn6162qaf/LC4=
 github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708/go.mod h1:mkS8jKcz8otdfEXhJs1QQ/DKoIY1NFFsRPKS0RwQENI=
 github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230320143102-7a16078ce517/go.mod h1:ZiFZcrue3+n2mHH+KLHRipbYVULkgy3Myko5S7IIs74=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230629083404-7adc3c0fdfac h1:sSXsnNJdM78MAAQ11OEPTDyeq9x7QYJQ6L9P2q+z5eE=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230629083404-7adc3c0fdfac/go.mod h1:ZWpfrRjWhBPryIMCDK8kAew4hji0QUQxj3Uhc2COlMU=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230807142628-f787e7ab594e h1:5iMgqxmb7ZobBi0LNPKbQSnLxmaLCp37DXigeXbVtgI=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230807142628-f787e7ab594e/go.mod h1:ZWpfrRjWhBPryIMCDK8kAew4hji0QUQxj3Uhc2COlMU=
 github.com/TykTechnologies/kin-openapi v0.90.0 h1:kHw0mtANwIpmlU6eCeeCgRMa52EiPPhEZPuHc3lKawo=
 github.com/TykTechnologies/kin-openapi v0.90.0/go.mod h1:pkzuiceujHvAuDu3bTD/AD5OacuP4eMfrz9QhJlMvdQ=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c h1:j6fd0Fz1R4oSWOmcooGjrdahqrML+btQ+PfEJw8SzbA=

--- a/internal/graphql/otel_graphql_engine.go
+++ b/internal/graphql/otel_graphql_engine.go
@@ -79,7 +79,7 @@ func (o *OtelGraphqlEngineV2) Resolve(resolveContext *resolve.Context, planResul
 	var operationName = "ResolvePlan"
 	ctx, span := o.tracerProvider.Tracer().Start(o.traceContext, operationName)
 	defer span.End()
-	resolveContext.Context = ctx
+	resolveContext = resolveContext.WithContext(ctx)
 	if err := o.engine.Resolve(resolveContext, planResult, writer); err != nil {
 		span.SetStatus(otel.SPAN_STATUS_ERROR, "failed to resolve")
 		return err


### PR DESCRIPTION
This PR updates `graphql-go-tools` dependency.

See [TT-9257](https://tyktech.atlassian.net/browse/TT-9257) for details.

[TT-9257]: https://tyktech.atlassian.net/browse/TT-9257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ