### PR TITLE
Use canonical golang:1.22 image to test otel breaking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,9 @@ jobs:
           echo '#!/bin/sh
           ci/bin/unlock-agent.sh
           go install github.com/tyklabs/packagecloud@latest
+          curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
+          echo "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+          apt-get update && apt-get install -y docker-ce-cli
           curl -fsSL https://github.com/goreleaser/goreleaser/releases/latest/download/goreleaser_Linux_x86_64.tar.gz  | tar -C /usr/bin/ -xzf - goreleaser
           git config --global url."https://${{ secrets.ORG_GH_TOKEN }}@github.com".insteadOf "https://github.com"
           git config --global --add safe.directory /go/src/github.com/TykTechnologies/tyk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
           - 1.21-bullseye
         include:
           - golang_cross: 1.21-bullseye
+            override: golang:1.22
             goreleaser: 'ci/goreleaser/goreleaser.yml'
             cgo: 1
             rpmvers: 'el/7 el/8 el/9 amazon/2 amazon/2023'
@@ -81,6 +82,8 @@ jobs:
         run: |
           echo '#!/bin/sh
           ci/bin/unlock-agent.sh
+          go install github.com/tyklabs/packagecloud@latest
+          curl -fsSL https://github.com/goreleaser/goreleaser/releases/latest/download/goreleaser_Linux_x86_64.tar.gz  | tar -C /usr/bin/ -xzf - goreleaser
           git config --global url."https://${{ secrets.ORG_GH_TOKEN }}@github.com".insteadOf "https://github.com"
           git config --global --add safe.directory /go/src/github.com/TykTechnologies/tyk
           goreleaser release --clean -f ${{ matrix.goreleaser }} ${{ !startsWith(github.ref, 'refs/tags/') && ' --snapshot --skip=sign' || '' }}' | tee /tmp/build.sh
@@ -103,7 +106,7 @@ jobs:
           -v ~/.cache/go-build:/cache/go-build                                   \
           -v /tmp/build.sh:/tmp/build.sh                                         \
           -w /go/src/github.com/TykTechnologies/tyk                      \
-          tykio/golang-cross:${{ matrix.golang_cross }} /tmp/build.sh
+          ${{ matrix.override }} /tmp/build.sh
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::754489498669:role/ecr_rw_tyk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,7 @@ jobs:
         run: |
           echo '#!/bin/sh
           ci/bin/unlock-agent.sh
+          apt-get update && apt-get upgrade && apt install -y lsb-release
           go install github.com/tyklabs/packagecloud@latest
           curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
           echo "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,10 +147,10 @@ jobs:
           set +e
           IFS=$'\n' tags=($t)
           for tag in "${tags[@]}"; do
-             for arch in amd64 arm64; do
+             for arch in amd64; do
                  docker tag tykio/tyk-gateway:${build_tag}-${arch} ${tag}-${arch} && docker push ${tag}-${arch}
              done
-             docker manifest create ${tag} ${tag}-amd64 ${tag}-arm64 && docker manifest push ${tag}
+             docker manifest create ${tag} ${tag}-amd64 && docker manifest push ${tag}
           done
       - uses: actions/upload-artifact@v4
         if: ${{ matrix.golang_cross == '1.21-bullseye' }}
@@ -410,7 +410,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: "."
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           file: ci/Dockerfile.distroless
           push: ${{ startsWith(github.ref, 'refs/tags') }}
           tags: ${{ steps.distroless_metadata.outputs.tags }}
@@ -426,7 +426,6 @@ jobs:
       matrix:
         arch:
           - amd64
-          - arm64
         distro:
           - ubuntu:xenial
           - ubuntu:bionic

--- a/ci/goreleaser/goreleaser.yml
+++ b/ci/goreleaser/goreleaser.yml
@@ -19,38 +19,6 @@ builds:
     goarch:
       - amd64
     binary: tyk
