### PR TITLE
[TT-13217] Add updated dockerfile, test with 5.3.0/5.3.6-rc4

### DIFF
--- a/docs/plugins/python/Dockerfile
+++ b/docs/plugins/python/Dockerfile
@@ -1,0 +1,18 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} AS base
+
+# Alias for gateway release.
+
+FROM python:3.11-bookworm
+COPY --from=base /opt/tyk-gateway/ /opt/tyk-gateway/
+RUN pip install setuptools && pip install google && pip install 'protobuf==4.24.4'
+
+EXPOSE 8080 80 443
+
+ENV PYTHON_VERSION=3.11
+ENV PORT=8080
+
+WORKDIR /opt/tyk-gateway/
+
+ENTRYPOINT ["/opt/tyk-gateway/tyk" ]
+CMD [ "--conf=/opt/tyk-gateway/tyk.conf" ]

--- a/docs/plugins/python/Dockerfile
+++ b/docs/plugins/python/Dockerfile
@@ -1,8 +1,6 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE} AS base
 
-# Alias for gateway release.
-
 FROM python:3.11-bookworm
 COPY --from=base /opt/tyk-gateway/ /opt/tyk-gateway/
 RUN pip install setuptools && pip install google && pip install 'protobuf==4.24.4'

--- a/docs/plugins/python/Taskfile.yml
+++ b/docs/plugins/python/Taskfile.yml
@@ -1,0 +1,34 @@
+# yamllint disable rule:line-length
+---
+version: "3"
+
+# Taskfile tests the provided Dockerfile, see `test` for more details.
+# This confirms a python environment, not end to end as it doesn't confirm
+# gateway python plugin loading works. We're missing acceptance tests.
+
+vars:
+  base: '{{.BASE_IMAGE | default "tykio/tyk-gateway:v5.3.6-rc4"}}'
+  image: internal/tyk-gateway
+  platform: '{{.BUILD_PLATFORM | default "linux/amd64"}}'
+
+tasks:
+  build:
+    desc: "Build docker images"
+    vars:
+      tags: latest
+      args: --rm --build-arg BASE_IMAGE={{.base}} --platform {{.platform}} -q --no-cache --pull
+    cmds:
+      - for:
+          var: tags
+          as: tag
+        cmd: docker build {{.args}} -t {{.image}}:{{.tag}} -f Dockerfile .
+
+  test:
+    desc: "Print python version"
+    cmds:
+      - BASE_IMAGE=tykio/tyk-gateway:v5.3.6-rc4 task build
+      - docker run --rm --entrypoint=/bin/bash {{.image}} -c "python -V"
+      - docker run --rm --entrypoint=/bin/bash {{.image}} -c "/opt/tyk-gateway/tyk version"
+      - BASE_IMAGE=tykio/tyk-gateway:v5.3.0 task build
+      - docker run --rm --entrypoint=/bin/bash {{.image}} -c "python -V"
+      - docker run --rm --entrypoint=/bin/bash {{.image}} -c "/opt/tyk-gateway/tyk version"


### PR DESCRIPTION
Adds a testing dockerfile to run gateway in a python env. Since introducing distroless, the package manager to install python wasn't available. The dockerfile solution is to add gateway to an image containing python.

```
ARG BASE_IMAGE
FROM ${BASE_IMAGE} AS base

FROM python:3.11-bookworm
COPY --from=base /opt/tyk-gateway/ /opt/tyk-gateway/
RUN pip install setuptools && pip install google && pip install 'protobuf==4.24.4'

EXPOSE 8080 80 443

ENV PYTHON_VERSION=3.11
ENV PORT=8080

WORKDIR /opt/tyk-gateway/

ENTRYPOINT ["/opt/tyk-gateway/tyk" ]
CMD [ "--conf=/opt/tyk-gateway/tyk.conf" ]
```