### PR TITLE
Tyk OAS API definition is not available to Response Plugin if no Request Plugin loaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,10 @@
 .vagrant/
 .venv/
 .vscode/
+.air.toml
 coverage/
 temp/
+/tmp
 /middleware/bundles
 testapps/
 

--- a/goplugin/mw_go_plugin_test.go
+++ b/goplugin/mw_go_plugin_test.go
@@ -578,7 +578,7 @@ func TestGoPlugin_MyResponsePluginAccessingOASAPI(t *testing.T) {
 		ts.Gw.BuildAndLoadAPI(func(spec *gateway.APISpec) {
 			spec.IsOAS = true
 			spec.OAS = oasDoc
-			spec.Proxy.ListenPath = "/goplugin/stanalone_response_plugin"
+			spec.Proxy.ListenPath = "/goplugin/standalone_response_plugin"
 			spec.UseKeylessAccess = true
 			spec.UseStandardAuth = false
 			spec.UseGoPluginAuth = false
@@ -595,7 +595,7 @@ func TestGoPlugin_MyResponsePluginAccessingOASAPI(t *testing.T) {
 
 		ts.Run(t, []test.TestCase{
 			{
-				Path: "/goplugin/stanalone_response_plugin/plugin_hit",
+				Path: "/goplugin/standalone_response_plugin/plugin_hit",
 				Code: http.StatusOK,
 				HeadersMatch: map[string]string{
 					"X-OAS-Doc-Title": oasDoc.Info.Title,

--- a/goplugin/mw_go_plugin_test.go
+++ b/goplugin/mw_go_plugin_test.go
@@ -5,7 +5,6 @@ package goplugin_test
 
 import (
 	"context"
-	"github.com/TykTechnologies/tyk/internal/maps"
 	"net/http"
 	"testing"
 
@@ -598,9 +597,9 @@ func TestGoPlugin_MyResponsePluginAccessingOASAPI(t *testing.T) {
 			{
 				Path: "/goplugin/stanalone_response_plugin/plugin_hit",
 				Code: http.StatusOK,
-				HeadersMatch: maps.New(
-					maps.WithEntry("X-OAS-Doc-Title", oasDoc.Info.Title),
-				),
+				HeadersMatch: map[string]string{
+					"X-OAS-Doc-Title": oasDoc.Info.Title,
+				},
 			},
 		}...)
 	})

--- a/test/goplugins/test_goplugin.go
+++ b/test/goplugins/test_goplugin.go
@@ -16,10 +16,6 @@ import (
 	"github.com/TykTechnologies/tyk/user"
 )
 
-const (
-	XOASDocTitle = "X-OAS-Doc-Title"
-)
-
 // MyPluginPre checks if session is NOT present, adds custom header
 // with initial URI path and will be used as "pre" custom MW
 func MyPluginPre(rw http.ResponseWriter, r *http.Request) {
@@ -200,13 +196,22 @@ func MyAnalyticsPluginMaskJSONLoginBody(record *analytics.AnalyticsRecord) {
 
 func MyPluginAccessingOASAPI(rw http.ResponseWriter, r *http.Request) {
 	oas := ctx.GetOASDefinition(r)
-	rw.Header().Add(XOASDocTitle, oas.Info.Title)
+	rw.Header().Add("X-OAS-Doc-Title", oas.Info.Title)
+	rw.Header().Add("X-My-Plugin-Accessing-OAS-API", oas.Info.Title)
 }
 
-// MyResponsePluginAccessingOASAPI fake
+// MyResponsePluginAccessingOASAPI fake plugin which modifies data
 func MyResponsePluginAccessingOASAPI(rw http.ResponseWriter, _ *http.Response, req *http.Request) {
 	oas := ctx.GetOASDefinition(req)
-	rw.Header().Add(XOASDocTitle, oas.Info.Title)
+	rw.Header().Add("X-OAS-Doc-Title", oas.Info.Title)
+	rw.Header().Add("X-My-Response-Plugin-Accessing-OAS-API", oas.Info.Title)
+}
+
+// MyResponsePluginAccessingOASAPI2 fake plugin which modifies headers
+func MyResponsePluginAccessingOASAPI2(rw http.ResponseWriter, _ *http.Response, req *http.Request) {
+	oas := ctx.GetOASDefinition(req)
+	rw.Header().Add("X-OAS-Doc-Title", oas.Info.Title)
+	rw.Header().Add("X-My-Response-Plugin-Accessing-OAS-API-2", oas.Info.Title)
 }
 
 func MyPluginReturningError(rw http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
### **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description
Couple of tests were added to meet acceptance criteria

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Tests


___

### **Description**
- Added acceptance tests for Go-plugin OAS API access in response plugins

- Tested standalone, chained, and combined request/response plugin scenarios

- Enhanced test plugins to set additional headers for OAS API info

- Implemented new response plugin for chained middleware validation


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mw_go_plugin_test.go</strong><dd><code>Add acceptance tests for Go-plugin OAS API in response plugins</code></dd></summary>
<hr>

goplugin/mw_go_plugin_test.go

<li>Added three new subtests for Go-plugin OAS API access in response <br>plugins<br> <li> Tested standalone response plugin, chained response plugins, and <br>combined request/response plugins<br> <li> Validated correct OAS API info propagation via custom headers<br> <li> Updated test paths and header assertions for new scenarios


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7064/files#diff-0ad6c75c29b2656d9d5cfa9108d32a3b242c339c1688ce168516ed213a5f482b">+92/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_goplugin.go</strong><dd><code>Enhance test plugins for OAS API header assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/goplugins/test_goplugin.go

<li>Removed unused XOASDocTitle constant<br> <li> Enhanced MyPluginAccessingOASAPI and MyResponsePluginAccessingOASAPI <br>to set extra headers<br> <li> Added new MyResponsePluginAccessingOASAPI2 for chained response plugin <br>testing


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7064/files#diff-6b57b162c0610abdd8c4edf02dab0718ef7daa1c986aeae2e13adf9904ec3459">+12/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>