### PR TITLE
[SYSE-372 release-5.3] Implement custom rules for enterprise artifacts in package promotion

### DIFF
--- a/ci/goreleaser/goreleaser.yml
+++ b/ci/goreleaser/goreleaser.yml
@@ -81,7 +81,7 @@ nfpms:
     description: Tyk Open Source API Gateway written in Go, supporting REST, GraphQL, TCP and gRPC protocols Built with boringssl
     package_name: tyk-gateway-fips
     file_name_template: "{{ .ConventionalFileName }}"
-    builds:
+    ids:
       - fips-amd64
     formats:
       - deb
@@ -138,7 +138,7 @@ nfpms:
     description: Tyk Open Source API Gateway written in Go, supporting REST, GraphQL, TCP and gRPC protocols
     package_name: tyk-gateway
     file_name_template: "{{ .ConventionalFileName }}"
-    builds:
+    ids:
       - std-amd64
       - std-arm64
       - std-s390x
@@ -196,7 +196,7 @@ publishers:
       - fips
     env:
       - PACKAGECLOUD_TOKEN={{ .Env.PACKAGECLOUD_TOKEN }}
-    cmd: packagecloud publish --debvers "{{ .Env.DEBVERS }}" --rpmvers "{{ .Env.RPMVERS }}" tyk/ {{ .ArtifactPath }}
+    cmd: packagecloud publish --debvers "{{ .Env.DEBVERS }}" --rpmvers "{{ .Env.RPMVERS }}" tyk/tyk-ee-unstable {{ .ArtifactPath }}
   - name: std
     ids:
       - std
@@ -205,7 +205,7 @@ publishers:
     cmd: packagecloud publish --debvers "{{ .Env.DEBVERS }}" --rpmvers "{{ .Env.RPMVERS }}" tyk/tyk-gateway-unstable {{ .ArtifactPath }}
 # This disables archives
 archives:
-  - format: binary
+  - formats: ['binary']
     allow_different_binary_count: true
 checksum:
   disable: true


### PR DESCRIPTION
### **User description**
We going to change how packages get delivered to our customers, and separate enterprise and oss level artifacts. TLDR: OSS users will get access only to the latest, paid https://docs.google.com/document/d/1JN0iz7fn23nNg0uAlh57nYCdxgYsUyJhIXf4IYksPWE/edit#heading=h.vfoxsz8vofwd 
fips and ee builds go to tyk-ee-unstable.
the std build go to the existing repos.
In addition to the existing protmotion, promote versions from tyk-ee-unstable to tyk-ee.


___

### **PR Type**
Enhancement


___

### **Description**
- Replace `builds` key with `ids` in nfpm configs.

- Update publisher commands to reference enterprise unstable repos.

- Adjust archive configuration from `format` to `formats`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>goreleaser.yml</strong><dd><code>Config changes for enterprise artifact promotion.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ci/goreleaser/goreleaser.yml

<li>Replaced <code>builds</code> keys with <code>ids</code> for both fips and std packages.<br> <li> Modified fips publisher command to publish to <code>tyk/tyk-ee-unstable</code>.<br> <li> Updated archive configuration to use <code>formats</code> instead of <code>format</code>.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7006/files#diff-fb944a05459e4d713bc7541efd6e721cbe992a556353c09c4eb66a8eae9b856e">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>