### PR TITLE
[TT-11753] fix thelper.bug.major lint error

### DIFF
--- a/apidef/adapter/gqlengineadapter/utils_test.go
+++ b/apidef/adapter/gqlengineadapter/utils_test.go
@@ -32,6 +32,7 @@ func TestParseSchema(t *testing.T) {
 func TestGraphqlDataSourceWebSocketProtocol(t *testing.T) {
 	run := func(subscriptionType apidef.SubscriptionType, expectedWebSocketProtocol string) func(t *testing.T) {
 		return func(t *testing.T) {
+			t.Helper()
 			actualProtocol := graphqlDataSourceWebSocketProtocol(subscriptionType)
 			assert.Equal(t, expectedWebSocketProtocol, actualProtocol)
 		}
@@ -57,6 +58,7 @@ func TestGraphqlDataSourceWebSocketProtocol(t *testing.T) {
 func TestGraphqlSubscriptionType(t *testing.T) {
 	run := func(subscriptionType apidef.SubscriptionType, expectedGraphQLSubscriptionType graphql.SubscriptionType) func(t *testing.T) {
 		return func(t *testing.T) {
+			t.Helper()
 			actualSubscriptionType := graphqlSubscriptionType(subscriptionType)
 			assert.Equal(t, expectedGraphQLSubscriptionType, actualSubscriptionType)
 		}

--- a/apidef/adapter/utils_test.go
+++ b/apidef/adapter/utils_test.go
@@ -16,6 +16,7 @@ func TestIsSupergraphAPIDefinition(t *testing.T) {
 	}
 	run := func(input testInput) func(t *testing.T) {
 		return func(t *testing.T) {
+			t.Helper()
 			for _, executionMode := range input.executionModes {
 				apiDef := &apidef.APIDefinition{
 					GraphQL: apidef.GraphQLConfig{
@@ -72,6 +73,7 @@ func TestIsProxyOnlyAPIDefinition(t *testing.T) {
 	}
 	run := func(input testInput) func(t *testing.T) {
 		return func(t *testing.T) {
+			t.Helper()
 			for _, executionMode := range input.executionModes {
 				apiDef := &apidef.APIDefinition{
 					GraphQL: apidef.GraphQLConfig{
@@ -128,6 +130,7 @@ func TestIsUniversalDataGraphAPIDefinition(t *testing.T) {
 	}
 	run := func(input testInput) func(t *testing.T) {
 		return func(t *testing.T) {
+			t.Helper()
 			for _, executionMode := range input.executionModes {
 				apiDef := &apidef.APIDefinition{
 					GraphQL: apidef.GraphQLConfig{
@@ -184,6 +187,7 @@ func TestGraphqlEngineAdapterTypeFromApiDefinition(t *testing.T) {
 
 	run := func(input testInput) func(t *testing.T) {
 		return func(t *testing.T) {
+			t.Helper()
 			apiDef := &apidef.APIDefinition{
 				GraphQL: apidef.GraphQLConfig{
 					Enabled:       true,

--- a/apidef/migration_test.go
+++ b/apidef/migration_test.go
@@ -351,6 +351,7 @@ func TestAPIDefinition_MigrateVersioning_StripPath(t *testing.T) {
 	}
 
 	check := func(t *testing.T, base APIDefinition, stripVersioningData bool) {
+		t.Helper()
 		versions, err := base.MigrateVersioning()
 		assert.NoError(t, err)
 

--- a/apidef/oas/default_test.go
+++ b/apidef/oas/default_test.go
@@ -1546,6 +1546,7 @@ func TestOAS_importAuthentication(t *testing.T) {
 
 	t.Run("add first authentication in case of OR condition", func(t *testing.T) {
 		check := func(t *testing.T, enable bool) {
+			t.Helper()
 			oas := OAS{}
 			oas.Security = openapi3.SecurityRequirements{
 				{testSecurityNameToken: []string{}},
@@ -1672,6 +1673,7 @@ func TestOAS_importAuthentication(t *testing.T) {
 
 	t.Run("add multiple authentication with AND condition", func(t *testing.T) {
 		check := func(t *testing.T, enable bool) {
+			t.Helper()
 			oas := OAS{}
 			oas.Security = openapi3.SecurityRequirements{
 				{testSecurityNameToken: []string{}, testSecurityNameJWT: []string{}},
@@ -1754,6 +1756,7 @@ func TestSecuritySchemes_Import(t *testing.T) {
 
 	t.Run("token", func(t *testing.T) {
 		check := func(t *testing.T, enable bool) {
+			t.Helper()
 			securitySchemes := SecuritySchemes{}
 			nativeSecurityScheme := &openapi3.SecurityScheme{
 				Type: typeAPIKey,

--- a/apidef/oas/root_test.go
+++ b/apidef/oas/root_test.go
@@ -214,6 +214,7 @@ func TestState(t *testing.T) {
 
 // Fill populates the given input with non-default values. Index is where to start incrementing values.
 func Fill(t *testing.T, input interface{}, index int) {
+	t.Helper()
 	v := reflect.ValueOf(input).Elem()
 
 	switch kind := v.Type().Kind(); kind {
@@ -352,6 +353,7 @@ func getNonEmptyFields(data interface{}, prefix string) (fields []string) {
 }
 
 func FillTestAuthConfigs(t *testing.T, index int) map[string]apidef.AuthConfig {
+	t.Helper()
 	authConfigs := make(map[string]apidef.AuthConfig)
 
 	a := apidef.AuthConfig{}
@@ -372,6 +374,7 @@ func FillTestAuthConfigs(t *testing.T, index int) map[string]apidef.AuthConfig {
 }
 
 func FillTestVersionData(t *testing.T, index int) apidef.VersionData {
+	t.Helper()
 	versionInfo := apidef.VersionInfo{}
 	Fill(t, &versionInfo, index)
 

--- a/apidef/validator_test.go
+++ b/apidef/validator_test.go
@@ -43,6 +43,7 @@ func TestValidationResult_ErrorStrings(t *testing.T) {
 
 func runValidationTest(apiDef *APIDefinition, ruleSet ValidationRuleSet, expectedValidationResult ValidationResult) func(t *testing.T) {
 	return func(t *testing.T) {
+		t.Helper()
 		result := Validate(apiDef, ruleSet)
 		assert.Equal(t, expectedValidationResult.IsValid, result.IsValid)
 		assert.ElementsMatch(t, expectedValidationResult.Errors, result.Errors)

--- a/cli/bundler/bundler_test.go
+++ b/cli/bundler/bundler_test.go
@@ -44,6 +44,7 @@ func TestMain(m *testing.M) {
 }
 
 func writeManifestFile(t testing.TB, manifest interface{}, filename string) *string {
+	t.Helper()
 	var data []byte
 	var err error
 	switch manifest.(type) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -149,7 +149,8 @@ func TestConfigFiles(t *testing.T) {
 
 func TestConfig_GetEventTriggers(t *testing.T) {
 
-	assert := func(t *testing.T, config string, expected string) {
+	assertFunc := func(t *testing.T, config string, expected string) {
+		t.Helper()
 		conf := &Config{}
 
 		f, err := ioutil.TempFile("", "tyk.conf")
@@ -178,17 +179,17 @@ func TestConfig_GetEventTriggers(t *testing.T) {
 
 	t.Run("Deprecated configuration", func(t *testing.T) {
 		deprecated := `{"event_trigers_defunct": {"deprecated": []}}`
-		assert(t, deprecated, "deprecated")
+		assertFunc(t, deprecated, "deprecated")
 	})
 
 	t.Run("Current configuration", func(t *testing.T) {
 		current := `{"event_triggers_defunct": {"current": []}}`
-		assert(t, current, "current")
+		assertFunc(t, current, "current")
 	})
 
 	t.Run("Both configured", func(t *testing.T) {
 		both := `{"event_trigers_defunct": {"deprecated": []}, "event_triggers_defunct": {"current": []}}`
-		assert(t, both, "current")
+		assertFunc(t, both, "current")
 	})
 
 }

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -666,6 +666,7 @@ func TestOldMockResponse(t *testing.T) {
 	}
 
 	check := func(t *testing.T, api *APISpec, tc []test.TestCase) {
+		t.Helper()
 		ts.Gw.LoadAPI(api)
 		_, _ = ts.Run(t, tc...)
 
@@ -1261,6 +1262,7 @@ func TestAPIDefinitionLoader(t *testing.T) {
 	l := APIDefinitionLoader{Gw: ts.Gw}
 
 	executeAndAssert := func(t *testing.T, tpl *textTemplate.Template) {
+		t.Helper()
 		var bodyBuffer bytes.Buffer
 		err := tpl.Execute(&bodyBuffer, map[string]string{
 			"value1": "value-1",

--- a/gateway/api_loader_test.go
+++ b/gateway/api_loader_test.go
@@ -190,6 +190,7 @@ func TestGraphQLPlayground(t *testing.T) {
 	})[0]
 
 	run := func(t *testing.T, playgroundPath string, api *APISpec, env string) {
+		t.Helper()
 		endpoint := api.Proxy.ListenPath
 		if env == "cloud" {
 			endpoint = fmt.Sprintf("/%s/", api.Slug)

--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -1022,7 +1022,7 @@ func TestHashKeyHandlerLegacyWithHashFunc(t *testing.T) {
 }
 
 func (ts *Test) testHashKeyHandlerHelper(t *testing.T, expectedHashSize int) {
-
+	t.Helper()
 	ts.Gw.BuildAndLoadAPI()
 
 	withAccess := CreateStandardSession()
@@ -1146,7 +1146,7 @@ func (ts *Test) testHashKeyHandlerHelper(t *testing.T, expectedHashSize int) {
 }
 
 func (ts *Test) testHashFuncAndBAHelper(t *testing.T) {
-
+	t.Helper()
 	session := ts.testPrepareBasicAuth(false)
 
 	_, _ = ts.Run(t, []test.TestCase{
@@ -3543,6 +3543,7 @@ func testGetOldAPI(t *testing.T, d *Test, id, name string) (oldAPI apidef.APIDef
 }
 
 func testPatchOAS(t *testing.T, ts *Test, api oas.OAS, params map[string]string, apiID string) {
+	t.Helper()
 	patchPath := fmt.Sprintf("/tyk/apis/oas/%s", apiID)
 
 	_, _ = ts.Run(t, []test.TestCase{
@@ -3554,6 +3555,7 @@ func testPatchOAS(t *testing.T, ts *Test, api oas.OAS, params map[string]string,
 }
 
 func testImportOAS(t *testing.T, ts *Test, testCase test.TestCase) string {
+	t.Helper()
 	var importResp apiModifyKeySuccess
 
 	testCase.Path = "/tyk/apis/oas/import"
@@ -3874,6 +3876,7 @@ func TestPurgeOAuthClientTokensEndpoint(t *testing.T) {
 	})
 
 	assertTokensLen := func(t *testing.T, storageManager storage.Handler, storageKey string, expectedTokensLen int) {
+		t.Helper()
 		nowTs := time.Now().Unix()
 		startScore := strconv.FormatInt(nowTs, 10)
 		tokens, _, err := storageManager.GetSortedSetRange(storageKey, startScore, "+inf")

--- a/gateway/cert_go1.10_test.go
+++ b/gateway/cert_go1.10_test.go
@@ -48,6 +48,7 @@ var (
 )
 
 func newUpstreamSSL(t *testing.T, gw *Gateway, serverCert tls.Certificate, handler http.HandlerFunc) (*httptest.Server, string, func()) {
+	t.Helper()
 	pubID, err := gw.uploadCertPublicKey(serverCert)
 	if err != nil {
 		t.Error(err)

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -517,6 +517,7 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 
 	t.Run("Multiple APIs on same domain", func(t *testing.T) {
 		testSameDomain := func(t *testing.T, domain string) {
+			t.Helper()
 			clientCertID, _ := ts.Gw.CertificateManager.Add(clientCertPem, "")
 			defer ts.Gw.CertificateManager.Delete(clientCertID, "")
 
@@ -597,6 +598,7 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 
 	t.Run("Multiple APIs with Mutual TLS on the same domain", func(t *testing.T) {
 		testSameDomain := func(t *testing.T, domain string) {
+			t.Helper()
 			clientCertID, _ := ts.Gw.CertificateManager.Add(clientCertPem, "")
 			defer ts.Gw.CertificateManager.Delete(clientCertID, "")
 
@@ -710,6 +712,7 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 
 	t.Run("Multiple APIs, mutual on custom", func(t *testing.T) {
 		testSameDomain := func(t *testing.T, domain string) {
+			t.Helper()
 			clientCertID, _ := ts.Gw.CertificateManager.Add(clientCertPem, "")
 			defer ts.Gw.CertificateManager.Delete(clientCertID, "")
 
@@ -804,6 +807,7 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 
 	t.Run("Multiple APIs, mutual on empty", func(t *testing.T) {
 		testSameDomain := func(t *testing.T, domain string) {
+			t.Helper()
 			clientCertID, _ := ts.Gw.CertificateManager.Add(clientCertPem, "")
 			defer ts.Gw.CertificateManager.Delete(clientCertID, "")
 

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -1275,6 +1275,7 @@ func TestOldCachePlugin(t *testing.T) {
 	headerCache := map[string]string{"x-tyk-cached-response": "1"}
 
 	check := func(t *testing.T) {
+		t.Helper()
 		cache := storage.RedisCluster{KeyPrefix: "cache-", ConnectionHandler: ts.Gw.StorageConnectionHandler}
 		defer cache.DeleteScanMatch("*")
 

--- a/gateway/grpc_streaming_client_test.go
+++ b/gateway/grpc_streaming_client_test.go
@@ -38,6 +38,7 @@ import (
 
 // printFeature gets the feature for the given point.
 func printFeature(t *testing.T, client pb.RouteGuideClient, point *pb.Point) {
+	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	feature, err := client.GetFeature(ctx, point)
@@ -62,6 +63,7 @@ const expectedFeatures = `[{"name":"Patriots Path, Mendham, NJ 07945, USA","loca
 
 // printFeatures lists all the features within the given bounding Rectangle.
 func printFeatures(t *testing.T, client pb.RouteGuideClient, rect *pb.Rectangle) {
+	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	stream, err := client.ListFeatures(ctx, rect)
@@ -88,6 +90,7 @@ func printFeatures(t *testing.T, client pb.RouteGuideClient, rect *pb.Rectangle)
 
 // runRecordRoute sends a sequence of points to server and expects to get a RouteSummary from server.
 func runRecordRoute(t *testing.T, client pb.RouteGuideClient) {
+	t.Helper()
 	// Create a random number of random points
 	r := mathRand.New(mathRand.NewSource(time.Now().UnixNano()))
 	pointCount := int(r.Int31n(100)) + 2 // Traverse at least two points
@@ -119,6 +122,7 @@ func runRecordRoute(t *testing.T, client pb.RouteGuideClient) {
 // runRouteChat receives a sequence of route notes, while sending notes for various locations
 // this test bidirectional grpc data streaming
 func runRouteChat(t *testing.T, client pb.RouteGuideClient) {
+	t.Helper()
 	notes := []*pb.RouteNote{
 		{Location: &pb.Point{Latitude: 0, Longitude: 1}, Message: "First message"},
 		{Location: &pb.Point{Latitude: 0, Longitude: 2}, Message: "Second message"},
@@ -185,6 +189,7 @@ func randomPoint(r *mathRand.Rand) *pb.Point {
 }
 
 func testGRPCStreamClient(t *testing.T, addr string, opts ...grpc.DialOption) {
+	t.Helper()
 	opts = append(opts, grpc.WithBlock())
 	conn, err := grpc.Dial(addr, opts...)
 	if err != nil {

--- a/gateway/grpc_streaming_server_test.go
+++ b/gateway/grpc_streaming_server_test.go
@@ -137,6 +137,7 @@ func (s *routeGuideServer) RouteChat(stream pb.RouteGuide_RouteChatServer) error
 
 // loadFeatures loads features from a JSON file.
 func (s *routeGuideServer) loadFeatures(t *testing.T) {
+	t.Helper()
 	if err := json.Unmarshal(exampleData, &s.savedFeatures); err != nil {
 		t.Fatalf("Failed to load default features: %v", err)
 	}
@@ -187,12 +188,14 @@ func serialize(point *pb.Point) string {
 }
 
 func newServer(t *testing.T) *routeGuideServer {
+	t.Helper()
 	s := &routeGuideServer{routeNotes: make(map[string][]*pb.RouteNote)}
 	s.loadFeatures(t)
 	return s
 }
 
 func setupStreamSVC(t *testing.T, grpcServer *grpc.Server) {
+	t.Helper()
 	pb.RegisterRouteGuideServer(grpcServer, newServer(t))
 }
 

--- a/gateway/grpc_test.go
+++ b/gateway/grpc_test.go
@@ -493,6 +493,7 @@ func (s *server) SayHello(ctx context.Context, in *pbExample.HelloRequest) (*pbE
 }
 
 func startGRPCServerH2C(t *testing.T, fn func(*testing.T, *grpc.Server)) (net.Listener, *grpc.Server) {
+	t.Helper()
 	ls := openListener(t)
 	s := grpc.NewServer()
 	fn(t, s)
@@ -506,6 +507,7 @@ func startGRPCServerH2C(t *testing.T, fn func(*testing.T, *grpc.Server)) (net.Li
 }
 
 func toTarget(t *testing.T, scheme string, ls net.Listener) string {
+	t.Helper()
 	_, port, err := net.SplitHostPort(ls.Addr().String())
 	if err != nil {
 		t.Fatal(err)
@@ -557,6 +559,7 @@ func setupHelloSVC(t *testing.T, s *grpc.Server) {
 }
 
 func startGRPCServer(t *testing.T, clientCert *x509.Certificate, fn func(t *testing.T, s *grpc.Server)) (net.Listener, *grpc.Server) {
+	t.Helper()
 	// Server
 	ls := openListener(t)
 	opts := grpcServerCreds(t, clientCert)
@@ -573,6 +576,7 @@ func startGRPCServer(t *testing.T, clientCert *x509.Certificate, fn func(t *test
 }
 
 func sayHelloWithGRPCClientH2C(t *testing.T, address string, name string) *pbExample.HelloReply {
+	t.Helper()
 	conn, err := grpc.Dial(address, grpc.WithInsecure())
 	if err != nil {
 		t.Fatalf("did not connect: %v", err)
@@ -625,6 +629,7 @@ func grpcCreds(cert *tls.Certificate, caCert []byte, basicAuth bool, token strin
 }
 
 func sayHelloWithGRPCClient(t *testing.T, cert *tls.Certificate, caCert []byte, basicAuth bool, token string, address string, name string) *pbExample.HelloReply {
+	t.Helper()
 	// gRPC client
 	opts := grpcCreds(cert, caCert, basicAuth, token)
 	conn, err := grpc.Dial(address, opts...)

--- a/gateway/handler_success_test.go
+++ b/gateway/handler_success_test.go
@@ -142,6 +142,7 @@ func TestAnalyticRecord_GraphStats(t *testing.T) {
 				Query: `{ hello(name: "World") httpMethod }`,
 			},
 			checkFunc: func(t *testing.T, record *analytics.AnalyticsRecord) {
+				t.Helper()
 				assert.True(t, record.GraphQLStats.IsGraphQL)
 				assert.False(t, record.GraphQLStats.HasErrors)
 				assert.ElementsMatch(t, []string{"hello", "httpMethod"}, record.GraphQLStats.RootFields)
@@ -157,6 +158,7 @@ func TestAnalyticRecord_GraphStats(t *testing.T) {
 				Variables: []byte(`{"in":"hello"}`),
 			},
 			checkFunc: func(t *testing.T, record *analytics.AnalyticsRecord) {
+				t.Helper()
 				assert.True(t, record.GraphQLStats.IsGraphQL)
 				assert.False(t, record.GraphQLStats.HasErrors)
 				assert.ElementsMatch(t, []string{"httpMethod", "hello"}, record.GraphQLStats.RootFields)
@@ -177,6 +179,7 @@ func TestAnalyticRecord_GraphStats(t *testing.T) {
 				spec.EnableDetailedRecording = true
 			},
 			checkFunc: func(t *testing.T, record *analytics.AnalyticsRecord) {
+				t.Helper()
 				assert.True(t, record.GraphQLStats.IsGraphQL)
 				assert.True(t, record.GraphQLStats.HasErrors)
 				assert.ElementsMatch(t, []string{"hello", "httpMethod"}, record.GraphQLStats.RootFields)
@@ -199,6 +202,7 @@ func TestAnalyticRecord_GraphStats(t *testing.T) {
 				spec.Proxy.TargetURL = testGraphQLProxyUpstreamError
 			},
 			checkFunc: func(t *testing.T, record *analytics.AnalyticsRecord) {
+				t.Helper()
 				assert.True(t, record.GraphQLStats.IsGraphQL)
 				assert.True(t, record.GraphQLStats.HasErrors)
 				assert.ElementsMatch(t, []string{"hello", "httpMethod"}, record.GraphQLStats.RootFields)

--- a/gateway/middleware_test.go
+++ b/gateway/middleware_test.go
@@ -315,6 +315,7 @@ func TestSessionLimiter_RedisQuotaExceeded_PerAPI(t *testing.T) {
 	assert.Equal(t, session.AccessRights[apis[2].APIID].AllowanceScope, "")
 
 	sendReqAndCheckQuota := func(t *testing.T, apiID string, expectedQuotaRemaining int64, perAPI bool) {
+		t.Helper()
 		_, _ = g.Run(t, test.TestCase{Path: fmt.Sprintf("/%s/", apiID), Headers: headers, Code: http.StatusOK})
 
 		resp, _ := g.Run(t, test.TestCase{Path: "/tyk/keys/" + key, AdminAuth: true, Code: http.StatusOK})

--- a/gateway/multiauth_test.go
+++ b/gateway/multiauth_test.go
@@ -96,7 +96,7 @@ func (ts *Test) getMultiAuthStandardAndBasicAuthChain(spec *APISpec) http.Handle
 }
 
 func (ts *Test) testPrepareMultiSessionBA(t testing.TB, isBench bool) (*APISpec, *http.Request) {
-
+	t.Helper()
 	spec := ts.Gw.LoadSampleAPI(multiAuthDev)
 
 	// Create BA

--- a/gateway/mw_api_rate_limit_test.go
+++ b/gateway/mw_api_rate_limit_test.go
@@ -105,6 +105,7 @@ func TestRLOpen(t *testing.T) {
 
 func requestThrottlingTest(limiter string, testLevel string) func(t *testing.T) {
 	return func(t *testing.T) {
+		t.Helper()
 		ts := StartTest(nil)
 		defer ts.Close()
 

--- a/gateway/mw_graphql_test.go
+++ b/gateway/mw_graphql_test.go
@@ -305,6 +305,7 @@ func TestGraphQLMiddleware_RequestValidation(t *testing.T) {
 
 func TestGraphQLMiddleware_EngineMode(t *testing.T) {
 	assertReviewsSubgraphResponse := func(t *testing.T) func(bytes []byte) bool {
+		t.Helper()
 		return func(bytes []byte) bool {
 			expected := `{"data":{"_entities":[{"reviews":[{"body":"A highly effective form of birth control."},{"body":"Fedoras are one of the most fashionable hats around and can look great with a variety of outfits."}]}]}}`
 			var body json.RawMessage
@@ -1168,6 +1169,7 @@ func TestGraphQLMiddleware_EngineMode(t *testing.T) {
 				t.Run("should send configured headers upstream", func(t *testing.T) {
 					run := func(apiSpec func(testServerURL string) func(apiSpec *APISpec), requestHeaders, expectedHeaders http.Header) func(t *testing.T) {
 						return func(t *testing.T) {
+							t.Helper()
 							wg := sync.WaitGroup{}
 							wg.Add(2)
 

--- a/gateway/mw_http_signature_validation_test.go
+++ b/gateway/mw_http_signature_validation_test.go
@@ -125,6 +125,7 @@ func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
 }
 
 func testPrepareHMACAuthSessionPass(tb testing.TB, ts *Test, hashFn func() hash.Hash, eventWG *sync.WaitGroup, withHeader bool, isBench bool) (string, *APISpec, *http.Request, string) {
+	tb.Helper()
 	spec := ts.Gw.LoadSampleAPI(hmacAuthDef)
 
 	session := createHMACAuthSession()
@@ -182,7 +183,7 @@ func testPrepareHMACAuthSessionPass(tb testing.TB, ts *Test, hashFn func() hash.
 }
 
 func testPrepareRSAAuthSessionPass(tb testing.TB, eventWG *sync.WaitGroup, privateKey *rsa.PrivateKey, pubCertId string, withHeader bool, isBench bool, ts *Test) (string, *APISpec, *http.Request, string) {
-
+	tb.Helper()
 	spec := ts.Gw.LoadSampleAPI(hmacAuthDef)
 	session := createRSAAuthSession(pubCertId)
 

--- a/gateway/mw_jwt_test.go
+++ b/gateway/mw_jwt_test.go
@@ -1813,6 +1813,7 @@ func TestJWTDefaultPolicies(t *testing.T) {
 	sessionID := ts.Gw.generateToken(spec.OrgID, keyID)
 
 	assert := func(t *testing.T, expected []string) {
+		t.Helper()
 		session, _ := ts.Gw.GlobalSessionManager.SessionDetail(spec.OrgID, sessionID, false)
 		actual := session.PolicyIDs()
 		if !reflect.DeepEqual(expected, actual) {

--- a/gateway/mw_oas_validate_request_test.go
+++ b/gateway/mw_oas_validate_request_test.go
@@ -152,6 +152,7 @@ func TestValidateRequest(t *testing.T) {
 
 	t.Run("default error response code", func(t *testing.T) {
 		check := func(t *testing.T) {
+			t.Helper()
 			_, _ = ts.Run(t, []test.TestCase{
 				{Data: `{"name": 123}`, Code: http.StatusOK, Method: http.MethodPost, Headers: headers, Path: "/product/push"},
 				{Data: `{"name": 123}`, Code: http.StatusUnprocessableEntity, Method: http.MethodPost, Headers: headers, Path: "/product/post"},

--- a/gateway/mw_organisation_activity_test.go
+++ b/gateway/mw_organisation_activity_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (ts *Test) testPrepareProcessRequestQuotaLimit(tb testing.TB, data map[string]interface{}) {
-
+	tb.Helper()
 	// load API
 	orgID := "test-org-" + uuid.New()
 

--- a/gateway/mw_redis_cache_test.go
+++ b/gateway/mw_redis_cache_test.go
@@ -27,6 +27,7 @@ func TestRedisCacheMiddlewareUnit(t *testing.T) {
 		{
 			Name: "isTimeStampExpired",
 			Fn: func(t *testing.T) {
+				t.Helper()
 				mw := &RedisCacheMiddleware{BaseMiddleware: &BaseMiddleware{}}
 
 				assert.True(t, mw.isTimeStampExpired("invalid"))
@@ -38,6 +39,7 @@ func TestRedisCacheMiddlewareUnit(t *testing.T) {
 		{
 			Name: "decodePayload",
 			Fn: func(t *testing.T) {
+				t.Helper()
 				mw := &RedisCacheMiddleware{BaseMiddleware: &BaseMiddleware{}}
 
 				if data, expire, err := mw.decodePayload("dGVzdGluZwo=|123"); true {
@@ -59,6 +61,7 @@ func TestRedisCacheMiddlewareUnit(t *testing.T) {
 		{
 			Name: "encodePayload",
 			Fn: func(t *testing.T) {
+				t.Helper()
 				mw := &ResponseCacheMiddleware{}
 
 				result := mw.encodePayload("test", 123)
@@ -107,6 +110,7 @@ func TestRedisCacheMiddleware(t *testing.T) {
 
 	check := func(t *testing.T, p params) {
 		subCheck := func(t *testing.T, cachingActive bool, p params) {
+			t.Helper()
 			headersMatch := make(map[string]string)
 			if cachingActive {
 				headersMatch["x-tyk-cached-response"] = "1"

--- a/gateway/mw_transform_test.go
+++ b/gateway/mw_transform_test.go
@@ -251,6 +251,7 @@ func BenchmarkTransformJSONMarshal(b *testing.B) {
 
 func TestTransformXMLMarshal(t *testing.T) {
 	assert := func(t *testing.T, input string, tmpl string, output string, inputType apidef.RequestInputType) {
+		t.Helper()
 		tmeta := testPrepareTransformXMLMarshal(tmpl, inputType)
 		r := TestReq(t, "GET", "/", input)
 

--- a/gateway/mw_version_check_test.go
+++ b/gateway/mw_version_check_test.go
@@ -355,6 +355,7 @@ func TestOldVersioning_DefaultVersionEmpty(t *testing.T) {
 	})[0]
 
 	check := func(t *testing.T, tc []test.TestCase, apis ...*APISpec) {
+		t.Helper()
 		ts.Gw.LoadAPI(apis...)
 		_, _ = ts.Run(t, tc...)
 	}
@@ -396,6 +397,7 @@ func TestOldVersioning_StripPath(t *testing.T) {
 	}
 
 	check := func(t *testing.T, api *APISpec, tc test.TestCase) {
+		t.Helper()
 		ts.Gw.LoadAPI(api)
 		_, _ = ts.Run(t, tc)
 
@@ -443,7 +445,9 @@ func TestOldVersioning_Expires(t *testing.T) {
 	}
 
 	check := func(t *testing.T, api *APISpec, tc test.TestCase, expirationHeaderEmpty bool) {
+		t.Helper()
 		subCheck := func(t *testing.T, apis ...*APISpec) {
+			t.Helper()
 			ts.Gw.LoadAPI(apis...)
 			resp, _ := ts.Run(t, tc)
 

--- a/gateway/oauth_manager_test.go
+++ b/gateway/oauth_manager_test.go
@@ -705,6 +705,7 @@ func TestAPIClientAuthorizeTokenWithPolicy(t *testing.T) {
 }
 
 func getAuthCode(t *testing.T, ts *Test) map[string]string {
+	t.Helper()
 	param := make(url.Values)
 	param.Set("response_type", "code")
 	param.Set("redirect_uri", authRedirectUri)
@@ -857,7 +858,7 @@ func TestGetClientTokens(t *testing.T) {
 
 func testGetClientTokens(t *testing.T, hashed bool) {
 	test.Flaky(t) // TODO: TT-5253
-
+	t.Helper()
 	conf := func(globalConf *config.Config) {
 		// set tokens to be expired after 1 second
 		globalConf.OauthTokenExpire = 1
@@ -976,6 +977,7 @@ type tokenData struct {
 }
 
 func getToken(t *testing.T, ts *Test) tokenData {
+	t.Helper()
 	authData := getAuthCode(t, ts)
 
 	param := make(url.Values)

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -440,6 +440,8 @@ func (s *Test) TestPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesD
 			name:     "MultiNonPart",
 			policies: []string{"nonpart1", "nonpart2", "nonexistent"},
 			sessMatch: func(t *testing.T, s *user.SessionState) {
+				t.Helper()
+
 				want := map[string]user.AccessDefinition{
 					"a": {
 						Limit:          user.APILimit{},
@@ -458,6 +460,8 @@ func (s *Test) TestPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesD
 			name:     "MultiACLPolicy",
 			policies: []string{"nonpart3"},
 			sessMatch: func(t *testing.T, s *user.SessionState) {
+				t.Helper()
+
 				want := map[string]user.AccessDefinition{
 					"a": {
 						Limit: user.APILimit{},
@@ -688,6 +692,8 @@ func (s *Test) TestPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesD
 			name:     "Per API is set to true with no other partitions set to true",
 			policies: []string{"per_api_and_no_other_partitions"},
 			sessMatch: func(t *testing.T, s *user.SessionState) {
+				t.Helper()
+
 				want := map[string]user.AccessDefinition{
 					"d": {
 						Limit: user.APILimit{
@@ -730,6 +736,8 @@ func (s *Test) TestPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesD
 			name:     "Per API is set to true and some API gets limit set from policy's fields",
 			policies: []string{"per_api_with_limit_set_from_policy"},
 			sessMatch: func(t *testing.T, s *user.SessionState) {
+				t.Helper()
+
 				want := map[string]user.AccessDefinition{
 					"e": {
 						Limit: user.APILimit{
@@ -787,6 +795,8 @@ func (s *Test) TestPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesD
 			name:     "Merge restricted fields for the same GraphQL API",
 			policies: []string{"restricted-types1", "restricted-types2"},
 			sessMatch: func(t *testing.T, s *user.SessionState) {
+				t.Helper()
+
 				want := map[string]user.AccessDefinition{
 					"a": { // It should get intersection of restricted types.
 						RestrictedTypes: []graphql.Type{
@@ -804,6 +814,8 @@ func (s *Test) TestPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesD
 			name:     "Merge allowed fields for the same GraphQL API",
 			policies: []string{"allowed-types1", "allowed-types2"},
 			sessMatch: func(t *testing.T, s *user.SessionState) {
+				t.Helper()
+
 				want := map[string]user.AccessDefinition{
 					"a": { // It should get intersection of restricted types.
 						AllowedTypes: []graphql.Type{
@@ -821,6 +833,8 @@ func (s *Test) TestPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesD
 			name:     "If GQL introspection is disabled, it remains disabled after merging",
 			policies: []string{"introspection-disabled", "introspection-enabled"},
 			sessMatch: func(t *testing.T, s *user.SessionState) {
+				t.Helper()
+
 				want := map[string]user.AccessDefinition{
 					"a": {
 						DisableIntrospection: true, // If GQL introspection is disabled, it remains disabled after merging.
@@ -835,6 +849,8 @@ func (s *Test) TestPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesD
 			name:     "Merge field level depth limit for the same GraphQL API",
 			policies: []string{"field-level-depth-limit1", "field-level-depth-limit2"},
 			sessMatch: func(t *testing.T, s *user.SessionState) {
+				t.Helper()
+
 				want := map[string]user.AccessDefinition{
 					"graphql-api": {
 						Limit: user.APILimit{},
@@ -863,6 +879,8 @@ func (s *Test) TestPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesD
 			policies: []string{"throttle1"},
 			errMatch: "",
 			sessMatch: func(t *testing.T, s *user.SessionState) {
+				t.Helper()
+
 				if s.ThrottleRetryLimit != 99 {
 					t.Fatalf("Throttle interval should be 9 inherited from policy")
 				}
@@ -873,6 +891,8 @@ func (s *Test) TestPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesD
 			name:     "inherit quota and rate from partitioned policies",
 			policies: []string{"quota1", "rate3"},
 			sessMatch: func(t *testing.T, s *user.SessionState) {
+				t.Helper()
+
 				if s.QuotaMax != 2 {
 					t.Fatalf("quota should be the same as quota policy")
 				}
@@ -888,6 +908,8 @@ func (s *Test) TestPrepareApplyPolicies() (*BaseMiddleware, []testApplyPoliciesD
 			name:     "inherit quota and rate from partitioned policies applied in different order",
 			policies: []string{"rate3", "quota1"},
 			sessMatch: func(t *testing.T, s *user.SessionState) {
+				t.Helper()
+
 				if s.QuotaMax != 2 {
 					t.Fatalf("quota should be the same as quota policy")
 				}

--- a/gateway/redis_signals_test.go
+++ b/gateway/redis_signals_test.go
@@ -23,6 +23,7 @@ func TestPubSubInternals(t *testing.T) {
 		{
 			name: "test error log, err == nil",
 			testFn: func(t *testing.T) {
+				t.Helper()
 				var err error
 				assert.False(t, g.Gw.logPubSubError(err, message))
 			},
@@ -30,13 +31,15 @@ func TestPubSubInternals(t *testing.T) {
 		{
 			name: "test error log, err != nil",
 			testFn: func(t *testing.T) {
-				var err error = errors.New("test err")
+				t.Helper()
+				var err = errors.New("test err")
 				assert.True(t, g.Gw.logPubSubError(err, message))
 			},
 		},
 		{
 			name: "test add delay",
 			testFn: func(t *testing.T) {
+				t.Helper()
 				g.Gw.addPubSubDelay(time.Microsecond)
 				assert.True(t, true)
 			},

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -759,6 +759,7 @@ func TestCheckHeaderInRemoveList(t *testing.T) {
 }
 
 func testRequestIPHops(t testing.TB) {
+	t.Helper()
 	req := &http.Request{
 		Header:     http.Header{},
 		RemoteAddr: "test.com:80",

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -175,6 +175,7 @@ func (r *ReloadMachinery) Queued() bool {
 // EnsureQueued this will block until any queue happens. It will timeout after
 // 100ms
 func (r *ReloadMachinery) EnsureQueued(t *testing.T) {
+	t.Helper()
 	tick := time.NewTicker(time.Millisecond)
 	defer tick.Stop()
 
@@ -198,6 +199,8 @@ func (r *ReloadMachinery) EnsureQueued(t *testing.T) {
 // EnsureReloaded this will block until any reload happens. It will timeout after
 // 200ms
 func (r *ReloadMachinery) EnsureReloaded(t *testing.T) {
+	t.Helper()
+
 	tick := time.NewTicker(time.Millisecond)
 	defer tick.Stop()
 	for {
@@ -225,6 +228,8 @@ func (r *ReloadMachinery) Tick() {
 // TickOk triggers a reload and ensures a queue happened and a reload cycle
 // happens. This will block until all the cases are met.
 func (r *ReloadMachinery) TickOk(t *testing.T) {
+	t.Helper()
+
 	r.EnsureQueued(t)
 	r.Tick()
 	r.EnsureReloaded(t)
@@ -1321,6 +1326,8 @@ func (s *Test) Run(t testing.TB, testCases ...test.TestCase) (*http.Response, er
 
 // TODO:(gernest) when hot reload is supported enable this.
 func (s *Test) RunExt(t testing.TB, testCases ...test.TestCase) {
+	t.Helper()
+
 	s.Run(t, testCases...)
 	var testMatrix = []struct {
 		goagain          bool

--- a/internal/graphengine/engine_v1_test.go
+++ b/internal/graphengine/engine_v1_test.go
@@ -345,6 +345,8 @@ func withExecutionModeTestEngineV1(executionMode apidef.GraphQLExecutionMode) te
 }
 
 func newTestEngineV1(t *testing.T, options ...testEngineV1Option) (*EngineV1, engineV1Mocks) {
+	t.Helper()
+
 	definedOptions := testEngineV1Options{}
 	for _, option := range options {
 		option(&definedOptions)

--- a/internal/graphengine/engine_v2_test.go
+++ b/internal/graphengine/engine_v2_test.go
@@ -419,6 +419,8 @@ func withOpenTelemetryTestEngineV2(detailedTracing bool) testEngineV2Option {
 }
 
 func newTestEngineV2(t *testing.T, options ...testEngineV2Option) (*EngineV2, engineV2Mocks) {
+	t.Helper()
+
 	definedOptions := testEngineV2Options{
 		otelConfig:    EngineV2OTelConfig{},
 		apiDefinition: newTestApiDefinitionV2(apidef.GraphQLExecutionModeProxyOnly, "http://example.com"),

--- a/internal/graphengine/engine_v3_test.go
+++ b/internal/graphengine/engine_v3_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func NewTestEngine(t *testing.T) *EngineV3 {
+	t.Helper()
+
 	gqlTools := graphqlGoToolsV2{}
 	parsedSchema, err := gqlTools.parseSchema(testSchemaEngineV1)
 	require.NoError(t, err)

--- a/internal/graphengine/graphql_go_tools_v1_test.go
+++ b/internal/graphengine/graphql_go_tools_v1_test.go
@@ -912,6 +912,8 @@ func TestReverseProxyPreHandlerV1_PreHandle(t *testing.T) {
 }
 
 func newTestGraphqlRequestProcessorV1(t *testing.T) *graphqlRequestProcessorV1 {
+	t.Helper()
+
 	gqlTools := graphqlGoToolsV1{}
 	parsedSchema, err := gqlTools.parseSchema(testSchemaEngineV1)
 	require.NoError(t, err)
@@ -924,6 +926,8 @@ func newTestGraphqlRequestProcessorV1(t *testing.T) *graphqlRequestProcessorV1 {
 }
 
 func newTestGraphqlRequestProcessorWithOtelV1(t *testing.T) *graphqlRequestProcessorWithOTelV1 {
+	t.Helper()
+
 	gqlTools := graphqlGoToolsV1{}
 	parsedSchema, err := gqlTools.parseSchema(testSchemaEngineV1)
 	require.NoError(t, err)
@@ -958,6 +962,8 @@ func withTestComplexityCheckerV1Schema(schema string) testComplexityCheckerV1Opt
 }
 
 func newTestComplexityCheckerV1(t *testing.T, options ...testComplexityCheckerV1Option) *complexityCheckerV1 {
+	t.Helper()
+
 	opts := &testComplexityCheckerV1Options{
 		schema: testSchemaEngineV1,
 	}
@@ -978,6 +984,8 @@ func newTestComplexityCheckerV1(t *testing.T, options ...testComplexityCheckerV1
 }
 
 func newTestGranularAccessCheckerV1(t *testing.T) *granularAccessCheckerV1 {
+	t.Helper()
+
 	gqlTools := graphqlGoToolsV1{}
 	parsedSchema, err := gqlTools.parseSchema(testSchemaEngineV1)
 	require.NoError(t, err)

--- a/internal/rate/sliding_log_test.go
+++ b/internal/rate/sliding_log_test.go
@@ -80,7 +80,7 @@ func TestSlidingLog_GetCount(t *testing.T) {
 	assert.True(t, ok)
 
 	for _, tx := range []bool{true, false} {
-		assertGetCount(ctx, t, db, tx)
+		assertGetCount(t, ctx, db, tx)
 	}
 }
 
@@ -101,7 +101,7 @@ func TestSlidingLog_Get(t *testing.T) {
 	assert.True(t, ok)
 
 	for _, tx := range []bool{true, false} {
-		assertGet(ctx, t, db, tx)
+		assertGet(t, ctx, db, tx)
 	}
 }
 
@@ -165,7 +165,9 @@ func assertPipelinerError(ctx context.Context, tb testing.TB, conn redis.Univers
 	assert.Equal(tb, int64(testRequestCount), count)
 }
 
-func assertGetCount(ctx context.Context, tb testing.TB, conn redis.UniversalClient, tx bool) {
+func assertGetCount(tb testing.TB, ctx context.Context, conn redis.UniversalClient, tx bool) {
+	tb.Helper()
+
 	rl := rate.NewSlidingLogRedis(conn, tx, nil)
 
 	key, per := uuid.New(), int64(5)
@@ -183,7 +185,9 @@ func assertGetCount(ctx context.Context, tb testing.TB, conn redis.UniversalClie
 	assert.Equal(tb, int64(testRequestCount), count)
 }
 
-func assertGet(ctx context.Context, tb testing.TB, conn redis.UniversalClient, tx bool) {
+func assertGet(tb testing.TB, ctx context.Context, conn redis.UniversalClient, tx bool) {
+	tb.Helper()
+
 	rl := rate.NewSlidingLogRedis(conn, tx, nil)
 
 	key, per := uuid.New(), int64(5)
@@ -244,25 +248,25 @@ func BenchmarkSlidingLog_Count(b *testing.B) {
 
 	b.Run("set/get count pipelined", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			assertGetCount(ctx, b, db, false)
+			assertGetCount(b, ctx, db, false)
 		}
 	})
 
 	b.Run("set/get count transaction", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			assertGetCount(ctx, b, db, true)
+			assertGetCount(b, ctx, db, true)
 		}
 	})
 
 	b.Run("set/get pipelined", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			assertGet(ctx, b, db, false)
+			assertGet(b, ctx, db, false)
 		}
 	})
 
 	b.Run("set/get transaction", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			assertGet(ctx, b, db, true)
+			assertGet(b, ctx, db, true)
 		}
 	})
 }

--- a/tcp/tcp_test.go
+++ b/tcp/tcp_test.go
@@ -194,6 +194,8 @@ func TestProxyMultiTarget(t *testing.T) {
 }
 
 func testRunner(t *testing.T, proxy *Proxy, hostname string, useSSL bool, testCases ...test.TCPTestCase) {
+	t.Helper()
+
 	var proxyLn net.Listener
 	var err error
 


### PR DESCRIPTION
### **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description

fix thelper.bug.major lint error reported by golangci-lint  on sonarcloud
## Related Issue
https://tyktech.atlassian.net/browse/TT-11753

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added `t.Helper()` to multiple test functions across various files to improve error reporting and debugging.
- Renamed `assert` function to `assertFunc` in `config/config_test.go` for clarity.
- Reordered function parameters in `internal/rate/sliding_log_test.go` for consistency.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>40 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>utils_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

apidef/adapter/gqlengineadapter/utils_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-1db9a553f1ea5691637919d538a690f24b16a029b4dd4ad3de30937c7fe19b9a">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>utils_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

apidef/adapter/utils_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-825f14e2b8fe1c89eb28fd7bdec8157a9332bbfebc7dced4322363963906a6e0">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>migration_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

apidef/migration_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-d79d77f814074b9e483554e36687e22fda759045141c3b094b039428744ff94c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>default_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

apidef/oas/default_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-ab6848f71731083885a9d7d7970faa68a6783a98477c78413ae3979cb5add7db">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>root_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

apidef/oas/root_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-4d144465b7fabaf2db8915de1ce3b6ff8c91a93c62d614c38fa38bdae28e23a2">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>validator_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

apidef/validator_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-baf578c5ffb8d45b34b536041aa0b9c12fb082f3ed7c0c02a2e95f6f5bdacefd">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>bundler_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

cli/bundler/bundler_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-ca677a25368595e118a0500bbde9d4bad2e757eaf1cbdb2514a95a9670786028">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>config_test.go</strong><dd><code>Add `t.Helper()` and rename `assert` to `assertFunc`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/config_test.go

<li>Added <code>t.Helper()</code> to test functions.<br> <li> Renamed <code>assert</code> function to <code>assertFunc</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-373f5578b8f362a364b50b0d01919a57da64c128547ca10d49df8ae422237c82">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>api_definition_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

gateway/api_definition_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-2394daab6fdc5f8dc234699c80c0548947ee3d68d2e33858258d73a8b5eb6f44">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>api_loader_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

gateway/api_loader_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-f696545a659f4d96421b253edef4bcc8da0e7f52120b8f8866d32cbbb7cc1afc">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>api_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

gateway/api_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-10b4a3d7bdd8d98e48b288d27fd46d9ee436617806c46913fdf7942c0e4a992e">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cert_go1.10_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

gateway/cert_go1.10_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-84d921f89dca720ff05643dbc36df8568e6a7cbdcd71cf1cf0c0a5a28c650be7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cert_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

gateway/cert_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-481696cb18de8c3880e0ca21318fe00fd4eb89bc48994e43b7c34729ef4a7ee2">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>gateway_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

gateway/gateway_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-d34c7069ce5e81d45082b19eb3e869ee1a086e185dcd6630e75e3ed0d368b546">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>grpc_streaming_client_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

gateway/grpc_streaming_client_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-1268c35895b3fe58b2bcf8a9cd4c0d75d2dde60d91e18deba254c19622d301f5">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>grpc_streaming_server_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

gateway/grpc_streaming_server_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-61f9d7f56d9104b7efc7a5c913b8d4958f3cd33acee96eeafe31a9df4a98337a">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>grpc_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

gateway/grpc_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-d450b0f742036333148e25629f6bc8465dc2b4b5f7d44ca83170c87e10d0e6ff">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>handler_success_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

gateway/handler_success_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-42a565d872ff6c1f380386f4ee2f75bfa87991b52728a1a9a1772452bb0cd1bb">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>middleware_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

gateway/middleware_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-6a09a08e3f82cc5e9d8c6b5c8426d75ea1e5d85e15ab008fca1f512e7c49c1e6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>multiauth_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

gateway/multiauth_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-f7a567eba510b8bdffbc8e0878461e5dac9c066e8cc5feaa18eeccde54555f22">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_api_rate_limit_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

gateway/mw_api_rate_limit_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-8485978214ae83eb8aeeda3519a1e90350a2a84067de47462f40f0938861dc45">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_graphql_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

gateway/mw_graphql_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-72c11b8efcaceccfbbd87e75565353706443bf56420d3fdba6b5bf5f632f4b33">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_http_signature_validation_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

gateway/mw_http_signature_validation_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-40d0e4791d3a68e4aa9992996d4ad6b8af51908630814fde4d5ff1bea81b7b96">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_jwt_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

gateway/mw_jwt_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-406bf8fdb6c0cc77f04c6245c70abfc592ddb1525aa843200d850e14d135ebfc">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_oas_validate_request_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

gateway/mw_oas_validate_request_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-604233bec52920ea748b8d634974f76e63a2b2cb2c8c558cc896217be8b2886b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_organisation_activity_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

gateway/mw_organisation_activity_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-b3bbd18e384b7f03f44c0d6c9a5205e8acdd117029e1e73412089191ec8e833a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_redis_cache_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

gateway/mw_redis_cache_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-d8dff1ef1bffcd3497ebe385c14e17ebf4423d644ac5447c324bdd1b5de3ba94">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_transform_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

gateway/mw_transform_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-ec6f80b3dcb001b2a2ac9b7277fff606bd77d796f99b8c1d10b8d0d55863deb3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_version_check_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

gateway/mw_version_check_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-ed8d515ea6f4f1a67801c8eb3ac5f195d36dac57a2dff6da736886f8772941ae">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>oauth_manager_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

gateway/oauth_manager_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-139c3beb238f234728bde9f619f501cf730a7e275d17c8511277272d1dcd6fc6">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>policy_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

gateway/policy_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-40d701767204255c38c7dd64939d6bb8df621640c4bddfe5f56080380476a18a">+22/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>redis_signals_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

gateway/redis_signals_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-649c63e353de51d89b7b5ca93b8e6f3716034cf1a7e27492a3d674f5a8c0791e">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>reverse_proxy_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

gateway/reverse_proxy_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-ce040f6555143f760fba6059744bc600b6954f0966dfb0fa2832b5eabf7a3c3f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>testutil.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

gateway/testutil.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-7aaf6ae49fb8f58a8c99d337fedd15b3e430dd928ed547e425ef429b10d28ce8">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>engine_v1_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

internal/graphengine/engine_v1_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-0f97ab77e84a391f87ba740d786c4a63cf5e801026e854962d569d8051df37de">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>engine_v2_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

internal/graphengine/engine_v2_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-e0a388eaeb817a8e437f0a9f7d333bf82343171d43f4605600a071e82438fad9">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>engine_v3_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

internal/graphengine/engine_v3_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-4948a6d04106feed51c084f3e15a3aac17a098791678c577355dcd7ba5a839d4">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>graphql_go_tools_v1_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

internal/graphengine/graphql_go_tools_v1_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-f2bd01488bead3cbb84ccfbd8595400eb3153a94a19587308a9fe24edfc13267">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>sliding_log_test.go</strong><dd><code>Add `t.Helper()` and reorder function parameters for consistency</code></dd></summary>
<hr>

internal/rate/sliding_log_test.go

<li>Added <code>t.Helper()</code> to test functions.<br> <li> Reordered function parameters for consistency.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-c84adf20904a21ae2dbaeba6b76ef8671abae88e10dc2b49f708b880180c6a08">+12/-8</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tcp_test.go</strong><dd><code>Add `t.Helper()` to test functions for better error reporting</code></dd></summary>
<hr>

tcp/tcp_test.go

- Added `t.Helper()` to test functions.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6429/files#diff-0034cc1ba4ed89ee5d9eb9817110c32f78b2107a8fc4a925adf1ba2af4846050">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

