### PR TITLE
Merging to release-5.3.6: [TT-13128] Updated description for prefix and suffix matching config options (#6555)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -403,47 +403,43 @@ type HttpServerOptionsConfig struct {
 	// Regular expressions and parameterized routes will be left alone regardless of this setting.
 	EnableStrictRoutes bool `json:"enable_strict_routes"`
 
-	// EnablePathPrefixMatching changes the URL matching from wildcard mode to prefix mode.
-	// For example, `/json` matches `*/json*` by current default behaviour.
-	// If prefix matching is enabled, the match will be performed as a prefix match (`/json*`).
-	//
-	// The `/json` url would be matched as `^/json` against the following paths:
-	//
-	// - Full listen path and versioning URL (`/listen-path/v4/json`)
-	// - Stripped listen path URL (`/v4/json`)
-	// - Stripped version information (`/json`) - match.
-	//
-	// If versioning is disabled then the following URLs are considered:
-	//
-	// - Full listen path and endpoint (`/listen-path/json`)
-	// - Stripped listen path (`/json`) - match.
-	//
-	// For inputs that start with `/`, a prefix match is ensured by
-	// prepending the start of string `^` caret.
-	//
-	// For all other cases, the pattern remains unmodified.
-	//
-	// Combine this option with `enable_path_suffix_matching` to achieve
-	// exact url matching with `/json` being evaluated as `^/json$`.
+	// EnablePathPrefixMatching changes how the gateway matches incoming URL paths against routes (patterns) defined in the API definition.
+	// By default, the gateway uses wildcard matching. When EnablePathPrefixMatching is enabled, it switches to prefix matching. For example, a defined path such as `/json` will only match request URLs that begin with `/json`, rather than matching any URL containing `/json`.
+
+	// The gateway checks the request URL against several variations depending on whether path versioning is enabled:
+	// - Full path (listen path + version + endpoint): `/listen-path/v4/json`
+	// - Non-versioned full path (listen path + endpoint): `/listen-path/json`
+	// - Path without version (endpoint only): `/json`
+
+	// For patterns that start with `/`, the gateway prepends `^` before performing the check, ensuring a true prefix match.
+	// For patterns that start with `^`, the gateway will already perform prefix matching so EnablePathPrefixMatching will have no impact.
+	// This option allows for more specific and controlled routing of API requests, potentially reducing unintended matches. Note that you may need to adjust existing route definitions when enabling this option.
+
+	// Example:
+
+	// With wildcard matching, `/json` might match `/api/v1/data/json`.
+	// With prefix matching, `/json` would not match `/api/v1/data/json`, but would match `/json/data`.
+
+	// Combining EnablePathPrefixMatching with EnablePathSuffixMatching will result in exact URL matching, with `/json` being evaluated as `^/json$`.
 	EnablePathPrefixMatching bool `json:"enable_path_prefix_matching"`
 
-	// EnablePathSuffixMatching changes the URL matching to match as a suffix.
-	// For example: `/json` is matched as `/json$` against the following paths:
-	//
-	// - Full listen path and versioning URL (`/listen-path/v4/json`)
-	// - Stripped listen path URL (`/v4/json`)
-	// - Stripped version information (`/json`) - match.
-	//
-	// If versioning is disabled then the following URLs are considered:
-	//
-	// - Full listen path and endpoint (`/listen-path/json`)
-	// - Stripped listen path (`/json`) - match.
-	//
-	// If the input pattern already ends with a `$` (`/json$`)
-	// then the pattern remains unmodified.
-	//
-	// Combine this option with `enable_path_prefix_matching` to achieve
-	// exact url matching with `/json` being evaluated as `^/json$`.
+	// EnablePathSuffixMatching changes how the gateway matches incoming URL paths against routes (patterns) defined in the API definition.
+	// By default, the gateway uses wildcard matching. When EnablePathSuffixMatching is enabled, it switches to suffix matching. For example, a defined path such as `/json` will only match request URLs that end with `/json`, rather than matching any URL containing `/json`.
+
+	// The gateway checks the request URL against several variations depending on whether path versioning is enabled:
+	// - Full path (listen path + version + endpoint): `/listen-path/v4/json`
+	// - Non-versioned full path (listen path + endpoint): `/listen-path/json`
+	// - Path without version (endpoint only): `/json`
+
+	// For patterns that already end with `$`, the gateway will already perform suffix matching so EnablePathSuffixMatching will have no impact. For all other patterns, the gateway appends `$` before performing the check, ensuring a true suffix match.
+	// This option allows for more specific and controlled routing of API requests, potentially reducing unintended matches. Note that you may need to adjust existing route definitions when enabling this option.
+
+	// Example:
+
+	// With wildcard matching, `/json` might match `/api/v1/json/data`.
+	// With suffix matching, `/json` would not match `/api/v1/json/data`, but would match `/api/v1/json`.
+
+	// Combining EnablePathSuffixMatching with EnablePathPrefixMatching will result in exact URL matching, with `/json` being evaluated as `^/json$`.
 	EnablePathSuffixMatching bool `json:"enable_path_suffix_matching"`
 
 	// Disable TLS verification. Required if you are using self-signed certificates.


### PR DESCRIPTION
### **User description**
[TT-13128] Updated description for prefix and suffix matching config options (#6555)

### **PR Type**
documentation


___

### **Description**
- Updated the documentation for `EnablePathPrefixMatching` to clarify
its behavior, including how it changes URL matching from wildcard to
prefix mode.
- Enhanced the description for `EnablePathSuffixMatching`, explaining
its switch from wildcard to suffix mode.
- Added examples to illustrate the differences between wildcard, prefix,
and suffix matching.
- Noted the potential need for adjustments in existing route definitions
when enabling these options.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>config.go</strong><dd><code>Clarify and enhance
documentation for path matching options</code></dd></summary>
<hr>

config/config.go

<li>Updated descriptions for <code>EnablePathPrefixMatching</code> and
<br><code>EnablePathSuffixMatching</code>.<br> <li> Clarified the
behavior of prefix and suffix matching.<br> <li> Provided examples for
both matching options.<br> <li> Explained the impact on existing route
definitions.<br>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6555/files#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17">+35/-39</a>&nbsp;
</td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools
and their descriptions

[TT-13128]: https://tyktech.atlassian.net/browse/TT-13128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Updated the documentation for `EnablePathPrefixMatching` to clarify its behavior, including how it changes URL matching from wildcard to prefix mode.
- Enhanced the description for `EnablePathSuffixMatching`, explaining its switch from wildcard to suffix mode.
- Added examples to illustrate the differences between wildcard, prefix, and suffix matching.
- Noted the potential need for adjustments in existing route definitions when enabling these options.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.go</strong><dd><code>Clarify and enhance documentation for path matching options</code></dd></summary>
<hr>

config/config.go

<li>Updated documentation for <code>EnablePathPrefixMatching</code> and <br><code>EnablePathSuffixMatching</code>.<br> <li> Clarified the behavior of prefix and suffix matching.<br> <li> Provided examples for both matching options.<br> <li> Explained the impact on existing route definitions.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6557/files#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17">+35/-39</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

