### PR TITLE
[TT-11913] Custom Analytics Plugins

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -576,6 +576,7 @@ type MiddlewareSection struct {
 	PostKeyAuth []MiddlewareDefinition `bson:"post_key_auth" json:"post_key_auth"`
 	AuthCheck   MiddlewareDefinition   `bson:"auth_check" json:"auth_check"`
 	Response    []MiddlewareDefinition `bson:"response" json:"response"`
+	TrafficLogs []MiddlewareDefinition `bson:"traffic_logs" json:"traffic_logs"`
 	Driver      MiddlewareDriver       `bson:"driver" json:"driver"`
 	IdExtractor MiddlewareIdExtractor  `bson:"id_extractor" json:"id_extractor"`
 }

--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -1580,7 +1580,6 @@ type TrafficLogs struct {
 	// TagHeaders is a string array of HTTP headers that can be extracted
 	// and transformed into analytics tags (statistics aggregated by tag, per hour).
 	TagHeaders []string `bson:"tagHeaders" json:"tagHeaders,omitempty"`
-
 	// Plugins configures custom plugins to allow for extensive modifications to analytics records
 	// The plugins would be executed in the order of configuration in the list.
 	Plugins CustomPlugins `bson:"plugins,omitempty" json:"plugins,omitempty"`
@@ -1591,13 +1590,13 @@ func (t *TrafficLogs) Fill(api apidef.APIDefinition) {
 	t.Enabled = !api.DoNotTrack
 	t.TagHeaders = api.TagHeaders
 
-	if len(api.CustomMiddleware.Response) == 0 {
+	if len(api.CustomMiddleware.TrafficLogs) == 0 {
 		t.Plugins = nil
 		return
 	}
 
-	t.Plugins = make(CustomPlugins, len(api.CustomMiddleware.Response))
-	t.Plugins.Fill(api.CustomMiddleware.Response)
+	t.Plugins = make(CustomPlugins, len(api.CustomMiddleware.TrafficLogs))
+	t.Plugins.Fill(api.CustomMiddleware.TrafficLogs)
 }
 
 // ExtractTo extracts *TrafficLogs into *apidef.APIDefinition.
@@ -1606,12 +1605,12 @@ func (t *TrafficLogs) ExtractTo(api *apidef.APIDefinition) {
 	api.TagHeaders = t.TagHeaders
 
 	if len(t.Plugins) == 0 {
-		api.CustomMiddleware.Response = nil
+		api.CustomMiddleware.TrafficLogs = nil
 		return
 	}
 
-	api.CustomMiddleware.Response = make([]apidef.MiddlewareDefinition, len(t.Plugins))
-	t.Plugins.ExtractTo(api.CustomMiddleware.Response)
+	api.CustomMiddleware.TrafficLogs = make([]apidef.MiddlewareDefinition, len(t.Plugins))
+	t.Plugins.ExtractTo(api.CustomMiddleware.TrafficLogs)
 }
 
 // GlobalRequestSizeLimit holds configuration about the global limits for request sizes.

--- a/apidef/oas/middleware_test.go
+++ b/apidef/oas/middleware_test.go
@@ -44,6 +44,9 @@ func TestMiddleware(t *testing.T) {
 				ResponsePlugin: &ResponsePlugin{
 					Plugins: customPlugins,
 				},
+				TrafficLogs: &TrafficLogs{
+					Plugins: customPlugins,
+				},
 			},
 		}
 
@@ -58,6 +61,7 @@ func TestMiddleware(t *testing.T) {
 				PostAuthenticationPlugin: &PostAuthenticationPlugin{},
 				PostPlugin:               &PostPlugin{},
 				ResponsePlugin:           &ResponsePlugin{},
+				TrafficLogs:              &TrafficLogs{},
 			},
 		}
 		resultMiddleware.Fill(convertedAPI)
@@ -68,6 +72,9 @@ func TestMiddleware(t *testing.T) {
 				PostAuthenticationPlugins: customPlugins,
 				PostPlugins:               customPlugins,
 				ResponsePlugins:           customPlugins,
+				TrafficLogs: &TrafficLogs{
+					Plugins: customPlugins,
+				},
 			},
 		}
 		assert.Equal(t, expectedMW, resultMiddleware)

--- a/apidef/oas/middleware_test.go
+++ b/apidef/oas/middleware_test.go
@@ -219,6 +219,29 @@ func TestTrafficLogs(t *testing.T) {
 		trafficLogs.ExtractTo(&convertedAPI)
 		assert.Empty(t, convertedAPI.TagHeaders)
 	})
+
+	t.Run("with custom plugin", func(t *testing.T) {
+		t.Parallel()
+		expectedTrafficLogsPlugin := TrafficLogs{
+			Enabled:    true,
+			TagHeaders: []string{},
+			Plugins: CustomPlugins{
+				{
+					Enabled:      true,
+					FunctionName: "CustomAnalyticsPlugin",
+					Path:         "/path/to/plugin",
+				},
+			},
+		}
+
+		api := apidef.APIDefinition{}
+		api.SetDisabledFlags()
+		expectedTrafficLogsPlugin.ExtractTo(&api)
+
+		actualTrafficLogsPlugin := TrafficLogs{}
+		actualTrafficLogsPlugin.Fill(api)
+		assert.Equal(t, expectedTrafficLogsPlugin, actualTrafficLogsPlugin)
+	})
 }
 
 func TestPluginConfig(t *testing.T) {

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -1999,7 +1999,10 @@
           }
         },
         "plugins": {
-          "$ref": "#/definitions/X-Tyk-CustomPluginConfig"
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/X-Tyk-CustomPluginConfig"
+          }
         }
       },
       "required": [

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -1997,6 +1997,9 @@
           "items": {
             "type": "string"
           }
+        },
+        "plugins": {
+          "$ref": "#/definitions/X-Tyk-CustomPluginConfig"
         }
       },
       "required": [


### PR DESCRIPTION
PR for [TT-11913](https://tyktech.atlassian.net/browse/TT-11913)

This PR adds `Plugins` section to `TrafficLogs` and related unit tests. UI and integration tests will be implemented separately. 

In `api_definitions.go` file, I added `TrafficLogs []MiddlewareDefinition` field but In OAS contract, `TrafficLogs` has also `Enabled` and `TagHeaders` fields. Currently, we don't extract those fields to classic API definition. I think we might need to add a new struct for `TrafficLogs` to `api_defitions.go` file that covers that fields along with the custom plugins configuration.  