### PR TITLE
[TT-10189] add endpoint to purge expired oAuth tokens after retention period

### DIFF
--- a/gateway/api.go
+++ b/gateway/api.go
@@ -2559,6 +2559,25 @@ func (gw *Gateway) oAuthClientTokensHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	switch r.Method {
+	case http.MethodGet:
+		handleGetOAuthTokenForClients(w, r, keyName, apiSpec)
+	case http.MethodDelete:
+		handleDeleteExpiredTokensForClients(w, keyName, apiSpec)
+	}
+}
+
+func handleDeleteExpiredTokensForClients(w http.ResponseWriter, keyName string, apiSpec *APISpec) {
+	err := apiSpec.OAuthManager.OsinServer.Storage.PurgeExpiredTokens(keyName)
+	if err != nil {
+		doJSONWrite(w, http.StatusInternalServerError, apiError("purging expired tokens failed"))
+		return
+	}
+
+	doJSONWrite(w, http.StatusOK, apiOk("expired tokens purged"))
+}
+
+func handleGetOAuthTokenForClients(w http.ResponseWriter, r *http.Request, keyName string, apiSpec *APISpec) {
 	if p := r.URL.Query().Get("page"); p != "" {
 		page := 1
 

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -702,7 +702,7 @@ func (gw *Gateway) loadControlAPIEndpoints(muxer *mux.Router) {
 	r.HandleFunc("/certs/{certID:[^/]*}", gw.certHandler).Methods("POST", "GET", "DELETE")
 	r.HandleFunc("/oauth/clients/{apiID}", gw.oAuthClientHandler).Methods("GET", "DELETE")
 	r.HandleFunc("/oauth/clients/{apiID}/{keyName:[^/]*}", gw.oAuthClientHandler).Methods("GET", "DELETE")
-	r.HandleFunc("/oauth/clients/{apiID}/{keyName}/tokens", gw.oAuthClientTokensHandler).Methods("GET")
+	r.HandleFunc("/oauth/clients/{apiID}/{keyName}/tokens", gw.oAuthClientTokensHandler).Methods(http.MethodGet, http.MethodDelete)
 
 	r.HandleFunc("/schema", gw.schemaHandler).Methods(http.MethodGet)
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Add `DELETE` method to endpoint `/oauth/clients/{apiID}/{keyName}/tokens` to purge expired token after retention period. 

## Related Issue

https://tyktech.atlassian.net/browse/TT-10189

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
