### PR TITLE
Merging to release-5.3: [TT-11440/TT-11461] Add functionName to replace name in OAS virtual endpoint and endpoint  post plugin (#6098)

### DIFF
--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -1,6 +1,7 @@
 package oas
 
 import (
+	"encoding/json"
 	"net/http"
 	"sort"
 	"strings"
@@ -1204,8 +1205,11 @@ func (p *ResponsePlugin) ExtractTo(api *apidef.APIDefinition) {
 type VirtualEndpoint struct {
 	// Enabled activates virtual endpoint.
 	Enabled bool `bson:"enabled" json:"enabled"` // required.
-	// Name is the name of JS function.
-	Name string `bson:"name" json:"name"` // required.
+	// Name is the name of plugin function to be executed.
+	// Deprecated: Use FunctionName instead.
+	Name string `bson:"name,omitempty" json:"name,omitempty"`
+	// FunctionName is the name of plugin function to be executed.
+	FunctionName string `bson:"functionName" json:"functionName"` // required.
 	// Path is the path to JS file.
 	Path string `bson:"path,omitempty" json:"path,omitempty"`
 	// Body is the JS function to execute encoded in base64 format.
@@ -1216,10 +1220,32 @@ type VirtualEndpoint struct {
 	RequireSession bool `bson:"requireSession,omitempty" json:"requireSession,omitempty"`
 }
 
+// MarshalJSON is a custom JSON marshaler for the VirtualEndpoint struct. It is implemented
+// to facilitate a smooth migration from deprecated fields that were previously used to represent
+// the same data.
+func (v *VirtualEndpoint) MarshalJSON() ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	type Alias VirtualEndpoint
+
+	var payload = Alias(*v)
+
+	if payload.FunctionName == "" && payload.Name != "" {
+		payload.FunctionName = payload.Name
+		payload.Name = ""
+	}
+
+	// to prevent infinite recursion
+	return json.Marshal(payload)
+}
+
 // Fill fills *VirtualEndpoint from apidef.VirtualMeta.
 func (v *VirtualEndpoint) Fill(meta apidef.VirtualMeta) {
 	v.Enabled = !meta.Disabled
-	v.Name = meta.ResponseFunctionName
+	v.FunctionName = meta.ResponseFunctionName
+	v.Name = ""
 	v.RequireSession = meta.UseSession
 	v.ProxyOnError = meta.ProxyOnError
 	if meta.FunctionSourceType == apidef.UseBlob {
@@ -1232,7 +1258,13 @@ func (v *VirtualEndpoint) Fill(meta apidef.VirtualMeta) {
 // ExtractTo extracts *VirtualEndpoint to *apidef.VirtualMeta.
 func (v *VirtualEndpoint) ExtractTo(meta *apidef.VirtualMeta) {
 	meta.Disabled = !v.Enabled
-	meta.ResponseFunctionName = v.Name
+	if v.FunctionName != "" {
+		meta.ResponseFunctionName = v.FunctionName
+		v.Name = ""
+	} else {
+		meta.ResponseFunctionName = v.Name
+	}
+
 	meta.UseSession = v.RequireSession
 	meta.ProxyOnError = v.ProxyOnError
 	if v.Body != "" {
@@ -1251,9 +1283,32 @@ type EndpointPostPlugin struct {
 	// Enabled activates post plugin.
 	Enabled bool `bson:"enabled" json:"enabled"` // required.
 	// Name is the name of plugin function to be executed.
-	Name string `bson:"name" json:"name"` // required.
+	// Deprecated: Use FunctionName instead.
+	Name string `bson:"name,omitempty" json:"name,omitempty"`
+	// FunctionName is the name of plugin function to be executed.
+	FunctionName string `bson:"functionName" json:"functionName"` // required.
 	// Path is the path to plugin.
 	Path string `bson:"path" json:"path"` // required.
+}
+
+// MarshalJSON is a custom JSON marshaler for the EndpointPostPlugin struct. It is implemented
+// to facilitate a smooth migration from deprecated fields that were previously used to represent
+// the same data.
+func (ep *EndpointPostPlugin) MarshalJSON() ([]byte, error) {
+	if ep == nil {
+		return nil, nil
+	}
+
+	// to prevent infinite recursion
+	type Alias EndpointPostPlugin
+
+	payload := Alias(*ep)
+	if payload.FunctionName == "" && payload.Name != "" {
+		payload.FunctionName = payload.Name
+		payload.Name = ""
+	}
+
+	return json.Marshal(payload)
 }
 
 // Fill fills *EndpointPostPlugin from apidef.GoPluginMeta.
@@ -1263,9 +1318,9 @@ func (e EndpointPostPlugins) Fill(meta apidef.GoPluginMeta) {
 	}
 
 	e[0] = EndpointPostPlugin{
-		Enabled: !meta.Disabled,
-		Name:    meta.SymbolName,
-		Path:    meta.PluginPath,
+		Enabled:      !meta.Disabled,
+		FunctionName: meta.SymbolName,
+		Path:         meta.PluginPath,
 	}
 }
 
@@ -1277,7 +1332,11 @@ func (e EndpointPostPlugins) ExtractTo(meta *apidef.GoPluginMeta) {
 
 	meta.Disabled = !e[0].Enabled
 	meta.PluginPath = e[0].Path
-	meta.SymbolName = e[0].Name
+	if e[0].FunctionName != "" {
+		meta.SymbolName = e[0].FunctionName
+	} else {
+		meta.SymbolName = e[0].Name
+	}
 }
 
 // CircuitBreaker holds configuration for the circuit breaker middleware.

--- a/apidef/oas/middleware_test.go
+++ b/apidef/oas/middleware_test.go
@@ -1,6 +1,7 @@
 package oas
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -603,7 +604,7 @@ func TestVirtualEndpoint(t *testing.T) {
 		t.Parallel()
 		expectedVirtualEndpoint := VirtualEndpoint{
 			Enabled:        true,
-			Name:           "virtualFunc",
+			FunctionName:   "virtualFunc",
 			Body:           "test body",
 			ProxyOnError:   true,
 			RequireSession: true,
@@ -631,7 +632,7 @@ func TestVirtualEndpoint(t *testing.T) {
 		t.Parallel()
 		expectedVirtualEndpoint := VirtualEndpoint{
 			Enabled:        true,
-			Name:           "virtualFunc",
+			FunctionName:   "virtualFunc",
 			Path:           "/path/to/js",
 			ProxyOnError:   true,
 			RequireSession: true,
@@ -661,7 +662,7 @@ func TestVirtualEndpoint(t *testing.T) {
 			Enabled:        true,
 			Path:           "/path/to/js",
 			Body:           "test body",
-			Name:           "virtualFunc",
+			FunctionName:   "virtualFunc",
 			ProxyOnError:   true,
 			RequireSession: true,
 		}
@@ -682,6 +683,48 @@ func TestVirtualEndpoint(t *testing.T) {
 		expectedVirtualEndpoint := virtualEndpoint
 		expectedVirtualEndpoint.Path = ""
 		assert.Equal(t, expectedVirtualEndpoint, actualVirtualEndpoint)
+	})
+
+	t.Run("functionName should have precedence", func(t *testing.T) {
+		t.Parallel()
+		virtualEndpoint := VirtualEndpoint{
+			Enabled:        true,
+			Path:           "/path/to/js",
+			Body:           "test body",
+			Name:           "virtualFunc",
+			FunctionName:   "newVirtualFunc",
+			ProxyOnError:   true,
+			RequireSession: true,
+		}
+
+		meta := apidef.VirtualMeta{}
+		virtualEndpoint.ExtractTo(&meta)
+		assert.Equal(t, apidef.VirtualMeta{
+			Disabled:             false,
+			ResponseFunctionName: "newVirtualFunc",
+			FunctionSourceURI:    "test body",
+			FunctionSourceType:   apidef.UseBlob,
+			ProxyOnError:         true,
+			UseSession:           true,
+		}, meta)
+
+		actualVirtualEndpoint := VirtualEndpoint{}
+		actualVirtualEndpoint.Fill(meta)
+		expectedVirtualEndpoint := virtualEndpoint
+		expectedVirtualEndpoint.Name = ""
+		expectedVirtualEndpoint.Path = ""
+		assert.Equal(t, expectedVirtualEndpoint, actualVirtualEndpoint)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		v := VirtualEndpoint{
+			Enabled: true,
+			Name:    "func",
+		}
+		body, err := json.Marshal(&v)
+		assert.NoError(t, err)
+		assert.Contains(t, string(body), "functionName")
+		assert.NotContains(t, string(body), "name")
 	})
 }
 
@@ -717,9 +760,9 @@ func TestEndpointPostPlugins(t *testing.T) {
 		t.Parallel()
 		expectedEndpointPostPlugins := EndpointPostPlugins{
 			{
-				Enabled: true,
-				Name:    "symbolFunc",
-				Path:    "/path/to/so",
+				Enabled:      true,
+				FunctionName: "symbolFunc",
+				Path:         "/path/to/so",
 			},
 		}
 
@@ -730,6 +773,39 @@ func TestEndpointPostPlugins(t *testing.T) {
 		actualEndpointPostPlugins.Fill(meta)
 
 		assert.Equal(t, expectedEndpointPostPlugins, actualEndpointPostPlugins)
+	})
+
+	t.Run("value - function name should have precedence", func(t *testing.T) {
+		t.Parallel()
+		endpointPostPlugin := EndpointPostPlugins{
+			{
+				Enabled:      true,
+				Name:         "symbolFunc",
+				FunctionName: "newSymbolFunc",
+				Path:         "/path/to/so",
+			},
+		}
+
+		meta := apidef.GoPluginMeta{}
+		endpointPostPlugin.ExtractTo(&meta)
+
+		actualEndpointPostPlugins := make(EndpointPostPlugins, 1)
+		actualEndpointPostPlugins.Fill(meta)
+
+		expectedEndpointPostPlugins := endpointPostPlugin
+		expectedEndpointPostPlugins[0].Name = ""
+		assert.Equal(t, expectedEndpointPostPlugins, actualEndpointPostPlugins)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		v := EndpointPostPlugin{
+			Enabled: true,
+			Name:    "func",
+		}
+		body, err := json.Marshal(&v)
+		assert.NoError(t, err)
+		assert.Contains(t, string(body), "functionName")
+		assert.NotContains(t, string(body), "name")
 	})
 }
 

--- a/apidef/oas/operation_test.go
+++ b/apidef/oas/operation_test.go
@@ -49,7 +49,9 @@ func TestOAS_PathsAndOperations(t *testing.T) {
 	operation.TransformRequestBody.Path = ""          // if `path` and `body` are present, `body` would take precedence, detailed tests can be found in middleware_test.go
 	operation.TransformResponseBody.Path = ""         // if `path` and `body` are present, `body` would take precedence, detailed tests can be found in middleware_test.go
 	operation.VirtualEndpoint.Path = ""               // if `path` and `body` are present, `body` would take precedence, detailed tests can be found in middleware_test.go
+	operation.VirtualEndpoint.Name = ""               // Name is deprecated.
 	operation.PostPlugins = operation.PostPlugins[:1] // only 1 post plugin is considered at this point, ignore others.
+	operation.PostPlugins[0].Name = ""                // Name is deprecated.
 	xTykAPIGateway := &XTykAPIGateway{
 		Middleware: &Middleware{
 			Operations: Operations{

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -788,6 +788,9 @@
         "name": {
           "type": "string"
         },
+        "functionName": {
+          "type": "string"
+        },
         "path": {
           "type": "string"
         },
@@ -803,7 +806,7 @@
       },
       "required": [
         "enabled",
-        "name"
+        "functionName"
       ]
     },
     "X-Tyk-URLRewrite": {
@@ -941,13 +944,16 @@
         "name": {
           "type": "string"
         },
+        "functionName": {
+          "type": "string"
+        },
         "path": {
           "type": "string"
         }
       },
       "required": [
         "enabled",
-        "name",
+        "functionName",
         "path"
       ]
     },


### PR DESCRIPTION
## **User description**
[TT-11440/TT-11461] Add functionName to replace name in OAS virtual endpoint and endpoint  post plugin (#6098)

## **User description**
<!-- Provide a general summary of your changes in the Title above -->

Add functionName to replace name in OAS virtual endpoint and endpoint
post plugin
<!-- Describe your changes in detail -->

## Related Issue
https://tyktech.atlassian.net/browse/TT-11440
https://tyktech.atlassian.net/browse/TT-11461

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

## **Type**
enhancement


___

## **Description**
- Deprecated `Name` field in favor of `FunctionName` for both
`VirtualEndpoint` and `EndpointPostPlugin` configurations to clarify the
purpose and usage.
- Ensured backward compatibility by retaining the `Name` field but
marking it as deprecated.
- Updated related methods (`Fill` and `ExtractTo`) to prioritize
`FunctionName` over `Name` when both are provided.
- Modified and added unit tests to reflect changes and validate the
precedence of `FunctionName` over `Name`.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>middleware.go</strong><dd><code>Deprecate Name in Favor
of FunctionName for Plugin Configurations</code></dd></summary>
<hr>

apidef/oas/middleware.go
<li>Deprecated <code>Name</code> in favor of <code>FunctionName</code>
for both <code>VirtualEndpoint</code> and
<br><code>EndpointPostPlugin</code>.<br> <li> Added handling to prefer
<code>FunctionName</code> over <code>Name</code> if both are
provided.<br> <li> Updated <code>Fill</code> and <code>ExtractTo</code>
methods to support the new <code>FunctionName</code> <br>field.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6098/files#diff-992ec7c28d25fd54f6491d295389757705cd114bc869a35cba50d42e548cdc6e">+26/-9</a>&nbsp;
&nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>middleware_test.go</strong><dd><code>Update Tests for
FunctionName Precedence and Usage</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/middleware_test.go
<li>Updated tests to use <code>FunctionName</code> instead of
<code>Name</code>.<br> <li> Added tests to ensure
<code>FunctionName</code> has precedence over <code>Name</code>.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6098/files#diff-0af31cb29ae298a6ac3e402b283ab364a6fd793fd04f253ef7c4983234c17bef">+59/-6</a>&nbsp;
&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools
and their descriptions


___

## **Type**
enhancement


___

## **Description**
- Deprecated `Name` field in `VirtualEndpoint` and `EndpointPostPlugin`, replaced with `FunctionName` to better reflect its purpose.
- Added custom JSON marshaling to handle the transition from `Name` to `FunctionName`, ensuring backward compatibility.
- Updated tests and JSON schema to align with the changes introduced for `FunctionName`.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>middleware.go</strong><dd><code>Deprecate Name Field in Favor of FunctionName for VirtualEndpoint and </code><br><code>EndpointPostPlugin</code></dd></summary>
<hr>

apidef/oas/middleware.go
<li>Added JSON marshaling logic for <code>VirtualEndpoint</code> and <code>EndpointPostPlugin</code> <br>to handle deprecated <code>Name</code> field and prioritize <code>FunctionName</code>.<br> <li> Deprecated <code>Name</code> field in <code>VirtualEndpoint</code> and <code>EndpointPostPlugin</code>, <br>replaced with <code>FunctionName</code>.<br> <li> Updated <code>Fill</code> and <code>ExtractTo</code> methods to support the new <code>FunctionName</code> <br>field.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6113/files#diff-992ec7c28d25fd54f6491d295389757705cd114bc869a35cba50d42e548cdc6e">+68/-9</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>x-tyk-api-gateway.json</strong><dd><code>Update JSON Schema to Reflect FunctionName Changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/schema/x-tyk-api-gateway.json
<li>Updated JSON schema to include <code>functionName</code> and mark it as required <br>for <code>VirtualEndpoint</code> and <code>EndpointPostPlugin</code>.<br> <li> Deprecated <code>name</code> field in JSON schema for <code>VirtualEndpoint</code> and <br><code>EndpointPostPlugin</code>.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6113/files#diff-78828969c0c04cc1a776dfc93a8bad3c499a8c83e6169f83e96d090bed3e7dd0">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>middleware_test.go</strong><dd><code>Update Tests for VirtualEndpoint and EndpointPostPlugin to Reflect </code><br><code>FunctionName Changes</code></dd></summary>
<hr>

apidef/oas/middleware_test.go
<li>Updated tests to use <code>FunctionName</code> instead of <code>Name</code>.<br> <li> Added tests to ensure <code>FunctionName</code> has precedence over <code>Name</code>.<br> <li> Added JSON marshaling tests to verify <code>functionName</code> is included and <br><code>name</code> is excluded.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6113/files#diff-0af31cb29ae298a6ac3e402b283ab364a6fd793fd04f253ef7c4983234c17bef">+82/-6</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>operation_test.go</strong><dd><code>Update Operation Tests to Ignore Deprecated Name Field</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/operation_test.go
<li>Updated tests to ignore deprecated <code>Name</code> field in <code>VirtualEndpoint</code> and <br><code>EndpointPostPlugin</code>.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6113/files#diff-cd234db716d6d2edc97c135ef546021c9ab4fa9282d63964bd155d41635cf964">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

