### PR TITLE
Merging to release-5.2: fix subscriptions headers not being passed upstream (TT-9670) (#5438)

### DIFF
--- a/apidef/adapter/gqlengineadapter/adapter_proxy_only.go
+++ b/apidef/adapter/gqlengineadapter/adapter_proxy_only.go
@@ -29,6 +29,9 @@ func (p *ProxyOnly) EngineConfig() (*graphql.EngineV2Configuration, error) {
 	}
 
 	staticHeaders := make(http.Header)
+	for key, value := range p.ApiDefinition.GraphQL.Proxy.RequestHeaders {
+		staticHeaders.Set(key, value)
+	}
 
 	url := p.ApiDefinition.Proxy.TargetURL
 	if strings.HasPrefix(url, "tyk://") {

--- a/gateway/mw_graphql_test.go
+++ b/gateway/mw_graphql_test.go
@@ -3,7 +3,9 @@ package gateway
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -526,7 +528,7 @@ func TestGraphQLMiddleware_EngineMode(t *testing.T) {
 				spec.UseKeylessAccess = true
 				spec.Proxy.ListenPath = "/"
 				spec.GraphQL.Enabled = true
-				spec.GraphQL.ExecutionMode = apidef.GraphQLExecutionModeExecutionEngine
+				spec.GraphQL.ExecutionMode = apidef.GraphQLExecutionModeProxyOnly
 				spec.GraphQL.Version = apidef.GraphQLConfigVersion2
 			})[0]
 
@@ -691,6 +693,137 @@ func TestGraphQLMiddleware_EngineMode(t *testing.T) {
 						assert.Equal(t, `{"id":"1","type":"error","payload":[{"message":"depth limit exceeded"}]}`, string(msg))
 						assert.NoError(t, err)
 					})
