### PR TITLE
[TT-9310] Building Node Info on every call to getGroupLoginCallback with synchroniser enabled

### DIFF
--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -195,7 +195,7 @@ func (r *RPCStorageHandler) getGroupLoginCallback(synchroniserEnabled bool) func
 		}
 	}
 	if synchroniserEnabled {
-		forcer := rpc.NewSyncForcer(r.Gw.RedisController, r.buildNodeInfo())
+		forcer := rpc.NewSyncForcer(r.Gw.RedisController, r.buildNodeInfo)
 		groupLoginCallbackFn = forcer.GroupLoginCallback
 	}
 	return groupLoginCallbackFn

--- a/rpc/synchronization_forcer.go
+++ b/rpc/synchronization_forcer.go
@@ -8,14 +8,14 @@ import (
 )
 
 type SyncronizerForcer struct {
-	store    *storage.RedisCluster
-	nodeData []byte
+	store           *storage.RedisCluster
+	getNodeDataFunc func() []byte
 }
 
 // NewSyncForcer returns a new syncforcer with a connected redis with a key prefix synchronizer-group- for group synchronization control.
-func NewSyncForcer(redisController *storage.RedisController, nodeData []byte) *SyncronizerForcer {
+func NewSyncForcer(redisController *storage.RedisController, getNodeDataFunc func() []byte) *SyncronizerForcer {
 	sf := &SyncronizerForcer{}
-	sf.nodeData = nodeData
+	sf.getNodeDataFunc = getNodeDataFunc
 	sf.store = &storage.RedisCluster{KeyPrefix: "synchronizer-group-", RedisController: redisController}
 	sf.store.Connect()
 
@@ -41,7 +41,7 @@ func (sf *SyncronizerForcer) GroupLoginCallback(userKey string, groupID string) 
 	return apidef.GroupLoginRequest{
 		UserKey:   userKey,
 		GroupID:   groupID,
-		Node:      sf.nodeData,
+		Node:      sf.getNodeDataFunc(),
 		ForceSync: shouldForce,
 	}
 }

--- a/rpc/synchronization_forcer_test.go
+++ b/rpc/synchronization_forcer_test.go
@@ -58,3 +58,13 @@ func TestGroupLoginCallback(t *testing.T) {
 	assert.Equal(t, key, groupLogin.UserKey)
 	assert.Equal(t, groupID, groupLogin.GroupID)
 }
+
+func TestGetNodeDataFunc(t *testing.T) {
+	// Checking if the getNodeDataFunc is returning different values on each call
+	valueToFetch := "foo"
+	sf := NewSyncForcer(rc, func() []byte { return []byte(valueToFetch) })
+	assert.Equal(t, valueToFetch, string(sf.getNodeDataFunc()))
+
+	valueToFetch = "bar"
+	assert.Equal(t, valueToFetch, string(sf.getNodeDataFunc()))
+}

--- a/rpc/synchronization_forcer_test.go
+++ b/rpc/synchronization_forcer_test.go
@@ -29,7 +29,7 @@ func init() {
 }
 
 func TestNewSyncForcer(t *testing.T) {
-	sf := NewSyncForcer(rc, []byte{})
+	sf := NewSyncForcer(rc, func() []byte { return []byte{} })
 
 	assert.True(t, sf.store.ControllerInitiated())
 	assert.Equal(t, "synchronizer-group-", sf.store.KeyPrefix)
@@ -38,7 +38,7 @@ func TestNewSyncForcer(t *testing.T) {
 }
 
 func TestGroupLoginCallback(t *testing.T) {
-	sf := NewSyncForcer(rc, []byte{})
+	sf := NewSyncForcer(rc, func() []byte { return []byte{} })
 	defer sf.store.DeleteAllKeys()
 
 	key := "key"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
We're now building the node info every time `getGroupLoginCallback` is called and syncroniser is enabled. Previous behavior was executing this function only once, so if the state of the info changed, MDCB wouldn't notice it. Now, we're calling `buildNodeInfo()` to fetch this data from Redis on each call. The same scenario was already happening when syncroniser wasn't enabled.
<!-- Describe your changes in detail -->

## Related Issue
https://tyktech.atlassian.net/browse/TT-9310?atlOrigin=eyJpIjoiM2MwZTY0OWJhZjEwNGQzMWE3NzJmNjUwZGFiM2RkOGUiLCJwIjoiaiJ9
<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested
Manual test and unit tests
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
