### PR TITLE
[TT-13271] Make enabled and allowedAuthorizeTypes required fields

### DIFF
--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -2122,7 +2122,11 @@
             "password"
           ]
         }
-      }
+      },
+      "required": [
+        "enabled",
+        "allowedAuthorizeTypes"
+      ]
     }
   }
 }


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added "enabled" and "allowedAuthorizeTypes" as required fields in the API Gateway schema to ensure these fields are always provided.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>x-tyk-api-gateway.json</strong><dd><code>Add required fields to API Gateway schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/schema/x-tyk-api-gateway.json

<li>Added "enabled" to the list of required fields.<br> <li> Added "allowedAuthorizeTypes" to the list of required fields.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6673/files#diff-78828969c0c04cc1a776dfc93a8bad3c499a8c83e6169f83e96d090bed3e7dd0">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information