### PR TITLE
[TT-16176] Generate relative patsh when tags are disabled or 0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -436,6 +436,36 @@ jobs:
         with:
           report_xml: 'true'
           execution_status: ${{ steps.test_execution.outcome }}
+  aggregator-ci-test:
+    name: Aggregated CI Status
+    runs-on: ubuntu-latest
+    # Dynamically determine which jobs to depend on based on repository configuration
+    needs: [goreleaser, api-tests]
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    steps:
+      - name: Aggregate results
+        run: |
+          failed=()
+          # Get the needs context as JSON once
+          needs_json='${{ toJSON(needs) }}'
+
+          # Loop through all jobs in the needs context
+          for job in $(echo "$needs_json" | jq -r 'keys[]'); do
+            job_result=$(echo "$needs_json" | jq -r --arg job "$job" '.[$job].result')
+
+            if [[ "$job_result" != "success" ]]; then
+              failed+=("$job")
+            fi
+          done
+
+          if (( ${#failed[@]} )); then
+            # Join the failed job names with commas
+            failed_jobs=$(IFS=", "; echo "${failed[*]}")
+            echo "❌ Failed jobs ----- : $failed_jobs"
+            exit 1
+          fi
+
+          echo "✅ All required jobs succeeded"
   test-controller-distros:
     if: github.event.pull_request.draft == false
     needs:

--- a/gateway/redis_signals.go
+++ b/gateway/redis_signals.go
@@ -140,10 +140,8 @@ func (gw *Gateway) handleRedisEvent(v interface{}, handled func(NotificationComm
 	case NoticeDashboardConfigRequest:
 		gw.handleSendMiniConfig(notif.Payload)
 	case NoticeGatewayDRLNotification:
-		if gw.GetConfig().ManagementNode {
-			// DRL is not initialized, going through would
-			// be mostly harmless but would flood the log
-			// with warnings since DRLManager.Ready == false
+		if gw.isDRLDisabled() {
+			// DRL is disabled - other Rate Limiter is being used or this is a Management Node.
 			return
 		}
 		gw.onServerStatusReceivedHandler(notif.Payload)

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -2052,15 +2052,13 @@ func handleDashboardRegistration(gw *Gateway) {
 func (gw *Gateway) startDRL() {
 	gwConfig := gw.GetConfig()
 
-	disabled := gwConfig.ManagementNode || gwConfig.EnableSentinelRateLimiter || gwConfig.EnableRedisRollingLimiter || gwConfig.EnableFixedWindowRateLimiter
-
 	gw.drlOnce.Do(func() {
 		drlManager := &drl.DRL{}
 		gw.SessionLimiter = NewSessionLimiter(gw.ctx, &gwConfig, drlManager, &gwConfig.ExternalServices)
 
 		gw.DRLManager = drlManager
 
-		if disabled {
+		if gw.isDRLDisabled() {
 			return
 		}
 
@@ -2075,6 +2073,12 @@ func (gw *Gateway) startDRL() {
 
 		gw.startRateLimitNotifications()
 	})
+}
+
+func (gw *Gateway) isDRLDisabled() bool {
+	gwConfig := gw.GetConfig()
+
+	return gwConfig.ManagementNode || gwConfig.EnableSentinelRateLimiter || gwConfig.EnableRedisRollingLimiter || gwConfig.EnableFixedWindowRateLimiter
 }
 
 func (gw *Gateway) setupPortsWhitelist() {


### PR DESCRIPTION
 When gateway tags are enabled with values that don't match any edge endpoints, the server URL generation was incorrectly including the default host URL. This resulted in APIs showing both absolute and relative server URLs when they should only show the relative path.

<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-16176" title="TT-16176" target="_blank">TT-16176</a>
</summary>

|         |    |
|---------|----|
| Status  | In Code Review |
| Summary | [regression][API base path] Server URLs not changed when gateway tags are disabled |

Generated at: 2025-11-25 17:57:09

</details>

<!---TykTechnologies/jira-linter ends here-->

