### PR TITLE
Revert "Merging to release-5.8: [TT-5588] [OAS] gateway apiKey import generates unnecessary object (#7270)"

### DIFF
--- a/apidef/oas/security.go
+++ b/apidef/oas/security.go
@@ -30,7 +30,7 @@ type Token struct {
 	Enabled bool `bson:"enabled" json:"enabled"` // required
 
 	// AuthSources contains the configuration for authentication sources.
-	AuthSources `bson:",inline" json:"-"`
+	AuthSources `bson:",inline" json:",inline"`
 
 	// EnableClientCertificate allows to create dynamic keys based on certificates.
 	//

--- a/apidef/oas/security_test.go
+++ b/apidef/oas/security_test.go
@@ -1,7 +1,6 @@
 package oas
 
 import (
-	"encoding/json"
 	"sort"
 	"testing"
 
@@ -199,20 +198,6 @@ func TestOAS_Token(t *testing.T) {
 	convertedOAS.fillToken(api)
 
 	assert.Equal(t, oas, convertedOAS)
-
-	// Make sure AuthSources are not serialized into json.
-	token.Query = &AuthSource{Enabled: true}
-	token.Header = &AuthSource{Enabled: true}
-	token.Cookie = &AuthSource{Enabled: true}
-	bytes, err := json.Marshal(token)
-	assert.NoError(t, err)
-
-	var unmarshalledToken Token
-	err = json.Unmarshal(bytes, &unmarshalledToken)
-	assert.NoError(t, err)
-	assert.Nil(t, unmarshalledToken.Query)
-	assert.Nil(t, unmarshalledToken.Header)
-	assert.Nil(t, unmarshalledToken.Cookie)
 }
 
 func TestOAS_Token_MultipleSecuritySchemes(t *testing.T) {


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-5588" title="TT-5588" target="_blank">TT-5588</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>[OAS] gateway apiKey import generates unnecessary object</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20codilime_refined%20ORDER%20BY%20created%20DESC" title="codilime_refined">codilime_refined</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

Reverts TykTechnologies/tyk#7291


___

### **PR Type**
Bug fix, Tests


___

### **Description**
Revert exclusion of `AuthSources` from JSON.
Restore JSON inline serialization for `Token.AuthSources`.
Remove test asserting non-serialization of `AuthSources`.
Keep token fill logic and assertions intact.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Token["Token struct"]
  JSONTag["JSON tag for AuthSources"]
  Tests["Security tests"]
  Token -- "AuthSources json:',inline'" --> JSONTag
  Tests -- "remove non-serialization round-trip" --> JSONTag
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>security.go</strong><dd><code>Restore inline JSON serialization for AuthSources</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/security.go

<ul><li>Change <code>Token.AuthSources</code> tag to <code>json:",inline"</code>.<br> <li> Re-enable JSON serialization of embedded <code>AuthSources</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7298/files#diff-15e7d47137452ca4f3f6139aa8c007cdb426152c41846f712f8bf5dfb607afcc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>security_test.go</strong><dd><code>Remove test asserting AuthSources non-serialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/security_test.go

<ul><li>Remove JSON round-trip test for <code>AuthSources</code>.<br> <li> Drop <code>encoding/json</code> import no longer used.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7298/files#diff-5184167309db0462243e424baca87b5bb668962d8cc1076629fdcf11f00487e5">+0/-15</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

