### PR TITLE
Merging to release-5.2.2: TT-10344 Fix rpc ClientIsConnected (#5692)

### DIFF
--- a/rpc/rpc_client.go
+++ b/rpc/rpc_client.go
@@ -72,7 +72,7 @@ type rpcOpts struct {
 
 func (r rpcOpts) ClientIsConnected() bool {
 	if v := r.clientIsConnected.Load(); v != nil {
-		return v.(bool) && !r.GetEmergencyMode()
+		return v.(bool)
 	}
 
 	return false

--- a/rpc/rpc_client_test.go
+++ b/rpc/rpc_client_test.go
@@ -44,34 +44,19 @@ func TestClientIsConnected(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		name          string
-		connected     bool
-		emergencyMode bool
-		expected      bool
+		name      string
+		connected bool
+		expected  bool
 	}{
 		{
-			name:          "When client is connected and not in emergency mode",
-			connected:     true,
-			emergencyMode: false,
-			expected:      true,
+			name:      "When client is connected and not in emergency mode",
+			connected: true,
+			expected:  true,
 		},
 		{
-			name:          "When client is disconnected and not in emergency mode",
-			connected:     false,
-			emergencyMode: false,
-			expected:      false,
-		},
-		{
-			name:          "When client is connected and in emergency mode",
-			connected:     true,
-			emergencyMode: true,
-			expected:      false,
-		},
-		{
-			name:          "When client is disconnected and in emergency mode",
-			connected:     false,
-			emergencyMode: true,
-			expected:      false,
+			name:      "When client is disconnected and not in emergency mode",
+			connected: false,
+			expected:  false,
 		},
 	}
 
@@ -79,10 +64,8 @@ func TestClientIsConnected(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := rpcOpts{}
 			r.clientIsConnected.Store(tt.connected)
-			r.emergencyMode.Store(tt.emergencyMode)
 			defer func() {
 				r.clientIsConnected.Store(false)
-				r.emergencyMode.Store(false)
 			}()
 
 			got := r.ClientIsConnected()


### PR DESCRIPTION
TT-10344 Fix rpc ClientIsConnected (#5692)

<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
Reverting changes introduced in `func (r rpcOpts) ClientIsConnected()
bool` onhttps://github.com/TykTechnologies/tyk/pull/5574.

`clientIsConnected` fn is called on `FuncClientSingleton`
https://github.com/TykTechnologies/tyk/blob/master/rpc/rpc_client.go#L469
and if it fails while trying to `GroupLogin`, the function `recoverOps`
will not ever be able to recover
https://github.com/TykTechnologies/tyk/blob/master/rpc/rpc_client.go#L444
and exit emergency mode.




## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why