### PR TITLE
[0000] exp/semgrep: Update from LSC semgrep rule

### DIFF
--- a/ci/tests/ci-semgrep.txt
+++ b/ci/tests/ci-semgrep.txt
@@ -1,0 +1,1 @@
+Last ran on Thu Jun 27 14:21:56 UTC 2024 by @titpetric

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -719,10 +719,9 @@ func (gw *Gateway) handleGetAllKeys(filter string) (interface{}, int) {
 
 	sessionsObj := apiAllKeys{fixedSessions}
 
-	log.WithFields(logrus.Fields{
-		"prefix": "api",
-		"status": "ok",
-	}).Info("Retrieved key list.")
+	apiLog.WithFields(logrus.Fields{
+ 	"status": "ok",
+ }).Info("Retrieved key list.")
 
 	return sessionsObj, http.StatusOK
 }
@@ -1027,10 +1026,9 @@ func (gw *Gateway) handleGetAPI(apiID string, oasEndpoint bool) (interface{}, in
 		return spec.APIDefinition, http.StatusOK
 	}
 
-	log.WithFields(logrus.Fields{
-		"prefix": "api",
-		"apiID":  fmt.Sprintf("%q", apiID),
-	}).Error("API doesn't exist.")
+	apiLog.WithFields(logrus.Fields{
+ 	"apiID":  fmt.Sprintf("%q", apiID),
+ }).Error("API doesn't exist.")
 
 	return apiError(apidef.ErrAPINotFound.Error()), http.StatusNotFound
 }
@@ -1911,17 +1909,14 @@ func (gw *Gateway) handleDeleteOrgKey(orgID string) (interface{}, int) {
 }
 
 func (gw *Gateway) groupResetHandler(w http.ResponseWriter, r *http.Request) {
-	log.WithFields(logrus.Fields{
-		"prefix": "api",
-		"status": "ok",
-	}).Info("Group reload accepted.")
+	apiLog.WithFields(logrus.Fields{
+ 	"status": "ok",
+ }).Info("Group reload accepted.")
 
 	// Signal to the group via redis
 	gw.MainNotifier.Notify(Notification{Command: NoticeGroupReload, Gw: gw})
 
-	log.WithFields(logrus.Fields{
-		"prefix": "api",
-	}).Info("Reloaded URL Structure - Success")
+	apiLog.Info("Reloaded URL Structure - Success")
 
 	doJSONWrite(w, http.StatusOK, apiOk(""))
 }
@@ -1941,9 +1936,7 @@ func (gw *Gateway) resetHandler(fn func()) http.HandlerFunc {
 			gw.reloadURLStructure(fn)
 		}
 
-		log.WithFields(logrus.Fields{
-			"prefix": "api",
-		}).Info("Reload URL Structure - Scheduled")
+		apiLog.Info("Reload URL Structure - Scheduled")
 		wg.Wait()
 		doJSONWrite(w, http.StatusOK, apiOk(""))
 	}
@@ -2161,9 +2154,7 @@ func (gw *Gateway) createOauthClient(w http.ResponseWriter, r *http.Request) {
 	}
 
 	storageID := oauthClientStorageID(newClient.GetId())
