### PR TITLE
Merging to release-5.9: [TT-9234] regression fixes (#7207)

### DIFF
--- a/gateway/server.go
+++ b/gateway/server.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/TykTechnologies/tyk/tcp"
 	"github.com/TykTechnologies/tyk/trace"
 
 	"sync/atomic"
@@ -1753,6 +1754,10 @@ func Start() {
 	gw := NewGateway(gwConfig, ctx)
 	gwConfig = gw.GetConfig()
 
+	if err := gw.initSystem(); err != nil {
+		mainLog.Fatalf("Error initialising system: %v", err)
+	}
+
 	shutdownComplete := make(chan struct{})
 	go func() {
 		sig := <-sigChan
@@ -1772,10 +1777,6 @@ func Start() {
 		}
 		close(shutdownComplete)
 	}()
-
-	if err := gw.initSystem(); err != nil {
-		mainLog.Fatalf("Error initialising system: %v", err)
-	}
 
 	if !gw.isRunningTests() && gwConfig.ControlAPIPort == 0 {
 		mainLog.Warn("The control_api_port should be changed for production")
@@ -2077,6 +2078,64 @@ func (gw *Gateway) SetConfig(conf config.Config, skipReload ...bool) {
 	gw.configMu.Unlock()
 }
 
+// shutdownHTTPServer gracefully shuts down an HTTP server
+func (gw *Gateway) shutdownHTTPServer(ctx context.Context, server *http.Server, port int, wg *sync.WaitGroup, errChan chan<- error) {
+	if server == nil {
+		return
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		mainLog.Infof("Shutting down HTTP server on %s", server.Addr)
+
+		// Server.Shutdown gracefully shuts down the server without
+		// interrupting any active connections
+		if err := server.Shutdown(ctx); err != nil {
+			mainLog.Errorf("Error shutting down HTTP server on port %d: %v", port, err)
+			select {
+			case errChan <- err:
+			default:
+				// Channel closed, ignore
+			}
+		}
+	}()
+}
+
+// shutdownTCPProxy gracefully shuts down a TCP proxy
+func (gw *Gateway) shutdownTCPProxy(ctx context.Context, listener net.Listener, port int, protocol string, proxy *tcp.Proxy, wg *sync.WaitGroup, errChan chan<- error) {
+	if proxy == nil || listener == nil {
+		return
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		mainLog.Infof("Shutting down TCP proxy on port %d (%s)", port, protocol)
+
+		// Set the shutdown context to signal existing connections to terminate gracefully
+		proxy.SetShutdownContext(ctx)
+
+		// Close the listener to stop accepting new connections
+		// Note: This will cause Serve() to exit, but existing connections continue
+		if err := listener.Close(); err != nil {
+			mainLog.Errorf("Error shutting down TCP proxy listener on port %d: %v", port, err)
+			select {
+			case errChan <- err:
+			default:
+				// Channel closed, ignore
+			}
+		}
+
+		// Wait for all active connections to finish or timeout
+		if err := proxy.Shutdown(ctx); err != nil {
+			mainLog.Warnf("TCP proxy shutdown timeout on port %d: %v", port, err)
+		} else {
+			mainLog.Debugf("TCP proxy gracefully shut down on port %d", port)
+		}
+	}()
+}
+
 // gracefulShutdown performs a graceful shutdown of all services
 func (gw *Gateway) gracefulShutdown(ctx context.Context) error {
 	mainLog.Info("Stop signal received.")
@@ -2085,26 +2144,14 @@ func (gw *Gateway) gracefulShutdown(ctx context.Context) error {
 	var wg sync.WaitGroup
 	errChan := make(chan error, 10) // Buffer for potential errors
 
-	// Shutdown all HTTP servers in the proxy mux
+	// Shutdown all HTTP servers and TCP proxies in the proxy mux
 	gw.DefaultProxyMux.Lock()
 	for _, p := range gw.DefaultProxyMux.proxies {
 		if p.httpServer != nil {
-			wg.Add(1)
-			go func(server *http.Server, port int) {
-				defer wg.Done()
-				mainLog.Infof("Shutting down HTTP server on %s", server.Addr)
-
-				// Server.Shutdown gracefully shuts down the server without
-				// interrupting any active connections
-				if err := server.Shutdown(ctx); err != nil {
-					mainLog.Errorf("Error shutting down HTTP server on port %d: %v", port, err)
-					select {
-					case errChan <- err:
-					default:
-						// Channel closed, ignore
-					}
-				}
-			}(p.httpServer, p.port)
+			gw.shutdownHTTPServer(ctx, p.httpServer, p.port, &wg, errChan)
+		}
+		if p.tcpProxy != nil && p.listener != nil {
+			gw.shutdownTCPProxy(ctx, p.listener, p.port, p.protocol, p.tcpProxy, &wg, errChan)
 		}
 	}
 	gw.DefaultProxyMux.Unlock()
@@ -2118,7 +2165,7 @@ func (gw *Gateway) gracefulShutdown(ctx context.Context) error {
 
 	select {
 	case <-serverShutdownDone:
-		mainLog.Info("All HTTP servers gracefully shut down")
+		mainLog.Info("All HTTP servers and TCP proxies gracefully shut down")
 	case <-ctx.Done():
 		mainLog.Warning("Shutdown timeout reached, some connections may have been terminated")
 		// Wait for goroutines to finish even after timeout to prevent panic

--- a/tcp/tcp.go
+++ b/tcp/tcp.go
@@ -70,6 +70,11 @@ type Proxy struct {
 	SyncStats func(Stat)
 	// Duration in which connection stats will be flushed. Defaults to one second.
 	StatsSyncInterval time.Duration
+
+	// Connection tracking for graceful shutdown
+	activeConns sync.WaitGroup
+	shutdownCtx context.Context
+	shutdown    context.CancelFunc
 }
 
 func (p *Proxy) AddDomainHandler(domain, target string, modifier *Modifier) {
@@ -105,14 +110,61 @@ func (p *Proxy) RemoveDomainHandler(domain string) {
 	delete(p.muxer, domain)
 }
 
+// Shutdown initiates graceful shutdown and waits for all connections to finish
+func (p *Proxy) Shutdown(ctx context.Context) error {
+	// Wait for all connections to finish or timeout
+	done := make(chan struct{})
+	go func() {
+		p.activeConns.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		log.Debug("All TCP connections gracefully closed")
+		return nil
+	case <-ctx.Done():
+		log.Warning("TCP proxy shutdown timeout reached, forcing connection termination")
+		// Only now force cancel all connections
+		p.Lock()
+		if p.shutdown != nil {
+			p.shutdown()
+		}
+		p.Unlock()
+		return ctx.Err()
+	}
+}
+
+// SetShutdownContext sets the shutdown context from the caller
+func (p *Proxy) SetShutdownContext(ctx context.Context) {
+	p.Lock()
+	defer p.Unlock()
+	p.shutdownCtx, p.shutdown = context.WithCancel(ctx)
+}
+
+// initShutdownContext initializes the shutdown context if not already done
+func (p *Proxy) initShutdownContext() {
+	p.Lock()
+	defer p.Unlock()
+	if p.shutdownCtx == nil {
+		p.shutdownCtx, p.shutdown = context.WithCancel(context.Background())
+	}
+}
+
 func (p *Proxy) Serve(l net.Listener) error {
+	p.initShutdownContext()
+
 	for {
 		conn, err := l.Accept()
 		if err != nil {
 			log.WithError(err).Warning("Can't accept connection")
 			return err
 		}
+
+		p.activeConns.Add(1)
 		go func() {
+			// Track this connection only when we actually start handling it
+			defer p.activeConns.Done()
 			if err := p.handleConn(conn); err != nil {
 				log.WithError(err).Warning("Can't handle connection")
 			}
@@ -344,6 +396,14 @@ func (p *Proxy) pipe(src, dst net.Conn, opts pipeOpts) {
 	buf := make([]byte, 65535)
 
 	for {
+		// Check if shutdown has been initiated
+		select {
+		case <-p.shutdownCtx.Done():
+			log.Debug("TCP connection terminating due to graceful shutdown")
+			return
+		default:
+		}
+
 		var readDeadline time.Time
 		if p.ReadTimeout != 0 {
 			readDeadline = time.Now().Add(p.ReadTimeout)

--- a/tcp/tcp_test.go
+++ b/tcp/tcp_test.go
@@ -1,10 +1,14 @@
 package tcp
 
 import (
+	"context"
 	"crypto/tls"
+	"errors"
 	"net"
 	"reflect"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/TykTechnologies/tyk/test"
 )
@@ -225,4 +229,424 @@ func testRunner(t *testing.T, proxy *Proxy, hostname string, useSSL bool, testCa
 		Hostname: hostname,
 	}
 	runner.Run(t, testCases...)
+}
+
+func TestProxy_Shutdown(t *testing.T) {
+	tests := []struct {
+		name           string
+		setupProxy     func() *Proxy
+		setupContext   func() (context.Context, context.CancelFunc)
+		expectError    bool
+		errorType      error
+		beforeShutdown func(*Proxy, net.Listener)
+	}{
+		{
+			name: "shutdown with no active connections",
+			setupProxy: func() *Proxy {
+				return &Proxy{}
+			},
+			setupContext: func() (context.Context, context.CancelFunc) {
+				return context.WithTimeout(context.Background(), 5*time.Second)
+			},
+			expectError: false,
+		},
+		{
+			name: "shutdown with active connections that complete quickly",
+			setupProxy: func() *Proxy {
+				return &Proxy{}
+			},
+			setupContext: func() (context.Context, context.CancelFunc) {
+				return context.WithTimeout(context.Background(), 5*time.Second)
+			},
+			expectError: false,
+			beforeShutdown: func(proxy *Proxy, _ net.Listener) {
+				// Simulate active connections by calling activeConns.Add
+				proxy.activeConns.Add(2)
+
+				// Simulate connections completing
+				go func() {
+					time.Sleep(100 * time.Millisecond)
+					proxy.activeConns.Done()
+					proxy.activeConns.Done()
+				}()
+			},
+		},
+		{
+			name: "shutdown timeout with slow connections",
+			setupProxy: func() *Proxy {
+				return &Proxy{}
+			},
+			setupContext: func() (context.Context, context.CancelFunc) {
+				return context.WithTimeout(context.Background(), 200*time.Millisecond)
+			},
+			expectError: true,
+			errorType:   context.DeadlineExceeded,
+			beforeShutdown: func(proxy *Proxy, _ net.Listener) {
+				// Simulate slow connections that don't complete in time
+				proxy.activeConns.Add(1)
+				// Don't call Done() to simulate hanging connection
+			},
+		},
+		{
+			name: "shutdown with cancelled context",
+			setupProxy: func() *Proxy {
+				return &Proxy{}
+			},
+			setupContext: func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				// Cancel immediately to test context cancellation
+				cancel()
+				return ctx, func() {}
+			},
+			expectError: true,
+			errorType:   context.Canceled,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proxy := tt.setupProxy()
+			ctx, cancel := tt.setupContext()
+			defer cancel()
+
+			// Initialize shutdown context if not already done
+			proxy.initShutdownContext()
+
+			if tt.beforeShutdown != nil {
+				tt.beforeShutdown(proxy, nil)
+			}
+
+			err := proxy.Shutdown(ctx)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+					return
+				}
+				if tt.errorType != nil && !errors.Is(err, tt.errorType) {
+					t.Errorf("expected error type %v, got %v", tt.errorType, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error but got: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestProxy_SetShutdownContext(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupProxy  func() *Proxy
+		setupCtx    func() context.Context
+		validateCtx func(*testing.T, *Proxy, context.Context)
+	}{
+		{
+			name: "set shutdown context",
+			setupProxy: func() *Proxy {
+				return &Proxy{}
+			},
+			setupCtx: func() context.Context {
+				return context.Background()
+			},
+			validateCtx: func(t *testing.T, p *Proxy, _ context.Context) {
+				if p.shutdownCtx == nil {
+					t.Error("shutdown context should not be nil after setting")
+				}
+				if p.shutdown == nil {
+					t.Error("shutdown cancel function should not be nil after setting")
+				}
+			},
+		},
+		{
+			name: "overwrite existing shutdown context",
+			setupProxy: func() *Proxy {
+				p := &Proxy{}
+				// Set initial context
+				ctx, cancel := context.WithCancel(context.Background())
+				p.shutdownCtx = ctx
+				p.shutdown = cancel
+				return p
+			},
+			setupCtx: func() context.Context {
+				return context.Background()
+			},
+			validateCtx: func(t *testing.T, p *Proxy, _ context.Context) {
+				if p.shutdownCtx == nil {
+					t.Error("shutdown context should not be nil after overwriting")
+				}
+				if p.shutdown == nil {
+					t.Error("shutdown cancel function should not be nil after overwriting")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proxy := tt.setupProxy()
+			ctx := tt.setupCtx()
+
+			proxy.SetShutdownContext(ctx)
+
+			tt.validateCtx(t, proxy, ctx)
+		})
+	}
+}
+
+func TestProxy_initShutdownContext(t *testing.T) {
+	tests := []struct {
+		name       string
+		setupProxy func() *Proxy
+		validate   func(*testing.T, *Proxy)
+	}{
+		{
+			name: "initialize when context is nil",
+			setupProxy: func() *Proxy {
+				return &Proxy{}
+			},
+			validate: func(t *testing.T, p *Proxy) {
+				if p.shutdownCtx == nil {
+					t.Error("shutdown context should be initialized")
+				}
+				if p.shutdown == nil {
+					t.Error("shutdown cancel function should be initialized")
+				}
+			},
+		},
+		{
+			name: "don't reinitialize when context exists",
+			setupProxy: func() *Proxy {
+				p := &Proxy{}
+				ctx, cancel := context.WithCancel(context.Background())
+				p.shutdownCtx = ctx
+				p.shutdown = cancel
+				return p
+			},
+			validate: func(t *testing.T, p *Proxy) {
+				originalCtx := p.shutdownCtx
+				// Can't compare functions, just check they exist
+				originalCancelExists := p.shutdown != nil
+
+				p.initShutdownContext()
+
+				if p.shutdownCtx != originalCtx {
+					t.Error("shutdown context should not be reinitialized when it already exists")
+				}
+				if !originalCancelExists || p.shutdown == nil {
+					t.Error("shutdown cancel function should not be reinitialized when it already exists")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proxy := tt.setupProxy()
+			proxy.initShutdownContext()
+			tt.validate(t, proxy)
+		})
+	}
+}
+
+func TestProxy_ServeWithGracefulShutdown(t *testing.T) {
+	// Test that Serve properly tracks connections and responds to shutdown
+	upstream := test.TcpMock(false, func(in []byte, _ error) (out []byte) {
+		// Simulate slow response to test connection tracking
+		time.Sleep(100 * time.Millisecond)
+		return in
+	})
+	defer upstream.Close()
+
+	proxy := &Proxy{}
+	proxy.AddDomainHandler("", upstream.Addr().String(), nil)
+
+	// Set up listener
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("Failed to create listener: %v", err)
+	}
+	defer listener.Close()
+
+	// Start proxy in goroutine
+	serveDone := make(chan struct{})
+	go func() {
+		defer close(serveDone)
+		_ = proxy.Serve(listener)
+	}()
+
+	// Give proxy time to start
+	time.Sleep(50 * time.Millisecond)
+
+	// Connect client and start sending data
+	conn, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatalf("Failed to connect to proxy: %v", err)
+	}
+
+	// Send data in background to keep connection active
+	clientDone := make(chan struct{})
+	go func() {
+		defer close(clientDone)
+		defer conn.Close()
+
+		// Send data
+		_, err := conn.Write([]byte("test"))
+		if err != nil {
+			t.Logf("Client write error (expected during shutdown): %v", err)
+			return
+		}
+
+		// Try to read response
+		buf := make([]byte, 4)
+		_, err = conn.Read(buf)
+		if err != nil {
+			t.Logf("Client read error (expected during shutdown): %v", err)
+		}
+	}()
+
+	// Wait a bit for connection to be established
+	time.Sleep(50 * time.Millisecond)
+
+	// Set shutdown context and close listener to trigger shutdown
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	proxy.SetShutdownContext(shutdownCtx)
+
+	// Close listener to stop accepting new connections
+	listener.Close()
+
+	// Wait for serve to complete
+	select {
+	case <-serveDone:
+		// Expected - serve should exit after listener is closed
+	case <-time.After(3 * time.Second):
+		t.Error("Serve did not exit in reasonable time")
+	}
+
+	// Test graceful shutdown
+	err = proxy.Shutdown(shutdownCtx)
+	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("Unexpected shutdown error: %v", err)
+	}
+
+	// Wait for client connection to finish
+	select {
+	case <-clientDone:
+		// Client finished
+	case <-time.After(1 * time.Second):
+		t.Log("Client connection took longer than expected to finish")
+	}
+}
+
+func TestProxy_ConcurrentConnectionTracking(t *testing.T) {
+	// Test that connection tracking is thread-safe
+	proxy := &Proxy{}
+	proxy.initShutdownContext()
+
+	var wg sync.WaitGroup
+	numGoroutines := 10
+	numOperationsPerGoroutine := 100
+
+	// Simulate concurrent connection tracking
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < numOperationsPerGoroutine; j++ {
+				proxy.activeConns.Add(1)
+				proxy.activeConns.Done()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Test shutdown with no active connections
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	err := proxy.Shutdown(ctx)
+	if err != nil {
+		t.Errorf("Shutdown failed after concurrent operations: %v", err)
+	}
+}
+
+func TestProxy_ShutdownIntegration(t *testing.T) {
+	// Test that TCP proxy properly shuts down connections when shutdown context is cancelled
+	upstream := test.TcpMock(false, func(in []byte, _ error) (out []byte) {
+		// Simulate slow response to test shutdown during active connection
+		time.Sleep(200 * time.Millisecond)
+		return in
+	})
+	defer upstream.Close()
+
+	proxy := &Proxy{}
+	proxy.AddDomainHandler("", upstream.Addr().String(), nil)
+
+	// Set up listener
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("Failed to create listener: %v", err)
+	}
+
+	// Set shutdown context before starting
+	shutdownCtx, cancel := context.WithCancel(context.Background())
+	proxy.SetShutdownContext(shutdownCtx)
+
+	// Start proxy in background
+	serveDone := make(chan struct{})
+	go func() {
+		defer close(serveDone)
+		proxy.Serve(listener)
+	}()
+
+	// Give proxy time to start
+	time.Sleep(50 * time.Millisecond)
+
+	// Connect and start sending data
+	conn, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatalf("Failed to connect to proxy: %v", err)
+	}
+	defer conn.Close()
+
+	// Send data to establish connection
+	go func() {
+		conn.Write([]byte("test"))
+	}()
+
+	// Wait for connection to be established
+	time.Sleep(50 * time.Millisecond)
+
+	// Trigger shutdown by cancelling context
+	cancel()
+
+	// Close listener to stop accepting new connections
+	listener.Close()
+
+	// Test that shutdown completes within reasonable time
+	shutdownCompleted := make(chan struct{})
+	go func() {
+		defer close(shutdownCompleted)
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+		proxy.Shutdown(ctx)
+	}()
+
+	select {
+	case <-shutdownCompleted:
+		// Expected - shutdown should complete
+	case <-time.After(2 * time.Second):
+		t.Error("Shutdown did not complete in reasonable time")
+	}
+
+	// Verify that serve exits
+	select {
+	case <-serveDone:
+		// Expected - serve should exit after listener is closed
+	case <-time.After(1 * time.Second):
+		t.Error("Serve did not exit after listener was closed")
+	}
 }


### PR DESCRIPTION
### **User description**
[TT-9234] regression fixes (#7207)

<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-9234"
title="TT-9234" target="_blank">TT-9234</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Graceful shutdown of Gateway</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Story"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium"
/>
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Test</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20QA_Fail%20ORDER%20BY%20created%20DESC"
title="QA_Fail">QA_Fail</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20customer_bug%20ORDER%20BY%20created%20DESC"
title="customer_bug">customer_bug</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20jira_escalated%20ORDER%20BY%20created%20DESC"
title="jira_escalated">jira_escalated</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20rel3-2025-candidate-commercial%20ORDER%20BY%20created%20DESC"
title="rel3-2025-candidate-commercial">rel3-2025-candidate-commercial</a>,
<a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20rel3-2025-commitment-commercial%20ORDER%20BY%20created%20DESC"
title="rel3-2025-commitment-commercial">rel3-2025-commitment-commercial</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->
Fixes TCP graceful shutdown not being handled.
## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why

[TT-9234]: https://tyktech.atlassian.net/browse/TT-9234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Tests, Enhancement


___

### **Description**
- Adds graceful shutdown support for TCP proxies in Gateway.

- Refactors shutdown logic to handle both HTTP servers and TCP proxies.

- Implements connection tracking and shutdown context in TCP proxy.

- Introduces comprehensive tests for TCP proxy shutdown scenarios.


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Gateway shutdown initiated"] -- "Iterate proxies" --> B["HTTP server shutdown"]
  A -- "Iterate proxies" --> C["TCP proxy shutdown"]
  C -- "Set shutdown context, close listener, wait for connections" --> D["Active TCP connections tracked"]
  D -- "All connections closed or timeout" --> E["Shutdown complete"]
  B -- "All HTTP servers closed" --> E
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.go</strong><dd><code>Add graceful shutdown logic for TCP proxies in Gateway</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/server.go

<li>Adds shutdown logic for TCP proxies alongside HTTP servers.<br> <li> Refactors shutdown code into helper methods for HTTP and TCP.<br> <li> Updates logs to reflect shutdown of both HTTP and TCP proxies.<br> <li> Ensures TCP proxies are gracefully shut down during Gateway shutdown.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7213/files#diff-4652d1bf175a0be8f5e61ef7177c9666f23e077d8626b73ac9d13358fa8b525b">+69/-22</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tcp.go</strong><dd><code>Add connection tracking and graceful shutdown to TCP Proxy</code></dd></summary>
<hr>

tcp/tcp.go

<li>Implements connection tracking for active TCP connections.<br> <li> Adds shutdown context and graceful shutdown logic to Proxy.<br> <li> Ensures all connections are closed or cancelled on shutdown.<br> <li> Integrates shutdown context checks into connection handling.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7213/files#diff-4964880da1ba03845181b6d43ad9c238e7ff6c8f6a1766deb10d65ebdcc7e4ec">+60/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server_test.go</strong><dd><code>Add comprehensive tests for Gateway TCP proxy shutdown</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/server_test.go

<li>Adds tests for Gateway's graceful shutdown with TCP proxies.<br> <li> Covers scenarios with HTTP, TCP, mixed, and concurrent proxies.<br> <li> Tests shutdown with active connections and timeouts.<br> <li> Ensures robust coverage for shutdown logic.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7213/files#diff-d9f006370c9748c09affd99d0a4edeb8f3419057703a67fd70838a764a485696">+397/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tcp_test.go</strong><dd><code>Add tests for TCP Proxy graceful shutdown and concurrency</code></dd></summary>
<hr>

tcp/tcp_test.go

<li>Adds unit and integration tests for TCP Proxy shutdown.<br> <li> Tests connection tracking, shutdown context, and concurrency.<br> <li> Validates shutdown with active, slow, and cancelled connections.<br> <li> Ensures thread-safety and correct shutdown behavior.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7213/files#diff-0034cc1ba4ed89ee5d9eb9817110c32f78b2107a8fc4a925adf1ba2af4846050">+424/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>