### PR TITLE
Merging to release-5.2: [TT-9924]remove muxer, proxy from explicitRouteHandler (#5482)

### DIFF
--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -774,7 +774,6 @@ func (gw *Gateway) loadHTTPService(spec *APISpec, apisByListen map[string]int, g
 		spec.Proxy.ListenPath,
 	}
 
-<<<<<<< HEAD
 	// Register routes for each prefixe
 	for _, prefix := range prefixes {
 		subrouter := router.PathPrefix(prefix).Subrouter()
@@ -785,15 +784,11 @@ func (gw *Gateway) loadHTTPService(spec *APISpec, apisByListen map[string]int, g
 			subrouter.Handle(rateLimitEndpoint, chainObj.RateLimitChain)
 		}
 
-		httpHandler := explicitRouteSubpaths(prefix, chainObj.ThisHandler, muxer, gwConfig.HttpServerOptions.EnableStrictRoutes)
+		httpHandler := explicitRouteSubpaths(prefix, chainObj.ThisHandler, gwConfig.HttpServerOptions.EnableStrictRoutes)
 
 		// Attach handlers
 		subrouter.NewRoute().Handler(httpHandler)
 	}
-=======
-	httpHandler := explicitRouteSubpaths(spec.Proxy.ListenPath, chainObj.ThisHandler, gwConfig.HttpServerOptions.EnableStrictRoutes)
-	subrouter.NewRoute().Handler(httpHandler)
->>>>>>> 213ac5b3... [TT-9924]remove muxer, proxy from explicitRouteHandler (#5482)
 
 	return chainObj
 }

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -694,7 +694,6 @@ func (gw *Gateway) fuzzyFindAPI(search string) *APISpec {
 type explicitRouteHandler struct {
 	prefix  string
 	handler http.Handler
-	muxer   *proxyMux
 }
 
 func (h *explicitRouteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -702,10 +701,12 @@ func (h *explicitRouteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		h.handler.ServeHTTP(w, r)
 		return
 	}
-	h.muxer.handle404(w, r)
+
+	w.WriteHeader(http.StatusNotFound)
+	_, _ = fmt.Fprint(w, http.StatusText(http.StatusNotFound))
 }
 
-func explicitRouteSubpaths(prefix string, handler http.Handler, muxer *proxyMux, enabled bool) http.Handler {
+func explicitRouteSubpaths(prefix string, handler http.Handler, enabled bool) http.Handler {
 	// feature is enabled via config option
 	if !enabled {
 		return handler
@@ -723,7 +724,6 @@ func explicitRouteSubpaths(prefix string, handler http.Handler, muxer *proxyMux,
 	return &explicitRouteHandler{
 		prefix:  prefix,
 		handler: handler,
-		muxer:   muxer,
 	}
 }
 
@@ -774,6 +774,7 @@ func (gw *Gateway) loadHTTPService(spec *APISpec, apisByListen map[string]int, g
 		spec.Proxy.ListenPath,
 	}
 
+<<<<<<< HEAD
 	// Register routes for each prefixe
 	for _, prefix := range prefixes {
 		subrouter := router.PathPrefix(prefix).Subrouter()
@@ -789,6 +790,10 @@ func (gw *Gateway) loadHTTPService(spec *APISpec, apisByListen map[string]int, g
 		// Attach handlers
 		subrouter.NewRoute().Handler(httpHandler)
 	}
+=======
+	httpHandler := explicitRouteSubpaths(spec.Proxy.ListenPath, chainObj.ThisHandler, gwConfig.HttpServerOptions.EnableStrictRoutes)
+	subrouter.NewRoute().Handler(httpHandler)
+>>>>>>> 213ac5b3... [TT-9924]remove muxer, proxy from explicitRouteHandler (#5482)
 
 	return chainObj
 }


### PR DESCRIPTION
[TT-9924]remove muxer, proxy from explicitRouteHandler (#5482)

Remove muxer from explicitRouteHandler

[TT-9924]: https://tyktech.atlassian.net/browse/TT-9924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