### PR TITLE
[TT-10909]: fix issue with missing upstream headers in graphql proxy only

### DIFF
--- a/ci/tests/tracing/scenarios/tyk_test-graphql-tracing-invalid_404.yml
+++ b/ci/tests/tracing/scenarios/tyk_test-graphql-tracing-invalid_404.yml
@@ -6,7 +6,7 @@ spec:
   trigger:
     type: http
     httpRequest:
-      method: GET
+      method: POST
       url: tyk:8080/test-graphql-tracing-invalid/test-graphql-tracing-invalid
       body: "{\n  \"query\": \"{\\n  country(code: \\\"NG\\\"){\\n    name\\n  }\\n}\"\n}"
       headers:

--- a/gateway/handler_success_test.go
+++ b/gateway/handler_success_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/httpclient"
+
 	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
 	"github.com/TykTechnologies/tyk-pump/analytics"
 	"github.com/TykTechnologies/tyk/test"
@@ -228,6 +230,9 @@ func TestAnalyticRecord_GraphStats(t *testing.T) {
 				Data:   tc.request,
 				Method: http.MethodPost,
 				Code:   tc.code,
+				Headers: map[string]string{
+					httpclient.AcceptEncodingHeader: "",
+				},
 			})
 			assert.NoError(t, err)
 		})

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -997,6 +997,44 @@ func TestGraphQL_ProxyOnlyHeaders(t *testing.T) {
 	})
 }
 
