### PR TITLE
[TT-13011] implement combining endpoint rate limits from non partitioned policies.

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Run Gateway Tests
         id: ci-tests
         run: |
-          task test:e2e-combined args="-race -timeout=15m"
+          task test:e2e args="-race -timeout=15m"
           task test:coverage
 
       # golangci-lint actions *require* issues-exit-code=0 to pass data along to sonarcloud

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -52,11 +53,12 @@ func TestLoadPoliciesFromDashboardReLogin(t *testing.T) {
 }
 
 type testApplyPoliciesData struct {
-	name      string
-	policies  []string
-	errMatch  string                               // substring
-	sessMatch func(*testing.T, *user.SessionState) // ignored if nil
-	session   *user.SessionState
+	name         string
+	policies     []string
+	errMatch     string                               // substring
+	sessMatch    func(*testing.T, *user.SessionState) // ignored if nil
+	session      *user.SessionState
+	reverseOrder bool
 }
 
 func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testApplyPoliciesData) {
@@ -85,19 +87,19 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 	nilSessionTCs := []testApplyPoliciesData{
 		{
 			"Empty", nil,
-			"", nil, nil,
+			"", nil, nil, false,
 		},
 		{
 			"Single", []string{"nonpart1"},
-			"", nil, nil,
+			"", nil, nil, false,
 		},
 		{
 			"Missing", []string{"nonexistent"},
-			"not found", nil, nil,
+			"not found", nil, nil, false,
 		},
 		{
 			"DiffOrg", []string{"difforg"},
-			"different org", nil, nil,
+			"different org", nil, nil, false,
 		},
 	}
 	tests = append(tests, nilSessionTCs...)
@@ -151,7 +153,7 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 				if s.QuotaMax != -1 {
 					t.Fatalf("want unlimited quota to be -1")
 				}
-			}, nil,
+			}, nil, false,
 		},
 		{
 			"QuotaPart", []string{"quota1"},
@@ -159,7 +161,7 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 				if s.QuotaMax != 2 {
 					t.Fatalf("want QuotaMax to be 2")
 				}
-			}, nil,
+			}, nil, false,
 		},
 		{
 			"QuotaParts", []string{"quota1", "quota2"},
@@ -167,13 +169,13 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 				if s.QuotaMax != 3 {
 					t.Fatalf("Should pick bigger value")
 				}
-			}, nil,
+			}, nil, false,
 		},
 		{
 			"QuotaParts with acl", []string{"quota5", "quota4"},
 			"", func(t *testing.T, s *user.SessionState) {
 				assert.Equal(t, int64(4), s.QuotaMax)
-			}, nil,
+			}, nil, false,
 		},
 		{
 			"QuotaPart with access rights", []string{"quota3"},
@@ -181,7 +183,7 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 				if s.QuotaMax != 3 {
 					t.Fatalf("quota should be the same as policy quota")
 				}
-			}, nil,
+			}, nil, false,
 		},
 		{
 			"QuotaPart with access rights in multi-policy", []string{"quota4", "nonpart1"},
@@ -193,7 +195,7 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 				// Don't apply api 'b' coming from quota4 policy
 				want := map[string]user.AccessDefinition{"a": {Limit: user.APILimit{}}}
 				assert.Equal(t, want, s.AccessRights)
-			}, nil,
+			}, nil, false,
 		},
 	}
 	tests = append(tests, quotaPartitionTCs...)
@@ -203,7 +205,7 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 			"RatePart with unlimited", []string{"unlimited-rate"},
 			"", func(t *testing.T, s *user.SessionState) {
 				assert.True(t, s.Rate <= 0, "want unlimited rate to be <= 0")
-			}, nil,
+			}, nil, false,
 		},
 		{
 			"RatePart", []string{"rate1"},
@@ -211,7 +213,7 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 				if s.Rate != 3 {
 					t.Fatalf("want Rate to be 3")
 				}
-			}, nil,
+			}, nil, false,
 		},
 		{
 			"RateParts", []string{"rate1", "rate2"},
@@ -219,25 +221,25 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 				if s.Rate != 4 {
 					t.Fatalf("Should pick bigger value")
 				}
-			}, nil,
+			}, nil, false,
 		},
 		{
 			"RateParts with acl", []string{"rate5", "rate4"},
 			"", func(t *testing.T, s *user.SessionState) {
 				assert.Equal(t, float64(10), s.Rate)
-			}, nil,
+			}, nil, false,
 		},
 		{
 			"RateParts with acl respected by session", []string{"rate4", "rate5"},
 			"", func(t *testing.T, s *user.SessionState) {
 				assert.Equal(t, float64(10), s.Rate)
-			}, &user.SessionState{Rate: 20},
+			}, &user.SessionState{Rate: 20}, false,
 		},
 		{
 			"Rate with no partition respected by session", []string{"rate-no-partition"},
 			"", func(t *testing.T, s *user.SessionState) {
 				assert.Equal(t, float64(12), s.Rate)
-			}, &user.SessionState{Rate: 20},
+			}, &user.SessionState{Rate: 20}, false,
 		},
 	}
 	tests = append(tests, rateLimitPartitionTCs...)
