### PR TITLE
[testing] Remove dnsmock, lifecycle reorg, NewTest api

### DIFF
--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -140,7 +140,6 @@ type configTestReverseProxyDnsCache struct {
 }
 
 func (s *Test) flakySetupTestReverseProxyDnsCache(cfg *configTestReverseProxyDnsCache) func() {
-	pullDomains := s.MockHandle.PushDomains(cfg.etcHostsMap, nil)
 	s.Gw.dnsCacheManager.InitDNSCaching(
 		time.Duration(cfg.dnsConfig.TTL)*time.Second, time.Duration(cfg.dnsConfig.CheckInterval)*time.Second)
 
@@ -151,7 +150,6 @@ func (s *Test) flakySetupTestReverseProxyDnsCache(cfg *configTestReverseProxyDns
 	s.Gw.SetConfig(globalConf)
 
 	return func() {
-		pullDomains()
 		s.Gw.dnsCacheManager.DisposeCache()
 		globalConf.HttpServerOptions.EnableWebSockets = enableWebSockets
 		s.Gw.SetConfig(globalConf)
@@ -188,11 +186,7 @@ func TestReverseProxyDnsCache(t *testing.T) {
 	)
 
 	ts := StartTest(nil)
-	ts.MockHandle, _ = test.InitDNSMock(etcHostsMap, nil)
 	defer ts.Close()
-	defer func() {
-		_ = ts.MockHandle.ShutdownDnsMock()
-	}()
 
 	tearDown := ts.flakySetupTestReverseProxyDnsCache(&configTestReverseProxyDnsCache{t, etcHostsMap,
 		config.DnsCacheConfig{

--- a/gateway/test.go
+++ b/gateway/test.go
@@ -1,0 +1,181 @@
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+
+	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/test"
+)
+
+type Test struct {
+	URL        string
+	testRunner *test.HTTPTestRunner
+	// GlobalConfig deprecate this and instead use GW.getConfig()
+	GlobalConfig     config.Config
+	config           TestConfig
+	Gw               *Gateway `json:"-"`
+	HttpHandler      *http.Server
+	TestServerRouter *mux.Router
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	dynamicHandlers map[string]http.HandlerFunc
+
+	Parent testing.TB
+}
+
+type TestConfig struct {
+	SeparateControlAPI bool
+	Delay              time.Duration
+	HotReload          bool
+	overrideDefaults   bool
+	CoprocessConfig    config.CoProcessConfig
+}
+
+type TestOption func(*Test)
+
+func NewTest(tb testing.TB, genConf func(*config.Config), opts ...TestOption) *Test {
+	tb.Helper()
+
+	t := &Test{
+		Parent:          tb,
+		dynamicHandlers: make(map[string]http.HandlerFunc),
+	}
+
+	for _, optfn := range opts {
+		optfn(t)
+	}
+
+	t.Gw = t.start(genConf)
+
+	tb.Cleanup(t.Close)
+
+	return t
+}
+
+func NewTestConfigOption(conf TestConfig) func(*Test) {
+	return func(t *Test) {
+		t.config = conf
+	}
+}
+
+// Start is the root event point where a gateway object is created, and
+// can enforce lifecycle via the *Test objects, and TestOption implementation.
+// For example, if somebody wanted to have some default options set up,
+// one could set a timeout by implementing:
+//
+// - `func NewTestTimeoutOption(d time.Duration) func(*Test)`
+//
+// To use, it should be passed to NewTest as an argument. A default timeout
+// may be implemented in the future and set from NewTest as well.
+func (s *Test) start(genConf func(globalConf *config.Config)) *Gateway {
+	// init and create gw
+	ctx, cancel := context.WithCancel(context.Background())
+
+	log.Info("starting test")
+
+	s.ctx = ctx
+	s.cancel = func() {
+		cancel()
+		log.Info("Cancelling test context")
+	}
+
+	gw := s.newGateway(genConf)
+	gw.setupPortsWhitelist()
+	gw.startServer()
+	gw.setupGlobals()
+
+	// Set up a default org manager so we can traverse non-live paths
+	if !gw.GetConfig().SupressDefaultOrgStore {
+		gw.DefaultOrgStore.Init(gw.getGlobalStorageHandler("orgkey.", false))
+		gw.DefaultQuotaStore.Init(gw.getGlobalStorageHandler("orgkey.", false))
+	}
+
+	s.GlobalConfig = gw.GetConfig()
+
+	scheme := "http://"
+	if s.GlobalConfig.HttpServerOptions.UseSSL {
+		scheme = "https://"
+	}
+
+	s.URL = scheme + gw.DefaultProxyMux.getProxy(gw.GetConfig().ListenPort, gw.GetConfig()).listener.Addr().String()
+
+	s.testRunner = &test.HTTPTestRunner{
+		RequestBuilder: func(tc *test.TestCase) (*http.Request, error) {
+			tc.BaseURL = s.URL
+			if tc.ControlRequest {
+				if s.config.SeparateControlAPI {
+					tc.BaseURL = scheme + s.controlProxy().listener.Addr().String()
+				} else if s.GlobalConfig.ControlAPIHostname != "" {
+					tc.Domain = s.GlobalConfig.ControlAPIHostname
+				}
+			}
+			r, err := test.NewRequest(tc)
+
+			if tc.AdminAuth {
+				r = s.withAuth(r)
+			}
+
+			if s.config.Delay > 0 {
+				tc.Delay = s.config.Delay
+			}
+
+			return r, err
+		},
+		Do: test.HttpServerRunner(),
+	}
+
+	return gw
+}
+
+// Close is the shutdown lifecycle for a gateway integration test w/ storage.
+func (s *Test) Close() {
+	defer s.cancel()
+
+	for _, p := range s.Gw.DefaultProxyMux.proxies {
+		if p.listener != nil {
+			p.listener.Close()
+		}
+	}
+
+	gwConfig := s.Gw.GetConfig()
+
+	s.Gw.DefaultProxyMux.swap(&proxyMux{}, s.Gw)
+	if s.config.SeparateControlAPI {
+		gwConfig.ControlAPIPort = 0
+		s.Gw.SetConfig(gwConfig)
+	}
+
+	// if jsvm enabled we need to unmount to prevent high memory consumption
+	if s.Gw.GetConfig().EnableJSVM {
+		s.Gw.GlobalEventsJSVM.VM = nil
+	}
+
+	ctxShutDown, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := s.HttpHandler.Shutdown(ctxShutDown)
+	if err != nil {
+		log.WithError(err).Error("shutting down the http handler")
+	} else {
+		log.Info("server exited properly")
+	}
+
+	s.Gw.Analytics.Stop()
+	s.Gw.ReloadTestCase.StopTicker()
+	s.Gw.GlobalHostChecker.StopPoller()
+	s.Gw.NewRelicApplication.Shutdown(5 * time.Second)
+
+	err = s.RemoveApis()
+	if err != nil {
+		log.WithError(err).Error("could not remove apis")
+	}
+
+	s.Gw.cacheClose()
+}


### PR DESCRIPTION
### **PR Type**

Enhancement, Tests

- [ ] pass genConf via *Test, add functional option for it
- [ ] add functional option to set the config explicitly
- [ ] default constructor should not take genConf (by usage it's 10:1)

___

### **Description**
- Removed `dnsmock` dependency and related code from tests.

- Introduced `NewTest` API with functional options for test configuration.

- Refactored lifecycle management into a new `test.go` file.

- Simplified and streamlined test setup and teardown processes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reverse_proxy_test.go</strong><dd><code>Remove `dnsmock` and update test setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/reverse_proxy_test.go

<li>Removed <code>dnsmock</code> usage and related setup/teardown calls.<br> <li> Updated test setup to use new <code>flakySetupTestReverseProxyDnsCache</code>.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6875/files#diff-ce040f6555143f760fba6059744bc600b6954f0966dfb0fa2832b5eabf7a3c3f">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test.go</strong><dd><code>Introduce `Test` struct and `NewTest` API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/test.go

<li>Added a new <code>Test</code> struct for managing test lifecycle.<br> <li> Introduced <code>NewTest</code> API with functional options for configuration.<br> <li> Implemented lifecycle methods like <code>start</code> and <code>Close</code>.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6875/files#diff-f670faa025c42c7b8bcab156073b19514efd878d2951093017e20bf3d4c2c15a">+181/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>testutil.go</strong><dd><code>Remove `dnsmock` and refactor test utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/testutil.go

<li>Removed <code>dnsmock</code> initialization and related configuration.<br> <li> Deleted redundant <code>Test</code> struct and lifecycle methods.<br> <li> Simplified <code>StartTest</code> and removed unused fields.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6875/files#diff-7aaf6ae49fb8f58a8c99d337fedd15b3e430dd928ed547e425ef429b10d28ce8">+0/-148</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>