### PR TITLE
Merging to release-5.8: [TT-7524] [OAS] Gateway CE behaves differently from Dashboard for middleware and PATCH (#7261)

### DIFF
--- a/apidef/oas/default.go
+++ b/apidef/oas/default.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -220,19 +221,43 @@ func (s *OAS) importMiddlewares(overRideValues TykExtensionConfigParams) {
 		xTykAPIGateway.Middleware = &Middleware{}
 	}
 
+<<<<<<< HEAD
 	for path, pathItem := range s.Paths {
+=======
+	currentOperations := make([]string, 0)
+
+	for path, pathItem := range s.Paths.Map() {
+>>>>>>> dbabb5f84... [TT-7524] [OAS] Gateway CE behaves differently from Dashboard for middleware and PATCH (#7261)
 		overRideValues.pathItemHasParameters = len(pathItem.Parameters) > 0
 		for _, method := range allowedMethods {
 			if operation := pathItem.GetOperation(method); operation != nil {
 				tykOperation := s.getTykOperation(method, path)
 				tykOperation.Import(operation, overRideValues)
+				currentOperations = append(currentOperations, s.getOperationID(path, method))
 				s.deleteTykOperationIfEmpty(tykOperation, method, path)
 			}
 		}
 	}
 
+	s.removeObsoleteOperations(currentOperations)
+
 	if ShouldOmit(xTykAPIGateway.Middleware) {
 		xTykAPIGateway.Middleware = nil
+	}
+}
+
+func (s *OAS) removeObsoleteOperations(currentOperations []string) {
+	tykOperations := s.getTykOperations()
+	obsoleteOperations := make([]string, 0)
+
+	for id := range tykOperations {
+		if !slices.Contains(currentOperations, id) {
+			obsoleteOperations = append(obsoleteOperations, id)
+		}
+	}
+
+	for _, operationID := range obsoleteOperations {
+		delete(tykOperations, operationID)
 	}
 }
 

--- a/apidef/oas/default.go
+++ b/apidef/oas/default.go
@@ -221,13 +221,9 @@ func (s *OAS) importMiddlewares(overRideValues TykExtensionConfigParams) {
 		xTykAPIGateway.Middleware = &Middleware{}
 	}
 
-<<<<<<< HEAD
-	for path, pathItem := range s.Paths {
-=======
 	currentOperations := make([]string, 0)
 
-	for path, pathItem := range s.Paths.Map() {
->>>>>>> dbabb5f84... [TT-7524] [OAS] Gateway CE behaves differently from Dashboard for middleware and PATCH (#7261)
+	for path, pathItem := range s.Paths {
 		overRideValues.pathItemHasParameters = len(pathItem.Parameters) > 0
 		for _, method := range allowedMethods {
 			if operation := pathItem.GetOperation(method); operation != nil {

--- a/apidef/oas/default_test.go
+++ b/apidef/oas/default_test.go
@@ -552,6 +552,34 @@ func TestOAS_BuildDefaultTykExtension(t *testing.T) {
 			return operations
 		}
 
+		t.Run("operations not present in new oas paths definition should be removed", func(t *testing.T) {
+			fakeOperationName := "fakeOperation"
+			fakeOperation := &Operation{
+				MockResponse: &MockResponse{
+					Enabled: true,
+				},
+			}
+			oasDef := getOASDef(true, true)
+
+			tykExtensionConfigParams := TykExtensionConfigParams{
+				MockResponse: &trueVal,
+			}
+
+			extension := &XTykAPIGateway{
+				Middleware: &Middleware{
+					Operations: map[string]*Operation{fakeOperationName: fakeOperation},
+				},
+			}
+			oasDef.SetTykExtension(extension)
+			assert.Greater(t, len(oasDef.getTykOperations()), 0)
+
+			expectedOperations := getExpectedOperations(true, true, middlewareMockResponse)
+			err := oasDef.BuildDefaultTykExtension(tykExtensionConfigParams, true)
+
+			assert.NoError(t, err)
+			assert.Equal(t, expectedOperations, oasDef.getTykOperations())
+		})
+
 		t.Run("allowList", func(t *testing.T) {
 			t.Run("enable allowList for all paths when no configured operationID in OAS", func(t *testing.T) {
 				oasDef := getOASDef(false, false)


### PR DESCRIPTION
### **User description**
[TT-7524] [OAS] Gateway CE behaves differently from Dashboard for middleware and PATCH (#7261)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-7524"
title="TT-7524" target="_blank">TT-7524</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
<td>[OAS] Gateway CE behaves differently from Dashboard for middleware
and PATCH</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20codilime_refined%20ORDER%20BY%20created%20DESC"
title="codilime_refined">codilime_refined</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

Updating an API with the PATCH /tyk/apis/oas/{apiId} command via Gateway
API does not trigger the Tyk vendor extension (x-tyk-api-gateway)
update, which results in the API description being out of sync or
invalid.

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [x] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Bug fix, Tests


___

### **Description**
Remove obsolete Tyk operations on OAS PATCH
Track current operations during import
Add test verifying obsolete cleanup
Keep Gateway and Dashboard behavior consistent


___

### Diagram Walkthrough


```mermaid
flowchart LR
  OAS["OAS Paths/Operations"] -- "importMiddlewares" --> Collect["Collect current operation IDs"]
  Collect -- "compare" --> Cleanup["removeObsoleteOperations deletes stale ops"]
  Cleanup -- "result" --> XTyk["x-tyk-api-gateway middleware up-to-date"]
  Test["Unit test"] -- "asserts cleanup" --> Cleanup
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>default.go</strong><dd><code>Remove obsolete operations during middleware import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/default.go

<ul><li>Track current operation IDs during import.<br> <li> Remove obsolete operations via new helper.<br> <li> Use slices.Contains for membership checks.<br> <li> Invoke cleanup after per-operation import.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7292/files#diff-83c3a85bdd05785178ee519b05b1fe2008435dc4ae9448d72b080b5f67c491ad">+21/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>default_test.go</strong><dd><code>Test cleanup of obsolete Tyk operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/default_test.go

<ul><li>Add test ensuring obsolete operations are removed.<br> <li> Validate Tyk extension matches expected operations.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7292/files#diff-ab6848f71731083885a9d7d7970faa68a6783a98477c78413ae3979cb5add7db">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



[TT-7524]: https://tyktech.atlassian.net/browse/TT-7524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