### PR TITLE
[TT-4866] Add oas.URLRewrite data model, Fill, ExtractTo, update apidef

### DIFF
--- a/.taskfiles/lint.yml
+++ b/.taskfiles/lint.yml
@@ -3,6 +3,8 @@ version: "3"
 
 vars:
   golangci: '--max-same-issues=0 --max-issues-per-linter=0'
+  root:
+    sh: git rev-parse --show-toplevel
   package:
     sh: go mod edit -json | jq .Module.Path -r
 

--- a/.taskfiles/lint.yml
+++ b/.taskfiles/lint.yml
@@ -3,8 +3,6 @@ version: "3"
 
 vars:
   golangci: '--max-same-issues=0 --max-issues-per-linter=0'
-  root:
-    sh: git rev-parse --show-toplevel
   package:
     sh: go mod edit -json | jq .Module.Path -r
 

--- a/apidef/api_definition_test.go
+++ b/apidef/api_definition_test.go
@@ -32,7 +32,7 @@ func TestStringRegexMap(t *testing.T) {
 	var v StringRegexMap
 	assert.True(t, v.Empty())
 
-	v = StringRegexMap{MatchPattern:".*"}
+	v = StringRegexMap{MatchPattern: ".*"}
 	assert.False(t, v.Empty())
 
 	v = StringRegexMap{Reverse: true}

--- a/apidef/api_definition_test.go
+++ b/apidef/api_definition_test.go
@@ -28,6 +28,28 @@ func TestSchema(t *testing.T) {
 	}
 }
 
