### PR TITLE
Merging to release-5.6: [TT-13088] Fixed godoc for path prefix and sufix configs (#6610)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -410,40 +410,40 @@ type HttpServerOptionsConfig struct {
 
 	// EnablePathPrefixMatching changes how the gateway matches incoming URL paths against routes (patterns) defined in the API definition.
 	// By default, the gateway uses wildcard matching. When EnablePathPrefixMatching is enabled, it switches to prefix matching. For example, a defined path such as `/json` will only match request URLs that begin with `/json`, rather than matching any URL containing `/json`.
-
+	//
 	// The gateway checks the request URL against several variations depending on whether path versioning is enabled:
 	// - Full path (listen path + version + endpoint): `/listen-path/v4/json`
 	// - Non-versioned full path (listen path + endpoint): `/listen-path/json`
 	// - Path without version (endpoint only): `/json`
-
+	//
 	// For patterns that start with `/`, the gateway prepends `^` before performing the check, ensuring a true prefix match.
 	// For patterns that start with `^`, the gateway will already perform prefix matching so EnablePathPrefixMatching will have no impact.
 	// This option allows for more specific and controlled routing of API requests, potentially reducing unintended matches. Note that you may need to adjust existing route definitions when enabling this option.
-
+	//
 	// Example:
-
+	//
 	// With wildcard matching, `/json` might match `/api/v1/data/json`.
 	// With prefix matching, `/json` would not match `/api/v1/data/json`, but would match `/json/data`.
-
+	//
 	// Combining EnablePathPrefixMatching with EnablePathSuffixMatching will result in exact URL matching, with `/json` being evaluated as `^/json$`.
 	EnablePathPrefixMatching bool `json:"enable_path_prefix_matching"`
 
 	// EnablePathSuffixMatching changes how the gateway matches incoming URL paths against routes (patterns) defined in the API definition.
 	// By default, the gateway uses wildcard matching. When EnablePathSuffixMatching is enabled, it switches to suffix matching. For example, a defined path such as `/json` will only match request URLs that end with `/json`, rather than matching any URL containing `/json`.
-
+	//
 	// The gateway checks the request URL against several variations depending on whether path versioning is enabled:
 	// - Full path (listen path + version + endpoint): `/listen-path/v4/json`
 	// - Non-versioned full path (listen path + endpoint): `/listen-path/json`
 	// - Path without version (endpoint only): `/json`
-
+	//
 	// For patterns that already end with `$`, the gateway will already perform suffix matching so EnablePathSuffixMatching will have no impact. For all other patterns, the gateway appends `$` before performing the check, ensuring a true suffix match.
 	// This option allows for more specific and controlled routing of API requests, potentially reducing unintended matches. Note that you may need to adjust existing route definitions when enabling this option.
-
+	//
 	// Example:
-
+	//
 	// With wildcard matching, `/json` might match `/api/v1/json/data`.
 	// With suffix matching, `/json` would not match `/api/v1/json/data`, but would match `/api/v1/json`.
-
+	//
 	// Combining EnablePathSuffixMatching with EnablePathPrefixMatching will result in exact URL matching, with `/json` being evaluated as `^/json$`.
 	EnablePathSuffixMatching bool `json:"enable_path_suffix_matching"`
 


### PR DESCRIPTION

<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-13088" title="TT-13088" target="_blank">TT-13088</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Trigger docs update for 5.6.0</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Code Review</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

[TT-13088] Fixed godoc for path prefix and sufix configs (#6610)

[TT-13088]: https://tyktech.atlassian.net/browse/TT-13088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