### PR TITLE
[TT-13008]: modified default streams logger

### DIFF
--- a/ee/middleware/streams/manager.go
+++ b/ee/middleware/streams/manager.go
@@ -85,6 +85,16 @@ func (sm *Manager) createStream(streamID string, config map[string]interface{}) 
 	streamFullID := fmt.Sprintf("%s_%s", sm.mw.Spec.APIID, streamID)
 	sm.mw.Logger().Debugf("Creating stream: %s", streamFullID)
 
+	// add logger to config
+	config["logger"] = map[string]interface{}{
+		"level":         "INFO",
+		"format":        "json",
+		"add_timestamp": true,
+		"static_fields": map[string]interface{}{
+			"stream": streamID,
+		},
+	}
+
 	stream := NewStream(sm.mw.allowedUnsafe)
 	err := stream.Start(config, &handleFuncAdapter{
 		mw:       sm.mw,


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-13008" title="TT-13008" target="_blank">TT-13008</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Backoff strategy for reconnection when broker is down</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description
Added a logger to created streams to change the format of logging used by benthos
[TT-13008](https://tyktech.atlassian.net/browse/TT-13008)
<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


[TT-13008]: https://tyktech.atlassian.net/browse/TT-13008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
enhancement


___

### **Description**
- Enhanced the stream creation process by adding a logger configuration.
- Configured the logger to use 'INFO' level and 'json' format for better logging consistency.
- Included static fields in the logger configuration to provide context, such as the stream ID.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manager.go</strong><dd><code>Add logger configuration to stream creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ee/middleware/streams/manager.go

<li>Added a logger configuration to the stream creation process.<br> <li> Configured logger with level 'INFO', format 'json', and timestamp <br>addition.<br> <li> Added static fields to logger configuration, including the stream ID.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6665/files#diff-3e372b3346d8d296e6953152c89202a634d7654f10549676af9aea8628e13dfb">+10/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information