### PR TITLE
Exp/quota checks

### DIFF
--- a/ctx/ctx.go
+++ b/ctx/ctx.go
@@ -53,6 +53,7 @@ const (
 	// CacheOptions holds cache options required for cache writer middleware.
 	CacheOptions
 	OASDefinition
+	SelfLooping
 )
 
 func ctxSetSession(r *http.Request, s *user.SessionState, scheduleUpdate bool, hashKey bool) {

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -3181,8 +3181,8 @@ func ctxCheckLimits(r *http.Request) bool {
 		return false
 	}
 
-	// If looping disabled, allow all
-	if ctxLoopingEnabled(r) {
+	// If looping disabled, check all
+	if !ctxLoopingEnabled(r) {
 		return true
 	}
 

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -3182,7 +3182,7 @@ func ctxCheckLimits(r *http.Request) bool {
 	}
 
 	// If looping disabled, allow all
-	if !ctxLoopingEnabled(r) {
+	if ctxLoopingEnabled(r) {
 		return true
 	}
 

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -3176,6 +3176,11 @@ func ctxSetCheckLoopLimits(r *http.Request, b bool) {
 
 // Should we check Rate limits and Quotas?
 func ctxCheckLimits(r *http.Request) bool {
+	// If this is a self loop, do not need to check the limits and quotas.
+	if ctxSelfLooping(r) {
+		return false
+	}
+
 	// If looping disabled, allow all
 	if !ctxLoopingEnabled(r) {
 		return true
@@ -3260,6 +3265,20 @@ func ctxGetDefaultVersion(r *http.Request) bool {
 
 func ctxSetDefaultVersion(r *http.Request) {
 	setCtxValue(r, ctx.VersionDefault, true)
+}
+
+func ctxSetSelfLooping(r *http.Request, value bool) {
+	setCtxValue(r, ctx.SelfLooping, value)
+}
+
+func ctxSelfLooping(r *http.Request) bool {
+	if v := r.Context().Value(ctx.SelfLooping); v != nil {
+		if boolVal, ok := v.(bool); ok {
+			return boolVal
+		}
+	}
+
+	return false
 }
 
 func ctxLoopingEnabled(r *http.Request) bool {

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -598,6 +598,7 @@ func (d *DummyProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		var handler http.Handler
 		if r.URL.Hostname() == "self" {
+			ctxSetSelfLooping(r, true)
 			if h, found := d.Gw.apisHandlesByID.Load(d.SH.Spec.APIID); found {
 				if chain, ok := h.(*ChainObject); ok {
 					handler = chain.ThisHandler


### PR DESCRIPTION
### **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduced a new context key `SelfLooping` and methods `ctxSetSelfLooping` and `ctxSelfLooping` to manage self-looping state in requests.
- Updated `ctxCheckLimits` to bypass rate limit and quota checks for self-looping requests.
- Modified `api_loader` to set self-looping state for requests targeting the "self" hostname.
- Enhanced test cases to verify rate limit headers and ensure correct behavior with URL rewrite.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ctx.go</strong><dd><code>Add support for self-looping state in request context</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ctx/ctx.go

<li>Added a new constant <code>SelfLooping</code> to the context keys.<br> <li> Introduced <code>ctxSetSelfLooping</code> and <code>ctxSelfLooping</code> methods for managing <br>self-looping state in requests.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6780/files#diff-600f5f552779994b15324fda108549eec7e7be30b1d8a1a16ee8344243e0cbc7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>api.go</strong><dd><code>Modify rate limit and quota checks for self-looping requests</code></dd></summary>
<hr>

gateway/api.go

<li>Updated <code>ctxCheckLimits</code> to skip rate limit and quota checks for <br>self-looping requests.<br> <li> Added methods to set and retrieve self-looping state in the request <br>context.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6780/files#diff-644cda3aeb4ac7f325359e85fcddb810f100dd5e6fa480b0d9f9363a743c4e05">+20/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>api_loader.go</strong><dd><code>Set self-looping state for "self" hostname requests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_loader.go

<li>Set self-looping state in the context for requests targeting the <br>"self" hostname.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6780/files#diff-cdf0b7f176c9d18e1a314b78ddefc2cb3a94b3de66f1f360174692c915734c68">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>middleware_test.go</strong><dd><code>Enhance tests for quota and rate limit behavior with URL rewrite</code></dd></summary>
<hr>

gateway/middleware_test.go

<li>Enabled extended paths in the API version for testing.<br> <li> Added assertions to verify rate limit headers in test cases.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6780/files#diff-6a09a08e3f82cc5e9d8c6b5c8426d75ea1e5d85e15ab008fca1f512e7c49c1e6">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information