### PR TITLE
Add support for application/soap+xml error handling

### DIFF
--- a/gateway/handler_error.go
+++ b/gateway/handler_error.go
@@ -98,6 +98,9 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 		contentType = strings.Split(contentType, ";")[0]
 
 		switch contentType {
+		case header.ApplicationSoapXML:
+			templateExtension = "xml"
+			contentType = header.ApplicationSoapXML
 		case header.ApplicationXML:
 			templateExtension = "xml"
 			contentType = header.ApplicationXML

--- a/header/header.go
+++ b/header/header.go
@@ -17,10 +17,11 @@ const (
 )
 
 const (
-	TykHookshot     = "Tyk-Hookshot"
-	ApplicationJSON = "application/json"
-	ApplicationXML  = "application/xml"
-	TextXML         = "text/xml"
+	TykHookshot     	= "Tyk-Hookshot"
+	ApplicationJSON 	= "application/json"
+	ApplicationXML  	= "application/xml"
+	ApplicationSoapXML  = "application/soap+xml"
+	TextXML         	= "text/xml"
 )
 
 const (

--- a/header/header.go
+++ b/header/header.go
@@ -20,7 +20,7 @@ const (
 	TykHookshot     	= "Tyk-Hookshot"
 	ApplicationJSON 	= "application/json"
 	ApplicationXML  	= "application/xml"
-	ApplicationSoapXML  = "application/soap+xml"
+	ApplicationSoapXML 	= "application/soap+xml"
 	TextXML         	= "text/xml"
 )
 


### PR DESCRIPTION
## Description
Currently, Tyk returns a JSON response when a request with Content-Type "application/soap+xml" incurs in an error. Added support to return XML instead.  

## Related Issue
https://github.com/TykTechnologies/tyk/issues/6602


## How This Has Been Tested
Not tested

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
- [x] I ensured that the documentation is up to date