@@ -249,7 +251,7 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 				if s.MaxQueryDepth != -1 {
 					t.Fatalf("unlimitied query depth should be -1")
 				}
-			}, nil,
+			}, nil, false,
 		},
 		{
 			"ComplexityPart", []string{"complexity1"},
@@ -257,7 +259,7 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 				if s.MaxQueryDepth != 2 {
 					t.Fatalf("want MaxQueryDepth to be 2")
 				}
-			}, nil,
+			}, nil, false,
 		},
 		{
 			"ComplexityParts", []string{"complexity1", "complexity2"},
@@ -265,7 +267,7 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 				if s.MaxQueryDepth != 3 {
 					t.Fatalf("Should pick bigger value")
 				}
-			}, nil,
+			}, nil, false,
 		},
 	}
 	tests = append(tests, complexityPartitionTCs...)
@@ -277,21 +279,21 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 				want := map[string]user.AccessDefinition{"a": {Limit: user.APILimit{}}}
 
 				assert.Equal(t, want, s.AccessRights)
-			}, nil,
+			}, nil, false,
 		},
 		{
 			"AclPart", []string{"acl1", "acl2"},
 			"", func(t *testing.T, s *user.SessionState) {
 				want := map[string]user.AccessDefinition{"a": {Limit: user.APILimit{}}, "b": {Limit: user.APILimit{}}}
 				assert.Equal(t, want, s.AccessRights)
-			}, nil,
+			}, nil, false,
 		},
 		{
 			"Acl for a and rate for a,b", []string{"acl1", "rate-for-a-b"},
 			"", func(t *testing.T, s *user.SessionState) {
 				want := map[string]user.AccessDefinition{"a": {Limit: user.APILimit{RateLimit: user.RateLimit{Rate: 4, Per: 1}}}}
 				assert.Equal(t, want, s.AccessRights)
-			}, nil,
+			}, nil, false,
 		},
 		{
 			"Acl for a,b and individual rate for a,b", []string{"acl-for-a-b", "rate-for-a", "rate-for-b"},
@@ -301,7 +303,7 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 					"b": {Limit: user.APILimit{RateLimit: user.RateLimit{Rate: 2, Per: 1}}},
 				}
 				assert.Equal(t, want, s.AccessRights)
-			}, nil,
+			}, nil, false,
 		},
 		{
 			"RightsUpdate", []string{"acl3"},
@@ -318,7 +320,7 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 					t.Fatalf("couldn't apply policy: %s", err.Error())
 				}
 				assert.Equal(t, newPolicy.AccessRights, ses.AccessRights)
-			}, nil,
+			}, nil, false,
 		},
 	}
 	tests = append(tests, aclPartitionTCs...)
@@ -330,7 +332,7 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 				if !s.IsInactive {
 					t.Fatalf("want IsInactive to be true")
 				}
-			}, nil,
+			}, nil, false,
 		},
 		{
 			"InactiveMergeAll", []string{"inactive1", "inactive2"},
@@ -338,7 +340,7 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 				if !s.IsInactive {
 					t.Fatalf("want IsInactive to be true")
 				}
-			}, nil,
+			}, nil, false,
 		},
 		{
 			"InactiveWithSession", []string{"tags1", "tags2"},
@@ -348,7 +350,7 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 				}
 			}, &user.SessionState{
 				IsInactive: true,
-			},
+			}, false,
 		},
 	}
 	tests = append(tests, inactiveTCs...)
@@ -653,7 +655,7 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 				if s.ThrottleInterval != 9 {
 					t.Fatalf("Throttle interval should be 9 inherited from policy")
 				}
