### PR TITLE
[TT-7815] ensure path params are migrated to OAS

### DIFF
--- a/apidef/oas/operation.go
+++ b/apidef/oas/operation.go
@@ -11,7 +11,6 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 
 	"github.com/TykTechnologies/tyk/apidef"
-	"github.com/TykTechnologies/tyk/internal/httputil"
 	"github.com/TykTechnologies/tyk/internal/oasutil"
 	"github.com/TykTechnologies/tyk/regexp"
 )
@@ -1053,7 +1052,7 @@ func hasMockResponse(methodActions map[string]apidef.EndpointMethodMeta) bool {
 
 // parsePathSegment parses a single path segment and determines if it contains a regex pattern.
 func parsePathSegment(segment string, regexCount int, hasRegex bool) (pathPart, int, bool) {
-	if httputil.IsMuxTemplate(segment) {
+	if strings.HasPrefix(segment, "{") && strings.HasSuffix(segment, "}") {
 		return parseMuxTemplate(segment, regexCount)
 	} else if isIdentifier(segment) {
 		return pathPart{name: segment, value: segment, isRegex: false}, regexCount, hasRegex

--- a/apidef/oas/operation.go
+++ b/apidef/oas/operation.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -14,6 +13,7 @@ import (
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/internal/httputil"
 	"github.com/TykTechnologies/tyk/internal/oasutil"
+	"github.com/TykTechnologies/tyk/regexp"
 )
 
 // Operations holds Operation definitions.
@@ -1065,8 +1065,7 @@ func parsePathSegment(segment string, regexCount int, hasRegex bool) (pathPart, 
 
 // parseMuxTemplate parses a segment that is a mux template and extracts the name or assigns a custom regex name.
 func parseMuxTemplate(segment string, regexCount int) (pathPart, int, bool) {
-	segment = strings.TrimPrefix(segment, "{")
-	segment = strings.TrimSuffix(segment, "}")
+	segment = strings.Trim(segment, "{}")
 
 	name, _, ok := strings.Cut(segment, ":")
 	if ok || isIdentifier(segment) {

--- a/apidef/oas/operation_test.go
+++ b/apidef/oas/operation_test.go
@@ -1280,6 +1280,23 @@ func TestSplitPath(t *testing.T) {
 			wantParts: []pathPart{},
 			wantRegex: false,
 		},
+		"path with multiple regexes": {
+			input: "/users/{userId:[0-9]+}/posts/{postId:[a-z]+}/[a-z]+/{[0-9]{2}}/[a-z]{10}/abc/{id}/def/[0-9]+",
+			wantParts: []pathPart{
+				{name: "users", value: "users", isRegex: false},
+				{name: "userId", isRegex: true},
+				{name: "posts", value: "posts", isRegex: false},
+				{name: "postId", isRegex: true},
+				{name: "customRegex1", value: "[a-z]+", isRegex: true},
+				{name: "customRegex2", isRegex: true},
+				{name: "customRegex3", value: "[a-z]{10}", isRegex: true},
+				{name: "abc", value: "abc", isRegex: false},
+				{name: "id", isRegex: true},
+				{name: "def", value: "def", isRegex: false},
+				{name: "customRegex4", value: "[0-9]+", isRegex: true},
+			},
+			wantRegex: true,
+		},
 	}
 
 	for name, tc := range tests {

--- a/apidef/oas/testdata/fixtures/path_params.yml
+++ b/apidef/oas/testdata/fixtures/path_params.yml
@@ -29,6 +29,7 @@ tests:
               required: true
               schema:
                 type: string
+                pattern: <nil>
   - desc: "Path params - classic"
     source: "classic"
     input:
@@ -56,7 +57,8 @@ tests:
               in: path
               required: true
               schema:
-                type: string                  
+                type: string
+                pattern: "<nil>"
   - desc: "Path params - classic"
     source: "classic"
     input:
@@ -137,8 +139,10 @@ tests:
               required: true
               schema:
                 type: string
+                pattern: <nil>
             - name: id
               in: path
               required: true
               schema:
                 type: string
+                pattern: <nil>

--- a/apidef/oas/testdata/fixtures/path_params.yml
+++ b/apidef/oas/testdata/fixtures/path_params.yml
@@ -1,0 +1,144 @@
+---
+name: "Path Params"
+tests:
+  - desc: "Path params - classic"
+    source: "classic"
+    input:
+      version_data:
+        versions:
+          "":
+            extended_paths:
+              white_list:
+                - path: "/test/{id}"
+                  method: ""
+                  ignore_case: false
+                  disabled: false
+                  method_actions:
+                    GET:
+                      action: "reply"
+                      code: 200
+                      headers:
+                        Content-Type: "application/json"
+                      data: '{"message": "success"}'
+    output:
+      paths:
+        /test/{id}:
+          parameters:
+            - name: id
+              in: path
+              required: true
+              schema:
+                type: string
+  - desc: "Path params - classic"
+    source: "classic"
+    input:
+      version_data:
+        versions:
+          "":
+            extended_paths:
+              white_list:
+                - path: "/test/{testId:[0-9]+}"
+                  method: ""
+                  ignore_case: false
+                  disabled: false
+                  method_actions:
+                    GET:
+                      action: "reply"
+                      code: 200
+                      headers:
+                        Content-Type: "application/json"
+                      data: '{"message": "success"}'
+    output:
+      paths:
+        /test/{testId}:
+          parameters:
+            - name: testId
+              in: path
+              required: true
+              schema:
+                type: string                  
+  - desc: "Path params - classic"
+    source: "classic"
+    input:
+      version_data:
+        versions:
+          "":
+            extended_paths:
+              white_list:
+                - path: "/test/[0-9]+"
+                  method: ""
+                  ignore_case: false
+                  disabled: false
+                  method_actions:
+                    GET:
+                      action: "reply"
+                      code: 200
+                      headers:
+                        Content-Type: "application/json"
+                      data: '{"message": "success"}'
+    output:
+      paths:
+        /test/{customRegex1}:
+          parameters:
+            - name: customRegex1
+              in: path
+              required: true
+              schema:
+                type: string
+                pattern: "[0-9]+"
+  - desc: "Path params - classic"
+    source: "classic"
+    input:
+      version_data:
+        versions:
+          "":
+            extended_paths:
+              white_list:
+                - path: "/test/testId"
+                  method: ""
+                  ignore_case: false
+                  disabled: false
+                  method_actions:
+                    GET:
+                      action: "reply"
+                      code: 200
+                      headers:
+                        Content-Type: "application/json"
+                      data: '{"message": "success"}'
+    output:
+      paths:
+        /test/testId:
+          parameters: <nil>
+  - desc: "Path params - classic"
+    source: "classic"
+    input:
+      version_data:
+        versions:
+          "":
+            extended_paths:
+              white_list:
+                - path: "/test/{[0-9]+}/{id}"
+                  method: ""
+                  ignore_case: false
+                  disabled: false
+                  method_actions:
+                    GET:
+                      action: "reply"
+                      code: 200
+                      headers:
+                        Content-Type: "application/json"
+                      data: '{"message": "success"}'
+    output:
+      paths:
+        /test/{customRegex1}/{id}:
+          parameters:
+            - name: customRegex1
+              in: path
+              required: true
+              schema:
+                type: string
+            - name: id
+              in: path
+              required: true
+              schema:
+                type: string

--- a/apidef/oas/testdata/fixtures/path_params.yml
+++ b/apidef/oas/testdata/fixtures/path_params.yml
@@ -1,8 +1,7 @@
 ---
 name: "Path Params"
 tests:
-  - desc: "Path params - classic"
-    source: "classic"
+  - source: "classic"
     input:
       version_data:
         versions:
@@ -30,8 +29,7 @@ tests:
               schema:
                 type: string
                 pattern: <nil>
-  - desc: "Path params - classic"
-    source: "classic"
+  - source: "classic"
     input:
       version_data:
         versions:
@@ -59,8 +57,7 @@ tests:
               schema:
                 type: string
                 pattern: "<nil>"
-  - desc: "Path params - classic"
-    source: "classic"
+  - source: "classic"
     input:
       version_data:
         versions:
@@ -88,8 +85,7 @@ tests:
               schema:
                 type: string
                 pattern: "[0-9]+"
-  - desc: "Path params - classic"
-    source: "classic"
+  - source: "classic"
     input:
       version_data:
         versions:
@@ -111,8 +107,7 @@ tests:
       paths:
         /test/testId:
           parameters: <nil>
-  - desc: "Path params - classic"
-    source: "classic"
+  - source: "classic"
     input:
       version_data:
         versions:
@@ -146,3 +141,37 @@ tests:
               schema:
                 type: string
                 pattern: <nil>
+  - source: "classic"
+    input:
+      version_data:
+        versions:
+          "":
+            extended_paths:
+              white_list:
+                - path: "/abc/{id}/def/[0-9]+"
+                  method: ""
+                  ignore_case: false
+                  disabled: false
+                  method_actions:
+                    GET:
+                      action: "reply"
+                      code: 200
+                      headers:
+                        Content-Type: "application/json"
+                      data: '{"message": "success"}'
+    output:
+      paths:
+        /abc/{id}/def/{customRegex1}:
+          parameters:
+            - name: id
+              in: path
+              required: true
+              schema:
+                type: string
+                pattern: <nil>
+            - name: customRegex1
+              in: path
+              required: true
+              schema:
+                type: string
+                pattern: "[0-9]+"


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-7815" title="TT-7815" target="_blank">TT-7815</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Cannot migrate API with endpoints containing path parameter </td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20DoD_Fail%20ORDER%20BY%20created%20DESC" title="DoD_Fail">DoD_Fail</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20QA_Fail%20ORDER%20BY%20created%20DESC" title="QA_Fail">QA_Fail</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20Re_open%20ORDER%20BY%20created%20DESC" title="Re_open">Re_open</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->
This PR makes sure that path params are successfully migrated from Classic to OAS

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->
https://tyktech.atlassian.net/browse/TT-7815

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
- Bug fix
- Enhancement
- Tests



___

### **Description**
- Refactored path splitting logic for OAS conversion.

- Introduced helper functions for regex and mux template parsing.

- Added unit tests covering various path parameter scenarios.

- Provided test fixtures for classic to OAS migration.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operation.go</strong><dd><code>Enhance path parameter migration in OAS operations.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/operation.go

<li>Added import for regexp and httputil.<br> <li> Refactored splitPath with empty path check.<br> <li> Introduced parsePathSegment, parseMuxTemplate, and isIdentifier.<br> <li> Improved regex detection and parameter naming.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6966/files#diff-6d92d2d5b09a5fa7129609bb7cd0d383d015250ec07062b6a93a83257be51fb5">+49/-18</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operation_test.go</strong><dd><code>Add unit tests for splitPath functionality.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/operation_test.go

<li>Added TestSplitPath covering diverse scenarios.<br> <li> Verified correct parsing for simple, regex, and mux templates.<br> <li> Ensured empty and root paths are handled.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6966/files#diff-cd234db716d6d2edc97c135ef546021c9ab4fa9282d63964bd155d41635cf964">+72/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>path_params.yml</strong><dd><code>Add path params test fixture for OAS migration.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/testdata/fixtures/path_params.yml

<li>Created YAML fixtures for classic path parameter migration.<br> <li> Defined multiple test cases with varied input patterns.<br> <li> Mapped expected outputs for both simple and regex parameters.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6966/files#diff-0368200f5970a6c4e9bbfa2bb67a2af7568412926cf37d42a65579ef9bea4570">+144/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>