### PR TITLE
fix panic in oas

### DIFF
--- a/gateway/api.go
+++ b/gateway/api.go
@@ -72,9 +72,7 @@ const (
 	oAuthClientTokensKeyPattern = "oauth-data.*oauth-client-tokens.*"
 )
 
-var (
-	ErrRequestMalformed = errors.New("request malformed")
-)
+var ErrRequestMalformed = errors.New("request malformed")
 
 // apiModifyKeySuccess represents when a Key modification was successful
 //
@@ -143,14 +141,12 @@ func doJSONWrite(w http.ResponseWriter, code int, obj interface{}) {
 }
 
 func doJSONExport(w http.ResponseWriter, code int, obj interface{}, fileName string) {
-
 	if code != http.StatusOK {
 		doJSONWrite(w, code, obj)
 		return
 	}
 
 	stream, err := json.MarshalIndent(obj, "", "  ")
-
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -165,7 +161,6 @@ func doJSONExport(w http.ResponseWriter, code int, obj interface{}, fileName str
 		job := instrument.NewJob("SystemAPIError")
 		job.Event(err.Error())
 	}
-
 }
 
 type MethodNotAllowedHandler struct{}
@@ -508,7 +503,7 @@ func (gw *Gateway) handleAddOrUpdate(keyName string, r *http.Request, isHashed b
 		keyName = gw.generateToken(newSession.OrgID, keyName)
 	}
 
-	//set the original expiry if the content in payload is a past time
+	// set the original expiry if the content in payload is a past time
 	if time.Now().After(time.Unix(newSession.Expires, 0)) && newSession.Expires > 1 {
 		newSession.Expires = originalKey.Expires
 	}
