### PR TITLE
[TT-10641] Add go caches to smoke tests, fix go.mod/sum for release

### DIFF
--- a/smoke-tests/plugin-aliasing/foobar-plugin/go.mod
+++ b/smoke-tests/plugin-aliasing/foobar-plugin/go.mod
@@ -2,3 +2,4 @@ module github.com/TykTechnologies/tyk/smoke-tests/plugin-compiler/foobar-plugin
 
 go 1.16
 
+require github.com/kr/pretty v0.3.1 // indirect

--- a/smoke-tests/plugin-aliasing/foobar-plugin/go.sum
+++ b/smoke-tests/plugin-aliasing/foobar-plugin/go.sum
@@ -1,0 +1,8 @@
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
+github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=

--- a/smoke-tests/plugin-aliasing/helloworld-plugin/go.mod
+++ b/smoke-tests/plugin-aliasing/helloworld-plugin/go.mod
@@ -1,3 +1,5 @@
 module github.com/TykTechnologies/tyk/smoke-tests/plugin-compiler/helloworld-plugin
 
 go 1.16
+
+require github.com/kr/pretty v0.3.1 // indirect

--- a/smoke-tests/plugin-aliasing/helloworld-plugin/go.sum
+++ b/smoke-tests/plugin-aliasing/helloworld-plugin/go.sum
@@ -1,0 +1,8 @@
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
+github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=

--- a/smoke-tests/plugin-aliasing/test.sh
+++ b/smoke-tests/plugin-aliasing/test.sh
@@ -26,8 +26,13 @@ GATEWAY_VERSION=$(echo $GATEWAY_VERSION | perl -n -e'/(\d+).(\d+).(\d+)/'' && pr
 
 rm -rfv foobar-plugin/*.so helloworld-plugin/*.so
 
-docker run --rm -e GO_GET=1 -v `pwd`/foobar-plugin:/plugin-source $PLUGIN_COMPILER_IMAGE foobar-plugin.so
-docker run --rm -e GO_GET=1 -v `pwd`/helloworld-plugin:/plugin-source $PLUGIN_COMPILER_IMAGE helloworld-plugin.so
+docker volume create plugin-aliasing-go-mod-cache
+docker volume create plugin-aliasing-go-build-cache
+
+cache_args="-v plugin-aliasing-go-mod-cache:/go/pkg/mod -v plugin-aliasing-go-build-cache:/root/.cache/go-build"
+
+docker run --rm -e GO_GET=1 $cache_args -v `pwd`/foobar-plugin:/plugin-source $PLUGIN_COMPILER_IMAGE foobar-plugin.so
+docker run --rm -e GO_GET=1 $cache_args -v `pwd`/helloworld-plugin:/plugin-source $PLUGIN_COMPILER_IMAGE helloworld-plugin.so
 
 # if params were not sent, then attempt to get them from env vars
 if [[ $GOOS == "" ]] && [[ $GOARCH == "" ]]; then


### PR DESCRIPTION
This PR implements the following:

- Fixes go.mod/go.sum issues for smoke-tests, needed a go get
- Added docker volumes into test to cache go get / go build cache

Tested as follows with `v5.2.4-rc2`, from /smoke-tests/plugin-aliasing:

```
export GATEWAY_IMAGE="tykio/tyk-gateway:v5.2.4-rc2"
export PLUGIN_COMPILER_IMAGE="tykio/tyk-plugin-compiler:v5.2.4-rc2"
./test.sh
```

https://tyktech.atlassian.net/browse/TT-10641