### PR TITLE
[TT-11185] release docs 5.3.0 update

### DIFF
--- a/apidef/oas/authentication.go
+++ b/apidef/oas/authentication.go
@@ -314,7 +314,7 @@ func (as *AuthSources) ExtractTo(authConfig *apidef.AuthConfig) {
 
 // AuthSource defines an authentication source.
 type AuthSource struct {
-	// Enabled enables the auth source.
+	// Enabled activates the auth source.
 	// Tyk classic API definition: `auth_configs[X].use_param/use_cookie`
 	Enabled bool `bson:"enabled" json:"enabled"` // required
 	// Name is the name of the auth source.
@@ -422,7 +422,7 @@ type ScopeToPolicy struct {
 
 // HMAC holds the configuration for the HMAC authentication mode.
 type HMAC struct {
-	// Enabled enables the HMAC authentication mode.
+	// Enabled activates the HMAC authentication mode.
 	// Tyk classic API definition: `enable_signature_checking`
 	Enabled bool `bson:"enabled" json:"enabled"` // required
 
@@ -476,7 +476,7 @@ func (h *HMAC) ExtractTo(api *apidef.APIDefinition) {
 
 // OIDC contains configuration for the OIDC authentication mode.
 type OIDC struct {
-	// Enabled enables the OIDC authentication mode.
+	// Enabled activates the OIDC authentication mode.
 	//
 	// Tyk classic API definition: `use_openid`
 	Enabled bool `bson:"enabled" json:"enabled"` // required
@@ -588,7 +588,7 @@ type ClientToPolicy struct {
 
 // CustomPluginAuthentication holds configuration for custom plugins.
 type CustomPluginAuthentication struct {
-	// Enabled enables the CustomPluginAuthentication authentication mode.
+	// Enabled activates the CustomPluginAuthentication authentication mode.
 	//
 	// Tyk classic API definition: `enable_coprocess_auth`/`use_go_plugin_auth`.
 	Enabled bool `bson:"enabled" json:"enabled"` // required
@@ -651,7 +651,7 @@ func (c *CustomPluginAuthentication) ExtractTo(api *apidef.APIDefinition) {
 
 // AuthenticationPlugin holds the configuration for custom authentication plugin.
 type AuthenticationPlugin struct {
-	// Enabled enables custom authentication plugin.
+	// Enabled activates custom authentication plugin.
 	Enabled bool `bson:"enabled" json:"enabled"` // required.
 	// FunctionName is the name of authentication method.
 	FunctionName string `bson:"functionName" json:"functionName"` // required.
@@ -758,7 +758,7 @@ func (id *IDExtractorConfig) ExtractTo(api *apidef.APIDefinition) {
 
 // IDExtractor configures ID Extractor.
 type IDExtractor struct {
-	// Enabled enables ID extractor with coprocess authentication.
+	// Enabled activates ID extractor with coprocess authentication.
 	Enabled bool `bson:"enabled" json:"enabled"` // required
 	// Source is the source from which ID to be extracted from.
 	Source apidef.IdExtractorSource `bson:"source" json:"source"` // required

--- a/apidef/oas/authentication.go
+++ b/apidef/oas/authentication.go
@@ -655,7 +655,7 @@ type AuthenticationPlugin struct {
 	Enabled bool `bson:"enabled" json:"enabled"` // required.
 	// FunctionName is the name of authentication method.
 	FunctionName string `bson:"functionName" json:"functionName"` // required.
-	// Path is the path to shared object file in case of gopluign mode or path to js code in case of otto auth plugin.
+	// Path is the path to shared object file in case of goplugin mode or path to JS code in case of otto auth plugin.
 	Path string `bson:"path" json:"path"`
 	// RawBodyOnly if set to true, do not fill body in request or response object.
 	RawBodyOnly bool `bson:"rawBodyOnly,omitempty" json:"rawBodyOnly,omitempty"`

--- a/apidef/oas/authentication.go
+++ b/apidef/oas/authentication.go
@@ -429,14 +429,16 @@ type HMAC struct {
 	// AuthSources contains authentication token source configuration (header, cookie, query).
 	AuthSources `bson:",inline" json:",inline"`
 
-	// AllowedAlgorithms is the array of HMAC algorithms which are allowed. Tyk supports the following HMAC algorithms:
+	// AllowedAlgorithms is the array of HMAC algorithms which are allowed.
+	//
+	// Tyk supports the following HMAC algorithms:
 	//
 	// - `hmac-sha1`
 	// - `hmac-sha256`
 	// - `hmac-sha384`
 	// - `hmac-sha512`
 	//
-	// and reads the value from algorithm header.
+	// and reads the value from the algorithm header.
 	//
 	// Tyk classic API definition: `hmac_allowed_algorithms`
 	AllowedAlgorithms []string `bson:"allowedAlgorithms,omitempty" json:"allowedAlgorithms,omitempty"`
@@ -489,7 +491,7 @@ type OIDC struct {
 	// Tyk classic API definition: `openid_options.segregate_by_client`.
 	SegregateByClientId bool `bson:"segregateByClientId,omitempty" json:"segregateByClientId,omitempty"`
 
-	// Providers contains a list of authorised providers and their Client IDs, and matched policies.
+	// Providers contains a list of authorised providers, their Client IDs and matched policies.
 	//
 	// Tyk classic API definition: `openid_options.providers`.
 	Providers []Provider `bson:"providers,omitempty" json:"providers,omitempty"`

--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -1080,7 +1080,11 @@ func (c CustomPlugins) ExtractTo(mwDefs []apidef.MiddlewareDefinition) {
 	}
 }
 
-// PrePlugin configures pre stage plugins.
+// PrePlugin configures pre-request plugins.
+//
+// Pre-request plugins are executed before the request is sent to the
+// upstream target and before any authentication information is extracted
+// from the header or parameter list of the request.
 type PrePlugin struct {
 	// Plugins configures custom plugins to be run on pre authentication stage.
 	// The plugins would be executed in the order of configuration in the list.

--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -1042,7 +1042,7 @@ type CustomPlugin struct {
 	Enabled bool `bson:"enabled" json:"enabled"` // required.
 	// FunctionName is the name of authentication method.
 	FunctionName string `bson:"functionName" json:"functionName"` // required.
-	// Path is the path to shared object file in case of gopluign mode or path to js code in case of otto auth plugin.
+	// Path is the path to shared object file in case of goplugin mode or path to JS code in case of otto auth plugin.
 	Path string `bson:"path" json:"path"`
 	// RawBodyOnly if set to true, do not fill body in request or response object.
 	RawBodyOnly bool `bson:"rawBodyOnly,omitempty" json:"rawBodyOnly,omitempty"`
@@ -1200,11 +1200,11 @@ func (p *ResponsePlugin) ExtractTo(api *apidef.APIDefinition) {
 type VirtualEndpoint struct {
 	// Enabled enables virtual endpoint.
 	Enabled bool `bson:"enabled" json:"enabled"` // required.
-	// Name is the name of js function.
+	// Name is the name of JS function.
 	Name string `bson:"name" json:"name"` // required.
-	// Path is the path to js file.
+	// Path is the path to JS file.
 	Path string `bson:"path,omitempty" json:"path,omitempty"`
-	// Body is the js function to execute encoded in base64 format.
+	// Body is the JS function to execute encoded in base64 format.
 	Body string `bson:"body,omitempty" json:"body,omitempty"`
 	// ProxyOnError proxies if virtual endpoint errors out.
 	ProxyOnError bool `bson:"proxyOnError,omitempty" json:"proxyOnError,omitempty"`

--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -277,7 +277,7 @@ func (g *Global) ExtractTo(api *apidef.APIDefinition) {
 
 // PluginConfigData configures config data for custom plugins.
 type PluginConfigData struct {
-	// Enabled enables custom plugin config data.
+	// Enabled activates custom plugin config data.
 	Enabled bool `bson:"enabled" json:"enabled"` // required.
 
 	// Value is the value of custom plugin config data.
@@ -365,7 +365,7 @@ func (p *PluginConfig) ExtractTo(api *apidef.APIDefinition) {
 
 // PluginBundle holds configuration for custom plugins.
 type PluginBundle struct {
-	// Enabled enables the custom plugin bundles.
+	// Enabled activates the custom plugin bundles.
 	//
 	// Tyk classic API definition: `custom_middleware_bundle_disabled`
 	Enabled bool `bson:"enabled" json:"enabled"` // required.
@@ -885,7 +885,7 @@ type Header struct {
 
 // TransformRequestMethod holds configuration for rewriting request methods.
 type TransformRequestMethod struct {
-	// Enabled enables Method Transform for the given path and method.
+	// Enabled activates Method Transform for the given path and method.
 	Enabled bool `bson:"enabled" json:"enabled"`
 	// ToMethod is the http method value to which the method of an incoming request will be transformed.
 	ToMethod string `bson:"toMethod" json:"toMethod"`
@@ -905,7 +905,7 @@ func (tm *TransformRequestMethod) ExtractTo(meta *apidef.MethodTransformMeta) {
 
 // TransformBody holds configuration about request/response body transformations.
 type TransformBody struct {
-	// Enabled enables transform request/request body middleware.
+	// Enabled activates transform request/request body middleware.
 	Enabled bool `bson:"enabled" json:"enabled"`
 	// Format of the request/response body, xml or json.
 	Format apidef.RequestInputType `bson:"format" json:"format"`
@@ -942,7 +942,7 @@ func (tr *TransformBody) ExtractTo(meta *apidef.TemplateMeta) {
 
 // TransformHeaders holds configuration about request/response header transformations.
 type TransformHeaders struct {
-	// Enabled enables Header Transform for the given path and method.
+	// Enabled activates Header Transform for the given path and method.
 	Enabled bool `bson:"enabled" json:"enabled"`
 	// Remove specifies header names to be removed from the request/response.
 	Remove []string `bson:"remove,omitempty" json:"remove,omitempty"`
@@ -1038,7 +1038,7 @@ func (et *EnforceTimeout) ExtractTo(meta *apidef.HardTimeoutMeta) {
 
 // CustomPlugin configures custom plugin.
 type CustomPlugin struct {
-	// Enabled enables the custom pre plugin.
+	// Enabled activates the custom pre plugin.
 	Enabled bool `bson:"enabled" json:"enabled"` // required.
 	// FunctionName is the name of authentication method.
 	FunctionName string `bson:"functionName" json:"functionName"` // required.
@@ -1198,7 +1198,7 @@ func (p *ResponsePlugin) ExtractTo(api *apidef.APIDefinition) {
 
 // VirtualEndpoint contains virtual endpoint configuration.
 type VirtualEndpoint struct {
-	// Enabled enables virtual endpoint.
+	// Enabled activates virtual endpoint.
 	Enabled bool `bson:"enabled" json:"enabled"` // required.
 	// Name is the name of JS function.
 	Name string `bson:"name" json:"name"` // required.
@@ -1244,7 +1244,7 @@ type EndpointPostPlugins []EndpointPostPlugin
 
 // EndpointPostPlugin contains endpoint level post plugin configuration.
 type EndpointPostPlugin struct {
-	// Enabled enables post plugin.
+	// Enabled activates post plugin.
 	Enabled bool `bson:"enabled" json:"enabled"` // required.
 	// Name is the name of plugin function to be executed.
 	Name string `bson:"name" json:"name"` // required.
@@ -1279,7 +1279,7 @@ func (e EndpointPostPlugins) ExtractTo(meta *apidef.GoPluginMeta) {
 // CircuitBreaker holds configuration for the circuit breaker middleware.
 // Tyk classic API definition: `version_data.versions..extended_paths.circuit_breakers[*]`.
 type CircuitBreaker struct {
-	// Enabled enables the Circuit Breaker functionality.
+	// Enabled activates the Circuit Breaker functionality.
 	// Tyk classic API definition: `version_data.versions..extended_paths.circuit_breakers[*].disabled`.
 	Enabled bool `bson:"enabled" json:"enabled"`
 	// Threshold is the proportion from each `sampleSize` requests that must fail for the breaker to be tripped. This must be a value between 0.0 and 1.0. If `sampleSize` is 100 then a threshold of 0.4 means that the breaker will be tripped if 40 out of every 100 requests fails.
@@ -1316,7 +1316,7 @@ func (cb *CircuitBreaker) ExtractTo(circuitBreaker *apidef.CircuitBreakerMeta) {
 
 // RequestSizeLimit limits the maximum allowed size of the request body in bytes.
 type RequestSizeLimit struct {
-	// Enabled enables the Request Size Limit functionality.
+	// Enabled activates the Request Size Limit functionality.
 	Enabled bool `bson:"enabled" json:"enabled"`
 	// Value is the maximum allowed size of the request body in bytes.
 	Value int64 `bson:"value" json:"value"`

--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -1051,7 +1051,7 @@ type CustomPlugin struct {
 	RequireSession bool `bson:"requireSession,omitempty" json:"requireSession,omitempty"`
 }
 
-// CustomPlugins is a list of CustomPlugin.
+// CustomPlugins is a list of CustomPlugin objects.
 type CustomPlugins []CustomPlugin
 
 // Fill fills CustomPlugins from supplied Middleware definitions.

--- a/apidef/oas/operation.go
+++ b/apidef/oas/operation.go
@@ -711,7 +711,7 @@ func (s *OAS) fillOASValidateRequest(metas []apidef.ValidatePathMeta) {
 
 // MockResponse configures the mock responses.
 type MockResponse struct {
-	// Enabled enables the mock response middleware.
+	// Enabled activates the mock response middleware.
 	Enabled bool `bson:"enabled" json:"enabled"`
 	// Code is the HTTP response code that will be returned.
 	Code int `bson:"code,omitempty" json:"code,omitempty"`
@@ -723,9 +723,9 @@ type MockResponse struct {
 	FromOASExamples *FromOASExamples `bson:"fromOASExamples,omitempty" json:"fromOASExamples,omitempty"`
 }
 
-// FromOASExamples configures mock responses should be returned from OAS example responses.
+// FromOASExamples configures mock responses that should be returned from OAS example responses.
 type FromOASExamples struct {
-	// Enabled enables getting a mock response from OAS examples or schemas documented in OAS.
+	// Enabled activates getting a mock response from OAS examples or schemas documented in OAS.
 	Enabled bool `bson:"enabled" json:"enabled"`
 	// Code is the default HTTP response code that the gateway reads from the path responses documented in OAS.
 	Code int `bson:"code,omitempty" json:"code,omitempty"`

--- a/apidef/oas/security.go
+++ b/apidef/oas/security.go
@@ -409,20 +409,27 @@ type OAuthProvider struct {
 type JWTValidation struct {
 	// Enabled enables OAuth access token validation by introspection to a third party.
 	Enabled bool `bson:"enabled" json:"enabled"`
+
 	// SigningMethod to verify signing method used in jwt - allowed values HMAC/RSA/ECDSA.
 	SigningMethod string `bson:"signingMethod" json:"signingMethod"`
-	// Source is the secret to verify signature, it could be one among:
+
+	// Source is the secret to verify signature. Valid values are:
+	//
 	// - a base64 encoded static secret,
 	// - a valid JWK URL in plain text,
 	// - a valid JWK URL in base64 encoded format.
 	Source string `bson:"source" json:"source"`
+
 	// IdentityBaseField is the identity claim name.
 	IdentityBaseField string `bson:"identityBaseField,omitempty" json:"identityBaseField,omitempty"`
-	// IssuedAtValidationSkew is the clock skew to be considered while validating iat claim.
+
+	// IssuedAtValidationSkew is the clock skew to be considered while validating the iat claim.
 	IssuedAtValidationSkew uint64 `bson:"issuedAtValidationSkew,omitempty" json:"issuedAtValidationSkew,omitempty"`
-	// NotBeforeValidationSkew is the clock skew to be considered while validating nbf claim.
+
+	// NotBeforeValidationSkew is the clock skew to be considered while validating the nbf claim.
 	NotBeforeValidationSkew uint64 `bson:"notBeforeValidationSkew,omitempty" json:"notBeforeValidationSkew,omitempty"`
-	// ExpiresAtValidationSkew is the clock skew to be considered while validating exp claim.
+
+	// ExpiresAtValidationSkew is the clock skew to be considered while validating the exp claim.
 	ExpiresAtValidationSkew uint64 `bson:"expiresAtValidationSkew,omitempty" json:"expiresAtValidationSkew,omitempty"`
 }
 

--- a/apidef/oas/security.go
+++ b/apidef/oas/security.go
@@ -460,7 +460,7 @@ type Introspection struct {
 	URL string `bson:"url" json:"url"`
 	// ClientID is the public identifier for the client, acquired from the third party.
 	ClientID string `bson:"clientId" json:"clientId"`
-	// ClientSecret is a secret known only to the client and the authorization server, acquired from the third party.
+	// ClientSecret is a secret known only to the client and the authorisation server, acquired from the third party.
 	ClientSecret string `bson:"clientSecret" json:"clientSecret"`
 	// IdentityBaseField is the key showing where to find the user id in the claims. If it is empty, the `sub` key is looked at.
 	IdentityBaseField string `bson:"identityBaseField,omitempty" json:"identityBaseField,omitempty"`

--- a/apidef/oas/security.go
+++ b/apidef/oas/security.go
@@ -24,7 +24,7 @@ const (
 
 // Token holds the values related to authentication tokens.
 type Token struct {
-	// Enabled enables the token based authentication mode.
+	// Enabled activates the token based authentication mode.
 	//
 	// Tyk classic API definition: `auth_configs["authToken"].use_standard_auth`
 	Enabled bool `bson:"enabled" json:"enabled"` // required
@@ -207,7 +207,7 @@ func (s *OAS) extractJWTTo(api *apidef.APIDefinition, name string) {
 
 // Basic type holds configuration values related to http basic authentication.
 type Basic struct {
-	// Enabled enables the basic authentication mode.
+	// Enabled activates the basic authentication mode.
 	// Tyk classic API definition: `use_basic_auth`
 	Enabled     bool `bson:"enabled" json:"enabled"` // required
 	AuthSources `bson:",inline" json:",inline"`
@@ -296,7 +296,7 @@ func (s *OAS) extractBasicTo(api *apidef.APIDefinition, name string) {
 
 // ExtractCredentialsFromBody configures extracting credentials from the request body.
 type ExtractCredentialsFromBody struct {
-	// Enabled enables extracting credentials from body.
+	// Enabled activates extracting credentials from body.
 	// Tyk classic API definition: `basic_auth.extract_from_body`
 	Enabled bool `bson:"enabled" json:"enabled"` // required
 	// UserRegexp is the regex for username e.g. `<User>(.*)</User>`.
@@ -407,7 +407,7 @@ type OAuthProvider struct {
 }
 
 type JWTValidation struct {
-	// Enabled enables OAuth access token validation by introspection to a third party.
+	// Enabled activates OAuth access token validation by introspection to a third party.
 	Enabled bool `bson:"enabled" json:"enabled"`
 
 	// SigningMethod to verify signing method used in jwt - allowed values HMAC/RSA/ECDSA.
@@ -454,7 +454,7 @@ func (j *JWTValidation) ExtractTo(jwt *apidef.JWTValidation) {
 }
 
 type Introspection struct {
-	// Enabled enables OAuth access token validation by introspection to a third party.
+	// Enabled activates OAuth access token validation by introspection to a third party.
 	Enabled bool `bson:"enabled" json:"enabled"`
 	// URL is the URL of the third party provider's introspection endpoint.
 	URL string `bson:"url" json:"url"`
@@ -498,7 +498,7 @@ func (i *Introspection) ExtractTo(intros *apidef.Introspection) {
 }
 
 type IntrospectionCache struct {
-	// Enabled enables the caching mechanism for introspection responses.
+	// Enabled activates the caching mechanism for introspection responses.
 	Enabled bool `bson:"enabled" json:"enabled"`
 	// Timeout is the duration in seconds of how long the cached value stays.
 	// For introspection caching, it is suggested to use a short interval.

--- a/apidef/oas/server.go
+++ b/apidef/oas/server.go
@@ -144,7 +144,7 @@ type ListenPath struct {
 
 	// Strip removes the inbound listen path (as accessed by the client) when generating the outgoing request (to the upstream service).
 	//
-	// For example, a scenario where the Tyk base address is `http://acme.com/', the listen path is `example/` and the upstream URL is `http://httpbin.org/`:
+	// For example, consider the scenario where the Tyk base address is `http://acme.com/', the listen path is `example/` and the upstream URL is `http://httpbin.org/`:
 	//
 	// - If the client application sends a request to `http://acme.com/example/get` then the request will be proxied to `http://httpbin.org/example/get`
 	// - If stripListenPath is set to `true`, the `example` listen path is removed and the request would be proxied to `http://httpbin.org/get`.

--- a/apidef/oas/server.go
+++ b/apidef/oas/server.go
@@ -212,7 +212,7 @@ type Domain struct {
 	// Name is the name of the domain.
 	Name string `bson:"name" json:"name"`
 	// Certificates defines a field for specifying certificate IDs or file paths
-	// that the Gateway can utilize to dynamically load certificates for your custom domain.
+	// that the Gateway can utilise to dynamically load certificates for your custom domain.
 	//
 	// Tyk classic API definition: `certificates`
 	Certificates []string `bson:"certificates,omitempty" json:"certificates,omitempty"`

--- a/apidef/oas/server.go
+++ b/apidef/oas/server.go
@@ -8,7 +8,7 @@ import (
 type Server struct {
 	// ListenPath is the base path on Tyk to which requests for this API should
 	// be sent. Tyk listens for any requests coming into the host at this
-	// path, on the port that Tyk is configured to run on, and processes these
+	// path, on the port that Tyk is configured to run on and processes these
 	// accordingly.
 	ListenPath ListenPath `bson:"listenPath" json:"listenPath"` // required
 
@@ -135,14 +135,14 @@ func (s *Server) ExtractTo(api *apidef.APIDefinition) {
 
 // ListenPath is the base path on Tyk to which requests for this API
 // should be sent. Tyk listens out for any requests coming into the host at
-// this path, on the port that Tyk is configured to run on, and processes
+// this path, on the port that Tyk is configured to run on and processes
 // these accordingly.
 type ListenPath struct {
 	// Value is the value of the listen path e.g. `/api/` or `/` or `/httpbin/`.
 	// Tyk classic API definition: `proxy.listen_path`
 	Value string `bson:"value" json:"value"` // required
 
-	// Strip removes the inbound listen path (as accessed by the client) when generating the outgoing request (to the upstream service).
+	// Strip removes the inbound listen path (as accessed by the client) when generating the outbound request for the upstream service.
 	//
 	// For example, consider the scenario where the Tyk base address is `http://acme.com/', the listen path is `example/` and the upstream URL is `http://httpbin.org/`:
 	//

--- a/apidef/oas/server.go
+++ b/apidef/oas/server.go
@@ -167,7 +167,7 @@ func (lp *ListenPath) ExtractTo(api *apidef.APIDefinition) {
 
 // ClientCertificates contains the configurations related to establishing static mutual TLS between the client and Tyk.
 type ClientCertificates struct {
-	// Enabled enables static mTLS for the API.
+	// Enabled activates static mTLS for the API.
 	Enabled bool `bson:"enabled" json:"enabled"`
 	// Allowlist is the list of client certificates which are allowed.
 	Allowlist []string `bson:"allowlist" json:"allowlist"`
@@ -187,7 +187,7 @@ func (cc *ClientCertificates) ExtractTo(api *apidef.APIDefinition) {
 
 // GatewayTags holds a list of segment tags that should apply for a gateway.
 type GatewayTags struct {
-	// Enabled enables use of segment tags.
+	// Enabled activates use of segment tags.
 	Enabled bool `bson:"enabled" json:"enabled"`
 	// Tags is a list of segment tags
 	Tags []string `bson:"tags" json:"tags"`
@@ -234,7 +234,7 @@ func (cd *Domain) Fill(api apidef.APIDefinition) {
 
 // DetailedActivityLogs holds the configuration related to recording detailed analytics.
 type DetailedActivityLogs struct {
-	// Enabled enables/disables detailed activity logs.
+	// Enabled activates detailed activity logs.
 	//
 	// Tyk classic API definition: `enable_detailed_recording`
 	Enabled bool `bson:"enabled" json:"enabled"`
@@ -252,7 +252,7 @@ func (d *DetailedActivityLogs) Fill(api apidef.APIDefinition) {
 
 // DetailedTracing holds the configuration of the detailed tracing.
 type DetailedTracing struct {
-	// Enabled enables detailed tracing.
+	// Enabled activates detailed tracing.
 	Enabled bool `bson:"enabled" json:"enabled"`
 }
 

--- a/apidef/oas/upstream.go
+++ b/apidef/oas/upstream.go
@@ -133,7 +133,7 @@ func (u *Upstream) ExtractTo(api *apidef.APIDefinition) {
 
 // ServiceDiscovery holds configuration required for service discovery.
 type ServiceDiscovery struct {
-	// Enabled enables Service Discovery.
+	// Enabled activates Service Discovery.
 	//
 	// Tyk classic API definition: `service_discovery.use_discovery_service`
 	Enabled bool `bson:"enabled" json:"enabled"` // required
@@ -332,7 +332,7 @@ func (t *Test) ExtractTo(uptimeTests *apidef.UptimeTests) {
 
 // MutualTLS contains the configuration for establishment of mutual TLS between Tyk and the upstream server.
 type MutualTLS struct {
-	// Enabled enables/disables upstream mutual TLS for the API.
+	// Enabled activates upstream mutual TLS for the API.
 	// Tyk classic API definition: `upstream_certificates_disabled`
 	Enabled bool `bson:"enabled" json:"enabled"`
 
@@ -465,7 +465,7 @@ func (cp *CertificatePinning) ExtractTo(api *apidef.APIDefinition) {
 // The API-level rate limit applies a base-line limit on the frequency of requests to the upstream service for all endpoints. The frequency of requests is configured in two parts: the time interval and the number of requests that can be made during each interval.
 // Tyk classic API definition: `global_rate_limit`.
 type RateLimit struct {
-	// Enabled enables/disables API level rate limiting for this API.
+	// Enabled activates API level rate limiting for this API.
 	//
 	// Tyk classic API definition: `!disable_rate_limit`.
 	Enabled bool `json:"enabled" bson:"enabled"`

--- a/apidef/oas/upstream.go
+++ b/apidef/oas/upstream.go
@@ -248,7 +248,7 @@ type ServiceDiscoveryCache struct {
 	Timeout int64 `bson:"timeout,omitempty" json:"timeout,omitempty"`
 }
 
-// CacheOptions returns the timeout value in effect, and a bool if cache is enabled.
+// CacheOptions returns the timeout value in effect and a bool if cache is enabled.
 func (sd *ServiceDiscovery) CacheOptions() (int64, bool) {
 	if sd.Cache != nil {
 		return sd.Cache.Timeout, sd.Cache.Enabled
@@ -481,7 +481,7 @@ type RateLimit struct {
 	Rate int `json:"rate" bson:"rate"`
 	// Per defines the time interval for rate limiting using shorthand notation.
 	// The value of Per is a string that specifies the interval in a compact form,
-	// where hours, minutes, and seconds are denoted by 'h', 'm', and 's' respectively.
+	// where hours, minutes and seconds are denoted by 'h', 'm' and 's' respectively.
 	// Multiple units can be combined to represent the duration.
 	//
 	// Examples of valid shorthand notations:
@@ -491,7 +491,7 @@ type RateLimit struct {
 	// - "1m29s": one minute and twenty-nine seconds
 	// - "1h30m" : one hour and thirty minutes
 	//
-	// An empty value is interpreted as "0s", implying no rate limiting interval effectively disabling the API-level rate limit.
+	// An empty value is interpreted as "0s", implying no rate limiting interval, which disables the API-level rate limit.
 	// It's important to format the string correctly, as invalid formats will
 	// be considered as 0s/empty.
 	//

--- a/apidef/oas/url_rewrite.go
+++ b/apidef/oas/url_rewrite.go
@@ -10,7 +10,7 @@ import (
 // URLRewrite configures URL rewriting.
 // Tyk classic API definition: `version_data.versions[].extended_paths.url_rewrite`.
 type URLRewrite struct {
-	// Enabled enables URL rewriting if set to true.
+	// Enabled activates URL rewriting if set to true.
 	Enabled bool `bson:"enabled" json:"enabled"`
 
 	// Pattern is the regular expression against which the request URL is compared for the primary rewrite check.
@@ -109,9 +109,13 @@ type URLRewriteRule struct {
 	// - `requestContext`, match pattern against request context
 	In URLRewriteInput `bson:"in" json:"in"`
 
-	// Name is the index in the input identified in `in` that should be used to
-	// locate the value for this rule. When `in` is set to `requestBody`, the
-	// value is ignored.
+	// Name is the index in the value declared inside `in`.
+	//
+	// Example: for `in=query`, `name=q`, the parameter `q` would
+	// be read from the request query parameters.
+	//
+	// The value of name is unused when `in` is set to `requestBody`,
+	// as the request body is a single value and not a set of values.
 	Name string `bson:"name,omitempty" json:"name,omitempty"`
 
 	// Pattern is the regular expression against which the `in` values are compared for this rule check.


### PR DESCRIPTION
This PR addresses feedback raised up in DX review.

- fixes typos
- removes oxford comma
- rewords some unclear docs
- adds docs
- consistent docs for `enabled` fields