### PR TITLE
[TT-11440/TT-11461] Add functionName to replace name in OAS virtual endpoint and endpoint  post plugin

### DIFF
--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -1220,6 +1220,9 @@ type VirtualEndpoint struct {
 	RequireSession bool `bson:"requireSession,omitempty" json:"requireSession,omitempty"`
 }
 
+// MarshalJSON is a custom JSON marshaler for the VirtualEndpoint struct. It is implemented
+// to facilitate a smooth migration from deprecated fields that were previously used to represent
+// the same data.
 func (v *VirtualEndpoint) MarshalJSON() ([]byte, error) {
 	if v.FunctionName == "" && v.Name != "" {
 		v.FunctionName = v.Name
@@ -1286,6 +1289,9 @@ type EndpointPostPlugin struct {
 	Path string `bson:"path" json:"path"` // required.
 }
 
+// MarshalJSON is a custom JSON marshaler for the EndpointPostPlugin struct. It is implemented
+// to facilitate a smooth migration from deprecated fields that were previously used to represent
+// the same data.
 func (ep *EndpointPostPlugin) MarshalJSON() ([]byte, error) {
 	if ep.FunctionName == "" && ep.Name != "" {
 		ep.FunctionName = ep.Name

--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -1227,15 +1227,16 @@ func (v *VirtualEndpoint) MarshalJSON() ([]byte, error) {
 	if v == nil {
 		return nil, nil
 	}
-	copyVirtualEndpoint := *v
-	if copyVirtualEndpoint.FunctionName == "" && copyVirtualEndpoint.Name != "" {
-		copyVirtualEndpoint.FunctionName = copyVirtualEndpoint.Name
-		copyVirtualEndpoint.Name = ""
-	}
 
 	type Alias VirtualEndpoint
 
-	var payload = Alias(copyVirtualEndpoint)
+	var payload = Alias(*v)
+
+	if payload.FunctionName == "" && payload.Name != "" {
+		payload.FunctionName = payload.Name
+		payload.Name = ""
+	}
+
 	// to prevent infinite recursion
 	return json.Marshal(payload)
 }
@@ -1298,16 +1299,15 @@ func (ep *EndpointPostPlugin) MarshalJSON() ([]byte, error) {
 		return nil, nil
 	}
 
-	copyEndpointPostPlugin := *ep
-	if copyEndpointPostPlugin.FunctionName == "" && copyEndpointPostPlugin.Name != "" {
-		copyEndpointPostPlugin.FunctionName = copyEndpointPostPlugin.Name
-		copyEndpointPostPlugin.Name = ""
-	}
-
 	// to prevent infinite recursion
 	type Alias EndpointPostPlugin
 
-	payload := Alias(copyEndpointPostPlugin)
+	payload := Alias(*ep)
+	if payload.FunctionName == "" && payload.Name != "" {
+		payload.FunctionName = payload.Name
+		payload.Name = ""
+	}
+
 	return json.Marshal(payload)
 }
 

--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -1,6 +1,7 @@
 package oas
 
 import (
+	"encoding/json"
 	"net/http"
 	"sort"
 	"strings"
@@ -1219,6 +1220,22 @@ type VirtualEndpoint struct {
 	RequireSession bool `bson:"requireSession,omitempty" json:"requireSession,omitempty"`
 }
 
+func (v *VirtualEndpoint) MarshalJSON() ([]byte, error) {
+	if v.FunctionName == "" && v.Name != "" {
+		v.FunctionName = v.Name
+		v.Name = ""
+	}
+
+	type Alias VirtualEndpoint
+
+	// to prevent infinite recursion
+	return json.Marshal(&struct {
+		*Alias
+	}{
+		Alias: (*Alias)(v),
+	})
+}
+
 // Fill fills *VirtualEndpoint from apidef.VirtualMeta.
 func (v *VirtualEndpoint) Fill(meta apidef.VirtualMeta) {
 	v.Enabled = !meta.Disabled
@@ -1267,6 +1284,22 @@ type EndpointPostPlugin struct {
 	FunctionName string `bson:"functionName" json:"functionName"` // required.
 	// Path is the path to plugin.
 	Path string `bson:"path" json:"path"` // required.
+}
+
+func (ep *EndpointPostPlugin) MarshalJSON() ([]byte, error) {
+	if ep.FunctionName == "" && ep.Name != "" {
+		ep.FunctionName = ep.Name
+		ep.Name = ""
+	}
+
+	type Alias EndpointPostPlugin
+
+	// to prevent infinite recursion
+	return json.Marshal(&struct {
+		*Alias
+	}{
+		Alias: (*Alias)(ep),
+	})
 }
 
 // Fill fills *EndpointPostPlugin from apidef.GoPluginMeta.

--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -1224,19 +1224,20 @@ type VirtualEndpoint struct {
 // to facilitate a smooth migration from deprecated fields that were previously used to represent
 // the same data.
 func (v *VirtualEndpoint) MarshalJSON() ([]byte, error) {
-	if v.FunctionName == "" && v.Name != "" {
-		v.FunctionName = v.Name
-		v.Name = ""
+	if v == nil {
+		return nil, nil
+	}
+	copyVirtualEndpoint := *v
+	if copyVirtualEndpoint.FunctionName == "" && copyVirtualEndpoint.Name != "" {
+		copyVirtualEndpoint.FunctionName = copyVirtualEndpoint.Name
+		copyVirtualEndpoint.Name = ""
 	}
 
 	type Alias VirtualEndpoint
 
+	var payload = Alias(copyVirtualEndpoint)
 	// to prevent infinite recursion
-	return json.Marshal(&struct {
-		*Alias
-	}{
-		Alias: (*Alias)(v),
-	})
+	return json.Marshal(payload)
 }
 
 // Fill fills *VirtualEndpoint from apidef.VirtualMeta.
@@ -1293,19 +1294,21 @@ type EndpointPostPlugin struct {
 // to facilitate a smooth migration from deprecated fields that were previously used to represent
 // the same data.
 func (ep *EndpointPostPlugin) MarshalJSON() ([]byte, error) {
-	if ep.FunctionName == "" && ep.Name != "" {
-		ep.FunctionName = ep.Name
-		ep.Name = ""
+	if ep == nil {
+		return nil, nil
 	}
 
-	type Alias EndpointPostPlugin
+	copyEndpointPostPlugin := *ep
+	if copyEndpointPostPlugin.FunctionName == "" && copyEndpointPostPlugin.Name != "" {
+		copyEndpointPostPlugin.FunctionName = copyEndpointPostPlugin.Name
+		copyEndpointPostPlugin.Name = ""
+	}
 
 	// to prevent infinite recursion
-	return json.Marshal(&struct {
-		*Alias
-	}{
-		Alias: (*Alias)(ep),
-	})
+	type Alias EndpointPostPlugin
+
+	payload := Alias(copyEndpointPostPlugin)
+	return json.Marshal(payload)
 }
 
 // Fill fills *EndpointPostPlugin from apidef.GoPluginMeta.

--- a/apidef/oas/middleware_test.go
+++ b/apidef/oas/middleware_test.go
@@ -1,6 +1,7 @@
 package oas
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -714,6 +715,17 @@ func TestVirtualEndpoint(t *testing.T) {
 		expectedVirtualEndpoint.Path = ""
 		assert.Equal(t, expectedVirtualEndpoint, actualVirtualEndpoint)
 	})
+
+	t.Run("json", func(t *testing.T) {
+		v := VirtualEndpoint{
+			Enabled: true,
+			Name:    "func",
+		}
+		body, err := json.Marshal(&v)
+		assert.NoError(t, err)
+		assert.Contains(t, string(body), "functionName")
+		assert.NotContains(t, string(body), "name")
+	})
 }
 
 func TestEndpointPostPlugins(t *testing.T) {
@@ -783,6 +795,17 @@ func TestEndpointPostPlugins(t *testing.T) {
 		expectedEndpointPostPlugins := endpointPostPlugin
 		expectedEndpointPostPlugins[0].Name = ""
 		assert.Equal(t, expectedEndpointPostPlugins, actualEndpointPostPlugins)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		v := EndpointPostPlugin{
+			Enabled: true,
+			Name:    "func",
+		}
+		body, err := json.Marshal(&v)
+		assert.NoError(t, err)
+		assert.Contains(t, string(body), "functionName")
+		assert.NotContains(t, string(body), "name")
 	})
 }
 

--- a/apidef/oas/operation_test.go
+++ b/apidef/oas/operation_test.go
@@ -49,7 +49,9 @@ func TestOAS_PathsAndOperations(t *testing.T) {
 	operation.TransformRequestBody.Path = ""          // if `path` and `body` are present, `body` would take precedence, detailed tests can be found in middleware_test.go
 	operation.TransformResponseBody.Path = ""         // if `path` and `body` are present, `body` would take precedence, detailed tests can be found in middleware_test.go
 	operation.VirtualEndpoint.Path = ""               // if `path` and `body` are present, `body` would take precedence, detailed tests can be found in middleware_test.go
+	operation.VirtualEndpoint.Name = ""               // Name is deprecated.
 	operation.PostPlugins = operation.PostPlugins[:1] // only 1 post plugin is considered at this point, ignore others.
+	operation.PostPlugins[0].Name = ""                // Name is deprecated.
 	xTykAPIGateway := &XTykAPIGateway{
 		Middleware: &Middleware{
 			Operations: Operations{

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -788,6 +788,9 @@
         "name": {
           "type": "string"
         },
+        "functionName": {
+          "type": "string"
+        },
         "path": {
           "type": "string"
         },
@@ -803,7 +806,7 @@
       },
       "required": [
         "enabled",
-        "name"
+        "functionName"
       ]
     },
     "X-Tyk-URLRewrite": {
@@ -941,13 +944,16 @@
         "name": {
           "type": "string"
         },
+        "functionName": {
+          "type": "string"
+        },
         "path": {
           "type": "string"
         }
       },
       "required": [
         "enabled",
-        "name",
+        "functionName",
         "path"
       ]
     },


### PR DESCRIPTION
## **User description**
<!-- Provide a general summary of your changes in the Title above -->

Add functionName to replace name in OAS virtual endpoint and endpoint  post plugin
<!-- Describe your changes in detail -->

## Related Issue
https://tyktech.atlassian.net/browse/TT-11440
https://tyktech.atlassian.net/browse/TT-11461

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

## **Type**
enhancement


___

## **Description**
- Deprecated `Name` field in favor of `FunctionName` for both `VirtualEndpoint` and `EndpointPostPlugin` configurations to clarify the purpose and usage.
- Ensured backward compatibility by retaining the `Name` field but marking it as deprecated.
- Updated related methods (`Fill` and `ExtractTo`) to prioritize `FunctionName` over `Name` when both are provided.
- Modified and added unit tests to reflect changes and validate the precedence of `FunctionName` over `Name`.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>middleware.go</strong><dd><code>Deprecate Name in Favor of FunctionName for Plugin Configurations</code></dd></summary>
<hr>

apidef/oas/middleware.go
<li>Deprecated <code>Name</code> in favor of <code>FunctionName</code> for both <code>VirtualEndpoint</code> and <br><code>EndpointPostPlugin</code>.<br> <li> Added handling to prefer <code>FunctionName</code> over <code>Name</code> if both are provided.<br> <li> Updated <code>Fill</code> and <code>ExtractTo</code> methods to support the new <code>FunctionName</code> <br>field.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6098/files#diff-992ec7c28d25fd54f6491d295389757705cd114bc869a35cba50d42e548cdc6e">+26/-9</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>middleware_test.go</strong><dd><code>Update Tests for FunctionName Precedence and Usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/middleware_test.go
<li>Updated tests to use <code>FunctionName</code> instead of <code>Name</code>.<br> <li> Added tests to ensure <code>FunctionName</code> has precedence over <code>Name</code>.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6098/files#diff-0af31cb29ae298a6ac3e402b283ab364a6fd793fd04f253ef7c4983234c17bef">+59/-6</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

