### PR TITLE
Merging to release-5.8: [TT-15201] Sometimes the data plane gateway returns 404 page not found (#7487)

### DIFF
--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -751,13 +751,10 @@ func (r *RPCStorageHandler) GetApiDefinitions(orgId string, tags []string) strin
 				"tags":  strings.Join(tags, ","),
 			},
 		)
-
-		if r.IsRetriableError(err) {
-			if rpc.Login() {
-				return r.GetApiDefinitions(orgId, tags)
-			}
-		}
-
+		// FuncClientSingleton already tries to call GetApiDefinitions with backoff.
+		// Callers of the "RPCStorageHandler.GetApiDefinitions" method should switch to the fallback
+		// by enabling emergency mode. See syncResourcesWithReload in the server.go file.
+		log.Debugf("RPC Handler: GetApiDefinitions() returned %s, returning empty string", err)
 		return ""
 	}
 	log.Debug("API Definitions retrieved")
@@ -782,12 +779,10 @@ func (r *RPCStorageHandler) GetPolicies(orgId string) string {
 			},
 		)
 
-		if r.IsRetriableError(err) {
-			if rpc.Login() {
-				return r.GetPolicies(orgId)
-			}
-		}
-
+		// FuncClientSingleton already tries to call GetPolicies with backoff.
+		// Callers of the "RPCStorageHandler.GetPolicies" method should switch to the fallback
+		// by enabling emergency mode. See syncResourcesWithReload in the server.go file.
+		log.Debugf("RPC Handler: GetPolicies() returned %s, returning empty string", err)
 		return ""
 	}
 

--- a/gateway/rpc_storage_handler_test.go
+++ b/gateway/rpc_storage_handler_test.go
@@ -780,6 +780,206 @@ func TestProcessKeySpaceChanges_UserKeyReset(t *testing.T) {
 	}
 }
 
