### PR TITLE
Add docker images built using FIPS binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
             debvers: 'ubuntu/xenial ubuntu/bionic ubuntu/focal ubuntu/jammy ubuntu/noble debian/jessie debian/buster debian/bullseye debian/bookworm debian/trixie'
     outputs:
       ee_tags: ${{ steps.ci_metadata_ee.outputs.tags }}
+      fips_tags: ${{ steps.ci_metadata_fips.outputs.tags }}
       std_tags: ${{ steps.ci_metadata_std.outputs.tags }}
       commit_author: ${{ steps.set_outputs.outputs.commit_author}}
     steps:
@@ -197,6 +198,71 @@ jobs:
           labels: ${{ steps.tag_metadata_ee.outputs.labels }}
           build-args: |
             BUILD_PACKAGE_NAME=tyk-gateway-ee
+      - name: Docker metadata for fips CI
+        id: ci_metadata_fips
+        if: ${{ matrix.golang_cross == '1.24-bullseye' }}
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ steps.ecr.outputs.registry }}/tyk
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,format=long
+            type=semver,pattern={{major}},prefix=v
+            type=semver,pattern={{major}}.{{minor}},prefix=v
+            type=semver,pattern={{version}},prefix=v
+      - name: push fips image to CI
+        if: ${{ matrix.golang_cross == '1.24-bullseye' }}
+        uses: docker/build-push-action@v6
+        with:
+          context: "dist"
+          platforms: linux/amd64,linux/arm64,linux/s390x
+          file: ci/Dockerfile.distroless
+          provenance: mode=max
+          sbom: true
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ${{ steps.ci_metadata_fips.outputs.tags }}
+          labels: ${{ steps.ci_metadata_fips.outputs.labels }}
+          build-args: |
+            BUILD_PACKAGE_NAME=tyk-gateway-fips
+      - name: Docker metadata for fips tag push
+        id: tag_metadata_fips
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            tykio/tyk-gateway
+          flavor: |
+            latest=false
+            prefix=v
+          tags: |
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}}
+          labels: |
+            org.opencontainers.image.title=Tyk Gateway FIPS
+            org.opencontainers.image.description=Tyk Open Source API Gateway written in Go, supporting REST, GraphQL, TCP and gRPC protocols Built with boringssl
+            org.opencontainers.image.vendor=tyk.io
+            org.opencontainers.image.version=${{ github.ref_name }}
+      - name: push fips image to prod
+        if: ${{ matrix.golang_cross == '1.24-bullseye' }}
+        uses: docker/build-push-action@v6
+        with:
+          context: "dist"
+          platforms: linux/amd64,linux/arm64,linux/s390x
+          file: ci/Dockerfile.distroless
+          provenance: mode=max
+          sbom: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: ${{ startsWith(github.ref, 'refs/tags') }}
+          tags: ${{ steps.tag_metadata_fips.outputs.tags }}
+          labels: ${{ steps.tag_metadata_fips.outputs.labels }}
+          build-args: |
+            BUILD_PACKAGE_NAME=tyk-gateway-fips
       - name: Docker metadata for std CI
         id: ci_metadata_std
         if: ${{ matrix.golang_cross == '1.24-bullseye' }}

--- a/ci/Dockerfile.std
+++ b/ci/Dockerfile.std
@@ -13,16 +13,16 @@ RUN apt-get update \
 RUN dpkg --purge --force-remove-essential curl ncurses-base || true
 RUN rm -fv /usr/bin/passwd /usr/sbin/adduser || true
 
+# Comment this to test in dev
+COPY dist/${BUILD_PACKAGE_NAME}_*_${TARGETARCH}.deb /
+RUN dpkg -i /${BUILD_PACKAGE_NAME}_*_${TARGETARCH}.deb && find / -maxdepth 1 -name "*.deb" -delete
+
 # Clean up caches, unwanted .a and .o files
 RUN rm -rf /root/.cache \
     && apt-get -y autoremove \
     && apt-get clean \
