### PR TITLE
Merging to release-5.3: [TT-11585] Process DeleteAPICache event (#6190)

### DIFF
--- a/gateway/api.go
+++ b/gateway/api.go
@@ -2845,11 +2845,7 @@ func userRatesCheck(w http.ResponseWriter, r *http.Request) {
 func (gw *Gateway) invalidateCacheHandler(w http.ResponseWriter, r *http.Request) {
 	apiID := mux.Vars(r)["apiID"]
 
-	keyPrefix := "cache-" + apiID
-	matchPattern := keyPrefix + "*"
-	store := storage.RedisCluster{KeyPrefix: keyPrefix, IsCache: true, ConnectionHandler: gw.StorageConnectionHandler}
-
-	if ok := store.DeleteScanMatch(matchPattern); !ok {
+	if ok := gw.invalidateAPICache(apiID); !ok {
 		err := errors.New("scan/delete failed")
 		var orgid string
 		if spec := gw.getApiSpec(apiID); spec != nil {

--- a/gateway/delete_api_cache.go
+++ b/gateway/delete_api_cache.go
@@ -1,0 +1,12 @@
+package gateway
+
+import (
+	"fmt"
+
+	"github.com/TykTechnologies/tyk/storage"
+)
+
+func (gw *Gateway) invalidateAPICache(apiID string) bool {
+	store := storage.RedisCluster{IsCache: true, ConnectionHandler: gw.StorageConnectionHandler}
+	return store.DeleteScanMatch(fmt.Sprintf("cache-%s*", apiID))
+}

--- a/gateway/redis_signals.go
+++ b/gateway/redis_signals.go
@@ -20,6 +20,10 @@ import (
 
 type NotificationCommand string
 
+func (n NotificationCommand) String() string {
+	return string(n)
+}
+
 const (
 	RedisPubSubChannel = "tyk.cluster.notifications"
 
@@ -35,6 +39,8 @@ const (
 	NoticeGatewayDRLNotification NotificationCommand = "NoticeGatewayDRLNotification"
 	KeySpaceUpdateNotification   NotificationCommand = "KeySpaceUpdateNotification"
 	OAuthPurgeLapsedTokens       NotificationCommand = "OAuthPurgeLapsedTokens"
+	// NoticeDeleteAPICache is the command with which event is emitted from dashboard to invalidate cache for an API.
+	NoticeDeleteAPICache NotificationCommand = "DeleteAPICache"
 )
 
 // Notification is a type that encodes a message published to a pub sub channel (shared between implementations)
@@ -146,6 +152,10 @@ func (gw *Gateway) handleRedisEvent(v interface{}, handled func(NotificationComm
 	case OAuthPurgeLapsedTokens:
 		if err := gw.purgeLapsedOAuthTokens(); err != nil {
 			log.WithError(err).Errorf("error while purging tokens for event %s", OAuthPurgeLapsedTokens)
+		}
+	case NoticeDeleteAPICache:
+		if ok := gw.invalidateAPICache(notif.Payload); !ok {
+			log.WithError(err).Errorf("cache invalidation failed for: %s", notif.Payload)
 		}
 	default:
 		pubSubLog.Warnf("Unknown notification command: %q", notif.Command)

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -990,6 +990,7 @@ func (r *RPCStorageHandler) ProcessKeySpaceChanges(keys []string, orgId string) 
 	CertificatesToRemove := map[string]string{}
 	CertificatesToAdd := map[string]string{}
 	OauthClients := map[string]string{}
+	apiIDsToDeleteCache := make([]string, 0)
 
 	for _, key := range keys {
 		splitKeys := strings.Split(key, ":")
@@ -1013,6 +1014,8 @@ func (r *RPCStorageHandler) ProcessKeySpaceChanges(keys []string, orgId string) 
 			case OauthClientAdded, OauthClientUpdated, OauthClientRemoved:
 				OauthClients[splitKeys[0]] = action
 				notRegularKeys[key] = true
+			case NoticeDeleteAPICache.String():
+				apiIDsToDeleteCache = append(apiIDsToDeleteCache, splitKeys[0])
 			default:
 				log.Debug("ignoring processing of action:", action)
 			}
@@ -1108,6 +1111,14 @@ func (r *RPCStorageHandler) ProcessKeySpaceChanges(keys []string, orgId string) 
 		}
 	}
 
+	for _, apiID := range apiIDsToDeleteCache {
+		if r.Gw.invalidateAPICache(apiID) {
+			log.WithField("apiID", apiID).Info("cache invalidated")
+			continue
+		}
+
+		log.WithField("apiID", apiID).Error("cache invalidation failed")
+	}
 	// Notify rest of gateways in cluster to flush cache
 	n := Notification{
 		Command: KeySpaceUpdateNotification,

--- a/tests/regression/issue_11585_test.go
+++ b/tests/regression/issue_11585_test.go
@@ -1,0 +1,100 @@
+package regression
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/gateway"
+	"github.com/TykTechnologies/tyk/storage"
+	"github.com/TykTechnologies/tyk/test"
+)
+
+func Test_Issue11585_DeleteAPICacheSignal(t *testing.T) {
+	t.Run("redis event", func(t *testing.T) {
+		ts := gateway.StartTest(nil)
+		defer ts.Close()
+
+		api := ts.Gw.BuildAndLoadAPI(func(spec *gateway.APISpec) {
+			spec.UseKeylessAccess = true
+			spec.Proxy.ListenPath = "/cache-api/"
+			spec.CacheOptions = apidef.CacheOptions{
+				EnableCache:          true,
+				CacheTimeout:         120,
+				CacheAllSafeRequests: true,
+			}
+		})[0]
+
+		// hit an api to create cache
+		_, _ = ts.Run(t, test.TestCase{
+			Path: "/cache-api/",
+			Code: http.StatusOK,
+		})
+
+		// emit event
+		n := gateway.Notification{
+			Command: gateway.NoticeDeleteAPICache,
+			Payload: api.APIID,
+			Gw:      ts.Gw,
+		}
+		ts.Gw.MainNotifier.Notify(n)
+
+		time.Sleep(time.Millisecond * 50)
+		scanCacheKeys(t, ts.Gw.StorageConnectionHandler, api.APIID, true)
+	})
+
+	t.Run("rpc", func(t *testing.T) {
+		ts := gateway.StartTest(nil)
+		defer ts.Close()
+
+		rpcListener := gateway.RPCStorageHandler{
+			KeyPrefix:        "rpc.listener.",
+			SuppressRegister: true,
+			Gw:               ts.Gw,
+		}
+
+		api := ts.Gw.BuildAndLoadAPI(func(spec *gateway.APISpec) {
+			spec.UseKeylessAccess = true
+			spec.Proxy.ListenPath = "/cache-api/"
+			spec.CacheOptions = apidef.CacheOptions{
+				EnableCache:          true,
+				CacheTimeout:         120,
+				CacheAllSafeRequests: true,
+			}
+		})[0]
+
+		// hit an api to create cache
+		_, _ = ts.Run(t, test.TestCase{
+			Path: "/cache-api/",
+			Code: http.StatusOK,
+		})
+
+		buildStringEvent := func(apiID string) string {
+			return fmt.Sprintf("%s:%s", apiID, gateway.NoticeDeleteAPICache.String())
+		}
+
+		t.Run("different api id in event", func(t *testing.T) {
+			scanCacheKeys(t, ts.Gw.StorageConnectionHandler, api.APIID, false)
+			rpcListener.ProcessKeySpaceChanges([]string{buildStringEvent("non-existing-api-id")}, api.OrgID)
+			scanCacheKeys(t, ts.Gw.StorageConnectionHandler, api.APIID, false)
+		})
+
+		t.Run("same api id in event", func(t *testing.T) {
+			scanCacheKeys(t, ts.Gw.StorageConnectionHandler, api.APIID, false)
+			rpcListener.ProcessKeySpaceChanges([]string{buildStringEvent(api.APIID)}, api.OrgID)
+			scanCacheKeys(t, ts.Gw.StorageConnectionHandler, api.APIID, true)
+		})
+	})
+}
+
+func scanCacheKeys(t *testing.T, storageConnHandler *storage.ConnectionHandler, apiID string, expectEmtpy bool) {
+	t.Helper()
+	store := storage.RedisCluster{IsCache: true, ConnectionHandler: storageConnHandler}
+	cacheKeys, err := store.ScanKeys(fmt.Sprintf("cache-%s*", apiID))
+	assert.NoError(t, err)
+	assert.Equal(t, expectEmtpy, len(cacheKeys) == 0)
+}


### PR DESCRIPTION
## **User description**
[TT-11585] Process DeleteAPICache event (#6190)

## **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description
This PR adds
* A redis event handler to react on event `DeleteAPICache`, this is used
when gateway is used in pro mode.
* A processor in edge gateways to invalidate cache via `DeleteAPICache`
action via mdcb RPC.

## Related Issue
https://tyktech.atlassian.net/browse/TT-11585

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Introduced a new method `invalidateAPICache` to centralize the logic
for API cache invalidation.
- Added handling for a new signal `NoticeDeleteAPICache` to trigger the
cache invalidation process.
- Created tests to ensure the functionality of the new cache
invalidation method.
- Updated key space change processing to include the `DeleteAPICache`
action.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>api.go</strong><dd><code>Refactor API Cache
Invalidation Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api.go
<li>Refactored cache invalidation logic into a separate method
<br><code>invalidateAPICache</code>.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6190/files#diff-644cda3aeb4ac7f325359e85fcddb810f100dd5e6fa480b0d9f9363a743c4e05">+1/-5</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
<summary><strong>delete_api_cache.go</strong><dd><code>Introduce Method
for API Cache Invalidation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

gateway/delete_api_cache.go
<li>Introduced a new method <code>invalidateAPICache</code> to
encapsulate the cache <br>invalidation logic.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6190/files#diff-8606dab58155ef5aab8c6f3364c0c6cdab44cad70addd3cc427bbeb99d412de7">+10/-0</a>&nbsp;
&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
<summary><strong>redis_signals.go</strong><dd><code>Handle Delete API
Cache Signal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

gateway/redis_signals.go
<li>Added handling for <code>NoticeDeleteAPICache</code> signal to
trigger cache <br>invalidation.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6190/files#diff-18cb136722c238e19b02741a85510dfd464343f85365482f0873aa60a37718af">+5/-0</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
<summary><strong>rpc_storage_handler.go</strong><dd><code>Process
DeleteAPICache Action in Key Space Changes</code>&nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/rpc_storage_handler.go
<li>Added <code>DeleteAPICache</code> to the list of actions to process
for key space <br>changes.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6190/files#diff-8875f75b602664c44b62b67a4da41d748124ad270573a44db4ec977ee5d68021">+4/-0</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>delete_api_cache_test.go</strong><dd><code>Add Tests
for API Cache Invalidation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/delete_api_cache_test.go
- Added tests for the new `invalidateAPICache` method.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6190/files#diff-bf04614dddae2c523c9030b8571e35816c01d916f0023b3b66f2e45f84c528bf">+34/-0</a>&nbsp;
&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools
and their descriptions

[TT-11585]: https://tyktech.atlassian.net/browse/TT-11585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Introduced a new function `invalidateAPICache` to centralize the logic for API cache invalidation.
- Added handling for a new Redis notification command `NoticeDeleteAPICache` to support cache invalidation from dashboard events.
- Enhanced RPC storage handler to process `NoticeDeleteAPICache` events for cache invalidation.
- Added regression tests to ensure the correct processing of DeleteAPICache signals.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api.go</strong><dd><code>Refactor cache invalidation to use new function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api.go
<li>Refactored cache invalidation logic into a separate function <br><code>invalidateAPICache</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6194/files#diff-644cda3aeb4ac7f325359e85fcddb810f100dd5e6fa480b0d9f9363a743c4e05">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>delete_api_cache.go</strong><dd><code>Introduce function for API cache invalidation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/delete_api_cache.go
<li>Introduced <code>invalidateAPICache</code> function to handle API cache <br>invalidation logic.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6194/files#diff-8606dab58155ef5aab8c6f3364c0c6cdab44cad70addd3cc427bbeb99d412de7">+12/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>redis_signals.go</strong><dd><code>Support for DeleteAPICache event in Redis signals</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/redis_signals.go
<li>Added <code>NoticeDeleteAPICache</code> notification command for cache <br>invalidation.<br> <li> Implemented handling for <code>NoticeDeleteAPICache</code> to invalidate cache.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6194/files#diff-18cb136722c238e19b02741a85510dfd464343f85365482f0873aa60a37718af">+10/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_storage_handler.go</strong><dd><code>RPC storage handler support for DeleteAPICache event</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/rpc_storage_handler.go
<li>Added handling for <code>NoticeDeleteAPICache</code> event in RPC storage handler.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6194/files#diff-8875f75b602664c44b62b67a4da41d748124ad270573a44db4ec977ee5d68021">+11/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>issue_11585_test.go</strong><dd><code>Regression tests for DeleteAPICache signal processing</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/regression/issue_11585_test.go
- Added regression tests for DeleteAPICache signal processing.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6194/files#diff-e99a72da54bd070d11803d8a35638c89665a2efe0af67c2fe5f28de69c863fe7">+100/-0</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

