### PR TITLE
[TT-11997] Header case insensitivity

### DIFF
--- a/internal/graphengine/transport.go
+++ b/internal/graphengine/transport.go
@@ -100,7 +100,6 @@ func (g *GraphQLEngineTransport) applyRequestHeadersRewriteRules(r *http.Request
 				// Has more than one value, so it's different.
 				// OR
 				// It has only one value, check and overwrite it if required.
-				r.Header.Del(key)
 				r.Header.Set(key, rewriteRule.Value)
 				return true // applied
 			}

--- a/internal/graphengine/transport.go
+++ b/internal/graphengine/transport.go
@@ -137,6 +137,8 @@ func (g *GraphQLEngineTransport) applyRequestHeadersRewriteRules(r *http.Request
 			continue
 		}
 
+		// forwardedHeaderKey is already canonical.
+
 		if ruleOne(r, forwardedHeaderKey, forwardedHeaderValues) {
 			continue
 		}


### PR DESCRIPTION
### **User description**
This PR addresses the problem explained here https://tyktech.atlassian.net/browse/TT-11997?focusedCommentId=54161


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added a new test case to verify request headers rewrite with case insensitivity.
- Canonicalized header names in the `request_headers_rewrite` configuration to ensure consistent handling.
- Removed unnecessary `Header.Del` operation in the header rewrite logic.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mw_graphql_test.go</strong><dd><code>Add test for request headers rewrite case insensitivity</code>&nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_graphql_test.go
<li>Added a new test case to verify request headers rewrite with case <br>insensitivity.<br> <li> Configured the test to check if headers are correctly rewritten before <br>hitting the upstream.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6316/files#diff-72c11b8efcaceccfbbd87e75565353706443bf56420d3fdba6b5bf5f632f4b33">+47/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reverse_proxy.go</strong><dd><code>Canonicalize header names in request headers rewrite configuration</code></dd></summary>
<hr>

gateway/reverse_proxy.go
<li>Canonicalized header names in the <code>request_headers_rewrite</code> <br>configuration.<br> <li> Ensured headers are rewritten using the canonical MIME header key <br>format.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6316/files#diff-e6e07722257f7e41691e471185ad6d84fd56dc9e5459526ea32e9a5e8fa1a01b">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>transport.go</strong><dd><code>Remove unnecessary header deletion in rewrite rules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/graphengine/transport.go
<li>Removed unnecessary <code>Header.Del</code> operation.<br> <li> Ensured header rewrite rules are applied correctly without deletion.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6316/files#diff-564061c9b29366529eb1f6f10fe39671d2ac738a4731ffd2c8b04dcc0a8cd610">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