+func TestGraphQL_ProxyOnlyPassHeadersWithOTel(t *testing.T) {
+	g := StartTest(func(globalConf *config.Config) {
+		globalConf.OpenTelemetry.Enabled = true
+	})
+	defer g.Close()
+
+	spec := BuildAPI(func(spec *APISpec) {
+		spec.Name = "tyk-api"
+		spec.APIID = "tyk-api"
+		spec.GraphQL.Enabled = true
+		spec.GraphQL.ExecutionMode = apidef.GraphQLExecutionModeProxyOnly
+		spec.GraphQL.Schema = gqlCountriesSchema
+		spec.GraphQL.Version = apidef.GraphQLConfigVersion2
+		spec.Proxy.TargetURL = TestHttpAny + "/dynamic"
+		spec.Proxy.ListenPath = "/"
+	})[0]
+
+	g.Gw.LoadAPI(spec)
+	g.AddDynamicHandler("/dynamic", func(writer http.ResponseWriter, r *http.Request) {
+		if gotten := r.Header.Get("custom-client-header"); gotten != "custom-value" {
+			t.Errorf("expected upstream to recieve header `custom-client-header` with value of `custom-value`, instead got %s", gotten)
+		}
+	})
+
+	_, err := g.Run(t, test.TestCase{
+		Path: "/",
+		Headers: map[string]string{
+			"custom-client-header": "custom-value",
+		},
+		Method: http.MethodPost,
+		Data: graphql.Request{
+			Query: gqlContinentQuery,
+		},
+	})
+
+	assert.NoError(t, err)
+}
+
 func TestGraphQL_InternalDataSource(t *testing.T) {
 	g := StartTest(nil)
 	defer g.Close()

--- a/internal/graphengine/engine_v2.go
+++ b/internal/graphengine/engine_v2.go
@@ -3,9 +3,10 @@ package graphengine
 import (
 	"context"
 	"errors"
-	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/httpclient"
 	"net/http"
 	"strings"
+
+	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/httpclient"
 
 	"github.com/jensneuse/abstractlogger"
 	"github.com/sirupsen/logrus"

--- a/internal/graphengine/engine_v2.go
+++ b/internal/graphengine/engine_v2.go
@@ -297,7 +297,7 @@ func (e *EngineV2) handoverRequestToGraphQLExecutionEngine(gqlRequest *graphql.R
 		// In this case, upstreamResponse is nil.
 		// See TT-6419 for further info.
 		if proxyOnlyCtx.upstreamResponse != nil {
-			header = proxyOnlyCtx.upstreamResponse.Header
+			header = proxyOnlyCtx.forwardedRequest.Header
 			httpStatus = proxyOnlyCtx.upstreamResponse.StatusCode
 			if e.ApiDefinition.GraphQL.Proxy.UseResponseExtensions.OnErrorForwarding && httpStatus >= http.StatusBadRequest {
 				err = e.gqlTools.returnErrorsFromUpstream(proxyOnlyCtx, &resultWriter, e.seekReadCloser)

--- a/internal/graphengine/engine_v2.go
+++ b/internal/graphengine/engine_v2.go
@@ -262,7 +262,7 @@ func (e *EngineV2) handoverRequestToGraphQLExecutionEngine(gqlRequest *graphql.R
 	span := otel.SpanFromContext(outreq.Context())
 	reqCtx := otel.ContextWithSpan(context.Background(), span)
 	if isProxyOnly {
-		reqCtx = NewGraphQLProxyOnlyContext(reqCtx, outreq)
+		reqCtx = SetProxyOnlyContextValue(reqCtx, outreq)
 	}
 
 	resultWriter := graphql.NewEngineResultWriter()
@@ -290,7 +290,7 @@ func (e *EngineV2) handoverRequestToGraphQLExecutionEngine(gqlRequest *graphql.R
 	header.Set("Content-Type", "application/json")
 
 	if isProxyOnly {
-		proxyOnlyCtx := reqCtx.(*GraphQLProxyOnlyContext)
+		proxyOnlyCtx := GetProxyOnlyContextValue(reqCtx)
 		// There is a case in the proxy-only mode where the request can be handled
 		// by the library without calling the upstream.
 		// This is a valid query for proxy-only mode: query { __typename }

--- a/internal/graphengine/engine_v2.go
+++ b/internal/graphengine/engine_v2.go
@@ -302,6 +302,9 @@ func (e *EngineV2) handoverRequestToGraphQLExecutionEngine(gqlRequest *graphql.R
 		if proxyOnlyCtx.upstreamResponse != nil {
 			header = proxyOnlyCtx.upstreamResponse.Header
 			httpStatus = proxyOnlyCtx.upstreamResponse.StatusCode
+			// change the value of the header's content encoding to use the content encoding defined by the accept encoding
+			contentEncoding := selectContentEncodingToBeUsed(proxyOnlyCtx.forwardedRequest.Header.Get(httpclient.AcceptEncodingHeader))
+			header.Set(httpclient.ContentEncodingHeader, contentEncoding)
 			if e.ApiDefinition.GraphQL.Proxy.UseResponseExtensions.OnErrorForwarding && httpStatus >= http.StatusBadRequest {
 				err = e.gqlTools.returnErrorsFromUpstream(proxyOnlyCtx, &resultWriter, e.seekReadCloser)
 				if err != nil {
@@ -309,9 +312,6 @@ func (e *EngineV2) handoverRequestToGraphQLExecutionEngine(gqlRequest *graphql.R
 				}
 			}
 
-			// change the value of the header's content encoding to use the content encoding defined by the accept encoding
-			contentEncoding := selectContentEncodingToBeUsed(proxyOnlyCtx.forwardedRequest.Header.Get(httpclient.AcceptEncodingHeader))
-			header.Set(httpclient.ContentEncodingHeader, contentEncoding)
 		}
 	}
 	res = resultWriter.AsHTTPResponse(httpStatus, header)

--- a/internal/graphengine/graphql_go_tools_v1.go
+++ b/internal/graphengine/graphql_go_tools_v1.go
@@ -87,7 +87,7 @@ func (g graphqlGoToolsV1) headerModifier(outreq *http.Request, additionalHeaders
 	}
 }
 
-func (g graphqlGoToolsV1) returnErrorsFromUpstream(proxyOnlyCtx *GraphQLProxyOnlyContext, resultWriter *graphql.EngineResultWriter, seekReadCloser SeekReadCloserFunc) error {
+func (g graphqlGoToolsV1) returnErrorsFromUpstream(proxyOnlyCtx *GraphQLProxyOnlyContextValues, resultWriter *graphql.EngineResultWriter, seekReadCloser SeekReadCloserFunc) error {
 	body, err := seekReadCloser(proxyOnlyCtx.upstreamResponse.Body)
 	if body == nil {
 		// Response body already read by graphql-go-tools, and it's not re-readable. Quit silently.

--- a/internal/graphengine/transport.go
+++ b/internal/graphengine/transport.go
@@ -27,18 +27,18 @@ func NewGraphQLEngineTransport(transportType GraphQLEngineTransportType, origina
 func (g *GraphQLEngineTransport) RoundTrip(request *http.Request) (res *http.Response, err error) {
 	switch g.transportType {
 	case GraphQLEngineTransportTypeProxyOnly:
-		proxyOnlyCtx, ok := request.Context().(*GraphQLProxyOnlyContext)
-		if ok {
-			return g.handleProxyOnly(proxyOnlyCtx, request)
+		val := GetProxyOnlyContextValue(request.Context())
+		if val != nil {
+			return g.handleProxyOnly(val, request)
 		}
 	}
 
 	return g.originalTransport.RoundTrip(request)
 }
 
-func (g *GraphQLEngineTransport) handleProxyOnly(proxyOnlyCtx *GraphQLProxyOnlyContext, request *http.Request) (*http.Response, error) {
-	request.Method = proxyOnlyCtx.forwardedRequest.Method
-	g.setProxyOnlyHeaders(proxyOnlyCtx, request)
+func (g *GraphQLEngineTransport) handleProxyOnly(proxyOnlyValues *GraphQLProxyOnlyContextValues, request *http.Request) (*http.Response, error) {
+	request.Method = proxyOnlyValues.forwardedRequest.Method
+	g.setProxyOnlyHeaders(proxyOnlyValues, request)
 
 	response, err := g.originalTransport.RoundTrip(request)
 	if err != nil {
@@ -65,13 +65,13 @@ func (g *GraphQLEngineTransport) handleProxyOnly(proxyOnlyCtx *GraphQLProxyOnlyC
 		}
 		response.Body = reusableBody
 	}
-	proxyOnlyCtx.upstreamResponse = response
+	proxyOnlyValues.upstreamResponse = response
 	return response, err
 }
 
-func (g *GraphQLEngineTransport) setProxyOnlyHeaders(proxyOnlyCtx *GraphQLProxyOnlyContext, r *http.Request) {
-	for forwardedHeaderKey, forwardedHeaderValues := range proxyOnlyCtx.forwardedRequest.Header {
-		if proxyOnlyCtx.ignoreForwardedHeaders[forwardedHeaderKey] {
+func (g *GraphQLEngineTransport) setProxyOnlyHeaders(proxyOnlyValues *GraphQLProxyOnlyContextValues, r *http.Request) {
+	for forwardedHeaderKey, forwardedHeaderValues := range proxyOnlyValues.forwardedRequest.Header {
+		if proxyOnlyValues.ignoreForwardedHeaders[forwardedHeaderKey] {
 			continue
 		}
 


### PR DESCRIPTION
## **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes an issue where the requests from the client were not sent upstream. This was due to an edge case cause by the open telemetry context modification

[TT-10909](https://tyktech.atlassian.net/browse/TT-10909)

This PR also fixes a situation where the requested content-encoding by the client is ignored

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


[TT-10909]: https://tyktech.atlassian.net/browse/TT-10909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

## **Type**
bug_fix, enhancement


___

## **Description**
- Added a new test to ensure headers are correctly passed to the upstream when OpenTelemetry is enabled.
- Introduced a new context management strategy for GraphQL proxy-only mode to correctly forward headers.
- Updated various components within the internal GraphQL engine to utilize the new context structure for header forwarding.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reverse_proxy_test.go</strong><dd><code>Add Test for GraphQL Proxy with OpenTelemetry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/reverse_proxy_test.go
<li>Added a new test <code>TestGraphQL_ProxyOnlyPassHeadersWithOTel</code> to ensure <br>headers are passed upstream when OpenTelemetry is enabled.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6166/files#diff-ce040f6555143f760fba6059744bc600b6954f0966dfb0fa2832b5eabf7a3c3f">+38/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>context.go</strong><dd><code>Manage GraphQL Proxy Context for Headers Forwarding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/graphengine/context.go
<li>Introduced <code>GraphQLProxyOnlyContextValues</code> struct to store request and <br>response details.<br> <li> Added functions <code>SetProxyOnlyContextValue</code> and <code>GetProxyOnlyContextValue</code> <br>for managing GraphQL proxy context.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6166/files#diff-59c1392237cf0565e56acd0f46f7500043ec66fff078bf211ceefbb983baaf94">+31/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>engine_v2.go</strong><dd><code>Integrate New Context Management in Engine V2</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/graphengine/engine_v2.go
<li>Modified to use <code>SetProxyOnlyContextValue</code> for setting proxy context.<br> <li> Updated to retrieve proxy context using <code>GetProxyOnlyContextValue</code>.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6166/files#diff-b1eaa954c9836f395e1d49090e85c739e3878747c8bd748f556fc5a53ff7b191">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>graphql_go_tools_v1.go</strong><dd><code>Update Error Handling with New Context Structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/graphengine/graphql_go_tools_v1.go
<li>Updated <code>returnErrorsFromUpstream</code> to use <code>GraphQLProxyOnlyContextValues</code>.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6166/files#diff-e592cc8ca6ac39e7574765d7f2bbf19193f173791a1b0930d4dde7f9412dc882">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>transport.go</strong><dd><code>Refactor Transport Logic for GraphQL Proxy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/graphengine/transport.go
<li>Refactored to use <code>GraphQLProxyOnlyContextValues</code> for handling <br>proxy-only requests.<br> <li> Adjusted header forwarding logic to accommodate new context structure.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6166/files#diff-564061c9b29366529eb1f6f10fe39671d2ac738a4731ffd2c8b04dcc0a8cd610">+10/-10</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

