### PR TITLE
[TT-10778] Apply missing scheme config for consul kv

### DIFF
--- a/storage/kv/consul.go
+++ b/storage/kv/consul.go
@@ -36,6 +36,10 @@ func newConsul(conf config.ConsulConfig) (Store, error) {
 		defaultCfg.Address = conf.Address
 	}
 
+	if conf.Scheme != "" {
+		defaultCfg.Scheme = conf.Scheme
+	}
+
 	if conf.Datacenter != "" {
 		defaultCfg.Datacenter = conf.Datacenter
 	}


### PR DESCRIPTION
When the connection to consul becomes a secure one with `https`, the gateway cannot connect.