### PR TITLE
Merging to release-5-lts: [TT-7560] skip loading API when custom middleware bundle fetch fails (#6211)

### DIFF
--- a/gateway/coprocess_id_extractor_test.go
+++ b/gateway/coprocess_id_extractor_test.go
@@ -31,7 +31,7 @@ const (
 func (ts *Test) createSpecTestFrom(tb testing.TB, def *apidef.APIDefinition) *APISpec {
 	tb.Helper()
 	loader := APIDefinitionLoader{Gw: ts.Gw}
-	spec := loader.MakeSpec(&nestedApiDefinition{APIDefinition: def}, nil)
+	spec, _ := loader.MakeSpec(&nestedApiDefinition{APIDefinition: def}, nil)
 	tname := tb.Name()
 	redisStore := &storage.RedisCluster{KeyPrefix: tname + "-apikey.", RedisController: ts.Gw.RedisController}
 	healthStore := &storage.RedisCluster{KeyPrefix: tname + "-apihealth.", RedisController: ts.Gw.RedisController}

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -928,7 +928,7 @@ func TestReq(t testing.TB, method, urlStr string, body interface{}) *http.Reques
 func (gw *Gateway) CreateDefinitionFromString(defStr string) *APISpec {
 	loader := APIDefinitionLoader{Gw: gw}
 	def := loader.ParseDefinition(strings.NewReader(defStr))
-	spec := loader.MakeSpec(&nestedApiDefinition{APIDefinition: &def}, nil)
+	spec, _ := loader.MakeSpec(&nestedApiDefinition{APIDefinition: &def}, nil)
 	return spec
 }
 

--- a/gateway/tracing.go
+++ b/gateway/tracing.go
@@ -116,7 +116,12 @@ func (gw *Gateway) traceHandler(w http.ResponseWriter, r *http.Request) {
 	subrouter := mux.NewRouter()
 
 	loader := &APIDefinitionLoader{Gw: gw}
-	spec := loader.MakeSpec(&nestedApiDefinition{APIDefinition: traceReq.Spec}, logrus.NewEntry(logger))
+
+	spec, err := loader.MakeSpec(&nestedApiDefinition{APIDefinition: traceReq.Spec}, logrus.NewEntry(logger))
+	if err != nil {
+		doJSONWrite(w, http.StatusBadRequest, traceResponse{Message: "error", Logs: logStorage.String()})
+		return
+	}
 
 	chainObj := gw.processSpec(spec, nil, &gs, logrus.NewEntry(logger))
 


### PR DESCRIPTION
[TT-7560] skip loading API when custom middleware bundle fetch fails (#6211)

## **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description
Skip loading an API when the custom middleware bundle fetch fails.

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

## **Type**
bug_fix, enhancement


___

## **Description**
- Modified `MakeSpec` in `api_definition.go` to return an error along
with `*APISpec`, enhancing error handling during API spec creation.
- Implemented error handling in various functions and tests that call
`MakeSpec`, ensuring that API loading can be skipped if a custom
middleware bundle fetch fails.
- Added and updated tests to cover new scenarios related to custom
middleware bundle fetching and API loading behavior.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>api_definition.go</strong><dd><code>Handle Errors in
API Spec Creation and Skip on Bundle Fetch
Failures</code></dd></summary>
<hr>

gateway/api_definition.go
<li>Changed <code>MakeSpec</code> to return an error along with
<code>*APISpec</code>.<br> <li> Updated <code>prepareSpecs</code> and
<code>loadDefFromFilePath</code> to handle errors from
<br><code>MakeSpec</code>.<br> <li> Modified API loading to skip APIs
when bundle fetch fails.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6211/files#diff-0cf80174bbafb36f6d4f4308ebbd971b2833b76a936bad568220aa1a4ba0ee8b">+11/-8</a>&nbsp;
&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
<summary><strong>tracing.go</strong><dd><code>Improve Error Handling in
Trace Handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; </dd></summary>
<hr>

gateway/tracing.go
<li>Updated trace handler to handle errors from <code>MakeSpec</code>
and return an <br>appropriate response.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6211/files#diff-0069987d730b02812808925a17e1434ca7558a4dfc8661beb27ccd11afb8c77d">+6/-1</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>coprocess_bundle_test.go</strong><dd><code>Test Custom
Middleware Bundle Fetch Scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/coprocess_bundle_test.go
<li>Added tests to verify API loading behavior with custom middleware
<br>bundle fetch scenarios.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6211/files#diff-7fded1570c90f7be73d562f3ebcbb32fe4d50548dc5e959d8ecadddef13941fa">+24/-0</a>&nbsp;
&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>

<summary><strong>coprocess_id_extractor_test.go</strong><dd><code>Update
Spec Creation in ID Extractor Tests</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; </dd></summary>
<hr>

gateway/coprocess_id_extractor_test.go
- Updated `createSpecTestFrom` to handle errors from `MakeSpec`.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6211/files#diff-077f3e65a150ce6b3b1c2ebc67e0482f1a5446ff6264754607d86c4691984375">+1/-1</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
<summary><strong>gateway_test.go</strong><dd><code>Test API Loading
Failure on Bundle Fetch Failure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/gateway_test.go
<li>Added a test case to verify the behavior when API loading fails due
to <br>bundle fetch failure.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6211/files#diff-d34c7069ce5e81d45082b19eb3e869ee1a086e185dcd6630e75e3ed0d368b546">+13/-0</a>&nbsp;
&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
<summary><strong>testutil.go</strong><dd><code>Handle Spec Creation
Errors in Test Utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/testutil.go
<li>Updated <code>CreateDefinitionFromString</code> to handle errors
from <code>MakeSpec</code>.


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6211/files#diff-7aaf6ae49fb8f58a8c99d337fedd15b3e430dd928ed547e425ef429b10d28ce8">+1/-1</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools
and their descriptions