### PR TITLE
[TT-12566/TT-12927] fix merging rate limits

### DIFF
--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -436,8 +436,8 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 					"c": {
 						Limit: user.APILimit{
 							RateLimit: user.RateLimit{
-								Rate: 2000,
-								Per:  60,
+								Rate: 3000,
+								Per:  10,
 							},
 							QuotaMax: -1,
 						},
@@ -524,8 +524,8 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 							QuotaMax:         5000,
 							QuotaRenewalRate: 3600,
 							RateLimit: user.RateLimit{
-								Rate: 400,
-								Per:  25,
+								Rate: 200,
+								Per:  10,
 							},
 						},
 						AllowanceScope: "d",
@@ -764,11 +764,11 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 						Limit: user.APILimit{
 							QuotaMax: -1,
 							RateLimit: user.RateLimit{
-								Rate: 300,
+								Rate: 500,
 								Per:  1,
 							},
 						},
-						AllowanceScope: "per_api_with_endpoint_limits_on_e",
+						AllowanceScope: "per_api_with_endpoint_limits_on_d_and_e",
 						Endpoints:      endpointsConfig,
 					},
 					"d": {
@@ -776,7 +776,7 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 							QuotaMax:         5000,
 							QuotaRenewalRate: 3600,
 							RateLimit: user.RateLimit{
-								Rate: 100,
+								Rate: 200,
 								Per:  10,
 							},
 						},
@@ -842,8 +842,8 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 							{
 								Name: "POST",
 								Limit: user.RateLimit{
-									Rate: 300,
-									Per:  10,
+									Rate: 400,
+									Per:  11,
 								},
 							},
 						},
@@ -867,7 +867,7 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 				apiELimits := user.APILimit{
 					QuotaMax: -1,
 					RateLimit: user.RateLimit{
-						Rate: 300,
+						Rate: 500,
 						Per:  1,
 					},
 				}
@@ -877,7 +877,7 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 					QuotaMax:         5000,
 					QuotaRenewalRate: 3600,
 					RateLimit: user.RateLimit{
-						Rate: 100,
+						Rate: 200,
 						Per:  10,
 					},
 				}

--- a/gateway/testdata/policies.json
+++ b/gateway/testdata/policies.json
@@ -605,7 +605,7 @@
     }
   },
   "per_api_with_endpoint_limits_on_d_and_e": {
-    "id": "per_api_with_endpoint_limits_on_e",
+    "id": "per_api_with_endpoint_limits_on_d_and_e",
     "rate": 500,
     "per": 1,
     "quota_max": -1,
@@ -674,7 +674,7 @@
     }
   },
   "per_endpoint_limits_different_on_api_d": {
-    "id": "per_api_with_endpoint_limits_on_e",
+    "id": "per_endpoint_limits_different_on_api_d",
     "rate": 500,
     "per": 1,
     "quota_max": -1,

--- a/internal/policy/apply.go
+++ b/internal/policy/apply.go
@@ -533,7 +533,7 @@ func (t *Service) updateSessionRootVars(session *user.SessionState, rights map[s
 }
 
 func (t *Service) applyAPILevelLimits(policyAD user.AccessDefinition, currAD user.AccessDefinition) user.AccessDefinition {
-	if currAD.Limit.Duration() > policyAD.Limit.Duration() {
+	if policyAD.Limit.Duration() > currAD.Limit.Duration() {
 		policyAD.Limit.Per = currAD.Limit.Per
 		policyAD.Limit.Rate = currAD.Limit.Rate
 		policyAD.Limit.Smoothing = currAD.Limit.Smoothing
@@ -565,7 +565,7 @@ func (t *Service) applyEndpointLevelLimits(policyEndpoints user.Endpoints, currE
 	policyEPMap := policyEndpoints.Map()
 	for currEP, currRL := range currEPMap {
 		if policyRL, ok := policyEPMap[currEP]; ok {
-			if currRL.Duration() > policyRL.Duration() {
+			if policyRL.Duration() > currRL.Duration() {
 				policyEPMap[currEP] = currRL
 			}
 		}


### PR DESCRIPTION
### **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description

Fix combining rate limits with per api and per endpoint

## Related Issue
Parent ticket: https://tyktech.atlassian.net/browse/TT-12566
sub task: https://tyktech.atlassian.net/browse/TT-12927

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Bug fix


___

### **Description**
- Updated rate limits in test cases to ensure correct application of policies.
- Fixed logic in `applyAPILevelLimits` and `applyEndpointLevelLimits` functions to correctly compare and apply rate limit durations.
- Corrected policy identifiers in test data to align with updated endpoint limits.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>policy_test.go</strong><dd><code>Update rate limits in policy test cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/policy_test.go

<li>Updated rate limits for various API endpoints in test cases.<br> <li> Adjusted <code>Rate</code> and <code>Per</code> values for endpoints "c", "d", "e", and specific <br>paths.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6472/files#diff-40d701767204255c38c7dd64939d6bb8df621640c4bddfe5f56080380476a18a">+11/-11</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>apply.go</strong><dd><code>Fix logic for applying API and endpoint level limits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/policy/apply.go

<li>Corrected logic for applying API level limits.<br> <li> Fixed condition to compare policy and current access definition <br>durations.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6472/files#diff-59b92e9d31f142f1d99b746eb3ff7db4e26bf6c3044c9b87b58034a947ee04d1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>policies.json</strong><dd><code>Update policy identifiers in test data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/testdata/policies.json

<li>Updated policy IDs to reflect correct endpoint limits.<br> <li> Changed policy identifiers for clarity and accuracy.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6472/files#diff-d20906fb23674ef58fee794635f5c1f668eb36f9dc4ce0f4b7d3dbd816e13eb5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

