### PR TITLE
misc performance optimizations

### DIFF
--- a/ctx/ctx.go
+++ b/ctx/ctx.go
@@ -53,6 +53,7 @@ const (
 	CacheOptions
 	OASDefinition
 	SelfLooping
+	RequestLogger
 )
 
 func ctxSetSession(r *http.Request, s *user.SessionState, scheduleUpdate bool, hashKey bool) {

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -3381,6 +3381,19 @@ func ctxGetRequestStatus(r *http.Request) (stat RequestStatus) {
 	return
 }
 
+func ctxSetRequestLogger(r *http.Request, logger *logrus.Entry) {
+	setCtxValue(r, ctx.RequestLogger, logger)
+}
+
+func ctxGetRequestLogger(r *http.Request) *logrus.Entry {
+	if v := r.Context().Value(ctx.RequestLogger); v != nil {
+		if logger, ok := v.(*logrus.Entry); ok {
+			return logger
+		}
+	}
+	return nil
+}
+
 var createOauthClientSecret = func() string {
 	secret := uuid.New()
 	return base64.StdEncoding.EncodeToString([]byte(secret))

--- a/gateway/log_helpers.go
+++ b/gateway/log_helpers.go
@@ -65,3 +65,18 @@ func (gw *Gateway) getExplicitLogEntryForRequest(logger *logrus.Entry, path stri
 	}
 	return logger.WithFields(fields)
 }
+
+// getOrCreateRequestLogger returns a cached logger from the request context
+// or creates a new one if it doesn't exist. This reduces allocations by
+// ensuring the logger is only created once per request instead of once per middleware.
+func (gw *Gateway) getOrCreateRequestLogger(r *http.Request, key string) *logrus.Entry {
+	// Check if logger already exists in context
+	if logger := ctxGetRequestLogger(r); logger != nil {
+		return logger
+	}
+
+	// Create new logger and cache it in context
+	logger := gw.getLogEntryForRequest(logrus.NewEntry(log), r, key, nil)
+	ctxSetRequestLogger(r, logger)
+	return logger
+}

--- a/gateway/middleware_decorators.go
+++ b/gateway/middleware_decorators.go
@@ -22,7 +22,10 @@ func withLogger(
 ) tykResponseDecorator {
 
 	return func(origin TykResponseHandler) TykResponseHandler {
-		origin.setLogger(logger.WithField("mw", origin.Name()).WithField("type", "response"))
+		origin.setLogger(logger.WithFields(logrus.Fields{
+			"mw":   origin.Name(),
+			"type": "response",
+		}))
 
 		return &logDecorator{
 			TykResponseHandler: origin,
@@ -51,14 +54,19 @@ func (d *logDecorator) HandleResponse(
 ) error {
 
 	start := time.Now()
-	d.logger().WithField("ts", start.UnixNano()).Debug("Started")
+	logger := d.logger()
+	if logger.Logger.IsLevelEnabled(logrus.DebugLevel) {
+		logger.WithField("ts", start.UnixNano()).Debug("Started")
+	}
 
 	if err := d.TykResponseHandler.HandleResponse(writer, response, request, state); err != nil {
 		d.logger().WithField("ns", time.Since(start).Nanoseconds()).WithError(err).Error("Failed to process response")
 		return err
 	}
 
-	d.logger().WithField("ns", time.Since(start).Nanoseconds()).Debug("Finished")
+	if logger.Logger.IsLevelEnabled(logrus.DebugLevel) {
+		logger.WithField("ns", time.Since(start).Nanoseconds()).Debug("Finished")
+	}
 
 	return nil
 }

--- a/gateway/mw_granular_access.go
+++ b/gateway/mw_granular_access.go
@@ -69,7 +69,11 @@ func (m *GranularAccessMiddleware) ProcessRequest(w http.ResponseWriter, r *http
 			// if loglevel is set to debug verbosity increases and all requests are logged,
 			// regardless if an error occured or not.
 			if gwConfig.LogLevel == "debug" || err != nil {
-				logger = logger.WithError(err).WithField("pattern", pattern).WithField("match", match)
+				logger = logger.WithFields(logrus.Fields{
+				"error":   err,
+				"pattern": pattern,
+				"match":   match,
+			})
 				if err != nil {
 					logger.Error("error matching endpoint")
 				} else {

--- a/gateway/mw_url_rewrite.go
+++ b/gateway/mw_url_rewrite.go
@@ -536,7 +536,11 @@ func (m *URLRewriteMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Req
 	}
 
 	if err = m.CheckHostRewrite(oldPath, p, r); err != nil {
-		log.WithError(err).WithField("from", oldPath).WithField("to", p).Error("Checking Host rewrite: error parsing URL")
+		log.WithFields(logrus.Fields{
+			"error": err,
+			"from":  oldPath,
+			"to":    p,
+		}).Error("Checking Host rewrite: error parsing URL")
 	}
 
 	newURL, err := url.Parse(p)

--- a/gateway/proxy_muxer.go
+++ b/gateway/proxy_muxer.go
@@ -206,8 +206,10 @@ func (m *proxyMux) setRouter(port int, protocol string, router *mux.Router, conf
 func (m *proxyMux) handle404(w http.ResponseWriter, r *http.Request) {
 	if m.track404Logs {
 		requestMeta := fmt.Sprintf("%s %s %s", r.Method, r.URL.Path, r.Proto)
-		log.WithField("request", requestMeta).WithField("origin", r.RemoteAddr).
-			Error(http.StatusText(http.StatusNotFound))
+		log.WithFields(logrus.Fields{
+			"request": requestMeta,
+			"origin":  r.RemoteAddr,
+		}).Error(http.StatusText(http.StatusNotFound))
 	}
 
 	w.WriteHeader(http.StatusNotFound)

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -516,12 +516,16 @@ var hopHeaders = []string{
 
 func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) ProxyResponse {
 	startTime := time.Now()
-	p.logger.WithField("ts", startTime.UnixNano()).Debug("Started")
+	if p.logger.Logger.IsLevelEnabled(logrus.DebugLevel) {
+		p.logger.WithField("ts", startTime.UnixNano()).Debug("Started")
+	}
 
 	resp := p.WrappedServeHTTP(rw, req, recordDetail(req, p.TykAPISpec))
 
 	finishTime := time.Since(startTime)
-	p.logger.WithField("ns", finishTime.Nanoseconds()).Debug("Finished")
+	if p.logger.Logger.IsLevelEnabled(logrus.DebugLevel) {
+		p.logger.WithField("ns", finishTime.Nanoseconds()).Debug("Finished")
+	}
 
 	// make response body to be nopCloser and re-readable before serve it through chain of middlewares
 	nopCloseResponseBody(resp.Response)
@@ -531,12 +535,16 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) Prox
 
 func (p *ReverseProxy) ServeHTTPForCache(rw http.ResponseWriter, req *http.Request) ProxyResponse {
 	startTime := time.Now()
-	p.logger.WithField("ts", startTime.UnixNano()).Debug("Started")
+	if p.logger.Logger.IsLevelEnabled(logrus.DebugLevel) {
+		p.logger.WithField("ts", startTime.UnixNano()).Debug("Started")
+	}
 
 	resp := p.WrappedServeHTTP(rw, req, true)
 	nopCloseResponseBody(resp.Response)
 	finishTime := time.Since(startTime)
-	p.logger.WithField("ns", finishTime.Nanoseconds()).Debug("Finished")
+	if p.logger.Logger.IsLevelEnabled(logrus.DebugLevel) {
+		p.logger.WithField("ns", finishTime.Nanoseconds()).Debug("Finished")
+	}
 
 	return resp
 }
@@ -831,7 +839,9 @@ func (rt *TykRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 			return nil, errors.New("handler could")
 		}
 
-		rt.logger.WithField("looping_url", "tyk://"+r.Host).Debug("Executing request on internal route")
+		if rt.logger.Logger.IsLevelEnabled(logrus.DebugLevel) {
+			rt.logger.WithField("looping_url", "tyk://"+r.Host).Debug("Executing request on internal route")
+		}
 
 		return handleInMemoryLoop(handler, r)
 	}


### PR DESCRIPTION
### **User description**
1. Replace chained withFields to use a single WithFields
2. check for debug log enabled before invoking debug logs
3. store request logger in the context to minimize amount of instantiation calls.

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


___

### **PR Type**
Enhancement


___

### **Description**
- Add context-cached request logger

- Reduce debug log allocations

- Use batched WithFields calls

- Guard debug logs with level checks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Ctx["Add ctx key: `RequestLogger`"] -- used by --> GW["Gateway logger helpers"]
  GW -- provides --> GetOrCreate["`getOrCreateRequestLogger(r, key)`"]
  GetOrCreate -- caches in --> Ctx
  Middlewares["Middlewares and decorators"] -- use --> GetOrCreate
  DebugChecks["Debug-level guards"] -- wrap --> Logs["Start/Finish debug logs"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>ctx.go</strong><dd><code>Introduce `RequestLogger` context key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7483/files#diff-600f5f552779994b15324fda108549eec7e7be30b1d8a1a16ee8344243e0cbc7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>api.go</strong><dd><code>Add getters/setters for request logger in context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7483/files#diff-644cda3aeb4ac7f325359e85fcddb810f100dd5e6fa480b0d9f9363a743c4e05">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>log_helpers.go</strong><dd><code>Cache per-request logger via context utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7483/files#diff-09ae6fbbd4356171d32de9c73885565376af155e3d75d3e9fa78c4d3abad7fdb">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>middleware.go</strong><dd><code>Guard debug logs; use context logger in BaseMiddleware</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7483/files#diff-703054910891a4db633eca0f42ed779d6b4fa75cd9b3aa4c503e681364201c1b">+21/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>middleware_decorators.go</strong><dd><code>Batch log fields and guard debug timings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7483/files#diff-fa58c743ea567e4559ce0d281d5ba46fa5c74b20b4b99199fa66931077be487a">+11/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mw_granular_access.go</strong><dd><code>Batch fields for structured logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7483/files#diff-618f7d55751d572562a29506a13beba2da969436e974f8b51df7d9708c925436">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mw_url_rewrite.go</strong><dd><code>Use WithFields for error context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7483/files#diff-84a6a5c810334aaa8702669f2aebf0284f116d83e8a55ec9d1d5b8bae87f1be6">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proxy_muxer.go</strong><dd><code>Consolidate 404 logs with WithFields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7483/files#diff-89fb6731880400cb95ba8860c935a308de5f55aaa41aa2c76abf3ee4773d7a87">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>reverse_proxy.go</strong><dd><code>Add debug-level guards for start/finish logs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7483/files#diff-e6e07722257f7e41691e471185ad6d84fd56dc9e5459526ea32e9a5e8fa1a01b">+15/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

