### PR TITLE
readable duration

### DIFF
--- a/apidef/oas/event_test.go
+++ b/apidef/oas/event_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/internal/event"
+	"github.com/TykTechnologies/tyk/internal/time"
 )
 
 func TestEventHandlers(t *testing.T) {
@@ -33,7 +34,7 @@ func TestEventHandlers(t *testing.T) {
 							URL:            "https://webhook.site/uuid",
 							Headers:        Headers{{Name: "Auth", Value: "key"}},
 							BodyTemplate:   "/path/to/template",
-							CoolDownPeriod: "20s",
+							CoolDownPeriod: time.ReadableDuration(time.Second * 20),
 							Method:         http.MethodPost,
 						},
 					},
@@ -47,7 +48,7 @@ func TestEventHandlers(t *testing.T) {
 							URL:            "https://webhook.site/uuid",
 							Headers:        Headers{{Name: "Auth", Value: "key"}},
 							BodyTemplate:   "/path/to/template",
-							CoolDownPeriod: "20s",
+							CoolDownPeriod: time.ReadableDuration(time.Second * 20),
 							Method:         http.MethodPost,
 						},
 					},
@@ -100,7 +101,7 @@ func TestEventHandlers(t *testing.T) {
 							URL:            "https://webhook.site/uuid",
 							Headers:        Headers{{Name: "Auth", Value: "key"}},
 							BodyTemplate:   "/path/to/template",
-							CoolDownPeriod: "20s",
+							CoolDownPeriod: time.ReadableDuration(time.Second * 20),
 							Method:         http.MethodPost,
 						},
 					},
@@ -180,7 +181,7 @@ func TestEventHandlers(t *testing.T) {
 							URL:            "https://webhook.site/uuid",
 							Headers:        Headers{{Name: "Auth", Value: "key"}},
 							BodyTemplate:   "/path/to/template",
-							CoolDownPeriod: "20s",
+							CoolDownPeriod: time.ReadableDuration(time.Second * 20),
 							Method:         http.MethodPost,
 						},
 					},
@@ -194,7 +195,7 @@ func TestEventHandlers(t *testing.T) {
 							URL:            "https://webhook.site/uuid",
 							Headers:        Headers{{Name: "Auth", Value: "key"}},
 							BodyTemplate:   "/path/to/template",
-							CoolDownPeriod: "20s",
+							CoolDownPeriod: time.ReadableDuration(time.Second * 20),
 							Method:         http.MethodPost,
 						},
 					},
@@ -234,7 +235,7 @@ func TestEventHandler_MarshalJSON(t *testing.T) {
 			URL:            "https://webhook.site/uuid",
 			Headers:        Headers{{Name: "Auth", Value: "key"}},
 			BodyTemplate:   "/path/to/template",
-			CoolDownPeriod: "20s",
+			CoolDownPeriod: time.ReadableDuration(time.Second * 20),
 			Method:         http.MethodPost,
 		},
 	}
@@ -299,7 +300,7 @@ func TestEventHandler_UnmarshalJSON(t *testing.T) {
 			URL:            "https://webhook.site/uuid",
 			Headers:        Headers{{Name: "Auth", Value: "key"}},
 			BodyTemplate:   "/path/to/template",
-			CoolDownPeriod: "20s",
+			CoolDownPeriod: time.ReadableDuration(time.Second * 20),
 			Method:         http.MethodPost,
 		},
 	}

--- a/apidef/oas/linter_test.go
+++ b/apidef/oas/linter_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 
 	"github.com/TykTechnologies/tyk/internal/event"
+	"github.com/TykTechnologies/tyk/internal/time"
 )
 
 func TestXTykGateway_Lint(t *testing.T) {
@@ -71,14 +72,14 @@ func TestXTykGateway_Lint(t *testing.T) {
 			settings.Server.EventHandlers[i].Kind = event.WebhookKind
 			settings.Server.EventHandlers[i].Webhook.Method = http.MethodPost
 			settings.Server.EventHandlers[i].Trigger = event.QuotaExceeded
-			settings.Server.EventHandlers[i].Webhook.CoolDownPeriod = "20s"
+			settings.Server.EventHandlers[i].Webhook.CoolDownPeriod = time.ReadableDuration(time.Second * 20)
 		}
 
 		for idx, _ := range settings.Middleware.Operations {
 			settings.Middleware.Operations[idx].CircuitBreaker.Threshold = 0.5
 		}
 
-		settings.Upstream.RateLimit.Per = "10s"
+		settings.Upstream.RateLimit.Per = time.ReadableDuration(10 * time.Second)
 	}
 
 	// Encode data to json

