### PR TITLE
[TT-10909]: fix issue with missing upstream headers in graphql proxy only

### DIFF
--- a/gateway/mw_graphql_transport_test.go
+++ b/gateway/mw_graphql_transport_test.go
@@ -121,7 +121,7 @@ func TestGraphQLEngineTransport_RoundTrip(t *testing.T) {
 
 		forwardedRequest.Header.Set("X-Custom-Key", "custom-value")
 		forwardedRequest.Header.Set("X-Other-Value", "other-value")
-		ctx := NewGraphQLProxyOnlyContext(context.Background(), forwardedRequest)
+		ctx := SetProxyOnlyContextValue(context.Background(), forwardedRequest)
 
 		httpClient := http.Client{
 			Transport: NewGraphQLEngineTransport(GraphQLEngineTransportTypeProxyOnly, http.DefaultTransport),
@@ -215,7 +215,7 @@ func TestGraphQLEngineTransport_RoundTrip(t *testing.T) {
 
 		forwardedRequest.Header.Set("X-Custom-Key", "custom-value")
 		forwardedRequest.Header.Set("X-Other-Value", "other-value")
-		ctx := NewGraphQLProxyOnlyContext(context.Background(), forwardedRequest)
+		ctx := SetProxyOnlyContextValue(context.Background(), forwardedRequest)
 
 		httpClient := http.Client{
 			Transport: NewGraphQLEngineTransport(GraphQLEngineTransportTypeMultiUpstream, http.DefaultTransport),

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -995,6 +995,42 @@ func TestGraphQL_ProxyOnlyHeaders(t *testing.T) {
 	})
 }
 
+func TestGraphQL_ProxyOnlyPassHeaders(t *testing.T) {
+	g := StartTest(nil)
+	defer g.Close()
+
+	spec := BuildAPI(func(spec *APISpec) {
+		spec.Name = "tyk-api"
+		spec.APIID = "tyk-api"
+		spec.GraphQL.Enabled = true
+		spec.GraphQL.ExecutionMode = apidef.GraphQLExecutionModeProxyOnly
+		spec.GraphQL.Schema = gqlCountriesSchema
+		spec.GraphQL.Version = apidef.GraphQLConfigVersion2
+		spec.Proxy.TargetURL = TestHttpAny + "/dynamic"
+		spec.Proxy.ListenPath = "/"
+	})[0]
+
+	g.Gw.LoadAPI(spec)
+	g.AddDynamicHandler("/dynamic", func(writer http.ResponseWriter, r *http.Request) {
+		if gotten := r.Header.Get("custom-client-header"); gotten != "custom-value" {
+			t.Errorf("expected upstream to recieve header `custom-client-header` with value of `custom-value`, instead got %s", gotten)
+		}
+	})
+
+	_, err := g.Run(t, test.TestCase{
+		Path: "/",
+		Headers: map[string]string{
+			"custom-client-header": "custom-value",
+		},
+		Method: http.MethodPost,
+		Data: graphql.Request{
+			Query: gqlContinentQuery,
+		},
+	})
+
+	assert.NoError(t, err)
+}
+
 func TestGraphQL_InternalDataSource(t *testing.T) {
 	g := StartTest(nil)
 	defer g.Close()

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -995,8 +995,10 @@ func TestGraphQL_ProxyOnlyHeaders(t *testing.T) {
 	})
 }
 
-func TestGraphQL_ProxyOnlyPassHeaders(t *testing.T) {
-	g := StartTest(nil)
+func TestGraphQL_ProxyOnlyPassHeadersWithOTel(t *testing.T) {
+	g := StartTest(func(globalConf *config.Config) {
+		globalConf.OpenTelemetry.Enabled = true
+	})
 	defer g.Close()
 
 	spec := BuildAPI(func(spec *APISpec) {

--- a/go.mod
+++ b/go.mod
@@ -219,4 +219,4 @@ require (
 	nhooyr.io/websocket v1.8.10 // indirect
 )
 
-//replace github.com/TykTechnologies/graphql-go-tools => ../graphql-go-tools
+replace github.com/TykTechnologies/graphql-go-tools => ../graphql-go-tools

--- a/go.mod
+++ b/go.mod
@@ -219,4 +219,4 @@ require (
 	nhooyr.io/websocket v1.8.10 // indirect
 )
 
-replace github.com/TykTechnologies/graphql-go-tools => ../graphql-go-tools
+//replace github.com/TykTechnologies/graphql-go-tools => ../graphql-go-tools


### PR DESCRIPTION
## **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes an issue where the requests from the client were not sent upstream. This was due to an edge case cause by the open telemetry context modification

[TT-10909](https://tyktech.atlassian.net/browse/TT-10909)

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


[TT-10909]: https://tyktech.atlassian.net/browse/TT-10909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

## **Type**
Bug fix


___

## **Description**
- Refactored the `GraphQLProxyOnlyContext` to use context values instead of embedding context. This change was made in the `gateway/mw_graphql_transport.go` file.
- Added a function `WithOtelEnabled` to enable OpenTelemetry in the `gateway/mw_graphql_transport.go` file.
- Updated the `handleProxyOnly` and `setProxyOnlyHeaders` functions to use the new context values in the `gateway/mw_graphql_transport.go` file.
- Updated tests in the `gateway/mw_graphql_transport_test.go` file to use the new context value functions.
- Updated the `handoverRequestToGraphQLExecutionEngine` and `returnErrorsFromUpstream` functions in the `gateway/reverse_proxy.go` file to use the new context value functions.
- Enabled OpenTelemetry in the `gateway/reverse_proxy.go` file if it's configured.
- Added a test for passing headers with OpenTelemetry enabled in the `gateway/reverse_proxy_test.go` file.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mw_graphql_transport.go</strong><dd><code>Refactor GraphQL proxy context and enable OpenTelemetry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_graphql_transport.go
- Refactored `GraphQLProxyOnlyContext` to use context values instead of <br>  embedding context.
- Added `WithOtelEnabled` function to enable OpenTelemetry.
- Updated `handleProxyOnly` and `setProxyOnlyHeaders` functions to use <br>  the new context values.
    </details>
  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6024/files#diff-f75d622cc8e7e488b4c7795f381baa5177c568dbfcfbb4422bedf7b4b31c31ba">+31/-16</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>reverse_proxy.go</strong><dd><code>Update reverse proxy for GraphQL proxy context refactor and 

 OpenTelemetry</code></dd></summary>
<hr>

gateway/reverse_proxy.go
- Updated `handoverRequestToGraphQLExecutionEngine` and <br>  `returnErrorsFromUpstream` functions to use the new context value <br>  functions.
- Enabled OpenTelemetry if it's configured.
    </details>
  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6024/files#diff-e6e07722257f7e41691e471185ad6d84fd56dc9e5459526ea32e9a5e8fa1a01b">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mw_graphql_transport_test.go</strong><dd><code>Update tests for GraphQL proxy context refactor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_graphql_transport_test.go
- Updated tests to use the new context value functions.
    </details>
  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6024/files#diff-995651c0174dc99d73f6f1481e63dd5eb995a5f77ac3fadef41f11cff1863cd5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>reverse_proxy_test.go</strong><dd><code>Add test for OpenTelemetry enabled headers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/reverse_proxy_test.go
- Added a test for passing headers with OpenTelemetry enabled.
    </details>
  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6024/files#diff-ce040f6555143f760fba6059744bc600b6954f0966dfb0fa2832b5eabf7a3c3f">+38/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
