### PR TITLE
[TT-10987] Return final rate limiter decision for leaky bucket

### DIFF
--- a/gateway/session_manager.go
+++ b/gateway/session_manager.go
@@ -255,6 +255,7 @@ func (l *SessionLimiter) ForwardMessage(r *http.Request, currentSession *user.Se
 			if errors.Is(err, rate.ErrLimitExhausted) {
 				return sessionFailRateLimit
 			}
+			return sessionFailNone
 		}
 
 		switch {


### PR DESCRIPTION
Fixes a missed return from the new rate limiters block.

https://tyktech.atlassian.net/browse/TT-10987