### PR TITLE
Set pipefail

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,6 +234,7 @@ jobs:
         working-directory: auto
         id: test_execution
         run: |
+          set -o pipefail
           echo "### API tests ${{ matrix.db }} ${{ matrix.conf }}" >> $GITHUB_STEP_SUMMARY
           if docker run --rm --network auto_default --env-file pytest.env -v ${{ github.workspace }}/reports:/app/reports \
              ${{ steps.ecr.outputs.registry }}/tyk-automated-tests:${{ needs.test-controller.outputs.gd_tag }} \


### PR DESCRIPTION
## **User description**
This PR fixs a critical bug on regresion tests not failing properly.


___

## **Type**
bug_fix


___

## **Description**
- Added `set -o pipefail` in the GitHub Actions workflow to address a critical bug where regression tests were not failing as expected. This ensures that the pipeline will fail if any command within it fails, improving the reliability of the test suite.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Ensure Regression Tests Fail Properly by Setting Pipefail</code></dd></summary>
<hr>

.github/workflows/release.yml
<li>Added <code>set -o pipefail</code> to ensure the pipeline fails if any command in a <br>pipeline fails.<br>


</details>
    

  </td>
  <td><a href="https:/TykTechnologies/tyk/pull/6074/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

