### PR TITLE
Merging to release-5.8: [TT-15869] cooldown defaults not working and minor datetime format adjustments (#7386)

### DIFF
--- a/gateway/event_handler_webhooks.go
+++ b/gateway/event_handler_webhooks.go
@@ -90,7 +90,11 @@ func (w *WebHookHandler) Init(handlerConf interface{}) error {
 			"target": w.conf.TargetPath,
 		}).Info("Loading default template.")
 		defaultPath := filepath.Join(w.Gw.GetConfig().TemplatePath, "default_webhook.json")
-		w.template, err = htmltemplate.ParseFiles(defaultPath)
+		w.template = htmltemplate.New("default_webhook.json").Funcs(htmltemplate.FuncMap{
+			"as_rfc3339":             templateFuncAsRFC3339(),
+			"as_rfc3339_from_string": templateFuncAsRFC3339FromString(log),
+		})
+		w.template, err = w.template.ParseFiles(defaultPath)
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "webhooks",
@@ -278,4 +282,29 @@ func (w *WebHookHandler) HandleEvent(em config.EventMessage) {
 	}
 
 	w.setHookFired(reqChecksum)
+}
+
+func templateFuncAsRFC3339() func(time.Time) string {
+	return func(t time.Time) string {
+		return t.Format(time.RFC3339)
+	}
+}
+
+func templateFuncAsRFC3339FromString(log *logrus.Logger) func(string) string {
+	return func(s string) string {
+		t, err := time.Parse("2006-01-02 15:04:05.999999 -0700 MST", s)
+		if err == nil {
+			return t.Format(time.RFC3339)
+		}
+
+		log.WithFields(logrus.Fields{
+			"prefix":   "webhooks",
+			"datetime": s,
+			"error":    err.Error(),
+		}).
+			Debug("Could not parse time to RFC3339 from string.")
+
+		// Fallback to the original string
+		return s
+	}
 }

--- a/gateway/event_handler_webhooks_test.go
+++ b/gateway/event_handler_webhooks_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	logrus "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/TykTechnologies/tyk/config"
@@ -333,4 +334,31 @@ func TestWebhookContentTypeHeader(t *testing.T) {
 		})
 	}
 
