### PR TITLE
[TT-10979] golangci-lint: add revive to enforce godoc, improve task lint

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,3 +13,8 @@
 /ci/images/plugin-compiler/             @TykTechnologies/core-api-squad
 .github/workflows/ci-tests.yml          @TykTechnologies/core-api-squad
 .github/workflows/release-tests.yml     @TykTechnologies/core-api-squad
+/.taskfiles/                            @TykTechnologies/core-api-squad
+/Dockerfile                             @TykTechnologies/core-api-squad
+/Makefile                               @TykTechnologies/core-api-squad
+/Taskfile.yml                           @TykTechnologies/core-api-squad
+/docker-compose.yml                     @TykTechnologies/core-api-squad

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -85,8 +85,17 @@ linters:
     - nilerr
     - misspell
     - goimports
+    - revive
 
 linters-settings:
+  revive:
+    ignore-generated-header: true
+    severity: error
+    enable-all-rules: false
+    rules:
+      - name: exported
+        disabled: false
+
   govet:
     check-shadowing: true
     enable-all: true
@@ -104,6 +113,7 @@ linters-settings:
       - (*github.com/TykTechnologies/tyk/gateway.Test).Run
 
 issues:
+  exclude-use-default: false
   exclude-rules:
     - path: _test\.go
       linters:

--- a/.taskfiles/lint.yml
+++ b/.taskfiles/lint.yml
@@ -2,6 +2,9 @@
 version: "3"
 
 vars:
+  golangci: '--max-same-issues=0 --max-issues-per-linter=0'
+  root:
+    sh: git rev-parse --show-toplevel
   package:
     sh: go mod edit -json | jq .Module.Path -r
 
@@ -10,6 +13,24 @@ tasks:
     desc: "Run linters"
     cmds:
       - task: vet
+      - task: golangci-lint
+        vars:
+          args: "{{.golangci}} --new-from-rev=origin/master"
+      - task: x-tyk-gateway
+
+  all:
+    desc: "Run linters (full source)"
+    cmds:
+      - task: vet
+      - task: golangci-lint
+        vars:
+          args: "{{.golangci}}"
+      - task: x-tyk-gateway
+
+  x-tyk-gateway:
+    desc: "Lint x-tyk-gateway schema"
+    cmds:
+      - go test -run=TestXTykGateway_Lint -v ./apidef/oas/
 
   vet:
     desc: "Run go vet"
@@ -18,8 +39,9 @@ tasks:
 
   golangci-lint:
     desc: "Run golangci-lint"
+    require: [args]
     cmds:
-      - golangci-lint run ./...
+      - golangci-lint run {{.args}} -v ./...
 
   goimports:
     desc: "Run goimports"

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ lint-fast: lint-install
 
 lint-install:
 	go install golang.org/x/tools/cmd/goimports@latest
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.0
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2
 	go install github.com/fatih/faillint@latest
 	go install go.uber.org/mock/mockgen@v0.4.0
 


### PR DESCRIPTION
Add configuration to enforce godoc:

- revive linter enabled, only exported analyzer enabled
- exclude-use-default disabled (this allows printing of godoc errors, by default are excluded)
- improved `task lint` - run on PR changes only, `task lint:all` - for complete repo

https://tyktech.atlassian.net/browse/TT-10979