### PR TITLE
Merging to release-5-lts: TT-10797 Hex validation for long keys on TokenOrg (#5876)

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -24,6 +24,8 @@ var ErrKeyNotFound = errors.New("key not found")
 
 var ErrMDCBConnectionLost = errors.New("mdcb connection is lost")
 
+const MongoBsonIdLength = 24
+
 // Handler is a standard interface to a storage backend, used by
 // AuthorisationManager to read and write key values to the backend
 type Handler interface {
@@ -127,8 +129,12 @@ func TokenOrg(token string) string {
 	}
 
 	// 24 is mongo bson id length
-	if len(token) > 24 {
-		return token[:24]
+	if len(token) > MongoBsonIdLength {
+		newToken := token[:MongoBsonIdLength]
+		_, err := hex.DecodeString(newToken)
+		if err == nil {
+			return newToken
+		}
 	}
 
 	return ""

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1,0 +1,41 @@
+package storage
+
+import "testing"
+
+func Test_TokenOrg(t *testing.T) {
+	tcs := []struct {
+		name           string
+		givenKey       string
+		expectedResult string
+	}{
+		{
+			name:           "long non-b64 key - without orgId ",
+			givenKey:       "testdata-JJNIsqyZViCvcnbX8ouvG7yctsH1irHa2aklAFYC",
+			expectedResult: "",
+		},
+		{
+			name:           "b64 key",
+			givenKey:       "eyJvcmciOiI2NDkyZjY2ZTZlYmJjNTZjNmE2YmYwMjIiLCJpZCI6IjEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU5IiwiaCI6Im11cm11cjY0In0=",
+			expectedResult: "6492f66e6ebbc56c6a6bf022",
+		},
+		{
+			name:           "long non-b64 key - with orgId",
+			givenKey:       "6492f66e6ebbc56c6a6bf022657c162274933214b91ea570",
+			expectedResult: "6492f66e6ebbc56c6a6bf022",
+		},
+		{
+			name:           "short non-b64 key",
+			givenKey:       "6492f66e6e",
+			expectedResult: "",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := TokenOrg(tc.givenKey)
+			if result != tc.expectedResult {
+				t.Errorf("Expected %s, got %s", tc.expectedResult, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
TT-10797 Hex validation for long keys on TokenOrg (#5876)

<!-- Provide a general summary of your changes in the Title above -->

## Description
When Gateway try to extract the orgId of custom keys with len > 24
characters, it will extract part of the custom key independent if it's
the actual orgID or not.
This PR adds a validation if the token > 24 and it's not a hex string (
orgId's are mongoId's ); it will return an empty string.

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->
https://tyktech.atlassian.net/browse/TT-10797
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
If the custom key has more than 24 characters, it is get deleted from
Edge Redis on update.
## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why