### PR TITLE
TT-10895, replaced url parameters from upstream url with default values

### DIFF
--- a/apidef/oas/default.go
+++ b/apidef/oas/default.go
@@ -98,6 +98,13 @@ func (s *OAS) BuildDefaultTykExtension(overRideValues TykExtensionConfigParams, 
 		}
 
 		upstreamURL = s.Servers[0].URL
+		if s.isURLParamatrized(upstreamURL) {
+			for name, variable := range s.Servers[0].Variables {
+				if strings.Contains(upstreamURL, "{"+name+"}") {
+					upstreamURL = strings.ReplaceAll(upstreamURL, "{"+name+"}", variable.Default)
+				}
+			}
+		}
 	}
 
 	if upstreamURL != "" {
@@ -118,6 +125,10 @@ func (s *OAS) BuildDefaultTykExtension(overRideValues TykExtensionConfigParams, 
 	s.importMiddlewares(overRideValues)
 
 	return nil
+}
+
+func (s *OAS) isURLParamatrized(url string) bool {
+	return strings.Contains(url, "{") && strings.Contains(url, "}")
 }
 
 func (s *OAS) importAuthentication(enable bool) error {

--- a/apidef/oas/default_test.go
+++ b/apidef/oas/default_test.go
@@ -1247,6 +1247,49 @@ func TestOAS_BuildDefaultTykExtension(t *testing.T) {
 
 		assert.Equal(t, expectedTykExtension, *oasDef.GetTykExtension())
 	})
+
+	t.Run("build tyk-extension should overwrite upstream url params with defaults values", func(t *testing.T) {
+		oasDef := OAS{
+			T: openapi3.T{
+				Info: &openapi3.Info{
+					Title: "OAS API",
+				},
+				Servers: openapi3.Servers{
+					{
+						URL: "https://example-org.com/api/{bestApiGateway}",
+						Variables: map[string]*openapi3.ServerVariable{
+							"bestApiGateway": {
+								Default: "tyk",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := oasDef.BuildDefaultTykExtension(TykExtensionConfigParams{}, true)
+		assert.NoError(t, err)
+
+		expectedTykExtension := XTykAPIGateway{
+			Server: Server{
+				ListenPath: ListenPath{
+					Value: "/",
+					Strip: true,
+				},
+			},
+			Upstream: Upstream{
+				URL: "https://example-org.com/api/tyk",
+			},
+			Info: Info{
+				Name: "OAS API",
+				State: State{
+					Active: true,
+				},
+			},
+		}
+
+		assert.Equal(t, expectedTykExtension, *oasDef.GetTykExtension())
+	})
 }
 
 func TestGetTykExtensionConfigParams(t *testing.T) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
TASK: https://tyktech.atlassian.net/browse/TT-10895
SUBTASK: https://tyktech.atlassian.net/browse/TT-11066
## Description
Added logic that replaces upstream URL parameters with default values from the first OAS servers entry.
<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
