### PR TITLE
Merging to release-5-lts: [TT-6011] Fix non-functional coprocess apis, add tests (#4055)

### DIFF
--- a/gateway/coprocess_api.go
+++ b/gateway/coprocess_api.go
@@ -17,12 +17,12 @@ import (
 const CoProcessDefaultKeyPrefix = "coprocess-data:"
 
 func getStorageForPython(ctx context.Context) storage.RedisCluster {
-	rc := storage.NewConnectionHandler(ctx)
+	rc := storage.NewRedisController(ctx)
 
-	go rc.Connect(ctx, nil, &config.Config{})
+	go rc.ConnectToRedis(ctx, nil, &config.Config{})
 	rc.WaitConnect(ctx)
 
-	return storage.RedisCluster{KeyPrefix: CoProcessDefaultKeyPrefix, ConnectionHandler: rc}
+	return storage.RedisCluster{KeyPrefix: CoProcessDefaultKeyPrefix, RedisController: rc}
 }
 
 // TykStoreData is a CoProcess API function for storing data.
@@ -32,10 +32,6 @@ func TykStoreData(CKey, CValue *C.char, CTTL C.int) {
 	key := C.GoString(CKey)
 	value := C.GoString(CValue)
 	ttl := int64(CTTL)
-<<<<<<< HEAD
-	rc := storage.NewRedisController(context.TODO())
-	store := storage.RedisCluster{KeyPrefix: CoProcessDefaultKeyPrefix, RedisController: rc}
-=======
 
 	// Timeout storing data after 1 second
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -43,7 +39,6 @@ func TykStoreData(CKey, CValue *C.char, CTTL C.int) {
 
 	store := getStorageForPython(ctx)
 
->>>>>>> 9cb830488... [TT-6011] Fix non-functional coprocess apis, add tests (#4055)
 	err := store.SetKey(key, value, ttl)
 	if err != nil {
 		log.WithError(err).Error("could not set key")

--- a/gateway/coprocess_api.go
+++ b/gateway/coprocess_api.go
@@ -4,15 +4,26 @@ import "C"
 
 import (
 	"context"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/storage"
 )
 
 // CoProcessDefaultKeyPrefix is used as a key prefix for this CP.
 const CoProcessDefaultKeyPrefix = "coprocess-data:"
+
+func getStorageForPython(ctx context.Context) storage.RedisCluster {
+	rc := storage.NewConnectionHandler(ctx)
+
+	go rc.Connect(ctx, nil, &config.Config{})
+	rc.WaitConnect(ctx)
+
+	return storage.RedisCluster{KeyPrefix: CoProcessDefaultKeyPrefix, ConnectionHandler: rc}
+}
 
 // TykStoreData is a CoProcess API function for storing data.
 //
@@ -21,8 +32,18 @@ func TykStoreData(CKey, CValue *C.char, CTTL C.int) {
 	key := C.GoString(CKey)
 	value := C.GoString(CValue)
 	ttl := int64(CTTL)
+<<<<<<< HEAD
 	rc := storage.NewRedisController(context.TODO())
 	store := storage.RedisCluster{KeyPrefix: CoProcessDefaultKeyPrefix, RedisController: rc}
+=======
+
+	// Timeout storing data after 1 second
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	store := getStorageForPython(ctx)
+
+>>>>>>> 9cb830488... [TT-6011] Fix non-functional coprocess apis, add tests (#4055)
 	err := store.SetKey(key, value, ttl)
 	if err != nil {
 		log.WithError(err).Error("could not set key")
@@ -35,9 +56,17 @@ func TykStoreData(CKey, CValue *C.char, CTTL C.int) {
 func TykGetData(CKey *C.char) *C.char {
 	key := C.GoString(CKey)
 
-	store := storage.RedisCluster{KeyPrefix: CoProcessDefaultKeyPrefix}
-	// TODO: return error
-	val, _ := store.GetKey(key)
+	// Timeout storing data after 1 second
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	store := getStorageForPython(ctx)
+
+	val, err := store.GetKey(key)
+	if err != nil {
+		log.WithError(err).Error("could not get key")
+	}
+
 	return C.CString(val)
 }
 
@@ -80,4 +109,16 @@ func CoProcessLog(CMessage, CLogLevel *C.char) {
 			"prefix": "python",
 		}).Info(message)
 	}
+}
+
+func cgoCString(in string) *C.char {
+	return C.CString(in)
+}
+
+func cgoGoString(in *C.char) string {
+	return C.GoString(in)
+}
+
+func cgoCint(in int) C.int {
+	return C.int(in)
 }

--- a/gateway/coprocess_api_test.go
+++ b/gateway/coprocess_api_test.go
@@ -1,0 +1,53 @@
+package gateway
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk/apidef"
+)
+
+func TestCoprocessAPIs(t *testing.T) {
+	k := "keyName"
+	v := "valueOf"
+
+	key := cgoCString(k)
+	val := cgoCString(v)
+	ttl := cgoCint(60)
+
+	TykStoreData(key, val, ttl)
+
+	result := TykGetData(key)
+
+	assert.True(t, cgoGoString(result) == v)
+}
+
+func TestCoprocessLog(t *testing.T) {
+	levels := []string{"debug", "error", "warning", "info"}
+	for idx, level := range levels {
+		CoProcessLog(cgoCString(fmt.Sprintf("test logging message %d", idx)), cgoCString(level))
+	}
+	assert.True(t, true)
+}
+
+func TestCoprocessSystemEvent(t *testing.T) {
+	name := cgoCString("test-event")
+	payload := cgoCString("test-payload")
+
+	invoked := false
+	GatewayFireSystemEvent = func(name apidef.TykEvent, meta interface{}) {
+		invoked = true
+
+		metaVal, ok := meta.(EventMetaDefault)
+
+		assert.True(t, ok)
+		assert.Equal(t, "test-event", string(name))
+		assert.Equal(t, "test-payload", metaVal.Message)
+	}
+
+	TykTriggerEvent(name, payload)
+
+	assert.True(t, invoked, "should invoke global fire event hook")
+}

--- a/gateway/coprocess_bundle_test.go
+++ b/gateway/coprocess_bundle_test.go
@@ -225,7 +225,6 @@ pre.NewProcessRequest(function(request, session) {
 }
 
 func TestResponseOverride(t *testing.T) {
-	test.Flaky(t)
 	pythonVersion := test.GetPythonVersion()
 
 	ts := StartTest(nil, TestConfig{


### PR DESCRIPTION
[TT-6011] Fix non-functional coprocess apis, add tests (#4055)

## Description

This PR adds test for the coprocess StoreData and GetData apis. It fixes
an issue with the redis connection and updates use to latest storage
package changes.

https://tyktech.atlassian.net/browse/TT-6011

## Motivation and Context

Coprocess APIs don't connect to redis, don't have timeouts. I fixed
opening the Redis connection, added unit tests to verify functionality
and add code coverage.

## How This Has Been Tested

```
$ TYK_LOGLEVEL=debug go test -run=TestCoprocess -v .
[May 17 13:54:52] DEBUG Using serializer protobuf for analytics 

=== RUN   TestCoprocessAPIs
time="May 17 13:54:52" level=debug msg="Creating new Redis connection pool"
time="May 17 13:54:52" level=info msg="--> [REDIS] Creating single-node client"
time="May 17 13:54:52" level=debug msg="Creating new Redis connection pool"
time="May 17 13:54:52" level=info msg="--> [REDIS] Creating single-node client"
time="May 17 13:54:52" level=debug msg="Creating new Redis connection pool"
time="May 17 13:54:52" level=info msg="--> [REDIS] Creating single-node client"
time="May 17 13:54:52" level=debug msg="Creating new Redis connection pool"
time="May 17 13:54:52" level=info msg="--> [REDIS] Creating single-node client"
time="May 17 13:54:52" level=debug msg="Creating new Redis connection pool"
time="May 17 13:54:52" level=info msg="--> [REDIS] Creating single-node client"
time="May 17 13:54:52" level=debug msg="Creating new Redis connection pool"
time="May 17 13:54:52" level=info msg="--> [REDIS] Creating single-node client"
--- PASS: TestCoprocessAPIs (0.02s)
=== RUN   TestCoprocessLog
time="May 17 13:54:52" level=debug msg="test logging message 0" prefix=python
time="May 17 13:54:52" level=error msg="test logging message 1" prefix=python
time="May 17 13:54:52" level=warning msg="test logging message 2" prefix=python
time="May 17 13:54:52" level=info msg="test logging message 3" prefix=python
--- PASS: TestCoprocessLog (0.00s)
=== RUN   TestCoprocessSystemEvent
--- PASS: TestCoprocessSystemEvent (0.00s)
PASS
ok  	github.com/TykTechnologies/tyk/gateway	0.048s
```

Before? No tests.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [x] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're
here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix
branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [ ] Make sure you are making a pull request against the **`master`
branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
- [ ] If you've changed APIs, describe what needs to be updated in the
documentation.
- [ ] If new config option added, ensure that it can be set via ENV
variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod
tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for
this update.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`

## Final note for review

These functions need to access the gateway config (e.g. load it).
Currently, I'm only passing `&config.Config{}` to use defaults, which
works for tests but won't work on a custom-configured gateway instance.
Need to get the actual config. How? ;)

---------

Co-authored-by: Tit Petric <tit@tyk.io>

[TT-6011]: https://tyktech.atlassian.net/browse/TT-6011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