### PR TITLE
POC Shim for redis conn in goplugins

### DIFF
--- a/apidef/adapter/gqlengineadapter/adapter_proxy_only.go
+++ b/apidef/adapter/gqlengineadapter/adapter_proxy_only.go
@@ -54,6 +54,6 @@ func (p *ProxyOnly) EngineConfig() (*graphql.EngineV2Configuration, error) {
 		graphql.WithProxySubscriptionClientFactory(subscriptionClientFactoryOrDefault(p.subscriptionClientFactory)),
 	).EngineV2Configuration()
 
-	v2Config.EnableSingleFlight(true)
+	v2Config.EnableSingleFlight(false)
 	return &v2Config, err
 }

--- a/apidef/adapter/gqlengineadapter/adapter_udg.go
+++ b/apidef/adapter/gqlengineadapter/adapter_udg.go
@@ -32,7 +32,7 @@ func (u *UniversalDataGraph) EngineConfig() (*graphql.EngineV2Configuration, err
 	}
 
 	conf := graphql.NewEngineV2Configuration(u.Schema)
-	conf.EnableSingleFlight(true)
+	conf.EnableSingleFlight(false)
 
 	fieldConfigs := u.engineConfigV2FieldConfigs()
 	datsSources, err := u.engineConfigV2DataSources()

