### PR TITLE
[TT-11746] Add linter for regression test names

### DIFF
--- a/docker/services/Taskfile.yml
+++ b/docker/services/Taskfile.yml
@@ -1,0 +1,13 @@
+---
+version: "3"
+
+tasks:
+  up:
+    desc: "Bring up services"
+    cmds:
+      - docker compose up -d --remove-orphans
+
+  down:
+    desc: "Tear down services"
+    cmds:
+      - docker compose down --remove-orphans

--- a/docker/services/docker-compose.yml
+++ b/docker/services/docker-compose.yml
@@ -1,0 +1,15 @@
+---
+# This file is intended only to start the docker compose services that
+# are required for testing. It will not start any tyk services. It's
+# intended to be used for go tests.
+#
+# To start the full docker compose stack take a look at the
+# docker-compose.yml file in the root directory.
+
+include:
+  - ./redis.yml
+
+networks:
+  proxy:
+    name: proxy
+    driver: bridge

--- a/docker/services/redis.yml
+++ b/docker/services/redis.yml
@@ -1,0 +1,9 @@
+---
+services:
+  redis:
+    image: redis:6-alpine
+    networks:
+      - proxy
+    ports:
+      - 6379:6379
+    command: redis-server --appendonly yes

--- a/tests/regression/Taskfile.yml
+++ b/tests/regression/Taskfile.yml
@@ -24,6 +24,7 @@ tasks:
     deps: [ test:build ]
     cmds:
       - defer: { task: test:clean }
+      - task: test:lint
       - task: test:run
 
   test:build:
@@ -37,6 +38,16 @@ tasks:
     cmds:
       - defer: { task: services:down }
       - ./regression.test -test.v
+
+  test:lint:
+    desc: "Lint tests"
+    internal: true
+    quiet: true
+    vars:
+      funcs:
+        sh: ./regression.test -test.list=Test | egrep -v 'Test_Issue[0-9]+' || true
+    cmds:
+      - cmd: '{{if ne .funcs ""}}echo -e "Naming violations:\n{{.funcs}}" && exit 1 {{end}}'
 
   test:clean:
     desc: "Clean up temporary files"

--- a/tests/regression/Taskfile.yml
+++ b/tests/regression/Taskfile.yml
@@ -53,4 +53,4 @@ tasks:
     desc: "Clean up temporary files"
     aliases: [ clean ]
     cmds:
-      - rm regression.test -f
+      - rm -f regression.test


### PR DESCRIPTION
## **User description**
Tests only change, adds linting for regression test functions names. Imports docker/services for test env setup.

Intended for: master, release-5.3, release-5-lts.

https://tyktech.atlassian.net/browse/TT-11746


___

## **Type**
tests, enhancement


___

## **Description**
- Introduced a new linting task (`test:lint`) to enforce naming conventions for regression tests.
- The linting task checks if test names follow the specified regex pattern, aiming to prevent naming violations.
- This linting step is integrated into the test workflow, ensuring that tests with improper names are flagged before execution.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Taskfile.yml</strong><dd><code>Add Linting Task for Regression Test Names</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/regression/Taskfile.yml
<li>Added a new task <code>test:lint</code> for linting test names.<br> <li> The <code>test:lint</code> task checks for naming violations against a regex <br>pattern and exits with an error if violations are found.<br> <li> Integrated <code>test:lint</code> task into the test workflow before running tests.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6191/files#diff-32da89368e3551ec281e80af08b54c3410bcea3257e75af6bac113a51d822a55">+11/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

