### PR TITLE
[TT-12897] Merge path based permissions when combining policies

### DIFF
--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/TykTechnologies/tyk/internal/graphengine"
 	"github.com/TykTechnologies/tyk/internal/httputil"
-	"github.com/TykTechnologies/tyk/internal/model"
 
 	"github.com/getkin/kin-openapi/routers/gorillamux"
 
@@ -48,6 +47,7 @@ import (
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/internal/model"
 	"github.com/TykTechnologies/tyk/regexp"
 	"github.com/TykTechnologies/tyk/rpc"
 	"github.com/TykTechnologies/tyk/storage"
@@ -494,7 +494,7 @@ func (a APIDefinitionLoader) FromDashboardService(endpoint string) ([]*APISpec, 
 	}
 
 	// Extract tagged APIs#
-	list := &model.MergedAPIList{}
+	list := model.NewMergedAPIList()
 	inBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Error("Couldn't read api definition list")
@@ -652,15 +652,12 @@ func (a APIDefinitionLoader) FromRPC(store RPCDataLoader, orgId string, gw *Gate
 }
 
 func (a APIDefinitionLoader) processRPCDefinitions(apiCollection string, gw *Gateway) ([]*APISpec, error) {
-
 	var payload []model.MergedAPI
 	if err := json.Unmarshal([]byte(apiCollection), &payload); err != nil {
 		return nil, err
 	}
 
-	list := &model.MergedAPIList{
-		Message: payload,
-	}
+	list := model.NewMergedAPIList(payload...)
 
 	gwConfig := a.Gw.GetConfig()
 

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/TykTechnologies/tyk/apidef/oas"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/internal/model"
+	"github.com/TykTechnologies/tyk/internal/policy"
 	"github.com/TykTechnologies/tyk/rpc"
 	"github.com/TykTechnologies/tyk/test"
 	"github.com/TykTechnologies/tyk/user"
@@ -1449,7 +1450,7 @@ func Test_LoadAPIsFromRPC(t *testing.T) {
 	loader := APIDefinitionLoader{Gw: ts.Gw}
 
 	t.Run("load APIs from RPC - success", func(t *testing.T) {
-		mockedStorage := &RPCDataLoaderMock{
+		mockedStorage := &policy.RPCDataLoaderMock{
 			ShouldConnect: true,
 			Apis: []model.MergedAPI{
 				{APIDefinition: &apidef.APIDefinition{Id: objectID, OrgID: "org1", APIID: "api1"}},
@@ -1463,7 +1464,7 @@ func Test_LoadAPIsFromRPC(t *testing.T) {
 	})
 
 	t.Run("load APIs from RPC - success - then fail", func(t *testing.T) {
-		mockedStorage := &RPCDataLoaderMock{
+		mockedStorage := &policy.RPCDataLoaderMock{
 			ShouldConnect: true,
 			Apis: []model.MergedAPI{
 				{APIDefinition: &apidef.APIDefinition{Id: objectID, OrgID: "org1", APIID: "api1"}},

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -41,3 +41,22 @@ func (gw *Gateway) PolicyCount() int {
 
 	return len(gw.policiesByID)
 }
+
+// SetPolicies updates the internal policy map with a new policy map.
+func (gw *Gateway) SetPolicies(pols map[string]user.Policy) {
+	gw.policiesMu.Lock()
+	defer gw.policiesMu.Unlock()
+
+	gw.policiesByID = pols
+}
+
+// SetPoliciesByID will update the internal policiesByID map with new policies.
+// The key used will be the policy ID.
+func (gw *Gateway) SetPoliciesByID(pols ...user.Policy) {
+	gw.policiesMu.Lock()
+	defer gw.policiesMu.Unlock()
+
+	for _, pol := range pols {
+		gw.policiesByID[pol.ID] = pol
+	}
+}

--- a/gateway/health_check.go
+++ b/gateway/health_check.go
@@ -8,29 +8,42 @@ import (
 	"sync"
 	"time"
 
-	"github.com/TykTechnologies/tyk/internal/model"
-	"github.com/TykTechnologies/tyk/rpc"
-
 	"github.com/sirupsen/logrus"
 
 	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/internal/model"
+	"github.com/TykTechnologies/tyk/rpc"
 	"github.com/TykTechnologies/tyk/storage"
+)
+
+type (
+	HealthCheckItem     = model.HealthCheckItem
+	HealthCheckStatus   = model.HealthCheckStatus
+	HealthCheckResponse = model.HealthCheckResponse
+)
+
+const (
+	Pass      = model.Pass
+	Fail      = model.Fail
+	Warn      = model.Warn
+	Datastore = model.Datastore
+	System    = model.System
 )
 
 func (gw *Gateway) setCurrentHealthCheckInfo(h map[string]model.HealthCheckItem) {
 	gw.healthCheckInfo.Store(h)
 }
 
-func (gw *Gateway) getHealthCheckInfo() map[string]model.HealthCheckItem {
-	ret, ok := gw.healthCheckInfo.Load().(map[string]model.HealthCheckItem)
+func (gw *Gateway) getHealthCheckInfo() map[string]HealthCheckItem {
+	ret, ok := gw.healthCheckInfo.Load().(map[string]HealthCheckItem)
 	if !ok {
-		return make(map[string]model.HealthCheckItem, 0)
+		return make(map[string]HealthCheckItem, 0)
 	}
 	return ret
 }
 
 func (gw *Gateway) initHealthCheck(ctx context.Context) {
-	gw.setCurrentHealthCheckInfo(make(map[string]model.HealthCheckItem, 3))
+	gw.setCurrentHealthCheckInfo(make(map[string]HealthCheckItem, 3))
 
 	go func(ctx context.Context) {
 		var n = gw.GetConfig().LivenessCheck.CheckDuration
@@ -58,12 +71,12 @@ func (gw *Gateway) initHealthCheck(ctx context.Context) {
 }
 
 type SafeHealthCheck struct {
-	info map[string]model.HealthCheckItem
+	info map[string]HealthCheckItem
 	mux  sync.Mutex
 }
 
 func (gw *Gateway) gatherHealthChecks() {
-	allInfos := SafeHealthCheck{info: make(map[string]model.HealthCheckItem, 3)}
+	allInfos := SafeHealthCheck{info: make(map[string]HealthCheckItem, 3)}
 
 	redisStore := storage.RedisCluster{KeyPrefix: "livenesscheck-", ConnectionHandler: gw.StorageConnectionHandler}
 
@@ -75,9 +88,9 @@ func (gw *Gateway) gatherHealthChecks() {
 	go func() {
 		defer wg.Done()
 
-		var checkItem = model.HealthCheckItem{
-			Status:        model.Pass,
-			ComponentType: model.Datastore,
+		var checkItem = HealthCheckItem{
+			Status:        Pass,
+			ComponentType: Datastore,
 			Time:          time.Now().Format(time.RFC3339),
 		}
 
@@ -85,7 +98,7 @@ func (gw *Gateway) gatherHealthChecks() {
 		if err != nil {
 			mainLog.WithField("liveness-check", true).WithError(err).Error("Redis health check failed")
 			checkItem.Output = err.Error()
-			checkItem.Status = model.Fail
+			checkItem.Status = Fail
 		}
 
 		allInfos.mux.Lock()
@@ -99,9 +112,9 @@ func (gw *Gateway) gatherHealthChecks() {
 		go func() {
 			defer wg.Done()
 
-			var checkItem = model.HealthCheckItem{
-				Status:        model.Pass,
-				ComponentType: model.Datastore,
+			var checkItem = HealthCheckItem{
+				Status:        Pass,
+				ComponentType: Datastore,
 				Time:          time.Now().Format(time.RFC3339),
 			}
 
@@ -109,14 +122,14 @@ func (gw *Gateway) gatherHealthChecks() {
 				err := errors.New("Dashboard service not initialized")
 				mainLog.WithField("liveness-check", true).Error(err)
 				checkItem.Output = err.Error()
-				checkItem.Status = model.Fail
+				checkItem.Status = Fail
 			} else if err := gw.DashService.Ping(); err != nil {
 				mainLog.WithField("liveness-check", true).Error(err)
 				checkItem.Output = err.Error()
-				checkItem.Status = model.Fail
+				checkItem.Status = Fail
 			}
 
-			checkItem.ComponentType = model.System
+			checkItem.ComponentType = System
 
 			allInfos.mux.Lock()
 			allInfos.info["dashboard"] = checkItem
@@ -131,18 +144,18 @@ func (gw *Gateway) gatherHealthChecks() {
 		go func() {
 			defer wg.Done()
 
-			var checkItem = model.HealthCheckItem{
-				Status:        model.Pass,
-				ComponentType: model.Datastore,
+			var checkItem = HealthCheckItem{
+				Status:        Pass,
+				ComponentType: Datastore,
 				Time:          time.Now().Format(time.RFC3339),
 			}
 
 			if !rpc.Login() {
 				checkItem.Output = "Could not connect to RPC"
-				checkItem.Status = model.Fail
+				checkItem.Status = Fail
 			}
 
-			checkItem.ComponentType = model.System
+			checkItem.ComponentType = System
 
 			allInfos.mux.Lock()
 			allInfos.info["rpc"] = checkItem
@@ -165,8 +178,8 @@ func (gw *Gateway) liveCheckHandler(w http.ResponseWriter, r *http.Request) {
 
 	checks := gw.getHealthCheckInfo()
 
-	res := model.HealthCheckResponse{
-		Status:      model.Pass,
+	res := HealthCheckResponse{
+		Status:      Pass,
 		Version:     VERSION,
 		Description: "Tyk GW",
 		Details:     checks,
@@ -175,22 +188,22 @@ func (gw *Gateway) liveCheckHandler(w http.ResponseWriter, r *http.Request) {
 	var failCount int
 
 	for _, v := range checks {
-		if v.Status == model.Fail {
+		if v.Status == Fail {
 			failCount++
 		}
 	}
 
-	var status model.HealthCheckStatus
+	var status HealthCheckStatus
 
 	switch failCount {
 	case 0:
-		status = model.Pass
+		status = Pass
 
 	case len(checks):
-		status = model.Fail
+		status = Fail
 
 	default:
-		status = model.Warn
+		status = Warn
 	}
 
 	res.Status = status

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -16,11 +16,9 @@ import (
 
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/header"
-	"github.com/TykTechnologies/tyk/rpc"
 	"github.com/TykTechnologies/tyk/test"
 	"github.com/TykTechnologies/tyk/user"
 
-	"github.com/TykTechnologies/tyk/internal/model"
 	"github.com/TykTechnologies/tyk/internal/uuid"
 )
 
@@ -720,74 +718,4 @@ func TestParsePoliciesFromRPC(t *testing.T) {
 		})
 	}
 
-}
-
-type RPCDataLoaderMock struct {
-	ShouldConnect bool
-	Policies      []user.Policy
-	Apis          []model.MergedAPI
-}
-
-func (s *RPCDataLoaderMock) Connect() bool {
-	return s.ShouldConnect
-}
-
-func (s *RPCDataLoaderMock) GetApiDefinitions(orgId string, tags []string) string {
-	apiList, err := json.Marshal(s.Apis)
-	if err != nil {
-		return ""
-	}
-	return string(apiList)
-}
-func (s *RPCDataLoaderMock) GetPolicies(orgId string) string {
-	policyList, err := json.Marshal(s.Policies)
-	if err != nil {
-		return ""
-	}
-	return string(policyList)
-}
-
-func Test_LoadPoliciesFromRPC(t *testing.T) {
-	ts := StartTest(nil)
-	defer ts.Close()
-	objectID := persistentmodel.NewObjectID()
-
-	t.Run("load policies from RPC - success", func(t *testing.T) {
-		mockedStorage := &RPCDataLoaderMock{
-			ShouldConnect: true,
-			Policies: []user.Policy{
-				{MID: objectID, ID: "", OrgID: "org1"},
-			},
-		}
-
-		polMap, err := ts.Gw.LoadPoliciesFromRPC(mockedStorage, "org1", true)
-
-		assert.NoError(t, err, "error loading policies from RPC:", err)
-		assert.Equal(t, 1, len(polMap), "expected 0 policies to be loaded from RPC")
-	})
-
-	t.Run("load policies from RPC - success - then fail", func(t *testing.T) {
-		mockedStorage := &RPCDataLoaderMock{
-			ShouldConnect: true,
-			Policies: []user.Policy{
-				{MID: objectID, ID: "", OrgID: "org1"},
-			},
-		}
-		// we load the Policies from RPC successfully - it should store the Policies in the backup
-		polMap, err := ts.Gw.LoadPoliciesFromRPC(mockedStorage, "org1", true)
-
-		assert.NoError(t, err, "error loading policies from RPC:", err)
-		assert.Equal(t, 1, len(polMap), "expected 0 policies to be loaded from RPC")
-
-		// we now simulate a failure to connect to RPC
-		mockedStorage.ShouldConnect = false
-		rpc.SetEmergencyMode(t, true)
-		defer rpc.ResetEmergencyMode()
-
-		// we now try to load the Policies again, and expect it to load the Policies from the backup
-		polMap, err = ts.Gw.LoadPoliciesFromRPC(mockedStorage, "org1", true)
-
-		assert.NoError(t, err, "error loading policies from RPC:", err)
-		assert.Equal(t, 1, len(polMap), "expected 0 policies to be loaded from RPC")
-	})
 }

--- a/internal/policy/Taskfile.yml
+++ b/internal/policy/Taskfile.yml
@@ -19,7 +19,23 @@ tasks:
       - defer: { task: services:down }
       - goimports -w .
       - go fmt ./...
+      - task: test
+        vars:
+          run: '{{.run}}'
+
+  test:
+    desc: "Run tests"
+    requires:
+      vars: [run]
+    cmds:
       - go test -count=1 -run='({{.run}})' -cover -coverprofile=pkg.cov -v .
+
+  stress:
+    desc: "Run stress tests"
+    requires:
+      vars: [run]
+    cmds:
+      - go test -count=2000 -run='({{.run}})' -cover -coverprofile=pkg.cov .
 
   cover:
     desc: "Show source coverage"

--- a/internal/policy/apply_test.go
+++ b/internal/policy/apply_test.go
@@ -9,11 +9,9 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
-
-	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
-
 	"github.com/stretchr/testify/assert"
 
+	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
 	"github.com/TykTechnologies/tyk/internal/policy"
 	"github.com/TykTechnologies/tyk/user"
 )
@@ -22,9 +20,9 @@ import (
 var testDataFS embed.FS
 
 func TestApplyRateLimits_PolicyLimits(t *testing.T) {
-	svc := &policy.Service{}
-
 	t.Run("policy limits unset", func(t *testing.T) {
+		svc := &policy.Service{}
+
 		session := &user.SessionState{
 			Rate: 5,
 			Per:  10,
@@ -44,6 +42,8 @@ func TestApplyRateLimits_PolicyLimits(t *testing.T) {
 	})
 
 	t.Run("policy limits apply all", func(t *testing.T) {
+		svc := &policy.Service{}
+
 		session := &user.SessionState{
 			Rate: 5,
 			Per:  10,
@@ -69,6 +69,8 @@ func TestApplyRateLimits_PolicyLimits(t *testing.T) {
 	// changes are applied to api limits, but skipped on
 	// the session as the session has a higher allowance.
 	t.Run("policy limits apply per-api", func(t *testing.T) {
+		svc := &policy.Service{}
+
 		session := &user.SessionState{
 			Rate: 15,
 			Per:  10,
@@ -93,6 +95,8 @@ func TestApplyRateLimits_PolicyLimits(t *testing.T) {
 	// As the policy defined a lower rate than apiLimits,
 	// no changes to api limits are applied.
 	t.Run("policy limits skip", func(t *testing.T) {
+		svc := &policy.Service{}
+
 		session := &user.SessionState{
 			Rate: 5,
 			Per:  10,
@@ -117,29 +121,26 @@ func TestApplyRateLimits_PolicyLimits(t *testing.T) {
 func TestApplyRateLimits_FromCustomPolicies(t *testing.T) {
 	svc := &policy.Service{}
 
-	t.Run("Custom policies", func(t *testing.T) {
-		session := &user.SessionState{}
-		session.SetCustomPolicies([]user.Policy{
-			{
-				ID:           "pol1",
-				Partitions:   user.PolicyPartitions{RateLimit: true},
-				Rate:         8,
-				Per:          1,
-				AccessRights: map[string]user.AccessDefinition{"a": {}},
-			},
-			{
-				ID:           "pol2",
-				Partitions:   user.PolicyPartitions{RateLimit: true},
-				Rate:         10,
-				Per:          1,
-				AccessRights: map[string]user.AccessDefinition{"a": {}},
-			},
-		})
-
-		svc.Apply(session)
-
-		assert.Equal(t, 10, int(session.Rate))
+	session := &user.SessionState{}
+	session.SetCustomPolicies([]user.Policy{
+		{
+			ID:           "pol1",
+			Partitions:   user.PolicyPartitions{RateLimit: true},
+			Rate:         8,
+			Per:          1,
+			AccessRights: map[string]user.AccessDefinition{"a": {}},
+		},
+		{
+			ID:           "pol2",
+			Partitions:   user.PolicyPartitions{RateLimit: true},
+			Rate:         10,
+			Per:          1,
+			AccessRights: map[string]user.AccessDefinition{"a": {}},
+		},
 	})
+
+	assert.NoError(t, svc.Apply(session))
+	assert.Equal(t, 10, int(session.Rate))
 }
 
 func TestApplyEndpointLevelLimits(t *testing.T) {
@@ -190,7 +191,7 @@ func testPrepareApplyPolicies(tb testing.TB) (*policy.Service, []testApplyPolici
 	err = json.Unmarshal(f, &repoPols)
 	assert.NoError(tb, err)
 
-	store := policy.NewStore(repoPols)
+	store := policy.NewStoreMap(repoPols)
 	orgID := ""
 	service := policy.New(&orgID, store, logrus.StandardLogger())
 

--- a/internal/policy/rpc.go
+++ b/internal/policy/rpc.go
@@ -1,0 +1,42 @@
+package policy
+
+import (
+	"encoding/json"
+
+	"github.com/TykTechnologies/tyk/internal/model"
+	"github.com/TykTechnologies/tyk/user"
+)
+
+// RPCDataLoaderMock is a policy-related test utility.
+type RPCDataLoaderMock struct {
+	ShouldConnect bool
+	Policies      []user.Policy
+	Apis          []model.MergedAPI
+}
+
+// Connect will return the connection status.
+func (s *RPCDataLoaderMock) Connect() bool {
+	return s.ShouldConnect
+}
+
+// GetApiDefinitions returns the internal Apis as a json string.
+func (s *RPCDataLoaderMock) GetApiDefinitions(_ string, tags []string) string {
+	if len(tags) > 1 {
+		panic("not implemented")
+	}
+
+	apiList, err := json.Marshal(s.Apis)
+	if err != nil {
+		return ""
+	}
+	return string(apiList)
+}
+
+// GetPolicies returns the internal Policies as a json string.
+func (s *RPCDataLoaderMock) GetPolicies(_ string) string {
+	policyList, err := json.Marshal(s.Policies)
+	if err != nil {
+		return ""
+	}
+	return string(policyList)
+}

--- a/internal/policy/store.go
+++ b/internal/policy/store.go
@@ -4,20 +4,27 @@ import (
 	"github.com/TykTechnologies/tyk/user"
 )
 
-// Store is an in-memory policy storage object that
-// implements the repository for policy access. We
-// do not implement concurrency protections here.
+// Store is an in-memory policy storage object that implements the
+// repository for policy access. We  do not implement concurrency
+// protections here. Where order is important, use this.
 type Store struct {
-	policies map[string]user.Policy
+	policies []user.Policy
 }
 
-func NewStore(policies map[string]user.Policy) *Store {
+// NewStore returns a new policy.Store.
+func NewStore(policies []user.Policy) *Store {
 	return &Store{
 		policies: policies,
 	}
 }
 
+// PolicyIDs returns a list policy IDs in the store.
+// It will return nil if no policies exist.
 func (s *Store) PolicyIDs() []string {
+	if len(s.policies) == 0 {
+		return nil
+	}
+
 	policyIDs := make([]string, 0, len(s.policies))
 	for _, val := range s.policies {
 		policyIDs = append(policyIDs, val.ID)
@@ -25,11 +32,17 @@ func (s *Store) PolicyIDs() []string {
 	return policyIDs
 }
 
+// PolicyByID returns a policy by ID.
 func (s *Store) PolicyByID(id string) (user.Policy, bool) {
-	v, ok := s.policies[id]
-	return v, ok
+	for _, pol := range s.policies {
+		if pol.ID == id {
+			return pol, true
+		}
+	}
+	return user.Policy{}, false
 }
 
+// PolicyCount returns the number of policies in the store.
 func (s *Store) PolicyCount() int {
 	return len(s.policies)
 }

--- a/internal/policy/store_map.go
+++ b/internal/policy/store_map.go
@@ -1,0 +1,46 @@
+package policy
+
+import (
+	"github.com/TykTechnologies/tyk/user"
+)
+
+// StoreMap is same as Store, but doesn't preserve order.
+type StoreMap struct {
+	policies map[string]user.Policy
+}
+
+// NewStoreMap returns a new policy.StoreMap.
+func NewStoreMap(policies map[string]user.Policy) *StoreMap {
+	if len(policies) == 0 {
+		policies = make(map[string]user.Policy)
+	}
+
+	return &StoreMap{
+		policies: policies,
+	}
+}
+
+// PolicyIDs returns a list policy IDs in the store.
+// It will return nil if no policies exist.
+func (s *StoreMap) PolicyIDs() []string {
+	if len(s.policies) == 0 {
+		return nil
+	}
+
+	policyIDs := make([]string, 0, len(s.policies))
+	for _, val := range s.policies {
+		policyIDs = append(policyIDs, val.ID)
+	}
+	return policyIDs
+}
+
+// PolicyByID returns a policy by ID.
+func (s *StoreMap) PolicyByID(id string) (user.Policy, bool) {
+	v, ok := s.policies[id]
+	return v, ok
+}
+
+// PolicyCount returns the number of policies in the store.
+func (s *StoreMap) PolicyCount() int {
+	return len(s.policies)
+}

--- a/internal/policy/util_test.go
+++ b/internal/policy/util_test.go
@@ -1,0 +1,64 @@
+package policy_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk/internal/policy"
+	"github.com/TykTechnologies/tyk/user"
+)
+
+func TestMergeAllowedURLs(t *testing.T) {
+	svc := &policy.Service{}
+
+	session := &user.SessionState{}
+	policies := []user.Policy{
+		{
+			ID: "pol1",
+			AccessRights: map[string]user.AccessDefinition{
+				"a": {
+					AllowedURLs: []user.AccessSpec{
+						{URL: "/user", Methods: []string{"GET"}},
+						{URL: "/companies", Methods: []string{"GET"}},
+					},
+				},
+			},
+		},
+		{
+			ID: "pol2",
+			AccessRights: map[string]user.AccessDefinition{
+				"a": {
+					AllowedURLs: []user.AccessSpec{
+						{URL: "/user", Methods: []string{"POST", "PATCH", "PUT"}},
+						{URL: "/companies", Methods: []string{"POST"}},
+						{URL: "/admin", Methods: []string{"GET", "POST"}},
+					},
+				},
+			},
+		},
+		{
+			ID: "pol3",
+			AccessRights: map[string]user.AccessDefinition{
+				"a": {
+					AllowedURLs: []user.AccessSpec{
+						{URL: "/admin/cache", Methods: []string{"DELETE"}},
+					},
+				},
+			},
+		},
+	}
+
+	session.SetCustomPolicies(policies)
+
+	assert.NoError(t, svc.Apply(session))
+
+	want := []user.AccessSpec{
+		{URL: "/user", Methods: []string{"GET", "POST", "PATCH", "PUT"}},
+		{URL: "/companies", Methods: []string{"GET", "POST"}},
+		{URL: "/admin", Methods: []string{"GET", "POST"}},
+		{URL: "/admin/cache", Methods: []string{"DELETE"}},
+	}
+
+	assert.Equal(t, want, session.AccessRights["a"].AllowedURLs)
+}

--- a/rpc/synchronization_forcer.go
+++ b/rpc/synchronization_forcer.go
@@ -3,7 +3,7 @@ package rpc
 import (
 	"errors"
 
-	"github.com/TykTechnologies/tyk/internal/model"
+	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/storage"
 )
 
@@ -38,7 +38,7 @@ func (sf *SyncronizerForcer) GroupLoginCallback(userKey string, groupID string) 
 		Log.Info("Forcing MDCB synchronization for group:", groupID)
 	}
 
-	return model.GroupLoginRequest{
+	return apidef.GroupLoginRequest{
 		UserKey:   userKey,
 		GroupID:   groupID,
 		Node:      sf.getNodeDataFunc(),

--- a/rpc/synchronization_forcer.go
+++ b/rpc/synchronization_forcer.go
@@ -3,7 +3,7 @@ package rpc
 import (
 	"errors"
 
-	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/internal/model"
 	"github.com/TykTechnologies/tyk/storage"
 )
 
@@ -38,7 +38,7 @@ func (sf *SyncronizerForcer) GroupLoginCallback(userKey string, groupID string) 
 		Log.Info("Forcing MDCB synchronization for group:", groupID)
 	}
 
-	return apidef.GroupLoginRequest{
+	return model.GroupLoginRequest{
 		UserKey:   userKey,
 		GroupID:   groupID,
 		Node:      sf.getNodeDataFunc(),

--- a/rpc/synchronization_forcer_test.go
+++ b/rpc/synchronization_forcer_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
-	"github.com/TykTechnologies/tyk/internal/model"
 	"github.com/TykTechnologies/tyk/storage"
 )
 
@@ -52,14 +52,14 @@ func TestGroupLoginCallback(t *testing.T) {
 	groupID := "group"
 
 	//first time, it should force since the group key doesn't exists
-	groupLogin, ok := sf.GroupLoginCallback(key, groupID).(model.GroupLoginRequest)
+	groupLogin, ok := sf.GroupLoginCallback(key, groupID).(apidef.GroupLoginRequest)
 	assert.True(t, ok)
 	assert.Equal(t, true, groupLogin.ForceSync)
 	assert.Equal(t, key, groupLogin.UserKey)
 	assert.Equal(t, groupID, groupLogin.GroupID)
 
 	//second time, it shouldn't force since the group key already exists
-	groupLogin, ok = sf.GroupLoginCallback(key, groupID).(model.GroupLoginRequest)
+	groupLogin, ok = sf.GroupLoginCallback(key, groupID).(apidef.GroupLoginRequest)
 	assert.True(t, ok)
 	assert.Equal(t, false, groupLogin.ForceSync)
 	assert.Equal(t, key, groupLogin.UserKey)

--- a/rpc/synchronization_forcer_test.go
+++ b/rpc/synchronization_forcer_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/internal/model"
 	"github.com/TykTechnologies/tyk/storage"
 )
 
@@ -52,14 +52,14 @@ func TestGroupLoginCallback(t *testing.T) {
 	groupID := "group"
 
 	//first time, it should force since the group key doesn't exists
-	groupLogin, ok := sf.GroupLoginCallback(key, groupID).(apidef.GroupLoginRequest)
+	groupLogin, ok := sf.GroupLoginCallback(key, groupID).(model.GroupLoginRequest)
 	assert.True(t, ok)
 	assert.Equal(t, true, groupLogin.ForceSync)
 	assert.Equal(t, key, groupLogin.UserKey)
 	assert.Equal(t, groupID, groupLogin.GroupID)
 
 	//second time, it shouldn't force since the group key already exists
-	groupLogin, ok = sf.GroupLoginCallback(key, groupID).(apidef.GroupLoginRequest)
+	groupLogin, ok = sf.GroupLoginCallback(key, groupID).(model.GroupLoginRequest)
 	assert.True(t, ok)
 	assert.Equal(t, false, groupLogin.ForceSync)
 	assert.Equal(t, key, groupLogin.UserKey)

--- a/tests/policy/Taskfile.yml
+++ b/tests/policy/Taskfile.yml
@@ -7,7 +7,7 @@ includes:
     dir: ../../docker/services
 
 vars:
-  coverage: quota.cov
+  coverage: policy.cov
   testArgs: -v
 
 tasks:

--- a/tests/policy/allowed_urls_test.go
+++ b/tests/policy/allowed_urls_test.go
@@ -1,0 +1,172 @@
+package policy
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk/internal/policy"
+	"github.com/TykTechnologies/tyk/internal/uuid"
+	"github.com/TykTechnologies/tyk/test"
+	"github.com/TykTechnologies/tyk/user"
+)
+
+// The integration test.
+func TestAllowedURLs(t *testing.T) {
+	ts := StartTest(nil)
+	t.Cleanup(ts.Close)
+
+	policyBase := user.Policy{
+		ID:               uuid.New(),
+		Per:              1,
+		Rate:             1000,
+		QuotaMax:         50,
+		QuotaRenewalRate: 3600,
+		OrgID:            DefaultOrg,
+		AccessRights: map[string]user.AccessDefinition{
+			"api1": {
+				Versions: []string{"v1"},
+				Limit: user.APILimit{
+					QuotaMax:         100,
+					QuotaRenewalRate: 3600,
+					RateLimit: user.RateLimit{
+						Rate: 1000,
+						Per:  1,
+					},
+				},
+				AllowedURLs: []user.AccessSpec{
+					{URL: "/user", Methods: []string{"GET"}},
+					{URL: "/companies", Methods: []string{"GET"}},
+				},
+			},
+			"api2": {
+				Versions: []string{"v1"},
+				Limit: user.APILimit{
+					QuotaMax:         200,
+					QuotaRenewalRate: 3600,
+					RateLimit: user.RateLimit{
+						Rate: 1000,
+						Per:  1,
+					},
+				},
+				AllowedURLs: []user.AccessSpec{
+					{URL: "/user", Methods: []string{"POST", "PATCH", "PUT"}},
+					{URL: "/companies", Methods: []string{"POST"}},
+					{URL: "/admin", Methods: []string{"GET", "POST"}},
+				},
+			},
+			"api3": {
+				Versions: []string{"v1"},
+				AllowedURLs: []user.AccessSpec{
+					{URL: "/admin/cache", Methods: []string{"DELETE"}},
+				},
+			},
+		},
+	}
+
+	policyWithPaths := user.Policy{
+		ID:               uuid.New(),
+		Per:              1,
+		Rate:             1000,
+		QuotaMax:         50,
+		QuotaRenewalRate: 3600,
+		OrgID:            DefaultOrg,
+		AccessRights: map[string]user.AccessDefinition{
+			"api1": {
+				Versions: []string{"v1"},
+				AllowedURLs: []user.AccessSpec{
+					{URL: "/appended", Methods: []string{"GET"}},
+				},
+			},
+			"api2": {
+				Versions: []string{"v1"},
+				AllowedURLs: []user.AccessSpec{
+					{URL: "/appended", Methods: []string{"GET"}},
+				},
+			},
+			"api3": {
+				Versions: []string{"v1"},
+				AllowedURLs: []user.AccessSpec{
+					{URL: "/appended", Methods: []string{"GET"}},
+				},
+			},
+		},
+	}
+
+	ts.Gw.SetPoliciesByID(policyBase, policyWithPaths)
+
+	// load APIs
+	ts.Gw.BuildAndLoadAPI(
+		func(spec *APISpec) {
+			spec.Name = "api 1"
+			spec.APIID = "api1"
+			spec.UseKeylessAccess = false
+			spec.Proxy.ListenPath = "/api1"
+			spec.OrgID = DefaultOrg
+		},
+		func(spec *APISpec) {
+			spec.Name = "api 2"
+			spec.APIID = "api2"
+			spec.UseKeylessAccess = false
+			spec.Proxy.ListenPath = "/api2"
+			spec.OrgID = DefaultOrg
+		},
+		func(spec *APISpec) {
+			spec.Name = "api 3"
+			spec.APIID = "api3"
+			spec.UseKeylessAccess = false
+			spec.Proxy.ListenPath = "/api3"
+			spec.OrgID = DefaultOrg
+		},
+	)
+
+	// create test session
+	session := &user.SessionState{
+		ApplyPolicies: []string{policyBase.ID, policyWithPaths.ID},
+		OrgID:         DefaultOrg,
+		AccessRights: map[string]user.AccessDefinition{
+			"api1": {
+				APIID:    "api1",
+				Versions: []string{"v1"},
+			},
+			"api2": {
+				APIID:    "api2",
+				Versions: []string{"v1"},
+			},
+			"api3": {
+				APIID:    "api3",
+				Versions: []string{"v1"},
+			},
+		},
+	}
+
+	// create key
+	key := uuid.New()
+	ts.Run(t, test.TestCase{Method: http.MethodPost, Path: "/tyk/keys/" + key, Data: session, AdminAuth: true, Code: 200})
+
+	// check key session
+	t.Run("Check key session", func(t *testing.T) {
+		ts.Run(t, []test.TestCase{
+			{
+				Method:    http.MethodGet,
+				Path:      fmt.Sprintf("/tyk/keys/%v?org_id=%v", key, DefaultOrg),
+				AdminAuth: true,
+				Code:      http.StatusOK,
+				BodyMatchFunc: func(data []byte) bool {
+					session := user.SessionState{}
+					assert.NoError(t, json.Unmarshal(data, &session))
+
+					for _, apiName := range []string{"api1", "api2", "api3"} {
+						want := policy.MergeAllowedURLs(policyBase.AccessRights[apiName].AllowedURLs, policyWithPaths.AccessRights[apiName].AllowedURLs)
+						assert.Equal(t, want, session.AccessRights[apiName].AllowedURLs, fmt.Sprintf("api %q allowed urls don't match", apiName))
+					}
+
+					return true
+				},
+			},
+		}...)
+	})
+}

--- a/tests/policy/shim.go
+++ b/tests/policy/shim.go
@@ -1,0 +1,9 @@
+package policy
+
+import "github.com/TykTechnologies/tyk/gateway"
+
+const DefaultOrg = "default-org-id"
+
+type APISpec = gateway.APISpec
+
+var StartTest = gateway.StartTest

--- a/user/custom_policies.go
+++ b/user/custom_policies.go
@@ -6,10 +6,26 @@ import (
 	"fmt"
 )
 
+// CustomPolicies returns a map of custom policies on the session.
+// To preserve policy order, use GetCustomPolicies instead.
 func (s *SessionState) CustomPolicies() (map[string]Policy, error) {
+	customPolicies, err := s.GetCustomPolicies()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]Policy, len(customPolicies))
+	for i := 0; i < len(customPolicies); i++ {
+		result[customPolicies[i].ID] = customPolicies[i]
+	}
+
+	return result, nil
+}
+
+// GetCustomPolicies is like CustomPolicies but returns the list, preserving order.
+func (s *SessionState) GetCustomPolicies() ([]Policy, error) {
 	var (
 		customPolicies []Policy
-		ret            map[string]Policy
 	)
 
 	metadataPolicies, found := s.MetaData["policies"].([]interface{})
@@ -22,16 +38,14 @@ func (s *SessionState) CustomPolicies() (map[string]Policy, error) {
 		return nil, fmt.Errorf("failed to marshal metadata policies: %w", err)
 	}
 
-	_ = json.Unmarshal(polJSON, &customPolicies)
-
-	ret = make(map[string]Policy, len(customPolicies))
-	for i := 0; i < len(customPolicies); i++ {
-		ret[customPolicies[i].ID] = customPolicies[i]
+	if err := json.Unmarshal(polJSON, &customPolicies); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal metadata policies: %w", err)
 	}
 
-	return ret, nil
+	return customPolicies, err
 }
 
+// SetCustomPolicies sets custom policies into session metadata.
 func (s *SessionState) SetCustomPolicies(list []Policy) {
 	if s.MetaData == nil {
 		s.MetaData = make(map[string]interface{})

--- a/user/session.go
+++ b/user/session.go
@@ -10,10 +10,7 @@ import (
 	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
 
 	"github.com/TykTechnologies/tyk/apidef"
-	logger "github.com/TykTechnologies/tyk/log"
 )
-
-var log = logger.Get()
 
 type HashType string
 


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-12897" title="TT-12897" target="_blank">TT-12897</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>[Security]Path-Based Permissions permissions in policies are not preserved when policies are combined</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20customer_bug%20ORDER%20BY%20created%20DESC" title="customer_bug">customer_bug</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20jira_escalated%20ORDER%20BY%20created%20DESC" title="jira_escalated">jira_escalated</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

PR uses custom policies to combine several policies with access rights set.

Since a `map` was in the path, user API for custom policies needed an extension to preserve policy ID order. The existing function returning a map didn't handle json decode errors properly and go semantics when looping over maps don't preserve this order, but it's random so tests would fail. Verified with `task stress`.

Issue: https://tyktech.atlassian.net/browse/TT-12897


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Enhanced policy application logic by introducing `MergeAllowedURLs` to merge allowed URLs efficiently.
- Refactored `Store` to use a slice for policies, and introduced `StoreMap` for unordered policy storage.
- Improved custom policy handling by adding `GetCustomPolicies` to preserve policy order.
- Updated tests to ensure proper application of policies and added new tests for `MergeAllowedURLs`.
- Updated Taskfile to include a new `stress` task for running stress tests.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>apply.go</strong><dd><code>Enhance policy application logic and logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/policy/apply.go

<li>Introduced <code>MergeAllowedURLs</code> function to merge allowed URLs.<br> <li> Updated <code>Logger</code> function to return a <code>logrus.Entry</code>.<br> <li> Changed <code>session.CustomPolicies()</code> to <code>session.GetCustomPolicies()</code>.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6597/files#diff-59b92e9d31f142f1d99b746eb3ff7db4e26bf6c3044c9b87b58034a947ee04d1">+9/-17</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>store.go</strong><dd><code>Refactor Store to use slice for policies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/policy/store.go

<li>Changed <code>Store</code> to use a slice for policies.<br> <li> Updated methods to accommodate slice-based storage.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6597/files#diff-13dec7bc453c9ff99550c83d2f86a017bbf7fb863584dc30603af15d29ef9d3d">+20/-7</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>store_map.go</strong><dd><code>Add StoreMap for unordered policy storage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/policy/store_map.go

<li>Introduced <code>StoreMap</code> for unordered policy storage.<br> <li> Implemented methods for <code>StoreMap</code>.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6597/files#diff-24a7a95a1cf4f14b59a3475127dc45541357638d6949323255faeeb2ed657d27">+46/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>util.go</strong><dd><code>Introduce MergeAllowedURLs and remove unused functions</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/policy/util.go

<li>Added <code>MergeAllowedURLs</code> function for merging URL access specs.<br> <li> Removed <code>copyAllowedURLs</code> and <code>contains</code> functions.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6597/files#diff-0323c3da13f08a9ccd340ac04208d680856354fd566dffcad925fa6645639955">+46/-70</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>custom_policies.go</strong><dd><code>Enhance custom policies handling with order preservation</code>&nbsp; </dd></summary>
<hr>

user/custom_policies.go

<li>Added <code>GetCustomPolicies</code> to preserve policy order.<br> <li> Updated <code>CustomPolicies</code> to use <code>GetCustomPolicies</code>.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6597/files#diff-911674993eef6c43a04edc0e90ea1f2e6d595792eef840d23b2e3deb1c8265c5">+21/-7</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>apply_test.go</strong><dd><code>Update tests for policy application</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/policy/apply_test.go

<li>Added initialization of <code>policy.Service</code> in tests.<br> <li> Ensured <code>Apply</code> method is tested with <code>assert.NoError</code>.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6597/files#diff-5af7e299a6b0ce11e22f8aa4a01854b1151f4b54dccc68f0cd1cbedee5aed7c8">+29/-28</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>util_test.go</strong><dd><code>Add tests for MergeAllowedURLs function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/policy/util_test.go

- Added tests for `MergeAllowedURLs` function.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6597/files#diff-c750a1b8a01d19dacf02ba7512b8e2b987bf8147cf3345a4374504d9d5b3840e">+64/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Taskfile.yml</strong><dd><code>Update Taskfile with stress test task</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/policy/Taskfile.yml

<li>Added <code>stress</code> task for running stress tests.<br> <li> Updated <code>default</code> task to include <code>test</code>.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6597/files#diff-e0f19d4dd27acb397e19ccb080f3142a09f5978699da5843bfc71e7ffa4bb775">+16/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information