### PR TITLE
Fetch explicit pull request ref or github ref in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
       - name: "Add Git safe.directory"
         run: git config --global --add safe.directory $GITHUB_WORKSPACE


### PR DESCRIPTION
Docker images built from pull requests don't contain correct label values for the github hash.

This PR fixes it by explicitly using the pull request sha ref in the checkout action.