### PR TITLE
[TT-12814] Make schema more flexible, don't enforce additionalProperties: false

### DIFF
--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -15,7 +15,6 @@
       "$ref": "#/definitions/X-Tyk-Middleware"
     }
   },
-  "additionalProperties": false,
   "required": [
     "info",
     "upstream",
@@ -24,7 +23,6 @@
   "definitions": {
     "X-Tyk-ServiceDiscovery": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -67,7 +65,6 @@
     },
     "X-Tyk-ServiceDiscoveryCache": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -83,7 +80,6 @@
     },
     "X-Tyk-DetailedActivityLogs": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -95,7 +91,6 @@
     },
     "X-Tyk-AuthSource": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -110,7 +105,6 @@
     },
     "X-Tyk-MutualTLS": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -131,7 +125,6 @@
     },
     "X-Tyk-DomainToCertificate": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "domain": {
           "$ref": "#/definitions/X-Tyk-DomainDef"
@@ -147,7 +140,6 @@
     },
     "X-Tyk-CertificatePinning": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -168,7 +160,6 @@
     },
     "X-Tyk-PinnedPublicKeys": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "domain": {
           "$ref": "#/definitions/X-Tyk-DomainDef"
@@ -185,7 +176,6 @@
     },
     "X-Tyk-ClientToPolicy": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "clientId": {
           "type": "string"
@@ -197,7 +187,6 @@
     },
     "X-Tyk-Provider": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "issuer": {
           "type": "string"
@@ -214,7 +203,6 @@
     },
     "X-Tyk-ScopeToPolicy": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "scope": {
           "type": "string"
@@ -226,7 +214,6 @@
     },
     "X-Tyk-Scopes": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "claimName": {
           "type": "string"
@@ -243,7 +230,6 @@
     },
     "X-Tyk-ClientCertificates": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -260,7 +246,6 @@
     },
     "X-Tyk-PluginConfig": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "driver": {
           "type": "string",
@@ -282,7 +267,6 @@
     },
     "X-Tyk-PluginConfigData": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -298,7 +282,6 @@
     },
     "X-Tyk-CustomPluginConfig": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "plugins": {
           "$ref": "#/definitions/X-Tyk-CustomPlugins"
@@ -315,7 +298,6 @@
       "minItems": 1
     },
     "X-Tyk-CustomPluginDefinition": {
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -340,7 +322,6 @@
     },
     "X-Tyk-IDExtractorConfig": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "headerName": {
           "type": "string"
@@ -361,7 +342,6 @@
     },
     "X-Tyk-IDExtractor": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -395,7 +375,6 @@
     },
     "X-Tyk-AuthenticationPlugin": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -420,7 +399,6 @@
     },
     "X-Tyk-PluginBundle": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -437,7 +415,6 @@
     },
     "X-Tyk-CORS": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -493,7 +470,6 @@
     },
     "X-Tyk-Cache": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -531,7 +507,6 @@
     },
     "X-Tyk-Global": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "pluginConfig": {
           "$ref": "#/definitions/X-Tyk-PluginConfig"
@@ -582,7 +557,6 @@
     },
     "X-Tyk-Allowance": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -597,7 +571,6 @@
     },
     "X-Tyk-TransformRequestMethod": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -613,7 +586,6 @@
     },
     "X-Tyk-TransformBody": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -652,7 +624,6 @@
     },
     "X-Tyk-TransformHeaders": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -680,7 +651,6 @@
     },
     "X-Tyk-CachePlugin": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -708,7 +678,6 @@
     },
     "X-Tyk-EnforceTimeout": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -725,7 +694,6 @@
     },
     "X-Tyk-ValidateRequest": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -740,7 +708,6 @@
     },
     "X-Tyk-MockResponse": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -785,7 +752,6 @@
     },
     "X-Tyk-RequestSizeLimit": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -802,7 +768,6 @@
     },
     "X-Tyk-VirtualEndpoint": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -833,7 +798,6 @@
     },
     "X-Tyk-URLRewrite": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -861,7 +825,6 @@
     },
     "X-Tyk-TrackEndpoint": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -873,7 +836,6 @@
     },
     "X-Tyk-URLRewriteTrigger": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "condition": {
           "enum": [
@@ -905,7 +867,6 @@
     },
     "X-Tyk-URLRewriteRuleForRequestBody": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "in": {
           "enum": [
@@ -929,7 +890,6 @@
     },
     "X-Tyk-URLRewriteRule": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "in": {
           "enum": [
@@ -958,7 +918,6 @@
     },
     "X-Tyk-EndpointPostPlugin": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -981,7 +940,6 @@
     },
     "X-Tyk-Internal": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -993,7 +951,6 @@
     },
     "X-Tyk-Operation": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "allow": {
           "$ref": "#/definitions/X-Tyk-Allowance"
@@ -1071,12 +1028,10 @@
         "\\S+": {
           "$ref": "#/definitions/X-Tyk-Operation"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "X-Tyk-Middleware": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "global": {
           "$ref": "#/definitions/X-Tyk-Global"
@@ -1088,7 +1043,6 @@
     },
     "X-Tyk-ListenPath": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "value": {
           "type": "string",
@@ -1104,7 +1058,6 @@
     },
     "X-Tyk-HMAC": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -1137,7 +1090,6 @@
     },
     "X-Tyk-OIDC": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -1172,7 +1124,6 @@
     },
     "X-Tyk-CustomPluginAuthentication": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -1196,7 +1147,6 @@
     },
     "X-Tyk-Authentication": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -1257,7 +1207,6 @@
     },
     "X-Tyk-Server": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "listenPath": {
           "$ref": "#/definitions/X-Tyk-ListenPath"
@@ -1302,7 +1251,6 @@
     },
     "X-Tyk-GatewayTags": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -1324,7 +1272,6 @@
     },
     "X-Tyk-Upstream": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "url": {
           "type": "string",
@@ -1360,7 +1307,6 @@
     },
     "X-Tyk-State": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "active": {
           "type": "boolean"
@@ -1375,7 +1321,6 @@
     },
     "X-Tyk-Versioning": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -1422,7 +1367,6 @@
     },
     "X-Tyk-VersionToID": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "name": {
           "type": "string",
@@ -1440,7 +1384,6 @@
     },
     "X-Tyk-Info": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "id": {
           "type": "string"
@@ -1472,7 +1415,6 @@
     },
     "X-Tyk-ExtractCredentialsFromBody": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -1490,7 +1432,6 @@
     },
     "X-Tyk-Notifications": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "sharedSecret": {
           "type": "string"
@@ -1502,7 +1443,6 @@
     },
     "X-Tyk-Signature": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -1533,7 +1473,6 @@
     },
     "X-Tyk-Token": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -1560,7 +1499,6 @@
     },
     "X-Tyk-JWT": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -1628,7 +1566,6 @@
     },
     "X-Tyk-Basic": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -1658,7 +1595,6 @@
     },
     "X-Tyk-OAuth": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -1698,7 +1634,6 @@
     },
     "X-Tyk-ExternalOAuth": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -1727,7 +1662,6 @@
     },
     "X-Tyk-OAuthProvider": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "jwt": {
           "$ref": "#/definitions/X-Tyk-JWTValidation"
@@ -1739,7 +1673,6 @@
     },
     "X-Tyk-JWTValidation": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -1771,7 +1704,6 @@
     },
     "X-Tyk-Introspection": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -1811,7 +1743,6 @@
     },
     "X-Tyk-CustomDomain": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -1835,7 +1766,6 @@
     },
     "X-Tyk-Header": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "name": {
           "type": "string"
@@ -1903,7 +1833,6 @@
     },
     "X-Tyk-DetailedTracing": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -1956,7 +1885,6 @@
     },
     "X-Tyk-Webhook-Without-ID": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean"


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-12814" title="TT-12814" target="_blank">TT-12814</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Make OAS JSON schema more flexible (do not enforce additionalProperties)</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

https://tyktech.atlassian.net/browse/TT-12814


___

### **PR Type**
Enhancement


___

### **Description**
- Removed `additionalProperties: false` from multiple object definitions in the JSON schema to enhance flexibility.
- This change allows additional properties in the schema, making it more compatible and less strict.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>x-tyk-api-gateway.json</strong><dd><code>Relax schema strictness by removing `additionalProperties: false`</code></dd></summary>
<hr>

apidef/oas/schema/x-tyk-api-gateway.json

<li>Removed <code>additionalProperties: false</code> from multiple object definitions.<br> <li> Enhanced flexibility of the JSON schema by allowing additional <br>properties.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6640/files#diff-78828969c0c04cc1a776dfc93a8bad3c499a8c83e6169f83e96d090bed3e7dd0">+1/-73</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information