### PR TITLE
Merging to release-5.8: [TT-10496] GRPC plugins do not work with service names (#7052)

### DIFF
--- a/gateway/coprocess_grpc.go
+++ b/gateway/coprocess_grpc.go
@@ -23,11 +23,7 @@ type GRPCDispatcher struct {
 	coprocess.Dispatcher
 }
 
-<<<<<<< HEAD
-func (gw *Gateway) dialer(_ string, timeout time.Duration) (net.Conn, error) {
-=======
 func (gw *Gateway) GetCoProcessGrpcServerTargetURL() (*url.URL, error) {
->>>>>>> 41d831444... [TT-10496] GRPC plugins do not work with service names (#7052)
 	grpcURL, err := url.Parse(gw.GetConfig().CoProcessOptions.CoProcessGRPCServer)
 	if err != nil {
 		log.WithFields(logrus.Fields{

--- a/gateway/coprocess_grpc_test.go
+++ b/gateway/coprocess_grpc_test.go
@@ -1,0 +1,71 @@
+package gateway
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/TykTechnologies/tyk/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetCoProcessGrpcServerTargetURL(t *testing.T) {
+	tests := []struct {
+		name                string
+		coProcessGRPCServer string
+		expectedURL         string
+		expectError         bool
+	}{
+		{
+			name:                "Invalid URL",
+			coProcessGRPCServer: "://invalid",
+			expectedURL:         "",
+			expectError:         true,
+		},
+		{
+			name:                "URL without tcp:// prefix",
+			coProcessGRPCServer: "localhost:9000",
+			expectedURL:         "localhost:9000",
+			expectError:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a gateway instance with mock config
+			gw := &Gateway{}
+
+			// Set up the config with the test CoProcessGRPCServer value
+			conf := config.Config{}
+			conf.CoProcessOptions.CoProcessGRPCServer = tt.coProcessGRPCServer
+			gw.SetConfig(conf)
+
+			// Call the function being tested
+			grpcURL, err := gw.GetCoProcessGrpcServerTargetURL()
+
+			// Check if error matches expectation
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, grpcURL)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, grpcURL)
+				assert.Equal(t, tt.expectedURL, grpcURL.String())
+			}
+		})
+	}
+}
+
+func TestGetCoProcessGrpcServerTargetURLAsString(t *testing.T) {
+	// Create a test URL
+	testURL, _ := url.Parse("localhost:9000")
+
+	// Call the function being tested
+	result := GetCoProcessGrpcServerTargetUrlAsString(testURL)
+
+	// Check the result
+	assert.Equal(t, "localhost:9000", result)
+}
+
+func TestGetCoProcessGrpcServerTargetUrlAsString(t *testing.T) {
+	assert.Equal(t, "localhost:3000", GetCoProcessGrpcServerTargetUrlAsString(&url.URL{Scheme: "tcp", Host: "localhost:3000"}))
+}


### PR DESCRIPTION
### **User description**
[TT-10496] GRPC plugins do not work with service names (#7052)

### **User description**
Removed dialer when trying to load grpc plugins and used non-depcrecated
methods that should make use of dns instead of forcing tcp

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Replaced deprecated gRPC dial method with modern connection approach

- Removed custom dialer to enable DNS-based service name resolution

- Adopted grpc.WithTransportCredentials(insecure.NewCredentials()) for security

- Added unit tests for new gRPC server URL handling logic


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coprocess_grpc.go</strong><dd><code>Refactor gRPC connection logic and enable service name support</code></dd></summary>
<hr>

gateway/coprocess_grpc.go

<li>Removed deprecated grpc.Dial with custom dialer<br> <li> Introduced helper methods for gRPC server URL parsing<br> <li> Switched to grpc.NewClient and modern dial options<br> <li> Enabled DNS-based service name resolution for gRPC plugins


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7122/files#diff-53c2775617dfe21b5a271269cd737bcc2818e2f0243b9a6e6bf5a73b14180334">+24/-17</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coprocess_grpc_test.go</strong><dd><code>Add tests for gRPC server URL parsing and conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/coprocess_grpc_test.go

<li>Added unit tests for gRPC server URL parsing logic<br> <li> Tested error handling and string conversion of target URLs<br> <li> Ensured correct handling of various URL formats


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7122/files#diff-f4f62aa096b94059b112a9e645c16f5661195b3cb59d79ef5fe475fcb7660de1">+71/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>