### PR TITLE
[TT-11119] "Error socket hang up" for GQL proxy with OTel.

### DIFF
--- a/gateway/mw_graphql.go
+++ b/gateway/mw_graphql.go
@@ -246,7 +246,7 @@ func (m *GraphQLMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 	}
 
 	defer ctxSetGraphQLRequest(r, &gqlRequest)
-	if conf := m.Gw.GetConfig(); conf.OpenTelemetry.Enabled && m.Spec.DetailedTracing {
+	if conf := m.Gw.GetConfig(); conf.OpenTelemetry.Enabled && m.Spec.DetailedTracing && m.Spec.GraphQL.Version == apidef.GraphQLConfigVersion2 {
 		ctx, span := m.Gw.TracerProvider.Tracer().Start(r.Context(), "GraphqlMiddleware Validation")
 		defer span.End()
 		*r = *r.WithContext(ctx)


### PR DESCRIPTION
PR for [TT-11119](https://tyktech.atlassian.net/browse/TT-11119). 

If OTel and detailed tracing are enabled but the GQL version is not 2 GW fails to serve the request and panics.
