### PR TITLE
Merging to release-5.3: [TT-13277] Improve API listen path sorting to prioritize static segments over parameters (#6987)

### DIFF
--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -924,8 +924,29 @@ func sortSpecsByListenPath(specs []*APISpec) {
 		if (specs[i].Domain == "") != (specs[j].Domain == "") {
 			return specs[i].Domain != ""
 		}
-		return len(specs[i].Proxy.ListenPath) > len(specs[j].Proxy.ListenPath)
+
+		return listenPathLength(specs[i].Proxy.ListenPath) > listenPathLength(specs[j].Proxy.ListenPath)
 	})
+}
+
+func listenPathLength(listenPath string) int {
+	// If the path doesn't contain '{', compute the length directly
+	if !strings.Contains(listenPath, "{") {
+		return len(listenPath)
+	}
+
+	// Split the path into segments and calculate the total length
+	length := strings.Count(listenPath, "/")
+
+	for _, segment := range strings.Split(listenPath, "/") {
+		// Skip segments enclosed by {} with non-empty content
+		if len(segment) > 2 && segment[0] == '{' && segment[len(segment)-1] == '}' {
+			continue
+		}
+		length += len(segment)
+	}
+
+	return length
 }
 
 // Create the individual API (app) specs based on live configurations and assign middleware

--- a/gateway/api_loader_test.go
+++ b/gateway/api_loader_test.go
@@ -9516,3 +9516,110 @@ func TestAPILoaderValidation(t *testing.T) {
 		)
 	})
 }