--- a/apidef/oas/time.go
+++ b/apidef/oas/time.go
@@ -1,0 +1,6 @@
+package oas
+
+import "github.com/TykTechnologies/tyk/internal/time"
+
+// ReadableDuration is an alias maintained to be used in imports.
+type ReadableDuration = time.ReadableDuration

--- a/apidef/oas/upstream_test.go
+++ b/apidef/oas/upstream_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/internal/time"
 )
 
 func TestCacheOptions(t *testing.T) {
@@ -114,7 +115,7 @@ func TestUpstream(t *testing.T) {
 				RateLimit: &RateLimit{
 					Enabled: true,
 					Rate:    10,
-					Per:     "1h20m10s",
+					Per:     time.ReadableDuration(time.Hour + 20*time.Minute + 10*time.Second),
 				},
 			}
 
@@ -127,29 +128,6 @@ func TestUpstream(t *testing.T) {
 			var resultUpstream Upstream
 			resultUpstream.Fill(convertedAPI)
 
-			assert.Equal(t, rateLimitUpstream, resultUpstream)
-		})
-
-		t.Run("invalid duration", func(t *testing.T) {
-			rateLimitUpstream := Upstream{
-				RateLimit: &RateLimit{
-					Enabled: true,
-					Rate:    10,
-					Per:     "1d1h",
-				},
-			}
-
-			var convertedAPI apidef.APIDefinition
-			convertedAPI.SetDisabledFlags()
-			rateLimitUpstream.ExtractTo(&convertedAPI)
-
-			assert.Equal(t, float64(0), convertedAPI.GlobalRateLimit.Per)
-
-			var resultUpstream Upstream
-			resultUpstream.Fill(convertedAPI)
-
-			expectedUpstream := rateLimitUpstream
-			expectedUpstream.RateLimit.Per = ""
 			assert.Equal(t, rateLimitUpstream, resultUpstream)
 		})
 

--- a/internal/time/duration.go
+++ b/internal/time/duration.go
@@ -1,0 +1,57 @@
+package time
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+type Duration = time.Duration
+
+const (
+	Nanosecond  = time.Nanosecond
+	Microsecond = time.Microsecond
+	Millisecond = time.Millisecond
+	Second      = time.Second
+	Minute      = time.Minute
+	Hour        = time.Hour
+)
+
+// ReadableDuration is a type alias for time.Duration, so that shorthand notation can be used.
+// Examples of valid shorthand notations:
+// - "1h"   : one hour
+// - "20m"  : twenty minutes
+// - "30s"  : thirty seconds
+// - "1m29s": one minute and twenty-nine seconds
+// - "1h30m" : one hour and thirty minutes
+//
+// An empty value is interpreted as "0s".
+// It's important to format the string correctly, as invalid formats will
+// be considered as 0s/empty.
+type ReadableDuration time.Duration
+
+func (d ReadableDuration) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, time.Duration(d).String())), nil
+}
+
+func (d *ReadableDuration) UnmarshalJSON(data []byte) error {
+	in, err := strconv.Unquote(string(data))
+	if err != nil {
+		return errors.New("error while parsing duration")
+	}
+
+	if in == "" {
+		*d = 0
+		return nil
+	}
+
+	// suppress error, return zero value
+	duration, _ := time.ParseDuration(in)
+	*d = ReadableDuration(duration)
+	return nil
+}
+
+func (d ReadableDuration) Seconds() float64 {
+	return Duration(d).Seconds()
+}

--- a/internal/time/duration_test.go
+++ b/internal/time/duration_test.go
@@ -1,0 +1,59 @@
+package time
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadableDuration_MarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid", func(t *testing.T) {
+		duration := ReadableDuration(time.Minute * 5)
+		expectedJSON := []byte(`"5m0s"`)
+		resultJSON, err := json.Marshal(&duration)
+		assert.NoError(t, err)
+		assert.Equal(t, string(expectedJSON), string(resultJSON))
+	})
+
+	t.Run("0 duration", func(t *testing.T) {
+		var emptyDuration = ReadableDuration(0)
+		expectedJSON := []byte(`"0s"`)
+		resultJSON, err := json.Marshal(emptyDuration)
+		assert.NoError(t, err)
+		assert.Equal(t, string(expectedJSON), string(resultJSON))
+	})
+}
+
+func TestReadableDuration_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid duration", func(t *testing.T) {
+		inputJSON := []byte(`"2h30m"`)
+		var duration ReadableDuration
+		err := json.Unmarshal(inputJSON, &duration)
+		assert.NoError(t, err)
+		expectedDuration := ReadableDuration(time.Hour*2 + time.Minute*30)
+		assert.Equal(t, expectedDuration, duration)
+	})
+
+	t.Run("empty duration", func(t *testing.T) {
+		emptyJSON := []byte(`""`)
+		var emptyDuration ReadableDuration
+		err := json.Unmarshal(emptyJSON, &emptyDuration)
+		assert.NoError(t, err)
+		assert.Equal(t, ReadableDuration(0), emptyDuration)
+
+	})
+
+	t.Run("invalid duration", func(t *testing.T) {
+		invalidJSON := []byte(`"invalid"`)
+		var invalidDuration ReadableDuration
+		err := json.Unmarshal(invalidJSON, &invalidDuration)
+		assert.NoError(t, err)
+		assert.Equal(t, ReadableDuration(0), invalidDuration)
+	})
+}


