### PR TITLE
Merging to release-5.2: [TT-10362] Update python autodetect regexp to accept 2 digit minor (#5683)

### DIFF
--- a/dlpython/main.go
+++ b/dlpython/main.go
@@ -31,7 +31,7 @@ var (
 	errLibLoad        = errors.New("Couldn't load library")
 	errOSNotSupported = errors.New("OS not supported")
 
-	pythonExpr = regexp.MustCompile(`(^python3(\.)?(\d)?(m)?(\-config)?$)`)
+	pythonExpr = regexp.MustCompile(`(^python3(\.)?(\d+)?(m)?(\-config)?$)`)
 
 	pythonConfigPath  string
 	pythonLibraryPath string


### PR DESCRIPTION
[TT-10362] Update python autodetect regexp to accept 2 digit minor (#5683)

<!-- Provide a general summary of your changes in the Title above -->

## Description

Update regexp to autodetect python version

## Related Issue
https://tyktech.atlassian.net/browse/TT-10362

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why

[TT-10362]: https://tyktech.atlassian.net/browse/TT-10362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