### PR TITLE
Merging to release-4-lts: [TT-10329] fix getargspec removal from python stdlib in 3.11 (deprecated since python 3.0) (#5664)

### DIFF
--- a/coprocess/python/tyk/decorators.py
+++ b/coprocess/python/tyk/decorators.py
@@ -1,4 +1,4 @@
-from inspect import getargspec
+from inspect import getfullargspec
 
 
 class HandlerDecorator(object):
@@ -14,7 +14,7 @@ class Hook(object):
     def __init__(self, f):
         self.name = f.__name__
         self.f = f
-        self.arg_count = len(getargspec(f)[0])
+        self.arg_count = len(getfullargspec(f)[0])
 
     def __call__(self, *args, **kwargs):
         if self.arg_count == 3:


### PR DESCRIPTION
[TT-10329] fix getargspec removal from python stdlib in 3.11 (deprecated since python 3.0) (#5664)

https://tyktech.atlassian.net/browse/TT-10329

---------

Co-authored-by: Tit Petric <tit@tyk.io>

[TT-10329]: https://tyktech.atlassian.net/browse/TT-10329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