+func TestGetApiDefinitions_Fails_With_Timeout(t *testing.T) {
+	wait := make(chan struct{})
+	defer func() {
+		close(wait)
+	}()
+
+	dispatcher := gorpc.NewDispatcher()
+	dispatcher.AddFunc("Login", func(_, _ string) bool {
+		return true
+	})
+	dispatcher.AddFunc("Disconnect", func(_ string, _ *model.GroupLoginRequest) error {
+		return nil
+	})
+	dispatcher.AddFunc("GetApiDefinitions", func(_ string, _ interface{}) (string, error) {
+		<-wait // wait until the defer method is called
+		return "sample-response", nil
+	})
+
+	rpcMock, connectionString := startRPCMock(dispatcher)
+	defer stopRPCMock(rpcMock)
+
+	g := StartTest(func(globalConf *config.Config) {
+		globalConf.SlaveOptions.UseRPC = true
+		globalConf.SlaveOptions.RPCKey = "test_org"
+		globalConf.SlaveOptions.APIKey = "key"
+		globalConf.SlaveOptions.ConnectionString = connectionString
+		globalConf.SlaveOptions.CallTimeout = 1
+		globalConf.SlaveOptions.RPCPoolSize = 2
+		globalConf.SlaveOptions.DisableKeySpaceSync = true
+	})
+	g.Gw.afterConfSetup() // sets SlaveOptions.CallTimeout to GlobalRPCCallTimeout
+
+	defer g.Close()
+
+	time.Sleep(100 * time.Millisecond)
+
+	rpcListener := RPCStorageHandler{
+		KeyPrefix:        "rpc.listener.",
+		SuppressRegister: true,
+		HashKeys:         false,
+		Gw:               g.Gw,
+	}
+
+	connected := rpcListener.Connect()
+	if !connected {
+		t.Fatal("Failed to connect to RPC server")
+	}
+	// GetApiDefinitions calls rpc.FuncClientSingleton with a backoff algorithm.
+	// The algorithm tries to call the RPC method 3 times with a 10-millisecond interval.
+	// So the "GetApiDefinitions" method will be called 4 times, including the first try.
+	// It should return an empty string instead of "sample-response".
+	assert.Equal(t, "", rpcListener.GetApiDefinitions("test_org", nil))
+}
+
+func TestGetApiDefinitions(t *testing.T) {
+	var GetApiDefinitionsResponse = "sample-response"
+
+	dispatcher := gorpc.NewDispatcher()
+	dispatcher.AddFunc("Login", func(_, _ string) bool {
+		return true
+	})
+	dispatcher.AddFunc("Disconnect", func(_ string, _ *model.GroupLoginRequest) error {
+		return nil
+	})
+	dispatcher.AddFunc("GetApiDefinitions", func(_ string, _ interface{}) (string, error) {
+		return GetApiDefinitionsResponse, nil
+	})
+
+	rpcMock, connectionString := startRPCMock(dispatcher)
+	defer stopRPCMock(rpcMock)
+
+	g := StartTest(func(globalConf *config.Config) {
+		globalConf.SlaveOptions.UseRPC = true
+		globalConf.SlaveOptions.RPCKey = "test_org"
+		globalConf.SlaveOptions.APIKey = "key"
+		globalConf.SlaveOptions.ConnectionString = connectionString
+		globalConf.SlaveOptions.CallTimeout = 1
+		globalConf.SlaveOptions.RPCPoolSize = 2
+		globalConf.SlaveOptions.DisableKeySpaceSync = true
+	})
+	g.Gw.afterConfSetup() // sets SlaveOptions.CallTimeout to GlobalRPCCallTimeout
+
+	defer g.Close()
+
+	time.Sleep(100 * time.Millisecond)
+
+	rpcListener := RPCStorageHandler{
+		KeyPrefix:        "rpc.listener.",
+		SuppressRegister: true,
+		HashKeys:         false,
+		Gw:               g.Gw,
+	}
+
+	connected := rpcListener.Connect()
+	if !connected {
+		t.Fatal("Failed to connect to RPC server")
+	}
+	assert.Equal(t, GetApiDefinitionsResponse, rpcListener.GetApiDefinitions("test_org", nil))
+}
+
+func TestGetPolicies(t *testing.T) {
+	var GetPoliciesResponse = "sample-response"
+
+	dispatcher := gorpc.NewDispatcher()
+	dispatcher.AddFunc("Login", func(_, _ string) bool {
+		return true
+	})
+	dispatcher.AddFunc("Disconnect", func(_ string, _ *model.GroupLoginRequest) error {
+		return nil
+	})
+	dispatcher.AddFunc("GetPolicies", func(_ string, _ interface{}) (string, error) {
+		return GetPoliciesResponse, nil
+	})
+
+	rpcMock, connectionString := startRPCMock(dispatcher)
+	defer stopRPCMock(rpcMock)
+
+	g := StartTest(func(globalConf *config.Config) {
+		globalConf.SlaveOptions.UseRPC = true
+		globalConf.SlaveOptions.RPCKey = "test_org"
+		globalConf.SlaveOptions.APIKey = "key"
+		globalConf.SlaveOptions.ConnectionString = connectionString
+		globalConf.SlaveOptions.CallTimeout = 1
+		globalConf.SlaveOptions.RPCPoolSize = 2
+		globalConf.SlaveOptions.DisableKeySpaceSync = true
+	})
+	g.Gw.afterConfSetup() // sets SlaveOptions.CallTimeout to GlobalRPCCallTimeout
+
+	defer g.Close()
+
+	time.Sleep(100 * time.Millisecond)
+
+	rpcListener := RPCStorageHandler{
+		KeyPrefix:        "rpc.listener.",
+		SuppressRegister: true,
+		HashKeys:         false,
+		Gw:               g.Gw,
+	}
+
+	connected := rpcListener.Connect()
+	if !connected {
+		t.Fatal("Failed to connect to RPC server")
+	}
+	assert.Equal(t, GetPoliciesResponse, rpcListener.GetPolicies("test_org"))
+}
+
+func TestGetPolicies_Fails_With_Timeout(t *testing.T) {
+	wait := make(chan struct{})
+	defer func() {
+		close(wait)
+	}()
+
+	dispatcher := gorpc.NewDispatcher()
+	dispatcher.AddFunc("Login", func(_, _ string) bool {
+		return true
+	})
+	dispatcher.AddFunc("Disconnect", func(_ string, _ *model.GroupLoginRequest) error {
+		return nil
+	})
+	dispatcher.AddFunc("GetPolicies", func(_ string, _ interface{}) (string, error) {
+		<-wait // wait until the defer method is called
+		return "sample-response", nil
+	})
+
+	rpcMock, connectionString := startRPCMock(dispatcher)
+	defer stopRPCMock(rpcMock)
+
+	g := StartTest(func(globalConf *config.Config) {
+		globalConf.SlaveOptions.UseRPC = true
+		globalConf.SlaveOptions.RPCKey = "test_org"
+		globalConf.SlaveOptions.APIKey = "key"
+		globalConf.SlaveOptions.ConnectionString = connectionString
+		globalConf.SlaveOptions.CallTimeout = 1
+		globalConf.SlaveOptions.RPCPoolSize = 2
+		globalConf.SlaveOptions.DisableKeySpaceSync = true
+	})
+	g.Gw.afterConfSetup() // sets SlaveOptions.CallTimeout to GlobalRPCCallTimeout
+
+	defer g.Close()
+
+	time.Sleep(100 * time.Millisecond)
+
+	rpcListener := RPCStorageHandler{
+		KeyPrefix:        "rpc.listener.",
+		SuppressRegister: true,
+		HashKeys:         false,
+		Gw:               g.Gw,
+	}
+
+	connected := rpcListener.Connect()
+	if !connected {
+		t.Fatal("Failed to connect to RPC server")
+	}
+	// GetPolicies calls rpc.FuncClientSingleton with a backoff algorithm.
+	// The algorithm tries to call the RPC method 3 times with a 10-millisecond interval.
+	// So the "GetPolicies" method will be called 4 times, including the first try.
+	// It should return an empty string instead of "sample-response".
+	assert.Equal(t, "", rpcListener.GetPolicies("test_org"))
+}
+
 func TestIsRetriableError(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()


### PR DESCRIPTION
### **User description**
[TT-15201] Sometimes the data plane gateway returns 404 page not found (#7487)

This PR addresses a race condition and excessive retry behavior in the
RPC flow during GW startup.

**Background & Findings:**

* The `rpc` package defines a global `rpcOpts` struct holding state in
`atomic.Value` fields. While atomic operations are thread-safe, event
ordering isn’t guaranteed.
* The global `emergencyMode` flag starts as `true` and is toggled by
various parts of the code. Any change affects the entire process, and
`rpc.IsEmergencyMode` is used in `FromRPC` to decide whether to load API
specs from MDCB or the backup.
* If `emergencyMode` is set to `false` just before `FromRPC` is
called—while MDCB is down or responding slowly—the GW tries to fetch
specs over RPC and gets stuck waiting instead of falling back.
* `rpc.FuncClientSingleton` already retries with exponential backoff,
but `GetApiDefinitions` added another recursive retry layer on top,
causing potential infinite loops and long startup delays.

**What changed:**

* Removed the recursive retry in `GetApiDefinitions`. The method now
fails fast and relies on the GW's built-in resource sync retry mechanism
instead. See `syncResourcesWithReload` method:
https://github.com/TykTechnologies/tyk/blob/e3c1e7aee10f7ef7fd86ce6a3d61164ffb31aa8b/gateway/server.go#L1145
* Introduced controlled retries through configuration:

  ```json
  "resource_sync": {
      "retry_attempts": 2,
      "interval": 1
  }
  ```

With this config, after 2 failed attempts, the GW activates the
emergency mode and loads API specs from the backup.

**Timeout considerations:**

* `slave_options.call_timeout` defaults to 30 seconds. Since
`rpc.FuncClientSingleton` retries 4 times, this leads to a 120 second
total wait before failure.
* This excessive timeout amplifies the startup delay when MDCB is slow
or unreachable. Smaller timeout values should be recommended for
smoother failover.

**Result:**

* GW now fails over faster and more predictably.
* The RPC flow is cleaner—no redundant retry layers.
* Startup race conditions around `emergencyMode` are less likely to
leave the system hanging.

Related ticket:
[TT-15201](https://tyktech.atlassian.net/browse/TT-15201)



[TT-15201]:
https://tyktech.atlassian.net/browse/TT-15201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ




<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-15201" title="TT-15201"
target="_blank">TT-15201</a>
</summary>

|         |    |
|---------|----|
| Status  | In Code Review |
| Summary | Sometimes the data plane gateway returns '404 page not
found' when it can't load APIs from MDCB during startup |

Generated at: 2025-10-29 09:28:16

</details>

<!---TykTechnologies/jira-linter ends here-->

[TT-15201]: https://tyktech.atlassian.net/browse/TT-15201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TT-15201]: https://tyktech.atlassian.net/browse/TT-15201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Tests, Enhancement


___

### **Description**
- Remove recursive RPC retries in handlers

- Fail fast and rely on fallback mode

- Add tests for timeouts and success paths

- Improve debug logs for RPC failures


___

### Diagram Walkthrough


```mermaid
flowchart LR
  rpcCalls["RPC handlers: GetApiDefinitions/GetPolicies"]
  backoff["FuncClientSingleton backoff (built-in)"]
  failFast["Fail fast on error"]
  emergency["Gateway emergency mode fallback"]
  tests["Unit tests: success and timeout cases"]

  rpcCalls -- "use" --> backoff
  backoff -- "error" --> failFast
  failFast -- "empty result triggers" --> emergency
  tests -- "verify" --> failFast
  tests -- "verify" --> rpcCalls
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_storage_handler.go</strong><dd><code>Remove recursive retries; add fail-fast logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/rpc_storage_handler.go

<ul><li>Remove recursive retry logic in <code>GetApiDefinitions</code>.<br> <li> Remove recursive retry logic in <code>GetPolicies</code>.<br> <li> Add debug logs explaining fail-fast and fallback behavior.<br> <li> Rely on <code>FuncClientSingleton</code> backoff and emergency mode.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7490/files#diff-8875f75b602664c44b62b67a4da41d748124ad270573a44db4ec977ee5d68021">+8/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_storage_handler_test.go</strong><dd><code>Add RPC timeout and success unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/rpc_storage_handler_test.go

<ul><li>Add timeout tests for <code>GetApiDefinitions</code> and <code>GetPolicies</code>.<br> <li> Add success-path tests for both RPC methods.<br> <li> Use mocked dispatcher and RPC server for scenarios.<br> <li> Ensure empty string returned on timeout/backoff exhaustion.</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7490/files#diff-69de989a02b3bc32ae376c514ee84633c609200db22385c0e16c361d6ea74cd6">+200/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

