### PR TITLE
Merging to release-5.3: added a waitgroup to wait until all the pool connections are dialed (#6487)

### DIFF
--- a/rpc/rpc_client.go
+++ b/rpc/rpc_client.go
@@ -49,6 +49,7 @@ var (
 	// UseSyncLoginRPC for tests where we dont need to execute as a goroutine
 	UseSyncLoginRPC bool
 
+	connectionDialingWG  sync.WaitGroup
 	AnalyticsSerializers []serializer.AnalyticsSerializer
 )
 
@@ -257,8 +258,12 @@ func Connect(connConfig Config, suppressRegister bool, dispatcherFuncs map[strin
 		clientSingleton.Conns = 5
 	}
 
-	clientSingleton.Dial = func(addr string) (conn net.Conn, err error) {
+	for i := 0; i < clientSingleton.Conns; i++ {
+		connectionDialingWG.Add(1)
+	}
 
+	clientSingleton.Dial = func(addr string) (conn net.Conn, err error) {
+		defer connectionDialingWG.Done()
 		dialer := &net.Dialer{
 			Timeout:   10 * time.Second,
 			KeepAlive: 30 * time.Second,
@@ -294,8 +299,10 @@ func Connect(connConfig Config, suppressRegister bool, dispatcherFuncs map[strin
 		conn.Write([]byte("proto2"))
 		conn.Write([]byte{byte(len(connID))})
 		conn.Write([]byte(connID))
+
 		return conn, nil
 	}
+
 	clientSingleton.Start()
 
 	loadDispatcher(dispatcherFuncs)
@@ -304,11 +311,14 @@ func Connect(connConfig Config, suppressRegister bool, dispatcherFuncs map[strin
 		funcClientSingleton = dispatcher.NewFuncClient(clientSingleton)
 	}
 
+	// wait until all the pool connections are dialed so we can call login
+	connectionDialingWG.Wait()
 	handleLogin()
 	if !suppressRegister {
 		register()
 		go checkDisconnect()
 	}
+
 	return true
 }
 


### PR DESCRIPTION
added a waitgroup to wait until all the pool connections are dialed (#6487)

### **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description

On connect to RPC do not loose control on when the initial connections
is done (dial) as it might happens that gw cannot connect or reach the
MDCB server but anyway attempts to login and pull resources (policies &
apis). So, instead, wait until the dialing is succesful so gw do not
start without apis loaded as described in the ticket

## Related Issue

https://tyktech.atlassian.net/browse/TT-12537

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
enhancement


___

### **Description**
- Added a `sync.WaitGroup` to ensure all RPC pool connections are dialed
before proceeding with login and resource synchronization.
- Modified the `Connect` function to wait for all connections to be
established, preventing premature login attempts.
- Improved the reliability of the gateway startup by ensuring that APIs
are loaded only after successful connection dialing.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>rpc_client.go</strong><dd><code>Implement wait group
for connection dialing synchronization</code></dd></summary>
<hr>

rpc/rpc_client.go

<li>Introduced a <code>sync.WaitGroup</code> to manage connection
dialing.<br> <li> Modified the connection dialing process to wait for
all connections to <br>be established before proceeding.<br> <li>
Ensured that the <code>handleLogin</code> function is called only after
all <br>connections are dialed.<br>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6487/files#diff-3b88914c99bb9418e44e6389ce73579843562e8900730b380d7fff2e95c51033">+10/-1</a>&nbsp;
&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools
and their descriptions

---------

Co-authored-by: sredny buitrago <sredny@srednys-MacBook-Pro.local>