### PR TITLE
Merging to release-5.7: Merging to release-5.3: [TT-12775] Request size limit breaks GET and DELETE requests (#6734)

### DIFF
--- a/gateway/mw_request_size_limit.go
+++ b/gateway/mw_request_size_limit.go
@@ -11,6 +11,20 @@ import (
 	"github.com/TykTechnologies/tyk/header"
 )
 
+// As for the HTTP methods spec:
+//
+//	HTTP request bodies are theoretically allowed for all methods except TRACE,
+//	however they are not commonly used except in PUT, POST and PATCH. Because of this,
+//	they may not be supported properly by some client frameworks, and you should not allow
+//	request bodies for GET, DELETE, TRACE, OPTIONS and HEAD methods.
+var skippedMethods = map[string]struct{}{
+	http.MethodGet:     {},
+	http.MethodDelete:  {},
+	http.MethodTrace:   {},
+	http.MethodOptions: {},
+	http.MethodHead:    {},
+}
+
 // RequestSizeLimitMiddleware is a middleware that will enforce a limit on the request body size. The request has
 // already been copied to memory when this middleware is called. Therefore, this middleware can't protect the gateway
 // itself from large requests.
@@ -59,6 +73,10 @@ func (t *RequestSizeLimitMiddleware) checkRequestLimit(r *http.Request, sizeLimi
 
 // RequestSizeLimit will check a request for maximum request size, this can be a global limit or a matched limit.
 func (t *RequestSizeLimitMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
+	if _, ok := skippedMethods[r.Method]; ok {
+		return nil, http.StatusOK
+	}
+
 	logger := t.Logger()
 	logger.Debug("Request size limiter active")
 

--- a/gateway/mw_request_size_limit_test.go
+++ b/gateway/mw_request_size_limit_test.go
@@ -51,4 +51,13 @@ func TestRequestSizeLimit(t *testing.T) {
 			}...)
 		})
 	})
+
+	t.Run("should not break the request, if the method is skipped", func(t *testing.T) {
+		// GET, DELETE, TRACE, OPTIONS and HEAD
+		for method, _ := range skippedMethods {
+			_, _ = ts.Run(t, []test.TestCase{
+				{Method: method, Path: "/sample/", Code: http.StatusOK},
+			}...)
+		}
+	})
 }


### PR DESCRIPTION
Merging to release-5.3: [TT-12775] Request size limit breaks GET and DELETE requests (#6734)

[TT-12775] Request size limit breaks GET and DELETE requests (#6734)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-12775"
title="TT-12775" target="_blank">TT-12775</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Request size limit breaks GET and DELETE requests</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20'24Bugsmash%20ORDER%20BY%20created%20DESC"
title="'24Bugsmash">'24Bugsmash</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20customer_bug%20ORDER%20BY%20created%20DESC"
title="customer_bug">customer_bug</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20jira_escalated%20ORDER%20BY%20created%20DESC"
title="jira_escalated">jira_escalated</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

PR for https://tyktech.atlassian.net/browse/TT-12775

This PR changes behavior to set `statedCL` to zero and continue
processing the request, instead of returning an error with HTTP 411.

The issue states the following:

> The bug aside, a proposed consideration for refinement of this
feature; a potential memory optimisation point -
The current implementation reads the entire request and then checks if
the size limit is exceeded.
Proposal: Read requests only up to the point of the set limit.

The implementation reads the request size from
`http.Request.ContentLength`, it doesn't read the whole request body to
count the bytes.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed a bug where requests with missing `Content-Length` headers would
break by setting `statedCL` to "0" instead of returning an error.
- Added comprehensive tests to verify that requests without
`Content-Length` headers are processed correctly across various HTTP
methods.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>mw_request_size_limit.go</strong><dd><code>Adjust
request size limit handling for missing Content-Length
header</code></dd></summary>
<hr>

gateway/mw_request_size_limit.go

<li>Modified the behavior to set <code>statedCL</code> to "0" when the
<code>Content-Length</code> <br>header is absent.<br> <li> Removed the
error response for missing <code>Content-Length</code> header.<br>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6734/files#diff-601cc6b053789b90f3c9fbf42b251e8e560e547981f0d17089893db743ef5b9e">+1/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>mw_request_size_limit_test.go</strong><dd><code>Add
tests for handling requests without Content-Length
header</code></dd></summary>
<hr>

gateway/mw_request_size_limit_test.go

<li>Added a new test case to ensure requests do not break when
<br><code>Content-Length</code> is absent.<br> <li> Tested multiple HTTP
methods for this scenario.<br>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6734/files#diff-107317fefc06776e7acf5e35daac311b025a92c6721432272dbd7c7dcdd854f8">+19/-0</a>&nbsp;
&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull
request to receive relevant information