### PR TITLE
[TT-15065] Mock response stops working after kin-openapi upgrade

### DIFF
--- a/apidef/oas/example.go
+++ b/apidef/oas/example.go
@@ -36,6 +36,8 @@ func emptyExampleVal(schema *openapi3.Schema) interface{} {
 		return 0
 	case schema.Type.Is(openapi3.TypeBoolean):
 		return true
+	case schema.Type.Is(openapi3.TypeArray):
+		return []interface{}{}
 	default:
 		return nil
 	}

--- a/apidef/oas/example.go
+++ b/apidef/oas/example.go
@@ -4,6 +4,10 @@ import "github.com/getkin/kin-openapi/openapi3"
 
 // ExampleExtractor returns an example payload according to the openapi3.SchemaRef object.
 func ExampleExtractor(schema *openapi3.SchemaRef) interface{} {
+	if schema == nil {
+		return nil
+	}
+
 	val := schema.Value
 	if val.Example != nil {
 		return val.Example

--- a/gateway/mock_response.go
+++ b/gateway/mock_response.go
@@ -129,8 +129,7 @@ func mockFromOAS(r *http.Request, operation *openapi3.Operation, fromOASExamples
 	// Example selection precedence:
 	// 1. Direct example on the media type (media.Example)
 	// 2. Named example from Examples map (media.Examples) - if name provided, use it; otherwise, pick first by sorted key
-	// 3. Example from the schema (media.Schema.Value.Example)
-	// If none found, return error
+	// If none found, return fallback solution
 	var example interface{}
 
 	// 1. Direct example on the media type
@@ -164,14 +163,9 @@ func mockFromOAS(r *http.Request, operation *openapi3.Operation, fromOASExamples
 		}
 	}
 
-	// 3. Example from the schema
-	if example == nil && media.Schema != nil && media.Schema.Value != nil && media.Schema.Value.Example != nil {
-		example = media.Schema.Value.Example
-	}
-
 	// Nil check: if no example found, return error
 	if example == nil {
-		return http.StatusNotFound, "", nil, nil, errors.New("there is no example response for the content type: " + contentType)
+		example = oas.ExampleExtractor(media.Schema)
 	}
 
 	// Marshal the example to JSON for the response body

--- a/gateway/mock_response_test.go
+++ b/gateway/mock_response_test.go
@@ -538,7 +538,7 @@ func TestMockFromOAS_ExampleHandling(t *testing.T) {
 		}
 	})
 
-	t.Run("fallback handling", func(t *testing.T) {
+	t.Run("fallback handling does not respond with error if example is not provided", func(t *testing.T) {
 		// Test the fallback behavior when examples aren't available
 		operation := openapi3.NewOperation()
 		responses := openapi3.NewResponses()
@@ -574,16 +574,14 @@ func TestMockFromOAS_ExampleHandling(t *testing.T) {
 		req := &http.Request{Header: http.Header{}}
 		code, _, _, _, err := mockFromOAS(req, operation, fromOASExamples)
 
-		assert.Error(t, err)
-		assert.Equal(t, http.StatusNotFound, code)
-		assert.Contains(t, err.Error(), "there is no example response for the content type")
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, code)
 
 		// Test with empty examples map
-		fromOASExamples.Code = 201
+		fromOASExamples.Code = http.StatusCreated
 		code, _, _, _, err = mockFromOAS(req, operation, fromOASExamples)
 
-		assert.Error(t, err)
-		assert.Equal(t, http.StatusNotFound, code)
-		assert.Contains(t, err.Error(), "there is no example response for the content type")
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusCreated, code)
 	})
 }


### PR DESCRIPTION
### **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Bug fix


___

### **Description**
- Fix mock response fallback logic after kin-openapi upgrade

- Use schema-based example extraction when no example is defined

- Add array type handling to example value generator


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>example.go</strong><dd><code>Add array type handling to example value generator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/example.go

<li>Add support for array type in example value generator<br> <li> Return empty array for schemas of type array


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7120/files#diff-c0497e72a44a6bb933a726e099e0d8a019323bbd9caff4dfd7fd8b0776406db1">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mock_response.go</strong><dd><code>Fix mock response fallback to use schema-based extraction</code></dd></summary>
<hr>

gateway/mock_response.go

<li>Change fallback logic to use schema-based example extraction<br> <li> Remove direct schema example usage in favor of extractor<br> <li> Ensure mock responses are generated even if no example is defined


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7120/files#diff-8aef512076b7695a6fa276dfc7f2b11f9e0d3b4a4d7f33b8404cbb29b47d3a9f">+2/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>