### PR TITLE
remove x/net/context, in stdlib since 1.7

### DIFF
--- a/gateway/coprocess_grpc.go
+++ b/gateway/coprocess_grpc.go
@@ -1,13 +1,13 @@
 package gateway
 
 import (
+	"context"
 	"errors"
 	"net"
 	"net/url"
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	"github.com/TykTechnologies/tyk/apidef"

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/binary"
@@ -34,7 +35,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
-	"golang.org/x/net/context"
 
 	"github.com/TykTechnologies/tyk/internal/httputil"
 	"github.com/TykTechnologies/tyk/internal/otel"


### PR DESCRIPTION
> As of Go 1.7 this package is available in the standard library under the name context.

https://pkg.go.dev/golang.org/x/net/context