### PR TITLE
[TT-15868] Fixing panic when using JWT as a second authentication method in compliant mode

### DIFF
--- a/apidef/oas/security_test.go
+++ b/apidef/oas/security_test.go
@@ -1591,3 +1591,365 @@ func TestCompliantModeSecuritySeparation(t *testing.T) {
 		assert.Equal(t, SecurityProcessingModeCompliant, auth.SecurityProcessingMode)
 	})
 }
+
+// TestGetJWTConfiguration_ORAuthentication tests GetJWTConfiguration with OR authentication scenarios
+// This test ensures that the JWT configuration is correctly retrieved based on the security processing mode
+// and prevents regression of the panic issue when JWT is not the first security requirement.
+func TestGetJWTConfiguration_ORAuthentication(t *testing.T) {
+	// Helper function to create test OAS with JWT as second security requirement
+	createTestOAS := func(processingMode string) *OAS {
+		oas := &OAS{}
+		oas.T = openapi3.T{
+			OpenAPI: "3.0.3",
+			Components: &openapi3.Components{
+				SecuritySchemes: openapi3.SecuritySchemes{
+					"apiKeyAuth": &openapi3.SecuritySchemeRef{
+						Value: &openapi3.SecurityScheme{
+							Type: "apiKey",
+							In:   "header",
+							Name: "X-API-Key",
+						},
+					},
+					"jwtAuth": &openapi3.SecuritySchemeRef{
+						Value: &openapi3.SecurityScheme{
+							Type:         typeHTTP,
+							Scheme:       schemeBearer,
+							BearerFormat: bearerFormatJWT,
+						},
+					},
+					"basicAuth": &openapi3.SecuritySchemeRef{
+						Value: &openapi3.SecurityScheme{
+							Type:   typeHTTP,
+							Scheme: "basic",
+						},
+					},
+				},
+			},
+			// IMPORTANT: JWT is second in the security requirements (API key is first)
+			Security: openapi3.SecurityRequirements{
+				openapi3.SecurityRequirement{"apiKeyAuth": []string{}},
+				openapi3.SecurityRequirement{"jwtAuth": []string{}},
+			},
+		}
+
+		// Set up Tyk extension with JWT configuration
+		tykExtension := &XTykAPIGateway{
+			Server: Server{
+				Authentication: &Authentication{
+					SecurityProcessingMode: processingMode,
+					SecuritySchemes: SecuritySchemes{
+						"apiKeyAuth": &Token{
+							Enabled: func() *bool { b := true; return &b }(),
+						},
+						"jwtAuth": &JWT{
+							Enabled:           true,
+							SigningMethod:     "hmac",
+							Source:            "YS1zdHJpbmctc2VjcmV0LWF0LWxlYXN0LTI1Ni1iaXRzLWxvbmc=",
+							IdentityBaseField: "sub",
+							PolicyFieldName:   "policy",
+							AllowedIssuers:    []string{"test-issuer"},
+							AllowedAudiences:  []string{"test-audience"},
+							JTIValidation: JTIValidation{
+								Enabled: false,
+							},
+						},
+					},
+				},
+			},
+		}
+		oas.SetTykExtension(tykExtension)
+		return oas
+	}
+
+	t.Run("Legacy mode - should NOT find JWT when it's not first", func(t *testing.T) {
+		oas := createTestOAS(SecurityProcessingModeLegacy)
+		
+		jwtConfig := oas.GetJWTConfiguration()
+		assert.Nil(t, jwtConfig, "In legacy mode, JWT should NOT be found when it's not the first security requirement")
+	})
+
+	t.Run("Compliant mode - should find JWT even when it's not first", func(t *testing.T) {
+		oas := createTestOAS(SecurityProcessingModeCompliant)
+		
+		jwtConfig := oas.GetJWTConfiguration()
+		assert.NotNil(t, jwtConfig, "In compliant mode, JWT should be found even when it's not the first security requirement")
+		assert.Equal(t, "hmac", jwtConfig.SigningMethod)
+		assert.Equal(t, "sub", jwtConfig.IdentityBaseField)
+		assert.Equal(t, "policy", jwtConfig.PolicyFieldName)
+		assert.Equal(t, []string{"test-issuer"}, jwtConfig.AllowedIssuers)
+		assert.Equal(t, []string{"test-audience"}, jwtConfig.AllowedAudiences)
+	})
+
+	t.Run("Default (empty) mode - should use legacy behavior", func(t *testing.T) {
+		oas := createTestOAS("")
+		
+		jwtConfig := oas.GetJWTConfiguration()
+		assert.Nil(t, jwtConfig, "With empty/default mode, should behave like legacy mode")
+	})
+
+	t.Run("Legacy mode - should find JWT when it's first", func(t *testing.T) {
+		oas := &OAS{}
+		oas.T = openapi3.T{
+			OpenAPI: "3.0.3",
+			Components: &openapi3.Components{
+				SecuritySchemes: openapi3.SecuritySchemes{
+					"jwtAuth": &openapi3.SecuritySchemeRef{
+						Value: &openapi3.SecurityScheme{
+							Type:         typeHTTP,
+							Scheme:       schemeBearer,
+							BearerFormat: bearerFormatJWT,
+						},
+					},
+					"apiKeyAuth": &openapi3.SecuritySchemeRef{
+						Value: &openapi3.SecurityScheme{
+							Type: "apiKey",
+							In:   "header",
+							Name: "X-API-Key",
+						},
+					},
+				},
+			},
+			// JWT is first this time
+			Security: openapi3.SecurityRequirements{
+				openapi3.SecurityRequirement{"jwtAuth": []string{}},
+				openapi3.SecurityRequirement{"apiKeyAuth": []string{}},
+			},
+		}
+
+		tykExtension := &XTykAPIGateway{
+			Server: Server{
+				Authentication: &Authentication{
+					SecurityProcessingMode: SecurityProcessingModeLegacy,
+					SecuritySchemes: SecuritySchemes{
+						"jwtAuth": &JWT{
+							Enabled:       true,
+							SigningMethod: "rsa",
+							Source:        "cHVibGljLWtleQ==",
+						},
+					},
+				},
+			},
+		}
+		oas.SetTykExtension(tykExtension)
+		
+		jwtConfig := oas.GetJWTConfiguration()
+		assert.NotNil(t, jwtConfig, "Legacy mode should find JWT when it's the first security requirement")
+		assert.Equal(t, "rsa", jwtConfig.SigningMethod)
+	})
+
+	t.Run("Compliant mode - JWT as third requirement", func(t *testing.T) {
+		oas := &OAS{}
+		oas.T = openapi3.T{
+			OpenAPI: "3.0.3",
+			Components: &openapi3.Components{
+				SecuritySchemes: openapi3.SecuritySchemes{
+					"basicAuth": &openapi3.SecuritySchemeRef{
+						Value: &openapi3.SecurityScheme{
+							Type:   typeHTTP,
+							Scheme: "basic",
+						},
+					},
+					"apiKeyAuth": &openapi3.SecuritySchemeRef{
+						Value: &openapi3.SecurityScheme{
+							Type: "apiKey",
+							In:   "header",
+							Name: "X-API-Key",
+						},
+					},
+					"jwtAuth": &openapi3.SecuritySchemeRef{
+						Value: &openapi3.SecurityScheme{
+							Type:         typeHTTP,
+							Scheme:       schemeBearer,
+							BearerFormat: bearerFormatJWT,
+						},
+					},
+				},
+			},
+			// JWT is third in the list
+			Security: openapi3.SecurityRequirements{
+				openapi3.SecurityRequirement{"basicAuth": []string{}},
+				openapi3.SecurityRequirement{"apiKeyAuth": []string{}},
+				openapi3.SecurityRequirement{"jwtAuth": []string{}},
+			},
+		}
+
+		tykExtension := &XTykAPIGateway{
+			Server: Server{
+				Authentication: &Authentication{
+					SecurityProcessingMode: SecurityProcessingModeCompliant,
+					SecuritySchemes: SecuritySchemes{
+						"jwtAuth": &JWT{
+							Enabled:       true,
+							SigningMethod: "ecdsa",
+							Source:        "ZWNkc2Eta2V5",
+						},
+					},
+				},
+			},
+		}
+		oas.SetTykExtension(tykExtension)
+		
+		jwtConfig := oas.GetJWTConfiguration()
+		assert.NotNil(t, jwtConfig, "Compliant mode should find JWT regardless of its position")
+		assert.Equal(t, "ecdsa", jwtConfig.SigningMethod)
+	})
+
+	t.Run("No JWT in security requirements - both modes return nil", func(t *testing.T) {
+		for _, mode := range []string{SecurityProcessingModeLegacy, SecurityProcessingModeCompliant} {
+			t.Run(mode, func(t *testing.T) {
+				oas := &OAS{}
+				oas.T = openapi3.T{
+					OpenAPI: "3.0.3",
+					Components: &openapi3.Components{
+						SecuritySchemes: openapi3.SecuritySchemes{
+							"apiKeyAuth": &openapi3.SecuritySchemeRef{
+								Value: &openapi3.SecurityScheme{
+									Type: "apiKey",
+									In:   "header",
+									Name: "X-API-Key",
+								},
+							},
+							"basicAuth": &openapi3.SecuritySchemeRef{
+								Value: &openapi3.SecurityScheme{
+									Type:   typeHTTP,
+									Scheme: "basic",
+								},
+							},
+						},
+					},
+					Security: openapi3.SecurityRequirements{
+						openapi3.SecurityRequirement{"apiKeyAuth": []string{}},
+						openapi3.SecurityRequirement{"basicAuth": []string{}},
+					},
+				}
+
+				tykExtension := &XTykAPIGateway{
+					Server: Server{
+						Authentication: &Authentication{
+							SecurityProcessingMode: mode,
+							SecuritySchemes: SecuritySchemes{
+								"apiKeyAuth": &Token{
+									Enabled: func() *bool { b := true; return &b }(),
+								},
+							},
+						},
+					},
+				}
+				oas.SetTykExtension(tykExtension)
+				
+				jwtConfig := oas.GetJWTConfiguration()
+				assert.Nil(t, jwtConfig, "Should return nil when no JWT security scheme exists")
+			})
+		}
+	})
+
+	t.Run("JWT with wrong type - both modes return nil", func(t *testing.T) {
+		oas := &OAS{}
+		oas.T = openapi3.T{
+			OpenAPI: "3.0.3",
+			Components: &openapi3.Components{
+				SecuritySchemes: openapi3.SecuritySchemes{
+					"wrongJWT": &openapi3.SecuritySchemeRef{
+						Value: &openapi3.SecurityScheme{
+							Type:   typeHTTP,
+							Scheme: "bearer", // Missing BearerFormat: "JWT"
+						},
+					},
+				},
+			},
+			Security: openapi3.SecurityRequirements{
+				openapi3.SecurityRequirement{"wrongJWT": []string{}},
+			},
+		}
+
+		tykExtension := &XTykAPIGateway{
+			Server: Server{
+				Authentication: &Authentication{
+					SecurityProcessingMode: SecurityProcessingModeCompliant,
+					SecuritySchemes: SecuritySchemes{
+						"wrongJWT": &JWT{
+							Enabled: true,
+						},
+					},
+				},
+			},
+		}
+		oas.SetTykExtension(tykExtension)
+		
+		jwtConfig := oas.GetJWTConfiguration()
+		assert.Nil(t, jwtConfig, "Should return nil when security scheme is not properly typed as JWT")
+	})
+
+	t.Run("Empty Security array - both modes return nil", func(t *testing.T) {
+		for _, mode := range []string{SecurityProcessingModeLegacy, SecurityProcessingModeCompliant} {
+			t.Run(mode, func(t *testing.T) {
+				oas := &OAS{}
+				oas.T = openapi3.T{
+					OpenAPI: "3.0.3",
+					Components: &openapi3.Components{
+						SecuritySchemes: openapi3.SecuritySchemes{
+							"jwtAuth": &openapi3.SecuritySchemeRef{
+								Value: &openapi3.SecurityScheme{
+									Type:         typeHTTP,
+									Scheme:       schemeBearer,
+									BearerFormat: bearerFormatJWT,
+								},
+							},
+						},
+					},
+					Security: openapi3.SecurityRequirements{}, // Empty security requirements
+				}
+
+				tykExtension := &XTykAPIGateway{
+					Server: Server{
+						Authentication: &Authentication{
+							SecurityProcessingMode: mode,
+							SecuritySchemes: SecuritySchemes{
+								"jwtAuth": &JWT{
+									Enabled: true,
+								},
+							},
+						},
+					},
+				}
+				oas.SetTykExtension(tykExtension)
+				
+				jwtConfig := oas.GetJWTConfiguration()
+				assert.Nil(t, jwtConfig, "Should return nil when Security array is empty")
+			})
+		}
+	})
+
+	t.Run("Nil getTykAuthentication - defaults to legacy mode", func(t *testing.T) {
+		oas := &OAS{}
+		oas.T = openapi3.T{
+			OpenAPI: "3.0.3",
+			Components: &openapi3.Components{
+				SecuritySchemes: openapi3.SecuritySchemes{
+					"apiKeyAuth": &openapi3.SecuritySchemeRef{
+						Value: &openapi3.SecurityScheme{
+							Type: "apiKey",
+							In:   "header",
+							Name: "X-API-Key",
+						},
+					},
+					"jwtAuth": &openapi3.SecuritySchemeRef{
+						Value: &openapi3.SecurityScheme{
+							Type:         typeHTTP,
+							Scheme:       schemeBearer,
+							BearerFormat: bearerFormatJWT,
+						},
+					},
+				},
+			},
+			Security: openapi3.SecurityRequirements{
+				openapi3.SecurityRequirement{"apiKeyAuth": []string{}},
+				openapi3.SecurityRequirement{"jwtAuth": []string{}}, // JWT is second
+			},
+		}
+
+		// No Tyk extension set - should default to legacy mode
+		jwtConfig := oas.GetJWTConfiguration()
+		assert.Nil(t, jwtConfig, "Should behave as legacy mode when getTykAuthentication is nil")
+	})
+}

