### PR TITLE
Merging to release-5.3: [TT-13021], fixed missing lines (#6787)

### DIFF
--- a/gateway/mw_url_rewrite.go
+++ b/gateway/mw_url_rewrite.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
@@ -700,6 +701,7 @@ func checkPayload(r *http.Request, options apidef.StringRegexMap, triggernum int
 		log.WithError(err).Error("error reading request body")
 		return false
 	}
+	r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 
 	// Perform regex matching on the request body
 	matched, matches := options.FindAllStringSubmatch(string(bodyBytes), -1)

--- a/gateway/mw_validate_json.go
+++ b/gateway/mw_validate_json.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -54,6 +55,7 @@ func (k *ValidateJSON) ProcessRequest(w http.ResponseWriter, r *http.Request, _ 
 	if err != nil {
 		return err, http.StatusBadRequest
 	}
+	r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 	defer r.Body.Close()
 	inputLoader := gojsonschema.NewBytesLoader(bodyBytes)
 


### PR DESCRIPTION
### **User description**
[TT-13021], fixed missing lines (#6787)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-13021"
title="TT-13021" target="_blank">TT-13021</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
<td>URL Rewrite with `Transfer-Encoding: chunked` Header removes the
response payload body</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20'24Bugsmash%20ORDER%20BY%20created%20DESC"
title="'24Bugsmash">'24Bugsmash</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20QA_Fail%20ORDER%20BY%20created%20DESC"
title="QA_Fail">QA_Fail</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20customer_bug%20ORDER%20BY%20created%20DESC"
title="customer_bug">customer_bug</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20jira_escalated%20ORDER%20BY%20created%20DESC"
title="jira_escalated">jira_escalated</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description
TASK: https://tyktech.atlassian.net/browse/TT-13021
<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed an issue where the request body was not properly reset after
being read, which could cause issues in subsequent processing.
- Updated `gateway/mw_url_rewrite.go` to use `io.NopCloser` and
`bytes.NewBuffer` for resetting the request body after reading.
- Updated `gateway/mw_validate_json.go` to ensure the request body is
reset after reading for JSON validation.
- Added `bytes` package imports in both files to support the changes.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>mw_url_rewrite.go</strong><dd><code>Fix request body
handling in URL rewrite middleware</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_url_rewrite.go

<li>Added <code>bytes</code> package import for handling request
body.<br> <li> Ensured the request body is reset after reading it using
<code>io.NopCloser</code> <br>and <code>bytes.NewBuffer</code>.<br> <li>
Improved handling of request body to allow further processing after
<br>reading.<br>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6787/files#diff-84a6a5c810334aaa8702669f2aebf0284f116d83e8a55ec9d1d5b8bae87f1be6">+2/-0</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>mw_validate_json.go</strong><dd><code>Fix request body
handling in JSON validation middleware</code>&nbsp; &nbsp;
</dd></summary>
<hr>

gateway/mw_validate_json.go

<li>Added <code>bytes</code> package import for handling request
body.<br> <li> Ensured the request body is reset after reading it using
<code>io.NopCloser</code> <br>and <code>bytes.NewBuffer</code>.<br> <li>
Improved request body handling for JSON validation.<br>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6787/files#diff-0f0c6b9ac40c5e01908a5b24b1d03111c8d8b4dbc1ddc0251d17c3c1b5328ab5">+2/-0</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull
request to receive relevant information

[TT-13021]: https://tyktech.atlassian.net/browse/TT-13021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed an issue where the request body was not properly reset after being read, which could cause issues in subsequent processing.
- Updated `gateway/mw_url_rewrite.go` to use `io.NopCloser` and `bytes.NewBuffer` for resetting the request body after reading.
- Updated `gateway/mw_validate_json.go` to ensure the request body is reset after reading for JSON validation.
- Added `bytes` package imports in both files to support the changes.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mw_url_rewrite.go</strong><dd><code>Fix request body handling in URL rewrite middleware</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_url_rewrite.go

<li>Added <code>bytes</code> package import for handling request body.<br> <li> Ensured the request body is reset after reading using <code>io.NopCloser</code> and <br><code>bytes.NewBuffer</code>.<br> <li> Improved handling of request body to allow further processing after <br>reading.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6789/files#diff-84a6a5c810334aaa8702669f2aebf0284f116d83e8a55ec9d1d5b8bae87f1be6">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mw_validate_json.go</strong><dd><code>Fix request body handling in JSON validation middleware</code>&nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_validate_json.go

<li>Added <code>bytes</code> package import for handling request body.<br> <li> Ensured the request body is reset after reading using <code>io.NopCloser</code> and <br><code>bytes.NewBuffer</code>.<br> <li> Improved request body handling for JSON validation.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6789/files#diff-0f0c6b9ac40c5e01908a5b24b1d03111c8d8b4dbc1ddc0251d17c3c1b5328ab5">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information