### PR TITLE
TT-11135, correctly validate URL rewrite key field

### DIFF
--- a/apidef/oas/linter_test.go
+++ b/apidef/oas/linter_test.go
@@ -38,11 +38,21 @@ func TestXTykGateway_Lint(t *testing.T) {
 						Rules:     []*URLRewriteRule{},
 					}
 					for _, in := range URLRewriteInputs {
-						rule := &URLRewriteRule{
-							In:      in,
-							Pattern: ".*",
+						var rule URLRewriteRule
+						if in == InputRequestBody {
+							rule = URLRewriteRule{
+								In:      in,
+								Pattern: ".*",
+							}
+						} else {
+							rule = URLRewriteRule{
+								In:      in,
+								Name:    "test",
+								Pattern: ".*",
+							}
 						}
-						trigger.Rules = append(trigger.Rules, rule)
+
+						trigger.Rules = append(trigger.Rules, &rule)
 					}
 					triggers = append(triggers, trigger)
 				}

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -861,11 +861,16 @@
         },
         "rules": {
           "type": "array",
-          "items": [
-            {
-              "$ref": "#/definitions/X-Tyk-URLRewriteRule"
-            }
-          ]
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/X-Tyk-URLRewriteRule"
+              },
+              {
+                "$ref": "#/definitions/X-Tyk-URLRewriteRuleForRequestBody"
+              }
+            ]
+          }
         }
       },
       "required": [
@@ -873,17 +878,12 @@
         "rewriteTo"
       ]
     },
-    "X-Tyk-URLRewriteRule": {
+    "X-Tyk-URLRewriteRuleForRequestBody": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "in": {
           "enum": [
-            "query",
-            "path",
-            "header",
-            "sessionMetadata",
-            "requestContext",
             "requestBody"
           ]
         },
@@ -899,6 +899,35 @@
       },
       "required": [
         "in",
+        "pattern"
+      ]
+    },
+    "X-Tyk-URLRewriteRule": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "in": {
+          "enum": [
+            "query",
+            "path",
+            "header",
+            "sessionMetadata",
+            "requestContext"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "pattern": {
+          "type": "string"
+        },
+        "negate": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "in",
+        "name",
         "pattern"
       ]
     },


### PR DESCRIPTION
## **User description**
<!-- Provide a general summary of your changes in the Title above -->
TASK: https://tyktech.atlassian.net/browse/TT-11135
## Description

Added a little hack inside schema to allow for different types of URL Rewrite schemas to treat the situation in which we have "name" for the non requestBody case.
<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

## **Type**
enhancement


___

## **Description**
- Introduced a new schema definition `X-Tyk-URLRewriteRuleForRequestBody` to enable URL rewrite rules specifically for request bodies.
- Enhanced the `rules` property in `X-Tyk-URLRewrite` to accept an array of either `X-Tyk-URLRewriteRule` or `X-Tyk-URLRewriteRuleForRequestBody`, enhancing flexibility.
- Adjusted the `X-Tyk-URLRewriteRule` to require the `name` property, aligning with the new structure.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>x-tyk-api-gateway.json</strong><dd><code>Support for URL Rewrite Rules on Request Bodies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/schema/x-tyk-api-gateway.json
<li>Added <code>X-Tyk-URLRewriteRuleForRequestBody</code> definition to support URL <br>rewrite rules for request bodies.<br> <li> Updated <code>rules</code> items in <code>X-Tyk-URLRewrite</code> to support <code>anyOf</code> with the new <br><code>X-Tyk-URLRewriteRuleForRequestBody</code>.<br> <li> Made <code>name</code> a required property in <code>X-Tyk-URLRewriteRule</code>.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6034/files#diff-78828969c0c04cc1a776dfc93a8bad3c499a8c83e6169f83e96d090bed3e7dd0">+36/-7</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
