### PR TITLE
[TT-11758] fix sonarcloud reported issues on errorlint.bug.major

### DIFF
--- a/cli/importer/importer.go
+++ b/cli/importer/importer.go
@@ -254,7 +254,7 @@ func (i *Importer) handleWSDLMode() error {
 		//Add into existing API
 		def, err = i.apiDefLoadFile(*i.forAPI)
 		if err != nil {
-			return fmt.Errorf("failed to load and decode file data for API Definition: %v", err)
+			return fmt.Errorf("failed to load and decode file data for API Definition: %w", err)
 		}
 
 		versionData, err := w.ConvertIntoApiVersion(*i.asMock)

--- a/cli/linter/linter.go
+++ b/cli/linter/linter.go
@@ -2,6 +2,7 @@ package linter
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -70,7 +71,8 @@ func addFormats(chain *schema.FormatCheckerChain) {
 	}))
 	chain.Add("host-no-port", stringFormat(func(host string) bool {
 		_, port, err := net.SplitHostPort(host)
-		if a, ok := err.(*net.AddrError); ok && a.Err == "missing port in address" {
+		var a *net.AddrError
+		if errors.As(err, &a) && a.Err == "missing port in address" {
 			// port being missing is ok
 			err = nil
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -1292,10 +1292,10 @@ func FillEnv(conf *Config) error {
 	}
 
 	if err := envconfig.Process(envPrefix, conf); err != nil {
-		return fmt.Errorf("failed to process config env vars: %v", err)
+		return fmt.Errorf("failed to process config env vars: %w", err)
 	}
 	if err := processCustom(envPrefix, conf, loadZipkin, loadJaeger); err != nil {
-		return fmt.Errorf("failed to process config custom loader: %v", err)
+		return fmt.Errorf("failed to process config custom loader: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
### **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description

fix issues reported on [sonarcloud](https://sonarcloud.io/project/issues?rules=external_golangci-lint%3Aerrorlint.bug.major&issueStatuses=OPEN%2CCONFIRMED&types=BUG&id=TykTechnologies_tyk) via goalngcilint

## Related Issue
https://tyktech.atlassian.net/browse/TT-11758

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Bug fix


___

### **Description**
- Improved error wrapping by replacing `%v` with `%w` in `fmt.Errorf` in `handleWSDLMode` function in `cli/importer/importer.go`.
- Added `errors` package import and used `errors.As` for type assertion in `addFormats` function in `cli/linter/linter.go`.
- Improved error wrapping by replacing `%v` with `%w` in `fmt.Errorf` in `FillEnv` function in `config/config.go`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>importer.go</strong><dd><code>Improve error wrapping in `handleWSDLMode` function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/importer/importer.go

- Replaced `%v` with `%w` in `fmt.Errorf` to wrap errors properly.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6435/files#diff-2e14c21430010c2da93c039ec6e6df36715bb097488416389dec548d1db2be46">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>linter.go</strong><dd><code>Use `errors.As` for type assertion in `addFormats` function</code></dd></summary>
<hr>

cli/linter/linter.go

<li>Added <code>errors</code> package import.<br> <li> Used <code>errors.As</code> for type assertion in <code>addFormats</code> function.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6435/files#diff-17b2a65a9143043763498d0464d38d5098cf1b985e865cf76af8944020d3be9d">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>config.go</strong><dd><code>Improve error wrapping in `FillEnv` function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/config.go

- Replaced `%v` with `%w` in `fmt.Errorf` to wrap errors properly.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6435/files#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

