### PR TITLE
[TT-5790] Update EnsureTransport and related tests

### DIFF
--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -124,21 +124,26 @@ func urlFromService(spec *APISpec, gw *Gateway) (*apidef.HostList, error) {
 // httpScheme matches http://* and https://*, case insensitive
 var httpScheme = regexp.MustCompile(`^(?i)https?://`)
 
+// EnsureTransport sanitizes host/protocol pairs and returns a valid URL.
 func EnsureTransport(host, protocol string) string {
 	host = strings.TrimSpace(host)
 	protocol = strings.TrimSpace(protocol)
+
+	// sanitize protocol
+	if protocol == "" {
+		protocol = "http"
+	}
+
+	// if host has no protocol, amend it
+	if !strings.Contains(host, "://") {
+		host = protocol + "://" + host
+	}
+
+	host = strings.Replace(host, "h2c://", "http://", 1)
+
 	u, err := url.Parse(host)
 	if err != nil {
 		return host
-	}
-	switch u.Scheme {
-	case "":
-		if protocol == "" {
-			protocol = "http"
-		}
-		u.Scheme = protocol
-	case "h2c":
-		u.Scheme = "http"
 	}
 	return u.String()
 }

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -1585,6 +1585,23 @@ func TestEnsureTransport(t *testing.T) {
 	cases := []struct {
 		host, protocol, expect string
 	}{
+		// This section tests EnsureTransport if port + IP is supplied
+		{"https://192.168.1.1:443 ", "https", "https://192.168.1.1:443"},
+		{"192.168.1.1:443 ", "https", "https://192.168.1.1:443"},
+		{"http://192.168.1.1:80 ", "https", "http://192.168.1.1:80"},
+		{"192.168.1.1:2000 ", "tls", "tls://192.168.1.1:2000"},
+		{"192.168.1.1:2000 ", "", "http://192.168.1.1:2000"},
+		// This section tests EnsureTransport if port is supplied
+		{"https://httpbin.org:443 ", "https", "https://httpbin.org:443"},
+		{"httpbin.org:443 ", "https", "https://httpbin.org:443"},
+		{"http://httpbin.org:80 ", "https", "http://httpbin.org:80"},
+		{"httpbin.org:2000 ", "tls", "tls://httpbin.org:2000"},
+		{"httpbin.org:2000 ", "", "http://httpbin.org:2000"},
+		// This is the h2c proto to http conversion
+		{"http://httpbin.org ", "h2c", "http://httpbin.org"},
+		{"h2c://httpbin.org ", "h2c", "http://httpbin.org"},
+		{"httpbin.org ", "h2c", "http://httpbin.org"},
+		// This is the default parse section
 		{"https://httpbin.org ", "https", "https://httpbin.org"},
 		{"httpbin.org ", "https", "https://httpbin.org"},
 		{"http://httpbin.org ", "https", "http://httpbin.org"},
@@ -1594,9 +1611,11 @@ func TestEnsureTransport(t *testing.T) {
 	for i, v := range cases {
 		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
 			g := EnsureTransport(v.host, v.protocol)
-			if g != v.expect {
-				t.Errorf("expected %q got %q", v.expect, g)
-			}
+
+			assert.Equal(t, v.expect, g)
+
+			_, err := url.Parse(g)
+			assert.NoError(t, err)
 		})
 	}
 }


### PR DESCRIPTION
## **User description**
Several tests encountered parsing errors where the URL parser complained that "the first path segment in URL cannot contain colon". This occurred because the URLs were missing the scheme (e.g., `http://`) and couldn't be parsed.

This PR improves EnsureTransport to better construct a valid URL from the `host` and `protocol` parameters.

- Improves test with more test cases for IP:port and protocol pairs
- Verifies intended behaviour with h2c URL parsing (coalescing to http scheme) with a unit test

https://tyktech.atlassian.net/browse/TT-5790

___

## **Type**
enhancement, tests


___

## **Description**
- Refactored `EnsureTransport` to automatically handle missing protocols by defaulting to "http" and to prepend the protocol if it's missing in the host string.
- Removed outdated switch-case logic in `EnsureTransport`, simplifying the URL scheme handling.
- Expanded unit tests in `reverse_proxy_test.go` to cover new scenarios including IP addresses with ports, and protocol handling.
- Improved test assertions to use `assert.Equal` and added checks to ensure URLs are parsable after processing.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reverse_proxy.go</strong><dd><code>Refactor EnsureTransport to handle URL schemes more robustly</code></dd></summary>
<hr>

gateway/reverse_proxy.go
<li>Added logic to <code>EnsureTransport</code> to handle missing protocols by <br>defaulting to "http".<br> <li> Amended the function to prepend protocol if missing in the host <br>string.<br> <li> Replaced specific scheme handling with a more generic approach.<br> <li> Removed old switch-case logic that handled schemes.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6243/files#diff-e6e07722257f7e41691e471185ad6d84fd56dc9e5459526ea32e9a5e8fa1a01b">+14/-9</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reverse_proxy_test.go</strong><dd><code>Extend tests for EnsureTransport with more scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/reverse_proxy_test.go
<li>Expanded test cases for <code>EnsureTransport</code> to cover scenarios with IP <br>addresses and ports.<br> <li> Added tests for default protocol handling and h2c to http conversion.<br> <li> Replaced error checks with <code>assert.Equal</code> and added URL parse <br>verification.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6243/files#diff-ce040f6555143f760fba6059744bc600b6954f0966dfb0fa2832b5eabf7a3c3f">+22/-3</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

