### PR TITLE
[TT-10829] Update DRL to latest

### DIFF
--- a/gateway/oauth_manager_test.go
+++ b/gateway/oauth_manager_test.go
@@ -44,7 +44,7 @@ const (
 const keyRules = `{
 	"last_check": 1402492859,
 	"org_id": "53ac07777cbb8c2d53000002",
-	"rate": 1,
+	"rate": 3,
 	"per": 1,
 	"quota_max": -1,
 	"quota_renews": 1399567002,
@@ -55,7 +55,7 @@ const keyRules = `{
 const keyRulesWithMetadata = `{
 	"last_check": 1402492859,
 	"org_id": "53ac07777cbb8c2d53000002",
-	"rate": 1,
+	"rate": 3,
 	"per": 1,
 	"quota_max": -1,
 	"quota_renews": 1399567002,

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/TykTechnologies/again v0.0.0-20190805133618-6ad301e7eaed
 	github.com/TykTechnologies/circuitbreaker v2.2.2+incompatible
-	github.com/TykTechnologies/drl v0.0.0-20221208085827-9bc9b4338f26
+	github.com/TykTechnologies/drl v0.0.0-20231218155806-88e4363884a2
 	github.com/TykTechnologies/goautosocket v0.0.0-20190430121222-97bfa5e7e481
 	github.com/TykTechnologies/gojsonschema v0.0.0-20170222154038-dcb3e4bb7990
 	github.com/TykTechnologies/gorpc v0.0.0-20210624160652-fe65bda0ccb9

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,6 @@ github.com/TykTechnologies/again v0.0.0-20190805133618-6ad301e7eaed h1:/h52kySW0
 github.com/TykTechnologies/again v0.0.0-20190805133618-6ad301e7eaed/go.mod h1:OUrgdjjCoYX2GZY9Vathb4ExCO9WuPtU1piuOpNw19Q=
 github.com/TykTechnologies/circuitbreaker v2.2.2+incompatible h1:UgJdsV/fBL5Ctx43EGKFxkX0W3MqqeRruadDQ1Kzhn4=
 github.com/TykTechnologies/circuitbreaker v2.2.2+incompatible/go.mod h1:f2+J36wN08/zLudMnO+QaqaBhTdQuIqemtaeEQbhMEM=
-github.com/TykTechnologies/drl v0.0.0-20221208085827-9bc9b4338f26 h1:1vrig7Ce10JAi5oosaHcQaiH6KdxlnbB9yG/0fBrMiA=
-github.com/TykTechnologies/drl v0.0.0-20221208085827-9bc9b4338f26/go.mod h1:F3Ff6Ih4t1i/etqNJHI2K3jverRhNl759J/ra95/3Hk=
 github.com/TykTechnologies/drl v0.0.0-20231218155806-88e4363884a2 h1:jsQNOqSUq4nTzqTlZ7pCsn6g1H8ZYFbORhdmkprxx7M=
 github.com/TykTechnologies/drl v0.0.0-20231218155806-88e4363884a2/go.mod h1:F3Ff6Ih4t1i/etqNJHI2K3jverRhNl759J/ra95/3Hk=
 github.com/TykTechnologies/goautosocket v0.0.0-20190430121222-97bfa5e7e481 h1:fPcSnu5/IBgyqf73GHA99QuwMDbfWH+L4BEX9EZ5kUo=

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/TykTechnologies/circuitbreaker v2.2.2+incompatible h1:UgJdsV/fBL5Ctx4
 github.com/TykTechnologies/circuitbreaker v2.2.2+incompatible/go.mod h1:f2+J36wN08/zLudMnO+QaqaBhTdQuIqemtaeEQbhMEM=
 github.com/TykTechnologies/drl v0.0.0-20221208085827-9bc9b4338f26 h1:1vrig7Ce10JAi5oosaHcQaiH6KdxlnbB9yG/0fBrMiA=
 github.com/TykTechnologies/drl v0.0.0-20221208085827-9bc9b4338f26/go.mod h1:F3Ff6Ih4t1i/etqNJHI2K3jverRhNl759J/ra95/3Hk=
+github.com/TykTechnologies/drl v0.0.0-20231218155806-88e4363884a2 h1:jsQNOqSUq4nTzqTlZ7pCsn6g1H8ZYFbORhdmkprxx7M=
+github.com/TykTechnologies/drl v0.0.0-20231218155806-88e4363884a2/go.mod h1:F3Ff6Ih4t1i/etqNJHI2K3jverRhNl759J/ra95/3Hk=
 github.com/TykTechnologies/goautosocket v0.0.0-20190430121222-97bfa5e7e481 h1:fPcSnu5/IBgyqf73GHA99QuwMDbfWH+L4BEX9EZ5kUo=
 github.com/TykTechnologies/goautosocket v0.0.0-20190430121222-97bfa5e7e481/go.mod h1:CtF8OunV123VfKa8Z9kKcIPHgcd67hSAwFMLlS7FvS4=
 github.com/TykTechnologies/gojsonschema v0.0.0-20170222154038-dcb3e4bb7990 h1:CJRTgg13M3vJG9S7k7kpnvDRMGMywm5OsN6eUE8VwJE=


### PR DESCRIPTION
This PR updates the DRL dependency to it's latest version.

It includes a fix from https://github.com/TykTechnologies/drl/pull/15

https://tyktech.atlassian.net/browse/TT-10829