### PR TITLE
Merging to release-5.2: [TT-9966] Fix/test testutil bugs (#5527)

### DIFF
--- a/gateway/mw_api_rate_limit_test.go
+++ b/gateway/mw_api_rate_limit_test.go
@@ -70,8 +70,6 @@ func TestRLOpen(t *testing.T) {
 
 	spec := ts.Gw.LoadSampleAPI(openRLDefSmall)
 
-	req := TestReq(t, "GET", "/rl_test/", nil)
-
 	ts.Gw.DRLManager.SetCurrentTokenValue(1)
 	ts.Gw.DRLManager.RequestTokenValue = 1
 
@@ -79,7 +77,10 @@ func TestRLOpen(t *testing.T) {
 	chain := ts.getRLOpenChain(spec)
 	for a := 0; a <= 10; a++ {
 		recorder := httptest.NewRecorder()
+
+		req := TestReq(t, "GET", "/rl_test/", nil)
 		chain.ServeHTTP(recorder, req)
+
 		if a < 3 {
 			if recorder.Code != 200 {
 				t.Fatalf("Rate limit kicked in too early, after only %v requests", a)
@@ -222,8 +223,6 @@ func TestRLClosed(t *testing.T) {
 
 	spec := ts.Gw.LoadSampleAPI(closedRLDefSmall)
 
-	req := TestReq(t, "GET", "/rl_closed_test/", nil)
-
 	session := createRLSession()
 	customToken := uuid.New()
 
@@ -232,7 +231,6 @@ func TestRLClosed(t *testing.T) {
 	if err != nil {
 		t.Error("could not update session in Session Manager. " + err.Error())
 	}
-	req.Header.Set("authorization", "Bearer "+customToken)
 
 	ts.Gw.DRLManager.SetCurrentTokenValue(1)
 	ts.Gw.DRLManager.RequestTokenValue = 1
@@ -240,7 +238,11 @@ func TestRLClosed(t *testing.T) {
 	chain := ts.getGlobalRLAuthKeyChain(spec)
 	for a := 0; a <= 10; a++ {
 		recorder := httptest.NewRecorder()
+
+		req := TestReq(t, "GET", "/rl_closed_test/", nil)
+		req.Header.Set("authorization", "Bearer "+customToken)
 		chain.ServeHTTP(recorder, req)
+
 		if a < 3 {
 			if recorder.Code != 200 {
 				t.Fatalf("Rate limit kicked in too early, after only %v requests", a)
@@ -263,15 +265,16 @@ func TestRLOpenWithReload(t *testing.T) {
 
 	spec := ts.Gw.LoadSampleAPI(openRLDefSmall)
 
-	req := TestReq(t, "GET", "/rl_test/", nil)
-
 	ts.Gw.DRLManager.SetCurrentTokenValue(1)
 	ts.Gw.DRLManager.RequestTokenValue = 1
 
 	chain := ts.getRLOpenChain(spec)
 	for a := 0; a <= 10; a++ {
 		recorder := httptest.NewRecorder()
+
+		req := TestReq(t, "GET", "/rl_test/", nil)
 		chain.ServeHTTP(recorder, req)
+
 		if a < 3 {
 			if recorder.Code != 200 {
 				t.Fatalf("Rate limit (pre change) kicked in too early, after only %v requests", a)
@@ -290,7 +293,10 @@ func TestRLOpenWithReload(t *testing.T) {
 	chain = ts.getRLOpenChain(spec)
 	for a := 0; a <= 30; a++ {
 		recorder := httptest.NewRecorder()
+
+		req := TestReq(t, "GET", "/rl_test/", nil)
 		chain.ServeHTTP(recorder, req)
+
 		if a < 20 {
 			if recorder.Code != 200 {
 				t.Fatalf("Rate limit (post change) kicked in too early, after only %v requests", a)

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -1223,7 +1223,7 @@ func (s *Test) ReloadGatewayProxy() {
 }
 
 func (s *Test) Close() {
-	s.cancel()
+	defer s.cancel()
 
 	for _, p := range s.Gw.DefaultProxyMux.proxies {
 		if p.listener != nil {

--- a/test/http.go
+++ b/test/http.go
@@ -33,14 +33,15 @@ type TestCase struct {
 	Cookies         []*http.Cookie    `json:",omitempty"`
 	Delay           time.Duration     `json:",omitempty"`
 	BodyMatch       string            `json:",omitempty"` // regex
-	BodyMatchFunc   func([]byte) bool `json:",omitempty"`
 	BodyNotMatch    string            `json:",omitempty"`
 	HeadersMatch    map[string]string `json:",omitempty"`
 	HeadersNotMatch map[string]string `json:",omitempty"`
 	JSONMatch       map[string]string `json:",omitempty"`
 	ErrorMatch      string            `json:",omitempty"`
-	BeforeFn        func()            `json:"-"`
-	Client          *http.Client      `json:"-"`
+
+	BodyMatchFunc func([]byte) bool `json:"-"`
+	BeforeFn      func()            `json:"-"`
+	Client        *http.Client      `json:"-"`
 
 	AdminAuth      bool `json:",omitempty"`
 	ControlRequest bool `json:",omitempty"`
@@ -275,7 +276,9 @@ func (r HTTPTestRunner) Run(t testing.TB, testCases ...TestCase) (*http.Response
 	}
 
 	for ti, tc := range testCases {
-		req, err := r.RequestBuilder(&tc)
+		var tc *TestCase = &tc
+
+		req, err := r.RequestBuilder(tc)
 		if err != nil {
 			t.Errorf("[%d] Request build error: %s", ti, err.Error())
 			continue
@@ -284,7 +287,7 @@ func (r HTTPTestRunner) Run(t testing.TB, testCases ...TestCase) (*http.Response
 		retryCount := 0
 	retry:
 
-		lastResponse, lastError = r.Do(req, &tc)
+		lastResponse, lastError = r.Do(req, tc)
 		tcJSON, _ := json.Marshal(tc)
 
 		if lastError != nil {
@@ -307,13 +310,11 @@ func (r HTTPTestRunner) Run(t testing.TB, testCases ...TestCase) (*http.Response
 		}
 
 		respCopy := copyResponse(lastResponse)
-		if lastError = r.Assert(respCopy, &tc); lastError != nil {
+		if lastError = r.Assert(respCopy, tc); lastError != nil {
 			t.Errorf("[%d] %s. %s\n", ti, lastError.Error(), string(tcJSON))
 		}
 
-		delay := tc.Delay
-
-		if delay > 0 {
+		if delay := tc.Delay; delay > 0 {
 			time.Sleep(delay)
 		}
 	}


### PR DESCRIPTION
[TT-9966] Fix/test testutil bugs (#5527)

- TestCase swallowed marshall error fix (functions can't be marshalled)
- Gateway test context cancellation (needs to happen after analytics
flush to storage...)
- Reused *http.Request in tests (bug, request modified in place)

Test scope change only.

https://tyktech.atlassian.net/browse/TT-9966

---------

Co-authored-by: Tit Petric <tit@tyk.io>

[TT-9966]: https://tyktech.atlassian.net/browse/TT-9966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