### PR TITLE
Merging to release-5.3: update graphql-go-tools (#6274)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,12 @@ require (
 	github.com/TykTechnologies/gojsonschema v0.0.0-20170222154038-dcb3e4bb7990
 	github.com/TykTechnologies/gorpc v0.0.0-20210624160652-fe65bda0ccb9
 	github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708
+<<<<<<< HEAD
 	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20240307094213-c97832a5054b
+=======
+	github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20240514110121-f9fa4a18e042
+	github.com/TykTechnologies/graphql-translator v0.0.0-20240319092712-4ba87e4c06ff
+>>>>>>> df3e3d242... update graphql-go-tools (#6274)
 	github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c
 	github.com/TykTechnologies/murmur3 v0.0.0-20230310161213-aad17efd5632
 	github.com/TykTechnologies/openid2go v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -47,10 +47,19 @@ github.com/TykTechnologies/gorpc v0.0.0-20210624160652-fe65bda0ccb9 h1:fbxHiuw/2
 github.com/TykTechnologies/gorpc v0.0.0-20210624160652-fe65bda0ccb9/go.mod h1:v6v7Mlj08+EmEcXOfpuTxGt2qYU9yhqqtv4QF9Wf50E=
 github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708 h1:cmXjlMzcexhc/Cg+QB/c2CPUVs1ux9xn6162qaf/LC4=
 github.com/TykTechnologies/goverify v0.0.0-20220808203004-1486f89e7708/go.mod h1:mkS8jKcz8otdfEXhJs1QQ/DKoIY1NFFsRPKS0RwQENI=
+<<<<<<< HEAD
 github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20240307094213-c97832a5054b h1:2yI9WrfsLvDX8WqtbNUsMUAbJx7FuixrkwtUMa4nczo=
 github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20240307094213-c97832a5054b/go.mod h1:ZWio73jm6W96BcZGmGZlKGZ+JGfjAaTwTdLQbpSeJz8=
 github.com/TykTechnologies/graphql-go-tools/v2 v2.0.0-20240131151522-40a1ee2bbfc3 h1:AN/173UtBXp69KOYxv02wi4dySSz0BzGj57x5dwiMrA=
 github.com/TykTechnologies/graphql-go-tools/v2 v2.0.0-20240131151522-40a1ee2bbfc3/go.mod h1:2WzP19RkAqCmrNOJFRR+u9pYkccG1UHkBbxVySwtnG4=
+=======
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20240514110121-f9fa4a18e042 h1:g8WE6z6X5mVO43x9XjHD7IXGfzaP0HquL5jcjZIAW6g=
+github.com/TykTechnologies/graphql-go-tools v1.6.2-0.20240514110121-f9fa4a18e042/go.mod h1:DCYkq1ZoUZ/pGESE+j3C7wuyDPSt1Mlu0jVgIoDABJY=
+github.com/TykTechnologies/graphql-go-tools/v2 v2.0.0-20240509085643-e95cdc317e1d h1:ntmDECMD7475TK/cxshJ1b8KJvUM1wppohd0qZjqUqI=
+github.com/TykTechnologies/graphql-go-tools/v2 v2.0.0-20240509085643-e95cdc317e1d/go.mod h1:eOt2cxB9sZ80mz4q1UKzzk9CE4QZaS6jP20X2LwPwy8=
+github.com/TykTechnologies/graphql-translator v0.0.0-20240319092712-4ba87e4c06ff h1:kFA240S1Y4snsEL4Ng4Ch1Ib2N04A15Y+9KYumK6uCg=
+github.com/TykTechnologies/graphql-translator v0.0.0-20240319092712-4ba87e4c06ff/go.mod h1:K3KhGG9CmvXv1lJhKZpnLb1tC8N1oIzXTunQsc6N9og=
+>>>>>>> df3e3d242... update graphql-go-tools (#6274)
 github.com/TykTechnologies/kin-openapi v0.90.0 h1:kHw0mtANwIpmlU6eCeeCgRMa52EiPPhEZPuHc3lKawo=
 github.com/TykTechnologies/kin-openapi v0.90.0/go.mod h1:pkzuiceujHvAuDu3bTD/AD5OacuP4eMfrz9QhJlMvdQ=
 github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c h1:j6fd0Fz1R4oSWOmcooGjrdahqrML+btQ+PfEJw8SzbA=


### PR DESCRIPTION
update graphql-go-tools (#6274)

update graphql-go-tools to its latest `master`