### PR TITLE
[TT-11739] Clean up rate limiting area, decouple GlobalConfig in APISpec

### DIFF
--- a/config/rate_limit.go
+++ b/config/rate_limit.go
@@ -10,7 +10,7 @@ type RateLimit struct {
 	// EnableFixedWindow enables fixed window rate limiting.
 	EnableFixedWindowRateLimiter bool `json:"enable_fixed_window_rate_limiter"`
 
-	// Redis based rate limiter with fixed window. Provides 100% rate limiting accuracy, but require two additional Redis roundtrip for each request.
+	// Redis based rate limiter with sliding log. Provides 100% rate limiting accuracy, but require two additional Redis roundtrip for each request.
 	EnableRedisRollingLimiter bool `json:"enable_redis_rolling_limiter"`
 
 	// To enable, set to `true`. The sentinel-based rate limiter delivers a smoother performance curve as rate-limit calculations happen off-thread, but a stricter time-out based cool-down for clients. For example, when a throttling action is triggered, they are required to cool-down for the period of the rate limit.

--- a/gateway/mw_api_rate_limit.go
+++ b/gateway/mw_api_rate_limit.go
@@ -77,7 +77,6 @@ func (k *RateLimitForAPI) ProcessRequest(w http.ResponseWriter, r *http.Request,
 		storeRef,
 		true,
 		false,
-		&k.Spec.GlobalConfig,
 		k.Spec,
 		false,
 	)

--- a/gateway/mw_api_rate_limit.go
+++ b/gateway/mw_api_rate_limit.go
@@ -71,7 +71,9 @@ func (k *RateLimitForAPI) ProcessRequest(w http.ResponseWriter, r *http.Request,
 	storeRef := k.Gw.GlobalSessionManager.Store()
 	customQuotaKey := ""
 
-	reason := k.Gw.SessionLimiter.ForwardMessage(r, k.apiSess,
+	reason := k.Gw.SessionLimiter.ForwardMessage(
+		r,
+		k.apiSess,
 		k.keyName,
 		customQuotaKey,
 		storeRef,

--- a/gateway/mw_js_plugin.go
+++ b/gateway/mw_js_plugin.go
@@ -166,7 +166,7 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 
 	specAsJson := specToJson(d.Spec)
 
-	session := new(user.SessionState)
+	session := &user.SessionState{}
 
 	// Encode the session object (if not a pre-process)
 	if !d.Pre && d.UseSession {

--- a/gateway/mw_js_plugin_test.go
+++ b/gateway/mw_js_plugin_test.go
@@ -905,11 +905,15 @@ func TestMiniRequestObject_ReconstructParams(t *testing.T) {
 
 func TestJSVM_Auth(t *testing.T) {
 	for _, hashKeys := range []bool{true, false} {
-		testJSVM_Auth(t, hashKeys)
+		t.Run(fmt.Sprintf("hashKeys=%v", hashKeys), func(t *testing.T) {
+			testJSVM_Auth(t, hashKeys)
+		})
 	}
 }
 
 func testJSVM_Auth(t *testing.T, hashKeys bool) {
+	t.Helper()
+
 	ts := StartTest(func(c *config.Config) {
 		c.HashKeys = hashKeys
 	})

--- a/gateway/mw_organisation_activity.go
+++ b/gateway/mw_organisation_activity.go
@@ -113,7 +113,6 @@ func (k *OrganizationMonitor) ProcessRequestLive(r *http.Request, orgSession *us
 		k.Spec.OrgSessionManager.Store(),
 		orgSession.Per > 0 && orgSession.Rate > 0,
 		true,
-		&k.Spec.GlobalConfig,
 		k.Spec,
 		false,
 	)
@@ -248,7 +247,6 @@ func (k *OrganizationMonitor) AllowAccessNext(
 		k.Spec.OrgSessionManager.Store(),
 		session.Per > 0 && session.Rate > 0,
 		true,
-		&k.Spec.GlobalConfig,
 		k.Spec,
 		false,
 	)

--- a/gateway/mw_rate_limiting.go
+++ b/gateway/mw_rate_limiting.go
@@ -91,7 +91,6 @@ func (k *RateLimitAndQuotaCheck) ProcessRequest(w http.ResponseWriter, r *http.R
 		storeRef,
 		!k.Spec.DisableRateLimit,
 		!k.Spec.DisableQuota,
-		&k.Spec.GlobalConfig,
 		k.Spec,
 		false,
 	)
@@ -125,7 +124,6 @@ func (k *RateLimitAndQuotaCheck) ProcessRequest(w http.ResponseWriter, r *http.R
 					storeRef,
 					!k.Spec.DisableRateLimit,
 					!k.Spec.DisableQuota,
-					&k.Spec.GlobalConfig,
 					k.Spec,
 					true,
 				)

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -1850,7 +1850,7 @@ func handleDashboardRegistration(gw *Gateway) {
 func (gw *Gateway) startDRL() {
 	gwConfig := gw.GetConfig()
 
-	disabled := gwConfig.ManagementNode || gwConfig.EnableSentinelRateLimiter || gw.GetConfig().EnableRedisRollingLimiter
+	disabled := gwConfig.ManagementNode || gwConfig.EnableSentinelRateLimiter || gwConfig.EnableRedisRollingLimiter || gwConfig.EnableFixedWindowRateLimiter
 
 	gw.drlOnce.Do(func() {
 		drlManager := &drl.DRL{}

--- a/gateway/session_manager.go
+++ b/gateway/session_manager.go
@@ -34,8 +34,10 @@ const (
 	// QuotaKeyPrefix serves as a standard prefix for generating quota keys.
 	QuotaKeyPrefix = "quota-"
 
+	// RateLimitKeyPrefix serves as a standard prefix for generating rate limiter keys.
 	RateLimitKeyPrefix = rate.LimiterKeyPrefix
 
+	// SentinelRateLimitKeyPostfix is appended to the rate limiting key to combine into a sentinel key.
 	SentinelRateLimitKeyPostfix = ".BLOCKED"
 )
 

--- a/gateway/session_manager.go
+++ b/gateway/session_manager.go
@@ -295,7 +295,7 @@ func (l *SessionLimiter) ForwardMessage(r *http.Request, currentSession *user.Se
 
 }
 
-func (l *SessionLimiter) RedisQuotaExceeded(r *http.Request, currentSession *user.SessionState, quotaKey string, scope string, limit *user.APILimit, store storage.Handler, hashKeys bool) bool {
+func (l *SessionLimiter) RedisQuotaExceeded(r *http.Request, currentSession *user.SessionState, quotaKey, scope string, limit *user.APILimit, store storage.Handler, hashKeys bool) bool {
 	// Unlimited?
 	if limit.QuotaMax == -1 || limit.QuotaMax == 0 {
 		// No quota set

--- a/gateway/session_manager.go
+++ b/gateway/session_manager.go
@@ -160,16 +160,16 @@ func (l *SessionLimiter) limitSentinel(currentSession *user.SessionState, key st
 		rateLimiterSentinelKey = RateLimitKeyPrefix + rateScope + key + SentinelRateLimitKeyPostfix
 	}
 
-	defer func() {
-		go l.doRollingWindowWrite(key, rateLimiterKey, rateLimiterSentinelKey, currentSession, store, globalConf, apiLimit, dryRun)
-	}()
-
 	// Check sentinel
 	_, sentinelActive := store.GetRawKey(rateLimiterSentinelKey)
 	if sentinelActive == nil {
 		// Sentinel is set, fail
 		return true
 	}
+
+	defer func() {
+		go l.doRollingWindowWrite(key, rateLimiterKey, rateLimiterSentinelKey, currentSession, store, globalConf, apiLimit, dryRun)
+	}()
 
 	return false
 }

--- a/internal/rate/limiter.go
+++ b/internal/rate/limiter.go
@@ -38,8 +38,9 @@ func LimiterKey(currentSession *user.SessionState, allowanceScope string, key st
 		rateScope = allowanceScope + "-"
 	}
 
-	if useCustomKey {
-		return Prefix(LimiterKeyPrefix, rateScope, key)
+	if !useCustomKey && !currentSession.KeyHashEmpty() {
+		return Prefix(LimiterKeyPrefix, rateScope, currentSession.KeyHash())
 	}
-	return Prefix(LimiterKeyPrefix, rateScope, currentSession.KeyHash())
+
+	return Prefix(LimiterKeyPrefix, rateScope, key)
 }

--- a/internal/rate/limiter.go
+++ b/internal/rate/limiter.go
@@ -14,16 +14,16 @@ func Limiter(gwConfig *config.Config, redis redis.UniversalClient) limiter.Limit
 		return nil
 	}
 
-	res := limiter.NewLimiter(name, redis)
+	res := limiter.NewLimiter(redis)
 
-	switch {
-	case name == LimitLeakyBucket:
+	switch name {
+	case LimitLeakyBucket:
 		return res.LeakyBucket
-	case name == LimitTokenBucket:
+	case LimitTokenBucket:
 		return res.TokenBucket
-	case name == LimitFixedWindow:
+	case LimitFixedWindow:
 		return res.FixedWindow
-	case name == LimitSlidingWindow:
+	case LimitSlidingWindow:
 		return res.SlidingWindow
 	}
 

--- a/internal/rate/limiter/limiter.go
+++ b/internal/rate/limiter/limiter.go
@@ -2,7 +2,6 @@ package limiter
 
 import (
 	"context"
-	"strings"
 
 	"github.com/TykTechnologies/exp/pkg/limiters"
 
@@ -12,8 +11,7 @@ import (
 var ErrLimitExhausted = limiters.ErrLimitExhausted
 
 type Limiter struct {
-	prefix string
-	redis  redis.UniversalClient
+	redis redis.UniversalClient
 
 	lock   limiters.DistLocker
 	logger limiters.Logger
@@ -22,9 +20,8 @@ type Limiter struct {
 
 type LimiterFunc func(ctx context.Context, key string, rate float64, per float64) error
 
-func NewLimiter(prefix string, redis redis.UniversalClient) *Limiter {
+func NewLimiter(redis redis.UniversalClient) *Limiter {
 	return &Limiter{
-		prefix: prefix,
 		redis:  redis,
 		lock:   limiters.NewLockNoop(),
 		logger: limiters.NewStdLogger(),
@@ -34,26 +31,4 @@ func NewLimiter(prefix string, redis redis.UniversalClient) *Limiter {
 
 func (l *Limiter) redisLock(name string) limiters.DistLocker {
 	return limiters.NewLockRedis(redis.NewPool(l.redis), name+"-lock")
-}
-
-func Prefix(params ...string) string {
-	var res strings.Builder
-	var written int
-
-	for _, p := range params {
-		p = strings.Trim(p, "-")
-		if p == "" {
-			continue
-		}
-
-		if written == 0 {
-			res.Write([]byte(p))
-			written++
-			continue
-		}
-
-		res.Write([]byte("-"))
-		res.Write([]byte(p))
-	}
-	return res.String()
 }

--- a/internal/rate/limiter/limiter.go
+++ b/internal/rate/limiter/limiter.go
@@ -41,6 +41,7 @@ func Prefix(params ...string) string {
 	var written int
 
 	for _, p := range params {
+		p = strings.Trim(p, "-")
 		if p == "" {
 			continue
 		}

--- a/internal/rate/limiter/limiter_fixed_window.go
+++ b/internal/rate/limiter/limiter_fixed_window.go
@@ -15,12 +15,10 @@ func (l *Limiter) FixedWindow(ctx context.Context, key string, rate float64, per
 		ttl      = time.Duration(per * float64(time.Second))
 	)
 
-	rateLimitPrefix := Prefix(l.prefix, key)
-
 	if l.redis != nil {
-		storage = limiters.NewFixedWindowRedis(l.redis, rateLimitPrefix)
+		storage = limiters.NewFixedWindowRedis(l.redis, key)
 	} else {
-		storage = limiters.LocalFixedWindow(rateLimitPrefix)
+		storage = limiters.LocalFixedWindow(key)
 	}
 
 	limiter := limiters.NewFixedWindow(capacity, ttl, storage, l.clock)

--- a/internal/rate/limiter/limiter_leaky_bucket.go
+++ b/internal/rate/limiter/limiter_leaky_bucket.go
@@ -18,14 +18,12 @@ func (l *Limiter) LeakyBucket(ctx context.Context, key string, rate float64, per
 		raceCheck  = false
 	)
 
-	rateLimitPrefix := Prefix(l.prefix, key)
-
 	if l.redis != nil {
-		locker = l.redisLock(l.prefix)
-		storage = limiters.NewLeakyBucketRedis(l.redis, rateLimitPrefix, ttl, raceCheck)
+		locker = l.redisLock(key)
+		storage = limiters.NewLeakyBucketRedis(l.redis, key, ttl, raceCheck)
 	} else {
 		locker = l.lock
-		storage = limiters.LocalLeakyBucket(rateLimitPrefix)
+		storage = limiters.LocalLeakyBucket(key)
 	}
 
 	limiter := limiters.NewLeakyBucket(capacity, outputRate, locker, storage, l.clock, l.logger)

--- a/internal/rate/limiter/limiter_sliding_window.go
+++ b/internal/rate/limiter/limiter_sliding_window.go
@@ -15,12 +15,10 @@ func (l *Limiter) SlidingWindow(ctx context.Context, key string, rate float64, p
 		ttl      = time.Duration(per * float64(time.Second))
 	)
 
-	rateLimitPrefix := Prefix(l.prefix, key)
-
 	if l.redis != nil {
-		storage = limiters.NewSlidingWindowRedis(l.redis, rateLimitPrefix)
+		storage = limiters.NewSlidingWindowRedis(l.redis, key)
 	} else {
-		storage = limiters.LocalSlidingWindow(rateLimitPrefix)
+		storage = limiters.LocalSlidingWindow(key)
 	}
 
 	// TODO: when doing rate sliding rate limits, the counts for two windows are

--- a/internal/rate/limiter/limiter_token_bucket.go
+++ b/internal/rate/limiter/limiter_token_bucket.go
@@ -17,14 +17,12 @@ func (l *Limiter) TokenBucket(ctx context.Context, key string, rate float64, per
 		raceCheck = false
 	)
 
-	rateLimitPrefix := Prefix(l.prefix, key)
-
 	if l.redis != nil {
-		locker = l.redisLock(l.prefix)
-		storage = limiters.NewTokenBucketRedis(l.redis, rateLimitPrefix, ttl, raceCheck)
+		locker = l.redisLock(key)
+		storage = limiters.NewTokenBucketRedis(l.redis, key, ttl, raceCheck)
 	} else {
 		locker = l.lock
-		storage = limiters.LocalTokenBucket(rateLimitPrefix)
+		storage = limiters.LocalTokenBucket(key)
 	}
 
 	limiter := limiters.NewTokenBucket(capacity, ttl, locker, storage, l.clock, l.logger)

--- a/internal/rate/rate.go
+++ b/internal/rate/rate.go
@@ -5,8 +5,11 @@ import (
 )
 
 var (
+	// ErrLimitExhausted is returned when the request should be blocked.
 	ErrLimitExhausted = limiter.ErrLimitExhausted
-	Prefix            = limiter.Prefix
+
+	// Prefix is a utility function to generate rate limiter redis key names.
+	Prefix = limiter.Prefix
 )
 
 // The following constants enumerate implemented rate limiters.

--- a/internal/rate/rate.go
+++ b/internal/rate/rate.go
@@ -1,15 +1,14 @@
 package rate
 
 import (
+	"strings"
+
 	"github.com/TykTechnologies/tyk/internal/rate/limiter"
 )
 
 var (
 	// ErrLimitExhausted is returned when the request should be blocked.
 	ErrLimitExhausted = limiter.ErrLimitExhausted
-
-	// Prefix is a utility function to generate rate limiter redis key names.
-	Prefix = limiter.Prefix
 )
 
 // The following constants enumerate implemented rate limiters.
@@ -24,3 +23,26 @@ const (
 	// LimiterKeyPrefix serves as a standard prefix for generating rate limit keys.
 	LimiterKeyPrefix = "rate-limit-"
 )
+
+// Prefix is a utility function to generate rate limiter redis key names.
+func Prefix(params ...string) string {
+	var res strings.Builder
+	var written int
+
+	for _, p := range params {
+		p = strings.Trim(p, "-")
+		if p == "" {
+			continue
+		}
+
+		if written == 0 {
+			res.Write([]byte(p))
+			written++
+			continue
+		}
+
+		res.Write([]byte("-"))
+		res.Write([]byte(p))
+	}
+	return res.String()
+}

--- a/internal/rate/rate.go
+++ b/internal/rate/rate.go
@@ -4,13 +4,20 @@ import (
 	"github.com/TykTechnologies/tyk/internal/rate/limiter"
 )
 
-var ErrLimitExhausted = limiter.ErrLimitExhausted
+var (
+	ErrLimitExhausted = limiter.ErrLimitExhausted
+	Prefix            = limiter.Prefix
+)
 
-var Prefix = limiter.Prefix
-
+// The following constants enumerate implemented rate limiters.
 const (
 	LimitLeakyBucket   string = "leaky-bucket"
 	LimitTokenBucket   string = "token-bucket"
 	LimitFixedWindow   string = "fixed-window"
 	LimitSlidingWindow string = "sliding-window"
+)
+
+const (
+	// LimiterKeyPrefix serves as a standard prefix for generating rate limit keys.
+	LimiterKeyPrefix = "rate-limit-"
 )


### PR DESCRIPTION
### **User description**

Clean up refactor of rate limits area:

- use rate limiter config object (apispec.GlobalConfig dropped)
- moved rate limiter key computation to happen before rate limiter logic, deduplicate
- minimized passed arguments

Fixing bugs:

- fixes new rate limiter not proceeding to quota to maintain existing behaviour
- key computation on new rate limiter now consistent with others (`rate-` prefix)

https://tyktech.atlassian.net/browse/TT-11739

___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Decoupled `GlobalConfig` from various rate limiting and quota management functions across multiple files to enhance modularity.
- Centralized rate limiter key prefix usage and standardized key generation logic.
- Removed redundant parameters and streamlined logic in session management and rate limiting functions.
- Added new utility functions to manage rate limiter configurations and key generation more effectively.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mw_api_rate_limit.go</strong><dd><code>Simplify API Rate Limiting Logic and Decouple Global Config</code></dd></summary>
<hr>

gateway/mw_api_rate_limit.go
<li>Removed reference to <code>GlobalConfig</code> from rate limiting logic.<br> <li> Simplified function arguments by removing unnecessary parameters.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6262/files#diff-46326b04f936c839922e970db5c2924156cc797070948f3dc9c589d04661d6d2">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_organisation_activity.go</strong><dd><code>Refactor Organisation Activity Rate Limiting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_organisation_activity.go
<li>Removed <code>GlobalConfig</code> references in rate limiting checks.<br> <li> Streamlined function parameters to enhance clarity and <br>maintainability.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6262/files#diff-26dd955903317b085be06642ae3e76fe41c8c53844d8758a1a1c8bd05b0110a2">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_rate_limiting.go</strong><dd><code>Refactor Rate Limiting and Quota Checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_rate_limiting.go
<li>Decoupled <code>GlobalConfig</code> from rate limiting and quota checks.<br> <li> Consolidated rate limiting key computation logic.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6262/files#diff-4bf8ae01ccab67bb786468f793f6bb4324c8f6b950b0e98e203effebe763a630">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>session_manager.go</strong><dd><code>Centralize Rate Limiter Key Prefix and Optimize Session Limiter</code></dd></summary>
<hr>

gateway/session_manager.go
<li>Centralized rate limiter key prefix to <code>rate.LimiterKeyPrefix</code>.<br> <li> Optimized session limiter functions by removing redundant parameters <br>and simplifying logic.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6262/files#diff-e6b40a285464cd86736e970c4c0b320b44c75b18b363d38c200e9a9d36cdabb6">+42/-74</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>limiter.go</strong><dd><code>Enhance Rate Limiter Configuration and Key Generation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/rate/limiter.go
<li>Added <code>LimiterKey</code> function to standardize rate limiter key generation.<br> <li> Enhanced modularity by separating limiter configuration logic.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6262/files#diff-84e3fda0965028c6e464ae0916aaef0af63d0367fde6f910b513a610f2a34ee5">+16/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rate.go</strong><dd><code>Update Constants and Error Handling for Rate Limiters</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/rate/rate.go
<li>Introduced <code>LimiterKeyPrefix</code> for consistent key naming.<br> <li> Updated constants and error handling for rate limiters.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6262/files#diff-666e0b0c32c831ededfd6c780dbf916d10e4b7d9c8e02f157bf1dca1d58a360d">+10/-3</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

