### PR TITLE
[TT-10109] Fix policy lookup map distortion

### DIFF
--- a/gateway/middleware_test.go
+++ b/gateway/middleware_test.go
@@ -343,3 +343,65 @@ func TestSessionLimiter_RedisQuotaExceeded_PerAPI(t *testing.T) {
 	sendReqAndCheckQuota(t, apis[2].APIID, 24, false)
 	sendReqAndCheckQuota(t, apis[2].APIID, 23, false)
 }
+
+func TestCopyAllowedURLs(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input []user.AccessSpec
+	}{
+		{
+			name: "Copy non-empty slice of AccessSpec with non-empty Methods",
+			input: []user.AccessSpec{
+				{
+					URL:     "http://example.com",
+					Methods: []string{"GET", "POST"},
+				},
+				{
+					URL:     "http://example.org",
+					Methods: []string{"GET"},
+				},
+			},
+		},
+		{
+			name: "Copy non-empty slice of AccessSpec with empty Methods",
+			input: []user.AccessSpec{
+				{
+					URL:     "http://example.com",
+					Methods: []string{},
+				},
+				{
+					URL:     "http://example.org",
+					Methods: []string{},
+				},
+			},
+		},
+		{
+			name: "Copy non-empty slice of AccessSpec with nil Methods",
+			input: []user.AccessSpec{
+				{
+					URL:     "http://example.com",
+					Methods: nil,
+				},
+				{
+					URL:     "http://example.org",
+					Methods: nil,
+				},
+			},
+		},
+		{
+			name:  "Copy empty slice of AccessSpec",
+			input: []user.AccessSpec{},
+		},
+		{
+			name:  "Copy nil slice of AccessSpec",
+			input: []user.AccessSpec(nil),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			copied := copyAllowedURLs(tc.input)
+			assert.Equal(t, tc.input, copied)
+		})
+	}
+}

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -304,7 +304,7 @@ func (s *Test) TestPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesD
 			ID: "per_path_1",
 			AccessRights: map[string]user.AccessDefinition{"a": {
 				AllowedURLs: []user.AccessSpec{
-					{URL: "/user", Methods: []string{"GET"}},
+					{URL: "/user", Methods: []string{"GET", "POST"}},
 				},
 			}, "b": {
 				AllowedURLs: []user.AccessSpec{
@@ -316,7 +316,7 @@ func (s *Test) TestPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesD
 			ID: "per_path_2",
 			AccessRights: map[string]user.AccessDefinition{"a": {
 				AllowedURLs: []user.AccessSpec{
-					{URL: "/user", Methods: []string{"GET", "POST"}},
+					{URL: "/user", Methods: []string{"GET"}},
 					{URL: "/companies", Methods: []string{"GET", "POST"}},
 				},
 			}},
@@ -752,7 +752,7 @@ func (s *Test) TestPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesD
 		{
 			name:     "Merge per path rules for the same API",
 			policies: []string{"per-path2", "per-path1"},
-			sessMatch: func(t *testing.T, s *user.SessionState) {
+			sessMatch: func(t *testing.T, sess *user.SessionState) {
 				want := map[string]user.AccessDefinition{
 					"a": {
 						AllowedURLs: []user.AccessSpec{
@@ -769,7 +769,11 @@ func (s *Test) TestPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesD
 					},
 				}
 
-				assert.Equal(t, want, s.AccessRights)
+				assert.Equal(t, user.AccessSpec{
+					URL: "/user", Methods: []string{"GET"},
+				}, s.Gw.getPolicy("per-path2").AccessRights["a"].AllowedURLs[0])
+
+				assert.Equal(t, want, sess.AccessRights)
 			},
 		},
 		{


### PR DESCRIPTION
https://tyktech.atlassian.net/browse/TT-10109

The policy lookup map is distorted by `ApplyPolicies` function so it ends up wrong path base permission values in the session object.

See how it gets the original policy object and changes values inside it: https://github.com/TykTechnologies/tyk/blob/6c6b1535921543d2e2f34d65bbba7d67baffb547/gateway/middleware.go#L493