### PR TITLE
[TT-11348] fix inverted logic for detailed activity logs

### DIFF
--- a/apidef/oas/oas_test.go
+++ b/apidef/oas/oas_test.go
@@ -257,7 +257,6 @@ func TestOAS_ExtractTo_ResetAPIDefinition(t *testing.T) {
 		"APIDefinition.ResponseProcessors[0].Options",
 		"APIDefinition.DoNotTrack",
 		"APIDefinition.TagHeaders[0]",
-		"APIDefinition.EnableDetailedRecording",
 		"APIDefinition.GraphQL.Enabled",
 		"APIDefinition.GraphQL.ExecutionMode",
 		"APIDefinition.GraphQL.Version",

--- a/apidef/oas/server.go
+++ b/apidef/oas/server.go
@@ -242,12 +242,12 @@ type DetailedActivityLogs struct {
 
 // ExtractTo extracts *DetailedActivityLogs into *apidef.APIDefinition.
 func (d *DetailedActivityLogs) ExtractTo(api *apidef.APIDefinition) {
-	api.EnableDetailedRecording = !d.Enabled
+	api.EnableDetailedRecording = d.Enabled
 }
 
 // Fill fills *DetailedActivityLogs from apidef.APIDefinition.
 func (d *DetailedActivityLogs) Fill(api apidef.APIDefinition) {
-	d.Enabled = !api.EnableDetailedRecording
+	d.Enabled = api.EnableDetailedRecording
 }
 
 // DetailedTracing holds the configuration of the detailed tracing.


### PR DESCRIPTION
## **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description

Fix inverted conversion for detailed activity logs
## Related Issue
https://tyktech.atlassian.net/browse/TT-11348
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

## **Type**
bug_fix


___

## **Description**
- Corrected the inverted logic for enabling detailed activity logs in the API definition.
- Removed unnecessary reset of `EnableDetailedRecording` in test setup, streamlining the testing process.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>oas_test.go</strong><dd><code>Update Test Reset List for Detailed Activity Logs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/oas_test.go
<li>Removed <code>APIDefinition.EnableDetailedRecording</code> from a test reset list, <br>indicating it no longer needs to be reset for tests.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6063/files#diff-74029ee88132d30d6478c96a35f8bb2200e0c8e6f42f2c9b147dc6bb7ce74644">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>server.go</strong><dd><code>Fix Inverted Logic for Detailed Activity Logs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/server.go
<li>Corrected the logic for enabling detailed activity logs by setting <br><code>EnableDetailedRecording</code> directly based on the <code>Enabled</code> flag.<br> <li> Updated the <code>Fill</code> method to directly reflect the <br><code>EnableDetailedRecording</code> status in the <code>Enabled</code> flag of <br><code>DetailedActivityLogs</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6063/files#diff-21857c42e8659f7980014e277c3c758703f29e9e5c0c40553f2584cddb870808">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

