### PR TITLE
Backport/release 5.2.4/plugin compiler and smoke tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,15 @@
-/ci/ @TykTechnologies/devops
-.github/workflows/release.yml @TykTechnologies/devops
-.github/workflows/sync-automation.yml @TykTechnologies/devops
-.github/workflows/pac.yml @TykTechnologies/devops
-/repo-policy/ @TykTechnologies/devops
+# SysE/DevOps ownership of CI release pipeline, repo policy, automations.
+
+/ci/                                    @TykTechnologies/devops
+.github/workflows/release.yml           @TykTechnologies/devops
+.github/workflows/sync-automation.yml   @TykTechnologies/devops
+.github/workflows/pac.yml               @TykTechnologies/devops
+/repo-policy/                           @TykTechnologies/devops
+
+# Core API Squad ownership of plugin compiler and related tests.
+
+/smoke-tests/                           @TykTechnologies/core-api-squad
+/ci/tests/                              @TykTechnologies/core-api-squad
+/ci/images/plugin-compiler/             @TykTechnologies/core-api-squad
+.github/workflows/ci-tests.yml          @TykTechnologies/core-api-squad
+.github/workflows/release-tests.yml     @TykTechnologies/core-api-squad

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -1,0 +1,88 @@
+name: Run CI tests and smoke tests
+
+on:
+  workflow_call:
+
+jobs:
+  ci-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: arn:aws:iam::754489498669:role/ecr_rw_tyk
+          role-session-name: cipush
+          aws-region: eu-central-1
+
+      - id: ecr
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          mask-password: 'true'
+
+      - name: Run /ci/tests
+        shell: bash
+        env:
+          GITHUB_TAG: ${{ github.ref }}
+          GATEWAY_IMAGE: ${{ steps.ecr.outputs.registry }}/tyk:sha-${{ github.sha }}
+          PLUGIN_COMPILER_IMAGE: ${{ steps.ecr.outputs.registry }}/tyk-plugin-compiler:sha-${{ github.sha }}
+        run: |
+          set -eaxo pipefail
+          for d in ci/tests/*/
+          do
+              echo Attempting to test $d
+              if [ -d $d ] && [ -e $d/test.sh ]; then
+                  cd $d
+                  ./test.sh
+                  cd -
+              fi
+          done
+
+  smoke-tests:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags')
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: arn:aws:iam::754489498669:role/ecr_rw_tyk
+          role-session-name: cipush
+          aws-region: eu-central-1
+
+      - id: ecr
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          mask-password: 'true'
+
+      - name: Run /smoke-tests
+
+        # This job only runs whenever a tag is created. A tag is required
+        # for a functional plugin compiler build for when the GO_GET=1 env
+        # is provided. The plugin compiler cannot fetch the referenced
+        # commit from a PR, but requires a /heads or /tags reference.
+        #
+        # See https://github.com/golang/go/issues/31191 for more info.
+
+        shell: bash
+        env:
+          GITHUB_TAG: ${{ github.ref }}
+          GATEWAY_IMAGE: ${{ steps.ecr.outputs.registry }}/tyk:sha-${{ github.sha }}
+          PLUGIN_COMPILER_IMAGE: ${{ steps.ecr.outputs.registry }}/tyk-plugin-compiler:sha-${{ github.sha }}
+        run: |
+          set -eaxo pipefail
+          for d in smoke-tests/*/
+          do
+              echo Attempting to test $d
+              if [ -d $d ] && [ -e $d/test.sh ]; then
+                  cd $d
+                  ./test.sh
+                  cd -
+              fi
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -370,75 +370,11 @@ jobs:
       - name: Test the built container image with api functionality test.
         run: |
           docker run --network ${{ job.container.network }} --rm test-${{ matrix.distro }}
-
-  smoke-tests:
+  
+  release-tests:
     needs:
       - goreleaser
-    runs-on: ubuntu-latest
     permissions:
-      id-token: write   # AWS OIDC JWT
-      contents: read    # actions/checkout
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
-
-      - uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: arn:aws:iam::754489498669:role/ecr_rw_tyk
-          role-session-name: cipush
-          aws-region: eu-central-1
-          # Don't mask to pass it across job boundaries
-          mask-aws-account-id: false
-
-      - uses: aws-actions/amazon-ecr-login@v1
-        id: ecr
-        with:
-          mask-password: 'true'
-
-      - name: "Run ci/tests"
-        shell: bash
-        env:
-          GITHUB_TAG: ${{ github.ref }}
-          GATEWAY_IMAGE: ${{ steps.ecr.outputs.registry }}/tyk:${{ github.sha }}
-          PLUGIN_COMPILER_IMAGE: ${{ steps.ecr.outputs.registry }}/tyk-plugin-compiler:sha-${{ github.sha }}
-        run: |
-          set -eaxo pipefail
-          for d in ci/tests/*/
-          do
-              echo Attempting to test $d
-              if [ -d $d ] && [ -e $d/test.sh ]; then
-                  cd $d
-                  ./test.sh ${{ needs.goreleaser.outputs.tag }}
-                  cd -
-              fi
-          done
-
-      - name: "Run smoke-tests"
-
-        # This job only runs whenever a tag is created. A tag is required
-        # for a functional plugin compiler build for when the GO_GET=1 env
-        # is provided. The plugin compiler cannot fetch the referenced
-        # commit from a PR, but requires a /heads or /tags reference.
-        #
-        # See https://github.com/golang/go/issues/31191 for more info.
-
-        if: startsWith(github.ref, 'refs/tags')
-        shell: bash
-        env:
-          GITHUB_TAG: ${{ github.ref }}
-          GATEWAY_IMAGE: ${{ steps.ecr.outputs.registry }}/tyk:${{ github.sha }}
-          PLUGIN_COMPILER_IMAGE: ${{ steps.ecr.outputs.registry }}/tyk-plugin-compiler:sha-${{ github.sha }}
-        run: |
-          set -eaxo pipefail
-          for d in smoke-tests/*/
-          do
-              echo Attempting to test $d
-              if [ -d $d ] && [ -e $d/test.sh ]; then
-                  cd $d
-                  ./test.sh ${{ needs.goreleaser.outputs.tag }}
-                  cd -
-              fi
-          done
-
+      id-token: write   # This is required for requesting the JWT
+      contents: read    # This is required for actions/checkout
+    uses: ./.github/workflows/release-tests.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,10 +134,9 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha
-            type=sha,format=long,prefix=
-            type=semver,pattern=v{{major}}.{{minor}}
-            type=semver,pattern=v{{version}}
+            type=sha,format=long
+            type=semver,pattern=v{{major}}.{{minor}},prefix=v
+            type=semver,pattern=v{{version}},prefix=v
 
       - name: CI push
         shell: bash


### PR DESCRIPTION
Backports of:

- TT-10649 fixes goreleaser, reverts ci tests, adds codeowners
- adjustment of release.yml docker image tags to pass smoke tests