### PR TITLE
[TT-12702] revert wrappedServeHTTP to use recordDetail

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -334,7 +334,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download --repo github.com/tyklabs/tyk-pro --archive tar.gz -O env.tgz
+          gh release download --repo github.com/TykTechnologies/tyk-pro --archive tar.gz -O env.tgz
           mkdir auto && tar --strip-components=1 -C auto -xzvf env.tgz
       - name: env up
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ tyk_linux_*
 *.test
 
 main
+
+/coprocess/*.pb.go-e

--- a/gateway/handler_success.go
+++ b/gateway/handler_success.go
@@ -343,19 +343,16 @@ func recordDetail(r *http.Request, spec *APISpec) bool {
 		}
 	}
 
-	// Are we even checking?
-	if !spec.GlobalConfig.EnforceOrgDataDetailLogging {
-		return spec.GraphQL.Enabled || spec.GlobalConfig.AnalyticsConfig.EnableDetailedRecording
+	// decide based on org session.
+	if spec.GlobalConfig.EnforceOrgDataDetailLogging {
+		session, ok := r.Context().Value(ctx.OrgSessionContext).(*user.SessionState)
+		if ok && session != nil {
+			return session.EnableDetailedRecording || session.EnableDetailRecording // nolint:staticcheck // Deprecated DetailRecording
+		}
 	}
 
-	// We are, so get session data
-	session, ok := r.Context().Value(ctx.OrgSessionContext).(*user.SessionState)
-	if ok && session != nil {
-		return session.EnableDetailedRecording || session.EnableDetailRecording // nolint:staticcheck // Deprecated DetailRecording
-	}
-
-	// no session found, use global config
-	return spec.GlobalConfig.AnalyticsConfig.EnableDetailedRecording
+	// no org session found, use global config
+	return spec.GraphQL.Enabled || spec.GlobalConfig.AnalyticsConfig.EnableDetailedRecording
 }
 
 // ServeHTTP will store the request details in the analytics store if necessary and proxy the request to it's

--- a/gateway/handler_success.go
+++ b/gateway/handler_success.go
@@ -345,7 +345,7 @@ func recordDetail(r *http.Request, spec *APISpec) bool {
 
 	// Are we even checking?
 	if !spec.GlobalConfig.EnforceOrgDataDetailLogging {
-		return spec.GlobalConfig.AnalyticsConfig.EnableDetailedRecording
+		return spec.GraphQL.Enabled || spec.GlobalConfig.AnalyticsConfig.EnableDetailedRecording
 	}
 
 	// We are, so get session data

--- a/gateway/handler_success_test.go
+++ b/gateway/handler_success_test.go
@@ -102,6 +102,13 @@ func TestRecordDetail(t *testing.T) {
 			},
 			expect: true,
 		},
+		{
+			title: "graphql request",
+			spec: testAPISpec(func(spec *APISpec) {
+				spec.GraphQL.Enabled = true
+			}),
+			expect: true,
+		},
 	}
 
 	for _, tc := range testcases {

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -515,7 +515,7 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) Prox
 	startTime := time.Now()
 	p.logger.WithField("ts", startTime.UnixNano()).Debug("Started")
 
-	resp := p.WrappedServeHTTP(rw, req, true)
+	resp := p.WrappedServeHTTP(rw, req, recordDetail(req, p.TykAPISpec))
 
 	finishTime := time.Since(startTime)
 	p.logger.WithField("ns", finishTime.Nanoseconds()).Debug("Finished")

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -2026,7 +2026,7 @@ func TestQuotaResponseHeaders(t *testing.T) {
 }
 
 func BenchmarkLargeResponsePayload(b *testing.B) {
-	ts := StartTest(func(globalConf *config.Config) {})
+	ts := StartTest(func(_ *config.Config) {})
 	b.Cleanup(func() {
 		ts.Close()
 	})
@@ -2035,13 +2035,13 @@ func BenchmarkLargeResponsePayload(b *testing.B) {
 	payloadSize := 500 * 1024 * 1024 // 500 MB in bytes
 	largePayload := bytes.Repeat([]byte("x"), payloadSize)
 
-	largePayloadHandler := func(w http.ResponseWriter, r *http.Request) {
+	largePayloadHandler := func(w http.ResponseWriter, _ *http.Request) {
 
 		// Write the payload to the response writer
 		w.Header().Set("Content-Type", "application/octet-stream")
 		w.Header().Set("Content-Length", strconv.Itoa(payloadSize))
 		w.WriteHeader(http.StatusOK)
-		w.Write(largePayload)
+		_, _ = w.Write(largePayload)
 	}
 
 	// Create a test server with the largePayloadHandler


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-12702" title="TT-12702" target="_blank">TT-12702</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Regression in Gateway handling larger payloads (speed and memory usage)</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20customer_bug%20ORDER%20BY%20created%20DESC" title="customer_bug">customer_bug</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20jira_escalated%20ORDER%20BY%20created%20DESC" title="jira_escalated">jira_escalated</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

This PR reverts https://github.com/TykTechnologies/tyk/pull/5716/files#diff-e6e07722257f7e41691e471185ad6d84fd56dc9e5459526ea32e9a5e8fa1a01bL518 - causing high memory consumption when handling large response payloads even when detailed recording is not enabled.

## Related Issue
https://tyktech.atlassian.net/browse/TT-12702

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

### Benchmarks
#### Master
```
goos: darwin
goarch: arm64
pkg: github.com/TykTechnologies/tyk/gateway
BenchmarkLargeResponsePayload-12               1        1733155792 ns/op        6423694584 B/op   170266 allocs/op
BenchmarkLargeResponsePayload-12               1        1045400334 ns/op        6423182768 B/op   162467 allocs/op
BenchmarkLargeResponsePayload-12               2        1056169500 ns/op        6150103228 B/op    81801 allocs/op
BenchmarkLargeResponsePayload-12               2         582477250 ns/op        6150050508 B/op    81405 allocs/op
BenchmarkLargeResponsePayload-12               2         544049688 ns/op        6150056996 B/op    81414 allocs/op
BenchmarkLargeResponsePayload-12               3         406709014 ns/op        6059011672 B/op    54435 allocs/op
BenchmarkLargeResponsePayload-12               3         408792639 ns/op        6059018274 B/op    54438 allocs/op
BenchmarkLargeResponsePayload-12               3         409801597 ns/op        6059023178 B/op    54441 allocs/op
BenchmarkLargeResponsePayload-12               3         432873930 ns/op        6059030749 B/op    54524 allocs/op
BenchmarkLargeResponsePayload-12               3         419910931 ns/op        6059010736 B/op    54438 allocs/op
BenchmarkLargeResponsePayload-12               3         441840542 ns/op        6059018002 B/op    54440 allocs/op
BenchmarkLargeResponsePayload-12               3         404177667 ns/op        6059027448 B/op    54449 allocs/op
BenchmarkLargeResponsePayload-12               3         408969153 ns/op        6059020826 B/op    54435 allocs/op
BenchmarkLargeResponsePayload-12               3         442027917 ns/op        6059023066 B/op    54480 allocs/op
BenchmarkLargeResponsePayload-12               3         425106861 ns/op        6059018101 B/op    54432 allocs/op
BenchmarkLargeResponsePayload-12               3         532385903 ns/op        6059022578 B/op    54506 allocs/op
BenchmarkLargeResponsePayload-12               3         426969986 ns/op        6059023218 B/op    54440 allocs/op
BenchmarkLargeResponsePayload-12               3         413833320 ns/op        6059027762 B/op    54450 allocs/op
BenchmarkLargeResponsePayload-12               3         451929514 ns/op        6237968360 B/op    54447 allocs/op
BenchmarkLargeResponsePayload-12               3         397716597 ns/op        6059025890 B/op    54445 allocs/op
PASS
ok      github.com/TykTechnologies/tyk/gateway  49.175s
```

#### PR branch
```
goos: darwin
goarch: arm64
pkg: github.com/TykTechnologies/tyk/gateway
BenchmarkLargeResponsePayload-12               1        1356068083 ns/op        4557237568 B/op   169981 allocs/op
BenchmarkLargeResponsePayload-12               2         742401458 ns/op        4283642056 B/op    81542 allocs/op
BenchmarkLargeResponsePayload-12               4         317117062 ns/op        4147070728 B/op    40949 allocs/op
BenchmarkLargeResponsePayload-12               4         298472167 ns/op        4147074542 B/op    40935 allocs/op
BenchmarkLargeResponsePayload-12               4         294437177 ns/op        4147072386 B/op    40935 allocs/op
BenchmarkLargeResponsePayload-12               4         309100688 ns/op        4147068268 B/op    40904 allocs/op
BenchmarkLargeResponsePayload-12               4         297184354 ns/op        4147070226 B/op    40925 allocs/op
BenchmarkLargeResponsePayload-12               3         486690125 ns/op        4192594322 B/op    54475 allocs/op
BenchmarkLargeResponsePayload-12               4         294243364 ns/op        4147069956 B/op    40900 allocs/op
BenchmarkLargeResponsePayload-12               4         297884250 ns/op        4147069348 B/op    40902 allocs/op
BenchmarkLargeResponsePayload-12               4         278709729 ns/op        4147068876 B/op    40887 allocs/op
BenchmarkLargeResponsePayload-12               4         292365864 ns/op        4147069428 B/op    40895 allocs/op
BenchmarkLargeResponsePayload-12               4         313283802 ns/op        4147065954 B/op    40902 allocs/op
BenchmarkLargeResponsePayload-12               4         314389510 ns/op        4147065562 B/op    40907 allocs/op
BenchmarkLargeResponsePayload-12               4         302698010 ns/op        4147069650 B/op    40905 allocs/op
BenchmarkLargeResponsePayload-12               4         303036000 ns/op        4147068274 B/op    40929 allocs/op
BenchmarkLargeResponsePayload-12               4         298318542 ns/op        4147065250 B/op    40897 allocs/op
BenchmarkLargeResponsePayload-12               3         358369500 ns/op        4192571469 B/op    54383 allocs/op
BenchmarkLargeResponsePayload-12               3         400718208 ns/op        4192586336 B/op    54380 allocs/op
BenchmarkLargeResponsePayload-12               3         348493847 ns/op        4192581192 B/op    54387 allocs/op
PASS
ok      github.com/TykTechnologies/tyk/gateway  55.063s
```

#### Benchstat
```
benchstat master.txt pr.txt              
goos: darwin
goarch: arm64
pkg: github.com/TykTechnologies/tyk/gateway
                        │  master.txt  │                pr.txt                │
                        │    sec/op    │    sec/op     vs base                │
LargeResponsePayload-12   429.9m ± 24%   306.1m ± 14%  -28.81% (p=0.000 n=20)

                        │  master.txt  │                pr.txt                │
                        │     B/op     │     B/op      vs base                │
LargeResponsePayload-12   5.643Gi ± 2%   3.862Gi ± 1%  -31.56% (p=0.000 n=20)

                        │ master.txt  │                pr.txt                │
                        │  allocs/op  │  allocs/op    vs base                │
LargeResponsePayload-12   54.45k ± 0%   40.93k ± 33%  -24.83% (p=0.000 n=20)
```

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Bug fix


___

### **Description**
- Reverted the `WrappedServeHTTP` function call to use the `recordDetail` function, addressing a regression issue in handling larger payloads.
- This change is aimed at improving speed and memory usage in the Gateway.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reverse_proxy.go</strong><dd><code>Revert WrappedServeHTTP to use recordDetail function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/reverse_proxy.go

<li>Reverted the <code>WrappedServeHTTP</code> function call to use <code>recordDetail</code>.<br> <li> Modified the argument passed to <code>WrappedServeHTTP</code> for improved request <br>handling.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6654/files#diff-e6e07722257f7e41691e471185ad6d84fd56dc9e5459526ea32e9a5e8fa1a01b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information