-	log.WithFields(logrus.Fields{
-		"prefix": "api",
-	}).Debug("Created storage ID: ", storageID)
+	apiLog.Debug("Created storage ID: ", storageID)
 
 	if newOauthClient.APIID != "" {
 		// set client only for passed API ID
@@ -2426,10 +2417,9 @@ func (gw *Gateway) invalidateOauthRefresh(w http.ResponseWriter, r *http.Request
 	}
 	apiSpec := gw.getApiSpec(apiID)
 
-	log.WithFields(logrus.Fields{
-		"prefix": "api",
-		"apiID":  apiID,
-	}).Debug("Looking for refresh token in API Register")
+	apiLog.WithFields(logrus.Fields{
+ 	"apiID":  apiID,
+ }).Debug("Looking for refresh token in API Register")
 
 	if apiSpec == nil {
 		log.WithFields(logrus.Fields{

--- a/gateway/cert.go
+++ b/gateway/cert.go
@@ -66,7 +66,7 @@ var cipherSuites = map[string]uint16{
 	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305":  0xcca9,
 }
 
-var certLog = log.WithField("prefix", "certs")
+var certLog = certLog
 
 func (gw *Gateway) getUpstreamCertificate(host string, spec *APISpec) (cert *tls.Certificate) {
 	var certID string

--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -57,9 +57,7 @@ func CreateCoProcessMiddleware(hookName string, hookType coprocess.HookType, mwD
 }
 
 func DoCoprocessReload() {
-	log.WithFields(logrus.Fields{
-		"prefix": "coprocess",
-	}).Info("Reloading middlewares")
+	coprocessLog.Info("Reloading middlewares")
 	if dispatcher := loadedDrivers[apidef.PythonDriver]; dispatcher != nil {
 		dispatcher.Reload()
 	}
@@ -251,9 +249,7 @@ func (c *CoProcessor) ObjectPostProcess(object *coprocess.Object, r *http.Reques
 // CoProcessInit creates a new CoProcessDispatcher, it will be called when Tyk starts.
 func (gw *Gateway) CoProcessInit() {
 	if !gw.GetConfig().CoProcessOptions.EnableCoProcess {
-		log.WithFields(logrus.Fields{
-			"prefix": "coprocess",
-		}).Info("Rich plugins are disabled")
+		coprocessLog.Info("Rich plugins are disabled")
 		return
 	}
 
@@ -262,13 +258,9 @@ func (gw *Gateway) CoProcessInit() {
 		var err error
 		loadedDrivers[apidef.GrpcDriver], err = gw.NewGRPCDispatcher()
 		if err == nil {
-			log.WithFields(logrus.Fields{
-				"prefix": "coprocess",
-			}).Info("gRPC dispatcher was initialized")
+			coprocessLog.Info("gRPC dispatcher was initialized")
 		} else {
-			log.WithFields(logrus.Fields{
-				"prefix": "coprocess",
-			}).WithError(err).Error("Couldn't load gRPC dispatcher")
+			coprocessLog.WithError(err).Error("Couldn't load gRPC dispatcher")
 		}
 	}
 
@@ -278,9 +270,7 @@ func (gw *Gateway) CoProcessInit() {
 func (m *CoProcessMiddleware) EnabledForSpec() bool {
 
 	if !m.Gw.GetConfig().CoProcessOptions.EnableCoProcess {
-		log.WithFields(logrus.Fields{
-			"prefix": "coprocess",
-		}).Error("Your API specifies a CP custom middleware, either Tyk wasn't build with CP support or CP is not enabled in your Tyk configuration file!")
+		coprocessLog.Error("Your API specifies a CP custom middleware, either Tyk wasn't build with CP support or CP is not enabled in your Tyk configuration file!")
 		return false
 	}
 
@@ -292,22 +282,16 @@ func (m *CoProcessMiddleware) EnabledForSpec() bool {
 	}
 
 	if !supported {
-		log.WithFields(logrus.Fields{
-			"prefix": "coprocess",
-		}).Errorf("Unsupported driver '%s'", m.Spec.CustomMiddleware.Driver)
+		coprocessLog.Errorf("Unsupported driver '%s'", m.Spec.CustomMiddleware.Driver)
 		return false
 	}
 
 	if d, _ := loadedDrivers[m.Spec.CustomMiddleware.Driver]; d == nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "coprocess",
-		}).Errorf("Driver '%s' isn't loaded", m.Spec.CustomMiddleware.Driver)
+		coprocessLog.Errorf("Driver '%s' isn't loaded", m.Spec.CustomMiddleware.Driver)
 		return false
 	}
 
-	log.WithFields(logrus.Fields{
-		"prefix": "coprocess",
-	}).Debug("Enabling CP middleware.")
+	coprocessLog.Debug("Enabling CP middleware.")
 	m.successHandler = &SuccessHandler{m.BaseMiddleware}
 	return true
 }
@@ -552,9 +536,7 @@ func (h *CustomMiddlewareResponseHook) HandleError(rw http.ResponseWriter, req *
 }
 
 func (h *CustomMiddlewareResponseHook) HandleResponse(rw http.ResponseWriter, res *http.Response, req *http.Request, ses *user.SessionState) error {
-	log.WithFields(logrus.Fields{
-		"prefix": "coprocess",
-	}).Debugf("Response hook '%s' is called", h.mw.Name())
+	coprocessLog.Debugf("Response hook '%s' is called", h.mw.Name())
 	coProcessor := CoProcessor{
 		Middleware: h.mw,
 	}

--- a/gateway/coprocess_api.go
+++ b/gateway/coprocess_api.go
@@ -88,21 +88,13 @@ func CoProcessLog(CMessage, CLogLevel *C.char) {
 	logLevel := C.GoString(CLogLevel)
 	switch logLevel {
 	case "debug":
-		log.WithFields(logrus.Fields{
-			"prefix": "python",
-		}).Debug(message)
+		pythonLog.Debug(message)
 	case "error":
-		log.WithFields(logrus.Fields{
-			"prefix": "python",
-		}).Error(message)
+		pythonLog.Error(message)
 	case "warning":
-		log.WithFields(logrus.Fields{
-			"prefix": "python",
-		}).Warning(message)
+		pythonLog.Warning(message)
 	default:
-		log.WithFields(logrus.Fields{
-			"prefix": "python",
-		}).Info(message)
+		pythonLog.Info(message)
 	}
 }
 

--- a/gateway/coprocess_bundle.go
+++ b/gateway/coprocess_bundle.go
@@ -42,9 +42,7 @@ type Bundle struct {
 
 // Verify performs a signature verification on the bundle file.
 func (b *Bundle) Verify() error {
-	log.WithFields(logrus.Fields{
-		"prefix": "main",
-	}).Info("----> Verifying bundle: ", b.Spec.CustomMiddlewareBundle)
+	mainLog.Info("----> Verifying bundle: ", b.Spec.CustomMiddlewareBundle)
 
 	var useSignature bool
 	bundleVerifier := b.Gw.NotificationVerifier
@@ -108,14 +106,10 @@ func (b *Bundle) AddToSpec() {
 		var err error
 		loadedDrivers[apidef.PythonDriver], err = NewPythonDispatcher(b.Gw.GetConfig())
 		if err != nil {
-			log.WithFields(logrus.Fields{
-				"prefix": "coprocess",
-			}).WithError(err).Error("Couldn't load Python dispatcher")
+			coprocessLog.WithError(err).Error("Couldn't load Python dispatcher")
 			return
 		}
-		log.WithFields(logrus.Fields{
-			"prefix": "coprocess",
-		}).Info("Python dispatcher was initialized")
+		coprocessLog.Info("Python dispatcher was initialized")
 	}
 	dispatcher := loadedDrivers[b.Spec.CustomMiddleware.Driver]
 	if dispatcher != nil {
@@ -223,9 +217,7 @@ func (gw *Gateway) fetchBundle(spec *APISpec) (Bundle, error) {
 	var err error
 
 	if !gw.GetConfig().EnableBundleDownloader {
-		log.WithFields(logrus.Fields{
-			"prefix": "main",
-		}).Warning("Bundle downloader is disabled.")
+		mainLog.Warning("Bundle downloader is disabled.")
 		err = errors.New("Bundle downloader is disabled")
 		return bundle, err
 	}
@@ -305,9 +297,7 @@ func saveBundle(bundle *Bundle, destPath string, spec *APISpec) error {
 
 // loadBundleManifest will parse the manifest file and return the bundle parameters.
 func loadBundleManifest(bundle *Bundle, spec *APISpec, skipVerification bool) error {
-	log.WithFields(logrus.Fields{
-		"prefix": "main",
-	}).Info("----> Loading bundle: ", spec.CustomMiddlewareBundle)
+	mainLog.Info("----> Loading bundle: ", spec.CustomMiddlewareBundle)
 
 	manifestPath := filepath.Join(bundle.Path, "manifest.json")
 	f, err := os.Open(manifestPath)
@@ -317,9 +307,7 @@ func loadBundleManifest(bundle *Bundle, spec *APISpec, skipVerification bool) er
 	defer f.Close()
 
 	if err := json.NewDecoder(f).Decode(&bundle.Manifest); err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "main",
-		}).Info("----> Couldn't unmarshal the manifest file for bundle: ", spec.CustomMiddlewareBundle)
+		mainLog.Info("----> Couldn't unmarshal the manifest file for bundle: ", spec.CustomMiddlewareBundle)
 		return err
 	}
 
@@ -328,9 +316,7 @@ func loadBundleManifest(bundle *Bundle, spec *APISpec, skipVerification bool) er
 	}
 
 	if err := bundle.Verify(); err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "main",
-		}).Info("----> Bundle verification failed: ", spec.CustomMiddlewareBundle)
+		mainLog.Info("----> Bundle verification failed: ", spec.CustomMiddlewareBundle)
 		return err
 	}
 	return nil
@@ -369,9 +355,7 @@ func (gw *Gateway) loadBundle(spec *APISpec) error {
 	// Skip if the bundle destination path already exists.
 	// The bundle exists, load and return:
 	if _, err := os.Stat(destPath); err == nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "main",
-		}).Info("Loading existing bundle: ", spec.CustomMiddlewareBundle)
+		mainLog.Info("Loading existing bundle: ", spec.CustomMiddlewareBundle)
 
 		bundle := Bundle{
 			Name: spec.CustomMiddlewareBundle,
@@ -382,23 +366,17 @@ func (gw *Gateway) loadBundle(spec *APISpec) error {
 
 		err = loadBundleManifest(&bundle, spec, true)
 		if err != nil {
-			log.WithFields(logrus.Fields{
-				"prefix": "main",
-			}).Info("----> Couldn't load bundle: ", spec.CustomMiddlewareBundle, " ", err)
+			mainLog.Info("----> Couldn't load bundle: ", spec.CustomMiddlewareBundle, " ", err)
 		}
 
-		log.WithFields(logrus.Fields{
-			"prefix": "main",
-		}).Info("----> Using bundle: ", spec.CustomMiddlewareBundle)
+		mainLog.Info("----> Using bundle: ", spec.CustomMiddlewareBundle)
 
 		bundle.AddToSpec()
 
 		return nil
 	}
 
-	log.WithFields(logrus.Fields{
-		"prefix": "main",
-	}).Info("----> Fetching Bundle: ", spec.CustomMiddlewareBundle)
+	mainLog.Info("----> Fetching Bundle: ", spec.CustomMiddlewareBundle)
 
 	bundle, err := gw.fetchBundle(spec)
 	if err != nil {
@@ -413,9 +391,7 @@ func (gw *Gateway) loadBundle(spec *APISpec) error {
 		return bundleError(spec, err, "Couldn't save bundle")
 	}
 
-	log.WithFields(logrus.Fields{
-		"prefix": "main",
-	}).Debug("----> Saving Bundle: ", spec.CustomMiddlewareBundle)
+	mainLog.Debug("----> Saving Bundle: ", spec.CustomMiddlewareBundle)
 
 	// Set the destination path:
 	bundle.Path = destPath
@@ -429,9 +405,7 @@ func (gw *Gateway) loadBundle(spec *APISpec) error {
 		return err
 	}
 
-	log.WithFields(logrus.Fields{
-		"prefix": "main",
-	}).Info("----> Bundle is valid, adding to spec: ", spec.CustomMiddlewareBundle)
+	mainLog.Info("----> Bundle is valid, adding to spec: ", spec.CustomMiddlewareBundle)
 
 	bundle.AddToSpec()
 

--- a/gateway/coprocess_grpc.go
+++ b/gateway/coprocess_grpc.go
@@ -27,17 +27,13 @@ type GRPCDispatcher struct {
 func (gw *Gateway) dialer(addr string, timeout time.Duration) (net.Conn, error) {
 	grpcURL, err := url.Parse(gw.GetConfig().CoProcessOptions.CoProcessGRPCServer)
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "coprocess",
-		}).Error(err)
+		coprocessLog.Error(err)
 		return nil, err
 	}
 
 	if grpcURL == nil || gw.GetConfig().CoProcessOptions.CoProcessGRPCServer == "" {
 		errString := "No gRPC URL is set!"
-		log.WithFields(logrus.Fields{
-			"prefix": "coprocess",
-		}).Error(errString)
+		coprocessLog.Error(errString)
 		return nil, errors.New(errString)
 	}
 
@@ -58,9 +54,7 @@ func (d *GRPCDispatcher) DispatchEvent(eventJSON []byte) {
 
 	_, err := grpcClient.DispatchEvent(context.Background(), eventObject)
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "coprocess",
-		}).Error(err)
+		coprocessLog.Error(err)
 	}
 }
 
@@ -102,9 +96,7 @@ func (gw *Gateway) NewGRPCDispatcher() (coprocess.Dispatcher, error) {
 
 	if err != nil {
 
-		log.WithFields(logrus.Fields{
-			"prefix": "coprocess",
-		}).Error(err)
+		coprocessLog.Error(err)
 		return nil, err
 	}
 	return &GRPCDispatcher{}, nil

--- a/gateway/coprocess_helpers.go
+++ b/gateway/coprocess_helpers.go
@@ -138,9 +138,7 @@ func ProtoSessionState(session *user.SessionState) *coprocess.SessionState {
 			default:
 				jsonValue, err := json.Marshal(v)
 				if err != nil {
-					log.WithFields(logrus.Fields{
-						"prefix": "coprocess",
-					}).WithError(err).Error("Couldn't encode session metadata")
+					coprocessLog.WithError(err).Error("Couldn't encode session metadata")
 					continue
 				}
 				metadata[k] = string(jsonValue)

--- a/gateway/coprocess_lua.go
+++ b/gateway/coprocess_lua.go
@@ -90,13 +90,9 @@ func init() {
 	var err error
 	loadedDrivers[apidef.LuaDriver], err = NewLuaDispatcher()
 	if err == nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "coprocess",
-		}).Info("Lua dispatcher was initialized")
+		coprocessLog.Info("Lua dispatcher was initialized")
 	} else {
-		log.WithFields(logrus.Fields{
-			"prefix": "coprocess",
-		}).WithError(err).Error("Couldn't load Lua dispatcher")
+		coprocessLog.WithError(err).Error("Couldn't load Lua dispatcher")
 	}
 }
 
@@ -174,9 +170,7 @@ func (d *LuaDispatcher) Reload() {
 		middlewarePath := filepath.Join(MiddlewareBasePath, f.Name())
 		contents, err := ioutil.ReadFile(middlewarePath)
 		if err != nil {
-			log.WithFields(logrus.Fields{
-				"prefix": "coprocess",
-			}).Error("Failed to read middleware file: ", err)
+			coprocessLog.Error("Failed to read middleware file: ", err)
 		}
 
 		d.MiddlewareCache[f.Name()] = string(contents)
@@ -190,17 +184,13 @@ func (d *LuaDispatcher) HandleMiddlewareCache(b *apidef.BundleManifest, basePath
 		if err == nil {
 			d.ModuleCache[f] = string(contents)
 		} else {
-			log.WithFields(logrus.Fields{
-				"prefix": "coprocess",
-			}).Error("Failed to read bundle file: ", err)
+			coprocessLog.Error("Failed to read bundle file: ", err)
 		}
 	}
 }
 
 func (d *LuaDispatcher) LoadModules() {
-	log.WithFields(logrus.Fields{
-		"prefix": "coprocess",
-	}).Info("Loading Tyk/Lua modules.")
+	coprocessLog.Info("Loading Tyk/Lua modules.")
 
 	if d.ModuleCache == nil {
 		d.ModuleCache = make(map[string]string, 0)
@@ -213,9 +203,7 @@ func (d *LuaDispatcher) LoadModules() {
 	if err == nil {
 		d.ModuleCache["bundle.lua"] = string(contents)
 	} else {
-		log.WithFields(logrus.Fields{
-			"prefix": "coprocess",
-		}).Error("Failed to read bundle file: ", err)
+		coprocessLog.Error("Failed to read bundle file: ", err)
 	}
 }
 

--- a/gateway/coprocess_python.go
+++ b/gateway/coprocess_python.go
@@ -50,9 +50,7 @@ func (d *PythonDispatcher) Dispatch(object *coprocess.Object) (*coprocess.Object
 	// Find the dispatch_hook:
 	dispatchHookFunc, err := python.PyObjectGetAttr(dispatcherInstance, "dispatch_hook")
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "python",
-		}).Fatal(err)
+		pythonLog.Fatal(err)
 		python.PyErr_Print()
 		pythonLock.Unlock()
 		return nil, err
@@ -60,9 +58,7 @@ func (d *PythonDispatcher) Dispatch(object *coprocess.Object) (*coprocess.Object
 
 	objectBytes, err := python.PyBytesFromString(objectMsg)
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "python",
-		}).Fatal(err)
+		pythonLog.Fatal(err)
 		python.PyErr_Print()
 		pythonLock.Unlock()
 		return nil, err
@@ -70,9 +66,7 @@ func (d *PythonDispatcher) Dispatch(object *coprocess.Object) (*coprocess.Object
 
 	args, err := python.PyTupleNew(1)
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "python",
-		}).Fatal(err)
+		pythonLog.Fatal(err)
 		python.PyErr_Print()
 		pythonLock.Unlock()
 		return nil, err
@@ -81,9 +75,7 @@ func (d *PythonDispatcher) Dispatch(object *coprocess.Object) (*coprocess.Object
 	python.PyTupleSetItem(args, 0, objectBytes)
 	result, err := python.PyObjectCallObject(dispatchHookFunc, args)
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "python",
-		}).Error(err)
+		pythonLog.Error(err)
 		python.PyErr_Print()
 		pythonLock.Unlock()
 		return nil, err
