### PR TITLE
Merging to release-5-lts: [TT-10518] Tests/address some racy tests (#5771)

### DIFF
--- a/gateway/looping_test.go
+++ b/gateway/looping_test.go
@@ -1,5 +1,5 @@
-//go:build !race
-// +build !race
+//go:build !race || unstable
+// +build !race unstable
 
 // Looping by itself has race nature
 package gateway
@@ -185,6 +185,8 @@ func TestLooping(t *testing.T) {
 	})
 
 	t.Run("VirtualEndpoint or plugins", func(t *testing.T) {
+		test.Flaky(t) // TT-10511
+
 		ts.testPrepareVirtualEndpoint(`
             function testVirtData(request, session, config) {
                 var loopLocation = "/default"
@@ -326,6 +328,8 @@ func TestLooping(t *testing.T) {
 }
 
 func TestConcurrencyReloads(t *testing.T) {
+	test.Racy(t) // TT-10510
+
 	var wg sync.WaitGroup
 
 	ts := StartTest(nil)

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/TykTechnologies/tyk/internal/cache"
@@ -195,15 +196,30 @@ func (gw *Gateway) mwList(mws ...TykMiddleware) []alice.Constructor {
 // BaseMiddleware wraps up the ApiSpec and Proxy objects to be included in a
 // middleware handler, this can probably be handled better.
 type BaseMiddleware struct {
-	Spec   *APISpec
-	Proxy  ReturningHttpHandler
-	logger *logrus.Entry
-	Gw     *Gateway `json:"-"`
+	Spec  *APISpec
+	Proxy ReturningHttpHandler
+	Gw    *Gateway `json:"-"`
+
+	loggerMu sync.Mutex
+	logger   *logrus.Entry
 }
 
-func (t BaseMiddleware) Base() *BaseMiddleware { return &t }
+func (t *BaseMiddleware) Base() *BaseMiddleware {
+	t.loggerMu.Lock()
+	defer t.loggerMu.Unlock()
 
-func (t BaseMiddleware) Logger() (logger *logrus.Entry) {
+	return &BaseMiddleware{
+		Spec:   t.Spec,
+		Proxy:  t.Proxy,
+		Gw:     t.Gw,
+		logger: t.logger,
+	}
+}
+
+func (t *BaseMiddleware) Logger() (logger *logrus.Entry) {
+	t.loggerMu.Lock()
+	defer t.loggerMu.Unlock()
+
 	if t.logger == nil {
 		t.logger = logrus.NewEntry(log)
 	}
@@ -212,11 +228,21 @@ func (t BaseMiddleware) Logger() (logger *logrus.Entry) {
 }
 
 func (t *BaseMiddleware) SetName(name string) {
-	t.logger = t.Logger().WithField("mw", name)
+	logger := t.Logger()
+
+	t.loggerMu.Lock()
+	defer t.loggerMu.Unlock()
+
+	t.logger = logger.WithField("mw", name)
 }
 
 func (t *BaseMiddleware) SetRequestLogger(r *http.Request) {
-	t.logger = t.Gw.getLogEntryForRequest(t.Logger(), r, ctxGetAuthToken(r), nil)
+	logger := t.Logger()
+
+	t.loggerMu.Lock()
+	defer t.loggerMu.Unlock()
+
+	t.logger = t.Gw.getLogEntryForRequest(logger, r, ctxGetAuthToken(r), nil)
 }
 
 func (t BaseMiddleware) Init() {}

--- a/gateway/mw_organisation_activity_test.go
+++ b/gateway/mw_organisation_activity_test.go
@@ -1,5 +1,5 @@
-//go:build !race
-// +build !race
+//go:build !race || unstable
+// +build !race unstable
 
 package gateway
 

--- a/gateway/rpc_test.go
+++ b/gateway/rpc_test.go
@@ -1,5 +1,5 @@
-//go:build !race
-// +build !race
+//go:build !race || unstable
+// +build !race unstable
 
 package gateway
 


### PR DESCRIPTION
[TT-10518] Tests/address some racy tests (#5771)

- Adds `unstable` build tag to tests with `!race` (so we can run them
with `-race -tags=unstable`)
- Fixes a race over base middleware Logger(), SetLogger() and Base()
- looping tests marked as flaky or racy respectively (jira tickets in
comments)

https://tyktech.atlassian.net/browse/TT-10518

---------

Co-authored-by: Tit Petric <tit@tyk.io>

[TT-10518]: https://tyktech.atlassian.net/browse/TT-10518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