### PR TITLE
[TT-15507] Reverting /hello endpoint to always return 200 status code

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 /tyk
 /Dockerfile
+/go.work
+/go.work.sum

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ testapps/
 /*.bak
 /.air.toml
 
+/go.work
+/go.work.sum
+
 
 /tyk
 logs/

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ testapps/
 /*.json
 /*.bak
 /.air.toml
+/go.work
+/go.work.sum
 
 /go.work
 /go.work.sum

--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -118,7 +118,7 @@ const (
 	CoprocessType = "coprocess"
 	OAuthType     = "oauth"
 	// ExternalOAuthType holds configuration for an external OAuth provider.
-	// Deprecated: ExternalOAuth support has been deprecated from 5.7.0.
+	// Deprecated: ExternalOAuth support was deprecated in Tyk 5.7.0.
 	// To avoid any disruptions, we recommend that you use JSON Web Token (JWT) instead,
 	// as explained in https://tyk.io/docs/basic-config-and-security/security/authentication-authorization/ext-oauth-middleware/.
 	ExternalOAuthType = "externalOAuth"

--- a/apidef/oas/builder.go
+++ b/apidef/oas/builder.go
@@ -199,12 +199,41 @@ func WithDelete(path string, fn EndpointFactory) BuilderOption {
 	return withEndpoint(http.MethodDelete, path, fn)
 }
 
+// RateLimit adds rate limit middleware to current endpoint.
 func (eb *EndpointBuilder) RateLimit(amount uint, duration time.Duration, enabled ...bool) *EndpointBuilder {
 	if rl, err := newRateLimit(amount, duration, enabled...); err != nil {
 		eb.errors = append(eb.errors, err)
 	} else {
 		eb.operation().RateLimit = (*RateLimitEndpoint)(rl)
 	}
+
+	return eb
+}
+
+// TransformResponseHeaders adds TransformResponseHeaders middleware to current endpoint.
+func (eb *EndpointBuilder) TransformResponseHeaders(factory func(*TransformHeaders)) *EndpointBuilder {
+	op := eb.operation().TransformResponseHeaders
+
+	if op == nil {
+		op = &TransformHeaders{Enabled: true}
+		eb.operation().TransformResponseHeaders = op
+	}
+
+	factory(op)
+
+	return eb
+}
+
+// TransformResponseBody adds TransformResponseBody middleware to current endpoint.
+func (eb *EndpointBuilder) TransformResponseBody(factory func(*TransformBody)) *EndpointBuilder {
+	op := eb.operation().TransformResponseBody
+
+	if op == nil {
+		op = &TransformBody{Enabled: true}
+		eb.operation().TransformResponseBody = op
+	}
+
+	factory(op)
 
 	return eb
 }

--- a/apidef/oas/header.go
+++ b/apidef/oas/header.go
@@ -14,13 +14,22 @@ type Header struct {
 type Headers []Header
 
 // Map transforms Headers into a map.
-func (hs Headers) Map() map[string]string {
-	var headersMap = make(map[string]string, len(hs))
-	for _, h := range hs {
+func (hs *Headers) Map() map[string]string {
+	if hs == nil {
+		return map[string]string{}
+	}
+
+	var headersMap = make(map[string]string, len(*hs))
+	for _, h := range *hs {
 		headersMap[h.Name] = h.Value
 	}
 
 	return headersMap
+}
+
+// Add new header entry.
+func (hs *Headers) Add(hdr, value string) {
+	*hs = append(*hs, Header{Name: hdr, Value: value})
 }
 
 // NewHeaders creates Headers from in map.

--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -1178,6 +1178,11 @@ type TransformHeaders struct {
 	Add Headers `bson:"add,omitempty" json:"add,omitempty"`
 }
 
+// AppendAddOp appends add operation to TransformHeaders middleware.
+func (th *TransformHeaders) AppendAddOp(name, value string) {
+	th.Add = append(th.Add, Header{Name: name, Value: value})
+}
+
 // Fill fills *TransformHeaders from apidef.HeaderInjectionMeta.
 func (th *TransformHeaders) Fill(meta apidef.HeaderInjectionMeta) {
 	th.Enabled = !meta.Disabled

--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -1811,7 +1811,7 @@ func (g *GlobalRequestSizeLimit) ExtractTo(api *apidef.APIDefinition) {
 
 // ContextVariables holds the configuration related to Tyk context variables.
 type ContextVariables struct {
-	// Enabled enables context variables to be passed to Tyk middlewares.
+	// Enabled makes context variables available in selected middleware (URL rewrite, header transform, body transform).
 	//
 	// Tyk classic API definition: `enable_context_vars`.
 	Enabled bool `json:"enabled" bson:"enabled"`

--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -1811,7 +1811,7 @@ func (g *GlobalRequestSizeLimit) ExtractTo(api *apidef.APIDefinition) {
 
 // ContextVariables holds the configuration related to Tyk context variables.
 type ContextVariables struct {
-	// Enabled makes context variables available in selected middleware (URL rewrite, header transform, body transform).
+	// Enabled provides access to context variables from specific Tyk middleware (URL rewrite, header and body transform).
 	//
 	// Tyk classic API definition: `enable_context_vars`.
 	Enabled bool `json:"enabled" bson:"enabled"`

--- a/apidef/oas/oas.go
+++ b/apidef/oas/oas.go
@@ -5,11 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/samber/lo"
 	"strings"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/internal/oasutil"
 	"github.com/TykTechnologies/tyk/internal/reflect"
+
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
@@ -340,28 +343,53 @@ func (s *OAS) getTykOperations() (operations Operations) {
 	return
 }
 
+// RemoveServer removes the server from the server list if it's already present.
+// It accepts regex-based server URLs, such as https://{subdomain:[a-z]+}.example.com/{version}
+func (s *OAS) RemoveServer(serverUrl string) error {
+	if len(serverUrl) == 0 {
+		return nil
+	}
+
+	parsed, err := oasutil.ParseServerUrl(serverUrl)
+
+	if err != nil {
+		return err
+	}
+
+	s.Servers = lo.Filter(s.Servers, func(server *openapi3.Server, _ int) bool {
+		return server.URL != parsed.UrlNormalized
+	})
+
+	return nil
+}
+
 // AddServers adds a server into the servers definition if not already present.
-func (s *OAS) AddServers(apiURLs ...string) {
+func (s *OAS) AddServers(apiURLs ...string) error {
 	apiURLSet := make(map[string]struct{})
-	newServers := openapi3.Servers{}
+	var newServers openapi3.Servers
+
 	for _, apiURL := range apiURLs {
-		if strings.Contains(apiURL, "{") && strings.Contains(apiURL, "}") {
-			continue
+		serverUrl, err := oasutil.ParseServerUrl(apiURL)
+
+		if err != nil {
+			return err
 		}
 
 		newServers = append(newServers, &openapi3.Server{
-			URL: apiURL,
+			URL:       serverUrl.UrlNormalized,
+			Variables: serverUrl.Variables,
 		})
+
 		apiURLSet[apiURL] = struct{}{}
 	}
 
 	if len(newServers) == 0 {
-		return
+		return nil
 	}
 
 	if len(s.Servers) == 0 {
 		s.Servers = newServers
-		return
+		return nil
 	}
 
 	// check if apiURL already exists in servers object
@@ -374,6 +402,7 @@ func (s *OAS) AddServers(apiURLs ...string) {
 	}
 
 	s.Servers = newServers
+	return nil
 }
 
 // UpdateServers sets or updates the first servers URL if it matches oldAPIURL.

--- a/apidef/oas/oas_test.go
+++ b/apidef/oas/oas_test.go
@@ -7,16 +7,14 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/oasdiff/yaml"
-
 	"github.com/TykTechnologies/storage/persistent/model"
-
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/internal/event"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/yaml"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestOAS(t *testing.T) {
@@ -309,23 +307,32 @@ func TestOAS_AddServers(t *testing.T) {
 	type args struct {
 		apiURLs []string
 	}
+
 	tests := []struct {
-		name         string
-		fields       fields
-		args         args
-		expectedURLs []string
+		name            string
+		fields          fields
+		args            args
+		expectedServers openapi3.Servers
 	}{
 		{
-			name:         "empty servers",
-			fields:       fields{T: openapi3.T{}},
-			args:         args{apiURLs: []string{"http://127.0.0.1:8080/api"}},
-			expectedURLs: []string{"http://127.0.0.1:8080/api"},
+			name:   "empty servers",
+			fields: fields{T: openapi3.T{}},
+			args:   args{apiURLs: []string{"http://127.0.0.1:8080/api"}},
+			expectedServers: openapi3.Servers{
+				{URL: "http://127.0.0.1:8080/api"},
+			},
 		},
 		{
-			name:         "empty servers and named parameters",
-			fields:       fields{T: openapi3.T{}},
-			args:         args{apiURLs: []string{"http://{subdomain}/api"}},
-			expectedURLs: nil,
+			name:   "empty servers and named parameters with regex",
+			fields: fields{T: openapi3.T{}},
+			args:   args{apiURLs: []string{"http://{subdomain:[a-z]+}/api"}},
+			expectedServers: openapi3.Servers{
+				{URL: "http://{subdomain}/api", Variables: map[string]*openapi3.ServerVariable{
+					"subdomain": {
+						Default: "pathParam1",
+					},
+				}},
+			},
 		},
 		{
 			name: "non-empty servers",
@@ -336,8 +343,11 @@ func TestOAS_AddServers(t *testing.T) {
 					},
 				},
 			}},
-			args:         args{apiURLs: []string{"http://127.0.0.1:8080/api"}},
-			expectedURLs: []string{"http://127.0.0.1:8080/api", "http://example-upstream.org/api"},
+			args: args{apiURLs: []string{"http://127.0.0.1:8080/api"}},
+			expectedServers: openapi3.Servers{
+				{URL: "http://127.0.0.1:8080/api"},
+				{URL: "http://example-upstream.org/api"},
+			},
 		},
 		{
 			name: "non-empty servers and mix on named parameters and normal urls",
@@ -348,8 +358,15 @@ func TestOAS_AddServers(t *testing.T) {
 					},
 				},
 			}},
-			args:         args{apiURLs: []string{"http://127.0.0.1:8080/api", "http://{subdomain}/api"}},
-			expectedURLs: []string{"http://127.0.0.1:8080/api", "http://example-upstream.org/api"},
+			args: args{apiURLs: []string{"http://127.0.0.1:8080/api", "http://{subdomain}/api/{version:v\\d+}"}},
+			expectedServers: openapi3.Servers{
+				{URL: "http://127.0.0.1:8080/api"},
+				{URL: "http://example-upstream.org/api"},
+				{URL: "http://{subdomain}/api/{version}", Variables: map[string]*openapi3.ServerVariable{
+					"subdomain": {Default: "pathParam1"},
+					"version":   {Default: "pathParam2"},
+				}},
+			},
 		},
 		{
 			name: "non-empty servers having same URL that of apiURL",
@@ -367,10 +384,10 @@ func TestOAS_AddServers(t *testing.T) {
 				},
 			}},
 			args: args{apiURLs: []string{"http://127.0.0.1:8080/api"}},
-			expectedURLs: []string{
-				"http://127.0.0.1:8080/api",
-				"http://example-upstream.org/api",
-				"http://legacy-upstream.org/api",
+			expectedServers: openapi3.Servers{
+				{URL: "http://127.0.0.1:8080/api"},
+				{URL: "http://example-upstream.org/api"},
+				{URL: "http://legacy-upstream.org/api"},
 			},
 		},
 		{
@@ -386,28 +403,19 @@ func TestOAS_AddServers(t *testing.T) {
 				},
 			}},
 			args: args{apiURLs: []string{"http://127.0.0.1:8080/api"}},
-			expectedURLs: []string{
-				"http://127.0.0.1:8080/api",
-				"http://example-upstream.org/api",
+			expectedServers: openapi3.Servers{
+				{URL: "http://127.0.0.1:8080/api"},
+				{URL: "http://example-upstream.org/api"},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := &OAS{
-				T: tt.fields.T,
-			}
-			s.AddServers(tt.args.apiURLs...)
-			if tt.expectedURLs == nil {
-				assert.Empty(t, s.Servers)
-				return
-			}
-			var serverURLs []string
-			for _, server := range s.Servers {
-				serverURLs = append(serverURLs, server.URL)
-			}
+			s := &OAS{T: tt.fields.T}
+			err := s.AddServers(tt.args.apiURLs...)
 
-			assert.ElementsMatch(t, tt.expectedURLs, serverURLs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, tt.expectedServers, s.Servers)
 		})
 	}
 }
@@ -1515,4 +1523,57 @@ func TestYaml(t *testing.T) {
 	yamlOASDoc.SetTykExtension(nil)
 	oasDoc.SetTykExtension(nil)
 	assert.Equal(t, oasDoc, yamlOASDoc)
+}
+
+func Test_RemoveServer(t *testing.T) {
+	createOas := func() *OAS {
+		var spec openapi3.T
+
+		spec.OpenAPI = "3.0.3"
+		spec.Info = &openapi3.Info{
+			Title:   "Test API",
+			Version: "1.0.0",
+		}
+
+		spec.Servers = append(spec.Servers, &openapi3.Server{
+			URL: "https://{sub}.example.com/{version}",
+			Variables: map[string]*openapi3.ServerVariable{
+				"version": {
+					Default: "v1",
+				},
+				"sub": {
+					Default: "default",
+				},
+			},
+		})
+
+		return &OAS{spec}
+	}
+
+	t.Run("removes without fail", func(t *testing.T) {
+		spec := createOas()
+		err := spec.RemoveServer("https://{sub:[a-z]+}.example.com/{version:[0-9]+}")
+		assert.NoError(t, err)
+		assert.Len(t, spec.Servers, 0)
+	})
+
+	t.Run("does no remove no one server if server url is empty", func(t *testing.T) {
+		spec := createOas()
+		err := spec.RemoveServer("")
+		assert.NoError(t, err)
+		assert.Len(t, spec.Servers, 1)
+	})
+
+	t.Run("does not fail if given server does not exist", func(t *testing.T) {
+		spec := createOas()
+		err := spec.RemoveServer("https://example.com")
+		assert.NoError(t, err)
+		assert.Len(t, spec.Servers, 1)
+	})
+
+	t.Run("fails if invalid regex was provided", func(t *testing.T) {
+		spec := createOas()
+		err := spec.RemoveServer("https://{sub:[a-z]+}.example.com/{version:[0-9]+}}")
+		assert.Error(t, err)
+	})
 }

--- a/apidef/oas/root.go
+++ b/apidef/oas/root.go
@@ -194,10 +194,6 @@ func (v *Versioning) Fill(api apidef.APIDefinition) {
 		return v.Versions[i].Name < v.Versions[j].Name
 	})
 
-	if ShouldOmit(v.Versions) {
-		v.Versions = nil
-	}
-
 	v.StripVersioningData = api.VersionDefinition.StripVersioningData
 	v.FallbackToDefault = api.VersionDefinition.FallbackToDefault
 	v.UrlVersioningPattern = api.VersionDefinition.UrlVersioningPattern

--- a/apidef/oas/root_test.go
+++ b/apidef/oas/root_test.go
@@ -391,6 +391,7 @@ func FillTestVersionData(t *testing.T, index int) apidef.VersionData {
 
 func TestVersioning(t *testing.T) {
 	var emptyVersioning Versioning
+	emptyVersioning.Versions = []VersionToID{}
 
 	var convertedAPI apidef.APIDefinition
 	emptyVersioning.ExtractTo(&convertedAPI)

--- a/apidef/oas/security.go
+++ b/apidef/oas/security.go
@@ -108,9 +108,7 @@ type JWT struct {
 	// Tyk classic API definition: `jwt_source`
 	Source string `bson:"source,omitempty" json:"source,omitempty"`
 
-	// JwksURIs contains a list of whitelisted JWK endpoints.
-	//
-	// Tyk classic API definition: `jwt_jwks_uris`
+	// JwksURIs contains a list of JSON Web Key Sets (JWKS) endpoints from which Tyk will retrieve JWKS to validate JSON Web Tokens (JWTs).
 	JwksURIs []apidef.JWK `bson:"jwksURIs,omitempty" json:"jwksURIs,omitempty"`
 
 	// SigningMethod contains the signing method to use for the JWT.
@@ -641,7 +639,7 @@ func (c *IntrospectionCache) ExtractTo(cache *apidef.IntrospectionCache) {
 }
 
 // ExternalOAuth holds configuration for an external OAuth provider.
-// Deprecated: ExternalOAuth support has been deprecated from 5.7.0.
+// Deprecated: ExternalOAuth support was deprecated in Tyk 5.7.0.
 // To avoid any disruptions, we recommend that you use JSON Web Token (JWT) instead,
 // as explained in https://tyk.io/docs/basic-config-and-security/security/authentication-authorization/ext-oauth-middleware/.
 type ExternalOAuth struct {

--- a/apidef/oas/upstream.go
+++ b/apidef/oas/upstream.go
@@ -293,6 +293,7 @@ func (u *Upstream) loadBalancingExtractTo(api *apidef.APIDefinition) {
 //
 // Example:
 //
+//	```
 //	{
 //	  "proxy_url": "http(s)://proxy.url:1234",
 //	  "minVersion": "1.0",
@@ -304,6 +305,7 @@ func (u *Upstream) loadBalancingExtractTo(api *apidef.APIDefinition) {
 //	  "insecureSkipVerify": true,
 //	  "forceCommonNameCheck": false
 //	}
+//	```
 //
 // Tyk classic API definition: `proxy.transport`
 type TLSTransport struct {

--- a/ci/tests/tracing/scenarios/tyk_tykprotocol_200.yml
+++ b/ci/tests/tracing/scenarios/tyk_tykprotocol_200.yml
@@ -12,7 +12,7 @@ spec:
       - key: Content-Type
         value: application/json
   specs:
-  - name: /tykprotocl/ip http attributes
+  - name: /tykprotocol/ip http attributes
     selector: span[tracetest.span.type="http" name="GET /tykprotocol/ip" http.method="GET"]
     assertions:
     - attr:http.status_code = 200

--- a/config/config.go
+++ b/config/config.go
@@ -586,7 +586,7 @@ type CoProcessConfig struct {
 	// Authority used in GRPC connection
 	GRPCAuthority string `json:"grpc_authority"`
 
-	// GRPCRoundRobinLoadBalancing enables round robin load balancing for grpc services
+	// GRPCRoundRobinLoadBalancing enables round robin load balancing for gRPC services; you must provide the address of the load balanced service using `dns:///` protocol in `coprocess_grpc_server`.
 	GRPCRoundRobinLoadBalancing bool `json:"grpc_round_robin_load_balancing"`
 
 	// Sets the path to built-in Tyk modules. This will be part of the Python module lookup path. The value used here is the default one for most installations.

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,8 @@ import (
 
 type IPsHandleStrategy string
 
+const GracefulShutdownDefaultDuration = 30
+
 var (
 	log = logger.Get()
 
@@ -52,7 +54,7 @@ var (
 		LivenessCheck: LivenessCheckConfig{
 			CheckDuration: time.Second * 10,
 		},
-		GracefulShutdownTimeoutDuration: 30,
+		GracefulShutdownTimeoutDuration: GracefulShutdownDefaultDuration,
 		Streaming: StreamingConfig{
 			Enabled:     false,
 			AllowUnsafe: []string{},

--- a/ctx/ctx.go
+++ b/ctx/ctx.go
@@ -33,6 +33,7 @@ const (
 	TrackThisEndpoint
 	DoNotTrackThisEndpoint
 	UrlRewritePath
+	InternalRedirectTarget
 	RequestMethod
 	OrigRequestURL
 	LoopLevel
@@ -47,7 +48,6 @@ const (
 	RequestStatus
 	GraphQLRequest
 	GraphQLIsWebSocketUpgrade
-	OASOperation
 
 	// CacheOptions holds cache options required for cache writer middleware.
 	CacheOptions

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -69,6 +69,7 @@ import (
 	"github.com/TykTechnologies/tyk/user"
 
 	gql "github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
+	lib "github.com/TykTechnologies/tyk/lib/apidef"
 )
 
 const (
@@ -1049,13 +1050,31 @@ func (gw *Gateway) handleGetAPIOAS(apiID string, modePublic bool) (interface{}, 
 
 func (gw *Gateway) handleAddApi(r *http.Request, fs afero.Fs, oasEndpoint bool) (interface{}, int) {
 	var (
-		newDef             apidef.APIDefinition
-		oasObj             oas.OAS
-		baseAPIID          = r.FormValue("base_api_id")
-		baseAPIVersionName = r.FormValue("base_api_version_name")
-		newVersionName     = r.FormValue("new_version_name")
-		setDefault         = r.FormValue("set_default") == "true"
+		newDef apidef.APIDefinition
+		oasObj oas.OAS
 	)
+
+	versionParams := lib.NewVersionQueryParameters(r.URL.Query())
+	err := versionParams.Validate(func() (bool, string) {
+		baseApiID := versionParams.Get(lib.BaseAPIID)
+		baseApi := gw.getApiSpec(baseApiID)
+		if baseApi != nil {
+			return true, baseApi.VersionDefinition.Name
+		}
+
+		return false, ""
+	})
+
+	if err != nil {
+		// https://tyktech.atlassian.net/browse/TT-7523?focusedCommentId=100547
+		// Sadly we are averse to changing (incorrect) HTTP error codes, because these could be considered breaking changes by some of our clients.
+		// Please return HTTP 422 here, because currently the request doesn’t generate an error.
+		if errors.Is(err, lib.ErrNewVersionRequired) {
+			return apiError(err.Error()), http.StatusUnprocessableEntity
+		}
+
+		return apiError(err.Error()), http.StatusBadRequest
+	}
 
 	if oasEndpoint {
 		if err := json.NewDecoder(r.Body).Decode(&oasObj); err != nil {
@@ -1102,60 +1121,20 @@ func (gw *Gateway) handleAddApi(r *http.Request, fs afero.Fs, oasEndpoint bool) 
 		}
 	}
 
-	if baseAPIID != "" {
-		if baseAPIPtr := gw.getApiSpec(baseAPIID); baseAPIPtr == nil {
-			log.Errorf("Couldn't find a base API to bind with the given API id: %s", baseAPIID)
+	if !versionParams.IsEmpty(lib.BaseAPIID) {
+		baseAPI := gw.getApiSpec(versionParams.Get(lib.BaseAPIID))
+		baseAPI.VersionDefinition = lib.ConfigureVersionDefinition(baseAPI.VersionDefinition, versionParams, newDef.APIID)
+
+		if baseAPI.IsOAS {
+			baseAPI.OAS.Fill(*baseAPI.APIDefinition)
+			err, _ := gw.writeOASAndAPIDefToFile(fs, baseAPI.APIDefinition, &baseAPI.OAS)
+			if err != nil {
+				log.WithError(err).Errorf("Error occurred while updating base OAS API with id: %s", baseAPI.APIID)
+			}
 		} else {
-			apiInBytes, err := json.Marshal(baseAPIPtr)
+			err, _ := gw.writeToFile(fs, baseAPI.APIDefinition, baseAPI.APIID)
 			if err != nil {
-				log.WithError(err).Error("Couldn't marshal API spec")
-			}
-
-			var baseAPI APISpec
-			err = json.Unmarshal(apiInBytes, &baseAPI)
-			if err != nil {
-				log.WithError(err).Error("Couldn't unmarshal API spec")
-			}
-
-			baseAPI.VersionDefinition.Enabled = true
-			if baseAPIVersionName != "" {
-				baseAPI.VersionDefinition.Name = baseAPIVersionName
-				baseAPI.VersionDefinition.Default = baseAPIVersionName
-			}
-
-			if baseAPI.VersionDefinition.Key == "" {
-				baseAPI.VersionDefinition.Key = apidef.DefaultAPIVersionKey
-			}
-
-			if baseAPI.VersionDefinition.Location == "" {
-				baseAPI.VersionDefinition.Location = apidef.HeaderLocation
-			}
-
-			if baseAPI.VersionDefinition.Default == "" {
-				baseAPI.VersionDefinition.Default = apidef.Self
-			}
-
-			if baseAPI.VersionDefinition.Versions == nil {
-				baseAPI.VersionDefinition.Versions = make(map[string]string)
-			}
-
-			baseAPI.VersionDefinition.Versions[newVersionName] = newDef.APIID
-
-			if setDefault {
-				baseAPI.VersionDefinition.Default = newVersionName
-			}
-
-			if baseAPI.IsOAS {
-				baseAPI.OAS.Fill(*baseAPI.APIDefinition)
-				err, _ := gw.writeOASAndAPIDefToFile(fs, baseAPI.APIDefinition, &baseAPI.OAS)
-				if err != nil {
-					log.WithError(err).Errorf("Error occurred while updating base OAS API with id: %s", baseAPI.APIID)
-				}
-			} else {
-				err, _ := gw.writeToFile(fs, baseAPI.APIDefinition, baseAPI.APIID)
-				if err != nil {
-					log.WithError(err).Errorf("Error occurred while updating base API with id: %s", baseAPI.APIID)
-				}
+				log.WithError(err).Errorf("Error occurred while updating base API with id: %s", baseAPI.APIID)
 			}
 		}
 	}

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -3178,6 +3178,25 @@ func ctxGetUrlRewritePath(r *http.Request) string {
 	return ""
 }
 
+func ctxSetInternalRedirectTarget(r *http.Request, u *url.URL) {
+	setCtxValue(r, ctx.InternalRedirectTarget, u)
+}
+
+func ctxGetInternalRedirectTarget(r *http.Request) *url.URL {
+	if v := r.Context().Value(ctx.InternalRedirectTarget); v != nil {
+		if val, ok := v.(*url.URL); ok {
+			return val
+		}
+	}
+
+	if r.URL == nil {
+		return nil
+	}
+
+	clone := *r.URL
+	return &clone
+}
+
 func ctxSetCheckLoopLimits(r *http.Request, b bool) {
 	setCtxValue(r, ctx.CheckLoopLimits, b)
 }
@@ -3351,14 +3370,6 @@ func ctxIncThrottleLevel(r *http.Request, throttleLimit int) {
 	ctxSetThrottleLevel(r, ctxThrottleLevel(r)+1)
 }
 
-func ctxTraceEnabled(r *http.Request) bool {
-	return r.Context().Value(ctx.Trace) != nil
-}
-
-func ctxSetTrace(r *http.Request) {
-	setCtxValue(r, ctx.Trace, true)
-}
-
 func ctxSetSpanAttributes(r *http.Request, mwName string, attrs ...otel.SpanAttribute) {
 	if len(attrs) > 0 {
 		setCtxValue(r, mwName, attrs)
@@ -3382,17 +3393,6 @@ func ctxSetRequestStatus(r *http.Request, stat RequestStatus) {
 func ctxGetRequestStatus(r *http.Request) (stat RequestStatus) {
 	if v := r.Context().Value(ctx.RequestStatus); v != nil {
 		stat = v.(RequestStatus)
-	}
-	return
-}
-
-func ctxSetOperation(r *http.Request, op *Operation) {
-	setCtxValue(r, ctx.OASOperation, op)
-}
-
-func ctxGetOperation(r *http.Request) (op *Operation) {
-	if v := r.Context().Value(ctx.OASOperation); v != nil {
-		op = v.(*Operation)
 	}
 	return
 }

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -1081,7 +1081,10 @@ func (gw *Gateway) handleAddApi(r *http.Request, fs afero.Fs, oasEndpoint bool) 
 
 	if oasEndpoint {
 		newAPIURL := getAPIURL(newDef, gw.GetConfig())
-		oasObj.AddServers(newAPIURL)
+
+		if err := oasObj.AddServers(newAPIURL); err != nil {
+			return apiError(err.Error()), http.StatusBadRequest
+		}
 
 		newDef.IsOAS = true
 		oasObj.GetTykExtension().Info.ID = newDef.APIID

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -1500,34 +1500,34 @@ func Test_LoadAPIsFromRPC(t *testing.T) {
 
 func TestAPISpec_hasMock(t *testing.T) {
 	s := APISpec{APIDefinition: &apidef.APIDefinition{}}
-	assert.False(t, s.hasMock())
+	assert.False(t, s.hasActiveMock())
 
 	s.IsOAS = true
-	assert.False(t, s.hasMock())
+	assert.False(t, s.hasActiveMock())
 
 	s.OAS = oas.OAS{}
-	assert.False(t, s.hasMock())
+	assert.False(t, s.hasActiveMock())
 
 	xTyk := &oas.XTykAPIGateway{}
 	s.OAS.SetTykExtension(xTyk)
-	assert.False(t, s.hasMock())
+	assert.False(t, s.hasActiveMock())
 
 	middleware := &oas.Middleware{}
 	xTyk.Middleware = middleware
-	assert.False(t, s.hasMock())
+	assert.False(t, s.hasActiveMock())
 
 	op := &oas.Operation{}
 	middleware.Operations = oas.Operations{
 		"my-operation": op,
 	}
-	assert.False(t, s.hasMock())
+	assert.False(t, s.hasActiveMock())
 
 	mock := &oas.MockResponse{}
 	op.MockResponse = mock
-	assert.False(t, s.hasMock())
+	assert.False(t, s.hasActiveMock())
 
 	mock.Enabled = true
-	assert.True(t, s.hasMock())
+	assert.True(t, s.hasActiveMock())
 }
 
 func TestAPISpec_isStreamingAPI(t *testing.T) {

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/justinas/alice"
-	"github.com/rs/cors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/TykTechnologies/tyk/apidef"
@@ -135,21 +134,6 @@ func (gw *Gateway) generateSubRoutes(spec *APISpec, router *mux.Router) {
 	if spec.UseOauth2 {
 		oauthManager := gw.addOAuthHandlers(spec, router)
 		spec.OAuthManager = oauthManager
-	}
-
-	if spec.CORS.Enable {
-		c := cors.New(cors.Options{
-			AllowedOrigins:     spec.CORS.AllowedOrigins,
-			AllowedMethods:     spec.CORS.AllowedMethods,
-			AllowedHeaders:     spec.CORS.AllowedHeaders,
-			ExposedHeaders:     spec.CORS.ExposedHeaders,
-			AllowCredentials:   spec.CORS.AllowCredentials,
-			MaxAge:             spec.CORS.MaxAge,
-			OptionsPassthrough: spec.CORS.OptionsPassthrough,
-			Debug:              spec.CORS.Debug,
-		})
-
-		router.Use(c.Handler)
 	}
 }
 
@@ -316,6 +300,7 @@ func (gw *Gateway) processSpec(
 	}
 
 	gw.mwAppendEnabled(&chainArray, &VersionCheck{BaseMiddleware: baseMid.Copy()})
+	gw.mwAppendEnabled(&chainArray, &CORSMiddleware{BaseMiddleware: baseMid.Copy()})
 
 	for _, obj := range mwPreFuncs {
 		if mwDriver == apidef.GoPluginDriver {

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -123,7 +123,7 @@ func fixFuncPath(pathPrefix string, funcs []apidef.MiddlewareDefinition) {
 	}
 }
 
-func (gw *Gateway) generateSubRoutes(spec *APISpec, router *mux.Router, logger *logrus.Entry) {
+func (gw *Gateway) generateSubRoutes(spec *APISpec, router *mux.Router) {
 	if spec.GraphQL.GraphQLPlayground.Enabled {
 		gw.loadGraphQLPlayground(spec, router)
 	}
@@ -470,6 +470,10 @@ func (gw *Gateway) processSpec(
 	gw.mwAppendEnabled(&chainArray, &TransformMethod{BaseMiddleware: baseMid.Copy()})
 
 	// Earliest we can respond with cache get 200 ok
+	gw.mwAppendEnabled(&chainArray, newMockResponseMiddleware(
+		baseMid.Copy(),
+		withOpenTelemetry(gw.GetConfig().OpenTelemetry.Enabled),
+	))
 	gw.mwAppendEnabled(&chainArray, &RedisCacheMiddleware{BaseMiddleware: baseMid.Copy(), store: &cacheStore})
 
 	gw.mwAppendEnabled(&chainArray, &VirtualEndpoint{BaseMiddleware: baseMid.Copy()})
@@ -666,13 +670,24 @@ func (d *DummyProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if d.SH.Spec.target.Scheme == "tyk" {
 		handler, _, found := d.Gw.findInternalHttpHandlerByNameOrID(d.SH.Spec.target.Host)
+
 		if !found {
 			handler := ErrorHandler{d.SH.Base()}
 			handler.HandleError(w, r, "Couldn't detect target", http.StatusInternalServerError, true)
 			return
 		}
 
+		targetUrl, err := d.SH.Spec.getRedirectTargetUrl(ctxGetInternalRedirectTarget(r))
+
+		if err != nil {
+			log.Errorf("failed to create internal redirect url: %s", err)
+			handler := ErrorHandler{d.SH.Base()}
+			handler.HandleError(w, r, "Failed to perform internal redirect", http.StatusInternalServerError, true)
+			return
+		}
+
 		d.SH.Spec.SanitizeProxyPaths(r)
+		ctxSetInternalRedirectTarget(r, targetUrl)
 		ctxSetVersionInfo(r, nil)
 		handler.ServeHTTP(w, r)
 		return
@@ -832,7 +847,7 @@ func (gw *Gateway) loadHTTPService(spec *APISpec, apisByListen map[string]int, g
 	for _, prefix := range prefixes {
 		subrouter := router.PathPrefix(prefix).Subrouter()
 
-		gw.generateSubRoutes(spec, subrouter, logrus.NewEntry(log))
+		gw.generateSubRoutes(spec, subrouter)
 
 		if !chainObj.Open {
 			subrouter.Handle(rateLimitEndpoint, chainObj.RateLimitChain)

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -171,6 +171,7 @@ func (gw *Gateway) processSpec(
 		"org_id":   spec.OrgID,
 		"api_id":   spec.APIID,
 		"api_name": spec.Name,
+		"type":     "request",
 	})
 
 	var coprocessLog = logger.WithFields(logrus.Fields{
@@ -297,7 +298,7 @@ func (gw *Gateway) processSpec(
 	}
 
 	// Create the response processors, pass all the loaded custom middleware response functions:
-	gw.createResponseMiddlewareChain(spec, mwResponseFuncs)
+	gw.createResponseMiddlewareChain(spec, mwResponseFuncs, logger)
 
 	baseMid := NewBaseMiddleware(gw, spec, proxy, logger)
 

--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -2189,7 +2189,8 @@ func TestHandleAddApi_AddVersionAtomically(t *testing.T) {
 		{AdminAuth: true, Method: http.MethodPost, Data: v2,
 			Path: fmt.Sprintf("/tyk/apis?base_api_id=%s&new_version_name=%s&set_default=true&base_api_version_name=%s", baseAPI.APIID, v2VersionName, baseVersionName),
 			BodyMatchFunc: func(i []byte) bool {
-				assert.Len(t, baseAPI.VersionDefinition.Versions, 0)
+				// Gateway addApi function modifies baseAPI in it's internal storage - gw.apisByID
+				assert.Len(t, baseAPI.VersionDefinition.Versions, 1)
 				ts.Gw.DoReload()
 				return true
 			},
@@ -2267,7 +2268,8 @@ func TestHandleAddOASApi_AddVersionAtomically(t *testing.T) {
 		{AdminAuth: true, Method: http.MethodPost, Data: &v2.OAS,
 			Path: fmt.Sprintf("/tyk/apis/oas?base_api_id=%s&new_version_name=%s&set_default=true&base_api_version_name=%s", baseAPI.APIID, v2VersionName, baseVersionName),
 			BodyMatchFunc: func(i []byte) bool {
-				assert.Len(t, baseAPI.VersionDefinition.Versions, 0)
+				// Gateway addApi function modifies baseAPI in it's internal storage - gw.apisByID
+				assert.Len(t, baseAPI.VersionDefinition.Versions, 1)
 				ts.Gw.DoReload()
 				return true
 			},

--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -552,28 +552,30 @@ func (h *CustomMiddlewareResponseHook) HandleError(rw http.ResponseWriter, req *
 }
 
 func (h *CustomMiddlewareResponseHook) HandleResponse(rw http.ResponseWriter, res *http.Response, req *http.Request, ses *user.SessionState) error {
-	log.WithFields(logrus.Fields{
+
+	h.logger().WithFields(logrus.Fields{
 		"prefix": "coprocess",
 	}).Debugf("Response hook '%s' is called", h.mw.Name())
+
 	coProcessor := CoProcessor{
 		Middleware: h.mw,
 	}
 
 	object, err := coProcessor.BuildObject(req, res, h.mw.Spec)
 	if err != nil {
-		log.WithError(err).Debug("Couldn't build request object")
+		h.logger().WithError(err).Debug("Couldn't build request object")
 		return errors.New("Middleware error")
 	}
 	object.Session = ProtoSessionState(ses)
 
 	retObject, err := coProcessor.Dispatch(object)
 	if err != nil {
-		log.WithError(err).Debug("Couldn't dispatch request object")
+		h.logger().WithError(err).Debug("Couldn't dispatch request object")
 		return errors.New("Middleware error")
 	}
 
 	if retObject.Response == nil {
-		log.WithError(err).Debug("No response object returned by response hook")
+		h.logger().WithError(err).Debug("No response object returned by response hook")
 		return errors.New("Middleware error")
 	}
 

--- a/gateway/coprocess.go
+++ b/gateway/coprocess.go
@@ -3,23 +3,22 @@ package gateway
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
 	"net/url"
 	"reflect"
 	"strings"
 	"time"
 	"unicode/utf8"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/TykTechnologies/tyk-pump/analytics"
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/coprocess"
+	"github.com/TykTechnologies/tyk/internal/middleware"
 	"github.com/TykTechnologies/tyk/user"
-
-	"errors"
-	"fmt"
-	"io/ioutil"
-	"net/http"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -446,7 +445,7 @@ func (m *CoProcessMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Requ
 		}
 		res.ContentLength = int64(len(returnObject.Request.ReturnOverrides.ResponseBody))
 		m.successHandler.RecordHit(r, analytics.Latency(analytics.Latency{Total: int64(ms)}), int(returnObject.Request.ReturnOverrides.ResponseCode), res, false)
-		return nil, mwStatusRespond
+		return nil, middleware.StatusRespond
 	}
 
 	// Is this a CP authentication middleware?

--- a/gateway/health_check.go
+++ b/gateway/health_check.go
@@ -301,8 +301,8 @@ func (gw *Gateway) isCriticalFailure(component string) bool {
 		return true
 	}
 
-	// Consider RPC critical only if using RPC
-	if component == "rpc" && gw.GetConfig().Policies.PolicySource == "rpc" {
+	// Consider RPC critical only if using RPC and gw not in emergency mode
+	if component == "rpc" && gw.GetConfig().Policies.PolicySource == "rpc" && !rpc.IsEmergencyMode() {
 		return true
 	}
 

--- a/gateway/health_check_test.go
+++ b/gateway/health_check_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/rpc"
 	"github.com/TykTechnologies/tyk/storage"
 )
 
@@ -354,6 +355,7 @@ func TestGateway_isCriticalFailure(t *testing.T) {
 		component      string
 		check          HealthCheckItem
 		setupConfig    func(*config.Config)
+		setupFunc      func(*testing.T)
 		expectedResult bool
 	}{
 		{
@@ -456,6 +458,36 @@ func TestGateway_isCriticalFailure(t *testing.T) {
 			},
 			expectedResult: true, // Critical based on component and config, not status
 		},
+		{
+			name:      "rpc component is NOT critical when PolicySource is rpc but in emergency mode",
+			component: "rpc",
+			check: HealthCheckItem{
+				Status:        Fail,
+				ComponentType: System,
+			},
+			setupConfig: func(conf *config.Config) {
+				conf.Policies.PolicySource = "rpc"
+			},
+			setupFunc: func(t *testing.T) {
+				rpc.SetEmergencyMode(t, true)
+			},
+			expectedResult: false,
+		},
+		{
+			name:      "rpc component is critical when PolicySource is rpc and NOT in emergency mode",
+			component: "rpc",
+			check: HealthCheckItem{
+				Status:        Fail,
+				ComponentType: System,
+			},
+			setupConfig: func(conf *config.Config) {
+				conf.Policies.PolicySource = "rpc"
+			},
+			setupFunc: func(t *testing.T) {
+				rpc.SetEmergencyMode(t, false)
+			},
+			expectedResult: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -463,6 +495,12 @@ func TestGateway_isCriticalFailure(t *testing.T) {
 			// Create a new gateway instance for each test
 			conf := config.Config{}
 			tt.setupConfig(&conf)
+
+			// Setup emergency mode if needed
+			if tt.setupFunc != nil {
+				tt.setupFunc(t)
+			}
+
 			gw := NewGateway(conf, nil)
 
 			// Call the function under test

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -746,6 +746,7 @@ func handleResponseChain(chain []TykResponseHandler, rw http.ResponseWriter, res
 			return false, err
 		}
 	}
+
 	return false, nil
 }
 

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -694,7 +694,13 @@ func (t *BaseMiddleware) generateSessionID(id string) string {
 	return t.Gw.generateToken(t.Spec.OrgID, keyID)
 }
 
+type ResponseMwLogger interface {
+	setLogger(entry *logrus.Entry)
+	logger() *logrus.Entry
+}
+
 type TykResponseHandler interface {
+	ResponseMwLogger
 	Enabled() bool
 	Init(interface{}, *APISpec) error
 	Name() string
@@ -819,6 +825,7 @@ func parseForm(r *http.Request) {
 type BaseTykResponseHandler struct {
 	Spec *APISpec `json:"-"`
 	Gw   *Gateway `json:"-"`
+	log  *logrus.Entry
 }
 
 func (b *BaseTykResponseHandler) Enabled() bool {
@@ -838,3 +845,14 @@ func (b *BaseTykResponseHandler) HandleResponse(rw http.ResponseWriter, res *htt
 }
 
 func (b *BaseTykResponseHandler) HandleError(writer http.ResponseWriter, h *http.Request) {}
+
+func (b *BaseTykResponseHandler) setLogger(logger *logrus.Entry) {
+	b.log = logger
+}
+
+func (b *BaseTykResponseHandler) logger() *logrus.Entry {
+	if b.log == nil {
+		return logrus.NewEntry(log)
+	}
+	return b.log
+}

--- a/gateway/middleware_decorators.go
+++ b/gateway/middleware_decorators.go
@@ -1,0 +1,64 @@
+package gateway
+
+import (
+	"github.com/TykTechnologies/tyk/user"
+	"github.com/sirupsen/logrus"
+	"net/http"
+	"time"
+)
+
+var _ TykResponseHandler = (*logDecorator)(nil)
+
+type (
+	logDecorator struct {
+		TykResponseHandler
+	}
+
+	tykResponseDecorator func(origin TykResponseHandler) TykResponseHandler
+)
+
+func withLogger(
+	logger *logrus.Entry,
+) tykResponseDecorator {
+
+	return func(origin TykResponseHandler) TykResponseHandler {
+		origin.setLogger(logger.WithField("mw", origin.Name()).WithField("type", "response"))
+
+		return &logDecorator{
+			TykResponseHandler: origin,
+		}
+	}
+}
+
+func decorateReqMiddlewares(origin TykResponseHandler, decorators ...tykResponseDecorator) TykResponseHandler {
+	for _, fn := range decorators {
+		origin = fn(origin)
+	}
+	return origin
+}
+
+func makeDefaultDecorator(logger *logrus.Entry) tykResponseDecorator {
+	return func(origin TykResponseHandler) TykResponseHandler {
+		return decorateReqMiddlewares(origin, withLogger(logger))
+	}
+}
+
+func (d *logDecorator) HandleResponse(
+	writer http.ResponseWriter,
+	response *http.Response,
+	request *http.Request,
+	state *user.SessionState,
+) error {
+
+	start := time.Now()
+	d.logger().WithField("ts", start.UnixNano()).Debug("Started")
+
+	if err := d.TykResponseHandler.HandleResponse(writer, response, request, state); err != nil {
+		d.logger().WithField("ns", time.Since(start).Nanoseconds()).WithError(err).Error("Failed to process response")
+		return err
+	}
+
+	d.logger().WithField("ns", time.Since(start).Nanoseconds()).Debug("Finished")
+
+	return nil
+}

--- a/gateway/model_apispec.go
+++ b/gateway/model_apispec.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"github.com/TykTechnologies/tyk/internal/errors"
 	"net/http"
 	"net/url"
 	"strings"
@@ -58,7 +59,7 @@ type APISpec struct {
 
 	GraphEngine graphengine.Engine
 
-	OASRouter routers.Router
+	oasRouter routers.Router
 }
 
 // CheckSpecMatchesStatus checks if a URL spec has a specific status.
@@ -138,16 +139,29 @@ func (a *APISpec) injectIntoReqContext(req *http.Request) {
 	}
 }
 
-func (a *APISpec) findOperations(r *http.Request) *Operation {
+func (a *APISpec) findOperation(r *http.Request) *Operation {
 	middleware := a.OAS.GetTykMiddleware()
 	if middleware == nil {
 		return nil
 	}
 
-	route, pathParams, err := a.OASRouter.FindRoute(r)
+	if a.oasRouter == nil {
+		log.Warningf("OAS router not initialized properly. Unable to find route for %s %v", r.Method, r.URL)
+		return nil
+	}
+
+	rClone := *r
+	rClone.URL = ctxGetInternalRedirectTarget(r)
+
+	route, pathParams, err := a.oasRouter.FindRoute(&rClone)
+
+	if errors.Is(err, routers.ErrPathNotFound) {
+		log.Tracef("Unable to find route for %s %v at spec %v", r.Method, r.URL, a.Id)
+		return nil
+	}
 
 	if err != nil {
-		log.Debugf("Error finding route: %v", err)
+		log.Errorf("Error finding route: %v", err)
 		return nil
 	}
 
@@ -161,11 +175,5 @@ func (a *APISpec) findOperations(r *http.Request) *Operation {
 		Operation:  operation,
 		route:      route,
 		pathParams: pathParams,
-	}
-}
-
-func (a *APISpec) SetupOperation(r *http.Request) {
-	if mockOp := a.findOperations(r); mockOp != nil {
-		ctxSetOperation(r, mockOp)
 	}
 }

--- a/gateway/mw_cors.go
+++ b/gateway/mw_cors.go
@@ -1,0 +1,43 @@
+package gateway
+
+import (
+	"github.com/TykTechnologies/tyk/internal/middleware"
+	"github.com/rs/cors"
+	"net/http"
+)
+
+type CORSMiddleware struct {
+	*BaseMiddleware
+	corsHandler *cors.Cors
+}
+
+func (c *CORSMiddleware) Name() string {
+	return "CORSMiddleware"
+}
+
+func (c *CORSMiddleware) EnabledForSpec() bool {
+	return c.Spec.CORS.Enable
+}
+
+func (c *CORSMiddleware) Init() {
+	c.corsHandler = cors.New(cors.Options{
+		AllowedOrigins:     c.Spec.CORS.AllowedOrigins,
+		AllowedMethods:     c.Spec.CORS.AllowedMethods,
+		AllowedHeaders:     c.Spec.CORS.AllowedHeaders,
+		ExposedHeaders:     c.Spec.CORS.ExposedHeaders,
+		AllowCredentials:   c.Spec.CORS.AllowCredentials,
+		MaxAge:             c.Spec.CORS.MaxAge,
+		OptionsPassthrough: c.Spec.CORS.OptionsPassthrough,
+		Debug:              c.Spec.CORS.Debug,
+	})
+}
+
+func (c *CORSMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
+	c.corsHandler.HandlerFunc(w, r)
+
+	if r.Method == http.MethodOptions && !c.Spec.CORS.OptionsPassthrough {
+		return nil, middleware.StatusRespond
+	}
+
+	return nil, http.StatusOK
+}

--- a/gateway/mw_cors_test.go
+++ b/gateway/mw_cors_test.go
@@ -1,0 +1,187 @@
+package gateway
+
+import (
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/internal/middleware"
+	"github.com/TykTechnologies/tyk/internal/uuid"
+	"github.com/TykTechnologies/tyk/test"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCORSMiddleware_ProcessRequest_PreflightRequest(t *testing.T) {
+	corsConf := createCORSConfig()
+	m := createCORSMiddleware(corsConf)
+	m.Init()
+
+	t.Run("preflight request - successful", func(t *testing.T) {
+		origin := "http://example.com"
+		resp := executePreFlightRequest(t, m, origin)
+
+		assert.Equal(t, origin, resp.Header.Get("Access-Control-Allow-Origin"))
+		assert.Equal(t, "true", resp.Header.Get("Access-Control-Allow-Credentials"))
+		assert.Contains(t, resp.Header.Get("Access-Control-Allow-Methods"), http.MethodPost)
+	})
+
+	t.Run("preflight request - different origin", func(t *testing.T) {
+		origin := "http://wrong-origin.com"
+		resp := executePreFlightRequest(t, m, origin)
+
+		assert.Empty(t, resp.Header.Get("Access-Control-Allow-Origin"))
+		assert.Empty(t, resp.Header.Get("Access-Control-Allow-Credentials"))
+		assert.Empty(t, resp.Header.Get("Access-Control-Allow-Methods"))
+	})
+}
+
+func executePreFlightRequest(t *testing.T, mw *CORSMiddleware, origin string) *http.Response {
+	req := httptest.NewRequest(http.MethodOptions, "/test", nil)
+	req.Header.Set("Origin", origin)
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+	req.Header.Set("Access-Control-Request-Headers", "authorization, content-type")
+
+	w := httptest.NewRecorder()
+
+	err, code := mw.ProcessRequest(w, req, nil)
+	assert.Nil(t, err)
+	assert.Equal(t, middleware.StatusRespond, code, "Should respond immediately for preflight requests")
+
+	return w.Result()
+}
+
+func TestCORSMiddleware_ProcessRequest_RegularRequest(t *testing.T) {
+	corsConf := createCORSConfig()
+	m := createCORSMiddleware(corsConf)
+	m.Init()
+
+	t.Run("regular request - successful", func(t *testing.T) {
+		origin := "http://example.com"
+		resp := executeRegularRequest(t, m, origin)
+
+		assert.Equal(t, origin, resp.Header.Get("Access-Control-Allow-Origin"))
+		assert.Equal(t, "true", resp.Header.Get("Access-Control-Allow-Credentials"))
+		assert.Contains(t, resp.Header.Get("Access-Control-Expose-Headers"), "X-Rate-Limit")
+	})
+
+	t.Run("regular request - different origin", func(t *testing.T) {
+		origin := "http://wrong-origin.com"
+		resp := executeRegularRequest(t, m, origin)
+
+		assert.Empty(t, resp.Header.Get("Access-Control-Allow-Origin"))
+		assert.Empty(t, resp.Header.Get("Access-Control-Allow-Credentials"))
+		assert.Empty(t, resp.Header.Get("Access-Control-Expose-Headers"))
+	})
+}
+
+func executeRegularRequest(t *testing.T, mw *CORSMiddleware, origin string) *http.Response {
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Origin", origin)
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+
+	err, code := mw.ProcessRequest(w, req, nil)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, code, "Should continue middleware chain for regular requests")
+
+	return w.Result()
+}
+
+func TestCORSMiddleware_testApi(t *testing.T) {
+	g := StartTest(nil)
+	defer g.Close()
+
+	api1ID := uuid.New()
+	api2ID := uuid.New()
+
+	apis := g.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "CORS test API"
+		spec.APIID = api1ID
+		spec.Proxy.ListenPath = "/cors-api/"
+		spec.CORS.Enable = false
+		spec.CORS.ExposedHeaders = []string{"Custom-Header"}
+		spec.CORS.AllowedOrigins = []string{"*"}
+	}, func(spec *APISpec) {
+		spec.Name = "Another API"
+		spec.APIID = api2ID
+		spec.Proxy.ListenPath = "/another-api/"
+		spec.CORS.ExposedHeaders = []string{"Custom-Header"}
+		spec.CORS.AllowedOrigins = []string{"*"}
+	})
+
+	headers := map[string]string{
+		"Origin": "my-custom-origin",
+	}
+
+	headersMatch := map[string]string{
+		"Access-Control-Allow-Origin":   "*",
+		"Access-Control-Expose-Headers": "Custom-Header",
+	}
+
+	t.Run("CORS disabled", func(t *testing.T) {
+		_, _ = g.Run(t, []test.TestCase{
+			{Path: "/cors-api/", Headers: headers, HeadersNotMatch: headersMatch, Code: http.StatusOK},
+		}...)
+	})
+
+	t.Run("CORS enabled", func(t *testing.T) {
+		apis[0].CORS.Enable = true
+		g.Gw.LoadAPI(apis...)
+
+		_, _ = g.Run(t, []test.TestCase{
+			{Path: "/cors-api/", Headers: headers, HeadersMatch: headersMatch, Code: http.StatusOK},
+			{Path: "/another-api/", Headers: headers, HeadersNotMatch: headersMatch, Code: http.StatusOK},
+			{Path: "/" + api1ID + "/", Headers: headers, HeadersMatch: headersMatch, Code: http.StatusOK},
+			{Path: "/" + api2ID + "/", Headers: headers, HeadersNotMatch: headersMatch, Code: http.StatusOK},
+		}...)
+	})
+
+	t.Run("oauth endpoints", func(t *testing.T) {
+		apis[0].UseOauth2 = true
+		apis[0].CORS.Enable = false
+
+		g.Gw.LoadAPI(apis...)
+
+		t.Run("CORS disabled", func(t *testing.T) {
+			_, _ = g.Run(t, []test.TestCase{
+				{Path: "/cors-api/oauth/token", Headers: headers, HeadersNotMatch: headersMatch, Code: http.StatusForbidden},
+			}...)
+		})
+
+		t.Run("CORS enabled", func(t *testing.T) {
+			apis[0].CORS.Enable = true
+			g.Gw.LoadAPI(apis...)
+
+			_, _ = g.Run(t, []test.TestCase{
+				{Path: "/cors-api/oauth/token", Headers: headers, HeadersMatch: headersMatch, Code: http.StatusForbidden},
+			}...)
+		})
+	})
+}
+
+func createCORSConfig() apidef.CORSConfig {
+	return apidef.CORSConfig{
+		Enable:             true,
+		AllowedOrigins:     []string{"http://example.com"},
+		AllowedMethods:     []string{"GET", "POST"},
+		AllowedHeaders:     []string{"Content-Type", "Authorization"},
+		ExposedHeaders:     []string{"X-Rate-Limit"},
+		AllowCredentials:   true,
+		MaxAge:             86400,
+		OptionsPassthrough: false,
+		Debug:              false,
+	}
+}
+
+func createCORSMiddleware(corsConf apidef.CORSConfig) *CORSMiddleware {
+	return &CORSMiddleware{
+		BaseMiddleware: &BaseMiddleware{
+			Spec: &APISpec{
+				APIDefinition: &apidef.APIDefinition{
+					CORS: corsConf,
+				},
+			},
+		},
+	}
+}

--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -8,12 +8,12 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/TykTechnologies/tyk-pump/analytics"
-	"github.com/TykTechnologies/tyk/apidef"
-
 	"github.com/sirupsen/logrus"
 
+	"github.com/TykTechnologies/tyk-pump/analytics"
+	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/goplugin"
+	"github.com/TykTechnologies/tyk/internal/middleware"
 	"github.com/TykTechnologies/tyk/request"
 )
 
@@ -257,7 +257,7 @@ func (m *GoPluginMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reque
 			successHandler.RecordHit(r, analytics.Latency{Total: int64(ms)}, rw.statusCodeSent, rw.getHttpResponse(r), false)
 
 			// no need to continue passing this request down to reverse proxy
-			respCode = mwStatusRespond
+			respCode = middleware.StatusRespond
 		}
 	} else {
 		respCode = http.StatusOK

--- a/gateway/mw_js_plugin.go
+++ b/gateway/mw_js_plugin.go
@@ -15,11 +15,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/TykTechnologies/tyk/apidef"
-
 	"github.com/robertkrimen/otto"
 	_ "github.com/robertkrimen/otto/underscore"
 
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/internal/middleware"
 	"github.com/TykTechnologies/tyk/user"
 
 	"github.com/sirupsen/logrus"
@@ -298,7 +298,7 @@ func (d *DynamicMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 		}
 
 		d.Gw.forceResponse(w, r, &responseObject, d.Spec, session, d.Pre, logger)
-		return nil, mwStatusRespond
+		return nil, middleware.StatusRespond
 	}
 
 	if d.Auth {

--- a/gateway/mw_mock_response.go
+++ b/gateway/mw_mock_response.go
@@ -133,6 +133,8 @@ func (m *mockResponseMiddleware) mockResponse(r *http.Request) (*http.Response, 
 
 	res.Body = io.NopCloser(bytes.NewBuffer(body))
 
+	m.Spec.sendRateLimitHeaders(ctxGetSession(r), res)
+
 	return res, nil
 }
 

--- a/gateway/mw_mock_response_test.go
+++ b/gateway/mw_mock_response_test.go
@@ -2,14 +2,16 @@ package gateway
 
 import (
 	"context"
-	"github.com/TykTechnologies/tyk/header"
 	"net/http"
 	"testing"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/internal/uuid"
 	"github.com/TykTechnologies/tyk/test"
 )
 
@@ -583,5 +585,83 @@ func TestMockFromOAS_ExampleHandling(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusCreated, code)
+	})
+}
+
+func TestMockResponseWithInternalRedirect(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	firstApi := BuildOASAPI(func(oasDef *oas.OAS) {
+		opId := uuid.New()
+
+		headers := oas.Headers{}
+		headers.Add("Content-Type", "application/json")
+
+		tykExt := oasDef.GetTykExtension()
+		tykExt.Info.ID = "v1-api-name"
+		tykExt.Info.Name = "v1-api-name"
+		tykExt.Server.ListenPath.Value = "/v1-api-name"
+		tykExt.Middleware = &oas.Middleware{}
+		tykExt.Middleware.Operations = oas.Operations{}
+		tykExt.Middleware.Operations[opId] = &oas.Operation{
+			MockResponse: &oas.MockResponse{
+				Enabled: true,
+				Code:    201,
+				Body:    "[null]",
+				Headers: headers,
+			},
+		}
+
+		desc := "hello world"
+		responses := openapi3.NewResponses()
+		responses.Delete("default")
+		responses.Set("200", &openapi3.ResponseRef{
+			Value: &openapi3.Response{
+				Description: &desc,
+				Content: openapi3.Content{
+					"application/json": &openapi3.MediaType{},
+				},
+			},
+		})
+
+		oasDef.Paths = openapi3.NewPaths()
+		oasDef.Paths.Set("/hello", &openapi3.PathItem{
+			Get: &openapi3.Operation{
+				OperationID: opId,
+				Responses:   responses,
+			},
+		})
+	})[0]
+
+	//Create second API that redirects to the first API
+	secondAPI := BuildOASAPI(func(oasDef *oas.OAS) {
+		tykExt := oasDef.GetTykExtension()
+		tykExt.Info.ID = "test_redirect"
+		tykExt.Info.Name = "Test Redirect API"
+		tykExt.Server.ListenPath.Value = "/test_redirect"
+		tykExt.Server.ListenPath.Strip = true
+		tykExt.Upstream.URL = "tyk://v1-api-name"
+	})[0]
+
+	for spec := range ts.Gw.LoadAPI(firstApi, secondAPI) {
+		require.NotNil(t, spec, "expected to load api properly")
+	}
+
+	t.Run("direct request should respond with mocked data", func(t *testing.T) {
+		_, _ = ts.Run(t, test.TestCase{
+			Path:   "/v1-api-name/hello",
+			Method: http.MethodGet,
+			Code:   201,
+		})
+	})
+
+	// Test case: Request to the second API should return the mocked response from the first API
+	t.Run("Request to second API should return mocked response from first API", func(t *testing.T) {
+		_, _ = ts.Run(t, test.TestCase{
+			Path:   "/test_redirect/hello",
+			Method: http.MethodGet,
+			Code:   201,
+		})
 	})
 }

--- a/gateway/mw_oas_validate_request.go
+++ b/gateway/mw_oas_validate_request.go
@@ -66,7 +66,7 @@ func (k *ValidateRequest) EnabledForSpec() bool {
 
 // ProcessRequest will run any checks on the request on the way through the system, return an error to have the chain fail
 func (k *ValidateRequest) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
-	operation := ctxGetOperation(r)
+	operation := k.Spec.findOperation(r)
 
 	if operation == nil {
 		return nil, http.StatusOK

--- a/gateway/mw_redis_cache.go
+++ b/gateway/mw_redis_cache.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/TykTechnologies/murmur3"
 	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/internal/middleware"
 	"github.com/TykTechnologies/tyk/regexp"
 	"github.com/TykTechnologies/tyk/request"
 	"github.com/TykTechnologies/tyk/storage"
@@ -279,7 +280,7 @@ func (m *RedisCacheMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 	}
 
 	// Stop any further execution after we wrote cache out
-	return nil, mwStatusRespond
+	return nil, middleware.StatusRespond
 }
 
 func isSafeMethod(method string) bool {

--- a/gateway/mw_version_check.go
+++ b/gateway/mw_version_check.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/internal/middleware"
 	"github.com/TykTechnologies/tyk/internal/otel"
 	"github.com/TykTechnologies/tyk/request"
 )
@@ -91,7 +92,7 @@ func (v *VersionCheck) ProcessRequest(w http.ResponseWriter, r *http.Request, _ 
 		v.Spec.SanitizeProxyPaths(r)
 
 		handler.ServeHTTP(w, r)
-		return nil, mwStatusRespond
+		return nil, middleware.StatusRespond
 	}
 outside:
 	// Check versioning, blacklist, whitelist and ignored status
@@ -127,7 +128,7 @@ outside:
 		}
 
 		v.DoMockReply(w, mockMeta)
-		return nil, mwStatusRespond
+		return nil, middleware.StatusRespond
 	}
 
 	if !v.Spec.ExpirationTs.IsZero() {

--- a/gateway/mw_version_check.go
+++ b/gateway/mw_version_check.go
@@ -94,8 +94,6 @@ func (v *VersionCheck) ProcessRequest(w http.ResponseWriter, r *http.Request, _ 
 		return nil, mwStatusRespond
 	}
 outside:
-	v.Spec.SetupOperation(r)
-
 	// Check versioning, blacklist, whitelist and ignored status
 	requestValid, stat := v.Spec.RequestValid(r)
 	if !requestValid {

--- a/gateway/mw_virtual_endpoint.go
+++ b/gateway/mw_virtual_endpoint.go
@@ -12,7 +12,6 @@ import (
 	"net/url"
 	"os"
 	"reflect"
-	"strconv"
 	"strings"
 	"time"
 
@@ -21,7 +20,6 @@ import (
 
 	"github.com/TykTechnologies/tyk-pump/analytics"
 	"github.com/TykTechnologies/tyk/apidef"
-	"github.com/TykTechnologies/tyk/header"
 	"github.com/TykTechnologies/tyk/internal/middleware"
 	"github.com/TykTechnologies/tyk/user"
 	"github.com/sirupsen/logrus"
@@ -333,14 +331,7 @@ func (gw *Gateway) handleForcedResponse(rw http.ResponseWriter, res *http.Respon
 		res.Header.Set("Connection", "close")
 	}
 
-	// Add resource headers
-	if ses != nil {
-		// We have found a session, lets report back
-		quotaMax, quotaRemaining, _, quotaRenews := ses.GetQuotaLimitByAPIID(spec.APIID)
-		res.Header.Set(header.XRateLimitLimit, strconv.Itoa(int(quotaMax)))
-		res.Header.Set(header.XRateLimitRemaining, strconv.Itoa(int(quotaRemaining)))
-		res.Header.Set(header.XRateLimitReset, strconv.Itoa(int(quotaRenews)))
-	}
+	spec.sendRateLimitHeaders(ses, res)
 
 	copyHeader(rw.Header(), res.Header, gw.GetConfig().IgnoreCanonicalMIMEHeaderKey)
 

--- a/gateway/mw_virtual_endpoint.go
+++ b/gateway/mw_virtual_endpoint.go
@@ -48,7 +48,7 @@ type VMResponseObject struct {
 	SessionMeta map[string]interface{}
 }
 
-// DynamicMiddleware is a generic middleware that will execute JS code before continuing
+// VirtualEndpoint is a generic middleware that will execute JS code before continuing
 type VirtualEndpoint struct {
 	*BaseMiddleware
 

--- a/gateway/mw_virtual_endpoint.go
+++ b/gateway/mw_virtual_endpoint.go
@@ -20,11 +20,10 @@ import (
 	_ "github.com/robertkrimen/otto/underscore"
 
 	"github.com/TykTechnologies/tyk-pump/analytics"
-
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/internal/middleware"
 	"github.com/TykTechnologies/tyk/user"
-
 	"github.com/sirupsen/logrus"
 )
 
@@ -318,7 +317,7 @@ func (d *VirtualEndpoint) ProcessRequest(w http.ResponseWriter, r *http.Request,
 		return errors.New(message), http.StatusInternalServerError
 	}
 
-	return nil, mwStatusRespond
+	return nil, middleware.StatusRespond
 }
 
 func (d *VirtualEndpoint) HandleResponse(rw http.ResponseWriter, res *http.Response, ses *user.SessionState) {

--- a/gateway/policy.go
+++ b/gateway/policy.go
@@ -227,6 +227,9 @@ func (gw *Gateway) LoadPoliciesFromRPC(store RPCDataLoader, orgId string, allowE
 	}
 
 	rpcPolicies := store.GetPolicies(orgId)
+	if rpcPolicies == "" {
+		return nil, errors.New("failed to fetch policies from RPC store; connection may be down")
+	}
 
 	policies, err := parsePoliciesFromRPC(rpcPolicies, allowExplicit)
 

--- a/gateway/res_handler_go_plugin.go
+++ b/gateway/res_handler_go_plugin.go
@@ -16,15 +16,14 @@ type ResponseGoPluginMiddleware struct {
 	BaseTykResponseHandler
 	Path       string // path to .so file
 	SymbolName string // function symbol to look up
-	logger     *logrus.Entry
 	ResHandler func(rw http.ResponseWriter, res *http.Response, req *http.Request)
 }
 
-func (h ResponseGoPluginMiddleware) Base() *BaseTykResponseHandler {
+func (h *ResponseGoPluginMiddleware) Base() *BaseTykResponseHandler {
 	return &h.BaseTykResponseHandler
 }
 
-func (ResponseGoPluginMiddleware) Name() string {
+func (h *ResponseGoPluginMiddleware) Name() string {
 	return "ResponseGoPluginMiddleware"
 }
 
@@ -33,20 +32,22 @@ func (h *ResponseGoPluginMiddleware) Init(c interface{}, spec *APISpec) error {
 	h.Path = c.(apidef.MiddlewareDefinition).Path
 	h.SymbolName = c.(apidef.MiddlewareDefinition).Name
 
-	h.logger = log.WithFields(logrus.Fields{
-		"mwPath":       h.Path,
-		"mwSymbolName": h.SymbolName,
-	})
+	h.setLogger(
+		h.logger().WithFields(logrus.Fields{
+			"mwPath":       h.Path,
+			"mwSymbolName": h.SymbolName,
+		}),
+	)
 
 	if h.ResHandler != nil {
-		h.logger.Info("Go-plugin middleware is already initialized")
+		h.logger().Info("Go-plugin middleware is already initialized")
 		// noop
 		return nil
 	}
 
 	newPath, err := goplugin.GetPluginFileNameToLoad(goplugin.FileSystemStorage{}, h.Path)
 	if err != nil {
-		h.logger.WithError(err).Error("Could not load Go-plugin. File was not found")
+		h.logger().WithError(err).Error("Could not load Go-plugin. File was not found")
 		return err
 	}
 	if h.Path != newPath {
@@ -55,25 +56,16 @@ func (h *ResponseGoPluginMiddleware) Init(c interface{}, spec *APISpec) error {
 
 	// try to load plugin
 	if h.ResHandler, err = goplugin.GetResponseHandler(h.Path, h.SymbolName); err != nil {
-		h.logger.WithError(err).Error("Could not load Go-plugin")
+		h.logger().WithError(err).Error("Could not load Go-plugin")
 		return err
 	}
-	h.logger.Infof("Loaded Go response plugin: %s", h.SymbolName)
+	h.logger().Infof("Loaded Go response plugin: %s", h.SymbolName)
 
 	return nil
 }
 
-func (h *ResponseGoPluginMiddleware) HandleError(rw http.ResponseWriter, req *http.Request) {
-	//noop
-}
-
-func (h *ResponseGoPluginMiddleware) HandleResponse(w http.ResponseWriter, res *http.Response, req *http.Request, ses *user.SessionState) error {
-	err := h.HandleGoPluginResponse(w, res, req)
-	if err != nil {
-		return err
-	}
-
-	return nil
+func (h *ResponseGoPluginMiddleware) HandleResponse(w http.ResponseWriter, res *http.Response, req *http.Request, _ *user.SessionState) error {
+	return h.HandleGoPluginResponse(w, res, req)
 }
 
 func (h *ResponseGoPluginMiddleware) HandleGoPluginResponse(w http.ResponseWriter, res *http.Response, req *http.Request) error {
@@ -82,8 +74,7 @@ func (h *ResponseGoPluginMiddleware) HandleGoPluginResponse(w http.ResponseWrite
 		if e := recover(); e != nil {
 			err := fmt.Errorf("%v", e)
 			w.WriteHeader(http.StatusInternalServerError)
-			h.logger.WithError(err).Error("Recovered from panic while running Go-plugin middleware func")
-
+			h.logger().WithError(err).Error("Recovered from panic while running Go-plugin middleware func")
 		}
 	}()
 
@@ -103,7 +94,7 @@ func (h *ResponseGoPluginMiddleware) HandleGoPluginResponse(w http.ResponseWrite
 
 	// calculate latency
 	ms := DurationToMillisecond(time.Since(t1))
-	h.logger.WithField("ms", ms).Debug("Go-plugin response processing took")
+	h.logger().WithField("ms", ms).Debug("Go-plugin response processing took")
 
 	// check if response was sent
 	if rw.responseSent {
@@ -113,7 +104,7 @@ func (h *ResponseGoPluginMiddleware) HandleGoPluginResponse(w http.ResponseWrite
 			// base middleware will report this error to analytics if needed
 			w.WriteHeader(rw.statusCodeSent)
 			err := fmt.Errorf("plugin function sent error response code: %d", rw.statusCodeSent)
-			h.logger.WithError(err).Error("Returned error code while processing response with Go-plugin middleware func")
+			h.logger().WithError(err).Error("Returned error code while processing response with Go-plugin middleware func")
 			return err
 		}
 	}

--- a/gateway/res_handler_header_injector.go
+++ b/gateway/res_handler_header_injector.go
@@ -58,10 +58,13 @@ func (h *HeaderInjector) HandleResponse(rw http.ResponseWriter, res *http.Respon
 	found, meta := h.Spec.CheckSpecMatchesStatus(req, versionPaths, HeaderInjectedResponse)
 	if found {
 		hmeta := meta.(*apidef.HeaderInjectionMeta)
+
 		for _, dKey := range hmeta.DeleteHeaders {
+			h.logger().Debug("Removing: ", dKey)
 			res.Header.Del(dKey)
 		}
 		for nKey, nVal := range hmeta.AddHeaders {
+			h.logger().Debugf("Adding: %v: %v", nKey, nVal)
 			setCustomHeader(res.Header, nKey, h.Gw.ReplaceTykVariables(req, nVal, false), ignoreCanonical)
 		}
 	}
@@ -69,20 +72,23 @@ func (h *HeaderInjector) HandleResponse(rw http.ResponseWriter, res *http.Respon
 	// Manage global response header options with versionInfo
 	if !vInfo.GlobalResponseHeadersDisabled {
 		for _, key := range vInfo.GlobalResponseHeadersRemove {
-			log.Debug("Removing: ", key)
+			h.logger().Debug("Removing: ", key)
 			res.Header.Del(key)
 		}
 
 		for key, val := range vInfo.GlobalResponseHeaders {
-			log.Debug("Adding: ", key)
+			h.logger().Debug("Adding: ", key)
 			setCustomHeader(res.Header, key, h.Gw.ReplaceTykVariables(req, val, false), ignoreCanonical)
 		}
 
 		// Manage global response header options with response_processors
 		for _, n := range h.config.RemoveHeaders {
+			h.logger().Debug("Removing global: ", n)
 			res.Header.Del(n)
 		}
+
 		for header, v := range h.config.AddHeaders {
+			h.logger().Debug("Adding global: ", header)
 			setCustomHeader(res.Header, header, h.Gw.ReplaceTykVariables(req, v, false), ignoreCanonical)
 		}
 	}

--- a/gateway/res_handler_jq_transform_dummy.go
+++ b/gateway/res_handler_jq_transform_dummy.go
@@ -31,6 +31,6 @@ func (h *ResponseTransformJQMiddleware) HandleError(rw http.ResponseWriter, req 
 }
 
 func (h *ResponseTransformJQMiddleware) HandleResponse(rw http.ResponseWriter, res *http.Response, req *http.Request, ses *user.SessionState) error {
-	log.Warning("JQ transforms not supported")
+	h.logger().Warning("JQ transforms not supported")
 	return nil
 }

--- a/gateway/res_handler_transform.go
+++ b/gateway/res_handler_transform.go
@@ -97,7 +97,7 @@ func (r *ResponseTransformMiddleware) HandleError(rw http.ResponseWriter, req *h
 }
 
 func (r *ResponseTransformMiddleware) HandleResponse(rw http.ResponseWriter, res *http.Response, req *http.Request, ses *user.SessionState) error {
-	logger := log.WithFields(logrus.Fields{
+	logger := r.logger().WithFields(logrus.Fields{
 		"prefix":      "outbound-transform",
 		"server_name": r.Spec.Proxy.TargetURL,
 		"api_id":      r.Spec.APIID,
@@ -107,7 +107,9 @@ func (r *ResponseTransformMiddleware) HandleResponse(rw http.ResponseWriter, res
 	versionInfo, _ := r.Spec.Version(req)
 	versionPaths := r.Spec.RxPaths[versionInfo.Name]
 	found, meta := r.Spec.CheckSpecMatchesStatus(req, versionPaths, TransformedResponse)
+
 	if !found {
+		logger.Warning("CheckSpecMatchesStatus not found. Transformation stopped.")
 		return nil
 	}
 	tmeta := meta.(*TransformSpec)

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -24,7 +24,6 @@ import (
 	"net/http"
 	"net/textproto"
 	"net/url"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -1406,14 +1405,7 @@ func (p *ReverseProxy) HandleResponse(rw http.ResponseWriter, res *http.Response
 		res.Header.Set(header.Connection, "close")
 	}
 
-	// Add resource headers
-	if ses != nil {
-		// We have found a session, lets report back
-		quotaMax, quotaRemaining, _, quotaRenews := ses.GetQuotaLimitByAPIID(p.TykAPISpec.APIID)
-		res.Header.Set(header.XRateLimitLimit, strconv.Itoa(int(quotaMax)))
-		res.Header.Set(header.XRateLimitRemaining, strconv.Itoa(int(quotaRemaining)))
-		res.Header.Set(header.XRateLimitReset, strconv.Itoa(int(quotaRenews)))
-	}
+	p.TykAPISpec.sendRateLimitHeaders(ses, res)
 
 	copyHeader(rw.Header(), res.Header, p.Gw.GetConfig().IgnoreCanonicalMIMEHeaderKey)
 

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -989,12 +989,6 @@ func (p *ReverseProxy) handleOutboundRequest(roundTripper *TykRoundTripper, outr
 		latency = time.Since(begin)
 	}()
 
-	if p.TykAPISpec.hasMock() {
-		if res, err = p.mockResponse(outreq); res != nil {
-			return
-		}
-	}
-
 	if p.TykAPISpec.GraphQL.Enabled {
 		res, hijacked, err = p.handleGraphQL(roundTripper, outreq, w)
 		return

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -1617,11 +1617,6 @@ func TestGraphQL_OptionsPassThrough(t *testing.T) {
 			Path:    "/starwars",
 			Headers: headers,
 			Code:    http.StatusOK,
-			HeadersMatch: map[string]string{
-				"Access-Control-Allow-Methods": http.MethodPost,
-				"Access-Control-Allow-Headers": "content-type",
-				"Access-Control-Allow-Origin":  "*",
-			},
 		})
 	})
 	t.Run("UDG should not pass through", func(t *testing.T) {

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -719,7 +719,15 @@ func (r RPCStorageHandler) RemoveFromSet(keyName, value string) {
 
 func (r RPCStorageHandler) IsRetriableError(err error) bool {
 	if err != nil {
-		return err.Error() == "Access Denied"
+		errMsg := err.Error()
+		// Access denied errors (authentication issues)
+		if errMsg == "Access Denied" {
+			return true
+		}
+		// Timeout errors from gorpc library
+		if strings.Contains(errMsg, "Cannot obtain response during timeout") {
+			return true
+		}
 	}
 	return false
 }

--- a/gateway/rpc_storage_handler_test.go
+++ b/gateway/rpc_storage_handler_test.go
@@ -779,3 +779,38 @@ func TestProcessKeySpaceChanges_UserKeyReset(t *testing.T) {
 		})
 	}
 }
+
+func TestIsRetriableError(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	rpcHandler := RPCStorageHandler{
+		KeyPrefix:        "rpc.listener.",
+		SuppressRegister: true,
+		Gw:               ts.Gw,
+	}
+
+	testCases := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "Access Denied error is retriable",
+			err:      errors.New("Access Denied"),
+			expected: true,
+		},
+		{
+			name:     "Timeout error is retriable",
+			err:      errors.New("Cannot obtain response during timeout=30s"),
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := rpcHandler.IsRetriableError(tc.err)
+			assert.Equal(t, tc.expected, result, "IsRetriableError(%v) should return %v", tc.err, tc.expected)
+		})
+	}
+}

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -1757,6 +1757,12 @@ func Start() {
 		sig := <-sigChan
 		mainLog.Infof("Shutdown signal received: %v. Initiating graceful shutdown...", sig)
 		cancel()
+
+		// we need to set default cfg value here as the ctx is created before the afterconf is executed
+		if gwConfig.GracefulShutdownTimeoutDuration == 0 {
+			gwConfig.GracefulShutdownTimeoutDuration = config.GracefulShutdownDefaultDuration
+		}
+
 		shutdownCtx, shutdownCancel := context.WithTimeout(
 			context.Background(), time.Duration(gwConfig.GracefulShutdownTimeoutDuration)*time.Second)
 		defer shutdownCancel()
@@ -2090,7 +2096,11 @@ func (gw *Gateway) gracefulShutdown(ctx context.Context) error {
 				// interrupting any active connections
 				if err := server.Shutdown(ctx); err != nil {
 					mainLog.Errorf("Error shutting down HTTP server on port %d: %v", port, err)
-					errChan <- err
+					select {
+					case errChan <- err:
+					default:
+						// Channel closed, ignore
+					}
 				}
 			}(p.httpServer, p.port)
 		}
@@ -2109,6 +2119,8 @@ func (gw *Gateway) gracefulShutdown(ctx context.Context) error {
 		mainLog.Info("All HTTP servers gracefully shut down")
 	case <-ctx.Done():
 		mainLog.Warning("Shutdown timeout reached, some connections may have been terminated")
+		// Wait for goroutines to finish even after timeout to prevent panic
+		<-serverShutdownDone
 	}
 
 	// Close all cache stores and other resources

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -950,7 +950,7 @@ func (gw *Gateway) createResponseMiddlewareChain(
 	spec *APISpec,
 	middlewares []apidef.MiddlewareDefinition,
 	log *logrus.Entry,
-) {
+) []TykResponseHandler {
 
 	var (
 		responseMWChain []TykResponseHandler
@@ -1025,9 +1025,7 @@ func (gw *Gateway) createResponseMiddlewareChain(
 		log.WithError(err).Debug("Failed to init processor")
 	}
 
-	responseMWChain = append(responseMWChain, processor)
-
-	spec.ResponseChain = responseMWChain
+	return append(responseMWChain, processor)
 }
 
 func (gw *Gateway) isRPCMode() bool {

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/TykTechnologies/tyk/tcp"
 	"github.com/TykTechnologies/tyk/trace"
 
 	"sync/atomic"
@@ -1753,6 +1754,10 @@ func Start() {
 	gw := NewGateway(gwConfig, ctx)
 	gwConfig = gw.GetConfig()
 
+	if err := gw.initSystem(); err != nil {
+		mainLog.Fatalf("Error initialising system: %v", err)
+	}
+
 	shutdownComplete := make(chan struct{})
 	go func() {
 		sig := <-sigChan
@@ -1772,10 +1777,6 @@ func Start() {
 		}
 		close(shutdownComplete)
 	}()
-
-	if err := gw.initSystem(); err != nil {
-		mainLog.Fatalf("Error initialising system: %v", err)
-	}
 
 	if !gw.isRunningTests() && gwConfig.ControlAPIPort == 0 {
 		mainLog.Warn("The control_api_port should be changed for production")
@@ -2077,6 +2078,64 @@ func (gw *Gateway) SetConfig(conf config.Config, skipReload ...bool) {
 	gw.configMu.Unlock()
 }
 
+// shutdownHTTPServer gracefully shuts down an HTTP server
+func (gw *Gateway) shutdownHTTPServer(ctx context.Context, server *http.Server, port int, wg *sync.WaitGroup, errChan chan<- error) {
+	if server == nil {
+		return
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		mainLog.Infof("Shutting down HTTP server on %s", server.Addr)
+
+		// Server.Shutdown gracefully shuts down the server without
+		// interrupting any active connections
+		if err := server.Shutdown(ctx); err != nil {
+			mainLog.Errorf("Error shutting down HTTP server on port %d: %v", port, err)
+			select {
+			case errChan <- err:
+			default:
+				// Channel closed, ignore
+			}
+		}
+	}()
+}
+
+// shutdownTCPProxy gracefully shuts down a TCP proxy
+func (gw *Gateway) shutdownTCPProxy(ctx context.Context, listener net.Listener, port int, protocol string, proxy *tcp.Proxy, wg *sync.WaitGroup, errChan chan<- error) {
+	if proxy == nil || listener == nil {
+		return
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		mainLog.Infof("Shutting down TCP proxy on port %d (%s)", port, protocol)
+
+		// Set the shutdown context to signal existing connections to terminate gracefully
+		proxy.SetShutdownContext(ctx)
+
+		// Close the listener to stop accepting new connections
+		// Note: This will cause Serve() to exit, but existing connections continue
+		if err := listener.Close(); err != nil {
+			mainLog.Errorf("Error shutting down TCP proxy listener on port %d: %v", port, err)
+			select {
+			case errChan <- err:
+			default:
+				// Channel closed, ignore
+			}
+		}
+
+		// Wait for all active connections to finish or timeout
+		if err := proxy.Shutdown(ctx); err != nil {
+			mainLog.Warnf("TCP proxy shutdown timeout on port %d: %v", port, err)
+		} else {
+			mainLog.Debugf("TCP proxy gracefully shut down on port %d", port)
+		}
+	}()
+}
+
 // gracefulShutdown performs a graceful shutdown of all services
 func (gw *Gateway) gracefulShutdown(ctx context.Context) error {
 	mainLog.Info("Stop signal received.")
@@ -2085,26 +2144,14 @@ func (gw *Gateway) gracefulShutdown(ctx context.Context) error {
 	var wg sync.WaitGroup
 	errChan := make(chan error, 10) // Buffer for potential errors
 
-	// Shutdown all HTTP servers in the proxy mux
+	// Shutdown all HTTP servers and TCP proxies in the proxy mux
 	gw.DefaultProxyMux.Lock()
 	for _, p := range gw.DefaultProxyMux.proxies {
 		if p.httpServer != nil {
-			wg.Add(1)
-			go func(server *http.Server, port int) {
-				defer wg.Done()
-				mainLog.Infof("Shutting down HTTP server on %s", server.Addr)
-
-				// Server.Shutdown gracefully shuts down the server without
-				// interrupting any active connections
-				if err := server.Shutdown(ctx); err != nil {
-					mainLog.Errorf("Error shutting down HTTP server on port %d: %v", port, err)
-					select {
-					case errChan <- err:
-					default:
-						// Channel closed, ignore
-					}
-				}
-			}(p.httpServer, p.port)
+			gw.shutdownHTTPServer(ctx, p.httpServer, p.port, &wg, errChan)
+		}
+		if p.tcpProxy != nil && p.listener != nil {
+			gw.shutdownTCPProxy(ctx, p.listener, p.port, p.protocol, p.tcpProxy, &wg, errChan)
 		}
 	}
 	gw.DefaultProxyMux.Unlock()
@@ -2118,7 +2165,7 @@ func (gw *Gateway) gracefulShutdown(ctx context.Context) error {
 
 	select {
 	case <-serverShutdownDone:
-		mainLog.Info("All HTTP servers gracefully shut down")
+		mainLog.Info("All HTTP servers and TCP proxies gracefully shut down")
 	case <-ctx.Done():
 		mainLog.Warning("Shutdown timeout reached, some connections may have been terminated")
 		// Wait for goroutines to finish even after timeout to prevent panic

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -623,11 +623,15 @@ func (gw *Gateway) syncPolicies() (count int, err error) {
 		mainLog.Debugf(" - %s", id)
 	}
 
+	if err != nil {
+		return len(pols), err
+	}
+
 	gw.policiesMu.Lock()
 	defer gw.policiesMu.Unlock()
 	gw.policiesByID = pols
 
-	return len(pols), err
+	return len(pols), nil
 }
 
 // stripSlashes removes any trailing slashes from the request's URL
@@ -1094,6 +1098,24 @@ func syncResourcesWithReload(resource string, conf config.Config, syncFunc func(
 		}
 
 		mainLog.Errorf("Error during syncing %s: %s, attempt count %d", resource, err.Error(), i)
+
+		// Check if this is the last attempt
+		if i == conf.ResourceSync.RetryAttempts+1 {
+			// For RPC-based resources, trigger emergency mode if all retries failed
+			if conf.SlaveOptions.UseRPC {
+				mainLog.Warningf("All %s sync attempts failed, triggering emergency mode", resource)
+				rpc.EnableEmergencyMode(true)
+
+				// Try one more time with emergency mode enabled
+				count, err = syncFunc()
+				if err == nil {
+					mainLog.Infof("Successfully loaded %s from backup after enabling emergency mode", resource)
+					return count, nil
+				}
+			}
+			break
+		}
+
 		time.Sleep(time.Duration(conf.ResourceSync.Interval) * time.Second)
 	}
 

--- a/gateway/server_test.go
+++ b/gateway/server_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/internal/netutil"
 	"github.com/TykTechnologies/tyk/internal/otel"
+	"github.com/TykTechnologies/tyk/rpc"
 	"github.com/TykTechnologies/tyk/test"
 	"github.com/TykTechnologies/tyk/user"
 )
@@ -210,7 +211,7 @@ func TestGateway_SyncResourcesWithReload(t *testing.T) {
 		syncFunc, hitCounter := syncFuncSuccessAt(t, 5)
 		startTime := time.Now()
 		resourceCount, err := syncResourcesWithReload("apis", ts.Gw.GetConfig(), syncFunc)
-		assert.Greater(t, time.Since(startTime), time.Second*3)
+		assert.Greater(t, time.Since(startTime), time.Second*2)
 		assert.ErrorIs(t, err, syncErr)
 		assert.Zero(t, resourceCount)
 		assert.Equal(t, 3, *hitCounter)
@@ -227,6 +228,48 @@ func TestGateway_SyncResourcesWithReload(t *testing.T) {
 		assert.Equal(t, 2, *hitCounter)
 	})
 
+	t.Run("RPC timeout triggers emergency mode and loads from backup", func(t *testing.T) {
+		t.Parallel()
+
+		// Configure gateway for RPC mode
+		conf := ts.Gw.GetConfig()
+		conf.SlaveOptions.UseRPC = true
+
+		// Create a sync function that simulates timeout errors initially, then succeeds when emergency mode is enabled
+		var hitCount int
+		timeoutError := errors.New("Cannot obtain response during timeout=30s")
+
+		syncFunc := func() (int, error) {
+			hitCount++
+
+			// Always fail with timeout for the first retryAttempts+1 attempts (normal + last attempt)
+			// This ensures emergency mode gets triggered properly
+			if hitCount <= retryAttempts+1 {
+				return 0, timeoutError
+			}
+
+			// Succeed when emergency mode is enabled (backup loading)
+			// This will be called after emergency mode is enabled
+			return 5, nil // Simulate loading 5 items from backup
+		}
+
+		// Ensure we start without emergency mode
+		rpc.ResetEmergencyMode()
+		defer rpc.ResetEmergencyMode()
+
+		// Test the sync with timeout -> emergency mode -> success flow
+		resourceCount, err := syncResourcesWithReload("policies", conf, syncFunc)
+
+		// Should succeed after triggering emergency mode
+		assert.NoError(t, err)
+		assert.Equal(t, 5, resourceCount)
+
+		// Should have attempted retries + 1 emergency mode attempt
+		assert.Equal(t, retryAttempts+2, hitCount)
+
+		// Emergency mode should be enabled
+		assert.True(t, rpc.IsEmergencyMode())
+	})
 }
 
 type gatewayGetHostDetailsTestCheckFn func(*testing.T, *test.BufferedLogger, *Gateway)

--- a/gateway/testutil.go
+++ b/gateway/testutil.go
@@ -638,13 +638,27 @@ func graphqlProxyUpstreamHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	w.WriteHeader(responseCode)
-	_, _ = w.Write([]byte(`{
+	response := []byte(`{
 		"data": {
 			"hello": "` + name + `",
 			"httpMethod": "` + r.Method + `",
 		}
-	}`))
+	}`)
+
+	// Only supports GZIP for testing purposes
+	acceptEncodingHeader := r.Header.Get("Accept-Encoding")
+	if acceptEncodingHeader != "" && strings.Contains(acceptEncodingHeader, "gzip") {
+		w.Header().Set("Content-Encoding", "gzip")
+		gz := gzip.NewWriter(w)
+		defer func() {
+			_ = gz.Close()
+		}()
+		w.WriteHeader(responseCode)
+		_, _ = gz.Write(response)
+		return
+	}
+	w.WriteHeader(responseCode)
+	_, _ = w.Write(response)
 }
 
 func graphqlDataSourceHandler(w http.ResponseWriter, r *http.Request) {

--- a/gateway/tracing.go
+++ b/gateway/tracing.go
@@ -52,14 +52,22 @@ type traceResponse struct {
 }
 
 type traceLogEntry struct {
-	ApiId   string     `json:"api_id,omitempty"`
-	ApiName string     `json:"api_name,omitempty"`
-	Level   string     `json:"level,omitempty"`
-	Msg     string     `json:"msg,omitempty"`
-	Mw      string     `json:"mw,omitempty"`
-	OrgId   string     `json:"org_id,omitempty"`
-	Ts      *time.Time `json:"time,omitempty"`
+	ApiId   string       `json:"api_id,omitempty"`
+	ApiName string       `json:"api_name,omitempty"`
+	Level   string       `json:"level,omitempty"`
+	Msg     string       `json:"msg,omitempty"`
+	Mw      string       `json:"mw,omitempty"`
+	OrgId   string       `json:"org_id,omitempty"`
+	Ts      *time.Time   `json:"time,omitempty"`
+	Type    traceLogType `json:"type"`
 }
+
+type traceLogType string
+
+const (
+	traceLogRequest  traceLogType = "request"
+	traceLogResponse traceLogType = "response"
+)
 
 func (tr *traceResponse) parseTrace() (*http.Request, *http.Response, error) {
 	return parseTrace(tr.Response)

--- a/gateway/tracing.go
+++ b/gateway/tracing.go
@@ -65,6 +65,10 @@ type traceLogEntry struct {
 
 type traceLogType string
 
+func (s traceLogType) String() string {
+	return string(s)
+}
+
 const (
 	traceLogRequest  traceLogType = "request"
 	traceLogResponse traceLogType = "response"
@@ -195,7 +199,6 @@ func (gw *Gateway) traceHandler(w http.ResponseWriter, r *http.Request) {
 	logger.Out = &logStorage
 
 	gs := gw.prepareStorage()
-	subrouter := mux.NewRouter()
 
 	loader := &APIDefinitionLoader{Gw: gw}
 	traceReq.Spec.IsOAS = true
@@ -217,7 +220,7 @@ func (gw *Gateway) traceHandler(w http.ResponseWriter, r *http.Request) {
 		logrus.NewEntry(logger),
 		WithQuotaKey(spec.Checksum),
 	)
-	gw.generateSubRoutes(spec, subrouter)
+	gw.generateSubRoutes(spec, mux.NewRouter())
 
 	if chainObj.ThisHandler == nil {
 		doJSONWrite(w, http.StatusBadRequest, traceResponse{Message: "error", Logs: logStorage.String()})

--- a/gateway/tracing_test.go
+++ b/gateway/tracing_test.go
@@ -3,7 +3,10 @@ package gateway
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
+	"github.com/google/uuid"
+	"github.com/mccutchen/go-httpbin/v2/httpbin"
 	"github.com/samber/lo"
 	"io"
 	"net/http"
@@ -19,239 +22,337 @@ import (
 	"github.com/TykTechnologies/tyk/apidef/oas"
 )
 
-func TestTraceHttpRequest_toRequest(t *testing.T) {
+func TestTraceHttpRequest(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	const body = `{"foo":"bar"}`
-	var headers = http.Header{}
-	headers.Add("key", "value")
-	headers.Add("Content-Type", "application/json")
+	testServer := httptest.NewServer(httpbin.New())
+	defer testServer.Close()
 
-	tr := traceRequest{
-		Request: &traceHttpRequest{Path: "", Method: http.MethodPost, Body: body, Headers: headers},
-		Spec: &apidef.APIDefinition{
-			Proxy: apidef.ProxyConfig{
-				ListenPath: "",
+	t.Run("#toRequest", func(t *testing.T) {
+		const body = `{"foo":"bar"}`
+		var headers = http.Header{}
+		headers.Add("key", "value")
+		headers.Add("Content-Type", "application/json")
+
+		tr := traceRequest{
+			Request: &traceHttpRequest{Path: "", Method: http.MethodPost, Body: body, Headers: headers},
+			Spec: &apidef.APIDefinition{
+				Proxy: apidef.ProxyConfig{
+					ListenPath: "",
+				},
 			},
-		},
-		OAS: &oas.OAS{},
-	}
+			OAS: &oas.OAS{},
+		}
 
-	request, err := tr.toRequest(ctx, ts.Gw.GetConfig().IgnoreCanonicalMIMEHeaderKey)
-	assert.NoError(t, err)
-	assert.NotNil(t, request)
+		request, err := tr.toRequest(ctx, ts.Gw.GetConfig().IgnoreCanonicalMIMEHeaderKey)
+		assert.NoError(t, err)
+		assert.NotNil(t, request)
 
-	bodyInBytes, err := io.ReadAll(request.Body)
-	assert.NoError(t, err)
+		bodyInBytes, err := io.ReadAll(request.Body)
+		assert.NoError(t, err)
 
-	assert.Equal(t, http.MethodPost, request.Method)
-	assert.Equal(t, "", request.URL.Host)
-	assert.Equal(t, "", request.URL.Path)
-	assert.Equal(t, headers, request.Header)
-	assert.Equal(t, string(bodyInBytes), body)
+		assert.Equal(t, http.MethodPost, request.Method)
+		assert.Equal(t, "", request.URL.Host)
+		assert.Equal(t, "", request.URL.Path)
+		assert.Equal(t, headers, request.Header)
+		assert.Equal(t, string(bodyInBytes), body)
+	})
+
+	t.Run("api-scoped rate limit works as expected", func(t *testing.T) {
+		oasDef, err := oas.NewOas(
+			oas.WithTestDefaults(),
+			oas.WithGlobalRateLimit(1, 60*time.Second),
+			oas.WithGet("/rate-limited-api", func(b *oas.EndpointBuilder) {
+				b.Mock(func(_ *oas.MockResponse) {})
+			}),
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, oasDef)
+
+		// Create trace request
+		traceReq := traceRequest{
+			Request: &traceHttpRequest{
+				Method: http.MethodGet,
+				Path:   "/test/rate-limited-api",
+			},
+			OAS: oasDef,
+		}
+
+		// Marshal trace request
+		reqBody, err := json.Marshal(traceReq)
+		require.NoError(t, err)
+		require.NotNil(t, reqBody)
+
+		// First request should succeed
+		req1 := httptest.NewRequest(http.MethodPost, "/debug/trace", bytes.NewReader(reqBody))
+		req1.Header.Set("Content-Type", "application/json")
+
+		// Listen path is empty
+
+		w1 := httptest.NewRecorder()
+		ts.Gw.traceHandler(w1, req1)
+		require.Equal(t, http.StatusOK, w1.Code)
+
+		// Second request should be rate limited
+		req2 := httptest.NewRequest(http.MethodPost, "/debug/trace", bytes.NewReader(reqBody))
+		req2.Header.Set("Content-Type", "application/json")
+
+		w2 := httptest.NewRecorder()
+		ts.Gw.traceHandler(w2, req2)
+
+		// Parse response
+		var traceResp2 traceResponse
+		err = json.Unmarshal(w2.Body.Bytes(), &traceResp2)
+		assert.NoError(t, err)
+
+		logs, err := traceResp2.logs()
+		require.NoError(t, err)
+
+		_, tResponse, err := traceResp2.parseTrace()
+		require.NoError(t, err)
+
+		defer func() {
+			_ = tResponse.Body.Close()
+		}()
+
+		// Verify rate limit response
+		assert.Equal(t, http.StatusTooManyRequests, tResponse.StatusCode)
+		require.True(t, lo.SomeBy(logs, func(item traceLogEntry) bool {
+			return strings.Contains(item.Msg, "API Rate Limit Exceeded")
+		}))
+	})
+
+	t.Run("endpoint-scoped rate limit middleware works as expected", func(t *testing.T) {
+		oasDef, err := oas.NewOas(
+			oas.WithTestDefaults(),
+			oas.WithGet("/rate-limited-api", func(b *oas.EndpointBuilder) {
+				b.Mock(func(_ *oas.MockResponse) {}).RateLimit(1, time.Second)
+			}),
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, oasDef)
+
+		// Create trace request
+		traceReq := traceRequest{
+			Request: &traceHttpRequest{
+				Method: http.MethodGet,
+				Path:   "/rate-limited-api",
+			},
+			OAS: oasDef,
+		}
+
+		// Marshal trace request
+		reqBody, err := json.Marshal(traceReq)
+		require.NoError(t, err)
+		require.NotNil(t, reqBody)
+
+		// First request should succeed
+		req1 := httptest.NewRequest(http.MethodPost, "/debug/trace", bytes.NewReader(reqBody))
+		req1.Header.Set("Content-Type", "application/json")
+		req1 = ts.withAuth(req1)
+
+		w1 := httptest.NewRecorder()
+		ts.Gw.traceHandler(w1, req1)
+		require.Equal(t, http.StatusOK, w1.Code)
+
+		// Second request should be rate limited
+		req2 := httptest.NewRequest(http.MethodPost, "/debug/trace", bytes.NewReader(reqBody))
+		req2.Header.Set("Content-Type", "application/json")
+
+		w2 := httptest.NewRecorder()
+		ts.Gw.traceHandler(w2, req2)
+
+		// Parse response
+		var traceResp2 traceResponse
+		err = json.Unmarshal(w2.Body.Bytes(), &traceResp2)
+		assert.NoError(t, err)
+
+		logs, err := traceResp2.logs()
+		require.NoError(t, err)
+
+		_, tResponse, err := traceResp2.parseTrace()
+		require.NoError(t, err)
+
+		// Verify rate limit response
+		require.Equal(t, http.StatusTooManyRequests, tResponse.StatusCode)
+		require.True(t, lo.SomeBy(logs, func(item traceLogEntry) bool {
+			return strings.Contains(item.Msg, "API Rate Limit Exceeded")
+		}))
+	})
+
+	t.Run("mock middleware works as expected", func(t *testing.T) {
+		type typedResponse struct {
+			Message string `json:"message"`
+		}
+
+		srcMessage := typedResponse{
+			Message: "knock knock this is mock",
+		}
+
+		msgJson, err := json.Marshal(srcMessage)
+		require.NoError(t, err)
+
+		oasDef, err := oas.NewOas(
+			oas.WithTestDefaults(),
+			oas.WithGet("/mock", func(b *oas.EndpointBuilder) {
+				b.Mock(func(mock *oas.MockResponse) {
+					mock.Code = http.StatusCreated
+					mock.Body = string(msgJson)
+					mock.Headers = append(mock.Headers, oas.Header{Name: "hello", Value: "world"})
+					mock.Headers = append(mock.Headers, oas.Header{Name: "Content-Type", Value: "application/json"})
+				})
+			}),
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, oasDef)
+
+		// Create trace request
+		traceReq := traceRequest{
+			Request: &traceHttpRequest{
+				Method: http.MethodGet,
+				Path:   "/mock",
+			},
+			OAS: oasDef,
+		}
+
+		reqBody, err := json.Marshal(traceReq)
+		require.NoError(t, err)
+		require.NotNil(t, reqBody)
+
+		req := httptest.NewRequest(http.MethodPost, "/debug/trace", bytes.NewReader(reqBody))
+		req.Header.Set("Content-Type", "application/json")
+
+		res := httptest.NewRecorder()
+		ts.Gw.traceHandler(res, req)
+		require.Equal(t, http.StatusOK, res.Code)
+
+		var traceResp traceResponse
+
+		err = json.NewDecoder(res.Body).Decode(&traceResp)
+		assert.NoError(t, err)
+
+		request, response, err := traceResp.parseTrace()
+		require.NoError(t, err)
+
+		defer func() {
+			_ = response.Body.Close()
+		}()
+
+		require.NotNil(t, request)
+		require.NotNil(t, response)
+
+		var mockedResponse typedResponse
+		require.Equal(t, http.StatusCreated, response.StatusCode)
+		err = json.NewDecoder(response.Body).Decode(&mockedResponse)
+		assert.NoError(t, err)
+		assert.Equal(t, srcMessage.Message, mockedResponse.Message)
+	})
+
+	t.Run("responds with log request/response logs", func(t *testing.T) {
+		type HeaderCnf struct {
+			Name  string
+			Value string
+		}
+
+		type UuidDto struct {
+			Uuid string `json:"uuid"`
+		}
+
+		type WrappedUuidDto struct {
+			Data UuidDto `json:"data"`
+		}
+
+		var hdr = HeaderCnf{Name: "Content-Type", Value: "application/json"}
+
+		oasDef, err := oas.NewOas(
+			oas.WithTestDefaults(),
+			oas.WithUpstreamUrl(testServer.URL),
+			oas.WithGet("/uuid", func(b *oas.EndpointBuilder) {
+				b.
+					TransformResponseHeaders(func(headers *oas.TransformHeaders) {
+						headers.AppendAddOp(hdr.Name, hdr.Value)
+					}).
+					TransformResponseBody(func(tb *oas.TransformBody) {
+						tb.Enabled = true
+						tb.Format = apidef.RequestJSON
+						tb.Body = base64.StdEncoding.EncodeToString([]byte(`{"data": {{ . | toJSON }}}`))
+					})
+			}),
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, oasDef)
+
+		traceReq := traceRequest{
+			Request: &traceHttpRequest{
+				Method: http.MethodGet,
+				Path:   "/uuid",
+			},
+			OAS: oasDef,
+		}
+
+		reqBody, err := json.Marshal(traceReq)
+		require.NoError(t, err)
+		require.NotNil(t, reqBody)
+
+		req := httptest.NewRequest(http.MethodPost, "/debug/trace", bytes.NewReader(reqBody))
+		req.Header.Set("Content-Type", "application/json")
+
+		res := httptest.NewRecorder()
+		ts.Gw.traceHandler(res, req)
+		require.Equal(t, http.StatusOK, res.Code)
+
+		var traceResp traceResponse
+		err = json.NewDecoder(res.Body).Decode(&traceResp)
+		assert.NoError(t, err)
+
+		request, response, err := traceResp.parseTrace()
+		require.NoError(t, err)
+
+		defer func() {
+			_ = response.Body.Close()
+		}()
+
+		require.NotNil(t, request)
+		require.NotNil(t, response)
+		require.Equal(t, http.StatusOK, response.StatusCode)
+
+		logs, err := traceResp.logs()
+		assert.NoError(t, err)
+
+		assert.Greater(t, lo.CountBy(logs, byType(traceLogResponse)), 0)
+		assert.True(t, lo.CountBy(logs, byMiddleware(new(HeaderInjector).Name())) > 0, "at least one mw log exist")
+		assert.Equal(t, response.Header.Values(hdr.Name), []string{hdr.Value})
+
+		responseBody, err := io.ReadAll(response.Body)
+		require.NoError(t, err)
+
+		// todo: should be replace by other struct cause of builder does not work properly
+		var uuidDto UuidDto
+		require.NoError(t, json.Unmarshal(responseBody, &uuidDto))
+
+		require.True(t, lo.CountBy(logs, byMiddleware(new(ResponseTransformMiddleware).Name())) > 0)
+		require.NoError(t, uuid.Validate(uuidDto.Uuid))
+	})
 }
 
-func TestTraceHandler_RateLimiterGlobalWorksAsExpected(t *testing.T) {
-	ts := StartTest(nil)
-	defer ts.Close()
+type cntPredicate[T any] func(T) bool
 
-	oasDef, err := oas.NewOas(
-		oas.WithTestDefaults(),
-		oas.WithGlobalRateLimit(1, 60*time.Second),
-		oas.WithGet("/rate-limited-api", func(b *oas.EndpointBuilder) {
-			b.Mock(func(_ *oas.MockResponse) {})
-		}),
-	)
-
-	require.NoError(t, err)
-	require.NotNil(t, oasDef)
-
-	// Create trace request
-	traceReq := traceRequest{
-		Request: &traceHttpRequest{
-			Method: http.MethodGet,
-			Path:   "/test/rate-limited-api",
-		},
-		OAS: oasDef,
+func byType(typ traceLogType) cntPredicate[traceLogEntry] {
+	return func(entry traceLogEntry) bool {
+		return entry.Type == typ
 	}
-
-	// Marshal trace request
-	reqBody, err := json.Marshal(traceReq)
-	require.NoError(t, err)
-	require.NotNil(t, reqBody)
-
-	// First request should succeed
-	req1 := httptest.NewRequest(http.MethodPost, "/debug/trace", bytes.NewReader(reqBody))
-	req1.Header.Set("Content-Type", "application/json")
-
-	// Listen path is empty
-
-	w1 := httptest.NewRecorder()
-	ts.Gw.traceHandler(w1, req1)
-	require.Equal(t, http.StatusOK, w1.Code)
-
-	// Second request should be rate limited
-	req2 := httptest.NewRequest(http.MethodPost, "/debug/trace", bytes.NewReader(reqBody))
-	req2.Header.Set("Content-Type", "application/json")
-
-	w2 := httptest.NewRecorder()
-	ts.Gw.traceHandler(w2, req2)
-
-	// Parse response
-	var traceResp2 traceResponse
-	err = json.Unmarshal(w2.Body.Bytes(), &traceResp2)
-	assert.NoError(t, err)
-
-	logs, err := traceResp2.logs()
-	require.NoError(t, err)
-
-	_, tResponse, err := traceResp2.parseTrace()
-	require.NoError(t, err)
-
-	defer func() {
-		_ = tResponse.Body.Close()
-	}()
-
-	// Verify rate limit response
-	assert.Equal(t, http.StatusTooManyRequests, tResponse.StatusCode)
-	require.True(t, lo.SomeBy(logs, func(item traceLogEntry) bool {
-		return strings.Contains(item.Msg, "API Rate Limit Exceeded")
-	}))
 }
 
-func TestTraceHandler_RateLimiterExceeded(t *testing.T) {
-	ts := StartTest(nil)
-	defer ts.Close()
-
-	oasDef, err := oas.NewOas(
-		oas.WithTestDefaults(),
-		oas.WithGet("/rate-limited-api", func(b *oas.EndpointBuilder) {
-			b.Mock(func(_ *oas.MockResponse) {}).RateLimit(1, time.Second)
-		}),
-	)
-
-	require.NoError(t, err)
-	require.NotNil(t, oasDef)
-
-	// Create trace request
-	traceReq := traceRequest{
-		Request: &traceHttpRequest{
-			Method: http.MethodGet,
-			Path:   "/rate-limited-api",
-		},
-		OAS: oasDef,
+func byMiddleware(mwName string) cntPredicate[traceLogEntry] {
+	return func(entry traceLogEntry) bool {
+		return entry.Mw == mwName
 	}
-
-	// Marshal trace request
-	reqBody, err := json.Marshal(traceReq)
-	require.NoError(t, err)
-	require.NotNil(t, reqBody)
-
-	// First request should succeed
-	req1 := httptest.NewRequest(http.MethodPost, "/debug/trace", bytes.NewReader(reqBody))
-	req1.Header.Set("Content-Type", "application/json")
-	req1 = ts.withAuth(req1)
-
-	w1 := httptest.NewRecorder()
-	ts.Gw.traceHandler(w1, req1)
-	require.Equal(t, http.StatusOK, w1.Code)
-
-	// Second request should be rate limited
-	req2 := httptest.NewRequest(http.MethodPost, "/debug/trace", bytes.NewReader(reqBody))
-	req2.Header.Set("Content-Type", "application/json")
-
-	w2 := httptest.NewRecorder()
-	ts.Gw.traceHandler(w2, req2)
-
-	// Parse response
-	var traceResp2 traceResponse
-	err = json.Unmarshal(w2.Body.Bytes(), &traceResp2)
-	assert.NoError(t, err)
-
-	logs, err := traceResp2.logs()
-	require.NoError(t, err)
-
-	_, tResponse, err := traceResp2.parseTrace()
-	require.NoError(t, err)
-
-	// Verify rate limit response
-	require.Equal(t, http.StatusTooManyRequests, tResponse.StatusCode)
-	require.True(t, lo.SomeBy(logs, func(item traceLogEntry) bool {
-		return strings.Contains(item.Msg, "API Rate Limit Exceeded")
-	}))
-}
-
-func TestTraceHandler_MockMiddlewareRespondsWithProvidedData(t *testing.T) {
-	ts := StartTest(nil)
-	defer ts.Close()
-
-	type typedResponse struct {
-		Message string `json:"message"`
-	}
-
-	srcMessage := typedResponse{
-		Message: "knock knock this is mock",
-	}
-
-	msgJson, err := json.Marshal(srcMessage)
-	require.NoError(t, err)
-
-	oasDef, err := oas.NewOas(
-		oas.WithTestDefaults(),
-		oas.WithGet("/mock", func(b *oas.EndpointBuilder) {
-			b.Mock(func(mock *oas.MockResponse) {
-				mock.Code = http.StatusCreated
-				mock.Body = string(msgJson)
-				mock.Headers = append(mock.Headers, oas.Header{Name: "hello", Value: "world"})
-				mock.Headers = append(mock.Headers, oas.Header{Name: "Content-Type", Value: "application/json"})
-			})
-		}),
-	)
-
-	require.NoError(t, err)
-	require.NotNil(t, oasDef)
-
-	// Create trace request
-	traceReq := traceRequest{
-		Request: &traceHttpRequest{
-			Method: http.MethodGet,
-			Path:   "/mock",
-		},
-		OAS: oasDef,
-	}
-
-	reqBody, err := json.Marshal(traceReq)
-	require.NoError(t, err)
-	require.NotNil(t, reqBody)
-
-	req := httptest.NewRequest(http.MethodPost, "/debug/trace", bytes.NewReader(reqBody))
-	req.Header.Set("Content-Type", "application/json")
-
-	res := httptest.NewRecorder()
-	ts.Gw.traceHandler(res, req)
-	require.Equal(t, http.StatusOK, res.Code)
-
-	var traceResp traceResponse
-
-	err = json.NewDecoder(res.Body).Decode(&traceResp)
-	assert.NoError(t, err)
-
-	request, response, err := traceResp.parseTrace()
-	require.NoError(t, err)
-
-	defer func() {
-		_ = response.Body.Close()
-	}()
-
-	require.NotNil(t, request)
-	require.NotNil(t, response)
-
-	var mockedResponse typedResponse
-	require.Equal(t, http.StatusCreated, response.StatusCode)
-	err = json.NewDecoder(response.Body).Decode(&mockedResponse)
-	assert.NoError(t, err)
-	assert.Equal(t, srcMessage.Message, mockedResponse.Message)
 }

--- a/gateway/tracing_test.go
+++ b/gateway/tracing_test.go
@@ -5,9 +5,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"github.com/google/uuid"
-	"github.com/mccutchen/go-httpbin/v2/httpbin"
-	"github.com/samber/lo"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -15,6 +12,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/internal/middleware"
+	"github.com/google/uuid"
+	"github.com/mccutchen/go-httpbin/v2/httpbin"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -64,7 +66,7 @@ func TestTraceHttpRequest(t *testing.T) {
 
 	t.Run("api-scoped rate limit works as expected", func(t *testing.T) {
 		oasDef, err := oas.NewOas(
-			oas.WithTestDefaults(),
+			oas.WithTestListenPathAndUpstream("/test", testServer.URL),
 			oas.WithGlobalRateLimit(1, 60*time.Second),
 			oas.WithGet("/rate-limited-api", func(b *oas.EndpointBuilder) {
 				b.Mock(func(_ *oas.MockResponse) {})
@@ -78,7 +80,7 @@ func TestTraceHttpRequest(t *testing.T) {
 		traceReq := traceRequest{
 			Request: &traceHttpRequest{
 				Method: http.MethodGet,
-				Path:   "/test/rate-limited-api",
+				Path:   "/rate-limited-api",
 			},
 			OAS: oasDef,
 		}
@@ -98,6 +100,21 @@ func TestTraceHttpRequest(t *testing.T) {
 		ts.Gw.traceHandler(w1, req1)
 		require.Equal(t, http.StatusOK, w1.Code)
 
+		var traceResp1 traceResponse
+		err = json.Unmarshal(w1.Body.Bytes(), &traceResp1)
+		assert.NoError(t, err)
+
+		_, tResponse1, err := traceResp1.parseTrace()
+		require.NoError(t, err)
+
+		// Verify rate limit response
+		assert.Equal(t, http.StatusOK, tResponse1.StatusCode)
+		logs1, err := traceResp1.logs()
+		assert.NoError(t, err)
+		require.True(t, lo.SomeBy(logs1, func(logEntry traceLogEntry) bool {
+			return logEntry.Mw == new(mockResponseMiddleware).Name() && logEntry.Code == middleware.StatusRespond
+		}))
+
 		// Second request should be rate limited
 		req2 := httptest.NewRequest(http.MethodPost, "/debug/trace", bytes.NewReader(reqBody))
 		req2.Header.Set("Content-Type", "application/json")
@@ -110,26 +127,22 @@ func TestTraceHttpRequest(t *testing.T) {
 		err = json.Unmarshal(w2.Body.Bytes(), &traceResp2)
 		assert.NoError(t, err)
 
-		logs, err := traceResp2.logs()
+		logs2, err := traceResp2.logs()
 		require.NoError(t, err)
 
-		_, tResponse, err := traceResp2.parseTrace()
+		_, tResponse2, err := traceResp2.parseTrace()
 		require.NoError(t, err)
-
-		defer func() {
-			_ = tResponse.Body.Close()
-		}()
 
 		// Verify rate limit response
-		assert.Equal(t, http.StatusTooManyRequests, tResponse.StatusCode)
-		require.True(t, lo.SomeBy(logs, func(item traceLogEntry) bool {
+		assert.Equal(t, http.StatusTooManyRequests, tResponse2.StatusCode)
+		require.True(t, lo.SomeBy(logs2, func(item traceLogEntry) bool {
 			return strings.Contains(item.Msg, "API Rate Limit Exceeded")
 		}))
 	})
 
 	t.Run("endpoint-scoped rate limit middleware works as expected", func(t *testing.T) {
 		oasDef, err := oas.NewOas(
-			oas.WithTestDefaults(),
+			oas.WithTestListenPathAndUpstream("/test", testServer.URL),
 			oas.WithGet("/rate-limited-api", func(b *oas.EndpointBuilder) {
 				b.Mock(func(_ *oas.MockResponse) {}).RateLimit(1, time.Second)
 			}),
@@ -199,13 +212,13 @@ func TestTraceHttpRequest(t *testing.T) {
 		require.NoError(t, err)
 
 		oasDef, err := oas.NewOas(
-			oas.WithTestDefaults(),
+			oas.WithTestListenPathAndUpstream("/test", testServer.URL),
 			oas.WithGet("/mock", func(b *oas.EndpointBuilder) {
 				b.Mock(func(mock *oas.MockResponse) {
 					mock.Code = http.StatusCreated
 					mock.Body = string(msgJson)
-					mock.Headers = append(mock.Headers, oas.Header{Name: "hello", Value: "world"})
-					mock.Headers = append(mock.Headers, oas.Header{Name: "Content-Type", Value: "application/json"})
+					mock.Headers.Add("hello", "world")
+					mock.Headers.Add(header.ContentType, "application/json")
 				})
 			}),
 		)
@@ -272,8 +285,7 @@ func TestTraceHttpRequest(t *testing.T) {
 		var hdr = HeaderCnf{Name: "Content-Type", Value: "application/json"}
 
 		oasDef, err := oas.NewOas(
-			oas.WithTestDefaults(),
-			oas.WithUpstreamUrl(testServer.URL),
+			oas.WithTestListenPathAndUpstream("/test", testServer.URL),
 			oas.WithGet("/uuid", func(b *oas.EndpointBuilder) {
 				b.
 					TransformResponseHeaders(func(headers *oas.TransformHeaders) {

--- a/gateway/tracing_test.go
+++ b/gateway/tracing_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"github.com/TykTechnologies/tyk/internal/oasbuilder"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -65,10 +66,10 @@ func TestTraceHttpRequest(t *testing.T) {
 	})
 
 	t.Run("api-scoped rate limit works as expected", func(t *testing.T) {
-		oasDef, err := oas.NewOas(
-			oas.WithTestListenPathAndUpstream("/test", testServer.URL),
-			oas.WithGlobalRateLimit(1, 60*time.Second),
-			oas.WithGet("/rate-limited-api", func(b *oas.EndpointBuilder) {
+		oasDef, err := oasbuilder.Build(
+			oasbuilder.WithTestListenPathAndUpstream("/test", testServer.URL),
+			oasbuilder.WithGlobalRateLimit(1, 60*time.Second),
+			oasbuilder.WithGet("/rate-limited-api", func(b *oasbuilder.EndpointBuilder) {
 				b.Mock(func(_ *oas.MockResponse) {})
 			}),
 		)
@@ -141,9 +142,9 @@ func TestTraceHttpRequest(t *testing.T) {
 	})
 
 	t.Run("endpoint-scoped rate limit middleware works as expected", func(t *testing.T) {
-		oasDef, err := oas.NewOas(
-			oas.WithTestListenPathAndUpstream("/test", testServer.URL),
-			oas.WithGet("/rate-limited-api", func(b *oas.EndpointBuilder) {
+		oasDef, err := oasbuilder.Build(
+			oasbuilder.WithTestListenPathAndUpstream("/test", testServer.URL),
+			oasbuilder.WithGet("/rate-limited-api", func(b *oasbuilder.EndpointBuilder) {
 				b.Mock(func(_ *oas.MockResponse) {}).RateLimit(1, time.Second)
 			}),
 		)
@@ -211,9 +212,9 @@ func TestTraceHttpRequest(t *testing.T) {
 		msgJson, err := json.Marshal(srcMessage)
 		require.NoError(t, err)
 
-		oasDef, err := oas.NewOas(
-			oas.WithTestListenPathAndUpstream("/test", testServer.URL),
-			oas.WithGet("/mock", func(b *oas.EndpointBuilder) {
+		oasDef, err := oasbuilder.Build(
+			oasbuilder.WithTestListenPathAndUpstream("/test", testServer.URL),
+			oasbuilder.WithGet("/mock", func(b *oasbuilder.EndpointBuilder) {
 				b.Mock(func(mock *oas.MockResponse) {
 					mock.Code = http.StatusCreated
 					mock.Body = string(msgJson)
@@ -284,9 +285,9 @@ func TestTraceHttpRequest(t *testing.T) {
 
 		var hdr = HeaderCnf{Name: "Content-Type", Value: "application/json"}
 
-		oasDef, err := oas.NewOas(
-			oas.WithTestListenPathAndUpstream("/test", testServer.URL),
-			oas.WithGet("/uuid", func(b *oas.EndpointBuilder) {
+		oasDef, err := oasbuilder.Build(
+			oasbuilder.WithTestListenPathAndUpstream("/test", testServer.URL),
+			oasbuilder.WithGet("/uuid", func(b *oasbuilder.EndpointBuilder) {
 				b.
 					TransformResponseHeaders(func(headers *oas.TransformHeaders) {
 						headers.AppendAddOp(hdr.Name, hdr.Value)

--- a/go.mod
+++ b/go.mod
@@ -105,6 +105,7 @@ require (
 	github.com/goccy/go-yaml v1.15.23
 	github.com/google/go-cmp v0.7.0
 	github.com/huandu/go-clone/generic v1.7.2
+	github.com/mccutchen/go-httpbin/v2 v2.18.2
 	github.com/nats-io/nats.go v1.38.0
 	github.com/newrelic/go-agent/v3 v3.35.1
 	github.com/newrelic/go-agent/v3/integrations/nrgorilla v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -1882,6 +1882,8 @@ github.com/mavricknz/asn1-ber v0.0.0-20151103223136-b9df1c2f4213 h1:3DongGRjJZvI
 github.com/mavricknz/asn1-ber v0.0.0-20151103223136-b9df1c2f4213/go.mod h1:v/ZufymxjcI3pnNmQIUQQKxnHLTblrjZ4MNLs5DrZ1o=
 github.com/mavricknz/ldap v0.0.0-20160227184754-f5a958005e43 h1:x4SDcUPDTMzuFEdWe5lTznj1echpsd0ApTkZOdwtm7g=
 github.com/mavricknz/ldap v0.0.0-20160227184754-f5a958005e43/go.mod h1:z76yvVwVulPd8FyifHe8UEHeud6XXaSan0ibi2sDy6w=
+github.com/mccutchen/go-httpbin/v2 v2.18.2 h1:UU5rd5ohZFX7ZyuTwINL4EBnParq0nM2JoJIVjA6hGQ=
+github.com/mccutchen/go-httpbin/v2 v2.18.2/go.mod h1:GBy5I7XwZ4ZLhT3hcq39I4ikwN9x4QUt6EAxNiR8Jus=
 github.com/mdelapenya/tlscert v0.1.0 h1:YTpF579PYUX475eOL+6zyEO3ngLTOUWck78NBuJVXaM=
 github.com/mdelapenya/tlscert v0.1.0/go.mod h1:wrbyM/DwbFCeCeqdPX/8c6hNOqQgbf0rUDErE1uD+64=
 github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=

--- a/internal/crypto/ciphers.go
+++ b/internal/crypto/ciphers.go
@@ -52,7 +52,8 @@ func TLSVersions(in []uint16) []string {
 
 // GetCiphers generates a list of CipherSuite from the available ciphers.
 func GetCiphers() []*CipherSuite {
-	ciphers := tls.CipherSuites()
+	ciphers := append(tls.CipherSuites(), tls.InsecureCipherSuites()...)
+
 	result := make([]*CipherSuite, 0, len(ciphers))
 
 	for _, cipher := range ciphers {
@@ -67,9 +68,31 @@ func GetCiphers() []*CipherSuite {
 func ResolveCipher(cipherName string) (uint16, error) {
 	ciphers := GetCiphers()
 	for _, cipher := range ciphers {
-		if strings.EqualFold(cipher.Name, cipherName) {
+		if cipherNamesEqual(cipherName, cipher.Name) {
 			return cipher.ID, nil
 		}
 	}
 	return 0, fmt.Errorf("cipher %s not found", cipherName)
+}
+
+func cipherNamesEqual(s1, s2 string) bool {
+	// Legacy names for the corresponding cipher suites with the correct _SHA256
+	// suffix, retained for backward compatibility.
+	// TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305   = TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+	// TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305 = TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+	//
+	// Reference:
+	// - https://github.com/golang/go/blob/master/src/crypto/tls/cipher_suites.go#L720
+	legacyAlias := map[string]string{
+		"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305":   "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+		"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305": "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+	}
+
+	original := s1
+
+	if alias, ok := legacyAlias[strings.ToUpper(s1)]; ok {
+		original = alias
+	}
+
+	return strings.EqualFold(original, s2)
 }

--- a/internal/crypto/ciphers_test.go
+++ b/internal/crypto/ciphers_test.go
@@ -42,6 +42,39 @@ func TestGetCiphers(t *testing.T) {
 	}
 }
 
+var legacyCipherSuites = []string{
+	"TLS_RSA_WITH_AES_128_CBC_SHA",
+	"TLS_RSA_WITH_RC4_128_SHA",
+	"TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+	"TLS_RSA_WITH_AES_256_CBC_SHA",
+	"TLS_RSA_WITH_AES_128_CBC_SHA256",
+	"TLS_RSA_WITH_AES_128_GCM_SHA256",
+	"TLS_RSA_WITH_AES_256_GCM_SHA384",
+	"TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
+	"TLS_ECDHE_RSA_WITH_RC4_128_SHA",
+	"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA",
+	"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+	"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+}
+
+func TestLegacyCipherSuites(t *testing.T) {
+	ciphers := GetCiphers()
+
+	totalCiphers := map[string]bool{}
+
+	for _, cipher := range ciphers {
+		totalCiphers[cipher.Name] = true
+	}
+
+	for _, cipher := range legacyCipherSuites {
+		if !totalCiphers[cipher] {
+			t.Errorf("Expected %s to be removed", cipher)
+		}
+	}
+}
+
 func TestResolveCipher(t *testing.T) {
 	testCases := []struct {
 		name     string
@@ -54,6 +87,8 @@ func TestResolveCipher(t *testing.T) {
 		{"Case insensitive", "tls_ecdhe_rsa_with_aes_128_gcm_sha256", 0xc02f, false},
 		{"Empty input", "", 0, true},
 		{"Partial match", "TLS_ECDHE", 0, true},
+		{"Legacy cipher TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305", "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305", 0xcca8, false},
+		{"Legacy cipher TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305", "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305", 0xcca9, false},
 	}
 
 	for _, tc := range testCases {
@@ -93,6 +128,57 @@ func TestTLSVersions(t *testing.T) {
 				if v != tc.expected[i] {
 					t.Errorf("Expected version %s at index %d, got %s", tc.expected[i], i, v)
 				}
+			}
+		})
+	}
+}
+
+func TestCipherNamesEqual(t *testing.T) {
+	cases := map[string]struct {
+		s1, s2   string
+		expected bool
+	}{
+		"canonical match": {
+			s1:       "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+			s2:       "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+			expected: true,
+		},
+		"legacy to canonical": {
+			s1:       "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+			s2:       "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+			expected: true,
+		},
+		"canonical to legacy": {
+			s1:       "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+			s2:       "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+			expected: false,
+		},
+		"ecdsa legacy to canonical": {
+			s1:       "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+			s2:       "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+			expected: true,
+		},
+		"ecdsa canonical to legacy": {
+			s1:       "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+			s2:       "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+			expected: false,
+		},
+		"case-insensitive": {
+			s1:       "tls_ecdhe_rsa_with_chacha20_poly1305",
+			s2:       "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+			expected: true,
+		},
+		"no match": {
+			s1:       "TLS_FAKE_CIPHER",
+			s2:       "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+			expected: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := cipherNamesEqual(tc.s1, tc.s2); got != tc.expected {
+				t.Errorf("compareCipherName(%q, %q) = %v; want %v", tc.s1, tc.s2, got, tc.expected)
 			}
 		})
 	}

--- a/internal/oasbuilder/builder.go
+++ b/internal/oasbuilder/builder.go
@@ -1,4 +1,4 @@
-package oas
+package oasbuilder
 
 import (
 	"errors"
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/TykTechnologies/tyk/apidef/oas"
 	"github.com/TykTechnologies/tyk/common/option"
 	tykheaders "github.com/TykTechnologies/tyk/header"
 	"github.com/TykTechnologies/tyk/internal/uuid"
@@ -15,33 +16,26 @@ import (
 )
 
 type (
-	// Builder OAS builder is responsible for providing methods for building valid OAS object.
 	Builder struct {
 		errors         []error
-		oas            *OAS
-		xTykAPIGateway *XTykAPIGateway
+		oas            *oas.OAS
+		xTykAPIGateway *oas.XTykAPIGateway
 	}
 
-	// EndpointBuilder OAS endpoint builder should be used for building endpoint and binding middlewares to it.
 	EndpointBuilder struct {
 		method string
 		path   string
 		errors []error
-		op     *Operation
+		op     *oas.Operation
 	}
 
-	// BuilderOption optional parameter should be used to define builder options in declarative way.
 	BuilderOption = option.Option[Builder]
 
-	// EndpointFactory factory method in which endpoint builder should be used.
 	EndpointFactory func(b *EndpointBuilder)
 )
 
 const (
 	minAllowedTimeFrameLength = time.Millisecond * 100
-
-	// UpstreamUrlDefault default upstream url for OAS
-	UpstreamUrlDefault = "http://localhost:3478/"
 )
 
 var (
@@ -50,13 +44,12 @@ var (
 	ErrEmptyApiSlug          = errors.New("empty api slug")
 )
 
-// NewOas returns an allocated *OAS due to provided options
-func NewOas(opts ...BuilderOption) (*OAS, error) {
-	return option.New(opts).Build(NewBuilder()).Build()
+func Build(opts ...BuilderOption) (*oas.OAS, error) {
+	return option.New(opts).Build(New()).Build()
 }
 
-func NewBuilder() Builder {
-	oasDef := OAS{}
+func New() Builder {
+	oasDef := oas.OAS{}
 
 	oasDef.OpenAPI = "3.0.0"
 	oasDef.Info = &openapi3.Info{
@@ -65,21 +58,21 @@ func NewBuilder() Builder {
 	}
 	oasDef.Paths = openapi3.NewPaths()
 
-	xTykAPIGateway := XTykAPIGateway{
-		Info: Info{},
+	xTykAPIGateway := oas.XTykAPIGateway{
+		Info: oas.Info{},
 
-		Server: Server{
-			ListenPath: ListenPath{
+		Server: oas.Server{
+			ListenPath: oas.ListenPath{
 				Strip: true,
 			},
 		},
 
-		Upstream: Upstream{
-			Proxy: &Proxy{Enabled: true},
+		Upstream: oas.Upstream{
+			Proxy: &oas.Proxy{Enabled: true},
 		},
 
-		Middleware: &Middleware{
-			Operations: Operations{},
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{},
 		},
 	}
 
@@ -94,7 +87,7 @@ func (b *Builder) appendErrors(errs ...error) {
 	b.errors = append(b.errors, errs...)
 }
 
-func (b *Builder) Build() (*OAS, error) {
+func (b *Builder) Build() (*oas.OAS, error) {
 	if len(b.errors) > 0 {
 		return nil, errors.Join(b.errors...)
 	}
@@ -104,8 +97,6 @@ func (b *Builder) Build() (*OAS, error) {
 	return b.oas, nil
 }
 
-// WithTestListenPathAndUpstream sets defaults options
-// to be sued for testing
 func WithTestListenPathAndUpstream(path, upstreamUrl string) BuilderOption {
 	return combine(
 		withRandomId(),
@@ -121,7 +112,6 @@ func WithListenPath(path string, strip bool) BuilderOption {
 	}
 }
 
-// combine combines some options
 func combine(opts ...BuilderOption) BuilderOption {
 	return func(b *Builder) {
 		for _, apply := range opts {
@@ -130,7 +120,6 @@ func combine(opts ...BuilderOption) BuilderOption {
 	}
 }
 
-// WithUpstreamUrl defines upstream url
 func WithUpstreamUrl(upstreamUrl string) BuilderOption {
 	return func(b *Builder) {
 		if _, err := url.Parse(upstreamUrl); err != nil {
@@ -151,7 +140,6 @@ func withRandomId() BuilderOption {
 	}
 }
 
-// WithGlobalRateLimit defines global rate limit
 func WithGlobalRateLimit(rate uint, duration time.Duration, enabled ...bool) BuilderOption {
 	return func(b *Builder) {
 		if rl, err := newRateLimit(rate, duration, enabled...); err != nil {
@@ -163,7 +151,7 @@ func WithGlobalRateLimit(rate uint, duration time.Duration, enabled ...bool) Bui
 	}
 }
 
-func newRateLimit(rate uint, duration time.Duration, enabled ...bool) (*RateLimit, error) {
+func newRateLimit(rate uint, duration time.Duration, enabled ...bool) (*oas.RateLimit, error) {
 	if duration < minAllowedTimeFrameLength {
 		return nil, ErrMinRateLimitExceeded
 	}
@@ -177,10 +165,10 @@ func newRateLimit(rate uint, duration time.Duration, enabled ...bool) (*RateLimi
 		enable = enabled[0]
 	}
 
-	return &RateLimit{
+	return &oas.RateLimit{
 		Enabled: enable,
 		Rate:    int(rate),
-		Per:     ReadableDuration(duration),
+		Per:     oas.ReadableDuration(duration),
 	}, nil
 }
 
@@ -197,22 +185,18 @@ func withEndpoint(method, path string, fn EndpointFactory) BuilderOption {
 	}
 }
 
-// WithGet add get endpoint/path to OAS
 func WithGet(path string, fn EndpointFactory) BuilderOption {
 	return withEndpoint(http.MethodGet, path, fn)
 }
 
-// WithPost add post endpoint/path to OAS
 func WithPost(path string, fn EndpointFactory) BuilderOption {
 	return withEndpoint(http.MethodPost, path, fn)
 }
 
-// WithPut add put endpoint/path to OAS
 func WithPut(path string, fn EndpointFactory) BuilderOption {
 	return withEndpoint(http.MethodPut, path, fn)
 }
 
-// WithDelete add delete endpoint/path to OAS
 func WithDelete(path string, fn EndpointFactory) BuilderOption {
 	return withEndpoint(http.MethodDelete, path, fn)
 }
@@ -222,18 +206,17 @@ func (eb *EndpointBuilder) RateLimit(amount uint, duration time.Duration, enable
 	if rl, err := newRateLimit(amount, duration, enabled...); err != nil {
 		eb.errors = append(eb.errors, err)
 	} else {
-		eb.operation().RateLimit = (*RateLimitEndpoint)(rl)
+		eb.operation().RateLimit = (*oas.RateLimitEndpoint)(rl)
 	}
 
 	return eb
 }
 
-// TransformResponseHeaders adds TransformResponseHeaders middleware to current endpoint.
-func (eb *EndpointBuilder) TransformResponseHeaders(factory func(*TransformHeaders)) *EndpointBuilder {
+func (eb *EndpointBuilder) TransformResponseHeaders(factory func(*oas.TransformHeaders)) *EndpointBuilder {
 	op := eb.operation().TransformResponseHeaders
 
 	if op == nil {
-		op = &TransformHeaders{Enabled: true}
+		op = &oas.TransformHeaders{Enabled: true}
 		eb.operation().TransformResponseHeaders = op
 	}
 
@@ -242,12 +225,11 @@ func (eb *EndpointBuilder) TransformResponseHeaders(factory func(*TransformHeade
 	return eb
 }
 
-// TransformResponseBody adds TransformResponseBody middleware to current endpoint.
-func (eb *EndpointBuilder) TransformResponseBody(factory func(*TransformBody)) *EndpointBuilder {
+func (eb *EndpointBuilder) TransformResponseBody(factory func(*oas.TransformBody)) *EndpointBuilder {
 	op := eb.operation().TransformResponseBody
 
 	if op == nil {
-		op = &TransformBody{Enabled: true}
+		op = &oas.TransformBody{Enabled: true}
 		eb.operation().TransformResponseBody = op
 	}
 
@@ -257,11 +239,11 @@ func (eb *EndpointBuilder) TransformResponseBody(factory func(*TransformBody)) *
 }
 
 func (eb *EndpointBuilder) MockDefault() *EndpointBuilder {
-	return eb.Mock(func(_ *MockResponse) {})
+	return eb.Mock(func(_ *oas.MockResponse) {})
 }
 
-func (eb *EndpointBuilder) Mock(fn func(mock *MockResponse)) *EndpointBuilder {
-	var mock MockResponse
+func (eb *EndpointBuilder) Mock(fn func(mock *oas.MockResponse)) *EndpointBuilder {
+	var mock oas.MockResponse
 	mock.Enabled = true
 	mock.Code = http.StatusOK
 	mock.Headers.Add(tykheaders.ContentType, tykheaders.ApplicationJSON)
@@ -277,9 +259,9 @@ func (eb *EndpointBuilder) operationId() string {
 	return strings.TrimPrefix(strings.ToLower(eb.path+eb.method), "/")
 }
 
-func (eb *EndpointBuilder) operation() *Operation {
+func (eb *EndpointBuilder) operation() *oas.Operation {
 	if eb.op == nil {
-		eb.op = &Operation{}
+		eb.op = &oas.Operation{}
 	}
 
 	return eb.op

--- a/internal/oasutil/servers.go
+++ b/internal/oasutil/servers.go
@@ -1,0 +1,162 @@
+package oasutil
+
+import (
+	"errors"
+	"fmt"
+	"github.com/getkin/kin-openapi/openapi3"
+	"strings"
+)
+
+var (
+	ErrParse                = errors.New("failed to parse")
+	ErrEmptyVariableName    = errors.New("empty variable name")
+	ErrVariableCollision    = errors.New("variable collision")
+	ErrUnexpectedCurlyBrace = errors.New("unexpected closing curly brace")
+	errUnreachable          = errors.New("unreachable")
+)
+
+const (
+	DefaultServerUrlPrefix = "pathParam"
+	openCurlyBrace         = '{'
+	closeCurlyBrace        = '}'
+)
+
+type ServerUrl struct {
+	// Url template acceptable by tyk extension
+	// eg "{subdomain:[a-z]+}.example.com" or "api.example.com"
+	Url string
+
+	// UrlNormalized acceptable by oas specification
+	// "{subdomain}.example.com"
+	UrlNormalized string
+
+	// Variables server variables
+	Variables map[string]*openapi3.ServerVariable
+}
+
+func newServerUrl(originUrl string) ServerUrl {
+	return ServerUrl{
+		Url: originUrl,
+	}
+}
+
+func (u *ServerUrl) addVariable(name, defaultValue string) error {
+	if u.Variables == nil {
+		u.Variables = make(map[string]*openapi3.ServerVariable)
+	}
+
+	if _, ok := u.Variables[name]; ok {
+		return ErrVariableCollision
+	}
+
+	u.Variables[name] = &openapi3.ServerVariable{
+		Default: defaultValue,
+	}
+
+	return nil
+}
+
+// ParseServerUrl
+// Url template e.g. "{subdomain:[a-z]+}.example.com" or "api.example.com"
+func ParseServerUrl(url string) (*ServerUrl, error) {
+	var parser serverUrlParser
+	return parser.parse(url)
+}
+
+type serverUrlParser struct {
+	url     string
+	pos     int
+	counter int
+}
+
+type serverVariable struct {
+	name, pattern string
+}
+
+func (p *serverUrlParser) parse(url string) (*ServerUrl, error) {
+	p.url = url
+
+	result := newServerUrl(url)
+
+	var buf []byte
+
+	for p.pos < len(url) {
+		ch := url[p.pos]
+
+		switch ch {
+		case closeCurlyBrace:
+			return nil, ErrUnexpectedCurlyBrace
+
+		case openCurlyBrace:
+			result.UrlNormalized += string(buf)
+			buf = nil
+
+			variable, err := p.extractValueBetweenBraces()
+
+			if err != nil {
+				return nil, err
+			}
+
+			if err = result.addVariable(variable.name, p.nextParamName()); err != nil {
+				return nil, err
+			}
+
+			result.UrlNormalized += string(openCurlyBrace) + variable.name + string(closeCurlyBrace)
+
+		default:
+			buf = append(buf, ch)
+			p.pos++
+		}
+	}
+
+	result.UrlNormalized += string(buf)
+
+	return &result, nil
+}
+
+func (p *serverUrlParser) extractValueBetweenBraces() (serverVariable, error) {
+	if p.url[p.pos] != openCurlyBrace {
+		return serverVariable{}, errUnreachable
+	}
+
+	p.pos++
+	start := p.pos
+
+	for p.pos < len(p.url) {
+		ch := p.url[p.pos]
+
+		switch {
+		case ch == closeCurlyBrace && p.pos == start:
+			return serverVariable{}, ErrEmptyVariableName
+		case ch == closeCurlyBrace:
+			p.pos++
+
+			var contents = p.url[start : p.pos-1]
+			var name = contents
+			var pattern = ""
+
+			if pos := strings.Index(contents, ":"); pos != -1 {
+				name = contents[:pos]
+				pattern = contents[pos+1:]
+			}
+
+			if len(contents) == 0 || len(name) == 0 {
+				return serverVariable{}, ErrEmptyVariableName
+			}
+
+			return serverVariable{
+				name:    name,
+				pattern: pattern,
+			}, nil
+		default:
+			p.pos++
+		}
+	}
+
+	return serverVariable{}, fmt.Errorf("%w: expected closing curly brace at position %d", ErrParse, p.pos)
+}
+
+func (p *serverUrlParser) nextParamName() string {
+	p.counter++
+	return fmt.Sprintf("%s%d", DefaultServerUrlPrefix, p.counter)
+}

--- a/internal/oasutil/servers_test.go
+++ b/internal/oasutil/servers_test.go
@@ -1,0 +1,91 @@
+package oasutil_test
+
+import (
+	"github.com/TykTechnologies/tyk/internal/oasutil"
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestParseServerUrl(t *testing.T) {
+	t.Run("positive test cases", func(t *testing.T) {
+		type testCase struct {
+			name     string
+			input    string
+			expected *oasutil.ServerUrl
+		}
+
+		for _, tCase := range []testCase{
+			{"simple test case", "example.com", &oasutil.ServerUrl{
+				Url:           "example.com",
+				UrlNormalized: "example.com",
+			}},
+			{"complex test case", "https://{subdomain:[a-z]+}.example.com/{version:v[0-9]+}", &oasutil.ServerUrl{
+				Url:           "https://{subdomain:[a-z]+}.example.com/{version:v[0-9]+}",
+				UrlNormalized: "https://{subdomain}.example.com/{version}",
+				Variables: map[string]*openapi3.ServerVariable{
+					"subdomain": {
+						Default: oasutil.DefaultServerUrlPrefix + "1",
+					},
+					"version": {
+						Default: oasutil.DefaultServerUrlPrefix + "2",
+					},
+				},
+			}},
+			{"accepts routes without patterns", "https://{subdomain}.example.com/{version}", &oasutil.ServerUrl{
+				Url:           "https://{subdomain}.example.com/{version}",
+				UrlNormalized: "https://{subdomain}.example.com/{version}",
+				Variables: map[string]*openapi3.ServerVariable{
+					"subdomain": {
+						Default: oasutil.DefaultServerUrlPrefix + "1",
+					},
+					"version": {
+						Default: oasutil.DefaultServerUrlPrefix + "2",
+					},
+				},
+			}},
+			{"one letter variable", "https://example.com/{v}/", &oasutil.ServerUrl{
+				Url:           "https://example.com/{v}/",
+				UrlNormalized: "https://example.com/{v}/",
+				Variables: map[string]*openapi3.ServerVariable{
+					"v": {
+						Default: oasutil.DefaultServerUrlPrefix + "1",
+					},
+				},
+			}},
+			{"parses empty line", "", &oasutil.ServerUrl{
+				Url:           "",
+				UrlNormalized: "",
+				Variables:     nil,
+			}},
+		} {
+			t.Run(tCase.name, func(t *testing.T) {
+				res, err := oasutil.ParseServerUrl(tCase.input)
+				assert.NoError(t, err)
+				assert.Equal(t, tCase.expected, res)
+			})
+		}
+	})
+
+	t.Run("error test cases", func(t *testing.T) {
+		type testCase struct {
+			name        string
+			input       string
+			expectedErr error
+		}
+
+		for _, tCase := range []testCase{
+			{"unexpected curly brace 1", "}example.com", oasutil.ErrUnexpectedCurlyBrace},
+			{"unexpected curly brace 2", "example}.com", oasutil.ErrUnexpectedCurlyBrace},
+			{"empty variable name", "example{}.com", oasutil.ErrEmptyVariableName},
+			{"empty variable name 2", "example{:[a-z]+}.com", oasutil.ErrEmptyVariableName},
+			{"no closed brace", "{example.com", oasutil.ErrParse},
+			{"server variable collision", "{version:[a-z]+}.example.com/{version:[0-9]+}", oasutil.ErrVariableCollision},
+		} {
+			t.Run(tCase.name, func(t *testing.T) {
+				_, err := oasutil.ParseServerUrl(tCase.input)
+				assert.ErrorContains(t, err, tCase.expectedErr.Error())
+			})
+		}
+	})
+}

--- a/internal/time/duration.go
+++ b/internal/time/duration.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -26,6 +27,15 @@ const (
 	Hour = time.Hour
 )
 
+const (
+	EndingHour        = "h"
+	EndingMinute      = "m"
+	EndingSecond      = "s"
+	EndingMillisecond = "ms"
+	EndingMicrosecond = "µs"
+	EndingNanosecond  = "ns"
+)
+
 // ReadableDuration is a type alias for time.Duration, so that shorthand notation can be used.
 // Examples of valid shorthand notations:
 // - "1h"   : one hour
@@ -41,7 +51,7 @@ type ReadableDuration time.Duration
 
 // MarshalJSON converts ReadableDuration into human-readable shorthand notation for time.Duration into json format.
 func (d ReadableDuration) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf(`"%s"`, time.Duration(d).String())), nil
+	return []byte(fmt.Sprintf(`"%s"`, d.format())), nil
 }
 
 // UnmarshalJSON converts human-readable shorthand notation for time.Duration into ReadableDuration from json format.
@@ -81,4 +91,51 @@ func (d ReadableDuration) Nanoseconds() int64 {
 // Microseconds returns ReadableDuration in microseconds.
 func (d ReadableDuration) Microseconds() int64 {
 	return Duration(d).Microseconds()
+}
+
+// formats time duration dur to validation pattern ^(\d+h)?(\d+m)?(\d+s)?(\d+ms)?(\d+µs)?(\d+ns)%
+func (d ReadableDuration) format() string {
+	if d == 0 {
+		return "0s"
+	}
+
+	var sb strings.Builder
+	var rest = int64(d)
+
+	if rest < 0 {
+		rest *= -1
+		sb.WriteByte('-')
+	}
+
+	for _, conv := range convertCases {
+		if rest == 0 {
+			break
+		}
+
+		curr := rest / int64(conv.duration)
+		rest -= curr * int64(conv.duration)
+
+		if curr == 0 {
+			continue
+		}
+
+		sb.WriteString(strconv.FormatInt(curr, 10))
+		sb.WriteString(conv.ending)
+	}
+
+	return sb.String()
+}
+
+type convertCase struct {
+	duration time.Duration
+	ending   string
+}
+
+var convertCases = []convertCase{
+	{time.Hour, EndingHour},
+	{time.Minute, EndingMinute},
+	{time.Second, EndingSecond},
+	{time.Millisecond, EndingMillisecond},
+	{time.Microsecond, EndingMicrosecond},
+	{time.Nanosecond, EndingNanosecond},
 }

--- a/internal/time/duration_test.go
+++ b/internal/time/duration_test.go
@@ -13,7 +13,7 @@ func TestReadableDuration_MarshalJSON(t *testing.T) {
 
 	t.Run("valid", func(t *testing.T) {
 		duration := ReadableDuration(time.Minute * 5)
-		expectedJSON := []byte(`"5m0s"`)
+		expectedJSON := []byte(`"5m"`)
 		resultJSON, err := json.Marshal(&duration)
 		assert.NoError(t, err)
 		assert.Equal(t, string(expectedJSON), string(resultJSON))
@@ -33,6 +33,27 @@ func TestReadableDuration_MarshalJSON(t *testing.T) {
 		resultJSON, err := json.Marshal(&duration)
 		assert.NoError(t, err)
 		assert.Equal(t, string(expectedJSON), string(resultJSON))
+	})
+
+	t.Run("90 seconds", func(t *testing.T) {
+		duration := ReadableDuration(time.Second * 90)
+		expectedJSON := []byte(`"1m30s"`)
+		resultJSON, err := json.Marshal(&duration)
+		assert.NoError(t, err)
+		assert.Equal(t, string(expectedJSON), string(resultJSON))
+	})
+
+	t.Run("complex duration", func(t *testing.T) {
+		duration := ReadableDuration(1*time.Hour + 2*time.Minute + 3*time.Second + 4*time.Millisecond + 5*time.Microsecond + 6*time.Nanosecond)
+		assert.Equal(t, "1h2m3s4ms5µs6ns", duration.format())
+
+		duration = ReadableDuration(1*time.Hour + (2+60)*time.Minute + 3*time.Second + 4*time.Millisecond + 5*time.Microsecond + 6*time.Nanosecond)
+		assert.Equal(t, "2h2m3s4ms5µs6ns", duration.format())
+	})
+
+	t.Run("negative duration", func(t *testing.T) {
+		duration := ReadableDuration(-1 * time.Second * 90)
+		assert.Equal(t, "-1m30s", duration.format())
 	})
 }
 

--- a/lib/apidef/version.go
+++ b/lib/apidef/version.go
@@ -1,0 +1,198 @@
+package apidef
+
+import (
+	"errors"
+	"fmt"
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/common/option"
+	"net/url"
+)
+
+const (
+	// BaseAPIID represents the parameter for the base API identifier.
+	// This is used to identify the original API that a version is based on.
+	BaseAPIID VersionParameter = iota
+
+	// BaseAPIVersionName represents the parameter for the base API version name.
+	// This is used to specify the name of the version in the base API.
+	BaseAPIVersionName
+
+	// NewVersionName represents the parameter for the new version name.
+	// This is used when creating a new version of an API.
+	NewVersionName
+
+	// SetDefault represents the parameter that determines if a version should be set as default.
+	// When true, the new version will be marked as the default version for the API.
+	SetDefault
+
+	// paramCount is used internally to track the number of version parameters.
+	paramCount
+)
+
+const TrueString = "true"
+
+var (
+	// ErrNewVersionRequired is returned when a new version name is required but not provided.
+	// This error occurs during validation when attempting to create a new API version.
+	ErrNewVersionRequired = errors.New("The new version name is required")
+)
+
+// VersionParameter represents the type of parameter used in API version configuration.
+// It defines the possible parameters that can be used when working with API versions.
+type VersionParameter int
+
+// String returns the string representation of a VersionParameter.
+// It converts the numeric parameter value to its corresponding string identifier.
+func (v VersionParameter) String() string {
+	return []string{"base_api_id", "base_api_version_name", "new_version_name", "set_default"}[v]
+}
+
+// AllVersionParameters returns a slice containing all available version parameters.
+// This is useful for iterating through all possible version parameters.
+func AllVersionParameters() []VersionParameter {
+	params := make([]VersionParameter, paramCount)
+	for i := range params {
+		params[i] = VersionParameter(i)
+	}
+
+	return params
+}
+
+// VersionQueryParameters holds the version-related parameters extracted from HTTP requests.
+// It provides methods to access and validate these parameters.
+type VersionQueryParameters struct {
+	versionParams map[string]string
+}
+
+// Validate checks if the version parameters are valid.
+// It takes a function that checks if the base API exists and returns an error if validation fails.
+// The doesBaseApiExists function should return whether the base API exists and its name.
+func (v *VersionQueryParameters) Validate(doesBaseApiExists func() (bool, string)) error {
+	if v.IsEmpty(BaseAPIID) {
+		return nil
+	}
+	baseID := v.Get(BaseAPIID)
+
+	if v.IsEmpty(NewVersionName) {
+		return ErrNewVersionRequired
+	}
+
+	exists, baseName := doesBaseApiExists()
+	if !exists {
+		return fmt.Errorf("%s is not a valid Base API version", baseID)
+	}
+
+	if v.IsEmpty(BaseAPIVersionName) && baseName == "" {
+		return fmt.Errorf("you need to provide a version name for the new Base API: %s", baseID)
+	}
+
+	return nil
+}
+
+// IsEmpty checks if a specific version parameter is empty or not set.
+// Returns true if the parameter is empty, false otherwise.
+func (v *VersionQueryParameters) IsEmpty(param VersionParameter) bool {
+	return v.versionParams[param.String()] == ""
+}
+
+// Get retrieves the value of a specific version parameter.
+// Returns the string value of the parameter.
+func (v *VersionQueryParameters) Get(param VersionParameter) string {
+	return v.versionParams[param.String()]
+}
+
+// NewVersionQueryParameters creates a new VersionQueryParameters instance from an HTTP request.
+// It extracts all version-related parameters from the request's URL query.
+func NewVersionQueryParameters(query url.Values) *VersionQueryParameters {
+	versionParams := &VersionQueryParameters{
+		versionParams: make(map[string]string, paramCount),
+	}
+
+	for _, param := range AllVersionParameters() {
+		paramName := param.String()
+		versionParams.versionParams[paramName] = query.Get(paramName)
+	}
+
+	return versionParams
+}
+
+// WithVersionName creates an option that sets the version name in a VersionDefinition.
+func WithVersionName(name string) option.Option[apidef.VersionDefinition] {
+	return func(version *apidef.VersionDefinition) {
+		version.Name = name
+	}
+}
+
+// WithBaseID creates an option that sets the version baseID in a VersionDefinition.
+func WithBaseID(id string) option.Option[apidef.VersionDefinition] {
+	return func(version *apidef.VersionDefinition) {
+		version.BaseID = id
+	}
+}
+
+// AddVersion creates an option that adds a version mapping to a VersionDefinition.
+// It associates a version name with an API ID in the Versions map.
+func AddVersion(versionName, apiID string) option.Option[apidef.VersionDefinition] {
+	return func(vd *apidef.VersionDefinition) {
+		vd.Versions[versionName] = apiID
+	}
+}
+
+// SetAsDefault creates an option that marks a specific version as the default.
+// This sets the Default field in the VersionDefinition to the specified version name.
+func SetAsDefault(versionName string) option.Option[apidef.VersionDefinition] {
+	return func(vd *apidef.VersionDefinition) {
+		vd.Default = versionName
+	}
+}
+
+// ConfigureVersionDefinition sets up the version definition with default values if not already set.
+// It applies the provided parameters to configure the version definition and ensures
+// that required fields have appropriate values.
+func ConfigureVersionDefinition(def apidef.VersionDefinition, params *VersionQueryParameters, newApiID string) apidef.VersionDefinition {
+	opts := make([]option.Option[apidef.VersionDefinition], 0)
+
+	if !params.IsEmpty(BaseAPIID) {
+		def.Enabled = true
+
+		if !params.IsEmpty(BaseAPIVersionName) {
+			opts = append(opts, WithVersionName(params.Get(BaseAPIVersionName)))
+		}
+
+		if !params.IsEmpty(SetDefault) {
+			setDefault := params.Get(SetDefault)
+			if setDefault == TrueString {
+				opts = append(opts, SetAsDefault(params.Get(NewVersionName)))
+			}
+		}
+
+		if !params.IsEmpty(BaseAPIID) {
+			opts = append(opts, WithBaseID(params.Get(BaseAPIID)))
+		}
+
+		opts = append(opts, AddVersion(params.Get(NewVersionName), newApiID))
+	}
+
+	// When baseAPIID is missing in the request params, and it's versioning is enabled then set versioning ID as APIID
+	if params.IsEmpty(BaseAPIID) && def.BaseID == "" {
+		def.BaseID = newApiID
+	}
+
+	if def.Key == "" {
+		def.Key = apidef.DefaultAPIVersionKey
+	}
+
+	if def.Location == "" {
+		def.Location = apidef.HeaderLocation
+	}
+
+	if def.Default == "" {
+		def.Default = apidef.Self
+	}
+
+	if def.Versions == nil {
+		def.Versions = make(map[string]string)
+	}
+
+	return *option.New(opts).Build(def)
+}

--- a/lib/apidef/version_test.go
+++ b/lib/apidef/version_test.go
@@ -1,0 +1,188 @@
+package apidef
+
+import (
+	"fmt"
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestVersionParameter_String(t *testing.T) {
+	assert.Equal(t, "base_api_id", BaseAPIID.String())
+	assert.Equal(t, "base_api_version_name", BaseAPIVersionName.String())
+	assert.Equal(t, "new_version_name", NewVersionName.String())
+	assert.Equal(t, "set_default", SetDefault.String())
+}
+
+func TestVersionQueryParameters_Validate(t *testing.T) {
+	baseApiExists := func(exists bool, name string) func() (bool, string) {
+		return func() (bool, string) {
+			return exists, name
+		}
+	}
+
+	existentApiName := "existing-api"
+	nonExistentApiName := "non-existent-api"
+
+	t.Run("Empty base ID", func(t *testing.T) {
+		queryParams := &VersionQueryParameters{
+			versionParams: map[string]string{
+				BaseAPIID.String(): "",
+			},
+		}
+		err := queryParams.Validate(baseApiExists(false, ""))
+		assert.NoError(t, err)
+	})
+
+	t.Run("Non-existent base API", func(t *testing.T) {
+		queryParams := &VersionQueryParameters{
+			versionParams: map[string]string{
+				BaseAPIID.String():      nonExistentApiName,
+				NewVersionName.String(): "v1",
+			},
+		}
+		err := queryParams.Validate(baseApiExists(false, nonExistentApiName))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), fmt.Sprintf("%s is not a valid Base API version", nonExistentApiName))
+	})
+
+	t.Run("Missing version name - empty base name", func(t *testing.T) {
+		queryParams := &VersionQueryParameters{
+			versionParams: map[string]string{
+				BaseAPIID.String():          existentApiName,
+				NewVersionName.String():     "v1",
+				BaseAPIVersionName.String(): "",
+			},
+		}
+		err := queryParams.Validate(baseApiExists(true, ""))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), fmt.Sprintf("you need to provide a version name for the new Base API: %s", existentApiName))
+	})
+
+	t.Run("Missing version name - non empty base name", func(t *testing.T) {
+		queryParams := &VersionQueryParameters{
+			versionParams: map[string]string{
+				BaseAPIID.String():          existentApiName,
+				NewVersionName.String():     "v1",
+				BaseAPIVersionName.String(): "",
+			},
+		}
+		err := queryParams.Validate(baseApiExists(true, "baseID"))
+		assert.NoError(t, err)
+	})
+
+	t.Run("Valid parameters", func(t *testing.T) {
+		queryParams := &VersionQueryParameters{
+			versionParams: map[string]string{
+				BaseAPIID.String():          existentApiName,
+				NewVersionName.String():     "v2",
+				BaseAPIVersionName.String(): "v1",
+			},
+		}
+		err := queryParams.Validate(baseApiExists(true, "v1"))
+		assert.NoError(t, err)
+	})
+}
+
+func TestVersionQueryParameters_IsEmpty(t *testing.T) {
+	queryParams := &VersionQueryParameters{
+		versionParams: map[string]string{
+			BaseAPIID.String():          "api-123",
+			BaseAPIVersionName.String(): "v1",
+			NewVersionName.String():     "",
+		},
+	}
+
+	assert.False(t, queryParams.IsEmpty(BaseAPIID))
+	assert.False(t, queryParams.IsEmpty(BaseAPIVersionName))
+
+	assert.True(t, queryParams.IsEmpty(NewVersionName))
+	assert.True(t, queryParams.IsEmpty(SetDefault))
+}
+
+func TestVersionQueryParameters_Get(t *testing.T) {
+	queryParams := &VersionQueryParameters{
+		versionParams: map[string]string{
+			BaseAPIID.String():          "api-123",
+			BaseAPIVersionName.String(): "v1",
+		},
+	}
+
+	assert.Equal(t, "api-123", queryParams.Get(BaseAPIID))
+	assert.Equal(t, "v1", queryParams.Get(BaseAPIVersionName))
+
+	assert.Empty(t, queryParams.Get(NewVersionName))
+}
+
+func TestAllVersionParameters(t *testing.T) {
+	params := AllVersionParameters()
+	assert.Len(t, params, int(paramCount))
+	assert.Contains(t, params, BaseAPIID)
+	assert.Contains(t, params, BaseAPIVersionName)
+	assert.Contains(t, params, NewVersionName)
+	assert.Contains(t, params, SetDefault)
+}
+
+func TestNewVersionQueryParameters(t *testing.T) {
+	baseAPIID := "api-123"
+	baseVersion := "v1"
+	newVersion := "v2"
+	setDefault := "true"
+
+	u, _ := url.Parse(fmt.Sprintf("http://example.com/api?base_api_id=%s&base_api_version_name=%s&new_version_name=%s&set_default=%s", baseAPIID, baseVersion, newVersion, setDefault))
+	req := &http.Request{
+		URL: u,
+	}
+
+	queryParams := NewVersionQueryParameters(req.URL.Query())
+
+	assert.Equal(t, baseAPIID, queryParams.Get(BaseAPIID))
+	assert.Equal(t, baseVersion, queryParams.Get(BaseAPIVersionName))
+	assert.Equal(t, newVersion, queryParams.Get(NewVersionName))
+	assert.Equal(t, setDefault, queryParams.Get(SetDefault))
+}
+
+func TestConfigureVersionDefinition(t *testing.T) {
+	baseName := "v1"
+	versionName := "v2"
+	apiID := "api-123"
+
+	t.Run("Basic configuration", func(t *testing.T) {
+		baseDefinition := apidef.VersionDefinition{}
+		versionParams := &VersionQueryParameters{
+			versionParams: map[string]string{
+				BaseAPIID.String():          apiID,
+				BaseAPIVersionName.String(): baseName,
+				NewVersionName.String():     versionName,
+			},
+		}
+
+		result := ConfigureVersionDefinition(baseDefinition, versionParams, apiID)
+
+		assert.True(t, result.Enabled)
+		assert.Equal(t, apiID, result.BaseID)
+		assert.Equal(t, baseName, result.Name)
+		assert.Equal(t, apidef.DefaultAPIVersionKey, result.Key)
+		assert.Equal(t, apidef.HeaderLocation, result.Location)
+		assert.Equal(t, apidef.Self, result.Default)
+		assert.Equal(t, apiID, result.Versions[versionName])
+	})
+
+	t.Run("With set default", func(t *testing.T) {
+		baseDefinition := apidef.VersionDefinition{}
+		versionParams := &VersionQueryParameters{
+			versionParams: map[string]string{
+				BaseAPIID.String():      apiID,
+				NewVersionName.String(): versionName,
+				SetDefault.String():     "true",
+			},
+		}
+
+		result := ConfigureVersionDefinition(baseDefinition, versionParams, apiID)
+
+		assert.Equal(t, versionName, result.Default)
+		assert.Equal(t, apiID, result.Versions[versionName])
+	})
+}

--- a/rpc/dns_resolver.go
+++ b/rpc/dns_resolver.go
@@ -1,0 +1,130 @@
+package rpc
+
+import (
+	"net"
+	"sync"
+)
+
+var (
+	// for dns monitoring
+	lastResolvedIPs []string
+	dnsRefreshMutex sync.RWMutex
+
+	// global resolver to be replaced in tests
+	dnsResolver DNSResolver = &DefaultDNSResolver{}
+
+	// declare funcs as vars that we can override in testing
+	safeReconnectRPCClient func(suppressRegister bool)
+)
+
+//nolint:gochecknoinits
+func init() {
+	safeReconnectRPCClient = defaultSafeReconnectRPCClient
+}
+
+// DNSResolver provides methods for DNS resolution
+type DNSResolver interface {
+	LookupIP(host string) ([]net.IP, error)
+}
+
+// DefaultDNSResolver implements DNSResolver using the standard library
+type DefaultDNSResolver struct{}
+
+func (r *DefaultDNSResolver) LookupIP(host string) ([]net.IP, error) {
+	return net.LookupIP(host)
+}
+
+// updateResolvedIPs checks if DNS resolution has changed using the provided resolver
+func updateResolvedIPs(host string, resolver DNSResolver) bool {
+	ips, err := resolver.LookupIP(host)
+	if err != nil {
+		Log.Error("Failed to resolve host during DNS refresh:", err)
+		return false
+	}
+
+	// Extract IPv4 addresses
+	newIPs := make([]string, 0, len(ips))
+	for _, ip := range ips {
+		if ipv4 := ip.To4(); ipv4 != nil {
+			newIPs = append(newIPs, ipv4.String())
+		}
+	}
+
+	dnsRefreshMutex.Lock()
+	defer dnsRefreshMutex.Unlock()
+
+	// Check if IPs have changed
+	changed := !equalStringSlices(lastResolvedIPs, newIPs)
+	if changed {
+		Log.Debug("DNS resolution changed from", lastResolvedIPs, "to", newIPs)
+		lastResolvedIPs = newIPs
+	}
+
+	return changed
+}
+
+// checkDNSAndReconnect checks if DNS resolution has changed and reconnects if needed
+func checkDNSAndReconnect(connectionString string, suppressRegister bool) bool {
+	host, _, err := net.SplitHostPort(connectionString)
+	if err != nil {
+		Log.Error("Failed to parse connection string for DNS check:", err)
+		return false
+	}
+
+	// Check if DNS has changed
+	if changed := updateResolvedIPs(host, dnsResolver); changed {
+		Log.Info("MDCB DNS resolution changed, reconnecting as self-healing mechanism...")
+		safeReconnectRPCClient(suppressRegister)
+		return true
+	}
+	return false
+}
+
+// checkAndHandleDNSChange checks if DNS has changed and handles reconnection if needed.
+// Returns true if DNS changed and reconnection was attempted, false otherwise.
+// Also returns a boolean indicating whether the function should retry the RPC call.
+func checkAndHandleDNSChange(connectionString string, suppressRegister bool) (dnsChanged bool, shouldRetry bool) {
+
+	// Skip if we've already checked DNS after an error, or we're in emergency mode
+	if values.GetDNSCheckedAfterError() || values.GetEmergencyMode() {
+		Log.Debug("Skipping DNS check - already checked or in emergency mode")
+		return false, false
+	}
+
+	// Mark that we've checked DNS
+	values.SetDNSCheckedAfterError(true)
+	Log.Info("RPC error detected, checking DNS as self-healing mechanism...")
+
+	// Check if DNS has changed and reconnect if needed
+	if changed := checkDNSAndReconnect(connectionString, suppressRegister); changed {
+		return true, true // DNS changed, should retry
+	}
+
+	// DNS hasn't changed
+	Log.Warning("MDCB connection failed. DNS unchanged - check MDCB service and network.")
+	return false, false // DNS unchanged, should not retry
+}
+
+func defaultSafeReconnectRPCClient(suppressRegister bool) {
+	// Stop existing client
+	if clientSingleton != nil {
+		oldClient := clientSingleton
+		clientSingleton = nil // Clear reference first
+		oldClient.Stop()      // Then stop the old client
+	}
+
+	// Reinitialize client
+	Log.Info("Reinitializing RPC client after DNS change...")
+	initializeClient()
+
+	// Reinitialize function client
+	if dispatcher != nil {
+		funcClientSingleton = dispatcher.NewFuncClient(clientSingleton)
+	}
+
+	// Relogin
+	handleLogin()
+	if !suppressRegister {
+		register()
+	}
+}

--- a/rpc/dns_resolver_test.go
+++ b/rpc/dns_resolver_test.go
@@ -1,0 +1,501 @@
+package rpc
+
+import (
+	"errors"
+	"net"
+	"testing"
+)
+
+// Helper function to create IP addresses for testing
+func makeIPs(ips ...string) []net.IP {
+	result := make([]net.IP, len(ips))
+	for i, ip := range ips {
+		result[i] = net.ParseIP(ip)
+	}
+	return result
+}
+
+// MockDNSResolver implements DNSResolver for testing
+type MockDNSResolver struct {
+	LookupIPFunc func(host string) ([]net.IP, error)
+}
+
+func (m *MockDNSResolver) LookupIP(host string) ([]net.IP, error) {
+	return m.LookupIPFunc(host)
+}
+
+func TestCheckDNSAndReconnect(t *testing.T) {
+	// Save original values and restore after test
+	originalSafeReconnect := safeReconnectRPCClient
+	originalIPs := lastResolvedIPs
+	originalResolver := dnsResolver
+
+	defer func() {
+		safeReconnectRPCClient = originalSafeReconnect
+		lastResolvedIPs = originalIPs
+		dnsResolver = originalResolver
+	}()
+
+	// Test cases
+	tests := []struct {
+		name                string
+		connectionString    string
+		initialIPs          []string
+		resolvedIPs         []net.IP
+		resolveError        error
+		expectedResult      bool
+		expectReconnectCall bool
+		expectDNSLookup     bool
+	}{
+		{
+			name:                "DNS changed - should reconnect",
+			connectionString:    "example.com:8080",
+			initialIPs:          []string{"192.168.1.1"},
+			resolvedIPs:         makeIPs("192.168.1.2"),
+			resolveError:        nil,
+			expectedResult:      true,
+			expectReconnectCall: true,
+			expectDNSLookup:     true,
+		},
+		{
+			name:                "DNS unchanged - should not reconnect",
+			connectionString:    "example.com:8080",
+			initialIPs:          []string{"192.168.1.1"},
+			resolvedIPs:         makeIPs("192.168.1.1"),
+			resolveError:        nil,
+			expectedResult:      false,
+			expectReconnectCall: false,
+			expectDNSLookup:     true,
+		},
+		{
+			name:                "DNS resolution error - should not reconnect",
+			connectionString:    "example.com:8080",
+			initialIPs:          []string{"192.168.1.1"},
+			resolvedIPs:         nil,
+			resolveError:        errors.New("DNS resolution failed"),
+			expectedResult:      false,
+			expectReconnectCall: false,
+			expectDNSLookup:     true,
+		},
+		{
+			name:                "Invalid connection string - should not check DNS or reconnect",
+			connectionString:    "invalid-no-port", // Missing port
+			initialIPs:          []string{"192.168.1.1"},
+			resolvedIPs:         makeIPs("192.168.1.2"),
+			resolveError:        nil,
+			expectedResult:      false,
+			expectReconnectCall: false,
+			expectDNSLookup:     false,
+		},
+		{
+			name:                "Empty connection string - should not check DNS or reconnect",
+			connectionString:    "",
+			initialIPs:          []string{"192.168.1.1"},
+			resolvedIPs:         makeIPs("192.168.1.2"),
+			resolveError:        nil,
+			expectedResult:      false,
+			expectReconnectCall: false,
+			expectDNSLookup:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set initial IPs
+			lastResolvedIPs = tt.initialIPs
+
+			// Create a mock resolver
+			dnsLookupCalled := false
+			mockResolver := &MockDNSResolver{}
+			mockResolver.LookupIPFunc = func(_ string) ([]net.IP, error) {
+				dnsLookupCalled = true
+				return tt.resolvedIPs, tt.resolveError
+			}
+			dnsResolver = mockResolver
+
+			// Create a mock reconnect function
+			reconnectCalled := false
+			safeReconnectRPCClient = func(_ bool) {
+				reconnectCalled = true
+			}
+
+			// Call the function
+			result := checkDNSAndReconnect(tt.connectionString, false)
+
+			// Check result
+			if result != tt.expectedResult {
+				t.Errorf("checkDNSAndReconnect() = %v, expected %v", result, tt.expectedResult)
+			}
+
+			// Check if reconnect was called as expected
+			if reconnectCalled != tt.expectReconnectCall {
+				t.Errorf("reconnect called = %v, expected %v", reconnectCalled, tt.expectReconnectCall)
+			}
+
+			// Check if DNS lookup was performed as expected
+			if dnsLookupCalled != tt.expectDNSLookup {
+				t.Errorf("DNS lookup performed = %v, expected %v", dnsLookupCalled, tt.expectDNSLookup)
+			}
+		})
+	}
+}
+
+func TestUpdateResolvedIPs(t *testing.T) {
+	// Save original values and restore after test
+	originalIPs := lastResolvedIPs
+	defer func() {
+		lastResolvedIPs = originalIPs
+	}()
+
+	// Create a mock resolver
+	mockResolver := &MockDNSResolver{}
+
+	// Test cases
+	tests := []struct {
+		name           string
+		initialIPs     []string
+		resolvedIPs    []net.IP
+		resolveError   error
+		expectedResult bool
+		expectedIPs    []string
+	}{
+		{
+			name:           "first resolution",
+			initialIPs:     nil,
+			resolvedIPs:    makeIPs("192.168.1.1", "192.168.1.2"),
+			resolveError:   nil,
+			expectedResult: true,
+			expectedIPs:    []string{"192.168.1.1", "192.168.1.2"},
+		},
+		{
+			name:           "same IPs",
+			initialIPs:     []string{"192.168.1.1", "192.168.1.2"},
+			resolvedIPs:    makeIPs("192.168.1.1", "192.168.1.2"),
+			resolveError:   nil,
+			expectedResult: false,
+			expectedIPs:    []string{"192.168.1.1", "192.168.1.2"},
+		},
+		{
+			name:           "different IPs",
+			initialIPs:     []string{"192.168.1.1", "192.168.1.2"},
+			resolvedIPs:    makeIPs("192.168.1.1", "192.168.1.3"),
+			resolveError:   nil,
+			expectedResult: true,
+			expectedIPs:    []string{"192.168.1.1", "192.168.1.3"},
+		},
+		{
+			name:           "different order",
+			initialIPs:     []string{"192.168.1.1", "192.168.1.2"},
+			resolvedIPs:    makeIPs("192.168.1.2", "192.168.1.1"),
+			resolveError:   nil,
+			expectedResult: false,                                  // Order doesn't matter
+			expectedIPs:    []string{"192.168.1.1", "192.168.1.2"}, // Original IPs should remain
+		},
+		{
+			name:           "more IPs",
+			initialIPs:     []string{"192.168.1.1", "192.168.1.2"},
+			resolvedIPs:    makeIPs("192.168.1.1", "192.168.1.2", "192.168.1.3"),
+			resolveError:   nil,
+			expectedResult: true,
+			expectedIPs:    []string{"192.168.1.1", "192.168.1.2", "192.168.1.3"},
+		},
+		{
+			name:           "fewer IPs",
+			initialIPs:     []string{"192.168.1.1", "192.168.1.2", "192.168.1.3"},
+			resolvedIPs:    makeIPs("192.168.1.1", "192.168.1.2"),
+			resolveError:   nil,
+			expectedResult: true,
+			expectedIPs:    []string{"192.168.1.1", "192.168.1.2"},
+		},
+		{
+			name:           "resolve error",
+			initialIPs:     []string{"192.168.1.1", "192.168.1.2"},
+			resolvedIPs:    nil,
+			resolveError:   errors.New("DNS resolution failed"),
+			expectedResult: false,
+			expectedIPs:    []string{"192.168.1.1", "192.168.1.2"}, // Original IPs should remain
+		},
+		{
+			name:           "mixed IPv4 and IPv6",
+			initialIPs:     []string{"192.168.1.1"},
+			resolvedIPs:    []net.IP{net.ParseIP("192.168.1.1"), net.ParseIP("2001:db8::1")},
+			resolveError:   nil,
+			expectedResult: false, // Only IPv4 addresses are considered, so no change
+			expectedIPs:    []string{"192.168.1.1"},
+		},
+		{
+			name:           "only IPv6",
+			initialIPs:     []string{"192.168.1.1"},
+			resolvedIPs:    []net.IP{net.ParseIP("2001:db8::1"), net.ParseIP("2001:db8::2")},
+			resolveError:   nil,
+			expectedResult: true,       // All IPv4 addresses are gone
+			expectedIPs:    []string{}, // Should be empty since no IPv4 addresses
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set initial IPs
+			lastResolvedIPs = tt.initialIPs
+
+			// Configure mock resolver
+			mockResolver.LookupIPFunc = func(_ string) ([]net.IP, error) {
+				return tt.resolvedIPs, tt.resolveError
+			}
+
+			// Call the function
+			result := updateResolvedIPs("example.com", mockResolver)
+
+			// Check result
+			if result != tt.expectedResult {
+				t.Errorf("updateResolvedIPs() = %v, expected %v", result, tt.expectedResult)
+			}
+
+			// Check that lastResolvedIPs was updated correctly
+			if !equalStringSlices(lastResolvedIPs, tt.expectedIPs) {
+				t.Errorf("lastResolvedIPs = %v, expected %v", lastResolvedIPs, tt.expectedIPs)
+			}
+		})
+	}
+}
+
+func TestCheckAndHandleDNSChange(t *testing.T) {
+	// Save original values and restore after test
+	originalSafeReconnectRPCClient := safeReconnectRPCClient
+	originalIPs := lastResolvedIPs
+	originalResolver := dnsResolver
+
+	// Save original values state
+	originalDNSChecked := values.GetDNSCheckedAfterError()
+	originalEmergencyMode := values.GetEmergencyMode()
+
+	defer func() {
+		// Restore all original values
+		safeReconnectRPCClient = originalSafeReconnectRPCClient
+		lastResolvedIPs = originalIPs
+		dnsResolver = originalResolver
+		values.SetDNSCheckedAfterError(originalDNSChecked)
+		values.SetEmergencyMode(originalEmergencyMode)
+	}()
+
+	// Test cases
+	tests := []struct {
+		name                 string
+		initialIPs           []string
+		resolvedIPs          []net.IP
+		resolveError         error
+		dnsCheckedAfterError bool
+		emergencyMode        bool
+		expectedDNSChanged   bool
+		expectedShouldRetry  bool
+		expectReconnectCall  bool
+	}{
+		{
+			name:                 "DNS changed - should reconnect and retry",
+			initialIPs:           []string{"192.168.1.1"},
+			resolvedIPs:          makeIPs("192.168.1.2"),
+			resolveError:         nil,
+			dnsCheckedAfterError: false,
+			emergencyMode:        false,
+			expectedDNSChanged:   true,
+			expectedShouldRetry:  true,
+			expectReconnectCall:  true,
+		},
+		{
+			name:                 "DNS unchanged - should not reconnect or retry",
+			initialIPs:           []string{"192.168.1.1"},
+			resolvedIPs:          makeIPs("192.168.1.1"),
+			resolveError:         nil,
+			dnsCheckedAfterError: false,
+			emergencyMode:        false,
+			expectedDNSChanged:   false,
+			expectedShouldRetry:  false,
+			expectReconnectCall:  false,
+		},
+		{
+			name:                 "DNS already checked - should skip check",
+			initialIPs:           []string{"192.168.1.1"},
+			resolvedIPs:          makeIPs("192.168.1.2"), // Would trigger reconnect if checked
+			resolveError:         nil,
+			dnsCheckedAfterError: true,
+			emergencyMode:        false,
+			expectedDNSChanged:   false,
+			expectedShouldRetry:  false,
+			expectReconnectCall:  false,
+		},
+		{
+			name:                 "In emergency mode - should skip check",
+			initialIPs:           []string{"192.168.1.1"},
+			resolvedIPs:          makeIPs("192.168.1.2"), // Would trigger reconnect if checked
+			resolveError:         nil,
+			dnsCheckedAfterError: false,
+			emergencyMode:        true,
+			expectedDNSChanged:   false,
+			expectedShouldRetry:  false,
+			expectReconnectCall:  false,
+		},
+		{
+			name:                 "DNS resolution error - should not reconnect",
+			initialIPs:           []string{"192.168.1.1"},
+			resolvedIPs:          nil,
+			resolveError:         errors.New("DNS resolution failed"),
+			dnsCheckedAfterError: false,
+			emergencyMode:        false,
+			expectedDNSChanged:   false,
+			expectedShouldRetry:  false,
+			expectReconnectCall:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set initial IPs
+			lastResolvedIPs = tt.initialIPs
+
+			// Create a mock resolver
+			mockResolver := &MockDNSResolver{}
+			mockResolver.LookupIPFunc = func(_ string) ([]net.IP, error) {
+				return tt.resolvedIPs, tt.resolveError
+			}
+			dnsResolver = mockResolver
+
+			// Set initial state values
+			values.SetDNSCheckedAfterError(tt.dnsCheckedAfterError)
+			values.SetEmergencyMode(tt.emergencyMode)
+
+			// Create a mock reconnect function
+			reconnectCalled := false
+			safeReconnectRPCClient = func(_ bool) {
+				reconnectCalled = true
+			}
+
+			// Call the function
+			dnsChanged, shouldRetry := checkAndHandleDNSChange("example.com:8080", false)
+
+			// Check results
+			if dnsChanged != tt.expectedDNSChanged {
+				t.Errorf("dnsChanged = %v, expected %v", dnsChanged, tt.expectedDNSChanged)
+			}
+
+			if shouldRetry != tt.expectedShouldRetry {
+				t.Errorf("shouldRetry = %v, expected %v", shouldRetry, tt.expectedShouldRetry)
+			}
+
+			// Check if reconnect was called as expected
+			if reconnectCalled != tt.expectReconnectCall {
+				t.Errorf("reconnect called = %v, expected %v", reconnectCalled, tt.expectReconnectCall)
+			}
+
+			// If we weren't already in DNS checked state and not in emergency mode,
+			// verify that DNS checked flag was set to true
+			if !tt.dnsCheckedAfterError && !tt.emergencyMode {
+				if !values.GetDNSCheckedAfterError() {
+					t.Error("DNS checked flag should have been set to true")
+				}
+			}
+		})
+	}
+}
+
+func TestDNSIsOnlyCheckedOncePerConnectionIssue(t *testing.T) {
+	// Save original values and restore after test
+	originalSafeReconnectRPCClient := safeReconnectRPCClient
+	originalIPs := lastResolvedIPs
+	originalResolver := dnsResolver
+	originalDNSChecked := values.GetDNSCheckedAfterError()
+	originalEmergencyMode := values.GetEmergencyMode()
+
+	defer func() {
+		// Restore all original values
+		safeReconnectRPCClient = originalSafeReconnectRPCClient
+		lastResolvedIPs = originalIPs
+		dnsResolver = originalResolver
+		values.SetDNSCheckedAfterError(originalDNSChecked)
+		values.SetEmergencyMode(originalEmergencyMode)
+	}()
+
+	// Setup initial state
+	values.SetDNSCheckedAfterError(false)
+	values.SetEmergencyMode(false)
+	lastResolvedIPs = []string{"192.168.1.1"}
+
+	// Create a mock resolver that returns different IPs on each call
+	dnsLookupCount := 0
+	mockResolver := &MockDNSResolver{}
+	mockResolver.LookupIPFunc = func(_ string) ([]net.IP, error) {
+		dnsLookupCount++
+		// Return different IPs each time
+		if dnsLookupCount == 1 {
+			return makeIPs("192.168.1.2"), nil
+		} else {
+			return makeIPs("192.168.1.3"), nil
+		}
+	}
+	dnsResolver = mockResolver
+
+	// Create a mock reconnect function that counts calls
+	reconnectCount := 0
+	safeReconnectRPCClient = func(_ bool) {
+		reconnectCount++
+	}
+
+	// First call - should check DNS and reconnect
+	dnsChanged1, shouldRetry1 := checkAndHandleDNSChange("example.com:8080", false)
+
+	// Verify first call results
+	if !dnsChanged1 {
+		t.Error("First call: dnsChanged should be true")
+	}
+	if !shouldRetry1 {
+		t.Error("First call: shouldRetry should be true")
+	}
+	if dnsLookupCount != 1 {
+		t.Errorf("First call: DNS lookup count should be 1, got %d", dnsLookupCount)
+	}
+	if reconnectCount != 1 {
+		t.Errorf("First call: reconnect count should be 1, got %d", reconnectCount)
+	}
+	if !values.GetDNSCheckedAfterError() {
+		t.Error("First call: DNS checked flag should be set to true")
+	}
+
+	// Second call - should skip DNS check because dnsCheckedAfterError is true
+	dnsChanged2, shouldRetry2 := checkAndHandleDNSChange("example.com:8080", false)
+
+	// Verify second call results
+	if dnsChanged2 {
+		t.Error("Second call: dnsChanged should be false")
+	}
+	if shouldRetry2 {
+		t.Error("Second call: shouldRetry should be false")
+	}
+	if dnsLookupCount != 1 {
+		t.Errorf("Second call: DNS lookup count should still be 1, got %d", dnsLookupCount)
+	}
+	if reconnectCount != 1 {
+		t.Errorf("Second call: reconnect count should still be 1, got %d", reconnectCount)
+	}
+
+	// Now simulate a successful login which resets the DNS checked flag
+	values.SetDNSCheckedAfterError(false)
+
+	// Third call after successful login - should check DNS again
+	dnsChanged3, shouldRetry3 := checkAndHandleDNSChange("example.com:8080", false)
+
+	// Verify third call results
+	if !dnsChanged3 {
+		t.Error("Third call: dnsChanged should be true")
+	}
+	if !shouldRetry3 {
+		t.Error("Third call: shouldRetry should be true")
+	}
+	if dnsLookupCount != 2 {
+		t.Errorf("Third call: DNS lookup count should be 2, got %d", dnsLookupCount)
+	}
+	if reconnectCount != 2 {
+		t.Errorf("Third call: reconnect count should be 2, got %d", reconnectCount)
+	}
+	if !values.GetDNSCheckedAfterError() {
+		t.Error("Third call: DNS checked flag should be set to true again")
+	}
+}

--- a/rpc/rpc_client.go
+++ b/rpc/rpc_client.go
@@ -55,7 +55,7 @@ var (
 // ErrRPCIsDown this is returned when we can't reach rpc server.
 var ErrRPCIsDown = errors.New("RPCStorageHandler: rpc is either down or was not configured")
 
-// rpc.Login is callend may places we only need one in flight at a time.
+// rpc.Login is called may places we only need one in flight at a time.
 var loginFlight singleflight.Group
 
 var values rpcOpts
@@ -68,6 +68,24 @@ type rpcOpts struct {
 	emergencyModeLoaded atomic.Value
 	config              atomic.Value
 	clientIsConnected   atomic.Value
+
+	// dnsCheckedAfterError tracks whether DNS has been checked after a connection error.
+	// This ensures DNS is only checked once per disconnection event, rather than
+	// on every failed RPC call. It's reset to false when a successful connection is made.
+	dnsCheckedAfterError atomic.Value
+}
+
+func (r *rpcOpts) SetDNSCheckedAfterError(checked bool) {
+	r.dnsCheckedAfterError.Store(checked)
+}
+
+func (r *rpcOpts) GetDNSCheckedAfterError() bool {
+	if v := r.dnsCheckedAfterError.Load(); v != nil {
+		if b, ok := v.(bool); ok {
+			return b
+		}
+	}
+	return false
 }
 
 func (r rpcOpts) ClientIsConnected() bool {
@@ -90,6 +108,7 @@ func (r *rpcOpts) Reset() {
 	r.emergencyMode.Store(false)
 	r.emergencyModeLoaded.Store(false)
 	r.clientIsConnected.Store(false)
+	r.dnsCheckedAfterError.Store(false)
 }
 
 func (r *rpcOpts) SetLoadCounts(n int) {
@@ -237,6 +256,12 @@ func Connect(
 		go checkDisconnect()
 	}
 
+	// Initial DNS resolution and get first ip
+	host, _, err := net.SplitHostPort(connConfig.ConnectionString)
+	if err == nil {
+		updateResolvedIPs(host, dnsResolver)
+	}
+
 	return true
 }
 
@@ -367,6 +392,11 @@ func loginBase() bool {
 		rpcLoginMu.Unlock()
 		return false
 	}
+
+	// Login was successful, reset the DNS check flag
+	values.SetDNSCheckedAfterError(false)
+	Log.Debug("Reset DNS check flag after successful login")
+
 	return true
 }
 
@@ -489,6 +519,17 @@ func FuncClientSingleton(funcName string, request interface{}) (result interface
 			return ErrRPCIsDown
 		}
 		result, err = funcClientSingleton.CallTimeout(funcName, request, GlobalRPCCallTimeout)
+
+		// If there's an error, handle it with our dedicated error handler
+		if err != nil {
+			if handleRPCError(err, values.Config().ConnectionString) {
+				// Error was handled and we should retry
+				return nil
+			}
+			// Error wasn't handled or we shouldn't retry
+			return err
+		}
+
 		return nil
 	}, backoff.WithMaxRetries(
 		backoff.NewConstantBackOff(10*time.Millisecond), 3,
@@ -497,6 +538,26 @@ func FuncClientSingleton(funcName string, request interface{}) (result interface
 		err = be
 	}
 	return
+}
+
+// handleRPCError processes RPC errors and determines if a retry should be attempted
+// Returns true if the error was handled and a retry should be attempted
+func handleRPCError(err error, connectionString string) bool {
+	if err == nil {
+		return false
+	}
+
+	Log.WithError(err).Debug("[RPC Store] --> Call failed")
+
+	// Check if it's a network-related error that might be resolved by a DNS check
+	if isNetworkError(err) {
+		Log.Debug("[RPC Store] Network error detected, checking DNS...")
+		dnsChanged, shouldRetry := checkAndHandleDNSChange(connectionString, false)
+		return dnsChanged && shouldRetry
+	}
+
+	Log.Debug("[RPC Store] Non-network error, skipping DNS check")
+	return false
 }
 
 var rpcConnectionsPool []net.Conn
@@ -562,4 +623,9 @@ func SetEmergencyMode(t *testing.T, value bool) {
 func SetLoadCounts(t *testing.T, value int) {
 	t.Helper()
 	values.SetLoadCounts(value)
+}
+
+// EnableEmergencyMode sets the emergency mode state for production use
+func EnableEmergencyMode(enabled bool) {
+	values.SetEmergencyMode(enabled)
 }

--- a/rpc/utils.go
+++ b/rpc/utils.go
@@ -1,0 +1,36 @@
+package rpc
+
+import "strings"
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	mapA := make(map[string]struct{}, len(a))
+	for _, val := range a {
+		mapA[val] = struct{}{}
+	}
+
+	for _, val := range b {
+		if _, exists := mapA[val]; !exists {
+			return false
+		}
+	}
+
+	return true
+}
+
+func isNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errStr := err.Error()
+
+	// Check for specific network-related error patterns
+	return strings.Contains(errStr, "unexpected response type: <nil>. Expected *dispatcherResponse") ||
+		strings.Contains(errStr, "Cannot obtain response during timeout") ||
+		strings.Contains(errStr, "rpc is either down or was not configured") ||
+		strings.Contains(errStr, "Cannot decode response")
+}

--- a/rpc/utils_test.go
+++ b/rpc/utils_test.go
@@ -1,0 +1,143 @@
+package rpc
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestEqualStringSlices(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        []string
+		b        []string
+		expected bool
+	}{
+		{
+			name:     "empty slices",
+			a:        []string{},
+			b:        []string{},
+			expected: true,
+		},
+		{
+			name:     "nil slices",
+			a:        nil,
+			b:        nil,
+			expected: true,
+		},
+		{
+			name:     "nil and empty",
+			a:        nil,
+			b:        []string{},
+			expected: true,
+		},
+		{
+			name:     "single element same",
+			a:        []string{"test"},
+			b:        []string{"test"},
+			expected: true,
+		},
+		{
+			name:     "single element different",
+			a:        []string{"test1"},
+			b:        []string{"test2"},
+			expected: false,
+		},
+		{
+			name:     "multiple elements same order",
+			a:        []string{"a", "b", "c"},
+			b:        []string{"a", "b", "c"},
+			expected: true,
+		},
+		{
+			name:     "multiple elements different order",
+			a:        []string{"a", "b", "c"},
+			b:        []string{"c", "a", "b"},
+			expected: true,
+		},
+		{
+			name:     "different lengths",
+			a:        []string{"a", "b"},
+			b:        []string{"a", "b", "c"},
+			expected: false,
+		},
+		{
+			name:     "subset",
+			a:        []string{"a", "b"},
+			b:        []string{"a", "b", "a"},
+			expected: false,
+		},
+		{
+			name:     "same elements with duplicates",
+			a:        []string{"a", "b", "a"},
+			b:        []string{"a", "a", "b"},
+			expected: true,
+		},
+		{
+			name:     "different elements with same length",
+			a:        []string{"a", "b", "c"},
+			b:        []string{"a", "b", "d"},
+			expected: false,
+		},
+		{
+			name:     "empty string elements",
+			a:        []string{"", "b"},
+			b:        []string{"", "b"},
+			expected: true,
+		},
+		{
+			name:     "case sensitivity",
+			a:        []string{"A", "b"},
+			b:        []string{"a", "b"},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := equalStringSlices(tt.a, tt.b)
+			if result != tt.expected {
+				t.Errorf("equalStringSlices(%v, %v) = %v, expected %v",
+					tt.a, tt.b, result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestIsNetworkError tests the isNetworkError function
+func TestIsNetworkError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "non-network error",
+			err:      errors.New("some random error"),
+			expected: false,
+		},
+		{
+			name:     "unexpected response type error",
+			err:      errors.New("unexpected response type: <nil>. Expected *dispatcherResponse"),
+			expected: true,
+		},
+		{
+			name:     "timeout error",
+			err:      errors.New("Cannot obtain response during timeout=30s"),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isNetworkError(tt.err)
+			if result != tt.expected {
+				t.Errorf("isNetworkError(%v) = %v, expected %v", tt.err, result, tt.expected)
+			}
+		})
+	}
+}

--- a/swagger.yml
+++ b/swagger.yml
@@ -33,7 +33,7 @@ info:
     name: Mozilla Public License Version 2.0
     url: https://github.com/TykTechnologies/tyk/blob/master/LICENSE.md
   title: Tyk Gateway API
-  version: 5.8.0
+  version: 5.9.0
 servers:
 - url: https://{tenant}
   variables:

--- a/tcp/tcp.go
+++ b/tcp/tcp.go
@@ -70,6 +70,11 @@ type Proxy struct {
 	SyncStats func(Stat)
 	// Duration in which connection stats will be flushed. Defaults to one second.
 	StatsSyncInterval time.Duration
+
+	// Connection tracking for graceful shutdown
+	activeConns sync.WaitGroup
+	shutdownCtx context.Context
+	shutdown    context.CancelFunc
 }
 
 func (p *Proxy) AddDomainHandler(domain, target string, modifier *Modifier) {
@@ -105,14 +110,61 @@ func (p *Proxy) RemoveDomainHandler(domain string) {
 	delete(p.muxer, domain)
 }
 
+// Shutdown initiates graceful shutdown and waits for all connections to finish
+func (p *Proxy) Shutdown(ctx context.Context) error {
+	// Wait for all connections to finish or timeout
+	done := make(chan struct{})
+	go func() {
+		p.activeConns.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		log.Debug("All TCP connections gracefully closed")
+		return nil
+	case <-ctx.Done():
+		log.Warning("TCP proxy shutdown timeout reached, forcing connection termination")
+		// Only now force cancel all connections
+		p.Lock()
+		if p.shutdown != nil {
+			p.shutdown()
+		}
+		p.Unlock()
+		return ctx.Err()
+	}
+}
+
+// SetShutdownContext sets the shutdown context from the caller
+func (p *Proxy) SetShutdownContext(ctx context.Context) {
+	p.Lock()
+	defer p.Unlock()
+	p.shutdownCtx, p.shutdown = context.WithCancel(ctx)
+}
+
+// initShutdownContext initializes the shutdown context if not already done
+func (p *Proxy) initShutdownContext() {
+	p.Lock()
+	defer p.Unlock()
+	if p.shutdownCtx == nil {
+		p.shutdownCtx, p.shutdown = context.WithCancel(context.Background())
+	}
+}
+
 func (p *Proxy) Serve(l net.Listener) error {
+	p.initShutdownContext()
+
 	for {
 		conn, err := l.Accept()
 		if err != nil {
 			log.WithError(err).Warning("Can't accept connection")
 			return err
 		}
+
+		p.activeConns.Add(1)
 		go func() {
+			// Track this connection only when we actually start handling it
+			defer p.activeConns.Done()
 			if err := p.handleConn(conn); err != nil {
 				log.WithError(err).Warning("Can't handle connection")
 			}
@@ -344,6 +396,14 @@ func (p *Proxy) pipe(src, dst net.Conn, opts pipeOpts) {
 	buf := make([]byte, 65535)
 
 	for {
+		// Check if shutdown has been initiated
+		select {
+		case <-p.shutdownCtx.Done():
+			log.Debug("TCP connection terminating due to graceful shutdown")
+			return
+		default:
+		}
+
 		var readDeadline time.Time
 		if p.ReadTimeout != 0 {
 			readDeadline = time.Now().Add(p.ReadTimeout)

--- a/tcp/tcp_test.go
+++ b/tcp/tcp_test.go
@@ -1,10 +1,14 @@
 package tcp
 
 import (
+	"context"
 	"crypto/tls"
+	"errors"
 	"net"
 	"reflect"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/TykTechnologies/tyk/test"
 )
@@ -225,4 +229,424 @@ func testRunner(t *testing.T, proxy *Proxy, hostname string, useSSL bool, testCa
 		Hostname: hostname,
 	}
 	runner.Run(t, testCases...)
+}
+
+func TestProxy_Shutdown(t *testing.T) {
+	tests := []struct {
+		name           string
+		setupProxy     func() *Proxy
+		setupContext   func() (context.Context, context.CancelFunc)
+		expectError    bool
+		errorType      error
+		beforeShutdown func(*Proxy, net.Listener)
+	}{
+		{
+			name: "shutdown with no active connections",
+			setupProxy: func() *Proxy {
+				return &Proxy{}
+			},
+			setupContext: func() (context.Context, context.CancelFunc) {
+				return context.WithTimeout(context.Background(), 5*time.Second)
+			},
+			expectError: false,
+		},
+		{
+			name: "shutdown with active connections that complete quickly",
+			setupProxy: func() *Proxy {
+				return &Proxy{}
+			},
+			setupContext: func() (context.Context, context.CancelFunc) {
+				return context.WithTimeout(context.Background(), 5*time.Second)
+			},
+			expectError: false,
+			beforeShutdown: func(proxy *Proxy, _ net.Listener) {
+				// Simulate active connections by calling activeConns.Add
+				proxy.activeConns.Add(2)
+
+				// Simulate connections completing
+				go func() {
+					time.Sleep(100 * time.Millisecond)
+					proxy.activeConns.Done()
+					proxy.activeConns.Done()
+				}()
+			},
+		},
+		{
+			name: "shutdown timeout with slow connections",
+			setupProxy: func() *Proxy {
+				return &Proxy{}
+			},
+			setupContext: func() (context.Context, context.CancelFunc) {
+				return context.WithTimeout(context.Background(), 200*time.Millisecond)
+			},
+			expectError: true,
+			errorType:   context.DeadlineExceeded,
+			beforeShutdown: func(proxy *Proxy, _ net.Listener) {
+				// Simulate slow connections that don't complete in time
+				proxy.activeConns.Add(1)
+				// Don't call Done() to simulate hanging connection
+			},
+		},
+		{
+			name: "shutdown with cancelled context",
+			setupProxy: func() *Proxy {
+				return &Proxy{}
+			},
+			setupContext: func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				// Cancel immediately to test context cancellation
+				cancel()
+				return ctx, func() {}
+			},
+			expectError: true,
+			errorType:   context.Canceled,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proxy := tt.setupProxy()
+			ctx, cancel := tt.setupContext()
+			defer cancel()
+
+			// Initialize shutdown context if not already done
+			proxy.initShutdownContext()
+
+			if tt.beforeShutdown != nil {
+				tt.beforeShutdown(proxy, nil)
+			}
+
+			err := proxy.Shutdown(ctx)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+					return
+				}
+				if tt.errorType != nil && !errors.Is(err, tt.errorType) {
+					t.Errorf("expected error type %v, got %v", tt.errorType, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error but got: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestProxy_SetShutdownContext(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupProxy  func() *Proxy
+		setupCtx    func() context.Context
+		validateCtx func(*testing.T, *Proxy, context.Context)
+	}{
+		{
+			name: "set shutdown context",
+			setupProxy: func() *Proxy {
+				return &Proxy{}
+			},
+			setupCtx: func() context.Context {
+				return context.Background()
+			},
+			validateCtx: func(t *testing.T, p *Proxy, _ context.Context) {
+				if p.shutdownCtx == nil {
+					t.Error("shutdown context should not be nil after setting")
+				}
+				if p.shutdown == nil {
+					t.Error("shutdown cancel function should not be nil after setting")
+				}
+			},
+		},
+		{
+			name: "overwrite existing shutdown context",
+			setupProxy: func() *Proxy {
+				p := &Proxy{}
+				// Set initial context
+				ctx, cancel := context.WithCancel(context.Background())
+				p.shutdownCtx = ctx
+				p.shutdown = cancel
+				return p
+			},
+			setupCtx: func() context.Context {
+				return context.Background()
+			},
+			validateCtx: func(t *testing.T, p *Proxy, _ context.Context) {
+				if p.shutdownCtx == nil {
+					t.Error("shutdown context should not be nil after overwriting")
+				}
+				if p.shutdown == nil {
+					t.Error("shutdown cancel function should not be nil after overwriting")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proxy := tt.setupProxy()
+			ctx := tt.setupCtx()
+
+			proxy.SetShutdownContext(ctx)
+
+			tt.validateCtx(t, proxy, ctx)
+		})
+	}
+}
+
+func TestProxy_initShutdownContext(t *testing.T) {
+	tests := []struct {
+		name       string
+		setupProxy func() *Proxy
+		validate   func(*testing.T, *Proxy)
+	}{
+		{
+			name: "initialize when context is nil",
+			setupProxy: func() *Proxy {
+				return &Proxy{}
+			},
+			validate: func(t *testing.T, p *Proxy) {
+				if p.shutdownCtx == nil {
+					t.Error("shutdown context should be initialized")
+				}
+				if p.shutdown == nil {
+					t.Error("shutdown cancel function should be initialized")
+				}
+			},
+		},
+		{
+			name: "don't reinitialize when context exists",
+			setupProxy: func() *Proxy {
+				p := &Proxy{}
+				ctx, cancel := context.WithCancel(context.Background())
+				p.shutdownCtx = ctx
+				p.shutdown = cancel
+				return p
+			},
+			validate: func(t *testing.T, p *Proxy) {
+				originalCtx := p.shutdownCtx
+				// Can't compare functions, just check they exist
+				originalCancelExists := p.shutdown != nil
+
+				p.initShutdownContext()
+
+				if p.shutdownCtx != originalCtx {
+					t.Error("shutdown context should not be reinitialized when it already exists")
+				}
+				if !originalCancelExists || p.shutdown == nil {
+					t.Error("shutdown cancel function should not be reinitialized when it already exists")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proxy := tt.setupProxy()
+			proxy.initShutdownContext()
+			tt.validate(t, proxy)
+		})
+	}
+}
+
+func TestProxy_ServeWithGracefulShutdown(t *testing.T) {
+	// Test that Serve properly tracks connections and responds to shutdown
+	upstream := test.TcpMock(false, func(in []byte, _ error) (out []byte) {
+		// Simulate slow response to test connection tracking
+		time.Sleep(100 * time.Millisecond)
+		return in
+	})
+	defer upstream.Close()
+
+	proxy := &Proxy{}
+	proxy.AddDomainHandler("", upstream.Addr().String(), nil)
+
+	// Set up listener
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("Failed to create listener: %v", err)
+	}
+	defer listener.Close()
+
+	// Start proxy in goroutine
+	serveDone := make(chan struct{})
+	go func() {
+		defer close(serveDone)
+		_ = proxy.Serve(listener)
+	}()
+
+	// Give proxy time to start
+	time.Sleep(50 * time.Millisecond)
+
+	// Connect client and start sending data
+	conn, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatalf("Failed to connect to proxy: %v", err)
+	}
+
+	// Send data in background to keep connection active
+	clientDone := make(chan struct{})
+	go func() {
+		defer close(clientDone)
+		defer conn.Close()
+
+		// Send data
+		_, err := conn.Write([]byte("test"))
+		if err != nil {
+			t.Logf("Client write error (expected during shutdown): %v", err)
+			return
+		}
+
+		// Try to read response
+		buf := make([]byte, 4)
+		_, err = conn.Read(buf)
+		if err != nil {
+			t.Logf("Client read error (expected during shutdown): %v", err)
+		}
+	}()
+
+	// Wait a bit for connection to be established
+	time.Sleep(50 * time.Millisecond)
+
+	// Set shutdown context and close listener to trigger shutdown
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	proxy.SetShutdownContext(shutdownCtx)
+
+	// Close listener to stop accepting new connections
+	listener.Close()
+
+	// Wait for serve to complete
+	select {
+	case <-serveDone:
+		// Expected - serve should exit after listener is closed
+	case <-time.After(3 * time.Second):
+		t.Error("Serve did not exit in reasonable time")
+	}
+
+	// Test graceful shutdown
+	err = proxy.Shutdown(shutdownCtx)
+	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("Unexpected shutdown error: %v", err)
+	}
+
+	// Wait for client connection to finish
+	select {
+	case <-clientDone:
+		// Client finished
+	case <-time.After(1 * time.Second):
+		t.Log("Client connection took longer than expected to finish")
+	}
+}
+
+func TestProxy_ConcurrentConnectionTracking(t *testing.T) {
+	// Test that connection tracking is thread-safe
+	proxy := &Proxy{}
+	proxy.initShutdownContext()
+
+	var wg sync.WaitGroup
+	numGoroutines := 10
+	numOperationsPerGoroutine := 100
+
+	// Simulate concurrent connection tracking
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < numOperationsPerGoroutine; j++ {
+				proxy.activeConns.Add(1)
+				proxy.activeConns.Done()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Test shutdown with no active connections
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	err := proxy.Shutdown(ctx)
+	if err != nil {
+		t.Errorf("Shutdown failed after concurrent operations: %v", err)
+	}
+}
+
+func TestProxy_ShutdownIntegration(t *testing.T) {
+	// Test that TCP proxy properly shuts down connections when shutdown context is cancelled
+	upstream := test.TcpMock(false, func(in []byte, _ error) (out []byte) {
+		// Simulate slow response to test shutdown during active connection
+		time.Sleep(200 * time.Millisecond)
+		return in
+	})
+	defer upstream.Close()
+
+	proxy := &Proxy{}
+	proxy.AddDomainHandler("", upstream.Addr().String(), nil)
+
+	// Set up listener
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("Failed to create listener: %v", err)
+	}
+
+	// Set shutdown context before starting
+	shutdownCtx, cancel := context.WithCancel(context.Background())
+	proxy.SetShutdownContext(shutdownCtx)
+
+	// Start proxy in background
+	serveDone := make(chan struct{})
+	go func() {
+		defer close(serveDone)
+		proxy.Serve(listener)
+	}()
+
+	// Give proxy time to start
+	time.Sleep(50 * time.Millisecond)
+
+	// Connect and start sending data
+	conn, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatalf("Failed to connect to proxy: %v", err)
+	}
+	defer conn.Close()
+
+	// Send data to establish connection
+	go func() {
+		conn.Write([]byte("test"))
+	}()
+
+	// Wait for connection to be established
+	time.Sleep(50 * time.Millisecond)
+
+	// Trigger shutdown by cancelling context
+	cancel()
+
+	// Close listener to stop accepting new connections
+	listener.Close()
+
+	// Test that shutdown completes within reasonable time
+	shutdownCompleted := make(chan struct{})
+	go func() {
+		defer close(shutdownCompleted)
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+		proxy.Shutdown(ctx)
+	}()
+
+	select {
+	case <-shutdownCompleted:
+		// Expected - shutdown should complete
+	case <-time.After(2 * time.Second):
+		t.Error("Shutdown did not complete in reasonable time")
+	}
+
+	// Verify that serve exits
+	select {
+	case <-serveDone:
+		// Expected - serve should exit after listener is closed
+	case <-time.After(1 * time.Second):
+		t.Error("Serve did not exit after listener was closed")
+	}
 }


### PR DESCRIPTION
### **User description**
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Bug fix


___

### **Description**
- Reverts `/hello` (liveness) endpoint to always return HTTP 200

- Removes logic for dynamic HTTP status based on health checks

- Ensures JSON encoding errors are logged in readiness handler

- Simplifies health status calculation for liveness endpoint


___

### Diagram Walkthrough


```mermaid
flowchart LR
  oldLogic["Dynamic HTTP status for /hello"] -- "removed" --> static200["Always return HTTP 200"]
  healthChecks["Health check evaluation"] -- "simplified" --> statusCalc["Simplified status calculation"]
  readinessHandler["Readiness handler"] -- "add error logging" --> errorLog["Logs JSON encoding errors"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>health_check.go</strong><dd><code>Revert liveness endpoint to static 200 and improve error logging</code></dd></summary>
<hr>

gateway/health_check.go

<ul><li><code>/hello</code> endpoint now always returns HTTP 200 status<br> <li> Removed dynamic status code logic based on health checks<br> <li> Simplified health status calculation for liveness checks<br> <li> Added error logging for JSON encoding in readiness handler</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7280/files#diff-978a2d1427d9209765e541618af10683944c6396df1a6fb8b5221e4f16658a6a">+24/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

