### PR TITLE
[TT-11126] fix internal endpoint middleware not working in conjunction with other middleware enabled

### DIFF
--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -1458,7 +1458,6 @@ func (a *APISpec) getURLStatus(stat URLStatus) RequestStatus {
 
 // URLAllowedAndIgnored checks if a url is allowed and ignored.
 func (a *APISpec) URLAllowedAndIgnored(r *http.Request, rxPaths []URLSpec, whiteListStatus bool) (RequestStatus, interface{}) {
-	// Check if ignored
 	for i := range rxPaths {
 		if !rxPaths[i].Spec.MatchString(r.URL.Path) {
 			continue
@@ -1466,6 +1465,13 @@ func (a *APISpec) URLAllowedAndIgnored(r *http.Request, rxPaths []URLSpec, white
 
 		if r.Method == rxPaths[i].Internal.Method && rxPaths[i].Status == Internal && !ctxLoopingEnabled(r) {
 			return EndPointNotAllowed, nil
+		}
+	}
+
+	// Check if ignored
+	for i := range rxPaths {
+		if !rxPaths[i].Spec.MatchString(r.URL.Path) {
+			continue
 		}
 
 		if rxPaths[i].MethodActions == nil {

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -1464,6 +1464,10 @@ func (a *APISpec) URLAllowedAndIgnored(r *http.Request, rxPaths []URLSpec, white
 			continue
 		}
 
+		if r.Method == rxPaths[i].Internal.Method && rxPaths[i].Status == Internal && !ctxLoopingEnabled(r) {
+			return EndPointNotAllowed, nil
+		}
+
 		if rxPaths[i].MethodActions == nil {
 			switch rxPaths[i].Status {
 			case WhiteList:
@@ -1516,10 +1520,6 @@ func (a *APISpec) URLAllowedAndIgnored(r *http.Request, rxPaths []URLSpec, white
 				log.Error("URL Method Action was not set to NoAction, blocking.")
 				return EndPointNotAllowed, nil
 			}
-		}
-
-		if r.Method == rxPaths[i].Internal.Method && rxPaths[i].Status == Internal && !ctxLoopingEnabled(r) {
-			return EndPointNotAllowed, nil
 		}
 
 		if whiteListStatus {

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -1588,3 +1588,35 @@ func TestReplaceSecrets(t *testing.T) {
 	assert.Equal(t, "Ghiur", api1.JWTSigningMethod)
 	assert.Equal(t, "Ghiur", api2.AuthConfigs[apidef.OAuthType].AuthHeaderName)
 }
+
+func TestInternalEndpointMW_TT_11126(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+			json.Unmarshal([]byte(`[
+                        {
+                            "path": "/headers",
+                            "method": "GET",
+                            "disabled": false
+						}
+				]`), &v.ExtendedPaths.Internal)
+			json.Unmarshal([]byte(`[
+                    {
+                        "disabled": false,
+                        "add_headers": {
+                            "New-Header": "Value"
+                        },
+                        "path": "/headers",
+                        "method": "GET",
+                    }
+                ]`), &v.ExtendedPaths.TransformHeader)
+		})
+		spec.Proxy.ListenPath = "/"
+	})
+
+	ts.Run(t, []test.TestCase{
+		{Path: "/headers", Code: http.StatusForbidden},
+	}...)
+}

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -1595,28 +1595,28 @@ func TestInternalEndpointMW_TT_11126(t *testing.T) {
 
 	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 		UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
-			json.Unmarshal([]byte(`[
-                        {
-                            "path": "/headers",
-                            "method": "GET",
-                            "disabled": false
-						}
-				]`), &v.ExtendedPaths.Internal)
-			json.Unmarshal([]byte(`[
+			assert.NoError(t, json.Unmarshal([]byte(`[
                     {
                         "disabled": false,
                         "add_headers": {
                             "New-Header": "Value"
                         },
                         "path": "/headers",
-                        "method": "GET",
+                        "method": "GET"
                     }
-                ]`), &v.ExtendedPaths.TransformHeader)
+                ]`), &v.ExtendedPaths.TransformHeader))
+			assert.NoError(t, json.Unmarshal([]byte(`[
+                        {
+                            "path": "/headers",
+                            "method": "GET",
+                            "disabled": false
+						}
+				]`), &v.ExtendedPaths.Internal))
 		})
 		spec.Proxy.ListenPath = "/"
 	})
 
-	ts.Run(t, []test.TestCase{
+	_, _ = ts.Run(t, []test.TestCase{
 		{Path: "/headers", Code: http.StatusForbidden},
 	}...)
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

internal endpoint middleware doesn't work when other middlewares are enabled on the same endpoint. 
This PR fixes it. 

## Related Issue
https://tyktech.atlassian.net/browse/TT-11126

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
