### PR TITLE
Merging to release-5.8: [TT-14252] Add customValidationRule interface to generate_bento_config_schema script (#7057)

### DIFF
--- a/apidef/streams/bento/schema/bento-v1.2.0-supported-schema.json
+++ b/apidef/streams/bento/schema/bento-v1.2.0-supported-schema.json
@@ -1486,7 +1486,40 @@
               },
               "type": "object"
             },
+<<<<<<< HEAD:apidef/streams/bento/schema/bento-v1.2.0-supported-schema.json
             {
+=======
+            "url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "verb": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "url"
+          ],
+          "type": "object"
+        },
+        "http_server": {
+          "additionalProperties": false,
+          "properties": {
+            "address": {
+              "type": "string"
+            },
+            "allowed_verbs": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "cert_file": {
+              "type": "string"
+            },
+            "cors": {
+              "additionalProperties": false,
+>>>>>>> 18f959848... [TT-14252] Add customValidationRule interface to generate_bento_config_schema script (#7057):apidef/streams/bento/schema/bento-config-schema.json
               "properties": {
                 "group_by": {
                   "items": {
@@ -2299,6 +2332,16 @@
                 }
               },
               "type": "object"
+<<<<<<< HEAD:apidef/streams/bento/schema/bento-v1.2.0-supported-schema.json
+=======
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "verb": {
+              "type": "string"
+>>>>>>> 18f959848... [TT-14252] Add customValidationRule interface to generate_bento_config_schema script (#7057):apidef/streams/bento/schema/bento-config-schema.json
             }
           ]
         },

--- a/apidef/streams/bento/schema/generate_bento_config_schema.go
+++ b/apidef/streams/bento/schema/generate_bento_config_schema.go
@@ -1,0 +1,376 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/buger/jsonparser"
+	_ "github.com/warpstreamlabs/bento/public/components/amqp09"
+	_ "github.com/warpstreamlabs/bento/public/components/amqp1"
+	_ "github.com/warpstreamlabs/bento/public/components/io"
+	_ "github.com/warpstreamlabs/bento/public/components/kafka"
+	_ "github.com/warpstreamlabs/bento/public/components/mqtt"
+	"github.com/warpstreamlabs/bento/public/service"
+)
+
+const defaultOutput = "bento-config-schema.json"
+
+// customValidationRule is an interface for defining custom validation rules for JSON schemas.
+type customValidationRule interface {
+	// Name returns the name of the validation rule.
+	Name() string
+
+	// Apply applies the validation rule to the provided input data and
+	// returns the processed data or an error if validation fails.
+	Apply(input []byte) ([]byte, error)
+}
+
+var result = []byte(`{}`)
+
+var properties = []string{
+	"http",
+	"input",
+	"input_resources",
+	"output",
+	"output_resources",
+	"processor_resources",
+	"shutdown_delay",
+	"shutdown_timeout",
+	"pipeline",
+}
+
+var definitions = []string{
+	"processor",
+	"scanner",
+}
+
+var supportedSources = []string{
+	"broker",
+	"http_client",
+	"http_server",
+	"kafka",
+	"amqp_0_9",
+	"amqp_1",
+	"mqtt",
+}
+
+func printErrorAndExit(err error) {
+	_, _ = fmt.Fprint(os.Stdout, err)
+	os.Exit(1)
+}
+
+func findTemplate(kind string, data []byte) ([]byte, error) {
+	kindData, _, _, err := jsonparser.Get(data, kind, "allOf")
+	if err != nil {
+		return nil, err
+	}
+
+	var template []byte
+	_, err = jsonparser.ArrayEach(kindData, func(value []byte, _ jsonparser.ValueType, _ int, _ error) {
+		_, _, _, getErr := jsonparser.Get(value, "properties")
+		if errors.Is(getErr, jsonparser.KeyPathNotFoundError) {
+			// continue
+			return
+		}
+		if getErr != nil {
+			printErrorAndExit(getErr)
+		}
+		template = value
+	})
+	return template, err
+}
+
+func scanProperties(data []byte) error {
+	return jsonparser.ObjectEach(data, func(key []byte, value []byte, _ jsonparser.ValueType, _ int) error {
+		var err error
+		for _, property := range properties {
+			if string(key) == property {
+				result, err = jsonparser.Set(result, value, "properties", property)
+				if err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
+}
+
+func insertDefinitions(data []byte) error {
+	for _, kind := range []string{"input", "output"} {
+		template, err := findTemplate(kind, data)
+		if err != nil {
+			return err
+		}
+		result, err = jsonparser.Set(result, template, "definitions", kind)
+		if err != nil {
+			return err
+		}
+
+		err = scanDefinitionsForKind(kind, data)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func scanDefinitions(data []byte) error {
+	err := jsonparser.ObjectEach(data, func(key []byte, value []byte, _ jsonparser.ValueType, _ int) error {
+		var err error
+		for _, definition := range definitions {
+			if string(key) == definition {
+				result, err = jsonparser.Set(result, value, "definitions", definition)
+				if err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return insertDefinitions(data)
+}
+
+func insertDefinitionKind(kind string, anyOfItems []byte) error {
+	_, err := jsonparser.ArrayEach(anyOfItems, func(value []byte, _ jsonparser.ValueType, _ int, _ error) {
+		for _, source := range supportedSources {
+			var data []byte
+			var jsonErr error
+			data, _, _, jsonErr = jsonparser.Get(value, "properties", source)
+			if errors.Is(jsonErr, jsonparser.KeyPathNotFoundError) {
+				continue
+			}
+			if jsonErr != nil {
+				printErrorAndExit(jsonErr)
+				return
+			}
+
+			result, jsonErr = jsonparser.Set(result, data, "definitions", kind, "properties", source)
+			if jsonErr != nil {
+				printErrorAndExit(jsonErr)
+				return
+			}
+		}
+	})
+	return err
+}
+
+func scanDefinitionsForKind(kind string, data []byte) error {
+	bentoInputs, dataType, _, err := jsonparser.Get(data, kind, "allOf")
+	if err != nil {
+		return err
+	}
+	if dataType != jsonparser.Array {
+		return fmt.Errorf("expected array but got %s", dataType)
+	}
+
+	_, err = jsonparser.ArrayEach(bentoInputs, func(value []byte, dataType jsonparser.ValueType, _ int, _ error) {
+		if dataType != jsonparser.Object {
+			return
+		}
+
+		anyOfItems, _, _, getErr := jsonparser.Get(value, "anyOf")
+		if errors.Is(getErr, jsonparser.KeyPathNotFoundError) {
+			// Continue
+			return
+		}
+		if getErr != nil {
+			printErrorAndExit(getErr)
+		}
+
+		insertErr := insertDefinitionKind(kind, anyOfItems)
+		if insertErr != nil {
+			printErrorAndExit(insertErr)
+		}
+	})
+	return err
+}
+
+func saveFile(outputPath string) error {
+	file, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("error creating file on the disk: %w", err)
+	}
+
+	buf := bytes.NewBuffer(nil)
+	err = json.Indent(buf, result, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error indenting bento configuration validator: %w", err)
+	}
+
+	_, err = file.Write(buf.Bytes())
+	if err != nil {
+		return fmt.Errorf("error writing to file on the disk: %w", err)
+	}
+
+	err = file.Sync()
+	if err != nil {
+		return fmt.Errorf("error running fsync on the file: %w", err)
+	}
+
+	err = file.Close()
+	if err != nil {
+		return fmt.Errorf("error closing file on the disk: %w", err)
+	}
+	return nil
+}
+
+func generateBentoConfigSchema(output string, rules []customValidationRule) error {
+	data, err := service.GlobalEnvironment().FullConfigSchema("", "").MarshalJSONSchema()
+	if err != nil {
+		return fmt.Errorf("error marshaling bento schema: %w", err)
+	}
+
+	err = jsonparser.ObjectEach(data, func(key []byte, value []byte, _ jsonparser.ValueType, _ int) error {
+		if string(key) == "properties" {
+			result, err = jsonparser.Set(result, []byte("{}"), "properties")
+			if err != nil {
+				return err
+			}
+			return scanProperties(value)
+		} else if string(key) == "definitions" {
+			result, err = jsonparser.Set(result, []byte("{}"), "definitions")
+			if err != nil {
+				return err
+			}
+			return scanDefinitions(value)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("error generating bento configuration validator: %w", err)
+	}
+
+	for _, rule := range rules {
+		result, err = rule.Apply(result)
+		if err != nil {
+			return fmt.Errorf("error applying rule %s: %w", rule.Name(), err)
+		}
+	}
+
+	return saveFile(output)
+}
+
+func usage() {
+	var msg = `Usage: generate_bent_config_schema [options] ...
+
+This program generates a JSON schema for the Input/Output resources Tyk supports.
+
+Options:
+  -h, --help    Print this message and exit.
+  -o, --output  Path to save the generated schema. 
+                Default is '%s' in the current working folder.
+`
+	_, err := fmt.Fprintf(os.Stdout, msg, defaultOutput)
+	if err != nil {
+		panic(err)
+	}
+}
+
+type arguments struct {
+	help   bool
+	output string
+}
+
+/*
+How to use this program?
+
+generate_bento_config_schema generates a JSON schema for the Input/Output resources we support.
+
+Simply,
+
+go run generate_bento_config.go
+
+It'll generate a `bento-config-schema.json` file in the current working folder. You can also set
+an output path via -output-path <string> parameter.
+
+Run via task runner:
+
+task generate-bento-config-validator-schema
+
+The task will automatically update `apidef/streams/bento/schema/bento-config-schema.json` file.
+*/
+func main() {
+	/*
+			How to add a new Input/Output source
+			1- Import the related component for its side effects, for example if you want to produce a JSON schema that supports redis component,
+			   you can import it like the following:
+
+		       _ "github.com/warpstreamlabs/bento/public/components/redis"
+
+			2- Add its name to `supportedSources` slice. You should know that some components exposes different input/output sources
+			   For example, components/kafka exposes `kafka` and `kafka_franz`. You need to dig into the Bento's codebase to understand
+		       which input/output is exposed by a component.
+	*/
+
+	// Importing a small number of components was preferred instead of importing `components/all` because importing all components
+	// results in a huge `definitions/processor` object and there is no way to know which processor are used by the components we support.
+
+	var args arguments
+	f := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	f.SetOutput(ioutil.Discard)
+	f.BoolVar(&args.help, "h", false, "")
+	f.BoolVar(&args.help, "help", false, "")
+	f.StringVar(&args.output, "output", defaultOutput, "")
+	f.StringVar(&args.output, "o", defaultOutput, "")
+	if err := f.Parse(os.Args[1:]); err != nil {
+		_, _ = fmt.Fprintf(os.Stdout, "failed to parse CLI arguments: %v\n", err)
+		usage()
+		os.Exit(1)
+	}
+
+	if args.help {
+		usage()
+		return
+	}
+
+	if err := generateBentoConfigSchema(args.output, []customValidationRule{&addURIFormatToHTTPClientRule{}}); err != nil {
+		printErrorAndExit(err)
+	}
+	_, _ = fmt.Fprintf(os.Stdout, "Bento schema generated in '%s'\n", args.output)
+}
+
+// Custom rules defined here
+
+// addURIFormatToHTTPClientRule represents a custom rule for adding URI format validation to HTTP client URL properties in a schema.
+type addURIFormatToHTTPClientRule struct{}
+
+var _ customValidationRule = (*addURIFormatToHTTPClientRule)(nil)
+
+func (a *addURIFormatToHTTPClientRule) Name() string {
+	return "add_uri_format_to_http_client"
+}
+
+func (a *addURIFormatToHTTPClientRule) setModifiedURLSection(input, data []byte, keys ...string) ([]byte, error) {
+	data, err := jsonparser.Set(data, []byte("\"uri\""), "format")
+	if err != nil {
+		return nil, err
+	}
+	return jsonparser.Set(input, data, keys...)
+}
+
+func (a *addURIFormatToHTTPClientRule) Apply(input []byte) ([]byte, error) {
+	for _, kind := range []string{"input", "output"} {
+		data, dataType, _, err := jsonparser.Get(input, "definitions", kind, "properties", "http_client", "properties", "url")
+		if err != nil {
+			return nil, fmt.Errorf("error while applying %s rule, getting URL property returned: %w", a.Name(), err)
+		}
+		if dataType != jsonparser.Object {
+			return nil, fmt.Errorf("error while applying %s rule, URL property is not an object", a.Name())
+		}
+
+		input, err = a.setModifiedURLSection(input, data, "definitions", kind, "properties", "http_client", "properties", "url")
+		if err != nil {
+			return nil, fmt.Errorf("error while applying %s rule, setting URL property returned: %w", a.Name(), err)
+		}
+	}
+	return input, nil
+}

--- a/apidef/streams/bento/schema/generate_bento_config_schema_test.go
+++ b/apidef/streams/bento/schema/generate_bento_config_schema_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/buger/jsonparser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateBentoConfigSchema(t *testing.T) {
+	// temporary directory will be automatically removed when the test complete.
+	tempFile, err := os.CreateTemp(t.TempDir(), "test-output-*.json")
+	if err != nil {
+		t.Fatalf("Failed to create temporary file: %v", err)
+	}
+	defer func() {
+		require.NoError(t, tempFile.Close())
+	}()
+
+	err = generateBentoConfigSchema(tempFile.Name(), []customValidationRule{})
+	require.NoError(t, err)
+
+	file, err := os.Open(tempFile.Name())
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(file)
+	require.NoError(t, err)
+
+	var definitionKinds = []string{"input", "output"}
+	for _, definitionKind := range definitionKinds {
+		for _, source := range supportedSources {
+			_, _, _, err = jsonparser.Get(data, "definitions", definitionKind, "properties", source)
+			require.NoError(t, err)
+		}
+	}
+}
+
+func TestAddURIFormatToHTTPClient(t *testing.T) {
+	// temporary directory will be automatically removed when the test complete.
+	tempFile, err := os.CreateTemp(t.TempDir(), "test-output-*.json")
+	if err != nil {
+		t.Fatalf("Failed to create temporary file: %v", err)
+	}
+	defer func() {
+		require.NoError(t, tempFile.Close())
+	}()
+
+	err = generateBentoConfigSchema(tempFile.Name(), []customValidationRule{
+		&addURIFormatToHTTPClientRule{},
+	})
+	require.NoError(t, err)
+
+	file, err := os.Open(tempFile.Name())
+	require.NoError(t, err)
+
+	input, err := io.ReadAll(file)
+	require.NoError(t, err)
+
+	for _, kind := range []string{"input", "output"} {
+		data, dataType, _, err := jsonparser.Get(input, "definitions", kind, "properties", "http_client", "properties", "url", "format")
+		require.NoError(t, err)
+		require.Equal(t, jsonparser.String, dataType)
+		require.Equal(t, "uri", string(data))
+	}
+}
+
+func TestAddURIFormatToHTTPClient_Malformed_input(t *testing.T) {
+	rule := &addURIFormatToHTTPClientRule{}
+
+	t.Run("Key path not found", func(t *testing.T) {
+		_, err := rule.Apply([]byte(`{}`))
+		require.Errorf(t, err, "error while applying add_uri_format_to_http_client rule, getting URL property returned: Key path not found")
+	})
+
+	t.Run("Unknown value type", func(t *testing.T) {
+		var err error
+		input := []byte(`{}`)
+		for _, kind := range []string{"input", "output"} {
+			// Value type must be an object.
+			input, err = jsonparser.Set(input, []byte("some-string"), "definitions", kind, "properties", "http_client", "properties", "url")
+			require.NoError(t, err)
+		}
+
+		_, err = rule.Apply(input)
+		require.ErrorContains(t, err, "error while applying add_uri_format_to_http_client rule, getting URL property returned: Unknown value type")
+	})
+
+	t.Run("URL property is not an object", func(t *testing.T) {
+		var err error
+		input := []byte(`{}`)
+		for _, kind := range []string{"input", "output"} {
+			// Value type must be an object.
+			input, err = jsonparser.Set(input, []byte("\"some-string\""), "definitions", kind, "properties", "http_client", "properties", "url")
+			require.NoError(t, err)
+		}
+
+		_, err = rule.Apply(input)
+		require.ErrorContains(t, err, "error while applying add_uri_format_to_http_client rule, URL property is not an object")
+	})
+
+	t.Run("Malformed url object", func(t *testing.T) {
+		input := []byte(`{}`)
+		data := "some-string"
+		_, err := rule.setModifiedURLSection(input, []byte(data), "some", "path")
+		require.ErrorIs(t, err, jsonparser.KeyPathNotFoundError)
+	})
+}

--- a/docs/dev/how-to-generate-bento-config-validation-schema.md
+++ b/docs/dev/how-to-generate-bento-config-validation-schema.md
@@ -1,0 +1,71 @@
+# How to generate Bento Configuration Validator Schema for Tyk
+
+There is a script named `generate_bento_config_schema` under `apidef/streams/bento/schema` folder in Tyk GW repository. 
+This script generates a JSON schema for the input & output resources that Tyk supports. There are two ways to run this script.
+
+## Running the script directly
+
+Simply, `go run generate_bento_config_schema.go` command in the source code folder. 
+It'll generate a file named `bento-config-schema.json` in the current working folder. 
+You can also set an output path via `-output <string>` parameter.
+
+This is useful for development purposes.
+
+## Running via task runner
+
+Simply run the following command under Tyk GW repository’s root folder.
+
+```shell
+task generate-bento-config-validator-schema
+```
+
+The task will automatically update `apidef/streams/bento/schema/bento-config-schema.json` file. 
+This should be done after upgrading Bento in Tyk GW.
+
+## How to add a new input & output resources
+
+**1-** Import the related component for its side effects.
+
+For example if you want to produce a JSON schema that supports redis component, 
+you can import it like the following:
+
+```go
+ _ "http://github.com/warpstreamlabs/bento/public/components/redis"`
+```
+
+**2-** Add the component name to `supportedSources` slice. You should know that some 
+components exposes different input/output sources.
+
+For example, `components/kafka` exposes `kafka` and `kafka_franz`. You need to dig into the Bento's codebase to understand 
+which input/output is exposed by a component.
+
+See the list of components: https://github.com/warpstreamlabs/bento/tree/main/public/components
+
+Importing all components was not preferred because it results in generating a gigantic JSON schema, and it’s too hard to 
+navigate in that file and debug possible issues. 
+
+## How to add a new validator rule
+
+A validator rule has been defined by a simple interface:
+
+```go
+// customValidationRule is an interface for defining custom validation rules for JSON schemas.
+type customValidationRule interface {
+	// Name returns the name of the validation rule.
+	Name() string
+
+	// Apply applies the validation rule to the provided input data and
+	// returns the processed data or an error if validation fails.
+	Apply(input []byte) ([]byte, error)
+}
+```
+
+`Apply` method takes the input and returns the processed input by the validator rule implementation. 
+
+You can add rules to the pipeline like the following, `generateBentoConfigSchema` will take a list of rules and apply them respectively.
+
+```go
+err = generateBentoConfigSchema(args.output, []customValidationRule{
+	&addURIFormatToHTTPClientRule{}
+})
+```


### PR DESCRIPTION
[TT-14252] Add customValidationRule interface to generate_bento_config_schema script (#7057)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-14252"
title="TT-14252" target="_blank">TT-14252</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
<td>Once the gateway starts producing "unsupported protocol scheme"
errors about streams APIs it never stops</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20customer_bug%20ORDER%20BY%20created%20DESC"
title="customer_bug">customer_bug</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

PR for https://tyktech.atlassian.net/browse/TT-14252

This PR adds a new interface to `generate_bento_config_schema` script to
add custom rules to schema generation process. By this way, adding new
rules will be easy and not requires hacky if-else blocks in the schema
generation code.

The first rule is `add_uri_format_to_http_client`, it adds `format: uri`
to url object of `http_client` schema.

After adding `format: uri` to the `url` object, the validator checks the
url format and the API returns the following error:

```
default_stream: input.http_client.url: Does not match format 'uri' output.http_client.url: Does not match format 'uri'
```

It's still possible to reproduce the bug because API creation page of
the Dashboard uses OAS APIs to create Tyk Stream APIs, the frontend code
should be improved to use Tyk Stream APIs. A followup ticket will be
created for this improvement.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduced `customValidationRule` interface for schema customization.

- Added `addURIFormatToHTTPClient` rule to enforce URI format on HTTP
client URLs.

- Updated schema generation logic to apply custom rules.

- Added tests for the new custom validation rule mechanism.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>generate_bento_config_schema.go</strong><dd><code>Add
custom validation rule interface and URI format rule</code>&nbsp;
</dd></summary>
<hr>

apidef/streams/bento/schema/generate_bento_config_schema.go

<li>Introduced <code>customValidationRule</code> interface for schema
rules.<br> <li> Implemented <code>addURIFormatToHTTPClient</code> rule
to set <code>format: uri</code> on HTTP <br>client URLs.<br> <li>
Modified schema generation to apply custom rules.<br> <li> Refactored
main function to use new rule system.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7057/files#diff-6df17fac938f7b6fc05640fdfefd4315887362243e6130b53aec9563d12c84c5">+57/-2</a>&nbsp;
&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>bento-config-schema.json</strong><dd><code>Enforce URI
format on HTTP client URL in schema</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/streams/bento/schema/bento-config-schema.json

<li>Added <code>"format": "uri"</code> to HTTP client <code>url</code>
properties in both input and <br>output schemas.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7057/files#diff-4b2f0593b81d1e09f7c731419b226631c3a77fa117d573fcb47912f0d6024b02">+4/-2</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>

<summary><strong>generate_bento_config_schema_test.go</strong><dd><code>Add
and update tests for custom validation rules</code>&nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/streams/bento/schema/generate_bento_config_schema_test.go

<li>Updated tests to use new rule interface.<br> <li> Added test for
<code>addURIFormatToHTTPClient</code> rule.<br> <li> Verified
<code>format: uri</code> is set for HTTP client URLs.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7057/files#diff-6d36a7643c6cc8915692734ac9bb3e39e76c6dfa5d82a1a93cff0883b169185d">+30/-1</a>&nbsp;
&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary> Need help?</summary><li>Type <code>/help how to
...</code> in the comments thread for any questions about PR-Agent
usage.</li><li>Check out the <a
href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a>
for more information.</li></details>

[TT-14252]: https://tyktech.atlassian.net/browse/TT-14252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