### PR TITLE
Merging to release-5.3: [TT-11260] GraphQL introspection impossible if Allow List is enabled (#6043)

### DIFF
--- a/internal/graphengine/graphql_go_tools_v1.go
+++ b/internal/graphengine/graphql_go_tools_v1.go
@@ -420,6 +420,15 @@ func (g *granularAccessCheckerV1) CheckGraphQLRequestFieldAllowance(w http.Respo
 		if accessDefinition.DisableIntrospection {
 			return GraphQLGranularAccessResult{FailReason: GranularAccessFailReasonIntrospectionDisabled}
 		}
+
+		// See TT-11260
+		//
+		// Introspection should be possible when Disable Introspection is turned off in policy settings,
+		// regardless of Allow List or Block List settings.
+		//
+		// Agreed solution: if Disable Introspection is turned off, then the Allow or Block list settings
+		// should be ignored, but only for the introspection query.
+		return GraphQLGranularAccessResult{FailReason: GranularAccessFailReasonNone}
 	}
 
 	if len(accessDefinition.AllowedTypes) != 0 {


### PR DESCRIPTION
[TT-11260] GraphQL introspection impossible if Allow List is enabled (#6043)

## **User description**
PR for [TT-11260](https://tyktech.atlassian.net/browse/TT-11260)

Introspection should be possible when Disable Introspection is turned
off in policy settings, regardless of Allow List or Block List settings.

Agreed solution: if Disable Introspection is turned off, then the Allow
or Block list settings should be ignored, but only for the introspection
query.

[TT-11260]:
https://tyktech.atlassian.net/browse/TT-11260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

## **Type**
bug_fix, tests


___

## **Description**
- Implemented a fix to allow GraphQL introspection queries when the
Disable Introspection setting is turned off, regardless of Allow List or
Block List settings.
- Added comprehensive tests to ensure the correct behavior of
introspection queries under various policy configurations.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>graphql_go_tools_v1.go</strong><dd><code>Allow GraphQL
Introspection with Allow/Block List Enabled</code></dd></summary>
<hr>

internal/graphengine/graphql_go_tools_v1.go
<li>Added logic to allow GraphQL introspection queries regardless of
Allow <br>List or Block List settings when Disable Introspection is
turned off.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6043/files#diff-e592cc8ca6ac39e7574765d7f2bbf19193f173791a1b0930d4dde7f9412dc882">+9/-0</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>graphql_go_tools_v1_test.go</strong><dd><code>Tests for
GraphQL Introspection with Allow/Block List</code>&nbsp; &nbsp; &nbsp;
&nbsp; </dd></summary>
<hr>

internal/graphengine/graphql_go_tools_v1_test.go
<li>Added tests to verify that introspection queries are allowed when
<br>Disable Introspection is turned off, even if Allow List or Block
List <br>is configured.<br> <li> Tests cover scenarios with both Allow
List and Block List settings.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6043/files#diff-f2bd01488bead3cbb84ccfbd8595400eb3153a94a19587308a9fe24edfc13267">+66/-0</a>&nbsp;
&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a
description for the PR - title, type, summary, walkthrough and labels.
The tool can be triggered
[automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools)
every time a new PR is opened, or can be invoked manually by commenting
on a PR.

When commenting, to edit
[configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46)
related to the describe tool (`pr_description` section), use the
following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration
file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app),
use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation
</strong></summary><hr>

- When you first install the app, the [default
mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools)
for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will
keep the original title, and will add the original user description
above the generated description.

- Markers are an alternative way to control the generated description,
to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in
the PR description with the relevant content, where `marker_name` is one
of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does
not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels
</strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`,
`Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom
labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem)
in the repo's labels page or via configuration file, you can get
tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is
performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the
Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different
possibilities. Define custom labels that are relevant for your repo and
use cases.
Note that Labels are not mutually exclusive, so you can add multiple
label categories.
Make sure to provide proper title, and a detailed and well-phrased
description for each label, so the tool will know when to suggest it.


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough
💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries
directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file,
while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary`
in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top
of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes
summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the
"Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra
instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide
the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra
instructions, you are the prompter. Notice that the general structure of
the description is fixed, and cannot be changed. Extra instructions can
change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to
make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent
commands</strong></summary><hr>

> To invoke the PR-Agent, add a comment using one of the following
commands:
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the
contents of the PR.
> - **/improve [--extended]**: Suggest code improvements. Extended mode
provides a higher quality feedback.
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's
contents.
> - **/add_docs** 💎: Generate docstring for new components introduced in
the PR.
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's
contents.
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes
walkthrough for each component.

>See the [tools
guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md)
for more details.
>To list the possible configuration parameters, add a **/config**
comment.
 


</details></td></tr>

</table>

See the [describe
usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md)
page for a comprehensive guide on using this tool.


</details>