### PR TITLE
Merging to release-5.3: [TT-12975] Fix flaky test caused by missed Close invocation (#6481)

### DIFF
--- a/.taskfiles/test.yml
+++ b/.taskfiles/test.yml
@@ -18,7 +18,11 @@ vars:
   tags: '{{ .tags | default "goplugin dev" }}'
   args: '{{ .args | default "-timeout=15m" }}'
   buildArgs: -cover -tags "{{.tags}}"
+<<<<<<< HEAD
   testArgs: -failfast -coverpkg=./... {{.buildArgs}}
+=======
+  testArgs: -coverpkg=github.com/TykTechnologies/tyk/...,./... {{.buildArgs}}
+>>>>>>> a616b24e1... [TT-12975] Fix flaky test caused by missed Close invocation (#6481)
   python:
     sh: python3 -c 'import sys; print("%d.%d" % (sys.version_info[0], sys.version_info[1]))'
 

--- a/gateway/server_test.go
+++ b/gateway/server_test.go
@@ -161,6 +161,7 @@ func TestGateway_SyncResourcesWithReload(t *testing.T) {
 		globalConf.ResourceSync.RetryAttempts = retryAttempts
 		globalConf.ResourceSync.Interval = 1
 	})
+	defer ts.Close()
 
 	var syncErr = errors.New("sync error")
 	syncFuncSuccessAt := func(t *testing.T, successAt int) (func() (int, error), *int) {
@@ -216,3 +217,151 @@ func TestGateway_SyncResourcesWithReload(t *testing.T) {
 	})
 
 }
+<<<<<<< HEAD
+=======
+
+type gatewayGetHostDetailsTestCheckFn func(*testing.T, *test.BufferedLogger, *Gateway)
+
+func gatewayGetHostDetailsTestHasErr(wantErr bool, errorText string) gatewayGetHostDetailsTestCheckFn {
+	return func(t *testing.T, bl *test.BufferedLogger, _ *Gateway) {
+		t.Helper()
+		logs := bl.GetLogs(logrus.ErrorLevel)
+		if wantErr {
+			assert.NotEmpty(t, logs, "Expected error logs but got none")
+			if errorText != "" {
+				for _, log := range logs {
+					assert.Contains(t, log.Message, errorText, "Expected log message to contain %q", errorText)
+				}
+			}
+		} else {
+			assert.Empty(t, logs, "Expected no error logs but got some")
+		}
+	}
+}
+
+func gatewayGetHostDetailsTestAddress() gatewayGetHostDetailsTestCheckFn {
+	return func(t *testing.T, _ *test.BufferedLogger, gw *Gateway) {
+		t.Helper()
+		assert.NotNil(t, net.ParseIP(gw.hostDetails.Address))
+	}
+}
+
+func defineGatewayGetHostDetailsTests() []struct {
+	name                string
+	before              func(*Gateway)
+	readPIDFromFile     func(string) (int, error)
+	netutilGetIpAddress func() ([]string, error)
+	checks              []gatewayGetHostDetailsTestCheckFn
+} {
+	var check = func(fns ...gatewayGetHostDetailsTestCheckFn) []gatewayGetHostDetailsTestCheckFn { return fns }
+
+	return []struct {
+		name                string
+		before              func(*Gateway)
+		readPIDFromFile     func(string) (int, error)
+		netutilGetIpAddress func() ([]string, error)
+		checks              []gatewayGetHostDetailsTestCheckFn
+	}{
+		{
+			name:            "fail-read-pid",
+			readPIDFromFile: func(_ string) (int, error) { return 0, fmt.Errorf("Error opening file") },
+			before: func(gw *Gateway) {
+				gw.SetConfig(config.Config{
+					ListenAddress: "127.0.0.1",
+				})
+			},
+			checks: check(
+				gatewayGetHostDetailsTestHasErr(true, "Error opening file"),
+			),
+		},
+		{
+			name:            "success-listen-address-set",
+			readPIDFromFile: func(string) (int, error) { return 1000, nil },
+			before: func(gw *Gateway) {
+				gw.SetConfig(config.Config{
+					ListenAddress: "127.0.0.1",
+				})
+			},
+			checks: check(
+				gatewayGetHostDetailsTestHasErr(false, ""),
+				gatewayGetHostDetailsTestAddress(),
+			),
+		},
+		{
+			name:            "success-listen-address-not-set",
+			readPIDFromFile: func(_ string) (int, error) { return 1000, nil },
+			before: func(gw *Gateway) {
+				gw.SetConfig(config.Config{
+					ListenAddress: "",
+				})
+			},
+			checks: check(
+				gatewayGetHostDetailsTestHasErr(false, ""),
+				gatewayGetHostDetailsTestAddress(),
+			),
+		},
+		{
+			name:            "fail-getting-network-address",
+			readPIDFromFile: func(_ string) (int, error) { return 1000, nil },
+			before: func(gw *Gateway) {
+				gw.SetConfig(config.Config{
+					ListenAddress: "",
+				})
+			},
+			netutilGetIpAddress: func() ([]string, error) { return nil, fmt.Errorf("Error getting network addresses") },
+			checks: check(
+				gatewayGetHostDetailsTestHasErr(true, "Error getting network addresses"),
+			),
+		},
+	}
+}
+
+func TestGatewayGetHostDetails(t *testing.T) {
+	// This test has several issue over globals, `mainLog`, etc.
+	// There's only rewriting it.
+	t.Skip()
+
+	var (
+		orig_readPIDFromFile = readPIDFromFile
+		orig_mainLog         = mainLog
+		orig_getIpAddress    = netutil.GetIpAddress
+		bl                   = test.NewBufferingLogger()
+	)
+
+	tests := defineGatewayGetHostDetailsTests()
+
+	// restore the original functions
+	defer func() {
+		readPIDFromFile = orig_readPIDFromFile
+		mainLog = orig_mainLog
+		getIpAddress = orig_getIpAddress
+	}()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// clear logger mock buffer
+			bl.ClearLogs()
+			// replace functions with mocks
+			mainLog = bl.Logger.WithField("prefix", "test")
+			if tt.readPIDFromFile != nil {
+				readPIDFromFile = tt.readPIDFromFile
+			}
+
+			if tt.netutilGetIpAddress != nil {
+				getIpAddress = tt.netutilGetIpAddress
+			}
+
+			gw := &Gateway{}
+
+			if tt.before != nil {
+				tt.before(gw)
+			}
+
+			gw.getHostDetails(gw.GetConfig().PIDFileLocation)
+			for _, c := range tt.checks {
+				c(t, bl, gw)
+			}
+		})
+	}
+}
+>>>>>>> a616b24e1... [TT-12975] Fix flaky test caused by missed Close invocation (#6481)


### PR DESCRIPTION
[TT-12975] Fix flaky test caused by missed Close invocation (#6481)

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added a `defer ts.Close()` statement in
`TestGateway_SyncResourcesWithReload` to ensure resources are properly
closed after the test execution.
- This change addresses a potential resource leak that could cause flaky
tests, improving test reliability.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>server_test.go</strong><dd><code>Add resource cleanup
to fix flaky test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></summary>
<hr>

gateway/server_test.go

<li>Added a <code>defer ts.Close()</code> statement to ensure resources
are properly <br>closed after the test execution.<br> <li> This change
addresses a potential resource leak that could cause flaky
<br>tests.<br>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6481/files#diff-d9f006370c9748c09affd99d0a4edeb8f3419057703a67fd70838a764a485696">+1/-0</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools
and their descriptions

Co-authored-by: Tit Petric <tit@tyk.io>