### PR TITLE
Merging to release-5.9: [TT-8963] Unable to loop mocked endpoint (#7105)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 /tyk
 /Dockerfile
+/go.work
+/go.work.sum

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ testapps/
 /*.json
 /*.bak
 /.air.toml
+/go.work
+/go.work.sum
 
 /go.work
 /go.work.sum

--- a/apidef/oas/header.go
+++ b/apidef/oas/header.go
@@ -14,13 +14,22 @@ type Header struct {
 type Headers []Header
 
 // Map transforms Headers into a map.
-func (hs Headers) Map() map[string]string {
-	var headersMap = make(map[string]string, len(hs))
-	for _, h := range hs {
+func (hs *Headers) Map() map[string]string {
+	if hs == nil {
+		return map[string]string{}
+	}
+
+	var headersMap = make(map[string]string, len(*hs))
+	for _, h := range *hs {
 		headersMap[h.Name] = h.Value
 	}
 
 	return headersMap
+}
+
+// Add new header entry.
+func (hs *Headers) Add(hdr, value string) {
+	*hs = append(*hs, Header{Name: hdr, Value: value})
 }
 
 // NewHeaders creates Headers from in map.

--- a/ci/tests/tracing/scenarios/tyk_tykprotocol_200.yml
+++ b/ci/tests/tracing/scenarios/tyk_tykprotocol_200.yml
@@ -12,7 +12,7 @@ spec:
       - key: Content-Type
         value: application/json
   specs:
-  - name: /tykprotocl/ip http attributes
+  - name: /tykprotocol/ip http attributes
     selector: span[tracetest.span.type="http" name="GET /tykprotocol/ip" http.method="GET"]
     assertions:
     - attr:http.status_code = 200

--- a/ctx/ctx.go
+++ b/ctx/ctx.go
@@ -33,6 +33,7 @@ const (
 	TrackThisEndpoint
 	DoNotTrackThisEndpoint
 	UrlRewritePath
+	InternalRedirectTarget
 	RequestMethod
 	OrigRequestURL
 	LoopLevel
@@ -47,7 +48,6 @@ const (
 	RequestStatus
 	GraphQLRequest
 	GraphQLIsWebSocketUpgrade
-	OASOperation
 
 	// CacheOptions holds cache options required for cache writer middleware.
 	CacheOptions

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -3178,6 +3178,25 @@ func ctxGetUrlRewritePath(r *http.Request) string {
 	return ""
 }
 
+func ctxSetInternalRedirectTarget(r *http.Request, u *url.URL) {
+	setCtxValue(r, ctx.InternalRedirectTarget, u)
+}
+
+func ctxGetInternalRedirectTarget(r *http.Request) *url.URL {
+	if v := r.Context().Value(ctx.InternalRedirectTarget); v != nil {
+		if val, ok := v.(*url.URL); ok {
+			return val
+		}
+	}
+
+	if r.URL == nil {
+		return nil
+	}
+
+	clone := *r.URL
+	return &clone
+}
+
 func ctxSetCheckLoopLimits(r *http.Request, b bool) {
 	setCtxValue(r, ctx.CheckLoopLimits, b)
 }
@@ -3351,14 +3370,6 @@ func ctxIncThrottleLevel(r *http.Request, throttleLimit int) {
 	ctxSetThrottleLevel(r, ctxThrottleLevel(r)+1)
 }
 
-func ctxTraceEnabled(r *http.Request) bool {
-	return r.Context().Value(ctx.Trace) != nil
-}
-
-func ctxSetTrace(r *http.Request) {
-	setCtxValue(r, ctx.Trace, true)
-}
-
 func ctxSetSpanAttributes(r *http.Request, mwName string, attrs ...otel.SpanAttribute) {
 	if len(attrs) > 0 {
 		setCtxValue(r, mwName, attrs)
@@ -3382,17 +3393,6 @@ func ctxSetRequestStatus(r *http.Request, stat RequestStatus) {
 func ctxGetRequestStatus(r *http.Request) (stat RequestStatus) {
 	if v := r.Context().Value(ctx.RequestStatus); v != nil {
 		stat = v.(RequestStatus)
-	}
-	return
-}
-
-func ctxSetOperation(r *http.Request, op *Operation) {
-	setCtxValue(r, ctx.OASOperation, op)
-}
-
-func ctxGetOperation(r *http.Request) (op *Operation) {
-	if v := r.Context().Value(ctx.OASOperation); v != nil {
-		op = v.(*Operation)
 	}
 	return
 }

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -1500,34 +1500,34 @@ func Test_LoadAPIsFromRPC(t *testing.T) {
 
 func TestAPISpec_hasMock(t *testing.T) {
 	s := APISpec{APIDefinition: &apidef.APIDefinition{}}
-	assert.False(t, s.hasMock())
+	assert.False(t, s.hasActiveMock())
 
 	s.IsOAS = true
-	assert.False(t, s.hasMock())
+	assert.False(t, s.hasActiveMock())
 
 	s.OAS = oas.OAS{}
-	assert.False(t, s.hasMock())
+	assert.False(t, s.hasActiveMock())
 
 	xTyk := &oas.XTykAPIGateway{}
 	s.OAS.SetTykExtension(xTyk)
-	assert.False(t, s.hasMock())
+	assert.False(t, s.hasActiveMock())
 
 	middleware := &oas.Middleware{}
 	xTyk.Middleware = middleware
-	assert.False(t, s.hasMock())
+	assert.False(t, s.hasActiveMock())
 
 	op := &oas.Operation{}
 	middleware.Operations = oas.Operations{
 		"my-operation": op,
 	}
-	assert.False(t, s.hasMock())
+	assert.False(t, s.hasActiveMock())
 
 	mock := &oas.MockResponse{}
 	op.MockResponse = mock
-	assert.False(t, s.hasMock())
+	assert.False(t, s.hasActiveMock())
 
 	mock.Enabled = true
-	assert.True(t, s.hasMock())
+	assert.True(t, s.hasActiveMock())
 }
 
 func TestAPISpec_isStreamingAPI(t *testing.T) {

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -123,7 +123,7 @@ func fixFuncPath(pathPrefix string, funcs []apidef.MiddlewareDefinition) {
 	}
 }
 
-func (gw *Gateway) generateSubRoutes(spec *APISpec, router *mux.Router, logger *logrus.Entry) {
+func (gw *Gateway) generateSubRoutes(spec *APISpec, router *mux.Router) {
 	if spec.GraphQL.GraphQLPlayground.Enabled {
 		gw.loadGraphQLPlayground(spec, router)
 	}
@@ -470,6 +470,10 @@ func (gw *Gateway) processSpec(
 	gw.mwAppendEnabled(&chainArray, &TransformMethod{BaseMiddleware: baseMid.Copy()})
 
 	// Earliest we can respond with cache get 200 ok
+	gw.mwAppendEnabled(&chainArray, newMockResponseMiddleware(
+		baseMid.Copy(),
+		withOpenTelemetry(gw.GetConfig().OpenTelemetry.Enabled),
+	))
 	gw.mwAppendEnabled(&chainArray, &RedisCacheMiddleware{BaseMiddleware: baseMid.Copy(), store: &cacheStore})
 
 	gw.mwAppendEnabled(&chainArray, &VirtualEndpoint{BaseMiddleware: baseMid.Copy()})
@@ -666,13 +670,24 @@ func (d *DummyProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if d.SH.Spec.target.Scheme == "tyk" {
 		handler, _, found := d.Gw.findInternalHttpHandlerByNameOrID(d.SH.Spec.target.Host)
+
 		if !found {
 			handler := ErrorHandler{d.SH.Base()}
 			handler.HandleError(w, r, "Couldn't detect target", http.StatusInternalServerError, true)
 			return
 		}
 
+		targetUrl, err := d.SH.Spec.getRedirectTargetUrl(ctxGetInternalRedirectTarget(r))
+
+		if err != nil {
+			log.Errorf("failed to create internal redirect url: %s", err)
+			handler := ErrorHandler{d.SH.Base()}
+			handler.HandleError(w, r, "Failed to perform internal redirect", http.StatusInternalServerError, true)
+			return
+		}
+
 		d.SH.Spec.SanitizeProxyPaths(r)
+		ctxSetInternalRedirectTarget(r, targetUrl)
 		ctxSetVersionInfo(r, nil)
 		handler.ServeHTTP(w, r)
 		return
@@ -832,7 +847,7 @@ func (gw *Gateway) loadHTTPService(spec *APISpec, apisByListen map[string]int, g
 	for _, prefix := range prefixes {
 		subrouter := router.PathPrefix(prefix).Subrouter()
 
-		gw.generateSubRoutes(spec, subrouter, logrus.NewEntry(log))
+		gw.generateSubRoutes(spec, subrouter)
 
 		if !chainObj.Open {
 			subrouter.Handle(rateLimitEndpoint, chainObj.RateLimitChain)

--- a/gateway/model_apispec.go
+++ b/gateway/model_apispec.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"github.com/TykTechnologies/tyk/internal/errors"
 	"net/http"
 	"net/url"
 	"strings"
@@ -58,7 +59,7 @@ type APISpec struct {
 
 	GraphEngine graphengine.Engine
 
-	OASRouter routers.Router
+	oasRouter routers.Router
 }
 
 // CheckSpecMatchesStatus checks if a URL spec has a specific status.
@@ -138,16 +139,29 @@ func (a *APISpec) injectIntoReqContext(req *http.Request) {
 	}
 }
 
-func (a *APISpec) findOperations(r *http.Request) *Operation {
+func (a *APISpec) findOperation(r *http.Request) *Operation {
 	middleware := a.OAS.GetTykMiddleware()
 	if middleware == nil {
 		return nil
 	}
 
-	route, pathParams, err := a.OASRouter.FindRoute(r)
+	if a.oasRouter == nil {
+		log.Warningf("OAS router not initialized properly. Unable to find route for %s %v", r.Method, r.URL)
+		return nil
+	}
+
+	rClone := *r
+	rClone.URL = ctxGetInternalRedirectTarget(r)
+
+	route, pathParams, err := a.oasRouter.FindRoute(&rClone)
+
+	if errors.Is(err, routers.ErrPathNotFound) {
+		log.Tracef("Unable to find route for %s %v at spec %v", r.Method, r.URL, a.Id)
+		return nil
+	}
 
 	if err != nil {
-		log.Debugf("Error finding route: %v", err)
+		log.Errorf("Error finding route: %v", err)
 		return nil
 	}
 
@@ -161,11 +175,5 @@ func (a *APISpec) findOperations(r *http.Request) *Operation {
 		Operation:  operation,
 		route:      route,
 		pathParams: pathParams,
-	}
-}
-
-func (a *APISpec) SetupOperation(r *http.Request) {
-	if mockOp := a.findOperations(r); mockOp != nil {
-		ctxSetOperation(r, mockOp)
 	}
 }

--- a/gateway/mw_mock_response_test.go
+++ b/gateway/mw_mock_response_test.go
@@ -2,14 +2,16 @@ package gateway
 
 import (
 	"context"
-	"github.com/TykTechnologies/tyk/header"
 	"net/http"
 	"testing"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/internal/uuid"
 	"github.com/TykTechnologies/tyk/test"
 )
 
@@ -583,5 +585,83 @@ func TestMockFromOAS_ExampleHandling(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusCreated, code)
+	})
+}
+
+func TestMockResponseWithInternalRedirect(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	firstApi := BuildOASAPI(func(oasDef *oas.OAS) {
+		opId := uuid.New()
+
+		headers := oas.Headers{}
+		headers.Add("Content-Type", "application/json")
+
+		tykExt := oasDef.GetTykExtension()
+		tykExt.Info.ID = "v1-api-name"
+		tykExt.Info.Name = "v1-api-name"
+		tykExt.Server.ListenPath.Value = "/v1-api-name"
+		tykExt.Middleware = &oas.Middleware{}
+		tykExt.Middleware.Operations = oas.Operations{}
+		tykExt.Middleware.Operations[opId] = &oas.Operation{
+			MockResponse: &oas.MockResponse{
+				Enabled: true,
+				Code:    201,
+				Body:    "[null]",
+				Headers: headers,
+			},
+		}
+
+		desc := "hello world"
+		responses := openapi3.NewResponses()
+		responses.Delete("default")
+		responses.Set("200", &openapi3.ResponseRef{
+			Value: &openapi3.Response{
+				Description: &desc,
+				Content: openapi3.Content{
+					"application/json": &openapi3.MediaType{},
+				},
+			},
+		})
+
+		oasDef.Paths = openapi3.NewPaths()
+		oasDef.Paths.Set("/hello", &openapi3.PathItem{
+			Get: &openapi3.Operation{
+				OperationID: opId,
+				Responses:   responses,
+			},
+		})
+	})[0]
+
+	//Create second API that redirects to the first API
+	secondAPI := BuildOASAPI(func(oasDef *oas.OAS) {
+		tykExt := oasDef.GetTykExtension()
+		tykExt.Info.ID = "test_redirect"
+		tykExt.Info.Name = "Test Redirect API"
+		tykExt.Server.ListenPath.Value = "/test_redirect"
+		tykExt.Server.ListenPath.Strip = true
+		tykExt.Upstream.URL = "tyk://v1-api-name"
+	})[0]
+
+	for spec := range ts.Gw.LoadAPI(firstApi, secondAPI) {
+		require.NotNil(t, spec, "expected to load api properly")
+	}
+
+	t.Run("direct request should respond with mocked data", func(t *testing.T) {
+		_, _ = ts.Run(t, test.TestCase{
+			Path:   "/v1-api-name/hello",
+			Method: http.MethodGet,
+			Code:   201,
+		})
+	})
+
+	// Test case: Request to the second API should return the mocked response from the first API
+	t.Run("Request to second API should return mocked response from first API", func(t *testing.T) {
+		_, _ = ts.Run(t, test.TestCase{
+			Path:   "/test_redirect/hello",
+			Method: http.MethodGet,
+			Code:   201,
+		})
 	})
 }

--- a/gateway/mw_oas_validate_request.go
+++ b/gateway/mw_oas_validate_request.go
@@ -66,7 +66,7 @@ func (k *ValidateRequest) EnabledForSpec() bool {
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (k *ValidateRequest) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
-	operation := ctxGetOperation(r)
+	operation := k.Spec.findOperation(r)
 
 	if operation == nil {
 		return nil, http.StatusOK

--- a/gateway/mw_version_check.go
+++ b/gateway/mw_version_check.go
@@ -94,8 +94,6 @@ func (v *VersionCheck) ProcessRequest(w http.ResponseWriter, r *http.Request, _ 
 		return nil, mwStatusRespond
 	}
 outside:
-	v.Spec.SetupOperation(r)
-
 	// Check versioning, blacklist, whitelist and ignored status
 	requestValid, stat := v.Spec.RequestValid(r)
 	if !requestValid {

--- a/gateway/mw_virtual_endpoint.go
+++ b/gateway/mw_virtual_endpoint.go
@@ -48,7 +48,7 @@ type VMResponseObject struct {
 	SessionMeta map[string]interface{}
 }
 
-// DynamicMiddleware is a generic middleware that will execute JS code before continuing
+// VirtualEndpoint is a generic middleware that will execute JS code before continuing
 type VirtualEndpoint struct {
 	*BaseMiddleware
 

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -989,12 +989,6 @@ func (p *ReverseProxy) handleOutboundRequest(roundTripper *TykRoundTripper, outr
 		latency = time.Since(begin)
 	}()
 
-	if p.TykAPISpec.hasMock() {
-		if res, err = p.mockResponse(outreq); res != nil {
-			return
-		}
-	}
-
 	if p.TykAPISpec.GraphQL.Enabled {
 		res, hijacked, err = p.handleGraphQL(roundTripper, outreq, w)
 		return

--- a/gateway/tracing_test.go
+++ b/gateway/tracing_test.go
@@ -5,9 +5,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"github.com/google/uuid"
-	"github.com/mccutchen/go-httpbin/v2/httpbin"
-	"github.com/samber/lo"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -15,6 +12,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/internal/middleware"
+	"github.com/google/uuid"
+	"github.com/mccutchen/go-httpbin/v2/httpbin"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -64,7 +66,7 @@ func TestTraceHttpRequest(t *testing.T) {
 
 	t.Run("api-scoped rate limit works as expected", func(t *testing.T) {
 		oasDef, err := oas.NewOas(
-			oas.WithTestDefaults(),
+			oas.WithTestListenPathAndUpstream("/test", testServer.URL),
 			oas.WithGlobalRateLimit(1, 60*time.Second),
 			oas.WithGet("/rate-limited-api", func(b *oas.EndpointBuilder) {
 				b.Mock(func(_ *oas.MockResponse) {})
@@ -78,7 +80,7 @@ func TestTraceHttpRequest(t *testing.T) {
 		traceReq := traceRequest{
 			Request: &traceHttpRequest{
 				Method: http.MethodGet,
-				Path:   "/test/rate-limited-api",
+				Path:   "/rate-limited-api",
 			},
 			OAS: oasDef,
 		}
@@ -98,6 +100,21 @@ func TestTraceHttpRequest(t *testing.T) {
 		ts.Gw.traceHandler(w1, req1)
 		require.Equal(t, http.StatusOK, w1.Code)
 
+		var traceResp1 traceResponse
+		err = json.Unmarshal(w1.Body.Bytes(), &traceResp1)
+		assert.NoError(t, err)
+
+		_, tResponse1, err := traceResp1.parseTrace()
+		require.NoError(t, err)
+
+		// Verify rate limit response
+		assert.Equal(t, http.StatusOK, tResponse1.StatusCode)
+		logs1, err := traceResp1.logs()
+		assert.NoError(t, err)
+		require.True(t, lo.SomeBy(logs1, func(logEntry traceLogEntry) bool {
+			return logEntry.Mw == new(mockResponseMiddleware).Name() && logEntry.Code == middleware.StatusRespond
+		}))
+
 		// Second request should be rate limited
 		req2 := httptest.NewRequest(http.MethodPost, "/debug/trace", bytes.NewReader(reqBody))
 		req2.Header.Set("Content-Type", "application/json")
@@ -110,26 +127,22 @@ func TestTraceHttpRequest(t *testing.T) {
 		err = json.Unmarshal(w2.Body.Bytes(), &traceResp2)
 		assert.NoError(t, err)
 
-		logs, err := traceResp2.logs()
+		logs2, err := traceResp2.logs()
 		require.NoError(t, err)
 
-		_, tResponse, err := traceResp2.parseTrace()
+		_, tResponse2, err := traceResp2.parseTrace()
 		require.NoError(t, err)
-
-		defer func() {
-			_ = tResponse.Body.Close()
-		}()
 
 		// Verify rate limit response
-		assert.Equal(t, http.StatusTooManyRequests, tResponse.StatusCode)
-		require.True(t, lo.SomeBy(logs, func(item traceLogEntry) bool {
+		assert.Equal(t, http.StatusTooManyRequests, tResponse2.StatusCode)
+		require.True(t, lo.SomeBy(logs2, func(item traceLogEntry) bool {
 			return strings.Contains(item.Msg, "API Rate Limit Exceeded")
 		}))
 	})
 
 	t.Run("endpoint-scoped rate limit middleware works as expected", func(t *testing.T) {
 		oasDef, err := oas.NewOas(
-			oas.WithTestDefaults(),
+			oas.WithTestListenPathAndUpstream("/test", testServer.URL),
 			oas.WithGet("/rate-limited-api", func(b *oas.EndpointBuilder) {
 				b.Mock(func(_ *oas.MockResponse) {}).RateLimit(1, time.Second)
 			}),
@@ -199,13 +212,13 @@ func TestTraceHttpRequest(t *testing.T) {
 		require.NoError(t, err)
 
 		oasDef, err := oas.NewOas(
-			oas.WithTestDefaults(),
+			oas.WithTestListenPathAndUpstream("/test", testServer.URL),
 			oas.WithGet("/mock", func(b *oas.EndpointBuilder) {
 				b.Mock(func(mock *oas.MockResponse) {
 					mock.Code = http.StatusCreated
 					mock.Body = string(msgJson)
-					mock.Headers = append(mock.Headers, oas.Header{Name: "hello", Value: "world"})
-					mock.Headers = append(mock.Headers, oas.Header{Name: "Content-Type", Value: "application/json"})
+					mock.Headers.Add("hello", "world")
+					mock.Headers.Add(header.ContentType, "application/json")
 				})
 			}),
 		)
@@ -272,8 +285,7 @@ func TestTraceHttpRequest(t *testing.T) {
 		var hdr = HeaderCnf{Name: "Content-Type", Value: "application/json"}
 
 		oasDef, err := oas.NewOas(
-			oas.WithTestDefaults(),
-			oas.WithUpstreamUrl(testServer.URL),
+			oas.WithTestListenPathAndUpstream("/test", testServer.URL),
 			oas.WithGet("/uuid", func(b *oas.EndpointBuilder) {
 				b.
 					TransformResponseHeaders(func(headers *oas.TransformHeaders) {


### PR DESCRIPTION
### **User description**
[TT-8963] Unable to loop mocked endpoint (#7105)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-8963"
title="TT-8963" target="_blank">TT-8963</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Unable to loop mocked endpoint</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20codilime_refined%20ORDER%20BY%20created%20DESC"
title="codilime_refined">codilime_refined</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [x] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Refactored mock response handling into dedicated middleware

- Improved detection and processing of active OAS mock responses

- Added comprehensive unit tests for mock response middleware

- Updated API spec and routing logic for middleware integration


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10
files</summary><table>
<tr>
<td><strong>event.go</strong><dd><code>Use new header mapping utility in
webhook config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7105/files#diff-528a9f5b311ff21c0b3a9b273e61398209ca8b51550327e4d437bba81e49d577">+1/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
<td><strong>header.go</strong><dd><code>Refactor header mapping and add
header addition method</code>&nbsp; &nbsp; &nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7105/files#diff-0df51be6c650a8f510e1bc8b7b532f010bb7dbeb6841e6e84b37d368c12fd41e">+6/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
<td><strong>api_definition.go</strong><dd><code>Add path rewriting and
refactor mock detection logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7105/files#diff-0cf80174bbafb36f6d4f4308ebbd971b2833b76a936bad568220aa1a4ba0ee8b">+16/-2</a>&nbsp;
&nbsp; </td>

</tr>

<tr>
<td><strong>api_loader.go</strong><dd><code>Integrate mock response
middleware in middleware chain</code>&nbsp; &nbsp; &nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7105/files#diff-cdf0b7f176c9d18e1a314b78ddefc2cb3a94b3de66f1f360174692c915734c68">+4/-3</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
<td><strong>model_apispec.go</strong><dd><code>Refactor OAS router usage
and operation finding logic</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7105/files#diff-80c49b9bdb411a3d5a4706ec3ff138ef44154d0306040c19eba1cb5559f199d6">+15/-9</a>&nbsp;
&nbsp; </td>

</tr>

<tr>
<td><strong>mw_mock_response.go</strong><dd><code>Extract and implement
mock response as standalone middleware</code></dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7105/files#diff-fa778ebf662b147d9693791799966dbd20fca6eb5dc98b2e7264230b4e0cbfbd">+76/-2</a>&nbsp;
&nbsp; </td>

</tr>

<tr>
<td><strong>mw_oas_validate_request.go</strong><dd><code>Use new
operation finding logic in request validation</code>&nbsp; &nbsp; &nbsp;
&nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7105/files#diff-f5de96d1354ffab65e076f23a58337a7799a212f6e70dea59b56576042ecd69a">+1/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
<td><strong>mw_version_check.go</strong><dd><code>Remove legacy
SetupOperation call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7105/files#diff-ea28ed4980be684295449af109cad7cef58b8823d9f270ab3f1537441645579a">+1/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
<td><strong>reverse_proxy.go</strong><dd><code>Remove legacy mock
response handling from reverse proxy</code>&nbsp; &nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7105/files#diff-e6e07722257f7e41691e471185ad6d84fd56dc9e5459526ea32e9a5e8fa1a01b">+0/-6</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
<td><strong>tracing.go</strong><dd><code>Update tracing handler to new
subroute generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7105/files#diff-0069987d730b02812808925a17e1434ca7558a4dfc8661beb27ccd11afb8c77d">+3/-2</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4
files</summary><table>
<tr>
<td><strong>header_test.go</strong><dd><code>Update tests for new header
mapping function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7105/files#diff-3f889a92dbfb32e1fa85b9c50793063836eacc5aced049134917b5a0fda2c463">+1/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
<td><strong>api_definition_test.go</strong><dd><code>Update tests for
new mock detection method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7105/files#diff-2394daab6fdc5f8dc234699c80c0548947ee3d68d2e33858258d73a8b5eb6f44">+8/-8</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
<td><strong>mw_mock_response_test.go</strong><dd><code>Add comprehensive
tests for mock response middleware</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7105/files#diff-ec0f656660a941868ea6c8fdd5116fe3f385f3de107aed70b7ecf0cc215c503e">[link]</a>&nbsp;
&nbsp; </td>

</tr>

<tr>
<td><strong>tracing_test.go</strong><dd><code>Use new header addition
method in mock setup for tests</code>&nbsp; &nbsp; &nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7105/files#diff-17a8010aa6755f9c464858ca32ade86af22931c1671b644b97b0a6f984ead54b">+3/-2</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>2
files</summary><table>
<tr>
<td><strong>ctx.go</strong><dd><code>Remove unused OASOperation context
key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7105/files#diff-600f5f552779994b15324fda108549eec7e7be30b1d8a1a16ee8344243e0cbc7">+0/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
<td><strong>api.go</strong><dd><code>Remove unused OAS operation context
functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7105/files#diff-644cda3aeb4ac7f325359e85fcddb810f100dd5e6fa480b0d9f9363a743c4e05">+10/-10</a>&nbsp;
</td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary> Need help?</summary><li>Type <code>/help how to
...</code> in the comments thread for any questions about PR-Agent
usage.</li><li>Check out the <a
href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a>
for more information.</li></details>


___
### Report

In general, the work included:

1. Creation of a new mockResponseMiddleware: A middleware component was
implemented that intercepts API requests and returns mock responses when
configured, eliminating the need to call upstream services.
2. Support for two mock response types was added:
- Custom mock responses with manually configured status codes, bodies,
and headers
- Mock responses derived from OpenAPI examples defined in API
specifications
4. Resolution of an issue with looping through mocked endpoints: The
branch name suggests there was a problem with iterating through mocked
endpoints, which was resolved. This likely involved ensuring proper
handling of multiple mock configurations or preventing infinite loops in
certain scenarios.
5. Implementation of proper redirect handling: Functionality was added
to correctly handle HTTP redirects when using mock responses, ensuring
that redirect responses work as expected.
6. Addition of tests: Tests were created to verify the functionality of
the mock response middleware, ensuring it correctly handles various
scenarios.

This enhancement improves the API gateway's simulation capabilities,
making it more useful for testing and development environments where
actual upstream services might not be available or where controlled
responses are needed for testing specific scenarios.

[TT-8963]: https://tyktech.atlassian.net/browse/TT-8963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Refactored mock response logic into standalone middleware

- Improved detection and handling of active OAS mock responses

- Added comprehensive unit tests for mock response middleware and internal redirects

- Updated API spec, routing, and tracing logic for middleware integration


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>builder.go</strong><dd><code>Refactor OAS builder for improved test setup and mock defaults</code></dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7149/files#diff-be3e44eb5029c9f950164be1e80b16d9252f998cb83441dcb81d21ac664b4c69">+50/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>header.go</strong><dd><code>Refactor header mapping and add header addition method</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7149/files#diff-0df51be6c650a8f510e1bc8b7b532f010bb7dbeb6841e6e84b37d368c12fd41e">+12/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>api_definition.go</strong><dd><code>Add path rewriting and refactor mock detection logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7149/files#diff-0cf80174bbafb36f6d4f4308ebbd971b2833b76a936bad568220aa1a4ba0ee8b">+21/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>api_loader.go</strong><dd><code>Integrate mock response middleware in middleware chain and subroute </code><br><code>generation</code></dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7149/files#diff-cdf0b7f176c9d18e1a314b78ddefc2cb3a94b3de66f1f360174692c915734c68">+17/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>model_apispec.go</strong><dd><code>Refactor OAS router usage and operation finding logic</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7149/files#diff-80c49b9bdb411a3d5a4706ec3ff138ef44154d0306040c19eba1cb5559f199d6">+18/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>mw_mock_response.go</strong><dd><code>Extract and implement mock response as standalone middleware</code></dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7149/files#diff-fa778ebf662b147d9693791799966dbd20fca6eb5dc98b2e7264230b4e0cbfbd">+80/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mw_oas_validate_request.go</strong><dd><code>Use new operation finding logic in request validation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7149/files#diff-f5de96d1354ffab65e076f23a58337a7799a212f6e70dea59b56576042ecd69a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mw_version_check.go</strong><dd><code>Remove legacy SetupOperation call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7149/files#diff-ea28ed4980be684295449af109cad7cef58b8823d9f270ab3f1537441645579a">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>reverse_proxy.go</strong><dd><code>Remove legacy mock response handling from reverse proxy</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7149/files#diff-e6e07722257f7e41691e471185ad6d84fd56dc9e5459526ea32e9a5e8fa1a01b">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tracing.go</strong><dd><code>Update tracing handler to new subroute generation and log structure</code></dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7149/files#diff-0069987d730b02812808925a17e1434ca7558a4dfc8661beb27ccd11afb8c77d">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>ctx.go</strong><dd><code>Remove unused OASOperation context key, add internal redirect target</code></dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7149/files#diff-600f5f552779994b15324fda108549eec7e7be30b1d8a1a16ee8344243e0cbc7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>api.go</strong><dd><code>Remove unused OAS operation context functions, add internal redirect </code><br><code>helpers</code></dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7149/files#diff-644cda3aeb4ac7f325359e85fcddb810f100dd5e6fa480b0d9f9363a743c4e05">+19/-19</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>api_definition_test.go</strong><dd><code>Update tests for new mock detection method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7149/files#diff-2394daab6fdc5f8dc234699c80c0548947ee3d68d2e33858258d73a8b5eb6f44">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mw_mock_response_test.go</strong><dd><code>Add comprehensive tests for mock response middleware and redirects</code></dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7149/files#diff-ec0f656660a941868ea6c8fdd5116fe3f385f3de107aed70b7ecf0cc215c503e">+81/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tracing_test.go</strong><dd><code>Use new header addition and OAS builder methods in tests</code>&nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7149/files#diff-17a8010aa6755f9c464858ca32ade86af22931c1671b644b97b0a6f984ead54b">+31/-19</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>tyk_tykprotocol_200.yml</strong><dd><code>Fix typo in tracing scenario name for tykprotocol</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7149/files#diff-208ea307f413f94d5c607391304371c84f78de69da0568826585ab5293fb680b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>mw_virtual_endpoint.go</strong><dd><code>Update comment for VirtualEndpoint middleware</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7149/files#diff-daf72ac3b29609a9f2a77cccf648f91ba62b2ad977a7c5a44602c72b2a28b2e5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>.dockerignore</strong><dd><code>Add go.work and go.work.sum to dockerignore</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7149/files#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>