### PR TITLE
Merging to release-5.2: [TT-7971] share version internally (#5705)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,6 @@
 .vscode/
 temp/
 /middleware/bundles
-/middleware/e1d21f942ec746ed416ab97fe1bf07e8/
-/middleware/e1d21f942ec746ed416ab97fe1bf07e8_IGNORED/
 testapps/
 
 /vendor
@@ -15,8 +13,8 @@ testapps/
 /utils/build_hybrid.sh
 /utils/cloud_release.sh
 
-build_tools/
-build/
+/build_tools
+/build
 
 /*.conf
 /*.json

--- a/ci/goreleaser/goreleaser-5.0.yml
+++ b/ci/goreleaser/goreleaser-5.0.yml
@@ -10,7 +10,10 @@ builds:
     flags:
       - -tags=goplugin
     ldflags:
-      - -X github.com/TykTechnologies/tyk/gateway.VERSION={{.Version}} -X github.com/TykTechnologies/tyk/gateway.Commit={{.FullCommit}} -X github.com/TykTechnologies/tyk/gateway.buildDate={{.Date}} -X github.com/TykTechnologies/tyk/gateway.builtBy=goreleaser
+      - -X github.com/TykTechnologies/tyk/internal/build.Version={{.Version}}
+      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
     goos:
       - linux
     goarch:
@@ -20,7 +23,10 @@ builds:
     flags:
       - -tags=goplugin
     ldflags:
-      - -X github.com/TykTechnologies/tyk/gateway.VERSION={{.Version}} -X github.com/TykTechnologies/tyk/gateway.Commit={{.FullCommit}} -X github.com/TykTechnologies/tyk/gateway.buildDate={{.Date}} -X github.com/TykTechnologies/tyk/gateway.builtBy=goreleaser
+      - -X github.com/TykTechnologies/tyk/internal/build.Version={{.Version}}
+      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
     env:
       - CC=aarch64-linux-gnu-gcc
     goos:

--- a/ci/goreleaser/goreleaser.yml
+++ b/ci/goreleaser/goreleaser.yml
@@ -11,7 +11,10 @@ builds:
       - -trimpath
       - -tags=goplugin
     ldflags:
-      - -X github.com/TykTechnologies/tyk/gateway.VERSION={{.Version}} -X github.com/TykTechnologies/tyk/gateway.Commit={{.FullCommit}} -X github.com/TykTechnologies/tyk/gateway.buildDate={{.Date}} -X github.com/TykTechnologies/tyk/gateway.builtBy=goreleaser
+      - -X github.com/TykTechnologies/tyk/internal/build.Version={{.Version}}
+      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
     goos:
       - linux
     goarch:
@@ -22,7 +25,10 @@ builds:
       - -trimpath
       - -tags=goplugin
     ldflags:
-      - -X github.com/TykTechnologies/tyk/gateway.VERSION={{.Version}} -X github.com/TykTechnologies/tyk/gateway.Commit={{.FullCommit}} -X github.com/TykTechnologies/tyk/gateway.buildDate={{.Date}} -X github.com/TykTechnologies/tyk/gateway.builtBy=goreleaser
+      - -X github.com/TykTechnologies/tyk/internal/build.Version={{.Version}}
+      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
     env:
       - CC=aarch64-linux-gnu-gcc
     goos:
@@ -30,6 +36,25 @@ builds:
     goarch:
       - arm64
     binary: tyk
+<<<<<<< HEAD
+=======
+  - id: std-s390x
+    flags:
+      - -trimpath
+      - -tags=goplugin 
+    ldflags:
+      - -X github.com/TykTechnologies/tyk/internal/build.Version={{.Version}}
+      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
+    env:
+      - CC=s390x-linux-gnu-gcc
+    goos:
+      - linux
+    goarch:
+      - s390x
+    binary: tyk
+>>>>>>> ded68078... [TT-7971] share version internally (#5705)
 
 dockers:
   # Build tykio/tyk-gateway, docker.tyk.io/tyk-gateway/tyk-gateway (amd64)

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -13,6 +13,7 @@ import (
 	"github.com/TykTechnologies/tyk/cli/importer"
 	"github.com/TykTechnologies/tyk/cli/linter"
 	"github.com/TykTechnologies/tyk/cli/plugin"
+	"github.com/TykTechnologies/tyk/internal/build"
 	logger "github.com/TykTechnologies/tyk/log"
 )
 
@@ -50,10 +51,10 @@ var (
 )
 
 // Init sets all flags and subcommands.
-func Init(version string, confPaths []string) {
+func Init(confPaths []string) {
 	app = kingpin.New(appName, appDesc)
 	app.HelpFlag.Short('h')
-	app.Version(version)
+	app.Version(build.Version)
 
 	// Start/default command:
 	startCmd := app.Command("start", "Starts the Tyk Gateway")

--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -142,7 +142,7 @@ func (m *GoPluginMiddleware) loadPlugin() bool {
 	// try to load plugin
 	var err error
 
-	newPath, err := goplugin.GetPluginFileNameToLoad(goplugin.FileSystemStorage{}, m.Path, VERSION)
+	newPath, err := goplugin.GetPluginFileNameToLoad(goplugin.FileSystemStorage{}, m.Path)
 	if err != nil {
 		m.logger.WithError(err).Error("plugin file not found")
 		return false

--- a/gateway/res_handler_go_plugin.go
+++ b/gateway/res_handler_go_plugin.go
@@ -45,7 +45,7 @@ func (h *ResponseGoPluginMiddleware) Init(c interface{}, spec *APISpec) error {
 		return nil
 	}
 
-	newPath, err := goplugin.GetPluginFileNameToLoad(goplugin.FileSystemStorage{}, h.Path, VERSION)
+	newPath, err := goplugin.GetPluginFileNameToLoad(goplugin.FileSystemStorage{}, h.Path)
 	if err != nil {
 		h.logger.WithError(err).Error("Could not load Go-plugin. File was not found")
 		return err

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -1547,7 +1547,7 @@ func Start() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	cli.Init(VERSION, confPaths)
+	cli.Init(confPaths)
 	cli.Parse()
 	// Stop gateway process if not running in "start" mode:
 	if !cli.DefaultMode {

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -1141,7 +1141,7 @@ func (s *Test) newGateway(genConf func(globalConf *config.Config)) *Gateway {
 	defaultTestConfig = gwConfig
 	gw.SetConfig(gwConfig)
 
-	cli.Init(VERSION, confPaths)
+	cli.Init(confPaths)
 
 	err = gw.initialiseSystem()
 	if err != nil {

--- a/gateway/version.go
+++ b/gateway/version.go
@@ -1,4 +1,14 @@
 package gateway
 
-var VERSION = "v4.3.0"
-var builtBy, Commit, buildDate string
+import (
+	"github.com/TykTechnologies/tyk/internal/build"
+)
+
+// Deprecated: All of the following variables are deprecated in favor of
+// importing the information from the internal/build package directly.
+// These placeholders remain for compatibility but are likely to be
+// removed in a future version.
+var (
+	VERSION = build.Version
+	Commit  = build.Commit
+)

--- a/goplugin/plugin_name_builder_test.go
+++ b/goplugin/plugin_name_builder_test.go
@@ -1,7 +1,6 @@
 package goplugin
 
 import (
-	"fmt"
 	"runtime"
 	"strings"
 	"testing"
@@ -29,8 +28,9 @@ func (ms MockStorage) fileExist(path string) bool {
 
 func TestGetPluginFileNameToLoad(t *testing.T) {
 	// it can be any version, but for testing we will take this one
-	gwVersion := "v4.1.0"
-	gwVersionWithoutPrefix := "4.1.0"
+	gwVersion := getPrefixedVersion()
+	gwVersionWithoutPrefix := gwVersion[1:]
+
 	OSandArch := runtime.GOOS + "_" + runtime.GOARCH
 
 	testCases := []struct {
@@ -38,124 +38,39 @@ func TestGetPluginFileNameToLoad(t *testing.T) {
 		pluginName       string
 		files            []string
 		expectedFileName string
-		version          string
 	}{
 		{
 			name:             "base name file exist",
 			pluginName:       "myplugin.so",
 			files:            []string{"myplugin.so", "myplugin", "anything-else"},
 			expectedFileName: "myplugin.so",
-			version:          gwVersion,
 		},
 		{
 			name:             "exist plugin file that follows new formatting",
 			pluginName:       "myplugin.so",
-			files:            []string{"myplugin_v4.1.0_" + OSandArch + ".so", "myplugin_v4.1.0_linux_amd64.so", "myplugin", "anything-else"},
-			expectedFileName: "./myplugin_v4.1.0_" + OSandArch + ".so",
-			version:          gwVersion,
+			files:            []string{"myplugin_" + gwVersion + "_" + OSandArch + ".so", "myplugin_" + gwVersion + "_linux_amd64.so", "myplugin", "anything-else"},
+			expectedFileName: "./myplugin_" + gwVersion + "_" + OSandArch + ".so",
 		},
 		{
 			// in some point we had an issue where name loaded didn't contain prefix v. So we keep it for backward compatibility
 			name:             "exist plugin file that follows new formatting but gw version without prefix v",
 			pluginName:       "myplugin.so",
-			files:            []string{"myplugin_4.1.0_" + OSandArch + ".so", "myplugin", "anything-else", "myplugin.so"},
-			expectedFileName: "./myplugin_4.1.0_" + OSandArch + ".so",
-			version:          gwVersionWithoutPrefix,
+			files:            []string{"myplugin_" + gwVersionWithoutPrefix + "_" + OSandArch + ".so", "myplugin", "anything-else", "myplugin.so"},
+			expectedFileName: "./myplugin_" + gwVersionWithoutPrefix + "_" + OSandArch + ".so",
 		},
 		{
 			name:             "append prefix to gateway version",
 			pluginName:       "myplugin.so",
-			files:            []string{"myplugin_v4.1.0_" + OSandArch + ".so"},
-			expectedFileName: "./myplugin_v4.1.0_" + OSandArch + ".so",
-			version:          gwVersionWithoutPrefix,
+			files:            []string{"myplugin_" + gwVersion + "_" + OSandArch + ".so"},
+			expectedFileName: "./myplugin_" + gwVersion + "_" + OSandArch + ".so",
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			filenameToLoad, err := GetPluginFileNameToLoad(MockStorage{files: testCase.files}, testCase.pluginName, testCase.version)
+			filenameToLoad, err := GetPluginFileNameToLoad(MockStorage{files: testCase.files}, testCase.pluginName)
 			assert.NoError(t, err)
 			assert.Equal(t, testCase.expectedFileName, filenameToLoad)
-		})
-	}
-
-}
-
-func TestGetPrefixedVersion(t *testing.T) {
-	version := getPrefixedVersion("v4.1.0")
-	expectedVersion := "v4.1.0"
-	assert.Equal(t, expectedVersion, version)
-
-	testCases := []struct {
-		name, version, expectedVersion string
-	}{
-		{
-			name:            "version with the prefix V",
-			version:         "v4.1.0",
-			expectedVersion: "v4.1.0",
-		},
-		{
-			name:            "version without the prefix v",
-			version:         "4.1.0",
-			expectedVersion: "v4.1.0",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			version := getPrefixedVersion(tc.version)
-			assert.Equal(t, tc.expectedVersion, version)
-		})
-	}
-}
-
-func TestGetGoPluginNameFromTykVersion(t *testing.T) {
-
-	type testCase struct {
-		version, userDefinedName, inferredName string
-	}
-	goos := runtime.GOOS
-	goarch := runtime.GOARCH
-
-	testcases := []testCase{
-		{"", "", ""},
-	}
-
-	// Go middleware compiler only reads the pre-injected
-	// VERSION value from version.go, expecting to search
-	// plugin with clean version in filename (no -rc16).
-	expectVersion := "v4.1.0"
-
-	versions := []struct {
-		version, expectedVersion string
-	}{
-		{
-			version:         expectVersion,
-			expectedVersion: expectVersion,
-		},
-		{
-			version:         expectVersion + "-rc16",
-			expectedVersion: expectVersion,
-		},
-		{
-			version:         "4.1.0",
-			expectedVersion: "4.1.0",
-		},
-	}
-	for _, version := range versions {
-		testcases = append(testcases, []testCase{
-			{version.version, "plugin.so", fmt.Sprintf("./plugin_%v_%v_%v.so", version.expectedVersion, goos, goarch)},
-			{version.version, "/some/path/plugin.so", fmt.Sprintf("/some/path/plugin_%v_%v_%v.so", version.expectedVersion, goos, goarch)},
-			{version.version, "/some/path/plugin", fmt.Sprintf("/some/path/plugin_%v_%v_%v.so", version.expectedVersion, goos, goarch)},
-			{version.version, "./plugin.so", fmt.Sprintf("./plugin_%v_%v_%v.so", version.expectedVersion, goos, goarch)},
-		}...)
-	}
-
-	for _, tc := range testcases {
-		t.Run(fmt.Sprintf("GW version:%v-Plugin Name:%v", tc.version, tc.inferredName), func(t *testing.T) {
-
-			newPluginPath := getPluginNameFromTykVersion(tc.version, tc.userDefinedName)
-			assert.Equal(t, tc.inferredName, newPluginPath)
 		})
 	}
 }

--- a/internal/build/README.md
+++ b/internal/build/README.md
@@ -1,0 +1,12 @@
+# Build package
+
+This package contains values that are injected by goreleaser at build
+time. The main used value in gateway is `VERSION`, notably by goplugins,
+as well as by the gateway itself, providing build information.
+
+This enables:
+
+```
+import "github.com/TykTechnologies/tyk/internal/build"
+// use build.VERSION
+```

--- a/internal/build/version.go
+++ b/internal/build/version.go
@@ -1,0 +1,17 @@
+package build
+
+// These values are injected at build-time from CI.
+var (
+	// Version contains the tagged gateway version. It may contain a `rc` suffix,
+	// which may be delimited with `-rc` or any other suffix. Follows Semver+Tag.
+	Version = "v5.3.0-dev"
+
+	// BuiltBy contains the environment name from the build (goreleaser).
+	BuiltBy string = "dev"
+
+	// BuildDate is the date the build was made at.
+	BuildDate string
+
+	// Commit is the commit hash for the build source.
+	Commit string
+)


### PR DESCRIPTION
[TT-7971] share version internally (#5705)

https://tyktech.atlassian.net/browse/TT-7971

This moves the injected version info into `internal/build` package.
This way it can be reused between all packages without polluting the
API.

- Updates cli.Init to not pass version over api,
- Updates goplugin.GetFileNameToLoad to not pass version,
- Marks gateway.VERSION and .Commit as deprecated
- Updates ci/goreleaser with the new ldflags params

Tested with CI tests passing and:

```
# go build -ldflags="-X github.com/TykTechnologies/tyk/internal/build.Version=1.2.3" . && ./tyk --version
1.2.3
```

Closes #4735

---------

Co-authored-by: Tit Petric <tit@tyk.io>