### PR TITLE
Merging to release-5-lts: [TT-5988] Use defaults APISpec if no API ID found (inactive or deleted) (#5423)

### DIFF
--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -269,6 +269,12 @@ func TestKeyHandler(t *testing.T) {
 	}
 	withBadPolicyJSON := test.MarshalJSON(t)(withBadPolicy)
 
+	withUnknownAPI := CreateStandardSession()
+	withUnknownAPI.AccessRights = map[string]user.AccessDefinition{"unknown": {
+		APIID: "unknown", Versions: []string{"v1"},
+	}}
+	withUnknownAPIJSON := test.MarshalJSON(t)(withUnknownAPI)
+
 	t.Run("Create key", func(t *testing.T) {
 		_, _ = ts.Run(t, []test.TestCase{
 			// Master keys should be disabled by default
@@ -405,6 +411,7 @@ func TestKeyHandler(t *testing.T) {
 			// Without data
 			{Method: "PUT", Path: "/tyk/keys/" + knownKey, AdminAuth: true, Code: 400},
 			{Method: "PUT", Path: "/tyk/keys/" + knownKey, Data: string(withAccessJSON), AdminAuth: true, Code: 200},
+			{Method: "PUT", Path: "/tyk/keys/" + knownKey, Data: string(withUnknownAPIJSON), AdminAuth: true, Code: 200},
 			{Method: "PUT", Path: "/tyk/keys/" + knownKey + "?api_id=test", Data: string(withAccessJSON), AdminAuth: true, Code: 200},
 			{Method: "PUT", Path: "/tyk/keys/" + knownKey + "?api_id=none", Data: string(withAccessJSON), AdminAuth: true, Code: 200},
 		}...)


### PR DESCRIPTION
[TT-5988] Use defaults APISpec if no API ID found (inactive or deleted) (#5423)

https://tyktech.atlassian.net/browse/TT-5988

Before:


![image](https://github.com/TykTechnologies/tyk/assets/233360/8e2b6b60-5ef1-49a3-a1b7-6014b3de5218)

After:


![image](https://github.com/TykTechnologies/tyk/assets/233360/c42fd8f0-de85-4905-b3c0-fdf3f5685993)

Final recorded key data:

```
{
  "last_check": 0,
  "allowance": 1000,
  "rate": 1000,
  "per": 60,
  "throttle_interval": -1,
  "throttle_retry_limit": -1,
  "max_query_depth": -1,
  "date_created": "2023-08-16T12:21:53.662653883Z",
  "expires": 1693398822,
  "quota_max": -1,
  "quota_renews": 1692190432,
  "quota_remaining": 0,
  "quota_renewal_rate": -1,
  "access_rights": {
    "b07c5d3d288f42674a2770aa31981f48": {
      "api_name": "api 2",
      "api_id": "b07c5d3d288f42674a2770aa31981f48",
      "versions": [
        "Default"
      ],
      "allowed_urls": null,
      "restricted_types": [],
      "allowed_types": null,
      "limit": {
        "rate": 0,
        "per": 0,
        "throttle_interval": 0,
        "throttle_retry_limit": 0,
        "max_query_depth": 0,
        "quota_max": 0,
        "quota_renews": 0,
        "quota_remaining": 0,
        "quota_renewal_rate": 0
      },
      "field_access_rights": [],
      "disable_introspection": false,
      "allowance_scope": ""
    },
    "d77069245b9444766c399015c903c1fb": {
      "api_name": "api 1",
      "api_id": "d77069245b9444766c399015c903c1fb",
      "versions": [
        "Default"
      ],
      "allowed_urls": null,
      "restricted_types": [],
      "allowed_types": null,
      "limit": {
        "rate": 0,
        "per": 0,
        "throttle_interval": 0,
        "throttle_retry_limit": 0,
        "max_query_depth": 0,
        "quota_max": 0,
        "quota_renews": 0,
        "quota_remaining": 0,
        "quota_renewal_rate": 0
      },
      "field_access_rights": [],
      "disable_introspection": false,
      "allowance_scope": ""
    }
  },
  "org_id": "64dcbf11a164cd000109d282",
  "oauth_client_id": "",
  "oauth_keys": null,
  "certificate": "",
  "basic_auth_data": {
    "password": "",
    "hash_type": ""
  },
  "jwt_data": {
    "secret": ""
  },
  "hmac_enabled": false,
  "enable_http_signature_validation": false,
  "hmac_string": "",
  "rsa_certificate_id": "",
  "is_inactive": false,
  "apply_policy_id": "",
  "apply_policies": [],
  "data_expires": 0,
  "monitor": {
    "trigger_limits": null
  },
  "enable_detail_recording": false,
  "enable_detailed_recording": false,
  "meta_data": {},
  "tags": [],
  "alias": "",
  "last_updated": "1692190433",
  "id_extractor_deadline": 0,
  "session_lifetime": 0
}
```

API 2 is inactive and honored in access_rights above:

![image](https://github.com/TykTechnologies/tyk/assets/233360/bf75d695-6543-4038-82a9-e80905654df7)

PR also addresses some found defects:

1. logging was inconsistent/spaghetti code (now we log with same log
fields in function),
2. pre-existing errors - added a `test.JSONMarshal(t)` utility to assert
no errors occured (sonarcloud)
3. updated tests to ensure coverage for the change

---------

Co-authored-by: Tit Petric <tit@tyk.io>