### PR TITLE
Merging to release-5.3: [TT-13819] Benchmark updates, session limiter workaround for test goroutine leak (#6826)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,9 +8,13 @@
 
 # Core API Squad ownership of plugin compiler and related tests.
 
+<<<<<<< HEAD
 /smoke-tests/                           @TykTechnologies/core-api-squad
 /ci/tests/                              @TykTechnologies/core-api-squad
 /ci/images/plugin-compiler/             @TykTechnologies/core-api-squad
+=======
+/bin/                                   @TykTechnologies/core-api-squad
+>>>>>>> 155e11bb3... [TT-13819] Benchmark updates, session limiter workaround for test goroutine leak (#6826)
 .github/workflows/ci-tests.yml          @TykTechnologies/core-api-squad
 .github/workflows/release-tests.yml     @TykTechnologies/core-api-squad
 /.taskfiles/                            @TykTechnologies/core-api-squad

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,23 +2,21 @@
 
 /ci/                                    @TykTechnologies/devops
 .github/workflows/release.yml           @TykTechnologies/devops
-.github/workflows/sync-automation.yml   @TykTechnologies/devops
-.github/workflows/pac.yml               @TykTechnologies/devops
-/repo-policy/                           @TykTechnologies/devops
 
-# Core API Squad ownership of plugin compiler and related tests.
+# Core API Squad ownership of CI test pipeline and developer tooling.
 
-<<<<<<< HEAD
-/smoke-tests/                           @TykTechnologies/core-api-squad
-/ci/tests/                              @TykTechnologies/core-api-squad
-/ci/images/plugin-compiler/             @TykTechnologies/core-api-squad
-=======
 /bin/                                   @TykTechnologies/core-api-squad
->>>>>>> 155e11bb3... [TT-13819] Benchmark updates, session limiter workaround for test goroutine leak (#6826)
 .github/workflows/ci-tests.yml          @TykTechnologies/core-api-squad
 .github/workflows/release-tests.yml     @TykTechnologies/core-api-squad
 /.taskfiles/                            @TykTechnologies/core-api-squad
 /Dockerfile                             @TykTechnologies/core-api-squad
+/docker/                                @TykTechnologies/core-api-squad
 /Makefile                               @TykTechnologies/core-api-squad
 /Taskfile.yml                           @TykTechnologies/core-api-squad
 /docker-compose.yml                     @TykTechnologies/core-api-squad
+
+# Core API Squad ownership of plugin compiler and related tests.
+
+/smoke-tests/                           @TykTechnologies/core-api-squad
+/ci/tests/                              @TykTechnologies/core-api-squad
+/ci/images/plugin-compiler/             @TykTechnologies/core-api-squad

--- a/bin/ci-benchmark.sh
+++ b/bin/ci-benchmark.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
-
 set -e
 
-benchRegex=${1:-.}
+# Build gw test binary
+go test -o gateway.test -c ./gateway
 
-TYK_LOGLEVEL= go test -run=NONE -bench=$benchRegex || fatal "go test -run=NONE -bench=$benchRegex"
+BENCHMARKS=$(./gateway.test -test.list=Bench.+)
+
+for benchmark in $BENCHMARKS; do
+	echo $benchmark
+	benchRegex="^${benchmark}$"
+	./gateway.test -test.run=^$ -test.bench=$benchRegex -test.count=1 \
+			-test.benchtime 30s -test.benchmem \
+			-test.cpuprofile=coverage/$benchmark-cpu.out \
+			-test.memprofile=coverage/$benchmark-mem.out \
+			-test.trace=coverage/$benchmark-trace.out
+done

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -1019,6 +1019,8 @@ func (ts *Test) testPrepareDefaultVersion() (string, *APISpec) {
 		spec.Proxy.ListenPath = "/"
 
 		spec.UseKeylessAccess = false
+		spec.DisableRateLimit = true
+		spec.DisableQuota = true
 	})[0]
 
 	return CreateSession(ts.Gw, func(s *user.SessionState) {

--- a/gateway/event_system_test.go
+++ b/gateway/event_system_test.go
@@ -173,6 +173,8 @@ func TestInitGenericEventHandlers(t *testing.T) {
 }
 
 func BenchmarkInitGenericEventHandlers(b *testing.B) {
+	b.Skip()
+
 	ts := StartTest(nil)
 	defer ts.Close()
 

--- a/gateway/mw_basic_auth_test.go
+++ b/gateway/mw_basic_auth_test.go
@@ -21,7 +21,6 @@ func genAuthHeader(username, password string) string {
 }
 
 func (ts *Test) testPrepareBasicAuth(cacheDisabled bool) *user.SessionState {
-
 	session := CreateStandardSession()
 	session.BasicAuthData.Password = "password"
 	session.AccessRights = map[string]user.AccessDefinition{"test": {APIID: "test", Versions: []string{"v1"}}}
@@ -33,6 +32,8 @@ func (ts *Test) testPrepareBasicAuth(cacheDisabled bool) *user.SessionState {
 		spec.UseKeylessAccess = false
 		spec.Proxy.ListenPath = "/"
 		spec.OrgID = "default"
+		spec.DisableRateLimit = true
+		spec.DisableQuota = true
 	})
 
 	return session

--- a/gateway/mw_jwt_test.go
+++ b/gateway/mw_jwt_test.go
@@ -141,6 +141,8 @@ func (ts *Test) prepareGenericJWTSession(testName string, method string, claimNa
 		spec.EnableJWT = true
 		spec.Proxy.ListenPath = "/"
 		spec.JWTSkipKid = ApiSkipKid
+		spec.DisableRateLimit = true
+		spec.DisableQuota = true
 
 		if claimName != KID {
 			spec.JWTIdentityBaseField = claimName
@@ -471,6 +473,8 @@ func (ts *Test) prepareJWTSessionRSAWithRawSourceOnWithClientID(isBench bool) st
 		spec.JWTIdentityBaseField = "user_id"
 		spec.JWTClientIDBaseField = "azp"
 		spec.Proxy.ListenPath = "/"
+		spec.DisableRateLimit = true
+		spec.DisableQuota = true
 	})[0]
 
 	policyID := ts.CreatePolicy(func(p *user.Policy) {
@@ -552,6 +556,8 @@ func (ts *Test) prepareJWTSessionRSAWithRawSource() string {
 		spec.JWTIdentityBaseField = "user_id"
 		spec.JWTPolicyFieldName = "policy_id"
 		spec.Proxy.ListenPath = "/"
+		spec.DisableRateLimit = true
+		spec.DisableQuota = true
 	})
 
 	pID := ts.CreatePolicy(func(p *user.Policy) {
@@ -1503,6 +1509,8 @@ func (ts *Test) prepareJWTSessionRSAWithJWK() string {
 		spec.JWTIdentityBaseField = "user_id"
 		spec.JWTPolicyFieldName = "policy_id"
 		spec.Proxy.ListenPath = "/"
+		spec.DisableRateLimit = true
+		spec.DisableQuota = true
 	})
 
 	pID := ts.CreatePolicy(func(p *user.Policy) {
@@ -1571,6 +1579,8 @@ func (ts *Test) prepareJWTSessionRSAWithEncodedJWK() (*APISpec, string) {
 		spec.JWTIdentityBaseField = "user_id"
 		spec.JWTPolicyFieldName = "policy_id"
 		spec.Proxy.ListenPath = "/"
+		spec.DisableRateLimit = true
+		spec.DisableQuota = true
 	})[0]
 
 	pID := ts.CreatePolicy(func(p *user.Policy) {

--- a/gateway/mw_transform_test.go
+++ b/gateway/mw_transform_test.go
@@ -37,11 +37,10 @@ func TestTransformNonAscii(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()
 
-	ad := apidef.APIDefinition{}
-	spec := APISpec{APIDefinition: &ad}
-	spec.EnableContextVars = false
-	base := &BaseMiddleware{Spec: &spec, Gw: ts.Gw}
-	base.Spec.EnableContextVars = false
+	ad := &apidef.APIDefinition{}
+	spec := &APISpec{APIDefinition: ad}
+	base := &BaseMiddleware{Spec: spec, Gw: ts.Gw}
+
 	transform := TransformMiddleware{base}
 
 	if err := transformBody(r, tmeta, &transform); err != nil {
@@ -64,15 +63,16 @@ func BenchmarkTransformNonAscii(b *testing.B) {
 	ts := StartTest(nil)
 	defer ts.Close()
 
-	spec := APISpec{}
-	base := &BaseMiddleware{Spec: &spec, Gw: ts.Gw}
-	base.Spec.EnableContextVars = false
-	transform := TransformMiddleware{base}
+	ad := &apidef.APIDefinition{}
+	spec := &APISpec{APIDefinition: ad}
+	base := &BaseMiddleware{Spec: spec, Gw: ts.Gw}
+
+	transform := &TransformMiddleware{base}
 
 	for i := 0; i < b.N; i++ {
 		r := TestReq(b, "GET", "/", in)
 
-		if err := transformBody(r, tmeta, &transform); err != nil {
+		if err := transformBody(r, tmeta, transform); err != nil {
 			b.Fatalf("wanted nil error, got %v", err)
 		}
 	}
@@ -90,10 +90,10 @@ func TestTransformXMLCrash(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()
 
-	ad := apidef.APIDefinition{}
-	spec := APISpec{APIDefinition: &ad}
-	base := &BaseMiddleware{Spec: &spec, Gw: ts.Gw}
-	base.Spec.EnableContextVars = false
+	ad := &apidef.APIDefinition{}
+	spec := &APISpec{APIDefinition: ad}
+	base := &BaseMiddleware{Spec: spec, Gw: ts.Gw}
+
 	transform := TransformMiddleware{base}
 
 	if err := transformBody(r, tmeta, &transform); err == nil {
@@ -145,10 +145,10 @@ func TestTransformJSONMarshalXMLInput(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()
 
-	ad := apidef.APIDefinition{}
-	spec := APISpec{APIDefinition: &ad}
-	base := &BaseMiddleware{Spec: &spec, Gw: ts.Gw}
-	base.Spec.EnableContextVars = false
+	ad := &apidef.APIDefinition{}
+	spec := &APISpec{APIDefinition: ad}
+	base := &BaseMiddleware{Spec: spec, Gw: ts.Gw}
+
 	transform := TransformMiddleware{base}
 
 	if err := transformBody(r, tmeta, &transform); err != nil {
@@ -172,10 +172,10 @@ func TestTransformJSONMarshalJSONInput(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()
 
-	ad := apidef.APIDefinition{}
-	spec := APISpec{APIDefinition: &ad}
-	base := &BaseMiddleware{Spec: &spec, Gw: ts.Gw}
-	base.Spec.EnableContextVars = false
+	ad := &apidef.APIDefinition{}
+	spec := &APISpec{APIDefinition: ad}
+	base := &BaseMiddleware{Spec: spec, Gw: ts.Gw}
+
 	transform := TransformMiddleware{base}
 
 	if err := transformBody(r, tmeta, &transform); err != nil {
@@ -211,10 +211,10 @@ func TestTransformJSONMarshalJSONArrayInput(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()
 
-	ad := apidef.APIDefinition{}
-	spec := APISpec{APIDefinition: &ad}
-	base := &BaseMiddleware{Spec: &spec, Gw: ts.Gw}
-	base.Spec.EnableContextVars = false
+	ad := &apidef.APIDefinition{}
+	spec := &APISpec{APIDefinition: ad}
+	base := &BaseMiddleware{Spec: spec, Gw: ts.Gw}
+
 	transform := TransformMiddleware{base}
 
 	if err := transformBody(r, tmeta, &transform); err != nil {
@@ -236,9 +236,10 @@ func BenchmarkTransformJSONMarshal(b *testing.B) {
 	ts := StartTest(nil)
 	defer ts.Close()
 
-	spec := APISpec{}
-	base := &BaseMiddleware{Spec: &spec, Gw: ts.Gw}
-	base.Spec.EnableContextVars = false
+	ad := &apidef.APIDefinition{}
+	spec := &APISpec{APIDefinition: ad}
+	base := &BaseMiddleware{Spec: spec, Gw: ts.Gw}
+
 	transform := TransformMiddleware{base}
 
 	for i := 0; i < b.N; i++ {
@@ -257,10 +258,10 @@ func TestTransformXMLMarshal(t *testing.T) {
 		ts := StartTest(nil)
 		defer ts.Close()
 
-		ad := apidef.APIDefinition{}
-		spec := APISpec{APIDefinition: &ad}
-		base := &BaseMiddleware{Spec: &spec, Gw: ts.Gw}
-		base.Spec.EnableContextVars = false
+		ad := &apidef.APIDefinition{}
+		spec := &APISpec{APIDefinition: ad}
+		base := &BaseMiddleware{Spec: spec, Gw: ts.Gw}
+
 		transform := TransformMiddleware{base}
 
 		if err := transformBody(r, tmeta, &transform); err != nil {

--- a/gateway/mw_version_check_test.go
+++ b/gateway/mw_version_check_test.go
@@ -20,6 +20,8 @@ func (ts *Test) testPrepareVersioning() (string, string) {
 		spec.VersionDefinition.Location = "header"
 		spec.VersionDefinition.Key = "version"
 		spec.Proxy.ListenPath = "/"
+		spec.DisableRateLimit = true
+		spec.DisableQuota = true
 		spec.VersionData.Versions["expired"] = apidef.VersionInfo{
 			Name:    "expired",
 			Expires: "2006-01-02 15:04",

--- a/gateway/oauth_manager_test.go
+++ b/gateway/oauth_manager_test.go
@@ -1399,6 +1399,8 @@ func TestPurgeOAuthClientTokens(t *testing.T) {
 }
 
 func BenchmarkPurgeLapsedOAuthTokens(b *testing.B) {
+	b.Skip()
+
 	conf := func(globalConf *config.Config) {
 		// set tokens to be expired after 1 second
 		globalConf.OauthTokenExpire = 1

--- a/gateway/res_handler_header_injector_test.go
+++ b/gateway/res_handler_header_injector_test.go
@@ -16,6 +16,8 @@ func testPrepareResponseHeaderInjection(ts *Test) {
 		spec.UseKeylessAccess = true
 		spec.Proxy.ListenPath = "/"
 		spec.OrgID = "default"
+		spec.DisableRateLimit = true
+		spec.DisableQuota = true
 		UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
 			v.UseExtendedPaths = true
 			json.Unmarshal([]byte(`[
@@ -136,10 +138,6 @@ func BenchmarkResponseHeaderInjection(b *testing.B) {
 	}
 
 	deleteHeaders := map[string]string{
-		"X-Tyk-Test":         "1",
-		cachedResponseHeader: "1",
-	}
-	deleteHeadersCached := map[string]string{
 		"X-Tyk-Test": "1",
 	}
 
@@ -151,9 +149,12 @@ func BenchmarkResponseHeaderInjection(b *testing.B) {
 			{Method: "GET", Path: "/test-with-slash", HeadersMatch: addHeaders, HeadersNotMatch: deleteHeaders},
 			{Method: "GET", Path: "/test-no-slash", HeadersMatch: addHeaders, HeadersNotMatch: deleteHeaders},
 			{Method: "GET", Path: "/rewrite-test", HeadersMatch: addHeaders, HeadersNotMatch: deleteHeaders, BodyMatch: `"Url":"/newpath"`},
-			{Method: "GET", Path: "/rewrite-test", HeadersMatch: addHeadersCached, HeadersNotMatch: deleteHeadersCached, BodyMatch: `"X-I-Am":"Request"`},
-			{Method: "GET", Path: "/rewrite-test", HeadersMatch: addHeadersCached, HeadersNotMatch: deleteHeadersCached, BodyMatch: userAgent},
+			{Method: "GET", Path: "/rewrite-test", HeadersMatch: addHeadersCached, HeadersNotMatch: deleteHeaders, BodyMatch: `"X-I-Am":"Request"`},
+			{Method: "GET", Path: "/rewrite-test", HeadersMatch: addHeadersCached, HeadersNotMatch: deleteHeaders, BodyMatch: userAgent},
 		}...)
+
+		// It's a loop, first time won't be cached.
+		addHeaders[cachedResponseHeader] = "1"
 	}
 }
 

--- a/gateway/session_manager.go
+++ b/gateway/session_manager.go
@@ -51,6 +51,9 @@ type SessionLimiter struct {
 	limiterStorage redis.UniversalClient
 }
 
+// Encourage reuse in NewSessionLimiter.
+var sessionLimiterBucketStore = memorycache.New()
+
 // NewSessionLimiter initializes the session limiter.
 //
 // The session limiter initializes the storage required for rate limiters.
@@ -63,7 +66,7 @@ func NewSessionLimiter(ctx context.Context, conf *config.Config, drlManager *drl
 		ctx:         ctx,
 		drlManager:  drlManager,
 		config:      conf,
-		bucketStore: memorycache.New(),
+		bucketStore: sessionLimiterBucketStore,
 	}
 
 	log.Infof("[RATELIMIT] %s", conf.RateLimit.String())


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-13819" title="TT-13819" target="_blank">TT-13819</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Local testing, run and collect go test benchmarks across releases</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20SESAP%20ORDER%20BY%20created%20DESC" title="SESAP">SESAP</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

[TT-13819] Benchmark updates, session limiter workaround for test goroutine leak (#6826)

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added `DisableRateLimit` and `DisableQuota` flags in multiple test
cases.

- Improved benchmark scripts and added skipping for specific benchmarks.

- Refactored session limiter to encourage reuse of `bucketStore`.

- Updated CI benchmark script for better profiling and output.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>7
files</summary><table>
<tr>
<td><strong>api_definition_test.go</strong><dd><code>Added
<code>DisableRateLimit</code> and <code>DisableQuota</code> flags in API
definition tests</code></dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6826/files#diff-2394daab6fdc5f8dc234699c80c0548947ee3d68d2e33858258d73a8b5eb6f44">+2/-0</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
<td><strong>event_system_test.go</strong><dd><code>Added benchmark
skipping for generic event handlers</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6826/files#diff-59fda3ebcb87e3c16f222e51988dfb18be9239c84caeef0137db04ffe9ab8f3c">+2/-0</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
<td><strong>mw_basic_auth_test.go</strong><dd><code>Added
`DisableRateLimit` and `DisableQuota` flags in basic auth
tests</code></dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6826/files#diff-148b4d4c5c77fa4382e83fd583c36d21bba7b52217f821095abbc517d277b16f">+2/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
<td><strong>mw_jwt_test.go</strong><dd><code>Added `DisableRateLimit`
and `DisableQuota` flags in JWT tests</code></dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6826/files#diff-406bf8fdb6c0cc77f04c6245c70abfc592ddb1525aa843200d850e14d135ebfc">+10/-0</a>&nbsp;
&nbsp; </td>

</tr>

<tr>
<td><strong>mw_transform_test.go</strong><dd><code>Refactored transform
middleware benchmarks for better structure</code></dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6826/files#diff-ec6f80b3dcb001b2a2ac9b7277fff606bd77d796f99b8c1d10b8d0d55863deb3">+9/-7</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
<td><strong>oauth_manager_test.go</strong><dd><code>Added benchmark
skipping for OAuth token purging</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6826/files#diff-139c3beb238f234728bde9f619f501cf730a7e275d17c8511277272d1dcd6fc6">+2/-0</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>

<td><strong>res_handler_header_injector_test.go</strong><dd><code>Adjusted
header injection benchmarks and test cases</code>&nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6826/files#diff-1c82da1ac85593e31ce947ef821703967ceb8065a5434c6749b802a1b93f9117">+7/-6</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2
files</summary><table>
<tr>
<td><strong>session_manager.go</strong><dd><code>Refactored session
limiter to reuse `bucketStore`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6826/files#diff-e6b40a285464cd86736e970c4c0b320b44c75b18b363d38c200e9a9d36cdabb6">+4/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
<td><strong>ci-benchmark.sh</strong><dd><code>Enhanced CI benchmark
script with profiling and output improvements</code></dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6826/files#diff-e789974499a5ba77194df612e751bc3db20b73c389466c679e4e74521199dd48">+9/-3</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration
changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
<td><strong>CODEOWNERS</strong><dd><code>Updated ownership for `/bin/`
directory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6826/files#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7">+1/-0</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull
request to receive relevant information

---------

Co-authored-by: Tit Petric <tit@tyk.io>

[TT-13819]: https://tyktech.atlassian.net/browse/TT-13819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added `DisableRateLimit` and `DisableQuota` flags in multiple test cases.

- Refactored session limiter to reuse `bucketStore` for efficiency.

- Enhanced CI benchmark script with profiling and output improvements.

- Improved and refactored test benchmarks for better structure and skipping.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>api_definition_test.go</strong><dd><code>Added `DisableRateLimit` and `DisableQuota` flags in API tests</code></dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6831/files#diff-2394daab6fdc5f8dc234699c80c0548947ee3d68d2e33858258d73a8b5eb6f44">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>event_system_test.go</strong><dd><code>Added benchmark skipping for generic event handlers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6831/files#diff-59fda3ebcb87e3c16f222e51988dfb18be9239c84caeef0137db04ffe9ab8f3c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mw_basic_auth_test.go</strong><dd><code>Added `DisableRateLimit` and `DisableQuota` flags in basic auth tests</code></dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6831/files#diff-148b4d4c5c77fa4382e83fd583c36d21bba7b52217f821095abbc517d277b16f">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mw_jwt_test.go</strong><dd><code>Added `DisableRateLimit` and `DisableQuota` flags in JWT tests</code></dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6831/files#diff-406bf8fdb6c0cc77f04c6245c70abfc592ddb1525aa843200d850e14d135ebfc">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mw_transform_test.go</strong><dd><code>Refactored transform middleware benchmarks for better structure</code></dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6831/files#diff-ec6f80b3dcb001b2a2ac9b7277fff606bd77d796f99b8c1d10b8d0d55863deb3">+34/-33</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>mw_version_check_test.go</strong><dd><code>Added `DisableRateLimit` and `DisableQuota` flags in versioning tests</code></dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6831/files#diff-ed8d515ea6f4f1a67801c8eb3ac5f195d36dac57a2dff6da736886f8772941ae">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>oauth_manager_test.go</strong><dd><code>Added benchmark skipping for OAuth token purging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6831/files#diff-139c3beb238f234728bde9f619f501cf730a7e275d17c8511277272d1dcd6fc6">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>res_handler_header_injector_test.go</strong><dd><code>Adjusted header injection benchmarks and test cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6831/files#diff-1c82da1ac85593e31ce947ef821703967ceb8065a5434c6749b802a1b93f9117">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>session_manager.go</strong><dd><code>Refactored session limiter to reuse `bucketStore`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6831/files#diff-e6b40a285464cd86736e970c4c0b320b44c75b18b363d38c200e9a9d36cdabb6">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ci-benchmark.sh</strong><dd><code>Enhanced CI benchmark script with profiling improvements</code>&nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6831/files#diff-e789974499a5ba77194df612e751bc3db20b73c389466c679e4e74521199dd48">+13/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>CODEOWNERS</strong><dd><code>Updated ownership for `/bin/` directory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6831/files#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7">+9/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information