### PR TITLE
[TT-1570/TT-12587]mTLS: allow validating client certificates against root certificate authority

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -135,7 +135,7 @@ jobs:
             -Dsonar.projectKey=TykTechnologies_tyk
             -Dsonar.sources=.
             -Dsonar.exclusions=**/testdata/*,test/**,coprocess/**/*,ci/**,smoke-tests/**,apidef/oas/schema/schema.gen.go
-            -Dsonar.coverage.exclusions=**/*_test.go,**/mock/*
+            -Dsonar.coverage.exclusions=**/*_test.go,**/mock/*,internal/crypto/testutil.go
             -Dsonar.test.inclusions=**/*_test.go
             -Dsonar.tests=.
             -Dsonar.go.coverage.reportPaths=coverage/*.cov

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -135,7 +135,7 @@ jobs:
             -Dsonar.projectKey=TykTechnologies_tyk
             -Dsonar.sources=.
             -Dsonar.exclusions=**/testdata/*,test/**,coprocess/**/*,ci/**,smoke-tests/**,apidef/oas/schema/schema.gen.go
-            -Dsonar.coverage.exclusions=**/*_test.go,**/mock/*,internal/crypto/testutil.go
+            -Dsonar.coverage.exclusions=**/*_test.go,**/mock/*
             -Dsonar.test.inclusions=**/*_test.go
             -Dsonar.tests=.
             -Dsonar.go.coverage.reportPaths=coverage/*.cov

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -1854,7 +1854,7 @@ func TestStaticMTLSAPI(t *testing.T) {
 			})
 		})
 
-		t.Run("invalid client", func(t *testing.T) {
+		t.Run("invalid client with self signed certificate", func(t *testing.T) {
 			_, _, _, invalidClientCert := crypto.GenCertificate(&x509.Certificate{}, false)
 			tlsConfig := GetTLSConfig(&invalidClientCert, nil)
 			tlsConfig.InsecureSkipVerify = false
@@ -1863,10 +1863,10 @@ func TestStaticMTLSAPI(t *testing.T) {
 			invalidClient := &http.Client{Transport: transport}
 			u, err := url.Parse(ts.URL)
 
-			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("localhost:%s/static-mtls", u.Port()), nil)
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%s/static-mtls", u.Port()), nil)
 			assert.NoError(t, err)
 			_, err = invalidClient.Do(req)
-			assert.Error(t, err)
+			assert.ErrorContains(t, err, "tls: failed to verify certificate: x509: certificate signed by unknown authority")
 		})
 
 	})

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -313,6 +313,7 @@ func TestGatewayControlAPIMutualTLS(t *testing.T) {
 			}
 		}
 		ts := StartTest(conf)
+		defer ts.Close()
 
 		certID, err = ts.Gw.CertificateManager.Add(combinedPEM, "default")
 		assert.NoError(t, err)
@@ -1823,6 +1824,7 @@ func TestStaticMTLSAPI(t *testing.T) {
 			globalConf.SuppressRedisSignalReload = true
 		}
 		ts := StartTest(conf)
+		defer ts.Close()
 
 		certID, err = ts.Gw.CertificateManager.Add(combinedPEM, "default")
 		assert.NoError(t, err)

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -344,7 +344,7 @@ func TestGatewayControlAPIMutualTLS(t *testing.T) {
 			})
 		})
 
-		t.Run("invalid client", func(t *testing.T) {
+		t.Run("invalid client with different cert authority", func(t *testing.T) {
 			_, _, _, invalidClientCert := crypto.GenCertificate(&x509.Certificate{}, false)
 			tlsConfig := GetTLSConfig(&invalidClientCert, nil)
 			tlsConfig.InsecureSkipVerify = false
@@ -353,10 +353,10 @@ func TestGatewayControlAPIMutualTLS(t *testing.T) {
 			invalidClient := &http.Client{Transport: transport}
 			u, err := url.Parse(ts.URL)
 
-			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("localhost:%s/static-mtls", u.Port()), nil)
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%s/static-mtls", u.Port()), nil)
 			assert.NoError(t, err)
 			_, err = invalidClient.Do(req)
-			assert.Error(t, err)
+			assert.ErrorContains(t, err, "tls: failed to verify certificate: x509: certificate signed by unknown authority")
 		})
 
 	})

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -2,16 +2,12 @@ package gateway
 
 import (
 	"bytes"
-	"crypto/rand"
-	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/json"
-	"encoding/pem"
 	"fmt"
 	"io/ioutil"
-	"math/big"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -292,10 +288,10 @@ func TestGatewayControlAPIMutualTLS(t *testing.T) {
 	})
 
 	t.Run("validate client cert against certificate authority", func(t *testing.T) {
-		rootCertPEM, rootKeyPEM, err := generateRootCertAndKey(t)
+		rootCertPEM, rootKeyPEM, err := crypto.GenerateRootCertAndKey(t)
 		assert.NoError(t, err)
 
-		serverCertPEM, serverKeyPEM, err := generateServerCertAndKeyChain(t, rootCertPEM, rootKeyPEM)
+		serverCertPEM, serverKeyPEM, err := crypto.GenerateServerCertAndKeyChain(t, rootCertPEM, rootKeyPEM)
 		assert.NoError(t, err)
 		combinedPEM := bytes.Join([][]byte{serverCertPEM.Bytes(), serverKeyPEM.Bytes()}, []byte("\n"))
 
@@ -327,7 +323,7 @@ func TestGatewayControlAPIMutualTLS(t *testing.T) {
 
 		ts.ReloadGatewayProxy()
 
-		clientCertPEM, clientKeyPEM, err := generateClientCertAndKeyChain(t, rootCertPEM, rootKeyPEM)
+		clientCertPEM, clientKeyPEM, err := crypto.GenerateClientCertAndKeyChain(t, rootCertPEM, rootKeyPEM)
 		assert.NoError(t, err)
 
 		clientCert, _ := tls.X509KeyPair(clientCertPEM.Bytes(), clientKeyPEM.Bytes())
@@ -1809,10 +1805,10 @@ func TestStaticMTLSAPI(t *testing.T) {
 	})
 
 	t.Run("validate client cert against certificate authority", func(t *testing.T) {
-		rootCertPEM, rootKeyPEM, err := generateRootCertAndKey(t)
+		rootCertPEM, rootKeyPEM, err := crypto.GenerateRootCertAndKey(t)
 		assert.NoError(t, err)
 
-		serverCertPEM, serverKeyPEM, err := generateServerCertAndKeyChain(t, rootCertPEM, rootKeyPEM)
+		serverCertPEM, serverKeyPEM, err := crypto.GenerateServerCertAndKeyChain(t, rootCertPEM, rootKeyPEM)
 		assert.NoError(t, err)
 		combinedPEM := bytes.Join([][]byte{serverCertPEM.Bytes(), serverKeyPEM.Bytes()}, []byte("\n"))
 
@@ -1833,7 +1829,7 @@ func TestStaticMTLSAPI(t *testing.T) {
 		defer ts.Gw.CertificateManager.Delete(certID, "default")
 		ts.ReloadGatewayProxy()
 
-		clientCertPEM, clientKeyPEM, err := generateClientCertAndKeyChain(t, rootCertPEM, rootKeyPEM)
+		clientCertPEM, clientKeyPEM, err := crypto.GenerateClientCertAndKeyChain(t, rootCertPEM, rootKeyPEM)
 		assert.NoError(t, err)
 
 		rootCertID, err := ts.Gw.CertificateManager.Add(rootCertPEM, "default")
@@ -1874,190 +1870,4 @@ func TestStaticMTLSAPI(t *testing.T) {
 		})
 
 	})
-}
-
-func generateRootCertAndKey(tb testing.TB) ([]byte, []byte, error) {
-	tb.Helper()
-	// Generate RSA key pair
-	rootKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Create a template for the root certificate
-	rootCertTemplate := x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject: pkix.Name{
-			Organization:  []string{"Tyk Technologies Ltd"},
-			Country:       []string{"UK"},
-			Province:      []string{"London"},
-			Locality:      []string{"London"},
-			StreetAddress: []string{"Worship Street"},
-		},
-		NotBefore:             time.Now(),
-		NotAfter:              time.Now().AddDate(10, 0, 0), // 10 years
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
-		BasicConstraintsValid: true,
-		IsCA:                  true,
-	}
-
-	// Create the root certificate
-	rootCertDER, err := x509.CreateCertificate(rand.Reader, &rootCertTemplate, &rootCertTemplate, &rootKey.PublicKey, rootKey)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Encode the root certificate to PEM format
-	var rootCertPEM bytes.Buffer
-	_ = pem.Encode(&rootCertPEM, &pem.Block{Type: "CERTIFICATE", Bytes: rootCertDER})
-
-	// Encode the root private key to PEM format
-	var rootKeyPEM bytes.Buffer
-	_ = pem.Encode(&rootKeyPEM, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(rootKey)})
-
-	return rootCertPEM.Bytes(), rootKeyPEM.Bytes(), nil
-}
-
-func generateServerCertAndKeyPEM(tb testing.TB, rootCertPEM, rootKeyPEM []byte) (*bytes.Buffer, *bytes.Buffer, error) {
-	tb.Helper()
-
-	rootCertBlock, _ := pem.Decode(rootCertPEM)
-	if rootCertBlock == nil || rootCertBlock.Type != "CERTIFICATE" {
-		return nil, nil, fmt.Errorf("failed to decode root certificate PEM")
-	}
-	rootCert, err := x509.ParseCertificate(rootCertBlock.Bytes)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Decode the root private key
-	rootKeyBlock, _ := pem.Decode(rootKeyPEM)
-	if rootKeyBlock == nil || rootKeyBlock.Type != "RSA PRIVATE KEY" {
-		return nil, nil, fmt.Errorf("failed to decode root key PEM")
-	}
-	rootKey, err := x509.ParsePKCS1PrivateKey(rootKeyBlock.Bytes)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Generate RSA key pair for the server
-	serverKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Create a template for the server certificate
-	serverCertTemplate := x509.Certificate{
-		SerialNumber: big.NewInt(2),
-		Subject: pkix.Name{
-			Organization:  []string{"Tyk Technologies Ltd"},
-			Country:       []string{"UK"},
-			Province:      []string{"London"},
-			Locality:      []string{"London"},
-			StreetAddress: []string{"Worship Street"},
-		},
-		NotBefore:   time.Now(),
-		NotAfter:    time.Now().AddDate(1, 0, 0), // 1 year
-		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
-		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		IPAddresses: []net.IP{net.ParseIP("127.0.0.1")},
-		DNSNames:    []string{"localhost"},
-	}
-
-	// Create the server certificate signed by the root CA
-	serverCertDER, err := x509.CreateCertificate(rand.Reader, &serverCertTemplate, rootCert, &serverKey.PublicKey, rootKey)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Encode the server certificate to PEM format
-	var serverCertPEM bytes.Buffer
-	_ = pem.Encode(&serverCertPEM, &pem.Block{Type: "CERTIFICATE", Bytes: serverCertDER})
-
-	// Encode the server private key to PEM format
-	var serverKeyPEM bytes.Buffer
-	_ = pem.Encode(&serverKeyPEM, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(serverKey)})
-
-	return &serverCertPEM, &serverKeyPEM, nil
-}
-
-func generateServerCertAndKeyChain(tb testing.TB, rootCertPEM, rootKeyPEM []byte) (*bytes.Buffer, *bytes.Buffer, error) {
-	tb.Helper()
-	serverCertPEM, serverKeyPEM, err := generateServerCertAndKeyPEM(tb, rootCertPEM, rootKeyPEM)
-	assert.NoError(tb, err)
-	// Include the root certificate in the client certificate chain
-	_, _ = serverCertPEM.Write(rootCertPEM)
-
-	return serverCertPEM, serverKeyPEM, nil
-}
-
-func generateClientCertAndKeyPEM(tb testing.TB, rootCertPEM, rootKeyPEM []byte) (*bytes.Buffer, *bytes.Buffer, error) {
-	tb.Helper()
-	// Decode the root certificate
-	rootCertBlock, _ := pem.Decode(rootCertPEM)
-	if rootCertBlock == nil || rootCertBlock.Type != "CERTIFICATE" {
-		return nil, nil, fmt.Errorf("failed to decode root certificate PEM")
-	}
-	rootCert, err := x509.ParseCertificate(rootCertBlock.Bytes)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Decode the root private key
-	rootKeyBlock, _ := pem.Decode(rootKeyPEM)
-	if rootKeyBlock == nil || rootKeyBlock.Type != "RSA PRIVATE KEY" {
-		return nil, nil, fmt.Errorf("failed to decode root key PEM")
-	}
-	rootKey, err := x509.ParsePKCS1PrivateKey(rootKeyBlock.Bytes)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Generate RSA key pair for the client
-	clientKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Create a template for the client certificate
-	clientCertTemplate := x509.Certificate{
-		SerialNumber: big.NewInt(3),
-		Subject: pkix.Name{
-			Organization:  []string{"Tyk Technologies Ltd"},
-			Country:       []string{"UK"},
-			Province:      []string{"London"},
-			Locality:      []string{"London"},
-			StreetAddress: []string{"Worship Street"},
-		},
-		NotBefore:   time.Now(),
-		NotAfter:    time.Now().AddDate(1, 0, 0), // 1 year
-		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
-		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
-	}
-
-	// Create the client certificate signed by the root CA
-	clientCertDER, err := x509.CreateCertificate(rand.Reader, &clientCertTemplate, rootCert, &clientKey.PublicKey, rootKey)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Encode the client certificate to PEM format
-	var clientCertPEM bytes.Buffer
-	_ = pem.Encode(&clientCertPEM, &pem.Block{Type: "CERTIFICATE", Bytes: clientCertDER})
-
-	// Encode the client private key to PEM format
-	var clientKeyPEM bytes.Buffer
-	_ = pem.Encode(&clientKeyPEM, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(clientKey)})
-
-	return &clientCertPEM, &clientKeyPEM, nil
-}
-
-func generateClientCertAndKeyChain(tb testing.TB, rootCertPEM, rootKeyPEM []byte) (*bytes.Buffer, *bytes.Buffer, error) {
-	tb.Helper()
-	clientCertPEM, clientKeyPEM, err := generateClientCertAndKeyPEM(tb, rootCertPEM, rootKeyPEM)
-	assert.NoError(tb, err)
-	// Include the root certificate in the client certificate chain
-	_, _ = clientCertPEM.Write(rootCertPEM)
-
-	return clientCertPEM, clientKeyPEM, nil
 }

--- a/internal/crypto/helpers.go
+++ b/internal/crypto/helpers.go
@@ -97,28 +97,33 @@ func ValidateRequestCerts(r *http.Request, certs []*tls.Certificate) error {
 		return errors.New("Client TLS certificate is required")
 	}
 
-	leaf := r.TLS.PeerCertificates[0]
+	// no certs to verify
+	if len(certs) == 0 {
+		return nil
+	}
 
-	certID := HexSHA256(leaf.Raw)
-	for _, cert := range certs {
-		// In case a cert can't be parsed or is invalid,
-		// it will be present in the cert list as 'nil'
-		if cert == nil {
-			// Invalid cert, continue to next one
-			continue
-		}
-
-		// Extensions[0] contains cache of certificate SHA256
-		if string(cert.Leaf.Extensions[0].Value) == certID {
-			if time.Now().After(cert.Leaf.NotAfter) {
-				return ErrCertExpired
+	for _, peerCertificate := range r.TLS.PeerCertificates {
+		certID := HexSHA256(peerCertificate.Raw)
+		for _, cert := range certs {
+			// In case a cert can't be parsed or is invalid,
+			// it will be present in the cert list as 'nil'
+			if cert == nil {
+				// Invalid cert, continue to next one
+				continue
 			}
-			// Happy flow, we matched a certificate
-			return nil
+
+			// Extensions[0] contains cache of certificate SHA256
+			if string(cert.Leaf.Extensions[0].Value) == certID {
+				if time.Now().After(cert.Leaf.NotAfter) {
+					return ErrCertExpired
+				}
+				// Happy flow, we matched a certificate
+				return nil
+			}
 		}
 	}
 
-	return errors.New("Certificate with SHA256 " + certID + " not allowed")
+	return errors.New("Certificate with SHA256 " + HexSHA256(r.TLS.PeerCertificates[0].Raw) + " not allowed")
 }
 
 // IsPublicKey verifies if given certificate is a public key only.

--- a/internal/crypto/helpers.go
+++ b/internal/crypto/helpers.go
@@ -97,11 +97,6 @@ func ValidateRequestCerts(r *http.Request, certs []*tls.Certificate) error {
 		return errors.New("Client TLS certificate is required")
 	}
 
-	// no certs to verify
-	if len(certs) == 0 {
-		return nil
-	}
-
 	for _, peerCertificate := range r.TLS.PeerCertificates {
 		certID := HexSHA256(peerCertificate.Raw)
 		for _, cert := range certs {

--- a/internal/crypto/testutil.go
+++ b/internal/crypto/testutil.go
@@ -16,6 +16,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var certSubject = pkix.Name{
+	Organization:  []string{"Tyk Technologies Ltd"},
+	Country:       []string{"UK"},
+	Province:      []string{"London"},
+	Locality:      []string{"London"},
+	StreetAddress: []string{"Worship Street"},
+}
+
 // GenerateRootCertAndKey generates a root certificate and private key for testing purposes.
 // It returns the root certificate and private key in PEM format along with an error, if any.
 //
@@ -36,14 +44,8 @@ func GenerateRootCertAndKey(tb testing.TB) ([]byte, []byte, error) {
 
 	// Create a template for the root certificate
 	rootCertTemplate := x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject: pkix.Name{
-			Organization:  []string{"Tyk Technologies Ltd"},
-			Country:       []string{"UK"},
-			Province:      []string{"London"},
-			Locality:      []string{"London"},
-			StreetAddress: []string{"Worship Street"},
-		},
+		SerialNumber:          big.NewInt(1),
+		Subject:               certSubject,
 		NotBefore:             time.Now(),
 		NotAfter:              time.Now().AddDate(10, 0, 0), // 10 years
 		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
@@ -96,19 +98,13 @@ func GenerateServerCertAndKeyPEM(tb testing.TB, rootCertPEM, rootKeyPEM []byte) 
 	// Create a template for the server certificate
 	serverCertTemplate := x509.Certificate{
 		SerialNumber: big.NewInt(2),
-		Subject: pkix.Name{
-			Organization:  []string{"Tyk Technologies Ltd"},
-			Country:       []string{"UK"},
-			Province:      []string{"London"},
-			Locality:      []string{"London"},
-			StreetAddress: []string{"Worship Street"},
-		},
-		NotBefore:   time.Now(),
-		NotAfter:    time.Now().AddDate(1, 0, 0), // 1 year
-		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
-		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		IPAddresses: []net.IP{net.ParseIP("127.0.0.1")},
-		DNSNames:    []string{"localhost"},
+		Subject:      certSubject,
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(1, 0, 0), // 1 year
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+		DNSNames:     []string{"localhost"},
 	}
 
 	// Create the server certificate signed by the root CA
@@ -179,17 +175,11 @@ func GenerateClientCertAndKeyPEM(tb testing.TB, rootCertPEM, rootKeyPEM []byte) 
 	// Create a template for the client certificate
 	clientCertTemplate := x509.Certificate{
 		SerialNumber: big.NewInt(3),
-		Subject: pkix.Name{
-			Organization:  []string{"Tyk Technologies Ltd"},
-			Country:       []string{"UK"},
-			Province:      []string{"London"},
-			Locality:      []string{"London"},
-			StreetAddress: []string{"Worship Street"},
-		},
-		NotBefore:   time.Now(),
-		NotAfter:    time.Now().AddDate(1, 0, 0), // 1 year
-		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
-		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		Subject:      certSubject,
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(1, 0, 0), // 1 year
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 	}
 
 	// Create the client certificate signed by the root CA

--- a/internal/crypto/testutil.go
+++ b/internal/crypto/testutil.go
@@ -16,6 +16,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	rsaPrivateKey = "RSA PRIVATE KEY"
+	certificate   = "CERTIFICATE"
+)
+
 var certSubject = pkix.Name{
 	Organization:  []string{"Tyk Technologies Ltd"},
 	Country:       []string{"UK"},
@@ -61,11 +66,11 @@ func GenerateRootCertAndKey(tb testing.TB) ([]byte, []byte, error) {
 
 	// Encode the root certificate to PEM format
 	var rootCertPEM bytes.Buffer
-	assert.NoError(tb, pem.Encode(&rootCertPEM, &pem.Block{Type: "CERTIFICATE", Bytes: rootCertDER}))
+	assert.NoError(tb, pem.Encode(&rootCertPEM, &pem.Block{Type: certificate, Bytes: rootCertDER}))
 
 	// Encode the root private key to PEM format
 	var rootKeyPEM bytes.Buffer
-	assert.NoError(tb, pem.Encode(&rootKeyPEM, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(rootKey)}))
+	assert.NoError(tb, pem.Encode(&rootKeyPEM, &pem.Block{Type: rsaPrivateKey, Bytes: x509.MarshalPKCS1PrivateKey(rootKey)}))
 
 	return rootCertPEM.Bytes(), rootKeyPEM.Bytes(), nil
 }
@@ -115,11 +120,11 @@ func GenerateServerCertAndKeyPEM(tb testing.TB, rootCertPEM, rootKeyPEM []byte) 
 
 	// Encode the server certificate to PEM format
 	var serverCertPEM bytes.Buffer
-	assert.NoError(tb, pem.Encode(&serverCertPEM, &pem.Block{Type: "CERTIFICATE", Bytes: serverCertDER}))
+	assert.NoError(tb, pem.Encode(&serverCertPEM, &pem.Block{Type: certificate, Bytes: serverCertDER}))
 
 	// Encode the server private key to PEM format
 	var serverKeyPEM bytes.Buffer
-	assert.NoError(tb, pem.Encode(&serverKeyPEM, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(serverKey)}))
+	assert.NoError(tb, pem.Encode(&serverKeyPEM, &pem.Block{Type: rsaPrivateKey, Bytes: x509.MarshalPKCS1PrivateKey(serverKey)}))
 
 	return &serverCertPEM, &serverKeyPEM, nil
 }
@@ -190,11 +195,11 @@ func GenerateClientCertAndKeyPEM(tb testing.TB, rootCertPEM, rootKeyPEM []byte) 
 
 	// Encode the client certificate to PEM format
 	var clientCertPEM bytes.Buffer
-	assert.NoError(tb, pem.Encode(&clientCertPEM, &pem.Block{Type: "CERTIFICATE", Bytes: clientCertDER}))
+	assert.NoError(tb, pem.Encode(&clientCertPEM, &pem.Block{Type: certificate, Bytes: clientCertDER}))
 
 	// Encode the client private key to PEM format
 	var clientKeyPEM bytes.Buffer
-	assert.NoError(tb, pem.Encode(&clientKeyPEM, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(clientKey)}))
+	assert.NoError(tb, pem.Encode(&clientKeyPEM, &pem.Block{Type: rsaPrivateKey, Bytes: x509.MarshalPKCS1PrivateKey(clientKey)}))
 
 	return &clientCertPEM, &clientKeyPEM, nil
 }
@@ -225,7 +230,7 @@ func GenerateClientCertAndKeyChain(tb testing.TB, rootCertPEM, rootKeyPEM []byte
 func decodeRootCertAndKey(rootCertPEM, rootKeyPEM []byte) (*x509.Certificate, *rsa.PrivateKey, error) {
 	// Decode the root certificate
 	rootCertBlock, _ := pem.Decode(rootCertPEM)
-	if rootCertBlock == nil || rootCertBlock.Type != "CERTIFICATE" {
+	if rootCertBlock == nil || rootCertBlock.Type != certificate {
 		return nil, nil, fmt.Errorf("failed to decode root certificate PEM")
 	}
 
@@ -236,7 +241,7 @@ func decodeRootCertAndKey(rootCertPEM, rootKeyPEM []byte) (*x509.Certificate, *r
 
 	// Decode the root private key
 	rootKeyBlock, _ := pem.Decode(rootKeyPEM)
-	if rootKeyBlock == nil || rootKeyBlock.Type != "RSA PRIVATE KEY" {
+	if rootKeyBlock == nil || rootKeyBlock.Type != rsaPrivateKey {
 		return nil, nil, fmt.Errorf("failed to decode root key PEM")
 	}
 	rootKey, err := x509.ParsePKCS1PrivateKey(rootKeyBlock.Bytes)

--- a/internal/crypto/testutil.go
+++ b/internal/crypto/testutil.go
@@ -59,11 +59,11 @@ func GenerateRootCertAndKey(tb testing.TB) ([]byte, []byte, error) {
 
 	// Encode the root certificate to PEM format
 	var rootCertPEM bytes.Buffer
-	_ = pem.Encode(&rootCertPEM, &pem.Block{Type: "CERTIFICATE", Bytes: rootCertDER})
+	assert.NoError(tb, pem.Encode(&rootCertPEM, &pem.Block{Type: "CERTIFICATE", Bytes: rootCertDER}))
 
 	// Encode the root private key to PEM format
 	var rootKeyPEM bytes.Buffer
-	_ = pem.Encode(&rootKeyPEM, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(rootKey)})
+	assert.NoError(tb, pem.Encode(&rootKeyPEM, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(rootKey)}))
 
 	return rootCertPEM.Bytes(), rootKeyPEM.Bytes(), nil
 }
@@ -135,11 +135,11 @@ func GenerateServerCertAndKeyPEM(tb testing.TB, rootCertPEM, rootKeyPEM []byte) 
 
 	// Encode the server certificate to PEM format
 	var serverCertPEM bytes.Buffer
-	_ = pem.Encode(&serverCertPEM, &pem.Block{Type: "CERTIFICATE", Bytes: serverCertDER})
+	assert.NoError(tb, pem.Encode(&serverCertPEM, &pem.Block{Type: "CERTIFICATE", Bytes: serverCertDER}))
 
 	// Encode the server private key to PEM format
 	var serverKeyPEM bytes.Buffer
-	_ = pem.Encode(&serverKeyPEM, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(serverKey)})
+	assert.NoError(tb, pem.Encode(&serverKeyPEM, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(serverKey)}))
 
 	return &serverCertPEM, &serverKeyPEM, nil
 }
@@ -232,11 +232,11 @@ func GenerateClientCertAndKeyPEM(tb testing.TB, rootCertPEM, rootKeyPEM []byte) 
 
 	// Encode the client certificate to PEM format
 	var clientCertPEM bytes.Buffer
-	_ = pem.Encode(&clientCertPEM, &pem.Block{Type: "CERTIFICATE", Bytes: clientCertDER})
+	assert.NoError(tb, pem.Encode(&clientCertPEM, &pem.Block{Type: "CERTIFICATE", Bytes: clientCertDER}))
 
 	// Encode the client private key to PEM format
 	var clientKeyPEM bytes.Buffer
-	_ = pem.Encode(&clientKeyPEM, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(clientKey)})
+	assert.NoError(tb, pem.Encode(&clientKeyPEM, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(clientKey)}))
 
 	return &clientCertPEM, &clientKeyPEM, nil
 }

--- a/internal/crypto/testutil.go
+++ b/internal/crypto/testutil.go
@@ -1,0 +1,265 @@
+package crypto
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// GenerateRootCertAndKey generates a root certificate and private key for testing purposes.
+// It returns the root certificate and private key in PEM format along with an error, if any.
+//
+// Parameters:
+// - tb: The testing.TB instance to log errors and fail the test if necessary.
+//
+// Returns:
+// - []byte: The root certificate in PEM format.
+// - []byte: The root private key in PEM format.
+// - error: Any error encountered during the generation.
+func GenerateRootCertAndKey(tb testing.TB) ([]byte, []byte, error) {
+	tb.Helper()
+	// Generate RSA key pair
+	rootKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Create a template for the root certificate
+	rootCertTemplate := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization:  []string{"Tyk Technologies Ltd"},
+			Country:       []string{"UK"},
+			Province:      []string{"London"},
+			Locality:      []string{"London"},
+			StreetAddress: []string{"Worship Street"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0), // 10 years
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	// Create the root certificate
+	rootCertDER, err := x509.CreateCertificate(rand.Reader, &rootCertTemplate, &rootCertTemplate, &rootKey.PublicKey, rootKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Encode the root certificate to PEM format
+	var rootCertPEM bytes.Buffer
+	_ = pem.Encode(&rootCertPEM, &pem.Block{Type: "CERTIFICATE", Bytes: rootCertDER})
+
+	// Encode the root private key to PEM format
+	var rootKeyPEM bytes.Buffer
+	_ = pem.Encode(&rootKeyPEM, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(rootKey)})
+
+	return rootCertPEM.Bytes(), rootKeyPEM.Bytes(), nil
+}
+
+// GenerateServerCertAndKeyPEM generates a server certificate and private key signed by the given root certificate
+// and key for testing purposes.
+// It returns the server certificate and private key in PEM format along with an error, if any.
+//
+// Parameters:
+// - tb: The testing.TB instance to log errors and fail the test if necessary.
+// - rootCertPEM: The root certificate in PEM format.
+// - rootKeyPEM: The root private key in PEM format.
+//
+// Returns:
+// - *bytes.Buffer: The server certificate in PEM format.
+// - *bytes.Buffer: The server private key in PEM format.
+// - error: Any error encountered during the generation.
+func GenerateServerCertAndKeyPEM(tb testing.TB, rootCertPEM, rootKeyPEM []byte) (*bytes.Buffer, *bytes.Buffer, error) {
+	tb.Helper()
+
+	rootCertBlock, _ := pem.Decode(rootCertPEM)
+	if rootCertBlock == nil || rootCertBlock.Type != "CERTIFICATE" {
+		return nil, nil, fmt.Errorf("failed to decode root certificate PEM")
+	}
+	rootCert, err := x509.ParseCertificate(rootCertBlock.Bytes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Decode the root private key
+	rootKeyBlock, _ := pem.Decode(rootKeyPEM)
+	if rootKeyBlock == nil || rootKeyBlock.Type != "RSA PRIVATE KEY" {
+		return nil, nil, fmt.Errorf("failed to decode root key PEM")
+	}
+	rootKey, err := x509.ParsePKCS1PrivateKey(rootKeyBlock.Bytes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Generate RSA key pair for the server
+	serverKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Create a template for the server certificate
+	serverCertTemplate := x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			Organization:  []string{"Tyk Technologies Ltd"},
+			Country:       []string{"UK"},
+			Province:      []string{"London"},
+			Locality:      []string{"London"},
+			StreetAddress: []string{"Worship Street"},
+		},
+		NotBefore:   time.Now(),
+		NotAfter:    time.Now().AddDate(1, 0, 0), // 1 year
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses: []net.IP{net.ParseIP("127.0.0.1")},
+		DNSNames:    []string{"localhost"},
+	}
+
+	// Create the server certificate signed by the root CA
+	serverCertDER, err := x509.CreateCertificate(rand.Reader, &serverCertTemplate, rootCert, &serverKey.PublicKey, rootKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Encode the server certificate to PEM format
+	var serverCertPEM bytes.Buffer
+	_ = pem.Encode(&serverCertPEM, &pem.Block{Type: "CERTIFICATE", Bytes: serverCertDER})
+
+	// Encode the server private key to PEM format
+	var serverKeyPEM bytes.Buffer
+	_ = pem.Encode(&serverKeyPEM, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(serverKey)})
+
+	return &serverCertPEM, &serverKeyPEM, nil
+}
+
+// GenerateServerCertAndKeyChain generates a server certificate and private key signed by the given root certificate and key,
+// and includes the root certificate in the chain for testing purposes.
+// It returns the server certificate chain and private key in PEM format along with an error, if any.
+//
+// Parameters:
+// - tb: The testing.TB instance to log errors and fail the test if necessary.
+// - rootCertPEM: The root certificate in PEM format.
+// - rootKeyPEM: The root private key in PEM format.
+//
+// Returns:
+// - *bytes.Buffer: The server certificate chain in PEM format.
+// - *bytes.Buffer: The server private key in PEM format.
+// - error: Any error encountered during the generation.
+func GenerateServerCertAndKeyChain(tb testing.TB, rootCertPEM, rootKeyPEM []byte) (*bytes.Buffer, *bytes.Buffer, error) {
+	tb.Helper()
+	serverCertPEM, serverKeyPEM, err := GenerateServerCertAndKeyPEM(tb, rootCertPEM, rootKeyPEM)
+	assert.NoError(tb, err)
+	// Include the root certificate in the client certificate chain
+	_, _ = serverCertPEM.Write(rootCertPEM)
+
+	return serverCertPEM, serverKeyPEM, nil
+}
+
+// GenerateClientCertAndKeyPEM generates a client certificate and private key signed by the given root certificate
+// and key for testing purposes.
+// It returns the client certificate and private key in PEM format along with an error, if any.
+//
+// Parameters:
+// - tb: The testing.TB instance to log errors and fail the test if necessary.
+// - rootCertPEM: The root certificate in PEM format.
+// - rootKeyPEM: The root private key in PEM format.
+//
+// Returns:
+// - *bytes.Buffer: The client certificate in PEM format.
+// - *bytes.Buffer: The client private key in PEM format.
+// - error: Any error encountered during the generation.
+func GenerateClientCertAndKeyPEM(tb testing.TB, rootCertPEM, rootKeyPEM []byte) (*bytes.Buffer, *bytes.Buffer, error) {
+	tb.Helper()
+	// Decode the root certificate
+	rootCertBlock, _ := pem.Decode(rootCertPEM)
+	if rootCertBlock == nil || rootCertBlock.Type != "CERTIFICATE" {
+		return nil, nil, fmt.Errorf("failed to decode root certificate PEM")
+	}
+	rootCert, err := x509.ParseCertificate(rootCertBlock.Bytes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Decode the root private key
+	rootKeyBlock, _ := pem.Decode(rootKeyPEM)
+	if rootKeyBlock == nil || rootKeyBlock.Type != "RSA PRIVATE KEY" {
+		return nil, nil, fmt.Errorf("failed to decode root key PEM")
+	}
+	rootKey, err := x509.ParsePKCS1PrivateKey(rootKeyBlock.Bytes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Generate RSA key pair for the client
+	clientKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Create a template for the client certificate
+	clientCertTemplate := x509.Certificate{
+		SerialNumber: big.NewInt(3),
+		Subject: pkix.Name{
+			Organization:  []string{"Tyk Technologies Ltd"},
+			Country:       []string{"UK"},
+			Province:      []string{"London"},
+			Locality:      []string{"London"},
+			StreetAddress: []string{"Worship Street"},
+		},
+		NotBefore:   time.Now(),
+		NotAfter:    time.Now().AddDate(1, 0, 0), // 1 year
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	// Create the client certificate signed by the root CA
+	clientCertDER, err := x509.CreateCertificate(rand.Reader, &clientCertTemplate, rootCert, &clientKey.PublicKey, rootKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Encode the client certificate to PEM format
+	var clientCertPEM bytes.Buffer
+	_ = pem.Encode(&clientCertPEM, &pem.Block{Type: "CERTIFICATE", Bytes: clientCertDER})
+
+	// Encode the client private key to PEM format
+	var clientKeyPEM bytes.Buffer
+	_ = pem.Encode(&clientKeyPEM, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(clientKey)})
+
+	return &clientCertPEM, &clientKeyPEM, nil
+}
+
+// GenerateClientCertAndKeyChain generates a client certificate and private key signed by the given root certificate and key,
+// and includes the root certificate in the chain for testing purposes.
+// It returns the client certificate chain and private key in PEM format along with an error, if any.
+//
+// Parameters:
+// - tb: The testing.TB instance to log errors and fail the test if necessary.
+// - rootCertPEM: The root certificate in PEM format.
+// - rootKeyPEM: The root private key in PEM format.
+//
+// Returns:
+// - *bytes.Buffer: The client certificate chain in PEM format.
+// - *bytes.Buffer: The client private key in PEM format.
+// - error: Any error encountered during the generation.
+func GenerateClientCertAndKeyChain(tb testing.TB, rootCertPEM, rootKeyPEM []byte) (*bytes.Buffer, *bytes.Buffer, error) {
+	tb.Helper()
+	clientCertPEM, clientKeyPEM, err := GenerateClientCertAndKeyPEM(tb, rootCertPEM, rootKeyPEM)
+	assert.NoError(tb, err)
+	// Include the root certificate in the client certificate chain
+	_, _ = clientCertPEM.Write(rootCertPEM)
+
+	return clientCertPEM, clientKeyPEM, nil
+}


### PR DESCRIPTION
### **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description
mTLS: allow validating client certificates against root certificate authority
## Related Issue
Parent: https://tyktech.atlassian.net/browse/TT-1570
Subtask: https://tyktech.atlassian.net/browse/TT-12587
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added comprehensive tests for validating client certificates against a root certificate authority in mutual TLS scenarios.
- Implemented helper functions to generate root, server, and client certificates and keys for testing purposes.
- Enhanced the `ValidateRequestCerts` function to handle multiple peer certificates and improved error handling.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cert_test.go</strong><dd><code>Add mTLS validation tests and certificate generation helpers</code></dd></summary>
<hr>

gateway/cert_test.go

<li>Added tests for validating client certificates against a root <br>certificate authority.<br> <li> Implemented helper functions to generate root, server, and client <br>certificates and keys.<br> <li> Enhanced mutual TLS tests to include valid and invalid client <br>scenarios.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6405/files#diff-481696cb18de8c3880e0ca21318fe00fd4eb89bc48994e43b7c34729ef4a7ee2">+328/-0</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>helpers.go</strong><dd><code>Enhance certificate validation logic in mTLS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/crypto/helpers.go

<li>Modified <code>ValidateRequestCerts</code> to handle multiple peer certificates.<br> <li> Improved error handling for certificate validation.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6405/files#diff-3d1fc755c46eaa99e9f1edf358b9e00842342ae6333902959d7a68b46d156829">+22/-17</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

