### PR TITLE
[TT-13936] Improve RPC connection handling for user key reset events

### DIFF
--- a/gateway/redis_signals.go
+++ b/gateway/redis_signals.go
@@ -387,8 +387,12 @@ func (gw *Gateway) handleUserKeyReset(payload string) {
 		// If we're using a KV store, update the API key there as well
 		gw.updateKeyInStore(config.Private.EdgeOriginalAPIKeyPath, newKey)
 
-		if store, ok := gw.GlobalSessionManager.Store().(*RPCStorageHandler); ok {
-			store.Connect()
+		if gw.isRPCMode() {
+			ok := gw.RPCListener.Connect()
+			if !ok {
+				log.Error("Failed to establish RPC connection")
+			}
+
 		}
 	}
 }

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -1074,6 +1074,10 @@ func (r *RPCStorageHandler) ProcessKeySpaceChanges(keys []string, orgId string) 
 	for oldKey, newKey := range userKeyResets {
 		if r.Gw.GetConfig().SlaveOptions.APIKey == oldKey {
 			config := r.Gw.GetConfig()
+
+			// Updating the key in the KV store if we are using one
+			r.Gw.updateKeyInStore(config.Private.EdgeOriginalAPIKeyPath, newKey)
+
 			config.SlaveOptions.APIKey = newKey
 			r.Gw.SetConfig(config)
 			connected := r.Connect()


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-13936" title="TT-13936" target="_blank">TT-13936</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>(Gateway) Key Rotation for MDCB Data Planes</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Code Review</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20QA_Fail%20ORDER%20BY%20created%20DESC" title="QA_Fail">QA_Fail</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description
- Updated `handleUserKeyReset` to use `isRPCMode()` and `RPCListener.Connect()`
- Added error logging for RPC connection failures
- Ensure key updates are propagated to KV store during key reset events
- Simplified RPC connection logic in key reset handling
<!-- Describe your changes in detail -->

## Related Issue
https://tyktech.atlassian.net/jira/software/c/projects/TT/boards/42?selectedIssue=TT-13936
<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context
https://tyktech.atlassian.net/jira/software/c/projects/TT/boards/42?selectedIssue=TT-13936
<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Improved RPC connection handling during user key reset events.

- Added error logging for RPC connection failures.

- Ensured key updates are propagated to the KV store.

- Simplified and streamlined RPC connection logic.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>redis_signals.go</strong><dd><code>Enhance RPC connection handling in `handleUserKeyReset`</code>&nbsp; &nbsp; </dd></summary>
<hr>

gateway/redis_signals.go

<li>Added <code>isRPCMode()</code> check before RPC connection attempts.<br> <li> Introduced error logging for failed RPC connections.<br> <li> Simplified logic for handling RPC connections during key resets.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6904/files#diff-18cb136722c238e19b02741a85510dfd464343f85365482f0873aa60a37718af">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_storage_handler.go</strong><dd><code>Improve key update and RPC connection logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/rpc_storage_handler.go

<li>Updated KV store with new key during user key resets.<br> <li> Added error handling for RPC connection failures.<br> <li> Streamlined logic for updating API keys in RPC mode.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6904/files#diff-8875f75b602664c44b62b67a4da41d748124ad270573a44db4ec977ee5d68021">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>