### PR TITLE
Merging to release-5.2: [TT-10531] improve plugin tests area (#5777)

### DIFF
--- a/bin/ci-tests.sh
+++ b/bin/ci-tests.sh
@@ -17,7 +17,8 @@ set -e
 
 # build Go-plugin used in tests
 echo "Building go plugin"
-go build -race -o ./test/goplugins/goplugins.so -buildmode=plugin ./test/goplugins
+go build -o ./test/goplugins/goplugins.so -buildmode=plugin ./test/goplugins
+go build -race -o ./test/goplugins/goplugins_race.so -buildmode=plugin ./test/goplugins
 
 for pkg in ${PKGS}; do
     tags=""

--- a/goplugin/mw_go_plugin_test.go
+++ b/goplugin/mw_go_plugin_test.go
@@ -19,6 +19,13 @@ import (
 	"github.com/TykTechnologies/tyk/test"
 )
 
+func goPluginFilename() string {
+	if test.IsRaceEnabled() {
+		return "../test/goplugins/goplugins_race.so"
+	}
+	return "../test/goplugins/goplugins.so"
+}
+
 /*func TestMain(m *testing.M) {
 	os.Exit(gateway.InitTestMain(context.Background(), m))
 }*/
@@ -43,23 +50,23 @@ func TestGoPluginMWs(t *testing.T) {
 			Pre: []apidef.MiddlewareDefinition{
 				{
 					Name: "MyPluginPre",
-					Path: "../test/goplugins/goplugins.so",
+					Path: goPluginFilename(),
 				},
 			},
 			AuthCheck: apidef.MiddlewareDefinition{
 				Name: "MyPluginAuthCheck",
-				Path: "../test/goplugins/goplugins.so",
+				Path: goPluginFilename(),
 			},
 			PostKeyAuth: []apidef.MiddlewareDefinition{
 				{
 					Name: "MyPluginPostKeyAuth",
-					Path: "../test/goplugins/goplugins.so",
+					Path: goPluginFilename(),
 				},
 			},
 			Post: []apidef.MiddlewareDefinition{
 				{
 					Name: "MyPluginPost",
-					Path: "../test/goplugins/goplugins.so",
+					Path: goPluginFilename(),
 				},
 			},
 		}
@@ -78,23 +85,23 @@ func TestGoPluginMWs(t *testing.T) {
 			Pre: []apidef.MiddlewareDefinition{
 				{
 					Name: "MyPluginPre",
-					Path: "../test/goplugins/goplugins.so",
+					Path: goPluginFilename(),
 				},
 			},
 			AuthCheck: apidef.MiddlewareDefinition{
 				Name: "MyPluginAuthCheck",
-				Path: "../test/goplugins/goplugins.so",
+				Path: goPluginFilename(),
 			},
 			PostKeyAuth: []apidef.MiddlewareDefinition{
 				{
 					Name: "MyPluginPostKeyAuth",
-					Path: "../test/goplugins/goplugins.so",
+					Path: goPluginFilename(),
 				},
 			},
 			Post: []apidef.MiddlewareDefinition{
 				{
 					Name: "MyPluginPost",
-					Path: "../test/goplugins/goplugins.so",
+					Path: goPluginFilename(),
 				},
 			},
 		}
@@ -113,21 +120,21 @@ func TestGoPluginMWs(t *testing.T) {
 				{
 					Disabled: true,
 					Name:     "MyPluginPre",
-					Path:     "../test/goplugins/goplugins.so",
+					Path:     goPluginFilename(),
 				},
 			},
 			PostKeyAuth: []apidef.MiddlewareDefinition{
 				{
 					Disabled: true,
 					Name:     "MyPluginPostKeyAuth",
-					Path:     "../test/goplugins/goplugins.so",
+					Path:     goPluginFilename(),
 				},
 			},
 			Post: []apidef.MiddlewareDefinition{
 				{
 					Disabled: true,
 					Name:     "MyPluginPost",
-					Path:     "../test/goplugins/goplugins.so",
+					Path:     goPluginFilename(),
 				},
 			},
 		}
@@ -148,26 +155,26 @@ func TestGoPluginMWs(t *testing.T) {
 					{
 						Disabled: true,
 						Name:     "MyPluginPre",
-						Path:     "../test/goplugins/goplugins.so",
+						Path:     goPluginFilename(),
 					},
 				},
 				AuthCheck: apidef.MiddlewareDefinition{
 					Disabled: true,
 					Name:     "MyPluginAuthCheck",
-					Path:     "../test/goplugins/goplugins.so",
+					Path:     goPluginFilename(),
 				},
 				PostKeyAuth: []apidef.MiddlewareDefinition{
 					{
 						Disabled: true,
 						Name:     "MyPluginPostKeyAuth",
-						Path:     "../test/goplugins/goplugins.so",
+						Path:     goPluginFilename(),
 					},
 				},
 				Post: []apidef.MiddlewareDefinition{
 					{
 						Disabled: true,
 						Name:     "MyPluginPost",
-						Path:     "../test/goplugins/goplugins.so",
+						Path:     goPluginFilename(),
 					},
 				},
 			}
