### PR TITLE
Create plugins/native and plugins/registry implementations

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -131,7 +131,7 @@ jobs:
             -Dsonar.projectKey=TykTechnologies_tyk
             -Dsonar.sources=.
             -Dsonar.exclusions=coprocess/**/*,ci/**,smoke-tests/**,apidef/oas/schema/schema.gen.go
-            -Dsonar.coverage.exclusions=**/*_test.go,**/mock/*
+            -Dsonar.coverage.exclusions=**/*_test.go,**/mock/*,**/testdata/*
             -Dsonar.test.inclusions=**/*_test.go
             -Dsonar.tests=.
             -Dsonar.go.coverage.reportPaths=*.cov

--- a/plugins/Taskfile.yml
+++ b/plugins/Taskfile.yml
@@ -1,0 +1,18 @@
+---
+version: "3"
+
+tasks:
+  test:
+    desc: "Build plugin and run tests"
+    cmds:
+      - task: build
+      - goimports -w .
+      - go fmt ./...
+      - go test -cover -count=100 -tags plugins_native_test -race ./...
+
+  build:
+    internal: true
+    desc: "Build testdata plugin"
+    dir: ./native/testdata
+    cmds:
+      - go build -buildmode=plugin -race -o plugin.so .

--- a/plugins/model/model.go
+++ b/plugins/model/model.go
@@ -1,0 +1,33 @@
+// Package model holds symbols required for all plugin types.
+// This is a data model only package and should avoid logic.
+
+package model
+
+import (
+	"errors"
+	"plugin"
+)
+
+// Plugin is the common interface that should be implemented by
+// any plugin type. It allows to load a plugin symbol, and list
+// plugin symbols. If a plugin subsystem can't implement a symbols
+// list, it is expected to return a model.ErrNoSymbols.
+type Plugin interface {
+	// Lookup retrieves the value for a symbol.
+	Lookup(name string) (plugin.Symbol, error)
+
+	// Symbols lists all plugin symbols and types of symbol.
+	Symbols() (map[string]string, error)
+}
+
+// Registry is an optional interface implemented by plugin loaders.
+type Registry interface {
+	// Register adds a plugin callback to the registry.
+	Register(name string, val plugin.Symbol)
+}
+
+// ErrNoSymbols is returned from Symbols() if no symbols can be listed.
+var ErrNoSymbols = errors.New("No symbols found")
+
+// ErrNotFound is returned from Lookup() if symbol is not found.
+var ErrNotFound = errors.New("Symbol not found")

--- a/plugins/native/native.go
+++ b/plugins/native/native.go
@@ -1,0 +1,80 @@
+// The native package provides a plugin subsystem that extends the
+// behaviour of the standard library `plugin` package.
+//
+// The behaviour is extended with a Symbols() that allows listing
+// the plugin symbols declared and their function signatures.
+
+package native
+
+import (
+	"fmt"
+	"plugin"
+	"strings"
+
+	"github.com/TykTechnologies/tyk/plugins/model"
+)
+
+// Plugin is the utility object that wraps plugin.Plugin.
+type Plugin struct {
+	name   string
+	plugin *plugin.Plugin
+}
+
+// Assert that plugin implements model.Plugin interfaces.
+var _ model.Plugin = &Plugin{}
+
+// NewPlugin will attempt to open the plugin with plugin.Open and provide
+// an internal representation of the plugin. It implements a compatible API
+// signature to the internal plugin package.
+func NewPlugin(name string) (*Plugin, error) {
+	p, err := plugin.Open(name)
+	if err != nil {
+		return nil, fmt.Errorf("Error loading native plugin %s: %w", name, err)
+	}
+
+	result := &Plugin{
+		name:   name,
+		plugin: p,
+	}
+
+	return result, nil
+}
+
+// Lookup returns the plugin symbol value from the loaded plugin.
+func (p *Plugin) Lookup(name string) (plugin.Symbol, error) {
+	return p.plugin.Lookup(name)
+}
+
+// Symbols will traverse the internal representation of plugin.Plugin and use
+// the reflection features inside fmt.Sprintf (`%+v` and `%T`). This isn't likely
+// to work in restricted environments where reflection is not available. Note that
+// particularly reflection is disabled in google app engine sandbox environments.
+func (p *Plugin) Symbols() (map[string]string, error) {
+	internals := fmt.Sprintf("%+v", p.plugin)
+
+	// extract syms map from stdlib internal symbols table
+	parts := strings.SplitN(internals, "syms:map[", 2)
+	if len(parts) < 2 {
+		return nil, model.ErrNoSymbols
+	}
+
+	// split on map closure
+	parts = strings.SplitN(parts[1], "]", 2)
+
+	// get symbols list
+	symbols := strings.Fields(parts[0])
+	result := make(map[string]string, len(symbols))
+	for _, sym := range symbols {
+		symAddr := strings.Split(sym, ":")
+		name := symAddr[0]
+
+		symbol, err := p.plugin.Lookup(name)
+		if err != nil {
+			return nil, fmt.Errorf("Error looking up symbol: %w", err)
+		}
+
+		result[name] = fmt.Sprintf("%T", symbol)
+	}
+
+	return result, nil
+}

