### PR TITLE
[TT-10649] Fix/plugin compiler ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,15 @@
-/ci/ @TykTechnologies/devops
-.github/workflows/release.yml @TykTechnologies/devops
-.github/workflows/sync-automation.yml @TykTechnologies/devops
-.github/workflows/pac.yml @TykTechnologies/devops
-/repo-policy/ @TykTechnologies/devops
+# SysE/DevOps ownership of CI release pipeline, repo policy, automations.
+
+/ci/                                    @TykTechnologies/devops
+.github/workflows/release.yml           @TykTechnologies/devops
+.github/workflows/sync-automation.yml   @TykTechnologies/devops
+.github/workflows/pac.yml               @TykTechnologies/devops
+/repo-policy/                           @TykTechnologies/devops
+
+# Core API Squad ownership of plugin compiler and related tests.
+
+/smoke-tests/                           @TykTechnologies/core-api-squad
+/ci/tests/                              @TykTechnologies/core-api-squad
+/ci/images/plugin-compiler/             @TykTechnologies/core-api-squad
+.github/workflows/ci-tests.yml          @TykTechnologies/core-api-squad
+.github/workflows/release-tests.yml     @TykTechnologies/core-api-squad

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -36,7 +36,7 @@ jobs:
               echo Attempting to test $d
               if [ -d $d ] && [ -e $d/test.sh ]; then
                   cd $d
-                  ./test.sh ${{ steps.ecr.outputs.registry }}/tyk:sha-${{ github.sha }}
+                  ./test.sh
                   cd -
               fi
           done
@@ -82,7 +82,7 @@ jobs:
               echo Attempting to test $d
               if [ -d $d ] && [ -e $d/test.sh ]; then
                   cd $d
-                  ./test.sh ${{ steps.ecr.outputs.registry }}/tyk:sha-${{ github.sha }}
+                  ./test.sh
                   cd -
               fi
           done

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 jobs:
-  smoke-tests:
+  ci-tests:
     runs-on: ubuntu-latest
 
     steps:
@@ -23,7 +23,7 @@ jobs:
         with:
           mask-password: 'true'
 
-      - name: Run ci/tests
+      - name: Run /ci/tests
         shell: bash
         env:
           GITHUB_TAG: ${{ github.ref }}
@@ -41,7 +41,27 @@ jobs:
               fi
           done
 
-      - name: Run smoke-tests
+  smoke-tests:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags')
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: arn:aws:iam::754489498669:role/ecr_rw_tyk
+          role-session-name: cipush
+          aws-region: eu-central-1
+
+      - id: ecr
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          mask-password: 'true'
+
+      - name: Run /smoke-tests
 
         # This job only runs whenever a tag is created. A tag is required
         # for a functional plugin compiler build for when the GO_GET=1 env
@@ -50,7 +70,6 @@ jobs:
         #
         # See https://github.com/golang/go/issues/31191 for more info.
 
-        if: startsWith(github.ref, 'refs/tags')
         shell: bash
         env:
           GITHUB_TAG: ${{ github.ref }}

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -1,5 +1,8 @@
 name: Run CI tests and smoke tests
 
+on:
+  workflow_call:
+
 jobs:
   smoke-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -1,0 +1,66 @@
