### PR TITLE
Merging to release-5-lts: [TT-9227] Persist GraphQL doesn't work in conjunction with Response Body Transform (#5457)

### DIFF
--- a/gateway/mw_persist_graphql_operation.go
+++ b/gateway/mw_persist_graphql_operation.go
@@ -46,6 +46,8 @@ func (i *PersistGraphQLOperationMiddleware) ProcessRequest(w http.ResponseWriter
 		return nil, http.StatusOK
 	}
 	mwSpec, _ := meta.(*apidef.PersistGraphQLMeta)
+
+	ctxSetRequestMethod(r, r.Method)
 	r.Method = http.MethodPost
 
 	_, err := io.ReadAll(r.Body)
@@ -96,6 +98,8 @@ func (i *PersistGraphQLOperationMiddleware) ProcessRequest(w http.ResponseWriter
 	nopCloseRequestBody(r)
 
 	r.Header.Set("Content-Type", "application/json")
+
+	ctxSetUrlRewritePath(r, r.URL.Path)
 	r.URL.Path = "/"
 
 	return nil, http.StatusOK

--- a/gateway/mw_persist_graphql_operation_test.go
+++ b/gateway/mw_persist_graphql_operation_test.go
@@ -1,7 +1,10 @@
 package gateway
 
 import (
+	"bytes"
+	"encoding/base64"
 	"encoding/json"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -381,5 +384,61 @@ func TestGraphqlPersist_MultipleVersions(t *testing.T) {
 			return testResp.Body == string(gqlRequestContinent)
 		}},
 	)
+	assert.NoError(t, err)
+}
+
+func TestGraphQLPersist_TransformResponse(t *testing.T) {
+	// See TT-9227
+	ts := StartTest(nil)
+	t.Cleanup(func() {
+		ts.Close()
+	})
+	expectedResponse := "{\"test\": \"response\"}"
+	templateSource := base64.StdEncoding.EncodeToString([]byte(expectedResponse))
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "gql-rest"
+		spec.OrgID = "default"
+		spec.Proxy.ListenPath = "/gql-rest/"
+		spec.Proxy.TargetURL = TestHttpAny
+		spec.EnableContextVars = true
+		spec.VersionData.NotVersioned = false
+		spec.VersionData.Versions["Default"] = apidef.VersionInfo{
+			Name:             "Default",
+			Expires:          "3000-01-02 00:00",
+			UseExtendedPaths: true,
+			ExtendedPaths: apidef.ExtendedPathsSet{
+				TransformResponse: []apidef.TemplateMeta{
+					{
+						Disabled: false,
+						TemplateData: apidef.TemplateData{
+							Input:          apidef.RequestJSON,
+							Mode:           apidef.UseBlob,
+							EnableSession:  false,
+							TemplateSource: templateSource,
+						},
+						Path:   "/getCountryByCode/{countryCode}",
+						Method: http.MethodGet,
+					},
+				},
+				PersistGraphQL: []apidef.PersistGraphQLMeta{
+					{
+						Path:      "/getCountryByCode/{countryCode}",
+						Method:    "GET",
+						Operation: testGQLQueryCountryCode,
+						Variables: map[string]interface{}{
+							"countryCode": "$path.countryCode",
+						},
+					},
+				},
+			},
+		}
+	})
+
+	_, err := ts.Run(t,
+		test.TestCase{Path: "/gql-rest/getCountryByCode/NG", Method: "GET", BodyMatchFunc: func(body []byte) bool {
+			return bytes.Equal(body, []byte(expectedResponse))
+		}},
+	)
+
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
[TT-9227] Persist GraphQL doesn't work in conjunction with Response Body Transform (#5457)

<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-9227"
title="TT-9227" target="_blank">TT-9227</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
<td>Persist GraphQL doesn't work in conjunction with Response Body
Transform</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20master%20ORDER%20BY%20created%20DESC"
title="master">master</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20release-5-lts%20ORDER%20BY%20created%20DESC"
title="release-5-lts">release-5-lts</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20release-5.2%20ORDER%20BY%20created%20DESC"
title="release-5.2">release-5.2</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

See [TT-9227](https://tyktech.atlassian.net/browse/TT-9227).

When I apply a Persist GraphQL and Response Body Transform, the Response
Body Transform applies.

[TT-9227]:
https://tyktech.atlassian.net/browse/TT-9227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