### PR TITLE
Merging to release-5.8: [TT-14369] ReadableDuration does not handle time values that "mix" subsecond units - extending tests duration_test.go (#7293)

### DIFF
--- a/internal/time/duration_test.go
+++ b/internal/time/duration_test.go
@@ -49,6 +49,15 @@ func TestReadableDuration_MarshalJSON(t *testing.T) {
 
 		duration = ReadableDuration(1*time.Hour + (2+60)*time.Minute + 3*time.Second + 4*time.Millisecond + 5*time.Microsecond + 6*time.Nanosecond)
 		assert.Equal(t, "2h2m3s4ms5µs6ns", duration.format())
+
+		duration = ReadableDuration(71*time.Second + 10*time.Millisecond)
+		assert.Equal(t, "1m11s10ms", duration.format())
+
+		duration = ReadableDuration(1*time.Millisecond + 1*time.Nanosecond)
+		assert.Equal(t, "1ms1ns", duration.format())
+
+		duration = ReadableDuration(1*time.Second + 1*time.Nanosecond)
+		assert.Equal(t, "1s1ns", duration.format())
 	})
 
 	t.Run("negative duration", func(t *testing.T) {


### PR DESCRIPTION
### **User description**
[TT-14369] ReadableDuration does not handle time values that "mix" subsecond units - extending tests duration_test.go (#7293)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-14369"
title="TT-14369" target="_blank">TT-14369</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
<td>[OAS] ReadableDuration does not handle time values that "mix"
subsecond units during migration from Classic</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20codilime_refined%20ORDER%20BY%20created%20DESC"
title="codilime_refined">codilime_refined</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Tests


___

### **Description**
Add unit tests for complex durations
Cover mixed subsecond unit formatting
Validate nanosecond and millisecond combos
Extend edge cases for normalization


___

### Diagram Walkthrough


```mermaid
flowchart LR
  tests["duration_test.go"] -- "add cases" --> format["ReadableDuration.format() behavior"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>duration_test.go</strong><dd><code>Add edge-case tests
for duration formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/time/duration_test.go

<ul><li>Add tests for 71m + 10ms normalization<br> <li> Add duplicate
minute case with expected 11ms<br> <li> Add ms+ns and s+ns formatting
checks<br> <li> Extend complex duration coverage</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7293/files#diff-71942cdc77128266498b62e712f82d0c63bbb39d236fe9e6677f49080c28cea1">+12/-0</a>&nbsp;
&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

Co-authored-by: Yaroslav Kotsur <yarikkotsur@gmail.com>

[TT-14369]: https://tyktech.atlassian.net/browse/TT-14369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Tests


___

### **Description**
- Add mixed subsecond duration tests

- Validate seconds-plus-nanoseconds formatting

- Normalize seconds to minutes in output

- Extend complex duration coverage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  tests["duration_test.go"] --> cases["Complex and mixed subsecond cases"]
  cases -- "format() expectations" --> output["Normalized readable strings"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>duration_test.go</strong><dd><code>Extend tests for mixed subsecond formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/time/duration_test.go

<ul><li>Add cases for 71s + 10ms -> 1m11s10ms<br> <li> Add ms+ns (1ms1ns) and s+ns (1s1ns) checks<br> <li> Extend complex duration suite without code changes</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7335/files#diff-71942cdc77128266498b62e712f82d0c63bbb39d236fe9e6677f49080c28cea1">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

