### PR TITLE
TT-14564 Enable tls for rate limiter

### DIFF
--- a/gateway/server.go
+++ b/gateway/server.go
@@ -2021,8 +2021,13 @@ func (gw *Gateway) startDRL() {
 
 	gw.drlOnce.Do(func() {
 		drlManager := &drl.DRL{}
-		gw.SessionLimiter = NewSessionLimiter(gw.ctx, &gwConfig, drlManager)
+		sessionLimiter, err := NewSessionLimiter(gw.ctx, &gwConfig, drlManager)
+		if err != nil {
+			mainLog.WithError(err).Error("Could not initialise session limiter")
+			return
+		}
 
+		gw.SessionLimiter = sessionLimiter
 		gw.DRLManager = drlManager
 
 		if disabled {

--- a/internal/rate/storage.go
+++ b/internal/rate/storage.go
@@ -2,14 +2,25 @@ package rate
 
 import (
 	"crypto/tls"
+	"crypto/x509"
+	temporalStorageErr "github.com/TykTechnologies/storage/temporal/temperr"
+	"os"
 	"time"
 
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/internal/redis"
 )
 
+// use temporalStorageErr for consistency in errors returned
+var (
+	InvalidTLSVersion    = temporalStorageErr.InvalidTLSVersion
+	InvalidTLSMinVersion = temporalStorageErr.InvalidTLSMinVersion
+	InvalidTLSMaxVersion = temporalStorageErr.InvalidTLSMaxVersion
+	AppendCertsFromPEM   = temporalStorageErr.AppendCertsFromPEM
+)
+
 // NewStorage provides a redis v9 client for rate limiter use.
-func NewStorage(cfg *config.StorageOptionsConf) redis.UniversalClient {
+func NewStorage(cfg *config.StorageOptionsConf) (redis.UniversalClient, error) {
 	// poolSize applies per cluster node and not for the whole cluster.
 	poolSize := 500
 	if cfg.MaxActive > 0 {
@@ -22,12 +33,9 @@ func NewStorage(cfg *config.StorageOptionsConf) redis.UniversalClient {
 		timeout = time.Duration(cfg.Timeout) * time.Second
 	}
 
-	var tlsConfig *tls.Config
-
-	if cfg.UseSSL {
-		tlsConfig = &tls.Config{
-			InsecureSkipVerify: cfg.SSLInsecureSkipVerify,
-		}
+	tlsConfig, err := loadTLSConfig(cfg)
+	if err != nil {
+		return nil, err
 	}
 
 	opts := &redis.UniversalOptions{
@@ -46,12 +54,94 @@ func NewStorage(cfg *config.StorageOptionsConf) redis.UniversalClient {
 	}
 
 	if opts.MasterName != "" {
-		return redis.NewFailoverClient(opts.Failover())
+		return redis.NewFailoverClient(opts.Failover()), nil
 	}
 
 	if cfg.EnableCluster {
-		return redis.NewClusterClient(opts.Cluster())
+		return redis.NewClusterClient(opts.Cluster()), nil
 	}
 
-	return redis.NewClient(opts.Simple())
+	return redis.NewClient(opts.Simple()), nil
+}
+
+func loadTLSConfig(cfg *config.StorageOptionsConf) (*tls.Config, error) {
+	if !cfg.UseSSL {
+		return nil, nil
+	}
+
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: cfg.SSLInsecureSkipVerify,
+	}
+
+	// add certs and key files
+	if cfg.CertFile != "" && cfg.KeyFile != "" {
+		cert, err := tls.LoadX509KeyPair(cfg.CertFile, cfg.KeyFile)
+		if err == nil {
+			tlsConfig.Certificates = []tls.Certificate{cert}
+		} else {
+			return nil, err
+		}
+	}
+
+	// Add CA file if provided
+	if cfg.CAFile != "" {
+		caCert, err := os.ReadFile(cfg.CAFile)
+		if err != nil {
+			return nil, err
+		}
+
+		caCertPool := x509.NewCertPool()
+		if !caCertPool.AppendCertsFromPEM(caCert) {
+			return nil, AppendCertsFromPEM
+		}
+		tlsConfig.RootCAs = caCertPool
+	}
+
+	minVersion, maxVersion, err := handleTLSVersion(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	tlsConfig.MinVersion = uint16(minVersion)
+	tlsConfig.MaxVersion = uint16(maxVersion)
+
+	return tlsConfig, nil
+}
+
+func handleTLSVersion(cfg *config.StorageOptionsConf) (minVersion, maxVersion int, err error) {
+	validVersions := map[string]int{
+		"1.0": tls.VersionTLS10,
+		"1.1": tls.VersionTLS11,
+		"1.2": tls.VersionTLS12,
+		"1.3": tls.VersionTLS13,
+	}
+
+	if cfg.TLSMaxVersion == "" {
+		cfg.TLSMaxVersion = "1.3"
+	}
+
+	if _, ok := validVersions[cfg.TLSMaxVersion]; ok {
+		maxVersion = validVersions[cfg.TLSMaxVersion]
+	} else {
+		err = InvalidTLSMaxVersion
+		return
+	}
+
+	if cfg.TLSMinVersion == "" {
+		cfg.TLSMinVersion = "1.2"
+	}
+
+	if _, ok := validVersions[cfg.TLSMinVersion]; ok {
+		minVersion = validVersions[cfg.TLSMinVersion]
+	} else {
+		err = InvalidTLSMinVersion
+		return
+	}
+
+	if minVersion > maxVersion {
+		err = InvalidTLSVersion
+		return
+	}
+
+	return
 }

--- a/internal/rate/storage_test.go
+++ b/internal/rate/storage_test.go
@@ -1,6 +1,12 @@
 package rate
 
 import (
+	"crypto/tls"
+	"errors"
+	"github.com/TykTechnologies/tyk/internal/crypto"
+	"github.com/stretchr/testify/require"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,6 +15,7 @@ import (
 )
 
 func TestNewStorage(t *testing.T) {
+	var err error
 	conf, err := config.NewDefaultWithEnv()
 	assert.NoError(t, err)
 
@@ -17,15 +24,237 @@ func TestNewStorage(t *testing.T) {
 	conf.Storage.Timeout = 4
 	conf.Storage.UseSSL = true
 
-	client := NewStorage(&conf.Storage)
+	client, err := NewStorage(&conf.Storage)
 	assert.NotNil(t, client)
 
 	conf.Storage.EnableCluster = true
-	client = NewStorage(&conf.Storage)
+	client, err = NewStorage(&conf.Storage)
 	assert.NotNil(t, client)
 
 	conf.Storage.EnableCluster = false
 	conf.Storage.MasterName = "redis"
-	client = NewStorage(&conf.Storage)
+	client, err = NewStorage(&conf.Storage)
 	assert.NotNil(t, client)
+}
+
+func TestHandleTLSVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     config.StorageOptionsConf
+		wantMin int
+		wantMax int
+		wantErr error
+	}{
+		{
+			name:    "defaults applied",
+			cfg:     config.StorageOptionsConf{},
+			wantMin: tls.VersionTLS12,
+			wantMax: tls.VersionTLS13,
+			wantErr: nil,
+		},
+		{
+			name: "valid explicit versions",
+			cfg: config.StorageOptionsConf{
+				TLSMinVersion: "1.1",
+				TLSMaxVersion: "1.2",
+			},
+			wantMin: tls.VersionTLS11,
+			wantMax: tls.VersionTLS12,
+			wantErr: nil,
+		},
+		{
+			name: "invalid max version",
+			cfg: config.StorageOptionsConf{
+				TLSMaxVersion: "2.0",
+			},
+			wantErr: InvalidTLSMaxVersion,
+		},
+		{
+			name: "invalid min version",
+			cfg: config.StorageOptionsConf{
+				TLSMinVersion: "0.9",
+			},
+			wantErr: InvalidTLSMinVersion,
+		},
+		{
+			name: "min greater than max",
+			cfg: config.StorageOptionsConf{
+				TLSMinVersion: "1.3",
+				TLSMaxVersion: "1.2",
+			},
+			wantErr: InvalidTLSVersion,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			minV, maxV, err := handleTLSVersion(&tt.cfg)
+
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("expected err %v, got %v", tt.wantErr, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if minV != tt.wantMin {
+				t.Errorf("minVersion: expected %v, got %v", tt.wantMin, minV)
+			}
+			if maxV != tt.wantMax {
+				t.Errorf("maxVersion: expected %v, got %v", tt.wantMax, maxV)
+			}
+		})
+	}
+}
+
+func TestLoadTLSConfig(t *testing.T) {
+	// Create a temporary directory for our test certificates
+	tempDir, err := os.MkdirTemp("", "tls-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Generate root certificate and key
+	rootCertPEM, rootKeyPEM, err := crypto.GenerateRootCertAndKey(t)
+	require.NoError(t, err)
+
+	// Generate server certificate and key
+	serverCertPEM, serverKeyPEM, err := crypto.GenerateServerCertAndKeyPEM(t, rootCertPEM, rootKeyPEM)
+	require.NoError(t, err)
+
+	// Write certificates and keys to files
+	certFile := filepath.Join(tempDir, "cert.pem")
+	keyFile := filepath.Join(tempDir, "key.pem")
+	caFile := filepath.Join(tempDir, "ca.pem")
+
+	require.NoError(t, os.WriteFile(certFile, serverCertPEM.Bytes(), 0644))
+	require.NoError(t, os.WriteFile(keyFile, serverKeyPEM.Bytes(), 0644))
+	require.NoError(t, os.WriteFile(caFile, rootCertPEM, 0644))
+
+	tests := []struct {
+		name           string
+		config         *config.StorageOptionsConf
+		expectError    bool
+		errorSubstring string
+		checkFunc      func(*testing.T, *tls.Config)
+	}{
+		{
+			name: "TLS disabled",
+			config: &config.StorageOptionsConf{
+				UseSSL: false,
+			},
+			expectError: false,
+			checkFunc: func(t *testing.T, c *tls.Config) {
+				assert.Nil(t, c, "TLS config should be nil when TLS is disabled")
+			},
+		},
+		{
+			name: "Basic TLS config",
+			config: &config.StorageOptionsConf{
+				UseSSL:                true,
+				SSLInsecureSkipVerify: true,
+			},
+			expectError: false,
+			checkFunc: func(t *testing.T, c *tls.Config) {
+				assert.NotNil(t, c, "TLS config should not be nil")
+				assert.True(t, c.InsecureSkipVerify, "InsecureSkipVerify should be true")
+			},
+		},
+		{
+			name: "TLS with certificates",
+			config: &config.StorageOptionsConf{
+				UseSSL:   true,
+				CertFile: certFile,
+				KeyFile:  keyFile,
+				CAFile:   caFile,
+			},
+			expectError: false,
+			checkFunc: func(t *testing.T, c *tls.Config) {
+				assert.NotNil(t, c, "TLS config should not be nil")
+				assert.Len(t, c.Certificates, 1, "Should have 1 certificate")
+				assert.NotNil(t, c.RootCAs, "RootCAs should not be nil")
+			},
+		},
+		{
+			name: "TLS with invalid certificate path",
+			config: &config.StorageOptionsConf{
+				UseSSL:   true,
+				CertFile: "nonexistent.crt",
+				KeyFile:  keyFile,
+			},
+			expectError:    true,
+			errorSubstring: "no such file or directory",
+		},
+		{
+			name: "TLS with invalid key path",
+			config: &config.StorageOptionsConf{
+				UseSSL:   true,
+				CertFile: certFile,
+				KeyFile:  "nonexistent.key",
+			},
+			expectError:    true,
+			errorSubstring: "no such file or directory",
+		},
+		{
+			name: "TLS with invalid CA path",
+			config: &config.StorageOptionsConf{
+				UseSSL: true,
+				CAFile: "nonexistent.ca",
+			},
+			expectError:    true,
+			errorSubstring: "no such file or directory",
+		},
+		{
+			name: "TLS with valid min and max versions",
+			config: &config.StorageOptionsConf{
+				UseSSL:        true,
+				TLSMinVersion: "1.2",
+				TLSMaxVersion: "1.3",
+			},
+			expectError: false,
+			checkFunc: func(t *testing.T, c *tls.Config) {
+				assert.NotNil(t, c, "TLS config should not be nil")
+				assert.Equal(t, uint16(tls.VersionTLS12), c.MinVersion, "MinVersion should be TLS 1.2")
+				assert.Equal(t, uint16(tls.VersionTLS13), c.MaxVersion, "MaxVersion should be TLS 1.3")
+			},
+		},
+		{
+			name: "TLS with invalid min version",
+			config: &config.StorageOptionsConf{
+				UseSSL:        true,
+				TLSMinVersion: "invalid",
+			},
+			expectError:    true,
+			errorSubstring: "invalid MinVersion specified",
+		},
+		{
+			name: "TLS with invalid max version",
+			config: &config.StorageOptionsConf{
+				UseSSL:        true,
+				TLSMaxVersion: "invalid",
+			},
+			expectError:    true,
+			errorSubstring: "invalid MaxVersion specified",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tlsConfig, err := loadTLSConfig(tt.config)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.errorSubstring != "" {
+					assert.Contains(t, err.Error(), tt.errorSubstring)
+				}
+			} else {
+				assert.NoError(t, err)
+				if tt.checkFunc != nil {
+					tt.checkFunc(t, tlsConfig)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

As the rate limiter is using its own connection to redis and is not using the temporal storage interface then here we just enable the TLS options for the rate limiter, it uses the configs that we already know for the redis connection. No new configs were added

## Related Issue

TT-14564

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

- Added unit tests

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
