### PR TITLE
Revert "Merging to release-5.3: [TT-12343] Use API endpoint hard timeouts over global timeout setting (#6976)"

### DIFF
--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -1187,12 +1187,6 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 
 		timeout := proxyTimeout(p.TykAPISpec)
 
-		// If an enforced timeout is configured for this API endpoint, use it instead
-		// of the global default timeout, as it should take precedence
-		if isTimeoutEnforced {
-			timeout = enforcedTimeout
-		}
-
 		p.TykAPISpec.HTTPTransport = p.httpTransport(timeout, rw, req, outreq)
 		p.TykAPISpec.HTTPTransportCreated = time.Now()
 

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -25,6 +24,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/TykTechnologies/tyk/user"
+
+	"github.com/TykTechnologies/tyk/header"
+
 	"github.com/TykTechnologies/graphql-go-tools/pkg/execution/datasource"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
 	"github.com/TykTechnologies/tyk-pump/analytics"
@@ -33,10 +36,8 @@ import (
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/ctx"
 	"github.com/TykTechnologies/tyk/dnscache"
-	"github.com/TykTechnologies/tyk/header"
 	"github.com/TykTechnologies/tyk/request"
 	"github.com/TykTechnologies/tyk/test"
-	"github.com/TykTechnologies/tyk/user"
 )
 
 func TestCopyHeader_NoDuplicateCORSHeaders(t *testing.T) {
@@ -760,7 +761,6 @@ func TestCheckHeaderInRemoveList(t *testing.T) {
 }
 
 func testRequestIPHops(t testing.TB) {
-	t.Helper()
 	req := &http.Request{
 		Header:     http.Header{},
 		RemoteAddr: "test.com:80",
@@ -1797,7 +1797,7 @@ func TestReverseProxyWebSocketCancelation(t *testing.T) {
 		case line == terminalMsg: // this case before "err == io.EOF"
 			t.Fatalf("The websocket request was not canceled, unfortunately!")
 
-		case errors.Is(err, io.EOF):
+		case err == io.EOF:
 			return
 
 		case err != nil:
@@ -2084,280 +2084,4 @@ func BenchmarkLargeResponsePayload(b *testing.B) {
 			Code:   http.StatusOK,
 		})
 	}
-}
-
-func TestTimeoutPrioritization(t *testing.T) {
-	t.Parallel()
-
-	ts := StartTest(func(c *config.Config) {
-		c.ProxyDefaultTimeout = 2
-	})
-	defer ts.Close()
-
-	t.Run("Basic Timeout Behavior - enforced timeout higher than default", func(t *testing.T) {
-		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			time.Sleep(1 * time.Second)
-			w.Write([]byte("Success"))
-		}))
-		defer upstream.Close()
-
-		api := BuildAPI(func(spec *APISpec) {
-			spec.Proxy.ListenPath = "/"
-			spec.Proxy.TargetURL = upstream.URL
-			spec.UseKeylessAccess = true
-			spec.EnforcedTimeoutEnabled = true
-			UpdateAPIVersion(spec, "", func(version *apidef.VersionInfo) {
-				version.UseExtendedPaths = true
-				version.ExtendedPaths.HardTimeouts = []apidef.HardTimeoutMeta{
-					{
-						Disabled: false,
-						Path:     "/test1",
-						Method:   http.MethodGet,
-						TimeOut:  4,
-					},
-				}
-			})
-		})[0]
-
-		ts.Gw.LoadAPI(api)
-
-		_, _ = ts.Run(t, test.TestCase{
-			Method:    http.MethodGet,
-			Path:      "/test1",
-			Code:      http.StatusOK,
-			BodyMatch: "Success",
-		})
-	})
-
-	t.Run("Basic Timeout Behavior - enforced timeout lower than default", func(t *testing.T) {
-		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			time.Sleep(3 * time.Second)
-			w.Write([]byte("Success"))
-		}))
-		defer upstream.Close()
-
-		api := BuildAPI(func(spec *APISpec) {
-			spec.Proxy.ListenPath = "/"
-			spec.Proxy.TargetURL = upstream.URL
-			spec.UseKeylessAccess = true
-			spec.EnforcedTimeoutEnabled = true
-			UpdateAPIVersion(spec, "", func(version *apidef.VersionInfo) {
-				version.UseExtendedPaths = true
-				version.ExtendedPaths.HardTimeouts = []apidef.HardTimeoutMeta{
-					{
-						Disabled: false,
-						Path:     "/test2",
-						Method:   http.MethodGet,
-						TimeOut:  1,
-					},
-				}
-			})
-		})[0]
-
-		ts.Gw.LoadAPI(api)
-
-		_, _ = ts.Run(t, test.TestCase{
-			Method:    http.MethodGet,
-			Path:      "/test2",
-			Code:      http.StatusGatewayTimeout,
-			BodyMatch: "Upstream service reached hard timeout",
-		})
-	})
-
-	t.Run("Basic Timeout Behavior - delay higher than both timeouts", func(t *testing.T) {
-		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			time.Sleep(3 * time.Second)
-			w.Write([]byte("Success"))
-		}))
-		defer upstream.Close()
-
-		api := BuildAPI(func(spec *APISpec) {
-			spec.Proxy.ListenPath = "/"
-			spec.Proxy.TargetURL = upstream.URL
-			spec.UseKeylessAccess = true
-			spec.EnforcedTimeoutEnabled = true
-			UpdateAPIVersion(spec, "", func(version *apidef.VersionInfo) {
-				version.UseExtendedPaths = true
-				version.ExtendedPaths.HardTimeouts = []apidef.HardTimeoutMeta{
-					{
-						Disabled: false,
-						Path:     "/test3",
-						Method:   http.MethodGet,
-						TimeOut:  1,
-					},
-				}
-			})
-		})[0]
-
-		ts.Gw.LoadAPI(api)
-
-		_, _ = ts.Run(t, test.TestCase{
-			Method:    http.MethodGet,
-			Path:      "/test3",
-			Code:      http.StatusGatewayTimeout,
-			BodyMatch: "Upstream service reached hard timeout",
-		})
-	})
-
-	t.Run("Basic Timeout Behavior - delay within enforced timeout", func(t *testing.T) {
-		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			time.Sleep(1 * time.Second)
-			w.Write([]byte("Success"))
-		}))
-		defer upstream.Close()
-
-		api := BuildAPI(func(spec *APISpec) {
-			spec.Proxy.ListenPath = "/"
-			spec.Proxy.TargetURL = upstream.URL
-			spec.UseKeylessAccess = true
-			spec.EnforcedTimeoutEnabled = true
-			UpdateAPIVersion(spec, "", func(version *apidef.VersionInfo) {
-				version.UseExtendedPaths = true
-				version.ExtendedPaths.HardTimeouts = []apidef.HardTimeoutMeta{
-					{
-						Disabled: false,
-						Path:     "/test4",
-						Method:   http.MethodGet,
-						TimeOut:  3,
-					},
-				}
-			})
-		})[0]
-
-		ts.Gw.LoadAPI(api)
-
-		_, _ = ts.Run(t, test.TestCase{
-			Method:    http.MethodGet,
-			Path:      "/test4",
-			Code:      http.StatusOK,
-			BodyMatch: "Success",
-		})
-	})
-
-	t.Run("Multiple Endpoints with Different Enforced Timeouts", func(t *testing.T) {
-		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasPrefix(r.URL.Path, "/delay/") {
-				time.Sleep(1000 * time.Millisecond)
-				w.Write([]byte("Delay 1s response"))
-			} else if strings.HasPrefix(r.URL.Path, "/delay2/") {
-				time.Sleep(2000 * time.Millisecond)
-				w.Write([]byte("Delay2 2s response"))
-			} else {
-				w.WriteHeader(http.StatusNotFound)
-			}
-		}))
-		defer upstream.Close()
-
-		api := BuildAPI(func(spec *APISpec) {
-			spec.Proxy.ListenPath = "/"
-			spec.Proxy.TargetURL = upstream.URL
-			spec.UseKeylessAccess = true
-			spec.EnforcedTimeoutEnabled = true
-			UpdateAPIVersion(spec, "", func(version *apidef.VersionInfo) {
-				version.UseExtendedPaths = true
-				version.ExtendedPaths.HardTimeouts = []apidef.HardTimeoutMeta{
-					{
-						Disabled: false,
-						Path:     "^/delay/1$",
-						Method:   http.MethodGet,
-						TimeOut:  4,
-					},
-					{
-						Disabled: false,
-						Path:     "^/delay2/2$",
-						Method:   http.MethodGet,
-						TimeOut:  1,
-					},
-				}
-			})
-		})[0]
-
-		ts.Gw.LoadAPI(api)
-
-		_, _ = ts.Run(t, test.TestCase{
-			Method:    http.MethodGet,
-			Path:      "/delay/1",
-			Code:      http.StatusOK,
-			BodyMatch: "Delay 1s response",
-		})
-
-		_, _ = ts.Run(t, test.TestCase{
-			Method:    http.MethodGet,
-			Path:      "/delay2/2",
-			Code:      http.StatusGatewayTimeout,
-			BodyMatch: "Upstream service reached hard timeout",
-		})
-	})
-
-	t.Run("Explicit vs Default Global Timeout", func(t *testing.T) {
-		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasPrefix(r.URL.Path, "/delay/1000") {
-				time.Sleep(1000 * time.Millisecond)
-				w.Write([]byte("Delay 1s response"))
-			} else if strings.HasPrefix(r.URL.Path, "/delay/4000") {
-				time.Sleep(4000 * time.Millisecond)
-				w.Write([]byte("Delay 4s response"))
-			} else if strings.HasPrefix(r.URL.Path, "/delay2/1000") {
-				time.Sleep(1000 * time.Millisecond)
-				w.Write([]byte("Delay2 1s response"))
-			} else if strings.HasPrefix(r.URL.Path, "/delay2/4000") {
-				time.Sleep(4000 * time.Millisecond)
-				w.Write([]byte("Delay2 4s response"))
-			} else {
-				w.WriteHeader(http.StatusNotFound)
-			}
-		}))
-		defer upstream.Close()
-
-		api := BuildAPI(func(spec *APISpec) {
-			spec.Proxy.ListenPath = "/"
-			spec.Proxy.TargetURL = upstream.URL
-			spec.UseKeylessAccess = true
-			spec.EnforcedTimeoutEnabled = true
-			UpdateAPIVersion(spec, "", func(version *apidef.VersionInfo) {
-				version.UseExtendedPaths = true
-				version.ExtendedPaths.HardTimeouts = []apidef.HardTimeoutMeta{
-					{
-						Disabled: false,
-						Path:     "/delay/.*",
-						Method:   http.MethodGet,
-						TimeOut:  3,
-					},
-					// No explicit timeout for /delay2/* endpoints - will use global
-				}
-			})
-		})[0]
-
-		ts.Gw.LoadAPI(api)
-
-		// Test case 1: Should succeed (delay 45ms < enforced timeout 60ms)
-		_, _ = ts.Run(t, test.TestCase{
-			Method:    http.MethodGet,
-			Path:      "/delay/1000",
-			Code:      http.StatusOK,
-			BodyMatch: "Delay 1s response",
-		})
-
-		_, _ = ts.Run(t, test.TestCase{
-			Method:    http.MethodGet,
-			Path:      "/delay/4000",
-			Code:      http.StatusGatewayTimeout,
-			BodyMatch: "Upstream service reached hard timeout",
-		})
-
-		_, _ = ts.Run(t, test.TestCase{
-			Method:    http.MethodGet,
-			Path:      "/delay2/1000",
-			Code:      http.StatusOK,
-			BodyMatch: "Delay2 1s response",
-		})
-
-		// Test case 4: Should timeout at global value (delay 60ms > global timeout 50ms)
-		_, _ = ts.Run(t, test.TestCase{
-			Method:    http.MethodGet,
-			Path:      "/delay2/4000",
-			Code:      http.StatusGatewayTimeout,
-			BodyMatch: "Upstream service reached hard timeout",
-		})
-	})
 }


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-12343" title="TT-12343" target="_blank">TT-12343</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>proxy_default_timeout overrides enforced timeout middleware but should only be applied when enforced timeout is unset</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%205.8.1Refinement%20ORDER%20BY%20created%20DESC" title="5.8.1Refinement">5.8.1Refinement</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20Commercial_candidate_rel2-2025%20ORDER%20BY%20created%20DESC" title="Commercial_candidate_rel2-2025">Commercial_candidate_rel2-2025</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20QA_Fail%20ORDER%20BY%20created%20DESC" title="QA_Fail">QA_Fail</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20customer_bug%20ORDER%20BY%20created%20DESC" title="customer_bug">customer_bug</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20innersource-candidate%20ORDER%20BY%20created%20DESC" title="innersource-candidate">innersource-candidate</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20jira_escalated%20ORDER%20BY%20created%20DESC" title="jira_escalated">jira_escalated</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20r2-commercial-candidate%20ORDER%20BY%20created%20DESC" title="r2-commercial-candidate">r2-commercial-candidate</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

Reverts TykTechnologies/tyk#6981


___

### **PR Type**
- Bug fix
- Tests



___

### **Description**
- Removed enforced timeout override from reverse proxy.

- Deleted TestTimeoutPrioritization and related test cases.

- Revert changes that prioritized API endpoint hard timeouts.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reverse_proxy.go</strong><dd><code>Remove enforced timeout override logic.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/reverse_proxy.go

<li>Removed check for enforced timeout usage.<br> <li> Now only global timeout is applied.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6999/files#diff-e6e07722257f7e41691e471185ad6d84fd56dc9e5459526ea32e9a5e8fa1a01b">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reverse_proxy_test.go</strong><dd><code>Remove tests for enforced timeout.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/reverse_proxy_test.go

<li>Deleted TestTimeoutPrioritization function.<br> <li> Removed related test scenarios and redundant imports.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/6999/files#diff-ce040f6555143f760fba6059744bc600b6954f0966dfb0fa2832b5eabf7a3c3f">+5/-281</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>