### PR TITLE
[TT-14254] The logs produced by the gateway about streams APIs should be in the same format as the other gateway logs

### DIFF
--- a/ee/middleware/streams/bento_log_adapter.go
+++ b/ee/middleware/streams/bento_log_adapter.go
@@ -1,6 +1,9 @@
 package streams
 
 import (
+	"fmt"
+	"io"
+
 	"github.com/buger/jsonparser"
 	"github.com/sirupsen/logrus"
 )
@@ -10,10 +13,16 @@ const (
 	bentoLogLevelField   = "level"
 )
 
+// bentoLogAdapter translates Bento logs to Tyk logs and applies our logging conventions
 type bentoLogAdapter struct {
 	logger *logrus.Entry
 }
 
+func newBentoLogAdapter(logger *logrus.Entry) *bentoLogAdapter {
+	return &bentoLogAdapter{logger: logger}
+}
+
+// bentoLogLine represents a structured log entry with a log level, a message, and additional fields.
 type bentoLogLine struct {
 	// log level
 	level logrus.Level
@@ -25,6 +34,8 @@ type bentoLogLine struct {
 	fields map[string]interface{}
 }
 
+// Write processes a log entry in JSON format, parses its fields, and logs the message using the embedded logger.
+// Returns the number of bytes written (always 0) and an error if parsing fails.
 func (w *bentoLogAdapter) Write(p []byte) (n int, err error) {
 	line := bentoLogLine{
 		fields: make(map[string]interface{}),
@@ -43,12 +54,12 @@ func (w *bentoLogAdapter) Write(p []byte) (n int, err error) {
 				line.level = logrus.InfoLevel
 			}
 		} else {
-			line.fields[string(key)] = string(value)
+			line.fields["bento_"+string(key)] = string(value)
 		}
 		return nil
 	})
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("error while parsing Bento log line: '%s': %w", string(p), err)
 	}
 
 	logger := w.logger
@@ -56,5 +67,8 @@ func (w *bentoLogAdapter) Write(p []byte) (n int, err error) {
 		logger = logger.WithField(k, v)
 	}
 	logger.Logln(line.level, line.msg)
-	return n, err
+	return 0, err
 }
+
+// Interface guard
+var _ io.Writer = (*bentoLogAdapter)(nil)