--- a/apidef/oas/authentication.go
+++ b/apidef/oas/authentication.go
@@ -314,7 +314,7 @@ func (as *AuthSources) ExtractTo(authConfig *apidef.AuthConfig) {
 
 // AuthSource defines an authentication source.
 type AuthSource struct {
-	// Enabled enables the auth source.
+	// Enabled activates the auth source.
 	// Tyk classic API definition: `auth_configs[X].use_param/use_cookie`
 	Enabled bool `bson:"enabled" json:"enabled"` // required
 	// Name is the name of the auth source.
@@ -422,21 +422,23 @@ type ScopeToPolicy struct {
 
 // HMAC holds the configuration for the HMAC authentication mode.
 type HMAC struct {
-	// Enabled enables the HMAC authentication mode.
+	// Enabled activates the HMAC authentication mode.
 	// Tyk classic API definition: `enable_signature_checking`
 	Enabled bool `bson:"enabled" json:"enabled"` // required
 
 	// AuthSources contains authentication token source configuration (header, cookie, query).
 	AuthSources `bson:",inline" json:",inline"`
 
-	// AllowedAlgorithms is the array of HMAC algorithms which are allowed. Tyk supports the following HMAC algorithms:
+	// AllowedAlgorithms is the array of HMAC algorithms which are allowed.
+	//
+	// Tyk supports the following HMAC algorithms:
 	//
 	// - `hmac-sha1`
 	// - `hmac-sha256`
 	// - `hmac-sha384`
 	// - `hmac-sha512`
 	//
-	// and reads the value from algorithm header.
+	// and reads the value from the algorithm header.
 	//
 	// Tyk classic API definition: `hmac_allowed_algorithms`
 	AllowedAlgorithms []string `bson:"allowedAlgorithms,omitempty" json:"allowedAlgorithms,omitempty"`
@@ -476,7 +478,7 @@ func (h *HMAC) ExtractTo(api *apidef.APIDefinition) {
 
 // OIDC contains configuration for the OIDC authentication mode.
 type OIDC struct {
-	// Enabled enables the OIDC authentication mode.
+	// Enabled activates the OIDC authentication mode.
 	//
 	// Tyk classic API definition: `use_openid`
 	Enabled bool `bson:"enabled" json:"enabled"` // required
@@ -489,7 +491,7 @@ type OIDC struct {
 	// Tyk classic API definition: `openid_options.segregate_by_client`.
 	SegregateByClientId bool `bson:"segregateByClientId,omitempty" json:"segregateByClientId,omitempty"`
 
-	// Providers contains a list of authorised providers and their Client IDs, and matched policies.
+	// Providers contains a list of authorised providers, their Client IDs and matched policies.
 	//
 	// Tyk classic API definition: `openid_options.providers`.
 	Providers []Provider `bson:"providers,omitempty" json:"providers,omitempty"`
@@ -588,7 +590,7 @@ type ClientToPolicy struct {
 
 // CustomPluginAuthentication holds configuration for custom plugins.
 type CustomPluginAuthentication struct {
-	// Enabled enables the CustomPluginAuthentication authentication mode.
+	// Enabled activates the CustomPluginAuthentication authentication mode.
 	//
 	// Tyk classic API definition: `enable_coprocess_auth`/`use_go_plugin_auth`.
 	Enabled bool `bson:"enabled" json:"enabled"` // required
@@ -651,11 +653,11 @@ func (c *CustomPluginAuthentication) ExtractTo(api *apidef.APIDefinition) {
 
 // AuthenticationPlugin holds the configuration for custom authentication plugin.
 type AuthenticationPlugin struct {
-	// Enabled enables custom authentication plugin.
+	// Enabled activates custom authentication plugin.
 	Enabled bool `bson:"enabled" json:"enabled"` // required.
 	// FunctionName is the name of authentication method.
 	FunctionName string `bson:"functionName" json:"functionName"` // required.
-	// Path is the path to shared object file in case of gopluign mode or path to js code in case of otto auth plugin.
+	// Path is the path to shared object file in case of goplugin mode or path to JS code in case of otto auth plugin.
 	Path string `bson:"path" json:"path"`
 	// RawBodyOnly if set to true, do not fill body in request or response object.
 	RawBodyOnly bool `bson:"rawBodyOnly,omitempty" json:"rawBodyOnly,omitempty"`
@@ -758,7 +760,7 @@ func (id *IDExtractorConfig) ExtractTo(api *apidef.APIDefinition) {
 
 // IDExtractor configures ID Extractor.
 type IDExtractor struct {
-	// Enabled enables ID extractor with coprocess authentication.
+	// Enabled activates ID extractor with coprocess authentication.
 	Enabled bool `bson:"enabled" json:"enabled"` // required
 	// Source is the source from which ID to be extracted from.
 	Source apidef.IdExtractorSource `bson:"source" json:"source"` // required

--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -277,7 +277,7 @@ func (g *Global) ExtractTo(api *apidef.APIDefinition) {
 
 // PluginConfigData configures config data for custom plugins.
 type PluginConfigData struct {
-	// Enabled enables custom plugin config data.
+	// Enabled activates custom plugin config data.
 	Enabled bool `bson:"enabled" json:"enabled"` // required.
 
 	// Value is the value of custom plugin config data.
@@ -365,7 +365,7 @@ func (p *PluginConfig) ExtractTo(api *apidef.APIDefinition) {
 
 // PluginBundle holds configuration for custom plugins.
 type PluginBundle struct {
-	// Enabled enables the custom plugin bundles.
+	// Enabled activates the custom plugin bundles.
 	//
 	// Tyk classic API definition: `custom_middleware_bundle_disabled`
 	Enabled bool `bson:"enabled" json:"enabled"` // required.
@@ -398,7 +398,7 @@ type CORS struct {
 	// Tyk classic API definition: `CORS.max_age`.
 	MaxAge int `bson:"maxAge,omitempty" json:"maxAge,omitempty"`
 
-	// AllowCredentials indicates whether the request can include user credentials like cookies,
+	// AllowCredentials indicates if the request can include user credentials like cookies,
 	// HTTP authentication or client side SSL certificates.
 	//
 	// Tyk classic API definition: `CORS.allow_credentials`.
@@ -885,7 +885,7 @@ type Header struct {
 
 // TransformRequestMethod holds configuration for rewriting request methods.
 type TransformRequestMethod struct {
-	// Enabled enables Method Transform for the given path and method.
+	// Enabled activates Method Transform for the given path and method.
 	Enabled bool `bson:"enabled" json:"enabled"`
 	// ToMethod is the http method value to which the method of an incoming request will be transformed.
 	ToMethod string `bson:"toMethod" json:"toMethod"`
@@ -905,7 +905,7 @@ func (tm *TransformRequestMethod) ExtractTo(meta *apidef.MethodTransformMeta) {
 
 // TransformBody holds configuration about request/response body transformations.
 type TransformBody struct {
-	// Enabled enables transform request/request body middleware.
+	// Enabled activates transform request/request body middleware.
 	Enabled bool `bson:"enabled" json:"enabled"`
 	// Format of the request/response body, xml or json.
 	Format apidef.RequestInputType `bson:"format" json:"format"`
@@ -942,7 +942,7 @@ func (tr *TransformBody) ExtractTo(meta *apidef.TemplateMeta) {
 
 // TransformHeaders holds configuration about request/response header transformations.
 type TransformHeaders struct {
-	// Enabled enables Header Transform for the given path and method.
+	// Enabled activates Header Transform for the given path and method.
 	Enabled bool `bson:"enabled" json:"enabled"`
 	// Remove specifies header names to be removed from the request/response.
 	Remove []string `bson:"remove,omitempty" json:"remove,omitempty"`
@@ -1038,11 +1038,11 @@ func (et *EnforceTimeout) ExtractTo(meta *apidef.HardTimeoutMeta) {
 
 // CustomPlugin configures custom plugin.
 type CustomPlugin struct {
-	// Enabled enables the custom pre plugin.
+	// Enabled activates the custom pre plugin.
 	Enabled bool `bson:"enabled" json:"enabled"` // required.
 	// FunctionName is the name of authentication method.
 	FunctionName string `bson:"functionName" json:"functionName"` // required.
-	// Path is the path to shared object file in case of gopluign mode or path to js code in case of otto auth plugin.
+	// Path is the path to shared object file in case of goplugin mode or path to JS code in case of otto auth plugin.
 	Path string `bson:"path" json:"path"`
 	// RawBodyOnly if set to true, do not fill body in request or response object.
 	RawBodyOnly bool `bson:"rawBodyOnly,omitempty" json:"rawBodyOnly,omitempty"`
@@ -1051,7 +1051,7 @@ type CustomPlugin struct {
 	RequireSession bool `bson:"requireSession,omitempty" json:"requireSession,omitempty"`
 }
 
-// CustomPlugins is a list of CustomPlugin.
+// CustomPlugins is a list of CustomPlugin objects.
 type CustomPlugins []CustomPlugin
 
 // Fill fills CustomPlugins from supplied Middleware definitions.
@@ -1080,7 +1080,11 @@ func (c CustomPlugins) ExtractTo(mwDefs []apidef.MiddlewareDefinition) {
 	}
 }
 
-// PrePlugin configures pre stage plugins.
+// PrePlugin configures pre-request plugins.
+//
+// Pre-request plugins are executed before the request is sent to the
+// upstream target and before any authentication information is extracted
+// from the header or parameter list of the request.
 type PrePlugin struct {
 	// Plugins configures custom plugins to be run on pre authentication stage.
 	// The plugins would be executed in the order of configuration in the list.
@@ -1198,13 +1202,13 @@ func (p *ResponsePlugin) ExtractTo(api *apidef.APIDefinition) {
 
 // VirtualEndpoint contains virtual endpoint configuration.
 type VirtualEndpoint struct {
-	// Enabled enables virtual endpoint.
+	// Enabled activates virtual endpoint.
 	Enabled bool `bson:"enabled" json:"enabled"` // required.
-	// Name is the name of js function.
+	// Name is the name of JS function.
 	Name string `bson:"name" json:"name"` // required.
-	// Path is the path to js file.
+	// Path is the path to JS file.
 	Path string `bson:"path,omitempty" json:"path,omitempty"`
-	// Body is the js function to execute encoded in base64 format.
+	// Body is the JS function to execute encoded in base64 format.
 	Body string `bson:"body,omitempty" json:"body,omitempty"`
 	// ProxyOnError proxies if virtual endpoint errors out.
 	ProxyOnError bool `bson:"proxyOnError,omitempty" json:"proxyOnError,omitempty"`
@@ -1244,7 +1248,7 @@ type EndpointPostPlugins []EndpointPostPlugin
 
 // EndpointPostPlugin contains endpoint level post plugin configuration.
 type EndpointPostPlugin struct {
-	// Enabled enables post plugin.
+	// Enabled activates post plugin.
 	Enabled bool `bson:"enabled" json:"enabled"` // required.
 	// Name is the name of plugin function to be executed.
 	Name string `bson:"name" json:"name"` // required.
@@ -1279,7 +1283,7 @@ func (e EndpointPostPlugins) ExtractTo(meta *apidef.GoPluginMeta) {
 // CircuitBreaker holds configuration for the circuit breaker middleware.
 // Tyk classic API definition: `version_data.versions..extended_paths.circuit_breakers[*]`.
 type CircuitBreaker struct {
-	// Enabled enables the Circuit Breaker functionality.
+	// Enabled activates the Circuit Breaker functionality.
 	// Tyk classic API definition: `version_data.versions..extended_paths.circuit_breakers[*].disabled`.
 	Enabled bool `bson:"enabled" json:"enabled"`
 	// Threshold is the proportion from each `sampleSize` requests that must fail for the breaker to be tripped. This must be a value between 0.0 and 1.0. If `sampleSize` is 100 then a threshold of 0.4 means that the breaker will be tripped if 40 out of every 100 requests fails.
@@ -1316,7 +1320,7 @@ func (cb *CircuitBreaker) ExtractTo(circuitBreaker *apidef.CircuitBreakerMeta) {
 
 // RequestSizeLimit limits the maximum allowed size of the request body in bytes.
 type RequestSizeLimit struct {
-	// Enabled enables the Request Size Limit functionality.
+	// Enabled activates the Request Size Limit functionality.
 	Enabled bool `bson:"enabled" json:"enabled"`
 	// Value is the maximum allowed size of the request body in bytes.
 	Value int64 `bson:"value" json:"value"`

--- a/apidef/oas/oas.go
+++ b/apidef/oas/oas.go
@@ -308,10 +308,18 @@ func (s *OAS) AddServers(apiURLs ...string) {
 	apiURLSet := make(map[string]struct{})
 	newServers := openapi3.Servers{}
 	for _, apiURL := range apiURLs {
+		if strings.Contains(apiURL, "{") && strings.Contains(apiURL, "}") {
+			continue
+		}
+
 		newServers = append(newServers, &openapi3.Server{
 			URL: apiURL,
 		})
 		apiURLSet[apiURL] = struct{}{}
+	}
+
+	if len(newServers) == 0 {
+		return
 	}
 
 	if len(s.Servers) == 0 {

--- a/apidef/oas/oas_test.go
+++ b/apidef/oas/oas_test.go
@@ -257,7 +257,6 @@ func TestOAS_ExtractTo_ResetAPIDefinition(t *testing.T) {
 		"APIDefinition.ResponseProcessors[0].Options",
 		"APIDefinition.DoNotTrack",
 		"APIDefinition.TagHeaders[0]",
-		"APIDefinition.EnableDetailedRecording",
 		"APIDefinition.GraphQL.Enabled",
 		"APIDefinition.GraphQL.ExecutionMode",
 		"APIDefinition.GraphQL.Version",

--- a/apidef/oas/oasutil.go
+++ b/apidef/oas/oasutil.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 )
 
-// ShouldOmit checks whether a field should be set to empty and omitted from OAS JSON.
+// ShouldOmit checks if a field should be set to empty and omitted from OAS JSON.
 func ShouldOmit(i interface{}) bool {
 	return IsZero(reflect.ValueOf(i))
 }

--- a/apidef/oas/operation.go
+++ b/apidef/oas/operation.go
@@ -711,7 +711,7 @@ func (s *OAS) fillOASValidateRequest(metas []apidef.ValidatePathMeta) {
 
 // MockResponse configures the mock responses.
 type MockResponse struct {
-	// Enabled enables the mock response middleware.
+	// Enabled activates the mock response middleware.
 	Enabled bool `bson:"enabled" json:"enabled"`
 	// Code is the HTTP response code that will be returned.
 	Code int `bson:"code,omitempty" json:"code,omitempty"`
@@ -723,9 +723,9 @@ type MockResponse struct {
 	FromOASExamples *FromOASExamples `bson:"fromOASExamples,omitempty" json:"fromOASExamples,omitempty"`
 }
 
-// FromOASExamples configures mock responses should be returned from OAS example responses.
+// FromOASExamples configures mock responses that should be returned from OAS example responses.
 type FromOASExamples struct {
-	// Enabled enables getting a mock response from OAS examples or schemas documented in OAS.
+	// Enabled activates getting a mock response from OAS examples or schemas documented in OAS.
 	Enabled bool `bson:"enabled" json:"enabled"`
 	// Code is the default HTTP response code that the gateway reads from the path responses documented in OAS.
 	Code int `bson:"code,omitempty" json:"code,omitempty"`

--- a/apidef/oas/root.go
+++ b/apidef/oas/root.go
@@ -128,7 +128,7 @@ func (i *Info) ExtractTo(api *apidef.APIDefinition) {
 	}
 }
 
-// State holds configuration for the status of the API within Tyk - whether it is currently active and whether it is exposed externally.
+// State holds configuration for the status of the API within Tyk - if it is currently active and if it is exposed externally.
 type State struct {
 	// Active enables the API so that Tyk will listen for and process requests made to the listenPath.
 	// Tyk classic API definition: `active`

--- a/apidef/oas/security.go
+++ b/apidef/oas/security.go
@@ -24,7 +24,7 @@ const (
 
 // Token holds the values related to authentication tokens.
 type Token struct {
-	// Enabled enables the token based authentication mode.
+	// Enabled activates the token based authentication mode.
 	//
 	// Tyk classic API definition: `auth_configs["authToken"].use_standard_auth`
 	Enabled bool `bson:"enabled" json:"enabled"` // required
@@ -207,7 +207,7 @@ func (s *OAS) extractJWTTo(api *apidef.APIDefinition, name string) {
 
 // Basic type holds configuration values related to http basic authentication.
 type Basic struct {
-	// Enabled enables the basic authentication mode.
+	// Enabled activates the basic authentication mode.
 	// Tyk classic API definition: `use_basic_auth`
 	Enabled     bool `bson:"enabled" json:"enabled"` // required
 	AuthSources `bson:",inline" json:",inline"`
@@ -296,7 +296,7 @@ func (s *OAS) extractBasicTo(api *apidef.APIDefinition, name string) {
 
 // ExtractCredentialsFromBody configures extracting credentials from the request body.
 type ExtractCredentialsFromBody struct {
-	// Enabled enables extracting credentials from body.
+	// Enabled activates extracting credentials from body.
 	// Tyk classic API definition: `basic_auth.extract_from_body`
 	Enabled bool `bson:"enabled" json:"enabled"` // required
 	// UserRegexp is the regex for username e.g. `<User>(.*)</User>`.
@@ -407,22 +407,29 @@ type OAuthProvider struct {
 }
 
 type JWTValidation struct {
-	// Enabled enables OAuth access token validation by introspection to a third party.
+	// Enabled activates OAuth access token validation by introspection to a third party.
 	Enabled bool `bson:"enabled" json:"enabled"`
+
 	// SigningMethod to verify signing method used in jwt - allowed values HMAC/RSA/ECDSA.
 	SigningMethod string `bson:"signingMethod" json:"signingMethod"`
-	// Source is the secret to verify signature, it could be one among:
+
+	// Source is the secret to verify signature. Valid values are:
+	//
 	// - a base64 encoded static secret,
 	// - a valid JWK URL in plain text,
 	// - a valid JWK URL in base64 encoded format.
 	Source string `bson:"source" json:"source"`
+
 	// IdentityBaseField is the identity claim name.
 	IdentityBaseField string `bson:"identityBaseField,omitempty" json:"identityBaseField,omitempty"`
-	// IssuedAtValidationSkew is the clock skew to be considered while validating iat claim.
+
+	// IssuedAtValidationSkew is the clock skew to be considered while validating the iat claim.
 	IssuedAtValidationSkew uint64 `bson:"issuedAtValidationSkew,omitempty" json:"issuedAtValidationSkew,omitempty"`
-	// NotBeforeValidationSkew is the clock skew to be considered while validating nbf claim.
+
+	// NotBeforeValidationSkew is the clock skew to be considered while validating the nbf claim.
 	NotBeforeValidationSkew uint64 `bson:"notBeforeValidationSkew,omitempty" json:"notBeforeValidationSkew,omitempty"`
-	// ExpiresAtValidationSkew is the clock skew to be considered while validating exp claim.
+
+	// ExpiresAtValidationSkew is the clock skew to be considered while validating the exp claim.
 	ExpiresAtValidationSkew uint64 `bson:"expiresAtValidationSkew,omitempty" json:"expiresAtValidationSkew,omitempty"`
 }
 
@@ -447,13 +454,13 @@ func (j *JWTValidation) ExtractTo(jwt *apidef.JWTValidation) {
 }
 
 type Introspection struct {
-	// Enabled enables OAuth access token validation by introspection to a third party.
+	// Enabled activates OAuth access token validation by introspection to a third party.
 	Enabled bool `bson:"enabled" json:"enabled"`
 	// URL is the URL of the third party provider's introspection endpoint.
 	URL string `bson:"url" json:"url"`
 	// ClientID is the public identifier for the client, acquired from the third party.
 	ClientID string `bson:"clientId" json:"clientId"`
-	// ClientSecret is a secret known only to the client and the authorization server, acquired from the third party.
+	// ClientSecret is a secret known only to the client and the authorisation server, acquired from the third party.
 	ClientSecret string `bson:"clientSecret" json:"clientSecret"`
 	// IdentityBaseField is the key showing where to find the user id in the claims. If it is empty, the `sub` key is looked at.
 	IdentityBaseField string `bson:"identityBaseField,omitempty" json:"identityBaseField,omitempty"`
@@ -491,7 +498,7 @@ func (i *Introspection) ExtractTo(intros *apidef.Introspection) {
 }
 
 type IntrospectionCache struct {
-	// Enabled enables the caching mechanism for introspection responses.
+	// Enabled activates the caching mechanism for introspection responses.
 	Enabled bool `bson:"enabled" json:"enabled"`
 	// Timeout is the duration in seconds of how long the cached value stays.
 	// For introspection caching, it is suggested to use a short interval.

--- a/apidef/oas/server.go
+++ b/apidef/oas/server.go
@@ -242,12 +242,12 @@ type DetailedActivityLogs struct {
 
 // ExtractTo extracts *DetailedActivityLogs into *apidef.APIDefinition.
 func (d *DetailedActivityLogs) ExtractTo(api *apidef.APIDefinition) {
-	api.EnableDetailedRecording = !d.Enabled
+	api.EnableDetailedRecording = d.Enabled
 }
 
 // Fill fills *DetailedActivityLogs from apidef.APIDefinition.
 func (d *DetailedActivityLogs) Fill(api apidef.APIDefinition) {
-	d.Enabled = !api.EnableDetailedRecording
+	d.Enabled = api.EnableDetailedRecording
 }
 
 // DetailedTracing holds the configuration of the detailed tracing.

--- a/apidef/oas/server.go
+++ b/apidef/oas/server.go
@@ -8,7 +8,7 @@ import (
 type Server struct {
 	// ListenPath is the base path on Tyk to which requests for this API should
 	// be sent. Tyk listens for any requests coming into the host at this
-	// path, on the port that Tyk is configured to run on, and processes these
+	// path, on the port that Tyk is configured to run on and processes these
 	// accordingly.
 	ListenPath ListenPath `bson:"listenPath" json:"listenPath"` // required
 
@@ -135,16 +135,16 @@ func (s *Server) ExtractTo(api *apidef.APIDefinition) {
 
 // ListenPath is the base path on Tyk to which requests for this API
 // should be sent. Tyk listens out for any requests coming into the host at
-// this path, on the port that Tyk is configured to run on, and processes
+// this path, on the port that Tyk is configured to run on and processes
 // these accordingly.
 type ListenPath struct {
 	// Value is the value of the listen path e.g. `/api/` or `/` or `/httpbin/`.
 	// Tyk classic API definition: `proxy.listen_path`
 	Value string `bson:"value" json:"value"` // required
 
-	// Strip removes the inbound listen path (as accessed by the client) when generating the outgoing request (to the upstream service).
+	// Strip removes the inbound listen path (as accessed by the client) when generating the outbound request for the upstream service.
 	//
-	// For example, a scenario where the Tyk base address is `http://acme.com/', the listen path is `example/` and the upstream URL is `http://httpbin.org/`:
+	// For example, consider the scenario where the Tyk base address is `http://acme.com/', the listen path is `example/` and the upstream URL is `http://httpbin.org/`:
 	//
 	// - If the client application sends a request to `http://acme.com/example/get` then the request will be proxied to `http://httpbin.org/example/get`
 	// - If stripListenPath is set to `true`, the `example` listen path is removed and the request would be proxied to `http://httpbin.org/get`.
@@ -167,7 +167,7 @@ func (lp *ListenPath) ExtractTo(api *apidef.APIDefinition) {
 
 // ClientCertificates contains the configurations related to establishing static mutual TLS between the client and Tyk.
 type ClientCertificates struct {
-	// Enabled enables static mTLS for the API.
+	// Enabled activates static mTLS for the API.
 	Enabled bool `bson:"enabled" json:"enabled"`
 	// Allowlist is the list of client certificates which are allowed.
 	Allowlist []string `bson:"allowlist" json:"allowlist"`
@@ -187,7 +187,7 @@ func (cc *ClientCertificates) ExtractTo(api *apidef.APIDefinition) {
 
 // GatewayTags holds a list of segment tags that should apply for a gateway.
 type GatewayTags struct {
-	// Enabled enables use of segment tags.
+	// Enabled activates use of segment tags.
 	Enabled bool `bson:"enabled" json:"enabled"`
 	// Tags is a list of segment tags
 	Tags []string `bson:"tags" json:"tags"`
@@ -212,7 +212,7 @@ type Domain struct {
 	// Name is the name of the domain.
 	Name string `bson:"name" json:"name"`
 	// Certificates defines a field for specifying certificate IDs or file paths
-	// that the Gateway can utilize to dynamically load certificates for your custom domain.
+	// that the Gateway can utilise to dynamically load certificates for your custom domain.
 	//
 	// Tyk classic API definition: `certificates`
 	Certificates []string `bson:"certificates,omitempty" json:"certificates,omitempty"`
@@ -234,7 +234,7 @@ func (cd *Domain) Fill(api apidef.APIDefinition) {
 
 // DetailedActivityLogs holds the configuration related to recording detailed analytics.
 type DetailedActivityLogs struct {
-	// Enabled enables/disables detailed activity logs.
+	// Enabled activates detailed activity logs.
 	//
 	// Tyk classic API definition: `enable_detailed_recording`
 	Enabled bool `bson:"enabled" json:"enabled"`
@@ -252,7 +252,7 @@ func (d *DetailedActivityLogs) Fill(api apidef.APIDefinition) {
 
 // DetailedTracing holds the configuration of the detailed tracing.
 type DetailedTracing struct {
-	// Enabled enables detailed tracing.
+	// Enabled activates detailed tracing.
 	Enabled bool `bson:"enabled" json:"enabled"`
 }
 

--- a/apidef/oas/upstream.go
+++ b/apidef/oas/upstream.go
@@ -10,7 +10,7 @@ import (
 
 // Upstream holds configuration for the upstream server to which Tyk should proxy requests.
 type Upstream struct {
-	// URL defines the upstream address (or Target URL) to which requests should be proxied.
+	// URL defines the upstream address (or target URL) to which requests should be proxied.
 	// Tyk classic API definition: `proxy.target_url`
 	URL string `bson:"url" json:"url"` // required
 
@@ -21,7 +21,7 @@ type Upstream struct {
 	// Test contains the configuration related to uptime tests.
 	Test *Test `bson:"test,omitempty" json:"test,omitempty"`
 
-	// MutualTLS contains the configuration for establishment of mutual TLS between Tyk and the upstream server.
+	// MutualTLS contains the configuration for establishing a mutual TLS connection between Tyk and the upstream server.
 	MutualTLS *MutualTLS `bson:"mutualTLS,omitempty" json:"mutualTLS,omitempty"`
 
 	// CertificatePinning contains the configuration related to certificate pinning.
@@ -133,7 +133,7 @@ func (u *Upstream) ExtractTo(api *apidef.APIDefinition) {
 
 // ServiceDiscovery holds configuration required for service discovery.
 type ServiceDiscovery struct {
-	// Enabled enables Service Discovery.
+	// Enabled activates Service Discovery.
 	//
 	// Tyk classic API definition: `service_discovery.use_discovery_service`
 	Enabled bool `bson:"enabled" json:"enabled"` // required
@@ -248,7 +248,7 @@ type ServiceDiscoveryCache struct {
 	Timeout int64 `bson:"timeout,omitempty" json:"timeout,omitempty"`
 }
 
-// CacheOptions returns the timeout value in effect, and a bool if cache is enabled.
+// CacheOptions returns the timeout value in effect and a bool if cache is enabled.
 func (sd *ServiceDiscovery) CacheOptions() (int64, bool) {
 	if sd.Cache != nil {
 		return sd.Cache.Timeout, sd.Cache.Enabled
@@ -330,9 +330,9 @@ func (t *Test) ExtractTo(uptimeTests *apidef.UptimeTests) {
 	t.ServiceDiscovery.ExtractTo(&uptimeTests.Config.ServiceDiscovery)
 }
 
-// MutualTLS contains the configuration for establishment of mutual TLS between Tyk and the upstream server.
+// MutualTLS contains the configuration for establishing a mutual TLS connection between Tyk and the upstream server.
 type MutualTLS struct {
-	// Enabled enables/disables upstream mutual TLS for the API.
+	// Enabled activates upstream mutual TLS for the API.
 	// Tyk classic API definition: `upstream_certificates_disabled`
 	Enabled bool `bson:"enabled" json:"enabled"`
 
@@ -465,7 +465,7 @@ func (cp *CertificatePinning) ExtractTo(api *apidef.APIDefinition) {
 // The API-level rate limit applies a base-line limit on the frequency of requests to the upstream service for all endpoints. The frequency of requests is configured in two parts: the time interval and the number of requests that can be made during each interval.
 // Tyk classic API definition: `global_rate_limit`.
 type RateLimit struct {
-	// Enabled enables/disables API level rate limiting for this API.
+	// Enabled activates API level rate limiting for this API.
 	//
 	// Tyk classic API definition: `!disable_rate_limit`.
 	Enabled bool `json:"enabled" bson:"enabled"`
@@ -481,7 +481,7 @@ type RateLimit struct {
 	Rate int `json:"rate" bson:"rate"`
 	// Per defines the time interval for rate limiting using shorthand notation.
 	// The value of Per is a string that specifies the interval in a compact form,
-	// where hours, minutes, and seconds are denoted by 'h', 'm', and 's' respectively.
+	// where hours, minutes and seconds are denoted by 'h', 'm' and 's' respectively.
 	// Multiple units can be combined to represent the duration.
 	//
 	// Examples of valid shorthand notations:
@@ -491,7 +491,7 @@ type RateLimit struct {
 	// - "1m29s": one minute and twenty-nine seconds
 	// - "1h30m" : one hour and thirty minutes
 	//
-	// An empty value is interpreted as "0s", implying no rate limiting interval effectively disabling the API-level rate limit.
+	// An empty value is interpreted as "0s", implying no rate limiting interval, which disables the API-level rate limit.
 	// It's important to format the string correctly, as invalid formats will
 	// be considered as 0s/empty.
 	//

--- a/apidef/oas/url_rewrite.go
+++ b/apidef/oas/url_rewrite.go
@@ -10,7 +10,7 @@ import (
 // URLRewrite configures URL rewriting.
 // Tyk classic API definition: `version_data.versions[].extended_paths.url_rewrite`.
 type URLRewrite struct {
-	// Enabled enables URL rewriting if set to true.
+	// Enabled activates URL rewriting if set to true.
 	Enabled bool `bson:"enabled" json:"enabled"`
 
 	// Pattern is the regular expression against which the request URL is compared for the primary rewrite check.
@@ -84,7 +84,7 @@ type URLRewriteTrigger struct {
 	Condition URLRewriteCondition `bson:"condition" json:"condition"`
 
 	// Rules contain individual checks that are combined according to the
-	// `condition` to determine whether the URL rewrite will be triggered.
+	// `condition` to determine if the URL rewrite will be triggered.
 	// If empty, the trigger is ignored.
 	Rules []*URLRewriteRule `bson:"rules,omitempty" json:"rules,omitempty"`
 
@@ -109,9 +109,13 @@ type URLRewriteRule struct {
 	// - `requestContext`, match pattern against request context
 	In URLRewriteInput `bson:"in" json:"in"`
 
-	// Name is the index in the input identified in `in` that should be used to
-	// locate the value for this rule. When `in` is set to `requestBody`, the
-	// value is ignored.
+	// Name is the index in the value declared inside `in`.
+	//
+	// Example: for `in=query`, `name=q`, the parameter `q` would
+	// be read from the request query parameters.
+	//
+	// The value of name is unused when `in` is set to `requestBody`,
+	// as the request body is a single value and not a set of values.
 	Name string `bson:"name,omitempty" json:"name,omitempty"`
 
 	// Pattern is the regular expression against which the `in` values are compared for this rule check.

--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -405,15 +405,6 @@
     "jsvm_timeout": {
       "type": "integer"
     },
-    "enable_leaky_bucket_rate_limiter": {
-      "type": "boolean"
-    },
-    "enable_rate_limiter_storage": {
-      "type": "boolean"
-    },
-    "rate_limiter_storage": {
-      "$ref": "#/definitions/StorageOptions"
-    },
     "enable_non_transactional_rate_limiter": {
       "type": "boolean"
     },

--- a/config/config.go
+++ b/config/config.go
@@ -151,11 +151,11 @@ type StorageOptionsConf struct {
 	// Maximum TLS version that is supported.
 	// Options: ["1.0", "1.1", "1.2", "1.3"].
 	// Defaults to "1.3".
-	MaxVersion string `json:"max_version"`
+	TLSMaxVersion string `json:"tls_max_version"`
 	// Minimum TLS version that is supported.
 	// Options: ["1.0", "1.1", "1.2", "1.3"].
 	// Defaults to "1.2".
-	MinVersion string `json:"min_version"`
+	TLSMinVersion string `json:"tls_min_version"`
 }
 
 type NormalisedURLConfig struct {

--- a/config/development.go
+++ b/config/development.go
@@ -5,6 +5,15 @@ package config
 
 // DevelopmentConfig extends Config for development builds.
 type DevelopmentConfig struct {
+	// EnableLeakyBucketRateLimiter enables leaky bucket rate limiting.
+	//
+	// LeakyBucket will delay requests so they are processed in a FIFO
+	// style queue, ensuring a constant request rate and smoothing out
+	// traffic spikes. This comes at some cost to gateway instances, as
+	// the connections would be held for a longer time, instead of
+	// blocking the requests when they go over the defined rate limits.
+	EnableLeakyBucketRateLimiter bool `json:"enable_leaky_bucket_rate_limiter"`
+
 	// EnableTokenBucket enables token bucket rate limiting.
 	EnableTokenBucketRateLimiter bool `json:"enable_token_bucket_rate_limiter"`
 

--- a/config/rate_limit.go
+++ b/config/rate_limit.go
@@ -7,15 +7,6 @@ import (
 // RateLimit contains flags and configuration for controlling rate limiting behaviour.
 // It is embedded in the main config structure.
 type RateLimit struct {
-	// EnableLeakyBucketRateLimiter enables leaky bucket rate limiting.
-	//
-	// LeakyBucket will delay requests so they are processed in a FIFO
-	// style queue, ensuring a constant request rate and smoothing out
-	// traffic spikes. This comes at some cost to gateway instances, as
-	// the connections would be held for a longer time, instead of
-	// blocking the requests when they go over the defined rate limits.
-	EnableLeakyBucketRateLimiter bool `json:"enable_leaky_bucket_rate_limiter"`
-
 	// Redis based rate limiter with fixed window. Provides 100% rate limiting accuracy, but require two additional Redis roundtrip for each request.
 	EnableRedisRollingLimiter bool `json:"enable_redis_rolling_limiter"`
 
@@ -46,10 +37,6 @@ func (r *RateLimit) String() string {
 	info := "using transactions"
 	if r.EnableNonTransactionalRateLimiter {
 		info = "using pipeline"
-	}
-
-	if r.EnableLeakyBucketRateLimiter {
-		return "Leaky Bucket Rate Limiter enabled"
 	}
 
 	if r.EnableRedisRollingLimiter {

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -1458,6 +1458,16 @@ func (a *APISpec) getURLStatus(stat URLStatus) RequestStatus {
 
 // URLAllowedAndIgnored checks if a url is allowed and ignored.
 func (a *APISpec) URLAllowedAndIgnored(r *http.Request, rxPaths []URLSpec, whiteListStatus bool) (RequestStatus, interface{}) {
+	for i := range rxPaths {
+		if !rxPaths[i].Spec.MatchString(r.URL.Path) {
+			continue
+		}
+
+		if r.Method == rxPaths[i].Internal.Method && rxPaths[i].Status == Internal && !ctxLoopingEnabled(r) {
+			return EndPointNotAllowed, nil
+		}
+	}
+
 	// Check if ignored
 	for i := range rxPaths {
 		if !rxPaths[i].Spec.MatchString(r.URL.Path) {
@@ -1516,10 +1526,6 @@ func (a *APISpec) URLAllowedAndIgnored(r *http.Request, rxPaths []URLSpec, white
 				log.Error("URL Method Action was not set to NoAction, blocking.")
 				return EndPointNotAllowed, nil
 			}
-		}
-
-		if r.Method == rxPaths[i].Internal.Method && rxPaths[i].Status == Internal && !ctxLoopingEnabled(r) {
-			return EndPointNotAllowed, nil
 		}
 
 		if whiteListStatus {

--- a/gateway/mw_rate_limiting_test.go
+++ b/gateway/mw_rate_limiting_test.go
@@ -240,8 +240,6 @@ func providerCustomRatelimitKey(t *testing.T, limiter string) {
 				globalConf.RateLimit.DRLEnableSentinelRateLimiter = true
 			case "NonTransactional":
 				globalConf.RateLimit.EnableNonTransactionalRateLimiter = true
-			case "LeakyBucket":
-				globalConf.RateLimit.EnableLeakyBucketRateLimiter = true
 			default:
 				t.Fatal("There is no such a rate limiter:", limiter)
 			}
@@ -395,8 +393,4 @@ func TestMwRateLimiting_CustomRatelimitKeyDRL(t *testing.T) {
 
 func TestMwRateLimiting_CustomRatelimitKeyNonTransactional(t *testing.T) {
 	providerCustomRatelimitKey(t, "NonTransactional")
-}
-
-func TestMwRateLimiting_CustomRatelimitKeyEnableLeakyBucketRateLimiter(t *testing.T) {
-	providerCustomRatelimitKey(t, "LeakyBucket")
 }

--- a/gateway/util.go
+++ b/gateway/util.go
@@ -163,6 +163,10 @@ func shouldReloadSpec(existingSpec, newSpec *APISpec) bool {
 		return true
 	}
 
+	if !newSpec.CustomMiddlewareBundleDisabled && newSpec.CustomMiddlewareBundle != "" {
+		return true
+	}
+
 	if newSpec.CustomMiddleware.Driver == apidef.GrpcDriver {
 		return false
 	}

--- a/gateway/util_test.go
+++ b/gateway/util_test.go
@@ -449,6 +449,44 @@ func Test_shouldReloadSpec(t *testing.T) {
 
 		assertionHelper(t, tcs)
 	})
+
+	t.Run("bundle", func(t *testing.T) {
+		t.Parallel()
+		tcs := []testCase{
+			{
+				name: "bundle disabled",
+				spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddlewareBundleDisabled: true,
+						CustomMiddlewareBundle:         "bundle.zip",
+					},
+				},
+				want: false,
+			},
+			{
+				name: "bundle enabled with empty bundle value",
+				spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddlewareBundleDisabled: false,
+						CustomMiddlewareBundle:         "",
+					},
+				},
+				want: false,
+			},
+			{
+				name: "bundle enabled with valid bundle value",
+				spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddlewareBundleDisabled: false,
+						CustomMiddlewareBundle:         "bundle.zip",
+					},
+				},
+				want: true,
+			},
+		}
+
+		assertionHelper(t, tcs)
+	})
 }
 
 func TestAreMapsEqual(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/TykTechnologies/gojsonschema v0.0.0-20170222154038-dcb3e4bb7990
 	github.com/TykTechnologies/gorpc v0.0.0-20210624160652-fe65bda0ccb9
 	github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708
-	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20240209085720-1cf3310b87c4
+	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20240216093312-47bc0f5043b5
 	github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c
 	github.com/TykTechnologies/murmur3 v0.0.0-20230310161213-aad17efd5632
 	github.com/TykTechnologies/openid2go v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ github.com/TykTechnologies/gorpc v0.0.0-20210624160652-fe65bda0ccb9 h1:fbxHiuw/2
 github.com/TykTechnologies/gorpc v0.0.0-20210624160652-fe65bda0ccb9/go.mod h1:v6v7Mlj08+EmEcXOfpuTxGt2qYU9yhqqtv4QF9Wf50E=
 github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708 h1:cmXjlMzcexhc/Cg+QB/c2CPUVs1ux9xn6162qaf/LC4=
 github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708/go.mod h1:mkS8jKcz8otdfEXhJs1QQ/DKoIY1NFFsRPKS0RwQENI=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20240209085720-1cf3310b87c4 h1:/JOx9Jqhs9hkYCHCNuV/E9TxOXovLS10F2doUZ9H8Ek=
-github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20240209085720-1cf3310b87c4/go.mod h1:ZWio73jm6W96BcZGmGZlKGZ+JGfjAaTwTdLQbpSeJz8=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20240216093312-47bc0f5043b5 h1:awVnCCy6Vb1rnKXB/qTw46oeZDdA/V7ted1mex7Q5kE=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20240216093312-47bc0f5043b5/go.mod h1:ZWio73jm6W96BcZGmGZlKGZ+JGfjAaTwTdLQbpSeJz8=
 github.com/TykTechnologies/graphql-go-tools/v2 v2.0.0-20240131151522-40a1ee2bbfc3 h1:AN/173UtBXp69KOYxv02wi4dySSz0BzGj57x5dwiMrA=
 github.com/TykTechnologies/graphql-go-tools/v2 v2.0.0-20240131151522-40a1ee2bbfc3/go.mod h1:2WzP19RkAqCmrNOJFRR+u9pYkccG1UHkBbxVySwtnG4=
 github.com/TykTechnologies/kin-openapi v0.90.0 h1:kHw0mtANwIpmlU6eCeeCgRMa52EiPPhEZPuHc3lKawo=

--- a/internal/graphengine/graphql_go_tools_v1.go
+++ b/internal/graphengine/graphql_go_tools_v1.go
@@ -420,6 +420,15 @@ func (g *granularAccessCheckerV1) CheckGraphQLRequestFieldAllowance(w http.Respo
 		if accessDefinition.DisableIntrospection {
 			return GraphQLGranularAccessResult{FailReason: GranularAccessFailReasonIntrospectionDisabled}
 		}
+
+		// See TT-11260
+		//
+		// Introspection should be possible when Disable Introspection is turned off in policy settings,
+		// regardless of Allow List or Block List settings.
+		//
+		// Agreed solution: if Disable Introspection is turned off, then the Allow or Block list settings
+		// should be ignored, but only for the introspection query.
+		return GraphQLGranularAccessResult{FailReason: GranularAccessFailReasonNone}
 	}
 
 	if len(accessDefinition.AllowedTypes) != 0 {

--- a/internal/rate/rate_nodev.go
+++ b/internal/rate/rate_nodev.go
@@ -10,8 +10,5 @@ import (
 // LimiterKind returns the kind of rate limiter enabled by config.
 // This function is used for release builds.
 func LimiterKind(c *config.Config) (string, bool) {
-	if c.EnableLeakyBucketRateLimiter {
-		return LimitLeakyBucket, true
-	}
 	return "", false
 }

--- a/storage/connection_handler.go
+++ b/storage/connection_handler.go
@@ -273,8 +273,8 @@ func NewConnector(connType string, conf config.Config) (model.Connector, error) 
 			CAFile:             cfg.CAFile,
 			CertFile:           cfg.CertFile,
 			KeyFile:            cfg.KeyFile,
-			MinVersion:         cfg.MinVersion,
-			MaxVersion:         cfg.MaxVersion,
+			MinVersion:         cfg.TLSMinVersion,
+			MaxVersion:         cfg.TLSMaxVersion,
 		}
 		opts = append(opts, model.WithTLS(&tls))
 	}

--- a/storage/redis_shim.go
+++ b/storage/redis_shim.go
@@ -1,0 +1,1 @@
+package storage

--- a/swagger.yml
+++ b/swagger.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Tyk Gateway API
-  version: 5.2.0
+  version: 5.3.0
   description: |-
     The Tyk Gateway API is the primary means for integrating your application with the Tyk API Gateway system. This API is very small, and has no granular permissions system. It is intended to be used purely for internal automation and integration.
 


### PR DESCRIPTION
## **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description

In order to not break compatibility of goplugins importing the redis implementation of the last versions of gw, is required to create a bridge that translates old instructions into new redis store instructions.

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Implemented logic to allow GraphQL introspection queries regardless of Allow List or Block List settings when Disable Introspection is turned off.
- Added tests to ensure correct behavior of introspection queries under various policy configurations.
- Updated comments for clarity and consistency across various structs in the API definition.
- Renamed `MaxVersion` and `MinVersion` to `TLSMaxVersion` and `TLSMinVersion` in `StorageOptionsConf` and connection handler.
- Added `EnableLeakyBucketRateLimiter` field in `DevelopmentConfig` and removed `EnableLeakyBucketRateLimiter` field from `RateLimit`.
- Refactored `URLAllowedAndIgnored` for early internal endpoint check and added corresponding tests.
- Added check for `CustomMiddlewareBundleDisabled` and `CustomMiddlewareBundle` in `shouldReloadSpec` and added corresponding tests.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>adapter_proxy_only.go</strong><dd><code>Disable SingleFlight in ProxyOnly Engine Configuration</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/adapter/gqlengineadapter/adapter_proxy_only.go
- Disabled `EnableSingleFlight` in `ProxyOnly` engine configuration.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6095/files#diff-c3d2491b83997adf408861dc51e396c95e2baabba8286309f5c344cfcee7d78b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>adapter_udg.go</strong><dd><code>Disable SingleFlight in UDG Engine Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/adapter/gqlengineadapter/adapter_udg.go
- Disabled `EnableSingleFlight` in UDG engine configuration.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6095/files#diff-f01b6f97ed0e7bbe78b66c8d0c5e34fbabf49683a4a0784f7b25ebaabe97c03b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>oas.go</strong><dd><code>Skip Adding Servers with Named Parameters in OAS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/oas.go
<li>Added checks to skip adding servers with named parameters in <br><code>AddServers</code>.<br> <li> Return early if no new servers are added.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6095/files#diff-80279b1d59499a41a77ff7a16a6e2c9b9b785a4fd1326c351da6884c867658d7">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>config.go</strong><dd><code>Rename TLS Version Fields in StorageOptionsConf</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/config.go
<li>Renamed <code>MaxVersion</code> and <code>MinVersion</code> to <code>TLSMaxVersion</code> and <code>TLSMinVersion</code> <br>in <code>StorageOptionsConf</code>.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6095/files#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>development.go</strong><dd><code>Add Leaky Bucket Rate Limiter Field to DevelopmentConfig</code>&nbsp; </dd></summary>
<hr>

config/development.go
- Added `EnableLeakyBucketRateLimiter` field in `DevelopmentConfig`.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6095/files#diff-d2253d9377e5163d9de068a2df71738383fb97e0b07b64482404a83610cd53b8">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rate_limit.go</strong><dd><code>Remove Leaky Bucket Rate Limiter Field from RateLimit</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/rate_limit.go
- Removed `EnableLeakyBucketRateLimiter` field from `RateLimit`.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6095/files#diff-375bf116f8d6527c50d7591d7cb01e8f821b22df4a4ca18b4da4c6f0d526f18e">+0/-13</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>api_definition.go</strong><dd><code>Refactor URLAllowedAndIgnored for Early Internal Endpoint Check</code></dd></summary>
<hr>

gateway/api_definition.go
<li>Refactored <code>URLAllowedAndIgnored</code> to check for internal endpoints <br>earlier.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6095/files#diff-0cf80174bbafb36f6d4f4308ebbd971b2833b76a936bad568220aa1a4ba0ee8b">+10/-4</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>util.go</strong><dd><code>Add Check for Custom Middleware Bundle in shouldReloadSpec</code></dd></summary>
<hr>

gateway/util.go
<li>Added check for <code>CustomMiddlewareBundleDisabled</code> and <br><code>CustomMiddlewareBundle</code> in <code>shouldReloadSpec</code>.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6095/files#diff-1aa619f406837fb44ac6fba2c8922795eba0285dc4c8d2b0c15755b60b9ee1a5">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>graphql_go_tools_v1.go</strong><dd><code>Allow GraphQL Introspection with Allow/Block List Enabled</code></dd></summary>
<hr>

internal/graphengine/graphql_go_tools_v1.go
<li>Implemented logic to allow GraphQL introspection queries regardless of <br>Allow List or Block List settings when Disable Introspection is turned <br>off.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6095/files#diff-e592cc8ca6ac39e7574765d7f2bbf19193f173791a1b0930d4dde7f9412dc882">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>connection_handler.go</strong><dd><code>Rename TLS Version Fields in Connection Handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

storage/connection_handler.go
<li>Renamed <code>MaxVersion</code> and <code>MinVersion</code> to <code>TLSMaxVersion</code> and <code>TLSMinVersion</code> <br>in TLS configuration.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6095/files#diff-72363b0f8dc68eaf5cbf796451f0363df87931fc33077d8c1f1e7f0a2def928f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>authentication.go</strong><dd><code>Improve Comments in Authentication Structs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/authentication.go
<li>Updated comments for clarity and consistency across authentication <br>structs.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6095/files#diff-e51c9d24d4235e7cc53048cc1d92967d177585ba5e073f14876308a97bef6326">+12/-10</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>middleware.go</strong><dd><code>Improve Comments in Middleware Structs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/middleware.go
<li>Updated comments for clarity and consistency across middleware <br>structs.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6095/files#diff-992ec7c28d25fd54f6491d295389757705cd114bc869a35cba50d42e548cdc6e">+21/-17</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>oasutil.go</strong><dd><code>Clarify Comment for ShouldOmit Function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/oasutil.go
- Updated comment for `ShouldOmit` function for clarity.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6095/files#diff-acdca6da0b63041bf4f1979aacab64b344f7a540ffe4decc52574dde5cffbb33">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>operation.go</strong><dd><code>Improve Comments in Operation Structs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/operation.go
<li>Updated comments for clarity and consistency across operation structs.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6095/files#diff-6d92d2d5b09a5fa7129609bb7cd0d383d015250ec07062b6a93a83257be51fb5">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>root.go</strong><dd><code>Clarify Comment for State Struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/root.go
- Updated comment for `State` struct for clarity.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6095/files#diff-9c56b2bdb992e0a7db76809d4c516e1cd61c9486c7f0437b344c0032476af80f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>security.go</strong><dd><code>Improve Comments in Security Structs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/security.go
<li>Updated comments for clarity and consistency across security structs.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6095/files#diff-15e7d47137452ca4f3f6139aa8c007cdb426152c41846f712f8bf5dfb607afcc">+18/-11</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>server.go</strong><dd><code>Improve Comments in Server Configuration Structs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/server.go
<li>Updated comments for clarity and consistency across server <br>configuration structs.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6095/files#diff-21857c42e8659f7980014e277c3c758703f29e9e5c0c40553f2584cddb870808">+11/-11</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>upstream.go</strong><dd><code>Improve Comments in Upstream Configuration Structs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/upstream.go
<li>Updated comments for clarity and consistency across upstream <br>configuration structs.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6095/files#diff-7b0941c7f37fe5a2a23047e0822a65519ca11c371660f36555b59a60f000e3f4">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>url_rewrite.go</strong><dd><code>Improve Comments in URL Rewrite Configuration Structs</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/url_rewrite.go
<li>Updated comments for clarity and consistency across URL rewrite <br>configuration structs.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6095/files#diff-7317c6061fb6488e079d733230045c7cbc1b4b2ffb98bb7da20d4025f4976e51">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>oas_test.go</strong><dd><code>Add Tests for AddServers Method Handling Named Parameters</code></dd></summary>
<hr>

apidef/oas/oas_test.go
<li>Added tests for <code>AddServers</code> method to handle named parameters and empty <br>servers.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6095/files#diff-74029ee88132d30d6478c96a35f8bb2200e0c8e6f42f2c9b147dc6bb7ce74644">+45/-12</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>api_definition_test.go</strong><dd><code>Add Test for Internal Endpoint Middleware Handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_definition_test.go
- Added test for internal endpoint middleware handling.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6095/files#diff-2394daab6fdc5f8dc234699c80c0548947ee3d68d2e33858258d73a8b5eb6f44">+32/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_rate_limiting_test.go</strong><dd><code>Remove Tests for LeakyBucket Rate Limiter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_rate_limiting_test.go
- Removed tests for `LeakyBucket` rate limiter.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6095/files#diff-7cf2199231924147d538ba7ad576a48a3c0e691852077e147c9b2d86ba9b7c4d">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>util_test.go</strong><dd><code>Add Tests for shouldReloadSpec Handling Custom Middleware Bundle</code></dd></summary>
<hr>

gateway/util_test.go
<li>Added tests for <code>shouldReloadSpec</code> handling custom middleware bundle.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6095/files#diff-3ca88235eab68f9eb691c139bb6e45f10a4038d4c02cf435f66ef7394734f925">+38/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>graphql_go_tools_v1_test.go</strong><dd><code>Add Tests for GraphQL Introspection Query Behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/graphengine/graphql_go_tools_v1_test.go
<li>Added tests to ensure correct behavior of introspection queries under <br>various policy configurations.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6095/files#diff-f2bd01488bead3cbb84ccfbd8595400eb3153a94a19587308a9fe24edfc13267">+66/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

