### PR TITLE
Merging to release-5.10: [TT-15869] cooldown defaults not working and minor datetime format adjustments (#7386)

### DIFF
--- a/gateway/event_handler_webhooks.go
+++ b/gateway/event_handler_webhooks.go
@@ -95,7 +95,11 @@ func (w *WebHookHandler) Init(handlerConf interface{}) error {
 			"target": w.conf.TargetPath,
 		}).Info("Loading default template.")
 		defaultPath := filepath.Join(w.Gw.GetConfig().TemplatePath, "default_webhook.json")
-		w.template, err = htmltemplate.ParseFiles(defaultPath)
+		w.template = htmltemplate.New("default_webhook.json").Funcs(htmltemplate.FuncMap{
+			"as_rfc3339":             templateFuncAsRFC3339(),
+			"as_rfc3339_from_string": templateFuncAsRFC3339FromString(log),
+		})
+		w.template, err = w.template.ParseFiles(defaultPath)
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "webhooks",
@@ -336,4 +340,29 @@ func (w *WebHookHandler) HandleEvent(em config.EventMessage) {
 	}
 
 	w.setHookFired(reqChecksum)
+}
+
+func templateFuncAsRFC3339() func(time.Time) string {
+	return func(t time.Time) string {
+		return t.Format(time.RFC3339)
+	}
+}
+
+func templateFuncAsRFC3339FromString(log *logrus.Logger) func(string) string {
+	return func(s string) string {
+		t, err := time.Parse("2006-01-02 15:04:05.999999 -0700 MST", s)
+		if err == nil {
+			return t.Format(time.RFC3339)
+		}
+
+		log.WithFields(logrus.Fields{
+			"prefix":   "webhooks",
+			"datetime": s,
+			"error":    err.Error(),
+		}).
+			Debug("Could not parse time to RFC3339 from string.")
+
+		// Fallback to the original string
+		return s
+	}
 }

--- a/gateway/event_handler_webhooks_test.go
+++ b/gateway/event_handler_webhooks_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	logrus "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -540,4 +541,31 @@ func TestWebhookContentTypeHeader(t *testing.T) {
 		})
 	}
 
+}
+
+func TestWebhookTemplateFuncs(t *testing.T) {
+	t.Run("as_RFC3339", func(t *testing.T) {
+		asRFC3339Func := templateFuncAsRFC3339()
+		inputTime := time.Date(2025, 1, 2, 3, 4, 5, 6, time.UTC)
+		expected := "2025-01-02T03:04:05Z"
+		actual := asRFC3339Func(inputTime)
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("as_RFC3339_from_string", func(t *testing.T) {
+		noopLogger, _ := logrus.NewNullLogger()
+		asRFC3339FromStringFunc := templateFuncAsRFC3339FromString(noopLogger)
+
+		t.Run("invalid time", func(t *testing.T) {
+			input := "2025/01/02 03:04:05"
+			expected := "2025/01/02 03:04:05"
+			assert.Equal(t, expected, asRFC3339FromStringFunc(input))
+		})
+
+		t.Run("valid time", func(t *testing.T) {
+			input := "2025-01-02 03:04:05.999999 +0200 CEST"
+			expected := "2025-01-02T03:04:05+02:00"
+			assert.Equal(t, expected, asRFC3339FromStringFunc(input))
+		})
+	})
 }

--- a/internal/certcheck/batcher.go
+++ b/internal/certcheck/batcher.go
@@ -116,7 +116,7 @@ func NewCertificateExpiryCheckBatcher(logger *logrus.Entry, apiMetaData APIMetaD
 	return &CertificateExpiryCheckBatcher{
 		logger:                logger,
 		apiMetaData:           apiMetaData,
-		config:                cfg,
+		config:                applyConfigDefaults(cfg),
 		batch:                 NewBatch(),
 		inMemoryCooldownCache: inMemoryCache,
 		fallbackCooldownCache: fallbackCache,
@@ -408,6 +408,22 @@ func (c *CertificateExpiryCheckBatcher) composeExpiredMessage(certInfo CertInfo,
 		}
 	}
 	return fmt.Sprintf("Certificate %s is expired since %d hours", certInfo.CommonName, hoursSinceExpiry)
+}
+
+func applyConfigDefaults(cfg config.CertificateExpiryMonitorConfig) config.CertificateExpiryMonitorConfig {
+	if cfg.WarningThresholdDays == 0 {
+		cfg.WarningThresholdDays = config.DefaultWarningThresholdDays
+	}
+
+	if cfg.CheckCooldownSeconds == 0 {
+		cfg.CheckCooldownSeconds = config.DefaultCheckCooldownSeconds
+	}
+
+	if cfg.EventCooldownSeconds == 0 {
+		cfg.EventCooldownSeconds = config.DefaultEventCooldownSeconds
+	}
+
+	return cfg
 }
 
 // Interface Guards

--- a/internal/certcheck/batcher_test.go
+++ b/internal/certcheck/batcher_test.go
@@ -1495,3 +1495,25 @@ func TestCertInfo_DaysUntilExpiry(t *testing.T) {
 		})
 	}
 }