--- a/ee/middleware/streams/bento_log_adapter_test.go
+++ b/ee/middleware/streams/bento_log_adapter_test.go
@@ -1,0 +1,79 @@
+package streams
+
+import (
+	"bytes"
+	"io"
+	"regexp"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	bentoInfoLogLine = "{\"label\":\"\",\"level\":\"info\",\"msg\":\"Output type kafka " +
+		"is now active\",\"path\":\"root.output.retry.output\",\"stream\":\"default_stream\"," +
+		"\"time\":\"2025-07-16T11:38:20+03:00\"}\n"
+	expectedInfoLogLine = "level=info msg=\"Output type kafka is now active\" " +
+		"bento_label= bento_path=root.output.retry.output bento_stream=default_stream\n"
+
+	bentoErrorLogLine = "{\"label\":\"\",\"level\":\"error\",\"msg\":\"Failed to send '1' messages: " +
+		"kafka: client has run out of available brokers to talk to: read tcp [::1]:50152->[::1]:9092:" +
+		" read: connection reset by peer\",\"path\":\"root.output.retry.output\",\"stream\":\"default_stream\"," +
+		"\"time\":\"2025-07-16T11:38:29+03:00\"}\n"
+	expectedErrorLogLine = "level=error msg=\"Failed to send '1' messages: kafka: client has run out of " +
+		"available brokers to talk to: read tcp [::1]:50152->[::1]:9092: read: connection reset by peer\" " +
+		"bento_label= bento_path=root.output.retry.output bento_stream=default_stream\n"
+
+	bentoLogLineWithUndefinedLevel = "{\"label\":\"\",\"level\":\"undefined-level\",\"msg\":\"Output type kafka " +
+		"is now active\",\"path\":\"root.output.retry.output\",\"stream\":\"default_stream\"," +
+		"\"time\":\"2025-07-16T11:38:20+03:00\"}\n"
+	expectedLogLineWithUndefinedLevel = "level=info msg=\"Output type kafka is now active\" " +
+		"bento_label= bento_path=root.output.retry.output bento_stream=default_stream\n"
+)
+
+func newLogrusInstance(output io.Writer) *logrus.Entry {
+	rootLogger := logrus.New()
+	rootLogger.SetOutput(output)
+	return logrus.NewEntry(rootLogger)
+}
+
+func pruneTimeSection(line string) string {
+	re := regexp.MustCompile(`time="[^"]*"\s*`)
+	return re.ReplaceAllString(line, "")
+}
+
+func TestBentoLogAdapter(t *testing.T) {
+	type testDefinition struct {
+		bentoLogLine       string
+		expectedTykLogLine string
+	}
+	testDefinitions := []testDefinition{
+		{
+			bentoLogLine:       bentoInfoLogLine,
+			expectedTykLogLine: expectedInfoLogLine,
+		},
+		{
+			bentoLogLine:       bentoErrorLogLine,
+			expectedTykLogLine: expectedErrorLogLine,
+		},
+		{
+			bentoLogLine:       bentoLogLineWithUndefinedLevel,
+			expectedTykLogLine: expectedLogLineWithUndefinedLevel,
+		},
+	}
+	for _, definition := range testDefinitions {
+		output := bytes.NewBuffer(nil)
+		adapter := newBentoLogAdapter(newLogrusInstance(output))
+		_, err := adapter.Write([]byte(definition.bentoLogLine))
+		assert.Nil(t, err)
+		assert.Equal(t, definition.expectedTykLogLine, pruneTimeSection(output.String()))
+	}
+}
+
+func TestBentoLogAdapter_Corrupt_Log_Line(t *testing.T) {
+	output := bytes.NewBuffer(nil)
+	adapter := newBentoLogAdapter(newLogrusInstance(output))
+	_, err := adapter.Write([]byte("{"))
+	assert.ErrorContains(t, err, "error while parsing Bento log line: '{': Malformed JSON error")
+}

