### PR TITLE
fix unnecessary call to DeleteRawKey if no allowance scope is defined

### DIFF
--- a/gateway/auth_manager.go
+++ b/gateway/auth_manager.go
@@ -79,9 +79,20 @@ func (b *DefaultSessionManager) ResetQuota(keyName string, session *user.Session
 	// Fix the raw key
 	b.store.DeleteRawKey(rawKey)
 
+	b.deleteRawKeysWithAllowanceScope(b.store, session, keyName)
+}
+
+func (b *DefaultSessionManager) deleteRawKeysWithAllowanceScope(store storage.Handler, session *user.SessionState, keyName string) {
+	if store == nil || session == nil {
+		return
+	}
+
 	for _, acl := range session.AccessRights {
-		rawKey = QuotaKeyPrefix + acl.AllowanceScope + "-" + keyName
-		b.store.DeleteRawKey(rawKey)
+		if acl.AllowanceScope == "" {
+			continue
+		}
+		rawKey := QuotaKeyPrefix + acl.AllowanceScope + "-" + keyName
+		store.DeleteRawKey(rawKey)
 	}
 }
 

--- a/gateway/auth_manager_test.go
+++ b/gateway/auth_manager_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -380,4 +381,193 @@ func TestCustomKeysEdgeGw(t *testing.T) {
 
 	}
 
+}
+
+func TestDeleteRawKeysWithAllowanceScope(t *testing.T) {
+	sessionManager := DefaultSessionManager{}
+
+	t.Run("should not panic if storage.Handler is nil", func(t *testing.T) {
+		session := &user.SessionState{
+			AccessRights: map[string]user.AccessDefinition{
+				"ar1": {AllowanceScope: "scope1"},
+			},
+		}
+
+		sessionManager.deleteRawKeysWithAllowanceScope(nil, session, "keyName")
+	})
+
+	t.Run("should not panic if session is nil", func(t *testing.T) {
+		handler := newCountingStorageHandler()
+		sessionManager.deleteRawKeysWithAllowanceScope(handler, nil, "keyName")
+
+		assert.Equal(t, 0, handler.deleteRawKeyCount)
+	})
+
+	t.Run("should not call DeleteRawKey of the storage handler if no allowance scope is defined in any AccessDefinition", func(t *testing.T) {
+		// Lets create 10,000 elements, see TT-11721
+		const elementsCount = 10_000
+		accessRights := make(map[string]user.AccessDefinition, elementsCount)
+		for i := 0; i < elementsCount; i++ {
+			key := fmt.Sprintf("ar-%d", i)
+			accessRights[key] = user.AccessDefinition{AllowanceScope: ""}
+		}
+
+		session := &user.SessionState{
+			AccessRights: accessRights,
+		}
+
+		handler := newCountingStorageHandler()
+		sessionManager.deleteRawKeysWithAllowanceScope(handler, session, "keyName")
+
+		assert.Equal(t, 0, handler.deleteRawKeyCount)
+	})
+
+	t.Run("should only call DeleteRawKey of the storage handler as many times as allowance scopes are defined", func(t *testing.T) {
+		session := &user.SessionState{
+			AccessRights: map[string]user.AccessDefinition{
+				"ar1": {AllowanceScope: ""},
+				"ar2": {AllowanceScope: "scope2"},
+				"ar3": {AllowanceScope: "scope3"},
+				"ar4": {AllowanceScope: ""},
+			},
+		}
+
+		handler := newCountingStorageHandler()
+		sessionManager.deleteRawKeysWithAllowanceScope(handler, session, "keyName")
+
+		assert.Equal(t, 2, handler.deleteRawKeyCount)
+	})
+}
+
+type countingStorageHandler struct {
+	deleteRawKeyMutex *sync.Mutex
+	deleteRawKeyCount int
+}
+
+func newCountingStorageHandler() *countingStorageHandler {
+	return &countingStorageHandler{
+		deleteRawKeyMutex: &sync.Mutex{},
+		deleteRawKeyCount: 0,
+	}
+}
+
+func (c *countingStorageHandler) GetKey(s string) (string, error) {
+	return "", nil
+}
+
+func (c *countingStorageHandler) GetMultiKey(strings []string) ([]string, error) {
+	return nil, nil
+}
+
+func (c *countingStorageHandler) GetRawKey(s string) (string, error) {
+	return "", nil
+}
+
+func (c *countingStorageHandler) SetKey(s string, s2 string, i int64) error {
+	return nil
+}
+
+func (c *countingStorageHandler) SetRawKey(s string, s2 string, i int64) error {
+	return nil
+}
+
+func (c *countingStorageHandler) SetExp(s string, i int64) error {
+	return nil
+}
+
+func (c *countingStorageHandler) GetExp(s string) (int64, error) {
+	return 0, nil
+}
+
+func (c *countingStorageHandler) GetKeys(s string) []string {
+	return nil
+}
+
+func (c *countingStorageHandler) DeleteKey(s string) bool {
+	return false
+}
+
+func (c *countingStorageHandler) DeleteAllKeys() bool {
+	return false
+}
+
+func (c *countingStorageHandler) DeleteRawKey(s string) bool {
+	c.deleteRawKeyMutex.Lock()
+	defer c.deleteRawKeyMutex.Unlock()
+	c.deleteRawKeyCount++
+	return true
+}
+
+func (c *countingStorageHandler) Connect() bool {
+	return false
+}
+
+func (c *countingStorageHandler) GetKeysAndValues() map[string]string {
+	return nil
+}
+
+func (c *countingStorageHandler) GetKeysAndValuesWithFilter(s string) map[string]string {
+	return nil
+}
+
+func (c *countingStorageHandler) DeleteKeys(strings []string) bool {
+	return false
+}
+
+func (c *countingStorageHandler) Decrement(s string) {}
+
+func (c *countingStorageHandler) IncrememntWithExpire(s string, i int64) int64 {
+	return 0
+}
+
+func (c *countingStorageHandler) SetRollingWindow(key string, per int64, val string, pipeline bool) (int, []interface{}) {
+	return 0, nil
+}
+
+func (c *countingStorageHandler) GetRollingWindow(key string, per int64, pipeline bool) (int, []interface{}) {
+	return 0, nil
+}
+
+func (c *countingStorageHandler) GetSet(s string) (map[string]string, error) {
+	return nil, nil
+}
+
+func (c *countingStorageHandler) AddToSet(s string, s2 string) {}
+
+func (c *countingStorageHandler) GetAndDeleteSet(s string) []interface{} {
+	return nil
+}
+
+func (c *countingStorageHandler) RemoveFromSet(s string, s2 string) {}
+
+func (c *countingStorageHandler) DeleteScanMatch(s string) bool {
+	return false
+}
+
+func (c *countingStorageHandler) GetKeyPrefix() string {
+	return ""
+}
+
+func (c *countingStorageHandler) AddToSortedSet(s string, s2 string, f float64) {}
+
+func (c *countingStorageHandler) GetSortedSetRange(s string, s2 string, s3 string) ([]string, []float64, error) {
+	return nil, nil, nil
+}
+
+func (c *countingStorageHandler) RemoveSortedSetRange(s string, s2 string, s3 string) error {
+	return nil
+}
+
+func (c *countingStorageHandler) GetListRange(s string, i int64, i2 int64) ([]string, error) {
+	return nil, nil
+}
+
+func (c *countingStorageHandler) RemoveFromList(s string, s2 string) error {
+	return nil
+}
+
+func (c *countingStorageHandler) AppendToSet(s string, s2 string) {}
+
+func (c *countingStorageHandler) Exists(s string) (bool, error) {
+	return false, nil
 }


