### PR TITLE
[TT-10518] Tests/address some racy tests

### DIFF
--- a/gateway/looping_test.go
+++ b/gateway/looping_test.go
@@ -1,5 +1,5 @@
-//go:build !race
-// +build !race
+//go:build !race || unstable
+// +build !race unstable
 
 // Looping by itself has race nature
 package gateway
@@ -185,6 +185,8 @@ func TestLooping(t *testing.T) {
 	})
 
 	t.Run("VirtualEndpoint or plugins", func(t *testing.T) {
+		test.Flaky(t) // TT-10511
+
 		ts.testPrepareVirtualEndpoint(`
             function testVirtData(request, session, config) {
                 var loopLocation = "/default"
@@ -326,6 +328,8 @@ func TestLooping(t *testing.T) {
 }
 
 func TestConcurrencyReloads(t *testing.T) {
+	test.Racy(t) // TT-10510
+
 	var wg sync.WaitGroup
 
 	ts := StartTest(nil)

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -242,10 +242,14 @@ type BaseMiddleware struct {
 }
 
 func (t *BaseMiddleware) Base() *BaseMiddleware {
+	t.loggerMu.Lock()
+	defer t.loggerMu.Unlock()
+
 	return &BaseMiddleware{
-		Spec:  t.Spec,
-		Proxy: t.Proxy,
-		Gw:    t.Gw,
+		Spec:   t.Spec,
+		Proxy:  t.Proxy,
+		Gw:     t.Gw,
+		logger: t.logger,
 	}
 }
 

--- a/gateway/mw_organisation_activity_test.go
+++ b/gateway/mw_organisation_activity_test.go
@@ -1,5 +1,5 @@
-//go:build !race
-// +build !race
+//go:build !race || unstable
+// +build !race unstable
 
 package gateway
 

--- a/gateway/rpc_test.go
+++ b/gateway/rpc_test.go
@@ -1,5 +1,5 @@
-//go:build !race
-// +build !race
+//go:build !race || unstable
+// +build !race unstable
 
 package gateway
 


### PR DESCRIPTION
- Adds `unstable` build tag to tests with `!race` (so we can run them with `-race -tags=unstable`)
- Fixes a race over base middleware Logger(), SetLogger() and Base()
- looping tests marked as flaky or racy respectively (jira tickets in comments)

https://tyktech.atlassian.net/browse/TT-10518
