### PR TITLE
[TT-15747] OAS versioning identifier key is conditionally required based on the location

### DIFF
--- a/apidef/oas/root.go
+++ b/apidef/oas/root.go
@@ -165,7 +165,7 @@ type Versioning struct {
 	// - `url`.
 	Location string `bson:"location" json:"location"` // required
 	// Key contains the name of the key to check for versioning information.
-	Key string `bson:"key" json:"key"` // required
+	Key string `bson:"key" json:"key,omitempty"` // required conditionally
 	// Versions contains a list of versions that map to individual API IDs.
 	Versions []VersionToID `bson:"versions" json:"versions"` // required
 	// StripVersioningData is a boolean flag, if set to `true`, the API responses will be stripped of versioning data.

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -1454,8 +1454,20 @@
         }
       },
       "required": [
-        "location",
-        "key"
+        "location"
+      ],
+      "anyOf": [
+        {
+          "properties": {
+            "location": { "enum": ["header", "url-param"] }
+          },
+          "required": ["key"]
+        },
+        {
+          "properties": {
+            "location": { "enum": ["url"] }
+          }
+        }
       ]
     },
     "X-Tyk-VersionToID": {


### PR DESCRIPTION
TT-15747

Updated OAS versioning validation to make the key field conditionally required based on the versioning location strategy.

**Changes**

Modified validation logic: key field is now required only for header/url-param locations, optional for url location
Updated JSON schema: Added anyOf constraints for conditional validation
Enhanced test coverage: Added comprehensive validation tests for different location scenarios

**Technical Details**

Changed Key field to use json:"key,omitempty" tag in [root.go](vscode-webview://0nck40lrte3n58jfbdflgrjnr7ed8unr00dnmuedrafion5ear6v/apidef/oas/root.go:168)
Updated JSON schema with conditional requirements in [x-tyk-api-gateway.json](vscode-webview://0nck40lrte3n58jfbdflgrjnr7ed8unr00dnmuedrafion5ear6v/apidef/oas/schema/x-tyk-api-gateway.json:1454)
Added TestVersioningSchemaValidation with test cases for valid/invalid configurations