### PR TITLE
[TT-7325] PoC: Don't count blocked requests during sentinel key lifetime

### DIFF
--- a/gateway/session_manager.go
+++ b/gateway/session_manager.go
@@ -160,16 +160,16 @@ func (l *SessionLimiter) limitSentinel(currentSession *user.SessionState, key st
 		rateLimiterSentinelKey = RateLimitKeyPrefix + rateScope + key + SentinelRateLimitKeyPostfix
 	}
 
-	defer func() {
-		go l.doRollingWindowWrite(key, rateLimiterKey, rateLimiterSentinelKey, currentSession, store, globalConf, apiLimit, dryRun)
-	}()
-
 	// Check sentinel
 	_, sentinelActive := store.GetRawKey(rateLimiterSentinelKey)
 	if sentinelActive == nil {
 		// Sentinel is set, fail
 		return true
 	}
+
+	defer func() {
+		go l.doRollingWindowWrite(key, rateLimiterKey, rateLimiterSentinelKey, currentSession, store, globalConf, apiLimit, dryRun)
+	}()
 
 	return false
 }


### PR DESCRIPTION
## **User description**

PR contains two changes:

- sentinel rate limit blocks and doesn't count blocked requests until key expires
- copy of quota implementation to implement fixed window rate limit (ejects the default DRL/RRL case)

Not intended for merge, intended for test/demo purposes only.

https://tyktech.atlassian.net/browse/TT-7325

___

## **Type**
bug_fix


___

## **Description**
- Moved the deferred function call for `doRollingWindowWrite` to execute only if the sentinel key is not active. This prevents rate-limited requests from being counted when a sentinel key is set, aligning with the intended behavior of not counting blocked requests during the sentinel key's lifetime.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>session_manager.go</strong><dd><code>Modify deferred function call position in session limiter</code></dd></summary>
<hr>

gateway/session_manager.go
- Moved the deferred function call to after the sentinel key check.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6239/files#diff-e6b40a285464cd86736e970c4c0b320b44c75b18b363d38c200e9a9d36cdabb6">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

