### PR TITLE
[DX-1045]fix integer format issue  issue

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -2167,6 +2167,9 @@ components:
         jwt_expires_at_validation_skew:
           format: int64
           type: integer
+          minimum: 0
+          maximum: 18446744073709551615
+          example: 18446744073615
           x-go-name: JWTExpiresAtValidationSkew
         jwt_identity_base_field:
           type: string
@@ -2174,10 +2177,16 @@ components:
         jwt_issued_at_validation_skew:
           format: int64
           type: integer
+          minimum: 0
+          maximum: 18446744073709551615
+          example: 18446744073615
           x-go-name: JWTIssuedAtValidationSkew
         jwt_not_before_validation_skew:
           format: int64
           type: integer
+          minimum: 0
+          maximum: 18446744073709551615
+          example: 18446744073615
           x-go-name: JWTNotBeforeValidationSkew
         jwt_policy_field_name:
           type: string

--- a/swagger.yml
+++ b/swagger.yml
@@ -2165,18 +2165,18 @@ components:
           type: string
           x-go-name: JWTClientIDBaseField
         jwt_expires_at_validation_skew:
-          format: uint64
+          format: int64
           type: integer
           x-go-name: JWTExpiresAtValidationSkew
         jwt_identity_base_field:
           type: string
           x-go-name: JWTIdentityBaseField
         jwt_issued_at_validation_skew:
-          format: uint64
+          format: int64
           type: integer
           x-go-name: JWTIssuedAtValidationSkew
         jwt_not_before_validation_skew:
-          format: uint64
+          format: int64
           type: integer
           x-go-name: JWTNotBeforeValidationSkew
         jwt_policy_field_name:

--- a/swagger.yml
+++ b/swagger.yml
@@ -2284,8 +2284,11 @@ components:
                   type: boolean
                   x-go-name: SSLInsecureSkipVerify
                 ssl_min_version:
-                  format: uint16
+                  format: int64
+                  description: Represents the SSL minimum version
                   type: integer
+                  minimum: 0
+                  maximum: 65535
                   x-go-name: SSLMinVersion
               type: object
               x-go-name: Transport


### PR DESCRIPTION
## **User description**
- OAS does not have format type  uint64 for integers. I only has int64 and int32.
- This pull request changes  uint64 to int64.
- Added min and max to make use uint is enforced 
-
Reference : https://swagger.io/docs/specification/data-models/data-types/#numbers
DX-1045

___

## **Type**
bug_fix


___

## **Description**
- Corrected the integer format issue in the Swagger configuration by changing `uint64` to `int64` for three fields to align with the OpenAPI Specification.
- This change ensures compatibility with the OpenAPI Specification's supported integer formats.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>swagger.yml
</strong><dd><code>Fix Integer Format Issue in Swagger Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

swagger.yml
<li>Changed <code>format</code> from <code>uint64</code> to <code>int64</code> for <br><code>jwt_expires_at_validation_skew</code>, <code>jwt_issued_at_validation_skew</code>, and <br><code>jwt_not_before_validation_skew</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6032/files#diff-8f3c4cb253eee09ae2401daa7279a8bbfbfd4168bb579c3ac0ee5c672d63bb2c"></a></td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
