### PR TITLE
Reciords actual token counts for OpenAI and Anthropic reponses

### DIFF
--- a/apps/quickstart.json
+++ b/apps/quickstart.json
@@ -6,6 +6,7 @@
         "location": "",
         "key": ""
     },
+    "tags": ["llm", "anthropic"],
     "use_keyless": true,
     "auth": {
         "auth_header_name": ""
@@ -27,8 +28,14 @@
     },
     "proxy": {
         "listen_path": "/quickstart/",
-        "target_url": "http://httpbin.org/",
+        "target_url": "https://api.anthropic.com",
         "strip_listen_path": true
     },
-    "do_not_track": true
+    "do_not_track": true,
+    "response_processors": [
+        {
+            "name": "llm_reponse_reporter",
+            "options": {}
+        }
+    ]
 }

--- a/ctx/ctx.go
+++ b/ctx/ctx.go
@@ -48,6 +48,10 @@ const (
 	GraphQLIsWebSocketUpgrade
 	OASOperation
 
+	LLMResponseReporterInputTokens
+	LLMResponseReporterOutputTokens
+	LLMResponseReporterTotalTokens
+
 	// CacheOptions holds cache options required for cache writer middleware.
 	CacheOptions
 	OASDefinition

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -3105,6 +3105,27 @@ func ctxGetSession(r *http.Request) *user.SessionState {
 	return ctx.GetSession(r)
 }
 
+func ctxGetLLMResponseReporterInputTokens(r *http.Request) int {
+	if v := r.Context().Value(ctx.LLMResponseReporterInputTokens); v != nil {
+		return v.(int)
+	}
+	return 0
+}
+
+func ctxGetLLMResponseReporterOutputTokens(r *http.Request) int {
+	if v := r.Context().Value(ctx.LLMResponseReporterOutputTokens); v != nil {
+		return v.(int)
+	}
+	return 0
+}
+
+func ctxGetLLMResponseReporterTotalTokens(r *http.Request) int {
+	if v := r.Context().Value(ctx.LLMResponseReporterTotalTokens); v != nil {
+		return v.(int)
+	}
+	return 0
+}
+
 func ctxSetSession(r *http.Request, s *user.SessionState, scheduleUpdate bool, hashKey bool) {
 	ctx.SetSession(r, s, scheduleUpdate, hashKey)
 }

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -1022,6 +1022,9 @@ func (gw *Gateway) responseProcessorByName(name string, baseHandler BaseTykRespo
 		return &CustomMiddlewareResponseHook{BaseTykResponseHandler: baseHandler}
 	case "goplugin_res_hook":
 		return &ResponseGoPluginMiddleware{BaseTykResponseHandler: baseHandler}
+	case "llm_reponse_reporter":
+		return &LLMResponseReporter{BaseTykResponseHandler: baseHandler}
+
 	}
 
 	return nil

--- a/gateway/res_handler_llm_reporting.go
+++ b/gateway/res_handler_llm_reporting.go
@@ -1,0 +1,83 @@
+package gateway
+
+import (
+	"net/http"
+
+	"github.com/mitchellh/mapstructure"
+
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/user"
+)
+
+type LLMResponseReporterOptions struct {
+}
+
+type LLMResponseReporter struct {
+	BaseTykResponseHandler
+	config HeaderInjectorOptions
+}
+
+func (h *LLMResponseReporter) Base() *BaseTykResponseHandler {
+	return &h.BaseTykResponseHandler
+}
+
+func (*LLMResponseReporter) Name() string {
+	return "LLMResponseReporter"
+}
+
+func (h *LLMResponseReporter) Enabled() bool {
+	for _, v := range h.Spec.Tags {
+		if v == "llm" {
+			return true
+		}
+	}
+}
+
+func (h *LLMResponseReporter) Init(c interface{}, spec *APISpec) error {
+	h.Spec = spec
+	return mapstructure.Decode(c, &h.config)
+}
+
+func (h *LLMResponseReporter) HandleError(rw http.ResponseWriter, req *http.Request) {
+}
+
+func (h *LLMResponseReporter) HandleResponse(rw http.ResponseWriter, res *http.Response, req *http.Request, ses *user.SessionState) error {
+	// TODO: This should only target specific paths
+	ignoreCanonical := h.Gw.GetConfig().IgnoreCanonicalMIMEHeaderKey
+	vInfo, _ := h.Spec.Version(req)
+	versionPaths := h.Spec.RxPaths[vInfo.Name]
+
+	found, meta := h.Spec.CheckSpecMatchesStatus(req, versionPaths, HeaderInjectedResponse)
+	if found {
+		hmeta := meta.(*apidef.HeaderInjectionMeta)
+		for _, dKey := range hmeta.DeleteHeaders {
+			res.Header.Del(dKey)
+		}
+		for nKey, nVal := range hmeta.AddHeaders {
+			setCustomHeader(res.Header, nKey, h.Gw.replaceTykVariables(req, nVal, false), ignoreCanonical)
+		}
+	}
+
+	// Manage global response header options with versionInfo
+	if !vInfo.GlobalResponseHeadersDisabled {
+		for _, key := range vInfo.GlobalResponseHeadersRemove {
+			log.Debug("Removing: ", key)
+			res.Header.Del(key)
+		}
+
+		for key, val := range vInfo.GlobalResponseHeaders {
+			log.Debug("Adding: ", key)
+			setCustomHeader(res.Header, key, h.Gw.replaceTykVariables(req, val, false), ignoreCanonical)
+		}
+
+		// Manage global response header options with response_processors
+		for _, n := range h.config.RemoveHeaders {
+			res.Header.Del(n)
+		}
+		for header, v := range h.config.AddHeaders {
+			setCustomHeader(res.Header, header, h.Gw.replaceTykVariables(req, v, false), ignoreCanonical)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This response middleware will extract token usage from. OpenAI and Anthropic APIs and provide them as context to be recorded in Analytics

## Description
- Adds `res_handler_llm_reporting.mw`
- Middleware will:
  - Search for `openai` or `anthropic` tags in the Spec to activate
  - If present, will decode responses from the API into generic holders
  - Will extract token count information from the response for reporting
  - Creates three context entries: `LLMResponseReporterInputTokens`, `LLMResponseReporterOutputTokens`, `LLMResponseReporterTotalTokens` which hold the data for further processing.

## Motivation and Context

Similarly to the other middleware, instead of providing data pre-proxy, this middleware will provide actuals from the vendor, this could be used for quota work, while the prior middleware could be used for rate limiting or flagging usage patterns. 

## How This Has Been Tested
- Manual testing against the anthropic and OpenAI APIs


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
