### PR TITLE
Merging to release-5.3: [TT-12816] Fix/distroless python release tests (#6455)

### DIFF
--- a/ci/tests/python-plugins/docker-compose.yml
+++ b/ci/tests/python-plugins/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   redis:
     image: redis

--- a/ci/tests/python-plugins/extend-python/Dockerfile
+++ b/ci/tests/python-plugins/extend-python/Dockerfile
@@ -1,8 +1,10 @@
 ARG BASE_IMAGE
-FROM ${BASE_IMAGE}
+FROM ${BASE_IMAGE} as tyk
 
-# For Python plugins
-RUN apt-get install -y python3-setuptools libpython3-dev python3-dev python3-grpcio
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y python3-setuptools libpython3-dev python3-dev python3-grpcio
+
+COPY --from=tyk /opt/tyk-gateway/ /opt/tyk-gateway/
 
 EXPOSE 8080 80 443
 

--- a/ci/tests/python-plugins/src/Dockerfile
+++ b/ci/tests/python-plugins/src/Dockerfile
@@ -1,11 +1,15 @@
 ARG BASE_IMAGE
-FROM ${BASE_IMAGE}
+FROM ${BASE_IMAGE} as tyk
 
-RUN apt-get update && apt-get install -y busybox
+FROM debian:bookworm-slim
+
+COPY --from=tyk /opt/tyk-gateway/tyk /opt/tyk-gateway/tyk
 
 WORKDIR /tmp
 
 ADD . .
+
+RUN apt-get update && apt-get install -y busybox
 
 RUN rm -f bundle.zip && /opt/tyk-gateway/tyk bundle build -y
 


### PR DESCRIPTION
### **User description**
[TT-12816] Fix/distroless python release tests (#6455)

### **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes release tests failing since gateway started using
distroless base image.

## Related Issue
https://tyktech.atlassian.net/browse/TT-12816

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Removed version specification from the Docker Compose file to ensure
compatibility with different Docker Compose versions.
- Enhanced the `extend-python` Dockerfile by adding a multi-stage build
to download and extract Debian packages, optimizing the installation
process.
- Improved the `src` Dockerfile by implementing a multi-stage build for
the Tyk gateway and moving `busybox` installation to a separate stage.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Configuration
changes</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>docker-compose.yml</strong><dd><code>Remove version
specification from Docker Compose file</code>&nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

ci/tests/python-plugins/docker-compose.yml

- Removed version specification from the Docker Compose file.



</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6455/files#diff-d9680afddda712f4bbd24f5c62c9c844c1ddf8e422cf6b3f759ed049269d8474">+0/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>Dockerfile</strong><dd><code>Use multi-stage build to
optimize Python dependencies installation</code></dd></summary>
<hr>

ci/tests/python-plugins/extend-python/Dockerfile

<li>Added a stage to download and extract Debian packages.<br> <li>
Replaced direct package installation with copying extracted files.<br>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6455/files#diff-4cf1d94bc92d3610c5837d11dac4a095109464507c9014f2d93d8785df86ed2b">+9/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
<summary><strong>Dockerfile</strong><dd><code>Implement multi-stage
build for Tyk gateway and dependencies</code></dd></summary>
<hr>

ci/tests/python-plugins/src/Dockerfile

<li>Added a multi-stage build for the Tyk gateway.<br> <li> Moved
<code>busybox</code> installation to a separate stage.<br>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6455/files#diff-6d5c4ddb7c75e8e0c5c91e66b49471dbf2ac1101fbb10ca04e58ca8a0130380b">+6/-2</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools
and their descriptions

[TT-12816]: https://tyktech.atlassian.net/browse/TT-12816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Removed version specification from the Docker Compose file to ensure compatibility with different Docker Compose versions.
- Updated `ci/tests/python-plugins/extend-python/Dockerfile` to use a multistage build, adding a new stage based on `debian:bookworm-slim` and installing necessary Python packages.
- Updated `ci/tests/python-plugins/src/Dockerfile` to use a multistage build, adding a new stage based on `debian:bookworm-slim`, copying the `tyk` binary, and installing `busybox`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Remove version specification from Docker Compose file</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ci/tests/python-plugins/docker-compose.yml

- Removed version specification from the Docker Compose file.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6458/files#diff-d9680afddda712f4bbd24f5c62c9c844c1ddf8e422cf6b3f759ed049269d8474">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Update Dockerfile to use multistage build for Python plugins</code></dd></summary>
<hr>

ci/tests/python-plugins/extend-python/Dockerfile

<li>Changed base image handling to use a multistage build.<br> <li> Added a new stage using <code>debian:bookworm-slim</code>.<br> <li> Installed necessary Python packages in the new stage.<br> <li> Copied files from the initial stage to the new stage.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6458/files#diff-4cf1d94bc92d3610c5837d11dac4a095109464507c9014f2d93d8785df86ed2b">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Update Dockerfile to use multistage build and copy `tyk` binary</code></dd></summary>
<hr>

ci/tests/python-plugins/src/Dockerfile

<li>Changed base image handling to use a multistage build.<br> <li> Added a new stage using <code>debian:bookworm-slim</code>.<br> <li> Copied <code>tyk</code> binary from the initial stage to the new stage.<br> <li> Installed <code>busybox</code> in the new stage.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6458/files#diff-6d5c4ddb7c75e8e0c5c91e66b49471dbf2ac1101fbb10ca04e58ca8a0130380b">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