@@ -93,9 +85,7 @@ func (d *PythonDispatcher) Dispatch(object *coprocess.Object) (*coprocess.Object
 
 	newObjectPtr, err := python.PyTupleGetItem(result, 0)
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "python",
-		}).Error(err)
+		pythonLog.Error(err)
 		python.PyErr_Print()
 		pythonLock.Unlock()
 		return nil, err
@@ -103,9 +93,7 @@ func (d *PythonDispatcher) Dispatch(object *coprocess.Object) (*coprocess.Object
 
 	newObjectLen, err := python.PyTupleGetItem(result, 1)
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "python",
-		}).Error(err)
+		pythonLog.Error(err)
 		python.PyErr_Print()
 		pythonLock.Unlock()
 		return nil, err
@@ -113,9 +101,7 @@ func (d *PythonDispatcher) Dispatch(object *coprocess.Object) (*coprocess.Object
 
 	newObjectBytes, err := python.PyBytesAsString(newObjectPtr, python.PyLongAsLong(newObjectLen))
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "python",
-		}).Error(err)
+		pythonLog.Error(err)
 		python.PyErr_Print()
 		pythonLock.Unlock()
 		return nil, err
@@ -126,9 +112,7 @@ func (d *PythonDispatcher) Dispatch(object *coprocess.Object) (*coprocess.Object
 	newObject := &coprocess.Object{}
 	err = proto.Unmarshal(newObjectBytes, newObject)
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "python",
-		}).Error(err)
+		pythonLog.Error(err)
 		return nil, err
 	}
 	return newObject, nil
@@ -155,26 +139,20 @@ func (d *PythonDispatcher) HandleMiddlewareCache(b *apidef.BundleManifest, baseP
 	defer pythonLock.Unlock()
 	dispatcherLoadBundle, err := python.PyObjectGetAttr(dispatcherInstance, "load_bundle")
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "python",
-		}).Error(err)
+		pythonLog.Error(err)
 		return
 	}
 
 	args, err := python.PyTupleNew(1)
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "python",
-		}).Error(err)
+		pythonLog.Error(err)
 		python.PyErr_Print()
 		return
 	}
 	python.PyTupleSetItem(args, 0, basePath)
 	_, err = python.PyObjectCallObject(dispatcherLoadBundle, args)
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "python",
-		}).Error(err)
+		pythonLog.Error(err)
 		python.PyErr_Print()
 	}
 }
@@ -188,14 +166,10 @@ func PythonInit(pythonVersion string) error {
 	}
 	err = python.Init()
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "coprocess",
-		}).Fatalf("Couldn't initialize Python - %s", err.Error())
+		coprocessLog.Fatalf("Couldn't initialize Python - %s", err.Error())
 		return err
 	}
-	log.WithFields(logrus.Fields{
-		"prefix": "coprocess",
-	}).Infof("Python version '%s' loaded", ver)
+	coprocessLog.Infof("Python version '%s' loaded", ver)
 	return nil
 }
 
@@ -205,17 +179,13 @@ func PythonLoadDispatcher() error {
 	defer pythonLock.Unlock()
 	moduleDict, err := python.LoadModuleDict("dispatcher")
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "coprocess",
-		}).Fatalf("Couldn't initialize Python dispatcher")
+		coprocessLog.Fatalf("Couldn't initialize Python dispatcher")
 		python.PyErr_Print()
 		return err
 	}
 	dispatcherClass, err = python.GetItem(moduleDict, "TykDispatcher")
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "coprocess",
-		}).Fatalf("Couldn't initialize Python dispatcher")
+		coprocessLog.Fatalf("Couldn't initialize Python dispatcher")
 		python.PyErr_Print()
 		return err
 	}
@@ -228,23 +198,17 @@ func PythonNewDispatcher(bundleRootPath string) (coprocess.Dispatcher, error) {
 	defer pythonLock.Unlock()
 	args, err := python.PyTupleNew(1)
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "python",
-		}).Fatal(err)
+		pythonLog.Fatal(err)
 		return nil, err
 	}
 	if err := python.PyTupleSetItem(args, 0, bundleRootPath); err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "python",
-		}).Error(err)
+		pythonLog.Error(err)
 		python.PyErr_Print()
 		return nil, err
 	}
 	dispatcherInstance, err = python.PyObjectCallObject(dispatcherClass, args)
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "python",
-		}).Error(err)
+		pythonLog.Error(err)
 		python.PyErr_Print()
 		return nil, err
 	}
@@ -277,9 +241,7 @@ func NewPythonDispatcher(conf config.Config) (dispatcher coprocess.Dispatcher, e
 	if workDir == "" {
 		tykBin, _ := os.Executable()
 		workDir = filepath.Dir(tykBin)
-		log.WithFields(logrus.Fields{
-			"prefix": "coprocess",
-		}).Debugf("Python path prefix isn't set, using '%s'", workDir)
+		coprocessLog.Debugf("Python path prefix isn't set, using '%s'", workDir)
 	}
 	dispatcherPath := filepath.Join(workDir, "coprocess", "python")
 	tykPath := filepath.Join(dispatcherPath, "tyk")
@@ -306,9 +268,7 @@ func NewPythonDispatcher(conf config.Config) (dispatcher coprocess.Dispatcher, e
 		}
 		dispatcher, err = PythonNewDispatcher(bundleRootPath)
 		if err != nil {
-			log.WithFields(logrus.Fields{
-				"prefix": "coprocess",
-			}).Error(err)
+			coprocessLog.Error(err)
 		}
 
 		initDone <- err

--- a/gateway/dashboard_register.go
+++ b/gateway/dashboard_register.go
@@ -13,7 +13,7 @@ import (
 	"github.com/TykTechnologies/tyk/header"
 )
 
-var dashLog = log.WithField("prefix", "dashboard")
+var dashLog = dashLog
 
 type NodeResponseOK struct {
 	Status  string

--- a/gateway/distributed_rate_limiter.go
+++ b/gateway/distributed_rate_limiter.go
@@ -85,10 +85,9 @@ func (gw *Gateway) onServerStatusReceivedHandler(payload string) {
 
 	serverData := drl.Server{}
 	if err := json.Unmarshal([]byte(payload), &serverData); err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix":  "pub-sub",
-			"payload": string(payload),
-		}).Error("Failed unmarshal server data: ", err)
+		pubSubLog.WithFields(logrus.Fields{
+  	"payload": string(payload),
+  }).Error("Failed unmarshal server data: ", err)
 		return
 	}
 

