### PR TITLE
[TT-15488] reverted /hello endpoint to old way of working and fixed liveness endpoint logic

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -48,6 +48,7 @@ var (
 		},
 		HealthCheckEndpointName:    "hello",
 		ReadinessCheckEndpointName: "ready",
+		LivenessCheckEndpointName:  "live",
 		CoProcessOptions: CoProcessConfig{
 			EnableCoProcess: false,
 		},
@@ -940,6 +941,10 @@ type Config struct {
 	// ReadinessCheckEndpointName Enables you to change the readiness endpoint
 	// Default is "/ready"
 	ReadinessCheckEndpointName string `json:"readiness_check_endpoint_name"`
+
+	// LivenessCheckEndpointName Enables you to change the liveness endpoint
+	// Default is "/live"
+	LivenessCheckEndpointName string `json:"liveness_check_endpoint_name"`
 
 	// GracefulShutdownTimeoutDuration sets how many seconds the gateway should wait for an existing connection
 	//to finish before shutting down the server. Defaults to 30 seconds.

--- a/gateway/health_check_test.go
+++ b/gateway/health_check_test.go
@@ -710,6 +710,498 @@ func TestGateway_evaluateHealthChecks(t *testing.T) {
 	}
 }
 
+func TestGateway_helloHandler(t *testing.T) {
+	tests := []struct {
+		name                   string
+		method                 string
+		setupGateway           func(*Gateway)
+		setupHealthCheck       func(*Gateway)
+		expectedStatus         int
+		expectedResponseStatus HealthCheckStatus
+		expectedErrorMessage   string
+	}{
+		{
+			name:                 "method not allowed - POST",
+			method:               http.MethodPost,
+			setupGateway:         func(_ *Gateway) {},
+			setupHealthCheck:     func(_ *Gateway) {},
+			expectedStatus:       http.StatusMethodNotAllowed,
+			expectedErrorMessage: "Method Not Allowed",
+		},
+		{
+			name:                 "method not allowed - PUT",
+			method:               http.MethodPut,
+			setupGateway:         func(_ *Gateway) {},
+			setupHealthCheck:     func(_ *Gateway) {},
+			expectedStatus:       http.StatusMethodNotAllowed,
+			expectedErrorMessage: "Method Not Allowed",
+		},
+		{
+			name:   "always returns 200 OK even with redis failure",
+			method: http.MethodGet,
+			setupGateway: func(_ *Gateway) {
+				// No special setup needed
+			},
+			setupHealthCheck: func(gw *Gateway) {
+				// Set up health check with failed redis
+				healthInfo := map[string]HealthCheckItem{
+					"redis": {
+						Status:        Fail,
+						ComponentType: Datastore,
+						Output:        "Connection failed",
+					},
+				}
+				gw.setCurrentHealthCheckInfo(healthInfo)
+			},
+			expectedStatus:         http.StatusOK,
+			expectedResponseStatus: Fail,
+		},
+		{
+			name:   "returns 200 OK with all checks passing",
+			method: http.MethodGet,
+			setupGateway: func(_ *Gateway) {
+				// No special setup needed
+			},
+			setupHealthCheck: func(gw *Gateway) {
+				// Set up health check with all passing
+				healthInfo := map[string]HealthCheckItem{
+					"redis": {
+						Status:        Pass,
+						ComponentType: Datastore,
+					},
+					"dashboard": {
+						Status:        Pass,
+						ComponentType: System,
+					},
+				}
+				gw.setCurrentHealthCheckInfo(healthInfo)
+			},
+			expectedStatus:         http.StatusOK,
+			expectedResponseStatus: Pass,
+		},
+		{
+			name:   "returns 200 OK with mixed status - warning",
+			method: http.MethodGet,
+			setupGateway: func(_ *Gateway) {
+				// No special setup needed
+			},
+			setupHealthCheck: func(gw *Gateway) {
+				// Set up health check with mixed results
+				healthInfo := map[string]HealthCheckItem{
+					"redis": {
+						Status:        Pass,
+						ComponentType: Datastore,
+					},
+					"dashboard": {
+						Status:        Fail,
+						ComponentType: System,
+					},
+					"custom": {
+						Status:        Pass,
+						ComponentType: System,
+					},
+				}
+				gw.setCurrentHealthCheckInfo(healthInfo)
+			},
+			expectedStatus:         http.StatusOK,
+			expectedResponseStatus: Warn,
+		},
+		{
+			name:   "returns 200 OK with all checks failing",
+			method: http.MethodGet,
+			setupGateway: func(_ *Gateway) {
+				// No special setup needed
+			},
+			setupHealthCheck: func(gw *Gateway) {
+				// Set up health check with all failing
+				healthInfo := map[string]HealthCheckItem{
+					"redis": {
+						Status:        Fail,
+						ComponentType: Datastore,
+						Output:        "Redis connection failed",
+					},
+					"dashboard": {
+						Status:        Fail,
+						ComponentType: System,
+						Output:        "Dashboard service unavailable",
+					},
+				}
+				gw.setCurrentHealthCheckInfo(healthInfo)
+			},
+			expectedStatus:         http.StatusOK,
+			expectedResponseStatus: Fail,
+		},
+		{
+			name:   "hide generator header enabled",
+			method: http.MethodGet,
+			setupGateway: func(gw *Gateway) {
+				// Enable HideGeneratorHeader
+				conf := gw.GetConfig()
+				conf.HideGeneratorHeader = true
+				gw.SetConfig(conf)
+			},
+			setupHealthCheck: func(gw *Gateway) {
+				// Set up health check with passing redis
+				healthInfo := map[string]HealthCheckItem{
+					"redis": {
+						Status:        Pass,
+						ComponentType: Datastore,
+					},
+				}
+				gw.setCurrentHealthCheckInfo(healthInfo)
+			},
+			expectedStatus:         http.StatusOK,
+			expectedResponseStatus: Pass,
+		},
+		{
+			name:   "empty health check info",
+			method: http.MethodGet,
+			setupGateway: func(_ *Gateway) {
+				// No special setup needed
+			},
+			setupHealthCheck: func(gw *Gateway) {
+				// No health check data
+				gw.setCurrentHealthCheckInfo(map[string]HealthCheckItem{})
+			},
+			expectedStatus:         http.StatusOK,
+			expectedResponseStatus: Pass, // Pass when no checks present
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a new gateway instance for each test
+			gw := NewGateway(config.Config{}, nil)
+
+			// Apply test-specific setup
+			tt.setupGateway(gw)
+			tt.setupHealthCheck(gw)
+
+			// Create request
+			req := httptest.NewRequest(tt.method, "/hello", nil)
+			w := httptest.NewRecorder()
+
+			// Call the handler
+			gw.helloHandler(w, req)
+
+			// Check status code - hello always returns 200 except for method not allowed
+			assert.Equal(t, tt.expectedStatus, w.Code)
+
+			// Check content type
+			if w.Code != http.StatusMethodNotAllowed {
+				assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+			}
+
+			// Check response body
+			if tt.expectedStatus == http.StatusOK {
+				var response HealthCheckResponse
+				err := json.Unmarshal(w.Body.Bytes(), &response)
+				require.NoError(t, err)
+
+				assert.Equal(t, tt.expectedResponseStatus, response.Status)
+				assert.Equal(t, VERSION, response.Version)
+				assert.Equal(t, "Tyk GW", response.Description)
+				// Details field is expected to be present (can be empty map or nil)
+				if response.Details == nil {
+					assert.Nil(t, response.Details)
+				} else {
+					assert.NotNil(t, response.Details)
+				}
+			} else if tt.expectedStatus == http.StatusMethodNotAllowed {
+				var errorResponse apiStatusMessage
+				err := json.Unmarshal(w.Body.Bytes(), &errorResponse)
+				require.NoError(t, err)
+
+				assert.Equal(t, "error", errorResponse.Status)
+				assert.Equal(t, tt.expectedErrorMessage, errorResponse.Message)
+			}
+		})
+	}
+}
+
+func TestGateway_liveCheckHandler(t *testing.T) {
+	tests := []struct {
+		name                   string
+		method                 string
+		setupGateway           func(*Gateway)
+		setupHealthCheck       func(*Gateway)
+		expectedStatus         int
+		expectedResponseStatus HealthCheckStatus
+		expectedErrorMessage   string
+	}{
+		{
+			name:                 "method not allowed - POST",
+			method:               http.MethodPost,
+			setupGateway:         func(_ *Gateway) {},
+			setupHealthCheck:     func(_ *Gateway) {},
+			expectedStatus:       http.StatusMethodNotAllowed,
+			expectedErrorMessage: "Method Not Allowed",
+		},
+		{
+			name:                 "method not allowed - PUT",
+			method:               http.MethodPut,
+			setupGateway:         func(_ *Gateway) {},
+			setupHealthCheck:     func(_ *Gateway) {},
+			expectedStatus:       http.StatusMethodNotAllowed,
+			expectedErrorMessage: "Method Not Allowed",
+		},
+		{
+			name:   "all checks passing - returns 200",
+			method: http.MethodGet,
+			setupGateway: func(_ *Gateway) {
+				// No special setup needed
+			},
+			setupHealthCheck: func(gw *Gateway) {
+				// Set up health check with all passing
+				healthInfo := map[string]HealthCheckItem{
+					"redis": {
+						Status:        Pass,
+						ComponentType: Datastore,
+					},
+					"dashboard": {
+						Status:        Pass,
+						ComponentType: System,
+					},
+				}
+				gw.setCurrentHealthCheckInfo(healthInfo)
+			},
+			expectedStatus:         http.StatusOK,
+			expectedResponseStatus: Pass,
+		},
+		{
+			name:   "partial non-critical failures - returns 200 with warning",
+			method: http.MethodGet,
+			setupGateway: func(gw *Gateway) {
+				// Disable UseDBAppConfigs to make dashboard non-critical
+				conf := gw.GetConfig()
+				conf.UseDBAppConfigs = false
+				gw.SetConfig(conf)
+			},
+			setupHealthCheck: func(gw *Gateway) {
+				// Set up health check with mixed results
+				healthInfo := map[string]HealthCheckItem{
+					"redis": {
+						Status:        Pass,
+						ComponentType: Datastore,
+					},
+					"dashboard": {
+						Status:        Fail,
+						ComponentType: System,
+						Output:        "Dashboard service unavailable",
+					},
+					"custom": {
+						Status:        Pass,
+						ComponentType: System,
+					},
+				}
+				gw.setCurrentHealthCheckInfo(healthInfo)
+			},
+			expectedStatus:         http.StatusOK,
+			expectedResponseStatus: Warn,
+		},
+		{
+			name:   "all checks failing - returns 200 with fail status",
+			method: http.MethodGet,
+			setupGateway: func(_ *Gateway) {
+				// No special setup needed
+			},
+			setupHealthCheck: func(gw *Gateway) {
+				// Set up health check with all failing
+				healthInfo := map[string]HealthCheckItem{
+					"redis": {
+						Status:        Fail,
+						ComponentType: Datastore,
+						Output:        "Redis connection failed",
+					},
+					"dashboard": {
+						Status:        Fail,
+						ComponentType: System,
+						Output:        "Dashboard service unavailable",
+					},
+				}
+				gw.setCurrentHealthCheckInfo(healthInfo)
+			},
+			expectedStatus:         http.StatusOK,
+			expectedResponseStatus: Fail,
+		},
+		{
+			name:   "hide generator header enabled",
+			method: http.MethodGet,
+			setupGateway: func(gw *Gateway) {
+				// Enable HideGeneratorHeader
+				conf := gw.GetConfig()
+				conf.HideGeneratorHeader = true
+				gw.SetConfig(conf)
+			},
+			setupHealthCheck: func(gw *Gateway) {
+				// Set up health check with passing redis
+				healthInfo := map[string]HealthCheckItem{
+					"redis": {
+						Status:        Pass,
+						ComponentType: Datastore,
+					},
+				}
+				gw.setCurrentHealthCheckInfo(healthInfo)
+			},
+			expectedStatus:         http.StatusOK,
+			expectedResponseStatus: Pass,
+		},
+		{
+			name:   "empty health check info",
+			method: http.MethodGet,
+			setupGateway: func(_ *Gateway) {
+				// No special setup needed
+			},
+			setupHealthCheck: func(gw *Gateway) {
+				// No health check data
+				gw.setCurrentHealthCheckInfo(map[string]HealthCheckItem{})
+			},
+			expectedStatus:         http.StatusOK,
+			expectedResponseStatus: Pass, // Pass when no checks present
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a new gateway instance for each test
+			gw := NewGateway(config.Config{}, nil)
+
+			// Apply test-specific setup
+			tt.setupGateway(gw)
+			tt.setupHealthCheck(gw)
+
+			// Create request
+			req := httptest.NewRequest(tt.method, "/live", nil)
+			w := httptest.NewRecorder()
+
+			// Call the handler
+			gw.liveCheckHandler(w, req)
+
+			// Check status code - live check always returns 200 (original behavior)
+			assert.Equal(t, tt.expectedStatus, w.Code)
+
+			// Check content type
+			if w.Code != http.StatusMethodNotAllowed {
+				assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+			}
+
+			// Check response body
+			if tt.expectedStatus == http.StatusOK {
+				var response HealthCheckResponse
+				err := json.Unmarshal(w.Body.Bytes(), &response)
+				require.NoError(t, err)
+
+				assert.Equal(t, tt.expectedResponseStatus, response.Status)
+				assert.Equal(t, VERSION, response.Version)
+				assert.Equal(t, "Tyk GW", response.Description)
+				// Details field is expected to be present (can be empty map or nil)
+				if response.Details == nil {
+					assert.Nil(t, response.Details)
+				} else {
+					assert.NotNil(t, response.Details)
+				}
+			} else if tt.expectedStatus == http.StatusMethodNotAllowed {
+				var errorResponse apiStatusMessage
+				err := json.Unmarshal(w.Body.Bytes(), &errorResponse)
+				require.NoError(t, err)
+
+				assert.Equal(t, "error", errorResponse.Status)
+				assert.Equal(t, tt.expectedErrorMessage, errorResponse.Message)
+			}
+		})
+	}
+}
+
+func TestGateway_helloHandler_Integration(t *testing.T) {
+	// Integration test using the actual test framework
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	t.Run("hello endpoint responds correctly", func(t *testing.T) {
+		// Test with a working gateway - use the configured hello endpoint name
+		helloPath := "/" + ts.Gw.GetConfig().HealthCheckEndpointName
+		resp, err := http.Get(ts.URL + helloPath)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+		var response HealthCheckResponse
+		err = json.NewDecoder(resp.Body).Decode(&response)
+		require.NoError(t, err)
+
+		assert.Equal(t, VERSION, response.Version)
+		assert.Equal(t, "Tyk GW", response.Description)
+		// Status will be pass/warn/fail based on actual health checks, but always 200 status code
+		assert.Contains(t, []HealthCheckStatus{Pass, Warn, Fail}, response.Status)
+	})
+
+	t.Run("method not allowed", func(t *testing.T) {
+		helloPath := "/" + ts.Gw.GetConfig().HealthCheckEndpointName
+		req, err := http.NewRequest(http.MethodPost, ts.URL+helloPath, nil)
+		require.NoError(t, err)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+
+		var errorResponse apiStatusMessage
+		err = json.NewDecoder(resp.Body).Decode(&errorResponse)
+		require.NoError(t, err)
+
+		assert.Equal(t, "error", errorResponse.Status)
+		assert.Equal(t, "Method Not Allowed", errorResponse.Message)
+	})
+}
+
+func TestGateway_liveCheckHandler_Integration(t *testing.T) {
+	// Integration test using the actual test framework
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	t.Run("live endpoint responds correctly", func(t *testing.T) {
+		// Test with a working gateway - use the configured live endpoint name
+		livePath := "/" + ts.Gw.GetConfig().LivenessCheckEndpointName
+		resp, err := http.Get(ts.URL + livePath)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+		var response HealthCheckResponse
+		err = json.NewDecoder(resp.Body).Decode(&response)
+		require.NoError(t, err)
+
+		assert.Equal(t, VERSION, response.Version)
+		assert.Equal(t, "Tyk GW", response.Description)
+		// Status will be pass/warn/fail based on actual health checks, always 200 status code
+		assert.Contains(t, []HealthCheckStatus{Pass, Warn, Fail}, response.Status)
+	})
+
+	t.Run("method not allowed", func(t *testing.T) {
+		livePath := "/" + ts.Gw.GetConfig().LivenessCheckEndpointName
+		req, err := http.NewRequest(http.MethodPost, ts.URL+livePath, nil)
+		require.NoError(t, err)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+
+		var errorResponse apiStatusMessage
+		err = json.NewDecoder(resp.Body).Decode(&errorResponse)
+		require.NoError(t, err)
+
+		assert.Equal(t, "error", errorResponse.Status)
+		assert.Equal(t, "Method Not Allowed", errorResponse.Message)
+	})
+}
+
 func TestGateway_determineHealthStatus(t *testing.T) {
 	tests := []struct {
 		name               string

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -683,8 +683,9 @@ func (gw *Gateway) loadControlAPIEndpoints(muxer *mux.Router) {
 		}
 	}
 
-	muxer.HandleFunc("/"+gw.GetConfig().HealthCheckEndpointName, gw.liveCheckHandler)
+	muxer.HandleFunc("/"+gw.GetConfig().HealthCheckEndpointName, gw.helloHandler)
 	muxer.HandleFunc("/"+gw.GetConfig().ReadinessCheckEndpointName, gw.readinessHandler)
+	muxer.HandleFunc("/"+gw.GetConfig().LivenessCheckEndpointName, gw.liveCheckHandler)
 
 	r := mux.NewRouter()
 	muxer.PathPrefix("/tyk/").Handler(http.StripPrefix("/tyk",
@@ -1560,6 +1561,10 @@ func (gw *Gateway) afterConfSetup() {
 
 	if conf.ReadinessCheckEndpointName == "" {
 		conf.ReadinessCheckEndpointName = "ready"
+	}
+
+	if conf.LivenessCheckEndpointName == "" {
+		conf.LivenessCheckEndpointName = "live"
 	}
 
 	var err error


### PR DESCRIPTION
 Description

  This PR introduces a new /live liveness endpoint and updates the gateway's health check behavior to better handle Redis failures. The key changes include:

  - Added a new dedicated /live endpoint for Kubernetes liveness probes that treats Redis as non-critical
  - Reverted the /hello endpoint to its original behavior of always returning 200 OK with detailed health information
  - Updated health check logic to differentiate between critical and non-critical failures for liveness checks
  - Added comprehensive test coverage for the new liveness functionality
  - Updated Go version to 1.24 across all workflows and build configurations

  Related Issue

  TT-15488 - Unexpected change in treatment of Redis being down by the gateway liveness endpoint

  Motivation and Context

  The original /hello endpoint was modified to return 5xx status codes when Redis was down, which caused issues with Kubernetes liveness probes. This change was problematic because:

  1. Redis failures don't necessarily mean the gateway can't serve requests if APIs/policies are already loaded in memory
  2. Kubernetes liveness probes would restart healthy gateway pods when Redis was temporarily unavailable
  3. This behavior was inconsistent with how other non-critical components were handled

  This PR addresses these issues by:
  - Creating a dedicated liveness endpoint that treats Redis as non-critical
  - Preserving backward compatibility by reverting /hello to its original behavior
  - Providing better separation of concerns between different health check use cases

  How This Has Been Tested

  - Added comprehensive unit tests for the new liveness health check logic in gateway/health_check_test.go:779
  - Tests cover various scenarios including Redis failures, dashboard failures, and RPC failures
  - Verified that the /live endpoint returns 200 OK when Redis is down but other critical components are healthy
  - Confirmed that the /hello endpoint maintains its original behavior of always returning 200 OK
  - All existing health check tests continue to pass

  Screenshots (if appropriate)

  N/A

  Types of changes

  - New feature (non-breaking change which adds functionality)
  - Bug fix (non-breaking change which fixes an issue)
  - Breaking change (fix or feature that would cause existing functionality to change)
  - Refactoring or add test (improvements in base code or adds test coverage to functionality)
