### PR TITLE
Merging to release-5-lts: [TT-10750] Extract and update sliding log functionality, update ratelimit (#5925)

### DIFF
--- a/gateway/session_manager.go
+++ b/gateway/session_manager.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	"github.com/TykTechnologies/leakybucket/memorycache"
 
 	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/internal/rate"
 	"github.com/TykTechnologies/tyk/storage"
 	"github.com/TykTechnologies/tyk/user"
 )
@@ -38,45 +40,59 @@ type SessionLimiter struct {
 	Gw          *Gateway `json:"-"`
 }
 
+func (l *SessionLimiter) Context() context.Context {
+	return l.Gw.ctx
+}
+
 func (l *SessionLimiter) doRollingWindowWrite(key, rateLimiterKey, rateLimiterSentinelKey string,
 	currentSession *user.SessionState,
 	store storage.Handler,
 	globalConf *config.Config,
 	apiLimit *user.APILimit, dryRun bool) bool {
 
-	var per, rate float64
+	ctx := l.Context()
+
+	var per, cost float64
 
 	if apiLimit != nil { // respect limit on API level
 		per = apiLimit.Per
-		rate = apiLimit.Rate
+		cost = apiLimit.Rate
 	} else {
 		per = currentSession.Per
-		rate = currentSession.Rate
+		cost = currentSession.Rate
 	}
 
 	log.Debug("[RATELIMIT] Inbound raw key is: ", key)
 	log.Debug("[RATELIMIT] Rate limiter key is: ", rateLimiterKey)
 	pipeline := globalConf.EnableNonTransactionalRateLimiter
 
-	var ratePerPeriodNow int
-	if dryRun {
-		ratePerPeriodNow, _ = store.GetRollingWindow(rateLimiterKey, int64(per), pipeline)
-	} else {
-		ratePerPeriodNow, _ = store.SetRollingWindow(rateLimiterKey, int64(per), "-1", pipeline)
+	ratelimit, err := rate.NewSlidingLog(store, pipeline)
+	if err != nil {
+		log.WithError(err).Error("error creating sliding log")
+		return true
 	}
 
-	//log.Info("Num Requests: ", ratePerPeriodNow)
+	var ratePerPeriodNow int64
+	if dryRun {
+		ratePerPeriodNow, err = ratelimit.GetCount(ctx, time.Now(), rateLimiterKey, int64(per))
+	} else {
+		ratePerPeriodNow, err = ratelimit.SetCount(ctx, time.Now(), rateLimiterKey, int64(per))
+	}
+
+	if err != nil {
+		log.WithError(err).Error("error writing sliding log")
+	}
 
 	// Subtract by 1 because of the delayed add in the window
-	subtractor := 1
+	var subtractor int64 = 1
 	if globalConf.EnableSentinelRateLimiter || globalConf.DRLEnableSentinelRateLimiter {
 		// and another subtraction because of the preemptive limit
 		subtractor = 2
 	}
+
 	// The test TestRateLimitForAPIAndRateLimitAndQuotaCheck
-	// will only work with ththese two lines here
-	//log.Info("break: ", (int(currentSession.Rate) - subtractor))
-	if ratePerPeriodNow > int(rate)-subtractor {
+	// will only work with these two lines here
+	if ratePerPeriodNow > int64(cost)-subtractor {
 		// Set a sentinel value with expire
 		if globalConf.EnableSentinelRateLimiter || globalConf.DRLEnableSentinelRateLimiter {
 			if !dryRun {

--- a/internal/rate/Taskfile.yml
+++ b/internal/rate/Taskfile.yml
@@ -1,0 +1,44 @@
+---
+version: "3"
+
+vars:
+  testArgs: -v
+
+tasks:
+  test:
+    desc: "Run tests (requires redis)"
+    cmds:
+      - task: fmt
+      - go test {{.testArgs}} -count=1 -gcflags="-m=3" -cover -coverprofile=rate.cov .
+
+  bench:
+    desc: "Run benchmarks"
+    cmds:
+      - task: fmt
+      - go test {{.testArgs}} -count=1 -tags integration -bench=. -benchtime=10s -benchmem .
+
+  fmt:
+    internal: true
+    desc: "Invoke fmt"
+    cmds:
+      - goimports -w .
+      - go fmt ./...
+
+  cover:
+    desc: "Show source coverage"
+    aliases: [coverage, cov]
+    cmds:
+      - go tool cover -func=rate.cov
+
+  uncover:
+    desc: "Show uncovered source"
+    cmds:
+      - uncover rate.cov
+
+  install:uncover:
+    desc: "Install uncover"
+    internal: true
+    env:
+      GOBIN: /usr/local/bin
+    cmds:
+      - go install github.com/gregoryv/uncover/...@latest

--- a/internal/rate/sliding_log.go
+++ b/internal/rate/sliding_log.go
@@ -1,0 +1,173 @@
+package rate
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+)
+
+// SlidingLog implements sliding log storage in redis.
+type SlidingLog struct {
+	conn     redis.UniversalClient
+	pipeline bool
+
+	// PipelineFn is exposed for black box tests in the same package.
+	PipelineFn func(context.Context, func(redis.Pipeliner) error) error
+}
+
+// RedisClientProvider is a hidden storage API, providing us with a redis.UniversalClient.
+type RedisClientProvider interface {
+	// Client returns the redis.UniversalClient or an error if not available.
+	Client() (redis.UniversalClient, error)
+}
+
+// ErrRedisClientProvider is returned if NewSlidingLog isn't passed a valid RedisClientProvider parameter.
+var ErrRedisClientProvider = errors.New("Client doesn't implement RedisClientProvider")
+
+// NewSlidingLog creates a new SlidingLog instance with a storage.Handler. In case
+// the storage is offline, it's expected to return nil and an error to handle.
+func NewSlidingLog(client interface{}, pipeline bool) (*SlidingLog, error) {
+	cluster, ok := client.(RedisClientProvider)
+	if !ok {
+		return nil, ErrRedisClientProvider
+	}
+
+	conn, err := cluster.Client()
+	if err != nil {
+		return nil, err
+	}
+
+	return NewSlidingLogRedis(conn, pipeline), nil
+}
+
+// NewSlidingLogRedis creates a new SlidingLog instance with a redis.UniversalClient.
+func NewSlidingLogRedis(conn redis.UniversalClient, pipeline bool) *SlidingLog {
+	return &SlidingLog{
+		conn:     conn,
+		pipeline: pipeline,
+	}
+}
+
+// ExecPipeline will run a pipeline function in a pipeline or transaction.
+func (r *SlidingLog) ExecPipeline(ctx context.Context, pipeFn func(redis.Pipeliner) error) error {
+	if r.PipelineFn != nil {
+		return r.PipelineFn(ctx, pipeFn)
+	}
+
+	return r.execPipeline(ctx, pipeFn)
+}
+
+func (r *SlidingLog) execPipeline(ctx context.Context, pipeFn func(redis.Pipeliner) error) error {
+	if r.pipeline {
+		_, err := r.conn.Pipelined(ctx, pipeFn)
+		return err
+	}
+
+	_, err := r.conn.TxPipelined(ctx, pipeFn)
+	return err
+}
+
+// SetCount returns the number of items in the current sliding log window, before adding a new item.
+// The sliding log is trimmed removing older items, and a `per` seconds expiration is set on the complete log.
+func (r *SlidingLog) SetCount(ctx context.Context, now time.Time, keyName string, per int64) (int64, error) {
+	onePeriodAgo := now.Add(time.Duration(-1*per) * time.Second)
+
+	var res *redis.IntCmd
+
+	pipeFn := func(pipe redis.Pipeliner) error {
+		pipe.ZRemRangeByScore(ctx, keyName, "-inf", strconv.Itoa(int(onePeriodAgo.UnixNano())))
+		res = pipe.ZCard(ctx, keyName)
+
+		element := &redis.Z{
+			Score:  float64(now.UnixNano()),
+			Member: strconv.Itoa(int(now.UnixNano())),
+		}
+
+		pipe.ZAdd(ctx, keyName, element)
+		pipe.Expire(ctx, keyName, time.Duration(per)*time.Second)
+
+		return nil
+	}
+
+	if err := r.ExecPipeline(ctx, pipeFn); err != nil {
+		return 0, err
+	}
+
+	return res.Result()
+}
+
+// GetCount returns the number of items in the current sliding log window.
+// The sliding log is trimmed removing older items.
+func (r *SlidingLog) GetCount(ctx context.Context, now time.Time, keyName string, per int64) (int64, error) {
+	onePeriodAgo := now.Add(time.Duration(-1*per) * time.Second)
+
+	var res *redis.IntCmd
+
+	pipeFn := func(pipe redis.Pipeliner) error {
+		pipe.ZRemRangeByScore(ctx, keyName, "-inf", strconv.Itoa(int(onePeriodAgo.UnixNano())))
+		res = pipe.ZCard(ctx, keyName)
+
+		return nil
+	}
+
+	if err := r.ExecPipeline(ctx, pipeFn); err != nil {
+		return 0, err
+	}
+
+	return res.Result()
+}
+
+// Set returns the items in the current sliding log window, before adding a new item.
+// The sliding log is trimmed removing older items, and a `per` seconds expiration is set on the complete log.
+func (r *SlidingLog) Set(ctx context.Context, now time.Time, keyName string, per int64) ([]string, error) {
+	onePeriodAgo := now.Add(time.Duration(-1*per) * time.Second)
+
+	var res *redis.StringSliceCmd
+
+	pipeFn := func(pipe redis.Pipeliner) error {
+		pipe.ZRemRangeByScore(ctx, keyName, "-inf", strconv.Itoa(int(onePeriodAgo.UnixNano())))
+		res = pipe.ZRange(ctx, keyName, 0, -1)
+
+		element := &redis.Z{
+			Score:  float64(now.UnixNano()),
+			Member: strconv.Itoa(int(now.UnixNano())),
+		}
+
+		element.Member = strconv.Itoa(int(now.UnixNano()))
+
+		pipe.ZAdd(ctx, keyName, element)
+		pipe.Expire(ctx, keyName, time.Duration(per)*time.Second)
+
+		return nil
+	}
+
+	if err := r.ExecPipeline(ctx, pipeFn); err != nil {
+		return nil, err
+	}
+
+	return res.Result()
+}
+
+// Get returns the items in the current sliding log window.
+// The sliding log is trimmed removing older items.
+func (r *SlidingLog) Get(ctx context.Context, now time.Time, keyName string, per int64) ([]string, error) {
+	onePeriodAgo := now.Add(time.Duration(-1*per) * time.Second)
+
+	var res *redis.StringSliceCmd
+
+	pipeFn := func(pipe redis.Pipeliner) error {
+		pipe.ZRemRangeByScore(ctx, keyName, "-inf", strconv.Itoa(int(onePeriodAgo.UnixNano())))
+		res = pipe.ZRange(ctx, keyName, 0, -1)
+
+		return nil
+	}
+
+	if err := r.ExecPipeline(ctx, pipeFn); err != nil {
+		return nil, err
+	}
+
+	return res.Result()
+}

--- a/internal/rate/sliding_log_test.go
+++ b/internal/rate/sliding_log_test.go
@@ -1,0 +1,201 @@
+package rate_test
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/internal/rate"
+	"github.com/TykTechnologies/tyk/internal/uuid"
+	"github.com/TykTechnologies/tyk/storage"
+)
+
+// TestRollingWindow_GetCount is an integration test that tests counter behaviour.
+func TestRollingWindow_GetCount(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	conf, err := config.New()
+	assert.NoError(t, err)
+
+	conn := storage.NewRedisClusterPool(false, false, *conf)
+
+	for _, tx := range []bool{true, false} {
+		assertGetCount(ctx, t, conn, tx)
+	}
+}
+
+// TestRollingWindow_Get is an integration test that tests log behaviour.
+func TestRollingWindow_Get(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	conf, err := config.New()
+	assert.NoError(t, err)
+
+	conn := storage.NewRedisClusterPool(false, false, *conf)
+
+	for _, tx := range []bool{true, false} {
+		assertGet(ctx, t, conn, tx)
+	}
+}
+
+// TestRollingWindow_pipelinerError is testing that pipeline errors are returned as expected.
+func TestRollingWindow_pipelinerError(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	conf, err := config.New()
+	assert.NoError(t, err)
+
+	rc := storage.NewRedisController(ctx)
+	go rc.ConnectToRedis(ctx, nil, conf)
+
+	timeout, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+
+	connected := rc.WaitConnect(timeout)
+	if !connected {
+		panic("can't connect to redis '" + conf.Storage.Host + "', timeout")
+	}
+
+	rl, err := rate.NewSlidingLog(&storage.RedisCluster{KeyPrefix: "test-cluster", RedisController: rc}, false)
+	assert.NoError(t, err)
+
+	rl.PipelineFn = func(context.Context, func(redis.Pipeliner) error) error {
+		return io.EOF
+	}
+
+	_, err = rl.Get(ctx, time.Now(), "test", 5)
+	assert.Error(t, err, io.EOF)
+
+	_, err = rl.GetCount(ctx, time.Now(), "test", 5)
+	assert.Error(t, err, io.EOF)
+
+	_, err = rl.Set(ctx, time.Now(), "test", 5)
+	assert.Error(t, err, io.EOF)
+
+	_, err = rl.SetCount(ctx, time.Now(), "test", 5)
+	assert.Error(t, err, io.EOF)
+}
+
+const testRequestCount int = 1000
+
+func assertPipelinerError(ctx context.Context, tb testing.TB, conn redis.UniversalClient, tx bool) {
+	rl := rate.NewSlidingLogRedis(conn, tx)
+
+	key, per := uuid.New(), int64(5)
+
+	for i := 0; i < testRequestCount; i++ {
+		now := time.Now()
+		_, err := rl.SetCount(ctx, now, key, per)
+		assert.NoError(tb, err)
+	}
+
+	now := time.Now()
+	count, err := rl.GetCount(ctx, now, key, per)
+
+	assert.NoError(tb, err)
+	assert.Equal(tb, int64(testRequestCount), count)
+}
+
+func assertGetCount(ctx context.Context, tb testing.TB, conn redis.UniversalClient, tx bool) {
+	rl := rate.NewSlidingLogRedis(conn, tx)
+
+	key, per := uuid.New(), int64(5)
+
+	for i := 0; i < testRequestCount; i++ {
+		now := time.Now()
+		_, err := rl.SetCount(ctx, now, key, per)
+		assert.NoError(tb, err)
+	}
+
+	now := time.Now()
+	count, err := rl.GetCount(ctx, now, key, per)
+
+	assert.NoError(tb, err)
+	assert.Equal(tb, int64(testRequestCount), count)
+}
+
+func assertGet(ctx context.Context, tb testing.TB, conn redis.UniversalClient, tx bool) {
+	rl := rate.NewSlidingLogRedis(conn, tx)
+
+	key, per := uuid.New(), int64(5)
+
+	for i := 0; i < testRequestCount; i++ {
+		now := time.Now()
+		_, err := rl.Set(ctx, now, key, per)
+		assert.NoError(tb, err)
+	}
+
+	now := time.Now()
+	count, err := rl.Get(ctx, now, key, per)
+
+	assert.NoError(tb, err)
+	assert.Len(tb, count, testRequestCount)
+}
+
+func assertNew(ctx context.Context, tb testing.TB, conn redis.UniversalClient, tx bool) {
+	rl := rate.NewSlidingLogRedis(conn, tx)
+	assert.NotNil(tb, rl)
+}
+
+func BenchmarkRollingWindow_New(b *testing.B) {
+	ctx := context.Background()
+
+	conf, err := config.New()
+	assert.NoError(b, err)
+
+	conn := storage.NewRedisClusterPool(false, false, *conf)
+
+	b.ResetTimer()
+
+	b.Run("constructor", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			assertNew(ctx, b, conn, false)
+		}
+	})
+}
+
+func BenchmarkRollingWindow_Count(b *testing.B) {
+	ctx := context.Background()
+
+	conf, err := config.New()
+	assert.NoError(b, err)
+
+	conn := storage.NewRedisClusterPool(false, false, *conf)
+
+	b.ResetTimer()
+
+	b.Run("set/get count pipelined", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			assertGetCount(ctx, b, conn, false)
+		}
+	})
+
+	b.Run("set/get count transaction", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			assertGetCount(ctx, b, conn, true)
+		}
+	})
+
+	b.Run("set/get pipelined", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			assertGet(ctx, b, conn, false)
+		}
+	})
+
+	b.Run("set/get transaction", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			assertGet(ctx, b, conn, true)
+		}
+	})
+}

