### PR TITLE
Merging to release-5.10.0: [TT-15891]  made jwkruris cache_timeout ReadableDuration (#7406)

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -18,6 +18,7 @@ import (
 	"github.com/TykTechnologies/tyk/internal/event"
 
 	"github.com/TykTechnologies/tyk/internal/reflect"
+	tyktime "github.com/TykTechnologies/tyk/internal/time"
 
 	"golang.org/x/oauth2"
 
@@ -782,7 +783,15 @@ type JWK struct {
 	// URL is the jwk endpoint
 	URL string `json:"url"`
 	// CacheTimeout defines how long the JWKS will be kept in the cache before forcing a refresh from the JWKS endpoint.
-	CacheTimeout int64 `bson:"cache_timeout" json:"cache_timeout"`
+	CacheTimeout tyktime.ReadableDuration `bson:"cache_timeout" json:"cache_timeout"`
+}
+
+// GetCacheTimeoutSeconds returns the cache timeout in seconds, using the default expiration if CacheTimeout is zero or negative.
+func (jwk *JWK) GetCacheTimeoutSeconds(defaultExpiration int64) int64 {
+	if jwk.CacheTimeout > 0 {
+		return int64(jwk.CacheTimeout.Seconds())
+	}
+	return defaultExpiration
 }
 
 // UpstreamAuth holds the configurations related to upstream API authentication.

--- a/apidef/jwk_test.go
+++ b/apidef/jwk_test.go
@@ -1,0 +1,111 @@
+package apidef
+
+import (
+	"testing"
+	"time"
+
+	tyktime "github.com/TykTechnologies/tyk/internal/time"
+)
+
+func TestJWK_GetCacheTimeoutSeconds(t *testing.T) {
+	tests := []struct {
+		name              string
+		cacheTimeout      tyktime.ReadableDuration
+		defaultExpiration int64
+		expectedResult    int64
+		description       string
+	}{
+		{
+			name:              "5 minutes timeout",
+			cacheTimeout:      tyktime.ReadableDuration(5 * time.Minute),
+			defaultExpiration: 300,
+			expectedResult:    300, // 5 * 60 seconds
+			description:       "Should return 300 seconds for 5 minute timeout",
+		},
+		{
+			name:              "30 seconds timeout",
+			cacheTimeout:      tyktime.ReadableDuration(30 * time.Second),
+			defaultExpiration: 300,
+			expectedResult:    30,
+			description:       "Should return 30 seconds for 30 second timeout",
+		},
+		{
+			name:              "1 hour timeout",
+			cacheTimeout:      tyktime.ReadableDuration(1 * time.Hour),
+			defaultExpiration: 300,
+			expectedResult:    3600, // 60 * 60 seconds
+			description:       "Should return 3600 seconds for 1 hour timeout",
+		},
+		{
+			name:              "2 hours 30 minutes timeout",
+			cacheTimeout:      tyktime.ReadableDuration(2*time.Hour + 30*time.Minute),
+			defaultExpiration: 300,
+			expectedResult:    9000, // (2 * 60 + 30) * 60 seconds
+			description:       "Should return 9000 seconds for 2h30m timeout",
+		},
+		{
+			name:              "500 milliseconds timeout",
+			cacheTimeout:      tyktime.ReadableDuration(500 * time.Millisecond),
+			defaultExpiration: 300,
+			expectedResult:    0, // Less than 1 second, rounds down to 0
+			description:       "Should return 0 seconds for 500ms timeout (rounds down)",
+		},
+		{
+			name:              "1.5 seconds timeout",
+			cacheTimeout:      tyktime.ReadableDuration(1500 * time.Millisecond),
+			defaultExpiration: 300,
+			expectedResult:    1, // 1.5 seconds rounds down to 1
+			description:       "Should return 1 second for 1.5s timeout (rounds down)",
+		},
+		{
+			name:              "zero duration",
+			cacheTimeout:      tyktime.ReadableDuration(0),
+			defaultExpiration: 300,
+			expectedResult:    300, // Should return default expiration
+			description:       "Should return default expiration for zero duration",
+		},
+		{
+			name:              "negative duration",
+			cacheTimeout:      tyktime.ReadableDuration(-1 * time.Minute),
+			defaultExpiration: 300,
+			expectedResult:    300, // Should return default expiration
+			description:       "Should return default expiration for negative duration",
+		},
+		{
+			name:              "very small duration",
+			cacheTimeout:      tyktime.ReadableDuration(1 * time.Nanosecond),
+			defaultExpiration: 300,
+			expectedResult:    0, // Less than 1 second, rounds down to 0
+			description:       "Should return 0 for very small duration (rounds down)",
+		},
+		{
+			name:              "zero default expiration",
+			cacheTimeout:      tyktime.ReadableDuration(0),
+			defaultExpiration: 0,
+			expectedResult:    0, // Should return 0 when default is 0
+			description:       "Should return 0 when default expiration is 0",
+		},
+		{
+			name:              "large timeout with zero default",
+			cacheTimeout:      tyktime.ReadableDuration(10 * time.Minute),
+			defaultExpiration: 0,
+			expectedResult:    600, // 10 * 60 seconds
+			description:       "Should return 600 seconds for 10 minute timeout even with zero default",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jwk := &JWK{
+				URL:          "https://example.com/jwks",
+				CacheTimeout: tt.cacheTimeout,
+			}
+
+			result := jwk.GetCacheTimeoutSeconds(tt.defaultExpiration)
+
+			if result != tt.expectedResult {
+				t.Errorf("Expected %d, got %d. %s", tt.expectedResult, result, tt.description)
+			}
+		})
+	}
+}

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -1661,8 +1661,7 @@
                 "format": "uri"
               },
               "cacheTimeout": {
-                "type": "number",
-                "minimum": 0
+                "$ref": "#/definitions/X-Tyk-ReadableDuration"
               }
             },
             "required": ["url"]

