### PR TITLE
[TT-12343] Use API endpoint hard timeouts over global timeout setting

### DIFF
--- a/apidef/oas/operation.go
+++ b/apidef/oas/operation.go
@@ -650,9 +650,23 @@ func (s *OAS) getOperationID(inPath, method string) string {
 		newPath := buildPath(parts, strings.HasSuffix(inPath, "/"))
 
 		p = createOrGetPathItem(newPath)
-		p.Parameters = []*openapi3.ParameterRef{}
+
+		// We should check if the parameters are already set before initializing it.
+		if p.Parameters == nil {
+			p.Parameters = []*openapi3.ParameterRef{}
+		}
+
+		existingParams := make(map[string]bool)
+		for _, existingParam := range p.Parameters {
+			existingParams[existingParam.Value.Name] = true
+		}
 
 		for _, part := range parts {
+			// Skip adding the parameter if it already exists so that we don't override it.
+			if existingParams[part.name] {
+				continue
+			}
+
 			if part.isRegex {
 				schema := &openapi3.SchemaRef{
 					Value: &openapi3.Schema{


### PR DESCRIPTION
### **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description
If an enforced timeout is configured for an API endpoint, now we will use it instead of the global default timeout, as it should take precedence.
<!-- Describe your changes in detail -->

## Related Issue
https://tyktech.atlassian.net/browse/TT-12343
<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context
https://tyktech.atlassian.net/browse/TT-11285
<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested
Unit tests
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [x] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Use API endpoint enforced timeout when configured

- Update reverse proxy to prioritize enforced timeout

- Add comprehensive tests for timeout scenarios

- Validate behavior against global and explicit timeout settings


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reverse_proxy.go</strong><dd><code>Use enforced API endpoint timeout in reverse proxy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/reverse_proxy.go

<li>Add check for enforced timeout using <code>isTimeoutEnforced</code><br> <li> Update HTTP transport with the correct timeout value


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6976/files#diff-e6e07722257f7e41691e471185ad6d84fd56dc9e5459526ea32e9a5e8fa1a01b">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reverse_proxy_test.go</strong><dd><code>Add comprehensive timeout prioritization tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/reverse_proxy_test.go

<li>Introduce <code>TestTimeoutPrioritization</code> with multiple timeout cases<br> <li> Test endpoints with differing enforced and default timeout values<br> <li> Verify gateway responses under various delay scenarios


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6976/files#diff-ce040f6555143f760fba6059744bc600b6954f0966dfb0fa2832b5eabf7a3c3f">+274/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>