### PR TITLE
Merging to release-5.8: [TT-11387] Unhelpful error messages in UI when creating APIs via OpenAPI import (#7080)

### DIFF
--- a/apidef/oas/default.go
+++ b/apidef/oas/default.go
@@ -25,7 +25,7 @@ var (
 	errEmptyServersObject  = errors.New("The ‘servers’ object is empty in your OAS. You can either add a ‘servers’ section to your OpenAPI description or provide a Custom Upstream URL in the manual configuration options below.")
 	errEmptySecurityObject = errors.New("The ‘security’ object is empty in your OAS. When enabling authentication, your OpenAPI description must include a ‘security’ object that defines the authentication schemes. You can either add a ‘security’ object or disable authentication in the API settings.")
 	errInvalidUpstreamURL  = errors.New("The manually configured upstream URL is not valid. The URL must be absolute and properly formatted (e.g. https://example.com). Please check the URL format and try again.")
-	errInvalidServerURL    = errors.New("The first entry in the ‘servers’ object of your OAS in not valid. The URL must be absolute and properly formatted (e.g. https://example.com).")
+	errInvalidServerURL    = errors.New("The first entry in the ‘servers’ object of your OAS is not valid. The URL must be absolute and properly formatted (e.g. https://example.com).")
 
 	allowedMethods = []string{
 		http.MethodConnect,
@@ -256,7 +256,7 @@ func getURLFormatErr(fromParam bool, upstreamURL string) error {
 		if fromParam {
 			return errInvalidUpstreamURL
 		}
-		return fmt.Errorf("%w: %s", errInvalidServerURL, fmt.Sprintf(invalidServerURLFmt, parsedURL))
+		return fmt.Errorf("%w %s", errInvalidServerURL, fmt.Sprintf(invalidServerURLFmt, parsedURL))
 	}
 
 	return nil


### PR DESCRIPTION
### **User description**
[TT-11387] Unhelpful error messages in UI when creating APIs via OpenAPI import (#7080)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-11387"
title="TT-11387" target="_blank">TT-11387</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
<td>Unhelpful error messages in UI when creating APIs via OpenAPI
import</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20QA_Fail%20ORDER%20BY%20created%20DESC"
title="QA_Fail">QA_Fail</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20codilime_refined%20ORDER%20BY%20created%20DESC"
title="codilime_refined">codilime_refined</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

Fixed typos in errInvalidServerURL error.

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [x] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Bug fix


___

### **Description**
- Corrected typo in `errInvalidServerURL` error message.

- Improved formatting of error message composition in `getURLFormatErr`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>default.go</strong><dd><code>Correct typo and improve
error message formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/default.go

<li>Fixed typo in <code>errInvalidServerURL</code> error message ("in
not valid" to "is <br>not valid").<br> <li> Adjusted error message
formatting in <code>getURLFormatErr</code> for clarity.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7080/files#diff-83c3a85bdd05785178ee519b05b1fe2008435dc4ae9448d72b080b5f67c491ad">+2/-2</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary> Need help?</summary><li>Type <code>/help how to
...</code> in the comments thread for any questions about PR-Agent
usage.</li><li>Check out the <a
href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a>
for more information.</li></details>

[TT-11387]: https://tyktech.atlassian.net/browse/TT-11387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed typo in `errInvalidServerURL` error message.

- Improved error message formatting in `getURLFormatErr`.

- Enhanced clarity of OpenAPI import error reporting.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>default.go</strong><dd><code>Fix typo and improve error formatting for server URL validation</code></dd></summary>
<hr>

apidef/oas/default.go

<li>Corrected typo in <code>errInvalidServerURL</code> ("in not valid" to "is not <br>valid").<br> <li> Improved formatting of error message composition in <code>getURLFormatErr</code>.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7081/files#diff-83c3a85bdd05785178ee519b05b1fe2008435dc4ae9448d72b080b5f67c491ad">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>