### PR TITLE
[TT-12775] Add request size limit test for POST, PUT and PATCH methods.

### DIFF
--- a/gateway/mw_request_size_limit_test.go
+++ b/gateway/mw_request_size_limit_test.go
@@ -81,9 +81,9 @@ func TestRequestSizeLimit(t *testing.T) {
 		}
 		reqSizeLimitMiddleware := &RequestSizeLimitMiddleware{baseMid}
 
-		body := bytes.NewBufferString(strings.Repeat("a", 3))
 		for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodPatch} {
 			// Content-Length is missing in this request.
+			body := bytes.NewBufferString(strings.Repeat("a", 3))
 			r, err := http.NewRequest(method, "/sample", body)
 			require.NoError(t, err)
 

--- a/gateway/mw_request_size_limit_test.go
+++ b/gateway/mw_request_size_limit_test.go
@@ -1,9 +1,15 @@
 package gateway
 
 import (
+	"bytes"
+	"context"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	logrus "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/test"
@@ -58,6 +64,33 @@ func TestRequestSizeLimit(t *testing.T) {
 			_, _ = ts.Run(t, []test.TestCase{
 				{Method: method, Path: "/sample/", Code: http.StatusOK},
 			}...)
+		}
+	})
+
+	t.Run("should break the request, if content-length is missing", func(t *testing.T) {
+		// Golang's HTTP client automatically adds Content-Length to the request for POST, PUT and PATCH methods.
+		logger, _ := logrus.NewNullLogger()
+		spec := ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+			UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+				v.GlobalSizeLimit = 1024
+			})
+		})[0]
+		baseMid := &BaseMiddleware{
+			Spec:   spec,
+			logger: logger.WithContext(context.Background()),
+		}
+		reqSizeLimitMiddleware := &RequestSizeLimitMiddleware{baseMid}
+
+		body := bytes.NewBufferString(strings.Repeat("a", 3))
+		for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodPatch} {
+			// Content-Length is missing in this request.
+			r, err := http.NewRequest(method, "/sample", body)
+			require.NoError(t, err)
+
+			rw := httptest.NewRecorder()
+			err, code := reqSizeLimitMiddleware.ProcessRequest(rw, r, nil)
+			require.Equal(t, http.StatusLengthRequired, code)
+			require.Errorf(t, err, "Content length is required for this request")
 		}
 	})
 }

--- a/gateway/mw_request_size_limit_test.go
+++ b/gateway/mw_request_size_limit_test.go
@@ -84,8 +84,7 @@ func TestRequestSizeLimit(t *testing.T) {
 		for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodPatch} {
 			// Content-Length is missing in this request.
 			body := bytes.NewBufferString(strings.Repeat("a", 3))
-			r, err := http.NewRequest(method, "/sample", body)
-			require.NoError(t, err)
+			r := httptest.NewRequest(method, "/sample", body)
 
 			rw := httptest.NewRecorder()
 			err, code := reqSizeLimitMiddleware.ProcessRequest(rw, r, nil)


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-12775" title="TT-12775" target="_blank">TT-12775</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Request size limit breaks GET and DELETE requests</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Code Review</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20'24Bugsmash%20ORDER%20BY%20created%20DESC" title="'24Bugsmash">'24Bugsmash</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20customer_bug%20ORDER%20BY%20created%20DESC" title="customer_bug">customer_bug</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20jira_escalated%20ORDER%20BY%20created%20DESC" title="jira_escalated">jira_escalated</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

Follow up PR for https://github.com/TykTechnologies/tyk/pull/6734 

This PR adds a negative test case for POST, PUT and PATCH methods. The test is more complex than the existing ones because Golang http package automatically adds `Content-Length` to request if the method is POST, PUT or PATCH.


___

### **PR Type**
Tests, Bug fix


___

### **Description**
- Added a new test case to ensure that requests without `Content-Length` headers for POST, PUT, and PATCH methods are correctly handled by the middleware.
- Verified that the middleware returns `StatusLengthRequired` and logs an appropriate error message when the `Content-Length` header is missing.
- Improved test coverage for request size limit functionality.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mw_request_size_limit_test.go</strong><dd><code>Add test case for missing Content-Length in POST, PUT, PATCH methods</code></dd></summary>
<hr>

gateway/mw_request_size_limit_test.go

<li>Added a new test case to validate behavior when <code>Content-Length</code> is <br>missing for POST, PUT, and PATCH methods.<br> <li> Introduced a logger and middleware setup for the new test case.<br> <li> Verified that the middleware returns <code>StatusLengthRequired</code> and an <br>appropriate error message when <code>Content-Length</code> is missing.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6751/files#diff-107317fefc06776e7acf5e35daac311b025a92c6721432272dbd7c7dcdd854f8">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information