+				})
+
+				t.Run("should send configured headers upstream", func(t *testing.T) {
+					run := func(apiSpec func(testServerURL string) func(apiSpec *APISpec), requestHeaders, expectedHeaders http.Header) func(t *testing.T) {
+						return func(t *testing.T) {
+							wsTestServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+								for expectedHeaderKey := range expectedHeaders {
+									values := r.Header.Values(expectedHeaderKey)
+									headerExists := assert.Greater(t, len(values), 0, fmt.Sprintf("no header values found for header '%s'", expectedHeaderKey))
+									if !headerExists {
+										return
+									}
+									for _, expectedHeaderValue := range expectedHeaders[expectedHeaderKey] {
+										assert.Contains(t, values, expectedHeaderValue, fmt.Sprintf("expected header value '%s' was not found for '%s'", expectedHeaderValue, expectedHeaderKey))
+									}
+								}
+							}))
+							defer wsTestServer.Close()
+
+							g.Gw.BuildAndLoadAPI(apiSpec(wsTestServer.URL))
+
+							wsConnHeaders := http.Header{
+								header.SecWebSocketProtocol: {string(gqlwebsocket.ProtocolGraphQLWS)},
+							}
+
+							for key, value := range requestHeaders {
+								wsConnHeaders.Set(key, value[0])
+							}
+
+							wsConn, _, err := websocket.DefaultDialer.Dial(baseURL, wsConnHeaders)
+							require.NoError(t, err)
+							defer wsConn.Close()
+
+							// Send a connection init message to gateway
+							err = wsConn.WriteMessage(websocket.BinaryMessage, []byte(`{"type":"connection_init"}`))
+							require.NoError(t, err)
+
+							// Gateway should acknowledge the connection
+							_, msg, err := wsConn.ReadMessage()
+							require.Equal(t, `{"type":"connection_ack"}`, string(msg))
+							require.NoError(t, err)
+
+							// Start subscription
+							err = wsConn.WriteMessage(websocket.BinaryMessage, []byte(`{"id":"1","type":"start","payload":{"query":"subscription { subscribe }"}}`))
+							require.NoError(t, err)
+
+							_, msg, err = wsConn.ReadMessage()
+							require.Equal(t, `{"id":"1","type":"error","payload":[{"message":"failed to WebSocket dial: expected handshake response status code 101 but got 200"}]}`, string(msg))
+						}
+					}
+
+					t.Run("for proxy-only", run(
+						func(testServerURL string) func(apiSpec *APISpec) {
+							return func(spec *APISpec) {
+								spec.UseKeylessAccess = true
+								spec.Proxy.ListenPath = "/"
+								spec.EnableContextVars = true
+								spec.GraphQL.Enabled = true
+								spec.GraphQL.ExecutionMode = apidef.GraphQLExecutionModeProxyOnly
+								spec.GraphQL.Version = apidef.GraphQLConfigVersion2
+								spec.GraphQL.Schema = `type Query { hello: String } type Subscription { subscribe: String }`
+								spec.GraphQL.Proxy.RequestHeaders = map[string]string{
+									"My-Custom-Header": "custom-value",
+									"From-Request":     "$tyk_context.headers_X_My_Request",
+								}
+								spec.Proxy.TargetURL = testServerURL
+							}
+						},
+						http.Header{
+							"X-My-Request": {"request-value"},
+						},
+						http.Header{
+							"My-Custom-Header": {"custom-value"},
+							"From-Request":     {"request-value"},
+						},
+					))
+
+					t.Run("for udg", run(
+						func(testServerURL string) func(apiSpec *APISpec) {
+							return func(spec *APISpec) {
+								spec.UseKeylessAccess = true
+								spec.Proxy.ListenPath = "/"
+								spec.EnableContextVars = true
+								spec.GraphQL.Enabled = true
+								spec.GraphQL.ExecutionMode = apidef.GraphQLExecutionModeExecutionEngine
+								spec.GraphQL.Version = apidef.GraphQLConfigVersion2
+								spec.GraphQL.Schema = `type Query { hello: String } type Subscription { subscribe: String }`
+								spec.GraphQL.Engine.GlobalHeaders = []apidef.UDGGlobalHeader{
+									{
+										Key:   "Global-Key",
+										Value: "global-value",
+									},
+									{
+										Key:   "Already-Used-Key",
+										Value: "global-used-value",
+									},
+								}
+								spec.GraphQL.Engine.DataSources = []apidef.GraphQLEngineDataSource{
+									{
+										Kind:     apidef.GraphQLEngineDataSourceKindGraphQL,
+										Name:     "ds",
+										Internal: false,
+										RootFields: []apidef.GraphQLTypeFields{
+											{
+												Type:   "Subscription",
+												Fields: []string{"subscribe"},
+											},
+										},
+										Config: []byte(fmt.Sprintf(`{
+											"url": "%s",
+											"method": "POST",
+											"headers": {
+												"Already-Used-Key": "local-used-value",
+												"Local-Key": "local-value",
+												"Context-Key": "$tyk_context.headers_X_My_Request"
+											}
+										}`, testServerURL)),
+									},
+								}
+							}
+						},
+						http.Header{
+							"X-My-Request": {"request-value"},
+						},
+						http.Header{
+							"Already-Used-Key": {"local-used-value"},
+							"Local-Key":        {"local-value"},
+							"Context-Key":      {"request-value"},
+							"Global-Key":       {"global-value"},
+						},
+					))
 				})
 			})
 		})

--- a/gateway/mw_graphql_transport_test.go
+++ b/gateway/mw_graphql_transport_test.go
@@ -3,15 +3,10 @@ package gateway
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
-
-	gql "github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
-	"github.com/TykTechnologies/tyk/test"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -62,59 +57,6 @@ func TestDetermineGraphQLEngineTransportType(t *testing.T) {
 			assert.Equal(t, tc.expected, result)
 		})
 	}
