### PR TITLE
Merging to release-5.9.0: [TT-14914] No response middleware information in Tyk OAS API Debugger (#7158)

### DIFF
--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -171,6 +171,10 @@ func (gw *Gateway) processSpec(
 		"org_id":   spec.OrgID,
 		"api_id":   spec.APIID,
 		"api_name": spec.Name,
+<<<<<<< HEAD
+=======
+		"type":     traceLogRequest.String(),
+>>>>>>> 773ff7b23... [TT-14914] No response middleware information in Tyk OAS API Debugger (#7158)
 	})
 
 	var coprocessLog = logger.WithFields(logrus.Fields{
@@ -297,7 +301,11 @@ func (gw *Gateway) processSpec(
 	}
 
 	// Create the response processors, pass all the loaded custom middleware response functions:
+<<<<<<< HEAD
 	gw.createResponseMiddlewareChain(spec, mwResponseFuncs)
+=======
+	spec.ResponseChain = gw.createResponseMiddlewareChain(spec, mwResponseFuncs, logger)
+>>>>>>> 773ff7b23... [TT-14914] No response middleware information in Tyk OAS API Debugger (#7158)
 
 	baseMid := NewBaseMiddleware(gw, spec, proxy, logger)
 
@@ -469,8 +477,11 @@ func (gw *Gateway) processSpec(
 	gw.mwAppendEnabled(&chainArray, &TransformMethod{BaseMiddleware: baseMid.Copy()})
 
 	// Earliest we can respond with cache get 200 ok
+<<<<<<< HEAD
+=======
+	gw.mwAppendEnabled(&chainArray, newMockResponseMiddleware(baseMid.Copy()))
+>>>>>>> 773ff7b23... [TT-14914] No response middleware information in Tyk OAS API Debugger (#7158)
 	gw.mwAppendEnabled(&chainArray, &RedisCacheMiddleware{BaseMiddleware: baseMid.Copy(), store: &cacheStore})
-
 	gw.mwAppendEnabled(&chainArray, &VirtualEndpoint{BaseMiddleware: baseMid.Copy()})
 	gw.mwAppendEnabled(&chainArray, &RequestSigning{BaseMiddleware: baseMid.Copy()})
 	gw.mwAppendEnabled(&chainArray, &GoPluginMiddleware{BaseMiddleware: baseMid.Copy()})

--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -3,23 +3,22 @@ package gateway
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
 	"net/url"
 	"reflect"
 	"strings"
 	"time"
 	"unicode/utf8"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/TykTechnologies/tyk-pump/analytics"
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/coprocess"
+	"github.com/TykTechnologies/tyk/internal/middleware"
 	"github.com/TykTechnologies/tyk/user"
-
-	"errors"
-	"fmt"
-	"io/ioutil"
-	"net/http"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -446,7 +445,7 @@ func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 		}
 		res.ContentLength = int64(len(returnObject.Request.ReturnOverrides.ResponseBody))
 		m.successHandler.RecordHit(r, analytics.Latency(analytics.Latency{Total: int64(ms)}), int(returnObject.Request.ReturnOverrides.ResponseCode), res, false)
-		return nil, mwStatusRespond
+		return nil, middleware.StatusRespond
 	}
 
 	// Is this a CP authentication middleware?

--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -8,12 +8,12 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/TykTechnologies/tyk-pump/analytics"
-	"github.com/TykTechnologies/tyk/apidef"
-
 	"github.com/sirupsen/logrus"
 
+	"github.com/TykTechnologies/tyk-pump/analytics"
+	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/goplugin"
+	"github.com/TykTechnologies/tyk/internal/middleware"
 	"github.com/TykTechnologies/tyk/request"
 )
 
@@ -257,7 +257,7 @@ func (m *GoPluginMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reque
 			successHandler.RecordHit(r, analytics.Latency{Total: int64(ms)}, rw.statusCodeSent, rw.getHttpResponse(r), false)
 
 			// no need to continue passing this request down to reverse proxy
-			respCode = mwStatusRespond
+			respCode = middleware.StatusRespond
 		}
 	} else {
 		respCode = http.StatusOK

--- a/gateway/mw_js_plugin.go
+++ b/gateway/mw_js_plugin.go
@@ -15,11 +15,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/TykTechnologies/tyk/apidef"
-
 	"github.com/robertkrimen/otto"
 	_ "github.com/robertkrimen/otto/underscore"
 
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/internal/middleware"
 	"github.com/TykTechnologies/tyk/user"
 
 	"github.com/sirupsen/logrus"
@@ -298,7 +298,7 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 		}
 
 		d.Gw.forceResponse(w, r, &responseObject, d.Spec, session, d.Pre, logger)
-		return nil, mwStatusRespond
+		return nil, middleware.StatusRespond
 	}
 
 	if d.Auth {

--- a/gateway/mw_redis_cache.go
+++ b/gateway/mw_redis_cache.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/TykTechnologies/murmur3"
 	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/internal/middleware"
 	"github.com/TykTechnologies/tyk/regexp"
 	"github.com/TykTechnologies/tyk/request"
 	"github.com/TykTechnologies/tyk/storage"
@@ -279,7 +280,7 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 	}
 
 	// Stop any further execution after we wrote cache out
-	return nil, mwStatusRespond
+	return nil, middleware.StatusRespond
 }
 
 func isSafeMethod(method string) bool {

--- a/gateway/mw_version_check.go
+++ b/gateway/mw_version_check.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/internal/middleware"
 	"github.com/TykTechnologies/tyk/internal/otel"
 	"github.com/TykTechnologies/tyk/request"
 )
