### PR TITLE
improve error handling of streams in non-ee version (TT-13269)

### DIFF
--- a/ee/errors.go
+++ b/ee/errors.go
@@ -1,0 +1,9 @@
+package ee
+
+import (
+	"errors"
+)
+
+var (
+	ErrActionNotAllowed = errors.New("action not allowed")
+)

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -19,6 +19,7 @@ import (
 	texttemplate "text/template"
 	"time"
 
+	"github.com/TykTechnologies/tyk/ee/middleware/streams"
 	"github.com/TykTechnologies/tyk/storage/kv"
 
 	"github.com/getkin/kin-openapi/routers"
@@ -34,7 +35,7 @@ import (
 
 	"github.com/cenk/backoff"
 
-	sprig "github.com/Masterminds/sprig/v3"
+	"github.com/Masterminds/sprig/v3"
 
 	"github.com/sirupsen/logrus"
 
@@ -312,6 +313,15 @@ func (s *APISpec) validateTCP() error {
 func (s *APISpec) validateHTTP() error {
 	// NOOP
 	return nil
+}
+
+func (s *APISpec) isStreamingAPI() bool {
+	if s.OAS.T.Extensions == nil {
+		return false
+	}
+
+	_, ok := s.OAS.T.Extensions[streams.ExtensionTykStreaming]
+	return ok
 }
 
 // APIDefinitionLoader will load an Api definition from a storage

--- a/gateway/mw_streaming.go
+++ b/gateway/mw_streaming.go
@@ -5,6 +5,12 @@ package gateway
 
 import (
 	"net/http"
+
+	"github.com/TykTechnologies/tyk/ee"
+)
+
+const (
+	MessageStreamingOnlySupportedInEE = "streaming is supported only in Tyk Enterprise Edition"
 )
 
 func getStreamingMiddleware(base *BaseMiddleware) TykMiddleware {
@@ -16,14 +22,17 @@ type dummyStreamingMiddleware struct {
 }
 
 func (d *dummyStreamingMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
-	return nil, http.StatusOK
+	failHttpCode := http.StatusForbidden
+	d.Logger().WithField("status_code", failHttpCode).Errorf("Error: %s", MessageStreamingOnlySupportedInEE)
+	return ee.ErrActionNotAllowed, failHttpCode
 }
 
 func (d *dummyStreamingMiddleware) EnabledForSpec() bool {
 	streamingConfig := d.Gw.GetConfig().Streaming
 
-	if streamingConfig.Enabled {
-		d.Logger().Error("Error: Streaming is supported only in Tyk Enterprise Edition")
+	if streamingConfig.Enabled && d.Spec.isStreamingAPI() {
+		d.Logger().Warnf("Warning: %s", MessageStreamingOnlySupportedInEE)
+		return true
 	}
 
 	return false


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-13269" title="TT-13269" target="_blank">TT-13269</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>[GW EE] Implement conditional compilation for streams in GW EE</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

This PR improves the error handling of streams API in Tyk Non-EE version.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Introduced a new error variable `ErrActionNotAllowed` for handling restricted actions.
- Added a method `isStreamingAPI` to determine if an API spec supports streaming.
- Enhanced the `dummyStreamingMiddleware` to log errors and return appropriate HTTP status codes when streaming is not supported.
- Added tests for the `isStreamingAPI` method to ensure correct functionality.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>errors.go</strong><dd><code>Introduce new error variable for action restrictions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ee/errors.go

- Added a new error variable `ErrActionNotAllowed`.



</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6691/files#diff-822f4595f51c8f7bb5132cf8efb90a3941203fe34129309c21ef8d0f2eb57e3b">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>api_definition.go</strong><dd><code>Add method to check streaming API support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_definition.go

<li>Added a new method <code>isStreamingAPI</code> to check for streaming API <br>extensions.<br> <li> Imported <code>streams</code> package for streaming API support.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6691/files#diff-0cf80174bbafb36f6d4f4308ebbd971b2833b76a936bad568220aa1a4ba0ee8b">+11/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api_definition_test.go</strong><dd><code>Add tests for streaming API detection method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_definition_test.go

<li>Added tests for the new <code>isStreamingAPI</code> method.<br> <li> Included <code>streams</code> package in imports for testing.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6691/files#diff-2394daab6fdc5f8dc234699c80c0548947ee3d68d2e33858258d73a8b5eb6f44">+51/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mw_streaming.go</strong><dd><code>Improve error handling and logging for streaming middleware</code></dd></summary>
<hr>

gateway/mw_streaming.go

<li>Enhanced error handling in <code>dummyStreamingMiddleware</code>.<br> <li> Added logging for unsupported streaming actions.<br> <li> Introduced constant message for unsupported streaming.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6691/files#diff-6f565750150d990575c808f1ca8f38483160dc6edf05f1534cd0bedb27c2e6c8">+12/-3</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information