### PR DESCRIPTION
### **User description**
This PR fixes an issue where `DeleteRawKey` is called multiple times for AllowanceScopes that are non-existent.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added a new method `deleteRawKeysWithAllowanceScope` in `DefaultSessionManager` to handle deletion of raw keys with allowance scopes.
- Modified `ResetQuota` to use the new method for better handling of raw key deletions.
- Implemented checks to skip deletion if the allowance scope is empty, preventing unnecessary calls.
- Added comprehensive unit tests for the new method, covering various edge cases and ensuring correct behavior.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auth_manager.go</strong><dd><code>Add method to handle raw key deletion with allowance scopes</code></dd></summary>
<hr>

gateway/auth_manager.go
<li>Added a new method <code>deleteRawKeysWithAllowanceScope</code> to handle deletion <br>of raw keys with allowance scopes.<br> <li> Modified <code>ResetQuota</code> to use the new method.<br> <li> Added checks to skip deletion if the allowance scope is empty.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6373/files#diff-311e18b071d244ed1615c0019215b633278679df373288b3451bcc5cf7c52c4e">+13/-2</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auth_manager_test.go</strong><dd><code>Add unit tests for deleteRawKeysWithAllowanceScope method</code></dd></summary>
<hr>

gateway/auth_manager_test.go
<li>Added unit tests for <code>deleteRawKeysWithAllowanceScope</code> method.<br> <li> Created a mock <code>countingStorageHandler</code> to count delete operations.<br> <li> Tested various scenarios including nil storage handler, nil session, <br>and sessions with/without allowance scopes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6373/files#diff-665d567ebb80f4c7bb6c683cc8ad317928a10b450468634506012a20a54153c9">+190/-0</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

