### PR TITLE
[TT-13185] upstream oauth allowed_authorize_types not being filled on API creation

### DIFF
--- a/apidef/oas/oas_test.go
+++ b/apidef/oas/oas_test.go
@@ -312,7 +312,6 @@ func TestOAS_ExtractTo_ResetAPIDefinition(t *testing.T) {
 		"APIDefinition.AnalyticsPlugin.Enabled",
 		"APIDefinition.AnalyticsPlugin.PluginPath",
 		"APIDefinition.AnalyticsPlugin.FuncName",
-		"APIDefinition.UpstreamAuth.OAuth.AllowedAuthorizeTypes[0]",
 		"APIDefinition.UpstreamAuth.OAuth.ClientCredentials.Enabled",
 		"APIDefinition.UpstreamAuth.OAuth.ClientCredentials.ExtraMetadata[0]",
 		"APIDefinition.UpstreamAuth.OAuth.PasswordAuthentication.Header.Enabled",

--- a/apidef/oas/upstream.go
+++ b/apidef/oas/upstream.go
@@ -732,6 +732,7 @@ func (p *PasswordAuthentication) Fill(api apidef.PasswordAuthentication) {
 
 func (u *UpstreamOAuth) Fill(api apidef.UpstreamOAuth) {
 	u.Enabled = api.Enabled
+	u.AllowedAuthorizeTypes = api.AllowedAuthorizeTypes
 
 	if u.ClientCredentials == nil {
 		u.ClientCredentials = &ClientCredentials{}
@@ -774,7 +775,7 @@ func (p *PasswordAuthentication) ExtractTo(api *apidef.PasswordAuthentication) {
 
 func (u *UpstreamOAuth) ExtractTo(api *apidef.UpstreamOAuth) {
 	api.Enabled = u.Enabled
-
+	api.AllowedAuthorizeTypes = u.AllowedAuthorizeTypes
 	if u.ClientCredentials == nil {
 		u.ClientCredentials = &ClientCredentials{}
 		defer func() {

--- a/gateway/mw_oauth2_auth.go
+++ b/gateway/mw_oauth2_auth.go
@@ -168,6 +168,8 @@ func getOAuthHeaderProvider(oauthConfig apidef.UpstreamOAuth) (OAuthHeaderProvid
 	}
 
 	switch {
+	case len(oauthConfig.AllowedAuthorizeTypes) == 0:
+		return nil, fmt.Errorf("no OAuth configuration selected")
 	case len(oauthConfig.AllowedAuthorizeTypes) > 1:
 		return nil, fmt.Errorf("both client credentials and password authentication are provided")
 	case oauthConfig.AllowedAuthorizeTypes[0] == ClientCredentialsAuthorizeType:


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-13185" title="TT-13185" target="_blank">TT-13185</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Implement OAuth 2.0 Password Flow for API Gateway Authentication with Upstream Server</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>Ready for Testing</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20QA_Fail%20ORDER%20BY%20created%20DESC" title="QA_Fail">QA_Fail</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

Fixed bug with allowed authorize types not being filled via OAS API creation.

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed a bug where `AllowedAuthorizeTypes` was not being filled in the `UpstreamOAuth` struct during API creation.
- Updated the `Fill` and `ExtractTo` methods in `UpstreamOAuth` to include the `AllowedAuthorizeTypes` field.
- Added error handling in `getOAuthHeaderProvider` to manage cases where `AllowedAuthorizeTypes` is empty.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>upstream.go</strong><dd><code>Fix missing AllowedAuthorizeTypes in UpstreamOAuth methods</code></dd></summary>
<hr>

apidef/oas/upstream.go

<li>Added <code>AllowedAuthorizeTypes</code> field to <code>Fill</code> method in <code>UpstreamOAuth</code>.<br> <li> Added <code>AllowedAuthorizeTypes</code> field to <code>ExtractTo</code> method in <br><code>UpstreamOAuth</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6676/files#diff-7b0941c7f37fe5a2a23047e0822a65519ca11c371660f36555b59a60f000e3f4">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mw_oauth2_auth.go</strong><dd><code>Add error handling for empty AllowedAuthorizeTypes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_oauth2_auth.go

<li>Added error handling for empty <code>AllowedAuthorizeTypes</code> in <br><code>getOAuthHeaderProvider</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6676/files#diff-a90347c3ad28f06a7bd1c5554ce63448774cb486cf4e9961af2323423ce8209d">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information