### PR TITLE
Merging to release-5.3: [TT-12688] extractto to honor sorting (#6430)

### DIFF
--- a/apidef/oas/operation.go
+++ b/apidef/oas/operation.go
@@ -169,9 +169,8 @@ func (s *OAS) extractPathsAndOperations(ep *apidef.ExtendedPathsSet) {
 		return
 	}
 
-	for id, tykOp := range tykOperations {
-	found:
-		for _, pathItem := range oasutil.SortByPathLength(s.Paths) {
+	for _, pathItem := range oasutil.SortByPathLength(s.Paths) {
+		for id, tykOp := range tykOperations {
 			path := pathItem.Path
 			for method, operation := range pathItem.Operations() {
 				if id == operation.OperationID {
@@ -193,7 +192,12 @@ func (s *OAS) extractPathsAndOperations(ep *apidef.ExtendedPathsSet) {
 					tykOp.extractTrackEndpointTo(ep, path, method)
 					tykOp.extractDoNotTrackEndpointTo(ep, path, method)
 					tykOp.extractRequestSizeLimitTo(ep, path, method)
+<<<<<<< HEAD
 					break found
+=======
+					tykOp.extractRateLimitEndpointTo(ep, path, method)
+					break
+>>>>>>> cbaf8709f... [TT-12688] extractto to honor sorting (#6430)
 				}
 			}
 		}

--- a/apidef/oas/operation.go
+++ b/apidef/oas/operation.go
@@ -192,12 +192,7 @@ func (s *OAS) extractPathsAndOperations(ep *apidef.ExtendedPathsSet) {
 					tykOp.extractTrackEndpointTo(ep, path, method)
 					tykOp.extractDoNotTrackEndpointTo(ep, path, method)
 					tykOp.extractRequestSizeLimitTo(ep, path, method)
-<<<<<<< HEAD
-					break found
-=======
-					tykOp.extractRateLimitEndpointTo(ep, path, method)
 					break
->>>>>>> cbaf8709f... [TT-12688] extractto to honor sorting (#6430)
 				}
 			}
 		}

--- a/apidef/oas/operation_test.go
+++ b/apidef/oas/operation_test.go
@@ -2,6 +2,7 @@ package oas
 
 import (
 	"context"
+	"embed"
 	"strings"
 	"testing"
 
@@ -21,6 +22,38 @@ func minimumValidOAS() OAS {
 			OpenAPI: DefaultOpenAPI,
 		},
 	}
+}
+
+//go:embed testdata/urlSorting.json
+var urlSortingFS embed.FS
+
+func TestOAS_PathsAndOperations_sorting(t *testing.T) {
+	var oasDef OAS
+	var classicDef apidef.APIDefinition
+
+	decode(t, urlSortingFS, &oasDef, "testdata/urlSorting.json")
+
+	oasDef.ExtractTo(&classicDef)
+
+	got := []string{}
+	for _, v := range classicDef.VersionData.Versions[""].ExtendedPaths.Ignored {
+		got = append(got, v.Path)
+	}
+
+	want := []string{
+		"/test/abc/def",
+		"/anything/dupa",
+		"/anything/dupe",
+		"/anything/dupi",
+		"/anything/dupo",
+		"/anything/{id}",
+		"/test/abc",
+		"/test/{id}",
+		"/anything",
+		"/test",
+	}
+
+	assert.Equal(t, want, got)
 }
 
 func TestOAS_PathsAndOperations(t *testing.T) {

--- a/apidef/oas/testdata/urlSorting.json
+++ b/apidef/oas/testdata/urlSorting.json
@@ -1,0 +1,221 @@
+{
+  "info": {
+    "title": "test",
+    "version": "1.0.0"
+  },
+  "openapi": "3.0.3",
+  "servers": [
+    {
+      "url": "http://tyk-gateway:8080/rate-limit/"
+    }
+  ],
+  "security": [],
+  "paths": {
+    "/anything": {
+      "get": {
+        "operationId": "anythingget",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/anything/dupa": {
+      "get": {
+        "operationId": "anything/dupaget",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/anything/dupe": {
+      "get": {
+        "operationId": "anything/dupeget",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/anything/dupi": {
+      "get": {
+        "operationId": "anything/dupiget",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/anything/dupo": {
+      "get": {
+        "operationId": "anything/dupoget",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/anything/{id}": {
+      "get": {
+        "operationId": "anything/{id}get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/test": {
+      "get": {
+        "operationId": "testget",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/test/abc": {
+      "get": {
+        "operationId": "test/abcget",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/test/abc/def": {
+      "get": {
+        "operationId": "test/abc/defget",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/test/{id}": {
+      "get": {
+        "operationId": "test/{id}get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {}
+  },
+  "x-tyk-api-gateway": {
+    "info": {
+      "dbId": "66a0d64a208a080001587cb3",
+      "id": "5bf76548acb3488b5c2da2f715cf42c3",
+      "orgId": "66a0d637208a080001587cb1",
+      "name": "test",
+      "state": {
+        "active": true,
+        "internal": false
+      }
+    },
+    "middleware": {
+      "global": {
+        "contextVariables": {
+          "enabled": true
+        },
+        "trafficLogs": {
+          "enabled": true
+        }
+      },
+      "operations": {
+        "anythingget": {
+          "ignoreAuthentication": {
+            "enabled": true
+          }
+        },
+        "anything/dupaget": {
+          "ignoreAuthentication": {
+            "enabled": true
+          }
+        },
+        "anything/dupeget": {
+          "ignoreAuthentication": {
+            "enabled": true
+          }
+        },
+        "anything/dupiget": {
+          "ignoreAuthentication": {
+            "enabled": true
+          }
+        },
+        "anything/dupoget": {
+          "ignoreAuthentication": {
+            "enabled": true
+          }
+        },
+        "anything/{id}get": {
+          "ignoreAuthentication": {
+            "enabled": true
+          }
+        },
+        "testget": {
+          "ignoreAuthentication": {
+            "enabled": true
+          }
+        },
+        "test/abcget": {
+          "ignoreAuthentication": {
+            "enabled": true
+          }
+        },
+        "test/abc/defget": {
+          "ignoreAuthentication": {
+            "enabled": true
+          }
+        },
+        "test/{id}get": {
+          "ignoreAuthentication": {
+            "enabled": true
+          }
+        }
+      }
+    },
+    "server": {
+      "listenPath": {
+        "strip": true,
+        "value": "/rate-limit/"
+      }
+    },
+    "upstream": {
+      "url": "http://httpbin.org/"
+    }
+  }
+}


### PR DESCRIPTION
### **User description**
[TT-12688] extractto to honor sorting (#6430)

### **User description**
ExtractTo first listed the operations to match by id, reversed order to
first sort paths.
Tests didn't cover the full ExtractTo behaviour but only the sort
behaviour, added full decode test.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Refactored the `extractPathsAndOperations` method to prioritize path
sorting before matching operations.
- Added new tests to verify the sorting of paths and operations.
- Refactored existing tests to align with the new sorting logic.
- Included new JSON test data for comprehensive testing of URL sorting.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>operation.go</strong><dd><code>Refactor path and
operation extraction logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/operation.go

<li>Refactored loop structure to prioritize path sorting before
operation <br>matching.<br> <li> Removed redundant label for breaking
out of nested loops.<br>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6430/files#diff-6d92d2d5b09a5fa7129609bb7cd0d383d015250ec07062b6a93a83257be51fb5">+3/-4</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>operation_test.go</strong><dd><code>Add tests for path
and operation sorting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; </dd></summary>
<hr>

apidef/oas/operation_test.go

<li>Added embedded test data for URL sorting.<br> <li> Implemented new
test to verify path and operation sorting.<br>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6430/files#diff-cd234db716d6d2edc97c135ef546021c9ab4fa9282d63964bd155d41635cf964">+33/-0</a>&nbsp;
&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
<summary><strong>paths_test.go</strong><dd><code>Refactor and update
path sorting tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/oasutil/paths_test.go

<li>Refactored test data setup for path sorting.<br> <li> Updated tests
to verify new sorting logic.<br>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6430/files#diff-f7100add729da81f3978c1f77efdb68106b5c7cae34c7fd7b70689a1c3896a93">+33/-28</a>&nbsp;
</td>

</tr>                    

<tr>
  <td>
    <details>
<summary><strong>urlSorting.json</strong><dd><code>Add JSON test data
for URL sorting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/testdata/urlSorting.json

- Added new JSON test data for URL sorting.



</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6430/files#diff-149f9349205863cfdc89182fa91276f8804e9053a593b6bd11152821e9458c06">+221/-0</a>&nbsp;
</td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools
and their descriptions

---------

Co-authored-by: Tit Petric <tit@tyk.io>

[TT-12688]: https://tyktech.atlassian.net/browse/TT-12688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Refactored the `extractPathsAndOperations` method to prioritize path sorting before matching operations.
- Removed redundant label for breaking out of nested loops.
- Added new tests to verify the sorting of paths and operations.
- Refactored existing tests to align with the new sorting logic.
- Included new JSON test data for comprehensive testing of URL sorting.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operation.go</strong><dd><code>Refactor path and operation extraction logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/operation.go

<li>Refactored loop structure to prioritize path sorting before operation <br>matching.<br> <li> Removed redundant label for breaking out of nested loops.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6431/files#diff-6d92d2d5b09a5fa7129609bb7cd0d383d015250ec07062b6a93a83257be51fb5">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operation_test.go</strong><dd><code>Add tests for path sorting in operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/operation_test.go

<li>Added new test <code>TestOAS_PathsAndOperations_sorting</code> to verify path <br>sorting.<br> <li> Embedded new JSON test data for comprehensive testing.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6431/files#diff-cd234db716d6d2edc97c135ef546021c9ab4fa9282d63964bd155d41635cf964">+33/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>paths_test.go</strong><dd><code>Refactor and update path sorting tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/oasutil/paths_test.go

<li>Refactored test data setup for path sorting tests.<br> <li> Updated test cases to cover new sorting logic.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6431/files#diff-f7100add729da81f3978c1f77efdb68106b5c7cae34c7fd7b70689a1c3896a93">+33/-28</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>urlSorting.json</strong><dd><code>Add JSON test data for URL sorting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/testdata/urlSorting.json

- Added new JSON test data for URL sorting.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6431/files#diff-149f9349205863cfdc89182fa91276f8804e9053a593b6bd11152821e9458c06">+221/-0</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

