### PR TITLE
[TT-11755] fix lint errors (staticcheck.bug.err)

### DIFF
--- a/apidef/notifications.go
+++ b/apidef/notifications.go
@@ -3,7 +3,7 @@ package apidef
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"time"
@@ -79,7 +79,7 @@ func (n NotificationsManager) SendRequest(wait bool, count int, notification int
 		return
 	}
 	defer resp.Body.Close()
-	_, err = ioutil.ReadAll(resp.Body)
+	_, err = io.ReadAll(resp.Body)
 	if err != nil {
 		log.Error("Request failed, trying again in 10s. Error was: ", err)
 		count++

--- a/apidef/oas/root_test.go
+++ b/apidef/oas/root_test.go
@@ -231,7 +231,6 @@ func getNonEmptyFields(data interface{}, prefix string) (fields []string) {
 			for j := 0; j < field.Len(); j++ {
 				elemFullName := fullName + fmt.Sprintf("[%d]", j)
 				fields = append(fields, getNonEmptyFields(field.Index(j).Interface(), elemFullName)...)
-				break
 			}
 
 		case reflect.Map:

--- a/certs/manager.go
+++ b/certs/manager.go
@@ -12,7 +12,7 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"errors"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -415,7 +415,7 @@ func (c *certificateManager) List(certIDs []string, mode CertificateType) (out [
 		// fallback to file
 		if err != nil {
 			// Try read from file
-			rawCert, err = ioutil.ReadFile(id)
+			rawCert, err = os.ReadFile(id)
 			if err != nil {
 				c.logger.Warn("Can't retrieve certificate:", id, err)
 				out = append(out, nil)
@@ -464,7 +464,7 @@ func (c *certificateManager) ListPublicKeys(keyIDs []string) (out []string) {
 			}
 			rawKey = []byte(val)
 		} else {
-			rawKey, err = ioutil.ReadFile(id)
+			rawKey, err = os.ReadFile(id)
 			if err != nil {
 				c.logger.Error("Error while reading public key from file:", id, err)
 				out = append(out, "")
@@ -501,7 +501,7 @@ func (c *certificateManager) ListRawPublicKey(keyID string) (out interface{}) {
 		}
 		rawKey = []byte(val)
 	} else {
-		rawKey, err = ioutil.ReadFile(keyID)
+		rawKey, err = os.ReadFile(keyID)
 		if err != nil {
 			c.logger.Error("Error while reading public key from file:", keyID, err)
 			return nil

--- a/certs/manager_test.go
+++ b/certs/manager_test.go
@@ -8,7 +8,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -117,7 +116,7 @@ func TestAddCertificate(t *testing.T) {
 
 func TestCertificateStorage(t *testing.T) {
 	m := newManager()
-	dir, _ := ioutil.TempDir("", "certs")
+	dir, _ := os.MkdirTemp("", "certs")
 
 	defer func() {
 		os.RemoveAll(dir)
@@ -125,7 +124,7 @@ func TestCertificateStorage(t *testing.T) {
 
 	certPem, _ := genCertificateFromCommonName("file", false)
 	certPath := filepath.Join(dir, "cert.pem")
-	ioutil.WriteFile(certPath, certPem, 0666)
+	os.WriteFile(certPath, certPem, 0666)
 
 	privateCertPEM, keyCertPEM := genCertificateFromCommonName("private", false)
 	privateCertID, _ := m.Add(append(privateCertPEM, keyCertPEM...), "")

--- a/ci/tests/plugin-compiler/testdata/basic-plugin/test_goplugin.go
+++ b/ci/tests/plugin-compiler/testdata/basic-plugin/test_goplugin.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -103,7 +104,7 @@ func MyPluginResponse(rw http.ResponseWriter, res *http.Response, req *http.Requ
 
 	buf.Write([]byte(`{"message":"response injected message"}`))
 
-	res.Body = ioutil.NopCloser(&buf)
+	res.Body = io.NopCloser(&buf)
 
 	apiDefinition := ctx.GetDefinition(req)
 	if apiDefinition == nil {

--- a/ci/tests/plugin-compiler/testdata/complex-plugin/plugin/plugin.go
+++ b/ci/tests/plugin-compiler/testdata/complex-plugin/plugin/plugin.go
@@ -98,7 +98,7 @@ func MyPluginResponse(rw http.ResponseWriter, res *http.Response, req *http.Requ
 
 	buf.Write([]byte(`{"message":"response injected message"}`))
 
-	res.Body = ioutil.NopCloser(&buf)
+	res.Body = io.NopCloser(&buf)
 
 	apiDefinition := ctx.GetDefinition(req)
 	if apiDefinition == nil {

--- a/cli/bundler/bundler.go
+++ b/cli/bundler/bundler.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/TykTechnologies/goverify"
@@ -74,7 +73,7 @@ func (b *Bundler) Build(ctx *kingpin.ParseContext) error {
 	bundleBuf := new(bytes.Buffer)
 	for _, file := range manifest.FileList {
 		var data []byte
-		data, err = ioutil.ReadFile(file)
+		data, err = os.ReadFile(file)
 		if err != nil {
 			break
 		}
@@ -121,7 +120,7 @@ func (b *Bundler) Build(ctx *kingpin.ParseContext) error {
 			break
 		}
 		var data []byte
-		data, err = ioutil.ReadFile(file)
+		data, err = os.ReadFile(file)
 		if err != nil {
 			break
 		}
@@ -137,7 +136,7 @@ func (b *Bundler) Build(ctx *kingpin.ParseContext) error {
 	newManifest, err := zipWriter.Create(defaultManifestPath)
 	_, err = newManifest.Write(manifestData)
 	zipWriter.Close()
-	err = ioutil.WriteFile(bundlePath, buf.Bytes(), defaultBundlePerm)
+	err = os.WriteFile(bundlePath, buf.Bytes(), defaultBundlePerm)
 	if err != nil {
 		return err
 	}
@@ -188,7 +187,7 @@ func (b *Bundler) validateManifest(manifest *apidef.BundleManifest) (err error) 
 }
 
 func (b *Bundler) loadManifest(path string) (manifest *apidef.BundleManifest, err error) {
-	rawManifest, err := ioutil.ReadFile(path)
+	rawManifest, err := os.ReadFile(path)
 	if err != nil {
 		return manifest, errManifestLoad
 	}

--- a/cli/bundler/bundler_test.go
+++ b/cli/bundler/bundler_test.go
@@ -4,12 +4,12 @@ import (
 	"archive/zip"
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/stretchr/testify/assert"
 
 	kingpin "github.com/alecthomas/kingpin/v2"
 )
@@ -56,7 +56,7 @@ func writeManifestFile(t testing.TB, manifest interface{}, filename string) *str
 		manifestString := manifest.(string)
 		data = []byte(manifestString)
 	}
-	ioutil.WriteFile(filename, data, 0600)
+	err = os.WriteFile(filename, data, 0600)
 	if err != nil {
 		t.Fatalf("Couldn't write manifest file: %s", err.Error())
 	}
@@ -135,7 +135,7 @@ func TestBuild(t *testing.T) {
 	// Build a simple bundle:
 	t.Run("Simple bundle build", func(t *testing.T) {
 		ctx := &kingpin.ParseContext{}
-		err := ioutil.WriteFile("middleware.py", []byte(""), 0600)
+		err := os.WriteFile("middleware.py", []byte(""), 0600)
 		if err != nil {
 			t.Fatalf("Couldn't write middleware.py: %s", err.Error())
 		}
@@ -157,6 +157,8 @@ func TestBuild(t *testing.T) {
 		skipSigning := true
 		bundler.skipSigning = &skipSigning
 		err = bundler.Build(ctx)
+		assert.NoError(t, err)
+
 		zipFile, err := zip.OpenReader("bundle.zip")
 		if err != nil {
 			t.Fatalf("Couldn't initialize ZIP reader: %s\n", err.Error())

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -4,7 +4,6 @@ package cli
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	kingpin "github.com/alecthomas/kingpin/v2"
@@ -78,7 +77,7 @@ func Init(confPaths []string) {
 	// Linter:
 	lintCmd := app.Command("lint", "Runs a linter on Tyk configuration file")
 	lintCmd.Action(func(c *kingpin.ParseContext) error {
-		confSchema, err := ioutil.ReadFile("cli/linter/schema.json")
+		confSchema, err := os.ReadFile("cli/linter/schema.json")
 		if err != nil {
 			return err
 		}

--- a/cli/linter/linter_test.go
+++ b/cli/linter/linter_test.go
@@ -1,11 +1,9 @@
 //go:build !dev
-// +build !dev
 
 package linter
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -111,7 +109,7 @@ func allContains(got, want []string) bool {
 func TestLint(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			f, err := ioutil.TempFile("", "tyk-lint")
+			f, err := os.CreateTemp("", "tyk-lint")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -120,7 +118,7 @@ func TestLint(t *testing.T) {
 			}
 			f.Close()
 
-			confSchema, err := ioutil.ReadFile("cli/linter/schema.json")
+			confSchema, err := os.ReadFile("cli/linter/schema.json")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -1214,10 +1213,10 @@ func WriteConf(path string, conf *Config) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(path, bs, 0644)
+	return os.WriteFile(path, bs, 0644)
 }
 
-// writeDefault will set conf to the default config and write it to disk
+// WriteDefault will set conf to the default config and write it to disk
 // in path, if the path is non-empty.
 func WriteDefault(path string, conf *Config) error {
 	_, b, _, _ := runtime.Caller(0)

--- a/coprocess/coprocess_test.go
+++ b/coprocess/coprocess_test.go
@@ -12,8 +12,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/justinas/alice"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/sirupsen/logrus"
 

--- a/coprocess/grpc/coprocess_grpc_test.go
+++ b/coprocess/grpc/coprocess_grpc_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"mime/multipart"
 	"net"
@@ -484,7 +484,7 @@ func TestGRPCDispatch(t *testing.T) {
 	defer ts.Close()
 	defer grpcServer.Stop()
 
-	keyID := gateway.CreateSession(ts.Gw, func(s *user.SessionState) {
+	_, keyID := ts.CreateSession(func(s *user.SessionState) {
 		s.MetaData = map[string]interface{}{
 			"testkey":  map[string]interface{}{"nestedkey": "nestedvalue"},
 			"testkey2": "testvalue",
@@ -502,7 +502,8 @@ func TestGRPCDispatch(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Request failed: %s", err.Error())
 		}
-		data, err := ioutil.ReadAll(res.Body)
+
+		data, err := io.ReadAll(res.Body)
 		if err != nil {
 			t.Fatalf("Couldn't read response body: %s", err.Error())
 		}
@@ -602,7 +603,7 @@ func BenchmarkGRPCDispatch(b *testing.B) {
 	defer ts.Close()
 	defer grpcServer.Stop()
 
-	keyID := gateway.CreateSession(ts.Gw)
+	_, keyID := ts.CreateSession()
 	headers := map[string]string{"authorization": keyID}
 
 	b.Run("Pre Hook with SetHeaders", func(b *testing.B) {

--- a/coprocess/python/coprocess_python_test.go
+++ b/coprocess/python/coprocess_python_test.go
@@ -310,7 +310,7 @@ func TestPythonBundles(t *testing.T) {
 
 		postHookBundle := ts.RegisterBundle("python_with_post_hook", pythonBundleWithPostHook)
 
-		keyID := gateway.CreateSession(ts.Gw, func(s *user.SessionState) {
+		_, keyID := ts.CreateSession(func(s *user.SessionState) {
 			s.MetaData = map[string]interface{}{
 				"testkey":   map[string]interface{}{"nestedkey": "nestedvalue"},
 				"stringkey": "testvalue",
@@ -338,7 +338,7 @@ func TestPythonBundles(t *testing.T) {
 
 		responseHookBundle := ts.RegisterBundle("python_with_response_hook", pythonBundleWithResponseHook)
 
-		keyID := gateway.CreateSession(ts.Gw, func(s *user.SessionState) {
+		_, keyID := ts.CreateSession(func(s *user.SessionState) {
 			s.MetaData = map[string]interface{}{
 				"testkey":   map[string]interface{}{"nestedkey": "nestedvalue"},
 				"stringkey": "testvalue",

--- a/gateway/analytics.go
+++ b/gateway/analytics.go
@@ -141,14 +141,14 @@ func (r *RedisAnalyticsHandler) recordWorker() {
 	// this is buffer to send one pipelined command to redis
 	// use r.recordsBufferSize as cap to reduce slice re-allocations
 	recordsBuffer := make([][]byte, 0, r.workerBufferSize)
-	mathRand.Seed(time.Now().Unix())
+	rand := mathRand.New(mathRand.NewSource(time.Now().Unix()))
 
 	// read records from channel and process
 	lastSentTs := time.Now()
 	for {
 		analyticKey := analyticsKeyName
 		if r.enableMultipleAnalyticsKeys {
-			suffix := mathRand.Intn(10)
+			suffix := rand.Intn(10)
 			analyticKey = fmt.Sprintf("%v_%v", analyticKey, suffix)
 		}
 		serliazerSuffix := r.analyticsSerializer.GetSuffix()

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -33,7 +33,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -439,8 +438,8 @@ func (gw *Gateway) handleAddOrUpdate(keyName string, r *http.Request, isHashed b
 	// decode payload
 	newSession := &user.SessionState{}
 
-	contents, _ := ioutil.ReadAll(r.Body)
-	r.Body = ioutil.NopCloser(bytes.NewReader(contents))
+	contents, _ := io.ReadAll(r.Body)
+	r.Body = io.NopCloser(bytes.NewReader(contents))
 
 	if err := json.Unmarshal(contents, newSession); err != nil {
 		log.Error("Couldn't decode new session object: ", err)
@@ -939,7 +938,7 @@ func (gw *Gateway) handleAddOrUpdatePolicy(polID string, r *http.Request) (inter
 		return apiError("Marshalling failed"), http.StatusInternalServerError
 	}
 
-	if err := ioutil.WriteFile(polFilePath, asByte, 0644); err != nil {
+	if err := os.WriteFile(polFilePath, asByte, 0644); err != nil {
 		log.Error("Failed to create file! - ", err)
 		return apiError("Failed to create file!"), http.StatusInternalServerError
 	}
@@ -1266,7 +1265,7 @@ func (gw *Gateway) writeToFile(fs afero.Fs, newDef interface{}, filename string)
 		return errors.New("marshalling failed"), http.StatusInternalServerError
 	}
 
-	if err := ioutil.WriteFile(defFilePath, asByte, 0644); err != nil {
+	if err := os.WriteFile(defFilePath, asByte, 0644); err != nil {
 		log.Infof("EL file path: %v", defFilePath)
 		log.Error("Failed to create file! - ", err)
 		return errors.New("file object creation failed, write error"), http.StatusInternalServerError
@@ -1512,7 +1511,7 @@ func (gw *Gateway) apiOASPatchHandler(w http.ResponseWriter, r *http.Request) {
 	tykExtensionConfigParams := oas.GetTykExtensionConfigParams(r)
 
 	if oasObj.GetTykExtension() != nil && tykExtensionConfigParams == nil {
-		r.Body = ioutil.NopCloser(bytes.NewReader(reqBodyInBytes))
+		r.Body = io.NopCloser(bytes.NewReader(reqBodyInBytes))
 		obj, code := gw.handleUpdateApi(apiID, r, afero.NewOsFs(), true)
 		doJSONWrite(w, code, obj)
 		return
@@ -1550,7 +1549,7 @@ func (gw *Gateway) apiOASPatchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	r.Body = ioutil.NopCloser(bytes.NewReader(oasAPIInBytes))
+	r.Body = io.NopCloser(bytes.NewReader(oasAPIInBytes))
 
 	log.Debugf("PATCHing API: %q", apiID)
 	obj, code := gw.handleUpdateApi(apiID, r, afero.NewOsFs(), true)
@@ -3012,7 +3011,7 @@ func (gw *Gateway) validateOAS(next http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 
-		r.Body = ioutil.NopCloser(bytes.NewReader(reqBodyInBytes))
+		r.Body = io.NopCloser(bytes.NewReader(reqBodyInBytes))
 		next.ServeHTTP(w, r)
 	}
 }
@@ -3055,7 +3054,7 @@ func (gw *Gateway) makeImportedOASTykAPI(next http.HandlerFunc) http.HandlerFunc
 			return
 		}
 
-		r.Body = ioutil.NopCloser(bytes.NewReader(apiInBytes))
+		r.Body = io.NopCloser(bytes.NewReader(apiInBytes))
 		next.ServeHTTP(w, r)
 	}
 }
@@ -3437,7 +3436,7 @@ func invalidateTokens(prevClient ExtendedOsinClientInterface, updatedClient OAut
 
 func extractOASObjFromReq(reqBody io.Reader) ([]byte, *oas.OAS, error) {
 	var oasObj oas.OAS
-	reqBodyInBytes, err := ioutil.ReadAll(reqBody)
+	reqBodyInBytes, err := io.ReadAll(reqBody)
 	if err != nil {
 		return nil, nil, ErrRequestMalformed
 	}

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -507,13 +506,13 @@ func (a APIDefinitionLoader) FromDashboardService(endpoint string) ([]*APISpec, 
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusForbidden {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		a.Gw.reLogin()
 		return nil, fmt.Errorf("login failure, Response was: %v", string(body))
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		a.Gw.reLogin()
 		return nil, fmt.Errorf("dashboard API error, response was: %v", string(body))
 	}

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -6,10 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"sync"
 	"testing"
 	textTemplate "text/template"
@@ -1295,7 +1295,7 @@ func TestAPIDefinitionLoader(t *testing.T) {
 	})
 
 	t.Run("loadBlobTemplate", func(t *testing.T) {
-		templateInBytes, _ := ioutil.ReadFile(testTemplatePath)
+		templateInBytes, _ := os.ReadFile(testTemplatePath)
 		tempBase64 := base64.StdEncoding.EncodeToString(templateInBytes)
 
 		temp, err := l.loadBlobTemplate(tempBase64)

--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -3567,7 +3566,7 @@ func testGetOASAPI(t *testing.T, d *Test, id, name, title string) (oasDoc openap
 	resp, _ := d.Run(t, test.TestCase{AdminAuth: true, Method: http.MethodGet, Path: getPath,
 		BodyMatch: bodyMatch, Code: http.StatusOK})
 
-	respInBytes, _ := ioutil.ReadAll(resp.Body)
+	respInBytes, _ := io.ReadAll(resp.Body)
 	_ = json.Unmarshal(respInBytes, &oasDoc)
 
 	return oasDoc
@@ -3582,7 +3581,7 @@ func testGetOldAPI(t *testing.T, d *Test, id, name string) (oldAPI apidef.APIDef
 	resp, _ := d.Run(t, test.TestCase{AdminAuth: true, Method: http.MethodGet, Path: getPath,
 		BodyMatch: bodyMatch, BodyNotMatch: "components", Code: http.StatusOK})
 
-	respInBytes, _ := ioutil.ReadAll(resp.Body)
+	respInBytes, _ := io.ReadAll(resp.Body)
 	_ = json.Unmarshal(respInBytes, &oldAPI)
 
 	return oldAPI
@@ -3606,7 +3605,7 @@ func testImportOAS(t *testing.T, ts *Test, testCase test.TestCase) string {
 	testCase.Method = http.MethodPost
 	resp, _ := ts.Run(t, testCase)
 
-	respInBytes, _ := ioutil.ReadAll(resp.Body)
+	respInBytes, _ := io.ReadAll(resp.Body)
 	_ = json.Unmarshal(respInBytes, &importResp)
 
 	ts.Gw.DoReload()

--- a/gateway/batch_requests.go
+++ b/gateway/batch_requests.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -69,7 +69,7 @@ func (b *BatchRequestHandler) doRequest(req *http.Request, relURL string) BatchR
 	}
 
 	defer resp.Body.Close()
-	content, err := ioutil.ReadAll(resp.Body)
+	content, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Warning("Body read failure! ", err)
 		return BatchReplyUnit{}

--- a/gateway/batch_requests_test.go
+++ b/gateway/batch_requests_test.go
@@ -5,7 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -61,7 +61,7 @@ func TestBatch(t *testing.T) {
 
 	resp, _ := ts.Do(test.TestCase{Method: "POST", Path: "/v1/tyk/batch/", Data: testBatchRequest})
 	if resp != nil {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		defer resp.Body.Close()
 
 		var batchResponse []map[string]json.RawMessage

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -46,7 +45,7 @@ func TestGatewayTLS(t *testing.T) {
 	// Configure server
 	serverCertPem, serverPrivPem, combinedPEM, _ := crypto.GenServerCertificate()
 
-	dir, _ := ioutil.TempDir("", "certs")
+	dir, _ := os.MkdirTemp("", "certs")
 	defer os.RemoveAll(dir)
 
 	client := GetTLSClient(nil, nil)
@@ -69,13 +68,13 @@ func TestGatewayTLS(t *testing.T) {
 	t.Run("Legacy TLS certificate path", func(t *testing.T) {
 
 		certFilePath := filepath.Join(dir, "server.crt")
-		err := ioutil.WriteFile(certFilePath, serverCertPem, 0666)
+		err := os.WriteFile(certFilePath, serverCertPem, 0666)
 		if err != nil {
 			t.Error("writing serverCertPem")
 		}
 
 		certKeyPath := filepath.Join(dir, "server.key")
-		err = ioutil.WriteFile(certKeyPath, serverPrivPem, 0666)
+		err = os.WriteFile(certKeyPath, serverPrivPem, 0666)
 		if err != nil {
 			t.Error("writing serverPrivPem")
 		}
@@ -104,7 +103,7 @@ func TestGatewayTLS(t *testing.T) {
 
 	t.Run("File certificate path", func(t *testing.T) {
 		certPath := filepath.Join(dir, "server.pem")
-		err := ioutil.WriteFile(certPath, combinedPEM, 0666)
+		err := os.WriteFile(certPath, combinedPEM, 0666)
 		if err != nil {
 			t.Error("could not write server.pem file")
 		}
@@ -160,7 +159,7 @@ func TestGatewayTLS(t *testing.T) {
 func TestGatewayControlAPIMutualTLS(t *testing.T) {
 	// Configure server
 	serverCertPem, _, combinedPEM, _ := crypto.GenServerCertificate()
-	dir, _ := ioutil.TempDir("", "certs")
+	dir, _ := os.MkdirTemp("", "certs")
 
 	defer func() {
 		os.RemoveAll(dir)

--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/url"
 	"reflect"
 	"strings"
@@ -105,7 +106,7 @@ func (c *CoProcessor) BuildObject(req *http.Request, res *http.Response, spec *A
 	if req.Body != nil {
 		defer req.Body.Close()
 		var err error
-		miniRequestObject.RawBody, err = ioutil.ReadAll(req.Body)
+		miniRequestObject.RawBody, err = io.ReadAll(req.Body)
 		if err != nil {
 			return nil, err
 		}
@@ -175,12 +176,12 @@ func (c *CoProcessor) BuildObject(req *http.Request, res *http.Response, spec *A
 			resObj.MultivalueHeaders = append(resObj.MultivalueHeaders, &currentHeader)
 		}
 		resObj.StatusCode = int32(res.StatusCode)
-		rawBody, err := ioutil.ReadAll(res.Body)
+		rawBody, err := io.ReadAll(res.Body)
 		if err != nil {
 			return nil, err
 		}
 		resObj.RawBody = rawBody
-		res.Body = ioutil.NopCloser(bytes.NewReader(rawBody))
+		res.Body = io.NopCloser(bytes.NewReader(rawBody))
 		if utf8.Valid(rawBody) && !c.Middleware.RawBodyOnly {
 			resObj.Body = string(rawBody)
 		}
@@ -193,7 +194,7 @@ func (c *CoProcessor) BuildObject(req *http.Request, res *http.Response, spec *A
 // ObjectPostProcess does CoProcessObject post-processing (adding/removing headers or params, etc.).
 func (c *CoProcessor) ObjectPostProcess(object *coprocess.Object, r *http.Request, origURL string, origMethod string) (err error) {
 	r.ContentLength = int64(len(object.Request.RawBody))
-	r.Body = ioutil.NopCloser(bytes.NewReader(object.Request.RawBody))
+	r.Body = io.NopCloser(bytes.NewReader(object.Request.RawBody))
 	nopCloseRequestBody(r)
 
 	logger := c.Middleware.Logger()
@@ -596,7 +597,7 @@ func (h *CustomMiddlewareResponseHook) HandleResponse(rw http.ResponseWriter, re
 
 	// Set response body:
 	bodyBuf := bytes.NewBuffer(retObject.Response.RawBody)
-	res.Body = ioutil.NopCloser(bodyBuf)
+	res.Body = io.NopCloser(bodyBuf)
 
 	res.StatusCode = int(retObject.Response.StatusCode)
 	return nil

--- a/gateway/coprocess_bundle.go
+++ b/gateway/coprocess_bundle.go
@@ -17,7 +17,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -162,7 +161,7 @@ func (g *HTTPBundleGetter) Get() ([]byte, error) {
 	}
 
 	defer resp.Body.Close()
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 // Get mocks an HTTP(S) GET request.

--- a/gateway/coprocess_grpc.go
+++ b/gateway/coprocess_grpc.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/coprocess"
@@ -93,7 +94,7 @@ func (gw *Gateway) NewGRPCDispatcher() (coprocess.Dispatcher, error) {
 	var err error
 	grpcConnection, err = grpc.Dial("",
 		gw.grpcCallOpts(),
-		grpc.WithInsecure(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithAuthority(authority),
 		grpc.WithDialer(gw.dialer),
 	)

--- a/gateway/coprocess_id_extractor.go
+++ b/gateway/coprocess_id_extractor.go
@@ -68,7 +68,7 @@ func (e *BaseExtractor) ExtractForm(r *http.Request, paramName string) (formValu
 
 // ExtractBody is used when BodySource is specified.
 func (e *BaseExtractor) ExtractBody(r *http.Request) (string, error) {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return "", err
 	}

--- a/gateway/coprocess_lua.go
+++ b/gateway/coprocess_lua.go
@@ -172,7 +172,7 @@ func (d *LuaDispatcher) Reload() {
 
 	for _, f := range files {
 		middlewarePath := filepath.Join(MiddlewareBasePath, f.Name())
-		contents, err := ioutil.ReadFile(middlewarePath)
+		contents, err := os.ReadFile(middlewarePath)
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "coprocess",
@@ -186,7 +186,7 @@ func (d *LuaDispatcher) Reload() {
 func (d *LuaDispatcher) HandleMiddlewareCache(b *apidef.BundleManifest, basePath string) {
 	for _, f := range b.FileList {
 		fullPath := filepath.Join(basePath, f)
-		contents, err := ioutil.ReadFile(fullPath)
+		contents, err := os.ReadFile(fullPath)
 		if err == nil {
 			d.ModuleCache[f] = string(contents)
 		} else {
@@ -208,7 +208,7 @@ func (d *LuaDispatcher) LoadModules() {
 	}
 
 	middlewarePath := filepath.Join(ModuleBasePath, "bundle.lua")
-	contents, err := ioutil.ReadFile(middlewarePath)
+	contents, err := os.ReadFile(middlewarePath)
 
 	if err == nil {
 		d.ModuleCache["bundle.lua"] = string(contents)

--- a/gateway/coprocess_python.go
+++ b/gateway/coprocess_python.go
@@ -18,7 +18,7 @@ import (
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/coprocess"
 
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 
 	python "github.com/TykTechnologies/tyk/dlpython"
 )

--- a/gateway/event_handler_webhooks.go
+++ b/gateway/event_handler_webhooks.go
@@ -244,7 +244,7 @@ func (w *WebHookHandler) HandleEvent(em config.EventMessage) {
 	} else {
 		defer resp.Body.Close()
 		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-			content, err := ioutil.ReadAll(resp.Body)
+			content, err := io.ReadAll(resp.Body)
 			if err == nil {
 				log.WithFields(logrus.Fields{
 					"prefix":       "webhooks",

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -335,7 +335,7 @@ func TestQuota(t *testing.T) {
 		}
 
 		var data map[string]string
-		body, _ := ioutil.ReadAll(r.Body)
+		body, _ := io.ReadAll(r.Body)
 		json.Unmarshal(body, &data)
 
 		if data["event"] != "QuotaExceeded" || data["message"] != "Key Quota Limit Exceeded" || data["key"] != keyID {

--- a/gateway/grpc_streaming_server_test.go
+++ b/gateway/grpc_streaming_server_test.go
@@ -34,7 +34,7 @@ import (
 
 	"google.golang.org/grpc"
 
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 
 	pb "google.golang.org/grpc/examples/route_guide/routeguide"
 )

--- a/gateway/grpc_test.go
+++ b/gateway/grpc_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/TykTechnologies/tyk/certs"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/TykTechnologies/tyk/config"
 
@@ -84,7 +85,7 @@ func TestHTTP2_h2C(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer w.Body.Close()
-	b, err := ioutil.ReadAll(w.Body)
+	b, err := io.ReadAll(w.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -462,7 +463,7 @@ func TestGRPC_TokenBasedAuthentication(t *testing.T) {
 	}...)
 
 	// Read key
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	var resMap map[string]string
 	err := json.Unmarshal(body, &resMap)
 	if err != nil {
@@ -573,7 +574,7 @@ func startGRPCServer(t *testing.T, clientCert *x509.Certificate, fn func(t *test
 }
 
 func sayHelloWithGRPCClientH2C(t *testing.T, address string, name string) *pbExample.HelloReply {
-	conn, err := grpc.Dial(address, grpc.WithInsecure())
+	conn, err := grpc.Dial(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("did not connect: %v", err)
 	}
@@ -781,7 +782,7 @@ func TestGRPC_Stream_TokenBasedAuthentication(t *testing.T) {
 	}
 
 	// Read key
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Error("Fail reading body from create key request")
 	}
@@ -885,5 +886,5 @@ func TestGRPC_Stream_H2C(t *testing.T) {
 	})
 
 	// gRPC client
-	testGRPCStreamClient(t, "localhost:6666", grpc.WithInsecure())
+	testGRPCStreamClient(t, "localhost:6666", grpc.WithTransportCredentials(insecure.NewCredentials()))
 }

--- a/gateway/handler_error.go
+++ b/gateway/handler_error.go
@@ -166,7 +166,7 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 
 			rsp := io.MultiWriter(w, &log)
 			tmplExecutor.Execute(rsp, &apiError)
-			response.Body = ioutil.NopCloser(&log)
+			response.Body = io.NopCloser(&log)
 		}
 	}
 

--- a/gateway/handler_error_test.go
+++ b/gateway/handler_error_test.go
@@ -2,7 +2,6 @@ package gateway
 
 import (
 	"bytes"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -20,7 +19,7 @@ func (s *Test) TestHandleError_text_xml(t *testing.T) {
 	<code>500</code>
 	<message>{{.Message}}</message>
 </error>`
-	err := ioutil.WriteFile(file, []byte(xml), 0600)
+	err := os.WriteFile(file, []byte(xml), 0600)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/gateway/handler_success.go
+++ b/gateway/handler_success.go
@@ -230,7 +230,7 @@ func (s *SuccessHandler) RecordHit(r *http.Request, timing analytics.Latency, co
 				// Get the wire format representation
 				var wireFormatRes bytes.Buffer
 				responseCopy.Write(&wireFormatRes)
-				responseCopy.Body = ioutil.NopCloser(bytes.NewBuffer(responseContent))
+				responseCopy.Body = io.NopCloser(bytes.NewBuffer(responseContent))
 				rawResponse = base64.StdEncoding.EncodeToString(wireFormatRes.Bytes())
 			}
 		}

--- a/gateway/host_checker.go
+++ b/gateway/host_checker.go
@@ -90,11 +90,11 @@ func (h *HostUptimeChecker) getStaggeredTime() time.Duration {
 		return time.Duration(h.checkTimeout) * time.Second
 	}
 
-	mathRand.Seed(time.Now().Unix())
+	rand := mathRand.New(mathRand.NewSource(time.Now().Unix()))
 	min := h.checkTimeout - 3
 	max := h.checkTimeout + 3
 
-	dur := mathRand.Intn(max-min) + min
+	dur := rand.Intn(max-min) + min
 
 	return time.Duration(dur) * time.Second
 }
@@ -259,7 +259,6 @@ func (h *HostUptimeChecker) CheckHost(toCheck HostData) {
 				if err != nil {
 					log.Errorf("Failed to send %s :%v", cmd.Message, err)
 					report.IsTCPError = true
-					break
 				}
 			case "expect":
 				buf := make([]byte, len(cmd.Message))

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -1067,11 +1067,11 @@ func parseForm(r *http.Request) {
 	// application/x-www-form-urlencoded
 	if r.Header.Get("Content-Type") == "application/x-www-form-urlencoded" && r.Form == nil {
 		var b bytes.Buffer
-		r.Body = ioutil.NopCloser(io.TeeReader(r.Body, &b))
+		r.Body = io.NopCloser(io.TeeReader(r.Body, &b))
 
 		r.ParseForm()
 
-		r.Body = ioutil.NopCloser(&b)
+		r.Body = io.NopCloser(&b)
 		return
 	}
 

--- a/gateway/middleware_test.go
+++ b/gateway/middleware_test.go
@@ -319,7 +319,7 @@ func TestSessionLimiter_RedisQuotaExceeded_PerAPI(t *testing.T) {
 		_, _ = g.Run(t, test.TestCase{Path: fmt.Sprintf("/%s/", apiID), Headers: headers, Code: http.StatusOK})
 
 		resp, _ := g.Run(t, test.TestCase{Path: "/tyk/keys/" + key, AdminAuth: true, Code: http.StatusOK})
-		bodyInBytes, _ := ioutil.ReadAll(resp.Body)
+		bodyInBytes, _ := io.ReadAll(resp.Body)
 		var session user.SessionState
 		_ = json.Unmarshal(bodyInBytes, &session)
 

--- a/gateway/mw_basic_auth.go
+++ b/gateway/mw_basic_auth.go
@@ -124,8 +124,8 @@ func (k *BasicAuthKeyIsValid) basicAuthHeaderCredentials(w http.ResponseWriter, 
 }
 
 func (k *BasicAuthKeyIsValid) basicAuthBodyCredentials(w http.ResponseWriter, r *http.Request) (username, password string, err error, code int) {
-	body, _ := ioutil.ReadAll(r.Body)
-	r.Body = ioutil.NopCloser(bytes.NewReader(body))
+	body, _ := io.ReadAll(r.Body)
+	r.Body = io.NopCloser(bytes.NewReader(body))
 
 	userMatch := k.bodyUserRegexp.FindAllSubmatch(body, 1)
 	if len(userMatch) == 0 {

--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -83,7 +83,7 @@ func (w *customResponseWriter) getHttpResponse(r *http.Request) *http.Response {
 		ContentLength: w.dataLength,
 	}
 	if w.copyData {
-		httpResponse.Body = ioutil.NopCloser(bytes.NewReader(w.data))
+		httpResponse.Body = io.NopCloser(bytes.NewReader(w.data))
 	}
 
 	return httpResponse

--- a/gateway/mw_js_plugin.go
+++ b/gateway/mw_js_plugin.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -119,7 +119,7 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 	logger := d.Logger()
 
 	// Create the proxy object
-	originalBody, err := ioutil.ReadAll(r.Body)
+	originalBody, err := io.ReadAll(r.Body)
 	if err != nil {
 		logger.WithError(err).Error("Failed to read request body")
 		return nil, http.StatusOK
@@ -234,10 +234,10 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 	// Reconstruct the request parts
 	if newRequestData.Request.IgnoreBody {
 		r.ContentLength = int64(len(originalBody))
-		r.Body = ioutil.NopCloser(bytes.NewReader(originalBody))
+		r.Body = io.NopCloser(bytes.NewReader(originalBody))
 	} else {
 		r.ContentLength = int64(len(newRequestData.Request.Body))
-		r.Body = ioutil.NopCloser(bytes.NewReader(newRequestData.Request.Body))
+		r.Body = io.NopCloser(bytes.NewReader(newRequestData.Request.Body))
 	}
 
 	// make sure request's body can be re-read again
@@ -574,7 +574,7 @@ func (j *JSVM) LoadTykJSApi() {
 			return otto.Value{}
 		}
 
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		bodyStr := string(body)
 		tykResp := TykJSHttpResponse{
 			Code:        resp.StatusCode,

--- a/gateway/mw_js_plugin_test.go
+++ b/gateway/mw_js_plugin_test.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -182,11 +182,11 @@ leakMid.NewProcessRequest(function(request, session) {
 
 	want := body + " appended"
 
-	newBodyInBytes, _ := ioutil.ReadAll(req.Body)
+	newBodyInBytes, _ := io.ReadAll(req.Body)
 	assert.Equal(t, want, string(newBodyInBytes))
 
 	t.Run("check request body is re-readable", func(t *testing.T) {
-		newBodyInBytes, _ = ioutil.ReadAll(req.Body)
+		newBodyInBytes, _ = io.ReadAll(req.Body)
 		assert.Equal(t, want, string(newBodyInBytes))
 	})
 }
@@ -492,7 +492,7 @@ testJSVMCore.NewProcessRequest(function(request, session, config) {
 		MiddlewareClassName: "testJSVMCore",
 		Pre:                 true,
 	}
-	tfile, err := ioutil.TempFile("", "tykjs")
+	tfile, err := os.CreateTemp("", "tykjs")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -554,7 +554,7 @@ leakMid.NewProcessRequest(function(request, session) {
 	dynMid.Spec.JSVM = jsvm
 	dynMid.ProcessRequest(nil, req, nil)
 
-	bs, err := ioutil.ReadAll(req.Body)
+	bs, err := io.ReadAll(req.Body)
 	if err != nil {
 		t.Fatalf("failed to read final body: %v", err)
 	}

--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -114,7 +114,7 @@ func (k *JWTMiddleware) legacyGetSecretFromURL(url, kid, keyType string) (interf
 	}
 
 	for _, val := range jwkSet.Keys {
-		if val.KID != kid || strings.ToLower(val.Kty) != strings.ToLower(keyType) {
+		if val.KID != kid || !strings.EqualFold(val.Kty, keyType) {
 			continue
 		}
 		if len(val.X5c) > 0 {

--- a/gateway/mw_redis_cache.go
+++ b/gateway/mw_redis_cache.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"hash"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -104,7 +103,7 @@ func readBody(req *http.Request) (bodyBytes []byte, err error) {
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.ReadAll(req.Body)
+	return io.ReadAll(req.Body)
 }
 
 func isBodyHashRequired(request *http.Request) bool {

--- a/gateway/mw_transform.go
+++ b/gateway/mw_transform.go
@@ -52,7 +52,7 @@ func (t *TransformMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 }
 
 func transformBody(r *http.Request, tmeta *TransformSpec, t *TransformMiddleware) error {
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	defer r.Body.Close()
 
 	// Put into an interface:

--- a/gateway/mw_transform_jq.go
+++ b/gateway/mw_transform_jq.go
@@ -91,7 +91,7 @@ func (t *TransformJQMiddleware) transformJQBody(r *http.Request, ts *TransformJQ
 
 	transformed, _ := json.Marshal(jqResult.Body)
 	bodyBuffer := bytes.NewBuffer(transformed)
-	r.Body = ioutil.NopCloser(bodyBuffer)
+	r.Body = io.NopCloser(bodyBuffer)
 	r.ContentLength = int64(bodyBuffer.Len())
 	t
 	// Replace header in the request

--- a/gateway/mw_transform_test.go
+++ b/gateway/mw_transform_test.go
@@ -47,7 +47,7 @@ func TestTransformNonAscii(t *testing.T) {
 	if err := transformBody(r, tmeta, &transform); err != nil {
 		t.Fatalf("wanted nil error, got %v", err)
 	}
-	gotBs, err := ioutil.ReadAll(r.Body)
+	gotBs, err := io.ReadAll(r.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,7 +154,7 @@ func TestTransformJSONMarshalXMLInput(t *testing.T) {
 	if err := transformBody(r, tmeta, &transform); err != nil {
 		t.Fatalf("wanted nil error, got %v", err)
 	}
-	gotBs, err := ioutil.ReadAll(r.Body)
+	gotBs, err := io.ReadAll(r.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -181,7 +181,7 @@ func TestTransformJSONMarshalJSONInput(t *testing.T) {
 	if err := transformBody(r, tmeta, &transform); err != nil {
 		t.Fatalf("wanted nil error, got %v", err)
 	}
-	gotBs, err := ioutil.ReadAll(r.Body)
+	gotBs, err := io.ReadAll(r.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -220,7 +220,7 @@ func TestTransformJSONMarshalJSONArrayInput(t *testing.T) {
 	if err := transformBody(r, tmeta, &transform); err != nil {
 		t.Fatalf("wanted nil error, got %v", err)
 	}
-	gotBs, err := ioutil.ReadAll(r.Body)
+	gotBs, err := io.ReadAll(r.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -266,7 +266,7 @@ func TestTransformXMLMarshal(t *testing.T) {
 		if err := transformBody(r, tmeta, &transform); err != nil {
 			t.Fatalf("wanted nil error, got %v", err)
 		}
-		gotBs, err := ioutil.ReadAll(r.Body)
+		gotBs, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/gateway/mw_url_rewrite.go
+++ b/gateway/mw_url_rewrite.go
@@ -692,7 +692,7 @@ func checkContextTrigger(r *http.Request, options map[string]apidef.StringRegexM
 
 func checkPayload(r *http.Request, options apidef.StringRegexMap, triggernum int) bool {
 	contextData := ctxGetData(r)
-	bodyBytes, _ := ioutil.ReadAll(r.Body)
+	bodyBytes, _ := io.ReadAll(r.Body)
 
 	matched, matches := options.FindAllStringSubmatch(string(bodyBytes), -1)
 

--- a/gateway/mw_validate_json.go
+++ b/gateway/mw_validate_json.go
@@ -49,7 +49,7 @@ func (k *ValidateJSON) ProcessRequest(w http.ResponseWriter, r *http.Request, _ 
 	}
 
 	// Load input body into gojsonschema
-	bodyBytes, err := ioutil.ReadAll(r.Body)
+	bodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {
 		return err, http.StatusBadRequest
 	}

--- a/gateway/mw_virtual_endpoint.go
+++ b/gateway/mw_virtual_endpoint.go
@@ -131,7 +131,7 @@ func (d *VirtualEndpoint) ServeHTTPForCache(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Create the proxy object
-	originalBody, err := ioutil.ReadAll(r.Body)
+	originalBody, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read request body: %w", err)
 	}
@@ -149,7 +149,7 @@ func (d *VirtualEndpoint) ServeHTTPForCache(w http.ResponseWriter, r *http.Reque
 	}
 
 	// We need to copy the body _back_ for the decode
-	r.Body = ioutil.NopCloser(bytes.NewReader(originalBody))
+	r.Body = io.NopCloser(bytes.NewReader(originalBody))
 	parseForm(r)
 	requestData.Params = r.Form
 

--- a/gateway/policy.go
+++ b/gateway/policy.go
@@ -145,7 +145,7 @@ func (gw *Gateway) LoadPoliciesFromDashboard(endpoint, secret string, allowExpli
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		log.Error("Policy request login failure, Response was: ", string(body))
 		gw.reLogin()
 		return nil, ErrPoliciesFetchFailed

--- a/gateway/proxy_muxer_test.go
+++ b/gateway/proxy_muxer_test.go
@@ -340,7 +340,7 @@ func TestHTTP_custom_ports(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer w.Body.Close()
-	b, err := ioutil.ReadAll(w.Body)
+	b, err := io.ReadAll(w.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/gateway/redis_signal_handle_config.go
+++ b/gateway/redis_signal_handle_config.go
@@ -2,7 +2,6 @@ package gateway
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"syscall"
 	"time"
@@ -28,7 +27,7 @@ func (gw *Gateway) backupConfiguration() error {
 	now := time.Now()
 	asStr := now.Format("Mon-Jan-_2-15-04-05-2006")
 	fName := asStr + ".tyk.conf"
-	return ioutil.WriteFile(fName, oldConfig, 0644)
+	return os.WriteFile(fName, oldConfig, 0644)
 }
 
 func writeNewConfiguration(payload ConfigPayload) error {
@@ -36,7 +35,7 @@ func writeNewConfiguration(payload ConfigPayload) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(confPaths[0], newConfig, 0644)
+	return os.WriteFile(confPaths[0], newConfig, 0644)
 }
 
 func (gw *Gateway) handleNewConfiguration(payload string) {

--- a/gateway/res_handler_jq_transform.go
+++ b/gateway/res_handler_jq_transform.go
@@ -60,7 +60,7 @@ func (h *ResponseTransformJQMiddleware) HandleResponse(rw http.ResponseWriter, r
 	bodyBuffer := bytes.NewBuffer(transformed)
 	res.Header.Set("Content-Length", strconv.Itoa(bodyBuffer.Len()))
 	res.ContentLength = int64(bodyBuffer.Len())
-	res.Body = ioutil.NopCloser(bodyBuffer)
+	res.Body = io.NopCloser(bodyBuffer)
 
 	// Replace header in the response
 	ignoreCanonical := h.GetConfig().IgnoreCanonicalMIMEHeaderKey

--- a/gateway/res_handler_transform.go
+++ b/gateway/res_handler_transform.go
@@ -59,7 +59,7 @@ func respBodyReader(req *http.Request, resp *http.Response) io.ReadCloser {
 		reader, err := gzip.NewReader(resp.Body)
 		if err != nil {
 			log.Error("Body decompression error:", err)
-			return ioutil.NopCloser(bytes.NewReader(nil))
+			return io.NopCloser(bytes.NewReader(nil))
 		}
 
 		// represents unknown length
@@ -113,7 +113,7 @@ func (r *ResponseTransformMiddleware) HandleResponse(rw http.ResponseWriter, res
 	tmeta := meta.(*TransformSpec)
 
 	respBody := respBodyReader(req, res)
-	body, _ := ioutil.ReadAll(respBody)
+	body, _ := io.ReadAll(respBody)
 	defer respBody.Close()
 
 	// Put into an interface:
@@ -180,7 +180,7 @@ func (r *ResponseTransformMiddleware) HandleResponse(rw http.ResponseWriter, res
 
 	res.ContentLength = int64(bodyBuffer.Len())
 	res.Header.Set("Content-Length", strconv.Itoa(bodyBuffer.Len()))
-	res.Body = ioutil.NopCloser(&bodyBuffer)
+	res.Body = io.NopCloser(&bodyBuffer)
 
 	return nil
 }

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -570,7 +569,7 @@ func (p *ReverseProxy) CheckHeaderInRemoveList(hdr string, spec *APISpec, req *h
 	vInfo, _ := spec.Version(req)
 	versionPaths := spec.RxPaths[vInfo.Name]
 	for _, gdKey := range vInfo.GlobalHeadersRemove {
-		if strings.ToLower(gdKey) == strings.ToLower(hdr) {
+		if strings.EqualFold(gdKey, hdr) {
 			return true
 		}
 	}
@@ -579,7 +578,7 @@ func (p *ReverseProxy) CheckHeaderInRemoveList(hdr string, spec *APISpec, req *h
 	if found, meta := spec.CheckSpecMatchesStatus(req, versionPaths, HeaderInjected); found {
 		hmeta := meta.(*apidef.HeaderInjectionMeta)
 		for _, gdKey := range hmeta.DeleteHeaders {
-			if strings.ToLower(gdKey) == strings.ToLower(hdr) {
+			if strings.EqualFold(gdKey, hdr) {
 				return true
 			}
 		}
@@ -1324,8 +1323,8 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 			*bodyBuffer2 = bodyBuffer
 
 			// Create new ReadClosers so we can split output
-			res.Body = ioutil.NopCloser(&bodyBuffer)
-			inres.Body = ioutil.NopCloser(bodyBuffer2)
+			res.Body = io.NopCloser(&bodyBuffer)
+			inres.Body = io.NopCloser(bodyBuffer2)
 		}
 	}
 
@@ -1528,7 +1527,7 @@ func (p *ReverseProxy) handleUpgradeResponse(rw http.ResponseWriter, req *http.R
 	go spc.copyFromBackend(errc)
 	<-errc
 
-	res.Body = ioutil.NopCloser(strings.NewReader(""))
+	res.Body = io.NopCloser(strings.NewReader(""))
 
 	return nil
 }

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	htmlTemplate "html/template"
-	"io/ioutil"
+	"io"
 	stdlog "log"
 	"log/syslog"
 	"net"
@@ -1215,9 +1215,9 @@ func (gw *Gateway) initialiseSystem() error {
 		// `go test` without TYK_LOGLEVEL set defaults to no log
 		// output
 		log.SetLevel(logrus.ErrorLevel)
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 		gorpc.SetErrorLogger(func(string, ...interface{}) {})
-		stdlog.SetOutput(ioutil.Discard)
+		stdlog.SetOutput(io.Discard)
 	} else if *cli.DebugMode {
 		log.Level = logrus.DebugLevel
 		mainLog.Debug("Enabling debug-level output")
@@ -1346,11 +1346,11 @@ func writePIDFile(file string) error {
 		return err
 	}
 	pid := strconv.Itoa(os.Getpid())
-	return ioutil.WriteFile(file, []byte(pid), 0600)
+	return os.WriteFile(file, []byte(pid), 0600)
 }
 
 func readPIDFromFile(file string) (int, error) {
-	b, err := ioutil.ReadFile(file)
+	b, err := os.ReadFile(file)
 	if err != nil {
 		return 0, err
 	}
@@ -1813,7 +1813,7 @@ func (gw *Gateway) start() {
 
 	// 1s is the minimum amount of time between hot reloads. The
 	// interval counts from the start of one reload to the next.
-	go gw.reloadLoop(time.Tick(reloadInterval))
+	go gw.reloadLoop(time.NewTicker(reloadInterval).C)
 	go gw.reloadQueueLoop()
 }
 

--- a/gateway/service_discovery.go
+++ b/gateway/service_discovery.go
@@ -52,7 +52,7 @@ func (s *ServiceDiscovery) getServiceData(name string) (string, error) {
 	}
 
 	defer resp.Body.Close()
-	contents, err := ioutil.ReadAll(resp.Body)
+	contents, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	mathRand "math/rand"
 	"net"
 	"net/http"
@@ -60,7 +59,7 @@ var (
 	discardMuxer = mux.NewRouter()
 
 	// Used to store the test bundles:
-	testMiddlewarePath, _ = ioutil.TempDir("", "tyk-middleware-path")
+	testMiddlewarePath, _ = os.MkdirTemp("", "tyk-middleware-path")
 
 	defaultTestConfig config.Config
 	EnableTestDNSMock = false
@@ -303,7 +302,7 @@ func (s *Test) RegisterJSFileMiddleware(apiid string, files map[string]string) {
 	}
 
 	for file, content := range files {
-		err = ioutil.WriteFile(gwConfig.MiddlewarePath+"/"+apiid+"/"+file, []byte(content), 0755)
+		err = os.WriteFile(gwConfig.MiddlewarePath+"/"+apiid+"/"+file, []byte(content), 0755)
 		if err != nil {
 			log.WithError(err).Error("writing in file")
 		}
@@ -475,7 +474,7 @@ func (s *Test) testHttpHandler(gw *Gateway) *mux.Router {
 		}
 		r.URL.Opaque = r.URL.RawPath
 		w.Header().Set("X-Tyk-Test", "1")
-		body, _ := ioutil.ReadAll(r.Body)
+		body, _ := io.ReadAll(r.Body)
 
 		err := json.NewEncoder(w).Encode(TestHttpResponse{
 			Method:  r.Method,
@@ -1086,7 +1085,7 @@ func (s *Test) newGateway(genConf func(globalConf *config.Config)) *Gateway {
 
 	var err error
 	gwConfig.Storage.Database = mathRand.Intn(15)
-	gwConfig.AppPath, err = ioutil.TempDir("", "tyk-test-")
+	gwConfig.AppPath, err = os.MkdirTemp("", "tyk-test-")
 
 	if err != nil {
 		panic(err)
@@ -1713,7 +1712,7 @@ func BuildAPI(apiGens ...func(spec *APISpec)) (specs []*APISpec) {
 func (gw *Gateway) LoadAPI(specs ...*APISpec) (out []*APISpec) {
 	gwConf := gw.GetConfig()
 	oldPath := gwConf.AppPath
-	gwConf.AppPath, _ = ioutil.TempDir("", "apps")
+	gwConf.AppPath, _ = os.MkdirTemp("", "apps")
 	gw.SetConfig(gwConf, true)
 	defer func() {
 		globalConf := gw.GetConfig()
@@ -1734,7 +1733,7 @@ func (gw *Gateway) LoadAPI(specs ...*APISpec) (out []*APISpec) {
 		}
 
 		specFilePath := filepath.Join(gwConf.AppPath, spec.APIID+strconv.Itoa(i)+".json")
-		if err := ioutil.WriteFile(specFilePath, specBytes, 0644); err != nil {
+		if err := os.WriteFile(specFilePath, specBytes, 0644); err != nil {
 			panic(err)
 		}
 
@@ -1745,7 +1744,7 @@ func (gw *Gateway) LoadAPI(specs ...*APISpec) (out []*APISpec) {
 		}
 
 		oasSpecFilePath := filepath.Join(gwConf.AppPath, spec.APIID+strconv.Itoa(i)+"-oas.json")
-		if err := ioutil.WriteFile(oasSpecFilePath, oasSpecBytes, 0644); err != nil {
+		if err := os.WriteFile(oasSpecFilePath, oasSpecBytes, 0644); err != nil {
 			panic(err)
 		}
 	}

--- a/gateway/tracing_test.go
+++ b/gateway/tracing_test.go
@@ -18,7 +18,7 @@ func TestTraceHttpRequest_toRequest(t *testing.T) {
 	tr := &traceHttpRequest{Path: "", Method: http.MethodPost, Body: body, Headers: header}
 
 	request, err := tr.toRequest(ts.Gw.GetConfig().IgnoreCanonicalMIMEHeaderKey)
-	bodyInBytes, _ := ioutil.ReadAll(request.Body)
+	bodyInBytes, _ := io.ReadAll(request.Body)
 
 	assert.NoError(t, err)
 	assert.Equal(t, http.MethodPost, request.Method)

--- a/test/goplugins/test_goplugin.go
+++ b/test/goplugins/test_goplugin.go
@@ -103,7 +103,7 @@ func MyPluginResponse(rw http.ResponseWriter, res *http.Response, req *http.Requ
 
 	buf.Write([]byte(`{"message":"response injected message"}`))
 
-	res.Body = ioutil.NopCloser(&buf)
+	res.Body = io.NopCloser(&buf)
 
 	apiDefinition := ctx.GetDefinition(req)
 	if apiDefinition == nil {

--- a/test/http.go
+++ b/test/http.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -48,8 +47,8 @@ type TestCase struct {
 }
 
 func AssertResponse(resp *http.Response, tc *TestCase) error {
-	body, _ := ioutil.ReadAll(resp.Body)
-	resp.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body = io.NopCloser(bytes.NewBuffer(body))
 	defer resp.Body.Close()
 
 	if tc.Code != 0 && resp.StatusCode != tc.Code {


### PR DESCRIPTION
## **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

## **Type**
enhancement


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>60 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>notifications.go</strong><dd><code>Replace deprecated ioutil with io package in notifications.go</code></dd></summary>
<hr>

apidef/notifications.go
<li>Replace <code>ioutil</code> with <code>io</code> for <code>ReadAll</code> method.<br> <li> Minor formatting adjustments.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-205ab475fe3ecbd033839c2ff583e8b4b3f656ded8a5570c6f6e581dc86971f0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>root_test.go</strong><dd><code>Remove unnecessary break statement in root_test.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/root_test.go
- Remove unnecessary `break` statement in a switch case.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-4d144465b7fabaf2db8915de1ce3b6ff8c91a93c62d614c38fa38bdae28e23a2">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>manager.go</strong><dd><code>Replace deprecated ioutil with os package in manager.go</code>&nbsp; &nbsp; </dd></summary>
<hr>

certs/manager.go
<li>Replace <code>ioutil</code> with <code>os</code> for <code>ReadFile</code> method.<br> <li> Minor formatting adjustments.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-78e768b2719ac9f70038499f847de2843db20d8ca21a963ea63b82010d711039">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>manager_test.go</strong><dd><code>Use os package for file operations in manager_test.go</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

certs/manager_test.go
<li>Replace <code>ioutil</code> with <code>os</code> for temporary directory creation and file <br>writing.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-46dee1931e248ad5a05261ace1d2095f3182c7c5126ee8b980f04b761ff8c3a1">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>test_goplugin.go</strong><dd><code>Replace deprecated ioutil with io package in test_goplugin.go</code></dd></summary>
<hr>

ci/tests/plugin-compiler/testdata/basic-plugin/test_goplugin.go
- Replace `ioutil` with `io` for `NopCloser` method.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-85056cba7a499fc74d6a1631c82925bf5cbadafb0d5b050d75c0920812dbcb77">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>plugin.go</strong><dd><code>Replace deprecated ioutil with io package in plugin.go</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ci/tests/plugin-compiler/testdata/complex-plugin/plugin/plugin.go
- Replace `ioutil` with `io` for `NopCloser` method.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-d544a6ab16903561c9150b04cd76970c2fdf38da4af766b3f153b26ed4034d3f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>bundler.go</strong><dd><code>Use os package for file operations in bundler.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/bundler/bundler.go
- Replace `ioutil` with `os` for file operations.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-4b6c235894ec97f5181e76933a9efb95cf56f17c929875456e771406e079ccf8">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>bundler_test.go</strong><dd><code>Use os package and improve error checking in bundler_test.go</code></dd></summary>
<hr>

cli/bundler/bundler_test.go
<li>Replace <code>ioutil</code> with <code>os</code> for file writing and temporary directory <br>creation.<br> <li> Use <code>assert.NoError</code> for error checking.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-ca677a25368595e118a0500bbde9d4bad2e757eaf1cbdb2514a95a9670786028">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cli.go</strong><dd><code>Replace deprecated ioutil with os package in cli.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/cli.go
- Replace `ioutil` with `os` for reading files.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>linter_test.go</strong><dd><code>Use os package for file operations in linter_test.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/linter/linter_test.go
- Replace `ioutil` with `os` for file operations.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-810cce952d4a0a39f8b4149de04c5bcbb0044c65a5f71c50240b98e9d9646c79">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>config.go</strong><dd><code>Replace deprecated ioutil with os package in config.go</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/config.go
<li>Replace <code>ioutil</code> with <code>os</code> for file writing.<br> <li> Minor documentation update.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>config_test.go</strong><dd><code>Use os package and improve error checking in config_test.go</code></dd></summary>
<hr>

config/config_test.go
<li>Replace <code>ioutil</code> with <code>os</code> for file operations.<br> <li> Use <code>assert.NoError</code> for error checking.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-373f5578b8f362a364b50b0d01919a57da64c128547ca10d49df8ae422237c82">+23/-15</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>coprocess_test.go</strong><dd><code>Update session creation method in coprocess_test.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

coprocess/coprocess_test.go
<li>Replace <code>CreateSession</code> with <code>CreateSession</code> and keyID return in tests.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-0e07a5675f97a3eca0f46515bd4675569679816a385afd2c79d096c5eeb74667">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>coprocess_grpc_test.go</strong><dd><code>Update session creation and replace deprecated ioutil in </code><br><code>coprocess_grpc_test.go</code></dd></summary>
<hr>

coprocess/grpc/coprocess_grpc_test.go
<li>Replace <code>ioutil</code> with <code>io</code> for reading response body.<br> <li> Replace <code>CreateSession</code> with <code>CreateSession</code> and keyID return in tests.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-c5b0bcf682a084942dee611f5b6c7ff202dd49424b90d39658c4634f0422064a">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>coprocess_python_test.go</strong><dd><code>Update session creation method in coprocess_python_test.go</code></dd></summary>
<hr>

coprocess/python/coprocess_python_test.go
<li>Replace <code>CreateSession</code> with <code>CreateSession</code> and keyID return in tests.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-d05809c154606ecb0d7d70b9aa4d3b26bc88ac1a9c31f4ef5e1729da1e8db44c">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>analytics.go</strong><dd><code>Use thread-safe rand instance in analytics.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/analytics.go
<li>Replace <code>mathRand.Seed</code> with new <code>rand</code> instance for thread safety.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-96796da097eb152628700f491f99bfd2b5e87cc8314d0b1c1879cdb173c3bcdc">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>api.go</strong><dd><code>Replace deprecated ioutil with io and os packages in api.go</code></dd></summary>
<hr>

gateway/api.go
<li>Replace <code>ioutil</code> with <code>io</code> for reading and closing request body.<br> <li> Replace <code>ioutil</code> with <code>os</code> for file writing.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-644cda3aeb4ac7f325359e85fcddb810f100dd5e6fa480b0d9f9363a743c4e05">+9/-10</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>api_definition.go</strong><dd><code>Replace deprecated ioutil with io package in api_definition.go</code></dd></summary>
<hr>

gateway/api_definition.go
- Replace `ioutil` with `io` for reading response body.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-0cf80174bbafb36f6d4f4308ebbd971b2833b76a936bad568220aa1a4ba0ee8b">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>api_definition_test.go</strong><dd><code>Use os package for file operations in api_definition_test.go</code></dd></summary>
<hr>

gateway/api_definition_test.go
- Replace `ioutil` with `os` for reading files.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-2394daab6fdc5f8dc234699c80c0548947ee3d68d2e33858258d73a8b5eb6f44">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>api_test.go</strong><dd><code>Replace deprecated ioutil with io package in api_test.go</code>&nbsp; </dd></summary>
<hr>

gateway/api_test.go
- Replace `ioutil` with `io` for reading response body.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-10b4a3d7bdd8d98e48b288d27fd46d9ee436617806c46913fdf7942c0e4a992e">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>batch_requests.go</strong><dd><code>Replace deprecated ioutil with io package in batch_requests.go</code></dd></summary>
<hr>

gateway/batch_requests.go
- Replace `ioutil` with `io` for reading response body.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-2592f5fcee155ea0616be637ef7cf4479ae41a23beaadd230c26d8e3f056cd04">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>batch_requests_test.go</strong><dd><code>Replace deprecated ioutil with io package in batch_requests_test.go</code></dd></summary>
<hr>

gateway/batch_requests_test.go
- Replace `ioutil` with `io` for reading response body.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-0df804185e129b11321be2cb54d509f208cc9ca88627bad1c16c6be1c9091507">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cert.go</strong><dd><code>Replace deprecated ioutil with io package in cert.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/cert.go
- Replace `ioutil` with `io` for reading request body.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-43b9bc3a5fe2dc862ae2eec0d3eb417d369a3ce32b8c3176c784822e17c2c2b1">+11/-2</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cert_test.go</strong><dd><code>Use os package for file operations in cert_test.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/cert_test.go
<li>Replace <code>ioutil</code> with <code>os</code> for temporary directory creation and file <br>writing.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-481696cb18de8c3880e0ca21318fe00fd4eb89bc48994e43b7c34729ef4a7ee2">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>coprocess.go</strong><dd><code>Replace deprecated ioutil with io package in coprocess.go</code></dd></summary>
<hr>

gateway/coprocess.go
- Replace `ioutil` with `io` for reading request and response body.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-9cbfe628982b2afb94d1e9a5200fc9a4fdc00cb58fe65d1090a3725e4e4c5953">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>coprocess_bundle.go</strong><dd><code>Replace deprecated ioutil with io package in coprocess_bundle.go</code></dd></summary>
<hr>

gateway/coprocess_bundle.go
- Replace `ioutil` with `io` for reading response body.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-72df0cbfd3765a5d0bff62196c11008596608a21a53dbb9c65bfc6f008dbfa29">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>coprocess_grpc.go</strong><dd><code>Use secure gRPC credentials in coprocess_grpc.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/coprocess_grpc.go
<li>Replace <code>grpc.WithInsecure()</code> with <br><code>grpc.WithTransportCredentials(insecure.NewCredentials())</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-53c2775617dfe21b5a271269cd737bcc2818e2f0243b9a6e6bf5a73b14180334">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>coprocess_id_extractor.go</strong><dd><code>Replace deprecated ioutil with io package in coprocess_id_extractor.go</code></dd></summary>
<hr>

gateway/coprocess_id_extractor.go
- Replace `ioutil` with `io` for reading request body.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-538366e054e6d03772528105a15742f5aa9f1de9cf7574858b125ea70d83aca8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>coprocess_lua.go</strong><dd><code>Use os package for file operations in coprocess_lua.go</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/coprocess_lua.go
- Replace `ioutil` with `os` for reading files.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-e04169f69b26a74f07739b7bf298c83ec1de968cb6999e4312b4c9b0330ee364">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>coprocess_python.go</strong><dd><code>Update protobuf import path in coprocess_python.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/coprocess_python.go
<li>Replace <code>github.com/golang/protobuf/proto</code> with <br><code>google.golang.org/protobuf/proto</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-99efa86a36e8dd524534b6c25e9079779cdf3a03e4d99744426b9dc5ae2a01ef">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>event_handler_webhooks.go</strong><dd><code>Replace deprecated ioutil with io package in event_handler_webhooks.go</code></dd></summary>
<hr>

gateway/event_handler_webhooks.go
- Replace `ioutil` with `io` for reading response body.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-6587ad3f2629cfa6c84a71144127acd6cc7824e5141f0b4961848945a87e0198">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>gateway_test.go</strong><dd><code>Replace deprecated ioutil with io package in gateway_test.go</code></dd></summary>
<hr>

gateway/gateway_test.go
- Replace `ioutil` with `io` for reading response body.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-d34c7069ce5e81d45082b19eb3e869ee1a086e185dcd6630e75e3ed0d368b546">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>grpc_streaming_server_test.go</strong><dd><code>Update protobuf import path in grpc_streaming_server_test.go</code></dd></summary>
<hr>

gateway/grpc_streaming_server_test.go
<li>Replace <code>github.com/golang/protobuf/proto</code> with <br><code>google.golang.org/protobuf/proto</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-61f9d7f56d9104b7efc7a5c913b8d4958f3cd33acee96eeafe31a9df4a98337a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>grpc_test.go</strong><dd><code>Update gRPC credentials and replace deprecated ioutil in grpc_test.go</code></dd></summary>
<hr>

gateway/grpc_test.go
<li>Replace <code>ioutil</code> with <code>io</code> for reading response body.<br> <li> Replace <code>grpc.WithInsecure()</code> with <br><code>grpc.WithTransportCredentials(insecure.NewCredentials())</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-d450b0f742036333148e25629f6bc8465dc2b4b5f7d44ca83170c87e10d0e6ff">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>handler_error.go</strong><dd><code>Replace deprecated ioutil with io package in handler_error.go</code></dd></summary>
<hr>

gateway/handler_error.go
- Replace `ioutil` with `io` for creating `NopCloser`.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-d3b05530ad23401f3b8f33bb1a467cd807a29a6b09c7430d01d069f626b20f77">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>handler_error_test.go</strong><dd><code>Use os package for file operations in handler_error_test.go</code></dd></summary>
<hr>

gateway/handler_error_test.go
- Replace `ioutil` with `os` for file writing.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-530de66339b5f5dbe9e19144fe4215f0aa021c8414c8f3b840d3175b2d6675da">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>handler_success.go</strong><dd><code>Replace deprecated ioutil with io package in handler_success.go</code></dd></summary>
<hr>

gateway/handler_success.go
- Replace `ioutil` with `io` for creating `NopCloser`.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-45135957493eca37f2e3e9a81079577777133c53b27cf95ea2ff0329c05bd006">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>host_checker.go</strong><dd><code>Use thread-safe rand instance in host_checker.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/host_checker.go
<li>Replace <code>mathRand.Seed</code> with new <code>rand</code> instance for thread safety.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-a0eaa8c9fb4c1479a5b080cd3b6faf25ce1d218ca107d5b07888d4ffc97aadac">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>middleware.go</strong><dd><code>Replace deprecated ioutil with io package in middleware.go</code></dd></summary>
<hr>

gateway/middleware.go
- Replace `ioutil` with `io` for creating `NopCloser`.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-703054910891a4db633eca0f42ed779d6b4fa75cd9b3aa4c503e681364201c1b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>middleware_test.go</strong><dd><code>Replace deprecated ioutil with io package in middleware_test.go</code></dd></summary>
<hr>

gateway/middleware_test.go
- Replace `ioutil` with `io` for reading response body.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-6a09a08e3f82cc5e9d8c6b5c8426d75ea1e5d85e15ab008fca1f512e7c49c1e6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_basic_auth.go</strong><dd><code>Replace deprecated ioutil with io package in mw_basic_auth.go</code></dd></summary>
<hr>

gateway/mw_basic_auth.go
- Replace `ioutil` with `io` for creating `NopCloser`.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-3dd66447b7bd6a3fe7c8c091cd3ba4756bce80d01f7967f90b689c1ca2dadb73">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_go_plugin.go</strong><dd><code>Replace deprecated ioutil with io package in mw_go_plugin.go</code></dd></summary>
<hr>

gateway/mw_go_plugin.go
- Replace `ioutil` with `io` for creating `NopCloser`.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-0f31abef73bf795e1a8d331202330c73011a74d10fd66e49b9359716a6d18fd9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_js_plugin.go</strong><dd><code>Replace deprecated ioutil with io package in mw_js_plugin.go</code></dd></summary>
<hr>

gateway/mw_js_plugin.go
<li>Replace <code>ioutil</code> with <code>io</code> for reading request body and creating <br><code>NopCloser</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-78cd278aba997558b7daa7897051a794ef860076d45c93be792791db39381ca0">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_js_plugin_test.go</strong><dd><code>Replace deprecated ioutil with io package in mw_js_plugin_test.go</code></dd></summary>
<hr>

gateway/mw_js_plugin_test.go
- Replace `ioutil` with `io` for reading request body.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-88ea01d67d890203d11074358ea2dbb949b8f1aa2a6e5afd9fe4459278f148d6">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_jwt.go</strong><dd><code>Improve string comparison in mw_jwt.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_jwt.go
- Use `strings.EqualFold` for case-insensitive string comparison.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-e8bce0f6790c8c56b30e24dbeebb0fc4aa0879ab5ea5f6ef6dbe68931410e237">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_redis_cache.go</strong><dd><code>Replace deprecated ioutil with io package in mw_redis_cache.go</code></dd></summary>
<hr>

gateway/mw_redis_cache.go
- Replace `ioutil` with `io` for reading request body.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-6266e0dbd16cef89e6de86a2c893114ba07799c804e2138172f9f94b08cdded8">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_transform.go</strong><dd><code>Replace deprecated ioutil with io package in mw_transform.go</code></dd></summary>
<hr>

gateway/mw_transform.go
- Replace `ioutil` with `io` for reading request body.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-d7a3cdc3dcabd415dffee6c044ea27dbe877add0ddc42471e10943125693fc12">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_transform_jq.go</strong><dd><code>Replace deprecated ioutil with io package in mw_transform_jq.go</code></dd></summary>
<hr>

gateway/mw_transform_jq.go
- Replace `ioutil` with `io` for creating `NopCloser`.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-d630866c58438781b036a3a12e3d1668c964b007a5d0727eb363fcae086e3c35">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_transform_test.go</strong><dd><code>Replace deprecated ioutil with io package in mw_transform_test.go</code></dd></summary>
<hr>

gateway/mw_transform_test.go
- Replace `ioutil` with `io` for reading request body.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-ec6f80b3dcb001b2a2ac9b7277fff606bd77d796f99b8c1d10b8d0d55863deb3">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_url_rewrite.go</strong><dd><code>Improve string comparison in mw_url_rewrite.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_url_rewrite.go
- Use `strings.EqualFold` for case-insensitive string comparison.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-84a6a5c810334aaa8702669f2aebf0284f116d83e8a55ec9d1d5b8bae87f1be6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_validate_json.go</strong><dd><code>Replace deprecated ioutil with io package in mw_validate_json.go</code></dd></summary>
<hr>

gateway/mw_validate_json.go
- Replace `ioutil` with `io` for reading request body.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-0f0c6b9ac40c5e01908a5b24b1d03111c8d8b4dbc1ddc0251d17c3c1b5328ab5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_virtual_endpoint.go</strong><dd><code>Replace deprecated ioutil with io package in mw_virtual_endpoint.go</code></dd></summary>
<hr>

gateway/mw_virtual_endpoint.go
<li>Replace <code>ioutil</code> with <code>io</code> for reading request body and creating <br><code>NopCloser</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-daf72ac3b29609a9f2a77cccf648f91ba62b2ad977a7c5a44602c72b2a28b2e5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>policy.go</strong><dd><code>Replace deprecated ioutil with io package in policy.go</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/policy.go
- Replace `ioutil` with `io` for reading response body.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-ec674104322b26b82def55e9be32117753ab66e7840490481eb6eb4c15bc35e7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>proxy_muxer_test.go</strong><dd><code>Replace deprecated ioutil with io package in proxy_muxer_test.go</code></dd></summary>
<hr>

gateway/proxy_muxer_test.go
- Replace `ioutil` with `io` for reading response body.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-77759e37c86fafcb11595d3dabf0500740f312236588bdacba09bf75977244ac">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>redis_signal_handle_config.go</strong><dd><code>Use os package for file operations in redis_signal_handle_config.go</code></dd></summary>
<hr>

gateway/redis_signal_handle_config.go
- Replace `ioutil` with `os` for file writing.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-8e9e52ce3324a6171144c38a4c77d4da8bb520eb4ec443c3d025fbadcbf15dae">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>reverse_proxy.go</strong><dd><code>Replace deprecated ioutil and improve string comparison in </code><br><code>reverse_proxy.go</code></dd></summary>
<hr>

gateway/reverse_proxy.go
<li>Replace <code>ioutil</code> with <code>io</code> for creating <code>NopCloser</code>.<br> <li> Use <code>strings.EqualFold</code> for case-insensitive string comparison.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-e6e07722257f7e41691e471185ad6d84fd56dc9e5459526ea32e9a5e8fa1a01b">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>reverse_proxy_test.go</strong><dd><code>Replace deprecated ioutil with io package in reverse_proxy_test.go</code></dd></summary>
<hr>

gateway/reverse_proxy_test.go
- Replace `ioutil` with `io` for creating `NopCloser`.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-ce040f6555143f760fba6059744bc600b6954f0966dfb0fa2832b5eabf7a3c3f">+14/-13</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>server.go</strong><dd><code>Replace deprecated ioutil with io package in server.go</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/server.go
- Replace `ioutil` with `io` for discarding log output.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-4652d1bf175a0be8f5e61ef7177c9666f23e077d8626b73ac9d13358fa8b525b">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>service_discovery.go</strong><dd><code>Replace deprecated ioutil with io package in service_discovery.go</code></dd></summary>
<hr>

gateway/service_discovery.go
- Replace `ioutil` with `io` for reading response body.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-e89e292b6e3cb1a8b2b9c7944ee2da24ea005b490272b5f591a327d102b87799">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>testutil.go</strong><dd><code>Use os package for file operations in testutil.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/testutil.go
<li>Replace <code>ioutil</code> with <code>os</code> for temporary directory creation and file <br>writing.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6196/files#diff-7aaf6ae49fb8f58a8c99d337fedd15b3e430dd928ed547e425ef429b10d28ce8">+7/-8</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

