### PR TITLE
Merging to release-5.2: [TT-10181] Fix error message when trying to use classic enpoint for OAS API (#5764)

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -114,7 +114,7 @@ const (
 )
 
 var (
-	ErrAPIMigrated                = errors.New("the supplied API definition is in Tyk classic format, please use OAS format for this API")
+	ErrClassicAPIExpected         = errors.New("this API endpoint only supports Tyk Classic APIs; please use the appropriate Tyk OAS API endpoint")
 	ErrAPINotMigrated             = errors.New("the supplied API definition is in OAS format, please use the Tyk classic format for this API")
 	ErrOASGetForOldAPI            = errors.New("the requested API definition is in Tyk classic format, please use old api endpoint")
 	ErrImportWithTykExtension     = errors.New("the import payload should not contain x-tyk-api-gateway")

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -1187,7 +1187,7 @@ func (gw *Gateway) handleUpdateApi(apiID string, r *http.Request, fs afero.Fs, o
 		oasObj.ExtractTo(&newDef)
 	} else {
 		if spec.IsOAS {
-			return apiError(apidef.ErrAPIMigrated.Error()), http.StatusBadRequest
+			return apiError(apidef.ErrClassicAPIExpected.Error()), http.StatusBadRequest
 		}
 
 		if err := json.NewDecoder(r.Body).Decode(&newDef); err != nil {

--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -2730,7 +2730,7 @@ func TestOAS(t *testing.T) {
 
 					_, _ = ts.Run(t, []test.TestCase{
 						{AdminAuth: true, Method: http.MethodPut, Path: updatePath, Data: &oasAPIInOld,
-							BodyMatch: apidef.ErrAPIMigrated.Error(), Code: http.StatusBadRequest},
+							BodyMatch: apidef.ErrClassicAPIExpected.Error(), Code: http.StatusBadRequest},
 					}...)
 				})
 			})


### PR DESCRIPTION
[TT-10181] Fix error message when trying to use classic enpoint for OAS API (#5764)

Ticket: https://tyktech.atlassian.net/browse/TT-10181