### PR TITLE
Encourage mocking of BaseMiddleware and *Gateway, code/model reuse

### DIFF
--- a/apidef/const.go
+++ b/apidef/const.go
@@ -1,0 +1,22 @@
+package apidef
+
+// These are all known tyk event types. The string value is the code used to hook at
+// the api definition JSON/BSON level. Register new event types here.
+const (
+	EventQuotaExceeded        TykEvent = "QuotaExceeded"
+	EventRateLimitExceeded    TykEvent = "RatelimitExceeded"
+	EventAuthFailure          TykEvent = "AuthFailure"
+	EventKeyExpired           TykEvent = "KeyExpired"
+	EventVersionFailure       TykEvent = "VersionFailure"
+	EventOrgQuotaExceeded     TykEvent = "OrgQuotaExceeded"
+	EventOrgRateLimitExceeded TykEvent = "OrgRateLimitExceeded"
+	EventTriggerExceeded      TykEvent = "TriggerExceeded"
+	EventBreakerTriggered     TykEvent = "BreakerTriggered"
+	EventBreakerTripped       TykEvent = "BreakerTripped"
+	EventBreakerReset         TykEvent = "BreakerReset"
+	EventHOSTDOWN             TykEvent = "HostDown"
+	EventHOSTUP               TykEvent = "HostUp"
+	EventTokenCreated         TykEvent = "TokenCreated"
+	EventTokenUpdated         TykEvent = "TokenUpdated"
+	EventTokenDeleted         TykEvent = "TokenDeleted"
+)

