### PR TITLE
[TT-12494] Fix flaky TestCacheEtag and related cache tests

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -94,6 +94,7 @@ jobs:
           pip install google
           pip install 'protobuf==4.24.4'
 
+          task --version
           task lint
 
           git add --all
@@ -125,7 +126,7 @@ jobs:
       - name: Run Gateway Tests
         id: ci-tests
         run: |
-          task test:e2e args="-race -timeout=15m"
+          task test:e2e-combined args="-race -timeout=15m"
           task test:coverage
 
       # golangci-lint actions *require* issues-exit-code=0 to pass data along to sonarcloud
@@ -152,7 +153,7 @@ jobs:
             -Dsonar.coverage.exclusions=**/*_test.go,**/mock/*
             -Dsonar.test.inclusions=**/*_test.go
             -Dsonar.tests=.
-            -Dsonar.go.coverage.reportPaths=coverage/*.cov
+            -Dsonar.go.coverage.reportPaths=coverage/gateway-all.cov
             -Dsonar.go.golangci-lint.reportPaths=golanglint.xml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -17,6 +17,14 @@ on:
       - master
       - release-**
 
+# Only have one runner per PR, and per merged commit.
+#
+# - As a PR gets new commits, any old run jobs get cancelled (PR number)
+# - As a commit gets merged, it doesn't cancel previous running PR's (github.sha)
+concurrency:
+  group: ${{ github.event.pull_request.number || github.sha }}-ci-tests
+  cancel-in-progress: true
+
 env:
   PYTHON_VERSION: "3.11"
   PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python

--- a/.taskfiles/test.yml
+++ b/.taskfiles/test.yml
@@ -44,7 +44,7 @@ tasks:
       package:
         sh: go mod edit -json | jq .Module.Path -r
       packages:
-        sh: go list ./... | tail -n +2 | sed -e 's|{{.package}}|.|g'
+        sh: go list ./... | sed -e 's|{{.package}}|.|g'
     cmds:
       - defer: { task: services:down }
       - rm -rf coverage && mkdir -p coverage

--- a/docker/services/Taskfile.yml
+++ b/docker/services/Taskfile.yml
@@ -5,7 +5,7 @@ tasks:
   up:
     desc: "Bring up services"
     cmds:
-      - docker compose up -d --remove-orphans
+      - docker compose up -d --remove-orphans --wait
 
   down:
     desc: "Tear down services"

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -1294,6 +1294,8 @@ func TestCacheEtag(t *testing.T) {
 }
 
 func TestOldCachePlugin(t *testing.T) {
+	test.Exclusive(t) // Test uses cache-* while other tests delete it.
+
 	ts := StartTest(nil)
 	t.Cleanup(ts.Close)
 

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -1296,9 +1296,6 @@ func TestCacheEtag(t *testing.T) {
 func TestOldCachePlugin(t *testing.T) {
 	test.Exclusive(t) // Test uses cache-* while other tests delete it.
 
-	ts := StartTest(nil)
-	t.Cleanup(ts.Close)
-
 	api := BuildAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/"
 		UpdateAPIVersion(spec, "v1", func(version *apidef.VersionInfo) {
@@ -1315,8 +1312,11 @@ func TestOldCachePlugin(t *testing.T) {
 
 	check := func(t *testing.T) {
 		t.Helper()
+
+		ts := StartTest(nil)
 		cache := storage.RedisCluster{KeyPrefix: "cache-", ConnectionHandler: ts.Gw.StorageConnectionHandler}
 		t.Cleanup(func() {
+			ts.Close()
 			cache.DeleteScanMatch("*")
 		})
 

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -41,7 +41,7 @@ func testKey(testName string, name string) string {
 
 func TestParambasedAuth(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Auth.UseParam = true
@@ -74,7 +74,7 @@ func TestParambasedAuth(t *testing.T) {
 
 func TestStripPathWithURLRewrite(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	t.Run("rewrite URL containing listen path", func(t *testing.T) {
 		ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
@@ -104,7 +104,7 @@ func TestStripPathWithURLRewrite(t *testing.T) {
 
 func TestSkipTargetPassEscapingOff(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	t.Run("With escaping, default", func(t *testing.T) {
 		globalConf := ts.Gw.GetConfig()
@@ -212,7 +212,7 @@ func TestSkipTargetPassEscapingOffWithSkipURLCleaningTrue(t *testing.T) {
 		c.HttpServerOptions.SkipURLCleaning = true
 	}
 	ts := StartTest(conf)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	ts.TestServerRouter.SkipClean(true)
 
@@ -326,7 +326,7 @@ func TestQuota(t *testing.T) {
 	test.Exclusive(t) // Uses quota, need to limit parallelism due to DeleteAllKeys.
 
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	var keyID string
 
@@ -413,11 +413,11 @@ func TestListener(t *testing.T) {
 	ts.Gw.ReloadTestCase.Enable()
 	ts.Gw.ReloadTestCase.StartTicker()
 
-	defer func() {
+	t.Cleanup(func() {
 		ts.Gw.ReloadTestCase.StopTicker()
 		ts.Gw.ReloadTestCase.Disable()
 		ts.Close()
-	}()
+	})
 
 	tests := []test.TestCase{
 		// Cleanup before tests
@@ -451,7 +451,7 @@ func TestListenerWithStrictRoutes(t *testing.T) {
 	ts := StartTest(func(globalConf *config.Config) {
 		globalConf.HttpServerOptions.EnableStrictRoutes = true
 	})
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	ts.Gw.ReloadTestCase.Enable()
 	defer ts.Gw.ReloadTestCase.Disable()
@@ -491,7 +491,7 @@ func TestControlListener(t *testing.T) {
 	ts := StartTest(nil, TestConfig{
 		SeparateControlAPI: true,
 	})
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	tests := []test.TestCase{
 		{Method: "GET", Path: "/", Code: 404},
@@ -528,7 +528,7 @@ func TestHttpPprof(t *testing.T) {
 		ts := StartTest(conf, TestConfig{
 			SeparateControlAPI: true,
 		})
-		defer ts.Close()
+		t.Cleanup(ts.Close)
 
 		_, _ = ts.Run(t, []test.TestCase{
 			{Path: "/debug/pprof/", Code: 404},
@@ -543,7 +543,7 @@ func TestHttpPprof(t *testing.T) {
 		ts := StartTest(conf, TestConfig{
 			SeparateControlAPI: true,
 		})
-		defer ts.Close()
+		t.Cleanup(ts.Close)
 
 		_, _ = ts.Run(t, []test.TestCase{
 			{Path: "/debug/pprof/", Code: 404},
@@ -555,7 +555,7 @@ func TestHttpPprof(t *testing.T) {
 
 func TestManagementNodeRedisEvents(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	globalConf := ts.Gw.GetConfig()
 	globalConf.ManagementNode = false
@@ -630,7 +630,7 @@ func TestManagementNodeRedisEvents(t *testing.T) {
 
 func TestListenPathTykPrefix(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/tyk-foo/"
@@ -661,7 +661,7 @@ func TestReloadGoroutineLeakWithTest(t *testing.T) {
 
 func TestReloadGoroutineLeakWithCircuitBreaker(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	globalConf := ts.Gw.GetConfig()
 	globalConf.EnableJSVM = false
@@ -723,7 +723,7 @@ func TestProxyProtocol(t *testing.T) {
 	defer l.Close()
 	go listenProxyProto(l)
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 	rp, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
@@ -767,7 +767,7 @@ func TestProxyProtocol(t *testing.T) {
 
 func TestProxyUserAgent(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/"
@@ -787,7 +787,7 @@ func TestProxyUserAgent(t *testing.T) {
 
 func TestSkipUrlCleaning(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	globalConf := ts.Gw.GetConfig()
 	globalConf.HttpServerOptions.OverrideDefaults = true
@@ -811,7 +811,7 @@ func TestSkipUrlCleaning(t *testing.T) {
 
 func TestMultiTargetProxy(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 		spec.VersionData.NotVersioned = false
@@ -841,7 +841,7 @@ func TestMultiTargetProxy(t *testing.T) {
 
 func TestCustomDomain(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	localClient := test.NewClientLocal()
 
@@ -896,7 +896,7 @@ func TestGatewayHealthCheck(t *testing.T) {
 
 	t.Run("control api port == listen port", func(t *testing.T) {
 		ts := StartTest(nil)
-		defer ts.Close()
+		t.Cleanup(ts.Close)
 
 		t.Run("Without APIs", func(t *testing.T) {
 			_, _ = ts.Run(t, []test.TestCase{
@@ -919,7 +919,7 @@ func TestGatewayHealthCheck(t *testing.T) {
 		ts := StartTest(nil, TestConfig{
 			SeparateControlAPI: true,
 		})
-		defer ts.Close()
+		t.Cleanup(ts.Close)
 
 		t.Run("Without APIs", func(t *testing.T) {
 			_, _ = ts.Run(t, []test.TestCase{
@@ -1391,7 +1391,7 @@ func TestAdvanceCacheTimeoutPerEndpoint(t *testing.T) {
 
 func TestWebsocketsSeveralOpenClose(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	globalConf := ts.Gw.GetConfig()
 	globalConf.HttpServerOptions.EnableWebSockets = true
@@ -1488,7 +1488,7 @@ func TestWebsocketsSeveralOpenClose(t *testing.T) {
 
 func TestWebsocketsAndHTTPEndpointMatch(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	globalConf := ts.Gw.GetConfig()
 	globalConf.HttpServerOptions.EnableWebSockets = true
@@ -1621,7 +1621,7 @@ func createTestUptream(t *testing.T, allowedConns int, readsPerConn int) net.Lis
 
 func TestKeepAliveConns(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	t.Run("Should use same connection", func(t *testing.T) {
 		// set keep alive option
@@ -1700,7 +1700,7 @@ func TestKeepAliveConns(t *testing.T) {
 // API's global rate limit.
 func TestRateLimitForAPIAndRateLimitAndQuotaCheck(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	globalCfg := ts.Gw.GetConfig()
 	globalCfg.EnableNonTransactionalRateLimiter = false
@@ -1741,7 +1741,7 @@ func TestRateLimitForAPIAndRateLimitAndQuotaCheck(t *testing.T) {
 
 func TestTracing(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	ts.Gw.prepareStorage()
 
@@ -1798,7 +1798,7 @@ func TestBrokenClients(t *testing.T) {
 		gwConf.ProxyDefaultTimeout = 1
 	}
 	ts := StartTest(conf)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 		spec.UseKeylessAccess = true
@@ -1844,7 +1844,7 @@ func TestCache_singleErrorResponse(t *testing.T) {
 	}))
 
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 		spec.UseKeylessAccess = true
@@ -1877,7 +1877,7 @@ func TestCache_singleErrorResponse(t *testing.T) {
 
 func TestOverrideErrors(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	defer defaultTykErrors()
 

--- a/tests/regression/Taskfile.yml
+++ b/tests/regression/Taskfile.yml
@@ -45,7 +45,7 @@ tasks:
     quiet: true
     vars:
       funcs:
-        sh: ./regression.test -test.list=Test | egrep -v 'Test_Issue[0-9]+' || true
+        sh: ./regression.test -test.list=Test | egrep -v '(Test_Issue[0-9]+|TestLoadAPISpec)' || true
     cmds:
       - cmd: '{{if ne .funcs ""}}echo -e "Naming violations:\n{{.funcs}}" && exit 1 {{end}}'
 

--- a/tests/regression/issue_10104_test.go
+++ b/tests/regression/issue_10104_test.go
@@ -13,7 +13,7 @@ func Test_Issue10104(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	// load api definition from file
-	ts.Gw.LoadAPI(loadAPISpec(t, "testdata/issue-10104-apidef.json"))
+	ts.Gw.LoadAPI(LoadAPISpec(t, "testdata/issue-10104-apidef.json"))
 
 	// issue request against /test to trigger panic
 	ts.Run(t, []test.TestCase{

--- a/tests/regression/issue_11806_test.go
+++ b/tests/regression/issue_11806_test.go
@@ -20,8 +20,8 @@ func Test_Issue11806_DomainRouting(t *testing.T) {
 		conf.EnableCustomDomains = true
 	}
 
-	noDomain := loadAPISpec(t, "testdata/issue-11806-api-no-domain.json")
-	withDomain := loadAPISpec(t, "testdata/issue-11806-api-with-domain.json")
+	noDomain := LoadAPISpec(t, "testdata/issue-11806-api-no-domain.json")
+	withDomain := LoadAPISpec(t, "testdata/issue-11806-api-with-domain.json")
 
 	t.Run("Load listenPath without domain first", func(t *testing.T) {
 		ts := gateway.StartTest(testConfig)

--- a/tests/regression/issue_12865_test.go
+++ b/tests/regression/issue_12865_test.go
@@ -17,10 +17,10 @@ func Test_Issue12865(t *testing.T) {
 			c.HttpServerOptions.EnablePathPrefixMatching = false
 			c.HttpServerOptions.EnablePathSuffixMatching = false
 		})
-		defer ts.Close()
+		t.Cleanup(ts.Close)
 
 		// load api definition from file
-		api := loadAPISpec(t, "testdata/issue-12865.json")
+		api := LoadAPISpec(t, "testdata/issue-12865.json")
 
 		ts.Gw.LoadAPI(api)
 
@@ -56,10 +56,10 @@ func Test_Issue12865(t *testing.T) {
 			c.HttpServerOptions.EnablePathPrefixMatching = true
 			c.HttpServerOptions.EnablePathSuffixMatching = false
 		})
-		defer ts.Close()
+		t.Cleanup(ts.Close)
 
 		// load api definition from file
-		api := loadAPISpec(t, "testdata/issue-12865.json")
+		api := LoadAPISpec(t, "testdata/issue-12865.json")
 
 		ts.Gw.LoadAPI(api)
 
@@ -95,10 +95,10 @@ func Test_Issue12865(t *testing.T) {
 			c.HttpServerOptions.EnablePathPrefixMatching = true
 			c.HttpServerOptions.EnablePathSuffixMatching = true
 		})
-		defer ts.Close()
+		t.Cleanup(ts.Close)
 
 		// load api definition from file
-		api := loadAPISpec(t, "testdata/issue-12865.json")
+		api := LoadAPISpec(t, "testdata/issue-12865.json")
 
 		ts.Gw.LoadAPI(api)
 
@@ -134,10 +134,10 @@ func Test_Issue12865(t *testing.T) {
 			c.HttpServerOptions.EnablePathPrefixMatching = false
 			c.HttpServerOptions.EnablePathSuffixMatching = true
 		})
-		defer ts.Close()
+		t.Cleanup(ts.Close)
 
 		// load api definition from file
-		api := loadAPISpec(t, "testdata/issue-12865.json")
+		api := LoadAPISpec(t, "testdata/issue-12865.json")
 
 		ts.Gw.LoadAPI(api)
 

--- a/tests/regression/testdata/issue-12865.json
+++ b/tests/regression/testdata/issue-12865.json
@@ -292,7 +292,7 @@
                             "path": "/status",
                             "method": "GET",
                             "match_pattern": "/status/(.*)",
-                            "rewrite_to": "http://google.com",
+                            "rewrite_to": "http://httpbin.org",
                             "triggers": []
                         }
                     ],


### PR DESCRIPTION
### **User description**
This considers some necessary improvements:

- [x] revert test to run e2e-combined (e2e only has some CI specific issues when running, not seen on local)
- [x] add cancellation group to CI tests, new commits on PR cancel old CI Tests run
- [x] pass only the merged .cov file to sonarcloud (not all of them)
- [x] https://tyktech.atlassian.net/browse/TT-12494 (tests issue, deleting caches, defer)
- [x] fix some dialing out in tests/regression (httpbin/google)

gateway_test.go: The tests are flaky on account they delete the redis cache. Deleting a redis cache from a test interferes with other tests that also read/write cache data from redis.

tests/regression: using external resources (confirmed fix)


___

### **PR Type**
enhancement, tests


___

### **Description**
- Added concurrency settings to the CI workflow to ensure only one runner per PR and commit, canceling old runs on new commits.
- Updated the test command to `test:e2e-combined` to address CI-specific issues.
- Changed the sonar coverage report path to use a merged `.cov` file (`gateway-all.cov`).
- Simplified the package listing command in the test task configuration.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci-tests.yml</strong><dd><code>Enhance CI workflow with concurrency and test improvements</code></dd></summary>
<hr>

.github/workflows/ci-tests.yml

<li>Added concurrency settings to CI tests to cancel old runs on new <br>commits.<br> <li> Changed test command to <code>test:e2e-combined</code>.<br> <li> Updated sonar coverage report path to <code>gateway-all.cov</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6508/files#diff-03609cb60b0c6e92fb771eb8787d6722b8c31ca4c03eabc788e147acd8c6fb43">+11/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>test.yml</strong><dd><code>Simplify package listing command in test task</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.taskfiles/test.yml

- Simplified the package listing command in the test task.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6508/files#diff-f1fbe7f7f14888019b8845634ed008e1c43f6e5a5c0b2707336fc7f8e15a36fb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

