### PR TITLE
Merging to release-5.2: TT-9957 Fix timeouts when getting keys when mdcb is down (#5574)

### DIFF
--- a/rpc/rpc_client.go
+++ b/rpc/rpc_client.go
@@ -72,8 +72,9 @@ type rpcOpts struct {
 
 func (r rpcOpts) ClientIsConnected() bool {
 	if v := r.clientIsConnected.Load(); v != nil {
-		return v.(bool)
+		return v.(bool) && !r.GetEmergencyMode()
 	}
+
 	return false
 }
 

--- a/rpc/rpc_client_test.go
+++ b/rpc/rpc_client_test.go
@@ -39,3 +39,56 @@ func TestRecoveryFromEmregencyMode(t *testing.T) {
 		t.Fatal("expected to recover from emergency mode")
 	}
 }
+
+func TestClientIsConnected(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		connected     bool
+		emergencyMode bool
+		expected      bool
+	}{
+		{
+			name:          "When client is connected and not in emergency mode",
+			connected:     true,
+			emergencyMode: false,
+			expected:      true,
+		},
+		{
+			name:          "When client is disconnected and not in emergency mode",
+			connected:     false,
+			emergencyMode: false,
+			expected:      false,
+		},
+		{
+			name:          "When client is connected and in emergency mode",
+			connected:     true,
+			emergencyMode: true,
+			expected:      false,
+		},
+		{
+			name:          "When client is disconnected and in emergency mode",
+			connected:     false,
+			emergencyMode: true,
+			expected:      false,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			r := rpcOpts{}
+			r.clientIsConnected.Store(tt.connected)
+			r.emergencyMode.Store(tt.emergencyMode)
+			defer func() {
+				r.clientIsConnected.Store(false)
+				r.emergencyMode.Store(false)
+			}()
+
+			got := r.ClientIsConnected()
+			if got != tt.expected {
+				t.Errorf("ClientIsConnected() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
TT-9957 Fix timeouts when getting keys when mdcb is down (#5574)

- Have a JWT token with client_id claim
- Start edge gateway, MDCB disconnected, try to use JWT token with
client_id claim, it can be a bit slow first time, but overall works well
- Start edge gateway with MDCb connected, and turn off MDCB in the
middle, same token hangs

It happens because `IsClientConnected` function do not respect emergency
mode. Now it does.

Additionally I added a 1 second cache for failed GetKey attempts (or
when key not found), to the RPC GetRawKey function, which should
signiciantly improve latency for cases like when JWT is used with
client_id scope, but not actually use DCR, and such client_id in Tyk
does not exits.

---------

Co-authored-by: tbuchaillot <tombuchaillot89@gmail.com>