### PR TITLE
TT-14059: Extend service discovery tests and fixtures

### DIFF
--- a/apidef/oas/linter_test.go
+++ b/apidef/oas/linter_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -143,7 +142,7 @@ func TestXTykGateway_Lint(t *testing.T) {
 	require.NoError(t, err)
 
 	// Load schema
-	schema, err := os.ReadFile("schema/x-tyk-api-gateway.json")
+	schema, err := schemaDir.ReadFile("schema/x-tyk-api-gateway.strict.json")
 	require.NoError(t, err)
 
 	// Run schema validation

--- a/apidef/oas/schema/build.sh
+++ b/apidef/oas/schema/build.sh
@@ -4,4 +4,16 @@
 #
 # For development, we want this property set to validate the JSON schema
 # against the implementation and expose uncovered fields.
-jq -r '(.additionalProperties = false) | (.definitions |= map_values(. + {"additionalProperties": false}))' x-tyk-api-gateway.json > x-tyk-api-gateway.strict.json
+
+
+input="x-tyk-api-gateway.json"
+output="x-tyk-api-gateway.strict.json"
+
+cat $input \
+	| jq -r '(.additionalProperties = false) | (.definitions |= map_values(. + {"additionalProperties": false}))' \
+	| jq -r '.definitions["X-Tyk-EventHandlers"].additionalProperties = true' \
+	| jq -r '.definitions["X-Tyk-Webhook-With-ID"].additionalProperties = true' \
+	| jq -r '.definitions["X-Tyk-Webhook-Without-ID"].additionalProperties = true' \
+	| jq -r '.definitions["X-Tyk-JSVMEvent"].additionalProperties = true' \
+	| jq -r '.definitions["X-Tyk-LogEvent"].additionalProperties = true' \
+	> $output

--- a/apidef/oas/schema/x-tyk-api-gateway.strict.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.strict.json
@@ -2028,7 +2028,7 @@
           "$ref": "#/definitions/X-Tyk-LogEvent"
         }
       ],
-      "additionalProperties": false
+      "additionalProperties": true
     },
     "X-Tyk-Webhook-With-ID": {
       "type": "object",
@@ -2059,7 +2059,7 @@
         "id",
         "cooldownPeriod"
       ],
-      "additionalProperties": false
+      "additionalProperties": true
     },
     "X-Tyk-Webhook-Without-ID": {
       "type": "object",
@@ -2115,7 +2115,7 @@
         "cooldownPeriod",
         "bodyTemplate"
       ],
-      "additionalProperties": false
+      "additionalProperties": true
     },
     "X-Tyk-JSVMEvent": {
       "type": "object",
@@ -2150,7 +2150,7 @@
         "functionName",
         "path"
       ],
-      "additionalProperties": false
+      "additionalProperties": true
     },
     "X-Tyk-LogEvent": {
       "type": "object",
@@ -2181,7 +2181,7 @@
         "name",
         "logPrefix"
       ],
