### PR TITLE
Merging to release-5.8.0: [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)

### DIFF
--- a/apidef/oas/operation.go
+++ b/apidef/oas/operation.go
@@ -577,46 +577,6 @@ func (o *Operation) extractRequestSizeLimitTo(ep *apidef.ExtendedPathsSet, path 
 	ep.SizeLimit = append(ep.SizeLimit, meta)
 }
 
-<<<<<<< HEAD
-// extractMockResponsePaths converts OAS mock responses to classic API format.
-// While classic APIs have direct support for mock responses, the API Designer UI
-// doesn't support them yet. Therefore, we are extracting them to a combination of
-// allow list entries and method actions instead.
-func (o *Operation) extractMockResponsePaths(ep *apidef.ExtendedPathsSet, path, method string) {
-	if o.MockResponse == nil {
-		return
-	}
-
-	headers := make(map[string]string)
-
-	for _, header := range o.MockResponse.Headers {
-		headers[http.CanonicalHeaderKey(header.Name)] = header.Value
-	}
-
-	if ep.WhiteList == nil {
-		ep.WhiteList = make([]apidef.EndPointMeta, 0)
-	}
-
-	wl := apidef.EndPointMeta{
-		Disabled: !o.MockResponse.Enabled,
-		Path:     path,
-		Method:   method,
-	}
-
-	wl.MethodActions = make(map[string]apidef.EndpointMethodMeta)
-
-	wl.MethodActions[method] = apidef.EndpointMethodMeta{
-		Action:  apidef.Reply,
-		Code:    o.MockResponse.Code,
-		Data:    o.MockResponse.Body,
-		Headers: headers,
-	}
-
-	ep.WhiteList = append(ep.WhiteList, wl)
-}
-
-=======
->>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
 // detect possible regex pattern:
 // - character match ([a-z])
 // - greedy match (.*)

