### PR TITLE
Add security_requirements schema to support OpenAPI security configurations

### DIFF
--- a/apidef/oas/default.go
+++ b/apidef/oas/default.go
@@ -133,10 +133,15 @@ func (s *OAS) BuildDefaultTykExtension(overRideValues TykExtensionConfigParams, 
 		xTykAPIGateway.Upstream.URL = upstreamURL
 	}
 
-	if overRideValues.Authentication != nil {
+	if overRideValues.Authentication != nil && *overRideValues.Authentication {
 		err := s.importAuthentication(*overRideValues.Authentication)
 		if err != nil {
 			return err
+		}
+	} else {
+		s.Security = nil
+		if s.Components != nil {
+			s.Components.SecuritySchemes = nil
 		}
 	}
 

--- a/apidef/oas/default.go
+++ b/apidef/oas/default.go
@@ -139,11 +139,11 @@ func (s *OAS) BuildDefaultTykExtension(overRideValues TykExtensionConfigParams, 
 			return err
 		}
 	}
-	
+
 	if overRideValues.SecurityProcessingMode != "" {
 		authExists := xTykAPIGateway.Server.Authentication != nil
 		authEnabled := overRideValues.Authentication != nil && *overRideValues.Authentication
-		
+
 		if authEnabled || (!isImport && authExists) || (isImport && authExists) {
 			if xTykAPIGateway.Server.Authentication == nil {
 				xTykAPIGateway.Server.Authentication = &Authentication{}

--- a/apidef/oas/default.go
+++ b/apidef/oas/default.go
@@ -138,19 +138,18 @@ func (s *OAS) BuildDefaultTykExtension(overRideValues TykExtensionConfigParams, 
 		if err != nil {
 			return err
 		}
-	} else {
-		s.Security = nil
-		if s.Components != nil {
-			s.Components.SecuritySchemes = nil
-		}
 	}
-
-	// Set SecurityProcessingMode if provided
+	
 	if overRideValues.SecurityProcessingMode != "" {
-		if xTykAPIGateway.Server.Authentication == nil {
-			xTykAPIGateway.Server.Authentication = &Authentication{}
+		authExists := xTykAPIGateway.Server.Authentication != nil
+		authEnabled := overRideValues.Authentication != nil && *overRideValues.Authentication
+		
+		if authEnabled || (!isImport && authExists) || (isImport && authExists) {
+			if xTykAPIGateway.Server.Authentication == nil {
+				xTykAPIGateway.Server.Authentication = &Authentication{}
+			}
+			xTykAPIGateway.Server.Authentication.SecurityProcessingMode = overRideValues.SecurityProcessingMode
 		}
-		xTykAPIGateway.Server.Authentication.SecurityProcessingMode = overRideValues.SecurityProcessingMode
 	}
 
 	s.ImportMiddlewares(overRideValues)

--- a/apidef/oas/security.go
+++ b/apidef/oas/security.go
@@ -1004,7 +1004,8 @@ func isProprietaryAuth(authMethod string) bool {
 func (s *OAS) fillSecurity(api apidef.APIDefinition) {
 	tykAuthentication := s.GetTykExtension().Server.Authentication
 
-	if tykAuthentication == nil && api.UseKeylessAccess {
+	if tykAuthentication == nil && api.UseKeylessAccess && 
+		len(api.AuthConfigs) == 0 && len(api.SecurityRequirements) == 0 {
 		if s.T.Components == nil {
 			s.T.Components = &openapi3.Components{}
 		}

--- a/apidef/oas/security.go
+++ b/apidef/oas/security.go
@@ -1004,7 +1004,7 @@ func isProprietaryAuth(authMethod string) bool {
 func (s *OAS) fillSecurity(api apidef.APIDefinition) {
 	tykAuthentication := s.GetTykExtension().Server.Authentication
 
-	if tykAuthentication == nil && api.UseKeylessAccess && 
+	if tykAuthentication == nil && api.UseKeylessAccess &&
 		len(api.AuthConfigs) == 0 && len(api.SecurityRequirements) == 0 {
 		if s.T.Components == nil {
 			s.T.Components = &openapi3.Components{}

--- a/apidef/oas/security.go
+++ b/apidef/oas/security.go
@@ -1138,7 +1138,7 @@ func (s *OAS) extractSecurityTo(api *apidef.APIDefinition) {
 	if s.getTykAuthentication() != nil && s.getTykAuthentication().SecurityProcessingMode != "" {
 		processingMode = s.getTykAuthentication().SecurityProcessingMode
 	}
-	
+
 	if !wasNil {
 		if processingMode == SecurityProcessingModeCompliant {
 			api.SecurityRequirements = make([][]string, 0)

--- a/apidef/oas/security_test.go
+++ b/apidef/oas/security_test.go
@@ -1652,3 +1652,56 @@ func TestOAS_fillSecurity_KeylessAPIConditionalAuth(t *testing.T) {
 		assert.NotNil(t, oas.GetTykExtension().Server.Authentication)
 	})
 }
+
+func TestOAS_FillSecurityKeylessAPI(t *testing.T) {
+	t.Run("keyless API without auth configs should not create authentication", func(t *testing.T) {
+		api := apidef.APIDefinition{
+			UseKeylessAccess:     true,
+			AuthConfigs:          map[string]apidef.AuthConfig{},
+			SecurityRequirements: [][]string{},
+		}
+
+		oas := OAS{}
+		oas.SetTykExtension(&XTykAPIGateway{})
+
+		oas.fillSecurity(api)
+		tykExt := oas.GetTykExtension()
+		assert.Nil(t, tykExt.Server.Authentication,
+			"fillSecurity should not create authentication for keyless API without auth configs")
+	})
+
+	t.Run("keyless API with auth configs should create authentication", func(t *testing.T) {
+		api := apidef.APIDefinition{
+			UseKeylessAccess: true,
+			AuthConfigs: map[string]apidef.AuthConfig{
+				"test": {Name: "test"},
+			},
+			SecurityRequirements: [][]string{},
+		}
+
+		oas := OAS{}
+		oas.SetTykExtension(&XTykAPIGateway{})
+
+		oas.fillSecurity(api)
+		tykExt := oas.GetTykExtension()
+		assert.NotNil(t, tykExt.Server.Authentication,
+			"fillSecurity should create authentication for keyless API with auth configs")
+	})
+
+	t.Run("non-keyless API should create authentication", func(t *testing.T) {
+		api := apidef.APIDefinition{
+			UseKeylessAccess:     false,
+			UseBasicAuth:         true,
+			AuthConfigs:          map[string]apidef.AuthConfig{},
+			SecurityRequirements: [][]string{},
+		}
+
+		oas := OAS{}
+		oas.SetTykExtension(&XTykAPIGateway{})
+
+		oas.fillSecurity(api)
+		tykExt := oas.GetTykExtension()
+		assert.NotNil(t, tykExt.Server.Authentication,
+			"fillSecurity should create authentication for non-keyless API")
+	})
+}

--- a/apidef/schema.json
+++ b/apidef/schema.json
@@ -1137,6 +1137,18 @@
           }
         }
       }
+    },
+    "security_requirements": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
     }
   },
   "required": [


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add `security_requirements` to schema

- Support OpenAPI-style security arrays

- Allow null or array types

- Define string arrays per requirement


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Schema["schema.json"]
  SecReq["security_requirements property"]
  TypeDef["type: array|null"]
  Items["items: array of strings"]

  Schema -- "adds" --> SecReq
  SecReq -- "uses" --> TypeDef
  SecReq -- "defines" --> Items
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schema.json</strong><dd><code>Introduce `security_requirements` schema property</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/schema.json

<ul><li>Add <code>security_requirements</code> top-level property<br> <li> Support <code>array</code> or <code>null</code> types<br> <li> Define items as arrays of strings<br> <li> Align with OpenAPI security requirement structure</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7359/files#diff-32c8b876e77d1639afb2d20c37b74ed9e149b72cc7de429def13d3d454e075f3">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

