### PR TITLE
Merging to release-5.3: [TT-11806] Respect domain and listen path (#6289)

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -130,7 +130,7 @@ jobs:
             -Dsonar.organization=tyktechnologies
             -Dsonar.projectKey=TykTechnologies_tyk
             -Dsonar.sources=.
-            -Dsonar.exclusions=**/testdata/*,coprocess/**/*,ci/**,smoke-tests/**,apidef/oas/schema/schema.gen.go
+            -Dsonar.exclusions=**/testdata/*,test/**,coprocess/**/*,ci/**,smoke-tests/**,apidef/oas/schema/schema.gen.go
             -Dsonar.coverage.exclusions=**/*_test.go,**/mock/*
             -Dsonar.test.inclusions=**/*_test.go
             -Dsonar.tests=.

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -89,13 +89,12 @@ func countApisByListenHash(specs []*APISpec) map[string]int {
 		domain := spec.GetAPIDomain()
 		domainHash := generateDomainPath(domain, spec.Proxy.ListenPath)
 		if count[domainHash] == 0 {
-			dN := domain
-			if dN == "" {
-				dN = "(no host)"
+			if domain == "" {
+				domain = "(no host)"
 			}
 			mainLog.WithFields(logrus.Fields{
 				"api_name": spec.Name,
-				"domain":   dN,
+				"domain":   domain,
 			}).Info("Tracking hostname")
 		}
 		count[domainHash]++
@@ -792,7 +791,7 @@ func (gw *Gateway) loadHTTPService(spec *APISpec, apisByListen map[string]int, g
 		spec.Proxy.ListenPath,
 	}
 
-	// Register routes for each prefixe
+	// Register routes for each prefix
 	for _, prefix := range prefixes {
 		subrouter := router.PathPrefix(prefix).Subrouter()
 
@@ -923,6 +922,9 @@ func (gw *Gateway) loadApps(specs []*APISpec) {
 	// sort by listen path from longer to shorter, so that /foo
 	// doesn't break /foo-bar
 	sort.Slice(specs, func(i, j int) bool {
+		if specs[i].Domain != specs[j].Domain {
+			return len(specs[i].Domain) > len(specs[j].Domain)
+		}
 		return len(specs[i].Proxy.ListenPath) > len(specs[j].Proxy.ListenPath)
 	})
 

--- a/test/http.go
+++ b/test/http.go
@@ -16,6 +16,7 @@ import (
 )
 
 type TestCase struct {
+	Host    string `json:",omitempty"`
 	Method  string `json:",omitempty"`
 	Path    string `json:",omitempty"`
 	BaseURL string `json:",omitempty"`
@@ -282,6 +283,10 @@ func (r HTTPTestRunner) Run(t testing.TB, testCases ...TestCase) (*http.Response
 		if err != nil {
 			t.Errorf("[%d] Request build error: %s", ti, err.Error())
 			continue
+		}
+
+		if tc.Host != "" {
+			req.Host = tc.Host
 		}
 
 		retryCount := 0

--- a/tests/regression/issue_11806_test.go
+++ b/tests/regression/issue_11806_test.go
@@ -1,0 +1,176 @@
+package regression
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/gateway"
+	"github.com/TykTechnologies/tyk/internal/uuid"
+	"github.com/TykTechnologies/tyk/test"
+)
+
+func Test_Issue11806_DomainRouting(t *testing.T) {
+	testConfig := func(conf *config.Config) {
+		conf.EnableCustomDomains = true
+	}
+
+	noDomain := loadAPISpec(t, "testdata/issue-11806-api-no-domain.json")
+	withDomain := loadAPISpec(t, "testdata/issue-11806-api-with-domain.json")
+
+	t.Run("Load listenPath without domain first", func(t *testing.T) {
+		ts := gateway.StartTest(testConfig)
+		defer ts.Close()
+
+		ts.Gw.LoadAPI(noDomain, withDomain)
+
+		testDomainRouting(t, ts)
+	})
+
+	t.Run("Load listenPath with domain first", func(t *testing.T) {
+		ts := gateway.StartTest(testConfig)
+		defer ts.Close()
+
+		ts.Gw.LoadAPI(withDomain, noDomain)
+
+		testDomainRouting(t, ts)
+	})
+
+	t.Run("Test mux router expectations", func(t *testing.T) {
+		testSubrouterHost(t)
+	})
+
+	t.Run("Test gateway router expectations", func(t *testing.T) {
+		testRouteLongestPathFirst(t)
+	})
+}
+
+func testDomainRouting(tb testing.TB, ts *gateway.Test) {
+	tb.Helper()
+
+	ts.Run(tb, []test.TestCase{
+		{
+			Path:      "/test/",
+			Method:    http.MethodGet,
+			Code:      http.StatusOK,
+			BodyMatch: "fallthrough",
+		},
+		{
+			Path:      "/test/",
+			Host:      "customer.mydomain.com",
+			Method:    http.MethodGet,
+			Code:      http.StatusOK,
+			BodyMatch: "customer.mydomain.com",
+		},
+	}...)
+}
+
+// testSubrouterHost verifies directly with gorilla/mux, that the host subrouter
+// should be created before adding routes to the main router.
+func testSubrouterHost(t *testing.T) {
+	t.Helper()
+
+	// Create the main router
+	router := mux.NewRouter()
+	ctx := context.Background()
+
+	// Create a subrouter with a specific host
+	subrouter := router.Host("customer.mydomain.com").Subrouter()
+	subrouter.HandleFunc("/test", func(w http.ResponseWriter, _ *http.Request) {
+		_, err := w.Write([]byte("Subrouter"))
+		assert.NoError(t, err)
+	})
+
+	// Register a handler for /test on the main router
+	router.HandleFunc("/test", func(w http.ResponseWriter, _ *http.Request) {
+		_, err := w.Write([]byte("Main Router"))
+		assert.NoError(t, err)
+	})
+
+	// Test a request without the host header
+	reqWithoutHost, err := http.NewRequestWithContext(ctx, "GET", "/test", nil)
+	assert.NoError(t, err)
+
+	respWithoutHost := httptest.NewRecorder()
+	router.ServeHTTP(respWithoutHost, reqWithoutHost)
+	if respWithoutHost.Body.String() != "Main Router" {
+		t.Errorf("expected 'Main Router', got '%s'", respWithoutHost.Body.String())
+	}
+
+	// Test a request with a random host header
+	reqWithRandomHost, err := http.NewRequestWithContext(ctx, "GET", "/test", nil)
+	assert.NoError(t, err)
+
+	reqWithRandomHost.Host = "random.mydomain.com"
+	respWithRandomHost := httptest.NewRecorder()
+	router.ServeHTTP(respWithRandomHost, reqWithRandomHost)
+	if respWithRandomHost.Body.String() != "Main Router" {
+		t.Errorf("expected 'Main Router', got '%s'", respWithRandomHost.Body.String())
+	}
+
+	// Test a request with the specific host header
+	reqWithSpecificHost, err := http.NewRequestWithContext(ctx, "GET", "/test", nil)
+	assert.NoError(t, err)
+
+	reqWithSpecificHost.Host = "customer.mydomain.com"
+	respWithSpecificHost := httptest.NewRecorder()
+	router.ServeHTTP(respWithSpecificHost, reqWithSpecificHost)
+	if respWithSpecificHost.Body.String() != "Subrouter" {
+		t.Errorf("expected 'Subrouter', got '%s'", respWithSpecificHost.Body.String())
+	}
+}
+
+func testRouteLongestPathFirst(t *testing.T) {
+	t.Helper()
+
+	ts := gateway.StartTest(func(globalConf *config.Config) {
+		globalConf.EnableCustomDomains = true
+	})
+	defer ts.Close()
+
+	type hostAndPath struct {
+		host, path string
+	}
+
+	inputs := map[hostAndPath]bool{}
+	hosts := []string{"host1.local", "host2.local", "host3.local"}
+	paths := []string{"a", "ab", "a/b/c", "ab/c", "abc", "a/b/c"}
+
+	for _, host := range hosts {
+		for _, path := range paths {
+			inputs[hostAndPath{host, path}] = true
+		}
+	}
+
+	var apis []*gateway.APISpec
+
+	for hp := range inputs {
+		apis = append(apis, gateway.BuildAPI(func(spec *gateway.APISpec) {
+			spec.APIID = uuid.New()
+
+			spec.Domain = hp.host
+			spec.Proxy.ListenPath = "/" + hp.path
+		})[0])
+	}
+
+	ts.Gw.LoadAPI(apis...)
+
+	var testCases []test.TestCase
+
+	for hp := range inputs {
+		testCases = append(testCases, test.TestCase{
+			Client:    test.NewClientLocal(),
+			Path:      "/" + hp.path,
+			Domain:    hp.host,
+			Code:      200,
+			BodyMatch: `"Url":"/` + hp.path + `"`,
+		})
+	}
+
+	_, _ = ts.Run(t, testCases...)
+}

--- a/tests/regression/testdata/issue-11806-api-no-domain.json
+++ b/tests/regression/testdata/issue-11806-api-no-domain.json
@@ -1,0 +1,24 @@
+{
+  "api_id": "deadbeefce7c2b0001a066e0",
+  "active": true,
+  "auth": {
+    "auth_header_name": "Authorization"
+  },
+  "domain": "",
+  "name": "api1",
+  "proxy": {
+    "listen_path": "/test/",
+    "strip_listen_path": true,
+    "target_url": "http://httpbin.org/anything/api1/fallthrough"
+  },
+  "use_keyless": true,
+  "version_data": {
+    "not_versioned": true,
+    "versions": {
+      "Default": {
+        "name": "Default",
+        "use_extended_paths": true
+      }
+    }
+  }
+}

--- a/tests/regression/testdata/issue-11806-api-with-domain.json
+++ b/tests/regression/testdata/issue-11806-api-with-domain.json
@@ -1,0 +1,24 @@
+{
+  "api_id": "deadbeefce7c2b0001a066e1",
+  "active": true,
+  "auth": {
+    "auth_header_name": "Authorization"
+  },
+  "domain": "customer.mydomain.com",
+  "name": "api3",
+  "proxy": {
+    "listen_path": "/test/",
+    "strip_listen_path": true,
+    "target_url": "http://httpbin.org/anything/api3/customer.mydomain.com"
+  },
+  "use_keyless": true,
+  "version_data": {
+    "not_versioned": true,
+    "versions": {
+      "Default": {
+        "name": "Default",
+        "use_extended_paths": true
+      }
+    }
+  }
+}


### PR DESCRIPTION
### **User description**
[TT-11806] Respect domain and listen path (#6289)

### **User description**
PR reorders api specs with domains to be registered before fallback
(no-domain) specs.

Adds:

- Ability to set the host header for tests,
- Regression test testing gorilla mux expectations
- Moves a domain based api test out of gateway scope
- Tests loading apis with/without domain in different order

https://tyktech.atlassian.net/browse/TT-11806


___

### **PR Type**
enhancement, bug_fix, tests


___

### **Description**
- Enhanced domain handling in API spec loading by prioritizing domain
length.
- Fixed minor issues and typos in API loading logic.
- Added support for setting the host header in HTTP tests.
- Introduced comprehensive regression tests to ensure correct domain
routing.
- Added new test API specifications for testing domain and non-domain
routes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>api_loader.go</strong><dd><code>Enhance API loading
with domain prioritization and minor fixes</code></dd></summary>
<hr>

gateway/api_loader.go
<li>Improved domain handling in API spec counting.<br> <li> Fixed a typo
in a comment.<br> <li> Modified the sorting logic to prioritize domain
length before listen <br>path length.<br>


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6289/files#diff-cdf0b7f176c9d18e1a314b78ddefc2cb3a94b3de66f1f360174692c915734c68">+7/-5</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
<summary><strong>http.go</strong><dd><code>Support host header in HTTP
tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/http.go
- Added support for setting the host header in HTTP test cases.



</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6289/files#diff-a5530e34c740ce6fe2efe8dda5a356463c450696b39b97b91228f1be2491e05e">+5/-0</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>api_test.go</strong><dd><code>Remove redundant API
loading order test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_test.go
- Removed a redundant test case for API loading order.



</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6289/files#diff-10b4a3d7bdd8d98e48b288d27fd46d9ee436617806c46913fdf7942c0e4a992e">+0/-50</a>&nbsp;
&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
<summary><strong>issue_11806_test.go</strong><dd><code>Add regression
tests for domain routing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></summary>
<hr>

tests/regression/issue_11806_test.go
<li>Added comprehensive regression tests for domain routing issues.<br>
<li> Included tests for mux router and gateway router behaviors.<br>


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6289/files#diff-6414917e8c31f924c3a423765e285a34d988e923bd0f10d5cc56bacad99195d8">+165/-0</a>&nbsp;
</td>
</tr>                    

<tr>
  <td>
    <details>
<summary><strong>issue-11806-api-no-domain.json</strong><dd><code>Add
test API spec without domain</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

tests/regression/testdata/issue-11806-api-no-domain.json
- Added a new test API spec without a domain.



</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6289/files#diff-e8d8e335343405ef0e02562a51b4f8966cc03fe429e2c4b987504c6147bc00a7">+24/-0</a>&nbsp;
&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
<summary><strong>issue-11806-api-with-domain.json</strong><dd><code>Add
test API spec with domain</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/regression/testdata/issue-11806-api-with-domain.json
- Added a new test API spec with a domain.



</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6289/files#diff-f2b780fe118cacccbfe27e8784d7d2bae3cdc20f37c7bdccb4cf8146c9e6187b">+24/-0</a>&nbsp;
&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools
and their descriptions

---------

Co-authored-by: Tit Petric <tit@tyk.io>

[TT-11806]: https://tyktech.atlassian.net/browse/TT-11806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Enhanced domain handling in API spec loading by prioritizing domain length.
- Fixed minor issues and typos in API loading logic.
- Added support for setting the host header in HTTP tests.
- Introduced comprehensive regression tests to ensure correct domain routing.
- Added new test API specifications for testing domain and non-domain routes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api_loader.go</strong><dd><code>Enhance API loading with domain prioritization and minor fixes</code></dd></summary>
<hr>

gateway/api_loader.go
<li>Improved domain handling in API spec counting.<br> <li> Fixed a typo in a comment.<br> <li> Modified the sorting logic to prioritize domain length before listen <br>path length.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6290/files#diff-cdf0b7f176c9d18e1a314b78ddefc2cb3a94b3de66f1f360174692c915734c68">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>http.go</strong><dd><code>Support host header in HTTP tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/http.go
- Added support for setting the host header in HTTP tests.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6290/files#diff-a5530e34c740ce6fe2efe8dda5a356463c450696b39b97b91228f1be2491e05e">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api_test.go</strong><dd><code>Remove outdated API loader path order test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_test.go
<li>Removed a large block of test code related to API loader path <br>ordering.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6290/files#diff-10b4a3d7bdd8d98e48b288d27fd46d9ee436617806c46913fdf7942c0e4a992e">+0/-50</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>issue_11806_test.go</strong><dd><code>Comprehensive regression tests for domain routing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/regression/issue_11806_test.go
<li>Added a comprehensive regression test suite for domain routing issues.<br> <li> Tests both loading orders of APIs with and without domains.<br> <li> Includes direct testing with gorilla/mux to ensure correct subrouter <br>behavior.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6290/files#diff-6414917e8c31f924c3a423765e285a34d988e923bd0f10d5cc56bacad99195d8">+176/-0</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>issue-11806-api-no-domain.json</strong><dd><code>New test API spec without domain</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/regression/testdata/issue-11806-api-no-domain.json
- Added a new test API specification without a domain.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6290/files#diff-e8d8e335343405ef0e02562a51b4f8966cc03fe429e2c4b987504c6147bc00a7">+24/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>issue-11806-api-with-domain.json</strong><dd><code>New test API spec with domain</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/regression/testdata/issue-11806-api-with-domain.json
- Added a new test API specification with a domain.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6290/files#diff-f2b780fe118cacccbfe27e8784d7d2bae3cdc20f37c7bdccb4cf8146c9e6187b">+24/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci-tests.yml</strong><dd><code>Update CI configuration for test exclusions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-tests.yml
- Updated SonarQube test exclusions to include the 'test' directory.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6290/files#diff-03609cb60b0c6e92fb771eb8787d6722b8c31ca4c03eabc788e147acd8c6fb43">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

