### PR TITLE
[TT-11758] fix sonarcloud reported issues on errorlint.bug.major

### DIFF
--- a/cli/bundler/bundler_test.go
+++ b/cli/bundler/bundler_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -80,7 +81,7 @@ func TestBuild(t *testing.T) {
 	t.Run("Bundle errors", func(t *testing.T) {
 		ctx := &kingpin.ParseContext{}
 		err := bundler.Build(ctx)
-		if err != errManifestLoad {
+		if !errors.Is(err, errManifestLoad) {
 			t.Fatalf("Expected manifest load error, got: %s", err.Error())
 		}
 		filename := writeManifestFile(t, "{", defaultManifestPath)
@@ -101,7 +102,7 @@ func TestBuild(t *testing.T) {
 		}, defaultManifestPath)
 		bundler.manifestPath = filename
 		err = bundler.Build(ctx)
-		if err != errNoDriver {
+		if !errors.Is(err, errNoDriver) {
 			t.Fatal("Expected no driver error")
 		}
 		filename = writeManifestFile(t, &apidef.BundleManifest{
@@ -110,7 +111,7 @@ func TestBuild(t *testing.T) {
 		}, defaultManifestPath)
 		bundler.manifestPath = filename
 		err = bundler.Build(ctx)
-		if err != errNoHooks {
+		if !errors.Is(err, errNoHooks) {
 			t.Fatal("Expected no hooks error")
 		}
 		filename = writeManifestFile(t, &apidef.BundleManifest{

--- a/cli/importer/importer.go
+++ b/cli/importer/importer.go
@@ -25,7 +25,7 @@ const (
 var (
 	imp *Importer = &Importer{}
 
-	errUnknownMode = errors.New("Unknown mode")
+	errUnknownMode = errors.New("unknown mode")
 )
 
 // Importer wraps the import functionality.
@@ -61,7 +61,7 @@ func AddTo(app *kingpin.Application) {
 }
 
 // Import performs the import process.
-func (i *Importer) Import(ctx *kingpin.ParseContext) (err error) {
+func (i *Importer) Import(_ *kingpin.ParseContext) (err error) {
 	if *i.swaggerMode {
 		err = i.handleSwaggerMode()
 		if err != nil {
@@ -88,15 +88,15 @@ func (i *Importer) validateInput() error {
 
 	if *i.createAPI {
 		if *i.upstreamTarget == "" || *i.orgID == "" {
-			return fmt.Errorf("No upstream target or org ID defined, these are both required")
+			return fmt.Errorf("no upstream target or org ID defined, these are both required")
 		}
 	} else {
 		if *i.forAPI == "" {
-			return fmt.Errorf("If adding to an API, the path to the definition must be listed")
+			return fmt.Errorf("if adding to an API, the path to the definition must be listed")
 		}
 
 		if *i.asVersion == "" {
-			return fmt.Errorf("No version defined for this import operation, please set an import ID using the --as-version flag")
+			return fmt.Errorf("no version defined for this import operation, please set an import ID using the --as-version flag")
 		}
 	}
 
@@ -124,29 +124,29 @@ func (i *Importer) handleBluePrintMode() error {
 	if !*i.createAPI {
 		// Different branch, here we need an API Definition to modify
 		if *i.forAPI == "" {
-			return fmt.Errorf("If adding to an API, the path to the definition must be listed")
+			return fmt.Errorf("if adding to an API, the path to the definition must be listed")
 		}
 
 		if *i.asVersion == "" {
-			return fmt.Errorf("No version defined for this import operation, please set an import ID using the --as-version flag")
+			return fmt.Errorf("no version defined for this import operation, please set an import ID using the --as-version flag")
 		}
 
 		defFromFile, err := i.apiDefLoadFile(*i.forAPI)
 		if err != nil {
-			return fmt.Errorf("failed to load and decode file data for API Definition: %v", err)
+			return fmt.Errorf("failed to load and decode file data for API Definition: %w", err)
 		}
 
 		bp, err := i.bluePrintLoadFile(*i.input)
 		if err != nil {
-			return fmt.Errorf("File load error: %v", err)
+			return fmt.Errorf("file load error: %w", err)
 		}
 		versionData, err := bp.ConvertIntoApiVersion(*i.asMock)
 		if err != nil {
-			return fmt.Errorf("onversion into API Def failed: %v", err)
+			return fmt.Errorf("onversion into API Def failed: %w", err)
 		}
 
 		if err := bp.InsertIntoAPIDefinitionAsVersion(versionData, defFromFile, *i.asVersion); err != nil {
-			return fmt.Errorf("Insertion failed: %v", err)
+			return fmt.Errorf("insertion failed: %w", err)
 		}
 
 		i.printDef(defFromFile)
@@ -154,18 +154,18 @@ func (i *Importer) handleBluePrintMode() error {
 	}
 
 	if *i.upstreamTarget == "" && *i.orgID == "" {
-		return fmt.Errorf("No upstream target or org ID defined, these are both required")
+		return fmt.Errorf("no upstream target or org ID defined, these are both required")
 	}
 
 	// Create the API with the blueprint
 	bp, err := i.bluePrintLoadFile(*i.input)
 	if err != nil {
-		return fmt.Errorf("File load error: %v", err)
+		return fmt.Errorf("file load error: %w", err)
 	}
 
 	def, err := bp.ToAPIDefinition(*i.orgID, *i.upstreamTarget, *i.asMock)
 	if err != nil {
-		return fmt.Errorf("Failed to create API Definition from file")
+		return fmt.Errorf("failed to create API Definition from file")
 	}
 
 	i.printDef(def)
@@ -178,48 +178,48 @@ func (i *Importer) handleSwaggerMode() error {
 			// Create the API with the blueprint
 			s, err := i.swaggerLoadFile(*i.input)
 			if err != nil {
-				return fmt.Errorf("File load error: %v", err)
+				return fmt.Errorf("file load error: %w", err)
 			}
 
 			def, err := s.ToAPIDefinition(*i.orgID, *i.upstreamTarget, *i.asMock)
 			if err != nil {
-				return fmt.Errorf("Failed to create API Defintition from file")
+				return fmt.Errorf("failed to create API Defintition from file")
 			}
 
 			i.printDef(def)
 			return nil
 		}
 
-		return fmt.Errorf("No upstream target or org ID defined, these are both required")
+		return fmt.Errorf("no upstream target or org ID defined, these are both required")
 
 	}
 
 	// Different branch, here we need an API Definition to modify
 	if *i.forAPI == "" {
-		return fmt.Errorf("If adding to an API, the path to the definition must be listed")
+		return fmt.Errorf("if adding to an API, the path to the definition must be listed")
 	}
 
 	if *i.asVersion == "" {
-		return fmt.Errorf("No version defined for this import operation, please set an import ID using the --as-version flag")
+		return fmt.Errorf("no version defined for this import operation, please set an import ID using the --as-version flag")
 	}
 
 	defFromFile, err := i.apiDefLoadFile(*i.forAPI)
 	if err != nil {
-		return fmt.Errorf("failed to load and decode file data for API Definition: %v", err)
+		return fmt.Errorf("failed to load and decode file data for API Definition: %w", err)
 	}
 
 	s, err := i.swaggerLoadFile(*i.input)
 	if err != nil {
-		return fmt.Errorf("File load error: %v", err)
+		return fmt.Errorf("file load error: %w", err)
 	}
 
 	versionData, err := s.ConvertIntoApiVersion(*i.asMock)
 	if err != nil {
-		return fmt.Errorf("Conversion into API Def failed: %v", err)
+		return fmt.Errorf("conversion into API Def failed: %w", err)
 	}
 
 	if err := s.InsertIntoAPIDefinitionAsVersion(versionData, defFromFile, *i.asVersion); err != nil {
-		return fmt.Errorf("Insertion failed: %v", err)
+		return fmt.Errorf("insertion failed: %w", err)
 	}
 
 	i.printDef(defFromFile)
@@ -239,7 +239,7 @@ func (i *Importer) handleWSDLMode() error {
 	//Load WSDL file
 	w, err := i.wsdlLoadFile(*i.input)
 	if err != nil {
-		return fmt.Errorf("File load error: %v", err)
+		return fmt.Errorf("file load error: %w", err)
 	}
 
 	w.SetServicePortMapping(serviceportMapping)
@@ -248,7 +248,7 @@ func (i *Importer) handleWSDLMode() error {
 		//Create new API
 		def, err = w.ToAPIDefinition(*i.orgID, *i.upstreamTarget, *i.asMock)
 		if err != nil {
-			return fmt.Errorf("Failed to create API Defintition from file")
+			return fmt.Errorf("failed to create API Defintition from file")
 		}
 	} else {
 		//Add into existing API
@@ -259,11 +259,11 @@ func (i *Importer) handleWSDLMode() error {
 
 		versionData, err := w.ConvertIntoApiVersion(*i.asMock)
 		if err != nil {
-			return fmt.Errorf("Conversion into API Def failed: %v", err)
+			return fmt.Errorf("conversion into API Def failed: %w", err)
 		}
 
 		if err := w.InsertIntoAPIDefinitionAsVersion(versionData, def, *i.asVersion); err != nil {
-			return fmt.Errorf("Insertion failed: %v", err)
+			return fmt.Errorf("insertion failed: %w", err)
 		}
 
 	}

--- a/gateway/analytics_go_plugin.go
+++ b/gateway/analytics_go_plugin.go
@@ -49,7 +49,7 @@ func (m *GoAnalyticsPlugin) processRecord(record *analytics.AnalyticsRecord) (er
 	defer func() {
 
 		if e := recover(); e != nil {
-			err = fmt.Errorf("%v", errors.New(fmt.Sprint(err)))
+			err = errors.New(fmt.Sprint(err))
 			m.logger.WithError(err).Error("Recovered from panic while running Go-plugin middleware func")
 		}
 

--- a/gateway/batch_requests.go
+++ b/gateway/batch_requests.go
@@ -182,13 +182,13 @@ func (b *BatchRequestHandler) ManualBatchRequest(requestObject []byte) ([]byte, 
 	// Decode request
 	var batchRequest BatchRequestStructure
 	if err := json.Unmarshal(requestObject, &batchRequest); err != nil {
-		return nil, fmt.Errorf("Could not decode batch request, decoding failed: %v", err)
+		return nil, fmt.Errorf("could not decode batch request, decoding failed: %w", err)
 	}
 
 	// Construct the unsafe requests
 	requestSet, err := b.ConstructRequests(batchRequest, true)
 	if err != nil {
-		return nil, fmt.Errorf("Batch request creation failed , request structure malformed: %v", err)
+		return nil, fmt.Errorf("batch request creation failed , request structure malformed: %w", err)
 	}
 
 	// Run requests and collate responses
@@ -197,7 +197,7 @@ func (b *BatchRequestHandler) ManualBatchRequest(requestObject []byte) ([]byte, 
 	// Encode responses
 	replyMessage, err := json.Marshal(&replySet)
 	if err != nil {
-		return nil, fmt.Errorf("Couldn't encode response to string: %v", err)
+		return nil, fmt.Errorf("couldn't encode response to string: %w", err)
 	}
 
 	return replyMessage, nil

--- a/gateway/coprocess_events.go
+++ b/gateway/coprocess_events.go
@@ -34,7 +34,7 @@ func (l *CoProcessEventHandler) Init(handlerConf interface{}) error {
 
 	gValAsJSON, err := json.Marshal(globalVals)
 	if err != nil {
-		return fmt.Errorf("failed to marshal globals: %v", err)
+		return fmt.Errorf("failed to marshal globals: %w", err)
 	}
 
 	l.SpecJSON = json.RawMessage(gValAsJSON)

--- a/gateway/dashboard_register.go
+++ b/gateway/dashboard_register.go
@@ -166,7 +166,7 @@ func (h *HTTPDashboardHandler) NotifyDashboardOfEvent(event interface{}) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		err := fmt.Errorf("Unexpected status code while trying to notify dashboard of a key limit quota trigger.. Got %d", resp.StatusCode)
+		err := fmt.Errorf("unexpected status code while trying to notify dashboard of a key limit quota trigger.. Got %d", resp.StatusCode)
 		log.Error(err)
 		return err
 	}
@@ -323,7 +323,7 @@ func (h *HTTPDashboardHandler) DeRegister() error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("deregister request failed with status %w", resp.StatusCode)
+		return fmt.Errorf("deregister request failed with status %d", resp.StatusCode)
 	}
 
 	val := NodeResponseOK{}

--- a/gateway/dashboard_register.go
+++ b/gateway/dashboard_register.go
@@ -319,11 +319,11 @@ func (h *HTTPDashboardHandler) DeRegister() error {
 	resp, err := c.Do(req)
 
 	if err != nil {
-		return fmt.Errorf("deregister request failed with error %v", err)
+		return fmt.Errorf("deregister request failed with error %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("deregister request failed with status %v", resp.StatusCode)
+		return fmt.Errorf("deregister request failed with status %w", resp.StatusCode)
 	}
 
 	val := NodeResponseOK{}

--- a/gateway/grpc_streaming_client_test.go
+++ b/gateway/grpc_streaming_client_test.go
@@ -24,6 +24,7 @@ package gateway
 
 import (
 	"context"
+	"errors"
 	"io"
 	mathrand "math/rand"
 	"sync"
@@ -73,7 +74,7 @@ func printFeatures(t *testing.T, client pb.RouteGuideClient, rect *pb.Rectangle)
 	var features []*pb.Feature
 	for {
 		feature, err := stream.Recv()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			b := test.MarshalJSON(t)(features)
 			got := string(b)
 			if got != expectedFeatures {

--- a/gateway/grpc_streaming_server_test.go
+++ b/gateway/grpc_streaming_server_test.go
@@ -25,6 +25,7 @@ package gateway
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -80,7 +81,7 @@ func (s *routeGuideServer) RecordRoute(stream pb.RouteGuide_RecordRouteServer) e
 	startTime := time.Now()
 	for {
 		point, err := stream.Recv()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			endTime := time.Now()
 			return stream.SendAndClose(&pb.RouteSummary{
 				PointCount:   pointCount,
@@ -110,7 +111,7 @@ func (s *routeGuideServer) RecordRoute(stream pb.RouteGuide_RecordRouteServer) e
 func (s *routeGuideServer) RouteChat(stream pb.RouteGuide_RouteChatServer) error {
 	for {
 		in, err := stream.Recv()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return nil
 		}
 		if err != nil {

--- a/gateway/host_checker.go
+++ b/gateway/host_checker.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	mathrand "math/rand"
 	"net"
 	"net/http"
@@ -137,7 +138,7 @@ func (h *HostUptimeChecker) execCheck() {
 	h.resetListMu.Unlock()
 	for _, host := range h.HostList {
 		_, err := h.pool.ProcessCtx(h.Gw.ctx, host)
-		if err != nil && err != tunny.ErrPoolNotRunning {
+		if err != nil && !errors.Is(err, tunny.ErrPoolNotRunning) {
 			log.Warnf("[HOST CHECKER] could not send work, error: %v", err)
 		}
 	}

--- a/gateway/mock_response.go
+++ b/gateway/mock_response.go
@@ -43,7 +43,7 @@ func (p *ReverseProxy) mockResponse(r *http.Request) (*http.Response, error) {
 		code, contentType, body, headers, err = mockFromOAS(r, operation.route.Operation, mockResponse.FromOASExamples)
 		res.StatusCode = code
 		if err != nil {
-			err = fmt.Errorf("mock: %s", err)
+			err = fmt.Errorf("mock: %w", err)
 			return res, err
 		}
 	} else {

--- a/gateway/mw_external_oauth.go
+++ b/gateway/mw_external_oauth.go
@@ -229,7 +229,7 @@ func (k *ExternalOAuthMiddleware) introspection(accessToken string) (bool, strin
 		log.WithError(err).Debug("Doing OAuth introspection call")
 		claims, err = introspect(opts, accessToken)
 		if err != nil {
-			return false, "", fmt.Errorf("introspection err: %s", err)
+			return false, "", fmt.Errorf("introspection err: %w", err)
 		}
 
 		if opts.Cache.Enabled {
@@ -331,20 +331,20 @@ func introspect(opts apidef.Introspection, accessToken string) (jwt.MapClaims, e
 
 	res, err := http.Post(opts.URL, "application/x-www-form-urlencoded", strings.NewReader(body.Encode()))
 	if err != nil {
-		return nil, fmt.Errorf("error happened during the introspection call: %s", err)
+		return nil, fmt.Errorf("error happened during the introspection call: %w", err)
 	}
 
 	defer res.Body.Close()
 
 	bodyInBytes, err := io.ReadAll(res.Body)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't read the introspection call response: %s", err)
+		return nil, fmt.Errorf("couldn't read the introspection call response: %w", err)
 	}
 
 	var claims jwt.MapClaims
 	err = json.Unmarshal(bodyInBytes, &claims)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't unmarshal the introspection call response: %s", err)
+		return nil, fmt.Errorf("couldn't unmarshal the introspection call response: %w", err)
 	}
 
 	if res.StatusCode != http.StatusOK {

--- a/gateway/mw_oas_validate_request.go
+++ b/gateway/mw_oas_validate_request.go
@@ -91,7 +91,7 @@ func (k *ValidateRequest) ProcessRequest(w http.ResponseWriter, r *http.Request,
 
 	err := openapi3filter.ValidateRequest(r.Context(), requestValidationInput)
 	if err != nil {
-		return fmt.Errorf("request validation error: %v", err), errResponseCode
+		return fmt.Errorf("request validation error: %w", err), errResponseCode
 	}
 
 	// Handle Success

--- a/gateway/mw_transform.go
+++ b/gateway/mw_transform.go
@@ -67,7 +67,7 @@ func transformBody(r *http.Request, tmeta *TransformSpec, t *TransformMiddleware
 		var err error
 		bodyData, err = mxj.NewMapXml(body) // unmarshal
 		if err != nil {
-			return fmt.Errorf("error unmarshalling XML: %v", err)
+			return fmt.Errorf("error unmarshalling XML: %w", err)
 		}
 	case apidef.RequestJSON:
 		if len(body) == 0 {
@@ -104,7 +104,7 @@ func transformBody(r *http.Request, tmeta *TransformSpec, t *TransformMiddleware
 	// Apply to template
 	var bodyBuffer bytes.Buffer
 	if err := tmeta.Template.Execute(&bodyBuffer, bodyData); err != nil {
-		return fmt.Errorf("failed to apply template to request: %v", err)
+		return fmt.Errorf("failed to apply template to request: %w", err)
 	}
 
 	s := t.Gw.replaceTykVariables(r, bodyBuffer.String(), true)

--- a/gateway/mw_validate_json.go
+++ b/gateway/mw_validate_json.go
@@ -59,7 +59,7 @@ func (k *ValidateJSON) ProcessRequest(w http.ResponseWriter, r *http.Request, _ 
 	// Perform validation
 	result, err := gojsonschema.Validate(vPathMeta.SchemaCache, inputLoader)
 	if err != nil {
-		return fmt.Errorf("JSON parsing error: %v", err), http.StatusBadRequest
+		return fmt.Errorf("JSON parsing error: %w", err), http.StatusBadRequest
 	}
 
 	// Handle Failure

--- a/gateway/redis_signals.go
+++ b/gateway/redis_signals.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 
 	"strconv"
 	"strings"
@@ -250,7 +251,7 @@ func (r *RedisNotifier) Notify(notif interface{}) bool {
 	// pubSubLog.Debug("Sending notification", notif)
 
 	if err := r.store.Publish(r.channel, string(toSend)); err != nil {
-		if err != storage.ErrRedisIsDown {
+		if !errors.Is(err, storage.ErrRedisIsDown) {
 			pubSubLog.Error("Could not send notification: ", err)
 		}
 		return false

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -1474,7 +1474,7 @@ func (p *ReverseProxy) copyBuffer(dst io.Writer, src io.Reader) (int64, error) {
 	var written int64
 	for {
 		nr, rerr := src.Read(*buf)
-		if rerr != nil && rerr != io.EOF && rerr != context.Canceled {
+		if rerr != nil && !errors.Is(rerr, io.EOF) && !errors.Is(rerr, context.Canceled) {
 			p.logger.WithFields(logrus.Fields{
 				"prefix": "proxy",
 				"org_id": p.TykAPISpec.OrgID,
@@ -1531,15 +1531,15 @@ func (p *ReverseProxy) handleUpgradeResponse(rw http.ResponseWriter, req *http.R
 	defer close(backConnCloseCh)
 	conn, brw, err := hj.Hijack()
 	if err != nil {
-		return fmt.Errorf("Hijack failed on protocol switch: %v", err)
+		return fmt.Errorf("hijack failed on protocol switch: %w", err)
 	}
 	defer conn.Close()
 	res.Body = nil // so res.Write only writes the headers; we have res.Body in backConn above
 	if err := res.Write(brw); err != nil {
-		return fmt.Errorf("response write: %v", err)
+		return fmt.Errorf("response write: %w", err)
 	}
 	if err := brw.Flush(); err != nil {
-		return fmt.Errorf("response flush: %v", err)
+		return fmt.Errorf("response flush: %w", err)
 	}
 	errc := make(chan error, 1)
 	spc := switchProtocolCopier{user: conn, backend: backConn}
@@ -1645,7 +1645,7 @@ type nopCloser struct {
 // to have it ready for next read-cycle
 func (n nopCloser) Read(p []byte) (int, error) {
 	num, err := n.ReadSeeker.Read(p)
-	if err == io.EOF { // move to start to have it ready for next read cycle
+	if errors.Is(err, io.EOF) { // move to start to have it ready for next read cycle
 		_, seekErr := n.Seek(0, io.SeekStart)
 		if seekErr != nil {
 			log.WithError(seekErr).Error("can't rewind nopCloser")
@@ -1704,7 +1704,7 @@ func (n *nopCloserBuffer) Read(p []byte) (int, error) {
 	}
 
 	// move to start to have it ready for next read cycle
-	if err == io.EOF {
+	if errors.Is(err, io.EOF) {
 		_, seekErr := n.Seek(0, io.SeekStart)
 		if seekErr != nil {
 			log.WithError(seekErr).Error("can't rewind nopCloserBuffer")

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -1738,7 +1738,7 @@ func TestReverseProxyWebSocketCancelation(t *testing.T) {
 		case line == terminalMsg: // this case before "err == io.EOF"
 			t.Fatalf("The websocket request was not canceled, unfortunately!")
 
-		case err == io.EOF:
+		case errors.Is(err, io.EOF):
 			return
 
 		case err != nil:

--- a/internal/graphql/graphql_request.go
+++ b/internal/graphql/graphql_request.go
@@ -1,6 +1,7 @@
 package graphql
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/TykTechnologies/graphql-go-tools/pkg/astparser"
@@ -29,11 +30,11 @@ func NewGraphStatsExtractor() *GraphStatsExtractionVisitor {
 }
 
 func (g *GraphStatsExtractionVisitor) GraphErrors(response []byte) ([]string, error) {
-	errors := make([]string, 0)
+	errs := make([]string, 0)
 	errBytes, t, _, err := jsonparser.Get(response, "errors")
 	// check if the errors key exists in the response
 	if err != nil {
-		if err == jsonparser.KeyPathNotFoundError {
+		if errors.Is(err, jsonparser.KeyPathNotFoundError) {
 			return nil, nil
 		}
 		return nil, err
@@ -44,12 +45,12 @@ func (g *GraphStatsExtractionVisitor) GraphErrors(response []byte) ([]string, er
 			if err != nil {
 				return
 			}
-			errors = append(errors, message)
+			errs = append(errs, message)
 		}); err != nil {
 			return nil, err
 		}
 	}
-	return errors, nil
+	return errs, nil
 }
 
 func (g *GraphStatsExtractionVisitor) ExtractStats(rawRequest, response, schema string) (analytics.GraphQLStats, error) {

--- a/storage/kv/consul_test.go
+++ b/storage/kv/consul_test.go
@@ -1,8 +1,9 @@
 package kv
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	consulapi "github.com/hashicorp/consul/api"
 
@@ -21,7 +22,7 @@ func TestConsul_Get(t *testing.T) {
 
 	_, err = store.Get("key")
 
-	assert.ErrorIsf(t, err, ErrKeyNotFound, "Expect key not to exists")
+	assert.ErrorIs(t, err, ErrKeyNotFound)
 
 	con := store.(*Consul)
 

--- a/storage/kv/consul_test.go
+++ b/storage/kv/consul_test.go
@@ -1,6 +1,7 @@
 package kv
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 
 	consulapi "github.com/hashicorp/consul/api"
@@ -20,9 +21,7 @@ func TestConsul_Get(t *testing.T) {
 
 	_, err = store.Get("key")
 
-	if err != ErrKeyNotFound {
-		t.Fatal("Expect key not to exists")
-	}
+	assert.ErrorIsf(t, err, ErrKeyNotFound, "Expect key not to exists")
 
 	con := store.(*Consul)
 

--- a/storage/redis_cluster_test.go
+++ b/storage/redis_cluster_test.go
@@ -116,7 +116,7 @@ func TestRedisClusterGetMultiKey(t *testing.T) {
 	r.DeleteAllKeys()
 
 	_, err := r.GetMultiKey(keys)
-	if err != ErrKeyNotFound {
+	if !errors.Is(err, ErrKeyNotFound) {
 		t.Errorf("expected %v got %v", ErrKeyNotFound, err)
 	}
 	err = r.SetKey(keys[0], keys[0], 0)

--- a/tcp/tcp.go
+++ b/tcp/tcp.go
@@ -261,7 +261,7 @@ func (p *Proxy) handleConn(conn net.Conn) error {
 			if IsSocketClosed(err) && connectionClosed.Load().(bool) {
 				return
 			}
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				// End of stream from the client.
 				connectionClosed.Store(true)
 				log.WithField("conn", clientConn(conn)).Debug("End of client stream")
@@ -289,7 +289,7 @@ func (p *Proxy) handleConn(conn net.Conn) error {
 			if IsSocketClosed(err) && connectionClosed.Load().(bool) {
 				return
 			}
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				// End of stream from upstream
 				connectionClosed.Store(true)
 				log.WithField("conn", upstreamConn(rconn)).Debug("End of upstream stream")

--- a/test/http.go
+++ b/test/http.go
@@ -3,6 +3,7 @@ package test
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -197,8 +198,8 @@ type nopCloser struct {
 // to have it ready for next read-cycle
 func (n nopCloser) Read(p []byte) (int, error) {
 	num, err := n.ReadSeeker.Read(p)
-	if err == io.EOF { // move to start to have it ready for next read cycle
-		n.Seek(0, io.SeekStart)
+	if errors.Is(err, io.EOF) { // move to start to have it ready for next read cycle
+		_, _ = n.Seek(0, io.SeekStart)
 	}
 	return num, err
 }


### PR DESCRIPTION
### **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description

fix issues reported on [sonarcloud](https://sonarcloud.io/project/issues?rules=external_golangci-lint%3Aerrorlint.bug.major&issueStatuses=OPEN%2CCONFIRMED&types=BUG&id=TykTechnologies_tyk) via goalngcilint 

## Related Issue
https://tyktech.atlassian.net/browse/TT-11758

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added `errors` package import where necessary.
- Replaced direct error comparisons with `errors.Is` for better error handling.
- Used `%w` for error wrapping to provide more context.
- Standardized error messages to start with lowercase letters.
- Improved error handling in various test files using `assert.ErrorIsf`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>19 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>bundler_test.go</strong><dd><code>Improve error handling in bundler tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/bundler/bundler_test.go

<li>Added <code>errors</code> package import.<br> <li> Replaced direct error comparisons with <code>errors.Is</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6434/files#diff-ca677a25368595e118a0500bbde9d4bad2e757eaf1cbdb2514a95a9670786028">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>importer.go</strong><dd><code>Standardize error messages and improve error wrapping</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/importer/importer.go

<li>Standardized error messages to lowercase.<br> <li> Replaced direct error comparisons with <code>errors.Is</code>.<br> <li> Used <code>%w</code> for error wrapping.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6434/files#diff-2e14c21430010c2da93c039ec6e6df36715bb097488416389dec548d1db2be46">+27/-27</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>analytics_go_plugin.go</strong><dd><code>Simplify error assignment in defer function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/analytics_go_plugin.go

- Simplified error assignment in defer function.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6434/files#diff-cb35c821b08f61dd39174ff04aa88467294fb465840fac8041908a30d1a74d84">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>batch_requests.go</strong><dd><code>Improve error wrapping and standardize messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/batch_requests.go

<li>Used <code>%w</code> for error wrapping.<br> <li> Standardized error messages to lowercase.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6434/files#diff-2592f5fcee155ea0616be637ef7cf4479ae41a23beaadd230c26d8e3f056cd04">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>coprocess_events.go</strong><dd><code>Improve error wrapping in coprocess events</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/coprocess_events.go

- Used `%w` for error wrapping.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6434/files#diff-2d1a0fbc732d6ac61b375377d69d89513fb641c39c578b12a71b6e384c0ff5a8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>dashboard_register.go</strong><dd><code>Improve error wrapping in dashboard register</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/dashboard_register.go

- Used `%w` for error wrapping.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6434/files#diff-f504c88b3d2fa3b56b74c252aab41a934156879ef1150d33714225749e6cc94c">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>grpc_streaming_client_test.go</strong><dd><code>Improve error handling in gRPC streaming client tests</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/grpc_streaming_client_test.go

<li>Added <code>errors</code> package import.<br> <li> Replaced direct error comparisons with <code>errors.Is</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6434/files#diff-1268c35895b3fe58b2bcf8a9cd4c0d75d2dde60d91e18deba254c19622d301f5">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>grpc_streaming_server_test.go</strong><dd><code>Improve error handling in gRPC streaming server tests</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/grpc_streaming_server_test.go

<li>Added <code>errors</code> package import.<br> <li> Replaced direct error comparisons with <code>errors.Is</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6434/files#diff-61f9d7f56d9104b7efc7a5c913b8d4958f3cd33acee96eeafe31a9df4a98337a">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>host_checker.go</strong><dd><code>Improve error handling in host checker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/host_checker.go

<li>Added <code>errors</code> package import.<br> <li> Replaced direct error comparisons with <code>errors.Is</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6434/files#diff-a0eaa8c9fb4c1479a5b080cd3b6faf25ce1d218ca107d5b07888d4ffc97aadac">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mock_response.go</strong><dd><code>Improve error wrapping in mock response</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mock_response.go

- Used `%w` for error wrapping.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6434/files#diff-8aef512076b7695a6fa276dfc7f2b11f9e0d3b4a4d7f33b8404cbb29b47d3a9f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_external_oauth.go</strong><dd><code>Improve error wrapping in external OAuth middleware</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_external_oauth.go

- Used `%w` for error wrapping.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6434/files#diff-49758921227a3506a0c29936c58d02fbc8829d140acb5730de55f6621823a82c">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_oas_validate_request.go</strong><dd><code>Improve error wrapping in OAS request validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_oas_validate_request.go

- Used `%w` for error wrapping.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6434/files#diff-f5de96d1354ffab65e076f23a58337a7799a212f6e70dea59b56576042ecd69a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_transform.go</strong><dd><code>Improve error wrapping in request transformation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_transform.go

- Used `%w` for error wrapping.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6434/files#diff-d7a3cdc3dcabd415dffee6c044ea27dbe877add0ddc42471e10943125693fc12">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_validate_json.go</strong><dd><code>Improve error wrapping in JSON validation middleware</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_validate_json.go

- Used `%w` for error wrapping.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6434/files#diff-0f0c6b9ac40c5e01908a5b24b1d03111c8d8b4dbc1ddc0251d17c3c1b5328ab5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>redis_signals.go</strong><dd><code>Improve error handling in Redis signals</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/redis_signals.go

<li>Added <code>errors</code> package import.<br> <li> Replaced direct error comparisons with <code>errors.Is</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6434/files#diff-18cb136722c238e19b02741a85510dfd464343f85365482f0873aa60a37718af">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>reverse_proxy.go</strong><dd><code>Improve error handling and wrapping in reverse proxy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/reverse_proxy.go

<li>Replaced direct error comparisons with <code>errors.Is</code>.<br> <li> Used <code>%w</code> for error wrapping.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6434/files#diff-e6e07722257f7e41691e471185ad6d84fd56dc9e5459526ea32e9a5e8fa1a01b">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>reverse_proxy_test.go</strong><dd><code>Improve error handling in reverse proxy tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/reverse_proxy_test.go

- Replaced direct error comparisons with `errors.Is`.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6434/files#diff-ce040f6555143f760fba6059744bc600b6954f0966dfb0fa2832b5eabf7a3c3f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>graphql_request.go</strong><dd><code>Improve error handling in GraphQL request</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/graphql/graphql_request.go

<li>Added <code>errors</code> package import.<br> <li> Replaced direct error comparisons with <code>errors.Is</code>.<br> <li> Renamed variable to avoid shadowing.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6434/files#diff-8cc52a1c92c2035fddfc3c896e8028361b656a29a37c155ad262e9351ea8d540">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tcp.go</strong><dd><code>Improve error handling in TCP proxy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tcp/tcp.go

- Replaced direct error comparisons with `errors.Is`.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6434/files#diff-4964880da1ba03845181b6d43ad9c238e7ff6c8f6a1766deb10d65ebdcc7e4ec">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>consul_test.go</strong><dd><code>Use assert.ErrorIsf for error comparison in Consul tests</code>&nbsp; </dd></summary>
<hr>

storage/kv/consul_test.go

- Added `assert.ErrorIsf` for error comparison.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6434/files#diff-c657354858d474f8868624bc4a8c71e22be58b304b96e78f2150fac2d6f9cbe0">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>redis_cluster_test.go</strong><dd><code>Improve error handling in Redis cluster tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

storage/redis_cluster_test.go

<li>Added <code>errors</code> package import.<br> <li> Replaced direct error comparisons with <code>errors.Is</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6434/files#diff-6881545acab41fff3221454e0efb16302c696ea1217da926f80332a62ef51c71">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>http.go</strong><dd><code>Improve error handling in HTTP tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/http.go

<li>Added <code>errors</code> package import.<br> <li> Replaced direct error comparisons with <code>errors.Is</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6434/files#diff-a5530e34c740ce6fe2efe8dda5a356463c450696b39b97b91228f1be2491e05e">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