--- a/apidef/oas/security_test.go
+++ b/apidef/oas/security_test.go
@@ -1663,14 +1663,14 @@ func TestGetJWTConfiguration_ORAuthentication(t *testing.T) {
 
 	t.Run("Legacy mode - should NOT find JWT when it's not first", func(t *testing.T) {
 		oas := createTestOAS(SecurityProcessingModeLegacy)
-		
+
 		jwtConfig := oas.GetJWTConfiguration()
 		assert.Nil(t, jwtConfig, "In legacy mode, JWT should NOT be found when it's not the first security requirement")
 	})
 
 	t.Run("Compliant mode - should find JWT even when it's not first", func(t *testing.T) {
 		oas := createTestOAS(SecurityProcessingModeCompliant)
-		
+
 		jwtConfig := oas.GetJWTConfiguration()
 		assert.NotNil(t, jwtConfig, "In compliant mode, JWT should be found even when it's not the first security requirement")
 		assert.Equal(t, "hmac", jwtConfig.SigningMethod)
@@ -1682,7 +1682,7 @@ func TestGetJWTConfiguration_ORAuthentication(t *testing.T) {
 
 	t.Run("Default (empty) mode - should use legacy behavior", func(t *testing.T) {
 		oas := createTestOAS("")
-		
+
 		jwtConfig := oas.GetJWTConfiguration()
 		assert.Nil(t, jwtConfig, "With empty/default mode, should behave like legacy mode")
 	})
@@ -1731,7 +1731,7 @@ func TestGetJWTConfiguration_ORAuthentication(t *testing.T) {
 			},
 		}
 		oas.SetTykExtension(tykExtension)
-		
+
 		jwtConfig := oas.GetJWTConfiguration()
 		assert.NotNil(t, jwtConfig, "Legacy mode should find JWT when it's the first security requirement")
 		assert.Equal(t, "rsa", jwtConfig.SigningMethod)
@@ -1788,7 +1788,7 @@ func TestGetJWTConfiguration_ORAuthentication(t *testing.T) {
 			},
 		}
 		oas.SetTykExtension(tykExtension)
-		
+
 		jwtConfig := oas.GetJWTConfiguration()
 		assert.NotNil(t, jwtConfig, "Compliant mode should find JWT regardless of its position")
 		assert.Equal(t, "ecdsa", jwtConfig.SigningMethod)
@@ -1836,7 +1836,7 @@ func TestGetJWTConfiguration_ORAuthentication(t *testing.T) {
 					},
 				}
 				oas.SetTykExtension(tykExtension)
-				
+
 				jwtConfig := oas.GetJWTConfiguration()
 				assert.Nil(t, jwtConfig, "Should return nil when no JWT security scheme exists")
 			})
