### PR TITLE
Merging to release-5.4: [TT-12195] : Public playground still shows schema when introspection is turned off (#6397)

### DIFF
--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -903,8 +903,8 @@ func (gw *Gateway) loadGraphQLPlayground(spec *APISpec, subrouter *mux.Router) {
 		}
 
 		err := playgroundTemplate.ExecuteTemplate(rw, playgroundHTMLTemplateName, struct {
-			Url, Schema, PathPrefix string
-		}{endpoint, strconv.Quote(spec.GraphQL.Schema), path.Join(endpoint, playgroundPath)})
+			Url, PathPrefix string
+		}{endpoint, path.Join(endpoint, playgroundPath)})
 
 		if err != nil {
 			rw.WriteHeader(http.StatusInternalServerError)

--- a/templates/playground/index.html
+++ b/templates/playground/index.html
@@ -74,11 +74,9 @@
     // End - Show Error Snackbar
 
     const url = window.location.origin + "{{.Url}}";
-    const schema = {{.Schema}};
     const GraphiQlInitInstance = new window.GraphiqlInit({
       containerId: 'root',
       schemaUrls: [{url}],
-      schema: schema,
       onSubscriptionError: window.showError
     });
   </script>


### PR DESCRIPTION
### **User description**
[TT-12195] : Public playground still shows schema when introspection is turned off (#6397)

### **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description

Schema handling for public playground : Do not show schema by default
for public playground

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Bug fix


___

### **Description**
- Removed the `Schema` field from the struct passed to the GraphQL
playground template in `gateway/api_loader.go`.
- Updated the `GraphiQlInitInstance` initialization in
`templates/playground/index.html` to exclude the `schema` field.
- Ensured that the public playground does not show the schema when
introspection is turned off.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>api_loader.go</strong><dd><code>Remove schema from
GraphQL playground template data</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_loader.go

<li>Removed the <code>Schema</code> field from the struct passed to the
playground <br>template.<br> <li> Updated the struct to only include
<code>Url</code> and <code>PathPrefix</code>.<br>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6397/files#diff-cdf0b7f176c9d18e1a314b78ddefc2cb3a94b3de66f1f360174692c915734c68">+2/-2</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
<summary><strong>index.html</strong><dd><code>Exclude schema from
GraphiQL initialization in playground</code></dd></summary>
<hr>

templates/playground/index.html

<li>Removed the <code>schema</code> variable initialization.<br> <li>
Updated <code>GraphiQlInitInstance</code> initialization to exclude the
<code>schema</code> <br>field.<br>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6397/files#diff-98c2e4a69b270a6e10203409fff11a7ec1253faeaa0c1dd1b5cec5e137dcbf6f">+0/-2</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools
and their descriptions

[TT-12195]: https://tyktech.atlassian.net/browse/TT-12195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix


___

### **Description**
- Removed the schema from the struct passed to the GraphQL playground template in `gateway/api_loader.go`.
- Updated the GraphiQL instance initialization in `templates/playground/index.html` to exclude the schema, ensuring the schema is not shown by default in the public playground.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api_loader.go</strong><dd><code>Remove schema from GraphQL playground template struct</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_loader.go

<li>Removed schema from the struct passed to the playground template.<br> <li> Updated the struct to only include <code>Url</code> and <code>PathPrefix</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6426/files#diff-cdf0b7f176c9d18e1a314b78ddefc2cb3a94b3de66f1f360174692c915734c68">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Update GraphiQL instance initialization to exclude schema</code></dd></summary>
<hr>

templates/playground/index.html

<li>Removed schema initialization in the GraphiQL instance.<br> <li> Updated GraphiQL instance to only use <code>url</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6426/files#diff-98c2e4a69b270a6e10203409fff11a7ec1253faeaa0c1dd1b5cec5e137dcbf6f">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

