### PR TITLE
[TT-11371] Move leaky-bucket behind the dev build flag (5.3.0)

### DIFF
--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -405,15 +405,6 @@
     "jsvm_timeout": {
       "type": "integer"
     },
-    "enable_leaky_bucket_rate_limiter": {
-      "type": "boolean"
-    },
-    "enable_rate_limiter_storage": {
-      "type": "boolean"
-    },
-    "rate_limiter_storage": {
-      "$ref": "#/definitions/StorageOptions"
-    },
     "enable_non_transactional_rate_limiter": {
       "type": "boolean"
     },

--- a/config/development.go
+++ b/config/development.go
@@ -5,6 +5,15 @@ package config
 
 // DevelopmentConfig extends Config for development builds.
 type DevelopmentConfig struct {
+	// EnableLeakyBucketRateLimiter enables leaky bucket rate limiting.
+	//
+	// LeakyBucket will delay requests so they are processed in a FIFO
+	// style queue, ensuring a constant request rate and smoothing out
+	// traffic spikes. This comes at some cost to gateway instances, as
+	// the connections would be held for a longer time, instead of
+	// blocking the requests when they go over the defined rate limits.
+	EnableLeakyBucketRateLimiter bool `json:"enable_leaky_bucket_rate_limiter"`
+
 	// EnableTokenBucket enables token bucket rate limiting.
 	EnableTokenBucketRateLimiter bool `json:"enable_token_bucket_rate_limiter"`
 

--- a/config/rate_limit.go
+++ b/config/rate_limit.go
@@ -7,15 +7,6 @@ import (
 // RateLimit contains flags and configuration for controlling rate limiting behaviour.
 // It is embedded in the main config structure.
 type RateLimit struct {
-	// EnableLeakyBucketRateLimiter enables leaky bucket rate limiting.
-	//
-	// LeakyBucket will delay requests so they are processed in a FIFO
-	// style queue, ensuring a constant request rate and smoothing out
-	// traffic spikes. This comes at some cost to gateway instances, as
-	// the connections would be held for a longer time, instead of
-	// blocking the requests when they go over the defined rate limits.
-	EnableLeakyBucketRateLimiter bool `json:"enable_leaky_bucket_rate_limiter"`
-
 	// Redis based rate limiter with fixed window. Provides 100% rate limiting accuracy, but require two additional Redis roundtrip for each request.
 	EnableRedisRollingLimiter bool `json:"enable_redis_rolling_limiter"`
 
@@ -46,10 +37,6 @@ func (r *RateLimit) String() string {
 	info := "using transactions"
 	if r.EnableNonTransactionalRateLimiter {
 		info = "using pipeline"
-	}
-
-	if r.EnableLeakyBucketRateLimiter {
-		return "Leaky Bucket Rate Limiter enabled"
 	}
 
 	if r.EnableRedisRollingLimiter {

--- a/gateway/mw_rate_limiting_test.go
+++ b/gateway/mw_rate_limiting_test.go
@@ -240,8 +240,6 @@ func providerCustomRatelimitKey(t *testing.T, limiter string) {
 				globalConf.RateLimit.DRLEnableSentinelRateLimiter = true
 			case "NonTransactional":
 				globalConf.RateLimit.EnableNonTransactionalRateLimiter = true
-			case "LeakyBucket":
-				globalConf.RateLimit.EnableLeakyBucketRateLimiter = true
 			default:
 				t.Fatal("There is no such a rate limiter:", limiter)
 			}

--- a/gateway/mw_rate_limiting_test.go
+++ b/gateway/mw_rate_limiting_test.go
@@ -394,7 +394,3 @@ func TestMwRateLimiting_CustomRatelimitKeyDRL(t *testing.T) {
 func TestMwRateLimiting_CustomRatelimitKeyNonTransactional(t *testing.T) {
 	providerCustomRatelimitKey(t, "NonTransactional")
 }
-
-func TestMwRateLimiting_CustomRatelimitKeyEnableLeakyBucketRateLimiter(t *testing.T) {
-	providerCustomRatelimitKey(t, "LeakyBucket")
-}

--- a/internal/rate/rate_nodev.go
+++ b/internal/rate/rate_nodev.go
@@ -10,8 +10,5 @@ import (
 // LimiterKind returns the kind of rate limiter enabled by config.
 // This function is used for release builds.
 func LimiterKind(c *config.Config) (string, bool) {
-	if c.EnableLeakyBucketRateLimiter {
-		return LimitLeakyBucket, true
-	}
 	return "", false
 }


### PR DESCRIPTION
## **User description**
https://tyktech.atlassian.net/browse/TT-11371


___

## **Type**
enhancement, configuration changes


___

## **Description**
- Moved the Leaky Bucket rate limiter configuration behind a development build flag.
- Removed the Leaky Bucket rate limiter option from the main configuration, making it exclusive to development builds.
- Updated tests and internal logic to reflect the removal of the Leaky Bucket rate limiter from the main configuration.
- Adjusted CLI linter schema to remove references to the now development-only Leaky Bucket rate limiter.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>development.go</strong><dd><code>Add Leaky Bucket Rate Limiter to Development Config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/development.go
<li>Added <code>EnableLeakyBucketRateLimiter</code> configuration option to <br><code>DevelopmentConfig</code>.<br>


</details>
    

  </td>
  <td><a href="https:/TykTechnologies/tyk/pull/6073/files#diff-d2253d9377e5163d9de068a2df71738383fb97e0b07b64482404a83610cd53b8">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rate_limit.go</strong><dd><code>Remove Leaky Bucket Rate Limiter from Main Config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/rate_limit.go
<li>Removed <code>EnableLeakyBucketRateLimiter</code> from <code>RateLimit</code> struct.<br> <li> Adjusted string representation logic for rate limiters.<br>


</details>
    

  </td>
  <td><a href="https:/TykTechnologies/tyk/pull/6073/files#diff-375bf116f8d6527c50d7591d7cb01e8f821b22df4a4ca18b4da4c6f0d526f18e">+0/-13</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rate_nodev.go</strong><dd><code>Adjust Rate Limiter Handling for Release Builds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/rate/rate_nodev.go
- Removed Leaky Bucket rate limiter handling for release builds.



</details>
    

  </td>
  <td><a href="https:/TykTechnologies/tyk/pull/6073/files#diff-5c08f4f86a19b6cc3d2ee94a0253749acc927b606b1c56d6b73aee46547cf4f7">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>schema.json</strong><dd><code>Update CLI Linter Schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/linter/schema.json
- Removed JSON schema entries related to Leaky Bucket rate limiter.



</details>
    

  </td>
  <td><a href="https:/TykTechnologies/tyk/pull/6073/files#diff-103cec746d3e61d391c5a67c171963f66fea65d651d704d5540e60aa5d574f46">+0/-9</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mw_rate_limiting_test.go</strong><dd><code>Update Rate Limiting Middleware Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_rate_limiting_test.go
- Removed test case setup for Leaky Bucket rate limiter.



</details>
    

  </td>
  <td><a href="https:/TykTechnologies/tyk/pull/6073/files#diff-7cf2199231924147d538ba7ad576a48a3c0e691852077e147c9b2d86ba9b7c4d">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