+
+func TestSortSpecsByListenPath(t *testing.T) {
+	createSpec := func(listenPath string) *APISpec {
+		return &APISpec{
+			APIDefinition: &apidef.APIDefinition{
+				Proxy: apidef.ProxyConfig{
+					ListenPath: listenPath,
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		specs    []*APISpec
+		expected []string
+	}{
+		{
+			name: "Basic Parameter vs Static Path",
+			specs: []*APISpec{
+				createSpec("/foo"),
+				createSpec("/foo-bar"),
+				createSpec("/foo-bar-baz"),
+				createSpec("/foo"),
+				createSpec("/bar"),
+				createSpec("/bar/{id}"),
+				createSpec("/bar/{id}/baz"),
+				createSpec("/bar/id/baz"),
+				createSpec("/bar/{id}/baz/{id}"),
+				createSpec("/path/{param}/endpoint"),
+				createSpec("/path/specific/endpoint"),
+			},
+			expected: []string{
+				"/path/specific/endpoint",
+				"/path/{param}/endpoint",
+				"/foo-bar-baz",
+				"/bar/id/baz",
+				"/bar/{id}/baz/{id}",
+				"/bar/{id}/baz",
+				"/foo-bar",
+				"/bar/{id}",
+				"/foo",
+				"/foo",
+				"/bar",
+			},
+		},
+		{
+			name: "Multiple Parameters vs Longer Static Path",
+			specs: []*APISpec{
+				createSpec("/api/{param1}/{param2}/resource"),
+				createSpec("/api/specific/path/resource"),
+			},
+			expected: []string{
+				"/api/specific/path/resource",
+				"/api/{param1}/{param2}/resource",
+			},
+		},
+		{
+			name: "Identical Paths Except for Parameter",
+			specs: []*APISpec{
+				createSpec("/users/{id}/profile"),
+				createSpec("/users/settings/profile"),
+			},
+			expected: []string{
+				"/users/settings/profile",
+				"/users/{id}/profile",
+			},
+		},
+		{
+			name: "Customer Reported Case",
+			specs: []*APISpec{
+				createSpec("/information-concept/something/{thisisalongidname}/stuff"),
+				createSpec("/information-concept/something/ted/stuff/things"),
+			},
+			expected: []string{
+				"/information-concept/something/ted/stuff/things",
+				"/information-concept/something/{thisisalongidname}/stuff",
+			},
+		},
+		{
+			name: "Parameter at Different Position",
+			specs: []*APISpec{
+				createSpec("/products/{category}/items"),
+				createSpec("/products/featured/items/{id}"),
+			},
+			expected: []string{
+				"/products/featured/items/{id}",
+				"/products/{category}/items",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sortSpecsByListenPath(tt.specs)
+
+			var sortedPaths []string
+			for _, spec := range tt.specs {
+				sortedPaths = append(sortedPaths, spec.Proxy.ListenPath)
+			}
+
+			if !reflect.DeepEqual(sortedPaths, tt.expected) {
+				t.Errorf("Expected %v, but got %v", tt.expected, sortedPaths)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### **User description**
[TT-13277] Improve API listen path sorting to prioritize static segments over parameters (#6987)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-13277"
title="TT-13277" target="_blank">TT-13277</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
<td>Listen path length with pattern matching matches wrong api</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%205.8.1Refinement%20ORDER%20BY%20created%20DESC"
title="5.8.1Refinement">5.8.1Refinement</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20Commercial_candidate_rel2-2025%20ORDER%20BY%20created%20DESC"
title="Commercial_candidate_rel2-2025">Commercial_candidate_rel2-2025</a>,
<a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20Gold%20ORDER%20BY%20created%20DESC"
title="Gold">Gold</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20customer_bug%20ORDER%20BY%20created%20DESC"
title="customer_bug">customer_bug</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20jira_escalated%20ORDER%20BY%20created%20DESC"
title="jira_escalated">jira_escalated</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

This PR adjusts sorting logic to favor longer static paths by ignoring
parameter segment lengths, ensuring correct route precedence.

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->
https://tyktech.atlassian.net/browse/TT-13277

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
- Bug fix
- Tests



___

### **Description**
- Modified sortSpecsByListenPath to use computed length.

- Introduced computeListenPathLength to ignore parameter templates.

- Added unit tests verifying ListenPath sort ordering.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>api_loader.go</strong><dd><code>Refactor listen path
sort logic with helper function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

gateway/api_loader.go

<li>Replaced direct length comparison with computeListenPathLength.<br>
<li> Added computeListenPathLength to exclude parameter segment lengths.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6987/files#diff-cdf0b7f176c9d18e1a314b78ddefc2cb3a94b3de66f1f360174692c915734c68">+20/-1</a>&nbsp;
&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>api_loader_test.go</strong><dd><code>Add comprehensive
tests for ListenPath sorting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_loader_test.go

<li>Added TestSortSpecsByListenPath to cover various path scenarios.<br>
<li> Verified sorting order for static and parameterized paths.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/6987/files#diff-f696545a659f4d96421b253edef4bcc8da0e7f52120b8f8866d32cbbb7cc1afc">+114/-0</a>&nbsp;
</td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary> Need help?</summary><li>Type <code>/help how to
...</code> in the comments thread for any questions about PR-Agent
usage.</li><li>Check out the <a
href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a>
for more information.</li></details>

---------

Co-authored-by: Laurentiu <6229829+lghiur@users.noreply.github.com>

[TT-13277]: https://tyktech.atlassian.net/browse/TT-13277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
- Bug fix
- Tests



___

### **Description**
- Update sorting logic to ignore parameter segments.

- Add listenPathLength helper for accurate length.

- Introduce comprehensive tests for ListenPath ordering.

- Improve API route precedence with static paths.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api_loader.go</strong><dd><code>Refactor listen path sorting logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_loader.go

<li>Replaced direct length with listenPathLength.<br> <li> Added helper to exclude parameter segments.<br> <li> Refactored sortSpecsByListenPath function.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6996/files#diff-cdf0b7f176c9d18e1a314b78ddefc2cb3a94b3de66f1f360174692c915734c68">+22/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api_loader_test.go</strong><dd><code>Add comprehensive ListenPath sort tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_loader_test.go

<li>Added TestSortSpecsByListenPath unit test.<br> <li> Tested various static and parameter path cases.<br> <li> Validated expected sorting order.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6996/files#diff-f696545a659f4d96421b253edef4bcc8da0e7f52120b8f8866d32cbbb7cc1afc">+107/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>