### PR TITLE
POC: Add ability to output logs in stdout

### DIFF
--- a/gateway/server.go
+++ b/gateway/server.go
@@ -1201,7 +1201,7 @@ func (gw *Gateway) initSystem() error {
 
 	// Initialize the appropriate log formatter
 	if !gw.isRunningTests() && os.Getenv("TYK_LOGFORMAT") == "" && !*cli.DebugMode {
-		log.Formatter = logger.NewFormatter(gwConfig.LogFormat)
+		log.SetFormatter(logger.NewFormatter(gwConfig.LogFormat))
 		mainLog.Debugf("Set log format to %q", gwConfig.LogFormat)
 	}
 
@@ -1221,6 +1221,13 @@ func (gw *Gateway) initSystem() error {
 			mainLog.Fatalf("Invalid log level %q specified in config, must be error, warn, debug or info. ", level)
 		}
 		mainLog.Debugf("Set log level to %q", log.Level)
+	}
+
+	if !gw.isRunningTests() {
+		output := os.Getenv("TYK_LOGOUTPUT")
+		if output == "stdout" {
+			log.SetOutput(os.Stdout)
+		}
 	}
 
 	if gw.isRunningTests() && os.Getenv("TYK_LOGLEVEL") == "" {


### PR DESCRIPTION
This PR does:

1. use log.SetFormatter intead of the no-mutex version, safe api use
2. if TYK_LOGOUTPUT=stdout env is defined, the output goes to stdout

tested with:

```
# TYK_LOGOUTPUT=stdout ./tyk | head -n 1
time="Oct 02 18:32:06" level=info msg="Tyk API Gateway v5.5.0-dev" prefix=main
# git status .
On branch improvement/logging
```

Alternatively the same can be achieved with `2>&1`, but that's hard to inject into the container, especially with distroless where there isn't a shell available.

Alternative options:

- common to log the usual stuff into stdout, and log anything with error or above into stderr, [from me 3 year ago](https://github.com/go-bridget/colony/blob/master/internal/logger/logger.go).
- consider file logging, where logs get split into `error.log`, `debug.log`, `info.log`, warning, error...
- file logging but also consider log rotation a-la logrotate.d

My immediate other thought was to configure syslog:

```
// Enable Syslog log output
UseSyslog bool `json:"use_syslog"`
// Syslong transport to use. Values: tcp or udp.
SyslogTransport string `json:"syslog_transport"`
// Graylog server address
SyslogNetworkAddr string `json:"syslog_network_addr"`
```

Discarded this idea, as you'd actually have to have syslog in the distroless env. Syslog could be configured to log the output to file(s), but it seems as an unnecessary hop when you want to terminate the log data flow in the container.