### PR DESCRIPTION
### **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

## Related Issue
Parent: https://tyktech.atlassian.net/browse/TT-11966
Subtask: [TT-12064](https://tyktech.atlassian.net/browse/TT-12064)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
enhancement


___

### **Description**
- Introduced a new type `ReadableDuration` to handle duration fields in a user-friendly format.
- Updated `WebhookEvent`, `RateLimit`, and related tests to use `ReadableDuration`.
- Simplified duration parsing and formatting throughout the codebase using the new type.
- Added comprehensive tests for the new `ReadableDuration` type.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>event.go</strong><dd><code>Use ReadableDuration for WebhookEvent CoolDownPeriod</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/event.go
<li>Introduced <code>ReadableDuration</code> type for <code>CoolDownPeriod</code> in <code>WebhookEvent</code>.<br> <li> Simplified <code>GetWebhookConf</code> by directly using <code>Seconds()</code> method from <br><code>ReadableDuration</code>.<br> <li> Adjusted <code>Fill</code> method to use <code>ReadableDuration</code> for initializing <br><code>CoolDownPeriod</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6265/files#diff-528a9f5b311ff21c0b3a9b273e61398209ca8b51550327e4d437bba81e49d577">+10/-14</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>time.go</strong><dd><code>Define ReadableDuration Type Alias</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/time.go
<li>Created a new file to define <code>ReadableDuration</code> as an alias for <br><code>time.Duration</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6265/files#diff-56f5ed8764cba1fab5cc4615f02a769b2c9124e69b5972cb1b7921d1bded577b">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>upstream.go</strong><dd><code>Implement ReadableDuration in Upstream RateLimit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/upstream.go
<li>Replaced string type with <code>ReadableDuration</code> for <code>Per</code> in <code>RateLimit</code>.<br> <li> Simplified <code>Fill</code> and <code>ExtractTo</code> methods by using <code>ReadableDuration</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6265/files#diff-7b0941c7f37fe5a2a23047e0822a65519ca11c371660f36555b59a60f000e3f4">+4/-12</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>duration.go</strong><dd><code>Implement Custom ReadableDuration Type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/time/duration.go
<li>Implemented <code>ReadableDuration</code> type with custom JSON marshal/unmarshal <br>methods.<br> <li> Added methods for parsing and formatting durations in a user-friendly <br>format.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6265/files#diff-6e8ef3118f84cbcc935f27d5a3ad5f4eb86eb22728400e9322c9b796b9d8d855">+57/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>event_test.go</strong><dd><code>Update Event Tests to Use ReadableDuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/event_test.go
- Updated test cases to use `ReadableDuration` for `CoolDownPeriod`.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6265/files#diff-a1f19f96579a470e73c131a0e37895da0c21d378f6aa48067608274564e62da7">+8/-7</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>linter_test.go</strong><dd><code>Update Linter Tests for ReadableDuration Usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/linter_test.go
<li>Updated linter tests to use <code>ReadableDuration</code> for <code>CoolDownPeriod</code> and <br><code>Per</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6265/files#diff-b92239afd81e77a829fe7fe8410044dfd4dfda525d17dbf5f8811714a9c986d3">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>upstream_test.go</strong><dd><code>Update Upstream Tests for ReadableDuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/upstream_test.go
- Updated tests to use `ReadableDuration` for `Per` in `RateLimit`.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6265/files#diff-222cc254c0c6c09fa0cf50087860b837a0873e2aef3c84ec7d80b1014c149057">+2/-24</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>duration_test.go</strong><dd><code>Test Custom ReadableDuration Type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/time/duration_test.go
<li>Added tests for marshaling and unmarshaling <code>ReadableDuration</code>.<br> <li> Tested parsing and formatting of various duration strings.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6265/files#diff-71942cdc77128266498b62e712f82d0c63bbb39d236fe9e6677f49080c28cea1">+59/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions



[TT-12064]: https://tyktech.atlassian.net/browse/TT-12064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