### PR TITLE
Merging to release-5.3: [TT-12442] Force gw reload after registration to have synced polciies and apis (#6988)

### DIFF
--- a/gateway/dashboard_register.go
+++ b/gateway/dashboard_register.go
@@ -228,6 +228,7 @@ func (h *HTTPDashboardHandler) Register() error {
 	h.Gw.ServiceNonce = val.Nonce
 	h.Gw.ServiceNonceMutex.Unlock()
 	dashLog.Debug("Registration Finished: Nonce Set: ", val.Nonce)
+	h.Gw.DoReload()
 
 	return nil
 }

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -2258,21 +2258,13 @@ func TestTimeoutPrioritization(t *testing.T) {
 				version.ExtendedPaths.HardTimeouts = []apidef.HardTimeoutMeta{
 					{
 						Disabled: false,
-<<<<<<< HEAD
-						Path:     "^/delay/1$",
-=======
 						Path:     "^/delay/3$",
->>>>>>> 1ff18786f... [TT-12442] Force gw reload after registration to have synced polciies and apis (#6988)
 						Method:   http.MethodGet,
 						TimeOut:  4,
 					},
 					{
 						Disabled: false,
-<<<<<<< HEAD
-						Path:     "^/delay2/2$",
-=======
 						Path:     "^/delay2/3$",
->>>>>>> 1ff18786f... [TT-12442] Force gw reload after registration to have synced polciies and apis (#6988)
 						Method:   http.MethodGet,
 						TimeOut:  1,
 					},

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -2258,13 +2258,21 @@ func TestTimeoutPrioritization(t *testing.T) {
 				version.ExtendedPaths.HardTimeouts = []apidef.HardTimeoutMeta{
 					{
 						Disabled: false,
+<<<<<<< HEAD
 						Path:     "^/delay/1$",
+=======
+						Path:     "^/delay/3$",
+>>>>>>> 1ff18786f... [TT-12442] Force gw reload after registration to have synced polciies and apis (#6988)
 						Method:   http.MethodGet,
 						TimeOut:  4,
 					},
 					{
 						Disabled: false,
+<<<<<<< HEAD
 						Path:     "^/delay2/2$",
+=======
+						Path:     "^/delay2/3$",
+>>>>>>> 1ff18786f... [TT-12442] Force gw reload after registration to have synced polciies and apis (#6988)
 						Method:   http.MethodGet,
 						TimeOut:  1,
 					},


### PR DESCRIPTION
### **User description**
[TT-12442] Force gw reload after registration to have synced polciies and apis (#6988)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-12442"
title="TT-12442" target="_blank">TT-12442</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
<td>Pro licensing it messed up. Sometimes more gateways than are
licensed can get licences, sometimes gateways are refused when licences
are available</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Code Review</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%205.8.1Refinement%20ORDER%20BY%20created%20DESC"
title="5.8.1Refinement">5.8.1Refinement</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20Commercial_candidate_rel2-2025%20ORDER%20BY%20created%20DESC"
title="Commercial_candidate_rel2-2025">Commercial_candidate_rel2-2025</a>,
<a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20customer_bug%20ORDER%20BY%20created%20DESC"
title="customer_bug">customer_bug</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20jira_escalated%20ORDER%20BY%20created%20DESC"
title="jira_escalated">jira_escalated</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20r2-commercial-candidate%20ORDER%20BY%20created%20DESC"
title="r2-commercial-candidate">r2-commercial-candidate</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
- Bug fix
- Tests



___

### **Description**
- Call gateway reload post-nonce set

- Update reverse proxy test timeout paths


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboard_register.go</strong><dd><code>Trigger reload after registration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/dashboard_register.go

<li>Add h.Gw.DoReload() call after nonce is set<br> <li> Improve API and policy synchronization


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7018/files#diff-f504c88b3d2fa3b56b74c252aab41a934156879ef1150d33714225749e6cc94c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reverse_proxy_test.go</strong><dd><code>Update reverse proxy test timeout paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/reverse_proxy_test.go

<li>Update hard timeout regex from /1 to /3<br> <li> Update secondary timeout regex from /2 to /3


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7018/files#diff-ce040f6555143f760fba6059744bc600b6954f0966dfb0fa2832b5eabf7a3c3f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>