### PR TITLE
[TT-10532] Update taskfile, CI tests

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Run Gateway Tests
         id: ci-tests
         run: |
-          task test:e2e-combined
+          task test:e2e-combined args="-race -timeout=15m"
           task coverage
 
       - name: golangci-lint

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -113,7 +113,7 @@ jobs:
           $(go env GOPATH)/bin/golangci-lint run --out-format checkstyle --issues-exit-code=0 ./... > golanglint.xml
 
       - name: SonarCloud Scan
-        if: always()
+        if: always() && matrix.redis-version == 7
         uses: sonarsource/sonarcloud-github-action@master
         with:
           args: >

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        redis-version: [5, 7]
+        redis-version: [7]
         python-version: ["3.11"]
         go-version: [1.21.x]
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -124,7 +124,7 @@ jobs:
             -Dsonar.coverage.exclusions=**/*_test.go,**/mock/*
             -Dsonar.test.inclusions=**/*_test.go
             -Dsonar.tests=.
-            -Dsonar.go.coverage.reportPaths=coverage/gateway-all.cov
+            -Dsonar.go.coverage.reportPaths=coverage/*.cov
             -Dsonar.go.golangci-lint.reportPaths=golanglint.xml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -16,8 +16,6 @@ on:
       - release-**
 
 env:
-  TYK_DB_REDISHOST: localhost
-  TYK_GW_STORAGE_HOST: localhost
   PYTHON_VERSION: "3.11"
   PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
 
@@ -31,6 +29,9 @@ jobs:
         redis-version: [5, 7]
         python-version: ["3.11"]
         go-version: [1.21.x]
+
+    env:
+      REDIS_IMAGE=redis:${{ matrix.redis-version }}
 
     steps:
       - name: Checkout Tyk
@@ -48,6 +49,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Setup CI Tooling
+        uses: shrink/actions-docker-extract@v3
+        with:
+          image: tykio/ci-tools:latest
+          path: /usr/local/bin/.
+          destination: /usr/local/bin
+
       - name: Install Dependencies and basic hygiene test
         id: hygiene
         run: |
@@ -61,9 +69,7 @@ jobs:
           make lint
 
           git add --all
-
           git diff HEAD > git-state.log
-
           git_state_count=$(wc -l < git-state.log)
 
           if [[ $git_state_count -ne 0 ]]
@@ -79,10 +85,6 @@ jobs:
       - name: Fetch base branch
         if: ${{ github.event_name == 'pull_request' }}
         run: git fetch origin ${{ github.base_ref }}
-      - name: Start Redis
-        uses: supercharge/redis-github-action@1.2.0
-        with:
-          redis-version: ${{ matrix.redis-version }}
 
       - name: Cache
         uses: actions/cache@v2
@@ -95,35 +97,21 @@ jobs:
       - name: Run Gateway Tests
         id: ci-tests
         run: |
-          ./bin/ci-tests.sh 2>&1
-
-      - name: Notify status
-        if: ${{ failure() && github.event.pull_request.number && !github.event.pull_request.draft }}
-        uses: peter-evans/create-or-update-comment@v1
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            # :boom: CI tests failed :see_no_evil:
-
-            ## git-state
-            ```shellsession
-            ${{ steps.hygiene.outputs.git-state || 'all ok' }}
-            ```
-
-            Please look at [the run](https://github.com/TykTechnologies/tyk/pull/${{ github.event.pull_request.number }}/checks?check_run_id=${{ github.run_id }}) or in the _Checks_ tab.
-
-      - name: Download golangci-lint
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
+          task test:e2e-combined
+          task coverage
 
       - name: golangci-lint
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          $(go env GOPATH)/bin/golangci-lint run --out-format checkstyle --issues-exit-code=0 --new-from-rev=origin/${{ github.base_ref }} ./... > golanglint.xml
+          $(go env GOPATH)/bin/golangci-lint run --out-format checkstyle --issues-exit-code=1 --new-from-rev=origin/${{ github.base_ref }} ./... > golanglint.xml
+
       - name: golangci-lint-on-push
         if: ${{ github.event_name == 'push' }}
         run: |
           $(go env GOPATH)/bin/golangci-lint run --out-format checkstyle --issues-exit-code=0 ./... > golanglint.xml
+
       - name: SonarCloud Scan
+        if: always()
         uses: sonarsource/sonarcloud-github-action@master
         with:
           args: >
@@ -134,7 +122,7 @@ jobs:
             -Dsonar.coverage.exclusions=**/*_test.go,**/mock/*
             -Dsonar.test.inclusions=**/*_test.go
             -Dsonar.tests=.
