### PR TITLE
[TT-15734] Handle big.Int JSON marshaling errors in logrus formatter

### DIFF
--- a/log/json_formatter.go
+++ b/log/json_formatter.go
@@ -42,11 +42,14 @@ func (f *JSONFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 		data = newData
 	}
 
-	if len(entry.Data) > 0 {
-		if err, ok := entry.Data[logrus.ErrorKey]; ok {
-			data[logrus.FieldKeyLogrusError] = err
+	if v, ok := entry.Data[logrus.ErrorKey]; ok {
+		if e, ok := v.(error); ok {
+			data[logrus.FieldKeyLogrusError] = e.Error()
+		} else {
+			data[logrus.FieldKeyLogrusError] = v
 		}
 	}
+
 	if !f.DisableTimestamp {
 		data[logrus.FieldKeyTime] = entry.Time.Format(f.TimestampFormat)
 	}


### PR DESCRIPTION
### **User description**
<details open>
  <summary><a href="https://tyktech.atlassian.net/browse/TT-15734" title="TT-15734" target="_blank">TT-15734</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>JSONFormatter fails with certain data types</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://tyktech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Dev</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%202025_r6_candidate%20ORDER%20BY%20created%20DESC" title="2025_r6_candidate">2025_r6_candidate</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20AI-Complexity-Medium%20ORDER%20BY%20created%20DESC" title="AI-Complexity-Medium">AI-Complexity-Medium</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20AI-Priority-High%20ORDER%20BY%20created%20DESC" title="AI-Priority-High">AI-Priority-High</a>, <a href="https://tyktech.atlassian.net/issues?jql=project%20%3D%20TT%20AND%20labels%20%3D%20stability_theme_observability%20ORDER%20BY%20created%20DESC" title="stability_theme_observability">stability_theme_observability</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<!-- Provide a general summary of your changes in the Title above -->

## Description

The Problem:
When JSON logging was enabled, the gateway failed to marshal log entries containing big integer values. The JSON encoder couldn't serialize big.Int types, causing marshaling errors that prevented logs from being written to syslog and triggered premature rate limiting as a safety measure.

Why We Store in data[logrus.FieldKeyLogrusError]:
This is logrus's standard field key for structured error logging. It provides a consistent way to include error details in JSON logs, separates error information from other fields, and makes logs more searchable and parseable.

How e.Error() Solves It:
Converting error objects to strings using e.Error() ensures all error types (including those containing big.Int values) become JSON-serializable strings. This eliminates marshaling failures while preserving the error message content, allowing logs to flow properly to syslog and preventing the cascade of logging failures that caused operational issues.

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix error field JSON serialization

- Preserve non-error values in `error` key

- Add tests for formatter error handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  JSONF["JSONFormatter.Format"] -- "reads entry.Data[ErrorKey]" --> Branch{"type assertion"}
  Branch -- "error" --> ErrStr["use e.Error() string"]
  Branch -- "non-error" --> KeepVal["keep original value"]
  JSONF -- "serialize to JSON" --> Output["JSON log entry"]
  Tests["log/log_test.go"] -- "cover 3 scenarios" --> JSONF
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>json_formatter.go</strong><dd><code>Robust handling of `logrus.ErrorKey` in formatter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

log/json_formatter.go

<ul><li>Convert <code>error</code> values to string via <code>Error()</code>.<br> <li> Keep non-error <code>error</code> key values unchanged.<br> <li> Remove length guard; check key presence directly.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7465/files#diff-853aed4184e8d1b7471cd89678667aafd72d64933b38b3ad8c36b7f1319c7378">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>log_test.go</strong><dd><code>Tests for JSON formatter error key handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

log/log_test.go

<ul><li>Add tests for error type value.<br> <li> Add tests for non-error value.<br> <li> Add test when no error key present.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7465/files#diff-86c6c547a3e3c686a598e339acecbf5190185d424d96f9b9a0fff3d8513a90eb">+49/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