-			}, nil,
+			}, nil, false,
 		},
 		{
 			name:     "Throttle retry limit from policy",
@@ -681,7 +683,7 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 				assert.Equal(t, want, s.Tags)
 			}, &user.SessionState{
 				Tags: []string{"key-tag"},
-			},
+			}, false,
 		},
 	}
 	tests = append(tests, tagsTCs...)
@@ -689,7 +691,7 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 	partitionTCs := []testApplyPoliciesData{
 		{
 			"NonpartAndPart", []string{"nonpart1", "quota1"},
-			"", nil, nil,
+			"", nil, nil, false,
 		},
 		{
 			name:     "inherit quota and rate from partitioned policies",
@@ -786,6 +788,7 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 				}
 				assert.Equal(t, want, s.AccessRights)
 			},
+			reverseOrder: true,
 		},
 		{
 			name: "Endpoint level limits overlapping",
@@ -883,6 +886,7 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 				}
 				assert.Equal(t, apiDLimits, s.AccessRights["d"].Limit)
 			},
+			reverseOrder: true,
 		},
 		{
 			name:     "endpoint_rate_limits_on_acl_partition_only",
@@ -904,10 +908,172 @@ func (s *Test) testPrepareApplyPolicies(tb testing.TB) (*BaseMiddleware, []testA
 				assert.NotEmpty(t, s.AccessRights)
 				assert.Empty(t, s.AccessRights["d"].Endpoints)
 			},
+			reverseOrder: true,
 		},
 	}
 
 	tests = append(tests, endpointRLTCs...)
+
+	combinedEndpointRLTCs := []testApplyPoliciesData{
+		{
+			name: "combine_non_partitioned_policies_with_endpoint_rate_limits_configured_on_api_d",
+			policies: []string{
+				"api_d_get_endpoint_rl_1_configure_on_non_partitioned_policy",
+				"api_d_get_endpoint_rl_2_configure_on_non_partitioned_policy",
+			},
+			sessMatch: func(t *testing.T, s *user.SessionState) {
+				t.Helper()
+				assert.NotEmpty(t, s.AccessRights)
+				apiDEndpoints := user.Endpoints{
+					{
+						Path: "/get",
+						Methods: user.EndpointMethods{
+							{
+								Name: "GET",
+								Limit: user.RateLimit{
+									Rate: 20,
+									Per:  60,
+								},
+							},
+						},
+					},
+				}
+
+				assert.ElementsMatch(t, apiDEndpoints, s.AccessRights["d"].Endpoints)
+			},
+			reverseOrder: true,
+		},
+		{
+			name: "combine_non_partitioned_policies_with_endpoint_rate_limits_no_bound_configured_on_api_d",
+			policies: []string{
+				"api_d_get_endpoint_rl_1_configure_on_non_partitioned_policy",
+				"api_d_get_endpoint_rl_2_configure_on_non_partitioned_policy",
+				"api_d_get_endpoint_rl_3_configure_on_non_partitioned_policy",
+			},
+			sessMatch: func(t *testing.T, s *user.SessionState) {
+				t.Helper()
+				assert.NotEmpty(t, s.AccessRights)
+				apiDEndpoints := user.Endpoints{
+					{
+						Path: "/get",
+						Methods: user.EndpointMethods{
+							{
+								Name: "GET",
+								Limit: user.RateLimit{
+									Rate: -1,
+								},
+							},
+						},
+					},
+				}
+
+				assert.ElementsMatch(t, apiDEndpoints, s.AccessRights["d"].Endpoints)
+			},
+			reverseOrder: true,
+		},
+		{
+			name: "combine_non_partitioned_policies_with_multiple_endpoint_rate_limits_configured_on_api_d",
+			policies: []string{
+				"api_d_get_endpoint_rl_1_configure_on_non_partitioned_policy",
+				"api_d_get_endpoint_rl_2_configure_on_non_partitioned_policy",
+				"api_d_get_endpoint_rl_3_configure_on_non_partitioned_policy",
+				"api_d_post_endpoint_rl_1_configure_on_non_partitioned_policy",
+			},
+			sessMatch: func(t *testing.T, s *user.SessionState) {
+				t.Helper()
+				assert.NotEmpty(t, s.AccessRights)
+				apiDEndpoints := user.Endpoints{
+					{
+						Path: "/get",
+						Methods: user.EndpointMethods{
+							{
+								Name: "GET",
+								Limit: user.RateLimit{
+									Rate: -1,
+								},
+							},
+						},
+					},
+					{
+						Path: "/post",
+						Methods: user.EndpointMethods{
+							{
+								Name: "POST",
+								Limit: user.RateLimit{
+									Rate: 20,
+									Per:  60,
+								},
+							},
+						},
+					},
+				}
+
+				assert.ElementsMatch(t, apiDEndpoints, s.AccessRights["d"].Endpoints)
+			},
+			reverseOrder: true,
+		},
+		{
+			name: "combine_non_partitioned_policies_with_endpoint_rate_limits_configured_on_api_d_and_e",
+			policies: []string{
+				"api_d_get_endpoint_rl_1_configure_on_non_partitioned_policy",
+				"api_d_get_endpoint_rl_2_configure_on_non_partitioned_policy",
+				"api_d_get_endpoint_rl_3_configure_on_non_partitioned_policy",
+				"api_d_post_endpoint_rl_1_configure_on_non_partitioned_policy",
+				"api_e_get_endpoint_rl_1_configure_on_non_partitioned_policy",
+			},
+			sessMatch: func(t *testing.T, s *user.SessionState) {
+				t.Helper()
+				assert.NotEmpty(t, s.AccessRights)
+				apiDEndpoints := user.Endpoints{
+					{
+						Path: "/get",
+						Methods: user.EndpointMethods{
+							{
+								Name: "GET",
+								Limit: user.RateLimit{
+									Rate: -1,
+								},
+							},
+						},
+					},
+					{
+						Path: "/post",
+						Methods: user.EndpointMethods{
+							{
+								Name: "POST",
+								Limit: user.RateLimit{
+									Rate: 20,
+									Per:  60,
+								},
+							},
+						},
+					},
+				}
+
+				assert.ElementsMatch(t, apiDEndpoints, s.AccessRights["d"].Endpoints)
+
+				apiEEndpoints := user.Endpoints{
+					{
+						Path: "/get",
+						Methods: user.EndpointMethods{
+							{
+								Name: "GET",
+								Limit: user.RateLimit{
+									Rate: 100,
+									Per:  60,
+								},
+							},
+						},
+					},
+				}
+
+				assert.ElementsMatch(t, apiEEndpoints, s.AccessRights["e"].Endpoints)
+			},
+			reverseOrder: true,
+		},
+	}
+
+	tests = combinedEndpointRLTCs
 
 	return bmid, tests
 }
