### PR TITLE
[TT-11048] Regex on endpoint list issue

### DIFF
--- a/apidef/oas/oas.go
+++ b/apidef/oas/oas.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/TykTechnologies/tyk/common/option"
+	"github.com/TykTechnologies/tyk/internal/pathutil"
 	"strings"
 
 	"github.com/TykTechnologies/tyk/apidef"
@@ -434,11 +436,23 @@ func (s *OAS) ReplaceServers(apiURLs, oldAPIURLs []string) {
 
 // Validate validates OAS document by calling openapi3.T.Validate() function. In addition, it validates Security
 // Requirement section and it's requirements by calling OAS.validateSecurity() function.
-func (s *OAS) Validate(ctx context.Context, opts ...openapi3.ValidationOption) error {
-	validationErr := s.T.Validate(ctx, opts...)
-	securityErr := s.validateSecurity()
+func (s *OAS) Validate(ctx context.Context, opts ...option.Option[validatorCnf]) error {
+	cnf := option.New(opts).Build(validatorCnf{
+		allowClassic: false,
+	})
 
-	return errors.Join(validationErr, securityErr)
+	if err := errors.Join(
+		s.T.Validate(ctx, cnf.opts...),
+		s.validateSecurity(),
+	); err != nil {
+		return err
+	}
+
+	if cnf.allowClassic {
+		return nil
+	}
+
+	return s.validatePath()
 }
 
 // validateSecurity verifies that existing Security Requirement Objects has Security Schemes declared in the Security
@@ -460,6 +474,28 @@ func (s *OAS) validateSecurity() error {
 					key)
 				return errors.New(errorMsg)
 			}
+		}
+	}
+
+	return nil
+}
+
+// validatePath validate paths to contain only non-classic based path
+func (s *OAS) validatePath() error {
+	if s.Paths == nil {
+		return nil
+	}
+
+	for path := range s.Paths.Map() {
+		parsed, err := pathutil.ParsePath(path)
+
+		if err != nil {
+			log.WithError(err).Warnf("Failed to parse path '%s'", path)
+			return fmt.Errorf("Failed to parse path '%s'", path)
+		}
+
+		if parsed.HasReParams() {
+			return fmt.Errorf("OAS does not support classic-based path like this: '%s'", path)
 		}
 	}
 
@@ -515,8 +551,11 @@ func FillOASFromClassicAPIDefinition(api *apidef.APIDefinition, oas *OAS) (*OAS,
 
 	if err := oas.Validate(
 		context.Background(),
-		openapi3.DisableExamplesValidation(),
-		openapi3.DisableSchemaDefaultsValidation(),
+		WithAllowClassic(),
+		WithOpenApiOpts(
+			openapi3.DisableExamplesValidation(),
+			openapi3.DisableSchemaDefaultsValidation(),
+		),
 	); err != nil {
 		return nil, err
 	}

--- a/apidef/oas/validator.go
+++ b/apidef/oas/validator.go
@@ -4,6 +4,8 @@ import (
 	"embed"
 	"errors"
 	"fmt"
+	"github.com/TykTechnologies/tyk/common/option"
+	"github.com/getkin/kin-openapi/openapi3"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -232,4 +234,22 @@ func getMinorVersion(version string) (string, error) {
 
 	segments := v.Segments()
 	return fmt.Sprintf("%d.%d", segments[0], segments[1]), nil
+}
+
+type validatorCnf struct {
+	opts         []openapi3.ValidationOption
+	allowClassic bool
+}
+
+func WithOpenApiOpts(opts ...openapi3.ValidationOption) option.Option[validatorCnf] {
+	return func(v *validatorCnf) {
+		v.opts = opts
+	}
+}
+
+// WithAllowClassic allows using classic urls
+func WithAllowClassic() option.Option[validatorCnf] {
+	return func(v *validatorCnf) {
+		v.allowClassic = true
+	}
 }

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -3016,7 +3016,7 @@ func (gw *Gateway) validateOAS(next http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 
-		if err = oasObj.Validate(r.Context(), oas.GetValidationOptionsFromConfig(gw.GetConfig().OAS)...); err != nil {
+		if err = oasObj.Validate(r.Context(), oas.WithOpenApiOpts(oas.GetValidationOptionsFromConfig(gw.GetConfig().OAS)...)); err != nil {
 			doJSONWrite(w, http.StatusBadRequest, apiError(err.Error()))
 			return
 		}

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -205,7 +205,7 @@ func (s *APISpec) Unload() {
 // Validate returns nil if s is a valid spec and an error stating why the spec is not valid.
 func (s *APISpec) Validate(oasConfig config.OASConfig) error {
 	if s.IsOAS {
-		err := s.OAS.Validate(context.Background(), oas.GetValidationOptionsFromConfig(oasConfig)...)
+		err := s.OAS.Validate(context.Background(), oas.WithOpenApiOpts(oas.GetValidationOptionsFromConfig(oasConfig)...))
 		if err != nil {
 			return err
 		}

--- a/internal/pathutil/expose.go
+++ b/internal/pathutil/expose.go
@@ -1,0 +1,6 @@
+package pathutil
+
+// ParsePath responsible for parsing single
+func ParsePath(in string) (*Path, error) {
+	return NewParser().Parse(in)
+}

--- a/internal/pathutil/parameters.go
+++ b/internal/pathutil/parameters.go
@@ -1,0 +1,101 @@
+package pathutil
+
+import "github.com/getkin/kin-openapi/openapi3"
+
+// parameters
+// *openapi3.Parameters wrapper
+// create to provide gentle extension of existent parameters operation based or pathItem based
+type parameters struct {
+	*openapi3.Parameters
+}
+
+func wrapParameters(dest *openapi3.Parameters) *parameters {
+	return &parameters{dest}
+}
+
+func (p *parameters) replaceOrAppend(pRef *openapi3.ParameterRef) {
+	if pRef.Value == nil {
+		*p.Parameters = append(*p.Parameters, pRef)
+		return
+	}
+
+	if _, idx := p.find(pRef.Value.Name); idx == notFound {
+		*p.Parameters = append(*p.Parameters, pRef)
+	} else {
+		p.extendExistent(pRef, idx)
+	}
+}
+
+func (p *parameters) find(name string) (*openapi3.ParameterRef, int) {
+	for idx, param := range *p.Parameters {
+		if param.Value == nil {
+			continue
+		}
+
+		if param.Value.Name == name {
+			return param, idx
+		}
+	}
+
+	return nil, notFound
+}
+
+func (p *parameters) extendExistent(newRef *openapi3.ParameterRef, idx int) {
+	existent := (*p.Parameters)[idx]
+
+	switch {
+	case existent.Value == nil:
+		(*p.Parameters)[idx] = newRef
+
+	case isTypeOf(existent, openapi3.TypeString) &&
+		isTypeOf(newRef, openapi3.TypeString) &&
+		isPatternDefined(existent):
+
+	case !isTypeOf(existent, openapi3.TypeString):
+		// prefer type from input
+		return
+
+	case isDefinedSchemaValue(existent) &&
+		isDefinedSchemaValue(newRef) &&
+		isTypeOf(existent, openapi3.TypeString) &&
+		isTypeOf(newRef, openapi3.TypeString) &&
+		!isPatternDefined(existent) &&
+		isPatternDefined(newRef):
+		existent.Value.Schema.Value.Pattern = newRef.Value.Schema.Value.Pattern
+
+	default:
+		(*p.Parameters)[idx] = newRef
+	}
+}
+
+func (p *parameters) extendBy(src openapi3.Parameters) {
+	for _, parameterRef := range src {
+		p.replaceOrAppend(parameterRef)
+	}
+}
+
+func isDefinedSchemaValue(ref *openapi3.ParameterRef) bool {
+	return ref != nil && ref.Value != nil && ref.Value.Schema != nil && ref.Value.Schema.Value != nil
+}
+
+func isTypeOf(ref *openapi3.ParameterRef, expectedType string) bool {
+	if !isDefinedSchemaValue(ref) {
+		return false
+	}
+
+	for _, typ := range *(ref.Value.Schema.Value.Type) {
+		if typ == expectedType {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isPatternDefined(ref *openapi3.ParameterRef) bool {
+	if !isDefinedSchemaValue(ref) {
+		return false
+	}
+
+	return len(ref.Value.Schema.Value.Pattern) > 0
+}

--- a/internal/pathutil/parser.go
+++ b/internal/pathutil/parser.go
@@ -1,0 +1,459 @@
+package pathutil
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/TykTechnologies/tyk/common/option"
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+const (
+	slash                 = '/'
+	curlyBraceLeft        = '{'
+	curlyBraceRight       = '}'
+	muxIdPatternSeparator = ':'
+
+	// RePrefix default regexp prefix.
+	RePrefix            = "customRegex"
+	DefaultNonDefinedRe = ""
+)
+
+var (
+	ErrUnreachableCase  = errors.New("unreachable case")
+	ErrUnexpectedSlash  = errors.New("unexpected slash symbol in pattern")
+	ErrUnexpectedSymbol = errors.New("unexpected symbol")
+)
+
+// Parser responsible for parsing user-defined path of given OAS.
+type Parser struct {
+	anonymousReCounter int
+	prefix             string
+	stripSlashes       bool
+	ctrResets          bool
+}
+
+// WithNoStripSlashes skip strip slashes.
+// Removes slashes near each other.
+func WithNoStripSlashes() option.Option[Parser] {
+	return func(parser *Parser) {
+		parser.stripSlashes = false
+	}
+}
+
+// WithPrefix allows to use custom prefix.
+func WithPrefix(prefix string) option.Option[Parser] {
+	return func(parser *Parser) {
+		parser.prefix = prefix
+	}
+}
+
+// WithGlobalCounter enables counter resets on each parse call.
+// Useful for testing.
+func WithGlobalCounter() option.Option[Parser] {
+	return func(parser *Parser) {
+		parser.ctrResets = false
+	}
+}
+
+// NewParser instantiates new parser instance
+func NewParser(opts ...option.Option[Parser]) *Parser {
+	return option.New(opts).Build(Parser{
+		anonymousReCounter: 0,
+		prefix:             RePrefix,
+		stripSlashes:       true,
+		ctrResets:          true,
+	})
+}
+
+// Parse responsible for parsing next one path.
+func (p *Parser) Parse(path string) (*Path, error) {
+	if p.ctrResets {
+		defer func() {
+			p.anonymousReCounter = 0
+		}()
+	}
+
+	singlePathParser := newPathParser(path, p)
+
+	pPath, err := singlePathParser.parse()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return newNormalizedPath(pPath), nil
+}
+
+type pathParser struct {
+	src    string
+	pos    int
+	parent *Parser
+}
+
+func newPathParser(path string, parent *Parser) *pathParser {
+	return &pathParser{
+		src:    path,
+		pos:    0,
+		parent: parent,
+	}
+}
+
+func (p *pathParser) parse() ([]pathPart, error) {
+	var parts []pathPart
+
+	for p.pos < len(p.src) {
+		ch := p.src[p.pos]
+		var err error
+		var part pathPart
+
+		switch {
+		case ch == slash:
+			if p.parent.stripSlashes {
+				p.consumeAll(slash)
+			} else {
+				p.consumeOne(slash)
+			}
+
+			part = newPathPartSplitter()
+		case ch == curlyBraceLeft:
+			part, err = p.parseMuxRe()
+		default:
+			if id, ok := p.consumeSegmentPart(); ok {
+				part = newPathPartRaw(id)
+				break
+			}
+
+			part, err = p.parseAnonymousRe()
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		parts = append(parts, part)
+	}
+
+	return parts, nil
+}
+
+func (p *pathParser) consumeMuxIdentifier() (res string, ok bool, finished bool) {
+	if !isLetter(p.src[p.pos]) {
+		return
+	}
+
+	start := p.pos
+	for p.pos < len(p.src) && isMuxIdentifierSymbol(p.src[p.pos]) {
+		p.pos++
+	}
+
+	// end reached
+	if p.pos == len(p.src) {
+		p.pos = start
+		return
+	}
+
+	if p.src[p.pos] == muxIdPatternSeparator {
+		p.pos++
+		return p.src[start : p.pos-1], true, false
+	}
+
+	if p.src[p.pos] == curlyBraceRight {
+		p.pos++
+		return p.src[start : p.pos-1], true, true
+	}
+
+	p.pos = start
+	return
+}
+
+func (p *pathParser) parseMuxRe() (pathPart, error) {
+	if p.src[p.pos] != curlyBraceLeft {
+		return pathPart{}, ErrUnreachableCase
+	}
+
+	// consume first open curly brace
+	p.pos++
+	openBraceCtr := 1
+
+	paramName, idParsedOk, isFinished := p.consumeMuxIdentifier()
+
+	if isFinished {
+		return p.newPathPartParameter(paramName), nil
+	}
+
+	start := p.pos
+loop:
+	for p.pos < len(p.src) {
+		ch := p.src[p.pos]
+		p.pos++
+
+		switch ch {
+		case slash:
+			p.pos--
+			break loop
+		case curlyBraceLeft:
+			openBraceCtr++
+		case curlyBraceRight:
+			openBraceCtr--
+			if openBraceCtr == 0 {
+				// if next exists it should be /
+				if p.pos < len(p.src) && p.src[p.pos] != slash {
+					return pathPart{}, p.parseError(ErrUnexpectedSymbol)
+				}
+
+				break loop
+			}
+		default:
+		}
+	}
+
+	if openBraceCtr != 0 {
+		p.pos--
+		return pathPart{}, p.parseError(ErrUnexpectedSlash)
+	}
+
+	if !idParsedOk {
+		paramName = p.newAnonymousName()
+	}
+
+	return p.newPathPartRe(paramName, p.src[start:p.pos-1])
+}
+
+func (p *pathParser) parseError(err error) parseError {
+	return parseError{
+		prev: err,
+		pos:  p.pos,
+		src:  p.src,
+	}
+}
+
+func (p *pathParser) parseAnonymousRe() (pathPart, error) {
+	paramName, idParsedOk, isFinished := p.consumeMuxIdentifier()
+
+	if isFinished {
+		return pathPart{}, p.parseError(ErrUnreachableCase)
+	}
+
+	start := p.pos
+	braceCtr := 0
+
+loop:
+	for p.pos < len(p.src) {
+		ch := p.src[p.pos]
+		p.pos++
+
+		switch ch {
+		case slash:
+			p.pos--
+			break loop
+		case curlyBraceLeft:
+			braceCtr++
+		case curlyBraceRight:
+			braceCtr--
+		}
+	}
+
+	if braceCtr != 0 {
+		return pathPart{}, p.parseError(ErrUnexpectedSlash)
+	}
+
+	if !idParsedOk {
+		paramName = p.newAnonymousName()
+	}
+
+	return p.newPathPartRe(
+		paramName,
+		p.src[start:p.pos],
+	)
+}
+
+func (p *pathParser) consumeAll(ch byte) {
+	for p.consumeOne(ch) {
+	}
+}
+
+func (p *pathParser) consumeOne(ch byte) bool {
+	if p.pos < len(p.src) && p.src[p.pos] == ch {
+		p.pos++
+		return true
+	}
+
+	return false
+}
+
+func (p *pathParser) consumeSegmentPart() (string, bool) {
+	var b []byte
+	var pos = p.pos
+
+loop:
+	for pos < len(p.src) {
+		ch := p.src[pos]
+		pos++
+
+		switch {
+		case ch == slash:
+			pos--
+			break loop
+		// %XX -> are also allowed by RFC
+		// if is percent then consume two hex digits
+		case !isIdentifierSymbol(ch):
+			return "", false
+		default:
+			b = append(b, ch)
+		}
+	}
+
+	p.pos = pos
+	return string(b), len(b) > 0
+}
+
+func (p *pathParser) newAnonymousName() string {
+	p.parent.anonymousReCounter++
+	return fmt.Sprintf("%s%d", p.parent.prefix, p.parent.anonymousReCounter)
+}
+
+func (p *pathParser) newPathPartRe(name, pattern string) (pathPart, error) {
+	if _, err := regexp.Compile(fmt.Sprintf("^%s$", pattern)); err != nil {
+		return pathPart{}, p.parseError(err)
+	}
+
+	return pathPart{
+		name:    name,
+		pattern: pattern,
+		typ:     pathPartRe,
+		parameter: openapi3.
+			NewPathParameter(name).
+			WithSchema(openapi3.NewStringSchema().WithPattern(pattern)),
+	}, nil
+}
+
+func (p *pathParser) newPathPartParameter(name string) pathPart {
+	return pathPart{
+		name:    name,
+		pattern: "",
+		typ:     pathPartParameter,
+		parameter: openapi3.
+			NewPathParameter(name).
+			WithSchema(openapi3.NewStringSchema().WithPattern(DefaultNonDefinedRe)),
+	}
+}
+
+type parseError struct {
+	prev error
+	src  string
+	pos  int
+}
+
+func (e parseError) Error() string {
+	baseMsg := fmt.Sprintf(`failed to parse "%s" at %d`, e.src, e.pos)
+
+	if e.prev == nil {
+		return baseMsg
+	}
+
+	return fmt.Sprintf(`%s: %s`, baseMsg, e.prev.Error())
+}
+
+type pathPartType struct {
+	val string
+}
+
+var (
+	pathPartParameter = pathPartType{"parameter"}
+	pathPartRe        = pathPartType{"reg-exp"}
+	pathPartRaw       = pathPartType{"raw"}
+	pathPartSplitter  = pathPartType{"/"}
+)
+
+// pathPart regular expression part.
+type pathPart struct {
+	name      string
+	pattern   string
+	parameter *openapi3.Parameter
+	typ       pathPartType
+}
+
+func newPathPartSplitter() pathPart {
+	return pathPart{
+		typ: pathPartSplitter,
+	}
+}
+
+func newPathPartRaw(name string) pathPart {
+	return pathPart{
+		name: name,
+		typ:  pathPartRaw,
+	}
+}
+
+func (r *pathPart) normalize() string {
+	switch r.typ {
+	case pathPartSplitter:
+		return "/"
+	case pathPartRaw:
+		return r.name
+	case pathPartRe, pathPartParameter:
+		var sb strings.Builder
+		sb.Grow(len(r.name) + 2)
+		sb.WriteRune(curlyBraceLeft)
+		sb.WriteString(r.name)
+		sb.WriteRune(curlyBraceRight)
+		return sb.String()
+	default:
+		panic("invalid path part type")
+	}
+}
+
+func isIdentifierSymbol(s byte) bool {
+	return isLowerLetter(s) || isUpperLetter(s) || isDigit(s) || isUnderscoreOrMinusOrDot(s)
+}
+
+func isMuxIdentifierSymbol(s byte) bool {
+	return isLowerLetter(s) || isUpperLetter(s) || isDigit(s) || isUnderscoreOrMinus(s)
+}
+
+func isLetter(s byte) bool {
+	return isLowerLetter(s) || isUpperLetter(s)
+}
+
+func isLowerLetter(s byte) bool {
+	return s >= 'a' && s <= 'z'
+}
+
+func isUpperLetter(s byte) bool {
+	return s >= 'A' && s <= 'Z'
+}
+
+func isDigit(s byte) bool {
+	return s >= '0' && s <= '9'
+}
+
+func isOneOf(str string) func(byte) bool {
+	var arr [255]bool
+
+	for _, r := range []byte(str) {
+		arr[r] = true
+	}
+
+	return func(s byte) bool {
+		return arr[s]
+	}
+}
+
+func isHex(ch byte) bool {
+	return isDigit(ch) || (ch >= 'A' && ch <= 'F') || (ch >= 'a' && ch <= 'f')
+}
+
+var isUnderscoreOrMinus = isOneOf("_-")
+
+// isUnderscoreOrMinusOrDot
+// Using this function makes some inconsistency with RFC3986 and some valid parts cannot be accepted by gateway
+// Deprecated
+var isUnderscoreOrMinusOrDot = isOneOf("._-")
+
+// https://datatracker.ietf.org/doc/html/rfc3986#section-3.3
+// https://stackoverflow.com/questions/4669692/valid-characters-for-directory-part-of-a-url-for-short-links
+var isPathSegmentSpecial = isOneOf("-._~!$&'()*+,;=@:")

--- a/internal/pathutil/parser_test.go
+++ b/internal/pathutil/parser_test.go
@@ -1,0 +1,172 @@
+package pathutil_test
+
+import (
+	"github.com/TykTechnologies/tyk/internal/pathutil"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParser(t *testing.T) {
+	t.Run("positive tests cases common", func(t *testing.T) {
+		type testCase struct {
+			name             string
+			path             string
+			expectedIdPrefix string
+			expectedParams   map[string]string
+		}
+
+		parser := pathutil.NewParser()
+		emptyMap := make(map[string]string)
+
+		for _, tc := range []testCase{
+			{
+				"parses some data",
+				"/hello/world",
+				"hello/world",
+				emptyMap,
+			},
+			{"removes duplicated slashes", "/hello//world", "hello/world", emptyMap},
+			{"leaves trailing slash", "/hello//world//", "hello/world/", emptyMap},
+			{"parses anonymous regexp", "/users/[0-9]+", "users/{customRegex1}", map[string]string{
+				"customRegex1": "[0-9]+",
+			}},
+			{"parses anonymous regexp wis trailing slash", "/users/[0-9]+/", "users/{customRegex1}/", map[string]string{
+				"customRegex1": "[0-9]+",
+			}},
+			{"parses mux patterns with label", "/users/{id:[0-9]+}", "users/{id}", map[string]string{
+				"id": "[0-9]+",
+			}},
+
+			// Edson's test-cases
+			{"empty path", "", "", emptyMap},
+
+			// this test is not rfc3986 compatible cause of "/test/.*/end" is valid path
+			// but due to historical circumstances it can be treated as regex from old classic api as well
+			{"path with regex", "/test/.*/end", "test/{customRegex1}/end", map[string]string{
+				"customRegex1": ".*",
+			}},
+			{"path with curly braces", "/users/{id}/profile", "users/{id}/profile", map[string]string{
+				"id": pathutil.DefaultNonDefinedRe,
+			}},
+			{"path with named regex", "/users/{userId:[0-9]+}/posts", "users/{userId}/posts", map[string]string{
+				"userId": "[0-9]+",
+			}},
+			{"root path", "/", "", emptyMap},
+			{
+				"path with multiple regexes",
+				"/users/{userId:[0-9]+}/posts/{postId:[a-z]+}/[a-z]+/{[0-9]{2}}/[a-z]{10}/abc/{id}/def/[0-9]+",
+				"users/{userId}/posts/{postId}/{customRegex1}/{customRegex2}/{customRegex3}/abc/{id}/def/{customRegex4}",
+				map[string]string{
+					"customRegex1": "[a-z]+",
+					"customRegex2": "[0-9]{2}",
+					"customRegex3": "[a-z]{10}",
+					"customRegex4": "[0-9]+",
+					"id":           "",
+					"postId":       "[a-z]+",
+					"userId":       "[0-9]+",
+				},
+			},
+
+			{"parses mux patterns without label", "/users/{[0-9]{3}}/", "users/{customRegex1}/", map[string]string{
+				"customRegex1": "[0-9]{3}",
+			}},
+
+			{"parses mux patterns without label and additional prefix 1", "/users/{prefix[0-9]{1}}/", "users/{customRegex1}/", map[string]string{
+				"customRegex1": "prefix[0-9]{1}",
+			}},
+
+			{"parses mux patterns without label and additional prefix 2", "/users/prefix[0-9]{2}/", "users/{customRegex1}/", map[string]string{
+				"customRegex1": "prefix[0-9]{2}",
+			}},
+
+			{"compound re in one path", "/users/[a-z]{10}[0-9]{5}", "users/{customRegex1}", map[string]string{
+				"customRegex1": "[a-z]{10}[0-9]{5}",
+			}},
+
+			// documentation test cases from (https://tyk.io/docs/getting-started/key-concepts/url-matching/)
+			{"test case unknown", "/products/{productId}/reviews/{rating:\\d+}", "products/{productId}/reviews/{rating}", map[string]string{
+				"productId": "",
+				"rating":    "\\d+",
+			}},
+
+			{"must parse named identifier RegExp separated by colon", "/user/id:[0-9]+/accelerate", "user/{id}/accelerate", map[string]string{
+				"id": "[0-9]+",
+			}},
+
+			// tests for parsing grpc-style paths
+			{"grpc service", "/v1.Service", "v1.Service", map[string]string{}},
+			{"grpc nested service", "/v1.Service/stats.Service", "v1.Service/stats.Service", map[string]string{}},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Helper()
+
+				nPath, err := parser.Parse(tc.path)
+				assert.NoError(t, err)
+
+				assert.Equal(t, tc.expectedIdPrefix, nPath.RawOpIdPrefix())
+
+				resMap := paramsToMapHelper(t, nPath.Parameters())
+				assert.Equal(t, tc.expectedParams, resMap)
+			})
+		}
+	})
+
+	t.Run("global ctr", func(t *testing.T) {
+		type testCase struct {
+			name             string
+			path             string
+			expectedIdPrefix string
+			expectedParams   map[string]string
+		}
+
+		parser := pathutil.NewParser(pathutil.WithGlobalCounter())
+
+		for _, tc := range []testCase{
+			{"first case anon RegEx parameter", "/users/[0-9]+", "users/{customRegex1}", map[string]string{
+				"customRegex1": "[0-9]+",
+			}},
+			{"second case anon RegEx parameter", "/users/[a-z]+", "users/{customRegex2}", map[string]string{
+				"customRegex2": "[a-z]+",
+			}},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				nPath, err := parser.Parse(tc.path)
+				assert.NoError(t, err)
+
+				assert.Equal(t, tc.expectedIdPrefix, nPath.RawOpIdPrefix())
+
+				resMap := paramsToMapHelper(t, nPath.Parameters())
+				assert.Equal(t, tc.expectedParams, resMap)
+			})
+		}
+	})
+
+	t.Run("negative test cases", func(t *testing.T) {
+		parser := pathutil.NewParser(pathutil.WithGlobalCounter())
+
+		_, err := parser.Parse("/users/{aaa[0-9]{2}/}")
+		assert.ErrorContains(t, err, pathutil.ErrUnexpectedSlash.Error())
+
+		_, err = parser.Parse("/users/aaa[0-9]{2/}")
+		assert.ErrorContains(t, err, pathutil.ErrUnexpectedSlash.Error())
+
+		_, err = parser.Parse("/users/{[0-9]{2}}[0-9]{2}")
+		assert.ErrorContains(t, err, pathutil.ErrUnexpectedSymbol.Error())
+	})
+}
+
+func paramsToMapHelper(t *testing.T, parameters []*openapi3.Parameter) map[string]string {
+	t.Helper()
+
+	m := make(map[string]string, len(parameters))
+
+	for _, p := range parameters {
+		_, ok := m[p.Name]
+		assert.False(t, ok, "parameter %q does not exist", p.Name)
+		m[p.Name] = p.Schema.Value.Pattern
+	}
+
+	return m
+}

--- a/internal/pathutil/path.go
+++ b/internal/pathutil/path.go
@@ -1,0 +1,85 @@
+package pathutil
+
+import (
+	"github.com/TykTechnologies/tyk/internal/reflect"
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/samber/lo"
+	"strings"
+)
+
+const (
+	notFound = -1
+)
+
+type Path struct {
+	path       string
+	parameters []*openapi3.Parameter
+	parts      []pathPart
+}
+
+func newNormalizedPath(parts []pathPart) *Path {
+	var sb strings.Builder
+	var np Path
+
+	for _, part := range parts {
+		sb.WriteString(part.normalize())
+
+		if part.parameter != nil {
+			np.parameters = append(np.parameters, part.parameter)
+		}
+	}
+
+	np.path = sb.String()
+	np.parts = parts
+
+	return &np
+}
+
+// HasParams returns true if path has path-based parameters.
+func (o Path) HasParams() bool {
+	return len(o.parameters) != 0
+}
+
+// HasReParams returns true if it has classic based regex parameters defined in path
+func (o Path) HasReParams() bool {
+	return lo.SomeBy(o.parts, func(p pathPart) bool {
+		return p.typ == pathPartRe
+	})
+}
+
+// Parameters slices of path-based params.
+func (o Path) Parameters() []*openapi3.Parameter {
+	return reflect.Clone(o.parameters)
+}
+
+// OperationId create operation id by method name.
+func (o Path) OperationId(method string) string {
+	return o.RawOpIdPrefix() + strings.ToUpper(method)
+}
+
+// RawOpIdPrefix returns prefix.
+func (o Path) RawOpIdPrefix() string {
+	return strings.TrimPrefix(o.path, string(slash))
+}
+
+// PropagateTo takes existent parameters and propagates them to destination if those do not exi
+func (o Path) PropagateTo(dest openapi3.Parameters) {
+	if !o.HasParams() {
+		return
+	}
+
+	if dest == nil {
+		dest = openapi3.Parameters{}
+	}
+
+	wrapParameters(&dest).extendBy(o.parameterRefs())
+}
+
+// parameterRefs slices of path-based params.
+func (o Path) parameterRefs() []*openapi3.ParameterRef {
+	return lo.Map(o.parameters, func(parameter *openapi3.Parameter, _ int) *openapi3.ParameterRef {
+		return &openapi3.ParameterRef{
+			Value: reflect.Clone(parameter),
+		}
+	})
+}

--- a/internal/utils/domain.go
+++ b/internal/utils/domain.go
@@ -1,0 +1,7 @@
+package utils
+
+import "strings"
+
+func OperationId(path, method string) string {
+	return strings.TrimPrefix(path, "/") + strings.ToUpper(method)
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,0 +1,5 @@
+package utils
+
+func AsPtr[V any](in V) *V {
+	return &in
+}


### PR DESCRIPTION
### **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description

Let's examine this OpenAPI specification:

```yaml
openapi: 3.0.4
info:
  title: title
  version: 0.0.1-rc1
paths:
  "/users/.*":
    get:
      responses:
        200:
          description: "" 
```
The path "/users/.*" could be considered valid from:
- ClassicApi definition perspective
- OpenApi specification
- RFC-3986 compliance

However, when we send this kind of specification to the gateway, it undergoes a two-way transformation cycle (Extract/Fill). During the fill phase (transformation from classic API to OAS), the URL parser recognizes (.*) as a pattern and attempts to extract anonymous parameters (customRegexN) from it.

We cannot eliminate this transformation cycle at present. Therefore, the most straightforward solution is to block classic-API regex-based paths in the system. 

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduced robust path parsing and validation utilities

- Enhanced OAS path validation to reject classic-style regex paths

- Refactored OAS operation parameter handling for regex paths

- Added comprehensive unit tests for path parsing logic


___

### **Changes diagram**

```mermaid
flowchart LR
  A["OAS.Validate()"] -- "calls" --> B["validatePath()"]
  B -- "uses" --> C["pathutil.ParsePath()"]
  C -- "parses" --> D["Path struct (parameters, parts)"]
  D -- "used by" --> E["OAS operation parameter logic"]
  F["parser_test.go"] -- "tests" --> C
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>oas.go</strong><dd><code>Enforce OAS path validation and update validation options</code></dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7234/files#diff-80279b1d59499a41a77ff7a16a6e2c9b9b785a4fd1326c351da6884c867658d7">+45/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>operation.go</strong><dd><code>Refactor operation parameter handling for regex paths</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7234/files#diff-6d92d2d5b09a5fa7129609bb7cd0d383d015250ec07062b6a93a83257be51fb5">+5/-45</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>validator.go</strong><dd><code>Add validator config and options for classic path allowance</code></dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7234/files#diff-5a0a9da02098e9cfc6b907a281b6e1229c960c33c0efb39fe87a18f3356a6e64">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>api.go</strong><dd><code>Update OAS validation middleware to use new options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7234/files#diff-644cda3aeb4ac7f325359e85fcddb810f100dd5e6fa480b0d9f9363a743c4e05">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>api_definition.go</strong><dd><code>Use new OAS validation options in API spec validation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7234/files#diff-0cf80174bbafb36f6d4f4308ebbd971b2833b76a936bad568220aa1a4ba0ee8b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>expose.go</strong><dd><code>Expose ParsePath utility function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7234/files#diff-4b6fd33063067512d7b8df9aca1b93116a698377d6b5a2f94a2c5f363e8fb264">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>parameters.go</strong><dd><code>Add parameters wrapper for OpenAPI parameter extension</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7234/files#diff-fd82d4873d7931b273f834c4a900bf75addb538d00ed0972a1256220b30acea3">+101/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>parser.go</strong><dd><code>Implement robust path parser for OAS and classic paths</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7234/files#diff-828a4587efec3c785b5c0008b7886a1f00953622bf809fa14fbf00c38a436155">+459/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>path.go</strong><dd><code>Add Path struct for normalized path representation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7234/files#diff-fc5d6cc9a93f57d1632db4dc2c163a2af0a67039eba1436e5b1b4af355930910">+85/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>domain.go</strong><dd><code>Add utility for generating operation IDs from path and method</code></dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7234/files#diff-5c440d6c26a8e4d6510af61a2ee36a97023c5f7834179e805fa8791ef3abe303">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>utils.go</strong><dd><code>Add generic pointer utility function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7234/files#diff-a7cadd8b7616e655fd258138320b33eb96f7cce8e8663ec92651f49ce07df000">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>parser_test.go</strong><dd><code>Add comprehensive tests for path parsing logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7234/files#diff-3d326e6df8ed95c3ca713d535a0409ea8b6cee3f762bd4b7bcdd0c45a2a23b4b">+172/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>