### PR TITLE
Merging to release-5.10.1: [DX-2102] Bug Fixes and Improvements in Tyk OAS (#7419)

### DIFF
--- a/apidef/oas/middleware.go
+++ b/apidef/oas/middleware.go
@@ -741,7 +741,8 @@ func (c *Cache) ExtractTo(cache *apidef.CacheOptions) {
 	cache.CacheControlTTLHeader = c.ControlTTLHeaderName
 }
 
-// Paths is a mapping of API endpoints to Path plugin configurations.
+// Paths is a mapping of API endpoints to Path plugin configurations. This field is part of the [Middleware](#middleware) structure.
+// The string keys in this object represent URL path patterns (e.g. `/users`, `/users/{id}`, `/api/*`) that match API endpoints.
 type Paths map[string]*Path
 
 // Fill fills *Paths (map) from apidef.ExtendedPathSet.
@@ -994,6 +995,8 @@ type Plugins struct {
 	Block *Allowance `bson:"block,omitempty" json:"block,omitempty"`
 
 	// IgnoreAuthentication ignores authentication on request by allowance.
+	//
+	// Tyk classic API definition: version_data.versions..extended_paths.ignored[].
 	IgnoreAuthentication *Allowance `bson:"ignoreAuthentication,omitempty" json:"ignoreAuthentication,omitempty"`
 
 	// TransformRequestMethod allows you to transform the method of a request.

--- a/apidef/oas/operation.go
+++ b/apidef/oas/operation.go
@@ -15,7 +15,7 @@ import (
 	"github.com/TykTechnologies/tyk/regexp"
 )
 
-// Operations holds Operation definitions.
+// Operations holds Operation definitions. The string key in this object is the `operationID`, which is a unique identifier for each API operation.
 type Operations map[string]*Operation
 
 // Operation holds a request operation configuration, allowances, tranformations, caching, timeouts and validation.
@@ -27,6 +27,8 @@ type Operation struct {
 	Block *Allowance `bson:"block,omitempty" json:"block,omitempty"`
 
 	// IgnoreAuthentication ignores authentication on request by allowance.
+	//
+	// Tyk classic API definition: version_data.versions..extended_paths.ignored[].
 	IgnoreAuthentication *Allowance `bson:"ignoreAuthentication,omitempty" json:"ignoreAuthentication,omitempty"`
 
 	// Internal makes the endpoint only respond to internal requests.

--- a/apidef/oas/root.go
+++ b/apidef/oas/root.go
@@ -131,7 +131,10 @@ type State struct {
 	// Active enables the API so that Tyk will listen for and process requests made to the listenPath.
 	// Tyk classic API definition: `active`
 	Active bool `bson:"active" json:"active"` // required
-	// Internal makes the API accessible only internally.
+	// Internal controls the exposure of the API on the Gateway.
+	// When set to `true`, the API will not be made available for external access and will not be included in API listings returned by the Gateway's management APIs;
+	// it will be accessible only via [internal looping]({{< ref "advanced-configuration/transform-traffic/looping" >}}) or as a [child API version]({{< ref "api-management/api-versioning#base-and-child-apis" >}}).
+	//
 	// Tyk classic API definition: `internal`
 	Internal bool `bson:"internal,omitempty" json:"internal,omitempty"`
 }

--- a/apidef/oas/server.go
+++ b/apidef/oas/server.go
@@ -200,7 +200,7 @@ type ListenPath struct {
 
 	// Strip removes the inbound listen path (as accessed by the client) when generating the outbound request for the upstream service.
 	//
-	// For example, consider the scenario where the Tyk base address is `http://acme.com/', the listen path is `example/` and the upstream URL is `http://httpbin.org/`:
+	// For example, consider the scenario where the Tyk base address is `http://acme.com/`, the listen path is `example/` and the upstream URL is `http://httpbin.org/`:
 	//
 	// - If the client application sends a request to `http://acme.com/example/get` then the request will be proxied to `http://httpbin.org/example/get`
 	// - If stripListenPath is set to `true`, the `example` listen path is removed and the request would be proxied to `http://httpbin.org/get`.


### PR DESCRIPTION
### **User description**
[DX-2102] Bug Fixes and Improvements in Tyk OAS (#7419)

### **User description**
<!-- Provide a general summary of your changes in the Title above -->

Improved Tyk OAS documentation as per the Jira
https://tyktech.atlassian.net/browse/DX-2102

Changes have already been added in the
[docs](https://github.com/TykTechnologies/tyk-docs/pull/6949)

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an
issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps
to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the
JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code,
etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test
coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes
that apply -->
<!-- If there are no documentation updates required, mark the item as
checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning
why it's required
- [ ] I would like a code coverage CI quality gate exception and have
explained why


___

### **PR Type**
Documentation


___

### **Description**
- Clarify `Paths` key semantics and examples

- Document `Operations` keyed by `operationID`

- Expand `State.Internal` exposure behavior details

- Fix typo in `ListenPath` strip example


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Paths["Paths docs"] -- clarify keys/examples --> Middleware["Middleware struct context"]
  Operations["Operations docs"] -- key is operationID --> Operation["Operation definition"]
  StateInternal["State.Internal docs"] -- detail exposure behavior --> GatewayExposure["Gateway exposure rules"]
  ListenPath["ListenPath docs"] -- fix URL typo --> Example["Strip path example"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant
files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
<summary><strong>middleware.go</strong><dd><code>Clarify Paths map keys
and context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/middleware.go

<ul><li>Expand <code>Paths</code> comment with Middleware context<br>
<li> Explain string keys as URL patterns</ul>


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7419/files#diff-992ec7c28d25fd54f6491d295389757705cd114bc869a35cba50d42e548cdc6e">+2/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>operation.go</strong><dd><code>Describe Operations
keyed by operationID</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; </dd></summary>
<hr>

apidef/oas/operation.go

- Document `Operations` map keyed by `operationID`


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7419/files#diff-6d92d2d5b09a5fa7129609bb7cd0d383d015250ec07062b6a93a83257be51fb5">+1/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>root.go</strong><dd><code>Expand Internal field
exposure semantics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; </dd></summary>
<hr>

apidef/oas/root.go

- Elaborate `State.Internal` behavior and references


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7419/files#diff-9c56b2bdb992e0a7db76809d4c516e1cd61c9486c7f0437b344c0032476af80f">+1/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
<summary><strong>server.go</strong><dd><code>Fix ListenPath strip
example URL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/server.go

- Fix base URL typo in strip example


</details>


  </td>
<td><a
href="https://github.com/TykTechnologies/tyk/pull/7419/files#diff-21857c42e8659f7980014e277c3c758703f29e9e5c0c40553f2584cddb870808">+1/-1</a>&nbsp;
&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

[DX-2102]: https://tyktech.atlassian.net/browse/DX-2102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Documentation


___

### **Description**
- Clarify OAS Paths key semantics

- Document Operations keyed by operationID

- Expand State.Internal exposure behavior

- Fix ListenPath strip example typo


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Paths["Paths map docs"] -- clarify key patterns --> Middleware["Middleware struct"]
  Ops["Operations map docs"] -- keys are operationID --> Operation["Operation struct"]
  StateInt["State.Internal docs"] -- detail exposure --> Gateway["Gateway visibility rules"]
  Listen["ListenPath docs"] -- fix base URL typo --> Example["Strip path example"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>middleware.go</strong><dd><code>Clarify Paths keys and middleware context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/middleware.go

<ul><li>Explain <code>Paths</code> belongs to <code>Middleware</code><br> <li> Define string keys as URL path patterns<br> <li> Add classic definition note for <code>IgnoreAuthentication</code></ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7486/files#diff-992ec7c28d25fd54f6491d295389757705cd114bc869a35cba50d42e548cdc6e">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>operation.go</strong><dd><code>Document Operations map keyed by operationID</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/operation.go

<ul><li>State Operations keyed by <code>operationID</code><br> <li> Add classic mapping note for IgnoreAuthentication</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7486/files#diff-6d92d2d5b09a5fa7129609bb7cd0d383d015250ec07062b6a93a83257be51fb5">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>root.go</strong><dd><code>Elaborate State.Internal gateway exposure behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/root.go

<ul><li>Expand <code>State.Internal</code> exposure semantics<br> <li> Note internal looping and child API access</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7486/files#diff-9c56b2bdb992e0a7db76809d4c516e1cd61c9486c7f0437b344c0032476af80f">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>server.go</strong><dd><code>Correct ListenPath strip example URL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apidef/oas/server.go

<ul><li>Fix base URL typo in strip example<br> <li> Keep example behavior unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7486/files#diff-21857c42e8659f7980014e277c3c758703f29e9e5c0c40553f2584cddb870808">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