+
+func TestApplyConfigDefaults(t *testing.T) {
+	t.Run("without provided values", func(t *testing.T) {
+		providedCfg := config.CertificateExpiryMonitorConfig{}
+		actualCfg := applyConfigDefaults(providedCfg)
+		assert.Equal(t, config.DefaultWarningThresholdDays, actualCfg.WarningThresholdDays)
+		assert.Equal(t, config.DefaultCheckCooldownSeconds, actualCfg.CheckCooldownSeconds)
+		assert.Equal(t, config.DefaultEventCooldownSeconds, actualCfg.EventCooldownSeconds)
+	})
+
+	t.Run("with provided values", func(t *testing.T) {
+		providedCfg := config.CertificateExpiryMonitorConfig{
+			WarningThresholdDays: 10,
+			CheckCooldownSeconds: 100,
+			EventCooldownSeconds: 1000,
+		}
+		actualCfg := applyConfigDefaults(providedCfg)
+		assert.Equal(t, 10, actualCfg.WarningThresholdDays)
+		assert.Equal(t, 100, actualCfg.CheckCooldownSeconds)
+		assert.Equal(t, 1000, actualCfg.EventCooldownSeconds)
+	})
+}

--- a/templates/default_webhook.json
+++ b/templates/default_webhook.json
@@ -60,10 +60,10 @@
   "message": "{{.Meta.Message}}",
   "cert_id": "{{.Meta.CertID}}",
   "cert_name": "{{.Meta.CertName}}",
-  "expires_at": "{{.Meta.ExpiresAt}}",
+  "expires_at": "{{.Meta.ExpiresAt | as_rfc3339}}",
   "days_remaining": {{.Meta.DaysRemaining}},
   "api_id": "{{.Meta.APIID}}",
