### PR TITLE
Merging to release-5.2: [TT-10451] Remove init functions from gateway, enforce linting (#5761)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -75,6 +75,7 @@ linters:
     - ireturn
     - goerr113
   enable:
+    - gochecknoinits
     - thelper
     - errcheck
     - errorlint

--- a/.taskfiles/deps/Taskfile.yml
+++ b/.taskfiles/deps/Taskfile.yml
@@ -33,7 +33,7 @@ tasks:
     status:
       - type golangci-lint
     cmds:
-      - go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.0
+      - go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2
 
   faillint:
     internal: true

--- a/apidef/oas/validator.go
+++ b/apidef/oas/validator.go
@@ -27,9 +27,11 @@ const (
 )
 
 var (
-	log            = logger.Get()
+	log = logger.Get()
+
+	schemaOnce sync.Once
+
 	oasJSONSchemas map[string][]byte
-	mu             sync.Mutex
 	errorFormatter = func(errs []error) string {
 		var result strings.Builder
 		for i, err := range errs {
@@ -45,65 +47,63 @@ var (
 	defaultVersion string
 )
 
-func init() {
-	if err := loadOASSchema(); err != nil {
-		log.WithError(err).Error("loadOASSchema failed!")
-		return
-	}
-
-	setDefaultVersion()
-}
-
 func loadOASSchema() error {
-	mu.Lock()
-	defer mu.Unlock()
+	load := func() error {
+		xTykAPIGwSchema, err := schemaDir.ReadFile(fmt.Sprintf("schema/%s.json", ExtensionTykAPIGateway))
+		if err != nil {
+			return fmt.Errorf("%s loading failed: %w", ExtensionTykAPIGateway, err)
+		}
 
-	xTykAPIGwSchema, err := schemaDir.ReadFile(fmt.Sprintf("schema/%s.json", ExtensionTykAPIGateway))
-	if err != nil {
-		return fmt.Errorf("%s loading failed: %w", ExtensionTykAPIGateway, err)
+		xTykAPIGwSchemaWithoutDefs := jsonparser.Delete(xTykAPIGwSchema, keyDefinitions)
+		oasJSONSchemas = make(map[string][]byte)
+		members, err := schemaDir.ReadDir("schema")
+		for _, member := range members {
+			if member.IsDir() {
+				continue
+			}
+
+			fileName := member.Name()
+			if !strings.HasSuffix(fileName, ".json") {
+				continue
+			}
+
+			if strings.HasSuffix(fileName, fmt.Sprintf("%s.json", ExtensionTykAPIGateway)) {
+				continue
+			}
+
+			var data []byte
+			data, err = schemaDir.ReadFile(filepath.Join("schema/", fileName))
+			if err != nil {
+				return err
+			}
+
+			data, err = jsonparser.Set(data, xTykAPIGwSchemaWithoutDefs, keyProperties, ExtensionTykAPIGateway)
+			if err != nil {
+				return err
+			}
+
+			err = jsonparser.ObjectEach(xTykAPIGwSchema, func(key []byte, value []byte, dataType jsonparser.ValueType, offset int) error {
+				data, err = jsonparser.Set(data, value, keyDefinitions, string(key))
+				return err
+			}, keyDefinitions)
+			if err != nil {
+				return err
+			}
+
+			oasVersion := strings.TrimSuffix(fileName, ".json")
+			oasJSONSchemas[oasVersion] = data
+		}
+
+		setDefaultVersion()
+
+		return nil
 	}
 
-	xTykAPIGwSchemaWithoutDefs := jsonparser.Delete(xTykAPIGwSchema, keyDefinitions)
-	oasJSONSchemas = make(map[string][]byte)
-	members, err := schemaDir.ReadDir("schema")
-	for _, member := range members {
-		if member.IsDir() {
-			continue
-		}
-
-		fileName := member.Name()
-		if !strings.HasSuffix(fileName, ".json") {
-			continue
-		}
-
-		if strings.HasSuffix(fileName, fmt.Sprintf("%s.json", ExtensionTykAPIGateway)) {
-			continue
-		}
-
-		var data []byte
-		data, err = schemaDir.ReadFile(filepath.Join("schema/", fileName))
-		if err != nil {
-			return err
-		}
-
-		data, err = jsonparser.Set(data, xTykAPIGwSchemaWithoutDefs, keyProperties, ExtensionTykAPIGateway)
-		if err != nil {
-			return err
-		}
-
-		err = jsonparser.ObjectEach(xTykAPIGwSchema, func(key []byte, value []byte, dataType jsonparser.ValueType, offset int) error {
-			data, err = jsonparser.Set(data, value, keyDefinitions, string(key))
-			return err
-		}, keyDefinitions)
-		if err != nil {
-			return err
-		}
-
-		oasVersion := strings.TrimSuffix(fileName, ".json")
-		oasJSONSchemas[oasVersion] = data
-	}
-
-	return nil
+	var err error
+	schemaOnce.Do(func() {
+		err = load()
+	})
+	return err
 }
 
 // ValidateOASObject validates an OAS document against a particular OAS version.
@@ -137,8 +137,9 @@ func ValidateOASObject(documentBody []byte, oasVersion string) error {
 
 // GetOASSchema returns an oas schema for a particular version.
 func GetOASSchema(version string) ([]byte, error) {
-	mu.Lock()
-	defer mu.Unlock()
+	if err := loadOASSchema(); err != nil {
+		return nil, fmt.Errorf("loadOASSchema failed: %w", err)
+	}
 
 	if version == "" {
 		return oasJSONSchemas[defaultVersion], nil
@@ -171,8 +172,6 @@ func findDefaultVersion(rawVersions []string) string {
 }
 
 func setDefaultVersion() {
-	mu.Lock()
-	defer mu.Unlock()
 	var versions []string
 	for k := range oasJSONSchemas {
 		versions = append(versions, k)

--- a/cli/bundler/bundler.go
+++ b/cli/bundler/bundler.go
@@ -30,7 +30,7 @@ const (
 )
 
 var (
-	bundler *Bundler
+	bundler *Bundler = &Bundler{}
 
 	errNoHooks      = errors.New("No hooks defined")
 	errNoDriver     = errors.New("No driver specified")
@@ -47,10 +47,6 @@ type Bundler struct {
 	bundlePath   *string
 	skipSigning  *bool
 	manifestPath *string
-}
-
-func init() {
-	bundler = &Bundler{}
 }
 
 // Bundle is the entrypoint function for this subcommand.

--- a/cli/bundler/bundler_test.go
+++ b/cli/bundler/bundler_test.go
@@ -30,7 +30,7 @@ var (
 	}
 )
 
-func init() {
+func TestMain(m *testing.M) {
 	testApp = kingpin.New("tyk-cli", "")
 	AddTo(testApp)
 
@@ -39,6 +39,8 @@ func init() {
 	bundler.bundlePath = &bundlePath
 	manifestPath := defaultManifestPath
 	bundler.manifestPath = &manifestPath
+
+	os.Exit(m.Run())
 }
 
 func writeManifestFile(t testing.TB, manifest interface{}, filename string) *string {
@@ -69,6 +71,7 @@ func TestCommands(t *testing.T) {
 		t.Fatalf("Command not found")
 	}
 }
+
 func TestBuild(t *testing.T) {
 	defer os.Remove(defaultManifestPath)
 

--- a/cli/importer/importer.go
+++ b/cli/importer/importer.go
@@ -23,7 +23,8 @@ const (
 )
 
 var (
-	imp            *Importer
+	imp *Importer = &Importer{}
+
 	errUnknownMode = errors.New("Unknown mode")
 )
 
@@ -40,10 +41,6 @@ type Importer struct {
 	asMock         *bool
 	forAPI         *string
 	asVersion      *string
-}
-
-func init() {
-	imp = &Importer{}
 }
 
 // AddTo initializes an importer object.

--- a/coprocess/python/coprocess_id_extractor_python_test.go
+++ b/coprocess/python/coprocess_id_extractor_python_test.go
@@ -169,7 +169,7 @@ func TestValueExtractorHeaderSource(t *testing.T) {
 		ts := gateway.StartTest(nil, gateway.TestConfig{
 			CoprocessConfig: config.CoProcessConfig{
 				EnableCoProcess:  true,
-				PythonPathPrefix: pkgPath,
+				PythonPathPrefix: pkgPath(),
 			},
 		})
 		defer ts.Close()
@@ -195,7 +195,7 @@ func TestValueExtractorHeaderSource(t *testing.T) {
 		ts := gateway.StartTest(nil, gateway.TestConfig{
 			CoprocessConfig: config.CoProcessConfig{
 				EnableCoProcess:  true,
-				PythonPathPrefix: pkgPath,
+				PythonPathPrefix: pkgPath(),
 			},
 		})
 		defer ts.Close()
@@ -223,7 +223,7 @@ func TestValueExtractorHeaderSource(t *testing.T) {
 		ts := gateway.StartTest(nil, gateway.TestConfig{
 			CoprocessConfig: config.CoProcessConfig{
 				EnableCoProcess:  true,
-				PythonPathPrefix: pkgPath,
+				PythonPathPrefix: pkgPath(),
 			},
 		})
 		defer ts.Close()

--- a/coprocess/python/coprocess_python_test.go
+++ b/coprocess/python/coprocess_python_test.go
@@ -19,11 +19,9 @@ import (
 	"github.com/TykTechnologies/tyk/user"
 )
 
-var pkgPath string
-
-func init() {
+func pkgPath() string {
 	_, filename, _, _ := runtime.Caller(0)
-	pkgPath = filepath.Dir(filename) + "./../../"
+	return filepath.Dir(filename) + "./../../"
 }
 
 var pythonBundleWithAuthCheck = func(token1, token2 string) map[string]string {
@@ -224,7 +222,7 @@ func setupGateway() *gateway.Test {
 	ts := gateway.StartTest(nil, gateway.TestConfig{
 		CoprocessConfig: config.CoProcessConfig{
 			EnableCoProcess:  true,
-			PythonPathPrefix: pkgPath,
+			PythonPathPrefix: pkgPath(),
 		}})
 
 	return ts

--- a/dlpython/main_test.go
+++ b/dlpython/main_test.go
@@ -8,11 +8,13 @@ import (
 
 var testVersion = "3.5"
 
-func init() {
+func TestMain(m *testing.M) {
 	if versionOverride := os.Getenv("PYTHON_VERSION"); versionOverride != "" {
 		testVersion = versionOverride
 	}
 	fmt.Printf("Using Python %s for tests\n", testVersion)
+
+	os.Exit(m.Run())
 }
 
 func TestFindPythonConfig(t *testing.T) {

--- a/gateway/coprocess_bundle_test.go
+++ b/gateway/coprocess_bundle_test.go
@@ -22,11 +22,9 @@ var (
 	testBundlesPath = filepath.Join(testMiddlewarePath, "bundles")
 )
 
-var pkgPath string
-
-func init() {
+func pkgPath() string {
 	_, filename, _, _ := runtime.Caller(0)
-	pkgPath = filepath.Dir(filename) + "./.."
+	return filepath.Dir(filename) + "./.."
 }
 
 var grpcBundleWithAuthCheck = map[string]string{
@@ -233,7 +231,7 @@ func TestResponseOverride(t *testing.T) {
 	ts := StartTest(nil, TestConfig{
 		CoprocessConfig: config.CoProcessConfig{
 			EnableCoProcess:  true,
-			PythonPathPrefix: pkgPath,
+			PythonPathPrefix: pkgPath(),
 			PythonVersion:    pythonVersion,
 		}})
 	defer ts.Close()

--- a/gateway/handler_error.go
+++ b/gateway/handler_error.go
@@ -47,50 +47,9 @@ func errorAndStatusCode(errType string) (error, int) {
 
 func defaultTykErrors() {
 	TykErrors = make(map[string]config.TykError)
-	TykErrors[ErrAuthAuthorizationFieldMissing] = config.TykError{
-		Message: MsgAuthFieldMissing,
-		Code:    http.StatusUnauthorized,
-	}
 
-	TykErrors[ErrAuthKeyNotFound] = config.TykError{
-		Message: MsgApiAccessDisallowed,
-		Code:    http.StatusForbidden,
-	}
-
-	TykErrors[ErrAuthCertNotFound] = config.TykError{
-		Message: MsgApiAccessDisallowed,
-		Code:    http.StatusForbidden,
-	}
-
-	TykErrors[ErrAuthCertExpired] = config.TykError{
-		Message: MsgCertificateExpired,
-		Code:    http.StatusForbidden,
-	}
-
-	TykErrors[ErrAuthKeyIsInvalid] = config.TykError{
-		Message: MsgApiAccessDisallowed,
-		Code:    http.StatusForbidden,
-	}
-
-	TykErrors[ErrOAuthAuthorizationFieldMissing] = config.TykError{
-		Message: MsgAuthFieldMissing,
-		Code:    http.StatusBadRequest,
-	}
-
-	TykErrors[ErrOAuthAuthorizationFieldMalformed] = config.TykError{
-		Message: MsgBearerMailformed,
-		Code:    http.StatusBadRequest,
-	}
-
-	TykErrors[ErrOAuthKeyNotFound] = config.TykError{
-		Message: MsgKeyNotAuthorized,
-		Code:    http.StatusForbidden,
-	}
-
-	TykErrors[ErrOAuthClientDeleted] = config.TykError{
-		Message: MsgOauthClientRevoked,
-		Code:    http.StatusForbidden,
-	}
+	initAuthKeyErrors()
+	initOauth2KeyExistsErrors()
 }
 
 func overrideTykErrors(gw *Gateway) {

--- a/gateway/mw_auth_key.go
+++ b/gateway/mw_auth_key.go
@@ -35,7 +35,7 @@ const (
 	MsgInvalidKey      = "Attempted access with invalid key."
 )
 
-func init() {
+func initAuthKeyErrors() {
 	TykErrors[ErrAuthAuthorizationFieldMissing] = config.TykError{
 		Message: MsgAuthFieldMissing,
 		Code:    http.StatusUnauthorized,

--- a/gateway/mw_oauth2_key_exists.go
+++ b/gateway/mw_oauth2_key_exists.go
@@ -22,24 +22,24 @@ const (
 	ErrOAuthClientDeleted               = "oauth.client_deleted"
 )
 
-func init() {
+func initOauth2KeyExistsErrors() {
 	TykErrors[ErrOAuthAuthorizationFieldMissing] = config.TykError{
-		Message: "Authorization field missing",
+		Message: MsgAuthFieldMissing,
 		Code:    http.StatusBadRequest,
 	}
 
 	TykErrors[ErrOAuthAuthorizationFieldMalformed] = config.TykError{
-		Message: "Bearer token malformed",
+		Message: MsgBearerMailformed,
 		Code:    http.StatusBadRequest,
 	}
 
 	TykErrors[ErrOAuthKeyNotFound] = config.TykError{
-		Message: "Key not authorised",
+		Message: MsgKeyNotAuthorized,
 		Code:    http.StatusForbidden,
 	}
 
 	TykErrors[ErrOAuthClientDeleted] = config.TykError{
-		Message: "Key not authorised. OAuth client access was revoked",
+		Message: MsgOauthClientRevoked,
 		Code:    http.StatusForbidden,
 	}
 }

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -333,6 +333,8 @@ func (gw *Gateway) setupGlobals() {
 	gw.reloadMu.Lock()
 	defer gw.reloadMu.Unlock()
 
+	defaultTykErrors()
+
 	gwConfig := gw.GetConfig()
 	checkup.Run(&gwConfig)
 

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -231,6 +231,8 @@ func (r *ReloadMachinery) TickOk(t *testing.T) {
 }
 
 func InitTestMain(ctx context.Context, m *testing.M) int {
+	test.InitTestMain(ctx, m)
+
 	if EnableTestDNSMock {
 		var errMock error
 		MockHandle, errMock = test.InitDNSMock(test.DomainsToAddresses, nil)

--- a/log/log.go
+++ b/log/log.go
@@ -48,6 +48,7 @@ func (f *RawFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	return []byte(entry.Message), nil
 }
 
+//nolint:gochecknoinits
 func init() {
 	formatter := new(logrus.TextFormatter)
 	formatter.TimestampFormat = `Jan 02 15:04:05`

--- a/rpc/synchronization_forcer_test.go
+++ b/rpc/synchronization_forcer_test.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -14,7 +15,7 @@ import (
 
 var rc *storage.RedisController
 
-func init() {
+func TestMain(m *testing.M) {
 	conf, err := config.New()
 	if err != nil {
 		panic(err)
@@ -30,6 +31,8 @@ func init() {
 	if !connected {
 		panic("can't connect to redis '" + conf.Storage.Host + "', timeout")
 	}
+
+	os.Exit(m.Run())
 }
 
 func TestNewSyncForcer(t *testing.T) {

--- a/test/init.go
+++ b/test/init.go
@@ -1,37 +1,40 @@
 package test
 
 import (
+	"context"
 	"log"
 	"net/http"
 	"os"
 	"strconv"
 	"sync"
+	"testing"
 
 	_ "net/http/pprof"
 )
 
 var initOnce sync.Once
 
-func init() {
-	if interval := os.Getenv("TEST_MONITOR_INTERVAL"); interval != "" {
-		initOnce.Do(func() {
+func InitTestMain(_ context.Context, _ *testing.M) {
+	initOnce.Do(func() {
+		// Poor mans resource monitoring, prints runtime stats into logs
+		if interval := os.Getenv("TEST_MONITOR_INTERVAL"); interval != "" {
 			val, _ := strconv.Atoi(interval)
 			if val < 1 {
 				val = 1
 			}
 			go NewMonitor(val)
-		})
-	}
-
-	if pprof := os.Getenv("TEST_PPROF_ENABLE"); pprof == "1" {
-		var listen string
-		if listen = os.Getenv("TEST_PPROF_ADDR"); listen == "" {
-			listen = ":12345"
 		}
-		go func() {
-			log.Printf("Starting pprof on addr=%q", listen)
-			_ = http.ListenAndServe(listen, nil)
-		}()
-	}
 
+		// Enable pprof server from test env
+		if pprof := os.Getenv("TEST_PPROF_ENABLE"); pprof == "1" {
+			var listen string
+			if listen = os.Getenv("TEST_PPROF_ADDR"); listen == "" {
+				listen = ":12345"
+			}
+			go func() {
+				log.Printf("Starting pprof on addr=%q", listen)
+				_ = http.ListenAndServe(listen, nil)
+			}()
+		}
+	})
 }


### PR DESCRIPTION
[TT-10451] Remove init functions from gateway, enforce linting (#5761)

https://tyktech.atlassian.net/browse/TT-10451

Removes all init funcs except `/log`, we exclude that one from linting.

Unwanted behaviour fixes:

- test package init() leaked into prod code, enabling pprof server start
and a resource monitor
- gateway defaultTykErrors reset errors and duplicated code from two
init functions
- init oauth2 errors function updated to use declared consts

To resolve the first, an `test.InitTestMain` function is added and
invoked from gateway.InitTestMain

To verify:

```
golangci-lint run --no-config --disable-all -E gochecknoinits -v ./...
```

---------

Co-authored-by: Tit Petric <tit@tyk.io>

[TT-10451]: https://tyktech.atlassian.net/browse/TT-10451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