### PR TITLE
[TT-7524] [OAS] Gateway CE behaves differently from Dashboard for middleware and PATCH

### DIFF
--- a/apidef/oas/default_test.go
+++ b/apidef/oas/default_test.go
@@ -563,6 +563,34 @@ func TestOAS_BuildDefaultTykExtension(t *testing.T) {
 			return operations
 		}
 
+		t.Run("operations not present in new oas paths definition should be removed", func(t *testing.T) {
+			fakeOperationName := "fakeOperation"
+			fakeOperation := &Operation{
+				MockResponse: &MockResponse{
+					Enabled: true,
+				},
+			}
+			oasDef := getOASDef(true, true)
+
+			tykExtensionConfigParams := TykExtensionConfigParams{
+				MockResponse: &trueVal,
+			}
+
+			extension := &XTykAPIGateway{
+				Middleware: &Middleware{
+					Operations: map[string]*Operation{fakeOperationName: fakeOperation},
+				},
+			}
+			oasDef.SetTykExtension(extension)
+			assert.Greater(t, len(oasDef.getTykOperations()), 0)
+
+			expectedOperations := getExpectedOperations(true, true, middlewareMockResponse)
+			err := oasDef.BuildDefaultTykExtension(tykExtensionConfigParams, true)
+
+			assert.NoError(t, err)
+			assert.Equal(t, expectedOperations, oasDef.getTykOperations())
+		})
+
 		t.Run("allowList", func(t *testing.T) {
 			t.Run("enable allowList for all paths when no configured operationID in OAS", func(t *testing.T) {
 				oasDef := getOASDef(false, false)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Updating an API with the PATCH /tyk/apis/oas/{apiId} command via Gateway API does not trigger the Tyk vendor extension (x-tyk-api-gateway) update, which results in the API description being out of sync or invalid.

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
