### PR TITLE
[TT-13422] Do not allow empty string in upstream auth configuration strings

### DIFF
--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -96,7 +96,7 @@
           "type": "boolean"
         },
         "name": {
-          "type": "string"
+          "$ref": "#/definitions/X-Tyk-NonEmptyString"
         }
       },
       "required": [
@@ -2026,10 +2026,10 @@
           "$ref": "#/definitions/X-Tyk-AuthSource"
         },
         "username": {
-          "type": "string"
+          "$ref": "#/definitions/X-Tyk-NonEmptyString"
         },
         "password": {
-          "type": "string"
+          "$ref": "#/definitions/X-Tyk-NonEmptyString"
         }
       },
       "required": [
@@ -2062,13 +2062,13 @@
           "type": "object",
           "properties": {
             "clientId": {
-              "type": "string"
+              "$ref": "#/definitions/X-Tyk-NonEmptyString"
             },
             "clientSecret": {
-              "type": "string"
+              "$ref": "#/definitions/X-Tyk-NonEmptyString"
             },
             "tokenUrl": {
-              "type": "string"
+              "$ref": "#/definitions/X-Tyk-NonEmptyString"
             },
             "scopes": {
               "type": [
@@ -2096,13 +2096,13 @@
           "type": "object",
           "properties": {
             "clientId": {
-              "type": "string"
+              "$ref": "#/definitions/X-Tyk-NonEmptyString"
             },
             "clientSecret": {
-              "type": "string"
+              "$ref": "#/definitions/X-Tyk-NonEmptyString"
             },
             "tokenUrl": {
-              "type": "string"
+              "$ref": "#/definitions/X-Tyk-NonEmptyString"
             },
             "scopes": {
               "type": [
@@ -2111,10 +2111,10 @@
               ]
             },
             "username": {
-              "type": "string"
+              "$ref": "#/definitions/X-Tyk-NonEmptyString"
             },
             "password": {
-              "type": "string"
+              "$ref": "#/definitions/X-Tyk-NonEmptyString"
             },
             "header": {
               "$ref": "#/definitions/X-Tyk-AuthSource"
@@ -2139,7 +2139,10 @@
         "enabled",
         "allowedAuthorizeTypes"
       ]
+    },
+    "X-Tyk-NonEmptyString": {
+      "type": "string",
+      "pattern": "\\S+"
     }
-    
   }
 }

--- a/apidef/oas/upstream.go
+++ b/apidef/oas/upstream.go
@@ -694,9 +694,6 @@ type ClientCredentials struct {
 	TokenURL string `bson:"tokenUrl" json:"tokenUrl"`
 	// Scopes specifies optional requested permissions.
 	Scopes []string `bson:"scopes,omitempty" json:"scopes,omitempty"`
-	// HeaderName is the custom header name to be used for OAuth client credential flow authentication.
-	// Defaults to `Authorization`.
-	HeaderName string `bson:"headerName" json:"headerName"`
 	// ExtraMetadata holds the keys that we want to extract from the token and pass to the upstream.
 	ExtraMetadata []string `bson:"extraMetadata" json:"extraMetadata,omitempty"`
 }


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-13422" title="TT-13422" target="_blank">TT-13422</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Add validation rules on backend</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Sub-task" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />
        Sub-task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Test</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20QA_Fail%20ORDER%20BY%20created%20DESC" title="QA_Fail">QA_Fail</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

This PR updates OAS schema to not allow empty string in string data type configurations. 
It also removes unused `headerName` field from upstream OAuth client credentials.

## Related Issue
https://tyktech.atlassian.net/browse/TT-13422

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
enhancement, bug fix


___

### **Description**
- Removed the unused `HeaderName` field from the `ClientCredentials` struct in `upstream.go`.
- Updated the OpenAPI Specification (OAS) schema to enforce non-empty strings by introducing a new definition `X-Tyk-NonEmptyString`.
- Applied `X-Tyk-NonEmptyString` to relevant fields in the schema to prevent empty string configurations.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>upstream.go</strong><dd><code>Remove unused HeaderName field from ClientCredentials struct</code></dd></summary>
<hr>

apidef/oas/upstream.go

<li>Removed the unused <code>HeaderName</code> field from the <code>ClientCredentials</code> struct.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6699/files#diff-7b0941c7f37fe5a2a23047e0822a65519ca11c371660f36555b59a60f000e3f4">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>x-tyk-api-gateway.json</strong><dd><code>Enforce non-empty strings in OAS schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/schema/x-tyk-api-gateway.json

<li>Updated schema to use <code>X-Tyk-NonEmptyString</code> for string fields.<br> <li> Added a new definition <code>X-Tyk-NonEmptyString</code> to enforce non-empty <br>strings.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6699/files#diff-78828969c0c04cc1a776dfc93a8bad3c499a8c83e6169f83e96d090bed3e7dd0">+15/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information