### PR TITLE
[TT-11617] kvstore: replace values by correctly escaping them

### DIFF
--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -567,7 +567,7 @@ func escapeStringForJSON(input string) string {
 		return input
 	}
 	// trim the quotes from the escaped value
-	return string(escaped[1:len(escaped)-1])
+	return string(escaped[1 : len(escaped)-1])
 }
 
 func (a APIDefinitionLoader) replaceSecrets(in []byte) []byte {

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -654,7 +654,7 @@ func (a APIDefinitionLoader) replaceVaultSecrets(input *string) error {
 		val, ok := v.(string)
 		if !ok {
 			val = fmt.Sprint(v)
-			log.Warning("Vault secret %s is not a string (got %T, using %q)", k, v, val)
+			log.Warningf("Vault secret %s is not a string (got %T, using %q)", k, v, val)
 			continue
 		}
 


### PR DESCRIPTION
If a KV value contains a literal newline character or double quotes, the replacement of KV values inside the api definition will produce an invalid value. This PR adds an escape step, encoding the value for JSON.