### PR TITLE
Merging to release-5.8: [TT-14214]: added milisecond duration to readable duration (#6916)

### DIFF
--- a/apidef/oas/linter_test.go
+++ b/apidef/oas/linter_test.go
@@ -103,7 +103,7 @@ func TestXTykGateway_Lint(t *testing.T) {
 			LogRetentionPeriod:   ReadableDuration(10 * time.Second),
 			Tests: []UptimeTest{
 				{
-					Timeout: ReadableDuration(10 * time.Second),
+					Timeout: ReadableDuration(10 * time.Millisecond),
 					Commands: []UptimeTestCommand{
 						{
 							Name:    "send",

--- a/apidef/oas/middleware_test.go
+++ b/apidef/oas/middleware_test.go
@@ -276,8 +276,9 @@ func TestTrafficLogs(t *testing.T) {
 		var convertedAPI apidef.APIDefinition
 		var resultTrafficLogs TrafficLogs
 		trafficLogs := TrafficLogs{
-			Enabled:               true,
-			CustomRetentionPeriod: ReadableDuration(time.Minute * 2),
+			Enabled: true,
+			// add 50 milliseconds tp make sure the duration is floored
+			CustomRetentionPeriod: ReadableDuration(time.Minute*2 + time.Millisecond*50),
 		}
 
 		convertedAPI.SetDisabledFlags()
@@ -286,6 +287,8 @@ func TestTrafficLogs(t *testing.T) {
 		assert.Equal(t, int64(120), convertedAPI.ExpireAnalyticsAfter)
 
 		resultTrafficLogs.Fill(convertedAPI)
+		// change customretentionPeriod back to 2 minutes for comparison
+		trafficLogs.CustomRetentionPeriod = ReadableDuration(time.Minute * 2)
 
 		assert.Equal(t, trafficLogs, resultTrafficLogs)
 	})

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -2595,7 +2595,7 @@
     },
     "X-Tyk-ReadableDuration": {
       "type": "string",
-      "pattern": "^(\\d+h)?(\\d+m)?(\\d+s)?$"
+      "pattern": "^(\\d+h)?(\\d+m)?(\\d+s)?(\\d+ms)?$"
     },
     "X-Tyk-LoadBalancingTarget": {
       "type": "object",

--- a/apidef/oas/schema/x-tyk-api-gateway.strict.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.strict.json
@@ -2719,7 +2719,7 @@
     },
     "X-Tyk-ReadableDuration": {
       "type": "string",
-      "pattern": "^(\\d+h)?(\\d+m)?(\\d+s)?$",
+      "pattern": "^(\\d+h)?(\\d+m)?(\\d+s)?(\\d+ms)?$",
       "additionalProperties": false
     },
     "X-Tyk-LoadBalancingTarget": {

--- a/internal/time/duration.go
+++ b/internal/time/duration.go
@@ -3,6 +3,7 @@ package time
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"time"
 )
@@ -61,7 +62,13 @@ func (d *ReadableDuration) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// Seconds returns ReadableDuration in seconds.
+// Seconds returns ReadableDuration rounded down to the seconds.
 func (d ReadableDuration) Seconds() float64 {
-	return Duration(d).Seconds()
+	durationInSeconds := math.Floor(Duration(d).Seconds())
+	return durationInSeconds
+}
+
+// Millisecond returns ReadableDuration in milliseconds.
+func (d ReadableDuration) Milliseconds() int64 {
+	return Duration(d).Milliseconds()
 }

--- a/internal/time/duration_test.go
+++ b/internal/time/duration_test.go
@@ -26,6 +26,32 @@ func TestReadableDuration_MarshalJSON(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, string(expectedJSON), string(resultJSON))
 	})
+
+	t.Run("50 milliseconds", func(t *testing.T) {
+		duration := ReadableDuration(time.Millisecond * 50)
+		expectedJSON := []byte(`"50ms"`)
+		resultJSON, err := json.Marshal(&duration)
+		assert.NoError(t, err)
+		assert.Equal(t, string(expectedJSON), string(resultJSON))
+	})
+}
+
+func TestReadableDuration_Seconds(t *testing.T) {
+	t.Run("simple", func(t *testing.T) {
+		inputJSON := []byte(`"30m50ms"`)
+		var duration ReadableDuration
+		err := json.Unmarshal(inputJSON, &duration)
+		assert.NoError(t, err)
+		assert.Equal(t, float64(1800), duration.Seconds())
+	})
+
+	t.Run("milliseconds rounded to seconds", func(t *testing.T) {
+		inputJSON := []byte(`"30m2200ms"`)
+		var duration ReadableDuration
+		err := json.Unmarshal(inputJSON, &duration)
+		assert.NoError(t, err)
+		assert.Equal(t, float64(1802), duration.Seconds())
+	})
 }
 
 func TestReadableDuration_UnmarshalJSON(t *testing.T) {
@@ -37,6 +63,15 @@ func TestReadableDuration_UnmarshalJSON(t *testing.T) {
 		err := json.Unmarshal(inputJSON, &duration)
 		assert.NoError(t, err)
 		expectedDuration := ReadableDuration(time.Hour*2 + time.Minute*30)
+		assert.Equal(t, expectedDuration, duration)
+	})
+
+	t.Run("milliseconds and seconds", func(t *testing.T) {
+		inputJSON := []byte(`"30m12578ms"`)
+		var duration ReadableDuration
+		err := json.Unmarshal(inputJSON, &duration)
+		assert.NoError(t, err)
+		expectedDuration := ReadableDuration(time.Minute*30 + time.Millisecond*12578)
 		assert.Equal(t, expectedDuration, duration)
 	})
 


### PR DESCRIPTION
### **User description**
[TT-14214]: added milisecond duration to readable duration (#6916)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-14214"
title="TT-14214" target="_blank">TT-14214</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
<td>[OAS] ReadableDuration does not support millisecond granularity</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%205.8.0Regression%20ORDER%20BY%20created%20DESC"
title="5.8.0Regression">5.8.0Regression</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description
[TT-14214](https://tyktech.atlassian.net/browse/TT-14214)
<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


[TT-14214]:
https://tyktech.atlassian.net/browse/TT-14214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix
Tests
Enhancement



___

### **Description**
- Support millisecond granularity in ReadableDuration.

- Update uptime, middleware and upstream tests for ms precision.

- Add Milliseconds() method and floor Seconds() method.

- Extend JSON schema patterns to include optional ms component.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>linter_test.go</strong><dd><code>Update uptime test
timeout to millisecond precision</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/linter_test.go

<li>Changed uptime test timeout from 10s to 10ms.<br> <li> Validate
millisecond duration handling.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6916/files#diff-b92239afd81e77a829fe7fe8410044dfd4dfda525d17dbf5f8811714a9c986d3">+1/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>middleware_test.go</strong><dd><code>Refine traffic
logs retention period tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

apidef/oas/middleware_test.go

<li>Add 50ms offset to CustomRetentionPeriod.<br> <li> Reset retention
period to ensure valid assertions.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6916/files#diff-0af31cb29ae298a6ac3e402b283ab364a6fd793fd04f253ef7c4983234c17bef">+5/-2</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>upstream_test.go</strong><dd><code>Enhance uptime tests
with millisecond precision</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/upstream_test.go

<li>Introduce sub-test for empty uptime tests.<br> <li> Validate timeout
set to 50ms in filled uptime tests.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6916/files#diff-222cc254c0c6c09fa0cf50087860b837a0873e2aef3c84ec7d80b1014c149057">+33/-7</a>&nbsp;
&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>duration_test.go</strong><dd><code>Test millisecond
JSON marshaling and Seconds() flooring</code>&nbsp; &nbsp;
</dd></summary>
<hr>

internal/time/duration_test.go

<li>Add test for JSON marshaling of 50ms duration.<br> <li> Verify
Seconds() returns floored seconds from durations.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6916/files#diff-71942cdc77128266498b62e712f82d0c63bbb39d236fe9e6677f49080c28cea1">+17/-0</a>&nbsp;
&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>duration.go</strong><dd><code>Improve duration methods
for millisecond handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></summary>
<hr>

internal/time/duration.go

<li>Update Seconds() to return floored seconds.<br> <li> Add new
Milliseconds() method for precise duration.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6916/files#diff-6e8ef3118f84cbcc935f27d5a3ad5f4eb86eb22728400e9322c9b796b9d8d855">+8/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>x-tyk-api-gateway.json</strong><dd><code>Update JSON
schema regex for duration with ms support</code>&nbsp; &nbsp; &nbsp;
&nbsp; </dd></summary>
<hr>

apidef/oas/schema/x-tyk-api-gateway.json

- Update regex pattern to include optional milliseconds.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6916/files#diff-78828969c0c04cc1a776dfc93a8bad3c499a8c83e6169f83e96d090bed3e7dd0">+1/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>x-tyk-api-gateway.strict.json</strong><dd><code>Update
strict JSON schema regex for millisecond support</code>&nbsp; &nbsp;
</dd></summary>
<hr>

apidef/oas/schema/x-tyk-api-gateway.strict.json

- Modify strict schema regex to support optional ms duration.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6916/files#diff-39a62344d6b741814a58dfd2d219665ecdf962bbec8e755dbc61e1684bb4892a">+1/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary> Need help?</summary><li>Type <code>/help how to
...</code> in the comments thread for any questions about PR-Agent
usage.</li><li>Check out the <a
href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a>
for more information.</li></details>

[TT-14214]: https://tyktech.atlassian.net/browse/TT-14214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TT-14214]: https://tyktech.atlassian.net/browse/TT-14214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
- Bug fix
- Tests
- Enhancement



___

### **Description**
- Update Seconds() to return floored seconds.

- Add Milliseconds() for ms precision.

- Enhance tests for uptime, middleware, and duration.

- Update JSON schema regex for optional ms support.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>linter_test.go</strong><dd><code>Updated uptime test for ms precision.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/linter_test.go

<li>Changed uptime test Timeout from 10s to 10ms.<br> <li> Validates millisecond duration handling.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6929/files#diff-b92239afd81e77a829fe7fe8410044dfd4dfda525d17dbf5f8811714a9c986d3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>middleware_test.go</strong><dd><code>Updated middleware tests with ms offset.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/middleware_test.go

<li>Added 50ms offset to CustomRetentionPeriod.<br> <li> Reset retention period for accurate comparison.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6929/files#diff-0af31cb29ae298a6ac3e402b283ab364a6fd793fd04f253ef7c4983234c17bef">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>upstream_test.go</strong><dd><code>Enhanced uptime tests with millisecond precision.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/upstream_test.go

<li>Introduced sub-tests for empty and filled uptime.<br> <li> Validated Timeout set to 50ms in filled tests.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6929/files#diff-222cc254c0c6c09fa0cf50087860b837a0873e2aef3c84ec7d80b1014c149057">+33/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>duration_test.go</strong><dd><code>Updated duration tests for ms precision and flooring.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/time/duration_test.go

<li>Added test for JSON marshaling of 50ms.<br> <li> Tested Seconds() method for flooring behavior.<br> <li> Added test case for duration with ms in unmarshal.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6929/files#diff-71942cdc77128266498b62e712f82d0c63bbb39d236fe9e6677f49080c28cea1">+35/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>duration.go</strong><dd><code>Enhanced duration methods for ms handling.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/time/duration.go

<li>Modified Seconds() to floor the seconds value.<br> <li> Added new Milliseconds() method.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6929/files#diff-6e8ef3118f84cbcc935f27d5a3ad5f4eb86eb22728400e9322c9b796b9d8d855">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>x-tyk-api-gateway.json</strong><dd><code>Extended JSON schema for millisecond support.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/schema/x-tyk-api-gateway.json

- Updated regex pattern to include optional ms component.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6929/files#diff-78828969c0c04cc1a776dfc93a8bad3c499a8c83e6169f83e96d090bed3e7dd0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>x-tyk-api-gateway.strict.json</strong><dd><code>Extended strict JSON schema for optional ms.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/schema/x-tyk-api-gateway.strict.json

- Modified strict JSON schema regex to support ms durations.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6929/files#diff-39a62344d6b741814a58dfd2d219665ecdf962bbec8e755dbc61e1684bb4892a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>