### PR TITLE
[TT-11389]: moved graphql span attributes

### DIFF
--- a/.taskfiles/opentelemetry.yml
+++ b/.taskfiles/opentelemetry.yml
@@ -38,8 +38,10 @@ tasks:
       - tracetest test run -d ./ci/tests/tracing/scenarios/tyk_versioned_not_detailed_200.yml -w -o pretty
       - tracetest test run -d ./ci/tests/tracing/scenarios/tyk_versioned_not_detailed_403.yml -w -o pretty
       - tracetest test run -d ./ci/tests/tracing/scenarios/tyk_test-graphql-tracing_200.yml -w -o pretty
+      - tracetest test run -d ./ci/tests/tracing/scenarios/tyk_test-graphql-tracing_400.yml -w -o pretty
       - tracetest test run -d ./ci/tests/tracing/scenarios/tyk_test-graphql-tracing-invalid_404.yml -w -o pretty
       - tracetest test run -d ./ci/tests/tracing/scenarios/tyk_test-graphql-detailed-tracing-disabled_200.yaml -w -o pretty
+      - tracetest test run -d ./ci/tests/tracing/scenarios/tyk_test-graphql-detailed-tracing-disabled_400.yaml -w -o pretty
 
   teardown:
     desc: "teardown e2e opentelemetry tests enviroment"

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ mongo-shell:
 .PHONY: docker docker-std
 
 docker:
-	docker build --platform ${BUILD_PLATFORM} --rm -t internal/tyk-gateway --squash .
+	docker build --platform ${BUILD_PLATFORM} --rm -t internal/tyk-gateway .
 
 docker-std: build
 	docker build --platform ${BUILD_PLATFORM} --no-cache -t internal/tyk-gateway:std -f ci/Dockerfile.std .

--- a/ci/tests/tracing/scenarios/tyk_test-graphql-detailed-tracing-disabled_400.yaml
+++ b/ci/tests/tracing/scenarios/tyk_test-graphql-detailed-tracing-disabled_400.yaml
@@ -1,0 +1,21 @@
+type: Test
+spec:
+  id: QG5wPvASg
+  name: Test Graphql Detailed Tracing Disabled - Invalid Request
+  description: Test Graphql Detailed Tracing Disabled - Invalid Request
+  trigger:
+    type: http
+    httpRequest:
+      method: POST
+      url: tyk:8080/test-graphql-detailed-tracing-disabled/test-graphql-detailed-tracing-disabled
+      body: "{\n  \"query\": \"query test {\\n  country(code: \\\"NG\\\"){\\n    nam\\n  }\\n}\",\n  \"operationName\": \"test\"\n}"
+      headers:
+        - key: Content-Type
+          value: application/json
+  specs:
+    - selector: span[tracetest.span.type="general" name="GraphqlMiddleware Validation"]
+      name: Ensure graphql spans still exist
+      assertions:
+        - "attr:graphql.document = 'query test {\n  country(code: \"NG\"){\n    nam\n  }\n}'"
+        - attr:graphql.operation.name = "test"
+        - attr:graphql.operation.type = "query"

--- a/ci/tests/tracing/scenarios/tyk_test-graphql-tracing_200.yml
+++ b/ci/tests/tracing/scenarios/tyk_test-graphql-tracing_200.yml
@@ -23,13 +23,13 @@ spec:
       name: Make sure there are 3 subspans for graphql engine
       assertions:
         - attr:tracetest.selected_spans.count = 3
-    - selector: span[tracetest.span.type="general" name="GraphqlMiddleware Validation"]
+    - selector: span[tracetest.span.type="general" name="ValidateRequest"]
       name: Ensure Graphql Middleware Validation Exists And Spans correct
       assertions:
-        - attr:tracetest.span.name  =  "GraphqlMiddleware Validation"
-        - attr:graphql.operation.type     =     "query"
-        - attr:graphql.operation.name     =     "test"
-        - "attr:graphql.document = 'query test {\n  country(code: \"NG\"){\n    name\n  }\n}'"
+        - attr:tracetest.span.name   =   "ValidateRequest"
+        - attr:graphql.operation.type      =      "query"
+        - attr:graphql.operation.name      =      "test"
+        - "attr:graphql.document  =  'query test {\n  country(code: \"NG\"){\n    name\n  }\n}'"
     - selector: span[tracetest.span.type="general" name="ResolvePlan"]
       name: Ensure resolve plan exists
       assertions:

--- a/ci/tests/tracing/scenarios/tyk_test-graphql-tracing_200.yml
+++ b/ci/tests/tracing/scenarios/tyk_test-graphql-tracing_200.yml
@@ -24,16 +24,13 @@ spec:
       assertions:
         - attr:tracetest.selected_spans.count = 3
     - selector: span[tracetest.span.type="general" name="GraphqlMiddleware Validation"]
