### PR TITLE
Merging to release-5.3: TT-11443 Shim to keep compatibility in goplugins importing tyk redis (#6096)

### DIFF
--- a/storage/connection_handler_test.go
+++ b/storage/connection_handler_test.go
@@ -42,6 +42,12 @@ func TestRecoverLoop(t *testing.T) {
 func TestNewConnectionHandler(t *testing.T) {
 	ctx := context.Background()
 	handler := NewConnectionHandler(ctx)
+	RunNewConnectionHandlerTest(t, handler)
+}
+
+func RunNewConnectionHandlerTest(t *testing.T, handler *ConnectionHandler) {
+	t.Helper()
+
 	assert.NotNil(t, handler)
 	assert.NotNil(t, handler.connections)
 	assert.NotNil(t, handler.connectionsMu)

--- a/storage/redis_cluster_test.go
+++ b/storage/redis_cluster_test.go
@@ -39,6 +39,37 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+func TestRedisClusterGetConnectionHandler(t *testing.T) {
+	// Scenario 1: RedisController is not nil.
+	t.Run("with RedisController", func(t *testing.T) {
+		connHandler := NewConnectionHandler(context.Background())
+		mockRedisController := &RedisController{
+			connection: connHandler,
+		}
+		redisCluster := &RedisCluster{
+			RedisController: mockRedisController,
+		}
+
+		got := redisCluster.getConnectionHandler()
+		if got != connHandler {
+			t.Errorf("getConnectionHandler() with RedisController = %v, want %v", got, connHandler)
+		}
+	})
+
+	// Scenario 2: RedisController is nil.
+	t.Run("without RedisController", func(t *testing.T) {
+		connHandler := NewConnectionHandler(context.Background())
+		redisCluster := &RedisCluster{
+			ConnectionHandler: connHandler,
+		}
+
+		got := redisCluster.getConnectionHandler()
+		if got != connHandler {
+			t.Errorf("getConnectionHandler() without RedisController = %v, want %v", got, connHandler)
+		}
+	})
+}
+
 func TestHandleMessage(t *testing.T) {
 	cluster := &RedisCluster{}
 

--- a/storage/redis_shim.go
+++ b/storage/redis_shim.go
@@ -1,0 +1,46 @@
+package storage
+
+import (
+	"context"
+
+	"github.com/TykTechnologies/tyk/config"
+)
+
+// RedisController acts as a shim to provide backward compatibility for Go plugins users.
+// It facilitates connecting to Redis using Tyk's storage package in a way that doesn't break existing implementations.
+// changes here are sensible
+type RedisController struct {
+	connection *ConnectionHandler
+}
+
+// NewRedisController initializes a new RedisController. This method ensures Go plugins can connect to Redis
+// leveraging Tyk's internal storage mechanisms with minimal changes to their code.
+func NewRedisController(ctx context.Context) *RedisController {
+	return &RedisController{
+		connection: NewConnectionHandler(ctx),
+	}
+}
+
+// ConnectToRedis sets up the connection to Redis using specified configuration.
+// It abstracts the connection logic, allowing Go plugins to seamlessly integrate without direct interaction with the underlying storage logic.
+func (rc *RedisController) ConnectToRedis(ctx context.Context, onReconnect func(), conf *config.Config) {
+	rc.connection.Connect(ctx, onReconnect, conf)
+}
+
+// DisableRedis toggles the Redis connection's active status, providing a mechanism to dynamically
+// manage the connection state in response to runtime conditions or configurations.
+func (rc *RedisController) DisableRedis(setRedisDown bool) {
+	rc.connection.DisableStorage(setRedisDown)
+}
+
+// Connected checks the current state of the Redis connection, offering a simple interface
+// for Go plugins to verify connectivity without delving into the specifics of the storage layer.
+func (rc *RedisController) Connected() bool {
+	return rc.connection.Connected()
+}
+
+// WaitConnect blocks until a Redis connection is established, enabling Go plugins to wait
+// for connectivity before proceeding with operations that require Redis access.
+func (rc *RedisController) WaitConnect(ctx context.Context) bool {
+	return rc.connection.WaitConnect(ctx)
+}

--- a/storage/redis_shim_test.go
+++ b/storage/redis_shim_test.go
@@ -1,0 +1,58 @@
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk/config"
+)
+
+func TestNewRedisController(t *testing.T) {
+	ctx := context.Background()
+	redisController := NewRedisController(ctx)
+
+	RunNewConnectionHandlerTest(t, redisController.connection)
+}
+
+func TestDisableRedis(t *testing.T) {
+	ctx := context.Background()
+	redisController := NewRedisController(ctx)
+
+	// Initially storage should not be disabled.
+	assert.True(t, redisController.connection.enabled(), "Expected storage to be disabled initially")
+
+	// Disable storage and test.
+	redisController.DisableRedis(true)
+	assert.True(t, redisController.connection.disableStorage.Load().(bool), "Expected storage to be disabled")
+	assert.False(t, redisController.Connected(), "Expected storage to not be connected after disabling")
+}
+
+func TestConnectToRedis(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	conf, err := config.New()
+	assert.NoError(t, err)
+
+	onConnectCalled := make(chan bool, 1)
+	onConnect := func() {
+		onConnectCalled <- true
+	}
+
+	rc := NewRedisController(ctx)
+	rc.connection.storageUp.Store(false)
+	go rc.ConnectToRedis(ctx, onConnect, conf)
+
+	// let's wait one statusCheck cycle
+	time.Sleep(1100 * time.Millisecond)
+	// Simulate a connection event
+	rc.connection.storageUp.Store(false)
+
+	// Allow some time for the goroutine to run
+	time.Sleep(100 * time.Millisecond)
+	<-onConnectCalled
+	assert.True(t, rc.Connected(), "Expected storage to be connected")
+}


### PR DESCRIPTION
## **User description**
TT-11443 Shim to keep compatibility in goplugins importing tyk redis (#6096)

## **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description

In order to not break compatibility of goplugins importing the redis
implementation of the last versions of gw, is required to create a
bridge that translates old instructions into new redis store
instructions.

## Related Issue

TT-11443

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

## **Type**
enhancement


___

## **Description**
- Introduced a `redis_shim.go` file to ensure compatibility with
goplugins importing the Redis implementation from previous versions.
This acts as a bridge translating old Redis instructions to new Redis
store instructions, maintaining backward compatibility without breaking
existing implementations.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>redis_shim.go</strong><dd><code>Introduction of Redis
Shim for Go Plugins Compatibility</code>&nbsp; &nbsp; </dd></summary>
<hr>

storage/redis_shim.go
<li>Introduced a new file <code>redis_shim.go</code> for creating a
bridge between old <br>and new Redis store instructions.<br>


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6096/files#diff-b175b26ea2c5bc6f5eb907f40acdaea3f4d100a2bbbf50a12fdb64abdb57a040">+1/-0</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools
and their descriptions


___

## **Type**
enhancement


___

## **Description**
- Introduced `RedisController` to ensure backward compatibility for Go plugins using Tyk's Redis connections.
- Abstracted the retrieval of the connection handler in `RedisCluster` to support both `ConnectionHandler` and `RedisController`.
- Added new tests for the abstracted connection handler retrieval and `RedisController` methods.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>connection_handler_test.go</strong><dd><code>Refactor TestNewConnectionHandler with Helper Function</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

storage/connection_handler_test.go
<li>Added a new test helper function <code>RunNewConnectionHandlerTest</code> to <br>facilitate testing the <code>ConnectionHandler</code>.<br> <li> Modified <code>TestNewConnectionHandler</code> to use the new test helper function.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6121/files#diff-e62d696f1dffcbc88a14ce32af4f6da99f75d2f650020d2efebb0d39bcc97beb">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>redis_cluster.go</strong><dd><code>Abstract Connection Handler Retrieval in RedisCluster</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

storage/redis_cluster.go
<li>Added a new method <code>getConnectionHandler</code> to abstract the retrieval of <br>the connection handler, supporting both <code>ConnectionHandler</code> and <br><code>RedisController</code>.<br> <li> Modified various methods to use <code>getConnectionHandler</code> instead of <br>directly accessing <code>ConnectionHandler</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6121/files#diff-c6add7945790067ff72a544d688ebe904c14ad5b9a522d986aee7c54b1760100">+20/-11</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>redis_shim.go</strong><dd><code>Implement RedisController for Backward Compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

storage/redis_shim.go
<li>Introduced <code>RedisController</code> struct to act as a shim for backward <br>compatibility with Go plugins.<br> <li> Implemented methods <code>NewRedisController</code>, <code>ConnectToRedis</code>, <code>DisableRedis</code>, <br><code>Connected</code>, and <code>WaitConnect</code> in <code>RedisController</code> for managing Redis <br>connections.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6121/files#diff-b175b26ea2c5bc6f5eb907f40acdaea3f4d100a2bbbf50a12fdb64abdb57a040">+46/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>redis_cluster_test.go</strong><dd><code>Test for Abstracted Connection Handler Retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

storage/redis_cluster_test.go
<li>Added new tests <code>TestRedisClusterGetConnectionHandler</code> to verify the <br>correct retrieval of the connection handler through the new <br><code>getConnectionHandler</code> method.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6121/files#diff-6881545acab41fff3221454e0efb16302c696ea1217da926f80332a62ef51c71">+31/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>redis_shim_test.go</strong><dd><code>Test Coverage for RedisController Methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

storage/redis_shim_test.go
<li>Added tests for <code>RedisController</code> methods including <br><code>TestNewRedisController</code>, <code>TestDisableRedis</code>, and <code>TestConnectToRedis</code>.<br> <li> Utilized the <code>RunNewConnectionHandlerTest</code> helper function in <br><code>TestNewRedisController</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6121/files#diff-a2d171e2fb81d93dfafccc4f195ddcccd1faf252b273d1872173012360932bc5">+58/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

