### PR TITLE
[SYSE-372 master] Implement custom rules for enterprise artifacts in package promotion

### DIFF
--- a/ci/Dockerfile.distroless
+++ b/ci/Dockerfile.distroless
@@ -6,7 +6,8 @@ ARG BUILD_PACKAGE_NAME
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-COPY ${BUILD_PACKAGE_NAME}*${TARGETARCH}.deb /
+# The _ after the pkg name is to match tyk-gateway strictly and not tyk-gateway-fips (for example)
+COPY ${BUILD_PACKAGE_NAME}_*${TARGETARCH}.deb /
 RUN dpkg -i /${BUILD_PACKAGE_NAME}_*${TARGETARCH}.deb && rm /*.deb
 
 FROM gcr.io/distroless/base-debian12:latest

--- a/ci/Dockerfile.std
+++ b/ci/Dockerfile.std
@@ -21,7 +21,7 @@ RUN rm -rf /root/.cache \
     && find /usr/lib -type f -name '*.a' -o -name '*.o' -delete
 
 # Comment this to test in dev
-COPY ${BUILD_PACKAGE_NAME}*${TARGETARCH}.deb /
+COPY ${BUILD_PACKAGE_NAME}_*${TARGETARCH}.deb /
 RUN dpkg -i /${BUILD_PACKAGE_NAME}*${TARGETARCH}.deb && rm /*.deb
 
 ARG PORTS

--- a/ci/goreleaser/goreleaser.yml
+++ b/ci/goreleaser/goreleaser.yml
@@ -129,7 +129,7 @@ nfpms:
     description: Tyk API Gateway Enterprise Edition written in Go, supporting REST, GraphQL, TCP and gRPC protocols
     package_name: tyk-gateway-ee
     file_name_template: "{{ .ConventionalFileName }}"
-    builds:
+    ids:
       - ee-amd64
       - ee-arm64
       - ee-s390x
@@ -188,7 +188,7 @@ nfpms:
     description: Tyk Open Source API Gateway written in Go, supporting REST, GraphQL, TCP and gRPC protocols Built with boringssl
     package_name: tyk-gateway-fips
     file_name_template: "{{ .ConventionalFileName }}"
-    builds:
+    ids:
       - fips-amd64
     formats:
       - deb
@@ -245,7 +245,7 @@ nfpms:
     description: Tyk Open Source API Gateway written in Go, supporting REST, GraphQL, TCP and gRPC protocols
     package_name: tyk-gateway
     file_name_template: "{{ .ConventionalFileName }}"
-    builds:
+    ids:
       - std-amd64
       - std-arm64
       - std-s390x
@@ -303,13 +303,13 @@ publishers:
       - ee
     env:
       - PACKAGECLOUD_TOKEN={{ .Env.PACKAGECLOUD_TOKEN }}
-    cmd: packagecloud publish --debvers "{{ .Env.DEBVERS }}" --rpmvers "{{ .Env.RPMVERS }}" tyk/tyk-gateway-unstable {{ .ArtifactPath }}
+    cmd: packagecloud publish --debvers "{{ .Env.DEBVERS }}" --rpmvers "{{ .Env.RPMVERS }}" tyk/tyk-ee-unstable {{ .ArtifactPath }}
   - name: fips
     ids:
       - fips
     env:
       - PACKAGECLOUD_TOKEN={{ .Env.PACKAGECLOUD_TOKEN }}
-    cmd: packagecloud publish --debvers "{{ .Env.DEBVERS }}" --rpmvers "{{ .Env.RPMVERS }}" tyk/tyk-gateway-unstable {{ .ArtifactPath }}
+    cmd: packagecloud publish --debvers "{{ .Env.DEBVERS }}" --rpmvers "{{ .Env.RPMVERS }}" tyk/tyk-ee-unstable {{ .ArtifactPath }}
   - name: std
     ids:
       - std
@@ -318,7 +318,7 @@ publishers:
     cmd: packagecloud publish --debvers "{{ .Env.DEBVERS }}" --rpmvers "{{ .Env.RPMVERS }}" tyk/tyk-gateway-unstable {{ .ArtifactPath }}
 # This disables archives
 archives:
-  - format: binary
+  - formats: ['binary']
     allow_different_binary_count: true
 checksum:
   disable: true


### PR DESCRIPTION
### **User description**
We going to change how packages get delivered to our customers, and separate enterprise and oss level artifacts. TLDR: OSS users will get access only to the latest, paid https://docs.google.com/document/d/1JN0iz7fn23nNg0uAlh57nYCdxgYsUyJhIXf4IYksPWE/edit#heading=h.vfoxsz8vofwd 
fips and ee builds go to tyk-ee-unstable.
the std build go to the existing repos.
In addition to the existing protmotion, promote versions from tyk-ee-unstable to tyk-ee.


___

### **PR Type**
- Enhancement



___

### **Description**
- Updated Dockerfile COPY commands to use underscore for strict package matching.

- Replaced "builds" key with "ids" in goreleaser config sections.

- Adjusted publisher commands to target enterprise unstable repositories.

- Updated archive formats configuration.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile.dist</strong><dd><code>Refine package deb copy pattern in distroless Dockerfile</code>&nbsp; </dd></summary>
<hr>

ci/Dockerfile.dist

<li>Uses underscore in COPY command for strict package matching.<br> <li> Adds comment explaining underscore usage for tyk-gateway distinction.


</details>


  </td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile.std</strong><dd><code>Update standard build Dockerfile COPY command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ci/Dockerfile.std

<li>Changes COPY command to include underscore ensuring precise deb <br>selection.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7005/files#diff-a3b3e9cabd877d0bd0fc8f20a9fdca7f44d102547a5fdfcd398ea01637e5dfae">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>goreleaser.yml</strong><dd><code>Revise package build and publisher configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ci/goreleaser/goreleaser.yml

<li>Renames "builds" key to "ids" for package definitions.<br> <li> Updates publisher commands from tyk-gateway-unstable to <br>tyk-ee-unstable.<br> <li> Modifies archive configuration from "format" to "formats".


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7005/files#diff-fb944a05459e4d713bc7541efd6e721cbe992a556353c09c4eb66a8eae9b856e">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Additional files</strong></td><td><table>
<tr>
  <td><strong>Dockerfile.distroless</strong></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7005/files#diff-ab1e64220db8ccca1a52a505decc2beb2156d5ec3ecb7d6b8660cc3dc7e1f5bd">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>