### PR TITLE
Merging to release-5.3: [TT-12318] SSE streaming is broken (#6391)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,20 +24,8 @@ test:
 
 # lint runs all local linters that must pass before pushing
 .PHONY: lint lint-install lint-fast
-lint: lint-fast
-	goimports -local github.com/TykTechnologies,github.com/TykTechnologies/tyk/internal -w .
-	gofmt -w .
-
-lint-fast: lint-install
-	go generate ./...
-	go test -count 1 -v ./cli/linter/...
-	go fmt ./...
-	go mod tidy
-
-lint-install:
-	go install golang.org/x/tools/cmd/goimports@latest
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2
-	go install go.uber.org/mock/mockgen@v0.4.0
+lint:
+	task lint
 
 .PHONY: bench
 bench:

--- a/gateway/handler_success.go
+++ b/gateway/handler_success.go
@@ -325,7 +325,7 @@ func (s *SuccessHandler) RecordHit(r *http.Request, timing analytics.Latency, co
 
 func recordDetail(r *http.Request, spec *APISpec) bool {
 	// when streaming in grpc, we do not record the request
-	if IsGrpcStreaming(r) {
+	if httputil.IsStreamingRequest(r) {
 		return false
 	}
 

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -40,6 +40,7 @@ import (
 	"github.com/TykTechnologies/tyk/ctx"
 	"github.com/TykTechnologies/tyk/header"
 	"github.com/TykTechnologies/tyk/internal/graphengine"
+	"github.com/TykTechnologies/tyk/internal/httputil"
 	"github.com/TykTechnologies/tyk/internal/otel"
 	"github.com/TykTechnologies/tyk/regexp"
 	"github.com/TykTechnologies/tyk/trace"
@@ -512,12 +513,8 @@ var hopHeaders = []string{
 func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) ProxyResponse {
 	startTime := time.Now()
 	p.logger.WithField("ts", startTime.UnixNano()).Debug("Started")
-	var resp ProxyResponse
-	if IsGrpcStreaming(req) {
-		resp = p.WrappedServeHTTP(rw, req, false)
-	} else {
-		resp = p.WrappedServeHTTP(rw, req, true)
-	}
+
+	resp := p.WrappedServeHTTP(rw, req, true)
 
 	finishTime := time.Since(startTime)
 	p.logger.WithField("ns", finishTime.Nanoseconds()).Debug("Finished")
@@ -1097,7 +1094,7 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 
 	p.logger.Debug("Outbound request URL: ", outreq.URL.String())
 
-	outReqUpgrade, reqUpType := p.IsUpgrade(req)
+	reqUpType, outReqUpgrade := p.IsUpgrade(req)
 
 	// See RFC 2616, section 14.10.
 	if c := outreq.Header.Get("Connection"); c != "" {
@@ -1287,7 +1284,7 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 		return ProxyResponse{UpstreamLatency: upstreamLatency}
 	}
 
-	upgrade, _ := p.IsUpgrade(req)
+	_, upgrade := p.IsUpgrade(req)
 	// Deal with 101 Switching Protocols responses: (WebSocket, h2c, etc)
 	if upgrade && res.StatusCode == 101 {
 		if err := p.handleUpgradeResponse(rw, outreq, res); err != nil {
@@ -1315,6 +1312,11 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 	}
 
 	inres := new(http.Response)
+
+	if httputil.IsStreamingRequest(req) || httputil.IsStreamingResponse(res) {
+		withCache = false
+	}
+
 	if withCache {
 		*inres = *res // includes shallow copies of maps, but okay
 
@@ -1822,25 +1824,12 @@ func nopCloseResponseBody(r *http.Response) {
 	copyResponse(r)
 }
 
-func (p *ReverseProxy) IsUpgrade(req *http.Request) (bool, string) {
+// IsUpgrade will return the upgrade header value and true if present for the request.
+// It requires EnableWebSockets to be enabled in the gateway HTTP server config.
+func (p *ReverseProxy) IsUpgrade(req *http.Request) (string, bool) {
 	if !p.Gw.GetConfig().HttpServerOptions.EnableWebSockets {
-		return false, ""
+		return "", false
 	}
 
-	connection := strings.ToLower(strings.TrimSpace(req.Header.Get(header.Connection)))
-	if connection != "upgrade" {
-		return false, ""
-	}
-
-	upgrade := strings.ToLower(strings.TrimSpace(req.Header.Get("Upgrade")))
-	if upgrade != "" {
-		return true, upgrade
-	}
-
-	return false, ""
-}
-
-// IsGrpcStreaming  determines wether a request represents a grpc streaming req
-func IsGrpcStreaming(r *http.Request) bool {
-	return r.ContentLength == -1 && r.Header.Get(header.ContentType) == "application/grpc"
+	return httputil.IsUpgrade(req)
 }

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -1750,21 +1751,15 @@ func TestReverseProxyWebSocketCancelation(t *testing.T) {
 }
 
 func TestSSE(t *testing.T) {
-	test.Flaky(t) // TODO: TT-5250
-
-	// send and receive should be in order
-	var wg sync.WaitGroup
-
 	sseServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.Header().Set("Connection", "keep-alive")
 
 		flusher, _ := w.(http.Flusher)
 		for i := 0; i < 5; i++ {
-			wg.Wait()
 			fmt.Fprintf(w, "data: %d\n", i)
 			flusher.Flush()
-			wg.Add(1)
+			time.Sleep(50 * time.Millisecond)
 		}
 	}))
 
@@ -1784,7 +1779,10 @@ func TestSSE(t *testing.T) {
 
 	client := http.Client{}
 
-	stream := func(enableWebSockets bool) {
+	stream := func(enableWebSockets bool) error {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
 		globalConf := ts.Gw.GetConfig()
 		globalConf.HttpServerOptions.EnableWebSockets = enableWebSockets
 		ts.Gw.SetConfig(globalConf)
@@ -1796,28 +1794,42 @@ func TestSSE(t *testing.T) {
 		defer res.Body.Close()
 
 		i := 0
-		for {
-			line, err := reader.ReadBytes('\n')
-			if err != nil && err != io.EOF {
-				t.Fatal(err)
-			}
+		okChan := make(chan error)
 
-			if len(line) == 0 {
-				break
-			}
+		go func() {
+			for {
+				line, err := reader.ReadBytes('\n')
+				if err != nil && errors.Is(err, io.EOF) {
+					err = nil
+				}
 
-			assert.Equal(t, fmt.Sprintf("data: %v\n", i), string(line))
-			i++
-			wg.Done()
+				assert.NoError(t, err)
+
+				if len(line) == 0 {
+					break
+				}
+
+				assert.Equal(t, fmt.Sprintf("data: %v\n", i), string(line))
+				i++
+			}
+			close(okChan)
+		}()
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-okChan:
 		}
+		assert.Equal(t, i, 5)
+		return nil
 	}
 
 	t.Run("websockets disabled", func(t *testing.T) {
-		stream(false)
+		assert.NoError(t, stream(false))
 	})
 
 	t.Run("websockets enabled", func(t *testing.T) {
-		stream(true)
+		assert.NoError(t, stream(true))
 	})
 }
 

--- a/internal/httputil/streaming.go
+++ b/internal/httputil/streaming.go
@@ -1,0 +1,48 @@
+package httputil
+
+import (
+	"net/http"
+	"strings"
+)
+
+const (
+	headerContentType = "Content-Type"
+	headerUpgrade     = "Upgrade"
+	headerConnection  = "Connection"
+)
+
+// IsGrpcStreaming returns true if the request designates gRPC streaming.
+func IsGrpcStreaming(r *http.Request) bool {
+	return r.ContentLength == -1 && r.Header.Get(headerContentType) == "application/grpc"
+}
+
+// IsSseStreamingResponse returns true if the response designates SSE streaming.
+func IsSseStreamingResponse(r *http.Response) bool {
+	return r.Header.Get(headerContentType) == "text/event-stream"
+}
+
+// IsUpgrade checks if the request is an upgrade request and returns the upgrade type.
+func IsUpgrade(req *http.Request) (string, bool) {
+	connection := strings.ToLower(strings.TrimSpace(req.Header.Get(headerConnection)))
+	if connection != "upgrade" {
+		return "", false
+	}
+
+	upgrade := strings.ToLower(strings.TrimSpace(req.Header.Get(headerUpgrade)))
+	if upgrade != "" {
+		return upgrade, true
+	}
+
+	return "", false
+}
+
+// IsStreamingRequest returns true if the request designates streaming (gRPC or WebSocket).
+func IsStreamingRequest(r *http.Request) bool {
+	_, upgrade := IsUpgrade(r)
+	return upgrade || IsGrpcStreaming(r)
+}
+
+// IsStreamingResponse returns true if the response designates streaming (SSE).
+func IsStreamingResponse(r *http.Response) bool {
+	return IsSseStreamingResponse(r)
+}


### PR DESCRIPTION
### **User description**
[TT-12318] SSE streaming is broken (#6391)

### **User description**
This PR mends the evaluation if the cache should be used, considering:

- request: websockets (not cached), upgrade header
- request: a grpc streaming request (not cached)
- response: a SSE (server side streaming events) header

Previously the checks would handle only the request side to set a
caching flag to true; the change sets the flag to true absolutely, and
then evaluates the request and response disabling the cache before
copying the request into a buffer can occur.

The underlying cause/issue of the regression was a skipped flaky test
for SSE. The test case has now been restored to health.

Fixes:
https://tyktech.atlassian.net/browse/TT-12318
https://tyktech.atlassian.net/browse/TT-5250

Closes: #6322


___

### **PR Type**
Enhancement, Tests, Configuration changes


___

### **Description**
- Replaced specific gRPC streaming checks with generic streaming request
checks.
- Simplified and refactored reverse proxy logic to handle streaming
requests and responses.
- Added utility functions for streaming and upgrade checks.
- Refactored and stabilized SSE test.
- Simplified linting commands in Makefile.
- Modularized service definitions in Docker Compose by including
external Redis and HTTPBin services.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>handler_success.go</strong><dd><code>Replace gRPC
streaming check with generic streaming request
check</code></dd></summary>
<hr>

gateway/handler_success.go

- Replaced `IsGrpcStreaming` with `httputil.IsStreamingRequest`.



</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6391/files#diff-45135957493eca37f2e3e9a81079577777133c53b27cf95ea2ff0329c05bd006">+1/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
<summary><strong>reverse_proxy.go</strong><dd><code>Refactor reverse
proxy to handle streaming requests and responses</code></dd></summary>
<hr>

gateway/reverse_proxy.go

<li>Replaced <code>IsGrpcStreaming</code> with
<code>httputil.IsStreamingRequest</code>.<br> <li> Simplified
<code>ServeHTTP</code> method by removing conditional streaming
check.<br> <li> Refactored <code>IsUpgrade</code> method to return
upgrade type and boolean.<br> <li> Added streaming request and response
checks to disable caching.<br>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6391/files#diff-e6e07722257f7e41691e471185ad6d84fd56dc9e5459526ea32e9a5e8fa1a01b">+13/-26</a>&nbsp;
</td>

</tr>                    

<tr>
  <td>
    <details>
<summary><strong>streaming.go</strong><dd><code>Add utility functions
for streaming and upgrade checks</code>&nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

internal/httputil/streaming.go

<li>Added utility functions to check for streaming requests and
responses.<br> <li> Added utility function to check for upgrade
requests.<br>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6391/files#diff-3fe81a2ca7149490b32fa630f8b3818880b6f2f4929efa416a4c8c0174d0f43a">+48/-0</a>&nbsp;
&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>reverse_proxy_test.go</strong><dd><code>Refactor and
stabilize SSE test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

gateway/reverse_proxy_test.go

<li>Removed flaky test annotation.<br> <li> Refactored SSE test to use
context for timeout and synchronization.<br>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6391/files#diff-ce040f6555143f760fba6059744bc600b6954f0966dfb0fa2832b5eabf7a3c3f">+28/-20</a>&nbsp;
</td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration
changes</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>Makefile</strong><dd><code>Simplify linting commands in
Makefile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></summary>
<hr>

Makefile

- Simplified linting commands by using `task lint`.



</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6391/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+2/-14</a>&nbsp;
&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
<summary><strong>docker-compose.yml</strong><dd><code>Modularize service
definitions in Docker Compose</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml

<li>Included external service definitions for Redis and HTTPBin.<br>
<li> Removed inline Redis service definition.<br>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6391/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+4/-7</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
<summary><strong>docker-compose.yml</strong><dd><code>Include HTTPBin
service in Docker Compose</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; </dd></summary>
<hr>

docker/services/docker-compose.yml

- Included HTTPBin service definition.



</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6391/files#diff-8ce9686535a65153456ca4275ee4902069de9180063082f0d35f367b7c86f040">+1/-0</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
<summary><strong>httpbin.yml</strong><dd><code>Add HTTPBin service
definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

docker/services/httpbin.yml

- Added HTTPBin service definition for testing.



</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6391/files#diff-1a1b1d8bf4798076a41ca5f3bba0d465dc387e58b6593adbb28a4d5fe60eb810">+15/-0</a>&nbsp;
&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools
and their descriptions

---------

Co-authored-by: Tit Petric <tit@tyk.io>

[TT-12318]: https://tyktech.atlassian.net/browse/TT-12318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Enhancement, Tests, Configuration changes


___

### **Description**
- Replaced specific gRPC streaming checks with generic streaming request checks.
- Simplified and refactored reverse proxy logic to handle streaming requests and responses.
- Added utility functions for streaming and upgrade checks.
- Refactored and stabilized SSE test.
- Simplified linting commands in Makefile.
- Modularized service definitions in Docker Compose by including external Redis and HTTPBin services.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>handler_success.go</strong><dd><code>Replace gRPC streaming check with generic streaming request check</code></dd></summary>
<hr>

gateway/handler_success.go

<li>Replaced specific gRPC streaming check with a generic streaming <br>request check.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6398/files#diff-45135957493eca37f2e3e9a81079577777133c53b27cf95ea2ff0329c05bd006">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>reverse_proxy.go</strong><dd><code>Refactor reverse proxy logic for streaming requests and responses</code></dd></summary>
<hr>

gateway/reverse_proxy.go

<li>Refactored reverse proxy logic to handle streaming requests and <br>responses.<br> <li> Simplified upgrade handling and cache evaluation.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6398/files#diff-e6e07722257f7e41691e471185ad6d84fd56dc9e5459526ea32e9a5e8fa1a01b">+15/-26</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>streaming.go</strong><dd><code>Add utility functions for streaming and upgrade checks</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/httputil/streaming.go

- Added utility functions for streaming and upgrade checks.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6398/files#diff-3fe81a2ca7149490b32fa630f8b3818880b6f2f4929efa416a4c8c0174d0f43a">+48/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reverse_proxy_test.go</strong><dd><code>Refactor and stabilize SSE test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/reverse_proxy_test.go

<li>Refactored and stabilized SSE test.<br> <li> Improved test structure and error handling.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6398/files#diff-ce040f6555143f760fba6059744bc600b6954f0966dfb0fa2832b5eabf7a3c3f">+32/-20</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Simplify linting commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

- Simplified linting commands.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6398/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+2/-14</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Modularize service definitions in Docker Compose</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml

<li>Modularized service definitions by including external Redis and <br>HTTPBin services.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6398/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Include external Redis and HTTPBin services</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker/services/docker-compose.yml

- Included external Redis and HTTPBin services.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6398/files#diff-8ce9686535a65153456ca4275ee4902069de9180063082f0d35f367b7c86f040">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>httpbin.yml</strong><dd><code>Add HTTPBin service definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker/services/httpbin.yml

- Added HTTPBin service definition.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6398/files#diff-1a1b1d8bf4798076a41ca5f3bba0d465dc387e58b6593adbb28a4d5fe60eb810">+15/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

