### PR TITLE
[TT-10881] Make BaseMiddleware a pointer

### DIFF
--- a/coprocess/grpc/coprocess_grpc_test.go
+++ b/coprocess/grpc/coprocess_grpc_test.go
@@ -672,7 +672,7 @@ func TestGRPCAuthHook(t *testing.T) {
 
 	t.Run("id extractor enabled", func(t *testing.T) {
 		path := "/grpc-auth-hook-test-api-1/"
-		baseMW := gateway.BaseMiddleware{
+		baseMW := &gateway.BaseMiddleware{
 			Gw: ts.Gw,
 			Spec: &gateway.APISpec{
 				APIDefinition: &apidef.APIDefinition{

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -256,7 +256,7 @@ func (gw *Gateway) checkAndApplyTrialPeriod(keyName string, newSession *user.Ses
 
 func (gw *Gateway) applyPoliciesAndSave(keyName string, session *user.SessionState, spec *APISpec, isHashed bool) error {
 	// use basic middleware to apply policies to key/session (it also saves it)
-	mw := BaseMiddleware{
+	mw := &BaseMiddleware{
 		Spec: spec,
 		Gw:   gw,
 	}
@@ -447,7 +447,7 @@ func (gw *Gateway) handleAddOrUpdate(keyName string, r *http.Request, isHashed b
 		return apiError("Request malformed"), http.StatusBadRequest
 	}
 
-	mw := BaseMiddleware{Gw: gw}
+	mw := &BaseMiddleware{Gw: gw}
 	// TODO: handle apply policies error
 	mw.ApplyPolicies(newSession)
 	// DO ADD OR UPDATE
@@ -607,7 +607,7 @@ func (gw *Gateway) handleGetDetail(sessionKey, apiID, orgID string, byHash bool)
 		return apiError("Key not found"), http.StatusNotFound
 	}
 
-	mw := BaseMiddleware{Spec: spec, Gw: gw}
+	mw := &BaseMiddleware{Spec: spec, Gw: gw}
 	// TODO: handle apply policies error
 	mw.ApplyPolicies(&session)
 
@@ -1980,7 +1980,7 @@ func (gw *Gateway) createKeyHandler(w http.ResponseWriter, r *http.Request) {
 
 	sessionManager := gw.GlobalSessionManager
 
-	mw := BaseMiddleware{Gw: gw}
+	mw := &BaseMiddleware{Gw: gw}
 	if err := mw.ApplyPolicies(newSession); err != nil {
 		doJSONWrite(w, http.StatusInternalServerError, apiError("Failed to create key - "+err.Error()))
 		return
@@ -2102,7 +2102,7 @@ func (gw *Gateway) previewKeyHandler(w http.ResponseWriter, r *http.Request) {
 	newSession.LastUpdated = strconv.Itoa(int(time.Now().Unix()))
 	newSession.DateCreated = time.Now()
 
-	mw := BaseMiddleware{Gw: gw}
+	mw := &BaseMiddleware{Gw: gw}
 	// TODO: handle apply policies error
 	mw.ApplyPolicies(newSession)
 

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -293,7 +293,7 @@ func (gw *Gateway) processSpec(spec *APISpec, apisByListen map[string]int,
 	// Create the response processors, pass all the loaded custom middleware response functions:
 	gw.createResponseMiddlewareChain(spec, mwResponseFuncs)
 
-	baseMid := BaseMiddleware{Spec: spec, Proxy: proxy, logger: logger, Gw: gw}
+	baseMid := &BaseMiddleware{Spec: spec, Proxy: proxy, logger: logger, Gw: gw}
 
 	for _, v := range baseMid.Spec.VersionData.Versions {
 		if len(v.ExtendedPaths.CircuitBreaker) > 0 {
@@ -566,7 +566,7 @@ func (d *DummyProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	if found, err := isLoop(r); found {
 		if err != nil {
-			handler := ErrorHandler{*d.SH.Base()}
+			handler := ErrorHandler{d.SH.Base()}
 			handler.HandleError(w, r, err.Error(), http.StatusInternalServerError, true)
 			return
 		}
@@ -597,7 +597,7 @@ func (d *DummyProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 				}
 			} else {
-				handler := ErrorHandler{*d.SH.Base()}
+				handler := ErrorHandler{d.SH.Base()}
 				handler.HandleError(w, r, "Can't detect loop target", http.StatusInternalServerError, true)
 				return
 			}
@@ -621,7 +621,7 @@ func (d *DummyProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if d.SH.Spec.target.Scheme == "tyk" {
 		handler, _, found := d.Gw.findInternalHttpHandlerByNameOrID(d.SH.Spec.target.Host)
 		if !found {
-			handler := ErrorHandler{*d.SH.Base()}
+			handler := ErrorHandler{d.SH.Base()}
 			handler.HandleError(w, r, "Couldn't detect target", http.StatusInternalServerError, true)
 			return
 		}

--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -29,7 +29,8 @@ var (
 
 // CoProcessMiddleware is the basic CP middleware struct.
 type CoProcessMiddleware struct {
-	BaseMiddleware
+	*BaseMiddleware
+
 	HookType         coprocess.HookType
 	HookName         string
 	MiddlewareDriver apidef.MiddlewareDriver
@@ -43,7 +44,7 @@ func (m *CoProcessMiddleware) Name() string {
 }
 
 // CreateCoProcessMiddleware initializes a new CP middleware, takes hook type (pre, post, etc.), hook name ("my_hook") and driver ("python").
-func CreateCoProcessMiddleware(hookName string, hookType coprocess.HookType, mwDriver apidef.MiddlewareDriver, baseMid BaseMiddleware) func(http.Handler) http.Handler {
+func CreateCoProcessMiddleware(hookName string, hookType coprocess.HookType, mwDriver apidef.MiddlewareDriver, baseMid *BaseMiddleware) func(http.Handler) http.Handler {
 	dMiddleware := &CoProcessMiddleware{
 		BaseMiddleware:   baseMid,
 		HookType:         hookType,
@@ -524,7 +525,7 @@ func (h *CustomMiddlewareResponseHook) Init(mwDef interface{}, spec *APISpec) er
 	mwDefinition := mwDef.(apidef.MiddlewareDefinition)
 
 	h.mw = &CoProcessMiddleware{
-		BaseMiddleware: BaseMiddleware{
+		BaseMiddleware: &BaseMiddleware{
 			Spec: spec,
 			Gw:   h.Gw,
 		},

--- a/gateway/coprocess_id_extractor.go
+++ b/gateway/coprocess_id_extractor.go
@@ -20,14 +20,15 @@ import (
 // IdExtractor is the base interface for an ID extractor.
 type IdExtractor interface {
 	ExtractAndCheck(*http.Request) (string, ReturnOverrides)
-	GenerateSessionID(string, BaseMiddleware) string
+	GenerateSessionID(string, *BaseMiddleware) string
 }
 
 // BaseExtractor is the base structure for an ID extractor, it implements the IdExtractor interface. Other extractors may override some of its methods.
 type BaseExtractor struct {
 	Config            *apidef.MiddlewareIdExtractor
 	IDExtractorConfig apidef.IDExtractorConfig
-	BaseMiddleware
+	*BaseMiddleware
+
 	Spec *APISpec
 }
 
@@ -86,7 +87,7 @@ func (e *BaseExtractor) Error(r *http.Request, err error, message string) (retur
 }
 
 // GenerateSessionID is a helper for generating session IDs, it takes an input (usually the extractor output) and a middleware pointer.
-func (e *BaseExtractor) GenerateSessionID(input string, mw BaseMiddleware) (sessionID string) {
+func (e *BaseExtractor) GenerateSessionID(input string, mw *BaseMiddleware) (sessionID string) {
 	data := []byte(input)
 	tokenID := fmt.Sprintf("%x", md5.Sum(data))
 	sessionID = e.Gw.generateToken(mw.Spec.OrgID, tokenID)
@@ -253,7 +254,7 @@ func (e *XPathExtractor) ExtractAndCheck(r *http.Request) (SessionID string, ret
 }
 
 // newExtractor is called from the CP middleware for every API that specifies extractor settings.
-func newExtractor(referenceSpec *APISpec, mw BaseMiddleware) {
+func newExtractor(referenceSpec *APISpec, mw *BaseMiddleware) {
 	if referenceSpec.CustomMiddleware.IdExtractor.Disabled {
 		return
 	}

--- a/gateway/coprocess_id_extractor_test.go
+++ b/gateway/coprocess_id_extractor_test.go
@@ -56,7 +56,7 @@ func (ts *Test) prepareExtractor(tb testing.TB, extractorSource apidef.IdExtract
 	}
 
 	spec := ts.createSpecTestFrom(tb, def)
-	mw := BaseMiddleware{Spec: spec, Gw: ts.Gw}
+	mw := &BaseMiddleware{Spec: spec, Gw: ts.Gw}
 	newExtractor(spec, mw)
 
 	extractor, ok := spec.CustomMiddleware.IdExtractor.Extractor.(IdExtractor)

--- a/gateway/coprocess_test.go
+++ b/gateway/coprocess_test.go
@@ -245,7 +245,7 @@ func equalHeaders(h1, h2 []*coprocess.Header) bool {
 
 func TestCoProcessMiddlewareName(t *testing.T) {
 	// Initialize the CoProcessMiddleware
-	m := &CoProcessMiddleware{}
+	m := &CoProcessMiddleware{BaseMiddleware: &BaseMiddleware{}}
 
 	// Get the name using the method
 	name := m.Name()

--- a/gateway/handler_error.go
+++ b/gateway/handler_error.go
@@ -78,7 +78,7 @@ type APIError struct {
 // ErrorHandler is invoked whenever there is an issue with a proxied request, most middleware will invoke
 // the ErrorHandler if something is wrong with the request and halt the request processing through the chain
 type ErrorHandler struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 // TemplateExecutor is an interface used to switch between text/templates and html/template.

--- a/gateway/handler_success.go
+++ b/gateway/handler_success.go
@@ -43,7 +43,7 @@ type ReturningHttpHandler interface {
 
 // SuccessHandler represents the final ServeHTTP() request for a proxied API request
 type SuccessHandler struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 func tagHeaders(r *http.Request, th []string, tags []string) []string {

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -46,6 +46,7 @@ var (
 type TykMiddleware interface {
 	Init()
 	Base() *BaseMiddleware
+
 	SetName(string)
 	SetRequestLogger(*http.Request)
 	Logger() *logrus.Entry
@@ -98,7 +99,7 @@ func (tr TraceMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request,
 	return tr.TykMiddleware.ProcessRequest(w, r, conf)
 }
 
-func (gw *Gateway) createDynamicMiddleware(name string, isPre, useSession bool, baseMid BaseMiddleware) func(http.Handler) http.Handler {
+func (gw *Gateway) createDynamicMiddleware(name string, isPre, useSession bool, baseMid *BaseMiddleware) func(http.Handler) http.Handler {
 	dMiddleware := &DynamicMiddleware{
 		BaseMiddleware:      baseMid,
 		MiddlewareClassName: name,
@@ -168,7 +169,7 @@ func (gw *Gateway) createMiddleware(actualMW TykMiddleware) func(http.Handler) h
 					writeResponse = false
 				}
 
-				handler := ErrorHandler{*mw.Base()}
+				handler := ErrorHandler{mw.Base()}
 				handler.HandleError(w, r, err.Error(), errCode, writeResponse)
 
 				meta["error"] = err.Error()
@@ -282,15 +283,15 @@ func (t *BaseMiddleware) SetRequestLogger(r *http.Request) {
 	t.logger = t.Gw.getLogEntryForRequest(logger, r, ctxGetAuthToken(r), nil)
 }
 
-func (t BaseMiddleware) Init() {}
-func (t BaseMiddleware) EnabledForSpec() bool {
+func (t *BaseMiddleware) Init() {}
+func (t *BaseMiddleware) EnabledForSpec() bool {
 	return true
 }
-func (t BaseMiddleware) Config() (interface{}, error) {
+func (t *BaseMiddleware) Config() (interface{}, error) {
 	return nil, nil
 }
 
-func (t BaseMiddleware) OrgSession(orgID string) (user.SessionState, bool) {
+func (t *BaseMiddleware) OrgSession(orgID string) (user.SessionState, bool) {
 
 	if rpc.IsEmergencyMode() {
 		return user.SessionState{}, false
@@ -311,11 +312,11 @@ func (t BaseMiddleware) OrgSession(orgID string) (user.SessionState, bool) {
 	return session.Clone(), found
 }
 
-func (t BaseMiddleware) SetOrgExpiry(orgid string, expiry int64) {
+func (t *BaseMiddleware) SetOrgExpiry(orgid string, expiry int64) {
 	t.Gw.ExpiryCache.Set(orgid, expiry, cache.DefaultExpiration)
 }
 
-func (t BaseMiddleware) OrgSessionExpiry(orgid string) int64 {
+func (t *BaseMiddleware) OrgSessionExpiry(orgid string) int64 {
 	t.Logger().Debug("Checking: ", orgid)
 	// Cache failed attempt
 	id, err, _ := orgSessionExpiryCache.Do(orgid, func() (interface{}, error) {
@@ -341,7 +342,7 @@ func (t BaseMiddleware) OrgSessionExpiry(orgid string) int64 {
 	return id.(int64)
 }
 
-func (t BaseMiddleware) UpdateRequestSession(r *http.Request) bool {
+func (t *BaseMiddleware) UpdateRequestSession(r *http.Request) bool {
 	session := ctxGetSession(r)
 	token := ctxGetAuthToken(r)
 
@@ -372,7 +373,7 @@ func (t BaseMiddleware) UpdateRequestSession(r *http.Request) bool {
 
 // clearSession clears the quota, rate limit and complexity values so that partitioned policies can apply their values.
 // Otherwise, if the session has already a higher value, an applied policy will not win, and its values will be ignored.
-func (t BaseMiddleware) clearSession(session *user.SessionState) {
+func (t *BaseMiddleware) clearSession(session *user.SessionState) {
 	policies := session.PolicyIDs()
 	for _, polID := range policies {
 		t.Gw.policiesMu.RLock()
@@ -404,7 +405,7 @@ func (t BaseMiddleware) clearSession(session *user.SessionState) {
 
 // ApplyPolicies will check if any policies are loaded. If any are, it
 // will overwrite the session state to use the policy values.
-func (t BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
+func (t *BaseMiddleware) ApplyPolicies(session *user.SessionState) error {
 	rights := make(map[string]user.AccessDefinition)
 	tags := make(map[string]bool)
 	if session.MetaData == nil {
@@ -810,7 +811,7 @@ func copyAllowedURLs(input []user.AccessSpec) []user.AccessSpec {
 
 // CheckSessionAndIdentityForValidKey will check first the Session store for a valid key, if not found, it will try
 // the Auth Handler, if not found it will fail
-func (t BaseMiddleware) CheckSessionAndIdentityForValidKey(originalKey string, r *http.Request) (user.SessionState, bool) {
+func (t *BaseMiddleware) CheckSessionAndIdentityForValidKey(originalKey string, r *http.Request) (user.SessionState, bool) {
 	key := originalKey
 	minLength := t.Spec.GlobalConfig.MinTokenLength
 	if minLength == 0 {
@@ -907,19 +908,20 @@ func (t BaseMiddleware) CheckSessionAndIdentityForValidKey(originalKey string, r
 }
 
 // FireEvent is added to the BaseMiddleware object so it is available across the entire stack
-func (t BaseMiddleware) FireEvent(name apidef.TykEvent, meta interface{}) {
+func (t *BaseMiddleware) FireEvent(name apidef.TykEvent, meta interface{}) {
 	fireEvent(name, meta, t.Spec.EventPaths)
 }
 
-func (b BaseMiddleware) getAuthType() string {
+func (t *BaseMiddleware) getAuthType() string {
 	return ""
 }
 
-func (b BaseMiddleware) getAuthToken(authType string, r *http.Request) (string, apidef.AuthConfig) {
-	config, ok := b.Base().Spec.AuthConfigs[authType]
+func (t *BaseMiddleware) getAuthToken(authType string, r *http.Request) (string, apidef.AuthConfig) {
+	spec := t.Base().Spec
+	config, ok := spec.AuthConfigs[authType]
 	// Auth is deprecated. To maintain backward compatibility authToken and jwt cases are added.
 	if !ok && (authType == apidef.AuthTokenType || authType == apidef.JWTType) {
-		config = b.Base().Spec.Auth
+		config = spec.Auth
 	}
 
 	var (
@@ -972,11 +974,11 @@ func (b BaseMiddleware) getAuthToken(authType string, r *http.Request) (string, 
 	return key, config
 }
 
-func (b BaseMiddleware) generateSessionID(id string) string {
+func (t *BaseMiddleware) generateSessionID(id string) string {
 	// generate a virtual token
 	data := []byte(id)
 	keyID := fmt.Sprintf("%x", md5.Sum(data))
-	return b.Gw.generateToken(b.Spec.OrgID, keyID)
+	return t.Gw.generateToken(t.Spec.OrgID, keyID)
 }
 
 type TykResponseHandler interface {

--- a/gateway/middleware_test.go
+++ b/gateway/middleware_test.go
@@ -37,7 +37,7 @@ func TestBaseMiddleware_OrgSessionExpiry(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()
 
-	m := BaseMiddleware{
+	m := &BaseMiddleware{
 		Spec: &APISpec{
 			GlobalConfig: config.Config{
 				EnforceOrgDataAge: true,
@@ -80,7 +80,7 @@ func TestBaseMiddleware_getAuthType(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()
 
-	baseMid := BaseMiddleware{Spec: spec, Gw: ts.Gw}
+	baseMid := &BaseMiddleware{Spec: spec, Gw: ts.Gw}
 
 	r, _ := http.NewRequest(http.MethodGet, "", nil)
 	r.Header.Set("h1", "t1")
@@ -133,7 +133,7 @@ func TestBaseMiddleware_getAuthToken(t *testing.T) {
 		ts := StartTest(nil)
 		defer ts.Close()
 
-		baseMid := BaseMiddleware{Spec: spec, Gw: ts.Gw}
+		baseMid := &BaseMiddleware{Spec: spec, Gw: ts.Gw}
 
 		r, _ := http.NewRequest(http.MethodGet, "", nil)
 		r.AddCookie(&http.Cookie{
@@ -161,7 +161,7 @@ func TestBaseMiddleware_getAuthToken(t *testing.T) {
 		ts := StartTest(nil)
 		defer ts.Close()
 
-		baseMid := BaseMiddleware{Spec: spec, Gw: ts.Gw}
+		baseMid := &BaseMiddleware{Spec: spec, Gw: ts.Gw}
 
 		r, _ := http.NewRequest(http.MethodGet, "", nil)
 		r.AddCookie(&http.Cookie{
@@ -189,7 +189,7 @@ func TestBaseMiddleware_getAuthToken(t *testing.T) {
 		ts := StartTest(nil)
 		defer ts.Close()
 
-		baseMid := BaseMiddleware{Spec: spec, Gw: ts.Gw}
+		baseMid := &BaseMiddleware{Spec: spec, Gw: ts.Gw}
 
 		r, _ := http.NewRequest(http.MethodGet, "", nil)
 		r.Header.Set("h1", "t1")
@@ -214,7 +214,7 @@ func TestBaseMiddleware_getAuthToken(t *testing.T) {
 		ts := StartTest(nil)
 		defer ts.Close()
 
-		baseMid := BaseMiddleware{Spec: spec, Gw: ts.Gw}
+		baseMid := &BaseMiddleware{Spec: spec, Gw: ts.Gw}
 
 		r, _ := http.NewRequest(http.MethodGet, "", nil)
 		r.URL.RawQuery = "q1=t1"
@@ -239,7 +239,7 @@ func TestBaseMiddleware_getAuthToken(t *testing.T) {
 		ts := StartTest(nil)
 		defer ts.Close()
 
-		baseMid := BaseMiddleware{Spec: spec, Gw: ts.Gw}
+		baseMid := &BaseMiddleware{Spec: spec, Gw: ts.Gw}
 
 		r, _ := http.NewRequest(http.MethodGet, "", nil)
 		r.URL.RawQuery = "q1=t1"

--- a/gateway/multiauth_test.go
+++ b/gateway/multiauth_test.go
@@ -81,7 +81,7 @@ func (ts *Test) getMultiAuthStandardAndBasicAuthChain(spec *APISpec) http.Handle
 	remote, _ := url.Parse(TestHttpAny)
 	proxy := ts.Gw.TykNewSingleHostReverseProxy(remote, spec, nil)
 	proxyHandler := ProxyHandler(proxy, spec)
-	baseMid := BaseMiddleware{Spec: spec, Proxy: proxy, Gw: ts.Gw}
+	baseMid := &BaseMiddleware{Spec: spec, Proxy: proxy, Gw: ts.Gw}
 	chain := alice.New(ts.Gw.mwList(
 		&IPWhiteListMiddleware{baseMid},
 		&IPBlackListMiddleware{BaseMiddleware: baseMid},

--- a/gateway/mw_access_rights.go
+++ b/gateway/mw_access_rights.go
@@ -9,7 +9,7 @@ import (
 // permission to access the specific version. If no permission data is in the user.SessionState, then
 // it is assumed that the user can go through.
 type AccessRightsCheck struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 func (a *AccessRightsCheck) Name() string {

--- a/gateway/mw_api_rate_limit.go
+++ b/gateway/mw_api_rate_limit.go
@@ -15,7 +15,8 @@ import (
 // RateLimitAndQuotaCheck will check the incoming request and key whether it is within it's quota and
 // within it's rate limit, it makes use of the SessionLimiter object to do this
 type RateLimitForAPI struct {
-	BaseMiddleware
+	*BaseMiddleware
+
 	keyName string
 	apiSess *user.SessionState
 }

--- a/gateway/mw_api_rate_limit_test.go
+++ b/gateway/mw_api_rate_limit_test.go
@@ -35,7 +35,7 @@ func (ts *Test) getRLOpenChain(spec *APISpec) http.Handler {
 	remote, _ := url.Parse(spec.Proxy.TargetURL)
 	proxy := ts.Gw.TykNewSingleHostReverseProxy(remote, spec, nil)
 	proxyHandler := ProxyHandler(proxy, spec)
-	baseMid := BaseMiddleware{Spec: spec, Proxy: proxy, Gw: ts.Gw}
+	baseMid := &BaseMiddleware{Spec: spec, Proxy: proxy, Gw: ts.Gw}
 	chain := alice.New(ts.Gw.mwList(
 		&IPWhiteListMiddleware{baseMid},
 		&IPBlackListMiddleware{BaseMiddleware: baseMid},
@@ -50,7 +50,7 @@ func (ts *Test) getGlobalRLAuthKeyChain(spec *APISpec) http.Handler {
 	remote, _ := url.Parse(spec.Proxy.TargetURL)
 	proxy := ts.Gw.TykNewSingleHostReverseProxy(remote, spec, nil)
 	proxyHandler := ProxyHandler(proxy, spec)
-	baseMid := BaseMiddleware{Spec: spec, Proxy: proxy, Gw: ts.Gw}
+	baseMid := &BaseMiddleware{Spec: spec, Proxy: proxy, Gw: ts.Gw}
 	chain := alice.New(ts.Gw.mwList(
 		&IPWhiteListMiddleware{baseMid},
 		&IPBlackListMiddleware{BaseMiddleware: baseMid},

--- a/gateway/mw_auth_key.go
+++ b/gateway/mw_auth_key.go
@@ -65,7 +65,7 @@ func initAuthKeyErrors() {
 // KeyExists will check if the key being used to access the API is in the request data,
 // and then if the key is in the storage engine
 type AuthKey struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 func (k *AuthKey) Name() string {

--- a/gateway/mw_auth_key_test.go
+++ b/gateway/mw_auth_key_test.go
@@ -324,7 +324,7 @@ func getAuthKeyChain(spec *APISpec, ts *Test) http.Handler {
 	remote, _ := url.Parse(spec.Proxy.TargetURL)
 	proxy := ts.Gw.TykNewSingleHostReverseProxy(remote, spec, nil)
 	proxyHandler := ProxyHandler(proxy, spec)
-	baseMid := BaseMiddleware{Spec: spec, Proxy: proxy, Gw: ts.Gw}
+	baseMid := &BaseMiddleware{Spec: spec, Proxy: proxy, Gw: ts.Gw}
 	chain := alice.New(ts.Gw.mwList(
 		&IPWhiteListMiddleware{baseMid},
 		&IPBlackListMiddleware{BaseMiddleware: baseMid},

--- a/gateway/mw_basic_auth.go
+++ b/gateway/mw_basic_auth.go
@@ -30,7 +30,7 @@ var cacheGroup singleflight.Group
 
 // BasicAuthKeyIsValid uses a username instead of
 type BasicAuthKeyIsValid struct {
-	BaseMiddleware
+	*BaseMiddleware
 
 	bodyUserRegexp     *regexp.Regexp
 	bodyPasswordRegexp *regexp.Regexp

--- a/gateway/mw_basic_auth_test.go
+++ b/gateway/mw_basic_auth_test.go
@@ -169,7 +169,9 @@ func TestBasicAuthHashKeyFunc(t *testing.T) {
 
 			ts.Gw.apisMu.Lock()
 			assert.Len(t, ts.Gw.apiSpecs, 1)
-			k := &BasicAuthKeyIsValid{}
+			k := &BasicAuthKeyIsValid{
+				BaseMiddleware: &BaseMiddleware{},
+			}
 			k.Spec = ts.Gw.apiSpecs[0]
 			ts.Gw.apisMu.Unlock()
 

--- a/gateway/mw_certificate_check.go
+++ b/gateway/mw_certificate_check.go
@@ -9,7 +9,7 @@ import (
 
 // CertificateCheckMW is used if domain was not detected or multiple APIs bind on the same domain. In this case authentification check happens not on TLS side but on HTTP level using this middleware
 type CertificateCheckMW struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 func (m *CertificateCheckMW) Name() string {

--- a/gateway/mw_context_vars.go
+++ b/gateway/mw_context_vars.go
@@ -10,7 +10,7 @@ import (
 )
 
 type MiddlewareContextVars struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 func (m *MiddlewareContextVars) Name() string {

--- a/gateway/mw_example_test.go
+++ b/gateway/mw_example_test.go
@@ -13,7 +13,7 @@ import (
 // modifiedMiddleware is a sample custom middleware component, must inherit TykMiddleware
 // so you have access to spec and definition data
 type modifiedMiddleware struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 type modifiedMiddlewareConfig struct {

--- a/gateway/mw_external_oauth.go
+++ b/gateway/mw_external_oauth.go
@@ -30,7 +30,7 @@ var (
 )
 
 type ExternalOAuthMiddleware struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 func (k *ExternalOAuthMiddleware) Name() string {

--- a/gateway/mw_external_oauth_test.go
+++ b/gateway/mw_external_oauth_test.go
@@ -266,7 +266,7 @@ func TestGetSecretFromJWKOrConfig(t *testing.T) {
 	})[0]
 
 	k := ExternalOAuthMiddleware{
-		BaseMiddleware{
+		&BaseMiddleware{
 			Gw:   ts.Gw,
 			Spec: spec,
 		},

--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -91,7 +91,8 @@ func (w *customResponseWriter) getHttpResponse(r *http.Request) *http.Response {
 
 // GoPluginMiddleware is a generic middleware that will execute Go-plugin code before continuing
 type GoPluginMiddleware struct {
-	BaseMiddleware
+	*BaseMiddleware
+
 	Path           string // path to .so file
 	SymbolName     string // function symbol to look up
 	handler        http.HandlerFunc

--- a/gateway/mw_go_plugin_test.go
+++ b/gateway/mw_go_plugin_test.go
@@ -20,7 +20,9 @@ func TestLoadPlugin(t *testing.T) {
 }
 
 func TestGoPluginMiddleware_EnabledForSpec(t *testing.T) {
-	gpm := GoPluginMiddleware{}
+	gpm := GoPluginMiddleware{
+		BaseMiddleware: &BaseMiddleware{},
+	}
 	apiSpec := &APISpec{APIDefinition: &apidef.APIDefinition{}}
 	gpm.Spec = apiSpec
 

--- a/gateway/mw_granular_access.go
+++ b/gateway/mw_granular_access.go
@@ -9,7 +9,7 @@ import (
 
 // GranularAccessMiddleware will check if a URL is specifically enabled for the key
 type GranularAccessMiddleware struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 func (m *GranularAccessMiddleware) Name() string {

--- a/gateway/mw_graphql.go
+++ b/gateway/mw_graphql.go
@@ -40,7 +40,7 @@ var (
 )
 
 type GraphQLMiddleware struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 func (m *GraphQLMiddleware) Name() string {

--- a/gateway/mw_graphql_complexity.go
+++ b/gateway/mw_graphql_complexity.go
@@ -19,7 +19,7 @@ const (
 )
 
 type GraphQLComplexityMiddleware struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 func (m *GraphQLComplexityMiddleware) Name() string {

--- a/gateway/mw_graphql_complexity_test.go
+++ b/gateway/mw_graphql_complexity_test.go
@@ -258,7 +258,7 @@ func TestGraphQLComplexityMiddleware_ProcessRequest_GraphqlLimits(t *testing.T) 
 		spec.GraphQLExecutor.Schema = countriesSchema
 	})[0]
 	m := GraphQLComplexityMiddleware{
-		BaseMiddleware{
+		&BaseMiddleware{
 			Spec: apiSpec,
 		},
 	}

--- a/gateway/mw_graphql_granular_access.go
+++ b/gateway/mw_graphql_granular_access.go
@@ -23,7 +23,7 @@ const (
 const RestrictedFieldValidationFailedLogMsg = "Error during GraphQL request restricted fields validation: '%s'"
 
 type GraphQLGranularAccessMiddleware struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 func (m *GraphQLGranularAccessMiddleware) Name() string {

--- a/gateway/mw_http_signature_validation.go
+++ b/gateway/mw_http_signature_validation.go
@@ -30,7 +30,8 @@ const altHeaderSpec = "x-aux-date"
 
 // HTTPSignatureValidationMiddleware will check if the request has a signature, and if the request is allowed through
 type HTTPSignatureValidationMiddleware struct {
-	BaseMiddleware
+	*BaseMiddleware
+
 	lowercasePattern *regexp.Regexp
 }
 

--- a/gateway/mw_http_signature_validation_test.go
+++ b/gateway/mw_http_signature_validation_test.go
@@ -85,7 +85,7 @@ func (ts *Test) getHMACAuthChain(spec *APISpec) http.Handler {
 	remote, _ := url.Parse(TestHttpAny)
 	proxy := ts.Gw.TykNewSingleHostReverseProxy(remote, spec, nil)
 	proxyHandler := ProxyHandler(proxy, spec)
-	baseMid := BaseMiddleware{Spec: spec, Proxy: proxy, Gw: ts.Gw}
+	baseMid := &BaseMiddleware{Spec: spec, Proxy: proxy, Gw: ts.Gw}
 	chain := alice.New(ts.Gw.mwList(
 		&IPWhiteListMiddleware{baseMid},
 		&IPBlackListMiddleware{BaseMiddleware: baseMid},

--- a/gateway/mw_ip_blacklist.go
+++ b/gateway/mw_ip_blacklist.go
@@ -10,7 +10,7 @@ import (
 
 // IPBlackListMiddleware lets you define a list of IPs to block from upstream
 type IPBlackListMiddleware struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 func (i *IPBlackListMiddleware) Name() string {

--- a/gateway/mw_ip_blacklist_test.go
+++ b/gateway/mw_ip_blacklist_test.go
@@ -42,7 +42,7 @@ func TestIPBlacklistMiddleware(t *testing.T) {
 			req.Header.Set(header.XRealIP, tc.xRealIP)
 		}
 
-		mw := &IPBlackListMiddleware{}
+		mw := &IPBlackListMiddleware{BaseMiddleware: &BaseMiddleware{}}
 		mw.Spec = spec
 		_, code := mw.ProcessRequest(rec, req, nil)
 
@@ -58,7 +58,7 @@ func BenchmarkIPBlacklistMiddleware(b *testing.B) {
 
 	spec := testPrepareIPBlacklistMiddleware()
 
-	mw := &IPBlackListMiddleware{}
+	mw := &IPBlackListMiddleware{BaseMiddleware: &BaseMiddleware{}}
 	mw.Spec = spec
 
 	rec := httptest.NewRecorder()

--- a/gateway/mw_ip_whitelist.go
+++ b/gateway/mw_ip_whitelist.go
@@ -10,7 +10,7 @@ import (
 
 // IPWhiteListMiddleware lets you define a list of IPs to allow upstream
 type IPWhiteListMiddleware struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 func (i *IPWhiteListMiddleware) Name() string {

--- a/gateway/mw_ip_whitelist_test.go
+++ b/gateway/mw_ip_whitelist_test.go
@@ -42,7 +42,7 @@ func TestIPMiddlewarePass(t *testing.T) {
 			req.Header.Set(header.XRealIP, tc.xRealIP)
 		}
 
-		mw := &IPWhiteListMiddleware{}
+		mw := &IPWhiteListMiddleware{BaseMiddleware: &BaseMiddleware{}}
 		mw.Spec = spec
 		_, code := mw.ProcessRequest(rec, req, nil)
 
@@ -57,7 +57,7 @@ func BenchmarkIPMiddlewarePass(b *testing.B) {
 	b.ReportAllocs()
 
 	spec := testPrepareIPMiddlewarePass()
-	mw := &IPWhiteListMiddleware{}
+	mw := &IPWhiteListMiddleware{BaseMiddleware: &BaseMiddleware{}}
 	mw.Spec = spec
 
 	rec := httptest.NewRecorder()

--- a/gateway/mw_js_plugin.go
+++ b/gateway/mw_js_plugin.go
@@ -83,7 +83,8 @@ type VMReturnObject struct {
 
 // DynamicMiddleware is a generic middleware that will execute JS code before continuing
 type DynamicMiddleware struct {
-	BaseMiddleware
+	*BaseMiddleware
+
 	MiddlewareClassName string
 	Pre                 bool
 	UseSession          bool

--- a/gateway/mw_js_plugin_test.go
+++ b/gateway/mw_js_plugin_test.go
@@ -155,7 +155,7 @@ func TestJSVMBody(t *testing.T) {
 	defer ts.Close()
 
 	dynMid := &DynamicMiddleware{
-		BaseMiddleware: BaseMiddleware{
+		BaseMiddleware: &BaseMiddleware{
 			Spec: &APISpec{APIDefinition: &apidef.APIDefinition{}},
 			Gw:   ts.Gw,
 		},
@@ -196,7 +196,7 @@ func TestJSVMSessionMetadataUpdate(t *testing.T) {
 	defer ts.Close()
 
 	dynMid := &DynamicMiddleware{
-		BaseMiddleware: BaseMiddleware{
+		BaseMiddleware: &BaseMiddleware{
 			Spec: &APISpec{APIDefinition: &apidef.APIDefinition{}},
 			Gw:   ts.Gw,
 		},
@@ -334,7 +334,7 @@ func TestJSVMProcessTimeout(t *testing.T) {
 	defer ts.Close()
 
 	dynMid := &DynamicMiddleware{
-		BaseMiddleware: BaseMiddleware{
+		BaseMiddleware: &BaseMiddleware{
 			Spec: &APISpec{APIDefinition: &apidef.APIDefinition{}},
 			Gw:   ts.Gw,
 		},
@@ -390,7 +390,7 @@ func TestJSVMConfigData(t *testing.T) {
 			"foo": "bar",
 		}
 		dynMid := &DynamicMiddleware{
-			BaseMiddleware:      BaseMiddleware{Spec: spec, Proxy: nil, Gw: ts.Gw},
+			BaseMiddleware:      &BaseMiddleware{Spec: spec, Proxy: nil, Gw: ts.Gw},
 			MiddlewareClassName: "testJSVMData",
 			Pre:                 true,
 		}
@@ -414,7 +414,7 @@ func TestJSVMConfigData(t *testing.T) {
 		spec.ConfigDataDisabled = true
 
 		dynMid := &DynamicMiddleware{
-			BaseMiddleware:      BaseMiddleware{Spec: spec, Proxy: nil, Gw: ts.Gw},
+			BaseMiddleware:      &BaseMiddleware{Spec: spec, Proxy: nil, Gw: ts.Gw},
 			MiddlewareClassName: "testJSVMData",
 			Pre:                 true,
 		}
@@ -444,7 +444,7 @@ testJSVMData.NewProcessRequest(function(request, session, spec) {
 	return testJSVMData.ReturnData(request, {})
 });`
 	dynMid := &DynamicMiddleware{
-		BaseMiddleware:      BaseMiddleware{Spec: spec, Proxy: nil, Gw: ts.Gw},
+		BaseMiddleware:      &BaseMiddleware{Spec: spec, Proxy: nil, Gw: ts.Gw},
 		MiddlewareClassName: "testJSVMData",
 		Pre:                 true,
 	}
@@ -488,7 +488,7 @@ testJSVMCore.NewProcessRequest(function(request, session, config) {
 	return testJSVMCore.ReturnData(request, {})
 });`
 	dynMid := &DynamicMiddleware{
-		BaseMiddleware:      BaseMiddleware{Spec: spec, Proxy: nil, Gw: ts.Gw},
+		BaseMiddleware:      &BaseMiddleware{Spec: spec, Proxy: nil, Gw: ts.Gw},
 		MiddlewareClassName: "testJSVMCore",
 		Pre:                 true,
 	}
@@ -527,7 +527,7 @@ func TestJSVMRequestScheme(t *testing.T) {
 	defer ts.Close()
 
 	dynMid := &DynamicMiddleware{
-		BaseMiddleware: BaseMiddleware{
+		BaseMiddleware: &BaseMiddleware{
 			Spec: &APISpec{APIDefinition: &apidef.APIDefinition{}},
 			Gw:   ts.Gw,
 		},

--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -27,7 +27,7 @@ import (
 )
 
 type JWTMiddleware struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 const (

--- a/gateway/mw_jwt_test.go
+++ b/gateway/mw_jwt_test.go
@@ -2306,7 +2306,7 @@ func TestGetUserIDFromClaim(t *testing.T) {
 func TestJWTMiddleware_getSecretToVerifySignature_JWKNoKID(t *testing.T) {
 	const jwkURL = "https://jwk.com"
 
-	m := JWTMiddleware{}
+	m := JWTMiddleware{BaseMiddleware: &BaseMiddleware{}}
 	api := &apidef.APIDefinition{JWTSource: jwkURL}
 	m.Spec = &APISpec{APIDefinition: api}
 
@@ -2408,7 +2408,7 @@ func Test_getOAuthClientIDFromClaim(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			j := JWTMiddleware{}
+			j := JWTMiddleware{BaseMiddleware: &BaseMiddleware{}}
 			j.Spec = &APISpec{APIDefinition: &apidef.APIDefinition{}}
 
 			oauthClientID := j.getOAuthClientIDFromClaim(tc.claims)

--- a/gateway/mw_key_expired_check.go
+++ b/gateway/mw_key_expired_check.go
@@ -9,7 +9,7 @@ import (
 
 // KeyExpired middleware will check if the requesting key is expired or not. It makes use of the authManager to do so.
 type KeyExpired struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 func (k *KeyExpired) Name() string {

--- a/gateway/mw_method_transform.go
+++ b/gateway/mw_method_transform.go
@@ -10,7 +10,7 @@ import (
 
 // TransformMiddleware is a middleware that will apply a template to a request body to transform it's contents ready for an upstream API
 type TransformMethod struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 func (t *TransformMethod) Name() string {

--- a/gateway/mw_modify_headers.go
+++ b/gateway/mw_modify_headers.go
@@ -8,7 +8,7 @@ import (
 
 // TransformMiddleware is a middleware that will apply a template to a request body to transform it's contents ready for an upstream API
 type TransformHeaders struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 func (t *TransformHeaders) Name() string {

--- a/gateway/mw_modify_headers_test.go
+++ b/gateway/mw_modify_headers_test.go
@@ -17,7 +17,7 @@ func TestTransformHeaders_EnabledForSpec(t *testing.T) {
 		"Default": versionInfo,
 	}
 
-	th := TransformHeaders{}
+	th := TransformHeaders{BaseMiddleware: &BaseMiddleware{}}
 	th.Spec = &APISpec{APIDefinition: &apidef.APIDefinition{}}
 	th.Spec.VersionData.Versions = versions
 

--- a/gateway/mw_oas_validate_request.go
+++ b/gateway/mw_oas_validate_request.go
@@ -15,7 +15,7 @@ func init() {
 }
 
 type ValidateRequest struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 func (k *ValidateRequest) Name() string {

--- a/gateway/mw_oauth2_key_exists.go
+++ b/gateway/mw_oauth2_key_exists.go
@@ -47,7 +47,7 @@ func initOauth2KeyExistsErrors() {
 // Oauth2KeyExists will check if the key being used to access the API is in the request data,
 // and then if the key is in the storage engine
 type Oauth2KeyExists struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 func (k *Oauth2KeyExists) Name() string {

--- a/gateway/mw_openid.go
+++ b/gateway/mw_openid.go
@@ -19,7 +19,8 @@ import (
 const OIDPREFIX = "openid"
 
 type OpenIDMW struct {
-	BaseMiddleware
+	*BaseMiddleware
+
 	providerConfiguration     *openid.Configuration
 	provider_client_policymap map[string]map[string]string
 	lock                      sync.RWMutex

--- a/gateway/mw_organisation_activity.go
+++ b/gateway/mw_organisation_activity.go
@@ -21,7 +21,8 @@ var orgActiveMap sync.Map
 // RateLimitAndQuotaCheck will check the incoming request and key whether it is within it's quota and
 // within it's rate limit, it makes use of the SessionLimiter object to do this
 type OrganizationMonitor struct {
-	BaseMiddleware
+	*BaseMiddleware
+
 	sessionlimiter SessionLimiter
 	mon            Monitor
 }

--- a/gateway/mw_persist_graphql_operation.go
+++ b/gateway/mw_persist_graphql_operation.go
@@ -14,7 +14,7 @@ import (
 
 // PersistGraphQLOperationMiddleware lets you convert any HTTP request into a GraphQL Operation
 type PersistGraphQLOperationMiddleware struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 func (i *PersistGraphQLOperationMiddleware) Name() string {

--- a/gateway/mw_rate_check.go
+++ b/gateway/mw_rate_check.go
@@ -5,7 +5,7 @@ import (
 )
 
 type RateCheckMW struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 func (m *RateCheckMW) Name() string {

--- a/gateway/mw_rate_limiting.go
+++ b/gateway/mw_rate_limiting.go
@@ -13,7 +13,7 @@ import (
 // RateLimitAndQuotaCheck will check the incomming request and key whether it is within it's quota and
 // within it's rate limit, it makes use of the SessionLimiter object to do this
 type RateLimitAndQuotaCheck struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 func (k *RateLimitAndQuotaCheck) Name() string {

--- a/gateway/mw_redis_cache.go
+++ b/gateway/mw_redis_cache.go
@@ -29,7 +29,7 @@ const (
 
 // RedisCacheMiddleware is a caching middleware that will pull data from Redis instead of the upstream proxy
 type RedisCacheMiddleware struct {
-	BaseMiddleware
+	*BaseMiddleware
 
 	store storage.Handler
 	sh    SuccessHandler

--- a/gateway/mw_redis_cache_test.go
+++ b/gateway/mw_redis_cache_test.go
@@ -27,7 +27,7 @@ func TestRedisCacheMiddlewareUnit(t *testing.T) {
 		{
 			Name: "isTimeStampExpired",
 			Fn: func(t *testing.T) {
-				mw := &RedisCacheMiddleware{}
+				mw := &RedisCacheMiddleware{BaseMiddleware: &BaseMiddleware{}}
 
 				assert.True(t, mw.isTimeStampExpired("invalid"))
 				assert.True(t, mw.isTimeStampExpired("1"))
@@ -38,7 +38,7 @@ func TestRedisCacheMiddlewareUnit(t *testing.T) {
 		{
 			Name: "decodePayload",
 			Fn: func(t *testing.T) {
-				mw := &RedisCacheMiddleware{}
+				mw := &RedisCacheMiddleware{BaseMiddleware: &BaseMiddleware{}}
 
 				if data, expire, err := mw.decodePayload("dGVzdGluZwo=|123"); true {
 					assert.Equal(t, "testing\n", data)

--- a/gateway/mw_request_signing.go
+++ b/gateway/mw_request_signing.go
@@ -17,7 +17,7 @@ import (
 )
 
 type RequestSigning struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 func (s *RequestSigning) Name() string {

--- a/gateway/mw_request_size_limit.go
+++ b/gateway/mw_request_size_limit.go
@@ -15,7 +15,7 @@ import (
 // already been copied to memory when this middleware is called. Therefore, this middleware can't protect the gateway
 // itself from large requests.
 type RequestSizeLimitMiddleware struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 func (t *RequestSizeLimitMiddleware) Name() string {

--- a/gateway/mw_strip_auth.go
+++ b/gateway/mw_strip_auth.go
@@ -11,7 +11,7 @@ import (
 )
 
 type StripAuth struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 func (sa *StripAuth) Name() string {

--- a/gateway/mw_strip_auth_test.go
+++ b/gateway/mw_strip_auth_test.go
@@ -38,7 +38,7 @@ func TestStripAuth_stripFromHeaders(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("stripping %+v", tc), func(t *testing.T) {
 
-			sa := StripAuth{}
+			sa := StripAuth{BaseMiddleware: &BaseMiddleware{}}
 			sa.Spec = &APISpec{APIDefinition: &apidef.APIDefinition{}}
 
 			req, err := http.NewRequest("GET", "http://example.com", nil)
@@ -76,7 +76,7 @@ func TestStripAuth_stripFromHeaders(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		sa := StripAuth{}
+		sa := StripAuth{BaseMiddleware: &BaseMiddleware{}}
 		sa.Spec = &APISpec{APIDefinition: &apidef.APIDefinition{}}
 
 		key := "Authorization"
@@ -114,7 +114,7 @@ func BenchmarkStripAuth_stripFromHeaders(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		for _, tc := range testCases {
-			sa := StripAuth{}
+			sa := StripAuth{BaseMiddleware: &BaseMiddleware{}}
 			sa.Spec = &APISpec{APIDefinition: &apidef.APIDefinition{}}
 
 			req, err := http.NewRequest("GET", "http://example.com", nil)
@@ -165,7 +165,7 @@ func TestStripAuth_stripFromParams(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("stripping %s", tc.QueryParam), func(t *testing.T) {
 
-			sa := StripAuth{}
+			sa := StripAuth{BaseMiddleware: &BaseMiddleware{}}
 			sa.Spec = &APISpec{APIDefinition: &apidef.APIDefinition{}}
 
 			rawUrl := "http://example.com/abc"
@@ -207,7 +207,7 @@ func BenchmarkStripAuth_stripFromParams(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		for _, tc := range testCases {
-			sa := StripAuth{}
+			sa := StripAuth{BaseMiddleware: &BaseMiddleware{}}
 			sa.Spec = &APISpec{APIDefinition: &apidef.APIDefinition{}}
 
 			req, err := http.NewRequest("GET", "http://example.com/abc", nil)

--- a/gateway/mw_track_endpoints.go
+++ b/gateway/mw_track_endpoints.go
@@ -8,7 +8,7 @@ import (
 
 // TrackEndpointMiddleware sets context variables to enable or disable whether Tyk should record analytitcs for a specific path.
 type TrackEndpointMiddleware struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 func (t *TrackEndpointMiddleware) Name() string {

--- a/gateway/mw_transform.go
+++ b/gateway/mw_transform.go
@@ -20,7 +20,7 @@ func WrappedCharsetReader(s string, i io.Reader) (io.Reader, error) {
 
 // TransformMiddleware is a middleware that will apply a template to a request body to transform it's contents ready for an upstream API
 type TransformMiddleware struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 func (t *TransformMiddleware) Name() string {

--- a/gateway/mw_transform_jq.go
+++ b/gateway/mw_transform_jq.go
@@ -18,7 +18,7 @@ import (
 )
 
 type TransformJQMiddleware struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 // JQResult structure stores the result of Tyk-JQ filter.

--- a/gateway/mw_transform_jq_dummy.go
+++ b/gateway/mw_transform_jq_dummy.go
@@ -10,7 +10,7 @@ import (
 )
 
 type TransformJQMiddleware struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 func (t *TransformJQMiddleware) Name() string {

--- a/gateway/mw_transform_test.go
+++ b/gateway/mw_transform_test.go
@@ -40,7 +40,7 @@ func TestTransformNonAscii(t *testing.T) {
 	ad := apidef.APIDefinition{}
 	spec := APISpec{APIDefinition: &ad}
 	spec.EnableContextVars = false
-	base := BaseMiddleware{Spec: &spec, Gw: ts.Gw}
+	base := &BaseMiddleware{Spec: &spec, Gw: ts.Gw}
 	base.Spec.EnableContextVars = false
 	transform := TransformMiddleware{base}
 
@@ -65,7 +65,7 @@ func BenchmarkTransformNonAscii(b *testing.B) {
 	defer ts.Close()
 
 	spec := APISpec{}
-	base := BaseMiddleware{Spec: &spec, Gw: ts.Gw}
+	base := &BaseMiddleware{Spec: &spec, Gw: ts.Gw}
 	base.Spec.EnableContextVars = false
 	transform := TransformMiddleware{base}
 
@@ -92,7 +92,7 @@ func TestTransformXMLCrash(t *testing.T) {
 
 	ad := apidef.APIDefinition{}
 	spec := APISpec{APIDefinition: &ad}
-	base := BaseMiddleware{Spec: &spec, Gw: ts.Gw}
+	base := &BaseMiddleware{Spec: &spec, Gw: ts.Gw}
 	base.Spec.EnableContextVars = false
 	transform := TransformMiddleware{base}
 
@@ -147,7 +147,7 @@ func TestTransformJSONMarshalXMLInput(t *testing.T) {
 
 	ad := apidef.APIDefinition{}
 	spec := APISpec{APIDefinition: &ad}
-	base := BaseMiddleware{Spec: &spec, Gw: ts.Gw}
+	base := &BaseMiddleware{Spec: &spec, Gw: ts.Gw}
 	base.Spec.EnableContextVars = false
 	transform := TransformMiddleware{base}
 
@@ -174,7 +174,7 @@ func TestTransformJSONMarshalJSONInput(t *testing.T) {
 
 	ad := apidef.APIDefinition{}
 	spec := APISpec{APIDefinition: &ad}
-	base := BaseMiddleware{Spec: &spec, Gw: ts.Gw}
+	base := &BaseMiddleware{Spec: &spec, Gw: ts.Gw}
 	base.Spec.EnableContextVars = false
 	transform := TransformMiddleware{base}
 
@@ -213,7 +213,7 @@ func TestTransformJSONMarshalJSONArrayInput(t *testing.T) {
 
 	ad := apidef.APIDefinition{}
 	spec := APISpec{APIDefinition: &ad}
-	base := BaseMiddleware{Spec: &spec, Gw: ts.Gw}
+	base := &BaseMiddleware{Spec: &spec, Gw: ts.Gw}
 	base.Spec.EnableContextVars = false
 	transform := TransformMiddleware{base}
 
@@ -237,7 +237,7 @@ func BenchmarkTransformJSONMarshal(b *testing.B) {
 	defer ts.Close()
 
 	spec := APISpec{}
-	base := BaseMiddleware{Spec: &spec, Gw: ts.Gw}
+	base := &BaseMiddleware{Spec: &spec, Gw: ts.Gw}
 	base.Spec.EnableContextVars = false
 	transform := TransformMiddleware{base}
 
@@ -259,7 +259,7 @@ func TestTransformXMLMarshal(t *testing.T) {
 
 		ad := apidef.APIDefinition{}
 		spec := APISpec{APIDefinition: &ad}
-		base := BaseMiddleware{Spec: &spec, Gw: ts.Gw}
+		base := &BaseMiddleware{Spec: &spec, Gw: ts.Gw}
 		base.Spec.EnableContextVars = false
 		transform := TransformMiddleware{base}
 

--- a/gateway/mw_url_rewrite.go
+++ b/gateway/mw_url_rewrite.go
@@ -382,7 +382,7 @@ func valToStr(v interface{}) string {
 
 // URLRewriteMiddleware Will rewrite an inbund URL to a matching outbound one, it can also handle dynamic variable substitution
 type URLRewriteMiddleware struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 func (m *URLRewriteMiddleware) Name() string {

--- a/gateway/mw_url_rewrite_test.go
+++ b/gateway/mw_url_rewrite_test.go
@@ -1376,7 +1376,7 @@ func TestURLRewriteMiddleware_CheckHostRewrite(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := &URLRewriteMiddleware{}
+			m := &URLRewriteMiddleware{BaseMiddleware: &BaseMiddleware{}}
 			r := &http.Request{}
 			err := m.CheckHostRewrite(tt.args.oldPath, tt.args.newTarget, r)
 			assert.Equal(t, tt.errExpected, err != nil)

--- a/gateway/mw_url_rewrite_test.go
+++ b/gateway/mw_url_rewrite_test.go
@@ -1126,7 +1126,7 @@ func TestInitTriggerRx(t *testing.T) {
 
 	// prepare test data
 	testRewriteMW := &URLRewriteMiddleware{
-		BaseMiddleware: BaseMiddleware{
+		BaseMiddleware: &BaseMiddleware{
 			Spec: &APISpec{
 				APIDefinition: &apidef.APIDefinition{},
 			},

--- a/gateway/mw_validate_json.go
+++ b/gateway/mw_validate_json.go
@@ -11,7 +11,7 @@ import (
 )
 
 type ValidateJSON struct {
-	BaseMiddleware
+	*BaseMiddleware
 }
 
 func (k *ValidateJSON) Name() string {

--- a/gateway/mw_version_check.go
+++ b/gateway/mw_version_check.go
@@ -17,7 +17,8 @@ const XTykAPIExpires = "x-tyk-api-expires"
 
 // VersionCheck will check whether the version of the requested API the request is accessing has any restrictions on URL endpoints
 type VersionCheck struct {
-	BaseMiddleware
+	*BaseMiddleware
+
 	sh SuccessHandler
 }
 

--- a/gateway/mw_virtual_endpoint.go
+++ b/gateway/mw_virtual_endpoint.go
@@ -50,7 +50,8 @@ type VMResponseObject struct {
 
 // DynamicMiddleware is a generic middleware that will execute JS code before continuing
 type VirtualEndpoint struct {
-	BaseMiddleware
+	*BaseMiddleware
+
 	sh SuccessHandler
 }
 

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -345,7 +345,7 @@ func (gw *Gateway) TykNewSingleHostReverseProxy(target *url.URL, spec *APISpec, 
 		},
 		Gw: gw,
 	}
-	proxy.ErrorHandler.BaseMiddleware = BaseMiddleware{Spec: spec, Proxy: proxy, Gw: gw}
+	proxy.ErrorHandler.BaseMiddleware = &BaseMiddleware{Spec: spec, Proxy: proxy, Gw: gw}
 	return proxy
 }
 

--- a/gateway/rpc_test.go
+++ b/gateway/rpc_test.go
@@ -420,7 +420,7 @@ func TestOrgSessionWithRPCDown(t *testing.T) {
 	ts := StartTest(conf)
 	defer ts.Close()
 
-	m := BaseMiddleware{
+	m := &BaseMiddleware{
 		Spec: &APISpec{
 			GlobalConfig: config.Config{
 				EnforceOrgDataAge: true,

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -394,7 +394,7 @@ type TestHttpResponse struct {
 // ProxyHandler Proxies requests through to their final destination, if they make it through the middleware chain.
 func ProxyHandler(p *ReverseProxy, apiSpec *APISpec) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		baseMid := BaseMiddleware{Spec: apiSpec, Proxy: p, Gw: p.Gw}
+		baseMid := &BaseMiddleware{Spec: apiSpec, Proxy: p, Gw: p.Gw}
 		handler := SuccessHandler{baseMid}
 		// Skip all other execution
 		handler.ServeHTTP(w, r)


### PR DESCRIPTION
This resolves vet warnings about copying a mutex value.

Before: 189 warnings,
After: 7 warnings

```
# go vet -json ./... 2>&1 | summary vet
Warnings by message:
3 loop variable tc captured by func literal
2 func passes lock by value: github.com/TykTechnologies/tyk/gateway.APISpec
1 call of tc.reloadAPI copies lock value: github.com/TykTechnologies/tyk/gateway.APISpec
1 method Seek(offset int64, whence int64) (int64, error) should have signature Seek(int64, int) (int64, error)

Warnings by filename:
3 /root/tyk/tyk/gateway/handler_success_test.go
2 /root/tyk/tyk/apidef/oas/server_test.go
1 /root/tyk/tyk/test/util_test.go
1 /root/tyk/tyk/gateway/reverse_proxy.go

Total: 7
```

https://tyktech.atlassian.net/browse/TT-10881