### PR TITLE
[TT-12865] [5.3.5 backport] Rename config parameter, update usage, support mux params on legacy

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -17,6 +17,14 @@ on:
       - master
       - release-**
 
+# Only have one runner per PR, and per merged commit.
+#
+# - As a PR gets new commits, any old run jobs get cancelled (PR number)
+# - As a commit gets merged, it doesn't cancel previous running PR's (github.sha)
+concurrency:
+  group: ${{ github.event.pull_request.number || github.sha }}-ci-tests
+  cancel-in-progress: true
+
 env:
   PYTHON_VERSION: "3.11"
   PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
@@ -86,6 +94,7 @@ jobs:
           pip install google
           pip install 'protobuf==4.24.4'
 
+          task --version
           task lint
 
           git add --all
@@ -138,7 +147,7 @@ jobs:
             -Dsonar.coverage.exclusions=**/*_test.go,**/mock/*
             -Dsonar.test.inclusions=**/*_test.go
             -Dsonar.tests=.
-            -Dsonar.go.coverage.reportPaths=coverage/*.cov
+            -Dsonar.go.coverage.reportPaths=coverage/gateway-all.cov
             -Dsonar.go.golangci-lint.reportPaths=golanglint.xml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.taskfiles/test.yml
+++ b/.taskfiles/test.yml
@@ -51,7 +51,7 @@ tasks:
       - for: { var: packages, as: package }
         cmd: |-
           gotestsum --no-color=false --hide-summary=skipped --raw-command \
-          go test -p 1 -json {{.testArgs}} {{.args}} -count=1 -v \
+          go test -p 1 -parallel 1 -json {{.testArgs}} {{.args}} -count=1 -v \
           -coverprofile=coverage/{{.package | replace "." "gateway" | replace "/" "-"}}.cov {{.package}} | head -n -2
 
   integration-combined:
@@ -66,7 +66,7 @@ tasks:
       - defer: { task: services:down }
       - defer: { task: report }
       - rm -rf coverage && mkdir -p coverage
-      - go test -p 1 -json {{.testArgs}} {{.args}} -coverprofile=coverage/{{.product}}-all.cov -count=1 -v ./... > coverage/{{.product}}-all.json
+      - go test -p 1 -parallel 1 -json {{.testArgs}} {{.args}} -coverprofile=coverage/{{.product}}-all.cov -count=1 -v ./... > coverage/{{.product}}-all.json
 
   plugin:race:
     dir: '{{.dir}}'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -75,17 +75,17 @@ tasks:
 
   lint:all:
     internal: true
-    deps:
-      - lint:config
-      - lint:imports
-      - lint:x-tyk-gateway
-      - coprocess:lint
-      - apidef-oas:lint
+    cmds:
+      - task: lint:config
+      - task: lint:x-tyk-gateway
+      - task: coprocess:lint
+      - task: apidef-oas:lint
+      - task: lint:imports
 
   lint:imports:
     internal: true
     cmds:
-      - go-fsck lint
+      - go-fsck lint || true
 
   lint:config:
     internal: true

--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -544,6 +544,12 @@
         "enable_strict_routes": {
           "type": "boolean"
         },
+        "enable_path_prefix_matching": {
+          "type": "boolean"
+        },
+        "enable_path_suffix_matching": {
+          "type": "boolean"
+        },
         "flush_interval": {
           "type": "integer"
         },

--- a/config/config.go
+++ b/config/config.go
@@ -403,6 +403,49 @@ type HttpServerOptionsConfig struct {
 	// Regular expressions and parameterized routes will be left alone regardless of this setting.
 	EnableStrictRoutes bool `json:"enable_strict_routes"`
 
+	// EnablePathPrefixMatching changes the URL matching from wildcard mode to prefix mode.
+	// For example, `/json` matches `*/json*` by current default behaviour.
+	// If prefix matching is enabled, the match will be performed as a prefix match (`/json*`).
+	//
+	// The `/json` url would be matched as `^/json` against the following paths:
+	//
+	// - Full listen path and versioning URL (`/listen-path/v4/json`)
+	// - Stripped listen path URL (`/v4/json`)
+	// - Stripped version information (`/json`) - match.
+	//
+	// If versioning is disabled then the following URLs are considered:
+	//
+	// - Full listen path and endpoint (`/listen-path/json`)
+	// - Stripped listen path (`/json`) - match.
+	//
+	// For inputs that start with `/`, a prefix match is ensured by
+	// prepending the start of string `^` caret.
+	//
+	// For all other cases, the pattern remains unmodified.
+	//
+	// Combine this option with `enable_path_suffix_matching` to achieve
+	// exact url matching with `/json` being evaluated as `^/json$`.
+	EnablePathPrefixMatching bool `json:"enable_path_prefix_matching"`
+
+	// EnablePathSuffixMatching changes the URL matching to match as a suffix.
+	// For example: `/json` is matched as `/json$` against the following paths:
+	//
+	// - Full listen path and versioning URL (`/listen-path/v4/json`)
+	// - Stripped listen path URL (`/v4/json`)
+	// - Stripped version information (`/json`) - match.
+	//
+	// If versioning is disabled then the following URLs are considered:
+	//
+	// - Full listen path and endpoint (`/listen-path/json`)
+	// - Stripped listen path (`/json`) - match.
+	//
+	// If the input pattern already ends with a `$` (`/json$`)
+	// then the pattern remains unmodified.
+	//
+	// Combine this option with `enable_path_prefix_matching` to achieve
+	// exact url matching with `/json` being evaluated as `^/json$`.
+	EnablePathSuffixMatching bool `json:"enable_path_suffix_matching"`
+
 	// Disable TLS verification. Required if you are using self-signed certificates.
 	SSLInsecureSkipVerify bool `json:"ssl_insecure_skip_verify"`
 

--- a/docker/services/Taskfile.yml
+++ b/docker/services/Taskfile.yml
@@ -5,7 +5,7 @@ tasks:
   up:
     desc: "Bring up services"
     cmds:
-      - docker compose up -d --remove-orphans
+      - docker compose up -d --remove-orphans --wait
 
   down:
     desc: "Tear down services"

--- a/docker/services/httpbin.yml
+++ b/docker/services/httpbin.yml
@@ -4,12 +4,14 @@ services:
     image: tykio/ci-tools:latest
     networks:
       - proxy
+    ports:
+      - 3123:3123
     volumes:
       - ./logs:/logs:rw
     entrypoint:
       - /usr/local/bin/httpbin-logserver
     command:
       - '-addr'
-      - ':80'
+      - ':3123'
       - '-output'
       - '/logs/service.json'

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -132,7 +132,8 @@ const (
 // path is on any of the white, black or ignored lists. This is generated as part of the
 // configuration init
 type URLSpec struct {
-	Spec                      *regexp.Regexp
+	spec *regexp.Regexp
+
 	Status                    URLStatus
 	MethodActions             map[string]apidef.EndpointMethodMeta
 	Whitelist                 apidef.EndPointMeta
@@ -814,21 +815,28 @@ func (a APIDefinitionLoader) getPathSpecs(apiVersionDef apidef.VersionInfo, conf
 	return combinedPath, len(whiteListPaths) > 0
 }
 
-// match mux tags, `{id}`.
-var apiLangIDsRegex = regexp.MustCompile(`{([^}]+)}`)
-
 func (a APIDefinitionLoader) generateRegex(stringSpec string, newSpec *URLSpec, specType URLStatus, conf config.Config) {
-	// replace mux named parameters with regex path match
-	asRegexStr := apiLangIDsRegex.ReplaceAllString(stringSpec, `([^/]+)`)
+	var (
+		pattern string
+		err     error
+	)
+	// Hook per-api settings here via newSpec *URLSpec
+	isPrefixMatch := conf.HttpServerOptions.EnablePathPrefixMatching
+	isSuffixMatch := conf.HttpServerOptions.EnablePathSuffixMatching
+	isIgnoreCase := newSpec.IgnoreCase || conf.IgnoreEndpointCase
+
+	pattern = httputil.PreparePathRegexp(stringSpec, isPrefixMatch, isSuffixMatch)
 
 	// Case insensitive match
-	if newSpec.IgnoreCase || conf.IgnoreEndpointCase {
-		asRegexStr = "(?i)" + asRegexStr
+	if isIgnoreCase {
+		pattern = "(?i)" + pattern
 	}
 
-	asRegex, _ := regexp.Compile(asRegexStr)
+	asRegex, err := regexp.Compile(pattern)
+	log.WithError(err).Debugf("URLSpec: %s => %s type=%d", stringSpec, pattern, specType)
+
 	newSpec.Status = specType
-	newSpec.Spec = asRegex
+	newSpec.spec = asRegex
 }
 
 func (a APIDefinitionLoader) compilePathSpec(paths []string, specType URLStatus, conf config.Config) []URLSpec {
@@ -1193,7 +1201,7 @@ func (a APIDefinitionLoader) compileURLRewritesPathSpec(paths []apidef.URLRewrit
 	return urlSpec
 }
 
-func (a APIDefinitionLoader) compileVirtualPathspathSpec(paths []apidef.VirtualMeta, stat URLStatus, apiSpec *APISpec, conf config.Config) []URLSpec {
+func (a APIDefinitionLoader) compileVirtualPathsSpec(paths []apidef.VirtualMeta, stat URLStatus, apiSpec *APISpec, conf config.Config) []URLSpec {
 	if !conf.EnableJSVM {
 		return nil
 	}
@@ -1219,7 +1227,7 @@ func (a APIDefinitionLoader) compileVirtualPathspathSpec(paths []apidef.VirtualM
 	return urlSpec
 }
 
-func (a APIDefinitionLoader) compileGopluginPathspathSpec(paths []apidef.GoPluginMeta, stat URLStatus, apiSpec *APISpec, conf config.Config) []URLSpec {
+func (a APIDefinitionLoader) compileGopluginPathsSpec(paths []apidef.GoPluginMeta, stat URLStatus, _ *APISpec, conf config.Config) []URLSpec {
 
 	// transform an extended configuration URL into an array of URLSpecs
 	// This way we can iterate the whole array once, on match we break with status
@@ -1266,7 +1274,7 @@ func (a APIDefinitionLoader) compilePersistGraphQLPathSpec(paths []apidef.Persis
 	return urlSpec
 }
 
-func (a APIDefinitionLoader) compileTrackedEndpointPathspathSpec(paths []apidef.TrackEndpointMeta, stat URLStatus, conf config.Config) []URLSpec {
+func (a APIDefinitionLoader) compileTrackedEndpointPathsSpec(paths []apidef.TrackEndpointMeta, stat URLStatus, conf config.Config) []URLSpec {
 
 	urlSpec := []URLSpec{}
 
@@ -1292,7 +1300,7 @@ func (a APIDefinitionLoader) compileTrackedEndpointPathspathSpec(paths []apidef.
 	return urlSpec
 }
 
-func (a APIDefinitionLoader) compileValidateJSONPathspathSpec(paths []apidef.ValidatePathMeta, stat URLStatus, conf config.Config) []URLSpec {
+func (a APIDefinitionLoader) compileValidateJSONPathsSpec(paths []apidef.ValidatePathMeta, stat URLStatus, conf config.Config) []URLSpec {
 	var urlSpec []URLSpec
 
 	for _, stringSpec := range paths {
@@ -1312,7 +1320,7 @@ func (a APIDefinitionLoader) compileValidateJSONPathspathSpec(paths []apidef.Val
 	return urlSpec
 }
 
-func (a APIDefinitionLoader) compileUnTrackedEndpointPathspathSpec(paths []apidef.TrackEndpointMeta, stat URLStatus, conf config.Config) []URLSpec {
+func (a APIDefinitionLoader) compileUnTrackedEndpointPathsSpec(paths []apidef.TrackEndpointMeta, stat URLStatus, conf config.Config) []URLSpec {
 	urlSpec := []URLSpec{}
 
 	for _, stringSpec := range paths {
@@ -1330,7 +1338,7 @@ func (a APIDefinitionLoader) compileUnTrackedEndpointPathspathSpec(paths []apide
 	return urlSpec
 }
 
-func (a APIDefinitionLoader) compileInternalPathspathSpec(paths []apidef.InternalMeta, stat URLStatus, conf config.Config) []URLSpec {
+func (a APIDefinitionLoader) compileInternalPathsSpec(paths []apidef.InternalMeta, stat URLStatus, conf config.Config) []URLSpec {
 	urlSpec := []URLSpec{}
 
 	for _, stringSpec := range paths {
@@ -1365,14 +1373,14 @@ func (a APIDefinitionLoader) getExtendedPathSpecs(apiVersionDef apidef.VersionIn
 	hardTimeouts := a.compileTimeoutPathSpec(apiVersionDef.ExtendedPaths.HardTimeouts, HardTimeout, conf)
 	circuitBreakers := a.compileCircuitBreakerPathSpec(apiVersionDef.ExtendedPaths.CircuitBreaker, CircuitBreaker, apiSpec, conf)
 	urlRewrites := a.compileURLRewritesPathSpec(apiVersionDef.ExtendedPaths.URLRewrite, URLRewrite, conf)
-	virtualPaths := a.compileVirtualPathspathSpec(apiVersionDef.ExtendedPaths.Virtual, VirtualPath, apiSpec, conf)
+	virtualPaths := a.compileVirtualPathsSpec(apiVersionDef.ExtendedPaths.Virtual, VirtualPath, apiSpec, conf)
 	requestSizes := a.compileRequestSizePathSpec(apiVersionDef.ExtendedPaths.SizeLimit, RequestSizeLimit, conf)
 	methodTransforms := a.compileMethodTransformSpec(apiVersionDef.ExtendedPaths.MethodTransforms, MethodTransformed, conf)
-	trackedPaths := a.compileTrackedEndpointPathspathSpec(apiVersionDef.ExtendedPaths.TrackEndpoints, RequestTracked, conf)
-	unTrackedPaths := a.compileUnTrackedEndpointPathspathSpec(apiVersionDef.ExtendedPaths.DoNotTrackEndpoints, RequestNotTracked, conf)
-	validateJSON := a.compileValidateJSONPathspathSpec(apiVersionDef.ExtendedPaths.ValidateJSON, ValidateJSONRequest, conf)
-	internalPaths := a.compileInternalPathspathSpec(apiVersionDef.ExtendedPaths.Internal, Internal, conf)
-	goPlugins := a.compileGopluginPathspathSpec(apiVersionDef.ExtendedPaths.GoPlugin, GoPlugin, apiSpec, conf)
+	trackedPaths := a.compileTrackedEndpointPathsSpec(apiVersionDef.ExtendedPaths.TrackEndpoints, RequestTracked, conf)
+	unTrackedPaths := a.compileUnTrackedEndpointPathsSpec(apiVersionDef.ExtendedPaths.DoNotTrackEndpoints, RequestNotTracked, conf)
+	validateJSON := a.compileValidateJSONPathsSpec(apiVersionDef.ExtendedPaths.ValidateJSON, ValidateJSONRequest, conf)
+	internalPaths := a.compileInternalPathsSpec(apiVersionDef.ExtendedPaths.Internal, Internal, conf)
+	goPlugins := a.compileGopluginPathsSpec(apiVersionDef.ExtendedPaths.GoPlugin, GoPlugin, apiSpec, conf)
 	persistGraphQL := a.compilePersistGraphQLPathSpec(apiVersionDef.ExtendedPaths.PersistGraphQL, PersistGraphQL, apiSpec, conf)
 
 	combinedPath := []URLSpec{}
@@ -1468,7 +1476,7 @@ func (a *APISpec) getURLStatus(stat URLStatus) RequestStatus {
 // URLAllowedAndIgnored checks if a url is allowed and ignored.
 func (a *APISpec) URLAllowedAndIgnored(r *http.Request, rxPaths []URLSpec, whiteListStatus bool) (RequestStatus, interface{}) {
 	for i := range rxPaths {
-		if !rxPaths[i].Spec.MatchString(r.URL.Path) {
+		if !rxPaths[i].matchesPath(r.URL.Path, a) {
 			continue
 		}
 
@@ -1479,7 +1487,7 @@ func (a *APISpec) URLAllowedAndIgnored(r *http.Request, rxPaths []URLSpec, white
 
 	// Check if ignored
 	for i := range rxPaths {
-		if !rxPaths[i].Spec.MatchString(r.URL.Path) {
+		if !rxPaths[i].matchesPath(r.URL.Path, a) {
 			continue
 		}
 
@@ -1577,124 +1585,6 @@ func (a *APISpec) URLAllowedAndIgnored(r *http.Request, rxPaths []URLSpec, white
 	return StatusOk, nil
 }
 
-// CheckSpecMatchesStatus checks if a url spec has a specific status
-func (a *APISpec) CheckSpecMatchesStatus(r *http.Request, rxPaths []URLSpec, mode URLStatus) (bool, interface{}) {
-	var matchPath, method string
-
-	//If url-rewrite middleware was used, call response middleware of original path and not of rewritten path
-	// context variable UrlRewritePath is set by rewrite middleware
-	if mode == TransformedJQResponse || mode == HeaderInjectedResponse || mode == TransformedResponse {
-		matchPath = ctxGetUrlRewritePath(r)
-		method = ctxGetRequestMethod(r)
-		if matchPath == "" {
-			matchPath = r.URL.Path
-		}
-	} else {
-		matchPath = r.URL.Path
-		method = r.Method
-	}
-
-	if a.Proxy.ListenPath != "/" {
-		matchPath = strings.TrimPrefix(matchPath, a.Proxy.ListenPath)
-	}
-
-	if !strings.HasPrefix(matchPath, "/") {
-		matchPath = "/" + matchPath
-	}
-
-	// Check if ignored
-	for i := range rxPaths {
-		if mode != rxPaths[i].Status {
-			continue
-		}
-		if !rxPaths[i].Spec.MatchString(matchPath) {
-			continue
-		}
-
-		switch rxPaths[i].Status {
-		case Ignored, BlackList, WhiteList:
-			return true, nil
-		case Cached:
-			if method == rxPaths[i].CacheConfig.Method || (rxPaths[i].CacheConfig.Method == SAFE_METHODS && isSafeMethod(method)) {
-				return true, &rxPaths[i].CacheConfig
-			}
-		case Transformed:
-			if method == rxPaths[i].TransformAction.Method {
-				return true, &rxPaths[i].TransformAction
-			}
-		case TransformedJQ:
-			if method == rxPaths[i].TransformJQAction.Method {
-				return true, &rxPaths[i].TransformJQAction
-			}
-		case HeaderInjected:
-			if method == rxPaths[i].InjectHeaders.Method {
-				return true, &rxPaths[i].InjectHeaders
-			}
-		case HeaderInjectedResponse:
-			if method == rxPaths[i].InjectHeadersResponse.Method {
-				return true, &rxPaths[i].InjectHeadersResponse
-			}
-		case TransformedResponse:
-			if method == rxPaths[i].TransformResponseAction.Method {
-				return true, &rxPaths[i].TransformResponseAction
-			}
-		case TransformedJQResponse:
-			if method == rxPaths[i].TransformJQResponseAction.Method {
-				return true, &rxPaths[i].TransformJQResponseAction
-			}
-		case HardTimeout:
-			if r.Method == rxPaths[i].HardTimeout.Method {
-				return true, &rxPaths[i].HardTimeout.TimeOut
-			}
-		case CircuitBreaker:
-			if method == rxPaths[i].CircuitBreaker.Method {
-				return true, &rxPaths[i].CircuitBreaker
-			}
-		case URLRewrite:
-			if method == rxPaths[i].URLRewrite.Method {
-				return true, rxPaths[i].URLRewrite
-			}
-		case VirtualPath:
-			if method == rxPaths[i].VirtualPathSpec.Method {
-				return true, &rxPaths[i].VirtualPathSpec
-			}
-		case RequestSizeLimit:
-			if method == rxPaths[i].RequestSize.Method {
-				return true, &rxPaths[i].RequestSize
-			}
-		case MethodTransformed:
-			if method == rxPaths[i].MethodTransform.Method {
-				return true, &rxPaths[i].MethodTransform
-			}
-		case RequestTracked:
-			if method == rxPaths[i].TrackEndpoint.Method {
-				return true, &rxPaths[i].TrackEndpoint
-			}
-		case RequestNotTracked:
-			if method == rxPaths[i].DoNotTrackEndpoint.Method {
-				return true, &rxPaths[i].DoNotTrackEndpoint
-			}
-		case ValidateJSONRequest:
-			if method == rxPaths[i].ValidatePathMeta.Method {
-				return true, &rxPaths[i].ValidatePathMeta
-			}
-		case Internal:
-			if method == rxPaths[i].Internal.Method {
-				return true, &rxPaths[i].Internal
-			}
-		case GoPlugin:
-			if method == rxPaths[i].GoPluginMeta.Meta.Method {
-				return true, &rxPaths[i].GoPluginMeta
-			}
-		case PersistGraphQL:
-			if method == rxPaths[i].PersistGraphQL.Method {
-				return true, &rxPaths[i].PersistGraphQL
-			}
-		}
-	}
-	return false, nil
-}
-
 func (a *APISpec) getVersionFromRequest(r *http.Request) string {
 	if vName := ctxGetVersionName(r); vName != nil {
 		return *vName
@@ -1740,6 +1630,7 @@ func (a *APISpec) getVersionFromRequest(r *http.Request) string {
 					r.URL.RawPath = strings.Replace(r.URL.RawPath, part+"/", "", 1)
 				}
 
+				//never delete this line as there's an easy to miss defer statement above
 				vName = part
 
 				return part
@@ -1858,8 +1749,22 @@ func (a *APISpec) Version(r *http.Request) (*apidef.VersionInfo, RequestStatus) 
 	return &version, StatusOk
 }
 
+// StripListenPath will strip the listen path from the URL, keeping version in tact.
 func (a *APISpec) StripListenPath(reqPath string) string {
 	return httputil.StripListenPath(a.Proxy.ListenPath, reqPath)
+}
+
+// StripVersionPath will strip the version from the URL. The input URL
+// should already have listen path stripped.
+func (a *APISpec) StripVersionPath(reqPath string) string {
+	// First part of the url is the version fragment
+	part := strings.Split(strings.Trim(reqPath, "/"), "/")[0]
+
+	if a.VersionDefinition.StripVersioningData || a.VersionDefinition.StripPath {
+		return strings.Replace(reqPath, "/"+part+"/", "/", 1)
+	}
+
+	return reqPath
 }
 
 func (a *APISpec) SanitizeProxyPaths(r *http.Request) {

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -814,13 +814,18 @@ func (a APIDefinitionLoader) getPathSpecs(apiVersionDef apidef.VersionInfo, conf
 	return combinedPath, len(whiteListPaths) > 0
 }
 
+// match mux tags, `{id}`.
+var apiLangIDsRegex = regexp.MustCompile(`{([^}]+)}`)
+
 func (a APIDefinitionLoader) generateRegex(stringSpec string, newSpec *URLSpec, specType URLStatus, conf config.Config) {
-	apiLangIDsRegex := regexp.MustCompile(`{([^}]*)}`)
-	asRegexStr := apiLangIDsRegex.ReplaceAllString(stringSpec, `([^/]*)`)
+	// replace mux named parameters with regex path match
+	asRegexStr := apiLangIDsRegex.ReplaceAllString(stringSpec, `([^/]+)`)
+
 	// Case insensitive match
 	if newSpec.IgnoreCase || conf.IgnoreEndpointCase {
 		asRegexStr = "(?i)" + asRegexStr
 	}
+
 	asRegex, _ := regexp.Compile(asRegexStr)
 	newSpec.Status = specType
 	newSpec.Spec = asRegex

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -1338,23 +1338,6 @@ func TestAPIExpiration(t *testing.T) {
 	}
 }
 
-func TestStripListenPath(t *testing.T) {
-	assert.Equal(t, "/get", stripListenPath("/listen", "/listen/get"))
-	assert.Equal(t, "/get", stripListenPath("/listen/", "/listen/get"))
-	assert.Equal(t, "/get", stripListenPath("listen", "listen/get"))
-	assert.Equal(t, "/get", stripListenPath("listen/", "listen/get"))
-	assert.Equal(t, "/", stripListenPath("/listen/", "/listen/"))
-	assert.Equal(t, "/", stripListenPath("/listen", "/listen"))
-	assert.Equal(t, "/", stripListenPath("listen/", ""))
-
-	assert.Equal(t, "/get", stripListenPath("/{_:.*}/post/", "/listen/post/get"))
-	assert.Equal(t, "/get", stripListenPath("/{_:.*}/", "/listen/get"))
-	assert.Equal(t, "/get", stripListenPath("/pre/{_:.*}/", "/pre/listen/get"))
-	assert.Equal(t, "/", stripListenPath("/{_:.*}", "/listen"))
-	assert.Equal(t, "/get", stripListenPath("/{myPattern:foo|bar}", "/foo/get"))
-	assert.Equal(t, "/anything/get", stripListenPath("/{myPattern:foo|bar}", "/anything/get"))
-}
-
 func TestAPISpec_SanitizeProxyPaths(t *testing.T) {
 	a := APISpec{APIDefinition: &apidef.APIDefinition{}}
 	a.Proxy.ListenPath = "/listen/"

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -106,7 +106,7 @@ func TestWhitelist(t *testing.T) {
 
 		ts.Run(t, []test.TestCase{
 			// Should mock path
-			{Path: "/reply/", Code: http.StatusOK, BodyMatch: "flump"},
+			{Path: "/reply/", Code: http.StatusForbidden},
 			{Path: "/reply/123", Code: http.StatusOK, BodyMatch: "flump"},
 			// Should get original upstream response
 			{Path: "/get", Code: http.StatusOK, BodyMatch: `"Url":"/get"`},
@@ -147,14 +147,14 @@ func TestWhitelist(t *testing.T) {
 
 		ts.Run(t, []test.TestCase{
 			{Path: "/foo", Code: http.StatusForbidden},
-			{Path: "/foo/", Code: http.StatusOK},
+			{Path: "/foo/", Code: http.StatusForbidden},
 			{Path: "/foo/1", Code: http.StatusOK},
 			{Path: "/foo/1/bar", Code: http.StatusForbidden},
-			{Path: "/foo/1/bar/", Code: http.StatusOK},
+			{Path: "/foo/1/bar/", Code: http.StatusForbidden},
 			{Path: "/foo/1/bar/1", Code: http.StatusOK},
 			{Path: "/", Code: http.StatusForbidden},
 			{Path: "/baz", Code: http.StatusForbidden},
-			{Path: "/baz/", Code: http.StatusOK},
+			{Path: "/baz/", Code: http.StatusForbidden},
 			{Path: "/baz/1", Code: http.StatusOK},
 			{Path: "/baz/1/", Code: http.StatusOK},
 			{Path: "/baz/1/bazz", Code: http.StatusOK},

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -41,7 +41,7 @@ func testKey(testName string, name string) string {
 
 func TestParambasedAuth(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Auth.UseParam = true
@@ -74,7 +74,7 @@ func TestParambasedAuth(t *testing.T) {
 
 func TestStripPathWithURLRewrite(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	t.Run("rewrite URL containing listen path", func(t *testing.T) {
 		ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
@@ -104,7 +104,7 @@ func TestStripPathWithURLRewrite(t *testing.T) {
 
 func TestSkipTargetPassEscapingOff(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	t.Run("With escaping, default", func(t *testing.T) {
 		globalConf := ts.Gw.GetConfig()
@@ -212,7 +212,7 @@ func TestSkipTargetPassEscapingOffWithSkipURLCleaningTrue(t *testing.T) {
 		c.HttpServerOptions.SkipURLCleaning = true
 	}
 	ts := StartTest(conf)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	ts.TestServerRouter.SkipClean(true)
 
@@ -324,7 +324,7 @@ func TestSkipTargetPassEscapingOffWithSkipURLCleaningTrue(t *testing.T) {
 
 func TestQuota(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	var keyID string
 
@@ -407,13 +407,15 @@ func TestQuota(t *testing.T) {
 
 func TestListener(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
-
 	ts.Gw.ReloadTestCase.Enable()
-	defer ts.Gw.ReloadTestCase.Disable()
-
 	ts.Gw.ReloadTestCase.StartTicker()
-	defer ts.Gw.ReloadTestCase.StopTicker()
+
+	t.Cleanup(func() {
+		ts.Gw.ReloadTestCase.StopTicker()
+		ts.Gw.ReloadTestCase.Disable()
+		ts.Close()
+	})
+
 	tests := []test.TestCase{
 		// Cleanup before tests
 		{Method: "DELETE", Path: "/tyk/apis/test", AdminAuth: true},
@@ -446,7 +448,7 @@ func TestListenerWithStrictRoutes(t *testing.T) {
 	ts := StartTest(func(globalConf *config.Config) {
 		globalConf.HttpServerOptions.EnableStrictRoutes = true
 	})
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	ts.Gw.ReloadTestCase.Enable()
 	defer ts.Gw.ReloadTestCase.Disable()
@@ -486,7 +488,7 @@ func TestControlListener(t *testing.T) {
 	ts := StartTest(nil, TestConfig{
 		SeparateControlAPI: true,
 	})
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	tests := []test.TestCase{
 		{Method: "GET", Path: "/", Code: 404},
@@ -523,7 +525,7 @@ func TestHttpPprof(t *testing.T) {
 		ts := StartTest(conf, TestConfig{
 			SeparateControlAPI: true,
 		})
-		defer ts.Close()
+		t.Cleanup(ts.Close)
 
 		_, _ = ts.Run(t, []test.TestCase{
 			{Path: "/debug/pprof/", Code: 404},
@@ -538,7 +540,7 @@ func TestHttpPprof(t *testing.T) {
 		ts := StartTest(conf, TestConfig{
 			SeparateControlAPI: true,
 		})
-		defer ts.Close()
+		t.Cleanup(ts.Close)
 
 		_, _ = ts.Run(t, []test.TestCase{
 			{Path: "/debug/pprof/", Code: 404},
@@ -550,7 +552,7 @@ func TestHttpPprof(t *testing.T) {
 
 func TestManagementNodeRedisEvents(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	globalConf := ts.Gw.GetConfig()
 	globalConf.ManagementNode = false
@@ -625,7 +627,7 @@ func TestManagementNodeRedisEvents(t *testing.T) {
 
 func TestListenPathTykPrefix(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/tyk-foo/"
@@ -656,7 +658,7 @@ func TestReloadGoroutineLeakWithTest(t *testing.T) {
 
 func TestReloadGoroutineLeakWithCircuitBreaker(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	globalConf := ts.Gw.GetConfig()
 	globalConf.EnableJSVM = false
@@ -718,7 +720,7 @@ func TestProxyProtocol(t *testing.T) {
 	defer l.Close()
 	go listenProxyProto(l)
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 	rp, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
@@ -762,7 +764,7 @@ func TestProxyProtocol(t *testing.T) {
 
 func TestProxyUserAgent(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/"
@@ -782,7 +784,7 @@ func TestProxyUserAgent(t *testing.T) {
 
 func TestSkipUrlCleaning(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	globalConf := ts.Gw.GetConfig()
 	globalConf.HttpServerOptions.OverrideDefaults = true
@@ -806,7 +808,7 @@ func TestSkipUrlCleaning(t *testing.T) {
 
 func TestMultiTargetProxy(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 		spec.VersionData.NotVersioned = false
@@ -836,7 +838,7 @@ func TestMultiTargetProxy(t *testing.T) {
 
 func TestCustomDomain(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	localClient := test.NewClientLocal()
 
@@ -891,7 +893,7 @@ func TestGatewayHealthCheck(t *testing.T) {
 
 	t.Run("control api port == listen port", func(t *testing.T) {
 		ts := StartTest(nil)
-		defer ts.Close()
+		t.Cleanup(ts.Close)
 
 		t.Run("Without APIs", func(t *testing.T) {
 			_, _ = ts.Run(t, []test.TestCase{
@@ -914,7 +916,7 @@ func TestGatewayHealthCheck(t *testing.T) {
 		ts := StartTest(nil, TestConfig{
 			SeparateControlAPI: true,
 		})
-		defer ts.Close()
+		t.Cleanup(ts.Close)
 
 		t.Run("Without APIs", func(t *testing.T) {
 			_, _ = ts.Run(t, []test.TestCase{
@@ -937,10 +939,14 @@ func TestGatewayHealthCheck(t *testing.T) {
 }
 
 func TestCacheAllSafeRequests(t *testing.T) {
+	test.Exclusive(t) // Need to limit parallelism due to DeleteScanMatch.
+
 	ts := StartTest(nil)
-	defer ts.Close()
 	cache := storage.RedisCluster{KeyPrefix: "cache-", ConnectionHandler: ts.Gw.StorageConnectionHandler}
-	defer cache.DeleteScanMatch("*")
+	t.Cleanup(func() {
+		ts.Close()
+		cache.DeleteScanMatch("*")
+	})
 
 	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 		spec.CacheOptions = apidef.CacheOptions{
@@ -963,10 +969,15 @@ func TestCacheAllSafeRequests(t *testing.T) {
 }
 
 func TestCacheAllSafeRequestsWithCachedHeaders(t *testing.T) {
+	test.Exclusive(t) // Need to limit parallelism due to DeleteScanMatch.
+
 	ts := StartTest(nil)
-	defer ts.Close()
 	cache := storage.RedisCluster{KeyPrefix: "cache-", ConnectionHandler: ts.Gw.StorageConnectionHandler}
-	defer cache.DeleteScanMatch("*")
+	t.Cleanup(func() {
+		ts.Close()
+		cache.DeleteScanMatch("*")
+	})
+
 	authorization := "authorization"
 	tenant := "tenant-id"
 
@@ -1004,10 +1015,14 @@ func TestCacheAllSafeRequestsWithCachedHeaders(t *testing.T) {
 }
 
 func TestCacheWithAdvanceUrlRewrite(t *testing.T) {
+	test.Exclusive(t) // Need to limit parallelism due to DeleteScanMatch.
+
 	ts := StartTest(nil)
-	defer ts.Close()
 	cache := storage.RedisCluster{KeyPrefix: "cache-", ConnectionHandler: ts.Gw.StorageConnectionHandler}
-	defer cache.DeleteScanMatch("*")
+	t.Cleanup(func() {
+		ts.Close()
+		cache.DeleteScanMatch("*")
+	})
 
 	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 		version := spec.VersionData.Versions["v1"]
@@ -1059,10 +1074,15 @@ func TestCacheWithAdvanceUrlRewrite(t *testing.T) {
 }
 
 func TestCachePostRequest(t *testing.T) {
+	test.Exclusive(t) // Need to limit parallelism due to DeleteScanMatch.
+
 	ts := StartTest(nil)
-	defer ts.Close()
 	cache := storage.RedisCluster{KeyPrefix: "cache-", ConnectionHandler: ts.Gw.StorageConnectionHandler}
-	defer cache.DeleteScanMatch("*")
+	t.Cleanup(func() {
+		ts.Close()
+		cache.DeleteScanMatch("*")
+	})
+
 	tenant := "tenant-id"
 
 	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
@@ -1101,10 +1121,15 @@ func TestCachePostRequest(t *testing.T) {
 }
 
 func TestAdvanceCachePutRequest(t *testing.T) {
+	test.Exclusive(t) // Need to limit parallelism due to DeleteScanMatch.
+
 	ts := StartTest(nil)
-	defer ts.Close()
 	cache := storage.RedisCluster{KeyPrefix: "cache-", ConnectionHandler: ts.Gw.StorageConnectionHandler}
-	defer cache.DeleteScanMatch("*")
+	t.Cleanup(func() {
+		ts.Close()
+		cache.DeleteScanMatch("*")
+	})
+
 	tenant := "tenant-id"
 
 	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
@@ -1189,10 +1214,14 @@ func TestAdvanceCachePutRequest(t *testing.T) {
 }
 
 func TestCacheAllSafeRequestsWithAdvancedCacheEndpoint(t *testing.T) {
+	test.Exclusive(t) // Need to limit parallelism due to DeleteScanMatch.
+
 	ts := StartTest(nil)
-	defer ts.Close()
 	cache := storage.RedisCluster{KeyPrefix: "cache-", ConnectionHandler: ts.Gw.StorageConnectionHandler}
-	defer cache.DeleteScanMatch("*")
+	t.Cleanup(func() {
+		ts.Close()
+		cache.DeleteScanMatch("*")
+	})
 
 	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 		spec.CacheOptions = apidef.CacheOptions{
@@ -1224,10 +1253,15 @@ func TestCacheAllSafeRequestsWithAdvancedCacheEndpoint(t *testing.T) {
 }
 
 func TestCacheEtag(t *testing.T) {
+	test.Exclusive(t) // Test is exclusive due to deleting all the cache from redis (interference).
+
 	ts := StartTest(nil)
-	defer ts.Close()
 	cache := storage.RedisCluster{KeyPrefix: "cache-", ConnectionHandler: ts.Gw.StorageConnectionHandler}
-	defer cache.DeleteScanMatch("*")
+
+	t.Cleanup(func() {
+		ts.Close()
+		cache.DeleteScanMatch("*")
+	})
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Etag", "12345")
@@ -1257,8 +1291,7 @@ func TestCacheEtag(t *testing.T) {
 }
 
 func TestOldCachePlugin(t *testing.T) {
-	ts := StartTest(nil)
-	defer ts.Close()
+	test.Exclusive(t) // Test uses cache-* while other tests delete it.
 
 	api := BuildAPI(func(spec *APISpec) {
 		spec.Proxy.ListenPath = "/"
@@ -1275,8 +1308,14 @@ func TestOldCachePlugin(t *testing.T) {
 	headerCache := map[string]string{"x-tyk-cached-response": "1"}
 
 	check := func(t *testing.T) {
+		t.Helper()
+
+		ts := StartTest(nil)
 		cache := storage.RedisCluster{KeyPrefix: "cache-", ConnectionHandler: ts.Gw.StorageConnectionHandler}
-		defer cache.DeleteScanMatch("*")
+		t.Cleanup(func() {
+			ts.Close()
+			cache.DeleteScanMatch("*")
+		})
 
 		ts.Gw.LoadAPI(api)
 		_, _ = ts.Run(t, []test.TestCase{
@@ -1298,10 +1337,14 @@ func TestOldCachePlugin(t *testing.T) {
 }
 
 func TestAdvanceCacheTimeoutPerEndpoint(t *testing.T) {
+	test.Exclusive(t) // Need to limit parallelism due to DeleteScanMatch.
+
 	ts := StartTest(nil)
-	defer ts.Close()
 	cache := storage.RedisCluster{KeyPrefix: "cache-", ConnectionHandler: ts.Gw.StorageConnectionHandler}
-	defer cache.DeleteScanMatch("*")
+	t.Cleanup(func() {
+		ts.Close()
+		cache.DeleteScanMatch("*")
+	})
 
 	extendedPaths := apidef.ExtendedPathsSet{
 		AdvanceCacheConfig: []apidef.CacheMeta{
@@ -1345,7 +1388,7 @@ func TestAdvanceCacheTimeoutPerEndpoint(t *testing.T) {
 
 func TestWebsocketsSeveralOpenClose(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	globalConf := ts.Gw.GetConfig()
 	globalConf.HttpServerOptions.EnableWebSockets = true
@@ -1442,7 +1485,7 @@ func TestWebsocketsSeveralOpenClose(t *testing.T) {
 
 func TestWebsocketsAndHTTPEndpointMatch(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	globalConf := ts.Gw.GetConfig()
 	globalConf.HttpServerOptions.EnableWebSockets = true
@@ -1575,7 +1618,7 @@ func createTestUptream(t *testing.T, allowedConns int, readsPerConn int) net.Lis
 
 func TestKeepAliveConns(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	t.Run("Should use same connection", func(t *testing.T) {
 		// set keep alive option
@@ -1654,7 +1697,7 @@ func TestKeepAliveConns(t *testing.T) {
 // API's global rate limit.
 func TestRateLimitForAPIAndRateLimitAndQuotaCheck(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	globalCfg := ts.Gw.GetConfig()
 	globalCfg.EnableNonTransactionalRateLimiter = false
@@ -1695,7 +1738,7 @@ func TestRateLimitForAPIAndRateLimitAndQuotaCheck(t *testing.T) {
 
 func TestTracing(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	ts.Gw.prepareStorage()
 
@@ -1752,7 +1795,7 @@ func TestBrokenClients(t *testing.T) {
 		gwConf.ProxyDefaultTimeout = 1
 	}
 	ts := StartTest(conf)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 		spec.UseKeylessAccess = true
@@ -1798,7 +1841,7 @@ func TestCache_singleErrorResponse(t *testing.T) {
 	}))
 
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
 		spec.UseKeylessAccess = true
@@ -1831,7 +1874,7 @@ func TestCache_singleErrorResponse(t *testing.T) {
 
 func TestOverrideErrors(t *testing.T) {
 	ts := StartTest(nil)
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	defer defaultTykErrors()
 

--- a/gateway/handler_error.go
+++ b/gateway/handler_error.go
@@ -193,7 +193,7 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 		}
 
 		if e.Spec.Proxy.StripListenPath {
-			r.URL.Path = e.Spec.StripListenPath(r, r.URL.Path)
+			r.URL.Path = e.Spec.StripListenPath(r.URL.Path)
 		}
 
 		oauthClientID := ""

--- a/gateway/model_apispec.go
+++ b/gateway/model_apispec.go
@@ -1,0 +1,75 @@
+package gateway
+
+import (
+	"net/http"
+	"strings"
+)
+
+// CheckSpecMatchesStatus checks if a URL spec has a specific status.
+// Deprecated: The function doesn't follow go return conventions (T, ok); use FindSpecMatchesStatus;
+func (a *APISpec) CheckSpecMatchesStatus(r *http.Request, rxPaths []URLSpec, mode URLStatus) (bool, interface{}) {
+	matchPath, method := a.getMatchPathAndMethod(r, mode)
+
+	for i := range rxPaths {
+		if rxPaths[i].Status != mode {
+			continue
+		}
+		if !rxPaths[i].matchesMethod(method) {
+			continue
+		}
+		if !rxPaths[i].matchesPath(matchPath, a) {
+			continue
+		}
+
+		if spec, ok := rxPaths[i].modeSpecificSpec(mode); ok {
+			return true, spec
+		}
+	}
+	return false, nil
+}
+
+// FindSpecMatchesStatus checks if a URL spec has a specific status and returns the URLSpec for it.
+func (a *APISpec) FindSpecMatchesStatus(r *http.Request, rxPaths []URLSpec, mode URLStatus) (*URLSpec, bool) {
+	matchPath, method := a.getMatchPathAndMethod(r, mode)
+
+	for i := range rxPaths {
+		if rxPaths[i].Status != mode {
+			continue
+		}
+		if !rxPaths[i].matchesMethod(method) {
+			continue
+		}
+		if !rxPaths[i].matchesPath(matchPath, a) {
+			continue
+		}
+
+		return &rxPaths[i], true
+	}
+	return nil, false
+}
+
+// getMatchPathAndMethod retrieves the match path and method from the request based on the mode.
+func (a *APISpec) getMatchPathAndMethod(r *http.Request, mode URLStatus) (string, string) {
+	var (
+		matchPath = r.URL.Path
+		method    = r.Method
+	)
+
+	if mode == TransformedJQResponse || mode == HeaderInjectedResponse || mode == TransformedResponse {
+		matchPath = ctxGetUrlRewritePath(r)
+		method = ctxGetRequestMethod(r)
+		if matchPath == "" {
+			matchPath = r.URL.Path
+		}
+	}
+
+	if a.Proxy.ListenPath != "/" {
+		matchPath = a.StripListenPath(matchPath)
+	}
+
+	if !strings.HasPrefix(matchPath, "/") {
+		matchPath = "/" + matchPath
+	}
+
+	return matchPath, method
+}

--- a/gateway/model_urlspec.go
+++ b/gateway/model_urlspec.go
@@ -1,0 +1,120 @@
+package gateway
+
+// modeSpecificSpec returns the respective field of URLSpec if it matches the given mode.
+// Deprecated: Usage should not increase.
+func (u *URLSpec) modeSpecificSpec(mode URLStatus) (interface{}, bool) {
+	switch mode {
+	case Ignored, BlackList, WhiteList:
+		return nil, true
+	case Cached:
+		return &u.CacheConfig, true
+	case Transformed:
+		return &u.TransformAction, true
+	case TransformedJQ:
+		return &u.TransformJQAction, true
+	case HeaderInjected:
+		return &u.InjectHeaders, true
+	case HeaderInjectedResponse:
+		return &u.InjectHeadersResponse, true
+	case TransformedResponse:
+		return &u.TransformResponseAction, true
+	case TransformedJQResponse:
+		return &u.TransformJQResponseAction, true
+	case HardTimeout:
+		return &u.HardTimeout.TimeOut, true
+	case CircuitBreaker:
+		return &u.CircuitBreaker, true
+	case URLRewrite:
+		return u.URLRewrite, true
+	case VirtualPath:
+		return &u.VirtualPathSpec, true
+	case RequestSizeLimit:
+		return &u.RequestSize, true
+	case MethodTransformed:
+		return &u.MethodTransform, true
+	case RequestTracked:
+		return &u.TrackEndpoint, true
+	case RequestNotTracked:
+		return &u.DoNotTrackEndpoint, true
+	case ValidateJSONRequest:
+		return &u.ValidatePathMeta, true
+	case Internal:
+		return &u.Internal, true
+	case GoPlugin:
+		return &u.GoPluginMeta, true
+	case PersistGraphQL:
+		return &u.PersistGraphQL, true
+	default:
+		return nil, false
+	}
+}
+
+// matchesMethod checks if the given method matches the method required by the URLSpec for the current status.
+func (u *URLSpec) matchesMethod(method string) bool {
+	switch u.Status {
+	case Ignored, BlackList, WhiteList:
+		return true
+	case Cached:
+		return method == u.CacheConfig.Method || (u.CacheConfig.Method == SAFE_METHODS && isSafeMethod(method))
+	case Transformed:
+		return method == u.TransformAction.Method
+	case TransformedJQ:
+		return method == u.TransformJQAction.Method
+	case HeaderInjected:
+		return method == u.InjectHeaders.Method
+	case HeaderInjectedResponse:
+		return method == u.InjectHeadersResponse.Method
+	case TransformedResponse:
+		return method == u.TransformResponseAction.Method
+	case TransformedJQResponse:
+		return method == u.TransformJQResponseAction.Method
+	case HardTimeout:
+		return method == u.HardTimeout.Method
+	case CircuitBreaker:
+		return method == u.CircuitBreaker.Method
+	case URLRewrite:
+		return method == u.URLRewrite.Method
+	case VirtualPath:
+		return method == u.VirtualPathSpec.Method
+	case RequestSizeLimit:
+		return method == u.RequestSize.Method
+	case MethodTransformed:
+		return method == u.MethodTransform.Method
+	case RequestTracked:
+		return method == u.TrackEndpoint.Method
+	case RequestNotTracked:
+		return method == u.DoNotTrackEndpoint.Method
+	case ValidateJSONRequest:
+		return method == u.ValidatePathMeta.Method
+	case Internal:
+		return method == u.Internal.Method
+	case GoPlugin:
+		return method == u.GoPluginMeta.Meta.Method
+	case PersistGraphQL:
+		return method == u.PersistGraphQL.Method
+	default:
+		return false
+	}
+}
+
+// matchesPath takes the input string and matches it against an internal regex.
+// it will match the regex against the clean URL with stripped listen path first,
+// then it will match against the full URL including the listen path as provided.
+// APISpec to provide URL sanitization of the input is passed along.
+func (a *URLSpec) matchesPath(reqPath string, api *APISpec) bool {
+	clean := api.StripListenPath(reqPath)
+	noVersion := api.StripVersionPath(clean)
+	// match /users
+	if noVersion != clean && a.spec.MatchString(noVersion) {
+		return true
+	}
+	// match /v3/users
+	if a.spec.MatchString(clean) {
+		return true
+	}
+	// match /listenpath/v3/users
+	if a.spec.MatchString(reqPath) {
+		return true
+	}
+	return false
+}

--- a/gateway/mw_granular_access.go
+++ b/gateway/mw_granular_access.go
@@ -3,6 +3,10 @@ package gateway
 import (
 	"errors"
 	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/TykTechnologies/tyk/internal/httputil"
 	"github.com/TykTechnologies/tyk/regexp"
@@ -23,7 +27,6 @@ func (m *GranularAccessMiddleware) ProcessRequest(w http.ResponseWriter, r *http
 		return nil, http.StatusOK
 	}
 
-	logger := m.Logger().WithField("path", r.URL.Path)
 	session := ctxGetSession(r)
 
 	sessionVersionData, foundAPI := session.AccessRights[m.Spec.APIID]
@@ -35,39 +38,90 @@ func (m *GranularAccessMiddleware) ProcessRequest(w http.ResponseWriter, r *http
 		return nil, http.StatusOK
 	}
 
-	urlPath := m.Spec.StripListenPath(r.URL.Path)
+	gwConfig := m.Gw.GetConfig()
 
-	for _, accessSpec := range sessionVersionData.AllowedURLs {
-		url := accessSpec.URL
-		clean, err := httputil.GetPathRegexp(url)
-		if err != nil {
-			logger.WithError(err).Errorf("error getting path regex: %q, skipping", url)
-			continue
+	// Hook per-api settings here (m.Spec...)
+	isPrefixMatch := gwConfig.HttpServerOptions.EnablePathPrefixMatching
+	isSuffixMatch := gwConfig.HttpServerOptions.EnablePathSuffixMatching
+
+	if isPrefixMatch {
+		urlPaths := []string{
+			m.Spec.StripListenPath(r.URL.Path),
+			r.URL.Path,
 		}
 
-		asRegex, err := regexp.Compile(clean)
-		if err != nil {
-			logger.WithError(err).Errorf("error compiling path regex: %q, skipping", url)
-			continue
-		}
+		logger := m.Logger().WithField("paths", urlPaths)
 
-		match := asRegex.MatchString(urlPath)
+		for _, accessSpec := range sessionVersionData.AllowedURLs {
+			if !slices.Contains(accessSpec.Methods, r.Method) {
+				continue
+			}
 
-		logger.WithField("pattern", url).WithField("match", match).Debug("checking allowed url")
+			// Append $ if so configured to match end of request path.
+			pattern := httputil.PreparePathRegexp(accessSpec.URL, isPrefixMatch, isSuffixMatch)
+			if isSuffixMatch && !strings.HasSuffix(pattern, "$") {
+				pattern += "$"
+			}
 
-		if match {
-			// if a path is matched, but isn't matched on method,
-			// then we continue onto the next path for evaluation.
-			for _, method := range accessSpec.Methods {
-				if method == r.Method {
-					return nil, http.StatusOK
+			match, err := httputil.MatchPaths(pattern, urlPaths)
+
+			// unconditional log of err/match/url
+			// if loglevel is set to debug verbosity increases and all requests are logged,
+			// regardless if an error occured or not.
+			if gwConfig.LogLevel == "debug" || err != nil {
+				logger = logger.WithError(err).WithField("pattern", pattern).WithField("match", match)
+				if err != nil {
+					logger.Error("error matching endpoint")
+				} else {
+					logger.Debug("matching endpoint")
 				}
 			}
+
+			if err != nil || !match {
+				continue
+			}
+			return m.pass()
+		}
+
+		return m.block(logger)
+	}
+
+	logger := m.Logger().WithField("paths", []string{r.URL.Path})
+
+	// Legacy behaviour (5.5.0 and earlier), wildcard match against full request path.
+	// Fixed error handling in regex compilation to continue to next pattern (block).
+	urlPath := r.URL.Path
+
+	for _, accessSpec := range sessionVersionData.AllowedURLs {
+		if !slices.Contains(accessSpec.Methods, r.Method) {
+			continue
+		}
+
+		pattern := httputil.PreparePathRegexp(accessSpec.URL, false, isSuffixMatch)
+
+		logger.Debug("Checking: ", urlPath, " Against:", pattern)
+
+		// Wildcard match (user supplied, as-is)
+		asRegex, err := regexp.Compile(pattern)
+		if err != nil {
+			logger.WithError(err).Error("error compiling regex")
+			continue
+		}
+
+		match := asRegex.MatchString(r.URL.Path)
+		if match {
+			return m.pass()
 		}
 	}
 
+	return m.block(logger)
+}
+
+func (m *GranularAccessMiddleware) block(logger *logrus.Entry) (error, int) {
 	logger.Info("Attempted access to unauthorised endpoint (Granular).")
-
 	return errors.New("Access to this resource has been disallowed"), http.StatusForbidden
+}
 
+func (m *GranularAccessMiddleware) pass() (error, int) {
+	return nil, http.StatusOK
 }

--- a/gateway/mw_granular_access_test.go
+++ b/gateway/mw_granular_access_test.go
@@ -25,6 +25,10 @@ func TestGranularAccessMiddleware_ProcessRequest(t *testing.T) {
 				APIName: api.Name,
 				AllowedURLs: []user.AccessSpec{
 					{
+						URL:     "^/*.$",
+						Methods: []string{"GET"},
+					},
+					{
 						URL:     "^/valid_path.*",
 						Methods: []string{"GET"},
 					},

--- a/gateway/mw_request_signing.go
+++ b/gateway/mw_request_signing.go
@@ -77,17 +77,17 @@ func generateHeaderList(r *http.Request, headerList []string) []string {
 }
 
 func (s *RequestSigning) getRequestPath(r *http.Request) string {
-	path := r.URL.RequestURI()
+	urlPath := r.URL.RequestURI()
 
 	if newURL := ctxGetURLRewriteTarget(r); newURL != nil {
-		path = newURL.RequestURI()
+		urlPath = newURL.RequestURI()
 	} else {
 		if s.Spec.Proxy.StripListenPath {
-			path = s.Spec.StripListenPath(r, path)
+			urlPath = s.Spec.StripListenPath(urlPath)
 		}
 	}
 
-	return path
+	return urlPath
 }
 
 func (s *RequestSigning) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {

--- a/internal/httputil/Taskfile.yml
+++ b/internal/httputil/Taskfile.yml
@@ -1,10 +1,49 @@
 ---
 version: "3"
 
+vars:
+  testArgs: -v
+
 tasks:
-  default:
-    desc: "Run tests"
+  test:
+    desc: "Run tests (requires redis)"
     cmds:
-      - go fmt ./...
+      - task: fmt
+      - go test {{.testArgs}} -count=1 -cover -coverprofile=rate.cov -coverpkg=./... ./...
+
+  bench:
+    desc: "Run benchmarks"
+    cmds:
+      - task: fmt
+      - go test {{.testArgs}} -count=1 -tags integration -bench=. -benchtime=10s -benchmem ./...
+
+  fmt:
+    internal: true
+    desc: "Invoke fmt"
+    cmds:
       - goimports -w .
-      - go test -race -count=100 -cover .
+      - go fmt ./...
+
+  cover:
+    desc: "Show source coverage"
+    aliases: [coverage, cov]
+    cmds:
+      - go tool cover -func=rate.cov
+
+  uncover:
+    desc: "Show uncovered source"
+    cmds:
+      - uncover rate.cov
+
+  lint:
+    desc: "Lint docs"
+    cmds:
+      - schema-gen extract -o - | schema-gen lint -i -
+
+  install:uncover:
+    desc: "Install uncover"
+    internal: true
+    env:
+      GOBIN: /usr/local/bin
+    cmds:
+      - go install github.com/gregoryv/uncover/...@latest

--- a/internal/httputil/connection_watcher.go
+++ b/internal/httputil/connection_watcher.go
@@ -29,7 +29,6 @@ func (cw *ConnectionWatcher) OnStateChange(_ net.Conn, state http.ConnState) {
 }
 
 // Count returns the number of connections at the time the call.
-
 func (cw *ConnectionWatcher) Count() int {
 	return int(atomic.LoadInt64(&cw.n))
 }

--- a/internal/httputil/mux.go
+++ b/internal/httputil/mux.go
@@ -1,6 +1,8 @@
 package httputil
 
 import (
+	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -9,34 +11,55 @@ import (
 	"github.com/TykTechnologies/tyk/internal/maps"
 )
 
-// routeCache holds the raw routes as they are mapped to mux regular expressions.
-// e.g. `/foo` becomes `^/foo$` or similar, and parameters get matched and replaced.
+// routeCache holds the raw routes as they are mapped from mux parameters to regular expressions.
+// e.g. `/foo/{id}` becomes `^/foo/([^/]+)$` or similar.
 var pathRegexpCache = maps.NewStringMap()
 
-// GetPathRegexp will convert a mux route url to a regular expression string.
-// The results for subsequent invocations with the same parameters are cached.
-func GetPathRegexp(pattern string) (string, error) {
-	val, ok := pathRegexpCache.Get(pattern)
+// apiLandIDsRegex matches mux-style parameters like `{id}`.
+var apiLangIDsRegex = regexp.MustCompile(`{([^}]+)}`)
+
+// PreparePathRexep will replace mux-style parameters in input with a compatible regular expression.
+// Parameters like `{id}` would be replaced to `([^/]+)`. If the input pattern provides a starting
+// or ending delimiters (`^` or `$`), the pattern is returned.
+// If prefix is true, and pattern starts with /, the returned pattern prefixes a `^` to the regex.
+// No other prefix matches are possible so only `/` to `^/` conversion is considered.
+// If suffix is true, the returned pattern suffixes a `$` to the regex.
+// If both prefix and suffixes are achieved, an explicit match is made.
+func PreparePathRegexp(pattern string, prefix bool, suffix bool) string {
+	// Construct cache key from pattern and flags
+	key := fmt.Sprintf("%s:%v:%v", pattern, prefix, suffix)
+	val, ok := pathRegexpCache.Get(key)
 	if ok {
-		return val, nil
+		return val
 	}
 
+	// Replace mux named parameters with regex path match.
 	if IsMuxTemplate(pattern) {
-		dummyRouter := mux.NewRouter()
-		route := dummyRouter.PathPrefix(pattern)
-		result, err := route.GetPathRegexp()
-		if err != nil {
-			return "", err
-		}
-
-		pathRegexpCache.Set(pattern, result)
-		return result, nil
+		pattern = apiLangIDsRegex.ReplaceAllString(pattern, `([^/]+)`)
 	}
 
-	if strings.HasPrefix(pattern, "/") {
-		return "^" + pattern, nil
+	// Replace mux wildcard path with a `.*` (match 0 or more characters)
+	if strings.Contains(pattern, "/*") {
+		pattern = strings.ReplaceAll(pattern, "/*/", "/[^/]+/")
+		pattern = strings.ReplaceAll(pattern, "/*", "/.*")
 	}
-	return "^.*" + pattern, nil
+
+	// Pattern `/users` becomes `^/users`.
+	if prefix && strings.HasPrefix(pattern, "/") {
+		pattern = "^" + pattern
+	}
+
+	// Append $ if necessary to enforce suffix matching.
+	// Pattern `/users` becomes `/users$`.
+	// Pattern `^/users` becomes `^/users$`.
+	if suffix && !strings.HasSuffix(pattern, "$") {
+		pattern = pattern + "$"
+	}
+
+	// Save cache for following invocations.
+	pathRegexpCache.Set(key, pattern)
+
+	return pattern
 }
 
 // IsMuxTemplate determines if a pattern is a mux template by counting the number of opening and closing braces.
@@ -76,4 +99,41 @@ func StripListenPath(listenPath, urlPath string) (res string) {
 
 	reg := regexp.MustCompile(s)
 	return reg.ReplaceAllString(res, "")
+}
+
+// MatchPath matches regexp pattern with request endpoint.
+func MatchPath(pattern string, endpoint string) (bool, error) {
+	if strings.Trim(pattern, "^$") == "" || endpoint == "" {
+		return false, nil
+	}
+	if pattern == endpoint || pattern == "^"+endpoint+"$" {
+		return true, nil
+	}
+
+	asRegex, err := regexp.Compile(pattern)
+	if err != nil {
+		return false, err
+	}
+
+	return asRegex.MatchString(endpoint), nil
+}
+
+// MatchPaths matches regexp pattern with multiple request URLs endpoint paths.
+// It will return true if any of them is correctly matched, with no error.
+// If no matches occur, any errors will be retured joined with errors.Join.
+func MatchPaths(pattern string, endpoints []string) (bool, error) {
+	var errs []error
+
+	for _, endpoint := range endpoints {
+		match, err := MatchPath(pattern, endpoint)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if match {
+			return true, nil
+		}
+	}
+
+	return false, errors.Join(errs...)
 }

--- a/internal/httputil/mux.go
+++ b/internal/httputil/mux.go
@@ -1,0 +1,79 @@
+package httputil
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/gorilla/mux"
+
+	"github.com/TykTechnologies/tyk/internal/maps"
+)
+
+// routeCache holds the raw routes as they are mapped to mux regular expressions.
+// e.g. `/foo` becomes `^/foo$` or similar, and parameters get matched and replaced.
+var pathRegexpCache = maps.NewStringMap()
+
+// GetPathRegexp will convert a mux route url to a regular expression string.
+// The results for subsequent invocations with the same parameters are cached.
+func GetPathRegexp(pattern string) (string, error) {
+	val, ok := pathRegexpCache.Get(pattern)
+	if ok {
+		return val, nil
+	}
+
+	if IsMuxTemplate(pattern) {
+		dummyRouter := mux.NewRouter()
+		route := dummyRouter.PathPrefix(pattern)
+		result, err := route.GetPathRegexp()
+		if err != nil {
+			return "", err
+		}
+
+		pathRegexpCache.Set(pattern, result)
+		return result, nil
+	}
+
+	if strings.HasPrefix(pattern, "/") {
+		return "^" + pattern, nil
+	}
+	return "^.*" + pattern, nil
+}
+
+// IsMuxTemplate determines if a pattern is a mux template by counting the number of opening and closing braces.
+func IsMuxTemplate(pattern string) bool {
+	openBraces := strings.Count(pattern, "{")
+	closeBraces := strings.Count(pattern, "}")
+	return openBraces > 0 && openBraces == closeBraces
+}
+
+// StripListenPath will strip the listenPath from the passed urlPath.
+// If the listenPath contains mux variables, it will trim away the
+// matching pattern with a regular expression that mux provides.
+func StripListenPath(listenPath, urlPath string) (res string) {
+	defer func() {
+		if !strings.HasPrefix(res, "/") {
+			res = "/" + res
+		}
+	}()
+
+	res = urlPath
+
+	// early return on the simple case
+	if strings.HasPrefix(urlPath, listenPath) {
+		res = strings.TrimPrefix(res, listenPath)
+		return res
+	}
+
+	if !IsMuxTemplate(listenPath) {
+		return res
+	}
+
+	tmp := new(mux.Route).PathPrefix(listenPath)
+	s, err := tmp.GetPathRegexp()
+	if err != nil {
+		return res
+	}
+
+	reg := regexp.MustCompile(s)
+	return reg.ReplaceAllString(res, "")
+}

--- a/internal/httputil/mux_test.go
+++ b/internal/httputil/mux_test.go
@@ -1,0 +1,64 @@
+package httputil_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk/internal/httputil"
+)
+
+func testPathRegexp(tb testing.TB, in string, want string) string {
+	tb.Helper()
+
+	res, err := httputil.GetPathRegexp(in)
+	assert.NoError(tb, err)
+	if want != "" {
+		assert.Equal(tb, want, res)
+	}
+	return res
+}
+
+func TestGetPathRegexp(t *testing.T) {
+	tests := map[string]string{
+		"/users*.":                             "^/users*.",
+		"/users":                               "^/users",
+		"users":                                "^.*users",
+		"/users$":                              "^/users$",
+		"/users/.*":                            "^/users/.*",
+		"/users/{id}":                          "^/users/(?P<v0>[^/]+)",
+		"/users/{id}/profile/{type:[a-zA-Z]+}": "^/users/(?P<v0>[^/]+)/profile/(?P<v1>[a-zA-Z]+)",
+		"/static/{path}/assets/{file}":         "^/static/(?P<v0>[^/]+)/assets/(?P<v1>[^/]+)",
+		"/items/{itemID:[0-9]+}/details/{detail}": "^/items/(?P<v0>[0-9]+)/details/(?P<v1>[^/]+)",
+	}
+
+	for k, v := range tests {
+		testPathRegexp(t, k, v)
+	}
+}
+
+func TestGetPathRegexpWithRegexCompile(t *testing.T) {
+	pattern := testPathRegexp(t, "/api/v1/users/{userId}/roles/{roleId}", "")
+
+	matched, err := regexp.MatchString(pattern, "/api/v1/users/10512/roles/32587")
+	assert.NoError(t, err)
+	assert.True(t, matched, "The URL should match the pattern")
+}
+
+func TestStripListenPath(t *testing.T) {
+	assert.Equal(t, "/get", httputil.StripListenPath("/listen", "/listen/get"))
+	assert.Equal(t, "/get", httputil.StripListenPath("/listen/", "/listen/get"))
+	assert.Equal(t, "/get", httputil.StripListenPath("listen", "listen/get"))
+	assert.Equal(t, "/get", httputil.StripListenPath("listen/", "listen/get"))
+	assert.Equal(t, "/", httputil.StripListenPath("/listen/", "/listen/"))
+	assert.Equal(t, "/", httputil.StripListenPath("/listen", "/listen"))
+	assert.Equal(t, "/", httputil.StripListenPath("listen/", ""))
+
+	assert.Equal(t, "/get", httputil.StripListenPath("/{_:.*}/post/", "/listen/post/get"))
+	assert.Equal(t, "/get", httputil.StripListenPath("/{_:.*}/", "/listen/get"))
+	assert.Equal(t, "/get", httputil.StripListenPath("/pre/{_:.*}/", "/pre/listen/get"))
+	assert.Equal(t, "/", httputil.StripListenPath("/{_:.*}", "/listen"))
+	assert.Equal(t, "/get", httputil.StripListenPath("/{myPattern:foo|bar}", "/foo/get"))
+	assert.Equal(t, "/anything/get", httputil.StripListenPath("/{myPattern:foo|bar}", "/anything/get"))
+}

--- a/internal/httputil/mux_test.go
+++ b/internal/httputil/mux_test.go
@@ -9,37 +9,36 @@ import (
 	"github.com/TykTechnologies/tyk/internal/httputil"
 )
 
-func testPathRegexp(tb testing.TB, in string, want string) string {
+func pathRegexp(tb testing.TB, in string, want string) string {
 	tb.Helper()
 
-	res, err := httputil.GetPathRegexp(in)
-	assert.NoError(tb, err)
-	if want != "" {
-		assert.Equal(tb, want, res)
-	}
+	res := httputil.PreparePathRegexp(in, true, false)
+	assert.Equal(tb, want, res)
 	return res
 }
 
-func TestGetPathRegexp(t *testing.T) {
+func TestPreparePathRegexp(t *testing.T) {
 	tests := map[string]string{
 		"/users*.":                             "^/users*.",
 		"/users":                               "^/users",
-		"users":                                "^.*users",
+		"users":                                "users",
+		"^/test/users":                         "^/test/users",
 		"/users$":                              "^/users$",
 		"/users/.*":                            "^/users/.*",
-		"/users/{id}":                          "^/users/(?P<v0>[^/]+)",
-		"/users/{id}/profile/{type:[a-zA-Z]+}": "^/users/(?P<v0>[^/]+)/profile/(?P<v1>[a-zA-Z]+)",
-		"/static/{path}/assets/{file}":         "^/static/(?P<v0>[^/]+)/assets/(?P<v1>[^/]+)",
-		"/items/{itemID:[0-9]+}/details/{detail}": "^/items/(?P<v0>[0-9]+)/details/(?P<v1>[^/]+)",
+		"/users/{id}":                          "^/users/([^/]+)",
+		"/users/{id}$":                         "^/users/([^/]+)$",
+		"/users/{id}/profile/{type:[a-zA-Z]+}": "^/users/([^/]+)/profile/([^/]+)",
+		"/static/{path}/assets/{file}":         "^/static/([^/]+)/assets/([^/]+)",
+		"/items/{itemID:[0-9]+}/details/{detail}": "^/items/([^/]+)/details/([^/]+)",
 	}
 
 	for k, v := range tests {
-		testPathRegexp(t, k, v)
+		pathRegexp(t, k, v)
 	}
 }
 
 func TestGetPathRegexpWithRegexCompile(t *testing.T) {
-	pattern := testPathRegexp(t, "/api/v1/users/{userId}/roles/{roleId}", "")
+	pattern := pathRegexp(t, "/api/v1/users/{userId}/roles/{roleId}", "^/api/v1/users/([^/]+)/roles/([^/]+)")
 
 	matched, err := regexp.MatchString(pattern, "/api/v1/users/10512/roles/32587")
 	assert.NoError(t, err)
@@ -61,4 +60,103 @@ func TestStripListenPath(t *testing.T) {
 	assert.Equal(t, "/", httputil.StripListenPath("/{_:.*}", "/listen"))
 	assert.Equal(t, "/get", httputil.StripListenPath("/{myPattern:foo|bar}", "/foo/get"))
 	assert.Equal(t, "/anything/get", httputil.StripListenPath("/{myPattern:foo|bar}", "/anything/get"))
+}
+
+func TestMatchPaths(t *testing.T) {
+	tests := []struct {
+		name     string
+		pattern  string
+		endpoint string
+		match    bool
+		isErr    bool
+	}{
+		{
+			name:     "exact endpoints",
+			pattern:  "/api/v1/users",
+			endpoint: "/api/v1/users",
+			match:    true,
+			isErr:    false,
+		},
+		{
+			name:     "non matching concrete endpoints",
+			pattern:  "/api/v1/users",
+			endpoint: "/api/v1/admin",
+			match:    false,
+			isErr:    false,
+		},
+		{
+			name:     "regexp match",
+			pattern:  "/api/v1/user/\\d+",
+			endpoint: "/api/v1/user/123",
+			match:    true,
+			isErr:    false,
+		},
+		{
+			name:     "regexp non match",
+			pattern:  "/api/v1/user/\\d+",
+			endpoint: "/api/v1/user/abc",
+			match:    false,
+			isErr:    false,
+		},
+		{
+			name:     "mux var match",
+			pattern:  "/api/v1/user/{id}",
+			endpoint: "/api/v1/user/123",
+			match:    true,
+			isErr:    false,
+		},
+		{
+			name:     "invalid config regexp",
+			pattern:  "/api/v1/[user",
+			endpoint: "/api/v1/user",
+			match:    false,
+			isErr:    true,
+		},
+		{
+			name:     "wildcard endpoint",
+			pattern:  "/api/v1/*",
+			endpoint: "/api/v1/users",
+			match:    true,
+			isErr:    false,
+		},
+		{
+			name:     "empty config endpoint",
+			pattern:  "",
+			endpoint: "/api/v1/user",
+			match:    false,
+			isErr:    false,
+		},
+		{
+			name:     "empty request endpoint",
+			pattern:  "/api/v1/user",
+			endpoint: "",
+			match:    false,
+			isErr:    false,
+		},
+		{
+			name:     "both empty endpoints",
+			pattern:  "",
+			endpoint: "",
+			match:    false,
+			isErr:    false,
+		},
+		{
+			name:     "/ endpoint",
+			pattern:  "/",
+			endpoint: "/",
+			match:    true,
+			isErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// explicit match inputs as `^/path$`
+			pattern := httputil.PreparePathRegexp(tt.pattern, true, true)
+
+			result, err := httputil.MatchPaths(pattern, []string{tt.endpoint})
+			assert.Equal(t, tt.match, result)
+			assert.Equal(t, tt.isErr, err != nil)
+		})
+	}
 }

--- a/internal/httputil/response.go
+++ b/internal/httputil/response.go
@@ -24,9 +24,10 @@ func InternalServerError(w http.ResponseWriter, _ *http.Request) {
 	http.Error(w, http.StatusText(status), status)
 }
 
-func RemoveResponseTransferEncoding(response *http.Response, encoding string) {
+// RemoveResponseTransferEncoding will remove a transfer encoding hint from the response.
+func RemoveResponseTransferEncoding(response *http.Response, victim string) {
 	for i, value := range response.TransferEncoding {
-		if value == encoding {
+		if value == victim {
 			response.TransferEncoding = append(response.TransferEncoding[:i], response.TransferEncoding[i+1:]...)
 		}
 	}

--- a/internal/httputil/streaming_test.go
+++ b/internal/httputil/streaming_test.go
@@ -1,0 +1,80 @@
+package httputil_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/TykTechnologies/tyk/internal/httputil"
+)
+
+const (
+	headerContentType = "Content-Type"
+	headerUpgrade     = "Upgrade"
+	headerConnection  = "Connection"
+)
+
+// Helper function to create a request with specified headers
+func newRequestWithHeaders(tb testing.TB, contentLength int64, headers map[string]string) *http.Request {
+	tb.Helper()
+	req := &http.Request{
+		ContentLength: contentLength,
+		Header:        make(http.Header),
+	}
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+	return req
+}
+
+// Helper function to create a response with specified headers
+func newResponseWithHeaders(tb testing.TB, headers map[string]string) *http.Response {
+	tb.Helper()
+	resp := &http.Response{
+		Header: make(http.Header),
+	}
+	for key, value := range headers {
+		resp.Header.Set(key, value)
+	}
+	return resp
+}
+
+func TestIsGrpcStreaming(t *testing.T) {
+	assert.True(t, IsGrpcStreaming(newRequestWithHeaders(t, -1, map[string]string{headerContentType: "application/grpc"})))
+	assert.False(t, IsGrpcStreaming(newRequestWithHeaders(t, 0, map[string]string{headerContentType: "application/grpc"})))
+	assert.False(t, IsGrpcStreaming(newRequestWithHeaders(t, -1, map[string]string{headerContentType: "text/plain"})))
+}
+
+func TestIsSseStreamingResponse(t *testing.T) {
+	assert.True(t, IsSseStreamingResponse(newResponseWithHeaders(t, map[string]string{headerContentType: "text/event-stream"})))
+	assert.False(t, IsSseStreamingResponse(newResponseWithHeaders(t, map[string]string{headerContentType: "application/json"})))
+}
+
+func TestIsUpgrade(t *testing.T) {
+	req := newRequestWithHeaders(t, 0, map[string]string{headerConnection: "Upgrade", headerUpgrade: "websocket"})
+	upgradeType, ok := IsUpgrade(req)
+	assert.True(t, ok)
+	assert.Equal(t, "websocket", upgradeType)
+
+	req = newRequestWithHeaders(t, 0, map[string]string{headerConnection: "keep-alive", headerUpgrade: "websocket"})
+	upgradeType, ok = IsUpgrade(req)
+	assert.False(t, ok)
+	assert.Empty(t, upgradeType)
+
+	req = newRequestWithHeaders(t, 0, map[string]string{headerConnection: "Upgrade"})
+	upgradeType, ok = IsUpgrade(req)
+	assert.False(t, ok)
+	assert.Empty(t, upgradeType)
+}
+
+func TestIsStreamingRequest(t *testing.T) {
+	assert.True(t, IsStreamingRequest(newRequestWithHeaders(t, -1, map[string]string{headerContentType: "application/grpc"})))
+	assert.True(t, IsStreamingRequest(newRequestWithHeaders(t, 0, map[string]string{headerConnection: "Upgrade", headerUpgrade: "websocket"})))
+	assert.False(t, IsStreamingRequest(newRequestWithHeaders(t, 0, map[string]string{headerConnection: "keep-alive"})))
+}
+
+func TestIsStreamingResponse(t *testing.T) {
+	assert.True(t, IsStreamingResponse(newResponseWithHeaders(t, map[string]string{headerContentType: "text/event-stream"})))
+	assert.False(t, IsStreamingResponse(newResponseWithHeaders(t, map[string]string{headerContentType: "application/json"})))
+}

--- a/internal/maps/strings.go
+++ b/internal/maps/strings.go
@@ -1,0 +1,34 @@
+package maps
+
+import "sync"
+
+// StringMap holds a concurrency safe, type safe access to map[string]string.
+// Access is protected with a sync.RWMutex, optimized for reads.
+type StringMap struct {
+	mu   sync.RWMutex
+	data map[string]string
+}
+
+// NewStringMap returns a new *StringMap.
+func NewStringMap() *StringMap {
+	return &StringMap{
+		data: make(map[string]string),
+	}
+}
+
+// Set will set a value to a key in the map.
+func (s *StringMap) Set(key, value string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.data[key] = value
+}
+
+// Get returns the value, and if it existed in the map.
+func (s *StringMap) Get(key string) (string, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	v, ok := s.data[key]
+	return v, ok
+}

--- a/test/util.go
+++ b/test/util.go
@@ -2,7 +2,13 @@ package test
 
 import (
 	"os"
+	"sync"
 	"testing"
+)
+
+var (
+	// exclusiveTestMu is used by Exclusive()
+	exclusiveTestMu sync.Mutex
 )
 
 // CI returns true when a non-empty CI env is present
@@ -18,6 +24,15 @@ func Flaky(t *testing.T, fake ...func() (bool, func(...interface{}))) {
 // Racy skips a racy test in a CI environment
 func Racy(t *testing.T, fake ...func() (bool, func(...interface{}))) {
 	skipCI(t, "Skipping Racy test", fake...)
+}
+
+// Exclusive uses a lock to gate only a single test running.
+func Exclusive(t *testing.T) {
+	t.Log("# Test marked as exclusive")
+	exclusiveTestMu.Lock()
+	t.Cleanup(func() {
+		exclusiveTestMu.Unlock()
+	})
 }
 
 func skipCI(t *testing.T, message string, fake ...func() (bool, func(...interface{}))) {

--- a/tests/regression/Taskfile.yml
+++ b/tests/regression/Taskfile.yml
@@ -45,7 +45,7 @@ tasks:
     quiet: true
     vars:
       funcs:
-        sh: ./regression.test -test.list=Test | egrep -v 'Test_Issue[0-9]+' || true
+        sh: ./regression.test -test.list=Test | egrep -v '(Test_Issue[0-9]+|TestLoadAPISpec)' || true
     cmds:
       - cmd: '{{if ne .funcs ""}}echo -e "Naming violations:\n{{.funcs}}" && exit 1 {{end}}'
 

--- a/tests/regression/issue_10104_test.go
+++ b/tests/regression/issue_10104_test.go
@@ -13,7 +13,7 @@ func Test_Issue10104(t *testing.T) {
 	defer ts.Close()
 
 	// load api definition from file
-	ts.Gw.LoadAPI(loadAPISpec(t, "testdata/issue-10104-apidef.json"))
+	ts.Gw.LoadAPI(LoadAPISpec(t, "testdata/issue-10104-apidef.json"))
 
 	// issue request against /test to trigger panic
 	ts.Run(t, []test.TestCase{

--- a/tests/regression/issue_11806_test.go
+++ b/tests/regression/issue_11806_test.go
@@ -20,8 +20,8 @@ func Test_Issue11806_DomainRouting(t *testing.T) {
 		conf.EnableCustomDomains = true
 	}
 
-	noDomain := loadAPISpec(t, "testdata/issue-11806-api-no-domain.json")
-	withDomain := loadAPISpec(t, "testdata/issue-11806-api-with-domain.json")
+	noDomain := LoadAPISpec(t, "testdata/issue-11806-api-no-domain.json")
+	withDomain := LoadAPISpec(t, "testdata/issue-11806-api-with-domain.json")
 
 	t.Run("Load listenPath without domain first", func(t *testing.T) {
 		ts := gateway.StartTest(testConfig)

--- a/tests/regression/issue_12865_test.go
+++ b/tests/regression/issue_12865_test.go
@@ -1,0 +1,171 @@
+package regression
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/gateway"
+	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/test"
+	"github.com/TykTechnologies/tyk/user"
+)
+
+func Test_Issue12865(t *testing.T) {
+	t.Run("Wildcard", func(t *testing.T) {
+		ts := gateway.StartTest(func(c *config.Config) {
+			c.HttpServerOptions.EnablePathPrefixMatching = false
+			c.HttpServerOptions.EnablePathSuffixMatching = false
+		})
+		t.Cleanup(ts.Close)
+
+		// load api definition from file
+		api := LoadAPISpec(t, "testdata/issue-12865.json")
+
+		ts.Gw.LoadAPI(api)
+
+		_, directKey := ts.CreateSession(func(s *user.SessionState) {
+			s.AccessRights = map[string]user.AccessDefinition{
+				api.APIID: {
+					APIID:   api.APIID,
+					APIName: api.Name,
+					Limit: user.APILimit{
+						QuotaMax: 30,
+					},
+				},
+			}
+		})
+
+		headers := map[string]string{
+			header.Authorization: directKey,
+		}
+
+		// issue request against /test to trigger panic
+		ts.Run(t, []test.TestCase{
+			{Path: "/test/anything", Method: http.MethodGet, Code: http.StatusOK},
+			{Path: "/test/anything/health", Method: http.MethodGet, Code: http.StatusOK},
+			{Path: "/test/anything/status/200", Method: http.MethodGet, Code: http.StatusOK},
+			{Path: "/test/status/200", Method: http.MethodGet, Code: http.StatusUnauthorized},
+			{Headers: headers, Path: "/test/status/200", Method: http.MethodGet, Code: http.StatusOK},
+			{Path: "/test/status/200/anything", Method: http.MethodGet, Code: http.StatusOK},
+		}...)
+	})
+
+	t.Run("Prefix", func(t *testing.T) {
+		ts := gateway.StartTest(func(c *config.Config) {
+			c.HttpServerOptions.EnablePathPrefixMatching = true
+			c.HttpServerOptions.EnablePathSuffixMatching = false
+		})
+		t.Cleanup(ts.Close)
+
+		// load api definition from file
+		api := LoadAPISpec(t, "testdata/issue-12865.json")
+
+		ts.Gw.LoadAPI(api)
+
+		_, directKey := ts.CreateSession(func(s *user.SessionState) {
+			s.AccessRights = map[string]user.AccessDefinition{
+				api.APIID: {
+					APIID:   api.APIID,
+					APIName: api.Name,
+					Limit: user.APILimit{
+						QuotaMax: 30,
+					},
+				},
+			}
+		})
+
+		headers := map[string]string{
+			header.Authorization: directKey,
+		}
+
+		// issue request against /test to trigger panic
+		ts.Run(t, []test.TestCase{
+			{Path: "/test/anything", Method: http.MethodGet, Code: http.StatusOK},
+			{Path: "/test/anything/health", Method: http.MethodGet, Code: http.StatusOK},
+			{Path: "/test/anything/status/200", Method: http.MethodGet, Code: http.StatusOK},
+			{Path: "/test/status/200", Method: http.MethodGet, Code: http.StatusUnauthorized},
+			{Headers: headers, Path: "/test/status/200", Method: http.MethodGet, Code: http.StatusOK},
+			{Path: "/test/status/200/anything", Method: http.MethodGet, Code: http.StatusUnauthorized},
+		}...)
+	})
+
+	t.Run("Prefix and Suffix", func(t *testing.T) {
+		ts := gateway.StartTest(func(c *config.Config) {
+			c.HttpServerOptions.EnablePathPrefixMatching = true
+			c.HttpServerOptions.EnablePathSuffixMatching = true
+		})
+		t.Cleanup(ts.Close)
+
+		// load api definition from file
+		api := LoadAPISpec(t, "testdata/issue-12865.json")
+
+		ts.Gw.LoadAPI(api)
+
+		_, directKey := ts.CreateSession(func(s *user.SessionState) {
+			s.AccessRights = map[string]user.AccessDefinition{
+				api.APIID: {
+					APIID:   api.APIID,
+					APIName: api.Name,
+					Limit: user.APILimit{
+						QuotaMax: 30,
+					},
+				},
+			}
+		})
+
+		headers := map[string]string{
+			header.Authorization: directKey,
+		}
+
+		// issue request against /test to trigger panic
+		ts.Run(t, []test.TestCase{
+			{Path: "/test/anything", Method: http.MethodGet, Code: http.StatusOK},
+			{Path: "/test/anything/health", Method: http.MethodGet, Code: http.StatusUnauthorized},
+			{Path: "/test/anything/status/200", Method: http.MethodGet, Code: http.StatusUnauthorized},
+			{Path: "/test/status/200", Method: http.MethodGet, Code: http.StatusUnauthorized},
+			{Headers: headers, Path: "/test/status/200", Method: http.MethodGet, Code: http.StatusOK},
+			{Path: "/test/status/200/anything", Method: http.MethodGet, Code: http.StatusUnauthorized},
+		}...)
+	})
+
+	t.Run("Suffix", func(t *testing.T) {
+		ts := gateway.StartTest(func(c *config.Config) {
+			c.HttpServerOptions.EnablePathPrefixMatching = false
+			c.HttpServerOptions.EnablePathSuffixMatching = true
+		})
+		t.Cleanup(ts.Close)
+
+		// load api definition from file
+		api := LoadAPISpec(t, "testdata/issue-12865.json")
+
+		ts.Gw.LoadAPI(api)
+
+		_, directKey := ts.CreateSession(func(s *user.SessionState) {
+			s.AccessRights = map[string]user.AccessDefinition{
+				api.APIID: {
+					APIID:   api.APIID,
+					APIName: api.Name,
+					Limit: user.APILimit{
+						QuotaMax: 30,
+					},
+				},
+			}
+		})
+
+		headers := map[string]string{
+			header.Authorization: directKey,
+		}
+
+		// issue request against /test to trigger panic
+		ts.Run(t, []test.TestCase{
+			{Path: "/test/anything", Method: http.MethodGet, Code: http.StatusOK},
+			{Path: "/test/anything/health", Method: http.MethodGet, Code: http.StatusUnauthorized},
+			{Path: "/test/anything/status/200", Method: http.MethodGet, Code: http.StatusUnauthorized},
+			{Path: "/test/status/200", Method: http.MethodGet, Code: http.StatusUnauthorized},
+			{Headers: headers, Path: "/test/status/200", Method: http.MethodGet, Code: http.StatusOK},
+			{Path: "/test/status/200/anything", Method: http.MethodGet, Code: http.StatusNotFound},
+		}...)
+	})
+
+}

--- a/tests/regression/regression_test.go
+++ b/tests/regression/regression_test.go
@@ -1,10 +1,13 @@
 package regression
 
 import (
+	"bytes"
 	"embed"
 	"encoding/json"
+	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/TykTechnologies/tyk/apidef"
@@ -16,10 +19,10 @@ var (
 	testdata embed.FS
 )
 
-func loadAPISpec(tb testing.TB, filename string) *gateway.APISpec {
+func LoadAPISpec(tb testing.TB, filename string) *gateway.APISpec {
 	tb.Helper()
 
-	data := loadFile(tb, filename)
+	data := LoadFile(tb, filename)
 
 	apidef := &apidef.APIDefinition{}
 	err := json.Unmarshal(data, apidef)
@@ -30,10 +33,27 @@ func loadAPISpec(tb testing.TB, filename string) *gateway.APISpec {
 	}
 }
 
-func loadFile(tb testing.TB, filename string) []byte {
+func TestLoadAPISpec(t *testing.T) {
+	f := LoadAPISpec(t, "testdata/issue-10104-apidef.json")
+
+	assert.Equal(t, f.APIDefinition.Proxy.TargetURL, "http://127.0.0.1:3123/")
+}
+
+func LoadFile(tb testing.TB, filename string) []byte {
 	tb.Helper()
 
 	data, err := testdata.ReadFile(filename)
+
+	httpbin := os.Getenv("HTTPBIN_IMAGE")
+	if httpbin == "" {
+		httpbin = "127.0.0.1:3123"
+	}
+	replacement := []byte("//" + httpbin)
+
+	// auto replace from public to private endpoint, part of CI env
+	data = bytes.ReplaceAll(data, []byte("//httpbin.org"), replacement)
+	data = bytes.ReplaceAll(data, []byte("//google.com"), replacement)
+
 	require.NoError(tb, err, "Error reading file: %s", filename)
 
 	return data

--- a/tests/regression/testdata/issue-12865.json
+++ b/tests/regression/testdata/issue-12865.json
@@ -1,0 +1,501 @@
+{
+    "id": "66c5cebd5b600879903f1ad3",
+    "name": "test",
+    "slug": "temp",
+    "listen_port": 0,
+    "protocol": "",
+    "enable_proxy_protocol": false,
+    "api_id": "c88e2d8ed982400469a2d1738f055902",
+    "org_id": "645b3db586341f751f4258aa",
+    "use_keyless": false,
+    "use_oauth2": false,
+    "external_oauth": {
+        "enabled": false,
+        "providers": []
+    },
+    "use_openid": false,
+    "openid_options": {
+        "providers": [],
+        "segregate_by_client": false
+    },
+    "oauth_meta": {
+        "allowed_access_types": [],
+        "allowed_authorize_types": [],
+        "auth_login_redirect": ""
+    },
+    "auth": {
+        "name": "",
+        "use_param": false,
+        "param_name": "",
+        "use_cookie": false,
+        "cookie_name": "",
+        "disable_header": false,
+        "auth_header_name": "Authorization",
+        "use_certificate": false,
+        "validate_signature": false,
+        "signature": {
+            "algorithm": "",
+            "header": "",
+            "use_param": false,
+            "param_name": "",
+            "secret": "",
+            "allowed_clock_skew": 0,
+            "error_code": 0,
+            "error_message": ""
+        }
+    },
+    "auth_configs": {
+        "authToken": {
+            "name": "",
+            "use_param": false,
+            "param_name": "",
+            "use_cookie": false,
+            "cookie_name": "",
+            "disable_header": false,
+            "auth_header_name": "Authorization",
+            "use_certificate": false,
+            "validate_signature": false,
+            "signature": {
+                "algorithm": "",
+                "header": "",
+                "use_param": false,
+                "param_name": "",
+                "secret": "",
+                "allowed_clock_skew": 0,
+                "error_code": 0,
+                "error_message": ""
+            }
+        },
+        "basic": {
+            "name": "",
+            "use_param": false,
+            "param_name": "",
+            "use_cookie": false,
+            "cookie_name": "",
+            "disable_header": false,
+            "auth_header_name": "Authorization",
+            "use_certificate": false,
+            "validate_signature": false,
+            "signature": {
+                "algorithm": "",
+                "header": "",
+                "use_param": false,
+                "param_name": "",
+                "secret": "",
+                "allowed_clock_skew": 0,
+                "error_code": 0,
+                "error_message": ""
+            }
+        },
+        "coprocess": {
+            "name": "",
+            "use_param": false,
+            "param_name": "",
+            "use_cookie": false,
+            "cookie_name": "",
+            "disable_header": false,
+            "auth_header_name": "Authorization",
+            "use_certificate": false,
+            "validate_signature": false,
+            "signature": {
+                "algorithm": "",
+                "header": "",
+                "use_param": false,
+                "param_name": "",
+                "secret": "",
+                "allowed_clock_skew": 0,
+                "error_code": 0,
+                "error_message": ""
+            }
+        },
+        "hmac": {
+            "name": "",
+            "use_param": false,
+            "param_name": "",
+            "use_cookie": false,
+            "cookie_name": "",
+            "disable_header": false,
+            "auth_header_name": "Authorization",
+            "use_certificate": false,
+            "validate_signature": false,
+            "signature": {
+                "algorithm": "",
+                "header": "",
+                "use_param": false,
+                "param_name": "",
+                "secret": "",
+                "allowed_clock_skew": 0,
+                "error_code": 0,
+                "error_message": ""
+            }
+        },
+        "jwt": {
+            "name": "",
+            "use_param": false,
+            "param_name": "",
+            "use_cookie": false,
+            "cookie_name": "",
+            "disable_header": false,
+            "auth_header_name": "Authorization",
+            "use_certificate": false,
+            "validate_signature": false,
+            "signature": {
+                "algorithm": "",
+                "header": "",
+                "use_param": false,
+                "param_name": "",
+                "secret": "",
+                "allowed_clock_skew": 0,
+                "error_code": 0,
+                "error_message": ""
+            }
+        },
+        "oauth": {
+            "name": "",
+            "use_param": false,
+            "param_name": "",
+            "use_cookie": false,
+            "cookie_name": "",
+            "disable_header": false,
+            "auth_header_name": "Authorization",
+            "use_certificate": false,
+            "validate_signature": false,
+            "signature": {
+                "algorithm": "",
+                "header": "",
+                "use_param": false,
+                "param_name": "",
+                "secret": "",
+                "allowed_clock_skew": 0,
+                "error_code": 0,
+                "error_message": ""
+            }
+        },
+        "oidc": {
+            "name": "",
+            "use_param": false,
+            "param_name": "",
+            "use_cookie": false,
+            "cookie_name": "",
+            "disable_header": false,
+            "auth_header_name": "Authorization",
+            "use_certificate": false,
+            "validate_signature": false,
+            "signature": {
+                "algorithm": "",
+                "header": "",
+                "use_param": false,
+                "param_name": "",
+                "secret": "",
+                "allowed_clock_skew": 0,
+                "error_code": 0,
+                "error_message": ""
+            }
+        }
+    },
+    "use_basic_auth": false,
+    "basic_auth": {
+        "disable_caching": false,
+        "cache_ttl": 0,
+        "extract_from_body": false,
+        "body_user_regexp": "",
+        "body_password_regexp": ""
+    },
+    "use_mutual_tls_auth": false,
+    "client_certificates": [],
+    "upstream_certificates": {},
+    "pinned_public_keys": {},
+    "enable_jwt": false,
+    "use_standard_auth": true,
+    "use_go_plugin_auth": false,
+    "enable_coprocess_auth": false,
+    "custom_plugin_auth_enabled": false,
+    "jwt_signing_method": "",
+    "jwt_source": "",
+    "jwt_identity_base_field": "",
+    "jwt_client_base_field": "",
+    "jwt_policy_field_name": "",
+    "jwt_default_policies": [],
+    "jwt_issued_at_validation_skew": 0,
+    "jwt_expires_at_validation_skew": 0,
+    "jwt_not_before_validation_skew": 0,
+    "jwt_skip_kid": false,
+    "scopes": {
+        "jwt": {},
+        "oidc": {}
+    },
+    "idp_client_id_mapping_disabled": false,
+    "jwt_scope_to_policy_mapping": {},
+    "jwt_scope_claim_name": "",
+    "notifications": {
+        "shared_secret": "",
+        "oauth_on_keychange_url": ""
+    },
+    "enable_signature_checking": false,
+    "hmac_allowed_clock_skew": -1,
+    "hmac_allowed_algorithms": [],
+    "request_signing": {
+        "is_enabled": false,
+        "secret": "",
+        "key_id": "",
+        "algorithm": "",
+        "header_list": [],
+        "certificate_id": "",
+        "signature_header": ""
+    },
+    "base_identity_provided_by": "",
+    "definition": {
+        "enabled": false,
+        "name": "",
+        "default": "",
+        "location": "header",
+        "key": "x-api-version",
+        "strip_path": false,
+        "strip_versioning_data": false,
+        "url_versioning_pattern": "",
+        "fallback_to_default": false,
+        "versions": {}
+    },
+    "version_data": {
+        "not_versioned": true,
+        "default_version": "",
+        "versions": {
+            "Default": {
+                "name": "Default",
+                "expires": "",
+                "paths": {
+                    "ignored": [],
+                    "white_list": [],
+                    "black_list": []
+                },
+                "use_extended_paths": true,
+                "extended_paths": {
+                    "ignored": [
+                        {
+                            "disabled": false,
+                            "path": "/anything",
+                            "method": "",
+                            "ignore_case": false,
+                            "method_actions": {
+                                "GET": {
+                                    "action": "no_action",
+                                    "code": 200,
+                                    "data": "",
+                                    "headers": {}
+                                }
+                            }
+                        }
+                    ],
+                    "url_rewrites": [
+                        {
+                            "disabled": false,
+                            "path": "/status",
+                            "method": "GET",
+                            "match_pattern": "/status/(.*)",
+                            "rewrite_to": "http://httpbin.org",
+                            "triggers": []
+                        }
+                    ],
+                    "persist_graphql": [],
+                    "rate_limit": []
+                },
+                "global_headers": {},
+                "global_headers_remove": [],
+                "global_headers_disabled": false,
+                "global_response_headers": {},
+                "global_response_headers_remove": [],
+                "global_response_headers_disabled": false,
+                "ignore_endpoint_case": false,
+                "global_size_limit": 0,
+                "override_target": ""
+            }
+        }
+    },
+    "uptime_tests": {
+        "check_list": [],
+        "config": {
+            "expire_utime_after": 0,
+            "service_discovery": {
+                "use_discovery_service": false,
+                "query_endpoint": "",
+                "use_nested_query": false,
+                "parent_data_path": "",
+                "data_path": "",
+                "port_data_path": "",
+                "target_path": "",
+                "use_target_list": false,
+                "cache_disabled": false,
+                "cache_timeout": 60,
+                "endpoint_returns_list": false
+            },
+            "recheck_wait": 0
+        }
+    },
+    "proxy": {
+        "preserve_host_header": false,
+        "listen_path": "/test/",
+        "target_url": "http://httpbin.org/",
+        "disable_strip_slash": true,
+        "strip_listen_path": true,
+        "enable_load_balancing": false,
+        "target_list": [],
+        "check_host_against_uptime_tests": false,
+        "service_discovery": {
+            "use_discovery_service": false,
+            "query_endpoint": "",
+            "use_nested_query": false,
+            "parent_data_path": "",
+            "data_path": "",
+            "port_data_path": "",
+            "target_path": "",
+            "use_target_list": false,
+            "cache_disabled": false,
+            "cache_timeout": 0,
+            "endpoint_returns_list": false
+        },
+        "transport": {
+            "ssl_insecure_skip_verify": false,
+            "ssl_ciphers": [],
+            "ssl_min_version": 0,
+            "ssl_max_version": 0,
+            "ssl_force_common_name_check": false,
+            "proxy_url": ""
+        }
+    },
+    "disable_rate_limit": false,
+    "disable_quota": false,
+    "custom_middleware": {
+        "pre": [],
+        "post": [],
+        "post_key_auth": [],
+        "auth_check": {
+            "disabled": false,
+            "name": "",
+            "path": "",
+            "require_session": false,
+            "raw_body_only": false
+        },
+        "response": [],
+        "driver": "",
+        "id_extractor": {
+            "disabled": false,
+            "extract_from": "",
+            "extract_with": "",
+            "extractor_config": {}
+        }
+    },
+    "custom_middleware_bundle": "",
+    "custom_middleware_bundle_disabled": false,
+    "cache_options": {
+        "cache_timeout": 60,
+        "enable_cache": true,
+        "cache_all_safe_requests": false,
+        "cache_response_codes": [],
+        "enable_upstream_cache_control": false,
+        "cache_control_ttl_header": "",
+        "cache_by_headers": []
+    },
+    "session_lifetime": 0,
+    "active": true,
+    "internal": false,
+    "auth_provider": {
+        "name": "",
+        "storage_engine": "",
+        "meta": {}
+    },
+    "session_provider": {
+        "name": "",
+        "storage_engine": "",
+        "meta": {}
+    },
+    "event_handlers": {
+        "events": {}
+    },
+    "enable_batch_request_support": false,
+    "enable_ip_whitelisting": false,
+    "allowed_ips": [],
+    "enable_ip_blacklisting": false,
+    "blacklisted_ips": [],
+    "dont_set_quota_on_create": false,
+    "expire_analytics_after": 0,
+    "response_processors": [],
+    "CORS": {
+        "enable": false,
+        "allowed_origins": [
+            "*"
+        ],
+        "allowed_methods": [
+            "GET",
+            "POST",
+            "HEAD"
+        ],
+        "allowed_headers": [
+            "Origin",
+            "Accept",
+            "Content-Type",
+            "X-Requested-With",
+            "Authorization"
+        ],
+        "exposed_headers": [],
+        "allow_credentials": false,
+        "max_age": 24,
+        "options_passthrough": false,
+        "debug": false
+    },
+    "domain": "",
+    "certificates": [],
+    "do_not_track": false,
+    "enable_context_vars": false,
+    "config_data": {},
+    "config_data_disabled": false,
+    "tag_headers": [],
+    "global_rate_limit": {
+        "disabled": false,
+        "rate": 0,
+        "per": 0
+    },
+    "strip_auth_data": false,
+    "enable_detailed_recording": false,
+    "graphql": {
+        "enabled": false,
+        "execution_mode": "proxyOnly",
+        "version": "2",
+        "schema": "",
+        "type_field_configurations": [],
+        "playground": {
+            "enabled": false,
+            "path": ""
+        },
+        "engine": {
+            "field_configs": [],
+            "data_sources": [],
+            "global_headers": []
+        },
+        "proxy": {
+            "features": {
+                "use_immutable_headers": true
+            },
+            "auth_headers": {},
+            "request_headers": {},
+            "use_response_extensions": {
+                "on_error_forwarding": false
+            },
+            "request_headers_rewrite": {}
+        },
+        "subgraph": {
+            "sdl": ""
+        },
+        "supergraph": {
+            "subgraphs": [],
+            "merged_sdl": "",
+            "global_headers": {},
+            "disable_query_batching": false
+        },
+        "introspection": {
+            "disabled": false
+        }
+    },
+    "analytics_plugin": {},
+    "tags": [],
+    "detailed_tracing": false
+}


### PR DESCRIPTION
### **User description**
[TT-12865] Rename config parameter, update usage, support mux params on legacy (#6506)

enhancement

___

- Renamed configuration fields `EnablePrefixMatching` and `EnableSuffixMatching` to `EnablePathPrefixMatching` and `EnablePathSuffixMatching` respectively, across multiple files.
- Updated comments and documentation to reflect the new naming conventions.
- Modified test cases to use the updated configuration fields.
- Refactored middleware and session manager logic to accommodate the new path matching configuration.

___

<table><thead><tr><th></th><th align="left">Relevant

files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table> <tr>
  <td>
    <details>
<summary><strong>config.go</strong><dd><code>Rename configuration fields for path matching options</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/config.go

<li>Renamed <code>EnablePrefixMatching</code> to
<code>EnablePathPrefixMatching</code>.<br> <li> Renamed <code>EnableSuffixMatching</code> to
<code>EnablePathSuffixMatching</code>.<br> <li> Updated comments to reflect the new naming conventions.<br>

</details>

  </td>
<td><a

href="https://github.com/TykTechnologies/tyk/pull/6506/files#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17">+12/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>api_definition.go</strong><dd><code>Update API definition to use new path matching config</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_definition.go

<li>Updated variable names to use new path matching configuration fields.<br>

</details>

  </td>
<td><a

href="https://github.com/TykTechnologies/tyk/pull/6506/files#diff-0cf80174bbafb36f6d4f4308ebbd971b2833b76a936bad568220aa1a4ba0ee8b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>mw_granular_access.go</strong><dd><code>Refactor middleware to use updated path matching config</code>&nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_granular_access.go

<li>Updated variable names to use new path matching configuration fields.<br> <li> Refactored pattern preparation using <code>PreparePathRegexp</code>.<br>

</details>

  </td>
<td><a

href="https://github.com/TykTechnologies/tyk/pull/6506/files#diff-618f7d55751d572562a29506a13beba2da969436e974f8b51df7d9708c925436">+3/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>session_manager.go</strong><dd><code>Update session manager for new path matching config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/session_manager.go

<li>Updated variable names to use new path matching configuration fields.<br>

</details>

  </td>
<td><a

href="https://github.com/TykTechnologies/tyk/pull/6506/files#diff-e6b40a285464cd86736e970c4c0b320b44c75b18b363d38c200e9a9d36cdabb6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>schema.json</strong><dd><code>Update JSON schema for path matching configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/linter/schema.json

- Renamed JSON schema fields for path matching options.

</details>

  </td> <td><a

href="https://github.com/TykTechnologies/tyk/pull/6506/files#diff-103cec746d3e61d391c5a67c171963f66fea65d651d704d5540e60aa5d574f46">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table> <tr>
  <td>
    <details>
<summary><strong>api_definition_test.go</strong><dd><code>Update test configuration for path prefix matching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_definition_test.go

- Modified test configuration to use `EnablePathPrefixMatching`.

</details>

  </td> <td><a

href="https://github.com/TykTechnologies/tyk/pull/6506/files#diff-2394daab6fdc5f8dc234699c80c0548947ee3d68d2e33858258d73a8b5eb6f44">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>mw_granular_access_test.go</strong><dd><code>Update middleware test for path prefix matching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary> <hr>

gateway/mw_granular_access_test.go

- Modified test configuration to use `EnablePathPrefixMatching`.

</details>

  </td> <td><a

href="https://github.com/TykTechnologies/tyk/pull/6506/files#diff-8e0d7cfef26688edd7d08334d955039dab5deb3caf860d29eff6d09894eaba20">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools
and their descriptions

---------



[TT-12865]:
https://tyktech.atlassian.net/browse/TT-12865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

___

Enhancement, Tests

___

- Introduced new configuration options `EnablePathPrefixMatching` and `EnablePathSuffixMatching` to enhance URL path matching capabilities.
- Refactored URLSpec and related logic to support the new path matching configuration.
- Updated middleware and session management to utilize the new path matching options.
- Added comprehensive tests for the new path matching logic, including regression tests for issue 12865.
- Improved logging and error handling in path matching processes.

___

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td>
    <details>
<summary><strong>config.go</strong><dd><code>Add configuration for path prefix and suffix matching</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/config.go

<li>Added new configuration fields <code>EnablePathPrefixMatching</code> and <br><code>EnablePathSuffixMatching</code>.<br> <li> Updated comments to explain the new path matching configuration.<br>

</details>

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6507/files#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>api_definition.go</strong><dd><code>Refactor URLSpec and update path matching logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary> <hr>

gateway/api_definition.go

<li>Refactored URLSpec to use private fields and methods.<br> <li> Updated path matching logic to support new configuration.<br> <li> Renamed several functions for clarity.<br>

</details>

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6507/files#diff-0cf80174bbafb36f6d4f4308ebbd971b2833b76a936bad568220aa1a4ba0ee8b">+47/-142</a></td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>model_apispec.go</strong><dd><code>Refactor and deprecate CheckSpecMatchesStatus</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary> <hr>

gateway/model_apispec.go

<li>Moved <code>CheckSpecMatchesStatus</code> to a separate file and deprecated it.<br> <li> Added <code>FindSpecMatchesStatus</code> for improved status checking.<br>

</details>

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6507/files#diff-80c49b9bdb411a3d5a4706ec3ff138ef44154d0306040c19eba1cb5559f199d6">+75/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>model_urlspec.go</strong><dd><code>Add path and method matching methods to URLSpec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary> <hr>

gateway/model_urlspec.go

<li>Added new methods to URLSpec for matching paths and methods.<br> <li> Deprecated <code>modeSpecificSpec</code> method.<br>

</details>

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6507/files#diff-ed766dd1814a557a1943cd3483c6ef511ad1b8febc7bd59982792d0ab7e23cff">+120/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>mw_granular_access.go</strong><dd><code>Update GranularAccessMiddleware for new path matching</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_granular_access.go

<li>Updated middleware to use new path matching configuration.<br> <li> Improved logging and error handling in path matching.<br>

</details>

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6507/files#diff-618f7d55751d572562a29506a13beba2da969436e974f8b51df7d9708c925436">+74/-20</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>mux.go</strong><dd><code>Refactor path regex preparation and matching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary> <hr>

internal/httputil/mux.go

<li>Refactored path regex preparation and matching functions.<br> <li> Improved caching and handling of mux-style parameters.<br>

</details>

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6507/files#diff-3d9ee5f5e946d72e6f2ae662ff03ee5253bbdc15203d2e4f6e9f46c13011ebf8">+78/-18</a>&nbsp; </td>

</tr>

</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td>
    <details>
<summary><strong>api_definition_test.go</strong><dd><code>Update and add test cases for path matching logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_definition_test.go

<li>Updated test cases to reflect changes in path matching logic.<br> <li> Added new test cases for path prefix matching.<br>

</details>

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6507/files#diff-2394daab6fdc5f8dc234699c80c0548947ee3d68d2e33858258d73a8b5eb6f44">+12/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>mw_granular_access_test.go</strong><dd><code>Add tests for GranularAccessMiddleware path matching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_granular_access_test.go

<li>Added tests for new path matching logic in
GranularAccessMiddleware.<br> <li> Updated existing tests to use new configuration.<br>

</details>

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6507/files#diff-8e0d7cfef26688edd7d08334d955039dab5deb3caf860d29eff6d09894eaba20">+50/-28</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>mux_test.go</strong><dd><code>Add tests for path regex preparation and matching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/httputil/mux_test.go

<li>Added tests for new path matching functions.<br> <li> Updated existing tests to reflect changes in regex preparation.<br>

</details>

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6507/files#diff-8f7ce1891e221d7adb9e68f2e951f33edfbde2128187abb6e837ac01952d7888">+112/-14</a></td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>issue_12865_test.go</strong><dd><code>Add regression tests for issue 12865</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary> <hr>

tests/regression/issue_12865_test.go

<li>Added regression tests for issue 12865.<br> <li> Tested various configurations of path prefix and suffix matching.<br>

</details>

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6507/files#diff-1a4f9c47cb4152844d641098b6e7ca8e5e8739eefdec7178f9437750d11db6ec">+171/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table> <tr>
  <td>
    <details>
<summary><strong>test.yml</strong><dd><code>Update test task configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.taskfiles/test.yml

<li>Updated test task to exclude the first package in the list.<br> <li> Added a task to merge coverage reports.<br>

</details>

  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6507/files#diff-f1fbe7f7f14888019b8845634ed008e1c43f6e5a5c0b2707336fc7f8e15a36fb">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>schema.json</strong><dd><code>Update schema for new path matching configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/linter/schema.json

- Added new schema fields for path prefix and suffix matching.

</details>

  </td> <td><a
href="https://github.com/TykTechnologies/tyk/pull/6507/files#diff-103cec746d3e61d391c5a67c171963f66fea65d651d704d5540e60aa5d574f46">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools
and their descriptions

---------

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


[TT-12865]: https://tyktech.atlassian.net/browse/TT-12865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TT-12865]: https://tyktech.atlassian.net/browse/TT-12865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduced new configuration fields `EnablePathPrefixMatching` and `EnablePathSuffixMatching` to enhance URL path matching capabilities.
- Refactored URLSpec and related logic to support the new path matching configurations, improving error handling and logging.
- Updated and added new test cases to cover the new path matching options, ensuring comprehensive test coverage.
- Implemented utility functions for handling path regex preparation and matching, with caching for improved performance.
- Added regression tests for issue 12865, verifying the correct behavior of the new path matching configurations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>config.go</strong><dd><code>Add new configuration fields for path matching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/config.go

<li>Introduced new configuration fields <code>EnablePathPrefixMatching</code> and <br><code>EnablePathSuffixMatching</code>.<br> <li> Added detailed comments explaining the new path matching <br>configurations.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6510/files#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17">+43/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>api_definition.go</strong><dd><code>Refactor URLSpec and enhance path matching logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_definition.go

<li>Refactored URLSpec to use a private field for regex.<br> <li> Added logic to handle path prefix and suffix matching.<br> <li> Improved error logging for regex compilation.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6510/files#diff-0cf80174bbafb36f6d4f4308ebbd971b2833b76a936bad568220aa1a4ba0ee8b">+55/-166</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_granular_access.go</strong><dd><code>Enhance GranularAccessMiddleware with path matching options</code></dd></summary>
<hr>

gateway/mw_granular_access.go

<li>Enhanced GranularAccessMiddleware to support new path matching <br>options.<br> <li> Improved logging for access checks.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6510/files#diff-618f7d55751d572562a29506a13beba2da969436e974f8b51df7d9708c925436">+79/-12</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mux.go</strong><dd><code>Add utility functions for path regex handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/httputil/mux.go

<li>Introduced utility functions for path regex preparation and matching.<br> <li> Implemented caching for path regex patterns.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6510/files#diff-3d9ee5f5e946d72e6f2ae662ff03ee5253bbdc15203d2e4f6e9f46c13011ebf8">+139/-0</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>strings.go</strong><dd><code>Implement concurrency-safe string map</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/maps/strings.go

<li>Introduced a concurrency-safe map for string storage.<br> <li> Provided methods for setting and getting values.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6510/files#diff-5fa5e244ede81be68269555e950af79079de58236fe9c0e67e6f01a602d04dca">+34/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>api_definition_test.go</strong><dd><code>Update and add tests for path matching configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_definition_test.go

<li>Updated test cases to reflect new path matching configurations.<br> <li> Added new tests for prefix and suffix matching.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6510/files#diff-2394daab6fdc5f8dc234699c80c0548947ee3d68d2e33858258d73a8b5eb6f44">+16/-33</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mw_granular_access_test.go</strong><dd><code>Add tests for GranularAccessMiddleware path matching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_granular_access_test.go

<li>Added tests for GranularAccessMiddleware with new path matching <br>configurations.<br> <li> Ensured coverage for both prefix and suffix matching scenarios.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6510/files#diff-8e0d7cfef26688edd7d08334d955039dab5deb3caf860d29eff6d09894eaba20">+50/-24</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mux_test.go</strong><dd><code>Add tests for path regex utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/httputil/mux_test.go

<li>Added tests for path regex preparation and matching utilities.<br> <li> Verified caching behavior for regex patterns.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6510/files#diff-8f7ce1891e221d7adb9e68f2e951f33edfbde2128187abb6e837ac01952d7888">+162/-0</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>issue_12865_test.go</strong><dd><code>Add regression tests for issue 12865</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/regression/issue_12865_test.go

<li>Added regression tests for issue 12865.<br> <li> Tested various path matching configurations.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6510/files#diff-1a4f9c47cb4152844d641098b6e7ca8e5e8739eefdec7178f9437750d11db6ec">+171/-0</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>regression_test.go</strong><dd><code>Refactor and test API spec loading utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/regression/regression_test.go

<li>Refactored utility functions for loading API specs.<br> <li> Added test for loading API specs with environment variable <br>replacement.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6510/files#diff-24d0ac1f4eb4bb6e33d0db26aca8ef96aef2b67fd2730fcde6e952ce3d894696">+23/-3</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

