### PR TITLE
Merging to release-5.8: [TT-15141] Toggling default policy from inactive to active does not activate JWT in some cases (#7431)

### DIFF
--- a/internal/policy/apply_test.go
+++ b/internal/policy/apply_test.go
@@ -526,8 +526,8 @@ func testPrepareApplyPolicies(tb testing.TB) (*policy.Service, []testApplyPolici
 			"InactiveWithSession", []string{"tags1", "tags2"},
 			"", func(t *testing.T, s *user.SessionState) {
 				t.Helper()
-				if !s.IsInactive {
-					t.Fatalf("want IsInactive to be true")
+				if s.IsInactive {
+					t.Fatalf("both policies are active so we expect IsInactive to be false")
 				}
 			}, &user.SessionState{
 				IsInactive: true,
@@ -1291,7 +1291,12 @@ func TestService_Apply(t *testing.T) {
 				}
 				sess.SetPolicies(policies...)
 				if err := service.Apply(sess); err != nil {
-					assert.ErrorContains(t, err, tc.errMatch)
+					if tc.errMatch != "" {
+						assert.ErrorContains(t, err, tc.errMatch)
+					} else {
+						t.Fail()
+					}
+
 					return
 				}
 

--- a/internal/policy/testdata/policies.json
+++ b/internal/policy/testdata/policies.json
@@ -112,13 +112,21 @@
   },
   "complexity1": {
     "max_query_depth": 2,
+    "access_rights": {
+      "a": {}
+    },
     "partitions": {
+      "acl": true,
       "complexity": true
     }
   },
   "complexity2": {
     "max_query_depth": 3,
+    "access_rights": {
+      "a": {}
+    },
     "partitions": {
+      "acl": true,
       "complexity": true
     }
   },
@@ -191,14 +199,22 @@
     "partitions": {}
   },
   "inactive1": {
+    "access_rights": {
+      "a": {}
+    },
     "is_inactive": true,
     "partitions": {
+      "acl": true,
       "rate_limit": true
     }
   },
   "inactive2": {
+    "access_rights": {
+      "a": {}
+    },
     "is_inactive": true,
     "partitions": {
+      "acl": true,
       "quota": true
     }
   },
@@ -420,13 +436,21 @@
   },
   "quota1": {
     "quota_max": 2,
+    "access_rights": {
+      "a": {}
+    },
     "partitions": {
+      "acl": true,
       "quota": true
     }
   },
   "quota2": {
     "quota_max": 3,
+    "access_rights": {
+      "a": {}
+    },
     "partitions": {
+      "acl": true,
       "quota": true
     }
   },
@@ -436,6 +460,7 @@
       "a": {}
     },
     "partitions": {
+      "acl": true,
       "quota": true
     }
   },
@@ -454,6 +479,7 @@
       "b": {}
     },
     "partitions": {
+      "acl": true,
       "quota": true
     }
   },
@@ -498,13 +524,23 @@
   },
   "rate1": {
     "rate": 3,
+    "per": 1,
+    "access_rights": {
+      "a": {}
+    },
     "partitions": {
+      "acl": true,
       "rate_limit": true
     }
   },
   "rate2": {
     "rate": 4,
+    "per": 1,
+    "access_rights": {
+      "a": {}
+    },
     "partitions": {
+      "acl": true,
       "rate_limit": true
     }
   },
@@ -512,6 +548,7 @@
     "rate": 4,
     "per": 4,
     "partitions": {
+      "acl": true,
       "rate_limit": true
     }
   },
@@ -522,6 +559,7 @@
       "a": {}
     },
     "partitions": {
+      "acl": true,
       "rate_limit": true
     }
   },
@@ -532,6 +570,7 @@
       "a": {}
     },
     "partitions": {
+      "acl": true,
       "rate_limit": true
     }
   },
@@ -584,19 +623,27 @@
     "partitions": {}
   },
   "tags1": {
+    "access_rights": {
+      "a": {}
+    },
     "tags": [
       "tagA"
     ],
     "partitions": {
+      "acl": true,
       "quota": true
     }
   },
   "tags2": {
+    "access_rights": {
+      "a": {}
+    },
     "tags": [
       "tagX",
       "tagY"
     ],
     "partitions": {
+      "acl": true,
       "rate_limit": true
     }
   },
@@ -615,6 +662,7 @@
       "a": {}
     },
     "partitions": {
+      "acl": true,
       "quota": true
     }
   },
@@ -624,6 +672,7 @@
       "a": {}
     },
     "partitions": {
+      "acl": true,
       "rate_limit": true
     }
   },
