### PR TITLE
Merging to release-5.8.4: [TT-15505] Remove `negate` field as mandatory from the OAS API schema (#7284)

### DIFF
--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -920,8 +920,7 @@
       },
       "required": [
         "in",
-        "pattern",
-        "negate"
+        "pattern"
       ]
     },
     "X-Tyk-URLRewriteRule": {
@@ -949,8 +948,7 @@
       "required": [
         "in",
         "name",
-        "pattern",
-        "negate"
+        "pattern"
       ]
     },
     "X-Tyk-EndpointPostPlugin": {

--- a/apidef/oas/schema/x-tyk-api-gateway.strict.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.strict.json
@@ -959,8 +959,7 @@
       },
       "required": [
         "in",
-        "pattern",
-        "negate"
+        "pattern"
       ],
       "additionalProperties": false
     },
@@ -989,8 +988,7 @@
       "required": [
         "in",
         "name",
-        "pattern",
-        "negate"
+        "pattern"
       ],
       "additionalProperties": false
     },

--- a/apidef/oas/testdata/urlRewrite-native.json
+++ b/apidef/oas/testdata/urlRewrite-native.json
@@ -12,6 +12,10 @@
           "header_name": {
             "match_rx": "header_pattern",
             "reverse": true
+          },
+          "content-type": {
+            "match_rx": "header_pattern_without_negate",
+            "reverse": false
           }
         },
         "query_val_matches": {

--- a/apidef/oas/testdata/urlRewrite-oas.json
+++ b/apidef/oas/testdata/urlRewrite-oas.json
@@ -40,6 +40,11 @@
           "pattern": "request_context_pattern",
           "name": "request_context_name",
           "negate": false
+        },
+        {
+          "in": "header",
+          "pattern": "header_pattern_without_negate",
+          "name": "content-type"
         }
       ],
       "rewriteTo": "http://example.com/rewritten-one"

--- a/apidef/oas/url_rewrite.go
+++ b/apidef/oas/url_rewrite.go
@@ -116,7 +116,7 @@ type URLRewriteRule struct {
 
 	// Negate is a boolean negation operator. Setting it to true inverts the matching behaviour
 	// such that the rewrite will be triggered if the value does not match the `pattern` for this rule.
-	Negate bool `bson:"negate" json:"negate"`
+	Negate bool `bson:"negate,omitempty" json:"negate,omitempty"`
 }
 
 // Fill fills *URLRewrite receiver from apidef.URLRewriteMeta.