+}
+
+func TestWebhookTemplateFuncs(t *testing.T) {
+	t.Run("as_RFC3339", func(t *testing.T) {
+		asRFC3339Func := templateFuncAsRFC3339()
+		inputTime := time.Date(2025, 1, 2, 3, 4, 5, 6, time.UTC)
+		expected := "2025-01-02T03:04:05Z"
+		actual := asRFC3339Func(inputTime)
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("as_RFC3339_from_string", func(t *testing.T) {
+		noopLogger, _ := logrus.NewNullLogger()
+		asRFC3339FromStringFunc := templateFuncAsRFC3339FromString(noopLogger)
+
+		t.Run("invalid time", func(t *testing.T) {
+			input := "2025/01/02 03:04:05"
+			expected := "2025/01/02 03:04:05"
+			assert.Equal(t, expected, asRFC3339FromStringFunc(input))
+		})
+
+		t.Run("valid time", func(t *testing.T) {
+			input := "2025-01-02 03:04:05.999999 +0200 CEST"
+			expected := "2025-01-02T03:04:05+02:00"
+			assert.Equal(t, expected, asRFC3339FromStringFunc(input))
+		})
+	})
 }

--- a/internal/certcheck/batcher.go
+++ b/internal/certcheck/batcher.go
@@ -1,0 +1,430 @@
+package certcheck
+
+//go:generate mockgen -destination=./batcher_mock.go -package certcheck . Batcher,BackgroundBatcher
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/internal/event"
+	"github.com/TykTechnologies/tyk/internal/model"
+	"github.com/TykTechnologies/tyk/storage"
+)
+
+var (
+	// ErrFallbackCooldownCheckFailed is returned when the fallback cache is used, and the check cooldown cannot be checked.
+	ErrFallbackCooldownCheckFailed = errors.New("failed to check cooldown in fallback cache")
+)
+
+// Batch is a queue of certificates that are ready to be checked.
+type Batch struct {
+	lookupTable map[string]any
+	batchQueue  []CertInfo
+	mutex       sync.Mutex
+}
+
+// NewBatch creates a new Batch.
+func NewBatch() *Batch {
+	return &Batch{
+		lookupTable: make(map[string]any),
+		batchQueue:  make([]CertInfo, 0),
+		mutex:       sync.Mutex{},
+	}
+}
+
+// Append adds a certificate to the batch.
+func (b *Batch) Append(certInfo CertInfo) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	_, exists := b.lookupTable[certInfo.ID]
+	if exists {
+		return
+	}
+
+	b.lookupTable[certInfo.ID] = struct{}{}
+	b.batchQueue = append(b.batchQueue, certInfo)
+}
+
+// Size returns the number of certificates in the batch.
+func (b *Batch) Size() int {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+	return len(b.batchQueue)
+}
+
+// CopyAndClear returns a copy of the batch and clears the batch.
+func (b *Batch) CopyAndClear() []CertInfo {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	batchCopy := make([]CertInfo, len(b.batchQueue))
+	copy(batchCopy, b.batchQueue)
+
+	b.lookupTable = make(map[string]any)
+	b.batchQueue = b.batchQueue[:0]
+
+	return batchCopy
+}
+
+// Batcher processes and manages the addition of CertInfo objects, ensuring they are handled in a batch-like manner.
+type Batcher interface {
+	Add(cert CertInfo) error
+}
+
+// BackgroundBatcher is a Batcher that can be run in the background.
+type BackgroundBatcher interface {
+	Batcher
+	RunInBackground(ctx context.Context)
+	SetFlushInterval(time.Duration)
+}
+
+// CertificateExpiryCheckBatcher is a Batcher that checks certificates for expiry.
+type CertificateExpiryCheckBatcher struct {
+	logger                *logrus.Entry
+	apiMetaData           APIMetaData
+	config                config.CertificateExpiryMonitorConfig
+	batch                 *Batch
+	inMemoryCooldownCache CooldownCache
+	fallbackCooldownCache CooldownCache
+	flushTicker           *time.Ticker
+	fireEvent             FireEventFunc
+}
+
+// NewCertificateExpiryCheckBatcher creates a new CertificateExpiryCheckBatcher.
+func NewCertificateExpiryCheckBatcher(logger *logrus.Entry, apiMetaData APIMetaData, cfg config.CertificateExpiryMonitorConfig, fallbackStorage storage.Handler, eventFunc FireEventFunc) (*CertificateExpiryCheckBatcher, error) {
+	inMemoryCache, err := NewInMemoryCooldownCache()
+	if err != nil {
+		return nil, err
+	}
+
+	fallbackCache, err := NewRedisCooldownCache(fallbackStorage)
+	if err != nil {
+		return nil, err
+	}
+
+	logger = logger.WithField("api_id", apiMetaData.APIID).
+		WithField("api_name", apiMetaData.APIName).
+		WithField("task", "CertificateExpiryMonitorTask")
+
+	return &CertificateExpiryCheckBatcher{
+		logger:                logger,
+		apiMetaData:           apiMetaData,
+		config:                applyConfigDefaults(cfg),
+		batch:                 NewBatch(),
+		inMemoryCooldownCache: inMemoryCache,
+		fallbackCooldownCache: fallbackCache,
+		flushTicker:           time.NewTicker(30 * time.Second),
+		fireEvent:             eventFunc,
+	}, nil
+}
+
+// Add adds a certificate to the batch.
+func (c *CertificateExpiryCheckBatcher) Add(cert CertInfo) error {
+	c.batch.Append(cert)
+	return nil
+}
+
+// RunInBackground runs the batcher in the background.
+func (c *CertificateExpiryCheckBatcher) RunInBackground(ctx context.Context) {
+	for {
+		c.logger.
+			WithField("batch_size", c.batch.Size()).
+			Debug("Flush certificate expiry monitor batch")
+
+		batchCopy := c.batch.CopyAndClear()
+		for _, certInfo := range batchCopy {
+			existsInLocalCache := c.checkCooldownExistsInLocalCache(certInfo)
+			checkCooldownIsActive, err := c.isCheckCooldownActive(certInfo, existsInLocalCache)
+			if err != nil {
+				c.logger.
+					WithField("certID", certInfo.ID[:8]).
+					WithField("cooldown", "check").
+					WithError(err).
+					Error("Failed to check cooldown - skipping certificate")
+				continue
+			}
+
+			if checkCooldownIsActive {
+				continue
+			}
+
+			isExpired := c.isCertificateExpired(certInfo)
+			isExpiringSoon := c.isCertificateExpiringSoon(certInfo)
+			if isExpired || isExpiringSoon {
+				c.handleEventForCertificate(certInfo, isExpired)
+			}
+
+			c.setCheckCooldown(certInfo)
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-c.flushTicker.C:
+			continue
+		}
+	}
+}
+
+// SetFlushInterval sets the interval at which the batcher will flush the batch.
+func (c *CertificateExpiryCheckBatcher) SetFlushInterval(interval time.Duration) {
+	c.flushTicker.Reset(interval)
+}
+
+func (c *CertificateExpiryCheckBatcher) checkCooldownExistsInLocalCache(certInfo CertInfo) (exists bool) {
+	var err error
+	exists, err = c.inMemoryCooldownCache.HasCheckCooldown(certInfo.ID)
+	if err != nil {
+		c.logger.WithError(err).
+			WithField("certID", certInfo.ID[:8]).
+			WithField("cooldown", "check").
+			Error("Failed to check if check cooldown exists in in-memory cache")
+	}
+	return exists
+}
+
+func (c *CertificateExpiryCheckBatcher) isCheckCooldownActive(certInfo CertInfo, foundInLocalCache bool) (bool, error) {
+	checkCooldownActive := false
+	fallback := false
+	if foundInLocalCache {
+		var err error
+		checkCooldownActive, err = c.inMemoryCooldownCache.IsCheckCooldownActive(certInfo.ID)
+		if err != nil {
+			fallback = true
+			c.logger.
+				WithError(err).
+				WithField("certID", certInfo.ID[:8]).
+				WithField("cooldown", "check").
+				Error("Failed to check if check cooldown is active in in-memory cache")
+		}
+	}
+
+	if !foundInLocalCache || fallback {
+		var err error
+		checkCooldownActive, err = c.fallbackCooldownCache.IsCheckCooldownActive(certInfo.ID)
+		if err != nil {
+			c.logger.
+				WithError(err).
+				WithField("certID", certInfo.ID[:8]).
+				WithField("cooldown", "check").
+				Error("Failed to check if check cooldown is active in fallback cache")
+			return false, ErrFallbackCooldownCheckFailed
+		}
+	}
+
+	return checkCooldownActive, nil
+}
+
+func (c *CertificateExpiryCheckBatcher) setCheckCooldown(certInfo CertInfo) {
+	err := c.inMemoryCooldownCache.SetCheckCooldown(certInfo.ID, int64(c.config.CheckCooldownSeconds))
+	if err != nil {
+		c.logger.WithError(err).
+			WithField("certID", certInfo.ID[:8]).
+			WithField("cooldown", "check").
+			Error("Failed to set check cooldown for certificate in in-memory cache")
+	}
+	err = c.fallbackCooldownCache.SetCheckCooldown(certInfo.ID, int64(c.config.CheckCooldownSeconds))
+	if err != nil {
+		c.logger.WithError(err).
+			WithField("certID", certInfo.ID[:8]).
+			WithField("cooldown", "check").
+			Error("Failed to set check cooldown for certificate in fallback cache")
+	}
+}
+
+func (c *CertificateExpiryCheckBatcher) isCertificateExpired(certInfo CertInfo) bool {
+	return certInfo.UntilExpiry <= 0
+}
+
+func (c *CertificateExpiryCheckBatcher) isCertificateExpiringSoon(certInfo CertInfo) bool {
+	warningThresholdDays := c.config.WarningThresholdDays
+
+	if warningThresholdDays == 0 {
+		warningThresholdDays = config.DefaultWarningThresholdDays
+	}
+
+	warningThresholdDuration := time.Duration(warningThresholdDays) * 24 * time.Hour // Convert days to duration
+
+	// Certificate is expiring soon if it hasn't expired yet and is within the warning threshold
+	return certInfo.UntilExpiry > 0 && certInfo.UntilExpiry <= warningThresholdDuration
+}
+
+func (c *CertificateExpiryCheckBatcher) handleEventForCertificate(certInfo CertInfo, isExpired bool) {
+	exists := c.fireEventCooldownExistsInLocalCache(certInfo)
+	isFireEventCooldownActive, err := c.isFireEventCooldownActive(certInfo, exists)
+	if err != nil {
+		c.logger.
+			WithField("certID", certInfo.ID[:8]).
+			WithField("cooldown", "fireEvent").
+			WithError(err).
+			Error("Failed to check cooldown - skipping certificate")
+		return
+	}
+
+	if isFireEventCooldownActive {
+		return
+	}
+
+	if isExpired {
+		c.handleEventForExpiredCertificate(certInfo)
+	} else {
+		c.handleEventForSoonToExpireCertificate(certInfo)
+	}
+
+	c.setFireEventCooldown(certInfo)
+}
+
+func (c *CertificateExpiryCheckBatcher) handleEventForExpiredCertificate(certInfo CertInfo) {
+	// Calculate days and hours since expiry (negative duration)
+	daysSinceExpiry := certInfo.DaysUntilExpiry() * -1
+	hoursSinceExpiry := (certInfo.HoursUntilExpiry() % -24) * -1
+
+	eventMeta := EventCertificateExpiredMeta{
+		EventMetaDefault: model.EventMetaDefault{
+			Message: c.composeExpiredMessage(certInfo, daysSinceExpiry, hoursSinceExpiry),
+		},
+		CertID:          certInfo.ID,
+		CertName:        certInfo.CommonName,
+		ExpiredAt:       certInfo.NotAfter,
+		DaysSinceExpiry: daysSinceExpiry,
+		APIID:           c.apiMetaData.APIID,
+	}
+
+	c.fireEvent(event.CertificateExpired, eventMeta)
+	c.logger.
+		WithField("cert_id", certInfo.ID[:8]).
+		WithField("event_type", string(event.CertificateExpired)).
+		Debugf("EXPIRY EVENT FIRED for certificate '%s' - expired since %d hours", certInfo.CommonName, certInfo.HoursUntilExpiry())
+}
+
+func (c *CertificateExpiryCheckBatcher) handleEventForSoonToExpireCertificate(certInfo CertInfo) {
+	daysUntilExpiry := certInfo.DaysUntilExpiry()
+	remainingHours := int(certInfo.HoursUntilExpiry()) % 24
+
+	eventMeta := EventCertificateExpiringSoonMeta{
+		EventMetaDefault: model.EventMetaDefault{
+			Message: c.composeSoonToExpireMessage(certInfo, daysUntilExpiry, remainingHours),
+		},
+		CertID:        certInfo.ID,
+		CertName:      certInfo.CommonName,
+		ExpiresAt:     certInfo.NotAfter,
+		DaysRemaining: daysUntilExpiry,
+		APIID:         c.apiMetaData.APIID,
+	}
+
+	c.fireEvent(event.CertificateExpiringSoon, eventMeta)
+	c.logger.
+		WithField("cert_id", certInfo.ID[:8]).
+		WithField("event_type", string(event.CertificateExpiringSoon)).
+		Debugf("EXPIRY EVENT FIRED for certificate '%s' - expires in %d hours", certInfo.CommonName, certInfo.HoursUntilExpiry())
+}
+
+func (c *CertificateExpiryCheckBatcher) fireEventCooldownExistsInLocalCache(certInfo CertInfo) (exists bool) {
+	var err error
+	exists, err = c.inMemoryCooldownCache.HasFireEventCooldown(certInfo.ID)
+	if err != nil {
+		c.logger.WithError(err).
+			WithField("certID", certInfo.ID[:8]).
+			WithField("cooldown", "fireEvent").
+			Error("failed to check if fire event cooldown exists in in-memory cache")
+	}
+	return exists
+}
+
+func (c *CertificateExpiryCheckBatcher) isFireEventCooldownActive(certInfo CertInfo, foundInLocalCache bool) (bool, error) {
+	fireEventCooldownActive := false
+	useFallback := false
+
+	if foundInLocalCache {
+		var err error
+		fireEventCooldownActive, err = c.inMemoryCooldownCache.IsFireEventCooldownActive(certInfo.ID)
+		if err != nil {
+			c.logger.
+				WithError(err).
+				WithField("certID", certInfo.ID[:8]).
+				WithField("cooldown", "fireEvent").
+				Error("Failed to check if fire event cooldown is active in in-memory cache")
+			useFallback = true
+		}
+	}
+
+	if !foundInLocalCache || useFallback {
+		var err error
+		fireEventCooldownActive, err = c.fallbackCooldownCache.IsFireEventCooldownActive(certInfo.ID)
+		if err != nil {
+			c.logger.
+				WithError(err).
+				WithField("certID", certInfo.ID[:8]).
+				WithField("cooldown", "fireEvent").
+				Error("Failed to check if fire event cooldown is active in fallback cache")
+
+			return false, ErrFallbackCooldownCheckFailed
+		}
+	}
+	return fireEventCooldownActive, nil
+}
+
+func (c *CertificateExpiryCheckBatcher) setFireEventCooldown(certInfo CertInfo) {
+	err := c.inMemoryCooldownCache.SetFireEventCooldown(certInfo.ID, int64(c.config.EventCooldownSeconds))
+	if err != nil {
+		c.logger.WithError(err).
+			WithField("certID", certInfo.ID[:8]).
+			WithField("cooldown", "fireEvent").
+			Error("Failed to set fire event cooldown for certificate in in-memory cache")
+	}
+	err = c.fallbackCooldownCache.SetFireEventCooldown(certInfo.ID, int64(c.config.EventCooldownSeconds))
+	if err != nil {
+		c.logger.WithError(err).
+			WithField("certID", certInfo.ID[:8]).
+			WithField("cooldown", "fireEvent").
+			Error("Failed to set fire event cooldown for certificate in fallback cache")
+	}
+}
+
+func (c *CertificateExpiryCheckBatcher) composeSoonToExpireMessage(certInfo CertInfo, daysUntilExpiry int, remainingHours int) string {
+	if daysUntilExpiry > 0 {
+		if remainingHours > 0 {
+			return fmt.Sprintf("Certificate %s is expiring in %d days and %d hours", certInfo.CommonName, daysUntilExpiry, remainingHours)
+		} else {
+			return fmt.Sprintf("Certificate %s is expiring in %d days", certInfo.CommonName, daysUntilExpiry)
+		}
+	}
+	return fmt.Sprintf("Certificate %s is expiring in %d hours", certInfo.CommonName, remainingHours)
+}
+
+func (c *CertificateExpiryCheckBatcher) composeExpiredMessage(certInfo CertInfo, daysSinceExpiry int, hoursSinceExpiry int) string {
+	if daysSinceExpiry > 0 {
+		if hoursSinceExpiry > 0 {
+			return fmt.Sprintf("Certificate %s is expired since %d days and %d hours", certInfo.CommonName, daysSinceExpiry, hoursSinceExpiry)
+		} else {
+			return fmt.Sprintf("Certificate %s is expired since %d days", certInfo.CommonName, daysSinceExpiry)
+		}
+	}
+	return fmt.Sprintf("Certificate %s is expired since %d hours", certInfo.CommonName, hoursSinceExpiry)
+}
+
+func applyConfigDefaults(cfg config.CertificateExpiryMonitorConfig) config.CertificateExpiryMonitorConfig {
+	if cfg.WarningThresholdDays == 0 {
+		cfg.WarningThresholdDays = config.DefaultWarningThresholdDays
+	}
+
+	if cfg.CheckCooldownSeconds == 0 {
+		cfg.CheckCooldownSeconds = config.DefaultCheckCooldownSeconds
+	}
+
+	if cfg.EventCooldownSeconds == 0 {
+		cfg.EventCooldownSeconds = config.DefaultEventCooldownSeconds
+	}
+
+	return cfg
+}
+
+// Interface Guards
+var _ BackgroundBatcher = (*CertificateExpiryCheckBatcher)(nil)

