### PR TITLE
Merging to release-5.8: [TT-7815] ensure path params are migrated to OAS (#6966)

### DIFF
--- a/apidef/oas/operation_test.go
+++ b/apidef/oas/operation_test.go
@@ -1219,3 +1219,92 @@ func TestOAS_fillAllowance(t *testing.T) {
 		assert.False(t, operation.Allow.Enabled)
 	})
 }
+
+func TestSplitPath(t *testing.T) {
+	tests := map[string]struct {
+		input     string
+		wantParts []pathPart
+		wantRegex bool
+	}{
+		"simple path": {
+			input: "/test/path",
+			wantParts: []pathPart{
+				{name: "test", value: "test", isRegex: false},
+				{name: "path", value: "path", isRegex: false},
+			},
+			wantRegex: false,
+		},
+		"path with regex": {
+			input: "/test/.*/end",
+			wantParts: []pathPart{
+				{name: "test", value: "test", isRegex: false},
+				{name: "customRegex1", value: ".*", isRegex: true},
+				{name: "end", value: "end", isRegex: false},
+			},
+			wantRegex: true,
+		},
+		"path with curly braces": {
+			input: "/users/{id}/profile",
+			wantParts: []pathPart{
+				{name: "users", value: "users", isRegex: false},
+				{name: "id", isRegex: true},
+				{name: "profile", value: "profile", isRegex: false},
+			},
+			wantRegex: true,
+		},
+		"path with named regex": {
+			input: "/users/{userId:[0-9]+}/posts",
+			wantParts: []pathPart{
+				{name: "users", value: "users", isRegex: false},
+				{name: "userId", isRegex: true},
+				{name: "posts", value: "posts", isRegex: false},
+			},
+			wantRegex: true,
+		},
+		"path with named direct regex": {
+			input: "/users/[0-9]+/posts",
+			wantParts: []pathPart{
+				{name: "users", value: "users", isRegex: false},
+				{name: "customRegex1", value: "[0-9]+", isRegex: true},
+				{name: "posts", value: "posts", isRegex: false},
+			},
+			wantRegex: true,
+		},
+		"empty path": {
+			input:     "",
+			wantParts: []pathPart{},
+			wantRegex: false,
+		},
+		"root path": {
+			input:     "/",
+			wantParts: []pathPart{},
+			wantRegex: false,
+		},
+		"path with multiple regexes": {
+			input: "/users/{userId:[0-9]+}/posts/{postId:[a-z]+}/[a-z]+/{[0-9]{2}}/[a-z]{10}/abc/{id}/def/[0-9]+",
+			wantParts: []pathPart{
+				{name: "users", value: "users", isRegex: false},
+				{name: "userId", isRegex: true},
+				{name: "posts", value: "posts", isRegex: false},
+				{name: "postId", isRegex: true},
+				{name: "customRegex1", value: "[a-z]+", isRegex: true},
+				{name: "customRegex2", isRegex: true},
+				{name: "customRegex3", value: "[a-z]{10}", isRegex: true},
+				{name: "abc", value: "abc", isRegex: false},
+				{name: "id", isRegex: true},
+				{name: "def", value: "def", isRegex: false},
+				{name: "customRegex4", value: "[0-9]+", isRegex: true},
+			},
+			wantRegex: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			gotParts, gotRegex := splitPath(tc.input)
+
+			assert.Equal(t, tc.wantRegex, gotRegex, "regex detection mismatch")
+			assert.Equal(t, tc.wantParts, gotParts, "parts mismatch")
+		})
+	}
+}