-            -Dsonar.go.coverage.reportPaths=*.cov
+            -Dsonar.go.coverage.reportPaths=coverage/gateway-all.cov
             -Dsonar.go.golangci-lint.reportPaths=golanglint.xml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -56,6 +56,16 @@ jobs:
           path: /usr/local/bin/.
           destination: /usr/local/bin
 
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+
       - name: Install Dependencies and basic hygiene test
         id: hygiene
         run: |
@@ -85,14 +95,6 @@ jobs:
       - name: Fetch base branch
         if: ${{ github.event_name == 'pull_request' }}
         run: git fetch origin ${{ github.base_ref }}
-
-      - name: Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
 
       - name: Run Gateway Tests
         id: ci-tests

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        redis-version: [7]
+        redis-version: [5, 7]
         python-version: ["3.11"]
         go-version: [1.21.x]
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -31,7 +31,7 @@ jobs:
         go-version: [1.21.x]
 
     env:
-      REDIS_IMAGE=redis:${{ matrix.redis-version }}
+      REDIS_IMAGE: redis:${{ matrix.redis-version }}
 
     steps:
       - name: Checkout Tyk

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -98,7 +98,7 @@ jobs:
         id: ci-tests
         run: |
           task test:e2e-combined args="-race -timeout=15m"
-          task coverage
+          task test:coverage
 
       - name: golangci-lint
         if: ${{ github.event_name == 'pull_request' }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,7 +72,6 @@ linters:
     - testpackage
     - paralleltest
     - ireturn
-    - err113
   enable:
     - govet
     - forbidigo

--- a/.taskfiles/deps/Taskfile.yml
+++ b/.taskfiles/deps/Taskfile.yml
@@ -9,7 +9,11 @@ tasks:
       - golangci-lint
       - faillint
       - mockgen
-      - schema-gen
+    cmds:
+      - for: ['go-fsck', 'schema-gen', 'summary']
+        task: exp
+        vars:
+          name: '{{.ITEM}}'
 
   mockgen:
     internal: true
@@ -43,10 +47,11 @@ tasks:
     cmds:
       - go install github.com/fatih/faillint@latest
 
-  schema-gen:
-    internal: true
-    desc: 'Install exp/schema-gen'
+  exp:
+    desc: 'Install exp/cmd'
+    requires:
+      vars: [name]
     status:
-      - type schema-gen
+      - type {{.name}}
     cmds:
-      - go install github.com/TykTechnologies/exp/cmd/schema-gen@main
+      - go install github.com/TykTechnologies/exp/cmd/{{.name}}@main

--- a/.taskfiles/test.yml
+++ b/.taskfiles/test.yml
@@ -7,11 +7,18 @@ includes:
     taskfile: ../docker/services/Taskfile.yml
     dir: ../docker/services
 
+# Build and test flags should match. We don't include
+# `-trimpath` in CI tests, as there is a problem resolving
+# runtime.Caller to a valid path, needs test fixes.
+
 vars:
   dir:
     sh: git rev-parse --show-toplevel
   product: 'gateway'
   tags: '{{ .tags | default "goplugin dev" }}'
+  args: '{{ .args | default "-timeout=15m" }}'
+  buildArgs: -cover -tags "{{.tags}}"
+  testArgs: -failfast -coverpkg=./... {{.buildArgs}}
   python:
     sh: python3 -c 'import sys; print("%d.%d" % (sys.version_info[0], sys.version_info[1]))'
 
@@ -34,7 +41,6 @@ tasks:
     deps: [ clean, deps, plugin:race, plugin:norace, services:up ]
     silent: true
     vars:
-      args: '{{ .args | default "-timeout=15m" }}'
       package:
         sh: go mod edit -json | jq .Module.Path -r
       packages:
@@ -45,7 +51,7 @@ tasks:
       - for: { var: packages, as: package }
         cmd: |-
           gotestsum --no-color=false --hide-summary=skipped --raw-command \
-          go test -p 1 -coverpkg=./... -json -tags="{{.tags}}" {{.args}} -count=1 -v -cover \
+          go test -p 1 -json {{.testArgs}} {{.args}} -count=1 -v \
           -coverprofile=coverage/{{.package | replace "." "gateway" | replace "/" "-"}}.cov {{.package}} | head -n -2
 
   integration-combined:
@@ -53,33 +59,30 @@ tasks:
     desc: "Run e2e/integration tests"
     aliases: [ e2e-combined ]
     deps: [ clean, deps, plugin:race, plugin:norace, services:up ]
-    silent: true
     vars:
-      args: '{{ .args | default "-timeout=15m" }}'
       package:
         sh: go mod edit -json | jq .Module.Path -r
     cmds:
       - defer: { task: services:down }
       - defer: { task: report }
       - rm -rf coverage && mkdir -p coverage
-      - go test -p 1 -json -coverpkg=./... -tags="{{.tags}}" {{.args}} -cover -coverprofile=coverage/{{.product}}-all.cov -count=1 -v ./... > coverage/{{.product}}-all.json
+      - go test -p 1 -json {{.testArgs}} {{.args}} -coverprofile=coverage/{{.product}}-all.cov -count=1 -v ./... > coverage/{{.product}}-all.json
 
   plugin:race:
     dir: '{{.dir}}'
     desc: "Build plugin required for tests (with race)"
     cmds:
-      - go build -race -o ./test/goplugins/goplugins_race.so -buildmode=plugin ./test/goplugins
+      - go build {{.buildArgs}} -race -o ./test/goplugins/goplugins_race.so -buildmode=plugin ./test/goplugins
 
   plugin:norace:
     dir: '{{.dir}}'
     desc: "Build plugin required for tests (no race)"
     cmds:
-      - go build -o ./test/goplugins/goplugins.so -buildmode=plugin ./test/goplugins
+      - go build {{.buildArgs}} -o ./test/goplugins/goplugins.so -buildmode=plugin ./test/goplugins
 
   report:
     dir: '{{.dir}}'
     desc: "Run gotestsum on test run output"
-    silent: true
     vars:
       count: '{{ .count | default "10" }}'
     cmds:

--- a/.taskfiles/test.yml
+++ b/.taskfiles/test.yml
@@ -1,0 +1,84 @@
+---
+version: "3"
+
+includes:
+  deps: ./deps/Taskfile.yml
+  services:
+    taskfile: ../docker/services/Taskfile.yml
+    dir: ../docker/services
+
+vars:
+  dir:
+    sh: git rev-parse --show-toplevel
+  product: 'gateway'
+  tags: '{{ .tags | default "goplugin" }}'
+  python:
+    sh: python3 -c 'import sys; print("%d.%d" % (sys.version_info[0], sys.version_info[1]))'
+
+env:
+  PYTHON_VERSION: '{{.python}}'
+  CI: 'true'
+
+tasks:
+
+  # integration - run go tests with services
+  #
+  # Most of our go tests are integration tests using related services like
+  # mongodb, postgresql or redis. This task spins up the required services
+  # to run the tests and then runs the tests on the individual packages.
+
+  integration:
+    desc: "Run e2e/integration tests"
+    dir: '{{.dir}}'
+    aliases: [ e2e ]
+    deps: [ deps, plugin:race, plugin:norace, services:up ]
+    silent: true
+    vars:
+      args: '{{ .args | default "-timeout=15m" }}'
+      package:
+        sh: go mod edit -json | jq .Module.Path -r
+      packages:
+        sh: go list ./... | sed -e 's|{{.package}}|.|g'
+    cmds:
+      - defer: { task: services:down }
+      - rm -rf coverage && mkdir -p coverage
+      - for: { var: packages, as: package }
+        cmd: gotestsum --no-color=false --hide-summary=skipped --raw-command go test -p 1 -json -tags={{.tags}} {{.args}} -cover -coverprofile=coverage/{{.package | replace "." "gateway" | replace "/" "-"}}.cov -count=1 -v {{.package}} | head -n -2
+
+  integration-combined:
+    dir: '{{.dir}}'
+    desc: "Run e2e/integration tests"
+    aliases: [ e2e-combined ]
+    deps: [ deps, plugin:race, plugin:norace, services:up ]
+    silent: true
+    vars:
+      args: '{{ .args | default "-timeout=15m" }}'
+      package:
+        sh: go mod edit -json | jq .Module.Path -r
+    cmds:
+      - defer: { task: services:down }
+      - defer: { task: report }
+      - rm -rf coverage && mkdir -p coverage
+      - go test -p 1 -json -tags={{.tags}} {{.args}} -cover -coverprofile=coverage/{{.product}}-all.cov -count=1 -v ./... > coverage/{{.product}}-all.json
+
+  plugin:race:
+    dir: '{{.dir}}'
+    desc: "Build plugin required for tests (with race)"
+    cmds:
+      - go build -race -o ./test/goplugins/goplugins_race.so -buildmode=plugin ./test/goplugins
+
+  plugin:norace:
+    dir: '{{.dir}}'
+    desc: "Build plugin required for tests (no race)"
+    cmds:
+      - go build -o ./test/goplugins/goplugins.so -buildmode=plugin ./test/goplugins
+
+  report:
+    dir: '{{.dir}}'
+    desc: "Run gotestsum on test run output"
+    silent: true
+    vars:
+      count: '{{ .count | default "10" }}'
+    cmds:
+      - gotestsum --hide-summary=skipped --junitfile=unit-tests.xml --raw-command cat coverage/{{.product}}-all.json
+      - echo "Slowest {{.count}} tests:" && cat coverage/{{.product}}-all.json | gotestsum tool slowest | head -n {{.count}} | sed -e 's|{{.package}}/||g'

--- a/.taskfiles/test.yml
+++ b/.taskfiles/test.yml
@@ -31,7 +31,7 @@ tasks:
     desc: "Run e2e/integration tests"
     dir: '{{.dir}}'
     aliases: [ e2e ]
-    deps: [ deps, plugin:race, plugin:norace, services:up ]
+    deps: [ clean, deps, plugin:race, plugin:norace, services:up ]
     silent: true
     vars:
       args: '{{ .args | default "-timeout=15m" }}'
@@ -43,13 +43,16 @@ tasks:
       - defer: { task: services:down }
       - rm -rf coverage && mkdir -p coverage
       - for: { var: packages, as: package }
-        cmd: gotestsum --no-color=false --hide-summary=skipped --raw-command go test -p 1 -json -tags={{.tags}} {{.args}} -cover -coverprofile=coverage/{{.package | replace "." "gateway" | replace "/" "-"}}.cov -count=1 -v {{.package}} | head -n -2
+        cmd: |-
+          gotestsum --no-color=false --hide-summary=skipped --raw-command \
+          go test -p 1 -coverpkg=./... -json -tags={{.tags}} {{.args}} -count=1 -v -cover \
+          -coverprofile=coverage/{{.package | replace "." "gateway" | replace "/" "-"}}.cov {{.package}} | head -n -2
 
   integration-combined:
     dir: '{{.dir}}'
     desc: "Run e2e/integration tests"
     aliases: [ e2e-combined ]
-    deps: [ deps, plugin:race, plugin:norace, services:up ]
+    deps: [ clean, deps, plugin:race, plugin:norace, services:up ]
     silent: true
     vars:
       args: '{{ .args | default "-timeout=15m" }}'
@@ -59,7 +62,7 @@ tasks:
       - defer: { task: services:down }
       - defer: { task: report }
       - rm -rf coverage && mkdir -p coverage
-      - go test -p 1 -json -tags={{.tags}} {{.args}} -cover -coverprofile=coverage/{{.product}}-all.cov -count=1 -v ./... > coverage/{{.product}}-all.json
+      - go test -p 1 -json -coverpkg=./... -tags={{.tags}} {{.args}} -cover -coverprofile=coverage/{{.product}}-all.cov -count=1 -v ./... > coverage/{{.product}}-all.json
 
   plugin:race:
     dir: '{{.dir}}'
@@ -82,3 +85,27 @@ tasks:
     cmds:
       - gotestsum --hide-summary=skipped --junitfile=unit-tests.xml --raw-command cat coverage/{{.product}}-all.json
       - echo "Slowest {{.count}} tests:" && cat coverage/{{.product}}-all.json | gotestsum tool slowest | head -n {{.count}} | sed -e 's|{{.package}}/||g'
+
+  clean:
+    desc: "Clean test outputs"
+    cmds:
+      - rm -f coverage/*.{json,cov}
+
+  cover:
+    desc: "Show source coverage"
+    deps: [cover:merge]
+    cmds:
+      - go tool cover -func=coverage/{{.product}}-all.cov | summary coverfunc
+
+  uncover:
+    desc: "Show uncovered source"
+    deps: [cover:merge]
+    cmds:
+      - uncover coverage/{{.product}}-all.cov
+
+  cover:merge:
+    desc: "Merge coverage from e2e tests"
+    status:
+      - test -f coverage/{{.product}}-all.cov
+    cmds:
+      - gocovmerge coverage/*.cov > coverage/{{.product}}-all.cov

--- a/.taskfiles/test.yml
+++ b/.taskfiles/test.yml
@@ -11,7 +11,7 @@ vars:
   dir:
     sh: git rev-parse --show-toplevel
   product: 'gateway'
-  tags: '{{ .tags | default "goplugin" }}'
+  tags: '{{ .tags | default "goplugin dev" }}'
   python:
     sh: python3 -c 'import sys; print("%d.%d" % (sys.version_info[0], sys.version_info[1]))'
 
@@ -45,7 +45,7 @@ tasks:
       - for: { var: packages, as: package }
         cmd: |-
           gotestsum --no-color=false --hide-summary=skipped --raw-command \
-          go test -p 1 -coverpkg=./... -json -tags={{.tags}} {{.args}} -count=1 -v -cover \
+          go test -p 1 -coverpkg=./... -json -tags="{{.tags}}" {{.args}} -count=1 -v -cover \
           -coverprofile=coverage/{{.package | replace "." "gateway" | replace "/" "-"}}.cov {{.package}} | head -n -2
 
   integration-combined:
@@ -62,7 +62,7 @@ tasks:
       - defer: { task: services:down }
       - defer: { task: report }
       - rm -rf coverage && mkdir -p coverage
-      - go test -p 1 -json -coverpkg=./... -tags={{.tags}} {{.args}} -cover -coverprofile=coverage/{{.product}}-all.cov -count=1 -v ./... > coverage/{{.product}}-all.json
+      - go test -p 1 -json -coverpkg=./... -tags="{{.tags}}" {{.args}} -cover -coverprofile=coverage/{{.product}}-all.cov -count=1 -v ./... > coverage/{{.product}}-all.json
 
   plugin:race:
     dir: '{{.dir}}'

--- a/.taskfiles/test.yml
+++ b/.taskfiles/test.yml
@@ -96,6 +96,7 @@ tasks:
 
   cover:
     desc: "Show source coverage"
+    aliases: [cov, coverage]
     deps: [cover:merge]
     cmds:
       - go tool cover -func=coverage/{{.product}}-all.cov | summary coverfunc
@@ -108,6 +109,7 @@ tasks:
 
   cover:merge:
     desc: "Merge coverage from e2e tests"
+    internal: true
     status:
       - test -f coverage/{{.product}}-all.cov
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,12 +1,17 @@
+# yamllint disable rule:line-length
 ---
 version: "3"
 
 includes:
   lint: .taskfiles/lint.yml
+  test: .taskfiles/test.yml
   deps: .taskfiles/deps/Taskfile.yml
   opentelemetry:
     taskfile: ci/tests/tracing/Taskfile.yml
     dir: ci/tests/tracing/
+  services:
+    taskfile: docker/services/Taskfile.yml
+    dir: docker/services/
 
 tasks:
   docker:

--- a/docker/services/redis.yml
+++ b/docker/services/redis.yml
@@ -1,7 +1,7 @@
 ---
 services:
   redis:
-    image: redis:6-alpine
+    image: ${REDIS_IMAGE:-redis:6-alpine}
     networks:
       - proxy
     ports:

--- a/gateway/rpc_test.go
+++ b/gateway/rpc_test.go
@@ -1,6 +1,3 @@
-//go:build !race || unstable
-// +build !race unstable
-
 package gateway
 
 import (
@@ -112,6 +109,7 @@ const apiDefListTest2 = `[{
 }]`
 
 func TestSyncAPISpecsRPCFailure_CheckGlobals(t *testing.T) {
+	test.Flaky(t) // TT-9117
 
 	// We test to check if we are actually calling the GetApiDefinitions and
 	// GetPolicies.
@@ -166,6 +164,8 @@ func TestSyncAPISpecsRPCFailure_CheckGlobals(t *testing.T) {
 }
 
 func TestSyncAPISpecsRPCSuccess(t *testing.T) {
+	test.Flaky(t) // TT-9117
+
 	// Test RPC
 	rpc.UseSyncLoginRPC = true
 	var GetKeyCounter int
@@ -345,6 +345,8 @@ func TestSyncAPISpecsRPCSuccess(t *testing.T) {
 }
 
 func TestSyncAPISpecsRPC_redis_failure(t *testing.T) {
+	test.Flaky(t) // TT-9117
+
 	dispatcher := gorpc.NewDispatcher()
 	dispatcher.AddFunc("GetApiDefinitions", func(clientAddr string, dr *apidef.DefRequest) (string, error) {
 		return jsonMarshalString(BuildAPI(func(spec *APISpec) {
@@ -409,6 +411,8 @@ func TestSyncAPISpecsRPC_redis_failure(t *testing.T) {
 }
 
 func TestOrgSessionWithRPCDown(t *testing.T) {
+	test.Flaky(t) // TT-9117
+
 	//we need rpc down
 	conf := func(globalConf *config.Config) {
 		globalConf.SlaveOptions.ConnectionString = testHttpFailure

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -407,7 +407,6 @@ func (gw *Gateway) setupGlobals() {
 	}
 
 	// Load all the files that have the "error" prefix.
-	//	gwConfig.TemplatePath = "/Users/sredny/go/src/github.com/TykTechnologies/tyk/templates"
 	templatesDir := filepath.Join(gwConfig.TemplatePath, "error*")
 	gw.templates = htmlTemplate.Must(htmlTemplate.ParseGlob(templatesDir))
 	gw.templatesRaw = textTemplate.Must(textTemplate.ParseGlob(templatesDir))

--- a/storage/redis_cluster_test.go
+++ b/storage/redis_cluster_test.go
@@ -1996,17 +1996,18 @@ func TestStartPubSubHandler(t *testing.T) {
 		mockQueue.On("Subscribe", mock.Anything, "test-channel").Return(mockedSubscription, nil)
 		defer mockQueue.AssertExpectations(t)
 
-		callbackCalled := false
+		callbackCalled := make(chan bool, 1)
 		callback := func(obj interface{}) {
 			msg, ok := obj.(model.Message)
 			assert.True(t, ok)
 
-			callbackCalled = true
 			msgPayload, err := msg.Payload()
 			assert.NoError(t, err)
 			payload, err := msg.Payload()
 			assert.NoError(t, err)
 			assert.Equal(t, payload, msgPayload)
+
+			callbackCalled <- true
 		}
 
 		go func() {
@@ -2014,8 +2015,15 @@ func TestStartPubSubHandler(t *testing.T) {
 			_ = storage.StartPubSubHandler(context.Background(), "test-channel", callback)
 		}()
 
-		time.Sleep(100 * time.Millisecond) // Allow some time for the goroutine to run
-		assert.True(t, callbackCalled)
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		select {
+		case ok := <-callbackCalled:
+			assert.True(t, ok, "callback was called")
+		case <-ctx.Done():
+			assert.Fail(t, "callback was not called within the timeout period")
+		}
 	})
 
 	t.Run("error on receive", func(t *testing.T) {


### PR DESCRIPTION
This PR implements:

Taskfile.yml, .taskfiles/test.yml, taskfiles/deps/Taskfile.yml:

- added `test:e2e` and `test:e2e-combined`. By default they run without `-race`.
- included new CI dependencies in deps taskfile (provided with tykio/ci-tools for github CI, this is for local development)

ci-tests.yml:

- CI runs `task test:e2e-combined args="-race -timeout=15m"`
- CI runs `task test:coverage` to print per-package coverage report
- CI runs `task test:report` at to print slowest tests (only available in `e2e-combined`)
- CI Pipeline changes: run test environment from taskfiles
    - Cache moved up to happen before `make lint` (restore cache first)
    - Using tykio/ci-tools to get task, golangci-lint and other CI tooling, silence golangcilint config
    - Removed github comment notification, it's noise - it's a required pipeline

Pipeline for sonarcloud is now pinned to redis7, there is some unnecessary duplication due to the redis matrix and some actions like golangci-lint unfortunately run twice. Our next step should be to make the redis 7 pipeline required, and then remove the redis 5 pipeline, and then sanitize the state in a future review.

storage: test fix for a data race
gateway: rpc_test.go, agreed marking RPC test as flaky due to sensitivity to `-race` (ok'd with @sredxny)
docker/services: support REDIS_IMAGE to override for matrix test

https://tyktech.atlassian.net/browse/TT-10532