--- a/gateway/host_checker_manager.go
+++ b/gateway/host_checker_manager.go
@@ -100,9 +100,7 @@ func (hc *HostCheckerManager) CheckActivePollerLoop(ctx context.Context) {
 	tick := time.NewTicker(10 * time.Second)
 	defer func() {
 		tick.Stop()
-		log.WithFields(logrus.Fields{
-			"prefix": "host-check-mgr",
-		}).Debug("Stopping uptime tests")
+		hostCheckLog.Debug("Stopping uptime tests")
 	}()
 	for {
 		select {
@@ -118,16 +116,12 @@ func (hc *HostCheckerManager) checkPollerLoop(ctx context.Context) {
 	if !hc.stopLoop {
 		if hc.AmIPolling() {
 			if !hc.pollerStarted {
-				log.WithFields(logrus.Fields{
-					"prefix": "host-check-mgr",
-				}).Info("Starting Poller")
+				hostCheckLog.Info("Starting Poller")
 				hc.pollerStarted = true
 				hc.StartPoller(ctx)
 			}
 		} else {
-			log.WithFields(logrus.Fields{
-				"prefix": "host-check-mgr",
-			}).Debug("New master found, no tests running")
+			hostCheckLog.Debug("New master found, no tests running")
 			if hc.pollerStarted {
 				hc.StopPoller()
 				hc.pollerStarted = false
@@ -138,9 +132,7 @@ func (hc *HostCheckerManager) checkPollerLoop(ctx context.Context) {
 
 func (hc *HostCheckerManager) AmIPolling() bool {
 	if hc.store == nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "host-check-mgr",
-		}).Error("No storage instance set for uptime tests! Disabling poller...")
+		hostCheckLog.Error("No storage instance set for uptime tests! Disabling poller...")
 		return false
 	}
 	pollerCacheKey := PollerCacheKey
@@ -150,9 +142,7 @@ func (hc *HostCheckerManager) AmIPolling() bool {
 
 	activeInstance, err := hc.store.GetKey(pollerCacheKey)
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "host-check-mgr",
-		}).Debug("No Primary instance found, assuming control")
+		hostCheckLog.Debug("No Primary instance found, assuming control")
 		err := hc.store.SetKey(pollerCacheKey, hc.Id, 15)
 		if err != nil {
 			log.WithError(err).Error("cannot set key in pollerCacheKey")
@@ -161,9 +151,7 @@ func (hc *HostCheckerManager) AmIPolling() bool {
 	}
 
 	if activeInstance == hc.Id {
-		log.WithFields(logrus.Fields{
-			"prefix": "host-check-mgr",
-		}).Debug("Primary instance set, I am master")
+		hostCheckLog.Debug("Primary instance set, I am master")
 		err := hc.store.SetKey(pollerCacheKey, hc.Id, 15) // Reset TTL
 		if err != nil {
 			log.WithError(err).Error("could not reset TTL in polled cacheKey")
@@ -171,20 +159,14 @@ func (hc *HostCheckerManager) AmIPolling() bool {
 		return true
 	}
 
-	log.WithFields(logrus.Fields{
-		"prefix": "host-check-mgr",
-	}).Debug("Active Instance is: ", activeInstance)
-	log.WithFields(logrus.Fields{
-		"prefix": "host-check-mgr",
-	}).Debug("--- I am: ", hc.Id)
+	hostCheckLog.Debug("Active Instance is: ", activeInstance)
+	hostCheckLog.Debug("--- I am: ", hc.Id)
 	return false
 }
 
 func (hc *HostCheckerManager) StartPoller(ctx context.Context) {
 
-	log.WithFields(logrus.Fields{
-		"prefix": "host-check-mgr",
-	}).Debug("---> Initialising checker")
+	hostCheckLog.Debug("---> Initialising checker")
 
 	// If we are restarting, we want to retain the host list
 	hc.checkerMu.Lock()
@@ -204,13 +186,9 @@ func (hc *HostCheckerManager) StartPoller(ctx context.Context) {
 	)
 
 	// Start the check loop
-	log.WithFields(logrus.Fields{
-		"prefix": "host-check-mgr",
-	}).Debug("---> Starting checker")
+	hostCheckLog.Debug("---> Starting checker")
 	hc.checker.Start(ctx)
-	log.WithFields(logrus.Fields{
-		"prefix": "host-check-mgr",
-	}).Debug("---> Checker started.")
+	hostCheckLog.Debug("---> Checker started.")
 	hc.checkerMu.Unlock()
 }
 
@@ -232,9 +210,7 @@ func (hc *HostCheckerManager) OnHostReport(ctx context.Context, report HostHealt
 
 func (hc *HostCheckerManager) OnHostDown(ctx context.Context, report HostHealthReport) {
 	key := hc.getHostKey(report)
-	log.WithFields(logrus.Fields{
-		"prefix": "host-check-mgr",
-	}).Debug("Update key: ", key)
+	hostCheckLog.Debug("Update key: ", key)
 	err := hc.store.SetKey(key, "1", int64(hc.checker.checkTimeout*hc.checker.sampleTriggerLimit))
 	if err != nil {
 		log.WithError(err).Error("Host-Checker could not save key")
@@ -242,9 +218,7 @@ func (hc *HostCheckerManager) OnHostDown(ctx context.Context, report HostHealthR
 	hc.unhealthyHostList.Store(key, 1)
 	spec := hc.Gw.getApiSpec(report.MetaData[UnHealthyHostMetaDataAPIKey])
 	if spec == nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "host-check-mgr",
-		}).Warning("[HOST CHECKER MANAGER] Event can't fire for API that doesn't exist")
+		hostCheckLog.Warning("[HOST CHECKER MANAGER] Event can't fire for API that doesn't exist")
 		return
 	}
 
@@ -253,9 +227,7 @@ func (hc *HostCheckerManager) OnHostDown(ctx context.Context, report HostHealthR
 		HostInfo:         report,
 	})
 
-	log.WithFields(logrus.Fields{
-		"prefix": "host-check-mgr",
-	}).Warning("[HOST CHECKER MANAGER] Host is DOWN: ", report.CheckURL)
+	hostCheckLog.Warning("[HOST CHECKER MANAGER] Host is DOWN: ", report.CheckURL)
 
 	if spec.UptimeTests.Config.ServiceDiscovery.UseDiscoveryService {
 		apiID := spec.APIID
@@ -266,9 +238,7 @@ func (hc *HostCheckerManager) OnHostDown(ctx context.Context, report HostHealthR
 			hc.resetsInitiated[apiID] = true
 			// Lets re-check the uptime tests after x seconds
 			go func() {
-				log.WithFields(logrus.Fields{
-					"prefix": "host-check-mgr",
-				}).Printf("[HOST CHECKER MANAGER] Resetting test host list in %v seconds for API: %v", spec.UptimeTests.Config.RecheckWait, apiID)
+				hostCheckLog.Printf("[HOST CHECKER MANAGER] Resetting test host list in %v seconds for API: %v", spec.UptimeTests.Config.RecheckWait, apiID)
 				time.Sleep(time.Duration(spec.UptimeTests.Config.RecheckWait) * time.Second)
 				hc.DoServiceDiscoveryListUpdateForID(apiID)
 				delete(hc.resetsInitiated, apiID)
@@ -279,16 +249,12 @@ func (hc *HostCheckerManager) OnHostDown(ctx context.Context, report HostHealthR
 
 func (hc *HostCheckerManager) OnHostBackUp(ctx context.Context, report HostHealthReport) {
 	key := hc.getHostKey(report)
-	log.WithFields(logrus.Fields{
-		"prefix": "host-check-mgr",
-	}).Debug("Delete key: ", key)
+	hostCheckLog.Debug("Delete key: ", key)
 	hc.store.DeleteKey(key)
 	hc.unhealthyHostList.Delete(key)
 	spec := hc.Gw.getApiSpec(report.MetaData[UnHealthyHostMetaDataAPIKey])
 	if spec == nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "host-check-mgr",
-		}).Warning("[HOST CHECKER MANAGER] Event can't fire for API that doesn't exist")
+		hostCheckLog.Warning("[HOST CHECKER MANAGER] Event can't fire for API that doesn't exist")
 		return
 	}
 	spec.FireEvent(EventHOSTUP, EventHostStatusMeta{
@@ -296,22 +262,16 @@ func (hc *HostCheckerManager) OnHostBackUp(ctx context.Context, report HostHealt
 		HostInfo:         report,
 	})
 
-	log.WithFields(logrus.Fields{
-		"prefix": "host-check-mgr",
-	}).Warning("[HOST CHECKER MANAGER] Host is UP:   ", report.CheckURL)
+	hostCheckLog.Warning("[HOST CHECKER MANAGER] Host is UP:   ", report.CheckURL)
 }
 
 func (hc *HostCheckerManager) HostDown(urlStr string) bool {
 	u, err := url.Parse(urlStr)
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "host-check-mgr",
-		}).Error(err)
+		hostCheckLog.Error(err)
 	}
 
-	log.WithFields(logrus.Fields{
-		"prefix": "host-check-mgr",
-	}).Debug("Key is: ", PoolerHostSentinelKeyPrefix+u.Host)
+	hostCheckLog.Debug("Key is: ", PoolerHostSentinelKeyPrefix+u.Host)
 
 	key := PoolerHostSentinelKeyPrefix + u.Host
 	// If the node doesn't perform any uptime checks, query the storage:
@@ -330,9 +290,7 @@ func (hc *HostCheckerManager) PrepareTrackingHost(checkObject apidef.HostCheckOb
 	var hostData HostData
 	u, err := url.Parse(checkObject.CheckURL)
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "host-check-mgr",
-		}).Error(err)
+		hostCheckLog.Error(err)
 		return hostData, err
 	}
 
@@ -341,9 +299,7 @@ func (hc *HostCheckerManager) PrepareTrackingHost(checkObject apidef.HostCheckOb
 	if len(checkObject.Body) > 0 {
 		bodyByteArr, err = base64.StdEncoding.DecodeString(checkObject.Body)
 		if err != nil {
-			log.WithFields(logrus.Fields{
-				"prefix": "host-check-mgr",
-			}).Error("Failed to load blob data: ", err)
+			hostCheckLog.Error("Failed to load blob data: ", err)
 			return hostData, err
 		}
 		bodyData = string(bodyByteArr)
@@ -369,9 +325,7 @@ func (hc *HostCheckerManager) PrepareTrackingHost(checkObject apidef.HostCheckOb
 }
 
 func (hc *HostCheckerManager) UpdateTrackingList(hd []HostData) {
-	log.WithFields(logrus.Fields{
-		"prefix": "host-check-mgr",
-	}).Debug("--- Setting tracking list up")
+	hostCheckLog.Debug("--- Setting tracking list up")
 	newHostList := make(map[string]HostData)
 	for _, host := range hd {
 		newHostList[host.CheckURL] = host
@@ -380,18 +334,14 @@ func (hc *HostCheckerManager) UpdateTrackingList(hd []HostData) {
 	hc.checkerMu.Lock()
 	hc.currentHostList = newHostList
 	if hc.checker != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "host-check-mgr",
-		}).Debug("Reset initiated")
+		hostCheckLog.Debug("Reset initiated")
 		hc.checker.ResetList(newHostList)
 	}
 	hc.checkerMu.Unlock()
 }
 
 func (hc *HostCheckerManager) UpdateTrackingListByAPIID(hd []HostData, apiId string) {
-	log.WithFields(logrus.Fields{
-		"prefix": "host-check-mgr",
-	}).Debug("--- Setting tracking list up for ID: ", apiId)
+	hostCheckLog.Debug("--- Setting tracking list up for ID: ", apiId)
 	newHostList := make(map[string]HostData)
 
 	hc.checkerMu.Lock()
@@ -409,15 +359,11 @@ func (hc *HostCheckerManager) UpdateTrackingListByAPIID(hd []HostData, apiId str
 
 	hc.currentHostList = newHostList
 	if hc.checker != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "host-check-mgr",
-		}).Debug("Reset initiated")
+		hostCheckLog.Debug("Reset initiated")
 		hc.checker.ResetList(newHostList)
 	}
 	hc.checkerMu.Unlock()
-	log.WithFields(logrus.Fields{
-		"prefix": "host-check-mgr",
-	}).Info("--- Queued tracking list update for API: ", apiId)
+	hostCheckLog.Info("--- Queued tracking list update for API: ", apiId)
 }
 
 func (hc *HostCheckerManager) ListFromService(apiID string) ([]HostData, error) {
@@ -430,9 +376,7 @@ func (hc *HostCheckerManager) ListFromService(apiID string) ([]HostData, error) 
 	data, err := sd.Target(spec.UptimeTests.Config.ServiceDiscovery.QueryEndpoint)
 
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "host-check-mgr",
-		}).Error("[HOST CHECKER MANAGER] Failed to retrieve host list: ", err)
+		hostCheckLog.Error("[HOST CHECKER MANAGER] Failed to retrieve host list: ", err)
 		return nil, err
 	}
 
@@ -440,9 +384,7 @@ func (hc *HostCheckerManager) ListFromService(apiID string) ([]HostData, error) 
 	checkTargets := make([]apidef.HostCheckObject, 0)
 	data0, _ := data.GetIndex(0)
 	if err := json.Unmarshal([]byte(data0), &checkTargets); err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "host-check-mgr",
-		}).Error("[HOST CHECKER MANAGER] Decoder failed: ", err)
+		hostCheckLog.Error("[HOST CHECKER MANAGER] Decoder failed: ", err)
 		return nil, err
 	}
 
