### PR TITLE
Merging to release-5.3: [TT-15059][TT-11285] MDCB DNS critical fix and policy sync cherrypick (#7167)

### DIFF
--- a/gateway/policy.go
+++ b/gateway/policy.go
@@ -224,6 +224,9 @@ func (gw *Gateway) LoadPoliciesFromRPC(store RPCDataLoader, orgId string, allowE
 	}
 
 	rpcPolicies := store.GetPolicies(orgId)
+	if rpcPolicies == "" {
+		return nil, errors.New("failed to fetch policies from RPC store; connection may be down")
+	}
 
 	policies, err := parsePoliciesFromRPC(rpcPolicies, allowExplicit)
 

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -703,7 +703,15 @@ func (r RPCStorageHandler) RemoveFromSet(keyName, value string) {
 
 func (r RPCStorageHandler) IsRetriableError(err error) bool {
 	if err != nil {
-		return err.Error() == "Access Denied"
+		errMsg := err.Error()
+		// Access denied errors (authentication issues)
+		if errMsg == "Access Denied" {
+			return true
+		}
+		// Timeout errors from gorpc library
+		if strings.Contains(errMsg, "Cannot obtain response during timeout") {
+			return true
+		}
 	}
 	return false
 }

--- a/gateway/rpc_storage_handler_test.go
+++ b/gateway/rpc_storage_handler_test.go
@@ -651,3 +651,128 @@ func TestDeleteUsingTokenID(t *testing.T) {
 		assert.Equal(t, 404, status)
 	})
 }
+<<<<<<< HEAD
+=======
+
+func TestProcessKeySpaceChanges_UserKeyReset(t *testing.T) {
+	oldKey := "old-api-key"
+	newKey := "new-api-key"
+
+	dispatcher := gorpc.NewDispatcher()
+	dispatcher.AddFunc("Login", func(_, _ string) bool {
+		return true
+	})
+	dispatcher.AddFunc("Disconnect", func(_ string, _ *model.GroupLoginRequest) error {
+		return nil
+	})
+	dispatcher.AddFunc("GetKeySpaceUpdate", func(_, _ string) ([]string, error) {
+		return []string{}, nil
+	})
+	dispatcher.AddFunc("GetGroupKeySpaceUpdate", func(_ string, _ string) ([]string, error) {
+		return []string{}, nil
+	})
+
+	rpcMock, connectionString := startRPCMock(dispatcher)
+	defer stopRPCMock(rpcMock)
+
+	g := StartTest(func(globalConf *config.Config) {
+		globalConf.SlaveOptions.UseRPC = true
+		globalConf.SlaveOptions.RPCKey = "test_org"
+		globalConf.SlaveOptions.APIKey = oldKey
+		globalConf.SlaveOptions.ConnectionString = connectionString
+		globalConf.SlaveOptions.CallTimeout = 1
+		globalConf.SlaveOptions.RPCPoolSize = 2
+		globalConf.SlaveOptions.DisableKeySpaceSync = true
+	})
+	defer g.Close()
+
+	time.Sleep(100 * time.Millisecond)
+
+	rpcListener := RPCStorageHandler{
+		KeyPrefix:        "rpc.listener.",
+		SuppressRegister: true,
+		HashKeys:         false,
+		Gw:               g.Gw,
+	}
+
+	connected := rpcListener.Connect()
+	if !connected {
+		t.Fatal("Failed to connect to RPC server")
+	}
+
+	testCases := []struct {
+		name     string
+		keys     []string
+		expected string
+	}{
+		{
+			name:     "Valid key reset",
+			keys:     []string{fmt.Sprintf("%s.%s:UserKeyReset", oldKey, newKey)},
+			expected: newKey,
+		},
+		{
+			name:     "Invalid key format - no action",
+			keys:     []string{"invalid-format"},
+			expected: oldKey,
+		},
+		{
+			name:     "Invalid key format - wrong separator",
+			keys:     []string{"invalid-format:UserKeyReset"},
+			expected: oldKey,
+		},
+		{
+			name:     "Multiple keys with reset",
+			keys:     []string{fmt.Sprintf("%s.%s:UserKeyReset", oldKey, newKey), "other-key:action"},
+			expected: newKey,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Reset config before each test
+			config := g.Gw.GetConfig()
+			config.SlaveOptions.APIKey = oldKey
+			g.Gw.SetConfig(config)
+
+			rpcListener.ProcessKeySpaceChanges(tc.keys, DefaultOrg)
+			updatedConfig := g.Gw.GetConfig()
+			assert.Equal(t, tc.expected, updatedConfig.SlaveOptions.APIKey)
+		})
+	}
+}
+
+func TestIsRetriableError(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	rpcHandler := RPCStorageHandler{
+		KeyPrefix:        "rpc.listener.",
+		SuppressRegister: true,
+		Gw:               ts.Gw,
+	}
+
+	testCases := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "Access Denied error is retriable",
+			err:      errors.New("Access Denied"),
+			expected: true,
+		},
+		{
+			name:     "Timeout error is retriable",
+			err:      errors.New("Cannot obtain response during timeout=30s"),
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := rpcHandler.IsRetriableError(tc.err)
+			assert.Equal(t, tc.expected, result, "IsRetriableError(%v) should return %v", tc.err, tc.expected)
+		})
+	}
+}
+>>>>>>> 3fde8c6e8... [TT-15059][TT-11285] MDCB DNS critical fix and policy sync cherrypick (#7167)

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -582,11 +582,15 @@ func (gw *Gateway) syncPolicies() (count int, err error) {
 		mainLog.Debugf(" - %s", id)
 	}
 
+	if err != nil {
+		return len(pols), err
+	}
+
 	gw.policiesMu.Lock()
 	defer gw.policiesMu.Unlock()
 	gw.policiesByID = pols
 
-	return len(pols), err
+	return len(pols), nil
 }
 
 // stripSlashes removes any trailing slashes from the request's URL
