### PR TITLE
Merging to release-5.8: Disabled/empty uptime test fields migrated to Tyk OAS (#7069)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ testapps/
 /*.conf
 /*.json
 /*.bak
+/.air.toml
+
 
 /tyk
 logs/

--- a/apidef/oas/fixtures_test.go
+++ b/apidef/oas/fixtures_test.go
@@ -179,7 +179,8 @@ func createClassic(tb testing.TB, patch any) *apidef.APIDefinition {
 		assert.NoError(tb, json.Unmarshal(encodeJSON(tb, patch), &def))
 	}
 
-	def.Migrate()
+	_, err := def.Migrate()
+	assert.NoError(tb, err)
 
 	return def
 }

--- a/apidef/oas/testdata/fixtures/service_discovery.yml
+++ b/apidef/oas/testdata/fixtures/service_discovery.yml
@@ -59,11 +59,7 @@ tests:
         title: "Name"
       x-tyk-api-gateway:
         upstream:
-          serviceDiscovery:
-            enabled: false
-            cache:
-              enabled: false
-              timeout: 10
+          serviceDiscovery: "<nil>"
   - source: classic
     desc: |
       If service discovery is disabled (unconfigured) then honor cache_disabled=false as being still disabled.

--- a/apidef/oas/upstream.go
+++ b/apidef/oas/upstream.go
@@ -548,7 +548,7 @@ func (sd *ServiceDiscovery) Fill(serviceDiscovery apidef.ServiceDiscoveryConfigu
 		Timeout: timeout,
 	}
 
-	if !enabled && timeout == 0 {
+	if !sd.Cache.Enabled {
 		sd.Cache = nil
 	}
 
@@ -591,11 +591,11 @@ type UptimeTests struct {
 	// HostDownRetestPeriod is the time to wait until rechecking a failed test.
 	// If undefined, the default testing interval (10s) is in use.
 	// Setting this to a lower value would result in quicker recovery on failed checks.
-	HostDownRetestPeriod time.ReadableDuration `bson:"hostDownRetestPeriod" json:"hostDownRetestPeriod"`
+	HostDownRetestPeriod time.ReadableDuration `bson:"hostDownRetestPeriod" json:"hostDownRetestPeriod,omitempty"`
 
 	// LogRetentionPeriod holds a time to live for the uptime test results.
 	// If unset, a value of 100 years is the default.
-	LogRetentionPeriod time.ReadableDuration `bson:"logRetentionPeriod" json:"logRetentionPeriod"`
+	LogRetentionPeriod time.ReadableDuration `bson:"logRetentionPeriod" json:"logRetentionPeriod,omitempty"`
 }
 
 // UptimeTest configures an uptime test check.
@@ -612,7 +612,7 @@ type UptimeTest struct {
 
 	// Timeout declares a timeout for the request. If the test exceeds
 	// this timeout, the check fails.
-	Timeout time.ReadableDuration `bson:"timeout" json:"timeout"`
+	Timeout time.ReadableDuration `bson:"timeout" json:"timeout,omitempty"`
 
 	// Method allows you to customize the HTTP method for the test (`GET`, `POST`,...).
 	Method string `bson:"method" json:"method"`
@@ -621,7 +621,7 @@ type UptimeTest struct {
 	Headers map[string]string `bson:"headers" json:"headers,omitempty"`
 
 	// Body is the body of the test request.
-	Body string `bson:"body" json:"body"`
+	Body string `bson:"body" json:"body,omitempty"`
 
 	// Commands are used for TCP checks.
 	Commands []UptimeTestCommand `bson:"commands" json:"commands,omitempty"`
@@ -653,22 +653,20 @@ type UptimeTestCommand struct {
 
 // Fill fills *UptimeTests from apidef.UptimeTests.
 func (u *UptimeTests) Fill(uptimeTests apidef.UptimeTests) {
-	u.Enabled = !uptimeTests.Disabled
-
 	if u.ServiceDiscovery == nil {
 		u.ServiceDiscovery = &ServiceDiscovery{}
 	}
 
 	u.ServiceDiscovery.Fill(uptimeTests.Config.ServiceDiscovery)
+
 	if ShouldOmit(u.ServiceDiscovery) {
 		u.ServiceDiscovery = nil
 	}
 
-	u.Tests = nil
 	u.LogRetentionPeriod = ReadableDuration(time.Duration(uptimeTests.Config.ExpireUptimeAnalyticsAfter) * time.Second)
 	u.HostDownRetestPeriod = ReadableDuration(time.Duration(uptimeTests.Config.RecheckWait) * time.Second)
 
-	result := []UptimeTest{}
+	u.Tests = nil
 	for _, v := range uptimeTests.CheckList {
 		check := UptimeTest{
 			CheckURL:            u.fillCheckURL(v.Protocol, v.CheckURL),
@@ -681,13 +679,10 @@ func (u *UptimeTests) Fill(uptimeTests apidef.UptimeTests) {
 		for _, command := range v.Commands {
 			check.AddCommand(command.Name, command.Message)
 		}
-
-		result = append(result, check)
+		u.Tests = append(u.Tests, check)
 	}
 
-	if len(result) > 0 {
-		u.Tests = result
-	}
+	u.Enabled = len(u.Tests) > 0 && !uptimeTests.Disabled
 }
 
 // ExtractTo extracts *UptimeTests into *apidef.UptimeTests.


### PR DESCRIPTION
Disabled/empty uptime test fields migrated to Tyk OAS (#7069)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-14183"
title="TT-14183" target="_blank">TT-14183</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Disabled/empty uptime test fields migrated to Tyk OAS</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Code Review</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%205.8.0Regression%20ORDER%20BY%20created%20DESC"
title="5.8.0Regression">5.8.0Regression</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%205.8.1Refinement%20ORDER%20BY%20created%20DESC"
title="5.8.1Refinement">5.8.1Refinement</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20QA_Fail%20ORDER%20BY%20created%20DESC"
title="QA_Fail">QA_Fail</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20codilime_refined%20ORDER%20BY%20created%20DESC"
title="codilime_refined">codilime_refined</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->
Chnage migration rules

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [x] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixes migration of disabled/empty uptime test fields to Tyk OAS.

- Ensures empty uptime test fields are omitted in JSON serialization.

- Updates service discovery cache logic for disabled state.

- Adds and enhances tests for uptime test migration and serialization.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>upstream.go</strong><dd><code>Refactor uptime test and
cache migration logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/upstream.go

<li>Refactored uptime test migration to omit empty fields in JSON.<br>
<li> Changed cache logic to set cache to nil if not enabled.<br> <li>
Updated uptime test enabling logic to depend on test presence and
<br>disabled flag.<br> <li> Ensured empty body is omitted from JSON
output.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7069/files#diff-7b0941c7f37fe5a2a23047e0822a65519ca11c371660f36555b59a60f000e3f4">+6/-11</a>&nbsp;
&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>upstream_test.go</strong><dd><code>Add tests for uptime
test migration and serialization</code>&nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

apidef/oas/upstream_test.go

<li>Added tests for empty uptime test migration and JSON
serialization.<br> <li> Verified omission of empty body and protocol
fields in JSON.<br> <li> Checked that Fill produces empty structure when
no tests are present.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7069/files#diff-222cc254c0c6c09fa0cf50087860b837a0873e2aef3c84ec7d80b1014c149057">+44/-0</a>&nbsp;
&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>fixtures_test.go</strong><dd><code>Assert migration
errors in test fixtures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; </dd></summary>
<hr>

apidef/oas/fixtures_test.go

- Updated migration call to handle error and assert no error occurs.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7069/files#diff-2c27bf7208b7414ba0b07325bc834177a424d5348f2ffb4a78d46f428f8e303f">+2/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>service_discovery.yml</strong><dd><code>Update service
discovery fixture for disabled state</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/testdata/fixtures/service_discovery.yml

- Updated expected output for disabled service discovery to be nil.


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7069/files#diff-8a41102394fc3160d93fc56f1bcec9d1a03404724ba9e10dd624faf8e1154f65">+1/-5</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary> Need help?</summary><li>Type <code>/help how to
...</code> in the comments thread for any questions about PR-Agent
usage.</li><li>Check out the <a
href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a>
for more information.</li></details>