### PR TITLE
Fix/concurrent map access

### DIFF
--- a/user/session.go
+++ b/user/session.go
@@ -147,6 +147,7 @@ type SessionState struct {
 	// Used to store token hash
 	keyHash string
 	KeyID   string `json:"-"`
+	Mu      sync.RWMutex `json:"-"`
 }
 
 func NewSessionState() *SessionState {
@@ -155,6 +156,9 @@ func NewSessionState() *SessionState {
 
 // Clone  returns a fresh copy of s
 func (s SessionState) Clone() SessionState {
+	s.Mu.RLock()
+	defer s.Mu.RUnlock()
+	
 	// Simple vales are cloned by value
 	newSession := s
 	newSession.AccessRights = cloneAccess(s.AccessRights)

--- a/user/session.go
+++ b/user/session.go
@@ -147,7 +147,6 @@ type SessionState struct {
 	// Used to store token hash
 	keyHash string
 	KeyID   string `json:"-"`
-	Mu      sync.RWMutex `json:"-"`
 }
 
 func NewSessionState() *SessionState {
@@ -155,10 +154,7 @@ func NewSessionState() *SessionState {
 }
 
 // Clone  returns a fresh copy of s
-func (s SessionState) Clone() SessionState {
-	s.Mu.RLock()
-	defer s.Mu.RUnlock()
-	
+func (s SessionState) Clone() SessionState {	
 	// Simple vales are cloned by value
 	newSession := s
 	newSession.AccessRights = cloneAccess(s.AccessRights)


### PR DESCRIPTION
Apply policies at the moment modify Session MetaData field directly. However if you look at implementation of other fileds like AccessRights or Tags, it creates a new objects, and after assign them to sessions.

This change should remove concurrency issues from MetaData map access, during session cloning, because technically now we never modify MetaData object, just replace it with another map.

It also avoids using mutexes so performance impact is minimal.