### PR TITLE
Merging to release-5.8: [TT-14868] Request Body Not Recorded When Transfer-Encoding: chunked (#7061)

### DIFF
--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -1874,7 +1874,7 @@ func nopCloseResponseBody(r *http.Response) {
 
 // Creates a deep copy of source request.Body and replaces target request.Body with it.
 func deepCopyBody(source *http.Request, target *http.Request) error {
-	if source == nil || target == nil || source.Body == nil || source.ContentLength == -1 {
+	if source == nil || target == nil || source.Body == nil || httputil.IsStreamingRequest(source) {
 		return nil
 	}
 

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -891,9 +891,15 @@ func TestDeepCopyBody(t *testing.T) {
 	testData := []byte("testDeepCopy")
 	src = httptest.NewRequest(http.MethodPost, "/test", bytes.NewReader(testData))
 	src.ContentLength = -1
+	src.Header.Set("Content-Type", "application/grpc")
 	assert.Nil(t, deepCopyBody(src, trg),
-		"source request with ContentLength == -1 should return without any error")
-	assert.Nil(t, trg.Body, "target request body should not be updated when ContentLength == -1")
+		"grpc request should return without any error")
+	assert.Nil(t, trg.Body, "target request body should not be updated when it is grpc request")
+
+	src.Header.Set("Connection", "Upgrade")
+	assert.Nil(t, deepCopyBody(src, trg),
+		"upgraded request should return without any error")
+	assert.Nil(t, trg.Body, "target request body should not be updated when it is upgrade request")
 
 	src = httptest.NewRequest(http.MethodPost, "/test", bytes.NewReader(testData))
 	assert.Nil(t, deepCopyBody(src, trg), "request with body should return without any error")


### PR DESCRIPTION
### **User description**
[TT-14868] Request Body Not Recorded When Transfer-Encoding: chunked (#7061)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-14868"
title="TT-14868" target="_blank">TT-14868</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Request Body Not Recorded When Transfer-Encoding: chunked</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20codilime_refined%20ORDER%20BY%20created%20DESC"
title="codilime_refined">codilime_refined</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20customer_bug%20ORDER%20BY%20created%20DESC"
title="customer_bug">customer_bug</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20jira_escalated%20ORDER%20BY%20created%20DESC"
title="jira_escalated">jira_escalated</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

The request body is not captured in the analytics record if the request
uses Transfer-Encoding: chunked. This affects both Classic and OAS APIs.

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixes request body logging for chunked Transfer-Encoding requests

- Updates deepCopyBody to handle streaming requests correctly

- Expands unit tests for deepCopyBody with streaming scenarios

- Ensures grpc and upgrade requests are excluded from body copying


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>reverse_proxy.go</strong><dd><code>Fix deepCopyBody to
handle streaming and chunked requests</code></dd></summary>
<hr>

gateway/reverse_proxy.go

<li>Updates deepCopyBody to skip streaming requests using
<br>httputil.IsStreamingRequest<br> <li> Prevents body copying for
chunked, grpc, and upgrade requests


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7061/files#diff-e6e07722257f7e41691e471185ad6d84fd56dc9e5459526ea32e9a5e8fa1a01b">+1/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>reverse_proxy_test.go</strong><dd><code>Expand
deepCopyBody tests for streaming and grpc
scenarios</code></dd></summary>
<hr>

gateway/reverse_proxy_test.go

<li>Adds tests for grpc and upgrade request handling in deepCopyBody<br>
<li> Verifies that target body is not updated for streaming requests<br>
<li> Ensures correct behavior for non-streaming requests


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7061/files#diff-ce040f6555143f760fba6059744bc600b6954f0966dfb0fa2832b5eabf7a3c3f">+8/-2</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary> Need help?</summary><li>Type <code>/help how to
...</code> in the comments thread for any questions about PR-Agent
usage.</li><li>Check out the <a
href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a>
for more information.</li></details>

[TT-14868]: https://tyktech.atlassian.net/browse/TT-14868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixes request body copying for chunked and streaming requests

- Updates deepCopyBody to skip grpc and upgrade requests

- Expands unit tests for deepCopyBody with streaming scenarios

- Ensures target request body remains unchanged for excluded cases


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reverse_proxy.go</strong><dd><code>Fix deepCopyBody to handle streaming and chunked requests</code></dd></summary>
<hr>

gateway/reverse_proxy.go

<li>Updates deepCopyBody to use httputil.IsStreamingRequest for exclusion<br> <li> Prevents body copying for streaming, grpc, and upgrade requests


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7062/files#diff-e6e07722257f7e41691e471185ad6d84fd56dc9e5459526ea32e9a5e8fa1a01b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reverse_proxy_test.go</strong><dd><code>Expand deepCopyBody tests for streaming and grpc scenarios</code></dd></summary>
<hr>

gateway/reverse_proxy_test.go

<li>Adds tests for grpc and upgrade request handling in deepCopyBody<br> <li> Verifies target body is not updated for streaming/grpc/upgrade <br>requests<br> <li> Ensures correct behavior for non-streaming requests


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7062/files#diff-ce040f6555143f760fba6059744bc600b6954f0966dfb0fa2832b5eabf7a3c3f">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>