### PR TITLE
[TT-14413] Check for existing params before generating new ones

### DIFF
--- a/apidef/oas/operation.go
+++ b/apidef/oas/operation.go
@@ -650,9 +650,23 @@ func (s *OAS) getOperationID(inPath, method string) string {
 		newPath := buildPath(parts, strings.HasSuffix(inPath, "/"))
 
 		p = createOrGetPathItem(newPath)
-		p.Parameters = []*openapi3.ParameterRef{}
+
+		// We should check if the parameters are already set before initializing it.
+		if p.Parameters == nil {
+			p.Parameters = []*openapi3.ParameterRef{}
+		}
+
+		existingParams := make(map[string]bool)
+		for _, existingParam := range p.Parameters {
+			existingParams[existingParam.Value.Name] = true
+		}
 
 		for _, part := range parts {
+			// Skip adding the parameter if it already exists so that we don't override it.
+			if existingParams[part.name] {
+				continue
+			}
+
 			if part.isRegex {
 				schema := &openapi3.SchemaRef{
 					Value: &openapi3.Schema{


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-14413" title="TT-14413" target="_blank">TT-14413</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>API test test_oas_validate_request_parameters_on_path_level  is now failing across all repos</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%205.8.0Regression%20ORDER%20BY%20created%20DESC" title="5.8.0Regression">5.8.0Regression</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->
This PR make sure generateOperationID checks for existing params before generating new ones

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->
https://tyktech.atlassian.net/browse/TT-14413

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
- Bug fix
- Tests



___

### **Description**
- Prevent overwriting existing parameters.

- Add nil check before parameter initialization.

- Skip duplicate parameter additions.

- Include tests for operation ID and parameter retention.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operation.go</strong><dd><code>Check and preserve existing parameters.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/operation.go

<li>Added nil check for parameter initialization.<br> <li> Created map for existing parameters.<br> <li> Skips adding duplicate parameters.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6973/files#diff-6d92d2d5b09a5fa7129609bb7cd0d383d015250ec07062b6a93a83257be51fb5">+15/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operation_test.go</strong><dd><code>Add tests to validate operationID behavior.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/operation_test.go

<li>Introduced TestGetOperationID function.<br> <li> Validated operation ID generation.<br> <li> Verified parameter preservation.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6973/files#diff-cd234db716d6d2edc97c135ef546021c9ab4fa9282d63964bd155d41635cf964">+136/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>