--- a/apidef/oas/testdata/fixtures/path_params.yml
+++ b/apidef/oas/testdata/fixtures/path_params.yml
@@ -1,0 +1,177 @@
+---
+name: "Path Params"
+tests:
+  - source: "classic"
+    input:
+      version_data:
+        versions:
+          "":
+            extended_paths:
+              white_list:
+                - path: "/test/{id}"
+                  method: ""
+                  ignore_case: false
+                  disabled: false
+                  method_actions:
+                    GET:
+                      action: "reply"
+                      code: 200
+                      headers:
+                        Content-Type: "application/json"
+                      data: '{"message": "success"}'
+    output:
+      paths:
+        /test/{id}:
+          parameters:
+            - name: id
+              in: path
+              required: true
+              schema:
+                type: string
+                pattern: <nil>
+  - source: "classic"
+    input:
+      version_data:
+        versions:
+          "":
+            extended_paths:
+              white_list:
+                - path: "/test/{testId:[0-9]+}"
+                  method: ""
+                  ignore_case: false
+                  disabled: false
+                  method_actions:
+                    GET:
+                      action: "reply"
+                      code: 200
+                      headers:
+                        Content-Type: "application/json"
+                      data: '{"message": "success"}'
+    output:
+      paths:
+        /test/{testId}:
+          parameters:
+            - name: testId
+              in: path
+              required: true
+              schema:
+                type: string
+                pattern: "<nil>"
+  - source: "classic"
+    input:
+      version_data:
+        versions:
+          "":
+            extended_paths:
+              white_list:
+                - path: "/test/[0-9]+"
+                  method: ""
+                  ignore_case: false
+                  disabled: false
+                  method_actions:
+                    GET:
+                      action: "reply"
+                      code: 200
+                      headers:
+                        Content-Type: "application/json"
+                      data: '{"message": "success"}'
+    output:
+      paths:
+        /test/{customRegex1}:
+          parameters:
+            - name: customRegex1
+              in: path
+              required: true
+              schema:
+                type: string
+                pattern: "[0-9]+"
+  - source: "classic"
+    input:
+      version_data:
+        versions:
+          "":
+            extended_paths:
+              white_list:
+                - path: "/test/testId"
+                  method: ""
+                  ignore_case: false
+                  disabled: false
+                  method_actions:
+                    GET:
+                      action: "reply"
+                      code: 200
+                      headers:
+                        Content-Type: "application/json"
+                      data: '{"message": "success"}'
+    output:
+      paths:
+        /test/testId:
+          parameters: <nil>
+  - source: "classic"
+    input:
+      version_data:
+        versions:
+          "":
+            extended_paths:
+              white_list:
+                - path: "/test/{[0-9]+}/{id}"
+                  method: ""
+                  ignore_case: false
+                  disabled: false
+                  method_actions:
+                    GET:
+                      action: "reply"
+                      code: 200
+                      headers:
+                        Content-Type: "application/json"
+                      data: '{"message": "success"}'
+    output:
+      paths:
+        /test/{customRegex1}/{id}:
+          parameters:
+            - name: customRegex1
+              in: path
+              required: true
+              schema:
+                type: string
+                pattern: <nil>
+            - name: id
+              in: path
+              required: true
+              schema:
+                type: string
+                pattern: <nil>
+  - source: "classic"
+    input:
+      version_data:
+        versions:
+          "":
+            extended_paths:
+              white_list:
+                - path: "/abc/{id}/def/[0-9]+"
+                  method: ""
+                  ignore_case: false
+                  disabled: false
+                  method_actions:
+                    GET:
+                      action: "reply"
+                      code: 200
+                      headers:
+                        Content-Type: "application/json"
+                      data: '{"message": "success"}'
+    output:
+      paths:
+        /abc/{id}/def/{customRegex1}:
+          parameters:
+            - name: id
+              in: path
+              required: true
+              schema:
+                type: string
+                pattern: <nil>
+            - name: customRegex1
+              in: path
+              required: true
+              schema:
+                type: string
+                pattern: "[0-9]+"


