### PR TITLE
[TT-10786] Fix for writing out the heap profile at end of process

### DIFF
--- a/gateway/handler_error.go
+++ b/gateway/handler_error.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"runtime/pprof"
 	"strconv"
 	"strings"
 	"time"
@@ -171,10 +170,6 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 		}
 	}
 
-	if memProfFile != nil {
-		pprof.WriteHeapProfile(memProfFile)
-	}
-
 	if e.Spec.DoNotTrack || ctxGetDoNotTrack(r) {
 		return
 	}
@@ -318,8 +313,4 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 	}
 	// Report in health check
 	reportHealthValue(e.Spec, BlockedRequestLog, "-1")
-
-	if memProfFile != nil {
-		pprof.WriteHeapProfile(memProfFile)
-	}
 }

--- a/gateway/handler_success.go
+++ b/gateway/handler_success.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"runtime/pprof"
 	"strconv"
 	"strings"
 	"time"
@@ -322,10 +321,6 @@ func (s *SuccessHandler) RecordHit(r *http.Request, timing analytics.Latency, co
 
 	// Report in health check
 	reportHealthValue(s.Spec, RequestLog, strconv.FormatInt(timing.Total, 10))
-
-	if memProfFile != nil {
-		pprof.WriteHeapProfile(memProfFile)
-	}
 }
 
 func recordDetail(r *http.Request, spec *APISpec) bool {

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -1633,7 +1633,10 @@ func Start() {
 		if memProfFile, err = os.Create(memprofile); err != nil {
 			panic(err)
 		}
-		defer memProfFile.Close()
+		defer func() {
+			pprof.WriteHeapProfile(memProfFile)
+			memProfFile.Close()
+		}()
 	}
 	if *cli.CPUProfile {
 		mainLog.Info("Cpu profiling active")


### PR DESCRIPTION
The --memoryprofile function has a bug. It writes the heap file at the end of the request, while the correct place for it is at the end of the process. This fixes the following issue:

```
# go tool pprof tyk.1702510874.mprof 
tyk.1702510874.mprof: decompressing profile: flate: corrupt input before offset 1
failed to fetch any source profiles
```

After applying the fix:

```
# go tool pprof tyk.1702512004.mprof 
File: tyk
Build ID: 1c6b0b72c0718fb7d1cf8e02df57d24d4f0ca031
Type: inuse_space
Time: Dec 14, 2023 at 1:00am (CET)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 9594.63kB, 100% of 9594.63kB total
Showing top 10 nodes out of 72
      flat  flat%   sum%        cum   cum%
 2108.86kB 21.98% 21.98%  4217.71kB 43.96%  text/template.parseFiles
 2108.86kB 21.98% 43.96%  2108.86kB 21.98%  text/template/parse.(*Tree).newText (inline)
 1762.94kB 18.37% 62.33%  1762.94kB 18.37%  runtime/pprof.StartCPUProfile
 1024.88kB 10.68% 73.02%  1024.88kB 10.68%  github.com/santhosh-tekuri/jsonschema/v5.newSchema
  528.17kB  5.50% 78.52%   528.17kB  5.50%  github.com/TykTechnologies/tyk/gateway.(*Gateway).TykNewSingleHostReverseProxy.func4
  522.06kB  5.44% 83.96%   522.06kB  5.44%  encoding/json.typeFields
     514kB  5.36% 89.32%      514kB  5.36%  bufio.NewReaderSize
  512.56kB  5.34% 94.66%   512.56kB  5.34%  regexp.onePassCopy
  512.31kB  5.34%   100%   512.31kB  5.34%  regexp/syntax.(*compiler).inst
         0     0%   100%   522.06kB  5.44%  encoding/json.(*Decoder).Decode
```

Usually we're using `go test` so this is a little used flow. Fix needed to provide data during benchmarking.

https://tyktech.atlassian.net/browse/TT-10786