### PR TITLE
[TT-9590] Bump the redis import to v9, add internal/redis to manage the imports

### DIFF
--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	redis "github.com/go-redis/redis/v8"
+	redis "github.com/TykTechnologies/tyk/internal/redis"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/test"

--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -21,10 +21,11 @@ import (
 	"time"
 
 	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/go-redis/redis/v8"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/internal/redis"
 
 	"github.com/TykTechnologies/tyk/internal/uuid"
 

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -18,11 +18,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-redis/redis/v8"
 	"github.com/gorilla/websocket"
 	proxyproto "github.com/pires/go-proxyproto"
 	"github.com/stretchr/testify/assert"
 	msgpack "gopkg.in/vmihailenco/msgpack.v2"
+
+	"github.com/TykTechnologies/tyk/internal/redis"
 
 	"github.com/TykTechnologies/tyk-pump/analytics"
 	"github.com/TykTechnologies/tyk/apidef"

--- a/gateway/oauth_manager_test.go
+++ b/gateway/oauth_manager_test.go
@@ -16,10 +16,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-redis/redis/v8"
-	"github.com/go-redis/redismock/v8"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/internal/redis"
 
 	"github.com/TykTechnologies/tyk/config"
 
@@ -1403,7 +1403,7 @@ func TestPurgeOAuthClientTokens(t *testing.T) {
 			gw.SetConfig(config.Config{
 				OauthTokenExpiredRetainPeriod: 1,
 			})
-			db, mock := redismock.NewClientMock()
+			db, mock := redis.NewClientMock()
 			redisController := storage.NewRedisController(context.Background())
 			redisController.MockWith(db, true)
 			gw.RedisController = redisController
@@ -1417,7 +1417,7 @@ func TestPurgeOAuthClientTokens(t *testing.T) {
 			gw.SetConfig(config.Config{
 				OauthTokenExpiredRetainPeriod: 1,
 			})
-			db, mock := redismock.NewClientMock()
+			db, mock := redis.NewClientMock()
 			redisController := storage.NewRedisController(context.Background())
 			redisController.MockWith(db, true)
 			gw.RedisController = redisController
@@ -1431,7 +1431,7 @@ func TestPurgeOAuthClientTokens(t *testing.T) {
 			gw.SetConfig(config.Config{
 				OauthTokenExpiredRetainPeriod: 1,
 			})
-			db, mock := redismock.NewClientMock()
+			db, mock := redis.NewClientMock()
 			redisController := storage.NewRedisController(context.Background())
 			redisController.MockWith(db, true)
 			gw.RedisController = redisController
@@ -1475,7 +1475,6 @@ func BenchmarkPurgeLapsedOAuthTokens(b *testing.B) {
 		DialTimeout:  timeout,
 		ReadTimeout:  timeout,
 		WriteTimeout: timeout,
-		IdleTimeout:  240 * timeout,
 		PoolSize:     500,
 	}
 
@@ -1483,9 +1482,9 @@ func BenchmarkPurgeLapsedOAuthTokens(b *testing.B) {
 		ctx := context.Background()
 		now := time.Now()
 		nowTs := now.Unix()
-		var setMembers []*redis.Z
+		var setMembers []redis.Z
 		for k := 0; k < count; k++ {
-			setMembers = append(setMembers, &redis.Z{
+			setMembers = append(setMembers, redis.Z{
 				Score:  float64(nowTs - int64(k)),
 				Member: fmt.Sprintf("dummy-value-%d", k),
 			})
@@ -1493,7 +1492,7 @@ func BenchmarkPurgeLapsedOAuthTokens(b *testing.B) {
 
 		// add 10 more tokens to be not expired
 		for k := 0; k < count/10; k++ {
-			setMembers = append(setMembers, &redis.Z{
+			setMembers = append(setMembers, redis.Z{
 				Score:  float64(nowTs + int64((k)*1000)),
 				Member: fmt.Sprintf("dummy-value-%d", k),
 			})

--- a/gateway/redis_signals.go
+++ b/gateway/redis_signals.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-redis/redis/v8"
+	"github.com/TykTechnologies/tyk/internal/redis"
 
 	"github.com/TykTechnologies/goverify"
 	"github.com/TykTechnologies/tyk/internal/crypto"

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -10,7 +10,7 @@ import (
 	"github.com/TykTechnologies/tyk/internal/cache"
 	"github.com/TykTechnologies/tyk/rpc"
 
-	"github.com/go-redis/redis/v8"
+	"github.com/TykTechnologies/tyk/internal/redis"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/storage"

--- a/gateway/session_manager.go
+++ b/gateway/session_manager.go
@@ -7,14 +7,13 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/redis/go-redis/v9"
-
 	"github.com/TykTechnologies/drl"
 	"github.com/TykTechnologies/leakybucket"
 	"github.com/TykTechnologies/leakybucket/memorycache"
 
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/internal/rate"
+	"github.com/TykTechnologies/tyk/internal/redis"
 	"github.com/TykTechnologies/tyk/storage"
 	"github.com/TykTechnologies/tyk/user"
 )

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/gemnasium/logrus-graylog-hook v2.0.7+incompatible
 	github.com/getkin/kin-openapi v0.115.0
 	github.com/go-jose/go-jose/v3 v3.0.1
-	github.com/go-redis/redis/v8 v8.11.5
+	github.com/go-redis/redis/v8 v8.11.5 // indirect
 	github.com/gocraft/health v0.0.0-20170925182251-8675af27fef0
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang-jwt/jwt/v4 v4.5.0
@@ -88,7 +88,7 @@ require (
 	github.com/TykTechnologies/kin-openapi v0.90.0
 	github.com/TykTechnologies/opentelemetry v0.0.20
 	github.com/alecthomas/kingpin/v2 v2.4.0
-	github.com/go-redis/redismock/v8 v8.11.5
+	github.com/go-redis/redismock/v9 v9.2.0
 	github.com/google/go-cmp v0.6.0
 	github.com/newrelic/go-agent v2.13.0+incompatible
 	go.opentelemetry.io/otel v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -114,7 +114,6 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d h1:S2NE3iHSwP0XV47EEXL8mWmRdEfGscSJ+7EgePNgt0s=
 github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
@@ -211,8 +210,8 @@ github.com/go-redis/redis/v7 v7.4.0 h1:7obg6wUoj05T0EpY0o8B59S9w5yeMWql7sw2kwNW1
 github.com/go-redis/redis/v7 v7.4.0/go.mod h1:JDNMw23GTyLNC4GZu9njt15ctBQVn7xjRfnwdHj/Dcg=
 github.com/go-redis/redis/v8 v8.11.5 h1:AcZZR7igkdvfVmQTPnu9WE37LRrO/YrBH5zWyjDC0oI=
 github.com/go-redis/redis/v8 v8.11.5/go.mod h1:gREzHqY1hg6oD9ngVRbLStwAWKhA0FEgq8Jd4h5lpwo=
-github.com/go-redis/redismock/v8 v8.11.5 h1:RJFIiua58hrBrSpXhnGX3on79AU3S271H4ZhRI1wyVo=
-github.com/go-redis/redismock/v8 v8.11.5/go.mod h1:UaAU9dEe1C+eGr+FHV5prCWIt0hafyPWbGMEWE0UWdA=
+github.com/go-redis/redismock/v9 v9.2.0 h1:ZrMYQeKPECZPjOj5u9eyOjg8Nnb0BS9lkVIZ6IpsKLw=
+github.com/go-redis/redismock/v9 v9.2.0/go.mod h1:18KHfGDK4Y6c2R0H38EUGWAdc7ZQS9gfYxc94k7rWT0=
 github.com/go-redsync/redsync/v4 v4.11.0 h1:OPEcAxHBb95EzfwCKWM93ksOwHd5bTce2BD4+R14N6k=
 github.com/go-redsync/redsync/v4 v4.11.0/go.mod h1:ZfayzutkgeBmEmBlUR3j+rF6kN44UUGtEdfzhBFZTPc=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
@@ -492,14 +491,12 @@ github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
-github.com/onsi/ginkgo/v2 v2.0.0/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/ginkgo/v2 v2.1.4/go.mod h1:um6tUpWM/cxCK3/FK8BXqEiUMUwRgSM4JXG47RKZmLU=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
-github.com/onsi/gomega v1.18.1/go.mod h1:0q+aL8jAiMXy9hbwj2mr5GziHiwhAIQpFmmtT5hitRs=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/onsi/gomega v1.20.0/go.mod h1:DtrZpjmvpn2mPm4YWQa0/ALMDj9v4YxLgojwPeREyVo=
 github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=

--- a/internal/rate/limiter.go
+++ b/internal/rate/limiter.go
@@ -1,10 +1,9 @@
 package rate
 
 import (
-	"github.com/redis/go-redis/v9"
-
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/internal/rate/limiter"
+	"github.com/TykTechnologies/tyk/internal/redis"
 )
 
 func Limiter(gwConfig *config.Config, redis redis.UniversalClient) limiter.LimiterFunc {

--- a/internal/rate/limiter/limiter.go
+++ b/internal/rate/limiter/limiter.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"strings"
 
-	"github.com/go-redsync/redsync/v4/redis/goredis/v9"
-	"github.com/redis/go-redis/v9"
-
 	"github.com/TykTechnologies/exp/pkg/limiters"
+
+	"github.com/TykTechnologies/tyk/internal/redis"
 )
 
 var ErrLimitExhausted = limiters.ErrLimitExhausted
@@ -34,7 +33,7 @@ func NewLimiter(prefix string, redis redis.UniversalClient) *Limiter {
 }
 
 func (l *Limiter) redisLock(name string) limiters.DistLocker {
-	return limiters.NewLockRedis(goredis.NewPool(l.redis), name+"-lock")
+	return limiters.NewLockRedis(redis.NewPool(l.redis), name+"-lock")
 }
 
 func Prefix(params ...string) string {

--- a/internal/rate/sliding_log.go
+++ b/internal/rate/sliding_log.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/go-redis/redis/v8"
+	"github.com/TykTechnologies/tyk/internal/redis"
 )
 
 // SlidingLog implements sliding log storage in redis.
@@ -81,7 +81,7 @@ func (r *SlidingLog) SetCount(ctx context.Context, now time.Time, keyName string
 		pipe.ZRemRangeByScore(ctx, keyName, "-inf", strconv.Itoa(int(onePeriodAgo.UnixNano())))
 		res = pipe.ZCard(ctx, keyName)
 
-		element := &redis.Z{
+		element := redis.Z{
 			Score:  float64(now.UnixNano()),
 			Member: strconv.Itoa(int(now.UnixNano())),
 		}
@@ -131,12 +131,10 @@ func (r *SlidingLog) Set(ctx context.Context, now time.Time, keyName string, per
 		pipe.ZRemRangeByScore(ctx, keyName, "-inf", strconv.Itoa(int(onePeriodAgo.UnixNano())))
 		res = pipe.ZRange(ctx, keyName, 0, -1)
 
-		element := &redis.Z{
+		element := redis.Z{
 			Score:  float64(now.UnixNano()),
 			Member: strconv.Itoa(int(now.UnixNano())),
 		}
-
-		element.Member = strconv.Itoa(int(now.UnixNano()))
 
 		pipe.ZAdd(ctx, keyName, element)
 		pipe.Expire(ctx, keyName, time.Duration(per)*time.Second)

--- a/internal/rate/sliding_log_test.go
+++ b/internal/rate/sliding_log_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-redis/redis/v8"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk/internal/redis"
 
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/internal/rate"

--- a/internal/rate/storage.go
+++ b/internal/rate/storage.go
@@ -4,9 +4,8 @@ import (
 	"crypto/tls"
 	"time"
 
-	"github.com/redis/go-redis/v9"
-
 	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/internal/redis"
 )
 
 // NewStorage provides a redis v9 client for rate limiter use.

--- a/internal/redis/redis.go
+++ b/internal/redis/redis.go
@@ -1,0 +1,39 @@
+// The package redis serves as a refactoring aid. The complete gateway depends
+// on this package, and lists the symbols from the upstream dependency in use.
+package redis
+
+import (
+	"github.com/go-redis/redismock/v9"
+	"github.com/go-redsync/redsync/v4/redis/goredis/v9"
+	"github.com/redis/go-redis/v9"
+)
+
+var (
+	NewFailoverClient = redis.NewFailoverClient
+	NewClusterClient  = redis.NewClusterClient
+	NewClient         = redis.NewClient
+	NewClientMock     = redismock.NewClientMock
+	NewPool           = goredis.NewPool
+
+	Nil       = redis.Nil
+	ErrClosed = redis.ErrClosed
+)
+
+type (
+	UniversalClient  = redis.UniversalClient
+	UniversalOptions = redis.UniversalOptions
+	Pipeliner        = redis.Pipeliner
+
+	Client        = redis.Client
+	ClusterClient = redis.ClusterClient
+
+	Z            = redis.Z
+	ZRangeBy     = redis.ZRangeBy
+	ZRangeArgs   = redis.ZRangeArgs
+	Message      = redis.Message
+	Subscription = redis.Subscription
+
+	IntCmd         = redis.IntCmd
+	StringCmd      = redis.StringCmd
+	StringSliceCmd = redis.StringSliceCmd
+)

--- a/internal/redis/redis.go
+++ b/internal/redis/redis.go
@@ -1,5 +1,7 @@
 // The package redis serves as a refactoring aid. The complete gateway depends
 // on this package, and lists the symbols from the upstream dependency in use.
+//
+// nolint:revive
 package redis
 
 import (

--- a/storage/redis_cluster.go
+++ b/storage/redis_cluster.go
@@ -9,8 +9,9 @@ import (
 	"strings"
 	"time"
 
-	redis "github.com/go-redis/redis/v8"
 	"github.com/sirupsen/logrus"
+
+	redis "github.com/TykTechnologies/tyk/internal/redis"
 
 	"github.com/TykTechnologies/tyk/config"
 
@@ -77,7 +78,6 @@ func NewRedisClusterPool(isCache, isAnalytics bool, conf config.Config) redis.Un
 		DialTimeout:      timeout,
 		ReadTimeout:      timeout,
 		WriteTimeout:     timeout,
-		IdleTimeout:      240 * timeout,
 		PoolSize:         poolSize,
 		TLSConfig:        tlsConfig,
 	}
@@ -1076,7 +1076,7 @@ func (r *RedisCluster) SetRollingWindow(keyName string, per int64, value_overrid
 			element.Member = strconv.Itoa(int(now.UnixNano()))
 		}
 
-		pipe.ZAdd(r.RedisController.ctx, keyName, &element)
+		pipe.ZAdd(r.RedisController.ctx, keyName, element)
 		pipe.Expire(r.RedisController.ctx, keyName, time.Duration(per)*time.Second)
 
 		return nil
@@ -1189,7 +1189,7 @@ func (r *RedisCluster) AddToSortedSet(keyName, value string, score float64) {
 		return
 	}
 
-	if err := singleton.ZAdd(r.RedisController.ctx, fixedKey, &member).Err(); err != nil {
+	if err := singleton.ZAdd(r.RedisController.ctx, fixedKey, member).Err(); err != nil {
 		log.WithFields(logEntry).WithError(err).Error("ZADD command failed")
 	}
 }

--- a/storage/redis_cluster_test.go
+++ b/storage/redis_cluster_test.go
@@ -7,11 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-redis/redis/v8"
-	"github.com/go-redis/redismock/v8"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/internal/redis"
 )
 
 var rc *RedisController
@@ -249,7 +248,7 @@ func TestCheckIsOpen(t *testing.T) {
 
 func TestLock(t *testing.T) {
 	t.Run("redis down", func(t *testing.T) {
-		db, _ := redismock.NewClientMock()
+		db, _ := redis.NewClientMock()
 		redisCluster := &RedisCluster{
 			RedisController: &RedisController{
 				ctx:        context.Background(),
@@ -277,7 +276,7 @@ func TestLock(t *testing.T) {
 	})
 
 	t.Run("lock success", func(t *testing.T) {
-		db, mock := redismock.NewClientMock()
+		db, mock := redis.NewClientMock()
 		mock.ExpectSetNX("lock-key", "1", time.Second).SetVal(true)
 
 		redisCluster := &RedisCluster{
@@ -294,7 +293,7 @@ func TestLock(t *testing.T) {
 	})
 
 	t.Run("lock failure", func(t *testing.T) {
-		db, mock := redismock.NewClientMock()
+		db, mock := redis.NewClientMock()
 		mock.ExpectSetNX("lock-key", "1", time.Second).SetVal(false)
 
 		redisCluster := &RedisCluster{
@@ -311,7 +310,7 @@ func TestLock(t *testing.T) {
 	})
 
 	t.Run("lock error", func(t *testing.T) {
-		db, mock := redismock.NewClientMock()
+		db, mock := redis.NewClientMock()
 		mock.ExpectSetNX("lock-key", "1", time.Second).SetErr(errors.ErrUnsupported)
 
 		redisCluster := &RedisCluster{

--- a/storage/redis_controller.go
+++ b/storage/redis_controller.go
@@ -6,7 +6,8 @@ import (
 	"time"
 
 	"github.com/cenk/backoff"
-	redis "github.com/go-redis/redis/v8"
+
+	redis "github.com/TykTechnologies/tyk/internal/redis"
 
 	"github.com/TykTechnologies/tyk/config"
 )


### PR DESCRIPTION
This PR bumps the redis/v8 dependency and related packages to v9.

It creates `internal/redis` package to manage the import and list the symbols used in that package.

https://tyktech.atlassian.net/browse/TT-9590