### PR TITLE
Merging to release-5.8: [TT-14357]: fixed issue with stale context in UDG (#6977)

### DIFF
--- a/gateway/mw_graphql.go
+++ b/gateway/mw_graphql.go
@@ -83,17 +83,15 @@ func (m *GraphQLMiddleware) Init() {
 			},
 		})
 	} else if m.Spec.GraphQL.Version == apidef.GraphQLConfigVersion2 {
+		httpClient := &http.Client{
+			Transport: &http.Transport{TLSClientConfig: tlsClientConfig(m.Spec, nil)},
+		}
 		m.Spec.GraphEngine, err = graphengine.NewEngineV2(graphengine.EngineV2Options{
-			Logger:        log,
-			Schema:        schema,
-			ApiDefinition: m.Spec.APIDefinition,
-			HttpClient: &http.Client{
-				Transport: &http.Transport{TLSClientConfig: tlsClientConfig(m.Spec, nil)},
-			},
-			StreamingClient: &http.Client{
-				Timeout:   0,
-				Transport: &http.Transport{TLSClientConfig: tlsClientConfig(m.Spec, nil)},
-			},
+			Logger:          log,
+			Schema:          schema,
+			ApiDefinition:   m.Spec.APIDefinition,
+			HttpClient:      httpClient,
+			StreamingClient: httpClient,
 			OpenTelemetry: graphengine.EngineV2OTelConfig{
 				Enabled:        m.Gw.GetConfig().OpenTelemetry.Enabled,
 				TracerProvider: m.Gw.TracerProvider,

--- a/gateway/mw_request_size_limit_test.go
+++ b/gateway/mw_request_size_limit_test.go
@@ -61,7 +61,7 @@ func TestRequestSizeLimit(t *testing.T) {
 
 	t.Run("should not break the request, if the method is skipped", func(t *testing.T) {
 		// GET, DELETE, TRACE, OPTIONS and HEAD
-		for method, _ := range skippedMethods {
+		for method := range skippedMethods {
 			_, _ = ts.Run(t, []test.TestCase{
 				{Method: method, Path: "/sample/", Code: http.StatusOK},
 			}...)

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -14,10 +14,10 @@ func TestCache(t *testing.T) {
 func TestCache_Expired(t *testing.T) {
 	cache := &Cache{
 		items: map[string]Item{
-			"one": Item{
+			"one": {
 				Expiration: 1,
 			},
-			"two": Item{
+			"two": {
 				Expiration: 0,
 			},
 		},
@@ -30,7 +30,7 @@ func TestCache_Expired(t *testing.T) {
 
 	t.Run("Test Items", func(t *testing.T) {
 		want := map[string]Item{
-			"two": Item{
+			"two": {
 				Expiration: 0,
 			},
 		}

--- a/internal/graphengine/engine_v2.go
+++ b/internal/graphengine/engine_v2.go
@@ -291,7 +291,7 @@ func (e *EngineV2) handoverRequestToGraphQLExecutionEngine(gqlRequest *graphql.R
 	}
 
 	upstreamHeaders := additionalUpstreamHeaders(e.logger, outreq, e.ApiDefinition)
-	execOptions = append(execOptions, graphql.WithHeaderModifier(e.gqlTools.headerModifier(outreq, upstreamHeaders, e.tykVariableReplacer)))
+	execOptions = append(execOptions, graphql.WithHeaderModifier(e.gqlTools.headerModifier(upstreamHeaders)))
 
 	if e.OpenTelemetry.Executor != nil {
 		if err = e.OpenTelemetry.Executor.Execute(reqCtx, gqlRequest, &resultWriter, execOptions...); err != nil {
@@ -383,7 +383,7 @@ func (e *EngineV2) handoverWebSocketConnectionToGraphQLExecutionEngine(params *R
 	executorPool = subscription.NewExecutorV2Pool(
 		e.ExecutionEngine,
 		initialRequestContext,
-		subscription.WithExecutorV2HeaderModifier(e.gqlTools.headerModifier(params.OutRequest, upstreamHeaders, e.tykVariableReplacer)),
+		subscription.WithExecutorV2HeaderModifier(e.gqlTools.headerModifier(upstreamHeaders)),
 	)
 
 	go gqlwebsocket.Handle(

--- a/internal/graphengine/graphql_go_tools_v1.go
+++ b/internal/graphengine/graphql_go_tools_v1.go
@@ -72,17 +72,12 @@ func (g graphqlGoToolsV1) handleIntrospection(schema *graphql.Schema) (res *http
 	return
 }
 
-func (g graphqlGoToolsV1) headerModifier(outreq *http.Request, additionalHeaders http.Header, variableReplacer TykVariableReplacer) postprocess.HeaderModifier {
+func (g graphqlGoToolsV1) headerModifier(additionalHeaders http.Header) postprocess.HeaderModifier {
 	return func(header http.Header) {
 		for key := range additionalHeaders {
 			if header.Get(key) == "" {
 				header.Set(key, additionalHeaders.Get(key))
 			}
-		}
-
-		for key := range header {
-			val := variableReplacer(outreq, header.Get(key), false)
-			header.Set(key, val)
 		}
 	}
 }


### PR DESCRIPTION
### **User description**
[TT-14357]: fixed issue with stale context in UDG (#6977)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-14357"
title="TT-14357" target="_blank">TT-14357</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Stale context in UDG</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%205.8.1Refinement%20ORDER%20BY%20created%20DESC"
title="5.8.1Refinement">5.8.1Refinement</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20Commercial_candidate_rel3-2025%20ORDER%20BY%20created%20DESC"
title="Commercial_candidate_rel3-2025">Commercial_candidate_rel3-2025</a>,
<a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20customer_bug%20ORDER%20BY%20created%20DESC"
title="customer_bug">customer_bug</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description
In udg the headers are cached along with the plan for that request, so
subsequent request with different headers use old headers to the
upstream, this pr moves the header modification to the transport level
out of the cache.
<!-- Describe your changes in detail -->

## Benchmark results
|Run  | ns/op | byte/op | allocations
|----------|----------|----------|------|
| Before fix iteration 1   | 57626  | 1141010  | 1330 |
| Before fix iteration 2   | 577525  | 1138360  | 1332 |
| After fix iteration 1   | 586109  | 1143668 | 1350 |
| After fix iteration 2   | 582655  | 1143647  | 1347 |

### benchmark comments
This fix resolves a UDG request-handling issue but introduces a slight
overhead. Benchmark measurements show minor increases in ns/op and
allocations. While performance does dip slightly, the change ensures
correct behavior and is considered an acceptable tradeoff for improving
reliability.

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
- Bug fix
- Tests
- Enhancement



___

### **Description**
- Move header modification from cache to transport layer.

- Introduce variableReplaceRoundTripper for header updates.

- Extend tests and add benchmark for GraphQL UDG header behavior.

- Clean up minor code style and loop iteration issues.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>mw_request_size_limit_test.go</strong><dd><code>Refine
loop iteration in request size tests</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

gateway/mw_request_size_limit_test.go

<li>Refactored for-loop iteration over map keys.<br> <li> Improves
clarity in test execution.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6977/files#diff-107317fefc06776e7acf5e35daac311b025a92c6721432272dbd7c7dcdd854f8">+1/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>cache_test.go</strong><dd><code>Simplify Cache test
struct instantiation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; </dd></summary>
<hr>

internal/cache/cache_test.go

<li>Simplified struct initialization for cache tests.<br> <li> Improved
code formatting.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6977/files#diff-7fbdfb41b04a92f43e9826f893f4f7efa7431219a257f97f2c1d8219efb3f1fb">+3/-3</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>reverse_proxy_test.go</strong><dd><code>Add benchmark
and enhanced tests for GraphQL headers</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; </dd></summary>
<hr>

gateway/reverse_proxy_test.go

<li>Added BenchmarkGraphqlUDG test.<br> <li> Extended
TestGraphQL_UDGHeaders with follow-up header checks.<br> <li> Validated
proper header injection in GraphQL endpoints.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6977/files#diff-ce040f6555143f760fba6059744bc600b6954f0966dfb0fa2832b5eabf7a3c3f">+58/-0</a>&nbsp;
&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>engine_v2.go</strong><dd><code>Move header modification
to transport layer in EngineV2</code>&nbsp; &nbsp; </dd></summary>
<hr>

internal/graphengine/engine_v2.go

<li>Introduced variableReplaceRoundTripper type.<br> <li> Wrapped
reverse proxy RoundTripper to update headers.<br> <li> Removed inline
header modification using variable replacer.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6977/files#diff-b1eaa954c9836f395e1d49090e85c739e3878747c8bd748f556fc5a53ff7b191">+22/-2</a>&nbsp;
&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>graphql_go_tools_v1.go</strong><dd><code>Refactor
GraphQL header modifier function</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></summary>
<hr>

internal/graphengine/graphql_go_tools_v1.go

<li>Updated headerModifier to remove variable replacer.<br> <li>
Simplified function signature for header injection.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6977/files#diff-e592cc8ca6ac39e7574765d7f2bbf19193f173791a1b0930d4dde7f9412dc882">+1/-6</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary> Need help?</summary><li>Type <code>/help how to
...</code> in the comments thread for any questions about PR-Agent
usage.</li><li>Check out the <a
href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a>
for more information.</li></details>

[TT-14357]: https://tyktech.atlassian.net/browse/TT-14357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
- Bug fix
- Tests
- Enhancement



___

### **Description**
- Migrate GraphQL header updates to transport layer.

- Introduce variableReplaceRoundTripper for dynamic header injection.

- Unify HTTP client usage in GraphEngine V2 initialization.

- Enhance tests with new benchmarks and clearer iterations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>mw_graphql.go</strong><dd><code>Update GraphQL engine init with unified HTTP client.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6983/files#diff-c46e0f07348c8f519e5912f4394f048f43c1e3fb5063c27245272c8f645b4cab">+8/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>engine_v2.go</strong><dd><code>Simplify header modifier usage in execution engine.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6983/files#diff-b1eaa954c9836f395e1d49090e85c739e3878747c8bd748f556fc5a53ff7b191">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>graphql_go_tools_v1.go</strong><dd><code>Refactor GraphQL header modifier to simplify injection.</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6983/files#diff-e592cc8ca6ac39e7574765d7f2bbf19193f173791a1b0930d4dde7f9412dc882">+1/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>mw_request_size_limit_test.go</strong><dd><code>Refine loop iteration in request size tests.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6983/files#diff-107317fefc06776e7acf5e35daac311b025a92c6721432272dbd7c7dcdd854f8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>reverse_proxy_test.go</strong><dd><code>Add benchmark and extended header tests for GraphQL UDG.</code>&nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6983/files#diff-ce040f6555143f760fba6059744bc600b6954f0966dfb0fa2832b5eabf7a3c3f">+58/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cache_test.go</strong><dd><code>Simplify cache test struct instantiation.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6983/files#diff-7fbdfb41b04a92f43e9826f893f4f7efa7431219a257f97f2c1d8219efb3f1fb">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>reverse_proxy.go</strong><dd><code>Introduce roundtripper for header variable replacement.</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6983/files#diff-e6e07722257f7e41691e471185ad6d84fd56dc9e5459526ea32e9a5e8fa1a01b">+16/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>