### PR TITLE
[TT-12343] Improve Timeout Test Coverage and Consistency in TestTimeoutPrioritization

### DIFF
--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -2087,6 +2087,8 @@ func BenchmarkLargeResponsePayload(b *testing.B) {
 }
 
 func TestTimeoutPrioritization(t *testing.T) {
+	t.Parallel()
+
 	ts := StartTest(func(c *config.Config) {
 		c.ProxyDefaultTimeout = 2
 	})
@@ -2094,7 +2096,7 @@ func TestTimeoutPrioritization(t *testing.T) {
 
 	t.Run("Basic Timeout Behavior - enforced timeout higher than default", func(t *testing.T) {
 		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			time.Sleep(3 * time.Second)
+			time.Sleep(1 * time.Second)
 			w.Write([]byte("Success"))
 		}))
 		defer upstream.Close()
@@ -2129,7 +2131,7 @@ func TestTimeoutPrioritization(t *testing.T) {
 
 	t.Run("Basic Timeout Behavior - enforced timeout lower than default", func(t *testing.T) {
 		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			time.Sleep(1800 * time.Millisecond)
+			time.Sleep(3 * time.Second)
 			w.Write([]byte("Success"))
 		}))
 		defer upstream.Close()
@@ -2164,7 +2166,7 @@ func TestTimeoutPrioritization(t *testing.T) {
 
 	t.Run("Basic Timeout Behavior - delay higher than both timeouts", func(t *testing.T) {
 		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			time.Sleep(2500 * time.Millisecond)
+			time.Sleep(3 * time.Second)
 			w.Write([]byte("Success"))
 		}))
 		defer upstream.Close()
@@ -2199,7 +2201,7 @@ func TestTimeoutPrioritization(t *testing.T) {
 
 	t.Run("Basic Timeout Behavior - delay within enforced timeout", func(t *testing.T) {
 		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(1 * time.Second)
 			w.Write([]byte("Success"))
 		}))
 		defer upstream.Close()
@@ -2216,7 +2218,7 @@ func TestTimeoutPrioritization(t *testing.T) {
 						Disabled: false,
 						Path:     "/test4",
 						Method:   http.MethodGet,
-						TimeOut:  1,
+						TimeOut:  3,
 					},
 				}
 			})
