### PR TITLE
TT-14085: Remove the pmylund/go-cache dependency

### DIFF
--- a/dnscache/storage.go
+++ b/dnscache/storage.go
@@ -6,8 +6,9 @@ import (
 
 	"fmt"
 
-	cache "github.com/pmylund/go-cache"
 	"github.com/sirupsen/logrus"
+
+	"github.com/TykTechnologies/tyk/internal/cache"
 )
 
 // DnsCacheItem represents single record in cache
@@ -21,8 +22,10 @@ type DnsCacheStorage struct {
 }
 
 func NewDnsCacheStorage(expiration, checkInterval time.Duration) *DnsCacheStorage {
-	storage := DnsCacheStorage{cache.New(expiration, checkInterval)}
-	return &storage
+	storage := &DnsCacheStorage{
+		cache: cache.NewCache(expiration, checkInterval),
+	}
+	return storage
 }
 
 // Items returns map of non expired dns cache items

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -265,7 +265,7 @@ func (gw *Gateway) cacheCreate() {
 	gw.RPCCertCache = cache.New(int64(conf.SlaveOptions.RPCCertCacheExpiration), 15)
 }
 
-// stopCaches will close the caches in *Gateway, cleaning up the goroutines.
+// cacheClose will close the caches in *Gateway, cleaning up the goroutines.
 func (gw *Gateway) cacheClose() {
 	gw.SessionCache.Close()
 	gw.ServiceCache.Close()

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -226,16 +226,7 @@ func NewGateway(config config.Config, ctx context.Context) *Gateway {
 	}
 	gw.ConnectionWatcher = httputil.NewConnectionWatcher()
 
-	gw.SessionCache = cache.New(10, 5)
-	gw.ExpiryCache = cache.New(600, 10*60)
-	gw.UtilCache = cache.New(3600, 10*60)
-
-	var timeout = int64(config.ServiceDiscovery.DefaultCacheTimeout)
-	if timeout <= 0 {
-		timeout = 120 // 2 minutes
-	}
-
-	gw.ServiceCache = cache.New(timeout, 15)
+	gw.cacheCreate()
 
 	gw.apisByID = map[string]*APISpec{}
 	gw.apisHandlesByID = new(sync.Map)
@@ -254,6 +245,34 @@ func NewGateway(config config.Config, ctx context.Context) *Gateway {
 	gw.SessionID = uuid.New()
 
 	return gw
+}
+
+// cacheCreate will create the caches in *Gateway.
+func (gw *Gateway) cacheCreate() {
+	conf := gw.GetConfig()
+
+	gw.SessionCache = cache.New(10, 5)
+	gw.ExpiryCache = cache.New(600, 10*60)
+	gw.UtilCache = cache.New(3600, 10*60)
+
+	var timeout = int64(conf.ServiceDiscovery.DefaultCacheTimeout)
+	if timeout <= 0 {
+		timeout = 120 // 2 minutes
+	}
+	gw.ServiceCache = cache.New(timeout, 15)
+
+	gw.RPCGlobalCache = cache.New(int64(conf.SlaveOptions.RPCGlobalCacheExpiration), 15)
+	gw.RPCCertCache = cache.New(int64(conf.SlaveOptions.RPCCertCacheExpiration), 15)
+}
+
+// stopCaches will close the caches in *Gateway, cleaning up the goroutines.
+func (gw *Gateway) cacheClose() {
+	gw.SessionCache.Close()
+	gw.ServiceCache.Close()
+	gw.ExpiryCache.Close()
+	gw.UtilCache.Close()
+	gw.RPCGlobalCache.Close()
+	gw.RPCCertCache.Close()
 }
 
 // SetupNewRelic creates new newrelic.Application instance.
@@ -288,12 +307,6 @@ func (gw *Gateway) UnmarshalJSON(data []byte) error {
 }
 func (gw *Gateway) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct{}{})
-}
-
-func (gw *Gateway) initRPCCache() {
-	conf := gw.GetConfig()
-	gw.RPCGlobalCache = cache.New(int64(conf.SlaveOptions.RPCGlobalCacheExpiration), 15)
-	gw.RPCCertCache = cache.New(int64(conf.SlaveOptions.RPCCertCacheExpiration), 15)
 }
 
 // SetNodeID writes NodeID safely.
