### PR TITLE
Add package and tests for rolling window functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -81,6 +81,7 @@ require (
 require (
 	github.com/TykTechnologies/kin-openapi v0.90.0
 	github.com/TykTechnologies/opentelemetry v0.0.20
+	github.com/go-redis/redismock/v8 v8.11.5
 	github.com/google/go-cmp v0.5.9
 	go.opentelemetry.io/otel v1.19.0
 	go.opentelemetry.io/otel/trace v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,7 @@ github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyY
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d h1:S2NE3iHSwP0XV47EEXL8mWmRdEfGscSJ+7EgePNgt0s=
 github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
+github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
@@ -168,6 +169,8 @@ github.com/go-openapi/swag v0.19.5 h1:lTz6Ys4CmqqCQmZPBlbQENR1/GucA2bzYTE12Pw4tF
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-redis/redis/v8 v8.11.5 h1:AcZZR7igkdvfVmQTPnu9WE37LRrO/YrBH5zWyjDC0oI=
 github.com/go-redis/redis/v8 v8.11.5/go.mod h1:gREzHqY1hg6oD9ngVRbLStwAWKhA0FEgq8Jd4h5lpwo=
+github.com/go-redis/redismock/v8 v8.11.5 h1:RJFIiua58hrBrSpXhnGX3on79AU3S271H4ZhRI1wyVo=
+github.com/go-redis/redismock/v8 v8.11.5/go.mod h1:UaAU9dEe1C+eGr+FHV5prCWIt0hafyPWbGMEWE0UWdA=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
@@ -418,6 +421,8 @@ github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
+github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
+github.com/onsi/ginkgo/v2 v2.0.0/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/ginkgo/v2 v2.1.4/go.mod h1:um6tUpWM/cxCK3/FK8BXqEiUMUwRgSM4JXG47RKZmLU=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -425,6 +430,7 @@ github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
+github.com/onsi/gomega v1.18.1/go.mod h1:0q+aL8jAiMXy9hbwj2mr5GziHiwhAIQpFmmtT5hitRs=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/onsi/gomega v1.20.0 h1:8W0cWlwFkflGPLltQvLRB7ZVD5HuP6ng320w2IS245Q=
 github.com/onsi/gomega v1.20.0/go.mod h1:DtrZpjmvpn2mPm4YWQa0/ALMDj9v4YxLgojwPeREyVo=

--- a/internal/rate/Taskfile.yml
+++ b/internal/rate/Taskfile.yml
@@ -1,0 +1,25 @@
+---
+version: "3"
+
+tasks:
+  default:
+    desc: "Run tests"
+    cmds:
+      - goimports -w .
+      - go fmt ./...
+      - go test -tags unit -count=1 -cover -coverprofile=rate.cov .
+      - task: cover
+
+  cover:
+    desc: "Show source coverage"
+    aliases: [coverage, cov, uncover]
+    cmds:
+      - go tool cover -func=rate.cov
+      - uncover rate.cov
+
+  install:uncover:
+    desc: "Install uncover"
+    env:
+      GOBIN: /usr/local/bin
+    cmds:
+      - go install github.com/gregoryv/uncover/...@latest

--- a/internal/rate/rolling_window.go
+++ b/internal/rate/rolling_window.go
@@ -1,0 +1,86 @@
+package rate
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	redis "github.com/go-redis/redis/v8"
+
+	"github.com/TykTechnologies/tyk/storage"
+)
+
+type RedisCluster = storage.RedisCluster
+
+type RollingWindow struct {
+	redis redis.UniversalClient
+}
+
+func NewRollingWindow(redis redis.UniversalClient) *RollingWindow {
+	return &RollingWindow{
+		redis: redis,
+	}
+}
+
+// SetRollingWindow will append to a sorted set in redis and extract a timed window of values.
+func (rw *RollingWindow) SetRollingWindow(ctx context.Context, now time.Time, keyName string, per int64, value_override string, pipeline bool) ([]string, error) {
+	prevPeriod := now.Add(time.Duration(-1*per) * time.Second)
+	period := strconv.Itoa(int(prevPeriod.UnixNano()))
+	expire := time.Duration(per) * time.Second
+
+	element := &redis.Z{
+		Score:  float64(now.UnixNano()),
+		Member: value_override,
+	}
+	if value_override == "-1" {
+		element.Member = strconv.Itoa(int(now.UnixNano()))
+	}
+
+	var zrange *redis.StringSliceCmd
+
+	exec := rw.redis.TxPipelined
+	if pipeline {
+		exec = rw.redis.Pipelined
+	}
+
+	pipeFn := func(pipe redis.Pipeliner) error {
+		pipe.ZRemRangeByScore(ctx, keyName, "-inf", period)
+		zrange = pipe.ZRange(ctx, keyName, 0, -1)
+		pipe.ZAdd(ctx, keyName, element)
+		pipe.Expire(ctx, keyName, expire)
+		return nil
+	}
+
+	_, err := exec(ctx, pipeFn)
+	if err != nil {
+		return nil, err
+	}
+
+	return zrange.Result()
+}
+
+// GetRollingWindow will remove part of a sorted set in redis and extract a timed window of values.
+func (rw *RollingWindow) GetRollingWindow(ctx context.Context, now time.Time, keyName string, per int64, pipeline bool) ([]string, error) {
+	prevPeriod := now.Add(time.Duration(-1*per) * time.Second)
+	period := strconv.Itoa(int(prevPeriod.UnixNano()))
+
+	var zrange *redis.StringSliceCmd
+
+	exec := rw.redis.TxPipelined
+	if pipeline {
+		exec = rw.redis.Pipelined
+	}
+
+	pipeFn := func(pipe redis.Pipeliner) error {
+		pipe.ZRemRangeByScore(ctx, keyName, "-inf", period)
+		zrange = pipe.ZRange(ctx, keyName, 0, -1)
+		return nil
+	}
+
+	_, err := exec(ctx, pipeFn)
+	if err != nil {
+		return nil, err
+	}
+
+	return zrange.Result()
+}

--- a/internal/rate/rolling_window_test.go
+++ b/internal/rate/rolling_window_test.go
@@ -10,10 +10,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/TykTechnologies/tyk/internal/rate"
 	redis "github.com/go-redis/redis/v8"
 	redismock "github.com/go-redis/redismock/v8"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk/internal/rate"
 )
 
 func Test_GetRollingWindow(t *testing.T) {

--- a/internal/rate/rolling_window_test.go
+++ b/internal/rate/rolling_window_test.go
@@ -1,0 +1,260 @@
+//go:build unit
+// +build unit
+
+package rate_test
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/TykTechnologies/tyk/internal/rate"
+	redis "github.com/go-redis/redis/v8"
+	redismock "github.com/go-redis/redismock/v8"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetRollingWindow(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	var (
+		transactionOn        = false
+		transactionOff       = true
+		per            int64 = 60
+		key                  = "test-key"
+	)
+
+	now := time.Now()
+	wantErr := errors.New("Test error return")
+
+	previousPeriod := now.Add(time.Duration(-1*per) * time.Second)
+	previousVal := strconv.Itoa(int(previousPeriod.UnixNano()))
+
+	expectPipeline := func(mock redismock.ClientMock, values []string, err error) {
+		mock.ExpectZRemRangeByScore(key, "-inf", previousVal).SetVal(0)
+		if err != nil {
+			mock.ExpectZRange(key, 0, -1).SetErr(err)
+		} else {
+			mock.ExpectZRange(key, 0, -1).SetVal(values)
+		}
+	}
+
+	expectTxPipeline := func(mock redismock.ClientMock, values []string, err error) {
+		mock.ExpectTxPipeline()
+		expectPipeline(mock, values, err)
+		if err == nil {
+			mock.ExpectTxPipelineExec()
+		}
+	}
+
+	t.Run("no-transaction", func(t *testing.T) {
+		tx := transactionOff
+		expect := expectPipeline
+
+		t.Run("value", func(t *testing.T) {
+			conn, mock := redismock.NewClientMock()
+
+			want := []string{"a", "b", "c"}
+			expect(mock, want, nil)
+
+			rl := rate.NewRollingWindow(conn)
+			got, err := rl.GetRollingWindow(ctx, now, key, per, tx)
+
+			assert.NoError(t, mock.ExpectationsWereMet())
+
+			assert.NoError(t, err)
+			assert.Equal(t, want, got)
+		})
+
+		t.Run("error", func(t *testing.T) {
+			conn, mock := redismock.NewClientMock()
+
+			want := []string{"a", "b", "c"}
+			expect(mock, want, wantErr)
+
+			rl := rate.NewRollingWindow(conn)
+			got, err := rl.GetRollingWindow(ctx, now, key, per, tx)
+
+			assert.NoError(t, mock.ExpectationsWereMet())
+			assert.ErrorIs(t, err, wantErr)
+			assert.Nil(t, got)
+		})
+	})
+
+	t.Run("transaction", func(t *testing.T) {
+		tx := transactionOn
+		expect := expectTxPipeline
+
+		t.Run("value", func(t *testing.T) {
+			conn, mock := redismock.NewClientMock()
+
+			want := []string{"a", "b", "c"}
+			expect(mock, want, nil)
+
+			rl := rate.NewRollingWindow(conn)
+			got, err := rl.GetRollingWindow(ctx, now, key, per, tx)
+
+			assert.NoError(t, mock.ExpectationsWereMet())
+			assert.NoError(t, err)
+			assert.Equal(t, want, got)
+		})
+
+		t.Run("error", func(t *testing.T) {
+			conn, mock := redismock.NewClientMock()
+
+			want := []string{"a", "b", "c"}
+			expect(mock, want, wantErr)
+
+			rl := rate.NewRollingWindow(conn)
+			got, err := rl.GetRollingWindow(ctx, now, key, per, tx)
+
+			assert.NoError(t, mock.ExpectationsWereMet())
+			assert.ErrorIs(t, err, wantErr)
+			assert.Nil(t, got)
+		})
+	})
+}
+
+func Test_SetRollingWindow(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	var (
+		transactionOn        = false
+		transactionOff       = true
+		key                  = "test-key"
+		per            int64 = 60
+
+		perDuration time.Duration = time.Duration(per) * time.Second
+	)
+
+	now := time.Now()
+	wantErr := errors.New("Test error return")
+	previousPeriod := now.Add(time.Duration(-1*per) * time.Second)
+
+	nowVal := strconv.Itoa(int(now.UnixNano()))
+	previousVal := strconv.Itoa(int(previousPeriod.UnixNano()))
+
+	expectPipeline := func(mock redismock.ClientMock, member string, values []string, err error) {
+		mock.ExpectZRemRangeByScore(key, "-inf", previousVal).SetVal(0)
+
+		if err != nil {
+			mock.ExpectZRange(key, 0, -1).SetErr(err)
+			return
+		} else {
+			mock.ExpectZRange(key, 0, -1).SetVal(values)
+		}
+
+		mock.ExpectZAdd(key, &redis.Z{
+			Member: member,
+			Score:  float64(now.UnixNano()),
+		}).SetVal(1)
+
+		mock.ExpectExpire(key, perDuration).SetVal(true)
+	}
+
+	expectTxPipeline := func(mock redismock.ClientMock, member string, values []string, err error) {
+		mock.ExpectTxPipeline()
+		expectPipeline(mock, member, values, err)
+		if err == nil {
+			mock.ExpectTxPipelineExec()
+		}
+	}
+
+	t.Run("no-transaction", func(t *testing.T) {
+		tx := transactionOff
+		expect := expectPipeline
+
+		t.Run("default", func(t *testing.T) {
+			conn, mock := redismock.NewClientMock()
+
+			want := []string{"a", "b", "c"}
+			expect(mock, nowVal, want, nil)
+
+			rl := rate.NewRollingWindow(conn)
+			got, err := rl.SetRollingWindow(ctx, now, key, per, "-1", tx)
+
+			assert.NoError(t, err)
+			assert.Equal(t, want, got)
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+
+		t.Run("value", func(t *testing.T) {
+			conn, mock := redismock.NewClientMock()
+
+			want := []string{"a", "b", "c"}
+			expect(mock, "123", want, nil)
+
+			rl := rate.NewRollingWindow(conn)
+			got, err := rl.SetRollingWindow(ctx, now, key, per, "123", tx)
+
+			assert.NoError(t, err)
+			assert.Equal(t, want, got)
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+
+		t.Run("error", func(t *testing.T) {
+			conn, mock := redismock.NewClientMock()
+
+			want := []string{"a", "b", "c"}
+			expect(mock, "123", want, wantErr)
+
+			rl := rate.NewRollingWindow(conn)
+			got, err := rl.SetRollingWindow(ctx, now, key, per, "123", tx)
+
+			assert.NoError(t, mock.ExpectationsWereMet())
+			assert.ErrorIs(t, err, wantErr)
+			assert.Nil(t, got)
+		})
+	})
+
+	t.Run("transaction", func(t *testing.T) {
+		tx := transactionOn
+		expect := expectTxPipeline
+
+		t.Run("default", func(t *testing.T) {
+			conn, mock := redismock.NewClientMock()
+
+			want := []string{"a", "b", "c"}
+			expect(mock, nowVal, want, nil)
+
+			rl := rate.NewRollingWindow(conn)
+			got, err := rl.SetRollingWindow(ctx, now, key, per, "-1", tx)
+
+			assert.NoError(t, err)
+			assert.Equal(t, want, got)
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+
+		t.Run("value", func(t *testing.T) {
+			conn, mock := redismock.NewClientMock()
+
+			want := []string{"a", "b", "c"}
+			expect(mock, "123", want, nil)
+
+			rl := rate.NewRollingWindow(conn)
+			got, err := rl.SetRollingWindow(ctx, now, key, per, "123", tx)
+
+			assert.NoError(t, mock.ExpectationsWereMet())
+			assert.NoError(t, err)
+			assert.Equal(t, want, got)
+		})
+
+		t.Run("error", func(t *testing.T) {
+			conn, mock := redismock.NewClientMock()
+
+			want := []string{"a", "b", "c"}
+			expect(mock, "123", want, wantErr)
+
+			rl := rate.NewRollingWindow(conn)
+			got, err := rl.SetRollingWindow(ctx, now, key, per, "123", tx)
+
+			assert.NoError(t, mock.ExpectationsWereMet())
+			assert.ErrorIs(t, err, wantErr)
+			assert.Nil(t, got)
+		})
+	})
+}


### PR DESCRIPTION
POC:

- add internal/rate implementation of SetRollingWindow/GetRollingWindow
- add tests for internal/rate, 100% coverage, using redismock/v8

Notes:

- GetRollingWindow is used for "dry run" only, no real dependency on it.
- Most logic is in `gateway/session_manager.go` (drl, redis, sentinel...).
- Per api and per-session rate limits are enforced in SessionLimiter.ForwardMessage (poor).
- Rate limits for "limitSentinel" and "limitRedis" are identical rolling window implementations
- The difference between limitSentinel and limitRedis is sentinel does the write in background goroutine (implementation should be split so it's not :spaghetti:)
- Quota implemented in same area of session limiter (ForwardMessage)

```
package gateway // import "."

type SessionLimiter struct {
	Gw *Gateway `json:"-"`
	// Has unexported fields.
}

    SessionLimiter is the rate limiter for the API, use ForwardMessage() to
    check if a message should pass through or not

func (l *SessionLimiter) ForwardMessage(
        r *http.Request,
        currentSession *user.SessionState,
        key string,
        store storage.Handler,
        enableRL,
        enableQ bool,
        globalConf *config.Config,
        api *APISpec,
        dryRun bool
    ) sessionFailReason
    
    ForwardMessage will enforce rate limiting, returning a non-zero
    sessionFailReason if session limits have been exceeded. Key values to manage
    rate are Rate and Per, e.g. Rate of 10 messages Per 10 seconds

func (l *SessionLimiter) RedisQuotaExceeded(r *http.Request, currentSession *user.SessionState, scope string, limit *user.APILimit, store storage.Handler, hashKeys bool) bool
```

No direct test of SessionLimiter.FowardMessage

```
mw_api_rate_limit.go:	reason := k.Gw.SessionLimiter.ForwardMessage(r, k.apiSess,
mw_organisation_activity.go:	reason := k.Gw.SessionLimiter.ForwardMessage(
mw_organisation_activity.go:	reason := k.Gw.SessionLimiter.ForwardMessage(
mw_rate_limiting.go:	reason := k.Gw.SessionLimiter.ForwardMessage(
mw_rate_limiting.go:				reason = k.Gw.SessionLimiter.ForwardMessage(
```