-    && rm -rf /usr/include/* /var/cache/apt/archives /var/lib/{apt,dpkg,cache,log} \
+    && rm -rf /usr/include/* /var/cache/apt/archives /var/lib/apt /var/lib/cache /var/log/* \
     && find /usr/lib -type f -name '*.a' -o -name '*.o' -delete
-
-# Comment this to test in dev
-COPY ${BUILD_PACKAGE_NAME}_*${TARGETARCH}.deb /
-RUN dpkg -i /${BUILD_PACKAGE_NAME}*${TARGETARCH}.deb && rm /*.deb
 
 ARG PORTS
 

--- a/ci/goreleaser/goreleaser.yml
+++ b/ci/goreleaser/goreleaser.yml
@@ -63,7 +63,7 @@ builds:
     env:
       - NOP=nop # ignore this, it is jsut to avoid a complex conditional in the templates
       - CC=gcc
-      - $env
+      - GOEXPERIMENT=boringcrypto
     ldflags:
       - -X github.com/TykTechnologies/tyk/internal/build.Version={{.Version}}
       - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
@@ -73,6 +73,40 @@ builds:
       - linux
     goarch:
       - amd64
+    binary: tyk
+  - id: fips-arm64
+    flags:
+      - -tags=goplugin,fips,boringcrypto
+    env:
+      - NOP=nop # ignore this, it is jsut to avoid a complex conditional in the templates
+      - CC=aarch64-linux-gnu-gcc
+      - GOEXPERIMENT=boringcrypto
+    ldflags:
+      - -X github.com/TykTechnologies/tyk/internal/build.Version={{.Version}}
+      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
+    goos:
+      - linux
+    goarch:
+      - arm64
+    binary: tyk
+  - id: fips-s390x
+    flags:
+      - -tags=goplugin,fips,boringcrypto
+    env:
+      - NOP=nop # ignore this, it is jsut to avoid a complex conditional in the templates
+      - CC=s390x-linux-gnu-gcc
+      - GOEXPERIMENT=boringcrypto
+    ldflags:
+      - -X github.com/TykTechnologies/tyk/internal/build.Version={{.Version}}
+      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
+    goos:
+      - linux
+    goarch:
+      - s390x
     binary: tyk
   - id: std-amd64
     flags:
@@ -194,6 +228,8 @@ nfpms:
     file_name_template: "{{ .ConventionalFileName }}"
     ids:
       - fips-amd64
+      - fips-arm64
+      - fips-s390x
     formats:
       - deb
       - rpm
@@ -320,6 +356,317 @@ publishers:
     env:
       - PACKAGECLOUD_TOKEN={{ .Env.PACKAGECLOUD_TOKEN }}
     cmd: packagecloud publish --debvers "{{ .Env.DEBVERS }}" --rpmvers "{{ .Env.RPMVERS }}" tyk/tyk-gateway-unstable {{ .ArtifactPath }}
+dockers:
+  # Build tykio/tyk-gateway-ee ee (amd64)
+  - ids:
+      - ee-amd64
+    image_templates:
+      - "tykio/tyk-gateway-ee:{{.Tag}}-ee-amd64"
+    build_flag_templates:
+      - "--build-arg=PORTS=8080"
+      - "--build-arg=BUILD_PACKAGE_NAME=tyk-gateway-ee"
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}} Enterprise Edition"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+    use: buildx
+    goarch: amd64
+    goos: linux
+    dockerfile: ci/Dockerfile.std
+    extra_files:
+      - "ci/install/"
+      - "README.md"
+      - "dist/"
+      - "LICENSE.md"
+      - "apps/app_sample.json"
+      - "templates"
+      - "middleware"
+      - "event_handlers/sample"
+      - "policies"
+      - "coprocess"
+      - "tyk.conf.example"
+  # Build tykio/tyk-gateway-ee ee (arm64)
+  - ids:
+      - ee-arm64
+    image_templates:
+      - "tykio/tyk-gateway-ee:{{.Tag}}-ee-arm64"
+    build_flag_templates:
+      - "--build-arg=PORTS=8080"
+      - "--build-arg=BUILD_PACKAGE_NAME=tyk-gateway-ee"
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}} Enterprise Edition"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+    use: buildx
+    goarch: arm64
+    goos: linux
+    dockerfile: ci/Dockerfile.std
+    extra_files:
+      - "ci/install/"
+      - "README.md"
+      - "dist/"
+      - "LICENSE.md"
+      - "apps/app_sample.json"
+      - "templates"
+      - "middleware"
+      - "event_handlers/sample"
+      - "policies"
+      - "coprocess"
+      - "tyk.conf.example"
+  # Build tykio/tyk-gateway-ee ee (s390x)
+  - ids:
+      - ee-s390x
+    image_templates:
+      - "tykio/tyk-gateway-ee:{{.Tag}}-ee-s390x"
+    build_flag_templates:
+      - "--build-arg=PORTS=8080"
+      - "--build-arg=BUILD_PACKAGE_NAME=tyk-gateway-ee"
+      - "--platform=linux/s390x"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}} Enterprise Edition"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+    use: buildx
+    goarch: s390x
+    goos: linux
+    dockerfile: ci/Dockerfile.std
+    extra_files:
+      - "ci/install/"
+      - "README.md"
+      - "dist/"
+      - "LICENSE.md"
+      - "apps/app_sample.json"
+      - "templates"
+      - "middleware"
+      - "event_handlers/sample"
+      - "policies"
+      - "coprocess"
+      - "tyk.conf.example"
+  # Build tykio/tyk-gateway fips (amd64)
+  - ids:
+      - fips-amd64
+    image_templates:
+      - "tykio/tyk-gateway:{{.Tag}}-fips-amd64"
+    build_flag_templates:
+      - "--build-arg=PORTS=8080"
+      - "--build-arg=BUILD_PACKAGE_NAME=tyk-gateway-fips"
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}} FIPS"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+    use: buildx
+    goarch: amd64
+    goos: linux
+    dockerfile: ci/Dockerfile.std
+    extra_files:
+      - "ci/install/"
+      - "README.md"
+      - "dist/"
+      - "LICENSE.md"
+      - "apps/app_sample.json"
+      - "templates"
+      - "middleware"
+      - "event_handlers/sample"
+      - "policies"
+      - "coprocess"
+      - "tyk.conf.example"
+  # Build tykio/tyk-gateway fips (arm64)
+  - ids:
+      - fips-arm64
+    image_templates:
+      - "tykio/tyk-gateway:{{.Tag}}-fips-arm64"
+    build_flag_templates:
+      - "--build-arg=PORTS=8080"
+      - "--build-arg=BUILD_PACKAGE_NAME=tyk-gateway-fips"
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}} FIPS"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+    use: buildx
+    goarch: arm64
+    goos: linux
+    dockerfile: ci/Dockerfile.std
+    extra_files:
+      - "ci/install/"
+      - "README.md"
+      - "dist/"
+      - "LICENSE.md"
+      - "apps/app_sample.json"
+      - "templates"
+      - "middleware"
+      - "event_handlers/sample"
+      - "policies"
+      - "coprocess"
+      - "tyk.conf.example"
+  # Build tykio/tyk-gateway fips (s390x)
+  - ids:
+      - fips-s390x
+    image_templates:
+      - "tykio/tyk-gateway:{{.Tag}}-fips-s390x"
+    build_flag_templates:
+      - "--build-arg=PORTS=8080"
+      - "--build-arg=BUILD_PACKAGE_NAME=tyk-gateway-fips"
+      - "--platform=linux/s390x"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}} FIPS"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+    use: buildx
+    goarch: s390x
+    goos: linux
+    dockerfile: ci/Dockerfile.std
+    extra_files:
+      - "ci/install/"
+      - "README.md"
+      - "dist/"
+      - "LICENSE.md"
+      - "apps/app_sample.json"
+      - "templates"
+      - "middleware"
+      - "event_handlers/sample"
+      - "policies"
+      - "coprocess"
+      - "tyk.conf.example"
+  # Build tykio/tyk-gateway std (amd64)
+  - ids:
+      - std-amd64
+    image_templates:
+      - "tykio/tyk-gateway:{{.Tag}}-std-amd64"
+    build_flag_templates:
+      - "--build-arg=PORTS=8080"
+      - "--build-arg=BUILD_PACKAGE_NAME=tyk-gateway"
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+    use: buildx
+    goarch: amd64
+    goos: linux
+    dockerfile: ci/Dockerfile.std
+    extra_files:
+      - "ci/install/"
+      - "README.md"
+      - "dist/"
+      - "LICENSE.md"
+      - "apps/app_sample.json"
+      - "templates"
+      - "middleware"
+      - "event_handlers/sample"
+      - "policies"
+      - "coprocess"
+      - "tyk.conf.example"
+  # Build tykio/tyk-gateway std (arm64)
+  - ids:
+      - std-arm64
+    image_templates:
+      - "tykio/tyk-gateway:{{.Tag}}-std-arm64"
+    build_flag_templates:
+      - "--build-arg=PORTS=8080"
+      - "--build-arg=BUILD_PACKAGE_NAME=tyk-gateway"
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+    use: buildx
+    goarch: arm64
+    goos: linux
+    dockerfile: ci/Dockerfile.std
+    extra_files:
+      - "ci/install/"
+      - "README.md"
+      - "dist/"
+      - "LICENSE.md"
+      - "apps/app_sample.json"
+      - "templates"
+      - "middleware"
+      - "event_handlers/sample"
+      - "policies"
+      - "coprocess"
+      - "tyk.conf.example"
+  # Build tykio/tyk-gateway std (s390x)
+  - ids:
+      - std-s390x
+    image_templates:
+      - "tykio/tyk-gateway:{{.Tag}}-std-s390x"
+    build_flag_templates:
+      - "--build-arg=PORTS=8080"
+      - "--build-arg=BUILD_PACKAGE_NAME=tyk-gateway"
+      - "--platform=linux/s390x"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+    use: buildx
+    goarch: s390x
+    goos: linux
+    dockerfile: ci/Dockerfile.std
+    extra_files:
+      - "ci/install/"
+      - "README.md"
+      - "dist/"
+      - "LICENSE.md"
+      - "apps/app_sample.json"
+      - "templates"
+      - "middleware"
+      - "event_handlers/sample"
+      - "policies"
+      - "coprocess"
+      - "tyk.conf.example"
+docker_manifests:
+  # Multi-arch manifest for tykio/tyk-gateway-ee ee
+  - name_template: tykio/tyk-gateway-ee:{{ .Tag }}-ee
+    image_templates:
+      - tykio/tyk-gateway-ee:{{`{{ .Tag }}`}}-ee-amd64
+      - tykio/tyk-gateway-ee:{{`{{ .Tag }}`}}-ee-arm64
+      - tykio/tyk-gateway-ee:{{`{{ .Tag }}`}}-ee-s390x
+  - name_template: tykio/tyk-gateway-ee:v{{ .Major }}.{{ .Minor }}{{.Prerelease}}-ee
+    image_templates:
+      - tykio/tyk-gateway-ee:{{`{{ .Tag }}`}}-ee-amd64
+      - tykio/tyk-gateway-ee:{{`{{ .Tag }}`}}-ee-arm64
+      - tykio/tyk-gateway-ee:{{`{{ .Tag }}`}}-ee-s390x
+  - name_template: tykio/tyk-gateway-ee:v{{ .Major }}{{.Prerelease}}-ee
+    image_templates:
+      - tykio/tyk-gateway-ee:{{`{{ .Tag }}`}}-ee-amd64
+      - tykio/tyk-gateway-ee:{{`{{ .Tag }}`}}-ee-arm64
+      - tykio/tyk-gateway-ee:{{`{{ .Tag }}`}}-ee-s390x
+  # Multi-arch manifest for tykio/tyk-gateway fips
+  - name_template: tykio/tyk-gateway:{{ .Tag }}-fips
+    image_templates:
+      - tykio/tyk-gateway:{{`{{ .Tag }}`}}-fips-amd64
+      - tykio/tyk-gateway:{{`{{ .Tag }}`}}-fips-arm64
+      - tykio/tyk-gateway:{{`{{ .Tag }}`}}-fips-s390x
+  - name_template: tykio/tyk-gateway:v{{ .Major }}.{{ .Minor }}{{.Prerelease}}-fips
+    image_templates:
+      - tykio/tyk-gateway:{{`{{ .Tag }}`}}-fips-amd64
+      - tykio/tyk-gateway:{{`{{ .Tag }}`}}-fips-arm64
+      - tykio/tyk-gateway:{{`{{ .Tag }}`}}-fips-s390x
+  - name_template: tykio/tyk-gateway:v{{ .Major }}{{.Prerelease}}-fips
+    image_templates:
+      - tykio/tyk-gateway:{{`{{ .Tag }}`}}-fips-amd64
+      - tykio/tyk-gateway:{{`{{ .Tag }}`}}-fips-arm64
+      - tykio/tyk-gateway:{{`{{ .Tag }}`}}-fips-s390x
+  # Multi-arch manifest for tykio/tyk-gateway std
+  - name_template: tykio/tyk-gateway:{{ .Tag }}
+    image_templates:
+      - tykio/tyk-gateway:{{`{{ .Tag }}`}}-std-amd64
+      - tykio/tyk-gateway:{{`{{ .Tag }}`}}-std-arm64
+      - tykio/tyk-gateway:{{`{{ .Tag }}`}}-std-s390x
+  - name_template: tykio/tyk-gateway:v{{ .Major }}.{{ .Minor }}{{.Prerelease}}
+    image_templates:
+      - tykio/tyk-gateway:{{`{{ .Tag }}`}}-std-amd64
+      - tykio/tyk-gateway:{{`{{ .Tag }}`}}-std-arm64
+      - tykio/tyk-gateway:{{`{{ .Tag }}`}}-std-s390x
+  - name_template: tykio/tyk-gateway:v{{ .Major }}{{.Prerelease}}
+    image_templates:
+      - tykio/tyk-gateway:{{`{{ .Tag }}`}}-std-amd64
+      - tykio/tyk-gateway:{{`{{ .Tag }}`}}-std-arm64
+      - tykio/tyk-gateway:{{`{{ .Tag }}`}}-std-s390x
 # This disables archives
 archives:
   - formats: ['binary']


### PR DESCRIPTION
## Description

Auto generated changes by gromit to add fips compliant docker images to releases. These changes are in response to a customer request for fips compliant docker images. These are provided by using our existing fips binaries in a distroless image. THESE ARE NOT FIPS VALIDATED IMAGES. Tyk's FIPS documentation has been updated as a result of this request.

## Related Issue

[see this ticket](https://tyktech.atlassian.net/browse/TT-15334). A PR has also been made against branch `release-5.8` on `tyk-analytics`

## Motivation and Context

These images were request to be included in regular releases by a client.

## How This Has Been Tested

goreleaser was run locally, everything seems okay a fips image is built using the fips binary. More end to end testing is needed with the other fips components.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

- [x] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
