### PR TITLE
[TT-9972] release resources only after specs are completely switched during hot reload

### DIFF
--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -261,6 +261,7 @@ func (s *APISpec) Release() {
 		// Prevent new idle connections to be generated.
 		s.HTTPTransport.transport.DisableKeepAlives = true
 		s.HTTPTransport.transport.CloseIdleConnections()
+		s.HTTPTransport = nil
 	}
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

release resources only after specs are completely switched during hot reload
## Related Issue
https://tyktech.atlassian.net/browse/TT-9972

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
