### PR TITLE
Merging to release-5.8.1: [TT-14666], fix for panic on gateway side when upgrading old oas file (#7034)

### DIFF
--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -800,6 +800,10 @@ func (gw *Gateway) loadHTTPService(spec *APISpec, apisByListen map[string]int, g
 		chainObj = gw.processSpec(spec, apisByListen, gs, logrus.NewEntry(log))
 	}
 
+	if chainObj == nil {
+		return nil, fmt.Errorf("trying to import invalid api %s, skipping", spec.APIID)
+	}
+
 	if chainObj.Skip {
 		return chainObj, nil
 	}


### PR DESCRIPTION
### **User description**
[TT-14666], fix for panic on gateway side when upgrading old oas file (#7034)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-14666"
title="TT-14666" target="_blank">TT-14666</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>GW panics after updating from 5.0 with OAS API</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description
Fixes a gateway panic occurring when upgrading directly from
release-5-lts to the cve-fix branch. The issue is triggered during API
loading, specifically when a simple OAS API (external + active) was
created in a prior version. This bug does not appear if an intermediate
upgrade (e.g., to 5.1 or 5.8.0) is performed.

JIRA LINK: https://tyktech.atlassian.net/browse/TT-14666
<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Bug fix


___

### **Description**
- Prevents gateway panic when loading invalid OAS APIs after upgrade

- Adds nil check for `chainObj` in `loadHTTPService` function

- Returns error if attempting to import invalid API specification

- Improves robustness during direct upgrades from older versions


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>api_loader.go</strong><dd><code>Add nil check and error
return for invalid API spec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; </dd></summary>
<hr>

gateway/api_loader.go

<li>Adds a nil check for <code>chainObj</code> after processing API
spec<br> <li> Returns an error if <code>chainObj</code> is nil,
preventing panic<br> <li> Logs the invalid API import attempt with API
ID


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7034/files#diff-cdf0b7f176c9d18e1a314b78ddefc2cb3a94b3de66f1f360174692c915734c68">+4/-0</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary> Need help?</summary><li>Type <code>/help how to
...</code> in the comments thread for any questions about PR-Agent
usage.</li><li>Check out the <a
href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a>
for more information.</li></details>

[TT-14666]: https://tyktech.atlassian.net/browse/TT-14666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Prevents gateway panic when loading invalid OAS APIs after upgrade

- Adds nil check and error return in `loadHTTPService`

- Introduces regression test for legacy OAS migration scenario

- Implements mock session and health checker types for testing


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api_loader.go</strong><dd><code>Add nil check and error return for invalid API spec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_loader.go

<li>Adds a nil check for <code>chainObj</code> after processing API spec<br> <li> Returns an error if <code>chainObj</code> is nil, preventing panic


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7039/files#diff-cdf0b7f176c9d18e1a314b78ddefc2cb3a94b3de66f1f360174692c915734c68">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api_loader_test.go</strong><dd><code>Add regression test for legacy OAS migration and mocks</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_loader_test.go

<li>Adds regression test for legacy OAS API migration<br> <li> Implements mock session handler and health checker types for test<br> <li> Verifies error is returned when importing invalid legacy OAS API


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7039/files#diff-f696545a659f4d96421b253edef4bcc8da0e7f52120b8f8866d32cbbb7cc1afc">+94/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>