@@ -2235,11 +2237,11 @@ func TestTimeoutPrioritization(t *testing.T) {
 	t.Run("Multiple Endpoints with Different Enforced Timeouts", func(t *testing.T) {
 		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if strings.HasPrefix(r.URL.Path, "/delay/") {
-				time.Sleep(3200 * time.Millisecond)
-				w.Write([]byte("Delay 3.2s response"))
+				time.Sleep(1000 * time.Millisecond)
+				w.Write([]byte("Delay 1s response"))
 			} else if strings.HasPrefix(r.URL.Path, "/delay2/") {
-				time.Sleep(3200 * time.Millisecond)
-				w.Write([]byte("Delay2 3.2s response"))
+				time.Sleep(2000 * time.Millisecond)
+				w.Write([]byte("Delay2 2s response"))
 			} else {
 				w.WriteHeader(http.StatusNotFound)
 			}
@@ -2256,13 +2258,13 @@ func TestTimeoutPrioritization(t *testing.T) {
 				version.ExtendedPaths.HardTimeouts = []apidef.HardTimeoutMeta{
 					{
 						Disabled: false,
-						Path:     "^/delay/3$",
+						Path:     "^/delay/1$",
 						Method:   http.MethodGet,
 						TimeOut:  4,
 					},
 					{
 						Disabled: false,
-						Path:     "^/delay2/3$",
+						Path:     "^/delay2/2$",
 						Method:   http.MethodGet,
 						TimeOut:  1,
 					},
@@ -2274,14 +2276,14 @@ func TestTimeoutPrioritization(t *testing.T) {
 
 		_, _ = ts.Run(t, test.TestCase{
 			Method:    http.MethodGet,
-			Path:      "/delay/3",
+			Path:      "/delay/1",
 			Code:      http.StatusOK,
-			BodyMatch: "Delay 3.2s response",
+			BodyMatch: "Delay 1s response",
 		})
 
 		_, _ = ts.Run(t, test.TestCase{
 			Method:    http.MethodGet,
-			Path:      "/delay2/3",
+			Path:      "/delay2/2",
 			Code:      http.StatusGatewayTimeout,
 			BodyMatch: "Upstream service reached hard timeout",
 		})
@@ -2289,18 +2291,18 @@ func TestTimeoutPrioritization(t *testing.T) {
 
 	t.Run("Explicit vs Default Global Timeout", func(t *testing.T) {
 		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasPrefix(r.URL.Path, "/delay/2500") {
-				time.Sleep(2500 * time.Millisecond)
-				w.Write([]byte("Delay 2.5s response"))
+			if strings.HasPrefix(r.URL.Path, "/delay/2000") {
+				time.Sleep(2000 * time.Millisecond)
+				w.Write([]byte("Delay 2s response"))
 			} else if strings.HasPrefix(r.URL.Path, "/delay/4000") {
 				time.Sleep(4000 * time.Millisecond)
 				w.Write([]byte("Delay 4s response"))
 			} else if strings.HasPrefix(r.URL.Path, "/delay2/1000") {
 				time.Sleep(1000 * time.Millisecond)
 				w.Write([]byte("Delay2 1s response"))
-			} else if strings.HasPrefix(r.URL.Path, "/delay2/3500") {
-				time.Sleep(3500 * time.Millisecond)
-				w.Write([]byte("Delay2 3.5s response"))
+			} else if strings.HasPrefix(r.URL.Path, "/delay2/4000") {
+				time.Sleep(4000 * time.Millisecond)
+				w.Write([]byte("Delay2 4s response"))
 			} else {
 				w.WriteHeader(http.StatusNotFound)
 			}
@@ -2319,7 +2321,7 @@ func TestTimeoutPrioritization(t *testing.T) {
 						Disabled: false,
 						Path:     "/delay/.*",
 						Method:   http.MethodGet,
-						TimeOut:  3,
+						TimeOut:  4,
 					},
 					// No explicit timeout for /delay2/* endpoints - will use global
 				}
@@ -2331,9 +2333,9 @@ func TestTimeoutPrioritization(t *testing.T) {
 		// Test case 1: Should succeed (delay 45ms < enforced timeout 60ms)
 		_, _ = ts.Run(t, test.TestCase{
 			Method:    http.MethodGet,
-			Path:      "/delay/2500",
+			Path:      "/delay/2000",
 			Code:      http.StatusOK,
-			BodyMatch: "Delay 2.5s response",
+			BodyMatch: "Delay 2s response",
 		})
 
 		_, _ = ts.Run(t, test.TestCase{
@@ -2353,7 +2355,7 @@ func TestTimeoutPrioritization(t *testing.T) {
 		// Test case 4: Should timeout at global value (delay 60ms > global timeout 50ms)
 		_, _ = ts.Run(t, test.TestCase{
 			Method:    http.MethodGet,
-			Path:      "/delay2/3500",
+			Path:      "/delay2/4000",
 			Code:      http.StatusGatewayTimeout,
 			BodyMatch: "Upstream service reached hard timeout",
 		})

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -2298,8 +2298,8 @@ func TestTimeoutPrioritization(t *testing.T) {
 				time.Sleep(4000 * time.Millisecond)
 				w.Write([]byte("Delay 4s response"))
 			} else if strings.HasPrefix(r.URL.Path, "/delay2/1000") {
-				time.Sleep(2000 * time.Millisecond)
-				w.Write([]byte("Delay2 2s response"))
+				time.Sleep(1000 * time.Millisecond)
+				w.Write([]byte("Delay2 1s response"))
 			} else if strings.HasPrefix(r.URL.Path, "/delay2/4000") {
 				time.Sleep(4000 * time.Millisecond)
 				w.Write([]byte("Delay2 4s response"))
@@ -2349,7 +2349,7 @@ func TestTimeoutPrioritization(t *testing.T) {
 			Method:    http.MethodGet,
 			Path:      "/delay2/1000",
 			Code:      http.StatusOK,
-			BodyMatch: "Delay2 2s response",
+			BodyMatch: "Delay2 1s response",
 		})
 
 		// Test case 4: Should timeout at global value (delay 60ms > global timeout 50ms)

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -2291,15 +2291,15 @@ func TestTimeoutPrioritization(t *testing.T) {
 
 	t.Run("Explicit vs Default Global Timeout", func(t *testing.T) {
 		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasPrefix(r.URL.Path, "/delay/2000") {
-				time.Sleep(2000 * time.Millisecond)
-				w.Write([]byte("Delay 2s response"))
+			if strings.HasPrefix(r.URL.Path, "/delay/1000") {
+				time.Sleep(1000 * time.Millisecond)
+				w.Write([]byte("Delay 1s response"))
 			} else if strings.HasPrefix(r.URL.Path, "/delay/4000") {
 				time.Sleep(4000 * time.Millisecond)
 				w.Write([]byte("Delay 4s response"))
 			} else if strings.HasPrefix(r.URL.Path, "/delay2/1000") {
-				time.Sleep(1000 * time.Millisecond)
-				w.Write([]byte("Delay2 1s response"))
+				time.Sleep(2000 * time.Millisecond)
+				w.Write([]byte("Delay2 2s response"))
 			} else if strings.HasPrefix(r.URL.Path, "/delay2/4000") {
 				time.Sleep(4000 * time.Millisecond)
 				w.Write([]byte("Delay2 4s response"))
@@ -2321,7 +2321,7 @@ func TestTimeoutPrioritization(t *testing.T) {
 						Disabled: false,
 						Path:     "/delay/.*",
 						Method:   http.MethodGet,
-						TimeOut:  4,
+						TimeOut:  3,
 					},
 					// No explicit timeout for /delay2/* endpoints - will use global
 				}
@@ -2333,9 +2333,9 @@ func TestTimeoutPrioritization(t *testing.T) {
 		// Test case 1: Should succeed (delay 45ms < enforced timeout 60ms)
 		_, _ = ts.Run(t, test.TestCase{
 			Method:    http.MethodGet,
-			Path:      "/delay/2000",
+			Path:      "/delay/1000",
 			Code:      http.StatusOK,
-			BodyMatch: "Delay 2s response",
+			BodyMatch: "Delay 1s response",
 		})
 
 		_, _ = ts.Run(t, test.TestCase{
@@ -2349,7 +2349,7 @@ func TestTimeoutPrioritization(t *testing.T) {
 			Method:    http.MethodGet,
 			Path:      "/delay2/1000",
 			Code:      http.StatusOK,
-			BodyMatch: "Delay2 1s response",
+			BodyMatch: "Delay2 2s response",
 		})
 
 		// Test case 4: Should timeout at global value (delay 60ms > global timeout 50ms)


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-12343" title="TT-12343" target="_blank">TT-12343</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>proxy_default_timeout overrides enforced timeout middleware but should only be applied when enforced timeout is unset</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%205.8.1Refinement%20ORDER%20BY%20created%20DESC" title="5.8.1Refinement">5.8.1Refinement</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20Commercial_candidate_rel2-2025%20ORDER%20BY%20created%20DESC" title="Commercial_candidate_rel2-2025">Commercial_candidate_rel2-2025</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20QA_Fail%20ORDER%20BY%20created%20DESC" title="QA_Fail">QA_Fail</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20customer_bug%20ORDER%20BY%20created%20DESC" title="customer_bug">customer_bug</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20innersource-candidate%20ORDER%20BY%20created%20DESC" title="innersource-candidate">innersource-candidate</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20jira_escalated%20ORDER%20BY%20created%20DESC" title="jira_escalated">jira_escalated</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20r2-commercial-candidate%20ORDER%20BY%20created%20DESC" title="r2-commercial-candidate">r2-commercial-candidate</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->
This PR updates the timeout values in `TestTimeoutPrioritization` within `reverse_proxy_test.go` to improve test reliability and eliminate flakiness.

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->
https://tyktech.atlassian.net/browse/TT-12343

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Enable parallel test execution in timeout tests.

- Adjust sleep durations to reflect correct timeout behavior.

- Update endpoint paths and response texts accordingly.

- Modify hard timeout values for enforced vs default timeout tests.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reverse_proxy_test.go</strong><dd><code>Modify timeout test parameters and paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/reverse_proxy_test.go

<li>Added t.Parallel() for concurrent test execution.<br> <li> Revised sleep durations for various test scenarios.<br> <li> Changed endpoint paths and expected responses.<br> <li> Updated hard timeout values in test cases.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6992/files#diff-ce040f6555143f760fba6059744bc600b6954f0966dfb0fa2832b5eabf7a3c3f">+26/-24</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>