### PR TITLE
TT-12965: Improve performance of ctx.GetOASDefinition/GetDefinition

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -75,9 +75,9 @@ tasks:
 
   lint:extras:
     desc: "Run more specific linters"
-    deps:
-      - coprocess:lint
-      - apidef-oas:lint
+    cmds:
+      - task: coprocess:lint
+      - task: apidef-oas:lint
 
   # Used in CI by hooks, lint.
   fmt:

--- a/apidef/oas/oas.go
+++ b/apidef/oas/oas.go
@@ -6,11 +6,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/TykTechnologies/tyk/config"
-
 	"github.com/getkin/kin-openapi/openapi3"
 
 	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/config"
 )
 
 const (
@@ -201,22 +200,6 @@ func (s *OAS) RemoveTykExtension() {
 	}
 
 	delete(s.Extensions, ExtensionTykAPIGateway)
-}
-
-// Clone creates a deep copy of the OAS object and returns a new instance.
-func (s *OAS) Clone() (*OAS, error) {
-	oasInBytes, err := json.Marshal(s)
-	if err != nil {
-		return nil, err
-	}
-
-	var retOAS OAS
-	_ = json.Unmarshal(oasInBytes, &retOAS)
-
-	// convert Tyk extension from map to struct
-	retOAS.GetTykExtension()
-
-	return &retOAS, nil
 }
 
 func (s *OAS) getTykAuthentication() (authentication *Authentication) {

--- a/apidef/oas/oas.go
+++ b/apidef/oas/oas.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/internal/reflect"
 )
 
 const (
@@ -200,6 +201,11 @@ func (s *OAS) RemoveTykExtension() {
 	}
 
 	delete(s.Extensions, ExtensionTykAPIGateway)
+}
+
+// Clone creates a deep copy of the OAS object and returns a new instance.
+func (s *OAS) Clone() (*OAS, error) {
+	return reflect.Clone(s), nil
 }
 
 func (s *OAS) getTykAuthentication() (authentication *Authentication) {

--- a/apidef/oas/oas_test.go
+++ b/apidef/oas/oas_test.go
@@ -768,6 +768,58 @@ func TestOAS_MarshalJSON(t *testing.T) {
 	})
 }
 
