### PR TITLE
propagate context to internal data source (TT-10185)

### DIFF
--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -941,7 +941,10 @@ func createMemConnProviderIfNeeded(handler http.Handler, r *http.Request) error 
 	// start http server with in mem listener
 	// Note: do not try to use http.Server it is working only with mux
 	mux := http.NewServeMux()
-	mux.Handle("/", handler)
+	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, wrappingHandlerReq *http.Request) {
+		reqWithPropagatedContext := wrappingHandlerReq.WithContext(r.Context())
+		handler.ServeHTTP(w, reqWithPropagatedContext)
+	}))
 
 	go func() { _ = http.Serve(lis, mux) }()
 

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -1801,3 +1801,29 @@ func TestSetCustomHeaderMultipleValues(t *testing.T) {
 		})
 	}
 }
+
+func TestCreateMemConnProviderIfNeeded(t *testing.T) {
+	t.Run("should propagate context", func(t *testing.T) {
+		propagationContext := context.WithValue(context.Background(), "parentContextKey", "parentContextValue")
+		propagationContextWithCancel, cancel := context.WithCancel(propagationContext)
+		internalReq, err := http.NewRequest(http.MethodGet, "http://memoryhost/", nil)
+		require.NoError(t, err)
+
+		handler := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			assert.Equal(t, "parentContextValue", req.Context().Value("parentContextKey"))
+			cancel()
+		})
+
+		err = createMemConnProviderIfNeeded(handler, internalReq.WithContext(propagationContextWithCancel))
+		require.NoError(t, err)
+
+		assert.Eventuallyf(t, func() bool {
+			testReq, err := http.NewRequest(http.MethodGet, "http://memoryhost/", nil)
+			require.NoError(t, err)
+			_, err = memConnClient.Do(testReq)
+			require.NoError(t, err)
+			<-propagationContextWithCancel.Done()
+			return true
+		}, time.Second, time.Millisecond*25, "context was not canceled")
+	})
+}


### PR DESCRIPTION
This PR allows propagation of contextx for internal APIs / Data Sources.
It improves traces for open telemetry.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)