### PR TITLE
Merging to release-5.2: Adjust branch targets for plugin compiler (#5622)

### DIFF
--- a/.github/workflows/plugin-compiler-build.yml
+++ b/.github/workflows/plugin-compiler-build.yml
@@ -4,6 +4,9 @@ name: Plugin-compiler build
 on:
   pull_request:
   push:
+    branches:
+      - master
+      - release-**
     tags:
       - 'v*'
 


### PR DESCRIPTION
Adjust branch targets for plugin compiler (#5622)

Plugin compiler build required for smoke tests

Co-authored-by: Tit Petric <tit@tyk.io>