### PR TITLE
[TT-10477] Add "introspection" to API definition

### DIFF
--- a/apidef/adapter/asyncapi_test.go
+++ b/apidef/adapter/asyncapi_test.go
@@ -335,6 +335,9 @@ const expectedGraphqlConfig = `{
         "merged_sdl": "",
         "global_headers": null,
         "disable_query_batching": false
+    },
+    "introspection": {
+        "disabled": false
     }
 }`
 

--- a/apidef/adapter/openapi_test.go
+++ b/apidef/adapter/openapi_test.go
@@ -316,6 +316,9 @@ const expectedOpenAPIGraphQLConfig = `{
         "merged_sdl": "",
         "global_headers": null,
         "disable_query_batching": false
+    },
+    "introspection": {
+        "disabled": false
     }
 }`
 

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -742,6 +742,8 @@ type GraphQLConfig struct {
 	Subgraph GraphQLSubgraphConfig `bson:"subgraph" json:"subgraph"`
 	// Supergraph holds the configuration for a GraphQL federation supergraph.
 	Supergraph GraphQLSupergraphConfig `bson:"supergraph" json:"supergraph"`
+	// Introspection holds the configuration for GraphQL Introspection
+	Introspection GraphQLIntrospectionConfig `bson:"introspection" json:"introspection"`
 }
 
 type GraphQLConfigVersion string
@@ -751,6 +753,10 @@ const (
 	GraphQLConfigVersion1    GraphQLConfigVersion = "1"
 	GraphQLConfigVersion2    GraphQLConfigVersion = "2"
 )
+
+type GraphQLIntrospectionConfig struct {
+	Disabled bool `bson:"disabled" json:"disabled"`
+}
 
 type GraphQLResponseExtensions struct {
 	OnErrorForwarding bool `bson:"on_error_forwarding" json:"on_error_forwarding"`

--- a/apidef/oas/oas_test.go
+++ b/apidef/oas/oas_test.go
@@ -335,6 +335,7 @@ func TestOAS_ExtractTo_ResetAPIDefinition(t *testing.T) {
 		"APIDefinition.GraphQL.Supergraph.MergedSDL",
 		"APIDefinition.GraphQL.Supergraph.GlobalHeaders[0]",
 		"APIDefinition.GraphQL.Supergraph.DisableQueryBatching",
+		"APIDefinition.GraphQL.Introspection.Disabled",
 		"APIDefinition.AnalyticsPlugin.Enabled",
 		"APIDefinition.AnalyticsPlugin.PluginPath",
 		"APIDefinition.AnalyticsPlugin.FuncName",

--- a/apidef/schema.go
+++ b/apidef/schema.go
@@ -689,6 +689,14 @@ const Schema = `{
                         }
                     }
                 },
+                "introspection": {
+                    "type": ["object", "null"],
+                    "properties: {
+                        "disabled": {
+                            "type": "boolean"
+                        }
+                     }
+                },
                 "playground": {
                     "type": ["object", "null"],
                     "properties": {

--- a/apidef/schema.go
+++ b/apidef/schema.go
@@ -691,11 +691,11 @@ const Schema = `{
                 },
                 "introspection": {
                     "type": ["object", "null"],
-                    "properties: {
+                    "properties": {
                         "disabled": {
                             "type": "boolean"
                         }
-                     }
+                    }
                 },
                 "playground": {
                     "type": ["object", "null"],


### PR DESCRIPTION
A new configuration element has been added. `Introspection` struct is a field of `GraphQLConfig` struct. 

```
"introspection": {
        "disabled": false
}
```
See [TT-10477](https://tyktech.atlassian.net/browse/TT-10477) for details. 


[TT-10477]: https://tyktech.atlassian.net/browse/TT-10477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