--- a/storage/redis_cluster.go
+++ b/storage/redis_cluster.go
@@ -121,6 +121,15 @@ func (r *RedisCluster) Connect() bool {
 	return true
 }
 
+// Client will return a redis v8 RedisClient. This function allows
+// implementation using the old storage clients.
+func (r *RedisCluster) Client() (redis.UniversalClient, error) {
+	if err := r.up(); err != nil {
+		return nil, err
+	}
+	return r.singleton()
+}
+
 func (r *RedisCluster) singleton() (redis.UniversalClient, error) {
 	if r.RedisController == nil {
 		return nil, fmt.Errorf("Error trying to get singleton instance: RedisController is nil")


### PR DESCRIPTION
[TT-10750] Extract and update sliding log functionality, update ratelimit (#5925)

Implements an internal/rate.SlidingLog object to replace the sliding
window functions inside the storage package. It extends the storage
functions with an optimized counting method that avoids retrieving the
sliding log from redis on a rate limiter decision. Rate limiter updated
to use the optimized count functions.

The optimization is down to replacing ZRANGE with ZCARD, resulting in
better memory use due to less data being requested from redis. It
decreases the memory pressure on gateway.

| Benchmark | Iterations | Time/Iteration | Memory/Iteration |
Allocations/Iteration |

|---------------------------|------------|------------------|-------------------|------------------------|
| get_count_pipelined | 294 | 40,607,040 ns/op | 1,617,069 B/op | 43,032
allocs/op |
| get_count_not_pipelined | 316 | 44,422,147 ns/op | 1,264,799 B/op |
33,025 allocs/op |
| get_pipelined | 76 | 155,023,361 ns/op| 22,227,962 B/op | 545,534
allocs/op |
| get_not_pipelined | 75 | 150,580,911 ns/op| 21,883,555 B/op | 535,527
allocs/op |

Let's focus on summarizing the differences between get_count_pipelined
and get_pipelined benchmarks:

- get_count_pipelined is approximately 51% faster than get_pipelined in
terms of execution time per iteration.
- get_count_pipelined consumes approximately 86% less memory per
iteration compared to get_pipelined.
- get_count_pipelined involves approximately 87% fewer allocations per
iteration compared to get_pipelined.

These observations highlight the significant performance advantages of
get_count_pipelined over get_pipelined in terms of execution time,
memory consumption, and allocations per iteration.

Ultimately the sliding log functions are expensive for Redis as well,
due to the time complexity of the operations, and the amount of log data
being stored in redis. Consider the following:

- having shorter limit windows mean less data gets stored (60 req/second
is better than 3600 req/minute)
- when going over the rate limit, requests still get logged to redis and
continue without reducing load on redis

Different rate limiter implementations will be necessary to optimize
scaling behaviour.

---------

Co-authored-by: Tit Petric <tit@tyk.io>