### PR TITLE
Merging to release-5.8: [TT-13779] POST form parameters are not logged for Tyk OAS APIs (#7054)

### DIFF
--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -1097,6 +1097,15 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 
 	*outreq = *req // includes shallow copies of maps, but okay
 	*logreq = *req
+
+	deepCopyErr := deepCopyBody(req, outreq)
+	if deepCopyErr != nil {
+		p.logger.Debug("Unable to create deep copy of request, err: ", deepCopyErr)
+		p.ErrorHandler.HandleError(rw, logreq, "There was a problem with reading Body of the Request.",
+			http.StatusInternalServerError, true)
+		return ProxyResponse{}
+	}
+
 	// remove context data from the copies
 	setContext(outreq, context.Background())
 	setContext(logreq, context.Background())
@@ -1861,6 +1870,28 @@ func nopCloseResponseBody(r *http.Response) {
 	}
 
 	copyResponse(r)
+}
+
+// Creates a deep copy of source request.Body and replaces target request.Body with it.
+func deepCopyBody(source *http.Request, target *http.Request) error {
+	if source == nil || target == nil || source.Body == nil || source.ContentLength == -1 {
+		return nil
+	}
+
+	bodyBytes, err := io.ReadAll(source.Body)
+	defer func() {
+		source.Body.Close()
+		source.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+		nopCloseRequestBody(source)
+	}()
+	if err != nil {
+		return err
+	}
+
+	target.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+	nopCloseRequestBody(target)
+
+	return nil
 }
 
 // IsUpgrade will return the upgrade header value and true if present for the request.

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -377,6 +377,14 @@ func (s *Test) TestNewWrappedServeHTTP() *ReverseProxy {
 	return s.Gw.TykNewSingleHostReverseProxy(target, spec, nil)
 }
 
+func createReverseProxyAndServeHTTP(ts *Test, req *http.Request) (*httptest.ResponseRecorder, ProxyResponse) {
+	proxy := ts.TestNewWrappedServeHTTP()
+	recorder := httptest.NewRecorder()
+	resp := proxy.WrappedServeHTTP(recorder, req, false)
+
+	return recorder, resp
+}
+
 func TestWrappedServeHTTP(t *testing.T) {
 	idleConnTimeout = 1
 
@@ -384,15 +392,23 @@ func TestWrappedServeHTTP(t *testing.T) {
 	defer ts.Close()
 
 	for i := 0; i < 10; i++ {
-		proxy := ts.TestNewWrappedServeHTTP()
-		recorder := httptest.NewRecorder()
-		req, _ := http.NewRequest(http.MethodGet, "/", nil)
-		proxy.WrappedServeHTTP(recorder, req, false)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		_, _ = createReverseProxyAndServeHTTP(ts, req)
 	}
 
 	assert.Equal(t, 10, ts.Gw.ConnectionWatcher.Count())
 	time.Sleep(time.Second * 2)
 	assert.Equal(t, 0, ts.Gw.ConnectionWatcher.Count())
+
+	// Test error on deepCopyBody function
+	mockReadCloser := createMockReadCloserWithError(errors.New("test error"))
+	req := httptest.NewRequest(http.MethodPost, "/test", mockReadCloser)
+	// Set any ContentLength - httptest.NewRequest sets it only for bytes.Buffer, bytes.Reader and strings.Reader
+	req.ContentLength = 1
+	recorder, proxyResponse := createReverseProxyAndServeHTTP(ts, req)
+	assert.NotNil(t, proxyResponse, "error on deepCopyBody should return an empty ProxyResponse")
+	assert.Nil(t, proxyResponse.Response, "no response should be expected on error")
+	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
 }
 
 func TestCircuitBreaker5xxs(t *testing.T) {
@@ -861,6 +877,44 @@ func TestNopCloseResponseBody(t *testing.T) {
 			t.Error("3rd read, body's data is not as expectd")
 		}
 	}
+}
+
+func TestDeepCopyBody(t *testing.T) {
+	var src *http.Request
+	var trg *http.Request
+	assert.Nil(t, deepCopyBody(src, trg), "nil requests should remain nil without any error")
+
+	src = &http.Request{}
+	trg = &http.Request{}
+	assert.Nil(t, deepCopyBody(src, trg), "nil source request body should return without any error")
+
+	testData := []byte("testDeepCopy")
+	src = httptest.NewRequest(http.MethodPost, "/test", bytes.NewReader(testData))
+	src.ContentLength = -1
+	assert.Nil(t, deepCopyBody(src, trg),
+		"source request with ContentLength == -1 should return without any error")
+	assert.Nil(t, trg.Body, "target request body should not be updated when ContentLength == -1")
+
+	src = httptest.NewRequest(http.MethodPost, "/test", bytes.NewReader(testData))
+	assert.Nil(t, deepCopyBody(src, trg), "request with body should return without any error")
+	assert.NotNil(t, trg.Body, "target request body should be updated")
+	assert.True(t, src.Body != trg.Body, "target request should have different body than source request")
+
+	trgData, err := io.ReadAll(trg.Body)
+	assert.Nil(t, err, "target request body should be readable")
+	assert.Equal(t, testData, trgData, "target request body should contain the same data")
+
+	mockReadCloser := createMockReadCloserWithError(errors.New("test error"))
+	src = httptest.NewRequest(http.MethodPost, "/test", mockReadCloser)
+	// Set any ContentLength - httptest.NewRequest sets it only for bytes.Buffer, bytes.Reader and strings.Reader
+	src.ContentLength = int64(len(testData))
+	trg = &http.Request{}
+	err = deepCopyBody(src, trg)
+	assert.NotNil(t, err, "function should return an error when ReadAll fails")
+	assert.Nil(t, trg.Body, "target request body should not be updated when ReadAll fails")
+	assert.True(t, mockReadCloser.CloseCalled, "close function should have been called")
+	_, ok := src.Body.(*nopCloserBuffer)
+	assert.True(t, ok, "target request body should have been of type nopCloserBuffer")
 }
 
 func BenchmarkGraphqlUDG(b *testing.B) {

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -2124,3 +2124,34 @@ func TestHelperSSEStreamClient(tb testing.TB, ts *Test, enableWebSockets bool) e
 	assert.Equal(tb, i, 5)
 	return nil
 }
