### PR TITLE
artifact upload override warning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,7 +272,7 @@ jobs:
           name: docker-compose-logs-api-${{ matrix.db }}-${{ matrix.conf }}-${{ github.run_id }}
           path: ${{ github.workspace }}/docker-compose-api.log
           retention-days: 3
-          override: true
+          overwrite: true
       - name: Archive Integration tests report
         if: always()
         uses: actions/upload-artifact@v4
@@ -280,7 +280,7 @@ jobs:
           name: api-test-report-${{ matrix.db }}-${{ matrix.conf }}-${{ github.run_id }}
           retention-days: 3
           path: ${{ github.workspace }}/reports
-          override: true
+          overwrite: true
       - name: Fetch commit author
         if: failure() && steps.test_execution.outcome != 'success' && github.event_name == 'push'
         env:


### PR DESCRIPTION
## **User description**
- remove warning from API tests caused by wrong attribute 'override' instead of 'overwrite'


___

## **Type**
bug_fix


___

## **Description**
- Fixed an incorrect attribute in the GitHub Actions workflow that was causing warnings in API tests. The attribute `override` was corrected to `overwrite` in two steps:
  - Uploading docker-compose logs
  - Archiving Integration tests report


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Fix Incorrect Attribute in GitHub Actions Workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml
<li>Corrected the <code>override</code> attribute to <code>overwrite</code> in two steps of the <br>GitHub Actions workflow.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6149/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

