### PR TITLE
SYSE-274/Change tag policy for ci images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,8 +135,8 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=sha,format=long
-            type=semver,pattern=v{{major}}.{{minor}}
-            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}},prefix=v
+            type=semver,pattern=v{{version}},prefix=v
 
       - name: CI push
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,8 +134,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha
-            type=sha,format=long,prefix=
+            type=sha,format=long
             type=semver,pattern=v{{major}}.{{minor}}
             type=semver,pattern=v{{version}}
 


### PR DESCRIPTION
This PR is aimed to rework the tag for CI images, so repo can be clean out by using policy based on prefixes