@@ -91,7 +92,7 @@ func (v *VersionCheck) ProcessRequest(w http.ResponseWriter, r *http.Request, _ 
 		v.Spec.SanitizeProxyPaths(r)
 
 		handler.ServeHTTP(w, r)
-		return nil, mwStatusRespond
+		return nil, middleware.StatusRespond
 	}
 outside:
 	v.Spec.SetupOperation(r)
@@ -129,7 +130,7 @@ outside:
 		}
 
 		v.DoMockReply(w, mockMeta)
-		return nil, mwStatusRespond
+		return nil, middleware.StatusRespond
 	}
 
 	if !v.Spec.ExpirationTs.IsZero() {

--- a/gateway/mw_virtual_endpoint.go
+++ b/gateway/mw_virtual_endpoint.go
@@ -20,11 +20,10 @@ import (
 	_ "github.com/robertkrimen/otto/underscore"
 
 	"github.com/TykTechnologies/tyk-pump/analytics"
-
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/internal/middleware"
 	"github.com/TykTechnologies/tyk/user"
-
 	"github.com/sirupsen/logrus"
 )
 
@@ -318,7 +317,7 @@ func (d *VirtualEndpoint) ProcessRequest(w http.ResponseWriter, r *http.Request,
 		return errors.New(message), http.StatusInternalServerError
 	}
 
-	return nil, mwStatusRespond
+	return nil, middleware.StatusRespond
 }
 
 func (d *VirtualEndpoint) HandleResponse(rw http.ResponseWriter, res *http.Response, ses *user.SessionState) {

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -947,7 +947,16 @@ func (gw *Gateway) loadCustomMiddleware(spec *APISpec) ([]string, apidef.Middlew
 }
 
 // Create the response processor chain
+<<<<<<< HEAD
 func (gw *Gateway) createResponseMiddlewareChain(spec *APISpec, responseFuncs []apidef.MiddlewareDefinition) {
+=======
+func (gw *Gateway) createResponseMiddlewareChain(
+	spec *APISpec,
+	middlewares []apidef.MiddlewareDefinition,
+	log *logrus.Entry,
+) []TykResponseHandler {
+
+>>>>>>> 773ff7b23... [TT-14914] No response middleware information in Tyk OAS API Debugger (#7158)
 	var (
 		responseMWChain []TykResponseHandler
 		baseHandler     = BaseTykResponseHandler{Spec: spec, Gw: gw}
@@ -1015,9 +1024,7 @@ func (gw *Gateway) createResponseMiddlewareChain(spec *APISpec, responseFuncs []
 		mainLog.WithError(err).Debug("Failed to init processor")
 	}
 
-	responseMWChain = append(responseMWChain, processor)
-
-	spec.ResponseChain = responseMWChain
+	return append(responseMWChain, processor)
 }
 
 func (gw *Gateway) isRPCMode() bool {

--- a/gateway/tracing.go
+++ b/gateway/tracing.go
@@ -61,6 +61,20 @@ type traceLogEntry struct {
 	Ts      *time.Time `json:"time,omitempty"`
 }
 
+<<<<<<< HEAD
+=======
+type traceLogType string
+
+func (s traceLogType) String() string {
+	return string(s)
+}
+
+const (
+	traceLogRequest  traceLogType = "request"
+	traceLogResponse traceLogType = "response"
+)
+
+>>>>>>> 773ff7b23... [TT-14914] No response middleware information in Tyk OAS API Debugger (#7158)
 func (tr *traceResponse) parseTrace() (*http.Request, *http.Response, error) {
 	return parseTrace(tr.Response)
 }
@@ -188,7 +202,6 @@ func (gw *Gateway) traceHandler(w http.ResponseWriter, r *http.Request) {
 	logger.Out = &logStorage
 
 	gs := gw.prepareStorage()
-	subrouter := mux.NewRouter()
 
 	loader := &APIDefinitionLoader{Gw: gw}
 	traceReq.Spec.IsOAS = true
@@ -210,7 +223,11 @@ func (gw *Gateway) traceHandler(w http.ResponseWriter, r *http.Request) {
 		logrus.NewEntry(logger),
 		WithQuotaKey(spec.Checksum),
 	)
+<<<<<<< HEAD
 	gw.generateSubRoutes(spec, subrouter, logrus.NewEntry(logger))
+=======
+	gw.generateSubRoutes(spec, mux.NewRouter())
+>>>>>>> 773ff7b23... [TT-14914] No response middleware information in Tyk OAS API Debugger (#7158)
 
 	if chainObj.ThisHandler == nil {
 		doJSONWrite(w, http.StatusBadRequest, traceResponse{Message: "error", Logs: logStorage.String()})

--- a/gateway/tracing_test.go
+++ b/gateway/tracing_test.go
@@ -4,7 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+<<<<<<< HEAD
 	"github.com/samber/lo"
+=======
+	"github.com/TykTechnologies/tyk/internal/oasbuilder"
+>>>>>>> 773ff7b23... [TT-14914] No response middleware information in Tyk OAS API Debugger (#7158)
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -25,6 +29,7 @@ func TestTraceHttpRequest_toRequest(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+<<<<<<< HEAD
 	const body = `{"foo":"bar"}`
 	var headers = http.Header{}
 	headers.Add("key", "value")
@@ -35,6 +40,283 @@ func TestTraceHttpRequest_toRequest(t *testing.T) {
 		Spec: &apidef.APIDefinition{
 			Proxy: apidef.ProxyConfig{
 				ListenPath: "",
+=======
+	testServer := httptest.NewServer(httpbin.New())
+	defer testServer.Close()
+
+	t.Run("#toRequest", func(t *testing.T) {
+		const body = `{"foo":"bar"}`
+		var headers = http.Header{}
+		headers.Add("key", "value")
+		headers.Add("Content-Type", "application/json")
+
+		tr := traceRequest{
+			Request: &traceHttpRequest{Path: "", Method: http.MethodPost, Body: body, Headers: headers},
+			Spec: &apidef.APIDefinition{
+				Proxy: apidef.ProxyConfig{
+					ListenPath: "",
+				},
+			},
+			OAS: &oas.OAS{},
+		}
+
+		request, err := tr.toRequest(ctx, ts.Gw.GetConfig().IgnoreCanonicalMIMEHeaderKey)
+		assert.NoError(t, err)
+		assert.NotNil(t, request)
+
+		bodyInBytes, err := io.ReadAll(request.Body)
+		assert.NoError(t, err)
+
+		assert.Equal(t, http.MethodPost, request.Method)
+		assert.Equal(t, "", request.URL.Host)
+		assert.Equal(t, "", request.URL.Path)
+		assert.Equal(t, headers, request.Header)
+		assert.Equal(t, string(bodyInBytes), body)
+	})
+
+	t.Run("api-scoped rate limit works as expected", func(t *testing.T) {
+		oasDef, err := oasbuilder.Build(
+			oasbuilder.WithTestListenPathAndUpstream("/test", testServer.URL),
+			oasbuilder.WithGlobalRateLimit(1, 60*time.Second),
+			oasbuilder.WithGet("/rate-limited-api", func(b *oasbuilder.EndpointBuilder) {
+				b.Mock(func(_ *oas.MockResponse) {})
+			}),
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, oasDef)
+
+		// Create trace request
+		traceReq := traceRequest{
+			Request: &traceHttpRequest{
+				Method: http.MethodGet,
+				Path:   "/rate-limited-api",
+			},
+			OAS: oasDef,
+		}
+
+		// Marshal trace request
+		reqBody, err := json.Marshal(traceReq)
+		require.NoError(t, err)
+		require.NotNil(t, reqBody)
+
+		// First request should succeed
+		req1 := httptest.NewRequest(http.MethodPost, "/debug/trace", bytes.NewReader(reqBody))
+		req1.Header.Set("Content-Type", "application/json")
+
+		// Listen path is empty
+
+		w1 := httptest.NewRecorder()
+		ts.Gw.traceHandler(w1, req1)
+		require.Equal(t, http.StatusOK, w1.Code)
+
+		var traceResp1 traceResponse
+		err = json.Unmarshal(w1.Body.Bytes(), &traceResp1)
+		assert.NoError(t, err)
+
+		_, tResponse1, err := traceResp1.parseTrace()
+		require.NoError(t, err)
+
+		// Verify rate limit response
+		assert.Equal(t, http.StatusOK, tResponse1.StatusCode)
+		logs1, err := traceResp1.logs()
+		assert.NoError(t, err)
+		require.True(t, lo.SomeBy(logs1, func(logEntry traceLogEntry) bool {
+			return logEntry.Mw == new(mockResponseMiddleware).Name() && logEntry.Code == middleware.StatusRespond
+		}))
+
+		// Second request should be rate limited
+		req2 := httptest.NewRequest(http.MethodPost, "/debug/trace", bytes.NewReader(reqBody))
+		req2.Header.Set("Content-Type", "application/json")
+
+		w2 := httptest.NewRecorder()
+		ts.Gw.traceHandler(w2, req2)
+
+		// Parse response
+		var traceResp2 traceResponse
+		err = json.Unmarshal(w2.Body.Bytes(), &traceResp2)
+		assert.NoError(t, err)
+
+		logs2, err := traceResp2.logs()
+		require.NoError(t, err)
+
+		_, tResponse2, err := traceResp2.parseTrace()
+		require.NoError(t, err)
+
+		// Verify rate limit response
+		assert.Equal(t, http.StatusTooManyRequests, tResponse2.StatusCode)
+		require.True(t, lo.SomeBy(logs2, func(item traceLogEntry) bool {
+			return strings.Contains(item.Msg, "API Rate Limit Exceeded")
+		}))
+	})
+
+	t.Run("endpoint-scoped rate limit middleware works as expected", func(t *testing.T) {
+		oasDef, err := oasbuilder.Build(
+			oasbuilder.WithTestListenPathAndUpstream("/test", testServer.URL),
+			oasbuilder.WithGet("/rate-limited-api", func(b *oasbuilder.EndpointBuilder) {
+				b.Mock(func(_ *oas.MockResponse) {}).RateLimit(1, time.Second)
+			}),
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, oasDef)
+
+		// Create trace request
+		traceReq := traceRequest{
+			Request: &traceHttpRequest{
+				Method: http.MethodGet,
+				Path:   "/rate-limited-api",
+			},
+			OAS: oasDef,
+		}
+
+		// Marshal trace request
+		reqBody, err := json.Marshal(traceReq)
+		require.NoError(t, err)
+		require.NotNil(t, reqBody)
+
+		// First request should succeed
+		req1 := httptest.NewRequest(http.MethodPost, "/debug/trace", bytes.NewReader(reqBody))
+		req1.Header.Set("Content-Type", "application/json")
+		req1 = ts.withAuth(req1)
+
+		w1 := httptest.NewRecorder()
+		ts.Gw.traceHandler(w1, req1)
+		require.Equal(t, http.StatusOK, w1.Code)
+
+		// Second request should be rate limited
+		req2 := httptest.NewRequest(http.MethodPost, "/debug/trace", bytes.NewReader(reqBody))
+		req2.Header.Set("Content-Type", "application/json")
+
+		w2 := httptest.NewRecorder()
+		ts.Gw.traceHandler(w2, req2)
+
+		// Parse response
+		var traceResp2 traceResponse
+		err = json.Unmarshal(w2.Body.Bytes(), &traceResp2)
+		assert.NoError(t, err)
+
+		logs, err := traceResp2.logs()
+		require.NoError(t, err)
+
+		_, tResponse, err := traceResp2.parseTrace()
+		require.NoError(t, err)
+
+		// Verify rate limit response
+		require.Equal(t, http.StatusTooManyRequests, tResponse.StatusCode)
+		require.True(t, lo.SomeBy(logs, func(item traceLogEntry) bool {
+			return strings.Contains(item.Msg, "API Rate Limit Exceeded")
+		}))
+	})
+
+	t.Run("mock middleware works as expected", func(t *testing.T) {
+		type typedResponse struct {
+			Message string `json:"message"`
+		}
+
+		srcMessage := typedResponse{
+			Message: "knock knock this is mock",
+		}
+
+		msgJson, err := json.Marshal(srcMessage)
+		require.NoError(t, err)
+
+		oasDef, err := oasbuilder.Build(
+			oasbuilder.WithTestListenPathAndUpstream("/test", testServer.URL),
+			oasbuilder.WithGet("/mock", func(b *oasbuilder.EndpointBuilder) {
+				b.Mock(func(mock *oas.MockResponse) {
+					mock.Code = http.StatusCreated
+					mock.Body = string(msgJson)
+					mock.Headers.Add("hello", "world")
+					mock.Headers.Add(header.ContentType, "application/json")
+				})
+			}),
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, oasDef)
+
+		// Create trace request
+		traceReq := traceRequest{
+			Request: &traceHttpRequest{
+				Method: http.MethodGet,
+				Path:   "/mock",
+			},
+			OAS: oasDef,
+		}
+
+		reqBody, err := json.Marshal(traceReq)
+		require.NoError(t, err)
+		require.NotNil(t, reqBody)
+
+		req := httptest.NewRequest(http.MethodPost, "/debug/trace", bytes.NewReader(reqBody))
+		req.Header.Set("Content-Type", "application/json")
+
+		res := httptest.NewRecorder()
+		ts.Gw.traceHandler(res, req)
+		require.Equal(t, http.StatusOK, res.Code)
+
+		var traceResp traceResponse
+
+		err = json.NewDecoder(res.Body).Decode(&traceResp)
+		assert.NoError(t, err)
+
+		request, response, err := traceResp.parseTrace()
+		require.NoError(t, err)
+
+		defer func() {
+			_ = response.Body.Close()
+		}()
+
+		require.NotNil(t, request)
+		require.NotNil(t, response)
+
+		var mockedResponse typedResponse
+		require.Equal(t, http.StatusCreated, response.StatusCode)
+		err = json.NewDecoder(response.Body).Decode(&mockedResponse)
+		assert.NoError(t, err)
+		assert.Equal(t, srcMessage.Message, mockedResponse.Message)
+	})
+
+	t.Run("responds with log request/response logs", func(t *testing.T) {
+		type HeaderCnf struct {
+			Name  string
+			Value string
+		}
+
+		type UuidDto struct {
+			Uuid string `json:"uuid"`
+		}
+
+		type WrappedUuidDto struct {
+			Data UuidDto `json:"data"`
+		}
+
+		var hdr = HeaderCnf{Name: "Content-Type", Value: "application/json"}
+
+		oasDef, err := oasbuilder.Build(
+			oasbuilder.WithTestListenPathAndUpstream("/test", testServer.URL),
+			oasbuilder.WithGet("/uuid", func(b *oasbuilder.EndpointBuilder) {
+				b.
+					TransformResponseHeaders(func(headers *oas.TransformHeaders) {
+						headers.AppendAddOp(hdr.Name, hdr.Value)
+					}).
+					TransformResponseBody(func(tb *oas.TransformBody) {
+						tb.Enabled = true
+						tb.Format = apidef.RequestJSON
+						tb.Body = base64.StdEncoding.EncodeToString([]byte(`{"data": {{ . | toJSON }}}`))
+					})
+			}),
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, oasDef)
+
+		traceReq := traceRequest{
+			Request: &traceHttpRequest{
+				Method: http.MethodGet,
+				Path:   "/uuid",
+>>>>>>> 773ff7b23... [TT-14914] No response middleware information in Tyk OAS API Debugger (#7158)
 			},
 		},
 		OAS: &oas.OAS{},

--- a/internal/oasbuilder/builder.go
+++ b/internal/oasbuilder/builder.go
@@ -1,4 +1,4 @@
-package oas
+package oasbuilder
 
 import (
 	"errors"
@@ -8,38 +8,32 @@ import (
 	"strings"
 	"time"
 
+	"github.com/TykTechnologies/tyk/apidef/oas"
 	"github.com/TykTechnologies/tyk/common/option"
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
 type (
-	// Builder OAS builder is responsible for providing methods for building valid OAS object.
 	Builder struct {
 		errors         []error
-		oas            *OAS
-		xTykAPIGateway *XTykAPIGateway
+		oas            *oas.OAS
+		xTykAPIGateway *oas.XTykAPIGateway
 	}
 
-	// EndpointBuilder OAS endpoint builder should be used for building endpoint and binding middlewares to it.
 	EndpointBuilder struct {
 		method string
 		path   string
 		errors []error
-		op     *Operation
+		op     *oas.Operation
 	}
 
-	// BuilderOption optional parameter should be used to define builder options in declarative way.
 	BuilderOption = option.Option[Builder]
 
-	// EndpointFactory factory method in which endpoint builder should be used.
 	EndpointFactory func(b *EndpointBuilder)
 )
 
 const (
 	minAllowedTimeFrameLength = time.Millisecond * 100
-
-	// UpstreamUrlDefault default upstream url for OAS
-	UpstreamUrlDefault = "http://localhost:3478/"
 )
 
 var (
@@ -47,31 +41,30 @@ var (
 	ErrZeroAmountInRateLimit = errors.New("zero amount in rate limit")
 )
 
-// NewOas returns an allocated *OAS due to provided options
-func NewOas(opts ...BuilderOption) (*OAS, error) {
-	return option.New(opts).Build(NewBuilder()).Build()
+func Build(opts ...BuilderOption) (*oas.OAS, error) {
+	return option.New(opts).Build(New()).Build()
 }
 
-func NewBuilder() Builder {
-	oasDef := OAS{}
+func New() Builder {
+	oasDef := oas.OAS{}
 
 	oasDef.Paths = &openapi3.Paths{}
 
-	xTykAPIGateway := XTykAPIGateway{
-		Info: Info{},
+	xTykAPIGateway := oas.XTykAPIGateway{
+		Info: oas.Info{},
 
-		Server: Server{
-			ListenPath: ListenPath{
+		Server: oas.Server{
+			ListenPath: oas.ListenPath{
 				Strip: true,
 			},
 		},
 
-		Upstream: Upstream{
-			Proxy: &Proxy{Enabled: true},
+		Upstream: oas.Upstream{
+			Proxy: &oas.Proxy{Enabled: true},
 		},
 
-		Middleware: &Middleware{
-			Operations: Operations{},
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{},
 		},
 	}
 
@@ -86,7 +79,7 @@ func (b *Builder) appendErrors(errs ...error) {
 	b.errors = append(b.errors, errs...)
 }
 
-func (b *Builder) Build() (*OAS, error) {
+func (b *Builder) Build() (*oas.OAS, error) {
 	if len(b.errors) > 0 {
 		return nil, errors.Join(b.errors...)
 	}
@@ -96,9 +89,13 @@ func (b *Builder) Build() (*OAS, error) {
 	return b.oas, nil
 }
 
+<<<<<<< HEAD:apidef/oas/builder.go
 // WithTestDefaults sets defaults options
 // to be sued for testing
 func WithTestDefaults() BuilderOption {
+=======
+func WithTestListenPathAndUpstream(path, upstreamUrl string) BuilderOption {
+>>>>>>> 773ff7b23... [TT-14914] No response middleware information in Tyk OAS API Debugger (#7158):internal/oasbuilder/builder.go
 	return combine(
 		WithUpstreamUrl(UpstreamUrlDefault),
 		WithListenPath("/test", true),
@@ -112,7 +109,6 @@ func WithListenPath(path string, strip bool) BuilderOption {
 	}
 }
 
-// combine combines some options
 func combine(opts ...BuilderOption) BuilderOption {
 	return func(b *Builder) {
 		for _, apply := range opts {
@@ -121,7 +117,6 @@ func combine(opts ...BuilderOption) BuilderOption {
 	}
 }
 
-// WithUpstreamUrl defines upstream url
 func WithUpstreamUrl(upstreamUrl string) BuilderOption {
 	return func(b *Builder) {
 		if _, err := url.Parse(upstreamUrl); err != nil {
@@ -133,7 +128,19 @@ func WithUpstreamUrl(upstreamUrl string) BuilderOption {
 	}
 }
 
+<<<<<<< HEAD:apidef/oas/builder.go
 // WithGlobalRateLimit defines global rate limit
+=======
+func withRandomId() BuilderOption {
+	return func(b *Builder) {
+		b.xTykAPIGateway.Info.ID = uuid.New()
+		b.xTykAPIGateway.Info.Name = uuid.New()
+		b.xTykAPIGateway.Info.State.Active = true
+		b.xTykAPIGateway.Info.State.Internal = false
+	}
+}
+
+>>>>>>> 773ff7b23... [TT-14914] No response middleware information in Tyk OAS API Debugger (#7158):internal/oasbuilder/builder.go
 func WithGlobalRateLimit(rate uint, duration time.Duration, enabled ...bool) BuilderOption {
 	return func(b *Builder) {
 		if rl, err := newRateLimit(rate, duration, enabled...); err != nil {
@@ -145,7 +152,7 @@ func WithGlobalRateLimit(rate uint, duration time.Duration, enabled ...bool) Bui
 	}
 }
 
-func newRateLimit(rate uint, duration time.Duration, enabled ...bool) (*RateLimit, error) {
+func newRateLimit(rate uint, duration time.Duration, enabled ...bool) (*oas.RateLimit, error) {
 	if duration < minAllowedTimeFrameLength {
 		return nil, ErrMinRateLimitExceeded
 	}
@@ -159,10 +166,10 @@ func newRateLimit(rate uint, duration time.Duration, enabled ...bool) (*RateLimi
 		enable = enabled[0]
 	}
 
-	return &RateLimit{
+	return &oas.RateLimit{
 		Enabled: enable,
 		Rate:    int(rate),
-		Per:     ReadableDuration(duration),
+		Per:     oas.ReadableDuration(duration),
 	}, nil
 }
 
@@ -179,22 +186,18 @@ func withEndpoint(method, path string, fn EndpointFactory) BuilderOption {
 	}
 }
 
-// WithGet add get endpoint/path to OAS
 func WithGet(path string, fn EndpointFactory) BuilderOption {
 	return withEndpoint(http.MethodGet, path, fn)
 }
 
-// WithPost add post endpoint/path to OAS
 func WithPost(path string, fn EndpointFactory) BuilderOption {
 	return withEndpoint(http.MethodPost, path, fn)
 }
 
-// WithPut add put endpoint/path to OAS
 func WithPut(path string, fn EndpointFactory) BuilderOption {
 	return withEndpoint(http.MethodPut, path, fn)
 }
 
-// WithDelete add delete endpoint/path to OAS
 func WithDelete(path string, fn EndpointFactory) BuilderOption {
 	return withEndpoint(http.MethodDelete, path, fn)
 }
@@ -203,14 +206,49 @@ func (eb *EndpointBuilder) RateLimit(amount uint, duration time.Duration, enable
 	if rl, err := newRateLimit(amount, duration, enabled...); err != nil {
 		eb.errors = append(eb.errors, err)
 	} else {
-		eb.operation().RateLimit = (*RateLimitEndpoint)(rl)
+		eb.operation().RateLimit = (*oas.RateLimitEndpoint)(rl)
 	}
 
 	return eb
 }
 
+<<<<<<< HEAD:apidef/oas/builder.go
 func (eb *EndpointBuilder) Mock(fn func(mock *MockResponse)) *EndpointBuilder {
 	var mock MockResponse
+=======
+func (eb *EndpointBuilder) TransformResponseHeaders(factory func(*oas.TransformHeaders)) *EndpointBuilder {
+	op := eb.operation().TransformResponseHeaders
+
+	if op == nil {
+		op = &oas.TransformHeaders{Enabled: true}
+		eb.operation().TransformResponseHeaders = op
+	}
+
+	factory(op)
+
+	return eb
+}
+
+func (eb *EndpointBuilder) TransformResponseBody(factory func(*oas.TransformBody)) *EndpointBuilder {
+	op := eb.operation().TransformResponseBody
+
+	if op == nil {
+		op = &oas.TransformBody{Enabled: true}
+		eb.operation().TransformResponseBody = op
+	}
+
+	factory(op)
+
+	return eb
+}
+
+func (eb *EndpointBuilder) MockDefault() *EndpointBuilder {
+	return eb.Mock(func(_ *oas.MockResponse) {})
+}
+
+func (eb *EndpointBuilder) Mock(fn func(mock *oas.MockResponse)) *EndpointBuilder {
+	var mock oas.MockResponse
+>>>>>>> 773ff7b23... [TT-14914] No response middleware information in Tyk OAS API Debugger (#7158):internal/oasbuilder/builder.go
 	mock.Enabled = true
 	mock.Code = http.StatusOK
 	mock.Body = "ok"
@@ -225,9 +263,9 @@ func (eb *EndpointBuilder) operationId() string {
 	return strings.ToLower(eb.path + eb.path)
 }
 
-func (eb *EndpointBuilder) operation() *Operation {
+func (eb *EndpointBuilder) operation() *oas.Operation {
 	if eb.op == nil {
-		eb.op = &Operation{}
+		eb.op = &oas.Operation{}
 	}
 
 	return eb.op


### PR DESCRIPTION
[TT-14914] No response middleware information in Tyk OAS API Debugger (#7158)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-14914"
title="TT-14914" target="_blank">TT-14914</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
<td> No response middleware information in Tyk OAS API Debugger</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Code Review</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20QA_Fail%20ORDER%20BY%20created%20DESC"
title="QA_Fail">QA_Fail</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20codilime_refined%20ORDER%20BY%20created%20DESC"
title="codilime_refined">codilime_refined</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description
Provided changes:
1. Mocked response should have pass through response mw pipeline.
2. Builder from oas package moved to internal package named oas builder,
due to Laurentu's request.

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested
1. It was tested manually.

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [x] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Refactored OAS builder to internal package `oasbuilder`

- Updated all usages to reference new `oasbuilder` package

- Fixed response middleware chain assignment and handling

- Standardized middleware status codes and improved code clarity


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Move OAS builder to internal/oasbuilder"] -- "Refactor imports/usages" --> B["Update references in tracing_test.go"]
  B -- "Update endpoint builder usage" --> C["Standardize middleware status codes"]
  C -- "Improve response middleware chain" --> D["Fix response chain assignment in processSpec"]
  D -- "Enhance mock response middleware" --> E["Update related gateway files"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>11
files</summary><table>
<tr>
<td><strong>builder.go</strong><dd><code>Move and refactor OAS builder
to internal package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7158/files#diff-5d782e3804be22e326c374b6d2e39c588e06dc064b9788aa5fe6bc21584e6ebb">+31/-49</a>&nbsp;
</td>

</tr>

<tr>
<td><strong>middleware.go</strong><dd><code>Standardize middleware
status codes and handler logic</code>&nbsp; &nbsp; &nbsp; &nbsp;
</dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7158/files#diff-703054910891a4db633eca0f42ed779d6b4fa75cd9b3aa4c503e681364201c1b">+4/-5</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
<td><strong>mw_mock_response.go</strong><dd><code>Refactor mock response
middleware and response chain handling</code></dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7158/files#diff-fa778ebf662b147d9693791799966dbd20fca6eb5dc98b2e7264230b4e0cbfbd">+13/-14</a>&nbsp;
</td>

</tr>

<tr>
<td><strong>mw_redis_cache.go</strong><dd><code>Use standardized
middleware status code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7158/files#diff-6266e0dbd16cef89e6de86a2c893114ba07799c804e2138172f9f94b08cdded8">+2/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
<td><strong>mw_js_plugin.go</strong><dd><code>Use standardized
middleware status code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7158/files#diff-78cd278aba997558b7daa7897051a794ef860076d45c93be792791db39381ca0">+3/-3</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
<td><strong>mw_go_plugin.go</strong><dd><code>Use standardized
middleware status code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7158/files#diff-0f31abef73bf795e1a8d331202330c73011a74d10fd66e49b9359716a6d18fd9">+4/-4</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
<td><strong>mw_virtual_endpoint.go</strong><dd><code>Use standardized
middleware status code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7158/files#diff-daf72ac3b29609a9f2a77cccf648f91ba62b2ad977a7c5a44602c72b2a28b2e5">+2/-3</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
<td><strong>mw_version_check.go</strong><dd><code>Use standardized
middleware status code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7158/files#diff-ea28ed4980be684295449af109cad7cef58b8823d9f270ab3f1537441645579a">+3/-2</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
<td><strong>coprocess.go</strong><dd><code>Use standardized middleware
status code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7158/files#diff-9cbfe628982b2afb94d1e9a5200fc9a4fdc00cb58fe65d1090a3725e4e4c5953">+7/-8</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
<td><strong>tracing.go</strong><dd><code>Add String() to traceLogType
and minor cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7158/files#diff-0069987d730b02812808925a17e1434ca7558a4dfc8661beb27ccd11afb8c77d">+5/-2</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
<td><strong>server.go</strong><dd><code>Refactor response middleware
chain creation to return chain</code></dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7158/files#diff-4652d1bf175a0be8f5e61ef7177c9666f23e077d8626b73ac9d13358fa8b525b">+2/-4</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1
files</summary><table>
<tr>
<td><strong>tracing_test.go</strong><dd><code>Update OAS builder usage
to internal/oasbuilder</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7158/files#diff-17a8010aa6755f9c464858ca32ade86af22931c1671b644b97b0a6f984ead54b">+14/-13</a>&nbsp;
</td>

</tr>
</table></details></td></tr><tr><td><strong>Bug
fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
<td><strong>api_loader.go</strong><dd><code>Fix response middleware
chain assignment and logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7158/files#diff-cdf0b7f176c9d18e1a314b78ddefc2cb3a94b3de66f1f360174692c915734c68">+3/-7</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary> Need help?</summary><li>Type <code>/help how to
...</code> in the comments thread for any questions about PR-Agent
usage.</li><li>Check out the <a
href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a>
for more information.</li></details>