### PR TITLE
Revert "Merging to release-5.2: [TT-10133] Add ULID normalizer (#5588)"

### DIFF
--- a/ci/aws/hybrid/tyk_hybrid.conf
+++ b/ci/aws/hybrid/tyk_hybrid.conf
@@ -30,7 +30,6 @@
         "normalise_urls": {
             "enabled": true,
             "normalise_uuids": true,
-            "normalise_ulids": true,
             "normalise_numbers": true,
             "custom_patterns": []
         }

--- a/ci/images/hybrid/tyk/tyk.conf
+++ b/ci/images/hybrid/tyk/tyk.conf
@@ -30,7 +30,6 @@
     "normalise_urls": {
       "enabled": true,
       "normalise_uuids": true,
-      "normalise_ulids": true,
       "normalise_numbers": true,
       "custom_patterns": []
     }

--- a/ci/install/data/tyk.self_contained.conf
+++ b/ci/install/data/tyk.self_contained.conf
@@ -22,7 +22,6 @@
     "normalise_urls": {
       "enabled": true,
       "normalise_uuids": true,
-      "normalise_ulids": true,
       "normalise_numbers": true,
       "custom_patterns": []
     }

--- a/ci/install/data/tyk.with_dash.conf
+++ b/ci/install/data/tyk.with_dash.conf
@@ -32,7 +32,6 @@
     "normalise_urls": {
       "enabled": true,
       "normalise_uuids": true,
-      "normalise_ulids": true,
       "normalise_numbers": true,
       "custom_patterns": []
     }

--- a/ci/tests/python-plugins/src/tyk.conf
+++ b/ci/tests/python-plugins/src/tyk.conf
@@ -47,7 +47,6 @@
         "normalise_urls": {
             "enabled": true,
             "normalise_uuids": true,
-            "normalise_ulids": true,
             "normalise_numbers": true,
             "custom_patterns": []
         }

--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -224,9 +224,6 @@
             },
             "normalise_uuids": {
               "type": "boolean"
-            },
-            "normalise_ulids": {
-              "type": "boolean"
             }
           }
         },

