### PR TITLE
[TT-13998] make url of X-Tyk-Upstream optional when loadBalancing is present

### DIFF
--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -1368,7 +1368,7 @@
           "$ref": "#/definitions/X-Tyk-PreserveHostHeader"
         }
       },
-      "oneOf": [
+      "anyOf": [
         {
           "required": ["url"]
         },
@@ -2341,6 +2341,23 @@
       },
       "required": [
         "enabled"
+      ],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "enabled": { "const": true }
+            }
+          },
+          "then": {
+            "properties": {
+              "targets": {
+                "minItems": 1
+              }
+            },
+            "required": ["targets"]
+          }
+        }
       ]
     },
     "X-Tyk-PreserveHostHeader": {

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -1368,8 +1368,13 @@
           "$ref": "#/definitions/X-Tyk-PreserveHostHeader"
         }
       },
-      "required": [
-        "url"
+      "oneOf": [
+        {
+          "required": ["url"]
+        },
+        {
+          "required": ["loadBalancing"]
+        }
       ]
     },
     "X-Tyk-State": {

--- a/apidef/oas/validator.go
+++ b/apidef/oas/validator.go
@@ -25,6 +25,7 @@ const (
 	keyDefinitions              = "definitions"
 	keyProperties               = "properties"
 	keyRequired                 = "required"
+	keyAnyOf                    = "anyOf"
 	oasSchemaVersionNotFoundFmt = "Schema not found for version %q"
 )
 
@@ -157,6 +158,14 @@ func ValidateOASTemplate(documentBody []byte, oasVersion string) error {
 
 	for _, path := range unsetReqFieldsPaths {
 		definitions = jsonparser.Delete(definitions, path, keyRequired)
+	}
+
+	unsetAnyOfFieldsPaths := []string{
+		"X-Tyk-Upstream",
+	}
+
+	for _, path := range unsetAnyOfFieldsPaths {
+		definitions = jsonparser.Delete(definitions, path, keyAnyOf)
 	}
 
 	oasSchema, err = jsonparser.Set(oasSchema, definitions, keyDefinitions)


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-13998" title="TT-13998" target="_blank">TT-13998</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>[OAS Load balancer] upstream.URL is required when load balancer is enabled</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

This PR makes `upstream.url` optional when `upstream.loadBalancing[].targets.url` is present.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)


___

### **PR Type**
Bug fix


___

### **Description**
- Made `upstream.url` optional when `loadBalancing` is present.

- Updated OAS schema to include `oneOf` validation for `url` or `loadBalancing`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>x-tyk-api-gateway.json</strong><dd><code>Update OAS schema to validate `url` or `loadBalancing`</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/schema/x-tyk-api-gateway.json

<li>Replaced <code>required</code> array with <code>oneOf</code> validation.<br> <li> Ensured either <code>url</code> or <code>loadBalancing</code> is required.<br> <li> Adjusted schema to align with new validation logic.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6860/files#diff-78828969c0c04cc1a776dfc93a8bad3c499a8c83e6169f83e96d090bed3e7dd0">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>