### PR TITLE
[TT-13779] POST form parameters are not logged for Tyk OAS APIs

### DIFF
--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -1101,7 +1101,8 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 	deepCopyErr := deepCopyBody(req, outreq)
 	if deepCopyErr != nil {
 		p.logger.Debug("Unable to create deep copy of request, err: ", deepCopyErr)
-		p.ErrorHandler.HandleError(rw, logreq, "Service temporarily unavailable.", 503, true)
+		p.ErrorHandler.HandleError(rw, logreq, "There was a problem with reading Body of the Request.",
+			http.StatusInternalServerError, true)
 		return ProxyResponse{}
 	}
 

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -1873,7 +1873,7 @@ func nopCloseResponseBody(r *http.Response) {
 
 // Creates a deep copy of source request.Body and replaces target request.Body with it.
 func deepCopyBody(source *http.Request, target *http.Request) error {
-	if source.Body == nil || source.ContentLength == -1 {
+	if source == nil || target == nil || source.Body == nil || source.ContentLength == -1 {
 		return nil
 	}
 

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -2130,7 +2130,7 @@ type MockErrorReader struct {
 	ReturnError error
 }
 
-func (e *MockErrorReader) Read(p []byte) (n int, err error) {
+func (e *MockErrorReader) Read(_ []byte) (n int, err error) {
 	return 0, e.ReturnError
 }
 

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -2124,3 +2124,34 @@ func TestHelperSSEStreamClient(tb testing.TB, ts *Test, enableWebSockets bool) e
 	assert.Equal(tb, i, 5)
 	return nil
 }
+
+// MockErrorReader is a mock io.Reader that returns an error on Read
+type MockErrorReader struct {
+	ReturnError error
+}
+
+func (e *MockErrorReader) Read(p []byte) (n int, err error) {
+	return 0, e.ReturnError
+}
+
+type MockReadCloser struct {
+	Reader      io.Reader
+	CloseError  error
+	CloseCalled bool
+}
+
+func (m *MockReadCloser) Read(p []byte) (n int, err error) {
+	return m.Reader.Read(p)
+}
+
+func (m *MockReadCloser) Close() error {
+	m.CloseCalled = true
+
+	return m.CloseError
+}
+
+func createMockReadCloserWithError(err error) *MockReadCloser {
+	return &MockReadCloser{
+		Reader: &MockErrorReader{err},
+	}
+}


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-13779" title="TT-13779" target="_blank">TT-13779</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>POST form parameters are not logged for Tyk OAS APIs</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20Commercial_candidate_rel4-2025%20ORDER%20BY%20created%20DESC" title="Commercial_candidate_rel4-2025">Commercial_candidate_rel4-2025</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20codilime_refined%20ORDER%20BY%20created%20DESC" title="codilime_refined">codilime_refined</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20customer_bug%20ORDER%20BY%20created%20DESC" title="customer_bug">customer_bug</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20jira_escalated%20ORDER%20BY%20created%20DESC" title="jira_escalated">jira_escalated</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

## Description
When a request with Content-Type "application/x-www-form-urlencoded" is processed by Tyk, the form data (message body) is not included in the analytics logs sent to the pump. The request headers, including Content-Length (which reflects the form data's length), are properly logged, but the actual form data is missing from the message body in the logs.

This issue affects the completeness of analytics data for API endpoints that receive form data submissions, making it difficult for users to debug or audit these requests.

## Related Issue

## Motivation and Context

## How This Has Been Tested

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [x] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes deep copying of request body for outgoing requests

- Adds error handling for deep copy failures

- Ensures POST form parameters are logged for OAS APIs

- Updates request body management in reverse proxy handler


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reverse_proxy.go</strong><dd><code>Add deep copy of request body and error handling in reverse proxy</code></dd></summary>
<hr>

gateway/reverse_proxy.go

<li>Implements deepCopyBody to clone request bodies for proxying and <br>logging<br> <li> Integrates deep copy logic into WrappedServeHTTP with error handling<br> <li> Ensures both outgoing and logging requests have correct body content<br> <li> Adds debug logging and error response for deep copy failures


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7054/files#diff-e6e07722257f7e41691e471185ad6d84fd56dc9e5459526ea32e9a5e8fa1a01b">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>