### PR TITLE
[TT-11575] Fix unit of measurement for flush interval, should be milliseconds

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -434,7 +434,7 @@ type HttpServerOptionsConfig struct {
 	// This option does not give any hints to the client, on which certificate to pick (but this is very rare situation when it is required)
 	SkipClientCAAnnouncement bool `json:"skip_client_ca_announcement"`
 
-	// Set this to the number of seconds that Tyk uses to flush content from the proxied upstream connection to the open downstream connection.
+	// Set this to the number of milliseconds that Tyk uses to flush content from the proxied upstream connection to the open downstream connection.
 	// This option needed be set for streaming protocols like Server Side Events, or gRPC streaming.
 	FlushInterval int `json:"flush_interval"`
 


### PR DESCRIPTION
## **User description**
For further details refer to the PR raised by the external user in the docs repository https://github.com/TykTechnologies/tyk-docs/pull/4214

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

## Related Issue
[TT-11575](https://tyktech.atlassian.net/browse/TT-11575)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
@djablonski-moia @moia-dev has spotted a bug with the unit of measurement documented for GW Flush interval config variable. 

@djablonski-moia @moia-dev has kindly created a [PR](https://github.com/TykTechnologies/tyk-docs/pull/4214) which fixes the content in the automatically generated gateway config file.

This PR updates the doc comment in the Gateway config source file to allow the bug to be fixed and allow regeneration of the gateway config documentation.


## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [x] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


[TT-11575]: https://tyktech.atlassian.net/browse/TT-11575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

## **Type**
bug_fix


___

## **Description**
- Corrected the unit of measurement in the `FlushInterval` configuration option comment from seconds to milliseconds. This change ensures the documentation accurately reflects the code's expected unit for this setting.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.go</strong><dd><code>Correct Unit of Measurement in FlushInterval Comment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/config.go
<li>Updated the comment for <code>FlushInterval</code> to specify the unit of <br>measurement as milliseconds instead of seconds.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6139/files#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

