### PR TITLE
Update required checks for release-5.0.5

### DIFF
--- a/repo-policy/main.tf
+++ b/repo-policy/main.tf
@@ -74,7 +74,7 @@ module "tyk" {
 	reviewers = "0",
 	convos    = "false",
 	source_branch  = "release-5-lts",
-	required_tests = ["Go 1.16 Redis 5","1.16","1.16-el7"]},
+	required_tests = ["Go 1.16 Redis 5","1.16-bullseye","1.16-el7"]},
 { branch    = "release-5.1",
 	reviewers = "0",
 	convos    = "false",


### PR DESCRIPTION
The release job name was changed from 1.16 to 1.16-bullseye in `release-5-lts' in between 5.0.4 and 5.0.5. This was not updated for 5.0.5 repo policy.

