### PR TITLE
Merging to release-5.8.0: [TT-14276] Gateway panics if Uptime Tests are disabled in config but enabled in API definition  (#6960)

### DIFF
--- a/.taskfiles/lint.yml
+++ b/.taskfiles/lint.yml
@@ -12,7 +12,7 @@ tasks:
       - task: fmt
       - task: vet
       - task: check
-      - golangci-lint run --new-from-rev=origin/master --issues-exit-code=1 --fix ./...
+      - golangci-lint run --new-from-rev=origin/{{ .BRANCH_NAME }} --issues-exit-code=1 --fix ./...
 
   fmt:
     desc: "Run typical code cleanup steps"

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -167,10 +167,13 @@ func (gw *Gateway) nextTarget(targetData *apidef.HostList, spec *APISpec) (strin
 			if !spec.Proxy.CheckHostAgainstUptimeTests {
 				return host, nil // we don't care if it's up
 			}
-			// As checked by HostCheckerManager.AmIPolling
-			if gw.GlobalHostChecker.store == nil {
-				return host, nil
+
+			// GlobalHostCheck has not been initialized, return the host picked
+			// by round-robin algorithm.
+			if gw.GlobalHostChecker == nil {
+				return host, nil // we don't care if it's up
 			}
+			// As checked by HostCheckerManager.AmIPolling
 			if !gw.GlobalHostChecker.HostDown(host) {
 				return host, nil // we do care and it's up
 			}


### PR DESCRIPTION
### **User description**
[TT-14276] Gateway panics if Uptime Tests are disabled in config but enabled in API definition  (#6960)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-14276"
title="TT-14276" target="_blank">TT-14276</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
<td>Gateway panics if Uptime Tests are disabled in config but enabled in
API definition </td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%205.8.0Regression%20ORDER%20BY%20created%20DESC"
title="5.8.0Regression">5.8.0Regression</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

PR for [TT-14276](https://tyktech.atlassian.net/browse/TT-14276)

`Gateway.nextTarget` method was designed to use `GlobalHostChecker` to
control the selected host when `spec.Proxy.EnableLoadBalancing` and
`spec.Proxy.CheckHostAgainstUptimeTests` are set to `true`. This leads
to panic if the upstream tests are disabled globally in `tyk.conf`.

It was actually checking `GlobalHostChecker` with the following
condition:

```go
if gw.GlobalHostChecker.store == nil {
    return host, nil
}
```

But this block leads to panic because `gw.GlobalHostChecker` is nil.
This PR corrects the condition and adds an integration test to check
this specific combination of configuration parameters.

[TT-14276]:
https://tyktech.atlassian.net/browse/TT-14276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
- Bug fix



___

### **Description**
- Prevent gateway panic when uptime tests are disabled in config

- Add test verifying API returns 200 OK without GlobalHostChecker

- Update condition to safely handle nil GlobalHostChecker


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>host_checker_test.go</strong><dd><code>Add test for
disabled uptime tests scenario</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

gateway/host_checker_test.go

<li>Added new test case for uptime tests disabled in gateway config<br>
<li> Validates API responds with 200 OK without panicking


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6960/files#diff-cfc8f5368c14d8fa56d845b1250f465b78c8aa6bfc5b47d0a556d706fa6b8622">+34/-0</a>&nbsp;
&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>reverse_proxy.go</strong><dd><code>Refactor
GlobalHostChecker nil check in nextTarget</code>&nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/reverse_proxy.go

<li>Updated condition check for GlobalHostChecker<br> <li> Return host
early if GlobalHostChecker is nil to avoid panic


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6960/files#diff-e6e07722257f7e41691e471185ad6d84fd56dc9e5459526ea32e9a5e8fa1a01b">+6/-3</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary> Need help?</summary><li>Type <code>/help how to
...</code> in the comments thread for any questions about PR-Agent
usage.</li><li>Check out the <a
href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a>
for more information.</li></details>

[TT-14276]: https://tyktech.atlassian.net/browse/TT-14276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TT-14276]: https://tyktech.atlassian.net/browse/TT-14276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix


___

### **Description**
- Correct nil-check for GlobalHostChecker.

- Prevent gateway panic with disabled uptime tests.

- Add integration test to verify API response.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>host_checker_test.go</strong><dd><code>Add integration test for disabled uptime tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/host_checker_test.go

<li>Added integration test for disabled uptime tests.<br> <li> Verifies 200 OK response without panicking.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6962/files#diff-cfc8f5368c14d8fa56d845b1250f465b78c8aa6bfc5b47d0a556d706fa6b8622">+34/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reverse_proxy.go</strong><dd><code>Fix nil-check in nextTarget method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/reverse_proxy.go

<li>Updated nil-check for GlobalHostChecker.<br> <li> Prevents panic when uptime tests are disabled.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6962/files#diff-e6e07722257f7e41691e471185ad6d84fd56dc9e5459526ea32e9a5e8fa1a01b">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>