### PR TITLE
Merging to release-5.3: [TT-12550] policy key path permissions problem (#6437)

### DIFF
--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -1338,23 +1338,6 @@ func TestAPIExpiration(t *testing.T) {
 	}
 }
 
-func TestStripListenPath(t *testing.T) {
-	assert.Equal(t, "/get", stripListenPath("/listen", "/listen/get"))
-	assert.Equal(t, "/get", stripListenPath("/listen/", "/listen/get"))
-	assert.Equal(t, "/get", stripListenPath("listen", "listen/get"))
-	assert.Equal(t, "/get", stripListenPath("listen/", "listen/get"))
-	assert.Equal(t, "/", stripListenPath("/listen/", "/listen/"))
-	assert.Equal(t, "/", stripListenPath("/listen", "/listen"))
-	assert.Equal(t, "/", stripListenPath("listen/", ""))
-
-	assert.Equal(t, "/get", stripListenPath("/{_:.*}/post/", "/listen/post/get"))
-	assert.Equal(t, "/get", stripListenPath("/{_:.*}/", "/listen/get"))
-	assert.Equal(t, "/get", stripListenPath("/pre/{_:.*}/", "/pre/listen/get"))
-	assert.Equal(t, "/", stripListenPath("/{_:.*}", "/listen"))
-	assert.Equal(t, "/get", stripListenPath("/{myPattern:foo|bar}", "/foo/get"))
-	assert.Equal(t, "/anything/get", stripListenPath("/{myPattern:foo|bar}", "/anything/get"))
-}
-
 func TestAPISpec_SanitizeProxyPaths(t *testing.T) {
 	a := APISpec{APIDefinition: &apidef.APIDefinition{}}
 	a.Proxy.ListenPath = "/listen/"

--- a/gateway/handler_error.go
+++ b/gateway/handler_error.go
@@ -193,7 +193,7 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 		}
 
 		if e.Spec.Proxy.StripListenPath {
-			r.URL.Path = e.Spec.StripListenPath(r, r.URL.Path)
+			r.URL.Path = e.Spec.StripListenPath(r.URL.Path)
 		}
 
 		oauthClientID := ""

