### PR TITLE
Implement --auto-fill for bundler

### DIFF
--- a/cli/bundler/bundler.go
+++ b/cli/bundler/bundler.go
@@ -80,7 +80,8 @@ func (b *Bundler) Build(ctx *kingpin.ParseContext) error {
 		var data []byte
 
 		if b.autoFill != nil && *b.autoFill {
-			file = strings.ReplaceAll(file, "{version}", build.Version)
+			cleanVersion := build.CleanVersion(build.Version)
+			file = strings.ReplaceAll(file, "{version}", cleanVersion)
 			file = strings.ReplaceAll(file, "{os}", runtime.GOOS)
 			file = strings.ReplaceAll(file, "{arch}", runtime.GOARCH)
 		}

--- a/internal/build/version.go
+++ b/internal/build/version.go
@@ -1,5 +1,9 @@
 package build
 
+import (
+	"regexp"
+)
+
 // These values are injected at build-time from CI.
 var (
 	// Version contains the tagged gateway version. It may contain a `rc` suffix,
@@ -15,3 +19,18 @@ var (
 	// Commit is the commit hash for the build source.
 	Commit string
 )
+
+// versionRe matches a minimal semver, `v0.0.0`, where 0 may be any number.
+var versionRe = regexp.MustCompile(`^v\d+\.\d+\.\d+`)
+
+// CleanVersion returns a sanitized gateway version. If the version
+// doesn't match the semver regex, it will return the original string.
+func CleanVersion(version string) string {
+	// Find the first match of the regex in the version string
+	match := versionRe.FindString(version)
+	if match != "" {
+		return match
+	}
+	// Return as-is otherwise
+	return version
+}

--- a/internal/build/version_test.go
+++ b/internal/build/version_test.go
@@ -1,0 +1,29 @@
+package build_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk/internal/build"
+)
+
+func TestCleanVersion(t *testing.T) {
+	// Test cases
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"v1.2.3-beta", "v1.2.3"},
+		{"version v2.10.0", "version v2.10.0"}, // No match, returns original
+		{"v3.4.5", "v3.4.5"},
+		{"v3.4.5rc9", "v3.4.5"},
+		{"not-a-version", "not-a-version"}, // No match, returns original
+		{"v0.1.0-rc.1", "v0.1.0"},
+	}
+
+	for _, tc := range tests {
+		result := build.CleanVersion(tc.input)
+		assert.Equal(t, tc.expected, result, "Expected %s but got %s", tc.expected, result)
+	}
+}


### PR DESCRIPTION
### **User description**
Adds `--auto-fill` to `tyk bundle` command. It fills out:

- `{version}` - gateway version, e.g. `v5.3.0-rc2`
- `{os}` - runtime.GOOS, e.g. `linux`
- `{arch}` - runtime.GOARCH, e.g. `amd64`

It does this for any file provided in `FileList`.

```
{
  "file_list": [
    "CustomGoPlugin_{version}_{os}_{arch}.so"
  ],
  ...
}
```


___

### **PR Type**
enhancement


___

### **Description**
- Introduced a new `--auto-fill` feature in the `tyk bundle` command to automatically replace placeholders `{version}`, `{os}`, and `{arch}` in file names.
- Added a new `autoFill` flag to the `Bundler` struct to support this functionality.
- Updated the `Build` method to process file names with the new placeholders when the `--auto-fill` flag is set.
- Enhanced the command-line interface by adding the `--auto-fill` option, improving usability for users who need dynamic file naming.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bundler.go</strong><dd><code>Implement `--auto-fill` feature in bundler command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/bundler/bundler.go

<li>Added <code>runtime</code> and <code>strings</code> packages for OS and architecture <br>information.<br> <li> Introduced a new <code>autoFill</code> flag in the <code>Bundler</code> struct.<br> <li> Implemented logic to replace placeholders <code>{version}</code>, <code>{os}</code>, and <code>{arch}</code> <br>in file names.<br> <li> Added a command-line flag <code>--auto-fill</code> to enable this feature.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6477/files#diff-4b6c235894ec97f5181e76933a9efb95cf56f17c929875456e771406e079ccf8">+14/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

