### PR TITLE
[TT-12865] Rename config parameter, update usage, support mux params on legacy

### DIFF
--- a/.taskfiles/test.yml
+++ b/.taskfiles/test.yml
@@ -44,7 +44,7 @@ tasks:
       package:
         sh: go mod edit -json | jq .Module.Path -r
       packages:
-        sh: go list ./... | sed -e 's|{{.package}}|.|g'
+        sh: go list ./... | tail -n +2 | sed -e 's|{{.package}}|.|g'
     cmds:
       - defer: { task: services:down }
       - rm -rf coverage && mkdir -p coverage

--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -550,10 +550,10 @@
         "enable_strict_routes": {
           "type": "boolean"
         },
-        "enable_prefix_matching": {
+        "enable_path_prefix_matching": {
           "type": "boolean"
         },
-        "enable_suffix_matching": {
+        "enable_path_suffix_matching": {
           "type": "boolean"
         },
         "flush_interval": {

--- a/config/config.go
+++ b/config/config.go
@@ -408,7 +408,7 @@ type HttpServerOptionsConfig struct {
 	// Regular expressions and parameterized routes will be left alone regardless of this setting.
 	EnableStrictRoutes bool `json:"enable_strict_routes"`
 
-	// EnablePrefixMatching changes the URL matching from wildcard mode to prefix mode.
+	// EnablePathPrefixMatching changes the URL matching from wildcard mode to prefix mode.
 	// For example, `/json` matches `*/json*` by current default behaviour.
 	// If prefix matching is enabled, the match will be performed as a prefix match (`/json*`).
 	//
@@ -423,16 +423,16 @@ type HttpServerOptionsConfig struct {
 	// - Full listen path and endpoint (`/listen-path/json`)
 	// - Stripped listen path (`/json`) - match.
 	//
-	// For inputs that start with `/`, a prefix match is ensured by prepending
-	// the start of string `^` caret.
+	// For inputs that start with `/`, a prefix match is ensured by
+	// prepending the start of string `^` caret.
 	//
 	// For all other cases, the pattern remains unmodified.
 	//
-	// Combine this option with EnableSuffixMatching to achieve strict
-	// url matching with `/json` being evaluated as `^/json$`.
-	EnablePrefixMatching bool `json:"enable_prefix_matching"`
+	// Combine this option with `enable_path_suffix_matching` to achieve
+	// exact url matching with `/json` being evaluated as `^/json$`.
+	EnablePathPrefixMatching bool `json:"enable_path_prefix_matching"`
 
-	// EnableSuffixMatching changes the URL matching to match as a suffix.
+	// EnablePathSuffixMatching changes the URL matching to match as a suffix.
 	// For example: `/json` is matched as `/json$` against the following paths:
 	//
 	// - Full listen path and versioning URL (`/listen-path/v4/json`)
@@ -444,12 +444,12 @@ type HttpServerOptionsConfig struct {
 	// - Full listen path and endpoint (`/listen-path/json`)
 	// - Stripped listen path (`/json`) - match.
 	//
-	// If the input pattern already ends with a `$` (`/json$`) then
-	// the pattern remains unmodified.
+	// If the input pattern already ends with a `$` (`/json$`)
+	// then the pattern remains unmodified.
 	//
-	// Combine this option with EnablePrefixMatching to achieve strict
-	// url matching with `/json` being evaluated as `^/json$`.
-	EnableSuffixMatching bool `json:"enable_suffix_matching"`
+	// Combine this option with `enable_path_prefix_matching` to achieve
+	// exact url matching with `/json` being evaluated as `^/json$`.
+	EnablePathSuffixMatching bool `json:"enable_path_suffix_matching"`
 
 	// Disable TLS verification. Required if you are using self-signed certificates.
 	SSLInsecureSkipVerify bool `json:"ssl_insecure_skip_verify"`

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -824,8 +824,8 @@ func (a APIDefinitionLoader) generateRegex(stringSpec string, newSpec *URLSpec, 
 		err     error
 	)
 	// Hook per-api settings here via newSpec *URLSpec
-	isPrefixMatch := conf.HttpServerOptions.EnablePrefixMatching
-	isSuffixMatch := conf.HttpServerOptions.EnableSuffixMatching
+	isPrefixMatch := conf.HttpServerOptions.EnablePathPrefixMatching
+	isSuffixMatch := conf.HttpServerOptions.EnablePathSuffixMatching
 	isIgnoreCase := newSpec.IgnoreCase || conf.IgnoreEndpointCase
 
 	pattern = httputil.PreparePathRegexp(stringSpec, isPrefixMatch, isSuffixMatch)

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -419,7 +419,7 @@ func TestConflictingPaths(t *testing.T) {
 
 func TestIgnored(t *testing.T) {
 	ts := StartTest(func(c *config.Config) {
-		c.HttpServerOptions.EnablePrefixMatching = true
+		c.HttpServerOptions.EnablePathPrefixMatching = true
 	})
 	defer ts.Close()
 

--- a/gateway/mw_granular_access.go
+++ b/gateway/mw_granular_access.go
@@ -41,8 +41,8 @@ func (m *GranularAccessMiddleware) ProcessRequest(w http.ResponseWriter, r *http
 	gwConfig := m.Gw.GetConfig()
 
 	// Hook per-api settings here (m.Spec...)
-	isPrefixMatch := gwConfig.HttpServerOptions.EnablePrefixMatching
-	isSuffixMatch := gwConfig.HttpServerOptions.EnableSuffixMatching
+	isPrefixMatch := gwConfig.HttpServerOptions.EnablePathPrefixMatching
+	isSuffixMatch := gwConfig.HttpServerOptions.EnablePathSuffixMatching
 
 	if isPrefixMatch {
 		urlPaths := []string{
@@ -97,13 +97,7 @@ func (m *GranularAccessMiddleware) ProcessRequest(w http.ResponseWriter, r *http
 			continue
 		}
 
-		pattern := accessSpec.URL
-
-		// Extends legacy by honoring isSuffixMatch.
-		// Append $ if so configured to match end of request path.
-		if isSuffixMatch && !strings.HasSuffix(pattern, "$") {
-			pattern += "$"
-		}
+		pattern := httputil.PreparePathRegexp(accessSpec.URL, false, isSuffixMatch)
 
 		logger.Debug("Checking: ", urlPath, " Against:", pattern)
 

--- a/gateway/mw_granular_access_test.go
+++ b/gateway/mw_granular_access_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestGranularAccessMiddleware_ProcessRequest(t *testing.T) {
 	g := StartTest(func(c *config.Config) {
-		c.HttpServerOptions.EnablePrefixMatching = true
+		c.HttpServerOptions.EnablePathPrefixMatching = true
 	})
 	defer g.Close()
 

--- a/gateway/session_manager.go
+++ b/gateway/session_manager.go
@@ -230,8 +230,8 @@ func (sfr sessionFailReason) String() string {
 
 func (l *SessionLimiter) RateLimitInfo(r *http.Request, api *APISpec, endpoints user.Endpoints) (*user.EndpointRateLimitInfo, bool) {
 	// Hook per-api settings here (m.Spec...)
-	isPrefixMatch := l.config.HttpServerOptions.EnablePrefixMatching
-	isSuffixMatch := l.config.HttpServerOptions.EnableSuffixMatching
+	isPrefixMatch := l.config.HttpServerOptions.EnablePathPrefixMatching
+	isSuffixMatch := l.config.HttpServerOptions.EnablePathSuffixMatching
 
 	urlPaths := []string{
 		api.StripListenPath(r.URL.Path),

--- a/tests/regression/issue_12865_test.go
+++ b/tests/regression/issue_12865_test.go
@@ -14,8 +14,8 @@ import (
 func Test_Issue12865(t *testing.T) {
 	t.Run("Wildcard", func(t *testing.T) {
 		ts := gateway.StartTest(func(c *config.Config) {
-			c.HttpServerOptions.EnablePrefixMatching = false
-			c.HttpServerOptions.EnableSuffixMatching = false
+			c.HttpServerOptions.EnablePathPrefixMatching = false
+			c.HttpServerOptions.EnablePathSuffixMatching = false
 		})
 		defer ts.Close()
 
@@ -53,8 +53,8 @@ func Test_Issue12865(t *testing.T) {
 
 	t.Run("Prefix", func(t *testing.T) {
 		ts := gateway.StartTest(func(c *config.Config) {
-			c.HttpServerOptions.EnablePrefixMatching = true
-			c.HttpServerOptions.EnableSuffixMatching = false
+			c.HttpServerOptions.EnablePathPrefixMatching = true
+			c.HttpServerOptions.EnablePathSuffixMatching = false
 		})
 		defer ts.Close()
 
@@ -92,8 +92,8 @@ func Test_Issue12865(t *testing.T) {
 
 	t.Run("Prefix and Suffix", func(t *testing.T) {
 		ts := gateway.StartTest(func(c *config.Config) {
-			c.HttpServerOptions.EnablePrefixMatching = true
-			c.HttpServerOptions.EnableSuffixMatching = true
+			c.HttpServerOptions.EnablePathPrefixMatching = true
+			c.HttpServerOptions.EnablePathSuffixMatching = true
 		})
 		defer ts.Close()
 
@@ -131,8 +131,8 @@ func Test_Issue12865(t *testing.T) {
 
 	t.Run("Suffix", func(t *testing.T) {
 		ts := gateway.StartTest(func(c *config.Config) {
-			c.HttpServerOptions.EnablePrefixMatching = false
-			c.HttpServerOptions.EnableSuffixMatching = true
+			c.HttpServerOptions.EnablePathPrefixMatching = false
+			c.HttpServerOptions.EnablePathSuffixMatching = true
 		})
 		defer ts.Close()
 


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Renamed configuration fields `EnablePrefixMatching` and `EnableSuffixMatching` to `EnablePathPrefixMatching` and `EnablePathSuffixMatching` respectively, across multiple files.
- Updated comments and documentation to reflect the new naming conventions.
- Modified test cases to use the updated configuration fields.
- Refactored middleware and session manager logic to accommodate the new path matching configuration.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.go</strong><dd><code>Rename configuration fields for path matching options</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/config.go

<li>Renamed <code>EnablePrefixMatching</code> to <code>EnablePathPrefixMatching</code>.<br> <li> Renamed <code>EnableSuffixMatching</code> to <code>EnablePathSuffixMatching</code>.<br> <li> Updated comments to reflect the new naming conventions.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6506/files#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17">+12/-12</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>api_definition.go</strong><dd><code>Update API definition to use new path matching config</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_definition.go

<li>Updated variable names to use new path matching configuration fields.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6506/files#diff-0cf80174bbafb36f6d4f4308ebbd971b2833b76a936bad568220aa1a4ba0ee8b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_granular_access.go</strong><dd><code>Refactor middleware to use updated path matching config</code>&nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_granular_access.go

<li>Updated variable names to use new path matching configuration fields.<br> <li> Refactored pattern preparation using <code>PreparePathRegexp</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6506/files#diff-618f7d55751d572562a29506a13beba2da969436e974f8b51df7d9708c925436">+3/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>session_manager.go</strong><dd><code>Update session manager for new path matching config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/session_manager.go

<li>Updated variable names to use new path matching configuration fields.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6506/files#diff-e6b40a285464cd86736e970c4c0b320b44c75b18b363d38c200e9a9d36cdabb6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>schema.json</strong><dd><code>Update JSON schema for path matching configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/linter/schema.json

- Renamed JSON schema fields for path matching options.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6506/files#diff-103cec746d3e61d391c5a67c171963f66fea65d651d704d5540e60aa5d574f46">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api_definition_test.go</strong><dd><code>Update test configuration for path prefix matching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_definition_test.go

- Modified test configuration to use `EnablePathPrefixMatching`.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6506/files#diff-2394daab6fdc5f8dc234699c80c0548947ee3d68d2e33858258d73a8b5eb6f44">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_granular_access_test.go</strong><dd><code>Update middleware test for path prefix matching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_granular_access_test.go

- Modified test configuration to use `EnablePathPrefixMatching`.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6506/files#diff-8e0d7cfef26688edd7d08334d955039dab5deb3caf860d29eff6d09894eaba20">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

