### PR TITLE
Merging to release-5-lts: [TT-11119] "Error socket hang up" for GQL proxy with OTel. (#5978)

### DIFF
--- a/gateway/mw_graphql.go
+++ b/gateway/mw_graphql.go
@@ -233,6 +233,18 @@ func (m *GraphQLMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 	}
 
 	defer ctxSetGraphQLRequest(r, &gqlRequest)
+<<<<<<< HEAD
+=======
+	if conf := m.Gw.GetConfig(); conf.OpenTelemetry.Enabled && m.Spec.DetailedTracing && m.Spec.GraphQL.Version == apidef.GraphQLConfigVersion2 {
+		ctx, span := m.Gw.TracerProvider.Tracer().Start(r.Context(), "GraphqlMiddleware Validation")
+		defer span.End()
+		*r = *r.WithContext(ctx)
+		return m.validateRequestWithOtel(r.Context(), w, &gqlRequest)
+	} else {
+		return m.validateRequest(w, &gqlRequest)
+	}
+}
+>>>>>>> 86b69f8de... [TT-11119] "Error socket hang up" for GQL proxy with OTel. (#5978)
 
 	normalizationResult, err := gqlRequest.Normalize(m.Spec.GraphQLExecutor.Schema)
 	if err != nil {

--- a/gateway/mw_graphql_test.go
+++ b/gateway/mw_graphql_test.go
@@ -210,6 +210,96 @@ func TestGraphQLMiddleware_RequestValidation(t *testing.T) {
 			})
 		assert.NoError(t, err)
 	})
