### PR TITLE
[TT-12587] verify root CA on certificate check mw

### DIFF
--- a/internal/crypto/helpers.go
+++ b/internal/crypto/helpers.go
@@ -108,6 +108,15 @@ func ValidateRequestCerts(r *http.Request, certs []*tls.Certificate) error {
 		if cert.Leaf.IsCA && verifyCertAgainstCA(cert, peerCertificate) {
 			return nil
 		}
+
+		// Extensions[0] contains cache of certificate SHA256
+		if string(cert.Leaf.Extensions[0].Value) == certID {
+			if time.Now().After(cert.Leaf.NotAfter) {
+				return ErrCertExpired
+			}
+			// Happy flow, we matched a certificate
+			return nil
+		}
 	}
 
 	return errors.New("Certificate with SHA256 " + certID + " not allowed")

--- a/internal/crypto/helpers.go
+++ b/internal/crypto/helpers.go
@@ -97,6 +97,7 @@ func ValidateRequestCerts(r *http.Request, certs []*tls.Certificate) error {
 		return errors.New("Client TLS certificate is required")
 	}
 
+	// Loop through r.TLS.PeerCertificates to add intermediate CA certificates to the allow list.
 	for _, peerCertificate := range r.TLS.PeerCertificates {
 		certID := HexSHA256(peerCertificate.Raw)
 

--- a/internal/crypto/helpers.go
+++ b/internal/crypto/helpers.go
@@ -105,7 +105,7 @@ func ValidateRequestCerts(r *http.Request, certs []*tls.Certificate) error {
 			continue
 		}
 
-		if cert.Leaf.IsCA && verifyCertAgainstCA(cert, peerCertificate) {
+		if cert.Leaf.IsCA && verifyCertAgainstCA(cert, peerCertificate) == nil {
 			return nil
 		}
 
@@ -122,7 +122,7 @@ func ValidateRequestCerts(r *http.Request, certs []*tls.Certificate) error {
 	return errors.New("Certificate with SHA256 " + certID + " not allowed")
 }
 
-func verifyCertAgainstCA(caCert *tls.Certificate, peerCert *x509.Certificate) bool {
+func verifyCertAgainstCA(caCert *tls.Certificate, peerCert *x509.Certificate) error {
 	// Create a certificate pool and add the CA certificate to it
 	roots := x509.NewCertPool()
 	roots.AddCert(caCert.Leaf)
@@ -134,7 +134,7 @@ func verifyCertAgainstCA(caCert *tls.Certificate, peerCert *x509.Certificate) bo
 
 	// Verify the client certificate
 	_, err := peerCert.Verify(opts)
-	return err == nil
+	return err
 }
 
 // IsPublicKey verifies if given certificate is a public key only.


### PR DESCRIPTION
### **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description
Verify uploaded root CA certificate against client certificate in certificate check middleware.
Loop through peer certificate and do the checks so that intermediate CAs can also be added to allow list.

## Related Issue
https://tyktech.atlassian.net/browse/TT-12587

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added functionality to verify the uploaded root CA certificate against the client certificate in the certificate check middleware.
- Refactored the existing logic to simplify peer certificate handling.
- Introduced a new helper function `verifyCertAgainstCA` to encapsulate the CA verification logic.
- Improved error handling for scenarios where certificates are invalid or expired.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>helpers.go</strong><dd><code>Enhance mTLS validation with CA certificate verification</code>&nbsp; </dd></summary>
<hr>

internal/crypto/helpers.go

<li>Added verification of client certificate against CA certificate.<br> <li> Refactored the logic to handle peer certificates.<br> <li> Introduced <code>verifyCertAgainstCA</code> function to encapsulate CA <br>verification.<br> <li> Improved error handling for certificate validation.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6422/files#diff-3d1fc755c46eaa99e9f1edf358b9e00842342ae6333902959d7a68b46d156829">+29/-22</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

