### PR TITLE
[TT-11739] Re-add gateway.RateLimitExceeded (Dashboard coupling)

### DIFF
--- a/gateway/event_system.go
+++ b/gateway/event_system.go
@@ -27,6 +27,8 @@ const (
 const (
 	// EventQuotaExceeded is an alias maintained for backwards compatibility.
 	EventQuotaExceeded = event.QuotaExceeded
+	// RateLimitExceeded is an alias maintained for backwards compatibility.
+	RateLimitExceeded = event.RateLimitExceeded
 	// EventAuthFailure is an alias maintained for backwards compatibility.
 	EventAuthFailure = event.AuthFailure
 	// EventKeyExpired is an alias maintained for backwards compatibility.


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added the alias `RateLimitExceeded` in `gateway/event_system.go` to maintain backwards compatibility.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>event_system.go</strong><dd><code>Add alias `RateLimitExceeded` for backwards compatibility</code></dd></summary>
<hr>

gateway/event_system.go
- Added alias `RateLimitExceeded` for backwards compatibility.



</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6318/files#diff-d56e22d4f1b8d2e91bb643d30e678a3819691a18bfae8506b10e0af8dc279a0e">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

