### PR TITLE
Merging to release-5.8: [TT-14794][TT-14946] fix issue where an invalid stream path results in 500 (#7047)

### DIFF
--- a/ee/middleware/streams/middleware.go
+++ b/ee/middleware/streams/middleware.go
@@ -227,7 +227,8 @@ func (s *Middleware) processStreamsConfig(r *http.Request, streams map[string]an
 func (s *Middleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
 	strippedPath := s.Spec.StripListenPath(r.URL.Path)
 	if !s.defaultManager.hasPath(strippedPath) {
-		return nil, http.StatusOK
+		s.Logger().Debugf("Path not found: %s", strippedPath)
+		return errors.New("not found"), http.StatusNotFound
 	}
 
 	s.Logger().Debugf("Processing request: %s, %s", r.URL.Path, strippedPath)


### PR DESCRIPTION
### **User description**
[TT-14794] fix issue where an invalid stream path results in 500 (#7047)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-14794"
title="TT-14794" target="_blank">TT-14794</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
<td>Calling a wrong path on streams API returns `There was a problem
proxying the request`</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

This PR fixes an issue, where an invalid path would result in a 500
Internal Server Error without giving any feedback to the user.

Example:

SSE Output path on `/get/stream`.

When calling `/get/steam` would result in `500`.

Now it will respond with `404`.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix 500 error for invalid stream paths, return 404 instead

- Add tests for SSE output path error handling and success

- Implement test SSE client for streaming endpoint verification

- Improve debug logging for missing stream paths


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>middleware.go</strong><dd><code>Return 404 and log when
stream path is missing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ee/middleware/streams/middleware.go

<li>Return 404 Not Found with error for missing stream paths<br> <li>
Add debug log for unmatched stream paths


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7047/files#diff-0ce428c0f09dca65e3df6e72d01fee63b6f237785e41e6ecf0ce34a8b65c74a5">+2/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>mw_streaming_test.go</strong><dd><code>Add tests for
SSE output path error and success</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_streaming_test.go

<li>Add test to verify 404 for invalid SSE output paths<br> <li> Add
test for successful SSE connection and message receipt<br> <li>
Implement helper SSE client for testing streaming endpoints


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7047/files#diff-a0d1bd0196a741537a3c850e340225c8993e49d709c838af0f1b48b9893af1da">+148/-0</a>&nbsp;
</td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary> Need help?</summary><li>Type <code>/help how to
...</code> in the comments thread for any questions about PR-Agent
usage.</li><li>Check out the <a
href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a>
for more information.</li></details>

[TT-14794]: https://tyktech.atlassian.net/browse/TT-14794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Return 404 Not Found for invalid stream paths instead of 500.

- Add tests to verify SSE output path error handling and success.

- Implement a helper SSE client for streaming endpoint tests.

- Add debug logging for unmatched stream paths.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>middleware.go</strong><dd><code>Return 404 and log when stream path is missing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ee/middleware/streams/middleware.go

<li>Return 404 Not Found with error for missing stream paths.<br> <li> Add debug log for unmatched stream paths.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7078/files#diff-0ce428c0f09dca65e3df6e72d01fee63b6f237785e41e6ecf0ce34a8b65c74a5">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mw_streaming_test.go</strong><dd><code>Add tests for SSE output path error and success</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_streaming_test.go

<li>Add tests to verify 404 for invalid SSE output paths.<br> <li> Add test for successful SSE connection and message receipt.<br> <li> Implement helper SSE client for testing streaming endpoints.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7078/files#diff-a0d1bd0196a741537a3c850e340225c8993e49d709c838af0f1b48b9893af1da">+148/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>