### PR TITLE
Merging to release-5.8: Custom domain regex causing problems with servers (#7322)

### DIFF
--- a/internal/oasutil/servers.go
+++ b/internal/oasutil/servers.go
@@ -17,6 +17,7 @@ var (
 	ErrUnexpectedCurlyBrace = errors.New("unexpected closing curly brace")
 	ErrInvalidVariableName  = errors.New("invalid variable name")
 	ErrInvalidPattern       = errors.New("invalid pattern")
+	ErrNoCaptureGroup       = errors.New("capture groups are prohibited")
 	errUnreachable          = errors.New("unreachable")
 )
 
@@ -157,8 +158,10 @@ func (p *serverUrlParser) extractValueBetweenBraces() (serverVariable, error) {
 				return serverVariable{}, ErrInvalidVariableName
 			}
 
-			if _, err := regexp.Compile(pattern); err != nil {
+			if re, err := regexp.Compile(pattern); err != nil {
 				return serverVariable{}, errpack.Wrap(ErrInvalidPattern, "failed to compile pattern")
+			} else if hasCaptureGroups(re) {
+				return serverVariable{}, errpack.Wrap(ErrNoCaptureGroup, "using capture group is not allowed in server patterns")
 			}
 
 			return serverVariable{
@@ -180,4 +183,8 @@ func (p *serverUrlParser) nextParamName() string {
 
 func isValidIdentifier(name string) bool {
 	return identifierRe.MatchString(name)
+}
+
+func hasCaptureGroups(re *regexp.Regexp) bool {
+	return re.NumSubexp() > 0
 }

--- a/internal/oasutil/servers_test.go
+++ b/internal/oasutil/servers_test.go
@@ -58,6 +58,18 @@ func TestParseServerUrl(t *testing.T) {
 				UrlNormalized: "",
 				Variables:     nil,
 			}},
+			{"doesnt fail with non capture group", "https://{subdomain:(?:hello|world)}.example.com/{version:(?:v[0-9]+)}", &oasutil.ServerUrl{
+				Url:           "https://{subdomain:(?:hello|world)}.example.com/{version:(?:v[0-9]+)}",
+				UrlNormalized: "https://{subdomain}.example.com/{version}",
+				Variables: map[string]*openapi3.ServerVariable{
+					"subdomain": {
+						Default: oasutil.DefaultServerUrlPrefix + "1",
+					},
+					"version": {
+						Default: oasutil.DefaultServerUrlPrefix + "2",
+					},
+				},
+			}},
 		} {
 			t.Run(tCase.name, func(t *testing.T) {
 				res, err := oasutil.ParseServerUrl(tCase.input)
@@ -83,6 +95,8 @@ func TestParseServerUrl(t *testing.T) {
 			{"server variable collision", "{version:[a-z]+}.example.com/{version:[0-9]+}", oasutil.ErrVariableCollision},
 			{"double open", "{{subdomain}.example.com", oasutil.ErrInvalidVariableName},
 			{"invalid pattern", "{subdomain:[a-z]++}.example.com", oasutil.ErrInvalidPattern},
+			// using capture groups provide to fail gateway https://tyktech.atlassian.net/browse/TT-11244?focusedCommentId=101878
+			{"does not allow capture group", "{subdomain:([a-z]+)}.example.com", oasutil.ErrNoCaptureGroup},
 		} {
 			t.Run(tCase.name, func(t *testing.T) {
 				_, err := oasutil.ParseServerUrl(tCase.input)


### PR DESCRIPTION
### **User description**
Custom domain regex causing problems with servers (#7322)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-11244"
title="TT-11244" target="_blank">TT-11244</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Custom domain regex causing problems with servers</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20QA_Fail%20ORDER%20BY%20created%20DESC"
title="QA_Fail">QA_Fail</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20codilime_refined%20ORDER%20BY%20created%20DESC"
title="codilime_refined">codilime_refined</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description
Using capture groups in Custom Domain provides to GW crash. 
Current PR prevents capture groups usage in custom domain regexes.
It fixess issue described here
https://tyktech.atlassian.net/browse/TT-11244?focusedCommentId=101878
<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Bug fix, Tests


___

### **Description**
Disallow capture groups in server regex
Add explicit error for capture groups
Validate via new unit tests
Allow non-capturing groups usage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["servers.go: regex compile and check"] -- "error on capture groups" --> B["ErrNoCaptureGroup added"]
  A -- "allow non-capturing groups" --> C["hasCaptureGroups uses NumSubexp"]
  D["servers_test.go"] -- "adds positive/negative cases" --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>servers.go</strong><dd><code>Enforce no capture groups
in server patterns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/oasutil/servers.go

<ul><li>Add <code>ErrNoCaptureGroup</code> error.<br> <li> Reject regex
with capture groups after compile.<br> <li> Introduce
<code>hasCaptureGroups</code> using <code>NumSubexp</code>.<br> <li>
Keep allowing non-capturing groups.</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7322/files#diff-98dd06199bf9992e099563df9150f18cb38094f4dae3299f33c5330722ddac3d">+8/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>servers_test.go</strong><dd><code>Tests for capture vs
non-capture groups in servers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></summary>
<hr>

internal/oasutil/servers_test.go

<ul><li>Add test allowing non-capturing groups.<br> <li> Add test
rejecting capture groups with <code>ErrNoCaptureGroup</code>.</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7322/files#diff-4a274e0f05feb520d7ff68fb48a7a28020ea7525820ac8105f4c898854a19af8">+14/-0</a>&nbsp;
&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Prohibit capture groups in server regex

- Add explicit error `ErrNoCaptureGroup`

- Allow non-capturing groups in patterns

- Add unit tests for both cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  SG["servers.go: compile and validate regex"] 
  ERR["ErrNoCaptureGroup error added"]
  HCG["hasCaptureGroups uses NumSubexp()"]
  TEST["servers_test.go: positive/negative tests"]

  SG -- "detect capture groups" --> HCG
  HCG -- "if > 0" --> ERR
  TEST -- "assert allow non-capturing" --> SG
  TEST -- "assert reject capturing" --> ERR
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>servers.go</strong><dd><code>Enforce no capture groups in server patterns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/oasutil/servers.go

<ul><li>Add <code>ErrNoCaptureGroup</code> error constant.<br> <li> Reject patterns with capture groups after compile.<br> <li> Introduce <code>hasCaptureGroups</code> using <code>NumSubexp()</code>.<br> <li> Keep non-capturing groups allowed.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7331/files#diff-98dd06199bf9992e099563df9150f18cb38094f4dae3299f33c5330722ddac3d">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>servers_test.go</strong><dd><code>Tests for capturing vs non-capturing groups</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/oasutil/servers_test.go

<ul><li>Add test allowing non-capturing groups.<br> <li> Add test rejecting capturing groups with error.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7331/files#diff-4a274e0f05feb520d7ff68fb48a7a28020ea7525820ac8105f4c898854a19af8">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

