### PR TITLE
[TT-11091] Fix ratelimit key calculation for custom keys.

### DIFF
--- a/gateway/mw_rate_limiting_test.go
+++ b/gateway/mw_rate_limiting_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
-	"github.com/TykTechnologies/tyk/config"
-
 	"github.com/TykTechnologies/tyk/header"
 	"github.com/TykTechnologies/tyk/test"
 	"github.com/TykTechnologies/tyk/user"
@@ -193,7 +191,7 @@ func TestMwRateLimiting_DepthLimit(t *testing.T) {
 	})
 }
 
-func providerCustomRatelimitKey(t *testing.T, provider string) {
+func providerCustomRatelimitKey(t *testing.T, limiter string) {
 	tcs := []struct {
 		name     string
 		hashKey  bool
@@ -220,39 +218,45 @@ func providerCustomRatelimitKey(t *testing.T, provider string) {
 		},
 	}
 
-	// Tests are implemented for Redis, DRLSentinel (default) and NonTransactional rate limiters.
-	setRateLimitConfiguration := func(globalConf *config.Config, ratelimitProvider string) {
-		switch ratelimitProvider {
-		case "Redis":
-			globalConf.RateLimit.EnableRedisRollingLimiter = true
-		case "DRLSentinel":
-			globalConf.RateLimit.DRLEnableSentinelRateLimiter = true
-		case "Sentinel":
-			globalConf.RateLimit.EnableSentinelRateLimiter = true
-		}
-	}
-
 	for _, tc := range tcs {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			g := StartTest(func(globalConf *config.Config) {
-				globalConf.HashKeys = tc.hashKey
-				globalConf.HashKeyFunction = tc.hashAlgo
-				setRateLimitConfiguration(globalConf, provider)
-			})
-			defer g.Close()
+			ts := StartTest(nil)
+			defer ts.Close()
 
-			ok := g.Gw.GlobalSessionManager.Store().DeleteAllKeys()
+			globalConf := ts.Gw.GetConfig()
+
+			globalConf.HashKeys = tc.hashKey
+			globalConf.HashKeyFunction = tc.hashAlgo
+
+			switch limiter {
+			case "Redis":
+				globalConf.RateLimit.EnableRedisRollingLimiter = true
+			case "Sentinel":
+				globalConf.RateLimit.EnableSentinelRateLimiter = true
+			case "DRL":
+				globalConf.RateLimit.DRLEnableSentinelRateLimiter = true
+			case "NonTransactional":
+				globalConf.RateLimit.EnableNonTransactionalRateLimiter = true
+			case "LeakyBucket":
+				globalConf.RateLimit.EnableLeakyBucketRateLimiter = true
+			default:
+				t.Fatal("There is no such a rate limiter:", limiter)
+			}
+
+			ts.Gw.SetConfig(globalConf)
+
+			ok := ts.Gw.GlobalSessionManager.Store().DeleteAllKeys()
 			assert.True(t, ok)
 
-			customRateLimitKey := "portal-developer-1" + tc.hashAlgo + provider
+			customRateLimitKey := "portal-developer-1" + tc.hashAlgo + limiter
 
-			spec := g.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+			spec := ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 				spec.UseKeylessAccess = false
 				spec.Proxy.ListenPath = "/"
 			})[0]
 
-			_, firstQuotaKey := g.CreateSession(func(s *user.SessionState) {
+			_, firstQuotaKey := ts.CreateSession(func(s *user.SessionState) {
 				s.MaxQueryDepth = -1
 				s.AccessRights = map[string]user.AccessDefinition{
 					spec.APIID: {
@@ -270,7 +274,7 @@ func providerCustomRatelimitKey(t *testing.T, provider string) {
 				}
 			})
 
-			_, secondQuotaKey := g.CreateSession(func(s *user.SessionState) {
+			_, secondQuotaKey := ts.CreateSession(func(s *user.SessionState) {
 				s.MaxQueryDepth = -1
 				s.AccessRights = map[string]user.AccessDefinition{
 					spec.APIID: {
@@ -288,7 +292,7 @@ func providerCustomRatelimitKey(t *testing.T, provider string) {
 				}
 			})
 
-			_, firstRLKey := g.CreateSession(func(s *user.SessionState) {
+			_, firstRLKey := ts.CreateSession(func(s *user.SessionState) {
 				s.MaxQueryDepth = -1
 				s.AccessRights = map[string]user.AccessDefinition{
 					spec.APIID: {
@@ -306,7 +310,7 @@ func providerCustomRatelimitKey(t *testing.T, provider string) {
 				}
 			})
 
-			_, secondRLKey := g.CreateSession(func(s *user.SessionState) {
+			_, secondRLKey := ts.CreateSession(func(s *user.SessionState) {
 				s.MaxQueryDepth = -1
 				s.AccessRights = map[string]user.AccessDefinition{
 					spec.APIID: {
@@ -329,44 +333,44 @@ func providerCustomRatelimitKey(t *testing.T, provider string) {
 			authHeaderFirstRLKey := map[string]string{header.Authorization: firstRLKey}
 			authHeaderSecondRLKey := map[string]string{header.Authorization: secondRLKey}
 
-			t.Run("Custom quota key for "+provider, func(t *testing.T) {
+			t.Run("Custom quota key for "+limiter, func(t *testing.T) {
 
 				// Make first two calls with the first key. Both calls should be 200 OK since the quota is 3 calls.
-				_, _ = g.Run(t, []test.TestCase{
+				_, _ = ts.Run(t, []test.TestCase{
 					{Headers: authHeaderFirstQuotaKey, Code: http.StatusOK},
 					{Headers: authHeaderFirstQuotaKey, Code: http.StatusOK},
 				}...)
 
 				// The first call with the second key should be 200 OK.
 				// The next call should be 403 since the quota of 3 calls is shared between two credentials.
-				_, _ = g.Run(t, []test.TestCase{
+				_, _ = ts.Run(t, []test.TestCase{
 					{Headers: authHeaderSecondQuotaKey, Code: http.StatusOK},
 					{Headers: authHeaderSecondQuotaKey, Code: http.StatusForbidden},
 				}...)
 
 				// Since both keys have the same ratelimit key, the quota for the first key should be already spent.
-				_, _ = g.Run(t, []test.TestCase{
+				_, _ = ts.Run(t, []test.TestCase{
 					{Headers: authHeaderFirstQuotaKey, Code: http.StatusForbidden},
 				}...)
 			})
 
-			t.Run("Custom ratelimit key for "+provider, func(t *testing.T) {
+			t.Run("Custom ratelimit key for "+limiter, func(t *testing.T) {
 
 				// Make first two calls with the first key. Both calls should be 200 OK since the RL is 3 calls / 1000 s.
-				_, _ = g.Run(t, []test.TestCase{
+				_, _ = ts.Run(t, []test.TestCase{
 					{Headers: authHeaderFirstRLKey, Code: http.StatusOK, Delay: 100 * time.Millisecond},
 					{Headers: authHeaderFirstRLKey, Code: http.StatusOK, Delay: 100 * time.Millisecond},
 				}...)
 
 				// The first call with the second key should be 200 OK.
 				// The next call should be 429 since the ratelimit of 3 calls / 1000 s is shared between two credentials.
-				_, _ = g.Run(t, []test.TestCase{
+				_, _ = ts.Run(t, []test.TestCase{
 					{Headers: authHeaderSecondRLKey, Code: http.StatusOK, Delay: 100 * time.Millisecond},
 					{Headers: authHeaderSecondRLKey, Code: http.StatusTooManyRequests, Delay: 100 * time.Millisecond},
 				}...)
 
 				// Since both keys have the same ratelimit key, the raltelimit for the first key should be already spent.
-				_, _ = g.Run(t, []test.TestCase{
+				_, _ = ts.Run(t, []test.TestCase{
 					{Headers: authHeaderFirstRLKey, Code: http.StatusTooManyRequests, Delay: 100 * time.Millisecond},
 				}...)
 			})
@@ -379,10 +383,18 @@ func TestMwRateLimiting_CustomRatelimitKeyRedis(t *testing.T) {
 	providerCustomRatelimitKey(t, "Redis")
 }
 
-func TestMwRateLimiting_CustomRatelimitKeyDRLSentinel(t *testing.T) {
-	providerCustomRatelimitKey(t, "DRLSentinel")
-}
-
 func TestMwRateLimiting_CustomRatelimitKeySentinel(t *testing.T) {
 	providerCustomRatelimitKey(t, "Sentinel")
+}
+
+func TestMwRateLimiting_CustomRatelimitKeyDRL(t *testing.T) {
+	providerCustomRatelimitKey(t, "DRL")
+}
+
+func TestMwRateLimiting_CustomRatelimitKeyNonTransactional(t *testing.T) {
+	providerCustomRatelimitKey(t, "NonTransactional")
+}
+
+func TestMwRateLimiting_CustomRatelimitKeyEnableLeakyBucketRateLimiter(t *testing.T) {
+	providerCustomRatelimitKey(t, "LeakyBucket")
 }

--- a/gateway/mw_rate_limiting_test.go
+++ b/gateway/mw_rate_limiting_test.go
@@ -192,6 +192,8 @@ func TestMwRateLimiting_DepthLimit(t *testing.T) {
 }
 
 func providerCustomRatelimitKey(t *testing.T, limiter string) {
+	t.Helper()
+
 	tcs := []struct {
 		name     string
 		hashKey  bool

--- a/gateway/mw_rate_limiting_test.go
+++ b/gateway/mw_rate_limiting_test.go
@@ -225,8 +225,6 @@ func providerCustomRatelimitKey(t *testing.T, provider string) {
 		switch ratelimitProvider {
 		case "Redis":
 			globalConf.RateLimit.EnableRedisRollingLimiter = true
-		case "NonTransactional":
-			globalConf.RateLimit.EnableNonTransactionalRateLimiter = true
 		case "DRLSentinel":
 			globalConf.RateLimit.DRLEnableSentinelRateLimiter = true
 		case "Sentinel":
@@ -379,10 +377,6 @@ func providerCustomRatelimitKey(t *testing.T, provider string) {
 
 func TestMwRateLimiting_CustomRatelimitKeyRedis(t *testing.T) {
 	providerCustomRatelimitKey(t, "Redis")
-}
-
-func TestMwRateLimiting_CustomRatelimitKeyNonTransactional(t *testing.T) {
-	providerCustomRatelimitKey(t, "NonTransactional")
 }
 
 func TestMwRateLimiting_CustomRatelimitKeyDRLSentinel(t *testing.T) {

--- a/gateway/session_manager.go
+++ b/gateway/session_manager.go
@@ -31,8 +31,10 @@ type PublicSession struct {
 }
 
 const (
-	QuotaKeyPrefix     = "quota-"
-	RateLimitKeyPrefix = "rate-limit-"
+	// QuotaKeyPrefix serves as a standard prefix for generating quota keys wherever they are required to be calculated.
+	QuotaKeyPrefix              = "quota-"
+	RateLimitKeyPrefix          = "rate-limit-"
+	SentinelRateLimitKeyPostfix = ".BLOCKED"
 )
 
 // SessionLimiter is the rate limiter for the API, use ForwardMessage() to
@@ -150,11 +152,11 @@ func (l *SessionLimiter) limitSentinel(currentSession *user.SessionState, key st
 	store storage.Handler, globalConf *config.Config, apiLimit *user.APILimit, dryRun bool) bool {
 
 	rateLimiterKey := RateLimitKeyPrefix + rateScope + currentSession.KeyHash()
-	rateLimiterSentinelKey := RateLimitKeyPrefix + rateScope + currentSession.KeyHash() + ".BLOCKED"
+	rateLimiterSentinelKey := RateLimitKeyPrefix + rateScope + currentSession.KeyHash() + SentinelRateLimitKeyPostfix
 
 	if useCustomKey {
 		rateLimiterKey = RateLimitKeyPrefix + rateScope + key
-		rateLimiterSentinelKey = RateLimitKeyPrefix + rateScope + key + ".BLOCKED"
+		rateLimiterSentinelKey = RateLimitKeyPrefix + rateScope + key + SentinelRateLimitKeyPostfix
 	}
 
 	defer func() {
@@ -175,11 +177,11 @@ func (l *SessionLimiter) limitRedis(currentSession *user.SessionState, key strin
 	store storage.Handler, globalConf *config.Config, apiLimit *user.APILimit, dryRun bool) bool {
 
 	rateLimiterKey := RateLimitKeyPrefix + rateScope + currentSession.KeyHash()
-	rateLimiterSentinelKey := RateLimitKeyPrefix + rateScope + currentSession.KeyHash() + ".BLOCKED"
+	rateLimiterSentinelKey := RateLimitKeyPrefix + rateScope + currentSession.KeyHash() + SentinelRateLimitKeyPostfix
 
 	if useCustomKey {
 		rateLimiterKey = RateLimitKeyPrefix + rateScope + key
-		rateLimiterSentinelKey = RateLimitKeyPrefix + rateScope + key + ".BLOCKED"
+		rateLimiterSentinelKey = RateLimitKeyPrefix + rateScope + key + SentinelRateLimitKeyPostfix
 	}
 
 	if l.doRollingWindowWrite(key, rateLimiterKey, rateLimiterSentinelKey, currentSession, store, globalConf, apiLimit, dryRun) {

--- a/gateway/session_manager.go
+++ b/gateway/session_manager.go
@@ -31,8 +31,9 @@ type PublicSession struct {
 }
 
 const (
-	// QuotaKeyPrefix serves as a standard prefix for generating quota keys wherever they are required to be calculated.
-	QuotaKeyPrefix              = "quota-"
+	// QuotaKeyPrefix serves as a standard prefix for generating quota keys.
+	QuotaKeyPrefix = "quota-"
+	// RateLimitKeyPrefix serves as a standard prefix for generating rate limit keys.
 	RateLimitKeyPrefix          = "rate-limit-"
 	SentinelRateLimitKeyPostfix = ".BLOCKED"
 )


### PR DESCRIPTION
## **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description
Fix rate limit key calculation for limitSentinel, limitRDL, limitRedis to avoid the generation of unique keys based on the session timestamp and key hash.


## Related Issue
https://tyktech.atlassian.net/browse/TT-11091

## Motivation and Context


## How This Has Been Tested
- Unit tests for the Redis, RDL, and NonTransactional ratelimiter.
- Manual tests:
  - Create a policy with ratelimit (5 calls / 60 sec) and quota (6 calls / never renew), add rate_limit_pattern = $tyk_meta.developer_id to the metadata
  - Set hash_keys to true in both tyk.conf and tyk_analytics.conf
  - For each of the above ratelimiters:
     - Create a key for the above policy, set developer_id = 123 in the metadata
     - Create one more key for the above policy, set developer_id = 123 in the metadata
     - Make 2 calls with the first key (all 200OK)
     - Make 4 calls with the second key (the last call should be 429)
     - Wait 60 secs
     - Make 2 calls with the second key (the last call should be 403)
     - Make 1 call with the first key (should be 403)
  - Set hash_keys to false in both tyk.conf and tyk_analytics.conf
  - For each of the above ratelimiters:
     - Create a key for the above policy, set developer_id = 123 in the metadata
     - Create one more key for the above policy, set developer_id = 123 in the metadata
     - Make 2 calls with the first key (all 200OK)
     - Make 4 calls with the second key (the last call should be 429)
     - Wait 60 secs
     - Make 2 calls with the second key (the last call should be 403)
     - Make 1 call with the first key (should be 403)

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [x] I ensured that the documentation is up to date
- [x] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

## **Type**
bug_fix, tests


___

## **Description**
- Added support for custom rate limit keys across Sentinel, Redis, DRL, and NonTransactional rate limiters.
- Refactored rate limiting tests to cover multiple rate limiter providers, ensuring consistent behavior.
- Introduced a mechanism to toggle custom rate limit key usage, enhancing flexibility in rate limiting strategies.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mw_rate_limiting_test.go</strong><dd><code>Refactor and Extend Rate Limiting Tests for Multiple Providers</code></dd></summary>
<hr>

gateway/mw_rate_limiting_test.go
<li>Refactored custom rate limit key tests into a provider function to <br>support multiple rate limiters.<br> <li> Added tests for Redis, NonTransactional, DRLSentinel, and Sentinel <br>rate limiters.<br> <li> Introduced a delay between API calls in tests to simulate real-world <br>usage.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6041/files#diff-7cf2199231924147d538ba7ad576a48a3c0e691852077e147c9b2d86ba9b7c4d">+41/-9</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>session_manager.go</strong><dd><code>Support Custom Rate Limit Keys Across Rate Limiters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/session_manager.go
<li>Modified rate limiting functions to support custom rate limit keys.<br> <li> Added a <code>useCustomKey</code> parameter to rate limiting functions to toggle <br>custom key usage.<br> <li> Ensured custom rate limit key logic is applied across Sentinel, Redis, <br>and DRL rate limiters.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6041/files#diff-e6b40a285464cd86736e970c4c0b320b44c75b18b363d38c200e9a9d36cdabb6">+27/-9</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
