### PR TITLE
[TT-1417] Custom Key Registration Failing with sha256 enabled when OrgID is empty

### DIFF
--- a/gateway/api.go
+++ b/gateway/api.go
@@ -1602,12 +1602,15 @@ func (gw *Gateway) keyHandler(w http.ResponseWriter, r *http.Request) {
 			obj, code = gw.handleAddOrUpdate(origKeyName, r, isHashed)
 		}
 	case http.MethodGet:
-		if keyName != "" {
-			// Return single key detail
-			obj, code = gw.handleGetDetail(keyName, apiID, orgID, isHashed)
-			if code != http.StatusOK && hashKeyFunction != "" {
-				// try to use legacy key format
-				obj, code = gw.handleGetDetail(origKeyName, apiID, orgID, isHashed)
+		if origKeyName != "" {
+		keyTries:
+			for _, key := range []string{
+				gw.generateToken(orgID, origKeyName),
+				origKeyName,
+			} {
+				if obj, code = gw.handleGetDetail(key, apiID, orgID, isHashed); code == http.StatusOK {
+					break keyTries
+				}
 			}
 		} else {
 			// Return list of keys

--- a/gateway/api_keys_hander_test.go
+++ b/gateway/api_keys_hander_test.go
@@ -1,0 +1,142 @@
+package gateway
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/test"
+	"github.com/TykTechnologies/tyk/user"
+)
+
+type hashKeyFunction struct {
+	value string
+}
+
+func (hfn hashKeyFunction) name() string {
+	if hfn.value == "" {
+		return "none"
+	}
+
+	return hfn.value
+}
+
+var (
+	hashKeyFunctionNone      = hashKeyFunction{""}
+	hashKeyFunctionMurmur64  = hashKeyFunction{"murmur64"}
+	hashKeyFunctionMurmur128 = hashKeyFunction{"murmur128"}
+	hashKeyFunctionSha256    = hashKeyFunction{"sha256"}
+)
+
+func TestKeyHandlerHandler(t *testing.T) {
+	for _, tc := range []hashKeyFunction{
+		hashKeyFunctionNone,
+		hashKeyFunctionMurmur64,
+		hashKeyFunctionMurmur128,
+		hashKeyFunctionSha256,
+	} {
+		t.Run(tc.name(), func(t *testing.T) {
+			runTestKeyHandler(t, tc)
+		})
+	}
+}
+
+func runTestKeyHandler(t *testing.T, hashFunc hashKeyFunction) {
+	t.Helper()
+
+	ts := StartTest(func(cnf *config.Config) {
+		cnf.HashKeys = hashFunc != hashKeyFunctionNone
+		cnf.HashKeyFunction = hashFunc.value
+	})
+
+	t.Cleanup(ts.Close)
+
+	const keyId = "my-proper-id"
+	const orgId = "some-org"
+
+	keyDto := createKey(t, ts, keyId, orgId)
+
+	t.Run("direct get works if provided proper org id", func(t *testing.T) {
+		_, err := ts.Run(t, test.TestCase{
+			Path:      fmt.Sprintf("/tyk/keys/%s?org_id=%s", keyId, orgId),
+			Method:    http.MethodGet,
+			Code:      http.StatusOK,
+			AdminAuth: true,
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("access with responded does not work if wrong org_id provided", func(t *testing.T) {
+		_, err := ts.Run(t, test.TestCase{
+			Path:      fmt.Sprintf("/tyk/keys/%s?org_id=%s", keyId, ""),
+			Method:    http.MethodGet,
+			Code:      http.StatusNotFound,
+			AdminAuth: true,
+		})
+		assert.NoError(t, err)
+
+		_, err = ts.Run(t, test.TestCase{
+			Path:      fmt.Sprintf("/tyk/keys/%s?org_id=%s", keyId, "wrong-org-id"),
+			Method:    http.MethodGet,
+			Code:      http.StatusNotFound,
+			AdminAuth: true,
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("access with responded key works without passing org_id", func(t *testing.T) {
+		_, err := ts.Run(t, test.TestCase{
+			Path:      fmt.Sprintf("/tyk/keys/%s", keyDto.Key),
+			Method:    http.MethodGet,
+			Code:      http.StatusOK,
+			AdminAuth: true,
+		})
+		assert.NoError(t, err)
+	})
+}
+
+func createKey(t *testing.T, ts *Test, rawKey string, orgId string) *apiModifyKeySuccess {
+	t.Helper()
+
+	res, err := ts.Run(t, test.TestCase{
+		Path:      fmt.Sprintf("/tyk/keys/%s", rawKey),
+		Method:    http.MethodPost,
+		Code:      http.StatusOK,
+		AdminAuth: true,
+		Data: &user.SessionState{
+			OrgID: orgId,
+			AccessRights: map[string]user.AccessDefinition{
+				"fake_api_id": {
+					APIID:   "fake_ip_id",
+					APIName: "fake_api_name",
+				},
+			},
+		},
+	})
+
+	assert.NoError(t, err)
+
+	bData, err := io.ReadAll(res.Body)
+	assert.NoError(t, err)
+
+	defer func() {
+		err := res.Body.Close()
+		assert.NoError(t, err)
+	}()
+
+	var responseDto = new(apiModifyKeySuccess)
+
+	err = json.Unmarshal(bData, responseDto)
+	assert.NoError(t, err)
+
+	return responseDto
+}


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-1417" title="TT-1417" target="_blank">TT-1417</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Custom Key Registration Failing with sha256 enabled when OrgID is empty</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Code Review</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%202025_long_tail%20ORDER%20BY%20created%20DESC" title="2025_long_tail">2025_long_tail</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%202025_r6_candidate%20ORDER%20BY%20created%20DESC" title="2025_r6_candidate">2025_r6_candidate</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20A%20ORDER%20BY%20created%20DESC" title="A">A</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20AI-Complexity-Low%20ORDER%20BY%20created%20DESC" title="AI-Complexity-Low">AI-Complexity-Low</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20AI-Priority-Medium%20ORDER%20BY%20created%20DESC" title="AI-Priority-Medium">AI-Priority-Medium</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20America's%20ORDER%20BY%20created%20DESC" title="America's">America's</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20CSE%20ORDER%20BY%20created%20DESC" title="CSE">CSE</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20Gold%20ORDER%20BY%20created%20DESC" title="Gold">Gold</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20codilime_refined%20ORDER%20BY%20created%20DESC" title="codilime_refined">codilime_refined</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20customer_bug%20ORDER%20BY%20created%20DESC" title="customer_bug">customer_bug</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20github%20ORDER%20BY%20created%20DESC" title="github">github</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20jira_escalated%20ORDER%20BY%20created%20DESC" title="jira_escalated">jira_escalated</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix key GET to try org-scoped formats

- Add comprehensive hash-function test matrix

- Support lookup without org_id using returned key

- Preserve legacy key format fallback


___

### Diagram Walkthrough


```mermaid
flowchart LR
  GETReq["GET /tyk/keys/{id}"] -- "try org-scoped key" --> OrgScoped["gw.generateToken(orgID, key)"]
  GETReq -- "fallback to raw key" --> RawKey["origKeyName"]
  OrgScoped -- "found" --> OK["200 OK"]
  RawKey -- "found" --> OK
  RawKey -- "not found" --> NotFound["404 Not Found"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api.go</strong><dd><code>Robust key GET with org-scoped and raw fallbacks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api.go

<ul><li>On GET, try <code>generateToken(orgID, origKeyName)</code>.<br> <li> Fallback to <code>origKeyName</code> if first fails.<br> <li> Replace single attempt with ordered tries loop.<br> <li> Targets cases with empty or unknown <code>org_id</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7462/files#diff-644cda3aeb4ac7f325359e85fcddb810f100dd5e6fa480b0d9f9363a743c4e05">+9/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api_keys_hander_test.go</strong><dd><code>Tests cover key retrieval across hash functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/api_keys_hander_test.go

<ul><li>Add table-driven tests for hash functions.<br> <li> Verify GET with correct org_id succeeds.<br> <li> Ensure wrong/empty org_id returns 404.<br> <li> Validate GET without org_id using returned key works.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7462/files#diff-1f04b858edca05af9d4111f619224f2266ba48486579ccb9e3716fd40334f407">+142/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

