### PR TITLE
Merging to release-5.2: [TT-7971] Extend gateway with version command (#5708)

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -13,6 +13,7 @@ import (
 	"github.com/TykTechnologies/tyk/cli/importer"
 	"github.com/TykTechnologies/tyk/cli/linter"
 	"github.com/TykTechnologies/tyk/cli/plugin"
+	"github.com/TykTechnologies/tyk/cli/version"
 	"github.com/TykTechnologies/tyk/internal/build"
 	logger "github.com/TykTechnologies/tyk/log"
 )
@@ -97,6 +98,9 @@ func Init(confPaths []string) {
 		os.Exit(1)
 		return nil
 	})
+
+	// Add version command:
+	version.AddTo(app)
 
 	// Add import command:
 	importer.AddTo(app)

--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -1,0 +1,86 @@
+package version
+
+//lint:file-ignore faillint This file should be ignored by faillint (fmt in use).
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+	"strings"
+
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+
+	"github.com/TykTechnologies/tyk/internal/build"
+)
+
+const (
+	cmdName = "version"
+	cmdDesc = "Version and build information"
+)
+
+type versionInfo struct {
+	Version   string
+	BuiltBy   string
+	BuildDate string
+	Commit    string
+
+	// Go contains build related information
+	Go runtimeInfo
+
+	// Flags, unexposed
+	asJson *bool
+}
+
+type runtimeInfo struct {
+	Os      string
+	Arch    string
+	Version string
+}
+
+// String implements fmt.Stringer for the version info.
+func (v *versionInfo) String() string {
+	var output strings.Builder
+	output.WriteString("Release version: " + v.Version + "\n")
+	output.WriteString("Built by:        " + v.BuiltBy + "\n")
+	output.WriteString("Build date:      " + v.BuildDate + "\n")
+	output.WriteString("Commit:          " + v.Commit + "\n")
+	output.WriteString("Go version:      " + v.Go.Version + "\n")
+	output.WriteString("OS/Arch:         " + v.Go.Os + "/" + v.Go.Arch + "\n")
+	return output.String()
+}
+
+// Run is the entry point for printing out version information.
+func (v *versionInfo) Run(ctx *kingpin.ParseContext) (err error) {
+	if *v.asJson {
+		out, err := json.MarshalIndent(v, "", "    ")
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(string(out))
+		return nil
+	}
+
+	fmt.Println(v)
+	return nil
+}
+
+// AddTo initializes a version info object.
+func AddTo(app *kingpin.Application) {
+	cmd := app.Command(cmdName, cmdDesc)
+
+	info := &versionInfo{
+		Version:   build.Version,
+		BuiltBy:   build.BuiltBy,
+		BuildDate: build.BuildDate,
+		Commit:    build.Commit,
+		Go: runtimeInfo{
+			Os:      runtime.GOOS,
+			Arch:    runtime.GOARCH,
+			Version: runtime.Version(),
+		},
+		asJson: cmd.Flag("json", "Output in JSON format").Bool(),
+	}
+
+	cmd.Action(info.Run)
+}


### PR DESCRIPTION
[TT-7971] Extend gateway with version command (#5708)

Tested as follows, built gateway with injecting the build info:

```
# go build -ldflags="-X github.com/TykTechnologies/tyk/internal/build.Version={{.Version}} \
-X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}} \
-X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}} \
-X github.com/TykTechnologies/tyk/internal/build.BuiltBy=titpetric" .
```

Printing of build/runtime info:

```
# ./tyk version
Release version: {{.Version}}
Built by:        titpetric
Build date:      {{.Date}}
Commit:          {{.FullCommit}}
Go version:      go1.20
OS/Arch:         linux/amd64
```

Output as json with `--json` flag (for CI, `jq`, etc.)

```
# ./tyk version --json
{
    "Version": "{{.Version}}",
    "BuiltBy": "titpetric",
    "BuildDate": "{{.Date}}",
    "Commit": "{{.FullCommit}}",
    "Go": {
        "Os": "linux",
        "Arch": "amd64",
        "Version": "go1.20"
    }
}
```

https://tyktech.atlassian.net/browse/TT-7971

---------

Co-authored-by: Tit Petric <tit@tyk.io>

[TT-7971]: https://tyktech.atlassian.net/browse/TT-7971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