### PR TITLE
[TT-14879] Tyk Dashboard should use /api/apis/streams endpoints to create and import Tyk Stream APIs

### DIFF
--- a/apidef/streams/bento/schema/bento-config-schema.json
+++ b/apidef/streams/bento/schema/bento-config-schema.json
@@ -1161,6 +1161,15 @@
                     "custom_delimiter": {
                       "type": "string"
                     },
+                    "expected_headers": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "expected_number_of_fields": {
+                      "type": "number"
+                    },
                     "lazy_quotes": {
                       "type": "boolean"
                     },
@@ -1295,6 +1304,23 @@
                 "to_the_end": {
                   "additionalProperties": false,
                   "properties": {},
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "properties": {
+                "xml_documents": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "cast": {
+                      "type": "boolean"
+                    },
+                    "operator": {
+                      "type": "string"
+                    }
+                  },
                   "type": "object"
                 }
               },
@@ -2852,6 +2878,9 @@
               },
               "type": "object"
             },
+            "heartbeat": {
+              "type": "string"
+            },
             "key_file": {
               "type": "string"
             },
@@ -2864,6 +2893,9 @@
             "pong_wait": {
               "type": "string"
             },
+            "stream_format": {
+              "type": "string"
+            },
             "stream_path": {
               "type": "string"
             },
@@ -2871,6 +2903,9 @@
               "type": "string"
             },
             "write_wait": {
+              "type": "string"
+            },
+            "ws_message_type": {
               "type": "string"
             },
             "ws_path": {


### PR DESCRIPTION
### **User description**
PR for https://tyktech.atlassian.net/browse/TT-14879

This PR updates the bento config validator to the latest version.


___

### **PR Type**
enhancement


___

### **Description**
- Updated `bento-config-schema.json` to the latest schema version

- Added new CSV options: `expected_headers` and `expected_number_of_fields`

- Introduced new `xml_documents` object for stream processing

- Enhanced WebSocket config with `heartbeat`, `stream_format`, and `ws_message_type`


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bento-config-schema.json</strong><dd><code>Enhance bento-config-schema with new stream and WebSocket fields</code></dd></summary>
<hr>

apidef/streams/bento/schema/bento-config-schema.json

<li>Added <code>expected_headers</code> and <code>expected_number_of_fields</code> to CSV config<br> <li> Introduced <code>xml_documents</code> object with <code>cast</code> and <code>operator</code> fields<br> <li> Added WebSocket options: <code>heartbeat</code>, <code>stream_format</code>, <code>ws_message_type</code><br> <li> Updated schema to support new stream processing features


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7088/files#diff-4b2f0593b81d1e09f7c731419b226631c3a77fa117d573fcb47912f0d6024b02">+35/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>