### PR TITLE
TT-14192: Consistent use of imported package for gojsonschema, lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,6 +52,7 @@ linters:
     - errorlint # debt: measure error handling improvements
     - nilerr # debt: measure code that returns nil on non-nil error
     - revive # keep - measured for stats, shows code smells
+    - gomodguard # keep - for dependency management/enforcement
 
 linters-settings:
   fobidigo:
@@ -91,6 +92,17 @@ linters-settings:
       - time.Parse
       - strconv.ParseBool
       - strconv.ParseInt
+
+  # https://golangci-lint.run/usage/linters/#gomodguard
+  gomodguard:
+    blocked:
+      modules:
+        - "github.com/xeipuuv/gojsonschema":
+            recommendations:
+              - "github.com/TykTechnologies/internal/service/gojsonschema"
+            reason: "import pollution, unmaintained package"
+    # replaces are undesired due to CGO/plugins
+    local_replace_directives: true
 
 issues:
   max-issues-per-linter: 0
@@ -136,6 +148,9 @@ issues:
         - gocyclo # many functions can be very long
         - funlen # many functions can be very long
         - gosec # tests don't have CVEs
+    - path: ^internal/service/
+      linters:
+        - gomodguard
   exclude:
     - G404    # Use of weak random number generator (math/rand instead of crypto/rand)
     - SA9004  # only the first constant in this group has an explicit type

--- a/apidef/oas/linter_test.go
+++ b/apidef/oas/linter_test.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/xeipuuv/gojsonschema"
 
 	"github.com/TykTechnologies/tyk/internal/event"
+	"github.com/TykTechnologies/tyk/internal/service/gojsonschema"
 	"github.com/TykTechnologies/tyk/internal/time"
 )
 

--- a/apidef/oas/validator.go
+++ b/apidef/oas/validator.go
@@ -12,9 +12,9 @@ import (
 	"github.com/buger/jsonparser"
 	"github.com/hashicorp/go-multierror"
 	pkgver "github.com/hashicorp/go-version"
-	"github.com/xeipuuv/gojsonschema"
 
 	tykerrors "github.com/TykTechnologies/tyk/internal/errors"
+	"github.com/TykTechnologies/tyk/internal/service/gojsonschema"
 	logger "github.com/TykTechnologies/tyk/log"
 )
 

--- a/apidef/streams/validator.go
+++ b/apidef/streams/validator.go
@@ -14,9 +14,9 @@ import (
 	"github.com/buger/jsonparser"
 	"github.com/hashicorp/go-multierror"
 	pkgver "github.com/hashicorp/go-version"
-	"github.com/xeipuuv/gojsonschema"
 
 	"github.com/TykTechnologies/tyk/apidef/streams/bento"
+	"github.com/TykTechnologies/tyk/internal/service/gojsonschema"
 
 	tykerrors "github.com/TykTechnologies/tyk/internal/errors"
 )

--- a/internal/service/gojsonschema/gojsonschema.go
+++ b/internal/service/gojsonschema/gojsonschema.go
@@ -4,9 +4,17 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 )
 
-type JSONLoader = gojsonschema.JSONLoader
-type ResultError = gojsonschema.ResultError
+type (
+	JSONLoader              = gojsonschema.JSONLoader
+	ResultError             = gojsonschema.ResultError
+	Result                  = gojsonschema.Result
+	FormatCheckerChain      = gojsonschema.FormatCheckerChain
+	DoesNotMatchFormatError = gojsonschema.DoesNotMatchFormatError
+)
 
-var NewBytesLoader = gojsonschema.NewBytesLoader
-var NewGoLoader = gojsonschema.NewGoLoader
-var Validate = gojsonschema.Validate
+var (
+	NewBytesLoader = gojsonschema.NewBytesLoader
+	NewGoLoader    = gojsonschema.NewGoLoader
+	FormatCheckers = gojsonschema.FormatCheckers
+	Validate       = gojsonschema.Validate
+)


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix

https://tyktech.atlassian.net/browse/TT-14192
___

### **Description**
- Replaced direct imports of `gojsonschema` with an internal wrapper package.

- Added `gomodguard` linter to enforce dependency management rules.

- Updated `.golangci.yml` to block `gojsonschema` and recommend the internal wrapper.

- Enhanced internal wrapper for `gojsonschema` with additional type aliases and variables.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>linter_test.go</strong><dd><code>Use internal wrapper for `gojsonschema` in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/linter_test.go

<li>Replaced <code>gojsonschema</code> import with internal wrapper.<br> <li> Updated references to use the internal wrapper package.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6902/files#diff-b92239afd81e77a829fe7fe8410044dfd4dfda525d17dbf5f8811714a9c986d3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>validator.go</strong><dd><code>Switch to internal wrapper for `gojsonschema`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/validator.go

<li>Replaced <code>gojsonschema</code> import with internal wrapper.<br> <li> Updated references to use the internal wrapper package.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6902/files#diff-5a0a9da02098e9cfc6b907a281b6e1229c960c33c0efb39fe87a18f3356a6e64">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>validator.go</strong><dd><code>Migrate `gojsonschema` usage to internal wrapper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/streams/validator.go

<li>Replaced <code>gojsonschema</code> import with internal wrapper.<br> <li> Updated references to use the internal wrapper package.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6902/files#diff-351cfcacb241ec2c3a3172d8c17e1217d6e942b5962081e7f9fd1582e801ca7f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>linter.go</strong><dd><code>Refactor `gojsonschema` usage to internal wrapper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/linter/linter.go

<li>Replaced <code>gojsonschema</code> import with internal wrapper.<br> <li> Updated function calls to use internal wrapper.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6902/files#diff-17b2a65a9143043763498d0464d38d5098cf1b985e865cf76af8944020d3be9d">+8/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gojsonschema.go</strong><dd><code>Enhance internal wrapper for `gojsonschema`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/service/gojsonschema/gojsonschema.go

<li>Added type aliases for <code>gojsonschema</code> types.<br> <li> Added variables for <code>gojsonschema</code> functions and constants.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6902/files#diff-7f0567f192acf04d784fd4644157c449758a6b33aefadc297ae23dabe3843e81">+13/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.golangci.yml</strong><dd><code>Add `gomodguard` linter and block `gojsonschema`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.golangci.yml

<li>Added <code>gomodguard</code> linter for dependency management.<br> <li> Blocked <code>gojsonschema</code> and recommended internal wrapper.<br> <li> Configured <code>gomodguard</code> for local replace directives.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6902/files#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>