### PR TITLE
[TT-15742] Fix missing CertificateExpired events for certs expired <1h ago

### DIFF
--- a/gateway/mw_certificate_check.go
+++ b/gateway/mw_certificate_check.go
@@ -169,9 +169,9 @@ func (m *CertificateCheckMW) extractCertInfo(cert *tls.Certificate) (certInfo ce
 	}
 
 	return certcheck.CertInfo{
-		ID:               certID,
-		CommonName:       cert.Leaf.Subject.CommonName,
-		NotAfter:         cert.Leaf.NotAfter,
-		HoursUntilExpiry: int(time.Until(cert.Leaf.NotAfter).Hours()),
+		ID:          certID,
+		CommonName:  cert.Leaf.Subject.CommonName,
+		NotAfter:    cert.Leaf.NotAfter,
+		UntilExpiry: time.Until(cert.Leaf.NotAfter),
 	}, true
 }

--- a/internal/certcheck/batcher.go
+++ b/internal/certcheck/batcher.go
@@ -283,11 +283,8 @@ func (c *CertificateExpiryCheckBatcher) handleEventForCertificate(certInfo CertI
 
 func (c *CertificateExpiryCheckBatcher) handleEventForExpiredCertificate(certInfo CertInfo) {
 	// Calculate days and hours since expiry (negative duration)
-	daysSinceExpiry := int(certInfo.UntilExpiry.Hours()/24) * -1
-	hoursSinceExpiry := int(certInfo.UntilExpiry.Hours()) % 24
-	if hoursSinceExpiry != 0 {
-		hoursSinceExpiry *= -1
-	}
+	daysSinceExpiry := certInfo.DaysUntilExpiry() * -1
+	hoursSinceExpiry := (certInfo.HoursUntilExpiry() % -24) * -1
 
 	eventMeta := EventCertificateExpiredMeta{
 		EventMetaDefault: model.EventMetaDefault{
@@ -304,12 +301,12 @@ func (c *CertificateExpiryCheckBatcher) handleEventForExpiredCertificate(certInf
 	c.logger.
 		WithField("cert_id", certInfo.ID[:8]).
 		WithField("event_type", string(event.CertificateExpired)).
-		Debugf("EXPIRY EVENT FIRED for certificate '%s' - expired since %v", certInfo.CommonName, certInfo.UntilExpiry)
+		Debugf("EXPIRY EVENT FIRED for certificate '%s' - expired since %d hours", certInfo.CommonName, certInfo.HoursUntilExpiry())
 }
 
 func (c *CertificateExpiryCheckBatcher) handleEventForSoonToExpireCertificate(certInfo CertInfo) {
-	daysUntilExpiry := int(certInfo.UntilExpiry.Hours() / 24)
-	remainingHours := int(certInfo.UntilExpiry.Hours()) % 24
+	daysUntilExpiry := certInfo.DaysUntilExpiry()
+	remainingHours := int(certInfo.HoursUntilExpiry()) % 24
 
 	eventMeta := EventCertificateExpiringSoonMeta{
 		EventMetaDefault: model.EventMetaDefault{
@@ -326,7 +323,7 @@ func (c *CertificateExpiryCheckBatcher) handleEventForSoonToExpireCertificate(ce
 	c.logger.
 		WithField("cert_id", certInfo.ID[:8]).
 		WithField("event_type", string(event.CertificateExpiringSoon)).
-		Debugf("EXPIRY EVENT FIRED for certificate '%s' - expires in %v", certInfo.CommonName, certInfo.UntilExpiry)
+		Debugf("EXPIRY EVENT FIRED for certificate '%s' - expires in %d hours", certInfo.CommonName, certInfo.HoursUntilExpiry())
 }
 
 func (c *CertificateExpiryCheckBatcher) fireEventCooldownExistsInLocalCache(certInfo CertInfo) (exists bool) {

--- a/internal/certcheck/batcher_test.go
+++ b/internal/certcheck/batcher_test.go
@@ -2,7 +2,10 @@ package certcheck
 
 import (
 	"context"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"errors"
+	"math/big"
 	"testing"
 	"time"
 
@@ -13,6 +16,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/internal/crypto"
 	"github.com/TykTechnologies/tyk/internal/event"
 	"github.com/TykTechnologies/tyk/internal/model"
 
@@ -22,6 +26,36 @@ import (
 var testApiMetaData = APIMetaData{
 	APIID:   "123abc",
 	APIName: "API",
+}
+
+// createTestCertInfo creates a CertInfo from a real x509 certificate with the specified expiry time
+func createTestCertInfo(t *testing.T, commonName string, notAfter time.Time) CertInfo {
+	t.Helper()
+
+	// Create a real x509 certificate
+	_, _, _, tlsCert := crypto.GenCertificate(&x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: commonName,
+		},
+		NotBefore:   time.Now().Add(-time.Hour), // Valid from 1 hour ago
+		NotAfter:    notAfter,
+		KeyUsage:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}, true)
+
+	// Calculate the ID using the same method as the real code
+	certID := crypto.HexSHA256(tlsCert.Leaf.Raw)
+
+	// Calculate duration until expiry using the same method as the real code
+	untilExpiry := time.Until(notAfter)
+
+	return CertInfo{
+		ID:          certID,
+		CommonName:  tlsCert.Leaf.Subject.CommonName,
+		NotAfter:    tlsCert.Leaf.NotAfter,
+		UntilExpiry: untilExpiry,
+	}
 }
 
 type BatcherMocks struct {
@@ -437,10 +471,10 @@ func TestCertificateExpiryCheckBatcher(t *testing.T) {
 				now := time.Now()
 				expiry := now.Add(48 * time.Hour)
 				err = batcher.Add(CertInfo{
-					ID:               "test-cert-id",
-					HoursUntilExpiry: 48,
-					NotAfter:         expiry,
-					CommonName:       "test-cert",
+					ID:          "test-cert-id",
+					UntilExpiry: 48 * time.Hour, // 48 hours
+					NotAfter:    expiry,
+					CommonName:  "test-cert",
 				})
 				require.NoError(t, err)
 
@@ -493,10 +527,10 @@ func TestCertificateExpiryCheckBatcher(t *testing.T) {
 				now := time.Now()
 				expiredSince := now.Add(-50 * time.Hour)
 				err = batcher.Add(CertInfo{
-					ID:               "test-cert-id",
-					HoursUntilExpiry: -50,
-					NotAfter:         expiredSince,
-					CommonName:       "test-cert",
+					ID:          "test-cert-id",
+					UntilExpiry: -50 * time.Hour, // -50 hours
+					NotAfter:    expiredSince,
+					CommonName:  "test-cert",
 				})
 				require.NoError(t, err)
 
@@ -573,10 +607,10 @@ func TestCertificateExpiryCheckBatcher(t *testing.T) {
 				now := time.Now()
 				expiry := now.Add(48 * time.Hour)
 				err = batcher.Add(CertInfo{
-					ID:               "test-cert-id",
-					HoursUntilExpiry: 48,
-					NotAfter:         expiry,
-					CommonName:       "test-cert",
+					ID:          "test-cert-id",
+					UntilExpiry: 48 * time.Hour, // 48 hours
+					NotAfter:    expiry,
+					CommonName:  "test-cert",
 				})
 				require.NoError(t, err)
 
@@ -653,10 +687,10 @@ func TestCertificateExpiryCheckBatcher(t *testing.T) {
 				now := time.Now()
 				expiry := now.Add(48 * time.Hour)
 				err = batcher.Add(CertInfo{
-					ID:               "test-cert-id",
-					HoursUntilExpiry: 48,
-					NotAfter:         expiry,
-					CommonName:       "test-cert",
+					ID:          "test-cert-id",
+					UntilExpiry: 48 * time.Hour, // 48 hours
+					NotAfter:    expiry,
+					CommonName:  "test-cert",
 				})
 				require.NoError(t, err)
 
@@ -754,6 +788,561 @@ func TestCertificateExpiryCheckBatcher_composeExpiredMessage(t *testing.T) {
 		expectedMessage := "Certificate test-cert is expired since 2 hours"
 		assert.Equal(t, expectedMessage, actualMessage)
 	})
+}
+
+func TestCertificateExpiryCheckBatcher_isCertificateExpired(t *testing.T) {
+	batcher := &CertificateExpiryCheckBatcher{}
+
+	tests := map[string]struct {
+		commonName     string
+		hoursFromNow   float64
+		expectedResult bool
+		description    string
+	}{
+		"expired_certificate": {
+			commonName:     "expired-cert",
+			hoursFromNow:   -10, // 10 hours ago
+			expectedResult: true,
+			description:    "Should return true when certificate is expired (negative hours)",
+		},
+		"expired_certificate_30_minutes": {
+			commonName:     "expired-cert-30min",
+			hoursFromNow:   -0.5, // 30 minutes ago
+			expectedResult: true,
+			description:    "Should return true when certificate expired 30 minutes ago",
+		},
+		"just_expired_certificate": {
+			commonName:     "just-expired-cert",
+			hoursFromNow:   0, // Right now
+			expectedResult: true,
+			description:    "Should return true when certificate is exactly expired (zero hours)",
+		},
+		"expiring_soon_certificate_30_minutes": {
+			commonName:     "expiring-soon-cert-30min",
+			hoursFromNow:   0.5, // 30 minutes from now
+			expectedResult: false,
+			description:    "Should return false when certificate expires in 30 minutes (not expired with seconds precision)",
+		},
+		"valid_certificate": {
+			commonName:     "valid-cert",
+			hoursFromNow:   24, // 24 hours from now
+			expectedResult: false,
+			description:    "Should return false when certificate is not expired (positive hours)",
+		},
+		"long_valid_certificate": {
+			commonName:     "long-valid-cert",
+			hoursFromNow:   720, // 30 days from now
+			expectedResult: false,
+			description:    "Should return false when certificate has many hours until expiry",
+		},
+		"expired_certificate_1_second": {
+			commonName:     "expired-cert-1sec",
+			hoursFromNow:   -1.0 / 3600, // 1 second ago
+			expectedResult: true,
+			description:    "Should return true when certificate expired 1 second ago",
+		},
+		"expired_certificate_1_minute": {
+			commonName:     "expired-cert-1min",
+			hoursFromNow:   -1.0 / 60, // 1 minute ago
+			expectedResult: true,
+			description:    "Should return true when certificate expired 1 minute ago",
+		},
+		"expired_certificate_1_hour": {
+			commonName:     "expired-cert-1hour",
+			hoursFromNow:   -1, // 1 hour ago
+			expectedResult: true,
+			description:    "Should return true when certificate expired 1 hour ago",
+		},
+		"expired_certificate_1_day": {
+			commonName:     "expired-cert-1day",
+			hoursFromNow:   -24, // 1 day ago
+			expectedResult: true,
+			description:    "Should return true when certificate expired 1 day ago",
+		},
+		"expired_certificate_1_week": {
+			commonName:     "expired-cert-1week",
+			hoursFromNow:   -168, // 1 week ago (7 days)
+			expectedResult: true,
+			description:    "Should return true when certificate expired 1 week ago",
+		},
+		"expired_certificate_1_month": {
+			commonName:     "expired-cert-1month",
+			hoursFromNow:   -720, // 1 month ago (30 days)
+			expectedResult: true,
+			description:    "Should return true when certificate expired 1 month ago",
+		},
+		"expired_certificate_1_year": {
+			commonName:     "expired-cert-1year",
+			hoursFromNow:   -8760, // 1 year ago (365 days)
+			expectedResult: true,
+			description:    "Should return true when certificate expired 1 year ago",
+		},
+		"expiring_soon_certificate_1_second": {
+			commonName:     "expiring-soon-cert-1sec",
+			hoursFromNow:   1.0 / 3600, // 1 second from now
+			expectedResult: false,
+			description:    "Should return false when certificate expires in 1 second (not expired)",
+		},
+		"expiring_soon_certificate_1_minute": {
+			commonName:     "expiring-soon-cert-1min",
+			hoursFromNow:   1.0 / 60, // 1 minute from now
+			expectedResult: false,
+			description:    "Should return false when certificate expires in 1 minute (not expired)",
+		},
+		"expiring_soon_certificate_1_hour": {
+			commonName:     "expiring-soon-cert-1hour",
+			hoursFromNow:   1, // 1 hour from now
+			expectedResult: false,
+			description:    "Should return false when certificate expires in 1 hour (not expired)",
+		},
+		"expiring_soon_certificate_1_day": {
+			commonName:     "expiring-soon-cert-1day",
+			hoursFromNow:   24, // 1 day from now
+			expectedResult: false,
+			description:    "Should return false when certificate expires in 1 day (not expired)",
+		},
+		"expiring_soon_certificate_1_week": {
+			commonName:     "expiring-soon-cert-1week",
+			hoursFromNow:   168, // 1 week from now (7 days)
+			expectedResult: false,
+			description:    "Should return false when certificate expires in 1 week (not expired)",
+		},
+		"expiring_soon_certificate_1_month": {
+			commonName:     "expiring-soon-cert-1month",
+			hoursFromNow:   720, // 1 month from now (30 days)
+			expectedResult: false,
+			description:    "Should return false when certificate expires in 1 month (not expired)",
+		},
+		"expiring_soon_certificate_1_year": {
+			commonName:     "expiring-soon-cert-1year",
+			hoursFromNow:   8760, // 1 year from now (365 days)
+			expectedResult: false,
+			description:    "Should return false when certificate expires in 1 year (not expired)",
+		},
+		"expired_certificate_very_old": {
+			commonName:     "expired-cert-very-old",
+			hoursFromNow:   -87600, // 10 years ago
+			expectedResult: true,
+			description:    "Should return true when certificate expired 10 years ago",
+		},
+		"valid_certificate_very_future": {
+			commonName:     "valid-cert-very-future",
+			hoursFromNow:   87600, // 10 years from now
+			expectedResult: false,
+			description:    "Should return false when certificate expires in 10 years (not expired)",
+		},
+		"expired_certificate_fractional_seconds": {
+			commonName:     "expired-cert-fractional",
+			hoursFromNow:   -0.5 / 3600, // 0.5 seconds ago
+			expectedResult: true,
+			description:    "Should return true when certificate expired 0.5 seconds ago",
+		},
+		"expiring_soon_certificate_fractional_seconds": {
+			commonName:     "expiring-soon-cert-fractional",
+			hoursFromNow:   0.5 / 3600, // 0.5 seconds from now
+			expectedResult: false,
+			description:    "Should return false when certificate expires in 0.5 seconds (not expired)",
+		},
+		"expired_certificate_5_seconds": {
+			commonName:     "expired-cert-5sec",
+			hoursFromNow:   -5.0 / 3600, // 5 seconds ago
+			expectedResult: true,
+			description:    "Should return true when certificate expired 5 seconds ago",
+		},
+		"expiring_soon_certificate_5_seconds": {
+			commonName:     "expiring-soon-cert-5sec",
+			hoursFromNow:   5.0 / 3600, // 5 seconds from now
+			expectedResult: false,
+			description:    "Should return false when certificate expires in 5 seconds (not expired)",
+		},
+		"expired_certificate_10_seconds": {
+			commonName:     "expired-cert-10sec",
+			hoursFromNow:   -10.0 / 3600, // 10 seconds ago
+			expectedResult: true,
+			description:    "Should return true when certificate expired 10 seconds ago",
+		},
+		"expiring_soon_certificate_10_seconds": {
+			commonName:     "expiring-soon-cert-10sec",
+			hoursFromNow:   10.0 / 3600, // 10 seconds from now
+			expectedResult: false,
+			description:    "Should return false when certificate expires in 10 seconds (not expired)",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Create certificate with the specified expiry time
+			expiryTime := time.Now().Add(time.Duration(tt.hoursFromNow * float64(time.Hour)))
+			certInfo := createTestCertInfo(t, tt.commonName, expiryTime)
+
+			// Test the method
+			result := batcher.isCertificateExpired(certInfo)
+			assert.Equal(t, tt.expectedResult, result, tt.description)
+
+			// Verify UntilExpiry calculation
+			if tt.expectedResult {
+				assert.True(t, certInfo.UntilExpiry <= 0, "UntilExpiry should be <= 0 for expired cert")
+			} else {
+				assert.True(t, certInfo.UntilExpiry > 0, "UntilExpiry should be positive for valid cert")
+			}
+		})
+	}
+}
+
+func TestCertificateExpiryCheckBatcher_isCertificateExpiringSoon(t *testing.T) {
+	tests := map[string]struct {
+		commonName           string
+		hoursFromNow         float64
+		warningThresholdDays int
+		expectedResult       bool
+		description          string
+	}{
+		"expired_certificate": {
+			commonName:           "expired-cert",
+			hoursFromNow:         -10, // 10 hours ago
+			warningThresholdDays: 30,
+			expectedResult:       false,
+			description:          "Should return false when certificate is already expired",
+		},
+		"expired_certificate_30_minutes": {
+			commonName:           "expired-cert-30min",
+			hoursFromNow:         -1, // 1 hour ago (to ensure negative UntilExpiry)
+			warningThresholdDays: 30,
+			expectedResult:       false,
+			description:          "Should return false when certificate expired 1 hour ago",
+		},
+		"just_expired_certificate": {
+			commonName:           "just-expired-cert",
+			hoursFromNow:         -0.1, // Just expired (6 minutes ago)
+			warningThresholdDays: 30,
+			expectedResult:       false,
+			description:          "Should return false when certificate is just expired (negative time until expiry)",
+		},
+		"expiring_soon_certificate_30_minutes": {
+			commonName:           "expiring-soon-cert-30min",
+			hoursFromNow:         0.5, // 30 minutes from now
+			warningThresholdDays: 30,
+			expectedResult:       true,
+			description:          "Should return true when certificate expires in 30 minutes (truncated to 0, within threshold)",
+		},
+		"expiring_soon_certificate_1_day": {
+			commonName:           "expiring-soon-cert-1day",
+			hoursFromNow:         24, // 1 day from now
+			warningThresholdDays: 30,
+			expectedResult:       true,
+			description:          "Should return true when certificate expires in 1 day (within 30-day threshold)",
+		},
+		"expiring_soon_certificate_15_days": {
+			commonName:           "expiring-soon-cert-15days",
+			hoursFromNow:         15 * 24, // 15 days from now
+			warningThresholdDays: 30,
+			expectedResult:       true,
+			description:          "Should return true when certificate expires in 15 days (within 30-day threshold)",
+		},
+		"expiring_soon_certificate_30_days": {
+			commonName:           "expiring-soon-cert-30days",
+			hoursFromNow:         30 * 24, // 30 days from now
+			warningThresholdDays: 30,
+			expectedResult:       true,
+			description:          "Should return true when certificate expires in exactly 30 days (at threshold)",
+		},
+		"expiring_soon_certificate_30_days_1_hour": {
+			commonName:           "expiring-soon-cert-30days-1hour",
+			hoursFromNow:         30*24 + 1, // 30 days and 1 hour from now
+			warningThresholdDays: 30,
+			expectedResult:       false,
+			description:          "Should return false when certificate expires in 30 days and 1 hour (just over 30-day threshold)",
+		},
+		"expiring_soon_certificate_30_days_2_hours": {
+			commonName:           "expiring-soon-cert-30days-2hours",
+			hoursFromNow:         30*24 + 2, // 30 days and 2 hours from now
+			warningThresholdDays: 30,
+			expectedResult:       false,
+			description:          "Should return false when certificate expires in 30 days and 2 hours (just over 30-day threshold)",
+		},
+		"valid_certificate_60_days": {
+			commonName:           "valid-cert-60days",
+			hoursFromNow:         60 * 24, // 60 days from now
+			warningThresholdDays: 30,
+			expectedResult:       false,
+			description:          "Should return false when certificate expires in 60 days (well beyond threshold)",
+		},
+		"custom_threshold_1_day": {
+			commonName:           "custom-threshold-1day",
+			hoursFromNow:         12, // 12 hours from now
+			warningThresholdDays: 1,
+			expectedResult:       true,
+			description:          "Should return true when certificate expires in 12 hours with 1-day threshold",
+		},
+		"custom_threshold_1_day_over": {
+			commonName:           "custom-threshold-1day-over",
+			hoursFromNow:         25, // 25 hours from now
+			warningThresholdDays: 1,
+			expectedResult:       false,
+			description:          "Should return false when certificate expires in 25 hours with 1-day threshold (just over 1-day threshold)",
+		},
+		"custom_threshold_1_day_2_hours_over": {
+			commonName:           "custom-threshold-1day-2hours-over",
+			hoursFromNow:         26, // 26 hours from now
+			warningThresholdDays: 1,
+			expectedResult:       false,
+			description:          "Should return false when certificate expires in 26 hours with 1-day threshold (just over 1-day threshold)",
+		},
+		"zero_threshold_defaults_to_30_days": {
+			commonName:           "zero-threshold-default",
+			hoursFromNow:         15 * 24, // 15 days from now
+			warningThresholdDays: 0,       // Should default to 30 days
+			expectedResult:       true,
+			description:          "Should return true when certificate expires in 15 days with 0 threshold (defaults to 30 days)",
+		},
+		"minute_precision_30_minutes": {
+			commonName:           "minute-precision-30min",
+			hoursFromNow:         0.5, // 30 minutes from now
+			warningThresholdDays: 1,   // 1 day threshold
+			expectedResult:       true,
+			description:          "Should return true when certificate expires in 30 minutes with 1-day threshold (minute precision)",
+		},
+		"minute_precision_1_hour_1_minute": {
+			commonName:           "minute-precision-1hour-1min",
+			hoursFromNow:         1 + 1.0/60, // 1 hour and 1 minute from now
+			warningThresholdDays: 1,          // 1 day threshold
+			expectedResult:       true,
+			description:          "Should return true when certificate expires in 1 hour 1 minute with 1-day threshold (minute precision)",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Create batcher with custom warning threshold
+			batcher := &CertificateExpiryCheckBatcher{
+				config: config.CertificateExpiryMonitorConfig{
+					WarningThresholdDays: tt.warningThresholdDays,
+				},
+			}
+
+			// Create certificate with the specified expiry time
+			expiryTime := time.Now().Add(time.Duration(tt.hoursFromNow * float64(time.Hour)))
+			certInfo := createTestCertInfo(t, tt.commonName, expiryTime)
+
+			// Test the method
+			result := batcher.isCertificateExpiringSoon(certInfo)
+			assert.Equal(t, tt.expectedResult, result, tt.description)
+
+			// Verify time calculation with duration precision
+			untilExpiry := certInfo.UntilExpiry
+			actualThreshold := tt.warningThresholdDays
+			if actualThreshold == 0 {
+				actualThreshold = 30 // Default value
+			}
+			warningThresholdDuration := time.Duration(actualThreshold) * 24 * time.Hour // Convert days to duration
+
+			if tt.expectedResult {
+				assert.True(t, untilExpiry > 0, "Until expiry should be positive for expiring soon cert")
+				assert.True(t, untilExpiry <= warningThresholdDuration, "Until expiry should be within warning threshold")
+			} else {
+				// For false cases, either expired or beyond threshold
+				if untilExpiry <= 0 {
+					assert.True(t, untilExpiry <= 0, "Until expiry should be <= 0 for expired cert")
+				} else {
+					assert.True(t, untilExpiry > warningThresholdDuration, "Until expiry should be beyond warning threshold")
+				}
+			}
+		})
+	}
+}
+
+func TestCertInfo_HoursUntilExpiry(t *testing.T) {
+	tests := map[string]struct {
+		secondsUntilExpiry int
+		expectedHours      int
+		description        string
+	}{
+		"positive_hours": {
+			secondsUntilExpiry: 7200, // 2 hours
+			expectedHours:      2,
+			description:        "Should return 2 hours for 7200 seconds",
+		},
+		"fractional_hours_truncated": {
+			secondsUntilExpiry: 5400, // 1.5 hours
+			expectedHours:      1,
+			description:        "Should return 1 hour for 5400 seconds (truncated)",
+		},
+		"zero_seconds": {
+			secondsUntilExpiry: 0,
+			expectedHours:      0,
+			description:        "Should return 0 hours for 0 seconds",
+		},
+		"negative_seconds": {
+			secondsUntilExpiry: -3600, // -1 hour
+			expectedHours:      -1,
+			description:        "Should return -1 hour for -3600 seconds",
+		},
+		"large_positive": {
+			secondsUntilExpiry: 86400, // 24 hours
+			expectedHours:      24,
+			description:        "Should return 24 hours for 86400 seconds",
+		},
+		"large_negative": {
+			secondsUntilExpiry: -86400, // -24 hours
+			expectedHours:      -24,
+			description:        "Should return -24 hours for -86400 seconds",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			certInfo := CertInfo{
+				ID:          "test-cert",
+				CommonName:  "test.example.com",
+				NotAfter:    time.Now().Add(time.Duration(tt.secondsUntilExpiry) * time.Second),
+				UntilExpiry: time.Duration(tt.secondsUntilExpiry) * time.Second,
+			}
+
+			result := certInfo.HoursUntilExpiry()
+			assert.Equal(t, tt.expectedHours, result, tt.description)
+		})
+	}
+}
+
+func TestCertInfo_MinutesUntilExpiry(t *testing.T) {
+	tests := map[string]struct {
+		secondsUntilExpiry int
+		expectedMinutes    int
+		description        string
+	}{
+		"positive_minutes": {
+			secondsUntilExpiry: 120, // 2 minutes
+			expectedMinutes:    2,
+			description:        "Should return 2 minutes for 120 seconds",
+		},
+		"fractional_minutes_truncated": {
+			secondsUntilExpiry: 90, // 1.5 minutes
+			expectedMinutes:    1,
+			description:        "Should return 1 minute for 90 seconds (truncated)",
+		},
+		"zero_seconds": {
+			secondsUntilExpiry: 0,
+			expectedMinutes:    0,
+			description:        "Should return 0 minutes for 0 seconds",
+		},
+		"negative_seconds": {
+			secondsUntilExpiry: -60, // -1 minute
+			expectedMinutes:    -1,
+			description:        "Should return -1 minute for -60 seconds",
+		},
+		"large_positive": {
+			secondsUntilExpiry: 3600, // 60 minutes (1 hour)
+			expectedMinutes:    60,
+			description:        "Should return 60 minutes for 3600 seconds",
+		},
+		"large_negative": {
+			secondsUntilExpiry: -3600, // -60 minutes (-1 hour)
+			expectedMinutes:    -60,
+			description:        "Should return -60 minutes for -3600 seconds",
+		},
+		"exactly_one_minute": {
+			secondsUntilExpiry: 60, // 1 minute
+			expectedMinutes:    1,
+			description:        "Should return 1 minute for exactly 60 seconds",
+		},
+		"thirty_seconds": {
+			secondsUntilExpiry: 30, // 0.5 minutes
+			expectedMinutes:    0,
+			description:        "Should return 0 minutes for 30 seconds (truncated)",
+		},
+		"one_hour_thirty_minutes": {
+			secondsUntilExpiry: 5400, // 90 minutes (1.5 hours)
+			expectedMinutes:    90,
+			description:        "Should return 90 minutes for 5400 seconds",
+		},
+		"one_second": {
+			secondsUntilExpiry: 1, // 1 second
+			expectedMinutes:    0,
+			description:        "Should return 0 minutes for 1 second (truncated)",
+		},
+		"fifty_nine_seconds": {
+			secondsUntilExpiry: 59, // 59 seconds
+			expectedMinutes:    0,
+			description:        "Should return 0 minutes for 59 seconds (truncated)",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			certInfo := CertInfo{
+				ID:          "test-cert",
+				CommonName:  "test.example.com",
+				NotAfter:    time.Now().Add(time.Duration(tt.secondsUntilExpiry) * time.Second),
+				UntilExpiry: time.Duration(tt.secondsUntilExpiry) * time.Second,
+			}
+
+			result := certInfo.MinutesUntilExpiry()
+			assert.Equal(t, tt.expectedMinutes, result, tt.description)
+		})
+	}
+}
+
+func TestCertInfo_SecondsUntilExpiry(t *testing.T) {
+	tests := map[string]struct {
+		secondsUntilExpiry int
+		expectedSeconds    int
+		description        string
+	}{
+		"positive_seconds": {
+			secondsUntilExpiry: 120, // 2 minutes
+			expectedSeconds:    120,
+			description:        "Should return 120 seconds for 120 seconds",
+		},
+		"zero_seconds": {
+			secondsUntilExpiry: 0,
+			expectedSeconds:    0,
+			description:        "Should return 0 seconds for 0 seconds",
+		},
+		"negative_seconds": {
+			secondsUntilExpiry: -60, // -1 minute
+			expectedSeconds:    -60,
+			description:        "Should return -60 seconds for -60 seconds",
+		},
+		"large_positive": {
+			secondsUntilExpiry: 3600, // 1 hour
+			expectedSeconds:    3600,
+			description:        "Should return 3600 seconds for 3600 seconds",
+		},
+		"large_negative": {
+			secondsUntilExpiry: -3600, // -1 hour
+			expectedSeconds:    -3600,
+			description:        "Should return -3600 seconds for -3600 seconds",
+		},
+		"fractional_seconds_truncated": {
+			secondsUntilExpiry: 90, // 1.5 minutes
+			expectedSeconds:    90,
+			description:        "Should return 90 seconds for 90 seconds (no truncation for seconds)",
+		},
+		"one_second": {
+			secondsUntilExpiry: 1,
+			expectedSeconds:    1,
+			description:        "Should return 1 second for 1 second",
+		},
+		"fifty_nine_seconds": {
+			secondsUntilExpiry: 59,
+			expectedSeconds:    59,
+			description:        "Should return 59 seconds for 59 seconds",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			certInfo := CertInfo{
+				ID:          "test-cert",
+				CommonName:  "test.example.com",
+				NotAfter:    time.Now().Add(time.Duration(tt.secondsUntilExpiry) * time.Second),
+				UntilExpiry: time.Duration(tt.secondsUntilExpiry) * time.Second,
+			}
+
+			result := certInfo.SecondsUntilExpiry()
+			assert.Equal(t, tt.expectedSeconds, result, tt.description)
+		})
+	}
 }
 
 func createBatcherMocks(t *testing.T) (ctrl *gomock.Controller, batcherMocks *BatcherMocks) {

--- a/internal/certcheck/model.go
+++ b/internal/certcheck/model.go
@@ -42,6 +42,12 @@ func (c CertInfo) SecondsUntilExpiry() int {
 	return int(c.UntilExpiry.Seconds())
 }
 
+// DaysUntilExpiry returns the number of days until the certificate expires.
+// This is calculated from the UntilExpiry field for convenience.
+func (c CertInfo) DaysUntilExpiry() int {
+	return c.HoursUntilExpiry() / 24
+}
+
 // EventCertificateExpiringSoonMeta is the metadata structure for certificate expiration events.
 type EventCertificateExpiringSoonMeta struct {
 	model.EventMetaDefault

--- a/internal/certcheck/model.go
+++ b/internal/certcheck/model.go
@@ -18,10 +18,28 @@ type APIMetaData struct {
 
 // CertInfo is a structure that holds information about a certificate.
 type CertInfo struct {
-	ID               string
-	CommonName       string
-	NotAfter         time.Time
-	HoursUntilExpiry int
+	ID          string
+	CommonName  string
+	NotAfter    time.Time
+	UntilExpiry time.Duration
+}
+
+// HoursUntilExpiry returns the number of hours until the certificate expires.
+// This is calculated from the UntilExpiry field for convenience.
+func (c CertInfo) HoursUntilExpiry() int {
+	return int(c.UntilExpiry.Hours())
+}
+
+// MinutesUntilExpiry returns the number of minutes until the certificate expires.
+// This is calculated from the UntilExpiry field for convenience.
+func (c CertInfo) MinutesUntilExpiry() int {
+	return int(c.UntilExpiry.Minutes())
+}
+
+// SecondsUntilExpiry returns the number of seconds until the certificate expires.
+// This is calculated from the UntilExpiry field for convenience.
+func (c CertInfo) SecondsUntilExpiry() int {
+	return int(c.UntilExpiry.Seconds())
 }
 
 // EventCertificateExpiringSoonMeta is the metadata structure for certificate expiration events.


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-15742" title="TT-15742" target="_blank">TT-15742</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Expired certificate events not delivered</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description
This change fixes an issue where certificates that expired less than one hour ago were not marked as expired, which prevented CertificateExpired events from firing. The problem was caused by expiry detection relying on truncated integer hours, where only values strictly less than zero were considered expired. To resolve this, isCertificateExpired has been refactored to return true when UntilExpiry <= 0, ensuring certificates are treated as expired immediately after their NotAfter time. As part of this fix, the old HoursUntilExpiry field has been replaced with a duration-based UntilExpiry field in CertInfo, and the batcher logic, logs, and event metadata have been updated accordingly. Tests were also extended to cover sub-hour expiry scenarios, confirming that CertificateExpired events now fire reliably the moment a certificate has passed its expiration.
<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->
https://tyktech.atlassian.net/browse/TT-15742

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Fix expiry detection using duration

- Replace hours with duration in model

- Update logs and event metadata helpers

- Add comprehensive duration-based tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  MW["Middleware extracts CertInfo with duration"]
  Model["CertInfo uses UntilExpiry + helpers"]
  Batcher["Batcher checks expiry/soon with duration"]
  Tests["New tests cover sub-hour cases"]
  MW -- "populate UntilExpiry" --> Model
  Model -- "provide Hours/Minutes/Days helpers" --> Batcher
  Batcher -- "emit correct events/logs" --> Tests
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mw_certificate_check.go</strong><dd><code>Middleware now fills duration-based expiry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_certificate_check.go

<ul><li>Populate <code>CertInfo.UntilExpiry</code> from <code>time.Until</code><br> <li> Remove <code>HoursUntilExpiry</code> integer field usage</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7356/files#diff-98880123ee64214093f5dc48068d80906227411e1ccf584dc31aa75efcc4784a">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>model.go</strong><dd><code>CertInfo switches to duration with helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/certcheck/model.go

<ul><li>Replace <code>HoursUntilExpiry</code> with <code>UntilExpiry</code><br> <li> Add Hours/Minutes/Seconds/Days helper methods<br> <li> Update <code>CertInfo</code> structure accordingly</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7356/files#diff-d5ce39f2a3a3c26aee15751ac2d31e6eb98da274fad951dbb68a54282f78a226">+28/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>batcher.go</strong><dd><code>Batcher uses duration for expiry logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/certcheck/batcher.go

<ul><li>Use <code>UntilExpiry <= 0</code> for expired check<br> <li> Use duration threshold for expiring soon<br> <li> Switch logs/computations to helper methods<br> <li> Compute days/hours via new <code>CertInfo</code> helpers</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7356/files#diff-70d967648d3a4c204df7ea2dd127adc9968c6f7f0784ceb109497e826e2a244a">+11/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>batcher_test.go</strong><dd><code>Add comprehensive duration-based expiry tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/certcheck/batcher_test.go

<ul><li>Add real cert generation for tests<br> <li> Cover sub-hour and boundary expiry cases<br> <li> Test duration-based helper methods<br> <li> Update existing tests to <code>UntilExpiry</code></ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7356/files#diff-0c0c8cc1102f4dc49d63e417a5aa26c85fe4f94fe8c335149f8768ee5b8c9810">+743/-16</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

