### PR TITLE
[TT-13048] Flaky test due to using httpbin org, improvements

### DIFF
--- a/docker/services/httpbin.yml
+++ b/docker/services/httpbin.yml
@@ -4,12 +4,14 @@ services:
     image: tykio/ci-tools:latest
     networks:
       - proxy
+    ports:
+      - 3123:3123
     volumes:
       - ./logs:/logs:rw
     entrypoint:
       - /usr/local/bin/httpbin-logserver
     command:
       - '-addr'
-      - ':80'
+      - ':3123'
       - '-output'
       - '/logs/service.json'

--- a/tests/regression/issue_10104_test.go
+++ b/tests/regression/issue_10104_test.go
@@ -10,7 +10,7 @@ import (
 
 func Test_Issue10104(t *testing.T) {
 	ts := gateway.StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	// load api definition from file
 	ts.Gw.LoadAPI(loadAPISpec(t, "testdata/issue-10104-apidef.json"))

--- a/tests/regression/issue_11585_test.go
+++ b/tests/regression/issue_11585_test.go
@@ -17,7 +17,7 @@ import (
 func Test_Issue11585_DeleteAPICacheSignal(t *testing.T) {
 	t.Run("redis event", func(t *testing.T) {
 		ts := gateway.StartTest(nil)
-		defer ts.Close()
+		t.Cleanup(ts.Close)
 
 		api := ts.Gw.BuildAndLoadAPI(func(spec *gateway.APISpec) {
 			spec.UseKeylessAccess = true
@@ -49,7 +49,7 @@ func Test_Issue11585_DeleteAPICacheSignal(t *testing.T) {
 
 	t.Run("rpc", func(t *testing.T) {
 		ts := gateway.StartTest(nil)
-		defer ts.Close()
+		t.Cleanup(ts.Close)
 
 		rpcListener := gateway.RPCStorageHandler{
 			KeyPrefix:        "rpc.listener.",

--- a/tests/regression/issue_11806_test.go
+++ b/tests/regression/issue_11806_test.go
@@ -25,7 +25,7 @@ func Test_Issue11806_DomainRouting(t *testing.T) {
 
 	t.Run("Load listenPath without domain first", func(t *testing.T) {
 		ts := gateway.StartTest(testConfig)
-		defer ts.Close()
+		t.Cleanup(ts.Close)
 
 		ts.Gw.LoadAPI(noDomain, withDomain)
 
@@ -34,7 +34,7 @@ func Test_Issue11806_DomainRouting(t *testing.T) {
 
 	t.Run("Load listenPath with domain first", func(t *testing.T) {
 		ts := gateway.StartTest(testConfig)
-		defer ts.Close()
+		t.Cleanup(ts.Close)
 
 		ts.Gw.LoadAPI(withDomain, noDomain)
 
@@ -62,10 +62,10 @@ func testDomainRouting(tb testing.TB, ts *gateway.Test) {
 		},
 		{
 			Path:      "/test/",
-			Host:      "customer.mydomain.com",
+			Host:      "example.com",
 			Method:    http.MethodGet,
 			Code:      http.StatusOK,
-			BodyMatch: "customer.mydomain.com",
+			BodyMatch: "example.com",
 		},
 	}...)
 }
@@ -80,7 +80,7 @@ func testSubrouterHost(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a subrouter with a specific host
-	subrouter := router.Host("customer.mydomain.com").Subrouter()
+	subrouter := router.Host("example.com").Subrouter()
 	subrouter.HandleFunc("/test", func(w http.ResponseWriter, _ *http.Request) {
 		_, err := w.Write([]byte("Subrouter"))
 		assert.NoError(t, err)
@@ -117,7 +117,7 @@ func testSubrouterHost(t *testing.T) {
 	reqWithSpecificHost, err := http.NewRequestWithContext(ctx, "GET", "/test", nil)
 	assert.NoError(t, err)
 
-	reqWithSpecificHost.Host = "customer.mydomain.com"
+	reqWithSpecificHost.Host = "example.com"
 	respWithSpecificHost := httptest.NewRecorder()
 	router.ServeHTTP(respWithSpecificHost, reqWithSpecificHost)
 	if respWithSpecificHost.Body.String() != "Subrouter" {
@@ -131,7 +131,7 @@ func testRouteLongestPathFirst(t *testing.T) {
 	ts := gateway.StartTest(func(globalConf *config.Config) {
 		globalConf.EnableCustomDomains = true
 	})
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	type hostAndPath struct {
 		host, path string

--- a/tests/regression/regression_test.go
+++ b/tests/regression/regression_test.go
@@ -3,6 +3,7 @@ package regression
 import (
 	"embed"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -24,6 +25,9 @@ func loadAPISpec(tb testing.TB, filename string) *gateway.APISpec {
 	apidef := &apidef.APIDefinition{}
 	err := json.Unmarshal(data, apidef)
 	require.NoError(tb, err, "Error decoding API Definition: %s", filename)
+
+	// auto replace from public to private endpoint, part of CI env
+	apidef.Proxy.ListenPath = strings.ReplaceAll(apidef.Proxy.ListenPath, "httpbin.org", "127.0.0.1:3123")
 
 	return &gateway.APISpec{
 		APIDefinition: apidef,

--- a/tests/regression/testdata/issue-11806-api-with-domain.json
+++ b/tests/regression/testdata/issue-11806-api-with-domain.json
@@ -4,12 +4,12 @@
   "auth": {
     "auth_header_name": "Authorization"
   },
-  "domain": "customer.mydomain.com",
+  "domain": "example.com",
   "name": "api3",
   "proxy": {
     "listen_path": "/test/",
     "strip_listen_path": true,
-    "target_url": "http://httpbin.org/anything/api3/customer.mydomain.com"
+    "target_url": "http://httpbin.org/anything/api3/example.com"
   },
   "use_keyless": true,
   "version_data": {


### PR DESCRIPTION
Using httpbin.org is coupling our CI to their SLA, causing failing tests.

Test only change for:

- testing httpbin exposed on 3123
- fixes tests/regression flakyness due to httpbin.org usage
- t.Cleanup cleanup instead of defering server close in area (limited scope)

https://tyktech.atlassian.net/browse/TT-13048