### PR TITLE
Merging to release-5.8: [TT-14102] fix api level and endpoint level cache migration (#6931)

### DIFF
--- a/apidef/migration.go
+++ b/apidef/migration.go
@@ -13,6 +13,8 @@ import (
 
 const (
 	ResponseProcessorResponseBodyTransform = "response_body_transform"
+	// DefaultCacheTimeout is the default cache TTL in seconds if not specified for api and endpoint level caching
+	DefaultCacheTimeout int64 = 60
 )
 
 var (
@@ -349,27 +351,50 @@ func (a *APIDefinition) MigrateCachePlugin() {
 	if vInfo.UseExtendedPaths && len(list) > 0 {
 		var advCacheMethods []CacheMeta
 		for _, cache := range list {
-			newGetMethodCache := CacheMeta{
-				Path:   cache,
-				Method: http.MethodGet,
-			}
-			newHeadMethodCache := CacheMeta{
-				Path:   cache,
-				Method: http.MethodHead,
-			}
-			newOptionsMethodCache := CacheMeta{
-				Path:   cache,
-				Method: http.MethodOptions,
-			}
+			newGetMethodCache := createAdvancedCacheConfig(a.CacheOptions, cache, http.MethodGet)
+			newHeadMethodCache := createAdvancedCacheConfig(a.CacheOptions, cache, http.MethodHead)
+			newOptionsMethodCache := createAdvancedCacheConfig(a.CacheOptions, cache, http.MethodOptions)
+
 			advCacheMethods = append(advCacheMethods, newGetMethodCache, newHeadMethodCache, newOptionsMethodCache)
 		}
 
-		vInfo.ExtendedPaths.AdvanceCacheConfig = advCacheMethods
-		// reset cache to empty
+		// Combine the new method-specific cache configs with any existing advanced configs
+		// Note: existing configs are added last so they have higher priority (last wins)
+		vInfo.ExtendedPaths.AdvanceCacheConfig = append(advCacheMethods, vInfo.ExtendedPaths.AdvanceCacheConfig...)
+
+		// Clear the old simple cache paths since they've been migrated to the advanced configuration
 		vInfo.ExtendedPaths.Cached = nil
 	}
 
 	a.VersionData.Versions[""] = vInfo
+}
+
+// createAdvancedCacheConfig creates a new CacheMeta configuration for advanced caching.
+func createAdvancedCacheConfig(cacheOpts CacheOptions, path string, method string) CacheMeta {
+	// Default cache timeout in seconds if none is specified but caching is enabled
+	timeout := DefaultCacheTimeout
+
+	// Use the global cache timeout from cache_options.
+	// If not set (0), defaults to DefaultCacheTimeout (60s)
+	if cacheOpts.CacheTimeout > 0 {
+		timeout = cacheOpts.CacheTimeout
+	}
+
+	cacheResponseCodes := cacheOpts.CacheOnlyResponseCodes
+
+	return CacheMeta{
+		// When migrating to advanced cache configuration:
+		// - If global cache is disabled, create the advanced config but mark it as disabled
+		// - If global cache is enabled, create the advanced config as enabled
+		Disabled: !cacheOpts.EnableCache,
+		Path:     path,
+		Method:   method,
+		// Use the global cache timeout from cache_options.
+		// If not set (0), defaults to DefaultCacheTimeout (60s)
+		Timeout: timeout,
+		// We should take response codes from global cache (cache_options)
+		CacheOnlyResponseCodes: cacheResponseCodes,
+	}
 }
 
 func (a *APIDefinition) MigrateAuthentication() {

--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -1231,6 +1231,11 @@ func (a *CachePlugin) Fill(cm apidef.CacheMeta) {
 	a.CacheByRegex = cm.CacheKeyRegex
 	a.CacheResponseCodes = cm.CacheOnlyResponseCodes
 	a.Timeout = cm.Timeout
+
+	//TT-14102: Default cache timeout in seconds if none is specified but caching is enabled
+	if a.Enabled && a.Timeout == 0 {
+		a.Timeout = apidef.DefaultCacheTimeout
+	}
 }
 
 // ExtractTo extracts *CachePlugin values to *apidef.CacheMeta.

--- a/apidef/oas/testdata/fixtures/cache.yml
+++ b/apidef/oas/testdata/fixtures/cache.yml
@@ -1,0 +1,98 @@
+---
+name: "Cache"
+tests:
+  - desc: "basic cache - classic"
+    source: "classic"
+    input:
+      cache_options:
+        cache_timeout: 60
+        enable_cache: true
+        cache_all_safe_requests: false
+        cache_response_codes: []
+        enable_upstream_cache_control: false
+        cache_control_ttl_header: ''
+        cache_by_headers: []
+      version_data:
+        versions:
+          "":
+            name: Default
+            extended_paths:
+              cache:
+              - "/get"
+    output:
+      x-tyk-api-gateway:
+        middleware:
+          global:
+            cache:
+              cacheResponseCodes: []
+              cacheByHeaders: []
+              timeout: 60
+              enabled: true
+          operations: <nil>
+  - desc: "multiple advanced cache entries"
+    source: "classic"
+    input:
+      cache_options:
+        cache_timeout: 60
+        enable_cache: true
+        cache_all_safe_requests: false
+        cache_response_codes: []
+        enable_upstream_cache_control: false
+        cache_control_ttl_header: ''
+        cache_by_headers: []
+      version_data:
+        versions:
+          "":
+            name: Default
+            extended_paths:
+              advance_cache_config:
+              - path: "/get"
+                method: "GET"
+                cache_response_codes: []
+                disabled: false
+                timeout: 120        
+              - path: "/get"
+                method: "HEAD"
+                cache_response_codes: []
+                disabled: false
+                timeout: 150
+              - path: "/get"
+                method: "OPTIONS"
+                cache_response_codes: [
+                  200
+                ]
+                disabled: false
+                timeout: 200
+              - path: "/get"
+                method: "OPTIONS"
+                cache_response_codes: [
+                  204
+                ]
+                disabled: false
+                timeout: 300
+    output:
+      x-tyk-api-gateway:
+        middleware:
+          global:
+            cache:
+              cacheResponseCodes: []
+              cacheByHeaders: []
+              timeout: 60
+          operations:
+            getGET:
+              cache:
+                enabled: true
+                timeout: 120
+                cacheResponseCodes: []
+            getHEAD:
+              cache:
+                enabled: true
+                timeout: 150
+                cacheResponseCodes: []
+            getOPTIONS:
+              cache:
+                enabled: true
+                timeout: 300
+                cacheResponseCodes:
+                - 204
+                


### PR DESCRIPTION
### **User description**
[TT-14102] fix api level and endpoint level cache migration (#6931)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-14102"
title="TT-14102" target="_blank">TT-14102</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>[OAS migration] Cache and Advanced Cache combined</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

This PR ensures that `OAS` cache is migrated correctly from the
`classic` API. Values are imported from the API-level configuration
(lower priority) and/or endpoint-level configurations (higher priority).
For timeout, a default value of `60` is used if neither the API-level
nor endpoint-level configuration specifies one.

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

https://tyktech.atlassian.net/browse/TT-14102

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
- Enhancement



___

### **Description**
- Added debug logs to trace cache metadata.

- Logged response codes and timeout values.

- Aided testing of advanced cache behavior.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>mw_redis_cache.go</strong><dd><code>Add debug logs in
Redis cache middleware.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

gateway/mw_redis_cache.go

<li>Inserted log for <code>cacheMeta</code> details.<br> <li> Logged
<code>cacheOnlyResponseCodes</code> value.<br> <li> Logged
<code>timeout</code> parameter.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6931/files#diff-6266e0dbd16cef89e6de86a2c893114ba07799c804e2138172f9f94b08cdded8">+5/-0</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary> Need help?</summary><li>Type <code>/help how to
...</code> in the comments thread for any questions about PR-Agent
usage.</li><li>Check out the <a
href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a>
for more information.</li></details>

[TT-14102]: https://tyktech.atlassian.net/browse/TT-14102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
- Bug fix
- Enhancement



___

### **Description**
- Migrate simple cache settings to advanced config.

- Introduce helper createAdvancedCacheConfig function.

- Update middleware to apply default cache timeout.

- Add extensive tests and fixtures for cache migration.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>migration.go</strong><dd><code>Migrate cache config using helper function.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/migration.go

<li>Added DefaultCacheTimeout constant.<br> <li> Replaced basic cache migration with createAdvancedCacheConfig.<br> <li> Appended advanced cache config to preserve existing settings.<br> <li> Cleared old simple cache configuration.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6950/files#diff-e1d9b55a26f9d6225d56d6f0161959217308e5ad4d6934e7d7df4595d9c2a130">+39/-14</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>migration_test.go</strong><dd><code>Enhance cache migration tests.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/migration_test.go

<li>Removed outdated TestAPIDefinition_MigrateCachePlugin.<br> <li> Added new tests for cache migration behavior.<br> <li> Included tests for multiple cache paths and helper function.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6950/files#diff-d79d77f814074b9e483554e36687e22fda759045141c3b094b039428744ff94c">+326/-39</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>middleware_test.go</strong><dd><code>Add comprehensive tests for CachePlugin.Fill.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/middleware_test.go

<li>Introduced multiple tests for CachePlugin.Fill.<br> <li> Covered scenarios for default timeout, disabled cache, and regex <br>presence.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6950/files#diff-0af31cb29ae298a6ac3e402b283ab364a6fd793fd04f253ef7c4983234c17bef">+124/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cache.yml</strong><dd><code>Add cache fixture for integration testing.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/testdata/fixtures/cache.yml

<li>Added new cache test fixture configuration.<br> <li> Included scenarios for classic and advanced cache entries.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6950/files#diff-3938aa8840266a6527f058f3a7682ef6ce5279ddc3cdbef2be8317f3065beeb6">+98/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>middleware.go</strong><dd><code>Update middleware default timeout logic.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/middleware.go

<li>Updated Fill function to set default timeout.<br> <li> Enabled default cache timeout if none provided.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6950/files#diff-992ec7c28d25fd54f6491d295389757705cd114bc869a35cba50d42e548cdc6e">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>