### PR TITLE
[SYSE-370 release-5.3] June template application

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -283,9 +283,8 @@ jobs:
           BASE_REF: ${{startsWith(github.event_name, 'pull_request') && github.base_ref || github.ref_name}}
         run: |
           match_tag=${{steps.ecr.outputs.registry}}/$REPO:$BASE_REF
-          docker run -q --rm -v ~/.docker/config.json:/root/.docker/config.json tykio/gromit policy match ${match_tag} 2>versions.env
           tags=(${{ needs.goreleaser.outputs.tags }})
-          tyk_image=${tags[0]}
+          docker run -q --rm -v ~/.docker/config.json:/root/.docker/config.json tykio/gromit policy match ${tags[0]} ${match_tag} 2>versions.env
           echo '# alfa and beta have to come after the override
           tyk_alfa_image=$tyk_image
           tyk_beta_image=$tyk_image


### PR DESCRIPTION
- [x] Images not being pushed to dockerhub on tag when distroless feature is missing
- [x] Policy match fix
- [x] Fix github ref name for test-controller ui on push trigger
- [x] Test controller UI missing conf for push event and other missconfigs
- [x] Test controller UI duplicated lines under pump & sink
- [ ] Quality gates for tyk-analitycs UI and API regression tests
- [x] release-5.3 is not treated correctly in test-controller logic
- [ ] Implement custom rules for enterprise artifacts in package promotion
- [x] Test controller UI
- [x] Accomodate templates for new controller UI
- [x] Add mongo7 and redis7 with cache_DB config field