--- a/internal/certcheck/batcher_test.go
+++ b/internal/certcheck/batcher_test.go
@@ -1,0 +1,1519 @@
+package certcheck
+
+import (
+	"context"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/internal/crypto"
+	"github.com/TykTechnologies/tyk/internal/event"
+	"github.com/TykTechnologies/tyk/internal/model"
+
+	storagemock "github.com/TykTechnologies/tyk/storage/mock"
+)
+
+var testApiMetaData = APIMetaData{
+	APIID:   "123abc",
+	APIName: "API",
+}
+
+// createTestCertInfo creates a CertInfo from a real x509 certificate with the specified expiry time
+func createTestCertInfo(t *testing.T, commonName string, notAfter time.Time) CertInfo {
+	t.Helper()
+
+	// Create a real x509 certificate
+	_, _, _, tlsCert := crypto.GenCertificate(&x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: commonName,
+		},
+		NotBefore:   time.Now().Add(-time.Hour), // Valid from 1 hour ago
+		NotAfter:    notAfter,
+		KeyUsage:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}, true)
+
+	// Calculate the ID using the same method as the real code
+	certID := crypto.HexSHA256(tlsCert.Leaf.Raw)
+
+	// Calculate duration until expiry using the same method as the real code
+	untilExpiry := time.Until(notAfter)
+
+	return CertInfo{
+		ID:          certID,
+		CommonName:  tlsCert.Leaf.Subject.CommonName,
+		NotAfter:    tlsCert.Leaf.NotAfter,
+		UntilExpiry: untilExpiry,
+	}
+}
+
+type BatcherMocks struct {
+	ctrl              *gomock.Controller
+	logger            *logrus.Entry
+	redisStorageMock  *storagemock.MockHandler
+	localCacheMock    *MockCooldownCache
+	fallbackCacheMock *MockCooldownCache
+}
+
+func TestBatch(t *testing.T) {
+	batch := NewBatch()
+	assert.Equal(t, 0, batch.Size())
+
+	firstCert := CertInfo{ID: "first"}
+	secondCert := CertInfo{ID: "second"}
+
+	batch.Append(firstCert)
+	batch.Append(secondCert)
+	batch.Append(firstCert)
+	assert.Equal(t, 2, batch.Size())
+
+	copiedBatch := batch.CopyAndClear()
+	assert.Equal(t, 2, len(copiedBatch))
+	assert.Equal(t, firstCert.ID, copiedBatch[0].ID)
+	assert.Equal(t, secondCert.ID, copiedBatch[1].ID)
+	assert.Equal(t, 0, batch.Size())
+
+}
+
+func TestNewCertificateExpiryCheckBatcher_Add(t *testing.T) {
+	ctrl, batcherMocks := createBatcherMocks(t)
+	t.Cleanup(ctrl.Finish)
+
+	batcher, err := NewCertificateExpiryCheckBatcher(batcherMocks.logger, testApiMetaData, config.CertificateExpiryMonitorConfig{}, batcherMocks.redisStorageMock, nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, batcher.batch.Size())
+
+	err = batcher.Add(CertInfo{ID: "first"})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, batcher.batch.Size())
+}
+
+func TestCertificateExpiryCheckBatcher(t *testing.T) {
+	t.Run("With check cooldown", func(t *testing.T) {
+		t.Run("Should skip event firing checks when the check cooldown is active in local cache", func(t *testing.T) {
+			ctrl, batcherMocks := createBatcherMocks(t)
+			t.Cleanup(ctrl.Finish)
+
+			expiryCheckConfig := config.CertificateExpiryMonitorConfig{
+				WarningThresholdDays: 30,
+				CheckCooldownSeconds: 60,
+				EventCooldownSeconds: 60,
+			}
+
+			batcher, err := NewCertificateExpiryCheckBatcher(batcherMocks.logger, testApiMetaData, expiryCheckConfig, batcherMocks.redisStorageMock, nil)
+			require.NoError(t, err)
+
+			batcher.inMemoryCooldownCache = batcherMocks.localCacheMock
+			batcher.fallbackCooldownCache = batcherMocks.fallbackCacheMock
+			batcher.flushTicker = time.NewTicker(10 * time.Millisecond)
+
+			err = batcher.Add(CertInfo{ID: "test-cert-id"})
+			require.NoError(t, err)
+
+			batcherMocks.localCacheMock.EXPECT().HasCheckCooldown("test-cert-id").
+				Return(true, nil)
+
+			batcherMocks.localCacheMock.EXPECT().IsCheckCooldownActive("test-cert-id").
+				Return(true, nil)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			go batcher.RunInBackground(ctx)
+
+			cancel()
+			require.Eventuallyf(t, func() bool {
+				<-ctx.Done()
+				return true
+			}, 5*time.Second, 100*time.Millisecond, "batcher background context was not canceled")
+		})
+
+		t.Run("Should fallback if local cache check fails on initial key check", func(t *testing.T) {
+			ctrl, batcherMocks := createBatcherMocks(t)
+			t.Cleanup(ctrl.Finish)
+
+			expiryCheckConfig := config.CertificateExpiryMonitorConfig{
+				WarningThresholdDays: 30,
+				CheckCooldownSeconds: 60,
+				EventCooldownSeconds: 60,
+			}
+
+			batcher, err := NewCertificateExpiryCheckBatcher(batcherMocks.logger, testApiMetaData, expiryCheckConfig, batcherMocks.redisStorageMock, nil)
+			require.NoError(t, err)
+
+			batcher.inMemoryCooldownCache = batcherMocks.localCacheMock
+			batcher.fallbackCooldownCache = batcherMocks.fallbackCacheMock
+			batcher.flushTicker = time.NewTicker(10 * time.Millisecond)
+
+			err = batcher.Add(CertInfo{ID: "test-cert-id"})
+			require.NoError(t, err)
+
+			batcherMocks.localCacheMock.EXPECT().HasCheckCooldown("test-cert-id").
+				Return(false, errors.New("test error"))
+
+			batcherMocks.fallbackCacheMock.EXPECT().IsCheckCooldownActive("test-cert-id").
+				Return(true, nil)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			go batcher.RunInBackground(ctx)
+
+			cancel()
+			require.Eventuallyf(t, func() bool {
+				<-ctx.Done()
+				return true
+			}, 5*time.Second, 100*time.Millisecond, "batcher background context was not canceled")
+		})
+
+		t.Run("Should fallback if local cache check fails on actual value check", func(t *testing.T) {
+			ctrl, batcherMocks := createBatcherMocks(t)
+			t.Cleanup(ctrl.Finish)
+
+			expiryCheckConfig := config.CertificateExpiryMonitorConfig{
+				WarningThresholdDays: 30,
+				CheckCooldownSeconds: 60,
+				EventCooldownSeconds: 60,
+			}
+
+			batcher, err := NewCertificateExpiryCheckBatcher(batcherMocks.logger, testApiMetaData, expiryCheckConfig, batcherMocks.redisStorageMock, nil)
+			require.NoError(t, err)
+
+			batcher.inMemoryCooldownCache = batcherMocks.localCacheMock
+			batcher.fallbackCooldownCache = batcherMocks.fallbackCacheMock
+			batcher.flushTicker = time.NewTicker(10 * time.Millisecond)
+
+			err = batcher.Add(CertInfo{ID: "test-cert-id"})
+			require.NoError(t, err)
+
+			batcherMocks.localCacheMock.EXPECT().HasCheckCooldown("test-cert-id").
+				Return(true, nil)
+
+			batcherMocks.localCacheMock.EXPECT().IsCheckCooldownActive("test-cert-id").
+				Return(false, errors.New("local cache error"))
+
+			batcherMocks.fallbackCacheMock.EXPECT().IsCheckCooldownActive("test-cert-id").
+				Return(true, nil)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			go batcher.RunInBackground(ctx)
+
+			cancel()
+			require.Eventuallyf(t, func() bool {
+				<-ctx.Done()
+				return true
+			}, 5*time.Second, 100*time.Millisecond, "batcher background context was not canceled")
+		})
+
+		t.Run("Should skip certificate if fallback fails too", func(t *testing.T) {
+			ctrl, batcherMocks := createBatcherMocks(t)
+			t.Cleanup(ctrl.Finish)
+
+			expiryCheckConfig := config.CertificateExpiryMonitorConfig{
+				WarningThresholdDays: 30,
+				CheckCooldownSeconds: 60,
+				EventCooldownSeconds: 60,
+			}
+
+			batcher, err := NewCertificateExpiryCheckBatcher(batcherMocks.logger, testApiMetaData, expiryCheckConfig, batcherMocks.redisStorageMock, nil)
+			require.NoError(t, err)
+
+			batcher.inMemoryCooldownCache = batcherMocks.localCacheMock
+			batcher.fallbackCooldownCache = batcherMocks.fallbackCacheMock
+			batcher.flushTicker = time.NewTicker(10 * time.Millisecond)
+
+			err = batcher.Add(CertInfo{ID: "test-cert-id"})
+			require.NoError(t, err)
+
+			batcherMocks.localCacheMock.EXPECT().HasCheckCooldown("test-cert-id").
+				Return(false, nil)
+
+			batcherMocks.fallbackCacheMock.EXPECT().IsCheckCooldownActive("test-cert-id").
+				Return(false, errors.New("fallback cache error"))
+
+			ctx, cancel := context.WithCancel(context.Background())
+			go batcher.RunInBackground(ctx)
+
+			cancel()
+			require.Eventuallyf(t, func() bool {
+				<-ctx.Done()
+				return true
+			}, 5*time.Second, 100*time.Millisecond, "batcher background context was not canceled")
+		})
+	})
+
+	t.Run("With fire event cooldown", func(t *testing.T) {
+		t.Run("And cooldown is active", func(t *testing.T) {
+			t.Run("Should skip event firing but check for its cooldown in local cache", func(t *testing.T) {
+				ctrl, batcherMocks := createBatcherMocks(t)
+				t.Cleanup(ctrl.Finish)
+
+				expiryCheckConfig := config.CertificateExpiryMonitorConfig{
+					WarningThresholdDays: 30,
+					CheckCooldownSeconds: 60,
+					EventCooldownSeconds: 120,
+				}
+
+				batcher, err := NewCertificateExpiryCheckBatcher(batcherMocks.logger, testApiMetaData, expiryCheckConfig, batcherMocks.redisStorageMock, nil)
+				require.NoError(t, err)
+
+				batcher.inMemoryCooldownCache = batcherMocks.localCacheMock
+				batcher.fallbackCooldownCache = batcherMocks.fallbackCacheMock
+				batcher.flushTicker = time.NewTicker(10 * time.Millisecond)
+
+				err = batcher.Add(CertInfo{ID: "test-cert-id"})
+				require.NoError(t, err)
+
+				batcherMocks.localCacheMock.EXPECT().HasCheckCooldown("test-cert-id").
+					Return(true, nil)
+
+				batcherMocks.localCacheMock.EXPECT().IsCheckCooldownActive("test-cert-id").
+					Return(false, nil)
+
+				batcherMocks.localCacheMock.EXPECT().HasFireEventCooldown("test-cert-id").
+					Return(true, nil)
+
+				batcherMocks.localCacheMock.EXPECT().IsFireEventCooldownActive("test-cert-id").
+					Return(true, nil)
+
+				batcherMocks.localCacheMock.EXPECT().SetCheckCooldown("test-cert-id", int64(60)).
+					Return(nil)
+
+				batcherMocks.fallbackCacheMock.EXPECT().SetCheckCooldown("test-cert-id", int64(60)).
+					Return(nil)
+
+				ctx, cancel := context.WithCancel(context.Background())
+				go batcher.RunInBackground(ctx)
+
+				cancel()
+				require.Eventuallyf(t, func() bool {
+					<-ctx.Done()
+					return true
+				}, 5*time.Second, 100*time.Millisecond, "batcher background context was not canceled")
+			})
+
+			t.Run("Should skip event firing but check for its cooldown in fallback cache when initial lookup in local cache fails", func(t *testing.T) {
+				ctrl, batcherMocks := createBatcherMocks(t)
+				t.Cleanup(ctrl.Finish)
+
+				expiryCheckConfig := config.CertificateExpiryMonitorConfig{
+					WarningThresholdDays: 30,
+					CheckCooldownSeconds: 60,
+					EventCooldownSeconds: 120,
+				}
+
+				batcher, err := NewCertificateExpiryCheckBatcher(batcherMocks.logger, testApiMetaData, expiryCheckConfig, batcherMocks.redisStorageMock, nil)
+				require.NoError(t, err)
+
+				batcher.inMemoryCooldownCache = batcherMocks.localCacheMock
+				batcher.fallbackCooldownCache = batcherMocks.fallbackCacheMock
+				batcher.flushTicker = time.NewTicker(10 * time.Millisecond)
+
+				err = batcher.Add(CertInfo{ID: "test-cert-id"})
+				require.NoError(t, err)
+
+				batcherMocks.localCacheMock.EXPECT().HasCheckCooldown("test-cert-id").
+					Return(true, nil)
+
+				batcherMocks.localCacheMock.EXPECT().IsCheckCooldownActive("test-cert-id").
+					Return(false, nil)
+
+				batcherMocks.localCacheMock.EXPECT().HasFireEventCooldown("test-cert-id").
+					Return(false, errors.New("local cache error"))
+
+				batcherMocks.fallbackCacheMock.EXPECT().IsFireEventCooldownActive("test-cert-id").
+					Return(true, nil)
+
+				batcherMocks.localCacheMock.EXPECT().SetCheckCooldown("test-cert-id", int64(60)).
+					Return(nil)
+
+				batcherMocks.fallbackCacheMock.EXPECT().SetCheckCooldown("test-cert-id", int64(60)).
+					Return(nil)
+
+				ctx, cancel := context.WithCancel(context.Background())
+				go batcher.RunInBackground(ctx)
+
+				cancel()
+				require.Eventuallyf(t, func() bool {
+					<-ctx.Done()
+					return true
+				}, 5*time.Second, 100*time.Millisecond, "batcher background context was not canceled")
+			})
+
+			t.Run("Should skip event firing but check for its cooldown in fallback cache when value retrieval in local cache fails", func(t *testing.T) {
+				ctrl, batcherMocks := createBatcherMocks(t)
+				t.Cleanup(ctrl.Finish)
+
+				expiryCheckConfig := config.CertificateExpiryMonitorConfig{
+					WarningThresholdDays: 30,
+					CheckCooldownSeconds: 60,
+					EventCooldownSeconds: 120,
+				}
+
+				batcher, err := NewCertificateExpiryCheckBatcher(batcherMocks.logger, testApiMetaData, expiryCheckConfig, batcherMocks.redisStorageMock, nil)
+				require.NoError(t, err)
+
+				batcher.inMemoryCooldownCache = batcherMocks.localCacheMock
+				batcher.fallbackCooldownCache = batcherMocks.fallbackCacheMock
+				batcher.flushTicker = time.NewTicker(10 * time.Millisecond)
+
+				err = batcher.Add(CertInfo{ID: "test-cert-id"})
+				require.NoError(t, err)
+
+				batcherMocks.localCacheMock.EXPECT().HasCheckCooldown("test-cert-id").
+					Return(true, nil)
+
+				batcherMocks.localCacheMock.EXPECT().IsCheckCooldownActive("test-cert-id").
+					Return(false, nil)
+
+				batcherMocks.localCacheMock.EXPECT().HasFireEventCooldown("test-cert-id").
+					Return(true, nil)
+
+				batcherMocks.localCacheMock.EXPECT().IsFireEventCooldownActive("test-cert-id").
+					Return(false, errors.New("local cache error"))
+
+				batcherMocks.fallbackCacheMock.EXPECT().IsFireEventCooldownActive("test-cert-id").
+					Return(true, nil)
+
+				batcherMocks.localCacheMock.EXPECT().SetCheckCooldown("test-cert-id", int64(60)).
+					Return(nil)
+
+				batcherMocks.fallbackCacheMock.EXPECT().SetCheckCooldown("test-cert-id", int64(60)).
+					Return(nil)
+
+				ctx, cancel := context.WithCancel(context.Background())
+				go batcher.RunInBackground(ctx)
+
+				cancel()
+				require.Eventuallyf(t, func() bool {
+					<-ctx.Done()
+					return true
+				}, 5*time.Second, 100*time.Millisecond, "batcher background context was not canceled")
+			})
+
+			t.Run("Should skip event firing when local cache and fallback cache fail", func(t *testing.T) {
+				ctrl, batcherMocks := createBatcherMocks(t)
+				t.Cleanup(ctrl.Finish)
+
+				expiryCheckConfig := config.CertificateExpiryMonitorConfig{
+					WarningThresholdDays: 30,
+					CheckCooldownSeconds: 60,
+					EventCooldownSeconds: 120,
+				}
+
+				batcher, err := NewCertificateExpiryCheckBatcher(batcherMocks.logger, testApiMetaData, expiryCheckConfig, batcherMocks.redisStorageMock, nil)
+				require.NoError(t, err)
+
+				batcher.inMemoryCooldownCache = batcherMocks.localCacheMock
+				batcher.fallbackCooldownCache = batcherMocks.fallbackCacheMock
+				batcher.flushTicker = time.NewTicker(10 * time.Millisecond)
+
+				err = batcher.Add(CertInfo{ID: "test-cert-id"})
+				require.NoError(t, err)
+
+				batcherMocks.localCacheMock.EXPECT().HasCheckCooldown("test-cert-id").
+					Return(true, nil)
+
+				batcherMocks.localCacheMock.EXPECT().IsCheckCooldownActive("test-cert-id").
+					Return(false, nil)
+
+				batcherMocks.localCacheMock.EXPECT().HasFireEventCooldown("test-cert-id").
+					Return(true, nil)
+
+				batcherMocks.localCacheMock.EXPECT().IsFireEventCooldownActive("test-cert-id").
+					Return(false, errors.New("local cache error"))
+
+				batcherMocks.fallbackCacheMock.EXPECT().IsFireEventCooldownActive("test-cert-id").
+					Return(false, errors.New("fallback cache error"))
+
+				batcherMocks.localCacheMock.EXPECT().SetCheckCooldown("test-cert-id", int64(60)).
+					Return(nil)
+
+				batcherMocks.fallbackCacheMock.EXPECT().SetCheckCooldown("test-cert-id", int64(60)).
+					Return(nil)
+
+				ctx, cancel := context.WithCancel(context.Background())
+				go batcher.RunInBackground(ctx)
+
+				cancel()
+				require.Eventuallyf(t, func() bool {
+					<-ctx.Done()
+					return true
+				}, 5*time.Second, 100*time.Millisecond, "batcher background context was not canceled")
+			})
+		})
+
+		t.Run("And cooldown is inactive", func(t *testing.T) {
+			t.Run("Should not fire event when certificate is not expired or soon to expire", func(t *testing.T) {
+				ctrl, batcherMocks := createBatcherMocks(t)
+				t.Cleanup(ctrl.Finish)
+
+				expiryCheckConfig := config.CertificateExpiryMonitorConfig{
+					WarningThresholdDays: 1,
+					CheckCooldownSeconds: 60,
+					EventCooldownSeconds: 120,
+				}
+
+				batcher, err := NewCertificateExpiryCheckBatcher(batcherMocks.logger, testApiMetaData, expiryCheckConfig, batcherMocks.redisStorageMock, nil)
+				require.NoError(t, err)
+
+				batcher.inMemoryCooldownCache = batcherMocks.localCacheMock
+				batcher.fallbackCooldownCache = batcherMocks.fallbackCacheMock
+				batcher.flushTicker = time.NewTicker(10 * time.Millisecond)
+
+				now := time.Now()
+				expiry := now.Add(48 * time.Hour)
+				err = batcher.Add(CertInfo{
+					ID:          "test-cert-id",
+					UntilExpiry: 48 * time.Hour, // 48 hours
+					NotAfter:    expiry,
+					CommonName:  "test-cert",
+				})
+				require.NoError(t, err)
+
+				batcherMocks.localCacheMock.EXPECT().HasCheckCooldown("test-cert-id").
+					Return(true, nil)
+
+				batcherMocks.localCacheMock.EXPECT().IsCheckCooldownActive("test-cert-id").
+					Return(false, nil)
+
+				batcherMocks.localCacheMock.EXPECT().SetCheckCooldown("test-cert-id", int64(60)).
+					Return(nil)
+
+				batcherMocks.fallbackCacheMock.EXPECT().SetCheckCooldown("test-cert-id", int64(60)).
+					Return(nil)
+
+				ctx, cancel := context.WithCancel(context.Background())
+				go batcher.RunInBackground(ctx)
+
+				cancel()
+				require.Eventuallyf(t, func() bool {
+					<-ctx.Done()
+					return true
+				}, 5*time.Second, 100*time.Millisecond, "batcher background context was not canceled")
+			})
+
+			t.Run("Should fire event when certificate is expired", func(t *testing.T) {
+				var actualFiredEvent event.Event
+				var actualEventMeta EventCertificateExpiredMeta
+				fireEvent := func(event event.Event, meta any) {
+					actualFiredEvent = event
+					actualEventMeta = meta.(EventCertificateExpiredMeta)
+				}
+
+				ctrl, batcherMocks := createBatcherMocks(t)
+				t.Cleanup(ctrl.Finish)
+
+				expiryCheckConfig := config.CertificateExpiryMonitorConfig{
+					// Let's not provide WarningThresholdDays to test the default fallback
+					CheckCooldownSeconds: 60,
+					EventCooldownSeconds: 120,
+				}
+
+				batcher, err := NewCertificateExpiryCheckBatcher(batcherMocks.logger, testApiMetaData, expiryCheckConfig, batcherMocks.redisStorageMock, fireEvent)
+				require.NoError(t, err)
+
+				batcher.inMemoryCooldownCache = batcherMocks.localCacheMock
+				batcher.fallbackCooldownCache = batcherMocks.fallbackCacheMock
+				batcher.flushTicker = time.NewTicker(10 * time.Millisecond)
+
+				now := time.Now()
+				expiredSince := now.Add(-50 * time.Hour)
+				err = batcher.Add(CertInfo{
+					ID:          "test-cert-id",
+					UntilExpiry: -50 * time.Hour, // -50 hours
+					NotAfter:    expiredSince,
+					CommonName:  "test-cert",
+				})
+				require.NoError(t, err)
+
+				batcherMocks.localCacheMock.EXPECT().HasCheckCooldown("test-cert-id").
+					Return(true, nil)
+
+				batcherMocks.localCacheMock.EXPECT().IsCheckCooldownActive("test-cert-id").
+					Return(false, nil)
+
+				batcherMocks.localCacheMock.EXPECT().HasFireEventCooldown("test-cert-id").
+					Return(true, nil)
+
+				batcherMocks.localCacheMock.EXPECT().IsFireEventCooldownActive("test-cert-id").
+					Return(false, nil)
+
+				batcherMocks.localCacheMock.EXPECT().SetCheckCooldown("test-cert-id", int64(60)).
+					Return(nil)
+
+				batcherMocks.fallbackCacheMock.EXPECT().SetCheckCooldown("test-cert-id", int64(60)).
+					Return(nil)
+
+				batcherMocks.localCacheMock.EXPECT().SetFireEventCooldown("test-cert-id", int64(120)).
+					Return(nil)
+
+				batcherMocks.fallbackCacheMock.EXPECT().SetFireEventCooldown("test-cert-id", int64(120)).
+					Return(nil)
+
+				ctx, cancel := context.WithCancel(context.Background())
+				go batcher.RunInBackground(ctx)
+
+				cancel()
+				require.Eventuallyf(t, func() bool {
+					<-ctx.Done()
+					return true
+				}, 5*time.Second, 100*time.Millisecond, "batcher background context was not canceled")
+
+				assert.Equal(t, event.CertificateExpired, actualFiredEvent)
+				assert.Equal(t, EventCertificateExpiredMeta{
+					EventMetaDefault: model.EventMetaDefault{
+						Message: "Certificate test-cert is expired since 2 days and 2 hours",
+					},
+					CertID:          "test-cert-id",
+					CertName:        "test-cert",
+					ExpiredAt:       expiredSince,
+					DaysSinceExpiry: 2,
+					APIID:           "123abc",
+				}, actualEventMeta)
+			})
+
+			t.Run("Should fire event when certificate is soon to expire", func(t *testing.T) {
+				var actualFiredEvent event.Event
+				var actualEventMeta EventCertificateExpiringSoonMeta
+				fireEvent := func(event event.Event, meta any) {
+					actualFiredEvent = event
+					actualEventMeta = meta.(EventCertificateExpiringSoonMeta)
+				}
+
+				ctrl, batcherMocks := createBatcherMocks(t)
+				t.Cleanup(ctrl.Finish)
+
+				expiryCheckConfig := config.CertificateExpiryMonitorConfig{
+					// Let's not provide WarningThresholdDays to test the default fallback
+					CheckCooldownSeconds: 60,
+					EventCooldownSeconds: 120,
+				}
+
+				batcher, err := NewCertificateExpiryCheckBatcher(batcherMocks.logger, testApiMetaData, expiryCheckConfig, batcherMocks.redisStorageMock, fireEvent)
+				require.NoError(t, err)
+
+				batcher.inMemoryCooldownCache = batcherMocks.localCacheMock
+				batcher.fallbackCooldownCache = batcherMocks.fallbackCacheMock
+				batcher.flushTicker = time.NewTicker(10 * time.Millisecond)
+
+				now := time.Now()
+				expiry := now.Add(48 * time.Hour)
+				err = batcher.Add(CertInfo{
+					ID:          "test-cert-id",
+					UntilExpiry: 48 * time.Hour, // 48 hours
+					NotAfter:    expiry,
+					CommonName:  "test-cert",
+				})
+				require.NoError(t, err)
+
+				batcherMocks.localCacheMock.EXPECT().HasCheckCooldown("test-cert-id").
+					Return(true, nil)
+
+				batcherMocks.localCacheMock.EXPECT().IsCheckCooldownActive("test-cert-id").
+					Return(false, nil)
+
+				batcherMocks.localCacheMock.EXPECT().HasFireEventCooldown("test-cert-id").
+					Return(true, nil)
+
+				batcherMocks.localCacheMock.EXPECT().IsFireEventCooldownActive("test-cert-id").
+					Return(false, nil)
+
+				batcherMocks.localCacheMock.EXPECT().SetCheckCooldown("test-cert-id", int64(60)).
+					Return(nil)
+
+				batcherMocks.fallbackCacheMock.EXPECT().SetCheckCooldown("test-cert-id", int64(60)).
+					Return(nil)
+
+				batcherMocks.localCacheMock.EXPECT().SetFireEventCooldown("test-cert-id", int64(120)).
+					Return(nil)
+
+				batcherMocks.fallbackCacheMock.EXPECT().SetFireEventCooldown("test-cert-id", int64(120)).
+					Return(nil)
+
+				ctx, cancel := context.WithCancel(context.Background())
+				go batcher.RunInBackground(ctx)
+
+				cancel()
+				require.Eventuallyf(t, func() bool {
+					<-ctx.Done()
+					return true
+				}, 5*time.Second, 100*time.Millisecond, "batcher background context was not canceled")
+
+				assert.Equal(t, event.CertificateExpiringSoon, actualFiredEvent)
+				assert.Equal(t, EventCertificateExpiringSoonMeta{
+					EventMetaDefault: model.EventMetaDefault{
+						Message: "Certificate test-cert is expiring in 2 days",
+					},
+					CertID:        "test-cert-id",
+					CertName:      "test-cert",
+					ExpiresAt:     expiry,
+					DaysRemaining: 2,
+					APIID:         "123abc",
+				}, actualEventMeta)
+			})
+
+			t.Run("Should not brak when setting cooldowns fail", func(t *testing.T) {
+				var actualFiredEvent event.Event
+				var actualEventMeta EventCertificateExpiringSoonMeta
+				fireEvent := func(event event.Event, meta any) {
+					actualFiredEvent = event
+					actualEventMeta = meta.(EventCertificateExpiringSoonMeta)
+				}
+
+				ctrl, batcherMocks := createBatcherMocks(t)
+				t.Cleanup(ctrl.Finish)
+
+				expiryCheckConfig := config.CertificateExpiryMonitorConfig{
+					// Let's not provide WarningThresholdDays to test the default fallback
+					CheckCooldownSeconds: 60,
+					EventCooldownSeconds: 120,
+				}
+
+				batcher, err := NewCertificateExpiryCheckBatcher(batcherMocks.logger, testApiMetaData, expiryCheckConfig, batcherMocks.redisStorageMock, fireEvent)
+				require.NoError(t, err)
+
+				batcher.inMemoryCooldownCache = batcherMocks.localCacheMock
+				batcher.fallbackCooldownCache = batcherMocks.fallbackCacheMock
+				batcher.flushTicker = time.NewTicker(10 * time.Millisecond)
+
+				now := time.Now()
+				expiry := now.Add(48 * time.Hour)
+				err = batcher.Add(CertInfo{
+					ID:          "test-cert-id",
+					UntilExpiry: 48 * time.Hour, // 48 hours
+					NotAfter:    expiry,
+					CommonName:  "test-cert",
+				})
+				require.NoError(t, err)
+
+				batcherMocks.localCacheMock.EXPECT().HasCheckCooldown("test-cert-id").
+					Return(true, nil)
+
+				batcherMocks.localCacheMock.EXPECT().IsCheckCooldownActive("test-cert-id").
+					Return(false, nil)
+
+				batcherMocks.localCacheMock.EXPECT().HasFireEventCooldown("test-cert-id").
+					Return(true, nil)
+
+				batcherMocks.localCacheMock.EXPECT().IsFireEventCooldownActive("test-cert-id").
+					Return(false, nil)
+
+				batcherMocks.localCacheMock.EXPECT().SetCheckCooldown("test-cert-id", int64(60)).
+					Return(errors.New("set check cooldown in local cache failed"))
+
+				batcherMocks.fallbackCacheMock.EXPECT().SetCheckCooldown("test-cert-id", int64(60)).
+					Return(errors.New("set check cooldown in fallback cache failed"))
+
+				batcherMocks.localCacheMock.EXPECT().SetFireEventCooldown("test-cert-id", int64(120)).
+					Return(errors.New("set fire event cooldown in local cache failed"))
+
+				batcherMocks.fallbackCacheMock.EXPECT().SetFireEventCooldown("test-cert-id", int64(120)).
+					Return(errors.New("set fire event cooldown in fallback cache failed"))
+
+				ctx, cancel := context.WithCancel(context.Background())
+				go batcher.RunInBackground(ctx)
+
+				cancel()
+				require.Eventuallyf(t, func() bool {
+					<-ctx.Done()
+					return true
+				}, 5*time.Second, 100*time.Millisecond, "batcher background context was not canceled")
+
+				assert.Equal(t, event.CertificateExpiringSoon, actualFiredEvent)
+				assert.Equal(t, EventCertificateExpiringSoonMeta{
+					EventMetaDefault: model.EventMetaDefault{
+						Message: "Certificate test-cert is expiring in 2 days",
+					},
+					CertID:        "test-cert-id",
+					CertName:      "test-cert",
+					ExpiresAt:     expiry,
+					DaysRemaining: 2,
+					APIID:         "123abc",
+				}, actualEventMeta)
+			})
+		})
+
+	})
+}
+
+func TestCertificateExpiryCheckBatcher_composeSoonToExpire(t *testing.T) {
+	t.Run("Should compose expiry message with days and hours", func(t *testing.T) {
+		batcher := CertificateExpiryCheckBatcher{}
+		actualMessage := batcher.composeSoonToExpireMessage(CertInfo{CommonName: "test-cert"}, 5, 10)
+		expectedMessage := "Certificate test-cert is expiring in 5 days and 10 hours"
+		assert.Equal(t, expectedMessage, actualMessage)
+	})
+
+	t.Run("Should compose expiry message with days only", func(t *testing.T) {
+		batcher := CertificateExpiryCheckBatcher{}
+		actualMessage := batcher.composeSoonToExpireMessage(CertInfo{CommonName: "test-cert"}, 5, 0)
+		expectedMessage := "Certificate test-cert is expiring in 5 days"
+		assert.Equal(t, expectedMessage, actualMessage)
+	})
+
+	t.Run("Should compose expiry message with hours only", func(t *testing.T) {
+		batcher := CertificateExpiryCheckBatcher{}
+		actualMessage := batcher.composeSoonToExpireMessage(CertInfo{CommonName: "test-cert"}, 0, 2)
+		expectedMessage := "Certificate test-cert is expiring in 2 hours"
+		assert.Equal(t, expectedMessage, actualMessage)
+	})
+}
+
+func TestCertificateExpiryCheckBatcher_composeExpiredMessage(t *testing.T) {
+	t.Run("Should compose expiry message with days and hours", func(t *testing.T) {
+		batcher := CertificateExpiryCheckBatcher{}
+		actualMessage := batcher.composeExpiredMessage(CertInfo{CommonName: "test-cert"}, 5, 10)
+		expectedMessage := "Certificate test-cert is expired since 5 days and 10 hours"
+		assert.Equal(t, expectedMessage, actualMessage)
+	})
+
+	t.Run("Should compose expiry message with days only", func(t *testing.T) {
+		batcher := CertificateExpiryCheckBatcher{}
+		actualMessage := batcher.composeExpiredMessage(CertInfo{CommonName: "test-cert"}, 5, 0)
+		expectedMessage := "Certificate test-cert is expired since 5 days"
+		assert.Equal(t, expectedMessage, actualMessage)
+	})
+
+	t.Run("Should compose expiry message with hours only", func(t *testing.T) {
+		batcher := CertificateExpiryCheckBatcher{}
+		actualMessage := batcher.composeExpiredMessage(CertInfo{CommonName: "test-cert"}, 0, 2)
+		expectedMessage := "Certificate test-cert is expired since 2 hours"
+		assert.Equal(t, expectedMessage, actualMessage)
+	})
+}
+
+func TestCertificateExpiryCheckBatcher_isCertificateExpired(t *testing.T) {
+	batcher := &CertificateExpiryCheckBatcher{}
+
+	tests := map[string]struct {
+		commonName     string
+		hoursFromNow   float64
+		expectedResult bool
+		description    string
+	}{
+		"expired_certificate": {
+			commonName:     "expired-cert",
+			hoursFromNow:   -10, // 10 hours ago
+			expectedResult: true,
+			description:    "Should return true when certificate is expired (negative hours)",
+		},
+		"expired_certificate_30_minutes": {
+			commonName:     "expired-cert-30min",
+			hoursFromNow:   -0.5, // 30 minutes ago
+			expectedResult: true,
+			description:    "Should return true when certificate expired 30 minutes ago",
+		},
+		"just_expired_certificate": {
+			commonName:     "just-expired-cert",
+			hoursFromNow:   0, // Right now
+			expectedResult: true,
+			description:    "Should return true when certificate is exactly expired (zero hours)",
+		},
+		"expiring_soon_certificate_30_minutes": {
+			commonName:     "expiring-soon-cert-30min",
+			hoursFromNow:   0.5, // 30 minutes from now
+			expectedResult: false,
+			description:    "Should return false when certificate expires in 30 minutes (not expired with seconds precision)",
+		},
+		"valid_certificate": {
+			commonName:     "valid-cert",
+			hoursFromNow:   24, // 24 hours from now
+			expectedResult: false,
+			description:    "Should return false when certificate is not expired (positive hours)",
+		},
+		"long_valid_certificate": {
+			commonName:     "long-valid-cert",
+			hoursFromNow:   720, // 30 days from now
+			expectedResult: false,
+			description:    "Should return false when certificate has many hours until expiry",
+		},
+		"expired_certificate_1_second": {
+			commonName:     "expired-cert-1sec",
+			hoursFromNow:   -1.0 / 3600, // 1 second ago
+			expectedResult: true,
+			description:    "Should return true when certificate expired 1 second ago",
+		},
+		"expired_certificate_1_minute": {
+			commonName:     "expired-cert-1min",
+			hoursFromNow:   -1.0 / 60, // 1 minute ago
+			expectedResult: true,
+			description:    "Should return true when certificate expired 1 minute ago",
+		},
+		"expired_certificate_1_hour": {
+			commonName:     "expired-cert-1hour",
+			hoursFromNow:   -1, // 1 hour ago
+			expectedResult: true,
+			description:    "Should return true when certificate expired 1 hour ago",
+		},
+		"expired_certificate_1_day": {
+			commonName:     "expired-cert-1day",
+			hoursFromNow:   -24, // 1 day ago
+			expectedResult: true,
+			description:    "Should return true when certificate expired 1 day ago",
+		},
+		"expired_certificate_1_week": {
+			commonName:     "expired-cert-1week",
+			hoursFromNow:   -168, // 1 week ago (7 days)
+			expectedResult: true,
+			description:    "Should return true when certificate expired 1 week ago",
+		},
+		"expired_certificate_1_month": {
+			commonName:     "expired-cert-1month",
+			hoursFromNow:   -720, // 1 month ago (30 days)
+			expectedResult: true,
+			description:    "Should return true when certificate expired 1 month ago",
+		},
+		"expired_certificate_1_year": {
+			commonName:     "expired-cert-1year",
+			hoursFromNow:   -8760, // 1 year ago (365 days)
+			expectedResult: true,
+			description:    "Should return true when certificate expired 1 year ago",
+		},
+		"expiring_soon_certificate_1_second": {
+			commonName:     "expiring-soon-cert-1sec",
+			hoursFromNow:   1.0 / 3600, // 1 second from now
+			expectedResult: false,
+			description:    "Should return false when certificate expires in 1 second (not expired)",
+		},
+		"expiring_soon_certificate_1_minute": {
+			commonName:     "expiring-soon-cert-1min",
+			hoursFromNow:   1.0 / 60, // 1 minute from now
+			expectedResult: false,
+			description:    "Should return false when certificate expires in 1 minute (not expired)",
+		},
+		"expiring_soon_certificate_1_hour": {
+			commonName:     "expiring-soon-cert-1hour",
+			hoursFromNow:   1, // 1 hour from now
+			expectedResult: false,
+			description:    "Should return false when certificate expires in 1 hour (not expired)",
+		},
+		"expiring_soon_certificate_1_day": {
+			commonName:     "expiring-soon-cert-1day",
+			hoursFromNow:   24, // 1 day from now
+			expectedResult: false,
+			description:    "Should return false when certificate expires in 1 day (not expired)",
+		},
+		"expiring_soon_certificate_1_week": {
+			commonName:     "expiring-soon-cert-1week",
+			hoursFromNow:   168, // 1 week from now (7 days)
+			expectedResult: false,
+			description:    "Should return false when certificate expires in 1 week (not expired)",
+		},
+		"expiring_soon_certificate_1_month": {
+			commonName:     "expiring-soon-cert-1month",
+			hoursFromNow:   720, // 1 month from now (30 days)
+			expectedResult: false,
+			description:    "Should return false when certificate expires in 1 month (not expired)",
+		},
+		"expiring_soon_certificate_1_year": {
+			commonName:     "expiring-soon-cert-1year",
+			hoursFromNow:   8760, // 1 year from now (365 days)
+			expectedResult: false,
+			description:    "Should return false when certificate expires in 1 year (not expired)",
+		},
+		"expired_certificate_very_old": {
+			commonName:     "expired-cert-very-old",
+			hoursFromNow:   -87600, // 10 years ago
+			expectedResult: true,
+			description:    "Should return true when certificate expired 10 years ago",
+		},
+		"valid_certificate_very_future": {
+			commonName:     "valid-cert-very-future",
+			hoursFromNow:   87600, // 10 years from now
+			expectedResult: false,
+			description:    "Should return false when certificate expires in 10 years (not expired)",
+		},
+		"expired_certificate_fractional_seconds": {
+			commonName:     "expired-cert-fractional",
+			hoursFromNow:   -0.5 / 3600, // 0.5 seconds ago
+			expectedResult: true,
+			description:    "Should return true when certificate expired 0.5 seconds ago",
+		},
+		"expiring_soon_certificate_fractional_seconds": {
+			commonName:     "expiring-soon-cert-fractional",
+			hoursFromNow:   0.5 / 3600, // 0.5 seconds from now
+			expectedResult: false,
+			description:    "Should return false when certificate expires in 0.5 seconds (not expired)",
+		},
+		"expired_certificate_5_seconds": {
+			commonName:     "expired-cert-5sec",
+			hoursFromNow:   -5.0 / 3600, // 5 seconds ago
+			expectedResult: true,
+			description:    "Should return true when certificate expired 5 seconds ago",
+		},
+		"expiring_soon_certificate_5_seconds": {
+			commonName:     "expiring-soon-cert-5sec",
+			hoursFromNow:   5.0 / 3600, // 5 seconds from now
+			expectedResult: false,
+			description:    "Should return false when certificate expires in 5 seconds (not expired)",
+		},
+		"expired_certificate_10_seconds": {
+			commonName:     "expired-cert-10sec",
+			hoursFromNow:   -10.0 / 3600, // 10 seconds ago
+			expectedResult: true,
+			description:    "Should return true when certificate expired 10 seconds ago",
+		},
+		"expiring_soon_certificate_10_seconds": {
+			commonName:     "expiring-soon-cert-10sec",
+			hoursFromNow:   10.0 / 3600, // 10 seconds from now
+			expectedResult: false,
+			description:    "Should return false when certificate expires in 10 seconds (not expired)",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Create certificate with the specified expiry time
+			expiryTime := time.Now().Add(time.Duration(tt.hoursFromNow * float64(time.Hour)))
+			certInfo := createTestCertInfo(t, tt.commonName, expiryTime)
+
+			// Test the method
+			result := batcher.isCertificateExpired(certInfo)
+			assert.Equal(t, tt.expectedResult, result, tt.description)
+
+			// Verify UntilExpiry calculation
+			if tt.expectedResult {
+				assert.True(t, certInfo.UntilExpiry <= 0, "UntilExpiry should be <= 0 for expired cert")
+			} else {
+				assert.True(t, certInfo.UntilExpiry > 0, "UntilExpiry should be positive for valid cert")
+			}
+		})
+	}
+}
+
+func TestCertificateExpiryCheckBatcher_isCertificateExpiringSoon(t *testing.T) {
+	tests := map[string]struct {
+		commonName           string
+		hoursFromNow         float64
+		warningThresholdDays int
+		expectedResult       bool
+		description          string
+	}{
+		"expired_certificate": {
+			commonName:           "expired-cert",
+			hoursFromNow:         -10, // 10 hours ago
+			warningThresholdDays: 30,
+			expectedResult:       false,
+			description:          "Should return false when certificate is already expired",
+		},
+		"expired_certificate_30_minutes": {
+			commonName:           "expired-cert-30min",
+			hoursFromNow:         -1, // 1 hour ago (to ensure negative UntilExpiry)
+			warningThresholdDays: 30,
+			expectedResult:       false,
+			description:          "Should return false when certificate expired 1 hour ago",
+		},
+		"just_expired_certificate": {
+			commonName:           "just-expired-cert",
+			hoursFromNow:         -0.1, // Just expired (6 minutes ago)
+			warningThresholdDays: 30,
+			expectedResult:       false,
+			description:          "Should return false when certificate is just expired (negative time until expiry)",
+		},
+		"expiring_soon_certificate_30_minutes": {
+			commonName:           "expiring-soon-cert-30min",
+			hoursFromNow:         0.5, // 30 minutes from now
+			warningThresholdDays: 30,
+			expectedResult:       true,
+			description:          "Should return true when certificate expires in 30 minutes (truncated to 0, within threshold)",
+		},
+		"expiring_soon_certificate_1_day": {
+			commonName:           "expiring-soon-cert-1day",
+			hoursFromNow:         24, // 1 day from now
+			warningThresholdDays: 30,
+			expectedResult:       true,
+			description:          "Should return true when certificate expires in 1 day (within 30-day threshold)",
+		},
+		"expiring_soon_certificate_15_days": {
+			commonName:           "expiring-soon-cert-15days",
+			hoursFromNow:         15 * 24, // 15 days from now
+			warningThresholdDays: 30,
+			expectedResult:       true,
+			description:          "Should return true when certificate expires in 15 days (within 30-day threshold)",
+		},
+		"expiring_soon_certificate_30_days": {
+			commonName:           "expiring-soon-cert-30days",
+			hoursFromNow:         30 * 24, // 30 days from now
+			warningThresholdDays: 30,
+			expectedResult:       true,
+			description:          "Should return true when certificate expires in exactly 30 days (at threshold)",
+		},
+		"expiring_soon_certificate_30_days_1_hour": {
+			commonName:           "expiring-soon-cert-30days-1hour",
+			hoursFromNow:         30*24 + 1, // 30 days and 1 hour from now
+			warningThresholdDays: 30,
+			expectedResult:       false,
+			description:          "Should return false when certificate expires in 30 days and 1 hour (just over 30-day threshold)",
+		},
+		"expiring_soon_certificate_30_days_2_hours": {
+			commonName:           "expiring-soon-cert-30days-2hours",
+			hoursFromNow:         30*24 + 2, // 30 days and 2 hours from now
+			warningThresholdDays: 30,
+			expectedResult:       false,
+			description:          "Should return false when certificate expires in 30 days and 2 hours (just over 30-day threshold)",
+		},
+		"valid_certificate_60_days": {
+			commonName:           "valid-cert-60days",
+			hoursFromNow:         60 * 24, // 60 days from now
+			warningThresholdDays: 30,
+			expectedResult:       false,
+			description:          "Should return false when certificate expires in 60 days (well beyond threshold)",
+		},
+		"custom_threshold_1_day": {
+			commonName:           "custom-threshold-1day",
+			hoursFromNow:         12, // 12 hours from now
+			warningThresholdDays: 1,
+			expectedResult:       true,
+			description:          "Should return true when certificate expires in 12 hours with 1-day threshold",
+		},
+		"custom_threshold_1_day_over": {
+			commonName:           "custom-threshold-1day-over",
+			hoursFromNow:         25, // 25 hours from now
+			warningThresholdDays: 1,
+			expectedResult:       false,
+			description:          "Should return false when certificate expires in 25 hours with 1-day threshold (just over 1-day threshold)",
+		},
+		"custom_threshold_1_day_2_hours_over": {
+			commonName:           "custom-threshold-1day-2hours-over",
+			hoursFromNow:         26, // 26 hours from now
+			warningThresholdDays: 1,
+			expectedResult:       false,
+			description:          "Should return false when certificate expires in 26 hours with 1-day threshold (just over 1-day threshold)",
+		},
+		"zero_threshold_defaults_to_30_days": {
+			commonName:           "zero-threshold-default",
+			hoursFromNow:         15 * 24, // 15 days from now
+			warningThresholdDays: 0,       // Should default to 30 days
+			expectedResult:       true,
+			description:          "Should return true when certificate expires in 15 days with 0 threshold (defaults to 30 days)",
+		},
+		"minute_precision_30_minutes": {
+			commonName:           "minute-precision-30min",
+			hoursFromNow:         0.5, // 30 minutes from now
+			warningThresholdDays: 1,   // 1 day threshold
+			expectedResult:       true,
+			description:          "Should return true when certificate expires in 30 minutes with 1-day threshold (minute precision)",
+		},
+		"minute_precision_1_hour_1_minute": {
+			commonName:           "minute-precision-1hour-1min",
+			hoursFromNow:         1 + 1.0/60, // 1 hour and 1 minute from now
+			warningThresholdDays: 1,          // 1 day threshold
+			expectedResult:       true,
+			description:          "Should return true when certificate expires in 1 hour 1 minute with 1-day threshold (minute precision)",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Create batcher with custom warning threshold
+			batcher := &CertificateExpiryCheckBatcher{
+				config: config.CertificateExpiryMonitorConfig{
+					WarningThresholdDays: tt.warningThresholdDays,
+				},
+			}
+
+			// Create certificate with the specified expiry time
+			expiryTime := time.Now().Add(time.Duration(tt.hoursFromNow * float64(time.Hour)))
+			certInfo := createTestCertInfo(t, tt.commonName, expiryTime)
+
+			// Test the method
+			result := batcher.isCertificateExpiringSoon(certInfo)
+			assert.Equal(t, tt.expectedResult, result, tt.description)
+
+			// Verify time calculation with duration precision
+			untilExpiry := certInfo.UntilExpiry
+			actualThreshold := tt.warningThresholdDays
+			if actualThreshold == 0 {
+				actualThreshold = 30 // Default value
+			}
+			warningThresholdDuration := time.Duration(actualThreshold) * 24 * time.Hour // Convert days to duration
+
+			if tt.expectedResult {
+				assert.True(t, untilExpiry > 0, "Until expiry should be positive for expiring soon cert")
+				assert.True(t, untilExpiry <= warningThresholdDuration, "Until expiry should be within warning threshold")
+			} else {
+				// For false cases, either expired or beyond threshold
+				if untilExpiry <= 0 {
+					assert.True(t, untilExpiry <= 0, "Until expiry should be <= 0 for expired cert")
+				} else {
+					assert.True(t, untilExpiry > warningThresholdDuration, "Until expiry should be beyond warning threshold")
+				}
+			}
+		})
+	}
+}
+
+func TestCertInfo_HoursUntilExpiry(t *testing.T) {
+	tests := map[string]struct {
+		secondsUntilExpiry int
+		expectedHours      int
+		description        string
+	}{
+		"positive_hours": {
+			secondsUntilExpiry: 7200, // 2 hours
+			expectedHours:      2,
+			description:        "Should return 2 hours for 7200 seconds",
+		},
+		"fractional_hours_truncated": {
+			secondsUntilExpiry: 5400, // 1.5 hours
+			expectedHours:      1,
+			description:        "Should return 1 hour for 5400 seconds (truncated)",
+		},
+		"zero_seconds": {
+			secondsUntilExpiry: 0,
+			expectedHours:      0,
+			description:        "Should return 0 hours for 0 seconds",
+		},
+		"negative_seconds": {
+			secondsUntilExpiry: -3600, // -1 hour
+			expectedHours:      -1,
+			description:        "Should return -1 hour for -3600 seconds",
+		},
+		"large_positive": {
+			secondsUntilExpiry: 86400, // 24 hours
+			expectedHours:      24,
+			description:        "Should return 24 hours for 86400 seconds",
+		},
+		"large_negative": {
+			secondsUntilExpiry: -86400, // -24 hours
+			expectedHours:      -24,
+			description:        "Should return -24 hours for -86400 seconds",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			certInfo := CertInfo{
+				ID:          "test-cert",
+				CommonName:  "test.example.com",
+				NotAfter:    time.Now().Add(time.Duration(tt.secondsUntilExpiry) * time.Second),
+				UntilExpiry: time.Duration(tt.secondsUntilExpiry) * time.Second,
+			}
+
+			result := certInfo.HoursUntilExpiry()
+			assert.Equal(t, tt.expectedHours, result, tt.description)
+		})
+	}
+}
+
+func TestCertInfo_MinutesUntilExpiry(t *testing.T) {
+	tests := map[string]struct {
+		secondsUntilExpiry int
+		expectedMinutes    int
+		description        string
+	}{
+		"positive_minutes": {
+			secondsUntilExpiry: 120, // 2 minutes
+			expectedMinutes:    2,
+			description:        "Should return 2 minutes for 120 seconds",
+		},
+		"fractional_minutes_truncated": {
+			secondsUntilExpiry: 90, // 1.5 minutes
+			expectedMinutes:    1,
+			description:        "Should return 1 minute for 90 seconds (truncated)",
+		},
+		"zero_seconds": {
+			secondsUntilExpiry: 0,
+			expectedMinutes:    0,
+			description:        "Should return 0 minutes for 0 seconds",
+		},
+		"negative_seconds": {
+			secondsUntilExpiry: -60, // -1 minute
+			expectedMinutes:    -1,
+			description:        "Should return -1 minute for -60 seconds",
+		},
+		"large_positive": {
+			secondsUntilExpiry: 3600, // 60 minutes (1 hour)
+			expectedMinutes:    60,
+			description:        "Should return 60 minutes for 3600 seconds",
+		},
+		"large_negative": {
+			secondsUntilExpiry: -3600, // -60 minutes (-1 hour)
+			expectedMinutes:    -60,
+			description:        "Should return -60 minutes for -3600 seconds",
+		},
+		"exactly_one_minute": {
+			secondsUntilExpiry: 60, // 1 minute
+			expectedMinutes:    1,
+			description:        "Should return 1 minute for exactly 60 seconds",
+		},
+		"thirty_seconds": {
+			secondsUntilExpiry: 30, // 0.5 minutes
+			expectedMinutes:    0,
+			description:        "Should return 0 minutes for 30 seconds (truncated)",
+		},
+		"one_hour_thirty_minutes": {
+			secondsUntilExpiry: 5400, // 90 minutes (1.5 hours)
+			expectedMinutes:    90,
+			description:        "Should return 90 minutes for 5400 seconds",
+		},
+		"one_second": {
+			secondsUntilExpiry: 1, // 1 second
+			expectedMinutes:    0,
+			description:        "Should return 0 minutes for 1 second (truncated)",
+		},
+		"fifty_nine_seconds": {
+			secondsUntilExpiry: 59, // 59 seconds
+			expectedMinutes:    0,
+			description:        "Should return 0 minutes for 59 seconds (truncated)",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			certInfo := CertInfo{
+				ID:          "test-cert",
+				CommonName:  "test.example.com",
+				NotAfter:    time.Now().Add(time.Duration(tt.secondsUntilExpiry) * time.Second),
+				UntilExpiry: time.Duration(tt.secondsUntilExpiry) * time.Second,
+			}
+
+			result := certInfo.MinutesUntilExpiry()
+			assert.Equal(t, tt.expectedMinutes, result, tt.description)
+		})
+	}
+}
+
+func TestCertInfo_SecondsUntilExpiry(t *testing.T) {
+	tests := map[string]struct {
+		secondsUntilExpiry int
+		expectedSeconds    int
+		description        string
+	}{
+		"positive_seconds": {
+			secondsUntilExpiry: 120, // 2 minutes
+			expectedSeconds:    120,
+			description:        "Should return 120 seconds for 120 seconds",
+		},
+		"zero_seconds": {
+			secondsUntilExpiry: 0,
+			expectedSeconds:    0,
+			description:        "Should return 0 seconds for 0 seconds",
+		},
+		"negative_seconds": {
+			secondsUntilExpiry: -60, // -1 minute
+			expectedSeconds:    -60,
+			description:        "Should return -60 seconds for -60 seconds",
+		},
+		"large_positive": {
+			secondsUntilExpiry: 3600, // 1 hour
+			expectedSeconds:    3600,
+			description:        "Should return 3600 seconds for 3600 seconds",
+		},
+		"large_negative": {
+			secondsUntilExpiry: -3600, // -1 hour
+			expectedSeconds:    -3600,
+			description:        "Should return -3600 seconds for -3600 seconds",
+		},
+		"fractional_seconds_truncated": {
+			secondsUntilExpiry: 90, // 1.5 minutes
+			expectedSeconds:    90,
+			description:        "Should return 90 seconds for 90 seconds (no truncation for seconds)",
+		},
+		"one_second": {
+			secondsUntilExpiry: 1,
+			expectedSeconds:    1,
+			description:        "Should return 1 second for 1 second",
+		},
+		"fifty_nine_seconds": {
+			secondsUntilExpiry: 59,
+			expectedSeconds:    59,
+			description:        "Should return 59 seconds for 59 seconds",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			certInfo := CertInfo{
+				ID:          "test-cert",
+				CommonName:  "test.example.com",
+				NotAfter:    time.Now().Add(time.Duration(tt.secondsUntilExpiry) * time.Second),
+				UntilExpiry: time.Duration(tt.secondsUntilExpiry) * time.Second,
+			}
+
+			result := certInfo.SecondsUntilExpiry()
+			assert.Equal(t, tt.expectedSeconds, result, tt.description)
+		})
+	}
+}
+
+func createBatcherMocks(t *testing.T) (ctrl *gomock.Controller, batcherMocks *BatcherMocks) {
+	ctrl = gomock.NewController(t)
+	logger, _ := logrustest.NewNullLogger()
+
+	return ctrl, &BatcherMocks{
+		ctrl:              ctrl,
+		logger:            logrus.NewEntry(logger),
+		redisStorageMock:  storagemock.NewMockHandler(ctrl),
+		localCacheMock:    NewMockCooldownCache(ctrl),
+		fallbackCacheMock: NewMockCooldownCache(ctrl),
+	}
+}
+
+func TestCertInfo_DaysUntilExpiry(t *testing.T) {
+	tests := map[string]struct {
+		daysUntilExpiry int
+		expectedDays    int
+		description     string
+	}{
+		"positive_days": {
+			daysUntilExpiry: 30, // 30 days
+			expectedDays:    30,
+			description:     "Should return 30 days for 30 days",
+		},
+		"zero_days": {
+			daysUntilExpiry: 0,
+			expectedDays:    0,
+			description:     "Should return 0 days for 0 days",
+		},
+		"negative_days": {
+			daysUntilExpiry: -7, // -7 days (expired)
+			expectedDays:    -7,
+			description:     "Should return -7 days for -7 days",
+		},
+		"large_positive": {
+			daysUntilExpiry: 365, // 1 year
+			expectedDays:    365,
+			description:     "Should return 365 days for 365 days",
+		},
+		"large_negative": {
+			daysUntilExpiry: -365, // -1 year
+			expectedDays:    -365,
+			description:     "Should return -365 days for -365 days",
+		},
+		"fractional_days_truncated": {
+			daysUntilExpiry: 30, // 30.5 days should truncate to 30
+			expectedDays:    30,
+			description:     "Should return 30 days for 30.5 days (truncated)",
+		},
+		"one_day": {
+			daysUntilExpiry: 1,
+			expectedDays:    1,
+			description:     "Should return 1 day for 1 day",
+		},
+		"fractional_day_less_than_one": {
+			daysUntilExpiry: 0, // 0.5 days should truncate to 0
+			expectedDays:    0,
+			description:     "Should return 0 days for 0.5 days (truncated)",
+		},
+		"half_day": {
+			daysUntilExpiry: 0, // 12 hours = 0.5 days, should truncate to 0
+			expectedDays:    0,
+			description:     "Should return 0 days for 12 hours (0.5 days truncated)",
+		},
+		"one_and_half_days": {
+			daysUntilExpiry: 1, // 36 hours = 1.5 days, should truncate to 1
+			expectedDays:    1,
+			description:     "Should return 1 day for 36 hours (1.5 days truncated)",
+		},
+		"two_days": {
+			daysUntilExpiry: 2,
+			expectedDays:    2,
+			description:     "Should return 2 days for 2 days",
+		},
+		"seven_days": {
+			daysUntilExpiry: 7, // 1 week
+			expectedDays:    7,
+			description:     "Should return 7 days for 1 week",
+		},
+		"thirty_days": {
+			daysUntilExpiry: 30, // 1 month
+			expectedDays:    30,
+			description:     "Should return 30 days for 1 month",
+		},
+		"sixty_days": {
+			daysUntilExpiry: 60, // 2 months
+			expectedDays:    60,
+			description:     "Should return 60 days for 2 months",
+		},
+		"ninety_days": {
+			daysUntilExpiry: 90, // 3 months
+			expectedDays:    90,
+			description:     "Should return 90 days for 3 months",
+		},
+		"one_hundred_eighty_days": {
+			daysUntilExpiry: 180, // 6 months
+			expectedDays:    180,
+			description:     "Should return 180 days for 6 months",
+		},
+		"three_hundred_sixty_five_days": {
+			daysUntilExpiry: 365, // 1 year
+			expectedDays:    365,
+			description:     "Should return 365 days for 1 year",
+		},
+		"seven_hundred_thirty_days": {
+			daysUntilExpiry: 730, // 2 years
+			expectedDays:    730,
+			description:     "Should return 730 days for 2 years",
+		},
+		"negative_one_day": {
+			daysUntilExpiry: -1,
+			expectedDays:    -1,
+			description:     "Should return -1 day for -1 day",
+		},
+		"negative_seven_days": {
+			daysUntilExpiry: -7, // -1 week
+			expectedDays:    -7,
+			description:     "Should return -7 days for -1 week",
+		},
+		"negative_thirty_days": {
+			daysUntilExpiry: -30, // -1 month
+			expectedDays:    -30,
+			description:     "Should return -30 days for -1 month",
+		},
+		"negative_ninety_days": {
+			daysUntilExpiry: -90, // -3 months
+			expectedDays:    -90,
+			description:     "Should return -90 days for -3 months",
+		},
+		"negative_three_hundred_sixty_five_days": {
+			daysUntilExpiry: -365, // -1 year
+			expectedDays:    -365,
+			description:     "Should return -365 days for -1 year",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			certInfo := CertInfo{
+				ID:          "test-cert",
+				CommonName:  "test.example.com",
+				NotAfter:    time.Now().Add(time.Duration(tt.daysUntilExpiry) * 24 * time.Hour),
+				UntilExpiry: time.Duration(tt.daysUntilExpiry) * 24 * time.Hour,
+			}
+
+			result := certInfo.DaysUntilExpiry()
+			assert.Equal(t, tt.expectedDays, result, tt.description)
+		})
+	}
+}
+
+func TestApplyConfigDefaults(t *testing.T) {
+	t.Run("without provided values", func(t *testing.T) {
+		providedCfg := config.CertificateExpiryMonitorConfig{}
+		actualCfg := applyConfigDefaults(providedCfg)
+		assert.Equal(t, config.DefaultWarningThresholdDays, actualCfg.WarningThresholdDays)
+		assert.Equal(t, config.DefaultCheckCooldownSeconds, actualCfg.CheckCooldownSeconds)
+		assert.Equal(t, config.DefaultEventCooldownSeconds, actualCfg.EventCooldownSeconds)
+	})
+
+	t.Run("with provided values", func(t *testing.T) {
+		providedCfg := config.CertificateExpiryMonitorConfig{
+			WarningThresholdDays: 10,
+			CheckCooldownSeconds: 100,
+			EventCooldownSeconds: 1000,
+		}
+		actualCfg := applyConfigDefaults(providedCfg)
+		assert.Equal(t, 10, actualCfg.WarningThresholdDays)
+		assert.Equal(t, 100, actualCfg.CheckCooldownSeconds)
+		assert.Equal(t, 1000, actualCfg.EventCooldownSeconds)
+	})
+}

