### PR TITLE
[TT-3388] do not add cert to clientCA if it's just a public key(not a valid certificate)

### DIFF
--- a/certs/manager.go
+++ b/certs/manager.go
@@ -181,6 +181,10 @@ func publicKey(priv interface{}) interface{} {
 	}
 }
 
+func IsPublicKey(cert *tls.Certificate) bool {
+	return cert.Leaf != nil && strings.HasPrefix(cert.Leaf.Subject.CommonName, "Public Key: ")
+}
+
 func ParsePEMCertificate(data []byte, secret string) (*tls.Certificate, error) {
 	var cert tls.Certificate
 
@@ -595,7 +599,7 @@ func (c *certificateManager) CertPool(certIDs []string) *x509.CertPool {
 	pool := x509.NewCertPool()
 
 	for _, cert := range c.List(certIDs, CertificatePublic) {
-		if cert != nil {
+		if cert != nil && !IsPublicKey(cert) {
 			pool.AddCert(cert.Leaf)
 		}
 	}

--- a/certs/manager.go
+++ b/certs/manager.go
@@ -209,7 +209,7 @@ func ParsePEMCertificate(data []byte, secret string) (*tls.Certificate, error) {
 		if block.Type == "PUBLIC KEY" {
 			// Create a dummny cert just for listing purpose
 			cert.Certificate = append(cert.Certificate, block.Bytes)
-			cert.Leaf = tykcrypto.WrapPublicKeyInDummyX509Cert(block.Bytes)
+			cert.Leaf = tykcrypto.PrefixPublicKeyCommonName(block.Bytes)
 		}
 	}
 

--- a/certs/manager.go
+++ b/certs/manager.go
@@ -209,7 +209,7 @@ func ParsePEMCertificate(data []byte, secret string) (*tls.Certificate, error) {
 		if block.Type == "PUBLIC KEY" {
 			// Create a dummny cert just for listing purpose
 			cert.Certificate = append(cert.Certificate, block.Bytes)
-			cert.Leaf = &x509.Certificate{Subject: pkix.Name{CommonName: "Public Key: " + tykcrypto.HexSHA256(block.Bytes)}}
+			cert.Leaf = tykcrypto.WrapPublicKeyInDummyX509Cert(block.Bytes)
 		}
 	}
 

--- a/certs/manager.go
+++ b/certs/manager.go
@@ -181,6 +181,7 @@ func publicKey(priv interface{}) interface{} {
 	}
 }
 
+// IsPublicKey verifies if given certificate is a public key only.
 func IsPublicKey(cert *tls.Certificate) bool {
 	return cert.Leaf != nil && strings.HasPrefix(cert.Leaf.Subject.CommonName, "Public Key: ")
 }

--- a/certs/manager.go
+++ b/certs/manager.go
@@ -181,11 +181,6 @@ func publicKey(priv interface{}) interface{} {
 	}
 }
 
-// IsPublicKey verifies if given certificate is a public key only.
-func IsPublicKey(cert *tls.Certificate) bool {
-	return cert.Leaf != nil && strings.HasPrefix(cert.Leaf.Subject.CommonName, "Public Key: ")
-}
-
 func ParsePEMCertificate(data []byte, secret string) (*tls.Certificate, error) {
 	var cert tls.Certificate
 
@@ -600,7 +595,7 @@ func (c *certificateManager) CertPool(certIDs []string) *x509.CertPool {
 	pool := x509.NewCertPool()
 
 	for _, cert := range c.List(certIDs, CertificatePublic) {
-		if cert != nil && !IsPublicKey(cert) {
+		if cert != nil && !tykcrypto.IsPublicKey(cert) {
 			pool.AddCert(cert.Leaf)
 		}
 	}

--- a/gateway/cert.go
+++ b/gateway/cert.go
@@ -418,7 +418,7 @@ func (gw *Gateway) getTLSConfigForClient(baseConfig *tls.Config, listenPort int)
 					certIDs := append(spec.ClientCertificates, gwConfig.Security.Certificates.API...)
 
 					for _, cert := range gw.CertificateManager.List(certIDs, certs.CertificatePublic) {
-						if cert != nil && !certs.IsPublicKey(cert) {
+						if cert != nil && !crypto.IsPublicKey(cert) {
 							newConfig.ClientCAs.AddCert(cert.Leaf)
 						}
 					}

--- a/gateway/cert.go
+++ b/gateway/cert.go
@@ -418,7 +418,7 @@ func (gw *Gateway) getTLSConfigForClient(baseConfig *tls.Config, listenPort int)
 					certIDs := append(spec.ClientCertificates, gwConfig.Security.Certificates.API...)
 
 					for _, cert := range gw.CertificateManager.List(certIDs, certs.CertificatePublic) {
-						if cert != nil {
+						if cert != nil && !certs.IsPublicKey(cert) {
 							newConfig.ClientCAs.AddCert(cert.Leaf)
 						}
 					}

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -1613,7 +1613,7 @@ func TestStaticMTLSAPI(t *testing.T) {
 
 	generatePublicKey := func() []byte {
 		// Generate a private key.
-		priv, _ := rsa.GenerateKey(rand.Reader, 1024)
+		priv, _ := rsa.GenerateKey(rand.Reader, 2048)
 
 		// Derive the public key from the private key.
 		publicKey := &priv.PublicKey

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -1611,7 +1611,8 @@ func TestStaticMTLSAPI(t *testing.T) {
 		return ts, clientCertID, clientCert
 	}
 
-	generatePublicKey := func() []byte {
+	generatePublicKey := func(tb testing.TB) []byte {
+		tb.Helper()
 		// Generate a private key.
 		priv, _ := rsa.GenerateKey(rand.Reader, 2048)
 

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -1708,7 +1708,7 @@ func TestStaticMTLSAPI(t *testing.T) {
 		defer ctrl.Finish()
 
 		// generate a public key
-		publicKeyPEM := generatePublicKey()
+		publicKeyPEM := generatePublicKey(t)
 
 		certID, err := ts.Gw.CertificateManager.Add(publicKeyPEM, "")
 		assert.NoError(t, err)

--- a/internal/crypto/helpers.go
+++ b/internal/crypto/helpers.go
@@ -126,8 +126,9 @@ func IsPublicKey(cert *tls.Certificate) bool {
 	return cert.Leaf != nil && strings.HasPrefix(cert.Leaf.Subject.CommonName, "Public Key: ")
 }
 
-// WrapPublicKeyInDummyX509Cert wraps given blockBytes in x509.Certificate with CommonName prefixed with `Public Key:`.
-func WrapPublicKeyInDummyX509Cert(blockBytes []byte) *x509.Certificate {
+// PrefixPublicKeyCommonName returns x509.Certificate with prefixed CommonName.
+// This is used in UI/response to hint the type certificate during listing.
+func PrefixPublicKeyCommonName(blockBytes []byte) *x509.Certificate {
 	return &x509.Certificate{
 		Subject: pkix.Name{
 			CommonName: "Public Key: " + HexSHA256(blockBytes),

--- a/internal/crypto/helpers.go
+++ b/internal/crypto/helpers.go
@@ -13,6 +13,7 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -114,4 +115,9 @@ func ValidateRequestCerts(r *http.Request, certs []*tls.Certificate) error {
 	}
 
 	return errors.New("Certificate with SHA256 " + certID + " not allowed")
+}
+
+// IsPublicKey verifies if given certificate is a public key only.
+func IsPublicKey(cert *tls.Certificate) bool {
+	return cert.Leaf != nil && strings.HasPrefix(cert.Leaf.Subject.CommonName, "Public Key: ")
 }

--- a/internal/crypto/helpers.go
+++ b/internal/crypto/helpers.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/hex"
 	"encoding/pem"
 	"errors"
@@ -120,4 +121,9 @@ func ValidateRequestCerts(r *http.Request, certs []*tls.Certificate) error {
 // IsPublicKey verifies if given certificate is a public key only.
 func IsPublicKey(cert *tls.Certificate) bool {
 	return cert.Leaf != nil && strings.HasPrefix(cert.Leaf.Subject.CommonName, "Public Key: ")
+}
+
+// WrapPublicKeyInDummyX509Cert wraps given blockBytes in x509.Certificate with CommonName prefixed with `Public Key: `
+func WrapPublicKeyInDummyX509Cert(blockBytes []byte) *x509.Certificate {
+	return &x509.Certificate{Subject: pkix.Name{CommonName: "Public Key: " + HexSHA256(blockBytes)}}
 }

--- a/internal/crypto/helpers.go
+++ b/internal/crypto/helpers.go
@@ -126,9 +126,13 @@ func IsPublicKey(cert *tls.Certificate) bool {
 	return cert.Leaf != nil && strings.HasPrefix(cert.Leaf.Subject.CommonName, "Public Key: ")
 }
 
-// WrapPublicKeyInDummyX509Cert wraps given blockBytes in x509.Certificate with CommonName prefixed with `Public Key: `
+// WrapPublicKeyInDummyX509Cert wraps given blockBytes in x509.Certificate with CommonName prefixed with `Public Key:`.
 func WrapPublicKeyInDummyX509Cert(blockBytes []byte) *x509.Certificate {
-	return &x509.Certificate{Subject: pkix.Name{CommonName: "Public Key: " + HexSHA256(blockBytes)}}
+	return &x509.Certificate{
+		Subject: pkix.Name{
+			CommonName: "Public Key: " + HexSHA256(blockBytes),
+		},
+	}
 }
 
 // GenerateRSAPublicKey generates an RSA public key.

--- a/internal/crypto/helpers_test.go
+++ b/internal/crypto/helpers_test.go
@@ -5,6 +5,8 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIsPublicKey(t *testing.T) {
@@ -36,4 +38,9 @@ func TestIsPublicKey(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGenerateRSAPublicKey(t *testing.T) {
+	pubKey := GenerateRSAPublicKey(t)
+	assert.Contains(t, string(pubKey), "PUBLIC KEY")
 }

--- a/internal/crypto/helpers_test.go
+++ b/internal/crypto/helpers_test.go
@@ -27,7 +27,7 @@ func TestIsPublicKey(t *testing.T) {
 		},
 		{
 			name: "public key",
-			cert: &tls.Certificate{Leaf: WrapPublicKeyInDummyX509Cert([]byte("dummy-value"))},
+			cert: &tls.Certificate{Leaf: PrefixPublicKeyCommonName([]byte("dummy-value"))},
 			want: true,
 		},
 	}

--- a/internal/crypto/helpers_test.go
+++ b/internal/crypto/helpers_test.go
@@ -1,0 +1,39 @@
+package crypto
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"testing"
+)
+
+func TestIsPublicKey(t *testing.T) {
+	tests := []struct {
+		name string
+		cert *tls.Certificate
+		want bool
+	}{
+		{
+			name: "nil leaf",
+			cert: &tls.Certificate{Leaf: nil},
+			want: false,
+		},
+		{
+			name: "non public key",
+			cert: &tls.Certificate{Leaf: &x509.Certificate{Subject: pkix.Name{CommonName: "Non-Public Key: "}}},
+			want: false,
+		},
+		{
+			name: "public key",
+			cert: &tls.Certificate{Leaf: WrapPublicKeyInDummyX509Cert([]byte("dummy-value"))},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsPublicKey(tt.cert); got != tt.want {
+				t.Errorf("IsPublicKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

do not add cert to clientCA if it's just a public key(not a valid certificate)

https://github.com/TykTechnologies/tyk/blob/de4e811e2a3c959d7bd2431c50e0470264303107/certs/manager.go#L209 
During certificate listing, if the add cert entity is a just a public key and not a certificate, gateway currently adds a dummy certificate to it's leaf. This causes any TLS connections to the gateway to be broken since this dummy certificate would be used during client CA announcement. This PR changes it such that to skip the public key from being announced during handshake.


<!-- Describe your changes in detail -->

## Related Issue
https://tyktech.atlassian.net/browse/TT-3388

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
