### PR TITLE
Merging to release-5.3: [TT-12452] Clear up quota gated with a distributed redis lock (#6448)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -106,6 +106,8 @@ linters-settings:
         disabled: false
         arguments:
           - allowRegex: "^_"
+      - name: import-shadowing
+        disabled: false
       - name: exported
         disabled: false
 
@@ -124,6 +126,7 @@ linters-settings:
     check-blank: true
     exclude-functions:
       - (*github.com/TykTechnologies/tyk/gateway.Test).Run
+      - time.Parse
 
 issues:
   max-issues-per-linter: 0

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -48,6 +48,7 @@ import (
 	"github.com/TykTechnologies/tyk/config"
 
 	"github.com/TykTechnologies/tyk/internal/otel"
+	"github.com/TykTechnologies/tyk/internal/redis"
 	"github.com/TykTechnologies/tyk/internal/uuid"
 
 	"github.com/TykTechnologies/tyk/apidef/oas"
@@ -617,7 +618,7 @@ func (gw *Gateway) handleGetDetail(sessionKey, apiID, orgID string, byHash bool)
 			quotaKey = QuotaKeyPrefix + sessionKey
 		}
 
-		if usedQuota, err := gw.GlobalSessionManager.Store().GetRawKey(quotaKey); err == nil {
+		if usedQuota, err := gw.GlobalSessionManager.Store().GetRawKey(quotaKey); err == nil || errors.Is(err, redis.Nil) {
 			qInt, _ := strconv.Atoi(usedQuota)
 			remaining := session.QuotaMax - int64(qInt)
 
@@ -627,11 +628,10 @@ func (gw *Gateway) handleGetDetail(sessionKey, apiID, orgID string, byHash bool)
 				session.QuotaRemaining = remaining
 			}
 		} else {
-			log.WithFields(logrus.Fields{
-				"prefix":  "api",
-				"key":     gw.obfuscateKey(quotaKey),
-				"message": err,
-				"status":  "ok",
+			log.WithError(err).WithFields(logrus.Fields{
+				"prefix": "api",
+				"key":    gw.obfuscateKey(quotaKey),
+				"status": "ok",
 			}).Info("Can't retrieve key quota")
 		}
 	}

--- a/gateway/auth_manager.go
+++ b/gateway/auth_manager.go
@@ -75,13 +75,12 @@ func (b *DefaultSessionManager) ResetQuota(keyName string, session *user.Session
 
 	// Clear the rate limiter and
 	// Fix the raw key
-	keys := []string{rateLimiterSentinelKey, rawKey}
-	keys = append(keys, rawKeysWithAllowanceScope(keyName, session)...)
+	defaultKeys := []string{rateLimiterSentinelKey, rawKey}
+	keys := rawKeysWithAllowanceScope(defaultKeys, keyName, session)
 	b.store.DeleteRawKeys(keys)
 }
 
-func rawKeysWithAllowanceScope(keyName string, session *user.SessionState) []string {
-	keys := make([]string, 0)
+func rawKeysWithAllowanceScope(keys []string, keyName string, session *user.SessionState) []string {
 	for _, acl := range session.AccessRights {
 		if acl.AllowanceScope == "" {
 			continue

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -14,7 +14,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -328,8 +328,10 @@ func TestQuota(t *testing.T) {
 
 	var keyID string
 
-	var webhookWG sync.WaitGroup
+	var requestCount int64
 	webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&requestCount, 1)
+
 		if r.Header.Get("X-Tyk-Test-Header") != "Tyk v1.BANANA" {
 			t.Error("Custom webhook header not set", r.Header)
 		}
@@ -341,8 +343,6 @@ func TestQuota(t *testing.T) {
 		if data["event"] != "QuotaExceeded" || data["message"] != "Key Quota Limit Exceeded" || data["key"] != keyID {
 			t.Error("Webhook payload not match", data)
 		}
-
-		webhookWG.Done()
 	}))
 	defer webhook.Close()
 
@@ -392,7 +392,6 @@ func TestQuota(t *testing.T) {
 		"authorization": keyID,
 	}
 
-	webhookWG.Add(1)
 	_, _ = ts.Run(t, []test.TestCase{
 		{Path: "/", Headers: authHeaders, Code: 200},
 		// Ignored path should not affect quota
@@ -402,7 +401,9 @@ func TestQuota(t *testing.T) {
 		// Ignored path works without auth
 		{Path: "/get", Code: 200},
 	}...)
-	webhookWG.Wait()
+
+	want := int64(1)
+	assert.Equal(t, want, atomic.LoadInt64(&requestCount))
 }
 
 func TestListener(t *testing.T) {

--- a/gateway/middleware_test.go
+++ b/gateway/middleware_test.go
@@ -311,7 +311,7 @@ func TestSessionLimiter_RedisQuotaExceeded_PerAPI(t *testing.T) {
 	assert.Equal(t, session.AccessRights[apis[0].APIID].AllowanceScope, apis[0].APIID)
 	assert.Equal(t, session.AccessRights[apis[1].APIID].AllowanceScope, apis[1].APIID)
 
-	// Check allowcance scope is equal to "" because per api is not enabled for api3
+	// Check allowance scope is equal to "" because per api is not enabled for api3
 	assert.Equal(t, session.AccessRights[apis[2].APIID].AllowanceScope, "")
 
 	sendReqAndCheckQuota := func(t *testing.T, apiID string, expectedQuotaRemaining int64, perAPI bool) {

--- a/gateway/session_manager.go
+++ b/gateway/session_manager.go
@@ -7,12 +7,15 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/TykTechnologies/drl"
 	"github.com/TykTechnologies/leakybucket"
 	"github.com/TykTechnologies/leakybucket/memorycache"
 
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/internal/rate"
+	"github.com/TykTechnologies/tyk/internal/rate/limiter"
 	"github.com/TykTechnologies/tyk/internal/redis"
 	"github.com/TykTechnologies/tyk/storage"
 	"github.com/TykTechnologies/tyk/user"
@@ -327,6 +330,7 @@ func (l *SessionLimiter) ForwardMessage(r *http.Request, currentSession *user.Se
 
 }
 
+<<<<<<< HEAD
 func (l *SessionLimiter) RedisQuotaExceeded(r *http.Request, currentSession *user.SessionState, quotaKey, scope string, limit *user.APILimit, store storage.Handler, hashKeys bool) bool {
 	// Unlimited?
 	if limit.QuotaMax == -1 || limit.QuotaMax == 0 {
@@ -337,6 +341,18 @@ func (l *SessionLimiter) RedisQuotaExceeded(r *http.Request, currentSession *use
 	defer func() {
 		ctxScheduleSessionUpdate(r)
 	}()
+=======
+// RedisQuotaExceeded returns true if the request should be blocked as over quota.
+func (l *SessionLimiter) RedisQuotaExceeded(r *http.Request, session *user.SessionState, quotaKey, scope string, limit *user.APILimit, store storage.Handler, hashKeys bool) bool {
+	if limit.QuotaMax <= 0 {
+		return false
+	}
+
+	// don't use the requests cancellation context
+	ctx := context.Background()
+
+	session.Touch()
+>>>>>>> 36509786e... [TT-12452] Clear up quota gated with a distributed redis lock (#6448)
 
 	quotaScope := ""
 	if scope != "" {
@@ -353,11 +369,12 @@ func (l *SessionLimiter) RedisQuotaExceeded(r *http.Request, currentSession *use
 		key = quotaKey
 	}
 
+	now := time.Now().Truncate(0)
 	rawKey := QuotaKeyPrefix + quotaScope + key
-	quotaRenewalRate := limit.QuotaRenewalRate
-	quotaRenews := limit.QuotaRenews
+	quotaRenewalRate := time.Second * time.Duration(limit.QuotaRenewalRate)
 	quotaMax := limit.QuotaMax
 
+<<<<<<< HEAD
 	log.Debug("[QUOTA] Quota limiter key is: ", rawKey)
 	log.Debug("Renewing with TTL: ", quotaRenewalRate)
 	// INCR the key (If it equals 1 - set EXPIRE)
@@ -371,33 +388,52 @@ func (l *SessionLimiter) RedisQuotaExceeded(r *http.Request, currentSession *use
 		log.Debug("Now:", time.Now())
 		if time.Now().After(renewalDate) {
 			//for renew quota = never, once we get the quota max we must not allow using it again
+=======
+	// First, ensure a distributed lock
+	conn := l.limiterStorage
+	locker := limiter.NewLimiter(conn).Locker(rawKey)
+>>>>>>> 36509786e... [TT-12452] Clear up quota gated with a distributed redis lock (#6448)
 
-			if quotaRenewalRate <= 0 {
-				return true
-			}
-			// The renewal date is in the past, we should update the quota!
-			// Also, this fixes legacy issues where there is no TTL on quota buckets
-			log.Debug("Incorrect key expiry setting detected, correcting")
-			go store.DeleteRawKey(rawKey)
-			qInt = 1
-		} else {
-			// Renewal date is in the future and the quota is exceeded
-			return true
+	if err := locker.Lock(ctx); err != nil {
+		log.WithError(err).Error("error locking quota key, blocking")
+		return true
+	}
+	defer func() {
+		if err := locker.Unlock(ctx); err != nil {
+			log.WithError(err).Error("error unlocking quota key")
 		}
+	}()
 
+	var expired bool
+	var expiredAt time.Time
+	dur, err := conn.PTTL(ctx, rawKey).Result()
+	if err == nil || errors.Is(err, redis.Nil) {
+		if err == nil {
+			expiredAt = now.Add(dur)
+		} else {
+			expired = true
+			expiredAt = now.Add(quotaRenewalRate)
+			conn.Set(ctx, rawKey, 0, quotaRenewalRate)
+		}
+	} else {
+		log.WithError(err).Warn("error getting key TTL, blocking")
+		return true
 	}
 
-	// If this is a new Quota period, ensure we let the end user know
-	if qInt == 1 {
-		quotaRenews = time.Now().Unix() + quotaRenewalRate
+	qInt, err := conn.Incr(ctx, rawKey).Result()
+	if err != nil && !errors.Is(err, redis.Nil) {
+		log.WithError(err).Error("can't update quota, blocking")
+		return true
 	}
 
-	// If not, pass and set the values of the session to quotamax - counter
-	remaining := quotaMax - qInt
-	if remaining < 0 {
-		remaining = 0
+	logFields := logrus.Fields{
+		"quota":     qInt - 1,
+		"quotaMax":  quotaMax,
+		"expired":   expired,
+		"expiredAt": expiredAt,
 	}
 
+<<<<<<< HEAD
 	for k, v := range currentSession.AccessRights {
 		if v.Limit.IsEmpty() {
 			continue
@@ -413,8 +449,26 @@ func (l *SessionLimiter) RedisQuotaExceeded(r *http.Request, currentSession *use
 	if scope == "" {
 		currentSession.QuotaRemaining = remaining
 		currentSession.QuotaRenews = quotaRenews
+=======
+	log.WithFields(logFields).Debug("[QUOTA] Request")
+
+	if qInt-1 >= quotaMax {
+		log.WithFields(logFields).Debug("[QUOTA] Limits reached")
+
+		if expired {
+			if quotaRenewalRate <= 0 {
+				return true
+			}
+
+			go store.DeleteRawKey(rawKey)
+			qInt = 1
+		} else {
+			return true
+		}
+>>>>>>> 36509786e... [TT-12452] Clear up quota gated with a distributed redis lock (#6448)
 	}
 
+	l.updateSessionQuota(session, scope, quotaMax-qInt, expiredAt.Unix())
 	return false
 }
 
@@ -446,4 +500,31 @@ func GetAccessDefinitionByAPIIDOrSession(currentSession *user.SessionState, api 
 	}
 
 	return accessDef, allowanceScope, nil
+}
+
+// updateSessionQuota updates session attached access rights.
+//
+// When limits are defined, QuotaRemaining and QuotaRenews is updated for a matching
+// access rights definition for an api, and the session root.
+func (*SessionLimiter) updateSessionQuota(session *user.SessionState, scope string, remaining int64, renews int64) {
+	if remaining < 0 {
+		remaining = 0
+	}
+
+	for k, v := range session.AccessRights {
+		if v.Limit.IsEmpty() {
+			continue
+		}
+
+		if v.AllowanceScope == scope {
+			v.Limit.QuotaRemaining = remaining
+			v.Limit.QuotaRenews = renews
+		}
+		session.AccessRights[k] = v
+	}
+
+	if scope == "" {
+		session.QuotaRemaining = remaining
+		session.QuotaRenews = renews
+	}
 }

--- a/gateway/session_manager.go
+++ b/gateway/session_manager.go
@@ -339,7 +339,9 @@ func (l *SessionLimiter) RedisQuotaExceeded(r *http.Request, session *user.Sessi
 	// don't use the requests cancellation context
 	ctx := context.Background()
 
-	session.Touch()
+	defer func() {
+		ctxScheduleSessionUpdate(r)
+	}()
 
 	quotaScope := ""
 	if scope != "" {

--- a/internal/rate/Taskfile.yml
+++ b/internal/rate/Taskfile.yml
@@ -1,21 +1,27 @@
 ---
 version: "3"
 
+includes:
+  services: ../../docker/services/Taskfile.yml
+
 vars:
   testArgs: -v
 
 tasks:
   test:
     desc: "Run tests (requires redis)"
+    deps: [ services:up ]
     cmds:
+      - defer:
+          task: services:down
       - task: fmt
-      - go test {{.testArgs}} -count=1 -gcflags="-m=3" -cover -coverprofile=rate.cov .
+      - go test {{.testArgs}} -count=1 -cover -coverprofile=rate.cov -coverpkg=./... ./...
 
   bench:
     desc: "Run benchmarks"
     cmds:
       - task: fmt
-      - go test {{.testArgs}} -count=1 -tags integration -bench=. -benchtime=10s -benchmem .
+      - go test {{.testArgs}} -count=1 -tags integration -bench=. -benchtime=10s -benchmem ./...
 
   fmt:
     internal: true

--- a/internal/rate/limiter.go
+++ b/internal/rate/limiter.go
@@ -4,26 +4,38 @@ import (
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/internal/rate/limiter"
 	"github.com/TykTechnologies/tyk/internal/redis"
+	"github.com/TykTechnologies/tyk/user"
 )
 
+// Limiter returns the appropriate rate limiter as configured by gateway.
 func Limiter(gwConfig *config.Config, redis redis.UniversalClient) limiter.LimiterFunc {
 	name, ok := LimiterKind(gwConfig)
 	if !ok {
 		return nil
 	}
 
-	res := limiter.NewLimiter(name, redis)
+	res := limiter.NewLimiter(redis)
 
-	switch {
-	case name == LimitLeakyBucket:
+	switch name {
+	case LimitLeakyBucket:
 		return res.LeakyBucket
-	case name == LimitTokenBucket:
+	case LimitTokenBucket:
 		return res.TokenBucket
-	case name == LimitFixedWindow:
+	case LimitFixedWindow:
 		return res.FixedWindow
-	case name == LimitSlidingWindow:
+	case LimitSlidingWindow:
 		return res.SlidingWindow
 	}
 
 	return nil
+}
+
+// LimiterKey returns a redis key name based on passed parameters.
+// The key should be post-fixed if multiple keys are required (sentinel).
+func LimiterKey(currentSession *user.SessionState, rateScope string, key string, useCustomKey bool) string {
+	if !useCustomKey && !currentSession.KeyHashEmpty() {
+		return Prefix(LimiterKeyPrefix, rateScope, currentSession.KeyHash())
+	}
+
+	return Prefix(LimiterKeyPrefix, rateScope, key)
 }

--- a/internal/rate/limiter/limiter.go
+++ b/internal/rate/limiter/limiter.go
@@ -2,7 +2,6 @@ package limiter
 
 import (
 	"context"
-	"strings"
 
 	"github.com/TykTechnologies/exp/pkg/limiters"
 
@@ -12,8 +11,7 @@ import (
 var ErrLimitExhausted = limiters.ErrLimitExhausted
 
 type Limiter struct {
-	prefix string
-	redis  redis.UniversalClient
+	redis redis.UniversalClient
 
 	locker limiters.DistLocker
 	logger limiters.Logger
@@ -22,15 +20,10 @@ type Limiter struct {
 
 type LimiterFunc func(ctx context.Context, key string, rate float64, per float64) error
 
-<<<<<<< HEAD
-func NewLimiter(prefix string, redis redis.UniversalClient) *Limiter {
-=======
 // NewLimiter creates a new limiter object. It holds the redis client and the
 // default non-distributed locks, logger, and a clock for supporting tests.
 func NewLimiter(redis redis.UniversalClient) *Limiter {
->>>>>>> 36509786e... [TT-12452] Clear up quota gated with a distributed redis lock (#6448)
 	return &Limiter{
-		prefix: prefix,
 		redis:  redis,
 		locker: limiters.NewLockNoop(),
 		logger: limiters.NewStdLogger(),
@@ -45,25 +38,4 @@ func (l *Limiter) Locker(name string) limiters.DistLocker {
 		return limiters.NewLockRedis(redis.NewPool(l.redis), name+"-lock")
 	}
 	return l.locker
-}
-
-func Prefix(params ...string) string {
-	var res strings.Builder
-	var written int
-
-	for _, p := range params {
-		if p == "" {
-			continue
-		}
-
-		if written == 0 {
-			res.Write([]byte(p))
-			written++
-			continue
-		}
-
-		res.Write([]byte("-"))
-		res.Write([]byte(p))
-	}
-	return res.String()
 }

--- a/internal/rate/limiter/limiter_fixed_window.go
+++ b/internal/rate/limiter/limiter_fixed_window.go
@@ -15,12 +15,10 @@ func (l *Limiter) FixedWindow(ctx context.Context, key string, rate float64, per
 		ttl      = time.Duration(per * float64(time.Second))
 	)
 
-	rateLimitPrefix := Prefix(l.prefix, key)
-
 	if l.redis != nil {
-		storage = limiters.NewFixedWindowRedis(l.redis, rateLimitPrefix)
+		storage = limiters.NewFixedWindowRedis(l.redis, key)
 	} else {
-		storage = limiters.LocalFixedWindow(rateLimitPrefix)
+		storage = limiters.LocalFixedWindow(key)
 	}
 
 	limiter := limiters.NewFixedWindow(capacity, ttl, storage, l.clock)

--- a/internal/rate/limiter/limiter_leaky_bucket.go
+++ b/internal/rate/limiter/limiter_leaky_bucket.go
@@ -18,22 +18,11 @@ func (l *Limiter) LeakyBucket(ctx context.Context, key string, rate float64, per
 		raceCheck  = false
 	)
 
-<<<<<<< HEAD
-	rateLimitPrefix := Prefix(l.prefix, key)
-
-	if l.redis != nil {
-		locker = l.redisLock(l.prefix)
-		storage = limiters.NewLeakyBucketRedis(l.redis, rateLimitPrefix, ttl, raceCheck)
-	} else {
-		locker = l.lock
-		storage = limiters.LocalLeakyBucket(rateLimitPrefix)
-=======
 	locker = l.Locker(key)
 	if l.redis != nil {
 		storage = limiters.NewLeakyBucketRedis(l.redis, key, ttl, raceCheck)
 	} else {
 		storage = limiters.LocalLeakyBucket(key)
->>>>>>> 36509786e... [TT-12452] Clear up quota gated with a distributed redis lock (#6448)
 	}
 
 	limiter := limiters.NewLeakyBucket(capacity, outputRate, locker, storage, l.clock, l.logger)

--- a/internal/rate/limiter/limiter_leaky_bucket.go
+++ b/internal/rate/limiter/limiter_leaky_bucket.go
@@ -18,6 +18,7 @@ func (l *Limiter) LeakyBucket(ctx context.Context, key string, rate float64, per
 		raceCheck  = false
 	)
 
+<<<<<<< HEAD
 	rateLimitPrefix := Prefix(l.prefix, key)
 
 	if l.redis != nil {
@@ -26,6 +27,13 @@ func (l *Limiter) LeakyBucket(ctx context.Context, key string, rate float64, per
 	} else {
 		locker = l.lock
 		storage = limiters.LocalLeakyBucket(rateLimitPrefix)
+=======
+	locker = l.Locker(key)
+	if l.redis != nil {
+		storage = limiters.NewLeakyBucketRedis(l.redis, key, ttl, raceCheck)
+	} else {
+		storage = limiters.LocalLeakyBucket(key)
+>>>>>>> 36509786e... [TT-12452] Clear up quota gated with a distributed redis lock (#6448)
 	}
 
 	limiter := limiters.NewLeakyBucket(capacity, outputRate, locker, storage, l.clock, l.logger)

--- a/internal/rate/limiter/limiter_sliding_window.go
+++ b/internal/rate/limiter/limiter_sliding_window.go
@@ -15,12 +15,10 @@ func (l *Limiter) SlidingWindow(ctx context.Context, key string, rate float64, p
 		ttl      = time.Duration(per * float64(time.Second))
 	)
 
-	rateLimitPrefix := Prefix(l.prefix, key)
-
 	if l.redis != nil {
-		storage = limiters.NewSlidingWindowRedis(l.redis, rateLimitPrefix)
+		storage = limiters.NewSlidingWindowRedis(l.redis, key)
 	} else {
-		storage = limiters.LocalSlidingWindow(rateLimitPrefix)
+		storage = limiters.LocalSlidingWindow(key)
 	}
 
 	// TODO: when doing rate sliding rate limits, the counts for two windows are

--- a/internal/rate/limiter/limiter_token_bucket.go
+++ b/internal/rate/limiter/limiter_token_bucket.go
@@ -17,6 +17,7 @@ func (l *Limiter) TokenBucket(ctx context.Context, key string, rate float64, per
 		raceCheck = false
 	)
 
+<<<<<<< HEAD
 	rateLimitPrefix := Prefix(l.prefix, key)
 
 	if l.redis != nil {
@@ -25,6 +26,13 @@ func (l *Limiter) TokenBucket(ctx context.Context, key string, rate float64, per
 	} else {
 		locker = l.lock
 		storage = limiters.LocalTokenBucket(rateLimitPrefix)
+=======
+	locker = l.Locker(key)
+	if l.redis != nil {
+		storage = limiters.NewTokenBucketRedis(l.redis, key, ttl, raceCheck)
+	} else {
+		storage = limiters.LocalTokenBucket(key)
+>>>>>>> 36509786e... [TT-12452] Clear up quota gated with a distributed redis lock (#6448)
 	}
 
 	limiter := limiters.NewTokenBucket(capacity, ttl, locker, storage, l.clock, l.logger)

--- a/internal/rate/limiter/limiter_token_bucket.go
+++ b/internal/rate/limiter/limiter_token_bucket.go
@@ -17,22 +17,11 @@ func (l *Limiter) TokenBucket(ctx context.Context, key string, rate float64, per
 		raceCheck = false
 	)
 
-<<<<<<< HEAD
-	rateLimitPrefix := Prefix(l.prefix, key)
-
-	if l.redis != nil {
-		locker = l.redisLock(l.prefix)
-		storage = limiters.NewTokenBucketRedis(l.redis, rateLimitPrefix, ttl, raceCheck)
-	} else {
-		locker = l.lock
-		storage = limiters.LocalTokenBucket(rateLimitPrefix)
-=======
 	locker = l.Locker(key)
 	if l.redis != nil {
 		storage = limiters.NewTokenBucketRedis(l.redis, key, ttl, raceCheck)
 	} else {
 		storage = limiters.LocalTokenBucket(key)
->>>>>>> 36509786e... [TT-12452] Clear up quota gated with a distributed redis lock (#6448)
 	}
 
 	limiter := limiters.NewTokenBucket(capacity, ttl, locker, storage, l.clock, l.logger)

--- a/internal/rate/rate.go
+++ b/internal/rate/rate.go
@@ -1,16 +1,48 @@
 package rate
 
 import (
+	"strings"
+
 	"github.com/TykTechnologies/tyk/internal/rate/limiter"
 )
 
-var ErrLimitExhausted = limiter.ErrLimitExhausted
+var (
+	// ErrLimitExhausted is returned when the request should be blocked.
+	ErrLimitExhausted = limiter.ErrLimitExhausted
+)
 
-var Prefix = limiter.Prefix
-
+// The following constants enumerate implemented rate limiters.
 const (
 	LimitLeakyBucket   string = "leaky-bucket"
 	LimitTokenBucket   string = "token-bucket"
 	LimitFixedWindow   string = "fixed-window"
 	LimitSlidingWindow string = "sliding-window"
 )
+
+const (
+	// LimiterKeyPrefix serves as a standard prefix for generating rate limit keys.
+	LimiterKeyPrefix = "rate-limit-"
+)
+
+// Prefix is a utility function to generate rate limiter redis key names.
+func Prefix(params ...string) string {
+	var res strings.Builder
+	var written int
+
+	for _, p := range params {
+		p = strings.Trim(p, "-")
+		if p == "" {
+			continue
+		}
+
+		if written == 0 {
+			res.Write([]byte(p))
+			written++
+			continue
+		}
+
+		res.Write([]byte("-"))
+		res.Write([]byte(p))
+	}
+	return res.String()
+}

--- a/internal/rate/storage_test.go
+++ b/internal/rate/storage_test.go
@@ -1,0 +1,31 @@
+package rate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk/config"
+)
+
+func TestNewStorage(t *testing.T) {
+	conf, err := config.NewDefaultWithEnv()
+	assert.NoError(t, err)
+
+	// Coverage
+	conf.Storage.MaxActive = 100
+	conf.Storage.Timeout = 4
+	conf.Storage.UseSSL = true
+
+	client := NewStorage(&conf.Storage)
+	assert.NotNil(t, client)
+
+	conf.Storage.EnableCluster = true
+	client = NewStorage(&conf.Storage)
+	assert.NotNil(t, client)
+
+	conf.Storage.EnableCluster = false
+	conf.Storage.MasterName = "redis"
+	client = NewStorage(&conf.Storage)
+	assert.NotNil(t, client)
+}

--- a/storage/redis_cluster.go
+++ b/storage/redis_cluster.go
@@ -274,7 +274,9 @@ func (r *RedisCluster) GetKey(keyName string) (string, error) {
 
 	value, err := storage.Get(context.Background(), r.fixKey(keyName))
 	if err != nil {
-		log.Debug("Error trying to get value:", err)
+		if !errors.Is(err, redis.Nil) {
+			log.Debug("Error trying to get value:", err)
+		}
 		return "", ErrKeyNotFound
 	}
 
@@ -337,7 +339,9 @@ func (r *RedisCluster) GetRawKey(keyName string) (string, error) {
 
 	value, err := storage.Get(context.Background(), keyName)
 	if err != nil {
-		log.Debug("Error trying to get value:", err)
+		if !errors.Is(err, redis.Nil) {
+			log.Debug("Error trying to get value:", err)
+		}
 		return "", ErrKeyNotFound
 	}
 

--- a/tests/quota/Taskfile.yml
+++ b/tests/quota/Taskfile.yml
@@ -1,0 +1,51 @@
+---
+version: "3"
+
+includes:
+  services: ../../docker/services/Taskfile.yml
+
+vars:
+  coverage: quota.cov
+  testArgs: -v
+
+tasks:
+  test:
+    desc: "Run tests (requires redis)"
+    deps: [ services:up ]
+    cmds:
+      - defer:
+          task: services:down
+      - task: fmt
+      - go test {{.testArgs}} -count=1 -cover -coverprofile={{.coverage}} -coverpkg=./... ./...
+
+  bench:
+    desc: "Run benchmarks"
+    cmds:
+      - task: fmt
+      - go test {{.testArgs}} -count=1 -tags integration -run=^$ -bench=. -benchtime=10s -benchmem ./...
+
+  fmt:
+    internal: true
+    desc: "Invoke fmt"
+    cmds:
+      - goimports -w .
+      - go fmt ./...
+
+  cover:
+    desc: "Show source coverage"
+    aliases: [coverage, cov]
+    cmds:
+      - go tool cover -func={{.coverage}}
+
+  uncover:
+    desc: "Show uncovered source"
+    cmds:
+      - uncover {{.coverage}}
+
+  install:uncover:
+    desc: "Install uncover"
+    internal: true
+    env:
+      GOBIN: /usr/local/bin
+    cmds:
+      - go install github.com/gregoryv/uncover/...@latest

--- a/tests/quota/benchmark_quota_test.go
+++ b/tests/quota/benchmark_quota_test.go
@@ -1,0 +1,43 @@
+package quota
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/TykTechnologies/tyk/internal/uuid"
+	"github.com/TykTechnologies/tyk/test"
+)
+
+func BenchmarkQuota(b *testing.B) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	settings := map[string]interface{}{
+		"quota_max":          100000000,
+		"quota_remaining":    100000000,
+		"quota_renewal_rate": 300,
+	}
+
+	setupQuotaLimit(b, ts, "key-"+uuid.New(), settings)
+
+	var wg sync.WaitGroup
+
+	run := func() {
+		for i := 0; i < b.N; i++ {
+			ts.Run(b, test.TestCase{
+				Code: http.StatusOK,
+			})
+		}
+		wg.Done()
+	}
+
+	wg.Add(4)
+
+	go run()
+	go run()
+	go run()
+	go run()
+
+	wg.Wait()
+}

--- a/tests/quota/shim_test.go
+++ b/tests/quota/shim_test.go
@@ -1,0 +1,34 @@
+package quota
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/TykTechnologies/tyk/gateway"
+	"github.com/TykTechnologies/tyk/test"
+)
+
+var (
+	StartTest     = gateway.StartTest
+	CreateSession = gateway.CreateSession
+)
+
+type APISpec = gateway.APISpec
+type Test = gateway.Test
+
+func setupQuotaLimit(tb testing.TB, ts *Test, name string, data map[string]interface{}) {
+	tb.Helper()
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.UseKeylessAccess = true
+		spec.Proxy.ListenPath = "/"
+	})
+
+	ts.Run(tb, test.TestCase{
+		Path:      "/tyk/org/keys/" + name + "?reset_quota=1",
+		AdminAuth: true,
+		Method:    http.MethodPost,
+		Code:      http.StatusOK,
+		Data:      data,
+	})
+}


### PR DESCRIPTION
[TT-12452] Clear up quota gated with a distributed redis lock (#6448)

### **User description**
- adds a -time field into redis next to quotas, to handle the real
expiry
- adds distributed locking to fix races in a cluster of gateways
- cleanups for readability/understanding of the codebase


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added deletion of expiration key when resetting quota in
`gateway/auth_manager.go`.
- Introduced distributed locking for quota management in
`gateway/session_manager.go`.
- Added handling for quota expiration and renewal in
`gateway/session_manager.go`.
- Refactored quota check logic for clarity in
`gateway/session_manager.go`.
- Added `Locker` method to handle distributed locks in
`internal/rate/limiter/limiter.go`.
- Updated `Limiter` struct to use `locker` instead of `lock` in
`internal/rate/limiter/limiter.go`.
- Updated leaky bucket limiter to use `Locker` method in
`internal/rate/limiter/limiter_leaky_bucket.go`.
- Updated token bucket limiter to use `Locker` method in
`internal/rate/limiter/limiter_token_bucket.go`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>auth_manager.go</strong><dd><code>Add expiration key
deletion in quota reset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

gateway/auth_manager.go

- Added deletion of expiration key when resetting quota.



</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6448/files#diff-311e18b071d244ed1615c0019215b633278679df373288b3451bcc5cf7c52c4e">+2/-0</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
<summary><strong>session_manager.go</strong><dd><code>Implement
distributed locking and quota expiration handling</code></dd></summary>
<hr>

gateway/session_manager.go

<li>Introduced distributed locking for quota management.<br> <li> Added
handling for quota expiration and renewal.<br> <li> Refactored quota
check logic for clarity.<br>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6448/files#diff-e6b40a285464cd86736e970c4c0b320b44c75b18b363d38c200e9a9d36cdabb6">+83/-39</a>&nbsp;
</td>

</tr>                    

<tr>
  <td>
    <details>
<summary><strong>limiter.go</strong><dd><code>Add Locker method for
distributed locking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

internal/rate/limiter/limiter.go

<li>Added <code>Locker</code> method to handle distributed locks.<br>
<li> Updated <code>Limiter</code> struct to use <code>locker</code>
instead of <code>lock</code>.<br>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6448/files#diff-56d0d9635320b4cee711b1516c00f66a68da979a26d6fee92905578e08ffb3c1">+11/-4</a>&nbsp;
&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
<summary><strong>limiter_leaky_bucket.go</strong><dd><code>Use Locker
method in leaky bucket limiter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; </dd></summary>
<hr>

internal/rate/limiter/limiter_leaky_bucket.go

- Updated to use `Locker` method for distributed locking.



</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6448/files#diff-fd62f9da5d3e23cd41d9ff0a1b8cae8927c9faf0b2203a521f12d4497b6f433c">+1/-2</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
<summary><strong>limiter_token_bucket.go</strong><dd><code>Use Locker
method in token bucket limiter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; </dd></summary>
<hr>

internal/rate/limiter/limiter_token_bucket.go

- Updated to use `Locker` method for distributed locking.



</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6448/files#diff-08654de5694ab76207bf952e494ca48316e3cb814f473c2a8f13c835ef69fd9e">+1/-2</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools
and their descriptions

---------

Co-authored-by: Tit Petric <tit@tyk.io>

[TT-12452]: https://tyktech.atlassian.net/browse/TT-12452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