### PR TITLE
[TT-12492] Conditionally update session after api limits

### DIFF
--- a/internal/policy/apply.go
+++ b/internal/policy/apply.go
@@ -461,15 +461,18 @@ func (t *Service) ApplyRateLimits(session *user.SessionState, policy user.Policy
 		apiLimits.Rate = policyLimits.Rate
 		apiLimits.Per = policyLimits.Per
 		apiLimits.Smoothing = policyLimits.Smoothing
-	}
 
-	// sessionLimits, similar to apiLimits, get policy
-	// rate applied if the policy allows more requests.
-	sessionLimits := session.APILimit()
-	if t.emptyRateLimit(sessionLimits) || sessionLimits.Duration() > policyLimits.Duration() {
-		session.Rate = policyLimits.Rate
-		session.Per = policyLimits.Per
-		session.Smoothing = policyLimits.Smoothing
+		// sessionLimits, similar to apiLimits, get policy
+		// rate applied if the policy allows more requests.
+		//
+		// sessionLimits may be set to the default GlobalRateLimit,
+		// and should update only if api limits are updated.
+		sessionLimits := session.APILimit()
+		if t.emptyRateLimit(sessionLimits) || sessionLimits.Duration() > policyLimits.Duration() {
+			session.Rate = policyLimits.Rate
+			session.Per = policyLimits.Per
+			session.Smoothing = policyLimits.Smoothing
+		}
 	}
 }
 

--- a/internal/policy/apply.go
+++ b/internal/policy/apply.go
@@ -441,7 +441,7 @@ func (t *Service) Logger() *logrus.Logger {
 // The limits get written if filled and policyLimits allows a higher request rate.
 func (t *Service) ApplyRateLimits(session *user.SessionState, policy user.Policy, apiLimits *user.APILimit) {
 	policyLimits := policy.APILimit()
-	if policyLimits.Duration() == 0 {
+	if policyLimits.Rate != -1 && policyLimits.Duration() == 0 {
 		return
 	}
 

--- a/internal/policy/apply_test.go
+++ b/internal/policy/apply_test.go
@@ -91,7 +91,7 @@ func TestApplyRateLimits_PolicyLimits(t *testing.T) {
 		svc.ApplyRateLimits(session, policy, &apiLimits)
 
 		assert.Equal(t, 15, int(apiLimits.Rate))
-		assert.Equal(t, 10, int(session.Rate))
+		assert.Equal(t, 5, int(session.Rate))
 	})
 }
 

--- a/internal/policy/apply_test.go
+++ b/internal/policy/apply_test.go
@@ -121,4 +121,28 @@ func TestApplyRateLimits_FromCustomPolicies(t *testing.T) {
 
 		assert.Equal(t, 10, int(session.Rate))
 	})
+
+	t.Run("Unlimited policy", func(t *testing.T) {
+		session := &user.SessionState{}
+		session.SetCustomPolicies([]user.Policy{
+			{
+				ID:           "pol1",
+				Partitions:   user.PolicyPartitions{RateLimit: true},
+				Rate:         -1,
+				Per:          1,
+				AccessRights: map[string]user.AccessDefinition{"a": {}},
+			},
+			{
+				ID:           "pol2",
+				Partitions:   user.PolicyPartitions{RateLimit: true},
+				Rate:         10,
+				Per:          1,
+				AccessRights: map[string]user.AccessDefinition{"a": {}},
+			},
+		})
+
+		svc.Apply(session)
+
+		assert.Equal(t, -1, int(session.Rate))
+	})
 }


### PR DESCRIPTION
### **User description**

This reverts to previous behaviour when updating session limits so they are only updated if the api limits are updated first. The session holds the GlobalRateLimit as default value.

https://tyktech.atlassian.net/browse/TT-12492


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Refactored the rate limit application logic by replacing the `emptyRateLimit` function with `shouldUpdateRateLimit`.
- Added conditions to ensure session limits are updated only if API limits are updated.
- Updated the test `TestApplyRateLimits_PolicyLimits` to reflect the new logic for session rate limits.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>apply.go</strong><dd><code>Refactor rate limit application logic and conditional updates</code></dd></summary>
<hr>

internal/policy/apply.go
<li>Replaced <code>emptyRateLimit</code> function with <code>shouldUpdateRateLimit</code>.<br> <li> Added conditions to update session limits only if API limits are <br>updated.<br> <li> Refactored logic to determine when to apply rate limits.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6376/files#diff-59b92e9d31f142f1d99b746eb3ff7db4e26bf6c3044c9b87b58034a947ee04d1">+31/-12</a>&nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>apply_test.go</strong><dd><code>Update tests for rate limit application logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/policy/apply_test.go
<li>Updated test <code>TestApplyRateLimits_PolicyLimits</code> to reflect new session <br>rate limit logic.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6376/files#diff-5af7e299a6b0ce11e22f8aa4a01854b1151f4b54dccc68f0cd1cbedee5aed7c8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

