### PR TITLE
[TT-12332] Fix/coprocess response processor

### DIFF
--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -522,7 +522,15 @@ func (h CustomMiddlewareResponseHook) Base() *BaseTykResponseHandler {
 }
 
 func (h *CustomMiddlewareResponseHook) Init(mwDef interface{}, spec *APISpec) error {
-	mwDefinition := mwDef.(apidef.MiddlewareDefinition)
+	mwDefBytes, err := json.Marshal(mwDef)
+	if err != nil {
+		return err
+	}
+
+	var mwDefinition apidef.MiddlewareDefinition
+	if err := json.Unmarshal(mwDefBytes, &mwDefinition); err != nil {
+		return err
+	}
 
 	h.mw = &CoProcessMiddleware{
 		BaseMiddleware: &BaseMiddleware{


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests

https://tyktech.atlassian.net/browse/TT-12332

___

### **Description**
- Refactored the `Init` method in `CustomMiddlewareResponseHook` to use a new `scanConfig` method for JSON encoding and decoding of middleware definitions.
- Improved error handling in the `Init` method to provide more informative error messages.
- Added the `scanConfig` method to handle the conversion of `map[string]any` to `*apidef.MiddlewareDefinition`.
- Added unit tests for the `scanConfig` method to ensure it handles various input scenarios correctly.
- Updated assertions in `TestCoProcessMiddlewareName` to use `assert.Equal` instead of `require.Equal`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coprocess.go</strong><dd><code>Refactor middleware definition handling and improve error handling</code></dd></summary>
<hr>

gateway/coprocess.go
<li>Added <code>scanConfig</code> method to handle JSON encoding and decoding of <br>middleware definitions.<br> <li> Updated <code>Init</code> method to use <code>scanConfig</code> for processing middleware <br>definitions.<br> <li> Improved error handling in <code>Init</code> method.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6335/files#diff-9cbfe628982b2afb94d1e9a5200fc9a4fdc00cb58fe65d1090a3725e4e4c5953">+19/-1</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coprocess_test.go</strong><dd><code>Add unit tests for scanConfig method and update assertions</code></dd></summary>
<hr>

gateway/coprocess_test.go
<li>Added unit tests for <code>scanConfig</code> method.<br> <li> Replaced <code>require.Equal</code> with <code>assert.Equal</code> in <br><code>TestCoProcessMiddlewareName</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6335/files#diff-c0fdc6fa7ea0ffd782deb36e7843d48aefff201af73e79a2c742027cf4557f5f">+52/-5</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

