### PR TITLE
Fix URLRewrite, enable unused-param linter in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -93,6 +93,10 @@ linters-settings:
     severity: error
     enable-all-rules: false
     rules:
+      - name: unused-parameter
+        disabled: false
+        arguments:
+          - allowRegex: "^_"
       - name: exported
         disabled: false
 

--- a/apidef/oas/url_rewrite.go
+++ b/apidef/oas/url_rewrite.go
@@ -301,4 +301,5 @@ func (o *Operation) extractURLRewriteTo(ep *apidef.ExtendedPathsSet, path string
 
 	meta := apidef.URLRewriteMeta{Path: path, Method: method}
 	o.URLRewrite.ExtractTo(&meta)
+	ep.URLRewrite = append(ep.URLRewrite, meta)
 }


### PR DESCRIPTION
This fixes a migration issue with URLResponse due to the unused parameter.

- enables golangci-lint rule to detect unused parameters,
- extends test cases to load OAS api definition with urlRewrite