### PR TITLE
TT-14183: Fix uptimetests migrations, add fixtures, enabled flag

### DIFF
--- a/apidef/oas/oas_test.go
+++ b/apidef/oas/oas_test.go
@@ -211,6 +211,8 @@ func TestOAS_ExtractTo_ResetAPIDefinition(t *testing.T) {
 
 	a.VersionData.Versions[""] = vInfo
 
+	a.UptimeTests.Config.ServiceDiscovery.CacheDisabled = false
+
 	assert.Empty(t, a.Name)
 
 	noOASSupportFields := getNonEmptyFields(a, "APIDefinition")
@@ -232,7 +234,6 @@ func TestOAS_ExtractTo_ResetAPIDefinition(t *testing.T) {
 		"APIDefinition.VersionData.Versions[0].ExtendedPaths.PersistGraphQL[0].Method",
 		"APIDefinition.VersionData.Versions[0].ExtendedPaths.PersistGraphQL[0].Operation",
 		"APIDefinition.VersionData.Versions[0].ExtendedPaths.PersistGraphQL[0].Variables[0]",
-		"APIDefinition.UptimeTests.Config.ServiceDiscovery.CacheDisabled",
 		"APIDefinition.AuthProvider.Name",
 		"APIDefinition.AuthProvider.StorageEngine",
 		"APIDefinition.AuthProvider.Meta[0]",

--- a/apidef/oas/oas_test.go
+++ b/apidef/oas/oas_test.go
@@ -233,7 +233,6 @@ func TestOAS_ExtractTo_ResetAPIDefinition(t *testing.T) {
 		"APIDefinition.VersionData.Versions[0].ExtendedPaths.PersistGraphQL[0].Operation",
 		"APIDefinition.VersionData.Versions[0].ExtendedPaths.PersistGraphQL[0].Variables[0]",
 		"APIDefinition.UptimeTests.Config.ServiceDiscovery.CacheDisabled",
-		"APIDefinition.Proxy.CheckHostAgainstUptimeTests",
 		"APIDefinition.AuthProvider.Name",
 		"APIDefinition.AuthProvider.StorageEngine",
 		"APIDefinition.AuthProvider.Meta[0]",

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -2570,6 +2570,9 @@
     "X-Tyk-UptimeTests": {
       "type": "object",
       "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
         "hostDownRetestPeriod": {
           "$ref": "#/definitions/X-Tyk-ReadableDuration"
         },
@@ -2585,7 +2588,10 @@
             "$ref": "#/definitions/X-Tyk-UptimeTest"
           }
         }
-      }
+      },
+      "required": [
+        "enabled"
+      ]
     },
     "X-Tyk-ReadableDuration": {
       "type": "string",

--- a/apidef/oas/schema/x-tyk-api-gateway.strict.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.strict.json
@@ -2693,6 +2693,9 @@
     "X-Tyk-UptimeTests": {
       "type": "object",
       "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
         "hostDownRetestPeriod": {
           "$ref": "#/definitions/X-Tyk-ReadableDuration"
         },
@@ -2709,6 +2712,9 @@
           }
         }
       },
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     },
     "X-Tyk-ReadableDuration": {

--- a/apidef/oas/testdata/fixtures/upstream_uptimeTests.yml
+++ b/apidef/oas/testdata/fixtures/upstream_uptimeTests.yml
@@ -31,13 +31,15 @@ tests:
       proxy.check_host_against_uptime_tests: true
       uptime_tests.config.expire_utime_after: 10
       uptime_tests.config.recheck_wait: 20
-      uptime_tests.check_list.0.url: "https://www.google.com"
-      uptime_tests.check_list.0.protocol: "http"
-      uptime_tests.check_list.0.timeout: 1000000000
-      uptime_tests.check_list.0.method: "GET"
-      uptime_tests.check_list.0.headers.Content-Type: "application/json"
-      uptime_tests.check_list.0.body: "test"
-      uptime_tests.check_list.0.enable_proxy_protocol: true
+      uptime_tests:
+        check_list:
+          - url: "https://www.google.com"
+            protocol: "http"
+            timeout: 1000000000
+            method: "GET"
+            headers.Content-Type: "application/json"
+            body: "test"
+            enable_proxy_protocol: true
       serviceDiscovery: null
   - desc: "upstream uptime test classic"
     source: classic

--- a/apidef/oas/testdata/fixtures/upstream_uptimeTests.yml
+++ b/apidef/oas/testdata/fixtures/upstream_uptimeTests.yml
@@ -1,0 +1,56 @@
+---
+name: "Upstream uptime tests"
+tests:
+  - desc: "unset oas uptime tests"
+    source: oas
+    input:
+      x-tyk-api-gateway:
+        upstream: {}
+    output:
+      proxy:
+        check_host_against_uptime_tests: false
+  - desc: "upstream uptime test oas"
+    source: oas
+    input:
+      x-tyk-api-gateway:
+        upstream:
+          uptimeTests:
+            enabled: true
+            hostDownRetestPeriod: 20s
+            logRetentionPeriod: 10s
+    output:
+      proxy.check_host_against_uptime_tests: true
+      uptime_tests.config.expire_utime_after: 10
+      uptime_tests.config.recheck_wait: 20
+  - desc: "upstream uptime test classic"
+    source: classic
+    input:
+      proxy:
+        check_host_against_uptime_tests: true
+      uptime_tests:
+        config:
+          expire_utime_after: 10
+          recheck_wait: 20
+    output:
+      x-tyk-api-gateway:
+        upstream:
+          uptimeTests:
+            enabled: true
+            hostDownRetestPeriod: 20s
+            logRetentionPeriod: 10s
+  - desc: "upstream uptime test classic"
+    source: classic
+    input:
+      proxy:
+        check_host_against_uptime_tests: false
+      uptime_tests:
+        config:
+          expire_utime_after: 10
+          recheck_wait: 20
+    output:
+      x-tyk-api-gateway:
+        upstream:
+          uptimeTests:
+            enabled: false
+            hostDownRetestPeriod: 20s
+            logRetentionPeriod: 10s

--- a/apidef/oas/testdata/fixtures/upstream_uptimeTests.yml
+++ b/apidef/oas/testdata/fixtures/upstream_uptimeTests.yml
@@ -40,7 +40,7 @@ tests:
             headers.Content-Type: "application/json"
             body: "test"
             enable_proxy_protocol: true
-      serviceDiscovery: null
+      serviceDiscovery: <nil>
   - desc: "upstream uptime test classic"
     source: classic
     input:
@@ -60,7 +60,7 @@ tests:
     output:
       x-tyk-api-gateway:
         upstream:
-          serviceDiscovery: null
+          serviceDiscovery: <nil>
           uptimeTests:
             enabled: true
             hostDownRetestPeriod: 20s
@@ -92,7 +92,7 @@ tests:
     output:
       x-tyk-api-gateway:
         upstream:
-          serviceDiscovery: null
+          serviceDiscovery: <nil>
           uptimeTests:
             enabled: false
             hostDownRetestPeriod: 20s
@@ -130,7 +130,7 @@ tests:
     output:
       x-tyk-api-gateway:
         upstream:
-          serviceDiscovery: null
+          serviceDiscovery: <nil>
           uptimeTests:
             enabled: false
             hostDownRetestPeriod: 20s

--- a/apidef/oas/testdata/fixtures/upstream_uptimeTests.yml
+++ b/apidef/oas/testdata/fixtures/upstream_uptimeTests.yml
@@ -18,10 +18,27 @@ tests:
             enabled: true
             hostDownRetestPeriod: 20s
             logRetentionPeriod: 10s
+            tests:
+            - url: "https://www.google.com"
+              protocol: "http"
+              timeout: 1s
+              method: "GET"
+              enableProxyProtocol: true
+              headers:
+                "Content-Type": "application/json"
+              body: "test"
     output:
       proxy.check_host_against_uptime_tests: true
       uptime_tests.config.expire_utime_after: 10
       uptime_tests.config.recheck_wait: 20
+      uptime_tests.check_list.0.url: "https://www.google.com"
+      uptime_tests.check_list.0.protocol: "http"
+      uptime_tests.check_list.0.timeout: 1000000000
+      uptime_tests.check_list.0.method: "GET"
+      uptime_tests.check_list.0.headers.Content-Type: "application/json"
+      uptime_tests.check_list.0.body: "test"
+      uptime_tests.check_list.0.enable_proxy_protocol: true
+      serviceDiscovery: null
   - desc: "upstream uptime test classic"
     source: classic
     input:
@@ -31,13 +48,28 @@ tests:
         config:
           expire_utime_after: 10
           recheck_wait: 20
+        check_list:
+          - url: "https://www.google.com"
+            protocol: "http"
+            timeout: 2000000
+            method: "GET"
+            headers:
+              "Content-Type": "application/json"
     output:
       x-tyk-api-gateway:
         upstream:
+          serviceDiscovery: null
           uptimeTests:
             enabled: true
             hostDownRetestPeriod: 20s
             logRetentionPeriod: 10s
+            tests:
+            - url: "https://www.google.com"
+              protocol: "http"
+              timeout: 2ms
+              method: "GET"
+              headers:
+                "Content-Type": "application/json"
   - desc: "upstream uptime test classic"
     source: classic
     input:
@@ -47,10 +79,70 @@ tests:
         config:
           expire_utime_after: 10
           recheck_wait: 20
+        check_list:
+          - url: "https://www.google.com"
+            protocol: "http"
+            timeout: 2000000000
+            method: "GET"
+            enable_proxy_protocol: true
+            headers:
+              "Content-Type": "application/json"
     output:
       x-tyk-api-gateway:
         upstream:
+          serviceDiscovery: null
           uptimeTests:
             enabled: false
             hostDownRetestPeriod: 20s
             logRetentionPeriod: 10s
+            tests:
+            - url: "https://www.google.com"
+              protocol: "http"
+              timeout: 2s
+              method: "GET"
+              enableProxyProtocol: true
+              headers:
+                "Content-Type": "application/json"
+  - desc: "upstream uptime test classic - commands"
+    source: classic
+    input:
+      proxy:
+        check_host_against_uptime_tests: false
+      uptime_tests:
+        config:
+          expire_utime_after: 10
+          recheck_wait: 20
+        check_list:
+          - url: "https://www.google.com"
+            protocol: "http"
+            timeout: 2000000000
+            method: "GET"
+            enable_proxy_protocol: true
+            headers:
+              "Content-Type": "application/json"
+            commands:
+            - name: send
+              message: "test"
+            - name: expect
+              message: "test2"
+    output:
+      x-tyk-api-gateway:
+        upstream:
+          serviceDiscovery: null
+          uptimeTests:
+            enabled: false
+            hostDownRetestPeriod: 20s
+            logRetentionPeriod: 10s
+            tests:
+            - url: "https://www.google.com"
+              protocol: "http"
+              timeout: 2s
+              method: "GET"
+              enableProxyProtocol: true
+              headers:
+                "Content-Type": "application/json"
+              commands:
+              - name: send
+                message: "test"
+              - name: expect
+                message: "test2"

--- a/apidef/oas/upstream.go
+++ b/apidef/oas/upstream.go
@@ -665,12 +665,13 @@ func (t *UptimeTests) Fill(uptimeTests apidef.UptimeTests, enabled bool) {
 	result := []UptimeTest{}
 	for _, v := range uptimeTests.CheckList {
 		check := UptimeTest{
-			CheckURL: v.CheckURL,
-			Protocol: v.Protocol,
-			Timeout:  ReadableDuration(v.Timeout),
-			Method:   v.Method,
-			Headers:  v.Headers,
-			Body:     v.Body,
+			CheckURL:            v.CheckURL,
+			Protocol:            v.Protocol,
+			Timeout:             ReadableDuration(v.Timeout),
+			Method:              v.Method,
+			Headers:             v.Headers,
+			Body:                v.Body,
+			EnableProxyProtocol: v.EnableProxyProtocol,
 		}
 		for _, command := range v.Commands {
 			check.AddCommand(command.Name, command.Message)
@@ -705,12 +706,13 @@ func (t *UptimeTests) ExtractTo(uptimeTests *apidef.UptimeTests, enabled *bool) 
 	result := []apidef.HostCheckObject{}
 	for _, v := range t.Tests {
 		check := apidef.HostCheckObject{
-			CheckURL: v.CheckURL,
-			Protocol: v.Protocol,
-			Timeout:  time.Duration(v.Timeout),
-			Method:   v.Method,
-			Headers:  v.Headers,
-			Body:     v.Body,
+			CheckURL:            v.CheckURL,
+			Protocol:            v.Protocol,
+			Timeout:             time.Duration(v.Timeout),
+			Method:              v.Method,
+			Headers:             v.Headers,
+			Body:                v.Body,
+			EnableProxyProtocol: v.EnableProxyProtocol,
 		}
 		for _, command := range v.Commands {
 			check.AddCommand(command.Name, command.Message)

--- a/apidef/oas/upstream_test.go
+++ b/apidef/oas/upstream_test.go
@@ -149,12 +149,13 @@ func TestServiceDiscovery(t *testing.T) {
 
 func TestUptimeTests(t *testing.T) {
 	var emptyTest UptimeTests
+	var enabled bool
 
 	var convertedTest apidef.UptimeTests
-	emptyTest.ExtractTo(&convertedTest)
+	emptyTest.ExtractTo(&convertedTest, &enabled)
 
 	var resultTest UptimeTests
-	resultTest.Fill(convertedTest)
+	resultTest.Fill(convertedTest, enabled)
 
 	assert.Equal(t, emptyTest, resultTest)
 }


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-14183" title="TT-14183" target="_blank">TT-14183</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Disabled uptime test is migrated to OAS</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Sub-task" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />
        Sub-task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%205.8.0Regression%20ORDER%20BY%20created%20DESC" title="5.8.0Regression">5.8.0Regression</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

Adds implementation for uptimeTest enabled and adds test fixtures to cover the migration


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added `enabled` flag to `UptimeTests` for better configuration.

- Updated `Fill` and `ExtractTo` methods to handle the `enabled` flag.

- Introduced new test fixtures for `UptimeTests` validation.

- Enhanced unit tests to validate `enabled` flag functionality.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>oas_test.go</strong><dd><code>Remove unused field reference in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/oas_test.go

- Removed unused `CheckHostAgainstUptimeTests` field reference.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6908/files#diff-74029ee88132d30d6478c96a35f8bb2200e0c8e6f42f2c9b147dc6bb7ce74644">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>upstream_test.go</strong><dd><code>Update unit tests for `enabled` flag in UptimeTests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/upstream_test.go

<li>Updated unit tests to include <code>enabled</code> flag validation.<br> <li> Ensured <code>Fill</code> and <code>ExtractTo</code> methods are tested with <code>enabled</code>.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6908/files#diff-222cc254c0c6c09fa0cf50087860b837a0873e2aef3c84ec7d80b1014c149057">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>upstream_uptimeTests.yml</strong><dd><code>Add test fixtures for UptimeTests with `enabled` flag</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/testdata/fixtures/upstream_uptimeTests.yml

<li>Added new test fixtures for <code>UptimeTests</code>.<br> <li> Included scenarios for <code>enabled</code> flag in both OAS and classic formats.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6908/files#diff-9a802e07cd2339df0a9e2bdf6bb2abf225f6258f9962bb2da139f9fcbc0e3e25">+56/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>upstream.go</strong><dd><code>Add and integrate `enabled` flag in UptimeTests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/upstream.go

<li>Added <code>enabled</code> flag to <code>UptimeTests</code> struct.<br> <li> Updated <code>Fill</code> and <code>ExtractTo</code> methods to handle <code>enabled</code> flag.<br> <li> Adjusted logic to ensure proper handling of <code>enabled</code> flag.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6908/files#diff-7b0941c7f37fe5a2a23047e0822a65519ca11c371660f36555b59a60f000e3f4">+14/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>