@@ -1875,7 +1875,7 @@ func TestGetJWTConfiguration_ORAuthentication(t *testing.T) {
 			},
 		}
 		oas.SetTykExtension(tykExtension)
-		
+
 		jwtConfig := oas.GetJWTConfiguration()
 		assert.Nil(t, jwtConfig, "Should return nil when security scheme is not properly typed as JWT")
 	})
@@ -1913,7 +1913,7 @@ func TestGetJWTConfiguration_ORAuthentication(t *testing.T) {
 					},
 				}
 				oas.SetTykExtension(tykExtension)
-				
+
 				jwtConfig := oas.GetJWTConfiguration()
 				assert.Nil(t, jwtConfig, "Should return nil when Security array is empty")
 			})

--- a/gateway/mw_auth_or_wrapper_test.go
+++ b/gateway/mw_auth_or_wrapper_test.go
@@ -2612,7 +2612,7 @@ func TestMultiAuthMiddleware_OR_CompliantMode_JWT_Second(t *testing.T) {
 					Strip: true,
 				},
 				Authentication: &oas.Authentication{
-					Enabled: true,
+					Enabled:                true,
 					SecurityProcessingMode: oas.SecurityProcessingModeCompliant,
 					SecuritySchemes: oas.SecuritySchemes{
 						"apiKeyAuth": &oas.Token{
@@ -2650,12 +2650,12 @@ func TestMultiAuthMiddleware_OR_CompliantMode_JWT_Second(t *testing.T) {
 		oasDoc.ExtractTo(spec.APIDefinition)
 		spec.IsOAS = true
 		spec.OAS = oasDoc
-		
+
 		spec.SecurityRequirements = [][]string{
 			{"apiKeyAuth"},
 			{"jwtAuth"},
 		}
-		
+
 		spec.UseStandardAuth = true
 		spec.EnableJWT = true
 		spec.JWTSigningMethod = "rsa"
@@ -2705,8 +2705,8 @@ func TestMultiAuthMiddleware_OR_CompliantMode_JWT_Second(t *testing.T) {
 			Code: http.StatusUnauthorized,
 		},
 		{
-			Method: "GET",
-			Path:   "/jwt-second/get",
+			Method:  "GET",
+			Path:    "/jwt-second/get",
 			Headers: map[string]string{},
 			Code:    http.StatusUnauthorized,
 		},
@@ -2719,6 +2719,1015 @@ func TestMultiAuthMiddleware_OR_CompliantMode_JWT_Second(t *testing.T) {
 			Code: http.StatusForbidden,
 		},
 	}
+
+	ts.Run(t, testCases...)
+}
+
+func TestVendorExtension_MixedANDOR_LegacyMode(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	pID := ts.CreatePolicy(func(p *user.Policy) {
+		p.OrgID = ""
+		p.AccessRights = map[string]user.AccessDefinition{
+			"test-mixed-andor-legacy": {
+				APIName:  "Test Mixed ANDOR Legacy",
+				APIID:    "test-mixed-andor-legacy",
+				Versions: []string{"default"},
+			},
+		}
+	})
+
+	apiKey := CreateSession(ts.Gw, func(s *user.SessionState) {
+		s.OrgID = ""
+		s.AccessRights = map[string]user.AccessDefinition{
+			"test-mixed-andor-legacy": {
+				APIName:  "Test Mixed ANDOR Legacy",
+				APIID:    "test-mixed-andor-legacy",
+				Versions: []string{"default"},
+			},
+		}
+	})
+
+	hmacKey := "mixed-hmac-key"
+	hmacSecret := "mixed-hmac-secret"
+	hmacSession := CreateStandardSession()
+	hmacSession.OrgID = ""
+	hmacSession.HMACEnabled = true
+	hmacSession.HmacSecret = hmacSecret
+	hmacSession.AccessRights = map[string]user.AccessDefinition{
+		"test-mixed-andor-legacy": {
+			APIName:  "Test Mixed ANDOR Legacy",
+			APIID:    "test-mixed-andor-legacy",
+			Versions: []string{"default"},
+		},
+	}
+	_ = ts.Gw.GlobalSessionManager.UpdateSession(hmacKey, hmacSession, 60, false)
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.APIID = "test-mixed-andor-legacy"
+		spec.Name = "Test Mixed ANDOR Legacy"
+		spec.OrgID = ""
+		spec.Proxy.ListenPath = "/test-mixed-andor-legacy/"
+		spec.UseKeylessAccess = false
+
+		oasDoc := oas.OAS{}
+		oasDoc.T = openapi3.T{
+			OpenAPI: "3.0.3",
+			Info: &openapi3.Info{
+				Title:   spec.Name,
+				Version: "1.0.0",
+			},
+			Paths: openapi3.NewPaths(),
+			Components: &openapi3.Components{
+				SecuritySchemes: openapi3.SecuritySchemes{
+					"jwt": &openapi3.SecuritySchemeRef{
+						Value: &openapi3.SecurityScheme{
+							Type:         "http",
+							Scheme:       "bearer",
+							BearerFormat: "JWT",
+						},
+					},
+					"apikey": &openapi3.SecuritySchemeRef{
+						Value: &openapi3.SecurityScheme{
+							Type: "apiKey",
+							In:   "header",
+							Name: "X-API-Key",
+						},
+					},
+				},
+			},
+
+			Security: openapi3.SecurityRequirements{
+				openapi3.SecurityRequirement{"jwt": []string{}},
+				openapi3.SecurityRequirement{"apikey": []string{}},
+			},
+		}
+
+		tykExtension := &oas.XTykAPIGateway{
+			Info: oas.Info{
+				ID:   spec.APIID,
+				Name: spec.Name,
+				State: oas.State{
+					Active: true,
+				},
+			},
+			Server: oas.Server{
+				ListenPath: oas.ListenPath{
+					Value: spec.Proxy.ListenPath,
+					Strip: true,
+				},
+				Authentication: &oas.Authentication{
+					Enabled:                true,
+					SecurityProcessingMode: oas.SecurityProcessingModeLegacy,
+
+					Security: [][]string{
+						{"jwt", "hmac"},
+						{"apikey"},
+					},
+					SecuritySchemes: oas.SecuritySchemes{
+						"jwt": &oas.JWT{
+							Enabled:           true,
+							Source:            base64.StdEncoding.EncodeToString([]byte(jwtRSAPubKey)),
+							SigningMethod:     "rsa",
+							IdentityBaseField: "user_id",
+							PolicyFieldName:   "policy_id",
+							DefaultPolicies:   []string{pID},
+							AuthSources: oas.AuthSources{
+								Header: &oas.AuthSource{
+									Enabled: true,
+									Name:    "Authorization",
+								},
+							},
+						},
+						"apikey": &oas.Token{
+							Enabled: func() *bool { b := true; return &b }(),
+							AuthSources: oas.AuthSources{
+								Header: &oas.AuthSource{
+									Enabled: true,
+									Name:    "X-API-Key",
+								},
+							},
+						},
+						"hmac": &oas.HMAC{
+							Enabled: true,
+							AuthSources: oas.AuthSources{
+								Header: &oas.AuthSource{
+									Enabled: true,
+									Name:    "Authorization",
+								},
+							},
+						},
+					},
+				},
+			},
+			Upstream: oas.Upstream{
+				URL: TestHttpAny,
+			},
+		}
+
+		oasDoc.SetTykExtension(tykExtension)
+		oasDoc.ExtractTo(spec.APIDefinition)
+		spec.IsOAS = true
+		spec.OAS = oasDoc
+
+		spec.EnableSignatureChecking = true
+		spec.HmacAllowedAlgorithms = []string{"hmac-sha1", "hmac-sha256"}
+	})
+
+	jwtToken := CreateJWKToken(func(t *jwt.Token) {
+		t.Claims.(jwt.MapClaims)["user_id"] = "mixed-legacy-user"
+		t.Claims.(jwt.MapClaims)["policy_id"] = pID
+		t.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour).Unix()
+	})
+
+	testCases := []test.TestCase{
+
+		{
+			Method: "GET",
+			Path:   "/test-mixed-andor-legacy/",
+			Headers: map[string]string{
+				"Authorization": "Bearer " + jwtToken,
+			},
+			Code: http.StatusBadRequest,
+		},
+
+		{
+			Method: "GET",
+			Path:   "/test-mixed-andor-legacy/",
+			Headers: map[string]string{
+				"X-API-Key": apiKey,
+			},
+			Code: http.StatusBadRequest,
+		},
+
+		{
+			Method: "GET",
+			Path:   "/test-mixed-andor-legacy/",
+			Headers: map[string]string{
+				"Authorization": "Bearer " + jwtToken,
+			},
+			Code: http.StatusBadRequest,
+		},
+
+		{
+			Method:  "GET",
+			Path:    "/test-mixed-andor-legacy/",
+			Headers: map[string]string{},
+			Code:    http.StatusBadRequest,
+		},
+	}
+
+	t.Run("JWT and HMAC together in legacy mode", func(t *testing.T) {
+		date := time.Now().Format("Mon, 02 Jan 2006 15:04:05 MST")
+		headers := map[string]string{
+			"Date": date,
+		}
+
+		signature := generateHMACSignature("GET", "/test-mixed-andor-legacy/", headers, hmacSecret, "hmac-sha1")
+		_ = signature
+
+		testCase := test.TestCase{
+			Method: "GET",
+			Path:   "/test-mixed-andor-legacy/",
+			Headers: map[string]string{
+				"Authorization": "Bearer " + jwtToken,
+				"Date":          date,
+			},
+			Code: http.StatusBadRequest,
+		}
+
+		ts.Run(t, testCase)
+	})
+
+	ts.Run(t, testCases...)
+}
+
+func TestVendorExtension_MixedANDOR_CompliantMode(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	pID := ts.CreatePolicy(func(p *user.Policy) {
+		p.OrgID = ""
+		p.AccessRights = map[string]user.AccessDefinition{
+			"test-mixed-andor-compliant": {
+				APIName:  "Test Mixed ANDOR Compliant",
+				APIID:    "test-mixed-andor-compliant",
+				Versions: []string{"default"},
+			},
+		}
+	})
+
+	apiKey := CreateSession(ts.Gw, func(s *user.SessionState) {
+		s.OrgID = ""
+		s.AccessRights = map[string]user.AccessDefinition{
+			"test-mixed-andor-compliant": {
+				APIName:  "Test Mixed ANDOR Compliant",
+				APIID:    "test-mixed-andor-compliant",
+				Versions: []string{"default"},
+			},
+		}
+	})
+
+	hmacKey := "mixed-hmac-key-compliant"
+	hmacSecret := "mixed-hmac-secret-compliant"
+	hmacSession := CreateStandardSession()
+	hmacSession.OrgID = ""
+	hmacSession.HMACEnabled = true
+	hmacSession.HmacSecret = hmacSecret
+	hmacSession.AccessRights = map[string]user.AccessDefinition{
+		"test-mixed-andor-compliant": {
+			APIName:  "Test Mixed ANDOR Compliant",
+			APIID:    "test-mixed-andor-compliant",
+			Versions: []string{"default"},
+		},
+	}
+	_ = ts.Gw.GlobalSessionManager.UpdateSession(hmacKey, hmacSession, 60, false)
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.APIID = "test-mixed-andor-compliant"
+		spec.Name = "Test Mixed ANDOR Compliant"
+		spec.OrgID = ""
+		spec.Proxy.ListenPath = "/test-mixed-andor-compliant/"
+		spec.UseKeylessAccess = false
+
+		oasDoc := oas.OAS{}
+		oasDoc.T = openapi3.T{
+			OpenAPI: "3.0.3",
+			Info: &openapi3.Info{
+				Title:   spec.Name,
+				Version: "1.0.0",
+			},
+			Paths: openapi3.NewPaths(),
+			Components: &openapi3.Components{
+				SecuritySchemes: openapi3.SecuritySchemes{
+					"apikey": &openapi3.SecuritySchemeRef{
+						Value: &openapi3.SecurityScheme{
+							Type: "apiKey",
+							In:   "header",
+							Name: "X-API-Key",
+						},
+					},
+				},
+			},
+
+			Security: openapi3.SecurityRequirements{
+				openapi3.SecurityRequirement{"apikey": []string{}},
+			},
+		}
+
+		tykExtension := &oas.XTykAPIGateway{
+			Info: oas.Info{
+				ID:   spec.APIID,
+				Name: spec.Name,
+				State: oas.State{
+					Active: true,
+				},
+			},
+			Server: oas.Server{
+				ListenPath: oas.ListenPath{
+					Value: spec.Proxy.ListenPath,
+					Strip: true,
+				},
+				Authentication: &oas.Authentication{
+					Enabled:                true,
+					SecurityProcessingMode: oas.SecurityProcessingModeCompliant,
+
+					Security: [][]string{
+						{"jwt", "hmac"},
+						{"apikey"},
+					},
+					SecuritySchemes: oas.SecuritySchemes{
+						"jwt": &oas.JWT{
+							Enabled:           true,
+							Source:            base64.StdEncoding.EncodeToString([]byte(jwtRSAPubKey)),
+							SigningMethod:     "rsa",
+							IdentityBaseField: "user_id",
+							PolicyFieldName:   "policy_id",
+							DefaultPolicies:   []string{pID},
+							AuthSources: oas.AuthSources{
+								Header: &oas.AuthSource{
+									Enabled: true,
+									Name:    "Authorization",
+								},
+							},
+						},
+						"apikey": &oas.Token{
+							Enabled: func() *bool { b := true; return &b }(),
+							AuthSources: oas.AuthSources{
+								Header: &oas.AuthSource{
+									Enabled: true,
+									Name:    "X-API-Key",
+								},
+							},
+						},
+						"hmac": &oas.HMAC{
+							Enabled: true,
+							AuthSources: oas.AuthSources{
+								Header: &oas.AuthSource{
+									Enabled: true,
+									Name:    "X-HMAC-Signature",
+								},
+							},
+						},
+					},
+				},
+			},
+			Upstream: oas.Upstream{
+				URL: TestHttpAny,
+			},
+		}
+
+		oasDoc.SetTykExtension(tykExtension)
+		oasDoc.ExtractTo(spec.APIDefinition)
+		spec.IsOAS = true
+		spec.OAS = oasDoc
+
+		spec.EnableSignatureChecking = true
+		spec.HmacAllowedAlgorithms = []string{"hmac-sha1", "hmac-sha256"}
+	})
+
+	jwtToken := CreateJWKToken(func(t *jwt.Token) {
+		t.Claims.(jwt.MapClaims)["user_id"] = "mixed-compliant-user"
+		t.Claims.(jwt.MapClaims)["policy_id"] = pID
+		t.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour).Unix()
+	})
+
+	testCases := []test.TestCase{
+
+		{
+			Method: "GET",
+			Path:   "/test-mixed-andor-compliant/",
+			Headers: map[string]string{
+				"X-API-Key": apiKey,
+			},
+			Code: http.StatusOK,
+		},
+
+		{
+			Method: "GET",
+			Path:   "/test-mixed-andor-compliant/",
+			Headers: map[string]string{
+				"Authorization": "Bearer " + jwtToken,
+			},
+			Code: http.StatusUnauthorized,
+		},
+
+		{
+			Method: "GET",
+			Path:   "/test-mixed-andor-compliant/",
+			Headers: map[string]string{
+				"X-API-Key":     "invalid",
+				"Authorization": "Bearer " + jwtToken,
+			},
+			Code: http.StatusForbidden,
+		},
+
+		{
+			Method:  "GET",
+			Path:    "/test-mixed-andor-compliant/",
+			Headers: map[string]string{},
+			Code:    http.StatusUnauthorized,
+		},
+	}
+
+	ts.Run(t, testCases...)
+}
+
+func TestVendorExtension_ComplexCombination_LegacyMode(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.APIID = "test-complex-legacy"
+		spec.Name = "Test Complex Legacy"
+		spec.OrgID = ""
+		spec.Proxy.ListenPath = "/test-complex-legacy/"
+		spec.UseKeylessAccess = false
+
+		oasDoc := oas.OAS{}
+		oasDoc.T = openapi3.T{
+			OpenAPI: "3.0.3",
+			Info: &openapi3.Info{
+				Title:   spec.Name,
+				Version: "1.0.0",
+			},
+			Paths: openapi3.NewPaths(),
+			Components: &openapi3.Components{
+				SecuritySchemes: openapi3.SecuritySchemes{
+					"oauth2": &openapi3.SecuritySchemeRef{
+						Value: &openapi3.SecurityScheme{
+							Type: "oauth2",
+							Flows: &openapi3.OAuthFlows{
+								ClientCredentials: &openapi3.OAuthFlow{
+									TokenURL: "https://example.com/oauth/token",
+									Scopes:   map[string]string{"read": "Read access"},
+								},
+							},
+						},
+					},
+				},
+			},
+			Security: openapi3.SecurityRequirements{
+				openapi3.SecurityRequirement{"oauth2": []string{"read"}},
+			},
+		}
+
+		tykExtension := &oas.XTykAPIGateway{
+			Info: oas.Info{
+				ID:   spec.APIID,
+				Name: spec.Name,
+				State: oas.State{
+					Active: true,
+				},
+			},
+			Server: oas.Server{
+				ListenPath: oas.ListenPath{
+					Value: spec.Proxy.ListenPath,
+					Strip: true,
+				},
+				Authentication: &oas.Authentication{
+					Enabled:                true,
+					SecurityProcessingMode: oas.SecurityProcessingModeLegacy,
+
+					Security: [][]string{
+						{"oauth2"},
+						{"hmac", "custom"},
+					},
+					SecuritySchemes: oas.SecuritySchemes{
+						"oauth2": &oas.OAuth{
+							Enabled: true,
+							AuthSources: oas.AuthSources{
+								Header: &oas.AuthSource{
+									Enabled: true,
+									Name:    "Authorization",
+								},
+							},
+						},
+						"hmac": &oas.HMAC{
+							Enabled: true,
+							AuthSources: oas.AuthSources{
+								Header: &oas.AuthSource{
+									Enabled: true,
+									Name:    "X-HMAC-Signature",
+								},
+							},
+						},
+						"custom": &oas.CustomPluginAuthentication{
+							Enabled: true,
+							AuthSources: oas.AuthSources{
+								Header: &oas.AuthSource{
+									Enabled: true,
+									Name:    "X-Custom-Auth",
+								},
+							},
+						},
+					},
+				},
+			},
+			Upstream: oas.Upstream{
+				URL: TestHttpAny,
+			},
+		}
+
+		oasDoc.SetTykExtension(tykExtension)
+		oasDoc.ExtractTo(spec.APIDefinition)
+		spec.IsOAS = true
+		spec.OAS = oasDoc
+
+		spec.UseOauth2 = true
+	})
+
+	testCases := []test.TestCase{
+
+		{
+			Method:  "GET",
+			Path:    "/test-complex-legacy/",
+			Headers: map[string]string{},
+			Code:    http.StatusBadRequest,
+		},
+
+		{
+			Method: "GET",
+			Path:   "/test-complex-legacy/",
+			Headers: map[string]string{
+				"Authorization": "Bearer invalid-oauth-token",
+			},
+			Code: http.StatusForbidden,
+		},
+
+		{
+			Method: "GET",
+			Path:   "/test-complex-legacy/",
+			Headers: map[string]string{
+				"X-HMAC-Signature": "some-signature",
+				"X-Custom-Auth":    "custom-token",
+			},
+			Code: http.StatusBadRequest,
+		},
+	}
+
+	ts.Run(t, testCases...)
+}
+
+func TestVendorExtension_ComplexCombination_CompliantMode(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	hmacKey := "complex-hmac-key"
+	hmacSecret := "complex-hmac-secret"
+	hmacSession := CreateStandardSession()
+	hmacSession.OrgID = ""
+	hmacSession.HMACEnabled = true
+	hmacSession.HmacSecret = hmacSecret
+	hmacSession.AccessRights = map[string]user.AccessDefinition{
+		"test-complex-compliant": {
+			APIName:  "Test Complex Compliant",
+			APIID:    "test-complex-compliant",
+			Versions: []string{"default"},
+		},
+	}
+	_ = ts.Gw.GlobalSessionManager.UpdateSession(hmacKey, hmacSession, 60, false)
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.APIID = "test-complex-compliant"
+		spec.Name = "Test Complex Compliant"
+		spec.OrgID = ""
+		spec.Proxy.ListenPath = "/test-complex-compliant/"
+		spec.UseKeylessAccess = false
+
+		oasDoc := oas.OAS{}
+		oasDoc.T = openapi3.T{
+			OpenAPI: "3.0.3",
+			Info: &openapi3.Info{
+				Title:   spec.Name,
+				Version: "1.0.0",
+			},
+			Paths: openapi3.NewPaths(),
+		}
+
+		tykExtension := &oas.XTykAPIGateway{
+			Info: oas.Info{
+				ID:   spec.APIID,
+				Name: spec.Name,
+				State: oas.State{
+					Active: true,
+				},
+			},
+			Server: oas.Server{
+				ListenPath: oas.ListenPath{
+					Value: spec.Proxy.ListenPath,
+					Strip: true,
+				},
+				Authentication: &oas.Authentication{
+					Enabled:                true,
+					SecurityProcessingMode: oas.SecurityProcessingModeCompliant,
+					Security: [][]string{
+						{"oauth2"},
+						{"hmac", "custom"},
+					},
+					SecuritySchemes: oas.SecuritySchemes{
+						"oauth2": &oas.OAuth{
+							Enabled: true,
+							AuthSources: oas.AuthSources{
+								Header: &oas.AuthSource{
+									Enabled: true,
+									Name:    "Authorization",
+								},
+							},
+						},
+						"hmac": &oas.HMAC{
+							Enabled: true,
+							AuthSources: oas.AuthSources{
+								Header: &oas.AuthSource{
+									Enabled: true,
+									Name:    "Authorization",
+								},
+							},
+						},
+						"custom": &oas.CustomPluginAuthentication{
+							Enabled: true,
+							AuthSources: oas.AuthSources{
+								Header: &oas.AuthSource{
+									Enabled: true,
+									Name:    "X-Custom-Auth",
+								},
+							},
+						},
+					},
+				},
+			},
+			Upstream: oas.Upstream{
+				URL: TestHttpAny,
+			},
+		}
+
+		oasDoc.SetTykExtension(tykExtension)
+		oasDoc.ExtractTo(spec.APIDefinition)
+		spec.IsOAS = true
+		spec.OAS = oasDoc
+
+		spec.UseOauth2 = true
+		spec.EnableSignatureChecking = true
+		spec.HmacAllowedAlgorithms = []string{"hmac-sha1", "hmac-sha256"}
+		spec.CustomPluginAuthEnabled = true
+	})
+
+	testCases := []test.TestCase{
+
+		{
+			Method: "GET",
+			Path:   "/test-complex-compliant/",
+			Headers: map[string]string{
+				"Authorization": "Bearer invalid-oauth",
+			},
+			Code: http.StatusForbidden,
+		},
+
+		{
+			Method: "GET",
+			Path:   "/test-complex-compliant/",
+			Headers: map[string]string{
+				"Authorization": "HMAC some-signature",
+			},
+			Code: http.StatusBadRequest,
+		},
+
+		{
+			Method: "GET",
+			Path:   "/test-complex-compliant/",
+			Headers: map[string]string{
+				"X-Custom-Auth": "custom-token",
+			},
+			Code: http.StatusBadRequest,
+		},
+
+		{
+			Method:  "GET",
+			Path:    "/test-complex-compliant/",
+			Headers: map[string]string{},
+			Code:    http.StatusBadRequest,
+		},
+	}
+
+	ts.Run(t, testCases...)
+}
+
+func TestVendorExtension_EmptyOAS_LegacyMode(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	hmacKey := "empty-oas-hmac-key"
+	hmacSecret := "empty-oas-hmac-secret"
+	hmacSession := CreateStandardSession()
+	hmacSession.OrgID = ""
+	hmacSession.HMACEnabled = true
+	hmacSession.HmacSecret = hmacSecret
+	hmacSession.AccessRights = map[string]user.AccessDefinition{
+		"test-empty-oas-legacy": {
+			APIName:  "Test Empty OAS Legacy",
+			APIID:    "test-empty-oas-legacy",
+			Versions: []string{"default"},
+		},
+	}
+	_ = ts.Gw.GlobalSessionManager.UpdateSession(hmacKey, hmacSession, 60, false)
+
+	apiKey := CreateSession(ts.Gw, func(s *user.SessionState) {
+		s.OrgID = ""
+		s.AccessRights = map[string]user.AccessDefinition{
+			"test-empty-oas-legacy": {
+				APIName:  "Test Empty OAS Legacy",
+				APIID:    "test-empty-oas-legacy",
+				Versions: []string{"default"},
+			},
+		}
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.APIID = "test-empty-oas-legacy"
+		spec.Name = "Test Empty OAS Legacy"
+		spec.OrgID = ""
+		spec.Proxy.ListenPath = "/test-empty-oas-legacy/"
+		spec.UseKeylessAccess = false
+
+		oasDoc := oas.OAS{}
+		oasDoc.T = openapi3.T{
+			OpenAPI: "3.0.3",
+			Info: &openapi3.Info{
+				Title:   spec.Name,
+				Version: "1.0.0",
+			},
+			Paths: openapi3.NewPaths(),
+		}
+
+		tykExtension := &oas.XTykAPIGateway{
+			Info: oas.Info{
+				ID:   spec.APIID,
+				Name: spec.Name,
+				State: oas.State{
+					Active: true,
+				},
+			},
+			Server: oas.Server{
+				ListenPath: oas.ListenPath{
+					Value: spec.Proxy.ListenPath,
+					Strip: true,
+				},
+				Authentication: &oas.Authentication{
+					Enabled:                true,
+					SecurityProcessingMode: oas.SecurityProcessingModeLegacy,
+
+					Security: [][]string{
+						{"hmac"},
+						{"apikey"}, // Ignored in legacy
+					},
+					SecuritySchemes: oas.SecuritySchemes{
+						"hmac": &oas.HMAC{
+							Enabled: true,
+							AuthSources: oas.AuthSources{
+								Header: &oas.AuthSource{
+									Enabled: true,
+									Name:    "Authorization",
+								},
+							},
+						},
+						"apikey": &oas.Token{
+							Enabled: func() *bool { b := true; return &b }(),
+							AuthSources: oas.AuthSources{
+								Header: &oas.AuthSource{
+									Enabled: true,
+									Name:    "X-API-Key",
+								},
+							},
+						},
+					},
+				},
+			},
+			Upstream: oas.Upstream{
+				URL: TestHttpGet,
+			},
+		}
+
+		oasDoc.SetTykExtension(tykExtension)
+		oasDoc.ExtractTo(spec.APIDefinition)
+		spec.IsOAS = true
+		spec.OAS = oasDoc
+
+		spec.EnableSignatureChecking = true
+		spec.HmacAllowedAlgorithms = []string{"hmac-sha1", "hmac-sha256"}
+	})
+
+	testCases := []test.TestCase{
+
+		{
+			Method: "GET",
+			Path:   "/test-empty-oas-legacy/",
+			Headers: map[string]string{
+				"X-API-Key": apiKey,
+			},
+			Code: http.StatusBadRequest,
+		},
+
+		{
+			Method:  "GET",
+			Path:    "/test-empty-oas-legacy/",
+			Headers: map[string]string{},
+			Code:    http.StatusBadRequest,
+		},
+	}
+
+	t.Run("Valid HMAC in legacy mode with empty OAS", func(t *testing.T) {
+		date := time.Now().Format("Mon, 02 Jan 2006 15:04:05 MST")
+		headers := map[string]string{
+			"Date": date,
+		}
+
+		signature := generateHMACSignature("GET", "/test-empty-oas-legacy/", headers, hmacSecret, "hmac-sha1")
+		authHeader := fmt.Sprintf(`Signature keyId="%s",algorithm="hmac-sha1",headers="(request-target) date",signature="%s"`, hmacKey, signature)
+
+		testCase := test.TestCase{
+			Method: "GET",
+			Path:   "/test-empty-oas-legacy/",
+			Headers: map[string]string{
+				"Date":          date,
+				"Authorization": authHeader,
+			},
+			Code: http.StatusOK,
+		}
+
+		ts.Run(t, testCase)
+	})
+
+	ts.Run(t, testCases...)
+}
+
+func TestVendorExtension_EmptyOAS_CompliantMode(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	hmacKey := "empty-oas-hmac-compliant"
+	hmacSecret := "empty-oas-secret-compliant"
+	hmacSession := CreateStandardSession()
+	hmacSession.OrgID = ""
+	hmacSession.HMACEnabled = true
+	hmacSession.HmacSecret = hmacSecret
+	hmacSession.AccessRights = map[string]user.AccessDefinition{
+		"test-empty-oas-compliant": {
+			APIName:  "Test Empty OAS Compliant",
+			APIID:    "test-empty-oas-compliant",
+			Versions: []string{"default"},
+		},
+	}
+	_ = ts.Gw.GlobalSessionManager.UpdateSession(hmacKey, hmacSession, 60, false)
+
+	apiKey := CreateSession(ts.Gw, func(s *user.SessionState) {
+		s.OrgID = ""
+		s.AccessRights = map[string]user.AccessDefinition{
+			"test-empty-oas-compliant": {
+				APIName:  "Test Empty OAS Compliant",
+				APIID:    "test-empty-oas-compliant",
+				Versions: []string{"default"},
+			},
+		}
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.APIID = "test-empty-oas-compliant"
+		spec.Name = "Test Empty OAS Compliant"
+		spec.OrgID = ""
+		spec.Proxy.ListenPath = "/test-empty-oas-compliant/"
+		spec.UseKeylessAccess = false
+
+		oasDoc := oas.OAS{}
+		oasDoc.T = openapi3.T{
+			OpenAPI: "3.0.3",
+			Info: &openapi3.Info{
+				Title:   spec.Name,
+				Version: "1.0.0",
+			},
+			Paths: openapi3.NewPaths(),
+		}
+
+		tykExtension := &oas.XTykAPIGateway{
+			Info: oas.Info{
+				ID:   spec.APIID,
+				Name: spec.Name,
+				State: oas.State{
+					Active: true,
+				},
+			},
+			Server: oas.Server{
+				ListenPath: oas.ListenPath{
+					Value: spec.Proxy.ListenPath,
+					Strip: true,
+				},
+				Authentication: &oas.Authentication{
+					Enabled:                true,
+					SecurityProcessingMode: oas.SecurityProcessingModeCompliant,
+
+					Security: [][]string{
+						{"hmac"},
+						{"apikey"},
+					},
+					SecuritySchemes: oas.SecuritySchemes{
+						"hmac": &oas.HMAC{
+							Enabled: true,
+							AuthSources: oas.AuthSources{
+								Header: &oas.AuthSource{
+									Enabled: true,
+									Name:    "Authorization",
+								},
+							},
+						},
+						"apikey": &oas.Token{
+							Enabled: func() *bool { b := true; return &b }(),
+							AuthSources: oas.AuthSources{
+								Header: &oas.AuthSource{
+									Enabled: true,
+									Name:    "X-API-Key",
+								},
+							},
+						},
+					},
+				},
+			},
+			Upstream: oas.Upstream{
+				URL: TestHttpGet,
+			},
+		}
+
+		oasDoc.SetTykExtension(tykExtension)
+		oasDoc.ExtractTo(spec.APIDefinition)
+		spec.IsOAS = true
+		spec.OAS = oasDoc
+
+		spec.EnableSignatureChecking = true
+		spec.HmacAllowedAlgorithms = []string{"hmac-sha1", "hmac-sha256"}
+	})
+
+	testCases := []test.TestCase{
+
+		{
+			Method: "GET",
+			Path:   "/test-empty-oas-compliant/",
+			Headers: map[string]string{
+				"X-API-Key": apiKey,
+			},
+			Code: http.StatusBadRequest,
+		},
+
+		{
+			Method: "GET",
+			Path:   "/test-empty-oas-compliant/",
+			Headers: map[string]string{
+				"X-API-Key": "invalid",
+			},
+			Code: http.StatusBadRequest,
+		},
+
+		{
+			Method:  "GET",
+			Path:    "/test-empty-oas-compliant/",
+			Headers: map[string]string{},
+			Code:    http.StatusBadRequest,
+		},
+	}
+
+	t.Run("Valid HMAC in compliant mode with empty OAS", func(t *testing.T) {
+		date := time.Now().Format("Mon, 02 Jan 2006 15:04:05 MST")
+		headers := map[string]string{
+			"Date": date,
+		}
+
+		signature := generateHMACSignature("GET", "/test-empty-oas-compliant/", headers, hmacSecret, "hmac-sha1")
+		authHeader := fmt.Sprintf(`Signature keyId="%s",algorithm="hmac-sha1",headers="(request-target) date",signature="%s"`, hmacKey, signature)
+
+		testCase := test.TestCase{
+			Method: "GET",
+			Path:   "/test-empty-oas-compliant/",
+			Headers: map[string]string{
+				"Date":          date,
+				"Authorization": authHeader,
+			},
+			Code: http.StatusOK,
+		}
+
+		ts.Run(t, testCase)
+	})
+
+	t.Run("Invalid HMAC but valid API key in compliant mode", func(t *testing.T) {
+		testCase := test.TestCase{
+			Method: "GET",
+			Path:   "/test-empty-oas-compliant/",
+			Headers: map[string]string{
+				"Authorization": `Signature keyId="wrong",algorithm="hmac-sha1",signature="invalid"`,
+				"X-API-Key":     apiKey,
+			},
+			Code: http.StatusBadRequest,
+		}
+
+		ts.Run(t, testCase)
+	})
 
 	ts.Run(t, testCases...)
 }


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-15868" title="TT-15868" target="_blank">TT-15868</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Fix panic when using JWT as the second OR auth method</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Sub-task" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />
        Sub-task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description
