### PR TITLE
Add UpstreamHostOverride support for plugins and enhance reverse proxy handling

### DIFF
--- a/ctx/ctx.go
+++ b/ctx/ctx.go
@@ -53,6 +53,8 @@ const (
 	CacheOptions
 	OASDefinition
 	SelfLooping
+	// Used by plugins to override the upstream host
+	UpstreamHostOverride
 )
 
 func ctxSetSession(r *http.Request, s *user.SessionState, scheduleUpdate bool, hashKey bool) {

--- a/test/goplugins/url_redirect_plugin.go
+++ b/test/goplugins/url_redirect_plugin.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/TykTechnologies/tyk/ctx"
+	"github.com/TykTechnologies/tyk/log"
+)
+
+var logger = log.Get()
+
+func HeaderBasedRedirect(rw http.ResponseWriter, r *http.Request) {
+	routeTo := r.Header.Get("X-Route-To")
+	if routeTo == "" {
+		return
+	}
+
+	logger.Info("[PLUGIN] X-Route-To header: ", routeTo)
+
+	// Use the UpstreamHostOverride context key
+	// This can be either a host or a full URL
+	newCtx := context.WithValue(r.Context(), ctx.UpstreamHostOverride, routeTo)
+	*r = *r.WithContext(newCtx)
+
+	logger.Info("[PLUGIN] Set UpstreamHostOverride to: ", routeTo)
+}
+
+func main() {}


### PR DESCRIPTION
- Introduced UpstreamHostOverride constant in ctx package for plugin use.
- Implemented logic in reverse_proxy.go to allow plugins to override upstream host or URL.
- Added a new test file for URL redirect plugin to demonstrate UpstreamHostOverride functionality.

## Description

Adds a new context that is settable from custom go plugin.  THis allows URL overwrites.

## Motivation and Context

- Being able to set the host dynamically depending on conditions is a common use case.  This allows an operator to run a set of business logic rules and then set a new hostname as needed.

## How This Has Been Tested

Unit Tests and Manual testing of scenario.  The included custom plugin example is set and used.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
