### PR TITLE
Merging to release-5.2: [TT-9951] Avoid drl race from storage callbacks (#5506)

### DIFF
--- a/gateway/distributed_rate_limiter.go
+++ b/gateway/distributed_rate_limiter.go
@@ -9,14 +9,6 @@ import (
 	"github.com/TykTechnologies/drl"
 )
 
-func (gw *Gateway) setupDRL() {
-	drlManager := &drl.DRL{}
-	drlManager.Init(gw.ctx)
-	drlManager.ThisServerID = gw.GetNodeID() + "|" + gw.hostDetails.Hostname
-	log.Debug("DRL: Setting node ID: ", drlManager.ThisServerID)
-	gw.DRLManager = drlManager
-}
-
 func (gw *Gateway) startRateLimitNotifications() {
 	notificationFreq := gw.GetConfig().DRLNotificationFrequency
 	if notificationFreq == 0 {
@@ -52,7 +44,7 @@ func (gw *Gateway) getTagHash() string {
 }
 
 func (gw *Gateway) NotifyCurrentServerStatus() {
-	if gw.DRLManager == nil || !gw.DRLManager.Ready() {
+	if !gw.DRLManager.Ready() {
 		return
 	}
 
@@ -84,9 +76,10 @@ func (gw *Gateway) NotifyCurrentServerStatus() {
 }
 
 func (gw *Gateway) onServerStatusReceivedHandler(payload string) {
-	if gw.DRLManager == nil || !gw.DRLManager.Ready() {
-		log.Warning("DRL not ready, skipping this notification")
+	gw.startDRL()
 
+	if !gw.DRLManager.Ready() {
+		log.Warning("DRL not ready, skipping this notification")
 		return
 	}
 

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -1800,15 +1800,29 @@ func handleDashboardRegistration(gw *Gateway) {
 }
 
 func (gw *Gateway) startDRL() {
-	switch {
-	case gw.GetConfig().ManagementNode:
-		return
-	case gw.GetConfig().EnableSentinelRateLimiter, gw.GetConfig().EnableRedisRollingLimiter:
-		return
-	}
-	mainLog.Info("Initialising distributed rate limiter")
-	gw.setupDRL()
-	gw.startRateLimitNotifications()
+	gwConfig := gw.GetConfig()
+
+	disabled := gwConfig.ManagementNode || gwConfig.EnableSentinelRateLimiter || gw.GetConfig().EnableRedisRollingLimiter
+
+	gw.drlOnce.Do(func() {
+		drlManager := &drl.DRL{}
+		gw.DRLManager = drlManager
+
+		if disabled {
+			return
+		}
+
+		mainLog.Info("Initialising distributed rate limiter")
+
+		nodeID := gw.GetNodeID() + "|" + gw.hostDetails.Hostname
+
+		drlManager.ThisServerID = nodeID
+		drlManager.Init(gw.ctx)
+
+		log.Debug("DRL: Setting node ID: ", nodeID)
+
+		gw.startRateLimitNotifications()
+	})
 }
 
 func (gw *Gateway) setupPortsWhitelist() {
@@ -1851,9 +1865,8 @@ func (gw *Gateway) startServer() {
 	// handle dashboard registration and nonces if available
 	handleDashboardRegistration(gw)
 
-	gw.DRLManager = &drl.DRL{}
 	// at this point NodeID is ready to use by DRL
-	gw.drlOnce.Do(gw.startDRL)
+	gw.startDRL()
 
 	mainLog.Infof("Tyk Gateway started (%s)", VERSION)
 	address := gw.GetConfig().ListenAddress


### PR DESCRIPTION
[TT-9951] Avoid drl race from storage callbacks (#5506)

https://tyktech.atlassian.net/browse/TT-9951

The PR better protects a *drl.DRL value from being accessed, causing the
following race condition.

How this was tested (via PR #5474):

```
# gotestsum -- -run=^TestRedisCacheMiddlewareV2$ -v -count=2000 -race -failfast .
✓  gateway (9m18.077s)

DONE 10000 tests in 566.952s
```

```
==================
WARNING: DATA RACE
Read at 0x00c0010eb358 by goroutine 3208:
  github.com/TykTechnologies/tyk/gateway.(*Gateway).onServerStatusReceivedHandler()
      /root/tyk/tyk/gateway/distributed_rate_limiter.go:90 +0x6b
  github.com/TykTechnologies/tyk/gateway.(*Gateway).handleRedisEvent()
      /root/tyk/tyk/gateway/redis_signals.go:127 +0x6c4
  github.com/TykTechnologies/tyk/gateway.(*Gateway).startPubSubLoop.func1()
      /root/tyk/tyk/gateway/redis_signals.go:61 +0x48
  github.com/TykTechnologies/tyk/storage.(*RedisCluster).handleMessage()
      /root/tyk/tyk/storage/redis_cluster.go:795 +0x76
  github.com/TykTechnologies/tyk/storage.(*RedisCluster).handleReceive()
      /root/tyk/tyk/storage/redis_cluster.go:789 +0x69
  github.com/TykTechnologies/tyk/storage.(*RedisCluster).StartPubSubHandler()
      /root/tyk/tyk/storage/redis_cluster.go:779 +0x264
  github.com/TykTechnologies/tyk/gateway.(*Gateway).startPubSubLoop()
      /root/tyk/tyk/gateway/redis_signals.go:60 +0x129
  github.com/TykTechnologies/tyk/gateway.(*Test).newGateway.func5()
      /root/tyk/tyk/gateway/testutil.go:1173 +0x39

Previous write at 0x00c0010eb358 by goroutine 3153:
  github.com/TykTechnologies/tyk/gateway.(*Gateway).setupDRL()
      /root/tyk/tyk/gateway/distributed_rate_limiter.go:20 +0x224
  github.com/TykTechnologies/tyk/gateway.(*Gateway).startDRL()
      /root/tyk/tyk/gateway/server.go:1810 +0x271
  github.com/TykTechnologies/tyk/gateway.(*Gateway).startDRL-fm()
      <autogenerated>:1 +0x39
  sync.(*Once).doSlow()
      /go/src/sync/once.go:74 +0x101
  sync.(*Once).Do()
      /go/src/sync/once.go:65 +0x46
  github.com/TykTechnologies/tyk/gateway.(*Gateway).startServer()
      /root/tyk/tyk/gateway/server.go:1855 +0x632
  github.com/TykTechnologies/tyk/gateway.(*Test).start()
      /root/tyk/tyk/gateway/testutil.go:1009 +0x22e
  github.com/TykTechnologies/tyk/gateway.StartTest()
      /root/tyk/tyk/gateway/testutil.go:990 +0x199
  github.com/TykTechnologies/tyk/gateway.TestRedisCacheMiddlewareV2.func1()
      /root/tyk/tyk/gateway/mw_redis_cache_test.go:216 +0x7e
  testing.tRunner()
      /go/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /go/src/testing/testing.go:1629 +0x47

Goroutine 3208 (running) created at:
  github.com/TykTechnologies/tyk/gateway.(*Test).newGateway()
      /root/tyk/tyk/gateway/testutil.go:1173 +0x14e5
  github.com/TykTechnologies/tyk/gateway.(*Test).start()
      /root/tyk/tyk/gateway/testutil.go:1007 +0x219
  github.com/TykTechnologies/tyk/gateway.StartTest()
      /root/tyk/tyk/gateway/testutil.go:990 +0x199
  github.com/TykTechnologies/tyk/gateway.TestRedisCacheMiddlewareV2.func1()
      /root/tyk/tyk/gateway/mw_redis_cache_test.go:216 +0x7e
  testing.tRunner()
      /go/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /go/src/testing/testing.go:1629 +0x47

Goroutine 3153 (running) created at:
  testing.(*T).Run()
      /go/src/testing/testing.go:1629 +0x805
  github.com/TykTechnologies/tyk/gateway.TestRedisCacheMiddlewareV2()
      /root/tyk/tyk/gateway/mw_redis_cache_test.go:212 +0xf7
  testing.tRunner()
      /go/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /go/src/testing/testing.go:1629 +0x47
==================
```

---------

Co-authored-by: Tit Petric <tit@tyk.io>