### PR TITLE
Merging to release-5.3: [TT-9972] release resources only after specs are completely switched during hot reload (#5535)

### DIFF
--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -261,6 +261,7 @@ func (s *APISpec) Release() {
 		// Prevent new idle connections to be generated.
 		s.HTTPTransport.transport.DisableKeepAlives = true
 		s.HTTPTransport.transport.CloseIdleConnections()
+		s.HTTPTransport = nil
 	}
 }
 


### PR DESCRIPTION
## **User description**
[TT-9972] release resources only after specs are completely switched during hot reload (#5535)

<!-- Provide a general summary of your changes in the Title above -->

## Description

release resources only after specs are completely switched during hot
reload
## Related Issue
https://tyktech.atlassian.net/browse/TT-9972

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why

[TT-9972]: https://tyktech.atlassian.net/browse/TT-9972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

## **Type**
bug_fix


___

## **Description**
- Ensured that `HTTPTransport` is explicitly set to `nil` after closing idle connections to fully release API spec resources.
- Modified the API loading logic to delay the release of old API specs until after the new specs have been fully loaded and swapped. This change aims to prevent issues that could arise from prematurely releasing resources during hot reloads.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api_definition.go</strong><dd><code>Ensure HTTPTransport is Reset on API Spec Release</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_definition.go
<li>Added a line to set <code>HTTPTransport</code> to <code>nil</code> after closing idle <br>connections in the <code>Release</code> method.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6222/files#diff-0cf80174bbafb36f6d4f4308ebbd971b2833b76a936bad568220aa1a4ba0ee8b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>api_loader.go</strong><dd><code>Improve Resource Release Process During API Reload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_loader.go
<li>Modified the API loading process to collect specs that need to be <br>released, releasing them after the API swap to prevent premature <br>resource release.<br> <li> Ensured that <code>curSpec</code> is not nil before attempting to release it.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6222/files#diff-cdf0b7f176c9d18e1a314b78ddefc2cb3a94b3de66f1f360174692c915734c68">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

