### PR TITLE
[TT-11618] kvstore/config: replace/find strings in config for KV replacements

### DIFF
--- a/config/replace_test.go
+++ b/config/replace_test.go
@@ -5,8 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/TykTechnologies/tyk/internal/reflect"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk/internal/reflect"
 )
 
 func TestConfig_replaceKeyValue(t *testing.T) {

--- a/config/replace_test.go
+++ b/config/replace_test.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/TykTechnologies/tyk/internal/reflect"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfig_replaceKeyValue(t *testing.T) {
+	conf, err := NewDefaultWithEnv()
+	assert.NoError(t, err)
+
+	// sets up mock data by replacing the default string values
+	// with a value that is prefixed with `vault://`.
+	var index int
+	reflect.TraverseAndReplace(conf, func(string) (string, bool) {
+		index++
+		return "vault://key/" + fmt.Sprint(index), true
+	})
+
+	// list all values prefixed with `vault://`
+	values := reflect.TraverseAndFind(conf, func(in string) bool {
+		return strings.HasPrefix(in, "vault://")
+	})
+
+	// assert the found value count matches
+	assert.Len(t, values, index)
+	t.Logf("Found/replaced %d values", len(values))
+}

--- a/internal/reflect/find.go
+++ b/internal/reflect/find.go
@@ -1,0 +1,47 @@
+package reflect
+
+import (
+	"go/ast"
+	"reflect"
+)
+
+// TraverseAndFind traverses any object and invokes a specified function on string fields.
+// If a replacement has been made, it updates the values in the object with the new ones.
+func TraverseAndFind(obj interface{}, findFunc func(string) bool) []string {
+	var results []string
+
+	v := reflect.ValueOf(obj)
+
+	if v.Kind() != reflect.Ptr || v.IsNil() {
+		return results
+	}
+
+	v = v.Elem()
+
+	switch v.Kind() {
+	case reflect.String:
+		if v.CanSet() && v.CanAddr() {
+			value := v.String()
+			found := findFunc(value)
+			if found {
+				results = append(results, value)
+			}
+		}
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			field := v.Field(i)
+			fieldType := v.Type().Field(i)
+
+			if ast.IsExported(fieldType.Name) {
+				results = append(results, TraverseAndFind(field.Addr().Interface(), findFunc)...)
+			}
+		}
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			elem := v.Index(i)
+			results = append(results, TraverseAndFind(elem.Addr().Interface(), findFunc)...)
+		}
+	}
+
+	return results
+}

--- a/internal/reflect/find.go
+++ b/internal/reflect/find.go
@@ -6,7 +6,7 @@ import (
 )
 
 // TraverseAndFind traverses any object and invokes a specified function on string fields.
-// If a replacement has been made, it updates the values in the object with the new ones.
+// If the function returns true, the value will be returned in the result.
 func TraverseAndFind(obj interface{}, findFunc func(string) bool) []string {
 	var results []string
 

--- a/internal/reflect/find_test.go
+++ b/internal/reflect/find_test.go
@@ -1,0 +1,39 @@
+package reflect
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTraverseAndFind(t *testing.T) {
+	type Address struct {
+		Street string
+		City   string
+	}
+
+	type Person struct {
+		Name    string
+		Address Address
+		Phones  []string
+	}
+	p := Person{
+		Name: "John",
+		Address: Address{
+			Street: "123 Main St",
+			City:   "City",
+		},
+		Phones: []string{"123-456-7890", "456-789-0123"},
+	}
+
+	findFunc := func(s string) bool {
+		return len(s) > 10
+	}
+
+	foundStrings := TraverseAndFind(&p, findFunc)
+
+	expected := []string{"123 Main St", "123-456-7890", "456-789-0123"}
+
+	if !reflect.DeepEqual(foundStrings, expected) {
+		t.Errorf("TraverseAndFind did not find strings correctly. Expected: %v, Got: %v", expected, foundStrings)
+	}
+}

--- a/internal/reflect/replace.go
+++ b/internal/reflect/replace.go
@@ -1,0 +1,43 @@
+package reflect
+
+import (
+	"go/ast"
+	"reflect"
+)
+
+// TraverseAndReplace traverses any object and invokes a specified function on string fields.
+// If a replacement has been made, it updates the values in the object with the new ones.
+func TraverseAndReplace(obj interface{}, replaceFunc func(string) (string, bool)) {
+	v := reflect.ValueOf(obj)
+
+	if v.Kind() != reflect.Ptr || v.IsNil() {
+		return
+	}
+
+	v = v.Elem()
+
+	switch v.Kind() {
+	case reflect.String:
+		if v.CanSet() && v.CanAddr() {
+			oldValue := v.String()
+			newValue, replaced := replaceFunc(oldValue)
+			if replaced {
+				v.SetString(newValue)
+			}
+		}
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			field := v.Field(i)
+			fieldType := v.Type().Field(i)
+
+			if ast.IsExported(fieldType.Name) {
+				TraverseAndReplace(field.Addr().Interface(), replaceFunc)
+			}
+		}
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			elem := v.Index(i)
+			TraverseAndReplace(elem.Addr().Interface(), replaceFunc)
+		}
+	}
+}

--- a/internal/reflect/replace_test.go
+++ b/internal/reflect/replace_test.go
@@ -1,0 +1,50 @@
+package reflect
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTraverseAndReplace(t *testing.T) {
+	type address struct {
+		Street string
+		City   string
+	}
+
+	type Person struct {
+		Name    string
+		address address
+		Phones  []string
+	}
+
+	p := Person{
+		Name: "John",
+		address: address{
+			Street: "123 Main St",
+			City:   "John",
+		},
+		Phones: []string{"123-456-7890", "John"},
+	}
+
+	replaceFunc := func(s string) (string, bool) {
+		if s == "John" {
+			return "James", true
+		}
+		return s, false
+	}
+
+	TraverseAndReplace(&p, replaceFunc)
+
+	expected := Person{
+		Name: "James",
+		address: address{
+			Street: "123 Main St",
+			City:   "John",
+		},
+		Phones: []string{"123-456-7890", "James"},
+	}
+
+	if !reflect.DeepEqual(p, expected) {
+		t.Errorf("TraverseAndReplace did not replace values correctly. Expected: %v, Got: %v", expected, p)
+	}
+}


### PR DESCRIPTION
A testing PR to see if replacements of all keys on *Config based on KV references is possible:

- replacements are focused on string values,
- supports recursion/nesting, structs, slices and arrays

There is no `map` support at the moment (can be extended):

  - `StorageOptionsConf.Hosts`
  - `WebHookHandlerConf.HeaderList`
  - `CertificatesConfig.Upstream`
  - `SecurityConfig.PinnedPublicKeys`
  - `Tracer.Options` map and unknown value - can't be supported in current form (related failure in CI test run)
  - `Config.Secrets` - the source for `secrets://` (technically could read them from consul)
  - `Config.EventTriggers` and `Config.EventTriggersDefaults` (map of slices)
  - `Config.OverrideMessages`