### PR TITLE
Merging to release-5.10: [TT-15860]  initial fix for tls log (#7395)

### DIFF
--- a/ee/middleware/upstreamoauth/oauth_client_utils.go
+++ b/ee/middleware/upstreamoauth/oauth_client_utils.go
@@ -1,0 +1,46 @@
+package upstreamoauth
+
+import (
+	"net/http"
+
+	"github.com/TykTechnologies/tyk/internal/httpclient"
+)
+
+// createOAuthHTTPClient creates an HTTP client for OAuth operations with proper mTLS error handling
+func createOAuthHTTPClient(mw *Middleware) *http.Client {
+	gwConfig := mw.Gw.GetConfig()
+
+	// Check if external services are configured
+	if !gwConfig.ExternalServices.OAuth.MTLS.Enabled &&
+		!gwConfig.ExternalServices.OAuth.Proxy.Enabled &&
+		!gwConfig.ExternalServices.Global.Enabled {
+		return nil
+	}
+
+	// Create HTTP client factory
+	factory := httpclient.NewExternalHTTPClientFactory(&gwConfig.ExternalServices, mw.Gw.GetCertificateManager())
+
+	// Try to create OAuth client with proper error handling
+	httpClient, err := factory.CreateOAuthClient()
+	if err != nil {
+		// If mTLS is explicitly enabled and the error is related to certificate loading,
+		// we should not fallback to default client as this would bypass required mutual TLS authentication
+		if gwConfig.ExternalServices.OAuth.MTLS.Enabled && httpclient.IsMTLSError(err) {
+			if mw != nil && mw.Base != nil {
+				mw.Logger().WithError(err).Error("mTLS configuration failed for upstream OAuth. This is a security-critical error - requests cannot proceed without proper mutual TLS authentication.")
+			}
+			// Don't return a client at all - let the OAuth flow fail properly
+			return nil
+		}
+		// For other errors (e.g., not configured, proxy config), log warning and fallback
+		if mw != nil && mw.Base != nil {
+			mw.Logger().WithError(err).Warn("Failed to create custom HTTP httpClient for upstream OAuth, falling back to default httpClient. Check external services configuration.")
+		}
+		return nil
+	}
+
+	if mw != nil && mw.Base != nil {
+		mw.Logger().Debug("[ExternalServices] Using external services OAuth client")
+	}
+	return httpClient
+}

--- a/ee/middleware/upstreamoauth/oauth_client_utils_test.go
+++ b/ee/middleware/upstreamoauth/oauth_client_utils_test.go
@@ -1,0 +1,180 @@
+package upstreamoauth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/internal/httpclient"
+)
+
+// Test cases for createOAuthHTTPClient
+func TestCreateOAuthHTTPClient(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      config.Config
+		expectedNil bool
+		description string
+	}{
+		{
+			name: "no external services configured",
+			config: config.Config{
+				ExternalServices: config.ExternalServiceConfig{
+					OAuth: config.ServiceConfig{
+						MTLS:  config.MTLSConfig{Enabled: false},
+						Proxy: config.ProxyConfig{Enabled: false},
+					},
+					Global: config.GlobalProxyConfig{Enabled: false},
+				},
+			},
+			expectedNil: true,
+			description: "should return nil when no external services are configured",
+		},
+		{
+			name: "mTLS enabled but misconfigured",
+			config: config.Config{
+				ExternalServices: config.ExternalServiceConfig{
+					OAuth: config.ServiceConfig{
+						MTLS:  config.MTLSConfig{Enabled: true},
+						Proxy: config.ProxyConfig{Enabled: false},
+					},
+					Global: config.GlobalProxyConfig{Enabled: false},
+				},
+			},
+			expectedNil: true,
+			description: "should return nil when mTLS is enabled but misconfigured (no cert files or cert ID)",
+		},
+		{
+			name: "proxy only configuration",
+			config: config.Config{
+				ExternalServices: config.ExternalServiceConfig{
+					OAuth: config.ServiceConfig{
+						MTLS:  config.MTLSConfig{Enabled: false},
+						Proxy: config.ProxyConfig{Enabled: true},
+					},
+					Global: config.GlobalProxyConfig{Enabled: false},
+				},
+			},
+			expectedNil: false, // Factory creates a client even with basic proxy config
+			description: "should return client for proxy-only configuration",
+		},
+		{
+			name: "global configuration enabled",
+			config: config.Config{
+				ExternalServices: config.ExternalServiceConfig{
+					OAuth: config.ServiceConfig{
+						MTLS:  config.MTLSConfig{Enabled: false},
+						Proxy: config.ProxyConfig{Enabled: false},
+					},
+					Global: config.GlobalProxyConfig{Enabled: true},
+				},
+			},
+			expectedNil: false, // Factory creates a client even with basic global config
+			description: "should return client for global configuration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create mock middleware using existing mock types
+			mw := &Middleware{
+				Gw: &mockGateway{
+					config:      tt.config,
+					certManager: nil, // Use nil for simplicity in these tests
+				},
+				Base: &mockBaseMiddleware{},
+			}
+
+			// Call the function under test
+			client := createOAuthHTTPClient(mw)
+
+			// Verify the result
+			if tt.expectedNil {
+				assert.Nil(t, client, tt.description)
+			} else {
+				assert.NotNil(t, client, tt.description)
+			}
+		})
+	}
+}
+
+// TestCreateOAuthHTTPClient_MTLSErrorSecurity tests the security-critical behavior
+// where mTLS errors should not fallback to insecure clients
+func TestCreateOAuthHTTPClient_MTLSErrorSecurity(t *testing.T) {
+	// Test with mTLS enabled but misconfigured (no certificates provided)
+	cfg := config.Config{
+		ExternalServices: config.ExternalServiceConfig{
+			OAuth: config.ServiceConfig{
+				MTLS:  config.MTLSConfig{Enabled: true},
+				Proxy: config.ProxyConfig{Enabled: false},
+			},
+			Global: config.GlobalProxyConfig{Enabled: false},
+		},
+	}
+
+	mw := &Middleware{
+		Gw: &mockGateway{
+			config:      cfg,
+			certManager: nil, // Use nil for simplicity
+		},
+		Base: &mockBaseMiddleware{},
+	}
+
+	// Call the function - should return nil for security reasons when mTLS is misconfigured
+	client := createOAuthHTTPClient(mw)
+	assert.Nil(t, client, "should return nil for mTLS errors to prevent insecure fallback")
+
+	// Verify that IsMTLSError correctly identifies the error types
+	assert.True(t, httpclient.IsMTLSError(httpclient.ErrMTLSCertificateLoad))
+	assert.True(t, httpclient.IsMTLSError(httpclient.ErrMTLSCertificateStore))
+	assert.True(t, httpclient.IsMTLSError(httpclient.ErrMTLSCALoad))
+	assert.False(t, httpclient.IsMTLSError(assert.AnError))
+}
+
+// TestCreateOAuthHTTPClient_IsMTLSError tests the IsMTLSError function
+func TestCreateOAuthHTTPClient_IsMTLSError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "ErrMTLSCertificateLoad should return true",
+			err:      httpclient.ErrMTLSCertificateLoad,
+			expected: true,
+		},
+		{
+			name:     "ErrMTLSCertificateStore should return true",
+			err:      httpclient.ErrMTLSCertificateStore,
+			expected: true,
+		},
+		{
+			name:     "ErrMTLSCALoad should return true",
+			err:      httpclient.ErrMTLSCALoad,
+			expected: true,
+		},
+		{
+			name:     "wrapped mTLS error should return true",
+			err:      httpclient.ErrMTLSCertificateLoad,
+			expected: true,
+		},
+		{
+			name:     "non-mTLS error should return false",
+			err:      assert.AnError,
+			expected: false,
+		},
+		{
+			name:     "nil error should return false",
+			err:      nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := httpclient.IsMTLSError(tt.err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/ee/middleware/upstreamoauth/provider_client_credentials.go
+++ b/ee/middleware/upstreamoauth/provider_client_credentials.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 
 	"golang.org/x/oauth2"
-
-	"github.com/TykTechnologies/tyk/internal/httpclient"
 )
 
 func (client *ClientCredentialsClient) ObtainToken(ctx context.Context) (*oauth2.Token, error) {
@@ -35,30 +33,5 @@ func (client *ClientCredentialsClient) GetToken(r *http.Request) (string, error)
 
 // getHTTPClient creates an HTTP client with external services configuration if available
 func (client *ClientCredentialsClient) getHTTPClient() *http.Client {
-	gwConfig := client.mw.Gw.GetConfig()
-	if gwConfig.ExternalServices.OAuth.MTLS.Enabled ||
-		gwConfig.ExternalServices.OAuth.Proxy.Enabled ||
-		gwConfig.ExternalServices.Global.Enabled {
-
-		// Create HTTP httpClient factory
-		factory := httpclient.NewExternalHTTPClientFactory(&gwConfig.ExternalServices, client.mw.Gw.GetCertificateManager())
-
-		// Try to create OAuth httpClient with proper error handling
-		httpClient, err := factory.CreateOAuthClient()
-		if err != nil {
-			// Log the configuration error but continue with default httpClient
-			if client.mw != nil && client.mw.Base != nil {
-				client.mw.Logger().WithError(err).Warn("Failed to create custom HTTP httpClient for upstream OAuth, falling back to default httpClient. Check external services configuration.")
-			}
-			return nil
-		}
-
-		if client.mw != nil && client.mw.Base != nil {
-			client.mw.Logger().Debug("Successfully created custom HTTP httpClient for upstream OAuth with external services configuration")
-		}
-		return httpClient
-	}
-
-	// Return nil to use default HTTP client
-	return nil
+	return createOAuthHTTPClient(client.mw)
 }

--- a/ee/middleware/upstreamoauth/provider_password_authentication.go
+++ b/ee/middleware/upstreamoauth/provider_password_authentication.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 
 	"golang.org/x/oauth2"
-
-	"github.com/TykTechnologies/tyk/internal/httpclient"
 )
 
 func (client *PasswordClient) ObtainToken(ctx context.Context) (*oauth2.Token, error) {
@@ -34,30 +32,5 @@ func (client *PasswordClient) GetToken(r *http.Request) (string, error) {
 
 // getHTTPClient creates an HTTP client with external services configuration if available
 func (client *PasswordClient) getHTTPClient() *http.Client {
-	gwConfig := client.mw.Gw.GetConfig()
-	if gwConfig.ExternalServices.OAuth.MTLS.Enabled ||
-		gwConfig.ExternalServices.OAuth.Proxy.Enabled ||
-		gwConfig.ExternalServices.Global.Enabled {
-
-		// Create HTTP httpClient factory
-		factory := httpclient.NewExternalHTTPClientFactory(&gwConfig.ExternalServices, client.mw.Gw.GetCertificateManager())
-
-		// Try to create OAuth httpClient with proper error handling
-		httpClient, err := factory.CreateOAuthClient()
-		if err != nil {
-			// Log the configuration error but continue with default httpClient
-			if client.mw != nil && client.mw.Base != nil {
-				client.mw.Logger().WithError(err).Warn("Failed to create custom HTTP httpClient for upstream OAuth, falling back to default httpClient. Check external services configuration.")
-			}
-			return nil
-		}
-
-		if client.mw != nil && client.mw.Base != nil {
-			client.mw.Logger().Debug("Successfully created custom HTTP httpClient for upstream OAuth with external services configuration")
-		}
-		return httpClient
-	}
-
-	// Return nil to use default HTTP client
-	return nil
+	return createOAuthHTTPClient(client.mw)
 }

--- a/gateway/event_handler_webhooks.go
+++ b/gateway/event_handler_webhooks.go
@@ -20,6 +20,7 @@ import (
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/header"
 	"github.com/TykTechnologies/tyk/internal/certcheck"
+	"github.com/TykTechnologies/tyk/internal/httpclient"
 	"github.com/TykTechnologies/tyk/storage"
 )
 
@@ -300,9 +301,18 @@ func (w *WebHookHandler) HandleEvent(em config.EventMessage) {
 	clientFactory := NewExternalHTTPClientFactory(w.Gw)
 	cli, err := clientFactory.CreateWebhookClient()
 	if err != nil {
-		log.WithError(err).Debug("Failed to create webhook HTTP client, falling back to default")
-		log.Debug("[ExternalServices] Falling back to legacy webhook client due to factory error")
-		cli = &http.Client{Timeout: 30 * time.Second}
+		// Check if mTLS is explicitly enabled and error is certificate-related - if so, don't fallback as it would bypass security
+		gwConfig := w.Gw.GetConfig()
+		if gwConfig.ExternalServices.Webhooks.MTLS.Enabled && httpclient.IsMTLSError(err) {
+			log.WithError(err).Error("mTLS configuration failed for webhooks. Webhook delivery will be skipped to maintain security.")
+			// Skip webhook delivery entirely when mTLS is misconfigured
+			return
+		} else {
+			// For other errors (not configured, proxy config), fallback to default client
+			log.WithError(err).Debug("Failed to create webhook HTTP client, falling back to default")
+			log.Debug("[ExternalServices] Falling back to legacy webhook client due to factory error")
+			cli = &http.Client{Timeout: 30 * time.Second}
+		}
 	} else {
 		log.Debugf("[ExternalServices] Using external services webhook client for URL: %s", req.URL.String())
 	}

--- a/internal/httpclient/factory.go
+++ b/internal/httpclient/factory.go
@@ -3,6 +3,7 @@ package httpclient
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -15,6 +16,23 @@ import (
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/go-jose/go-jose/v3"
 )
+
+// Error types for proper error handling with errors.Is()
+var (
+	// ErrMTLSCertificateLoad indicates a failure to load mTLS certificates
+	ErrMTLSCertificateLoad = errors.New("mTLS certificate loading failed")
+	// ErrMTLSCertificateStore indicates a failure to load certificates from the certificate store
+	ErrMTLSCertificateStore = errors.New("mTLS certificate store access failed")
+	// ErrMTLSCALoad indicates a failure to load CA certificates
+	ErrMTLSCALoad = errors.New("mTLS CA certificate loading failed")
+)
+
+// IsMTLSError checks if the error is related to mTLS certificate loading
+func IsMTLSError(err error) bool {
+	return errors.Is(err, ErrMTLSCertificateLoad) ||
+		errors.Is(err, ErrMTLSCertificateStore) ||
+		errors.Is(err, ErrMTLSCALoad)
+}
 
 // CertificateManager is an alias for the actual certificate manager interface.
 type CertificateManager = certs.CertificateManager
@@ -305,14 +323,14 @@ func (f *ExternalHTTPClientFactory) getTLSConfig(serviceConfig config.ServiceCon
 		if serviceConfig.MTLS.IsCertificateStoreConfig() {
 			cert, err := f.loadCertificateFromStore(serviceConfig.MTLS.CertID)
 			if err != nil {
-				return nil, fmt.Errorf("failed to load certificate from store: %w", err)
+				return nil, fmt.Errorf("%w: %w", ErrMTLSCertificateStore, err)
 			}
 			tlsConfig.Certificates = []tls.Certificate{*cert}
 		} else if serviceConfig.MTLS.IsFileBasedConfig() {
 			// Priority 2: File-based certificates (existing behavior)
 			cert, err := tls.LoadX509KeyPair(serviceConfig.MTLS.CertFile, serviceConfig.MTLS.KeyFile)
 			if err != nil {
-				return nil, fmt.Errorf("failed to load client certificate: %w", err)
+				return nil, fmt.Errorf("%w: %w", ErrMTLSCertificateLoad, err)
 			}
 			tlsConfig.Certificates = []tls.Certificate{cert}
 		}
@@ -327,12 +345,12 @@ func (f *ExternalHTTPClientFactory) getTLSConfig(serviceConfig config.ServiceCon
 			// Existing file-based CA loading logic
 			caCert, err := ioutil.ReadFile(serviceConfig.MTLS.CAFile)
 			if err != nil {
-				return nil, fmt.Errorf("failed to read CA certificate: %w", err)
+				return nil, fmt.Errorf("%w: %w", ErrMTLSCALoad, err)
 			}
 
 			caCertPool := x509.NewCertPool()
 			if !caCertPool.AppendCertsFromPEM(caCert) {
-				return nil, fmt.Errorf("failed to parse CA certificate")
+				return nil, fmt.Errorf("%w: failed to parse CA certificate", ErrMTLSCALoad)
 			}
 			tlsConfig.RootCAs = caCertPool
 		}

--- a/internal/httpclient/factory_mtls_security_test.go
+++ b/internal/httpclient/factory_mtls_security_test.go
@@ -1,0 +1,374 @@
+package httpclient
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk/config"
+)
+
+// TestExternalHTTPClientFactory_MTLSSecurityValidation tests that when mTLS is enabled
+// but certificate files don't exist, the factory returns an error instead of falling back
+// to a default HTTP client, which would bypass the required mutual TLS authentication.
+func TestExternalHTTPClientFactory_MTLSSecurityValidation(t *testing.T) {
+	tests := []struct {
+		name          string
+		serviceConfig config.ServiceConfig
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "mTLS enabled with non-existent certificate files should fail",
+			serviceConfig: config.ServiceConfig{
+				MTLS: config.MTLSConfig{
+					Enabled:  true,
+					CertFile: "/nonexistent/path/client.crt",
+					KeyFile:  "/nonexistent/path/client.key",
+				},
+			},
+			expectError:   true,
+			errorContains: "mTLS certificate loading failed",
+		},
+		{
+			name: "mTLS enabled with non-existent CA file should fail",
+			serviceConfig: config.ServiceConfig{
+				MTLS: config.MTLSConfig{
+					Enabled: true,
+					CAFile:  "/nonexistent/path/ca.crt",
+				},
+			},
+			expectError:   true,
+			errorContains: "mTLS CA certificate loading failed",
+		},
+		{
+			name: "mTLS disabled should not fail",
+			serviceConfig: config.ServiceConfig{
+				Proxy: config.ProxyConfig{
+					Enabled: true, // Need some configuration to make service "configured"
+				},
+				MTLS: config.MTLSConfig{
+					Enabled: false,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "mTLS enabled with certificate store ID but no cert manager should fail",
+			serviceConfig: config.ServiceConfig{
+				MTLS: config.MTLSConfig{
+					Enabled: true,
+					CertID:  "test-cert-id",
+				},
+			},
+			expectError:   true,
+			errorContains: "certificate manager not available",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			factory := &ExternalHTTPClientFactory{
+				config: &config.ExternalServiceConfig{
+					OAuth: tt.serviceConfig,
+				},
+				certManager: nil, // No certificate manager for testing
+			}
+
+			client, err := factory.CreateOAuthClient()
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorContains)
+				assert.Nil(t, client)
+
+				// Also verify we can use IsMTLSError() for mTLS-related errors
+				if tt.name != "mTLS enabled with certificate store ID but no cert manager should fail" {
+					assert.True(t, IsMTLSError(err))
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, client)
+				assert.IsType(t, &http.Client{}, client)
+			}
+		})
+	}
+}
+
+// TestExternalHTTPClientFactory_MTLSFallbackSecurity tests that when mTLS configuration
+// fails, the system does not silently fall back to an insecure default client.
+func TestExternalHTTPClientFactory_MTLSFallbackSecurity(t *testing.T) {
+	factory := &ExternalHTTPClientFactory{
+		config: &config.ExternalServiceConfig{
+			OAuth: config.ServiceConfig{
+				MTLS: config.MTLSConfig{
+					Enabled:  true,
+					CertFile: "/nonexistent/cert.pem",
+					KeyFile:  "/nonexistent/key.pem",
+				},
+			},
+		},
+		certManager: nil,
+	}
+
+	// Attempt to create OAuth client with invalid mTLS configuration
+	client, err := factory.CreateOAuthClient()
+
+	// Should fail with error, not return a working client
+	assert.Error(t, err)
+	assert.Nil(t, client)
+	assert.Contains(t, err.Error(), "failed to configure TLS")
+
+	// Verify we can use IsMTLSError() to check for mTLS certificate loading errors
+	assert.True(t, IsMTLSError(err))
+}
+
+// TestExternalHTTPClientFactory_ProxyOnlyConfiguration tests that proxy-only
+// configuration (without mTLS) works correctly and doesn't fail.
+func TestExternalHTTPClientFactory_ProxyOnlyConfiguration(t *testing.T) {
+	factory := &ExternalHTTPClientFactory{
+		config: &config.ExternalServiceConfig{
+			OAuth: config.ServiceConfig{
+				Proxy: config.ProxyConfig{
+					Enabled:    true,
+					HTTPProxy:  "http://proxy.example.com:8080",
+					HTTPSProxy: "https://proxy.example.com:8080",
+				},
+			},
+		},
+		certManager: nil,
+	}
+
+	// Should succeed for proxy-only configuration
+	client, err := factory.CreateOAuthClient()
+
+	assert.NoError(t, err)
+	assert.NotNil(t, client)
+	assert.IsType(t, &http.Client{}, client)
+}
+
+// TestExternalHTTPClientFactory_CreateWebhookClient tests webhook client creation
+func TestExternalHTTPClientFactory_CreateWebhookClient(t *testing.T) {
+	tests := []struct {
+		name          string
+		serviceConfig config.ServiceConfig
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "webhook client with proxy configuration should succeed",
+			serviceConfig: config.ServiceConfig{
+				Proxy: config.ProxyConfig{
+					Enabled: true, // Enable proxy to make service configured
+				},
+				MTLS: config.MTLSConfig{
+					Enabled: false, // Disabled to avoid certificate errors in test
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "webhook client with invalid mTLS should fail",
+			serviceConfig: config.ServiceConfig{
+				MTLS: config.MTLSConfig{
+					Enabled:  true,
+					CertFile: "/nonexistent/cert.pem",
+					KeyFile:  "/nonexistent/key.pem",
+				},
+			},
+			expectError:   true,
+			errorContains: "failed to configure TLS",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			factory := &ExternalHTTPClientFactory{
+				config: &config.ExternalServiceConfig{
+					Webhooks: tt.serviceConfig,
+				},
+				certManager: nil,
+			}
+
+			client, err := factory.CreateWebhookClient()
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorContains)
+				assert.Nil(t, client)
+				assert.True(t, IsMTLSError(err))
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, client)
+				assert.IsType(t, &http.Client{}, client)
+			}
+		})
+	}
+}
+
+// TestExternalHTTPClientFactory_CreateHealthCheckClient tests health check client creation
+func TestExternalHTTPClientFactory_CreateHealthCheckClient(t *testing.T) {
+	tests := []struct {
+		name          string
+		serviceConfig config.ServiceConfig
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "health check client with proxy config should succeed",
+			serviceConfig: config.ServiceConfig{
+				Proxy: config.ProxyConfig{
+					Enabled: true, // Enable proxy to make service configured
+				},
+				MTLS: config.MTLSConfig{
+					Enabled: false, // Disabled to avoid certificate errors in test
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "health check client with invalid mTLS should fail",
+			serviceConfig: config.ServiceConfig{
+				MTLS: config.MTLSConfig{
+					Enabled:  true,
+					CertFile: "/nonexistent/cert.pem",
+					KeyFile:  "/nonexistent/key.pem",
+				},
+			},
+			expectError:   true,
+			errorContains: "failed to configure TLS",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			factory := &ExternalHTTPClientFactory{
+				config: &config.ExternalServiceConfig{
+					Health: tt.serviceConfig,
+				},
+				certManager: nil,
+			}
+
+			client, err := factory.CreateHealthCheckClient()
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorContains)
+				assert.Nil(t, client)
+				assert.True(t, IsMTLSError(err))
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, client)
+				assert.IsType(t, &http.Client{}, client)
+			}
+		})
+	}
+}
+
+// TestExternalHTTPClientFactory_CreateIntrospectionClient tests introspection client creation
+func TestExternalHTTPClientFactory_CreateIntrospectionClient(t *testing.T) {
+	tests := []struct {
+		name          string
+		serviceConfig config.ServiceConfig
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "introspection client with proxy config should succeed",
+			serviceConfig: config.ServiceConfig{
+				Proxy: config.ProxyConfig{
+					Enabled: true, // Enable proxy to make service configured
+				},
+				MTLS: config.MTLSConfig{
+					Enabled: false, // Disabled to avoid certificate errors in test
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "introspection client with invalid mTLS should fail",
+			serviceConfig: config.ServiceConfig{
+				MTLS: config.MTLSConfig{
+					Enabled:  true,
+					CertFile: "/nonexistent/cert.pem",
+					KeyFile:  "/nonexistent/key.pem",
+				},
+			},
+			expectError:   true,
+			errorContains: "failed to configure TLS",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			factory := &ExternalHTTPClientFactory{
+				config: &config.ExternalServiceConfig{
+					OAuth: tt.serviceConfig, // Introspection uses OAuth config
+				},
+				certManager: nil,
+			}
+
+			client, err := factory.CreateIntrospectionClient()
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorContains)
+				assert.Nil(t, client)
+				assert.True(t, IsMTLSError(err))
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, client)
+				assert.IsType(t, &http.Client{}, client)
+			}
+		})
+	}
+}
+
+// TestIsMTLSError tests the IsMTLSError function
+func TestIsMTLSError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "ErrMTLSCertificateLoad should return true",
+			err:      ErrMTLSCertificateLoad,
+			expected: true,
+		},
+		{
+			name:     "ErrMTLSCertificateStore should return true",
+			err:      ErrMTLSCertificateStore,
+			expected: true,
+		},
+		{
+			name:     "ErrMTLSCALoad should return true",
+			err:      ErrMTLSCALoad,
+			expected: true,
+		},
+		{
+			name:     "wrapped ErrMTLSCertificateLoad should return true",
+			err:      fmt.Errorf("wrapped error: %w", ErrMTLSCertificateLoad),
+			expected: true,
+		},
+		{
+			name:     "other error should return false",
+			err:      fmt.Errorf("some other error"),
+			expected: false,
+		},
+		{
+			name:     "nil error should return false",
+			err:      nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsMTLSError(tt.err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
### **User description**
[TT-15860]  initial fix for tls log (#7395)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-15860"
title="TT-15860" target="_blank">TT-15860</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Unnecessary error message in gateway logs</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Code Review</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description
Fixed tls errors not stopping the request and fallbacking to initial
http client.
<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Enforce no fallback on mTLS failures

- Introduce specific mTLS error types

- Add isMTLSError checks across services

- Improve logging and security handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["httpclient: define mTLS error types"] -- "used by" --> B["OAuth client creds: strict mTLS handling"]
  A -- "used by" --> C["OAuth password: strict mTLS handling"]
  A -- "used by" --> D["Webhooks: skip on mTLS failure"]
  A -- "used by" --> E["Health checks: fail on mTLS error"]
  A -- "used by" --> F["Service discovery: return mTLS error"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>

<summary><strong>provider_client_credentials.go</strong><dd><code>Strict
mTLS enforcement for OAuth client credentials</code>&nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></summary>
<hr>

ee/middleware/upstreamoauth/provider_client_credentials.go

<ul><li>Prevent fallback when mTLS enabled and fails<br> <li> Add
security-critical error log on mTLS misconfig<br> <li> Retain warning
fallback for non-mTLS errors</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7395/files#diff-f8b42f45421248f94f2d2780c267be98a2c891a14499e31b770b4998cdc26baa">+10/-1</a>&nbsp;
&nbsp; </td>

</tr>

<tr>
  <td>
    <details>

<summary><strong>provider_password_authentication.go</strong><dd><code>Strict
mTLS enforcement for OAuth password flow</code>&nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ee/middleware/upstreamoauth/provider_password_authentication.go

<ul><li>Add isMTLSError helper<br> <li> Block fallback when mTLS
certificate errors occur<br> <li> Log explicit security error on mTLS
failure</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7395/files#diff-ca91fe1184156c5461d4eeffa302e9b9f9db9787b33a3ab75f7e4dfb8e56b457">+18/-1</a>&nbsp;
&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>event_handler_webhooks.go</strong><dd><code>Secure
webhook handling on mTLS misconfiguration</code>&nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/event_handler_webhooks.go

<ul><li>Skip webhook delivery on mTLS failures<br> <li> Fallback only
for non-mTLS errors<br> <li> Add explicit error logging for mTLS
issues</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7395/files#diff-6587ad3f2629cfa6c84a71144127acd6cc7824e5141f0b4961848945a87e0198">+12/-3</a>&nbsp;
&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>host_checker.go</strong><dd><code>Health check fails
securely on mTLS errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

gateway/host_checker.go

<ul><li>Add isMTLSError helper<br> <li> Mark health check failed on mTLS
errors<br> <li> Fallback only for non-mTLS errors</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7395/files#diff-a0eaa8c9fb4c1479a5b080cd3b6faf25ce1d218ca107d5b07888d4ffc97aadac">+30/-12</a>&nbsp;
</td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>service_discovery.go</strong><dd><code>Discovery client
strict mTLS error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

gateway/service_discovery.go

<ul><li>Return error on mTLS failure for discovery<br> <li> Fallback to
default client only otherwise<br> <li> Add detailed logging for
decisions</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7395/files#diff-e89e292b6e3cb1a8b2b9c7944ee2da24ea005b490272b5f591a327d102b87799">+12/-3</a>&nbsp;
&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>factory.go</strong><dd><code>Typed mTLS errors in HTTP
client factory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</dd></summary>
<hr>

internal/httpclient/factory.go

<ul><li>Introduce dedicated mTLS error types<br> <li> Wrap
certificate/CA load errors with typed errors<br> <li> Enable errors.Is
matching for callers</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7395/files#diff-98e9301dcf6a3b77e941265d7fbb135a30314962500c8a64a3f608cefc5b78df">+15/-4</a>&nbsp;
&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

[TT-15860]: https://tyktech.atlassian.net/browse/TT-15860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Enforce no fallback on mTLS failures

- Add typed mTLS errors and helpers

- Secure OAuth/webhooks/health/discovery handling

- Add unit tests for mTLS behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Typed mTLS errors (httpclient)"] --> B["OAuth client utils (upstreamoauth)"]
  A --> C["Webhooks handler"]
  A --> D["Health checker"]
  A --> E["Service discovery"]
  B -- "used by" --> F["Client credentials flow"]
  B -- "used by" --> G["Password flow"]
  A -- "covered by" --> T["New mTLS tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>oauth_client_utils.go</strong><dd><code>Centralize OAuth HTTP client creation with mTLS checks</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7417/files#diff-ccf2841ff9bacb3b41eae5d0ce70c7f0055daa71a750e84e7944bc844f4d17a5">+46/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>provider_client_credentials.go</strong><dd><code>Use centralized OAuth client with secure fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7417/files#diff-f8b42f45421248f94f2d2780c267be98a2c891a14499e31b770b4998cdc26baa">+1/-28</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>provider_password_authentication.go</strong><dd><code>Use centralized OAuth client with secure fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7417/files#diff-ca91fe1184156c5461d4eeffa302e9b9f9db9787b33a3ab75f7e4dfb8e56b457">+1/-28</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>factory.go</strong><dd><code>Introduce typed mTLS errors and detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7417/files#diff-98e9301dcf6a3b77e941265d7fbb135a30314962500c8a64a3f608cefc5b78df">+22/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>oauth_client_utils_test.go</strong><dd><code>Tests for OAuth client creation and mTLS errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7417/files#diff-04cbd94deb40affcf1c988500d59355b34056e3f5e56ea07ac2571d4618de438">+180/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>factory_mtls_security_test.go</strong><dd><code>Unit tests for mTLS error typing and fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7417/files#diff-8065da40d7ed9f4537596f145be1df8c8cadd7e508110a06d2ef05de0762871f">+374/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>event_handler_webhooks.go</strong><dd><code>Skip webhook delivery on mTLS failures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7417/files#diff-6587ad3f2629cfa6c84a71144127acd6cc7824e5141f0b4961848945a87e0198">+13/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>host_checker.go</strong><dd><code>Mark health checks failed on mTLS errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7417/files#diff-a0eaa8c9fb4c1479a5b080cd3b6faf25ce1d218ca107d5b07888d4ffc97aadac">+23/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>service_discovery.go</strong><dd><code>Return error on discovery mTLS failure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7417/files#diff-e89e292b6e3cb1a8b2b9c7944ee2da24ea005b490272b5f591a327d102b87799">+13/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

