### PR TITLE
[TT-10532] Fix golangci-lint step to exit 0

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -102,10 +102,12 @@ jobs:
           task test:e2e-combined args="-race -timeout=15m"
           task test:coverage
 
+      # golangci-lint actions *require* issues-exit-code=0 to pass data along to sonarcloud
+      # rather than erroring out on github issues directly with out-format github.
       - name: golangci-lint
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          $(go env GOPATH)/bin/golangci-lint run --out-format checkstyle --issues-exit-code=1 --new-from-rev=origin/${{ github.base_ref }} ./... > golanglint.xml
+          $(go env GOPATH)/bin/golangci-lint run --out-format checkstyle --issues-exit-code=0 --new-from-rev=origin/${{ github.base_ref }} ./... > golanglint.xml
 
       - name: golangci-lint-on-push
         if: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
### **User description**
The change introduced in #6350 changed the exit-code incorrectly. Added comment.


___

### **PR Type**
bug fix, enhancement


___

### **Description**
- Fixed the `golangci-lint` step in the CI workflow to use `issues-exit-code=0` to ensure proper data passing to SonarCloud.
- Added comments to clarify the necessity of this change.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci-tests.yml</strong><dd><code>Fix golangci-lint exit code and add explanatory comments</code>&nbsp; </dd></summary>
<hr>

.github/workflows/ci-tests.yml
<li>Added comments to explain the need for <code>issues-exit-code=0</code> in <br>golangci-lint step.<br> <li> Changed <code>issues-exit-code</code> from 1 to 0 in golangci-lint step.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6369/files#diff-03609cb60b0c6e92fb771eb8787d6722b8c31ca4c03eabc788e147acd8c6fb43">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

