### PR TITLE
Merging to release-5.9: [TT-14914] No response middleware information in Tyk OAS API Debugger (#7208)

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -746,6 +746,7 @@ func handleResponseChain(chain []TykResponseHandler, rw http.ResponseWriter, res
 			return false, err
 		}
 	}
+
 	return false, nil
 }
 

--- a/gateway/mw_mock_response.go
+++ b/gateway/mw_mock_response.go
@@ -133,6 +133,8 @@ func (m *mockResponseMiddleware) mockResponse(r *http.Request) (*http.Response, 
 
 	res.Body = io.NopCloser(bytes.NewBuffer(body))
 
+	m.Spec.sendRateLimitHeaders(ctxGetSession(r), res)
+
 	return res, nil
 }
 

--- a/gateway/mw_virtual_endpoint.go
+++ b/gateway/mw_virtual_endpoint.go
@@ -12,7 +12,6 @@ import (
 	"net/url"
 	"os"
 	"reflect"
-	"strconv"
 	"strings"
 	"time"
 
@@ -21,7 +20,6 @@ import (
 
 	"github.com/TykTechnologies/tyk-pump/analytics"
 	"github.com/TykTechnologies/tyk/apidef"
-	"github.com/TykTechnologies/tyk/header"
 	"github.com/TykTechnologies/tyk/internal/middleware"
 	"github.com/TykTechnologies/tyk/user"
 	"github.com/sirupsen/logrus"
@@ -333,14 +331,7 @@ func (gw *Gateway) handleForcedResponse(rw http.ResponseWriter, res *http.Respon
 		res.Header.Set("Connection", "close")
 	}
 
-	// Add resource headers
-	if ses != nil {
-		// We have found a session, lets report back
-		quotaMax, quotaRemaining, _, quotaRenews := ses.GetQuotaLimitByAPIID(spec.APIID)
-		res.Header.Set(header.XRateLimitLimit, strconv.Itoa(int(quotaMax)))
-		res.Header.Set(header.XRateLimitRemaining, strconv.Itoa(int(quotaRemaining)))
-		res.Header.Set(header.XRateLimitReset, strconv.Itoa(int(quotaRenews)))
-	}
+	spec.sendRateLimitHeaders(ses, res)
 
 	copyHeader(rw.Header(), res.Header, gw.GetConfig().IgnoreCanonicalMIMEHeaderKey)
 

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -24,7 +24,6 @@ import (
 	"net/http"
 	"net/textproto"
 	"net/url"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -1406,14 +1405,7 @@ func (p *ReverseProxy) HandleResponse(rw http.ResponseWriter, res *http.Response
 		res.Header.Set(header.Connection, "close")
 	}
 
-	// Add resource headers
-	if ses != nil {
-		// We have found a session, lets report back
-		quotaMax, quotaRemaining, _, quotaRenews := ses.GetQuotaLimitByAPIID(p.TykAPISpec.APIID)
-		res.Header.Set(header.XRateLimitLimit, strconv.Itoa(int(quotaMax)))
-		res.Header.Set(header.XRateLimitRemaining, strconv.Itoa(int(quotaRemaining)))
-		res.Header.Set(header.XRateLimitReset, strconv.Itoa(int(quotaRenews)))
-	}
+	p.TykAPISpec.sendRateLimitHeaders(ses, res)
 
 	copyHeader(rw.Header(), res.Header, p.Gw.GetConfig().IgnoreCanonicalMIMEHeaderKey)
 


### PR DESCRIPTION
### **User description**
[TT-14914] No response middleware information in Tyk OAS API Debugger (#7208)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-14914"
title="TT-14914" target="_blank">TT-14914</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
<td> No response middleware information in Tyk OAS API Debugger</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Code Review</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20QA_Fail%20ORDER%20BY%20created%20DESC"
title="QA_Fail">QA_Fail</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20codilime_refined%20ORDER%20BY%20created%20DESC"
title="codilime_refined">codilime_refined</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description
Short fix that @radkrawczyk managed to find. 
XRateLimit* already headers present in mocked-response. In addition smal
refatoring.
Code responsible for sending those headers placed in one method.

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Centralized logic for sending rate-limit headers in responses

- Fixed missing rate-limit headers in mocked and cached responses

- Refactored code to use new `sendRateLimitHeaders` method

- Improved maintainability by removing duplicate header logic


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Duplicate rate-limit header logic"] -- "Refactored to" --> B["sendRateLimitHeaders method in APISpec"]
  B -- "Used by" --> C["Mock response middleware"]
  B -- "Used by" --> D["Redis cache middleware"]
  B -- "Used by" --> E["Virtual endpoint forced response"]
  B -- "Used by" --> F["Reverse proxy response handler"]
  C -- "Ensures" --> G["Consistent rate-limit headers in mocked responses"]
  D -- "Ensures" --> H["Consistent rate-limit headers in cached responses"]
  E -- "Ensures" --> I["Consistent rate-limit headers in forced responses"]
  F -- "Ensures" --> J["Consistent rate-limit headers in proxied responses"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>model_apispec.go</strong><dd><code>Add and use
centralized rate-limit header sender</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/model_apispec.go

<li>Added <code>sendRateLimitHeaders</code> method to centralize
rate-limit header <br>logic<br> <li> Utilizes session data to set
X-RateLimit headers on responses


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7208/files#diff-80c49b9bdb411a3d5a4706ec3ff138ef44154d0306040c19eba1cb5559f199d6">+22/-0</a>&nbsp;
&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>mw_redis_cache.go</strong><dd><code>Use centralized
rate-limit headers in cache middleware</code>&nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

gateway/mw_redis_cache.go

<li>Replaces inline rate-limit header logic with
<code>sendRateLimitHeaders</code><br> <li> Ensures cached responses
include consistent rate-limit headers


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7208/files#diff-6266e0dbd16cef89e6de86a2c893114ba07799c804e2138172f9f94b08cdded8">+1/-9</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>mw_virtual_endpoint.go</strong><dd><code>Use
centralized rate-limit headers in virtual endpoint
responses</code></dd></summary>
<hr>

gateway/mw_virtual_endpoint.go

<li>Replaces inline rate-limit header logic with
<code>sendRateLimitHeaders</code><br> <li> Ensures forced responses
include quota headers


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7208/files#diff-daf72ac3b29609a9f2a77cccf648f91ba62b2ad977a7c5a44602c72b2a28b2e5">+1/-10</a>&nbsp;
&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>reverse_proxy.go</strong><dd><code>Use centralized
rate-limit headers in reverse proxy responses</code></dd></summary>
<hr>

gateway/reverse_proxy.go

<li>Replaces inline rate-limit header logic with
<code>sendRateLimitHeaders</code><br> <li> Ensures proxied responses
include quota headers


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7208/files#diff-e6e07722257f7e41691e471185ad6d84fd56dc9e5459526ea32e9a5e8fa1a01b">+1/-9</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>mw_mock_response.go</strong><dd><code>Add rate-limit
headers to mocked responses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

gateway/mw_mock_response.go

<li>Calls <code>sendRateLimitHeaders</code> to add rate-limit headers to
mocked <br>responses<br> <li> Ensures mocked responses include quota
information


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7208/files#diff-fa778ebf662b147d9693791799966dbd20fca6eb5dc98b2e7264230b4e0cbfbd">+2/-0</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>middleware.go</strong><dd><code>Minor formatting
adjustment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></summary>
<hr>

gateway/middleware.go

- Minor formatting change (added blank line)
- No functional changes


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7208/files#diff-703054910891a4db633eca0f42ed779d6b4fa75cd9b3aa4c503e681364201c1b">+1/-0</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary> Need help?</summary><li>Type <code>/help how to
...</code> in the comments thread for any questions about PR-Agent
usage.</li><li>Check out the <a
href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a>
for more information.</li></details>

[TT-14914]: https://tyktech.atlassian.net/browse/TT-14914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Centralized rate-limit header logic in `sendRateLimitHeaders` method

- Ensured rate-limit headers are added to mocked, cached, forced, and proxied responses

- Removed duplicate header-setting code from multiple middleware components

- Minor formatting improvement in middleware code


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Duplicate rate-limit header logic"] -- "Refactored to" --> B["sendRateLimitHeaders method in APISpec"]
  B -- "Used by" --> C["Mock response middleware"]
  B -- "Used by" --> D["Redis cache middleware"]
  B -- "Used by" --> E["Virtual endpoint forced response"]
  B -- "Used by" --> F["Reverse proxy response handler"]
  C -- "Ensures" --> G["Consistent rate-limit headers in mocked responses"]
  D -- "Ensures" --> H["Consistent rate-limit headers in cached responses"]
  E -- "Ensures" --> I["Consistent rate-limit headers in forced responses"]
  F -- "Ensures" --> J["Consistent rate-limit headers in proxied responses"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>model_apispec.go</strong><dd><code>Add and use centralized rate-limit header sender</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/model_apispec.go

<ul><li>Added <code>sendRateLimitHeaders</code> method to centralize rate-limit header <br>logic<br> <li> Uses session data to set X-RateLimit headers on responses</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7253/files#diff-80c49b9bdb411a3d5a4706ec3ff138ef44154d0306040c19eba1cb5559f199d6">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mw_redis_cache.go</strong><dd><code>Use centralized rate-limit headers in cache middleware</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_redis_cache.go

<ul><li>Replaces inline rate-limit header logic with <code>sendRateLimitHeaders</code><br> <li> Ensures cached responses include consistent rate-limit headers</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7253/files#diff-6266e0dbd16cef89e6de86a2c893114ba07799c804e2138172f9f94b08cdded8">+1/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mw_virtual_endpoint.go</strong><dd><code>Use centralized rate-limit headers in virtual endpoint responses</code></dd></summary>
<hr>

gateway/mw_virtual_endpoint.go

<ul><li>Replaces inline rate-limit header logic with <code>sendRateLimitHeaders</code><br> <li> Ensures forced responses include quota headers</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7253/files#diff-daf72ac3b29609a9f2a77cccf648f91ba62b2ad977a7c5a44602c72b2a28b2e5">+1/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>reverse_proxy.go</strong><dd><code>Use centralized rate-limit headers in reverse proxy responses</code></dd></summary>
<hr>

gateway/reverse_proxy.go

<ul><li>Replaces inline rate-limit header logic with <code>sendRateLimitHeaders</code><br> <li> Ensures proxied responses include quota headers</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7253/files#diff-e6e07722257f7e41691e471185ad6d84fd56dc9e5459526ea32e9a5e8fa1a01b">+1/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mw_mock_response.go</strong><dd><code>Add rate-limit headers to mocked responses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_mock_response.go

<ul><li>Calls <code>sendRateLimitHeaders</code> to add rate-limit headers to mocked <br>responses<br> <li> Ensures mocked responses include quota information</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7253/files#diff-fa778ebf662b147d9693791799966dbd20fca6eb5dc98b2e7264230b4e0cbfbd">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>middleware.go</strong><dd><code>Minor formatting adjustment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/middleware.go

- Minor formatting change (added blank line)
- No functional changes


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7253/files#diff-703054910891a4db633eca0f42ed779d6b4fa75cd9b3aa4c503e681364201c1b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

