### PR TITLE
[TT-16121] Generate relative server urls for APIs with no matching tags

### DIFF
--- a/gateway/api_oas_servers.go
+++ b/gateway/api_oas_servers.go
@@ -34,7 +34,8 @@ func buildServerRegenerationConfig(conf config.Config) oas.ServerRegenerationCon
 	return oas.ServerRegenerationConfig{
 		Protocol:      protocol,
 		DefaultHost:   defaultHost,
-		EdgeEndpoints: nil, // Gateway doesn't have edge endpoints
+		EdgeEndpoints: nil,                      // Gateway doesn't have edge endpoints
+		HybridEnabled: conf.SlaveOptions.UseRPC, // MDCB/hybrid mode flag
 	}
 }
 

--- a/gateway/api_oas_servers_test.go
+++ b/gateway/api_oas_servers_test.go
@@ -3,11 +3,11 @@ package gateway
 import (
 	"testing"
 
-	"github.com/spf13/afero"
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/apidef/oas"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -556,8 +556,8 @@ func TestUpdateOldDefaultChildServersGW(t *testing.T) {
 			APIDefinition: oldDefaultChildAPIDef,
 			OAS: oas.OAS{T: openapi3.T{
 				Servers: openapi3.Servers{
-					{URL: "http://localhost:8080/products/v1"},  // Versioned URL
-					{URL: "http://localhost:8080/products"},     // Fallback URL (should be removed)
+					{URL: "http://localhost:8080/products/v1"}, // Versioned URL
+					{URL: "http://localhost:8080/products"},    // Fallback URL (should be removed)
 				},
 			}},
 		}
@@ -828,9 +828,9 @@ func TestUpdateOldDefaultChildServersGW(t *testing.T) {
 			APIDefinition: oldDefaultChildAPIDef,
 			OAS: oas.OAS{T: openapi3.T{
 				Servers: openapi3.Servers{
-					{URL: "http://localhost:8080/products/v1"},   // Versioned URL
-					{URL: "http://localhost:8080/products"},      // Fallback URL (should be removed)
-					{URL: "http://localhost:8080/products-v1"},   // Direct URL (should remain)
+					{URL: "http://localhost:8080/products/v1"}, // Versioned URL
+					{URL: "http://localhost:8080/products"},    // Fallback URL (should be removed)
+					{URL: "http://localhost:8080/products-v1"}, // Direct URL (should remain)
 				},
 			}},
 		}


### PR DESCRIPTION
[TT-16121](https://tyktech.atlassian.net/browse/TT-16121)

Problem Solved

Previously, when an API was tagged but its tags didn't match any configured edge endpoints, the system would
generate server URLs pointing to the control plane's default host (e.g., localhost:8080). This caused issues
in MDCB/hybrid deployments where:

APIs need to be accessible through multiple edge gateways
Edge gateways are dynamically added/removed
APIs should work across different edge locations without re-configuration
Solution

The system now generates relative path URLs (e.g., /api/v1) when API tags don't match edge endpoints, allowing
edge gateways to serve the API using their own hostname without requiring API definition updates.

[TT-16121]: https://tyktech.atlassian.net/browse/TT-16121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-16121" title="TT-16121" target="_blank">TT-16121</a>
</summary>

|         |    |
|---------|----|
| Status  | In Dev |
| Summary | Server URL generation logic enhancement for distributed deployments |

Generated at: 2025-11-18 16:19:59

</details>

<!---TykTechnologies/jira-linter ends here-->
