### PR TITLE
[TT-16172] Fixes bug where OAS server URLs endpoint returned "self" instead of actual version name in headers/query parameters.

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -464,6 +464,13 @@ type VersionDefinition struct {
 	BaseID string `bson:"base_id" json:"-"` // json tag is `-` because we want this to be hidden to user
 }
 
+func (v *VersionDefinition) ResolvedDefault() string {
+	if v.Default == Self {
+		return v.Name
+	}
+	return v.Default
+}
+
 type VersionData struct {
 	NotVersioned   bool                   `bson:"not_versioned" json:"not_versioned"`
 	DefaultVersion string                 `bson:"default_version" json:"default_version"`

--- a/apidef/api_definitions_test.go
+++ b/apidef/api_definitions_test.go
@@ -585,3 +585,59 @@ func TestAPIDefinition_IsBaseAPIWithVersioning(t *testing.T) {
 		})
 	}
 }
+
+func TestVersionDefinition_ResolvedDefault(t *testing.T) {
+	tests := []struct {
+		name     string
+		vd       VersionDefinition
+		expected string
+	}{
+		{
+			name: "resolves 'self' to actual version name",
+			vd: VersionDefinition{
+				Name:    "v1",
+				Default: Self,
+			},
+			expected: "v1",
+		},
+		{
+			name: "keeps specific version unchanged",
+			vd: VersionDefinition{
+				Name:    "v1",
+				Default: "v2",
+			},
+			expected: "v2",
+		},
+		{
+			name: "handles empty default",
+			vd: VersionDefinition{
+				Name:    "v1",
+				Default: "",
+			},
+			expected: "",
+		},
+		{
+			name: "handles empty name with self",
+			vd: VersionDefinition{
+				Name:    "",
+				Default: Self,
+			},
+			expected: "",
+		},
+		{
+			name: "handles both empty",
+			vd: VersionDefinition{
+				Name:    "",
+				Default: "",
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.vd.ResolvedDefault()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/gateway/versions_handler.go
+++ b/gateway/versions_handler.go
@@ -66,7 +66,7 @@ func (h *VersionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			VersionName:      name,
 			Internal:         currentAPI.Internal,
 			ExpirationDate:   currentAPI.Expiration,
-			IsDefaultVersion: baseAPI.VersionDefinition.Default == name,
+			IsDefaultVersion: baseAPI.VersionDefinition.ResolvedDefault() == name,
 		})
 	}
 
@@ -81,7 +81,7 @@ func (h *VersionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			VersionName:      baseAPI.VersionDefinition.Name,
 			Internal:         baseAPI.Internal,
 			ExpirationDate:   baseAPI.Expiration,
-			IsDefaultVersion: baseAPI.VersionDefinition.Default == baseAPI.VersionDefinition.Name,
+			IsDefaultVersion: baseAPI.VersionDefinition.ResolvedDefault() == baseAPI.VersionDefinition.Name,
 		}}, versionMetas.Metas...)
 	}
 


### PR DESCRIPTION
TT-16172

## Description

Updates the dashboard to use the gateway's `VersionDefinition.ResolvedDefault()` method for resolving the "self" version keyword, fixing a bug where the OAS server URLs endpoint returned the literal string "self" instead of the actual version name.

<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-16172" title="TT-16172" target="_blank">TT-16172</a>
</summary>

|         |    |
|---------|----|
| Status  | Open |
| Summary | [Versioning] header location shows `self`  |

Generated at: 2025-11-25 06:14:41

</details>

<!---TykTechnologies/jira-linter ends here-->
