### PR TITLE
[TT-10858/TT-11156] OAS migration: disable rate limit when per and rate are 0

### DIFF
--- a/apidef/migration.go
+++ b/apidef/migration.go
@@ -238,6 +238,7 @@ func (a *APIDefinition) Migrate() (versions []APIDefinition, err error) {
 	a.migrateCustomDomain()
 	a.migrateScopeToPolicy()
 	a.migrateResponseProcessors()
+	a.migrateGlobalRateLimit()
 
 	versions, err = a.MigrateVersioning()
 	if err != nil {
@@ -450,6 +451,10 @@ func (a *APIDefinition) SetDisabledFlags() {
 			a.VersionData.Versions[version].ExtendedPaths.GoPlugin[i].Disabled = true
 		}
 	}
+
+	if a.GlobalRateLimit.Per == 0 && a.GlobalRateLimit.Rate == 0 {
+		a.DisableRateLimit = true
+	}
 }
 
 func (a *APIDefinition) migrateScopeToPolicy() {
@@ -479,4 +484,10 @@ func (a *APIDefinition) migrateResponseProcessors() {
 	}
 
 	a.ResponseProcessors = responseProcessors
+}
+
+func (a *APIDefinition) migrateGlobalRateLimit() {
+	if a.GlobalRateLimit.Per == 0 && a.GlobalRateLimit.Rate == 0 {
+		a.DisableRateLimit = true
+	}
 }

--- a/apidef/migration_test.go
+++ b/apidef/migration_test.go
@@ -691,6 +691,7 @@ func TestSetDisabledFlags(t *testing.T) {
 				},
 			},
 		},
+		DisableRateLimit: true,
 	}
 	apiDef.SetDisabledFlags()
 	assert.Equal(t, expectedAPIDef, apiDef)
@@ -761,4 +762,24 @@ func TestAPIDefinition_migrateResponseProcessors(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Empty(t, base.ResponseProcessors)
+}
+
+func TestAPIDefinition_migrateGlobalRateLimit(t *testing.T) {
+	t.Run("per=0,rate=0", func(t *testing.T) {
+		base := oldTestAPI()
+		_, err := base.Migrate()
+		assert.NoError(t, err)
+
+		assert.True(t, base.DisableRateLimit)
+	})
+
+	t.Run("per!=0,rate=0", func(t *testing.T) {
+		base := oldTestAPI()
+		base.GlobalRateLimit.Per = 120
+		_, err := base.Migrate()
+		assert.NoError(t, err)
+
+		assert.False(t, base.DisableRateLimit)
+	})
+
 }


### PR DESCRIPTION
## **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description

OAS migration: disable rate limit when per and rate are 0
## Related Issue
Parent: https://tyktech.atlassian.net/browse/TT-10858
Subtask: https://tyktech.atlassian.net/browse/TT-11156
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

## **Type**
Bug fix


___

## **Description**
- This PR introduces changes to the migration process of the API definition, specifically for the global rate limit.
- A new function `migrateGlobalRateLimit()` has been added to handle the migration of the global rate limit. If both `Per` and `Rate` are 0, the rate limit is disabled.
- The `SetDisabledFlags()` function has been updated to include a condition that disables the rate limit when both `Per` and `Rate` are 0.
- Corresponding tests have been added and updated to ensure the correct functionality of these changes.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>migration.go</strong><dd><code>Implement Global Rate Limit Migration and Disablement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/migration.go
- Added a new function `migrateGlobalRateLimit()` to handle the <br>  migration of global rate limit.
- In the `SetDisabledFlags()` function, added a condition to disable <br>  rate limit when both `Per` and `Rate` are 0.
    </details>
  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6004/files#diff-e1d9b55a26f9d6225d56d6f0161959217308e5ad4d6934e7d7df4595d9c2a130">+11/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>migration_test.go</strong><dd><code>Add Tests for Global Rate Limit Migration and Disablement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/migration_test.go
- Added a new test function `TestAPIDefinition_migrateGlobalRateLimit()` <br>  to test the migration of global rate limit.
- Updated the `TestSetDisabledFlags()` function to include the <br>  `DisableRateLimit` flag in the expected API definition.
    </details>
  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6004/files#diff-d79d77f814074b9e483554e36687e22fda759045141c3b094b039428744ff94c">+21/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