--- a/apidef/oas/schema/x-tyk-api-gateway.strict.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.strict.json
@@ -1742,8 +1742,7 @@
                 "format": "uri"
               },
               "cacheTimeout": {
-                "type": "number",
-                "minimum": 0
+                "$ref": "#/definitions/X-Tyk-ReadableDuration"
               }
             },
             "required": [

--- a/apidef/oas/security.go
+++ b/apidef/oas/security.go
@@ -5,6 +5,7 @@ import (
 	"github.com/lonelycode/osin"
 
 	"github.com/TykTechnologies/tyk/apidef"
+	tyktime "github.com/TykTechnologies/tyk/internal/time"
 )
 
 const (
@@ -104,7 +105,7 @@ type JWK struct {
 	// URL is the JWKS endpoint.
 	URL string `json:"url"`
 	// CacheTimeout defines how long the JWKS will be kept in the cache before forcing a refresh from the JWKS endpoint.
-	CacheTimeout int64 `bson:"cacheTimeout" json:"cacheTimeout"`
+	CacheTimeout tyktime.ReadableDuration `bson:"cacheTimeout" json:"cacheTimeout"`
 }
 
 // JWT holds the configuration for the JWT middleware.

--- a/apidef/schema.json
+++ b/apidef/schema.json
@@ -128,8 +128,8 @@
             "format": "uri"
           },
           "cache_timeout": {
-            "type": "number",
-            "minimum": 0
+            "type": "string",
+            "pattern": "^(\\d+h)?(\\d+m)?(\\d+s)?(\\d+ms)?(\\d+µs)?(\\d+ns)?$"
           }
         },
         "required": ["url"]

--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -101,11 +101,7 @@ func (k *JWTMiddleware) Init() {
 					continue
 				}
 
