### PR TITLE
Feat/tt 13036/bring back changes

### DIFF
--- a/gateway/mw_streaming.go
+++ b/gateway/mw_streaming.go
@@ -229,7 +229,7 @@ func GetHTTPPaths(streamConfig map[string]interface{}) []string {
 
 func (s *StreamingMiddleware) getStreamsConfig(r *http.Request) *StreamsConfig {
 	config := &StreamsConfig{Streams: make(map[string]any)}
-	if s.Spec.IsOAS {
+	if !s.Spec.IsOAS {
 		return nil
 	}
 


### PR DESCRIPTION
### **User description**
This PR brings back what we have done in https://github.com/TykTechnologies/tyk/pull/6544, reverted by https://github.com/TykTechnologies/tyk/pull/6535


___

### **PR Type**
enhancement


___

### **Description**
- Refactored the `initStreams` function to use a `StreamsConfig` struct instead of a map for better type safety and clarity.
- Updated the `EnabledForSpec` method to utilize the `StreamsConfig` struct, enhancing the readability and maintainability of the code.
- Refactored the `getStreamsConfig` method to return a `StreamsConfig` struct, improving the structure and organization of the streaming configuration retrieval process.
- Enhanced logging and error handling within the `getStreamsConfig` method to provide more informative debug messages and handle errors more gracefully.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mw_streaming.go</strong><dd><code>Refactor streaming configuration handling and improve logging</code></dd></summary>
<hr>

gateway/mw_streaming.go

<li>Changed the <code>initStreams</code> function to use <code>StreamsConfig</code> instead of a <br>map.<br> <li> Updated <code>EnabledForSpec</code> to use <code>StreamsConfig</code>.<br> <li> Refactored <code>getStreamsConfig</code> to return a <code>StreamsConfig</code> struct.<br> <li> Improved logging and error handling in <code>getStreamsConfig</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6561/files#diff-6f565750150d990575c808f1ca8f38483160dc6edf05f1534cd0bedb27c2e6c8">+48/-42</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