@@ -450,9 +392,7 @@ func (hc *HostCheckerManager) ListFromService(apiID string) ([]HostData, error) 
 	for i, target := range checkTargets {
 		newHostDoc, err := hc.Gw.GlobalHostChecker.PrepareTrackingHost(target, spec.APIID)
 		if err != nil {
-			log.WithFields(logrus.Fields{
-				"prefix": "host-check-mgr",
-			}).Error("[HOST CHECKER MANAGER] failed to convert to HostData", err)
+			hostCheckLog.Error("[HOST CHECKER MANAGER] failed to convert to HostData", err)
 		} else {
 			hostData[i] = newHostDoc
 		}
@@ -461,20 +401,14 @@ func (hc *HostCheckerManager) ListFromService(apiID string) ([]HostData, error) 
 }
 
 func (hc *HostCheckerManager) DoServiceDiscoveryListUpdateForID(apiID string) {
-	log.WithFields(logrus.Fields{
-		"prefix": "host-check-mgr",
-	}).Debug("[HOST CHECKER MANAGER] Getting data from service")
+	hostCheckLog.Debug("[HOST CHECKER MANAGER] Getting data from service")
 	hostData, err := hc.ListFromService(apiID)
 	if err != nil {
 		return
 	}
 
-	log.WithFields(logrus.Fields{
-		"prefix": "host-check-mgr",
-	}).Debug("[HOST CHECKER MANAGER] Data was: \n", hostData)
-	log.WithFields(logrus.Fields{
-		"prefix": "host-check-mgr",
-	}).Info("[HOST CHECKER MANAGER] Refreshing uptime tests from service for API: ", apiID)
+	hostCheckLog.Debug("[HOST CHECKER MANAGER] Data was: \n", hostData)
+	hostCheckLog.Info("[HOST CHECKER MANAGER] Refreshing uptime tests from service for API: ", apiID)
 	hc.UpdateTrackingListByAPIID(hostData, apiID)
 }
 
@@ -521,15 +455,11 @@ func (hc *HostCheckerManager) RecordUptimeAnalytics(report HostHealthReport) err
 	encoded, err := msgpack.Marshal(newAnalyticsRecord)
 
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "host-check-mgr",
-		}).Error("Error encoding uptime data:", err)
+		hostCheckLog.Error("Error encoding uptime data:", err)
 		return err
 	}
 
-	log.WithFields(logrus.Fields{
-		"prefix": "host-check-mgr",
-	}).Debug("Recording uptime stat")
+	hostCheckLog.Debug("Recording uptime stat")
 	hc.store.AppendToSet(UptimeAnalytics_KEYNAME, string(encoded))
 	return nil
 }
@@ -546,9 +476,7 @@ func (gw *Gateway) InitHostCheckManager(ctx context.Context, store storage.Handl
 }
 
 func (gw *Gateway) SetCheckerHostList() {
-	log.WithFields(logrus.Fields{
-		"prefix": "host-check-mgr",
-	}).Info("Loading uptime tests...")
+	hostCheckLog.Info("Loading uptime tests...")
 	hostList := []HostData{}
 	gw.apisMu.RLock()
 	for _, spec := range gw.apisByID {
@@ -557,9 +485,7 @@ func (gw *Gateway) SetCheckerHostList() {
 			if err == nil {
 				hostList = append(hostList, hostList...)
 				for _, t := range hostList {
-					log.WithFields(logrus.Fields{
-						"prefix": "host-check-mgr",
-					}).WithFields(logrus.Fields{
+					hostCheckLog.WithFields(logrus.Fields{
 						"prefix": "host-check-mgr",
 					}).Info("---> Adding uptime test: ", t.CheckURL)
 				}
@@ -569,16 +495,10 @@ func (gw *Gateway) SetCheckerHostList() {
 				newHostDoc, err := gw.GlobalHostChecker.PrepareTrackingHost(checkItem, spec.APIID)
 				if err == nil {
 					hostList = append(hostList, newHostDoc)
-					log.WithFields(logrus.Fields{
-						"prefix": "host-check-mgr",
-					}).Info("---> Adding uptime test: ", checkItem.CheckURL)
+					hostCheckLog.Info("---> Adding uptime test: ", checkItem.CheckURL)
 				} else {
-					log.WithFields(logrus.Fields{
-						"prefix": "host-check-mgr",
-					}).Warning("---> Adding uptime test failed: ", checkItem.CheckURL)
-					log.WithFields(logrus.Fields{
-						"prefix": "host-check-mgr",
-					}).Warning("--------> Error was: ", err)
+					hostCheckLog.Warning("---> Adding uptime test failed: ", checkItem.CheckURL)
+					hostCheckLog.Warning("--------> Error was: ", err)
 				}
 
 			}

--- a/gateway/redis_signal_handle_config.go
+++ b/gateway/redis_signal_handle_config.go
@@ -49,44 +49,32 @@ func (gw *Gateway) handleNewConfiguration(payload string) {
 
 	err := json.Unmarshal([]byte(payload), &configPayload)
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "pub-sub",
-		}).Error("Failed to decode configuration payload: ", err)
+		pubSubLog.Error("Failed to decode configuration payload: ", err)
 		return
 	}
 
 	// Make sure payload matches nodeID and hostname
 	if configPayload.ForHostname != gw.hostDetails.Hostname && configPayload.ForNodeID != gw.GetNodeID() {
-		log.WithFields(logrus.Fields{
-			"prefix": "pub-sub",
-		}).Info("Configuration update received, no NodeID/Hostname match found")
+		pubSubLog.Info("Configuration update received, no NodeID/Hostname match found")
 		return
 	}
 
 	if !gw.GetConfig().AllowRemoteConfig {
-		log.WithFields(logrus.Fields{
-			"prefix": "pub-sub",
-		}).Warning("Ignoring new config: Remote configuration is not allowed for this node.")
+		pubSubLog.Warning("Ignoring new config: Remote configuration is not allowed for this node.")
 		return
 	}
 
 	if err := gw.backupConfiguration(); err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "pub-sub",
-		}).Error("Failed to backup existing configuration: ", err)
+		pubSubLog.Error("Failed to backup existing configuration: ", err)
 		return
 	}
 
 	if err := writeNewConfiguration(configPayload); err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "pub-sub",
-		}).Error("Failed to write new configuration: ", err)
+		pubSubLog.Error("Failed to write new configuration: ", err)
 		return
 	}
 
-	log.WithFields(logrus.Fields{
-		"prefix": "pub-sub",
-	}).Info("Initiating configuration reload")
+	pubSubLog.Info("Initiating configuration reload")
 
 	myPID := gw.hostDetails.PID
 	if myPID == 0 {
@@ -144,25 +132,19 @@ func (gw *Gateway) handleSendMiniConfig(payload string) {
 	configPayload := GetConfigPayload{}
 	err := json.Unmarshal([]byte(payload), &configPayload)
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "pub-sub",
-		}).Error("Failed unmarshal request: ", err)
+		pubSubLog.Error("Failed unmarshal request: ", err)
 		return
 	}
 
 	// Make sure payload matches nodeID and hostname
 	if configPayload.FromHostname != gw.hostDetails.Hostname && configPayload.FromNodeID != gw.GetNodeID() {
-		log.WithFields(logrus.Fields{
-			"prefix": "pub-sub",
-		}).Debug("Configuration request received, no NodeID/Hostname match found, ignoring")
+		pubSubLog.Debug("Configuration request received, no NodeID/Hostname match found, ignoring")
 		return
 	}
 
 	config, err := gw.getExistingConfig()
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "pub-sub",
-		}).Error("Failed to get existing configuration: ", err)
+		pubSubLog.Error("Failed to get existing configuration: ", err)
 		return
 	}
 
@@ -175,9 +157,7 @@ func (gw *Gateway) handleSendMiniConfig(payload string) {
 
 	payloadAsJSON, err := json.Marshal(returnPayload)
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"prefix": "pub-sub",
-		}).Error("Failed to get marshal configuration: ", err)
+		pubSubLog.Error("Failed to get marshal configuration: ", err)
 		return
 	}
 
@@ -188,8 +168,6 @@ func (gw *Gateway) handleSendMiniConfig(payload string) {
 	}
 
 	gw.MainNotifier.Notify(asNotification)
-	log.WithFields(logrus.Fields{
-		"prefix": "pub-sub",
-	}).Debug("Configuration request responded.")
+	pubSubLog.Debug("Configuration request responded.")
 
 }

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -71,8 +71,8 @@ import (
 
 var (
 	log       = logger.Get()
-	mainLog   = log.WithField("prefix", "main")
-	pubSubLog = log.WithField("prefix", "pub-sub")
+	mainLog   = mainLog
+	pubSubLog = pubSubLog
 	rawLog    = logger.GetRaw()
 
 	memProfFile         *os.File


### PR DESCRIPTION
Triggered by: titpetric

Semgrep version: 1.76.0
Errors reported: 0
Path scanned: 297
Results: 137

~~~yaml
- file: gateway/api.go
  line: 722
  message: Replacing apiLog prefix with logger (autofix)
  check: host.rules.tyk.log.apiLog.remove.prefix.from.Fields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "api",
		"status": "ok",
	}).Info("Retrieved key list.")

- file: gateway/api.go
  line: 1030
  message: Replacing apiLog prefix with logger (autofix)
  check: host.rules.tyk.log.apiLog.remove.prefix.from.Fields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "api",
		"apiID":  fmt.Sprintf("%q", apiID),
	}).Error("API doesn't exist.")

- file: gateway/api.go
  line: 1914
  message: Replacing apiLog prefix with logger (autofix)
  check: host.rules.tyk.log.apiLog.remove.prefix.from.Fields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "api",
		"status": "ok",
	}).Info("Group reload accepted.")

- file: gateway/api.go
  line: 1922
  message: Replacing apiLog prefix with logger (autofix)
  check: host.rules.tyk.log.apiLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "api",
	}).Info("Reloaded URL Structure - Success")

- file: gateway/api.go
  line: 1944
  message: Replacing apiLog prefix with logger (autofix)
  check: host.rules.tyk.log.apiLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "api",
		}).Info("Reload URL Structure - Scheduled")

- file: gateway/api.go
  line: 2164
  message: Replacing apiLog prefix with logger (autofix)
  check: host.rules.tyk.log.apiLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "api",
	}).Debug("Created storage ID: ", storageID)

- file: gateway/api.go
  line: 2429
  message: Replacing apiLog prefix with logger (autofix)
  check: host.rules.tyk.log.apiLog.remove.prefix.from.Fields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "api",
		"apiID":  apiID,
	}).Debug("Looking for refresh token in API Register")

- file: gateway/cert.go
  line: 69
  message: Replacing certLog prefix with logger (autofix)
  check: host.rules.tyk.log.certLog.remove.withField
  example: |
    var certLog = log.WithField("prefix", "certs")

