### PR TITLE
[Testing/Performance] API loads/reloads

### DIFF
--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -979,6 +979,8 @@ func (gw *Gateway) loadApps(specs []*APISpec) {
 	}
 
 	for _, spec := range specs {
+		spec := spec // silences loopclosure
+
 		go func() {
 			defer wg.Done()
 			defer func() {


### PR DESCRIPTION
This changes the behviour of generating/reloading APIs to happen in goroutines for each API, hopefully speeding up the reloads, performance where the number of APIs is high, and general performance overall.

It currently doesn't take resource friendliness into account so if one has 10000 apis, 10000 goroutines would start. Generally these are fast, but the operations within could cause bottlenecks. More benchmarking is needed, possibly added concurrency limits up to GOMAXPROCS.