--- a/config/config.go
+++ b/config/config.go
@@ -154,15 +154,6 @@ type NormalisedURLConfig struct {
 	// Each UUID will be replaced with a placeholder {uuid}
 	NormaliseUUIDs bool `json:"normalise_uuids"`
 
-	// Set this to true to have Tyk automatically clean up ULIDs. It will match the following style:
-	//
-	// * `/posts/01G9HHNKWGBHCQX7VG3JKSZ055/comments`
-	// * `/posts/01g9hhnkwgbhcqx7vg3jksz055/comments`
-	// * `/posts/01g9HHNKwgbhcqx7vg3JKSZ055/comments`
-
-	// Each ULID will be replaced with a placeholder {ulid}
-	NormaliseULIDs bool `json:"normalise_ulids"`
-
 	// Set this to true to have Tyk automatically match for numeric IDs, it will match with a preceding slash so as not to capture actual numbers:
 	NormaliseNumbers bool `json:"normalise_numbers"`
 
@@ -174,7 +165,6 @@ type NormalisedURLConfig struct {
 
 type NormaliseURLPatterns struct {
 	UUIDs  *regexp.Regexp
-	ULIDs  *regexp.Regexp
 	IDs    *regexp.Regexp
 	Custom []*regexp.Regexp
 }

--- a/gateway/analytics.go
+++ b/gateway/analytics.go
@@ -27,7 +27,6 @@ const (
 
 func (gw *Gateway) initNormalisationPatterns() (pats config.NormaliseURLPatterns) {
 	pats.UUIDs = regexp.MustCompile(`[0-9a-fA-F]{8}(-)?[0-9a-fA-F]{4}(-)?[0-9a-fA-F]{4}(-)?[0-9a-fA-F]{4}(-)?[0-9a-fA-F]{12}`)
-	pats.ULIDs = regexp.MustCompile(`(?i)[0-7][0-9A-HJKMNP-TV-Z]{25}`)
 	pats.IDs = regexp.MustCompile(`\/(\d+)`)
 
 	for _, pattern := range gw.GetConfig().AnalyticsConfig.NormaliseUrls.Custom {
@@ -237,10 +236,6 @@ func NormalisePath(a *analytics.AnalyticsRecord, globalConfig *config.Config) {
 
 	if globalConfig.AnalyticsConfig.NormaliseUrls.NormaliseUUIDs {
 		a.Path = globalConfig.AnalyticsConfig.NormaliseUrls.CompiledPatternSet.UUIDs.ReplaceAllString(a.Path, "{uuid}")
-	}
-
-	if globalConfig.AnalyticsConfig.NormaliseUrls.NormaliseULIDs {
-		a.Path = globalConfig.AnalyticsConfig.NormaliseUrls.CompiledPatternSet.ULIDs.ReplaceAllString(a.Path, "{ulid}")
 	}
 
 	if globalConfig.AnalyticsConfig.NormaliseUrls.NormaliseNumbers {

--- a/gateway/analytics_test.go
+++ b/gateway/analytics_test.go
@@ -551,7 +551,6 @@ func TestURLReplacer(t *testing.T) {
 	ts := StartTest(func(globalConf *config.Config) {
 		globalConf.AnalyticsConfig.NormaliseUrls.Enabled = true
 		globalConf.AnalyticsConfig.NormaliseUrls.NormaliseUUIDs = true
-		globalConf.AnalyticsConfig.NormaliseUrls.NormaliseULIDs = true
 		globalConf.AnalyticsConfig.NormaliseUrls.NormaliseNumbers = true
 		globalConf.AnalyticsConfig.NormaliseUrls.Custom = []string{"ihatethisstring"}
 	})
@@ -562,9 +561,6 @@ func TestURLReplacer(t *testing.T) {
 	recordUUID2 := analytics.AnalyticsRecord{Path: "/CA761232-ED42-11CE-BACD-00AA0057B223/search"}
 	recordUUID3 := analytics.AnalyticsRecord{Path: "/ca761232-ed42-11ce-BAcd-00aa0057b223/search"}
 	recordUUID4 := analytics.AnalyticsRecord{Path: "/ca761232-ed42-11ce-BAcd-00aa0057b223/search"}
-	recordULID1 := analytics.AnalyticsRecord{Path: "/posts/01G9HHNKWGBHCQX7VG3JKSZ055/comments"}
-	recordULID2 := analytics.AnalyticsRecord{Path: "/posts/01g9hhnkwgbhcqx7vg3jksz055/comments"}
-	recordULID3 := analytics.AnalyticsRecord{Path: "/posts/01g9HHNKwgbhcqx7vg3JKSZ055/comments"}
 	recordID1 := analytics.AnalyticsRecord{Path: "/widgets/123456/getParams"}
 	recordCust := analytics.AnalyticsRecord{Path: "/widgets/123456/getParams/ihatethisstring"}
 
@@ -575,9 +571,6 @@ func TestURLReplacer(t *testing.T) {
 	NormalisePath(&recordUUID2, &globalConf)
 	NormalisePath(&recordUUID3, &globalConf)
 	NormalisePath(&recordUUID4, &globalConf)
-	NormalisePath(&recordULID1, &globalConf)
-	NormalisePath(&recordULID2, &globalConf)
-	NormalisePath(&recordULID3, &globalConf)
 	NormalisePath(&recordID1, &globalConf)
 	NormalisePath(&recordCust, &globalConf)
 
@@ -602,10 +595,6 @@ func TestURLReplacer(t *testing.T) {
 		t.Error(recordUUID4.Path)
 	}
 
-	assert.Equal(t, "/posts/{ulid}/comments", recordULID1.Path, "Path not altered, is: ", recordULID1.Path)
-	assert.Equal(t, "/posts/{ulid}/comments", recordULID2.Path, "Path not altered, is: ", recordULID2.Path)
-	assert.Equal(t, "/posts/{ulid}/comments", recordULID3.Path, "Path not altered, is: ", recordULID3.Path)
-
 	if recordID1.Path != "/widgets/{id}/getParams" {
 		t.Error("Path not altered, is:")
 		t.Error(recordID1.Path)
@@ -622,7 +611,6 @@ func BenchmarkURLReplacer(b *testing.B) {
 	ts := StartTest(func(globalConf *config.Config) {
 		globalConf.AnalyticsConfig.NormaliseUrls.Enabled = true
 		globalConf.AnalyticsConfig.NormaliseUrls.NormaliseUUIDs = true
-		globalConf.AnalyticsConfig.NormaliseUrls.NormaliseULIDs = true
 		globalConf.AnalyticsConfig.NormaliseUrls.NormaliseNumbers = true
 		globalConf.AnalyticsConfig.NormaliseUrls.Custom = []string{"ihatethisstring"}
 	})
@@ -637,9 +625,6 @@ func BenchmarkURLReplacer(b *testing.B) {
 		recordUUID2 := analytics.AnalyticsRecord{Path: "/CA761232-ED42-11CE-BACD-00AA0057B223/search"}
 		recordUUID3 := analytics.AnalyticsRecord{Path: "/ca761232-ed42-11ce-BAcd-00aa0057b223/search"}
 		recordUUID4 := analytics.AnalyticsRecord{Path: "/ca761232-ed42-11ce-BAcd-00aa0057b223/search"}
-		recordULID1 := analytics.AnalyticsRecord{Path: "/posts/01G9HHNKWGBHCQX7VG3JKSZ055/comments"}
-		recordULID2 := analytics.AnalyticsRecord{Path: "/posts/01g9hhnkwgbhcqx7vg3jksz055/comments"}
-		recordULID3 := analytics.AnalyticsRecord{Path: "/posts/01g9HHNKwgbhcqx7vg3JKSZ055/comments"}
 		recordID1 := analytics.AnalyticsRecord{Path: "/widgets/123456/getParams"}
 		recordCust := analytics.AnalyticsRecord{Path: "/widgets/123456/getParams/ihatethisstring"}
 
@@ -647,9 +632,6 @@ func BenchmarkURLReplacer(b *testing.B) {
 		NormalisePath(&recordUUID2, &globalConf)
 		NormalisePath(&recordUUID3, &globalConf)
 		NormalisePath(&recordUUID4, &globalConf)
-		NormalisePath(&recordULID1, &globalConf)
-		NormalisePath(&recordULID2, &globalConf)
-		NormalisePath(&recordULID3, &globalConf)
 		NormalisePath(&recordID1, &globalConf)
 		NormalisePath(&recordCust, &globalConf)
 	}


### PR DESCRIPTION
Reverts TykTechnologies/tyk#5590 temporarily, moving it from 5.2.2 into 5.2.3