-  - id: std-arm64
-    flags:
-      - -trimpath
-      - -tags=goplugin
-    ldflags:
-      - -X github.com/TykTechnologies/tyk/internal/build.Version={{.Version}}
-      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
-      - -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
-      - -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
-    env:
-      - CC=aarch64-linux-gnu-gcc
-    goos:
-      - linux
-    goarch:
-      - arm64
-    binary: tyk
-  - id: std-s390x
-    flags:
-      - -trimpath
-      - -tags=goplugin
-    ldflags:
-      - -X github.com/TykTechnologies/tyk/internal/build.Version={{.Version}}
-      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
-      - -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
-      - -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
-    env:
-      - CC=s390x-linux-gnu-gcc
-    goos:
-      - linux
-    goarch:
-      - s390x
-    binary: tyk
 dockers:
   # Build tykio/tyk-gateway, docker.tyk.io/tyk-gateway/tyk-gateway (amd64)
   - ids:
@@ -80,93 +48,22 @@ dockers:
       - "policies"
       - "coprocess"
       - "tyk.conf.example"
-  # Build gateway hybrid container amd64
-  - ids:
-      - std
-    image_templates:
-      - "tykio/tyk-hybrid-docker:{{.Tag}}-amd64"
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}-hybrid"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-    use: buildx
-    goarch: amd64
-    goos: linux
-    dockerfile: ci/images/hybrid/Dockerfile
-    extra_files:
-      - "ci/images/hybrid/"
-  # The plugin compiler image is built outside of goreleaser in a
-  # plugin-compiler-build workflow.
-  # Build tykio/tyk-gateway, docker.tyk.io/tyk-gateway/tyk-gateway (arm64)
-  - ids:
-      - std
-    image_templates:
-      - "tykio/tyk-gateway:{{.Tag}}-arm64"
-      - "docker.tyk.io/tyk-gateway/tyk-gateway:{{.Tag}}-arm64"
-    build_flag_templates:
-      - "--build-arg=PORTS=8080"
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-    use: buildx
-    goarch: arm64
-    goos: linux
-    dockerfile: ci/Dockerfile.std
-    extra_files:
-      - "ci/install/"
-      - "README.md"
-      - "LICENSE.md"
-      - "apps/app_sample.json"
-      - "templates"
-      - "middleware"
-      - "event_handlers/sample"
-      - "policies"
-      - "coprocess"
-      - "tyk.conf.example"
-  # Build gateway hybrid container arm64
-  - ids:
-      - std
-    image_templates:
-      - "tykio/tyk-hybrid-docker:{{.Tag}}-arm64"
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}-hybrid"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-    use: buildx
-    goarch: arm64
-    goos: linux
-    dockerfile: ci/images/hybrid/Dockerfile
-    extra_files:
-      - "ci/images/hybrid/"
-      # The plugin compiler image is built outside of goreleaser in a
-      # plugin-compiler-build workflow.
 docker_manifests:
   - name_template: tykio/tyk-gateway:{{ .Tag }}
     image_templates:
       - tykio/tyk-gateway:{{ .Tag }}-amd64
-      - tykio/tyk-gateway:{{ .Tag }}-arm64
   - name_template: tykio/tyk-gateway:v{{ .Major }}.{{ .Minor }}{{.Prerelease}}
     image_templates:
       - tykio/tyk-gateway:{{ .Tag }}-amd64
-      - tykio/tyk-gateway:{{ .Tag }}-arm64
   - name_template: tykio/tyk-gateway:v{{ .Major }}{{.Prerelease}}
     image_templates:
       - tykio/tyk-gateway:{{ .Tag }}-amd64
-      - tykio/tyk-gateway:{{ .Tag }}-arm64
   - name_template: tykio/tyk-hybrid-docker:{{ .Tag }}
     image_templates:
       - tykio/tyk-hybrid-docker:{{ .Tag }}-amd64
-      - tykio/tyk-hybrid-docker:{{ .Tag }}-arm64
   - name_template: docker.tyk.io/tyk-gateway/tyk-gateway:{{ .Tag }}
     image_templates:
       - docker.tyk.io/tyk-gateway/tyk-gateway:{{ .Tag }}-amd64
-      - docker.tyk.io/tyk-gateway/tyk-gateway:{{ .Tag }}-arm64
 nfpms:
   - id: std
     vendor: "Tyk Technologies Ltd"
@@ -177,8 +74,6 @@ nfpms:
     file_name_template: "{{ .ConventionalFileName }}"
     builds:
       - std-linux
-      - std-arm64
-      - std-s390x
     formats:
       - deb
       - rpm


### PR DESCRIPTION
- try to build with golang:1.22
- eject arm/other builds for now