### PR TITLE
[TT-11954/TT-12155] add x-tyk-api-gateway.servers.contextVariables.enabled

### DIFF
--- a/apidef/oas/oas_test.go
+++ b/apidef/oas/oas_test.go
@@ -28,7 +28,6 @@ func TestOAS(t *testing.T) {
 
 		var convertedAPI apidef.APIDefinition
 		emptyOASPaths.ExtractTo(&convertedAPI)
-		assert.True(t, convertedAPI.EnableContextVars)
 
 		var resultOAS OAS
 		resultOAS.Fill(convertedAPI)

--- a/apidef/oas/root.go
+++ b/apidef/oas/root.go
@@ -54,9 +54,6 @@ func (x *XTykAPIGateway) ExtractTo(api *apidef.APIDefinition) {
 	}
 
 	x.Middleware.ExtractTo(api)
-
-	// will be always enabled
-	api.EnableContextVars = true
 }
 
 // Info contains the main metadata for the API definition.

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -1282,6 +1282,9 @@
               "$ref": "#/definitions/X-Tyk-EventHandlers"
             }
           ]
+        },
+        "contextVariables": {
+          "$ref": "#/definitions/X-Tyk-ContextVariables"
         }
       },
       "required": [
@@ -2017,6 +2020,17 @@
         "TokenCreated",
         "TokenUpdated",
         "TokenDeleted"
+      ]
+    },
+    "X-Tyk-ContextVariables": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "enabled"
       ]
     },
     "X-Tyk-UInt": {

--- a/apidef/oas/server.go
+++ b/apidef/oas/server.go
@@ -38,6 +38,9 @@ type Server struct {
 	//
 	// Tyk classic API definition: `event_handlers`
 	EventHandlers EventHandlers `bson:"eventHandlers,omitempty" json:"eventHandlers,omitempty"`
+
+	// ContextVariables contains the configuration related to Tyk context variables.
+	ContextVariables *ContextVariables `bson:"contextVariables,omitempty" json:"contextVariables,omitempty"`
 }
 
 // Fill fills *Server from apidef.APIDefinition.
@@ -94,6 +97,18 @@ func (s *Server) Fill(api apidef.APIDefinition) {
 	if ShouldOmit(s.EventHandlers) {
 		s.EventHandlers = nil
 	}
+
+	if s.ContextVariables == nil {
+		s.ContextVariables = &ContextVariables{}
+		// special case, do ShouldOmit omit check only if s.ContextVariables was nil.
+		defer func() {
+			if ShouldOmit(s.ContextVariables) {
+				s.ContextVariables = nil
+			}
+		}()
+	}
+
+	s.ContextVariables.Fill(api)
 }
 
 // ExtractTo extracts *Server into *apidef.APIDefinition.
@@ -153,6 +168,15 @@ func (s *Server) ExtractTo(api *apidef.APIDefinition) {
 	}
 
 	s.EventHandlers.ExtractTo(api)
+
+	if s.ContextVariables == nil {
+		s.ContextVariables = &ContextVariables{}
+		defer func() {
+			s.ContextVariables = nil
+		}()
+	}
+
+	s.ContextVariables.ExtractTo(api)
 }
 
 // ListenPath is the base path on Tyk to which requests for this API
@@ -286,4 +310,21 @@ func (dt *DetailedTracing) Fill(api apidef.APIDefinition) {
 // ExtractTo extracts *DetailedTracing into *apidef.APIDefinition.
 func (dt *DetailedTracing) ExtractTo(api *apidef.APIDefinition) {
 	api.DetailedTracing = dt.Enabled
+}
+
+// ContextVariables holds the configuration related to Tyk context variables.
+type ContextVariables struct {
+	// Enabled enables context variables to be passed to Tyk middlewares.
+	// Tyk classic API definition: `enable_context_vars`.
+	Enabled bool `json:"enabled" bson:"enabled"`
+}
+
+// Fill fills *ContextVariables from apidef.APIDefinition.
+func (c *ContextVariables) Fill(api apidef.APIDefinition) {
+	c.Enabled = api.EnableContextVars
+}
+
+// ExtractTo extracts *ContextVariables into *apidef.APIDefinition.
+func (c *ContextVariables) ExtractTo(api *apidef.APIDefinition) {
+	api.EnableContextVars = c.Enabled
 }

--- a/apidef/oas/server_test.go
+++ b/apidef/oas/server_test.go
@@ -323,3 +323,74 @@ func TestExportDetailedTracing(t *testing.T) {
 		})
 	}
 }
