### PR TITLE
[TT-12186] Fixes TestOAS_ExtractTo_ResetAPIDefinition with a valid event config

### DIFF
--- a/apidef/oas/oas_test.go
+++ b/apidef/oas/oas_test.go
@@ -6,13 +6,12 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/TykTechnologies/tyk/config"
-
 	"github.com/getkin/kin-openapi/openapi3"
-
 	"github.com/stretchr/testify/assert"
 
 	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/internal/event"
 )
 
 func TestOAS(t *testing.T) {
@@ -133,6 +132,18 @@ func TestOAS_ExtractTo_ResetAPIDefinition(t *testing.T) {
 	var a apidef.APIDefinition
 	Fill(t, &a, 0)
 
+	// Fill doesn't populate eventhandlers to a valid value, we do it now.
+	a.EventHandlers.Events = map[apidef.TykEvent][]apidef.EventHandlerTriggerConfig{
+		event.QuotaExceeded: {
+			{
+				Handler: event.WebHookHandler,
+				HandlerMeta: map[string]interface{}{
+					"target_path": "https://webhook.site/uuid",
+				},
+			},
+		},
+	}
+
 	var vInfo apidef.VersionInfo
 	Fill(t, &vInfo, 0)
 	a.VersionData.Versions = map[string]apidef.VersionInfo{
@@ -246,7 +257,6 @@ func TestOAS_ExtractTo_ResetAPIDefinition(t *testing.T) {
 		"APIDefinition.SessionProvider.Name",
 		"APIDefinition.SessionProvider.StorageEngine",
 		"APIDefinition.SessionProvider.Meta[0]",
-		"APIDefinition.EventHandlers.Events[0]",
 		"APIDefinition.EnableBatchRequestSupport",
 		"APIDefinition.EnableIpWhiteListing",
 		"APIDefinition.AllowedIPs[0]",


### PR DESCRIPTION
### **User description**
The migration wasn't handled correctly in test, test only change


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added a valid event handler configuration to the `TestOAS_ExtractTo_ResetAPIDefinition` test to ensure proper migration handling.
- Removed an incorrect assertion related to event handlers in the test.
- Updated import statements for better organization and readability.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>oas_test.go</strong><dd><code>Fix and enhance `TestOAS_ExtractTo_ResetAPIDefinition` test.</code></dd></summary>
<hr>

apidef/oas/oas_test.go
<li>Added valid event handler configuration to <br><code>TestOAS_ExtractTo_ResetAPIDefinition</code>.<br> <li> Removed an incorrect assertion in the test.<br> <li> Updated import statements for better organization.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6321/files#diff-74029ee88132d30d6478c96a35f8bb2200e0c8e6f42f2c9b147dc6bb7ce74644">+14/-4</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

