### PR TITLE
[TT-11990] Change default behaviour of request_headers

### DIFF
--- a/internal/graphengine/transport.go
+++ b/internal/graphengine/transport.go
@@ -76,8 +76,10 @@ func (g *GraphQLEngineTransport) setProxyOnlyHeaders(proxyOnlyValues *GraphQLPro
 		}
 
 		for _, forwardedHeaderValue := range forwardedHeaderValues {
-			exitingHeader := r.Header.Get(forwardedHeaderKey)
-			if exitingHeader != "" {
+			exitingHeaderValue := r.Header.Get(forwardedHeaderKey)
+			// Prioritize consumer's header value. Delete the header from request_headers
+			// and add the consumer's value. See TT-11990.
+			if exitingHeaderValue != "" {
 				r.Header.Del(forwardedHeaderKey)
 			}
 			r.Header.Add(forwardedHeaderKey, forwardedHeaderValue)

--- a/internal/graphengine/transport.go
+++ b/internal/graphengine/transport.go
@@ -76,6 +76,10 @@ func (g *GraphQLEngineTransport) setProxyOnlyHeaders(proxyOnlyValues *GraphQLPro
 		}
 
 		for _, forwardedHeaderValue := range forwardedHeaderValues {
+			exitingHeader := r.Header.Get(forwardedHeaderKey)
+			if exitingHeader != "" {
+				r.Header.Del(forwardedHeaderKey)
+			}
 			r.Header.Add(forwardedHeaderKey, forwardedHeaderValue)
 		}
 	}


### PR DESCRIPTION
### **User description**
See https://tyktech.atlassian.net/browse/TT-11990


___

### **PR Type**
enhancement, tests


___

### **Description**
- Added a new integration test in `gateway/mw_graphql_test.go` to verify that consumer's header values are prioritized over the default request headers in GraphQL middleware.
- Updated `internal/graphengine/transport.go` to enhance header management by prioritizing consumer's header values, deleting the header from request headers if it exists before adding the consumer's value.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mw_graphql_test.go</strong><dd><code>Add test for prioritizing consumer header values in GraphQL middleware</code></dd></summary>
<hr>

gateway/mw_graphql_test.go
<li>Added a new test case to ensure consumer's header values are <br>prioritized over default request headers.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6277/files#diff-72c11b8efcaceccfbbd87e75565353706443bf56420d3fdba6b5bf5f632f4b33">+41/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>transport.go</strong><dd><code>Modify header handling to prioritize consumer's values</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/graphengine/transport.go
<li>Modified header handling to prioritize consumer's header values by <br>deleting existing header from request headers if present.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6277/files#diff-564061c9b29366529eb1f6f10fe39671d2ac738a4731ffd2c8b04dcc0a8cd610">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