+func TestOAS_Clone(t *testing.T) {
+	s := &OAS{}
+	s.SetTykExtension(&XTykAPIGateway{Info: Info{
+		Name: "my-api",
+	}})
+
+	clonedOAS, err := s.Clone()
+	assert.NoError(t, err)
+	assert.Equal(t, s, clonedOAS)
+
+	s.GetTykExtension().Info.Name = "my-api-modified"
+	assert.NotEqual(t, s, clonedOAS)
+
+	t.Run("clone impossible to marshal value", func(t *testing.T) {
+		s.Extensions["weird extension"] = make(chan int)
+
+		result, err := s.Clone()
+		assert.NoError(t, err)
+
+		_, ok := result.Extensions["weird extension"]
+		assert.True(t, ok)
+	})
+}
+
+func BenchmarkOAS_Clone(b *testing.B) {
+	oas := &OAS{
+		T: openapi3.T{
+			Info: &openapi3.Info{
+				Title: "my-oas-doc",
+			},
+			Paths: map[string]*openapi3.PathItem{
+				"/get": {
+					Get: &openapi3.Operation{
+						Responses: openapi3.Responses{
+							"200": &openapi3.ResponseRef{
+								Value: &openapi3.Response{
+									Description: getStrPointer("some example endpoint"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for i := 0; i < b.N; i++ {
+		_, err := oas.Clone()
+		assert.NoError(b, err)
+	}
+}
+
 func TestMigrateAndFillOAS(t *testing.T) {
 	var api apidef.APIDefinition
 	api.SetDisabledFlags()

--- a/apidef/oas/oas_test.go
+++ b/apidef/oas/oas_test.go
@@ -768,54 +768,6 @@ func TestOAS_MarshalJSON(t *testing.T) {
 	})
 }
 
-func TestOAS_Clone(t *testing.T) {
-	s := &OAS{}
-	s.SetTykExtension(&XTykAPIGateway{Info: Info{
-		Name: "my-api",
-	}})
-
-	clonedOAS, err := s.Clone()
-	assert.NoError(t, err)
-	assert.Equal(t, s, clonedOAS)
-
-	s.GetTykExtension().Info.Name = "my-api-modified"
-	assert.NotEqual(t, s, clonedOAS)
-
-	t.Run("marshal error", func(t *testing.T) {
-		s.Extensions["weird extension"] = make(chan int)
-		_, err = s.Clone()
-		assert.ErrorContains(t, err, "unsupported type: chan int")
-	})
-}
-
-func BenchmarkOAS_Clone(b *testing.B) {
-	oas := &OAS{
-		T: openapi3.T{
-			Info: &openapi3.Info{
-				Title: "my-oas-doc",
-			},
-			Paths: map[string]*openapi3.PathItem{
-				"/get": {
-					Get: &openapi3.Operation{
-						Responses: openapi3.Responses{
-							"200": &openapi3.ResponseRef{
-								Value: &openapi3.Response{
-									Description: getStrPointer("some example endpoint"),
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	for i := 0; i < b.N; i++ {
-		_, err := oas.Clone()
-		assert.NoError(b, err)
-	}
-}
-
 func TestMigrateAndFillOAS(t *testing.T) {
 	var api apidef.APIDefinition
 	api.SetDisabledFlags()

--- a/coprocess/Taskfile.yml
+++ b/coprocess/Taskfile.yml
@@ -28,9 +28,6 @@ tasks:
   lint:
     desc: "Ensure linter pass"
     cmds:
-      # the replacement exists as a hack for:
-      # https://github.com/grpc/grpc-go/issues/7350
-      - sed -i -e 's/compatibility$/compatibility./g' *.pb.go
       - schema-gen extract -o - | schema-gen lint -i -
 
   deps:

--- a/ctx/Taskfile.yml
+++ b/ctx/Taskfile.yml
@@ -1,0 +1,34 @@
+---
+version: "3"
+
+vars:
+  coverage: ctx.cov
+
+tasks:
+  default:
+    desc: "Run everything"
+    cmds:
+      - task: fmt
+      - task: test
+
+  fmt:
+    desc: "Run formatters"
+    cmds:
+      - goimports -local github.com/TykTechnologies,github.com/TykTechnologies/tyk/internal -w .
+      - go fmt ./...
+
+  test:
+    desc: "Build/run tests"
+    cmds:
+      - go test -bench=. -benchtime=10s -race -cpu 1,2,4 -cover -coverprofile {{.coverage}} -coverpkg=$(go list .) -v .
+
+  cover:
+    desc: "Show source coverage"
+    aliases: [coverage, cov]
+    cmds:
+      - go tool cover -func={{.coverage}}
+
+  uncover:
+    desc: "Show uncovered source"
+    cmds:
+      - uncover {{.coverage}}

--- a/ctx/ctx.go
+++ b/ctx/ctx.go
@@ -5,16 +5,15 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/TykTechnologies/tyk/internal/httputil"
-
-	"github.com/TykTechnologies/tyk/apidef/oas"
-
-	"github.com/TykTechnologies/tyk/config"
-
 	"github.com/TykTechnologies/tyk/apidef"
-	logger "github.com/TykTechnologies/tyk/log"
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/internal/httputil"
+	"github.com/TykTechnologies/tyk/internal/reflect"
 	"github.com/TykTechnologies/tyk/storage"
 	"github.com/TykTechnologies/tyk/user"
+
+	logger "github.com/TykTechnologies/tyk/log"
 )
 
 type Key uint
@@ -57,7 +56,6 @@ const (
 )
 
 func ctxSetSession(r *http.Request, s *user.SessionState, scheduleUpdate bool, hashKey bool) {
-
 	if s == nil {
 		panic("setting a nil context SessionData")
 	}
@@ -84,7 +82,10 @@ func ctxSetSession(r *http.Request, s *user.SessionState, scheduleUpdate bool, h
 
 func GetAuthToken(r *http.Request) string {
 	if v := r.Context().Value(AuthToken); v != nil {
-		return v.(string)
+		value, ok := v.(string)
+		if ok {
+			return value
+		}
 	}
 	return ""
 }
@@ -114,45 +115,32 @@ func SetSession(r *http.Request, s *user.SessionState, scheduleUpdate bool, hash
 	}
 }
 
+// SetDefinition can be used to set a modified API definition to the request context.
 func SetDefinition(r *http.Request, s *apidef.APIDefinition) {
 	ctx := r.Context()
 	ctx = context.WithValue(ctx, Definition, s)
 	httputil.SetContext(r, ctx)
 }
 
+// GetDefinition will return a copy of the API definition valid for the request.
+// This copy is there to prevent shared API definition pointers.
 func GetDefinition(r *http.Request) *apidef.APIDefinition {
 	if v := r.Context().Value(Definition); v != nil {
 		if val, ok := v.(*apidef.APIDefinition); ok {
-			return val
-		} else {
-			logger.Get().Warning("APIDefinition struct differ from the gateway version, trying to unmarshal.")
-			def := apidef.APIDefinition{}
-			b, _ := json.Marshal(v)
-			e := json.Unmarshal(b, &def)
-			if e == nil {
-				return &def
-			}
+			return reflect.Clone(val)
 		}
 	}
+
 	return nil
 }
 
 // GetOASDefinition returns a deep copy of the OAS definition of the called API.
 func GetOASDefinition(r *http.Request) *oas.OAS {
-	v := r.Context().Value(OASDefinition)
-	if v == nil {
-		return nil
+	if v := r.Context().Value(OASDefinition); v != nil {
+		if val, ok := v.(*oas.OAS); ok {
+			return reflect.Clone(val)
+		}
 	}
 
-	val, ok := v.(*oas.OAS)
-	if !ok {
-		return nil
-	}
-
-	ret, err := val.Clone()
-	if err != nil {
-		logger.Get().WithError(err).Error("Cloning OAS object in the request context")
-	}
-
-	return ret
+	return nil
 }

--- a/ctx/ctx.go
+++ b/ctx/ctx.go
@@ -115,15 +115,14 @@ func SetSession(r *http.Request, s *user.SessionState, scheduleUpdate bool, hash
 	}
 }
 
-// SetDefinition can be used to set a modified API definition to the request context.
+// SetDefinition sets an API definition object to the request context.
 func SetDefinition(r *http.Request, s *apidef.APIDefinition) {
 	ctx := r.Context()
 	ctx = context.WithValue(ctx, Definition, s)
 	httputil.SetContext(r, ctx)
 }
 
-// GetDefinition will return a copy of the API definition valid for the request.
-// This copy is there to prevent shared API definition pointers.
+// GetDefinition will return a deep copy of the API definition valid for the request.
 func GetDefinition(r *http.Request) *apidef.APIDefinition {
 	if v := r.Context().Value(Definition); v != nil {
 		if val, ok := v.(*apidef.APIDefinition); ok {
@@ -134,7 +133,7 @@ func GetDefinition(r *http.Request) *apidef.APIDefinition {
 	return nil
 }
 
-// GetOASDefinition returns a deep copy of the OAS definition of the called API.
+// GetOASDefinition will return a deep copy of the OAS API definition valid for the request.
 func GetOASDefinition(r *http.Request) *oas.OAS {
 	if v := r.Context().Value(OASDefinition); v != nil {
 		if val, ok := v.(*oas.OAS); ok {

--- a/ctx/ctx.go
+++ b/ctx/ctx.go
@@ -133,6 +133,13 @@ func GetDefinition(r *http.Request) *apidef.APIDefinition {
 	return nil
 }
 
+// SetOASDefinition sets an OAS API definition object to the request context.
+func SetOASDefinition(r *http.Request, s *oas.OAS) {
+	ctx := r.Context()
+	ctx = context.WithValue(ctx, OASDefinition, s)
+	httputil.SetContext(r, ctx)
+}
+
 // GetOASDefinition will return a deep copy of the OAS API definition valid for the request.
 func GetOASDefinition(r *http.Request) *oas.OAS {
 	if v := r.Context().Value(OASDefinition); v != nil {

--- a/ctx/ctx_test.go
+++ b/ctx/ctx_test.go
@@ -1,0 +1,84 @@
+package ctx_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/ctx"
+	"github.com/TykTechnologies/tyk/internal/uuid"
+)
+
+// Test for GetDefinition
+func TestGetDefinition(t *testing.T) {
+	apiDef := &apidef.APIDefinition{
+		APIID: uuid.New(),
+	}
+
+	req := httptest.NewRequest("GET", "http://example.com", nil)
+
+	assert.Nil(t, ctx.GetDefinition(req))
+
+	ctx.SetDefinition(req, apiDef)
+	cloned := ctx.GetDefinition(req)
+
+	assert.Equal(t, apiDef, cloned)
+}
+
+// Test for GetOASDefinition
+func TestGetOASDefinition(t *testing.T) {
+	oasDef := &oas.OAS{}
+	oasDef.Info = &openapi3.Info{
+		Title:   uuid.New(),
+		Version: "1",
+	}
+
+	req := httptest.NewRequest("GET", "http://example.com", nil)
+
+	assert.Nil(t, ctx.GetOASDefinition(req))
+
+	ctx.SetOASDefinition(req, oasDef)
+	cloned := ctx.GetOASDefinition(req)
+
+	assert.Equal(t, oasDef, cloned)
+}
+
+// Benchmark for GetDefinition
+func BenchmarkGetDefinition(b *testing.B) {
+	apiDef := &apidef.APIDefinition{
+		APIID: uuid.New(),
+	}
+
+	req := httptest.NewRequest("GET", "http://example.com", nil)
+
+	ctx.SetDefinition(req, apiDef)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cloned := ctx.GetDefinition(req)
+		assert.Equal(b, apiDef, cloned)
+	}
+}
+
+// Benchmark for GetOASDefinition
+func BenchmarkGetOASDefinition(b *testing.B) {
+	oasDef := &oas.OAS{}
+	oasDef.Info = &openapi3.Info{
+		Title:   uuid.New(),
+		Version: "1",
+	}
+
+	req := httptest.NewRequest("GET", "http://example.com", nil)
+
+	ctx.SetOASDefinition(req, oasDef)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cloned := ctx.GetOASDefinition(req)
+		assert.Equal(b, oasDef, cloned)
+	}
+}

--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -2,14 +2,11 @@ package gateway
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"time"
-
-	"github.com/TykTechnologies/tyk/apidef/oas"
 
 	"github.com/TykTechnologies/tyk/ctx"
 
@@ -226,7 +223,7 @@ func (m *GoPluginMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reque
 
 	// Inject definition into request context:
 	if m.Spec.IsOAS {
-		setOASDefinition(r, &m.Spec.OAS)
+		ctx.SetOASDefinition(r, &m.Spec.OAS)
 	} else {
 		ctx.SetDefinition(r, m.Spec.APIDefinition)
 	}
@@ -273,10 +270,4 @@ func (m *GoPluginMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reque
 	}
 
 	return
-}
-
-func setOASDefinition(r *http.Request, s *oas.OAS) {
-	cntx := r.Context()
-	cntx = context.WithValue(cntx, ctx.OASDefinition, s)
-	setContext(r, cntx)
 }

--- a/go.mod
+++ b/go.mod
@@ -89,6 +89,7 @@ require (
 	github.com/go-redis/redismock/v9 v9.2.0
 	github.com/goccy/go-json v0.10.4
 	github.com/google/go-cmp v0.6.0
+	github.com/huandu/go-clone/generic v1.7.2
 	github.com/nats-io/nats.go v1.38.0
 	github.com/newrelic/go-agent/v3 v3.35.1
 	github.com/newrelic/go-agent/v3/integrations/nrgorilla v1.2.2
@@ -185,6 +186,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/raft v1.7.1 // indirect
 	github.com/hashicorp/serf v0.10.1 // indirect
+	github.com/huandu/go-clone v1.6.0 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/iancoleman/strcase v0.3.0 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -424,6 +424,12 @@ github.com/hashicorp/serf v0.10.1/go.mod h1:yL2t6BqATOLGc5HF7qbFkTfXoPIY0WZdWHfE
 github.com/hashicorp/vault/api v1.15.0 h1:O24FYQCWwhwKnF7CuSqP30S51rTV7vz1iACXE/pj5DA=
 github.com/hashicorp/vault/api v1.15.0/go.mod h1:+5YTO09JGn0u+b6ySD/LLVf8WkJCPLAL2Vkmrn2+CM8=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/huandu/go-assert v1.1.5 h1:fjemmA7sSfYHJD7CUqs9qTwwfdNAx7/j2/ZlHXzNB3c=
+github.com/huandu/go-assert v1.1.5/go.mod h1:yOLvuqZwmcHIC5rIzrBhT7D3Q9c3GFnd0JrPVhn/06U=
+github.com/huandu/go-clone v1.6.0 h1:HMo5uvg4wgfiy5FoGOqlFLQED/VGRm2D9Pi8g1FXPGc=
+github.com/huandu/go-clone v1.6.0/go.mod h1:ReGivhG6op3GYr+UY3lS6mxjKp7MIGTknuU5TbTVaXE=
+github.com/huandu/go-clone/generic v1.7.2 h1:47pQphxs1Xc9cVADjOHN+Bm5D0hNagwH9UXErbxgVKA=
+github.com/huandu/go-clone/generic v1.7.2/go.mod h1:xgd9ZebcMsBWWcBx5mVMCoqMX24gLWr5lQicr+nVXNs=
 github.com/huandu/xstrings v1.2.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=

--- a/internal/reflect/clone.go
+++ b/internal/reflect/clone.go
@@ -1,0 +1,11 @@
+package reflect
+
+import (
+	clone "github.com/huandu/go-clone/generic"
+)
+
+// Clone is a hacky way to wrap the generic declaration.
+// Using `var Clone = clone.Clone` is not allowed.
+func Clone[T any](t T) T {
+	return clone.Clone[T](t)
+}

--- a/internal/reflect/clone_test.go
+++ b/internal/reflect/clone_test.go
@@ -1,0 +1,59 @@
+package reflect_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/TykTechnologies/tyk/internal/reflect"
+)
+
+// cloneJSON performs cloning using JSON marshalling and unmarshalling.
+func cloneJSON[T any](t T) T {
+	data, err := json.Marshal(t)
+	if err != nil {
+		panic(err) // Should not happen in a benchmark test
+	}
+	var copy T
+	if err := json.Unmarshal(data, &copy); err != nil {
+		panic(err) // Should not happen in a benchmark test
+	}
+	return copy
+}
+
+// Sample struct to test cloning performance.
+type SampleStruct struct {
+	Name  string
+	Age   int
+	Email string
+	Tags  []string
+}
+
+// Benchmark for reflect.Clone
+func BenchmarkReflectClone(b *testing.B) {
+	sample := SampleStruct{
+		Name:  "John Doe",
+		Age:   30,
+		Email: "john.doe@example.com",
+		Tags:  []string{"golang", "performance", "benchmark"},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = reflect.Clone(sample)
+	}
+}
+
+// Benchmark for JSON-based cloning
+func BenchmarkJSONClone(b *testing.B) {
+	sample := SampleStruct{
+		Name:  "John Doe",
+		Age:   30,
+		Email: "john.doe@example.com",
+		Tags:  []string{"golang", "performance", "benchmark"},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = cloneJSON(sample)
+	}
+}


### PR DESCRIPTION
The *oas.OAS or *apidef.APIDefinition retrieved directly from context should be considered immutable, and depending on how plugins use the ctx package, this may cause issues. Each server request is started in a goroutine, making any map iteration dangerous due to the concurrency. By providing a deep copy that problem goes away.

The PR optimizes performance for the following functions:

- ctx.GetDefinition

This function returned the pointer to APIDefinition directly as if you would have used the context. This was a known defect until now. We now use the same deep copy mechanism that was optimized for OAS, to avoid concurrency concerns from plugins and improve stability.

- ctx.GetOASDefinition

Since we were aware of the defect of GetDefinition, this function used a naive copy mechanism to ensure that the copy is safe to use. It did rely on encoding/json, on the reasoning performance can be improved by a more optimized mechanism in the future (encoding/gob, msgpack...). Using a memory cloning approach, the following change was benchmarked, showing a reduction of latencies and allocations around -90%.

Benchmark master:

```
BenchmarkOAS_Clone     	   47610	     25781 ns/op	   15211 B/op	     206 allocs/op
BenchmarkOAS_Clone-2   	   44457	     25821 ns/op	   15214 B/op	     206 allocs/op
BenchmarkOAS_Clone-4   	   51541	     24412 ns/op	   15220 B/op	     206 allocs/op
BenchmarkOAS_Clone-8   	   47432	     27178 ns/op	   15228 B/op	     206 allocs/op
```

Benchmark PR:

```
BenchmarkOAS_Clone     	  390181	      2839 ns/op	    1408 B/op	      17 allocs/op
BenchmarkOAS_Clone-2   	  455761	      2547 ns/op	    1408 B/op	      17 allocs/op
BenchmarkOAS_Clone-4   	  436094	      2570 ns/op	    1408 B/op	      17 allocs/op
BenchmarkOAS_Clone-8   	  447078	      3100 ns/op	    1408 B/op	      17 allocs/op
```

- Improves ctx.GetOASDefinition
- Improves ctx.GetDefinition to return a copy (concurrency fix)
- Additional benchmarks added for ctx package
- Additional benchmarks added for reflect package
- Added huandu/go-clone and an internal type-generic reflect.Clone API.

Closes #6471

<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-12965" title="TT-12965" target="_blank">TT-12965</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>[Customer PR] Improve performance of ctx.GetOASDefinition()</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20customer_bug%20ORDER%20BY%20created%20DESC" title="customer_bug">customer_bug</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20github%20ORDER%20BY%20created%20DESC" title="github">github</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20jira_escalated%20ORDER%20BY%20created%20DESC" title="jira_escalated">jira_escalated</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

https://tyktech.atlassian.net/browse/TT-12965