### PR TITLE
[TT-15251] GW prints body decompression error when when you enable analytics 

### DIFF
--- a/gateway/handler_success.go
+++ b/gateway/handler_success.go
@@ -146,6 +146,9 @@ func recordGraphDetails(rec *analytics.AnalyticsRecord, r *http.Request, resp *h
 		respBody, err = io.ReadAll(resp.Body)
 		defer func() {
 			_ = resp.Body.Close()
+			// Create a new Reader and assign it to the response body, otherwise
+			// respBodyReader fails to decompress the body for further processing.
+			resp.Body = io.NopCloser(bytes.NewBuffer(respBody))
 			resp.Body = respBodyReader(r, resp)
 		}()
 		if err != nil {

--- a/gateway/handler_success.go
+++ b/gateway/handler_success.go
@@ -143,13 +143,14 @@ func recordGraphDetails(rec *analytics.AnalyticsRecord, r *http.Request, resp *h
 	)
 	if resp.Body != nil {
 		httputil.RemoveResponseTransferEncoding(resp, "chunked")
+		// respBodyReader tries to decompress the response body if the Accept-Encoding
+		// header is a non-empty string.
+		resp.Body = respBodyReader(r, resp)
 		respBody, err = io.ReadAll(resp.Body)
 		defer func() {
 			_ = resp.Body.Close()
-			// Create a new Reader and assign it to the response body, otherwise
-			// respBodyReader fails to decompress the body for further processing.
+			// Create a new Reader and assign it to the response body.
 			resp.Body = io.NopCloser(bytes.NewBuffer(respBody))
-			resp.Body = respBodyReader(r, resp)
 		}()
 		if err != nil {
 			logger.WithError(err).Error("error recording graph analytics")

--- a/gateway/handler_success_test.go
+++ b/gateway/handler_success_test.go
@@ -122,7 +122,7 @@ func TestRecordDetail(t *testing.T) {
 
 func TestAnalyticRecord_GraphStats(t *testing.T) {
 
-	apiDef := BuildAPI(func(spec *APISpec) {
+	generateApiDefinition := func(spec *APISpec) {
 		spec.Name = "graphql API"
 		spec.APIID = "graphql-api"
 		spec.Proxy.TargetURL = testGraphQLProxyUpstream
@@ -133,7 +133,7 @@ func TestAnalyticRecord_GraphStats(t *testing.T) {
 			Version:       apidef.GraphQLConfigVersion2,
 			Schema:        gqlProxyUpstreamSchema,
 		}
-	})[0]
+	}
 
 	testCases := []struct {
 		name      string
@@ -244,7 +244,7 @@ func TestAnalyticRecord_GraphStats(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			spec := apiDef
+			spec := BuildAPI(generateApiDefinition)[0]
 			if tc.reloadAPI != nil {
 				tc.reloadAPI(spec)
 			}

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -653,6 +653,7 @@ func graphqlProxyUpstreamHandler(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			_ = gz.Close()
 		}()
+		w.WriteHeader(responseCode)
 		_, _ = gz.Write(response)
 		return
 	}


### PR DESCRIPTION
### **User description**
PR for https://tyktech.atlassian.net/browse/TT-15251

The previous implementation was trying to reassign request body after extracting stats for a processed GQL request using `respBodyReader` method. That method fails because request body was already read and this leads to flood of the following messages:

```
time="Jul 09 13:33:07" level=error msg="Body decompression error:EOF"
time="Jul 09 13:33:07" level=error msg="Body decompression error:EOF"
time="Jul 09 13:33:07" level=error msg="Body decompression error:EOF"
```

I moved the call of `respBodyReader` to fix the bug and this also enables to extract stats from compressed GQL responses. I added an integration test for this case. 

I used a `io.NopCloser` to reset the reader. Do we need a compressed copy of the request body? Because we keep `Accept-Encoding` header. @kofoworola


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixes response body decompression error in analytics recording.

- Moves response body reader assignment before reading body.

- Adds integration test for compressed GraphQL response bodies.

- Updates test utilities to support gzip-encoded responses.


___

### **Changes diagram**

```mermaid
flowchart LR
  A["recordGraphDetails: Assign resp.Body before reading"] -- "Prevents decompression error" --> B["No more 'Body decompression error:EOF' logs"]
  B -- "Enables" --> C["Stats extraction from compressed GQL responses"]
  C -- "Test coverage" --> D["TestAnalyticRecord_GraphStats: gzip test added"]
  D -- "Test utility" --> E["graphqlProxyUpstreamHandler: gzip support"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>handler_success.go</strong><dd><code>Fix response body handling for decompression in analytics</code></dd></summary>
<hr>

gateway/handler_success.go

<li>Assigns <code>resp.Body</code> using <code>respBodyReader</code> before reading body.<br> <li> Ensures a new reader is set after reading for further processing.<br> <li> Prevents decompression errors when analytics are enabled.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7230/files#diff-45135957493eca37f2e3e9a81079577777133c53b27cf95ea2ff0329c05bd006">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>handler_success_test.go</strong><dd><code>Add and refactor tests for compressed GraphQL responses</code>&nbsp; &nbsp; </dd></summary>
<hr>

gateway/handler_success_test.go

<li>Adds test case for compressed (gzip) GraphQL response body.<br> <li> Refactors API definition setup for reuse.<br> <li> Ensures headers can be set per test case.<br> <li> Improves test consistency and coverage.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7230/files#diff-42a565d872ff6c1f380386f4ee2f75bfa87991b52728a1a9a1772452bb0cd1bb">+32/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>testutil.go</strong><dd><code>Add gzip encoding support to GraphQL test handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/testutil.go

<li>Updates test handler to support gzip-encoded responses.<br> <li> Sets <code>Content-Encoding: gzip</code> and compresses response if requested.<br> <li> Maintains backward compatibility for non-gzip requests.


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7230/files#diff-7aaf6ae49fb8f58a8c99d337fedd15b3e430dd928ed547e425ef429b10d28ce8">+17/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>