### PR TITLE
Merging to release-5.9: [TT-11244] Custom domain regex causing problems with servers (#7233)

### DIFF
--- a/apidef/oas/oas.go
+++ b/apidef/oas/oas.go
@@ -5,11 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/samber/lo"
 	"strings"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/internal/oasutil"
 	"github.com/TykTechnologies/tyk/internal/reflect"
+
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
@@ -340,28 +343,53 @@ func (s *OAS) getTykOperations() (operations Operations) {
 	return
 }
 
+// RemoveServer removes the server from the server list if it's already present.
+// It accepts regex-based server URLs, such as https://{subdomain:[a-z]+}.example.com/{version}
+func (s *OAS) RemoveServer(serverUrl string) error {
+	if len(serverUrl) == 0 {
+		return nil
+	}
+
+	parsed, err := oasutil.ParseServerUrl(serverUrl)
+
+	if err != nil {
+		return err
+	}
+
+	s.Servers = lo.Filter(s.Servers, func(server *openapi3.Server, _ int) bool {
+		return server.URL != parsed.UrlNormalized
+	})
+
+	return nil
+}
+
 // AddServers adds a server into the servers definition if not already present.
-func (s *OAS) AddServers(apiURLs ...string) {
+func (s *OAS) AddServers(apiURLs ...string) error {
 	apiURLSet := make(map[string]struct{})
-	newServers := openapi3.Servers{}
+	var newServers openapi3.Servers
+
 	for _, apiURL := range apiURLs {
-		if strings.Contains(apiURL, "{") && strings.Contains(apiURL, "}") {
-			continue
+		serverUrl, err := oasutil.ParseServerUrl(apiURL)
+
+		if err != nil {
+			return err
 		}
 
 		newServers = append(newServers, &openapi3.Server{
-			URL: apiURL,
+			URL:       serverUrl.UrlNormalized,
+			Variables: serverUrl.Variables,
 		})
+
 		apiURLSet[apiURL] = struct{}{}
 	}
 
 	if len(newServers) == 0 {
-		return
+		return nil
 	}
 
 	if len(s.Servers) == 0 {
 		s.Servers = newServers
-		return
+		return nil
 	}
 
 	// check if apiURL already exists in servers object
@@ -374,6 +402,7 @@ func (s *OAS) AddServers(apiURLs ...string) {
 	}
 
 	s.Servers = newServers
+	return nil
 }
 
 // UpdateServers sets or updates the first servers URL if it matches oldAPIURL.

--- a/apidef/oas/oas_test.go
+++ b/apidef/oas/oas_test.go
@@ -7,16 +7,14 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/oasdiff/yaml"
-
 	"github.com/TykTechnologies/storage/persistent/model"
-
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/internal/event"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/yaml"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestOAS(t *testing.T) {
@@ -309,23 +307,32 @@ func TestOAS_AddServers(t *testing.T) {
 	type args struct {
 		apiURLs []string
 	}
+
 	tests := []struct {
-		name         string
-		fields       fields
-		args         args
-		expectedURLs []string
+		name            string
+		fields          fields
+		args            args
+		expectedServers openapi3.Servers
 	}{
 		{
-			name:         "empty servers",
-			fields:       fields{T: openapi3.T{}},
-			args:         args{apiURLs: []string{"http://127.0.0.1:8080/api"}},
-			expectedURLs: []string{"http://127.0.0.1:8080/api"},
+			name:   "empty servers",
+			fields: fields{T: openapi3.T{}},
+			args:   args{apiURLs: []string{"http://127.0.0.1:8080/api"}},
+			expectedServers: openapi3.Servers{
+				{URL: "http://127.0.0.1:8080/api"},
+			},
 		},
 		{
-			name:         "empty servers and named parameters",
-			fields:       fields{T: openapi3.T{}},
-			args:         args{apiURLs: []string{"http://{subdomain}/api"}},
-			expectedURLs: nil,
+			name:   "empty servers and named parameters with regex",
+			fields: fields{T: openapi3.T{}},
+			args:   args{apiURLs: []string{"http://{subdomain:[a-z]+}/api"}},
+			expectedServers: openapi3.Servers{
+				{URL: "http://{subdomain}/api", Variables: map[string]*openapi3.ServerVariable{
+					"subdomain": {
+						Default: "pathParam1",
+					},
+				}},
+			},
 		},
 		{
 			name: "non-empty servers",
@@ -336,8 +343,11 @@ func TestOAS_AddServers(t *testing.T) {
 					},
 				},
 			}},
-			args:         args{apiURLs: []string{"http://127.0.0.1:8080/api"}},
-			expectedURLs: []string{"http://127.0.0.1:8080/api", "http://example-upstream.org/api"},
+			args: args{apiURLs: []string{"http://127.0.0.1:8080/api"}},
+			expectedServers: openapi3.Servers{
+				{URL: "http://127.0.0.1:8080/api"},
+				{URL: "http://example-upstream.org/api"},
+			},
 		},
 		{
 			name: "non-empty servers and mix on named parameters and normal urls",
@@ -348,8 +358,15 @@ func TestOAS_AddServers(t *testing.T) {
 					},
 				},
 			}},
-			args:         args{apiURLs: []string{"http://127.0.0.1:8080/api", "http://{subdomain}/api"}},
-			expectedURLs: []string{"http://127.0.0.1:8080/api", "http://example-upstream.org/api"},
+			args: args{apiURLs: []string{"http://127.0.0.1:8080/api", "http://{subdomain}/api/{version:v\\d+}"}},
+			expectedServers: openapi3.Servers{
+				{URL: "http://127.0.0.1:8080/api"},
+				{URL: "http://example-upstream.org/api"},
+				{URL: "http://{subdomain}/api/{version}", Variables: map[string]*openapi3.ServerVariable{
+					"subdomain": {Default: "pathParam1"},
+					"version":   {Default: "pathParam2"},
+				}},
+			},
 		},
 		{
 			name: "non-empty servers having same URL that of apiURL",
@@ -367,10 +384,10 @@ func TestOAS_AddServers(t *testing.T) {
 				},
 			}},
 			args: args{apiURLs: []string{"http://127.0.0.1:8080/api"}},
