### PR TITLE
Merging to release-5-lts: [TT-10856/TT-11778] fix quota limit remaining header value when key is created from policy and API is looped (#6199)

### DIFF
--- a/gateway/mw_auth_key.go
+++ b/gateway/mw_auth_key.go
@@ -93,6 +93,11 @@ func (k *AuthKey) ProcessRequest(_ http.ResponseWriter, r *http.Request, _ inter
 		return nil, http.StatusOK
 	}
 
+	// skip auth key check if the request is looped.
+	if ses := ctxGetSession(r); ses != nil && !ctxCheckLimits(r) {
+		return nil, http.StatusOK
+	}
+
 	key, authConfig := k.getAuthToken(k.getAuthType(), r)
 	var certHash string
 

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -20,14 +20,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
-<<<<<<< HEAD
 	"github.com/stretchr/testify/require"
-=======
-	"github.com/TykTechnologies/tyk/user"
 
 	"github.com/TykTechnologies/tyk/header"
->>>>>>> 83cfda178... [TT-10856/TT-11778] fix quota limit remaining header value when key is created from policy and API is looped (#6199)
+	"github.com/TykTechnologies/tyk/user"
 
 	"github.com/TykTechnologies/graphql-go-tools/pkg/execution/datasource"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
@@ -1827,34 +1823,6 @@ func TestSetCustomHeaderMultipleValues(t *testing.T) {
 		})
 	}
 }
-<<<<<<< HEAD
-=======
-
-func TestCreateMemConnProviderIfNeeded(t *testing.T) {
-	t.Run("should propagate context", func(t *testing.T) {
-		propagationContext := context.WithValue(context.Background(), "parentContextKey", "parentContextValue")
-		propagationContextWithCancel, cancel := context.WithCancel(propagationContext)
-		internalReq, err := http.NewRequest(http.MethodGet, "http://memoryhost/", nil)
-		require.NoError(t, err)
-
-		handler := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			assert.Equal(t, "parentContextValue", req.Context().Value("parentContextKey"))
-			cancel()
-		})
-
-		err = createMemConnProviderIfNeeded(handler, internalReq.WithContext(propagationContextWithCancel))
-		require.NoError(t, err)
-
-		assert.Eventuallyf(t, func() bool {
-			testReq, err := http.NewRequest(http.MethodGet, "http://memoryhost/", nil)
-			require.NoError(t, err)
-			_, err = memConnClient.Do(testReq)
-			require.NoError(t, err)
-			<-propagationContextWithCancel.Done()
-			return true
-		}, time.Second, time.Millisecond*25, "context was not canceled")
-	})
-}
 
 func TestQuotaResponseHeaders(t *testing.T) {
 	ts := StartTest(nil)
@@ -1982,4 +1950,3 @@ func TestQuotaResponseHeaders(t *testing.T) {
 	})
 
 }
->>>>>>> 83cfda178... [TT-10856/TT-11778] fix quota limit remaining header value when key is created from policy and API is looped (#6199)


### PR DESCRIPTION
[TT-10856/TT-11778] fix quota limit remaining header value when key is created from policy and API is looped (#6199)

## **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description
`X-RateLimit-Remaining` header was returning `0` when key was created
from policy and API is looped with `tyk://self`
This is because `AuthKey` middleware is calling
`CheckSessionAndIdentityForValidKey` once again during looping.
This check can be skipped like what we do for `RateLimitAndQuotaCheck`
middleware
## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

## **Type**
bug_fix


___

## **Description**
- Fixed an issue where `X-RateLimit-Remaining` header returned incorrect
values for looped requests when the key was created from a policy.
- Refactored test setup for quota middleware to streamline session
creation.
- Added comprehensive tests to ensure correct quota headers are returned
for various key and policy configurations.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>middleware_test.go</strong><dd><code>Refactor Test
Setup for Quota Middleware</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></summary>
<hr>

gateway/middleware_test.go
<li>Removed <code>createSessionWithQuota</code> function as it was
replaced with a more <br>streamlined session creation in tests.<br> <li>
Modified <code>TestQuotaNotAppliedWithURLRewrite</code> to use the new
session <br>creation method.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6199/files#diff-6a09a08e3f82cc5e9d8c6b5c8426d75ea1e5d85e15ab008fca1f512e7c49c1e6">+17/-28</a>&nbsp;
</td>
</tr>                    

<tr>
  <td>
    <details>
<summary><strong>reverse_proxy_test.go</strong><dd><code>Extend Tests
for Quota Response Headers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/reverse_proxy_test.go
<li>Added tests to verify correct quota headers for keys without
policies, <br>keys from policies with per API limits, and keys from
policies with <br>global limits.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6199/files#diff-ce040f6555143f760fba6059744bc600b6954f0966dfb0fa2832b5eabf7a3c3f">+112/-31</a></td>
</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>mw_auth_key.go</strong><dd><code>Skip Auth Key Check
for Looped Requests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_auth_key.go
<li>Added a check to skip auth key verification if the request is looped
<br>and session limits are not to be checked.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6199/files#diff-aeba053023a54c723dd9f83837e29ca0b2d9a212bc98fa6ad4bbb062669a1cf0">+5/-0</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools
and their descriptions