-}
-
-func TestGraphQLEngineTransport_GlobalHeaders(t *testing.T) {
-	initTestServer := func(t *testing.T, expectedHeaders map[string]string) *httptest.Server {
-		return httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-			for key, val := range expectedHeaders {
-				assert.Equal(t, val, request.Header.Get(key))
-			}
-		}))
-	}
-
-	t.Run("should add all global headers to upstream request", func(t *testing.T) {
-		testServer := initTestServer(t, map[string]string{
-			"test-global-header":     "header-value",
-			"test-datasource-header": "header-value",
-		})
-		defer testServer.Close()
-
-		testReq, err := http.NewRequest(http.MethodPost, testServer.URL, nil)
-		testReq.Header.Set("test-datasource-header", "header-value")
-		assert.NoError(t, err)
-
-		client := http.Client{
-			Transport: NewGraphQLEngineTransport(GraphQLEngineTransportTypeMultiUpstream, http.DefaultTransport, WithGlobalHeaders(map[string]string{
-				"test-global-header": "header-value",
-			})),
-		}
-
-		_, err = client.Do(testReq)
-		assert.NoError(t, err)
-	})
-
-	t.Run("should not replace existing global header", func(t *testing.T) {
-		testServer := initTestServer(t, map[string]string{
-			"test-global-header":     "header-value",
-			"test-datasource-header": "datasource-value",
-		})
-		defer testServer.Close()
-
-		testReq, err := http.NewRequest(http.MethodPost, testServer.URL, nil)
-		testReq.Header.Set("test-datasource-header", "datasource-value")
-		assert.NoError(t, err)
-
-		client := http.Client{
-			Transport: NewGraphQLEngineTransport(GraphQLEngineTransportTypeMultiUpstream, http.DefaultTransport, WithGlobalHeaders(map[string]string{
-				"test-global-header":     "header-value",
-				"test-datasource-header": "header-value",
-			})),
-		}
-
-		_, err = client.Do(testReq)
-		assert.NoError(t, err)
-	})
 }
 
 func TestGraphQLEngineTransport_RoundTrip(t *testing.T) {
@@ -295,146 +237,5 @@ func TestGraphQLEngineTransport_RoundTrip(t *testing.T) {
 		transportResponseBodyBytes, err := ioutil.ReadAll(transportResponse.Body)
 		require.NoError(t, err)
 		assert.Equal(t, response.body, string(transportResponseBodyBytes))
-	})
-}
-
-func TestGraphQLEngineTransport_ContextVars(t *testing.T) {
-	g := StartTest(nil)
-	defer g.Close()
-
-	customRestUpstreamURL, customGraphQLUpstreamURL := "/custom-rest-upstream", "/custom-graphql-upstream"
-
-	restConfig := apidef.GraphQLEngineDataSourceConfigREST{
-		Method: "GET",
-		Headers: map[string]string{
-			"rest-header": "rest-value",
-		},
-		URL: TestHttpAny + customRestUpstreamURL,
-	}
-	restConfigData, err := json.Marshal(restConfig)
-	require.NoError(t, err)
-
-	graphQLConfig := apidef.GraphQLEngineDataSourceConfigGraphQL{
-		URL:    TestHttpAny + customGraphQLUpstreamURL,
-		Method: "POST",
-	}
-	graphqlConfigData, err := json.Marshal(graphQLConfig)
-	require.NoError(t, err)
-
-	spec := BuildAPI(func(spec *APISpec) {
-		spec.GraphQL.Enabled = true
-		spec.GraphQL.Schema = gqlProxyUpstreamSchema
-		spec.EnableContextVars = true
-		spec.GraphQL.Version = apidef.GraphQLConfigVersion2
-		spec.GraphQL.Engine.FieldConfigs = []apidef.GraphQLFieldConfig{
-			{
-				TypeName:  "Query",
-				FieldName: "hello",
-			},
-			{
-				TypeName:  "Query",
-				FieldName: "httpMethod",
-			},
-		}
-		spec.GraphQL.Engine.DataSources = []apidef.GraphQLEngineDataSource{
-			{
-				Name:   "Main Rest Datasource",
-				Kind:   apidef.GraphQLEngineDataSourceKindREST,
-				Config: restConfigData,
-				RootFields: []apidef.GraphQLTypeFields{
-					{
-						Type:   "Query",
-						Fields: []string{"httpMethod"},
-					},
-				},
-			},
-			{
-				Name:   "Main GraphQL Datasource",
-				Kind:   apidef.GraphQLEngineDataSourceKindGraphQL,
-				Config: graphqlConfigData,
-				RootFields: []apidef.GraphQLTypeFields{
-					{
-						Type:   "Query",
-						Fields: []string{"hello"},
-					},
-				},
-			},
-		}
-		spec.UseKeylessAccess = true
-		spec.Proxy.ListenPath = "/"
-	})[0]
-
-	t.Run("replace global context vars successfully", func(t *testing.T) {
-		spec.GraphQL.Engine.GlobalHeaders = []apidef.UDGGlobalHeader{
-			{Key: "global-header", Value: "global-header-value"},
-			{Key: "global-header-second", Value: "$tyk_context.headers_Code"},
-		}
-		g.Gw.LoadAPI(spec)
-
-		receivedHeader := false
-		g.AddDynamicHandler(customRestUpstreamURL, func(writer http.ResponseWriter, request *http.Request) {
-			headers := request.Header
-			if headers.Get("global-header") == "global-header-value" && headers.Get("global-header-second") == "value" {
-				receivedHeader = true
-			}
-		})
-
-		_, err := g.Run(t, test.TestCase{
-			Path: "/", Method: "POST",
-			Data: gql.Request{
-				Query: `{httpMethod}`,
-			},
-			Headers: map[string]string{
-				"code": "value",
-			},
-			Code: 200,
-		})
-		assert.NoError(t, err)
-		assert.Eventuallyf(t, func() bool {
-			return receivedHeader
-		}, time.Second, time.Millisecond*100, "headers not sent to upstream")
-	})
-
-	t.Run("replace datasource context vars successfully", func(t *testing.T) {
-		spec.GraphQL.Engine.GlobalHeaders = []apidef.UDGGlobalHeader{
-			{Key: "global-header", Value: "$tyk_context.headers_Second"},
-		}
-
-		graphQLConfig.Headers = map[string]string{
-			"datasource-header": "$tyk_context.headers_Code",
-		}
-		graphqlConfigData, err := json.Marshal(graphQLConfig)
-		require.NoError(t, err)
-		spec.GraphQL.Engine.DataSources[1].Config = graphqlConfigData
-		g.Gw.LoadAPI(spec)
-
-		var receivedGQLHeader bool
-		g.AddDynamicHandler(customGraphQLUpstreamURL, func(writer http.ResponseWriter, request *http.Request) {
-			headers := request.Header
-			if headers.Get("global-header") == "second-value" && headers.Get("datasource-header") == "value" {
-				receivedGQLHeader = true
-			}
-		})
-
-		_, err = g.Run(t, test.TestCase{
-			Path: "/", Method: "POST",
-			Data: gql.Request{
-				Query: `
-{
-  hello(name: "Test")
-}
-`,
-			},
-			Headers: map[string]string{
-				"code":   "value",
-				"second": "second-value",
-			},
-			Code: 200,
-		})
-		assert.NoError(t, err)
-
-		assert.Eventuallyf(t, func() bool {
-			return receivedGQLHeader
-		}, time.Second, time.Millisecond*100, "headers not sent to upstream")
 	})
 }

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -853,15 +853,30 @@ func TestNopCloseResponseBody(t *testing.T) {
 	}
 }
 
