### PR TITLE
[TT-10555] Fix/trimpath plugin compatibility and loading

### DIFF
--- a/ci/images/plugin-compiler/data/build.sh
+++ b/ci/images/plugin-compiler/data/build.sh
@@ -78,7 +78,7 @@ if [[ "$GO_GET" == "1" ]]; then
 	go get github.com/TykTechnologies/tyk@${GITHUB_SHA}
 fi
 
-CC=$CC CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH go build -buildmode=plugin -trimpath -o $plugin_name
+CC=$CC CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH go build -buildmode=plugin -ldflags "-pluginpath=${PLUGIN_BUILD_PATH}" -o $plugin_name
 set +x
 
 mv $plugin_name $PLUGIN_SOURCE_PATH

--- a/ci/images/plugin-compiler/data/build.sh
+++ b/ci/images/plugin-compiler/data/build.sh
@@ -67,6 +67,14 @@ go work use ./$(basename $PLUGIN_BUILD_PATH)
 # Go to plugin build path
 cd $PLUGIN_BUILD_PATH
 
+if [ -n "${plugin_id}" ]; then
+	for filename in $(find ./ -name "*.go"); do
+		path=$(dirname $filename)
+		name=$(basename $filename)
+		mv $filename $path/${plugin_id}_$name
+	done
+fi
+
 # Dump settings for inspection
 
 echo "PLUGIN_BUILD_PATH: ${PLUGIN_BUILD_PATH}"
@@ -78,10 +86,11 @@ if [[ "$GO_GET" == "1" ]]; then
 	go get github.com/TykTechnologies/tyk@${GITHUB_SHA}
 fi
 
-CC=$CC CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH go build -buildmode=plugin -ldflags "-pluginpath=${PLUGIN_BUILD_PATH}" -o $plugin_name
+CC=$CC CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH go build -buildmode=plugin -trimpath -o $plugin_name
+
 set +x
 
-mv $plugin_name $PLUGIN_SOURCE_PATH
+mv *.so $PLUGIN_SOURCE_PATH
 
 # Clean up workspace
 rm -f $WORKSPACE_ROOT/go.work

--- a/ci/tests/plugin-compiler/Taskfile.yml
+++ b/ci/tests/plugin-compiler/Taskfile.yml
@@ -30,6 +30,7 @@ tasks:
     desc: "Run plugin compiler tests"
     cmds:
       - task: test:basic-plugin
+      - task: test:basic-plugin-id
       - task: test:test-plugin
 
   test:basic-plugin:
@@ -37,21 +38,39 @@ tasks:
     vars:
       plugin_path: '{{.root}}/ci/tests/plugin-compiler/testdata/basic-plugin'
       symbol: MyPluginPre