--- a/templates/default_webhook.json
+++ b/templates/default_webhook.json
@@ -54,6 +54,31 @@
     "message": "{{.Meta.Message}}",
     "api_id": "{{.Meta.APIID}}",
 }
+<<<<<<< HEAD
+=======
+{{ else if eq .Type "CertificateExpiringSoon"}}
+{
+  "event": "{{.Type}}",
+  "message": "{{.Meta.Message}}",
+  "cert_id": "{{.Meta.CertID}}",
+  "cert_name": "{{.Meta.CertName}}",
+  "expires_at": "{{.Meta.ExpiresAt | as_rfc3339}}",
+  "days_remaining": {{.Meta.DaysRemaining}},
+  "api_id": "{{.Meta.APIID}}",
+  "timestamp": "{{.TimeStamp | as_rfc3339_from_string}}"
+}
+{{ else if eq .Type "CertificateExpired"}}
+{
+  "event": "{{.Type}}",
+  "message": "{{.Meta.Message}}",
+  "cert_id": "{{.Meta.CertID}}",
+  "cert_name": "{{.Meta.CertName}}",
+  "expired_at": "{{.Meta.ExpiredAt | as_rfc3339}}",
+  "days_since_expiry": {{.Meta.DaysSinceExpiry}},
+  "api_id": "{{.Meta.APIID}}",
+  "timestamp": "{{.TimeStamp | as_rfc3339_from_string}}"
+}
+>>>>>>> b06b6aacc... [TT-15869] cooldown defaults not working and minor datetime format adjustments (#7386)
 {{ else}}
 {
     "event": "{{.Type}}",


### PR DESCRIPTION
[TT-15869] cooldown defaults not working and minor datetime format adjustments (#7386)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-15869"
title="TT-15869" target="_blank">TT-15869</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
<td>Certificate Expiry check and event cooldown defaults do not
work</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

This PR fixes an issue, where the config defaults were not being applied
to the certificate check batcher.
It also fixes a small issue with the date time format not following
RFC3339.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Apply certificate monitor config defaults

- Add RFC3339 datetime formatting to webhooks

- Update default webhook template with helpers

- Add unit tests for helpers and defaults


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cfg["CertificateExpiryMonitorConfig"] -- apply defaults --> def["applyConfigDefaults()"]
  def -- used in --> batcher["NewCertificateExpiryCheckBatcher"]
  tmpl["default_webhook.json"] -- uses --> funcs["template funcs: as_rfc3339, as_rfc3339_from_string"]
  web["WebHookHandler.Init"] -- register funcs --> funcs
  tests1["batcher_test"] -- verify --> def
  tests2["webhooks_test"] -- verify --> funcs
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>event_handler_webhooks.go</strong><dd><code>Add RFC3339
template helpers and integrate in webhook handler</code></dd></summary>
<hr>

gateway/event_handler_webhooks.go

<ul><li>Register template funcs for RFC3339 formatting<br> <li> Parse
default template with custom FuncMap<br> <li> Add helpers to format time
and parse string times<br> <li> Log debug on parsing failures, fallback
to original</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7386/files#diff-6587ad3f2629cfa6c84a71144127acd6cc7824e5141f0b4961848945a87e0198">+30/-1</a>&nbsp;
&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>default_webhook.json</strong><dd><code>Use RFC3339
formatting in default webhook template</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/default_webhook.json

<ul><li>Format certificate dates using RFC3339 helper<br> <li> Convert
event timestamps via string parsing helper<br> <li> Update fields:
expires_at, expired_at, timestamp</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7386/files#diff-0d9bf4709b7f8fbdba9b19f94583e3baff5ae95c016e9688dc3e151873ea257e">+4/-4</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>event_handler_webhooks_test.go</strong><dd><code>Test
webhook RFC3339 formatting helpers</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/event_handler_webhooks_test.go

<ul><li>Add tests for RFC3339 helper functions<br> <li> Verify invalid
and valid string parsing behavior<br> <li> Import test logger hook for
noop logging</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7386/files#diff-1a2f8d6ab4443031b0f8486809453f6389291a6f625745fe8c65ac5cdb0e9621">+28/-0</a>&nbsp;
&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>batcher_test.go</strong><dd><code>Test certificate
monitor default application</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/certcheck/batcher_test.go

<ul><li>Add tests for applyConfigDefaults behavior<br> <li> Validate
defaulting and preservation of provided values</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7386/files#diff-0c0c8cc1102f4dc49d63e417a5aa26c85fe4f94fe8c335149f8768ee5b8c9810">+22/-0</a>&nbsp;
&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>batcher.go</strong><dd><code>Apply defaults for
certificate monitor configuration</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; </dd></summary>
<hr>

internal/certcheck/batcher.go

<ul><li>Apply default config when values not provided<br> <li> Use
applyConfigDefaults in constructor<br> <li> Add helper to set cooldown
and threshold defaults</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7386/files#diff-70d967648d3a4c204df7ea2dd127adc9968c6f7f0784ceb109497e826e2a244a">+17/-1</a>&nbsp;
&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___