### PR TITLE
Fix using broker

### DIFF
--- a/gateway/mw_streaming.go
+++ b/gateway/mw_streaming.go
@@ -297,7 +297,7 @@ func (s *StreamingMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 
 	newRequest := &http.Request{
 		Method: r.Method,
-		URL: &url.URL{ Scheme: r.URL.Scheme, Host: r.URL.Host, Path: strippedPath}
+		URL: &url.URL{ Scheme: r.URL.Scheme, Host: r.URL.Host, Path: strippedPath},
 	}
 
 	if !s.defaultStreamManager.muxer.Match(newRequest, &mux.RouteMatch{}) {

--- a/gateway/mw_streaming.go
+++ b/gateway/mw_streaming.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -60,7 +61,7 @@ func (sm *StreamManager) initStreams(r *http.Request, specStreams map[string]int
 			httpPaths := GetHTTPPaths(streamMap)
 			
 			if sm.dryRun {
-				if !len(httpPaths) == 0 {
+				if len(httpPaths) == 0 {
 					err := sm.createStream(streamID, streamMap)
 					if err != nil {
 						sm.mw.Logger().WithError(err).Errorf("Error creating stream %s", streamID)
@@ -161,6 +162,24 @@ func (s *StreamingMiddleware) createStreamManager(r *http.Request) *StreamManage
 	newStreamManager.initStreams(r, s.getStreamsConfig(r))
 
 	return newStreamManager
+}
+
+// Helper function to extract paths from an http_server configuration
+func extractPaths(httpConfig map[string]interface{}) []string {
+	var paths []string
+	defaultPaths := map[string]string{
+		"path":        "/post",
+		"ws_path":     "/post/ws",
+		"stream_path": "/get/stream",
+	}
+	for key, defaultValue := range defaultPaths {
+		if val, ok := httpConfig[key].(string); ok {
+			paths = append(paths, val)
+		} else {
+			paths = append(paths, defaultValue)
+		}
+	}
+	return paths
 }
 
 // Helper function to extract HTTP server paths from a given configuration

--- a/gateway/mw_streaming.go
+++ b/gateway/mw_streaming.go
@@ -50,15 +50,17 @@ type StreamManager struct {
 	listenPaths []string
 }
 
-func (sm *StreamManager) initStreams(config *StreamsConfig) {
+
+func (sm *StreamManager) initStreams(r *http.Request, specStreams map[string]interface{}) {
 	// Clear existing routes for this consumer group
 	sm.muxer = mux.NewRouter()
 
-	for streamID, streamConfig := range config.Streams {
-		if streamMap, ok := streamConfig.(map[string]any); ok {
-			hasHttp := HasHttp(streamMap)
+	for streamID, streamConfig := range specStreams {
+		if streamMap, ok := streamConfig.(map[string]interface{}); ok {
+			httpPaths := GetHTTPPaths(streamMap)
+			
 			if sm.dryRun {
-				if !hasHttp {
+				if !len(httpPaths) == 0 {
 					err := sm.createStream(streamID, streamMap)
 					if err != nil {
 						sm.mw.Logger().WithError(err).Errorf("Error creating stream %s", streamID)
@@ -70,8 +72,16 @@ func (sm *StreamManager) initStreams(config *StreamsConfig) {
 					sm.mw.Logger().WithError(err).Errorf("Error creating stream %s", streamID)
 				}
 			}
-			sm.listenPaths = GetHTTPPaths(streamMap)
+			sm.listenPaths = append(sm.listenPaths, httpPaths...)
+		}
+	}
 
+	// If it is default stream manager, init muxer
+	if r == nil {
+		for _, path := range sm.listenPaths {
+			sm.muxer.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+				// Dummy handler
+			})
 		}
 	}
 }
@@ -148,121 +158,46 @@ func (s *StreamingMiddleware) createStreamManager(r *http.Request) *StreamManage
 	s.streamManagers.Store(streamID, newStreamManager)
 
 	// Call initStreams for the new StreamManager
-	newStreamManager.initStreams(s.getStreamsConfig(r))
+	newStreamManager.initStreams(r, s.getStreamsConfig(r))
 
 	return newStreamManager
 }
 
-func HasHttp(config map[string]interface{}) bool {
-    // Define the components to check
-    components := []string{"input", "output"}
-
-    for _, component := range components {
-        componentConfig, exists := config[component]
-        if !exists {
-            continue
-        }
-
-        componentMap, ok := componentConfig.(map[string]interface{})
-        if !ok {
-            continue
-        }
-
-        // Check if 'broker' exists under this component
-        if brokerConfig, found := componentMap["broker"]; found {
-            // 'broker' is expected to be a list of configurations
-            brokerList, ok := brokerConfig.([]interface{})
-            if !ok {
-                continue
-            }
-            for _, brokerItem := range brokerList {
-                brokerItemMap, ok := brokerItem.(map[string]interface{})
-                if !ok {
-                    continue
-                }
-                // Check if 'http_server' exists in the broker item
-                if _, found := brokerItemMap["http_server"]; found {
-                    return true
-                }
-            }
-        } else if _, found := componentMap["http_server"]; found {
-            // Check for 'http_server' directly under input/output
-            return true
-        }
-    }
-
-    return false
+// Helper function to extract HTTP server paths from a given configuration
+func extractHTTPServerPaths(config map[string]interface{}) []string {
+	if httpServerConfig, ok := config["http_server"].(map[string]interface{}); ok {
+		return extractPaths(httpServerConfig)
+	}
+	return nil
 }
 
+// Helper function to handle broker configurations
+func handleBroker(brokerConfig map[string]interface{}) []string {
+	var paths []string
+	for _, ioKey := range []string{"inputs", "outputs"} {
+		if ioList, ok := brokerConfig[ioKey].([]interface{}); ok {
+			for _, ioItem := range ioList {
+				if ioItemMap, ok := ioItem.(map[string]interface{}); ok {
+					paths = append(paths, extractHTTPServerPaths(ioItemMap)...)
+				}
+			}
+		}
+	}
+	return paths
+}
+
+// Main function to get HTTP paths from the stream configuration
 func GetHTTPPaths(streamConfig map[string]interface{}) []string {
-    paths := []string{}
-
-    // Define the path keys and their default values
-    pathKeys := []string{"path", "ws_path", "stream_path"}
-    defaultPaths := map[string]string{
-        "path":        "/post",
-        "ws_path":     "/post/ws",
-        "stream_path": "/get/stream",
-    }
-
-    // Components to process: 'input' and 'output'
-    components := []string{"input", "output"}
-
-    // Helper function to extract paths from an http_server config
-    extractPaths := func(httpConfig map[string]interface{}) {
-        for _, key := range pathKeys {
-            val, exists := httpConfig[key]
-            if !exists {
-                // Use default if key is missing
-                paths = append(paths, defaultPaths[key])
-            } else if pathStr, ok := val.(string); ok {
-                paths = append(paths, pathStr)
-            } else {
-                // Use default if value is not a string
-                paths = append(paths, defaultPaths[key])
-            }
-        }
-    }
-
-    for _, component := range components {
-        componentConfig, exists := streamConfig[component]
-        if !exists {
-            continue
-        }
-
-        componentMap, ok := componentConfig.(map[string]interface{})
-        if !ok {
-            continue
-        }
-
-        // Check if 'broker' exists under this component
-        if brokerConfig, exists := componentMap["broker"]; exists {
-            // 'broker' is a list of configurations
-            brokerList, ok := brokerConfig.([]interface{})
-            if !ok {
-                continue
-            }
-            for _, brokerItem := range brokerList {
-                brokerItemMap, ok := brokerItem.(map[string]interface{})
-                if !ok {
-                    continue
-                }
-                // Check if 'http_server' exists under this broker item
-                if httpServerConfig, exists := brokerItemMap["http_server"]; exists {
-                    if httpConfigMap, ok := httpServerConfig.(map[string]interface{}); ok {
-                        extractPaths(httpConfigMap)
-                    }
-                }
-            }
-        } else if httpServerConfig, exists := componentMap["http_server"]; exists {
-            // 'http_server' directly under component
-            if httpConfigMap, ok := httpServerConfig.(map[string]interface{}); ok {
-                extractPaths(httpConfigMap)
-            }
-        }
-    }
-
-    return paths
+	var paths []string
+	for _, component := range []string{"input", "output"} {
+		if componentMap, ok := streamConfig[component].(map[string]interface{}); ok {
+			paths = append(paths, extractHTTPServerPaths(componentMap)...)
+			if brokerConfig, ok := componentMap["broker"].(map[string]interface{}); ok {
+				paths = append(paths, handleBroker(brokerConfig)...)
+			}
+		}
+	}
+	return paths
 }
 
 func (s *StreamingMiddleware) getStreamsConfig(r *http.Request) *StreamsConfig {
@@ -360,8 +295,14 @@ func (s *StreamingMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 
 	s.Logger().Debugf("Processing request: %s, %s", r.URL.Path, strippedPath)
 
-	newRequest := r.Clone(r.Context())
-	newRequest.URL.Path = strippedPath
+	newRequest := &http.Request{
+		Method: r.Method,
+		URL: &url.URL{ Scheme: r.URL.Scheme, Host: r.URL.Host, Path: strippedPath}
+	}
+
+	if !s.defaultStreamManager.muxer.Match(newRequest, &mux.RouteMatch{}) {
+		return nil, http.StatusOK
+	}
 
 	var match mux.RouteMatch
 	streamManager := s.createStreamManager(r)

--- a/gateway/mw_streaming.go
+++ b/gateway/mw_streaming.go
@@ -154,18 +154,44 @@ func (s *StreamingMiddleware) createStreamManager(r *http.Request) *StreamManage
 }
 
 func HasHttp(config map[string]interface{}) bool {
-	for key := range config {
-		keyConfig := config[key]
-		keyConfigMap, ok := keyConfig.(map[string]interface{})
-		if !ok {
-			continue
-		}
+    // Define the components to check
+    components := []string{"input", "output"}
 
-		if _, found := keyConfigMap["http_server"]; found {
-			return true
-		}
-	}
-	return false
+    for _, component := range components {
+        componentConfig, exists := config[component]
+        if !exists {
+            continue
+        }
+
+        componentMap, ok := componentConfig.(map[string]interface{})
+        if !ok {
+            continue
+        }
+
+        // Check if 'broker' exists under this component
+        if brokerConfig, found := componentMap["broker"]; found {
+            // 'broker' is expected to be a list of configurations
+            brokerList, ok := brokerConfig.([]interface{})
+            if !ok {
+                continue
+            }
+            for _, brokerItem := range brokerList {
+                brokerItemMap, ok := brokerItem.(map[string]interface{})
+                if !ok {
+                    continue
+                }
+                // Check if 'http_server' exists in the broker item
+                if _, found := brokerItemMap["http_server"]; found {
+                    return true
+                }
+            }
+        } else if _, found := componentMap["http_server"]; found {
+            // Check for 'http_server' directly under input/output
+            return true
+        }
+    }
+
+    return false
 }
 
 func GetHTTPPaths(streamConfig map[string]interface{}) []string {

--- a/gateway/mw_streaming.go
+++ b/gateway/mw_streaming.go
@@ -169,41 +169,74 @@ func HasHttp(config map[string]interface{}) bool {
 }
 
 func GetHTTPPaths(streamConfig map[string]interface{}) []string {
-	paths := make([]string, 0)
-	pathKeys := []string{"path", "stream_path", "ws_path"}
-	components := []string{"output", "input"}
+    paths := []string{}
 
-	for _, component := range components {
-		componentConfig, ok := streamConfig[component]
-		if !ok {
-			continue
-		}
-		componentConfigMap, ok := componentConfig.(map[string]interface{})
-		if !ok {
-			continue
-		}
+    // Define the path keys and their default values
+    pathKeys := []string{"path", "ws_path", "stream_path"}
+    defaultPaths := map[string]string{
+        "path":        "/post",
+        "ws_path":     "/post/ws",
+        "stream_path": "/get/stream",
+    }
 
-		httpPaths, ok := componentConfigMap["http_server"]
-		if !ok {
-			continue
-		}
-		httpPathMap, ok := httpPaths.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		for _, pathItem := range pathKeys {
-			path, ok := httpPathMap[pathItem]
-			if !ok {
-				continue
-			}
+    // Components to process: 'input' and 'output'
+    components := []string{"input", "output"}
 
-			if pathString, ok := path.(string); ok {
-				paths = append(paths, pathString)
-			}
-		}
-	}
+    // Helper function to extract paths from an http_server config
+    extractPaths := func(httpConfig map[string]interface{}) {
+        for _, key := range pathKeys {
+            val, exists := httpConfig[key]
+            if !exists {
+                // Use default if key is missing
+                paths = append(paths, defaultPaths[key])
+            } else if pathStr, ok := val.(string); ok {
+                paths = append(paths, pathStr)
+            } else {
+                // Use default if value is not a string
+                paths = append(paths, defaultPaths[key])
+            }
+        }
+    }
 
-	return paths
+    for _, component := range components {
+        componentConfig, exists := streamConfig[component]
+        if !exists {
+            continue
+        }
+
+        componentMap, ok := componentConfig.(map[string]interface{})
+        if !ok {
+            continue
+        }
+
+        // Check if 'broker' exists under this component
+        if brokerConfig, exists := componentMap["broker"]; exists {
+            // 'broker' is a list of configurations
+            brokerList, ok := brokerConfig.([]interface{})
+            if !ok {
+                continue
+            }
+            for _, brokerItem := range brokerList {
+                brokerItemMap, ok := brokerItem.(map[string]interface{})
+                if !ok {
+                    continue
+                }
+                // Check if 'http_server' exists under this broker item
+                if httpServerConfig, exists := brokerItemMap["http_server"]; exists {
+                    if httpConfigMap, ok := httpServerConfig.(map[string]interface{}); ok {
+                        extractPaths(httpConfigMap)
+                    }
+                }
+            }
+        } else if httpServerConfig, exists := componentMap["http_server"]; exists {
+            // 'http_server' directly under component
+            if httpConfigMap, ok := httpServerConfig.(map[string]interface{}); ok {
+                extractPaths(httpConfigMap)
+            }
+        }
+    }
+
+    return paths
 }
 
 func (s *StreamingMiddleware) getStreamsConfig(r *http.Request) *StreamsConfig {


### PR DESCRIPTION
### **User description**
Ensure that it will work with broker input/ouput, e.g. :

```
input:
   broker:

output:
   broker:
```

Also remove hasHTTP, it does not needed because we can check if paths non empty. 
Additionally instead of just checking if path contains, brought back muxer.Match, by initialize defaultManager.muxer object. 
___

### **PR Type**
enhancement


___

### **Description**
- Refactored the `GetHTTPPaths` function to enhance support for broker input/output configurations.
- Added default path values for `path`, `ws_path`, and `stream_path` when they are missing or not strings.
- Introduced a helper function to streamline path extraction from HTTP server configurations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mw_streaming.go</strong><dd><code>Refactor GetHTTPPaths to support broker configurations and default </code><br><code>paths</code></dd></summary>
<hr>

gateway/mw_streaming.go

<li>Refactored the <code>GetHTTPPaths</code> function to handle broker configurations.<br> <li> Added default path values for missing or non-string path keys.<br> <li> Introduced a helper function to extract paths from HTTP server <br>configurations.<br> <li> Enhanced support for broker input/output configurations.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6535/files#diff-6f565750150d990575c808f1ca8f38483160dc6edf05f1534cd0bedb27c2e6c8">+68/-35</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

