### PR TITLE
[TT-10883] Address NodeID naming, move Node ID Set to NewGateway, fix tests

### DIFF
--- a/gateway/rpc_storage_handler_test.go
+++ b/gateway/rpc_storage_handler_test.go
@@ -425,8 +425,6 @@ func TestRPCStorageHandler_BuildNodeInfo(t *testing.T) {
 						"p1-meta": "p1-value",
 					}
 				})
-
-				ts.Gw.SetNodeID("")
 				return ts
 			},
 			expectedNodeInfo: apidef.NodeData{

--- a/gateway/rpc_storage_handler_test.go
+++ b/gateway/rpc_storage_handler_test.go
@@ -313,26 +313,26 @@ func TestGetGroupLoginCallback(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.testName, func(t *testing.T) {
-			g := StartTest(func(globalConf *config.Config) {
+			ts := StartTest(func(globalConf *config.Config) {
 				globalConf.SlaveOptions.SynchroniserEnabled = tc.syncEnabled
 			})
-			defer g.Close()
-			defer g.Gw.GlobalSessionManager.Store().DeleteAllKeys()
+			defer ts.Close()
+			defer ts.Gw.GlobalSessionManager.Store().DeleteAllKeys()
 
 			rpcListener := RPCStorageHandler{
 				KeyPrefix:        "rpc.listener.",
 				SuppressRegister: true,
-				Gw:               g.Gw,
+				Gw:               ts.Gw,
 			}
 
 			expectedNodeInfo := apidef.NodeData{
-				NodeID:      "",
+				NodeID:      ts.Gw.GetNodeID(),
 				GroupID:     "",
 				APIKey:      "",
 				TTL:         0,
 				Tags:        nil,
 				NodeVersion: VERSION,
-				Health:      g.Gw.getHealthCheckInfo(),
+				Health:      ts.Gw.getHealthCheckInfo(),
 				Stats: apidef.GWStats{
 					APIsCount:     0,
 					PoliciesCount: 0,
@@ -367,7 +367,6 @@ func TestRPCStorageHandler_BuildNodeInfo(t *testing.T) {
 				return ts
 			},
 			expectedNodeInfo: apidef.NodeData{
-				NodeID:      "",
 				GroupID:     "",
 				APIKey:      "",
 				TTL:         0,
@@ -392,7 +391,6 @@ func TestRPCStorageHandler_BuildNodeInfo(t *testing.T) {
 				return ts
 			},
 			expectedNodeInfo: apidef.NodeData{
-				NodeID:      "",
 				GroupID:     "group",
 				APIKey:      "apikey-test",
 				TTL:         1,
@@ -428,10 +426,10 @@ func TestRPCStorageHandler_BuildNodeInfo(t *testing.T) {
 					}
 				})
 
+				ts.Gw.SetNodeID("")
 				return ts
 			},
 			expectedNodeInfo: apidef.NodeData{
-				NodeID:      "",
 				GroupID:     "group",
 				TTL:         1,
 				Tags:        []string{"tag1"},
@@ -476,6 +474,10 @@ func TestRPCStorageHandler_BuildNodeInfo(t *testing.T) {
 			r := &RPCStorageHandler{Gw: ts.Gw}
 
 			tc.expectedNodeInfo.Health = ts.Gw.getHealthCheckInfo()
+
+			if tc.expectedNodeInfo.NodeID == "" {
+				tc.expectedNodeInfo.NodeID = ts.Gw.GetNodeID()
+			}
 
 			expected, err := json.Marshal(tc.expectedNodeInfo)
 			assert.Nil(t, err)


### PR DESCRIPTION
This is a cleanup/testing refactor.

- Fix naming of `.NodeID` to be unexposed, adjust naming of mutex (style, api protections)
- Refactor NewGateway to immediately allocate Gateway as a pointer. The value holds mutexes, this avoids filed stdlib issues when a sync.Mutex would be copied (should not).
- Move gateway SetNodeID and SessionID from Start() to NewGateway(), apply to test runs
- Fix tests for RPC storage handler testing for a predefined NodeID value that now changed

https://tyktech.atlassian.net/browse/TT-10883