### PR TITLE
Merging to release-5.2: [TT-10555] Reoder go.work/go.mod, add GO_TIDY env, test (#5822)

### DIFF
--- a/ci/images/plugin-compiler/data/build.sh
+++ b/ci/images/plugin-compiler/data/build.sh
@@ -69,11 +69,6 @@ if [[ "$DEBUG" == "1" ]] ; then
 	set -x
 fi
 
-# Create worspace
-cd $WORKSPACE_ROOT
-go work init ./tyk
-go work use ./$(basename $PLUGIN_BUILD_PATH)
-
 # Go to plugin build path
 cd $PLUGIN_BUILD_PATH
 
@@ -129,14 +124,25 @@ function ensureGoMod {
 
 ensureGoMod
 
-if [[ "$DEBUG" == "1" ]] ; then
-	git add .
-	git diff --cached
-fi
+# Create worspace after ensuring go.mod exists
+cd $WORKSPACE_ROOT
+go work init ./tyk
+go work use ./$(basename $PLUGIN_BUILD_PATH)
 
+# Go to plugin build path
+cd $PLUGIN_BUILD_PATH
 
 if [[ "$GO_GET" == "1" ]] ; then
 	go get github.com/TykTechnologies/tyk@${GITHUB_SHA}
+fi
+
+if [[ "$GO_TIDY" == "1" ]] ; then
+	go mod tidy
+fi
+
+if [[ "$DEBUG" == "1" ]] ; then
+	git add .
+	git diff --cached
 fi
 
 CC=$CC CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH go build -buildmode=plugin -trimpath -o $plugin_name

--- a/ci/tests/plugin-compiler/Taskfile.yml
+++ b/ci/tests/plugin-compiler/Taskfile.yml
@@ -123,3 +123,17 @@ tasks:
       - cp -f {{.plugin_path}}/*.so {{.plugin_path}}/plugin.so
       - docker run {{.args}} --entrypoint=/usr/local/bin/tyk {{.image}} plugin load -f plugin.so -s {{.symbol}}
       - strings {{.plugin_path}}/plugin.so | grep main.go
+
+  test:test-plugin-no-mod:
+    desc: "Test plugin compiler (test-plugin)"
+    vars:
+      plugin_path: '{{.root}}/ci/tests/plugin-compiler/testdata/test-plugin-no-mod'
+      symbol: AddFooBarHeader
+      args: --rm -e DEBUG=1 -v {{.plugin_path}}:/plugin-source -w /plugin-source
+    cmds:
+      - rm -f {{.plugin_path}}/*.so
+      - docker run {{.args}} {{.image}} plugin.so
+      - cp -f {{.plugin_path}}/*.so {{.plugin_path}}/plugin.so
+      - docker run {{.args}} --entrypoint=/usr/local/bin/tyk {{.image}} plugin load -f plugin.so -s {{.symbol}}
+      - strings {{.plugin_path}}/plugin.so | grep main.go
+

--- a/ci/tests/plugin-compiler/testdata/test-plugin-no-mod/main.go
+++ b/ci/tests/plugin-compiler/testdata/test-plugin-no-mod/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"html/template"
+	"net/http"
+
+	"github.com/Masterminds/sprig/v3"
+	// Example of package which is not part of Gateway
+	"github.com/kr/pretty"
+
+	"github.com/TykTechnologies/tyk/ctx"
+	"github.com/TykTechnologies/tyk/log"
+)
+
+var logger = log.Get()
+
+// AddFooBarHeader adds custom "Foo: Bar" header to the request
+//
+//nolint:deadcode
+func AddFooBarHeader(rw http.ResponseWriter, r *http.Request) {
+	r.Header.Add("Foo", "Bar")
+	logger.Info("Test")
+
+	api := ctx.GetDefinition(r)
+	if api != nil {
+		logger.Info("API Definition", pretty.Sprint(api))
+	}
+
+	// Set up variables and template.
+	tpl := `Hello {{.Name | trim | lower}}`
+
+	// Get the Sprig function map.
+	template.Must(template.New("test").Funcs(sprig.FuncMap()).Parse(tpl))
+}
+
+func main() {}


### PR DESCRIPTION
[TT-10555] Reoder go.work/go.mod, add GO_TIDY env, test (#5822)

This PR reorders workspace creation to happen after we ensure that the
plugin has a go.mod file; This resolves a particular build issue due to
ordering:

```
INFO: Creating go.mod
go: creating new go.mod: module tyk.internal/tyk_plugin123
go: to add module requirements and sums:
	go mod tidy
directory . is contained in a module that is not one of the workspace modules listed in go.work. You can add the module to the workspace using go work use .
```

Now, if a plugin doesn't contain a go.mod file, a mod file is created in
the plugin, **before** the workspace is created. This ensures a passing
build. A test case has been added to verify (task
test:test-plugin-no-mod).

A debugging feature has been added, if GO_TIDY=1 exists in the
environment, `go mod tidy` would be run. It's not required by default
but it may aid to resolve some issues.

https://tyktech.atlassian.net/browse/TT-10555

Co-authored-by: Tit Petric <tit@tyk.io>

[TT-10555]: https://tyktech.atlassian.net/browse/TT-10555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