### PR TITLE
Merging to release-5.6: [TT-13122] build multiarch image on 1.22-bullseye (#6549)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,7 @@ jobs:
             type=semver,pattern={{version}}
           labels: "org.opencontainers.image.title=tyk-gateway  (distroless) \norg.opencontainers.image.description=Tyk Open Source API Gateway written in Go, supporting REST, GraphQL, TCP and gRPC protocols\norg.opencontainers.image.vendor=tyk.io\norg.opencontainers.image.version=${{ github.ref_name }}\n"
       - name: build multiarch image
-        if: ${{ matrix.golang_cross == '1.21-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.22-bullseye' }}
         uses: docker/build-push-action@v5
         with:
           context: "dist"


### PR DESCRIPTION
### **User description**
[TT-13122] build multiarch image on 1.22-bullseye (#6549)

### **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description

build multiarch image on 1.22-bullseye, currently the step is skipped
with a typo from go 1.22 upgrade

## Related Issue
https://tyktech.atlassian.net/browse/TT-13122

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
configuration changes


___

### **Description**
- Updated the GitHub Actions workflow to build a multiarch Docker image
using `golang_cross` version `1.22-bullseye` instead of `1.21-bullseye`.
- This change ensures that the build process aligns with the updated Go
version requirements.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Configuration
changes</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>release.yml</strong><dd><code>Update multiarch image
build condition in release workflow</code></dd></summary>
<hr>

.github/workflows/release.yml

<li>Updated the condition for building a multiarch image.<br> <li>
Changed the <code>golang_cross</code> version from
<code>1.21-bullseye</code> to <code>1.22-bullseye</code>.<br>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6549/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+1/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools
and their descriptions

[TT-13122]: https://tyktech.atlassian.net/browse/TT-13122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
enhancement


___

### **Description**
- Corrected a typo in the GitHub Actions workflow file that caused the multiarch image build step to be skipped. The condition now correctly checks for `1.22-bullseye` instead of `1.21-bullseye`.
- This change ensures that the multiarch image is built using the correct Go version, aligning with the intended upgrade to Go 1.22.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Fix typo in multiarch image build condition for Go version</code></dd></summary>
<hr>

.github/workflows/release.yml

<li>Corrected the condition for building the multiarch image.<br> <li> Updated the Go version from 1.21-bullseye to 1.22-bullseye.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6550/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

