### PR TITLE
[TT-10966] Update/print rate limiter config info

### DIFF
--- a/config/rate_limit.go
+++ b/config/rate_limit.go
@@ -1,5 +1,9 @@
 package config
 
+import (
+	"fmt"
+)
+
 // RateLimit contains flags and configuration for controlling rate limiting behaviour.
 // It is embedded in the main config structure.
 type RateLimit struct {
@@ -35,4 +39,30 @@ type RateLimit struct {
 
 	// Controls which algorthm to use as a fallback when your distributed rate limiter can't be used.
 	DRLEnableSentinelRateLimiter bool `json:"drl_enable_sentinel_rate_limiter"`
+}
+
+// String returns a readable setting for the rate limiter in effect.
+func (r *RateLimit) String() string {
+	info := "using transactions"
+	if r.EnableNonTransactionalRateLimiter {
+		info = "using pipeline"
+	}
+
+	if r.EnableLeakyBucketRateLimiter {
+		return "Leaky Bucket Rate Limiter enabled"
+	}
+
+	if r.EnableRedisRollingLimiter {
+		return fmt.Sprintf("Redis Rate Limiter enabled (%s)", info)
+	}
+
+	if r.EnableSentinelRateLimiter {
+		return fmt.Sprintf("Redis Sentinel Rate Limiter enabled (%s)", info)
+	}
+
+	if r.DRLEnableSentinelRateLimiter {
+		return fmt.Sprintf("DRL with Redis Sentinel Rate Limiter enabled (%s)", info)
+	}
+
+	return fmt.Sprintf("DRL with Redis Rate Limiter enabled (%s)", info)
 }

--- a/gateway/session_manager.go
+++ b/gateway/session_manager.go
@@ -61,6 +61,8 @@ func NewSessionLimiter(ctx context.Context, conf *config.Config, drlManager *drl
 		bucketStore: memorycache.New(),
 	}
 
+	log.Infof("[RATELIMIT] %s", conf.RateLimit.String())
+
 	storageConf := conf.GetRateLimiterStorage()
 
 	switch storageConf.Type {


### PR DESCRIPTION
On gateway startup, print rate limiter configured. Covered with tests, verified:

```
root@carbon:~/tyk/tyk# ./tyk |& grep RATELIMIT
time="Jan 11 13:39:57" level=info msg="[RATELIMIT] DRL with Redis Rate Limiter enabled (using transactions)"
root@carbon:~/tyk/tyk# TYK_GW_ENABLELEAKYBUCKETRATELIMITER=true ./tyk |& grep RATELIMIT
time="Jan 11 13:40:12" level=info msg="[RATELIMIT] Leaky Bucket Rate Limiter enabled"
```

https://tyktech.atlassian.net/browse/TT-10966