### PR TITLE
Refactor error messages in OAS security validation for consistency

### DIFF
--- a/apidef/oas/oas.go
+++ b/apidef/oas/oas.go
@@ -498,13 +498,13 @@ func (s *OAS) validateSecurity() error {
 	}
 
 	if s.Components == nil || s.Components.SecuritySchemes == nil || len(s.Components.SecuritySchemes) == 0 {
-		return errors.New("no components or security schemes present in OAS")
+		return errors.New("No components or security schemes present in OAS")
 	}
 
 	for _, requirement := range s.Security {
 		for key := range requirement {
 			if _, ok := s.Components.SecuritySchemes[key]; !ok {
-				errorMsg := fmt.Sprintf("missing required Security Scheme '%s' in Components.SecuritySchemes. "+
+				errorMsg := fmt.Sprintf("Missing required Security Scheme '%s' in Components.SecuritySchemes. "+
 					"For more information please visit https://swagger.io/specification/#security-requirement-object",
 					key)
 				return errors.New(errorMsg)

--- a/apidef/oas/oas_test.go
+++ b/apidef/oas/oas_test.go
@@ -1458,9 +1458,9 @@ func TestOAS_ValidateSecurity(t *testing.T) {
 		createSecurityReq(oas, oauth2, []string{"read", "write"})
 	}
 
-	expectedErrorForNoComponentOrSchemes := "no components or security schemes present in OAS"
+	expectedErrorForNoComponentOrSchemes := "No components or security schemes present in OAS"
 	expectedErrorForMissingSchema := func(s string) string {
-		return fmt.Sprintf("missing required Security Scheme '%s' in Components.SecuritySchemes", s)
+		return fmt.Sprintf("Missing required Security Scheme '%s' in Components.SecuritySchemes", s)
 	}
 
 	tests := []struct {


### PR DESCRIPTION
### **User description**
Updated error messages in the OAS security validation logic to ensure consistent capitalization. The changes include modifying the error message for missing components and security schemes, as well as the error message for missing required security schemes in the components. This enhances clarity and maintains a uniform style across the error outputs.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Capitalize OAS security error messages

- Align tests with updated messages


___

### Diagram Walkthrough


```mermaid
flowchart LR
  src["oas.go: security validation errors"] -- "capitalize messages" --> behavior["Runtime error outputs"]
  tests["oas_test.go: expected messages"] -- "update to match" --> behavior
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>oas.go</strong><dd><code>Capitalize security validation error messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/oas.go

<ul><li>Capitalized error for missing components/security schemes.<br> <li> Capitalized error for missing required security scheme.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7440/files#diff-80279b1d59499a41a77ff7a16a6e2c9b9b785a4fd1326c351da6884c867658d7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>oas_test.go</strong><dd><code>Sync tests with capitalized error messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/oas_test.go

<ul><li>Update expected error strings to capitalized versions.<br> <li> Keep message format consistent with implementation.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7440/files#diff-74029ee88132d30d6478c96a35f8bb2200e0c8e6f42f2c9b147dc6bb7ce74644">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

