### PR TITLE
[TT-12095] Fixing unhashed API keys exposed in OTEL spans

### DIFF
--- a/gateway/mw_auth_key.go
+++ b/gateway/mw_auth_key.go
@@ -122,6 +122,7 @@ func (k *AuthKey) ProcessRequest(_ http.ResponseWriter, r *http.Request, _ inter
 
 	session, keyExists = k.CheckSessionAndIdentityForValidKey(key, r)
 	key = session.KeyID
+	hashedKey := session.KeyHash()
 	if !keyExists {
 		// fallback to search by cert
 		session, keyExists = k.CheckSessionAndIdentityForValidKey(certHash, r)
@@ -152,7 +153,7 @@ func (k *AuthKey) ProcessRequest(_ http.ResponseWriter, r *http.Request, _ inter
 		ctxSetSession(r, &session, updateSession, k.Gw.GetConfig().HashKeys)
 		k.setContextVars(r, key)
 		ctxSetSpanAttributes(r, k.Name(), []otel.SpanAttribute{
-			otel.APIKeyAttribute(key),
+			otel.APIKeyAttribute(hashedKey),
 			otel.APIKeyAliasAttribute(session.Alias),
 		}...)
 	}

--- a/gateway/mw_auth_key.go
+++ b/gateway/mw_auth_key.go
@@ -122,7 +122,6 @@ func (k *AuthKey) ProcessRequest(_ http.ResponseWriter, r *http.Request, _ inter
 
 	session, keyExists = k.CheckSessionAndIdentityForValidKey(key, r)
 	key = session.KeyID
-	hashedKey := session.KeyHash()
 	if !keyExists {
 		// fallback to search by cert
 		session, keyExists = k.CheckSessionAndIdentityForValidKey(certHash, r)
@@ -150,12 +149,18 @@ func (k *AuthKey) ProcessRequest(_ http.ResponseWriter, r *http.Request, _ inter
 	// Set session state on context, we will need it later
 	switch k.Spec.BaseIdentityProvidedBy {
 	case apidef.AuthToken, apidef.UnsetAuth:
-		ctxSetSession(r, &session, updateSession, k.Gw.GetConfig().HashKeys)
+		hashKeys := k.Gw.GetConfig().HashKeys
+		ctxSetSession(r, &session, updateSession, hashKeys)
+
 		k.setContextVars(r, key)
-		ctxSetSpanAttributes(r, k.Name(), []otel.SpanAttribute{
-			otel.APIKeyAttribute(hashedKey),
-			otel.APIKeyAliasAttribute(session.Alias),
-		}...)
+
+		attributes := []otel.SpanAttribute{otel.APIKeyAliasAttribute(session.Alias)}
+
+		if hashKeys {
+			attributes = append(attributes, otel.APIKeyAttribute(session.KeyHash()))
+		}
+
+		ctxSetSpanAttributes(r, k.Name(), attributes...)
 	}
 
 	// Try using org-key format first:

--- a/gateway/mw_oauth2_key_exists.go
+++ b/gateway/mw_oauth2_key_exists.go
@@ -130,7 +130,7 @@ func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request,
 	switch k.Spec.BaseIdentityProvidedBy {
 	case apidef.OAuthKey, apidef.UnsetAuth:
 		ctxSetSession(r, &session, false, k.Gw.GetConfig().HashKeys)
-		ctxSetSpanAttributes(r, k.Name(), otel.OAuthClientIDAttribute(session.OauthClientID))
+		ctxSetSpanAttributes(r, k.Name(), otel.OAuthClientIDAttribute(session.KeyHash()))
 	}
 
 	// Request is valid, carry on

--- a/gateway/mw_oauth2_key_exists.go
+++ b/gateway/mw_oauth2_key_exists.go
@@ -129,8 +129,11 @@ func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request,
 	// Set session state on context, we will need it later
 	switch k.Spec.BaseIdentityProvidedBy {
 	case apidef.OAuthKey, apidef.UnsetAuth:
-		ctxSetSession(r, &session, false, k.Gw.GetConfig().HashKeys)
-		ctxSetSpanAttributes(r, k.Name(), otel.OAuthClientIDAttribute(session.KeyHash()))
+		hashKeys := k.Gw.GetConfig().HashKeys
+		ctxSetSession(r, &session, false, hashKeys)
+		if hashKeys {
+			ctxSetSpanAttributes(r, k.Name(), otel.OAuthClientIDAttribute(session.KeyHash()))
+		}
 	}
 
 	// Request is valid, carry on


### PR DESCRIPTION
### **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description
`tyk.api.apikey` and `tyk.api.oauthid` attributes were exposing keys when OTEL was enabled. Now, the value of this attribute is the hashed key instead.
Can be checked when creating a key:
<img width="543" alt="image" src="https://github.com/TykTechnologies/tyk/assets/83959431/167e18b8-234f-4b2e-af19-35aa75bb3339">
Now, the attribute must show the hashed key, not the actual key.
<!-- Describe your changes in detail -->

## Related Issue
https://tyktech.atlassian.net/browse/TT-12095?atlOrigin=eyJpIjoiMGJkNjAxOTI1MWQ5NGE0ZWIyNDgyNzlmMDcxMTM4YmEiLCJwIjoiaiJ9
<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context
https://tyktech.atlassian.net/browse/TT-12095?atlOrigin=eyJpIjoiMGJkNjAxOTI1MWQ5NGE0ZWIyNDgyNzlmMDcxMTM4YmEiLCJwIjoiaiJ9
<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Bug fix


___

### **Description**
- Updated `gateway/mw_auth_key.go` to use the hashed API key in OTEL span attributes instead of the plain key.
- Updated `gateway/mw_oauth2_key_exists.go` to use the hashed OAuth client ID in OTEL span attributes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mw_auth_key.go</strong><dd><code>Use hashed API key in OTEL span attributes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_auth_key.go
<li>Added <code>hashedKey</code> variable to store the hashed key from the session.<br> <li> Updated OTEL span attribute to use the hashed key instead of the plain <br>key.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6296/files#diff-aeba053023a54c723dd9f83837e29ca0b2d9a212bc98fa6ad4bbb062669a1cf0">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_oauth2_key_exists.go</strong><dd><code>Use hashed OAuth client ID in OTEL span attributes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_oauth2_key_exists.go
<li>Updated OTEL span attribute to use the hashed key for OAuth client ID.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6296/files#diff-c50b0affcb835d15ff9bd169b21775b8023ebb0558a0c59d6c26cb821db544e9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