-func TestGraphQL_HeadersInjection(t *testing.T) {
+func TestGraphQL_UDGHeaders(t *testing.T) {
 	g := StartTest(nil)
 	t.Cleanup(g.Close)
 
 	composedAPI := BuildAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/"
+		spec.EnableContextVars = true
 		spec.GraphQL.Enabled = true
 		spec.GraphQL.ExecutionMode = apidef.GraphQLExecutionModeExecutionEngine
 		spec.GraphQL.Version = apidef.GraphQLConfigVersion2
+		spec.GraphQL.Engine.GlobalHeaders = []apidef.UDGGlobalHeader{
+			{
+				Key:   "Global-Static",
+				Value: "foobar",
+			},
+			{
+				Key:   "Global-Context",
+				Value: "$tyk_context.headers_Global_From_Request",
+			},
+			{
+				Key:   "Does-Exist-Already",
+				Value: "global-does-exist-already",
+			},
+		}
 
 		spec.GraphQL.Engine.DataSources = []apidef.GraphQLEngineDataSource{
 			generateRESTDataSourceV2(func(ds *apidef.GraphQLEngineDataSource, restConfig *apidef.GraphQLEngineDataSourceConfigREST) {
@@ -881,20 +896,28 @@ func TestGraphQL_HeadersInjection(t *testing.T) {
 
 	_, _ = g.Run(t, []test.TestCase{
 		{
-			Data:    headers,
-			Headers: map[string]string{"injected": "FOO"},
-			Code:    http.StatusOK,
+			Data: headers,
+			Headers: map[string]string{
+				"injected":            "FOO",
+				"From-Request":        "request-context",
+				"Global-From-Request": "request-global-context",
+			},
+			Code: http.StatusOK,
 
 			BodyMatchFunc: func(b []byte) bool {
 				return strings.Contains(string(b), `"headers":`) &&
 					strings.Contains(string(b), `{"name":"Injected","value":"FOO"}`) &&
-					strings.Contains(string(b), `{"name":"Static","value":"barbaz"}`)
+					strings.Contains(string(b), `{"name":"Static","value":"barbaz"}`) &&
+					strings.Contains(string(b), `{"name":"Context","value":"request-context"}`) &&
+					strings.Contains(string(b), `{"name":"Global-Static","value":"foobar"}`) &&
+					strings.Contains(string(b), `{"name":"Global-Context","value":"request-global-context"}`) &&
+					strings.Contains(string(b), `{"name":"Does-Exist-Already","value":"ds-does-exist-already"}`)
 			},
 		},
 	}...)
 }
 
-func TestGraphql_Headers(t *testing.T) {
+func TestGraphQL_ProxyOnlyHeaders(t *testing.T) {
 	g := StartTest(nil)
 	defer g.Close()
 

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -1493,7 +1493,9 @@ const testRESTHeadersDataSourceConfigurationV2 = `
 		"method": "GET",
 		"headers": {
 			"static": "barbaz",
-			"injected": "{{ .request.headers.injected }}"
+			"injected": "{{ .request.headers.injected }}",
+			"context": "$tyk_context.headers_From_Request",
+			"does-exist-already": "ds-does-exist-already"
 		},
 		"query": [],
 		"body": ""

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,11 @@ require (
 	github.com/TykTechnologies/gojsonschema v0.0.0-20170222154038-dcb3e4bb7990
 	github.com/TykTechnologies/gorpc v0.0.0-20210624160652-fe65bda0ccb9
 	github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708
+<<<<<<< HEAD
 	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230810130937-14e9bde9e643
+=======
+	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230817124341-e336e7b71d60
+>>>>>>> 9c3de7ba... fix subscriptions headers not being passed upstream (TT-9670) (#5438)
 	github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c
 	github.com/TykTechnologies/murmur3 v0.0.0-20230310161213-aad17efd5632
 	github.com/TykTechnologies/openid2go v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,13 @@ github.com/TykTechnologies/gorpc v0.0.0-20210624160652-fe65bda0ccb9/go.mod h1:v6
 github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708 h1:cmXjlMzcexhc/Cg+QB/c2CPUVs1ux9xn6162qaf/LC4=
 github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708/go.mod h1:mkS8jKcz8otdfEXhJs1QQ/DKoIY1NFFsRPKS0RwQENI=
 github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230320143102-7a16078ce517/go.mod h1:ZiFZcrue3+n2mHH+KLHRipbYVULkgy3Myko5S7IIs74=
+<<<<<<< HEAD
 github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230810130937-14e9bde9e643 h1:OtsSk3+y8ckIATx1J88r14wfBvFWLzdGhLpq9AmE99Q=
 github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230810130937-14e9bde9e643/go.mod h1:ZWpfrRjWhBPryIMCDK8kAew4hji0QUQxj3Uhc2COlMU=
+=======
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230817124341-e336e7b71d60 h1:kO6loVMjbX4KehnpUtdu0cY8wFeHg3KLyD6T0G3JF1Y=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20230817124341-e336e7b71d60/go.mod h1:ZWpfrRjWhBPryIMCDK8kAew4hji0QUQxj3Uhc2COlMU=
+>>>>>>> 9c3de7ba... fix subscriptions headers not being passed upstream (TT-9670) (#5438)
 github.com/TykTechnologies/kin-openapi v0.90.0 h1:kHw0mtANwIpmlU6eCeeCgRMa52EiPPhEZPuHc3lKawo=
 github.com/TykTechnologies/kin-openapi v0.90.0/go.mod h1:pkzuiceujHvAuDu3bTD/AD5OacuP4eMfrz9QhJlMvdQ=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c h1:j6fd0Fz1R4oSWOmcooGjrdahqrML+btQ+PfEJw8SzbA=


### PR DESCRIPTION
fix subscriptions headers not being passed upstream (TT-9670) (#5438)

<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-9670"
title="TT-9670" target="_blank">TT-9670</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Headers not being passed to subscriptions in proxy-only</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

This PR fixes an issue where subscription headers are not being passed
upstream.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)