+name: Run CI tests and smoke tests
+
+jobs:
+  smoke-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: arn:aws:iam::754489498669:role/ecr_rw_tyk
+          role-session-name: cipush
+          aws-region: eu-central-1
+
+      - id: ecr
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          mask-password: 'true'
+
+      - name: Run ci/tests
+        shell: bash
+        env:
+          GITHUB_TAG: ${{ github.ref }}
+          GATEWAY_IMAGE: ${{ steps.ecr.outputs.registry }}/tyk:sha-${{ github.sha }}
+          PLUGIN_COMPILER_IMAGE: ${{ steps.ecr.outputs.registry }}/tyk-plugin-compiler:sha-${{ github.sha }}
+        run: |
+          set -eaxo pipefail
+          for d in ci/tests/*/
+          do
+              echo Attempting to test $d
+              if [ -d $d ] && [ -e $d/test.sh ]; then
+                  cd $d
+                  ./test.sh ${{ steps.ecr.outputs.registry }}/tyk:sha-${{ github.sha }}
+                  cd -
+              fi
+          done
+
+      - name: Run smoke-tests
+
+        # This job only runs whenever a tag is created. A tag is required
+        # for a functional plugin compiler build for when the GO_GET=1 env
+        # is provided. The plugin compiler cannot fetch the referenced
+        # commit from a PR, but requires a /heads or /tags reference.
+        #
+        # See https://github.com/golang/go/issues/31191 for more info.
+
+        if: startsWith(github.ref, 'refs/tags')
+        shell: bash
+        env:
+          GITHUB_TAG: ${{ github.ref }}
+          GATEWAY_IMAGE: ${{ steps.ecr.outputs.registry }}/tyk:sha-${{ github.sha }}
+          PLUGIN_COMPILER_IMAGE: ${{ steps.ecr.outputs.registry }}/tyk-plugin-compiler:sha-${{ github.sha }}
+        run: |
+          set -eaxo pipefail
+          for d in smoke-tests/*/
+          do
+              echo Attempting to test $d
+              if [ -d $d ] && [ -e $d/test.sh ]; then
+                  cd $d
+                  ./test.sh ${{ steps.ecr.outputs.registry }}/tyk:sha-${{ github.sha }}
+                  cd -
+              fi
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -444,68 +444,7 @@ jobs:
     permissions:
       id-token: write   # This is required for requesting the JWT
       contents: read    # This is required for actions/checkout
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: arn:aws:iam::754489498669:role/ecr_rw_tyk
-          role-session-name: cipush
-          aws-region: eu-central-1
-
-      - id: ecr
-        uses: aws-actions/amazon-ecr-login@v1
-        with:
-          mask-password: 'true'
-
-      - name: Run ci/tests
-        shell: bash
-        env:
-          GITHUB_TAG: ${{ github.ref }}
-          GATEWAY_IMAGE: ${{ steps.ecr.outputs.registry }}/tyk:sha-${{ github.sha }}
-          PLUGIN_COMPILER_IMAGE: ${{ steps.ecr.outputs.registry }}/tyk-plugin-compiler:sha-${{ github.sha }}
-        run: |
-          set -eaxo pipefail
-          for d in ci/tests/*/
-          do
-              echo Attempting to test $d
-              if [ -d $d ] && [ -e $d/test.sh ]; then
-                  cd $d
-                  ./test.sh ${{ steps.ecr.outputs.registry }}/tyk:sha-${{ github.sha }}
-                  cd -
-              fi
-          done
-      - name: Run smoke-tests
-
-        # This job only runs whenever a tag is created. A tag is required
-        # for a functional plugin compiler build for when the GO_GET=1 env
-        # is provided. The plugin compiler cannot fetch the referenced
-        # commit from a PR, but requires a /heads or /tags reference.
-        #
-        # See https://github.com/golang/go/issues/31191 for more info.
-
-        if: startsWith(github.ref, 'refs/tags')
-        shell: bash
-        env:
-          GITHUB_TAG: ${{ github.ref }}
-          GATEWAY_IMAGE: ${{ steps.ecr.outputs.registry }}/tyk:sha-${{ github.sha }}
-          PLUGIN_COMPILER_IMAGE: ${{ steps.ecr.outputs.registry }}/tyk-plugin-compiler:sha-${{ github.sha }}
-        run: |
-          set -eaxo pipefail
-          for d in smoke-tests/*/
-          do
-              echo Attempting to test $d
-              if [ -d $d ] && [ -e $d/test.sh ]; then
-                  cd $d
-                  ./test.sh ${{ steps.ecr.outputs.registry }}/tyk:sha-${{ github.sha }}
-                  cd -
-              fi
-          done
-
+    uses: ./.github/workflows/release-tests.yml
 
   sbom:
     needs: goreleaser

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -438,7 +438,7 @@ jobs:
         run: |
           docker run --network ${{ job.container.network }} --rm test-${{ matrix.distro }}
   
-  smoke-tests:
+  release-tests:
     needs:
       - goreleaser
     permissions:

--- a/ci/goreleaser/goreleaser.yml
+++ b/ci/goreleaser/goreleaser.yml
@@ -11,7 +11,10 @@ builds:
       - -trimpath
       - -tags=goplugin 
     ldflags:
-      - -X github.com/TykTechnologies/tyk/gateway.VERSION={{.Version}} -X github.com/TykTechnologies/tyk/gateway.Commit={{.FullCommit}} -X github.com/TykTechnologies/tyk/gateway.buildDate={{.Date}} -X github.com/TykTechnologies/tyk/gateway.builtBy=goreleaser
+      - -X github.com/TykTechnologies/tyk/internal/build.Version={{.Version}}
+      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
     goos:
       - linux
     goarch:
@@ -22,7 +25,10 @@ builds:
       - -trimpath
       - -tags=goplugin 
     ldflags:
-      - -X github.com/TykTechnologies/tyk/gateway.VERSION={{.Version}} -X github.com/TykTechnologies/tyk/gateway.Commit={{.FullCommit}} -X github.com/TykTechnologies/tyk/gateway.buildDate={{.Date}} -X github.com/TykTechnologies/tyk/gateway.builtBy=goreleaser
+      - -X github.com/TykTechnologies/tyk/internal/build.Version={{.Version}}
+      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
     env:
       - CC=aarch64-linux-gnu-gcc
     goos:
@@ -35,7 +41,10 @@ builds:
       - -trimpath
       - -tags=goplugin 
     ldflags:
-      - -X github.com/TykTechnologies/tyk/gateway.VERSION={{.Version}} -X github.com/TykTechnologies/tyk/gateway.Commit={{.FullCommit}} -X github.com/TykTechnologies/tyk/gateway.buildDate={{.Date}} -X github.com/TykTechnologies/tyk/gateway.builtBy=goreleaser
+      - -X github.com/TykTechnologies/tyk/internal/build.Version={{.Version}}
+      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
     env:
       - CC=s390x-linux-gnu-gcc
     goos:

