### PR TITLE
[TT-13657]: Add protocol and port to oas

### DIFF
--- a/apidef/oas/linter_test.go
+++ b/apidef/oas/linter_test.go
@@ -91,6 +91,7 @@ func TestXTykGateway_Lint(t *testing.T) {
 			OAuth:     nil,
 		}
 		settings.Middleware.Global.TrafficLogs.RetentionPeriod.Value = ReadableDuration(time.Minute * 10)
+		settings.Server.Protocol = "http"
 	}
 
 	// Encode data to json

--- a/apidef/oas/linter_test.go
+++ b/apidef/oas/linter_test.go
@@ -92,6 +92,7 @@ func TestXTykGateway_Lint(t *testing.T) {
 		}
 		settings.Middleware.Global.TrafficLogs.RetentionPeriod.Value = ReadableDuration(time.Minute * 10)
 		settings.Server.Protocol = "http"
+		settings.Server.Port = 3000
 	}
 
 	// Encode data to json

--- a/apidef/oas/linter_test.go
+++ b/apidef/oas/linter_test.go
@@ -71,6 +71,8 @@ func TestXTykGateway_Lint(t *testing.T) {
 		settings.Server.Authentication.SecuritySchemes = map[string]interface{}{
 			"test-basic": securityScheme,
 		}
+		settings.Server.Protocol = "http"
+		settings.Server.Port = 3000
 		for i := range settings.Server.EventHandlers {
 			settings.Server.EventHandlers[i].Kind = event.WebhookKind
 			settings.Server.EventHandlers[i].Webhook.Method = http.MethodPost
@@ -91,8 +93,6 @@ func TestXTykGateway_Lint(t *testing.T) {
 			OAuth:     nil,
 		}
 		settings.Middleware.Global.TrafficLogs.RetentionPeriod.Value = ReadableDuration(time.Minute * 10)
-		settings.Server.Protocol = "http"
-		settings.Server.Port = 3000
 	}
 
 	// Encode data to json

--- a/apidef/oas/oas_test.go
+++ b/apidef/oas/oas_test.go
@@ -211,8 +211,6 @@ func TestOAS_ExtractTo_ResetAPIDefinition(t *testing.T) {
 
 	expectedFields := []string{
 		"APIDefinition.Slug",
-		"APIDefinition.ListenPort",
-		"APIDefinition.Protocol",
 		"APIDefinition.EnableProxyProtocol",
 		"APIDefinition.RequestSigning.IsEnabled",
 		"APIDefinition.RequestSigning.Secret",

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -1267,7 +1267,9 @@
           "$ref": "#/definitions/X-Tyk-IPAccessControl"
         },
         "port": {
-          "type": "integer"
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
         },
         "protocol": {
           "type": "string",

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -1265,6 +1265,17 @@
         },
         "ipAccessControl": {
           "$ref": "#/definitions/X-Tyk-IPAccessControl"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "protocol": {
+          "type": "string",
+          "enum": [
+            "http",
+            "http2",
+            "h2c"
+          ]
         }
       },
       "required": [

--- a/apidef/oas/server.go
+++ b/apidef/oas/server.go
@@ -43,10 +43,21 @@ type Server struct {
 	//
 	// Tyk classic API definition: `allowed_ips` and `blacklisted_ips`.
 	IPAccessControl *IPAccessControl `bson:"ipAccessControl,omitempty" json:"ipAccessControl,omitempty"`
+	// Protocol configures the HTTP protocol used by the API.
+	// Possible values are:
+	// - "http": Standard HTTP/1.1 protocol
+	// - "http2": HTTP/2 protocol with TLS
+	// - "h2c": HTTP/2 protocol without TLS (cleartext).
+	Protocol string `bson:"protocol" json:"protocol"`
+	// Port Setting this value will change the port that Tyk listens on. Default: 8080.
+	Port int `bson:"port" json:"port"`
 }
 
 // Fill fills *Server from apidef.APIDefinition.
 func (s *Server) Fill(api apidef.APIDefinition) {
+	s.Protocol = api.Protocol
+	s.Port = api.ListenPort
+
 	s.ListenPath.Fill(api)
 
 	if s.ClientCertificates == nil {
@@ -105,6 +116,8 @@ func (s *Server) Fill(api apidef.APIDefinition) {
 
 // ExtractTo extracts *Server into *apidef.APIDefinition.
 func (s *Server) ExtractTo(api *apidef.APIDefinition) {
+	api.Protocol = s.Protocol
+	api.ListenPort = s.Port
 	s.ListenPath.ExtractTo(api)
 
 	if s.ClientCertificates == nil {

--- a/apidef/oas/server.go
+++ b/apidef/oas/server.go
@@ -48,9 +48,9 @@ type Server struct {
 	// - "http": Standard HTTP/1.1 protocol
 	// - "http2": HTTP/2 protocol with TLS
 	// - "h2c": HTTP/2 protocol without TLS (cleartext).
-	Protocol string `bson:"protocol" json:"protocol"`
+	Protocol string `bson:"protocol,omitempty" json:"protocol,omitempty"`
 	// Port Setting this value will change the port that Tyk listens on. Default: 8080.
-	Port int `bson:"port" json:"port"`
+	Port int `bson:"port,omitempty" json:"port,omitempty"`
 }
 
 // Fill fills *Server from apidef.APIDefinition.

--- a/apidef/oas/server_test.go
+++ b/apidef/oas/server_test.go
@@ -10,18 +10,38 @@ import (
 )
 
 func TestServer(t *testing.T) {
-	t.Parallel()
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
 
-	var emptyServer Server
+		var emptyServer Server
 
-	var convertedAPI apidef.APIDefinition
-	convertedAPI.SetDisabledFlags()
-	emptyServer.ExtractTo(&convertedAPI)
+		var convertedAPI apidef.APIDefinition
+		convertedAPI.SetDisabledFlags()
+		emptyServer.ExtractTo(&convertedAPI)
 
-	var resultServer Server
-	resultServer.Fill(convertedAPI)
+		var resultServer Server
+		resultServer.Fill(convertedAPI)
 
-	assert.Equal(t, emptyServer, resultServer)
+		assert.Equal(t, emptyServer, resultServer)
+	})
+
+	t.Run("port protocol", func(t *testing.T) {
+		var server = Server{
+			Port:     3000,
+			Protocol: "http",
+		}
+		var convertedAPI apidef.APIDefinition
+		var resultServer Server
+
+		server.ExtractTo(&convertedAPI)
+
+		assert.Equal(t, server.Port, convertedAPI.ListenPort)
+		assert.Equal(t, server.Protocol, convertedAPI.Protocol)
+
+		resultServer.Fill(convertedAPI)
+		assert.Equal(t, server, resultServer)
+	})
+
 }
 
 func TestListenPath(t *testing.T) {


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-13657" title="TT-13657" target="_blank">TT-13657</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>[OAS] Granular control over client>gateway HTTP</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->
[TT-13657](https://tyktech.atlassian.net/browse/TT-13657)

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


[TT-13657]: https://tyktech.atlassian.net/browse/TT-13657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added `protocol` and `port` fields to the `Server` struct.

- Updated JSON schema to include `protocol` and `port` definitions.

- Enhanced tests to validate `protocol` and `port` functionality.

- Removed unused fields from migration tests.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>linter_test.go</strong><dd><code>Add default `protocol` value in linter test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/linter_test.go

- Added a default value for the `protocol` field in test settings.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6846/files#diff-b92239afd81e77a829fe7fe8410044dfd4dfda525d17dbf5f8811714a9c986d3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>oas_test.go</strong><dd><code>Remove unused fields from migration tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/oas_test.go

<li>Removed <code>ListenPort</code> and <code>Protocol</code> from the list of non-migrated fields.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6846/files#diff-74029ee88132d30d6478c96a35f8bb2200e0c8e6f42f2c9b147dc6bb7ce74644">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>server_test.go</strong><dd><code>Add tests for `protocol` and `port` in Server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/server_test.go

<li>Added test cases for <code>protocol</code> and <code>port</code> functionality.<br> <li> Enhanced test structure with sub-tests.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6846/files#diff-a194795077946243b2b6d04b30be360dbafff8e5eb03e6212081e45d1c72573f">+28/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.go</strong><dd><code>Add `protocol` and `port` fields to Server struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/server.go

<li>Added <code>protocol</code> and <code>port</code> fields to the <code>Server</code> struct.<br> <li> Updated <code>Fill</code> and <code>ExtractTo</code> methods to handle <code>protocol</code> and <code>port</code>.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6846/files#diff-21857c42e8659f7980014e277c3c758703f29e9e5c0c40553f2584cddb870808">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>x-tyk-api-gateway.json</strong><dd><code>Update JSON schema with `protocol` and `port` definitions</code></dd></summary>
<hr>

apidef/oas/schema/x-tyk-api-gateway.json

<li>Added <code>protocol</code> and <code>port</code> definitions to the JSON schema.<br> <li> Defined valid values for the <code>protocol</code> field.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6846/files#diff-78828969c0c04cc1a776dfc93a8bad3c499a8c83e6169f83e96d090bed3e7dd0">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>