### PR TITLE
[TT-11739] Fix RateLimitExceeded var name to include Event prefix

### DIFF
--- a/gateway/event_system.go
+++ b/gateway/event_system.go
@@ -28,7 +28,7 @@ const (
 	// EventQuotaExceeded is an alias maintained for backwards compatibility.
 	EventQuotaExceeded = event.QuotaExceeded
 	// RateLimitExceeded is an alias maintained for backwards compatibility.
-	RateLimitExceeded = event.RateLimitExceeded
+	EventRateLimitExceeded = event.RateLimitExceeded
 	// EventAuthFailure is an alias maintained for backwards compatibility.
 	EventAuthFailure = event.AuthFailure
 	// EventKeyExpired is an alias maintained for backwards compatibility.


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Renamed `RateLimitExceeded` to `EventRateLimitExceeded` in `gateway/event_system.go` to ensure naming consistency with other event aliases.
- Maintained backward compatibility by updating the alias.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>event_system.go</strong><dd><code>Rename RateLimitExceeded to EventRateLimitExceeded for consistency</code></dd></summary>
<hr>

gateway/event_system.go
<li>Renamed <code>RateLimitExceeded</code> to <code>EventRateLimitExceeded</code> for consistency.<br> <li> Maintained backward compatibility with alias changes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6319/files#diff-d56e22d4f1b8d2e91bb643d30e678a3819691a18bfae8506b10e0af8dc279a0e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

