### PR TITLE
[TT-15286] poc/errors customization

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -6,7 +6,6 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"github.com/TykTechnologies/tyk/config"
 	"net/http"
 	"text/template"
 	"time"
@@ -647,13 +646,18 @@ type Scopes struct {
 	OIDC ScopeClaim `bson:"oidc" json:"oidc,omitempty"`
 }
 
+type TykError struct {
+	Message string `json:"message" bson:"message"`
+	Code    int    `json:"code" bson:"code"`
+}
+
 // APIDefinition represents the configuration for a single proxied API and it's versions.
 //
 // swagger:model
 type APIDefinition struct {
 	Id model.ObjectID `bson:"_id,omitempty" json:"id,omitempty" gorm:"primaryKey;column:_id"`
 	// ErrorMessages allows API-level customization of error messages
-	ErrorMessages map[string]config.TykError `bson:"error_messages,omitempty" json:"error_messages,omitempty"`
+	ErrorMessages map[string]TykError `bson:"error_messages,omitempty" json:"error_messages,omitempty"`
 
 	Name                string        `bson:"name" json:"name"`
 	Expiration          string        `bson:"expiration" json:"expiration,omitempty"`

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -153,6 +153,8 @@ type EndpointMethodMeta struct {
 	Code    int                  `bson:"code" json:"code"`
 	Data    string               `bson:"data" json:"data"`
 	Headers map[string]string    `bson:"headers" json:"headers"`
+	// ErrorMessages allows endpoint-level customization of error messages
+	ErrorMessages map[string]TykError `bson:"error_messages,omitempty" json:"error_messages,omitempty"`
 }
 
 type MockResponseMeta struct {
@@ -387,6 +389,13 @@ type GoPluginMeta struct {
 	SymbolName string `bson:"func_name" json:"func_name"`
 }
 
+type ErrorMessagesMeta struct {
+	Path          string              `bson:"path" json:"path"`
+	Method        string              `bson:"method" json:"method"`
+	Disabled      bool                `bson:"disabled" json:"disabled"`
+	ErrorMessages map[string]TykError `bson:"error_messages" json:"error_messages"`
+}
+
 type ExtendedPathsSet struct {
 	Ignored                 []EndPointMeta        `bson:"ignored" json:"ignored,omitempty"`
 	WhiteList               []EndPointMeta        `bson:"white_list" json:"white_list,omitempty"`
@@ -414,6 +423,7 @@ type ExtendedPathsSet struct {
 	GoPlugin                []GoPluginMeta        `bson:"go_plugin" json:"go_plugin,omitempty"`
 	PersistGraphQL          []PersistGraphQLMeta  `bson:"persist_graphql" json:"persist_graphql"`
 	RateLimit               []RateLimitMeta       `bson:"rate_limit" json:"rate_limit"`
+	ErrorMessages           []ErrorMessagesMeta   `bson:"error_messages" json:"error_messages"`
 }
 
 // Clear omits values that have OAS API definition conversions in place.

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -6,6 +6,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"github.com/TykTechnologies/tyk/config"
 	"net/http"
 	"text/template"
 	"time"
@@ -650,21 +651,24 @@ type Scopes struct {
 //
 // swagger:model
 type APIDefinition struct {
-	Id                  model.ObjectID `bson:"_id,omitempty" json:"id,omitempty" gorm:"primaryKey;column:_id"`
-	Name                string         `bson:"name" json:"name"`
-	Expiration          string         `bson:"expiration" json:"expiration,omitempty"`
-	ExpirationTs        time.Time      `bson:"-" json:"-"`
-	Slug                string         `bson:"slug" json:"slug"`
-	ListenPort          int            `bson:"listen_port" json:"listen_port"`
-	Protocol            string         `bson:"protocol" json:"protocol"`
-	EnableProxyProtocol bool           `bson:"enable_proxy_protocol" json:"enable_proxy_protocol"`
-	APIID               string         `bson:"api_id" json:"api_id"`
-	OrgID               string         `bson:"org_id" json:"org_id"`
-	UseKeylessAccess    bool           `bson:"use_keyless" json:"use_keyless"`
-	UseOauth2           bool           `bson:"use_oauth2" json:"use_oauth2"`
-	ExternalOAuth       ExternalOAuth  `bson:"external_oauth" json:"external_oauth"`
-	UseOpenID           bool           `bson:"use_openid" json:"use_openid"`
-	OpenIDOptions       OpenIDOptions  `bson:"openid_options" json:"openid_options"`
+	Id model.ObjectID `bson:"_id,omitempty" json:"id,omitempty" gorm:"primaryKey;column:_id"`
+	// ErrorMessages allows API-level customization of error messages
+	ErrorMessages map[string]config.TykError `bson:"error_messages,omitempty" json:"error_messages,omitempty"`
+
+	Name                string        `bson:"name" json:"name"`
+	Expiration          string        `bson:"expiration" json:"expiration,omitempty"`
+	ExpirationTs        time.Time     `bson:"-" json:"-"`
+	Slug                string        `bson:"slug" json:"slug"`
+	ListenPort          int           `bson:"listen_port" json:"listen_port"`
+	Protocol            string        `bson:"protocol" json:"protocol"`
+	EnableProxyProtocol bool          `bson:"enable_proxy_protocol" json:"enable_proxy_protocol"`
+	APIID               string        `bson:"api_id" json:"api_id"`
+	OrgID               string        `bson:"org_id" json:"org_id"`
+	UseKeylessAccess    bool          `bson:"use_keyless" json:"use_keyless"`
+	UseOauth2           bool          `bson:"use_oauth2" json:"use_oauth2"`
+	ExternalOAuth       ExternalOAuth `bson:"external_oauth" json:"external_oauth"`
+	UseOpenID           bool          `bson:"use_openid" json:"use_openid"`
+	OpenIDOptions       OpenIDOptions `bson:"openid_options" json:"openid_options"`
 	Oauth2Meta          struct {
 		AllowedAccessTypes     []osin.AccessRequestType    `bson:"allowed_access_types" json:"allowed_access_types"`
 		AllowedAuthorizeTypes  []osin.AuthorizeRequestType `bson:"allowed_authorize_types" json:"allowed_authorize_types"`

--- a/apidef/oas/operation.go
+++ b/apidef/oas/operation.go
@@ -84,6 +84,9 @@ type Operation struct {
 
 	// RateLimit contains endpoint level rate limit configuration.
 	RateLimit *RateLimitEndpoint `bson:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+
+	// ErrorMessages allows endpoint-level customization of error messages
+	ErrorMessages map[string]apidef.TykError `bson:"error_messages,omitempty" json:"error_messages,omitempty"`
 }
 
 // AllowanceType holds the valid allowance types values.

--- a/apidef/oas/root.go
+++ b/apidef/oas/root.go
@@ -1,7 +1,6 @@
 package oas
 
 import (
-	"github.com/TykTechnologies/tyk/config"
 	"sort"
 
 	"github.com/TykTechnologies/storage/persistent/model"
@@ -22,7 +21,7 @@ type XTykAPIGateway struct {
 	// Middleware contains the configurations related to the Tyk middleware.
 	Middleware *Middleware `bson:"middleware,omitempty" json:"middleware,omitempty"`
 	// ErrorMessages allows API-level customization of error messages
-	ErrorMessages map[string]config.TykError `bson:"error_messages,omitempty" json:"error_messages,omitempty"`
+	ErrorMessages map[string]apidef.TykError `bson:"error_messages,omitempty" json:"error_messages,omitempty"`
 }
 
 // Fill fills *XTykAPIGateway from apidef.APIDefinition.

--- a/apidef/oas/root.go
+++ b/apidef/oas/root.go
@@ -31,6 +31,10 @@ func (x *XTykAPIGateway) Fill(api apidef.APIDefinition) {
 	x.Upstream.Fill(api)
 	x.Server.Fill(api)
 
+	if api.ErrorMessages != nil {
+		x.ErrorMessages = api.ErrorMessages
+	}
+
 	if x.Middleware == nil {
 		x.Middleware = &Middleware{}
 	}
@@ -57,9 +61,7 @@ func (x *XTykAPIGateway) ExtractTo(api *apidef.APIDefinition) {
 	}
 
 	if x.ErrorMessages != nil {
-		panic(x.ErrorMessages)
-	} else {
-		panic("-------------2---------------es nil")
+		api.ErrorMessages = x.ErrorMessages
 	}
 
 	x.Middleware.ExtractTo(api)

--- a/apidef/oas/root.go
+++ b/apidef/oas/root.go
@@ -1,6 +1,7 @@
 package oas
 
 import (
+	"github.com/TykTechnologies/tyk/config"
 	"sort"
 
 	"github.com/TykTechnologies/storage/persistent/model"
@@ -20,6 +21,8 @@ type XTykAPIGateway struct {
 	Server Server `bson:"server" json:"server"` // required
 	// Middleware contains the configurations related to the Tyk middleware.
 	Middleware *Middleware `bson:"middleware,omitempty" json:"middleware,omitempty"`
+	// ErrorMessages allows API-level customization of error messages
+	ErrorMessages map[string]config.TykError `bson:"error_messages,omitempty" json:"error_messages,omitempty"`
 }
 
 // Fill fills *XTykAPIGateway from apidef.APIDefinition.
@@ -51,6 +54,12 @@ func (x *XTykAPIGateway) ExtractTo(api *apidef.APIDefinition) {
 		defer func() {
 			x.Middleware = nil
 		}()
+	}
+
+	if x.ErrorMessages != nil {
+		panic(x.ErrorMessages)
+	} else {
+		panic("-------------2---------------es nil")
 	}
 
 	x.Middleware.ExtractTo(api)

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -5,6 +5,21 @@
     "info": {
       "$ref": "#/definitions/X-Tyk-Info"
     },
+    "error_messages": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["code", "message"]
+      }
+    },
     "upstream": {
       "$ref": "#/definitions/X-Tyk-Upstream"
     },
@@ -13,7 +28,8 @@
     },
     "middleware": {
       "$ref": "#/definitions/X-Tyk-Middleware"
-    }
+    },
+    "errors"
   },
   "required": [
     "info",

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -28,8 +28,7 @@
     },
     "middleware": {
       "$ref": "#/definitions/X-Tyk-Middleware"
-    },
-    "errors"
+    }
   },
   "required": [
     "info",

--- a/apidef/schema.json
+++ b/apidef/schema.json
@@ -7,6 +7,24 @@
   "id": "http://jsonschema.net",
   "additionalProperties": false,
   "properties": {
+    "error_messages": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["code", "message"]
+      }
+    },
     "is_site": {
       "type": "boolean"
     },

--- a/config/config.go
+++ b/config/config.go
@@ -1173,7 +1173,7 @@ type Config struct {
 	//  }
 	// }
 	// ```
-	OverrideMessages map[string]TykError `bson:"override_messages" json:"override_messages"`
+	OverrideMessages map[string]apidef.TykError `bson:"override_messages" json:"override_messages"`
 
 	// Cloud flag shows the Gateway runs in Tyk Cloud.
 	Cloud bool `json:"cloud"`

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -1879,7 +1879,7 @@ func TestOverrideErrors(t *testing.T) {
 
 	testConf := ts.Gw.GetConfig()
 
-	testConf.OverrideMessages = map[string]config.TykError{
+	testConf.OverrideMessages = map[string]apidef.TykError{
 		ErrOAuthAuthorizationFieldMissing: {
 			Message: message1,
 			Code:    code1,
@@ -1928,7 +1928,7 @@ func TestOverrideErrors(t *testing.T) {
 	assert(message6, code6, e, i)
 
 	t.Run("Partial override", func(t *testing.T) {
-		testConf.OverrideMessages = map[string]config.TykError{
+		testConf.OverrideMessages = map[string]apidef.TykError{
 			ErrOAuthAuthorizationFieldMissing: {
 				Code: code4,
 			},

--- a/gateway/handler_error.go
+++ b/gateway/handler_error.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	htmltemplate "html/template"
 	"io"
 	"io/ioutil"
@@ -41,6 +42,8 @@ var TykErrors = make(map[string]config.TykError)
 
 func errorAndStatusCode(errType string) (error, int) {
 	err := TykErrors[errType]
+	fmt.Println("-------.--------------Busca: ", errType)
+	fmt.Println("-------retorna:")
 	return errors.New(err.Message), err.Code
 }
 
@@ -53,9 +56,8 @@ func defaultTykErrors() {
 
 func overrideTykErrors(gw *Gateway) {
 	gwConfig := gw.GetConfig()
-
+	fmt.Println("--------OVERRIDING WITH CONFIGS")
 	for id, err := range gwConfig.OverrideMessages {
-
 		overridenErr := TykErrors[id]
 
 		if err.Code != 0 {
@@ -68,6 +70,7 @@ func overrideTykErrors(gw *Gateway) {
 
 		TykErrors[id] = overridenErr
 	}
+	fmt.Println("------AFTEr OVERRIDING:", TykErrors)
 }
 
 // APIError is generic error object returned if there is something wrong with the request

--- a/gateway/handler_error.go
+++ b/gateway/handler_error.go
@@ -393,6 +393,7 @@ func (e *ErrorHandler) getAPIErrorMessage(errType string, r *http.Request) (stri
 
 	// Fall back to global error messages
 	globalErr, exists := TykErrors[errType]
+	fmt.Println("Looking for ", errType, " in:", TykErrors)
 	if !exists {
 		return "An error occurred", http.StatusInternalServerError
 	}

--- a/gateway/handler_error.go
+++ b/gateway/handler_error.go
@@ -360,13 +360,12 @@ func (e *ErrorHandler) getAPIErrorMessage(errType string, r *http.Request) (stri
 					continue
 				}
 
-				// Check if the path matches
-				urlSpec := URLSpec{}
-				// Use the existing matchesPath method to check if the path matches
-				if !urlSpec.matchesPath(r.URL.Path, e.Spec) {
+				// Check if the path matches...ToDO: replace with regex
+				if !strings.HasSuffix(r.URL.Path, errorMeta.Path) {
 					continue
 				}
 
+				fmt.Println(errorMeta)
 				// Check if there's an error message for this error type
 				if apiErr, exists := errorMeta.ErrorMessages[errType]; exists {
 					return apiErr.Message, apiErr.Code

--- a/gateway/handler_error.go
+++ b/gateway/handler_error.go
@@ -16,8 +16,6 @@ import (
 	"github.com/TykTechnologies/tyk/apidef"
 
 	"github.com/TykTechnologies/tyk-pump/analytics"
-	"github.com/TykTechnologies/tyk/config"
-
 	"github.com/TykTechnologies/tyk/header"
 	"github.com/TykTechnologies/tyk/request"
 )
@@ -38,7 +36,7 @@ const (
 
 var errCustomBodyResponse = errors.New("errCustomBodyResponse")
 
-var TykErrors = make(map[string]config.TykError)
+var TykErrors = make(map[string]apidef.TykError)
 
 func (e *ErrorHandler) errorAndStatusCode(errType string) (error, int) {
 	message, code := e.getAPIErrorMessage(errType)
@@ -46,7 +44,7 @@ func (e *ErrorHandler) errorAndStatusCode(errType string) (error, int) {
 }
 
 func defaultTykErrors() {
-	TykErrors = make(map[string]config.TykError)
+	TykErrors = make(map[string]apidef.TykError)
 
 	initAuthKeyErrors()
 	initOauth2KeyExistsErrors()
@@ -353,6 +351,8 @@ func (e *ErrorHandler) getAPIErrorMessage(errType string) (string, int) {
 				if apiErr, exists := ext.ErrorMessages[errType]; exists {
 					return apiErr.Message, apiErr.Code
 				}
+			} else {
+				fmt.Println("--------errors nil for api")
 			}
 		}
 	}

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -694,9 +694,9 @@ func (t *BaseMiddleware) generateSessionID(id string) string {
 	return t.Gw.generateToken(t.Spec.OrgID, keyID)
 }
 
-func (t *BaseMiddleware) GetErrorAndStatusCode(errType string) (error, int) {
+func (t *BaseMiddleware) GetErrorAndStatusCode(errType string, r *http.Request) (error, int) {
 	handler := ErrorHandler{t}
-	return handler.errorAndStatusCode(errType)
+	return handler.errorAndStatusCode(errType, r)
 }
 
 type TykResponseHandler interface {

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -694,6 +694,11 @@ func (t *BaseMiddleware) generateSessionID(id string) string {
 	return t.Gw.generateToken(t.Spec.OrgID, keyID)
 }
 
+func (t *BaseMiddleware) GetErrorAndStatusCode(errType string) (error, int) {
+	handler := ErrorHandler{t}
+	return handler.errorAndStatusCode(errType)
+}
+
 type TykResponseHandler interface {
 	Enabled() bool
 	Init(interface{}, *APISpec) error

--- a/gateway/model_apispec.go
+++ b/gateway/model_apispec.go
@@ -60,7 +60,7 @@ type APISpec struct {
 
 	OASRouter routers.Router
 	// ErrorMessages allows API-level customization of error messages
-	ErrorMessages map[string]config.TykError `bson:"error_messages" json:"error_messages"`
+	ErrorMessages map[string]apidef.TykError `bson:"error_messages" json:"error_messages"`
 }
 
 // CheckSpecMatchesStatus checks if a URL spec has a specific status.

--- a/gateway/model_apispec.go
+++ b/gateway/model_apispec.go
@@ -59,6 +59,8 @@ type APISpec struct {
 	GraphEngine graphengine.Engine
 
 	OASRouter routers.Router
+	// ErrorMessages allows API-level customization of error messages
+	ErrorMessages map[string]config.TykError `bson:"error_messages" json:"error_messages"`
 }
 
 // CheckSpecMatchesStatus checks if a URL spec has a specific status.

--- a/gateway/mw_auth_key.go
+++ b/gateway/mw_auth_key.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -35,6 +36,7 @@ const (
 )
 
 func initAuthKeyErrors() {
+	fmt.Println("----------Inicia default values for errors---------")
 	TykErrors[ErrAuthAuthorizationFieldMissing] = config.TykError{
 		Message: MsgAuthFieldMissing,
 		Code:    http.StatusUnauthorized,

--- a/gateway/mw_auth_key.go
+++ b/gateway/mw_auth_key.go
@@ -112,13 +112,13 @@ func (k *AuthKey) ProcessRequest(_ http.ResponseWriter, r *http.Request, _ inter
 		log.Debug("Trying to find key by client certificate")
 		certHash = k.Spec.OrgID + crypto.HexSHA256(r.TLS.PeerCertificates[0].Raw)
 		if time.Now().After(r.TLS.PeerCertificates[0].NotAfter) {
-			return errorAndStatusCode(ErrAuthCertExpired)
+			return k.GetErrorAndStatusCode(ErrAuthCertExpired)
 		}
 
 		key = k.Gw.generateToken(k.Spec.OrgID, certHash)
 	} else {
 		k.Logger().Info("Attempted access with malformed header, no auth header found.")
-		return errorAndStatusCode(ErrAuthAuthorizationFieldMissing)
+		return k.GetErrorAndStatusCode(ErrAuthAuthorizationFieldMissing)
 	}
 
 	session, keyExists = k.CheckSessionAndIdentityForValidKey(key, r)
@@ -194,7 +194,7 @@ func (k *AuthKey) reportInvalidKey(key string, r *http.Request, msg string, errM
 	// Report in health check
 	reportHealthValue(k.Spec, KeyFailure, "1")
 
-	return errorAndStatusCode(errMsg)
+	return k.GetErrorAndStatusCode(errMsg)
 }
 
 func (k *AuthKey) validateSignature(r *http.Request, key string) (error, int) {

--- a/gateway/mw_auth_key.go
+++ b/gateway/mw_auth_key.go
@@ -28,10 +28,12 @@ const (
 	ErrAuthCertNotFound              = "auth.cert_not_found"
 	ErrAuthCertExpired               = "auth.cert_expired"
 	ErrAuthKeyIsInvalid              = "auth.key_is_invalid"
+	ErrValidationRequestFailed       = "validation.request_failed"
 
-	MsgNonExistentKey  = "Attempted access with non-existent key."
-	MsgNonExistentCert = "Attempted access with non-existent cert."
-	MsgInvalidKey      = "Attempted access with invalid key."
+	MsgNonExistentKey       = "Attempted access with non-existent key."
+	MsgNonExistentCert      = "Attempted access with non-existent cert."
+	MsgInvalidKey           = "Attempted access with invalid key."
+	ValidationRequestFailed = "validation did not pass"
 )
 
 func initAuthKeyErrors() {
@@ -39,6 +41,11 @@ func initAuthKeyErrors() {
 	TykErrors[ErrAuthAuthorizationFieldMissing] = apidef.TykError{
 		Message: MsgAuthFieldMissing,
 		Code:    http.StatusUnauthorized,
+	}
+
+	TykErrors[ErrValidationRequestFailed] = apidef.TykError{
+		Message: ValidationRequestFailed,
+		Code:    http.StatusUnprocessableEntity,
 	}
 
 	TykErrors[ErrAuthKeyNotFound] = apidef.TykError{

--- a/gateway/mw_auth_key.go
+++ b/gateway/mw_auth_key.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/TykTechnologies/tyk/apidef"
-	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/internal/crypto"
 	"github.com/TykTechnologies/tyk/internal/httpctx"
 	"github.com/TykTechnologies/tyk/internal/otel"
@@ -37,27 +36,27 @@ const (
 
 func initAuthKeyErrors() {
 	fmt.Println("----------Inicia default values for errors---------")
-	TykErrors[ErrAuthAuthorizationFieldMissing] = config.TykError{
+	TykErrors[ErrAuthAuthorizationFieldMissing] = apidef.TykError{
 		Message: MsgAuthFieldMissing,
 		Code:    http.StatusUnauthorized,
 	}
 
-	TykErrors[ErrAuthKeyNotFound] = config.TykError{
+	TykErrors[ErrAuthKeyNotFound] = apidef.TykError{
 		Message: MsgApiAccessDisallowed,
 		Code:    http.StatusForbidden,
 	}
 
-	TykErrors[ErrAuthCertNotFound] = config.TykError{
+	TykErrors[ErrAuthCertNotFound] = apidef.TykError{
 		Message: MsgApiAccessDisallowed,
 		Code:    http.StatusForbidden,
 	}
 
-	TykErrors[ErrAuthKeyIsInvalid] = config.TykError{
+	TykErrors[ErrAuthKeyIsInvalid] = apidef.TykError{
 		Message: MsgApiAccessDisallowed,
 		Code:    http.StatusForbidden,
 	}
 
-	TykErrors[ErrAuthCertExpired] = config.TykError{
+	TykErrors[ErrAuthCertExpired] = apidef.TykError{
 		Message: MsgCertificateExpired,
 		Code:    http.StatusForbidden,
 	}

--- a/gateway/mw_auth_key.go
+++ b/gateway/mw_auth_key.go
@@ -111,13 +111,13 @@ func (k *AuthKey) ProcessRequest(_ http.ResponseWriter, r *http.Request, _ inter
 		log.Debug("Trying to find key by client certificate")
 		certHash = k.Spec.OrgID + crypto.HexSHA256(r.TLS.PeerCertificates[0].Raw)
 		if time.Now().After(r.TLS.PeerCertificates[0].NotAfter) {
-			return k.GetErrorAndStatusCode(ErrAuthCertExpired)
+			return k.GetErrorAndStatusCode(ErrAuthCertExpired, r)
 		}
 
 		key = k.Gw.generateToken(k.Spec.OrgID, certHash)
 	} else {
 		k.Logger().Info("Attempted access with malformed header, no auth header found.")
-		return k.GetErrorAndStatusCode(ErrAuthAuthorizationFieldMissing)
+		return k.GetErrorAndStatusCode(ErrAuthAuthorizationFieldMissing, r)
 	}
 
 	session, keyExists = k.CheckSessionAndIdentityForValidKey(key, r)
@@ -193,7 +193,7 @@ func (k *AuthKey) reportInvalidKey(key string, r *http.Request, msg string, errM
 	// Report in health check
 	reportHealthValue(k.Spec, KeyFailure, "1")
 
-	return k.GetErrorAndStatusCode(errMsg)
+	return k.GetErrorAndStatusCode(errMsg, r)
 }
 
 func (k *AuthKey) validateSignature(r *http.Request, key string) (error, int) {

--- a/gateway/mw_oas_validate_request.go
+++ b/gateway/mw_oas_validate_request.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -76,10 +77,10 @@ func (k *ValidateRequest) ProcessRequest(w http.ResponseWriter, r *http.Request,
 		return nil, http.StatusOK
 	}
 
-	/*errResponseCode := http.StatusUnprocessableEntity
+	errResponseCode := http.StatusUnprocessableEntity
 	if validateRequest.ErrorResponseCode != 0 {
 		errResponseCode = validateRequest.ErrorResponseCode
-	}*/
+	}
 
 	// Validate request
 	requestValidationInput := &openapi3filter.RequestValidationInput{
@@ -95,8 +96,12 @@ func (k *ValidateRequest) ProcessRequest(w http.ResponseWriter, r *http.Request,
 
 	err := openapi3filter.ValidateRequest(r.Context(), requestValidationInput)
 	if err != nil {
-		//return fmt.Errorf("request validation error: %w", err), errResponseCode
-		return k.GetErrorAndStatusCode(ErrValidationRequestFailed, r)
+		retErr, retCode := k.GetErrorAndStatusCode(ErrValidationRequestFailed, r)
+		if retErr.Error() == ValidationRequestFailed {
+			// in case is the default then we return the old msg
+			return fmt.Errorf("request validation error: %w", err), errResponseCode
+		}
+		return retErr, retCode
 	}
 
 	// Handle Success

--- a/gateway/mw_oas_validate_request.go
+++ b/gateway/mw_oas_validate_request.go
@@ -2,7 +2,6 @@ package gateway
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -77,10 +76,10 @@ func (k *ValidateRequest) ProcessRequest(w http.ResponseWriter, r *http.Request,
 		return nil, http.StatusOK
 	}
 
-	errResponseCode := http.StatusUnprocessableEntity
+	/*errResponseCode := http.StatusUnprocessableEntity
 	if validateRequest.ErrorResponseCode != 0 {
 		errResponseCode = validateRequest.ErrorResponseCode
-	}
+	}*/
 
 	// Validate request
 	requestValidationInput := &openapi3filter.RequestValidationInput{
@@ -96,7 +95,8 @@ func (k *ValidateRequest) ProcessRequest(w http.ResponseWriter, r *http.Request,
 
 	err := openapi3filter.ValidateRequest(r.Context(), requestValidationInput)
 	if err != nil {
-		return fmt.Errorf("request validation error: %w", err), errResponseCode
+		//return fmt.Errorf("request validation error: %w", err), errResponseCode
+		return k.GetErrorAndStatusCode(ErrValidationRequestFailed, r)
 	}
 
 	// Handle Success

--- a/gateway/mw_oauth2_key_exists.go
+++ b/gateway/mw_oauth2_key_exists.go
@@ -77,13 +77,13 @@ func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request,
 	if len(parts) < 2 {
 		logger.Info("Attempted access with malformed header, no auth header found.")
 
-		return errorAndStatusCode(ErrOAuthAuthorizationFieldMissing)
+		return k.GetErrorAndStatusCode(ErrOAuthAuthorizationFieldMissing)
 	}
 
 	if strings.ToLower(parts[0]) != "bearer" {
 		logger.Info("Bearer token malformed")
 
-		return errorAndStatusCode(ErrOAuthAuthorizationFieldMalformed)
+		return k.GetErrorAndStatusCode(ErrOAuthAuthorizationFieldMalformed)
 	}
 
 	accessToken := parts[1]
@@ -101,7 +101,7 @@ func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request,
 		// Report in health check
 		reportHealthValue(k.Spec, KeyFailure, "-1")
 
-		return errorAndStatusCode(ErrOAuthKeyNotFound)
+		return k.GetErrorAndStatusCode(ErrOAuthKeyNotFound)
 	}
 
 	// Make sure OAuth-client is still present
@@ -123,7 +123,7 @@ func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request,
 	}
 	if oauthClientDeleted {
 		logger.WithField("oauthClientID", session.OauthClientID).Warning("Attempted access for deleted OAuth client.")
-		return errorAndStatusCode(ErrOAuthClientDeleted)
+		return k.GetErrorAndStatusCode(ErrOAuthClientDeleted)
 	}
 
 	// Set session state on context, we will need it later

--- a/gateway/mw_oauth2_key_exists.go
+++ b/gateway/mw_oauth2_key_exists.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/internal/otel"
 
 	"github.com/TykTechnologies/tyk/apidef"
@@ -23,22 +22,22 @@ const (
 )
 
 func initOauth2KeyExistsErrors() {
-	TykErrors[ErrOAuthAuthorizationFieldMissing] = config.TykError{
+	TykErrors[ErrOAuthAuthorizationFieldMissing] = apidef.TykError{
 		Message: MsgAuthFieldMissing,
 		Code:    http.StatusBadRequest,
 	}
 
-	TykErrors[ErrOAuthAuthorizationFieldMalformed] = config.TykError{
+	TykErrors[ErrOAuthAuthorizationFieldMalformed] = apidef.TykError{
 		Message: MsgBearerMailformed,
 		Code:    http.StatusBadRequest,
 	}
 
-	TykErrors[ErrOAuthKeyNotFound] = config.TykError{
+	TykErrors[ErrOAuthKeyNotFound] = apidef.TykError{
 		Message: MsgKeyNotAuthorized,
 		Code:    http.StatusForbidden,
 	}
 
-	TykErrors[ErrOAuthClientDeleted] = config.TykError{
+	TykErrors[ErrOAuthClientDeleted] = apidef.TykError{
 		Message: MsgOauthClientRevoked,
 		Code:    http.StatusForbidden,
 	}

--- a/gateway/mw_oauth2_key_exists.go
+++ b/gateway/mw_oauth2_key_exists.go
@@ -41,6 +41,7 @@ func initOauth2KeyExistsErrors() {
 		Message: MsgOauthClientRevoked,
 		Code:    http.StatusForbidden,
 	}
+
 }
 
 // Oauth2KeyExists will check if the key being used to access the API is in the request data,

--- a/gateway/mw_oauth2_key_exists.go
+++ b/gateway/mw_oauth2_key_exists.go
@@ -76,13 +76,13 @@ func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request,
 	if len(parts) < 2 {
 		logger.Info("Attempted access with malformed header, no auth header found.")
 
-		return k.GetErrorAndStatusCode(ErrOAuthAuthorizationFieldMissing)
+		return k.GetErrorAndStatusCode(ErrOAuthAuthorizationFieldMissing, r)
 	}
 
 	if strings.ToLower(parts[0]) != "bearer" {
 		logger.Info("Bearer token malformed")
 
-		return k.GetErrorAndStatusCode(ErrOAuthAuthorizationFieldMalformed)
+		return k.GetErrorAndStatusCode(ErrOAuthAuthorizationFieldMalformed, r)
 	}
 
 	accessToken := parts[1]
@@ -100,7 +100,7 @@ func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request,
 		// Report in health check
 		reportHealthValue(k.Spec, KeyFailure, "-1")
 
-		return k.GetErrorAndStatusCode(ErrOAuthKeyNotFound)
+		return k.GetErrorAndStatusCode(ErrOAuthKeyNotFound, r)
 	}
 
 	// Make sure OAuth-client is still present
@@ -122,7 +122,7 @@ func (k *Oauth2KeyExists) ProcessRequest(w http.ResponseWriter, r *http.Request,
 	}
 	if oauthClientDeleted {
 		logger.WithField("oauthClientID", session.OauthClientID).Warning("Attempted access for deleted OAuth client.")
-		return k.GetErrorAndStatusCode(ErrOAuthClientDeleted)
+		return k.GetErrorAndStatusCode(ErrOAuthClientDeleted, r)
 	}
 
 	// Set session state on context, we will need it later

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -569,6 +569,7 @@ func (gw *Gateway) syncAPISpecs() (int, error) {
 			mainLog.WithError(err).WithField("spec", v.Name).Error("Skipping loading spec because it failed validation")
 			continue
 		}
+		fmt.Printf("\ncargando apis, el error: %v \n", v.ErrorMessages)
 		filter = append(filter, v)
 	}
 

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -364,6 +364,7 @@ func (gw *Gateway) apisByIDLen() int {
 // Create all globals and init connection handlers
 func (gw *Gateway) setupGlobals() {
 	defaultTykErrors()
+	overrideTykErrors(gw)
 
 	gwConfig := gw.GetConfig()
 	checkup.Run(&gwConfig)
@@ -1315,8 +1316,6 @@ func (gw *Gateway) initSystem() error {
 		gw.SetConfig(gwConfig)
 		gw.afterConfSetup()
 	}
-
-	overrideTykErrors(gw)
 
 	gwConfig = gw.GetConfig()
 	if gwConfig.Storage.Type != "redis" {

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -532,7 +532,6 @@ func (gw *Gateway) syncAPISpecs() (int, error) {
 		}
 
 		s = tmpSpecs
-
 		mainLog.Debug("Downloading API Configurations from Dashboard Service")
 	} else if gw.GetConfig().SlaveOptions.UseRPC {
 		mainLog.Debug("Using RPC Configuration")
@@ -565,6 +564,8 @@ func (gw *Gateway) syncAPISpecs() (int, error) {
 	}
 	var filter []*APISpec
 	for _, v := range s {
+		mainLog.Infof("\napis: %+v \n", v.Name)
+		mainLog.Infof("\n: %+v \n", v.APIDefinition.ErrorMessages)
 		if err := v.Validate(gw.GetConfig().OAS); err != nil {
 			mainLog.WithError(err).WithField("spec", v.Name).Error("Skipping loading spec because it failed validation")
 			continue

--- a/templates/error_401.json
+++ b/templates/error_401.json
@@ -1,0 +1,3 @@
+{
+    "error": "Esto es un ejemplo"
+}


### PR DESCRIPTION
### **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Enhancement


___

### **Description**
- Add API-level error message customization support

- Update OAS and core API schemas for error messages

- Refactor error handling to use API-specific overrides

- Add example custom error JSON template


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>root.go</strong><dd><code>Add OAS error message customization field and extraction logic</code></dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7115/files#diff-9c56b2bdb992e0a7db76809d4c516e1cd61c9486c7f0437b344c0032476af80f">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>handler_error.go</strong><dd><code>Refactor error handling to support API-specific overrides</code></dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7115/files#diff-d3b05530ad23401f3b8f33bb1a467cd807a29a6b09c7430d01d069f626b20f77">+53/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>middleware.go</strong><dd><code>Add method for middleware to access API error overrides</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7115/files#diff-703054910891a4db633eca0f42ed779d6b4fa75cd9b3aa4c503e681364201c1b">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>model_apispec.go</strong><dd><code>Add ErrorMessages field to APISpec for per-API errors</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7115/files#diff-80c49b9bdb411a3d5a4706ec3ff138ef44154d0306040c19eba1cb5559f199d6">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mw_auth_key.go</strong><dd><code>Refactor auth key error returns to use API overrides</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7115/files#diff-aeba053023a54c723dd9f83837e29ca0b2d9a212bc98fa6ad4bbb062669a1cf0">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mw_oauth2_key_exists.go</strong><dd><code>Refactor OAuth2 key error returns to use API overrides</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7115/files#diff-c50b0affcb835d15ff9bd169b21775b8023ebb0558a0c59d6c26cb821db544e9">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>server.go</strong><dd><code>Ensure error overrides are set up in gateway initialization</code></dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7115/files#diff-4652d1bf175a0be8f5e61ef7177c9666f23e077d8626b73ac9d13358fa8b525b">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>x-tyk-api-gateway.json</strong><dd><code>Add error_messages property to OAS API schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7115/files#diff-78828969c0c04cc1a776dfc93a8bad3c499a8c83e6169f83e96d090bed3e7dd0">+17/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>schema.json</strong><dd><code>Add error_messages property to core API schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7115/files#diff-32c8b876e77d1639afb2d20c37b74ed9e149b72cc7de429def13d3d454e075f3">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>error_401.json</strong><dd><code>Add example custom error JSON template</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7115/files#diff-51c3c82278edee6afd631f7b48afaf314e74906a91aaac654075961765d4775c">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>