### PR TITLE
Merging to release-5.3: [TT-12193] Update error handling on webhook events when the event template has errors (#6312)

### DIFF
--- a/gateway/event_handler_webhooks.go
+++ b/gateway/event_handler_webhooks.go
@@ -207,12 +207,14 @@ func (w *WebHookHandler) BuildRequest(reqBody string) (*http.Request, error) {
 	return req, nil
 }
 
-// CreateBody will render the webhook event message template.
-// If an error occurs, a partially rendered template will be
-// returned alongside the error that occured.
+// CreateBody will render the webhook event message template and return it as a string.
+// If an error occurs, an empty string will be returned alongside an error.
 func (w *WebHookHandler) CreateBody(em config.EventMessage) (string, error) {
 	var reqBody bytes.Buffer
 	err := w.template.Execute(&reqBody, em)
+	if err != nil {
+		return "", err
+	}
 	return reqBody.String(), err
 }
 
@@ -226,7 +228,8 @@ func (w *WebHookHandler) HandleEvent(em config.EventMessage) {
 		// but we're passing on the partial rendered contents
 		log.WithError(err).WithFields(logrus.Fields{
 			"prefix": "webhooks",
-		}).Warn("Webhook template rendering error")
+		}).Error("Webhook template rendering error")
+		return
 	}
 
 	// Construct request (method, body, params)


### PR DESCRIPTION
### **User description**
[TT-12193] Update error handling on webhook events when the event template has errors (#6312)

### **User description**
- Error log raised from Warning to Error, stops handling the event
further
- CreateBody adjusted to not return rendered template contents if error
occurs


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Updated `CreateBody` method to return an empty string and error when
template rendering fails, instead of a partially rendered template.
- Changed log level from warning to error in `HandleEvent` method when a
template rendering error occurs.
- Added early return in `HandleEvent` to stop further processing if a
template error is encountered.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>event_handler_webhooks.go</strong><dd><code>Improve
error handling in webhook event processing</code>&nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/event_handler_webhooks.go
<li>Updated <code>CreateBody</code> to return an empty string on error
instead of a <br>partially rendered template.<br> <li> Changed log level
from warning to error in <code>HandleEvent</code> when a template
<br>rendering error occurs.<br> <li> Added early return in
<code>HandleEvent</code> to stop processing on template <br>error.<br>


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6312/files#diff-6587ad3f2629cfa6c84a71144127acd6cc7824e5141f0b4961848945a87e0198">+7/-4</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools
and their descriptions

Co-authored-by: Tit Petric <tit@tyk.io>

[TT-12193]: https://tyktech.atlassian.net/browse/TT-12193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Updated `CreateBody` method to return an empty string and error when template rendering fails, instead of a partially rendered template.
- Changed log level from warning to error in `HandleEvent` method when a template rendering error occurs.
- Added early return in `HandleEvent` to stop further processing if a template error is encountered.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>event_handler_webhooks.go</strong><dd><code>Improve error handling in webhook event processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/event_handler_webhooks.go
<li>Updated <code>CreateBody</code> to return an empty string on error instead of a <br>partially rendered template.<br> <li> Changed log level from warning to error in <code>HandleEvent</code> when a template <br>rendering error occurs.<br> <li> Added early return in <code>HandleEvent</code> to stop processing on template <br>error.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6313/files#diff-6587ad3f2629cfa6c84a71144127acd6cc7824e5141f0b4961848945a87e0198">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