+
+// MockErrorReader is a mock io.Reader that returns an error on Read
+type MockErrorReader struct {
+	ReturnError error
+}
+
+func (e *MockErrorReader) Read(_ []byte) (n int, err error) {
+	return 0, e.ReturnError
+}
+
+type MockReadCloser struct {
+	Reader      io.Reader
+	CloseError  error
+	CloseCalled bool
+}
+
+func (m *MockReadCloser) Read(p []byte) (n int, err error) {
+	return m.Reader.Read(p)
+}
+
+func (m *MockReadCloser) Close() error {
+	m.CloseCalled = true
+
+	return m.CloseError
+}
+
+func createMockReadCloserWithError(err error) *MockReadCloser {
+	return &MockReadCloser{
+		Reader: &MockErrorReader{err},
+	}
+}


### PR DESCRIPTION
### **User description**
[TT-13779] POST form parameters are not logged for Tyk OAS APIs (#7054)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-13779"
title="TT-13779" target="_blank">TT-13779</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>POST form parameters are not logged for Tyk OAS APIs</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20Commercial_candidate_rel4-2025%20ORDER%20BY%20created%20DESC"
title="Commercial_candidate_rel4-2025">Commercial_candidate_rel4-2025</a>,
<a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20codilime_refined%20ORDER%20BY%20created%20DESC"
title="codilime_refined">codilime_refined</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20customer_bug%20ORDER%20BY%20created%20DESC"
title="customer_bug">customer_bug</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20jira_escalated%20ORDER%20BY%20created%20DESC"
title="jira_escalated">jira_escalated</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

## Description
When a request with Content-Type "application/x-www-form-urlencoded" is
processed by Tyk, the form data (message body) is not included in the
analytics logs sent to the pump. The request headers, including
Content-Length (which reflects the form data's length), are properly
logged, but the actual form data is missing from the message body in the
logs.

This issue affects the completeness of analytics data for API endpoints
that receive form data submissions, making it difficult for users to
debug or audit these requests.

## Related Issue

## Motivation and Context

## How This Has Been Tested

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [x] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes deep copying of request body for outgoing requests

- Adds error handling for deep copy failures

- Ensures POST form parameters are logged for OAS APIs

- Updates request body management in reverse proxy handler


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>reverse_proxy.go</strong><dd><code>Add deep copy of
request body and error handling in reverse proxy</code></dd></summary>
<hr>

gateway/reverse_proxy.go

<li>Implements deepCopyBody to clone request bodies for proxying and
<br>logging<br> <li> Integrates deep copy logic into WrappedServeHTTP
with error handling<br> <li> Ensures both outgoing and logging requests
have correct body content<br> <li> Adds debug logging and error response
for deep copy failures


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7054/files#diff-e6e07722257f7e41691e471185ad6d84fd56dc9e5459526ea32e9a5e8fa1a01b">+31/-0</a>&nbsp;
&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary> Need help?</summary><li>Type <code>/help how to
...</code> in the comments thread for any questions about PR-Agent
usage.</li><li>Check out the <a
href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a>
for more information.</li></details>

[TT-13779]: https://tyktech.atlassian.net/browse/TT-13779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixes logging of POST form parameters for OAS APIs

- Adds deep copy logic for request bodies in reverse proxy

- Implements error handling for deep copy failures

- Adds and extends tests for deep copy and error scenarios


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reverse_proxy.go</strong><dd><code>Add deep copy and error handling for request bodies in reverse proxy</code></dd></summary>
<hr>

gateway/reverse_proxy.go

<li>Adds deepCopyBody function to clone request bodies for <br>outgoing/logging<br> <li> Integrates deep copy and error handling into WrappedServeHTTP<br> <li> Adds debug logging and error response for deep copy failures


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7059/files#diff-e6e07722257f7e41691e471185ad6d84fd56dc9e5459526ea32e9a5e8fa1a01b">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reverse_proxy_test.go</strong><dd><code>Add and extend tests for deepCopyBody and error handling</code>&nbsp; </dd></summary>
<hr>

gateway/reverse_proxy_test.go

<li>Adds tests for deepCopyBody function, including error scenarios<br> <li> Refactors and extends WrappedServeHTTP tests for error handling<br> <li> Verifies correct status codes and response on deep copy errors


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7059/files#diff-ce040f6555143f760fba6059744bc600b6954f0966dfb0fa2832b5eabf7a3c3f">+58/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>testutil.go</strong><dd><code>Add test utilities for mocking request body errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/testutil.go

<li>Adds MockErrorReader and MockReadCloser for simulating read/close <br>errors<br> <li> Adds helper to create mock read closers with errors for testing


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7059/files#diff-7aaf6ae49fb8f58a8c99d337fedd15b3e430dd928ed547e425ef429b10d28ce8">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>