### PR TITLE
Abstracts storage constructors back to interface, as prep for redis alternatives

### DIFF
--- a/certs/manager.go
+++ b/certs/manager.go
@@ -18,9 +18,10 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/TykTechnologies/tyk/interfaces"
 	"github.com/TykTechnologies/tyk/internal/cache"
 	tykcrypto "github.com/TykTechnologies/tyk/internal/crypto"
-	"github.com/TykTechnologies/tyk/storage"
+	"github.com/TykTechnologies/tyk/storage/mdcb"
 )
 
 const (
@@ -52,14 +53,14 @@ type CertificateManager interface {
 }
 
 type certificateManager struct {
-	storage         storage.Handler
+	storage         interfaces.Handler
 	logger          *logrus.Entry
 	cache           cache.Repository
 	secret          string
 	migrateCertList bool
 }
 
-func NewCertificateManager(storage storage.Handler, secret string, logger *logrus.Logger, migrateCertList bool) *certificateManager {
+func NewCertificateManager(storage interfaces.Handler, secret string, logger *logrus.Logger, migrateCertList bool) *certificateManager {
 	if logger == nil {
 		logger = logrus.New()
 	}
@@ -79,7 +80,7 @@ func getOrgFromKeyID(key, certID string) string {
 	return orgId
 }
 
-func NewSlaveCertManager(localStorage, rpcStorage storage.Handler, secret string, logger *logrus.Logger, migrateCertList bool) *certificateManager {
+func NewSlaveCertManager(localStorage, rpcStorage interfaces.Handler, secret string, logger *logrus.Logger, migrateCertList bool) *certificateManager {
 	if logger == nil {
 		logger = logrus.New()
 	}
@@ -101,7 +102,7 @@ func NewSlaveCertManager(localStorage, rpcStorage storage.Handler, secret string
 		return err
 	}
 
-	mdcbStorage := storage.NewMdcbStorage(localStorage, rpcStorage, log)
+	mdcbStorage := mdcb.NewMdcbStorage(localStorage, rpcStorage, log)
 	mdcbStorage.CallbackonPullfromRPC = &callbackOnPullCertFromRPC
 
 	cm.storage = mdcbStorage

--- a/certs/manager_test.go
+++ b/certs/manager_test.go
@@ -196,7 +196,7 @@ func TestStorageIndex(t *testing.T) {
 	storage, ok := m.storage.(*storage.DummyStorage)
 
 	if !ok {
-		t.Error("cannot make storage.DummyStorage of type storage.Handler")
+		t.Error("cannot make storage.DummyStorage of type interfaces.Handler")
 	}
 
 	if len(storage.IndexList) != 0 {

--- a/ctx/ctx.go
+++ b/ctx/ctx.go
@@ -6,12 +6,12 @@ import (
 	"net/http"
 
 	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/storage/util"
 
 	"github.com/TykTechnologies/tyk/config"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	logger "github.com/TykTechnologies/tyk/log"
-	"github.com/TykTechnologies/tyk/storage"
 	"github.com/TykTechnologies/tyk/user"
 )
 
@@ -69,7 +69,7 @@ func ctxSetSession(r *http.Request, s *user.SessionState, scheduleUpdate bool, h
 	}
 
 	if s.KeyHashEmpty() {
-		s.SetKeyHash(storage.HashKey(s.KeyID, hashKey))
+		s.SetKeyHash(util.HashKey(s.KeyID, hashKey))
 	}
 
 	ctx := r.Context()

--- a/gateway/analytics.go
+++ b/gateway/analytics.go
@@ -16,6 +16,7 @@ import (
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/regexp"
 	"github.com/TykTechnologies/tyk/storage"
+	"github.com/TykTechnologies/tyk/storage/util"
 )
 
 const analyticsKeyName = "tyk-system-analytics"
@@ -175,7 +176,7 @@ func (r *RedisAnalyticsHandler) recordWorker() {
 			// we have new record - prepare it and add to buffer
 
 			// If we are obfuscating API Keys, store the hashed representation (config check handled in hashing function)
-			record.APIKey = storage.HashKey(record.APIKey, r.globalConf.HashKeys)
+			record.APIKey = util.HashKey(record.APIKey, r.globalConf.HashKeys)
 
 			if r.globalConf.SlaveOptions.UseRPC {
 				// Extend tag list to include this data so wecan segment by node if necessary

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -2236,7 +2236,7 @@ func (gw *Gateway) createOauthClient(w http.ResponseWriter, r *http.Request) {
 					storageManager := gw.getGlobalMDCBStorageHandler(prefix, false)
 					storageManager.Connect()
 
-					store, err := storage.NewStorageHandler(storage.REDIS_CLUSTER,
+					store, err := storage.NewStorageHandler(storage.GetStorageForModule(storage.DEFAULT_MODULE),
 						storage.WithKeyPrefix(prefix),
 						storage.WithHashKeys(false),
 						storage.WithConnectionHandler(gw.StorageConnectionHandler))
@@ -2640,7 +2640,7 @@ func (gw *Gateway) getOauthClientDetails(keyName, apiID string) (interface{}, in
 		storageManager := gw.getGlobalMDCBStorageHandler(prefix, false)
 		storageManager.Connect()
 
-		store, err := storage.NewStorageHandler(storage.REDIS_CLUSTER,
+		store, err := storage.NewStorageHandler(storage.GetStorageForModule(storage.DEFAULT_MODULE),
 			storage.WithKeyPrefix(prefix),
 			storage.WithHashKeys(false),
 			storage.WithConnectionHandler(gw.StorageConnectionHandler))

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -19,6 +19,7 @@ import (
 	texttemplate "text/template"
 	"time"
 
+	"github.com/TykTechnologies/tyk/interfaces"
 	"github.com/TykTechnologies/tyk/storage/kv"
 
 	"github.com/getkin/kin-openapi/routers"
@@ -49,7 +50,6 @@ import (
 	"github.com/TykTechnologies/tyk/header"
 	"github.com/TykTechnologies/tyk/regexp"
 	"github.com/TykTechnologies/tyk/rpc"
-	"github.com/TykTechnologies/tyk/storage"
 )
 
 // const used by cache middleware
@@ -1421,7 +1421,7 @@ func (a APIDefinitionLoader) getExtendedPathSpecs(apiVersionDef apidef.VersionIn
 	return combinedPath, len(whiteListPaths) > 0
 }
 
-func (a *APISpec) Init(authStore, sessionStore, healthStore, orgStore storage.Handler) {
+func (a *APISpec) Init(authStore, sessionStore, healthStore, orgStore interfaces.Handler) {
 	a.AuthManager.Init(authStore)
 	a.Health.Init(healthStore)
 	a.OrgSessionManager.Init(orgStore)

--- a/gateway/api_healthcheck.go
+++ b/gateway/api_healthcheck.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/TykTechnologies/tyk/storage"
+	"github.com/TykTechnologies/tyk/interfaces"
 )
 
 type HealthPrefix string
@@ -19,7 +19,7 @@ const (
 )
 
 type HealthChecker interface {
-	Init(storage.Handler)
+	Init(interfaces.Handler)
 	ApiHealthValues() (HealthCheckValues, error)
 	StoreCounterVal(HealthPrefix, string)
 }
@@ -34,11 +34,11 @@ type HealthCheckValues struct {
 
 type DefaultHealthChecker struct {
 	Gw      *Gateway `json:"-"`
-	storage storage.Handler
+	storage interfaces.Handler
 	APIID   string
 }
 
-func (h *DefaultHealthChecker) Init(storeType storage.Handler) {
+func (h *DefaultHealthChecker) Init(storeType interfaces.Handler) {
 	if !h.Gw.GetConfig().HealthCheck.EnableHealthChecks {
 		return
 	}

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -44,7 +44,7 @@ type ChainObject struct {
 func (gw *Gateway) prepareStorage() generalStores {
 	var gs generalStores
 	var err error
-	gs.redisStore, err = storage.NewStorageHandler(storage.REDIS_CLUSTER,
+	gs.redisStore, err = storage.NewStorageHandler(storage.GetStorageForModule(storage.DEFAULT_MODULE),
 		storage.WithKeyPrefix("apikey-"),
 		storage.WithHashKeys(gw.GetConfig().HashKeys),
 		storage.WithConnectionHandler(gw.StorageConnectionHandler),
@@ -54,7 +54,7 @@ func (gw *Gateway) prepareStorage() generalStores {
 		log.WithError(err).Fatal("Failed to create redis storage handler")
 	}
 
-	gs.redisOrgStore, err = storage.NewStorageHandler(storage.REDIS_CLUSTER,
+	gs.redisOrgStore, err = storage.NewStorageHandler(storage.GetStorageForModule(storage.DEFAULT_MODULE),
 		storage.WithKeyPrefix("orgkey."),
 		storage.WithHashKeys(gw.GetConfig().HashKeys),
 		storage.WithConnectionHandler(gw.StorageConnectionHandler),
@@ -64,7 +64,7 @@ func (gw *Gateway) prepareStorage() generalStores {
 		log.WithError(err).Fatal("Failed to create redis storage handler")
 	}
 
-	gs.healthStore, err = storage.NewStorageHandler(storage.REDIS_CLUSTER,
+	gs.healthStore, err = storage.NewStorageHandler(storage.GetStorageForModule(storage.DEFAULT_MODULE),
 		storage.WithKeyPrefix("apihealth."),
 		storage.WithHashKeys(gw.GetConfig().HashKeys),
 		storage.WithConnectionHandler(gw.StorageConnectionHandler),
@@ -317,7 +317,7 @@ func (gw *Gateway) processSpec(spec *APISpec, apisByListen map[string]int,
 	}
 
 	keyPrefix := "cache-" + spec.APIID
-	cacheStore, err := storage.NewStorageHandler(storage.REDIS_CLUSTER,
+	cacheStore, err := storage.NewStorageHandler(storage.GetStorageForModule(storage.DEFAULT_MODULE),
 		storage.WithKeyPrefix(keyPrefix),
 		storage.WithConnectionHandler(gw.StorageConnectionHandler),
 		storage.IsCache(true),

--- a/gateway/auth_manager_test.go
+++ b/gateway/auth_manager_test.go
@@ -13,11 +13,11 @@ import (
 
 	"github.com/TykTechnologies/tyk/certs"
 	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/storage/util"
 
 	"github.com/TykTechnologies/tyk/header"
 
 	"github.com/TykTechnologies/tyk/apidef"
-	"github.com/TykTechnologies/tyk/storage"
 
 	"github.com/TykTechnologies/tyk/test"
 	"github.com/TykTechnologies/tyk/user"
@@ -86,7 +86,7 @@ func TestAuthenticationAfterUpdateKey(t *testing.T) {
 			APIID: api.APIID,
 		}}
 
-		err := ts.Gw.GlobalSessionManager.UpdateSession(storage.HashKey(key, ts.Gw.GetConfig().HashKeys), session, 0, ts.Gw.GetConfig().HashKeys)
+		err := ts.Gw.GlobalSessionManager.UpdateSession(util.HashKey(key, ts.Gw.GetConfig().HashKeys), session, 0, ts.Gw.GetConfig().HashKeys)
 		if err != nil {
 			t.Error("could not update session in Session Manager. " + err.Error())
 		}
@@ -103,7 +103,7 @@ func TestAuthenticationAfterUpdateKey(t *testing.T) {
 			APIID: "dummy",
 		}}
 
-		err = ts.Gw.GlobalSessionManager.UpdateSession(storage.HashKey(key, ts.Gw.GetConfig().HashKeys), session, 0, ts.Gw.GetConfig().HashKeys)
+		err = ts.Gw.GlobalSessionManager.UpdateSession(util.HashKey(key, ts.Gw.GetConfig().HashKeys), session, 0, ts.Gw.GetConfig().HashKeys)
 		if err != nil {
 			t.Error("could not update session in Session Manager. " + err.Error())
 		}
@@ -386,7 +386,7 @@ func TestCustomKeysEdgeGw(t *testing.T) {
 func TestDeleteRawKeysWithAllowanceScope(t *testing.T) {
 	sessionManager := DefaultSessionManager{}
 
-	t.Run("should not panic if storage.Handler is nil", func(t *testing.T) {
+	t.Run("should not panic if interfaces.Handler is nil", func(t *testing.T) {
 		session := &user.SessionState{
 			AccessRights: map[string]user.AccessDefinition{
 				"ar1": {AllowanceScope: "scope1"},

--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -23,11 +23,11 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/TykTechnologies/tyk/certs/mock"
+	"github.com/TykTechnologies/tyk/storage/util"
 
 	"github.com/TykTechnologies/tyk/internal/crypto"
 
 	"github.com/TykTechnologies/tyk/header"
-	"github.com/TykTechnologies/tyk/storage"
 
 	"github.com/TykTechnologies/tyk/user"
 
@@ -1310,7 +1310,7 @@ func TestKeyWithCertificateTLS(t *testing.T) {
 		_, _ = ts.Run(t, test.TestCase{Path: "/", Code: 200, Client: client})
 		session.Certificate = "fooBar"
 		// update redis directly since we have protection not to allow create of a session with wrong certificate
-		err = ts.Gw.GlobalSessionManager.UpdateSession(storage.HashKey(clientCertID, ts.Gw.GetConfig().HashKeys), session, 0, ts.Gw.GetConfig().HashKeys)
+		err = ts.Gw.GlobalSessionManager.UpdateSession(util.HashKey(clientCertID, ts.Gw.GetConfig().HashKeys), session, 0, ts.Gw.GetConfig().HashKeys)
 		if err != nil {
 			t.Error("could not update session in Session Manager. " + err.Error())
 		}

--- a/gateway/coprocess_api.go
+++ b/gateway/coprocess_api.go
@@ -25,7 +25,7 @@ func getStorageForPython(ctx context.Context) interfaces.Handler {
 	rc.WaitConnect(ctx)
 
 	store, err := storage.NewStorageHandler(
-		storage.REDIS_CLUSTER,
+		storage.GetStorageForModule(storage.DEFAULT_MODULE),
 		storage.WithKeyPrefix(CoProcessDefaultKeyPrefix),
 		storage.WithConnectionHandler(rc))
 

--- a/gateway/coprocess_api.go
+++ b/gateway/coprocess_api.go
@@ -10,19 +10,19 @@ import (
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
-	"github.com/TykTechnologies/tyk/storage"
+	redisCluster "github.com/TykTechnologies/tyk/storage/redis-cluster"
 )
 
 // CoProcessDefaultKeyPrefix is used as a key prefix for this CP.
 const CoProcessDefaultKeyPrefix = "coprocess-data:"
 
-func getStorageForPython(ctx context.Context) storage.RedisCluster {
-	rc := storage.NewConnectionHandler(ctx)
+func getStorageForPython(ctx context.Context) redisCluster.RedisCluster {
+	rc := redisCluster.NewConnectionHandler(ctx)
 
 	go rc.Connect(ctx, nil, &config.Config{})
 	rc.WaitConnect(ctx)
 
-	return storage.RedisCluster{KeyPrefix: CoProcessDefaultKeyPrefix, ConnectionHandler: rc}
+	return redisCluster.RedisCluster{KeyPrefix: CoProcessDefaultKeyPrefix, ConnectionHandler: rc}
 }
 
 // TykStoreData is a CoProcess API function for storing data.

--- a/gateway/coprocess_id_extractor_test.go
+++ b/gateway/coprocess_id_extractor_test.go
@@ -11,7 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/TykTechnologies/tyk/apidef"
-	"github.com/TykTechnologies/tyk/storage"
+	redisCluster "github.com/TykTechnologies/tyk/storage/redis-cluster"
+	"github.com/TykTechnologies/tyk/storage/util"
 )
 
 const (
@@ -33,9 +34,9 @@ func (ts *Test) createSpecTestFrom(tb testing.TB, def *apidef.APIDefinition) *AP
 	loader := APIDefinitionLoader{Gw: ts.Gw}
 	spec, _ := loader.MakeSpec(&nestedApiDefinition{APIDefinition: def}, nil)
 	tname := tb.Name()
-	redisStore := &storage.RedisCluster{KeyPrefix: tname + "-apikey.", ConnectionHandler: ts.Gw.StorageConnectionHandler}
-	healthStore := &storage.RedisCluster{KeyPrefix: tname + "-apihealth.", ConnectionHandler: ts.Gw.StorageConnectionHandler}
-	orgStore := &storage.RedisCluster{KeyPrefix: tname + "-orgKey.", ConnectionHandler: ts.Gw.StorageConnectionHandler}
+	redisStore := &redisCluster.RedisCluster{KeyPrefix: tname + "-apikey.", ConnectionHandler: ts.Gw.StorageConnectionHandler}
+	healthStore := &redisCluster.RedisCluster{KeyPrefix: tname + "-apihealth.", ConnectionHandler: ts.Gw.StorageConnectionHandler}
+	orgStore := &redisCluster.RedisCluster{KeyPrefix: tname + "-orgKey.", ConnectionHandler: ts.Gw.StorageConnectionHandler}
 	spec.Init(redisStore, redisStore, healthStore, orgStore)
 	return spec
 }
@@ -126,7 +127,7 @@ func TestValueExtractor(t *testing.T) {
 		if sessionID != testSessionID {
 			t.Fatalf("session ID doesn't match, expected %s, got %s", testSessionID, sessionID)
 		}
-		if storage.TokenOrg(sessionID) != spec.OrgID {
+		if util.TokenOrg(sessionID) != spec.OrgID {
 			t.Fatalf("session ID doesn't contain the org ID, got %s", sessionID)
 		}
 		if overrides.ResponseCode != 0 {
@@ -153,7 +154,7 @@ func TestValueExtractor(t *testing.T) {
 		if sessionID != testSessionID {
 			t.Fatalf("session ID doesn't match, expected %s, got %s", testSessionID, sessionID)
 		}
-		if storage.TokenOrg(sessionID) != spec.OrgID {
+		if util.TokenOrg(sessionID) != spec.OrgID {
 			t.Fatalf("session ID doesn't contain the org ID, got %s", sessionID)
 		}
 		if overrides.ResponseCode != 0 {
@@ -190,7 +191,7 @@ func TestRegexExtractor(t *testing.T) {
 		if sessionID != testSessionID {
 			t.Fatalf("session ID doesn't match, expected %s, got %s", testSessionID, sessionID)
 		}
-		if storage.TokenOrg(sessionID) != spec.OrgID {
+		if util.TokenOrg(sessionID) != spec.OrgID {
 			t.Fatalf("session ID doesn't contain the org ID, got %s", sessionID)
 		}
 		if overrides.ResponseCode != 0 {
@@ -219,7 +220,7 @@ func TestRegexExtractor(t *testing.T) {
 		if sessionID != testSessionID {
 			t.Fatalf("session ID doesn't match, expected %s, got %s", testSessionID, sessionID)
 		}
-		if storage.TokenOrg(sessionID) != spec.OrgID {
+		if util.TokenOrg(sessionID) != spec.OrgID {
 			t.Fatalf("session ID doesn't contain the org ID, got %s", sessionID)
 		}
 		if overrides.ResponseCode != 0 {
@@ -249,7 +250,7 @@ func TestRegexExtractor(t *testing.T) {
 		if sessionID != testSessionID {
 			t.Fatalf("session ID doesn't match, expected %s, got %s", testSessionID, sessionID)
 		}
-		if storage.TokenOrg(sessionID) != spec.OrgID {
+		if util.TokenOrg(sessionID) != spec.OrgID {
 			t.Fatalf("session ID doesn't contain the org ID, got %s", sessionID)
 		}
 		if overrides.ResponseCode != 0 {
@@ -285,7 +286,7 @@ func TestXPathExtractor(t *testing.T) {
 		if sessionID != testSessionID {
 			t.Fatalf("session ID doesn't match, expected %s, got %s", testSessionID, sessionID)
 		}
-		if storage.TokenOrg(sessionID) != spec.OrgID {
+		if util.TokenOrg(sessionID) != spec.OrgID {
 			t.Fatalf("session ID doesn't contain the org ID, got %s", sessionID)
 		}
 		if overrides.ResponseCode != 0 {
@@ -313,7 +314,7 @@ func TestXPathExtractor(t *testing.T) {
 		if sessionID != testSessionID {
 			t.Fatalf("session ID doesn't match, expected %s, got %s", testSessionID, sessionID)
 		}
-		if storage.TokenOrg(sessionID) != spec.OrgID {
+		if util.TokenOrg(sessionID) != spec.OrgID {
 			t.Fatalf("session ID doesn't contain the org ID, got %s", sessionID)
 		}
 		if overrides.ResponseCode != 0 {
@@ -342,7 +343,7 @@ func TestXPathExtractor(t *testing.T) {
 		if sessionID != testSessionID {
 			t.Fatalf("session ID doesn't match, expected %s, got %s", testSessionID, sessionID)
 		}
-		if storage.TokenOrg(sessionID) != spec.OrgID {
+		if util.TokenOrg(sessionID) != spec.OrgID {
 			t.Fatalf("session ID doesn't contain the org ID, got %s", sessionID)
 		}
 		if overrides.ResponseCode != 0 {

--- a/gateway/delete_api_cache.go
+++ b/gateway/delete_api_cache.go
@@ -8,7 +8,7 @@ import (
 
 func (gw *Gateway) invalidateAPICache(apiID string) bool {
 	store, err := storage.NewStorageHandler(
-		storage.REDIS_CLUSTER,
+		storage.GetStorageForModule(storage.DEFAULT_MODULE),
 		storage.WithConnectionHandler(gw.StorageConnectionHandler),
 		storage.IsCache(true),
 	)

--- a/gateway/delete_api_cache.go
+++ b/gateway/delete_api_cache.go
@@ -3,10 +3,20 @@ package gateway
 import (
 	"fmt"
 
-	redisCluster "github.com/TykTechnologies/tyk/storage/redis-cluster"
+	"github.com/TykTechnologies/tyk/storage"
 )
 
 func (gw *Gateway) invalidateAPICache(apiID string) bool {
-	store := redisCluster.RedisCluster{IsCache: true, ConnectionHandler: gw.StorageConnectionHandler}
+	store, err := storage.NewStorageHandler(
+		storage.REDIS_CLUSTER,
+		storage.WithConnectionHandler(gw.StorageConnectionHandler),
+		storage.IsCache(true),
+	)
+
+	if err != nil {
+		log.WithError(err).Error("could not create storage handler")
+		return false
+	}
+
 	return store.DeleteScanMatch(fmt.Sprintf("cache-%s*", apiID))
 }

--- a/gateway/delete_api_cache.go
+++ b/gateway/delete_api_cache.go
@@ -3,10 +3,10 @@ package gateway
 import (
 	"fmt"
 
-	"github.com/TykTechnologies/tyk/storage"
+	redisCluster "github.com/TykTechnologies/tyk/storage/redis-cluster"
 )
 
 func (gw *Gateway) invalidateAPICache(apiID string) bool {
-	store := storage.RedisCluster{IsCache: true, ConnectionHandler: gw.StorageConnectionHandler}
+	store := redisCluster.RedisCluster{IsCache: true, ConnectionHandler: gw.StorageConnectionHandler}
 	return store.DeleteScanMatch(fmt.Sprintf("cache-%s*", apiID))
 }

--- a/gateway/event_handler_webhooks.go
+++ b/gateway/event_handler_webhooks.go
@@ -18,8 +18,9 @@ import (
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/interfaces"
 	"github.com/TykTechnologies/tyk/internal/event"
-	"github.com/TykTechnologies/tyk/storage"
+	redisCluster "github.com/TykTechnologies/tyk/storage/redis-cluster"
 )
 
 type WebHookRequestMethod string
@@ -45,7 +46,7 @@ var (
 type WebHookHandler struct {
 	conf     apidef.WebHookHandlerConf
 	template *htmltemplate.Template // non-nil if Init is run without error
-	store    storage.Handler
+	store    interfaces.Handler
 
 	contentType      string
 	dashboardService DashboardServiceSender
@@ -69,7 +70,7 @@ func (w *WebHookHandler) Init(handlerConf interface{}) error {
 		return ErrEventHandlerDisabled
 	}
 
-	w.store = &storage.RedisCluster{KeyPrefix: "webhook.cache.", ConnectionHandler: w.Gw.StorageConnectionHandler}
+	w.store = &redisCluster.RedisCluster{KeyPrefix: "webhook.cache.", ConnectionHandler: w.Gw.StorageConnectionHandler}
 	w.store.Connect()
 
 	// Pre-load template on init

--- a/gateway/event_handler_webhooks.go
+++ b/gateway/event_handler_webhooks.go
@@ -71,7 +71,7 @@ func (w *WebHookHandler) Init(handlerConf interface{}) error {
 	}
 
 	w.store, err = storage.NewStorageHandler(
-		storage.REDIS_CLUSTER,
+		storage.GetStorageForModule(storage.DEFAULT_MODULE),
 		storage.WithKeyPrefix("webhook.cache."),
 		storage.WithConnectionHandler(w.Gw.StorageConnectionHandler),
 	)

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/TykTechnologies/tyk-pump/analytics"
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
-	"github.com/TykTechnologies/tyk/storage"
+	redisCluster "github.com/TykTechnologies/tyk/storage/redis-cluster"
 	"github.com/TykTechnologies/tyk/test"
 	"github.com/TykTechnologies/tyk/user"
 )
@@ -939,7 +939,7 @@ func TestGatewayHealthCheck(t *testing.T) {
 func TestCacheAllSafeRequests(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()
-	cache := storage.RedisCluster{KeyPrefix: "cache-", ConnectionHandler: ts.Gw.StorageConnectionHandler}
+	cache := redisCluster.RedisCluster{KeyPrefix: "cache-", ConnectionHandler: ts.Gw.StorageConnectionHandler}
 	defer cache.DeleteScanMatch("*")
 
 	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
@@ -965,7 +965,7 @@ func TestCacheAllSafeRequests(t *testing.T) {
 func TestCacheAllSafeRequestsWithCachedHeaders(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()
-	cache := storage.RedisCluster{KeyPrefix: "cache-", ConnectionHandler: ts.Gw.StorageConnectionHandler}
+	cache := redisCluster.RedisCluster{KeyPrefix: "cache-", ConnectionHandler: ts.Gw.StorageConnectionHandler}
 	defer cache.DeleteScanMatch("*")
 	authorization := "authorization"
 	tenant := "tenant-id"
@@ -1006,7 +1006,7 @@ func TestCacheAllSafeRequestsWithCachedHeaders(t *testing.T) {
 func TestCacheWithAdvanceUrlRewrite(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()
-	cache := storage.RedisCluster{KeyPrefix: "cache-", ConnectionHandler: ts.Gw.StorageConnectionHandler}
+	cache := redisCluster.RedisCluster{KeyPrefix: "cache-", ConnectionHandler: ts.Gw.StorageConnectionHandler}
 	defer cache.DeleteScanMatch("*")
 
 	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
@@ -1061,7 +1061,7 @@ func TestCacheWithAdvanceUrlRewrite(t *testing.T) {
 func TestCachePostRequest(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()
-	cache := storage.RedisCluster{KeyPrefix: "cache-", ConnectionHandler: ts.Gw.StorageConnectionHandler}
+	cache := redisCluster.RedisCluster{KeyPrefix: "cache-", ConnectionHandler: ts.Gw.StorageConnectionHandler}
 	defer cache.DeleteScanMatch("*")
 	tenant := "tenant-id"
 
@@ -1103,7 +1103,7 @@ func TestCachePostRequest(t *testing.T) {
 func TestAdvanceCachePutRequest(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()
-	cache := storage.RedisCluster{KeyPrefix: "cache-", ConnectionHandler: ts.Gw.StorageConnectionHandler}
+	cache := redisCluster.RedisCluster{KeyPrefix: "cache-", ConnectionHandler: ts.Gw.StorageConnectionHandler}
 	defer cache.DeleteScanMatch("*")
 	tenant := "tenant-id"
 
@@ -1191,7 +1191,7 @@ func TestAdvanceCachePutRequest(t *testing.T) {
 func TestCacheAllSafeRequestsWithAdvancedCacheEndpoint(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()
-	cache := storage.RedisCluster{KeyPrefix: "cache-", ConnectionHandler: ts.Gw.StorageConnectionHandler}
+	cache := redisCluster.RedisCluster{KeyPrefix: "cache-", ConnectionHandler: ts.Gw.StorageConnectionHandler}
 	defer cache.DeleteScanMatch("*")
 
 	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
@@ -1226,7 +1226,7 @@ func TestCacheAllSafeRequestsWithAdvancedCacheEndpoint(t *testing.T) {
 func TestCacheEtag(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()
-	cache := storage.RedisCluster{KeyPrefix: "cache-", ConnectionHandler: ts.Gw.StorageConnectionHandler}
+	cache := redisCluster.RedisCluster{KeyPrefix: "cache-", ConnectionHandler: ts.Gw.StorageConnectionHandler}
 	defer cache.DeleteScanMatch("*")
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1276,7 +1276,7 @@ func TestOldCachePlugin(t *testing.T) {
 
 	check := func(t *testing.T) {
 		t.Helper()
-		cache := storage.RedisCluster{KeyPrefix: "cache-", ConnectionHandler: ts.Gw.StorageConnectionHandler}
+		cache := redisCluster.RedisCluster{KeyPrefix: "cache-", ConnectionHandler: ts.Gw.StorageConnectionHandler}
 		defer cache.DeleteScanMatch("*")
 
 		ts.Gw.LoadAPI(api)
@@ -1301,7 +1301,7 @@ func TestOldCachePlugin(t *testing.T) {
 func TestAdvanceCacheTimeoutPerEndpoint(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()
-	cache := storage.RedisCluster{KeyPrefix: "cache-", ConnectionHandler: ts.Gw.StorageConnectionHandler}
+	cache := redisCluster.RedisCluster{KeyPrefix: "cache-", ConnectionHandler: ts.Gw.StorageConnectionHandler}
 	defer cache.DeleteScanMatch("*")
 
 	extendedPaths := apidef.ExtendedPathsSet{

--- a/gateway/health_check.go
+++ b/gateway/health_check.go
@@ -66,7 +66,7 @@ func (gw *Gateway) gatherHealthChecks() {
 	allInfos := SafeHealthCheck{info: make(map[string]apidef.HealthCheckItem, 3)}
 
 	store, err := storage.NewStorageHandler(
-		storage.REDIS_CLUSTER,
+		storage.GetStorageForModule(storage.DEFAULT_MODULE),
 		storage.WithKeyPrefix("livenesscheck-"),
 		storage.WithConnectionHandler(gw.StorageConnectionHandler))
 

--- a/gateway/health_check.go
+++ b/gateway/health_check.go
@@ -9,12 +9,12 @@ import (
 	"time"
 
 	"github.com/TykTechnologies/tyk/rpc"
+	redisCluster "github.com/TykTechnologies/tyk/storage/redis-cluster"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/header"
-	"github.com/TykTechnologies/tyk/storage"
 )
 
 func (gw *Gateway) setCurrentHealthCheckInfo(h map[string]apidef.HealthCheckItem) {
@@ -65,7 +65,7 @@ type SafeHealthCheck struct {
 func (gw *Gateway) gatherHealthChecks() {
 	allInfos := SafeHealthCheck{info: make(map[string]apidef.HealthCheckItem, 3)}
 
-	redisStore := storage.RedisCluster{KeyPrefix: "livenesscheck-", ConnectionHandler: gw.StorageConnectionHandler}
+	redisStore := redisCluster.RedisCluster{KeyPrefix: "livenesscheck-", ConnectionHandler: gw.StorageConnectionHandler}
 
 	key := "tyk-liveness-probe"
 

--- a/gateway/host_checker_manager.go
+++ b/gateway/host_checker_manager.go
@@ -13,16 +13,16 @@ import (
 	"github.com/sirupsen/logrus"
 	msgpack "gopkg.in/vmihailenco/msgpack.v2"
 
+	"github.com/TykTechnologies/tyk/interfaces"
 	"github.com/TykTechnologies/tyk/internal/uuid"
 
 	"github.com/TykTechnologies/tyk/apidef"
-	"github.com/TykTechnologies/tyk/storage"
 )
 
 type HostCheckerManager struct {
 	Gw                *Gateway `json:"-"`
 	Id                string
-	store             storage.Handler
+	store             interfaces.Handler
 	checkerMu         sync.Mutex
 	checker           *HostUptimeChecker
 	stopLoop          bool
@@ -72,7 +72,7 @@ const (
 	UptimeAnalytics_KEYNAME = "tyk-uptime-analytics"
 )
 
-func (hc *HostCheckerManager) Init(store storage.Handler) {
+func (hc *HostCheckerManager) Init(store interfaces.Handler) {
 	hc.store = store
 	hc.unhealthyHostList = new(sync.Map)
 	hc.resetsInitiated = make(map[string]bool)
@@ -534,7 +534,7 @@ func (hc *HostCheckerManager) RecordUptimeAnalytics(report HostHealthReport) err
 	return nil
 }
 
-func (gw *Gateway) InitHostCheckManager(ctx context.Context, store storage.Handler) {
+func (gw *Gateway) InitHostCheckManager(ctx context.Context, store interfaces.Handler) {
 	// Already initialized
 	if gw.GlobalHostChecker.Id != "" {
 		return

--- a/gateway/host_checker_manager_test.go
+++ b/gateway/host_checker_manager_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/TykTechnologies/tyk/apidef"
-	"github.com/TykTechnologies/tyk/storage"
+	redisCluster "github.com/TykTechnologies/tyk/storage/redis-cluster"
 	"github.com/TykTechnologies/tyk/test"
 )
 
@@ -14,7 +14,7 @@ func TestHostCheckerManagerInit(t *testing.T) {
 	defer ts.Close()
 
 	hc := HostCheckerManager{Gw: ts.Gw}
-	redisStorage := &storage.RedisCluster{KeyPrefix: "host-checker-test:", ConnectionHandler: ts.Gw.StorageConnectionHandler}
+	redisStorage := &redisCluster.RedisCluster{KeyPrefix: "host-checker-test:", ConnectionHandler: ts.Gw.StorageConnectionHandler}
 	hc.Init(redisStorage)
 
 	if hc.Id == "" {
@@ -45,7 +45,7 @@ func TestAmIPolling(t *testing.T) {
 	globalConf.UptimeTests.PollerGroup = groupID
 	ts.Gw.SetConfig(globalConf)
 
-	redisStorage := &storage.RedisCluster{KeyPrefix: "host-checker-test:", ConnectionHandler: ts.Gw.StorageConnectionHandler}
+	redisStorage := &redisCluster.RedisCluster{KeyPrefix: "host-checker-test:", ConnectionHandler: ts.Gw.StorageConnectionHandler}
 	hc.Init(redisStorage)
 	hc2 := HostCheckerManager{Gw: ts.Gw}
 	hc2.Init(redisStorage)
@@ -74,7 +74,7 @@ func TestAmIPolling(t *testing.T) {
 
 	//Testing if the PollerCacheKey doesn't contains the poller_group by default
 	hc = HostCheckerManager{Gw: ts.Gw}
-	redisStorage = &storage.RedisCluster{KeyPrefix: "host-checker-test:", ConnectionHandler: ts.Gw.StorageConnectionHandler}
+	redisStorage = &redisCluster.RedisCluster{KeyPrefix: "host-checker-test:", ConnectionHandler: ts.Gw.StorageConnectionHandler}
 	hc.Init(redisStorage)
 	hc.AmIPolling()
 
@@ -106,7 +106,7 @@ func TestCheckActivePollerLoop(t *testing.T) {
 	defer ts.Close()
 
 	hc := &HostCheckerManager{Gw: ts.Gw}
-	redisStorage := &storage.RedisCluster{KeyPrefix: "host-checker-test-1:", ConnectionHandler: ts.Gw.StorageConnectionHandler}
+	redisStorage := &redisCluster.RedisCluster{KeyPrefix: "host-checker-test-1:", ConnectionHandler: ts.Gw.StorageConnectionHandler}
 	hc.Init(redisStorage)
 
 	go hc.CheckActivePollerLoop(ts.Gw.ctx)
@@ -122,7 +122,7 @@ func TestStartPoller(t *testing.T) {
 	defer ts.Close()
 
 	hc := HostCheckerManager{Gw: ts.Gw}
-	redisStorage := &storage.RedisCluster{KeyPrefix: "host-checker-TestStartPoller:", ConnectionHandler: ts.Gw.StorageConnectionHandler}
+	redisStorage := &redisCluster.RedisCluster{KeyPrefix: "host-checker-TestStartPoller:", ConnectionHandler: ts.Gw.StorageConnectionHandler}
 	hc.Init(redisStorage)
 
 	hc.StartPoller(ts.Gw.ctx)
@@ -137,7 +137,7 @@ func TestRecordUptimeAnalytics(t *testing.T) {
 	defer ts.Close()
 	hc := &HostCheckerManager{Gw: ts.Gw}
 
-	redisStorage := &storage.RedisCluster{KeyPrefix: "host-checker-test-analytics:", ConnectionHandler: ts.Gw.StorageConnectionHandler}
+	redisStorage := &redisCluster.RedisCluster{KeyPrefix: "host-checker-test-analytics:", ConnectionHandler: ts.Gw.StorageConnectionHandler}
 	hc.Init(redisStorage)
 
 	spec := &APISpec{}

--- a/gateway/host_checker_test.go
+++ b/gateway/host_checker_test.go
@@ -17,10 +17,10 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/TykTechnologies/tyk/internal/uuid"
+	redisCluster "github.com/TykTechnologies/tyk/storage/redis-cluster"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
-	"github.com/TykTechnologies/tyk/storage"
 	"github.com/TykTechnologies/tyk/test"
 )
 
@@ -169,7 +169,7 @@ func TestHostChecker(t *testing.T) {
 		t.Error("Should set defaults", ts.Gw.GlobalHostChecker.checker.checkTimeout)
 	}
 
-	redisStore := ts.Gw.GlobalHostChecker.store.(*storage.RedisCluster)
+	redisStore := ts.Gw.GlobalHostChecker.store.(*redisCluster.RedisCluster)
 	if ttl, _ := redisStore.GetKeyTTL(PoolerHostSentinelKeyPrefix + testHttpFailure); int(ttl) != ts.Gw.GlobalHostChecker.checker.checkTimeout*ts.Gw.GlobalHostChecker.checker.sampleTriggerLimit {
 		t.Error("HostDown expiration key should be checkTimeout + 1", ttl)
 	}

--- a/gateway/ldap_auth_handler.go
+++ b/gateway/ldap_auth_handler.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mavricknz/ldap"
 )
 
-// LDAPStorageHandler implements storage.Handler, this is a read-only implementation to access keys from an LDAP service
+// LDAPStorageHandler implements interfaces.Handler, this is a read-only implementation to access keys from an LDAP service
 type LDAPStorageHandler struct {
 	LDAPServer           string
 	LDAPPort             uint16

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -17,6 +17,7 @@ import (
 	"github.com/TykTechnologies/tyk/internal/otel"
 	"github.com/TykTechnologies/tyk/internal/policy"
 	"github.com/TykTechnologies/tyk/rpc"
+	"github.com/TykTechnologies/tyk/storage/util"
 
 	"github.com/TykTechnologies/tyk/header"
 
@@ -29,7 +30,6 @@ import (
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/request"
-	"github.com/TykTechnologies/tyk/storage"
 	"github.com/TykTechnologies/tyk/trace"
 	"github.com/TykTechnologies/tyk/user"
 )
@@ -284,7 +284,7 @@ func (t *BaseMiddleware) OrgSession(orgID string) (user.SessionState, bool) {
 		t.Gw.ExpiryCache.Set(session.OrgID, session.DataExpires, cache.DefaultExpiration)
 	}
 
-	session.SetKeyHash(storage.HashKey(orgID, t.Gw.GetConfig().HashKeys))
+	session.SetKeyHash(util.HashKey(orgID, t.Gw.GetConfig().HashKeys))
 
 	return session.Clone(), found
 }
@@ -397,7 +397,7 @@ func (t *BaseMiddleware) CheckSessionAndIdentityForValidKey(originalKey string, 
 	keyHash := key
 	cacheKey := key
 	if t.Spec.GlobalConfig.HashKeys {
-		cacheKey = storage.HashStr(key, storage.HashMurmur64) // always hash cache keys with murmur64 to prevent collisions
+		cacheKey = util.HashStr(key, util.HashMurmur64) // always hash cache keys with murmur64 to prevent collisions
 	}
 
 	// Check in-memory cache
@@ -420,7 +420,7 @@ func (t *BaseMiddleware) CheckSessionAndIdentityForValidKey(originalKey string, 
 
 	if found {
 		if t.Spec.GlobalConfig.HashKeys {
-			keyHash = storage.HashStr(session.KeyID)
+			keyHash = util.HashStr(session.KeyID)
 		}
 		session := session.Clone()
 		session.SetKeyHash(keyHash)

--- a/gateway/mw_api_rate_limit.go
+++ b/gateway/mw_api_rate_limit.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/TykTechnologies/tyk/internal/event"
-	"github.com/TykTechnologies/tyk/storage"
+	"github.com/TykTechnologies/tyk/storage/util"
 	"github.com/TykTechnologies/tyk/user"
 )
 
@@ -54,14 +54,14 @@ func (k *RateLimitForAPI) getSession(r *http.Request) *user.SessionState {
 	if ok {
 		if limits := spec.RateLimit; limits.Valid() {
 			// track per-endpoint with a hash of the path
-			keyname := k.keyName + "-" + storage.HashStr(limits.Path)
+			keyname := k.keyName + "-" + util.HashStr(limits.Path)
 
 			session := &user.SessionState{
 				Rate:        limits.Rate,
 				Per:         limits.Per,
 				LastUpdated: k.apiSess.LastUpdated,
 			}
-			session.SetKeyHash(storage.HashKey(keyname, k.Gw.GetConfig().HashKeys))
+			session.SetKeyHash(util.HashKey(keyname, k.Gw.GetConfig().HashKeys))
 
 			return session
 		}
@@ -84,7 +84,7 @@ func (k *RateLimitForAPI) EnabledForSpec() bool {
 		Per:         k.Spec.GlobalRateLimit.Per,
 		LastUpdated: strconv.Itoa(int(time.Now().UnixNano())),
 	}
-	k.apiSess.SetKeyHash(storage.HashKey(k.keyName, k.Gw.GetConfig().HashKeys))
+	k.apiSess.SetKeyHash(util.HashKey(k.keyName, k.Gw.GetConfig().HashKeys))
 
 	return true
 }

--- a/gateway/mw_auth_key.go
+++ b/gateway/mw_auth_key.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/TykTechnologies/tyk/internal/crypto"
 	"github.com/TykTechnologies/tyk/internal/otel"
-	"github.com/TykTechnologies/tyk/storage"
+	"github.com/TykTechnologies/tyk/storage/util"
 
 	"github.com/TykTechnologies/tyk/user"
 
@@ -172,7 +172,7 @@ func (k *AuthKey) ProcessRequest(_ http.ResponseWriter, r *http.Request, _ inter
 	}
 
 	// As a second approach, try to use the internal ID that's part of the B64 JSON key:
-	keyID, err := storage.TokenID(key)
+	keyID, err := util.TokenID(key)
 	if err == nil {
 		err, statusCode := k.validateSignature(r, keyID)
 		if err == nil {

--- a/gateway/mw_auth_key_test.go
+++ b/gateway/mw_auth_key_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/TykTechnologies/tyk/certs"
 	"github.com/TykTechnologies/tyk/config"
 	signaturevalidator "github.com/TykTechnologies/tyk/signature_validator"
-	"github.com/TykTechnologies/tyk/storage"
+	"github.com/TykTechnologies/tyk/storage/util"
 	"github.com/TykTechnologies/tyk/test"
 	"github.com/TykTechnologies/tyk/user"
 
@@ -254,7 +254,7 @@ func TestSignatureValidation(t *testing.T) {
 		}
 
 		// Second request uses token (org ID + key) and token-based signature:
-		token, err := storage.GenerateToken("default", customKey, "murmur64")
+		token, err := util.GenerateToken("default", customKey, "murmur64")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/gateway/mw_basic_auth.go
+++ b/gateway/mw_basic_auth.go
@@ -16,7 +16,7 @@ import (
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/header"
 	"github.com/TykTechnologies/tyk/regexp"
-	"github.com/TykTechnologies/tyk/storage"
+	"github.com/TykTechnologies/tyk/storage/util"
 	"github.com/TykTechnologies/tyk/user"
 
 	"github.com/TykTechnologies/tyk/internal/cache"
@@ -189,7 +189,7 @@ func (k *BasicAuthKeyIsValid) ProcessRequest(w http.ResponseWriter, r *http.Requ
 		} else { // check for key with legacy format "org_id" + "user_name"
 			logger.Info("Could not find user, falling back to legacy format key.")
 			legacyKeyName := strings.TrimPrefix(username, k.Spec.OrgID)
-			keyName, _ = storage.GenerateToken(k.Spec.OrgID, legacyKeyName, "")
+			keyName, _ = util.GenerateToken(k.Spec.OrgID, legacyKeyName, "")
 			session, keyExists = k.CheckSessionAndIdentityForValidKey(keyName, r)
 			keyName = session.KeyID
 			if !keyExists {
@@ -227,7 +227,7 @@ func (k *BasicAuthKeyIsValid) checkPassword(session *user.SessionState, plainPas
 		hashAlgo := string(session.BasicAuthData.Hash)
 
 		// Checks the storage algo picked
-		hashedPassword := storage.HashStr(plainPassword, hashAlgo)
+		hashedPassword := util.HashStr(plainPassword, hashAlgo)
 		if session.BasicAuthData.Password != hashedPassword {
 			return errUnauthorized
 		}

--- a/gateway/mw_basic_auth_test.go
+++ b/gateway/mw_basic_auth_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/TykTechnologies/tyk/storage"
+	"github.com/TykTechnologies/tyk/storage/util"
 	"github.com/TykTechnologies/tyk/test"
 	"github.com/TykTechnologies/tyk/user"
 )
@@ -122,7 +122,7 @@ func TestBasicAuthLegacyWithHashFunc(t *testing.T) {
 	}...)
 
 	// set custom hashing function and check if we still do BA session auth with legacy key format
-	globalConf.HashKeyFunction = storage.HashMurmur64
+	globalConf.HashKeyFunction = util.HashMurmur64
 	ts.Gw.SetConfig(globalConf)
 
 	ts.Run(t, []test.TestCase{

--- a/gateway/mw_external_oauth.go
+++ b/gateway/mw_external_oauth.go
@@ -294,7 +294,7 @@ func isExpired(claims jwt.MapClaims) bool {
 
 func newIntrospectionCache(gw *Gateway) *introspectionCache {
 	store, err := storage.NewStorageHandler(
-		storage.REDIS_CLUSTER,
+		storage.GetStorageForModule(storage.DEFAULT_MODULE),
 		storage.WithKeyPrefix("introspection-"),
 		storage.WithConnectionHandler(gw.StorageConnectionHandler),
 	)

--- a/gateway/mw_external_oauth.go
+++ b/gateway/mw_external_oauth.go
@@ -15,7 +15,7 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 
 	"github.com/TykTechnologies/tyk/apidef"
-	"github.com/TykTechnologies/tyk/storage"
+	redisCluster "github.com/TykTechnologies/tyk/storage/redis-cluster"
 	"github.com/TykTechnologies/tyk/user"
 
 	"github.com/TykTechnologies/tyk/internal/cache"
@@ -292,11 +292,11 @@ func isExpired(claims jwt.MapClaims) bool {
 }
 
 func newIntrospectionCache(gw *Gateway) *introspectionCache {
-	return &introspectionCache{RedisCluster: storage.RedisCluster{KeyPrefix: "introspection-", ConnectionHandler: gw.StorageConnectionHandler}}
+	return &introspectionCache{RedisCluster: redisCluster.RedisCluster{KeyPrefix: "introspection-", ConnectionHandler: gw.StorageConnectionHandler}}
 }
 
 type introspectionCache struct {
-	storage.RedisCluster
+	redisCluster.RedisCluster
 }
 
 func (c *introspectionCache) GetRes(token string) (jwt.MapClaims, bool) {

--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -20,7 +20,7 @@ import (
 	"github.com/lonelycode/osin"
 
 	"github.com/TykTechnologies/tyk/apidef"
-	"github.com/TykTechnologies/tyk/storage"
+	redisCluster "github.com/TykTechnologies/tyk/storage/redis-cluster"
 	"github.com/TykTechnologies/tyk/user"
 
 	"github.com/TykTechnologies/tyk/internal/cache"
@@ -584,7 +584,7 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 					&RedisOsinStorageInterface{
 						storageManager,
 						k.Gw.GlobalSessionManager,
-						&storage.RedisCluster{KeyPrefix: prefix, HashKeys: false, ConnectionHandler: k.Gw.StorageConnectionHandler},
+						&redisCluster.RedisCluster{KeyPrefix: prefix, HashKeys: false, ConnectionHandler: k.Gw.StorageConnectionHandler},
 						k.Spec.OrgID,
 						k.Gw,
 					}),

--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -581,7 +581,7 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 			storageManager.Connect()
 
 			store, err := storage.NewStorageHandler(
-				storage.REDIS_CLUSTER,
+				storage.GetStorageForModule(storage.DEFAULT_MODULE),
 				storage.WithKeyPrefix(prefix),
 				storage.WithConnectionHandler(k.Gw.StorageConnectionHandler),
 			)

--- a/gateway/mw_redis_cache.go
+++ b/gateway/mw_redis_cache.go
@@ -18,9 +18,9 @@ import (
 
 	"github.com/TykTechnologies/murmur3"
 	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/interfaces"
 	"github.com/TykTechnologies/tyk/regexp"
 	"github.com/TykTechnologies/tyk/request"
-	"github.com/TykTechnologies/tyk/storage"
 )
 
 const (
@@ -31,7 +31,7 @@ const (
 type RedisCacheMiddleware struct {
 	*BaseMiddleware
 
-	store storage.Handler
+	store interfaces.Handler
 	sh    SuccessHandler
 }
 

--- a/gateway/oauth_manager.go
+++ b/gateway/oauth_manager.go
@@ -1194,7 +1194,7 @@ func (gw *Gateway) purgeLapsedOAuthTokens() error {
 	}
 
 	st, err := storage.NewStorageHandler(
-		storage.REDIS_CLUSTER,
+		storage.GetStorageForModule(storage.DEFAULT_MODULE),
 		storage.WithHashKeys(false),
 		storage.WithConnectionHandler(gw.StorageConnectionHandler),
 		storage.WithKeyPrefix(""),

--- a/gateway/oauth_manager_test.go
+++ b/gateway/oauth_manager_test.go
@@ -18,7 +18,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/TykTechnologies/tyk/interfaces"
 	"github.com/TykTechnologies/tyk/internal/redis"
+	"github.com/TykTechnologies/tyk/storage/util"
 
 	"github.com/TykTechnologies/tyk/config"
 
@@ -33,7 +35,6 @@ import (
 	"github.com/TykTechnologies/tyk/internal/uuid"
 
 	"github.com/TykTechnologies/tyk/apidef"
-	"github.com/TykTechnologies/tyk/storage"
 	"github.com/TykTechnologies/tyk/test"
 	"github.com/TykTechnologies/tyk/user"
 )
@@ -910,7 +911,7 @@ func testGetClientTokens(t *testing.T, hashed bool) {
 
 			if hashed {
 				// save tokens for future check
-				tokensID[storage.HashKey(response["access_token"].(string), ts.Gw.GetConfig().HashKeys)] = true
+				tokensID[util.HashKey(response["access_token"].(string), ts.Gw.GetConfig().HashKeys)] = true
 			} else {
 				tokensID[response["access_token"].(string)] = true
 			}
@@ -1315,7 +1316,7 @@ func TestJSONToFormValues(t *testing.T) {
 	})
 }
 
-func assertTokensLen(t *testing.T, storageManager storage.Handler, storageKey string, expectedTokensLen int) {
+func assertTokensLen(t *testing.T, storageManager interfaces.Handler, storageKey string, expectedTokensLen int) {
 	t.Helper()
 	nowTs := time.Now().Unix()
 	startScore := strconv.FormatInt(nowTs, 10)

--- a/gateway/redis_analytics_purger.go
+++ b/gateway/redis_analytics_purger.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/TykTechnologies/tyk/storage"
+	"github.com/TykTechnologies/tyk/interfaces"
 )
 
 // Purger is an interface that will define how the in-memory store will be purged
@@ -16,7 +16,7 @@ type Purger interface {
 }
 
 type RedisPurger struct {
-	Store storage.Handler
+	Store interfaces.Handler
 	Gw    *Gateway `json:"-"`
 }
 

--- a/gateway/redis_logrus_hook.go
+++ b/gateway/redis_logrus_hook.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"time"
 
+	"github.com/TykTechnologies/tyk/storage"
 	redisCluster "github.com/TykTechnologies/tyk/storage/redis-cluster"
 	"github.com/sirupsen/logrus"
 )
@@ -15,7 +16,24 @@ type redisChannelHook struct {
 func (gw *Gateway) newRedisHook() *redisChannelHook {
 	hook := &redisChannelHook{}
 	hook.formatter = new(logrus.JSONFormatter)
-	hook.notifier.store = &redisCluster.RedisCluster{KeyPrefix: "gateway-notifications:", ConnectionHandler: gw.StorageConnectionHandler}
+
+	st, err := storage.NewStorageHandler(
+		storage.REDIS_CLUSTER,
+		storage.WithConnectionHandler(gw.StorageConnectionHandler),
+		storage.WithKeyPrefix("gateway-notifications:"),
+	)
+
+	if err != nil {
+		log.WithError(err).Error("could not create storage handler")
+		return nil
+	}
+
+	storage, ok := st.(*redisCluster.RedisCluster)
+	if !ok {
+		log.Fatal("gateway channel hoook requires Redis storage")
+	}
+
+	hook.notifier.store = storage
 	hook.notifier.channel = "dashboard.ui.messages"
 	return hook
 }

--- a/gateway/redis_logrus_hook.go
+++ b/gateway/redis_logrus_hook.go
@@ -18,7 +18,7 @@ func (gw *Gateway) newRedisHook() *redisChannelHook {
 	hook.formatter = new(logrus.JSONFormatter)
 
 	st, err := storage.NewStorageHandler(
-		storage.REDIS_CLUSTER,
+		storage.GetStorageForModule(storage.DEFAULT_MODULE),
 		storage.WithConnectionHandler(gw.StorageConnectionHandler),
 		storage.WithKeyPrefix("gateway-notifications:"),
 	)

--- a/gateway/redis_logrus_hook.go
+++ b/gateway/redis_logrus_hook.go
@@ -3,9 +3,8 @@ package gateway
 import (
 	"time"
 
+	redisCluster "github.com/TykTechnologies/tyk/storage/redis-cluster"
 	"github.com/sirupsen/logrus"
-
-	"github.com/TykTechnologies/tyk/storage"
 )
 
 type redisChannelHook struct {
@@ -16,7 +15,7 @@ type redisChannelHook struct {
 func (gw *Gateway) newRedisHook() *redisChannelHook {
 	hook := &redisChannelHook{}
 	hook.formatter = new(logrus.JSONFormatter)
-	hook.notifier.store = &storage.RedisCluster{KeyPrefix: "gateway-notifications:", ConnectionHandler: gw.StorageConnectionHandler}
+	hook.notifier.store = &redisCluster.RedisCluster{KeyPrefix: "gateway-notifications:", ConnectionHandler: gw.StorageConnectionHandler}
 	hook.notifier.channel = "dashboard.ui.messages"
 	return hook
 }

--- a/gateway/redis_signals.go
+++ b/gateway/redis_signals.go
@@ -15,7 +15,7 @@ import (
 	temporalmodel "github.com/TykTechnologies/storage/temporal/model"
 
 	"github.com/TykTechnologies/tyk/internal/crypto"
-	"github.com/TykTechnologies/tyk/storage"
+	redisCluster "github.com/TykTechnologies/tyk/storage/redis-cluster"
 )
 
 type NotificationCommand string
@@ -59,7 +59,7 @@ func (n *Notification) Sign() {
 }
 
 func (gw *Gateway) startPubSubLoop() {
-	cacheStore := storage.RedisCluster{ConnectionHandler: gw.StorageConnectionHandler}
+	cacheStore := redisCluster.RedisCluster{ConnectionHandler: gw.StorageConnectionHandler}
 	cacheStore.Connect()
 
 	message := "Connection to Redis failed, reconnect in 10s"
@@ -228,7 +228,7 @@ func isPayloadSignatureValid(notification Notification) bool {
 
 // RedisNotifier will use redis pub/sub channels to send notifications
 type RedisNotifier struct {
-	store   *storage.RedisCluster
+	store   *redisCluster.RedisCluster
 	channel string
 	*Gateway
 }
@@ -251,7 +251,7 @@ func (r *RedisNotifier) Notify(notif interface{}) bool {
 	// pubSubLog.Debug("Sending notification", notif)
 
 	if err := r.store.Publish(r.channel, string(toSend)); err != nil {
-		if !errors.Is(err, storage.ErrRedisIsDown) {
+		if !errors.Is(err, redisCluster.ErrRedisIsDown) {
 			pubSubLog.Error("Could not send notification: ", err)
 		}
 		return false

--- a/gateway/redis_signals.go
+++ b/gateway/redis_signals.go
@@ -59,6 +59,7 @@ func (n *Notification) Sign() {
 }
 
 func (gw *Gateway) startPubSubLoop() {
+	// TODO: Interface this with the new storage handler
 	cacheStore := redisCluster.RedisCluster{ConnectionHandler: gw.StorageConnectionHandler}
 	cacheStore.Connect()
 

--- a/gateway/res_cache.go
+++ b/gateway/res_cache.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/TykTechnologies/tyk/storage"
+	"github.com/TykTechnologies/tyk/interfaces"
 	"github.com/TykTechnologies/tyk/user"
 )
 
@@ -22,7 +22,7 @@ const (
 // ResponseCacheMiddleware is a caching middleware that will pull data from Redis instead of the upstream proxy
 type ResponseCacheMiddleware struct {
 	BaseTykResponseHandler
-	store storage.Handler
+	store interfaces.Handler
 }
 
 func (m *ResponseCacheMiddleware) Base() *BaseTykResponseHandler {

--- a/gateway/rpc_backup_handlers.go
+++ b/gateway/rpc_backup_handlers.go
@@ -34,7 +34,7 @@ func (gw *Gateway) LoadDefinitionsFromRPCBackup() ([]*APISpec, error) {
 	checkKey := BackupApiKeyBase + tagList
 
 	store, err := storage.NewStorageHandler(
-		storage.REDIS_CLUSTER,
+		storage.GetStorageForModule(storage.DEFAULT_MODULE),
 		storage.WithConnectionHandler(gw.StorageConnectionHandler),
 		storage.WithKeyPrefix(RPCKeyPrefix),
 	)
@@ -73,7 +73,7 @@ func (gw *Gateway) saveRPCDefinitionsBackup(list string) error {
 	log.Info("--> Connecting to DB")
 
 	store, err := storage.NewStorageHandler(
-		storage.REDIS_CLUSTER,
+		storage.GetStorageForModule(storage.DEFAULT_MODULE),
 		storage.WithConnectionHandler(gw.StorageConnectionHandler),
 		storage.WithKeyPrefix(RPCKeyPrefix),
 	)
@@ -105,7 +105,7 @@ func (gw *Gateway) LoadPoliciesFromRPCBackup() (map[string]user.Policy, error) {
 	checkKey := BackupPolicyKeyBase + tagList
 
 	store, err := storage.NewStorageHandler(
-		storage.REDIS_CLUSTER,
+		storage.GetStorageForModule(storage.DEFAULT_MODULE),
 		storage.WithConnectionHandler(gw.StorageConnectionHandler),
 		storage.WithKeyPrefix(RPCKeyPrefix),
 	)
@@ -150,7 +150,7 @@ func (gw *Gateway) saveRPCPoliciesBackup(list string) error {
 	log.Info("--> Connecting to DB")
 
 	store, err := storage.NewStorageHandler(
-		storage.REDIS_CLUSTER,
+		storage.GetStorageForModule(storage.DEFAULT_MODULE),
 		storage.WithKeyPrefix(RPCKeyPrefix),
 		storage.WithConnectionHandler(gw.StorageConnectionHandler),
 	)

--- a/gateway/rpc_backup_handlers.go
+++ b/gateway/rpc_backup_handlers.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/TykTechnologies/tyk/storage"
+	redisCluster "github.com/TykTechnologies/tyk/storage/redis-cluster"
 	"github.com/TykTechnologies/tyk/user"
 )
 
@@ -33,7 +33,7 @@ func (gw *Gateway) LoadDefinitionsFromRPCBackup() ([]*APISpec, error) {
 	tagList := getTagListAsString(gw.GetConfig().DBAppConfOptions.Tags)
 	checkKey := BackupApiKeyBase + tagList
 
-	store := storage.RedisCluster{KeyPrefix: RPCKeyPrefix, ConnectionHandler: gw.StorageConnectionHandler}
+	store := redisCluster.RedisCluster{KeyPrefix: RPCKeyPrefix, ConnectionHandler: gw.StorageConnectionHandler}
 	connected := store.Connect()
 	log.Info("[RPC] --> Loading API definitions from backup")
 
@@ -63,7 +63,7 @@ func (gw *Gateway) saveRPCDefinitionsBackup(list string) error {
 
 	log.Info("--> Connecting to DB")
 
-	store := storage.RedisCluster{KeyPrefix: RPCKeyPrefix, ConnectionHandler: gw.StorageConnectionHandler}
+	store := redisCluster.RedisCluster{KeyPrefix: RPCKeyPrefix, ConnectionHandler: gw.StorageConnectionHandler}
 	connected := store.Connect()
 
 	log.Info("--> Connected to DB")
@@ -86,7 +86,7 @@ func (gw *Gateway) LoadPoliciesFromRPCBackup() (map[string]user.Policy, error) {
 	tagList := getTagListAsString(gw.GetConfig().DBAppConfOptions.Tags)
 	checkKey := BackupPolicyKeyBase + tagList
 
-	store := storage.RedisCluster{KeyPrefix: RPCKeyPrefix, ConnectionHandler: gw.StorageConnectionHandler}
+	store := redisCluster.RedisCluster{KeyPrefix: RPCKeyPrefix, ConnectionHandler: gw.StorageConnectionHandler}
 
 	connected := store.Connect()
 	log.Info("[RPC] Loading Policies from backup")
@@ -123,7 +123,7 @@ func (gw *Gateway) saveRPCPoliciesBackup(list string) error {
 
 	log.Info("--> Connecting to DB")
 
-	store := storage.RedisCluster{KeyPrefix: RPCKeyPrefix, ConnectionHandler: gw.StorageConnectionHandler}
+	store := redisCluster.RedisCluster{KeyPrefix: RPCKeyPrefix, ConnectionHandler: gw.StorageConnectionHandler}
 	connected := store.Connect()
 
 	log.Info("--> Connected to DB")

--- a/gateway/rpc_storage_handler_test.go
+++ b/gateway/rpc_storage_handler_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/TykTechnologies/tyk/internal/model"
 	"github.com/TykTechnologies/tyk/rpc"
+	"github.com/TykTechnologies/tyk/storage/shared"
+	"github.com/TykTechnologies/tyk/storage/util"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
@@ -18,7 +20,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/TykTechnologies/tyk/header"
-	"github.com/TykTechnologies/tyk/storage"
 	"github.com/TykTechnologies/tyk/test"
 	"github.com/TykTechnologies/tyk/user"
 )
@@ -36,7 +37,7 @@ func buildStringEvent(eventType, token, apiId string) string {
 	switch eventType {
 	case RevokeOauthHashedToken:
 		// string is as= {the-hashed-token}#hashed:{api-id}:oAuthRevokeToken
-		token = storage.HashStr(token)
+		token = util.HashStr(token)
 		return fmt.Sprintf("%s#hashed:%s:oAuthRevokeToken", token, apiId)
 	case RevokeOauthToken:
 		// string is as= {the-token}:{api-id}:oAuthRevokeToken
@@ -621,7 +622,7 @@ func TestGetRawKey(t *testing.T) {
 		}
 
 		_, err := rpcListener.GetRawKey("any-key")
-		assert.Equal(t, storage.ErrMDCBConnectionLost, err)
+		assert.Equal(t, shared.ErrMDCBConnectionLost, err)
 	})
 }
 
@@ -677,7 +678,7 @@ func TestDeleteUsingTokenID(t *testing.T) {
 		assert.Equal(t, http.StatusOK, status)
 		// it should not exist anymore
 		_, err = ts.Gw.GlobalSessionManager.Store().GetKey(customKey)
-		assert.ErrorIs(t, storage.ErrKeyNotFound, err)
+		assert.ErrorIs(t, shared.ErrKeyNotFound, err)
 	})
 
 	t.Run("status not found and TokenID do not exist", func(t *testing.T) {

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -349,7 +349,7 @@ func (gw *Gateway) setupGlobals() {
 		}
 
 		healthCheckStore, err := storage.NewStorageHandler(
-			storage.REDIS_CLUSTER,
+			storage.GetStorageForModule(storage.DEFAULT_MODULE),
 			storage.WithKeyPrefix("host-checker:"),
 			storage.WithConnectionHandler(gw.StorageConnectionHandler),
 			storage.IsAnalytics(true),
@@ -364,7 +364,7 @@ func (gw *Gateway) setupGlobals() {
 	gw.initHealthCheck(gw.ctx)
 
 	redisStore, err := storage.NewStorageHandler(
-		storage.REDIS_CLUSTER,
+		storage.GetStorageForModule(storage.DEFAULT_MODULE),
 		storage.WithKeyPrefix("apikey-"),
 		storage.WithConnectionHandler(gw.StorageConnectionHandler),
 		storage.WithHashKeys(gwConfig.HashKeys),
@@ -376,7 +376,7 @@ func (gw *Gateway) setupGlobals() {
 	gw.GlobalSessionManager.Init(redisStore)
 
 	versionStore, err := storage.NewStorageHandler(
-		storage.REDIS_CLUSTER,
+		storage.GetStorageForModule(storage.DEFAULT_MODULE),
 		storage.WithKeyPrefix("version-check-"),
 		storage.WithConnectionHandler(gw.StorageConnectionHandler),
 	)
@@ -457,7 +457,7 @@ func (gw *Gateway) setupGlobals() {
 	}
 
 	storeCert, err := storage.NewStorageHandler(
-		storage.REDIS_CLUSTER,
+		storage.GetStorageForModule(storage.DEFAULT_MODULE),
 		storage.WithConnectionHandler(gw.StorageConnectionHandler),
 		storage.WithKeyPrefix("cert-"),
 		storage.WithHashKeys(false),
@@ -788,7 +788,7 @@ func (gw *Gateway) addOAuthHandlers(spec *APISpec, muxer *mux.Router) *OAuthMana
 	storageManager.Connect()
 
 	store, err := storage.NewStorageHandler(
-		storage.REDIS_CLUSTER,
+		storage.GetStorageForModule(storage.DEFAULT_MODULE),
 		storage.WithKeyPrefix(prefix),
 		storage.WithConnectionHandler(gw.StorageConnectionHandler),
 		storage.WithHashKeys(false),
@@ -994,7 +994,7 @@ func (gw *Gateway) createResponseMiddlewareChain(spec *APISpec, responseFuncs []
 
 	keyPrefix := "cache-" + spec.APIID
 	cacheStore, err := storage.NewStorageHandler(
-		storage.REDIS_CLUSTER,
+		storage.GetStorageForModule(storage.DEFAULT_MODULE),
 		storage.WithKeyPrefix(keyPrefix),
 		storage.WithConnectionHandler(gw.StorageConnectionHandler),
 		storage.IsCache(true),
@@ -1625,7 +1625,7 @@ func (gw *Gateway) getHostDetails(file string) {
 }
 
 func (gw *Gateway) getGlobalMDCBStorageHandler(keyPrefix string, hashKeys bool) interfaces.Handler {
-	localStorage, err := storage.NewStorageHandler(storage.REDIS_CLUSTER,
+	localStorage, err := storage.NewStorageHandler(storage.GetStorageForModule(storage.DEFAULT_MODULE),
 		storage.WithKeyPrefix(keyPrefix),
 		storage.WithHashKeys(hashKeys),
 		storage.WithConnectionHandler(gw.StorageConnectionHandler))
@@ -1659,7 +1659,7 @@ func (gw *Gateway) getGlobalStorageHandler(keyPrefix string, hashKeys bool) inte
 		}
 	}
 
-	handler, err := storage.NewStorageHandler(storage.REDIS_CLUSTER,
+	handler, err := storage.NewStorageHandler(storage.GetStorageForModule(storage.DEFAULT_MODULE),
 		storage.WithKeyPrefix(keyPrefix),
 		storage.WithHashKeys(hashKeys),
 		storage.WithConnectionHandler(gw.StorageConnectionHandler))

--- a/gateway/session_manager.go
+++ b/gateway/session_manager.go
@@ -12,9 +12,10 @@ import (
 	"github.com/TykTechnologies/leakybucket/memorycache"
 
 	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/interfaces"
 	"github.com/TykTechnologies/tyk/internal/rate"
 	"github.com/TykTechnologies/tyk/internal/redis"
-	"github.com/TykTechnologies/tyk/storage"
+	"github.com/TykTechnologies/tyk/storage/util"
 	"github.com/TykTechnologies/tyk/user"
 )
 
@@ -226,7 +227,7 @@ func (sfr sessionFailReason) String() string {
 // sessionFailReason if session limits have been exceeded.
 // Key values to manage rate are Rate and Per, e.g. Rate of 10 messages
 // Per 10 seconds
-func (l *SessionLimiter) ForwardMessage(r *http.Request, session *user.SessionState, rateLimitKey string, quotaKey string, store storage.Handler, enableRL, enableQ bool, api *APISpec, dryRun bool) sessionFailReason {
+func (l *SessionLimiter) ForwardMessage(r *http.Request, session *user.SessionState, rateLimitKey string, quotaKey string, store interfaces.Handler, enableRL, enableQ bool, api *APISpec, dryRun bool) sessionFailReason {
 	// check for limit on API level (set to session by ApplyPolicies)
 	accessDef, allowanceScope, err := GetAccessDefinitionByAPIIDOrSession(session, api)
 	if err != nil {
@@ -309,7 +310,7 @@ func (l *SessionLimiter) ForwardMessage(r *http.Request, session *user.SessionSt
 
 }
 
-func (l *SessionLimiter) RedisQuotaExceeded(r *http.Request, session *user.SessionState, quotaKey, scope string, limit *user.APILimit, store storage.Handler, hashKeys bool) bool {
+func (l *SessionLimiter) RedisQuotaExceeded(r *http.Request, session *user.SessionState, quotaKey, scope string, limit *user.APILimit, store interfaces.Handler, hashKeys bool) bool {
 	// Unlimited?
 	if limit.QuotaMax == -1 || limit.QuotaMax == 0 {
 		// No quota set
@@ -326,7 +327,7 @@ func (l *SessionLimiter) RedisQuotaExceeded(r *http.Request, session *user.Sessi
 	key := session.KeyID
 
 	if hashKeys {
-		key = storage.HashStr(session.KeyID)
+		key = util.HashStr(session.KeyID)
 	}
 
 	if quotaKey != "" {

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -28,6 +28,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 
 	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/storage/util"
 
 	"github.com/TykTechnologies/tyk/rpc"
 
@@ -46,7 +47,6 @@ import (
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/cli"
 	"github.com/TykTechnologies/tyk/config"
-	"github.com/TykTechnologies/tyk/storage"
 	_ "github.com/TykTechnologies/tyk/templates" // Don't delete
 	"github.com/TykTechnologies/tyk/test"
 	_ "github.com/TykTechnologies/tyk/testdata" // Don't delete
@@ -832,7 +832,7 @@ func CreateSession(gw *Gateway, sGen ...func(s *user.SessionState)) string {
 	}
 
 	hashKeys := gw.GetConfig().HashKeys
-	hashedKey := storage.HashKey(key, hashKeys)
+	hashedKey := util.HashKey(key, hashKeys)
 	err := gw.GlobalSessionManager.UpdateSession(hashedKey, session, 60, hashKeys)
 	if err != nil {
 		log.WithError(err).Error("updating session.")
@@ -1142,7 +1142,7 @@ func (s *Test) newGateway(genConf func(globalConf *config.Config)) *Gateway {
 
 	gwConfig.AnalyticsConfig.GeoIPDBLocation = filepath.Join(rootPath, "testdata", "MaxMind-DB-test-ipv4-24.mmdb")
 	gwConfig.EnableJSVM = true
-	gwConfig.HashKeyFunction = storage.HashMurmur64
+	gwConfig.HashKeyFunction = util.HashMurmur64
 	gwConfig.Monitor.EnableTriggerMonitors = true
 	gwConfig.AnalyticsConfig.NormaliseUrls.Enabled = true
 	gwConfig.AllowInsecureConfigs = true

--- a/interfaces/storage.go
+++ b/interfaces/storage.go
@@ -1,0 +1,38 @@
+package interfaces
+
+// Handler is a standard interface to a storage backend, used by
+// AuthorisationManager to read and write key values to the backend
+type Handler interface {
+	GetKey(string) (string, error) // Returned string is expected to be a JSON object (user.SessionState)
+	GetMultiKey([]string) ([]string, error)
+	GetRawKey(string) (string, error)
+	SetKey(string, string, int64) error // Second input string is expected to be a JSON object (user.SessionState)
+	SetRawKey(string, string, int64) error
+	SetExp(string, int64) error   // Set key expiration
+	GetExp(string) (int64, error) // Returns expiry of a key
+	GetKeys(string) []string
+	DeleteKey(string) bool
+	DeleteAllKeys() bool
+	DeleteRawKey(string) bool
+	Connect() bool
+	GetKeysAndValues() map[string]string
+	GetKeysAndValuesWithFilter(string) map[string]string
+	DeleteKeys([]string) bool
+	Decrement(string)
+	IncrememntWithExpire(string, int64) int64
+	SetRollingWindow(key string, per int64, val string, pipeline bool) (int, []interface{})
+	GetRollingWindow(key string, per int64, pipeline bool) (int, []interface{})
+	GetSet(string) (map[string]string, error)
+	AddToSet(string, string)
+	GetAndDeleteSet(string) []interface{}
+	RemoveFromSet(string, string)
+	DeleteScanMatch(string) bool
+	GetKeyPrefix() string
+	AddToSortedSet(string, string, float64)
+	GetSortedSetRange(string, string, string) ([]string, []float64, error)
+	RemoveSortedSetRange(string, string, string) error
+	GetListRange(string, int64, int64) ([]string, error)
+	RemoveFromList(string, string) error
+	AppendToSet(string, string)
+	Exists(string) (bool, error)
+}

--- a/internal/rate/sliding_log.go
+++ b/internal/rate/sliding_log.go
@@ -26,7 +26,7 @@ type SlidingLog struct {
 // ErrRedisClientProvider is returned if NewSlidingLog isn't passed a valid RedisClientProvider parameter.
 var ErrRedisClientProvider = errors.New("Client doesn't implement RedisClientProvider")
 
-// NewSlidingLog creates a new SlidingLog instance with a storage.Handler. In case
+// NewSlidingLog creates a new SlidingLog instance with a interfaces.Handler. In case
 // the storage is offline, it's expected to return nil and an error to handle.
 func NewSlidingLog(client interface{}, pipeline bool, smoothingFn SmoothingFn) (*SlidingLog, error) {
 	cluster, ok := client.(model.RedisClientProvider)

--- a/internal/rate/sliding_log_test.go
+++ b/internal/rate/sliding_log_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/TykTechnologies/tyk/internal/redis"
+	redisCluster "github.com/TykTechnologies/tyk/storage/redis-cluster"
 
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/internal/rate"
 	"github.com/TykTechnologies/tyk/internal/uuid"
-	"github.com/TykTechnologies/tyk/storage"
 )
 
 // TestSlidingLog_Do is an integration test that tests counter behaviour.
@@ -25,7 +25,7 @@ func TestSlidingLog_Do(t *testing.T) {
 	conf, err := config.New()
 	assert.NoError(t, err)
 
-	conn, err := storage.NewConnector(storage.DefaultConn, *conf)
+	conn, err := redisCluster.NewConnector(redisCluster.DefaultConn, *conf)
 	assert.Nil(t, err)
 
 	var db redis.UniversalClient
@@ -72,7 +72,7 @@ func TestSlidingLog_GetCount(t *testing.T) {
 	conf, err := config.New()
 	assert.NoError(t, err)
 
-	conn, err := storage.NewConnector(storage.DefaultConn, *conf)
+	conn, err := redisCluster.NewConnector(redisCluster.DefaultConn, *conf)
 	assert.Nil(t, err)
 
 	var db redis.UniversalClient
@@ -93,7 +93,7 @@ func TestSlidingLog_Get(t *testing.T) {
 	conf, err := config.New()
 	assert.NoError(t, err)
 
-	conn, err := storage.NewConnector(storage.DefaultConn, *conf)
+	conn, err := redisCluster.NewConnector(redisCluster.DefaultConn, *conf)
 	assert.Nil(t, err)
 
 	var db redis.UniversalClient
@@ -114,7 +114,7 @@ func TestSlidingLog_pipelinerError(t *testing.T) {
 	conf, err := config.New()
 	assert.NoError(t, err)
 
-	rc := storage.NewConnectionHandler(ctx)
+	rc := redisCluster.NewConnectionHandler(ctx)
 	go rc.Connect(ctx, nil, conf)
 
 	timeout, cancel := context.WithTimeout(ctx, time.Second)
@@ -125,7 +125,7 @@ func TestSlidingLog_pipelinerError(t *testing.T) {
 		panic("can't connect to redis '" + conf.Storage.Host + "', timeout")
 	}
 
-	rl, err := rate.NewSlidingLog(&storage.RedisCluster{KeyPrefix: "test-cluster", ConnectionHandler: rc}, false, nil)
+	rl, err := rate.NewSlidingLog(&redisCluster.RedisCluster{KeyPrefix: "test-cluster", ConnectionHandler: rc}, false, nil)
 	assert.NoError(t, err)
 
 	rl.PipelineFn = func(context.Context, func(redis.Pipeliner) error) error {
@@ -216,7 +216,7 @@ func BenchmarkSlidingLog_New(b *testing.B) {
 	conf, err := config.New()
 	assert.NoError(b, err)
 
-	conn, err := storage.NewConnector(storage.DefaultConn, *conf)
+	conn, err := redisCluster.NewConnector(redisCluster.DefaultConn, *conf)
 	assert.Nil(b, err)
 
 	var db redis.UniversalClient
@@ -237,7 +237,7 @@ func BenchmarkSlidingLog_Count(b *testing.B) {
 	conf, err := config.New()
 	assert.NoError(b, err)
 
-	conn, err := storage.NewConnector(storage.DefaultConn, *conf)
+	conn, err := redisCluster.NewConnector(redisCluster.DefaultConn, *conf)
 	assert.Nil(b, err)
 
 	var db redis.UniversalClient

--- a/rpc/rpc_analytics_purger.go
+++ b/rpc/rpc_analytics_purger.go
@@ -7,10 +7,9 @@ import (
 	"time"
 
 	"github.com/TykTechnologies/tyk-pump/analytics"
+	"github.com/TykTechnologies/tyk/interfaces"
 
 	"github.com/vmihailenco/msgpack"
-
-	"github.com/TykTechnologies/tyk/storage"
 )
 
 const ANALYTICS_KEYNAME = "tyk-system-analytics"
@@ -18,7 +17,7 @@ const ANALYTICS_KEYNAME = "tyk-system-analytics"
 // RPCPurger will purge analytics data into a Mongo database, requires that the Mongo DB string is specified
 // in the Config object
 type Purger struct {
-	Store storage.Handler
+	Store interfaces.Handler
 }
 
 // Connect Connects to RPC

--- a/rpc/synchronization_forcer.go
+++ b/rpc/synchronization_forcer.go
@@ -20,7 +20,7 @@ func NewSyncForcer(controller *redisCluster.ConnectionHandler, getNodeDataFunc f
 	sf := &SyncronizerForcer{}
 	sf.getNodeDataFunc = getNodeDataFunc
 	store, err := storage.NewStorageHandler(
-		storage.REDIS_CLUSTER,
+		storage.GetStorageForModule(storage.DEFAULT_MODULE),
 		storage.WithConnectionHandler(controller),
 		storage.WithKeyPrefix("synchronizer-group-"),
 	)

--- a/rpc/synchronization_forcer.go
+++ b/rpc/synchronization_forcer.go
@@ -4,19 +4,20 @@ import (
 	"errors"
 
 	"github.com/TykTechnologies/tyk/apidef"
-	"github.com/TykTechnologies/tyk/storage"
+	redisCluster "github.com/TykTechnologies/tyk/storage/redis-cluster"
+	"github.com/TykTechnologies/tyk/storage/shared"
 )
 
 type SyncronizerForcer struct {
-	store           *storage.RedisCluster
+	store           *redisCluster.RedisCluster
 	getNodeDataFunc func() []byte
 }
 
 // NewSyncForcer returns a new syncforcer with a connected redis with a key prefix synchronizer-group- for group synchronization control.
-func NewSyncForcer(controller *storage.ConnectionHandler, getNodeDataFunc func() []byte) *SyncronizerForcer {
+func NewSyncForcer(controller *redisCluster.ConnectionHandler, getNodeDataFunc func() []byte) *SyncronizerForcer {
 	sf := &SyncronizerForcer{}
 	sf.getNodeDataFunc = getNodeDataFunc
-	sf.store = &storage.RedisCluster{KeyPrefix: "synchronizer-group-", ConnectionHandler: controller}
+	sf.store = &redisCluster.RedisCluster{KeyPrefix: "synchronizer-group-", ConnectionHandler: controller}
 	sf.store.Connect()
 
 	return sf
@@ -28,7 +29,7 @@ func (sf *SyncronizerForcer) GroupLoginCallback(userKey string, groupID string) 
 	shouldForce := false
 
 	_, err := sf.store.GetKey(groupID)
-	if err != nil && errors.Is(err, storage.ErrKeyNotFound) {
+	if err != nil && errors.Is(err, shared.ErrKeyNotFound) {
 		shouldForce = true
 
 		err = sf.store.SetKey(groupID, "", 0)

--- a/rpc/synchronization_forcer_test.go
+++ b/rpc/synchronization_forcer_test.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
-	"github.com/TykTechnologies/tyk/storage"
+	redisCluster "github.com/TykTechnologies/tyk/storage/redis-cluster"
 )
 
-var rc *storage.ConnectionHandler
+var rc *redisCluster.ConnectionHandler
 
 func TestMain(m *testing.M) {
 	conf, err := config.New()
@@ -21,7 +21,7 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 
-	rc = storage.NewConnectionHandler(context.Background())
+	rc = redisCluster.NewConnectionHandler(context.Background())
 	go rc.Connect(context.Background(), nil, conf)
 
 	timeout, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/storage/dummy/dummy.go
+++ b/storage/dummy/dummy.go
@@ -1,4 +1,4 @@
-package storage
+package dummy
 
 import (
 	"errors"

--- a/storage/dummy/dummy_test.go
+++ b/storage/dummy/dummy_test.go
@@ -1,4 +1,4 @@
-package storage
+package dummy
 
 import (
 	"reflect"

--- a/storage/mdcb/mdcb_storage.go
+++ b/storage/mdcb/mdcb_storage.go
@@ -1,20 +1,21 @@
-package storage
+package mdcb
 
 import (
 	"errors"
 	"strings"
 
+	"github.com/TykTechnologies/tyk/interfaces"
 	"github.com/sirupsen/logrus"
 )
 
 type MdcbStorage struct {
-	local                 Handler
-	rpc                   Handler
+	local                 interfaces.Handler
+	rpc                   interfaces.Handler
 	logger                *logrus.Entry
 	CallbackonPullfromRPC *func(key string, val string) error
 }
 
-func NewMdcbStorage(local, rpc Handler, log *logrus.Entry) *MdcbStorage {
+func NewMdcbStorage(local, rpc interfaces.Handler, log *logrus.Entry) *MdcbStorage {
 	return &MdcbStorage{
 		local:  local,
 		rpc:    rpc,

--- a/storage/mdcb/mdcb_storage.go
+++ b/storage/mdcb/mdcb_storage.go
@@ -9,17 +9,17 @@ import (
 )
 
 type MdcbStorage struct {
-	local                 interfaces.Handler
-	rpc                   interfaces.Handler
-	logger                *logrus.Entry
+	Local                 interfaces.Handler
+	Rpc                   interfaces.Handler
+	Logger                *logrus.Entry
 	CallbackonPullfromRPC *func(key string, val string) error
 }
 
 func NewMdcbStorage(local, rpc interfaces.Handler, log *logrus.Entry) *MdcbStorage {
 	return &MdcbStorage{
-		local:  local,
-		rpc:    rpc,
-		logger: log,
+		Local:  local,
+		Rpc:    rpc,
+		Logger: log,
 	}
 }
 
@@ -27,25 +27,25 @@ func (m MdcbStorage) GetKey(key string) (string, error) {
 	var val string
 	var err error
 
-	if m.local == nil {
-		return m.rpc.GetKey(key)
+	if m.Local == nil {
+		return m.Rpc.GetKey(key)
 	}
 
-	val, err = m.local.GetKey(key)
+	val, err = m.Local.GetKey(key)
 	if err != nil {
-		m.logger.Infof("Retrieving key from rpc.")
-		val, err = m.rpc.GetKey(key)
+		m.Logger.Infof("Retrieving key from rpc.")
+		val, err = m.Rpc.GetKey(key)
 
 		if err != nil {
 			resourceType := getResourceType(key)
-			m.logger.Errorf("cannot retrieve %v from rpc: %v", resourceType, err.Error())
+			m.Logger.Errorf("cannot retrieve %v from rpc: %v", resourceType, err.Error())
 			return val, err
 		}
 
 		if m.CallbackonPullfromRPC != nil {
 			err := (*m.CallbackonPullfromRPC)(key, val)
 			if err != nil {
-				m.logger.Error(err)
+				m.Logger.Error(err)
 			}
 		}
 	}
@@ -87,7 +87,7 @@ func (m MdcbStorage) GetRawKey(string) (string, error) {
 
 func (m MdcbStorage) SetKey(key string, content string, TTL int64) error {
 	// only set the value locally as rpc writtes is not allowed
-	errLocal := m.local.SetKey(key, content, TTL)
+	errLocal := m.Local.SetKey(key, content, TTL)
 
 	if errLocal != nil {
 		return errors.New("cannot save key in local")
@@ -111,20 +111,20 @@ func (m MdcbStorage) GetExp(string) (int64, error) {
 func (m MdcbStorage) GetKeys(key string) []string {
 	var val []string
 
-	if m.local != nil {
-		val = m.local.GetKeys(key)
+	if m.Local != nil {
+		val = m.Local.GetKeys(key)
 		if len(val) == 0 {
-			val = m.rpc.GetKeys(key)
+			val = m.Rpc.GetKeys(key)
 		}
 	} else {
-		val = m.rpc.GetKeys(key)
+		val = m.Rpc.GetKeys(key)
 	}
 	return val
 }
 
 func (m MdcbStorage) DeleteKey(key string) bool {
-	deleteLocal := m.local.DeleteKey(key)
-	deleteRPC := m.rpc.DeleteKey(key)
+	deleteLocal := m.Local.DeleteKey(key)
+	deleteRPC := m.Rpc.DeleteKey(key)
 
 	return deleteLocal || deleteRPC
 }
@@ -138,7 +138,7 @@ func (m MdcbStorage) DeleteRawKey(string) bool {
 }
 
 func (m MdcbStorage) Connect() bool {
-	return m.local.Connect() && m.rpc.Connect()
+	return m.Local.Connect() && m.Rpc.Connect()
 }
 
 func (m MdcbStorage) GetKeysAndValues() map[string]string {
@@ -146,7 +146,7 @@ func (m MdcbStorage) GetKeysAndValues() map[string]string {
 }
 
 func (m MdcbStorage) GetKeysAndValuesWithFilter(key string) map[string]string {
-	return m.local.GetKeysAndValuesWithFilter(key)
+	return m.Local.GetKeysAndValuesWithFilter(key)
 }
 
 func (m MdcbStorage) DeleteKeys([]string) bool {
@@ -170,16 +170,16 @@ func (m MdcbStorage) GetRollingWindow(key string, per int64, pipeline bool) (int
 }
 
 func (m MdcbStorage) GetSet(key string) (map[string]string, error) {
-	val, err := m.local.GetSet(key)
+	val, err := m.Local.GetSet(key)
 	if err != nil {
 		// try rpc
-		val, err = m.rpc.GetSet(key)
+		val, err = m.Rpc.GetSet(key)
 	}
 	return val, err
 }
 
 func (m MdcbStorage) AddToSet(key string, value string) {
-	m.local.AddToSet(key, value)
+	m.Local.AddToSet(key, value)
 }
 
 func (m MdcbStorage) GetAndDeleteSet(string) []interface{} {
@@ -187,12 +187,12 @@ func (m MdcbStorage) GetAndDeleteSet(string) []interface{} {
 }
 
 func (m MdcbStorage) RemoveFromSet(key string, value string) {
-	m.local.RemoveFromSet(key, value)
+	m.Local.RemoveFromSet(key, value)
 }
 
 func (m MdcbStorage) DeleteScanMatch(key string) bool {
-	deleteLocal := m.local.DeleteScanMatch(key)
-	deleteRPC := m.rpc.DeleteScanMatch(key)
+	deleteLocal := m.Local.DeleteScanMatch(key)
+	deleteRPC := m.Rpc.DeleteScanMatch(key)
 
 	return deleteLocal || deleteRPC
 }
@@ -217,21 +217,21 @@ func (m MdcbStorage) GetListRange(key string, from int64, to int64) ([]string, e
 	var val []string
 	var err error
 
-	if m.local == nil {
-		return m.rpc.GetListRange(key, from, to)
+	if m.Local == nil {
+		return m.Rpc.GetListRange(key, from, to)
 	}
 
-	val, err = m.local.GetListRange(key, from, to)
+	val, err = m.Local.GetListRange(key, from, to)
 	if err != nil {
-		val, err = m.rpc.GetListRange(key, from, to)
+		val, err = m.Rpc.GetListRange(key, from, to)
 	}
 
 	return val, err
 }
 
 func (m MdcbStorage) RemoveFromList(key string, value string) error {
-	errLocal := m.local.RemoveFromList(key, value)
-	errRpc := m.rpc.RemoveFromList(key, value)
+	errLocal := m.Local.RemoveFromList(key, value)
+	errRpc := m.Rpc.RemoveFromList(key, value)
 
 	if errLocal != nil && errRpc != nil {
 		return errors.New("cannot delete key in storages")
@@ -241,13 +241,13 @@ func (m MdcbStorage) RemoveFromList(key string, value string) error {
 }
 
 func (m MdcbStorage) AppendToSet(key string, value string) {
-	m.local.AppendToSet(key, value)
-	m.rpc.AppendToSet(key, value)
+	m.Local.AppendToSet(key, value)
+	m.Rpc.AppendToSet(key, value)
 }
 
 func (m MdcbStorage) Exists(key string) (bool, error) {
-	foundLocal, errLocal := m.local.Exists(key)
-	foundRpc, errRpc := m.rpc.Exists(key)
+	foundLocal, errLocal := m.Local.Exists(key)
+	foundRpc, errRpc := m.Rpc.Exists(key)
 
 	if errLocal != nil && errRpc != nil {
 		return false, errors.New("cannot find key in storages")

--- a/storage/mdcb/mdcb_storage_test.go
+++ b/storage/mdcb/mdcb_storage_test.go
@@ -1,10 +1,11 @@
-package storage
+package mdcb
 
 import (
 	"context"
 	"io"
 	"testing"
 
+	"github.com/TykTechnologies/tyk/storage/dummy"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
@@ -31,13 +32,13 @@ func TestGetResourceType(t *testing.T) {
 }
 
 func TestMdcbStorage_GetMultiKey(t *testing.T) {
-	rpcHandler := NewDummyStorage()
+	rpcHandler := dummy.NewDummyStorage()
 	err := rpcHandler.SetKey("key1", "1", 0)
 	if err != nil {
 		t.Error(err.Error())
 	}
 
-	localHandler := NewDummyStorage()
+	localHandler := dummy.NewDummyStorage()
 	err = localHandler.SetKey("key2", "1", 0)
 	if err != nil {
 		t.Error(err.Error())

--- a/storage/mdcb/options.go
+++ b/storage/mdcb/options.go
@@ -1,0 +1,34 @@
+package mdcb
+
+import (
+	"github.com/TykTechnologies/tyk/interfaces"
+	"github.com/sirupsen/logrus"
+)
+
+// MDCB Options
+func WithLocalStorageHandler(handler interfaces.Handler) func(interfaces.Handler) {
+	return func(impl interfaces.Handler) {
+		// Type assertion for more iplementations later
+		if impl, ok := impl.(*MdcbStorage); ok {
+			impl.Local = handler
+		}
+	}
+}
+
+func WithRpcStorageHandler(handler interfaces.Handler) func(interfaces.Handler) {
+	return func(impl interfaces.Handler) {
+		// Type assertion for more iplementations later
+		if impl, ok := impl.(*MdcbStorage); ok {
+			impl.Rpc = handler
+		}
+	}
+}
+
+func WithLogger(logger *logrus.Entry) func(interfaces.Handler) {
+	return func(impl interfaces.Handler) {
+		// Type assertion for more iplementations later
+		if impl, ok := impl.(*MdcbStorage); ok {
+			impl.Logger = logger
+		}
+	}
+}

--- a/storage/mdcb_options.go
+++ b/storage/mdcb_options.go
@@ -1,7 +1,8 @@
-package mdcb
+package storage
 
 import (
 	"github.com/TykTechnologies/tyk/interfaces"
+	"github.com/TykTechnologies/tyk/storage/mdcb"
 	"github.com/sirupsen/logrus"
 )
 
@@ -9,7 +10,7 @@ import (
 func WithLocalStorageHandler(handler interfaces.Handler) func(interfaces.Handler) {
 	return func(impl interfaces.Handler) {
 		// Type assertion for more iplementations later
-		if impl, ok := impl.(*MdcbStorage); ok {
+		if impl, ok := impl.(*mdcb.MdcbStorage); ok {
 			impl.Local = handler
 		}
 	}
@@ -18,7 +19,7 @@ func WithLocalStorageHandler(handler interfaces.Handler) func(interfaces.Handler
 func WithRpcStorageHandler(handler interfaces.Handler) func(interfaces.Handler) {
 	return func(impl interfaces.Handler) {
 		// Type assertion for more iplementations later
-		if impl, ok := impl.(*MdcbStorage); ok {
+		if impl, ok := impl.(*mdcb.MdcbStorage); ok {
 			impl.Rpc = handler
 		}
 	}
@@ -27,7 +28,7 @@ func WithRpcStorageHandler(handler interfaces.Handler) func(interfaces.Handler) 
 func WithLogger(logger *logrus.Entry) func(interfaces.Handler) {
 	return func(impl interfaces.Handler) {
 		// Type assertion for more iplementations later
-		if impl, ok := impl.(*MdcbStorage); ok {
+		if impl, ok := impl.(*mdcb.MdcbStorage); ok {
 			impl.Logger = logger
 		}
 	}

--- a/storage/redis-cluster/connection_handler.go
+++ b/storage/redis-cluster/connection_handler.go
@@ -1,4 +1,4 @@
-package storage
+package redisCluster
 
 import (
 	"context"

--- a/storage/redis-cluster/connection_handler_test.go
+++ b/storage/redis-cluster/connection_handler_test.go
@@ -1,4 +1,4 @@
-package storage
+package redisCluster
 
 import (
 	"context"

--- a/storage/redis-cluster/options.go
+++ b/storage/redis-cluster/options.go
@@ -1,0 +1,58 @@
+package redisCluster
+
+import "github.com/TykTechnologies/tyk/interfaces"
+
+// Redis Cluster Options
+func WithKeyPrefix(prefix string) func(interfaces.Handler) {
+	return func(impl interfaces.Handler) {
+		// Type assertion for more iplementations later
+		if impl, ok := impl.(*RedisCluster); ok {
+			impl.KeyPrefix = prefix
+		}
+	}
+}
+
+func WithHashKeys(hashKeys bool) func(interfaces.Handler) {
+	return func(impl interfaces.Handler) {
+		// Type assertion for more iplementations later
+		if impl, ok := impl.(*RedisCluster); ok {
+			impl.HashKeys = hashKeys
+		}
+	}
+}
+
+func WithConnectionhandler(handler *ConnectionHandler) func(interfaces.Handler) {
+	return func(impl interfaces.Handler) {
+		// Type assertion for more iplementations later
+		if impl, ok := impl.(*RedisCluster); ok {
+			impl.ConnectionHandler = handler
+		}
+	}
+}
+
+func IsCache(cache bool) func(interfaces.Handler) {
+	return func(impl interfaces.Handler) {
+		// Type assertion for more iplementations later
+		if impl, ok := impl.(*RedisCluster); ok {
+			impl.IsCache = cache
+		}
+	}
+}
+
+func IsAnalytics(analytics bool) func(interfaces.Handler) {
+	return func(impl interfaces.Handler) {
+		// Type assertion for more iplementations later
+		if impl, ok := impl.(*RedisCluster); ok {
+			impl.IsAnalytics = analytics
+		}
+	}
+}
+
+func WithRedisController(controller *RedisController) func(interfaces.Handler) {
+	return func(impl interfaces.Handler) {
+		// Type assertion for more iplementations later
+		if impl, ok := impl.(*RedisCluster); ok {
+			impl.RedisController = controller
+		}
+	}
+}

--- a/storage/redis-cluster/redis_cluster_test.go
+++ b/storage/redis-cluster/redis_cluster_test.go
@@ -1,4 +1,4 @@
-package storage
+package redisCluster
 
 import (
 	"context"
@@ -13,6 +13,7 @@ import (
 	tempmocks "github.com/TykTechnologies/storage/temporal/tempmocks"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/internal/redis"
+	"github.com/TykTechnologies/tyk/storage/shared"
 
 	"github.com/stretchr/testify/mock"
 )
@@ -116,8 +117,8 @@ func TestRedisClusterGetMultiKey(t *testing.T) {
 	r.DeleteAllKeys()
 
 	_, err := r.GetMultiKey(keys)
-	if !errors.Is(err, ErrKeyNotFound) {
-		t.Errorf("expected %v got %v", ErrKeyNotFound, err)
+	if !errors.Is(err, shared.ErrKeyNotFound) {
+		t.Errorf("expected %v got %v", shared.ErrKeyNotFound, err)
 	}
 	err = r.SetKey(keys[0], keys[0], 0)
 	if err != nil {
@@ -408,7 +409,7 @@ func TestGetKey(t *testing.T) {
 
 		val, err := storage.GetKey("key")
 		assert.Error(t, err)
-		assert.Equal(t, ErrKeyNotFound, err)
+		assert.Equal(t, shared.ErrKeyNotFound, err)
 		assert.Equal(t, "", val)
 		mockKv.AssertExpectations(t)
 	})
@@ -458,7 +459,7 @@ func TestGetMultiKey(t *testing.T) {
 
 		val, err := storage.GetMultiKey([]string{"key"})
 		assert.Error(t, err)
-		assert.Equal(t, ErrKeyNotFound, err)
+		assert.Equal(t, shared.ErrKeyNotFound, err)
 		assert.Equal(t, []string(nil), val)
 		mockKv.AssertExpectations(t)
 	})
@@ -503,11 +504,11 @@ func TestGetKeyTTL(t *testing.T) {
 		storage := &RedisCluster{ConnectionHandler: rc}
 		mockKv := tempmocks.NewKeyValue(t)
 		storage.kvStorage = mockKv
-		mockKv.On("TTL", mock.Anything, "key").Return(int64(0), ErrKeyNotFound)
+		mockKv.On("TTL", mock.Anything, "key").Return(int64(0), shared.ErrKeyNotFound)
 
 		val, err := storage.GetKeyTTL("key")
 		assert.Error(t, err)
-		assert.Equal(t, ErrKeyNotFound, err)
+		assert.Equal(t, shared.ErrKeyNotFound, err)
 		assert.Equal(t, int64(0), val)
 		mockKv.AssertExpectations(t)
 	})
@@ -541,11 +542,11 @@ func TestGetRawKey(t *testing.T) {
 		storage := &RedisCluster{ConnectionHandler: rc}
 		mockKv := tempmocks.NewKeyValue(t)
 		storage.kvStorage = mockKv
-		mockKv.On("Get", mock.Anything, "key").Return("", ErrKeyNotFound)
+		mockKv.On("Get", mock.Anything, "key").Return("", shared.ErrKeyNotFound)
 
 		val, err := storage.GetRawKey("key")
 		assert.Error(t, err)
-		assert.Equal(t, ErrKeyNotFound, err)
+		assert.Equal(t, shared.ErrKeyNotFound, err)
 		assert.Equal(t, "", val)
 		mockKv.AssertExpectations(t)
 	})
@@ -590,11 +591,11 @@ func TestGetExp(t *testing.T) {
 		storage := &RedisCluster{ConnectionHandler: rc}
 		mockKv := tempmocks.NewKeyValue(t)
 		storage.kvStorage = mockKv
-		mockKv.On("TTL", mock.Anything, "key").Return(int64(0), ErrKeyNotFound)
+		mockKv.On("TTL", mock.Anything, "key").Return(int64(0), shared.ErrKeyNotFound)
 
 		val, err := storage.GetExp("key")
 		assert.Error(t, err)
-		assert.Equal(t, ErrKeyNotFound, err)
+		assert.Equal(t, shared.ErrKeyNotFound, err)
 		assert.Equal(t, int64(0), val)
 		mockKv.AssertExpectations(t)
 	})
@@ -637,11 +638,11 @@ func TestSetExp(t *testing.T) {
 		storage := &RedisCluster{ConnectionHandler: rc}
 		mockKv := tempmocks.NewKeyValue(t)
 		storage.kvStorage = mockKv
-		mockKv.On("Expire", mock.Anything, "key", time.Duration(-1*time.Second)).Return(ErrKeyNotFound)
+		mockKv.On("Expire", mock.Anything, "key", time.Duration(-1*time.Second)).Return(shared.ErrKeyNotFound)
 
 		err := storage.SetExp("key", -1)
 		assert.Error(t, err)
-		assert.Equal(t, ErrKeyNotFound, err)
+		assert.Equal(t, shared.ErrKeyNotFound, err)
 		mockKv.AssertExpectations(t)
 	})
 }
@@ -683,11 +684,11 @@ func TestSetKey(t *testing.T) {
 		storage := &RedisCluster{ConnectionHandler: rc}
 		mockKv := tempmocks.NewKeyValue(t)
 		storage.kvStorage = mockKv
-		mockKv.On("Set", mock.Anything, "key", "value", time.Duration(-1*time.Second)).Return(ErrKeyNotFound)
+		mockKv.On("Set", mock.Anything, "key", "value", time.Duration(-1*time.Second)).Return(shared.ErrKeyNotFound)
 
 		err := storage.SetKey("key", "value", -1)
 		assert.Error(t, err)
-		assert.Equal(t, ErrKeyNotFound, err)
+		assert.Equal(t, shared.ErrKeyNotFound, err)
 		mockKv.AssertExpectations(t)
 	})
 }
@@ -729,11 +730,11 @@ func TestSetRawKey(t *testing.T) {
 		storage := &RedisCluster{ConnectionHandler: rc}
 		mockKv := tempmocks.NewKeyValue(t)
 		storage.kvStorage = mockKv
-		mockKv.On("Set", mock.Anything, "key", "value", time.Duration(-1*time.Second)).Return(ErrKeyNotFound)
+		mockKv.On("Set", mock.Anything, "key", "value", time.Duration(-1*time.Second)).Return(shared.ErrKeyNotFound)
 
 		err := storage.SetRawKey("key", "value", -1)
 		assert.Error(t, err)
-		assert.Equal(t, ErrKeyNotFound, err)
+		assert.Equal(t, shared.ErrKeyNotFound, err)
 		mockKv.AssertExpectations(t)
 	})
 }
@@ -771,7 +772,7 @@ func TestDecrement(t *testing.T) {
 		storage := &RedisCluster{ConnectionHandler: rc}
 		mockKv := tempmocks.NewKeyValue(t)
 		storage.kvStorage = mockKv
-		mockKv.On("Decrement", mock.Anything, "key").Return(int64(1), ErrKeyNotFound)
+		mockKv.On("Decrement", mock.Anything, "key").Return(int64(1), shared.ErrKeyNotFound)
 
 		storage.Decrement("key")
 		mockKv.AssertExpectations(t)
@@ -837,7 +838,7 @@ func TestIncrememntWithExpire(t *testing.T) {
 		storage := &RedisCluster{ConnectionHandler: rc}
 		mockKv := tempmocks.NewKeyValue(t)
 		storage.kvStorage = mockKv
-		mockKv.On("Increment", mock.Anything, "key").Return(int64(0), ErrKeyNotFound)
+		mockKv.On("Increment", mock.Anything, "key").Return(int64(0), shared.ErrKeyNotFound)
 
 		val := storage.IncrememntWithExpire("key", 0)
 		assert.Equal(t, int64(0), val)
@@ -947,7 +948,7 @@ func TestGetKeysAndValuesWithFilter(t *testing.T) {
 		storage := &RedisCluster{ConnectionHandler: rc}
 		mockKv := tempmocks.NewKeyValue(t)
 		storage.kvStorage = mockKv
-		mockKv.On("GetKeysAndValuesWithFilter", mock.Anything, "test").Return(map[string]interface{}{}, ErrKeyNotFound)
+		mockKv.On("GetKeysAndValuesWithFilter", mock.Anything, "test").Return(map[string]interface{}{}, shared.ErrKeyNotFound)
 
 		res := storage.GetKeysAndValuesWithFilter("test")
 		assert.Equal(t, map[string]string(map[string]string(nil)), res)
@@ -982,7 +983,7 @@ func TestGetKeysAndValues(t *testing.T) {
 		storage := &RedisCluster{ConnectionHandler: rc}
 		mockKv := tempmocks.NewKeyValue(t)
 		storage.kvStorage = mockKv
-		mockKv.On("GetKeysAndValuesWithFilter", mock.Anything, "").Return(map[string]interface{}{}, ErrKeyNotFound)
+		mockKv.On("GetKeysAndValuesWithFilter", mock.Anything, "").Return(map[string]interface{}{}, shared.ErrKeyNotFound)
 
 		res := storage.GetKeysAndValues()
 		assert.Equal(t, map[string]string(map[string]string(nil)), res)
@@ -1121,7 +1122,7 @@ func TestDeleteRawKey(t *testing.T) {
 		storage := &RedisCluster{ConnectionHandler: rc}
 		mockKv := tempmocks.NewKeyValue(t)
 		storage.kvStorage = mockKv
-		mockKv.On("Delete", mock.Anything, "key").Return(ErrKeyNotFound)
+		mockKv.On("Delete", mock.Anything, "key").Return(shared.ErrKeyNotFound)
 
 		deleted := storage.DeleteRawKey("key")
 		assert.False(t, deleted)
@@ -1166,7 +1167,7 @@ func TestDeleteScanMatch(t *testing.T) {
 		storage := &RedisCluster{ConnectionHandler: rc}
 		mockKv := tempmocks.NewKeyValue(t)
 		storage.kvStorage = mockKv
-		mockKv.On("DeleteScanMatch", mock.Anything, "key").Return(int64(0), ErrKeyNotFound)
+		mockKv.On("DeleteScanMatch", mock.Anything, "key").Return(int64(0), shared.ErrKeyNotFound)
 
 		deleted := storage.DeleteScanMatch("key")
 		assert.False(t, deleted)
@@ -1222,7 +1223,7 @@ func TestDeleteKeys(t *testing.T) {
 		storage := &RedisCluster{ConnectionHandler: rc}
 		mockKv := tempmocks.NewKeyValue(t)
 		storage.kvStorage = mockKv
-		mockKv.On("DeleteKeys", mock.Anything, mock.Anything).Return(int64(0), ErrKeyNotFound)
+		mockKv.On("DeleteKeys", mock.Anything, mock.Anything).Return(int64(0), shared.ErrKeyNotFound)
 
 		deleted := storage.DeleteKeys([]string{"key"})
 		assert.False(t, deleted)

--- a/storage/redis-cluster/redis_shim.go
+++ b/storage/redis-cluster/redis_shim.go
@@ -1,4 +1,4 @@
-package storage
+package redisCluster
 
 import (
 	"context"

--- a/storage/redis-cluster/redis_shim_test.go
+++ b/storage/redis-cluster/redis_shim_test.go
@@ -1,4 +1,4 @@
-package storage
+package redisCluster
 
 import (
 	"context"

--- a/storage/redis_options.go
+++ b/storage/redis_options.go
@@ -1,12 +1,15 @@
-package redisCluster
+package storage
 
-import "github.com/TykTechnologies/tyk/interfaces"
+import (
+	"github.com/TykTechnologies/tyk/interfaces"
+	redisCluster "github.com/TykTechnologies/tyk/storage/redis-cluster"
+)
 
 // Redis Cluster Options
 func WithKeyPrefix(prefix string) func(interfaces.Handler) {
 	return func(impl interfaces.Handler) {
 		// Type assertion for more iplementations later
-		if impl, ok := impl.(*RedisCluster); ok {
+		if impl, ok := impl.(*redisCluster.RedisCluster); ok {
 			impl.KeyPrefix = prefix
 		}
 	}
@@ -15,16 +18,16 @@ func WithKeyPrefix(prefix string) func(interfaces.Handler) {
 func WithHashKeys(hashKeys bool) func(interfaces.Handler) {
 	return func(impl interfaces.Handler) {
 		// Type assertion for more iplementations later
-		if impl, ok := impl.(*RedisCluster); ok {
+		if impl, ok := impl.(*redisCluster.RedisCluster); ok {
 			impl.HashKeys = hashKeys
 		}
 	}
 }
 
-func WithConnectionhandler(handler *ConnectionHandler) func(interfaces.Handler) {
+func WithConnectionHandler(handler *redisCluster.ConnectionHandler) func(interfaces.Handler) {
 	return func(impl interfaces.Handler) {
 		// Type assertion for more iplementations later
-		if impl, ok := impl.(*RedisCluster); ok {
+		if impl, ok := impl.(*redisCluster.RedisCluster); ok {
 			impl.ConnectionHandler = handler
 		}
 	}
@@ -33,7 +36,7 @@ func WithConnectionhandler(handler *ConnectionHandler) func(interfaces.Handler) 
 func IsCache(cache bool) func(interfaces.Handler) {
 	return func(impl interfaces.Handler) {
 		// Type assertion for more iplementations later
-		if impl, ok := impl.(*RedisCluster); ok {
+		if impl, ok := impl.(*redisCluster.RedisCluster); ok {
 			impl.IsCache = cache
 		}
 	}
@@ -42,16 +45,16 @@ func IsCache(cache bool) func(interfaces.Handler) {
 func IsAnalytics(analytics bool) func(interfaces.Handler) {
 	return func(impl interfaces.Handler) {
 		// Type assertion for more iplementations later
-		if impl, ok := impl.(*RedisCluster); ok {
+		if impl, ok := impl.(*redisCluster.RedisCluster); ok {
 			impl.IsAnalytics = analytics
 		}
 	}
 }
 
-func WithRedisController(controller *RedisController) func(interfaces.Handler) {
+func WithRedisController(controller *redisCluster.RedisController) func(interfaces.Handler) {
 	return func(impl interfaces.Handler) {
 		// Type assertion for more iplementations later
-		if impl, ok := impl.(*RedisCluster); ok {
+		if impl, ok := impl.(*redisCluster.RedisCluster); ok {
 			impl.RedisController = controller
 		}
 	}

--- a/storage/shared/errors.go
+++ b/storage/shared/errors.go
@@ -1,0 +1,7 @@
+package shared
+
+import "errors"
+
+// ErrKeyNotFound is a standard error for when a key is not found in the storage engine
+var ErrKeyNotFound = errors.New("key not found")
+var ErrMDCBConnectionLost = errors.New("mdcb connection is lost")

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1,67 +1,17 @@
 package storage
 
 import (
-	"crypto/sha256"
-	"encoding/base64"
-	"encoding/hex"
-	"errors"
 	"fmt"
-	"hash"
-	"strings"
 
-	"github.com/buger/jsonparser"
-
-	"github.com/TykTechnologies/murmur3"
-	logger "github.com/TykTechnologies/tyk/log"
-
-	"github.com/TykTechnologies/tyk/internal/uuid"
+	"github.com/TykTechnologies/tyk/interfaces"
+	redisCluster "github.com/TykTechnologies/tyk/storage/redis-cluster"
 )
 
-var log = logger.Get()
-
-// ErrKeyNotFound is a standard error for when a key is not found in the storage engine
-var ErrKeyNotFound = errors.New("key not found")
-
-var ErrMDCBConnectionLost = errors.New("mdcb connection is lost")
-
-const MongoBsonIdLength = 24
-
-// Handler is a standard interface to a storage backend, used by
-// AuthorisationManager to read and write key values to the backend
-type Handler interface {
-	GetKey(string) (string, error) // Returned string is expected to be a JSON object (user.SessionState)
-	GetMultiKey([]string) ([]string, error)
-	GetRawKey(string) (string, error)
-	SetKey(string, string, int64) error // Second input string is expected to be a JSON object (user.SessionState)
-	SetRawKey(string, string, int64) error
-	SetExp(string, int64) error   // Set key expiration
-	GetExp(string) (int64, error) // Returns expiry of a key
-	GetKeys(string) []string
-	DeleteKey(string) bool
-	DeleteAllKeys() bool
-	DeleteRawKey(string) bool
-	Connect() bool
-	GetKeysAndValues() map[string]string
-	GetKeysAndValuesWithFilter(string) map[string]string
-	DeleteKeys([]string) bool
-	Decrement(string)
-	IncrememntWithExpire(string, int64) int64
-	SetRollingWindow(key string, per int64, val string, pipeline bool) (int, []interface{})
-	GetRollingWindow(key string, per int64, pipeline bool) (int, []interface{})
-	GetSet(string) (map[string]string, error)
-	AddToSet(string, string)
-	GetAndDeleteSet(string) []interface{}
-	RemoveFromSet(string, string)
-	DeleteScanMatch(string) bool
-	GetKeyPrefix() string
-	AddToSortedSet(string, string, float64)
-	GetSortedSetRange(string, string, string) ([]string, []float64, error)
-	RemoveSortedSetRange(string, string, string) error
-	GetListRange(string, int64, int64) ([]string, error)
-	RemoveFromList(string, string) error
-	AppendToSet(string, string)
-	Exists(string) (bool, error)
-}
+const (
+	REDIS_CLUSTER = "redis"
+	MDCB          = "mdcb"
+	DUMMY         = "dummy"
+)
 
 type AnalyticsHandler interface {
 	Connect() bool
@@ -71,114 +21,47 @@ type AnalyticsHandler interface {
 	GetExp(string) (int64, error) // Returns expiry of a key
 }
 
-const defaultHashAlgorithm = "murmur64"
-
-// If hashing algorithm is empty, use legacy key generation
-func GenerateToken(orgID, keyID, hashAlgorithm string) (string, error) {
-	if keyID == "" {
-		keyID = uuid.NewHex()
-	}
-
-	if hashAlgorithm != "" {
-		_, err := hashFunction(hashAlgorithm)
-		if err != nil {
-			hashAlgorithm = defaultHashAlgorithm
-		}
-
-		jsonToken := fmt.Sprintf(`{"org":"%s","id":"%s","h":"%s"}`, orgID, keyID, hashAlgorithm)
-		return base64.StdEncoding.EncodeToString([]byte(jsonToken)), err
-	}
-
-	// Legacy keys
-	return orgID + keyID, nil
-}
-
-// `{"` in base64
-const B64JSONPrefix = "ey"
-
-func TokenHashAlgo(token string) string {
-	// Legacy tokens not b64 and not JSON records
-	if strings.HasPrefix(token, B64JSONPrefix) {
-		if jsonToken, err := base64.StdEncoding.DecodeString(token); err == nil {
-			hashAlgo, _ := jsonparser.GetString(jsonToken, "h")
-			return hashAlgo
+func WithKeyPrefix(prefix string) func(interfaces.Handler) {
+	return func(impl interfaces.Handler) {
+		// Type assertion for more iplementations later
+		if impl, ok := impl.(*redisCluster.RedisCluster); ok {
+			impl.KeyPrefix = prefix
 		}
 	}
-
-	return ""
 }
 
-// TODO: add checks
-func TokenID(token string) (id string, err error) {
-	jsonToken, err := base64.StdEncoding.DecodeString(token)
-	if err != nil {
-		return "", err
-	}
-
-	return jsonparser.GetString(jsonToken, "id")
-}
-
-func TokenOrg(token string) string {
-	if strings.HasPrefix(token, B64JSONPrefix) {
-		if jsonToken, err := base64.StdEncoding.DecodeString(token); err == nil {
-			// Checking error in case if it is a legacy tooken which just by accided has the same b64JSON prefix
-			if org, err := jsonparser.GetString(jsonToken, "org"); err == nil {
-				return org
-			}
+func WithHashKeys(hashKeys bool) func(interfaces.Handler) {
+	return func(impl interfaces.Handler) {
+		// Type assertion for more iplementations later
+		if impl, ok := impl.(*redisCluster.RedisCluster); ok {
+			impl.HashKeys = hashKeys
 		}
 	}
-
-	// 24 is mongo bson id length
-	if len(token) > MongoBsonIdLength {
-		newToken := token[:MongoBsonIdLength]
-		_, err := hex.DecodeString(newToken)
-		if err == nil {
-			return newToken
-		}
-	}
-
-	return ""
 }
 
-var (
-	HashSha256    = "sha256"
-	HashMurmur32  = "murmur32"
-	HashMurmur64  = "murmur64"
-	HashMurmur128 = "murmur128"
-)
+func WithConnectionhandler(handler *redisCluster.ConnectionHandler) func(interfaces.Handler) {
+	return func(impl interfaces.Handler) {
+		// Type assertion for more iplementations later
+		if impl, ok := impl.(*redisCluster.RedisCluster); ok {
+			impl.ConnectionHandler = handler
+		}
+	}
+}
 
-func hashFunction(algorithm string) (hash.Hash, error) {
-	switch algorithm {
-	case HashSha256:
-		return sha256.New(), nil
-	case HashMurmur64:
-		return murmur3.New64(), nil
-	case HashMurmur128:
-		return murmur3.New128(), nil
-	case "", HashMurmur32:
-		return murmur3.New32(), nil
+func NewStorageHandler(name string, opts ...func(interfaces.Handler)) (interfaces.Handler, error) {
+	var impl interfaces.Handler
+	switch name {
+	case REDIS_CLUSTER:
+		impl = &redisCluster.RedisCluster{}
+	case MDCB:
+		return nil, fmt.Errorf("mdcb storage handler is not implemented")
 	default:
-		return murmur3.New32(), fmt.Errorf("Unknown key hash function: %s. Falling back to murmur32.", algorithm)
-	}
-}
-
-func HashStr(in string, withAlg ...string) string {
-	var algo string
-	if len(withAlg) > 0 && withAlg[0] != "" {
-		algo = withAlg[0]
-	} else {
-		algo = TokenHashAlgo(in)
+		return nil, fmt.Errorf("unknown storage handler: %s", name)
 	}
 
-	h, _ := hashFunction(algo)
-	h.Write([]byte(in))
-	return hex.EncodeToString(h.Sum(nil))
-}
-
-func HashKey(in string, hashKey bool) string {
-	if !hashKey {
-		// Not hashing? Return the raw key
-		return in
+	for _, opt := range opts {
+		opt(impl)
 	}
-	return HashStr(in)
+
+	return impl, nil
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/TykTechnologies/tyk/interfaces"
+	"github.com/TykTechnologies/tyk/storage/mdcb"
 	redisCluster "github.com/TykTechnologies/tyk/storage/redis-cluster"
 )
 
@@ -21,40 +22,14 @@ type AnalyticsHandler interface {
 	GetExp(string) (int64, error) // Returns expiry of a key
 }
 
-func WithKeyPrefix(prefix string) func(interfaces.Handler) {
-	return func(impl interfaces.Handler) {
-		// Type assertion for more iplementations later
-		if impl, ok := impl.(*redisCluster.RedisCluster); ok {
-			impl.KeyPrefix = prefix
-		}
-	}
-}
-
-func WithHashKeys(hashKeys bool) func(interfaces.Handler) {
-	return func(impl interfaces.Handler) {
-		// Type assertion for more iplementations later
-		if impl, ok := impl.(*redisCluster.RedisCluster); ok {
-			impl.HashKeys = hashKeys
-		}
-	}
-}
-
-func WithConnectionhandler(handler *redisCluster.ConnectionHandler) func(interfaces.Handler) {
-	return func(impl interfaces.Handler) {
-		// Type assertion for more iplementations later
-		if impl, ok := impl.(*redisCluster.RedisCluster); ok {
-			impl.ConnectionHandler = handler
-		}
-	}
-}
-
 func NewStorageHandler(name string, opts ...func(interfaces.Handler)) (interfaces.Handler, error) {
 	var impl interfaces.Handler
 	switch name {
 	case REDIS_CLUSTER:
 		impl = &redisCluster.RedisCluster{}
 	case MDCB:
-		return nil, fmt.Errorf("mdcb storage handler is not implemented")
+		impl = mdcb.MdcbStorage{}
+
 	default:
 		return nil, fmt.Errorf("unknown storage handler: %s", name)
 	}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -40,3 +40,13 @@ func NewStorageHandler(name string, opts ...func(interfaces.Handler)) (interface
 
 	return impl, nil
 }
+
+const (
+	DEFAULT_MODULE = "default"
+)
+
+// GetStorageForModule returns the storage type for the given module.
+// Defaults to REDIS_CLUSTER for the initial implementation.
+func GetStorageForModule(module string) string {
+	return REDIS_CLUSTER
+}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1,6 +1,10 @@
 package storage
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/TykTechnologies/tyk/storage/util"
+)
 
 func Test_TokenOrg(t *testing.T) {
 	tcs := []struct {
@@ -32,7 +36,7 @@ func Test_TokenOrg(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			result := TokenOrg(tc.givenKey)
+			result := util.TokenOrg(tc.givenKey)
 			if result != tc.expectedResult {
 				t.Errorf("Expected %s, got %s", tc.expectedResult, result)
 			}

--- a/storage/util/util.go
+++ b/storage/util/util.go
@@ -1,0 +1,127 @@
+package util
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"strings"
+
+	"github.com/TykTechnologies/murmur3"
+	"github.com/TykTechnologies/tyk/internal/uuid"
+	"github.com/buger/jsonparser"
+)
+
+const defaultHashAlgorithm = "murmur64"
+const MongoBsonIdLength = 24
+
+// If hashing algorithm is empty, use legacy key generation
+func GenerateToken(orgID, keyID, hashAlgorithm string) (string, error) {
+	if keyID == "" {
+		keyID = uuid.NewHex()
+	}
+
+	if hashAlgorithm != "" {
+		_, err := hashFunction(hashAlgorithm)
+		if err != nil {
+			hashAlgorithm = defaultHashAlgorithm
+		}
+
+		jsonToken := fmt.Sprintf(`{"org":"%s","id":"%s","h":"%s"}`, orgID, keyID, hashAlgorithm)
+		return base64.StdEncoding.EncodeToString([]byte(jsonToken)), err
+	}
+
+	// Legacy keys
+	return orgID + keyID, nil
+}
+
+// `{"` in base64
+const B64JSONPrefix = "ey"
+
+func TokenHashAlgo(token string) string {
+	// Legacy tokens not b64 and not JSON records
+	if strings.HasPrefix(token, B64JSONPrefix) {
+		if jsonToken, err := base64.StdEncoding.DecodeString(token); err == nil {
+			hashAlgo, _ := jsonparser.GetString(jsonToken, "h")
+			return hashAlgo
+		}
+	}
+
+	return ""
+}
+
+// TODO: add checks
+func TokenID(token string) (id string, err error) {
+	jsonToken, err := base64.StdEncoding.DecodeString(token)
+	if err != nil {
+		return "", err
+	}
+
+	return jsonparser.GetString(jsonToken, "id")
+}
+
+func TokenOrg(token string) string {
+	if strings.HasPrefix(token, B64JSONPrefix) {
+		if jsonToken, err := base64.StdEncoding.DecodeString(token); err == nil {
+			// Checking error in case if it is a legacy tooken which just by accided has the same b64JSON prefix
+			if org, err := jsonparser.GetString(jsonToken, "org"); err == nil {
+				return org
+			}
+		}
+	}
+
+	// 24 is mongo bson id length
+	if len(token) > MongoBsonIdLength {
+		newToken := token[:MongoBsonIdLength]
+		_, err := hex.DecodeString(newToken)
+		if err == nil {
+			return newToken
+		}
+	}
+
+	return ""
+}
+
+var (
+	HashSha256    = "sha256"
+	HashMurmur32  = "murmur32"
+	HashMurmur64  = "murmur64"
+	HashMurmur128 = "murmur128"
+)
+
+func hashFunction(algorithm string) (hash.Hash, error) {
+	switch algorithm {
+	case HashSha256:
+		return sha256.New(), nil
+	case HashMurmur64:
+		return murmur3.New64(), nil
+	case HashMurmur128:
+		return murmur3.New128(), nil
+	case "", HashMurmur32:
+		return murmur3.New32(), nil
+	default:
+		return murmur3.New32(), fmt.Errorf("Unknown key hash function: %s. Falling back to murmur32.", algorithm)
+	}
+}
+
+func HashStr(in string, withAlg ...string) string {
+	var algo string
+	if len(withAlg) > 0 && withAlg[0] != "" {
+		algo = withAlg[0]
+	} else {
+		algo = TokenHashAlgo(in)
+	}
+
+	h, _ := hashFunction(algo)
+	h.Write([]byte(in))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func HashKey(in string, hashKey bool) string {
+	if !hashKey {
+		// Not hashing? Return the raw key
+		return in
+	}
+	return HashStr(in)
+}


### PR DESCRIPTION
### **User description**
This PR abstracts the storage handler implementations, which were all literals like `x :=. RedisCluster{blah:blah}` to instead take the Handler interface, and added a nifty constructor that allows for more dynamic configuration.

## Description
- Refactored the `storage` package into sub-modules for each store type (`redisCluster`, `MDCB`, `DUMMY`)
- Moved utility functions into their own package for storage
- Move the storage interface out into a separate interfaces package (not ideal, but it gets around circular imports)
- Created a generic constructor `storage.NewStorageHandler(type, opts...)` to consolidate instantiation
- Refactored all literal instantiations to use the constructor
- Added a dynamic storage "type" getter which can be hooked into configuration options at a alter stage for new back-ends

## Related Issue

[Remove dependency on Redis](https://tyktech.atlassian.net/browse/TT-9794)

## Motivation and Context
In order to eventually drop Redis, or be able to replace it with a different beack end that is more lightweight, the code base needs to use the existing Handler interface to interact with the back end, unfortunately over time, concrete implementations have crept in and made it harder to make the back-end pluggable. This PR aims to address that to some degree.

## How This Has Been Tested
lol, the code builds ;-)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Refactored storage handler initialization across multiple files to use a new dynamic constructor `NewStorageHandler`.
- Updated imports to use new storage packages, including `redisCluster`, `mdcb`, `shared`, and `util`.
- Moved utility functions for hashing and token generation to a new `util` package.
- Added options for configuring Redis storage handlers.
- Updated tests to reflect changes in storage handler initialization and utility functions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>server.go</strong><dd><code>Refactor storage handler initialization in server.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/server.go

<li>Replaced direct <code>RedisCluster</code> instantiations with <code>NewStorageHandler</code> <br>calls.<br> <li> Updated imports to use new storage packages.<br> <li> Refactored storage handler initialization to use dynamic constructor.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-4652d1bf175a0be8f5e61ef7177c9666f23e077d8626b73ac9d13358fa8b525b">+100/-21</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_storage_handler.go</strong><dd><code>Update storage handler and utility usage in rpc_storage_handler.go</code></dd></summary>
<hr>

gateway/rpc_storage_handler.go

<li>Updated storage handler to use new <code>util</code> package for hashing.<br> <li> Replaced direct <code>RedisCluster</code> references with <code>shared</code> package errors.<br> <li> Moved OAuth client event processing functions.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-8875f75b602664c44b62b67a4da41d748124ad270573a44db4ec977ee5d68021">+102/-100</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>api.go</strong><dd><code>Refactor storage handler usage and imports in api.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api.go

<li>Updated imports to use new storage packages.<br> <li> Replaced direct <code>RedisCluster</code> references with <code>NewStorageHandler</code> calls.<br> <li> Updated hashing functions to use <code>util</code> package.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-644cda3aeb4ac7f325359e85fcddb810f100dd5e6fa480b0d9f9363a743c4e05">+44/-11</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>storage.go</strong><dd><code>Refactor storage handler interface and add constructor</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

storage/storage.go

<li>Removed old storage handler interface and related functions.<br> <li> Added new storage handler constructor and module getter.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-2a93e444b612bd9853c32889fb82c4041760536f84356bb0db04738c19b62dde">+26/-158</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mdcb_storage.go</strong><dd><code>Update MdcbStorage to use new storage handler interface</code>&nbsp; &nbsp; </dd></summary>
<hr>

storage/mdcb/mdcb_storage.go

<li>Updated <code>MdcbStorage</code> struct to use new <code>interfaces.Handler</code>.<br> <li> Refactored methods to use new storage handler interface.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-5e177eb162e73446964037570024ca80fd8794c74a1f676a519e7a35aae5170a">+41/-40</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>oauth_manager.go</strong><dd><code>Refactor storage handler usage and imports in oauth_manager.go</code></dd></summary>
<hr>

gateway/oauth_manager.go

<li>Updated imports to use new storage packages.<br> <li> Replaced direct <code>RedisCluster</code> references with <code>NewStorageHandler</code> calls.<br> <li> Updated hashing functions to use <code>util</code> package.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-bcb7d4bc0ecfd071eff1cdbc75ccad0f5debef1d97f372c41c3637174b7448f9">+30/-12</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>util.go</strong><dd><code>Add utility functions for hashing and token generation</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

storage/util/util.go

<li>Added utility functions for hashing and token generation.<br> <li> Moved from <code>storage.go</code> to a new <code>util</code> package.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-99358d091a29bb1a3eea447f0d2665d6b021e9caee940d51665c3351dd8dc6db">+127/-0</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>redis_cluster.go</strong><dd><code>Update package name and references in redis_cluster.go</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

storage/redis-cluster/redis_cluster.go

<li>Changed package name to <code>redisCluster</code>.<br> <li> Updated error references to use <code>shared</code> package.<br> <li> Updated hashing functions to use <code>util</code> package.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-51a20375202aa3394ac58e692e9b91b5d111180a56f3c4ff007708f31db6e755">+11/-6</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>session_manager.go</strong><dd><code>Update session manager to use new storage handler interface</code></dd></summary>
<hr>

gateway/session_manager.go

<li>Updated imports to use new storage packages.<br> <li> Updated session limiter to use new storage handler interface.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-e6b40a285464cd86736e970c4c0b320b44c75b18b363d38c200e9a9d36cdabb6">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>redis_options.go</strong><dd><code>Add options for configuring Redis storage handlers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

storage/redis_options.go

- Added options for configuring Redis storage handlers.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-86399fa46a3e7024bd7548054e22ae17b3b5a7bebe16d9eab89dbd43f0d6728c">+61/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>redis_cluster_test.go</strong><dd><code>Update package name and error references in redis_cluster_test.go</code></dd></summary>
<hr>

storage/redis-cluster/redis_cluster_test.go

<li>Changed package name to <code>redisCluster</code>.<br> <li> Updated error references to use <code>shared</code> package.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-c1fb9d041ca57697e16ac98485ece82325ce0cb98d5aad30446ff0180c2698af">+25/-24</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>coprocess_id_extractor_test.go</strong><dd><code>Update imports and storage references in </code><br><code>coprocess_id_extractor_test.go</code></dd></summary>
<hr>

gateway/coprocess_id_extractor_test.go

<li>Updated imports to use new storage packages.<br> <li> Replaced direct <code>RedisCluster</code> references with <code>redisCluster</code>.<br> <li> Updated hashing functions to use <code>util</code> package.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-077f3e65a150ce6b3b1c2ebc67e0482f1a5446ff6264754607d86c4691984375">+13/-12</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>api_test.go</strong><dd><code>Update imports and storage references in api_test.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_test.go

<li>Updated imports to use new storage packages.<br> <li> Replaced direct <code>RedisCluster</code> references with <code>redisCluster</code>.<br> <li> Updated hashing functions to use <code>util</code> package.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-10b4a3d7bdd8d98e48b288d27fd46d9ee436617806c46913fdf7942c0e4a992e">+15/-13</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>host_checker_manager_test.go</strong><dd><code>Update imports and storage references in host_checker_manager_test.go</code></dd></summary>
<hr>

gateway/host_checker_manager_test.go

<li>Updated imports to use new storage packages.<br> <li> Replaced direct <code>RedisCluster</code> references with <code>redisCluster</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-a206c6658f37f08130cec5a58f9d79a92e8a71187c16736c8770ea553ea56ff8">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>sliding_log_test.go</strong><dd><code>Update imports and storage references in sliding_log_test.go</code></dd></summary>
<hr>

internal/rate/sliding_log_test.go

<li>Updated imports to use new storage packages.<br> <li> Replaced direct <code>RedisCluster</code> references with <code>redisCluster</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-c84adf20904a21ae2dbaeba6b76ef8671abae88e10dc2b49f708b880180c6a08">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Additional files (token-limit)</strong></td><td><details><summary>38 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>health_check.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/health_check.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-978a2d1427d9209765e541618af10683944c6396df1a6fb8b5221e4f16658a6a">+11/-3</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_api_rate_limit.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_api_rate_limit.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-46326b04f936c839922e970db5c2924156cc797070948f3dc9c589d04661d6d2">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>oauth_manager_test.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/oauth_manager_test.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-139c3beb238f234728bde9f619f501cf730a7e275d17c8511277272d1dcd6fc6">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_basic_auth.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_basic_auth.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-3dd66447b7bd6a3fe7c8c091cd3ba4756bce80d01f7967f90b689c1ca2dadb73">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>event_handler_webhooks.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/event_handler_webhooks.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-6587ad3f2629cfa6c84a71144127acd6cc7824e5141f0b4961848945a87e0198">+14/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>host_checker_manager.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/host_checker_manager.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-498bdcb75329a741b279e6a46c4b065f7ce4074fbfe095a99df75721d1098c70">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>redis_signals.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/redis_signals.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-18cb136722c238e19b02741a85510dfd464343f85365482f0873aa60a37718af">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cert_test.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/cert_test.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-481696cb18de8c3880e0ca21318fe00fd4eb89bc48994e43b7c34729ef4a7ee2">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>redis_logrus_hook.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/redis_logrus_hook.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-7f4638862428fb6daaabe2cf8cb9b940b045394aae1fa663af979bac0b78b13f">+20/-3</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_external_oauth.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_external_oauth.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-49758921227a3506a0c29936c58d02fbc8829d140acb5730de55f6621823a82c">+13/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>coprocess_api.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/coprocess_api.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-86e6e4228ccca1a0af600a1a385316b9c0f30ff1e11a8b1509dbc08616c79ed5">+14/-3</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>api_definition.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_definition.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-0cf80174bbafb36f6d4f4308ebbd971b2833b76a936bad568220aa1a4ba0ee8b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mdcb_options.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

storage/mdcb_options.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-05a55e44b7e6630671790faed331f94c7c1ad751dff566a83a43240f8a3cbc1f">+35/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_auth_key_test.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_auth_key_test.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-88dc394fafeec279777773491b1ff88056fb621a7367687bf2d8049ba85f6854">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_jwt.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_jwt.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-e8bce0f6790c8c56b30e24dbeebb0fc4aa0879ab5ea5f6ef6dbe68931410e237">+11/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ctx.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ctx/ctx.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-600f5f552779994b15324fda108549eec7e7be30b1d8a1a16ee8344243e0cbc7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>api_healthcheck.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_healthcheck.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-2a2f1770c58a010a686d7655d944e7a27576cba57fc32610aaafdc593ccdc57c">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>analytics.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/analytics.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-96796da097eb152628700f491f99bfd2b5e87cc8314d0b1c1879cdb173c3bcdc">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_auth_key.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_auth_key.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-aeba053023a54c723dd9f83837e29ca0b2d9a212bc98fa6ad4bbb062669a1cf0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_basic_auth_test.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_basic_auth_test.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-148b4d4c5c77fa4382e83fd583c36d21bba7b52217f821095abbc517d277b16f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mdcb_storage_test.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

storage/mdcb/mdcb_storage_test.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-e3b0624538f3591e9332b8dccdb20cf69f944a6113f8145ff09f871474ba3cde">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_redis_cache.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_redis_cache.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-6266e0dbd16cef89e6de86a2c893114ba07799c804e2138172f9f94b08cdded8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>synchronization_forcer_test.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rpc/synchronization_forcer_test.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-82db82fe7614f7b4a4098ff54aadfb8414edeb40267f0d951b6d545bbc867f5c">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>sliding_log.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/rate/sliding_log.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-c2300c4284e73a74e69f500492a1f9b15cac918acf19f05d105d3134e246b450">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_analytics_purger.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rpc/rpc_analytics_purger.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-5c903289cdf7f4a9b66ae77afd9c148144fbe12bdd224c82fff107f842946f7c">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>delete_api_cache.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/delete_api_cache.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-8606dab58155ef5aab8c6f3364c0c6cdab44cad70addd3cc427bbeb99d412de7">+11/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>storage_test.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

storage/storage_test.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-5d2b2661848e58eab6ec5e5dbdcd4cefca138e0e112bb8027dbc49671484bb90">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>redis_analytics_purger.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/redis_analytics_purger.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-a589fcaabb253fd654715ab4ccbe226c9919317d8c222388c560b480a9e8bfc4">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>res_cache.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/res_cache.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-b073df547bd9290da2477f24069cb6f0661f3fb1655b276aa206d938c8ca5f02">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>manager_test.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

certs/manager_test.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-46dee1931e248ad5a05261ace1d2095f3182c7c5126ee8b980f04b761ff8c3a1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ldap_auth_handler.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/ldap_auth_handler.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-91ea6f7e95a32b5939c8fbe9d698055fd7e33b60a00b8c515304f924ab4a7188">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>errors.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

storage/shared/errors.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-d8b4b84b861350cefd4ed564e6040205956b5e1289243070c71470650cdeb123">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>redis_shim_test.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

storage/redis-cluster/redis_shim_test.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-787a4f73794e8966bc319d0f2c6cc6de515c97db8392506752b5aee086b2a3b3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>redis_shim.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

storage/redis-cluster/redis_shim.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-c07b01c79c6fa4b245e647ee433d9d77673d1f61bf24e372f4cdb2a9aff8bf5f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>connection_handler_test.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

storage/redis-cluster/connection_handler_test.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-936fd8081bca2b679dfed8488a87b40fa78c42e1921f663a7517b401054ce1b3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>dummy_test.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

storage/dummy/dummy_test.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-18ef9ac6a61d8c9c34cc39fb4c06a0043bb3116e7ec7177e362d083955183780">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>connection_handler.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

storage/redis-cluster/connection_handler.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-3287b7486ba5ecf88eb14fbbadb5fc1e73162fbd9be20d583f7a7e4cd9c5fdba">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>dummy.go</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

storage/dummy/dummy.go

...



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6451/files#diff-4dcd9500584a8c20f7a2f1f52e89c86f636482f003c23f3f38cd2b1d43f2bb4b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