@@ -1037,6 +1041,24 @@ func syncResourcesWithReload(resource string, conf config.Config, syncFunc func(
 		}
 
 		mainLog.Errorf("Error during syncing %s: %s, attempt count %d", resource, err.Error(), i)
+
+		// Check if this is the last attempt
+		if i == conf.ResourceSync.RetryAttempts+1 {
+			// For RPC-based resources, trigger emergency mode if all retries failed
+			if conf.SlaveOptions.UseRPC {
+				mainLog.Warningf("All %s sync attempts failed, triggering emergency mode", resource)
+				rpc.EnableEmergencyMode(true)
+
+				// Try one more time with emergency mode enabled
+				count, err = syncFunc()
+				if err == nil {
+					mainLog.Infof("Successfully loaded %s from backup after enabling emergency mode", resource)
+					return count, nil
+				}
+			}
+			break
+		}
+
 		time.Sleep(time.Duration(conf.ResourceSync.Interval) * time.Second)
 	}
 

--- a/gateway/server_test.go
+++ b/gateway/server_test.go
@@ -10,6 +10,11 @@ import (
 
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/internal/otel"
+<<<<<<< HEAD
+=======
+	"github.com/TykTechnologies/tyk/rpc"
+	"github.com/TykTechnologies/tyk/test"
+>>>>>>> 3fde8c6e8... [TT-15059][TT-11285] MDCB DNS critical fix and policy sync cherrypick (#7167)
 	"github.com/TykTechnologies/tyk/user"
 )
 
@@ -199,7 +204,7 @@ func TestGateway_SyncResourcesWithReload(t *testing.T) {
 		syncFunc, hitCounter := syncFuncSuccessAt(t, 5)
 		startTime := time.Now()
 		resourceCount, err := syncResourcesWithReload("apis", ts.Gw.GetConfig(), syncFunc)
-		assert.Greater(t, time.Since(startTime), time.Second*3)
+		assert.Greater(t, time.Since(startTime), time.Second*2)
 		assert.ErrorIs(t, err, syncErr)
 		assert.Zero(t, resourceCount)
 		assert.Equal(t, 3, *hitCounter)
@@ -216,4 +221,46 @@ func TestGateway_SyncResourcesWithReload(t *testing.T) {
 		assert.Equal(t, 2, *hitCounter)
 	})
 
+	t.Run("RPC timeout triggers emergency mode and loads from backup", func(t *testing.T) {
+		t.Parallel()
+
+		// Configure gateway for RPC mode
+		conf := ts.Gw.GetConfig()
+		conf.SlaveOptions.UseRPC = true
+
+		// Create a sync function that simulates timeout errors initially, then succeeds when emergency mode is enabled
+		var hitCount int
+		timeoutError := errors.New("Cannot obtain response during timeout=30s")
+
+		syncFunc := func() (int, error) {
+			hitCount++
+
+			// Always fail with timeout for the first retryAttempts+1 attempts (normal + last attempt)
+			// This ensures emergency mode gets triggered properly
+			if hitCount <= retryAttempts+1 {
+				return 0, timeoutError
+			}
+
+			// Succeed when emergency mode is enabled (backup loading)
+			// This will be called after emergency mode is enabled
+			return 5, nil // Simulate loading 5 items from backup
+		}
+
+		// Ensure we start without emergency mode
+		rpc.ResetEmergencyMode()
+		defer rpc.ResetEmergencyMode()
+
+		// Test the sync with timeout -> emergency mode -> success flow
+		resourceCount, err := syncResourcesWithReload("policies", conf, syncFunc)
+
+		// Should succeed after triggering emergency mode
+		assert.NoError(t, err)
+		assert.Equal(t, 5, resourceCount)
+
+		// Should have attempted retries + 1 emergency mode attempt
+		assert.Equal(t, retryAttempts+2, hitCount)
+
+		// Emergency mode should be enabled
+		assert.True(t, rpc.IsEmergencyMode())
+	})
 }

