### PR TITLE
Merging to release-5-lts: TT-10688 when working with custom keys in edge gw use the base64 representation (#5832)

### DIFF
--- a/gateway/api.go
+++ b/gateway/api.go
@@ -741,12 +741,13 @@ func (gw *Gateway) handleAddKey(keyName, sessionString, orgId string) {
 			"status": "fail",
 			"err":    err,
 		}).Error("Failed to update key.")
+		return
 	}
 	log.WithFields(logrus.Fields{
 		"prefix": "RPC",
 		"key":    gw.obfuscateKey(keyName),
 		"status": "ok",
-	}).Info("Updated hashed key in slave storage.")
+	}).Info("Updated key in slave storage.")
 }
 
 func (gw *Gateway) handleDeleteKey(keyName, orgID, apiID string, resetQuota bool) (interface{}, int) {

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -1051,7 +1051,7 @@ func (r *RPCStorageHandler) ProcessKeySpaceChanges(keys []string, orgId string) 
 				_, status = r.Gw.handleDeleteHashedKey(key, orgId, "", resetQuota)
 			} else {
 				log.Info("--> removing cached key: ", r.Gw.obfuscateKey(key))
-				// in case it's an username (basic auth) then generate the token
+				// in case it's an username (basic auth) or custom-key then generate the token
 				if storage.TokenOrg(key) == "" {
 					key = r.Gw.generateToken(orgId, key)
 				}
@@ -1062,7 +1062,7 @@ func (r *RPCStorageHandler) ProcessKeySpaceChanges(keys []string, orgId string) 
 			if status == http.StatusNotFound && !synchronizerEnabled {
 				continue
 			}
-			r.Gw.getSessionAndCreate(splitKeys[0], r, isHashed, orgId)
+			r.Gw.getSessionAndCreate(key, r, isHashed, orgId)
 			r.Gw.SessionCache.Delete(key)
 			r.Gw.RPCGlobalCache.Delete(r.KeyPrefix + key)
 		}


### PR DESCRIPTION
TT-10688 when working with custom keys in edge gw use the base64 representation (#5832)

<!-- Provide a general summary of your changes in the Title above -->

In edge gws, when an updated key signal is received and the key is a
custom key then we must use the base64 representation to pull it
successfully from RPC.

<!-- Describe your changes in detail -->

## Related Issue

TT-10688

## Motivation and Context

Give smooth experience when working with keys in edge gws

## How This Has Been Tested

The next flow was used to test the functionality but in 2 scenearios:
hash keys enabled and disabled in dashboard, MDCB, controller GW, edge
gw:

- Create a custom key
- Use the key in the edge gw
- Update the key in the dashboard but using the custom-key value. For
this you have to: go and open the key from the key list, edit the key in
the url and set the custom value and reload, then click "update". You
can update a field in order to check that the change has been propagated
- Wait some seconds until the event is propagated to edge gws
- Check the edge redis and check that the key exists and the values are
up-to-date

Test not included in this PR, is suggested to continue the work in
https://github.com/TykTechnologies/tyk/pull/4252 so we can add reliable
tests easily.

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why