### PR TITLE
feat: add /spec endpoint to OAS APIs to expose OAS definitions

### DIFF
--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -118,6 +118,9 @@ func fixFuncPath(pathPrefix string, funcs []apidef.MiddlewareDefinition) {
 }
 
 func (gw *Gateway) generateSubRoutes(spec *APISpec, router *mux.Router, logger *logrus.Entry) {
+	// Add OAS spec endpoint for OAS APIs
+	gw.addOASSpecEndpoint(spec, router, logger)
+
 	if spec.GraphQL.GraphQLPlayground.Enabled {
 		gw.loadGraphQLPlayground(spec, router)
 	}

--- a/gateway/oas_spec_endpoint.go
+++ b/gateway/oas_spec_endpoint.go
@@ -1,0 +1,43 @@
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	oasSpecEndpoint = "/spec"
+)
+
+// addOASSpecEndpoint adds a /spec endpoint to OAS APIs that returns the OAS definition
+// This endpoint bypasses all middleware, including authentication, rate limiting, etc.
+func (gw *Gateway) addOASSpecEndpoint(spec *APISpec, router *mux.Router, logger *logrus.Entry) {
+	// Only add the endpoint to OAS APIs
+	if !spec.IsOAS {
+		return
+	}
+
+	logger.Debug("Adding OAS spec endpoint for API: ", spec.APIID)
+
+	// Create a direct handler for the /spec endpoint that completely bypasses middleware
+	// This is registered directly with the router, so it's processed before any middleware chain
+	router.HandleFunc(oasSpecEndpoint, func(w http.ResponseWriter, r *http.Request) {
+		// Set content type header
+		w.Header().Set("Content-Type", "application/json")
+
+		// Marshal the OAS definition to JSON
+		oasJSON, err := json.Marshal(spec.OAS)
+		if err != nil {
+			logger.WithError(err).Error("Error marshaling OAS spec to JSON")
+			http.Error(w, "Error generating OAS spec", http.StatusInternalServerError)
+			return
+		}
+
+		// Write the response
+		w.WriteHeader(http.StatusOK)
+		w.Write(oasJSON)
+	}).Methods(http.MethodGet)
+}


### PR DESCRIPTION
This commit adds a new feature that automatically creates a /spec endpoint for all OAS APIs. When accessed, this endpoint returns the complete OAS definition of the API as JSON. The endpoint bypasses all middleware, including authentication, making the OAS definition publicly accessible regardless of API security settings.

