### PR TITLE
[TT-13716]change external oas ref to a local copy in gateway

### DIFF
--- a/.redocly.lint-ignore.yaml
+++ b/.redocly.lint-ignore.yaml
@@ -16,7 +16,7 @@ swagger.yml:
       #/paths/~1tyk~1apis~1oas~1{apiID}/patch/requestBody/content/application~1json/schema
     - >-
       #/paths/~1tyk~1apis~1oas~1import/post/requestBody/content/application~1json/schema
-https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v3.0/schema.json:
+https://raw.githubusercontent.com/TykTechnologies/tyk/refs/heads/master/apidef/oas/schema/3.0.json:
   spec:
     - '#/id'
     - '#/$schema'

--- a/swagger.yml
+++ b/swagger.yml
@@ -563,7 +563,7 @@ paths:
               schema:
                 items:
                   allOf:
-                  - $ref: https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v3.0/schema.json
+                  - $ref: https://raw.githubusercontent.com/TykTechnologies/tyk/refs/heads/master/apidef/oas/schema/3.0.json
                   - $ref: '#/components/schemas/XTykAPIGateway'
                 type: array
           description: List of API definitions in Tyk OAS format.
@@ -664,7 +664,7 @@ paths:
                   url: https://localhost:8080
             schema:
               allOf:
-              - $ref: https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v3.0/schema.json
+              - $ref: https://raw.githubusercontent.com/TykTechnologies/tyk/refs/heads/master/apidef/oas/schema/3.0.json
               - $ref: '#/components/schemas/XTykAPIGateway'
       responses:
         "200":
@@ -802,7 +802,7 @@ paths:
                   $ref: '#/components/examples/oasExample'
               schema:
                 allOf:
-                - $ref: https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v3.0/schema.json
+                - $ref: https://raw.githubusercontent.com/TykTechnologies/tyk/refs/heads/master/apidef/oas/schema/3.0.json
                 - $ref: '#/components/schemas/XTykAPIGateway'
           description: OK
           headers:
@@ -912,7 +912,7 @@ paths:
                 upstream:
                   url: https://localhost:8080
             schema:
-              $ref: https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v3.0/schema.json
+              $ref: https://raw.githubusercontent.com/TykTechnologies/tyk/refs/heads/master/apidef/oas/schema/3.0.json
       responses:
         "200":
           content:
@@ -1025,7 +1025,7 @@ paths:
                   url: https://localhost:8080
             schema:
               allOf:
-              - $ref: https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v3.0/schema.json
+              - $ref: https://raw.githubusercontent.com/TykTechnologies/tyk/refs/heads/master/apidef/oas/schema/3.0.json
               - $ref: '#/components/schemas/XTykAPIGateway'
       responses:
         "200":
@@ -1334,7 +1334,7 @@ paths:
               servers:
               - url: https://localhost:8080
             schema:
-              $ref: https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v3.0/schema.json
+              $ref: https://raw.githubusercontent.com/TykTechnologies/tyk/refs/heads/master/apidef/oas/schema/3.0.json
       responses:
         "200":
           content:


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-13716" title="TT-13716" target="_blank">TT-13716</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>The external OAS we use for tyk oas api return 404 in tyk gateway</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Code Review</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

[TT-13716]

The external ref https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v3.0/schema.json returns error 404. 

To fix this we have changed from an external ref to a local schema that is saved in the gateway. This will help us have control of the schema.
We have changed https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v3.0/schema.json to https://raw.githubusercontent.com/TykTechnologies/tyk/refs/heads/master/apidef/oas/schema/3.0.json

[TT-13716]: https://tyktech.atlassian.net/browse/TT-13716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed an issue where the external OpenAPI schema reference URL returned a 404 error by replacing it with a local schema URL.
- Updated `.redocly.lint-ignore.yaml` to use the new local schema URL.
- Modified `swagger.yml` to replace all instances of the external schema reference with the local schema URL across multiple API paths.
- Ensured consistent usage of the local schema URL to improve reliability and control over the schema.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.redocly.lint-ignore.yaml</strong><dd><code>Replace external OpenAPI schema reference with local schema URL</code></dd></summary>
<hr>

.redocly.lint-ignore.yaml

<li>Updated the external OpenAPI schema reference URL to a local schema <br>URL.<br> <li> Ensured the new local schema URL is used consistently in the file.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6758/files#diff-e4fbedb98d4b719f6be66946eec4e940438c123f2303c842b449c528ade31579">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>swagger.yml</strong><dd><code>Update OpenAPI schema references in API definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

swagger.yml

<li>Replaced multiple instances of the external OpenAPI schema reference <br>URL with a local schema URL.<br> <li> Updated schema references in various API paths to use the local <br>schema.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6758/files#diff-8f3c4cb253eee09ae2401daa7279a8bbfbfd4168bb579c3ac0ee5c672d63bb2c">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information