### PR TITLE
[TT-12285] Add smoothing, fix duplicate x-go-name

### DIFF
--- a/apidef/rate_limit_smoothing.go
+++ b/apidef/rate_limit_smoothing.go
@@ -72,16 +72,16 @@ type RateLimitSmoothing struct {
 	// Enabled indicates if rate limit smoothing is active.
 	Enabled bool `json:"enabled" bson:"enabled"`
 
-	// Threshold is the request rate above which smoothing is applied.
+	// Threshold is the initial rate limit beyond which smoothing will be applied. It is a count of requests during the `per` interval and should be less than the maximum configured `rate`.
 	Threshold int64 `json:"threshold" bson:"threshold"`
 
-	// Trigger is the step factor determining when smoothing events trigger.
+	// Trigger is a fraction (typically in the range 0.1-1.0) of the step at which point a smoothing event will be emitted as the request rate approaches the current allowance.
 	Trigger float64 `json:"trigger" bson:"trigger"`
 
-	// Step is the increment/decrement for adjusting the rate limit.
+	// Step is the increment by which the current allowance will be increased or decreased each time a smoothing event is emitted.
 	Step int64 `json:"step" bson:"step"`
 
-	// Delay is the minimum time between rate limit changes (in seconds).
+	// Delay is a hold-off between smoothing events and controls how frequently the current allowance will step up or down (in seconds).
 	Delay int64 `json:"delay" bson:"delay"`
 }
 

