### PR TITLE
Merging to release-5.8: [TT-14370] [OAS] ReadableDuration converts some values to decimals causing a schema problem (#7256)

### DIFF
--- a/internal/time/duration.go
+++ b/internal/time/duration.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -26,6 +27,15 @@ const (
 	Hour = time.Hour
 )
 
+const (
+	EndingHour        = "h"
+	EndingMinute      = "m"
+	EndingSecond      = "s"
+	EndingMillisecond = "ms"
+	EndingMicrosecond = "µs"
+	EndingNanosecond  = "ns"
+)
+
 // ReadableDuration is a type alias for time.Duration, so that shorthand notation can be used.
 // Examples of valid shorthand notations:
 // - "1h"   : one hour
@@ -41,7 +51,7 @@ type ReadableDuration time.Duration
 
 // MarshalJSON converts ReadableDuration into human-readable shorthand notation for time.Duration into json format.
 func (d ReadableDuration) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf(`"%s"`, time.Duration(d).String())), nil
+	return []byte(fmt.Sprintf(`"%s"`, d.format())), nil
 }
 
 // UnmarshalJSON converts human-readable shorthand notation for time.Duration into ReadableDuration from json format.
@@ -81,4 +91,51 @@ func (d ReadableDuration) Nanoseconds() int64 {
 // Microseconds returns ReadableDuration in microseconds.
 func (d ReadableDuration) Microseconds() int64 {
 	return Duration(d).Microseconds()
+}
+
+// formats time duration dur to validation pattern ^(\d+h)?(\d+m)?(\d+s)?(\d+ms)?(\d+µs)?(\d+ns)%
+func (d ReadableDuration) format() string {
+	if d == 0 {
+		return "0s"
+	}
+
+	var sb strings.Builder
+	var rest = int64(d)
+
+	if rest < 0 {
+		rest *= -1
+		sb.WriteByte('-')
+	}
+
+	for _, conv := range convertCases {
+		if rest == 0 {
+			break
+		}
+
+		curr := rest / int64(conv.duration)
+		rest -= curr * int64(conv.duration)
+
+		if curr == 0 {
+			continue
+		}
+
+		sb.WriteString(strconv.FormatInt(curr, 10))
+		sb.WriteString(conv.ending)
+	}
+
+	return sb.String()
+}
+
+type convertCase struct {
+	duration time.Duration
+	ending   string
+}
+
+var convertCases = []convertCase{
+	{time.Hour, EndingHour},
+	{time.Minute, EndingMinute},
+	{time.Second, EndingSecond},
+	{time.Millisecond, EndingMillisecond},
+	{time.Microsecond, EndingMicrosecond},
+	{time.Nanosecond, EndingNanosecond},
 }

--- a/internal/time/duration_test.go
+++ b/internal/time/duration_test.go
@@ -13,7 +13,7 @@ func TestReadableDuration_MarshalJSON(t *testing.T) {
 
 	t.Run("valid", func(t *testing.T) {
 		duration := ReadableDuration(time.Minute * 5)
-		expectedJSON := []byte(`"5m0s"`)
+		expectedJSON := []byte(`"5m"`)
 		resultJSON, err := json.Marshal(&duration)
 		assert.NoError(t, err)
 		assert.Equal(t, string(expectedJSON), string(resultJSON))
@@ -33,6 +33,27 @@ func TestReadableDuration_MarshalJSON(t *testing.T) {
 		resultJSON, err := json.Marshal(&duration)
 		assert.NoError(t, err)
 		assert.Equal(t, string(expectedJSON), string(resultJSON))
+	})
+
+	t.Run("90 seconds", func(t *testing.T) {
+		duration := ReadableDuration(time.Second * 90)
+		expectedJSON := []byte(`"1m30s"`)
+		resultJSON, err := json.Marshal(&duration)
+		assert.NoError(t, err)
+		assert.Equal(t, string(expectedJSON), string(resultJSON))
+	})
+
+	t.Run("complex duration", func(t *testing.T) {
+		duration := ReadableDuration(1*time.Hour + 2*time.Minute + 3*time.Second + 4*time.Millisecond + 5*time.Microsecond + 6*time.Nanosecond)
+		assert.Equal(t, "1h2m3s4ms5µs6ns", duration.format())
+
+		duration = ReadableDuration(1*time.Hour + (2+60)*time.Minute + 3*time.Second + 4*time.Millisecond + 5*time.Microsecond + 6*time.Nanosecond)
+		assert.Equal(t, "2h2m3s4ms5µs6ns", duration.format())
+	})
+
+	t.Run("negative duration", func(t *testing.T) {
+		duration := ReadableDuration(-1 * time.Second * 90)
+		assert.Equal(t, "-1m30s", duration.format())
 	})
 }
 


### PR DESCRIPTION
### **User description**
[TT-14370] [OAS] ReadableDuration converts some values to decimals causing a schema problem (#7256)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-14370"
title="TT-14370" target="_blank">TT-14370</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
<td>[OAS] ReadableDuration converts some values to decimals causing a
schema problem</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20codilime_refined%20ORDER%20BY%20created%20DESC"
title="codilime_refined">codilime_refined</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixes duration serialization to avoid decimal values in JSON.

- Implements custom formatting for `ReadableDuration` output.

- Adds new test cases for composite durations (e.g., "1m30s").

- Updates expected JSON outputs in tests for consistency.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  durationGo["duration.go: Add custom format for ReadableDuration"] -- "uses" --> durationTestGo["duration_test.go: Update & add tests for new format"]
  durationGo -- "fixes" --> "JSON serialization issue"
  durationTestGo -- "validates" --> "Correct output for various durations"
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>duration.go</strong><dd><code>Custom formatting for
ReadableDuration JSON serialization</code></dd></summary>
<hr>

internal/time/duration.go

<ul><li>Adds a custom <code>format()</code> method for
<code>ReadableDuration</code>.<br> <li> Ensures JSON serialization
outputs only integer values and valid <br>patterns.<br> <li> Introduces
constants and a conversion table for time units.<br> <li> Refactors
<code>MarshalJSON</code> to use the new formatting logic.</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7256/files#diff-6e8ef3118f84cbcc935f27d5a3ad5f4eb86eb22728400e9322c9b796b9d8d855">+53/-1</a>&nbsp;
&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>duration_test.go</strong><dd><code>Update and expand
tests for duration serialization</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/time/duration_test.go

<ul><li>Updates expected JSON output for minute-based durations.<br>
<li> Adds new test for composite durations (e.g., "1m30s").<br> <li>
Ensures tests align with new serialization logic.</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7256/files#diff-71942cdc77128266498b62e712f82d0c63bbb39d236fe9e6677f49080c28cea1">+9/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

[TT-14370]: https://tyktech.atlassian.net/browse/TT-14370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixes JSON serialization of `ReadableDuration` to avoid decimals.

- Implements custom formatting for duration string output.

- Adds and updates tests for composite and negative durations.

- Ensures output matches expected human-readable patterns.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  durationGo["duration.go: Add custom format for ReadableDuration"]
  durationTestGo["duration_test.go: Update & add tests for new format"]
  jsonSerialization["JSON serialization issue"]
  testValidation["Correct output for various durations"]

  durationGo -- "uses" --> durationTestGo
  durationGo -- "fixes" --> jsonSerialization
  durationTestGo -- "validates" --> testValidation
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>duration.go</strong><dd><code>Custom formatting for ReadableDuration JSON serialization</code></dd></summary>
<hr>

internal/time/duration.go

<ul><li>Adds custom <code>format()</code> method for <code>ReadableDuration</code>.<br> <li> Refactors <code>MarshalJSON</code> to use new formatting logic.<br> <li> Introduces constants and conversion table for time units.<br> <li> Ensures serialization outputs only integer values and valid patterns.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7263/files#diff-6e8ef3118f84cbcc935f27d5a3ad5f4eb86eb22728400e9322c9b796b9d8d855">+58/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>duration_test.go</strong><dd><code>Update and expand tests for duration serialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/time/duration_test.go

<ul><li>Updates expected JSON output for minute-based durations.<br> <li> Adds tests for composite and negative durations.<br> <li> Ensures tests align with new serialization logic.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7263/files#diff-71942cdc77128266498b62e712f82d0c63bbb39d236fe9e6677f49080c28cea1">+22/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

