### PR TITLE
[TT-11914/TT-12101]Add OAS trafficLogs

### DIFF
--- a/apidef/migration.go
+++ b/apidef/migration.go
@@ -459,6 +459,8 @@ func (a *APIDefinition) SetDisabledFlags() {
 		a.GlobalRateLimit.Disabled = true
 	}
 
+	a.DoNotTrack = true
+
 	a.setEventHandlersDisabledFlags()
 }
 

--- a/apidef/migration_test.go
+++ b/apidef/migration_test.go
@@ -724,6 +724,7 @@ func TestSetDisabledFlags(t *testing.T) {
 				},
 			},
 		},
+		DoNotTrack: true,
 	}
 	apiDef.SetDisabledFlags()
 	assert.Equal(t, expectedAPIDef, apiDef)

--- a/apidef/oas/default.go
+++ b/apidef/oas/default.go
@@ -66,6 +66,7 @@ func (s *OAS) BuildDefaultTykExtension(overRideValues TykExtensionConfigParams, 
 		xTykAPIGateway.Info.State.Internal = false
 		xTykAPIGateway.Server.ListenPath.Strip = true
 		xTykAPIGateway.enableContextVariablesIfEmpty()
+		xTykAPIGateway.enableTrafficLogsIfEmpty()
 	}
 
 	if xTykAPIGateway.Info.Name == "" {

--- a/apidef/oas/default_test.go
+++ b/apidef/oas/default_test.go
@@ -50,6 +50,9 @@ func TestOAS_BuildDefaultTykExtension(t *testing.T) {
 			},
 			Middleware: &Middleware{
 				Global: &Global{
+					TrafficLogs: &TrafficLogs{
+						Enabled: true,
+					},
 					ContextVariables: &ContextVariables{
 						Enabled: true,
 					},
@@ -105,6 +108,9 @@ func TestOAS_BuildDefaultTykExtension(t *testing.T) {
 			},
 			Middleware: &Middleware{
 				Global: &Global{
+					TrafficLogs: &TrafficLogs{
+						Enabled: true,
+					},
 					ContextVariables: &ContextVariables{
 						Enabled: true,
 					},
@@ -163,6 +169,9 @@ func TestOAS_BuildDefaultTykExtension(t *testing.T) {
 			},
 			Middleware: &Middleware{
 				Global: &Global{
+					TrafficLogs: &TrafficLogs{
+						Enabled: true,
+					},
 					ContextVariables: &ContextVariables{
 						Enabled: true,
 					},
@@ -278,6 +287,9 @@ func TestOAS_BuildDefaultTykExtension(t *testing.T) {
 			},
 			Middleware: &Middleware{
 				Global: &Global{
+					TrafficLogs: &TrafficLogs{
+						Enabled: true,
+					},
 					ContextVariables: &ContextVariables{
 						Enabled: true,
 					},
@@ -989,8 +1001,11 @@ func TestOAS_BuildDefaultTykExtension(t *testing.T) {
 					err := oasDef.BuildDefaultTykExtension(tykExtensionConfigParams, true)
 
 					assert.NoError(t, err)
-					assert.EqualValues(t, &Middleware{
+					assert.Equal(t, &Middleware{
 						Global: &Global{
+							TrafficLogs: &TrafficLogs{
+								Enabled: true,
+							},
 							ContextVariables: &ContextVariables{
 								Enabled: true,
 							},
@@ -1010,8 +1025,11 @@ func TestOAS_BuildDefaultTykExtension(t *testing.T) {
 				err := oasDef.BuildDefaultTykExtension(tykExtensionConfigParams, true)
 
 				assert.NoError(t, err)
-				assert.EqualValues(t, &Middleware{
+				assert.Equal(t, &Middleware{
 					Global: &Global{
+						TrafficLogs: &TrafficLogs{
+							Enabled: true,
+						},
 						ContextVariables: &ContextVariables{
 							Enabled: true,
 						},
@@ -1040,8 +1058,11 @@ func TestOAS_BuildDefaultTykExtension(t *testing.T) {
 					err := oasDef.BuildDefaultTykExtension(tykExtensionConfigParams, true)
 
 					assert.NoError(t, err)
-					assert.EqualValues(t, &Middleware{
+					assert.Equal(t, &Middleware{
 						Global: &Global{
+							TrafficLogs: &TrafficLogs{
+								Enabled: true,
+							},
 							ContextVariables: &ContextVariables{
 								Enabled: true,
 							},
@@ -1252,6 +1273,9 @@ func TestOAS_BuildDefaultTykExtension(t *testing.T) {
 		expectedTykExtension.Info.State.Active = true
 		expectedTykExtension.Middleware = &Middleware{
 			Global: &Global{
+				TrafficLogs: &TrafficLogs{
+					Enabled: true,
+				},
 				ContextVariables: &ContextVariables{
 					Enabled: true,
 				},
@@ -1344,6 +1368,9 @@ func TestOAS_BuildDefaultTykExtension(t *testing.T) {
 			},
 			Middleware: &Middleware{
 				Global: &Global{
+					TrafficLogs: &TrafficLogs{
+						Enabled: true,
+					},
 					ContextVariables: &ContextVariables{
 						Enabled: true,
 					},
@@ -1399,7 +1426,6 @@ func TestOAS_BuildDefaultTykExtension(t *testing.T) {
 		assert.NotNil(t, err)
 		assert.Contains(t, err.Error(), "server URL contains undefined variables")
 	})
-
 }
 
 func TestGetTykExtensionConfigParams(t *testing.T) {

--- a/apidef/oas/oas_test.go
+++ b/apidef/oas/oas_test.go
@@ -157,6 +157,7 @@ func TestOAS_ExtractTo_ResetAPIDefinition(t *testing.T) {
 	a.IDPClientIDMappingDisabled = false
 	a.EnableContextVars = false
 	a.DisableRateLimit = false
+	a.DoNotTrack = false
 
 	// deprecated fields
 	a.Auth = apidef.AuthConfig{}
@@ -255,7 +256,6 @@ func TestOAS_ExtractTo_ResetAPIDefinition(t *testing.T) {
 		"APIDefinition.ExpireAnalyticsAfter",
 		"APIDefinition.ResponseProcessors[0].Name",
 		"APIDefinition.ResponseProcessors[0].Options",
-		"APIDefinition.DoNotTrack",
 		"APIDefinition.TagHeaders[0]",
 		"APIDefinition.GraphQL.Enabled",
 		"APIDefinition.GraphQL.ExecutionMode",
@@ -931,7 +931,13 @@ func TestMigrateAndFillOAS_DropEmpties(t *testing.T) {
 	})
 
 	t.Run("plugin bundle", func(t *testing.T) {
-		assert.Nil(t, baseAPI.OAS.GetTykExtension().Middleware)
+		assert.Equal(t, &Middleware{
+			Global: &Global{
+				TrafficLogs: &TrafficLogs{
+					Enabled: true,
+				},
+			},
+		}, baseAPI.OAS.GetTykExtension().Middleware)
 	})
 
 	t.Run("mutualTLS", func(t *testing.T) {

--- a/apidef/oas/root.go
+++ b/apidef/oas/root.go
@@ -245,3 +245,21 @@ func (x *XTykAPIGateway) enableContextVariablesIfEmpty() {
 		}
 	}
 }
+
+// enableTrafficLogsIfEmpty enables traffic logs in middleware.global.trafficLogs.
+// Traffic logs will be set only if it is not set. If it is already set to false, it won't be enabled.
+func (x *XTykAPIGateway) enableTrafficLogsIfEmpty() {
+	if x.Middleware == nil {
+		x.Middleware = &Middleware{}
+	}
+
+	if x.Middleware.Global == nil {
+		x.Middleware.Global = &Global{}
+	}
+
+	if x.Middleware.Global.TrafficLogs == nil {
+		x.Middleware.Global.TrafficLogs = &TrafficLogs{
+			Enabled: true,
+		}
+	}
+}

--- a/apidef/oas/root_test.go
+++ b/apidef/oas/root_test.go
@@ -397,3 +397,97 @@ func TestVersioning(t *testing.T) {
 
 	assert.Equal(t, emptyVersioning, resultVersioning)
 }
+
+func TestXTykAPIGateway_enableTrafficLogsIfEmpty(t *testing.T) {
+	t.Parallel()
+	enabledExpectation := XTykAPIGateway{
+		Middleware: &Middleware{
+			Global: &Global{
+				TrafficLogs: &TrafficLogs{
+					Enabled: true,
+				},
+			},
+		},
+	}
+	disabledExpectation := XTykAPIGateway{
+		Middleware: &Middleware{
+			Global: &Global{
+				TrafficLogs: &TrafficLogs{
+					Enabled: false,
+				},
+			},
+		},
+	}
+	testCases := []struct {
+		name   string
+		in     XTykAPIGateway
+		expect XTykAPIGateway
+	}{
+		{
+			name:   "empty XTykAPIGateway",
+			in:     XTykAPIGateway{},
+			expect: enabledExpectation,
+		},
+		{
+			name: "empty XTykAPIGateway.Middleware",
+			in: XTykAPIGateway{
+				Middleware: &Middleware{},
+			},
+			expect: enabledExpectation,
+		},
+		{
+			name: "empty XTykAPIGateway.Middleware.Global",
+			in: XTykAPIGateway{
+				Middleware: &Middleware{
+					Global: &Global{},
+				},
+			},
+			expect: enabledExpectation,
+		},
+		{
+			name: "empty XTykAPIGateway.Middleware.Global.TrafficLogs",
+			in: XTykAPIGateway{
+				Middleware: &Middleware{
+					Global: &Global{
+						TrafficLogs: &TrafficLogs{},
+					},
+				},
+			},
+			expect: disabledExpectation,
+		},
+		{
+			name: "enabled XTykAPIGateway.Middleware.Global.TrafficLogs",
+			in: XTykAPIGateway{
+				Middleware: &Middleware{
+					Global: &Global{
+						TrafficLogs: &TrafficLogs{
+							Enabled: true,
+						},
+					},
+				},
+			},
+			expect: enabledExpectation,
+		},
+		{
+			name: "disabled XTykAPIGateway.Middleware.Global.TrafficLogs",
+			in: XTykAPIGateway{
+				Middleware: &Middleware{
+					Global: &Global{
+						TrafficLogs: &TrafficLogs{
+							Enabled: false,
+						},
+					},
+				},
+			},
+			expect: disabledExpectation,
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.in.enableTrafficLogsIfEmpty()
+			assert.EqualExportedValues(t, tc.expect, tc.in)
+		})
+	}
+}

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -574,6 +574,9 @@
         },
         "contextVariables": {
           "$ref": "#/definitions/X-Tyk-ContextVariables"
+        },
+        "trafficLogs": {
+          "$ref": "#/definitions/X-Tyk-TrafficLogs"
         }
       }
     },
@@ -1285,6 +1288,9 @@
               "$ref": "#/definitions/X-Tyk-EventHandlers"
             }
           ]
+        },
+        "contextVariables": {
+          "$ref": "#/definitions/X-Tyk-ContextVariables"
         }
       },
       "required": [
@@ -2023,6 +2029,17 @@
       ]
     },
     "X-Tyk-ContextVariables": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "enabled"
+      ]
+    },
+    "X-Tyk-TrafficLogs": {
       "type": "object",
       "properties": {
         "enabled": {

--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -3521,6 +3521,8 @@ func TestOAS(t *testing.T) {
 			assert.True(t, importedOAS.GetTykExtension().Server.ListenPath.Strip)
 			// ensure context variables are enabled by default in import
 			assert.True(t, importedOAS.GetTykMiddleware().Global.ContextVariables.Enabled)
+			// ensure traffic logs are enabled by default in import
+			assert.True(t, importedOAS.GetTykMiddleware().Global.TrafficLogs.Enabled)
 		})
 
 		t.Run("block when dashboard app config set to true", func(t *testing.T) {


### PR DESCRIPTION

## Description

Add OAS trafficLogs
Traffic logs would be enabled by default during OAS API import.
During create, it would respect what it is specified in the API definition.
## Related Issue
Parent: https://tyktech.atlassian.net/browse/TT-11914
Subtask: https://tyktech.atlassian.net/browse/TT-12101

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Enhancement


___

### **Description**
- Added functionality to enable traffic logs by default during OAS API import.
- Introduced `TrafficLogs` struct in middleware to handle API level log analytics.
- Updated JSON schema to support traffic logs configuration.
- Updated unit tests to ensure traffic logs are enabled by default.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>migration.go</strong><dd><code>Set DoNotTrack flag to true by default</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/migration.go
- Added `DoNotTrack` flag set to true in `APIDefinition` struct.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6287/files#diff-e1d9b55a26f9d6225d56d6f0161959217308e5ad4d6934e7d7df4595d9c2a130">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>default.go</strong><dd><code>Enable traffic logs by default on OAS import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/default.go
<li>Added a new function call to enable traffic logs by default during OAS <br>API import.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6287/files#diff-83c3a85bdd05785178ee519b05b1fe2008435dc4ae9448d72b080b5f67c491ad">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>middleware.go</strong><dd><code>Implement traffic log analytics configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/middleware.go
<li>Added <code>TrafficLogs</code> struct to handle API level log analytics.<br> <li> Implemented methods to fill and extract traffic log settings from <br><code>APIDefinition</code>.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6287/files#diff-992ec7c28d25fd54f6491d295389757705cd114bc869a35cba50d42e548cdc6e">+29/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>root.go</strong><dd><code>Conditionally enable traffic logs in middleware</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/root.go
<li>Added method to conditionally enable traffic logs if they are not <br>already configured.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6287/files#diff-9c56b2bdb992e0a7db76809d4c516e1cd61c9486c7f0437b344c0032476af80f">+18/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>default_test.go</strong><dd><code>Update tests to verify traffic logs are enabled</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/default_test.go
<li>Updated unit tests to check for enabled traffic logs in the middleware <br>configuration.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6287/files#diff-ab6848f71731083885a9d7d7970faa68a6783a98477c78413ae3979cb5add7db">+66/-4</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>x-tyk-api-gateway.json</strong><dd><code>Update JSON schema for traffic logs configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/schema/x-tyk-api-gateway.json
- Updated JSON schema to include `trafficLogs` configuration.


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6287/files#diff-78828969c0c04cc1a776dfc93a8bad3c499a8c83e6169f83e96d090bed3e7dd0">+14/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

