### PR TITLE
Merging to release-5.8: [TT-10496] gRPC plugins do not terminate gracefully and cannot be load balanced (#7111)

### DIFF
--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -327,6 +327,9 @@
         "grpc_authority": {
           "type": "string"
         },
+        "grpc_round_robin_load_balancing": {
+          "type": "boolean"
+        },
         "enable_coprocess": {
           "type": "boolean"
         },

--- a/config/config.go
+++ b/config/config.go
@@ -582,6 +582,9 @@ type CoProcessConfig struct {
 	// Authority used in GRPC connection
 	GRPCAuthority string `json:"grpc_authority"`
 
+	// GRPCRoundRobinLoadBalancing enables round robin load balancing for grpc services
+	GRPCRoundRobinLoadBalancing bool `json:"grpc_round_robin_load_balancing"`
+
 	// Sets the path to built-in Tyk modules. This will be part of the Python module lookup path. The value used here is the default one for most installations.
 	PythonPathPrefix string `json:"python_path_prefix"`
 

--- a/gateway/coprocess_grpc.go
+++ b/gateway/coprocess_grpc.go
@@ -100,6 +100,18 @@ func (gw *Gateway) NewGRPCDispatcher() (coprocess.Dispatcher, error) {
 
 	grpcClient = coprocess.NewDispatcherClient(grpcConnection)
 
+<<<<<<< HEAD
+=======
+	isRoundRobinEnabled := gw.GetConfig().CoProcessOptions.GRPCRoundRobinLoadBalancing
+	if isRoundRobinEnabled {
+		dialOptions = append(dialOptions, grpc.WithDefaultServiceConfig(`{"loadBalancingConfig": [{"round_robin":{}}]}`))
+	}
+
+	grpcConnection, err = grpc.NewClient(
+		GetCoProcessGrpcServerTargetUrlAsString(grpcUrl),
+		dialOptions...,
+	)
+>>>>>>> b44f7909f... [TT-10496] gRPC plugins do not terminate gracefully and cannot be load balanced (#7111)
 	if err != nil {
 
 		log.WithFields(logrus.Fields{


### PR DESCRIPTION
### **User description**
[TT-10496] gRPC plugins do not terminate gracefully and cannot be load balanced (#7111)

<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-10496"
title="TT-10496" target="_blank">TT-10496</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>gRPC plugins cannot be load balanced</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20Re_open%20ORDER%20BY%20created%20DESC"
title="Re_open">Re_open</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20community_bug%20ORDER%20BY%20created%20DESC"
title="community_bug">community_bug</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20gRPC%20ORDER%20BY%20created%20DESC"
title="gRPC">gRPC</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20github%20ORDER%20BY%20created%20DESC"
title="github">github</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20jira_escalated%20ORDER%20BY%20created%20DESC"
title="jira_escalated">jira_escalated</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20rel3-2025-candidate-commercial%20ORDER%20BY%20created%20DESC"
title="rel3-2025-candidate-commercial">rel3-2025-candidate-commercial</a>,
<a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20rel3-2025-commitment-commercial%20ORDER%20BY%20created%20DESC"
title="rel3-2025-commitment-commercial">rel3-2025-commitment-commercial</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why

---------

Co-authored-by: Laurentiu <6229829+lghiur@users.noreply.github.com>

[TT-10496]: https://tyktech.atlassian.net/browse/TT-10496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add round robin load balancing option for gRPC plugins

- Update config and schema to support new load balancing flag

- Modify gRPC dispatcher to use round robin when enabled

- Improve gRPC plugin termination and load balancing behavior


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.go</strong><dd><code>Add round robin load balancing config to CoProcessConfig</code>&nbsp; </dd></summary>
<hr>

config/config.go

<li>Add <code>GRPCRoundRobinLoadBalancing</code> boolean to <code>CoProcessConfig</code><br> <li> Document new config option for enabling round robin load balancing


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7121/files#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>schema.json</strong><dd><code>Update schema for round robin load balancing config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/linter/schema.json

<li>Add <code>grpc_round_robin_load_balancing</code> boolean property to schema<br> <li> Ensure config validation supports new load balancing option


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7121/files#diff-103cec746d3e61d391c5a67c171963f66fea65d651d704d5540e60aa5d574f46">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coprocess_grpc.go</strong><dd><code>Enable round robin load balancing in gRPC dispatcher</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/coprocess_grpc.go

<li>Check new config flag for round robin load balancing<br> <li> Add gRPC dial option for round robin when enabled<br> <li> Refactor dispatcher creation to support new option


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7121/files#diff-53c2775617dfe21b5a271269cd737bcc2818e2f0243b9a6e6bf5a73b14180334">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>