-      "additionalProperties": false
+      "additionalProperties": true
     },
     "X-Tyk-EventType": {
       "type": "string",

--- a/apidef/oas/testdata/fixtures/service_discovery.yml
+++ b/apidef/oas/testdata/fixtures/service_discovery.yml
@@ -34,3 +34,49 @@ tests:
         upstream:
           serviceDiscovery:
             enabled: true
+            cache:
+              enabled: true
+              timeout: 10
+  - desc: "From Classic to OAS"
+    source: classic
+    errors:
+      desc: "Errors are checked and wanted (general OAS validation)"
+      enabled: true
+      want: true
+    input:
+      name: "Name"
+      proxy:
+        service_discovery:
+          use_discovery_service: false
+          cache_disabled: true
+          cache_timeout: 10
+    output:
+      info:
+        title: "Name"
+      x-tyk-api-gateway:
+        upstream:
+          serviceDiscovery:
+            enabled: false
+            cache:
+              enabled: false
+              timeout: 10
+  # If service discovery is disabled (unconfigured) then honor
+  # cache_disabled=false as being still disabled.
+  - desc: "From Classic to OAS"
+    source: classic
+    errors:
+      desc: "Errors are checked and wanted (general OAS validation)"
+      enabled: true
+      want: true
+    input:
+      name: "Name"
+      proxy:
+        service_discovery:
+          use_discovery_service: false
+          cache_disabled: false
+    output:
+      info:
+        title: "Name"
+      x-tyk-api-gateway:
+        upstream:
+          serviceDiscovery: "<nil>"

--- a/apidef/oas/testdata/fixtures/service_discovery.yml
+++ b/apidef/oas/testdata/fixtures/service_discovery.yml
@@ -1,8 +1,9 @@
 ---
 name: "Service Discovery"
 tests:
-  - desc: "From OAS to Classic"
-    source: oas
+  - source: oas
+    desc: |
+      From OAS, enabling service discovery should fill expected classic fields.
     input:
       x-tyk-api-gateway:
         upstream:
@@ -14,8 +15,9 @@ tests:
           use_discovery_service: true
           cache_disabled: true
           cache_timeout: 0
-  - desc: "From Classic to OAS"
-    source: classic
+  - source: classic
+    desc: |
+      If service discovery is enabled, cache is not disabled, carry the settings to OAS.
     errors:
       desc: "Errors are checked and wanted (general OAS validation)"
       enabled: true
@@ -37,8 +39,10 @@ tests:
             cache:
               enabled: true
               timeout: 10
-  - desc: "From Classic to OAS"
-    source: classic
+  - source: classic
+    desc: |
+      If service discovery is disabled but cache is enabled, we consider the cache flag
+      reset to false. As the timeout is non-empty, we fill the OAS structure.
     errors:
       desc: "Errors are checked and wanted (general OAS validation)"
       enabled: true
@@ -60,10 +64,9 @@ tests:
             cache:
               enabled: false
               timeout: 10
-  # If service discovery is disabled (unconfigured) then honor
-  # cache_disabled=false as being still disabled.
-  - desc: "From Classic to OAS"
-    source: classic
+  - source: classic
+    desc: |
+      If service discovery is disabled (unconfigured) then honor cache_disabled=false as being still disabled.
     errors:
       desc: "Errors are checked and wanted (general OAS validation)"
       enabled: true


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-14059" title="TT-14059" target="_blank">TT-14059</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>[OAS Migration] Empty/disabled service discovery migrated to OAS</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%205.8.0Regression%20ORDER%20BY%20created%20DESC" title="5.8.0Regression">5.8.0Regression</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20QA_Fail%20ORDER%20BY%20created%20DESC" title="QA_Fail">QA_Fail</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

This PR extends Service Discovery migrations, fixes empty serviceDiscovery.cache migrations based on if service discovery is enabled or not. The default from classic now considers that SD needs to be enabled to consider the cache enabled, as well as having a non-zero timeout set.

Fixtures:

- ability to match `"<nil>"` to assert non-migrated values
- some adjustment to t.Run subtest names, include filename
- update description fields


___

### **PR Type**
- Bug fix
- Tests



___

### **Description**
- Fix cache migration logic in service discovery.

- Enhance fixtures with filename and improved subtests.

- Update YAML test fixtures with detailed descriptions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fixtures_test.go</strong><dd><code>Enhance fixtures test setup and logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/fixtures_test.go

<li>Added <code>Filename</code> field to <code>Fixture</code> struct.<br> <li> Set <code>Filename</code> with file name in test loader.<br> <li> Updated subtest names to include file name.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6909/files#diff-2c27bf7208b7414ba0b07325bc834177a424d5348f2ffb4a78d46f428f8e303f">+21/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service_discovery.yml</strong><dd><code>Update YAML test fixtures for service discovery</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/testdata/fixtures/service_discovery.yml

<li>Updated test case descriptions using block scalars.<br> <li> Modified YAML structure for service discovery tests.<br> <li> Added test case for disabled service discovery handling.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6909/files#diff-8a41102394fc3160d93fc56f1bcec9d1a03404724ba9e10dd624faf8e1154f65">+53/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>upstream.go</strong><dd><code>Correct service discovery cache migration logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/upstream.go

<li>Replaced manual cache handling with <code>CacheOptions</code>.<br> <li> Conditioned <code>Cache</code> assignment on combined flags.<br> <li> Adjusted <code>ExtractTo</code> to set cache based on <code>sd.Enabled</code>.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6909/files#diff-7b0941c7f37fe5a2a23047e0822a65519ca11c371660f36555b59a60f000e3f4">+13/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>