### PR TITLE
[TT-9894]: Fix response transform and persisted query on 5lts

### DIFF
--- a/gateway/mw_persist_graphql_operation.go
+++ b/gateway/mw_persist_graphql_operation.go
@@ -46,6 +46,8 @@ func (i *PersistGraphQLOperationMiddleware) ProcessRequest(w http.ResponseWriter
 		return nil, http.StatusOK
 	}
 	mwSpec, _ := meta.(*apidef.PersistGraphQLMeta)
+
+	ctxSetRequestMethod(r, r.Method)
 	r.Method = http.MethodPost
 
 	_, err := io.ReadAll(r.Body)
@@ -96,6 +98,7 @@ func (i *PersistGraphQLOperationMiddleware) ProcessRequest(w http.ResponseWriter
 	nopCloseRequestBody(r)
 
 	r.Header.Set("Content-Type", "application/json")
+	ctxSetUrlRewritePath(r, r.URL.Path)
 	r.URL.Path = "/"
 
 	return nil, http.StatusOK

--- a/gateway/mw_persist_graphql_operation_test.go
+++ b/gateway/mw_persist_graphql_operation_test.go
@@ -1,7 +1,10 @@
 package gateway
 
 import (
+	"bytes"
+	"encoding/base64"
 	"encoding/json"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -381,5 +384,61 @@ func TestGraphqlPersist_MultipleVersions(t *testing.T) {
 			return testResp.Body == string(gqlRequestContinent)
 		}},
 	)
+	assert.NoError(t, err)
+}
+
+func TestGraphQLPersist_TransformResponse(t *testing.T) {
+	// See TT-9227
+	ts := StartTest(nil)
+	t.Cleanup(func() {
+		ts.Close()
+	})
+	expectedResponse := "{\"test\": \"response\"}"
+	templateSource := base64.StdEncoding.EncodeToString([]byte(expectedResponse))
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "gql-rest"
+		spec.OrgID = "default"
+		spec.Proxy.ListenPath = "/gql-rest/"
+		spec.Proxy.TargetURL = TestHttpAny
+		spec.EnableContextVars = true
+		spec.VersionData.NotVersioned = false
+		spec.VersionData.Versions["Default"] = apidef.VersionInfo{
+			Name:             "Default",
+			Expires:          "3000-01-02 00:00",
+			UseExtendedPaths: true,
+			ExtendedPaths: apidef.ExtendedPathsSet{
+				TransformResponse: []apidef.TemplateMeta{
+					{
+						Disabled: false,
+						TemplateData: apidef.TemplateData{
+							Input:          apidef.RequestJSON,
+							Mode:           apidef.UseBlob,
+							EnableSession:  false,
+							TemplateSource: templateSource,
+						},
+						Path:   "/getCountryByCode/{countryCode}",
+						Method: http.MethodGet,
+					},
+				},
+				PersistGraphQL: []apidef.PersistGraphQLMeta{
+					{
+						Path:      "/getCountryByCode/{countryCode}",
+						Method:    "GET",
+						Operation: testGQLQueryCountryCode,
+						Variables: map[string]interface{}{
+							"countryCode": "$path.countryCode",
+						},
+					},
+				},
+			},
+		}
+	})
+
+	_, err := ts.Run(t,
+		test.TestCase{Path: "/gql-rest/getCountryByCode/NG", Method: "GET", BodyMatchFunc: func(body []byte) bool {
+			return bytes.Equal(body, []byte(expectedResponse))
+		}},
+	)
+
 	assert.NoError(t, err)
 }

--- a/gateway/mw_persist_graphql_operation_test.go
+++ b/gateway/mw_persist_graphql_operation_test.go
@@ -400,6 +400,11 @@ func TestGraphQLPersist_TransformResponse(t *testing.T) {
 		spec.OrgID = "default"
 		spec.Proxy.ListenPath = "/gql-rest/"
 		spec.Proxy.TargetURL = TestHttpAny
+		spec.ResponseProcessors = []apidef.ResponseProcessor{
+			{
+				Name: "response_body_transform",
+			},
+		}
 		spec.EnableContextVars = true
 		spec.VersionData.NotVersioned = false
 		spec.VersionData.Versions["Default"] = apidef.VersionInfo{


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->
[TT-9894](https://tyktech.atlassian.net/browse/TT-9894)

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


[TT-9894]: https://tyktech.atlassian.net/browse/TT-9894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