### PR TITLE
Merging to release-5.3.10: [TT-13440] correctly sync multi-value response headers with coprocess middleware (#6883)

### DIFF
--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -611,6 +611,7 @@ func (h *CustomMiddlewareResponseHook) HandleResponse(rw http.ResponseWriter, re
 // syncHeadersAndMultiValueHeaders synchronizes the content of 'headers' and 'multiValueHeaders'.
 // If a key is updated or added in 'headers', the corresponding key in 'multiValueHeaders' is also updated or added.
 // If a key is removed from 'headers', the corresponding key in 'multiValueHeaders' is also removed.
+// If multiValuesHeaders contains a key with multiple values and the same key is present in headers, the first value in multiValuesHeaders is updated with the value from headers, while the remaining values remain unchanged.
 func syncHeadersAndMultiValueHeaders(headers map[string]string, multiValueHeaders []*coprocess.Header) []*coprocess.Header {
 	updatedMultiValueHeaders := []*coprocess.Header{}
 
@@ -619,7 +620,12 @@ func syncHeadersAndMultiValueHeaders(headers map[string]string, multiValueHeader
 		for _, header := range multiValueHeaders {
 			if header.Key == k {
 				found = true
-				header.Values = []string{v}
+
+				// if the key is present in multiValueHeaders, update the first value with the value from headers
+				if len(header.Values) > 0 {
+					header.Values[0] = v
+				}
+
 				break
 			}
 		}

--- a/gateway/coprocess_test.go
+++ b/gateway/coprocess_test.go
@@ -214,6 +214,60 @@ func TestSyncHeadersAndMultiValueHeaders(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "keeping multivalue headers",
+			headers: map[string]string{
+				"Header": "newValue1",
+			},
+			initialMultiValueHeaders: []*coprocess.Header{
+				{
+					Key:    "Header",
+					Values: []string{"oldValue1", "value2"},
+				},
+			},
+			expectedMultiValueHeaders: []*coprocess.Header{
+				{
+					Key:    "Header",
+					Values: []string{"newValue1", "value2"},
+				},
+			},
+		},
+		{
+			name: "empty multi value headers",
+			headers: map[string]string{
+				"Header": "newValue1",
+			},
+			initialMultiValueHeaders: []*coprocess.Header{},
+			expectedMultiValueHeaders: []*coprocess.Header{
+				{Key: "Header", Values: []string{"newValue1"}},
+			},
+		},
+		{
+			name: "multiple Set-Cookie headers",
+			headers: map[string]string{
+				"Set-Cookie": "session=abc123; Path=/",
+			},
+			initialMultiValueHeaders: []*coprocess.Header{
+				{
+					Key: "Set-Cookie",
+					Values: []string{
+						"session=dce123; Path=/",
+						"user=john; Path=/",
+						"theme=dark; Path=/",
+					},
+				},
+			},
+			expectedMultiValueHeaders: []*coprocess.Header{
+				{
+					Key: "Set-Cookie",
+					Values: []string{
+						"session=abc123; Path=/",
+						"user=john; Path=/",
+						"theme=dark; Path=/",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
[TT-13440] correctly sync multi-value response headers with coprocess middleware (#6883)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-13440"
title="TT-13440" target="_blank">TT-13440</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
<td>[Community PR] Multi-value response headers are lost after sync with
coprocess middleware</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Code Review</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20community_bug%20ORDER%20BY%20created%20DESC"
title="community_bug">community_bug</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20github%20ORDER%20BY%20created%20DESC"
title="github">github</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

…ewares


<!-- Provide a general summary of your changes in the Title above -->

## Description

When synchronizing single- and multi-valued header representations (of
coprocess-based middleware responses) the list of values for any
multi-valued header is currently replaced by a list containing only the
value given by its single-value representation effectively dropping all
but the first value. Instead synchronization should affect/replace only
the first value and retain possibly remaining values.

<!-- Describe your changes in detail -->

## Related Issue
https://tyktech.atlassian.net/browse/TT-13440
https://github.com/TykTechnologies/tyk/issues/6411

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
We like to employ Tyk Gateway with a coprocess-based response middleware
attached to an upstream possibly responding with multiple _Set-Cookie_
headers. We also require our middleware to modify other headers like
_Location_. As is due to synchronization only the first _Set-Cookie_
header passes our middleware.

## How This Has Been Tested

This PR adds a
[test](https://github.com/TykTechnologies/tyk/pull/6883/files#diff-c0fdc6fa7ea0ffd782deb36e7843d48aefff201af73e79a2c742027cf4557f5f)
which should fail without proposed
[fix](https://github.com/TykTechnologies/tyk/pull/6883/files#diff-9cbfe628982b2afb94d1e9a5200fc9a4fdc00cb58fe65d1090a3725e4e4c5953).

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed synchronization of multi-value headers in coprocess middleware.

- Modified `syncHeadersAndMultiValueHeaders` to retain additional header
values.

- Added a new test case to validate multi-value header retention.

- Ensured existing functionality remains unaffected with updated logic.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>coprocess.go</strong><dd><code>Update multi-value
header synchronization logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/coprocess.go

<li>Enhanced synchronization logic for multi-value headers.<br> <li>
Ensured first value in multi-value headers matches single-value
<br>headers.<br> <li> Preserved additional values in multi-value headers
during updates.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6883/files#diff-9cbfe628982b2afb94d1e9a5200fc9a4fdc00cb58fe65d1090a3725e4e4c5953">+7/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>coprocess_test.go</strong><dd><code>Add tests for
multi-value header synchronization</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/coprocess_test.go

<li>Added test cases for multi-value header synchronization.<br> <li>
Covered scenarios with empty and multiple Set-Cookie headers.<br> <li>
Verified preservation of additional values in multi-value headers.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6883/files#diff-c0fdc6fa7ea0ffd782deb36e7843d48aefff201af73e79a2c742027cf4557f5f">+54/-0</a>&nbsp;
&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary> Need help?</summary><li>Type <code>/help how to
...</code> in the comments thread for any questions about PR-Agent
usage.</li><li>Check out the <a
href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a>
for more information.</li></details>

---------

Co-authored-by: Sebastian Kehr <kehr@iat.uni-leipzig.de>