### PR TITLE
Merging to release-5.8: [TT-15415] Added response body size validation (#7430)

### DIFF
--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -629,6 +629,9 @@
         },
         "max_request_body_size": {
           "type": "integer"
+        },
+        "max_response_body_size": {
+          "type": "integer"
         }
       }
     },

--- a/config/config.go
+++ b/config/config.go
@@ -538,6 +538,15 @@ type HttpServerOptionsConfig struct {
 	// See more information about setting request size limits here:
 	// https://tyk.io/docs/api-management/traffic-transformation/#request-size-limits
 	MaxRequestBodySize int64 `json:"max_request_body_size"`
+
+	// MaxResponseBodySize configures an upper limit for the size of the response body (payload) in bytes.
+	//
+	// This limit is currently applied only if the Response Body Transform middleware is enabled.
+	//
+	// The Gateway will return `HTTP 500 Response Body Too Large` if the response payload exceeds MaxResponseBodySize+1 bytes.
+	//
+	// A value of zero (default) means that no maximum is set and response bodies will not be limited.
+	MaxResponseBodySize int64 `json:"max_response_body_size"`
 }
 
 type AuthOverrideConf struct {


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-15415" title="TT-15415" target="_blank">TT-15415</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>[Zerocopter] Potential Resource Exhaustion Vulnerability in Tyk Gateway</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>Ready for Testing</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%202025_r5_confirmed%20ORDER%20BY%20created%20DESC" title="2025_r5_confirmed">2025_r5_confirmed</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20customer_bug%20ORDER%20BY%20created%20DESC" title="customer_bug">customer_bug</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20security%20ORDER%20BY%20created%20DESC" title="security">security</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20stability_theme_security%20ORDER%20BY%20created%20DESC" title="stability_theme_security">stability_theme_security</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20zerocopter%20ORDER%20BY%20created%20DESC" title="zerocopter">zerocopter</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

[TT-15415] Added response body size validation (#7430)

Introduced a new configuration option MaxResponseBodySize to set a maximum size limit for response bodies during transformation.

[TT-15415]: https://tyktech.atlassian.net/browse/TT-15415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Tests, Enhancement


___

### **Description**
- Add response body max size config

- Enforce limit in response transformer

- Return 500 when limit exceeded

- Add tests for size constraints


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cfg["HttpServerOptions.MaxResponseBodySize"]
  mw["ResponseTransformMiddleware"]
  lim["LimitReader(max+1)"]
  chk["Size check"]
  ok["Transform and rewrite body"]
  err["HTTP 500: Response body too large"]

  cfg -- "read in" --> mw
  mw -- "wrap reader" --> lim
  lim -- "ReadAll" --> chk
  chk -- "<= max" --> ok
  chk -- "> max" --> err
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.go</strong><dd><code>Add MaxResponseBodySize to server options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/config.go

<ul><li>Add <code>MaxResponseBodySize</code> field to <code>HttpServerOptionsConfig</code>.<br> <li> Document behavior, scope, and default.<br> <li> Describe 500 error when limit exceeded.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7457/files#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>res_handler_transform.go</strong><dd><code>Enforce response size in transform middleware</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/res_handler_transform.go

<ul><li>Introduce <code>ErrResponseSizeLimitExceeded</code>.<br> <li> Add <code>GetResponseBody</code> with limit enforcement.<br> <li> Use limit in <code>HandleResponse</code>; return 500 on exceed.<br> <li> Add logging for read and size violations.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7457/files#diff-f8499feb1343c99c7356d52ffd87f87d09af4c829daf3bb05b30bbceba47b9c1">+42/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>res_handler_transform_test.go</strong><dd><code>Tests for response body size enforcement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/res_handler_transform_test.go

<ul><li>Add tests covering body size constraints.<br> <li> Verify transform success within limits.<br> <li> Assert 500 and error message on exceed.<br> <li> Test zero (disabled) and boundary cases.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7457/files#diff-42198edda5bb9345202a11ffa53beb3730018f9613fa5d343df281375004eaf2">+100/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schema.json</strong><dd><code>Schema: add max_response_body_size option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/linter/schema.json

<ul><li>Extend schema with <code>max_response_body_size</code> integer.<br> <li> Keep <code>max_request_body_size</code> unchanged.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7457/files#diff-103cec746d3e61d391c5a67c171963f66fea65d651d704d5540e60aa5d574f46">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

