### PR TITLE
[DX-1473] Replace authorise with authorize

### DIFF
--- a/apidef/oas/authentication.go
+++ b/apidef/oas/authentication.go
@@ -491,7 +491,7 @@ type OIDC struct {
 	// Tyk classic API definition: `openid_options.segregate_by_client`.
 	SegregateByClientId bool `bson:"segregateByClientId,omitempty" json:"segregateByClientId,omitempty"`
 
-	// Providers contains a list of authorised providers, their Client IDs and matched policies.
+	// Providers contains a list of authorized providers, their Client IDs and matched policies.
 	//
 	// Tyk classic API definition: `openid_options.providers`.
 	Providers []Provider `bson:"providers,omitempty" json:"providers,omitempty"`

--- a/config/config.go
+++ b/config/config.go
@@ -325,7 +325,7 @@ type SlaveOptionsConfig struct {
 	// Your organisation ID to connect to the MDCB installation.
 	RPCKey string `json:"rpc_key"`
 
-	// This the API key of a user used to authenticate and authorise the Gateway’s access through MDCB.
+	// This the API key of a user used to authenticate and authorize the Gateway’s access through MDCB.
 	// The user should be a standard Dashboard user with minimal privileges so as to reduce any risk if the user is compromised.
 	// The suggested security settings are read for Real-time notifications and the remaining options set to deny.
 	APIKey string `json:"api_key"`
@@ -1046,7 +1046,7 @@ type Config struct {
 	// "override_messages": {
 	//   "oauth.auth_field_missing" : {
 	//    "code": 401,
-	//    "message": "Token is not authorised"
+	//    "message": "Token is not authorized"
 	//  }
 	// }
 	// ```


### PR DESCRIPTION
### **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description

Replace _authorise_ with _authorize_ for [PR](https://github.com/TykTechnologies/tyk-docs/pull/4937) raised in docs by @Roeegg2 

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

[DX-1473](https://tyktech.atlassian.net/browse/DX-1473)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
uk -> us spelling update

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [x] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
enhancement


___

### **Description**
- Updated spelling from 'authorise' to 'authorize' in comments and example messages across the codebase.
- Changes made in `apidef/oas/authentication.go` and `config/config.go` files.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>authentication.go</strong><dd><code>Update spelling from 'authorised' to 'authorized' in comments</code></dd></summary>
<hr>

apidef/oas/authentication.go

<li>Replaced <code>authorised</code> with <code>authorized</code> in the comment for the <code>Providers</code> <br>field.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6383/files#diff-e51c9d24d4235e7cc53048cc1d92967d177585ba5e073f14876308a97bef6326">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>config.go</strong><dd><code>Update spelling from 'authorise' to 'authorize' in comments and </code><br><code>examples</code></dd></summary>
<hr>

config/config.go

<li>Replaced <code>authorise</code> with <code>authorize</code> in the comment for the <code>APIKey</code> field.<br> <li> Updated the example message to use <code>authorized</code> instead of <code>authorised</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6383/files#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions



[DX-1473]: https://tyktech.atlassian.net/browse/DX-1473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