-			expectedURLs: []string{
-				"http://127.0.0.1:8080/api",
-				"http://example-upstream.org/api",
-				"http://legacy-upstream.org/api",
+			expectedServers: openapi3.Servers{
+				{URL: "http://127.0.0.1:8080/api"},
+				{URL: "http://example-upstream.org/api"},
+				{URL: "http://legacy-upstream.org/api"},
 			},
 		},
 		{
@@ -386,28 +403,19 @@ func TestOAS_AddServers(t *testing.T) {
 				},
 			}},
 			args: args{apiURLs: []string{"http://127.0.0.1:8080/api"}},
-			expectedURLs: []string{
-				"http://127.0.0.1:8080/api",
-				"http://example-upstream.org/api",
+			expectedServers: openapi3.Servers{
+				{URL: "http://127.0.0.1:8080/api"},
+				{URL: "http://example-upstream.org/api"},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := &OAS{
-				T: tt.fields.T,
-			}
-			s.AddServers(tt.args.apiURLs...)
-			if tt.expectedURLs == nil {
-				assert.Empty(t, s.Servers)
-				return
-			}
-			var serverURLs []string
-			for _, server := range s.Servers {
-				serverURLs = append(serverURLs, server.URL)
-			}
+			s := &OAS{T: tt.fields.T}
+			err := s.AddServers(tt.args.apiURLs...)
 
-			assert.ElementsMatch(t, tt.expectedURLs, serverURLs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, tt.expectedServers, s.Servers)
 		})
 	}
 }
