### PR TITLE
[TT-14666], fix for panic on gateway side when upgrading old oas file

### DIFF
--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -800,6 +800,10 @@ func (gw *Gateway) loadHTTPService(spec *APISpec, apisByListen map[string]int, g
 		chainObj = gw.processSpec(spec, apisByListen, gs, logrus.NewEntry(log))
 	}
 
+	if chainObj == nil {
+		return nil, fmt.Errorf("trying to import invalid api %s, skipping", spec.APIID)
+	}
+
 	if chainObj.Skip {
 		return chainObj, nil
 	}

--- a/gateway/api_loader_test.go
+++ b/gateway/api_loader_test.go
@@ -9637,7 +9637,7 @@ func TestForTyk5OasMigration(t *testing.T) {
 		spec.VersionData.Versions = map[string]apidef.VersionInfo{"a": {ExtendedPaths: apidef.ExtendedPathsSet{ValidateRequest: []apidef.ValidateRequestMeta{{Enabled: true}}}}}
 		spec.Name = "test-for-legacy-oas"
 		spec.APIID = "test-legacy-oas-api-id"
-		spec.Proxy.ListenPath = "/"
+		spec.Proxy.ListenPath = "/test-for-legacy-oas"
 		spec.AuthManager = MockSessionHandler{}
 		spec.Health = MockHealthChecker{}
 		spec.OrgSessionManager = MockSessionHandler{}

--- a/gateway/api_loader_test.go
+++ b/gateway/api_loader_test.go
@@ -9661,7 +9661,7 @@ func TestForTyk5OasMigration(t *testing.T) {
 
 type MockSessionHandler struct{}
 
-func (MockSessionHandler) Init(store storage.Handler) {
+func (MockSessionHandler) Init(storage.Handler) {
 	return
 }
 
@@ -9670,32 +9670,32 @@ func (MockSessionHandler) Store() storage.Handler {
 	panic("implement me")
 }
 
-func (MockSessionHandler) UpdateSession(keyName string, session *user.SessionState, resetTTLTo int64, hashed bool) error {
+func (MockSessionHandler) UpdateSession(string, *user.SessionState, int64, bool) error {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (MockSessionHandler) RemoveSession(orgID string, keyName string, hashed bool) bool {
+func (MockSessionHandler) RemoveSession(string, string, bool) bool {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (MockSessionHandler) SessionDetail(orgID string, keyName string, hashed bool) (user.SessionState, bool) {
+func (MockSessionHandler) SessionDetail(string, string, bool) (user.SessionState, bool) {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (MockSessionHandler) KeyExpired(newSession *user.SessionState) bool {
+func (MockSessionHandler) KeyExpired(*user.SessionState) bool {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (MockSessionHandler) Sessions(filter string) []string {
+func (MockSessionHandler) Sessions(string) []string {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (MockSessionHandler) ResetQuota(s string, state *user.SessionState, b bool) {
+func (MockSessionHandler) ResetQuota(string, *user.SessionState, bool) {
 	//TODO implement me
 	panic("implement me")
 }
@@ -9707,7 +9707,7 @@ func (MockSessionHandler) Stop() {
 
 type MockHealthChecker struct{}
 
-func (MockHealthChecker) Init(handler storage.Handler) {
+func (MockHealthChecker) Init(storage.Handler) {
 	return
 }
 
@@ -9716,7 +9716,7 @@ func (MockHealthChecker) ApiHealthValues() (HealthCheckValues, error) {
 	panic("implement me")
 }
 
-func (MockHealthChecker) StoreCounterVal(prefix HealthPrefix, s string) {
+func (MockHealthChecker) StoreCounterVal(HealthPrefix, string) {
 	//TODO implement me
 	panic("implement me")
 }

--- a/gateway/api_loader_test.go
+++ b/gateway/api_loader_test.go
@@ -9662,7 +9662,6 @@ func TestForTyk5OasMigration(t *testing.T) {
 type MockSessionHandler struct{}
 
 func (MockSessionHandler) Init(storage.Handler) {
-	return
 }
 
 func (MockSessionHandler) Store() storage.Handler {
@@ -9708,7 +9707,6 @@ func (MockSessionHandler) Stop() {
 type MockHealthChecker struct{}
 
 func (MockHealthChecker) Init(storage.Handler) {
-	return
 }
 
 func (MockHealthChecker) ApiHealthValues() (HealthCheckValues, error) {

--- a/gateway/api_loader_test.go
+++ b/gateway/api_loader_test.go
@@ -9636,7 +9636,7 @@ func TestForTyk5OasMigration(t *testing.T) {
 		spec.IsOAS = true
 		spec.VersionData.Versions = map[string]apidef.VersionInfo{"a": {ExtendedPaths: apidef.ExtendedPathsSet{ValidateRequest: []apidef.ValidateRequestMeta{{Enabled: true}}}}}
 		spec.Name = "test-for-legacy-oas"
-		spec.APIID = "test1"
+		spec.APIID = "test-legacy-oas-api-id"
 		spec.Proxy.ListenPath = "/"
 		spec.AuthManager = MockSessionHandler{}
 		spec.Health = MockHealthChecker{}

--- a/gateway/api_loader_test.go
+++ b/gateway/api_loader_test.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	_ "path"
 	"reflect"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -19,6 +20,7 @@ import (
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/internal/uuid"
+	"github.com/TykTechnologies/tyk/storage"
 	"github.com/TykTechnologies/tyk/test"
 	"github.com/TykTechnologies/tyk/trace"
 	"github.com/TykTechnologies/tyk/user"
@@ -9623,4 +9625,98 @@ func TestSortSpecsByListenPath(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestForTyk5OasMigration(t *testing.T) {
+	g := StartTest(nil)
+	defer g.Close()
+
+	internal := BuildAPI(func(spec *APISpec) {
+		spec.OAS.Extensions = nil
+		spec.IsOAS = true
+		spec.VersionData.Versions = map[string]apidef.VersionInfo{"a": {ExtendedPaths: apidef.ExtendedPathsSet{ValidateRequest: []apidef.ValidateRequestMeta{{Enabled: true}}}}}
+		spec.Name = "test-for-legacy-oas"
+		spec.APIID = "test1"
+		spec.Proxy.ListenPath = "/"
+		spec.AuthManager = MockSessionHandler{}
+		spec.Health = MockHealthChecker{}
+		spec.OrgSessionManager = MockSessionHandler{}
+	})[0]
+
+	g.Gw.apisMu.Lock()
+	g.Gw.apisByID[internal.APIID] = internal
+	g.Gw.apisMu.Unlock()
+
+	if g.Gw.apisHandlesByID == nil {
+		g.Gw.apisHandlesByID = new(sync.Map)
+	}
+	g.Gw.apisHandlesByID.Delete(internal.APIID)
+
+	apiByListenPath := map[string]int{}
+
+	_, err := g.Gw.loadHTTPService(internal, apiByListenPath, &generalStores{}, &proxyMux{})
+
+	assert.Equal(t, fmt.Sprint(err.Error()), "trying to import invalid api test1, skipping")
+}
+
+type MockSessionHandler struct{}
+
+func (MockSessionHandler) Init(store storage.Handler) {
+	return
+}
+
+func (MockSessionHandler) Store() storage.Handler {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (MockSessionHandler) UpdateSession(keyName string, session *user.SessionState, resetTTLTo int64, hashed bool) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (MockSessionHandler) RemoveSession(orgID string, keyName string, hashed bool) bool {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (MockSessionHandler) SessionDetail(orgID string, keyName string, hashed bool) (user.SessionState, bool) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (MockSessionHandler) KeyExpired(newSession *user.SessionState) bool {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (MockSessionHandler) Sessions(filter string) []string {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (MockSessionHandler) ResetQuota(s string, state *user.SessionState, b bool) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (MockSessionHandler) Stop() {
+	//TODO implement me
+	panic("implement me")
+}
+
+type MockHealthChecker struct{}
+
+func (MockHealthChecker) Init(handler storage.Handler) {
+	return
+}
+
+func (MockHealthChecker) ApiHealthValues() (HealthCheckValues, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (MockHealthChecker) StoreCounterVal(prefix HealthPrefix, s string) {
+	//TODO implement me
+	panic("implement me")
 }

--- a/gateway/api_loader_test.go
+++ b/gateway/api_loader_test.go
@@ -9656,7 +9656,7 @@ func TestForTyk5OasMigration(t *testing.T) {
 
 	_, err := g.Gw.loadHTTPService(internal, apiByListenPath, &generalStores{}, &proxyMux{})
 
-	assert.Equal(t, fmt.Sprint(err.Error()), "trying to import invalid api test1, skipping")
+	assert.Equal(t, fmt.Sprint(err.Error()), "trying to import invalid api test-legacy-oas-api-id, skipping")
 }
 
 type MockSessionHandler struct{}


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-14666" title="TT-14666" target="_blank">TT-14666</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>GW panics after updating from 5.0 with OAS API</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description
Fixes a gateway panic occurring when upgrading directly from release-5-lts to the cve-fix branch. The issue is triggered during API loading, specifically when a simple OAS API (external + active) was created in a prior version. This bug does not appear if an intermediate upgrade (e.g., to 5.1 or 5.8.0) is performed.

JIRA LINK: https://tyktech.atlassian.net/browse/TT-14666
<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Bug fix


___

### **Description**
- Prevents gateway panic when loading invalid OAS APIs after upgrade

- Adds nil check for `chainObj` in `loadHTTPService` function

- Returns error if attempting to import invalid API specification

- Improves robustness during direct upgrades from older versions


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api_loader.go</strong><dd><code>Add nil check and error return for invalid API spec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_loader.go

<li>Adds a nil check for <code>chainObj</code> after processing API spec<br> <li> Returns an error if <code>chainObj</code> is nil, preventing panic<br> <li> Logs the invalid API import attempt with API ID


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7034/files#diff-cdf0b7f176c9d18e1a314b78ddefc2cb3a94b3de66f1f360174692c915734c68">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>