### PR TITLE
[TT-12308] Query parameters not respected by OAS import endpoint

### DIFF
--- a/apidef/oas/oasutil_test.go
+++ b/apidef/oas/oasutil_test.go
@@ -11,6 +11,7 @@ type testStruct struct {
 	Array     []string
 	Map       map[string]string
 	SubStruct *subStruct
+	BoolPtr   *bool
 }
 
 type subStruct struct {
@@ -24,6 +25,8 @@ func TestShouldOmit(t *testing.T) {
 	v4 := testStruct{Bool: true}
 	v5 := testStruct{Array: []string{"a"}}
 	v6 := testStruct{Map: map[string]string{"a": "b"}}
+	v7 := testStruct{Array: make([]string, 0), Map: make(map[string]string), SubStruct: &subStruct{SubMap: make(map[string]string)}, BoolPtr: boolPtr(false)}
+	v8 := testStruct{Array: make([]string, 0), Map: make(map[string]string), SubStruct: &subStruct{SubMap: make(map[string]string)}, BoolPtr: boolPtr(true)}
 
 	assert.True(t, ShouldOmit(v1))
 	assert.True(t, ShouldOmit(v2))
@@ -31,4 +34,10 @@ func TestShouldOmit(t *testing.T) {
 	assert.False(t, ShouldOmit(v4))
 	assert.False(t, ShouldOmit(v5))
 	assert.False(t, ShouldOmit(v6))
+	assert.False(t, ShouldOmit(v7))
+	assert.False(t, ShouldOmit(v8))
+}
+
+func boolPtr(v bool) *bool {
+	return &v
 }

--- a/internal/reflect/reflect.go
+++ b/internal/reflect/reflect.go
@@ -37,7 +37,14 @@ func IsZero(v reflect.Value) bool {
 	case reflect.Chan, reflect.Func, reflect.Interface, reflect.UnsafePointer:
 		return v.IsNil()
 	case reflect.Ptr:
-		return v.IsNil() || IsZero(v.Elem())
+		if v.IsNil() {
+			return true
+		}
+		if v.Elem().Kind() == reflect.Bool {
+			return false
+		}
+
+		return IsZero(v.Elem())
 	case reflect.Slice, reflect.Map:
 		return v.Len() == 0
 	case reflect.String:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

When using the Dashboard API’s OAS import endpoint to create an API from an OpenAPI document, boolean query parameters (allowList, mockResponse, validateRequest, authentication) with the value false are ignored unless the listenPath parameter is also provided. This due func IsZero not recognizing bool pointer as a non zero value.

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