--- a/ee/middleware/streams/log_adapter.go
+++ b/ee/middleware/streams/log_adapter.go
@@ -1,0 +1,60 @@
+package streams
+
+import (
+	"github.com/buger/jsonparser"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	bentoLogMessageField = "msg"
+	bentoLogLevelField   = "level"
+)
+
+type bentoLogAdapter struct {
+	logger *logrus.Entry
+}
+
+type bentoLogLine struct {
+	// log level
+	level logrus.Level
+
+	// log message
+	msg string
+
+	// All other fields
+	fields map[string]interface{}
+}
+
+func (w *bentoLogAdapter) Write(p []byte) (n int, err error) {
+	line := bentoLogLine{
+		fields: make(map[string]interface{}),
+	}
+	err = jsonparser.ObjectEach(p, func(key []byte, value []byte, dataType jsonparser.ValueType, offset int) error {
+		if string(key) == "time" {
+			// discard time, the own logger of Tyk has this field
+			return nil
+		}
+		if (string(key) == bentoLogMessageField) && (dataType == jsonparser.String) {
+			line.msg = string(value)
+		} else if (string(key) == bentoLogLevelField) && (dataType == jsonparser.String) {
+			var logrusErr error
+			line.level, logrusErr = logrus.ParseLevel(string(value))
+			if logrusErr != nil {
+				line.level = logrus.InfoLevel
+			}
+		} else {
+			line.fields[string(key)] = string(value)
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	logger := w.logger
+	for k, v := range line.fields {
+		logger = logger.WithField(k, v)
+	}
+	logger.Logf(line.level, line.msg)
+	return n, err
+}

--- a/ee/middleware/streams/log_adapter.go
+++ b/ee/middleware/streams/log_adapter.go
@@ -29,7 +29,7 @@ func (w *bentoLogAdapter) Write(p []byte) (n int, err error) {
 	line := bentoLogLine{
 		fields: make(map[string]interface{}),
 	}
-	err = jsonparser.ObjectEach(p, func(key []byte, value []byte, dataType jsonparser.ValueType, offset int) error {
+	err = jsonparser.ObjectEach(p, func(key []byte, value []byte, dataType jsonparser.ValueType, _ int) error {
 		if string(key) == "time" {
 			// discard time, the own logger of Tyk has this field
 			return nil
@@ -55,6 +55,6 @@ func (w *bentoLogAdapter) Write(p []byte) (n int, err error) {
 	for k, v := range line.fields {
 		logger = logger.WithField(k, v)
 	}
-	logger.Logf(line.level, line.msg)
+	logger.Logln(line.level, line.msg)
 	return n, err
 }

--- a/ee/middleware/streams/manager.go
+++ b/ee/middleware/streams/manager.go
@@ -94,7 +94,7 @@ func (sm *Manager) createStream(streamID string, config map[string]interface{}) 
 		},
 	}
 
-	stream := NewStream(sm.mw.allowedUnsafe)
+	stream := NewStream(sm.mw.allowedUnsafe, sm.mw.Logger())
 	err := stream.Start(config, &HandleFuncAdapter{
 		StreamMiddleware: sm.mw,
 		StreamID:         streamFullID,

--- a/ee/middleware/streams/stream.go
+++ b/ee/middleware/streams/stream.go
@@ -50,7 +50,7 @@ func (s *Stream) Start(config map[string]interface{}, mux service.HTTPMultiplexe
 
 	s.logger.Debugf("Building new stream")
 	builder := service.NewStreamBuilder()
-	handler := slog.NewJSONHandler(&bentoLogAdapter{logger: s.logger}, nil)
+	handler := slog.NewJSONHandler(newBentoLogAdapter(s.logger), nil)
 	builder.SetLogger(slog.New(handler))
 
 	err = builder.SetYAML(string(configPayload))

--- a/ee/middleware/streams/stream.go
+++ b/ee/middleware/streams/stream.go
@@ -20,8 +20,8 @@ import (
 type Stream struct {
 	allowedUnsafe []string
 	streamConfig  string
-	stream *service.Stream
-	logger *logrus.Entry
+	stream        *service.Stream
+	logger        *logrus.Entry
 }
 
 // NewStream creates a new stream without initializing it

--- a/ee/middleware/streams/stream.go
+++ b/ee/middleware/streams/stream.go
@@ -3,7 +3,7 @@ package streams
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"regexp"
 	"strings"
 	"time"
@@ -20,54 +20,42 @@ import (
 type Stream struct {
 	allowedUnsafe []string
 	streamConfig  string
-	stream        *service.Stream
-	log           *logrus.Logger
+	stream *service.Stream
+	logger *logrus.Entry
 }
 
 // NewStream creates a new stream without initializing it
-func NewStream(allowUnsafe []string) *Stream {
-	logger := logrus.New()
-	logger.Out = log.Writer()
-	logger.Formatter = &logrus.TextFormatter{
-		FullTimestamp: true,
-	}
-	logger.Level = logrus.DebugLevel
-
+func NewStream(allowUnsafe []string, logger *logrus.Entry) *Stream {
 	if len(allowUnsafe) > 0 {
 		logger.Warnf("Allowing unsafe components: %v", allowUnsafe)
 	}
 
 	return &Stream{
-		log:           logger,
+		logger:        logger,
 		allowedUnsafe: allowUnsafe,
 	}
 }
 
-// SetLogger to be used by the stream
-func (s *Stream) SetLogger(logger *logrus.Logger) {
-	if logger != nil {
-		s.log = logger
-	}
-}
-
-// Start loads up the configuration and starts the stream. Non blocking
+// Start loads up the configuration and starts the stream. Non-blocking
 func (s *Stream) Start(config map[string]interface{}, mux service.HTTPMultiplexer) error {
-	s.log.Debugf("Starting stream")
+	s.logger.Debugf("Starting stream")
 
 	configPayload, err := yaml.Marshal(config)
 	if err != nil {
-		s.log.Errorf("Failed to marshal config: %v", err)
+		s.logger.Errorf("Failed to marshal config: %v", err)
 		return err
 	}
 
 	configPayload = s.removeUnsafe(configPayload)
 
-	s.log.Debugf("Building new stream")
+	s.logger.Debugf("Building new stream")
 	builder := service.NewStreamBuilder()
+	handler := slog.NewJSONHandler(&bentoLogAdapter{logger: s.logger}, nil)
+	builder.SetLogger(slog.New(handler))
 
 	err = builder.SetYAML(string(configPayload))
 	if err != nil {
-		s.log.Errorf("Failed to set YAML: %v", err)
+		s.logger.Errorf("Failed to set YAML: %v", err)
 		return err
 	}
 
@@ -77,41 +65,41 @@ func (s *Stream) Start(config map[string]interface{}, mux service.HTTPMultiplexe
 
 	stream, err := builder.Build()
 	if err != nil {
-		s.log.Errorf("Failed to build stream: %v", err)
+		s.logger.Errorf("Failed to build stream: %v", err)
 		return err
 	}
 
 	s.streamConfig = string(configPayload)
 	s.stream = stream
 
-	s.log.Debugf("Stream built successfully, starting it")
+	s.logger.Debugf("Stream built successfully, starting it")
 
 	errChan := make(chan error, 1)
 	go func() {
-		s.log.Infof("Starting stream")
+		s.logger.Infof("Starting stream")
 		errChan <- stream.Run(context.Background())
 	}()
 
 	select {
 	case err := <-errChan:
 		if err != nil {
-			s.log.Errorf("Stream encountered an error: %v", err)
+			s.logger.Errorf("Stream encountered an error: %v", err)
 			return err
 		}
 	case <-time.After(100 * time.Millisecond):
 		// If no error after a short delay, assume stream started successfully
 	}
 
-	s.log.Debugf("Stream started successfully")
+	s.logger.Debugf("Stream started successfully")
 	return nil
 }
 
 // Stop cleans up the stream
 func (s *Stream) Stop() error {
-	s.log.Printf("Stopping stream")
+	s.logger.Printf("Stopping stream")
 
 	if s.stream == nil {
-		s.log.Printf("No active stream to stop")
+		s.logger.Printf("No active stream to stop")
 		return nil
 	}
 
@@ -126,12 +114,12 @@ func (s *Stream) Stop() error {
 	select {
 	case err := <-errChan:
 		if err != nil {
-			s.log.Printf("Error stopping stream: %v", err)
+			s.logger.Printf("Error stopping stream: %v", err)
 		} else {
-			s.log.Printf("Stream stopped successfully")
+			s.logger.Printf("Stream stopped successfully")
 		}
 	case <-stopCtx.Done():
-		s.log.Printf("Timeout while stopping stream")
+		s.logger.Printf("Timeout while stopping stream")
 	}
 
 	s.streamConfig = ""
@@ -188,7 +176,7 @@ func (s *Stream) removeUnsafe(yamlBytes []byte) []byte {
 			// Remove matched parts
 			yamlString = re.ReplaceAllString(yamlString, "")
 
-			s.log.Info("Removed unsafe component: ", key)
+			s.logger.Info("Removed unsafe component: ", key)
 		}
 	}
 	return []byte(yamlString)

--- a/ee/middleware/streams/stream_test.go
+++ b/ee/middleware/streams/stream_test.go
@@ -4,12 +4,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 )
 
 func TestStreamStart(t *testing.T) {
-	str := NewStream(nil)
+	str := NewStream(nil, testLogger())
 	require.NotNil(t, str)
 
 	t.Run("success", func(t *testing.T) {
@@ -46,6 +47,7 @@ func TestStreamStart(t *testing.T) {
 }
 
 func TestStreamStop(t *testing.T) {
+	logger := testLogger()
 	validConfig := map[string]interface{}{
 		"input": map[string]interface{}{
 			"http_server": map[string]interface{}{
@@ -59,7 +61,7 @@ func TestStreamStop(t *testing.T) {
 		},
 	}
 	t.Run("successfully stop", func(t *testing.T) {
-		str := NewStream(nil)
+		str := NewStream(nil, logger)
 		require.NotNil(t, str)
 
 		err := str.Start(validConfig, nil)
@@ -70,7 +72,7 @@ func TestStreamStop(t *testing.T) {
 	})
 
 	t.Run("no error stopping cause no stream", func(t *testing.T) {
-		str := NewStream(nil)
+		str := NewStream(nil, logger)
 		require.NotNil(t, str)
 
 		err := str.Start(validConfig, nil)
@@ -82,8 +84,9 @@ func TestStreamStop(t *testing.T) {
 }
 
 func TestRemoveAndWhitelistUnsafeComponents(t *testing.T) {
+	logger := logrus.NewEntry(logrus.New())
 	t.Run("Remove Unsafe Components", func(t *testing.T) {
-		stream := NewStream(nil)
+		stream := NewStream(nil, logger)
 		unsafeConfig := map[string]interface{}{
 			"input": map[string]interface{}{
 				"type": "file",
@@ -112,7 +115,7 @@ func TestRemoveAndWhitelistUnsafeComponents(t *testing.T) {
 	})
 
 	t.Run("Whitelist Components", func(t *testing.T) {
-		stream := NewStream([]string{"file", "socket"})
+		stream := NewStream([]string{"file", "socket"}, logger)
 
 		unsafeConfig := map[string]interface{}{
 			"input": map[string]interface{}{
@@ -149,4 +152,8 @@ func containsUnsafeComponent(configPayload []byte) bool {
 		}
 	}
 	return false
+}
+
+func testLogger() *logrus.Entry {
+	return logrus.NewEntry(logrus.New())
 }


### PR DESCRIPTION
### **User description**
PR for https://tyktech.atlassian.net/browse/TT-14254

I have implemented a log adapter to translate Bento logs to Tyk's logging convention. The new logger. 

Log lines before the fix. Every Tyk Stream creates its own Logrus instance and Bento uses its own logger. This will cause issues with log aggregators like logz.io for Ara and Datadog making the product harder to support.

```
DEBU[2025-07-21T11:12:02+03:00] Starting stream
DEBU[2025-07-21T11:12:02+03:00] Building new stream
DEBU[2025-07-21T11:12:02+03:00] Stream built successfully, starting it
INFO[2025-07-21T11:12:02+03:00] Starting stream
{"label":"","level":"info","msg":"Output type kafka is now active","path":"root.output","stream":"default_stream","time":"2025-07-21T11:12:02+03:00"}
DEBU[2025-07-21T11:12:02+03:00] Stream started successfully
time="Jul 21 11:12:02" level=info msg="Successfully created stream: bce952d368e141286911e87d24807f6b_default_stream" api_id=bce952d368e141286911e87d24807f6b api_name=backoff-retry mw=StreamingMiddleware org_id=6821ac21f2c73410d7f5cdfa type=request
time="Jul 21 11:12:38" level=info msg="Removing inactive stream manager: 3cacc3925d6de947d369b0a159a4b898ae116fa2fe8ddea2031b618ecc27e4f1" api_id=bce952d368e141286911e87d24807f6b api_name=backoff-retry mw=StreamingMiddleware org_id=6821ac21f2c73410d7f5cdfa type=request
INFO[2025-07-21T11:12:38+03:00] Stopping stream
INFO[2025-07-21T11:12:38+03:00] Stream stopped successfully
```

After the fix, it looks like the following. Bento and Tyk streams use the gateway's logger:

```
time="Jul 21 11:09:33" level=info msg="Starting stream" api_id=bce952d368e141286911e87d24807f6b api_name=backoff-retry mw=StreamingMiddleware org_id=6821ac21f2c73410d7f5cdfa type=request
time="Jul 21 11:09:33" level=info msg="Output type kafka is now active" api_id=bce952d368e141286911e87d24807f6b api_name=backoff-retry bento_label= bento_path=root.output mw=StreamingMiddleware org_id=6821ac21f2c73410d7f5cdfa type=request
time="Jul 21 11:09:33" level=info msg="Successfully created stream: bce952d368e141286911e87d24807f6b_default_stream" api_id=bce952d368e141286911e87d24807f6b api_name=backoff-retry mw=StreamingMiddleware org_id=6821ac21f2c73410d7f5cdfa type=request
time="Jul 21 11:10:27" level=info msg="Removing inactive stream manager: 3cacc3925d6de947d369b0a159a4b898ae116fa2fe8ddea2031b618ecc27e4f1" api_id=bce952d368e141286911e87d24807f6b api_name=backoff-retry mw=StreamingMiddleware org_id=6821ac21f2c73410d7f5cdfa type=request
time="Jul 21 11:10:27" level=info msg="Stopping stream" api_id=bce952d368e141286911e87d24807f6b api_name=backoff-retry mw=StreamingMiddleware org_id=6821ac21f2c73410d7f5cdfa type=request
time="Jul 21 11:10:27" level=info msg="Stream stopped successfully" api_id=bce952d368e141286911e87d24807f6b api_name=backoff-retry mw=StreamingMiddleware org_id=6821ac21f2c73410d7f5cdfa type=request
```


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduced `bentoLogAdapter` to unify Bento and Tyk log formats

- Refactored stream logging to use injected logger and adapter

- Updated stream creation and tests for new logging approach

- Added comprehensive unit tests for log adapter functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Bento log output"] -- "via bentoLogAdapter" --> B["Tyk logger (logrus.Entry)"]
  B -- "used in Stream" --> C["Stream lifecycle (Start/Stop)"]
  D["Stream creation"] -- "inject logger" --> C
  E["Unit tests"] -- "test adapter & stream" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bento_log_adapter.go</strong><dd><code>Add Bento-to-Tyk log adapter for unified logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ee/middleware/streams/bento_log_adapter.go

<ul><li>Added new <code>bentoLogAdapter</code> type to translate Bento logs to Tyk format<br> <li> Implements <code>io.Writer</code> to parse JSON log lines and forward to logrus<br> <li> Handles log level mapping, message extraction, and field prefixing<br> <li> Ensures interface compliance and error handling for malformed logs</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7245/files#diff-317ddef92ffd0685991a22c5c62b758b1d8f6afc9a4453123d32aa4e58550651">+74/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>stream.go</strong><dd><code>Refactor Stream to use injected logger and log adapter</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ee/middleware/streams/stream.go

<ul><li>Refactored to use injected <code>logrus.Entry</code> for logging instead of <br>internal logger<br> <li> Integrated <code>bentoLogAdapter</code> via <code>slog.NewJSONHandler</code> for Bento logs<br> <li> Updated all logging calls to use new logger<br> <li> Improved comments and logging consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7245/files#diff-12571ea9605d5a2dd5ab5aa36972649881f87a84a39b7074213d29d24fc396a8">+22/-34</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>manager.go</strong><dd><code>Inject logger into Stream during creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ee/middleware/streams/manager.go

<ul><li>Modified stream creation to inject logger into <code>NewStream</code><br> <li> Ensures all streams use unified logging approach</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7245/files#diff-3e372b3346d8d296e6953152c89202a634d7654f10549676af9aea8628e13dfb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bento_log_adapter_test.go</strong><dd><code>Add tests for Bento log adapter functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ee/middleware/streams/bento_log_adapter_test.go

<ul><li>Added unit tests for <code>bentoLogAdapter</code> covering info, error, and <br>undefined levels<br> <li> Tests correct field mapping and log output format<br> <li> Includes test for handling malformed/corrupt log lines</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7245/files#diff-a6348482f9267925b69aa6fd11156cf43a6cb6b2f4e0fd21a996b4e6adcefcf0">+79/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>stream_test.go</strong><dd><code>Update stream tests for logger injection and refactor</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ee/middleware/streams/stream_test.go

<ul><li>Updated tests to use new logger-injected <code>NewStream</code> signature<br> <li> Added helper for test logger creation<br> <li> Ensured tests are compatible with refactored logging</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7245/files#diff-7831fa7a5e3c834833b4f09c7e28a36275214856a2df3d4b70c8cce6f1328afb">+12/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

