### PR TITLE
[TT-12957] fixed issue when migrating from classic to oas that was leaving a broken url

### DIFF
--- a/apidef/oas/upstream.go
+++ b/apidef/oas/upstream.go
@@ -736,6 +736,10 @@ func (u *UptimeTests) ExtractTo(uptimeTests *apidef.UptimeTests) {
 // This needs to be done because classic can have invalid protocol and checkURL combinations, e.g.
 // protocol=tcp, checkURL=https://myservice.fake
 func (u *UptimeTests) fillCheckURL(protocol string, checkURL string) string {
+	// in classic API, protocol can be empty so we need to check for that and return the original URL
+	if protocol == "" {
+		return checkURL
+	}
 	protocolessURL := checkURL
 	splitURL := strings.Split(checkURL, "://")
 	if len(splitURL) > 1 {


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-14304" title="TT-14304" target="_blank">TT-14304</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>remove protocol from uptimeTests.tests in OAS</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Sub-task" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />
        Sub-task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20QA_Fail%20ORDER%20BY%20created%20DESC" title="QA_Fail">QA_Fail</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

MAIN TASK: https://tyktech.atlassian.net/browse/TT-12957
SUBTASK: https://tyktech.atlassian.net/browse/TT-14304

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Bug fix


___

### **Description**
- Return original URL when protocol is empty.

- Prevent invalid protocol addition for classic API.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>upstream.go</strong><dd><code>Handle empty protocol in checkURL function.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/upstream.go

<li>Added check for empty protocol.<br> <li> Return original URL for classic API.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6947/files#diff-7b0941c7f37fe5a2a23047e0822a65519ca11c371660f36555b59a60f000e3f4">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>