+<<<<<<< HEAD
+=======
+
+	t.Run("fail input validation with otel tracing active", func(t *testing.T) {
+		local := StartTest(func(globalConf *config.Config) {
+			globalConf.OpenTelemetry.Enabled = true
+		})
+		defer local.Close()
+		testSpec := BuildAPI(func(spec *APISpec) {
+			spec.GraphQL.ExecutionMode = apidef.GraphQLExecutionModeProxyOnly
+			spec.GraphQL.Schema = gqlCountriesSchema
+			spec.GraphQL.Version = apidef.GraphQLConfigVersion2
+			spec.Proxy.TargetURL = testGraphQLProxyUpstream
+			spec.Proxy.ListenPath = "/"
+			spec.GraphQL.Enabled = true
+		})[0]
+
+		local.Gw.LoadAPI(testSpec)
+
+		_, err := local.Run(
+			t,
+			test.TestCase{
+				Path:   "/",
+				Method: http.MethodPost,
+				Data: gql.Request{
+					Query:     gqlContinentQueryVariable,
+					Variables: []byte(`{"code":null}`),
+				},
+				Code: 400,
+			},
+			test.TestCase{
+				Path:   "/",
+				Method: http.MethodPost,
+				Data: gql.Request{
+					Query:     gqlStateQueryVariable,
+					Variables: []byte(`{"filter":{"code":{"eq":"filterString"}}}`),
+				},
+				Code: 400,
+				BodyMatchFunc: func(i []byte) bool {
+					return strings.Contains(string(i), `Validation for variable \"filter\" failed`)
+				},
+			})
+		assert.NoError(t, err)
+	})
+
+	t.Run("fail input validation if GQL engine is not v2, but OTel and detailed tracing is enabled", func(t *testing.T) {
+		// See TT-11119, if OTel and detailed tracing is enabled but the GQL version is not 2 GW fails to serve the request
+		// and panics.
+		local := StartTest(func(globalConf *config.Config) {
+			globalConf.OpenTelemetry.Enabled = true
+		})
+		defer local.Close()
+		testSpec := BuildAPI(func(spec *APISpec) {
+			spec.GraphQL.ExecutionMode = apidef.GraphQLExecutionModeProxyOnly
+			spec.GraphQL.Schema = gqlCountriesSchema
+			spec.DetailedTracing = true
+			spec.GraphQL.Version = apidef.GraphQLConfigVersionNone
+			spec.Proxy.TargetURL = testGraphQLProxyUpstream
+			spec.Proxy.ListenPath = "/"
+			spec.GraphQL.Enabled = true
+		})[0]
+
+		local.Gw.LoadAPI(testSpec)
+
+		_, err := local.Run(
+			t,
+			test.TestCase{
+				Path:   "/",
+				Method: http.MethodPost,
+				Data: gql.Request{
+					Query:     gqlContinentQueryVariable,
+					Variables: []byte(`{"code":null}`),
+				},
+				Code: 400,
+			},
+			test.TestCase{
+				Path:   "/",
+				Method: http.MethodPost,
+				Data: gql.Request{
+					Query:     gqlStateQueryVariable,
+					Variables: []byte(`{"filter":{"code":{"eq":"filterString"}}}`),
+				},
+				Code: 400,
+				BodyMatchFunc: func(i []byte) bool {
+					return strings.Contains(string(i), `Validation for variable \"filter\" failed`)
+				},
+			})
+		assert.NoError(t, err)
+	})
+>>>>>>> 86b69f8de... [TT-11119] "Error socket hang up" for GQL proxy with OTel. (#5978)
 }
 
 func TestGraphQLMiddleware_EngineMode(t *testing.T) {


### PR DESCRIPTION
[TT-11119] "Error socket hang up" for GQL proxy with OTel. (#5978)

## **User description**
PR for [TT-11119](https://tyktech.atlassian.net/browse/TT-11119). 

If OTel and detailed tracing are enabled but the GQL version is not 2 GW
fails to serve the request and panics.


[TT-11119]:
https://tyktech.atlassian.net/browse/TT-11119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

## **Type**
Bug fix


___

## **Description**
- This PR fixes an issue where the gateway would fail to serve the
request and panic if OpenTelemetry and DetailedTracing were enabled but
the GraphQL version was not 2.
- A condition has been added in the `ProcessRequest` function in
`mw_graphql.go` to check if the GraphQL version is 2 when OpenTelemetry
and DetailedTracing are enabled.
- A test case has been added in `mw_graphql_test.go` to validate this
fix.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>mw_graphql.go</strong><dd><code>Fix for OpenTelemetry
and DetailedTracing with non-version 2 GraphQL</code></dd></summary>
<hr>

gateway/mw_graphql.go
- Added a condition to check if the GraphQL version is 2 when <br>
OpenTelemetry and DetailedTracing are enabled.
    </details>
  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/5978/files#diff-c46e0f07348c8f519e5912f4394f048f43c1e3fb5063c27245272c8f645b4cab">+1/-1</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>mw_graphql_test.go</strong><dd><code>Test case for
OpenTelemetry and DetailedTracing with non-version 2

 GraphQL</code></dd></summary>
<hr>

gateway/mw_graphql_test.go
- Added a test case to validate the fix for the issue when OpenTelemetry
<br> and DetailedTracing are enabled but the GraphQL version is not 2.
    </details>
  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/5978/files#diff-72c11b8efcaceccfbbd87e75565353706443bf56420d3fdba6b5bf5f632f4b33">+45/-0</a>&nbsp;
&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a
description for the PR - title, type, summary, walkthrough and labels.
The tool can be triggered
[automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools)
every time a new PR is opened, or can be invoked manually by commenting
on a PR.

When commenting, to edit
[configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46)
related to the describe tool (`pr_description` section), use the
following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration
file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app),
use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation
</strong></summary><hr>

- When you first install the app, the [default
mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools)
for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will
keep the original title, and will add the original user description
above the generated description.

- Markers are an alternative way to control the generated description,
to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in
the PR description with the relevant content, where `marker_name` is one
of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does
not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels
</strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`,
`Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom
labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem)
in the repo's labels page or via configuration file, you can get
tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is
performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the
Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different
possibilities. Define custom labels that are relevant for your repo and
use cases.
Note that Labels are not mutually exclusive, so you can add multiple
label categories.
Make sure to provide proper title, and a detailed and well-phrased
description for each label, so the tool will know when to suggest it.


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough
💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries
directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file,
while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary`
in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top
of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes
summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the
"Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra
instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide
the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra
instructions, you are the prompter. Notice that the general structure of
the description is fixed, and cannot be changed. Extra instructions can
change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to
make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent
commands</strong></summary><hr>

> To invoke the PR-Agent, add a comment using one of the following
commands:
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the
contents of the PR.
> - **/improve [--extended]**: Suggest code improvements. Extended mode
provides a higher quality feedback.
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's
contents.
> - **/add_docs** 💎: Generate docstring for new components introduced in
the PR.
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's
contents.
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes
walkthrough for each component.

>See the [tools
guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md)
for more details.
>To list the possible configuration parameters, add a **/config**
comment.
 


</details></td></tr>

</table>

See the [describe
usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md)
page for a comprehensive guide on using this tool.


</details>