### PR TITLE
[TT-9628/TT-9724] Reset OpenIDOptions.Providers when extracting OAS to API def

### DIFF
--- a/apidef/oas/authentication.go
+++ b/apidef/oas/authentication.go
@@ -399,11 +399,8 @@ func (s *Scopes) Fill(scopeClaim *apidef.ScopeClaim) {
 func (s *Scopes) ExtractTo(scopeClaim *apidef.ScopeClaim) {
 	scopeClaim.ScopeClaimName = s.ClaimName
 
+	scopeClaim.ScopeToPolicy = map[string]string{}
 	for _, v := range s.ScopeToPolicyMapping {
-		if scopeClaim.ScopeToPolicy == nil {
-			scopeClaim.ScopeToPolicy = make(map[string]string)
-		}
-
 		scopeClaim.ScopeToPolicy[v.Scope] = v.PolicyID
 	}
 }
@@ -549,7 +546,7 @@ func (o *OIDC) ExtractTo(api *apidef.APIDefinition) {
 	api.AuthConfigs["oidc"] = authConfig
 
 	api.OpenIDOptions.SegregateByClient = o.SegregateByClientId
-
+	api.OpenIDOptions.Providers = []apidef.OIDProviderConfig{}
 	for _, p := range o.Providers {
 		clientIDs := make(map[string]string)
 		for _, mapping := range p.ClientToPolicyMapping {

--- a/apidef/oas/authentication_test.go
+++ b/apidef/oas/authentication_test.go
@@ -104,6 +104,26 @@ func TestOIDC(t *testing.T) {
 	emptyOIDC.Fill(convertedAPI)
 
 	assert.Equal(t, emptyOIDC, resultOIDC)
+
+	t.Run("providers", func(t *testing.T) {
+		var api apidef.APIDefinition
+		api.OpenIDOptions.Providers = []apidef.OIDProviderConfig{{Issuer: "1234"}}
+
+		var oas OAS
+		xTyk := &XTykAPIGateway{Server: Server{
+			Authentication: &Authentication{
+				OIDC: &OIDC{
+					Providers: []Provider{{Issuer: "5678"}},
+				},
+			},
+		}}
+
+		oas.SetTykExtension(xTyk)
+		oas.ExtractTo(&api)
+
+		assert.Len(t, api.OpenIDOptions.Providers, 1)
+		assert.Equal(t, "5678", api.OpenIDOptions.Providers[0].Issuer)
+	})
 }
 
 func TestCustomPlugin(t *testing.T) {


### PR DESCRIPTION
APIDef OIDC Providers should be reset before extracting OAS ones.

Parent: https://tyktech.atlassian.net/browse/TT-9628
Subtask: https://tyktech.atlassian.net/browse/TT-9724