### PR TITLE
[TT-12193] Fix poor error handling in webhook event templates

### DIFF
--- a/gateway/event_handler_webhooks.go
+++ b/gateway/event_handler_webhooks.go
@@ -200,7 +200,10 @@ func (w *WebHookHandler) BuildRequest(reqBody string) (*http.Request, error) {
 
 func (w *WebHookHandler) CreateBody(em config.EventMessage) (string, error) {
 	var reqBody bytes.Buffer
-	w.template.Execute(&reqBody, em)
+
+	if err := w.template.Execute(&reqBody, em); err != nil {
+		return "", err
+	}
 
 	return reqBody.String(), nil
 }

--- a/gateway/event_handler_webhooks_test.go
+++ b/gateway/event_handler_webhooks_test.go
@@ -12,19 +12,19 @@ import (
 	"github.com/TykTechnologies/tyk/header"
 )
 
-func (ts *Test) createGetHandler() *WebHookHandler {
-	eventHandlerConf := config.WebHookHandlerConf{
+func (ts *Test) createWebHookHandler(t *testing.T) *WebHookHandler {
+	t.Helper()
+
+	handler := &WebHookHandler{Gw: ts.Gw}
+	err := handler.Init(config.WebHookHandlerConf{
 		TargetPath:   TestHttpGet,
 		Method:       "GET",
 		EventTimeout: 10,
-		TemplatePath: "../templates/default_webhook.json",
 		HeaderList:   map[string]string{"x-tyk-test": "TEST"},
-	}
-	ev := &WebHookHandler{Gw: ts.Gw}
-	if err := ev.Init(eventHandlerConf); err != nil {
-		panic(err)
-	}
-	return ev
+	})
+	assert.NoError(t, err)
+
+	return handler
 }
 
 func TestNewValid(t *testing.T) {
@@ -86,7 +86,7 @@ func TestChecksum(t *testing.T) {
 		"timestamp": 2014-11-27 12:52:05.944549825 &#43;0000 GMT
 	}`
 
-	hook := ts.createGetHandler()
+	hook := ts.createWebHookHandler(t)
 	checksum, err := hook.Checksum(rBody)
 
 	if err != nil {
@@ -103,7 +103,7 @@ func TestBuildRequest(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()
 
-	hook := ts.createGetHandler()
+	hook := ts.createWebHookHandler(t)
 
 	rBody := `{
 		"event": "QuotaExceeded",
@@ -151,9 +151,8 @@ func TestBuildRequestIngoreCanonicalHeaderKey(t *testing.T) {
 		t.Fatal(err)
 	}
 	req, err := ev.BuildRequest("")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
+
 	got := req.Header[NonCanonicalHeaderKey][0]
 	if got != NonCanonicalHeaderKey {
 		t.Errorf("expected %q got %q", NonCanonicalHeaderKey, got)
@@ -167,17 +166,16 @@ func TestCreateBody(t *testing.T) {
 	em := config.EventMessage{
 		Type:      EventQuotaExceeded,
 		TimeStamp: "0",
+		Meta:      EventKeyFailureMeta{},
 	}
 
-	hook := ts.createGetHandler()
+	hook := ts.createWebHookHandler(t)
 	body, err := hook.CreateBody(em)
-	if err != nil {
-		t.Error("Create body failed with error! ", err)
-	}
+	assert.NoError(t, err)
 
 	expectedBody := `"event": "QuotaExceeded"`
 	if !strings.Contains(body, expectedBody) {
-		t.Error("Body incorrect, is: ", body)
+		t.Errorf("Body incorrect, is: %q", body)
 	}
 }
 
@@ -185,7 +183,7 @@ func TestGet(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()
 
-	eventHandler := ts.createGetHandler()
+	eventHandler := ts.createWebHookHandler(t)
 
 	eventMessage := config.EventMessage{
 		Type: EventKeyExpired,
@@ -196,7 +194,9 @@ func TestGet(t *testing.T) {
 			Key:              "123456789",
 		},
 	}
-	body, _ := eventHandler.CreateBody(eventMessage)
+
+	body, err := eventHandler.CreateBody(eventMessage)
+	assert.NoError(t, err)
 
 	checksum, _ := eventHandler.Checksum(body)
 	eventHandler.HandleEvent(eventMessage)
@@ -325,9 +325,7 @@ func TestWebhookContentTypeHeader(t *testing.T) {
 			}
 
 			req, err := hook.BuildRequest("")
-			if err != nil {
-				t.Fatal("Failed to build request with error ", err)
-			}
+			assert.NoError(t, err)
 
 			if req.Header.Get(header.ContentType) != ts.ExpectedContentType {
 				t.Fatalf("Expect Content-Type %s. Got %s", ts.ExpectedContentType, req.Header.Get("Content-Type"))


### PR DESCRIPTION
### **User description**
Fixes error handling in webhook handler templates

https://tyktech.atlassian.net/browse/TT-12193

___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added error handling for template execution in the `CreateBody` method of `WebHookHandler`.
- Refactored test helper function to include error handling.
- Replaced panic and error checks with `assert.NoError` in tests.
- Improved error messages in tests for better clarity.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>event_handler_webhooks.go</strong><dd><code>Add error handling in `CreateBody` method of WebHookHandler</code></dd></summary>
<hr>

gateway/event_handler_webhooks.go
<li>Added error handling for template execution in <code>CreateBody</code> method.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6303/files#diff-6587ad3f2629cfa6c84a71144127acd6cc7824e5141f0b4961848945a87e0198">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>event_handler_webhooks_test.go</strong><dd><code>Improve error handling and assertions in webhook handler tests</code></dd></summary>
<hr>

gateway/event_handler_webhooks_test.go
<li>Refactored test helper function to include error handling.<br> <li> Replaced panic and error checks with <code>assert.NoError</code>.<br> <li> Improved error messages in tests.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6303/files#diff-1a2f8d6ab4443031b0f8486809453f6389291a6f625745fe8c65ac5cdb0e9621">+22/-24</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

