### PR TITLE
Merging to release-5.3: [TT-11627] Migrate failling to golangci-lint/forbidigo, fix issues (#6152)

### DIFF
--- a/.faillint
+++ b/.faillint
@@ -1,2 +1,0 @@
-fmt.{Print,Printf,Println}
-net/http.Get

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -71,11 +71,11 @@ linters:
     - tagliatelle
     - testpackage
     - paralleltest
-    - forbidigo
     - ireturn
     - goerr113
   enable:
     - govet
+    - forbidigo
     - gochecknoinits
     - thelper
     - errcheck
@@ -88,6 +88,15 @@ linters:
     - revive
 
 linters-settings:
+  fobidigo:
+    forbid:
+      - p: ^fmt\.Print.*$
+        msg: Do not commit print statements, use t.Log or Logrus.
+      - p: ^net\/http\.(Get|Head|Post|Form).*$
+        msg: Do not use top level http package functions, NewRequestWithContext is encouraged.
+    exclude-godoc-examples: false
+    analyze-types: true
+
   revive:
     ignore-generated-header: true
     severity: error
@@ -117,8 +126,13 @@ linters-settings:
       - (*github.com/TykTechnologies/tyk/gateway.Test).Run
 
 issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
   exclude-use-default: false
   exclude-rules:
+    - path: ^cli/
+      linters:
+        - forbidigo # cli package uses fmt.Print by design
     - path: _test\.go
       linters:
         - dupl # many functions looks like dupes

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ test:
 lint: lint-fast
 	goimports -local github.com/TykTechnologies,github.com/TykTechnologies/tyk/internal -w .
 	gofmt -w .
-	faillint -ignore-tests -paths "$(shell grep -v '^#' .faillint | xargs echo | sed 's/ /,/g')" ./...
 
 lint-fast: lint-install
 	go generate ./...
@@ -38,7 +37,6 @@ lint-fast: lint-install
 lint-install:
 	go install golang.org/x/tools/cmd/goimports@latest
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2
-	go install github.com/fatih/faillint@latest
 	go install go.uber.org/mock/mockgen@v0.4.0
 
 .PHONY: bench

--- a/apidef/oas/linter_test.go
+++ b/apidef/oas/linter_test.go
@@ -3,7 +3,6 @@ package oas
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"os"
 	"testing"
 
@@ -101,7 +100,7 @@ func TestXTykGateway_Lint(t *testing.T) {
 	errs := result.Errors()
 	if len(errs) > 0 {
 		for _, err := range errs {
-			fmt.Printf("%s\n", err)
+			t.Logf("%s\n", err)
 		}
 		t.Fail()
 	}

--- a/apidef/oas/root_test.go
+++ b/apidef/oas/root_test.go
@@ -82,8 +82,10 @@ func TestXTykAPIGateway(t *testing.T) {
 		xTykAPIGateway := XTykAPIGateway{}
 		xTykAPIGateway.Fill(initialAPI)
 
-		ss, _ := json.MarshalIndent(xTykAPIGateway, "", "  ")
-		fmt.Println(string(ss))
+		ss, err := json.MarshalIndent(xTykAPIGateway, "", "  ")
+		assert.NoError(t, err)
+
+		t.Logf("JSON from filled old:\n%s", string(ss))
 
 		var convertedAPI apidef.APIDefinition
 		xTykAPIGateway.ExtractTo(&convertedAPI)

--- a/dlpython/main_test.go
+++ b/dlpython/main_test.go
@@ -1,7 +1,6 @@
 package python
 
 import (
-	"fmt"
 	"os"
 	"testing"
 )
@@ -12,8 +11,6 @@ func TestMain(m *testing.M) {
 	if versionOverride := os.Getenv("PYTHON_VERSION"); versionOverride != "" {
 		testVersion = versionOverride
 	}
-	fmt.Printf("Using Python %s for tests\n", testVersion)
-
 	os.Exit(m.Run())
 }
 

--- a/gateway/host_checker_test.go
+++ b/gateway/host_checker_test.go
@@ -3,7 +3,6 @@ package gateway
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -214,8 +213,8 @@ func TestReverseProxyAllDown(t *testing.T) {
 	}
 	ts.Gw.GlobalHostChecker.checkerMu.Lock()
 	if ts.Gw.GlobalHostChecker.checker == nil {
-		fmt.Printf("\nStop loop: %v\n", !ts.Gw.GlobalHostChecker.stopLoop)
-		fmt.Printf("\n Am I pooling: %v\n", ts.Gw.GlobalHostChecker.AmIPolling())
+		t.Logf("Stop loop: %v\n", !ts.Gw.GlobalHostChecker.stopLoop)
+		t.Logf("Am I pooling: %v\n", ts.Gw.GlobalHostChecker.AmIPolling())
 	}
 	ts.Gw.GlobalHostChecker.checkerMu.Unlock()
 

--- a/user/custom_policies_test.go
+++ b/user/custom_policies_test.go
@@ -1,7 +1,6 @@
 package user
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -49,7 +48,7 @@ func TestSessionState_CustomPolicies(t *testing.T) {
 		{
 			name: "policies-invalid-object",
 			session: &SessionState{
-				MetaData: map[string]interface{}{"policies": []interface{}{fmt.Print}},
+				MetaData: map[string]interface{}{"policies": []interface{}{TestSessionState_SetCustomPolicies}},
 			},
 			want:    nil,
 			wantErr: true,


### PR DESCRIPTION
[TT-11627] Migrate failling to golangci-lint/forbidigo, fix issues (#6152)

## **User description**
Tests only changes.

https://tyktech.atlassian.net/browse/TT-11627


___

## **Type**
enhancement, tests


___

## **Description**
- Migrated from `faillint` to `golangci-lint/forbidigo` and fixed issues
by replacing `fmt.Printf` with `t.Logf` in various test files for better
logging practices.
- Added error handling for `json.MarshalIndent` in
`apidef/oas/root_test.go`.
- Configured `forbidigo` linter to forbid `fmt.Print*` and top-level
`net/http` package functions, enhancing code quality.
- Removed `faillint` tool installation and usage from the Makefile,
streamlining the linting process.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>linter_test.go</strong><dd><code>Replace fmt.Printf
with t.Logf in OAS Linter Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/linter_test.go
- Replaced `fmt.Printf` with `t.Logf` for error logging in tests.



</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6152/files#diff-b92239afd81e77a829fe7fe8410044dfd4dfda525d17dbf5f8811714a9c986d3">+1/-2</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
<summary><strong>root_test.go</strong><dd><code>Improve Error Handling
and Logging in OAS Root Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

apidef/oas/root_test.go
<li>Added error handling for <code>json.MarshalIndent</code>.<br> <li>
Replaced <code>fmt.Println</code> with <code>t.Logf</code> for logging
in tests.<br>


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6152/files#diff-4d144465b7fabaf2db8915de1ce3b6ff8c91a93c62d614c38fa38bdae28e23a2">+4/-2</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
<summary><strong>main_test.go</strong><dd><code>Use t.Logf for Version
Logging in Python Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dlpython/main_test.go
- Replaced `fmt.Printf` with `t.Logf` for version logging in tests.



</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6152/files#diff-f8e159e1152ee20ea353fb647d7a7344414006fbd259c4e7073b47c96e8745cb">+1/-2</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
<summary><strong>host_checker_test.go</strong><dd><code>Replace
fmt.Printf with t.Logf in Gateway Host Checker
Tests</code></dd></summary>
<hr>

gateway/host_checker_test.go
- Replaced `fmt.Printf` with `t.Logf` for logging in tests.



</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6152/files#diff-cfc8f5368c14d8fa56d845b1250f465b78c8aa6bfc5b47d0a556d706fa6b8622">+2/-3</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
<summary><strong>custom_policies_test.go</strong><dd><code>Correct Test
Metadata in Custom Policies Tests</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

user/custom_policies_test.go
<li>Replaced <code>fmt.Print</code> with
<code>TestSessionState_SetCustomPolicies</code> in test
<br>metadata.<br>


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6152/files#diff-c7b1cd92c4c30590d5da9f0d601d6a4957bedded8680da8434c4b76be5a5ed4c">+1/-2</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Configuration
changes</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>.golangci.yml</strong><dd><code>Configure forbidigo
Linter and Adjust Issue Handling</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; </dd></summary>
<hr>

.golangci.yml
<li>Enabled <code>forbidigo</code> linter and configured it to forbid
<code>fmt.Print*</code> and <br>top-level <code>net/http</code> package
functions.<br> <li> Added rules to exclude <code>forbidigo</code> linter
in the <code>cli</code> package and <br>adjusted issue handling
settings.<br>


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6152/files#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9">+15/-1</a>&nbsp;
&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
<summary><strong>Makefile</strong><dd><code>Remove faillint Tool from
Linting Process</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

Makefile
- Removed `faillint` tool installation and usage.



</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6152/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+0/-2</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools
and their descriptions

---------

Co-authored-by: Tit Petric <tit@tyk.io>