### PR TITLE
[SYSE-15]: Change smoke tests back to split approach

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -407,21 +407,15 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
         with:
           mask-password: 'true'
+
       - name: Run ci/tests
         shell: bash
-        env:        
+        env:
           GITHUB_TAG: ${{ github.ref }}
           GATEWAY_IMAGE: ${{ steps.ecr.outputs.registry }}/tyk:sha-${{ github.sha }}
           PLUGIN_COMPILER_IMAGE: ${{ steps.ecr.outputs.registry }}/tyk-plugin-compiler:sha-${{ github.sha }}
         run: |
           set -eaxo pipefail
-          if [ ! -d smoke-tests ]; then
-             echo "::warning No repo specific smoke tests defined"
-          fi
-          if [ ! -d ci/tests ]; then
-             echo "::warning No ci tests defined"
-             exit 0
-          fi
           for d in ci/tests/*/
           do
               echo Attempting to test $d
@@ -431,6 +425,23 @@ jobs:
                   cd -
               fi
           done
+      - name: Run smoke-tests
+
+        # This job only runs whenever a tag is created. A tag is required
+        # for a functional plugin compiler build for when the GO_GET=1 env
+        # is provided. The plugin compiler cannot fetch the referenced
+        # commit from a PR, but requires a /heads or /tags reference.
+        #
+        # See https://github.com/golang/go/issues/31191 for more info.
+
+        if: startsWith(github.ref, 'refs/tags')
+        shell: bash
+        env:
+          GITHUB_TAG: ${{ github.ref }}
+          GATEWAY_IMAGE: ${{ steps.ecr.outputs.registry }}/tyk:sha-${{ github.sha }}
+          PLUGIN_COMPILER_IMAGE: ${{ steps.ecr.outputs.registry }}/tyk-plugin-compiler:sha-${{ github.sha }}
+        run: |
+          set -eaxo pipefail
           for d in smoke-tests/*/
           do
               echo Attempting to test $d


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

The template changes in https://github.com/TykTechnologies/tyk/pull/5681 caused changes in the updated smoke test workflow by unifying the split running of `ci/tests/` and `smoke-tests`.
This PR reverts it.
