### PR TITLE
Merging to release-5-lts: [TT-11274] update condition to reload spec (#6062)

### DIFF
--- a/gateway/util.go
+++ b/gateway/util.go
@@ -163,6 +163,10 @@ func shouldReloadSpec(existingSpec, newSpec *APISpec) bool {
 		return true
 	}
 
+	if !newSpec.CustomMiddlewareBundleDisabled && newSpec.CustomMiddlewareBundle != "" {
+		return true
+	}
+
 	if newSpec.CustomMiddleware.Driver == apidef.GrpcDriver {
 		return false
 	}

--- a/gateway/util_test.go
+++ b/gateway/util_test.go
@@ -449,6 +449,44 @@ func Test_shouldReloadSpec(t *testing.T) {
 
 		assertionHelper(t, tcs)
 	})
+
+	t.Run("bundle", func(t *testing.T) {
+		t.Parallel()
+		tcs := []testCase{
+			{
+				name: "bundle disabled",
+				spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddlewareBundleDisabled: true,
+						CustomMiddlewareBundle:         "bundle.zip",
+					},
+				},
+				want: false,
+			},
+			{
+				name: "bundle enabled with empty bundle value",
+				spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddlewareBundleDisabled: false,
+						CustomMiddlewareBundle:         "",
+					},
+				},
+				want: false,
+			},
+			{
+				name: "bundle enabled with valid bundle value",
+				spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddlewareBundleDisabled: false,
+						CustomMiddlewareBundle:         "bundle.zip",
+					},
+				},
+				want: true,
+			},
+		}
+
+		assertionHelper(t, tcs)
+	})
 }
 
 func TestAreMapsEqual(t *testing.T) {


### PR DESCRIPTION
[TT-11274] update condition to reload spec (#6062)

<!-- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes the panic from 2nd gateway reload when one of the API
contains a JSVM middleware which is served using bundle.
In `shouldReloadSpec(existingSpec, newSpec *APISpec) bool` , we have
added the cases where an API spec needs to be reloaded. This should have
considered the case when middlewares served using bundle as well.
However this particular panic was happening from 2nd gateway reload
after gateway startup and the API was skipped from getting loaded to the
gateway. The reason being a disconnect between the values returned by
`shouldReloadSpec` at different locations in the code flow. It returns
`false` in
[MakeSpec](https://github.com/TykTechnologies/tyk/blob/6f0cf54672008a9ab30cd3a90746c309eab65f01/gateway/api_definition.go#L319),
but on later calls it will return true(from already populated middleware
section of previously existing spec, the load happens
[here](https://github.com/TykTechnologies/tyk/blob/6f0cf54672008a9ab30cd3a90746c309eab65f01/gateway/api_definition.go#L367)).
To fix this, `shouldReloadSpec` needs to be modified to return true when
a middleware is served via bundle

## Related Issue
https://tyktech.atlassian.net/browse/TT-11274

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why

[TT-11274]: https://tyktech.atlassian.net/browse/TT-11274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