### PR TITLE
Merging to release-5.3.0: [TT-11413] Fix apidef GlobalRateLimit migrations (#6086)

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -742,8 +742,9 @@ type SignatureConfig struct {
 }
 
 type GlobalRateLimit struct {
-	Rate float64 `bson:"rate" json:"rate"`
-	Per  float64 `bson:"per" json:"per"`
+	Disabled bool    `bson:"disabled" json:"disabled"`
+	Rate     float64 `bson:"rate" json:"rate"`
+	Per      float64 `bson:"per" json:"per"`
 }
 
 type BundleManifest struct {

--- a/apidef/migration.go
+++ b/apidef/migration.go
@@ -455,8 +455,8 @@ func (a *APIDefinition) SetDisabledFlags() {
 		}
 	}
 
-	if a.GlobalRateLimit.Per == 0 && a.GlobalRateLimit.Rate == 0 {
-		a.DisableRateLimit = true
+	if a.GlobalRateLimit.Per <= 0 || a.GlobalRateLimit.Rate <= 0 {
+		a.GlobalRateLimit.Disabled = true
 	}
 }
 
@@ -490,7 +490,7 @@ func (a *APIDefinition) migrateResponseProcessors() {
 }
 
 func (a *APIDefinition) migrateGlobalRateLimit() {
-	if a.GlobalRateLimit.Per == 0 && a.GlobalRateLimit.Rate == 0 {
-		a.DisableRateLimit = true
+	if a.GlobalRateLimit.Per <= 0 || a.GlobalRateLimit.Rate <= 0 {
+		a.GlobalRateLimit.Disabled = true
 	}
 }

--- a/apidef/migration_test.go
+++ b/apidef/migration_test.go
@@ -694,7 +694,9 @@ func TestSetDisabledFlags(t *testing.T) {
 				},
 			},
 		},
-		DisableRateLimit: true,
+		GlobalRateLimit: GlobalRateLimit{
+			Disabled: true,
+		},
 	}
 	apiDef.SetDisabledFlags()
 	assert.Equal(t, expectedAPIDef, apiDef)
@@ -773,7 +775,7 @@ func TestAPIDefinition_migrateGlobalRateLimit(t *testing.T) {
 		_, err := base.Migrate()
 		assert.NoError(t, err)
 
-		assert.True(t, base.DisableRateLimit)
+		assert.True(t, base.GlobalRateLimit.Disabled)
 	})
 
 	t.Run("per!=0,rate=0", func(t *testing.T) {
@@ -782,7 +784,25 @@ func TestAPIDefinition_migrateGlobalRateLimit(t *testing.T) {
 		_, err := base.Migrate()
 		assert.NoError(t, err)
 
-		assert.False(t, base.DisableRateLimit)
+		assert.True(t, base.GlobalRateLimit.Disabled)
 	})
 
+	t.Run("per=0,rate!=0", func(t *testing.T) {
+		base := oldTestAPI()
+		base.GlobalRateLimit.Rate = 1
+		_, err := base.Migrate()
+		assert.NoError(t, err)
+
+		assert.True(t, base.GlobalRateLimit.Disabled)
+	})
+
+	t.Run("per!=0,rate!=0", func(t *testing.T) {
+		base := oldTestAPI()
+		base.GlobalRateLimit.Rate = 1
+		base.GlobalRateLimit.Per = 1
+		_, err := base.Migrate()
+		assert.NoError(t, err)
+
+		assert.False(t, base.GlobalRateLimit.Disabled)
+	})
 }

