### PR TITLE
Merging to release-5-lts: TT-13130 only mark the wg as done when the connection is stablished (#6574)

### DIFF
--- a/rpc/rpc_client.go
+++ b/rpc/rpc_client.go
@@ -263,7 +263,6 @@ func Connect(connConfig Config, suppressRegister bool, dispatcherFuncs map[strin
 	}
 
 	clientSingleton.Dial = func(addr string) (conn net.Conn, err error) {
-		defer connectionDialingWG.Done()
 		dialer := &net.Dialer{
 			Timeout:   10 * time.Second,
 			KeepAlive: 30 * time.Second,
@@ -299,6 +298,8 @@ func Connect(connConfig Config, suppressRegister bool, dispatcherFuncs map[strin
 		conn.Write([]byte("proto2"))
 		conn.Write([]byte{byte(len(connID))})
 		conn.Write([]byte(connID))
+		// only mark as done is connection is established
+		connectionDialingWG.Done()
 
 		return conn, nil
 	}


### PR DESCRIPTION
TT-13130 only mark the wg as done when the connection is stablished (#6574)

### **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description

When the gw is ran as edge we want this to wait until the connection is
established with MDCB before attempting to pull policies and apis, we
should only mark the connection waitgroup as done when the connection is
successful not on every attempt

## Related Issue

TT-13130

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed the logic in `rpc_client.go` to ensure the waitgroup is marked
as done only when a connection is successfully established.
- Removed the `Done()` call from the defer statement and added it after
the connection is confirmed.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>rpc_client.go</strong><dd><code>Fix waitgroup
completion logic in connection establishment</code></dd></summary>
<hr>

rpc/rpc_client.go

<li>Removed the <code>Done()</code> call from the defer statement in the
<code>Dial</code> function.<br> <li> Added <code>Done()</code> call
after the connection is successfully established.<br> <li> Ensures the
waitgroup is marked as done only upon successful <br>connection.<br>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6574/files#diff-3b88914c99bb9418e44e6389ce73579843562e8900730b380d7fff2e95c51033">+2/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull
request to receive relevant information

Co-authored-by: sredny buitrago <sredny@srednys-MacBook-Pro.local>