--- a/gateway/event_system.go
+++ b/gateway/event_system.go
@@ -1,11 +1,8 @@
 package gateway
 
 import (
-	"bytes"
-	"encoding/base64"
 	"errors"
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -13,51 +10,40 @@ import (
 	circuit "github.com/TykTechnologies/circuitbreaker"
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/gateway/model"
 )
 
 // The name for event handlers as defined in the API Definition JSON/BSON format
 const EH_LogHandler apidef.TykEventHandlerName = "eh_log_handler"
 
-// Register new event types here, the string is the code used to hook at the Api Deifnititon JSON/BSON level
+// Alias the event types (refactoring shim).
 const (
-	EventQuotaExceeded        apidef.TykEvent = "QuotaExceeded"
-	EventRateLimitExceeded    apidef.TykEvent = "RatelimitExceeded"
-	EventAuthFailure          apidef.TykEvent = "AuthFailure"
-	EventKeyExpired           apidef.TykEvent = "KeyExpired"
-	EventVersionFailure       apidef.TykEvent = "VersionFailure"
-	EventOrgQuotaExceeded     apidef.TykEvent = "OrgQuotaExceeded"
-	EventOrgRateLimitExceeded apidef.TykEvent = "OrgRateLimitExceeded"
-	EventTriggerExceeded      apidef.TykEvent = "TriggerExceeded"
-	EventBreakerTriggered     apidef.TykEvent = "BreakerTriggered"
-	EventBreakerTripped       apidef.TykEvent = "BreakerTripped"
-	EventBreakerReset         apidef.TykEvent = "BreakerReset"
-	EventHOSTDOWN             apidef.TykEvent = "HostDown"
-	EventHOSTUP               apidef.TykEvent = "HostUp"
-	EventTokenCreated         apidef.TykEvent = "TokenCreated"
-	EventTokenUpdated         apidef.TykEvent = "TokenUpdated"
-	EventTokenDeleted         apidef.TykEvent = "TokenDeleted"
+	EventQuotaExceeded        = apidef.EventQuotaExceeded
+	EventRateLimitExceeded    = apidef.EventRateLimitExceeded
+	EventAuthFailure          = apidef.EventAuthFailure
+	EventKeyExpired           = apidef.EventKeyExpired
+	EventVersionFailure       = apidef.EventVersionFailure
+	EventOrgQuotaExceeded     = apidef.EventOrgQuotaExceeded
+	EventOrgRateLimitExceeded = apidef.EventOrgRateLimitExceeded
+	EventTriggerExceeded      = apidef.EventTriggerExceeded
+	EventBreakerTriggered     = apidef.EventBreakerTriggered
+	EventBreakerTripped       = apidef.EventBreakerTripped
+	EventBreakerReset         = apidef.EventBreakerReset
+	EventHOSTDOWN             = apidef.EventHOSTDOWN
+	EventHOSTUP               = apidef.EventHOSTUP
+	EventTokenCreated         = apidef.EventTokenCreated
+	EventTokenUpdated         = apidef.EventTokenUpdated
+	EventTokenDeleted         = apidef.EventTokenDeleted
 )
 
-// EventMetaDefault is a standard embedded struct to be used with custom event metadata types, gives an interface for
-// easily extending event metadata objects
-type EventMetaDefault struct {
-	Message            string
-	OriginatingRequest string
-}
+type EventMetaDefault = model.EventMetaDefault
 
 type EventHostStatusMeta struct {
 	EventMetaDefault
 	HostInfo HostHealthReport
 }
 
-// EventKeyFailureMeta is the metadata structure for any failure related
-// to a key, such as quota or auth failures.
-type EventKeyFailureMeta struct {
-	EventMetaDefault
-	Path   string
-	Origin string
-	Key    string
-}
+type EventKeyFailureMeta = model.EventKeyFailureMeta
 
 // EventCurcuitBreakerMeta is the event status for a circuit breaker tripping
 type EventCurcuitBreakerMeta struct {
@@ -88,15 +74,6 @@ type EventTokenMeta struct {
 	EventMetaDefault
 	Org string
 	Key string
-}
-
-// EncodeRequestToEvent will write the request out in wire protocol and
-// encode it to base64 and store it in an Event object
-func EncodeRequestToEvent(r *http.Request) string {
-	var asBytes bytes.Buffer
-	r.Write(&asBytes)
-
-	return base64.StdEncoding.EncodeToString(asBytes.Bytes())
 }
 
 // EventHandlerByName is a convenience function to get event handler instances from an API Definition

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -241,6 +241,20 @@ type BaseMiddleware struct {
 	logger   *logrus.Entry
 }
 
+func (t *BaseMiddleware) NewSession(keyName string) *user.SessionState {
+	sess := &user.SessionState{
+		Rate:        t.Spec.GlobalRateLimit.Rate,
+		Per:         t.Spec.GlobalRateLimit.Per,
+		LastUpdated: strconv.Itoa(int(time.Now().UnixNano())),
+	}
+	sess.SetKeyHash(storage.HashKey(keyName, t.Gw.GetConfig().HashKeys))
+	return sess
+}
+
+func (t *BaseMiddleware) ObfuscateKey(token string) string {
+	return t.Gw.obfuscateKey(token)
+}
+
 func (t *BaseMiddleware) Base() *BaseMiddleware {
 	t.loggerMu.Lock()
 	defer t.loggerMu.Unlock()

--- a/gateway/model/events.go
+++ b/gateway/model/events.go
@@ -1,0 +1,18 @@
+package model
+
+// EventMetaDefault is a standard embedded struct to be used with custom
+// event metadata types, gives an interface for easily extending event
+// metadata objects.
+type EventMetaDefault struct {
+	Message            string
+	OriginatingRequest string
+}
+
+// EventKeyFailureMeta is the metadata structure for any failure related
+// to a key, such as quota or auth failures.
+type EventKeyFailureMeta struct {
+	EventMetaDefault
+	Path   string
+	Origin string
+	Key    string
+}

--- a/gateway/mw_api_rate_limit.go
+++ b/gateway/mw_api_rate_limit.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/TykTechnologies/tyk/internal/httputil"
 	"github.com/TykTechnologies/tyk/request"
 	"github.com/TykTechnologies/tyk/storage"
 	"github.com/TykTechnologies/tyk/user"
@@ -48,7 +49,7 @@ func (k *RateLimitForAPI) handleRateLimitFailure(r *http.Request, token string) 
 
 	// Fire a rate limit exceeded event
 	k.FireEvent(EventRateLimitExceeded, EventKeyFailureMeta{
-		EventMetaDefault: EventMetaDefault{Message: "API Rate Limit Exceeded", OriginatingRequest: EncodeRequestToEvent(r)},
+		EventMetaDefault: EventMetaDefault{Message: "API Rate Limit Exceeded", OriginatingRequest: httputil.EncodeRequest(r)},
 		Path:             r.URL.Path,
 		Origin:           request.RealIP(r),
 		Key:              token,

--- a/gateway/mw_auth_key.go
+++ b/gateway/mw_auth_key.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/TykTechnologies/tyk/internal/crypto"
+	"github.com/TykTechnologies/tyk/internal/httputil"
 	"github.com/TykTechnologies/tyk/internal/otel"
 	"github.com/TykTechnologies/tyk/storage"
 
@@ -256,7 +257,7 @@ func stripBearer(token string) string {
 // TODO: move this method to base middleware?
 func AuthFailed(m TykMiddleware, r *http.Request, token string) {
 	m.Base().FireEvent(EventAuthFailure, EventKeyFailureMeta{
-		EventMetaDefault: EventMetaDefault{Message: "Auth Failure", OriginatingRequest: EncodeRequestToEvent(r)},
+		EventMetaDefault: EventMetaDefault{Message: "Auth Failure", OriginatingRequest: httputil.EncodeRequest(r)},
 		Path:             r.URL.Path,
 		Origin:           request.RealIP(r),
 		Key:              token,

--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/internal/httputil"
 
 	"github.com/TykTechnologies/tyk/ctx"
 
@@ -249,7 +250,7 @@ func (m *GoPluginMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reque
 		case rw.statusCodeSent == http.StatusForbidden:
 			logger.WithError(err).Error("Authentication error in Go-plugin middleware func")
 			m.Base().FireEvent(EventAuthFailure, EventKeyFailureMeta{
-				EventMetaDefault: EventMetaDefault{Message: "Auth Failure", OriginatingRequest: EncodeRequestToEvent(r)},
+				EventMetaDefault: EventMetaDefault{Message: "Auth Failure", OriginatingRequest: httputil.EncodeRequest(r)},
 				Path:             r.URL.Path,
 				Origin:           request.RealIP(r),
 				Key:              "n/a",

--- a/gateway/mw_key_expired_check.go
+++ b/gateway/mw_key_expired_check.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/TykTechnologies/tyk/internal/httputil"
 	"github.com/TykTechnologies/tyk/request"
 )
 
@@ -33,7 +34,7 @@ func (k *KeyExpired) ProcessRequest(w http.ResponseWriter, r *http.Request, _ in
 		logger.Info("Attempted access from inactive key.")
 		// Fire a key expired event
 		k.FireEvent(EventKeyExpired, EventKeyFailureMeta{
-			EventMetaDefault: EventMetaDefault{Message: "Attempted access from inactive key.", OriginatingRequest: EncodeRequestToEvent(r)},
+			EventMetaDefault: EventMetaDefault{Message: "Attempted access from inactive key.", OriginatingRequest: httputil.EncodeRequest(r)},
 			Path:             r.URL.Path,
 			Origin:           request.RealIP(r),
 			Key:              token,
@@ -51,7 +52,7 @@ func (k *KeyExpired) ProcessRequest(w http.ResponseWriter, r *http.Request, _ in
 	logger.Info("Attempted access from expired key.")
 
 	k.FireEvent(EventKeyExpired, EventKeyFailureMeta{
-		EventMetaDefault: EventMetaDefault{Message: "Attempted access from expired key.", OriginatingRequest: EncodeRequestToEvent(r)},
+		EventMetaDefault: EventMetaDefault{Message: "Attempted access from expired key.", OriginatingRequest: httputil.EncodeRequest(r)},
 		Path:             r.URL.Path,
 		Origin:           request.RealIP(r),
 		Key:              token,

--- a/gateway/mw_organisation_activity.go
+++ b/gateway/mw_organisation_activity.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/TykTechnologies/tyk/ctx"
+	"github.com/TykTechnologies/tyk/internal/httputil"
 	"github.com/TykTechnologies/tyk/request"
 	"github.com/TykTechnologies/tyk/user"
 )
@@ -137,7 +138,7 @@ func (k *OrganizationMonitor) ProcessRequestLive(r *http.Request, orgSession *us
 			EventKeyFailureMeta{
 				EventMetaDefault: EventMetaDefault{
 					Message:            "Organisation quota has been exceeded",
-					OriginatingRequest: EncodeRequestToEvent(r),
+					OriginatingRequest: httputil.EncodeRequest(r),
 				},
 				Path:   r.URL.Path,
 				Origin: request.RealIP(r),
@@ -154,7 +155,7 @@ func (k *OrganizationMonitor) ProcessRequestLive(r *http.Request, orgSession *us
 			EventKeyFailureMeta{
 				EventMetaDefault: EventMetaDefault{
 					Message:            "Organisation rate limit has been exceeded",
-					OriginatingRequest: EncodeRequestToEvent(r),
+					OriginatingRequest: httputil.EncodeRequest(r),
 				},
 				Path:   r.URL.Path,
 				Origin: request.RealIP(r),

--- a/gateway/mw_rate_limiting.go
+++ b/gateway/mw_rate_limiting.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/TykTechnologies/tyk/internal/httputil"
 	"github.com/TykTechnologies/tyk/request"
 )
 
@@ -29,7 +30,7 @@ func (k *RateLimitAndQuotaCheck) handleRateLimitFailure(r *http.Request, token s
 
 	// Fire a rate limit exceeded event
 	k.FireEvent(EventRateLimitExceeded, EventKeyFailureMeta{
-		EventMetaDefault: EventMetaDefault{Message: "Key Rate Limit Exceeded", OriginatingRequest: EncodeRequestToEvent(r)},
+		EventMetaDefault: EventMetaDefault{Message: "Key Rate Limit Exceeded", OriginatingRequest: httputil.EncodeRequest(r)},
 		Path:             r.URL.Path,
 		Origin:           request.RealIP(r),
 		Key:              token,
@@ -46,7 +47,7 @@ func (k *RateLimitAndQuotaCheck) handleQuotaFailure(r *http.Request, token strin
 
 	// Fire a quota exceeded event
 	k.FireEvent(EventQuotaExceeded, EventKeyFailureMeta{
-		EventMetaDefault: EventMetaDefault{Message: "Key Quota Limit Exceeded", OriginatingRequest: EncodeRequestToEvent(r)},
+		EventMetaDefault: EventMetaDefault{Message: "Key Quota Limit Exceeded", OriginatingRequest: httputil.EncodeRequest(r)},
 		Path:             r.URL.Path,
 		Origin:           request.RealIP(r),
 		Key:              token,

--- a/gateway/mw_version_check.go
+++ b/gateway/mw_version_check.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/internal/httputil"
 	"github.com/TykTechnologies/tyk/internal/otel"
 	"github.com/TykTechnologies/tyk/request"
 )
@@ -120,7 +121,7 @@ outside:
 		v.FireEvent(EventVersionFailure, EventVersionFailureMeta{
 			EventMetaDefault: EventMetaDefault{
 				Message:            "Attempted access to disallowed version / path.",
-				OriginatingRequest: EncodeRequestToEvent(r),
+				OriginatingRequest: httputil.EncodeRequest(r),
 			},
 			Path:   r.URL.Path,
 			Origin: request.RealIP(r),

--- a/internal/httputil/request.go
+++ b/internal/httputil/request.go
@@ -1,6 +1,10 @@
 package httputil
 
-import "net/http"
+import (
+	"bytes"
+	"encoding/base64"
+	"net/http"
+)
 
 // TransferEncoding gets the header value from the request.
 func TransferEncoding(req *http.Request) string {
@@ -15,4 +19,13 @@ func TransferEncoding(req *http.Request) string {
 // HasTransferEncoding returns true if a transfer encoding header is present.
 func HasTransferEncoding(req *http.Request) bool {
 	return TransferEncoding(req) != ""
+}
+
+// EncodeRequest will write the request out in wire protocol and return
+// it it as a base64 encoded string.
+func EncodeRequest(r *http.Request) string {
+	var asBytes bytes.Buffer
+	r.Write(&asBytes)
+
+	return base64.StdEncoding.EncodeToString(asBytes.Bytes())
 }


### PR DESCRIPTION
Continues: #5828 

Changes to encourage code reuse:

- Event constants are moved from gateway into apidef to be usable from new packages,
- EncodeRequestToEvent is renamed/moved into internal/httputil.EncodeRequest, usage updated,
- EventMetaDefault and EventKeyFailureMeta moved into gateway/model

Changes to encourage mocking and test isolation:

- Base middleware implements `NewSession(keyName string) *user.Session`,
- Base middleware implements `ObfuscateKey` function (to avoid a dependency on `*Gateway.obfuscateKey`)

The changes allow for a BaseMiddleware interface as such:

```
type BaseMiddleware interface {
        Logger() *logrus.Entry

        NewSession(keyName string) *user.SessionState

        FireEvent(name apidef.TykEvent, meta interface{})

        ObfuscateKey(token string) string
}
```

This covers some but not all the current couplings in rate limit middleware.