### PR TITLE
Merging to release-5.7: Revert "[TT-13422] Do not allow empty string in upstream auth configuration strings" (#6702)

### DIFF
--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -96,7 +96,7 @@
           "type": "boolean"
         },
         "name": {
-          "$ref": "#/definitions/X-Tyk-NonEmptyString"
+          "type": "string"
         }
       },
       "required": [
@@ -2023,7 +2023,7 @@
           "type": "boolean"
         },
         "header": {
-          "$ref": "#/definitions/X-Tyk-AuthSource"
+          "$ref": "#/definitions/X-Tyk-UpstreamAuthSource"
         },
         "username": {
           "$ref": "#/definitions/X-Tyk-NonEmptyString"
@@ -2077,7 +2077,7 @@
               ]
             },
             "header": {
-              "$ref": "#/definitions/X-Tyk-AuthSource"
+              "$ref": "#/definitions/X-Tyk-UpstreamAuthSource"
             },
             "extraMetadata": {
               "type": [
@@ -2117,7 +2117,7 @@
               "$ref": "#/definitions/X-Tyk-NonEmptyString"
             },
             "header": {
-              "$ref": "#/definitions/X-Tyk-AuthSource"
+              "$ref": "#/definitions/X-Tyk-UpstreamAuthSource"
             },
             "extraMetadata": {
               "type": [
@@ -2143,6 +2143,17 @@
     "X-Tyk-NonEmptyString": {
       "type": "string",
       "pattern": "\\S+"
+    },
+    "X-Tyk-UpstreamAuthSource": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
### **User description**
Revert "[TT-13422] Do not allow empty string in upstream auth configuration strings" (#6702)

Reverts TykTechnologies/tyk#6699
temporary revert with common change for AuthSource

[TT-13422]: https://tyktech.atlassian.net/browse/TT-13422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
enhancement, bug fix


___

### **Description**
- Reverted the enforcement of non-empty strings for certain fields in the OpenAPI Specification (OAS) schema.
- Introduced a new definition `X-Tyk-UpstreamAuthSource` to replace `X-Tyk-AuthSource` in specific schema fields.
- Updated schema references to use `X-Tyk-UpstreamAuthSource` instead of `X-Tyk-AuthSource`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>x-tyk-api-gateway.json</strong><dd><code>Revert non-empty string enforcement and update auth source references</code></dd></summary>
<hr>

apidef/oas/schema/x-tyk-api-gateway.json

<li>Reverted the use of <code>X-Tyk-NonEmptyString</code> for certain fields.<br> <li> Introduced a new definition <code>X-Tyk-UpstreamAuthSource</code>.<br> <li> Updated references from <code>X-Tyk-AuthSource</code> to <code>X-Tyk-UpstreamAuthSource</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6703/files#diff-78828969c0c04cc1a776dfc93a8bad3c499a8c83e6169f83e96d090bed3e7dd0">+15/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information