+
+func TestContextVariables(t *testing.T) {
+	t.Parallel()
+	t.Run("fill", func(t *testing.T) {
+		t.Parallel()
+		testcases := []struct {
+			title    string
+			input    apidef.APIDefinition
+			expected *ContextVariables
+		}{
+			{
+				"enabled",
+				apidef.APIDefinition{EnableContextVars: true},
+				&ContextVariables{Enabled: true},
+			},
+			{
+				"disabled",
+				apidef.APIDefinition{EnableContextVars: false},
+				nil,
+			},
+		}
+
+		for _, tc := range testcases {
+			tc := tc
+			t.Run(tc.title, func(t *testing.T) {
+				t.Parallel()
+
+				server := new(Server)
+				server.Fill(tc.input)
+
+				assert.Equal(t, tc.expected, server.ContextVariables)
+			})
+		}
+	})
+
+	t.Run("extractTo", func(t *testing.T) {
+		t.Parallel()
+
+		testcases := []struct {
+			title    string
+			input    *ContextVariables
+			expected bool
+		}{
+			{
+				"enabled",
+				&ContextVariables{Enabled: true},
+				true,
+			},
+			{
+				"disabled",
+				nil,
+				false,
+			},
+		}
+
+		for _, tc := range testcases {
+			tc := tc // Creating a new 'tc' scoped to the loop
+			t.Run(tc.title, func(t *testing.T) {
+				t.Parallel()
+
+				server := new(Server)
+				server.ContextVariables = tc.input
+
+				var apiDef apidef.APIDefinition
+				server.ExtractTo(&apiDef)
+
+				assert.Equal(t, tc.expected, apiDef.EnableContextVars)
+			})
+		}
+	})
+}

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -1063,6 +1063,11 @@ func (gw *Gateway) handleAddApi(r *http.Request, fs afero.Fs, oasEndpoint bool) 
 			return apiError("Request malformed"), http.StatusBadRequest
 		}
 
