### PR TITLE
Merging to release-5.3: [TT-13439] update response content-length when response body is modified by coprocess response hook (#6732)

### DIFF
--- a/coprocess/grpc/coprocess_grpc_test.go
+++ b/coprocess/grpc/coprocess_grpc_test.go
@@ -11,9 +11,12 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/TykTechnologies/tyk/header"
 
 	"github.com/stretchr/testify/assert"
 
@@ -567,6 +570,9 @@ func TestGRPCDispatch(t *testing.T) {
 			Code:      http.StatusOK,
 			Headers:   headers,
 			BodyMatch: "newbody",
+			HeadersMatch: map[string]string{
+				header.ContentLength: strconv.Itoa(len("newbody")),
+			},
 		})
 	})
 

--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -598,6 +598,12 @@ func (h *CustomMiddlewareResponseHook) HandleResponse(rw http.ResponseWriter, re
 	bodyBuf := bytes.NewBuffer(retObject.Response.RawBody)
 	res.Body = ioutil.NopCloser(bodyBuf)
 
+	//set response body length with the size of response body returned from the hook
+	//so that it is updated accordingly in the response object
+	responseBodyLen := len(retObject.Response.RawBody)
+	res.ContentLength = int64(responseBodyLen)
+	res.Header.Set("Content-Length", fmt.Sprintf("%d", responseBodyLen))
+
 	res.StatusCode = int(retObject.Response.StatusCode)
 	return nil
 }


### PR DESCRIPTION
### **User description**
[TT-13439] update response content-length when response body is modified by coprocess response hook (#6732)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-13439"
title="TT-13439" target="_blank">TT-13439</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
<td>Analytics data is corrupted when a response plugin changes the
response</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20'24Bugsmash%20ORDER%20BY%20created%20DESC"
title="'24Bugsmash">'24Bugsmash</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20customer_bug%20ORDER%20BY%20created%20DESC"
title="customer_bug">customer_bug</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20jira_escalated%20ORDER%20BY%20created%20DESC"
title="jira_escalated">jira_escalated</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---


<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

## Related Issue
https://tyktech.atlassian.net/browse/TT-13439

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed a bug where the `Content-Length` header was not updated when the
response body was modified by a coprocess response hook.
- Updated the `HandleResponse` function to set the `Content-Length`
header based on the size of the modified response body.
- Enhanced test cases to verify that the `Content-Length` header matches
the length of the modified response body.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>coprocess_grpc_test.go</strong><dd><code>Update test
case to verify Content-Length header</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

coprocess/grpc/coprocess_grpc_test.go

<li>Added import for <code>strconv</code> package.<br> <li> Added import
for <code>header</code> package.<br> <li> Updated test case to match
<code>Content-Length</code> header.<br>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6732/files#diff-c5b0bcf682a084942dee611f5b6c7ff202dd49424b90d39658c4634f0422064a">+5/-0</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>coprocess.go</strong><dd><code>Update Content-Length
header for modified response body</code>&nbsp; &nbsp; </dd></summary>
<hr>

gateway/coprocess.go

<li>Set response body length in response object.<br> <li> Updated
<code>Content-Length</code> header based on modified response body.<br>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6732/files#diff-9cbfe628982b2afb94d1e9a5200fc9a4fdc00cb58fe65d1090a3725e4e4c5953">+6/-0</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull
request to receive relevant information

[TT-13439]: https://tyktech.atlassian.net/browse/TT-13439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed a bug where the `Content-Length` header was not updated when the response body was modified by a coprocess response hook.
- Updated the `HandleResponse` function to calculate and set the `Content-Length` header based on the size of the modified response body.
- Enhanced test cases to verify that the `Content-Length` header matches the length of the modified response body.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coprocess_grpc_test.go</strong><dd><code>Update test case to verify Content-Length header</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

coprocess/grpc/coprocess_grpc_test.go

<li>Added import for <code>strconv</code> and <code>header</code> packages.<br> <li> Updated test case to verify that the <code>Content-Length</code> header matches the <br>length of the modified response body.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6737/files#diff-c5b0bcf682a084942dee611f5b6c7ff202dd49424b90d39658c4634f0422064a">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coprocess.go</strong><dd><code>Update Content-Length header for modified response body</code>&nbsp; &nbsp; </dd></summary>
<hr>

gateway/coprocess.go

<li>Updated <code>HandleResponse</code> function to set the <code>Content-Length</code> header based <br>on the modified response body.<br> <li> Added logic to calculate and set the response body length in the <br>response object.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6737/files#diff-9cbfe628982b2afb94d1e9a5200fc9a4fdc00cb58fe65d1090a3725e4e4c5953">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information