-      args: --rm -v {{.plugin_path}}:/plugin-source -w /plugin-source
+      args: --rm -e DEBUG=1 -v {{.plugin_path}}:/plugin-source -w /plugin-source
     cmds:
       - rm -f {{.plugin_path}}/*.so
       - docker run {{.args}} {{.image}} plugin.so
       - cp -f {{.plugin_path}}/*.so {{.plugin_path}}/plugin.so
       - docker run {{.args}} --entrypoint=/usr/local/bin/tyk {{.image}} plugin load -f plugin.so -s {{.symbol}}
+      - strings {{.plugin_path}}/plugin.so | grep test_goplugin.go
+
+  test:basic-plugin-id:
+    desc: "Test plugin compiler (basic-plugin)"
+    vars:
+      plugin_path: '{{.root}}/ci/tests/plugin-compiler/testdata/basic-plugin'
+      symbol: MyPluginPre
+      args: --rm -e DEBUG=1 -v {{.plugin_path}}:/plugin-source -w /plugin-source
+    cmds:
+      - rm -f {{.plugin_path}}/*.so
+      - docker run {{.args}} {{.image}} plugin.so 123
+      - mv -f {{.plugin_path}}/plugin_*.so {{.plugin_path}}/plugin1.so
+      - docker run {{.args}} {{.image}} plugin.so 456
+      - mv -f {{.plugin_path}}/plugin_*.so {{.plugin_path}}/plugin2.so
+      - docker run {{.args}} --entrypoint=/usr/local/bin/tyk {{.image}} plugin load -f plugin1.so,plugin2.so -s {{.symbol}}
+      - strings {{.plugin_path}}/plugin*.so | grep test_goplugin.go
+
 
   test:test-plugin:
     desc: "Test plugin compiler (test-plugin)"
     vars:
       plugin_path: '{{.root}}/ci/tests/plugin-compiler/testdata/test-plugin'
       symbol: AddFooBarHeader
-      args: --rm -v {{.plugin_path}}:/plugin-source -w /plugin-source
+      args: --rm -e DEBUG=1 -v {{.plugin_path}}:/plugin-source -w /plugin-source
     cmds:
       - rm -f {{.plugin_path}}/*.so
       - docker run {{.args}} {{.image}} plugin.so
       - cp -f {{.plugin_path}}/*.so {{.plugin_path}}/plugin.so
       - docker run {{.args}} --entrypoint=/usr/local/bin/tyk {{.image}} plugin load -f plugin.so -s {{.symbol}}
+      - strings {{.plugin_path}}/plugin.so | grep main.go

--- a/ci/tests/plugin-compiler/Taskfile.yml
+++ b/ci/tests/plugin-compiler/Taskfile.yml
@@ -31,7 +31,57 @@ tasks:
     cmds:
       - task: test:basic-plugin
       - task: test:basic-plugin-id
+      - task: test:complex-plugin
       - task: test:test-plugin
+
+  test:basic-plugin-invalid:
+    desc: "Test plugin compiler (basic-plugin)"
+    deps: [test:basic-plugin-sync]
+    vars:
+      plugin_path: '{{.root}}/ci/tests/plugin-compiler/testdata/basic-plugin-test'
+      symbol: MyPluginPre
+      args: --rm -v {{.plugin_path}}:/plugin-source -w /plugin-source
+    cmds:
+      - rm -f {{.plugin_path}}/*.so
+      - docker run {{.args}} {{.image}} plugin.so 666
+
+  test:basic-plugin-sync:
+    desc: "Prepare complex-plugin-test/"
+    internal: true
+    dir: ./testdata
+    cmds:
+      - rsync -a --del ./basic-plugin/ ./basic-plugin-test/
+      - cd basic-plugin-test && go mod edit -module com
+
+  test:complex-plugin:
+    desc: "Test import replacement + plugin_id"
+    deps: [test:complex-plugin-sync]
+    dir: ./testdata/complex-plugin-test
+    vars:
+      plugin_path: '{{.root}}/ci/tests/plugin-compiler/testdata/complex-plugin-test'
+      symbol: MyPluginPre
+      args: --rm -e DEBUG=1 -v {{.plugin_path}}:/plugin-source -w /plugin-source
+    cmds:
+      - rm -f {{.plugin_path}}/*.so
+      - docker run {{.args}} {{.image}} plugin.so 123
+      - mv -f {{.plugin_path}}/plugin_*.so {{.plugin_path}}/plugin1.so
+      - docker run {{.args}} {{.image}} plugin.so 456
+      - mv -f {{.plugin_path}}/plugin_*.so {{.plugin_path}}/plugin2.so
+      - docker run {{.args}} --entrypoint=/usr/local/bin/tyk {{.image}} plugin load -f plugin1.so,plugin2.so -s {{.symbol}}
+      - strings {{.plugin_path}}/plugin*.so | grep plugin.go
+
+  test:complex-plugin-sync:
+    desc: "Prepare complex-plugin-test/"
+    internal: true
+    dir: ./testdata
+    cmds:
+      - rsync -a --del ./complex-plugin/ ./complex-plugin-test/
+
+  complex-plugin-test:
+    desc: "Prepare a complex plugin test folder"
+    internal: true
+    cmds:
+
 
   test:basic-plugin:
     desc: "Test plugin compiler (basic-plugin)"
@@ -60,7 +110,6 @@ tasks:
       - mv -f {{.plugin_path}}/plugin_*.so {{.plugin_path}}/plugin2.so
       - docker run {{.args}} --entrypoint=/usr/local/bin/tyk {{.image}} plugin load -f plugin1.so,plugin2.so -s {{.symbol}}
       - strings {{.plugin_path}}/plugin*.so | grep test_goplugin.go
-
 
   test:test-plugin:
     desc: "Test plugin compiler (test-plugin)"

--- a/ci/tests/plugin-compiler/testdata/.gitignore
+++ b/ci/tests/plugin-compiler/testdata/.gitignore
@@ -3,3 +3,4 @@
 
 # Ignore test scratch folder
 /complex-plugin-test
+/basic-plugin-test

--- a/ci/tests/plugin-compiler/testdata/.gitignore
+++ b/ci/tests/plugin-compiler/testdata/.gitignore
@@ -1,2 +1,5 @@
 # Ignore built assets
 *.so
+
+# Ignore test scratch folder
+/complex-plugin-test

--- a/ci/tests/plugin-compiler/testdata/Taskfile.yml
+++ b/ci/tests/plugin-compiler/testdata/Taskfile.yml
@@ -1,7 +1,10 @@
 # This taskfile aims to test the package replacement from a go.mod package.
 # To support "plugin_id", the package name in the go.mod for a plugin is amended,
 # and the imports in the plugin corrected to the new import path.
-
+#
+# For the plugin compiler, the test is replicated one folder up:
+#
+# - `task test:complex-plugin`
 ---
 version: "3"
 
@@ -11,13 +14,7 @@ env:
 
 tasks:
   default:
-    desc: "Test govers import replacement (dry run)"
-    dir: ./complex-plugin
-    cmds:
-      - govers -m example.com/basic-plugin -d -n example.com/basic-plugin/v123
-
-  replace:
-    desc: "Test govers import replacement (real)"
+    desc: "Test import replacement"
     deps: [ complex-plugin-test ]
     dir: ./complex-plugin-test
     cmds:
@@ -28,7 +25,7 @@ tasks:
       - go test -count=1 -race -v ./...
 
   complex-plugin-test:
-    desc: "Prepare a complex plugin test folder"
+    desc: "Prepare complex-plugin-test/"
     internal: true
     cmds:
       - rsync -a --del ./complex-plugin/ ./complex-plugin-test/

--- a/ci/tests/plugin-compiler/testdata/Taskfile.yml
+++ b/ci/tests/plugin-compiler/testdata/Taskfile.yml
@@ -1,0 +1,34 @@
+# This taskfile aims to test the package replacement from a go.mod package.
+# To support "plugin_id", the package name in the go.mod for a plugin is amended,
+# and the imports in the plugin corrected to the new import path.
+
+---
+version: "3"
+
+env:
+  OLD_MODULE: example.com/basic-plugin
+  NEW_MODULE: example.com/basic-plugin/v123
+
+tasks:
+  default:
+    desc: "Test govers import replacement (dry run)"
+    dir: ./complex-plugin
+    cmds:
+      - govers -m example.com/basic-plugin -d -n example.com/basic-plugin/v123
+
+  replace:
+    desc: "Test govers import replacement (real)"
+    deps: [ complex-plugin-test ]
+    dir: ./complex-plugin-test
+    cmds:
+      - go get github.com/TykTechnologies/tyk@master
+      - go mod edit -module $NEW_MODULE
+      - find ./ -type f -name '*.go' -exec sed -i -e "s,\"${OLD_MODULE},\"${NEW_MODULE},g" {} \;
+      - go build -buildmode=plugin -trimpath .
+      - go test -count=1 -race -v ./...
+
+  complex-plugin-test:
+    desc: "Prepare a complex plugin test folder"
+    internal: true
+    cmds:
+      - rsync -a --del ./complex-plugin/ ./complex-plugin-test/

--- a/ci/tests/plugin-compiler/testdata/complex-plugin/README.md
+++ b/ci/tests/plugin-compiler/testdata/complex-plugin/README.md
@@ -5,5 +5,5 @@ import paths. The import paths get replaced in plugin compiler.
 
 It's a structural rewrite of `../basic-plugin` and adds no new functionality.
 
-For more details about the test case, run `task replace` in parent folder,
-or cross reference with the implementation of plugin_id in plugin compiler.
+For more details about the test case, run `task` in parent folder, or
+cross reference with the implementation of plugin_id in plugin compiler.

--- a/ci/tests/plugin-compiler/testdata/complex-plugin/README.md
+++ b/ci/tests/plugin-compiler/testdata/complex-plugin/README.md
@@ -1,0 +1,9 @@
+# Complex plugin
+
+This location serves as a more complex plugin that has self-referencing
+import paths. The import paths get replaced in plugin compiler.
+
+It's a structural rewrite of `../basic-plugin` and adds no new functionality.
+
+For more details about the test case, run `task replace` in parent folder,
+or cross reference with the implementation of plugin_id in plugin compiler.

--- a/ci/tests/plugin-compiler/testdata/complex-plugin/analytics/plugin.go
+++ b/ci/tests/plugin-compiler/testdata/complex-plugin/analytics/plugin.go
@@ -1,0 +1,60 @@
+package analytics
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/base64"
+	"net/http"
+
+	"github.com/buger/jsonparser"
+
+	"github.com/TykTechnologies/tyk-pump/analytics"
+)
+
+func MyAnalyticsPluginDeleteHeader(record *analytics.AnalyticsRecord) {
+	str, err := base64.StdEncoding.DecodeString(record.RawResponse)
+	if err != nil {
+		return
+	}
+
+	var b = &bytes.Buffer{}
+	b.Write(str)
+
+	r := bufio.NewReader(b)
+	var resp *http.Response
+	resp, err = http.ReadResponse(r, nil)
+	if err != nil {
+		return
+	}
+	resp.Header.Del("Server")
+	var bNew bytes.Buffer
+	_ = resp.Write(&bNew)
+	record.RawResponse = base64.StdEncoding.EncodeToString(bNew.Bytes())
+}
+
+func MyAnalyticsPluginMaskJSONLoginBody(record *analytics.AnalyticsRecord) {
+	if record.ContentLength < 1 {
+		return
+	}
+	d, err := base64.StdEncoding.DecodeString(record.RawRequest)
+	if err != nil {
+		return
+	}
+	var mask = []byte("\"****\"")
+	const endOfHeaders = "\r\n\r\n"
+	paths := [][]string{
+		{"email"},
+		{"password"},
+		{"data", "email"},
+		{"data", "password"},
+	}
+	if i := bytes.Index(d, []byte(endOfHeaders)); i > 0 || (i+4) < len(d) {
+		body := d[i+4:]
+		jsonparser.EachKey(body, func(idx int, _ []byte, _ jsonparser.ValueType, _ error) {
+			body, _ = jsonparser.Set(body, mask, paths[idx]...)
+		}, paths...)
+		if err == nil {
+			record.RawRequest = base64.StdEncoding.EncodeToString(append(d[:i+4], body...))
+		}
+	}
+}

--- a/ci/tests/plugin-compiler/testdata/complex-plugin/analytics/plugin_test.go
+++ b/ci/tests/plugin-compiler/testdata/complex-plugin/analytics/plugin_test.go
@@ -1,0 +1,49 @@
+package analytics_test
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/buger/jsonparser"
+
+	pumpAnalytics "github.com/TykTechnologies/tyk-pump/analytics"
+
+	"example.com/basic-plugin/analytics"
+)
+
+func ExampleMyAnalyticsPluginDeleteHeader() {
+	record := pumpAnalytics.AnalyticsRecord{
+		ContentLength: 5,
+		RawResponse:   base64.StdEncoding.EncodeToString([]byte("HTTP/1.1 200 OK\r\nServer: golang\r\nContent-Length: 5\r\n\r\nHello")),
+	}
+	analytics.MyAnalyticsPluginDeleteHeader(&record)
+	data, _ := base64.StdEncoding.DecodeString(record.RawResponse)
+	fmt.Printf("%q", string(data))
+	// Output: "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nHello"
+}
+
+func ExampleMyAnalyticsPluginMaskJSONLoginBody() {
+	record := pumpAnalytics.AnalyticsRecord{
+		ContentLength: 72,
+		RawRequest:    base64.StdEncoding.EncodeToString([]byte("POST / HTTP/1.1\r\nHost: server.com\r\nContent-Length: 72\r\n\r\n{\"email\": \"m\", \"password\": \"p\", \"data\": {\"email\": \"m\", \"password\": \"p\"}}")),
+	}
+	analytics.MyAnalyticsPluginMaskJSONLoginBody(&record)
+	data, _ := base64.StdEncoding.DecodeString(record.RawRequest)
+	const endOfHeaders = "\r\n\r\n"
+	paths := [][]string{
+		{"email"},
+		{"password"},
+		{"data", "email"},
+		{"data", "password"},
+	}
+	if i := bytes.Index(data, []byte(endOfHeaders)); i > 0 || (i+4) < len(data) {
+		jsonparser.EachKey(data[i+4:], func(_ int, v []byte, _ jsonparser.ValueType, _ error) {
+			fmt.Println(string(v))
+		}, paths...)
+	}
+	// Output: ****
+	//****
+	//****
+	//****
+}

--- a/ci/tests/plugin-compiler/testdata/complex-plugin/go.mod
+++ b/ci/tests/plugin-compiler/testdata/complex-plugin/go.mod
@@ -1,0 +1,3 @@
+module example.com/basic-plugin
+
+go 1.19

--- a/ci/tests/plugin-compiler/testdata/complex-plugin/plugin.go
+++ b/ci/tests/plugin-compiler/testdata/complex-plugin/plugin.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"example.com/basic-plugin/analytics"
+	"example.com/basic-plugin/plugin"
+)
+
+var MyPluginPre = plugin.MyPluginPre
+var MyPluginAuthCheck = plugin.MyPluginAuthCheck
+var MyPluginPostKeyAuth = plugin.MyPluginPostKeyAuth
+var MyPluginPost = plugin.MyPluginPost
+var MyPluginResponse = plugin.MyPluginResponse
+var MyPluginPerPathFoo = plugin.MyPluginPerPathFoo
+var MyPluginPerPathBar = plugin.MyPluginPerPathBar
+var MyPluginPerPathResp = plugin.MyPluginPerPathResp
+
+var MyAnalyticsPluginDeleteHeader = analytics.MyAnalyticsPluginDeleteHeader
+var MyAnalyticsPluginMaskJSONLoginBody = analytics.MyAnalyticsPluginMaskJSONLoginBody

--- a/ci/tests/plugin-compiler/testdata/complex-plugin/plugin/plugin.go
+++ b/ci/tests/plugin-compiler/testdata/complex-plugin/plugin/plugin.go
@@ -1,0 +1,143 @@
+package plugin
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/TykTechnologies/tyk/ctx"
+	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/user"
+)
+
+// MyPluginPre checks if session is NOT present, adds custom header
+// with initial URI path and will be used as "pre" custom MW
+func MyPluginPre(rw http.ResponseWriter, r *http.Request) {
+	session := ctx.GetSession(r)
+	if session != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	rw.Header().Add(header.XInitialURI, r.URL.RequestURI())
+}
+
+// MyPluginAuthCheck does custom auth and will be used as
+// "auth_check" custom MW
+func MyPluginAuthCheck(rw http.ResponseWriter, r *http.Request) {
+	// perform auth (only one token "abc" is allowed)
+	token := r.Header.Get(header.Authorization)
+	if token != "abc" {
+		rw.Header().Add(header.XAuthResult, "failed")
+		rw.WriteHeader(http.StatusForbidden)
+		_, _ = rw.Write([]byte("auth failed"))
+		return
+	}
+
+	// create session
+	session := &user.SessionState{
+		OrgID: "default",
+		Alias: "abc-session",
+		KeyID: token,
+	}
+
+	ctx.SetSession(r, session, true, true)
+	rw.Header().Add(header.XAuthResult, "OK")
+}
+
+// MyPluginPostKeyAuth checks if session is present, adds custom header with session-alias
+// and will be used as "post_key_auth" custom MW
+func MyPluginPostKeyAuth(rw http.ResponseWriter, r *http.Request) {
+	session := ctx.GetSession(r)
+	if session == nil {
+		rw.Header().Add(header.XSessionAlias, "not found")
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	rw.Header().Add(header.XSessionAlias, session.Alias)
+}
+
+// MyPluginPost prepares and sends reply, will be used as "post" custom MW
+func MyPluginPost(rw http.ResponseWriter, r *http.Request) {
+
+	replyData := map[string]interface{}{
+		"message": "post message",
+	}
+
+	jsonData, err := json.Marshal(replyData)
+	if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	apiDefinition := ctx.GetDefinition(r)
+	if apiDefinition == nil {
+		rw.Header().Add("X-Plugin-Data", "null")
+	} else {
+		pluginConfig, ok := apiDefinition.ConfigData["my-context-data"].(string)
+		if !ok || pluginConfig == "" {
+			rw.Header().Add("X-Plugin-Data", "null")
+		} else {
+			rw.Header().Add("X-Plugin-Data", pluginConfig)
+		}
+
+	}
+	rw.Header().Set(header.ContentType, header.ApplicationJSON)
+	rw.WriteHeader(http.StatusOK)
+	rw.Write(jsonData)
+}
+
+// MyPluginResponse intercepts response from upstream which we can then manipulate
+func MyPluginResponse(rw http.ResponseWriter, res *http.Response, req *http.Request) {
+
+	res.Header.Add("X-Response-Added", "resp-added")
+
+	var buf bytes.Buffer
+
+	buf.Write([]byte(`{"message":"response injected message"}`))
+
+	res.Body = ioutil.NopCloser(&buf)
+
+	apiDefinition := ctx.GetDefinition(req)
+	if apiDefinition == nil {
+		res.Header.Add("X-Plugin-Data", "null")
+		return
+	}
+	pluginConfig, ok := apiDefinition.ConfigData["my-context-data"].(string)
+	if !ok || pluginConfig == "" {
+		res.Header.Add("X-Plugin-Data", "null")
+		return
+	}
+	res.Header.Add("X-Plugin-Data", pluginConfig)
+}
+
+func MyPluginPerPathFoo(rw http.ResponseWriter, r *http.Request) {
+
+	rw.Header().Add("X-foo", "foo")
+
+}
+
+func MyPluginPerPathBar(rw http.ResponseWriter, r *http.Request) {
+	rw.Header().Add("X-bar", "bar")
+
+}
+
+func MyPluginPerPathResp(rw http.ResponseWriter, r *http.Request) {
+	// prepare data to send
+	replyData := map[string]string{
+		"current_time": "now",
+	}
+
+	jsonData, err := json.Marshal(replyData)
+	if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// send HTTP response from Golang plugin
+	rw.Header().Set("Content-Type", "application/json")
+	rw.WriteHeader(http.StatusOK)
+	rw.Write(jsonData)
+}

--- a/cli/plugin/plugin.go
+++ b/cli/plugin/plugin.go
@@ -4,6 +4,7 @@ package plugin
 
 import (
 	"fmt"
+	"strings"
 
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 
@@ -33,12 +34,14 @@ func (p *pluginLoader) Load(_ *kingpin.ParseContext) (err error) {
 }
 
 func (p *pluginLoader) load() error {
-	funcSymbol, err := goplugin.GetSymbol(*p.file, *p.symbol)
-	if err != nil {
-		return fmt.Errorf("unexpected error: %w", err)
-	}
+	for _, filename := range strings.Split(*p.file, ",") {
+		funcSymbol, err := goplugin.GetSymbol(filename, *p.symbol)
+		if err != nil {
+			return fmt.Errorf("unexpected error: %w", err)
+		}
 
-	fmt.Printf("[file=%s, symbol=%s] loaded ok, got %v\n", *p.file, *p.symbol, funcSymbol)
+		fmt.Printf("[file=%s, symbol=%s] loaded ok, got %v\n", filename, *p.symbol, funcSymbol)
+	}
 	return nil
 }
 


### PR DESCRIPTION
This PR changes the plugin compiler to adjust the module in use based on $plugin_id argument.

Why this is needed:

Since we use `-trimpath` to increase plugin/gateway compatibility, the filesystem paths are omitted from the built plugin. Previously we would rely on that behaviour to reload plugins, by compiling the plugin in a unique plugin path. Currently, the plugin build relies only on the go module, so amending go.mod and the source file imports is needed.

This PR adds tests and test scaffolding to verify the changes.

Extended tests and behaviour:

- extends tyk plugin load to take multiple args, namely plugin1.so,plugin2.so
- extended plugin compiler with debug output if DEBUG=1 env is provided
- implemented the two-plugin testcase using different plugin builds
- added complex-plugin test case with subpackages
- added plugin test case with invalid/simplistic go.mod module
- plugin compiler prints a warning if plugin module doesn't contain a dot:

```
WARN: Plugin go.mod module doesn't contain a dot, consider amending it to prevent conflicts
      Current value: com
    Suggested value: github.com/org/plugin-repo
```

The replacement uses the go module name as a replacement pattern. If a go module name like `net` would be set, the plugin compiler would attempt replacing all imports with the prefix. That would conflict with the standard library, `net/http` and other similar packages under the namespace. It's also invalid for the plugin to declare it's module as `plugin`, as a standard library package of the same name exists and may conflict, result in unpredicted behaviour.

https://tyktech.atlassian.net/browse/TT-10555