### PR TITLE
[TT-11377] Adding “node_is_segmented” flag under “node” to complement “tags”

### DIFF
--- a/apidef/rpc.go
+++ b/apidef/rpc.go
@@ -23,14 +23,15 @@ type GroupLoginRequest struct {
 }
 
 type NodeData struct {
-	NodeID      string                     `json:"node_id"`
-	APIKey      string                     `json:"api_key"`
-	GroupID     string                     `json:"group_id"`
-	NodeVersion string                     `json:"node_version"`
-	TTL         int64                      `json:"ttl"`
-	Tags        []string                   `json:"tags"`
-	Health      map[string]HealthCheckItem `json:"health"`
-	Stats       GWStats                    `json:"stats"`
+	NodeID          string                     `json:"node_id"`
+	APIKey          string                     `json:"api_key"`
+	GroupID         string                     `json:"group_id"`
+	NodeVersion     string                     `json:"node_version"`
+	TTL             int64                      `json:"ttl"`
+	NodeIsSegmented bool                       `json:"node_is_segmented"`
+	Tags            []string                   `json:"tags"`
+	Health          map[string]HealthCheckItem `json:"health"`
+	Stats           GWStats                    `json:"stats"`
 }
 
 type GWStats struct {

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -159,13 +159,14 @@ func (r *RPCStorageHandler) buildNodeInfo() []byte {
 	}
 
 	node := apidef.NodeData{
-		NodeID:      r.Gw.GetNodeID(),
-		GroupID:     config.SlaveOptions.GroupID,
-		APIKey:      config.SlaveOptions.APIKey,
-		NodeVersion: VERSION,
-		TTL:         intCheckDuration,
-		Tags:        config.DBAppConfOptions.Tags,
-		Health:      r.Gw.getHealthCheckInfo(),
+		NodeID:          r.Gw.GetNodeID(),
+		GroupID:         config.SlaveOptions.GroupID,
+		APIKey:          config.SlaveOptions.APIKey,
+		NodeVersion:     VERSION,
+		TTL:             intCheckDuration,
+		NodeIsSegmented: config.DBAppConfOptions.NodeIsSegmented,
+		Tags:            config.DBAppConfOptions.Tags,
+		Health:          r.Gw.getHealthCheckInfo(),
 		Stats: apidef.GWStats{
 			APIsCount:     r.Gw.apisByIDLen(),
 			PoliciesCount: r.Gw.policiesByIDLen(),

--- a/gateway/rpc_storage_handler_test.go
+++ b/gateway/rpc_storage_handler_test.go
@@ -462,6 +462,32 @@ func TestRPCStorageHandler_BuildNodeInfo(t *testing.T) {
 				},
 			},
 		},
+		{
+			testName: "with segmented node",
+			givenTs: func() *Test {
+				ts := StartTest(func(globalConf *config.Config) {
+					globalConf.SlaveOptions.GroupID = "group"
+					globalConf.DBAppConfOptions.Tags = []string{"tag1", "tag2"}
+					globalConf.LivenessCheck.CheckDuration = 1000000000
+					globalConf.DBAppConfOptions.NodeIsSegmented = true
+				})
+
+				ts.Gw.SetNodeID("test-node-id")
+				return ts
+			},
+			expectedNodeInfo: apidef.NodeData{
+				NodeID:          "test-node-id",
+				GroupID:         "group",
+				TTL:             1,
+				Tags:            []string{"tag1", "tag2"},
+				NodeIsSegmented: true,
+				NodeVersion:     VERSION,
+				Stats: apidef.GWStats{
+					APIsCount:     0,
+					PoliciesCount: 0,
+				},
+			},
+		},
 	}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
## Description
Adding `node_is_segmented` flag under `node` to complement `tags`.

MDCB PR: https://github.com/TykTechnologies/tyk-sink/pull/496
<!-- Describe your changes in detail -->

## Related Issue
https://tyktech.atlassian.net/browse/TT-11377?atlOrigin=eyJpIjoiNmNiY2VjZjM3NGZlNDBiZjgwNmNlOTMyOWRjYzIwN2EiLCJwIjoiaiJ9
<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context
https://tyktech.atlassian.net/browse/TT-11377?atlOrigin=eyJpIjoiNmNiY2VjZjM3NGZlNDBiZjgwNmNlOTMyOWRjYzIwN2EiLCJwIjoiaiJ9
<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested
Unit tests
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

## **Type**
enhancement, tests


___

## **Description**
- Added a new boolean field `NodeIsSegmented` to the `NodeData` struct to indicate if a node is segmented.
- Updated `buildNodeInfo` in `rpc_storage_handler.go` to populate the `NodeIsSegmented` field from the configuration.
- Introduced a new test case in `rpc_storage_handler_test.go` to verify the behavior when the `NodeIsSegmented` flag is set to true.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc.go</strong><dd><code>Add NodeIsSegmented Field to NodeData Struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/rpc.go
- Added `NodeIsSegmented` boolean field to `NodeData` struct.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6093/files#diff-8cfd476d3e5aafb95ff2e1ebbf5d797daccc9bde48fa791cdfbd0c9132508c85">+9/-8</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_storage_handler.go</strong><dd><code>Populate NodeIsSegmented in buildNodeInfo Function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/rpc_storage_handler.go
<li>Populated <code>NodeIsSegmented</code> in <code>buildNodeInfo</code> function from <br>configuration.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6093/files#diff-8875f75b602664c44b62b67a4da41d748124ad270573a44db4ec977ee5d68021">+8/-7</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_storage_handler_test.go</strong><dd><code>Test Case for NodeIsSegmented Flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/rpc_storage_handler_test.go
- Added test case for `NodeIsSegmented` flag being true.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6093/files#diff-69de989a02b3bc32ae376c514ee84633c609200db22385c0e16c361d6ea74cd6">+26/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