--- a/ci/tests/api-functionality/test.sh
+++ b/ci/tests/api-functionality/test.sh
@@ -4,11 +4,7 @@ set -eo pipefail
 function setup {
 	local tag=${1:-"v0.0.0"}
 	# Setup required env vars for docker compose
-	if [[ $tag =~ ":" ]];then #it means is not a tag but complete image url
-		export GATEWAY_IMAGE=${tag}
-	else
-		export GATEWAY_IMAGE=${GATEWAY_IMAGE:-"tykio/tyk-gateway:${tag}"}
-	fi
+	export GATEWAY_IMAGE=${GATEWAY_IMAGE:-"tykio/tyk-gateway:${tag}"}
 
 	docker pull -q $GATEWAY_IMAGE
 }

--- a/ci/tests/plugin-compiler/test.sh
+++ b/ci/tests/plugin-compiler/test.sh
@@ -5,13 +5,8 @@ function setup {
 	local tag=${1:-"v0.0.0"}
 
 	# Setup required env vars for docker compose
-	if [[ $tag =~ ":" ]];then #it means is not a tag but complete image url
-		export GATEWAY_IMAGE=${tag}
-		export PLUGIN_COMPILER_IMAGE=${PLUGIN_COMPILER_IMAGE:-"754489498669.dkr.ecr.eu-central-1.amazonaws.com:sha-${tag#*:}"}
-	else
-		export GATEWAY_IMAGE=${GATEWAY_IMAGE:-"tykio/tyk-gateway:${tag}"}
-		export PLUGIN_COMPILER_IMAGE=${PLUGIN_COMPILER_IMAGE:-"tykio/tyk-plugin-compiler:${tag}"}
-	fi
+	export GATEWAY_IMAGE=${GATEWAY_IMAGE:-"tykio/tyk-gateway:${tag}"}
+	export PLUGIN_COMPILER_IMAGE=${PLUGIN_COMPILER_IMAGE:-"tykio/tyk-plugin-compiler:${tag}"}
 
 	docker pull -q $GATEWAY_IMAGE
 	docker pull -q $PLUGIN_COMPILER_IMAGE

--- a/ci/tests/python-plugins/test.sh
+++ b/ci/tests/python-plugins/test.sh
@@ -5,11 +5,7 @@ function setup {
 	local tag=${1:-"v0.0.0"}
 
 	# Setup required env vars for docker compose
-	if [[ $tag =~ ":" ]];then #it means is not a tag but complete image url
-		export GATEWAY_IMAGE=${tag}
-	else
-		export GATEWAY_IMAGE=${GATEWAY_IMAGE:-"tykio/tyk-gateway:${tag}"}
-	fi
+	export GATEWAY_IMAGE=${GATEWAY_IMAGE:-"tykio/tyk-gateway:${tag}"}
 
 	docker pull -q $GATEWAY_IMAGE
 }

--- a/smoke-tests/plugin-aliasing/test.sh
+++ b/smoke-tests/plugin-aliasing/test.sh
@@ -5,13 +5,8 @@ function setup {
 	local tag=${1:-"v0.0.0"}
 
 	# Setup required env vars for docker compose
-	if [[ $tag =~ ":" ]];then #it means is not a tag but complete image url
-		export GATEWAY_IMAGE=${tag}
-		export PLUGIN_COMPILER_IMAGE=${PLUGIN_COMPILER_IMAGE:-"754489498669.dkr.ecr.eu-central-1.amazonaws.com:sha-${tag#*:}"}
-	else
-		export GATEWAY_IMAGE=${GATEWAY_IMAGE:-"tykio/tyk-gateway:${tag}"}
-		export PLUGIN_COMPILER_IMAGE=${PLUGIN_COMPILER_IMAGE:-"tykio/tyk-plugin-compiler:${tag}"}
-	fi
+	export GATEWAY_IMAGE=${GATEWAY_IMAGE:-"tykio/tyk-gateway:${tag}"}
+	export PLUGIN_COMPILER_IMAGE=${PLUGIN_COMPILER_IMAGE:-"tykio/tyk-plugin-compiler:${tag}"}
 
 	docker pull -q $GATEWAY_IMAGE || true
 	docker pull -q $PLUGIN_COMPILER_IMAGE || true


### PR DESCRIPTION
PR implements the following:

- updates .github/CODEOWNERS for plugin compiler locations
- extracts smoke tests from release.yml into release-tests.yml (remove from templating)
- splits release-tests into two jobs: ci/tests and smoke-tests (parallel)

PR reverts the following changes:

- revert goreleaser.yml ldflags -X variable inject parameters to internal/build.Version
- revert ci/ and smoke-test/ changes in test.sh arguments (images are passed via ENV)

https://tyktech.atlassian.net/browse/TT-10649