### PR TITLE
[TT-12688] Ensure OAS API paths get applied to gateway by length, sort by path

### DIFF
--- a/apidef/oas/oasutil.go
+++ b/apidef/oas/oasutil.go
@@ -2,59 +2,11 @@ package oas
 
 import (
 	"encoding/json"
-	"math"
-	"reflect"
+
+	"github.com/TykTechnologies/tyk/internal/reflect"
 )
 
-// ShouldOmit checks if a field should be set to empty and omitted from OAS JSON.
-func ShouldOmit(i interface{}) bool {
-	return IsZero(reflect.ValueOf(i))
-}
-
-// IsZero is a customized implementation of reflect.Value.IsZero. The built-in function accepts slice, map and pointer fields
-// having 0 length as not zero. In OAS, we would like them to be counted as empty so we separated slice, map and pointer to
-// different cases.
-func IsZero(v reflect.Value) bool {
-	switch v.Kind() {
-	case reflect.Bool:
-		return !v.Bool()
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return v.Int() == 0
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-		return v.Uint() == 0
-	case reflect.Float32, reflect.Float64:
-		return math.Float64bits(v.Float()) == 0
-	case reflect.Complex64, reflect.Complex128:
-		c := v.Complex()
-		return math.Float64bits(real(c)) == 0 && math.Float64bits(imag(c)) == 0
-	case reflect.Array:
-		for i := 0; i < v.Len(); i++ {
-			if !IsZero(v.Index(i)) {
-				return false
-			}
-		}
-		return true
-	case reflect.Chan, reflect.Func, reflect.Interface, reflect.UnsafePointer:
-		return v.IsNil()
-	case reflect.Ptr:
-		return v.IsNil() || IsZero(v.Elem())
-	case reflect.Slice, reflect.Map:
-		return v.Len() == 0
-	case reflect.String:
-		return v.Len() == 0
-	case reflect.Struct:
-		for i := 0; i < v.NumField(); i++ {
-			if !IsZero(v.Field(i)) {
-				return false
-			}
-		}
-		return true
-	default:
-		// This should never happens, but will act as a safeguard for
-		// later, as a default value doesn't makes sense here.
-		panic(&reflect.ValueError{Method: "oas.IsZero", Kind: v.Kind()})
-	}
-}
+var ShouldOmit = reflect.IsEmpty
 
 func toStructIfMap(input interface{}, val interface{}) bool {
 	mapInput, ok := input.(map[string]interface{})

--- a/apidef/oas/oasutil.go
+++ b/apidef/oas/oasutil.go
@@ -6,8 +6,6 @@ import (
 	"github.com/TykTechnologies/tyk/internal/reflect"
 )
 
-var ShouldOmit = reflect.IsEmpty
-
 func toStructIfMap(input interface{}, val interface{}) bool {
 	mapInput, ok := input.(map[string]interface{})
 	if !ok {
@@ -26,3 +24,6 @@ func toStructIfMap(input interface{}, val interface{}) bool {
 
 	return true
 }
+
+// ShouldOmit is a compatibility alias. It may be removed in the future.
+var ShouldOmit = reflect.IsEmpty

--- a/apidef/oas/operation.go
+++ b/apidef/oas/operation.go
@@ -176,28 +176,28 @@ func (s *OAS) extractPathsAndOperations(ep *apidef.ExtendedPathsSet) {
 	for id, tykOp := range tykOperations {
 	found:
 		for _, pathItem := range oasutil.SortByPathLength(s.Paths) {
-			pathURL := pathItem.Value
-			for method, operation := range pathItem.Item.Operations() {
+			path := pathItem.Path
+			for method, operation := range pathItem.Operations() {
 				if id == operation.OperationID {
-					tykOp.extractAllowanceTo(ep, pathURL, method, allow)
-					tykOp.extractAllowanceTo(ep, pathURL, method, block)
-					tykOp.extractAllowanceTo(ep, pathURL, method, ignoreAuthentication)
-					tykOp.extractInternalTo(ep, pathURL, method)
-					tykOp.extractTransformRequestMethodTo(ep, pathURL, method)
-					tykOp.extractTransformRequestBodyTo(ep, pathURL, method)
-					tykOp.extractTransformResponseBodyTo(ep, pathURL, method)
-					tykOp.extractTransformRequestHeadersTo(ep, pathURL, method)
-					tykOp.extractTransformResponseHeadersTo(ep, pathURL, method)
-					tykOp.extractURLRewriteTo(ep, pathURL, method)
-					tykOp.extractCacheTo(ep, pathURL, method)
-					tykOp.extractEnforceTimeoutTo(ep, pathURL, method)
-					tykOp.extractVirtualEndpointTo(ep, pathURL, method)
-					tykOp.extractEndpointPostPluginTo(ep, pathURL, method)
-					tykOp.extractCircuitBreakerTo(ep, pathURL, method)
-					tykOp.extractTrackEndpointTo(ep, pathURL, method)
-					tykOp.extractDoNotTrackEndpointTo(ep, pathURL, method)
-					tykOp.extractRequestSizeLimitTo(ep, pathURL, method)
-					tykOp.extractRateLimitEndpointTo(ep, pathURL, method)
+					tykOp.extractAllowanceTo(ep, path, method, allow)
+					tykOp.extractAllowanceTo(ep, path, method, block)
+					tykOp.extractAllowanceTo(ep, path, method, ignoreAuthentication)
+					tykOp.extractInternalTo(ep, path, method)
+					tykOp.extractTransformRequestMethodTo(ep, path, method)
+					tykOp.extractTransformRequestBodyTo(ep, path, method)
+					tykOp.extractTransformResponseBodyTo(ep, path, method)
+					tykOp.extractTransformRequestHeadersTo(ep, path, method)
+					tykOp.extractTransformResponseHeadersTo(ep, path, method)
+					tykOp.extractURLRewriteTo(ep, path, method)
+					tykOp.extractCacheTo(ep, path, method)
+					tykOp.extractEnforceTimeoutTo(ep, path, method)
+					tykOp.extractVirtualEndpointTo(ep, path, method)
+					tykOp.extractEndpointPostPluginTo(ep, path, method)
+					tykOp.extractCircuitBreakerTo(ep, path, method)
+					tykOp.extractTrackEndpointTo(ep, path, method)
+					tykOp.extractDoNotTrackEndpointTo(ep, path, method)
+					tykOp.extractRequestSizeLimitTo(ep, path, method)
+					tykOp.extractRateLimitEndpointTo(ep, path, method)
 					break found
 				}
 			}

--- a/apidef/oas/operation.go
+++ b/apidef/oas/operation.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -170,6 +171,8 @@ type pathItem struct {
 	pathValue string
 }
 
+var pathParamRegex = regexp.MustCompile(`\{[^}]+\}`)
+
 func sortByPathLength(in openapi3.Paths) []pathItem {
 	// get urls
 	paths := []string{}
@@ -177,11 +180,14 @@ func sortByPathLength(in openapi3.Paths) []pathItem {
 		paths = append(paths, k)
 	}
 
-	// sort by length
+	// sort by length and lexicographically
 	sort.Slice(paths, func(i, j int) bool {
-		il, jl := len(paths[i]), len(paths[j])
+		pathI := pathParamRegex.ReplaceAllString(paths[i], "")
+		pathJ := pathParamRegex.ReplaceAllString(paths[j], "")
+
+		il, jl := len(pathI), len(pathJ)
 		if il == jl {
-			return paths[i] < paths[j]
+			return pathI < pathJ
 		}
 		return il > jl
 	})

--- a/apidef/oas/operation_test.go
+++ b/apidef/oas/operation_test.go
@@ -252,6 +252,7 @@ func TestOAS_sortByPathLength(t *testing.T) {
 		"/test/c":       nil,
 		"/test/sub1":    nil,
 		"/test/sub{id}": nil,
+		"/test/sub2":    nil,
 		"/test":         nil,
 		"/test/{id}":    nil,
 	}
@@ -265,6 +266,7 @@ func TestOAS_sortByPathLength(t *testing.T) {
 
 	want := []string{
 		"/test/sub1",
+		"/test/sub2",
 		"/test/sub{id}",
 		"/test/a",
 		"/test/b",

--- a/apidef/oas/operation_test.go
+++ b/apidef/oas/operation_test.go
@@ -244,3 +244,23 @@ func TestOAS_RegexPaths(t *testing.T) {
 		assert.Equalf(t, tc.input, got, "test %d: rebuilt link, expected %v, got %v", i, tc.input, got)
 	}
 }
+
+func TestOAS_sortByPathLength(t *testing.T) {
+	paths := openapi3.Paths{
+		"/test/a":    nil,
+		"/test/b":    nil,
+		"/test/c":    nil,
+		"/test/sub1": nil,
+		"/test":      nil,
+		"/test/sub2": nil,
+	}
+
+	out := sortByPathLength(paths)
+	assert.Len(t, out, 6)
+	assert.Equal(t, "/test/sub1", out[0].pathValue)
+	assert.Equal(t, "/test/sub2", out[1].pathValue)
+	assert.Equal(t, "/test/a", out[2].pathValue)
+	assert.Equal(t, "/test/b", out[3].pathValue)
+	assert.Equal(t, "/test/c", out[4].pathValue)
+	assert.Equal(t, "/test", out[5].pathValue)
+}

--- a/apidef/oas/operation_test.go
+++ b/apidef/oas/operation_test.go
@@ -244,37 +244,3 @@ func TestOAS_RegexPaths(t *testing.T) {
 		assert.Equalf(t, tc.input, got, "test %d: rebuilt link, expected %v, got %v", i, tc.input, got)
 	}
 }
-
-func TestOAS_sortByPathLength(t *testing.T) {
-	paths := openapi3.Paths{
-		"/test/a":       nil,
-		"/test/b":       nil,
-		"/test/c":       nil,
-		"/test/sub1":    nil,
-		"/test/sub{id}": nil,
-		"/test/sub2":    nil,
-		"/test":         nil,
-		"/test/{id}":    nil,
-	}
-
-	out := sortByPathLength(paths)
-
-	got := []string{}
-	for _, v := range out {
-		got = append(got, v.pathValue)
-	}
-
-	want := []string{
-		"/test/sub1",
-		"/test/sub2",
-		"/test/sub{id}",
-		"/test/a",
-		"/test/b",
-		"/test/c",
-		"/test/{id}",
-		"/test",
-	}
-
-	assert.Equal(t, want, got)
-
-}

--- a/apidef/oas/operation_test.go
+++ b/apidef/oas/operation_test.go
@@ -247,20 +247,32 @@ func TestOAS_RegexPaths(t *testing.T) {
 
 func TestOAS_sortByPathLength(t *testing.T) {
 	paths := openapi3.Paths{
-		"/test/a":    nil,
-		"/test/b":    nil,
-		"/test/c":    nil,
-		"/test/sub1": nil,
-		"/test":      nil,
-		"/test/sub2": nil,
+		"/test/a":       nil,
+		"/test/b":       nil,
+		"/test/c":       nil,
+		"/test/sub1":    nil,
+		"/test/sub{id}": nil,
+		"/test":         nil,
+		"/test/{id}":    nil,
 	}
 
 	out := sortByPathLength(paths)
-	assert.Len(t, out, 6)
-	assert.Equal(t, "/test/sub1", out[0].pathValue)
-	assert.Equal(t, "/test/sub2", out[1].pathValue)
-	assert.Equal(t, "/test/a", out[2].pathValue)
-	assert.Equal(t, "/test/b", out[3].pathValue)
-	assert.Equal(t, "/test/c", out[4].pathValue)
-	assert.Equal(t, "/test", out[5].pathValue)
+
+	got := []string{}
+	for _, v := range out {
+		got = append(got, v.pathValue)
+	}
+
+	want := []string{
+		"/test/sub1",
+		"/test/sub{id}",
+		"/test/a",
+		"/test/b",
+		"/test/c",
+		"/test/{id}",
+		"/test",
+	}
+
+	assert.Equal(t, want, got)
+
 }

--- a/internal/oasutil/paths.go
+++ b/internal/oasutil/paths.go
@@ -67,14 +67,3 @@ func SortByPathLength(in openapi3.Paths) []PathItem {
 
 	return ExtractPaths(in, paths)
 }
-
-// SortByMatchingOrder returns paths in matching order from
-// the kin-openapi library.
-//
-// Check the test function for sorting expectations.
-func SortByMatchingOrder(in openapi3.Paths) []PathItem {
-	// get urls
-	paths := in.InMatchingOrder()
-
-	return ExtractPaths(in, paths)
-}

--- a/internal/oasutil/paths.go
+++ b/internal/oasutil/paths.go
@@ -55,3 +55,24 @@ func SortByPathLength(in openapi3.Paths) []PathItem {
 
 	return result
 }
+
+// SortByMatchingOrder returns paths in matching order from
+// the kin-openapi library.
+//
+// Check the test function for sorting expectations.
+func SortByMatchingOrder(in openapi3.Paths) []PathItem {
+	// get urls
+	paths := in.InMatchingOrder()
+
+	// collect url and pathItem
+	result := []PathItem{}
+	for _, v := range paths {
+		value := PathItem{
+			PathItem: in[v],
+			Path:     v,
+		}
+		result = append(result, value)
+	}
+
+	return result
+}

--- a/internal/oasutil/paths.go
+++ b/internal/oasutil/paths.go
@@ -7,14 +7,23 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
+// PathItem holds the path to a particular OAS path item.
 type PathItem struct {
+	// PathItem represents an openapi3.Paths value.
 	*openapi3.PathItem
 
+	// Path is an openapi3.Paths key, the endpoint URL.
 	Path string
 }
 
 var pathParamRegex = regexp.MustCompile(`\{[^}]+\}`)
 
+// SortByPathLength decomposes an openapi3.Paths to a sorted []PathItem.
+// The sorting takes the length of the paths into account, as well as
+// path parameters, sorting them by length descending, and ordering
+// path parameters after the statically defined paths.
+//
+// Check the test function for sorting expectations.
 func SortByPathLength(in openapi3.Paths) []PathItem {
 	// get urls
 	paths := []string{}

--- a/internal/oasutil/paths.go
+++ b/internal/oasutil/paths.go
@@ -52,6 +52,13 @@ func SortByPathLength(in openapi3.Paths) []PathItem {
 		pathI := pathParamRegex.ReplaceAllString(paths[i], "")
 		pathJ := pathParamRegex.ReplaceAllString(paths[j], "")
 
+		// handle /sub and /sub{id} order with raw path.
+		if pathI == pathJ {
+			// we're reversing indexes here so path with
+			// parameter is sorted after the literal.
+			pathI, pathJ = paths[j], paths[i]
+		}
+
 		// sort by number of path fragments
 		k, v := strings.Count(pathI, "/"), strings.Count(pathJ, "/")
 		if k != v {

--- a/internal/oasutil/paths.go
+++ b/internal/oasutil/paths.go
@@ -8,8 +8,9 @@ import (
 )
 
 type PathItem struct {
-	Item  *openapi3.PathItem
-	Value string
+	*openapi3.PathItem
+
+	Path string
 }
 
 var pathParamRegex = regexp.MustCompile(`\{[^}]+\}`)
@@ -37,8 +38,8 @@ func SortByPathLength(in openapi3.Paths) []PathItem {
 	result := []PathItem{}
 	for _, v := range paths {
 		value := PathItem{
-			Item:  in[v],
-			Value: v,
+			PathItem: in[v],
+			Path:     v,
 		}
 		result = append(result, value)
 	}

--- a/internal/oasutil/paths.go
+++ b/internal/oasutil/paths.go
@@ -1,0 +1,47 @@
+package oasutil
+
+import (
+	"regexp"
+	"sort"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+type PathItem struct {
+	Item  *openapi3.PathItem
+	Value string
+}
+
+var pathParamRegex = regexp.MustCompile(`\{[^}]+\}`)
+
+func SortByPathLength(in openapi3.Paths) []PathItem {
+	// get urls
+	paths := []string{}
+	for k := range in {
+		paths = append(paths, k)
+	}
+
+	// sort by length and lexicographically
+	sort.Slice(paths, func(i, j int) bool {
+		pathI := pathParamRegex.ReplaceAllString(paths[i], "")
+		pathJ := pathParamRegex.ReplaceAllString(paths[j], "")
+
+		il, jl := len(pathI), len(pathJ)
+		if il == jl {
+			return pathI < pathJ
+		}
+		return il > jl
+	})
+
+	// collect url and pathItem
+	result := []PathItem{}
+	for _, v := range paths {
+		value := PathItem{
+			Item:  in[v],
+			Value: v,
+		}
+		result = append(result, value)
+	}
+
+	return result
+}

--- a/internal/oasutil/paths.go
+++ b/internal/oasutil/paths.go
@@ -3,6 +3,7 @@ package oasutil
 import (
 	"regexp"
 	"sort"
+	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
 )
@@ -35,6 +36,12 @@ func SortByPathLength(in openapi3.Paths) []PathItem {
 	sort.Slice(paths, func(i, j int) bool {
 		pathI := pathParamRegex.ReplaceAllString(paths[i], "")
 		pathJ := pathParamRegex.ReplaceAllString(paths[j], "")
+
+		// sort by number of path fragments
+		k, v := strings.Count(pathI, "/"), strings.Count(pathJ, "/")
+		if k != v {
+			return k > v
+		}
 
 		il, jl := len(pathI), len(pathJ)
 		if il == jl {

--- a/internal/oasutil/paths.go
+++ b/internal/oasutil/paths.go
@@ -19,6 +19,21 @@ type PathItem struct {
 
 var pathParamRegex = regexp.MustCompile(`\{[^}]+\}`)
 
+// ExtractPaths will extract paths with the given order.
+func ExtractPaths(in openapi3.Paths, order []string) []PathItem {
+	// collect url and pathItem
+	result := []PathItem{}
+	for _, v := range order {
+		value := PathItem{
+			PathItem: in[v],
+			Path:     v,
+		}
+		result = append(result, value)
+	}
+
+	return result
+}
+
 // SortByPathLength decomposes an openapi3.Paths to a sorted []PathItem.
 // The sorting takes the length of the paths into account, as well as
 // path parameters, sorting them by length descending, and ordering
@@ -50,17 +65,7 @@ func SortByPathLength(in openapi3.Paths) []PathItem {
 		return il > jl
 	})
 
-	// collect url and pathItem
-	result := []PathItem{}
-	for _, v := range paths {
-		value := PathItem{
-			PathItem: in[v],
-			Path:     v,
-		}
-		result = append(result, value)
-	}
-
-	return result
+	return ExtractPaths(in, paths)
 }
 
 // SortByMatchingOrder returns paths in matching order from
@@ -71,15 +76,5 @@ func SortByMatchingOrder(in openapi3.Paths) []PathItem {
 	// get urls
 	paths := in.InMatchingOrder()
 
-	// collect url and pathItem
-	result := []PathItem{}
-	for _, v := range paths {
-		value := PathItem{
-			PathItem: in[v],
-			Path:     v,
-		}
-		result = append(result, value)
-	}
-
-	return result
+	return ExtractPaths(in, paths)
 }

--- a/internal/oasutil/paths_test.go
+++ b/internal/oasutil/paths_test.go
@@ -9,14 +9,16 @@ import (
 
 func TestSortByPathLength(t *testing.T) {
 	paths := openapi3.Paths{
-		"/test/a":       nil,
-		"/test/b":       nil,
-		"/test/c":       nil,
-		"/test/sub1":    nil,
-		"/test/sub{id}": nil,
-		"/test/sub2":    nil,
-		"/test":         nil,
-		"/test/{id}":    nil,
+		"/test/a":           nil,
+		"/test/b":           nil,
+		"/test/c":           nil,
+		"/test/{id}/asset":  nil,
+		"/test/{id}/{file}": nil,
+		"/test/sub1":        nil,
+		"/test/sub{id}":     nil,
+		"/test/sub2":        nil,
+		"/test":             nil,
+		"/test/{id}":        nil,
 	}
 
 	out := SortByPathLength(paths)
@@ -27,9 +29,11 @@ func TestSortByPathLength(t *testing.T) {
 	}
 
 	want := []string{
+		"/test/{id}/asset",
 		"/test/sub1",
 		"/test/sub2",
 		"/test/sub{id}",
+		"/test/{id}/{file}",
 		"/test/a",
 		"/test/b",
 		"/test/c",
@@ -38,5 +42,41 @@ func TestSortByPathLength(t *testing.T) {
 	}
 
 	assert.Equal(t, want, got)
+}
 
+func TestSortByMatchingOrder(t *testing.T) {
+	paths := openapi3.Paths{
+		"/test/a":           nil,
+		"/test/b":           nil,
+		"/test/c":           nil,
+		"/test/{id}/asset":  nil,
+		"/test/{id}/{file}": nil,
+		"/test/sub1":        nil,
+		"/test/sub{id}":     nil,
+		"/test/sub2":        nil,
+		"/test":             nil,
+		"/test/{id}":        nil,
+	}
+
+	out := SortByMatchingOrder(paths)
+
+	got := []string{}
+	for _, v := range out {
+		got = append(got, v.Path)
+	}
+
+	want := []string{
+		"/test/sub2",
+		"/test/sub1",
+		"/test/c",
+		"/test/b",
+		"/test/a",
+		"/test",
+		"/test/{id}/asset",
+		"/test/{id}",
+		"/test/sub{id}",
+		"/test/{id}/{file}",
+	}
+
+	assert.Equal(t, want, got)
 }

--- a/internal/oasutil/paths_test.go
+++ b/internal/oasutil/paths_test.go
@@ -1,0 +1,42 @@
+package oasutil
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSortByPathLength(t *testing.T) {
+	paths := openapi3.Paths{
+		"/test/a":       nil,
+		"/test/b":       nil,
+		"/test/c":       nil,
+		"/test/sub1":    nil,
+		"/test/sub{id}": nil,
+		"/test/sub2":    nil,
+		"/test":         nil,
+		"/test/{id}":    nil,
+	}
+
+	out := SortByPathLength(paths)
+
+	got := []string{}
+	for _, v := range out {
+		got = append(got, v.Value)
+	}
+
+	want := []string{
+		"/test/sub1",
+		"/test/sub2",
+		"/test/sub{id}",
+		"/test/a",
+		"/test/b",
+		"/test/c",
+		"/test/{id}",
+		"/test",
+	}
+
+	assert.Equal(t, want, got)
+
+}

--- a/internal/oasutil/paths_test.go
+++ b/internal/oasutil/paths_test.go
@@ -7,19 +7,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var testPathsForSorting = openapi3.Paths{
+	"/test/a":           nil,
+	"/test/b":           nil,
+	"/test/c":           nil,
+	"/test/{id}/asset":  nil,
+	"/test/{id}/{file}": nil,
+	"/test/sub":         nil,
+	"/test/sub1":        nil,
+	"/test/sub{id}":     nil,
+	"/test/sub2":        nil,
+	"/test":             nil,
+	"/test/{id}":        nil,
+}
+
 func TestSortByPathLength(t *testing.T) {
-	paths := openapi3.Paths{
-		"/test/a":           nil,
-		"/test/b":           nil,
-		"/test/c":           nil,
-		"/test/{id}/asset":  nil,
-		"/test/{id}/{file}": nil,
-		"/test/sub1":        nil,
-		"/test/sub{id}":     nil,
-		"/test/sub2":        nil,
-		"/test":             nil,
-		"/test/{id}":        nil,
-	}
+	paths := testPathsForSorting
 
 	out := SortByPathLength(paths)
 
@@ -33,6 +36,7 @@ func TestSortByPathLength(t *testing.T) {
 		"/test/{id}/{file}",
 		"/test/sub1",
 		"/test/sub2",
+		"/test/sub",
 		"/test/sub{id}",
 		"/test/a",
 		"/test/b",
@@ -45,18 +49,7 @@ func TestSortByPathLength(t *testing.T) {
 }
 
 func TestSortByMatchingOrder(t *testing.T) {
-	paths := openapi3.Paths{
-		"/test/a":           nil,
-		"/test/b":           nil,
-		"/test/c":           nil,
-		"/test/{id}/asset":  nil,
-		"/test/{id}/{file}": nil,
-		"/test/sub1":        nil,
-		"/test/sub{id}":     nil,
-		"/test/sub2":        nil,
-		"/test":             nil,
-		"/test/{id}":        nil,
-	}
+	paths := testPathsForSorting
 
 	out := SortByMatchingOrder(paths)
 
@@ -68,6 +61,7 @@ func TestSortByMatchingOrder(t *testing.T) {
 	want := []string{
 		"/test/sub2",
 		"/test/sub1",
+		"/test/sub",
 		"/test/c",
 		"/test/b",
 		"/test/a",

--- a/internal/oasutil/paths_test.go
+++ b/internal/oasutil/paths_test.go
@@ -21,6 +21,7 @@ var testPathsForSorting = openapi3.Paths{
 	"/test/{id}":        nil,
 }
 
+// TestSortByPathLength tests our custom sorting for the OAS paths.
 func TestSortByPathLength(t *testing.T) {
 	paths := testPathsForSorting
 
@@ -48,10 +49,12 @@ func TestSortByPathLength(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
-func TestSortByMatchingOrder(t *testing.T) {
+// TestExtractPath uses the upstream library to extract an ordered list of paths.
+func TestExtractPaths(t *testing.T) {
 	paths := testPathsForSorting
+	order := paths.InMatchingOrder()
 
-	out := SortByMatchingOrder(paths)
+	out := ExtractPaths(paths, order)
 
 	got := []string{}
 	for _, v := range out {

--- a/internal/oasutil/paths_test.go
+++ b/internal/oasutil/paths_test.go
@@ -30,10 +30,10 @@ func TestSortByPathLength(t *testing.T) {
 
 	want := []string{
 		"/test/{id}/asset",
+		"/test/{id}/{file}",
 		"/test/sub1",
 		"/test/sub2",
 		"/test/sub{id}",
-		"/test/{id}/{file}",
 		"/test/a",
 		"/test/b",
 		"/test/c",
@@ -74,7 +74,7 @@ func TestSortByMatchingOrder(t *testing.T) {
 		"/test",
 		"/test/{id}/asset",
 		"/test/{id}",
-		"/test/sub{id}",
+		"/test/sub{id}", // this is problematic, should be one line up
 		"/test/{id}/{file}",
 	}
 

--- a/internal/oasutil/paths_test.go
+++ b/internal/oasutil/paths_test.go
@@ -23,7 +23,7 @@ func TestSortByPathLength(t *testing.T) {
 
 	got := []string{}
 	for _, v := range out {
-		got = append(got, v.Value)
+		got = append(got, v.Path)
 	}
 
 	want := []string{


### PR DESCRIPTION
### **User description**
This enforces path conversions between OAS paths (map) to classic paths (ordered).

For paths like `/test` and `/test/abc`, they /may/ get registered in an invalid order with high probability. This means that middleware defined on /test would run on /test/abc, somewhat close to 50% (random between two options).

The solution is to convert the OAS paths map into an ordered slice. The slice is ordered by the length of the path, placing longer paths before shorter ones. Added a sorting function and a test covering the expectation.

https://tyktech.atlassian.net/browse/TT-12688


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added a new `pathItem` type and `sortByPathLength` function to ensure OAS paths are sorted by length before processing.
- Modified `extractPathsAndOperations` to use the sorted paths, ensuring middleware is applied correctly.
- Added `TestOAS_sortByPathLength` to verify the correct sorting of paths by length.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operation.go</strong><dd><code>Sort OAS paths by length before processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/operation.go

<li>Added a new <code>pathItem</code> type and <code>sortByPathLength</code> function.<br> <li> Modified <code>extractPathsAndOperations</code> to use sorted paths.<br> <li> Ensured paths are processed in order of length, longest first.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6425/files#diff-6d92d2d5b09a5fa7129609bb7cd0d383d015250ec07062b6a93a83257be51fb5">+57/-21</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operation_test.go</strong><dd><code>Add test for sorting OAS paths by length</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/operation_test.go

<li>Added <code>TestOAS_sortByPathLength</code> to verify path sorting.<br> <li> Ensured test cases cover various path lengths and orders.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6425/files#diff-cd234db716d6d2edc97c135ef546021c9ab4fa9282d63964bd155d41635cf964">+20/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