--- a/rpc/dns_resolver.go
+++ b/rpc/dns_resolver.go
@@ -1,0 +1,130 @@
+package rpc
+
+import (
+	"net"
+	"sync"
+)
+
+var (
+	// for dns monitoring
+	lastResolvedIPs []string
+	dnsRefreshMutex sync.RWMutex
+
+	// global resolver to be replaced in tests
+	dnsResolver DNSResolver = &DefaultDNSResolver{}
+
+	// declare funcs as vars that we can override in testing
+	safeReconnectRPCClient func(suppressRegister bool)
+)
+
+//nolint:gochecknoinits
+func init() {
+	safeReconnectRPCClient = defaultSafeReconnectRPCClient
+}
+
+// DNSResolver provides methods for DNS resolution
+type DNSResolver interface {
+	LookupIP(host string) ([]net.IP, error)
+}
+
+// DefaultDNSResolver implements DNSResolver using the standard library
+type DefaultDNSResolver struct{}
+
+func (r *DefaultDNSResolver) LookupIP(host string) ([]net.IP, error) {
+	return net.LookupIP(host)
+}
+
+// updateResolvedIPs checks if DNS resolution has changed using the provided resolver
+func updateResolvedIPs(host string, resolver DNSResolver) bool {
+	ips, err := resolver.LookupIP(host)
+	if err != nil {
+		Log.Error("Failed to resolve host during DNS refresh:", err)
+		return false
+	}
+
+	// Extract IPv4 addresses
+	newIPs := make([]string, 0, len(ips))
+	for _, ip := range ips {
+		if ipv4 := ip.To4(); ipv4 != nil {
+			newIPs = append(newIPs, ipv4.String())
+		}
+	}
+
+	dnsRefreshMutex.Lock()
+	defer dnsRefreshMutex.Unlock()
+
+	// Check if IPs have changed
+	changed := !equalStringSlices(lastResolvedIPs, newIPs)
+	if changed {
+		Log.Debug("DNS resolution changed from", lastResolvedIPs, "to", newIPs)
+		lastResolvedIPs = newIPs
+	}
+
+	return changed
+}
+
+// checkDNSAndReconnect checks if DNS resolution has changed and reconnects if needed
+func checkDNSAndReconnect(connectionString string, suppressRegister bool) bool {
+	host, _, err := net.SplitHostPort(connectionString)
+	if err != nil {
+		Log.Error("Failed to parse connection string for DNS check:", err)
+		return false
+	}
+
+	// Check if DNS has changed
+	if changed := updateResolvedIPs(host, dnsResolver); changed {
+		Log.Info("MDCB DNS resolution changed, reconnecting as self-healing mechanism...")
+		safeReconnectRPCClient(suppressRegister)
+		return true
+	}
+	return false
+}
+
+// checkAndHandleDNSChange checks if DNS has changed and handles reconnection if needed.
+// Returns true if DNS changed and reconnection was attempted, false otherwise.
+// Also returns a boolean indicating whether the function should retry the RPC call.
+func checkAndHandleDNSChange(connectionString string, suppressRegister bool) (dnsChanged bool, shouldRetry bool) {
+
+	// Skip if we've already checked DNS after an error, or we're in emergency mode
+	if values.GetDNSCheckedAfterError() || values.GetEmergencyMode() {
+		Log.Debug("Skipping DNS check - already checked or in emergency mode")
+		return false, false
+	}
+
+	// Mark that we've checked DNS
+	values.SetDNSCheckedAfterError(true)
+	Log.Info("RPC error detected, checking DNS as self-healing mechanism...")
+
+	// Check if DNS has changed and reconnect if needed
+	if changed := checkDNSAndReconnect(connectionString, suppressRegister); changed {
+		return true, true // DNS changed, should retry
+	}
+
+	// DNS hasn't changed
+	Log.Warning("MDCB connection failed. DNS unchanged - check MDCB service and network.")
+	return false, false // DNS unchanged, should not retry
+}
+
+func defaultSafeReconnectRPCClient(suppressRegister bool) {
+	// Stop existing client
+	if clientSingleton != nil {
+		oldClient := clientSingleton
+		clientSingleton = nil // Clear reference first
+		oldClient.Stop()      // Then stop the old client
+	}
+
+	// Reinitialize client
+	Log.Info("Reinitializing RPC client after DNS change...")
+	initializeClient()
+
+	// Reinitialize function client
+	if dispatcher != nil {
+		funcClientSingleton = dispatcher.NewFuncClient(clientSingleton)
+	}
+
+	// Relogin
+	handleLogin()
+	if !suppressRegister {
+		register()
+	}
+}

