### PR TITLE
Merging to release-5-lts: [TT-9628/TT-9724] Respect existing extended paths in OAS.ExtractTo (#5399)

### DIFF
--- a/apidef/oas/oas.go
+++ b/apidef/oas/oas.go
@@ -93,7 +93,7 @@ func (s *OAS) ExtractTo(api *apidef.APIDefinition) {
 
 	s.extractSecurityTo(api)
 
-	var ep apidef.ExtendedPathsSet
+	ep := api.VersionData.Versions[Main].ExtendedPaths
 	s.extractPathsAndOperations(&ep)
 
 	api.VersionData.Versions = map[string]apidef.VersionInfo{

--- a/apidef/oas/oas_test.go
+++ b/apidef/oas/oas_test.go
@@ -106,6 +106,24 @@ func TestOAS(t *testing.T) {
 	})
 }
 
+func TestOAS_ExtractTo_DontTouchExistingClassicFields(t *testing.T) {
+	var api apidef.APIDefinition
+	api.VersionData.Versions = map[string]apidef.VersionInfo{
+		Main: {
+			ExtendedPaths: apidef.ExtendedPathsSet{
+				TransformHeader: []apidef.HeaderInjectionMeta{
+					{},
+				},
+			},
+		},
+	}
+
+	var s OAS
+	s.ExtractTo(&api)
+
+	assert.Len(t, api.VersionData.Versions[Main].ExtendedPaths.TransformHeader, 1)
+}
+
 func TestOAS_AddServers(t *testing.T) {
 	t.Parallel()
 	type fields struct {

--- a/apidef/oas/root.go
+++ b/apidef/oas/root.go
@@ -106,8 +106,10 @@ func (i *Info) ExtractTo(api *apidef.APIDefinition) {
 	// everytime
 	api.VersionData.NotVersioned = true
 	api.VersionData.DefaultVersion = ""
-	api.VersionData.Versions = map[string]apidef.VersionInfo{
-		"": {},
+	if len(api.VersionData.Versions) == 0 {
+		api.VersionData.Versions = map[string]apidef.VersionInfo{
+			"": {},
+		}
 	}
 }
 


### PR DESCRIPTION
[TT-9628/TT-9724] Respect existing extended paths in OAS.ExtractTo (#5399)

Parent: https://tyktech.atlassian.net/browse/TT-9628
Subtask: https://tyktech.atlassian.net/browse/TT-9724