- file: gateway/coprocess.go
  line: 60
  message: Replacing coprocessLog prefix with logger (autofix)
  check: host.rules.tyk.log.coprocessLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "coprocess",
	}).Info("Reloading middlewares")

- file: gateway/coprocess.go
  line: 254
  message: Replacing coprocessLog prefix with logger (autofix)
  check: host.rules.tyk.log.coprocessLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "coprocess",
		}).Info("Rich plugins are disabled")

- file: gateway/coprocess.go
  line: 265
  message: Replacing coprocessLog prefix with logger (autofix)
  check: host.rules.tyk.log.coprocessLog.remove.withFields
  example: |
    			log.WithFields(logrus.Fields{
				"prefix": "coprocess",
			}).Info("gRPC dispatcher was initialized")

- file: gateway/coprocess.go
  line: 269
  message: Replacing coprocessLog prefix with logger (autofix)
  check: host.rules.tyk.log.coprocessLog.remove.withFields
  example: |
    			log.WithFields(logrus.Fields{
				"prefix": "coprocess",
			}).WithError(err).Error("Couldn't load gRPC dispatcher")

- file: gateway/coprocess.go
  line: 281
  message: Replacing coprocessLog prefix with logger (autofix)
  check: host.rules.tyk.log.coprocessLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "coprocess",
		}).Error("Your API specifies a CP custom middleware, either Tyk wasn't build with CP support or CP is not enabled in your Tyk configuration file!")

- file: gateway/coprocess.go
  line: 295
  message: Replacing coprocessLog prefix with logger (autofix)
  check: host.rules.tyk.log.coprocessLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "coprocess",
		}).Errorf("Unsupported driver '%s'", m.Spec.CustomMiddleware.Driver)

- file: gateway/coprocess.go
  line: 302
  message: Replacing coprocessLog prefix with logger (autofix)
  check: host.rules.tyk.log.coprocessLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "coprocess",
		}).Errorf("Driver '%s' isn't loaded", m.Spec.CustomMiddleware.Driver)

- file: gateway/coprocess.go
  line: 308
  message: Replacing coprocessLog prefix with logger (autofix)
  check: host.rules.tyk.log.coprocessLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "coprocess",
	}).Debug("Enabling CP middleware.")

- file: gateway/coprocess.go
  line: 555
  message: Replacing coprocessLog prefix with logger (autofix)
  check: host.rules.tyk.log.coprocessLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "coprocess",
	}).Debugf("Response hook '%s' is called", h.mw.Name())

- file: gateway/coprocess_api.go
  line: 91
  message: Replacing pythonLog prefix with logger (autofix)
  check: host.rules.tyk.log.pythonLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "python",
		}).Debug(message)

- file: gateway/coprocess_api.go
  line: 95
  message: Replacing pythonLog prefix with logger (autofix)
  check: host.rules.tyk.log.pythonLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "python",
		}).Error(message)

- file: gateway/coprocess_api.go
  line: 99
  message: Replacing pythonLog prefix with logger (autofix)
  check: host.rules.tyk.log.pythonLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "python",
		}).Warning(message)

- file: gateway/coprocess_api.go
  line: 103
  message: Replacing pythonLog prefix with logger (autofix)
  check: host.rules.tyk.log.pythonLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "python",
		}).Info(message)

- file: gateway/coprocess_bundle.go
  line: 45
  message: Replacing mainLog prefix with logger (autofix)
  check: host.rules.tyk.log.mainLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "main",
	}).Info("----> Verifying bundle: ", b.Spec.CustomMiddlewareBundle)

- file: gateway/coprocess_bundle.go
  line: 111
  message: Replacing coprocessLog prefix with logger (autofix)
  check: host.rules.tyk.log.coprocessLog.remove.withFields
  example: |
    			log.WithFields(logrus.Fields{
				"prefix": "coprocess",
			}).WithError(err).Error("Couldn't load Python dispatcher")

- file: gateway/coprocess_bundle.go
  line: 116
  message: Replacing coprocessLog prefix with logger (autofix)
  check: host.rules.tyk.log.coprocessLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "coprocess",
		}).Info("Python dispatcher was initialized")

- file: gateway/coprocess_bundle.go
  line: 226
  message: Replacing mainLog prefix with logger (autofix)
  check: host.rules.tyk.log.mainLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "main",
		}).Warning("Bundle downloader is disabled.")

- file: gateway/coprocess_bundle.go
  line: 308
  message: Replacing mainLog prefix with logger (autofix)
  check: host.rules.tyk.log.mainLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "main",
	}).Info("----> Loading bundle: ", spec.CustomMiddlewareBundle)

- file: gateway/coprocess_bundle.go
  line: 320
  message: Replacing mainLog prefix with logger (autofix)
  check: host.rules.tyk.log.mainLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "main",
		}).Info("----> Couldn't unmarshal the manifest file for bundle: ", spec.CustomMiddlewareBundle)

- file: gateway/coprocess_bundle.go
  line: 331
  message: Replacing mainLog prefix with logger (autofix)
  check: host.rules.tyk.log.mainLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "main",
		}).Info("----> Bundle verification failed: ", spec.CustomMiddlewareBundle)

- file: gateway/coprocess_bundle.go
  line: 372
  message: Replacing mainLog prefix with logger (autofix)
  check: host.rules.tyk.log.mainLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "main",
		}).Info("Loading existing bundle: ", spec.CustomMiddlewareBundle)

- file: gateway/coprocess_bundle.go
  line: 385
  message: Replacing mainLog prefix with logger (autofix)
  check: host.rules.tyk.log.mainLog.remove.withFields
  example: |
    			log.WithFields(logrus.Fields{
				"prefix": "main",
			}).Info("----> Couldn't load bundle: ", spec.CustomMiddlewareBundle, " ", err)

- file: gateway/coprocess_bundle.go
  line: 390
  message: Replacing mainLog prefix with logger (autofix)
  check: host.rules.tyk.log.mainLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "main",
		}).Info("----> Using bundle: ", spec.CustomMiddlewareBundle)

- file: gateway/coprocess_bundle.go
  line: 399
  message: Replacing mainLog prefix with logger (autofix)
  check: host.rules.tyk.log.mainLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "main",
	}).Info("----> Fetching Bundle: ", spec.CustomMiddlewareBundle)

- file: gateway/coprocess_bundle.go
  line: 416
  message: Replacing mainLog prefix with logger (autofix)
  check: host.rules.tyk.log.mainLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "main",
	}).Debug("----> Saving Bundle: ", spec.CustomMiddlewareBundle)

- file: gateway/coprocess_bundle.go
  line: 432
  message: Replacing mainLog prefix with logger (autofix)
  check: host.rules.tyk.log.mainLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "main",
	}).Info("----> Bundle is valid, adding to spec: ", spec.CustomMiddlewareBundle)

- file: gateway/coprocess_grpc.go
  line: 30
  message: Replacing coprocessLog prefix with logger (autofix)
  check: host.rules.tyk.log.coprocessLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "coprocess",
		}).Error(err)

- file: gateway/coprocess_grpc.go
  line: 38
  message: Replacing coprocessLog prefix with logger (autofix)
  check: host.rules.tyk.log.coprocessLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "coprocess",
		}).Error(errString)

- file: gateway/coprocess_grpc.go
  line: 61
  message: Replacing coprocessLog prefix with logger (autofix)
  check: host.rules.tyk.log.coprocessLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "coprocess",
		}).Error(err)

- file: gateway/coprocess_grpc.go
  line: 105
  message: Replacing coprocessLog prefix with logger (autofix)
  check: host.rules.tyk.log.coprocessLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "coprocess",
		}).Error(err)

- file: gateway/coprocess_helpers.go
  line: 141
  message: Replacing coprocessLog prefix with logger (autofix)
  check: host.rules.tyk.log.coprocessLog.remove.withFields
  example: |
    					log.WithFields(logrus.Fields{
						"prefix": "coprocess",
					}).WithError(err).Error("Couldn't encode session metadata")

- file: gateway/coprocess_lua.go
  line: 93
  message: Replacing coprocessLog prefix with logger (autofix)
  check: host.rules.tyk.log.coprocessLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "coprocess",
		}).Info("Lua dispatcher was initialized")

- file: gateway/coprocess_lua.go
  line: 97
  message: Replacing coprocessLog prefix with logger (autofix)
  check: host.rules.tyk.log.coprocessLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "coprocess",
		}).WithError(err).Error("Couldn't load Lua dispatcher")

- file: gateway/coprocess_lua.go
  line: 177
  message: Replacing coprocessLog prefix with logger (autofix)
  check: host.rules.tyk.log.coprocessLog.remove.withFields
  example: |
    			log.WithFields(logrus.Fields{
				"prefix": "coprocess",
			}).Error("Failed to read middleware file: ", err)

- file: gateway/coprocess_lua.go
  line: 193
  message: Replacing coprocessLog prefix with logger (autofix)
  check: host.rules.tyk.log.coprocessLog.remove.withFields
  example: |
    			log.WithFields(logrus.Fields{
				"prefix": "coprocess",
			}).Error("Failed to read bundle file: ", err)

- file: gateway/coprocess_lua.go
  line: 201
  message: Replacing coprocessLog prefix with logger (autofix)
  check: host.rules.tyk.log.coprocessLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "coprocess",
	}).Info("Loading Tyk/Lua modules.")

- file: gateway/coprocess_lua.go
  line: 216
  message: Replacing coprocessLog prefix with logger (autofix)
  check: host.rules.tyk.log.coprocessLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "coprocess",
		}).Error("Failed to read bundle file: ", err)

- file: gateway/coprocess_python.go
  line: 53
  message: Replacing pythonLog prefix with logger (autofix)
  check: host.rules.tyk.log.pythonLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "python",
		}).Fatal(err)

- file: gateway/coprocess_python.go
  line: 63
  message: Replacing pythonLog prefix with logger (autofix)
  check: host.rules.tyk.log.pythonLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "python",
		}).Fatal(err)

- file: gateway/coprocess_python.go
  line: 73
  message: Replacing pythonLog prefix with logger (autofix)
  check: host.rules.tyk.log.pythonLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "python",
		}).Fatal(err)

- file: gateway/coprocess_python.go
  line: 84
  message: Replacing pythonLog prefix with logger (autofix)
  check: host.rules.tyk.log.pythonLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "python",
		}).Error(err)

- file: gateway/coprocess_python.go
  line: 96
  message: Replacing pythonLog prefix with logger (autofix)
  check: host.rules.tyk.log.pythonLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "python",
		}).Error(err)

