### PR TITLE
add logic for use_immutable_headers (TT-12190)

### DIFF
--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -1011,14 +1011,19 @@ func (p *ReverseProxy) handleGraphQL(roundTripper *TykRoundTripper, outreq *http
 	needsEngine := needsGraphQLExecutionEngine(p.TykAPISpec)
 
 	res, hijacked, err = p.TykAPISpec.GraphEngine.HandleReverseProxy(graphengine.ReverseProxyParams{
-		RoundTripper:          roundTripper,
-		ResponseWriter:        w,
-		OutRequest:            outreq,
-		WebSocketUpgrader:     &p.wsUpgrader,
-		NeedsEngine:           needsEngine,
-		IsCORSPreflight:       isCORSPreflight(outreq),
-		IsWebSocketUpgrade:    isWebSocketUpgrade,
-		RequestHeadersRewrite: p.TykAPISpec.GraphQL.Proxy.RequestHeadersRewrite,
+		RoundTripper:       roundTripper,
+		ResponseWriter:     w,
+		OutRequest:         outreq,
+		WebSocketUpgrader:  &p.wsUpgrader,
+		NeedsEngine:        needsEngine,
+		IsCORSPreflight:    isCORSPreflight(outreq),
+		IsWebSocketUpgrade: isWebSocketUpgrade,
+		HeadersConfig: graphengine.ReverseProxyHeadersConfig{
+			ProxyOnly: graphengine.ProxyOnlyHeadersConfig{
+				UseImmutableHeaders:   p.TykAPISpec.GraphQL.Proxy.Features.UseImmutableHeaders,
+				RequestHeadersRewrite: p.TykAPISpec.GraphQL.Proxy.RequestHeadersRewrite,
+			},
+		},
 	})
 	if err != nil {
 		return nil, hijacked, err

--- a/internal/graphengine/engine.go
+++ b/internal/graphengine/engine.go
@@ -85,13 +85,22 @@ type GranularAccessChecker interface {
 }
 
 type ReverseProxyParams struct {
-	RoundTripper          http.RoundTripper
-	ResponseWriter        http.ResponseWriter
-	OutRequest            *http.Request
-	WebSocketUpgrader     *websocket.Upgrader
-	NeedsEngine           bool
-	IsCORSPreflight       bool
-	IsWebSocketUpgrade    bool
+	RoundTripper       http.RoundTripper
+	ResponseWriter     http.ResponseWriter
+	OutRequest         *http.Request
+	WebSocketUpgrader  *websocket.Upgrader
+	NeedsEngine        bool
+	IsCORSPreflight    bool
+	IsWebSocketUpgrade bool
+	HeadersConfig      ReverseProxyHeadersConfig
+}
+
+type ReverseProxyHeadersConfig struct {
+	ProxyOnly ProxyOnlyHeadersConfig
+}
+
+type ProxyOnlyHeadersConfig struct {
+	UseImmutableHeaders   bool
 	RequestHeadersRewrite map[string]apidef.RequestHeadersRewriteConfig
 }
 

--- a/internal/graphengine/graphql_go_tools_v1.go
+++ b/internal/graphengine/graphql_go_tools_v1.go
@@ -490,7 +490,7 @@ func (r *reverseProxyPreHandlerV1) PreHandle(params ReverseProxyParams) (reverse
 		DetermineGraphQLEngineTransportType(r.apiDefinition),
 		params.RoundTripper,
 		r.newReusableBodyReadCloser,
-		params.RequestHeadersRewrite,
+		params.HeadersConfig,
 	)
 
 	switch {

--- a/internal/graphengine/graphql_go_tools_v2.go
+++ b/internal/graphengine/graphql_go_tools_v2.go
@@ -17,6 +17,7 @@ import (
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/graphql"
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/introspection"
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/operationreport"
+
 	"github.com/TykTechnologies/tyk/apidef"
 )
 
@@ -124,7 +125,7 @@ func (r *reverseProxyPreHandlerV2) PreHandle(params ReverseProxyParams) (reverse
 		DetermineGraphQLEngineTransportType(r.apiDefinition),
 		params.RoundTripper,
 		r.newReusableBodyReadCloser,
-		params.RequestHeadersRewrite,
+		params.HeadersConfig,
 	)
 
 	switch {

--- a/internal/graphengine/transport_test.go
+++ b/internal/graphengine/transport_test.go
@@ -1,0 +1,114 @@
+package graphengine
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGraphQLEngineTransport_RoundTrip(t *testing.T) {
+	t.Run("feature use_immutable_headers", func(t *testing.T) {
+		t.Run("should overwrite request headers when use_immutable_headers is false", func(t *testing.T) {
+			transport := NewGraphQLEngineTransport(
+				GraphQLEngineTransportTypeProxyOnly,
+				nopRoundTripper{},
+				testReusableReadCloser,
+				ReverseProxyHeadersConfig{
+					ProxyOnly: ProxyOnlyHeadersConfig{
+						UseImmutableHeaders: false,
+					},
+				},
+			)
+
+			_, ctx, err := prepareInboundRequest(http.MethodPost, "http://example.com/graphql", nil, map[string]string{
+				"Authorization": "Bearer 123",
+			})
+			require.NoError(t, err)
+
+			outboundRequest, err := prepareOutboundRequest(ctx, http.MethodPost, "http://example.com/graphql", nil, map[string]string{
+				"Authorization": "none",
+				"X-Custom":      "added-custom-value",
+			})
+			require.NoError(t, err)
+
+			_, err = transport.RoundTrip(outboundRequest)
+			assert.NoError(t, err)
+			assert.Equal(t, "none", outboundRequest.Header.Get("Authorization"))
+			assert.Equal(t, "added-custom-value", outboundRequest.Header.Get("X-Custom"))
+		})
+
+		t.Run("should not overwrite request headers when use_immutable_headers is true", func(t *testing.T) {
+			transport := NewGraphQLEngineTransport(
+				GraphQLEngineTransportTypeProxyOnly,
+				nopRoundTripper{},
+				testReusableReadCloser,
+				ReverseProxyHeadersConfig{
+					ProxyOnly: ProxyOnlyHeadersConfig{
+						UseImmutableHeaders: true,
+					},
+				},
+			)
+
+			_, ctx, err := prepareInboundRequest(http.MethodPost, "http://example.com/graphql", nil, map[string]string{
+				"Authorization": "Bearer 123",
+			})
+			require.NoError(t, err)
+
+			outboundRequest, err := prepareOutboundRequest(ctx, http.MethodPost, "http://example.com/graphql", nil, map[string]string{
+				"Authorization": "none",
+				"X-Custom":      "added-custom-value",
+			})
+			require.NoError(t, err)
+
+			_, err = transport.RoundTrip(outboundRequest)
+			assert.NoError(t, err)
+			assert.Equal(t, "Bearer 123", outboundRequest.Header.Get("Authorization"))
+			assert.Equal(t, "added-custom-value", outboundRequest.Header.Get("X-Custom"))
+		})
+	})
+}
+
+func prepareInboundRequest(method string, url string, body io.Reader, headers map[string]string) (*http.Request, context.Context, error) {
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+
+	ctx := SetProxyOnlyContextValue(req.Context(), req)
+	return req, ctx, err
+}
+
+func prepareOutboundRequest(ctx context.Context, method string, url string, body io.Reader, headers map[string]string) (*http.Request, error) {
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+
+	req = req.WithContext(ctx)
+	return req, err
+}
+
+type nopRoundTripper struct{}
+
+func (m nopRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp := httptest.NewRecorder()
+	resp.WriteHeader(http.StatusOK)
+	return resp.Result(), nil
+}
+
+func testReusableReadCloser(readCloser io.ReadCloser) (io.ReadCloser, error) {
+	return readCloser, nil
+}


### PR DESCRIPTION
This PR adds the logic for `use_immutable_headers` for GraphQL proxy-only

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)
