### PR TITLE
Merging to release-5.9.0: [TT-14990] Update GetCiphers to restore support for legacy TLS cipher suites (#7173)

### DIFF
--- a/internal/crypto/ciphers.go
+++ b/internal/crypto/ciphers.go
@@ -52,7 +52,8 @@ func TLSVersions(in []uint16) []string {
 
 // GetCiphers generates a list of CipherSuite from the available ciphers.
 func GetCiphers() []*CipherSuite {
-	ciphers := tls.CipherSuites()
+	ciphers := append(tls.CipherSuites(), tls.InsecureCipherSuites()...)
+
 	result := make([]*CipherSuite, 0, len(ciphers))
 
 	for _, cipher := range ciphers {
@@ -67,9 +68,31 @@ func GetCiphers() []*CipherSuite {
 func ResolveCipher(cipherName string) (uint16, error) {
 	ciphers := GetCiphers()
 	for _, cipher := range ciphers {
-		if strings.EqualFold(cipher.Name, cipherName) {
+		if cipherNamesEqual(cipherName, cipher.Name) {
 			return cipher.ID, nil
 		}
 	}
 	return 0, fmt.Errorf("cipher %s not found", cipherName)
+}
+
+func cipherNamesEqual(s1, s2 string) bool {
+	// Legacy names for the corresponding cipher suites with the correct _SHA256
+	// suffix, retained for backward compatibility.
+	// TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305   = TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+	// TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305 = TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+	//
+	// Reference:
+	// - https://github.com/golang/go/blob/master/src/crypto/tls/cipher_suites.go#L720
+	legacyAlias := map[string]string{
+		"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305":   "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+		"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305": "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+	}
+
+	original := s1
+
+	if alias, ok := legacyAlias[strings.ToUpper(s1)]; ok {
+		original = alias
+	}
+
+	return strings.EqualFold(original, s2)
 }

--- a/internal/crypto/ciphers_test.go
+++ b/internal/crypto/ciphers_test.go
@@ -42,6 +42,39 @@ func TestGetCiphers(t *testing.T) {
 	}
 }
 
+var legacyCipherSuites = []string{
+	"TLS_RSA_WITH_AES_128_CBC_SHA",
+	"TLS_RSA_WITH_RC4_128_SHA",
+	"TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+	"TLS_RSA_WITH_AES_256_CBC_SHA",
+	"TLS_RSA_WITH_AES_128_CBC_SHA256",
+	"TLS_RSA_WITH_AES_128_GCM_SHA256",
+	"TLS_RSA_WITH_AES_256_GCM_SHA384",
+	"TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
+	"TLS_ECDHE_RSA_WITH_RC4_128_SHA",
+	"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA",
+	"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+	"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+}
+
+func TestLegacyCipherSuites(t *testing.T) {
+	ciphers := GetCiphers()
+
+	totalCiphers := map[string]bool{}
+
+	for _, cipher := range ciphers {
+		totalCiphers[cipher.Name] = true
+	}
+
+	for _, cipher := range legacyCipherSuites {
+		if !totalCiphers[cipher] {
+			t.Errorf("Expected %s to be removed", cipher)
+		}
+	}
+}
+
 func TestResolveCipher(t *testing.T) {
 	testCases := []struct {
 		name     string
@@ -54,6 +87,8 @@ func TestResolveCipher(t *testing.T) {
 		{"Case insensitive", "tls_ecdhe_rsa_with_aes_128_gcm_sha256", 0xc02f, false},
 		{"Empty input", "", 0, true},
 		{"Partial match", "TLS_ECDHE", 0, true},
+		{"Legacy cipher TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305", "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305", 0xcca8, false},
+		{"Legacy cipher TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305", "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305", 0xcca9, false},
 	}
 
 	for _, tc := range testCases {
@@ -93,6 +128,57 @@ func TestTLSVersions(t *testing.T) {
 				if v != tc.expected[i] {
 					t.Errorf("Expected version %s at index %d, got %s", tc.expected[i], i, v)
 				}
+			}
+		})
+	}
+}
+
+func TestCipherNamesEqual(t *testing.T) {
+	cases := map[string]struct {
+		s1, s2   string
+		expected bool
+	}{
+		"canonical match": {
+			s1:       "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+			s2:       "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+			expected: true,
+		},
+		"legacy to canonical": {
+			s1:       "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+			s2:       "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+			expected: true,
+		},
+		"canonical to legacy": {
+			s1:       "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+			s2:       "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+			expected: false,
+		},
+		"ecdsa legacy to canonical": {
+			s1:       "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+			s2:       "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+			expected: true,
+		},
+		"ecdsa canonical to legacy": {
+			s1:       "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+			s2:       "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+			expected: false,
+		},
+		"case-insensitive": {
+			s1:       "tls_ecdhe_rsa_with_chacha20_poly1305",
+			s2:       "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+			expected: true,
+		},
+		"no match": {
+			s1:       "TLS_FAKE_CIPHER",
+			s2:       "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+			expected: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := cipherNamesEqual(tc.s1, tc.s2); got != tc.expected {
+				t.Errorf("compareCipherName(%q, %q) = %v; want %v", tc.s1, tc.s2, got, tc.expected)
 			}
 		})
 	}


### PR DESCRIPTION
### **User description**
[TT-14990] Update GetCiphers to restore support for legacy TLS cipher suites (#7173)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-14990"
title="TT-14990" target="_blank">TT-14990</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>[Regression] Missing TLS Ciphers in Tyk v5.8</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20QA_Fail%20ORDER%20BY%20created%20DESC"
title="QA_Fail">QA_Fail</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20customer_bug%20ORDER%20BY%20created%20DESC"
title="customer_bug">customer_bug</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20jira_escalated%20ORDER%20BY%20created%20DESC"
title="jira_escalated">jira_escalated</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->
This PR addresses an issue introduced in Tyk Gateway v5.8.1 where
several previously supported TLS 1.2 cipher suites were no longer
recognized when specified in the configuration. These include legacy
ciphers like TLS_RSA_WITH_AES_128_CBC_SHA,
TLS_RSA_WITH_3DES_EDE_CBC_SHA, and others that are still required by
certain legacy clients and devices. It also adds backward compatibility
for legacy cipher names like TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, which
Go internally maps to ..._SHA256.

In Go, these cipher suites are no longer returned by tls.CipherSuites()
alone, as they are considered insecure. However, they can still be
explicitly enabled by using tls.InsecureCipherSuites().

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->
https://tyktech.atlassian.net/browse/TT-14990

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Restores support for legacy/insecure TLS cipher suites in `GetCiphers`

- Updates cipher name resolution for legacy aliases (e.g., CHACHA20_POLY1305)

- Adds comprehensive tests for legacy cipher suite inclusion

- Adds tests for legacy and canonical cipher name matching logic


___

### **Changes diagram**

```mermaid
flowchart LR
  A["GetCiphers()"] -- "previously: only secure ciphers" --> B["Returned incomplete cipher list"]
  A -- "now: secure + insecure ciphers" --> C["Returns full cipher suite list"]
  C -- "legacy cipher names supported" --> D["Improved cipher name resolution"]
  D -- "tested via new test cases" --> E["Comprehensive test coverage"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ciphers.go</strong><dd><code>Restore legacy TLS ciphers and add alias-aware name resolution</code></dd></summary>
<hr>

internal/crypto/ciphers.go

<li>Appends insecure cipher suites to the output of <code>GetCiphers</code><br> <li> Adds <code>cipherNamesEqual</code> for legacy cipher name aliasing<br> <li> Updates <code>ResolveCipher</code> to use new name comparison logic<br> <li> Improves backward compatibility for legacy cipher names


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7184/files#diff-86698d97685ca2876f216471bdf44651d965be0b5c80ee67fa3dbb31929431e5">+25/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ciphers_test.go</strong><dd><code>Add tests for legacy cipher support and name resolution</code>&nbsp; &nbsp; </dd></summary>
<hr>

internal/crypto/ciphers_test.go

<li>Adds test to verify legacy cipher suites are present in <code>GetCiphers</code><br> <li> Adds tests for legacy and canonical cipher name matching<br> <li> Expands <code>TestResolveCipher</code> to cover legacy aliases<br> <li> Improves test coverage for cipher suite handling


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7184/files#diff-6682fccccf9d48c22219d058852fc4028780285a1bc62ad23c96664fced508aa">+86/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>