### PR TITLE
LLM reporting Middleware that tracks token counts for AI APIs

### DIFF
--- a/apps/quickstart.json
+++ b/apps/quickstart.json
@@ -6,6 +6,7 @@
         "location": "",
         "key": ""
     },
+    "tags": ["llm"],
     "use_keyless": true,
     "auth": {
         "auth_header_name": ""
@@ -30,5 +31,5 @@
         "target_url": "http://httpbin.org/",
         "strip_listen_path": true
     },
-    "do_not_track": true
+    "do_not_track": false
 }

--- a/ctx/ctx.go
+++ b/ctx/ctx.go
@@ -47,6 +47,9 @@ const (
 	GraphQLRequest
 	GraphQLIsWebSocketUpgrade
 	OASOperation
+	LLMReport_Model
+	LLMReport_NumTokens
+	LLMReport_Estimate
 
 	// CacheOptions holds cache options required for cache writer middleware.
 	CacheOptions

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -3105,6 +3105,27 @@ func ctxGetSession(r *http.Request) *user.SessionState {
 	return ctx.GetSession(r)
 }
 
+func ctxGetLLMReportTokenCount(r *http.Request) int {
+	if v := r.Context().Value(ctx.LLMReport_NumTokens); v != nil {
+		return v.(int)
+	}
+	return 0
+}
+
+func ctxGetLLMReportModelName(r *http.Request) string {
+	if v := r.Context().Value(ctx.LLMReport_Model); v != nil {
+		return v.(string)
+	}
+	return ""
+}
+
+func ctxGetLLMReportIsEstimate(r *http.Request) bool {
+	if v := r.Context().Value(ctx.LLMReport_Estimate); v != nil {
+		return v.(bool)
+	}
+	return false
+}
+
 func ctxSetSession(r *http.Request, s *user.SessionState, scheduleUpdate bool, hashKey bool) {
 	ctx.SetSession(r, s, scheduleUpdate, hashKey)
 }

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -445,6 +445,7 @@ func (gw *Gateway) processSpec(spec *APISpec, apisByListen map[string]int,
 
 	gw.mwAppendEnabled(&chainArray, &VirtualEndpoint{BaseMiddleware: baseMid})
 	gw.mwAppendEnabled(&chainArray, &RequestSigning{BaseMiddleware: baseMid})
+	gw.mwAppendEnabled(&chainArray, &LLMReport{BaseMiddleware: baseMid})
 	gw.mwAppendEnabled(&chainArray, &GoPluginMiddleware{BaseMiddleware: baseMid})
 
 	for _, obj := range mwPostFuncs {

--- a/gateway/mw_llm_reporter.go
+++ b/gateway/mw_llm_reporter.go
@@ -1,0 +1,132 @@
+package gateway
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/TykTechnologies/tyk/ctx"
+	"github.com/pkoukk/tiktoken-go"
+)
+
+type msgObject struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type baseCompletionObject struct {
+	Model    string      `json:"model"`
+	Messages []msgObject `json:"messages"`
+}
+
+type LLMReport struct {
+	*BaseMiddleware
+}
+
+func (sa *LLMReport) Name() string {
+	return "StripAuth"
+}
+
+func (sa *LLMReport) EnabledForSpec() bool {
+	for _, t := range sa.Spec.Tags {
+		if strings.Contains(t, "llm") {
+			if os.Getenv("TIKTOKEN_CACHE_DIR") == "" {
+				sa.Logger().Warn("TIKTOKEN_CACHE_DIR is not set, LLM reporting will be slow")
+			}
+
+			return true
+		}
+	}
+
+	return false
+}
+
+func (sa *LLMReport) decodeBody(r *http.Request) (*baseCompletionObject, error) {
+	if r.Header.Get("Content-Type") != "application/json" {
+		return nil, fmt.Errorf("Content-Type is not application/json")
+	}
+
+	dat, err := copyBody(r.Body, false)
+	if err != nil {
+		return nil, err
+	}
+
+	bd, err := io.ReadAll(dat)
+	if err != nil {
+		return nil, err
+	}
+
+	var msg baseCompletionObject
+	err = json.Unmarshal(bd, &msg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &msg, nil
+}
+
+func (sa *LLMReport) detectModel(msg *baseCompletionObject) (string, bool) {
+	model := "gpt-3.5-turbo"
+	isEstimate := false
+
+	if msg.Model != "" {
+		model = msg.Model
+	}
+
+	_, ok := tiktoken.MODEL_TO_ENCODING[model]
+	if !ok {
+		model = "gpt-3.5-turbo"
+		isEstimate = true
+	}
+
+	return model, isEstimate
+}
+
+func (sa *LLMReport) countTokens(msg *baseCompletionObject) (int, bool, error) {
+	blob := ""
+	for _, m := range msg.Messages {
+		blob += m.Role
+		blob += m.Content
+	}
+
+	if len(blob) == 0 {
+		return 0, false, fmt.Errorf("no content to encode")
+	}
+
+	modelName, isEstimate := sa.detectModel(msg)
+
+	tkm, err := tiktoken.EncodingForModel(modelName)
+	if err != nil {
+		return 0, false, err
+	}
+
+	// encode
+	token := tkm.Encode(blob, nil, nil)
+	return len(token), isEstimate, nil
+}
+
+func (sa *LLMReport) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
+	if r.Method != "POST" {
+		return nil, http.StatusOK
+	}
+
+	msg, err := sa.decodeBody(r)
+	if err != nil {
+		return err, http.StatusBadRequest
+	}
+
+	count, isEstimate, err := sa.countTokens(msg)
+	if err != nil {
+		return err, http.StatusBadRequest
+	}
+
+	// Pick these up in RecordHit()
+	setCtxValue(r, ctx.LLMReport_Model, msg.Model)
+	setCtxValue(r, ctx.LLMReport_NumTokens, count)
+	setCtxValue(r, ctx.LLMReport_Estimate, isEstimate)
+
+	return nil, http.StatusOK
+}

--- a/go.mod
+++ b/go.mod
@@ -93,6 +93,7 @@ require (
 	github.com/go-redis/redismock/v9 v9.2.0
 	github.com/google/go-cmp v0.6.0
 	github.com/newrelic/go-agent v2.13.0+incompatible
+	github.com/pkoukk/tiktoken-go v0.1.7
 	go.opentelemetry.io/otel v1.19.0
 	go.opentelemetry.io/otel/trace v1.19.0
 	go.uber.org/mock v0.4.0
@@ -117,6 +118,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/dlclark/regexp2 v1.10.0 // indirect
 	github.com/eapache/go-resiliency v1.4.0 // indirect
 	github.com/eapache/go-xerial-snappy v0.0.0-20230731223053-c322873962e3 // indirect
 	github.com/eapache/queue v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -141,6 +141,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/dlclark/regexp2 v1.10.0 h1:+/GIL799phkJqYW+3YbOd8LCcbHzT0Pbo8zl70MHsq0=
+github.com/dlclark/regexp2 v1.10.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/docker/cli v20.10.17+incompatible h1:eO2KS7ZFeov5UJeaDmIs1NFEDRf32PaqRpvoEkKBy5M=
 github.com/docker/cli v20.10.17+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker v20.10.7+incompatible h1:Z6O9Nhsjv+ayUEeI1IojKbYcsGdgYSNqxe1s2MYzUhQ=
@@ -535,6 +537,8 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkoukk/tiktoken-go v0.1.7 h1:qOBHXX4PHtvIvmOtyg1EeKlwFRiMKAcoMp4Q+bLQDmw=
+github.com/pkoukk/tiktoken-go v0.1.7/go.mod h1:9NiV+i9mJKGj1rYOT+njbv+ZwA/zJxYdewGl6qVatpg=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
Adds a new middleware that uses tiktoken to count AI message tokens (support OpenAI and Anthropic)

## Description

- Adds `mw_llm_reporter.go` middleware 
- Hooks after transforms and auth
- The middleware is only loaded if the API is tagged with `llm`
- `LLMReporter` middleware will 
  - decode outbound body to a base API message format used by both Anthropic and OpenAI (Gemini uses a different content structure)
  - attempt to build a content blob from the message payload 
  - attempt to detect the model being used in the request
  - use the tiktoken library to estimate the number of tokens, if it can't get a clear read on the model being used it will tag the count as estiamted
  - Set three values into the context: `ctx.LLMReport_Model`, `ctx.LLMReport_NumTokens`, and `ctx.LLMReport_Estimate`.
 - These context values can later be used in the `RecordHit` function to store the data in an an alytics record (as this is part of Tyk Pump I did not extend the pump record)

## Motivation and Context

We've had multiple requests for this kind of reporting and it is relatively easy to add to our analytics, it is also something our competitors already do and will allow us to have a matching feature.

## How This Has Been Tested
- Manual testing directly with dummy requests from OpenAI and Anthropic docs

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