@@ -919,26 +1085,41 @@ func TestApplyPolicies(t *testing.T) {
 	bmid, tests := ts.testPrepareApplyPolicies(t)
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			sess := tc.session
-			if sess == nil {
-				sess = &user.SessionState{}
+		pols := [][]string{tc.policies}
+		if tc.reverseOrder {
+			var copyPols = make([]string, len(tc.policies))
+			copy(copyPols, tc.policies)
+			slices.Reverse(copyPols)
+			pols = append(pols, copyPols)
+		}
+
+		for i, policies := range pols {
+			name := tc.name
+			if i == 1 {
+				name = fmt.Sprintf("%s, reversed=%t", name, true)
 			}
-			sess.SetPolicies(tc.policies...)
-			errStr := ""
-			if err := bmid.ApplyPolicies(sess); err != nil {
-				errStr = err.Error()
-			}
-			if tc.errMatch == "" && errStr != "" {
-				t.Fatalf("didn't want err but got %s", errStr)
-			} else if !strings.Contains(errStr, tc.errMatch) {
-				t.Fatalf("error %q doesn't match %q",
-					errStr, tc.errMatch)
-			}
-			if tc.sessMatch != nil {
-				tc.sessMatch(t, sess)
-			}
-		})
+
+			t.Run(name, func(t *testing.T) {
+				sess := tc.session
+				if sess == nil {
+					sess = &user.SessionState{}
+				}
+				sess.SetPolicies(policies...)
+				errStr := ""
+				if err := bmid.ApplyPolicies(sess); err != nil {
+					errStr = err.Error()
+				}
+				if tc.errMatch == "" && errStr != "" {
+					t.Fatalf("didn't want err but got %s", errStr)
+				} else if !strings.Contains(errStr, tc.errMatch) {
+					t.Fatalf("error %q doesn't match %q",
+						errStr, tc.errMatch)
+				}
+				if tc.sessMatch != nil {
+					tc.sessMatch(t, sess)
+				}
+			})
+		}
 	}
 }
 

