### PR TITLE
[TT-16109] Export GenerateTykServers so it can be used by Dashboard API

### DIFF
--- a/apidef/oas/servers_regeneration.go
+++ b/apidef/oas/servers_regeneration.go
@@ -94,6 +94,29 @@ func (s *OAS) RegenerateServers(
 	return nil
 }
 
+// GenerateTykServers generates and returns only Tyk-managed server URLs for an API.
+// This is a convenience method that generates servers without modifying the OAS spec.
+// Unlike RegenerateServers, this does not include user-defined servers and does not
+// modify the OAS servers array.
+func (s *OAS) GenerateTykServers(
+	apiData *apidef.APIDefinition,
+	baseAPI *apidef.APIDefinition,
+	config ServerRegenerationConfig,
+	versionName string,
+) []*openapi3.Server {
+	serverInfos := generateTykServers(apiData, baseAPI, config, versionName)
+
+	servers := make([]*openapi3.Server, len(serverInfos))
+	for i, info := range serverInfos {
+		servers[i] = &openapi3.Server{
+			URL:         info.url,
+			Description: info.description,
+		}
+	}
+
+	return servers
+}
+
 // generateTykServers generates all Tyk-managed server URLs for an API.
 func generateTykServers(
 	apiData *apidef.APIDefinition,


### PR DESCRIPTION
## Description

Exposese `GenerateTykServers` so that Dashboard can use it when generating the tyk OAS urls and return them via /api/apis/oas/{:apiId}/urls implemented here https://github.com/TykTechnologies/tyk-analytics/pull/5030

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-16109" title="TT-16109" target="_blank">TT-16109</a>
</summary>

|         |    |
|---------|----|
| Status  | In Dev |
| Summary | Add a new Dashboard API endpoint to retrieve Tyk-generated URLs from Tyk OAS API definitions |

Generated at: 2025-11-11 12:05:08

</details>

<!---TykTechnologies/jira-linter ends here-->

