### PR TITLE
[TT-11439/TT-11452] fix custom plugins contract

### DIFF
--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -305,9 +305,11 @@ func (g *Global) extractPrePluginsTo(api *apidef.APIDefinition) {
 		return
 	}
 
-	if g.PrePlugin != nil {
-		g.PrePlugin.ExtractTo(api)
+	if g.PrePlugin == nil {
+		g.PrePlugin = &PrePlugin{}
 	}
+
+	g.PrePlugin.ExtractTo(api)
 }
 
 func (g *Global) extractPostAuthenticationPluginsTo(api *apidef.APIDefinition) {
@@ -321,9 +323,11 @@ func (g *Global) extractPostAuthenticationPluginsTo(api *apidef.APIDefinition) {
 		return
 	}
 
-	if g.PostAuthenticationPlugin != nil {
-		g.PostAuthenticationPlugin.ExtractTo(api)
+	if g.PostAuthenticationPlugin == nil {
+		g.PostAuthenticationPlugin = &PostAuthenticationPlugin{}
 	}
+
+	g.PostAuthenticationPlugin.ExtractTo(api)
 }
 
 func (g *Global) extractPostPluginsTo(api *apidef.APIDefinition) {
@@ -337,9 +341,11 @@ func (g *Global) extractPostPluginsTo(api *apidef.APIDefinition) {
 		return
 	}
 
-	if g.PostPlugin != nil {
-		g.PostPlugin.ExtractTo(api)
+	if g.PostPlugin == nil {
+		g.PostPlugin = &PostPlugin{}
 	}
+
+	g.PostPlugin.ExtractTo(api)
 }
 
 func (g *Global) extractResponsePluginsTo(api *apidef.APIDefinition) {
@@ -352,9 +358,11 @@ func (g *Global) extractResponsePluginsTo(api *apidef.APIDefinition) {
 		g.ResponsePlugins.ExtractTo(api.CustomMiddleware.Response)
 	}
 
-	if g.ResponsePlugin != nil {
-		g.ResponsePlugin.ExtractTo(api)
+	if g.ResponsePlugin == nil {
+		g.ResponsePlugin = &ResponsePlugin{}
 	}
+
+	g.ResponsePlugin.ExtractTo(api)
 }
 
 // PluginConfigData configures config data for custom plugins.

--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -241,50 +241,11 @@ func (g *Global) ExtractTo(api *apidef.APIDefinition) {
 
 	g.CORS.ExtractTo(&api.CORS)
 
-	if g.PrePlugins != nil {
-		api.CustomMiddleware.Pre = make([]apidef.MiddlewareDefinition, len(g.PrePlugins))
-		g.PrePlugins.ExtractTo(api.CustomMiddleware.Pre)
-		g.PrePlugin = nil
-	} else {
-		if g.PrePlugin == nil {
-			g.PrePlugin = &PrePlugin{}
-			defer func() {
-				g.PrePlugin = nil
-			}()
-		}
+	g.extractPrePluginsTo(api)
 
-		g.PrePlugin.ExtractTo(api)
-	}
+	g.extractPostAuthenticationPluginsTo(api)
 
-	if g.PostAuthenticationPlugins != nil {
-		api.CustomMiddleware.PostKeyAuth = make([]apidef.MiddlewareDefinition, len(g.PostAuthenticationPlugins))
-		g.PostAuthenticationPlugins.ExtractTo(api.CustomMiddleware.PostKeyAuth)
-		g.PostAuthenticationPlugin = nil
-	} else {
-		if g.PostAuthenticationPlugin == nil {
-			g.PostAuthenticationPlugin = &PostAuthenticationPlugin{}
-			defer func() {
-				g.PostAuthenticationPlugin = nil
-			}()
-		}
-
-		g.PostAuthenticationPlugin.ExtractTo(api)
-	}
-
-	if g.PostPlugins != nil {
-		api.CustomMiddleware.Post = make([]apidef.MiddlewareDefinition, len(g.PostPlugins))
-		g.PostPlugins.ExtractTo(api.CustomMiddleware.Post)
-		g.PostPlugin = nil
-	} else {
-		if g.PostPlugin == nil {
-			g.PostPlugin = &PostPlugin{}
-			defer func() {
-				g.PostPlugin = nil
-			}()
-		}
-
-		g.PostPlugin.ExtractTo(api)
-	}
+	g.extractPostPluginsTo(api)
 
 	if g.Cache == nil {
 		g.Cache = &Cache{}
@@ -295,20 +256,7 @@ func (g *Global) ExtractTo(api *apidef.APIDefinition) {
 
 	g.Cache.ExtractTo(&api.CacheOptions)
 
-	if g.ResponsePlugins != nil {
-		api.CustomMiddleware.Response = make([]apidef.MiddlewareDefinition, len(g.ResponsePlugins))
-		g.ResponsePlugins.ExtractTo(api.CustomMiddleware.Response)
-		g.ResponsePlugin = nil
-	} else {
-		if g.ResponsePlugin == nil {
-			g.ResponsePlugin = &ResponsePlugin{}
-			defer func() {
-				g.ResponsePlugin = nil
-			}()
-		}
-
-		g.ResponsePlugin.ExtractTo(api)
-	}
+	g.extractResponsePluginsTo(api)
 
 	if g.TransformRequestHeaders == nil {
 		g.TransformRequestHeaders = &TransformHeaders{}
@@ -345,6 +293,74 @@ func (g *Global) ExtractTo(api *apidef.APIDefinition) {
 	vInfo.GlobalResponseHeaders = resHeaderMeta.AddHeaders
 	vInfo.GlobalResponseHeadersRemove = resHeaderMeta.DeleteHeaders
 	api.VersionData.Versions[Main] = vInfo
+}
+
+func (g *Global) extractPrePluginsTo(api *apidef.APIDefinition) {
+	if g.PrePlugins != nil {
+		api.CustomMiddleware.Pre = make([]apidef.MiddlewareDefinition, len(g.PrePlugins))
+		g.PrePlugins.ExtractTo(api.CustomMiddleware.Pre)
+		g.PrePlugin = nil
+	} else {
+		if g.PrePlugin == nil {
+			g.PrePlugin = &PrePlugin{}
+			defer func() {
+				g.PrePlugin = nil
+			}()
+		}
+
+		g.PrePlugin.ExtractTo(api)
+	}
+}
+
+func (g *Global) extractPostAuthenticationPluginsTo(api *apidef.APIDefinition) {
+	if g.PostAuthenticationPlugins != nil {
+		api.CustomMiddleware.PostKeyAuth = make([]apidef.MiddlewareDefinition, len(g.PostAuthenticationPlugins))
+		g.PostAuthenticationPlugins.ExtractTo(api.CustomMiddleware.PostKeyAuth)
+		g.PostAuthenticationPlugin = nil
+	} else {
+		if g.PostAuthenticationPlugin == nil {
+			g.PostAuthenticationPlugin = &PostAuthenticationPlugin{}
+			defer func() {
+				g.PostAuthenticationPlugin = nil
+			}()
+		}
+
+		g.PostAuthenticationPlugin.ExtractTo(api)
+	}
+}
+
+func (g *Global) extractPostPluginsTo(api *apidef.APIDefinition) {
+	if g.PostPlugins != nil {
+		api.CustomMiddleware.Post = make([]apidef.MiddlewareDefinition, len(g.PostPlugins))
+		g.PostPlugins.ExtractTo(api.CustomMiddleware.Post)
+		g.PostPlugin = nil
+	} else {
+		if g.PostPlugin == nil {
+			g.PostPlugin = &PostPlugin{}
+			defer func() {
+				g.PostPlugin = nil
+			}()
+		}
+
+		g.PostPlugin.ExtractTo(api)
+	}
+}
+
+func (g *Global) extractResponsePluginsTo(api *apidef.APIDefinition) {
+	if g.ResponsePlugins != nil {
+		api.CustomMiddleware.Response = make([]apidef.MiddlewareDefinition, len(g.ResponsePlugins))
+		g.ResponsePlugins.ExtractTo(api.CustomMiddleware.Response)
+		g.ResponsePlugin = nil
+	} else {
+		if g.ResponsePlugin == nil {
+			g.ResponsePlugin = &ResponsePlugin{}
+			defer func() {
+				g.ResponsePlugin = nil
+			}()
+		}
+
+		g.ResponsePlugin.ExtractTo(api)
+	}
 }
 
 // PluginConfigData configures config data for custom plugins.

--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -128,11 +128,12 @@ func (g *Global) MarshalJSON() ([]byte, error) {
 
 	type Alias Global
 
+	var payload = Alias(*g)
 	// to prevent infinite recursion
 	return json.Marshal(&struct {
-		*Alias
+		Alias
 	}{
-		Alias: (*Alias)(g),
+		Alias: payload,
 	})
 }
 

--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -120,6 +120,7 @@ func (g *Global) Fill(api apidef.APIDefinition) {
 	if g.PrePlugins == nil {
 		g.PrePlugins = make(CustomPlugins, len(api.CustomMiddleware.Pre))
 		g.PrePlugins.Fill(api.CustomMiddleware.Pre)
+		g.PrePlugin = nil
 	}
 
 	if ShouldOmit(g.PrePlugins) {
@@ -129,6 +130,7 @@ func (g *Global) Fill(api apidef.APIDefinition) {
 	if g.PostAuthenticationPlugins == nil {
 		g.PostAuthenticationPlugins = make(CustomPlugins, len(api.CustomMiddleware.PostKeyAuth))
 		g.PostAuthenticationPlugins.Fill(api.CustomMiddleware.PostKeyAuth)
+		g.PostAuthenticationPlugin = nil
 	}
 
 	if ShouldOmit(g.PostAuthenticationPlugins) {
@@ -138,6 +140,7 @@ func (g *Global) Fill(api apidef.APIDefinition) {
 	if g.PostPlugins == nil {
 		g.PostPlugins = make(CustomPlugins, len(api.CustomMiddleware.Post))
 		g.PostPlugins.Fill(api.CustomMiddleware.Post)
+		g.PostPlugin = nil
 	}
 
 	if ShouldOmit(g.PostPlugins) {
@@ -156,6 +159,7 @@ func (g *Global) Fill(api apidef.APIDefinition) {
 	if g.ResponsePlugins == nil {
 		g.ResponsePlugins = make(CustomPlugins, len(api.CustomMiddleware.Response))
 		g.ResponsePlugins.Fill(api.CustomMiddleware.Response)
+		g.ResponsePlugin = nil
 	}
 
 	if ShouldOmit(g.ResponsePlugins) {

--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -106,30 +106,30 @@ func (g *Global) MarshalJSON() ([]byte, error) {
 		return nil, nil
 	}
 
-	copyGlobal := *g
-	if copyGlobal.PrePlugin != nil {
-		copyGlobal.PrePlugins = copyGlobal.PrePlugin.Plugins
-		copyGlobal.PrePlugin = nil
-	}
-
-	if copyGlobal.PostAuthenticationPlugin != nil {
-		copyGlobal.PostAuthenticationPlugins = copyGlobal.PostAuthenticationPlugin.Plugins
-		copyGlobal.PostAuthenticationPlugin = nil
-	}
-
-	if copyGlobal.PostPlugin != nil {
-		copyGlobal.PostPlugins = copyGlobal.PostPlugin.Plugins
-		copyGlobal.PostPlugin = nil
-	}
-
-	if copyGlobal.ResponsePlugin != nil {
-		copyGlobal.ResponsePlugins = copyGlobal.ResponsePlugin.Plugins
-		copyGlobal.ResponsePlugin = nil
-	}
-
 	type Alias Global
 
-	var payload = Alias(copyGlobal)
+	var payload = Alias(*g)
+
+	if payload.PrePlugin != nil {
+		payload.PrePlugins = payload.PrePlugin.Plugins
+		payload.PrePlugin = nil
+	}
+
+	if payload.PostAuthenticationPlugin != nil {
+		payload.PostAuthenticationPlugins = payload.PostAuthenticationPlugin.Plugins
+		payload.PostAuthenticationPlugin = nil
+	}
+
+	if payload.PostPlugin != nil {
+		payload.PostPlugins = payload.PostPlugin.Plugins
+		payload.PostPlugin = nil
+	}
+
+	if payload.ResponsePlugin != nil {
+		payload.ResponsePlugins = payload.ResponsePlugin.Plugins
+		payload.ResponsePlugin = nil
+	}
+
 	// to prevent infinite recursion
 	return json.Marshal(payload)
 }

--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -97,6 +97,10 @@ type Global struct {
 	TransformResponseHeaders *TransformHeaders `bson:"transformResponseHeaders,omitempty" json:"transformResponseHeaders,omitempty"`
 }
 
+// MarshalJSON is a custom JSON marshaler for the Global struct. It is implemented
+// to facilitate a smooth migration from deprecated fields that were previously used to represent
+// the same data. This custom marshaler ensures backwards compatibility and proper handling of the
+// deprecated fields during the migration process.
 func (g *Global) MarshalJSON() ([]byte, error) {
 	if g == nil {
 		return nil, nil

--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -106,35 +106,32 @@ func (g *Global) MarshalJSON() ([]byte, error) {
 		return nil, nil
 	}
 
-	if g.PrePlugin != nil {
-		g.PrePlugins = g.PrePlugin.Plugins
-		g.PrePlugin = nil
+	copyGlobal := *g
+	if copyGlobal.PrePlugin != nil {
+		copyGlobal.PrePlugins = copyGlobal.PrePlugin.Plugins
+		copyGlobal.PrePlugin = nil
 	}
 
-	if g.PostAuthenticationPlugin != nil {
-		g.PostAuthenticationPlugins = g.PostAuthenticationPlugin.Plugins
-		g.PostAuthenticationPlugin = nil
+	if copyGlobal.PostAuthenticationPlugin != nil {
+		copyGlobal.PostAuthenticationPlugins = copyGlobal.PostAuthenticationPlugin.Plugins
+		copyGlobal.PostAuthenticationPlugin = nil
 	}
 
-	if g.PostPlugin != nil {
-		g.PostPlugins = g.PostPlugin.Plugins
-		g.PostPlugin = nil
+	if copyGlobal.PostPlugin != nil {
+		copyGlobal.PostPlugins = copyGlobal.PostPlugin.Plugins
+		copyGlobal.PostPlugin = nil
 	}
 
-	if g.ResponsePlugin != nil {
-		g.ResponsePlugins = g.ResponsePlugin.Plugins
-		g.ResponsePlugin = nil
+	if copyGlobal.ResponsePlugin != nil {
+		copyGlobal.ResponsePlugins = copyGlobal.ResponsePlugin.Plugins
+		copyGlobal.ResponsePlugin = nil
 	}
 
 	type Alias Global
 
-	var payload = Alias(*g)
+	var payload = Alias(copyGlobal)
 	// to prevent infinite recursion
-	return json.Marshal(&struct {
-		Alias
-	}{
-		Alias: payload,
-	})
+	return json.Marshal(payload)
 }
 
 // Fill fills *Global from apidef.APIDefinition.

--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -296,69 +296,65 @@ func (g *Global) ExtractTo(api *apidef.APIDefinition) {
 }
 
 func (g *Global) extractPrePluginsTo(api *apidef.APIDefinition) {
+	defer func() {
+		g.PrePlugin = nil
+	}()
+
+	// give precedence to PrePlugins over PrePlugin
 	if g.PrePlugins != nil {
 		api.CustomMiddleware.Pre = make([]apidef.MiddlewareDefinition, len(g.PrePlugins))
 		g.PrePlugins.ExtractTo(api.CustomMiddleware.Pre)
-		g.PrePlugin = nil
-	} else {
-		if g.PrePlugin == nil {
-			g.PrePlugin = &PrePlugin{}
-			defer func() {
-				g.PrePlugin = nil
-			}()
-		}
+		return
+	}
 
+	if g.PrePlugin != nil {
 		g.PrePlugin.ExtractTo(api)
 	}
 }
 
 func (g *Global) extractPostAuthenticationPluginsTo(api *apidef.APIDefinition) {
+	defer func() {
+		g.PostAuthenticationPlugin = nil
+	}()
+
 	if g.PostAuthenticationPlugins != nil {
 		api.CustomMiddleware.PostKeyAuth = make([]apidef.MiddlewareDefinition, len(g.PostAuthenticationPlugins))
 		g.PostAuthenticationPlugins.ExtractTo(api.CustomMiddleware.PostKeyAuth)
-		g.PostAuthenticationPlugin = nil
-	} else {
-		if g.PostAuthenticationPlugin == nil {
-			g.PostAuthenticationPlugin = &PostAuthenticationPlugin{}
-			defer func() {
-				g.PostAuthenticationPlugin = nil
-			}()
-		}
+		return
+	}
 
+	if g.PostAuthenticationPlugin != nil {
 		g.PostAuthenticationPlugin.ExtractTo(api)
 	}
 }
 
 func (g *Global) extractPostPluginsTo(api *apidef.APIDefinition) {
+	defer func() {
+		g.PostPlugin = nil
+	}()
+
 	if g.PostPlugins != nil {
 		api.CustomMiddleware.Post = make([]apidef.MiddlewareDefinition, len(g.PostPlugins))
 		g.PostPlugins.ExtractTo(api.CustomMiddleware.Post)
-		g.PostPlugin = nil
-	} else {
-		if g.PostPlugin == nil {
-			g.PostPlugin = &PostPlugin{}
-			defer func() {
-				g.PostPlugin = nil
-			}()
-		}
+		return
+	}
 
+	if g.PostPlugin != nil {
 		g.PostPlugin.ExtractTo(api)
 	}
 }
 
 func (g *Global) extractResponsePluginsTo(api *apidef.APIDefinition) {
+	defer func() {
+		g.ResponsePlugin = nil
+	}()
+
 	if g.ResponsePlugins != nil {
 		api.CustomMiddleware.Response = make([]apidef.MiddlewareDefinition, len(g.ResponsePlugins))
 		g.ResponsePlugins.ExtractTo(api.CustomMiddleware.Response)
-		g.ResponsePlugin = nil
-	} else {
-		if g.ResponsePlugin == nil {
-			g.ResponsePlugin = &ResponsePlugin{}
-			defer func() {
-				g.ResponsePlugin = nil
-			}()
-		}
+	}
 
+	if g.ResponsePlugin != nil {
 		g.ResponsePlugin.ExtractTo(api)
 	}
 }
@@ -1188,6 +1184,10 @@ type PrePlugin struct {
 	// Plugins configures custom plugins to be run on pre authentication stage.
 	// The plugins would be executed in the order of configuration in the list.
 	Plugins CustomPlugins `bson:"plugins,omitempty" json:"plugins,omitempty"`
+}
+
+func (p *PrePlugin) Migrate() CustomPlugins {
+	return p.Plugins
 }
 
 // Fill fills PrePlugin from supplied Tyk classic api definition.

--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -1124,6 +1124,10 @@ type CustomPlugins []CustomPlugin
 
 // Fill fills CustomPlugins from supplied Middleware definitions.
 func (c *CustomPlugins) Fill(mwDefs []apidef.MiddlewareDefinition) {
+	if len(mwDefs) == 0 {
+		return
+	}
+
 	customPlugins := make(CustomPlugins, len(mwDefs))
 	for i, mwDef := range mwDefs {
 		customPlugins[i] = CustomPlugin{

--- a/apidef/oas/middleware_test.go
+++ b/apidef/oas/middleware_test.go
@@ -22,14 +22,12 @@ func TestMiddleware(t *testing.T) {
 	assert.Equal(t, emptyMiddleware, resultMiddleware)
 
 	t.Run("plugins", func(t *testing.T) {
-		customPlugin := CustomPlugin{
-			Enabled:      true,
-			FunctionName: "func",
-			Path:         "/path",
-		}
-
 		customPlugins := CustomPlugins{
-			customPlugin,
+			CustomPlugin{
+				Enabled:      true,
+				FunctionName: "func",
+				Path:         "/path",
+			},
 		}
 		var pluginMW = Middleware{
 			Global: &Global{
@@ -53,7 +51,14 @@ func TestMiddleware(t *testing.T) {
 
 		pluginMW.ExtractTo(&convertedAPI)
 
-		var resultMiddleware Middleware
+		var resultMiddleware = Middleware{
+			Global: &Global{
+				PrePlugin:                &PrePlugin{},
+				PostAuthenticationPlugin: &PostAuthenticationPlugin{},
+				PostPlugin:               &PostPlugin{},
+				ResponsePlugin:           &ResponsePlugin{},
+			},
+		}
 		resultMiddleware.Fill(convertedAPI)
 
 		expectedMW := Middleware{

--- a/apidef/oas/middleware_test.go
+++ b/apidef/oas/middleware_test.go
@@ -403,6 +403,15 @@ func TestPrePlugin(t *testing.T) {
 
 func TestCustomPlugins(t *testing.T) {
 	t.Parallel()
+	t.Run("nil", func(t *testing.T) {
+		var (
+			nilCustomPlugins *CustomPlugins
+			mwDefs           []apidef.MiddlewareDefinition
+		)
+		nilCustomPlugins.ExtractTo(mwDefs)
+		assert.Nil(t, mwDefs)
+	})
+
 	t.Run("empty", func(t *testing.T) {
 		t.Parallel()
 		var (

--- a/apidef/oas/middleware_test.go
+++ b/apidef/oas/middleware_test.go
@@ -74,16 +74,49 @@ func TestMiddleware(t *testing.T) {
 }
 
 func TestGlobal(t *testing.T) {
-	var emptyGlobal Global
+	t.Run("empty", func(t *testing.T) {
+		var emptyGlobal Global
 
-	var convertedAPI apidef.APIDefinition
-	convertedAPI.SetDisabledFlags()
-	emptyGlobal.ExtractTo(&convertedAPI)
+		var convertedAPI apidef.APIDefinition
+		convertedAPI.SetDisabledFlags()
+		emptyGlobal.ExtractTo(&convertedAPI)
 
-	var resultGlobal Global
-	resultGlobal.Fill(convertedAPI)
+		var resultGlobal Global
+		resultGlobal.Fill(convertedAPI)
 
-	assert.Equal(t, emptyGlobal, resultGlobal)
+		assert.Equal(t, emptyGlobal, resultGlobal)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		g := Global{
+			PrePlugin: &PrePlugin{
+				Plugins: make(CustomPlugins, 1),
+			},
+			PostAuthenticationPlugin: &PostAuthenticationPlugin{
+				Plugins: make(CustomPlugins, 1),
+			},
+			PostPlugin: &PostPlugin{
+				Plugins: make(CustomPlugins, 1),
+			},
+			ResponsePlugin: &ResponsePlugin{
+				Plugins: make(CustomPlugins, 1),
+			},
+		}
+
+		body, err := json.Marshal(&g)
+		assert.NoError(t, err)
+
+		var updatedGlobal Global
+		assert.NoError(t, json.Unmarshal(body, &updatedGlobal))
+		assert.Nil(t, updatedGlobal.PrePlugin)
+		assert.NotNil(t, updatedGlobal.PrePlugins)
+		assert.Nil(t, updatedGlobal.PostAuthenticationPlugin)
+		assert.NotNil(t, updatedGlobal.PostAuthenticationPlugins)
+		assert.Nil(t, updatedGlobal.PostPlugin)
+		assert.NotNil(t, updatedGlobal.PostPlugins)
+		assert.Nil(t, updatedGlobal.ResponsePlugin)
+		assert.NotNil(t, updatedGlobal.ResponsePlugins)
+	})
 }
 
 func TestPluginConfig(t *testing.T) {

--- a/apidef/oas/middleware_test.go
+++ b/apidef/oas/middleware_test.go
@@ -20,6 +20,52 @@ func TestMiddleware(t *testing.T) {
 	resultMiddleware.Fill(convertedAPI)
 
 	assert.Equal(t, emptyMiddleware, resultMiddleware)
+
+	t.Run("plugins", func(t *testing.T) {
+		customPlugin := CustomPlugin{
+			Enabled:      true,
+			FunctionName: "func",
+			Path:         "/path",
+		}
+
+		customPlugins := CustomPlugins{
+			customPlugin,
+		}
+		var pluginMW = Middleware{
+			Global: &Global{
+				PrePlugin: &PrePlugin{
+					Plugins: customPlugins,
+				},
+				PostAuthenticationPlugin: &PostAuthenticationPlugin{
+					Plugins: customPlugins,
+				},
+				PostPlugin: &PostPlugin{
+					Plugins: customPlugins,
+				},
+				ResponsePlugin: &ResponsePlugin{
+					Plugins: customPlugins,
+				},
+			},
+		}
+
+		var convertedAPI apidef.APIDefinition
+		convertedAPI.SetDisabledFlags()
+
+		pluginMW.ExtractTo(&convertedAPI)
+
+		var resultMiddleware Middleware
+		resultMiddleware.Fill(convertedAPI)
+
+		expectedMW := Middleware{
+			Global: &Global{
+				PrePlugins:                customPlugins,
+				PostAuthenticationPlugins: customPlugins,
+				PostPlugins:               customPlugins,
+				ResponsePlugins:           customPlugins,
+			},
+		}
+		assert.Equal(t, expectedMW, resultMiddleware)
+	})
 }
 
 func TestGlobal(t *testing.T) {

--- a/apidef/oas/oas_test.go
+++ b/apidef/oas/oas_test.go
@@ -1123,16 +1123,15 @@ func TestMigrateAndFillOAS_CustomPlugins(t *testing.T) {
 		migratedAPI, _, err := MigrateAndFillOAS(&api)
 		assert.NoError(t, err)
 
-		expectedPrePlugin := PrePlugin{
-			Plugins: CustomPlugins{
-				{
-					Enabled:      true,
-					FunctionName: "Pre",
-					Path:         "/path/to/plugin",
-				},
+		expectedPrePlugin := CustomPlugins{
+			{
+				Enabled:      true,
+				FunctionName: "Pre",
+				Path:         "/path/to/plugin",
 			},
 		}
-		assert.Equal(t, expectedPrePlugin, *migratedAPI.OAS.GetTykExtension().Middleware.Global.PrePlugin)
+		assert.Equal(t, expectedPrePlugin, migratedAPI.OAS.GetTykExtension().Middleware.Global.PrePlugins)
+		assert.Nil(t, migratedAPI.OAS.GetTykExtension().Middleware.Global.PrePlugin)
 		assert.Equal(t, apidef.GoPluginDriver, migratedAPI.OAS.GetTykExtension().Middleware.Global.PluginConfig.Driver)
 	})
 
@@ -1161,16 +1160,15 @@ func TestMigrateAndFillOAS_CustomPlugins(t *testing.T) {
 		migratedAPI, _, err := MigrateAndFillOAS(&api)
 		assert.NoError(t, err)
 
-		expectedPrePlugin := PostAuthenticationPlugin{
-			Plugins: CustomPlugins{
-				{
-					Enabled:      true,
-					FunctionName: "PostAuth",
-					Path:         "/path/to/plugin",
-				},
+		expectedPrePlugin := CustomPlugins{
+			{
+				Enabled:      true,
+				FunctionName: "PostAuth",
+				Path:         "/path/to/plugin",
 			},
 		}
-		assert.Equal(t, expectedPrePlugin, *migratedAPI.OAS.GetTykExtension().Middleware.Global.PostAuthenticationPlugin)
+		assert.Equal(t, expectedPrePlugin, migratedAPI.OAS.GetTykExtension().Middleware.Global.PostAuthenticationPlugins)
+		assert.Nil(t, migratedAPI.OAS.GetTykExtension().Middleware.Global.PostAuthenticationPlugin)
 		assert.Equal(t, apidef.GoPluginDriver, migratedAPI.OAS.GetTykExtension().Middleware.Global.PluginConfig.Driver)
 	})
 
@@ -1199,16 +1197,15 @@ func TestMigrateAndFillOAS_CustomPlugins(t *testing.T) {
 		migratedAPI, _, err := MigrateAndFillOAS(&api)
 		assert.NoError(t, err)
 
-		expectedPrePlugin := PostPlugin{
-			Plugins: CustomPlugins{
-				{
-					Enabled:      true,
-					FunctionName: "Post",
-					Path:         "/path/to/plugin",
-				},
+		expectedPrePlugin := CustomPlugins{
+			{
+				Enabled:      true,
+				FunctionName: "Post",
+				Path:         "/path/to/plugin",
 			},
 		}
-		assert.Equal(t, expectedPrePlugin, *migratedAPI.OAS.GetTykExtension().Middleware.Global.PostPlugin)
+		assert.Equal(t, expectedPrePlugin, migratedAPI.OAS.GetTykExtension().Middleware.Global.PostPlugins)
+		assert.Nil(t, migratedAPI.OAS.GetTykExtension().Middleware.Global.PostPlugin)
 		assert.Equal(t, apidef.GoPluginDriver, migratedAPI.OAS.GetTykExtension().Middleware.Global.PluginConfig.Driver)
 	})
 
@@ -1237,16 +1234,15 @@ func TestMigrateAndFillOAS_CustomPlugins(t *testing.T) {
 		migratedAPI, _, err := MigrateAndFillOAS(&api)
 		assert.NoError(t, err)
 
-		expectedPrePlugin := ResponsePlugin{
-			Plugins: CustomPlugins{
-				{
-					Enabled:      true,
-					FunctionName: "Response",
-					Path:         "/path/to/plugin",
-				},
+		expectedPrePlugin := CustomPlugins{
+			{
+				Enabled:      true,
+				FunctionName: "Response",
+				Path:         "/path/to/plugin",
 			},
 		}
-		assert.Equal(t, expectedPrePlugin, *migratedAPI.OAS.GetTykExtension().Middleware.Global.ResponsePlugin)
+		assert.Equal(t, expectedPrePlugin, migratedAPI.OAS.GetTykExtension().Middleware.Global.ResponsePlugins)
+		assert.Nil(t, migratedAPI.OAS.GetTykExtension().Middleware.Global.ResponsePlugin)
 		assert.Equal(t, apidef.GoPluginDriver, migratedAPI.OAS.GetTykExtension().Middleware.Global.PluginConfig.Driver)
 	})
 }

--- a/apidef/oas/root.go
+++ b/apidef/oas/root.go
@@ -1,6 +1,7 @@
 package oas
 
 import (
+	"encoding/json"
 	"sort"
 
 	"github.com/TykTechnologies/storage/persistent/model"
@@ -20,6 +21,38 @@ type XTykAPIGateway struct {
 	Server Server `bson:"server" json:"server"` // required
 	// Middleware contains the configurations related to the Tyk middleware.
 	Middleware *Middleware `bson:"middleware,omitempty" json:"middleware,omitempty"`
+}
+
+func (x *XTykAPIGateway) MarshalJSON() ([]byte, error) {
+	if x.Middleware != nil && x.Middleware.Global != nil {
+		if x.Middleware.Global.PrePlugin != nil {
+			x.Middleware.Global.PrePlugins = x.Middleware.Global.PrePlugin.Plugins
+			x.Middleware.Global.PrePlugin = nil
+		}
+
+		if x.Middleware.Global.PostAuthenticationPlugin != nil {
+			x.Middleware.Global.PostAuthenticationPlugins = x.Middleware.Global.PostAuthenticationPlugin.Plugins
+			x.Middleware.Global.PostAuthenticationPlugin = nil
+		}
+
+		if x.Middleware.Global.PostPlugin != nil {
+			x.Middleware.Global.PostPlugins = x.Middleware.Global.PostPlugin.Plugins
+			x.Middleware.Global.PostPlugin = nil
+		}
+
+		if x.Middleware.Global.ResponsePlugin != nil {
+			x.Middleware.Global.ResponsePlugins = x.Middleware.Global.ResponsePlugin.Plugins
+			x.Middleware.Global.ResponsePlugin = nil
+		}
+	}
+	type Alias XTykAPIGateway
+
+	// to prevent infinite recursion
+	return json.Marshal(&struct {
+		*Alias
+	}{
+		Alias: (*Alias)(x),
+	})
 }
 
 // Fill fills *XTykAPIGateway from apidef.APIDefinition.

--- a/apidef/oas/root.go
+++ b/apidef/oas/root.go
@@ -1,7 +1,6 @@
 package oas
 
 import (
-	"encoding/json"
 	"sort"
 
 	"github.com/TykTechnologies/storage/persistent/model"
@@ -21,38 +20,6 @@ type XTykAPIGateway struct {
 	Server Server `bson:"server" json:"server"` // required
 	// Middleware contains the configurations related to the Tyk middleware.
 	Middleware *Middleware `bson:"middleware,omitempty" json:"middleware,omitempty"`
-}
-
-func (x *XTykAPIGateway) MarshalJSON() ([]byte, error) {
-	if x.Middleware != nil && x.Middleware.Global != nil {
-		if x.Middleware.Global.PrePlugin != nil {
-			x.Middleware.Global.PrePlugins = x.Middleware.Global.PrePlugin.Plugins
-			x.Middleware.Global.PrePlugin = nil
-		}
-
-		if x.Middleware.Global.PostAuthenticationPlugin != nil {
-			x.Middleware.Global.PostAuthenticationPlugins = x.Middleware.Global.PostAuthenticationPlugin.Plugins
-			x.Middleware.Global.PostAuthenticationPlugin = nil
-		}
-
-		if x.Middleware.Global.PostPlugin != nil {
-			x.Middleware.Global.PostPlugins = x.Middleware.Global.PostPlugin.Plugins
-			x.Middleware.Global.PostPlugin = nil
-		}
-
-		if x.Middleware.Global.ResponsePlugin != nil {
-			x.Middleware.Global.ResponsePlugins = x.Middleware.Global.ResponsePlugin.Plugins
-			x.Middleware.Global.ResponsePlugin = nil
-		}
-	}
-	type Alias XTykAPIGateway
-
-	// to prevent infinite recursion
-	return json.Marshal(&struct {
-		*Alias
-	}{
-		Alias: (*Alias)(x),
-	})
 }
 
 // Fill fills *XTykAPIGateway from apidef.APIDefinition.

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -301,14 +301,18 @@
       "additionalProperties": false,
       "properties": {
         "plugins": {
-          "type": "array",
-          "items": [
-            {
-              "$ref": "#/definitions/X-Tyk-CustomPluginDefinition"
-            }
-          ]
+          "$ref": "#/definitions/X-Tyk-CustomPlugins"
         }
       }
+    },
+    "X-Tyk-CustomPlugins": {
+      "type": "array",
+      "items": [
+        {
+          "$ref": "#/definitions/X-Tyk-CustomPluginDefinition"
+        }
+      ],
+      "minItems": 1
     },
     "X-Tyk-CustomPluginDefinition": {
       "additionalProperties": false,
@@ -538,14 +542,26 @@
         "prePlugin": {
           "$ref": "#/definitions/X-Tyk-CustomPluginConfig"
         },
+        "prePlugins": {
+          "$ref": "#/definitions/X-Tyk-CustomPlugins"
+        },
         "postAuthenticationPlugin": {
           "$ref": "#/definitions/X-Tyk-CustomPluginConfig"
+        },
+        "postAuthenticationPlugins": {
+          "$ref": "#/definitions/X-Tyk-CustomPlugins"
         },
         "postPlugin": {
           "$ref": "#/definitions/X-Tyk-CustomPluginConfig"
         },
+        "postPlugins": {
+          "$ref": "#/definitions/X-Tyk-CustomPlugins"
+        },
         "responsePlugin": {
           "$ref": "#/definitions/X-Tyk-CustomPluginConfig"
+        },
+        "responsePlugins": {
+          "$ref": "#/definitions/X-Tyk-CustomPlugins"
         },
         "cache": {
           "$ref": "#/definitions/X-Tyk-Cache"


### PR DESCRIPTION
## **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description

Fix custom plugins contract in OAS API definition to remove unnecessary nesting. 

## Related Issue
Parent: https://tyktech.atlassian.net/browse/TT-11439
Subtask: https://tyktech.atlassian.net/browse/TT-11452

## Motivation and Context

At the moment the Plugins configuration at API level follows this structure: 

```
responsePlugin: 
  plugins:
    - enabled: true
      functionName: ...
```

Same happens for: `responsePlugin`, `prePlugin`, `postPlugin`, `postAuthenticationPlugin` sections.

Having a `plugins` subsection doesn’t make sense at this point as there aren’t multiple options, so this PR removes the `plugins` structure and use the array of plugins directly in the main section, like: 
```
responsePlugins:
  - enabled true
    ....
```
Also all the plugin sections should be using plural: i.e `responsePlugins`, `prePlugins`, `postPlugins`, `postAuthenticationPlugins`. 
This PR adds these fields alongside maintaining `responsePlugin`, `prePlugin`, `postPlugin`, `postAuthenticationPlugin`  with a deprecated note, for backwards compatibility. This also provides an opportunity to do the migration in memory without doing hard storage level migrations.

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Deprecated singular custom plugin configurations (`PrePlugin`, `PostAuthenticationPlugin`, `PostPlugin`, `ResponsePlugin`) in favor of plural forms (`PrePlugins`, `PostAuthenticationPlugins`, `PostPlugins`, `ResponsePlugins`) to remove unnecessary nesting and align with the structure of having multiple plugins directly under their respective sections.
- Added new plural fields for custom plugins configuration, allowing for a more intuitive and streamlined configuration structure.
- Updated `Fill` and `ExtractTo` methods in `middleware.go` to support both singular and plural plugin configurations, ensuring backward compatibility.
- Introduced new schema definitions in `x-tyk-api-gateway.json` for the plural forms of custom plugins configurations and marked the singular forms as deprecated.
- Added and updated tests in `middleware_test.go` and `oas_test.go` to validate the migration from singular to plural plugin configurations.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>middleware.go</strong><dd><code>Refactor Custom Plugins Configuration to Support Plural Forms</code></dd></summary>
<hr>

apidef/oas/middleware.go
<li>Deprecated <code>PrePlugin</code>, <code>PostAuthenticationPlugin</code>, <code>PostPlugin</code>, and <br><code>ResponsePlugin</code> in favor of plural forms.<br> <li> Added new plural fields <code>PrePlugins</code>, <code>PostAuthenticationPlugins</code>, <br><code>PostPlugins</code>, and <code>ResponsePlugins</code> for custom plugins configuration.<br> <li> Updated <code>Fill</code> and <code>ExtractTo</code> methods to support both singular and plural <br>plugin configurations.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6097/files#diff-992ec7c28d25fd54f6491d295389757705cd114bc869a35cba50d42e548cdc6e">+91/-51</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>x-tyk-api-gateway.json</strong><dd><code>Schema Update to Support Plural Custom Plugins Configuration</code></dd></summary>
<hr>

apidef/oas/schema/x-tyk-api-gateway.json
<li>Introduced new schema definitions for plural custom plugins <br>configurations.<br> <li> Deprecated singular custom plugin configurations in favor of plural <br>forms.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6097/files#diff-78828969c0c04cc1a776dfc93a8bad3c499a8c83e6169f83e96d090bed3e7dd0">+20/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>middleware_test.go</strong><dd><code>Add Tests for Plural Custom Plugins Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/middleware_test.go
<li>Added tests to validate the migration from singular to plural plugin <br>configurations.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6097/files#diff-0af31cb29ae298a6ac3e402b283ab364a6fd793fd04f253ef7c4983234c17bef">+46/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>oas_test.go</strong><dd><code>Update Tests to Support Plural Custom Plugins Configuration</code></dd></summary>
<hr>

apidef/oas/oas_test.go
<li>Updated tests to reflect changes in custom plugins configuration from <br>singular to plural forms.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6097/files#diff-74029ee88132d30d6478c96a35f8bb2200e0c8e6f42f2c9b147dc6bb7ce74644">+28/-32</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