- file: gateway/coprocess_python.go
  line: 106
  message: Replacing pythonLog prefix with logger (autofix)
  check: host.rules.tyk.log.pythonLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "python",
		}).Error(err)

- file: gateway/coprocess_python.go
  line: 116
  message: Replacing pythonLog prefix with logger (autofix)
  check: host.rules.tyk.log.pythonLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "python",
		}).Error(err)

- file: gateway/coprocess_python.go
  line: 129
  message: Replacing pythonLog prefix with logger (autofix)
  check: host.rules.tyk.log.pythonLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "python",
		}).Error(err)

- file: gateway/coprocess_python.go
  line: 158
  message: Replacing pythonLog prefix with logger (autofix)
  check: host.rules.tyk.log.pythonLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "python",
		}).Error(err)

- file: gateway/coprocess_python.go
  line: 166
  message: Replacing pythonLog prefix with logger (autofix)
  check: host.rules.tyk.log.pythonLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "python",
		}).Error(err)

- file: gateway/coprocess_python.go
  line: 175
  message: Replacing pythonLog prefix with logger (autofix)
  check: host.rules.tyk.log.pythonLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "python",
		}).Error(err)

- file: gateway/coprocess_python.go
  line: 191
  message: Replacing coprocessLog prefix with logger (autofix)
  check: host.rules.tyk.log.coprocessLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "coprocess",
		}).Fatalf("Couldn't initialize Python - %s", err.Error())

- file: gateway/coprocess_python.go
  line: 196
  message: Replacing coprocessLog prefix with logger (autofix)
  check: host.rules.tyk.log.coprocessLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "coprocess",
	}).Infof("Python version '%s' loaded", ver)

- file: gateway/coprocess_python.go
  line: 208
  message: Replacing coprocessLog prefix with logger (autofix)
  check: host.rules.tyk.log.coprocessLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "coprocess",
		}).Fatalf("Couldn't initialize Python dispatcher")

- file: gateway/coprocess_python.go
  line: 216
  message: Replacing coprocessLog prefix with logger (autofix)
  check: host.rules.tyk.log.coprocessLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "coprocess",
		}).Fatalf("Couldn't initialize Python dispatcher")

- file: gateway/coprocess_python.go
  line: 231
  message: Replacing pythonLog prefix with logger (autofix)
  check: host.rules.tyk.log.pythonLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "python",
		}).Fatal(err)

- file: gateway/coprocess_python.go
  line: 237
  message: Replacing pythonLog prefix with logger (autofix)
  check: host.rules.tyk.log.pythonLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "python",
		}).Error(err)

- file: gateway/coprocess_python.go
  line: 245
  message: Replacing pythonLog prefix with logger (autofix)
  check: host.rules.tyk.log.pythonLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "python",
		}).Error(err)

- file: gateway/coprocess_python.go
  line: 280
  message: Replacing coprocessLog prefix with logger (autofix)
  check: host.rules.tyk.log.coprocessLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "coprocess",
		}).Debugf("Python path prefix isn't set, using '%s'", workDir)

- file: gateway/coprocess_python.go
  line: 309
  message: Replacing coprocessLog prefix with logger (autofix)
  check: host.rules.tyk.log.coprocessLog.remove.withFields
  example: |
    			log.WithFields(logrus.Fields{
				"prefix": "coprocess",
			}).Error(err)

- file: gateway/dashboard_register.go
  line: 16
  message: Replacing dashLog prefix with logger (autofix)
  check: host.rules.tyk.log.dashLog.remove.withField
  example: |
    var dashLog = log.WithField("prefix", "dashboard")

- file: gateway/distributed_rate_limiter.go
  line: 88
  message: Replacing pubSubLog prefix with logger (autofix)
  check: host.rules.tyk.log.pubSubLog.remove.prefix.from.Fields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix":  "pub-sub",
			"payload": string(payload),
		}).Error("Failed unmarshal server data: ", err)

- file: gateway/event_handler_webhooks.go
  line: 59
  message: Replacing webhookLog prefix with logger (autofix)
  check: host.rules.tyk.log.webhookLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "webhooks",
		}).Error("Problem getting configuration, skipping. ", err)

- file: gateway/event_handler_webhooks.go
  line: 66
  message: Replacing webhookLog prefix with logger (autofix)
  check: host.rules.tyk.log.webhookLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "webhooks",
		}).Infof("skipping disabled webhook %s", w.conf.Name)

- file: gateway/event_handler_webhooks.go
  line: 79
  message: Replacing webhookLog prefix with logger (autofix)
  check: host.rules.tyk.log.webhookLog.remove.prefix.from.Fields
  example: |
    			log.WithFields(logrus.Fields{
				"prefix": "webhooks",
				"target": w.conf.TargetPath,
			}).Warning("Custom template load failure, using default: ", err)

- file: gateway/event_handler_webhooks.go
  line: 93
  message: Replacing webhookLog prefix with logger (autofix)
  check: host.rules.tyk.log.webhookLog.remove.prefix.from.Fields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "webhooks",
			"target": w.conf.TargetPath,
		}).Info("Loading default template.")

- file: gateway/event_handler_webhooks.go
  line: 100
  message: Replacing webhookLog prefix with logger (autofix)
  check: host.rules.tyk.log.webhookLog.remove.withFields
  example: |
    			log.WithFields(logrus.Fields{
				"prefix": "webhooks",
			}).Error("Could not load the default template: ", err)

- file: gateway/event_handler_webhooks.go
  line: 108
  message: Replacing webhookLog prefix with logger (autofix)
  check: host.rules.tyk.log.webhookLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "webhooks",
	}).Debug("Timeout set to: ", w.conf.EventTimeout)

- file: gateway/event_handler_webhooks.go
  line: 113
  message: Replacing webhookLog prefix with logger (autofix)
  check: host.rules.tyk.log.webhookLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "webhooks",
		}).Error("Init failed for this webhook, invalid URL, URL must be absolute")

- file: gateway/event_handler_webhooks.go
  line: 130
  message: Replacing webhookLog prefix with logger (autofix)
  check: host.rules.tyk.log.webhookLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "webhooks",
		}).Debug("Event can fire, no duplicates found")

- file: gateway/event_handler_webhooks.go
  line: 141
  message: Replacing webhookLog prefix with logger (autofix)
  check: host.rules.tyk.log.webhookLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "webhooks",
	}).Debug("Setting Webhook Checksum: ", checksum)

- file: gateway/event_handler_webhooks.go
  line: 156
  message: Replacing webhookLog prefix with logger (autofix)
  check: host.rules.tyk.log.webhookLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "webhooks",
		}).Warning("Method must be one of GET, PUT, POST, DELETE or PATCH, defaulting to GET")

- file: gateway/event_handler_webhooks.go
  line: 164
  message: Replacing webhookLog prefix with logger (autofix)
  check: host.rules.tyk.log.webhookLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "webhooks",
	}).Debug("Checking URL: ", r)

- file: gateway/event_handler_webhooks.go
  line: 168
  message: Replacing webhookLog prefix with logger (autofix)
  check: host.rules.tyk.log.webhookLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "webhooks",
		}).Error("Failed to parse URL! ", err, r)

- file: gateway/event_handler_webhooks.go
  line: 187
  message: Replacing webhookLog prefix with logger (autofix)
  check: host.rules.tyk.log.webhookLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "webhooks",
		}).Error("Failed to create request object: ", err)

- file: gateway/event_handler_webhooks.go
  line: 250
  message: Replacing webhookLog prefix with logger (autofix)
  check: host.rules.tyk.log.webhookLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "webhooks",
		}).Error("Webhook request failed: ", err)

- file: gateway/event_handler_webhooks.go
  line: 258
  message: Replacing webhookLog prefix with logger (autofix)
  check: host.rules.tyk.log.webhookLog.remove.prefix.from.Fields
  example: |
    				log.WithFields(logrus.Fields{
					"prefix":       "webhooks",
					"responseCode": resp.StatusCode,
				}).Debug(string(content))

- file: gateway/event_handler_webhooks.go
  line: 263
  message: Replacing webhookLog prefix with logger (autofix)
  check: host.rules.tyk.log.webhookLog.remove.withFields
  example: |
    				log.WithFields(logrus.Fields{
					"prefix": "webhooks",
				}).Error(err)

- file: gateway/event_handler_webhooks.go
  line: 269
  message: Replacing webhookLog prefix with logger (autofix)
  check: host.rules.tyk.log.webhookLog.remove.prefix.from.Fields
  example: |
    			log.WithFields(logrus.Fields{
				"prefix":       "webhooks",
				"responseCode": resp.StatusCode,
			}).Error("Request to webhook failed")

- file: gateway/host_checker_manager.go
  line: 103
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "host-check-mgr",
		}).Debug("Stopping uptime tests")

- file: gateway/host_checker_manager.go
  line: 121
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    				log.WithFields(logrus.Fields{
					"prefix": "host-check-mgr",
				}).Info("Starting Poller")

- file: gateway/host_checker_manager.go
  line: 128
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    			log.WithFields(logrus.Fields{
				"prefix": "host-check-mgr",
			}).Debug("New master found, no tests running")

- file: gateway/host_checker_manager.go
  line: 141
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "host-check-mgr",
		}).Error("No storage instance set for uptime tests! Disabling poller...")

- file: gateway/host_checker_manager.go
  line: 153
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "host-check-mgr",
		}).Debug("No Primary instance found, assuming control")

- file: gateway/host_checker_manager.go
  line: 164
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "host-check-mgr",
		}).Debug("Primary instance set, I am master")

- file: gateway/host_checker_manager.go
  line: 174
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "host-check-mgr",
	}).Debug("Active Instance is: ", activeInstance)

- file: gateway/host_checker_manager.go
  line: 177
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "host-check-mgr",
	}).Debug("--- I am: ", hc.Id)

- file: gateway/host_checker_manager.go
  line: 185
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "host-check-mgr",
	}).Debug("---> Initialising checker")

- file: gateway/host_checker_manager.go
  line: 207
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "host-check-mgr",
	}).Debug("---> Starting checker")

- file: gateway/host_checker_manager.go
  line: 211
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "host-check-mgr",
	}).Debug("---> Checker started.")

- file: gateway/host_checker_manager.go
  line: 235
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "host-check-mgr",
	}).Debug("Update key: ", key)

- file: gateway/host_checker_manager.go
  line: 245
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "host-check-mgr",
		}).Warning("[HOST CHECKER MANAGER] Event can't fire for API that doesn't exist")

