### PR TITLE
Merging to release-5.0.15: [TT-13110] remove trimpath from 5-lts build (#6546)

### DIFF
--- a/ci/goreleaser/goreleaser.yml
+++ b/ci/goreleaser/goreleaser.yml
@@ -9,7 +9,6 @@ builds:
   - id: std
     flags:
       - -tags=ignore
-      - -trimpath
       - -tags=goplugin
     ldflags:
       - -X github.com/TykTechnologies/tyk/internal/build.Version={{.Version}}
@@ -24,7 +23,6 @@ builds:
   - id: fips
     flags:
       - -tags=ignore
-      - -trimpath
       - -tags=goplugin
       - -tags=fips,boringcrypto
     env:
@@ -42,7 +40,6 @@ builds:
   - id: std-arm64
     flags:
       - -tags=ignore
-      - -trimpath
       - -tags=goplugin
     ldflags:
       - -X github.com/TykTechnologies/tyk/internal/build.Version={{.Version}}


### PR DESCRIPTION
[TT-13110] remove trimpath from 5-lts build (#6546)

<!-- Provide a general summary of your changes in the Title above -->

## Description
Remove `-trimpath` build flag from goreleaser build so that plugins
built with tyk plugin compiler loads.


## Related Issue
https://tyktech.atlassian.net/browse/TT-13110

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why

[TT-13110]: https://tyktech.atlassian.net/browse/TT-13110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