@@ -633,6 +682,7 @@
       "a": {}
     },
     "partitions": {
+      "acl": true,
       "complexity": true
     }
   },


### PR DESCRIPTION
### **User description**
[TT-15141] Toggling default policy from inactive to active does not activate JWT in some cases (#7431)

### **User description**
<details open>
<summary><a href="https://tyktech.atlassian.net/browse/TT-15141"
title="TT-15141" target="_blank">TT-15141</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
<td>Toggling default policy from inactive to active does not activate
JWT in some cases</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
<img alt="Bug"
src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium"
/>
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
<td><a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%202025_long_tail%20ORDER%20BY%20created%20DESC"
title="2025_long_tail">2025_long_tail</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20AI-Complexity-Medium%20ORDER%20BY%20created%20DESC"
title="AI-Complexity-Medium">AI-Complexity-Medium</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20AI-Priority-High%20ORDER%20BY%20created%20DESC"
title="AI-Priority-High">AI-Priority-High</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20codilime_refined%20ORDER%20BY%20created%20DESC"
title="codilime_refined">codilime_refined</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20customer_bug%20ORDER%20BY%20created%20DESC"
title="customer_bug">customer_bug</a>, <a
href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20jira_escalated%20ORDER%20BY%20created%20DESC"
title="jira_escalated">jira_escalated</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

Setting a policy to draft will deactivate keys (as expected), but
setting it back to active does not reactivate the keys when policy is in
draft in time of the first request. Setting the policy back to active
should reactivate the keys.

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Compute inactivity from applied policies only

- Persist session state by touching session

- Refactor inactivity aggregation logic

- Improve key validity evaluation robustness


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Apply(session)"] -- "iterate policyIDs" --> B["Aggregate policy.IsInactive"]
  B -- "result" --> C["sessionInactiveState"]
  C -- "set" --> D["session.IsInactive"]
  A -- "after validations" --> E["session.Touch()"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Bug
fix</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>apply.go</strong><dd><code>Aggregate inactivity and
persist session via Touch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; </dd></summary>
<hr>

internal/policy/apply.go

<ul><li>Introduce local <code>sessionInactiveState</code>
aggregator.<br> <li> Set <code>session.IsInactive</code> once from
aggregated state.<br> <li> Call <code>session.Touch()</code> to persist
updated session.<br> <li> Clarify intent with comment on key validity
basis.</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7431/files#diff-59b92e9d31f142f1d99b746eb3ff7db4e26bf6c3044c9b87b58034a947ee04d1">+8/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

---------

Co-authored-by: Radosław Krawczyk <98938598+radkrawczyk@users.noreply.github.com>

[TT-15141]: https://tyktech.atlassian.net/browse/TT-15141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Aggregate inactivity across applied policies only

- Set session.IsInactive from aggregated state

- Persist updated session via session.Touch()

- Test updates and policy fixtures adjusted


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Apply(session)"] --> B["Iterate applied policy IDs"]
  B -- "OR policy.IsInactive" --> C["Aggregate inactivity"]
  C -- "set" --> D["session.IsInactive"]
  D -- "persist" --> E["session.Touch()"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>apply.go</strong><dd><code>Aggregate inactivity and persist session via Touch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/policy/apply.go

<ul><li>Add local aggregator <code>sessionInactiveState</code><br> <li> Compute inactivity from applied policies only<br> <li> Assign <code>session.IsInactive</code> once after loop<br> <li> Call <code>session.Touch()</code> to persist session<br> <li> Add clarifying comment on key validity basis</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7445/files#diff-59b92e9d31f142f1d99b746eb3ff7db4e26bf6c3044c9b87b58034a947ee04d1">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>apply_test.go</strong><dd><code>Adjust tests for new inactivity evaluation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/policy/apply_test.go

<ul><li>Update expectations for inactivity with active policies<br> <li> Improve error assertion logic with conditional match</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7445/files#diff-5af7e299a6b0ce11e22f8aa4a01854b1151f4b54dccc68f0cd1cbedee5aed7c8">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>policies.json</strong><dd><code>Align policy fixtures with ACL and access rights</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/policy/testdata/policies.json

<ul><li>Add <code>access_rights</code> to multiple test policies<br> <li> Enable <code>acl</code> partition where required<br> <li> Ensure rate/quota/complexity partitions align with ACL</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7445/files#diff-098134f4708ce69a2d65ed25b4e81b76ad30a54ace915d8c54e4630984038804">+50/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

