### PR TITLE
Merging to release-5-lts: [TT-10438] add date, date-time validation hooks for validate request on kin-openapi3 (#5980)

### DIFF
--- a/gateway/mw_oas_validate_request.go
+++ b/gateway/mw_oas_validate_request.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/getkin/kin-openapi/openapi3"
 
@@ -12,6 +13,15 @@ import (
 
 func init() {
 	openapi3.SchemaErrorDetailsDisabled = true
+	openapi3.DefineStringFormatCallback("date-time", func(value string) error {
+		_, err := time.Parse(time.RFC3339, value)
+		return err
+	})
+
+	openapi3.DefineStringFormatCallback("date", func(value string) error {
+		_, err := time.Parse(time.DateOnly, value)
+		return err
+	})
 }
 
 type ValidateRequest struct {

--- a/gateway/mw_oas_validate_request.go
+++ b/gateway/mw_oas_validate_request.go
@@ -11,6 +11,8 @@ import (
 	"github.com/getkin/kin-openapi/openapi3filter"
 )
 
+const dateOnlyTimeLayout = "2006-01-02"
+
 func init() {
 	openapi3.SchemaErrorDetailsDisabled = true
 	openapi3.DefineStringFormatCallback("date-time", func(value string) error {
@@ -19,7 +21,7 @@ func init() {
 	})
 
 	openapi3.DefineStringFormatCallback("date", func(value string) error {
-		_, err := time.Parse(time.DateOnly, value)
+		_, err := time.Parse(dateOnlyTimeLayout, value)
 		return err
 	})
 }

--- a/gateway/mw_oas_validate_request_test.go
+++ b/gateway/mw_oas_validate_request_test.go
@@ -41,6 +41,14 @@ const testOASForValidateRequest = `{
           },
           "owner": {
             "$ref": "#/components/schemas/Owner"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "expiryOn": {
+            "type": "string",
+            "format": "date"
           }
         }
       }
@@ -177,6 +185,20 @@ func TestValidateRequest(t *testing.T) {
 			apis[2].Proxy.StripListenPath = true
 			ts.Gw.LoadAPI(apis...)
 			check(t)
+		})
+
+		t.Run("validate date/date-time format", func(t *testing.T) {
+			apiPath := "/product/post"
+			_, _ = ts.Run(t, []test.TestCase{
+				{Data: `{"name": "123", "createdAt": "2016-02-30T14:30:15Z"}`, Code: http.StatusUnprocessableEntity,
+					Method: http.MethodPost, Headers: headers, Path: apiPath},
+				{Data: `{"name": "123", "createdAt": "2016-02-28T30:30:15Z"}`, Code: http.StatusUnprocessableEntity,
+					Method: http.MethodPost, Headers: headers, Path: apiPath},
+				{Data: `{"name": "123", "createdAt": "2016-02-28T12:30:15Z"}`, Code: http.StatusOK,
+					Method: http.MethodPost, Headers: headers, Path: apiPath},
+				{Data: `{"name": "123", "expiryOn": "2016-02-28"}`, Code: http.StatusOK,
+					Method: http.MethodPost, Headers: headers, Path: apiPath},
+			}...)
 		})
 	})
 


### PR DESCRIPTION
[TT-10438] add date, date-time validation hooks for validate request on kin-openapi3 (#5980)

## **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description
Currently, `date` and `date-time` string formats validates date string
using

https://github.com/getkin/kin-openapi/blob/529285c16a9d45f7f908c1d61e67abcc070d192f/openapi3/schema_formats.go#L91-L94,
this doesn't handle edge cases where date/time is out of range.
eg:
```
2016-02-30T14:30:15Z : 30th Feb
2016-03-30T99:99:99Z : 99 hour 99 min 99 sec
```
This PR adds a custom hook which validates `date`, `date-time` using
stdlib `time.Parse`

## Related Issue
https://tyktech.atlassian.net/browse/TT-10438
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

## **Type**
Bug fix


___

## **Description**
- This PR introduces a fix to the date and date-time string format
validation in the OpenAPI3 middleware. Previously, the validation didn't
handle edge cases where date/time is out of range.
- Custom hooks have been added to validate `date` and `date-time` using
the standard library `time.Parse` function. This ensures that the date
and time values are within the valid range.
- Corresponding tests have been added to ensure the correct functioning
of the new validation.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>mw_oas_validate_request.go</strong><dd><code>Added Date
and DateTime Validation Hooks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

gateway/mw_oas_validate_request.go
- Added custom hooks to validate `date` and `date-time` string formats
<br> using the standard library `time.Parse` function.
    </details>
  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/5980/files#diff-f5de96d1354ffab65e076f23a58337a7799a212f6e70dea59b56576042ecd69a">+10/-0</a>&nbsp;
&nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>

<summary><strong>mw_oas_validate_request_test.go</strong><dd><code>Added
Tests for Date and DateTime Validation</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_oas_validate_request_test.go
- Added test cases to validate the newly added date and date-time format
<br> validation.
    </details>
  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/5980/files#diff-604233bec52920ea748b8d634974f76e63a2b2cb2c8c558cc896217be8b2886b">+22/-0</a>&nbsp;
&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a
description for the PR - title, type, summary, walkthrough and labels.
The tool can be triggered
[automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools)
every time a new PR is opened, or can be invoked manually by commenting
on a PR.

When commenting, to edit
[configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46)
related to the describe tool (`pr_description` section), use the
following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration
file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app),
use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation
</strong></summary><hr>

- When you first install the app, the [default
mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools)
for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will
keep the original title, and will add the original user description
above the generated description.

- Markers are an alternative way to control the generated description,
to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in
the PR description with the relevant content, where `marker_name` is one
of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does
not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels
</strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`,
`Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom
labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem)
in the repo's labels page or via configuration file, you can get
tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is
performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the
Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different
possibilities. Define custom labels that are relevant for your repo and
use cases.
Note that Labels are not mutually exclusive, so you can add multiple
label categories.
Make sure to provide proper title, and a detailed and well-phrased
description for each label, so the tool will know when to suggest it.


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough
💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries
directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file,
while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary`
in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top
of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes
summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the
"Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra
instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide
the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra
instructions, you are the prompter. Notice that the general structure of
the description is fixed, and cannot be changed. Extra instructions can
change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to
make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent
commands</strong></summary><hr>

> To invoke the PR-Agent, add a comment using one of the following
commands:
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the
contents of the PR.
> - **/improve [--extended]**: Suggest code improvements. Extended mode
provides a higher quality feedback.
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's
contents.
> - **/add_docs** 💎: Generate docstring for new components introduced in
the PR.
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's
contents.
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes
walkthrough for each component.

>See the [tools
guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md)
for more details.
>To list the possible configuration parameters, add a **/config**
comment.
 


</details></td></tr>

</table>

See the [describe
usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md)
page for a comprehensive guide on using this tool.


</details>

[TT-10438]: https://tyktech.atlassian.net/browse/TT-10438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