--- a/apidef/oas/oas_test.go
+++ b/apidef/oas/oas_test.go
@@ -152,6 +152,7 @@ func TestOAS_ExtractTo_ResetAPIDefinition(t *testing.T) {
 	a.ConfigDataDisabled = false
 	a.CustomMiddleware.AuthCheck.Disabled = false
 	a.CustomMiddleware.IdExtractor.Disabled = false
+	a.GlobalRateLimit.Disabled = false
 	a.TagsDisabled = false
 	a.IsOAS = false
 	a.IDPClientIDMappingDisabled = false

--- a/apidef/oas/upstream.go
+++ b/apidef/oas/upstream.go
@@ -501,7 +501,7 @@ type RateLimit struct {
 
 // Fill fills *RateLimit from apidef.APIDefinition.
 func (r *RateLimit) Fill(api apidef.APIDefinition) {
-	r.Enabled = !api.DisableRateLimit
+	r.Enabled = !api.GlobalRateLimit.Disabled
 	r.Rate = int(api.GlobalRateLimit.Rate)
 	if per := api.GlobalRateLimit.Per; per != 0 {
 		perDuration := time.Duration(per) * time.Second
@@ -511,7 +511,7 @@ func (r *RateLimit) Fill(api apidef.APIDefinition) {
 
 // ExtractTo extracts *Ratelimit into *apidef.APIDefinition.
 func (r *RateLimit) ExtractTo(api *apidef.APIDefinition) {
-	api.DisableRateLimit = !r.Enabled
+	api.GlobalRateLimit.Disabled = !r.Enabled
 	api.GlobalRateLimit.Rate = float64(r.Rate)
 	perDuration, err := time.ParseDuration(r.Per)
 	if err != nil {


### PR DESCRIPTION
[TT-11413] Fix apidef GlobalRateLimit migrations (#6086)

## **Type**
bug_fix, enhancement


___

## **Description**
- Added a `Disabled` boolean field to the `GlobalRateLimit` struct to
explicitly enable or disable global rate limits.
- Modified migration logic to consider the new `Disabled` flag, setting
it to true if either `Per` or `Rate` is less or equal to 0.
- Updated existing tests and added new ones to cover the changes in
global rate limit logic.
- Adjusted OpenAPI Specification (OAS) related code to utilize the new
`Disabled` flag for rate limiting.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>api_definitions.go</strong><dd><code>Add Disabled Flag
to GlobalRateLimit Struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

apidef/api_definitions.go
<li>Added <code>Disabled</code> field to <code>GlobalRateLimit</code>
struct.<br> <li> This change allows for explicit disabling of global
rate limits.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6086/files#diff-9961ccc89a48d32db5b47ba3006315ef52f6e5007fb4b09f8c5d6d299c669d67">+3/-2</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
<summary><strong>migration.go</strong><dd><code>Enhance GlobalRateLimit
Migration Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; </dd></summary>
<hr>

apidef/migration.go
<li>Modified condition to disable global rate limit based on new
<code>Disabled</code> <br>flag.<br> <li> Adjusted logic to set
<code>GlobalRateLimit.Disabled</code> true if <code>Per</code> or
<code>Rate</code> is <br>less or equal to 0.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6086/files#diff-e1d9b55a26f9d6225d56d6f0161959217308e5ad4d6934e7d7df4595d9c2a130">+4/-4</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
<summary><strong>upstream.go</strong><dd><code>Use GlobalRateLimit
Disabled Flag in RateLimit Struct</code>&nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

apidef/oas/upstream.go
<li>Updated <code>RateLimit</code> struct methods to use
<code>GlobalRateLimit.Disabled</code> for <br>enabling/disabling rate
limits.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6086/files#diff-7b0941c7f37fe5a2a23047e0822a65519ca11c371660f36555b59a60f000e3f4">+2/-2</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>migration_test.go</strong><dd><code>Update Tests for
GlobalRateLimit Migration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

apidef/migration_test.go
<li>Updated tests to reflect new <code>Disabled</code> flag logic in
global rate limit.<br> <li> Added test cases for various scenarios of
<code>Per</code> and <code>Rate</code> values.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6086/files#diff-d79d77f814074b9e483554e36687e22fda759045141c3b094b039428744ff94c">+26/-3</a>&nbsp;
&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
<summary><strong>oas_test.go</strong><dd><code>Initialize
GlobalRateLimit Disabled in Tests</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

apidef/oas/oas_test.go
- Initialized `GlobalRateLimit.Disabled` to false in test setup.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6086/files#diff-74029ee88132d30d6478c96a35f8bb2200e0c8e6f42f2c9b147dc6bb7ce74644">+1/-0</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools
and their descriptions

---------

Co-authored-by: Tit Petric <tit@tyk.io>