### PR TITLE
Merging to release-5.8: [TT-7932] Errors migrating some versioned APIs to OAS (#7101)

### DIFF
--- a/apidef/oas/root.go
+++ b/apidef/oas/root.go
@@ -194,10 +194,6 @@ func (v *Versioning) Fill(api apidef.APIDefinition) {
 		return v.Versions[i].Name < v.Versions[j].Name
 	})
 
-	if ShouldOmit(v.Versions) {
-		v.Versions = nil
-	}
-
 	v.StripVersioningData = api.VersionDefinition.StripVersioningData
 	v.FallbackToDefault = api.VersionDefinition.FallbackToDefault
 	v.UrlVersioningPattern = api.VersionDefinition.UrlVersioningPattern

--- a/apidef/oas/root_test.go
+++ b/apidef/oas/root_test.go
@@ -391,6 +391,7 @@ func FillTestVersionData(t *testing.T, index int) apidef.VersionData {
 
 func TestVersioning(t *testing.T) {
 	var emptyVersioning Versioning
+	emptyVersioning.Versions = []VersionToID{}
 
 	var convertedAPI apidef.APIDefinition
 	emptyVersioning.ExtractTo(&convertedAPI)


### PR DESCRIPTION
### **User description**
[TT-7932] Errors migrating some versioned APIs to OAS (#7101)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-7932"
title="TT-7932" target="_blank">TT-7932</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Errors migrating some versioned APIs to OAS</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20codilime_refined%20ORDER%20BY%20created%20DESC"
title="codilime_refined">codilime_refined</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

## Description

When migrating a Swagger 2.0 API to a Tyk OAS API using the API
migration endpoint or UI, the migration fails with a validation error
related to the versioning field. The error occurs because the migration
process incorrectly sets the versions field to null instead of an empty
array [] when the source API doesn't have versioning information.

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix migration bug for APIs without versioning info

- Ensure `Versions` is set to empty array, not null

- Update test to initialize `Versions` as empty array


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>root.go</strong><dd><code>Preserve empty array for
Versions in migration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/root.go

<li>Removed logic that set <code>Versions</code> to nil when empty<br>
<li> Now always preserves empty array for <code>Versions</code>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7101/files#diff-9c56b2bdb992e0a7db76809d4c516e1cd61c9486c7f0437b344c0032476af80f">+0/-4</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>root_test.go</strong><dd><code>Test empty Versions
array initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; </dd></summary>
<hr>

apidef/oas/root_test.go

<li>Updated test to initialize <code>Versions</code> as empty array<br>
<li> Ensures correct handling of empty versioning in tests


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7101/files#diff-4d144465b7fabaf2db8915de1ce3b6ff8c91a93c62d614c38fa38bdae28e23a2">+1/-0</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary> Need help?</summary><li>Type <code>/help how to
...</code> in the comments thread for any questions about PR-Agent
usage.</li><li>Check out the <a
href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a>
for more information.</li></details>

[TT-7932]: https://tyktech.atlassian.net/browse/TT-7932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix migration bug: preserve empty array for `Versions` field

- Remove logic that set `Versions` to nil when empty

- Update test to initialize `Versions` as empty array

- Ensure correct handling of APIs without versioning info


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>root.go</strong><dd><code>Preserve empty array for Versions in migration logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/root.go

<li>Removed code that set <code>Versions</code> to nil when empty<br> <li> Now always preserves empty array for <code>Versions</code> during migration


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7135/files#diff-9c56b2bdb992e0a7db76809d4c516e1cd61c9486c7f0437b344c0032476af80f">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>root_test.go</strong><dd><code>Test empty Versions array initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/root_test.go

<li>Updated test to initialize <code>Versions</code> as empty array<br> <li> Ensures correct handling of empty versioning in tests


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7135/files#diff-4d144465b7fabaf2db8915de1ce3b6ff8c91a93c62d614c38fa38bdae28e23a2">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>