### PR TITLE
Merging to release-5.4: [TT-12425] exp/modcheck: Update go.mod dependencies (#6363)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,8 +38,13 @@ require (
 	github.com/golang/protobuf v1.5.3
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/mux v1.8.1
+<<<<<<< HEAD
 	github.com/gorilla/websocket v1.5.1
 	github.com/hashicorp/consul/api v1.26.1
+=======
+	github.com/gorilla/websocket v1.5.3
+	github.com/hashicorp/consul/api v1.29.1
+>>>>>>> 5d8cbd77a... [TT-12425] exp/modcheck: Update go.mod dependencies (#6363)
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/vault/api v1.12.1
@@ -48,7 +53,11 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/lonelycode/osin v0.0.0-20160423095202-da239c9dacb6
 	github.com/mavricknz/ldap v0.0.0-20160227184754-f5a958005e43
+<<<<<<< HEAD
 	github.com/miekg/dns v1.1.57
+=======
+	github.com/miekg/dns v1.1.61
+>>>>>>> 5d8cbd77a... [TT-12425] exp/modcheck: Update go.mod dependencies (#6363)
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/nsf/jsondiff v0.0.0-20230430225905-43f6cf3098c1 // test
@@ -64,7 +73,11 @@ require (
 	github.com/spf13/afero v1.11.0
 	github.com/stretchr/testify v1.8.4 // test
 	github.com/uber/jaeger-client-go v2.30.1-0.20220110192849-8d8e8fcfd04d+incompatible
+<<<<<<< HEAD
 	github.com/valyala/fasthttp v1.51.0 // test
+=======
+	github.com/valyala/fasthttp v1.55.0 // test
+>>>>>>> 5d8cbd77a... [TT-12425] exp/modcheck: Update go.mod dependencies (#6363)
 	github.com/vmihailenco/msgpack v4.0.4+incompatible
 	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/crypto v0.21.0
@@ -72,7 +85,11 @@ require (
 	golang.org/x/sync v0.6.0
 	google.golang.org/grpc v1.62.1
 	google.golang.org/grpc/examples v0.0.0-20220317213542-f95b001a48df // test
+<<<<<<< HEAD
 	google.golang.org/protobuf v1.33.0
+=======
+	google.golang.org/protobuf v1.34.2
+>>>>>>> 5d8cbd77a... [TT-12425] exp/modcheck: Update go.mod dependencies (#6363)
 	gopkg.in/vmihailenco/msgpack.v2 v2.9.2
 	gopkg.in/xmlpath.v2 v2.0.0-20150820204837-860cbeca3ebc
 	gopkg.in/yaml.v3 v3.0.1
@@ -164,7 +181,11 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.2 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
+<<<<<<< HEAD
 	github.com/klauspost/compress v1.17.0 // indirect
+=======
+	github.com/klauspost/compress v1.17.9 // indirect
+>>>>>>> 5d8cbd77a... [TT-12425] exp/modcheck: Update go.mod dependencies (#6363)
 	github.com/lonelycode/go-uuid v0.0.0-20141202165402-ed3ca8a15a93 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
@@ -206,11 +227,19 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/exp v0.0.0-20240112132812-db7319d0e0e3 // indirect
+<<<<<<< HEAD
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/tools v0.17.0 // indirect
+=======
+	golang.org/x/mod v0.18.0 // indirect
+	golang.org/x/sys v0.21.0 // indirect
+	golang.org/x/text v0.16.0 // indirect
+	golang.org/x/time v0.5.0 // indirect
+	golang.org/x/tools v0.22.0 // indirect
+>>>>>>> 5d8cbd77a... [TT-12425] exp/modcheck: Update go.mod dependencies (#6363)
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240123012728-ef4313101c80 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240123012728-ef4313101c80 // indirect

--- a/go.sum
+++ b/go.sum
@@ -299,8 +299,13 @@ github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
+<<<<<<< HEAD
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
+=======
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+>>>>>>> 5d8cbd77a... [TT-12425] exp/modcheck: Update go.mod dependencies (#6363)
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
 github.com/hashicorp/consul/api v1.26.1 h1:5oSXOO5fboPZeW5SN+TdGFP/BILDgBm19OrPZ/pICIM=
@@ -410,8 +415,13 @@ github.com/justinas/alice v1.2.0/go.mod h1:fN5HRH/reO/zrUflLfTN43t3vXvKzvZIENsNE
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+<<<<<<< HEAD
 github.com/klauspost/compress v1.17.0 h1:Rnbp4K9EjcDuVuHtd0dgA4qNuv9yKDYKK1ulpJwgrqM=
 github.com/klauspost/compress v1.17.0/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
+=======
+github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
+github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
+>>>>>>> 5d8cbd77a... [TT-12425] exp/modcheck: Update go.mod dependencies (#6363)
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -454,8 +464,13 @@ github.com/mavricknz/ldap v0.0.0-20160227184754-f5a958005e43 h1:x4SDcUPDTMzuFEdW
 github.com/mavricknz/ldap v0.0.0-20160227184754-f5a958005e43/go.mod h1:z76yvVwVulPd8FyifHe8UEHeud6XXaSan0ibi2sDy6w=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
+<<<<<<< HEAD
 github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
 github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
+=======
+github.com/miekg/dns v1.1.61 h1:nLxbwF3XxhwVSm8g9Dghm9MHPaUZuqhPiGL+675ZmEs=
+github.com/miekg/dns v1.1.61/go.mod h1:mnAarhS3nWaW+NVP2wTkYVIZyHNJ098SJZUki3eykwQ=
+>>>>>>> 5d8cbd77a... [TT-12425] exp/modcheck: Update go.mod dependencies (#6363)
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
@@ -633,8 +648,13 @@ github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0
 github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
+<<<<<<< HEAD
 github.com/valyala/fasthttp v1.51.0 h1:8b30A5JlZ6C7AS81RsWjYMQmrZG6feChmgAolCl1SqA=
 github.com/valyala/fasthttp v1.51.0/go.mod h1:oI2XroL+lI7vdXyYoQk03bXBThfFl2cVdIA3Xl7cH8g=
+=======
+github.com/valyala/fasthttp v1.55.0 h1:Zkefzgt6a7+bVKHnu/YaYSOPfNYNisSVBo/unVCf8k8=
+github.com/valyala/fasthttp v1.55.0/go.mod h1:NkY9JtkrpPKmgwV3HTaS2HWaJss9RSIsRVfcxxoHiOM=
+>>>>>>> 5d8cbd77a... [TT-12425] exp/modcheck: Update go.mod dependencies (#6363)
 github.com/vektah/gqlparser/v2 v2.5.1 h1:ZGu+bquAY23jsxDRcYpWjttRZrUz07LbiY77gUOHcr4=
 github.com/vektah/gqlparser/v2 v2.5.1/go.mod h1:mPgqFBu/woKTVYWyNk8cO3kh4S/f4aRFZrvOnp3hmCs=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
@@ -727,8 +747,13 @@ golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3/go.mod h1:3p9vT2HGsQu2K1YbXdKPJLVgG5VJdoTa1poYQBtP1AY=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+<<<<<<< HEAD
 golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
 golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+=======
+golang.org/x/mod v0.18.0 h1:5+9lSbEzPSdWkH32vYPBwEpX8KwDbM52Ud9xBUvNlb0=
+golang.org/x/mod v0.18.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+>>>>>>> 5d8cbd77a... [TT-12425] exp/modcheck: Update go.mod dependencies (#6363)
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -859,8 +884,13 @@ golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.10/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
+<<<<<<< HEAD
 golang.org/x/tools v0.17.0 h1:FvmRgNOcs3kOa+T20R1uhfP9F6HgG2mfxDv1vrx1Htc=
 golang.org/x/tools v0.17.0/go.mod h1:xsh6VxdV005rRVaS6SSAf9oiAqljS7UZUacMZ8Bnsps=
+=======
+golang.org/x/tools v0.22.0 h1:gqSGLZqv+AI9lIQzniJ0nZDRG5GBPsSi+DRNHWNz6yA=
+golang.org/x/tools v0.22.0/go.mod h1:aCwcsjqvq7Yqt6TNyX7QMU2enbQ/Gt0bo6krSeEri+c=
+>>>>>>> 5d8cbd77a... [TT-12425] exp/modcheck: Update go.mod dependencies (#6363)
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -907,8 +937,13 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+<<<<<<< HEAD
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+=======
+google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=
+google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
+>>>>>>> 5d8cbd77a... [TT-12425] exp/modcheck: Update go.mod dependencies (#6363)
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/cenkalti/backoff.v1 v1.1.0 h1:Arh75ttbsvlpVA7WtVpH4u9h6Zl46xuptxqLxPiSo4Y=
 gopkg.in/cenkalti/backoff.v1 v1.1.0/go.mod h1:J6Vskwqd+OMVJl8C33mmtxTBs2gyzfv7UDAkHu8BrjI=


### PR DESCRIPTION
[TT-12425] exp/modcheck: Update go.mod dependencies (#6363)

### **User description**
Triggered by: jeffy-mathew

| IMPORT | VERSION | LATEST | WARNINGS | CVES |
|:---|:---|:---|:---|:---|
| getkin/kin-openapi | v0.115.0 | v0.125.0 | Held back from upgrade | |
| gorilla/websocket | v1.5.2 | v1.5.3 | | 0 of 1 |
| miekg/dns | v1.1.59 | v1.1.61 | | 0 of 3 |
| valyala/fasthttp | v1.54.0 | v1.55.0 | | 0 of 1 |
| google.golang.org/protobuf | v1.34.1 | v1.34.2 | | 0 of 2 |
| go-redsync/redsync/v4 | v4.11.0 | v4.13.0 | Held back from upgrade | |
| newrelic/go-agent | v2.13.0 +incompatible | v3.33.0+incompatible |
Held back from upgrade | |
| go.opentelemetry.io/otel | v1.19.0 | v1.27.0 | Held back from upgrade
| |
| go.opentelemetry.io/otel/trace | v1.19.0 | v1.27.0 | Held back from
upgrade | |

<details>
  <summary>Steps performed</summary>

  ~~~
  + go get github.com/gorilla/websocket@v1.5.3
go: downloading github.com/gorilla/websocket v1.5.3
go: upgraded github.com/gorilla/websocket v1.5.2 => v1.5.3
+ go get github.com/miekg/dns@v1.1.61
go: downloading github.com/miekg/dns v1.1.61
go: downloading golang.org/x/tools v0.22.0
go: downloading golang.org/x/mod v0.18.0
go: upgraded github.com/miekg/dns v1.1.59 => v1.1.61
go: upgraded golang.org/x/mod v0.17.0 => v0.18.0
go: upgraded golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d =>
v0.22.0
+ go get github.com/valyala/fasthttp@v1.55.0
go: downloading github.com/valyala/fasthttp v1.55.0
go: downloading github.com/klauspost/compress v1.17.9
go: upgraded github.com/klauspost/compress v1.17.8 => v1.17.9
go: upgraded github.com/valyala/fasthttp v1.54.0 => v1.55.0
+ go get google.golang.org/protobuf@v1.34.2
go: downloading google.golang.org/protobuf v1.34.2
go: upgraded google.golang.org/protobuf v1.34.1 => v1.34.2
  ~~~
</details>

<details>
  <summary>go mod tidy output</summary>

  ```
  go: downloading github.com/jensneuse/diffview v1.0.0
go: downloading github.com/sebdah/goldie
v0.0.0-20180424091453-8784dd1ab561
go: downloading github.com/ory/dockertest/v3 v3.10.0
go: downloading gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
go: downloading github.com/evanphx/json-patch/v5 v5.1.0
go: downloading github.com/golang/mock v1.6.0
go: downloading github.com/onsi/ginkgo v1.16.5
go: downloading github.com/onsi/gomega v1.27.10
go: downloading github.com/go-test/deep v1.0.8
go: downloading github.com/fortytw2/leaktest v1.3.0
go: downloading github.com/Microsoft/go-winio v0.6.0
go: downloading github.com/docker/go-units v0.4.0
go: downloading github.com/99designs/gqlgen v0.17.22
go: downloading go.uber.org/goleak v1.2.1
go: downloading github.com/vektah/gqlparser/v2 v2.5.1
go: downloading github.com/ugorji/go/codec v1.2.7
go: downloading gonum.org/v1/gonum v0.14.0
go: downloading github.com/ugorji/go v1.2.7
go: downloading github.com/bsm/ginkgo/v2 v2.12.0
go: downloading github.com/bsm/gomega v1.27.10
go: downloading github.com/hashicorp/consul/proto-public v0.6.1
go: downloading github.com/hashicorp/consul/sdk v0.16.1
go: downloading github.com/kr/pretty v0.3.1
go: downloading github.com/sebdah/goldie/v2 v2.5.3
go: downloading github.com/go-redis/redis v6.15.9+incompatible
go: downloading github.com/go-redis/redis/v7 v7.4.0
go: downloading github.com/gomodule/redigo v1.8.9
go: downloading github.com/redis/rueidis v1.0.19
go: downloading github.com/stvp/tempredis
v0.0.0-20181119212430-b82af8480203
go: downloading github.com/frankban/quicktest v1.14.6
go: downloading github.com/jcmturner/goidentity/v6 v6.0.1
go: downloading github.com/docker/cli v20.10.17+incompatible
go: downloading github.com/opencontainers/runc v1.1.5
go: downloading github.com/Nvveen/Gotty
v0.0.0-20120604004816-cd527374f1e5
go: downloading github.com/moby/term v0.0.0-20201216013528-df9cb8a40635
go: downloading github.com/opencontainers/image-spec v1.0.2
go: downloading github.com/logrusorgru/aurora/v3 v3.0.0
go: downloading github.com/benbjohnson/clock v1.1.0
go: downloading github.com/hashicorp/go-msgpack v0.5.5
go: downloading github.com/hashicorp/memberlist v0.5.0
go: downloading github.com/kr/text v0.2.0
go: downloading github.com/rogpeppe/go-internal v1.11.0
go: downloading github.com/sergi/go-diff v1.1.0
go: downloading github.com/nxadm/tail v1.4.8
go: downloading github.com/docker/go-connections v0.4.0
go: downloading github.com/containerd/continuity v0.3.0
go: downloading github.com/opencontainers/go-digest v1.0.0
go: downloading github.com/agnivade/levenshtein v1.1.1
go: downloading github.com/pascaldekloe/goe v0.1.0
go: downloading github.com/google/btree v1.0.1
go: downloading github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529
go: downloading gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
go: downloading github.com/docker/docker v20.10.7+incompatible
go: downloading github.com/google/shlex
v0.0.0-20191202100458-e7afc7fbc510
go: downloading github.com/Azure/go-ansiterm
v0.0.0-20230124172434-306776ec8161
go: downloading github.com/golang/glog v1.2.0
go: downloading github.com/gogo/protobuf v1.3.2
  ```
</details>

JIRA: https://tyktech.atlassian.net/browse/TT-12425


___

### **PR Type**
Enhancement


___

### **Description**
- Updated several Go module dependencies to their latest versions in
`go.mod`:
  - `github.com/gorilla/websocket` from v1.5.2 to v1.5.3
  - `github.com/miekg/dns` from v1.1.59 to v1.1.61
  - `github.com/valyala/fasthttp` from v1.54.0 to v1.55.0
  - `google.golang.org/protobuf` from v1.34.1 to v1.34.2
- Updated corresponding checksums in `go.sum` to reflect the new
versions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Dependencies
</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>go.mod</strong><dd><code>Update Go module dependencies
to latest versions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go.mod
<li>Updated <code>github.com/gorilla/websocket</code> from v1.5.2 to
v1.5.3<br> <li> Updated <code>github.com/miekg/dns</code> from v1.1.59
to v1.1.61<br> <li> Updated <code>github.com/valyala/fasthttp</code>
from v1.54.0 to v1.55.0<br> <li> Updated
<code>google.golang.org/protobuf</code> from v1.34.1 to v1.34.2<br>


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6363/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+7/-7</a>&nbsp;
&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
<summary><strong>go.sum</strong><dd><code>Update Go module checksums for
dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go.sum
<li>Updated checksums for <code>github.com/gorilla/websocket</code> to
v1.5.3<br> <li> Updated checksums for <code>github.com/miekg/dns</code>
to v1.1.61<br> <li> Updated checksums for
<code>github.com/valyala/fasthttp</code> to v1.55.0<br> <li> Updated
checksums for <code>google.golang.org/protobuf</code> to v1.34.2<br>


</details>
    

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6363/files#diff-3295df7234525439d778f1b282d146a4f1ff6b415248aaac074e8042d9f42d63">+14/-14</a>&nbsp;
</td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools
and their descriptions

Co-authored-by: jeffy-mathew <8171046+jeffy-mathew@users.noreply.github.com>

[TT-12425]: https://tyktech.atlassian.net/browse/TT-12425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