+func TestStringRegexMap(t *testing.T) {
+	var v StringRegexMap
+	assert.True(t, v.Empty())
+
+	v = StringRegexMap{MatchPattern:".*"}
+	assert.False(t, v.Empty())
+
+	v = StringRegexMap{Reverse: true}
+	assert.False(t, v.Empty())
+}
+
+func TestRoutingTriggerOptions(t *testing.T) {
+	opts := NewRoutingTriggerOptions()
+
+	assert.NotNil(t, opts.HeaderMatches)
+	assert.NotNil(t, opts.QueryValMatches)
+	assert.NotNil(t, opts.PathPartMatches)
+	assert.NotNil(t, opts.SessionMetaMatches)
+	assert.NotNil(t, opts.RequestContextMatches)
+	assert.Empty(t, opts.PayloadMatches)
+}
+
 func TestEncodeForDB(t *testing.T) {
 	t.Run("EncodeForDB persist schema objects from extended path", func(t *testing.T) {
 		spec := DummyAPI()

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -233,6 +233,11 @@ type StringRegexMap struct {
 	matchRegex   *regexp.Regexp
 }
 
+// Empty is a utility function that returns true if the value is empty.
+func (r StringRegexMap) Empty() bool {
+	return r.MatchPattern == "" && !r.Reverse
+}
+
 type RoutingTriggerOptions struct {
 	HeaderMatches         map[string]StringRegexMap `bson:"header_matches" json:"header_matches"`
 	QueryValMatches       map[string]StringRegexMap `bson:"query_val_matches" json:"query_val_matches"`
@@ -242,6 +247,18 @@ type RoutingTriggerOptions struct {
 	PayloadMatches        StringRegexMap            `bson:"payload_matches" json:"payload_matches"`
 }
 
+// NewRoutingTriggerOptions allocates the maps inside RoutingTriggerOptions.
+func NewRoutingTriggerOptions() RoutingTriggerOptions {
+	return RoutingTriggerOptions{
+		HeaderMatches:         make(map[string]StringRegexMap),
+		QueryValMatches:       make(map[string]StringRegexMap),
+		PathPartMatches:       make(map[string]StringRegexMap),
+		SessionMetaMatches:    make(map[string]StringRegexMap),
+		RequestContextMatches: make(map[string]StringRegexMap),
+		PayloadMatches:        StringRegexMap{},
+	}
+}
+
 type RoutingTrigger struct {
 	On        RoutingTriggerOnType  `bson:"on" json:"on"`
 	Options   RoutingTriggerOptions `bson:"options" json:"options"`
@@ -249,6 +266,7 @@ type RoutingTrigger struct {
 }
 
 type URLRewriteMeta struct {
+	Disabled     bool             `bson:"disabled" json:"disabled"`
 	Path         string           `bson:"path" json:"path"`
 	Method       string           `bson:"method" json:"method"`
 	MatchPattern string           `bson:"match_pattern" json:"match_pattern"`

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -81,9 +81,8 @@ const (
 	UnsetAuth     AuthTypeEnum = ""
 
 	// For routing triggers
-	All    RoutingTriggerOnType = "all"
-	Any    RoutingTriggerOnType = "any"
-	Ignore RoutingTriggerOnType = ""
+	All RoutingTriggerOnType = "all"
+	Any RoutingTriggerOnType = "any"
 
 	// Subscription Types
 	GQLSubscriptionUndefined   SubscriptionType = ""

--- a/apidef/oas/default.go
+++ b/apidef/oas/default.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	invalidServerURLFmt          = "Please update %q to be a valid url or pass a valid url with upstreamURL query param"
+	invalidServerURLFmt          = "Please update %q to be a valid URL or pass a valid URL with upstreamURL query param"
 	unsupportedSecuritySchemeFmt = "unsupported security scheme: %s"
 
 	middlewareValidateRequest = "validateRequest"

--- a/apidef/oas/linter_test.go
+++ b/apidef/oas/linter_test.go
@@ -31,17 +31,22 @@ func TestXTykGateway_Lint(t *testing.T) {
 				op.TransformResponseBody.Format = "json"
 			}
 			if op.URLRewrite != nil {
-				for _, t := range op.URLRewrite.Triggers {
-					t.Condition = "any"
-					t.Rules = []*URLRewriteRule{}
+				triggers := []*URLRewriteTrigger{}
+				for _, cond := range URLRewriteConditions {
+					trigger := &URLRewriteTrigger{
+						Condition: cond,
+						Rules:     []*URLRewriteRule{},
+					}
 					for _, in := range URLRewriteInputs {
 						rule := &URLRewriteRule{
 							In:      in,
 							Pattern: ".*",
 						}
-						t.Rules = append(t.Rules, rule)
+						trigger.Rules = append(trigger.Rules, rule)
 					}
+					triggers = append(triggers, trigger)
 				}
+				op.URLRewrite.Triggers = triggers
 			}
 		}
 		settings.Server.Authentication.BaseIdentityProvider = ""

--- a/apidef/oas/linter_test.go
+++ b/apidef/oas/linter_test.go
@@ -30,6 +30,19 @@ func TestXTykGateway_Lint(t *testing.T) {
 			if op.TransformResponseBody != nil {
 				op.TransformResponseBody.Format = "json"
 			}
+			if op.URLRewrite != nil {
+				for _, t := range op.URLRewrite.Triggers {
+					t.Condition = "any"
+					t.Rules = []*URLRewriteRule{}
+					for _, in := range URLRewriteInputs {
+						rule := &URLRewriteRule{
+							In:      in,
+							Pattern: ".*",
+						}
+						t.Rules = append(t.Rules, rule)
+					}
+				}
+			}
 		}
 		settings.Server.Authentication.BaseIdentityProvider = ""
 		settings.Server.Authentication.Custom.Config.IDExtractor.Source = "body"

--- a/apidef/oas/oas_test.go
+++ b/apidef/oas/oas_test.go
@@ -203,6 +203,7 @@ func TestOAS_ExtractTo_ResetAPIDefinition(t *testing.T) {
 		"APIDefinition.VersionData.Versions[0].ExtendedPaths.CircuitBreaker[0].Samples",
 		"APIDefinition.VersionData.Versions[0].ExtendedPaths.CircuitBreaker[0].ReturnToServiceAfter",
 		"APIDefinition.VersionData.Versions[0].ExtendedPaths.CircuitBreaker[0].DisableHalfOpenState",
+		"APIDefinition.VersionData.Versions[0].ExtendedPaths.URLRewrite[0].Disabled",
 		"APIDefinition.VersionData.Versions[0].ExtendedPaths.URLRewrite[0].Path",
 		"APIDefinition.VersionData.Versions[0].ExtendedPaths.URLRewrite[0].Method",
 		"APIDefinition.VersionData.Versions[0].ExtendedPaths.URLRewrite[0].MatchPattern",

--- a/apidef/oas/operation.go
+++ b/apidef/oas/operation.go
@@ -42,6 +42,9 @@ type Operation struct {
 	// TransformResponseHeaders allows you to transform response headers.
 	TransformResponseHeaders *TransformHeaders `bson:"transformResponseHeaders,omitempty" json:"transformResponseHeaders,omitempty"`
 
+	// URLRewrite contains the url rewriting configuration.
+	URLRewrite *URLRewrite `bson:"urlRewrite,omitempty" json:"urlRewrite,omitempty"`
+
 	// Cache contains the caching plugin configuration.
 	Cache *CachePlugin `bson:"cache,omitempty" json:"cache,omitempty"`
 

--- a/apidef/oas/operation.go
+++ b/apidef/oas/operation.go
@@ -132,6 +132,7 @@ func (s *OAS) fillPathsAndOperations(ep apidef.ExtendedPathsSet) {
 	s.fillTransformResponseBody(ep.TransformResponse)
 	s.fillTransformRequestHeaders(ep.TransformHeader)
 	s.fillTransformResponseHeaders(ep.TransformResponseHeader)
+	s.fillURLRewrite(ep.URLRewrite)
 	s.fillCache(ep.AdvanceCacheConfig)
 	s.fillEnforceTimeout(ep.HardTimeouts)
 	s.fillOASValidateRequest(ep.ValidateJSON)
@@ -212,6 +213,22 @@ func newAllowance(prev **Allowance) *Allowance {
 	}
 
 	return *prev
+}
+
+func (s *OAS) fillURLRewrite(metas []apidef.URLRewriteMeta) {
+	for _, meta := range metas {
+		operationID := s.getOperationID(meta.Path, meta.Method)
+		operation := s.GetTykExtension().getOperation(operationID)
+
+		if operation.URLRewrite == nil {
+			operation.URLRewrite = &URLRewrite{}
+		}
+
+		operation.URLRewrite.Fill(meta)
+		if ShouldOmit(operation.URLRewrite) {
+			operation.URLRewrite = nil
+		}
+	}
 }
 
 func (s *OAS) fillTransformRequestMethod(metas []apidef.MethodTransformMeta) {

--- a/apidef/oas/operation.go
+++ b/apidef/oas/operation.go
@@ -42,7 +42,7 @@ type Operation struct {
 	// TransformResponseHeaders allows you to transform response headers.
 	TransformResponseHeaders *TransformHeaders `bson:"transformResponseHeaders,omitempty" json:"transformResponseHeaders,omitempty"`
 
-	// URLRewrite contains the url rewriting configuration.
+	// URLRewrite contains the URL rewriting configuration.
 	URLRewrite *URLRewrite `bson:"urlRewrite,omitempty" json:"urlRewrite,omitempty"`
 
 	// Cache contains the caching plugin configuration.
@@ -468,10 +468,10 @@ func isRegex(value string) bool {
 	return false
 }
 
-// splitPath splits url into folder parts, detecting regex patterns.
+// splitPath splits URL into folder parts, detecting regex patterns.
 func splitPath(inPath string) ([]pathPart, bool) {
-	// Each url fragment can contain a regex, but the whole
-	// url isn't just a regex (`/a/.*/foot` => `/a/{param1}/foot`)
+	// Each URL fragment can contain a regex, but the whole
+	// URL isn't just a regex (`/a/.*/foot` => `/a/{param1}/foot`)
 	parts := strings.Split(strings.Trim(inPath, "/"), "/")
 	result := make([]pathPart, len(parts))
 	found := 0
@@ -493,7 +493,7 @@ func splitPath(inPath string) ([]pathPart, bool) {
 	return result, found > 0
 }
 
-// buildPath converts the url paths with regex to named parameters
+// buildPath converts the URL paths with regex to named parameters
 // e.g. ["a", ".*"] becomes /a/{customRegex1}.
 func buildPath(parts []pathPart, appendSlash bool) string {
 	newPath := ""

--- a/apidef/oas/operation_test.go
+++ b/apidef/oas/operation_test.go
@@ -42,6 +42,7 @@ func TestOAS_PathsAndOperations(t *testing.T) {
 	Fill(t, &operation, 0)
 	operation.ValidateRequest = nil                   // This one also fills native part, let's skip it for this test.
 	operation.MockResponse = nil                      // This one also fills native part, let's skip it for this test.
+	operation.URLRewrite = nil                        // This one also fills native part, let's skip it for this test.
 	operation.TransformRequestBody.Path = ""          // if `path` and `body` are present, `body` would take precedence, detailed tests can be found in middleware_test.go
 	operation.TransformResponseBody.Path = ""         // if `path` and `body` are present, `body` would take precedence, detailed tests can be found in middleware_test.go
 	operation.VirtualEndpoint.Path = ""               // if `path` and `body` are present, `body` would take precedence, detailed tests can be found in middleware_test.go

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -820,7 +820,7 @@
       "additionalProperties": false,
       "properties": {
         "condition": {
-          "type": "string"
+          "enum": ["any", "all"]
         },
         "rewriteTo": {
           "type": "string"
@@ -844,7 +844,7 @@
       "additionalProperties": false,
       "properties": {
         "in": {
-          "type": "string"
+          "enum": ["query", "path", "header", "sessionMetadata", "requestContext", "requestBody"]
         },
         "name": {
           "type": "string"

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -789,6 +789,78 @@
         "name"
       ]
     },
+    "X-Tyk-URLRewrite": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "pattern": {
+          "type": "string"
+        },
+        "rewriteTo": {
+          "type": "string"
+        },
+        "triggers": {
+          "type": "array",
+          "items": [
+            {
+              "$ref": "#/definitions/X-Tyk-URLRewriteTrigger"
+            }
+          ]
+        }
+      },
+      "required": [
+        "enabled"
+      ]
+    },
+    "X-Tyk-URLRewriteTrigger": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "condition": {
+          "type": "string"
+        },
+        "rewriteTo": {
+          "type": "string"
+        },
+        "rules": {
+          "type": "array",
+          "items": [
+            {
+              "$ref": "#/definitions/X-Tyk-URLRewriteRule"
+            }
+          ]
+        }
+      },
+      "required": [
+        "condition",
+        "rewriteTo"
+      ]
+    },
+    "X-Tyk-URLRewriteRule": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "in": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "pattern": {
+          "type": "string"
+        },
+        "negate": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "in",
+        "pattern"
+      ]
+    },
     "X-Tyk-EndpointPostPlugin": {
       "type": "object",
       "additionalProperties": false,
@@ -839,6 +911,9 @@
         },
         "virtualEndpoint": {
           "$ref": "#/definitions/X-Tyk-VirtualEndpoint"
+        },
+        "urlRewrite": {
+          "$ref": "#/definitions/X-Tyk-URLRewrite"
         },
         "postPlugins": {
           "type": "array",

--- a/apidef/oas/schema/x-tyk-gateway.md
+++ b/apidef/oas/schema/x-tyk-gateway.md
@@ -914,7 +914,7 @@ TransformRequestHeaders allows you to transform request headers.
 TransformResponseHeaders allows you to transform response headers.
 
 **Field: `urlRewrite` ([URLRewrite](#urlrewrite))**
-URLRewrite contains the url rewriting configuration.
+URLRewrite contains the URL rewriting configuration.
 
 **Field: `cache` ([CachePlugin](#cacheplugin))**
 Cache contains the caching plugin configuration.
@@ -974,10 +974,11 @@ Body base64 encoded representation of the template.
 Enabled enables URL rewriting if set to true.
 
 **Field: `pattern` (`string`)**
-Pattern is the regular expression to match values against. If a value matches the defined pattern, the URL rewrite is triggered for the rule.
+Pattern is the regular expression against which the request URL is compared for the primary rewrite check.
+If this matches the defined pattern, the primary URL rewrite is triggered.
 
 **Field: `rewriteTo` (`string`)**
-RewriteTo specifies a URL to rewrite the request to, if the embedded URL rewrite rule is a match.
+RewriteTo specifies the URL to which the request shall be rewritten if the primary URL rewrite is triggered.
 
 **Field: `triggers` (`[]`[URLRewriteTrigger](#urlrewritetrigger))**
 Triggers contain advanced additional triggers for the URL rewrite.
@@ -987,17 +988,17 @@ The triggers are processed only if the requested URL matches the pattern above.
 ### **URLRewriteTrigger**
 
 **Field: `condition` ([](#))**
-Condition represents a boolean operator for rules.
+Condition indicates the logical combination that will be applied to the rules for an advanced trigger:
 
 - Value `any` means any of the defined trigger rules may match
 - Value `all` means all the defined trigger rules must match
 
 **Field: `rules` (`[]`[URLRewriteRule](#urlrewriterule))**
-Rules contain conditional triggers for URL rewriting.
-If empty, it enables non-conditional rewrites.
+Rules contain individual checks that are combined according to the `condition` to determine whether the URL rewrite will be triggered.
+If empty, the trigger is ignored.
 
 **Field: `rewriteTo` (`string`)**
-RewriteTo specifies a URL to rewrite the request to, if the conditions match.
+RewriteTo specifies the URL to which the request shall be rewritten if indicated by the combination of `condition` and `rules`.
 
 
 ### **URLRewriteRule**
@@ -1005,15 +1006,25 @@ RewriteTo specifies a URL to rewrite the request to, if the conditions match.
 **Field: `in` ([](#))**
 In specifies one of the valid inputs for URL rewriting.
 By default, it uses `url` as the input source.
+The following values are valid:
+
+- `url`, match pattern against URL
+- `query`, match pattern against named query parameter value
+- `path`, match pattern against named path parameter value
+- `header`, match pattern against named header value
+- `sessionMetadata`, match pattern against session metadata
+- `requestBody`, match pattern against request body
+- `requestContext`, match pattern against request context
 
 **Field: `name` (`string`)**
-Name is the index in the inputs. It is ignored for InputRequestBody as it contains only a single value, while the others are objects.
+Name is the index in the input identified in `in` that should be used to locate the value for this rule. `Name` is ignored for `InputRequestBody`rules as it contains only a single value, while the others are objects.
 
 **Field: `pattern` (`string`)**
-Pattern is the regular expression to match values against. If a value matches the defined pattern, the URL rewrite is triggered for the rule.
+Pattern is the regular expression against which the `in` values are compared for this rule check.
+If the value matches the defined `pattern`, the URL rewrite is triggered for this rule.
 
 **Field: `negate` (`boolean`)**
-Negate is a boolean negation operator. Setting it to true allows to negate the match if any, allowing for a "match all except <pattern>" style matching.
+Negate is a boolean negation operator. Setting it to true inverts the matching behaviour such that the rewrite will be triggered if the value does not match the `pattern` for this rule.
 
 
 ### **CachePlugin**

--- a/apidef/oas/schema/x-tyk-gateway.md
+++ b/apidef/oas/schema/x-tyk-gateway.md
@@ -913,6 +913,9 @@ TransformRequestHeaders allows you to transform request headers.
 **Field: `transformResponseHeaders` ([TransformHeaders](#transformheaders))**
 TransformResponseHeaders allows you to transform response headers.
 
+**Field: `urlRewrite` ([URLRewrite](#urlrewrite))**
+URLRewrite contains the url rewriting configuration.
+
 **Field: `cache` ([CachePlugin](#cacheplugin))**
 Cache contains the caching plugin configuration.
 
@@ -963,6 +966,53 @@ Path file path for the template.
 
 **Field: `body` (`string`)**
 Body base64 encoded representation of the template.
+
+
+### **URLRewrite**
+
+**Field: `enabled` (`boolean`)**
+Enabled enables URL rewriting if set to true.
+
+**Field: `pattern` (`string`)**
+Pattern is the regular expression to match values against. If a value matches the defined pattern, the URL rewrite is triggered for the rule.
+
+**Field: `rewriteTo` (`string`)**
+RewriteTo specifies a URL to rewrite the request to, if the embedded URL rewrite rule is a match.
+
+**Field: `triggers` (`[]`[URLRewriteTrigger](#urlrewritetrigger))**
+Triggers contain advanced additional triggers for the URL rewrite.
+The triggers are processed only if the requested URL matches the pattern above.
+
+
+### **URLRewriteTrigger**
+
+**Field: `condition` ([](#))**
+Condition represents a boolean operator for rules.
+If set to "and", all rules must match to trigger the rewrite.
+If set to "or", any of the rules can match to trigger the rewrite.
+
+**Field: `rules` (`[]`[URLRewriteRule](#urlrewriterule))**
+Rules contain conditional triggers for URL rewriting.
+If empty, it enables non-conditional rewrites.
+
+**Field: `rewriteTo` (`string`)**
+RewriteTo specifies a URL to rewrite the request to, if the conditions match.
+
+
+### **URLRewriteRule**
+
+**Field: `in` ([](#))**
+In specifies one of the valid inputs for URL rewriting.
+By default, it uses `url` as the input source.
+
+**Field: `name` (`string`)**
+Name is the index in the inputs. It is ignored for InputRequestBody as it contains only a single value, while the others are objects.
+
+**Field: `pattern` (`string`)**
+Pattern is the regular expression to match values against. If a value matches the defined pattern, the URL rewrite is triggered for the rule.
+
+**Field: `negate` (`boolean`)**
+Negate is a boolean negation operator. Setting it to true allows to negate the match if any, allowing for a "match all except <pattern>" style matching.
 
 
 ### **CachePlugin**

--- a/apidef/oas/schema/x-tyk-gateway.md
+++ b/apidef/oas/schema/x-tyk-gateway.md
@@ -988,8 +988,9 @@ The triggers are processed only if the requested URL matches the pattern above.
 
 **Field: `condition` ([](#))**
 Condition represents a boolean operator for rules.
-If set to "and", all rules must match to trigger the rewrite.
-If set to "or", any of the rules can match to trigger the rewrite.
+
+- Value `any` means any of the defined trigger rules may match
+- Value `all` means all the defined trigger rules must match
 
 **Field: `rules` (`[]`[URLRewriteRule](#urlrewriterule))**
 Rules contain conditional triggers for URL rewriting.

--- a/apidef/oas/security.go
+++ b/apidef/oas/security.go
@@ -413,8 +413,8 @@ type JWTValidation struct {
 	SigningMethod string `bson:"signingMethod" json:"signingMethod"`
 	// Source is the secret to verify signature, it could be one among:
 	// - a base64 encoded static secret,
-	// - a valid JWK url in plain text,
-	// - a valid JWK url in base64 encoded format.
+	// - a valid JWK URL in plain text,
+	// - a valid JWK URL in base64 encoded format.
 	Source string `bson:"source" json:"source"`
 	// IdentityBaseField is the identity claim name.
 	IdentityBaseField string `bson:"identityBaseField,omitempty" json:"identityBaseField,omitempty"`

--- a/apidef/oas/testdata/urlRewrite-native.json
+++ b/apidef/oas/testdata/urlRewrite-native.json
@@ -1,0 +1,74 @@
+{
+  "disabled": false,
+  "path": "",
+  "method": "",
+  "match_pattern": "example_pattern",
+  "rewrite_to": "http://example.com",
+  "triggers": [
+    {
+      "on": "any",
+      "options": {
+        "header_matches": {
+          "header_name": {
+            "match_rx": "header_pattern",
+            "reverse": true
+          }
+        },
+        "query_val_matches": {
+          "query_name": {
+            "match_rx": "query_pattern",
+            "reverse": true
+          }
+        },
+        "path_part_matches": {
+          "path_name": {
+            "match_rx": "path_pattern",
+            "reverse": false
+          }
+        },
+        "session_meta_matches": {
+          "session_metadata_name": {
+            "match_rx": "session_metadata_pattern",
+            "reverse": false
+          }
+        },
+        "request_context_matches": {
+          "request_context_name": {
+            "match_rx": "request_context_pattern",
+            "reverse": false
+          }
+        },
+        "payload_matches": {
+          "match_rx": "request_body_pattern",
+          "reverse": true
+        }
+      },
+      "rewrite_to": "http://example.com/rewritten-one"
+    },
+    {
+      "on": "all",
+      "options": {
+        "header_matches": {},
+        "query_val_matches": {
+          "query_name": {
+            "match_rx": "query_pattern",
+            "reverse": false
+          }
+        },
+        "path_part_matches": {
+          "path_name": {
+            "match_rx": "path_pattern",
+            "reverse": true
+          }
+        },
+        "session_meta_matches": {},
+        "request_context_matches": {},
+        "payload_matches": {
+          "match_rx": "",
+          "reverse": false
+        }
+      },
+      "rewrite_to": "http://example.com/rewritten-two"
+    }
+  ]
+}

--- a/apidef/oas/testdata/urlRewrite-oas.json
+++ b/apidef/oas/testdata/urlRewrite-oas.json
@@ -1,0 +1,66 @@
+{
+  "enabled": true,
+  "pattern": "example_pattern",
+  "rewriteTo": "http://example.com",
+  "triggers": [
+    {
+      "condition": "any",
+      "rules": [
+        {
+          "in": "query",
+          "pattern": "query_pattern",
+          "name": "query_name",
+          "negate": true
+        },
+        {
+          "in": "path",
+          "pattern": "path_pattern",
+          "name": "path_name",
+          "negate": false
+        },
+        {
+          "in": "header",
+          "pattern": "header_pattern",
+          "name": "header_name",
+          "negate": true
+        },
+        {
+          "in": "sessionMetadata",
+          "pattern": "session_metadata_pattern",
+          "name": "session_metadata_name",
+          "negate": false
+        },
+        {
+          "in": "requestBody",
+          "pattern": "request_body_pattern",
+          "negate": true
+        },
+        {
+          "in": "requestContext",
+          "pattern": "request_context_pattern",
+          "name": "request_context_name",
+          "negate": false
+        }
+      ],
+      "rewriteTo": "http://example.com/rewritten-one"
+    },
+    {
+      "condition": "all",
+      "rules": [
+        {
+          "in": "path",
+          "pattern": "path_pattern",
+          "name": "path_name",
+          "negate": true
+        },
+        {
+          "in": "query",
+          "pattern": "query_pattern",
+          "name": "query_name",
+          "negate": false
+        }
+      ],
+      "rewriteTo": "http://example.com/rewritten-two"
+    }
+  ]
+}

--- a/apidef/oas/url_rewrite.go
+++ b/apidef/oas/url_rewrite.go
@@ -171,7 +171,7 @@ func (v *URLRewrite) fillRules(from apidef.RoutingTriggerOptions) []*URLRewriteR
 	return result
 }
 
-func (v *URLRewrite) appendRules(rules *[]*URLRewriteRule, from map[string]apidef.StringRegexMap, in URLRewriteInput) {
+func (*URLRewrite) appendRules(rules *[]*URLRewriteRule, from map[string]apidef.StringRegexMap, in URLRewriteInput) {
 	for name, v := range from {
 		if v.Empty() {
 			continue
@@ -211,7 +211,7 @@ func (v *URLRewrite) extractTriggers() []apidef.RoutingTrigger {
 	return triggers
 }
 
-func (v *URLRewrite) extractTriggerOptions(rules []*URLRewriteRule) apidef.RoutingTriggerOptions {
+func (*URLRewrite) extractTriggerOptions(rules []*URLRewriteRule) apidef.RoutingTriggerOptions {
 	result := apidef.NewRoutingTriggerOptions()
 
 	for _, rule := range rules {

--- a/apidef/oas/url_rewrite.go
+++ b/apidef/oas/url_rewrite.go
@@ -1,0 +1,261 @@
+package oas
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/TykTechnologies/tyk/apidef"
+)
+
+// URLRewrite configures URL rewriting.
+type URLRewrite struct {
+	// Enabled enables URL rewriting if set to true.
+	Enabled bool `bson:"enabled" json:"enabled"`
+
+	// Pattern is the regular expression to match values against. If a value matches the
+	// defined pattern, the URL rewrite is triggered for the rule.
+	Pattern string `bson:"pattern,omitempty" json:"pattern,omitempty"`
+
+	// RewriteTo specifies a URL to rewrite the request to, if the
+	// embedded URL rewrite rule is a match.
+	RewriteTo string `bson:"rewriteTo,omitempty" json:"rewriteTo,omitempty"`
+
+	// Triggers contain advanced additional triggers for the URL rewrite.
+	// The triggers are processed only if the requested URL matches the pattern above.
+	Triggers []URLRewriteTrigger `bson:"triggers,omitempty" json:"triggers,omitempty"`
+}
+
+// URLRewriteInput defines the input for an URL rewrite rule.
+//
+// The following values are valid:
+//
+// - `url`, match pattern against URL
+// - `query`, match pattern against named query parameter value
+// - `path`, match pattern against named path parameter value
+// - `header`, match pattern against named header value
+// - `sessionMetadata`, match pattern against session metadata
+// - `requestBody`, match pattern against request body
+// - `requestContext`, match pattern against request context
+type URLRewriteInput string
+
+// URLRewriteConditions defines the matching mode for an URL rewrite rules.
+//
+// - Value `or` means any of the defined trigger rules may match
+// - Value `and` means all the defined trigger rules must match
+type URLRewriteCondition string
+
+const (
+	InputQuery           URLRewriteInput = "query"
+	InputPath            URLRewriteInput = "path"
+	InputHeader          URLRewriteInput = "header"
+	InputSessionMetadata URLRewriteInput = "sessionMetadata"
+	InputRequestBody     URLRewriteInput = "requestBody"
+	InputRequestContext  URLRewriteInput = "requestContext"
+
+	ConditionAll    URLRewriteCondition = "all"
+	ConditionAny    URLRewriteCondition = "any"
+	ConditionIgnore URLRewriteCondition = ""
+)
+
+var (
+	// URLRewriteInputs contains all valid URL rewrite input types.
+	URLRewriteInputs = []URLRewriteInput{
+		InputQuery,
+		InputPath,
+		InputHeader,
+		InputSessionMetadata,
+		InputRequestBody,
+		InputRequestContext,
+	}
+)
+
+// URLRewriteTrigger represents a set of matching rules for a rewrite.
+type URLRewriteTrigger struct {
+	// Condition represents a boolean operator for rules.
+	//
+	// If set to "and", all rules must match to trigger the rewrite.
+	// If set to "or", any of the rules can match to trigger the rewrite.
+	Condition URLRewriteCondition `bson:"condition" json:"condition"`
+
+	// Rules contain conditional triggers for URL rewriting.
+	// If empty, it enables non-conditional rewrites.
+	Rules []URLRewriteRule `bson:"rules,omitempty" json:"rules,omitempty"`
+
+	// RewriteTo specifies a URL to rewrite the request to, if the
+	// conditions match.
+	RewriteTo string `bson:"rewriteTo,omitempty" json:"rewriteTo,omitempty"`
+}
+
+// URLRewriteRule represents a rewrite matching rules.
+type URLRewriteRule struct {
+	// In specifies one of the valid inputs for URL rewriting.
+	// By default, it uses `url` as the input source.
+	In URLRewriteInput `bson:"in" json:"in"`
+
+	// Name is the index in the inputs. It is ignored for InputRequestBody
+	// as it contains only a single value, while the others are objects.
+	Name string `bson:"name,omitempty" json:"name,omitempty"`
+
+	// Pattern is the regular expression to match values against. If a value matches the
+	// defined pattern, the URL rewrite is triggered for the rule.
+	Pattern string `bson:"pattern,omitempty" json:"pattern,omitempty"`
+
+	// Negate is a boolean negation operator. Setting it to true allows to negate
+	// the match if any, allowing for a "match all except <pattern>" style matching.
+	Negate bool `bson:"negate,omitempty" json:"negate,omitempty"`
+}
+
+// Fill fills *URLRewrite receiver from apidef.URLRewriteMeta.
+func (v *URLRewrite) Fill(meta apidef.URLRewriteMeta) {
+	v.Enabled = !meta.Disabled
+	v.Pattern = meta.MatchPattern
+	v.RewriteTo = meta.RewriteTo
+
+	v.Triggers = v.fillTriggers(meta.Triggers)
+
+	if len(v.Triggers) == 0 {
+		v.Triggers = nil
+	}
+
+	v.Sort()
+}
+
+func (v *URLRewrite) fillTriggers(from []apidef.RoutingTrigger) []URLRewriteTrigger {
+	result := make([]URLRewriteTrigger, 0)
+	for _, t := range from {
+		rules := v.fillRules(t.Options)
+		if len(rules) == 0 {
+			continue
+		}
+
+		trigger := URLRewriteTrigger{
+			Condition: URLRewriteCondition(t.On),
+			Rules:     rules,
+			RewriteTo: t.RewriteTo,
+		}
+		result = append(result, trigger)
+	}
+	return result
+}
+
+// Sort reorders the internal trigger rules.
+func (v *URLRewrite) Sort() {
+	for _, t := range v.Triggers {
+		rules := t.Rules
+
+		sort.Slice(rules, func(i, j int) bool {
+			return rules[i].In.Index() < rules[j].In.Index()
+		})
+	}
+}
+
+func (v *URLRewrite) fillRules(from apidef.RoutingTriggerOptions) []URLRewriteRule {
+	result := []URLRewriteRule{}
+
+	v.appendRules(&result, from.HeaderMatches, InputHeader)
+	v.appendRules(&result, from.QueryValMatches, InputQuery)
+	v.appendRules(&result, from.PathPartMatches, InputPath)
+	v.appendRules(&result, from.SessionMetaMatches, InputSessionMetadata)
+	v.appendRules(&result, from.RequestContextMatches, InputRequestContext)
+
+	v.appendRules(&result, map[string]apidef.StringRegexMap{
+		"": from.PayloadMatches,
+	}, InputRequestBody)
+
+	return result
+}
+
+func (v *URLRewrite) appendRules(rules *[]URLRewriteRule, from map[string]apidef.StringRegexMap, in URLRewriteInput) {
+	for name, v := range from {
+		if v.Empty() {
+			continue
+		}
+
+		rule := URLRewriteRule{
+			In:      in,
+			Name:    name,
+			Pattern: v.MatchPattern,
+			Negate:  v.Reverse,
+		}
+		*rules = append(*rules, rule)
+	}
+}
+
+// ExtractTo fills *apidef.URLRewriteMeta from *URLRewrite.
+func (v *URLRewrite) ExtractTo(dest *apidef.URLRewriteMeta) {
+	dest.Disabled = !v.Enabled
+	dest.MatchPattern = v.Pattern
+	dest.RewriteTo = v.RewriteTo
+	dest.Triggers = v.extractTriggers()
+	if len(dest.Triggers) == 0 {
+		dest.Triggers = nil
+	}
+}
+
+func (v *URLRewrite) extractTriggers() []apidef.RoutingTrigger {
+	triggers := make([]apidef.RoutingTrigger, len(v.Triggers))
+	for i, trigger := range v.Triggers {
+		routingTrigger := apidef.RoutingTrigger{
+			On:        apidef.RoutingTriggerOnType(trigger.Condition),
+			RewriteTo: trigger.RewriteTo,
+			Options:   v.extractTriggerOptions(trigger.Rules),
+		}
+		triggers[i] = routingTrigger
+	}
+	return triggers
+}
+
+func (v *URLRewrite) extractTriggerOptions(rules []URLRewriteRule) apidef.RoutingTriggerOptions {
+	result := apidef.NewRoutingTriggerOptions()
+
+	for _, rule := range rules {
+		item := apidef.StringRegexMap{
+			MatchPattern: rule.Pattern,
+			Reverse:      rule.Negate,
+		}
+
+		switch rule.In {
+		case InputRequestBody:
+			result.PayloadMatches = item
+		case InputRequestContext:
+			result.RequestContextMatches[rule.Name] = item
+		case InputHeader:
+			result.HeaderMatches[rule.Name] = item
+		case InputPath:
+			result.PathPartMatches[rule.Name] = item
+		case InputQuery:
+			result.QueryValMatches[rule.Name] = item
+		case InputSessionMetadata:
+			result.SessionMetaMatches[rule.Name] = item
+		}
+	}
+
+	return result
+}
+
+// Valid returns true if the type value matches valid values, false otherwise.
+func (i URLRewriteInput) Valid() bool {
+	switch i {
+	case InputQuery, InputPath, InputHeader, InputSessionMetadata, InputRequestBody, InputRequestContext:
+		return true
+	}
+	return false
+}
+
+// Index returns the cardinal order for the value. Used for sorting.
+func (i URLRewriteInput) Index() int {
+	for k, v := range URLRewriteInputs {
+		if v == i {
+			return k
+		}
+	}
+	return -1
+}
+
+// Err returns an error if the type value is invalid, nil otherwise.
+func (i URLRewriteInput) Err() error {
+	if !i.Valid() {
+		return fmt.Errorf("Invalid value for URL rewrite input: %s", i)
+	}
+	return nil
+}

--- a/apidef/oas/url_rewrite.go
+++ b/apidef/oas/url_rewrite.go
@@ -22,7 +22,7 @@ type URLRewrite struct {
 
 	// Triggers contain advanced additional triggers for the URL rewrite.
 	// The triggers are processed only if the requested URL matches the pattern above.
-	Triggers []URLRewriteTrigger `bson:"triggers,omitempty" json:"triggers,omitempty"`
+	Triggers []*URLRewriteTrigger `bson:"triggers,omitempty" json:"triggers,omitempty"`
 }
 
 // URLRewriteInput defines the input for an URL rewrite rule.
@@ -79,7 +79,7 @@ type URLRewriteTrigger struct {
 
 	// Rules contain conditional triggers for URL rewriting.
 	// If empty, it enables non-conditional rewrites.
-	Rules []URLRewriteRule `bson:"rules,omitempty" json:"rules,omitempty"`
+	Rules []*URLRewriteRule `bson:"rules,omitempty" json:"rules,omitempty"`
 
 	// RewriteTo specifies a URL to rewrite the request to, if the
 	// conditions match.
@@ -120,15 +120,15 @@ func (v *URLRewrite) Fill(meta apidef.URLRewriteMeta) {
 	v.Sort()
 }
 
-func (v *URLRewrite) fillTriggers(from []apidef.RoutingTrigger) []URLRewriteTrigger {
-	result := make([]URLRewriteTrigger, 0)
+func (v *URLRewrite) fillTriggers(from []apidef.RoutingTrigger) []*URLRewriteTrigger {
+	result := make([]*URLRewriteTrigger, 0)
 	for _, t := range from {
 		rules := v.fillRules(t.Options)
 		if len(rules) == 0 {
 			continue
 		}
 
-		trigger := URLRewriteTrigger{
+		trigger := &URLRewriteTrigger{
 			Condition: URLRewriteCondition(t.On),
 			Rules:     rules,
 			RewriteTo: t.RewriteTo,
@@ -149,8 +149,8 @@ func (v *URLRewrite) Sort() {
 	}
 }
 
-func (v *URLRewrite) fillRules(from apidef.RoutingTriggerOptions) []URLRewriteRule {
-	result := []URLRewriteRule{}
+func (v *URLRewrite) fillRules(from apidef.RoutingTriggerOptions) []*URLRewriteRule {
+	result := []*URLRewriteRule{}
 
 	v.appendRules(&result, from.HeaderMatches, InputHeader)
 	v.appendRules(&result, from.QueryValMatches, InputQuery)
@@ -165,13 +165,13 @@ func (v *URLRewrite) fillRules(from apidef.RoutingTriggerOptions) []URLRewriteRu
 	return result
 }
 
-func (v *URLRewrite) appendRules(rules *[]URLRewriteRule, from map[string]apidef.StringRegexMap, in URLRewriteInput) {
+func (v *URLRewrite) appendRules(rules *[]*URLRewriteRule, from map[string]apidef.StringRegexMap, in URLRewriteInput) {
 	for name, v := range from {
 		if v.Empty() {
 			continue
 		}
 
-		rule := URLRewriteRule{
+		rule := &URLRewriteRule{
 			In:      in,
 			Name:    name,
 			Pattern: v.MatchPattern,
@@ -205,7 +205,7 @@ func (v *URLRewrite) extractTriggers() []apidef.RoutingTrigger {
 	return triggers
 }
 
-func (v *URLRewrite) extractTriggerOptions(rules []URLRewriteRule) apidef.RoutingTriggerOptions {
+func (v *URLRewrite) extractTriggerOptions(rules []*URLRewriteRule) apidef.RoutingTriggerOptions {
 	result := apidef.NewRoutingTriggerOptions()
 
 	for _, rule := range rules {

--- a/apidef/oas/url_rewrite.go
+++ b/apidef/oas/url_rewrite.go
@@ -52,13 +52,18 @@ const (
 	InputRequestBody     URLRewriteInput = "requestBody"
 	InputRequestContext  URLRewriteInput = "requestContext"
 
-	ConditionAll    URLRewriteCondition = "all"
-	ConditionAny    URLRewriteCondition = "any"
-	ConditionIgnore URLRewriteCondition = ""
+	ConditionAll URLRewriteCondition = "all"
+	ConditionAny URLRewriteCondition = "any"
 )
 
 var (
-	// URLRewriteInputs contains all valid URL rewrite input types.
+	// URLRewriteConditions contains all valid URL rewrite condition values.
+	URLRewriteConditions = []URLRewriteCondition{
+		ConditionAll,
+		ConditionAny,
+	}
+
+	// URLRewriteInputs contains all valid URL rewrite input values.
 	URLRewriteInputs = []URLRewriteInput{
 		InputQuery,
 		InputPath,

--- a/apidef/oas/url_rewrite.go
+++ b/apidef/oas/url_rewrite.go
@@ -83,7 +83,7 @@ type URLRewriteTrigger struct {
 
 	// RewriteTo specifies a URL to rewrite the request to, if the
 	// conditions match.
-	RewriteTo string `bson:"rewriteTo,omitempty" json:"rewriteTo,omitempty"`
+	RewriteTo string `bson:"rewriteTo" json:"rewriteTo"`
 }
 
 // URLRewriteRule represents a rewrite matching rules.
@@ -98,7 +98,7 @@ type URLRewriteRule struct {
 
 	// Pattern is the regular expression to match values against. If a value matches the
 	// defined pattern, the URL rewrite is triggered for the rule.
-	Pattern string `bson:"pattern,omitempty" json:"pattern,omitempty"`
+	Pattern string `bson:"pattern" json:"pattern"`
 
 	// Negate is a boolean negation operator. Setting it to true allows to negate
 	// the match if any, allowing for a "match all except <pattern>" style matching.

--- a/apidef/oas/url_rewrite.go
+++ b/apidef/oas/url_rewrite.go
@@ -8,6 +8,7 @@ import (
 )
 
 // URLRewrite configures URL rewriting.
+// Tyk classic API definition: `version_data.versions[].extended_paths.url_rewrite`.
 type URLRewrite struct {
 	// Enabled enables URL rewriting if set to true.
 	Enabled bool `bson:"enabled" json:"enabled"`
@@ -40,8 +41,8 @@ type URLRewriteInput string
 
 // URLRewriteConditions defines the matching mode for an URL rewrite rules.
 //
-// - Value `or` means any of the defined trigger rules may match
-// - Value `and` means all the defined trigger rules must match
+// - Value `any` means any of the defined trigger rules may match
+// - Value `all` means all the defined trigger rules must match
 type URLRewriteCondition string
 
 const (
@@ -78,8 +79,8 @@ var (
 type URLRewriteTrigger struct {
 	// Condition represents a boolean operator for rules.
 	//
-	// If set to "and", all rules must match to trigger the rewrite.
-	// If set to "or", any of the rules can match to trigger the rewrite.
+	// - Value `any` means any of the defined trigger rules may match
+	// - Value `all` means all the defined trigger rules must match
 	Condition URLRewriteCondition `bson:"condition" json:"condition"`
 
 	// Rules contain conditional triggers for URL rewriting.

--- a/apidef/oas/url_rewrite.go
+++ b/apidef/oas/url_rewrite.go
@@ -39,12 +39,13 @@ type URLRewrite struct {
 // - `requestContext`, match pattern against request context
 type URLRewriteInput string
 
-// URLRewriteConditions defines the matching mode for an URL rewrite rules.
+// URLRewriteCondition defines the matching mode for an URL rewrite rules.
 //
 // - Value `any` means any of the defined trigger rules may match
 // - Value `all` means all the defined trigger rules must match
 type URLRewriteCondition string
 
+// Enumerated constants for inputs and conditions.
 const (
 	InputQuery           URLRewriteInput = "query"
 	InputPath            URLRewriteInput = "path"

--- a/apidef/oas/url_rewrite_test.go
+++ b/apidef/oas/url_rewrite_test.go
@@ -3,7 +3,6 @@ package oas
 import (
 	"embed"
 	"encoding/json"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/apidef/oas/url_rewrite_test.go
+++ b/apidef/oas/url_rewrite_test.go
@@ -46,7 +46,7 @@ func TestURLRewrite_ExtractTo(t *testing.T) {
 	assert.Equal(t, native, extracted)
 }
 
-func decode(tb testing.TB, fs embed.FS, dest interface{}, filename string) {
+func decode(tb testing.TB, fs embed.FS, dest any, filename string) {
 	tb.Helper()
 
 	f, err := fs.ReadFile(filename)

--- a/apidef/oas/url_rewrite_test.go
+++ b/apidef/oas/url_rewrite_test.go
@@ -46,12 +46,12 @@ func TestURLRewrite_ExtractTo(t *testing.T) {
 	assert.Equal(t, native, extracted)
 }
 
-func decode(t testing.TB, fs embed.FS, dest interface{}, filename string) {
-	t.Helper()
+func decode(tb testing.TB, fs embed.FS, dest interface{}, filename string) {
+	tb.Helper()
 
 	f, err := fs.ReadFile(filename)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
 	err = json.Unmarshal(f, dest)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 }

--- a/apidef/oas/url_rewrite_test.go
+++ b/apidef/oas/url_rewrite_test.go
@@ -45,12 +45,6 @@ func TestURLRewrite_ExtractTo(t *testing.T) {
 	oasDef.ExtractTo(&extracted)
 
 	assert.Equal(t, native, extracted)
-
-	if false {
-		enc := json.NewEncoder(os.Stdout)
-		enc.SetIndent("", "  ")
-		enc.Encode(extracted)
-	}
 }
 
 func decode(t testing.TB, fs embed.FS, dest interface{}, filename string) {

--- a/apidef/oas/url_rewrite_test.go
+++ b/apidef/oas/url_rewrite_test.go
@@ -1,0 +1,64 @@
+package oas
+
+import (
+	"embed"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/apidef"
+)
+
+//go:embed testdata/urlRewrite-*.json
+var urlRewriteFS embed.FS
+
+func TestURLRewrite_Fill(t *testing.T) {
+	var (
+		native apidef.URLRewriteMeta
+		oasDef URLRewrite
+	)
+
+	decode(t, urlRewriteFS, &native, "testdata/urlRewrite-native.json")
+	decode(t, urlRewriteFS, &oasDef, "testdata/urlRewrite-oas.json")
+
+	filled := URLRewrite{}
+	filled.Fill(native)
+
+	oasDef.Sort()
+
+	assert.Equal(t, oasDef, filled)
+}
+
+func TestURLRewrite_ExtractTo(t *testing.T) {
+	var (
+		native apidef.URLRewriteMeta
+		oasDef URLRewrite
+	)
+
+	decode(t, urlRewriteFS, &native, "testdata/urlRewrite-native.json")
+	decode(t, urlRewriteFS, &oasDef, "testdata/urlRewrite-oas.json")
+
+	extracted := apidef.URLRewriteMeta{}
+	oasDef.ExtractTo(&extracted)
+
+	assert.Equal(t, native, extracted)
+
+	if false {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		enc.Encode(extracted)
+	}
+}
+
+func decode(t testing.TB, fs embed.FS, dest interface{}, filename string) {
+	t.Helper()
+
+	f, err := fs.ReadFile(filename)
+	require.NoError(t, err)
+
+	err = json.Unmarshal(f, dest)
+	require.NoError(t, err)
+}

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -1066,6 +1066,10 @@ func (a APIDefinitionLoader) compileURLRewritesPathSpec(paths []apidef.URLRewrit
 	urlSpec := []URLSpec{}
 
 	for _, stringSpec := range paths {
+		if stringSpec.Disabled {
+			continue
+		}
+
 		curStringSpec := stringSpec
 		newSpec := URLSpec{}
 		a.generateRegex(curStringSpec.Path, &newSpec, stat, conf)

--- a/gateway/mw_url_rewrite.go
+++ b/gateway/mw_url_rewrite.go
@@ -162,6 +162,7 @@ func (gw *Gateway) urlRewrite(meta *apidef.URLRewriteMeta, r *http.Request) (str
 				}
 				if total == setCount {
 					rewriteToPath = triggerOpts.RewriteTo
+					break
 				}
 			}
 		}

--- a/gateway/mw_url_rewrite.go
+++ b/gateway/mw_url_rewrite.go
@@ -390,6 +390,8 @@ func (m *URLRewriteMiddleware) Name() string {
 	return "URLRewriteMiddleware"
 }
 
+// InitTriggerRx will go over all defined URLRewrite triggers and initialize them. It
+// will skip disabled triggers, returning true if at least one trigger is enabled.
 func (m *URLRewriteMiddleware) InitTriggerRx() (enabled bool) {
 	// Generate regexp for each special match parameter
 	for verKey := range m.Spec.VersionData.Versions {


### PR DESCRIPTION
This PR adds the OAS definitions for URLRewrite middleware.

Observed issues:

- Enums are not supported by the current doc gen (oas.URLRewriteCondition, oas.URLRewriteInput)

Subtask: https://tyktech.atlassian.net/browse/TT-10960
