### PR TITLE
Merging to release-5.2.2: [10308] Hide expected signature from logs in HMAC (#5648)

### DIFF
--- a/gateway/mw_http_signature_validation.go
+++ b/gateway/mw_http_signature_validation.go
@@ -184,8 +184,7 @@ func (hm *HTTPSignatureValidationMiddleware) ProcessRequest(w http.ResponseWrite
 
 		if !matchPass {
 			logger.WithFields(logrus.Fields{
-				"expected": encodedSignature,
-				"got":      fieldValues.Signature,
+				"got": fieldValues.Signature,
 			}).Error("Signature string does not match!")
 			return hm.authorizationError(r)
 		}


### PR DESCRIPTION
[10308] Hide expected signature from logs in HMAC (#5648)

This PR removes the expected HMAC signature from the logs which are
printed when there is a mismatch.