### PR TITLE
Merging to release-5.8: [TT-15839] Adding bundle validation (#7422)

### DIFF
--- a/gateway/coprocess_bundle.go
+++ b/gateway/coprocess_bundle.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/TykTechnologies/goverify"
 	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/internal/sanitize"
 )
 
 var (
@@ -187,6 +188,10 @@ func (ZipBundleSaver) Save(bundle *Bundle, bundlePath string, spec *APISpec) err
 	}
 
 	for _, f := range reader.File {
+		if err := sanitize.ZipFilePath(f.Name, bundlePath); err != nil {
+			return err
+		}
+
 		destPath := filepath.Join(bundlePath, f.Name)
 
 		if f.FileHeader.Mode().IsDir() {
@@ -300,9 +305,8 @@ func saveBundle(bundle *Bundle, destPath string, spec *APISpec) error {
 	case "zip":
 		bundleSaver = ZipBundleSaver{}
 	}
-	bundleSaver.Save(bundle, destPath, spec)
 
-	return nil
+	return bundleSaver.Save(bundle, destPath, spec)
 }
 
 // loadBundleManifest will parse the manifest file and return the bundle parameters.

--- a/internal/sanitize/path.go
+++ b/internal/sanitize/path.go
@@ -1,0 +1,31 @@
+package sanitize
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+var ErrInvalidFilePath = errors.New("invalid file path in archive")
+
+// ZipFilePath validates that a file path from a zip archive is safe and within the expected directory.
+func ZipFilePath(filePath string, targetDir string) error {
+	cleanPath := filepath.Clean(filePath)
+
+	if filepath.IsAbs(cleanPath) || filepath.VolumeName(cleanPath) != "" {
+		return fmt.Errorf("%w: %s", ErrInvalidFilePath, filePath)
+	}
+
+	destPath := filepath.Join(targetDir, cleanPath)
+	relPath, err := filepath.Rel(targetDir, destPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve path: %s: %w", filePath, err)
+	}
+
+	if strings.HasPrefix(relPath, "..") {
+		return fmt.Errorf("%w: %s", ErrInvalidFilePath, filePath)
+	}
+
+	return nil
+}

--- a/internal/sanitize/path_test.go
+++ b/internal/sanitize/path_test.go
@@ -1,0 +1,78 @@
+package sanitize
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestZipFilePath(t *testing.T) {
+	targetDir := "/tmp/bundles/test-bundle"
+
+	tests := []struct {
+		filePath    string
+		targetDir   string
+		wantErr     bool
+		errContains error
+	}{
+		{
+			filePath:  "middleware.js",
+			targetDir: targetDir,
+			wantErr:   false,
+		},
+		{
+			filePath:  "lib/utils.js",
+			targetDir: targetDir,
+			wantErr:   false,
+		},
+		{
+			filePath:  "config.test.js",
+			targetDir: targetDir,
+			wantErr:   false,
+		},
+		{
+			filePath:    "/test/path",
+			targetDir:   targetDir,
+			wantErr:     true,
+			errContains: ErrInvalidFilePath,
+		},
+		{
+			filePath:    "../../test/path",
+			targetDir:   targetDir,
+			wantErr:     true,
+			errContains: ErrInvalidFilePath,
+		},
+		{
+			filePath:    "invalid/../../test/path",
+			targetDir:   targetDir,
+			wantErr:     true,
+			errContains: ErrInvalidFilePath,
+		},
+		{
+			filePath:    "./../test",
+			targetDir:   targetDir,
+			wantErr:     true,
+			errContains: ErrInvalidFilePath,
+		},
+		{
+			filePath:  "./middleware.js",
+			targetDir: targetDir,
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.filePath, func(t *testing.T) {
+			err := ZipFilePath(tt.filePath, tt.targetDir)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errContains != nil {
+					assert.ErrorIs(t, err, tt.errContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-15839" title="TT-15839" target="_blank">TT-15839</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>Ready for Testing</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%202025_r5_confirmed%20ORDER%20BY%20created%20DESC" title="2025_r5_confirmed">2025_r5_confirmed</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20security%20ORDER%20BY%20created%20DESC" title="security">security</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20stability_theme_security%20ORDER%20BY%20created%20DESC" title="stability_theme_security">stability_theme_security</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

[TT-15839] Adding bundle validation (#7422)

Added new internal/sanitize package to validate bundle zip files.

[TT-15839]: https://tyktech.atlassian.net/browse/TT-15839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Tests



___

### Diagram Walkthrough


```mermaid
flowchart LR
  ZipR["Zip reader files"] -- "validate f.Name" --> San["sanitize.ZipFilePath"]
  San -- "valid" --> Write["Create dirs/files under bundlePath"]
  San -- "invalid" --> Err["return ErrInvalidFilePath"]
  Save["saveBundle()"] -- "return saver.Save error" --> Caller["Gateway"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coprocess_bundle.go</strong><dd><code>Enforce zip path validation and error propagation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/coprocess_bundle.go

<ul><li>Validate each zip entry via sanitize.ZipFilePath.<br> <li> Join only validated names to bundle path.<br> <li> Return saver.Save error instead of discarding.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7455/files#diff-72df0cbfd3765a5d0bff62196c11008596608a21a53dbb9c65bfc6f008dbfa29">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>path.go</strong><dd><code>New sanitizer for safe zip file paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/sanitize/path.go

<ul><li>Add ZipFilePath validator preventing absolute/traversal paths.<br> <li> Introduce ErrInvalidFilePath for invalid archive paths.<br> <li> Ensure resolved path stays within targetDir.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7455/files#diff-b9e13b719317084494e793e9bdfc9d3bc428be5edf17fa2886844a9bf7886a5b">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>path_test.go</strong><dd><code>Tests for zip path sanitizer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/sanitize/path_test.go

<ul><li>Add tests covering valid and traversal cases.<br> <li> Assert ErrInvalidFilePath for unsafe inputs.<br> <li> Verify dot-prefixed safe paths pass.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7455/files#diff-f549ec274c88217e43c5c8a3a60b73e49c06b85d6ba1ab3dd0dccbec4b087228">+78/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

