### PR TITLE
Merging to release-5.0.11: TT-11288 Revert logger mutex (#6103)

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -9,7 +9,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/TykTechnologies/tyk/internal/cache"
@@ -196,30 +195,17 @@ func (gw *Gateway) mwList(mws ...TykMiddleware) []alice.Constructor {
 // BaseMiddleware wraps up the ApiSpec and Proxy objects to be included in a
 // middleware handler, this can probably be handled better.
 type BaseMiddleware struct {
-	Spec  *APISpec
-	Proxy ReturningHttpHandler
-	Gw    *Gateway `json:"-"`
-
-	loggerMu sync.Mutex
-	logger   *logrus.Entry
+	Spec   *APISpec
+	Proxy  ReturningHttpHandler
+	logger *logrus.Entry
+	Gw     *Gateway `json:"-"`
 }
 
-func (t *BaseMiddleware) Base() *BaseMiddleware {
-	t.loggerMu.Lock()
-	defer t.loggerMu.Unlock()
-
-	return &BaseMiddleware{
-		Spec:   t.Spec,
-		Proxy:  t.Proxy,
-		Gw:     t.Gw,
-		logger: t.logger,
-	}
+func (t BaseMiddleware) Base() *BaseMiddleware {
+	return &t
 }
 
 func (t *BaseMiddleware) Logger() (logger *logrus.Entry) {
-	t.loggerMu.Lock()
-	defer t.loggerMu.Unlock()
-
 	if t.logger == nil {
 		t.logger = logrus.NewEntry(log)
 	}
@@ -228,21 +214,11 @@ func (t *BaseMiddleware) Logger() (logger *logrus.Entry) {
 }
 
 func (t *BaseMiddleware) SetName(name string) {
-	logger := t.Logger()
-
-	t.loggerMu.Lock()
-	defer t.loggerMu.Unlock()
-
-	t.logger = logger.WithField("mw", name)
+	t.logger = t.Logger().WithField("mw", name)
 }
 
 func (t *BaseMiddleware) SetRequestLogger(r *http.Request) {
-	logger := t.Logger()
-
-	t.loggerMu.Lock()
-	defer t.loggerMu.Unlock()
-
-	t.logger = t.Gw.getLogEntryForRequest(logger, r, ctxGetAuthToken(r), nil)
+	t.logger = t.Gw.getLogEntryForRequest(t.Logger(), r, ctxGetAuthToken(r), nil)
 }
 
 func (t BaseMiddleware) Init() {}


### PR DESCRIPTION
TT-11288 Revert logger mutex (#6103)

## **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description

Remove the mutex for the  logger 

## Related Issue

TT-11288

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

## **Type**
bug_fix


___

## **Description**
- Removed the mutex lock from the logger in the `BaseMiddleware` struct
to address potential performance issues and simplify the code.
- Updated methods (`Base()`, `Logger()`, `SetName()`, and
`SetRequestLogger()`) in `BaseMiddleware` to operate without mutex
synchronization.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>middleware.go</strong><dd><code>Remove Logger Mutex in
BaseMiddleware</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/middleware.go
<li>Removed mutex (<code>sync.Mutex</code>) for logger in
<code>BaseMiddleware</code> struct.<br> <li> Simplified
<code>Base()</code>, <code>Logger()</code>, <code>SetName()</code>, and
<code>SetRequestLogger()</code> methods <br>by removing mutex locks and
unlocks.<br> <li> Ensured logger instance is directly manipulated
without mutex <br>synchronization.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6103/files#diff-703054910891a4db633eca0f42ed779d6b4fa75cd9b3aa4c503e681364201c1b">+8/-32</a>&nbsp;
&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools
and their descriptions