### PR TITLE
Merging to release-5.8: [OAS] gateway apiKey import generates unnecessary object (#7328)

### DIFF
--- a/apidef/oas/authentication.go
+++ b/apidef/oas/authentication.go
@@ -226,7 +226,7 @@ func (ss SecuritySchemes) Import(name string, nativeSS *openapi3.SecurityScheme,
 			}
 		}
 
-		token.Enabled = enable
+		token.Enabled = &enable
 	case nativeSS.Type == typeHTTP && nativeSS.Scheme == schemeBearer && nativeSS.BearerFormat == bearerFormatJWT:
 		jwt := &JWT{}
 		if ss[name] == nil {

--- a/apidef/oas/default_test.go
+++ b/apidef/oas/default_test.go
@@ -257,7 +257,7 @@ func TestOAS_BuildDefaultTykExtension(t *testing.T) {
 					BaseIdentityProvider: apidef.AuthToken,
 					SecuritySchemes: SecuritySchemes{
 						testSSMyAuth: &Token{
-							Enabled: true,
+							Enabled: getBoolPointer(true),
 						},
 						testSSMyAuthWithAnd: &OAuth{
 							Enabled: true,
@@ -1683,7 +1683,7 @@ func TestOAS_importAuthentication(t *testing.T) {
 
 			expectedSecuritySchemes := SecuritySchemes{
 				testSecurityNameToken: &Token{
-					Enabled: enable,
+					Enabled: &enable,
 				},
 			}
 
@@ -1724,7 +1724,7 @@ func TestOAS_importAuthentication(t *testing.T) {
 				Authentication: &Authentication{
 					SecuritySchemes: SecuritySchemes{
 						testSecurityNameToken: &Token{
-							Enabled: false,
+							Enabled: getBoolPointer(false),
 						},
 					},
 				},
@@ -1742,7 +1742,7 @@ func TestOAS_importAuthentication(t *testing.T) {
 
 		expectedSecuritySchemes := SecuritySchemes{
 			testSecurityNameToken: &Token{
-				Enabled: true,
+				Enabled: getBoolPointer(true),
 			},
 		}
 
@@ -1789,7 +1789,7 @@ func TestOAS_importAuthentication(t *testing.T) {
 
 			expectedSecuritySchemes := SecuritySchemes{
 				testSecurityNameToken: &Token{
-					Enabled: enable,
+					Enabled: &enable,
 				},
 				testSecurityNameJWT: &JWT{
 					Enabled: enable,
@@ -1841,7 +1841,7 @@ func TestSecuritySchemes_Import(t *testing.T) {
 			assert.NoError(t, err)
 
 			expectedToken := &Token{
-				Enabled: enable,
+				Enabled: &enable,
 			}
 
 			assert.Equal(t, expectedToken, securitySchemes[testSecurityNameToken])
@@ -1951,7 +1951,7 @@ func TestSecuritySchemes_Import(t *testing.T) {
 		assert.NoError(t, err)
 
 		expectedToken := &Token{
-			Enabled: true,
+			Enabled: getBoolPointer(true),
 		}
 
 		assert.Equal(t, expectedToken, securitySchemes[testSecurityNameToken])
@@ -2017,7 +2017,7 @@ func TestToken_Import(t *testing.T) {
 	token.Import(nativeSecurityScheme, true)
 
 	expectedToken := &Token{
-		Enabled: true,
+		Enabled: getBoolPointer(true),
 		AuthSources: AuthSources{
 			Header: &AuthSource{
 				Enabled: true,


### PR DESCRIPTION
### **User description**
[OAS] gateway apiKey import generates unnecessary object (#7328)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-5588"
title="TT-5588" target="_blank">TT-5588</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>[OAS] gateway apiKey import generates unnecessary object</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20QA_Fail%20ORDER%20BY%20created%20DESC"
title="QA_Fail">QA_Fail</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20codilime_refined%20ORDER%20BY%20created%20DESC"
title="codilime_refined">codilime_refined</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

The headerobject is unnecessarily generated during creation of a Tyk OAS
API by importing an OpenAPI description with security scheme defined.

This fix handles use case where disabled token was recognized as an
empty structure to be removed.

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Make `Token.Enabled` a pointer

- Preserve disabled token during import

- Adjust import/export to handle nil

- Update tests for pointer semantics


___

### Diagram Walkthrough


```mermaid
flowchart LR
  nativeSS["OpenAPI SecurityScheme"] -- import --> tokenEnabled["Token.Enabled as *bool"]
  tokenEnabled -- nil-safe mapping --> apiDef["APIDefinition.UseStandardAuth"]
  tests["Unit tests"] -- expect pointers --> securityTests["Security and default tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>authentication.go</strong><dd><code>Use pointer when
importing token enabled flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/authentication.go

<ul><li>Set <code>Token.Enabled</code> via <code>&enable</code>.<br>
<li> Ensure token enabled state stored as pointer on import.</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7328/files#diff-e51c9d24d4235e7cc53048cc1d92967d177585ba5e073f14876308a97bef6326">+1/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>security.go</strong><dd><code>Make Token.Enabled
pointer and handle nil flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/security.go

<ul><li>Change <code>Token.Enabled</code> type to
<code>*bool</code>.<br> <li> Set pointer in
<code>Token.Import</code>.<br> <li> Fill from APIDefinition using
pointer.<br> <li> Extract to APIDefinition handling nil safely.</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7328/files#diff-15e7d47137452ca4f3f6139aa8c007cdb426152c41846f712f8bf5dfb607afcc">+8/-4</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>default_test.go</strong><dd><code>Update tests for
pointer-based token enabled</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/default_test.go

<ul><li>Update expectations to use <code>getBoolPointer(...)</code>.<br>
<li> Adjust equality checks for pointer-enabled tokens.</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7328/files#diff-ab6848f71731083885a9d7d7970faa68a6783a98477c78413ae3979cb5add7db">+8/-8</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>security_test.go</strong><dd><code>Refactor token
tests, add disabled preservation</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/security_test.go

<ul><li>Refactor Token tests with enabled/disabled cases.<br> <li>
Expect pointers for enabled state.<br> <li> Ensure disabled token is
preserved in export/import.</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7328/files#diff-5184167309db0462243e424baca87b5bb668962d8cc1076629fdcf11f00487e5">+59/-36</a>&nbsp;
</td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Make `Token.Enabled` a pointer

- Preserve disabled token on import/export

- Nil-safe mapping to API definition

- Update tests for pointer semantics


___

### Diagram Walkthrough


```mermaid
flowchart LR
  oasSS["OpenAPI SecurityScheme"]
  tokenPtr["Token.Enabled as *bool"]
  apiDef["APIDefinition.UseStandardAuth"]
  tests["Unit tests updated"]

  oasSS -- import --> tokenPtr
  tokenPtr -- nil-safe extract --> apiDef
  apiDef -- fill --> tokenPtr
  tests -- assert pointers --> tokenPtr
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>authentication.go</strong><dd><code>Use pointer for token enabled during import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/authentication.go

<ul><li>Set <code>Token.Enabled</code> using pointer <code>&enable</code>.<br> <li> Ensure pointer assigned during security scheme import.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7336/files#diff-e51c9d24d4235e7cc53048cc1d92967d177585ba5e073f14876308a97bef6326">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>security.go</strong><dd><code>Make Token.Enabled pointer and handle nil paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/security.go

<ul><li>Change <code>Token.Enabled</code> type to <code>*bool</code>.<br> <li> Set pointer in <code>Token.Import</code>.<br> <li> Fill from APIDefinition using pointer.<br> <li> Extract to APIDefinition handling nil safely.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7336/files#diff-15e7d47137452ca4f3f6139aa8c007cdb426152c41846f712f8bf5dfb607afcc">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>default_test.go</strong><dd><code>Adapt defaults tests to pointer-based enabled</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/default_test.go

<ul><li>Update expectations to use bool pointers.<br> <li> Adjust imports/tests to compare pointer values.<br> <li> Replace literals with <code>getBoolPointer(...)</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7336/files#diff-ab6848f71731083885a9d7d7970faa68a6783a98477c78413ae3979cb5add7db">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>security_test.go</strong><dd><code>Refactor token tests; verify disabled preservation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/security_test.go

<ul><li>Refactor token tests into enabled/disabled cases.<br> <li> Expect pointer for enabled state.<br> <li> Ensure disabled token preserved across round-trip.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7336/files#diff-5184167309db0462243e424baca87b5bb668962d8cc1076629fdcf11f00487e5">+59/-36</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

