### PR TITLE
fix: adding key hashed information when api key invalid

### DIFF
--- a/gateway/mw_auth_key.go
+++ b/gateway/mw_auth_key.go
@@ -184,7 +184,10 @@ func (k *AuthKey) ProcessRequest(_ http.ResponseWriter, r *http.Request, _ inter
 }
 
 func (k *AuthKey) reportInvalidKey(key string, r *http.Request, msg string, errMsg string) (error, int) {
-	k.Logger().WithField("key", k.Gw.obfuscateKey(key)).Info(msg)
+	k.Logger().
+		WithField("key", k.Gw.obfuscateKey(key)).
+		WithField("key_hashed", storage.HashKey(key, k.Gw.GetConfig().HashKeys)).
+		Info(msg)
 
 	// Fire Authfailed Event
 	AuthFailed(k, r, key)
@@ -196,7 +199,6 @@ func (k *AuthKey) reportInvalidKey(key string, r *http.Request, msg string, errM
 }
 
 func (k *AuthKey) validateSignature(r *http.Request, key string) (error, int) {
-
 	_, authConfig := k.getAuthToken(k.getAuthType(), r)
 	logger := k.Logger().WithField("key", k.Gw.obfuscateKey(key))
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Logging key hashed information when checking for validity of API key

## Related Issue

## Motivation and Context

Provide additional information when troubleshooting 403 forbidden request

## How This Has Been Tested

Only logging added

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [x] I ensured that the documentation is up to date
- [x] I explained why this PR updates go.mod in detail with reasoning why it's required
- [x] I would like a code coverage CI quality gate exception and have explained why