--- a/gateway/testdata/policies.json
+++ b/gateway/testdata/policies.json
@@ -754,10 +754,154 @@
     }
   },
   "endpoint_rate_limits_on_quota_partition_only": {
-    "id": "endpoint_rate_limits_on_rate_limit_partition_disabled",
+    "id": "endpoint_rate_limits_on_quota_partition_only",
     "quota_max": 1000,
     "quota_renews":60,
     "partitions": {
+      "quota": true
+    }
+  },
+  "api_d_get_endpoint_rl_1_configure_on_non_partitioned_policy": {
+    "id": "api_d_get_endpoint_rl_1_configure_on_non_partitioned_policy",
+    "rate": 500,
+    "per": 1,
+    "quota_max": -1,
+    "access_rights": {
+      "d": {
+        "endpoints": [
+          {
+            "path": "/get",
+            "methods": [
+              {
+                "name": "GET",
+                "limit": {
+                  "rate": 10,
+                  "per": 60
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "partitions": {
+      "acl": true,
+      "rate_limit": true,
+      "quota": true
+    }
+  },
+  "api_d_get_endpoint_rl_2_configure_on_non_partitioned_policy": {
+    "id": "api_d_get_endpoint_rl_2_configure_on_non_partitioned_policy",
+    "rate": 500,
+    "per": 1,
+    "quota_max": -1,
+    "access_rights": {
+      "d": {
+        "endpoints": [
+          {
+            "path": "/get",
+            "methods": [
+              {
+                "name": "GET",
+                "limit": {
+                  "rate": 20,
+                  "per": 60
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "partitions": {
+      "acl": true,
+      "rate_limit": true,
+      "quota": true
+    }
+  },
+  "api_d_get_endpoint_rl_3_configure_on_non_partitioned_policy": {
+    "id": "api_d_get_endpoint_rl_3_configure_on_non_partitioned_policy",
+    "rate": 500,
+    "per": 1,
+    "quota_max": -1,
+    "access_rights": {
+      "d": {
+        "endpoints": [
+          {
+            "path": "/get",
+            "methods": [
+              {
+                "name": "GET",
+                "limit": {
+                  "rate": -1
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "partitions": {
+      "acl": true,
+      "rate_limit": true,
+      "quota": true
+    }
+  },
+  "api_d_post_endpoint_rl_1_configure_on_non_partitioned_policy": {
+    "id": "api_d_post_endpoint_rl_1_configure_on_non_partitioned_policy",
+    "rate": 500,
+    "per": 1,
+    "quota_max": -1,
+    "access_rights": {
+      "d": {
+        "endpoints": [
+          {
+            "path": "/post",
+            "methods": [
+              {
+                "name": "POST",
+                "limit": {
+                  "rate": 20,
+                  "per": 60
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "partitions": {
+      "acl": true,
+      "rate_limit": true,
+      "quota": true
+    }
+  },
+  "api_e_get_endpoint_rl_1_configure_on_non_partitioned_policy": {
+    "id": "api_e_get_endpoint_rl_1_configure_on_non_partitioned_policy",
+    "rate": 500,
+    "per": 1,
+    "quota_max": -1,
+    "access_rights": {
+      "e": {
+        "endpoints": [
+          {
+            "path": "/get",
+            "methods": [
+              {
+                "name": "GET",
+                "limit": {
+                  "rate": 100,
+                  "per": 60
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "partitions": {
+      "acl": true,
+      "rate_limit": true,
       "quota": true
     }
   }

--- a/internal/policy/apply.go
+++ b/internal/policy/apply.go
@@ -444,6 +444,10 @@ func (t *Service) applyPartitions(policy user.Policy, session *user.SessionState
 
 			t.ApplyRateLimits(session, policy, &ar.Limit)
 
+			if rightsAR, ok := rights[k]; ok {
+				ar.Endpoints = t.ApplyEndpointLevelLimits(v.Endpoints, rightsAR.Endpoints)
+			}
+
 			if policy.ThrottleRetryLimit > ar.Limit.ThrottleRetryLimit {
 				ar.Limit.ThrottleRetryLimit = policy.ThrottleRetryLimit
 				if policy.ThrottleRetryLimit > session.ThrottleRetryLimit {
@@ -534,14 +538,17 @@ func (t *Service) updateSessionRootVars(session *user.SessionState, rights map[s
 }
 
 func (t *Service) applyAPILevelLimits(policyAD user.AccessDefinition, currAD user.AccessDefinition) user.AccessDefinition {
+	var updated bool
 	if policyAD.Limit.Duration() > currAD.Limit.Duration() {
 		policyAD.Limit.Per = currAD.Limit.Per
 		policyAD.Limit.Rate = currAD.Limit.Rate
 		policyAD.Limit.Smoothing = currAD.Limit.Smoothing
+		updated = true
 	}
 
-	if greaterThanInt64(currAD.Limit.QuotaMax, policyAD.Limit.QuotaMax) {
+	if currAD.Limit.QuotaMax != policyAD.Limit.QuotaMax && greaterThanInt64(currAD.Limit.QuotaMax, policyAD.Limit.QuotaMax) {
 		policyAD.Limit.QuotaMax = currAD.Limit.QuotaMax
+		updated = true
 	}
 
 	if greaterThanInt64(currAD.Limit.QuotaRenewalRate, policyAD.Limit.QuotaRenewalRate) {
@@ -552,25 +559,48 @@ func (t *Service) applyAPILevelLimits(policyAD user.AccessDefinition, currAD use
 		policyAD.Limit.QuotaRenewalRate = 0
 	}
 
-	policyAD.Endpoints = t.applyEndpointLevelLimits(policyAD.Endpoints, currAD.Endpoints)
+	if updated {
+		policyAD.Limit.SetBy = currAD.Limit.SetBy
+		policyAD.AllowanceScope = currAD.AllowanceScope
+	}
+
+	policyAD.Endpoints = t.ApplyEndpointLevelLimits(policyAD.Endpoints, currAD.Endpoints)
 
 	return policyAD
 }
 
-func (t *Service) applyEndpointLevelLimits(policyEndpoints user.Endpoints, currEndpoints user.Endpoints) user.Endpoints {
+func (t *Service) ApplyEndpointLevelLimits(policyEndpoints user.Endpoints, currEndpoints user.Endpoints) user.Endpoints {
 	currEPMap := currEndpoints.Map()
-	if currEPMap == nil {
+	if len(currEPMap) == 0 {
 		return policyEndpoints
 	}
 
-	policyEPMap := policyEndpoints.Map()
+	result := policyEndpoints.Map()
+	if len(result) == 0 {
+		return currEPMap.Endpoints()
+	}
+
 	for currEP, currRL := range currEPMap {
-		if policyRL, ok := policyEPMap[currEP]; ok {
-			if policyRL.Duration() > currRL.Duration() {
-				policyEPMap[currEP] = currRL
-			}
+		policyRL, ok := result[currEP]
+		if !ok {
+			// merge missing endpoints
+			result[currEP] = currRL
+			continue
+		}
+
+		policyDur, currDur := policyRL.Duration(), currRL.Duration()
+		if policyDur > currDur {
+			result[currEP] = currRL
+			continue
+		}
+
+		// when duration is equal, use higher rate and per
+		// eg. when 10 per 60 and 5 per 30 comes in
+		// Duration would be 6s each, in such a case higher rate of 10 per 60 would be picked up.
+		if policyDur == currDur && currRL.Rate > policyRL.Rate {
+			result[currEP] = currRL
 		}
 	}
 
-	return policyEPMap.Endpoints()
+	return result.Endpoints()
 }

--- a/internal/policy/apply.go
+++ b/internal/policy/apply.go
@@ -569,6 +569,10 @@ func (t *Service) applyAPILevelLimits(policyAD user.AccessDefinition, currAD use
 	return policyAD
 }
 
+// ApplyEndpointLevelLimits combines policyEndpoints and currEndpoints and returns the combined value.
+// The returned endpoints would have the highest request rate from policyEndpoints and currEndpoints.
+// If both policyEndpoints and currEndpoints have an endpoint with same request duration but with different rate and per,
+// the rate limit with higher rate would be picked.
 func (t *Service) ApplyEndpointLevelLimits(policyEndpoints user.Endpoints, currEndpoints user.Endpoints) user.Endpoints {
 	currEPMap := currEndpoints.Map()
 	if len(currEPMap) == 0 {

--- a/internal/policy/apply.go
+++ b/internal/policy/apply.go
@@ -571,8 +571,6 @@ func (t *Service) applyAPILevelLimits(policyAD user.AccessDefinition, currAD use
 
 // ApplyEndpointLevelLimits combines policyEndpoints and currEndpoints and returns the combined value.
 // The returned endpoints would have the highest request rate from policyEndpoints and currEndpoints.
-// If both policyEndpoints and currEndpoints have an endpoint with same request duration but with different rate and per,
-// the rate limit with higher rate would be picked.
 func (t *Service) ApplyEndpointLevelLimits(policyEndpoints user.Endpoints, currEndpoints user.Endpoints) user.Endpoints {
 	currEPMap := currEndpoints.Map()
 	if len(currEPMap) == 0 {

--- a/internal/policy/apply_test.go
+++ b/internal/policy/apply_test.go
@@ -1,6 +1,8 @@
 package policy_test
 
 import (
+	"embed"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,6 +10,9 @@ import (
 	"github.com/TykTechnologies/tyk/internal/policy"
 	"github.com/TykTechnologies/tyk/user"
 )
+
+//go:embed testdata/*.json
+var testDataFS embed.FS
 
 func TestApplyRateLimits_PolicyLimits(t *testing.T) {
 	svc := &policy.Service{}
@@ -128,4 +133,27 @@ func TestApplyRateLimits_FromCustomPolicies(t *testing.T) {
 
 		assert.Equal(t, 10, int(session.Rate))
 	})
+}
+
+func TestApplyEndpointLevelLimits(t *testing.T) {
+	f, err := testDataFS.ReadFile("testdata/apply_endpoint_rl.json")
+	assert.NoError(t, err)
+
+	var testCases []struct {
+		Name     string         `json:"name"`
+		PolicyEP user.Endpoints `json:"policyEP"`
+		CurrEP   user.Endpoints `json:"currEP"`
+		Expected user.Endpoints `json:"expected"`
+	}
+	err = json.Unmarshal(f, &testCases)
+	assert.NoError(t, err)
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			service := policy.Service{}
+			result := service.ApplyEndpointLevelLimits(tc.PolicyEP, tc.CurrEP)
+			assert.ElementsMatch(t, tc.Expected, result)
+		})
+	}
+
 }

--- a/internal/policy/testdata/apply_endpoint_rl.json
+++ b/internal/policy/testdata/apply_endpoint_rl.json
@@ -1,0 +1,264 @@
+[
+  {
+    "name": "both empty",
+    "policyEP": [],
+    "currEP": [],
+    "expected": []
+  },
+  {
+    "name": "policy endpoints empty",
+    "policyEP": [],
+    "currEP": [
+      {
+        "path": "/user",
+        "methods": [
+          {
+            "name": "GET",
+            "limit": {
+              "rate": 10,
+              "per": 60
+            }
+          }
+        ]
+      }
+    ],
+    "expected": [
+      {
+        "path": "/user",
+        "methods": [
+          {
+            "name": "GET",
+            "limit": {
+              "rate": 10,
+              "per": 60
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "curr endpoints empty",
+    "policyEP": [
+      {
+        "path": "/user",
+        "methods": [
+          {
+            "name": "GET",
+            "limit": {
+              "rate": 10,
+              "per": 60
+            }
+          }
+        ]
+      }
+    ],
+    "currEP": [],
+    "expected": [
+      {
+        "path": "/user",
+        "methods": [
+          {
+            "name": "GET",
+            "limit": {
+              "rate": 10,
+              "per": 60
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "non overlapping endpoints",
+    "policyEP": [
+      {
+        "path": "/user",
+        "methods": [
+          {
+            "name": "GET",
+            "limit": {
+              "rate": 10,
+              "per": 60
+            }
+          }
+        ]
+      }
+    ],
+    "currEP": [
+      {
+        "path": "/admin",
+        "methods": [
+          {
+            "name": "POST",
+            "limit": {
+              "rate": 5,
+              "per": 30
+            }
+          }
+        ]
+      }
+    ],
+    "expected": [
+      {
+        "path": "/user",
+        "methods": [
+          {
+            "name": "GET",
+            "limit": {
+              "rate": 10,
+              "per": 60
+            }
+          }
+        ]
+      },
+      {
+        "path": "/admin",
+        "methods": [
+          {
+            "name": "POST",
+            "limit": {
+              "rate": 5,
+              "per": 30
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "overlapping endpoints with different limits #1",
+    "policyEP": [
+      {
+        "path": "/user",
+        "methods": [
+          {
+            "name": "GET",
+            "limit": {
+              "rate": 10,
+              "per": 60
+            }
+          }
+        ]
+      }
+    ],
+    "currEP": [
+      {
+        "path": "/user",
+        "methods": [
+          {
+            "name": "GET",
+            "limit": {
+              "rate": 5,
+              "per": 30
+            }
+          }
+        ]
+      }
+    ],
+    "expected": [
+      {
+        "path": "/user",
+        "methods": [
+          {
+            "name": "GET",
+            "limit": {
+              "rate": 10,
+              "per": 60
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "overlapping endpoints with different limits #2",
+    "currEP": [
+      {
+        "path": "/user",
+        "methods": [
+          {
+            "name": "GET",
+            "limit": {
+              "rate": 10,
+              "per": 60
+            }
+          }
+        ]
+      }
+    ],
+    "policyEP": [
+      {
+        "path": "/user",
+        "methods": [
+          {
+            "name": "GET",
+            "limit": {
+              "rate": 5,
+              "per": 30
+            }
+          }
+        ]
+      }
+    ],
+    "expected": [
+      {
+        "path": "/user",
+        "methods": [
+          {
+            "name": "GET",
+            "limit": {
+              "rate": 10,
+              "per": 60
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "overlapping endpoints with same limits",
+    "policyEP": [
+      {
+        "path": "/user",
+        "methods": [
+          {
+            "name": "GET",
+            "limit": {
+              "rate": 10,
+              "per": 60
+            }
+          }
+        ]
+      }
+    ],
+    "currEP": [
+      {
+        "path": "/user",
+        "methods": [
+          {
+            "name": "GET",
+            "limit": {
+              "rate": 10,
+              "per": 60
+            }
+          }
+        ]
+      }
+    ],
+    "expected": [
+      {
+        "path": "/user",
+        "methods": [
+          {
+            "name": "GET",
+            "limit": {
+              "rate": 10,
+              "per": 60
+            }
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION

## Description
This PR would allow combining endpoint rate limits by combining multiple non partitioned policies.

## Related Issue
Jira: https://tyktech.atlassian.net/browse/TT-13011

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Tests, Enhancement


___

### **Description**
- Enhanced the policy application logic to support combining endpoint rate limits from non-partitioned policies.
- Added comprehensive tests to verify the correct application of endpoint rate limits when combining multiple policies.
- Introduced new test data and updated existing test policies to cover various scenarios of endpoint rate limits.
- Modified the `applyAPILevelLimits` function to ensure correct updating of `SetBy` and `AllowanceScope` attributes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>policy_test.go</strong><dd><code>Enhance policy tests to include endpoint rate limits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/policy_test.go

<li>Added <code>reverseOrder</code> field to <code>testApplyPoliciesData</code> struct.<br> <li> Implemented tests for combining non-partitioned policies with endpoint <br>rate limits.<br> <li> Modified test logic to handle reversed policy order.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6494/files#diff-40d701767204255c38c7dd64939d6bb8df621640c4bddfe5f56080380476a18a">+235/-54</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>apply_test.go</strong><dd><code>Add tests for endpoint level limits application</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/policy/apply_test.go

<li>Added new test <code>TestApplyEndpointLevelLimits</code>.<br> <li> Embedded test data for endpoint rate limits.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6494/files#diff-5af7e299a6b0ce11e22f8aa4a01854b1151f4b54dccc68f0cd1cbedee5aed7c8">+28/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>policies.json</strong><dd><code>Update test policies with endpoint rate limits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/testdata/policies.json

<li>Added new policies for testing endpoint rate limits.<br> <li> Updated existing policy identifiers.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6494/files#diff-d20906fb23674ef58fee794635f5c1f668eb36f9dc4ce0f4b7d3dbd816e13eb5">+146/-2</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>apply_endpoint_rl.json</strong><dd><code>Add test data for endpoint rate limits application</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/policy/testdata/apply_endpoint_rl.json

- Added test cases for applying endpoint rate limits.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6494/files#diff-81bc9ec6c0a3fd3589d72bb74582835c17c22f83ce2acec38acc07091581d3e4">+264/-0</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>apply.go</strong><dd><code>Implement endpoint level limits application in policies</code>&nbsp; &nbsp; </dd></summary>
<hr>

internal/policy/apply.go

<li>Added logic to apply endpoint level limits when combining policies.<br> <li> Modified <code>applyAPILevelLimits</code> to update <code>SetBy</code> and <code>AllowanceScope</code>.<br> <li> Renamed <code>applyEndpointLevelLimits</code> to <code>ApplyEndpointLevelLimits</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6494/files#diff-59b92e9d31f142f1d99b746eb3ff7db4e26bf6c3044c9b87b58034a947ee04d1">+40/-10</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