@@ -1515,4 +1523,57 @@ func TestYaml(t *testing.T) {
 	yamlOASDoc.SetTykExtension(nil)
 	oasDoc.SetTykExtension(nil)
 	assert.Equal(t, oasDoc, yamlOASDoc)
+}
+
+func Test_RemoveServer(t *testing.T) {
+	createOas := func() *OAS {
+		var spec openapi3.T
+
+		spec.OpenAPI = "3.0.3"
+		spec.Info = &openapi3.Info{
+			Title:   "Test API",
+			Version: "1.0.0",
+		}
+
+		spec.Servers = append(spec.Servers, &openapi3.Server{
+			URL: "https://{sub}.example.com/{version}",
+			Variables: map[string]*openapi3.ServerVariable{
+				"version": {
+					Default: "v1",
+				},
+				"sub": {
+					Default: "default",
+				},
+			},
+		})
+
+		return &OAS{spec}
+	}
+
+	t.Run("removes without fail", func(t *testing.T) {
+		spec := createOas()
+		err := spec.RemoveServer("https://{sub:[a-z]+}.example.com/{version:[0-9]+}")
+		assert.NoError(t, err)
+		assert.Len(t, spec.Servers, 0)
+	})
+
+	t.Run("does no remove no one server if server url is empty", func(t *testing.T) {
+		spec := createOas()
+		err := spec.RemoveServer("")
+		assert.NoError(t, err)
+		assert.Len(t, spec.Servers, 1)
+	})
+
+	t.Run("does not fail if given server does not exist", func(t *testing.T) {
+		spec := createOas()
+		err := spec.RemoveServer("https://example.com")
+		assert.NoError(t, err)
+		assert.Len(t, spec.Servers, 1)
+	})
+
+	t.Run("fails if invalid regex was provided", func(t *testing.T) {
+		spec := createOas()
+		err := spec.RemoveServer("https://{sub:[a-z]+}.example.com/{version:[0-9]+}}")
+		assert.Error(t, err)
+	})
 }

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -1081,7 +1081,10 @@ func (gw *Gateway) handleAddApi(r *http.Request, fs afero.Fs, oasEndpoint bool) 
 
 	if oasEndpoint {
 		newAPIURL := getAPIURL(newDef, gw.GetConfig())
-		oasObj.AddServers(newAPIURL)
+
+		if err := oasObj.AddServers(newAPIURL); err != nil {
+			return apiError(err.Error()), http.StatusBadRequest
+		}
 
 		newDef.IsOAS = true
 		oasObj.GetTykExtension().Info.ID = newDef.APIID

--- a/internal/oasutil/servers.go
+++ b/internal/oasutil/servers.go
@@ -1,0 +1,162 @@
+package oasutil
+
+import (
+	"errors"
+	"fmt"
+	"github.com/getkin/kin-openapi/openapi3"
+	"strings"
+)
+
+var (
+	ErrParse                = errors.New("failed to parse")
+	ErrEmptyVariableName    = errors.New("empty variable name")
+	ErrVariableCollision    = errors.New("variable collision")
+	ErrUnexpectedCurlyBrace = errors.New("unexpected closing curly brace")
+	errUnreachable          = errors.New("unreachable")
+)
+
+const (
+	DefaultServerUrlPrefix = "pathParam"
+	openCurlyBrace         = '{'
+	closeCurlyBrace        = '}'
+)
+
+type ServerUrl struct {
+	// Url template acceptable by tyk extension
+	// eg "{subdomain:[a-z]+}.example.com" or "api.example.com"
+	Url string
+
+	// UrlNormalized acceptable by oas specification
+	// "{subdomain}.example.com"
+	UrlNormalized string
+
+	// Variables server variables
+	Variables map[string]*openapi3.ServerVariable
+}
+
+func newServerUrl(originUrl string) ServerUrl {
+	return ServerUrl{
+		Url: originUrl,
+	}
+}
+
+func (u *ServerUrl) addVariable(name, defaultValue string) error {
+	if u.Variables == nil {
+		u.Variables = make(map[string]*openapi3.ServerVariable)
+	}
+
+	if _, ok := u.Variables[name]; ok {
+		return ErrVariableCollision
+	}
+
+	u.Variables[name] = &openapi3.ServerVariable{
+		Default: defaultValue,
+	}
+
+	return nil
+}
+
+// ParseServerUrl
+// Url template e.g. "{subdomain:[a-z]+}.example.com" or "api.example.com"
+func ParseServerUrl(url string) (*ServerUrl, error) {
+	var parser serverUrlParser
+	return parser.parse(url)
+}
+
+type serverUrlParser struct {
+	url     string
+	pos     int
+	counter int
+}
+
+type serverVariable struct {
+	name, pattern string
+}
+
+func (p *serverUrlParser) parse(url string) (*ServerUrl, error) {
+	p.url = url
+
+	result := newServerUrl(url)
+
+	var buf []byte
+
+	for p.pos < len(url) {
+		ch := url[p.pos]
+
+		switch ch {
+		case closeCurlyBrace:
+			return nil, ErrUnexpectedCurlyBrace
+
+		case openCurlyBrace:
+			result.UrlNormalized += string(buf)
+			buf = nil
+
+			variable, err := p.extractValueBetweenBraces()
+
+			if err != nil {
+				return nil, err
+			}
+
+			if err = result.addVariable(variable.name, p.nextParamName()); err != nil {
+				return nil, err
+			}
+
+			result.UrlNormalized += string(openCurlyBrace) + variable.name + string(closeCurlyBrace)
+
+		default:
+			buf = append(buf, ch)
+			p.pos++
+		}
+	}
+
+	result.UrlNormalized += string(buf)
+
+	return &result, nil
+}
+
+func (p *serverUrlParser) extractValueBetweenBraces() (serverVariable, error) {
+	if p.url[p.pos] != openCurlyBrace {
+		return serverVariable{}, errUnreachable
+	}
+
+	p.pos++
+	start := p.pos
+
+	for p.pos < len(p.url) {
+		ch := p.url[p.pos]
+
+		switch {
+		case ch == closeCurlyBrace && p.pos == start:
+			return serverVariable{}, ErrEmptyVariableName
+		case ch == closeCurlyBrace:
+			p.pos++
+
+			var contents = p.url[start : p.pos-1]
+			var name = contents
+			var pattern = ""
+
+			if pos := strings.Index(contents, ":"); pos != -1 {
+				name = contents[:pos]
+				pattern = contents[pos+1:]
+			}
+
+			if len(contents) == 0 || len(name) == 0 {
+				return serverVariable{}, ErrEmptyVariableName
+			}
+
+			return serverVariable{
+				name:    name,
+				pattern: pattern,
+			}, nil
+		default:
+			p.pos++
+		}
+	}
+
+	return serverVariable{}, fmt.Errorf("%w: expected closing curly brace at position %d", ErrParse, p.pos)
+}
+
+func (p *serverUrlParser) nextParamName() string {
+	p.counter++
+	return fmt.Sprintf("%s%d", DefaultServerUrlPrefix, p.counter)
+}

--- a/internal/oasutil/servers_test.go
+++ b/internal/oasutil/servers_test.go
@@ -1,0 +1,91 @@
+package oasutil_test
+
+import (
+	"github.com/TykTechnologies/tyk/internal/oasutil"
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestParseServerUrl(t *testing.T) {
+	t.Run("positive test cases", func(t *testing.T) {
+		type testCase struct {
+			name     string
+			input    string
+			expected *oasutil.ServerUrl
+		}
+
+		for _, tCase := range []testCase{
+			{"simple test case", "example.com", &oasutil.ServerUrl{
+				Url:           "example.com",
+				UrlNormalized: "example.com",
+			}},
+			{"complex test case", "https://{subdomain:[a-z]+}.example.com/{version:v[0-9]+}", &oasutil.ServerUrl{
+				Url:           "https://{subdomain:[a-z]+}.example.com/{version:v[0-9]+}",
+				UrlNormalized: "https://{subdomain}.example.com/{version}",
+				Variables: map[string]*openapi3.ServerVariable{
+					"subdomain": {
+						Default: oasutil.DefaultServerUrlPrefix + "1",
+					},
+					"version": {
+						Default: oasutil.DefaultServerUrlPrefix + "2",
+					},
+				},
+			}},
+			{"accepts routes without patterns", "https://{subdomain}.example.com/{version}", &oasutil.ServerUrl{
+				Url:           "https://{subdomain}.example.com/{version}",
+				UrlNormalized: "https://{subdomain}.example.com/{version}",
+				Variables: map[string]*openapi3.ServerVariable{
+					"subdomain": {
+						Default: oasutil.DefaultServerUrlPrefix + "1",
+					},
+					"version": {
+						Default: oasutil.DefaultServerUrlPrefix + "2",
+					},
+				},
+			}},
+			{"one letter variable", "https://example.com/{v}/", &oasutil.ServerUrl{
+				Url:           "https://example.com/{v}/",
+				UrlNormalized: "https://example.com/{v}/",
+				Variables: map[string]*openapi3.ServerVariable{
+					"v": {
+						Default: oasutil.DefaultServerUrlPrefix + "1",
+					},
+				},
+			}},
+			{"parses empty line", "", &oasutil.ServerUrl{
+				Url:           "",
+				UrlNormalized: "",
+				Variables:     nil,
+			}},
+		} {
+			t.Run(tCase.name, func(t *testing.T) {
+				res, err := oasutil.ParseServerUrl(tCase.input)
+				assert.NoError(t, err)
+				assert.Equal(t, tCase.expected, res)
+			})
+		}
+	})
+
+	t.Run("error test cases", func(t *testing.T) {
+		type testCase struct {
+			name        string
+			input       string
+			expectedErr error
+		}
+
+		for _, tCase := range []testCase{
+			{"unexpected curly brace 1", "}example.com", oasutil.ErrUnexpectedCurlyBrace},
+			{"unexpected curly brace 2", "example}.com", oasutil.ErrUnexpectedCurlyBrace},
+			{"empty variable name", "example{}.com", oasutil.ErrEmptyVariableName},
+			{"empty variable name 2", "example{:[a-z]+}.com", oasutil.ErrEmptyVariableName},
+			{"no closed brace", "{example.com", oasutil.ErrParse},
+			{"server variable collision", "{version:[a-z]+}.example.com/{version:[0-9]+}", oasutil.ErrVariableCollision},
+		} {
+			t.Run(tCase.name, func(t *testing.T) {
+				_, err := oasutil.ParseServerUrl(tCase.input)
+				assert.ErrorContains(t, err, tCase.expectedErr.Error())
+			})
+		}
+	})
+}


### PR DESCRIPTION
### **User description**
[TT-11244] Custom domain regex causing problems with servers (#7233)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-11244"
title="TT-11244" target="_blank">TT-11244</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Custom domain regex causing problems with servers</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20codilime_refined%20ORDER%20BY%20created%20DESC"
title="codilime_refined">codilime_refined</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Fixed handling of custom domain regex in OAS server URLs.

- Added robust parsing for server URLs with regex and variables.

- Introduced `RemoveServer` method to remove servers by normalized URL.

- Enhanced and expanded tests for server URL parsing and server
management.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  oasutil["oasutil/servers.go: Server URL parser & helpers"]
  oas["apidef/oas/oas.go: AddServers/RemoveServer logic"]
  oastest["apidef/oas/oas_test.go: AddServers & RemoveServer tests"]
  gateway["gateway/api.go: Integrate AddServers error handling"]
  oasutiltest["internal/oasutil/servers_test.go: Parser unit tests"]

  oasutil -- "used by" --> oas
  oas -- "tested by" --> oastest
  oasutil -- "tested by" --> oasutiltest
  gateway -- "calls" --> oas
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>oas.go</strong><dd><code>Refactor and fix OAS server
URL add/remove logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/oas.go

<ul><li>Added <code>RemoveServer</code> method for removing servers by
normalized URL.<br> <li> Refactored <code>AddServers</code> to use new
server URL parser and handle <br>regex/variables.<br> <li> Updated
<code>AddServers</code> to return errors on invalid input.<br> <li>
Improved handling of server variables and normalization.</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7233/files#diff-80279b1d59499a41a77ff7a16a6e2c9b9b785a4fd1326c351da6884c867658d7">+36/-7</a>&nbsp;
&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>servers.go</strong><dd><code>Add robust OAS server URL
parser utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

internal/oasutil/servers.go

<ul><li>Introduced server URL parser handling regex and variables.<br>
<li> Added error types for parsing issues and collisions.<br> <li>
Provided normalization and variable extraction logic.<br> <li> Exported
<code>ParseServerUrl</code> for external use.</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7233/files#diff-98dd06199bf9992e099563df9150f18cb38094f4dae3299f33c5330722ddac3d">+162/-0</a>&nbsp;
</td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>oas_test.go</strong><dd><code>Expand and improve OAS
server management tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/oas_test.go

<ul><li>Updated <code>TestOAS_AddServers</code> to test new server URL
parsing and <br>normalization.<br> <li> Added
<code>Test_RemoveServer</code> for new removal logic and edge cases.<br>
<li> Improved assertions for server variables and error handling.</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7233/files#diff-74029ee88132d30d6478c96a35f8bb2200e0c8e6f42f2c9b147dc6bb7ce74644">+103/-42</a></td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>servers_test.go</strong><dd><code>Add unit tests for
OAS server URL parser</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; </dd></summary>
<hr>

internal/oasutil/servers_test.go

<ul><li>Added comprehensive unit tests for server URL parser.<br> <li>
Covered positive and negative cases, including regex and
collisions.</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7233/files#diff-4a274e0f05feb520d7ff68fb48a7a28020ea7525820ac8105f4c898854a19af8">+91/-0</a>&nbsp;
&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>api.go</strong><dd><code>Integrate AddServers error
handling in API creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

gateway/api.go

<ul><li>Updated OAS API add handler to handle errors from
<code>AddServers</code>.<br> <li> Returns HTTP 400 if server URL parsing
fails.</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7233/files#diff-644cda3aeb4ac7f325359e85fcddb810f100dd5e6fa480b0d9f9363a743c4e05">+4/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

[TT-11244]: https://tyktech.atlassian.net/browse/TT-11244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Fixed parsing and normalization of OAS server URLs with regex/variables.

- Added robust utility for parsing and managing OAS server URLs.

- Introduced RemoveServer method for removing servers by normalized URL.

- Expanded and improved tests for server URL parsing and server management.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  oasutil["oasutil/servers.go: Server URL parser & helpers"]
  oas["apidef/oas/oas.go: AddServers/RemoveServer logic"]
  oastest["apidef/oas/oas_test.go: AddServers & RemoveServer tests"]
  gateway["gateway/api.go: Integrate AddServers error handling"]
  oasutiltest["internal/oasutil/servers_test.go: Parser unit tests"]

  oasutil -- "used by" --> oas
  oas -- "tested by" --> oastest
  oasutil -- "tested by" --> oasutiltest
  gateway -- "calls" --> oas
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>oas.go</strong><dd><code>Refactor and fix OAS server URL add/remove logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/oas.go

<ul><li>Added RemoveServer method for removing servers by normalized URL.<br> <li> Refactored AddServers to use new server URL parser and handle <br>regex/variables.<br> <li> AddServers now returns errors on invalid input.<br> <li> Improved handling of server variables and normalization.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7260/files#diff-80279b1d59499a41a77ff7a16a6e2c9b9b785a4fd1326c351da6884c867658d7">+36/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>servers.go</strong><dd><code>Add robust OAS server URL parser utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/oasutil/servers.go

<ul><li>Introduced server URL parser handling regex and variables.<br> <li> Added error types for parsing issues and collisions.<br> <li> Provided normalization and variable extraction logic.<br> <li> Exported ParseServerUrl for external use.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7260/files#diff-98dd06199bf9992e099563df9150f18cb38094f4dae3299f33c5330722ddac3d">+162/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>oas_test.go</strong><dd><code>Expand and improve OAS server management tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/oas_test.go

<ul><li>Updated TestOAS_AddServers to test new server URL parsing and <br>normalization.<br> <li> Added Test_RemoveServer for new removal logic and edge cases.<br> <li> Improved assertions for server variables and error handling.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7260/files#diff-74029ee88132d30d6478c96a35f8bb2200e0c8e6f42f2c9b147dc6bb7ce74644">+103/-42</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>servers_test.go</strong><dd><code>Add unit tests for OAS server URL parser</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/oasutil/servers_test.go

<ul><li>Added comprehensive unit tests for server URL parser.<br> <li> Covered positive and negative cases, including regex and collisions.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7260/files#diff-4a274e0f05feb520d7ff68fb48a7a28020ea7525820ac8105f4c898854a19af8">+91/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api.go</strong><dd><code>Integrate AddServers error handling in API creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api.go

<ul><li>Updated OAS API add handler to handle errors from AddServers.<br> <li> Returns HTTP 400 if server URL parsing fails.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7260/files#diff-644cda3aeb4ac7f325359e85fcddb810f100dd5e6fa480b0d9f9363a743c4e05">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