-      name: Ensure Graphql Middleware Validation Exists
+      name: Ensure Graphql Middleware Validation Exists And Spans correct
       assertions:
         - attr:tracetest.span.name  =  "GraphqlMiddleware Validation"
+        - attr:graphql.operation.type     =     "query"
+        - attr:graphql.operation.name     =     "test"
+        - "attr:graphql.document = 'query test {\n  country(code: \"NG\"){\n    name\n  }\n}'"
     - selector: span[tracetest.span.type="general" name="ResolvePlan"]
       name: Ensure resolve plan exists
       assertions:
         - attr:name = "ResolvePlan"
-    - selector: span[tracetest.span.type="general" name="ValidateRequest"]
-      name: ensure graphql span keys are correct
-      assertions:
-        - attr:graphql.operation.type     =     "query"
-        - attr:graphql.operation.name     =     "test"
-        - "attr:graphql.document = 'query test {\n  country(code: \"NG\"){\n    name\n  }\n}'"

--- a/ci/tests/tracing/scenarios/tyk_test-graphql-tracing_400.yml
+++ b/ci/tests/tracing/scenarios/tyk_test-graphql-tracing_400.yml
@@ -1,0 +1,14 @@
+type: Test
+spec:
+  id: IjF4ED0SR
+  name: test graphql tracing bad request
+  description: test the graphql tracing that will trigger a bad request
+  trigger:
+    type: http
+    httpRequest:
+      method: POST
+      url: tyk:8080/test-graphql-tracing/test-graphql-tracing
+      body: "{\n  \"query\": \"query test {\\n  country(code: \\\"NG\\\"){\\n    nam\\n  }\\n}\",\n  \"operationName\": \"test\"\n}"
+      headers:
+        - key: Content-Type
+          value: application/json

--- a/ci/tests/tracing/scenarios/tyk_test-graphql-tracing_400.yml
+++ b/ci/tests/tracing/scenarios/tyk_test-graphql-tracing_400.yml
@@ -12,3 +12,9 @@ spec:
       headers:
         - key: Content-Type
           value: application/json
+  specs:
+    - selector: span[tracetest.span.type="general" name="NormalizeRequest"]
+      assertions:
+        - "attr:graphql.document = 'query test {\n  country(code: \"NG\"){\n    nam\n  }\n}'"
+        - attr:graphql.operation.name = "test"
+        - attr:graphql.operation.type = "query"