--- a/apidef/rate_limit_smoothing.go
+++ b/apidef/rate_limit_smoothing.go
@@ -49,19 +49,19 @@ import (
 //   - When the request rate falls below `allowance - (step + step * trigger)`,
 //     a RateLimitSmoothingDown event is emitted and allowance decreases by `step`.
 //
-// Example: Threshold: 400, Request allowance: 600, Current rate: 500, Step: 100, Trigger: 0.5
+// Example: Threshold: 400, Request allowance: 600, Current rate: 500, Step: 100, Trigger: 0.5.
 //
 // To trigger a RateLimitSmoothingUp event, the request rate must exceed:
 //
-//   - Allowance - (Step * Trigger)
-//   - Calculation: 600 - (100 * 0.5) = `550`
+//   - Calculation: Allowance - (Step * Trigger).
+//   - Example: 600 - (100 * 0.5) = `550`.
 //
 // Exceeding a request rate of `550` will increase the allowance to 700 (Allowance + Step).
 //
 // To trigger a RateLimitSmoothingDown event, the request rate must fall below:
 //
-//   - Allowance - (Step + (Step * Trigger))
-//   - Calculation: 600 - (100 + (100 * 0.5)) = 450
+//   - Calculation: Allowance - (Step + (Step * Trigger)).
+//   - Example: 600 - (100 + (100 * 0.5)) = 450.
 //
 // As the request rate falls below 450, that will decrease the allowance to 500 (Allowance - Step).
 //

--- a/apidef/rate_limit_smoothing.go
+++ b/apidef/rate_limit_smoothing.go
@@ -51,19 +51,23 @@ import (
 //
 // Example: Threshold: 400, Request allowance: 600, Current rate: 500, Step: 100, Trigger: 0.5
 //
-//   - To trigger a RateLimitSmoothingUp event, the request rate must exceed:
-//     Allowance - (Step * Trigger)
-//     Calculation: 600 - (100 * 0.5) = 550
-//     Exceeding a request rate of 550 will increase the allowance to 700 (Allowance + Step).
+// To trigger a RateLimitSmoothingUp event, the request rate must exceed:
 //
-//   - To trigger a RateLimitSmoothingDown event, the request rate must fall below:
-//     Allowance - (Step + (Step * Trigger))
-//     Calculation: 600 - (100 + (100 * 0.5)) = 450
-//     As the request rate falls below 450, that will decrease the allowance to 500 (Allowance - Step).
+//   - Allowance - (Step * Trigger)
+//   - Calculation: 600 - (100 * 0.5) = `550`
 //
-// This is used to compute a request allowance. The request allowance will
-// be smoothed between `threshold`, and the defined `rate` limit (maximum).
-// The request allowance will be updated internally every `delay` seconds.
+// Exceeding a request rate of `550` will increase the allowance to 700 (Allowance + Step).
+//
+// To trigger a RateLimitSmoothingDown event, the request rate must fall below:
+//
+//   - Allowance - (Step + (Step * Trigger))
+//   - Calculation: 600 - (100 + (100 * 0.5)) = 450
+//
+// As the request rate falls below 450, that will decrease the allowance to 500 (Allowance - Step).
+//
+// The request allowance will be smoothed between `threshold`, and the
+// defined `rate` limit (maximum). The request allowance will be updated
+// internally every `delay` seconds.
 type RateLimitSmoothing struct {
 	// Enabled indicates if rate limit smoothing is active.
 	Enabled bool `json:"enabled" bson:"enabled"`

--- a/swagger.yml
+++ b/swagger.yml
@@ -3083,7 +3083,7 @@ components:
           type: integer
           format: int64
           description: Delay is a hold-off between smoothing events and controls how frequently the current allowance will step up or down (in seconds).
-          mimimum: 1
+          minimum: 1
           x-go-name: Delay
         enabled:
           type: boolean
@@ -3093,19 +3093,19 @@ components:
           type: integer
           format: int64
           description: Step is the increment by which the current allowance will be increased or decreased each time a smoothing event is emitted.
-          mimimum: 1
+          minimum: 1
           x-go-name: Step
         threshold:
           type: integer
           format: int64
           description: Threshold is the initial rate limit beyond which smoothing will be applied. It is a count of requests during the `per` interval and should be less than the maximum configured `rate`.
-          mimimum: 1
+          minimum: 1
           x-go-name: Threshold
         trigger:
           type: number
           format: double
           description: Trigger is a fraction (typically in the range 0.1-1.0) of the step at which point a smoothing event will be emitted as the request rate approaches the current allowance.
-          mimimum: 0.01
+          minimum: 0.01
           multipleOf: 0.01
           x-go-name: Trigger
       title:  RateLimitSmoothing holds the rate smoothing configuration.

--- a/swagger.yml
+++ b/swagger.yml
@@ -3148,7 +3148,7 @@ components:
           Calculation: 600 - (100 + (100 * 0.5)) = 450
           As the request rate falls below 450, that will decrease the allowance to 500 (Allowance - Step).
       type: object
-      x-go-package: github.com/TykTechnologies/tyk/user
+      x-go-package: github.com/TykTechnologies/tyk/apidef
     Regexp:
       description: Regexp is a wrapper around regexp.Regexp but with caching
       properties:

--- a/swagger.yml
+++ b/swagger.yml
@@ -3153,7 +3153,7 @@ components:
           Calculation: 600 - (100 + (100 * 0.5)) = 450
           As the request rate falls below 450, that will decrease the allowance to 500 (Allowance - Step).
       type: object
-      x-go-package: github.com/TykTechnologies/tyk/user
+      x-go-package: github.com/TykTechnologies/tyk/apidef
     Regexp:
       description: Regexp is a wrapper around regexp.Regexp but with caching
       properties:

--- a/swagger.yml
+++ b/swagger.yml
@@ -3105,7 +3105,8 @@ components:
           type: number
           format: double
           description: Trigger is a fraction (typically in the range 0.1-1.0) of the step at which point a smoothing event will be emitted as the request rate approaches the current allowance.
-          minimum: 0.01
+          minimum: 0
+          exclusiveMinimum: true
           multipleOf: 0.01
           x-go-name: Trigger
       title:  RateLimitSmoothing holds the rate smoothing configuration.

--- a/swagger.yml
+++ b/swagger.yml
@@ -3082,7 +3082,7 @@ components:
         delay:
           type: integer
           format: int64
-          description: Delay is the minimum time between rate limit changes (in seconds).
+          description: Delay is a hold-off between smoothing events and controls how frequently the current allowance will step up or down (in seconds).
           x-go-name: Delay
         enabled:
           type: boolean
@@ -3091,17 +3091,17 @@ components:
         step:
           type: integer
           format: int64
-          description: Step is the increment/decrement for adjusting the rate limit.
+          description: Step is the increment by which the current allowance will be increased or decreased each time a smoothing event is emitted.
           x-go-name: Step
         threshold:
           type: integer
           format: int64
-          description: Threshold is the request rate above which smoothing is applied.
+          description: Threshold is the initial rate limit beyond which smoothing will be applied. It is a count of requests during the `per` interval and should be less than the maximum configured `rate`.
           x-go-name: Threshold
         trigger:
           type: number
           format: double
-          description: Trigger is the step factor determining when smoothing events trigger.
+          description: Trigger is a fraction (typically in the range 0.1-1.0) of the step at which point a smoothing event will be emitted as the request rate approaches the current allowance
           x-go-name: Trigger
       title:  RateLimitSmoothing holds the rate smoothing configuration.
       description: |-
@@ -3122,18 +3122,22 @@ components:
         - `threshold` after which to apply smoothing (minimum rate for window)
         - `trigger` configures at which fraction of a step a smoothing event is emitted
         - `step` is the value by which the rate allowance will get adjusted
-        - `delay` is the amount of seconds between smoothing updates
+        - `delay` is a hold-off in seconds providing a minimum period between rate allowance adjustments
     
         This is used to compute a request allowance. The request allowance will
-        be smoothed between `threshold`, and the defined rate limits (maximum).
+        be smoothed between `threshold`, and the defined `rate` limit (maximum).
         The request allowance will be updated internally every `delay` seconds.
     
-        The `step * trigger` value is substracted from the request allowance, and if
-        your request rate goes above that, then a RateLimitSmoothingUp event is
-        emitted and the allowance is increased by `step`. A RateLimitSmoothingDown
-        event is emitted when the request rate drops one step below that, and the
-        allowance then decreases by step.
+        To determine if the request rate is growing and needs to be smoothed, the `step * trigger` value is subtracted from the request allowance and, if
+        the request rate goes above that, then a RateLimitSmoothingUp event is
+        emitted and the rate allowance is increased by `step`.
+
+         Once the request allowance has been increased above the `threshold`, Tyk will start to check
+         for decreasing request rate. When the request rate drops `step * (1 + trigger)` below the request 
+        allowance, a `RateLimitSmoothingDown` event is emitted and the rate allowance is decreased by `step`.
     
+        After the request allowance has been adjusted (up or down), the request rate will be checked again over the next `delay` seconds and,  if required, further adjustment made to the rate allowance after the hold-off.
+
         For any allowance, events are emitted based on the following calculations:
     
          - When the request rate rises above `allowance - (step * trigger)`,
@@ -3141,7 +3145,7 @@ components:
          - When the request rate falls below `allowance - (step + step * trigger)`,
           a RateLimitSmoothingDown event is emitted and allowance decreases by `step`.
     
-        Example: Allowance: 600, Current rate: 500, Step: 100, Trigger: 0.5
+        Example: Threshold: 400, Request allowance: 600, Current rate: 500, Step: 100, Trigger: 0.5
     
          - To trigger a RateLimitSmoothingUp event, the request rate must exceed:
           Allowance - (Step * Trigger)

--- a/swagger.yml
+++ b/swagger.yml
@@ -3083,6 +3083,7 @@ components:
           type: integer
           format: int64
           description: Delay is a hold-off between smoothing events and controls how frequently the current allowance will step up or down (in seconds).
+          mimimum: 1
           x-go-name: Delay
         enabled:
           type: boolean
@@ -3092,16 +3093,20 @@ components:
           type: integer
           format: int64
           description: Step is the increment by which the current allowance will be increased or decreased each time a smoothing event is emitted.
+          mimimum: 1
           x-go-name: Step
         threshold:
           type: integer
           format: int64
           description: Threshold is the initial rate limit beyond which smoothing will be applied. It is a count of requests during the `per` interval and should be less than the maximum configured `rate`.
+          mimimum: 1
           x-go-name: Threshold
         trigger:
           type: number
           format: double
-          description: Trigger is a fraction (typically in the range 0.1-1.0) of the step at which point a smoothing event will be emitted as the request rate approaches the current allowance
+          description: Trigger is a fraction (typically in the range 0.1-1.0) of the step at which point a smoothing event will be emitted as the request rate approaches the current allowance.
+          mimimum: 0.01
+          multipleOf: 0.01
           x-go-name: Trigger
       title:  RateLimitSmoothing holds the rate smoothing configuration.
       description: |-
@@ -3124,20 +3129,22 @@ components:
         - `step` is the value by which the rate allowance will get adjusted
         - `delay` is a hold-off in seconds providing a minimum period between rate allowance adjustments
     
-        This is used to compute a request allowance. The request allowance will
-        be smoothed between `threshold`, and the defined `rate` limit (maximum).
-        The request allowance will be updated internally every `delay` seconds.
-    
-        To determine if the request rate is growing and needs to be smoothed, the `step * trigger` value is subtracted from the request allowance and, if
+        To determine if the request rate is growing and needs to be smoothed, the
+        `step * trigger` value is subtracted from the request allowance and, if
         the request rate goes above that, then a RateLimitSmoothingUp event is
         emitted and the rate allowance is increased by `step`.
-
-         Once the request allowance has been increased above the `threshold`, Tyk will start to check
-         for decreasing request rate. When the request rate drops `step * (1 + trigger)` below the request 
-        allowance, a `RateLimitSmoothingDown` event is emitted and the rate allowance is decreased by `step`.
     
-        After the request allowance has been adjusted (up or down), the request rate will be checked again over the next `delay` seconds and,  if required, further adjustment made to the rate allowance after the hold-off.
-
+        Once the request allowance has been increased above the `threshold`, Tyk
+        will start to check for decreasing request rate. When the request rate
+        drops `step * (1 + trigger)` below the request allowance, a
+        `RateLimitSmoothingDown` event is emitted and the rate allowance is
+        decreased by `step`.
+    
+        After the request allowance has been adjusted (up or down), the request
+        rate will be checked again over the next `delay` seconds and, if
+        required, further adjustment made to the rate allowance after the
+        hold-off.
+    
         For any allowance, events are emitted based on the following calculations:
     
          - When the request rate rises above `allowance - (step * trigger)`,
@@ -3145,17 +3152,25 @@ components:
          - When the request rate falls below `allowance - (step + step * trigger)`,
           a RateLimitSmoothingDown event is emitted and allowance decreases by `step`.
     
-        Example: Threshold: 400, Request allowance: 600, Current rate: 500, Step: 100, Trigger: 0.5
+        Example: Threshold: 400, Request allowance: 600, Current rate: 500, Step: 100, Trigger: 0.5.
     
-         - To trigger a RateLimitSmoothingUp event, the request rate must exceed:
-          Allowance - (Step * Trigger)
-          Calculation: 600 - (100 * 0.5) = 550
-          Exceeding a request rate of 550 will increase the allowance to 700 (Allowance + Step).
+        To trigger a RateLimitSmoothingUp event, the request rate must exceed:
     
-         - To trigger a RateLimitSmoothingDown event, the request rate must fall below:
-          Allowance - (Step + (Step * Trigger))
-          Calculation: 600 - (100 + (100 * 0.5)) = 450
-          As the request rate falls below 450, that will decrease the allowance to 500 (Allowance - Step).
+         - Calculation: Allowance - (Step * Trigger).
+         - Example: 600 - (100 * 0.5) = `550`.
+    
+        Exceeding a request rate of `550` will increase the allowance to 700 (Allowance + Step).
+    
+        To trigger a RateLimitSmoothingDown event, the request rate must fall below:
+    
+         - Calculation: Allowance - (Step + (Step * Trigger)).
+         - Example: 600 - (100 + (100 * 0.5)) = 450.
+    
+        As the request rate falls below 450, that will decrease the allowance to 500 (Allowance - Step).
+    
+        The request allowance will be smoothed between `threshold`, and the
+        defined `rate` limit (maximum). The request allowance will be updated
+        internally every `delay` seconds.
       type: object
       x-go-package: github.com/TykTechnologies/tyk/apidef
     Regexp:

--- a/swagger.yml
+++ b/swagger.yml
@@ -2157,7 +2157,7 @@ components:
           type: number
           x-go-name: HmacAllowedClockSkew
         id:
-          $ref: '#/components/schemas/ObjectId'
+          $ref: '#/components/schemas/ObjectID'
         internal:
           type: boolean
           x-go-name: Internal
@@ -2371,7 +2371,7 @@ components:
       type: object
       x-go-package: github.com/TykTechnologies/tyk/apidef
     APILimit:
-      description: APILimit stores quota and rate limit on ACL level (per API)
+      title: APILimit stores quota and rate limit on ACL level (per API)
       properties:
         per:
           format: double
@@ -2408,6 +2408,11 @@ components:
           format: int64
           type: integer
           x-go-name: ThrottleRetryLimit
+        smoothing:
+          type: object
+          $ref: '#/components/schemas/RateLimitSmoothing'
+          description: Smoothing contains rate limit smoothing settings.
+          x-go-name: Smoothing
       type: object
       x-go-package: github.com/TykTechnologies/tyk/user
     AccessDefinition:
@@ -2943,10 +2948,10 @@ components:
           x-go-name: Issuer
       type: object
       x-go-package: github.com/TykTechnologies/tyk/apidef
-    ObjectId:
+    ObjectID:
       description: 'http://www.mongodb.org/display/DOCS/Object+IDs'
       title: >-
-        ObjectId is a unique ID identifying a BSON value. It must be exactly 12
+        ObjectID is a unique ID identifying a BSON value. It must be exactly 12
         bytes
 
         long. MongoDB objects by default have such a property set in their "_id"
@@ -2969,7 +2974,7 @@ components:
     Policy:
       properties:
         _id:
-          $ref: '#/components/schemas/ObjectId'
+          $ref: '#/components/schemas/ObjectID'
           type: object
           x-go-name: MID
         id:
@@ -3148,7 +3153,7 @@ components:
           Calculation: 600 - (100 + (100 * 0.5)) = 450
           As the request rate falls below 450, that will decrease the allowance to 500 (Allowance - Step).
       type: object
-      x-go-package: github.com/TykTechnologies/tyk/apidef
+      x-go-package: github.com/TykTechnologies/tyk/user
     Regexp:
       description: Regexp is a wrapper around regexp.Regexp but with caching
       properties:

--- a/swagger.yml
+++ b/swagger.yml
@@ -2971,7 +2971,7 @@ components:
         _id:
           $ref: '#/components/schemas/ObjectId'
           type: object
-          x-go-name: ID
+          x-go-name: MID
         id:
           type: string
           x-go-name: ID
@@ -3040,11 +3040,17 @@ components:
         last_updated:
           type: string
           x-go-name: LastUpdates
+        smoothing:
+          type: object
+          $ref: '#/components/schemas/RateLimitSmoothing'
+          description: Smoothing contains rate limit smoothing settings.
+          x-go-name: Smoothing
         meta_data:
           type: object
           x-go-name: MetaData
         graphql_access_rights:
           $ref: '#/components/schemas/GraphAccessDefinition'
+      title: Policy represents a user policy
       type: object
       x-go-package: github.com/TykTechnologies/tyk/user
     PolicyPartitions:
@@ -3064,6 +3070,83 @@ components:
         per_api:
           type: boolean
           x-go-name: PerAPI
+      type: object
+      x-go-package: github.com/TykTechnologies/tyk/user
+    RateLimitSmoothing:
+      properties:
+        delay:
+          type: integer
+          format: int64
+          description: Delay is the minimum time between rate limit changes (in seconds).
+          x-go-name: Delay
+        enabled:
+          type: boolean
+          description: Enabled indicates if rate limit smoothing is active.
+          x-go-name: Enabled
+        step:
+          type: integer
+          format: int64
+          description: Step is the increment/decrement for adjusting the rate limit.
+          x-go-name: Step
+        threshold:
+          type: integer
+          format: int64
+          description: Threshold is the request rate above which smoothing is applied.
+          x-go-name: Threshold
+        trigger:
+          type: number
+          format: double
+          description: Trigger is the step factor determining when smoothing events trigger.
+          x-go-name: Trigger
+      title:  RateLimitSmoothing holds the rate smoothing configuration.
+      description: |-
+        Rate Limit Smoothing is a mechanism to dynamically adjust the request rate
+        limits based on the current traffic patterns. It helps in managing request
+        spikes by gradually increasing or decreasing the rate limit instead of making
+        abrupt changes or blocking requests excessively.
+    
+        Once the rate limit smoothing triggers an allowance change, one of the
+        following events is emitted:
+    
+        - `RateLimitSmoothingUp` when the allowance increases
+        - `RateLimitSmoothingDown` when the allowance decreases
+    
+        Events are emitted based on the configuration:
+    
+        - `enabled` (boolean) to enable or disable rate limit smoothing
+        - `threshold` after which to apply smoothing (minimum rate for window)
+        - `trigger` configures at which fraction of a step a smoothing event is emitted
+        - `step` is the value by which the rate allowance will get adjusted
+        - `delay` is the amount of seconds between smoothing updates
+    
+        This is used to compute a request allowance. The request allowance will
+        be smoothed between `threshold`, and the defined rate limits (maximum).
+        The request allowance will be updated internally every `delay` seconds.
+    
+        The `step * trigger` value is substracted from the request allowance, and if
+        your request rate goes above that, then a RateLimitSmoothingUp event is
+        emitted and the allowance is increased by `step`. A RateLimitSmoothingDown
+        event is emitted when the request rate drops one step below that, and the
+        allowance then decreases by step.
+    
+        For any allowance, events are emitted based on the following calculations:
+    
+         - When the request rate rises above `allowance - (step * trigger)`,
+          a RateLimitSmoothingUp event is emitted and allowance increases by `step`.
+         - When the request rate falls below `allowance - (step + step * trigger)`,
+          a RateLimitSmoothingDown event is emitted and allowance decreases by `step`.
+    
+        Example: Allowance: 600, Current rate: 500, Step: 100, Trigger: 0.5
+    
+         - To trigger a RateLimitSmoothingUp event, the request rate must exceed:
+          Allowance - (Step * Trigger)
+          Calculation: 600 - (100 * 0.5) = 550
+          Exceeding a request rate of 550 will increase the allowance to 700 (Allowance + Step).
+    
+         - To trigger a RateLimitSmoothingDown event, the request rate must fall below:
+          Allowance - (Step + (Step * Trigger))
+          Calculation: 600 - (100 + (100 * 0.5)) = 450
+          As the request rate falls below 450, that will decrease the allowance to 500 (Allowance - Step).
       type: object
       x-go-package: github.com/TykTechnologies/tyk/user
     Regexp:
@@ -3332,6 +3415,11 @@ components:
           format: int64
           type: integer
           x-go-name: SessionLifetime
+        smoothing:
+          type: object
+          $ref: '#/components/schemas/RateLimitSmoothing'
+          description: Smoothing contains rate limit smoothing settings.
+          x-go-name: Smoothing
         throttle_interval:
           format: double
           type: number


### PR DESCRIPTION
### **User description**
Document Smoothing in Policy and SessionState definitions. Fix Policy ID duplicate x-go-name.


___

### **PR Type**
enhancement, documentation


___

### **Description**
- Added a new `RateLimitSmoothing` schema to define rate limit smoothing settings, including properties like `delay`, `enabled`, `step`, `threshold`, and `trigger`.
- Updated the `Policy` and `SessionState` definitions to include the `smoothing` property referencing the new `RateLimitSmoothing` schema.
- Changed the `x-go-name` for the `_id` property in the `Policy` definition from `ID` to `MID` to fix a duplicate name issue.
- Provided detailed descriptions and titles for the new `RateLimitSmoothing` schema and its properties.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>swagger.yml</strong><dd><code>Add rate limit smoothing and update Policy schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

swagger.yml
<li>Added <code>smoothing</code> property to <code>Policy</code> and <code>SessionState</code> definitions.<br> <li> Introduced <code>RateLimitSmoothing</code> schema with detailed description and <br>properties.<br> <li> Changed <code>x-go-name</code> for <code>_id</code> property in <code>Policy</code> definition to <code>MID</code>.<br> <li> Added titles and descriptions for new and existing components.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6346/files#diff-8f3c4cb253eee09ae2401daa7279a8bbfbfd4168bb579c3ac0ee5c672d63bb2c">+89/-1</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

