### PR TITLE
[TT-16109][TT-16149] Fix fallback URLs and disabled domain handling after relative path changes

### DIFF
--- a/apidef/oas/servers_regeneration.go
+++ b/apidef/oas/servers_regeneration.go
@@ -195,7 +195,8 @@ func generateVersionedServers(
 	shouldAddFallbackURL := baseAPI.VersionDefinition.FallbackToDefault &&
 		baseAPI.VersionDefinition.Default != "" &&
 		baseAPI.VersionDefinition.Location != "header" &&
-		versionName == baseAPI.VersionDefinition.Default
+		(versionName == baseAPI.VersionDefinition.Default ||
+			(baseAPI.VersionDefinition.Default == apidef.Self && isBaseAPI))
 
 	// Always add versioned URLs
 	for _, host := range hosts {
@@ -237,8 +238,8 @@ func generateVersionedServers(
 
 // determineHosts determines which hosts to use for server URL generation.
 func determineHosts(apiData *apidef.APIDefinition, config ServerRegenerationConfig) []string {
-	if apiData.Domain != "" {
-		return []string{apiData.Domain}
+	if domain := apiData.GetAPIDomain(); domain != "" {
+		return []string{domain}
 	}
 
 	hosts := determineHostsWithEdgeSupport(apiData, config)


### PR DESCRIPTION
## What happened?
  Commit 398ef180d changed how we generate server URLs to always include relative paths. But it broke two things:

  1. **Disabled domains weren't working**: When an API had a custom
  domain but it was disabled, the code still treated it like it was active instead of falling back to the default host or edge endpoints.

  2. **"Self" default version broke**: When a versioned API uses
  `default: self` (meaning the base API IS the default version), it wasn't generating the fallback URLs correctly.

  ## The Fix
  - Changed from checking `apiData.Domain` directly to using `apiData.GetAPIDomain()` which properly checks if the domain is disabled
  - Updated the fallback URL logic to handle `default: self` correctly for base APIs

  ## What commit caused this?
  398ef180d - "[TT-16121] Always generate relative paths except when custom domains are configured"

  ## Tests Added
  - Disabled custom domain falling back to edge endpoints
  - Disabled custom domain falling back to default host
  - Base API with `default: self` getting both versioned and fallback URLs
  - Child API NOT getting fallback when base has `default: self`

[TT-16121]: https://tyktech.atlassian.net/browse/TT-16121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-16109" title="TT-16109" target="_blank">TT-16109</a>
</summary>

|         |    |
|---------|----|
| Status  | In Dev |
| Summary | Add a new Dashboard API endpoint to retrieve Tyk-generated URLs from Tyk OAS API definitions |

Generated at: 2025-11-21 10:30:00

</details>

<!---TykTechnologies/jira-linter ends here-->