--- a/gateway/mw_granular_access_test.go
+++ b/gateway/mw_granular_access_test.go
@@ -25,6 +25,10 @@ func TestGranularAccessMiddleware_ProcessRequest(t *testing.T) {
 				APIName: api.Name,
 				AllowedURLs: []user.AccessSpec{
 					{
+						URL:     "^/*.$",
+						Methods: []string{"GET"},
+					},
+					{
 						URL:     "^/valid_path.*",
 						Methods: []string{"GET"},
 					},

--- a/gateway/mw_request_signing.go
+++ b/gateway/mw_request_signing.go
@@ -77,17 +77,17 @@ func generateHeaderList(r *http.Request, headerList []string) []string {
 }
 
 func (s *RequestSigning) getRequestPath(r *http.Request) string {
-	path := r.URL.RequestURI()
+	urlPath := r.URL.RequestURI()
 
 	if newURL := ctxGetURLRewriteTarget(r); newURL != nil {
-		path = newURL.RequestURI()
+		urlPath = newURL.RequestURI()
 	} else {
 		if s.Spec.Proxy.StripListenPath {
-			path = s.Spec.StripListenPath(r, path)
+			urlPath = s.Spec.StripListenPath(urlPath)
 		}
 	}
 
-	return path
+	return urlPath
 }
 
 func (s *RequestSigning) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {

--- a/internal/httputil/Taskfile.yml
+++ b/internal/httputil/Taskfile.yml
@@ -1,10 +1,49 @@
 ---
 version: "3"
 
+vars:
+  testArgs: -v
+
 tasks:
-  default:
-    desc: "Run tests"
+  test:
+    desc: "Run tests (requires redis)"
     cmds:
-      - go fmt ./...
+      - task: fmt
+      - go test {{.testArgs}} -count=1 -cover -coverprofile=rate.cov -coverpkg=./... ./...
+
+  bench:
+    desc: "Run benchmarks"
+    cmds:
+      - task: fmt
+      - go test {{.testArgs}} -count=1 -tags integration -bench=. -benchtime=10s -benchmem ./...
+
+  fmt:
+    internal: true
+    desc: "Invoke fmt"
+    cmds:
       - goimports -w .
-      - go test -race -count=100 -cover .
+      - go fmt ./...
+
+  cover:
+    desc: "Show source coverage"
+    aliases: [coverage, cov]
+    cmds:
+      - go tool cover -func=rate.cov
+
+  uncover:
+    desc: "Show uncovered source"
+    cmds:
+      - uncover rate.cov
+
+  lint:
+    desc: "Lint docs"
+    cmds:
+      - schema-gen extract -o - | schema-gen lint -i -
+
+  install:uncover:
+    desc: "Install uncover"
+    internal: true
+    env:
+      GOBIN: /usr/local/bin
+    cmds:
+      - go install github.com/gregoryv/uncover/...@latest

--- a/internal/httputil/connection_watcher.go
+++ b/internal/httputil/connection_watcher.go
@@ -29,7 +29,6 @@ func (cw *ConnectionWatcher) OnStateChange(_ net.Conn, state http.ConnState) {
 }
 
 // Count returns the number of connections at the time the call.
-
 func (cw *ConnectionWatcher) Count() int {
 	return int(atomic.LoadInt64(&cw.n))
 }

--- a/internal/httputil/mux.go
+++ b/internal/httputil/mux.go
@@ -1,0 +1,79 @@
+package httputil
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/gorilla/mux"
+
+	"github.com/TykTechnologies/tyk/internal/maps"
+)
+
+// routeCache holds the raw routes as they are mapped to mux regular expressions.
+// e.g. `/foo` becomes `^/foo$` or similar, and parameters get matched and replaced.
+var pathRegexpCache = maps.NewStringMap()
+
+// GetPathRegexp will convert a mux route url to a regular expression string.
+// The results for subsequent invocations with the same parameters are cached.
+func GetPathRegexp(pattern string) (string, error) {
+	val, ok := pathRegexpCache.Get(pattern)
+	if ok {
+		return val, nil
+	}
+
+	if IsMuxTemplate(pattern) {
+		dummyRouter := mux.NewRouter()
+		route := dummyRouter.PathPrefix(pattern)
+		result, err := route.GetPathRegexp()
+		if err != nil {
+			return "", err
+		}
+
+		pathRegexpCache.Set(pattern, result)
+		return result, nil
+	}
+
+	if strings.HasPrefix(pattern, "/") {
+		return "^" + pattern, nil
+	}
+	return "^.*" + pattern, nil
+}
+
+// IsMuxTemplate determines if a pattern is a mux template by counting the number of opening and closing braces.
+func IsMuxTemplate(pattern string) bool {
+	openBraces := strings.Count(pattern, "{")
+	closeBraces := strings.Count(pattern, "}")
+	return openBraces > 0 && openBraces == closeBraces
+}
+
+// StripListenPath will strip the listenPath from the passed urlPath.
+// If the listenPath contains mux variables, it will trim away the
+// matching pattern with a regular expression that mux provides.
+func StripListenPath(listenPath, urlPath string) (res string) {
+	defer func() {
+		if !strings.HasPrefix(res, "/") {
+			res = "/" + res
+		}
+	}()
+
+	res = urlPath
+
+	// early return on the simple case
+	if strings.HasPrefix(urlPath, listenPath) {
+		res = strings.TrimPrefix(res, listenPath)
+		return res
+	}
+
+	if !IsMuxTemplate(listenPath) {
+		return res
+	}
+
+	tmp := new(mux.Route).PathPrefix(listenPath)
+	s, err := tmp.GetPathRegexp()
+	if err != nil {
+		return res
+	}
+
+	reg := regexp.MustCompile(s)
+	return reg.ReplaceAllString(res, "")
+}

--- a/internal/httputil/mux_test.go
+++ b/internal/httputil/mux_test.go
@@ -1,0 +1,64 @@
+package httputil_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk/internal/httputil"
+)
+
+func testPathRegexp(tb testing.TB, in string, want string) string {
+	tb.Helper()
+
+	res, err := httputil.GetPathRegexp(in)
+	assert.NoError(tb, err)
+	if want != "" {
+		assert.Equal(tb, want, res)
+	}
+	return res
+}
+
+func TestGetPathRegexp(t *testing.T) {
+	tests := map[string]string{
+		"/users*.":                             "^/users*.",
+		"/users":                               "^/users",
+		"users":                                "^.*users",
+		"/users$":                              "^/users$",
+		"/users/.*":                            "^/users/.*",
+		"/users/{id}":                          "^/users/(?P<v0>[^/]+)",
+		"/users/{id}/profile/{type:[a-zA-Z]+}": "^/users/(?P<v0>[^/]+)/profile/(?P<v1>[a-zA-Z]+)",
+		"/static/{path}/assets/{file}":         "^/static/(?P<v0>[^/]+)/assets/(?P<v1>[^/]+)",
+		"/items/{itemID:[0-9]+}/details/{detail}": "^/items/(?P<v0>[0-9]+)/details/(?P<v1>[^/]+)",
+	}
+
+	for k, v := range tests {
+		testPathRegexp(t, k, v)
+	}
+}
+
+func TestGetPathRegexpWithRegexCompile(t *testing.T) {
+	pattern := testPathRegexp(t, "/api/v1/users/{userId}/roles/{roleId}", "")
+
+	matched, err := regexp.MatchString(pattern, "/api/v1/users/10512/roles/32587")
+	assert.NoError(t, err)
+	assert.True(t, matched, "The URL should match the pattern")
+}
+
+func TestStripListenPath(t *testing.T) {
+	assert.Equal(t, "/get", httputil.StripListenPath("/listen", "/listen/get"))
+	assert.Equal(t, "/get", httputil.StripListenPath("/listen/", "/listen/get"))
+	assert.Equal(t, "/get", httputil.StripListenPath("listen", "listen/get"))
+	assert.Equal(t, "/get", httputil.StripListenPath("listen/", "listen/get"))
+	assert.Equal(t, "/", httputil.StripListenPath("/listen/", "/listen/"))
+	assert.Equal(t, "/", httputil.StripListenPath("/listen", "/listen"))
+	assert.Equal(t, "/", httputil.StripListenPath("listen/", ""))
+
+	assert.Equal(t, "/get", httputil.StripListenPath("/{_:.*}/post/", "/listen/post/get"))
+	assert.Equal(t, "/get", httputil.StripListenPath("/{_:.*}/", "/listen/get"))
+	assert.Equal(t, "/get", httputil.StripListenPath("/pre/{_:.*}/", "/pre/listen/get"))
+	assert.Equal(t, "/", httputil.StripListenPath("/{_:.*}", "/listen"))
+	assert.Equal(t, "/get", httputil.StripListenPath("/{myPattern:foo|bar}", "/foo/get"))
+	assert.Equal(t, "/anything/get", httputil.StripListenPath("/{myPattern:foo|bar}", "/anything/get"))
+}

--- a/internal/httputil/response.go
+++ b/internal/httputil/response.go
@@ -24,9 +24,10 @@ func InternalServerError(w http.ResponseWriter, _ *http.Request) {
 	http.Error(w, http.StatusText(status), status)
 }
 
-func RemoveResponseTransferEncoding(response *http.Response, encoding string) {
+// RemoveResponseTransferEncoding will remove a transfer encoding hint from the response.
+func RemoveResponseTransferEncoding(response *http.Response, victim string) {
 	for i, value := range response.TransferEncoding {
-		if value == encoding {
+		if value == victim {
 			response.TransferEncoding = append(response.TransferEncoding[:i], response.TransferEncoding[i+1:]...)
 		}
 	}

--- a/internal/httputil/streaming_test.go
+++ b/internal/httputil/streaming_test.go
@@ -1,0 +1,80 @@
+package httputil_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/TykTechnologies/tyk/internal/httputil"
+)
+
+const (
+	headerContentType = "Content-Type"
+	headerUpgrade     = "Upgrade"
+	headerConnection  = "Connection"
+)
+
+// Helper function to create a request with specified headers
+func newRequestWithHeaders(tb testing.TB, contentLength int64, headers map[string]string) *http.Request {
+	tb.Helper()
+	req := &http.Request{
+		ContentLength: contentLength,
+		Header:        make(http.Header),
+	}
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+	return req
+}
+
+// Helper function to create a response with specified headers
+func newResponseWithHeaders(tb testing.TB, headers map[string]string) *http.Response {
+	tb.Helper()
+	resp := &http.Response{
+		Header: make(http.Header),
+	}
+	for key, value := range headers {
+		resp.Header.Set(key, value)
+	}
+	return resp
+}
+
+func TestIsGrpcStreaming(t *testing.T) {
+	assert.True(t, IsGrpcStreaming(newRequestWithHeaders(t, -1, map[string]string{headerContentType: "application/grpc"})))
+	assert.False(t, IsGrpcStreaming(newRequestWithHeaders(t, 0, map[string]string{headerContentType: "application/grpc"})))
+	assert.False(t, IsGrpcStreaming(newRequestWithHeaders(t, -1, map[string]string{headerContentType: "text/plain"})))
+}
+
+func TestIsSseStreamingResponse(t *testing.T) {
+	assert.True(t, IsSseStreamingResponse(newResponseWithHeaders(t, map[string]string{headerContentType: "text/event-stream"})))
+	assert.False(t, IsSseStreamingResponse(newResponseWithHeaders(t, map[string]string{headerContentType: "application/json"})))
+}
+
+func TestIsUpgrade(t *testing.T) {
+	req := newRequestWithHeaders(t, 0, map[string]string{headerConnection: "Upgrade", headerUpgrade: "websocket"})
+	upgradeType, ok := IsUpgrade(req)
+	assert.True(t, ok)
+	assert.Equal(t, "websocket", upgradeType)
+
+	req = newRequestWithHeaders(t, 0, map[string]string{headerConnection: "keep-alive", headerUpgrade: "websocket"})
+	upgradeType, ok = IsUpgrade(req)
+	assert.False(t, ok)
+	assert.Empty(t, upgradeType)
+
+	req = newRequestWithHeaders(t, 0, map[string]string{headerConnection: "Upgrade"})
+	upgradeType, ok = IsUpgrade(req)
+	assert.False(t, ok)
+	assert.Empty(t, upgradeType)
+}
+
+func TestIsStreamingRequest(t *testing.T) {
+	assert.True(t, IsStreamingRequest(newRequestWithHeaders(t, -1, map[string]string{headerContentType: "application/grpc"})))
+	assert.True(t, IsStreamingRequest(newRequestWithHeaders(t, 0, map[string]string{headerConnection: "Upgrade", headerUpgrade: "websocket"})))
+	assert.False(t, IsStreamingRequest(newRequestWithHeaders(t, 0, map[string]string{headerConnection: "keep-alive"})))
+}
+
+func TestIsStreamingResponse(t *testing.T) {
+	assert.True(t, IsStreamingResponse(newResponseWithHeaders(t, map[string]string{headerContentType: "text/event-stream"})))
+	assert.False(t, IsStreamingResponse(newResponseWithHeaders(t, map[string]string{headerContentType: "application/json"})))
+}

--- a/internal/maps/strings.go
+++ b/internal/maps/strings.go
@@ -1,0 +1,34 @@
+package maps
+
+import "sync"
+
+// StringMap holds a concurrency safe, type safe access to map[string]string.
+// Access is protected with a sync.RWMutex, optimized for reads.
+type StringMap struct {
+	mu   sync.RWMutex
+	data map[string]string
+}
+
+// NewStringMap returns a new *StringMap.
+func NewStringMap() *StringMap {
+	return &StringMap{
+		data: make(map[string]string),
+	}
+}
+
+// Set will set a value to a key in the map.
+func (s *StringMap) Set(key, value string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.data[key] = value
+}
+
+// Get returns the value, and if it existed in the map.
+func (s *StringMap) Get(key string) (string, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	v, ok := s.data[key]
+	return v, ok
+}


### PR DESCRIPTION
### **User description**
[TT-12550] policy key path permissions problem (#6437)

### **User description**
Fixes two issues:

- invalid regex in allowed urls would allow all requests to pass
- mux path parameters unsupported `{id}` was considered literal (only
regex supported)

Input accessURL patterns are now handled by the mux library
(GetPathRegexp).

https://tyktech.atlassian.net/browse/TT-12550

___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Enhanced URL matching in `GranularAccessMiddleware` by converting mux
path parameters to regex.
- Improved logging to include path and pattern matching details.
- Handled regex compilation errors gracefully by skipping invalid
patterns.
- Added new `RouteRegexString` function to convert mux routes to regex.
- Introduced tests for `RouteRegexString` function.
- Added test case for invalid regex in allowed URLs.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>mw_granular_access.go</strong><dd><code>Enhance URL
matching and logging in GranularAccessMiddleware</code></dd></summary>
<hr>

gateway/mw_granular_access.go

<li>Added conversion of mux path parameters to regex.<br> <li> Improved
logging for path and pattern matching.<br> <li> Handled regex
compilation errors gracefully.<br>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6437/files#diff-618f7d55751d572562a29506a13beba2da969436e974f8b51df7d9708c925436">+12/-6</a>&nbsp;
&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
<summary><strong>route.go</strong><dd><code>Add RouteRegexString
function for mux route conversion</code>&nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

internal/httputil/route.go

<li>Introduced <code>RouteRegexString</code> function to convert mux
routes to regex.<br>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6437/files#diff-be202cd339a918297746198e9c73364977d25886235f105762bce816ff46e11e">+44/-0</a>&nbsp;
&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>mw_granular_access_test.go</strong><dd><code>Add test
case for invalid regex in allowed URLs</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_granular_access_test.go

- Added test case for invalid regex in allowed URLs.



</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6437/files#diff-8e0d7cfef26688edd7d08334d955039dab5deb3caf860d29eff6d09894eaba20">+4/-0</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
<summary><strong>route_test.go</strong><dd><code>Add tests for
RouteRegexString function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/httputil/route_test.go

- Added tests for `RouteRegexString` function.



</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6437/files#diff-a291c7018ab8c1fabe97ad7c94b8820dc47c889f79fb7376eb78c0abc3ccaed6">+24/-0</a>&nbsp;
&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools
and their descriptions

---------

Co-authored-by: Tit Petric <tit@tyk.io>

[TT-12550]: https://tyktech.atlassian.net/browse/TT-12550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Enhanced URL matching in `GranularAccessMiddleware` by converting mux path parameters to regex and improving logging.
- Refactored `StripListenPath` to use `httputil` and removed the `mux` dependency.
- Introduced `GetPathRegexp` and `StripListenPath` utility functions in `httputil`.
- Added tests for new utility functions and enhanced test coverage.
- Updated task automation with new tasks for testing, benchmarking, and formatting.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>api_definition.go</strong><dd><code>Refactor URL path handling and remove mux dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_definition.go

<li>Removed the <code>mux</code> dependency.<br> <li> Refactored <code>StripListenPath</code> to use <code>httputil</code>.<br> <li> Simplified URL path handling.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6469/files#diff-0cf80174bbafb36f6d4f4308ebbd971b2833b76a936bad568220aa1a4ba0ee8b">+6/-27</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_granular_access.go</strong><dd><code>Enhance URL matching and logging in GranularAccessMiddleware</code></dd></summary>
<hr>

gateway/mw_granular_access.go

<li>Enhanced URL matching with regex conversion.<br> <li> Improved logging with path and pattern details.<br> <li> Handled regex compilation errors gracefully.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6469/files#diff-618f7d55751d572562a29506a13beba2da969436e974f8b51df7d9708c925436">+20/-7</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mux.go</strong><dd><code>Introduce utility functions for mux route handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/httputil/mux.go

<li>Introduced <code>GetPathRegexp</code> to convert mux routes to regex.<br> <li> Added <code>StripListenPath</code> for URL path handling.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6469/files#diff-3d9ee5f5e946d72e6f2ae662ff03ee5253bbdc15203d2e4f6e9f46c13011ebf8">+79/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>strings.go</strong><dd><code>Add concurrency-safe StringMap utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/maps/strings.go

- Added a concurrency-safe `StringMap` for string storage.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6469/files#diff-5fa5e244ede81be68269555e950af79079de58236fe9c0e67e6f01a602d04dca">+34/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>api_definition_test.go</strong><dd><code>Remove obsolete tests for stripListenPath</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_definition_test.go

- Removed tests for `stripListenPath`.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6469/files#diff-2394daab6fdc5f8dc234699c80c0548947ee3d68d2e33858258d73a8b5eb6f44">+0/-17</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_granular_access_test.go</strong><dd><code>Add test case for invalid regex in allowed URLs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_granular_access_test.go

- Added test case for invalid regex in allowed URLs.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6469/files#diff-8e0d7cfef26688edd7d08334d955039dab5deb3caf860d29eff6d09894eaba20">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mux_test.go</strong><dd><code>Add tests for mux utility functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/httputil/mux_test.go

- Added tests for `GetPathRegexp` and `StripListenPath`.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6469/files#diff-8f7ce1891e221d7adb9e68f2e951f33edfbde2128187abb6e837ac01952d7888">+64/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>handler_error.go</strong><dd><code>Update StripListenPath usage in error handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/handler_error.go

- Updated `StripListenPath` usage to new signature.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6469/files#diff-d3b05530ad23401f3b8f33bb1a467cd807a29a6b09c7430d01d069f626b20f77">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_request_signing.go</strong><dd><code>Update StripListenPath usage in request signing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_request_signing.go

- Updated `StripListenPath` usage to new signature.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6469/files#diff-4930d7e23ba3866e7a220c1eacff5701bc59b3029b47226c55432db0615fb55a">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>Taskfile.yml</strong><dd><code>Add task automation for testing and formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/httputil/Taskfile.yml

- Added tasks for testing, benchmarking, and formatting.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6469/files#diff-31877aaad48d3baf442aa52077c28b873df2f2ac6c70941d409261460d7c3c8e">+43/-4</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

