### PR TITLE
Merging to release-5.8: [TT-14564] Fix: Add mutual TLS support for dedicated rate limiter Redis connection (#7301)

### DIFF
--- a/internal/rate/storage.go
+++ b/internal/rate/storage.go
@@ -2,10 +2,13 @@ package rate
 
 import (
 	"crypto/tls"
+	"crypto/x509"
+	"os"
 	"time"
 
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/internal/redis"
+	"github.com/sirupsen/logrus"
 )
 
 // NewStorage provides a redis v9 client for rate limiter use.
@@ -25,9 +28,7 @@ func NewStorage(cfg *config.StorageOptionsConf) redis.UniversalClient {
 	var tlsConfig *tls.Config
 
 	if cfg.UseSSL {
-		tlsConfig = &tls.Config{
-			InsecureSkipVerify: cfg.SSLInsecureSkipVerify,
-		}
+		tlsConfig = createTLSConfig(cfg)
 	}
 
 	opts := &redis.UniversalOptions{
@@ -54,4 +55,67 @@ func NewStorage(cfg *config.StorageOptionsConf) redis.UniversalClient {
 	}
 
 	return redis.NewClient(opts.Simple())
+}
+
+// createTLSConfig creates a TLS configuration with proper mTLS support
+func createTLSConfig(cfg *config.StorageOptionsConf) *tls.Config {
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: cfg.SSLInsecureSkipVerify,
+	}
+
+	// Set TLS versions if configured
+	if cfg.TLSMinVersion != "" {
+		if version, ok := getTLSVersion(cfg.TLSMinVersion); ok {
+			tlsConfig.MinVersion = version
+		}
+	}
+	if cfg.TLSMaxVersion != "" {
+		if version, ok := getTLSVersion(cfg.TLSMaxVersion); ok {
+			tlsConfig.MaxVersion = version
+		}
+	}
+
+	// Load CA certificate if provided
+	if cfg.CAFile != "" {
+		caCert, err := os.ReadFile(cfg.CAFile)
+		if err != nil {
+			logrus.WithError(err).Error("Failed to load CA certificate for rate limiter Redis")
+		} else {
+			caCertPool := x509.NewCertPool()
+			if !caCertPool.AppendCertsFromPEM(caCert) {
+				logrus.Error("Failed to parse CA certificate for rate limiter Redis")
+			} else {
+				tlsConfig.RootCAs = caCertPool
+			}
+		}
+	}
+
+	// Load client certificate and key for mutual TLS
+	if cfg.CertFile != "" && cfg.KeyFile != "" {
+		cert, err := tls.LoadX509KeyPair(cfg.CertFile, cfg.KeyFile)
+		if err != nil {
+			logrus.WithError(err).Error("Failed to load client certificate and key for rate limiter Redis")
+		} else {
+			tlsConfig.Certificates = []tls.Certificate{cert}
+		}
+	}
+
+	return tlsConfig
+}
+
+// getTLSVersion converts a string TLS version to the corresponding tls constant
+func getTLSVersion(version string) (uint16, bool) {
+	switch version {
+	case "1.0":
+		return tls.VersionTLS10, true
+	case "1.1":
+		return tls.VersionTLS11, true
+	case "1.2":
+		return tls.VersionTLS12, true
+	case "1.3":
+		return tls.VersionTLS13, true
+	default:
+		logrus.Warnf("Unknown TLS version: %s", version)
+		return 0, false
+	}
 }

--- a/internal/rate/storage_tls_test.go
+++ b/internal/rate/storage_tls_test.go
@@ -1,0 +1,273 @@
+package rate
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/TykTechnologies/tyk/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateTLSConfig(t *testing.T) {
+	t.Run("No SSL configured", func(t *testing.T) {
+		cfg := &config.StorageOptionsConf{
+			UseSSL: false,
+		}
+		tlsConfig := createTLSConfig(cfg)
+		assert.NotNil(t, tlsConfig)
+		assert.False(t, tlsConfig.InsecureSkipVerify)
+	})
+
+	t.Run("SSL with InsecureSkipVerify", func(t *testing.T) {
+		cfg := &config.StorageOptionsConf{
+			UseSSL:                true,
+			SSLInsecureSkipVerify: true,
+		}
+		tlsConfig := createTLSConfig(cfg)
+		assert.NotNil(t, tlsConfig)
+		assert.True(t, tlsConfig.InsecureSkipVerify)
+	})
+
+	t.Run("SSL with TLS versions", func(t *testing.T) {
+		cfg := &config.StorageOptionsConf{
+			UseSSL:        true,
+			TLSMinVersion: "1.2",
+			TLSMaxVersion: "1.3",
+		}
+		tlsConfig := createTLSConfig(cfg)
+		assert.NotNil(t, tlsConfig)
+		assert.Equal(t, uint16(tls.VersionTLS12), tlsConfig.MinVersion)
+		assert.Equal(t, uint16(tls.VersionTLS13), tlsConfig.MaxVersion)
+	})
+
+	t.Run("SSL with invalid TLS version", func(t *testing.T) {
+		cfg := &config.StorageOptionsConf{
+			UseSSL:        true,
+			TLSMinVersion: "invalid",
+		}
+		tlsConfig := createTLSConfig(cfg)
+		assert.NotNil(t, tlsConfig)
+		assert.Equal(t, uint16(0), tlsConfig.MinVersion) // Should be zero for invalid version
+	})
+
+	t.Run("SSL with CA certificate", func(t *testing.T) {
+		// Create a temporary CA certificate
+		tempDir := t.TempDir()
+		caFile := filepath.Join(tempDir, "ca.crt")
+		createTestCACert(t, caFile)
+
+		cfg := &config.StorageOptionsConf{
+			UseSSL: true,
+			CAFile: caFile,
+		}
+		tlsConfig := createTLSConfig(cfg)
+		assert.NotNil(t, tlsConfig)
+		assert.NotNil(t, tlsConfig.RootCAs)
+	})
+
+	t.Run("SSL with invalid CA certificate path", func(t *testing.T) {
+		cfg := &config.StorageOptionsConf{
+			UseSSL: true,
+			CAFile: "/nonexistent/ca.crt",
+		}
+		tlsConfig := createTLSConfig(cfg)
+		assert.NotNil(t, tlsConfig)
+		assert.Nil(t, tlsConfig.RootCAs) // Should be nil when CA loading fails
+	})
+
+	t.Run("SSL with client certificate and key", func(t *testing.T) {
+		// Create temporary client certificate and key
+		tempDir := t.TempDir()
+		certFile := filepath.Join(tempDir, "client.crt")
+		keyFile := filepath.Join(tempDir, "client.key")
+		createTestCertAndKey(t, certFile, keyFile)
+
+		cfg := &config.StorageOptionsConf{
+			UseSSL:   true,
+			CertFile: certFile,
+			KeyFile:  keyFile,
+		}
+		tlsConfig := createTLSConfig(cfg)
+		assert.NotNil(t, tlsConfig)
+		assert.Len(t, tlsConfig.Certificates, 1)
+	})
+
+	t.Run("SSL with only cert file (missing key)", func(t *testing.T) {
+		tempDir := t.TempDir()
+		certFile := filepath.Join(tempDir, "client.crt")
+		createTestCACert(t, certFile) // Just create a cert file
+
+		cfg := &config.StorageOptionsConf{
+			UseSSL:   true,
+			CertFile: certFile,
+		}
+		tlsConfig := createTLSConfig(cfg)
+		assert.NotNil(t, tlsConfig)
+		assert.Len(t, tlsConfig.Certificates, 0) // Should be empty when key is missing
+	})
+
+	t.Run("SSL with invalid client certificate path", func(t *testing.T) {
+		cfg := &config.StorageOptionsConf{
+			UseSSL:   true,
+			CertFile: "/nonexistent/client.crt",
+			KeyFile:  "/nonexistent/client.key",
+		}
+		tlsConfig := createTLSConfig(cfg)
+		assert.NotNil(t, tlsConfig)
+		assert.Len(t, tlsConfig.Certificates, 0) // Should be empty when loading fails
+	})
+
+	t.Run("SSL with full mTLS configuration", func(t *testing.T) {
+		// Create all certificates
+		tempDir := t.TempDir()
+		caFile := filepath.Join(tempDir, "ca.crt")
+		certFile := filepath.Join(tempDir, "client.crt")
+		keyFile := filepath.Join(tempDir, "client.key")
+
+		createTestCACert(t, caFile)
+		createTestCertAndKey(t, certFile, keyFile)
+
+		cfg := &config.StorageOptionsConf{
+			UseSSL:                true,
+			SSLInsecureSkipVerify: false,
+			CAFile:                caFile,
+			CertFile:              certFile,
+			KeyFile:               keyFile,
+			TLSMinVersion:         "1.2",
+			TLSMaxVersion:         "1.3",
+		}
+
+		tlsConfig := createTLSConfig(cfg)
+		assert.NotNil(t, tlsConfig)
+		assert.False(t, tlsConfig.InsecureSkipVerify)
+		assert.NotNil(t, tlsConfig.RootCAs)
+		assert.Len(t, tlsConfig.Certificates, 1)
+		assert.Equal(t, uint16(tls.VersionTLS12), tlsConfig.MinVersion)
+		assert.Equal(t, uint16(tls.VersionTLS13), tlsConfig.MaxVersion)
+	})
+
+	t.Run("SSL with partial failures still applies other settings", func(t *testing.T) {
+		// Test that even if CA loading fails, other TLS settings are still applied
+		tempDir := t.TempDir()
+		certFile := filepath.Join(tempDir, "client.crt")
+		keyFile := filepath.Join(tempDir, "client.key")
+		createTestCertAndKey(t, certFile, keyFile)
+
+		cfg := &config.StorageOptionsConf{
+			UseSSL:                true,
+			SSLInsecureSkipVerify: true,
+			CAFile:                "/nonexistent/ca.crt", // This will fail to load
+			CertFile:              certFile,              // But this should still work
+			KeyFile:               keyFile,
+			TLSMinVersion:         "1.2",
+			TLSMaxVersion:         "1.3",
+		}
+
+		tlsConfig := createTLSConfig(cfg)
+		assert.NotNil(t, tlsConfig)
+		assert.True(t, tlsConfig.InsecureSkipVerify)
+		assert.Nil(t, tlsConfig.RootCAs)                                // CA loading failed
+		assert.Len(t, tlsConfig.Certificates, 1)                        // But client cert still loaded
+		assert.Equal(t, uint16(tls.VersionTLS12), tlsConfig.MinVersion) // And TLS versions still set
+		assert.Equal(t, uint16(tls.VersionTLS13), tlsConfig.MaxVersion)
+	})
+}
+
+func TestGetTLSVersion(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected uint16
+		ok       bool
+	}{
+		{"1.0", tls.VersionTLS10, true},
+		{"1.1", tls.VersionTLS11, true},
+		{"1.2", tls.VersionTLS12, true},
+		{"1.3", tls.VersionTLS13, true},
+		{"invalid", 0, false},
+		{"", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			version, ok := getTLSVersion(tt.input)
+			assert.Equal(t, tt.expected, version)
+			assert.Equal(t, tt.ok, ok)
+		})
+	}
+}
+
+// Helper function to create a test CA certificate
+func createTestCACert(t *testing.T, filename string) {
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Test CA"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certDER,
+	})
+
+	err = os.WriteFile(filename, certPEM, 0644)
+	require.NoError(t, err)
+}
+
+// Helper function to create a test client certificate and key
+func createTestCertAndKey(t *testing.T, certFile, keyFile string) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Test Client"},
+		},
+		NotBefore:   time.Now(),
+		NotAfter:    time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certDER,
+	})
+
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(priv),
+	})
+
+	err = os.WriteFile(certFile, certPEM, 0644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(keyFile, keyPEM, 0600)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
### **User description**
[TT-14564] Fix: Add mutual TLS support for dedicated rate limiter Redis connection (#7301)

### **User description**
## Summary
This PR fixes a critical security issue where the dedicated Redis
connection for the rate limiter does not properly implement mutual TLS
(mTLS) authentication, even when configured.

## Problem Statement
The Tyk Gateway has two distinct code paths for establishing Redis
connections:
1. **Main Connection:** Handled by `storage.ConnectionHandler` -
correctly implements mTLS
2. **Rate Limiter Connection:** Dedicated connection via
`rate.NewStorage` when `rate_limiter.storage.type` is set to `redis`

The rate limiter's dedicated Redis connection code in
`internal/rate/storage.go` had a critical flaw. When `UseSSL` was
enabled, it only set the `InsecureSkipVerify` field and **completely
ignored** the client certificate configuration (`CertFile`, `KeyFile`,
`CAFile`).

### Security Impact
This creates a security vulnerability where:
- Even if administrators correctly configure mTLS for all Redis
connections
- The rate limiter's connection bypasses these security controls
- The connection either fails (if Redis requires client certs) or
connects insecurely

## Solution
Enhanced the `NewStorage` function in `internal/rate/storage.go` with
proper mTLS support:

### Key Changes:
1. **Added `createTLSConfig` helper function** that properly constructs
TLS configuration
2. **Full mTLS support:**
   - Loads CA certificates for server validation
   - Loads client certificate and key for mutual authentication
- Supports TLS version configuration (`TLSMinVersion`, `TLSMaxVersion`)
3. **Proper error handling** with appropriate logging for certificate
loading failures
4. **Maintains backward compatibility** with existing configurations

## Testing
✅ **Comprehensive test coverage added:**
- Unit tests for all TLS configuration scenarios
- Tests for basic SSL, mTLS, CA certificates, TLS versions
- Error case handling (invalid paths, missing files)
- All existing rate limiter tests continue to pass

### Test Results:
```bash
=== RUN   TestCreateTLSConfig
    --- PASS: TestCreateTLSConfig/No_SSL_configured
    --- PASS: TestCreateTLSConfig/SSL_with_InsecureSkipVerify
    --- PASS: TestCreateTLSConfig/SSL_with_TLS_versions
    --- PASS: TestCreateTLSConfig/SSL_with_invalid_TLS_version
    --- PASS: TestCreateTLSConfig/SSL_with_CA_certificate
    --- PASS: TestCreateTLSConfig/SSL_with_client_certificate_and_key
    --- PASS: TestCreateTLSConfig/SSL_with_full_mTLS_configuration
--- PASS: TestCreateTLSConfig
```

## Configuration Example
With this fix, the rate limiter now properly respects the following
configuration:
```yaml
rate_limiter:
  storage:
    type: redis
    use_ssl: true
    ca_file: /path/to/ca.pem
    cert_file: /path/to/client-cert.pem
    key_file: /path/to/client-key.pem
    tls_min_version: "1.2"
    tls_max_version: "1.3"
```

## Backward Compatibility
✅ This change is fully backward compatible:
- Existing configurations without mTLS continue to work
- Configurations with `InsecureSkipVerify` are preserved
- No breaking changes to the API or configuration structure

## Checklist
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
Add proper mTLS to rate limiter Redis
Introduce TLS version configuration support
Improve TLS error handling and logging
Add comprehensive unit tests for TLS paths


___

### Diagram Walkthrough


```mermaid
flowchart LR
  NewStorage["rate.NewStorage"] -- "cfg.UseSSL" --> createTLSConfig["Create TLS config with mTLS"]
  createTLSConfig --> CA["Load CA (RootCAs)"]
  createTLSConfig --> ClientCert["Load client cert/key"]
  createTLSConfig --> TLSVer["Set TLS min/max versions"]
  createTLSConfig --> ReturnTLS["Return *tls.Config"]
  Tests["storage_tls_test.go"] -- "unit tests" --> createTLSConfig
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>storage.go</strong><dd><code>Add mTLS-capable TLS
builder and integrate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

internal/rate/storage.go

<ul><li>Use <code>createTLSConfig</code> when <code>UseSSL</code> is
true<br> <li> Implement <code>createTLSConfig</code> for mTLS and TLS
versions<br> <li> Add <code>getTLSVersion</code> helper with
warnings<br> <li> Integrate logging for certificate load failures</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7301/files#diff-d19ef7f892927d9a3f4b3c6acf682164fc2c08cba131dca756d1bb9e0b49a510">+68/-3</a>&nbsp;
&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>storage_tls_test.go</strong><dd><code>Unit tests for
TLS config and mTLS paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></summary>
<hr>

internal/rate/storage_tls_test.go

<ul><li>Add unit tests for TLS config scenarios<br> <li> Cover CA
loading, client certs, TLS versions<br> <li> Include helpers to generate
test certs/keys<br> <li> Validate error and edge-case behaviors</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7301/files#diff-337239be22a7d67d01827455c48643738568c782c90a7b8fd117bf4733694905">+247/-0</a>&nbsp;
</td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

---------

Co-authored-by: Claude <noreply@anthropic.com>
Co-authored-by: sredny buitrago <sredny@srednys-MacBook-Pro.local>

[TT-14564]: https://tyktech.atlassian.net/browse/TT-14564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Tests


___

### **Description**
Add mTLS to rate limiter Redis
Support TLS min/max version config
Improve TLS cert loading and logging
Add unit tests for TLS scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  NewStorage["rate.NewStorage"] -- "cfg.UseSSL=true" --> CreateTLS["createTLSConfig builds *tls.Config"]
  CreateTLS --> CA["Load CA from cfg.CAFile -> RootCAs"]
  CreateTLS --> Client["Load client cert/key -> Certificates"]
  CreateTLS --> Versions["Set Min/Max TLS from cfg"]
  CreateTLS --> ReturnTLS["Return tls.Config"]
  Tests["storage_tls_test.go"] -- "unit tests" --> CreateTLS
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>storage.go</strong><dd><code>Add mTLS-capable TLS builder and integrate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/rate/storage.go

<ul><li>Use <code>createTLSConfig</code> when <code>UseSSL</code> is true<br> <li> Implement mTLS: CA roots and client cert/key<br> <li> Add TLS min/max version parsing with warnings<br> <li> Integrate error logging for TLS loading failures</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7313/files#diff-d19ef7f892927d9a3f4b3c6acf682164fc2c08cba131dca756d1bb9e0b49a510">+67/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>storage_tls_test.go</strong><dd><code>Tests for TLS config and mTLS paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/rate/storage_tls_test.go

<ul><li>Add unit tests for TLS config scenarios<br> <li> Cover CA loading, client certs, TLS versions<br> <li> Validate invalid paths and partial failure behavior<br> <li> Include helpers to generate test certs/keys</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7313/files#diff-337239be22a7d67d01827455c48643738568c782c90a7b8fd117bf4733694905">+273/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

