### PR TITLE
Fix SSE header detection

### DIFF
--- a/internal/httputil/streaming.go
+++ b/internal/httputil/streaming.go
@@ -16,9 +16,11 @@ func IsGrpcStreaming(r *http.Request) bool {
 	return r.ContentLength == -1 && r.Header.Get(headerContentType) == "application/grpc"
 }
 
-// IsSseStreamingResponse returns true if the response designates SSE streaming.
+// IsSseStreamingResponse returns true if the response designates SSE streaming. 
+// Content-Type text/event-stream headers with charset declaration ("text/event-stream; charset=utf-8") are evaluated to true
 func IsSseStreamingResponse(r *http.Response) bool {
-	return r.Header.Get(headerContentType) == "text/event-stream"
+	contentType := r.Header.Get(headerContentType)
+	return strings.HasPrefix(contentType, "text/event-stream")
 }
 
 // IsUpgrade checks if the request is an upgrade request and returns the upgrade type.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Fixes tyk.io SSE header detection.
Right now tyk.io does not consider this HTTP header `Content-Type: text/event-stream; charset=utf-8` as a SSE response due to exact string matching.

## Related Issue

https://github.com/TykTechnologies/tyk/issues/7238

## Motivation and Context

Python FastAPI uses the charset indication per default in all SSE streaming responses. Right now tyk.io does not work with those SSE responses.

## How This Has Been Tested

Tested with the reproduction code provided in the issue.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [x] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