@@ -839,12 +834,10 @@ func (gw *Gateway) handleDeleteHashedKeyWithLogs(keyName, orgID, apiID string, r
 }
 
 func (gw *Gateway) handleDeleteHashedKey(keyName, orgID, apiID string, resetQuota bool) (interface{}, int) {
-
 	session, ok := gw.GlobalSessionManager.SessionDetail(orgID, keyName, true)
 	keyName = session.KeyID
 	if !ok {
 		return apiError("There is no such key found"), http.StatusNotFound
-
 	}
 
 	if apiID == "-1" {
@@ -939,7 +932,7 @@ func (gw *Gateway) handleAddOrUpdatePolicy(polID string, r *http.Request) (inter
 		return apiError("Marshalling failed"), http.StatusInternalServerError
 	}
 
-	if err := ioutil.WriteFile(polFilePath, asByte, 0644); err != nil {
+	if err := ioutil.WriteFile(polFilePath, asByte, 0o644); err != nil {
 		log.Error("Failed to create file! - ", err)
 		return apiError("Failed to create file!"), http.StatusInternalServerError
 	}
@@ -1039,10 +1032,10 @@ func (gw *Gateway) handleGetAPIOAS(apiID string, modePublic bool) (interface{}, 
 
 	obj, code := gw.handleGetAPI(apiID, true)
 	if apiOAS, ok := obj.(*oas.OAS); ok && modePublic {
-		apiOAS.RemoveTykExtension()
+		oasCopy := *apiOAS
+		oasCopy.RemoveTykExtension()
 	}
 	return obj, code
-
 }
 
 func (gw *Gateway) handleAddApi(r *http.Request, fs afero.Fs, oasEndpoint bool) (interface{}, int) {
@@ -1266,7 +1259,7 @@ func (gw *Gateway) writeToFile(fs afero.Fs, newDef interface{}, filename string)
 		return errors.New("marshalling failed"), http.StatusInternalServerError
 	}
 
-	if err := ioutil.WriteFile(defFilePath, asByte, 0644); err != nil {
+	if err := ioutil.WriteFile(defFilePath, asByte, 0o644); err != nil {
 		log.Infof("EL file path: %v", defFilePath)
 		log.Error("Failed to create file! - ", err)
 		return errors.New("file object creation failed, write error"), http.StatusInternalServerError
@@ -1503,7 +1496,6 @@ func (gw *Gateway) apiOASPatchHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	reqBodyInBytes, oasObj, err := extractOASObjFromReq(r.Body)
-
 	if err != nil {
 		doJSONWrite(w, http.StatusBadRequest, apiError(err.Error()))
 		return
@@ -2049,7 +2041,6 @@ func (gw *Gateway) createKeyHandler(w http.ResponseWriter, r *http.Request) {
 			doJSONWrite(w, http.StatusBadRequest, apiError("Failed to create key, keys must have at least one Access Rights record set."))
 			return
 		}
-
 	}
 
 	obj := apiModifyKeySuccess{
@@ -2484,7 +2475,6 @@ func (gw *Gateway) invalidateOauthRefresh(w http.ResponseWriter, r *http.Request
 }
 
 func (gw *Gateway) rotateOauthClientHandler(w http.ResponseWriter, r *http.Request) {
-
 	apiID := mux.Vars(r)["apiID"]
 	keyName := mux.Vars(r)["keyName"]
 
@@ -2498,7 +2488,7 @@ func (gw *Gateway) getApisForOauthApp(w http.ResponseWriter, r *http.Request) {
 	appID := mux.Vars(r)["appID"]
 	orgID := r.FormValue("orgID")
 
-	//get all organization apis
+	// get all organization apis
 	apisIds := gw.getApisIdsForOrg(orgID)
 
 	for index := range apisIds {
@@ -2717,12 +2707,14 @@ func (gw *Gateway) handleDeleteOAuthClient(keyName, apiID string) (interface{}, 
 	return apiError("OAuth Client ID not found"), http.StatusNotFound
 }
 
-const oAuthNotPropagatedErr = "OAuth client list isn't available or hasn't been propagated yet."
-const oAuthClientNotFound = "OAuth client not found"
-const oauthClientIdEmpty = "client_id is required"
-const oauthClientSecretEmpty = "client_secret is required"
-const oauthClientSecretWrong = "client secret is wrong"
-const oauthTokenEmpty = "token is required"
+const (
+	oAuthNotPropagatedErr  = "OAuth client list isn't available or hasn't been propagated yet."
+	oAuthClientNotFound    = "OAuth client not found"
+	oauthClientIdEmpty     = "client_id is required"
+	oauthClientSecretEmpty = "client_secret is required"
+	oauthClientSecretWrong = "client secret is wrong"
+	oauthTokenEmpty        = "token is required"
+)
 
 func (gw *Gateway) getApiClients(apiID string) ([]ExtendedOsinClientInterface, apiStatusMessage, int) {
 	var err error
@@ -2759,7 +2751,6 @@ func (gw *Gateway) getApiClients(apiID string) ([]ExtendedOsinClientInterface, a
 
 // List Clients
 func (gw *Gateway) getOauthClients(apiID string) (interface{}, int) {
-
 	clientData, _, apiStatusCode := gw.getApiClients(apiID)
 
 	if apiStatusCode != 200 {
@@ -2872,7 +2863,6 @@ func (gw *Gateway) invalidateCacheHandler(w http.ResponseWriter, r *http.Request
 
 func (gw *Gateway) RevokeTokenHandler(w http.ResponseWriter, r *http.Request) {
 	err := r.ParseForm()
-
 	if err != nil {
 		doJSONWrite(w, http.StatusBadRequest, apiError("cannot parse form. Form malformed"))
 		return
@@ -2937,7 +2927,6 @@ func (gw *Gateway) GetStorageForApi(apiID string) (ExtendedOsinStorageInterface,
 
 func (gw *Gateway) RevokeAllTokensHandler(w http.ResponseWriter, r *http.Request) {
 	err := r.ParseForm()
-
 	if err != nil {
 		doJSONWrite(w, http.StatusBadRequest, apiError("cannot parse form. Form malformed"))
 		return
@@ -2959,7 +2948,7 @@ func (gw *Gateway) RevokeAllTokensHandler(w http.ResponseWriter, r *http.Request
 
 	apis := gw.getApisForOauthClientId(clientId, orgId)
 	if len(apis) == 0 {
-		//if api is 0 is because the client wasn't found
+		// if api is 0 is because the client wasn't found
 		doJSONWrite(w, http.StatusNotFound, apiError("oauth client doesn't exist"))
 		return
 	}
@@ -2986,7 +2975,6 @@ func (gw *Gateway) RevokeAllTokensHandler(w http.ResponseWriter, r *http.Request
 func (gw *Gateway) validateOAS(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		reqBodyInBytes, oasObj, err := extractOASObjFromReq(r.Body)
-
 		if err != nil {
 			doJSONWrite(w, http.StatusBadRequest, apiError(err.Error()))
 			return
@@ -3070,6 +3058,7 @@ func setContext(r *http.Request, ctx context.Context) {
 	r2 := r.WithContext(ctx)
 	*r = *r2
 }
+
 func setCtxValue(r *http.Request, key, val interface{}) {
 	setContext(r, context.WithValue(r.Context(), key, val))
 }
@@ -3420,7 +3409,6 @@ var createOauthClientSecret = func() string {
 
 // invalidate tokens if we had a new policy
 func invalidateTokens(prevClient ExtendedOsinClientInterface, updatedClient OAuthClient, oauthManager *OAuthManager) {
-
 	if prevPolicy := prevClient.GetPolicyID(); prevPolicy != "" && prevPolicy != updatedClient.PolicyID {
 		tokenList, err := oauthManager.OsinServer.Storage.GetClientTokens(updatedClient.ClientID)
 		if err != nil {


### PR DESCRIPTION
## **User description**
[TT-11960]
Since we return a pointer. When deleting x-tyk-gateway in OAS we get a panic due to a race condition.

[TT-11960]: https://tyktech.atlassian.net/browse/TT-11960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

## **Type**
Bug fix, Enhancement


___

## **Description**
- Fixed a race condition in `handleGetAPIOAS` that caused a panic by modifying the `apiOAS` directly. Now, a copy is made before any modifications.
- Improved readability and maintainability of the code by enhancing comments and formatting.
- Consolidated error constants into a single block for better organization and clarity.
- Updated file permission settings to use octal notation, aligning with Go's best practices.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api.go</strong><dd><code>Fix Panic in OAS Handling and Improve Code Quality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api.go
<li>Fixed a panic in <code>handleGetAPIOAS</code> by creating a copy of <code>apiOAS</code> before <br>modification.<br> <li> Improved code formatting and comments for better readability.<br> <li> Updated error constants to be grouped under a single <code>const</code> block.<br> <li> Changed file permission notation to octal in <code>ioutil.WriteFile</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6242/files#diff-644cda3aeb4ac7f325359e85fcddb810f100dd5e6fa480b0d9f9363a743c4e05">+17/-29</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

