### PR TITLE
[TT-9951] Avoid drl race from storage callbacks

### DIFF
--- a/gateway/distributed_rate_limiter.go
+++ b/gateway/distributed_rate_limiter.go
@@ -9,14 +9,6 @@ import (
 	"github.com/TykTechnologies/drl"
 )
 
-func (gw *Gateway) setupDRL() {
-	drlManager := &drl.DRL{}
-	drlManager.Init(gw.ctx)
-	drlManager.ThisServerID = gw.GetNodeID() + "|" + gw.hostDetails.Hostname
-	log.Debug("DRL: Setting node ID: ", drlManager.ThisServerID)
-	gw.DRLManager = drlManager
-}
-
 func (gw *Gateway) startRateLimitNotifications() {
 	notificationFreq := gw.GetConfig().DRLNotificationFrequency
 	if notificationFreq == 0 {
@@ -84,9 +76,12 @@ func (gw *Gateway) NotifyCurrentServerStatus() {
 }
 
 func (gw *Gateway) onServerStatusReceivedHandler(payload string) {
-	if gw.DRLManager == nil || !gw.DRLManager.Ready() {
-		log.Warning("DRL not ready, skipping this notification")
+	if !gw.startDRL() {
+		return
+	}
 
+	if !gw.DRLManager.Ready() {
+		log.Warning("DRL not ready, skipping this notification")
 		return
 	}
 

--- a/gateway/distributed_rate_limiter.go
+++ b/gateway/distributed_rate_limiter.go
@@ -44,7 +44,7 @@ func (gw *Gateway) getTagHash() string {
 }
 
 func (gw *Gateway) NotifyCurrentServerStatus() {
-	if gw.DRLManager == nil || !gw.DRLManager.Ready() {
+	if !gw.DRLManager.Ready() {
 		return
 	}
 
@@ -76,9 +76,7 @@ func (gw *Gateway) NotifyCurrentServerStatus() {
 }
 
 func (gw *Gateway) onServerStatusReceivedHandler(payload string) {
-	if !gw.startDRL() {
-		return
-	}
+	gw.startDRL()
 
 	if !gw.DRLManager.Ready() {
 		log.Warning("DRL not ready, skipping this notification")

--- a/gateway/mw_redis_cache_test.go
+++ b/gateway/mw_redis_cache_test.go
@@ -168,6 +168,118 @@ func TestRedisCacheMiddleware(t *testing.T) {
 	})
 }
 
+func TestRedisCacheMiddlewareV2(t *testing.T) {
+	type params struct {
+		path             string
+		bodyMatch        string
+		uncompressed     bool
+		transferEncoding []string
+	}
+
+	const compressed = "/compressed"
+	const chunked = "/chunked"
+
+	type testcase struct {
+		title         string
+		useCaching    bool
+		useCompressed bool
+		useChunked    bool
+	}
+
+	bools := []bool{false, true}
+
+	testcases := make([]testcase, 0, 1<<3)
+	for _, useCaching := range bools {
+		for _, useCompressed := range bools {
+			for _, useChunked := range bools {
+				if useChunked == useCompressed {
+					continue
+				}
+
+				testcases = append(testcases, testcase{
+					title:         fmt.Sprintf("cache=%v, chunked=%v, compressed=%v", useCaching, useChunked, useCompressed),
+					useCaching:    useCaching,
+					useChunked:    useChunked,
+					useCompressed: useCompressed,
+				})
+			}
+		}
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+
+		t.Run(tc.title, func(t *testing.T) {
+			conf := func(globalConf *config.Config) {
+				globalConf.AnalyticsConfig.EnableDetailedRecording = true
+			}
+			ts := StartTest(conf)
+			defer ts.Close()
+
+			ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+				spec.Proxy.ListenPath = "/"
+				spec.CacheOptions.CacheTimeout = 60
+				spec.CacheOptions.EnableCache = tc.useCaching
+
+				if tc.useCaching {
+					UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+						v.ExtendedPaths.Cached = []string{compressed, chunked}
+					})
+				}
+			})
+
+			var url, bodyMatch string
+			var wantHeaders map[string]string
+
+			if tc.useChunked {
+				url = "/chunked"
+				bodyMatch = "This is a chunked response"
+			}
+			if tc.useCompressed {
+				url = "/compressed"
+				bodyMatch = "This is a compressed response"
+			}
+			if tc.useCaching {
+				wantHeaders = map[string]string{
+					"x-tyk-cached-response": "1",
+				}
+			}
+
+			assert.NotEmpty(t, url)
+
+			ts.Gw.Analytics.mockEnabled = true
+			ts.Gw.Analytics.mockRecordHit = func(record *analytics.AnalyticsRecord) {
+				response, err := base64.StdEncoding.DecodeString(record.RawResponse)
+				assert.NoError(t, err)
+
+				assert.Contains(t, string(response), bodyMatch)
+			}
+
+			defer func() {
+				ts.Gw.Analytics.mockEnabled = false
+			}()
+
+			resp, _ := ts.Run(t, []test.TestCase{
+				{Path: url, BodyMatch: bodyMatch, Code: http.StatusOK},
+				{Path: url, HeadersMatch: wantHeaders, BodyMatch: bodyMatch, Code: http.StatusOK},
+			}...)
+
+			if tc.useChunked {
+				if tc.useCaching {
+					var empty []string
+					assert.Equal(t, empty, resp.TransferEncoding)
+				} else {
+					assert.Equal(t, []string{"chunked"}, resp.TransferEncoding)
+				}
+			}
+
+			if tc.useCompressed {
+				assert.True(t, resp.Uncompressed)
+			}
+		})
+	}
+}
+
 func Test_isSafeMethod(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/gateway/mw_redis_cache_test.go
+++ b/gateway/mw_redis_cache_test.go
@@ -169,13 +169,6 @@ func TestRedisCacheMiddleware(t *testing.T) {
 }
 
 func TestRedisCacheMiddlewareV2(t *testing.T) {
-	type params struct {
-		path             string
-		bodyMatch        string
-		uncompressed     bool
-		transferEncoding []string
-	}
-
 	const compressed = "/compressed"
 	const chunked = "/chunked"
 

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -1799,7 +1799,7 @@ func handleDashboardRegistration(gw *Gateway) {
 	}()
 }
 
-func (gw *Gateway) startDRL() bool {
+func (gw *Gateway) startDRL() {
 	gwConfig := gw.GetConfig()
 
 	disabled := gwConfig.ManagementNode || gwConfig.EnableSentinelRateLimiter || gw.GetConfig().EnableRedisRollingLimiter
@@ -1823,7 +1823,6 @@ func (gw *Gateway) startDRL() bool {
 
 		gw.startRateLimitNotifications()
 	})
-	return true
 }
 
 func (gw *Gateway) setupPortsWhitelist() {
@@ -1867,9 +1866,7 @@ func (gw *Gateway) startServer() {
 	handleDashboardRegistration(gw)
 
 	// at this point NodeID is ready to use by DRL
-	if !gw.startDRL() {
-		mainLog.Info("DRL is disabled")
-	}
+	gw.startDRL()
 
 	mainLog.Infof("Tyk Gateway started (%s)", VERSION)
 	address := gw.GetConfig().ListenAddress


### PR DESCRIPTION
https://tyktech.atlassian.net/browse/TT-9951

The PR better protects a *drl.DRL value from being accessed, causing the following race condition.

How this was tested (via PR #5474):

```
# gotestsum -- -run=^TestRedisCacheMiddlewareV2$ -v -count=2000 -race -failfast .
✓  gateway (9m18.077s)

DONE 10000 tests in 566.952s
```

```
==================
WARNING: DATA RACE
Read at 0x00c0010eb358 by goroutine 3208:
  github.com/TykTechnologies/tyk/gateway.(*Gateway).onServerStatusReceivedHandler()
      /root/tyk/tyk/gateway/distributed_rate_limiter.go:90 +0x6b
  github.com/TykTechnologies/tyk/gateway.(*Gateway).handleRedisEvent()
      /root/tyk/tyk/gateway/redis_signals.go:127 +0x6c4
  github.com/TykTechnologies/tyk/gateway.(*Gateway).startPubSubLoop.func1()
      /root/tyk/tyk/gateway/redis_signals.go:61 +0x48
  github.com/TykTechnologies/tyk/storage.(*RedisCluster).handleMessage()
      /root/tyk/tyk/storage/redis_cluster.go:795 +0x76
  github.com/TykTechnologies/tyk/storage.(*RedisCluster).handleReceive()
      /root/tyk/tyk/storage/redis_cluster.go:789 +0x69
  github.com/TykTechnologies/tyk/storage.(*RedisCluster).StartPubSubHandler()
      /root/tyk/tyk/storage/redis_cluster.go:779 +0x264
  github.com/TykTechnologies/tyk/gateway.(*Gateway).startPubSubLoop()
      /root/tyk/tyk/gateway/redis_signals.go:60 +0x129
  github.com/TykTechnologies/tyk/gateway.(*Test).newGateway.func5()
      /root/tyk/tyk/gateway/testutil.go:1173 +0x39

Previous write at 0x00c0010eb358 by goroutine 3153:
  github.com/TykTechnologies/tyk/gateway.(*Gateway).setupDRL()
      /root/tyk/tyk/gateway/distributed_rate_limiter.go:20 +0x224
  github.com/TykTechnologies/tyk/gateway.(*Gateway).startDRL()
      /root/tyk/tyk/gateway/server.go:1810 +0x271
  github.com/TykTechnologies/tyk/gateway.(*Gateway).startDRL-fm()
      <autogenerated>:1 +0x39
  sync.(*Once).doSlow()
      /go/src/sync/once.go:74 +0x101
  sync.(*Once).Do()
      /go/src/sync/once.go:65 +0x46
  github.com/TykTechnologies/tyk/gateway.(*Gateway).startServer()
      /root/tyk/tyk/gateway/server.go:1855 +0x632
  github.com/TykTechnologies/tyk/gateway.(*Test).start()
      /root/tyk/tyk/gateway/testutil.go:1009 +0x22e
  github.com/TykTechnologies/tyk/gateway.StartTest()
      /root/tyk/tyk/gateway/testutil.go:990 +0x199
  github.com/TykTechnologies/tyk/gateway.TestRedisCacheMiddlewareV2.func1()
      /root/tyk/tyk/gateway/mw_redis_cache_test.go:216 +0x7e
  testing.tRunner()
      /go/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /go/src/testing/testing.go:1629 +0x47

Goroutine 3208 (running) created at:
  github.com/TykTechnologies/tyk/gateway.(*Test).newGateway()
      /root/tyk/tyk/gateway/testutil.go:1173 +0x14e5
  github.com/TykTechnologies/tyk/gateway.(*Test).start()
      /root/tyk/tyk/gateway/testutil.go:1007 +0x219
  github.com/TykTechnologies/tyk/gateway.StartTest()
      /root/tyk/tyk/gateway/testutil.go:990 +0x199
  github.com/TykTechnologies/tyk/gateway.TestRedisCacheMiddlewareV2.func1()
      /root/tyk/tyk/gateway/mw_redis_cache_test.go:216 +0x7e
  testing.tRunner()
      /go/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /go/src/testing/testing.go:1629 +0x47

Goroutine 3153 (running) created at:
  testing.(*T).Run()
      /go/src/testing/testing.go:1629 +0x805
  github.com/TykTechnologies/tyk/gateway.TestRedisCacheMiddlewareV2()
      /root/tyk/tyk/gateway/mw_redis_cache_test.go:212 +0xf7
  testing.tRunner()
      /go/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /go/src/testing/testing.go:1629 +0x47
==================
```