### PR TITLE
[TT-11855] remove unnecessary packages resolving cve reports

### DIFF
--- a/ci/images/plugin-compiler/Dockerfile
+++ b/ci/images/plugin-compiler/Dockerfile
@@ -11,7 +11,7 @@ ENV PLUGIN_SOURCE_PATH=/plugin-source
 RUN mkdir -p $PLUGIN_SOURCE_PATH
 
 # remove for avoiding CVEs
-RUN apt-get purge -y --allow-remove-essential --auto-remove mercurial wget curl cmake ruby* python* docker* libsqlite* \
+RUN apt-get purge -y --allow-remove-essential --auto-remove mercurial wget curl automake cmake ruby* python* docker* libsqlite* qemu* \
 	&& rm -f /usr/bin/passwd /usr/sbin/adduser /usr/bin/goreleaser
 
 # This is already vendored from release pipeline

--- a/ci/images/plugin-compiler/Dockerfile
+++ b/ci/images/plugin-compiler/Dockerfile
@@ -11,11 +11,8 @@ ENV PLUGIN_SOURCE_PATH=/plugin-source
 RUN mkdir -p $PLUGIN_SOURCE_PATH
 
 # remove for avoiding CVEs
-RUN apt-get remove -y --allow-remove-essential --auto-remove mercurial ruby-dev \
-	&& rm /usr/bin/passwd && rm /usr/sbin/adduser
-
-# remove python 3.9 if exists.
-RUN apt-get remove -y --allow-remove-essential --auto-remove python3.9 || true
+RUN apt-get purge -y --allow-remove-essential --auto-remove mercurial wget curl cmake ruby* python* docker* libsqlite* \
+	&& rm -f /usr/bin/passwd /usr/sbin/adduser /usr/bin/goreleaser
 
 # This is already vendored from release pipeline
 WORKDIR /opt/tyk-gateway/src

--- a/ci/images/plugin-compiler/Taskfile.yml
+++ b/ci/images/plugin-compiler/Taskfile.yml
@@ -1,0 +1,24 @@
+---
+version: "3"
+
+vars:
+  tag: v0.0.0
+  image: internal/plugin-compiler
+  sha:
+    sh: git rev-parse HEAD
+  root:
+    sh: git rev-parse --show-toplevel
+
+tasks:
+  build:
+    desc: "Build test docker image"
+    dir: '{{.root}}'
+    cmds:
+      - docker build --no-cache --progress=plain --build-arg GITHUB_TAG={{.tag}} --build-arg GITHUB_SHA={{.sha}} --platform=linux/amd64 --rm -t {{.image}} -f ci/images/plugin-compiler/Dockerfile .
+
+  test:
+    desc: "Run test docker image"
+    dir: '{{.root}}'
+    cmds:
+      - docker run -it --rm --platform=linux/amd64 --entrypoint=/bin/bash {{.image}}
+


### PR DESCRIPTION
This PR removes several packages and files not in use by the plugin compiler:

- removes curl, wget, docker, cmake, automake (libcurl4)
- removes libcurl (partial, libcurl3 is required by git, git is required for plugin compiler)
- removes libsqlite3-0 (not required by plugin compiler)
- removes qemu (not in use for plugin compiler)
- removes /usr/bin/goreleaser binary

Removing the packages resolves the reported CVEs against them. A taskfile has been added for local testing with `task build`, `task test` (inspect), and the docker image produced is used in CVE checks on local.

https://tyktech.atlassian.net/browse/TT-11855