--- a/plugins/native/native_test.go
+++ b/plugins/native/native_test.go
@@ -1,0 +1,28 @@
+//go:build plugins_native_test
+// +build plugins_native_test
+
+package native_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk/plugins/native"
+)
+
+func TestPlugin(t *testing.T) {
+	p, err := native.NewPlugin("testdata/plugin.so")
+	assert.NoError(t, err)
+
+	symbols, err := p.Symbols()
+	assert.NoError(t, err)
+
+	for k, v := range symbols {
+		fmt.Println("-", k, v)
+	}
+
+	_, err = native.NewPlugin("testdata/plugin-404.so")
+	assert.Error(t, err)
+}

--- a/plugins/native/testdata/plugin.go
+++ b/plugins/native/testdata/plugin.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/buger/jsonparser"
+
+	"github.com/TykTechnologies/tyk-pump/analytics"
+	"github.com/TykTechnologies/tyk/ctx"
+	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/user"
+)
+
+// MyPluginPre checks if session is NOT present, adds custom header
+// with initial URI path and will be used as "pre" custom MW
+func MyPluginPre(rw http.ResponseWriter, r *http.Request) {
+	session := ctx.GetSession(r)
+	if session != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	rw.Header().Add(header.XInitialURI, r.URL.RequestURI())
+}
+
+// MyPluginAuthCheck does custom auth and will be used as
+// "auth_check" custom MW
+func MyPluginAuthCheck(rw http.ResponseWriter, r *http.Request) {
+	// perform auth (only one token "abc" is allowed)
+	token := r.Header.Get(header.Authorization)
+	if token != "abc" {
+		rw.Header().Add(header.XAuthResult, "failed")
+		rw.WriteHeader(http.StatusForbidden)
+		_, _ = rw.Write([]byte("auth failed"))
+		return
+	}
+
+	// create session
+	session := &user.SessionState{
+		OrgID: "default",
+		Alias: "abc-session",
+		KeyID: token,
+	}
+
+	ctx.SetSession(r, session, true, true)
+	rw.Header().Add(header.XAuthResult, "OK")
+}
+
+// MyPluginPostKeyAuth checks if session is present, adds custom header with session-alias
+// and will be used as "post_key_auth" custom MW
+func MyPluginPostKeyAuth(rw http.ResponseWriter, r *http.Request) {
+	session := ctx.GetSession(r)
+	if session == nil {
+		rw.Header().Add(header.XSessionAlias, "not found")
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	rw.Header().Add(header.XSessionAlias, session.Alias)
+}
+
+// MyPluginPost prepares and sends reply, will be used as "post" custom MW
+func MyPluginPost(rw http.ResponseWriter, r *http.Request) {
+
+	replyData := map[string]interface{}{
+		"message": "post message",
+	}
+
+	jsonData, err := json.Marshal(replyData)
+	if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	apiDefinition := ctx.GetDefinition(r)
+	if apiDefinition == nil {
+		rw.Header().Add("X-Plugin-Data", "null")
+	} else {
+		pluginConfig, ok := apiDefinition.ConfigData["my-context-data"].(string)
+		if !ok || pluginConfig == "" {
+			rw.Header().Add("X-Plugin-Data", "null")
+		} else {
+			rw.Header().Add("X-Plugin-Data", pluginConfig)
+		}
+
+	}
+	rw.Header().Set(header.ContentType, header.ApplicationJSON)
+	rw.WriteHeader(http.StatusOK)
+	rw.Write(jsonData)
+}
+
+// MyPluginResponse intercepts response from upstream which we can then manipulate
+func MyPluginResponse(rw http.ResponseWriter, res *http.Response, req *http.Request) {
+
+	res.Header.Add("X-Response-Added", "resp-added")
+
+	var buf bytes.Buffer
+
+	buf.Write([]byte(`{"message":"response injected message"}`))
+
+	res.Body = ioutil.NopCloser(&buf)
+
+	apiDefinition := ctx.GetDefinition(req)
+	if apiDefinition == nil {
+		res.Header.Add("X-Plugin-Data", "null")
+		return
+	}
+	pluginConfig, ok := apiDefinition.ConfigData["my-context-data"].(string)
+	if !ok || pluginConfig == "" {
+		res.Header.Add("X-Plugin-Data", "null")
+		return
+	}
+	res.Header.Add("X-Plugin-Data", pluginConfig)
+}
+
+func MyPluginPerPathFoo(rw http.ResponseWriter, r *http.Request) {
+	rw.Header().Add("X-foo", "foo")
+}
+
+func MyPluginPerPathBar(rw http.ResponseWriter, r *http.Request) {
+	rw.Header().Add("X-bar", "bar")
+}
+
+func MyPluginPerPathResp(rw http.ResponseWriter, r *http.Request) {
+	// prepare data to send
+	replyData := map[string]string{
+		"current_time": "now",
+	}
+
+	jsonData, err := json.Marshal(replyData)
+	if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// send HTTP response from Golang plugin
+	rw.Header().Set("Content-Type", "application/json")
+	rw.WriteHeader(http.StatusOK)
+	rw.Write(jsonData)
+}
+
+func MyAnalyticsPluginDeleteHeader(record *analytics.AnalyticsRecord) {
+	str, err := base64.StdEncoding.DecodeString(record.RawResponse)
+	if err != nil {
+		return
+	}
+
+	var b = &bytes.Buffer{}
+	b.Write(str)
+
+	r := bufio.NewReader(b)
+	var resp *http.Response
+	resp, err = http.ReadResponse(r, nil)
+	if err != nil {
+		return
+	}
+	resp.Header.Del("Server")
+	var bNew bytes.Buffer
+	_ = resp.Write(&bNew)
+	record.RawResponse = base64.StdEncoding.EncodeToString(bNew.Bytes())
+}
+
+func MyAnalyticsPluginMaskJSONLoginBody(record *analytics.AnalyticsRecord) {
+	if record.ContentLength < 1 {
+		return
+	}
+	d, err := base64.StdEncoding.DecodeString(record.RawRequest)
+	if err != nil {
+		return
+	}
+	var mask = []byte("\"****\"")
+	const endOfHeaders = "\r\n\r\n"
+	paths := [][]string{
+		{"email"},
+		{"password"},
+		{"data", "email"},
+		{"data", "password"},
+	}
+	if i := bytes.Index(d, []byte(endOfHeaders)); i > 0 || (i+4) < len(d) {
+		body := d[i+4:]
+		jsonparser.EachKey(body, func(idx int, _ []byte, _ jsonparser.ValueType, _ error) {
+			body, _ = jsonparser.Set(body, mask, paths[idx]...)
+		}, paths...)
+		if err == nil {
+			record.RawRequest = base64.StdEncoding.EncodeToString(append(d[:i+4], body...))
+		}
+	}
+}

--- a/plugins/registry/registry.go
+++ b/plugins/registry/registry.go
@@ -1,0 +1,61 @@
+// The registry package provides a plugin subsystem that matches the
+// native plugins. You can register plugin symbols and interchange the
+// instance of registry.Plugin with native.Plugin.
+package registry
+
+import (
+	"fmt"
+	"plugin"
+
+	"github.com/TykTechnologies/tyk/plugins/model"
+)
+
+// Plugin implements model.Plugin.
+type Plugin struct {
+	name string
+
+	syms map[string]plugin.Symbol
+}
+
+// Assert that plugin implements model.Plugin and model.Registry interfaces.
+var _ model.Plugin = &Plugin{}
+var _ model.Registry = &Plugin{}
+
+// NewPlugin will create a plugin registry object. After creating it, plugins
+// may be registered by invoking Register(). Any registered plugin will be
+// returned by the Lookup and Symbols methods.
+func NewPlugin(name string) (*Plugin, error) {
+	return &Plugin{
+		name: name,
+		syms: make(map[string]plugin.Symbol),
+	}, nil
+}
+
+// Register creates a plugin symbol to be returned by Lookup.
+func (p *Plugin) Register(name string, val plugin.Symbol) {
+	p.syms[name] = val
+}
+
+// Lookup returns the plugin symbol value from the loaded plugin.
+func (p *Plugin) Lookup(name string) (plugin.Symbol, error) {
+	if sym, ok := p.syms[name]; ok {
+		return sym, nil
+	}
+
+	return nil, model.ErrNotFound
+}
+
+// Symbols returns an internal map of symbols and it's type representations.
+func (p *Plugin) Symbols() (map[string]string, error) {
+	if len(p.syms) == 0 {
+		return nil, nil
+	}
+
+	result := make(map[string]string, len(p.syms))
+
+	for k, v := range p.syms {
+		result[k] = fmt.Sprintf("%T", v)
+	}
+
+	return result, nil
+}

--- a/plugins/registry/registry_test.go
+++ b/plugins/registry/registry_test.go
@@ -1,0 +1,37 @@
+package registry_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk/plugins/registry"
+)
+
+func TestPlugin(t *testing.T) {
+	p, err := registry.NewPlugin("internal")
+	assert.NoError(t, err)
+
+	symbols, err := p.Symbols()
+	assert.NoError(t, err)
+	assert.Nil(t, symbols, "Expected 0 symbols")
+
+	p.Register("key", func() bool {
+		return true
+	})
+
+	symbols, err = p.Symbols()
+	assert.NoError(t, err)
+	assert.Len(t, symbols, 1, "Expected 1 symbol")
+
+	fn, err := p.Lookup("key-404")
+	assert.Nil(t, fn)
+	assert.Error(t, err)
+
+	fn, err = p.Lookup("key")
+	assert.NoError(t, err)
+
+	fv, ok := fn.(func() bool)
+	assert.True(t, ok)
+	assert.True(t, fv())
+}


### PR DESCRIPTION
The PR adds a `/plugin` location, and within it the `model` package (shared by all plugin subsystems), and implementation for two plugin subsystems:

- `native` - the go plugins (Lookup),
- `registry` - native go functions (Register + Lookup)

The native interface implements our standard plugin subsystem. The registry interface allows several things:

- allows us to register new plugin symbols on gateway without needing `plugin.so` files,
- allows us to import gateway and register new plugin symbols without need to modify gateway,
- allows us us to put functionality behind build tags (dependency inversion principle).

One would use the native registry in api definitions the same way a shared object plugin would be used, except we would reference the plugin by a namespace (string) rather than a shared object filename.