### PR TITLE
Revert "[TT-9628/TT-9715] Allow overriding an OAS API by classic API format"

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -114,6 +114,7 @@ const (
 )
 
 var (
+	ErrAPIMigrated                = errors.New("the supplied API definition is in Tyk classic format, please use OAS format for this API")
 	ErrAPINotMigrated             = errors.New("the supplied API definition is in OAS format, please use the Tyk classic format for this API")
 	ErrOASGetForOldAPI            = errors.New("the requested API definition is in Tyk classic format, please use old api endpoint")
 	ErrImportWithTykExtension     = errors.New("the import payload should not contain x-tyk-api-gateway")

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -1189,6 +1189,10 @@ func (gw *Gateway) handleUpdateApi(apiID string, r *http.Request, fs afero.Fs, o
 
 		oasObj.ExtractTo(&newDef)
 	} else {
+		if spec.IsOAS {
+			return apiError(apidef.ErrAPIMigrated.Error()), http.StatusBadRequest
+		}
+
 		if err := json.NewDecoder(r.Body).Decode(&newDef); err != nil {
 			log.Error("Couldn't decode new API Definition object: ", err)
 			return apiError("Request malformed"), http.StatusBadRequest

--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -2717,6 +2717,15 @@ func TestOAS(t *testing.T) {
 				oasAPIInOld := testGetOldAPI(t, ts, apiID, "oas api")
 
 				oasAPIInOld.Name = "old-updated oas api"
+
+				t.Run("update oas API with old format - should fail", func(t *testing.T) {
+					updatePath := "/tyk/apis/" + apiID
+
+					_, _ = ts.Run(t, []test.TestCase{
+						{AdminAuth: true, Method: http.MethodPut, Path: updatePath, Data: &oasAPIInOld,
+							BodyMatch: apidef.ErrAPIMigrated.Error(), Code: http.StatusBadRequest},
+					}...)
+				})
 			})
 
 			t.Run("with oas and gateway tags enabled", func(t *testing.T) {


### PR DESCRIPTION
Reverts TykTechnologies/tyk#5373