### PR TITLE
[TT-11925] Reset plugin compiler build env to match gateway build env

### DIFF
--- a/.github/workflows/plugin-compiler-build.yml
+++ b/.github/workflows/plugin-compiler-build.yml
@@ -11,7 +11,7 @@ on:
       - 'v*'
 
 env:
-  GOLANG_CROSS: 1.21-bookworm
+  GOLANG_CROSS: 1.21-bullseye
 
 jobs:
   docker-build:

--- a/ci/images/plugin-compiler/Dockerfile
+++ b/ci/images/plugin-compiler/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=tykio/golang-cross:1.21-bookworm
+ARG BASE_IMAGE=tykio/golang-cross:1.21-bullseye
 FROM ${BASE_IMAGE}
 
 LABEL description="Image for plugin development"
@@ -13,8 +13,9 @@ ENV PLUGIN_SOURCE_PATH=/plugin-source
 
 RUN mkdir -p $TYK_GW_PATH $PLUGIN_SOURCE_PATH
 
-RUN apt-get remove -y --allow-remove-essential --auto-remove mercurial ruby* python* || true \
-	&& rm /usr/bin/passwd && rm /usr/sbin/adduser
+# remove for avoiding CVEs
+RUN apt-get purge -y --allow-remove-essential --auto-remove mercurial wget curl automake cmake python* docker* libsqlite* qemu* \
+	&& rm -f /usr/bin/passwd /usr/sbin/adduser /usr/bin/goreleaser
 
 ADD go.mod go.sum $TYK_GW_PATH
 WORKDIR $TYK_GW_PATH

--- a/ci/images/plugin-compiler/Taskfile.yml
+++ b/ci/images/plugin-compiler/Taskfile.yml
@@ -3,7 +3,7 @@ version: "3"
 
 vars:
   tag: v0.0.0
-  base: tykio/golang-cross:1.21-bookworm
+  image: internal/plugin-compiler
   sha:
     sh: git rev-parse HEAD
   root:
@@ -14,4 +14,10 @@ tasks:
     desc: "Build plugin compiler"
     dir: '{{.root}}'
     cmds:
-      - docker build --no-cache --progress=plain --build-arg GO_VERSION=1.21 --build-arg BASE_IMAGE={{.base}} --build-arg GITHUB_TAG={{.tag}} --build-arg GITHUB_SHA={{.sha}} --platform=linux/amd64 --rm -t internal/plugin-compiler -f ci/images/plugin-compiler/Dockerfile .
+      - docker build --no-cache --progress=plain --build-arg GO_VERSION=1.21 --build-arg GITHUB_TAG={{.tag}} --build-arg GITHUB_SHA={{.sha}} --platform=linux/amd64 --rm -t {{.image}} -f ci/images/plugin-compiler/Dockerfile .
+
+  test:
+    desc: "Run test docker image"
+    dir: '{{.root}}'
+    cmds:
+      - docker run -it --rm --platform=linux/amd64 --entrypoint=/bin/bash {{.image}}


### PR DESCRIPTION
## **User description**
Gateway uses bullseye for the build, while plugin compiler used bookworm. This resets the plugin compiler to use bullseye, as the build environment has to match for plugin compatibility.

This also removes unnecessary packages.

https://tyktech.atlassian.net/browse/TT-11925
https://tyktech.atlassian.net/browse/TT-11855

___

## **Type**
bug_fix


___

## **Description**
- The build environment for the plugin compiler has been updated to `1.21-bullseye` to match the gateway build environment, ensuring compatibility.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>plugin-compiler-build.yml</strong><dd><code>Update Plugin Compiler Build Environment to Match Gateway</code></dd></summary>
<hr>

.github/workflows/plugin-compiler-build.yml
<li>Updated the build environment for the plugin compiler to use <br><code>1.21-bullseye</code> instead of <code>1.21-bookworm</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6234/files#diff-f3a95a900eb0ac23af6314e9cdea29fa16af0a9bcb61793a83a32ff13d4c4e79">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