### PR DESCRIPTION
### **User description**
[TT-15505] Remove `negate` field as mandatory from the OAS API schema (#7284)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-15505"
title="TT-15505" target="_blank">TT-15505</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
<td>Fix URL Rewrite Middleware Schema breaking change introduced in
5.8.3 and 5.9.0</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20jira_escalated%20ORDER%20BY%20created%20DESC"
title="jira_escalated">jira_escalated</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

Make negate field optional in URL rewrite schema

The negate field was previously made mandatory in the OAS API schema,
which broke existing API definitions that don't have the negate field
defined. This prevented customers from updating their APIs.

This change:
  - Removes negate from required fields in both OAS schema files
  - Adds omitempty tags to the URLRewriteRule struct to handle optional
  negate field
  - Restores backward compatibility with existing API definitions

Fixes breaking change introduced in previous release where customers
with API definitions lacking negate field could not update their APIs.

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Make `negate` field optional in URL rewrite schema

- Remove `negate` from required fields in OAS schema files

- Add `omitempty` to `Negate` in `URLRewriteRule` struct

- Restore backward compatibility for existing API definitions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  schemaOld["OAS Schema: 'negate' required"] -- "remove from required" --> schemaNew["OAS Schema: 'negate' optional"]
  structOld["Go Struct: 'negate' mandatory"] -- "add omitempty" --> structNew["Go Struct: 'negate' optional"]
  schemaNew -- "restores compatibility" --> compatibility["Backward Compatibility"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>url_rewrite.go</strong><dd><code>Make `Negate` field
optional in Go struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

apidef/oas/url_rewrite.go

<ul><li>Add <code>omitempty</code> to <code>Negate</code> field in
<code>URLRewriteRule</code> struct<br> <li> Make <code>Negate</code>
optional in Go struct serialization</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7284/files#diff-7317c6061fb6488e079d733230045c7cbc1b4b2ffb98bb7da20d4025f4976e51">+1/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>x-tyk-api-gateway.json</strong><dd><code>Remove
`negate` from required fields in OAS schema</code>&nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/schema/x-tyk-api-gateway.json

<ul><li>Remove <code>negate</code> from required fields in two schema
definitions<br> <li> Make <code>negate</code> field optional in OAS
schema</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7284/files#diff-78828969c0c04cc1a776dfc93a8bad3c499a8c83e6169f83e96d090bed3e7dd0">+2/-4</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>x-tyk-api-gateway.strict.json</strong><dd><code>Remove
`negate` from required fields in strict OAS schema</code></dd></summary>
<hr>

apidef/oas/schema/x-tyk-api-gateway.strict.json

<ul><li>Remove <code>negate</code> from required fields in two strict
schema definitions<br> <li> Make <code>negate</code> field optional in
strict OAS schema</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7284/files#diff-39a62344d6b741814a58dfd2d219665ecdf962bbec8e755dbc61e1684bb4892a">+2/-4</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

---------

Co-authored-by: Claude <noreply@anthropic.com>

[TT-15505]: https://tyktech.atlassian.net/browse/TT-15505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Make URL rewrite negate optional

- Remove negate from OAS required lists

- Add omitempty to Go struct field

- Update testdata to cover optional negate


___

### Diagram Walkthrough


```mermaid
flowchart LR
  schemaOld["OAS schemas require negate"] -- "remove from required" --> schemaNew["OAS schemas: negate optional"]
  goOld["Go URLRewriteRule requires negate"] -- "add omitempty" --> goNew["Go struct: negate optional"]
  testsOld["Tests lacked optional cases"] -- "add samples" --> testsNew["Testdata includes rules w/o negate"]
  schemaNew -- "aligns with struct" --> goNew
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>url_rewrite.go</strong><dd><code>Make Negate optional in Go URLRewriteRule</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/url_rewrite.go

<ul><li>Add json/bson <code>omitempty</code> to <code>Negate</code><br> <li> Make <code>Negate</code> serialization optional</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7288/files#diff-7317c6061fb6488e079d733230045c7cbc1b4b2ffb98bb7da20d4025f4976e51">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>x-tyk-api-gateway.json</strong><dd><code>OAS schema: negate no longer required</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/schema/x-tyk-api-gateway.json

<ul><li>Remove <code>negate</code> from required in two defs<br> <li> Keep <code>negate</code> property as boolean, optional</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7288/files#diff-78828969c0c04cc1a776dfc93a8bad3c499a8c83e6169f83e96d090bed3e7dd0">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>x-tyk-api-gateway.strict.json</strong><dd><code>Strict OAS: make negate optional</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/schema/x-tyk-api-gateway.strict.json

<ul><li>Remove <code>negate</code> from required in two strict defs<br> <li> Preserve additionalProperties constraints</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7288/files#diff-39a62344d6b741814a58dfd2d219665ecdf962bbec8e755dbc61e1684bb4892a">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>urlRewrite-native.json</strong><dd><code>Testdata: native example without negate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/testdata/urlRewrite-native.json

<ul><li>Add header match example without negate<br> <li> Ensure both true/false reverse cases present</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7288/files#diff-f9dcb0576feb87022eb01c992073ea7c4c609df5dc433d00722989adad334403">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>urlRewrite-oas.json</strong><dd><code>Testdata: OAS rule without negate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/testdata/urlRewrite-oas.json

<ul><li>Add rule lacking <code>negate</code> field<br> <li> Cover header rule with only pattern/name</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7288/files#diff-4993a95df56573694ea2527f0aab7989e4457066935973c497be864c7549110d">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

