### PR TITLE
[TT-13440] fix: correctly sync multi-value response headers with coprocess middl…

### DIFF
--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -613,7 +613,7 @@ func syncHeadersAndMultiValueHeaders(headers map[string]string, multiValueHeader
 		for _, header := range multiValueHeaders {
 			if header.Key == k {
 				found = true
-				header.Values = []string{v}
+				header.Values[0] = v
 				break
 			}
 		}

--- a/gateway/coprocess_test.go
+++ b/gateway/coprocess_test.go
@@ -214,6 +214,24 @@ func TestSyncHeadersAndMultiValueHeaders(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "keeping multivalue headers",
+			headers: map[string]string{
+				"Header": "newValue1",
+			},
+			initialMultiValueHeaders: []*coprocess.Header{
+				{
+					Key:    "Header",
+					Values: []string{"oldValue1", "value2"},
+				},
+			},
+			expectedMultiValueHeaders: []*coprocess.Header{
+				{
+					Key:    "Header",
+					Values: []string{"newValue1", "value2"},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Hi, 

as this is my first PR to your project please let me know what further information you need for a review.




## Description

When synchronizing single- and multi-valued header representations (of coprocess-based middleware responses) the list of values for any multi-valued header is currently replaced by a list containing only the value given by its single-value representation effectively dropping all but the first value. Instead synchronization should affect/replace only the first value and retain possibly remaining values.

## Related Issue

fixes #6411 

## Motivation and Context

We like to employ Tyk Gateway with a coprocess-based response middleware attached to an upstream possibly responding with multiple _Set-Cookie_ headers. We also require our middleware to modify other headers like _Location_. As is due to synchronization only the first _Set-Cookie_ header passes our middleware.

## How This Has Been Tested

This PR adds a [test](https://github.com/TykTechnologies/tyk/pull/6394/commits/fe1d9c49af5a464ecb0ea2dba46fe0513b4414bf#diff-c0fdc6fa7ea0ffd782deb36e7843d48aefff201af73e79a2c742027cf4557f5f) which should fail without proposed [fix](https://github.com/TykTechnologies/tyk/pull/6394/commits/fe1d9c49af5a464ecb0ea2dba46fe0513b4414bf#diff-9cbfe628982b2afb94d1e9a5200fc9a4fdc00cb58fe65d1090a3725e4e4c5953).

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [x] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
