### PR TITLE
Merging to release-5.2: TT-9849 rename otel config to be exported as opentelemetry (#5442)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -945,7 +945,7 @@ type Config struct {
 	Tracer Tracer `json:"tracing"`
 
 	// Section for configuring Opentelemetry
-	OpenTelemetry otel.Config `json:"opentelemetry"`
+	OpenTelemetry otel.OpenTelemetry `json:"opentelemetry"`
 
 	NewRelic NewRelicConfig `json:"newrelic"`
 

--- a/gateway/server_test.go
+++ b/gateway/server_test.go
@@ -44,12 +44,12 @@ func TestGateway_afterConfSetup(t *testing.T) {
 		{
 			name: "opentelemetry options test",
 			initialConfig: config.Config{
-				OpenTelemetry: otel.Config{
+				OpenTelemetry: otel.OpenTelemetry{
 					Enabled: true,
 				},
 			},
 			expectedConfig: config.Config{
-				OpenTelemetry: otel.Config{
+				OpenTelemetry: otel.OpenTelemetry{
 					Enabled:            true,
 					Exporter:           "grpc",
 					Endpoint:           "localhost:4317",

--- a/internal/graphql/otel_graphql_engine_test.go
+++ b/internal/graphql/otel_graphql_engine_test.go
@@ -30,7 +30,7 @@ var tracerProvider otel.TracerProvider
 
 func TestMain(m *testing.M) {
 	//use noop tracer exporter
-	tracerProvider = otel.InitOpenTelemetry(context.Background(), logger.GetLogger(), &otel.Config{
+	tracerProvider = otel.InitOpenTelemetry(context.Background(), logger.GetLogger(), &otel.OpenTelemetry{
 		Enabled:  true,
 		Exporter: "invalid",
 	}, "test", "test", false, "", false, []string{})

--- a/internal/otel/otel.go
+++ b/internal/otel/otel.go
@@ -16,7 +16,7 @@ import (
 type (
 	TracerProvider = tyktrace.Provider
 
-	Config = otelconfig.OpenTelemetry
+	OpenTelemetry = otelconfig.OpenTelemetry
 
 	Sampling = otelconfig.Sampling
 
@@ -50,7 +50,7 @@ func ContextWithSpan(ctx context.Context, span tyktrace.Span) context.Context {
 // InitOpenTelemetry initializes OpenTelemetry - it returns a TracerProvider
 // which can be used to create a tracer. If OpenTelemetry is disabled or misconfigured,
 // a NoopProvider is returned.
-func InitOpenTelemetry(ctx context.Context, logger *logrus.Logger, gwConfig *Config, id string, version string,
+func InitOpenTelemetry(ctx context.Context, logger *logrus.Logger, gwConfig *OpenTelemetry, id string, version string,
 	useRPC bool, groupID string, isSegmented bool, segmentTags []string) TracerProvider {
 
 	traceLogger := logger.WithFields(logrus.Fields{

--- a/internal/otel/otel_test.go
+++ b/internal/otel/otel_test.go
@@ -23,7 +23,7 @@ func Test_InitOpenTelemetry(t *testing.T) {
 	tcs := []struct {
 		testName string
 
-		givenConfig  Config
+		givenConfig  OpenTelemetry
 		givenVersion string
 		givenId      string
 		setupFn      func() (string, func())
@@ -31,14 +31,14 @@ func Test_InitOpenTelemetry(t *testing.T) {
 	}{
 		{
 			testName: "opentelemetry disabled",
-			givenConfig: Config{
+			givenConfig: OpenTelemetry{
 				Enabled: false,
 			},
 			expectedType: tyktrace.NOOP_PROVIDER,
 		},
 		{
 			testName: "opentelemetry enabled, exporter set to http",
-			givenConfig: Config{
+			givenConfig: OpenTelemetry{
 				Enabled:  true,
 				Exporter: "http",
 				Endpoint: "http://localhost:4317",
@@ -55,7 +55,7 @@ func Test_InitOpenTelemetry(t *testing.T) {
 		},
 		{
 			testName: "opentelemetry enabled, exporter set to grpc",
-			givenConfig: Config{
+			givenConfig: OpenTelemetry{
 				Enabled:  true,
 				Exporter: "grpc",
 				Endpoint: "localhost:4317",
@@ -80,7 +80,7 @@ func Test_InitOpenTelemetry(t *testing.T) {
 		},
 		{
 			testName: "opentelemetry enabled, exporter set to invalid - noop provider should be used",
-			givenConfig: Config{
+			givenConfig: OpenTelemetry{
 				Enabled:  true,
 				Exporter: "invalid",
 				Endpoint: "localhost:4317",
@@ -250,7 +250,7 @@ func TestGatewayResourceAttributes(t *testing.T) {
 }
 
 func TestContextWithSpan(t *testing.T) {
-	provider := InitOpenTelemetry(context.Background(), logger.GetLogger(), &Config{
+	provider := InitOpenTelemetry(context.Background(), logger.GetLogger(), &OpenTelemetry{
 		Enabled:  true,
 		Endpoint: "invalid",
 	}, "test", "test", false, "", false, []string{})
@@ -297,8 +297,13 @@ func TestAddTraceID(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/", nil)
 			w := httptest.NewRecorder()
 
+<<<<<<< HEAD
 			otelConfig := Config{
 				Enabled:  tt.enabled,
+=======
+			otelConfig := OpenTelemetry{
+				Enabled:  true,
+>>>>>>> ca30b8fd... TT-9849 rename otel config to be exported as opentelemetry (#5442)
 				Exporter: "http",
 				Endpoint: "http://localhost:4317",
 			}


### PR DESCRIPTION
TT-9849 rename otel config to be exported as opentelemetry (#5442)

<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-9849"
title="TT-9849" target="_blank">TT-9849</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Publish new Gateway Configurations docs</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Story"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium"
/>
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Code Review</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

Renamed how we export the struct of opentelemetry to the other gw's
packages, currently otel repo have it exposed as `OpenTelemetry` then in
internal we renamed it to `Config`, this leads us to issues while
running the config doc generator as it will search for a struct named
`Config` in the otel repo (and it's not found).

## Related Issue

TT-9849

## Motivation and Context

Allow Config generator to deal with otel structs that doesn't live in
the gw repo

## How This Has Been Tested

- Build GW
- Unit tests

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why

---------

Co-authored-by: Tomas Buchaillot <tombuchaillot89@gmail.com>