### PR TITLE
[TT-12964] ignore endpoint rate limit configurations when rate limit partition is disabled

### DIFF
--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -884,6 +884,15 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 				assert.Equal(t, apiDLimits, s.AccessRights["d"].Limit)
 			},
 		},
+		{
+			name:     "endpoint_rate_limits_on_acl_partition_only",
+			policies: []string{"endpoint_rate_limits_on_acl_partition_only"},
+			sessMatch: func(t *testing.T, s *user.SessionState) {
+				t.Helper()
+				assert.NotEmpty(t, s.AccessRights)
+				assert.Empty(t, s.AccessRights["d"].Endpoints)
+			},
+		},
 	}
 
 	tests = append(tests, endpointRLTCs...)

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -893,6 +893,18 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 				assert.Empty(t, s.AccessRights["d"].Endpoints)
 			},
 		},
+		{
+			name: "endpoint_rate_limits_when_acl_and_quota_partitions_combined",
+			policies: []string{
+				"endpoint_rate_limits_on_acl_partition_only",
+				"endpoint_rate_limits_on_quota_partition_only",
+			},
+			sessMatch: func(t *testing.T, s *user.SessionState) {
+				t.Helper()
+				assert.NotEmpty(t, s.AccessRights)
+				assert.Empty(t, s.AccessRights["d"].Endpoints)
+			},
+		},
 	}
 
 	tests = append(tests, endpointRLTCs...)

--- a/gateway/testdata/policies.json
+++ b/gateway/testdata/policies.json
@@ -752,5 +752,13 @@
     "partitions": {
       "acl": true
     }
+  },
+  "endpoint_rate_limits_on_quota_partition_only": {
+    "id": "endpoint_rate_limits_on_rate_limit_partition_disabled",
+    "quota_max": 1000,
+    "quota_renews":60,
+    "partitions": {
+      "quota": true
+    }
   }
 }

--- a/gateway/testdata/policies.json
+++ b/gateway/testdata/policies.json
@@ -726,5 +726,31 @@
     "partitions": {
       "per_api": true
     }
+  },
+  "endpoint_rate_limits_on_acl_partition_only": {
+    "id": "endpoint_rate_limits_on_rate_limit_partition_disabled",
+    "rate": 500,
+    "per": 1,
+    "quota_max": -1,
+    "access_rights": {
+      "d": {
+        "endpoints": [
+          {
+            "path": "/get",
+            "methods": [
+              {
+                "name": "GET",
+                "limit": {
+                  "rate": -1
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "partitions": {
+      "acl": true
+    }
   }
 }

--- a/internal/policy/apply.go
+++ b/internal/policy/apply.go
@@ -206,6 +206,7 @@ func (t *Service) Apply(session *user.SessionState) error {
 			v.Limit.Smoothing = session.Smoothing
 			v.Limit.ThrottleInterval = session.ThrottleInterval
 			v.Limit.ThrottleRetryLimit = session.ThrottleRetryLimit
+			v.Endpoints = nil
 		}
 
 		if !applyState.didComplexity[k] {


### PR DESCRIPTION
### **User description**
ignore endpoint rate limit configurations when rate limit partition is disabled

<!-- Provide a general summary of your changes in the Title above -->

## Description

This PR makes apply policies ignore endpoint rate limits when rate limit partition is disabled
## Related Issue
JIRA link : https://tyktech.atlassian.net/browse/TT-12964

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
enhancement, tests


___

### **Description**
- Enhanced the `Apply` function to ignore endpoint rate limits when the rate limit partition is disabled, ensuring that endpoints are set to nil in such cases.
- Added new test cases in `policy_test.go` to verify the behavior of endpoint rate limits when partitions are disabled or combined.
- Updated `policies.json` with new policy configurations to support the new test cases, including specific endpoint paths and methods.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>policy_test.go</strong><dd><code>Add test cases for endpoint rate limits with partitioning</code></dd></summary>
<hr>

gateway/policy_test.go

<li>Added new test cases for endpoint rate limits when rate limit <br>partition is disabled.<br> <li> Ensured session state access rights are correctly validated in tests.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6491/files#diff-40d701767204255c38c7dd64939d6bb8df621640c4bddfe5f56080380476a18a">+21/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>policies.json</strong><dd><code>Add policy configurations for endpoint rate limit tests</code>&nbsp; &nbsp; </dd></summary>
<hr>

gateway/testdata/policies.json

<li>Added new policy configurations for testing endpoint rate limits with <br>ACL and quota partitions.<br> <li> Defined specific endpoint paths and methods for new policies.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6491/files#diff-d20906fb23674ef58fee794635f5c1f668eb36f9dc4ce0f4b7d3dbd816e13eb5">+53/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>apply.go</strong><dd><code>Ignore endpoint rate limits when partition is disabled</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/policy/apply.go

<li>Modified the <code>Apply</code> function to ignore endpoint rate limits when rate <br>limit partition is disabled.<br> <li> Set <code>Endpoints</code> to nil if rate limit is not applied.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6491/files#diff-59b92e9d31f142f1d99b746eb3ff7db4e26bf6c3044c9b87b58034a947ee04d1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

