### PR TITLE
[TT-11617] Add newline into apidef KV replacements test

### DIFF
--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -1553,7 +1553,7 @@ func TestAPISpec_setHasMock(t *testing.T) {
 func TestReplaceSecrets(t *testing.T) {
 	ts := StartTest(func(globalConf *config.Config) {
 		globalConf.Secrets = map[string]string{
-			"Laurentiu": "Ghiur",
+			"Laurentiu": "A\nB\n\"quote\"",
 		}
 	})
 	defer ts.Close()


### PR DESCRIPTION
## **User description**
This PR contains a test change that demonstrates the reported issue.

https://tyktech.atlassian.net/browse/TT-11617


___

## **Type**
enhancement


___

## **Description**
- This PR enhances a test case in `api_definition_test.go` to better demonstrate handling of newlines and quotes in KV replacements.
- It specifically modifies the value associated with the key "Laurentiu" in the `globalConf.Secrets` map to "A\nB\n\"quote\"", introducing newlines and a quote character to test the replacement functionality more thoroughly.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api_definition_test.go</strong><dd><code>Enhance Test for KV Replacements with Newlines and Quotes</code></dd></summary>
<hr>

gateway/api_definition_test.go
<li>Updated the value of "Laurentiu" in the <code>globalConf.Secrets</code> map to <br>include newlines and a quote.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6148/files#diff-2394daab6fdc5f8dc234699c80c0548947ee3d68d2e33858258d73a8b5eb6f44">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