--- a/rpc/dns_resolver_test.go
+++ b/rpc/dns_resolver_test.go
@@ -1,0 +1,501 @@
+package rpc
+
+import (
+	"errors"
+	"net"
+	"testing"
+)
+
+// Helper function to create IP addresses for testing
+func makeIPs(ips ...string) []net.IP {
+	result := make([]net.IP, len(ips))
+	for i, ip := range ips {
+		result[i] = net.ParseIP(ip)
+	}
+	return result
+}
+
+// MockDNSResolver implements DNSResolver for testing
+type MockDNSResolver struct {
+	LookupIPFunc func(host string) ([]net.IP, error)
+}
+
+func (m *MockDNSResolver) LookupIP(host string) ([]net.IP, error) {
+	return m.LookupIPFunc(host)
+}
+
+func TestCheckDNSAndReconnect(t *testing.T) {
+	// Save original values and restore after test
+	originalSafeReconnect := safeReconnectRPCClient
+	originalIPs := lastResolvedIPs
+	originalResolver := dnsResolver
+
+	defer func() {
+		safeReconnectRPCClient = originalSafeReconnect
+		lastResolvedIPs = originalIPs
+		dnsResolver = originalResolver
+	}()
+
+	// Test cases
+	tests := []struct {
+		name                string
+		connectionString    string
+		initialIPs          []string
+		resolvedIPs         []net.IP
+		resolveError        error
+		expectedResult      bool
+		expectReconnectCall bool
+		expectDNSLookup     bool
+	}{
+		{
+			name:                "DNS changed - should reconnect",
+			connectionString:    "example.com:8080",
+			initialIPs:          []string{"192.168.1.1"},
+			resolvedIPs:         makeIPs("192.168.1.2"),
+			resolveError:        nil,
+			expectedResult:      true,
+			expectReconnectCall: true,
+			expectDNSLookup:     true,
+		},
+		{
+			name:                "DNS unchanged - should not reconnect",
+			connectionString:    "example.com:8080",
+			initialIPs:          []string{"192.168.1.1"},
+			resolvedIPs:         makeIPs("192.168.1.1"),
+			resolveError:        nil,
+			expectedResult:      false,
+			expectReconnectCall: false,
+			expectDNSLookup:     true,
+		},
+		{
+			name:                "DNS resolution error - should not reconnect",
+			connectionString:    "example.com:8080",
+			initialIPs:          []string{"192.168.1.1"},
+			resolvedIPs:         nil,
+			resolveError:        errors.New("DNS resolution failed"),
+			expectedResult:      false,
+			expectReconnectCall: false,
+			expectDNSLookup:     true,
+		},
+		{
+			name:                "Invalid connection string - should not check DNS or reconnect",
+			connectionString:    "invalid-no-port", // Missing port
+			initialIPs:          []string{"192.168.1.1"},
+			resolvedIPs:         makeIPs("192.168.1.2"),
+			resolveError:        nil,
+			expectedResult:      false,
+			expectReconnectCall: false,
+			expectDNSLookup:     false,
+		},
+		{
+			name:                "Empty connection string - should not check DNS or reconnect",
+			connectionString:    "",
+			initialIPs:          []string{"192.168.1.1"},
+			resolvedIPs:         makeIPs("192.168.1.2"),
+			resolveError:        nil,
+			expectedResult:      false,
+			expectReconnectCall: false,
+			expectDNSLookup:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set initial IPs
+			lastResolvedIPs = tt.initialIPs
+
+			// Create a mock resolver
+			dnsLookupCalled := false
+			mockResolver := &MockDNSResolver{}
+			mockResolver.LookupIPFunc = func(_ string) ([]net.IP, error) {
+				dnsLookupCalled = true
+				return tt.resolvedIPs, tt.resolveError
+			}
+			dnsResolver = mockResolver
+
+			// Create a mock reconnect function
+			reconnectCalled := false
+			safeReconnectRPCClient = func(_ bool) {
+				reconnectCalled = true
+			}
+
+			// Call the function
+			result := checkDNSAndReconnect(tt.connectionString, false)
+
+			// Check result
+			if result != tt.expectedResult {
+				t.Errorf("checkDNSAndReconnect() = %v, expected %v", result, tt.expectedResult)
+			}
+
+			// Check if reconnect was called as expected
+			if reconnectCalled != tt.expectReconnectCall {
+				t.Errorf("reconnect called = %v, expected %v", reconnectCalled, tt.expectReconnectCall)
+			}
+
+			// Check if DNS lookup was performed as expected
+			if dnsLookupCalled != tt.expectDNSLookup {
+				t.Errorf("DNS lookup performed = %v, expected %v", dnsLookupCalled, tt.expectDNSLookup)
+			}
+		})
+	}
+}
+
+func TestUpdateResolvedIPs(t *testing.T) {
+	// Save original values and restore after test
+	originalIPs := lastResolvedIPs
+	defer func() {
+		lastResolvedIPs = originalIPs
+	}()
+
+	// Create a mock resolver
+	mockResolver := &MockDNSResolver{}
+
+	// Test cases
+	tests := []struct {
+		name           string
+		initialIPs     []string
+		resolvedIPs    []net.IP
+		resolveError   error
+		expectedResult bool
+		expectedIPs    []string
+	}{
+		{
+			name:           "first resolution",
+			initialIPs:     nil,
+			resolvedIPs:    makeIPs("192.168.1.1", "192.168.1.2"),
+			resolveError:   nil,
+			expectedResult: true,
+			expectedIPs:    []string{"192.168.1.1", "192.168.1.2"},
+		},
+		{
+			name:           "same IPs",
+			initialIPs:     []string{"192.168.1.1", "192.168.1.2"},
+			resolvedIPs:    makeIPs("192.168.1.1", "192.168.1.2"),
+			resolveError:   nil,
+			expectedResult: false,
+			expectedIPs:    []string{"192.168.1.1", "192.168.1.2"},
+		},
+		{
+			name:           "different IPs",
+			initialIPs:     []string{"192.168.1.1", "192.168.1.2"},
+			resolvedIPs:    makeIPs("192.168.1.1", "192.168.1.3"),
+			resolveError:   nil,
+			expectedResult: true,
+			expectedIPs:    []string{"192.168.1.1", "192.168.1.3"},
+		},
+		{
+			name:           "different order",
+			initialIPs:     []string{"192.168.1.1", "192.168.1.2"},
+			resolvedIPs:    makeIPs("192.168.1.2", "192.168.1.1"),
+			resolveError:   nil,
+			expectedResult: false,                                  // Order doesn't matter
+			expectedIPs:    []string{"192.168.1.1", "192.168.1.2"}, // Original IPs should remain
+		},
+		{
+			name:           "more IPs",
+			initialIPs:     []string{"192.168.1.1", "192.168.1.2"},
+			resolvedIPs:    makeIPs("192.168.1.1", "192.168.1.2", "192.168.1.3"),
+			resolveError:   nil,
+			expectedResult: true,
+			expectedIPs:    []string{"192.168.1.1", "192.168.1.2", "192.168.1.3"},
+		},
+		{
+			name:           "fewer IPs",
+			initialIPs:     []string{"192.168.1.1", "192.168.1.2", "192.168.1.3"},
+			resolvedIPs:    makeIPs("192.168.1.1", "192.168.1.2"),
+			resolveError:   nil,
+			expectedResult: true,
+			expectedIPs:    []string{"192.168.1.1", "192.168.1.2"},
+		},
+		{
+			name:           "resolve error",
+			initialIPs:     []string{"192.168.1.1", "192.168.1.2"},
+			resolvedIPs:    nil,
+			resolveError:   errors.New("DNS resolution failed"),
+			expectedResult: false,
+			expectedIPs:    []string{"192.168.1.1", "192.168.1.2"}, // Original IPs should remain
+		},
+		{
+			name:           "mixed IPv4 and IPv6",
+			initialIPs:     []string{"192.168.1.1"},
+			resolvedIPs:    []net.IP{net.ParseIP("192.168.1.1"), net.ParseIP("2001:db8::1")},
+			resolveError:   nil,
+			expectedResult: false, // Only IPv4 addresses are considered, so no change
+			expectedIPs:    []string{"192.168.1.1"},
+		},
+		{
+			name:           "only IPv6",
+			initialIPs:     []string{"192.168.1.1"},
+			resolvedIPs:    []net.IP{net.ParseIP("2001:db8::1"), net.ParseIP("2001:db8::2")},
+			resolveError:   nil,
+			expectedResult: true,       // All IPv4 addresses are gone
+			expectedIPs:    []string{}, // Should be empty since no IPv4 addresses
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set initial IPs
+			lastResolvedIPs = tt.initialIPs
+
+			// Configure mock resolver
+			mockResolver.LookupIPFunc = func(_ string) ([]net.IP, error) {
+				return tt.resolvedIPs, tt.resolveError
+			}
+
+			// Call the function
+			result := updateResolvedIPs("example.com", mockResolver)
+
+			// Check result
+			if result != tt.expectedResult {
+				t.Errorf("updateResolvedIPs() = %v, expected %v", result, tt.expectedResult)
+			}
+
+			// Check that lastResolvedIPs was updated correctly
+			if !equalStringSlices(lastResolvedIPs, tt.expectedIPs) {
+				t.Errorf("lastResolvedIPs = %v, expected %v", lastResolvedIPs, tt.expectedIPs)
+			}
+		})
+	}
+}
+
+func TestCheckAndHandleDNSChange(t *testing.T) {
+	// Save original values and restore after test
+	originalSafeReconnectRPCClient := safeReconnectRPCClient
+	originalIPs := lastResolvedIPs
+	originalResolver := dnsResolver
+
+	// Save original values state
+	originalDNSChecked := values.GetDNSCheckedAfterError()
+	originalEmergencyMode := values.GetEmergencyMode()
+
+	defer func() {
+		// Restore all original values
+		safeReconnectRPCClient = originalSafeReconnectRPCClient
+		lastResolvedIPs = originalIPs
+		dnsResolver = originalResolver
+		values.SetDNSCheckedAfterError(originalDNSChecked)
+		values.SetEmergencyMode(originalEmergencyMode)
+	}()
+
+	// Test cases
+	tests := []struct {
+		name                 string
+		initialIPs           []string
+		resolvedIPs          []net.IP
+		resolveError         error
+		dnsCheckedAfterError bool
+		emergencyMode        bool
+		expectedDNSChanged   bool
+		expectedShouldRetry  bool
+		expectReconnectCall  bool
+	}{
+		{
+			name:                 "DNS changed - should reconnect and retry",
+			initialIPs:           []string{"192.168.1.1"},
+			resolvedIPs:          makeIPs("192.168.1.2"),
+			resolveError:         nil,
+			dnsCheckedAfterError: false,
+			emergencyMode:        false,
+			expectedDNSChanged:   true,
+			expectedShouldRetry:  true,
+			expectReconnectCall:  true,
+		},
+		{
+			name:                 "DNS unchanged - should not reconnect or retry",
+			initialIPs:           []string{"192.168.1.1"},
+			resolvedIPs:          makeIPs("192.168.1.1"),
+			resolveError:         nil,
+			dnsCheckedAfterError: false,
+			emergencyMode:        false,
+			expectedDNSChanged:   false,
+			expectedShouldRetry:  false,
+			expectReconnectCall:  false,
+		},
+		{
+			name:                 "DNS already checked - should skip check",
+			initialIPs:           []string{"192.168.1.1"},
+			resolvedIPs:          makeIPs("192.168.1.2"), // Would trigger reconnect if checked
+			resolveError:         nil,
+			dnsCheckedAfterError: true,
+			emergencyMode:        false,
+			expectedDNSChanged:   false,
+			expectedShouldRetry:  false,
+			expectReconnectCall:  false,
+		},
+		{
+			name:                 "In emergency mode - should skip check",
+			initialIPs:           []string{"192.168.1.1"},
+			resolvedIPs:          makeIPs("192.168.1.2"), // Would trigger reconnect if checked
+			resolveError:         nil,
+			dnsCheckedAfterError: false,
+			emergencyMode:        true,
+			expectedDNSChanged:   false,
+			expectedShouldRetry:  false,
+			expectReconnectCall:  false,
+		},
+		{
+			name:                 "DNS resolution error - should not reconnect",
+			initialIPs:           []string{"192.168.1.1"},
+			resolvedIPs:          nil,
+			resolveError:         errors.New("DNS resolution failed"),
+			dnsCheckedAfterError: false,
+			emergencyMode:        false,
+			expectedDNSChanged:   false,
+			expectedShouldRetry:  false,
+			expectReconnectCall:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set initial IPs
+			lastResolvedIPs = tt.initialIPs
+
+			// Create a mock resolver
+			mockResolver := &MockDNSResolver{}
+			mockResolver.LookupIPFunc = func(_ string) ([]net.IP, error) {
+				return tt.resolvedIPs, tt.resolveError
+			}
+			dnsResolver = mockResolver
+
+			// Set initial state values
+			values.SetDNSCheckedAfterError(tt.dnsCheckedAfterError)
+			values.SetEmergencyMode(tt.emergencyMode)
+
+			// Create a mock reconnect function
+			reconnectCalled := false
+			safeReconnectRPCClient = func(_ bool) {
+				reconnectCalled = true
+			}
+
+			// Call the function
+			dnsChanged, shouldRetry := checkAndHandleDNSChange("example.com:8080", false)
+
+			// Check results
+			if dnsChanged != tt.expectedDNSChanged {
+				t.Errorf("dnsChanged = %v, expected %v", dnsChanged, tt.expectedDNSChanged)
+			}
+
+			if shouldRetry != tt.expectedShouldRetry {
+				t.Errorf("shouldRetry = %v, expected %v", shouldRetry, tt.expectedShouldRetry)
+			}
+
+			// Check if reconnect was called as expected
+			if reconnectCalled != tt.expectReconnectCall {
+				t.Errorf("reconnect called = %v, expected %v", reconnectCalled, tt.expectReconnectCall)
+			}
+
+			// If we weren't already in DNS checked state and not in emergency mode,
+			// verify that DNS checked flag was set to true
+			if !tt.dnsCheckedAfterError && !tt.emergencyMode {
+				if !values.GetDNSCheckedAfterError() {
+					t.Error("DNS checked flag should have been set to true")
+				}
+			}
+		})
+	}
+}
+
+func TestDNSIsOnlyCheckedOncePerConnectionIssue(t *testing.T) {
+	// Save original values and restore after test
+	originalSafeReconnectRPCClient := safeReconnectRPCClient
+	originalIPs := lastResolvedIPs
+	originalResolver := dnsResolver
+	originalDNSChecked := values.GetDNSCheckedAfterError()
+	originalEmergencyMode := values.GetEmergencyMode()
+
+	defer func() {
+		// Restore all original values
+		safeReconnectRPCClient = originalSafeReconnectRPCClient
+		lastResolvedIPs = originalIPs
+		dnsResolver = originalResolver
+		values.SetDNSCheckedAfterError(originalDNSChecked)
+		values.SetEmergencyMode(originalEmergencyMode)
+	}()
+
+	// Setup initial state
+	values.SetDNSCheckedAfterError(false)
+	values.SetEmergencyMode(false)
+	lastResolvedIPs = []string{"192.168.1.1"}
+
+	// Create a mock resolver that returns different IPs on each call
+	dnsLookupCount := 0
+	mockResolver := &MockDNSResolver{}
+	mockResolver.LookupIPFunc = func(_ string) ([]net.IP, error) {
+		dnsLookupCount++
+		// Return different IPs each time
+		if dnsLookupCount == 1 {
+			return makeIPs("192.168.1.2"), nil
+		} else {
+			return makeIPs("192.168.1.3"), nil
+		}
+	}
+	dnsResolver = mockResolver
+
+	// Create a mock reconnect function that counts calls
+	reconnectCount := 0
+	safeReconnectRPCClient = func(_ bool) {
+		reconnectCount++
+	}
+
+	// First call - should check DNS and reconnect
+	dnsChanged1, shouldRetry1 := checkAndHandleDNSChange("example.com:8080", false)
+
+	// Verify first call results
+	if !dnsChanged1 {
+		t.Error("First call: dnsChanged should be true")
+	}
+	if !shouldRetry1 {
+		t.Error("First call: shouldRetry should be true")
+	}
+	if dnsLookupCount != 1 {
+		t.Errorf("First call: DNS lookup count should be 1, got %d", dnsLookupCount)
+	}
+	if reconnectCount != 1 {
+		t.Errorf("First call: reconnect count should be 1, got %d", reconnectCount)
+	}
+	if !values.GetDNSCheckedAfterError() {
+		t.Error("First call: DNS checked flag should be set to true")
+	}
+
+	// Second call - should skip DNS check because dnsCheckedAfterError is true
+	dnsChanged2, shouldRetry2 := checkAndHandleDNSChange("example.com:8080", false)
+
+	// Verify second call results
+	if dnsChanged2 {
+		t.Error("Second call: dnsChanged should be false")
+	}
+	if shouldRetry2 {
+		t.Error("Second call: shouldRetry should be false")
+	}
+	if dnsLookupCount != 1 {
+		t.Errorf("Second call: DNS lookup count should still be 1, got %d", dnsLookupCount)
+	}
+	if reconnectCount != 1 {
+		t.Errorf("Second call: reconnect count should still be 1, got %d", reconnectCount)
+	}
+
+	// Now simulate a successful login which resets the DNS checked flag
+	values.SetDNSCheckedAfterError(false)
+
+	// Third call after successful login - should check DNS again
+	dnsChanged3, shouldRetry3 := checkAndHandleDNSChange("example.com:8080", false)
+
+	// Verify third call results
+	if !dnsChanged3 {
+		t.Error("Third call: dnsChanged should be true")
+	}
+	if !shouldRetry3 {
+		t.Error("Third call: shouldRetry should be true")
+	}
+	if dnsLookupCount != 2 {
+		t.Errorf("Third call: DNS lookup count should be 2, got %d", dnsLookupCount)
+	}
+	if reconnectCount != 2 {
+		t.Errorf("Third call: reconnect count should be 2, got %d", reconnectCount)
+	}
+	if !values.GetDNSCheckedAfterError() {
+		t.Error("Third call: DNS checked flag should be set to true again")
+	}
+}