There's a panic when using JWT as a second authentication method in compliant mode due to trying to access a nil pointer. In this PR we are fixing that.
<!-- Describe your changes in detail -->

## Related Issue
https://tyktech.atlassian.net/browse/TT-15868?atlOrigin=eyJpIjoiMzFjMDdkYmJmNGMxNDY1NjhlZDQzZDQ1ZTc5MDMxNWUiLCJwIjoiaiJ9
<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context
https://tyktech.atlassian.net/browse/TT-15868?atlOrigin=eyJpIjoiMzFjMDdkYmJmNGMxNDY1NjhlZDQzZDQ1ZTc5MDMxNWUiLCJwIjoiaiJ9
<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix JWT discovery across security requirements

- Prevent nil dereference in compliant mode

- Add comprehensive OR-auth JWT tests

- Cover mixed AND/OR auth flows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  GetJWT["GetJWTConfiguration logic"] -- "legacy: check first requirement" --> LegacyPath["First security only"]
  GetJWT -- "compliant: scan all requirements" --> CompliantPath["Any security requirement"]
  CompliantPath -- "find bearer JWT" --> ReturnJWT["Return Tyk JWT config"]
  LegacyPath -- "no JWT first" --> ReturnNil["Return nil"]
  Tests["New tests"] -- "OR auth, mixed modes" --> GetJWT
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>security.go</strong><dd><code>Compliant-mode JWT lookup across all requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/security.go

