### PR TITLE
Merging to release-5.3: [TT-12193] Add log for event handler webhook (#6310)

### DIFF
--- a/gateway/event_handler_webhooks.go
+++ b/gateway/event_handler_webhooks.go
@@ -207,21 +207,27 @@ func (w *WebHookHandler) BuildRequest(reqBody string) (*http.Request, error) {
 	return req, nil
 }
 
+// CreateBody will render the webhook event message template.
+// If an error occurs, a partially rendered template will be
+// returned alongside the error that occured.
 func (w *WebHookHandler) CreateBody(em config.EventMessage) (string, error) {
 	var reqBody bytes.Buffer
-
-	if err := w.template.Execute(&reqBody, em); err != nil {
-		return "", err
-	}
-
-	return reqBody.String(), nil
+	err := w.template.Execute(&reqBody, em)
+	return reqBody.String(), err
 }
 
 // HandleEvent will be fired when the event handler instance is found in an APISpec EventPaths object during a request chain
 func (w *WebHookHandler) HandleEvent(em config.EventMessage) {
 
 	// Inject event message into template, render to string
-	reqBody, _ := w.CreateBody(em)
+	reqBody, err := w.CreateBody(em)
+	if err != nil {
+		// We're just logging the template rendering issue here
+		// but we're passing on the partial rendered contents
+		log.WithError(err).WithFields(logrus.Fields{
+			"prefix": "webhooks",
+		}).Warn("Webhook template rendering error")
+	}
 
 	// Construct request (method, body, params)
 	req, err := w.BuildRequest(reqBody)


### PR DESCRIPTION
### **User description**
[TT-12193] Add log for event handler webhook (#6310)

Co-authored-by: Tit Petric <tit@tyk.io>

[TT-12193]: https://tyktech.atlassian.net/browse/TT-12193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added logging for webhook template rendering errors in the `HandleEvent` method.
- Modified the `CreateBody` method to return a partially rendered template and the error if one occurs.
- Enhanced error handling in the `HandleEvent` method to log template rendering issues while still passing on the partially rendered contents.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>event_handler_webhooks.go</strong><dd><code>Add logging and error handling for webhook template rendering</code></dd></summary>
<hr>

gateway/event_handler_webhooks.go
<li>Added logging for webhook template rendering errors.<br> <li> Modified <code>CreateBody</code> to return partially rendered template and error.<br> <li> Updated <code>HandleEvent</code> to log errors when template rendering fails.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6311/files#diff-6587ad3f2629cfa6c84a71144127acd6cc7824e5141f0b4961848945a87e0198">+13/-7</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

