### PR TITLE
[TT-12892] use same url matching logic in endpoint rate limiting as of allowed urls

### DIFF
--- a/gateway/session_manager.go
+++ b/gateway/session_manager.go
@@ -239,7 +239,8 @@ func (l *SessionLimiter) ForwardMessage(r *http.Request, session *user.SessionSt
 		endpointRLKeySuffix = ""
 	)
 
-	endpointRLInfo, doEndpointRL := accessDef.Endpoints.RateLimitInfo(r.Method, r.URL.Path)
+	reqEndpoint := api.StripListenPath(r.URL.Path)
+	endpointRLInfo, doEndpointRL := accessDef.Endpoints.RateLimitInfo(r.Method, reqEndpoint)
 	if doEndpointRL {
 		apiLimit.Rate = endpointRLInfo.Rate
 		apiLimit.Per = endpointRLInfo.Per

--- a/internal/httputil/mux.go
+++ b/internal/httputil/mux.go
@@ -77,3 +77,26 @@ func StripListenPath(listenPath, urlPath string) (res string) {
 	reg := regexp.MustCompile(s)
 	return reg.ReplaceAllString(res, "")
 }
+
+// MatchEndpoint matches configured endpoint/regexp with request endpoint.
+func MatchEndpoint(configEndpoint string, reqEndpoint string) (bool, error) {
+	if configEndpoint == reqEndpoint {
+		return true, nil
+	}
+
+	if configEndpoint == "" {
+		return false, nil
+	}
+
+	clean, err := GetPathRegexp(configEndpoint)
+	if err != nil {
+		return false, err
+	}
+
+	asRegex, err := regexp.Compile(clean)
+	if err != nil {
+		return false, err
+	}
+
+	return asRegex.MatchString(reqEndpoint), nil
+}

--- a/internal/httputil/mux.go
+++ b/internal/httputil/mux.go
@@ -78,17 +78,17 @@ func StripListenPath(listenPath, urlPath string) (res string) {
 	return reg.ReplaceAllString(res, "")
 }
 
-// MatchEndpoint matches configured endpoint/regexp with request endpoint.
-func MatchEndpoint(configEndpoint string, reqEndpoint string) (bool, error) {
-	if configEndpoint == reqEndpoint {
+// MatchEndpoint matches pattern with request endpoint.
+func MatchEndpoint(pattern string, endpoint string) (bool, error) {
+	if pattern == endpoint {
 		return true, nil
 	}
 
-	if configEndpoint == "" {
+	if pattern == "" {
 		return false, nil
 	}
 
-	clean, err := GetPathRegexp(configEndpoint)
+	clean, err := GetPathRegexp(pattern)
 	if err != nil {
 		return false, err
 	}
@@ -98,5 +98,5 @@ func MatchEndpoint(configEndpoint string, reqEndpoint string) (bool, error) {
 		return false, err
 	}
 
-	return asRegex.MatchString(reqEndpoint), nil
+	return asRegex.MatchString(endpoint), nil
 }

--- a/internal/httputil/mux_test.go
+++ b/internal/httputil/mux_test.go
@@ -65,80 +65,87 @@ func TestStripListenPath(t *testing.T) {
 
 func TestMatchEndpoint(t *testing.T) {
 	tests := []struct {
-		name           string
-		configEndpoint string
-		reqEndpoint    string
-		match          bool
-		isErr          bool
+		name     string
+		pattern  string
+		endpoint string
+		match    bool
+		isErr    bool
 	}{
 		{
-			name:           "exact endpoints",
-			configEndpoint: "/api/v1/users",
-			reqEndpoint:    "/api/v1/users",
-			match:          true,
-			isErr:          false,
+			name:     "exact endpoints",
+			pattern:  "/api/v1/users",
+			endpoint: "/api/v1/users",
+			match:    true,
+			isErr:    false,
 		},
 		{
-			name:           "non matching concrete endpoints",
-			configEndpoint: "/api/v1/users",
-			reqEndpoint:    "/api/v1/admin",
-			match:          false,
-			isErr:          false,
+			name:     "non matching concrete endpoints",
+			pattern:  "/api/v1/users",
+			endpoint: "/api/v1/admin",
+			match:    false,
+			isErr:    false,
 		},
 		{
-			name:           "regexp match",
-			configEndpoint: "/api/v1/user/\\d+",
-			reqEndpoint:    "/api/v1/user/123",
-			match:          true,
-			isErr:          false,
+			name:     "regexp match",
+			pattern:  "/api/v1/user/\\d+",
+			endpoint: "/api/v1/user/123",
+			match:    true,
+			isErr:    false,
 		},
 		{
-			name:           "invalid config regexp",
-			configEndpoint: "/api/v1/[user",
-			reqEndpoint:    "/api/v1/user",
-			match:          false,
-			isErr:          true,
+			name:     "mux var match",
+			pattern:  "/api/v1/user/{id}",
+			endpoint: "/api/v1/user/123",
+			match:    true,
+			isErr:    false,
 		},
 		{
-			name:           "wildcard endpoint",
-			configEndpoint: "/api/v1/*",
-			reqEndpoint:    "/api/v1/users",
-			match:          true,
-			isErr:          false,
+			name:     "invalid config regexp",
+			pattern:  "/api/v1/[user",
+			endpoint: "/api/v1/user",
+			match:    false,
+			isErr:    true,
 		},
 		{
-			name:           "empty config endpoint",
-			configEndpoint: "",
-			reqEndpoint:    "/api/v1/user",
-			match:          false,
-			isErr:          false,
+			name:     "wildcard endpoint",
+			pattern:  "/api/v1/*",
+			endpoint: "/api/v1/users",
+			match:    true,
+			isErr:    false,
 		},
 		{
-			name:           "empty request endpoint",
-			configEndpoint: "/api/v1/user",
-			reqEndpoint:    "",
-			match:          false,
-			isErr:          false,
+			name:     "empty config endpoint",
+			pattern:  "",
+			endpoint: "/api/v1/user",
+			match:    false,
+			isErr:    false,
 		},
 		{
-			name:           "both empty endpoints",
-			configEndpoint: "",
-			reqEndpoint:    "",
-			match:          true,
-			isErr:          false,
+			name:     "empty request endpoint",
+			pattern:  "/api/v1/user",
+			endpoint: "",
+			match:    false,
+			isErr:    false,
 		},
 		{
-			name:           "/ endpoint",
-			configEndpoint: "/",
-			reqEndpoint:    "/",
-			match:          true,
-			isErr:          false,
+			name:     "both empty endpoints",
+			pattern:  "",
+			endpoint: "",
+			match:    true,
+			isErr:    false,
+		},
+		{
+			name:     "/ endpoint",
+			pattern:  "/",
+			endpoint: "/",
+			match:    true,
+			isErr:    false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := httputil.MatchEndpoint(tt.configEndpoint, tt.reqEndpoint)
+			result, err := httputil.MatchEndpoint(tt.pattern, tt.endpoint)
 			assert.Equal(t, tt.match, result)
 			if tt.isErr {
 				assert.Error(t, err)

--- a/internal/httputil/mux_test.go
+++ b/internal/httputil/mux_test.go
@@ -154,9 +154,7 @@ func TestMatchEndpoint(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := httputil.MatchEndpoint(tt.pattern, tt.endpoint)
 			assert.Equal(t, tt.match, result)
-			if tt.isErr {
-				assert.Error(t, err)
-			}
+			assert.Equal(t, tt.isErr, err != nil)
 		})
 	}
 }

--- a/internal/httputil/mux_test.go
+++ b/internal/httputil/mux_test.go
@@ -93,6 +93,13 @@ func TestMatchEndpoint(t *testing.T) {
 			isErr:    false,
 		},
 		{
+			name:     "regexp non match",
+			pattern:  "/api/v1/user/\\d+",
+			endpoint: "/api/v1/user/abc",
+			match:    false,
+			isErr:    false,
+		},
+		{
 			name:     "mux var match",
 			pattern:  "/api/v1/user/{id}",
 			endpoint: "/api/v1/user/123",

--- a/user/session.go
+++ b/user/session.go
@@ -498,21 +498,7 @@ func (es Endpoints) RateLimitInfo(method string, reqEndpoint string) (*EndpointR
 	}
 
 	for _, endpoint := range es {
-		url := endpoint.Path
-		clean, err := httputil.GetPathRegexp(url)
-		if err != nil {
-			log.WithError(err).Errorf("error getting path regex: %q, skipping", url)
-			continue
-		}
-
-		asRegex, err := regexp.Compile(clean)
-		if err != nil {
-			log.WithError(err).Errorf("error compiling path regex: %q, skipping", url)
-			continue
-		}
-
-		match := asRegex.MatchString(reqEndpoint)
-		if !match {
+		if !endpoint.match(reqEndpoint) {
 			continue
 		}
 
@@ -530,4 +516,21 @@ func (es Endpoints) RateLimitInfo(method string, reqEndpoint string) (*EndpointR
 	}
 
 	return nil, false
+}
+
+func (e Endpoint) match(reqEndpoint string) bool {
+	url := e.Path
+	clean, err := httputil.GetPathRegexp(url)
+	if err != nil {
+		log.WithError(err).Errorf("error getting path regex: %q, skipping", url)
+		return false
+	}
+
+	asRegex, err := regexp.Compile(clean)
+	if err != nil {
+		log.WithError(err).Errorf("error compiling path regex: %q, skipping", url)
+		return false
+	}
+
+	return asRegex.MatchString(reqEndpoint)
 }

--- a/user/session.go
+++ b/user/session.go
@@ -198,6 +198,11 @@ type Endpoint struct {
 	Methods EndpointMethods `json:"methods,omitempty" msg:"methods"`
 }
 
+// match matches supplied endpoint with endpoint path.
+func (e Endpoint) match(endpoint string) (bool, error) {
+	return httputil.MatchEndpoint(e.Path, endpoint)
+}
+
 // EndpointMethods is a collection of EndpointMethod.
 type EndpointMethods []EndpointMethod
 
@@ -498,10 +503,9 @@ func (es Endpoints) RateLimitInfo(method string, reqEndpoint string) (*EndpointR
 	}
 
 	for _, endpoint := range es {
-		url := endpoint.Path
-		match, err := httputil.MatchEndpoint(url, reqEndpoint)
+		match, err := endpoint.match(reqEndpoint)
 		if err != nil {
-			log.WithError(err).Errorf("error matching path regex: %q, skipping", url)
+			log.WithError(err).Errorf("error matching path regex: %q, skipping", endpoint.Path)
 		}
 
 		if !match {


### PR DESCRIPTION
### **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description

This PR makes endpoint rate limiting use the same URL matching logic that is used in allowed URLs.

## Related Issue
Parent: https://tyktech.atlassian.net/browse/TT-12566
Subtask: https://tyktech.atlassian.net/browse/TT-12892

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
enhancement, bug fix


___

### **Description**
- Enhanced the endpoint rate limiting logic to use the same URL matching logic as allowed URLs by normalizing the request endpoint path.
- Introduced `GetPathRegexp` to compile endpoint paths into regex and added error handling for regex compilation failures.
- Updated the `RateLimitInfo` function to use the compiled regex for matching normalized endpoint paths.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>session_manager.go</strong><dd><code>Normalize endpoint path for rate limiting logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/session_manager.go

<li>Use <code>StripListenPath</code> to normalize request endpoint path.<br> <li> Update rate limiting logic to use normalized path.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6470/files#diff-e6b40a285464cd86736e970c4c0b320b44c75b18b363d38c200e9a9d36cdabb6">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>session.go</strong><dd><code>Enhance endpoint rate limiting with regex path matching</code>&nbsp; &nbsp; </dd></summary>
<hr>

user/session.go

<li>Introduce <code>GetPathRegexp</code> for endpoint path regex compilation.<br> <li> Add error handling for regex compilation.<br> <li> Update rate limiting logic to use compiled regex on normalized path.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6470/files#diff-95f1b81f7fbfef1d0372a02f3c2d557d32a3dd42e1a7d1626fdd209aaf7537f4">+12/-3</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

