### PR TITLE
feat/TT-9462/tag-cached-response

### DIFF
--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -445,7 +445,7 @@ func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 			ReadSeeker: strings.NewReader(returnObject.Request.ReturnOverrides.ResponseBody),
 		}
 		res.ContentLength = int64(len(returnObject.Request.ReturnOverrides.ResponseBody))
-		m.successHandler.RecordHit(r, analytics.Latency(analytics.Latency{Total: int64(ms)}), int(returnObject.Request.ReturnOverrides.ResponseCode), res)
+		m.successHandler.RecordHit(r, analytics.Latency(analytics.Latency{Total: int64(ms)}), int(returnObject.Request.ReturnOverrides.ResponseCode), res, false)
 		return nil, mwStatusRespond
 	}
 

--- a/gateway/handler_success.go
+++ b/gateway/handler_success.go
@@ -162,7 +162,7 @@ func recordGraphDetails(rec *analytics.AnalyticsRecord, r *http.Request, resp *h
 	rec.GraphQLStats = stats
 }
 
-func (s *SuccessHandler) RecordHit(r *http.Request, timing analytics.Latency, code int, responseCopy *http.Response) {
+func (s *SuccessHandler) RecordHit(r *http.Request, timing analytics.Latency, code int, responseCopy *http.Response, cached bool) {
 
 	if s.Spec.DoNotTrack || ctxGetDoNotTrack(r) {
 		return
@@ -199,6 +199,10 @@ func (s *SuccessHandler) RecordHit(r *http.Request, timing analytics.Latency, co
 
 		if len(s.Spec.Tags) > 0 {
 			tags = append(tags, s.Spec.Tags...)
+		}
+
+		if cached {
+			tags = append(tags, "cached-response")
 		}
 
 		rawRequest := ""
@@ -377,7 +381,7 @@ func (s *SuccessHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) *http
 			Total:    int64(millisec),
 			Upstream: int64(DurationToMillisecond(resp.UpstreamLatency)),
 		}
-		s.RecordHit(r, latency, resp.Response.StatusCode, resp.Response)
+		s.RecordHit(r, latency, resp.Response.StatusCode, resp.Response, false)
 	}
 	log.Debug("Done proxy")
 	return nil
@@ -404,7 +408,7 @@ func (s *SuccessHandler) ServeHTTPWithCache(w http.ResponseWriter, r *http.Reque
 			Total:    int64(millisec),
 			Upstream: int64(DurationToMillisecond(inRes.UpstreamLatency)),
 		}
-		s.RecordHit(r, latency, inRes.Response.StatusCode, inRes.Response)
+		s.RecordHit(r, latency, inRes.Response.StatusCode, inRes.Response, false)
 	}
 
 	return inRes

--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -263,7 +263,7 @@ func (m *GoPluginMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reque
 			logger.WithError(err).Error("Failed to process request with Go-plugin middleware func")
 		default:
 			// record 2XX to analytics
-			successHandler.RecordHit(r, analytics.Latency{Total: int64(ms)}, rw.statusCodeSent, rw.getHttpResponse(r))
+			successHandler.RecordHit(r, analytics.Latency{Total: int64(ms)}, rw.statusCodeSent, rw.getHttpResponse(r), false)
 
 			// no need to continue passing this request down to reverse proxy
 			respCode = mwStatusRespond

--- a/gateway/mw_redis_cache.go
+++ b/gateway/mw_redis_cache.go
@@ -275,7 +275,7 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 	// Record analytics
 	if !m.Spec.DoNotTrack {
 		ms := DurationToMillisecond(time.Since(t1))
-		m.sh.RecordHit(r, analytics.Latency{Total: int64(ms)}, newRes.StatusCode, newRes)
+		m.sh.RecordHit(r, analytics.Latency{Total: int64(ms)}, newRes.StatusCode, newRes, true)
 	}
 
 	// Stop any further execution after we wrote cache out

--- a/gateway/mw_virtual_endpoint.go
+++ b/gateway/mw_virtual_endpoint.go
@@ -234,7 +234,7 @@ func (d *VirtualEndpoint) ServeHTTPForCache(w http.ResponseWriter, r *http.Reque
 	d.Logger().Debug("JSVM Virtual Endpoint execution took: (ms) ", ms)
 
 	if copiedResponse != nil {
-		d.sh.RecordHit(r, analytics.Latency{Total: int64(ms)}, copiedResponse.StatusCode, copiedResponse)
+		d.sh.RecordHit(r, analytics.Latency{Total: int64(ms)}, copiedResponse.StatusCode, copiedResponse, false)
 	}
 
 	return copiedResponse, nil


### PR DESCRIPTION
### **User description**
## Description

For users of our redis cache there is currently no simple way to slice the analytics or log data in the dashboard by whether that traffic is cached from Tyk or not.

This feat adds a simple case that adds the tag "cached-response" anytime a response is served from our redis cache.


## Related Issue

https://tyktech.atlassian.net/browse/TT-9462



## How This Has Been Tested

1. Create API and enable caching - all safe request or per endpoint is a good option to test. It doesnt not make any difference which you choose.
2. send more than one request to the API
3. Check analytics and logs in Tyk dashboard, you can filter graphs by tag "cached-response" to split cached and non cached counters
4. Check log browser, response will contain "cached-response" tag when the cache hit occurs

## Screenshots (if appropriate)

<img width="1243" alt="Screenshot 2024-05-23 at 17 08 11" src="https://github.com/TykTechnologies/tyk/assets/31618778/3cdd5f66-60ea-47e2-83be-6be229ac6c8d">
<img width="1244" alt="Screenshot 2024-05-23 at 17 08 24" src="https://github.com/TykTechnologies/tyk/assets/31618778/2eaa844c-9ceb-46ed-9c34-aa841ea2745a">
<img width="1242" alt="Screenshot 2024-05-23 at 17 08 44" src="https://github.com/TykTechnologies/tyk/assets/31618778/5a88b36d-eceb-4752-9e53-1cf812417954">
<img width="1240" alt="Screenshot 2024-05-23 at 17 10 32" src="https://github.com/TykTechnologies/tyk/assets/31618778/60b7e298-30dc-4b7a-bb53-e02d5f8550d9">


## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Enhancement


___

### **Description**
- Enhanced the `RecordHit` function to accept a `cached` parameter.
- Added logic to tag responses with `cached-response` if they are served from the cache.
- Updated various middleware components to pass the `cached` parameter to `RecordHit`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coprocess.go</strong><dd><code>Add `cached` parameter to `RecordHit` function call.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/coprocess.go
- Updated `RecordHit` function call to include a `cached` parameter.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6308/files#diff-9cbfe628982b2afb94d1e9a5200fc9a4fdc00cb58fe65d1090a3725e4e4c5953">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>handler_success.go</strong><dd><code>Enhance `RecordHit` function to tag cached responses.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/handler_success.go
<li>Modified <code>RecordHit</code> function to accept a <code>cached</code> parameter.<br> <li> Added logic to append <code>cached-response</code> tag if <code>cached</code> is true.<br> <li> Updated <code>ServeHTTP</code> and <code>ServeHTTPWithCache</code> functions to call <code>RecordHit</code> <br>with <code>cached</code> parameter.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6308/files#diff-45135957493eca37f2e3e9a81079577777133c53b27cf95ea2ff0329c05bd006">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_go_plugin.go</strong><dd><code>Add `cached` parameter to `RecordHit` function call.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_go_plugin.go
- Updated `RecordHit` function call to include a `cached` parameter.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6308/files#diff-0f31abef73bf795e1a8d331202330c73011a74d10fd66e49b9359716a6d18fd9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_redis_cache.go</strong><dd><code>Tag responses from Redis cache as cached.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_redis_cache.go
<li>Updated <code>RecordHit</code> function call to include a <code>cached</code> parameter set to <br>true.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6308/files#diff-6266e0dbd16cef89e6de86a2c893114ba07799c804e2138172f9f94b08cdded8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_virtual_endpoint.go</strong><dd><code>Add `cached` parameter to `RecordHit` function call.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_virtual_endpoint.go
- Updated `RecordHit` function call to include a `cached` parameter.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6308/files#diff-daf72ac3b29609a9f2a77cccf648f91ba62b2ad977a7c5a44602c72b2a28b2e5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