@@ -289,7 +296,7 @@ func TestGoPluginResponseHook(t *testing.T) {
 			Response: []apidef.MiddlewareDefinition{
 				{
 					Name: "MyPluginResponse",
-					Path: "../test/goplugins/goplugins.so",
+					Path: goPluginFilename(),
 				},
 			},
 		}
@@ -329,21 +336,21 @@ func TestGoPluginPerPathSingleFile(t *testing.T) {
 		goPluginMetaFoo := apidef.GoPluginMeta{
 			Path:       "/foo",
 			Method:     "GET",
-			PluginPath: "../test/goplugins/goplugins.so",
+			PluginPath: goPluginFilename(),
 			SymbolName: "MyPluginPerPathFoo",
 		}
 
 		goPluginMetaBar := apidef.GoPluginMeta{
 			Path:       "/bar",
 			Method:     "GET",
-			PluginPath: "../test/goplugins/goplugins.so",
+			PluginPath: goPluginFilename(),
 			SymbolName: "MyPluginPerPathBar",
 		}
 
 		goPluginMetaResp := apidef.GoPluginMeta{
 			Path:       "/resp",
 			Method:     "GET",
-			PluginPath: "../test/goplugins/goplugins.so",
+			PluginPath: goPluginFilename(),
 			SymbolName: "MyPluginPerPathResp",
 		}
 
@@ -351,7 +358,7 @@ func TestGoPluginPerPathSingleFile(t *testing.T) {
 			Disabled:   true,
 			Path:       "/disabled",
 			Method:     "GET",
-			PluginPath: "../test/goplugins/goplugins.so",
+			PluginPath: goPluginFilename(),
 			SymbolName: "MyPluginPerPathResp",
 		}
 
@@ -424,14 +431,14 @@ func TestGoPluginAPIandPerPath(t *testing.T) {
 			Pre: []apidef.MiddlewareDefinition{
 				{
 					Name: "MyPluginPre",
-					Path: "../test/goplugins/goplugins.so",
+					Path: goPluginFilename(),
 				},
 			},
 		}
 		goPluginMetaFoo := apidef.GoPluginMeta{
 			Path:       "/foo",
 			Method:     "GET",
-			PluginPath: "../test/goplugins/goplugins.so",
+			PluginPath: goPluginFilename(),
 			SymbolName: "MyPluginPerPathFoo",
 		}
 		v := spec.VersionData.Versions["v1"]
@@ -533,7 +540,7 @@ func TestGoPlugin_AccessingOASAPIDef(t *testing.T) {
 			Pre: []apidef.MiddlewareDefinition{
 				{
 					Name: "MyPluginAccessingOASAPI",
-					Path: "../test/goplugins/goplugins.so",
+					Path: goPluginFilename(),
 				},
 			},
 		}
@@ -563,7 +570,7 @@ func TestGoPlugin_PreventDoubleError(t *testing.T) {
 			Pre: []apidef.MiddlewareDefinition{
 				{
 					Name: "MyPluginReturningError",
-					Path: "../test/goplugins/goplugins.so",
+					Path: goPluginFilename(),
 				},
 			},
 		}
@@ -599,7 +606,7 @@ func TestGoPlugin_ApplyPolicy(t *testing.T) {
 			Pre: []apidef.MiddlewareDefinition{
 				{
 					Name: "MyPluginApplyingPolicy",
-					Path: "../test/goplugins/goplugins.so",
+					Path: goPluginFilename(),
 				},
 			},
 		}

--- a/test/race_off.go
+++ b/test/race_off.go
@@ -1,0 +1,8 @@
+//go:build !race
+// +build !race
+
+package test
+
+func IsRaceEnabled() bool {
+	return false
+}

--- a/test/race_on.go
+++ b/test/race_on.go
@@ -1,0 +1,8 @@
+//go:build race
+// +build race
+
+package test
+
+func IsRaceEnabled() bool {
+	return true
+}

--- a/test/race_test.go
+++ b/test/race_test.go
@@ -1,0 +1,11 @@
+package test
+
+import "testing"
+
+func TestIsRaceEnabled(t *testing.T) {
+	if enabled := IsRaceEnabled(); enabled {
+		t.Log("Flag -race passed")
+	} else {
+		t.Log("Flag -race omitted")
+	}
+}


### PR DESCRIPTION
[TT-10531] improve plugin tests area (#5777)

PR does the following:

- compiles a plugin with and without race
- adds test.IsRaceEnabled
- fixes goplugin tests to load appropriate plugin

https://tyktech.atlassian.net/browse/TT-10531

---------

Co-authored-by: Tit Petric <tit@tyk.io>

[TT-10531]: https://tyktech.atlassian.net/browse/TT-10531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