### PR TITLE
remove logic that stops gw loading until emergency mode is triggered or rpc conn is successful

### DIFF
--- a/rpc/rpc_client.go
+++ b/rpc/rpc_client.go
@@ -303,8 +303,7 @@ func Connect(connConfig Config, suppressRegister bool, dispatcherFuncs map[strin
 	if funcClientSingleton == nil {
 		funcClientSingleton = dispatcher.NewFuncClient(clientSingleton)
 	}
-	// wait until a connection is dialed so we can call login or fall in emergency mode
-	waitForClientReadiness(clientSingleton)
+
 	handleLogin()
 
 	if !suppressRegister {
@@ -313,23 +312,6 @@ func Connect(connConfig Config, suppressRegister bool, dispatcherFuncs map[strin
 	}
 
 	return true
-}
-
-func waitForClientReadiness(clientSingleton *gorpc.Client) {
-	ticker := time.NewTicker(100 * time.Millisecond)
-	defer ticker.Stop()
-
-	for {
-		if IsEmergencyMode() {
-			return
-		}
-
-		select {
-		case <-clientSingleton.ClientReadyChan:
-			return
-		case <-ticker.C:
-		}
-	}
 }
 
 func handleLogin() {


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-14089" title="TT-14089" target="_blank">TT-14089</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Gateway: Cold start does not initialize gateway after restart </td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Test</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---



<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Bug fix


___

### **Description**
- Removed logic that delays gateway loading until emergency mode or RPC connection.

- Simplified the `Connect` function by removing `waitForClientReadiness`.

- Ensured gateway initialization proceeds without waiting for RPC readiness.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_client.go</strong><dd><code>Removed client readiness wait logic in RPC connection</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rpc/rpc_client.go

<li>Removed the <code>waitForClientReadiness</code> function entirely.<br> <li> Updated <code>Connect</code> function to no longer wait for client readiness.<br> <li> Simplified the flow for handling login and registration.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6890/files#diff-3b88914c99bb9418e44e6389ce73579843562e8900730b380d7fff2e95c51033">+1/-19</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>