### PR TITLE
update graphql-go-tools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/TykTechnologies/gojsonschema v0.0.0-20170222154038-dcb3e4bb7990
 	github.com/TykTechnologies/gorpc v0.0.0-20210624160652-fe65bda0ccb9
 	github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708
-	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230809131244-801d4374ae26
+	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230810113335-690b3ba0cef1
 	github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c
 	github.com/TykTechnologies/murmur3 v0.0.0-20230310161213-aad17efd5632
 	github.com/TykTechnologies/openid2go v0.1.2

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/TykTechnologies/gojsonschema v0.0.0-20170222154038-dcb3e4bb7990
 	github.com/TykTechnologies/gorpc v0.0.0-20210624160652-fe65bda0ccb9
 	github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708
-	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230810113335-690b3ba0cef1
+	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230810130937-14e9bde9e643
 	github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c
 	github.com/TykTechnologies/murmur3 v0.0.0-20230310161213-aad17efd5632
 	github.com/TykTechnologies/openid2go v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/TykTechnologies/gorpc v0.0.0-20210624160652-fe65bda0ccb9/go.mod h1:v6
 github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708 h1:cmXjlMzcexhc/Cg+QB/c2CPUVs1ux9xn6162qaf/LC4=
 github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708/go.mod h1:mkS8jKcz8otdfEXhJs1QQ/DKoIY1NFFsRPKS0RwQENI=
 github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230320143102-7a16078ce517/go.mod h1:ZiFZcrue3+n2mHH+KLHRipbYVULkgy3Myko5S7IIs74=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230810113335-690b3ba0cef1 h1:+b1NkrXYNT3bpVeBnT6uHxUyn86sIFGJRp7X3+x7k/g=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230810113335-690b3ba0cef1/go.mod h1:ZWpfrRjWhBPryIMCDK8kAew4hji0QUQxj3Uhc2COlMU=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230810130937-14e9bde9e643 h1:OtsSk3+y8ckIATx1J88r14wfBvFWLzdGhLpq9AmE99Q=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230810130937-14e9bde9e643/go.mod h1:ZWpfrRjWhBPryIMCDK8kAew4hji0QUQxj3Uhc2COlMU=
 github.com/TykTechnologies/kin-openapi v0.90.0 h1:kHw0mtANwIpmlU6eCeeCgRMa52EiPPhEZPuHc3lKawo=
 github.com/TykTechnologies/kin-openapi v0.90.0/go.mod h1:pkzuiceujHvAuDu3bTD/AD5OacuP4eMfrz9QhJlMvdQ=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c h1:j6fd0Fz1R4oSWOmcooGjrdahqrML+btQ+PfEJw8SzbA=

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/TykTechnologies/gorpc v0.0.0-20210624160652-fe65bda0ccb9/go.mod h1:v6
 github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708 h1:cmXjlMzcexhc/Cg+QB/c2CPUVs1ux9xn6162qaf/LC4=
 github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708/go.mod h1:mkS8jKcz8otdfEXhJs1QQ/DKoIY1NFFsRPKS0RwQENI=
 github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230320143102-7a16078ce517/go.mod h1:ZiFZcrue3+n2mHH+KLHRipbYVULkgy3Myko5S7IIs74=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230809131244-801d4374ae26 h1:LvDrPzO0PLEAlmaO+6WjdYBLzTKXCxGlW0gkuAzJG54=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230809131244-801d4374ae26/go.mod h1:ZWpfrRjWhBPryIMCDK8kAew4hji0QUQxj3Uhc2COlMU=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230810113335-690b3ba0cef1 h1:+b1NkrXYNT3bpVeBnT6uHxUyn86sIFGJRp7X3+x7k/g=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230810113335-690b3ba0cef1/go.mod h1:ZWpfrRjWhBPryIMCDK8kAew4hji0QUQxj3Uhc2COlMU=
 github.com/TykTechnologies/kin-openapi v0.90.0 h1:kHw0mtANwIpmlU6eCeeCgRMa52EiPPhEZPuHc3lKawo=
 github.com/TykTechnologies/kin-openapi v0.90.0/go.mod h1:pkzuiceujHvAuDu3bTD/AD5OacuP4eMfrz9QhJlMvdQ=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c h1:j6fd0Fz1R4oSWOmcooGjrdahqrML+btQ+PfEJw8SzbA=


### PR DESCRIPTION
This PR updates `graphql-go-tools` to its latest `master`