-				cacheTimeout := int64(cache.DefaultExpiration)
-				if jwk.CacheTimeout >= 0 {
-					cacheTimeout = jwk.CacheTimeout
-				}
-				jwkCache.Set(jwk.URL, jwkSet, cacheTimeout)
+				jwkCache.Set(jwk.URL, jwkSet, jwk.GetCacheTimeoutSeconds(cache.DefaultExpiration))
 			}
 		}()
 	}
@@ -307,7 +303,7 @@ func (k *JWTMiddleware) getSecretFromURL(url string, kidVal interface{}, keyType
 func (k *JWTMiddleware) findCacheTimeoutByURL(url string) int64 {
 	for _, uri := range k.Spec.JWTJwksURIs {
 		if uri.URL == url {
-			return uri.CacheTimeout
+			return uri.GetCacheTimeoutSeconds(cache.DefaultExpiration)
 		}
 	}
 	return cache.DefaultExpiration
@@ -461,11 +457,7 @@ func (k *JWTMiddleware) getSecretFromMultipleJWKURIs(jwkURIs []apidef.JWK, kidVa
 				continue
 			}
 
-			cacheTimeout := int64(cache.DefaultExpiration)
-			if jwk.CacheTimeout >= 0 {
-				cacheTimeout = jwk.CacheTimeout
-			}
-			jwkCache.Set(jwk.URL, jwkSet, cacheTimeout)
+			jwkCache.Set(jwk.URL, jwkSet, jwk.GetCacheTimeoutSeconds(cache.DefaultExpiration))
 			jwkSets = append(jwkSets, jwkSet)
 		}
 


### PR DESCRIPTION
### **User description**
[TT-15891]  made jwkruris cache_timeout ReadableDuration (#7406)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-15891"
title="TT-15891" target="_blank">TT-15891</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Dashboard does not expect JWKS cache timeout</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20QA_Fail%20ORDER%20BY%20created%20DESC"
title="QA_Fail">QA_Fail</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20regression-5.10.0%20ORDER%20BY%20created%20DESC"
title="regression-5.10.0">regression-5.10.0</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description
The ticket had a requirement to have the cacheTimeout option set as
ReadableDuration (e.g. "30m" or "1h" etc). This PR changes it from int
to ReadableDuration.
<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Use ReadableDuration for JWKS cache timeout

- Convert usages to seconds for caching

- Update OAS and JSON schemas accordingly

- Ensure positive durations before applying


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Struct fields use int64"] -- "replace with" --> B["ReadableDuration type"]
  B -- "duration to seconds" --> C["JWT middleware cache logic"]
  B -- "align types" --> D["OAS models"]
  D -- "schema refs" --> E["OAS JSON Schemas"]
  B -- "pattern" --> F["Legacy schema.json"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>api_definitions.go</strong><dd><code>Switch JWK cache
timeout to ReadableDuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/api_definitions.go

<ul><li>Import <code>internal/time</code> as <code>tyktime</code>.<br>
<li> Change <code>JWK.CacheTimeout</code> type to
<code>ReadableDuration</code>.</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7406/files#diff-9961ccc89a48d32db5b47ba3006315ef52f6e5007fb4b09f8c5d6d299c669d67">+2/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>security.go</strong><dd><code>OAS JWK model uses
ReadableDuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/security.go

<ul><li>Import <code>internal/time</code> as <code>tyktime</code>.<br>
<li> Update OAS <code>JWK.CacheTimeout</code> to
<code>ReadableDuration</code>.</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7406/files#diff-15e7d47137452ca4f3f6139aa8c007cdb426152c41846f712f8bf5dfb607afcc">+2/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>mw_jwt.go</strong><dd><code>Adapt cache logic to
ReadableDuration durations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/mw_jwt.go

<ul><li>Convert <code>ReadableDuration</code> to seconds when
caching.<br> <li> Apply only if duration > 0; default otherwise.<br>
<li> Update helper <code>findCacheTimeoutByURL</code> to return
seconds.</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7406/files#diff-e8bce0f6790c8c56b30e24dbeebb0fc4aa0879ab5ea5f6ef6dbe68931410e237">+7/-5</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>x-tyk-api-gateway.json</strong><dd><code>OAS schema
references ReadableDuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/schema/x-tyk-api-gateway.json

<ul><li>Change <code>jwksURIs[].cacheTimeout</code> to reference
<code>X-Tyk-ReadableDuration</code>.</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7406/files#diff-78828969c0c04cc1a776dfc93a8bad3c499a8c83e6169f83e96d090bed3e7dd0">+1/-2</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>x-tyk-api-gateway.strict.json</strong><dd><code>Strict
OAS schema uses ReadableDuration</code>&nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/schema/x-tyk-api-gateway.strict.json

<ul><li>Change <code>jwksURIs[].cacheTimeout</code> to reference
<code>X-Tyk-ReadableDuration</code>.</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7406/files#diff-39a62344d6b741814a58dfd2d219665ecdf962bbec8e755dbc61e1684bb4892a">+1/-2</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>schema.json</strong><dd><code>Legacy schema expects
readable duration string</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/schema.json

<ul><li>Change <code>jwt_jwks_uris[].cache_timeout</code> from number to
string.<br> <li> Add duration regex pattern for readable durations.</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7406/files#diff-32c8b876e77d1639afb2d20c37b74ed9e149b72cc7de429def13d3d454e075f3">+2/-2</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

[TT-15891]: https://tyktech.atlassian.net/browse/TT-15891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Enhancement, Tests, Documentation


___

### **Description**
- Use ReadableDuration for JWKS cache timeout

- Convert to seconds in cache logic

- Update OAS and legacy JSON schemas

- Add tests for duration conversion behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["JWK CacheTimeout int64"] -- "replace with" --> B["ReadableDuration"]
  B -- "Seconds() conversion" --> C["JWT middleware caching"]
  B -- "type alignment" --> D["OAS models"]
  D -- "schema ref" --> E["OAS JSON Schemas"]
  B -- "regex pattern" --> F["Legacy schema.json"]
  C -- "helper" --> G["GetCacheTimeoutSeconds()"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>api_definitions.go</strong><dd><code>JWK uses ReadableDuration and adds seconds helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7410/files#diff-9961ccc89a48d32db5b47ba3006315ef52f6e5007fb4b09f8c5d6d299c669d67">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>security.go</strong><dd><code>OAS JWK model switches to ReadableDuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7410/files#diff-15e7d47137452ca4f3f6139aa8c007cdb426152c41846f712f8bf5dfb607afcc">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>jwk_test.go</strong><dd><code>Tests for JWK cache timeout seconds conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7410/files#diff-b410397b92cadac5413a7d2687ef211d3641295f664e38526e02cec775556cf9">+111/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>mw_jwt_test.go</strong><dd><code>Tests cover ReadableDuration usage in middleware paths</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7410/files#diff-406bf8fdb6c0cc77f04c6245c70abfc592ddb1525aa843200d850e14d135ebfc">+194/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>mw_jwt.go</strong><dd><code>Middleware uses helper and seconds conversion for cache</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7410/files#diff-e8bce0f6790c8c56b30e24dbeebb0fc4aa0879ab5ea5f6ef6dbe68931410e237">+3/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>x-tyk-api-gateway.json</strong><dd><code>OAS schema references ReadableDuration for cacheTimeout</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7410/files#diff-78828969c0c04cc1a776dfc93a8bad3c499a8c83e6169f83e96d090bed3e7dd0">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>x-tyk-api-gateway.strict.json</strong><dd><code>Strict OAS schema references ReadableDuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7410/files#diff-39a62344d6b741814a58dfd2d219665ecdf962bbec8e755dbc61e1684bb4892a">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>schema.json</strong><dd><code>Legacy schema expects readable duration string with pattern</code></dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7410/files#diff-32c8b876e77d1639afb2d20c37b74ed9e149b72cc7de429def13d3d454e075f3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

