### PR TITLE
[TT-9628/TT-9724] Fix extractTo of custom plugin

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -400,15 +400,15 @@ type MiddlewareDefinition struct {
 // IDExtractorConfig specifies the configuration for ID extractor
 type IDExtractorConfig struct {
 	// HeaderName is the header name to extract ID from.
-	HeaderName string `mapstructure:"header_name" bson:"header_name" json:"header_name"`
+	HeaderName string `mapstructure:"header_name" bson:"header_name" json:"header_name,omitempty"`
 	// FormParamName is the form parameter name to extract ID from.
-	FormParamName string `mapstructure:"param_name" bson:"param_name" json:"param_name"`
+	FormParamName string `mapstructure:"param_name" bson:"param_name" json:"param_name,omitempty"`
 	// RegexExpression is the regular expression to match ID.
-	RegexExpression string `mapstructure:"regex_expression" bson:"regex_expression" json:"regex_expression"`
+	RegexExpression string `mapstructure:"regex_expression" bson:"regex_expression" json:"regex_expression,omitempty"`
 	// RegexMatchIndex is the index from which ID to be extracted after a match.
-	RegexMatchIndex int `mapstructure:"regex_match_index" bson:"regex_match_index" json:"regex_match_index"`
+	RegexMatchIndex int `mapstructure:"regex_match_index" bson:"regex_match_index" json:"regex_match_index,omitempty"`
 	// XPathExp is the xpath expression to match ID.
-	XPathExpression string `mapstructure:"xpath_expression" bson:"xpath_expression" json:"xpath_expression"`
+	XPathExpression string `mapstructure:"xpath_expression" bson:"xpath_expression" json:"xpath_expression,omitempty"`
 }
 
 type MiddlewareIdExtractor struct {

--- a/apidef/oas/authentication.go
+++ b/apidef/oas/authentication.go
@@ -3,6 +3,7 @@ package oas
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"sort"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -62,13 +63,11 @@ func (a *Authentication) Fill(api apidef.APIDefinition) {
 	a.StripAuthorizationData = api.StripAuthData
 	a.BaseIdentityProvider = api.BaseIdentityProvidedBy
 
-	if api.CustomPluginAuthEnabled {
-		if a.Custom == nil {
-			a.Custom = &CustomPluginAuthentication{}
-		}
-
-		a.Custom.Fill(api)
+	if a.Custom == nil {
+		a.Custom = &CustomPluginAuthentication{}
 	}
+
+	a.Custom.Fill(api)
 
 	if ShouldOmit(a.Custom) {
 		a.Custom = nil
@@ -117,9 +116,14 @@ func (a *Authentication) ExtractTo(api *apidef.APIDefinition) {
 		a.OIDC.ExtractTo(api)
 	}
 
-	if a.Custom != nil {
-		a.Custom.ExtractTo(api)
+	if a.Custom == nil {
+		a.Custom = &CustomPluginAuthentication{}
+		defer func() {
+			a.Custom = nil
+		}()
 	}
+
+	a.Custom.ExtractTo(api)
 }
 
 // SecuritySchemes holds security scheme values, filled with Import().
@@ -620,14 +624,19 @@ func (c *CustomPluginAuthentication) Fill(api apidef.APIDefinition) {
 func (c *CustomPluginAuthentication) ExtractTo(api *apidef.APIDefinition) {
 	api.CustomPluginAuthEnabled = c.Enabled
 
-	if c.Config != nil {
-		c.Config.ExtractTo(api)
+	if c.Config == nil {
+		c.Config = &AuthenticationPlugin{}
+		defer func() {
+			c.Config = nil
+		}()
 	}
+
+	c.Config.ExtractTo(api)
 
 	authConfig := apidef.AuthConfig{}
 	c.AuthSources.ExtractTo(&authConfig)
 
-	if ShouldOmit(authConfig) {
+	if reflect.DeepEqual(authConfig, apidef.AuthConfig{DisableHeader: true}) {
 		return
 	}
 
@@ -673,9 +682,14 @@ func (ap *AuthenticationPlugin) ExtractTo(api *apidef.APIDefinition) {
 	api.CustomMiddleware.AuthCheck.Path = ap.Path
 	api.CustomMiddleware.AuthCheck.RawBodyOnly = ap.RawBodyOnly
 
-	if ap.IDExtractor != nil {
-		ap.IDExtractor.ExtractTo(api)
+	if ap.IDExtractor == nil {
+		ap.IDExtractor = &IDExtractor{}
+		defer func() {
+			ap.IDExtractor = nil
+		}()
 	}
+
+	ap.IDExtractor.ExtractTo(api)
 }
 
 // IDExtractorConfig specifies the configuration for ID extractor.
@@ -732,6 +746,11 @@ func (id *IDExtractorConfig) ExtractTo(api *apidef.APIDefinition) {
 		log.WithError(err).Error("error while encoding IDExtractorConfig")
 		return
 	}
+
+	if len(extractorConfigMap) == 0 {
+		extractorConfigMap = nil
+	}
+
 	api.CustomMiddleware.IdExtractor.ExtractorConfig = extractorConfigMap
 }
 
@@ -769,7 +788,12 @@ func (id *IDExtractor) ExtractTo(api *apidef.APIDefinition) {
 	api.CustomMiddleware.IdExtractor.ExtractFrom = id.Source
 	api.CustomMiddleware.IdExtractor.ExtractWith = id.With
 
-	if id.Config != nil {
-		id.Config.ExtractTo(api)
+	if id.Config == nil {
+		id.Config = &IDExtractorConfig{}
+		defer func() {
+			id.Config = nil
+		}()
 	}
+
+	id.Config.ExtractTo(api)
 }

--- a/apidef/oas/oas_test.go
+++ b/apidef/oas/oas_test.go
@@ -147,6 +147,8 @@ func TestOAS_ExtractTo_ResetAPIDefinition(t *testing.T) {
 	a.CustomMiddlewareBundleDisabled = false
 	a.DomainDisabled = false
 	a.ConfigDataDisabled = false
+	a.CustomMiddleware.AuthCheck.Disabled = false
+	a.CustomMiddleware.IdExtractor.Disabled = false
 	a.TagsDisabled = false
 	a.IsOAS = false
 

--- a/apidef/oas/security.go
+++ b/apidef/oas/security.go
@@ -736,8 +736,8 @@ func resetSecuritySchemes(api *apidef.APIDefinition) {
 
 	// Custom
 	api.CustomPluginAuthEnabled = false
-	api.CustomMiddleware.AuthCheck = apidef.MiddlewareDefinition{}
-	api.CustomMiddleware.IdExtractor = apidef.MiddlewareIdExtractor{}
+	api.CustomMiddleware.AuthCheck = apidef.MiddlewareDefinition{Disabled: true}
+	api.CustomMiddleware.IdExtractor = apidef.MiddlewareIdExtractor{Disabled: true}
 }
 
 func (s *OAS) fillAPIKeyScheme(ac *apidef.AuthConfig) {


### PR DESCRIPTION

<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-9724" title="TT-9724" target="_blank">TT-9724</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>[DB] Respect classic apidef fields on OAS update</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Sub-task" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />
        Sub-task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Code Review</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

an extra fix for custom plugin.

Ticket:https://tyktech.atlassian.net/browse/TT-9628
Subtask: https://tyktech.atlassian.net/browse/TT-9724