### PR TITLE
[TT-10829] Fix race condition over RequestTokenValue

### DIFF
--- a/gateway/mw_api_rate_limit_test.go
+++ b/gateway/mw_api_rate_limit_test.go
@@ -70,9 +70,6 @@ func TestRLOpen(t *testing.T) {
 
 	spec := ts.Gw.LoadSampleAPI(openRLDefSmall)
 
-	ts.Gw.DRLManager.SetCurrentTokenValue(1)
-	ts.Gw.DRLManager.RequestTokenValue = 1
-
 	ts.Gw.DoReload()
 	chain := ts.getRLOpenChain(spec)
 	for a := 0; a <= 10; a++ {
@@ -104,8 +101,6 @@ func requestThrottlingTest(limiter string, testLevel string) func(t *testing.T) 
 
 		switch limiter {
 		case "InMemoryRateLimiter":
-			ts.Gw.DRLManager.SetCurrentTokenValue(1)
-			ts.Gw.DRLManager.RequestTokenValue = 1
 		case "SentinelRateLimiter":
 			globalCfg.EnableSentinelRateLimiter = true
 		case "RedisRollingRateLimiter":
@@ -232,9 +227,6 @@ func TestRLClosed(t *testing.T) {
 		t.Error("could not update session in Session Manager. " + err.Error())
 	}
 
-	ts.Gw.DRLManager.SetCurrentTokenValue(1)
-	ts.Gw.DRLManager.RequestTokenValue = 1
-
 	chain := ts.getGlobalRLAuthKeyChain(spec)
 	for a := 0; a <= 10; a++ {
 		recorder := httptest.NewRecorder()
@@ -264,9 +256,6 @@ func TestRLOpenWithReload(t *testing.T) {
 	defer ts.Close()
 
 	spec := ts.Gw.LoadSampleAPI(openRLDefSmall)
-
-	ts.Gw.DRLManager.SetCurrentTokenValue(1)
-	ts.Gw.DRLManager.RequestTokenValue = 1
 
 	chain := ts.getRLOpenChain(spec)
 	for a := 0; a <= 10; a++ {

--- a/gateway/mw_rate_limiting_test.go
+++ b/gateway/mw_rate_limiting_test.go
@@ -17,9 +17,6 @@ func TestRateLimit_Unlimited(t *testing.T) {
 	g := StartTest(nil)
 	defer g.Close()
 
-	g.Gw.DRLManager.SetCurrentTokenValue(1)
-	g.Gw.DRLManager.RequestTokenValue = 1
-
 	api := g.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/"
 		spec.UseKeylessAccess = false

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -1379,8 +1379,6 @@ func TestApplyMultiPolicies(t *testing.T) {
 	ts.Gw.policiesMu.RLock()
 	policy1.Rate = 1
 	policy1.LastUpdated = strconv.Itoa(int(time.Now().Unix() + 1))
-	ts.Gw.DRLManager.SetCurrentTokenValue(100)
-	defer ts.Gw.DRLManager.SetCurrentTokenValue(0)
 
 	ts.Gw.policiesByID = map[string]user.Policy{
 		"policy1": policy1,


### PR DESCRIPTION
Previously the default token value would have been 100, but the request token value would be unset (0).

With recent drl defaults changes, the token value and request token values now match, making those calls unnecessary. Change done here: https://github.com/TykTechnologies/drl/pull/15/files

- Removes SetCurrentTokenValue invocations
- Removes RequestTokenValue write (this fixes a data race in CI tests)