--- a/rpc/rpc_client.go
+++ b/rpc/rpc_client.go
@@ -56,7 +56,7 @@ var (
 // ErrRPCIsDown this is returned when we can't reach rpc server.
 var ErrRPCIsDown = errors.New("RPCStorageHandler: rpc is either down or was not configured")
 
-// rpc.Login is callend may places we only need one in flight at a time.
+// rpc.Login is called may places we only need one in flight at a time.
 var loginFlight singleflight.Group
 
 var values rpcOpts
@@ -69,6 +69,24 @@ type rpcOpts struct {
 	emergencyModeLoaded atomic.Value
 	config              atomic.Value
 	clientIsConnected   atomic.Value
+
+	// dnsCheckedAfterError tracks whether DNS has been checked after a connection error.
+	// This ensures DNS is only checked once per disconnection event, rather than
+	// on every failed RPC call. It's reset to false when a successful connection is made.
+	dnsCheckedAfterError atomic.Value
+}
+
+func (r *rpcOpts) SetDNSCheckedAfterError(checked bool) {
+	r.dnsCheckedAfterError.Store(checked)
+}
+
+func (r *rpcOpts) GetDNSCheckedAfterError() bool {
+	if v := r.dnsCheckedAfterError.Load(); v != nil {
+		if b, ok := v.(bool); ok {
+			return b
+		}
+	}
+	return false
 }
 
 func (r rpcOpts) ClientIsConnected() bool {
@@ -91,6 +109,7 @@ func (r *rpcOpts) Reset() {
 	r.emergencyMode.Store(false)
 	r.emergencyModeLoaded.Store(false)
 	r.clientIsConnected.Store(false)
+	r.dnsCheckedAfterError.Store(false)
 }
 
 func (r *rpcOpts) SetLoadCounts(n int) {
@@ -238,6 +257,12 @@ func Connect(
 		go checkDisconnect()
 	}
 
+	// Initial DNS resolution and get first ip
+	host, _, err := net.SplitHostPort(connConfig.ConnectionString)
+	if err == nil {
+		updateResolvedIPs(host, dnsResolver)
+	}
+
 	return true
 }
 
@@ -368,6 +393,11 @@ func loginBase() bool {
 		rpcLoginMu.Unlock()
 		return false
 	}
+
+	// Login was successful, reset the DNS check flag
+	values.SetDNSCheckedAfterError(false)
+	Log.Debug("Reset DNS check flag after successful login")
+
 	return true
 }
 
@@ -490,6 +520,17 @@ func FuncClientSingleton(funcName string, request interface{}) (result interface
 			return ErrRPCIsDown
 		}
 		result, err = funcClientSingleton.CallTimeout(funcName, request, GlobalRPCCallTimeout)
+
+		// If there's an error, handle it with our dedicated error handler
+		if err != nil {
+			if handleRPCError(err, values.Config().ConnectionString) {
+				// Error was handled and we should retry
+				return nil
+			}
+			// Error wasn't handled or we shouldn't retry
+			return err
+		}
+
 		return nil
 	}, backoff.WithMaxRetries(
 		backoff.NewConstantBackOff(10*time.Millisecond), 3,
@@ -498,6 +539,26 @@ func FuncClientSingleton(funcName string, request interface{}) (result interface
 		err = be
 	}
 	return
+}
+
+// handleRPCError processes RPC errors and determines if a retry should be attempted
+// Returns true if the error was handled and a retry should be attempted
+func handleRPCError(err error, connectionString string) bool {
+	if err == nil {
+		return false
+	}
+
+	Log.WithError(err).Debug("[RPC Store] --> Call failed")
+
+	// Check if it's a network-related error that might be resolved by a DNS check
+	if isNetworkError(err) {
+		Log.Debug("[RPC Store] Network error detected, checking DNS...")
+		dnsChanged, shouldRetry := checkAndHandleDNSChange(connectionString, false)
+		return dnsChanged && shouldRetry
+	}
+
+	Log.Debug("[RPC Store] Non-network error, skipping DNS check")
+	return false
 }
 
 var rpcConnectionsPool []net.Conn
