### PR TITLE
[TT-11909]: fix oas bug on session lifetime and add respect expiry

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -738,7 +738,6 @@ type APIDefinition struct {
 	CacheOptions                         CacheOptions           `bson:"cache_options" json:"cache_options"`
 	SessionLifetimeRespectsKeyExpiration bool                   `bson:"session_lifetime_respects_key_expiration" json:"session_lifetime_respects_key_expiration,omitempty"`
 	SessionLifetime                      int64                  `bson:"session_lifetime" json:"session_lifetime"`
-	SessionLifetimeDisabled              bool                   `bson:"session_lifetime_disabled" json:"session_lifetime_disabled"`
 	Active                               bool                   `bson:"active" json:"active"`
 	Internal                             bool                   `bson:"internal" json:"internal"`
 	AuthProvider                         AuthProviderMeta       `bson:"auth_provider" json:"auth_provider"`

--- a/apidef/migration.go
+++ b/apidef/migration.go
@@ -439,7 +439,6 @@ func (a *APIDefinition) SetDisabledFlags() {
 	a.Proxy.ServiceDiscovery.CacheDisabled = true
 	a.UptimeTests.Config.ServiceDiscovery.CacheDisabled = true
 	a.DisableExpireAnalytics = true
-	a.SessionLifetimeDisabled = true
 
 	for i := 0; i < len(a.CustomMiddleware.Pre); i++ {
 		a.CustomMiddleware.Pre[i].Disabled = true

--- a/apidef/migration_test.go
+++ b/apidef/migration_test.go
@@ -677,7 +677,6 @@ func TestSetDisabledFlags(t *testing.T) {
 		DomainDisabled:                 true,
 		CustomMiddlewareBundleDisabled: true,
 		ConfigDataDisabled:             true,
-		SessionLifetimeDisabled:        true,
 		Proxy: ProxyConfig{
 			ServiceDiscovery: ServiceDiscoveryConfiguration{
 				CacheDisabled: true,

--- a/apidef/oas/authentication.go
+++ b/apidef/oas/authentication.go
@@ -86,7 +86,7 @@ type KeyRetentionPeriod struct {
 	// Tyk classic API definition: `expire_analytics_after`.
 	Value ReadableDuration `bson:"value" json:"value"`
 	// RespectExpiry ensures that Tyk respects the expiry configured in the key when the API level configuration grants a shorter lifetime.
-	//That is, Redis waits the key expiration for physical removal.
+	//That is, Redis waits until the the key has expired before deleting it.
 	RespectExpiry bool `bson:"respectExpiry,omitempty" json:"respectExpiry,omitempty"`
 }
 

--- a/apidef/oas/authentication.go
+++ b/apidef/oas/authentication.go
@@ -85,18 +85,23 @@ type KeyRetentionPeriod struct {
 	//
 	// Tyk classic API definition: `expire_analytics_after`.
 	Value ReadableDuration `bson:"value" json:"value"`
+	// RespectExpiry respects the key expiration time when the session lifetime is less than the key expiration.
+	//That is, Redis waits the key expiration for physical removal.
+	RespectExpiry bool `bson:"respectExpiry,omitempty" json:"respectExpiry,omitempty"`
 }
 
 // Fill fills *KeyRetentionPeriod from apidef.APIDefinition.
 func (k *KeyRetentionPeriod) Fill(api apidef.APIDefinition) {
 	k.Enabled = !api.SessionLifetimeDisabled
-	k.Value = ReadableDuration(time.Duration(api.ExpireAnalyticsAfter) * time.Second)
+	k.Value = ReadableDuration(time.Duration(api.SessionLifetime) * time.Second)
+	k.RespectExpiry = api.SessionLifetimeRespectsKeyExpiration
 }
 
 // ExtractTo extracts *Authentication into *apidef.APIDefinition.
 func (k *KeyRetentionPeriod) ExtractTo(api *apidef.APIDefinition) {
 	api.SessionLifetimeDisabled = !k.Enabled
 	api.SessionLifetime = int64(k.Value.Seconds())
+	api.SessionLifetimeRespectsKeyExpiration = k.RespectExpiry
 }
 
 // Fill fills *Authentication from apidef.APIDefinition.

--- a/apidef/oas/authentication.go
+++ b/apidef/oas/authentication.go
@@ -86,7 +86,7 @@ type CustomKeyLifetime struct {
 	// Tyk classic API definition: `expire_analytics_after`.
 	Value ReadableDuration `bson:"value" json:"value"`
 	// RespectValidity ensures that Tyk respects the expiry configured in the key when the API level configuration grants a shorter lifetime.
-	//That is, Redis waits until the key has expired before deleting it.
+	// That is, Redis waits until the key has expired before deleting it.
 	RespectValidity bool `bson:"respectValidity,omitempty" json:"respectValidity,omitempty"`
 }
 
@@ -132,7 +132,9 @@ func (a *Authentication) Fill(api apidef.APIDefinition) {
 	if a.CustomKeyLifetime == nil {
 		a.CustomKeyLifetime = &CustomKeyLifetime{}
 	}
+
 	a.CustomKeyLifetime.Fill(api)
+
 	if ShouldOmit(a.CustomKeyLifetime) {
 		a.CustomKeyLifetime = nil
 	}
@@ -195,6 +197,7 @@ func (a *Authentication) ExtractTo(api *apidef.APIDefinition) {
 			a.CustomKeyLifetime = nil
 		}()
 	}
+
 	a.CustomKeyLifetime.ExtractTo(api)
 }
 

--- a/apidef/oas/authentication.go
+++ b/apidef/oas/authentication.go
@@ -85,7 +85,7 @@ type KeyRetentionPeriod struct {
 	//
 	// Tyk classic API definition: `expire_analytics_after`.
 	Value ReadableDuration `bson:"value" json:"value"`
-	// RespectExpiry respects the key expiration time when the session lifetime is less than the key expiration.
+	// RespectExpiry ensures that Tyk respects the expiry configured in the key when the API level configuration grants a shorter lifetime.
 	//That is, Redis waits the key expiration for physical removal.
 	RespectExpiry bool `bson:"respectExpiry,omitempty" json:"respectExpiry,omitempty"`
 }

--- a/apidef/oas/authentication_test.go
+++ b/apidef/oas/authentication_test.go
@@ -2,6 +2,7 @@ package oas
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -123,6 +124,39 @@ func TestOIDC(t *testing.T) {
 
 		assert.Len(t, api.OpenIDOptions.Providers, 1)
 		assert.Equal(t, "5678", api.OpenIDOptions.Providers[0].Issuer)
+	})
+}
+
+func TestKeyRetentionPeriod(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		var emptyKeyRetentionPeriod KeyRetentionPeriod
+		var convertedAPI apidef.APIDefinition
+		var resultKeyRetentionPeriod KeyRetentionPeriod
+
+		convertedAPI.SetDisabledFlags()
+		emptyKeyRetentionPeriod.ExtractTo(&convertedAPI)
+		resultKeyRetentionPeriod.Fill(convertedAPI)
+
+		assert.Equal(t, emptyKeyRetentionPeriod, resultKeyRetentionPeriod)
+	})
+
+	t.Run("filled", func(t *testing.T) {
+		var keyRetentionPeriod = KeyRetentionPeriod{
+			Enabled:       true,
+			Value:         ReadableDuration(5 * time.Minute),
+			RespectExpiry: true,
+		}
+		var convertedAPI apidef.APIDefinition
+		var resultKeyRetentionPeriod KeyRetentionPeriod
+
+		keyRetentionPeriod.ExtractTo(&convertedAPI)
+
+		assert.Equal(t, int64(300), convertedAPI.SessionLifetime)
+		assert.True(t, convertedAPI.SessionLifetimeRespectsKeyExpiration)
+
+		resultKeyRetentionPeriod.Fill(convertedAPI)
+
+		assert.Equal(t, keyRetentionPeriod, resultKeyRetentionPeriod)
 	})
 }
 

--- a/apidef/oas/authentication_test.go
+++ b/apidef/oas/authentication_test.go
@@ -129,25 +129,27 @@ func TestOIDC(t *testing.T) {
 
 func TestKeyRetentionPeriod(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		var emptyKeyRetentionPeriod KeyRetentionPeriod
+		var emptyCustomKeyLifetime CustomKeyLifetime
 		var convertedAPI apidef.APIDefinition
-		var resultKeyRetentionPeriod KeyRetentionPeriod
+		var resultCustomKeyLifetime CustomKeyLifetime
 
 		convertedAPI.SetDisabledFlags()
-		emptyKeyRetentionPeriod.ExtractTo(&convertedAPI)
-		resultKeyRetentionPeriod.Fill(convertedAPI)
+		emptyCustomKeyLifetime.ExtractTo(&convertedAPI)
+		resultCustomKeyLifetime.Fill(convertedAPI)
 
-		assert.Equal(t, emptyKeyRetentionPeriod, resultKeyRetentionPeriod)
+		assert.Equal(t, int64(0), convertedAPI.SessionLifetime)
+
+		assert.Equal(t, emptyCustomKeyLifetime, resultCustomKeyLifetime)
 	})
 
 	t.Run("filled", func(t *testing.T) {
-		var keyRetentionPeriod = KeyRetentionPeriod{
-			Enabled:       true,
-			Value:         ReadableDuration(5 * time.Minute),
-			RespectExpiry: true,
+		var keyRetentionPeriod = CustomKeyLifetime{
+			Enabled:         true,
+			Value:           ReadableDuration(5 * time.Minute),
+			RespectValidity: true,
 		}
 		var convertedAPI apidef.APIDefinition
-		var resultKeyRetentionPeriod KeyRetentionPeriod
+		var resultKeyRetentionPeriod CustomKeyLifetime
 
 		keyRetentionPeriod.ExtractTo(&convertedAPI)
 

--- a/apidef/oas/authentication_test.go
+++ b/apidef/oas/authentication_test.go
@@ -143,7 +143,7 @@ func TestKeyRetentionPeriod(t *testing.T) {
 	})
 
 	t.Run("filled", func(t *testing.T) {
-		var keyRetentionPeriod = CustomKeyLifetime{
+		keyRetentionPeriod := CustomKeyLifetime{
 			Enabled:         true,
 			Value:           ReadableDuration(5 * time.Minute),
 			RespectValidity: true,
@@ -178,7 +178,7 @@ func TestCustomPlugin(t *testing.T) {
 
 	t.Run("values", func(t *testing.T) {
 		t.Run("goplugin", func(t *testing.T) {
-			var expectedCustomPluginAuth = CustomPluginAuthentication{
+			expectedCustomPluginAuth := CustomPluginAuthentication{
 				Enabled: true,
 				Config: &AuthenticationPlugin{
 					Enabled:      true,
@@ -199,7 +199,7 @@ func TestCustomPlugin(t *testing.T) {
 		})
 
 		t.Run("coprocess", func(t *testing.T) {
-			var expectedCustomPluginAuth = CustomPluginAuthentication{
+			expectedCustomPluginAuth := CustomPluginAuthentication{
 				Enabled: true,
 				Config: &AuthenticationPlugin{
 					Enabled:      true,
@@ -225,7 +225,6 @@ func TestCustomPlugin(t *testing.T) {
 			assert.NotEmpty(t, actualCustomPluginAuth.AuthSources)
 		})
 	})
-
 }
 
 func TestIDExtractorConfig(t *testing.T) {
@@ -246,7 +245,8 @@ func TestIDExtractorConfig(t *testing.T) {
 
 	t.Run("values", func(t *testing.T) {
 		t.Parallel()
-		var expectedIDExtractorConfig = IDExtractorConfig{
+
+		expectedIDExtractorConfig := IDExtractorConfig{
 			HeaderName:       "Authorization",
 			FormParamName:    "Authorization",
 			RegexpMatchIndex: 1,
@@ -283,7 +283,8 @@ func TestIDExtractor(t *testing.T) {
 
 	t.Run("values", func(t *testing.T) {
 		t.Parallel()
-		var expectedIDExtractor = IDExtractor{
+
+		expectedIDExtractor := IDExtractor{
 			Enabled: true,
 			Source:  apidef.HeaderSource,
 			With:    apidef.ValueExtractor,

--- a/apidef/oas/linter_test.go
+++ b/apidef/oas/linter_test.go
@@ -85,7 +85,7 @@ func TestXTykGateway_Lint(t *testing.T) {
 		}
 
 		settings.Upstream.RateLimit.Per = ReadableDuration(10 * time.Second)
-		settings.Server.Authentication.KeyRetentionPeriod.Value = ReadableDuration(10 * time.Second)
+		settings.Server.Authentication.CustomKeyLifetime.Value = ReadableDuration(10 * time.Second)
 
 		settings.Upstream.Authentication = &UpstreamAuth{
 			Enabled:   false,

--- a/apidef/oas/oas_test.go
+++ b/apidef/oas/oas_test.go
@@ -252,7 +252,6 @@ func TestOAS_ExtractTo_ResetAPIDefinition(t *testing.T) {
 		"APIDefinition.Proxy.Transport.SSLForceCommonNameCheck",
 		"APIDefinition.Proxy.Transport.ProxyURL",
 		"APIDefinition.DisableQuota",
-		"APIDefinition.SessionLifetimeRespectsKeyExpiration",
 		"APIDefinition.AuthProvider.Name",
 		"APIDefinition.AuthProvider.StorageEngine",
 		"APIDefinition.AuthProvider.Meta[0]",

--- a/apidef/oas/oas_test.go
+++ b/apidef/oas/oas_test.go
@@ -175,7 +175,6 @@ func TestOAS_ExtractTo_ResetAPIDefinition(t *testing.T) {
 	a.DoNotTrack = false
 	a.IPAccessControlDisabled = false
 	a.DisableExpireAnalytics = false
-	a.SessionLifetimeDisabled = false
 
 	// deprecated fields
 	a.Auth = apidef.AuthConfig{}
@@ -1052,10 +1051,6 @@ func TestMigrateAndFillOAS_CustomPluginAuth(t *testing.T) {
 					Path:         "/path/to/plugin",
 				},
 			},
-			KeyRetentionPeriod: &KeyRetentionPeriod{
-				Enabled: true,
-				Value:   0,
-			},
 		}
 
 		assert.Equal(t, expectedAuthentication, *migratedAPI.OAS.GetTykExtension().Server.Authentication)
@@ -1105,10 +1100,6 @@ func TestMigrateAndFillOAS_CustomPluginAuth(t *testing.T) {
 						Name:    "Authorization",
 					},
 				},
-			},
-			KeyRetentionPeriod: &KeyRetentionPeriod{
-				Enabled: true,
-				Value:   0,
 			},
 		}
 

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -1213,6 +1213,9 @@
             "value": {
               "type": "string",
               "pattern": "^(\\d+h)?(\\d+m)?(\\d+s)?$"
+            },
+            "respectExpiry": {
+              "type": "boolean"
             }
           },
           "required": [

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -1204,7 +1204,7 @@
             }
           }
         },
-        "keyRetentionPeriod": {
+        "customKeyLifetime": {
           "type": "object",
           "properties": {
             "enabled": {
@@ -1212,9 +1212,12 @@
             },
             "value": {
               "type": "string",
-              "pattern": "^(\\d+h)?(\\d+m)?(\\d+s)?$"
+              "pattern": "^(\\d+h)?(\\d+m)?(\\d+s)?$",
+              "not": {
+                "pattern": "^(0h)?(0m)?(0s)?$"
+              }
             },
-            "respectExpiry": {
+            "respectValidity": {
               "type": "boolean"
             }
           },


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-11909" title="TT-11909" target="_blank">TT-11909</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>[OAS] Session lifetime </td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20QA_Fail%20ORDER%20BY%20created%20DESC" title="QA_Fail">QA_Fail</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->
[TT-11909](https://tyktech.atlassian.net/browse/TT-11909)

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


[TT-11909]: https://tyktech.atlassian.net/browse/TT-11909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Tests, Enhancement


___

### **Description**
- Added `RespectExpiry` field to `KeyRetentionPeriod` for session lifetime handling.

- Updated logic to respect key expiration in `Fill` and `ExtractTo` methods.

- Introduced unit tests for `KeyRetentionPeriod` to validate new functionality.

- Enhanced OpenAPI schema with `respectExpiry` property for `keyRetentionPeriod`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>authentication.go</strong><dd><code>Add `RespectExpiry` field and update logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/authentication.go

<li>Added <code>RespectExpiry</code> field to <code>KeyRetentionPeriod</code> struct.<br> <li> Updated <code>Fill</code> and <code>ExtractTo</code> methods to handle <code>RespectExpiry</code>.<br> <li> Adjusted <code>Value</code> logic to align with <code>SessionLifetime</code>.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6842/files#diff-e51c9d24d4235e7cc53048cc1d92967d177585ba5e073f14876308a97bef6326">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>x-tyk-api-gateway.json</strong><dd><code>Update OpenAPI schema with `respectExpiry`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/schema/x-tyk-api-gateway.json

<li>Added <code>respectExpiry</code> property to <code>keyRetentionPeriod</code> schema.<br> <li> Updated OpenAPI schema to reflect new functionality.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6842/files#diff-78828969c0c04cc1a776dfc93a8bad3c499a8c83e6169f83e96d090bed3e7dd0">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>authentication_test.go</strong><dd><code>Add tests for `KeyRetentionPeriod` and `RespectExpiry`</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/authentication_test.go

<li>Added unit tests for <code>KeyRetentionPeriod</code> functionality.<br> <li> Validated <code>RespectExpiry</code> behavior in <code>ExtractTo</code> and <code>Fill</code> methods.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6842/files#diff-039d0613514b07cabea08e47b93ef0a9c4500ed188f1ef040f8ddee65dd34487">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>oas_test.go</strong><dd><code>Remove redundant test case</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/oas_test.go

<li>Removed redundant test case for <code>SessionLifetimeRespectsKeyExpiration</code>.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6842/files#diff-74029ee88132d30d6478c96a35f8bb2200e0c8e6f42f2c9b147dc6bb7ce74644">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information