### PR TITLE
Merging to release-5.2: Update deprecated field note for service discovery cache (#5612)

### DIFF
--- a/apidef/oas/schema/x-tyk-gateway.md
+++ b/apidef/oas/schema/x-tyk-gateway.md
@@ -193,7 +193,7 @@ Tyk classic API definition: `service_discovery.use_target_list`.
 **Field: `cacheTimeout` (`int`)**
 CacheTimeout is the timeout of a cache value when a new data is loaded from a discovery service.
 Setting it too low will cause Tyk to call the SD service too often, setting it too high could mean that failures are not recovered from quickly enough.
-Deprecated: The field is deprecated, usage needs to be updated to configure caching.
+Deprecated: The field is deprecated. Use `service_discovery` to configure service discovery cache options.
 
 Tyk classic API definition: `service_discovery.cache_timeout`.
 

--- a/apidef/oas/upstream.go
+++ b/apidef/oas/upstream.go
@@ -187,7 +187,7 @@ type ServiceDiscovery struct {
 	// Setting it too low will cause Tyk to call the SD service too often, setting it too high could mean that
 	// failures are not recovered from quickly enough.
 	//
-	// Deprecated: The field is deprecated, usage needs to be updated to configure caching.
+	// Deprecated: The field is deprecated. Use `service_discovery` to configure service discovery cache options.
 	//
 	// Tyk classic API definition: `service_discovery.cache_timeout`
 	CacheTimeout int64 `bson:"cacheTimeout,omitempty" json:"cacheTimeout,omitempty"`


### PR DESCRIPTION
Update deprecated field note for service discovery cache (#5612)

Co-authored-by: Tit Petric <tit@tyk.io>