### PR TITLE
Makes /health endpoint return 500 if status is not 'pass'

### DIFF
--- a/gateway/health_check.go
+++ b/gateway/health_check.go
@@ -215,6 +215,10 @@ func (gw *Gateway) liveCheckHandler(w http.ResponseWriter, r *http.Request) {
 		addMascotHeaders(w)
 	}
 
-	w.WriteHeader(http.StatusOK)
+	if status == model.Pass {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
 	json.NewEncoder(w).Encode(res)
 }


### PR DESCRIPTION
## Description
Makes /health endpoint return 500 if status is not 'pass'

## Related Issue
https://github.com/TykTechnologies/tyk/issues/6674

## Motivation and Context
As issue

## How This Has Been Tested


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
- [x] I ensured that the documentation is up to date