--- a/internal/graphengine/engine_v2.go
+++ b/internal/graphengine/engine_v2.go
@@ -3,9 +3,10 @@ package graphengine
 import (
 	"context"
 	"errors"
+	"net/http"
+
 	"github.com/TykTechnologies/graphql-go-tools/pkg/ast"
 	semconv "github.com/TykTechnologies/opentelemetry/semconv/v1.0.0"
-	"net/http"
 
 	"github.com/jensneuse/abstractlogger"
 	"github.com/sirupsen/logrus"

--- a/internal/graphengine/engine_v2.go
+++ b/internal/graphengine/engine_v2.go
@@ -220,6 +220,7 @@ func (e *EngineV2) ProcessAndStoreGraphQLRequest(w http.ResponseWriter, r *http.
 		operationType, err := gqlRequest.OperationType()
 		if err != nil {
 			e.logger.Debug("error while getting operation type for trace", abstractlogger.Error(err))
+			return err, http.StatusBadRequest
 		}
 
 		span.SetAttributes(

--- a/internal/graphengine/engine_v2.go
+++ b/internal/graphengine/engine_v2.go
@@ -5,9 +5,6 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/TykTechnologies/graphql-go-tools/pkg/ast"
-	semconv "github.com/TykTechnologies/opentelemetry/semconv/v1.0.0"
-
 	"github.com/jensneuse/abstractlogger"
 	"github.com/sirupsen/logrus"
 
@@ -217,18 +214,6 @@ func (e *EngineV2) ProcessAndStoreGraphQLRequest(w http.ResponseWriter, r *http.
 	if e.OpenTelemetry.Enabled && e.ApiDefinition.DetailedTracing {
 		ctx, span := e.OpenTelemetry.TracerProvider.Tracer().Start(r.Context(), "GraphqlMiddleware Validation")
 		defer span.End()
-
-		operationType, err := gqlRequest.OperationType()
-		if err != nil {
-			e.logger.Debug("error while getting operation type for trace", abstractlogger.Error(err))
-			return err, http.StatusBadRequest
-		}
-
-		span.SetAttributes(
-			semconv.GraphQLOperationName(gqlRequest.OperationName),
-			semconv.GraphQLOperationType(graphqlinternal.PrintOperationType(ast.OperationType(operationType))),
-			semconv.GraphQLDocument(gqlRequest.Query),
-		)
 		*r = *r.WithContext(ctx)
 	}
 

--- a/internal/graphql/otel_graphql_engine_basic.go
+++ b/internal/graphql/otel_graphql_engine_basic.go
@@ -62,7 +62,7 @@ func (o *OtelGraphqlEngineV2Basic) Execute(inCtx context.Context, operation *gra
 
 	span.SetAttributes(
 		semconv.GraphQLOperationName(operation.OperationName),
-		semconv.GraphQLOperationType(printOperationType(ast.OperationType(operationType))),
+		semconv.GraphQLOperationType(PrintOperationType(ast.OperationType(operationType))),
 		semconv.GraphQLDocument(operation.Query),
 	)
 

--- a/internal/graphql/otel_graphql_engine_detailed.go
+++ b/internal/graphql/otel_graphql_engine_detailed.go
@@ -11,7 +11,6 @@ import (
 	"github.com/TykTechnologies/graphql-go-tools/pkg/lexer/literal"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/operationreport"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/postprocess"
-	semconv "github.com/TykTechnologies/opentelemetry/semconv/v1.0.0"
 	"github.com/TykTechnologies/tyk/internal/otel"
 )
 
@@ -75,19 +74,7 @@ func (o *OtelGraphqlEngineV2Detailed) ValidateForSchema(operation *graphql.Reque
 	_, span := o.tracerProvider.Tracer().Start(o.traceContext, operationName)
 	defer span.End()
 
-	operationType, err := operation.OperationType()
-	if err != nil {
-		span.SetStatus(otel.SPAN_STATUS_ERROR, "request validation failed")
-		return err
-	}
-
-	span.SetAttributes(
-		semconv.GraphQLOperationName(operation.OperationName),
-		semconv.GraphQLOperationType(printOperationType(ast.OperationType(operationType))),
-		semconv.GraphQLDocument(operation.Query),
-	)
-
-	err = o.engine.ValidateForSchema(operation)
+	err := o.engine.ValidateForSchema(operation)
 	if err != nil {
 		span.SetStatus(otel.SPAN_STATUS_ERROR, "request validation failed")
 		return err
@@ -173,7 +160,7 @@ func NewOtelGraphqlEngineV2Detailed(tracerProvider otel.TracerProvider, engine E
 	return otelEngine, nil
 }
 
-func printOperationType(operationType ast.OperationType) string {
+func PrintOperationType(operationType ast.OperationType) string {
 	switch operationType {
 	case ast.OperationTypeQuery:
 		return string(literal.QUERY)


### PR DESCRIPTION
## **User description**
moved the document info attributes for graphql requests to the GraphqlMiddlewareValidation span

<!-- Provide a general summary of your changes in the Title above -->

## Description
Moved the graphql-specific span attributes higher up the span chain so they can still be seen in the event of a request failure when detailed tracing is turned on

[TT-11389](https://tyktech.atlassian.net/browse/TT-11389)

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


[TT-11389]: https://tyktech.atlassian.net/browse/TT-11389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

## **Type**
enhancement


___

## **Description**
- Added OpenTelemetry semantic conventions for GraphQL operation name, type, and document in `ProcessAndStoreGraphQLRequest` method to enhance tracing capabilities.
- Refactored the way GraphQL operation type is determined and set on spans across different parts of the codebase.
- Removed redundant span attributes setting in the `ValidateForSchema` method of the detailed GraphQL engine.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>engine_v2.go</strong><dd><code>Add OpenTelemetry Attributes for GraphQL Requests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/graphengine/engine_v2.go
<li>Added OpenTelemetry semantic conventions for GraphQL in <br><code>ProcessAndStoreGraphQLRequest</code> method.<br> <li> Set attributes for GraphQL operation name, type, and document on the <br>span.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6088/files#diff-b1eaa954c9836f395e1d49090e85c739e3878747c8bd748f556fc5a53ff7b191">+13/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>otel_graphql_engine_basic.go</strong><dd><code>Use PrintOperationType for Span Attributes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/graphql/otel_graphql_engine_basic.go
<li>Modified to use <code>PrintOperationType</code> for setting GraphQL operation type <br>attribute on the span.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6088/files#diff-d2e2ab0951855338accb48c6985c5f880a8ea2746872c7cea5b64f308a5214c8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>otel_graphql_engine_detailed.go</strong><dd><code>Refactor Span Attributes Setting in GraphQL Engine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/graphql/otel_graphql_engine_detailed.go
<li>Removed span attributes setting from <code>ValidateForSchema</code> method.<br> <li> Exposed <code>PrintOperationType</code> function for external use.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6088/files#diff-799c8fc0e5c351c4903c0ecfcc1b9997473f469edcd25118edf447dc6ea4e771">+2/-15</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

