### PR TITLE
[TT-6446] Add http transport pool, get enforced timeout from APISpec

### DIFF
--- a/ctx/ctx.go
+++ b/ctx/ctx.go
@@ -17,6 +17,9 @@ import (
 
 type Key uint
 
+// These values hold the context keys. As the value is an iota,
+// values may never be removed or changed. Add new values to
+// the end of the list.
 const (
 	SessionData Key = iota
 	UpdateSession
@@ -46,10 +49,9 @@ const (
 	GraphQLRequest
 	GraphQLIsWebSocketUpgrade
 	OASOperation
-
-	// CacheOptions holds cache options required for cache writer middleware.
-	CacheOptions
+	CacheOptions // CacheOptions holds options required for cache writer middleware.
 	OASDefinition
+	APISpec
 )
 
 func setContext(r *http.Request, ctx context.Context) {

--- a/gateway/ctx.go
+++ b/gateway/ctx.go
@@ -1,0 +1,28 @@
+package gateway
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/TykTechnologies/tyk/ctx"
+)
+
+func ctxSetAPISpec(r *http.Request, apiSpec *APISpec) {
+	setCtxValue(r, ctx.APISpec, apiSpec)
+}
+
+func ctxGetAPISpec(c context.Context) *APISpec {
+	if apiSpec := c.Value(ctx.APISpec); apiSpec != nil {
+		return apiSpec.(*APISpec)
+	}
+	return nil
+}
+
+func ctxSetRetainHost(r *http.Request, retain bool) {
+	setCtxValue(r, ctx.RetainHost, retain)
+}
+
+func ctxGetRetainHost(c context.Context) bool {
+	retain, _ := c.Value(ctx.RetainHost).(bool)
+	return retain
+}

--- a/gateway/handler_success.go
+++ b/gateway/handler_success.go
@@ -11,13 +11,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/TykTechnologies/tyk/apidef"
-	"github.com/TykTechnologies/tyk/internal/httputil"
-
 	"github.com/TykTechnologies/tyk-pump/analytics"
+	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/ctx"
 	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/internal/httputil"
 	"github.com/TykTechnologies/tyk/request"
 	"github.com/TykTechnologies/tyk/user"
 )
@@ -286,7 +285,7 @@ func (s *SuccessHandler) RecordHit(r *http.Request, timing analytics.Latency, co
 
 func recordDetail(r *http.Request, spec *APISpec) bool {
 	// when streaming in grpc, we do not record the request
-	if IsGrpcStreaming(r) {
+	if httputil.IsStreaming(r) {
 		return false
 	}
 

--- a/internal/httputil/buffer_pool.go
+++ b/internal/httputil/buffer_pool.go
@@ -1,0 +1,38 @@
+package httputil
+
+import (
+	"net/http/httputil"
+	"sync"
+)
+
+// BufferPool is an interface for temporary buffer allocations.
+type BufferPool = httputil.BufferPool
+
+// NewSyncBufferPool creates a BufferPool backed with a sync.Pool.
+func NewSyncBufferPool(size int) *SyncBufferPool {
+	return &SyncBufferPool{
+		pool: sync.Pool{
+			New: func() any {
+				return make([]byte, size)
+			},
+		},
+	}
+}
+
+// SyncBufferPool is a sync.Pool backed BufferPool.
+type SyncBufferPool struct {
+	pool sync.Pool
+}
+
+// Get returns a slice to be used for buffering.
+func (b *SyncBufferPool) Get() []byte {
+	return b.pool.Get().([]byte)
+}
+
+// Put releases a slice that was used for buffering.
+func (b *SyncBufferPool) Put(buf []byte) {
+	b.pool.Put(buf)
+}
+
+// Assert that we implement the BufferPool interface.
+var _ BufferPool = &SyncBufferPool{}

--- a/internal/httputil/buffer_pool_test.go
+++ b/internal/httputil/buffer_pool_test.go
@@ -1,0 +1,16 @@
+package httputil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSyncBufferPool(t *testing.T) {
+	pool := NewSyncBufferPool(1024)
+
+	item := pool.Get()
+	assert.Len(t, item, 1024)
+
+	pool.Put(item)
+}

--- a/internal/httputil/connection_watcher.go
+++ b/internal/httputil/connection_watcher.go
@@ -29,7 +29,6 @@ func (cw *ConnectionWatcher) OnStateChange(_ net.Conn, state http.ConnState) {
 }
 
 // Count returns the number of connections at the time the call.
-
 func (cw *ConnectionWatcher) Count() int {
 	return int(atomic.LoadInt64(&cw.n))
 }

--- a/internal/httputil/dialer.go
+++ b/internal/httputil/dialer.go
@@ -1,0 +1,18 @@
+package httputil
+
+import (
+	"net"
+	"time"
+)
+
+// DefaultDialerTimeout holds the default dialer timeout value in seconds.
+const DefaultDialerTimeout = 30 * time.Second
+
+// NewDialer creates a net.Dialer with KeepAlive/Timeout set to `timeout` in seconds.
+func NewDialer(timeout time.Duration) *net.Dialer {
+	return &net.Dialer{
+		DualStack: true,
+		KeepAlive: timeout,
+		Timeout:   timeout,
+	}
+}

--- a/internal/httputil/dialer_test.go
+++ b/internal/httputil/dialer_test.go
@@ -1,0 +1,24 @@
+package httputil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDialer(t *testing.T) {
+	want := time.Duration(0)
+	dialer := NewDialer(time.Duration(0))
+
+	assert.NotNil(t, dialer)
+	assert.Equal(t, want, dialer.Timeout)
+	assert.Equal(t, want, dialer.KeepAlive)
+
+	want = 3 * time.Second
+	dialer = NewDialer(3 * time.Second)
+
+	assert.NotNil(t, dialer)
+	assert.Equal(t, want, dialer.Timeout)
+	assert.Equal(t, want, dialer.KeepAlive)
+}

--- a/internal/httputil/request.go
+++ b/internal/httputil/request.go
@@ -1,6 +1,10 @@
 package httputil
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/TykTechnologies/tyk/header"
+)
 
 // TransferEncoding gets the header value from the request.
 func TransferEncoding(req *http.Request) string {
@@ -15,4 +19,14 @@ func TransferEncoding(req *http.Request) string {
 // HasTransferEncoding returns true if a transfer encoding header is present.
 func HasTransferEncoding(req *http.Request) bool {
 	return TransferEncoding(req) != ""
+}
+
+// IsStreaming returns true if the request is a streaming request.
+func IsStreaming(r *http.Request) bool {
+	return r.ContentLength == -1
+}
+
+// IsGrpcStreaming returns true if the request is a gRPC streaming request.
+func IsGrpcStreaming(r *http.Request) bool {
+	return IsStreaming(r) && r.Header.Get(header.ContentType) == "application/grpc"
 }

--- a/internal/httputil/request_test.go
+++ b/internal/httputil/request_test.go
@@ -20,4 +20,8 @@ func TestTransferEncoding(t *testing.T) {
 	assert.True(t, checkTransferEncoding([]string{"chunked"}))
 	assert.False(t, checkTransferEncoding([]string{}))
 	assert.False(t, checkTransferEncoding(nil))
+
+	r, err := http.NewRequest("GET", "/", nil)
+	assert.NoError(t, err)
+	assert.False(t, httputil.IsGrpcStreaming(r))
 }

--- a/internal/httputil/response.go
+++ b/internal/httputil/response.go
@@ -24,6 +24,7 @@ func InternalServerError(w http.ResponseWriter, _ *http.Request) {
 	http.Error(w, http.StatusText(status), status)
 }
 
+// RemoveResponseTransferEncoding clears a value from http.Response TransferEncoding slice.
 func RemoveResponseTransferEncoding(response *http.Response, encoding string) {
 	for i, value := range response.TransferEncoding {
 		if value == encoding {

--- a/internal/httputil/transport.go
+++ b/internal/httputil/transport.go
@@ -1,0 +1,25 @@
+package httputil
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/TykTechnologies/tyk/config"
+)
+
+// DialContextFunc is the signature for a DialContext function.
+type DialContextFunc func(context.Context, string, string) (net.Conn, error)
+
+// NewTransport creates a http transport based on gateway config and dial context function.
+func NewTransport(config *config.Config, dialContext DialContextFunc) *http.Transport {
+	transport := &http.Transport{
+		DialContext:         dialContext,
+		MaxIdleConns:        config.MaxIdleConns,
+		MaxIdleConnsPerHost: config.MaxIdleConnsPerHost, // default is 100
+		TLSHandshakeTimeout: 10 * time.Second,
+	}
+
+	return transport
+}

--- a/internal/httputil/transport_pool.go
+++ b/internal/httputil/transport_pool.go
@@ -1,0 +1,79 @@
+package httputil
+
+import (
+	"net/http"
+	"sync"
+)
+
+// TransportPool holds a map of *http.Transport values.
+type TransportPool struct {
+	mu   sync.RWMutex
+	pool map[string]*http.Transport
+}
+
+// NewTransportPool creates a new *TransportPool.
+func NewTransportPool() *TransportPool {
+	return &TransportPool{
+		pool: make(map[string]*http.Transport),
+	}
+}
+
+// Put will set or replace transport by key. If a transport already exists,
+// the function will call CloseIdleConnections before replacing it.
+// It returns the *http.Transport that was just put into the pool.
+func (tp *TransportPool) Put(key string, transport *http.Transport) *http.Transport {
+	tp.mu.Lock()
+	defer tp.mu.Unlock()
+
+	prev, ok := tp.pool[key]
+
+	tp.pool[key] = transport
+
+	if ok {
+		defer func() {
+			go prev.CloseIdleConnections()
+		}()
+	}
+
+	return transport
+}
+
+// Get returns a transport for a key. Returns nil if no transport found.
+func (tp *TransportPool) Get(key string) *http.Transport {
+	tp.mu.RLock()
+	val, _ := tp.pool[key]
+	tp.mu.RUnlock()
+	return val
+}
+
+// CloseIdleConnections invokes CloseIdleConnections on all tracked transports.
+func (tp *TransportPool) CloseIdleConnections() {
+	tp.mu.Lock()
+	defer tp.mu.Unlock()
+
+	tp.closeIdleConnections()
+}
+
+func (tp *TransportPool) closeIdleConnections() {
+	for _, conn := range tp.pool {
+		// Prevent new idle connections to be generated.
+		conn.DisableKeepAlives = true
+		conn.CloseIdleConnections()
+	}
+}
+
+// Clear clears the pool invoking CloseIdleConnections as it goes.
+func (tp *TransportPool) Clear() {
+	tp.mu.Lock()
+	defer tp.mu.Unlock()
+
+	tp.clear()
+}
+
+func (tp *TransportPool) clear() {
+	tp.closeIdleConnections()
+
+	for key, _ := range tp.pool {
+		delete(tp.pool, key)
+	}
+}

--- a/internal/httputil/transport_pool_test.go
+++ b/internal/httputil/transport_pool_test.go
@@ -1,0 +1,26 @@
+package httputil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk/config"
+)
+
+func TestTransportPool(t *testing.T) {
+	tp := NewTransportPool()
+	assert.NotNil(t, tp)
+
+	t1 := NewTransport(&config.Config{MaxIdleConns: 100}, nil)
+	t2 := NewTransport(&config.Config{MaxIdleConns: 200}, nil)
+
+	assert.Equal(t, 100, tp.Put("key", t1).MaxIdleConns)
+	assert.Equal(t, 100, tp.Get("key").MaxIdleConns)
+
+	assert.Equal(t, 200, tp.Put("key", t2).MaxIdleConns)
+	assert.Equal(t, 200, tp.Get("key").MaxIdleConns)
+
+	tp.CloseIdleConnections()
+	tp.Clear()
+}


### PR DESCRIPTION
https://tyktech.atlassian.net/browse/TT-6446

- Updates reverse proxy with go stdlib improvements
- Use httputil.BufferPool
- Implement carrying *APISpec on context
- Ensure http transport created timeout from APISpec