### PR TITLE
Merging to master: Merging to release-5.3: [TT-13769] Extend plugin compiler test with arm64 cross build (#6813)

### DIFF
--- a/ci/tests/plugin-compiler/README.md
+++ b/ci/tests/plugin-compiler/README.md
@@ -38,6 +38,12 @@ The following variables are set as defaults:
 
 Use `task -l` to list available targets, or read on.
 
+Example: Run a plugin subtest against a release image.
+
+```
+task test:qa-plugin image=tykio/tyk-plugin-compiler:v5.3.9-rc4
+```
+
 ## Building and testing plugin compiler locally
 
 In order to build the plugin compiler images locally from source,

--- a/ci/tests/plugin-compiler/Taskfile.yml
+++ b/ci/tests/plugin-compiler/Taskfile.yml
@@ -1,3 +1,4 @@
+# yamllint disable rule:line-length
 ---
 version: "3"
 
@@ -82,7 +83,6 @@ tasks:
     internal: true
     cmds:
 
-
   test:basic-plugin:
     desc: "Test plugin compiler (basic-plugin)"
     vars:
@@ -93,6 +93,20 @@ tasks:
       - rm -f {{.plugin_path}}/*.so
       - docker run {{.args}} {{.image}} plugin.so
       - cp -f {{.plugin_path}}/*.so {{.plugin_path}}/plugin.so
+      - docker run {{.args}} --entrypoint=/usr/local/bin/tyk {{.image}} plugin load -f plugin.so -s {{.symbol}}
+      - strings {{.plugin_path}}/plugin.so | grep test_goplugin.go
+
+  test:qa-plugin:
+    desc: "Test plugin compiler (qa-plugin) amd64 e2e + arm64 build"
+    vars:
+      plugin_path: '{{.root}}/ci/tests/plugin-compiler/testdata/qa-plugin'
+      symbol: AuthCheck
+      args: --rm -e DEBUG=1 -v {{.plugin_path}}:/plugin-source -w /plugin-source
+    cmds:
+      - rm -f {{.plugin_path}}/*.so
+      - docker run {{.args}} {{.image}} plugin.so
+      - cp -f {{.plugin_path}}/*.so {{.plugin_path}}/plugin.so
+      - docker run -e GOARCH=arm64 {{.args}} {{.image}} plugin.so
       - docker run {{.args}} --entrypoint=/usr/local/bin/tyk {{.image}} plugin load -f plugin.so -s {{.symbol}}
       - strings {{.plugin_path}}/plugin.so | grep test_goplugin.go
 
@@ -136,4 +150,3 @@ tasks:
       - cp -f {{.plugin_path}}/*.so {{.plugin_path}}/plugin.so
       - docker run {{.args}} --entrypoint=/usr/local/bin/tyk {{.image}} plugin load -f plugin.so -s {{.symbol}}
       - strings {{.plugin_path}}/plugin.so | grep main.go
-

--- a/ci/tests/plugin-compiler/test.sh
+++ b/ci/tests/plugin-compiler/test.sh
@@ -22,6 +22,9 @@ rm -fv $PLUGIN_SOURCE_PATH/*.so || true
 docker run --rm -v $PLUGIN_SOURCE_PATH:/plugin-source $PLUGIN_COMPILER_IMAGE plugin.so
 cp $PLUGIN_SOURCE_PATH/*.so $PLUGIN_SOURCE_PATH/plugin.so 
 
+# Cross compile to arm64
+docker run --rm -e GOARCH=arm64 -v $PLUGIN_SOURCE_PATH:/plugin-source $PLUGIN_COMPILER_IMAGE plugin.so
+
 docker compose up -d --wait --force-recreate || { docker compose logs gw; exit 1; }
 
 curl http://localhost:8080/goplugin/headers | jq -e '.headers.Foo == "Bar"' || { docker compose logs gw; exit 1; }

--- a/ci/tests/plugin-compiler/testdata/qa-plugin/README.md
+++ b/ci/tests/plugin-compiler/testdata/qa-plugin/README.md
@@ -1,0 +1,6 @@
+# QA Plugin
+
+The only difference between this and other plugins is that this one does
+not provide a go.mod. This means a slightly different build path is
+tested for the plugin compiler, ensuring coverage for when no go.mod is
+provided.

--- a/ci/tests/plugin-compiler/testdata/qa-plugin/main.go
+++ b/ci/tests/plugin-compiler/testdata/qa-plugin/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/TykTechnologies/tyk/ctx"
+	"github.com/TykTechnologies/tyk/log"
+	"github.com/TykTechnologies/tyk/user"
+)
+
+var logger = log.Get()
+
+// AddFooBarHeader adds custom "Foo: Bar" header to the request
+func AddFooBarHeader(rw http.ResponseWriter, r *http.Request) {
+	r.Header.Add("Foo", "Bar")
+}
+
+// Custom Auth, applies a rate limit of
+// 2 per 10 given a token of "abc"
+func AuthCheck(rw http.ResponseWriter, r *http.Request) {
+	token := r.Header.Get("Authorization")
+	if token != "d3fd1a57-94ce-4a36-9dfe-679a8f493b49" && token != "3be61aa4-2490-4637-93b9-105001aa88a5" {
+		rw.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+	session := &user.SessionState{
+		Alias: token,
+		Rate:  2,
+		Per:   10,
+		MetaData: map[string]interface{}{
+			token: token,
+		},
+		KeyID: token,
+	}
+	ctx.SetSession(r, session, true)
+}
+func main() {}
+func init() {
+	logger.Info("--- Go custom plugin v4 init success! ---- ")
+}


### PR DESCRIPTION
### **User description**
Merging to release-5.3: [TT-13769] Extend plugin compiler test with arm64 cross build (#6813)

[TT-13769] Extend plugin compiler test with arm64 cross build (#6813)

### **PR Type**
tests


___

### **Description**
- Extended the plugin compiler test script to include a
cross-compilation step for the `arm64` architecture.
- Added a Docker command with the `GOARCH=arm64` environment variable to
enable arm64 builds.
- Ensures compatibility and testing for arm64 architecture in the plugin
compiler.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>test.sh</strong><dd><code>Add arm64 cross-compilation
to plugin compiler test script</code></dd></summary>
<hr>

ci/tests/plugin-compiler/test.sh

<li>Added a cross-compilation step for building the plugin for the
<code>arm64</code> <br>architecture.<br> <li> Introduced the use of the
<code>GOARCH=arm64</code> environment variable in the <br>Docker
command.<br>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6813/files#diff-2a616e71f9e61519f1e7fcd658f73d83a8ae561ef3108da000e7f5d77e38c244">+3/-0</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull
request to receive relevant information

---------

Co-authored-by: Tit Petric <tit@tyk.io>

[TT-13769]: https://tyktech.atlassian.net/browse/TT-13769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TT-13769]: https://tyktech.atlassian.net/browse/TT-13769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Tests


___

### **Description**
- Added a new QA plugin written in Go to test plugin compiler functionality, including custom header addition and authentication checks.
- Extended the plugin compiler test script to include cross-compilation for the `arm64` architecture using the `GOARCH=arm64` environment variable.
- Updated the `Taskfile.yml` to include a new task for testing the QA plugin with both amd64 and arm64 builds.
- Enhanced documentation with examples and explanations for the new QA plugin and arm64 testing capabilities.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Add QA plugin for testing plugin compiler functionality.</code>&nbsp; </dd></summary>
<hr>

ci/tests/plugin-compiler/testdata/qa-plugin/main.go

<li>Added a new Go plugin file for testing purposes.<br> <li> Implemented a custom header addition function and an authentication <br>check function.<br> <li> Included session handling with rate limiting for specific tokens.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6815/files#diff-86dfa3adae5c62183ab007110ef58748321b0717a5b000f20c6e7a65c19c3bda">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test.sh</strong><dd><code>Extend plugin compiler test script with arm64 cross-compilation.</code></dd></summary>
<hr>

ci/tests/plugin-compiler/test.sh

<li>Added a cross-compilation step for the <code>arm64</code> architecture.<br> <li> Introduced the <code>GOARCH=arm64</code> environment variable in the Docker <br>command.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6815/files#diff-2a616e71f9e61519f1e7fcd658f73d83a8ae561ef3108da000e7f5d77e38c244">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README with arm64 testing instructions.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ci/tests/plugin-compiler/README.md

<li>Added an example for running a plugin subtest against a release image.<br> <li> Updated documentation to reflect new testing capabilities.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6815/files#diff-f92a7008589bd37c860dfcc56cc93d64b5527b7103393bd7e2a52d7677ac1b42">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add README for QA plugin.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ci/tests/plugin-compiler/testdata/qa-plugin/README.md

<li>Added a README file for the QA plugin.<br> <li> Explained the purpose of the QA plugin and its unique build path.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6815/files#diff-135108e85b6489aea74da2a8b2a4fcc7d97251e98b14b7b27581c296bfb49c24">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Taskfile.yml</strong><dd><code>Add QA plugin test task with arm64 support.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ci/tests/plugin-compiler/Taskfile.yml

<li>Added a new task for testing the QA plugin with amd64 and arm64 <br>builds.<br> <li> Updated task definitions to include arm64 cross-compilation.<br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6815/files#diff-a096f84789729a36dded35410fb45add24bee39336c8a5f3eace1f910414f01e">+15/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information