### PR TITLE
Merging to release-5.8: TT-14163 when start the rpc set as default in emergency mode (#6910)

### DIFF
--- a/rpc/rpc_client.go
+++ b/rpc/rpc_client.go
@@ -202,17 +202,18 @@ func EmitErrorEventKv(jobName string, funcName string, err error, kv map[string]
 }
 
 // Connect will establish a connection to the RPC server specified in connection options
-func Connect(connConfig Config, suppressRegister bool, dispatcherFuncs map[string]interface{},
+func Connect(
+	connConfig Config,
+	suppressRegister bool,
+	dispatcherFuncs map[string]interface{},
 	getGroupLoginFunc func(string, string) interface{},
 	emergencyModeFunc func(),
-	emergencyModeLoadedFunc func()) bool {
+	emergencyModeLoadedFunc func(),
+) bool {
 	rpcConnectMu.Lock()
 	defer rpcConnectMu.Unlock()
-	values.config.Store(connConfig)
-	getGroupLoginCallback = getGroupLoginFunc
-	emergencyModeCallback = emergencyModeFunc
-	emergencyModeLoadedCallback = emergencyModeLoadedFunc
 
+	setupConnectionConfig(connConfig, getGroupLoginFunc, emergencyModeFunc, emergencyModeLoadedFunc)
 	if values.ClientIsConnected() {
 		Log.Debug("Using RPC singleton for connection")
 		return true
@@ -222,9 +223,38 @@ func Connect(connConfig Config, suppressRegister bool, dispatcherFuncs map[strin
 		return !values.GetEmergencyMode()
 	}
 
-	// RPC Client is unset
-	// Set up the cache
 	Log.Info("Setting new RPC connection!")
+	initializeClient()
+	loadDispatcher(dispatcherFuncs)
+
+	if funcClientSingleton == nil {
+		funcClientSingleton = dispatcher.NewFuncClient(clientSingleton)
+	}
+
+	handleLogin()
+	if !suppressRegister {
+		register()
+		go checkDisconnect()
+	}
+
+	return true
+}
+
+func setupConnectionConfig(
+	connConfig Config,
+	loginFunc func(string, string) interface{},
+	emergencyModeFunc func(),
+	emergencyModeLoadedFunc func(),
+) {
+	values.config.Store(connConfig)
+	getGroupLoginCallback = loginFunc
+	emergencyModeCallback = emergencyModeFunc
+	emergencyModeLoadedCallback = emergencyModeLoadedFunc
+}
+
+func initializeClient() {
+	//by default start in emergency until the rpc connection is stablished
+	values.SetEmergencyMode(true)
 
 	connID := uuid.New()
 
@@ -239,7 +269,6 @@ func Connect(connConfig Config, suppressRegister bool, dispatcherFuncs map[strin
 			MinVersion:         values.Config().SSLMinVersion,
 			MaxVersion:         values.Config().SSLMaxVersion,
 		}
-
 		clientSingleton = gorpc.NewTLSClient(values.Config().ConnectionString, clientCfg)
 	} else {
 		clientSingleton = gorpc.NewTCPClient(values.Config().ConnectionString)
@@ -256,6 +285,11 @@ func Connect(connConfig Config, suppressRegister bool, dispatcherFuncs map[strin
 		clientSingleton.Conns = 5
 	}
 
+	setupDialFunction(connID)
+	clientSingleton.Start()
+}
+
+func setupDialFunction(connID string) {
 	clientSingleton.Dial = func(addr string) (conn net.Conn, err error) {
 		dialer := &net.Dialer{
 			Timeout:   10 * time.Second,
@@ -294,41 +328,6 @@ func Connect(connConfig Config, suppressRegister bool, dispatcherFuncs map[strin
 		conn.Write([]byte(connID))
 
 		return conn, nil
-	}
-
-	clientSingleton.Start()
-
-	loadDispatcher(dispatcherFuncs)
-
-	if funcClientSingleton == nil {
-		funcClientSingleton = dispatcher.NewFuncClient(clientSingleton)
-	}
-	// wait until a connection is dialed so we can call login or fall in emergency mode
-	waitForClientReadiness(clientSingleton)
-	handleLogin()
-
-	if !suppressRegister {
-		register()
-		go checkDisconnect()
-	}
-
-	return true
-}
-
-func waitForClientReadiness(clientSingleton *gorpc.Client) {
-	ticker := time.NewTicker(100 * time.Millisecond)
-	defer ticker.Stop()
-
-	for {
-		if IsEmergencyMode() {
-			return
-		}
-
-		select {
-		case <-clientSingleton.ClientReadyChan:
-			return
-		case <-ticker.C:
-		}
 	}
 }
 


### PR DESCRIPTION
### **User description**
TT-14163 when start the rpc set as default in emergency mode (#6910)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-14163"
title="TT-14163" target="_blank">TT-14163</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Gateway enters in crashloop in emergency mode in k8n's</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

when start the rpc set as default in emergency mode.Some split in the
connect function to improve readability

<!-- Provide a general summary of your changes in the Title above -->

## Description

With this PR now the dataplane will start in emergency mode until the
RPC connection is successful. This will improve the start time when MDCB
is down and the gateway is restarted or a new pod is created in a K8s
environment. As a side work, some refactor of the ´Connect´ function to
improve readability.

## Related Issue

TT-14163

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

- Run an MDCB environment in k8s
- Shut down MDCB, Replicas=0
- Start a new dataplane gw pod -> it should be initialized and not fall
in crashback loop

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
- Enhancement



___

### **Description**
- Extracted configuration setup into a helper function.

- Added initializeClient to manage RPC client initialization.

- Introduced setupDialFunction for custom dialer configuration.

- Improved readability by splitting Connect function parameters.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>rpc_client.go</strong><dd><code>Refactored Connect and
added supporting helper functions.</code></dd></summary>
<hr>

rpc/rpc_client.go

<li>Reformatted Connect function signature for clarity.<br> <li> Created
setupConnectionConfig to store configuration and callbacks.<br> <li>
Added initializeClient to set emergency mode and start client.<br> <li>
Introduced setupDialFunction for dialer initialization.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6910/files#diff-3b88914c99bb9418e44e6389ce73579843562e8900730b380d7fff2e95c51033">+43/-44</a>&nbsp;
</td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary> Need help?</summary><li>Type <code>/help how to
...</code> in the comments thread for any questions about PR-Agent
usage.</li><li>Check out the <a
href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a>
for more information.</li></details>

Co-authored-by: sredny buitrago <sredny@srednys-MacBook-Pro.local>


___

### **PR Type**
- Enhancement



___

### **Description**
- Refactor Connect function for improved readability.

- Extract configuration and callback setup into a helper.

- Initialize client in emergency mode before establishing connection.

- Introduce helper to configure custom dialer.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_client.go</strong><dd><code>Enhance RPC client initialization and connection flow.</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rpc/rpc_client.go

<li>Reformatted Connect function parameters across multiple lines.<br> <li> Extracted setupConnectionConfig to encapsulate configuration storage.<br> <li> Introduced initializeClient to set emergency mode on startup.<br> <li> Added setupDialFunction for custom dialer configuration.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6934/files#diff-3b88914c99bb9418e44e6389ce73579843562e8900730b380d7fff2e95c51033">+43/-44</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>