### PR TITLE
[TT-10180] Update readme with go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,8 @@ go build
 ```
 
 
-Go version 1.12 is required to build `master`, the current development version. Tyk is officially supported on `linux/amd64`, `linux/i386` and `linux/arm64`.
+Go version 1.16 is required to build `master`, the current development version. Tyk is officially supported on `linux/amd64`, `linux/i386` and `linux/arm64`.
 
-Tests are run against both Go versions 1.12, 1.13, 1.14 and 1.15, however at present, only Go 1.12 is officially supported.
 In order to run tests locally use the following command:
 
 ```


### PR DESCRIPTION
Updated the Go version in the readme for 5-lts (to Go 1.16)
