### PR TITLE
[TT-14084] External OAuth is migrated as Keyless

### DIFF
--- a/apidef/oas/security.go
+++ b/apidef/oas/security.go
@@ -599,7 +599,14 @@ type ExternalOAuth struct {
 func (s *OAS) fillExternalOAuth(api apidef.APIDefinition) {
 	authConfig, ok := api.AuthConfigs[apidef.ExternalOAuthType]
 	if !ok || authConfig.Name == "" {
-		return
+		if !api.ExternalOAuth.Enabled {
+			return
+		}
+		// Assign a sensible default to authConfig if api.ExternalOAuth.Enabled is true.
+		authConfig = apidef.AuthConfig{
+			Name:          apidef.ExternalOAuthType,
+			DisableHeader: true,
+		}
 	}
 
 	s.fillOAuthSchemeForExternal(authConfig.Name)

--- a/apidef/oas/security_test.go
+++ b/apidef/oas/security_test.go
@@ -517,6 +517,23 @@ func TestOAS_ExternalOAuth(t *testing.T) {
 	assert.Equal(t, flows.AuthorizationCode.TokenURL, "{api-url}/oauth/token")
 
 	assert.Equal(t, oas, convertedOAS)
+
+	t.Run("when externalOAuthType doesn't exist in AuthConfigs", func(t *testing.T) {
+		// Delete externalOAuth config from AuthConfigs map, a sensible default config will be used by
+		// OAS.fillExternalOAuth method.
+		delete(api.AuthConfigs, apidef.ExternalOAuthType)
+
+		var convertedOASWithoutExternalOAuth OAS
+		convertedOASWithoutExternalOAuth.Components = &openapi3.Components{SecuritySchemes: oas.Components.SecuritySchemes}
+		convertedOASWithoutExternalOAuth.Fill(api)
+		authFlows := convertedOASWithoutExternalOAuth.Components.SecuritySchemes[securityName].Value.Flows
+		assert.Equal(t, authFlows.AuthorizationCode.AuthorizationURL, "{api-url}/oauth/authorize")
+		assert.Equal(t, authFlows.AuthorizationCode.TokenURL, "{api-url}/oauth/token")
+		assert.Equal(t,
+			oas.Components.SecuritySchemes[apidef.ExternalOAuthType],
+			convertedOASWithoutExternalOAuth.Components.SecuritySchemes[apidef.ExternalOAuthType],
+		)
+	})
 }
 
 func TestOAS_OIDC(t *testing.T) {


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-14084" title="TT-14084" target="_blank">TT-14084</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>[OAS Migration] External OAuth is migrated as Keyless</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

PR for [TT-14084](https://tyktech.atlassian.net/browse/TT-14084)

I preferred keeping the existing code that processes `AuthConfig` for `externalOAuth` type because, `AuthSources` has embedded into `ExternalOAuth` and there is code for migrating `externalOAuth` config from `AuthConfig` to OAS definition. 

The fix assigns a default value to `authConfig` if it doesn't define in `apidef.AuthConfig` but  `api.ExternalOAuth.Enabled` is `true`.

I used the default `apidef.AuthConfig` definition from `OAS.extractExternalOAuthTo` method.

[TT-14084]: https://tyktech.atlassian.net/browse/TT-14084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added a default `authConfig` when `externalOAuthType` is missing.

- Ensured `authConfig` is only set if `api.ExternalOAuth.Enabled` is true.

- Updated test cases to validate default `authConfig` behavior.

- Improved handling of `externalOAuth` migration in OAS definitions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>security.go</strong><dd><code>Handle missing `authConfig` for External OAuth</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/security.go

<li>Added a default <code>authConfig</code> when <code>externalOAuthType</code> is missing.<br> <li> Ensured <code>authConfig</code> is set only if <code>api.ExternalOAuth.Enabled</code> is true.<br> <li> Modified logic in <code>fillExternalOAuth</code> to handle missing configurations.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6895/files#diff-15e7d47137452ca4f3f6139aa8c007cdb426152c41846f712f8bf5dfb607afcc">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>security_test.go</strong><dd><code>Add test for default `authConfig` behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/security_test.go

<li>Added a test case for missing <code>externalOAuthType</code> in <code>AuthConfigs</code>.<br> <li> Verified default <code>authConfig</code> behavior in <code>fillExternalOAuth</code>.<br> <li> Ensured test coverage for <code>ExternalOAuth</code> migration logic.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6895/files#diff-5184167309db0462243e424baca87b5bb668962d8cc1076629fdcf11f00487e5">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>