### PR TITLE
Merging to release-5.8: [TT-11335] OAS URL rewrite schema update (#7099)

### DIFF
--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -920,7 +920,8 @@
       },
       "required": [
         "in",
-        "pattern"
+        "pattern",
+        "negate"
       ]
     },
     "X-Tyk-URLRewriteRule": {
@@ -948,7 +949,8 @@
       "required": [
         "in",
         "name",
-        "pattern"
+        "pattern",
+        "negate"
       ]
     },
     "X-Tyk-EndpointPostPlugin": {

--- a/apidef/oas/schema/x-tyk-api-gateway.strict.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.strict.json
@@ -959,7 +959,8 @@
       },
       "required": [
         "in",
-        "pattern"
+        "pattern",
+        "negate"
       ],
       "additionalProperties": false
     },
@@ -988,7 +989,8 @@
       "required": [
         "in",
         "name",
-        "pattern"
+        "pattern",
+        "negate"
       ],
       "additionalProperties": false
     },

--- a/apidef/oas/url_rewrite.go
+++ b/apidef/oas/url_rewrite.go
@@ -116,7 +116,7 @@ type URLRewriteRule struct {
 
 	// Negate is a boolean negation operator. Setting it to true inverts the matching behaviour
 	// such that the rewrite will be triggered if the value does not match the `pattern` for this rule.
-	Negate bool `bson:"negate,omitempty" json:"negate,omitempty"`
+	Negate bool `bson:"negate" json:"negate"`
 }
 
 // Fill fills *URLRewrite receiver from apidef.URLRewriteMeta.


### PR DESCRIPTION
### **User description**
[TT-11335] OAS URL rewrite schema update (#7099)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-11335"
title="TT-11335" target="_blank">TT-11335</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>OAS URL rewrite schema update</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20codilime_refined%20ORDER%20BY%20created%20DESC"
title="codilime_refined">codilime_refined</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

## Description

There is a schema inconsistency in the OAS URL Re-write middleware
between the frontend UI validation and the backend schema definition.
The "negate" field (displayed as "matches" in the UI) is treated as
mandatory in the UI but is optional in the backend schema. This allows
users to save configurations without providing this field, which then
defaults to "false" in the backend.

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Made `negate` field required in URL Rewrite backend schema

- Updated OpenAPI schema to require `negate` in relevant objects

- Ensured consistency between UI and backend validation for `negate`

- Improved schema reliability for URL Rewrite middleware


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>url_rewrite.go</strong><dd><code>Require `Negate` field
in URLRewriteRule struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/url_rewrite.go

<li>Changed <code>Negate</code> field in <code>URLRewriteRule</code>
struct to be required<br> <li> Removed <code>omitempty</code> from
<code>bson</code> and <code>json</code> tags for <code>Negate</code>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7099/files#diff-7317c6061fb6488e079d733230045c7cbc1b4b2ffb98bb7da20d4025f4976e51">+1/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>x-tyk-api-gateway.json</strong><dd><code>Require
`negate` in OpenAPI schema for URL Rewrite</code>&nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/schema/x-tyk-api-gateway.json

<li>Added <code>negate</code> to <code>required</code> array for URL
Rewrite rule schemas<br> <li> Updated both unnamed and named rule
definitions to require <code>negate</code>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7099/files#diff-78828969c0c04cc1a776dfc93a8bad3c499a8c83e6169f83e96d090bed3e7dd0">+4/-2</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary> Need help?</summary><li>Type <code>/help how to
...</code> in the comments thread for any questions about PR-Agent
usage.</li><li>Check out the <a
href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a>
for more information.</li></details>

[TT-11335]: https://tyktech.atlassian.net/browse/TT-11335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Made `negate` field required in URL Rewrite backend schema

- Updated OpenAPI and strict schemas to require `negate`

- Ensured backend and UI validation consistency for URL Rewrite

- Improved reliability of URL Rewrite middleware configuration


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>url_rewrite.go</strong><dd><code>Require `Negate` field in URLRewriteRule struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/url_rewrite.go

<li>Made <code>Negate</code> field in <code>URLRewriteRule</code> struct required<br> <li> Removed <code>omitempty</code> from <code>bson</code> and <code>json</code> tags for <code>Negate</code>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7100/files#diff-7317c6061fb6488e079d733230045c7cbc1b4b2ffb98bb7da20d4025f4976e51">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>x-tyk-api-gateway.json</strong><dd><code>Require `negate` in OpenAPI schema for URL Rewrite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/schema/x-tyk-api-gateway.json

<li>Added <code>negate</code> to <code>required</code> array for URL Rewrite rule schemas<br> <li> Updated both unnamed and named rule definitions to require <code>negate</code>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7100/files#diff-78828969c0c04cc1a776dfc93a8bad3c499a8c83e6169f83e96d090bed3e7dd0">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>x-tyk-api-gateway.strict.json</strong><dd><code>Require `negate` in strict OpenAPI schema for URL Rewrite</code></dd></summary>
<hr>

apidef/oas/schema/x-tyk-api-gateway.strict.json

<li>Added <code>negate</code> to <code>required</code> array in strict schema for URL Rewrite rules<br> <li> Updated both unnamed and named rule definitions to require <code>negate</code>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7100/files#diff-39a62344d6b741814a58dfd2d219665ecdf962bbec8e755dbc61e1684bb4892a">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>