- file: gateway/host_checker_manager.go
  line: 256
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "host-check-mgr",
	}).Warning("[HOST CHECKER MANAGER] Host is DOWN: ", report.CheckURL)

- file: gateway/host_checker_manager.go
  line: 269
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    				log.WithFields(logrus.Fields{
					"prefix": "host-check-mgr",
				}).Printf("[HOST CHECKER MANAGER] Resetting test host list in %v seconds for API: %v", spec.UptimeTests.Config.RecheckWait, apiID)

- file: gateway/host_checker_manager.go
  line: 282
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "host-check-mgr",
	}).Debug("Delete key: ", key)

- file: gateway/host_checker_manager.go
  line: 289
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "host-check-mgr",
		}).Warning("[HOST CHECKER MANAGER] Event can't fire for API that doesn't exist")

- file: gateway/host_checker_manager.go
  line: 299
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "host-check-mgr",
	}).Warning("[HOST CHECKER MANAGER] Host is UP:   ", report.CheckURL)

- file: gateway/host_checker_manager.go
  line: 307
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "host-check-mgr",
		}).Error(err)

- file: gateway/host_checker_manager.go
  line: 312
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "host-check-mgr",
	}).Debug("Key is: ", PoolerHostSentinelKeyPrefix+u.Host)

- file: gateway/host_checker_manager.go
  line: 333
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "host-check-mgr",
		}).Error(err)

- file: gateway/host_checker_manager.go
  line: 344
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    			log.WithFields(logrus.Fields{
				"prefix": "host-check-mgr",
			}).Error("Failed to load blob data: ", err)

- file: gateway/host_checker_manager.go
  line: 372
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "host-check-mgr",
	}).Debug("--- Setting tracking list up")

- file: gateway/host_checker_manager.go
  line: 383
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "host-check-mgr",
		}).Debug("Reset initiated")

- file: gateway/host_checker_manager.go
  line: 392
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "host-check-mgr",
	}).Debug("--- Setting tracking list up for ID: ", apiId)

- file: gateway/host_checker_manager.go
  line: 412
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "host-check-mgr",
		}).Debug("Reset initiated")

- file: gateway/host_checker_manager.go
  line: 418
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "host-check-mgr",
	}).Info("--- Queued tracking list update for API: ", apiId)

- file: gateway/host_checker_manager.go
  line: 433
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "host-check-mgr",
		}).Error("[HOST CHECKER MANAGER] Failed to retrieve host list: ", err)

- file: gateway/host_checker_manager.go
  line: 443
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "host-check-mgr",
		}).Error("[HOST CHECKER MANAGER] Decoder failed: ", err)

- file: gateway/host_checker_manager.go
  line: 453
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    			log.WithFields(logrus.Fields{
				"prefix": "host-check-mgr",
			}).Error("[HOST CHECKER MANAGER] failed to convert to HostData", err)

- file: gateway/host_checker_manager.go
  line: 464
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "host-check-mgr",
	}).Debug("[HOST CHECKER MANAGER] Getting data from service")

- file: gateway/host_checker_manager.go
  line: 472
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "host-check-mgr",
	}).Debug("[HOST CHECKER MANAGER] Data was: \n", hostData)

- file: gateway/host_checker_manager.go
  line: 475
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "host-check-mgr",
	}).Info("[HOST CHECKER MANAGER] Refreshing uptime tests from service for API: ", apiID)

- file: gateway/host_checker_manager.go
  line: 524
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "host-check-mgr",
		}).Error("Error encoding uptime data:", err)

- file: gateway/host_checker_manager.go
  line: 530
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "host-check-mgr",
	}).Debug("Recording uptime stat")

- file: gateway/host_checker_manager.go
  line: 549
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "host-check-mgr",
	}).Info("Loading uptime tests...")

- file: gateway/host_checker_manager.go
  line: 560
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    					log.WithFields(logrus.Fields{
						"prefix": "host-check-mgr",
					}).WithFields(logrus.Fields{

- file: gateway/host_checker_manager.go
  line: 572
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    					log.WithFields(logrus.Fields{
						"prefix": "host-check-mgr",
					}).Info("---> Adding uptime test: ", checkItem.CheckURL)

- file: gateway/host_checker_manager.go
  line: 576
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    					log.WithFields(logrus.Fields{
						"prefix": "host-check-mgr",
					}).Warning("---> Adding uptime test failed: ", checkItem.CheckURL)

- file: gateway/host_checker_manager.go
  line: 579
  message: Replacing hostCheckLog prefix with logger (autofix)
  check: host.rules.tyk.log.hostCheckLog.remove.withFields
  example: |
    					log.WithFields(logrus.Fields{
						"prefix": "host-check-mgr",
					}).Warning("--------> Error was: ", err)

- file: gateway/redis_signal_handle_config.go
  line: 52
  message: Replacing pubSubLog prefix with logger (autofix)
  check: host.rules.tyk.log.pubSubLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "pub-sub",
		}).Error("Failed to decode configuration payload: ", err)

- file: gateway/redis_signal_handle_config.go
  line: 60
  message: Replacing pubSubLog prefix with logger (autofix)
  check: host.rules.tyk.log.pubSubLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "pub-sub",
		}).Info("Configuration update received, no NodeID/Hostname match found")

- file: gateway/redis_signal_handle_config.go
  line: 67
  message: Replacing pubSubLog prefix with logger (autofix)
  check: host.rules.tyk.log.pubSubLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "pub-sub",
		}).Warning("Ignoring new config: Remote configuration is not allowed for this node.")

- file: gateway/redis_signal_handle_config.go
  line: 74
  message: Replacing pubSubLog prefix with logger (autofix)
  check: host.rules.tyk.log.pubSubLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "pub-sub",
		}).Error("Failed to backup existing configuration: ", err)

- file: gateway/redis_signal_handle_config.go
  line: 81
  message: Replacing pubSubLog prefix with logger (autofix)
  check: host.rules.tyk.log.pubSubLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "pub-sub",
		}).Error("Failed to write new configuration: ", err)

- file: gateway/redis_signal_handle_config.go
  line: 87
  message: Replacing pubSubLog prefix with logger (autofix)
  check: host.rules.tyk.log.pubSubLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "pub-sub",
	}).Info("Initiating configuration reload")

- file: gateway/redis_signal_handle_config.go
  line: 147
  message: Replacing pubSubLog prefix with logger (autofix)
  check: host.rules.tyk.log.pubSubLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "pub-sub",
		}).Error("Failed unmarshal request: ", err)

- file: gateway/redis_signal_handle_config.go
  line: 155
  message: Replacing pubSubLog prefix with logger (autofix)
  check: host.rules.tyk.log.pubSubLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "pub-sub",
		}).Debug("Configuration request received, no NodeID/Hostname match found, ignoring")

- file: gateway/redis_signal_handle_config.go
  line: 163
  message: Replacing pubSubLog prefix with logger (autofix)
  check: host.rules.tyk.log.pubSubLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "pub-sub",
		}).Error("Failed to get existing configuration: ", err)

- file: gateway/redis_signal_handle_config.go
  line: 178
  message: Replacing pubSubLog prefix with logger (autofix)
  check: host.rules.tyk.log.pubSubLog.remove.withFields
  example: |
    		log.WithFields(logrus.Fields{
			"prefix": "pub-sub",
		}).Error("Failed to get marshal configuration: ", err)

- file: gateway/redis_signal_handle_config.go
  line: 191
  message: Replacing pubSubLog prefix with logger (autofix)
  check: host.rules.tyk.log.pubSubLog.remove.withFields
  example: |
    	log.WithFields(logrus.Fields{
		"prefix": "pub-sub",
	}).Debug("Configuration request responded.")

- file: gateway/server.go
  line: 74
  message: Replacing mainLog prefix with logger (autofix)
  check: host.rules.tyk.log.mainLog.remove.withField
  example: |
    	mainLog   = log.WithField("prefix", "main")

- file: gateway/server.go
  line: 75
  message: Replacing pubSubLog prefix with logger (autofix)
  check: host.rules.tyk.log.pubSubLog.remove.withField
  example: |
    	pubSubLog = log.WithField("prefix", "pub-sub")


~~~

Checks by occurence:

- 40 host.rules.tyk.log.hostCheckLog.remove.withFields
- 28 host.rules.tyk.log.coprocessLog.remove.withFields
- 18 host.rules.tyk.log.pythonLog.remove.withFields
- 13 host.rules.tyk.log.webhookLog.remove.withFields
- 11 host.rules.tyk.log.mainLog.remove.withFields
- 11 host.rules.tyk.log.pubSubLog.remove.withFields
- 4 host.rules.tyk.log.apiLog.remove.prefix.from.Fields
- 4 host.rules.tyk.log.webhookLog.remove.prefix.from.Fields
- 3 host.rules.tyk.log.apiLog.remove.withFields
- 1 host.rules.tyk.log.mainLog.remove.withField
- 1 host.rules.tyk.log.dashLog.remove.withField
- 1 host.rules.tyk.log.pubSubLog.remove.prefix.from.Fields
- 1 host.rules.tyk.log.pubSubLog.remove.withField
- 1 host.rules.tyk.log.certLog.remove.withField

<details>
  <summary>Steps performed</summary>

  ~~~
  task: [pull] docker pull semgrep/semgrep -q
docker.io/semgrep/semgrep:latest
task: [default] docker run --rm -v /home/runner/work/exp/exp/lsc/semgrep/src:/src -v /home/runner/work/exp/exp/lsc/semgrep:/host semgrep/semgrep semgrep scan --metrics=off --config /host/rules/tyk/ --autofix --json -o /host/reports/semgrep.tyk.json || true
METRICS: Using configs from the Registry (like --config=p/ci) reports pseudonymous rule metrics to semgrep.dev.
To disable Registry rule metrics, use "--metrics=off".
Using configs only from local files (like --config=xyz.yml) does not enable metrics.

More information: https://semgrep.dev/docs/metrics

               
               
┌─────────────┐
│ Scan Status │
└─────────────┘
  Scanning 829 files tracked by git with 32 Code rules:
  Scanning 297 files with 32 go rules.
successfully modified 15 files.
                
                
┌──────────────┐
│ Scan Summary │
└──────────────┘
Some files were skipped or only partially analyzed.
  Scan was limited to files tracked by git.
  Scan skipped: 221 files matching .semgrepignore patterns
  For a full list of skipped files, run semgrep with the --verbose flag.

Ran 32 rules on 297 files: 137 findings.
  ~~~
</details>

JIRA: https://tyktech.atlassian.net/browse/0000