### PR TITLE
Merging to release-5-lts: [TT-11683]: fixed header forwarding (#6174)

### DIFF
--- a/ci/tests/tracing/scenarios/tyk_test-graphql-tracing-invalid_404.yml
+++ b/ci/tests/tracing/scenarios/tyk_test-graphql-tracing-invalid_404.yml
@@ -1,0 +1,24 @@
+type: Test
+spec:
+  id: mC3EJHq4g
+  name: Test Graphql Tracing Invalid
+  description: Invalid upstream URL
+  trigger:
+    type: http
+    httpRequest:
+      method: POST
+      url: tyk:8080/test-graphql-tracing-invalid/test-graphql-tracing-invalid
+      body: "{\n  \"query\": \"{\\n  country(code: \\\"NG\\\"){\\n    name\\n  }\\n}\"\n}"
+      headers:
+        - key: Content-Type
+          value: application/json
+  specs:
+    - selector: span[tracetest.span.type = "general" name = "ResolvePlan"] span[tracetest.span.type="http" name="HTTP POST" http.method="POST"]
+      name: Should return 404 for upstream
+      assertions:
+        - attr:http.status_code  =   404
+        - attr:http.url  =     "https://httpbin.com"
+    - selector: span[tracetest.span.type = "general" name = "GraphqlMiddleware Validation"] span[tracetest.span.type="general" name="GraphqlEngine"]
+      name: Make sure Graphql Engine is a child of GraphqlMiddleware Validation
+      assertions:
+        - attr:name = "GraphqlEngine"

--- a/gateway/mw_graphql_transport_test.go
+++ b/gateway/mw_graphql_transport_test.go
@@ -121,7 +121,7 @@ func TestGraphQLEngineTransport_RoundTrip(t *testing.T) {
 
 		forwardedRequest.Header.Set("X-Custom-Key", "custom-value")
 		forwardedRequest.Header.Set("X-Other-Value", "other-value")
-		ctx := NewGraphQLProxyOnlyContext(context.Background(), forwardedRequest)
+		ctx := SetProxyOnlyContextValue(context.Background(), forwardedRequest)
 
 		httpClient := http.Client{
 			Transport: NewGraphQLEngineTransport(GraphQLEngineTransportTypeProxyOnly, http.DefaultTransport),

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -28,6 +28,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/httpclient"
+
 	"github.com/buger/jsonparser"
 
 	"github.com/gorilla/websocket"
@@ -1077,7 +1079,7 @@ func (p *ReverseProxy) handleGraphQLEngineWebsocketUpgrade(roundTripper *TykRoun
 	return nil, true, nil
 }
 
-func returnErrorsFromUpstream(proxyOnlyCtx *GraphQLProxyOnlyContext, resultWriter *graphql.EngineResultWriter) error {
+func returnErrorsFromUpstream(proxyOnlyCtx *GraphQLProxyOnlyContextValues, resultWriter *graphql.EngineResultWriter) error {
 	body, ok := proxyOnlyCtx.upstreamResponse.Body.(*nopCloserBuffer)
 	if !ok {
 		// Response body already read by graphql-go-tools, and it's not re-readable. Quit silently.
@@ -1132,7 +1134,11 @@ func (p *ReverseProxy) handoverRequestToGraphQLExecutionEngine(roundTripper *Tyk
 		isProxyOnly := isGraphQLProxyOnly(p.TykAPISpec)
 		reqCtx := context.Background()
 		if isProxyOnly {
+<<<<<<< HEAD
 			reqCtx = NewGraphQLProxyOnlyContext(context.Background(), outreq)
+=======
+			reqCtx = SetProxyOnlyContextValue(reqCtx, outreq)
+>>>>>>> 0d9895c00... [TT-11683]: fixed header forwarding (#6174)
 		}
 
 		resultWriter := graphql.NewEngineResultWriter()
@@ -1154,7 +1160,7 @@ func (p *ReverseProxy) handoverRequestToGraphQLExecutionEngine(roundTripper *Tyk
 		header.Set("Content-Type", "application/json")
 
 		if isProxyOnly {
-			proxyOnlyCtx := reqCtx.(*GraphQLProxyOnlyContext)
+			proxyOnlyCtx := GetProxyOnlyContextValue(reqCtx)
 			// There is a case in the proxy-only mode where the request can be handled
 			// by the library without calling the upstream.
 			// This is a valid query for proxy-only mode: query { __typename }
@@ -1163,6 +1169,9 @@ func (p *ReverseProxy) handoverRequestToGraphQLExecutionEngine(roundTripper *Tyk
 			if proxyOnlyCtx.upstreamResponse != nil {
 				header = proxyOnlyCtx.upstreamResponse.Header
 				httpStatus = proxyOnlyCtx.upstreamResponse.StatusCode
+				// change the value of the header's content encoding to use the content encoding defined by the accept encoding
+				contentEncoding := selectContentEncodingToBeUsed(proxyOnlyCtx.forwardedRequest.Header.Get(httpclient.AcceptEncodingHeader))
+				header.Set(httpclient.ContentEncodingHeader, contentEncoding)
 				if p.TykAPISpec.GraphQL.Proxy.UseResponseExtensions.OnErrorForwarding && httpStatus >= http.StatusBadRequest {
 					err = returnErrorsFromUpstream(proxyOnlyCtx, &resultWriter)
 					if err != nil {
@@ -1177,6 +1186,34 @@ func (p *ReverseProxy) handoverRequestToGraphQLExecutionEngine(roundTripper *Tyk
 	}
 
 	return nil, false, errors.New("graphql configuration is invalid")
+}
+
+// selectContentEncodingToBeUsed selects the encoding value to be returned based on the IETF standards
+// if acceptedEncoding is a list of comma separated strings br,gzip, deflate; then it selects the first supported one
+// if it is a single value then it returns that value
+// if no supported encoding is found, it returns the last value
+func selectContentEncodingToBeUsed(acceptedEncoding string) string {
+	supportedHeaders := map[string]struct{}{
+		"gzip":    {},
+		"deflate": {},
+		"br":      {},
+	}
+
+	values := strings.Split(acceptedEncoding, ",")
+	if len(values) < 2 {
+		return values[0]
+	}
+
+	for i, e := range values {
+		enc := strings.TrimSpace(e)
+		if _, ok := supportedHeaders[enc]; ok {
+			return enc
+		}
+		if i == len(values)-1 {
+			return enc
+		}
+	}
+	return ""
 }
 
 func (p *ReverseProxy) handoverWebSocketConnectionToGraphQLExecutionEngine(roundTripper *TykRoundTripper, conn net.Conn, req *http.Request) {

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -984,6 +984,44 @@ func TestGraphQL_ProxyOnlyHeaders(t *testing.T) {
 	})
 }
 
+func TestGraphQL_ProxyOnlyPassHeadersWithOTel(t *testing.T) {
+	g := StartTest(func(globalConf *config.Config) {
+		globalConf.OpenTelemetry.Enabled = true
+	})
+	defer g.Close()
+
+	spec := BuildAPI(func(spec *APISpec) {
+		spec.Name = "tyk-api"
+		spec.APIID = "tyk-api"
+		spec.GraphQL.Enabled = true
+		spec.GraphQL.ExecutionMode = apidef.GraphQLExecutionModeProxyOnly
+		spec.GraphQL.Schema = gqlCountriesSchema
+		spec.GraphQL.Version = apidef.GraphQLConfigVersion2
+		spec.Proxy.TargetURL = TestHttpAny + "/dynamic"
+		spec.Proxy.ListenPath = "/"
+	})[0]
+
+	g.Gw.LoadAPI(spec)
+	g.AddDynamicHandler("/dynamic", func(writer http.ResponseWriter, r *http.Request) {
+		if gotten := r.Header.Get("custom-client-header"); gotten != "custom-value" {
+			t.Errorf("expected upstream to recieve header `custom-client-header` with value of `custom-value`, instead got %s", gotten)
+		}
+	})
+
+	_, err := g.Run(t, test.TestCase{
+		Path: "/",
+		Headers: map[string]string{
+			"custom-client-header": "custom-value",
+		},
+		Method: http.MethodPost,
+		Data: graphql.Request{
+			Query: gqlContinentQuery,
+		},
+	})
+
+	assert.NoError(t, err)
+}
+
 func TestGraphQL_InternalDataSource(t *testing.T) {
 	g := StartTest(nil)
 	defer g.Close()


### PR DESCRIPTION
[TT-11683]: fixed header forwarding (#6174)

## **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description
This ticket adds the header forwarding logic fix from [this
PR](https://github.com/TykTechnologies/tyk/pull/6166) to 5.2
<!-- Describe your changes in detail -->

[TT-11683](https://tyktech.atlassian.net/browse/TT-11683)
## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


[TT-11683]:
https://tyktech.atlassian.net/browse/TT-11683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

## **Type**
bug_fix, enhancement


___

## **Description**
- Enhanced GraphQL proxy handling with the introduction of
`GraphQLProxyOnlyContextValues` for better context management.
- Added a new function `selectContentEncodingToBeUsed` to determine the
appropriate content encoding based on the `Accept-Encoding` header.
- Improved header forwarding in GraphQL proxy-only mode, including a new
test case to validate this behavior.
- Updated a tracing test scenario for GraphQL to use the POST method.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>reverse_proxy.go</strong><dd><code>Enhancements and
Fixes in GraphQL Proxy Handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/reverse_proxy.go
<li>Imported <code>httpclient</code> from <code>graphql-go-tools</code>
for handling HTTP client <br>operations.<br> <li> Modified
<code>returnErrorsFromUpstream</code> to use
<code>GraphQLProxyOnlyContextValues</code> <br>instead of
<code>GraphQLProxyOnlyContext</code>.<br> <li> Added
<code>selectContentEncodingToBeUsed</code> function to select the
appropriate <br>content encoding based on the
<code>Accept-Encoding</code> header.<br> <li> Updated various functions
to utilize the new <br><code>GraphQLProxyOnlyContextValues</code>
structure for better header management.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6174/files#diff-e6e07722257f7e41691e471185ad6d84fd56dc9e5459526ea32e9a5e8fa1a01b">+35/-3</a>&nbsp;
&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
<summary><strong>mw_graphql_transport.go</strong><dd><code>Improved
Context Management in GraphQL Transport Middleware</code></dd></summary>
<hr>

gateway/mw_graphql_transport.go
<li>Introduced <code>GraphQLProxyOnlyContextValues</code> struct for
better management <br>of proxy-only context values.<br> <li> Added
functions <code>SetProxyOnlyContextValue</code> and
<code>GetProxyOnlyContextValue</code> <br>for setting and retrieving
proxy-only context values.<br> <li> Updated <code>handleProxyOnly</code>
and <code>setProxyOnlyHeaders</code> to use the new context <br>values
structure.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6174/files#diff-f75d622cc8e7e488b4c7795f381baa5177c568dbfcfbb4422bedf7b4b31c31ba">+36/-5</a>&nbsp;
&nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>reverse_proxy_test.go</strong><dd><code>New Test for
Header Forwarding in GraphQL Proxy-Only Mode</code></dd></summary>
<hr>

gateway/reverse_proxy_test.go
<li>Added a new test
<code>TestGraphQL_ProxyOnlyPassHeadersWithOTel</code> to ensure
<br>headers are correctly passed in proxy-only mode with OpenTelemetry
<br>enabled.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6174/files#diff-ce040f6555143f760fba6059744bc600b6954f0966dfb0fa2832b5eabf7a3c3f">+38/-0</a>&nbsp;
&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>

<summary><strong>tyk_test-graphql-tracing-invalid_404.yml</strong><dd><code>Update
Tracing Test Scenario for GraphQL</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ci/tests/tracing/scenarios/tyk_test-graphql-tracing-invalid_404.yml
<li>Changed the HTTP method from GET to POST in the tracing test
scenario <br>for GraphQL.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6174/files#diff-59e055d305e2edd7dc55944593332b42baa0a5b2a08d3a2c3592ec115223d459">+1/-1</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools
and their descriptions