-  "timestamp": "{{.TimeStamp}}"
+  "timestamp": "{{.TimeStamp | as_rfc3339_from_string}}"
 }
 {{ else if eq .Type "CertificateExpired"}}
 {
@@ -71,10 +71,10 @@
   "message": "{{.Meta.Message}}",
   "cert_id": "{{.Meta.CertID}}",
   "cert_name": "{{.Meta.CertName}}",
-  "expired_at": "{{.Meta.ExpiredAt}}",
+  "expired_at": "{{.Meta.ExpiredAt | as_rfc3339}}",
   "days_since_expiry": {{.Meta.DaysSinceExpiry}},
   "api_id": "{{.Meta.APIID}}",
-  "timestamp": "{{.TimeStamp}}"
+  "timestamp": "{{.TimeStamp | as_rfc3339_from_string}}"
 }
 {{ else}}
 {


### PR DESCRIPTION
### **User description**
[TT-15869] cooldown defaults not working and minor datetime format adjustments (#7386)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-15869"
title="TT-15869" target="_blank">TT-15869</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
<td>Certificate Expiry check and event cooldown defaults do not
work</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

This PR fixes an issue, where the config defaults were not being applied
to the certificate check batcher.
It also fixes a small issue with the date time format not following
RFC3339.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Apply certificate monitor config defaults

- Add RFC3339 datetime formatting to webhooks

- Update default webhook template with helpers

- Add unit tests for helpers and defaults


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cfg["CertificateExpiryMonitorConfig"] -- apply defaults --> def["applyConfigDefaults()"]
  def -- used in --> batcher["NewCertificateExpiryCheckBatcher"]
  tmpl["default_webhook.json"] -- uses --> funcs["template funcs: as_rfc3339, as_rfc3339_from_string"]
  web["WebHookHandler.Init"] -- register funcs --> funcs
  tests1["batcher_test"] -- verify --> def
  tests2["webhooks_test"] -- verify --> funcs
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>event_handler_webhooks.go</strong><dd><code>Add RFC3339
template helpers and integrate in webhook handler</code></dd></summary>
<hr>

gateway/event_handler_webhooks.go

<ul><li>Register template funcs for RFC3339 formatting<br> <li> Parse
default template with custom FuncMap<br> <li> Add helpers to format time
and parse string times<br> <li> Log debug on parsing failures, fallback
to original</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7386/files#diff-6587ad3f2629cfa6c84a71144127acd6cc7824e5141f0b4961848945a87e0198">+30/-1</a>&nbsp;
&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>default_webhook.json</strong><dd><code>Use RFC3339
formatting in default webhook template</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/default_webhook.json

<ul><li>Format certificate dates using RFC3339 helper<br> <li> Convert
event timestamps via string parsing helper<br> <li> Update fields:
expires_at, expired_at, timestamp</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7386/files#diff-0d9bf4709b7f8fbdba9b19f94583e3baff5ae95c016e9688dc3e151873ea257e">+4/-4</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>event_handler_webhooks_test.go</strong><dd><code>Test
webhook RFC3339 formatting helpers</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/event_handler_webhooks_test.go

<ul><li>Add tests for RFC3339 helper functions<br> <li> Verify invalid
and valid string parsing behavior<br> <li> Import test logger hook for
noop logging</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7386/files#diff-1a2f8d6ab4443031b0f8486809453f6389291a6f625745fe8c65ac5cdb0e9621">+28/-0</a>&nbsp;
&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>batcher_test.go</strong><dd><code>Test certificate
monitor default application</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/certcheck/batcher_test.go

<ul><li>Add tests for applyConfigDefaults behavior<br> <li> Validate
defaulting and preservation of provided values</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7386/files#diff-0c0c8cc1102f4dc49d63e417a5aa26c85fe4f94fe8c335149f8768ee5b8c9810">+22/-0</a>&nbsp;
&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>batcher.go</strong><dd><code>Apply defaults for
certificate monitor configuration</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; </dd></summary>
<hr>

internal/certcheck/batcher.go

<ul><li>Apply default config when values not provided<br> <li> Use
applyConfigDefaults in constructor<br> <li> Add helper to set cooldown
and threshold defaults</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7386/files#diff-70d967648d3a4c204df7ea2dd127adc9968c6f7f0784ceb109497e826e2a244a">+17/-1</a>&nbsp;
&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

[TT-15869]: https://tyktech.atlassian.net/browse/TT-15869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Apply defaults to certificate monitor

- Add RFC3339 webhook template helpers

- Update default webhook template timestamps

- Add unit tests for defaults and helpers


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cfg["CertificateExpiryMonitorConfig"] --> def["applyConfigDefaults()"]
  def -- used in --> batcher["NewCertificateExpiryCheckBatcher"]
  tmpl["default_webhook.json"] -- uses --> funcs["template funcs: as_rfc3339, as_rfc3339_from_string"]
  web["WebHookHandler.Init"] -- register funcs --> funcs
  tests1["batcher_test"] -- verify --> def
  tests2["webhooks_test"] -- verify --> funcs
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>event_handler_webhooks.go</strong><dd><code>RFC3339 helpers and integration in webhook handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/event_handler_webhooks.go

<ul><li>Register template funcs for RFC3339 formatting<br> <li> Parse default template with custom FuncMap<br> <li> Add helpers to format time and parse strings<br> <li> Debug-log parse failures and fallback gracefully</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7389/files#diff-6587ad3f2629cfa6c84a71144127acd6cc7824e5141f0b4961848945a87e0198">+30/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>default_webhook.json</strong><dd><code>Default webhook template uses RFC3339 helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/default_webhook.json

<ul><li>Use RFC3339 formatting for cert dates<br> <li> Convert timestamp via string parsing helper<br> <li> Update expires_at, expired_at, timestamp fields</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7389/files#diff-0d9bf4709b7f8fbdba9b19f94583e3baff5ae95c016e9688dc3e151873ea257e">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>event_handler_webhooks_test.go</strong><dd><code>Tests for webhook RFC3339 template helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/event_handler_webhooks_test.go

<ul><li>Add tests for RFC3339 helpers<br> <li> Cover valid and invalid time parsing<br> <li> Use noop test logger for debug logs</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7389/files#diff-1a2f8d6ab4443031b0f8486809453f6389291a6f625745fe8c65ac5cdb0e9621">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>batcher_test.go</strong><dd><code>Tests for certificate monitor config defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/certcheck/batcher_test.go

<ul><li>Test defaulting without provided values<br> <li> Ensure provided values are preserved</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7389/files#diff-0c0c8cc1102f4dc49d63e417a5aa26c85fe4f94fe8c335149f8768ee5b8c9810">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>batcher.go</strong><dd><code>Apply defaults for certificate monitor configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/certcheck/batcher.go

<ul><li>Apply config defaults in constructor<br> <li> Implement applyConfigDefaults helper<br> <li> Default warning and cooldown values when zero</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7389/files#diff-70d967648d3a4c204df7ea2dd127adc9968c6f7f0784ceb109497e826e2a244a">+17/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

