### PR TITLE
fix issue where upstream targets have been duplicated (TT-881)

### DIFF
--- a/apidef/oas/upstream.go
+++ b/apidef/oas/upstream.go
@@ -895,11 +895,7 @@ func (l *LoadBalancing) ExtractTo(api *apidef.APIDefinition) {
 		return
 	}
 
-	proxyConfTargets := api.Proxy.Targets
-	if proxyConfTargets == nil {
-		proxyConfTargets = make([]string, 0)
-	}
-
+	proxyConfTargets := make([]string, 0)
 	api.Proxy.EnableLoadBalancing = l.Enabled
 	for _, target := range l.Targets {
 		for i := 0; i < target.Weight; i++ {

--- a/apidef/oas/upstream_test.go
+++ b/apidef/oas/upstream_test.go
@@ -655,6 +655,11 @@ func TestLoadBalancing(t *testing.T) {
 				g.LoadBalancing = tc.input
 
 				var apiDef apidef.APIDefinition
+				apiDef.Proxy.Targets = []string{
+					"http://old1.upstream.test",
+					"http://old2.upstream.test",
+					"http://old3.upstream.test",
+				}
 				g.ExtractTo(&apiDef)
 
 				assert.Equal(t, tc.expectedEnabled, apiDef.Proxy.EnableLoadBalancing)


### PR DESCRIPTION
This PR fixes an issue where upstream targets are being duplicated therefore resulting in increased weights for load balancing.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)