### PR TITLE
[TT-10838] Reorder config load to happen before gateway is used/referenced

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - release-**
+      - test/tt-10838/fix-nodeid-tests
     types:
       - opened
       - reopened

--- a/gateway/redis_signals.go
+++ b/gateway/redis_signals.go
@@ -210,6 +210,7 @@ func isPayloadSignatureValid(notification Notification) bool {
 		}
 	}
 
+	pubSubLog.Error("Unknown payload signature algo: %s", notification.SignatureAlgo)
 	return false
 }
 

--- a/gateway/rpc_storage_handler_test.go
+++ b/gateway/rpc_storage_handler_test.go
@@ -425,8 +425,6 @@ func TestRPCStorageHandler_BuildNodeInfo(t *testing.T) {
 						"p1-meta": "p1-value",
 					}
 				})
-
-				ts.Gw.SetNodeID("")
 				return ts
 			},
 			expectedNodeInfo: apidef.NodeData{

--- a/gateway/rpc_storage_handler_test.go
+++ b/gateway/rpc_storage_handler_test.go
@@ -313,26 +313,26 @@ func TestGetGroupLoginCallback(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.testName, func(t *testing.T) {
-			g := StartTest(func(globalConf *config.Config) {
+			ts := StartTest(func(globalConf *config.Config) {
 				globalConf.SlaveOptions.SynchroniserEnabled = tc.syncEnabled
 			})
-			defer g.Close()
-			defer g.Gw.GlobalSessionManager.Store().DeleteAllKeys()
+			defer ts.Close()
+			defer ts.Gw.GlobalSessionManager.Store().DeleteAllKeys()
 
 			rpcListener := RPCStorageHandler{
 				KeyPrefix:        "rpc.listener.",
 				SuppressRegister: true,
-				Gw:               g.Gw,
+				Gw:               ts.Gw,
 			}
 
 			expectedNodeInfo := apidef.NodeData{
-				NodeID:      "",
+				NodeID:      ts.Gw.GetNodeID(),
 				GroupID:     "",
 				APIKey:      "",
 				TTL:         0,
 				Tags:        nil,
 				NodeVersion: VERSION,
-				Health:      g.Gw.getHealthCheckInfo(),
+				Health:      ts.Gw.getHealthCheckInfo(),
 				Stats: apidef.GWStats{
 					APIsCount:     0,
 					PoliciesCount: 0,
@@ -367,7 +367,6 @@ func TestRPCStorageHandler_BuildNodeInfo(t *testing.T) {
 				return ts
 			},
 			expectedNodeInfo: apidef.NodeData{
-				NodeID:      "",
 				GroupID:     "",
 				APIKey:      "",
 				TTL:         0,
@@ -392,7 +391,6 @@ func TestRPCStorageHandler_BuildNodeInfo(t *testing.T) {
 				return ts
 			},
 			expectedNodeInfo: apidef.NodeData{
-				NodeID:      "",
 				GroupID:     "group",
 				APIKey:      "apikey-test",
 				TTL:         1,
@@ -428,10 +426,10 @@ func TestRPCStorageHandler_BuildNodeInfo(t *testing.T) {
 					}
 				})
 
+				ts.Gw.SetNodeID("")
 				return ts
 			},
 			expectedNodeInfo: apidef.NodeData{
-				NodeID:      "",
 				GroupID:     "group",
 				TTL:         1,
 				Tags:        []string{"tag1"},
@@ -476,6 +474,10 @@ func TestRPCStorageHandler_BuildNodeInfo(t *testing.T) {
 			r := &RPCStorageHandler{Gw: ts.Gw}
 
 			tc.expectedNodeInfo.Health = ts.Gw.getHealthCheckInfo()
+
+			if tc.expectedNodeInfo.NodeID == "" {
+				tc.expectedNodeInfo.NodeID = ts.Gw.GetNodeID()
+			}
 
 			expected, err := json.Marshal(tc.expectedNodeInfo)
 			assert.Nil(t, err)

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -94,7 +94,8 @@ const appName = "tyk-gateway"
 
 type Gateway struct {
 	DefaultProxyMux *proxyMux
-	config          atomic.Value
+
+	config          *config.Config
 	configMu        sync.Mutex
 
 	ctx context.Context
@@ -1910,11 +1911,13 @@ func (gw *Gateway) startServer() {
 }
 
 func (gw *Gateway) GetConfig() config.Config {
-	return gw.config.Load().(config.Config)
+	gw.configMu.Lock()
+	defer gw.configMu.Unlock()
+	return *gw.config
 }
 
-func (gw *Gateway) SetConfig(conf config.Config, skipReload ...bool) {
+func (gw *Gateway) SetConfig(conf config.Config) {
 	gw.configMu.Lock()
-	gw.config.Store(conf)
+	gw.config = &conf
 	gw.configMu.Unlock()
 }

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -213,9 +213,9 @@ func NewGateway(config config.Config, ctx context.Context) *Gateway {
 		},
 		ctx: ctx,
 	}
-	gw.SetConfig(config)
 
 	gw.Analytics = RedisAnalyticsHandler{Gw: gw}
+	gw.SetConfig(config)
 	sessionManager := DefaultSessionManager{Gw: gw}
 	gw.GlobalSessionManager = SessionHandler(&sessionManager)
 	gw.DefaultOrgStore = DefaultSessionManager{Gw: gw}

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -1575,18 +1575,21 @@ func Start() {
 		os.Exit(0)
 	}
 
-	gwConfig := config.Config{}
-	if err := config.Load(confPaths, &gwConfig); err != nil {
-		mainLog.Errorf("Error loading config, using defaults: %v", err)
-		gwConfig = config.Default
+	loadConfig := func() config.Config {
+		gwConfig := config.Config{}
+		if err := config.Load(confPaths, &gwConfig); err != nil {
+			mainLog.Errorf("Error loading config, using defaults: %v", err)
+			return config.Default
+		}
+		return gwConfig
 	}
 
-	gw := NewGateway(gwConfig, ctx)
+	gw := NewGateway(loadConfig(), ctx)
 	if err := gw.initialiseSystem(); err != nil {
 		mainLog.Fatalf("Error initialising system: %v", err)
 	}
 
-	gwConfig = gw.GetConfig()
+	gwConfig := gw.GetConfig()
 	if gwConfig.ControlAPIPort == 0 {
 		mainLog.Warn("The control_api_port should be changed for production")
 	}

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -1714,12 +1714,12 @@ func (gw *Gateway) LoadAPI(specs ...*APISpec) (out []*APISpec) {
 	gwConf := gw.GetConfig()
 	oldPath := gwConf.AppPath
 	gwConf.AppPath, _ = ioutil.TempDir("", "apps")
-	gw.SetConfig(gwConf, true)
+	gw.SetConfig(gwConf)
 	defer func() {
 		globalConf := gw.GetConfig()
 		os.RemoveAll(globalConf.AppPath)
 		globalConf.AppPath = oldPath
-		gw.SetConfig(globalConf, true)
+		gw.SetConfig(globalConf)
 	}()
 
 	for i, spec := range specs {

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -44,7 +44,6 @@ import (
 	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
 
 	"github.com/TykTechnologies/tyk/apidef"
-	"github.com/TykTechnologies/tyk/cli"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/storage"
 	_ "github.com/TykTechnologies/tyk/templates" // Don't delete
@@ -1142,8 +1141,6 @@ func (s *Test) newGateway(genConf func(globalConf *config.Config)) *Gateway {
 
 	defaultTestConfig = gwConfig
 	gw.SetConfig(gwConfig)
-
-	cli.Init(confPaths)
 
 	err = gw.initialiseSystem()
 	if err != nil {


### PR DESCRIPTION
This PR reorders the config.Load to happen when we create a gateway instance. Previously, the `config.Default` value was being passed, and the configuration was loaded later on in `initialiseSystem`. The change enables referencing a valid gateway configuration from the services declared in NewGateway() and elsewhere.

Moved config logic into cli/ where it belongs.

https://tyktech.atlassian.net/browse/TT-10838