### PR TITLE
[TT-14252] Add customValidationRule interface to generate_bento_config_schema script

### DIFF
--- a/apidef/streams/bento/schema/bento-config-schema.json
+++ b/apidef/streams/bento/schema/bento-config-schema.json
@@ -1838,7 +1838,8 @@
               "type": "object"
             },
             "url": {
-              "type": "string"
+              "type": "string",
+              "format": "uri"
             },
             "verb": {
               "type": "string"
@@ -2809,7 +2810,8 @@
               "type": "object"
             },
             "url": {
-              "type": "string"
+              "type": "string",
+              "format": "uri"
             },
             "verb": {
               "type": "string"

--- a/apidef/streams/bento/schema/generate_bento_config_schema.go
+++ b/apidef/streams/bento/schema/generate_bento_config_schema.go
@@ -332,11 +332,7 @@ func main() {
 		return
 	}
 
-	customRules := []customValidationRule{
-		&addURIFormatToHTTPClient{},
-	}
-
-	if err := generateBentoConfigSchema(args.output, customRules); err != nil {
+	if err := generateBentoConfigSchema(args.output, []customValidationRule{&addURIFormatToHTTPClient{}}); err != nil {
 		printErrorAndExit(err)
 	}
 	_, _ = fmt.Fprintf(os.Stdout, "Bento schema generated in '%s'\n", args.output)

--- a/apidef/streams/bento/schema/generate_bento_config_schema.go
+++ b/apidef/streams/bento/schema/generate_bento_config_schema.go
@@ -332,7 +332,7 @@ func main() {
 		return
 	}
 
-	if err := generateBentoConfigSchema(args.output, []customValidationRule{&addURIFormatToHTTPClient{}}); err != nil {
+	if err := generateBentoConfigSchema(args.output, []customValidationRule{&addURIFormatToHTTPClientRule{}}); err != nil {
 		printErrorAndExit(err)
 	}
 	_, _ = fmt.Fprintf(os.Stdout, "Bento schema generated in '%s'\n", args.output)
@@ -340,14 +340,16 @@ func main() {
 
 // Custom rules defined here
 
-// addURIFormatToHTTPClient represents a custom rule for adding URI format validation to HTTP client URL properties in a schema.
-type addURIFormatToHTTPClient struct{}
+// addURIFormatToHTTPClientRule represents a custom rule for adding URI format validation to HTTP client URL properties in a schema.
+type addURIFormatToHTTPClientRule struct{}
 
-func (a *addURIFormatToHTTPClient) Name() string {
+var _ customValidationRule = (*addURIFormatToHTTPClientRule)(nil)
+
+func (a *addURIFormatToHTTPClientRule) Name() string {
 	return "add_uri_format_to_http_client"
 }
 
-func (a *addURIFormatToHTTPClient) Apply(input []byte) ([]byte, error) {
+func (a *addURIFormatToHTTPClientRule) Apply(input []byte) ([]byte, error) {
 	for _, kind := range []string{"input", "output"} {
 		data, dataType, _, err := jsonparser.Get(input, "definitions", kind, "properties", "http_client", "properties", "url")
 		if err != nil {
@@ -369,5 +371,3 @@ func (a *addURIFormatToHTTPClient) Apply(input []byte) ([]byte, error) {
 	}
 	return input, nil
 }
-
-var _ customValidationRule = (*addURIFormatToHTTPClient)(nil)

--- a/apidef/streams/bento/schema/generate_bento_config_schema.go
+++ b/apidef/streams/bento/schema/generate_bento_config_schema.go
@@ -349,6 +349,14 @@ func (a *addURIFormatToHTTPClientRule) Name() string {
 	return "add_uri_format_to_http_client"
 }
 
+func (a *addURIFormatToHTTPClientRule) setModifiedURLSection(input, data []byte, keys ...string) ([]byte, error) {
+	data, err := jsonparser.Set(data, []byte("\"uri\""), "format")
+	if err != nil {
+		return nil, err
+	}
+	return jsonparser.Set(input, data, keys...)
+}
+
 func (a *addURIFormatToHTTPClientRule) Apply(input []byte) ([]byte, error) {
 	for _, kind := range []string{"input", "output"} {
 		data, dataType, _, err := jsonparser.Get(input, "definitions", kind, "properties", "http_client", "properties", "url")
@@ -359,12 +367,7 @@ func (a *addURIFormatToHTTPClientRule) Apply(input []byte) ([]byte, error) {
 			return nil, fmt.Errorf("error while applying %s rule, URL property is not an object", a.Name())
 		}
 
-		data, err = jsonparser.Set(data, []byte("\"uri\""), "format")
-		if err != nil {
-			return nil, fmt.Errorf("error while applying %s rule, setting URL format returned: %w", a.Name(), err)
-		}
-
-		input, err = jsonparser.Set(input, data, "definitions", kind, "properties", "http_client", "properties", "url")
+		input, err = a.setModifiedURLSection(input, data, "definitions", kind, "properties", "http_client", "properties", "url")
 		if err != nil {
 			return nil, fmt.Errorf("error while applying %s rule, setting URL property returned: %w", a.Name(), err)
 		}

--- a/apidef/streams/bento/schema/generate_bento_config_schema_test.go
+++ b/apidef/streams/bento/schema/generate_bento_config_schema_test.go
@@ -65,3 +65,25 @@ func TestAddURIFormatToHTTPClient(t *testing.T) {
 		require.Equal(t, "uri", string(data))
 	}
 }
+
+func TestAddURIFormatToHTTPClient_Malformed_input(t *testing.T) {
+	rule := &addURIFormatToHTTPClient{}
+
+	t.Run("Key path not found", func(t *testing.T) {
+		_, err := rule.Apply([]byte(`{}`))
+		require.Errorf(t, err, "error while applying add_uri_format_to_http_client rule, getting URL property returned: Key path not found")
+	})
+
+	t.Run(" Unknown value type", func(t *testing.T) {
+		var err error
+		input := []byte(`{}`)
+		for _, kind := range []string{"input", "output"} {
+			// Value type must be an object.
+			input, err = jsonparser.Set(input, []byte("some-string"), "definitions", kind, "properties", "http_client", "properties", "url")
+			require.NoError(t, err)
+		}
+
+		_, err = rule.Apply(input)
+		require.Errorf(t, err, "error while applying add_uri_format_to_http_client rule, getting URL property returned: Unknown value type")
+	})
+}

--- a/apidef/streams/bento/schema/generate_bento_config_schema_test.go
+++ b/apidef/streams/bento/schema/generate_bento_config_schema_test.go
@@ -99,4 +99,11 @@ func TestAddURIFormatToHTTPClient_Malformed_input(t *testing.T) {
 		_, err = rule.Apply(input)
 		require.ErrorContains(t, err, "error while applying add_uri_format_to_http_client rule, URL property is not an object")
 	})
+
+	t.Run("Malformed url object", func(t *testing.T) {
+		input := []byte(`{}`)
+		data := "some-string"
+		_, err := rule.setModifiedURLSection(input, []byte(data), "some", "path")
+		require.ErrorIs(t, err, jsonparser.KeyPathNotFoundError)
+	})
 }

--- a/docs/dev/how-to-generate-bento-config-validation-schema.md
+++ b/docs/dev/how-to-generate-bento-config-validation-schema.md
@@ -43,3 +43,29 @@ See the list of components: https://github.com/warpstreamlabs/bento/tree/main/pu
 
 Importing all components was not preferred because it results in generating a gigantic JSON schema, and it’s too hard to 
 navigate in that file and debug possible issues. 
+
+## How to add a new validator rule
+
+A validator rule has been defined by a simple interface:
+
+```go
+// customValidationRule is an interface for defining custom validation rules for JSON schemas.
+type customValidationRule interface {
+	// Name returns the name of the validation rule.
+	Name() string
+
+	// Apply applies the validation rule to the provided input data and
+	// returns the processed data or an error if validation fails.
+	Apply(input []byte) ([]byte, error)
+}
+```
+
+`Apply` method takes the input and returns the processed input by the validator rule implementation. 
+
+You can add rules to the pipeline like the following, `generateBentoConfigSchema` will take a list of rules and apply them respectively.
+
+```go
+err = generateBentoConfigSchema(args.output, []customValidationRule{
+	&addURIFormatToHTTPClientRule{}
+})
+```


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-14252" title="TT-14252" target="_blank">TT-14252</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Once the gateway starts producing  "unsupported protocol scheme" errors about streams APIs it never stops</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20customer_bug%20ORDER%20BY%20created%20DESC" title="customer_bug">customer_bug</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

PR for https://tyktech.atlassian.net/browse/TT-14252

This PR adds a new interface to `generate_bento_config_schema` script to add custom rules to schema generation process. By this way, adding new rules will be easy and not requires hacky if-else blocks in the schema generation code.

The first rule is `add_uri_format_to_http_client`, it adds `format: uri` to url object of `http_client` schema.

After adding `format: uri` to the `url` object, the validator checks the url format and the API returns the following error:

```
default_stream: input.http_client.url: Does not match format 'uri' output.http_client.url: Does not match format 'uri'
```

It's still possible to reproduce the bug because API creation page of the Dashboard uses OAS APIs to create Tyk Stream APIs, the frontend code should be improved to use Tyk Stream APIs. A followup ticket will be created for this improvement.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduced `customValidationRule` interface for schema customization.

- Added `addURIFormatToHTTPClient` rule to enforce URI format on HTTP client URLs.

- Updated schema generation logic to apply custom rules.

- Added tests for the new custom validation rule mechanism.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generate_bento_config_schema.go</strong><dd><code>Add custom validation rule interface and URI format rule</code>&nbsp; </dd></summary>
<hr>

apidef/streams/bento/schema/generate_bento_config_schema.go

<li>Introduced <code>customValidationRule</code> interface for schema rules.<br> <li> Implemented <code>addURIFormatToHTTPClient</code> rule to set <code>format: uri</code> on HTTP <br>client URLs.<br> <li> Modified schema generation to apply custom rules.<br> <li> Refactored main function to use new rule system.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7057/files#diff-6df17fac938f7b6fc05640fdfefd4315887362243e6130b53aec9563d12c84c5">+57/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bento-config-schema.json</strong><dd><code>Enforce URI format on HTTP client URL in schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/streams/bento/schema/bento-config-schema.json

<li>Added <code>"format": "uri"</code> to HTTP client <code>url</code> properties in both input and <br>output schemas.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7057/files#diff-4b2f0593b81d1e09f7c731419b226631c3a77fa117d573fcb47912f0d6024b02">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generate_bento_config_schema_test.go</strong><dd><code>Add and update tests for custom validation rules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/streams/bento/schema/generate_bento_config_schema_test.go

<li>Updated tests to use new rule interface.<br> <li> Added test for <code>addURIFormatToHTTPClient</code> rule.<br> <li> Verified <code>format: uri</code> is set for HTTP client URLs.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7057/files#diff-6d36a7643c6cc8915692734ac9bb3e39e76c6dfa5d82a1a93cff0883b169185d">+30/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>