### PR TITLE
[SYSE-401] Use go 1.23 for builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,9 @@ jobs:
       fail-fast: false
       matrix:
         golang_cross:
-          - 1.22-bullseye
+          - 1.23-bullseye
         include:
-          - golang_cross: 1.22-bullseye
+          - golang_cross: 1.23-bullseye
             goreleaser: 'ci/goreleaser/goreleaser.yml'
             cgo: 1
             rpmvers: 'el/7 el/8 el/9 amazon/2 amazon/2023'
@@ -127,12 +127,12 @@ jobs:
           mask-aws-account-id: false
       - uses: aws-actions/amazon-ecr-login@v2
         id: ecr
-        if: ${{ matrix.golang_cross == '1.22-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.23-bullseye' }}
         with:
           mask-password: 'true'
       - name: Docker metadata for std CI
         id: ci_metadata_std
-        if: ${{ matrix.golang_cross == '1.22-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.23-bullseye' }}
         uses: docker/metadata-action@v5
         with:
           images: |
@@ -147,7 +147,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},prefix=v
             type=semver,pattern={{version}},prefix=v
       - name: push std image to CI
-        if: ${{ matrix.golang_cross == '1.22-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.23-bullseye' }}
         uses: docker/build-push-action@v6
         with:
           context: "dist"
@@ -182,7 +182,7 @@ jobs:
             org.opencontainers.image.vendor=tyk.io
             org.opencontainers.image.version=${{ github.ref_name }}
       - name: push std image to prod
-        if: ${{ matrix.golang_cross == '1.22-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.23-bullseye' }}
         uses: docker/build-push-action@v6
         with:
           context: "dist"
@@ -199,7 +199,7 @@ jobs:
             BUILD_PACKAGE_NAME=tyk-gateway
       - name: save deb
         uses: actions/upload-artifact@v4
-        if: ${{ matrix.golang_cross == '1.22-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.23-bullseye' }}
         with:
           name: deb
           retention-days: 1
@@ -209,7 +209,7 @@ jobs:
             !dist/*fips*.deb
       - name: save rpm
         uses: actions/upload-artifact@v4
-        if: ${{ matrix.golang_cross == '1.22-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.23-bullseye' }}
         with:
           name: rpm
           retention-days: 1
@@ -293,7 +293,7 @@ jobs:
           TYK_MDCB_LICENSE: ${{ secrets.MDCB_LICENSE }}
         run: |
           match_tag=${{steps.ecr.outputs.registry}}/tyk:$BASE_REF
-          tags=(${{ needs.goreleaser.outputs.ee_tags }})
+          tags=(${{ needs.goreleaser.outputs.std_tags }})
           set -eaxo pipefail
           docker run -q --rm -v ~/.docker/config.json:/root/.docker/config.json tykio/gromit policy match ${tags[0]} ${match_tag} 2>versions.env
           echo '# alfa and beta have to come after the override

--- a/ci/Dockerfile.distroless
+++ b/ci/Dockerfile.distroless
@@ -6,7 +6,8 @@ ARG BUILD_PACKAGE_NAME
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-COPY ${BUILD_PACKAGE_NAME}*${TARGETARCH}.deb /
+# The _ after the pkg name is to match tyk-gateway strictly and not tyk-gateway-fips (for example)
+COPY ${BUILD_PACKAGE_NAME}_*${TARGETARCH}.deb /
 RUN dpkg -i /${BUILD_PACKAGE_NAME}_*${TARGETARCH}.deb && rm /*.deb
 
 FROM gcr.io/distroless/base-debian12:latest

--- a/ci/Dockerfile.std
+++ b/ci/Dockerfile.std
@@ -21,7 +21,7 @@ RUN rm -rf /root/.cache \
     && find /usr/lib -type f -name '*.a' -o -name '*.o' -delete
 
 # Comment this to test in dev
-COPY ${BUILD_PACKAGE_NAME}*${TARGETARCH}.deb /
+COPY ${BUILD_PACKAGE_NAME}_*${TARGETARCH}.deb /
 RUN dpkg -i /${BUILD_PACKAGE_NAME}*${TARGETARCH}.deb && rm /*.deb
 
 ARG PORTS


### PR DESCRIPTION
### **User description**
Error introduced in #6943 because automerge was enabled and there were no required checks on release-5.3.


___

### **PR Type**
- Enhancement
- Tests



___

### **Description**
- Updated release workflow to use Go 1.23.

- Revised conditional checks for docker steps.

- Adjusted Dockerfile COPY patterns for strict package matching.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Update Go version and release step conditions.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<li>Switch build matrix from Go 1.22 to 1.23.<br> <li> Updated conditional checks for ECR login, metadata, and artifact <br>upload.<br> <li> Modified tag reference from EE to standard image.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6989/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile.distroless</strong><dd><code>Adjust COPY command for deb package in distroless image.</code>&nbsp; </dd></summary>
<hr>

ci/Dockerfile.distroless

<li>Changed COPY command to enforce underscore separation.<br> <li> Updated comment for strict package matching.<br> <li> Removed deb file after installation.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6989/files#diff-ab1e64220db8ccca1a52a505decc2beb2156d5ec3ecb7d6b8660cc3dc7e1f5bd">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile.std</strong><dd><code>Standard Dockerfile COPY pattern update.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ci/Dockerfile.std

<li>Updated COPY command to use underscore in package name.<br> <li> Ensured proper dpkg installation and cleanup.<br> <li> Minor adjustment for file matching consistency.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6989/files#diff-a3b3e9cabd877d0bd0fc8f20a9fdca7f44d102547a5fdfcd398ea01637e5dfae">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>