### PR TITLE
[TT-10565] Update graphql-go-tools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/TykTechnologies/gojsonschema v0.0.0-20170222154038-dcb3e4bb7990
 	github.com/TykTechnologies/gorpc v0.0.0-20210624160652-fe65bda0ccb9
 	github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708
-	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20231120113533-90b772abd0d9
+	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20231121123800-70500778ba66
 	github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c
 	github.com/TykTechnologies/murmur3 v0.0.0-20230310161213-aad17efd5632
 	github.com/TykTechnologies/openid2go v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/TykTechnologies/gorpc v0.0.0-20210624160652-fe65bda0ccb9 h1:fbxHiuw/2
 github.com/TykTechnologies/gorpc v0.0.0-20210624160652-fe65bda0ccb9/go.mod h1:v6v7Mlj08+EmEcXOfpuTxGt2qYU9yhqqtv4QF9Wf50E=
 github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708 h1:cmXjlMzcexhc/Cg+QB/c2CPUVs1ux9xn6162qaf/LC4=
 github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708/go.mod h1:mkS8jKcz8otdfEXhJs1QQ/DKoIY1NFFsRPKS0RwQENI=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20231120113533-90b772abd0d9 h1:C2GHBpwLywf+FPel8D7pP8Ws17lxKtxn+ahe2cayCLE=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20231120113533-90b772abd0d9/go.mod h1:BomzBTAQkPsVwFIQOAicT2wnEpIXE0rXjMjN4pf6PpQ=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20231121123800-70500778ba66 h1:cvOlc+A0d3GVNa9hm43gs00BnoHYKZaL6vFYGNQQfrM=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20231121123800-70500778ba66/go.mod h1:BomzBTAQkPsVwFIQOAicT2wnEpIXE0rXjMjN4pf6PpQ=
 github.com/TykTechnologies/kin-openapi v0.90.0 h1:kHw0mtANwIpmlU6eCeeCgRMa52EiPPhEZPuHc3lKawo=
 github.com/TykTechnologies/kin-openapi v0.90.0/go.mod h1:pkzuiceujHvAuDu3bTD/AD5OacuP4eMfrz9QhJlMvdQ=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c h1:j6fd0Fz1R4oSWOmcooGjrdahqrML+btQ+PfEJw8SzbA=


### PR DESCRIPTION
This PR updates `graphql-go-tools` dependency. See [TT-10565](https://tyktech.atlassian.net/browse/TT-10565) for details. 