### PR TITLE
[TT-12762]respect response plugins contract over responsePlugin.plugins

### DIFF
--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -414,6 +414,7 @@ func (g *Global) extractResponsePluginsTo(api *apidef.APIDefinition) {
 	if g.ResponsePlugins != nil {
 		api.CustomMiddleware.Response = make([]apidef.MiddlewareDefinition, len(g.ResponsePlugins))
 		g.ResponsePlugins.ExtractTo(api.CustomMiddleware.Response)
+		return
 	}
 
 	if g.ResponsePlugin == nil {

--- a/apidef/oas/middleware_test.go
+++ b/apidef/oas/middleware_test.go
@@ -29,6 +29,7 @@ func TestMiddleware(t *testing.T) {
 				Path:         "/path",
 			},
 		}
+
 		var pluginMW = Middleware{
 			Global: &Global{
 				PrePlugin: &PrePlugin{
@@ -69,6 +70,61 @@ func TestMiddleware(t *testing.T) {
 				ResponsePlugins:           customPlugins,
 			},
 		}
+		assert.Equal(t, expectedMW, resultMiddleware)
+	})
+
+	t.Run("response plugins", func(t *testing.T) {
+		customPlugins := CustomPlugins{
+			CustomPlugin{
+				Enabled:      true,
+				FunctionName: "func1",
+				Path:         "/path1",
+			},
+		}
+
+		responsePlugins := CustomPlugins{
+			CustomPlugin{
+				Enabled:      true,
+				FunctionName: "func2",
+				Path:         "/path2",
+			},
+			CustomPlugin{
+				Enabled:      true,
+				FunctionName: "func3",
+				Path:         "/path3",
+			},
+		}
+
+		var pluginMW = Middleware{
+			Global: &Global{
+				ResponsePlugin: &ResponsePlugin{
+					Plugins: customPlugins,
+				},
+				ResponsePlugins: responsePlugins,
+			},
+		}
+
+		var convertedAPI apidef.APIDefinition
+		convertedAPI.SetDisabledFlags()
+
+		pluginMW.ExtractTo(&convertedAPI)
+
+		// regression  https://tyktech.atlassian.net/browse/TT-12762
+		assert.Equal(t, len(responsePlugins), len(convertedAPI.CustomMiddleware.Response))
+
+		var resultMiddleware = Middleware{
+			Global: &Global{
+				ResponsePlugin: &ResponsePlugin{},
+			},
+		}
+		resultMiddleware.Fill(convertedAPI)
+
+		expectedMW := Middleware{
+			Global: &Global{
+				ResponsePlugins: responsePlugins,
+			},
+		}
+
 		assert.Equal(t, expectedMW, resultMiddleware)
 	})
 }


### PR DESCRIPTION
### **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description

Fix a bug where response plugins are not loaded when using OAS APIs.
## Related Issue
https://tyktech.atlassian.net/browse/TT-12762

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed a bug where response plugins were not loaded correctly when using OAS APIs by adding a return statement after extracting response plugins.
- Added a new test case to verify the correct extraction of response plugins and ensure the regression issue TT-12762 is resolved.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>middleware.go</strong><dd><code>Fix response plugins extraction logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/middleware.go

<li>Added a return statement after extracting response plugins to ensure <br>correct behavior.<br> <li> Initialized <code>ResponsePlugin</code> if it is nil.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6441/files#diff-992ec7c28d25fd54f6491d295389757705cd114bc869a35cba50d42e548cdc6e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>middleware_test.go</strong><dd><code>Add test for response plugins extraction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/middleware_test.go

<li>Added a new test case to verify the correct extraction of response <br>plugins.<br> <li> Ensured the test case checks for the regression issue TT-12762.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6441/files#diff-0af31cb29ae298a6ac3e402b283ab364a6fd793fd04f253ef7c4983234c17bef">+56/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

