### PR TITLE
Merging to release-5-lts: TT-10069 when pulling keys from RPC check if we have connectivity (#5643)

### DIFF
--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -214,6 +214,10 @@ func (r *RPCStorageHandler) GetRawKey(keyName string) (string, error) {
 		}
 	}
 
+	if rpc.IsEmergencyMode() {
+		return "", storage.ErrMDCBConnectionLost
+	}
+
 	value, err := rpc.FuncClientSingleton("GetKey", keyName)
 	if err != nil {
 		rpc.EmitErrorEventKv(

--- a/storage/mdcb_storage.go
+++ b/storage/mdcb_storage.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 )
@@ -35,7 +36,8 @@ func (m MdcbStorage) GetKey(key string) (string, error) {
 		val, err = m.rpc.GetKey(key)
 
 		if err != nil {
-			m.logger.Error("cannot retrieve key from rpc:" + err.Error())
+			resourceType := getResourceType(key)
+			m.logger.Errorf("cannot retrieve %v from rpc: %v", resourceType, err.Error())
 			return val, err
 		}
 
@@ -48,6 +50,19 @@ func (m MdcbStorage) GetKey(key string) (string, error) {
 	}
 
 	return val, err
+}
+
+func getResourceType(key string) string {
+	switch {
+	case strings.Contains(key, "oauth-clientid."):
+		return "Oauth Client"
+	case strings.HasPrefix(key, "cert"):
+		return "certificate"
+	case strings.HasPrefix(key, "apikey"):
+		return "api key"
+	default:
+		return "key"
+	}
 }
 
 func (m MdcbStorage) GetMultiKey([]string) ([]string, error) {

--- a/storage/mdcb_storage_test.go
+++ b/storage/mdcb_storage_test.go
@@ -1,0 +1,24 @@
+package storage
+
+import "testing"
+
+func TestGetResourceType(t *testing.T) {
+	tests := []struct {
+		key      string
+		expected string
+	}{
+		{"oauth-clientid.client-id", "Oauth Client"},
+		{"cert.something", "certificate"},
+		{"apikey.something", "api key"},
+		{"unmatched-key", "key"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			got := getResourceType(tt.key)
+			if got != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, got)
+			}
+		})
+	}
+}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -22,6 +22,8 @@ var log = logger.Get()
 // ErrKeyNotFound is a standard error for when a key is not found in the storage engine
 var ErrKeyNotFound = errors.New("key not found")
 
+var ErrMDCBConnectionLost = errors.New("mdcb connection is lost")
+
 // Handler is a standard interface to a storage backend, used by
 // AuthorisationManager to read and write key values to the backend
 type Handler interface {


### PR DESCRIPTION
TT-10069 when pulling keys from RPC check if we have connectivity (#5643)

<!-- Provide a general summary of your changes in the Title above -->

## Description

When attempting to pull a key from RPC check if the gateway has
connectivity, otherwise do not try and return the proper err msg. Also
when a rpc-key is not pulled we display what kind of key is it: oauth
client, api key, certificate, it defaults to the word "key"

## Related Issue

https://tyktech.atlassian.net/browse/TT-10069

## Motivation and Context

Give solution to https://tyktech.atlassian.net/browse/TT-10069

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why