### PR TITLE
Merging to release-5.3: [TT-12688] Ensure OAS API paths get applied to gateway by length, sort by path (#6425)

### DIFF
--- a/apidef/oas/oasutil.go
+++ b/apidef/oas/oasutil.go
@@ -2,59 +2,9 @@ package oas
 
 import (
 	"encoding/json"
-	"math"
-	"reflect"
+
+	"github.com/TykTechnologies/tyk/internal/reflect"
 )
-
-// ShouldOmit checks if a field should be set to empty and omitted from OAS JSON.
-func ShouldOmit(i interface{}) bool {
-	return IsZero(reflect.ValueOf(i))
-}
-
-// IsZero is a customized implementation of reflect.Value.IsZero. The built-in function accepts slice, map and pointer fields
-// having 0 length as not zero. In OAS, we would like them to be counted as empty so we separated slice, map and pointer to
-// different cases.
-func IsZero(v reflect.Value) bool {
-	switch v.Kind() {
-	case reflect.Bool:
-		return !v.Bool()
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return v.Int() == 0
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-		return v.Uint() == 0
-	case reflect.Float32, reflect.Float64:
-		return math.Float64bits(v.Float()) == 0
-	case reflect.Complex64, reflect.Complex128:
-		c := v.Complex()
-		return math.Float64bits(real(c)) == 0 && math.Float64bits(imag(c)) == 0
-	case reflect.Array:
-		for i := 0; i < v.Len(); i++ {
-			if !IsZero(v.Index(i)) {
-				return false
-			}
-		}
-		return true
-	case reflect.Chan, reflect.Func, reflect.Interface, reflect.UnsafePointer:
-		return v.IsNil()
-	case reflect.Ptr:
-		return v.IsNil() || IsZero(v.Elem())
-	case reflect.Slice, reflect.Map:
-		return v.Len() == 0
-	case reflect.String:
-		return v.Len() == 0
-	case reflect.Struct:
-		for i := 0; i < v.NumField(); i++ {
-			if !IsZero(v.Field(i)) {
-				return false
-			}
-		}
-		return true
-	default:
-		// This should never happens, but will act as a safeguard for
-		// later, as a default value doesn't makes sense here.
-		panic(&reflect.ValueError{Method: "oas.IsZero", Kind: v.Kind()})
-	}
-}
 
 func toStructIfMap(input interface{}, val interface{}) bool {
 	mapInput, ok := input.(map[string]interface{})
@@ -74,3 +24,6 @@ func toStructIfMap(input interface{}, val interface{}) bool {
 
 	return true
 }
+
+// ShouldOmit is a compatibility alias. It may be removed in the future.
+var ShouldOmit = reflect.IsEmpty

--- a/apidef/oas/operation.go
+++ b/apidef/oas/operation.go
@@ -9,6 +9,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 
 	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/internal/oasutil"
 )
 
 // Operations holds Operation definitions.
@@ -170,7 +171,8 @@ func (s *OAS) extractPathsAndOperations(ep *apidef.ExtendedPathsSet) {
 
 	for id, tykOp := range tykOperations {
 	found:
-		for path, pathItem := range s.Paths {
+		for _, pathItem := range oasutil.SortByPathLength(s.Paths) {
+			path := pathItem.Path
 			for method, operation := range pathItem.Operations() {
 				if id == operation.OperationID {
 					tykOp.extractAllowanceTo(ep, path, method, allow)

--- a/internal/oasutil/paths.go
+++ b/internal/oasutil/paths.go
@@ -1,0 +1,76 @@
+package oasutil
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// PathItem holds the path to a particular OAS path item.
+type PathItem struct {
+	// PathItem represents an openapi3.Paths value.
+	*openapi3.PathItem
+
+	// Path is an openapi3.Paths key, the endpoint URL.
+	Path string
+}
+
+var pathParamRegex = regexp.MustCompile(`\{[^}]+\}`)
+
+// ExtractPaths will extract paths with the given order.
+func ExtractPaths(in openapi3.Paths, order []string) []PathItem {
+	// collect url and pathItem
+	result := []PathItem{}
+	for _, v := range order {
+		value := PathItem{
+			PathItem: in[v],
+			Path:     v,
+		}
+		result = append(result, value)
+	}
+
+	return result
+}
+
+// SortByPathLength decomposes an openapi3.Paths to a sorted []PathItem.
+// The sorting takes the length of the paths into account, as well as
+// path parameters, sorting them by length descending, and ordering
+// path parameters after the statically defined paths.
+//
+// Check the test function for sorting expectations.
+func SortByPathLength(in openapi3.Paths) []PathItem {
+	// get urls
+	paths := []string{}
+	for k := range in {
+		paths = append(paths, k)
+	}
+
+	// sort by length and lexicographically
+	sort.Slice(paths, func(i, j int) bool {
+		pathI := pathParamRegex.ReplaceAllString(paths[i], "")
+		pathJ := pathParamRegex.ReplaceAllString(paths[j], "")
+
+		// handle /sub and /sub{id} order with raw path.
+		if pathI == pathJ {
+			// we're reversing indexes here so path with
+			// parameter is sorted after the literal.
+			pathI, pathJ = paths[j], paths[i]
+		}
+
+		// sort by number of path fragments
+		k, v := strings.Count(pathI, "/"), strings.Count(pathJ, "/")
+		if k != v {
+			return k > v
+		}
+
+		il, jl := len(pathI), len(pathJ)
+		if il == jl {
+			return pathI < pathJ
+		}
+		return il > jl
+	})
+
+	return ExtractPaths(in, paths)
+}

--- a/internal/oasutil/paths_test.go
+++ b/internal/oasutil/paths_test.go
@@ -1,0 +1,79 @@
+package oasutil
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/assert"
+)
+
+var testPathsForSorting = openapi3.Paths{
+	"/test/a":           nil,
+	"/test/b":           nil,
+	"/test/c":           nil,
+	"/test/{id}/asset":  nil,
+	"/test/{id}/{file}": nil,
+	"/test/sub":         nil,
+	"/test/sub1":        nil,
+	"/test/sub{id}":     nil,
+	"/test/sub2":        nil,
+	"/test":             nil,
+	"/test/{id}":        nil,
+}
+
+// TestSortByPathLength tests our custom sorting for the OAS paths.
+func TestSortByPathLength(t *testing.T) {
+	paths := testPathsForSorting
+
+	out := SortByPathLength(paths)
+
+	got := []string{}
+	for _, v := range out {
+		got = append(got, v.Path)
+	}
+
+	want := []string{
+		"/test/{id}/asset",
+		"/test/{id}/{file}",
+		"/test/sub1",
+		"/test/sub2",
+		"/test/sub",
+		"/test/sub{id}",
+		"/test/a",
+		"/test/b",
+		"/test/c",
+		"/test/{id}",
+		"/test",
+	}
+
+	assert.Equal(t, want, got)
+}
+
+// TestExtractPath uses the upstream library to extract an ordered list of paths.
+func TestExtractPaths(t *testing.T) {
+	paths := testPathsForSorting
+	order := paths.InMatchingOrder()
+
+	out := ExtractPaths(paths, order)
+
+	got := []string{}
+	for _, v := range out {
+		got = append(got, v.Path)
+	}
+
+	want := []string{
+		"/test/sub2",
+		"/test/sub1",
+		"/test/sub",
+		"/test/c",
+		"/test/b",
+		"/test/a",
+		"/test",
+		"/test/{id}/asset",
+		"/test/{id}",
+		"/test/sub{id}", // this is problematic, should be one line up
+		"/test/{id}/{file}",
+	}
+
+	assert.Equal(t, want, got)
+}


### PR DESCRIPTION
### **User description**
[TT-12688] Ensure OAS API paths get applied to gateway by length, sort by path (#6425)

### **User description**
This enforces path conversions between OAS paths (map) to classic paths
(ordered).

For paths like `/test` and `/test/abc`, they /may/ get registered in an
invalid order with high probability. This means that middleware defined
on /test would run on /test/abc, somewhat close to 50% (random between
two options).

The solution is to convert the OAS paths map into an ordered slice. The
slice is ordered by the length of the path, placing longer paths before
shorter ones. Added a sorting function and a test covering the
expectation.

https://tyktech.atlassian.net/browse/TT-12688


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added a new `pathItem` type and `sortByPathLength` function to ensure
OAS paths are sorted by length before processing.
- Modified `extractPathsAndOperations` to use the sorted paths, ensuring
middleware is applied correctly.
- Added `TestOAS_sortByPathLength` to verify the correct sorting of
paths by length.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>operation.go</strong><dd><code>Sort OAS paths by length
before processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/operation.go

<li>Added a new <code>pathItem</code> type and
<code>sortByPathLength</code> function.<br> <li> Modified
<code>extractPathsAndOperations</code> to use sorted paths.<br> <li>
Ensured paths are processed in order of length, longest first.<br>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6425/files#diff-6d92d2d5b09a5fa7129609bb7cd0d383d015250ec07062b6a93a83257be51fb5">+57/-21</a>&nbsp;
</td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>operation_test.go</strong><dd><code>Add test for
sorting OAS paths by length</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/operation_test.go

<li>Added <code>TestOAS_sortByPathLength</code> to verify path
sorting.<br> <li> Ensured test cases cover various path lengths and
orders.<br>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6425/files#diff-cd234db716d6d2edc97c135ef546021c9ab4fa9282d63964bd155d41635cf964">+20/-0</a>&nbsp;
&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools
and their descriptions

---------

Co-authored-by: Tit Petric <tit@tyk.io>

[TT-12688]: https://tyktech.atlassian.net/browse/TT-12688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added a new `pathItem` type and `sortByPathLength` function to ensure OAS paths are sorted by length before processing.
- Modified `extractPathsAndOperations` to use the sorted paths, ensuring middleware is applied correctly.
- Added `TestOAS_sortByPathLength` to verify the correct sorting of paths by length.
- Removed custom `IsZero` and `ShouldOmit` functions and replaced them with an alias for `reflect.IsEmpty`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>oasutil.go</strong><dd><code>Refactor OAS utility functions for path processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/oasutil.go

<li>Removed custom <code>IsZero</code> and <code>ShouldOmit</code> functions.<br> <li> Added alias for <code>ShouldOmit</code> to use <code>reflect.IsEmpty</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6428/files#diff-acdca6da0b63041bf4f1979aacab64b344f7a540ffe4decc52574dde5cffbb33">+5/-52</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>paths.go</strong><dd><code>Add utility functions for sorting and extracting OAS paths</code></dd></summary>
<hr>

internal/oasutil/paths.go

<li>Added <code>PathItem</code> struct and <code>SortByPathLength</code> function.<br> <li> Implemented <code>ExtractPaths</code> function.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6428/files#diff-e77fb2a6fdc25b3d4258f9ca23ea27d4ef9885abfb7ba982605ec85bac34c2ed">+76/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operation.go</strong><dd><code>Integrate path sorting in OAS operations extraction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/operation.go

<li>Integrated new path sorting function in <code>extractPathsAndOperations</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6428/files#diff-6d92d2d5b09a5fa7129609bb7cd0d383d015250ec07062b6a93a83257be51fb5">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>paths_test.go</strong><dd><code>Add tests for OAS path utility functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/oasutil/paths_test.go

- Added tests for `SortByPathLength` and `ExtractPaths` functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6428/files#diff-f7100add729da81f3978c1f77efdb68106b5c7cae34c7fd7b70689a1c3896a93">+79/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