<ul><li>Add processing mode detection with default legacy.<br> <li> In legacy, check only first security requirement.<br> <li> In compliant, scan all requirements for JWT.<br> <li> Return JWT config when bearer JWT found.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7384/files#diff-15e7d47137452ca4f3f6139aa8c007cdb426152c41846f712f8bf5dfb607afcc">+25/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>security_test.go</strong><dd><code>Tests for JWT config in OR-auth scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/security_test.go

<ul><li>Add tests for OR-auth JWT retrieval.<br> <li> Cover legacy vs compliant behavior.<br> <li> Validate various positions and absence of JWT.<br> <li> Ensure defaults to legacy when auth is nil.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7384/files#diff-5184167309db0462243e424baca87b5bb668962d8cc1076629fdcf11f00487e5">+362/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mw_auth_or_wrapper_test.go</strong><dd><code>E2E tests for mixed auth and compliant processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_auth_or_wrapper_test.go

<ul><li>Add end-to-end OR/AND auth tests.<br> <li> Validate JWT as second requirement in compliant mode.<br> <li> Add mixed AND/OR cases for both modes.<br> <li> Add empty OAS scenarios with HMAC/API key.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7384/files#diff-3a4c15ceae9b90006abf6a02b3820be582a7d845c27679cef7ee0b4a36fca6a3">+1200/-0</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