--- a/apidef/oas/operation_test.go
+++ b/apidef/oas/operation_test.go
@@ -3,13 +3,7 @@ package oas
 import (
 	"context"
 	"embed"
-<<<<<<< HEAD
-	"encoding/json"
 	"net/http"
-	"sort"
-=======
-	"net/http"
->>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
 	"strconv"
 	"strings"
 	"testing"
@@ -191,23 +185,9 @@ func TestOAS_MockResponse_extractPathsAndOperations(t *testing.T) {
 			want: func(t *testing.T, ep *apidef.ExtendedPathsSet) {
 				t.Helper()
 
-<<<<<<< HEAD
-				require.Len(t, ep.WhiteList, 1)
-
-				mockResp := ep.WhiteList[0]
-				require.Equal(t, "/test", mockResp.Path)
-				require.Equal(t, "GET", mockResp.Method)
-				require.NotNil(t, mockResp.MethodActions["GET"])
-				require.Equal(t, apidef.Reply, mockResp.MethodActions["GET"].Action)
-				require.Equal(t, 200, mockResp.MethodActions["GET"].Code)
-				require.Equal(t, `{"message": "success"}`, mockResp.MethodActions["GET"].Data)
-				require.Equal(t, map[string]string{"Content-Type": "application/json"}, mockResp.MethodActions["GET"].Headers)
-				require.False(t, mockResp.Disabled)
-=======
 				// Verify mock responses
 				mockResponses := ep.MockResponse
 				require.Len(t, mockResponses, 0)
->>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
 			},
 		},
 		{
@@ -259,46 +239,9 @@ func TestOAS_MockResponse_extractPathsAndOperations(t *testing.T) {
 			want: func(t *testing.T, ep *apidef.ExtendedPathsSet) {
 				t.Helper()
 
-<<<<<<< HEAD
-				assert.Len(t, ep.WhiteList, 2)
-
-				// Sort mock responses for consistent testing
-				sort.Slice(ep.WhiteList, func(i, j int) bool {
-					if ep.WhiteList[i].Path == ep.WhiteList[j].Path {
-						return ep.WhiteList[i].Method < ep.WhiteList[j].Method
-					}
-					return ep.WhiteList[i].Path < ep.WhiteList[j].Path
-				})
-
-				// Verify GET mock response
-				getMock := ep.WhiteList[0]
-				require.Equal(t, "/test", getMock.Path)
-				require.Equal(t, "GET", getMock.Method)
-				require.NotNil(t, getMock.MethodActions["GET"])
-				require.Equal(t, apidef.Reply, getMock.MethodActions["GET"].Action)
-				require.Equal(t, 200, getMock.MethodActions["GET"].Code)
-				require.Equal(t, `{"status": "ok"}`, getMock.MethodActions["GET"].Data)
-				require.Equal(t, map[string]string{"Content-Type": "application/json"}, getMock.MethodActions["GET"].Headers)
-				require.False(t, getMock.Disabled)
-
-				// Verify POST mock response
-				postMock := ep.WhiteList[1]
-				require.Equal(t, "/test", postMock.Path)
-				require.Equal(t, "POST", postMock.Method)
-				require.NotNil(t, postMock.MethodActions["POST"])
-				require.Equal(t, apidef.Reply, postMock.MethodActions["POST"].Action)
-				require.Equal(t, 201, postMock.MethodActions["POST"].Code)
-				require.Equal(t, `{"id": "123"}`, postMock.MethodActions["POST"].Data)
-				require.Equal(t, map[string]string{
-					"Content-Type": "application/json",
-					"Location":     "/test/123",
-				}, postMock.MethodActions["POST"].Headers)
-				require.False(t, postMock.Disabled)
-=======
 				// Verify mock responses
 				mockResponses := ep.MockResponse
 				require.Len(t, mockResponses, 0)
->>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
 			},
 		},
 		{
@@ -333,21 +276,9 @@ func TestOAS_MockResponse_extractPathsAndOperations(t *testing.T) {
 			want: func(t *testing.T, ep *apidef.ExtendedPathsSet) {
 				t.Helper()
 
-<<<<<<< HEAD
-				assert.Len(t, ep.WhiteList, 1)
-				mockResp := ep.WhiteList[0]
-				require.Equal(t, "/test", mockResp.Path)
-				require.Equal(t, "GET", mockResp.Method)
-				require.NotNil(t, mockResp.MethodActions["GET"])
-				require.Equal(t, apidef.Reply, mockResp.MethodActions["GET"].Action)
-				require.Equal(t, 404, mockResp.MethodActions["GET"].Code)
-				require.Equal(t, `{"error": "not found"}`, mockResp.MethodActions["GET"].Data)
-				require.True(t, mockResp.Disabled)
-=======
 				// Verify mock responses
 				mockResponses := ep.MockResponse
 				require.Len(t, mockResponses, 0)
->>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
 			},
 		},
 		{
@@ -425,38 +356,9 @@ func TestOAS_MockResponse_extractPathsAndOperations(t *testing.T) {
 			want: func(t *testing.T, ep *apidef.ExtendedPathsSet) {
 				t.Helper()
 
-<<<<<<< HEAD
-				assert.Len(t, ep.WhiteList, 2)
-
-				// Sort for consistent testing
-				sort.Slice(ep.WhiteList, func(i, j int) bool {
-					return ep.WhiteList[i].Path < ep.WhiteList[j].Path
-				})
-
-				// Verify items response
-				itemsResp := ep.WhiteList[0]
-				require.Equal(t, "/items", itemsResp.Path)
-				require.Equal(t, "GET", itemsResp.Method)
-				require.NotNil(t, itemsResp.MethodActions["GET"])
-				require.Equal(t, apidef.Reply, itemsResp.MethodActions["GET"].Action)
-				require.Equal(t, 200, itemsResp.MethodActions["GET"].Code)
-				require.Equal(t, `["item1", "item2"]`, itemsResp.MethodActions["GET"].Data)
-				require.Equal(t, map[string]string{"Content-Type": "application/json"}, itemsResp.MethodActions["GET"].Headers)
-
-				// Verify users response
-				usersResp := ep.WhiteList[1]
-				require.Equal(t, "/users", usersResp.Path)
-				require.Equal(t, "GET", usersResp.Method)
-				require.NotNil(t, usersResp.MethodActions["GET"])
-				require.Equal(t, apidef.Reply, usersResp.MethodActions["GET"].Action)
-				require.Equal(t, 200, usersResp.MethodActions["GET"].Code)
-				require.Equal(t, `["user1", "user2"]`, usersResp.MethodActions["GET"].Data)
-				require.Equal(t, map[string]string{"Content-Type": "application/json"}, usersResp.MethodActions["GET"].Headers)
-=======
 				// Verify mock responses
 				mockResponses := ep.MockResponse
 				require.Len(t, mockResponses, 0)
->>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
 			},
 		},
 	}
@@ -888,19 +790,11 @@ func TestOAS_MockResponse_fillMockResponsePaths(t *testing.T) {
 				// Verify 200 response
 				response200 := pathItem.Get.Responses.Get(200)
 				require.NotNil(t, response200, "Response for 200 should not be nil")
-<<<<<<< HEAD
-
-				mediaType200 := response200.Value.Content["application/json"]
-				require.NotNil(t, mediaType200)
-				require.NotNil(t, mediaType200.Examples)
-				require.Equal(t, `{"status": "success"}`, mediaType200.Examples["default"].Value.Value)
-=======
 				require.NotNil(t, response200.Value)
 				require.NotNil(t, response200.Value.Description)
 				tykOperation := spec.GetTykExtension().getOperation(pathItem.Get.OperationID)
 				require.NotNil(t, tykOperation)
 				require.Nil(t, tykOperation.Allow)
->>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
 			},
 		},
 		{
@@ -943,44 +837,32 @@ func TestOAS_MockResponse_fillMockResponsePaths(t *testing.T) {
 				jsonPath := spec.Paths["/test"]
 				require.NotNil(t, jsonPath)
 				jsonResponse := jsonPath.Get.Responses["200"].Value
-<<<<<<< HEAD
-				require.Equal(t, `{"data": "json"}`, jsonResponse.Content["application/json"].Examples["default"].Value.Value)
-=======
 				require.NotNil(t, jsonResponse)
 				require.NotNil(t, jsonResponse.Description)
 				tykOperation := spec.GetTykExtension().getOperation(jsonPath.Get.OperationID)
 				require.NotNil(t, tykOperation)
 				require.Nil(t, tykOperation.Allow)
->>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
 
 				// XML endpoint
 				xmlPath := spec.Paths["/test.xml"]
 				require.NotNil(t, xmlPath)
 				xmlResponse := xmlPath.Get.Responses["200"].Value
-<<<<<<< HEAD
-				require.Equal(t, `<data>xml</data>`, xmlResponse.Content["application/xml"].Examples["default"].Value.Value)
-=======
 				require.NotNil(t, xmlResponse)
 				require.NotNil(t, xmlResponse.Description)
 				tykOperation = spec.GetTykExtension().getOperation(xmlPath.Get.OperationID)
 				require.NotNil(t, tykOperation)
 				require.Nil(t, tykOperation.Allow)
->>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
 
 				// Text endpoint
 				txtPath := spec.Paths["/test.txt"]
 				require.NotNil(t, txtPath)
 
 				txtResponse := txtPath.Get.Responses["200"].Value
-<<<<<<< HEAD
-				require.Equal(t, `plain text`, txtResponse.Content["text/plain"].Examples["default"].Value.Value)
-=======
 				require.NotNil(t, txtResponse)
 				require.NotNil(t, txtResponse.Description)
 				tykOperation = spec.GetTykExtension().getOperation(txtPath.Get.OperationID)
 				require.NotNil(t, tykOperation)
 				require.Nil(t, tykOperation.Allow)
->>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
 			},
 		},
 		{
@@ -1008,30 +890,11 @@ func TestOAS_MockResponse_fillMockResponsePaths(t *testing.T) {
 				require.NotNil(t, pathItem)
 				response := pathItem.Get.Responses["200"].Value
 				require.NotNil(t, response)
-<<<<<<< HEAD
-
-				// Verify all headers
-				expectedHeaders := map[string]string{
-					"Content-Type":      "application/json",
-					"X-Custom-Header":   "custom-value",
-					"X-Request-ID":      "123",
-					"X-Correlation-ID":  "abc",
-					"Cache-Control":     "no-cache",
-					"X-RateLimit-Limit": "100",
-				}
-
-				for header, value := range expectedHeaders {
-					headerObj := response.Headers[http.CanonicalHeaderKey(header)]
-					require.NotNil(t, headerObj, "Header %s not found", header)
-					assert.Equal(t, value, headerObj.Value.Schema.Value.Example)
-				}
-=======
 				require.NotNil(t, response.Description)
 
 				tykOperation := spec.GetTykExtension().getOperation(pathItem.Get.OperationID)
 				require.NotNil(t, tykOperation)
 				require.Nil(t, tykOperation.Allow)
->>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
 			},
 		},
 		{
@@ -1053,19 +916,11 @@ func TestOAS_MockResponse_fillMockResponsePaths(t *testing.T) {
 				pathItem := spec.Paths["/test"]
 				require.NotNil(t, pathItem)
 
-<<<<<<< HEAD
-				verifyOASOperation(t, pathItem.Get, "GET", 200, `{"method":"get"}`)
-				verifyOASOperation(t, pathItem.Post, "POST", 201, `{"method":"post"}`)
-				verifyOASOperation(t, pathItem.Put, "PUT", 200, `{"method":"put"}`)
-				verifyOASOperation(t, pathItem.Patch, "PATCH", 200, `{"method":"patch"}`)
-				verifyOASOperation(t, pathItem.Delete, "DELETE", 204, ``)
-=======
 				verifyOASOperation(t, spec, pathItem.Get, "GET", 200)
 				verifyOASOperation(t, spec, pathItem.Post, "POST", 201)
 				verifyOASOperation(t, spec, pathItem.Put, "PUT", 200)
 				verifyOASOperation(t, spec, pathItem.Patch, "PATCH", 200)
 				verifyOASOperation(t, spec, pathItem.Delete, "DELETE", 204)
->>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
 			},
 		},
 	}
@@ -1173,11 +1028,7 @@ func TestOAS_MockResponse_fillMockResponsePaths(t *testing.T) {
 }
 
 // Helper function to verify OpenAPI operation responses
-<<<<<<< HEAD
-func verifyOASOperation(t *testing.T, op *openapi3.Operation, method string, code int, body string) {
-=======
 func verifyOASOperation(t *testing.T, spec *OAS, op *openapi3.Operation, method string, code int) {
->>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
 	t.Helper()
 
 	require.NotNil(t, op, "Operation %s should exist", method)
@@ -1188,30 +1039,6 @@ func verifyOASOperation(t *testing.T, spec *OAS, op *openapi3.Operation, method 
 
 	response := op.Responses[statusCode].Value
 	require.NotNil(t, response)
-<<<<<<< HEAD
-
-	if body != "" {
-		contentType := "text/plain" // default content type
-
-		var arrayValue []json.RawMessage
-		if err := json.Unmarshal([]byte(body), &arrayValue); err == nil {
-			contentType = "application/json"
-		}
-
-		var objectValue map[string]json.RawMessage
-		if err := json.Unmarshal([]byte(body), &objectValue); err == nil {
-			contentType = "application/json"
-		}
-
-		if ct, ok := response.Headers["Content-Type"]; ok {
-			contentType = ct.Value.Schema.Value.Example.(string)
-		}
-
-		require.NotNil(t, response.Content[contentType], "Content type %s not found", contentType)
-		require.NotNil(t, response.Content[contentType].Examples, "Examples for content type %s not found", contentType)
-		require.Equal(t, body, response.Content[contentType].Examples["default"].Value.Value)
-	}
-=======
 	require.NotNil(t, response.Description)
 
 	tykOperation := spec.GetTykExtension().getOperation(op.OperationID)
@@ -1400,5 +1227,4 @@ func TestOAS_fillAllowance(t *testing.T) {
 		assert.NotNil(t, operation.Allow)
 		assert.False(t, operation.Allow.Enabled)
 	})
->>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
 }

--- a/apidef/oas/operation_test.go
+++ b/apidef/oas/operation_test.go
@@ -3,9 +3,13 @@ package oas
 import (
 	"context"
 	"embed"
+<<<<<<< HEAD
 	"encoding/json"
 	"net/http"
 	"sort"
+=======
+	"net/http"
+>>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
 	"strconv"
 	"strings"
 	"testing"
@@ -187,6 +191,7 @@ func TestOAS_MockResponse_extractPathsAndOperations(t *testing.T) {
 			want: func(t *testing.T, ep *apidef.ExtendedPathsSet) {
 				t.Helper()
 
+<<<<<<< HEAD
 				require.Len(t, ep.WhiteList, 1)
 
 				mockResp := ep.WhiteList[0]
@@ -198,6 +203,11 @@ func TestOAS_MockResponse_extractPathsAndOperations(t *testing.T) {
 				require.Equal(t, `{"message": "success"}`, mockResp.MethodActions["GET"].Data)
 				require.Equal(t, map[string]string{"Content-Type": "application/json"}, mockResp.MethodActions["GET"].Headers)
 				require.False(t, mockResp.Disabled)
+=======
+				// Verify mock responses
+				mockResponses := ep.MockResponse
+				require.Len(t, mockResponses, 0)
+>>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
 			},
 		},
 		{
@@ -249,6 +259,7 @@ func TestOAS_MockResponse_extractPathsAndOperations(t *testing.T) {
 			want: func(t *testing.T, ep *apidef.ExtendedPathsSet) {
 				t.Helper()
 
+<<<<<<< HEAD
 				assert.Len(t, ep.WhiteList, 2)
 
 				// Sort mock responses for consistent testing
@@ -283,6 +294,11 @@ func TestOAS_MockResponse_extractPathsAndOperations(t *testing.T) {
 					"Location":     "/test/123",
 				}, postMock.MethodActions["POST"].Headers)
 				require.False(t, postMock.Disabled)
+=======
+				// Verify mock responses
+				mockResponses := ep.MockResponse
+				require.Len(t, mockResponses, 0)
+>>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
 			},
 		},
 		{
@@ -317,6 +333,7 @@ func TestOAS_MockResponse_extractPathsAndOperations(t *testing.T) {
 			want: func(t *testing.T, ep *apidef.ExtendedPathsSet) {
 				t.Helper()
 
+<<<<<<< HEAD
 				assert.Len(t, ep.WhiteList, 1)
 				mockResp := ep.WhiteList[0]
 				require.Equal(t, "/test", mockResp.Path)
@@ -326,6 +343,11 @@ func TestOAS_MockResponse_extractPathsAndOperations(t *testing.T) {
 				require.Equal(t, 404, mockResp.MethodActions["GET"].Code)
 				require.Equal(t, `{"error": "not found"}`, mockResp.MethodActions["GET"].Data)
 				require.True(t, mockResp.Disabled)
+=======
+				// Verify mock responses
+				mockResponses := ep.MockResponse
+				require.Len(t, mockResponses, 0)
+>>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
 			},
 		},
 		{
@@ -403,6 +425,7 @@ func TestOAS_MockResponse_extractPathsAndOperations(t *testing.T) {
 			want: func(t *testing.T, ep *apidef.ExtendedPathsSet) {
 				t.Helper()
 
+<<<<<<< HEAD
 				assert.Len(t, ep.WhiteList, 2)
 
 				// Sort for consistent testing
@@ -429,6 +452,11 @@ func TestOAS_MockResponse_extractPathsAndOperations(t *testing.T) {
 				require.Equal(t, 200, usersResp.MethodActions["GET"].Code)
 				require.Equal(t, `["user1", "user2"]`, usersResp.MethodActions["GET"].Data)
 				require.Equal(t, map[string]string{"Content-Type": "application/json"}, usersResp.MethodActions["GET"].Headers)
+=======
+				// Verify mock responses
+				mockResponses := ep.MockResponse
+				require.Len(t, mockResponses, 0)
+>>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
 			},
 		},
 	}
@@ -638,6 +666,9 @@ func TestOAS_MockResponse_fillMockResponsePaths(t *testing.T) {
 
 				pathItem := spec.Paths["/test"]
 				require.NotNil(t, pathItem)
+				tykOperation := spec.GetTykExtension().getOperation(pathItem.Get.OperationID)
+				require.NotNil(t, tykOperation)
+				require.Nil(t, tykOperation.Allow)
 
 				// Verify operation
 				require.NotNil(t, pathItem.Get)
@@ -704,6 +735,9 @@ func TestOAS_MockResponse_fillMockResponsePaths(t *testing.T) {
 				// Verify GET operation
 				require.NotNil(t, pathItem.Get)
 				require.Equal(t, "testGET", pathItem.Get.OperationID)
+				tykOperation := spec.GetTykExtension().getOperation(pathItem.Get.OperationID)
+				require.NotNil(t, tykOperation)
+				require.Nil(t, tykOperation.Allow)
 
 				response200Ref := pathItem.Get.Responses["200"]
 				require.NotNil(t, response200Ref, "Response ref for 200 should not be nil")
@@ -716,6 +750,9 @@ func TestOAS_MockResponse_fillMockResponsePaths(t *testing.T) {
 				// Verify POST operation
 				require.NotNil(t, pathItem.Post)
 				require.Equal(t, "testPOST", pathItem.Post.OperationID)
+				tykOperation = spec.GetTykExtension().getOperation(pathItem.Post.OperationID)
+				require.NotNil(t, tykOperation)
+				require.Nil(t, tykOperation.Allow)
 
 				postResponse := pathItem.Post.Responses["201"].Value
 				require.NotNil(t, postResponse)
@@ -741,6 +778,9 @@ func TestOAS_MockResponse_fillMockResponsePaths(t *testing.T) {
 				pathItem := spec.Paths["/test"]
 				require.NotNil(t, pathItem)
 				require.Equal(t, "testGET", pathItem.Get.OperationID)
+				tykOperation := spec.GetTykExtension().getOperation(pathItem.Get.OperationID)
+				require.NotNil(t, tykOperation)
+				require.Nil(t, tykOperation.Allow)
 
 				response204Ref := pathItem.Get.Responses["204"]
 				require.NotNil(t, response204Ref, "Response ref for 204 should not be nil")
@@ -786,6 +826,9 @@ func TestOAS_MockResponse_fillMockResponsePaths(t *testing.T) {
 				require.NotNil(t, usersPath)
 				require.NotNil(t, usersPath.Get)
 				require.Equal(t, "usersGET", usersPath.Get.OperationID)
+				tykOperation := spec.GetTykExtension().getOperation(usersPath.Get.OperationID)
+				require.NotNil(t, tykOperation)
+				require.Nil(t, tykOperation.Allow)
 
 				usersResponse := usersPath.Get.Responses["200"].Value
 				require.NotNil(t, usersResponse)
@@ -796,6 +839,9 @@ func TestOAS_MockResponse_fillMockResponsePaths(t *testing.T) {
 				require.NotNil(t, itemsPath)
 				require.NotNil(t, itemsPath.Get)
 				require.Equal(t, "itemsGET", itemsPath.Get.OperationID)
+				tykOperation = spec.GetTykExtension().getOperation(itemsPath.Get.OperationID)
+				require.NotNil(t, tykOperation)
+				require.Nil(t, tykOperation.Allow)
 
 				itemsResponse := itemsPath.Get.Responses["200"].Value
 				require.NotNil(t, itemsResponse)
@@ -842,11 +888,19 @@ func TestOAS_MockResponse_fillMockResponsePaths(t *testing.T) {
 				// Verify 200 response
 				response200 := pathItem.Get.Responses.Get(200)
 				require.NotNil(t, response200, "Response for 200 should not be nil")
+<<<<<<< HEAD
 
 				mediaType200 := response200.Value.Content["application/json"]
 				require.NotNil(t, mediaType200)
 				require.NotNil(t, mediaType200.Examples)
 				require.Equal(t, `{"status": "success"}`, mediaType200.Examples["default"].Value.Value)
+=======
+				require.NotNil(t, response200.Value)
+				require.NotNil(t, response200.Value.Description)
+				tykOperation := spec.GetTykExtension().getOperation(pathItem.Get.OperationID)
+				require.NotNil(t, tykOperation)
+				require.Nil(t, tykOperation.Allow)
+>>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
 			},
 		},
 		{
@@ -889,20 +943,44 @@ func TestOAS_MockResponse_fillMockResponsePaths(t *testing.T) {
 				jsonPath := spec.Paths["/test"]
 				require.NotNil(t, jsonPath)
 				jsonResponse := jsonPath.Get.Responses["200"].Value
+<<<<<<< HEAD
 				require.Equal(t, `{"data": "json"}`, jsonResponse.Content["application/json"].Examples["default"].Value.Value)
+=======
+				require.NotNil(t, jsonResponse)
+				require.NotNil(t, jsonResponse.Description)
+				tykOperation := spec.GetTykExtension().getOperation(jsonPath.Get.OperationID)
+				require.NotNil(t, tykOperation)
+				require.Nil(t, tykOperation.Allow)
+>>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
 
 				// XML endpoint
 				xmlPath := spec.Paths["/test.xml"]
 				require.NotNil(t, xmlPath)
 				xmlResponse := xmlPath.Get.Responses["200"].Value
+<<<<<<< HEAD
 				require.Equal(t, `<data>xml</data>`, xmlResponse.Content["application/xml"].Examples["default"].Value.Value)
+=======
+				require.NotNil(t, xmlResponse)
+				require.NotNil(t, xmlResponse.Description)
+				tykOperation = spec.GetTykExtension().getOperation(xmlPath.Get.OperationID)
+				require.NotNil(t, tykOperation)
+				require.Nil(t, tykOperation.Allow)
+>>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
 
 				// Text endpoint
 				txtPath := spec.Paths["/test.txt"]
 				require.NotNil(t, txtPath)
 
 				txtResponse := txtPath.Get.Responses["200"].Value
+<<<<<<< HEAD
 				require.Equal(t, `plain text`, txtResponse.Content["text/plain"].Examples["default"].Value.Value)
+=======
+				require.NotNil(t, txtResponse)
+				require.NotNil(t, txtResponse.Description)
+				tykOperation = spec.GetTykExtension().getOperation(txtPath.Get.OperationID)
+				require.NotNil(t, tykOperation)
+				require.Nil(t, tykOperation.Allow)
+>>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
 			},
 		},
 		{
@@ -930,6 +1008,7 @@ func TestOAS_MockResponse_fillMockResponsePaths(t *testing.T) {
 				require.NotNil(t, pathItem)
 				response := pathItem.Get.Responses["200"].Value
 				require.NotNil(t, response)
+<<<<<<< HEAD
 
 				// Verify all headers
 				expectedHeaders := map[string]string{
@@ -946,6 +1025,13 @@ func TestOAS_MockResponse_fillMockResponsePaths(t *testing.T) {
 					require.NotNil(t, headerObj, "Header %s not found", header)
 					assert.Equal(t, value, headerObj.Value.Schema.Value.Example)
 				}
+=======
+				require.NotNil(t, response.Description)
+
+				tykOperation := spec.GetTykExtension().getOperation(pathItem.Get.OperationID)
+				require.NotNil(t, tykOperation)
+				require.Nil(t, tykOperation.Allow)
+>>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
 			},
 		},
 		{
@@ -967,11 +1053,19 @@ func TestOAS_MockResponse_fillMockResponsePaths(t *testing.T) {
 				pathItem := spec.Paths["/test"]
 				require.NotNil(t, pathItem)
 
+<<<<<<< HEAD
 				verifyOASOperation(t, pathItem.Get, "GET", 200, `{"method":"get"}`)
 				verifyOASOperation(t, pathItem.Post, "POST", 201, `{"method":"post"}`)
 				verifyOASOperation(t, pathItem.Put, "PUT", 200, `{"method":"put"}`)
 				verifyOASOperation(t, pathItem.Patch, "PATCH", 200, `{"method":"patch"}`)
 				verifyOASOperation(t, pathItem.Delete, "DELETE", 204, ``)
+=======
+				verifyOASOperation(t, spec, pathItem.Get, "GET", 200)
+				verifyOASOperation(t, spec, pathItem.Post, "POST", 201)
+				verifyOASOperation(t, spec, pathItem.Put, "PUT", 200)
+				verifyOASOperation(t, spec, pathItem.Patch, "PATCH", 200)
+				verifyOASOperation(t, spec, pathItem.Delete, "DELETE", 204)
+>>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
 			},
 		},
 	}
@@ -1079,7 +1173,11 @@ func TestOAS_MockResponse_fillMockResponsePaths(t *testing.T) {
 }
 
 // Helper function to verify OpenAPI operation responses
+<<<<<<< HEAD
 func verifyOASOperation(t *testing.T, op *openapi3.Operation, method string, code int, body string) {
+=======
+func verifyOASOperation(t *testing.T, spec *OAS, op *openapi3.Operation, method string, code int) {
+>>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
 	t.Helper()
 
 	require.NotNil(t, op, "Operation %s should exist", method)
@@ -1090,6 +1188,7 @@ func verifyOASOperation(t *testing.T, op *openapi3.Operation, method string, cod
 
 	response := op.Responses[statusCode].Value
 	require.NotNil(t, response)
+<<<<<<< HEAD
 
 	if body != "" {
 		contentType := "text/plain" // default content type
@@ -1112,4 +1211,194 @@ func verifyOASOperation(t *testing.T, op *openapi3.Operation, method string, cod
 		require.NotNil(t, response.Content[contentType].Examples, "Examples for content type %s not found", contentType)
 		require.Equal(t, body, response.Content[contentType].Examples["default"].Value.Value)
 	}
+=======
+	require.NotNil(t, response.Description)
+
+	tykOperation := spec.GetTykExtension().getOperation(op.OperationID)
+	require.NotNil(t, tykOperation)
+	require.Nil(t, tykOperation.Allow)
+}
+
+func TestOAS_fillAllowance(t *testing.T) {
+	t.Run("should fill allow list correctly", func(t *testing.T) {
+		s := &OAS{
+			T: openapi3.T{
+				Paths: make(openapi3.Paths),
+			},
+		}
+
+		s.SetTykExtension(&XTykAPIGateway{
+			Middleware: &Middleware{
+				Operations: make(Operations),
+			},
+		})
+
+		endpointMetas := []apidef.EndPointMeta{
+			{
+				Path:   "/test",
+				Method: http.MethodGet,
+				MethodActions: map[string]apidef.EndpointMethodMeta{
+					http.MethodGet: {
+						Action: apidef.NoAction,
+					},
+				},
+			},
+		}
+
+		s.fillAllowance(endpointMetas, allow)
+
+		operationID := s.getOperationID("/test", http.MethodGet)
+		operation := s.GetTykExtension().getOperation(operationID)
+
+		assert.NotNil(t, operation.Allow)
+		assert.True(t, operation.Allow.Enabled)
+		assert.Nil(t, operation.Block)
+		assert.Nil(t, operation.IgnoreAuthentication)
+	})
+
+	t.Run("should fill block list correctly", func(t *testing.T) {
+		s := &OAS{
+			T: openapi3.T{
+				Paths: make(openapi3.Paths),
+			},
+		}
+
+		s.SetTykExtension(&XTykAPIGateway{
+			Middleware: &Middleware{
+				Operations: make(Operations),
+			},
+		})
+
+		endpointMetas := []apidef.EndPointMeta{
+			{
+				Path:   "/test",
+				Method: http.MethodGet,
+			},
+		}
+
+		s.fillAllowance(endpointMetas, block)
+
+		operationID := s.getOperationID("/test", http.MethodGet)
+		operation := s.GetTykExtension().getOperation(operationID)
+
+		assert.NotNil(t, operation.Block)
+		assert.True(t, operation.Block.Enabled)
+		assert.Nil(t, operation.Allow)
+		assert.Nil(t, operation.IgnoreAuthentication)
+	})
+
+	t.Run("should fill ignore authentication correctly", func(t *testing.T) {
+		s := &OAS{
+			T: openapi3.T{
+				Paths: make(openapi3.Paths),
+			},
+		}
+
+		s.SetTykExtension(&XTykAPIGateway{
+			Middleware: &Middleware{
+				Operations: make(Operations),
+			},
+		})
+
+		endpointMetas := []apidef.EndPointMeta{
+			{
+				Path:   "/test",
+				Method: http.MethodGet,
+			},
+		}
+
+		s.fillAllowance(endpointMetas, ignoreAuthentication)
+
+		operationID := s.getOperationID("/test", http.MethodGet)
+		operation := s.GetTykExtension().getOperation(operationID)
+
+		assert.NotNil(t, operation.IgnoreAuthentication)
+		assert.True(t, operation.IgnoreAuthentication.Enabled)
+		assert.Nil(t, operation.Allow)
+		assert.Nil(t, operation.Block)
+	})
+
+	t.Run("should skip Reply actions for allow list", func(t *testing.T) {
+		spec := &OAS{
+			T: openapi3.T{
+				Paths: make(openapi3.Paths),
+			},
+		}
+
+		spec.SetTykExtension(&XTykAPIGateway{
+			Middleware: &Middleware{
+				Operations: make(Operations),
+			},
+		})
+
+		endpointMetas := []apidef.EndPointMeta{
+			{
+				Path:   "/test",
+				Method: http.MethodGet,
+				MethodActions: map[string]apidef.EndpointMethodMeta{
+					http.MethodGet: {
+						Action: apidef.Reply,
+					},
+				},
+			},
+		}
+
+		spec.fillAllowance(endpointMetas, allow)
+
+		operationID := spec.getOperationID("/test", http.MethodGet)
+		operation := spec.GetTykExtension().getOperation(operationID)
+
+		assert.Nil(t, operation.Allow, "Allow should be nil for Reply actions")
+	})
+
+	t.Run("should handle empty endpoint metas", func(t *testing.T) {
+		s := &OAS{
+			T: openapi3.T{
+				Paths: make(openapi3.Paths),
+			},
+		}
+
+		s.SetTykExtension(&XTykAPIGateway{
+			Middleware: &Middleware{
+				Operations: make(Operations),
+			},
+		})
+
+		var endpointMetas []apidef.EndPointMeta
+
+		s.fillAllowance(endpointMetas, allow)
+
+		assert.Empty(t, s.Paths)
+	})
+
+	t.Run("should set allowance disabled when ShouldOmit returns true", func(t *testing.T) {
+		s := &OAS{
+			T: openapi3.T{
+				Paths: make(openapi3.Paths),
+			},
+		}
+
+		s.SetTykExtension(&XTykAPIGateway{
+			Middleware: &Middleware{
+				Operations: make(Operations),
+			},
+		})
+
+		endpointMetas := []apidef.EndPointMeta{
+			{
+				Path:     "/test",
+				Method:   http.MethodGet,
+				Disabled: true,
+			},
+		}
+
+		s.fillAllowance(endpointMetas, allow)
+
+		operationID := s.getOperationID("/test", http.MethodGet)
+		operation := s.GetTykExtension().getOperation(operationID)
+
+		assert.NotNil(t, operation.Allow)
+		assert.False(t, operation.Allow.Enabled)
+	})
+>>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
 }

--- a/apidef/oas/testdata/fixtures/mock_response.yml
+++ b/apidef/oas/testdata/fixtures/mock_response.yml
@@ -33,23 +33,8 @@ tests:
         versions:
           "":
             extended_paths:
-<<<<<<< HEAD
-              white_list:
-                - disabled: false
-                  path: "/test"
-                  method: "GET"
-                  ignore_case: false
-                  method_actions:
-                    GET:
-                      action: "reply"
-                      code: 200
-                      headers:
-                        Content-Type: "application/json"
-                      data: '{"message": "success"}'
-=======
               mock_response: <nil>
               white_list: <nil>
->>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
   - desc: "multiple methods on same path"
     source: oas
     input:
@@ -103,35 +88,8 @@ tests:
         versions:
           "":
             extended_paths:
-<<<<<<< HEAD
-              white_list:
-                - disabled: false
-                  path: "/test"
-                  method: "GET"
-                  ignore_case: false
-                  method_actions:
-                    GET:
-                      action: "reply"
-                      code: 200
-                      headers:
-                        Content-Type: "application/json"
-                      data: '{"status": "ok"}'
-                - disabled: false
-                  path: "/test"
-                  method: "POST"
-                  ignore_case: false
-                  method_actions:
-                    POST:
-                      action: "reply"
-                      code: 201
-                      headers:
-                        Content-Type: "application/json"
-                        Location: "/test/123"
-                      data: '{"id": "123"}'
-=======
               mock_response: <nil>
               white_list: <nil>
->>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
   - desc: "disabled mock response"
     source: oas
     input:
@@ -164,23 +122,8 @@ tests:
         versions:
           "":
             extended_paths:
-<<<<<<< HEAD
-              white_list:
-                - disabled: true
-                  path: "/test"
-                  method: "GET"
-                  ignore_case: false
-                  method_actions:
-                    GET:
-                      action: "reply"
-                      code: 404
-                      headers:
-                        Content-Type: "application/json"
-                      data: '{"error": "not found"}'
-=======
               mock_response: <nil>
               white_list: <nil>
->>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
   - desc: "basic mock response - classic"
     source: "classic"
     input:

--- a/apidef/oas/testdata/fixtures/mock_response.yml
+++ b/apidef/oas/testdata/fixtures/mock_response.yml
@@ -33,6 +33,7 @@ tests:
         versions:
           "":
             extended_paths:
+<<<<<<< HEAD
               white_list:
                 - disabled: false
                   path: "/test"
@@ -45,6 +46,10 @@ tests:
                       headers:
                         Content-Type: "application/json"
                       data: '{"message": "success"}'
+=======
+              mock_response: <nil>
+              white_list: <nil>
+>>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
   - desc: "multiple methods on same path"
     source: oas
     input:
@@ -98,6 +103,7 @@ tests:
         versions:
           "":
             extended_paths:
+<<<<<<< HEAD
               white_list:
                 - disabled: false
                   path: "/test"
@@ -122,6 +128,10 @@ tests:
                         Content-Type: "application/json"
                         Location: "/test/123"
                       data: '{"id": "123"}'
+=======
+              mock_response: <nil>
+              white_list: <nil>
+>>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
   - desc: "disabled mock response"
     source: oas
     input:
@@ -154,6 +164,7 @@ tests:
         versions:
           "":
             extended_paths:
+<<<<<<< HEAD
               white_list:
                 - disabled: true
                   path: "/test"
@@ -166,6 +177,10 @@ tests:
                       headers:
                         Content-Type: "application/json"
                       data: '{"error": "not found"}'
+=======
+              mock_response: <nil>
+              white_list: <nil>
+>>>>>>> a145dbd4d... [TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)
   - desc: "basic mock response - classic"
     source: "classic"
     input:
@@ -206,6 +221,7 @@ tests:
         middleware:
           operations:
             testGET:
+              allow: <nil>
               mockResponse:
                 enabled: true
                 code: 200
@@ -282,6 +298,7 @@ tests:
         middleware:
           operations:
             testGET:
+              allow: <nil>
               mockResponse:
                 enabled: true
                 code: 200
@@ -292,6 +309,7 @@ tests:
               ignoreAuthentication:
                 enabled: true
             testPOST:
+              allow: <nil>
               mockResponse:
                 enabled: true
                 code: 201
@@ -340,6 +358,7 @@ tests:
         middleware:
           operations:
             testGET:
+              allow: <nil>
               mockResponse:
                 enabled: false
                 code: 404


### PR DESCRIPTION
### **User description**
[TT-7306] Ensure ignoreAuthentication is only enabled in migration scenario (#6923)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-7306"
title="TT-7306" target="_blank">TT-7306</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
<td>[OAS:migration] Migrate Mock Response from Classic API Definition to
OAS API Definition</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20QA_Fail%20ORDER%20BY%20created%20DESC"
title="QA_Fail">QA_Fail</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->
This PR ensures that `ignoreAuthentication` is only present for OAS
definitions originating from a migrated classic `API`. If the OAS
definition is created directly, `ignoreAuthentication` should not be
included. This is achieved by removing `extractMockResponsePaths` and
related code.

Additionally, `fillAllowance` is updated to prevent creating an
allowance for mock response entries (`allow list` with `action=reply`).

## Related Issue
https://tyktech.atlassian.net/browse/TT-7306

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
- Bug fix
- Tests



___

### **Description**
- Removed legacy mock response extraction functionality.

- Deleted unused extractMockResponsePaths method.

- Updated tests to expect zero mock responses.

- Adjusted fixture to set mock_response to <nil>.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>operation.go</strong><dd><code>Remove mock response
extraction function.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

apidef/oas/operation.go

<li>Removed call to extractMockResponsePaths.<br> <li> Deleted
extractMockResponsePaths function.<br> <li> Cleaned up related
extraction logic.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6923/files#diff-6d92d2d5b09a5fa7129609bb7cd0d383d015250ec07062b6a93a83257be51fb5">+0/-24</a>&nbsp;
&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>operation_test.go</strong><dd><code>Update tests for
removed mock responses.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; </dd></summary>
<hr>

apidef/oas/operation_test.go

<li>Updated test expectations for mockResponse length.<br> <li> Removed
assertions for legacy mock response values.<br> <li> Adjusted test
conditions to expect no mock responses.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6923/files#diff-cd234db716d6d2edc97c135ef546021c9ab4fa9282d63964bd155d41635cf964">+4/-72</a>&nbsp;
&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>mock_response.yml</strong><dd><code>Update fixture to
remove mock response data.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/testdata/fixtures/mock_response.yml

<li>Replaced mock_response data with <nil> value.<br> <li> Set
white_list to <nil> in fixtures.<br> <li> Cleaned up legacy mock
response data.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6923/files#diff-c7c72a9398d68abedf9238cc2a9606521069e13034f921e7a979d859e0559c8d">+6/-36</a>&nbsp;
&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary> Need help?</summary><li>Type <code>/help how to
...</code> in the comments thread for any questions about PR-Agent
usage.</li><li>Check out the <a
href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a>
for more information.</li></details>

[TT-7306]: https://tyktech.atlassian.net/browse/TT-7306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
- Bug fix
- Tests



___

### **Description**
- Remove legacy mock response extraction functionality.

- Update fillAllowance to skip endpoints with reply actions.

- Revise tests to expect nil mock response and Allow configuration.

- Clean up test fixtures to remove outdated white_list data.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operation.go</strong><dd><code>Remove legacy extraction and add allowance nullification.</code></dd></summary>
<hr>

apidef/oas/operation.go

<li>Deleted call and definition of extractMockResponsePaths.<br> <li> Added line setting tykOperation.Allow to nil.<br> <li> Introduced new helper hasMockResponse for reply action checking.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6937/files#diff-6d92d2d5b09a5fa7129609bb7cd0d383d015250ec07062b6a93a83257be51fb5">+23/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operation_test.go</strong><dd><code>Update tests to align with removed mock responses.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/operation_test.go

<li>Updated tests to remove dependency on legacy white_list.<br> <li> Adjusted assertions to verify nil Allow field.<br> <li> Modified expectations for mock response removals.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6937/files#diff-cd234db716d6d2edc97c135ef546021c9ab4fa9282d63964bd155d41635cf964">+289/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mock_response.yml</strong><dd><code>Update fixtures to remove legacy mock responses.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/testdata/fixtures/mock_response.yml

<li>Replaced legacy mock_response and white_list data with <nil>.<br> <li> Cleaned up fixture values to suit direct OAS definitions.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6937/files#diff-c7c72a9398d68abedf9238cc2a9606521069e13034f921e7a979d859e0559c8d">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>