### PR TITLE
Merging to release-5.1: [TT-9365] Do not allow negative values on enforce timeout (#5410)

### DIFF
--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -580,7 +580,8 @@
           "type": "boolean"
         },
         "value": {
-          "type": "integer"
+          "type": "integer",
+          "minimum": 0
         }
       },
       "required": [

--- a/apidef/validator.go
+++ b/apidef/validator.go
@@ -56,6 +56,7 @@ var DefaultValidationRuleSet = ValidationRuleSet{
 	&RuleUniqueDataSourceNames{},
 	&RuleAtLeastEnableOneAuthSource{},
 	&RuleValidateIPList{},
+	&RuleValidateEnforceTimeout{},
 }
 
 func Validate(definition *APIDefinition, ruleSet ValidationRuleSet) ValidationResult {
@@ -179,4 +180,22 @@ func (r *RuleValidateIPList) validateIPAddr(ips []string) []error {
 	}
 
 	return errs
+}
+
+var ErrInvalidTimeoutValue = errors.New("invalid timeout value")
+
+type RuleValidateEnforceTimeout struct{}
+
+func (r *RuleValidateEnforceTimeout) Validate(apiDef *APIDefinition, validationResult *ValidationResult) {
+	if apiDef.VersionData.Versions != nil {
+		for _, vInfo := range apiDef.VersionData.Versions {
+			for _, hardTimeOutMeta := range vInfo.ExtendedPaths.HardTimeouts {
+				if hardTimeOutMeta.TimeOut < 0 {
+					validationResult.IsValid = false
+					validationResult.AppendError(ErrInvalidTimeoutValue)
+					return
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
[TT-9365] Do not allow negative values on enforce timeout (#5410)

<!-- Provide a general summary of your changes in the Title above -->

add rule to not allow negative values for enforce timeout on endpoint.
update oas json schema to set 0 as minimum value for enforce timeout.

<!-- Describe your changes in detail -->

https://tyktech.atlassian.net/browse/TT-9365
https://github.com/TykTechnologies/tyk/issues/4857

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why

[TT-9365]: https://tyktech.atlassian.net/browse/TT-9365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