### PR DESCRIPTION
### **User description**
[TT-7815] ensure path params are migrated to OAS (#6966)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-7815"
title="TT-7815" target="_blank">TT-7815</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
<td>Cannot migrate API with endpoints containing path parameter </td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20DoD_Fail%20ORDER%20BY%20created%20DESC"
title="DoD_Fail">DoD_Fail</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20QA_Fail%20ORDER%20BY%20created%20DESC"
title="QA_Fail">QA_Fail</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20Re_open%20ORDER%20BY%20created%20DESC"
title="Re_open">Re_open</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->
This PR makes sure that path params are successfully migrated from
Classic to OAS

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->
https://tyktech.atlassian.net/browse/TT-7815

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
- Bug fix
- Enhancement
- Tests



___

### **Description**
- Refactored path splitting logic for OAS conversion.

- Introduced helper functions for regex and mux template parsing.

- Added unit tests covering various path parameter scenarios.

- Provided test fixtures for classic to OAS migration.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>operation.go</strong><dd><code>Enhance path parameter
migration in OAS operations.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; </dd></summary>
<hr>

apidef/oas/operation.go

<li>Added import for regexp and httputil.<br> <li> Refactored splitPath
with empty path check.<br> <li> Introduced parsePathSegment,
parseMuxTemplate, and isIdentifier.<br> <li> Improved regex detection
and parameter naming.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6966/files#diff-6d92d2d5b09a5fa7129609bb7cd0d383d015250ec07062b6a93a83257be51fb5">+49/-18</a>&nbsp;
</td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>operation_test.go</strong><dd><code>Add unit tests for
splitPath functionality.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/operation_test.go

<li>Added TestSplitPath covering diverse scenarios.<br> <li> Verified
correct parsing for simple, regex, and mux templates.<br> <li> Ensured
empty and root paths are handled.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6966/files#diff-cd234db716d6d2edc97c135ef546021c9ab4fa9282d63964bd155d41635cf964">+72/-0</a>&nbsp;
&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>path_params.yml</strong><dd><code>Add path params test
fixture for OAS migration.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/testdata/fixtures/path_params.yml

<li>Created YAML fixtures for classic path parameter migration.<br> <li>
Defined multiple test cases with varied input patterns.<br> <li> Mapped
expected outputs for both simple and regex parameters.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6966/files#diff-0368200f5970a6c4e9bbfa2bb67a2af7568412926cf37d42a65579ef9bea4570">+144/-0</a>&nbsp;
</td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary> Need help?</summary><li>Type <code>/help how to
...</code> in the comments thread for any questions about PR-Agent
usage.</li><li>Check out the <a
href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a>
for more information.</li></details>

[TT-7815]: https://tyktech.atlassian.net/browse/TT-7815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
- Bug fix
- Enhancement
- Tests



___

### **Description**
- Refactored OAS path migration logic with empty check.

- Added helper functions for parsing path segments and mux templates.

- Improved regex detection and parameter naming.

- Introduced comprehensive unit tests and YAML fixtures.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operation.go</strong><dd><code>Refactor path splitting and regex handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/operation.go

<li>Added empty path check in splitPath.<br> <li> Introduced parsePathSegment, parseMuxTemplate, isIdentifier.<br> <li> Improved regex detection and parameter naming.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6971/files#diff-6d92d2d5b09a5fa7129609bb7cd0d383d015250ec07062b6a93a83257be51fb5">+47/-18</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operation_test.go</strong><dd><code>Add comprehensive TestSplitPath tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/operation_test.go

<li>Added TestSplitPath covering diverse path scenarios.<br> <li> Validated simple, regex, and mux templates.<br> <li> Handled empty and root paths correctly.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6971/files#diff-cd234db716d6d2edc97c135ef546021c9ab4fa9282d63964bd155d41635cf964">+89/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>path_params.yml</strong><dd><code>Add path parameters migration fixture tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/testdata/fixtures/path_params.yml

<li>Created YAML fixture for classic to OAS migration.<br> <li> Included varied test cases for path parameters.<br> <li> Defined expected outputs for both simple and regex.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6971/files#diff-0368200f5970a6c4e9bbfa2bb67a2af7568412926cf37d42a65579ef9bea4570">+177/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>