### PR TITLE
Merging to release-5.8: [TT-12957] oas uptime testing migration fails on timeout field (#6956)

### DIFF
--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -2595,7 +2595,7 @@
     },
     "X-Tyk-ReadableDuration": {
       "type": "string",
-      "pattern": "^(\\d+h)?(\\d+m)?(\\d+s)?(\\d+ms)?$"
+      "pattern": "^(\\d+h)?(\\d+m)?(\\d+s)?(\\d+ms)?(\\d+µs)?(\\d+ns)?$"
     },
     "X-Tyk-LoadBalancingTarget": {
       "type": "object",

--- a/apidef/oas/schema/x-tyk-api-gateway.strict.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.strict.json
@@ -2719,7 +2719,7 @@
     },
     "X-Tyk-ReadableDuration": {
       "type": "string",
-      "pattern": "^(\\d+h)?(\\d+m)?(\\d+s)?(\\d+ms)?$",
+      "pattern": "^(\\d+h)?(\\d+m)?(\\d+s)?(\\d+ms)?(\\d+µs)?(\\d+ns)?$",
       "additionalProperties": false
     },
     "X-Tyk-LoadBalancingTarget": {

--- a/apidef/oas/testdata/fixtures/upstream_uptimeTests.yml
+++ b/apidef/oas/testdata/fixtures/upstream_uptimeTests.yml
@@ -73,6 +73,64 @@ tests:
     source: classic
     input:
       uptime_tests:
+        disabled: true
+        config:
+          expire_utime_after: 10
+          recheck_wait: 20
+        check_list:
+          - url: "http://www.google.com"
+            protocol: "https"
+            timeout: 20000
+            method: "GET"
+            headers:
+              "Content-Type": "application/json"
+    output:
+      x-tyk-api-gateway:
+        upstream:
+          serviceDiscovery: <nil>
+          uptimeTests:
+            enabled: false
+            hostDownRetestPeriod: 20s
+            logRetentionPeriod: 10s
+            tests:
+              - url: "https://www.google.com"
+                timeout: 20µs
+                method: "GET"
+                headers:
+                  "Content-Type": "application/json"
+  - desc: "upstream uptime test classic"
+    source: classic
+    input:
+      uptime_tests:
+        disabled: true
+        config:
+          expire_utime_after: 10
+          recheck_wait: 20
+        check_list:
+          - url: "http://www.google.com"
+            protocol: "https"
+            timeout: 200
+            method: "GET"
+            headers:
+              "Content-Type": "application/json"
+    output:
+      x-tyk-api-gateway:
+        upstream:
+          serviceDiscovery: <nil>
+          uptimeTests:
+            enabled: false
+            hostDownRetestPeriod: 20s
+            logRetentionPeriod: 10s
+            tests:
+              - url: "https://www.google.com"
+                timeout: 200ns
+                method: "GET"
+                headers:
+                  "Content-Type": "application/json"
+  - desc: "upstream uptime test classic"
+    source: classic
+    input:
+      uptime_tests:
         disabled: false
         config:
           expire_utime_after: 10

--- a/internal/time/duration.go
+++ b/internal/time/duration.go
@@ -72,3 +72,13 @@ func (d ReadableDuration) Seconds() float64 {
 func (d ReadableDuration) Milliseconds() int64 {
 	return Duration(d).Milliseconds()
 }
+
+// Nanoseconds returns ReadableDuration in nanoseconds.
+func (d ReadableDuration) Nanoseconds() int64 {
+	return Duration(d).Nanoseconds()
+}
+
+// Microseconds returns ReadableDuration in microseconds.
+func (d ReadableDuration) Microseconds() int64 {
+	return Duration(d).Microseconds()
+}


### PR DESCRIPTION
### **User description**
[TT-12957] oas uptime testing migration fails on timeout field (#6956)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-12957"
title="TT-12957" target="_blank">TT-12957</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>[OAS] Uptime testing</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Story"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium"
/>
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Test</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20QA_Fail%20ORDER%20BY%20created%20DESC"
title="QA_Fail">QA_Fail</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Bug fix


___

### **Description**
- Fix timeout: convert value to seconds

- Return original URL if protocol is empty


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>upstream.go</strong><dd><code>Fix timeout conversion
and add empty protocol check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; </dd></summary>
<hr>

apidef/oas/upstream.go

<li>Multiply timeout by time.Second for proper conversion<br> <li> Add
check for empty protocol in fillCheckURL to return original URL


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6956/files#diff-7b0941c7f37fe5a2a23047e0822a65519ca11c371660f36555b59a60f000e3f4">+5/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary> Need help?</summary><li>Type <code>/help how to
...</code> in the comments thread for any questions about PR-Agent
usage.</li><li>Check out the <a
href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a>
for more information.</li></details>

[TT-12957]: https://tyktech.atlassian.net/browse/TT-12957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
- Bug fix



___

### **Description**
- Add Nanoseconds and Microseconds functions in duration.go.

- Extend X-Tyk-ReadableDuration regex to support µs and ns.

- Update uptime test fixtures to verify timeout conversion.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>duration.go</strong><dd><code>Add nanosecond and microsecond conversion functions.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/time/duration.go

- Added Nanoseconds() function.
- Added Microseconds() function.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6958/files#diff-6e8ef3118f84cbcc935f27d5a3ad5f4eb86eb22728400e9322c9b796b9d8d855">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>x-tyk-api-gateway.json</strong><dd><code>Extend duration regex to micro and nanoseconds.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/schema/x-tyk-api-gateway.json

<li>Extended regex for X-Tyk-ReadableDuration.<br> <li> Added patterns for microseconds (µs) and nanoseconds (ns).


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6958/files#diff-78828969c0c04cc1a776dfc93a8bad3c499a8c83e6169f83e96d090bed3e7dd0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>x-tyk-api-gateway.strict.json</strong><dd><code>Extend strict schema regex for duration.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/schema/x-tyk-api-gateway.strict.json

<li>Updated strict schema regex pattern.<br> <li> Included µs and ns in duration validation.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6958/files#diff-39a62344d6b741814a58dfd2d219665ecdf962bbec8e755dbc61e1684bb4892a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>upstream_uptimeTests.yml</strong><dd><code>Add uptime tests for micro/nanosecond timeouts.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/testdata/fixtures/upstream_uptimeTests.yml

<li>Added new test cases for uptime tests.<br> <li> Validated timeout conversion for µs and ns values.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6958/files#diff-9a802e07cd2339df0a9e2bdf6bb2abf225f6258f9962bb2da139f9fcbc0e3e25">+58/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>