### PR TITLE
Merging to master: [TT-11855] remove unnecessary packages resolving cve reports (#6223)

### DIFF
--- a/ci/images/plugin-compiler/Dockerfile
+++ b/ci/images/plugin-compiler/Dockerfile
@@ -13,11 +13,24 @@ ENV PLUGIN_SOURCE_PATH=/plugin-source
 
 RUN mkdir -p $TYK_GW_PATH $PLUGIN_SOURCE_PATH
 
+<<<<<<< HEAD
 RUN apt-get remove -y --allow-remove-essential --auto-remove mercurial ruby* python* || true \
 	&& rm /usr/bin/passwd && rm /usr/sbin/adduser
 
 ADD go.mod go.sum $TYK_GW_PATH
 WORKDIR $TYK_GW_PATH
+=======
+# remove for avoiding CVEs
+RUN apt-get purge -y --allow-remove-essential --auto-remove mercurial wget curl automake cmake ruby* python* docker* libsqlite* qemu* \
+	&& rm -f /usr/bin/passwd /usr/sbin/adduser /usr/bin/goreleaser
+
+# This is already vendored from release pipeline
+WORKDIR /opt/tyk-gateway/src
+ADD . /opt/tyk-gateway/src
+
+# TYK_GW_PATH points to the GOHOME source for gateway.
+ENV TYK_GW_PATH /go/src/github.com/TykTechnologies/tyk
+>>>>>>> 6f3540e34... [TT-11855] remove unnecessary packages resolving cve reports (#6223)
 
 RUN --mount=type=cache,mode=0755,target=/go/pkg/mod go mod download
 

--- a/ci/images/plugin-compiler/Taskfile.yml
+++ b/ci/images/plugin-compiler/Taskfile.yml
@@ -3,7 +3,11 @@ version: "3"
 
 vars:
   tag: v0.0.0
+<<<<<<< HEAD
   base: tykio/golang-cross:1.21-bookworm
+=======
+  image: internal/plugin-compiler
+>>>>>>> 6f3540e34... [TT-11855] remove unnecessary packages resolving cve reports (#6223)
   sha:
     sh: git rev-parse HEAD
   root:
@@ -11,7 +15,21 @@ vars:
 
 tasks:
   build:
+<<<<<<< HEAD
     desc: "Build plugin compiler"
     dir: '{{.root}}'
     cmds:
       - docker build --no-cache --progress=plain --build-arg GO_VERSION=1.21 --build-arg BASE_IMAGE={{.base}} --build-arg GITHUB_TAG={{.tag}} --build-arg GITHUB_SHA={{.sha}} --platform=linux/amd64 --rm -t internal/plugin-compiler -f ci/images/plugin-compiler/Dockerfile .
+=======
+    desc: "Build test docker image"
+    dir: '{{.root}}'
+    cmds:
+      - docker build --no-cache --progress=plain --build-arg GITHUB_TAG={{.tag}} --build-arg GITHUB_SHA={{.sha}} --platform=linux/amd64 --rm -t {{.image}} -f ci/images/plugin-compiler/Dockerfile .
+
+  test:
+    desc: "Run test docker image"
+    dir: '{{.root}}'
+    cmds:
+      - docker run -it --rm --platform=linux/amd64 --entrypoint=/bin/bash {{.image}}
+
+>>>>>>> 6f3540e34... [TT-11855] remove unnecessary packages resolving cve reports (#6223)


### PR DESCRIPTION
[TT-11855] remove unnecessary packages resolving cve reports (#6223)

This PR removes several packages and files not in use by the plugin
compiler:

- removes curl, wget, docker, cmake, automake (libcurl4)
- removes libcurl (partial, libcurl3 is required by git, git is required
for plugin compiler)
- removes libsqlite3-0 (not required by plugin compiler)
- removes qemu (not in use for plugin compiler)
- removes /usr/bin/goreleaser binary

Removing the packages resolves the reported CVEs against them. A
taskfile has been added for local testing with `task build`, `task test`
(inspect), and the docker image produced is used in CVE checks on local.

https://tyktech.atlassian.net/browse/TT-11855

---------

Co-authored-by: Tit Petric <tit@tyk.io>

[TT-11855]: https://tyktech.atlassian.net/browse/TT-11855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