### PR TITLE
[TT-14564] Fix: Add mutual TLS support for dedicated rate limiter Redis connection

### DIFF
--- a/internal/rate/storage.go
+++ b/internal/rate/storage.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/internal/redis"
+	"github.com/sirupsen/logrus"
 )
 
 // NewStorage provides a redis v9 client for rate limiter use.

--- a/internal/rate/storage_tls_test.go
+++ b/internal/rate/storage_tls_test.go
@@ -167,7 +167,7 @@ func TestCreateTLSConfig(t *testing.T) {
 			UseSSL:                true,
 			SSLInsecureSkipVerify: true,
 			CAFile:                "/nonexistent/ca.crt", // This will fail to load
-			CertFile:              certFile,               // But this should still work
+			CertFile:              certFile,              // But this should still work
 			KeyFile:               keyFile,
 			TLSMinVersion:         "1.2",
 			TLSMaxVersion:         "1.3",
@@ -176,7 +176,7 @@ func TestCreateTLSConfig(t *testing.T) {
 		tlsConfig := createTLSConfig(cfg)
 		assert.NotNil(t, tlsConfig)
 		assert.True(t, tlsConfig.InsecureSkipVerify)
-		assert.Nil(t, tlsConfig.RootCAs)                                 // CA loading failed
+		assert.Nil(t, tlsConfig.RootCAs)                                // CA loading failed
 		assert.Len(t, tlsConfig.Certificates, 1)                        // But client cert still loaded
 		assert.Equal(t, uint16(tls.VersionTLS12), tlsConfig.MinVersion) // And TLS versions still set
 		assert.Equal(t, uint16(tls.VersionTLS13), tlsConfig.MaxVersion)
@@ -246,10 +246,10 @@ func createTestCertAndKey(t *testing.T, certFile, keyFile string) {
 		Subject: pkix.Name{
 			Organization: []string{"Test Client"},
 		},
-		NotBefore:    time.Now(),
-		NotAfter:     time.Now().Add(365 * 24 * time.Hour),
-		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		NotBefore:   time.Now(),
+		NotAfter:    time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 	}
 
 	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)


### PR DESCRIPTION
### **User description**
## Summary
This PR fixes a critical security issue where the dedicated Redis connection for the rate limiter does not properly implement mutual TLS (mTLS) authentication, even when configured.

## Problem Statement
The Tyk Gateway has two distinct code paths for establishing Redis connections:
1. **Main Connection:** Handled by `storage.ConnectionHandler` - correctly implements mTLS
2. **Rate Limiter Connection:** Dedicated connection via `rate.NewStorage` when `rate_limiter.storage.type` is set to `redis`

The rate limiter's dedicated Redis connection code in `internal/rate/storage.go` had a critical flaw. When `UseSSL` was enabled, it only set the `InsecureSkipVerify` field and **completely ignored** the client certificate configuration (`CertFile`, `KeyFile`, `CAFile`).

### Security Impact
This creates a security vulnerability where:
- Even if administrators correctly configure mTLS for all Redis connections
- The rate limiter's connection bypasses these security controls
- The connection either fails (if Redis requires client certs) or connects insecurely

## Solution
Enhanced the `NewStorage` function in `internal/rate/storage.go` with proper mTLS support:

### Key Changes:
1. **Added `createTLSConfig` helper function** that properly constructs TLS configuration
2. **Full mTLS support:**
   - Loads CA certificates for server validation
   - Loads client certificate and key for mutual authentication
   - Supports TLS version configuration (`TLSMinVersion`, `TLSMaxVersion`)
3. **Proper error handling** with appropriate logging for certificate loading failures
4. **Maintains backward compatibility** with existing configurations

## Testing
✅ **Comprehensive test coverage added:**
- Unit tests for all TLS configuration scenarios
- Tests for basic SSL, mTLS, CA certificates, TLS versions
- Error case handling (invalid paths, missing files)
- All existing rate limiter tests continue to pass

### Test Results:
```bash
=== RUN   TestCreateTLSConfig
    --- PASS: TestCreateTLSConfig/No_SSL_configured
    --- PASS: TestCreateTLSConfig/SSL_with_InsecureSkipVerify
    --- PASS: TestCreateTLSConfig/SSL_with_TLS_versions
    --- PASS: TestCreateTLSConfig/SSL_with_invalid_TLS_version
    --- PASS: TestCreateTLSConfig/SSL_with_CA_certificate
    --- PASS: TestCreateTLSConfig/SSL_with_client_certificate_and_key
    --- PASS: TestCreateTLSConfig/SSL_with_full_mTLS_configuration
--- PASS: TestCreateTLSConfig
```

## Configuration Example
With this fix, the rate limiter now properly respects the following configuration:
```yaml
rate_limiter:
  storage:
    type: redis
    use_ssl: true
    ca_file: /path/to/ca.pem
    cert_file: /path/to/client-cert.pem
    key_file: /path/to/client-key.pem
    tls_min_version: "1.2"
    tls_max_version: "1.3"
```

## Backward Compatibility
✅ This change is fully backward compatible:
- Existing configurations without mTLS continue to work
- Configurations with `InsecureSkipVerify` are preserved
- No breaking changes to the API or configuration structure

## Checklist
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
Add proper mTLS to rate limiter Redis
Introduce TLS version configuration support
Improve TLS error handling and logging
Add comprehensive unit tests for TLS paths


___

### Diagram Walkthrough


```mermaid
flowchart LR
  NewStorage["rate.NewStorage"] -- "cfg.UseSSL" --> createTLSConfig["Create TLS config with mTLS"]
  createTLSConfig --> CA["Load CA (RootCAs)"]
  createTLSConfig --> ClientCert["Load client cert/key"]
  createTLSConfig --> TLSVer["Set TLS min/max versions"]
  createTLSConfig --> ReturnTLS["Return *tls.Config"]
  Tests["storage_tls_test.go"] -- "unit tests" --> createTLSConfig
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>storage.go</strong><dd><code>Add mTLS-capable TLS builder and integrate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/rate/storage.go

<ul><li>Use <code>createTLSConfig</code> when <code>UseSSL</code> is true<br> <li> Implement <code>createTLSConfig</code> for mTLS and TLS versions<br> <li> Add <code>getTLSVersion</code> helper with warnings<br> <li> Integrate logging for certificate load failures</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7301/files#diff-d19ef7f892927d9a3f4b3c6acf682164fc2c08cba131dca756d1bb9e0b49a510">+68/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>storage_tls_test.go</strong><dd><code>Unit tests for TLS config and mTLS paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/rate/storage_tls_test.go

<ul><li>Add unit tests for TLS config scenarios<br> <li> Cover CA loading, client certs, TLS versions<br> <li> Include helpers to generate test certs/keys<br> <li> Validate error and edge-case behaviors</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7301/files#diff-337239be22a7d67d01827455c48643738568c782c90a7b8fd117bf4733694905">+247/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