@@ -563,4 +624,9 @@ func SetEmergencyMode(t *testing.T, value bool) {
 func SetLoadCounts(t *testing.T, value int) {
 	t.Helper()
 	values.SetLoadCounts(value)
+}
+
+// EnableEmergencyMode sets the emergency mode state for production use
+func EnableEmergencyMode(enabled bool) {
+	values.SetEmergencyMode(enabled)
 }

--- a/rpc/utils.go
+++ b/rpc/utils.go
@@ -1,0 +1,36 @@
+package rpc
+
+import "strings"
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	mapA := make(map[string]struct{}, len(a))
+	for _, val := range a {
+		mapA[val] = struct{}{}
+	}
+
+	for _, val := range b {
+		if _, exists := mapA[val]; !exists {
+			return false
+		}
+	}
+
+	return true
+}
+
+func isNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errStr := err.Error()
+
+	// Check for specific network-related error patterns
+	return strings.Contains(errStr, "unexpected response type: <nil>. Expected *dispatcherResponse") ||
+		strings.Contains(errStr, "Cannot obtain response during timeout") ||
+		strings.Contains(errStr, "rpc is either down or was not configured") ||
+		strings.Contains(errStr, "Cannot decode response")
+}

--- a/rpc/utils_test.go
+++ b/rpc/utils_test.go
@@ -1,0 +1,143 @@
+package rpc
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestEqualStringSlices(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        []string
+		b        []string
+		expected bool
+	}{
+		{
+			name:     "empty slices",
+			a:        []string{},
+			b:        []string{},
+			expected: true,
+		},
+		{
+			name:     "nil slices",
+			a:        nil,
+			b:        nil,
+			expected: true,
+		},
+		{
+			name:     "nil and empty",
+			a:        nil,
+			b:        []string{},
+			expected: true,
+		},
+		{
+			name:     "single element same",
+			a:        []string{"test"},
+			b:        []string{"test"},
+			expected: true,
+		},
+		{
+			name:     "single element different",
+			a:        []string{"test1"},
+			b:        []string{"test2"},
+			expected: false,
+		},
+		{
+			name:     "multiple elements same order",
+			a:        []string{"a", "b", "c"},
+			b:        []string{"a", "b", "c"},
+			expected: true,
+		},
+		{
+			name:     "multiple elements different order",
+			a:        []string{"a", "b", "c"},
+			b:        []string{"c", "a", "b"},
+			expected: true,
+		},
+		{
+			name:     "different lengths",
+			a:        []string{"a", "b"},
+			b:        []string{"a", "b", "c"},
+			expected: false,
+		},
+		{
+			name:     "subset",
+			a:        []string{"a", "b"},
+			b:        []string{"a", "b", "a"},
+			expected: false,
+		},
+		{
+			name:     "same elements with duplicates",
+			a:        []string{"a", "b", "a"},
+			b:        []string{"a", "a", "b"},
+			expected: true,
+		},
+		{
+			name:     "different elements with same length",
+			a:        []string{"a", "b", "c"},
+			b:        []string{"a", "b", "d"},
+			expected: false,
+		},
+		{
+			name:     "empty string elements",
+			a:        []string{"", "b"},
+			b:        []string{"", "b"},
+			expected: true,
+		},
+		{
+			name:     "case sensitivity",
+			a:        []string{"A", "b"},
+			b:        []string{"a", "b"},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := equalStringSlices(tt.a, tt.b)
+			if result != tt.expected {
+				t.Errorf("equalStringSlices(%v, %v) = %v, expected %v",
+					tt.a, tt.b, result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestIsNetworkError tests the isNetworkError function
+func TestIsNetworkError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "non-network error",
+			err:      errors.New("some random error"),
+			expected: false,
+		},
+		{
+			name:     "unexpected response type error",
+			err:      errors.New("unexpected response type: <nil>. Expected *dispatcherResponse"),
+			expected: true,
+		},
+		{
+			name:     "timeout error",
+			err:      errors.New("Cannot obtain response during timeout=30s"),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isNetworkError(tt.err)
+			if result != tt.expected {
+				t.Errorf("isNetworkError(%v) = %v, expected %v", tt.err, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
[TT-15059][TT-11285] MDCB DNS critical fix and policy sync cherrypick (#7167)

### **User description**
<!-- Provide a general summary of your changes in the Title above -->

This PR contains the changes introduced in
https://github.com/TykTechnologies/tyk/pull/7127 and
https://github.com/TykTechnologies/tyk/pull/7136 but merged together to
allow for an easier release process.

This PR introduces a DNS refresh mechanism together with a bugfix around
the synchronization of policies when the connection to MDCB would time
out.

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Add DNS-based self-healing for RPC connection failures
  - Detect DNS changes and reconnect RPC client on failure
  - Only check DNS once per disconnection event

- Trigger emergency mode and load from backup on repeated RPC timeouts
  - Ensures gateway uses Redis backup if MDCB is unreachable

- Improve error handling for retriable RPC/network errors
  - Extend retriable error detection to include timeouts

- Add comprehensive unit tests for DNS logic and emergency mode


___

### **Changes diagram**

```mermaid
flowchart LR
  A["RPC connection fails"] -- "Check DNS once" --> B["DNS changed?"]
  B -- "Yes" --> C["Reconnect RPC client"]
  B -- "No" --> D["Log warning, no reconnect"]
  A -- "All retries fail" --> E["Trigger emergency mode"]
  E -- "Load from backup" --> F["Gateway uses Redis backup"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
<td><strong>policy.go</strong><dd><code>Add error handling for empty RPC
policy responses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7167/files#diff-ec674104322b26b82def55e9be32117753ab66e7840490481eb6eb4c15bc35e7">+3/-0</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>5
files</summary><table>
<tr>
<td><strong>rpc_storage_handler.go</strong><dd><code>Extend retriable
error detection for timeouts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7167/files#diff-8875f75b602664c44b62b67a4da41d748124ad270573a44db4ec977ee5d68021">+9/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
<td><strong>server.go</strong><dd><code>Trigger emergency mode and
backup loading on repeated RPC failures</code></dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7167/files#diff-4652d1bf175a0be8f5e61ef7177c9666f23e077d8626b73ac9d13358fa8b525b">+23/-1</a>&nbsp;
&nbsp; </td>

</tr>

<tr>
<td><strong>dns_resolver.go</strong><dd><code>Add DNS resolution and
self-healing reconnection logic</code>&nbsp; &nbsp; &nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7167/files#diff-3d4fcf2e5b1a8e522dcc0dc656f64dfa85e53f41e8c46c5466d422b8d56d8a82">+130/-0</a>&nbsp;
</td>

</tr>

<tr>
<td><strong>rpc_client.go</strong><dd><code>Integrate DNS check, error
handling, and emergency mode controls</code></dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7167/files#diff-3b88914c99bb9418e44e6389ce73579843562e8900730b380d7fff2e95c51033">+67/-1</a>&nbsp;
&nbsp; </td>

</tr>

<tr>
<td><strong>utils.go</strong><dd><code>Add utility functions for DNS and
network error detection</code></dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7167/files#diff-659e102b74cf8cae4db311100e475bee88ba1be6dd7b450c1e060dfee2fb3761">+36/-0</a>&nbsp;
&nbsp; </td>

</tr>

</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4
files</summary><table>
<tr>
<td><strong>rpc_storage_handler_test.go</strong><dd><code>Add unit tests
for retriable error logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7167/files#diff-69de989a02b3bc32ae376c514ee84633c609200db22385c0e16c361d6ea74cd6">+35/-0</a>&nbsp;
&nbsp; </td>

</tr>

<tr>
<td><strong>server_test.go</strong><dd><code>Add tests for emergency
mode and backup fallback logic</code>&nbsp; &nbsp; &nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7167/files#diff-d9f006370c9748c09affd99d0a4edeb8f3419057703a67fd70838a764a485696">+44/-1</a>&nbsp;
&nbsp; </td>

</tr>

<tr>
<td><strong>dns_resolver_test.go</strong><dd><code>Add comprehensive
unit tests for DNS resolution and reconnection</code></dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7167/files#diff-1f9e4fa330ed10e933704c2e1eb7c7244fcb2e7290fab58f248fedd18f1d6f0f">+501/-0</a>&nbsp;
</td>

</tr>

<tr>
<td><strong>utils_test.go</strong><dd><code>Add unit tests for utility
functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; </dd></td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7167/files#diff-509db1da354a66f1ed878475d2ca736b989cc45f3260caf3e7933704f74f766a">+143/-0</a>&nbsp;
</td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary> Need help?</summary><li>Type <code>/help how to
...</code> in the comments thread for any questions about PR-Agent
usage.</li><li>Check out the <a
href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a>
for more information.</li></details>

---------

Co-authored-by: sredny buitrago <sredny@srednys-MacBook-Pro.local>