+		// enable context variable by default for OAS APIs if not explicitly set to false.
+		if oasObj.GetTykExtension().Server.ContextVariables == nil {
+			oasObj.GetTykExtension().Server.ContextVariables = &oas.ContextVariables{Enabled: true}
+		}
+
 		oasObj.ExtractTo(&newDef)
 	} else {
 		if err := json.NewDecoder(r.Body).Decode(&newDef); err != nil {

--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -2614,9 +2614,28 @@ func TestOAS(t *testing.T) {
 
 	oasAPI = testGetOASAPI(t, ts, oasAPIID, "oas api", "oas doc")
 	assert.NotNil(t, oasAPI.Servers)
+	// assert context variables are enabled when contextVariables are not configured in the payload
+	tykOASAPI := oas.OAS{T: oasAPI}
+	assert.True(t, tykOASAPI.GetTykExtension().Server.ContextVariables.Enabled)
 
 	createdOldAPI := testGetOldAPI(t, ts, oldAPIID, "old api")
 	assert.NotNil(t, createdOldAPI)
+
+	t.Run("do not enable context variables when explicitly set to false in payload", func(t *testing.T) {
+		copyOASAPI := oas.OAS{T: oasAPI}
+		apiID2 := "apiid-2"
+		tykExt := *copyOASAPI.GetTykExtension()
+		tykExt.Info.ID = apiID2
+		tykExt.Server.ContextVariables = &oas.ContextVariables{Enabled: false}
+		copyOASAPI.SetTykExtension(&tykExt)
+		// Create OAS API
+		_, _ = ts.Run(t, test.TestCase{AdminAuth: true, Method: http.MethodPost, Path: oasBasePath, Data: &copyOASAPI,
+			BodyMatch: `"action":"added"`, Code: http.StatusOK})
+
+		ts.Gw.DoReload()
+		oasAPI = testGetOASAPI(t, ts, apiID2, "oas api", "oas doc")
+		assert.False(t, tykOASAPI.GetTykExtension().Server.ContextVariables.Enabled)
+	})
 
 	t.Run("OAS validation - should fail without x-tyk-api-gateway", func(t *testing.T) {
 		oasAPI.Paths = make(openapi3.Paths)
@@ -3519,6 +3538,8 @@ func TestOAS(t *testing.T) {
 			importT := testGetOASAPI(t, ts, importedOASAPIID, "example oas doc", "example oas doc")
 			importedOAS := oas.OAS{T: importT}
 			assert.True(t, importedOAS.GetTykExtension().Server.ListenPath.Strip)
+			// ensure context variables are enabled by default in import
+			assert.True(t, importedOAS.GetTykExtension().Server.ContextVariables.Enabled)
 		})
 
 		t.Run("block when dashboard app config set to true", func(t *testing.T) {


### PR DESCRIPTION
### **User description**
<!-- Provide a general summary of your changes in the Title above -->

- add x-tyk-api-gateway.servers.contextVariables.enabled
- enable context variables by default for OAS APIs if not explicitly configured otherwise.

<!-- Describe your changes in detail -->
Parent: https://tyktech.atlassian.net/browse/TT-11954
Subtask: https://tyktech.atlassian.net/browse/TT-12155
<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
enhancement


___

### **Description**
- Added handling and configuration for context variables in the OAS server structure.
- Removed hardcoded enabling of context variables, now configurable via JSON.
- Updated tests to reflect new logic and added new tests for context variable configuration.
- Updated JSON schema to include new `ContextVariables` definition.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>oas_test.go</strong><dd><code>Update OAS Test to Reflect Context Variable Changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/oas_test.go
- Removed assertion for `EnableContextVars` in `TestOAS`.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6281/files#diff-74029ee88132d30d6478c96a35f8bb2200e0c8e6f42f2c9b147dc6bb7ce74644">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>server_test.go</strong><dd><code>Add Tests for Context Variables in Server Struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/server_test.go
- Added tests for `ContextVariables` handling in `Server` struct.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6281/files#diff-a194795077946243b2b6d04b30be360dbafff8e5eb03e6212081e45d1c72573f">+71/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>api_test.go</strong><dd><code>Test Default Enabling of Context Variables in OAS APIs</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_test.go
<li>Added tests to ensure context variables are enabled by default and <br>respect explicit configuration.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6281/files#diff-10b4a3d7bdd8d98e48b288d27fd46d9ee436617806c46913fdf7942c0e4a992e">+21/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>root.go</strong><dd><code>Remove Hardcoded Context Variable Enabling in Root Extraction</code></dd></summary>
<hr>

apidef/oas/root.go
- Removed hardcoded enabling of `EnableContextVars`.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6281/files#diff-9c56b2bdb992e0a7db76809d4c516e1cd61c9486c7f0437b344c0032476af80f">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>server.go</strong><dd><code>Integrate Context Variables Handling in Server Struct</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/server.go
<li>Added handling for <code>ContextVariables</code> in <code>Server</code> struct.<br> <li> Implemented <code>Fill</code> and <code>ExtractTo</code> methods for <code>ContextVariables</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6281/files#diff-21857c42e8659f7980014e277c3c758703f29e9e5c0c40553f2584cddb870808">+41/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>api.go</strong><dd><code>Default Enable Context Variables for OAS APIs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api.go
<li>Added default enabling of context variables for OAS APIs if not <br>explicitly set.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6281/files#diff-644cda3aeb4ac7f325359e85fcddb810f100dd5e6fa480b0d9f9363a743c4e05">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>x-tyk-api-gateway.json</strong><dd><code>Add JSON Schema for Context Variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/schema/x-tyk-api-gateway.json
- Added schema definition for `ContextVariables`.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6281/files#diff-78828969c0c04cc1a776dfc93a8bad3c499a8c83e6169f83e96d090bed3e7dd0">+14/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

