### PR TITLE
[TT-14100] fix requireSession in OAS for custom auth plugins

### DIFF
--- a/apidef/oas/authentication.go
+++ b/apidef/oas/authentication.go
@@ -755,6 +755,8 @@ type AuthenticationPlugin struct {
 	Path string `bson:"path" json:"path"`
 	// RawBodyOnly if set to true, do not fill body in request or response object.
 	RawBodyOnly bool `bson:"rawBodyOnly,omitempty" json:"rawBodyOnly,omitempty"`
+	// RequireSession passes down the session information for plugins after authentication.
+	RequireSession bool `bson:"requireSession,omitempty" json:"requireSession,omitempty"`
 	// IDExtractor configures ID extractor with coprocess custom authentication.
 	IDExtractor *IDExtractor `bson:"idExtractor,omitempty" json:"idExtractor,omitempty"`
 }
@@ -763,6 +765,7 @@ func (ap *AuthenticationPlugin) Fill(api apidef.APIDefinition) {
 	ap.FunctionName = api.CustomMiddleware.AuthCheck.Name
 	ap.Path = api.CustomMiddleware.AuthCheck.Path
 	ap.RawBodyOnly = api.CustomMiddleware.AuthCheck.RawBodyOnly
+	ap.RequireSession = api.CustomMiddleware.AuthCheck.RequireSession
 	ap.Enabled = !api.CustomMiddleware.AuthCheck.Disabled
 	if ap.IDExtractor == nil {
 		ap.IDExtractor = &IDExtractor{}
@@ -779,6 +782,7 @@ func (ap *AuthenticationPlugin) ExtractTo(api *apidef.APIDefinition) {
 	api.CustomMiddleware.AuthCheck.Name = ap.FunctionName
 	api.CustomMiddleware.AuthCheck.Path = ap.Path
 	api.CustomMiddleware.AuthCheck.RawBodyOnly = ap.RawBodyOnly
+	api.CustomMiddleware.AuthCheck.RequireSession = ap.RequireSession
 
 	if ap.IDExtractor == nil {
 		ap.IDExtractor = &IDExtractor{}

--- a/apidef/oas/authentication_test.go
+++ b/apidef/oas/authentication_test.go
@@ -181,9 +181,10 @@ func TestCustomPlugin(t *testing.T) {
 			expectedCustomPluginAuth := CustomPluginAuthentication{
 				Enabled: true,
 				Config: &AuthenticationPlugin{
-					Enabled:      true,
-					FunctionName: "Auth",
-					Path:         "/path/to/plugin",
+					Enabled:        true,
+					FunctionName:   "Auth",
+					Path:           "/path/to/plugin",
+					RequireSession: true,
 				},
 			}
 
@@ -202,9 +203,10 @@ func TestCustomPlugin(t *testing.T) {
 			expectedCustomPluginAuth := CustomPluginAuthentication{
 				Enabled: true,
 				Config: &AuthenticationPlugin{
-					Enabled:      true,
-					FunctionName: "Auth",
-					Path:         "/path/to/plugin",
+					Enabled:        true,
+					FunctionName:   "Auth",
+					Path:           "/path/to/plugin",
+					RequireSession: true,
 				},
 				AuthSources: AuthSources{
 					Header: &AuthSource{

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -405,6 +405,9 @@
         "rawBodyOnly": {
           "type": "boolean"
         },
+        "requireSession": {
+          "type": "boolean"
+        },
         "idExtractor": {
           "$ref": "#/definitions/X-Tyk-IDExtractor"
         }

--- a/apidef/oas/schema/x-tyk-api-gateway.strict.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.strict.json
@@ -426,6 +426,9 @@
         "rawBodyOnly": {
           "type": "boolean"
         },
+        "requireSession": {
+          "type": "boolean"
+        },
         "idExtractor": {
           "$ref": "#/definitions/X-Tyk-IDExtractor"
         }


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-14100" title="TT-14100" target="_blank">TT-14100</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>[OAS] Auth plugin cannot set require_session</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

This PR fixes an issue with `requireSession` in custom auth plugins for OAS

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added `RequireSession` field to `AuthenticationPlugin` struct.

- Updated `Fill` and `ExtractTo` methods to handle `RequireSession`.

- Enhanced unit tests to validate `RequireSession` functionality.

- Fixed issue with custom auth plugins not setting `requireSession`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>authentication.go</strong><dd><code>Add and handle `RequireSession` in `AuthenticationPlugin`</code></dd></summary>
<hr>

apidef/oas/authentication.go

<li>Added <code>RequireSession</code> field to <code>AuthenticationPlugin</code> struct.<br> <li> Updated <code>Fill</code> method to populate <code>RequireSession</code>.<br> <li> Updated <code>ExtractTo</code> method to extract <code>RequireSession</code>.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6893/files#diff-e51c9d24d4235e7cc53048cc1d92967d177585ba5e073f14876308a97bef6326">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>authentication_test.go</strong><dd><code>Add tests for `RequireSession` in custom plugins</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/authentication_test.go

<li>Updated test cases to include <code>RequireSession</code> validation.<br> <li> Ensured <code>RequireSession</code> is correctly set in <code>goplugin</code> and <code>coprocess</code>.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6893/files#diff-039d0613514b07cabea08e47b93ef0a9c4500ed188f1ef040f8ddee65dd34487">+8/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>