### PR TITLE
Merging to release-5-lts: [TT-10370] Alias imports (#5691)

### DIFF
--- a/gateway/analytics.go
+++ b/gateway/analytics.go
@@ -2,7 +2,7 @@ package gateway
 
 import (
 	"fmt"
-	"math/rand"
+	mathRand "math/rand"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -140,14 +140,14 @@ func (r *RedisAnalyticsHandler) recordWorker() {
 	// this is buffer to send one pipelined command to redis
 	// use r.recordsBufferSize as cap to reduce slice re-allocations
 	recordsBuffer := make([][]byte, 0, r.workerBufferSize)
-	rand.Seed(time.Now().Unix())
+	mathRand.Seed(time.Now().Unix())
 
 	// read records from channel and process
 	lastSentTs := time.Now()
 	for {
 		analyticKey := analyticsKeyName
 		if r.enableMultipleAnalyticsKeys {
-			suffix := rand.Intn(10)
+			suffix := mathRand.Intn(10)
 			analyticKey = fmt.Sprintf("%v_%v", analyticKey, suffix)
 		}
 		serliazerSuffix := r.analyticsSerializer.GetSuffix()

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"text/template"
+	textTemplate "text/template"
 	"time"
 
 	"github.com/getkin/kin-openapi/routers"
@@ -170,7 +170,7 @@ type EndPointCacheMeta struct {
 
 type TransformSpec struct {
 	apidef.TemplateMeta
-	Template *template.Template
+	Template *textTemplate.Template
 }
 
 type ExtendedCircuitBreakerMeta struct {
@@ -816,21 +816,21 @@ func (a APIDefinitionLoader) compileCachedPathSpec(oldpaths []string, newpaths [
 	return urlSpec
 }
 
-func (a APIDefinitionLoader) filterSprigFuncs() template.FuncMap {
+func (a APIDefinitionLoader) filterSprigFuncs() textTemplate.FuncMap {
 	tmp := sprig.GenericFuncMap()
 	delete(tmp, "env")
 	delete(tmp, "expandenv")
 
-	return template.FuncMap(tmp)
+	return textTemplate.FuncMap(tmp)
 }
 
-func (a APIDefinitionLoader) loadFileTemplate(path string) (*template.Template, error) {
+func (a APIDefinitionLoader) loadFileTemplate(path string) (*textTemplate.Template, error) {
 	log.Debug("-- Loading template: ", path)
 	tmpName := filepath.Base(path)
 	return apidef.Template.New(tmpName).Funcs(a.filterSprigFuncs()).ParseFiles(path)
 }
 
-func (a APIDefinitionLoader) loadBlobTemplate(blob string) (*template.Template, error) {
+func (a APIDefinitionLoader) loadBlobTemplate(blob string) (*textTemplate.Template, error) {
 	log.Debug("-- Loading blob")
 	uDec, err := base64.StdEncoding.DecodeString(blob)
 	if err != nil {

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"text/template"
+	textTemplate "text/template"
 	"time"
 
 	"github.com/TykTechnologies/tyk/apidef/oas"
@@ -1302,9 +1302,9 @@ func TestAPIDefinitionLoader(t *testing.T) {
 
 	l := APIDefinitionLoader{Gw: ts.Gw}
 
-	executeAndAssert := func(t *testing.T, template *template.Template) {
+	executeAndAssert := func(t *testing.T, tpl *textTemplate.Template) {
 		var bodyBuffer bytes.Buffer
-		err := template.Execute(&bodyBuffer, map[string]string{
+		err := tpl.Execute(&bodyBuffer, map[string]string{
 			"value1": "value-1",
 			"value2": "value-2",
 		})

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"text/template"
+	textTemplate "text/template"
 
 	"github.com/gorilla/mux"
 	"github.com/justinas/alice"
@@ -822,7 +822,7 @@ type generalStores struct {
 	redisStore, redisOrgStore, healthStore, rpcAuthStore, rpcOrgStore storage.Handler
 }
 
-var playgroundTemplate *template.Template
+var playgroundTemplate *textTemplate.Template
 
 func (gw *Gateway) readGraphqlPlaygroundTemplate() {
 	playgroundPath := filepath.Join(gw.GetConfig().TemplatePath, "playground")
@@ -838,7 +838,7 @@ func (gw *Gateway) readGraphqlPlaygroundTemplate() {
 		paths = append(paths, filepath.Join(playgroundPath, file.Name()))
 	}
 
-	playgroundTemplate, err = template.ParseFiles(paths...)
+	playgroundTemplate, err = textTemplate.ParseFiles(paths...)
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "playground",

--- a/gateway/event_handler_webhooks.go
+++ b/gateway/event_handler_webhooks.go
@@ -5,7 +5,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"encoding/json"
-	"html/template"
+	htmlTemplate "html/template"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -37,7 +37,7 @@ const (
 // WebHookHandler is an event handler that triggers web hooks
 type WebHookHandler struct {
 	conf     config.WebHookHandlerConf
-	template *template.Template // non-nil if Init is run without error
+	template *htmlTemplate.Template // non-nil if Init is run without error
 	store    storage.Handler
 
 	contentType      string
@@ -77,7 +77,7 @@ func (w *WebHookHandler) Init(handlerConf interface{}) error {
 
 	// Pre-load template on init
 	if w.conf.TemplatePath != "" {
-		w.template, err = template.ParseFiles(w.conf.TemplatePath)
+		w.template, err = htmlTemplate.ParseFiles(w.conf.TemplatePath)
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "webhooks",
@@ -98,7 +98,7 @@ func (w *WebHookHandler) Init(handlerConf interface{}) error {
 			"target": w.conf.TargetPath,
 		}).Info("Loading default template.")
 		defaultPath := filepath.Join(w.Gw.GetConfig().TemplatePath, "default_webhook.json")
-		w.template, err = template.ParseFiles(defaultPath)
+		w.template, err = htmlTemplate.ParseFiles(defaultPath)
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "webhooks",

--- a/gateway/grpc_streaming_client_test.go
+++ b/gateway/grpc_streaming_client_test.go
@@ -25,7 +25,7 @@ package gateway
 import (
 	"context"
 	"io"
-	"math/rand"
+	mathRand "math/rand"
 	"sync"
 	"testing"
 	"time"
@@ -89,7 +89,7 @@ func printFeatures(t *testing.T, client pb.RouteGuideClient, rect *pb.Rectangle)
 // runRecordRoute sends a sequence of points to server and expects to get a RouteSummary from server.
 func runRecordRoute(t *testing.T, client pb.RouteGuideClient) {
 	// Create a random number of random points
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	r := mathRand.New(mathRand.NewSource(time.Now().UnixNano()))
 	pointCount := int(r.Int31n(100)) + 2 // Traverse at least two points
 	var points []*pb.Point
 	for i := 0; i < pointCount; i++ {
@@ -178,7 +178,7 @@ func runRouteChat(t *testing.T, client pb.RouteGuideClient) {
 	t.Logf("grpc stream closed")
 }
 
-func randomPoint(r *rand.Rand) *pb.Point {
+func randomPoint(r *mathRand.Rand) *pb.Point {
 	lat := (r.Int31n(180) - 90) * 1e7
 	long := (r.Int31n(360) - 180) * 1e7
 	return &pb.Point{Latitude: lat, Longitude: long}

--- a/gateway/grpc_test.go
+++ b/gateway/grpc_test.go
@@ -27,7 +27,7 @@ import (
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	pb "google.golang.org/grpc/examples/helloworld/helloworld"
+	pbExample "google.golang.org/grpc/examples/helloworld/helloworld"
 
 	"github.com/TykTechnologies/tyk/test"
 	"github.com/TykTechnologies/tyk/user"
@@ -483,13 +483,13 @@ func TestGRPC_TokenBasedAuthentication(t *testing.T) {
 
 // server is used to implement helloworld.GreeterServer.
 type server struct {
-	pb.UnimplementedGreeterServer
+	pbExample.UnimplementedGreeterServer
 }
 
 // SayHello implements helloworld.GreeterServer
-func (s *server) SayHello(ctx context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
+func (s *server) SayHello(ctx context.Context, in *pbExample.HelloRequest) (*pbExample.HelloReply, error) {
 	log.Printf("Received: %v", in.Name)
-	return &pb.HelloReply{Message: "Hello " + in.Name}, nil
+	return &pbExample.HelloReply{Message: "Hello " + in.Name}, nil
 }
 
 func startGRPCServerH2C(t *testing.T, fn func(*testing.T, *grpc.Server)) (net.Listener, *grpc.Server) {
@@ -553,7 +553,7 @@ func grpcServerCreds(t *testing.T, clientCert *x509.Certificate) []grpc.ServerOp
 }
 
 func setupHelloSVC(t *testing.T, s *grpc.Server) {
-	pb.RegisterGreeterServer(s, &server{})
+	pbExample.RegisterGreeterServer(s, &server{})
 }
 
 func startGRPCServer(t *testing.T, clientCert *x509.Certificate, fn func(t *testing.T, s *grpc.Server)) (net.Listener, *grpc.Server) {
@@ -572,18 +572,18 @@ func startGRPCServer(t *testing.T, clientCert *x509.Certificate, fn func(t *test
 
 }
 
-func sayHelloWithGRPCClientH2C(t *testing.T, address string, name string) *pb.HelloReply {
+func sayHelloWithGRPCClientH2C(t *testing.T, address string, name string) *pbExample.HelloReply {
 	conn, err := grpc.Dial(address, grpc.WithInsecure())
 	if err != nil {
 		t.Fatalf("did not connect: %v", err)
 	}
 	defer conn.Close()
-	c := pb.NewGreeterClient(conn)
+	c := pbExample.NewGreeterClient(conn)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	var header metadata.MD
-	r, err := c.SayHello(ctx, &pb.HelloRequest{Name: name}, grpc.Header(&header))
+	r, err := c.SayHello(ctx, &pbExample.HelloRequest{Name: name}, grpc.Header(&header))
 	if err != nil {
 		t.Fatalf("could not greet: %v", err)
 	}
@@ -624,7 +624,7 @@ func grpcCreds(cert *tls.Certificate, caCert []byte, basicAuth bool, token strin
 	return opts
 }
 
-func sayHelloWithGRPCClient(t *testing.T, cert *tls.Certificate, caCert []byte, basicAuth bool, token string, address string, name string) *pb.HelloReply {
+func sayHelloWithGRPCClient(t *testing.T, cert *tls.Certificate, caCert []byte, basicAuth bool, token string, address string, name string) *pbExample.HelloReply {
 	// gRPC client
 	opts := grpcCreds(cert, caCert, basicAuth, token)
 	conn, err := grpc.Dial(address, opts...)
@@ -632,11 +632,11 @@ func sayHelloWithGRPCClient(t *testing.T, cert *tls.Certificate, caCert []byte, 
 		t.Fatalf("did not connect: %v", err)
 	}
 	defer conn.Close()
-	c := pb.NewGreeterClient(conn)
+	c := pbExample.NewGreeterClient(conn)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	r, err := c.SayHello(ctx, &pb.HelloRequest{Name: name})
+	r, err := c.SayHello(ctx, &pbExample.HelloRequest{Name: name})
 	if err != nil {
 		t.Fatalf("could not greet: %v", err)
 	}

--- a/gateway/handler_error.go
+++ b/gateway/handler_error.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"errors"
-	"html/template"
+	htmlTemplate "html/template"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -114,7 +114,7 @@ func overrideTykErrors(gw *Gateway) {
 
 // APIError is generic error object returned if there is something wrong with the request
 type APIError struct {
-	Message template.HTML
+	Message htmlTemplate.HTML
 }
 
 // ErrorHandler is invoked whenever there is an issue with a proxied request, most middleware will invoke
@@ -194,10 +194,10 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 			var tmplExecutor TemplateExecutor
 			tmplExecutor = tmpl
 
-			apiError := APIError{template.HTML(template.JSEscapeString(errMsg))}
+			apiError := APIError{htmlTemplate.HTML(htmlTemplate.JSEscapeString(errMsg))}
 
 			if contentType == header.ApplicationXML || contentType == header.TextXML {
-				apiError.Message = template.HTML(errMsg)
+				apiError.Message = htmlTemplate.HTML(errMsg)
 
 				//we look up in the last defined templateName to obtain the template.
 				rawTmpl := e.Gw.templatesRaw.Lookup(templateName)

--- a/gateway/host_checker.go
+++ b/gateway/host_checker.go
@@ -3,7 +3,7 @@ package gateway
 import (
 	"context"
 	"crypto/tls"
-	"math/rand"
+	mathRand "math/rand"
 	"net"
 	"net/http"
 	"net/url"
@@ -90,11 +90,11 @@ func (h *HostUptimeChecker) getStaggeredTime() time.Duration {
 		return time.Duration(h.checkTimeout) * time.Second
 	}
 
-	rand.Seed(time.Now().Unix())
+	mathRand.Seed(time.Now().Unix())
 	min := h.checkTimeout - 3
 	max := h.checkTimeout + 3
 
-	dur := rand.Intn(max-min) + min
+	dur := mathRand.Intn(max-min) + min
 
 	return time.Duration(dur) * time.Second
 }

--- a/gateway/host_checker_test.go
+++ b/gateway/host_checker_test.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
-	"text/template"
+	textTemplate "text/template"
 	"time"
 
 	proxyproto "github.com/pires/go-proxyproto"
@@ -77,7 +77,7 @@ func TestHostChecker(t *testing.T) {
 	})
 	defer ts.Close()
 
-	specTmpl := template.Must(template.New("spec").Parse(sampleUptimeTestAPI))
+	specTmpl := textTemplate.Must(textTemplate.New("spec").Parse(sampleUptimeTestAPI))
 
 	tmplData := struct {
 		Host1, Host2 string
@@ -185,7 +185,7 @@ func TestReverseProxyAllDown(t *testing.T) {
 	})
 	defer ts.Close()
 
-	specTmpl := template.Must(template.New("spec").Parse(sampleUptimeTestAPI))
+	specTmpl := textTemplate.Must(textTemplate.New("spec").Parse(sampleUptimeTestAPI))
 
 	tmplData := struct {
 		Host1, Host2 string

--- a/gateway/mw_graphql.go
+++ b/gateway/mw_graphql.go
@@ -6,6 +6,11 @@ import (
 	"errors"
 	"net/http"
 
+<<<<<<< HEAD
+=======
+	graphqlinternal "github.com/TykTechnologies/tyk/internal/graphql"
+
+>>>>>>> 0a78cef4... [TT-10370] Alias imports (#5691)
 	"github.com/gorilla/websocket"
 	"github.com/jensneuse/abstractlogger"
 	"github.com/sirupsen/logrus"
@@ -187,6 +192,19 @@ func (m *GraphQLMiddleware) initGraphQLEngineV2(logger *abstractlogger.LogrusLog
 	}
 
 	m.Spec.GraphQLExecutor.EngineV2 = engine
+<<<<<<< HEAD
+=======
+	conf := m.Gw.GetConfig()
+	if conf.OpenTelemetry.Enabled {
+		executor, err := graphqlinternal.NewOtelGraphqlEngineV2(m.Gw.TracerProvider, engine)
+		if err != nil {
+			m.Logger().WithError(err).Error("error creating custom execution engine v2")
+			cancel()
+			return
+		}
+		m.Spec.GraphQLExecutor.OtelExecutor = executor
+	}
+>>>>>>> 0a78cef4... [TT-10370] Alias imports (#5691)
 	m.Spec.GraphQLExecutor.CancelV2 = cancel
 	m.Spec.GraphQLExecutor.HooksV2.BeforeFetchHook = m
 	m.Spec.GraphQLExecutor.HooksV2.AfterFetchHook = m

--- a/gateway/mw_graphql.go
+++ b/gateway/mw_graphql.go
@@ -6,11 +6,6 @@ import (
 	"errors"
 	"net/http"
 
-<<<<<<< HEAD
-=======
-	graphqlinternal "github.com/TykTechnologies/tyk/internal/graphql"
-
->>>>>>> 0a78cef4... [TT-10370] Alias imports (#5691)
 	"github.com/gorilla/websocket"
 	"github.com/jensneuse/abstractlogger"
 	"github.com/sirupsen/logrus"
@@ -192,19 +187,6 @@ func (m *GraphQLMiddleware) initGraphQLEngineV2(logger *abstractlogger.LogrusLog
 	}
 
 	m.Spec.GraphQLExecutor.EngineV2 = engine
-<<<<<<< HEAD
-=======
-	conf := m.Gw.GetConfig()
-	if conf.OpenTelemetry.Enabled {
-		executor, err := graphqlinternal.NewOtelGraphqlEngineV2(m.Gw.TracerProvider, engine)
-		if err != nil {
-			m.Logger().WithError(err).Error("error creating custom execution engine v2")
-			cancel()
-			return
-		}
-		m.Spec.GraphQLExecutor.OtelExecutor = executor
-	}
->>>>>>> 0a78cef4... [TT-10370] Alias imports (#5691)
 	m.Spec.GraphQLExecutor.CancelV2 = cancel
 	m.Spec.GraphQLExecutor.HooksV2.BeforeFetchHook = m
 	m.Spec.GraphQLExecutor.HooksV2.AfterFetchHook = m

--- a/gateway/mw_http_signature_validation.go
+++ b/gateway/mw_http_signature_validation.go
@@ -1,7 +1,6 @@
 package gateway
 
 import (
-	"crypto"
 	"crypto/hmac"
 	"crypto/rsa"
 	"crypto/sha1"
@@ -21,6 +20,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/internal/crypto"
 	"github.com/TykTechnologies/tyk/regexp"
 	"github.com/TykTechnologies/tyk/user"
 )

--- a/gateway/mw_http_signature_validation_test.go
+++ b/gateway/mw_http_signature_validation_test.go
@@ -1,9 +1,8 @@
 package gateway
 
 import (
-	"crypto"
 	"crypto/hmac"
-	"crypto/rand"
+	cryptoRand "crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
 	"crypto/sha256"
@@ -16,7 +15,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -27,8 +25,10 @@ import (
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/certs"
 	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/regexp"
 	"github.com/TykTechnologies/tyk/user"
 
+	"github.com/TykTechnologies/tyk/internal/crypto"
 	"github.com/TykTechnologies/tyk/internal/uuid"
 )
 
@@ -231,7 +231,7 @@ func testPrepareRSAAuthSessionPass(tb testing.TB, eventWG *sync.WaitGroup, priva
 	h.Write([]byte(signatureString))
 	hashed := h.Sum(nil)
 
-	signature, _ := rsa.SignPKCS1v15(rand.Reader, privateKey, crypto.SHA256, hashed)
+	signature, _ := rsa.SignPKCS1v15(cryptoRand.Reader, privateKey, crypto.SHA256, hashed)
 
 	sigString := base64.StdEncoding.EncodeToString(signature)
 

--- a/gateway/mw_js_plugin_test.go
+++ b/gateway/mw_js_plugin_test.go
@@ -8,23 +8,20 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/TykTechnologies/tyk/config"
-
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/TykTechnologies/tyk/ctx"
-	"github.com/TykTechnologies/tyk/user"
-
-	"github.com/sirupsen/logrus"
-
 	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/ctx"
 	logger "github.com/TykTechnologies/tyk/log"
+	"github.com/TykTechnologies/tyk/regexp"
 	"github.com/TykTechnologies/tyk/test"
+	"github.com/TykTechnologies/tyk/user"
 )
 
 func TestJSVM_StopProxyWhenFail(t *testing.T) {

--- a/gateway/mw_request_signing.go
+++ b/gateway/mw_request_signing.go
@@ -1,8 +1,7 @@
 package gateway
 
 import (
-	"crypto"
-	"crypto/rand"
+	cryptoRand "crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
 	"encoding/base64"
@@ -13,6 +12,8 @@ import (
 	"time"
 
 	"github.com/TykTechnologies/tyk/certs"
+
+	"github.com/TykTechnologies/tyk/internal/crypto"
 )
 
 type RequestSigning struct {
@@ -194,7 +195,7 @@ func generateRSAEncodedSignature(signatureString string, privateKey *rsa.Private
 	hashFunction.Write([]byte(signatureString))
 	hashed := hashFunction.Sum(nil)
 
-	rawsignature, err := rsa.SignPKCS1v15(rand.Reader, privateKey, hashType, hashed)
+	rawsignature, err := rsa.SignPKCS1v15(cryptoRand.Reader, privateKey, hashType, hashed)
 	if err != nil {
 		return "", err
 	}

--- a/gateway/mw_transform_test.go
+++ b/gateway/mw_transform_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
-	"text/template"
+	textTemplate "text/template"
 
 	"github.com/TykTechnologies/tyk/test"
 
@@ -22,7 +22,7 @@ func testPrepareTransformNonAscii() (*TransformSpec, string) {
 	tmpl := `[{{range $x, $s := .names.name}}"{{$s}}"{{if not $x}}, {{end}}{{end}}]`
 	tmeta := &TransformSpec{}
 	tmeta.TemplateData.Input = apidef.RequestXML
-	tmeta.Template = template.Must(template.New("blob").Parse(tmpl))
+	tmeta.Template = textTemplate.Must(textTemplate.New("blob").Parse(tmpl))
 	return tmeta, in
 }
 
@@ -85,7 +85,7 @@ func TestTransformXMLCrash(t *testing.T) {
 	r := TestReq(t, "GET", "/", in)
 	tmeta := &TransformSpec{}
 	tmeta.TemplateData.Input = apidef.RequestXML
-	tmeta.Template = template.Must(apidef.Template.New("").Parse(""))
+	tmeta.Template = textTemplate.Must(apidef.Template.New("").Parse(""))
 
 	ts := StartTest(nil)
 	defer ts.Close()
@@ -105,7 +105,7 @@ func testPrepareTransformJSONMarshal(inputType string) (tmeta *TransformSpec, in
 	tmeta = &TransformSpec{}
 	tmpl := `[{{range $x, $s := .names.name}}{{$s | jsonMarshal}}{{if not $x}}, {{end}}{{end}}]`
 	tmeta.TemplateData.Input = apidef.RequestXML
-	tmeta.Template = template.Must(apidef.Template.New("").Parse(tmpl))
+	tmeta.Template = textTemplate.Must(apidef.Template.New("").Parse(tmpl))
 
 	switch inputType {
 	case "json":
@@ -124,7 +124,7 @@ func testPrepareTransformJSONMarshal(inputType string) (tmeta *TransformSpec, in
 
 func testPrepareTransformXMLMarshal(tmpl string, inputType apidef.RequestInputType) (tmeta *TransformSpec) {
 	tmeta = &TransformSpec{}
-	tmeta.Template = template.Must(apidef.Template.New("").Parse(tmpl))
+	tmeta.Template = textTemplate.Must(apidef.Template.New("").Parse(tmpl))
 
 	switch inputType {
 	case apidef.RequestJSON:
@@ -194,7 +194,7 @@ func testPrepareTransformJSONMarshalArray(tb testing.TB) (tmeta *TransformSpec, 
 	tmeta = &TransformSpec{}
 	tmpl := `[{{ range $key, $value := .array }}{{ if $key }},{{ end }}{{ .abc }}{{ end }}]`
 	tmeta.TemplateData.Input = apidef.RequestXML
-	tmeta.Template = template.Must(apidef.Template.New("").Parse(tmpl))
+	tmeta.Template = textTemplate.Must(apidef.Template.New("").Parse(tmpl))
 
 	tmeta.TemplateData.Input = apidef.RequestJSON
 	in = `[{"abc": 123}, {"abc": 456}]`

--- a/gateway/redis_signals.go
+++ b/gateway/redis_signals.go
@@ -1,7 +1,6 @@
 package gateway
 
 import (
-	"crypto"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -14,6 +13,7 @@ import (
 	"github.com/go-redis/redis/v8"
 
 	"github.com/TykTechnologies/goverify"
+	"github.com/TykTechnologies/tyk/internal/crypto"
 	"github.com/TykTechnologies/tyk/storage"
 )
 

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math/rand"
+	mathRand "math/rand"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"text/template"
+	textTemplate "text/template"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -664,7 +664,7 @@ func TestCheckHeaderInRemoveList(t *testing.T) {
 		GlobalHeadersRemove   []string
 		ExtendedDeleteHeaders []string
 	}
-	tpl, err := template.New("test_tpl").Parse(`{
+	tpl, err := textTemplate.New("test_tpl").Parse(`{
 		"api_id": "1",
 		"version_data": {
 			"not_versioned": true,
@@ -1289,7 +1289,7 @@ func TestGraphQL_InternalDataSource_memConnProviders(t *testing.T) {
 	// tests run in parallel and memConnProviders is a global struct.
 	// For consistency, we use unique names for the subgraphs.
 	tykSubgraphAccounts := BuildAPI(func(spec *APISpec) {
-		spec.Name = fmt.Sprintf("subgraph-accounts-%d", rand.Intn(1000))
+		spec.Name = fmt.Sprintf("subgraph-accounts-%d", mathRand.Intn(1000))
 		spec.APIID = "subgraph1"
 		spec.Proxy.TargetURL = testSubgraphAccounts
 		spec.Proxy.ListenPath = "/tyk-subgraph-accounts"
@@ -1305,7 +1305,7 @@ func TestGraphQL_InternalDataSource_memConnProviders(t *testing.T) {
 	})[0]
 
 	tykSubgraphReviews := BuildAPI(func(spec *APISpec) {
-		spec.Name = fmt.Sprintf("subgraph-reviews-%d", rand.Intn(1000))
+		spec.Name = fmt.Sprintf("subgraph-reviews-%d", mathRand.Intn(1000))
 		spec.APIID = "subgraph2"
 		spec.Proxy.TargetURL = testSubgraphReviews
 		spec.Proxy.ListenPath = "/tyk-subgraph-reviews"

--- a/gateway/rpc_backup_handlers.go
+++ b/gateway/rpc_backup_handlers.go
@@ -3,7 +3,7 @@ package gateway
 import (
 	"crypto/aes"
 	"crypto/cipher"
-	"crypto/rand"
+	cryptoRand "crypto/rand"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -156,7 +156,7 @@ func encrypt(key []byte, text string) string {
 	// include it at the beginning of the ciphertext.
 	ciphertext := make([]byte, aes.BlockSize+len(plaintext))
 	iv := ciphertext[:aes.BlockSize]
-	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+	if _, err := io.ReadFull(cryptoRand.Reader, iv); err != nil {
 		log.Error(err)
 		return ""
 	}

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"html/template"
+	htmlTemplate "html/template"
 	"io/ioutil"
 	stdlog "log"
 	"log/syslog"
@@ -185,7 +185,7 @@ type Gateway struct {
 	TestBundles  map[string]map[string]string
 	TestBundleMu sync.Mutex
 
-	templates    *template.Template
+	templates    *htmlTemplate.Template
 	templatesRaw *textTemplate.Template
 
 	// RedisController keeps track of redis connection and singleton
@@ -399,7 +399,7 @@ func (gw *Gateway) setupGlobals() {
 	// Load all the files that have the "error" prefix.
 	//	gwConfig.TemplatePath = "/Users/sredny/go/src/github.com/TykTechnologies/tyk/templates"
 	templatesDir := filepath.Join(gwConfig.TemplatePath, "error*")
-	gw.templates = template.Must(template.ParseGlob(templatesDir))
+	gw.templates = htmlTemplate.Must(htmlTemplate.ParseGlob(templatesDir))
 	gw.templatesRaw = textTemplate.Must(textTemplate.ParseGlob(templatesDir))
 	gw.CoProcessInit()
 

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math/rand"
+	mathRand "math/rand"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -1082,7 +1082,7 @@ func (s *Test) newGateway(genConf func(globalConf *config.Config)) *Gateway {
 	s.MockHandle = MockHandle
 
 	var err error
-	gwConfig.Storage.Database = rand.Intn(15)
+	gwConfig.Storage.Database = mathRand.Intn(15)
 	gwConfig.AppPath, err = ioutil.TempDir("", "tyk-test-")
 
 	if err != nil {
@@ -1862,7 +1862,7 @@ func GenerateTestBinaryData() (buf *bytes.Buffer) {
 		c uint32
 	}
 	for i := 0; i < 10; i++ {
-		s := &testData{rand.Float32(), rand.Float64(), rand.Uint32()}
+		s := &testData{mathRand.Float32(), mathRand.Float64(), mathRand.Uint32()}
 		binary.Write(buf, binary.BigEndian, s)
 	}
 	return buf
@@ -1917,7 +1917,7 @@ func randStringBytes(n int) string {
 	b := make([]byte, n)
 
 	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
+		b[i] = letters[mathRand.Intn(len(letters))]
 	}
 
 	return string(b)

--- a/gateway/tracing.go
+++ b/gateway/tracing.go
@@ -5,13 +5,13 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"net/http/httputil"
 	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
 
 	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/internal/httputil"
 )
 
 type traceHttpRequest struct {

--- a/internal/crypto/alias.go
+++ b/internal/crypto/alias.go
@@ -1,0 +1,9 @@
+package crypto
+
+import (
+	"crypto"
+)
+
+type Hash = crypto.Hash
+
+const SHA256 = crypto.SHA256

--- a/internal/httputil/alias.go
+++ b/internal/httputil/alias.go
@@ -1,0 +1,8 @@
+package httputil
+
+import (
+	"net/http/httputil"
+)
+
+var DumpResponse = httputil.DumpResponse
+var DumpRequest = httputil.DumpRequest

--- a/storage/kv/consul.go
+++ b/storage/kv/consul.go
@@ -1,14 +1,14 @@
 package kv
 
 import (
-	"github.com/hashicorp/consul/api"
+	consulApi "github.com/hashicorp/consul/api"
 
 	"github.com/TykTechnologies/tyk/config"
 )
 
 // Consul is an implementation of a KV store which uses Consul as it's backend
 type Consul struct {
-	store *api.KV
+	store *consulApi.KV
 }
 
 // NewConsul returns a configured consul KV store adapter
@@ -30,7 +30,7 @@ func (c *Consul) Get(key string) (string, error) {
 }
 
 func newConsul(conf config.ConsulConfig) (Store, error) {
-	defaultCfg := api.DefaultConfig()
+	defaultCfg := consulApi.DefaultConfig()
 
 	if conf.Address != "" {
 		defaultCfg.Address = conf.Address
@@ -72,7 +72,7 @@ func newConsul(conf config.ConsulConfig) (Store, error) {
 		defaultCfg.TLSConfig.InsecureSkipVerify = conf.TLSConfig.InsecureSkipVerify
 	}
 
-	client, err := api.NewClient(defaultCfg)
+	client, err := consulApi.NewClient(defaultCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/kv/consul_test.go
+++ b/storage/kv/consul_test.go
@@ -3,9 +3,9 @@ package kv
 import (
 	"testing"
 
-	"github.com/TykTechnologies/tyk/config"
+	consulApi "github.com/hashicorp/consul/api"
 
-	"github.com/hashicorp/consul/api"
+	"github.com/TykTechnologies/tyk/config"
 )
 
 var _ Store = (*Consul)(nil)
@@ -26,7 +26,7 @@ func TestConsul_Get(t *testing.T) {
 
 	con := store.(*Consul)
 
-	_, err = con.store.Put(&api.KVPair{
+	_, err = con.store.Put(&consulApi.KVPair{
 		Key:   "key",
 		Value: []byte("value"),
 	}, nil)

--- a/storage/kv/vault.go
+++ b/storage/kv/vault.go
@@ -4,14 +4,14 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/hashicorp/vault/api"
+	vaultApi "github.com/hashicorp/vault/api"
 
 	"github.com/TykTechnologies/tyk/config"
 )
 
 // Vault is an implementation of a KV store which uses Consul as it's backend
 type Vault struct {
-	client *api.Client
+	client *vaultApi.Client
 	kvV2   bool
 }
 
@@ -67,7 +67,7 @@ func (v *Vault) Get(key string) (string, error) {
 }
 
 func newVault(conf config.VaultConfig) (Store, error) {
-	defaultCfg := api.DefaultConfig()
+	defaultCfg := vaultApi.DefaultConfig()
 
 	if conf.Address != "" {
 		defaultCfg.Address = conf.Address
@@ -89,7 +89,7 @@ func newVault(conf config.VaultConfig) (Store, error) {
 		return nil, errors.New("you must provide a root token in other to use vault")
 	}
 
-	client, err := api.NewClient(defaultCfg)
+	client, err := vaultApi.NewClient(defaultCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/trace/log.go
+++ b/trace/log.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	opentracing "github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+	opentracingLog "github.com/opentracing/opentracing-go/log"
 )
 
 // Logrus implements a subset of logrus api to reduce friction when we want
@@ -20,21 +20,21 @@ type Logrus interface {
 // Debug creates debug log on both logrus and span.
 func Debug(ctx context.Context, logrus Logrus, args ...interface{}) {
 	logrus.Debug(args...)
-	Log(ctx, log.String("DEBUG", fmt.Sprint(args...)))
+	Log(ctx, opentracingLog.String("DEBUG", fmt.Sprint(args...)))
 }
 
 func Error(ctx context.Context, logrus Logrus, args ...interface{}) {
 	logrus.Error(args...)
-	Log(ctx, log.String("ERROR", fmt.Sprint(args...)))
+	Log(ctx, opentracingLog.String("ERROR", fmt.Sprint(args...)))
 }
 
 func Warning(ctx context.Context, logrus Logrus, args ...interface{}) {
 	logrus.Warning(args...)
-	Log(ctx, log.String("WARN", fmt.Sprint(args...)))
+	Log(ctx, opentracingLog.String("WARN", fmt.Sprint(args...)))
 }
 
 // Log tries to check if there is a span in ctx and adds logs fields on the span.
-func Log(ctx context.Context, fields ...log.Field) {
+func Log(ctx context.Context, fields ...opentracingLog.Field) {
 	if span := opentracing.SpanFromContext(ctx); span != nil {
 		span.LogFields(fields...)
 	}
@@ -42,5 +42,5 @@ func Log(ctx context.Context, fields ...log.Field) {
 
 func Info(ctx context.Context, logrus Logrus, args ...interface{}) {
 	logrus.Info(args...)
-	Log(ctx, log.String("INFO", fmt.Sprint(args...)))
+	Log(ctx, opentracingLog.String("INFO", fmt.Sprint(args...)))
 }

--- a/trace/openzipkin/zipkin.go
+++ b/trace/openzipkin/zipkin.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	opentracing "github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+	opentracingLog "github.com/opentracing/opentracing-go/log"
 	zipkin "github.com/openzipkin/zipkin-go"
 	"github.com/openzipkin/zipkin-go/model"
 	"github.com/openzipkin/zipkin-go/propagation/b3"
@@ -50,7 +50,7 @@ func (s Span) SetTag(key string, value interface{}) opentracing.Span {
 	return s
 }
 
-func (s Span) LogFields(fields ...log.Field) {
+func (s Span) LogFields(fields ...opentracingLog.Field) {
 	now := time.Now()
 	lg := &logEncoder{h: func(key string, value interface{}) {
 		s.span.Annotate(now, fmt.Sprintf("%s %s", key, value))
@@ -69,17 +69,17 @@ func (e *logEncoder) emit(key string, value interface{}) {
 		e.h(key, value)
 	}
 }
-func (e *logEncoder) EmitString(key, value string)             { e.emit(key, value) }
-func (e *logEncoder) EmitBool(key string, value bool)          { e.emit(key, value) }
-func (e *logEncoder) EmitInt(key string, value int)            { e.emit(key, value) }
-func (e *logEncoder) EmitInt32(key string, value int32)        { e.emit(key, value) }
-func (e *logEncoder) EmitInt64(key string, value int64)        { e.emit(key, value) }
-func (e *logEncoder) EmitUint32(key string, value uint32)      { e.emit(key, value) }
-func (e *logEncoder) EmitUint64(key string, value uint64)      { e.emit(key, value) }
-func (e *logEncoder) EmitFloat32(key string, value float32)    { e.emit(key, value) }
-func (e *logEncoder) EmitFloat64(key string, value float64)    { e.emit(key, value) }
-func (e *logEncoder) EmitObject(key string, value interface{}) { e.emit(key, value) }
-func (e *logEncoder) EmitLazyLogger(value log.LazyLogger)      {}
+func (e *logEncoder) EmitString(key, value string)                   { e.emit(key, value) }
+func (e *logEncoder) EmitBool(key string, value bool)                { e.emit(key, value) }
+func (e *logEncoder) EmitInt(key string, value int)                  { e.emit(key, value) }
+func (e *logEncoder) EmitInt32(key string, value int32)              { e.emit(key, value) }
+func (e *logEncoder) EmitInt64(key string, value int64)              { e.emit(key, value) }
+func (e *logEncoder) EmitUint32(key string, value uint32)            { e.emit(key, value) }
+func (e *logEncoder) EmitUint64(key string, value uint64)            { e.emit(key, value) }
+func (e *logEncoder) EmitFloat32(key string, value float32)          { e.emit(key, value) }
+func (e *logEncoder) EmitFloat64(key string, value float64)          { e.emit(key, value) }
+func (e *logEncoder) EmitObject(key string, value interface{})       { e.emit(key, value) }
+func (e *logEncoder) EmitLazyLogger(value opentracingLog.LazyLogger) {}
 
 func (s Span) LogKV(alternatingKeyValues ...interface{})                   {}
 func (s Span) SetBaggageItem(restrictedKey, value string) opentracing.Span { return s }


### PR DESCRIPTION
[TT-10370] Alias imports (#5691)

This PR aliases imports within gateway packages, so the aliases are
non-conflicting inside individual package scopes.

To verify, run the following:

```
go install github.com/TykTechnologies/exp/cmd/go-fsck@978afcf81429325b9dcf51ec2afcc77a3d83e338
```

```
go-fsck lint ; echo $?
```

The command should exit with status 0 printed in the last line; The
command prints a few warnings around ignored files due to build tags.
This is expected and can be ignored.

https://tyktech.atlassian.net/browse/TT-10370

---------

Co-authored-by: Tit Petric <tit@tyk.io>

[TT-10370]: https://tyktech.atlassian.net/browse/TT-10370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