### PR TITLE
TT-2539 - renamed access log fields

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -270,7 +270,7 @@ type AccessLogsConfig struct {
 	// - `path` will include the path of the request.
 	// - `protocol` will include the protocol of the request.
 	// - `remote_addr` will include the remote address of the request.
-	// - `upstream_address` will include the upstream address (scheme, host and path)
+	// - `upstream_addr` will include the upstream address (scheme, host and path)
 	// - `upstream_latency` will include the upstream latency of the request.
 	// - `latency_total` will include the total latency of the request.
 	// - `user_agent` will include the user agent of the request.

--- a/internal/httputil/accesslog/record.go
+++ b/internal/httputil/accesslog/record.go
@@ -56,7 +56,7 @@ func (a *Record) WithRequest(req *http.Request, latency analytics.Latency) *Reco
 	a.fields["path"] = req.URL.Path
 	a.fields["protocol"] = req.Proto
 	a.fields["remote_addr"] = req.RemoteAddr
-	a.fields["upstream_address"] = upstreamAddress.String()
+	a.fields["upstream_addr"] = upstreamAddress.String()
 	a.fields["upstream_latency"] = latency.Upstream
 	a.fields["user_agent"] = req.UserAgent()
 	return a

--- a/internal/httputil/accesslog/record_test.go
+++ b/internal/httputil/accesslog/record_test.go
@@ -44,7 +44,7 @@ func TestRecord(t *testing.T) {
 		"path":             "/path",
 		"protocol":         "HTTP/1.1",
 		"status":           http.StatusOK,
-		"upstream_address": "http://example.com/path",
+		"upstream_addr":    "http://example.com/path",
 		"upstream_latency": int64(101),
 		"user_agent":       "user-agent",
 	}


### PR DESCRIPTION
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-2539" title="TT-2539" target="_blank">TT-2539</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Transaction/Access Logs</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>Ready for Testing</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20A%20ORDER%20BY%20created%20DESC" title="A">A</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20America's%20ORDER%20BY%20created%20DESC" title="America's">America's</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20CSE%20ORDER%20BY%20created%20DESC" title="CSE">CSE</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20Gold%20ORDER%20BY%20created%20DESC" title="Gold">Gold</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20QA_Fail%20ORDER%20BY%20created%20DESC" title="QA_Fail">QA_Fail</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20customer_request%20ORDER%20BY%20created%20DESC" title="customer_request">customer_request</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20innersource%20ORDER%20BY%20created%20DESC" title="innersource">innersource</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20jira_escalated%20ORDER%20BY%20created%20DESC" title="jira_escalated">jira_escalated</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

Resolved the field names for the access logs to follow the standard format / nomenclature.

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
