### PR TITLE
[TT-6446] Minimal approach to setting a context-enforced timeout

### DIFF
--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -554,9 +554,7 @@ func (p *ReverseProxy) CheckHardTimeoutEnforced(spec *APISpec, req *http.Request
 	return checkHardTimeoutEnforced(spec, req)
 }
 
-// This function returns if the request should have a hard timeout enforced.
-// If the request doesn't have a hard timeout enforced, then the transport
-// has a secondary timeout based on proxyDefaultTimeout return value.
+// Returns if the request should have a hard timeout enforced and the timeout value configured.
 func checkHardTimeoutEnforced(spec *APISpec, req *http.Request) (bool, float64) {
 	if !spec.EnforcedTimeoutEnabled {
 		return false, 0

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -538,8 +538,8 @@ func (p *ReverseProxy) ServeHTTPForCache(rw http.ResponseWriter, req *http.Reque
 	return resp
 }
 
-// This returns the expected 30 second default timeout in case
-// the ProxyDefaultTimeout value is undefined.
+// proxyDefaultTimeout returns the default timeout of 30 seconds
+// if the global ProxyDefaultTimeout value is undefined.
 func proxyDefaultTimeout(spec *APISpec) float64 {
 	if spec.GlobalConfig.ProxyDefaultTimeout > 0 {
 		return spec.GlobalConfig.ProxyDefaultTimeout

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -1476,7 +1476,7 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 			return ProxyResponse{UpstreamLatency: upstreamLatency}
 		}
 
-		if strings.Contains(err.Error(), "timeout awaiting response headers") {
+		if strings.Contains(err.Error(), "timeout awaiting response headers") || strings.Contains(err.Error(), "context deadline exceeded") {
 			p.ErrorHandler.HandleError(rw, logreq, "Upstream service reached hard timeout.", http.StatusGatewayTimeout, true)
 
 			if p.TykAPISpec.Proxy.ServiceDiscovery.UseDiscoveryService {


### PR DESCRIPTION
This changes the default proxy timeout to not be based on HardTimeout configured from an APISpec.

- If a hard timeout is configured, a context with timeout is created for the outgoing request,
- The transport timeout is configured to [proxy_default_timeout](https://tyk.io/docs/tyk-oss-gateway/configuration/#proxy_default_timeout) or 30 secs by default.

https://tyktech.atlassian.net/browse/TT-6446