### PR TITLE
[TT-9914] Update gorilla/mux, add flag to enable regexp caching

### DIFF
--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -570,6 +570,9 @@
         "enable_path_suffix_matching": {
           "type": "boolean"
         },
+        "enable_regexp_cache": {
+          "type": "boolean"
+        },
         "flush_interval": {
           "type": "integer"
         },

--- a/config/config.go
+++ b/config/config.go
@@ -479,6 +479,15 @@ type HttpServerOptionsConfig struct {
 	// Combining EnablePathSuffixMatching with EnablePathPrefixMatching will result in exact URL matching, with `/json` being evaluated as `^/json$`.
 	EnablePathSuffixMatching bool `json:"enable_path_suffix_matching"`
 
+	// EnableRegexpCache enables caching mux routes. This optimizes gateway reload behaviour, as the
+	// routes regular expressions only get compiled once. It's recommended to turn this on if you
+	// issue gateway reload commands. If you have a significant number of routes, memory usage
+	// can be optimized by keeping the cache disabled. The cache is disabled by default.
+	//
+	// The setting depends on `disable_regexp_cache=false`.
+	// By default, regexp cache is disabled.
+	EnableRegexpCache bool `json:"enable_regexp_cache"`
+
 	// Disable TLS verification. Required if you are using self-signed certificates.
 	SSLInsecureSkipVerify bool `json:"ssl_insecure_skip_verify"`
 

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.1
 	github.com/golang/protobuf v1.5.4
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/gorilla/mux v1.8.1
+	github.com/gorilla/mux v1.8.2-0.20240619235004-db9d1d0073d2
 	github.com/gorilla/websocket v1.5.3
 	github.com/hashicorp/consul/api v1.30.0
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -345,8 +345,8 @@ github.com/gorilla/css v1.0.1/go.mod h1:BvnYkspnSzMmwRK+b8/xgNPLiIuNZr6vbZBTPQ2A
 github.com/gorilla/handlers v1.5.2 h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyEE=
 github.com/gorilla/handlers v1.5.2/go.mod h1:dX+xVpaxdSw+q0Qek8SSsl3dfMk3jNddUkMzo0GtH0w=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
-github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
-github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
+github.com/gorilla/mux v1.8.2-0.20240619235004-db9d1d0073d2 h1:oZRjfKe/6Qh676XFYvylkCWd0gu8KVZeZYZwkNw6NAU=
+github.com/gorilla/mux v1.8.2-0.20240619235004-db9d1d0073d2/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=

--- a/regexp/cache.go
+++ b/regexp/cache.go
@@ -39,7 +39,7 @@ func (c *cache) add(key string, value interface{}) {
 
 func (c *cache) getRegexp(key string) (*regexp.Regexp, bool) {
 	if val, found := c.Get(key); found {
-		return val.(*regexp.Regexp).Copy(), true
+		return val.(*regexp.Regexp), true
 	}
 
 	return nil, false

--- a/regexp/regexp.go
+++ b/regexp/regexp.go
@@ -52,6 +52,15 @@ func Compile(expr string) (*Regexp, error) {
 	return compileCache.do(expr)
 }
 
+// CompileNative invokes Compile and unwraps the standard library *regexp.Regexp value.
+func CompileNative(expr string) (*regexp.Regexp, error) {
+	r, err := Compile(expr)
+	if err != nil {
+		return nil, err
+	}
+	return r.Regexp, nil
+}
+
 // CompilePOSIX does the same as regexp.CompilePOSIX but returns cached *Regexp instead.
 func CompilePOSIX(expr string) (*Regexp, error) {
 	return compilePOSIXCache.do(expr)


### PR DESCRIPTION
### **User description**
This PR improves performance in reload-heavy deployments. If the new flag is enabled, gorilla/mux should use the caching implementation from the regexp package, meaning each subsequent reload would avoid regexp compilation.


___

### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Added `EnableRegexpCache` configuration option to enable caching of mux routes, improving reload performance.
- Implemented logic in the gateway server to conditionally enable or disable regexp caching based on the new configuration option.
- Modified `getRegexp` function in the cache to return the original regexp object instead of a copy, optimizing retrieval.
- Added `CompileNative` function to unwrap standard library `*regexp.Regexp` values.
- Updated schema to include the `enable_regexp_cache` boolean option.
- Updated `gorilla/mux` dependency to a newer version and adjusted checksums accordingly.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.go</strong><dd><code>Add `EnableRegexpCache` option for mux route caching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/config.go
<li>Added <code>EnableRegexpCache</code> configuration option to enable caching of mux <br>routes.<br> <li> Documented the impact of enabling the cache on memory usage and reload <br>performance.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6309/files#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>server.go</strong><dd><code>Implement conditional regexp caching in gateway server</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/server.go
<li>Implemented logic to enable or disable regexp caching based on <br>configuration.<br> <li> Set <code>mux.RegexpCompileFunc</code> to use cached or standard regexp <br>compilation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6309/files#diff-4652d1bf175a0be8f5e61ef7177c9666f23e077d8626b73ac9d13358fa8b525b">+11/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cache.go</strong><dd><code>Optimize regexp cache retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

regexp/cache.go
<li>Modified <code>getRegexp</code> function to return the original regexp object <br>instead of a copy.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6309/files#diff-0420ba44813cfb841c564160f4a3106d2a9bc4c4477dc8ee4ab97582253f7753">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>regexp.go</strong><dd><code>Add `CompileNative` function for standard regexp unwrapping</code></dd></summary>
<hr>

regexp/regexp.go
<li>Added <code>CompileNative</code> function to unwrap standard library <code>*regexp.Regexp</code> <br>values.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6309/files#diff-79becb44849a31d956b769320262a37ae8445436bcb1d2553192f7d3e6277ebb">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schema.json</strong><dd><code>Update schema with `enable_regexp_cache` option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/linter/schema.json
- Added `enable_regexp_cache` boolean option to the schema.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6309/files#diff-103cec746d3e61d391c5a67c171963f66fea65d651d704d5540e60aa5d574f46">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Dependencies
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Update `gorilla/mux` dependency version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go.mod
<li>Updated <code>gorilla/mux</code> dependency to version <br><code>v1.8.2-0.20240522102346-de7178dc9dff</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6309/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>go.sum</strong><dd><code>Update checksums for `gorilla/mux` dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go.sum
<li>Updated checksums for <code>gorilla/mux</code> dependency to match new version.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6309/files#diff-3295df7234525439d778f1b282d146a4f1ff6b415248aaac074e8042d9f42d63">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

