### PR TITLE
Merging to release-5-lts: [TT-9749] when allow IPs validation fails, append errors instead of replacing (#5411)

### DIFF
--- a/apidef/validator.go
+++ b/apidef/validator.go
@@ -149,7 +149,7 @@ func (r *RuleValidateIPList) Validate(apiDef *APIDefinition, validationResult *V
 	if apiDef.EnableIpWhiteListing {
 		if errs := r.validateIPAddr(apiDef.AllowedIPs); len(errs) > 0 {
 			validationResult.IsValid = false
-			validationResult.Errors = errs
+			validationResult.Errors = append(validationResult.Errors, errs...)
 		}
 	}
 


### PR DESCRIPTION
[TT-9749] when allow IPs validation fails, append errors instead of replacing (#5411)

<!-- Provide a general summary of your changes in the Title above -->

## Description

when allow IPs validation fails, append errors instead of replacing

## Related Issue
https://tyktech.atlassian.net/browse/TT-9749
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why