### PR TITLE
Merging to release-5.8: [TT-12957] fix some issues with uptime_tests migrations to OAS (#6924)

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -889,8 +889,12 @@ type AnalyticsPluginConfig struct {
 
 // UptimeTests holds the test configuration for uptime tests.
 type UptimeTests struct {
+	// Disabled indicates whether the uptime test configuration is disabled.
+	Disabled bool `bson:"disabled" json:"disabled"`
+	// CheckList represents a collection of HostCheckObject used to define multiple checks in uptime test configurations.
 	CheckList []HostCheckObject `bson:"check_list" json:"check_list"`
-	Config    UptimeTestsConfig `bson:"config" json:"config"`
+	// Config defines the configuration settings for uptime tests, including analytics expiration and service discovery.
+	Config UptimeTestsConfig `bson:"config" json:"config"`
 }
 
 // UptimeTestCommand handles additional checks for tcp connections.

--- a/apidef/oas/oas_test.go
+++ b/apidef/oas/oas_test.go
@@ -186,6 +186,7 @@ func TestOAS_ExtractTo_ResetAPIDefinition(t *testing.T) {
 	a.EnableContextVars = false
 	a.DoNotTrack = false
 	a.IPAccessControlDisabled = false
+	a.UptimeTests.Disabled = false
 
 	// deprecated fields
 	a.Auth = apidef.AuthConfig{}

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -2432,6 +2432,9 @@
         "enabled": {
           "type": "boolean"
         },
+        "skipUnavailableHosts": {
+          "type": "boolean"
+        },
         "targets": {
           "type": "array",
           "items": [
@@ -2554,9 +2557,6 @@
           }
         },
         "method": {
-          "type": "string"
-        },
-        "protocol": {
           "type": "string"
         },
         "timeout": {

--- a/apidef/oas/schema/x-tyk-api-gateway.strict.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.strict.json
@@ -2532,6 +2532,9 @@
         "enabled": {
           "type": "boolean"
         },
+        "skipUnavailableHosts": {
+          "type": "boolean"
+        },
         "targets": {
           "type": "array",
           "items": [
@@ -2676,9 +2679,6 @@
           }
         },
         "method": {
-          "type": "string"
-        },
-        "protocol": {
           "type": "string"
         },
         "timeout": {

--- a/apidef/oas/testdata/fixtures/upstream_uptimeTests.yml
+++ b/apidef/oas/testdata/fixtures/upstream_uptimeTests.yml
@@ -20,7 +20,6 @@ tests:
             logRetentionPeriod: 10s
             tests:
             - url: "https://www.google.com"
-              protocol: "http"
               timeout: 1s
               method: "GET"
               enableProxyProtocol: true
@@ -28,13 +27,13 @@ tests:
                 "Content-Type": "application/json"
               body: "test"
     output:
-      proxy.check_host_against_uptime_tests: true
       uptime_tests.config.expire_utime_after: 10
       uptime_tests.config.recheck_wait: 20
       uptime_tests:
+        disabled: false
         check_list:
           - url: "https://www.google.com"
-            protocol: "http"
+            protocol: "https"
             timeout: 1000000000
             method: "GET"
             headers.Content-Type: "application/json"
@@ -44,49 +43,16 @@ tests:
   - desc: "upstream uptime test classic"
     source: classic
     input:
-      proxy:
-        check_host_against_uptime_tests: true
       uptime_tests:
+        disabled: true
         config:
           expire_utime_after: 10
           recheck_wait: 20
         check_list:
-          - url: "https://www.google.com"
-            protocol: "http"
+          - url: "http://www.google.com"
+            protocol: "https"
             timeout: 2000000
             method: "GET"
-            headers:
-              "Content-Type": "application/json"
-    output:
-      x-tyk-api-gateway:
-        upstream:
-          serviceDiscovery: <nil>
-          uptimeTests:
-            enabled: true
-            hostDownRetestPeriod: 20s
-            logRetentionPeriod: 10s
-            tests:
-            - url: "https://www.google.com"
-              protocol: "http"
-              timeout: 2ms
-              method: "GET"
-              headers:
-                "Content-Type": "application/json"
-  - desc: "upstream uptime test classic"
-    source: classic
-    input:
-      proxy:
-        check_host_against_uptime_tests: false
-      uptime_tests:
-        config:
-          expire_utime_after: 10
-          recheck_wait: 20
-        check_list:
-          - url: "https://www.google.com"
-            protocol: "http"
-            timeout: 2000000000
-            method: "GET"
-            enable_proxy_protocol: true
             headers:
               "Content-Type": "application/json"
     output:
@@ -99,7 +65,36 @@ tests:
             logRetentionPeriod: 10s
             tests:
             - url: "https://www.google.com"
-              protocol: "http"
+              timeout: 2ms
+              method: "GET"
+              headers:
+                "Content-Type": "application/json"
+  - desc: "upstream uptime test classic"
+    source: classic
+    input:
+      uptime_tests:
+        disabled: false
+        config:
+          expire_utime_after: 10
+          recheck_wait: 20
+        check_list:
+          - url: "https://www.google.com"
+            protocol: "https"
+            timeout: 2000000000
+            method: "GET"
+            enable_proxy_protocol: true
+            headers:
+              "Content-Type": "application/json"
+    output:
+      x-tyk-api-gateway:
+        upstream:
+          serviceDiscovery: <nil>
+          uptimeTests:
+            enabled: true
+            hostDownRetestPeriod: 20s
+            logRetentionPeriod: 10s
+            tests:
+            - url: "https://www.google.com"
               timeout: 2s
               method: "GET"
               enableProxyProtocol: true
@@ -108,15 +103,14 @@ tests:
   - desc: "upstream uptime test classic - commands"
     source: classic
     input:
-      proxy:
-        check_host_against_uptime_tests: false
       uptime_tests:
+        disabled: false
         config:
           expire_utime_after: 10
           recheck_wait: 20
         check_list:
           - url: "https://www.google.com"
-            protocol: "http"
+            protocol: "https"
             timeout: 2000000000
             method: "GET"
             enable_proxy_protocol: true
@@ -132,12 +126,11 @@ tests:
         upstream:
           serviceDiscovery: <nil>
           uptimeTests:
-            enabled: false
+            enabled: true
             hostDownRetestPeriod: 20s
             logRetentionPeriod: 10s
             tests:
             - url: "https://www.google.com"
-              protocol: "http"
               timeout: 2s
               method: "GET"
               enableProxyProtocol: true

--- a/apidef/oas/upstream.go
+++ b/apidef/oas/upstream.go
@@ -2,6 +2,7 @@ package oas
 
 import (
 	"crypto/tls"
+	"fmt"
 	"sort"
 	"strings"
 
@@ -78,7 +79,7 @@ func (u *Upstream) Fill(api apidef.APIDefinition) {
 		u.UptimeTests = &UptimeTests{}
 	}
 
-	u.UptimeTests.Fill(api.UptimeTests, api.Proxy.CheckHostAgainstUptimeTests)
+	u.UptimeTests.Fill(api.UptimeTests)
 	if ShouldOmit(u.UptimeTests) {
 		u.UptimeTests = nil
 	}
@@ -183,7 +184,7 @@ func (u *Upstream) ExtractTo(api *apidef.APIDefinition) {
 		}()
 	}
 
-	u.UptimeTests.ExtractTo(&api.UptimeTests, &api.Proxy.CheckHostAgainstUptimeTests)
+	u.UptimeTests.ExtractTo(&api.UptimeTests)
 
 	if u.MutualTLS == nil {
 		u.MutualTLS = &MutualTLS{}
@@ -576,10 +577,9 @@ func (sd *ServiceDiscovery) ExtractTo(serviceDiscovery *apidef.ServiceDiscoveryC
 
 // UptimeTests configures uptime tests.
 type UptimeTests struct {
-	// Enabled if true enables uptime tests.
-	//
-	// Tyk classic API definition: `check_hosts_against_uptime_tests`
-	Enabled bool `bson:"enabled" json:"enabled"` // required
+	// Enabled specifies whether the uptime tests are active or not.
+	// Tyk classic API definition: `uptime_tests.disabled`
+	Enabled bool `bson:"enabled" json:"enabled"`
 
 	// ServiceDiscovery contains the configuration related to test Service Discovery.
 	// Tyk classic API definition: `proxy.service_discovery`
@@ -607,12 +607,8 @@ type UptimeTest struct {
 	//
 	// - `http://database1.company.local`
 	// - `https://webcluster.service/health`
-	// - `127.0.0.1:6379` (for TCP checks).
+	// - `tcp://127.0.0.1:6379` (for TCP checks).
 	CheckURL string `bson:"url" json:"url"`
-
-	// Protocol is the protocol for the request. Supported values are
-	// `http` and `tcp`, depending on what kind of check is performed.
-	Protocol string `bson:"protocol" json:"protocol"`
 
 	// Timeout declares a timeout for the request. If the test exceeds
 	// this timeout, the check fails.
@@ -655,27 +651,27 @@ type UptimeTestCommand struct {
 	Message string `bson:"message" json:"message"`
 }
 
-// Fill fills *UptimeTests from apidef.UptimeTests and enabled.
-func (t *UptimeTests) Fill(uptimeTests apidef.UptimeTests, enabled bool) {
-	if t.ServiceDiscovery == nil {
-		t.ServiceDiscovery = &ServiceDiscovery{}
+// Fill fills *UptimeTests from apidef.UptimeTests.
+func (u *UptimeTests) Fill(uptimeTests apidef.UptimeTests) {
+	u.Enabled = !uptimeTests.Disabled
+
+	if u.ServiceDiscovery == nil {
+		u.ServiceDiscovery = &ServiceDiscovery{}
 	}
 
-	t.ServiceDiscovery.Fill(uptimeTests.Config.ServiceDiscovery)
-	if ShouldOmit(t.ServiceDiscovery) {
-		t.ServiceDiscovery = nil
+	u.ServiceDiscovery.Fill(uptimeTests.Config.ServiceDiscovery)
+	if ShouldOmit(u.ServiceDiscovery) {
+		u.ServiceDiscovery = nil
 	}
 
-	t.Tests = nil
-	t.Enabled = enabled
-	t.LogRetentionPeriod = ReadableDuration(time.Duration(uptimeTests.Config.ExpireUptimeAnalyticsAfter) * time.Second)
-	t.HostDownRetestPeriod = ReadableDuration(time.Duration(uptimeTests.Config.RecheckWait) * time.Second)
+	u.Tests = nil
+	u.LogRetentionPeriod = ReadableDuration(time.Duration(uptimeTests.Config.ExpireUptimeAnalyticsAfter) * time.Second)
+	u.HostDownRetestPeriod = ReadableDuration(time.Duration(uptimeTests.Config.RecheckWait) * time.Second)
 
 	result := []UptimeTest{}
 	for _, v := range uptimeTests.CheckList {
 		check := UptimeTest{
-			CheckURL:            v.CheckURL,
-			Protocol:            v.Protocol,
+			CheckURL:            u.fillCheckURL(v.Protocol, v.CheckURL),
 			Timeout:             ReadableDuration(v.Timeout),
 			Method:              v.Method,
 			Headers:             v.Headers,
@@ -690,33 +686,34 @@ func (t *UptimeTests) Fill(uptimeTests apidef.UptimeTests, enabled bool) {
 	}
 
 	if len(result) > 0 {
-		t.Tests = result
+		u.Tests = result
 	}
 }
 
-// ExtractTo extracts *UptimeTests into *apidef.UptimeTests and enabled.
-func (t *UptimeTests) ExtractTo(uptimeTests *apidef.UptimeTests, enabled *bool) {
-	if t.ServiceDiscovery == nil {
-		t.ServiceDiscovery = &ServiceDiscovery{}
+// ExtractTo extracts *UptimeTests into *apidef.UptimeTests.
+func (u *UptimeTests) ExtractTo(uptimeTests *apidef.UptimeTests) {
+	uptimeTests.Disabled = !u.Enabled
+
+	if u.ServiceDiscovery == nil {
+		u.ServiceDiscovery = &ServiceDiscovery{}
 		defer func() {
-			t.ServiceDiscovery = nil
+			u.ServiceDiscovery = nil
 		}()
 	}
 
-	t.ServiceDiscovery.ExtractTo(&uptimeTests.Config.ServiceDiscovery)
+	u.ServiceDiscovery.ExtractTo(&uptimeTests.Config.ServiceDiscovery)
 
-	*enabled = t.Enabled
-
-	uptimeTests.Config.ExpireUptimeAnalyticsAfter = int64(t.LogRetentionPeriod.Seconds())
-	uptimeTests.Config.RecheckWait = int(t.HostDownRetestPeriod.Seconds())
+	uptimeTests.Config.ExpireUptimeAnalyticsAfter = int64(u.LogRetentionPeriod.Seconds())
+	uptimeTests.Config.RecheckWait = int(u.HostDownRetestPeriod.Seconds())
 
 	uptimeTests.CheckList = nil
 
 	result := []apidef.HostCheckObject{}
-	for _, v := range t.Tests {
+	for _, v := range u.Tests {
+		classicProtocol, classicCheckURL := u.extractToProtocolAndCheckURL(v.CheckURL)
 		check := apidef.HostCheckObject{
-			CheckURL:            v.CheckURL,
-			Protocol:            v.Protocol,
+			CheckURL:            classicCheckURL,
+			Protocol:            classicProtocol,
 			Timeout:             time.Duration(v.Timeout),
 			Method:              v.Method,
 			Headers:             v.Headers,
@@ -733,6 +730,29 @@ func (t *UptimeTests) ExtractTo(uptimeTests *apidef.UptimeTests, enabled *bool) 
 	if len(result) > 0 {
 		uptimeTests.CheckList = result
 	}
+}
+
+// fillCheckURL constructs a valid URL by appending the protocol to the provided URL, removing any existing protocol.
+// This needs to be done because classic can have invalid protocol and checkURL combinations, e.g.
+// protocol=tcp, checkURL=https://myservice.fake
+func (u *UptimeTests) fillCheckURL(protocol string, checkURL string) string {
+	protocolessURL := checkURL
+	splitURL := strings.Split(checkURL, "://")
+	if len(splitURL) > 1 {
+		protocolessURL = splitURL[1]
+	}
+
+	return fmt.Sprintf("%s://%s", protocol, protocolessURL)
+}
+
+// extractToProtocolAndCheckURL splits a URL into its protocol and the remaining part of the URL, returning both as strings.
+// Classic has a special field for protocol while OAS only has checkURL. The protocol should remain inside checkURL.
+func (u *UptimeTests) extractToProtocolAndCheckURL(checkURL string) (classicProtocol, classicCheckURL string) {
+	splitURL := strings.Split(checkURL, "://")
+	if len(splitURL) > 1 {
+		return splitURL[0], checkURL
+	}
+	return "", checkURL // should never happen, but let's be sure to not have panics
 }
 
 // MutualTLS contains the configuration for establishing a mutual TLS connection between Tyk and the upstream server.
@@ -1261,6 +1281,9 @@ func (l *UpstreamRequestSigning) ExtractTo(api *apidef.APIDefinition) {
 type LoadBalancing struct {
 	// Enabled determines if load balancing is active.
 	Enabled bool `json:"enabled" bson:"enabled"` // required
+	// SkipUnavailableHosts determines whether to skip unavailable hosts during load balancing based on uptime tests.
+	// Tyk classic field: `proxy.check_host_against_uptime_tests`
+	SkipUnavailableHosts bool `json:"skipUnavailableHosts,omitempty" bson:"skipUnavailableHosts,omitempty"`
 	// Targets defines the list of targets with their respective weights for load balancing.
 	Targets []LoadBalancingTarget `json:"targets,omitempty" bson:"targets,omitempty"`
 }
@@ -1277,11 +1300,13 @@ type LoadBalancingTarget struct {
 func (l *LoadBalancing) Fill(api apidef.APIDefinition) {
 	if len(api.Proxy.Targets) == 0 {
 		api.Proxy.EnableLoadBalancing = false
+		api.Proxy.CheckHostAgainstUptimeTests = false
 		api.Proxy.Targets = nil
 		return
 	}
 
 	l.Enabled = api.Proxy.EnableLoadBalancing
+	l.SkipUnavailableHosts = api.Proxy.CheckHostAgainstUptimeTests
 
 	targetCounter := make(map[string]*LoadBalancingTarget)
 	for _, target := range api.Proxy.Targets {
@@ -1313,12 +1338,14 @@ func (l *LoadBalancing) Fill(api apidef.APIDefinition) {
 func (l *LoadBalancing) ExtractTo(api *apidef.APIDefinition) {
 	if len(l.Targets) == 0 {
 		api.Proxy.EnableLoadBalancing = false
+		api.Proxy.CheckHostAgainstUptimeTests = false
 		api.Proxy.Targets = nil
 		return
 	}
 
 	proxyConfTargets := make([]string, 0, len(l.Targets))
 	api.Proxy.EnableLoadBalancing = l.Enabled
+	api.Proxy.CheckHostAgainstUptimeTests = l.SkipUnavailableHosts
 	for _, target := range l.Targets {
 		for i := 0; i < target.Weight; i++ {
 			proxyConfTargets = append(proxyConfTargets, target.URL)

--- a/apidef/oas/upstream_test.go
+++ b/apidef/oas/upstream_test.go
@@ -150,13 +150,12 @@ func TestServiceDiscovery(t *testing.T) {
 func TestUptimeTests(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		var emptyTest UptimeTests
-		var enabled bool
 
 		var convertedTest apidef.UptimeTests
-		emptyTest.ExtractTo(&convertedTest, &enabled)
+		emptyTest.ExtractTo(&convertedTest)
 
 		var resultTest UptimeTests
-		resultTest.Fill(convertedTest, enabled)
+		resultTest.Fill(convertedTest)
 
 		assert.Equal(t, emptyTest, resultTest)
 	})
@@ -167,22 +166,20 @@ func TestUptimeTests(t *testing.T) {
 			ServiceDiscovery: nil,
 			Tests: []UptimeTest{
 				{
-					CheckURL: "test.com",
-					Protocol: "http",
+					CheckURL: "http://test.com",
 					Timeout:  ReadableDuration(time.Millisecond * 50),
 					Method:   "POST",
 				},
 			},
 		}
-		var convertedTest apidef.UptimeTests
-		var enabled bool
 
-		uptimeTests.ExtractTo(&convertedTest, &enabled)
+		var convertedTest apidef.UptimeTests
+
+		uptimeTests.ExtractTo(&convertedTest)
 
 		assert.Equal(t, time.Millisecond*50, convertedTest.CheckList[0].Timeout)
 		assert.Equal(t, uptimeTests.Tests[0].CheckURL, convertedTest.CheckList[0].CheckURL)
 		assert.Equal(t, uptimeTests.Tests[0].Method, convertedTest.CheckList[0].Method)
-		assert.Equal(t, uptimeTests.Tests[0].Protocol, convertedTest.CheckList[0].Protocol)
 	})
 }
 


### PR DESCRIPTION
[TT-12957] fix some issues with uptime_tests migrations to OAS (#6924)

Related tickets: TT-14302, TT-14303, TT-14304

This PR fixes following issues:
- correctly maps `check_host_against_uptime_tests` to
`loadBalancing.skipUnavailableHosts`
 - add `disabled` flag to uptime_tests including logic
 - remove `protocol` from `uptimeTests.tests` in OAS

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)