### PR TITLE
[TT-14621]corrected prefix for certificates (#7094)

### DIFF
--- a/storage/mdcb_storage.go
+++ b/storage/mdcb_storage.go
@@ -46,7 +46,7 @@ func getResourceType(key string) string {
 	switch {
 	case strings.Contains(key, "oauth-clientid."):
 		return resourceOauthClient
-	case strings.HasPrefix(key, "cert"):
+	case strings.HasPrefix(key, "raw-"):
 		return resourceCertificate
 	case strings.HasPrefix(key, "apikey"):
 		return resourceApiKey

--- a/storage/mdcb_storage_test.go
+++ b/storage/mdcb_storage_test.go
@@ -64,7 +64,7 @@ func TestGetResourceType(t *testing.T) {
 		expected string
 	}{
 		{"oauth-clientid.client-id", resourceOauthClient},
-		{"cert.something", resourceCertificate},
+		{"raw-something", resourceCertificate},
 		{"apikey.something", resourceApiKey},
 		{"unmatched-key", resourceKey},
 	}
@@ -194,7 +194,7 @@ func TestGetFromRPCAndCache(t *testing.T) {
 	}
 	m.OnRPCCertPull = mockSaveCert
 
-	certKey := "cert-my-cert-id"
+	certKey := "raw-my-cert-id"
 	rpcHandler.EXPECT().GetKey(certKey).Return("value", nil)
 	rpcVal, err = m.getFromRPCAndCache(certKey)
 	assert.Equal(t, "value", rpcVal)
@@ -234,7 +234,7 @@ func TestProcessResourceByType(t *testing.T) {
 		},
 		{
 			name: "Successful Certificate caching",
-			key:  "cert:cert1",
+			key:  "raw-cert1",
 			val:  "certdata1",
 			setupMocks: func(_ *mock.MockHandler) {
 				// Setup expectations for certificate caching if needed
@@ -243,7 +243,7 @@ func TestProcessResourceByType(t *testing.T) {
 		},
 		{
 			name: "Failed Certificate caching",
-			key:  "cert:failCert",
+			key:  "raw-failCert",
 			val:  "certdata2",
 			setupMocks: func(_ *mock.MockHandler) {
 				// Setup expectations for failed certificate caching if needed
@@ -268,9 +268,9 @@ func TestProcessResourceByType(t *testing.T) {
 			tc.setupMocks(setup.Local)
 
 			// If testing certificate caching, setup the callback
-			if strings.HasPrefix(tc.key, "cert:") {
+			if strings.HasPrefix(tc.key, "raw-") {
 				m.OnRPCCertPull = func(key, _ string) error {
-					if key == "cert:failCert" {
+					if key == "raw-failCert" {
 						return errCachingFailed
 					}
 					return nil


### PR DESCRIPTION
### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-14621" title="TT-14621" target="_blank">TT-14621</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
<td>[regression]Data plane gateways no longer store certificates in redis</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20customer_bug%20ORDER%20BY%20created%20DESC" title="customer_bug">customer_bug</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20jira_escalated%20ORDER%20BY%20created%20DESC" title="jira_escalated">jira_escalated</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20release3candidate%20ORDER%20BY%20created%20DESC" title="release3candidate">release3candidate</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. --> <!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes --> <!-- Include details of your testing environment, and the tests --> <!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix certificate key prefix from `cert` to `raw-` in storage logic

- Update tests to use new `raw-` prefix for certificates

- Ensure correct resource type detection for certificates

- Maintain test coverage for certificate-related storage operations


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mdcb_storage.go</strong><dd><code>Update certificate key prefix logic in storage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

storage/mdcb_storage.go

<li>Changed certificate key prefix check from <code>cert</code> to <code>raw-</code><br> <li> Ensured resource type detection aligns with new prefix


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7114/files#diff-c5739d542a422343ec22585ffa5e4ad7e2e91358db018a157dc23cb5096c04d2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mdcb_storage_test.go</strong><dd><code>Update tests for new certificate key prefix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

storage/mdcb_storage_test.go

<li>Updated all certificate-related test keys from <code>cert</code> to <code>raw-</code><br> <li> Adjusted test logic to match new certificate prefix<br> <li> Maintained test coverage for certificate caching and error handling


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7114/files#diff-6a40b704ea7dc3b61069eebd5d56464a66bb1c61095909aa9cc5e423c5c88422">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>