### PR TITLE
Merging to release-5.10.0: [TT-15852] fix days as integer for expiry events (#7371)

### DIFF
--- a/templates/default_webhook.json
+++ b/templates/default_webhook.json
@@ -61,7 +61,7 @@
   "cert_id": "{{.Meta.CertID}}",
   "cert_name": "{{.Meta.CertName}}",
   "expires_at": "{{.Meta.ExpiresAt}}",
-  "days_remaining": "{{.Meta.DaysRemaining}}",
+  "days_remaining": {{.Meta.DaysRemaining}},
   "api_id": "{{.Meta.APIID}}",
   "timestamp": "{{.TimeStamp}}"
 }
@@ -72,7 +72,7 @@
   "cert_id": "{{.Meta.CertID}}",
   "cert_name": "{{.Meta.CertName}}",
   "expired_at": "{{.Meta.ExpiredAt}}",
-  "days_since_expiry": "{{.Meta.DaysSinceExpiry}}",
+  "days_since_expiry": {{.Meta.DaysSinceExpiry}},
   "api_id": "{{.Meta.APIID}}",
   "timestamp": "{{.TimeStamp}}"
 }


### PR DESCRIPTION
[TT-15852] fix days as integer for expiry events (#7371)

### **User description**
This PR fixes a small issue, where days until expiry / since expiry from
expiry events where marshalled as strings instead of integers.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix numeric fields in webhook template

- Add tests for certificate event payloads

- Ensure days fields serialized as integers


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Template["default_webhook.json"]
  Tests["event_handler_webhooks_test.go"]
  Events["Certificate events payload"]
  Template -- "render JSON with int days" --> Events
  Tests -- "assert int fields, payload shape" --> Events
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>event_handler_webhooks_test.go</strong><dd><code>Add
tests validating integer days in webhook payload</code>&nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/event_handler_webhooks_test.go

<ul><li>Add TestTemplates covering certificate events.<br> <li> Validate
JSON unmarshalling with integer day fields.<br> <li> Use require/assert
for init and payload checks.</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7371/files#diff-1a2f8d6ab4443031b0f8486809453f6389291a6f625745fe8c65ac5cdb0e9621">+108/-0</a>&nbsp;
</td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>default_webhook.json</strong><dd><code>Serialize
certificate days fields as integers</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/default_webhook.json

<ul><li>Output <code>days_remaining</code> as integer (no quotes).<br>
<li> Output <code>days_since_expiry</code> as integer (no quotes).</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7371/files#diff-0d9bf4709b7f8fbdba9b19f94583e3baff5ae95c016e9688dc3e151873ea257e">+2/-2</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___