### PR TITLE
wip: [TT-13440] fix: correctly sync multi-value response headers with coprocess middleware

### DIFF
--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -619,7 +619,7 @@ func syncHeadersAndMultiValueHeaders(headers map[string]string, multiValueHeader
 		for _, header := range multiValueHeaders {
 			if header.Key == k {
 				found = true
-				header.Values = []string{v}
+				header.Values[0] = v
 				break
 			}
 		}

--- a/gateway/coprocess_test.go
+++ b/gateway/coprocess_test.go
@@ -214,6 +214,24 @@ func TestSyncHeadersAndMultiValueHeaders(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "keeping multivalue headers",
+			headers: map[string]string{
+				"Header": "newValue1",
+			},
+			initialMultiValueHeaders: []*coprocess.Header{
+				{
+					Key:    "Header",
+					Values: []string{"oldValue1", "value2"},
+				},
+			},
+			expectedMultiValueHeaders: []*coprocess.Header{
+				{
+					Key:    "Header",
+					Values: []string{"newValue1", "value2"},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

When synchronizing single- and multi-valued header representations (of coprocess-based middleware responses) the list of values for any multi-valued header is currently replaced by a list containing only the value given by its single-value representation effectively dropping all but the first value. Instead synchronization should affect/replace only the first value and retain possibly remaining values.

<!-- Describe your changes in detail -->

## Related Issue
https://tyktech.atlassian.net/browse/TT-13440
https://github.com/TykTechnologies/tyk/issues/6411

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
We like to employ Tyk Gateway with a coprocess-based response middleware attached to an upstream possibly responding with multiple _Set-Cookie_ headers. We also require our middleware to modify other headers like _Location_. As is due to synchronization only the first _Set-Cookie_ header passes our middleware.

## How This Has Been Tested

This PR adds a [test](https://github.com/TykTechnologies/tyk/pull/6872/commits/fe1d9c49af5a464ecb0ea2dba46fe0513b4414bf#diff-9cbfe628982b2afb94d1e9a5200fc9a4fdc00cb58fe65d1090a3725e4e4c5953).

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed synchronization of multi-value headers in coprocess middleware.

- Modified `syncHeadersAndMultiValueHeaders` to retain additional header values.

- Added a new test case to validate multi-value header retention.

- Ensured existing functionality remains unaffected with updated logic.
