### PR TITLE
Include insecure ciphers in selection

### DIFF
--- a/internal/crypto/ciphers.go
+++ b/internal/crypto/ciphers.go
@@ -53,9 +53,15 @@ func TLSVersions(in []uint16) []string {
 // GetCiphers generates a list of CipherSuite from the available ciphers.
 func GetCiphers() []*CipherSuite {
 	ciphers := tls.CipherSuites()
-	result := make([]*CipherSuite, 0, len(ciphers))
+	ciphersInsecure := tls.InsecureCipherSuites()
+
+	result := make([]*CipherSuite, 0, len(ciphers)+len(ciphersInsecure))
 
 	for _, cipher := range ciphers {
+		result = append(result, NewCipher(cipher))
+	}
+
+	for _, cipher := range ciphersInsecure {
 		result = append(result, NewCipher(cipher))
 	}
 


### PR DESCRIPTION
### **PR Type**
enhancement

> CipherSuites returns a list of cipher suites currently implemented by this package, excluding those with security issues, which are returned by [InsecureCipherSuites](https://pkg.go.dev/crypto/tls#InsecureCipherSuites).

___

### **Description**
- Added support for insecure ciphers in cipher selection.

- Extended the `GetCiphers` function to include insecure ciphers.

- Improved flexibility in cipher suite handling.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ciphers.go</strong><dd><code>Include insecure ciphers in `GetCiphers` function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/crypto/ciphers.go

<li>Added retrieval of insecure cipher suites using <br><code>tls.InsecureCipherSuites</code>.<br> <li> Updated <code>GetCiphers</code> to include both secure and insecure ciphers.<br> <li> Adjusted the result slice capacity to accommodate additional ciphers.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6869/files#diff-86698d97685ca2876f216471bdf44651d965be0b5c80ee67fa3dbb31929431e5">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>