@@ -1384,7 +1397,6 @@ func (gw *Gateway) initSystem() error {
 	gw.SetConfig(gwConfig)
 	config.Global = gw.GetConfig
 	gw.getHostDetails()
-	gw.initRPCCache()
 	gw.setupInstrumentation()
 
 	// cleanIdleMemConnProviders checks memconn.Provider (a part of internal API handling)

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -1322,6 +1322,8 @@ func (s *Test) Close() {
 	if err != nil {
 		log.Error("could not remove apis")
 	}
+
+	s.Gw.cacheClose()
 }
 
 // RemoveApis clean all the apis from a living gw

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,6 @@ require (
 	github.com/oschwald/maxminddb-golang v1.13.1
 	github.com/paulbellamy/ratecounter v0.2.0
 	github.com/pires/go-proxyproto v0.8.0
-	github.com/pmylund/go-cache v2.1.0+incompatible
 	github.com/robertkrimen/otto v0.5.1
 	github.com/rs/cors v1.11.1
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -674,8 +674,6 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/pmylund/go-cache v2.1.0+incompatible h1:n+7K51jLz6a3sCvff3BppuCAkixuDHuJ/C57Vw/XjTE=
-github.com/pmylund/go-cache v2.1.0+incompatible/go.mod h1:hmz95dGvINpbRZGsqPcd7B5xXY5+EKb5PpGhQY3NTHk=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=

--- a/internal/cache/Taskfile.yml
+++ b/internal/cache/Taskfile.yml
@@ -1,0 +1,34 @@
+---
+version: "3"
+
+vars:
+  coverage: cache.cov
+
+tasks:
+  default:
+    desc: "Run everything"
+    cmds:
+      - task: fmt
+      - task: test
+
+  fmt:
+    desc: "Run formatters"
+    cmds:
+      - goimports -local github.com/TykTechnologies,github.com/TykTechnologies/tyk/internal -w .
+      - go fmt ./...
+
+  test:
+    desc: "Build/run tests"
+    cmds:
+      - go test -bench=. -benchtime=10s -race -cpu 1,2,4 -cover -coverprofile {{.coverage}} -coverpkg=$(go list .) -v .
+
+  cover:
+    desc: "Show source coverage"
+    aliases: [coverage, cov]
+    cmds:
+      - go tool cover -func={{.coverage}}
+
+  uncover:
+    desc: "Show uncovered source"
+    cmds:
+      - uncover {{.coverage}}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,73 +1,153 @@
 package cache
 
 import (
+	"sync"
 	"time"
-
-	"github.com/pmylund/go-cache"
 )
 
-// DefaultExpiration is a helper value that uses the repository defaults.
-const DefaultExpiration int64 = 0
+const (
+	// For use with functions that take an expiration time.
+	NoExpiration time.Duration = -1
 
-// Repository interface is the API signature for an object cache.
-type Repository interface {
-	Get(string) (interface{}, bool)
-	Set(string, interface{}, int64)
-	Delete(string)
-	Count() int
-	Flush()
+	// For use with functions that take an expiration time. Equivalent to
+	// passing in the same expiration duration as was given to New() or
+	// NewFrom() when the cache was created (e.g. 5 minutes.)
+	DefaultExpiration time.Duration = 0
+)
+
+// Cache holds key-value pairs with a TTL.
+type Cache struct {
+	// expiration (<= 0 means never expire).
+	expiration time.Duration
+
+	// janitor holds a clean up goroutine
+	janitor *Janitor
+
+	// cache items and protecting mutex
+	mu    sync.RWMutex
+	items map[string]Item
 }
 
-// New creates a new cache instance.
-func New(defaultExpiration, cleanupInterval int64) Repository {
-	var (
-		defaultExpirationDuration = time.Duration(defaultExpiration) * time.Second
-		cleanupIntervalDuration   = time.Duration(cleanupInterval) * time.Second
-	)
-
-	return &repository{
-		defaultExpiration: defaultExpiration,
-		cleanupInterval:   cleanupInterval,
-		cache:             cache.New(defaultExpirationDuration, cleanupIntervalDuration),
+// NewCache creates a new *Cache for storing items with a TTL.
+func NewCache(expiration, cleanupInterval time.Duration) *Cache {
+	if expiration == DefaultExpiration {
+		expiration = -1
 	}
-}
 
-type repository struct {
-	// Default expiration interval, in seconds.
-	defaultExpiration int64
-
-	// Clean up interval, in seconds.
-	cleanupInterval int64
-
-	// The underlying cache driver.
-	cache *cache.Cache
-}
-
-// Get retrieves a cache item by key.
-func (r *repository) Get(key string) (interface{}, bool) {
-	return r.cache.Get(key)
-}
-
-// Set writes a cache item with a timeout in seconds. If timeout is zero,
-// the default expiration for the repository instance will be used.
-func (r *repository) Set(key string, value interface{}, timeout int64) {
-	if timeout <= 0 {
-		timeout = r.defaultExpiration
+	cache := &Cache{
+		items:      make(map[string]Item),
+		expiration: expiration,
 	}
-	r.cache.Set(key, value, time.Duration(timeout)*time.Second)
+
+	if cleanupInterval > 0 {
+		// Cache with a cleanup janitor.
+		cache.janitor = NewJanitor(cleanupInterval, cache.Cleanup)
+	}
+
+	return cache
 }
 
-// Delete cache item by key.
-func (r *repository) Delete(key string) {
-	r.cache.Delete(key)
+// Close implements an io.Closer; Invoke it to cancel the cleanup goroutine.
+func (c *Cache) Close() {
+	if c.janitor != nil {
+		c.janitor.Close()
+		c.janitor = nil
+	}
+	c.Flush()
 }
 
-// Count returns number of items in the cache.
-func (r *repository) Count() int {
-	return r.cache.ItemCount()
+// Add an item to the cache, replacing any existing item. If the duration is 0
+// (DefaultExpiration), the cache's default expiration time is used. If it is -1
+// (NoExpiration), the item never expires.
+func (c *Cache) Set(k string, x any, d time.Duration) {
+	var e int64
+	if d == DefaultExpiration {
+		d = c.expiration
+	}
+	if d > 0 {
+		e = time.Now().Add(d).UnixNano()
+	}
+	c.mu.Lock()
+	c.items[k] = Item{
+		Object:     x,
+		Expiration: e,
+	}
+	c.mu.Unlock()
 }
 
-// Flush flushes all the items from the cache.
-func (r *repository) Flush() {
-	r.cache.Flush()
+// Get an item from the cache. Returns the item or nil, and a bool indicating
+// whether the key was found.
+func (c *Cache) Get(k string) (any, bool) {
+	c.mu.RLock()
+
+	item, found := c.items[k]
+	if !found {
+		c.mu.RUnlock()
+		return nil, false
+	}
+
+	if item.Expiration > 0 {
+		if time.Now().UnixNano() > item.Expiration {
+			c.mu.RUnlock()
+			return nil, false
+		}
+	}
+
+	c.mu.RUnlock()
+	return item.Object, true
+}
+
+// Items copies all unexpired items in the cache into a new map and returns it.
+func (c *Cache) Items() map[string]Item {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	m := make(map[string]Item, len(c.items))
+
+	now := time.Now().UnixNano()
+	for k, v := range c.items {
+		if v.Expiration > 0 && now > v.Expiration {
+			continue
+		}
+		m[k] = v
+	}
+
+	return m
+}
+
+// Delete an item from the cache. Does nothing if the key is not in the cache.
+func (c *Cache) Delete(k string) {
+	c.mu.Lock()
+	delete(c.items, k)
+	c.mu.Unlock()
+}
+
+// Cleanup will delete all expired items from the cache map.
+func (c *Cache) Cleanup() {
+	now := time.Now().UnixNano()
+
+	c.mu.Lock()
+	for k, v := range c.items {
+		if v.Expiration > 0 && now > v.Expiration {
+			delete(c.items, k)
+		}
+	}
+	c.mu.Unlock()
+}
+
+// Count returns the number of items in cache, including expired items.
+// Expired items get cleaned up by the janitor periodically.
+func (c *Cache) Count() int {
+	c.mu.RLock()
+	n := len(c.items)
+	c.mu.RUnlock()
+
+	return n
+}
+
+// Flush deletes all items from the cache.
+func (c *Cache) Flush() {
+	c.mu.Lock()
+	c.items = map[string]Item{}
+	c.mu.Unlock()
 }

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -5,16 +5,6 @@ import (
 	"time"
 )
 
-const (
-	// For use with functions that take an expiration time.
-	NoExpiration time.Duration = -1
-
-	// For use with functions that take an expiration time. Equivalent to
-	// passing in the same expiration duration as was given to New() or
-	// NewFrom() when the cache was created (e.g. 5 minutes.)
-	DefaultExpiration time.Duration = 0
-)
-
 // Cache holds key-value pairs with a TTL.
 type Cache struct {
 	// expiration (<= 0 means never expire).
@@ -30,7 +20,7 @@ type Cache struct {
 
 // NewCache creates a new *Cache for storing items with a TTL.
 func NewCache(expiration, cleanupInterval time.Duration) *Cache {
-	if expiration == DefaultExpiration {
+	if expiration == 0 {
 		expiration = -1
 	}
 
@@ -56,12 +46,11 @@ func (c *Cache) Close() {
 	c.Flush()
 }
 
-// Add an item to the cache, replacing any existing item. If the duration is 0
-// (DefaultExpiration), the cache's default expiration time is used. If it is -1
-// (NoExpiration), the item never expires.
+// Add an item to the cache, replacing any existing item. If the duration is 0,
+// the cache's expiration time is used. If it is -1, the item never expires.
 func (c *Cache) Set(k string, x any, d time.Duration) {
 	var e int64
-	if d == DefaultExpiration {
+	if d == 0 {
 		d = c.expiration
 	}
 	if d > 0 {

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,34 +1,47 @@
-package cache_test
+package cache
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/TykTechnologies/tyk/internal/cache"
 )
 
 func TestCache(t *testing.T) {
-	t.Parallel()
+	cache := NewCache(0, 0)
+	assert.NotNil(t, cache)
+}
 
-	cache := cache.New(1, 1)
+func TestCache_Expired(t *testing.T) {
+	cache := &Cache{
+		items: map[string]Item{
+			"one": Item{
+				Expiration: 1,
+			},
+			"two": Item{
+				Expiration: 0,
+			},
+		},
+	}
 
-	assert.Equal(t, 0, cache.Count())
+	t.Run("Test Get", func(t *testing.T) {
+		_, ok := cache.Get("one")
+		assert.False(t, ok)
+	})
 
-	cache.Set("key", "value", 1)
-	assert.Equal(t, 1, cache.Count())
+	t.Run("Test Items", func(t *testing.T) {
+		want := map[string]Item{
+			"two": Item{
+				Expiration: 0,
+			},
+		}
 
-	cache.Set("key", "value", 0)
-	assert.Equal(t, 1, cache.Count())
+		got := cache.Items()
+		assert.Equal(t, want, got)
+	})
 
-	val, ok := cache.Get("key")
-	assert.True(t, ok)
-	assert.Equal(t, "value", val.(string))
-
-	cache.Delete("key")
-	assert.Equal(t, 0, cache.Count())
-
-	cache.Set("key", "value", 1)
-	cache.Flush()
-	assert.Equal(t, 0, cache.Count())
+	t.Run("Test Cleanup", func(t *testing.T) {
+		assert.Equal(t, 2, cache.Count())
+		cache.Cleanup()
+		assert.Equal(t, 1, cache.Count())
+	})
 }

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -44,4 +44,9 @@ func TestCache_Expired(t *testing.T) {
 		cache.Cleanup()
 		assert.Equal(t, 1, cache.Count())
 	})
+
+	t.Run("Test Set", func(t *testing.T) {
+		cache.Set("foo", "bar", 0)
+		assert.Equal(t, 2, cache.Count())
+	})
 }

--- a/internal/cache/const.go
+++ b/internal/cache/const.go
@@ -1,0 +1,7 @@
+package cache
+
+const (
+	// For use with functions that take an expiration time. Equivalent to
+	// passing in the same expiration duration as was given to NewCache().
+	DefaultExpiration = 0
+)

--- a/internal/cache/item.go
+++ b/internal/cache/item.go
@@ -1,0 +1,18 @@
+package cache
+
+import (
+	"time"
+)
+
+type Item struct {
+	Object     any
+	Expiration int64
+}
+
+// Returns true if the item has expired.
+func (item Item) Expired() bool {
+	if item.Expiration <= 0 {
+		return false
+	}
+	return time.Now().UnixNano() > item.Expiration
+}

--- a/internal/cache/item_test.go
+++ b/internal/cache/item_test.go
@@ -1,0 +1,47 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestItem_Expired(t *testing.T) {
+	var (
+		past   = time.Now().Add(-time.Minute).UnixNano()
+		future = time.Now().Add(+time.Minute).UnixNano()
+	)
+
+	type testCase struct {
+		title string
+		item  *Item
+		want  bool
+	}
+
+	testCases := []testCase{
+		{
+			title: "Default item: no expiration",
+			item:  &Item{},
+		},
+		{
+			title: "Negative expiration: no expiration",
+			item:  &Item{Expiration: -1},
+		},
+		{
+			title: "Future time: record not expired",
+			item:  &Item{Expiration: future},
+		},
+		{
+			title: "Current time: record expired",
+			item:  &Item{Expiration: past},
+			want:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.title, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.item.Expired())
+		})
+	}
+}

--- a/internal/cache/janitor.go
+++ b/internal/cache/janitor.go
@@ -1,0 +1,44 @@
+package cache
+
+import (
+	"time"
+)
+
+// Janitor is responsible for performing periodic cleanup operations.
+type Janitor struct {
+	Interval time.Duration
+	stop     chan bool
+}
+
+// NewJanitor returns a new Janitor that performs cleanup at the specified interval.
+func NewJanitor(interval time.Duration, cleanup func()) *Janitor {
+	janitor := &Janitor{
+		Interval: interval,
+		stop:     make(chan bool, 1),
+	}
+
+	go janitor.Run(cleanup)
+
+	return janitor
+}
+
+// Run starts the janitor which calls the provided cleanup function at every interval.
+func (j *Janitor) Run(cleanup func()) {
+	ticker := time.NewTicker(j.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			cleanup()
+		case <-j.stop:
+			close(j.stop)
+			return
+		}
+	}
+}
+
+// Close stops the janitor from performing further cleanup operations.
+func (j *Janitor) Close() {
+	j.stop <- true
+}

--- a/internal/cache/janitor_test.go
+++ b/internal/cache/janitor_test.go
@@ -1,0 +1,33 @@
+package cache
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestJanitor verifies that the Janitor executes the cleanup function periodically and stops when closed.
+func TestJanitor(t *testing.T) {
+	var count int32
+
+	// cleanup increments count.
+	cleanup := func() {
+		atomic.AddInt32(&count, 1)
+	}
+
+	janitor := NewJanitor(10*time.Millisecond, cleanup)
+
+	// Wait long enough for several cleanup calls.
+	time.Sleep(50 * time.Millisecond)
+
+	janitor.Close()
+
+	// Wait to ensure no further cleanup calls are made after Close.
+	time.Sleep(20 * time.Millisecond)
+
+	finalCount := atomic.LoadInt32(&count)
+
+	assert.NotEqual(t, int32(0), finalCount, "Expected cleanup() called")
+}

--- a/internal/cache/repository.go
+++ b/internal/cache/repository.go
@@ -1,0 +1,76 @@
+package cache
+
+import (
+	"time"
+)
+
+// Repository interface is the API signature for an object cache.
+type Repository interface {
+	Get(string) (interface{}, bool)
+	Set(string, interface{}, int64)
+	Delete(string)
+	Count() int
+	Flush()
+
+	Close()
+}
+
+// New creates a new cache instance.
+func New(defaultExpiration, cleanupInterval int64) Repository {
+	var (
+		defaultExpirationDuration = time.Duration(defaultExpiration) * time.Second
+		cleanupIntervalDuration   = time.Duration(cleanupInterval) * time.Second
+	)
+
+	return &repository{
+		defaultExpiration: defaultExpiration,
+		cleanupInterval:   cleanupInterval,
+		cache:             NewCache(defaultExpirationDuration, cleanupIntervalDuration),
+	}
+}
+
+type repository struct {
+	// The underlying cache driver.
+	cache *Cache
+
+	// Default expiration interval, in seconds.
+	defaultExpiration int64
+
+	// Clean up interval, in seconds.
+	cleanupInterval int64
+}
+
+// Get retrieves a cache item by key.
+func (r *repository) Get(key string) (interface{}, bool) {
+	return r.cache.Get(key)
+}
+
+// Set writes a cache item with a timeout in seconds. If timeout is zero,
+// the default expiration for the repository instance will be used.
+func (r *repository) Set(key string, value interface{}, timeout int64) {
+	if timeout <= 0 {
+		timeout = r.defaultExpiration
+	}
+	r.cache.Set(key, value, time.Duration(timeout)*time.Second)
+}
+
+// Delete cache item by key.
+func (r *repository) Delete(key string) {
+	r.cache.Delete(key)
+}
+
+// Count returns number of items in the cache.
+func (r *repository) Count() int {
+	return r.cache.Count()
+}
+
+// Flush flushes all the items from the cache.
+func (r *repository) Flush() {
+	r.cache.Flush()
+}
+
+// Close will stop background cleanup and clear the cache for garbage collection.
+// Close also flushes the data in the cache.
+func (r *repository) Close() {
+	r.cache.Close()
+}

--- a/internal/cache/repository_test.go
+++ b/internal/cache/repository_test.go
@@ -1,0 +1,45 @@
+package cache_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk/internal/cache"
+)
+
+func TestRepository(t *testing.T) {
+	cache := cache.New(1, 1)
+
+	assert.Equal(t, 0, cache.Count())
+
+	cache.Set("key", "value", 1)
+	assert.Equal(t, 1, cache.Count())
+
+	cache.Set("key", "value", 0)
+	assert.Equal(t, 1, cache.Count())
+
+	val, ok := cache.Get("key")
+	assert.True(t, ok)
+
+	castVal, ok := val.(string)
+	assert.True(t, ok)
+	assert.Equal(t, "value", castVal)
+
+	val2, ok := cache.Get("missing")
+	assert.False(t, ok)
+	assert.Nil(t, val2)
+
+	cache.Delete("key")
+	assert.Equal(t, 0, cache.Count())
+
+	cache.Set("key", "value", 1)
+	cache.Flush()
+	assert.Equal(t, 0, cache.Count())
+
+	cache.Set("key", "value", 1)
+	assert.Equal(t, 1, cache.Count())
+
+	cache.Close()
+	assert.Equal(t, 0, cache.Count())
+}

--- a/internal/cache/repository_test.go
+++ b/internal/cache/repository_test.go
@@ -9,37 +9,37 @@ import (
 )
 
 func TestRepository(t *testing.T) {
-	cache := cache.New(1, 1)
+	store := cache.New(1, 1)
 
-	assert.Equal(t, 0, cache.Count())
+	assert.Equal(t, 0, store.Count())
 
-	cache.Set("key", "value", 1)
-	assert.Equal(t, 1, cache.Count())
+	store.Set("key", "value", 1)
+	assert.Equal(t, 1, store.Count())
 
-	cache.Set("key", "value", 0)
-	assert.Equal(t, 1, cache.Count())
+	store.Set("key", "value", 0)
+	assert.Equal(t, 1, store.Count())
 
-	val, ok := cache.Get("key")
+	val, ok := store.Get("key")
 	assert.True(t, ok)
 
 	castVal, ok := val.(string)
 	assert.True(t, ok)
 	assert.Equal(t, "value", castVal)
 
-	val2, ok := cache.Get("missing")
+	val2, ok := store.Get("missing")
 	assert.False(t, ok)
 	assert.Nil(t, val2)
 
-	cache.Delete("key")
-	assert.Equal(t, 0, cache.Count())
+	store.Delete("key")
+	assert.Equal(t, 0, store.Count())
 
-	cache.Set("key", "value", 1)
-	cache.Flush()
-	assert.Equal(t, 0, cache.Count())
+	store.Set("key", "value", 1)
+	store.Flush()
+	assert.Equal(t, 0, store.Count())
 
-	cache.Set("key", "value", 1)
-	assert.Equal(t, 1, cache.Count())
+	store.Set("key", "value", 1)
+	assert.Equal(t, 1, store.Count())
 
-	cache.Close()
-	assert.Equal(t, 0, cache.Count())
+	store.Close()
+	assert.Equal(t, 0, store.Count())
 }

--- a/regexp/cache.go
+++ b/regexp/cache.go
@@ -4,7 +4,7 @@ import (
 	"regexp"
 	"time"
 
-	gocache "github.com/pmylund/go-cache"
+	gocache "github.com/TykTechnologies/tyk/internal/cache"
 )
 
 const (
@@ -17,13 +17,14 @@ const (
 
 type cache struct {
 	*gocache.Cache
+
 	isEnabled bool
 	ttl       time.Duration
 }
 
 func newCache(ttl time.Duration, isEnabled bool) *cache {
 	return &cache{
-		Cache:     gocache.New(ttl, defaultCacheCleanupInterval),
+		Cache:     gocache.NewCache(ttl, defaultCacheCleanupInterval),
 		isEnabled: isEnabled,
 		ttl:       ttl,
 	}
@@ -34,7 +35,7 @@ func (c *cache) enabled() bool {
 }
 
 func (c *cache) add(key string, value interface{}) {
-	c.Add(key, value, c.ttl)
+	c.Set(key, value, c.ttl)
 }
 
 func (c *cache) getRegexp(key string) (*regexp.Regexp, bool) {


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-14085" title="TT-14085" target="_blank">TT-14085</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>[Testing/memory leak] Remove pmylund/go-cache</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20SESAP%20ORDER%20BY%20created%20DESC" title="SESAP">SESAP</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

This implements a subset of go-cache as used in gateway under internal/cache, dropping the dependency.

https://tyktech.atlassian.net/browse/TT-14085


___

### **PR Type**
Enhancement, Tests, Bug fix


___

### **Description**
- Replaced `pmylund/go-cache` with a custom internal cache implementation.

- Introduced a new `internal/cache` package with cache, item, and janitor functionalities.

- Updated DNS cache, gateway, and regexp modules to use the new internal cache.

- Added comprehensive unit tests for the new cache implementation and its components.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>storage.go</strong><dd><code>Updated DNS cache to use internal cache</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6871/files#diff-71a52cd6346b22e5bcb1e45481fdfb05b761510d3eeb6b631f4129ed1e98b08f">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>server.go</strong><dd><code>Refactored gateway cache setup and teardown</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6871/files#diff-4652d1bf175a0be8f5e61ef7177c9666f23e077d8626b73ac9d13358fa8b525b">+29/-17</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>cache.go</strong><dd><code>Implemented custom cache with expiration and cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6871/files#diff-113f0a3ddf486bd0f7ee93e06851fe642139355ce485bd7acd848729688962b2">+117/-48</a></td>

</tr>

<tr>
  <td><strong>const.go</strong><dd><code>Added constants for cache expiration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6871/files#diff-448694a8bd4e5850fc1628a98916e274108b60b306cff2975b9a2163ab7cf5a2">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>item.go</strong><dd><code>Added cache item structure with expiration logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6871/files#diff-147d35cb74dbca325fb8155b41d86be735558ccf7e1a5b11c51a6f8df5931a6b">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>janitor.go</strong><dd><code>Implemented janitor for periodic cache cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6871/files#diff-2a5458b21c11f19afea01dc950c2f3caaeb1793b83d585443dfa347dbf8088aa">+44/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>repository.go</strong><dd><code>Added repository interface for cache abstraction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6871/files#diff-51bf85b4acebd1b757ab007b04a58ffc3b570f4c579252910895262c718bd877">+76/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cache.go</strong><dd><code>Updated regexp cache to use internal cache</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6871/files#diff-0420ba44813cfb841c564160f4a3106d2a9bc4c4477dc8ee4ab97582253f7753">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>testutil.go</strong><dd><code>Added cache cleanup in gateway test utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6871/files#diff-7aaf6ae49fb8f58a8c99d337fedd15b3e430dd928ed547e425ef429b10d28ce8">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cache_test.go</strong><dd><code>Added unit tests for custom cache implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6871/files#diff-7fbdfb41b04a92f43e9826f893f4f7efa7431219a257f97f2c1d8219efb3f1fb">+42/-24</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>item_test.go</strong><dd><code>Added unit tests for cache item expiration logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6871/files#diff-6451c091258b5c8ac564e0d6fc75ad211e3396850060b10fc373a1bd568d9ed9">+47/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>janitor_test.go</strong><dd><code>Added unit tests for janitor functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6871/files#diff-8549318827857e1a242451f72bba0b50fc221816657117017b3d22649acd987e">+33/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>repository_test.go</strong><dd><code>Added unit tests for cache repository implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6871/files#diff-7c39208ed77b58d98849988d77bfa71fff24184f061811a87672af313ada0dac">+45/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>go.mod</strong><dd><code>Removed `pmylund/go-cache` dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6871/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>go.sum</strong><dd><code>Removed `pmylund/go-cache` entries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6871/files#diff-3295df7234525439d778f1b282d146a4f1ff6b415248aaac074e8042d9f42d63">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Taskfile.yml</strong><dd><code>Added taskfile for cache package development</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6871/files#diff-b6690cc441b7677d64006ca10ac2360e951c7eec45cda9560763e0782e3767a8">+34/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>