### PR TITLE
Merging to release-5.3: TT-11748 dont attempt to remove ApiCacheDeletion key from redis (#6215)

### DIFF
--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -1016,6 +1016,7 @@ func (r *RPCStorageHandler) ProcessKeySpaceChanges(keys []string, orgId string) 
 				notRegularKeys[key] = true
 			case NoticeDeleteAPICache.String():
 				apiIDsToDeleteCache = append(apiIDsToDeleteCache, splitKeys[0])
+				notRegularKeys[key] = true
 			default:
 				log.Debug("ignoring processing of action:", action)
 			}


### PR DESCRIPTION
## **User description**
TT-11748 dont attempt to remove ApiCacheDeletion key from redis (#6215)

## **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description

when the key is to delete cache then we do not need to find the key in
redis and remove it as we do for ordinary keys as we will only trigger
the process to delete the api cache. Currently we have logs like:

```
time="Apr 08 19:28:42" level=info msg="--> removing cached key: ****ache"
time="Apr 08 19:28:43" level=error msg="Key not found in master - skipping"
```
Which are not desired in the given context

## Related Issue

TT-11748

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

## **Type**
bug_fix


___

## **Description**
- Fixes unnecessary removal attempts for API cache deletion keys by
marking them as not regular, thus avoiding error logs for missing keys.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>rpc_storage_handler.go</strong><dd><code>Avoid
Unnecessary Removal Attempts for API Cache Deletion
Keys</code></dd></summary>
<hr>

gateway/rpc_storage_handler.go
<li>Mark <code>NoticeDeleteAPICache</code> keys as not regular to avoid
unnecessary <br>removal attempts.<br>


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6215/files#diff-8875f75b602664c44b62b67a4da41d748124ad270573a44db4ec977ee5d68021">+1/-0</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools
and their descriptions


___

## **Type**
bug_fix


___

## **Description**
- Fixes an issue where keys intended for API cache deletion triggered unnecessary Redis lookup and removal attempts, leading to undesired log messages.
- Ensures that keys associated with `NoticeDeleteAPICache` are correctly marked to bypass the regular Redis key removal process.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_storage_handler.go</strong><dd><code>Avoid Unnecessary Redis Operations for API Cache Deletion Keys</code></dd></summary>
<hr>

gateway/rpc_storage_handler.go
<li>Mark <code>NoticeDeleteAPICache</code> keys as not regular to avoid unnecessary <br>Redis lookup and removal.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6218/files#diff-8875f75b602664c44b62b67a4da41d748124ad270573a44db4ec977ee5d68021">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

