### PR TITLE
[TT-13107] Remove verbose error logging if quota is disabled

### DIFF
--- a/gateway/session_manager.go
+++ b/gateway/session_manager.go
@@ -387,7 +387,6 @@ func (l *SessionLimiter) RedisQuotaExceeded(r *http.Request, session *user.Sessi
 	})
 
 	if limit.QuotaMax <= 0 {
-		logger.Error("Quota disabled: quota max <= 0")
 		return false
 	}
 


### PR DESCRIPTION
### **User description**
https://tyktech.atlassian.net/browse/TT-13107


___

### **PR Type**
Bug fix


___

### **Description**
- Removed verbose error logging in `RedisQuotaExceeded` function when the quota is disabled (quota max <= 0).
- This change prevents unnecessary error messages in the logs when quota settings are not applicable.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>session_manager.go</strong><dd><code>Remove verbose error logging for disabled quota</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/session_manager.go

<li>Removed verbose error logging when quota is disabled.<br> <li> Eliminated logging of "Quota disabled" message for quota max <= 0.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6528/files#diff-e6b40a285464cd86736e970c4c0b320b44c75b18b363d38c200e9a9d36cdabb6">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

