### PR TITLE
Merging to release-5.3: [TT-13048] Flaky test due to using httpbin org, improvements (#6504)

### DIFF
--- a/docker/services/httpbin.yml
+++ b/docker/services/httpbin.yml
@@ -4,12 +4,14 @@ services:
     image: tykio/ci-tools:latest
     networks:
       - proxy
+    ports:
+      - 3123:3123
     volumes:
       - ./logs:/logs:rw
     entrypoint:
       - /usr/local/bin/httpbin-logserver
     command:
       - '-addr'
-      - ':80'
+      - ':3123'
       - '-output'
       - '/logs/service.json'

--- a/tests/regression/issue_10104_test.go
+++ b/tests/regression/issue_10104_test.go
@@ -10,7 +10,7 @@ import (
 
 func Test_Issue10104(t *testing.T) {
 	ts := gateway.StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	// load api definition from file
 	ts.Gw.LoadAPI(loadAPISpec(t, "testdata/issue-10104-apidef.json"))

--- a/tests/regression/issue_11585_test.go
+++ b/tests/regression/issue_11585_test.go
@@ -17,7 +17,7 @@ import (
 func Test_Issue11585_DeleteAPICacheSignal(t *testing.T) {
 	t.Run("redis event", func(t *testing.T) {
 		ts := gateway.StartTest(nil)
-		defer ts.Close()
+		t.Cleanup(ts.Close)
 
 		api := ts.Gw.BuildAndLoadAPI(func(spec *gateway.APISpec) {
 			spec.UseKeylessAccess = true
@@ -49,7 +49,7 @@ func Test_Issue11585_DeleteAPICacheSignal(t *testing.T) {
 
 	t.Run("rpc", func(t *testing.T) {
 		ts := gateway.StartTest(nil)
-		defer ts.Close()
+		t.Cleanup(ts.Close)
 
 		rpcListener := gateway.RPCStorageHandler{
 			KeyPrefix:        "rpc.listener.",

--- a/tests/regression/issue_11806_test.go
+++ b/tests/regression/issue_11806_test.go
@@ -25,7 +25,7 @@ func Test_Issue11806_DomainRouting(t *testing.T) {
 
 	t.Run("Load listenPath without domain first", func(t *testing.T) {
 		ts := gateway.StartTest(testConfig)
-		defer ts.Close()
+		t.Cleanup(ts.Close)
 
 		ts.Gw.LoadAPI(noDomain, withDomain)
 
@@ -34,7 +34,7 @@ func Test_Issue11806_DomainRouting(t *testing.T) {
 
 	t.Run("Load listenPath with domain first", func(t *testing.T) {
 		ts := gateway.StartTest(testConfig)
-		defer ts.Close()
+		t.Cleanup(ts.Close)
 
 		ts.Gw.LoadAPI(withDomain, noDomain)
 
@@ -62,10 +62,10 @@ func testDomainRouting(tb testing.TB, ts *gateway.Test) {
 		},
 		{
 			Path:      "/test/",
-			Host:      "customer.mydomain.com",
+			Host:      "example.com",
 			Method:    http.MethodGet,
 			Code:      http.StatusOK,
-			BodyMatch: "customer.mydomain.com",
+			BodyMatch: "example.com",
 		},
 	}...)
 }
@@ -80,7 +80,7 @@ func testSubrouterHost(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a subrouter with a specific host
-	subrouter := router.Host("customer.mydomain.com").Subrouter()
+	subrouter := router.Host("example.com").Subrouter()
 	subrouter.HandleFunc("/test", func(w http.ResponseWriter, _ *http.Request) {
 		_, err := w.Write([]byte("Subrouter"))
 		assert.NoError(t, err)
@@ -117,7 +117,7 @@ func testSubrouterHost(t *testing.T) {
 	reqWithSpecificHost, err := http.NewRequestWithContext(ctx, "GET", "/test", nil)
 	assert.NoError(t, err)
 
-	reqWithSpecificHost.Host = "customer.mydomain.com"
+	reqWithSpecificHost.Host = "example.com"
 	respWithSpecificHost := httptest.NewRecorder()
 	router.ServeHTTP(respWithSpecificHost, reqWithSpecificHost)
 	if respWithSpecificHost.Body.String() != "Subrouter" {
@@ -131,7 +131,7 @@ func testRouteLongestPathFirst(t *testing.T) {
 	ts := gateway.StartTest(func(globalConf *config.Config) {
 		globalConf.EnableCustomDomains = true
 	})
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	type hostAndPath struct {
 		host, path string

--- a/tests/regression/regression_test.go
+++ b/tests/regression/regression_test.go
@@ -3,6 +3,7 @@ package regression
 import (
 	"embed"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -24,6 +25,9 @@ func loadAPISpec(tb testing.TB, filename string) *gateway.APISpec {
 	apidef := &apidef.APIDefinition{}
 	err := json.Unmarshal(data, apidef)
 	require.NoError(tb, err, "Error decoding API Definition: %s", filename)
+
+	// auto replace from public to private endpoint, part of CI env
+	apidef.Proxy.ListenPath = strings.ReplaceAll(apidef.Proxy.ListenPath, "httpbin.org", "127.0.0.1:3123")
 
 	return &gateway.APISpec{
 		APIDefinition: apidef,

--- a/tests/regression/testdata/issue-11806-api-with-domain.json
+++ b/tests/regression/testdata/issue-11806-api-with-domain.json
@@ -4,12 +4,12 @@
   "auth": {
     "auth_header_name": "Authorization"
   },
-  "domain": "customer.mydomain.com",
+  "domain": "example.com",
   "name": "api3",
   "proxy": {
     "listen_path": "/test/",
     "strip_listen_path": true,
-    "target_url": "http://httpbin.org/anything/api3/customer.mydomain.com"
+    "target_url": "http://httpbin.org/anything/api3/example.com"
   },
   "use_keyless": true,
   "version_data": {


### PR DESCRIPTION
### **User description**
[TT-13048] Flaky test due to using httpbin org, improvements (#6504)

Using httpbin.org is coupling our CI to their SLA, causing failing
tests.

Test only change for:

- testing httpbin exposed on 3123
- fixes tests/regression flakyness due to httpbin.org usage
- t.Cleanup cleanup instead of defering server close in area (limited
scope)

https://tyktech.atlassian.net/browse/TT-13048

---------

Co-authored-by: Tit Petric <tit@tyk.io>

[TT-13048]: https://tyktech.atlassian.net/browse/TT-13048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Tests


___

### **Description**
- Improved test cleanup by replacing `defer` with `t.Cleanup` in multiple test files.
- Updated domain references from "customer.mydomain.com" to "example.com" in tests and API definitions.
- Modified httpbin service configuration to use port 3123 instead of 80.
- Adjusted API spec loading to replace public endpoints with private ones for CI environments.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>issue_10104_test.go</strong><dd><code>Improve test cleanup using t.Cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/regression/issue_10104_test.go

<li>Replaced <code>defer ts.Close()</code> with <code>t.Cleanup(ts.Close)</code> for better test <br>cleanup.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6505/files#diff-fc9eecfe93848b08071a184af53473165b641230bccba931e8abbed89ac03d82">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>issue_11585_test.go</strong><dd><code>Enhance test cleanup with t.Cleanup in issue_11585_test</code>&nbsp; &nbsp; </dd></summary>
<hr>

tests/regression/issue_11585_test.go

<li>Replaced <code>defer ts.Close()</code> with <code>t.Cleanup(ts.Close)</code> in multiple test <br>cases.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6505/files#diff-e99a72da54bd070d11803d8a35638c89665a2efe0af67c2fe5f28de69c863fe7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>issue_11806_test.go</strong><dd><code>Improve test cleanup and update domain in issue_11806_test</code></dd></summary>
<hr>

tests/regression/issue_11806_test.go

<li>Replaced <code>defer ts.Close()</code> with <code>t.Cleanup(ts.Close)</code> in multiple test <br>cases.<br> <li> Updated host from "customer.mydomain.com" to "example.com".<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6505/files#diff-6414917e8c31f924c3a423765e285a34d988e923bd0f10d5cc56bacad99195d8">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>regression_test.go</strong><dd><code>Modify API spec loading for CI environment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/regression/regression_test.go

<li>Added string replacement to change public endpoint to private in CI <br>environment.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6505/files#diff-24d0ac1f4eb4bb6e33d0db26aca8ef96aef2b67fd2730fcde6e952ce3d894696">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>issue-11806-api-with-domain.json</strong><dd><code>Update domain and target URL in API definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/regression/testdata/issue-11806-api-with-domain.json

- Updated domain and target URL to use "example.com".



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6505/files#diff-f2b780fe118cacccbfe27e8784d7d2bae3cdc20f37c7bdccb4cf8146c9e6187b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>httpbin.yml</strong><dd><code>Update httpbin service port configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker/services/httpbin.yml

- Changed service port from 80 to 3123.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6505/files#diff-1a1b1d8bf4798076a41ca5f3bba0d465dc387e58b6593adbb28a4d5fe60eb810">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

