### PR TITLE
fix: fix slice init length

### DIFF
--- a/gateway/coprocess_helpers.go
+++ b/gateway/coprocess_helpers.go
@@ -14,7 +14,7 @@ func TykSessionState(session *coprocess.SessionState) *user.SessionState {
 	accessDefinitions := make(map[string]user.AccessDefinition, len(session.AccessRights))
 
 	for key, protoAccDef := range session.AccessRights {
-		allowedUrls := make([]user.AccessSpec, len(protoAccDef.AllowedUrls))
+		allowedUrls := make([]user.AccessSpec, 0, len(protoAccDef.AllowedUrls))
 		for _, protoAllowedURL := range protoAccDef.AllowedUrls {
 			allowedUrls = append(allowedUrls, user.AccessSpec{
 				URL:     protoAllowedURL.Url,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

The intention here should be to initialize a slice with a capacity of  len(protoAccDef.AllowedUrls)  rather than initializing the length of this slice.


## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
