### PR TITLE
Merging to release-5.2: [TT-10909]: fix issue with missing upstream headers in graphql proxy only (#6166)

### DIFF
--- a/ci/tests/tracing/scenarios/tyk_test-graphql-tracing-invalid_404.yml
+++ b/ci/tests/tracing/scenarios/tyk_test-graphql-tracing-invalid_404.yml
@@ -6,7 +6,7 @@ spec:
   trigger:
     type: http
     httpRequest:
-      method: GET
+      method: POST
       url: tyk:8080/test-graphql-tracing-invalid/test-graphql-tracing-invalid
       body: "{\n  \"query\": \"{\\n  country(code: \\\"NG\\\"){\\n    name\\n  }\\n}\"\n}"
       headers:

--- a/gateway/handler_success_test.go
+++ b/gateway/handler_success_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/httpclient"
+
 	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
 	"github.com/TykTechnologies/tyk-pump/analytics"
 	"github.com/TykTechnologies/tyk/test"
@@ -111,6 +113,135 @@ func TestRecordDetail(t *testing.T) {
 	}
 }
 
+<<<<<<< HEAD
+=======
+func TestAnalyticRecord_GraphStats(t *testing.T) {
+
+	apiDef := BuildAPI(func(spec *APISpec) {
+		spec.Name = "graphql API"
+		spec.APIID = "graphql-api"
+		spec.Proxy.TargetURL = testGraphQLProxyUpstream
+		spec.Proxy.ListenPath = "/"
+		spec.GraphQL = apidef.GraphQLConfig{
+			Enabled:       true,
+			ExecutionMode: apidef.GraphQLExecutionModeProxyOnly,
+			Version:       apidef.GraphQLConfigVersion2,
+			Schema:        gqlProxyUpstreamSchema,
+		}
+	})[0]
+
+	testCases := []struct {
+		name      string
+		code      int
+		request   graphql.Request
+		checkFunc func(*testing.T, *analytics.AnalyticsRecord)
+		reloadAPI func(*APISpec)
+	}{
+		{
+			name: "successfully generate stats",
+			code: http.StatusOK,
+			request: graphql.Request{
+				Query: `{ hello(name: "World") httpMethod }`,
+			},
+			checkFunc: func(t *testing.T, record *analytics.AnalyticsRecord) {
+				assert.True(t, record.GraphQLStats.IsGraphQL)
+				assert.False(t, record.GraphQLStats.HasErrors)
+				assert.ElementsMatch(t, []string{"hello", "httpMethod"}, record.GraphQLStats.RootFields)
+				assert.Equal(t, map[string][]string{}, record.GraphQLStats.Types)
+				assert.Equal(t, analytics.OperationQuery, record.GraphQLStats.OperationType)
+			},
+		},
+		{
+			name: "should have variables",
+			code: http.StatusOK,
+			request: graphql.Request{
+				Query:     `{ hello(name: "World") httpMethod }`,
+				Variables: []byte(`{"in":"hello"}`),
+			},
+			checkFunc: func(t *testing.T, record *analytics.AnalyticsRecord) {
+				assert.True(t, record.GraphQLStats.IsGraphQL)
+				assert.False(t, record.GraphQLStats.HasErrors)
+				assert.ElementsMatch(t, []string{"httpMethod", "hello"}, record.GraphQLStats.RootFields)
+				assert.Equal(t, map[string][]string{}, record.GraphQLStats.Types)
+				assert.Equal(t, analytics.OperationQuery, record.GraphQLStats.OperationType)
+				assert.Equal(t, `{"in":"hello"}`, record.GraphQLStats.Variables)
+			},
+		},
+		{
+			name: "should read response and error response request with detailed recording",
+			code: http.StatusInternalServerError,
+			request: graphql.Request{
+				Query:     `{ hello(name: "World") httpMethod }`,
+				Variables: []byte(`{"in":"hello"}`),
+			},
+			reloadAPI: func(spec *APISpec) {
+				spec.Proxy.TargetURL = testGraphQLProxyUpstreamError
+				spec.EnableDetailedRecording = true
+			},
+			checkFunc: func(t *testing.T, record *analytics.AnalyticsRecord) {
+				assert.True(t, record.GraphQLStats.IsGraphQL)
+				assert.True(t, record.GraphQLStats.HasErrors)
+				assert.ElementsMatch(t, []string{"hello", "httpMethod"}, record.GraphQLStats.RootFields)
+				assert.Equal(t, map[string][]string{}, record.GraphQLStats.Types)
+				assert.Equal(t, analytics.OperationQuery, record.GraphQLStats.OperationType)
+				assert.Equal(t, `{"in":"hello"}`, record.GraphQLStats.Variables)
+				assert.Equal(t, []analytics.GraphError{
+					{Message: "unable to resolve"},
+				}, record.GraphQLStats.Errors)
+			},
+		},
+		{
+			name: "should read response request without detailed recording",
+			code: http.StatusInternalServerError,
+			request: graphql.Request{
+				Query:     `{ hello(name: "World") httpMethod }`,
+				Variables: []byte(`{"in":"hello"}`),
+			},
+			reloadAPI: func(spec *APISpec) {
+				spec.Proxy.TargetURL = testGraphQLProxyUpstreamError
+			},
+			checkFunc: func(t *testing.T, record *analytics.AnalyticsRecord) {
+				assert.True(t, record.GraphQLStats.IsGraphQL)
+				assert.True(t, record.GraphQLStats.HasErrors)
+				assert.ElementsMatch(t, []string{"hello", "httpMethod"}, record.GraphQLStats.RootFields)
+				assert.Equal(t, map[string][]string{}, record.GraphQLStats.Types)
+				assert.Equal(t, analytics.OperationQuery, record.GraphQLStats.OperationType)
+				assert.Equal(t, `{"in":"hello"}`, record.GraphQLStats.Variables)
+				assert.Equal(t, []analytics.GraphError{
+					{Message: "unable to resolve"},
+				}, record.GraphQLStats.Errors)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := apiDef
+			if tc.reloadAPI != nil {
+				tc.reloadAPI(spec)
+			}
+
+			ts := StartTest(nil)
+			defer ts.Close()
+			ts.Gw.LoadAPI(spec)
+			ts.Gw.Analytics.mockEnabled = true
+			ts.Gw.Analytics.mockRecordHit = func(record *analytics.AnalyticsRecord) {
+				tc.checkFunc(t, record)
+			}
+			_, err := ts.Run(t, test.TestCase{
+				Data:   tc.request,
+				Method: http.MethodPost,
+				Code:   tc.code,
+				Headers: map[string]string{
+					httpclient.AcceptEncodingHeader: "",
+				},
+			})
+			assert.NoError(t, err)
+		})
+	}
+}
+
+>>>>>>> 6ab2b5693... [TT-10909]: fix issue with missing upstream headers in graphql proxy only (#6166)
 func TestAnalyticsIgnoreSubgraph(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()

--- a/gateway/mw_graphql_transport.go
+++ b/gateway/mw_graphql_transport.go
@@ -71,18 +71,18 @@ func NewGraphQLEngineTransport(transportType GraphQLEngineTransportType, origina
 func (g *GraphQLEngineTransport) RoundTrip(request *http.Request) (res *http.Response, err error) {
 	switch g.transportType {
 	case GraphQLEngineTransportTypeProxyOnly:
-		proxyOnlyCtx, ok := request.Context().(*GraphQLProxyOnlyContext)
-		if ok {
-			return g.handleProxyOnly(proxyOnlyCtx, request)
+		val := GetProxyOnlyContextValue(request.Context())
+		if val != nil {
+			return g.handleProxyOnly(val, request)
 		}
 	}
 
 	return g.originalTransport.RoundTrip(request)
 }
 
-func (g *GraphQLEngineTransport) handleProxyOnly(proxyOnlyCtx *GraphQLProxyOnlyContext, request *http.Request) (*http.Response, error) {
-	request.Method = proxyOnlyCtx.forwardedRequest.Method
-	g.setProxyOnlyHeaders(proxyOnlyCtx, request)
+func (g *GraphQLEngineTransport) handleProxyOnly(proxyOnlyValues *GraphQLProxyOnlyContextValues, request *http.Request) (*http.Response, error) {
+	request.Method = proxyOnlyValues.forwardedRequest.Method
+	g.setProxyOnlyHeaders(proxyOnlyValues, request)
 
 	response, err := g.originalTransport.RoundTrip(request)
 	if err != nil {
@@ -109,13 +109,13 @@ func (g *GraphQLEngineTransport) handleProxyOnly(proxyOnlyCtx *GraphQLProxyOnlyC
 		}
 		response.Body = reusableBody
 	}
-	proxyOnlyCtx.upstreamResponse = response
+	proxyOnlyValues.upstreamResponse = response
 	return response, err
 }
 
-func (g *GraphQLEngineTransport) setProxyOnlyHeaders(proxyOnlyCtx *GraphQLProxyOnlyContext, r *http.Request) {
-	for forwardedHeaderKey, forwardedHeaderValues := range proxyOnlyCtx.forwardedRequest.Header {
-		if proxyOnlyCtx.ignoreForwardedHeaders[forwardedHeaderKey] {
+func (g *GraphQLEngineTransport) setProxyOnlyHeaders(proxyOnlyValues *GraphQLProxyOnlyContextValues, r *http.Request) {
+	for forwardedHeaderKey, forwardedHeaderValues := range proxyOnlyValues.forwardedRequest.Header {
+		if proxyOnlyValues.ignoreForwardedHeaders[forwardedHeaderKey] {
 			continue
 		}
 

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -1000,6 +1000,44 @@ func TestGraphQL_ProxyOnlyHeaders(t *testing.T) {
 	})
 }
 
+func TestGraphQL_ProxyOnlyPassHeadersWithOTel(t *testing.T) {
+	g := StartTest(func(globalConf *config.Config) {
+		globalConf.OpenTelemetry.Enabled = true
+	})
+	defer g.Close()
+
+	spec := BuildAPI(func(spec *APISpec) {
+		spec.Name = "tyk-api"
+		spec.APIID = "tyk-api"
+		spec.GraphQL.Enabled = true
+		spec.GraphQL.ExecutionMode = apidef.GraphQLExecutionModeProxyOnly
+		spec.GraphQL.Schema = gqlCountriesSchema
+		spec.GraphQL.Version = apidef.GraphQLConfigVersion2
+		spec.Proxy.TargetURL = TestHttpAny + "/dynamic"
+		spec.Proxy.ListenPath = "/"
+	})[0]
+
+	g.Gw.LoadAPI(spec)
+	g.AddDynamicHandler("/dynamic", func(writer http.ResponseWriter, r *http.Request) {
+		if gotten := r.Header.Get("custom-client-header"); gotten != "custom-value" {
+			t.Errorf("expected upstream to recieve header `custom-client-header` with value of `custom-value`, instead got %s", gotten)
+		}
+	})
+
+	_, err := g.Run(t, test.TestCase{
+		Path: "/",
+		Headers: map[string]string{
+			"custom-client-header": "custom-value",
+		},
+		Method: http.MethodPost,
+		Data: graphql.Request{
+			Query: gqlContinentQuery,
+		},
+	})
+
+	assert.NoError(t, err)
+}
+
 func TestGraphQL_InternalDataSource(t *testing.T) {
 	g := StartTest(nil)
 	defer g.Close()

--- a/internal/graphengine/context.go
+++ b/internal/graphengine/context.go
@@ -1,0 +1,80 @@
+package graphengine
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/TykTechnologies/tyk/apidef"
+)
+
+type GraphQLEngineTransportType int
+
+const (
+	GraphQLEngineTransportTypeProxyOnly GraphQLEngineTransportType = iota
+	GraphQLEngineTransportTypeMultiUpstream
+)
+
+type contextKey struct{}
+
+var graphqlProxyContextInfo = contextKey{}
+
+type GraphQLProxyOnlyContextValues struct {
+	forwardedRequest       *http.Request
+	upstreamResponse       *http.Response
+	ignoreForwardedHeaders map[string]bool
+}
+
+func SetProxyOnlyContextValue(ctx context.Context, req *http.Request) context.Context {
+	value := &GraphQLProxyOnlyContextValues{
+		forwardedRequest: req,
+		ignoreForwardedHeaders: map[string]bool{
+			http.CanonicalHeaderKey("date"):           true,
+			http.CanonicalHeaderKey("content-type"):   true,
+			http.CanonicalHeaderKey("content-length"): true,
+		},
+	}
+
+	return context.WithValue(ctx, graphqlProxyContextInfo, value)
+}
+
+func GetProxyOnlyContextValue(ctx context.Context) *GraphQLProxyOnlyContextValues {
+	val, ok := ctx.Value(graphqlProxyContextInfo).(*GraphQLProxyOnlyContextValues)
+	if !ok {
+		return nil
+	}
+	return val
+}
+
+func DetermineGraphQLEngineTransportType(apiDefinition *apidef.APIDefinition) GraphQLEngineTransportType {
+	switch apiDefinition.GraphQL.ExecutionMode {
+	case apidef.GraphQLExecutionModeSubgraph:
+		fallthrough
+	case apidef.GraphQLExecutionModeProxyOnly:
+		return GraphQLEngineTransportTypeProxyOnly
+	}
+
+	return GraphQLEngineTransportTypeMultiUpstream
+}
+
+type GraphQLProxyOnlyContext struct {
+	context.Context
+	forwardedRequest       *http.Request
+	upstreamResponse       *http.Response
+	ignoreForwardedHeaders map[string]bool
+}
+
+func NewGraphQLProxyOnlyContext(ctx context.Context, forwardedRequest *http.Request) *GraphQLProxyOnlyContext {
+	return &GraphQLProxyOnlyContext{
+		Context:          ctx,
+		forwardedRequest: forwardedRequest,
+		ignoreForwardedHeaders: map[string]bool{
+			http.CanonicalHeaderKey("date"):           true,
+			http.CanonicalHeaderKey("content-type"):   true,
+			http.CanonicalHeaderKey("content-length"): true,
+		},
+	}
+}
+
+func (g *GraphQLProxyOnlyContext) Response() *http.Response {
+	return g.upstreamResponse
+}

--- a/internal/graphengine/engine_v2.go
+++ b/internal/graphengine/engine_v2.go
@@ -1,0 +1,391 @@
+package graphengine
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/httpclient"
+
+	"github.com/jensneuse/abstractlogger"
+	"github.com/sirupsen/logrus"
+
+	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/resolve"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/subscription"
+	gqlwebsocket "github.com/TykTechnologies/graphql-go-tools/pkg/subscription/websocket"
+
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/apidef/adapter"
+	graphqlinternal "github.com/TykTechnologies/tyk/internal/graphql"
+	"github.com/TykTechnologies/tyk/internal/otel"
+)
+
+type EngineV2OTelConfig struct {
+	Enabled        bool
+	Config         otel.OpenTelemetry
+	TracerProvider otel.TracerProvider
+	Executor       graphqlinternal.TykOtelExecutorI
+}
+
+type EngineV2Injections struct {
+	BeforeFetchHook           resolve.BeforeFetchHook
+	AfterFetchHook            resolve.AfterFetchHook
+	WebsocketOnBeforeStart    graphql.WebsocketBeforeStartHook
+	ContextStoreRequest       ContextStoreRequestV1Func
+	ContextRetrieveRequest    ContextRetrieveRequestV1Func
+	NewReusableBodyReadCloser NewReusableBodyReadCloserFunc
+	SeekReadCloser            SeekReadCloserFunc
+	TykVariableReplacer       TykVariableReplacer
+}
+
+type EngineV2 struct {
+	ExecutionEngine *graphql.ExecutionEngineV2
+	Schema          *graphql.Schema
+	ApiDefinition   *apidef.APIDefinition
+	HttpClient      *http.Client
+	StreamingClient *http.Client
+	OpenTelemetry   *EngineV2OTelConfig
+
+	logger                    abstractlogger.Logger
+	gqlTools                  graphqlGoToolsV1
+	graphqlRequestProcessor   GraphQLRequestProcessor
+	complexityChecker         ComplexityChecker
+	granularAccessChecker     GranularAccessChecker
+	reverseProxyPreHandler    ReverseProxyPreHandler
+	contextCancel             context.CancelFunc
+	beforeFetchHook           resolve.BeforeFetchHook
+	afterFetchHook            resolve.AfterFetchHook
+	ctxStoreRequestFunc       func(r *http.Request, gqlRequest *graphql.Request)
+	ctxRetrieveRequestFunc    func(r *http.Request) *graphql.Request
+	newReusableBodyReadCloser NewReusableBodyReadCloserFunc
+	seekReadCloser            SeekReadCloserFunc
+	tykVariableReplacer       TykVariableReplacer
+}
+
+type EngineV2Options struct {
+	Logger          *logrus.Logger
+	Schema          *graphql.Schema
+	ApiDefinition   *apidef.APIDefinition
+	HttpClient      *http.Client
+	StreamingClient *http.Client
+	OpenTelemetry   EngineV2OTelConfig
+	Injections      EngineV2Injections
+}
+
+func NewEngineV2(options EngineV2Options) (*EngineV2, error) {
+	logger := createAbstractLogrusLogger(options.Logger)
+	gqlTools := graphqlGoToolsV1{}
+
+	var parsedSchema = options.Schema
+	if parsedSchema == nil {
+		var err error
+		parsedSchema, err = gqlTools.parseSchema(options.ApiDefinition.GraphQL.Schema)
+		if err != nil {
+			logger.Error("error on schema parsing", abstractlogger.Error(err))
+			return nil, err
+		}
+	}
+
+	configAdapter := adapter.NewGraphQLConfigAdapter(options.ApiDefinition,
+		adapter.WithHttpClient(options.HttpClient),
+		adapter.WithStreamingClient(options.StreamingClient),
+		adapter.WithSchema(parsedSchema),
+	)
+
+	engineConfig, err := configAdapter.EngineConfigV2()
+	if err != nil {
+		options.Logger.WithError(err).Error("could not create engine v2 config")
+		return nil, err
+	}
+	engineConfig.SetWebsocketBeforeStartHook(options.Injections.WebsocketOnBeforeStart)
+	specCtx, cancel := context.WithCancel(context.Background())
+
+	executionEngine, err := graphql.NewExecutionEngineV2(specCtx, logger, *engineConfig)
+	if err != nil {
+		options.Logger.WithError(err).Error("could not create execution engine v2")
+		cancel()
+		return nil, err
+	}
+
+	requestProcessor := &graphqlRequestProcessorV1{
+		logger:             logger,
+		schema:             parsedSchema,
+		ctxRetrieveRequest: options.Injections.ContextRetrieveRequest,
+	}
+
+	complexityChecker := &complexityCheckerV1{
+		logger:             logger,
+		schema:             parsedSchema,
+		ctxRetrieveRequest: options.Injections.ContextRetrieveRequest,
+	}
+
+	granularAccessChecker := &granularAccessCheckerV1{
+		logger:                    logger,
+		schema:                    parsedSchema,
+		ctxRetrieveGraphQLRequest: options.Injections.ContextRetrieveRequest,
+	}
+
+	reverseProxyPreHandler := &reverseProxyPreHandlerV1{
+		ctxRetrieveGraphQLRequest: options.Injections.ContextRetrieveRequest,
+		apiDefinition:             options.ApiDefinition,
+		httpClient:                options.HttpClient,
+		newReusableBodyReadCloser: options.Injections.NewReusableBodyReadCloser,
+	}
+
+	engineV2 := &EngineV2{
+		ExecutionEngine:           executionEngine,
+		Schema:                    parsedSchema,
+		ApiDefinition:             options.ApiDefinition,
+		HttpClient:                options.HttpClient,
+		StreamingClient:           options.StreamingClient,
+		OpenTelemetry:             &options.OpenTelemetry,
+		logger:                    logger,
+		gqlTools:                  gqlTools,
+		graphqlRequestProcessor:   requestProcessor,
+		complexityChecker:         complexityChecker,
+		granularAccessChecker:     granularAccessChecker,
+		reverseProxyPreHandler:    reverseProxyPreHandler,
+		contextCancel:             cancel,
+		beforeFetchHook:           options.Injections.BeforeFetchHook,
+		afterFetchHook:            options.Injections.AfterFetchHook,
+		ctxStoreRequestFunc:       options.Injections.ContextStoreRequest,
+		ctxRetrieveRequestFunc:    options.Injections.ContextRetrieveRequest,
+		newReusableBodyReadCloser: options.Injections.NewReusableBodyReadCloser,
+		seekReadCloser:            options.Injections.SeekReadCloser,
+		tykVariableReplacer:       options.Injections.TykVariableReplacer,
+	}
+
+	if engineV2.OpenTelemetry == nil {
+		engineV2.OpenTelemetry = &EngineV2OTelConfig{}
+	}
+
+	if engineV2.OpenTelemetry.Enabled {
+		var executor graphqlinternal.TykOtelExecutorI
+		if options.ApiDefinition.DetailedTracing {
+			executor, err = graphqlinternal.NewOtelGraphqlEngineV2Detailed(engineV2.OpenTelemetry.TracerProvider, executionEngine, parsedSchema)
+		} else {
+			executor, err = graphqlinternal.NewOtelGraphqlEngineV2Basic(engineV2.OpenTelemetry.TracerProvider, executionEngine)
+		}
+		if err != nil {
+			options.Logger.WithError(err).Error("error creating custom execution engine v2")
+			cancel()
+			return nil, err
+		}
+
+		otelRequestProcessor := &graphqlRequestProcessorWithOTelV1{
+			logger:             logger,
+			schema:             parsedSchema,
+			otelExecutor:       executor,
+			ctxRetrieveRequest: options.Injections.ContextRetrieveRequest,
+		}
+		engineV2.graphqlRequestProcessor = otelRequestProcessor
+		engineV2.OpenTelemetry.Executor = executor
+	}
+
+	if isSupergraph(options.ApiDefinition) {
+		engineV2.ApiDefinition.GraphQL.Schema = engineV2.ApiDefinition.GraphQL.Supergraph.MergedSDL
+	}
+
+	return engineV2, nil
+}
+
+func (e *EngineV2) Version() EngineVersion {
+	return EngineVersionV2
+}
+
+func (e *EngineV2) HasSchema() bool {
+	return e.Schema != nil
+}
+
+func (e *EngineV2) Cancel() {
+	if e.contextCancel != nil {
+		e.contextCancel()
+	}
+}
+
+func (e *EngineV2) ProcessAndStoreGraphQLRequest(w http.ResponseWriter, r *http.Request) (err error, statusCode int) {
+	var gqlRequest graphql.Request
+	err = graphql.UnmarshalRequest(r.Body, &gqlRequest)
+	if err != nil {
+		e.logger.Debug("error while unmarshalling GraphQL request", abstractlogger.Error(err))
+		return err, http.StatusBadRequest
+	}
+
+	e.ctxStoreRequestFunc(r, &gqlRequest)
+	if e.OpenTelemetry.Enabled && e.ApiDefinition.DetailedTracing {
+		ctx, span := e.OpenTelemetry.TracerProvider.Tracer().Start(r.Context(), "GraphqlMiddleware Validation")
+		defer span.End()
+		*r = *r.WithContext(ctx)
+	}
+
+	return e.graphqlRequestProcessor.ProcessRequest(r.Context(), w, r)
+}
+
+func (e *EngineV2) ProcessGraphQLComplexity(r *http.Request, accessDefinition *ComplexityAccessDefinition) (err error, statusCode int) {
+	return complexityFailReasonAsHttpStatusCode(e.complexityChecker.DepthLimitExceeded(r, accessDefinition))
+}
+
+func (e *EngineV2) ProcessGraphQLGranularAccess(w http.ResponseWriter, r *http.Request, accessDefinition *GranularAccessDefinition) (err error, statusCode int) {
+	result := e.granularAccessChecker.CheckGraphQLRequestFieldAllowance(w, r, accessDefinition)
+	return granularAccessFailReasonAsHttpStatusCode(e.logger, &result, w)
+}
+
+func (e *EngineV2) HandleReverseProxy(params ReverseProxyParams) (res *http.Response, hijacked bool, err error) {
+	reverseProxyType, err := e.reverseProxyPreHandler.PreHandle(params)
+	if err != nil {
+		e.logger.Error("error on reverse proxy pre handler", abstractlogger.Error(err))
+		return nil, false, err
+	}
+
+	gqlRequest := e.ctxRetrieveRequestFunc(params.OutRequest)
+	switch reverseProxyType {
+	case ReverseProxyTypeIntrospection:
+		return e.gqlTools.handleIntrospection(e.Schema)
+	case ReverseProxyTypeWebsocketUpgrade:
+		return e.handoverWebSocketConnectionToGraphQLExecutionEngine(&params)
+	case ReverseProxyTypeGraphEngine:
+		return e.handoverRequestToGraphQLExecutionEngine(gqlRequest, params.OutRequest)
+	case ReverseProxyTypeNone:
+		return nil, false, nil
+	}
+
+	e.logger.Error("unknown reverse proxy type", abstractlogger.Int("reverseProxyType", int(reverseProxyType)))
+	return nil, false, ErrUnknownReverseProxyType
+}
+
+func (e *EngineV2) handoverRequestToGraphQLExecutionEngine(gqlRequest *graphql.Request, outreq *http.Request) (res *http.Response, hijacked bool, err error) {
+	if e.ExecutionEngine == nil {
+		err = errors.New("execution engine is nil")
+		return
+	}
+
+	isProxyOnly := isProxyOnly(e.ApiDefinition)
+	span := otel.SpanFromContext(outreq.Context())
+	reqCtx := otel.ContextWithSpan(context.Background(), span)
+	if isProxyOnly {
+		reqCtx = SetProxyOnlyContextValue(reqCtx, outreq)
+	}
+
+	resultWriter := graphql.NewEngineResultWriter()
+	execOptions := []graphql.ExecutionOptionsV2{
+		graphql.WithBeforeFetchHook(e.beforeFetchHook),
+		graphql.WithAfterFetchHook(e.afterFetchHook),
+	}
+
+	upstreamHeaders := additionalUpstreamHeaders(e.logger, outreq, e.ApiDefinition)
+	execOptions = append(execOptions, graphql.WithHeaderModifier(e.gqlTools.headerModifier(outreq, upstreamHeaders, e.tykVariableReplacer)))
+
+	if e.OpenTelemetry.Executor != nil {
+		if err = e.OpenTelemetry.Executor.Execute(reqCtx, gqlRequest, &resultWriter, execOptions...); err != nil {
+			return
+		}
+	} else {
+		err = e.ExecutionEngine.Execute(reqCtx, gqlRequest, &resultWriter, execOptions...)
+		if err != nil {
+			return
+		}
+	}
+
+	httpStatus := http.StatusOK
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+
+	if isProxyOnly {
+		proxyOnlyCtx := GetProxyOnlyContextValue(reqCtx)
+		// There is a case in the proxy-only mode where the request can be handled
+		// by the library without calling the upstream.
+		// This is a valid query for proxy-only mode: query { __typename }
+		// In this case, upstreamResponse is nil.
+		// See TT-6419 for further info.
+		if proxyOnlyCtx.upstreamResponse != nil {
+			header = proxyOnlyCtx.upstreamResponse.Header
+			httpStatus = proxyOnlyCtx.upstreamResponse.StatusCode
+			// change the value of the header's content encoding to use the content encoding defined by the accept encoding
+			contentEncoding := selectContentEncodingToBeUsed(proxyOnlyCtx.forwardedRequest.Header.Get(httpclient.AcceptEncodingHeader))
+			header.Set(httpclient.ContentEncodingHeader, contentEncoding)
+			if e.ApiDefinition.GraphQL.Proxy.UseResponseExtensions.OnErrorForwarding && httpStatus >= http.StatusBadRequest {
+				err = e.gqlTools.returnErrorsFromUpstream(proxyOnlyCtx, &resultWriter, e.seekReadCloser)
+				if err != nil {
+					return
+				}
+			}
+
+		}
+	}
+	res = resultWriter.AsHTTPResponse(httpStatus, header)
+	return
+}
+
+// selectContentEncodingToBeUsed selects the encoding value to be returned based on the IETF standards
+// if acceptedEncoding is a list of comma separated strings br,gzip, deflate; then it selects the first supported one
+// if it is a single value then it returns that value
+// if no supported encoding is found, it returns the last value
+func selectContentEncodingToBeUsed(acceptedEncoding string) string {
+	supportedHeaders := map[string]struct{}{
+		"gzip":    {},
+		"deflate": {},
+		"br":      {},
+	}
+
+	values := strings.Split(acceptedEncoding, ",")
+	if len(values) < 2 {
+		return values[0]
+	}
+
+	for i, e := range values {
+		enc := strings.TrimSpace(e)
+		if _, ok := supportedHeaders[enc]; ok {
+			return enc
+		}
+		if i == len(values)-1 {
+			return enc
+		}
+	}
+	return ""
+}
+
+func (e *EngineV2) handoverWebSocketConnectionToGraphQLExecutionEngine(params *ReverseProxyParams) (res *http.Response, hijacked bool, err error) {
+	conn, err := websocketConnWithUpgradeHeader(e.logger, params)
+	if err != nil {
+		e.logger.Error("could not upgrade websocket connection", abstractlogger.Error(err))
+		return nil, false, err
+	}
+
+	done := make(chan bool)
+	errChan := make(chan error)
+
+	var executorPool subscription.ExecutorPool
+
+	if e.ExecutionEngine == nil {
+		e.logger.Error("could not start graphql websocket handler: execution engine is nil")
+		return
+	}
+	initialRequestContext := subscription.NewInitialHttpRequestContext(params.OutRequest)
+	upstreamHeaders := additionalUpstreamHeaders(e.logger, params.OutRequest, e.ApiDefinition)
+	executorPool = subscription.NewExecutorV2Pool(
+		e.ExecutionEngine,
+		initialRequestContext,
+		subscription.WithExecutorV2HeaderModifier(e.gqlTools.headerModifier(params.OutRequest, upstreamHeaders, e.tykVariableReplacer)),
+	)
+
+	go gqlwebsocket.Handle(
+		done,
+		errChan,
+		conn,
+		executorPool,
+		gqlwebsocket.WithLogger(e.logger),
+		gqlwebsocket.WithProtocolFromRequestHeaders(params.OutRequest),
+	)
+	select {
+	case err := <-errChan:
+		e.logger.Error("could not start graphql websocket handler: ", abstractlogger.Error(err))
+	case <-done:
+	}
+
+	return nil, true, nil
+}
+
+// Interface Guard
+var _ Engine = (*EngineV2)(nil)

--- a/internal/graphengine/graphql_go_tools_v1.go
+++ b/internal/graphengine/graphql_go_tools_v1.go
@@ -1,0 +1,528 @@
+package graphengine
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/buger/jsonparser"
+	"github.com/jensneuse/abstractlogger"
+
+	"github.com/TykTechnologies/graphql-go-tools/pkg/execution/datasource"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/postprocess"
+
+	"github.com/TykTechnologies/tyk/apidef"
+	internalgraphql "github.com/TykTechnologies/tyk/internal/graphql"
+)
+
+const (
+	HTTPJSONDataSource   = "HTTPJSONDataSource"
+	GraphQLDataSource    = "GraphQLDataSource"
+	SchemaDataSource     = "SchemaDataSource"
+	TykRESTDataSource    = "TykRESTDataSource"
+	TykGraphQLDataSource = "TykGraphQLDataSource"
+)
+
+type ContextRetrieveRequestV1Func func(r *http.Request) *graphql.Request
+type ContextStoreRequestV1Func func(r *http.Request, gqlRequest *graphql.Request)
+
+type createExecutionEngineV1Params struct {
+	logger              abstractlogger.Logger
+	apiDef              *apidef.APIDefinition
+	schema              *graphql.Schema
+	httpClient          *http.Client
+	preSendHttpHook     datasource.PreSendHttpHook
+	postReceiveHttpHook datasource.PostReceiveHttpHook
+}
+
+// graphqlGoToolsV1 is a stateless utility struct that abstracts graphql-go-tools/v1 functionality. Also
+// useful for namespacing.
+type graphqlGoToolsV1 struct{}
+
+func (g graphqlGoToolsV1) parseSchema(schema string) (*graphql.Schema, error) {
+	parsedSchema, err := graphql.NewSchemaFromString(schema)
+	if err != nil {
+		return nil, err
+	}
+
+	normalizationResult, err := parsedSchema.Normalize()
+	if err != nil {
+		return nil, err
+	}
+
+	if !normalizationResult.Successful {
+		return nil, fmt.Errorf("schema normalization was not successful. Reason: %w", normalizationResult.Errors)
+	}
+
+	return parsedSchema, nil
+}
+
+func (g graphqlGoToolsV1) handleIntrospection(schema *graphql.Schema) (res *http.Response, hijacked bool, err error) {
+	var result *graphql.ExecutionResult
+	result, err = graphql.SchemaIntrospection(schema)
+	if err != nil {
+		return
+	}
+
+	res = result.GetAsHTTPResponse()
+	return
+}
+
+func (g graphqlGoToolsV1) headerModifier(outreq *http.Request, additionalHeaders http.Header, variableReplacer TykVariableReplacer) postprocess.HeaderModifier {
+	return func(header http.Header) {
+		for key := range additionalHeaders {
+			if header.Get(key) == "" {
+				header.Set(key, additionalHeaders.Get(key))
+			}
+		}
+
+		for key := range header {
+			val := variableReplacer(outreq, header.Get(key), false)
+			header.Set(key, val)
+		}
+	}
+}
+
+func (g graphqlGoToolsV1) returnErrorsFromUpstream(proxyOnlyCtx *GraphQLProxyOnlyContextValues, resultWriter *graphql.EngineResultWriter, seekReadCloser SeekReadCloserFunc) error {
+	body, err := seekReadCloser(proxyOnlyCtx.upstreamResponse.Body)
+	if body == nil {
+		// Response body already read by graphql-go-tools, and it's not re-readable. Quit silently.
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	responseBody, err := io.ReadAll(body)
+	if err != nil {
+		return err
+	}
+	// graphql-go-tools error message format: {"errors": [...]}
+	// Insert the upstream error into the first error message.
+	result, err := jsonparser.Set(resultWriter.Bytes(), responseBody, "errors", "[0]", "extensions")
+	if err != nil {
+		return err
+	}
+	resultWriter.Reset()
+	_, err = resultWriter.Write(result)
+	return err
+}
+
+func (g graphqlGoToolsV1) createExecutionEngine(params createExecutionEngineV1Params) (*graphql.ExecutionEngine, error) {
+	typeFieldConfigurations := params.apiDef.GraphQL.TypeFieldConfigurations
+	if params.schema.HasQueryType() {
+		typeFieldConfigurations = append(typeFieldConfigurations, datasource.TypeFieldConfiguration{
+			TypeName:  params.schema.QueryTypeName(),
+			FieldName: "__schema",
+			DataSource: datasource.SourceConfig{
+				Name: SchemaDataSource,
+				Config: func() json.RawMessage {
+					res, _ := json.Marshal(datasource.SchemaDataSourcePlannerConfig{})
+					return res
+				}(),
+			},
+		})
+	}
+
+	plannerConfig := datasource.PlannerConfiguration{
+		TypeFieldConfigurations: typeFieldConfigurations,
+	}
+
+	if params.logger == nil {
+		params.logger = abstractlogger.NoopLogger
+	}
+
+	engine, err := graphql.NewExecutionEngine(params.logger, params.schema, plannerConfig)
+	if err != nil {
+		params.logger.Error("graphql execution engine couldn't be created", abstractlogger.Error(err))
+		return nil, err
+	}
+
+	hooks := &datasource.Hooks{
+		PreSendHttpHook:     params.preSendHttpHook,
+		PostReceiveHttpHook: params.postReceiveHttpHook,
+	}
+
+	httpJSONOptions := graphql.DataSourceHttpJsonOptions{
+		HttpClient:         params.httpClient,
+		WhitelistedSchemes: []string{"tyk"},
+		Hooks:              hooks,
+	}
+
+	graphQLOptions := graphql.DataSourceGraphqlOptions{
+		HttpClient:         params.httpClient,
+		WhitelistedSchemes: []string{"tyk"},
+		Hooks:              hooks,
+	}
+
+	errMsgFormat := "%s couldn't be added"
+
+	err = engine.AddHttpJsonDataSourceWithOptions(HTTPJSONDataSource, httpJSONOptions)
+	if err != nil {
+		//g.logger.Error(fmt.Sprintf(errMsgFormat, HTTPJSONDataSource), abstractlogger.Error(err))
+		params.logger.Error(fmt.Sprintf(errMsgFormat, HTTPJSONDataSource), abstractlogger.Error(err))
+	}
+
+	err = engine.AddHttpJsonDataSourceWithOptions(TykRESTDataSource, httpJSONOptions)
+	if err != nil {
+		//g.logger.Error(fmt.Sprintf(errMsgFormat, HTTPJSONDataSource), abstractlogger.Error(err))
+		params.logger.Error(fmt.Sprintf(errMsgFormat, HTTPJSONDataSource), abstractlogger.Error(err))
+	}
+
+	err = engine.AddGraphqlDataSourceWithOptions(GraphQLDataSource, graphQLOptions)
+	if err != nil {
+		//g.logger.Error(fmt.Sprintf(errMsgFormat, GraphQLDataSource), abstractlogger.Error(err))
+		params.logger.Error(fmt.Sprintf(errMsgFormat, GraphQLDataSource), abstractlogger.Error(err))
+	}
+
+	err = engine.AddGraphqlDataSourceWithOptions(TykGraphQLDataSource, graphQLOptions)
+	if err != nil {
+		//g.logger.Error(fmt.Sprintf(errMsgFormat, GraphQLDataSource), abstractlogger.Error(err))
+		params.logger.Error(fmt.Sprintf(errMsgFormat, GraphQLDataSource), abstractlogger.Error(err))
+	}
+
+	err = engine.AddDataSource(SchemaDataSource, datasource.SchemaDataSourcePlannerFactoryFactory{})
+	if err != nil {
+		//g.logger.Error(fmt.Sprintf(errMsgFormat, SchemaDataSource), abstractlogger.Error(err))
+		params.logger.Error(fmt.Sprintf(errMsgFormat, SchemaDataSource), abstractlogger.Error(err))
+	}
+
+	return engine, err
+}
+
+type graphqlRequestProcessorV1 struct {
+	logger             abstractlogger.Logger
+	schema             *graphql.Schema
+	ctxRetrieveRequest ContextRetrieveRequestV1Func
+}
+
+func (g *graphqlRequestProcessorV1) ProcessRequest(ctx context.Context, w http.ResponseWriter, r *http.Request) (error, int) {
+	if r == nil {
+		g.logger.Error("request is nil")
+		return ProxyingRequestFailedErr, http.StatusInternalServerError
+	}
+
+	gqlRequest := g.ctxRetrieveRequest(r)
+	normalizationResult, err := gqlRequest.Normalize(g.schema)
+	if err != nil {
+		g.logger.Error("error while normalizing GraphQL request", abstractlogger.Error(err))
+		return ProxyingRequestFailedErr, http.StatusInternalServerError
+	}
+
+	if normalizationResult.Errors != nil && normalizationResult.Errors.Count() > 0 {
+		return writeGraphQLError(g.logger, w, normalizationResult.Errors)
+	}
+
+	validationResult, err := gqlRequest.ValidateForSchema(g.schema)
+	if err != nil {
+		g.logger.Error("error while validating GraphQL request", abstractlogger.Error(err))
+		return ProxyingRequestFailedErr, http.StatusInternalServerError
+	}
+
+	if validationResult.Errors != nil && validationResult.Errors.Count() > 0 {
+		return writeGraphQLError(g.logger, w, validationResult.Errors)
+	}
+
+	inputValidationResult, err := gqlRequest.ValidateInput(g.schema)
+	if err != nil {
+		g.logger.Error("error while validating variables for request", abstractlogger.Error(err))
+		return ProxyingRequestFailedErr, http.StatusInternalServerError
+	}
+	if inputValidationResult.Errors != nil && inputValidationResult.Errors.Count() > 0 {
+		return writeGraphQLError(g.logger, w, inputValidationResult.Errors)
+	}
+	return nil, http.StatusOK
+}
+
+type graphqlRequestProcessorWithOTelV1 struct {
+	logger             abstractlogger.Logger
+	schema             *graphql.Schema
+	otelExecutor       internalgraphql.TykOtelExecutorI
+	ctxRetrieveRequest ContextRetrieveRequestV1Func
+}
+
+func (g *graphqlRequestProcessorWithOTelV1) ProcessRequest(ctx context.Context, w http.ResponseWriter, r *http.Request) (error, int) {
+	if r == nil {
+		g.logger.Error("request is nil")
+		return ProxyingRequestFailedErr, http.StatusInternalServerError
+	}
+
+	g.otelExecutor.SetContext(ctx)
+	gqlRequest := g.ctxRetrieveRequest(r)
+
+	// normalization
+	err := g.otelExecutor.Normalize(gqlRequest)
+	if err != nil {
+		g.logger.Error("error while normalizing GraphqlRequest", abstractlogger.Error(err))
+		var reqErr graphql.RequestErrors
+		if errors.As(err, &reqErr) {
+			return writeGraphQLError(g.logger, w, reqErr)
+		}
+		return ProxyingRequestFailedErr, http.StatusInternalServerError
+	}
+
+	// validation
+	err = g.otelExecutor.ValidateForSchema(gqlRequest)
+	if err != nil {
+		g.logger.Error("error while validating GraphQL request", abstractlogger.Error(err))
+		var reqErr graphql.RequestErrors
+		if errors.As(err, &reqErr) {
+			return writeGraphQLError(g.logger, w, reqErr)
+		}
+		return ProxyingRequestFailedErr, http.StatusInternalServerError
+	}
+
+	// input validation
+	err = g.otelExecutor.InputValidation(gqlRequest)
+	if err != nil {
+		g.logger.Error("error while validating variables for request", abstractlogger.Error(err))
+		var reqErr graphql.RequestErrors
+		if errors.As(err, &reqErr) {
+			return writeGraphQLError(g.logger, w, reqErr)
+		}
+		return ProxyingRequestFailedErr, http.StatusInternalServerError
+	}
+	return nil, http.StatusOK
+}
+
+type complexityCheckerV1 struct {
+	logger             abstractlogger.Logger
+	schema             *graphql.Schema
+	ctxRetrieveRequest ContextRetrieveRequestV1Func
+}
+
+func (c *complexityCheckerV1) DepthLimitExceeded(r *http.Request, accessDefinition *ComplexityAccessDefinition) ComplexityFailReason {
+	if !c.depthLimitEnabled(accessDefinition) {
+		return ComplexityFailReasonNone
+	}
+
+	gqlRequest := c.ctxRetrieveRequest(r)
+	if gqlRequest == nil {
+		return ComplexityFailReasonNone
+	}
+
+	isIntrospectionQuery, err := gqlRequest.IsIntrospectionQuery()
+	if err != nil {
+		c.logger.Debug("error while checking for introspection query", abstractlogger.Error(err))
+		return ComplexityFailReasonInternalError
+	}
+
+	if isIntrospectionQuery {
+		return ComplexityFailReasonNone
+	}
+
+	complexityRes, err := gqlRequest.CalculateComplexity(graphql.DefaultComplexityCalculator, c.schema)
+	if err != nil {
+		c.logger.Error("error while calculating complexity of GraphQL request", abstractlogger.Error(err))
+		return ComplexityFailReasonInternalError
+	}
+
+	if complexityRes.Errors != nil && complexityRes.Errors.Count() > 0 {
+		c.logger.Error("error while calculating complexity of GraphQL request", abstractlogger.Error(complexityRes.Errors.ErrorByIndex(0)))
+		return ComplexityFailReasonInternalError
+	}
+
+	// do per query depth check
+	if len(accessDefinition.FieldAccessRights) == 0 {
+		if accessDefinition.Limit.MaxQueryDepth > 0 && complexityRes.Depth > accessDefinition.Limit.MaxQueryDepth {
+			c.logger.Debug("complexity of the request is higher than the allowed limit", abstractlogger.Int("maxQueryDepth", accessDefinition.Limit.MaxQueryDepth))
+			return ComplexityFailReasonDepthLimitExceeded
+		}
+		return ComplexityFailReasonNone
+	}
+
+	// do per query field depth check
+	for _, fieldComplexityRes := range complexityRes.PerRootField {
+		var (
+			fieldAccessDefinition ComplexityFieldAccessDefinition
+			hasPerFieldLimits     bool
+		)
+
+		for _, fieldAccessRight := range accessDefinition.FieldAccessRights {
+			if fieldComplexityRes.TypeName != fieldAccessRight.TypeName {
+				continue
+			}
+			if fieldComplexityRes.FieldName != fieldAccessRight.FieldName {
+				continue
+			}
+
+			fieldAccessDefinition = fieldAccessRight
+			hasPerFieldLimits = true
+			break
+		}
+
+		if hasPerFieldLimits {
+			if greaterThanIntConsideringUnlimited(fieldComplexityRes.Depth, fieldAccessDefinition.Limits.MaxQueryDepth) {
+				c.logger.Debug(
+					"depth of the root field is higher than the allowed field limit",
+					abstractlogger.Int("depth", fieldComplexityRes.Depth),
+					abstractlogger.String("rootField", fmt.Sprintf("%s.%s", fieldAccessDefinition.TypeName, fieldAccessDefinition.FieldName)),
+					abstractlogger.Int("maxQueryDepth", fieldAccessDefinition.Limits.MaxQueryDepth),
+				)
+
+				return ComplexityFailReasonDepthLimitExceeded
+			}
+			continue
+		}
+
+		// favour global limit for query field
+		// have to increase resulting field depth by 1 to get a global depth
+		queryDepth := fieldComplexityRes.Depth + 1
+		if greaterThanIntConsideringUnlimited(queryDepth, accessDefinition.Limit.MaxQueryDepth) {
+			c.logger.Debug(
+				"depth of the root field is higher than the allowed global limit",
+				abstractlogger.Int("depth", queryDepth),
+				abstractlogger.String("rootField", fmt.Sprintf("%s.%s", fieldComplexityRes.TypeName, fieldComplexityRes.FieldName)),
+				abstractlogger.Int("maxQueryDepth", accessDefinition.Limit.MaxQueryDepth),
+			)
+
+			return ComplexityFailReasonDepthLimitExceeded
+		}
+	}
+	return ComplexityFailReasonNone
+}
+
+func (c *complexityCheckerV1) depthLimitEnabled(accessDefinition *ComplexityAccessDefinition) bool {
+	if accessDefinition == nil {
+		return false
+	}
+
+	if accessDefinition.Limit.MaxQueryDepth == -1 && len(accessDefinition.FieldAccessRights) == 0 {
+		return false
+	}
+
+	return accessDefinition.Limit.MaxQueryDepth != -1 || len(accessDefinition.FieldAccessRights) != 0
+}
+
+type granularAccessCheckerV1 struct {
+	logger                    abstractlogger.Logger
+	schema                    *graphql.Schema
+	ctxRetrieveGraphQLRequest ContextRetrieveRequestV1Func
+}
+
+func (g *granularAccessCheckerV1) CheckGraphQLRequestFieldAllowance(w http.ResponseWriter, r *http.Request, accessDefinition *GranularAccessDefinition) GraphQLGranularAccessResult {
+	gqlRequest := g.ctxRetrieveGraphQLRequest(r)
+	if gqlRequest == nil {
+		return GraphQLGranularAccessResult{FailReason: GranularAccessFailReasonNone}
+	}
+
+	isIntrospection, err := gqlRequest.IsIntrospectionQueryStrict()
+	if err != nil {
+		return GraphQLGranularAccessResult{
+			FailReason:  GranularAccessFailReasonInternalError,
+			InternalErr: err,
+		}
+	}
+	if isIntrospection {
+		if accessDefinition.DisableIntrospection {
+			return GraphQLGranularAccessResult{FailReason: GranularAccessFailReasonIntrospectionDisabled}
+		}
+
+		// See TT-11260
+		//
+		// Introspection should be possible when Disable Introspection is turned off in policy settings,
+		// regardless of Allow List or Block List settings.
+		//
+		// Agreed solution: if Disable Introspection is turned off, then the Allow or Block list settings
+		// should be ignored, but only for the introspection query.
+		return GraphQLGranularAccessResult{FailReason: GranularAccessFailReasonNone}
+	}
+
+	if len(accessDefinition.AllowedTypes) != 0 {
+		fieldRestrictionList := graphql.FieldRestrictionList{
+			Kind:  graphql.AllowList,
+			Types: g.convertGranularAccessTypeToGraphQLType(accessDefinition.AllowedTypes),
+		}
+		return g.validateFieldRestrictions(gqlRequest, fieldRestrictionList, g.schema)
+	}
+
+	if len(accessDefinition.RestrictedTypes) != 0 {
+		fieldRestrictionList := graphql.FieldRestrictionList{
+			Kind:  graphql.BlockList,
+			Types: g.convertGranularAccessTypeToGraphQLType(accessDefinition.RestrictedTypes),
+		}
+		return g.validateFieldRestrictions(gqlRequest, fieldRestrictionList, g.schema)
+	}
+
+	// There are no restricted types. Every field is allowed access.
+	return GraphQLGranularAccessResult{FailReason: GranularAccessFailReasonNone}
+}
+
+func (g *granularAccessCheckerV1) validateFieldRestrictions(gqlRequest *graphql.Request, fieldRestrictionList graphql.FieldRestrictionList, schema *graphql.Schema) GraphQLGranularAccessResult {
+	result, err := gqlRequest.ValidateFieldRestrictions(schema, fieldRestrictionList, graphql.DefaultFieldsValidator{})
+	if err != nil {
+		return GraphQLGranularAccessResult{FailReason: GranularAccessFailReasonInternalError, InternalErr: err}
+	}
+
+	if !result.Valid || (result.Errors != nil && result.Errors.Count() > 0) {
+		return GraphQLGranularAccessResult{FailReason: GranularAccessFailReasonValidationError, ValidationError: result.Errors, writeErrorResponse: g.writeErrorResponse}
+	}
+	return GraphQLGranularAccessResult{FailReason: GranularAccessFailReasonNone}
+}
+
+func (g *granularAccessCheckerV1) convertGranularAccessTypeToGraphQLType(accessTypes []GranularAccessType) []graphql.Type {
+	var types []graphql.Type
+	for _, accessType := range accessTypes {
+		types = append(types, graphql.Type{
+			Name:   accessType.Name,
+			Fields: accessType.Fields,
+		})
+	}
+	return types
+}
+
+func (g *granularAccessCheckerV1) writeErrorResponse(w io.Writer, providedErr error) (n int, err error) {
+	return graphql.RequestErrorsFromError(providedErr).WriteResponse(w)
+}
+
+type reverseProxyPreHandlerV1 struct {
+	ctxRetrieveGraphQLRequest ContextRetrieveRequestV1Func
+	apiDefinition             *apidef.APIDefinition
+	httpClient                *http.Client
+	newReusableBodyReadCloser NewReusableBodyReadCloserFunc
+}
+
+func (r *reverseProxyPreHandlerV1) PreHandle(params ReverseProxyParams) (reverseProxyType ReverseProxyType, err error) {
+	r.httpClient.Transport = NewGraphQLEngineTransport(
+		DetermineGraphQLEngineTransportType(r.apiDefinition),
+		params.RoundTripper,
+		r.newReusableBodyReadCloser,
+	)
+
+	switch {
+	case params.IsCORSPreflight:
+		if params.NeedsEngine {
+			err = errors.New("options passthrough not allowed")
+			return ReverseProxyTypeNone, err
+		}
+	case params.IsWebSocketUpgrade:
+		if params.NeedsEngine {
+			return ReverseProxyTypeWebsocketUpgrade, nil
+		}
+	default:
+		gqlRequest := r.ctxRetrieveGraphQLRequest(params.OutRequest)
+		if gqlRequest == nil {
+			err = errors.New("graphql request is nil")
+			return
+		}
+		gqlRequest.SetHeader(params.OutRequest.Header)
+
+		var isIntrospection bool
+		isIntrospection, err = gqlRequest.IsIntrospectionQuery()
+		if err != nil {
+			return
+		}
+
+		if isIntrospection {
+			return ReverseProxyTypeIntrospection, nil
+		}
+		if params.NeedsEngine {
+			return ReverseProxyTypeGraphEngine, nil
+		}
+	}
+
+	return ReverseProxyTypeNone, nil
+}


### PR DESCRIPTION
## **User description**
[TT-10909]: fix issue with missing upstream headers in graphql proxy only (#6166)

## **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes an issue where the requests from the client were not sent
upstream. This was due to an edge case cause by the open telemetry
context modification

[TT-10909](https://tyktech.atlassian.net/browse/TT-10909)

This PR also fixes a situation where the requested content-encoding by
the client is ignored

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


[TT-10909]:
https://tyktech.atlassian.net/browse/TT-10909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

## **Type**
bug_fix, enhancement


___

## **Description**
- Added a new test to ensure headers are correctly passed to the
upstream when OpenTelemetry is enabled.
- Introduced a new context management strategy for GraphQL proxy-only
mode to correctly forward headers.
- Updated various components within the internal GraphQL engine to
utilize the new context structure for header forwarding.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>reverse_proxy_test.go</strong><dd><code>Add Test for
GraphQL Proxy with OpenTelemetry</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/reverse_proxy_test.go
<li>Added a new test
<code>TestGraphQL_ProxyOnlyPassHeadersWithOTel</code> to ensure
<br>headers are passed upstream when OpenTelemetry is enabled.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6166/files#diff-ce040f6555143f760fba6059744bc600b6954f0966dfb0fa2832b5eabf7a3c3f">+38/-0</a>&nbsp;
&nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>context.go</strong><dd><code>Manage GraphQL Proxy
Context for Headers Forwarding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; </dd></summary>
<hr>

internal/graphengine/context.go
<li>Introduced <code>GraphQLProxyOnlyContextValues</code> struct to
store request and <br>response details.<br> <li> Added functions
<code>SetProxyOnlyContextValue</code> and
<code>GetProxyOnlyContextValue</code> <br>for managing GraphQL proxy
context.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6166/files#diff-59c1392237cf0565e56acd0f46f7500043ec66fff078bf211ceefbb983baaf94">+31/-0</a>&nbsp;
&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
<summary><strong>engine_v2.go</strong><dd><code>Integrate New Context
Management in Engine V2</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/graphengine/engine_v2.go
<li>Modified to use <code>SetProxyOnlyContextValue</code> for setting
proxy context.<br> <li> Updated to retrieve proxy context using
<code>GetProxyOnlyContextValue</code>.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6166/files#diff-b1eaa954c9836f395e1d49090e85c739e3878747c8bd748f556fc5a53ff7b191">+2/-2</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
<summary><strong>graphql_go_tools_v1.go</strong><dd><code>Update Error
Handling with New Context Structure</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/graphengine/graphql_go_tools_v1.go
<li>Updated <code>returnErrorsFromUpstream</code> to use
<code>GraphQLProxyOnlyContextValues</code>.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6166/files#diff-e592cc8ca6ac39e7574765d7f2bbf19193f173791a1b0930d4dde7f9412dc882">+1/-1</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
<summary><strong>transport.go</strong><dd><code>Refactor Transport Logic
for GraphQL Proxy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/graphengine/transport.go
<li>Refactored to use <code>GraphQLProxyOnlyContextValues</code> for
handling <br>proxy-only requests.<br> <li> Adjusted header forwarding
logic to accommodate new context structure.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6166/files#diff-564061c9b29366529eb1f6f10fe39671d2ac738a4731ffd2c8b04dcc0a8cd610">+10/-10</a>&nbsp;
</td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools
and their descriptions

[TT-10909]: https://tyktech.atlassian.net/browse/TT-10909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TT-10909]: https://tyktech.atlassian.net/browse/TT-10909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TT-10909]: https://tyktech.atlassian.net/browse/TT-10909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

## **Type**
bug_fix, enhancement


___

## **Description**
- Introduces enhancements for GraphQL analytics recording, including a new test to verify correct behavior.
- Refactors GraphQL proxy handling to use a new context values structure, improving code readability and maintainability.
- Adds support for OpenTelemetry in GraphQL proxy handling, including a specific test to ensure headers are correctly passed.
- Implements a new version of the GraphQL engine with OpenTelemetry configuration, supporting both proxy only and multi-upstream transport types.
- Adds utility functions for common GraphQL engine operations, facilitating the creation of execution engines, request processing, and complexity checking.
- Modifies a tracing test scenario to use POST method and include a GraphQL query, ensuring accurate testing of GraphQL functionalities.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>handler_success_test.go</strong><dd><code>Add Test for GraphQL Analytics Recording</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/handler_success_test.go
<li>Adds new test <code>TestAnalyticRecord_GraphStats</code> to verify GraphQL <br>analytics recording.<br> <li> Modifies existing tests to accommodate new changes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6171/files#diff-42a565d872ff6c1f380386f4ee2f75bfa87991b52728a1a9a1772452bb0cd1bb">+131/-0</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_graphql_transport.go</strong><dd><code>Refactor GraphQL Proxy Only Handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_graphql_transport.go
<li>Refactors <code>handleProxyOnly</code> to use <code>GraphQLProxyOnlyContextValues</code>.<br> <li> Updates <code>setProxyOnlyHeaders</code> to work with the new context values <br>structure.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6171/files#diff-f75d622cc8e7e488b4c7795f381baa5177c568dbfcfbb4422bedf7b4b31c31ba">+10/-10</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>reverse_proxy_test.go</strong><dd><code>Add Test for GraphQL Proxy with OpenTelemetry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/reverse_proxy_test.go
<li>Adds new test <code>TestGraphQL_ProxyOnlyPassHeadersWithOTel</code> to ensure <br>headers pass with OpenTelemetry.<br> <li> Adjusts existing tests for new GraphQL handling.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6171/files#diff-ce040f6555143f760fba6059744bc600b6954f0966dfb0fa2832b5eabf7a3c3f">+38/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>context.go</strong><dd><code>Implement Context Management for GraphQL Engine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/graphengine/context.go
<li>Introduces new context management for GraphQL engine transport types.<br> <li> Adds utility functions for setting and getting proxy only context <br>values.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6171/files#diff-59c1392237cf0565e56acd0f46f7500043ec66fff078bf211ceefbb983baaf94">+80/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>engine_v2.go</strong><dd><code>Implement New Version of GraphQL Engine with OpenTelemetry Support</code></dd></summary>
<hr>

internal/graphengine/engine_v2.go
<li>Implements a new version of the GraphQL engine with OpenTelemetry <br>configuration.<br> <li> Adds handling for proxy only and multi-upstream transport types.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6171/files#diff-b1eaa954c9836f395e1d49090e85c739e3878747c8bd748f556fc5a53ff7b191">+391/-0</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>graphql_go_tools_v1.go</strong><dd><code>Add Utilities for GraphQL Engine Operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/graphengine/graphql_go_tools_v1.go
<li>Adds utility functions for GraphQL engine operations.<br> <li> Implements execution engine creation, request processing, and <br>complexity checking.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6171/files#diff-e592cc8ca6ac39e7574765d7f2bbf19193f173791a1b0930d4dde7f9412dc882">+528/-0</a>&nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tyk_test-graphql-tracing-invalid_404.yml</strong><dd><code>Modify Tracing Test Scenario for GraphQL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ci/tests/tracing/scenarios/tyk_test-graphql-tracing-invalid_404.yml
<li>Modifies HTTP method from GET to POST for a tracing test scenario.<br> <li> Updates request body to include a GraphQL query.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6171/files#diff-59e055d305e2edd7dc55944593332b42baa0a5b2a08d3a2c3592ec115223d459">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

