### PR TITLE
Merging to release-5.4: [TT-12323] fix panic when webhook handler is disabled (#6334)

### DIFF
--- a/gateway/event_handler_webhooks.go
+++ b/gateway/event_handler_webhooks.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/md5"
 	"encoding/hex"
+	"errors"
 	htmlTemplate "html/template"
 	"io/ioutil"
 	"net/http"
@@ -35,6 +36,11 @@ const (
 	EH_WebHook = event.WebHookHandler
 )
 
+var (
+	// ErrEventHandlerDisabled is returned when the event handler is disabled.
+	ErrEventHandlerDisabled = errors.New("event handler disabled")
+)
+
 // WebHookHandler is an event handler that triggers web hooks
 type WebHookHandler struct {
 	conf     apidef.WebHookHandlerConf
@@ -60,7 +66,7 @@ func (w *WebHookHandler) Init(handlerConf interface{}) error {
 		log.WithFields(logrus.Fields{
 			"prefix": "webhooks",
 		}).Infof("skipping disabled webhook %s", w.conf.Name)
-		return nil
+		return ErrEventHandlerDisabled
 	}
 
 	w.store = &storage.RedisCluster{KeyPrefix: "webhook.cache.", ConnectionHandler: w.Gw.StorageConnectionHandler}

--- a/gateway/event_handler_webhooks_test.go
+++ b/gateway/event_handler_webhooks_test.go
@@ -51,7 +51,7 @@ func TestNewValid(t *testing.T) {
 		conf["disabled"] = true
 		h := &WebHookHandler{Gw: ts.Gw}
 		err := h.Init(conf)
-		assert.NoError(t, err)
+		assert.ErrorIs(t, err, ErrEventHandlerDisabled)
 		assert.True(t, h.conf.Disabled)
 	})
 }


### PR DESCRIPTION
### **User description**
[TT-12323] fix panic when webhook handler is disabled (#6334)

### **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description

 fix panic when webhook handler is disabled

## Related Issue
https://tyktech.atlassian.net/browse/TT-12323
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added error handling for when the webhook handler is disabled by
introducing a new error variable `ErrEventHandlerDisabled`.
- Modified the `Init` method in `WebHookHandler` to return the new error
when the webhook is disabled.
- Updated the corresponding test to check for the
`ErrEventHandlerDisabled` error instead of no error.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>event_handler_webhooks.go</strong><dd><code>Add error
handling for disabled webhook handler</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/event_handler_webhooks.go
<li>Added error handling for disabled webhook handler.<br> <li>
Introduced <code>ErrEventHandlerDisabled</code> error variable.<br> <li>
Modified <code>Init</code> method to return
<code>ErrEventHandlerDisabled</code> when webhook is <br>disabled.<br>


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6334/files#diff-6587ad3f2629cfa6c84a71144127acd6cc7824e5141f0b4961848945a87e0198">+6/-1</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>

<summary><strong>event_handler_webhooks_test.go</strong><dd><code>Update
test for disabled webhook handler error</code>&nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/event_handler_webhooks_test.go
- Updated test to check for `ErrEventHandlerDisabled` error.



</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6334/files#diff-1a2f8d6ab4443031b0f8486809453f6389291a6f625745fe8c65ac5cdb0e9621">+1/-1</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools
and their descriptions

[TT-12323]: https://tyktech.atlassian.net/browse/TT-12323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added a new error `ErrEventHandlerDisabled` to indicate when the event handler is disabled in `gateway/event_handler_webhooks.go`.
- Modified the `Init` method in `WebHookHandler` to return `ErrEventHandlerDisabled` when the webhook handler is disabled.
- Updated the test case in `gateway/event_handler_webhooks_test.go` to check for `ErrEventHandlerDisabled` error when the webhook handler is disabled.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>event_handler_webhooks.go</strong><dd><code>Add error handling for disabled webhook handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/event_handler_webhooks.go
<li>Added a new error <code>ErrEventHandlerDisabled</code> to indicate when the event <br>handler is disabled.<br> <li> Modified the <code>Init</code> method to return <code>ErrEventHandlerDisabled</code> when the <br>webhook handler is disabled.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6340/files#diff-6587ad3f2629cfa6c84a71144127acd6cc7824e5141f0b4961848945a87e0198">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>event_handler_webhooks_test.go</strong><dd><code>Update tests for disabled webhook handler error</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/event_handler_webhooks_test.go
<li>Updated test case to check for <code>ErrEventHandlerDisabled</code> error when <br>webhook handler is disabled.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6340/files#diff-1a2f8d6ab4443031b0f8486809453f6389291a6f625745fe8c65ac5cdb0e9621">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

