### PR TITLE
FIPS Docker Images for LTS releases only TT-16023

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,6 @@ jobs:
             debvers: 'ubuntu/xenial ubuntu/bionic ubuntu/focal ubuntu/jammy ubuntu/noble debian/jessie debian/buster debian/bullseye debian/bookworm debian/trixie'
     outputs:
       ee_tags: ${{ steps.ci_metadata_ee.outputs.tags }}
-      fips_tags: ${{ steps.ci_metadata_fips.outputs.tags }}
       std_tags: ${{ steps.ci_metadata_std.outputs.tags }}
       commit_author: ${{ steps.set_outputs.outputs.commit_author}}
     steps:
@@ -198,71 +197,6 @@ jobs:
           labels: ${{ steps.tag_metadata_ee.outputs.labels }}
           build-args: |
             BUILD_PACKAGE_NAME=tyk-gateway-ee
-      - name: Docker metadata for fips CI
-        id: ci_metadata_fips
-        if: ${{ matrix.golang_cross == '1.24-bullseye' }}
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ${{ steps.ecr.outputs.registry }}/tyk
-          flavor: |
-            latest=false
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=sha,format=long
-            type=semver,pattern={{major}},prefix=v
-            type=semver,pattern={{major}}.{{minor}},prefix=v
-            type=semver,pattern={{version}},prefix=v
-      - name: push fips image to CI
-        if: ${{ matrix.golang_cross == '1.24-bullseye' }}
-        uses: docker/build-push-action@v6
-        with:
-          context: "dist"
-          platforms: linux/amd64
-          file: ci/Dockerfile.distroless
-          provenance: mode=max
-          sbom: true
-          push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          tags: ${{ steps.ci_metadata_fips.outputs.tags }}
-          labels: ${{ steps.ci_metadata_fips.outputs.labels }}
-          build-args: |
-            BUILD_PACKAGE_NAME=tyk-gateway-fips
-      - name: Docker metadata for fips tag push
-        id: tag_metadata_fips
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            tykio/tyk-gateway-fips
-          flavor: |
-            latest=false
-            prefix=v
-          tags: |
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{version}}
-          labels: |
-            org.opencontainers.image.title=Tyk Gateway FIPS
-            org.opencontainers.image.description=Tyk Open Source API Gateway written in Go, supporting REST, GraphQL, TCP and gRPC protocols Built with boringssl
-            org.opencontainers.image.vendor=tyk.io
-            org.opencontainers.image.version=${{ github.ref_name }}
-      - name: push fips image to prod
-        if: ${{ matrix.golang_cross == '1.24-bullseye' }}
-        uses: docker/build-push-action@v6
-        with:
-          context: "dist"
-          platforms: linux/amd64
-          file: ci/Dockerfile.distroless
-          provenance: mode=max
-          sbom: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          push: ${{ startsWith(github.ref, 'refs/tags') }}
-          tags: ${{ steps.tag_metadata_fips.outputs.tags }}
-          labels: ${{ steps.tag_metadata_fips.outputs.labels }}
-          build-args: |
-            BUILD_PACKAGE_NAME=tyk-gateway-fips
       - name: Docker metadata for std CI
         id: ci_metadata_std
         if: ${{ matrix.golang_cross == '1.24-bullseye' }}

--- a/ci/goreleaser/goreleaser.yml
+++ b/ci/goreleaser/goreleaser.yml
@@ -57,23 +57,6 @@ builds:
     goarch:
       - s390x
     binary: tyk
-  - id: fips-amd64
-    flags:
-      - -tags=goplugin,fips,boringcrypto
-    env:
-      - NOP=nop # ignore this, it is jsut to avoid a complex conditional in the templates
-      - CC=gcc
-      - GOEXPERIMENT=boringcrypto
-    ldflags:
-      - -X github.com/TykTechnologies/tyk/internal/build.Version={{.Version}}
-      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
-      - -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
-      - -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
-    goos:
-      - linux
-    goarch:
-      - amd64
-    binary: tyk
   - id: std-amd64
     flags:
       - -tags=goplugin
@@ -185,63 +168,6 @@ nfpms:
       signature:
         key_file: tyk.io.signing.key
         type: origin
-  - id: fips
-    vendor: "Tyk Technologies Ltd"
-    homepage: "https://tyk.io"
-    maintainer: "Tyk <info@tyk.io>"
-    description: Tyk Open Source API Gateway written in Go, supporting REST, GraphQL, TCP and gRPC protocols Built with boringssl
-    package_name: tyk-gateway-fips
-    file_name_template: "{{ .ConventionalFileName }}"
-    ids:
-      - fips-amd64
-    formats:
-      - deb
-      - rpm
-    contents:
-      - src: "README.md"
-        dst: "/opt/share/docs/tyk-gateway/README.md"
-      - src: "ci/install/*"
-        dst: "/opt/tyk-gateway/install"
-      - src: ci/install/inits/systemd/system/tyk-gateway.service
-        dst: /lib/systemd/system/tyk-gateway.service
-      - src: ci/install/inits/sysv/init.d/tyk-gateway
-        dst: /etc/init.d/tyk-gateway
-      - src: /opt/tyk-gateway
-        dst: /opt/tyk
-        type: "symlink"
-      - src: "LICENSE.md"
-        dst: "/opt/share/docs/tyk-gateway/LICENSE.md"
-      - src: "apps/app_sample.*"
-        dst: "/opt/tyk-gateway/apps"
-      - src: "templates/*.json"
-        dst: "/opt/tyk-gateway/templates"
-      - src: "templates/playground/*"
-        dst: "/opt/tyk-gateway/templates/playground"
-      - src: "middleware/*.js"
-        dst: "/opt/tyk-gateway/middleware"
-      - src: "event_handlers/sample/*.js"
-        dst: "/opt/tyk-gateway/event_handlers/sample"
-      - src: "policies/*.json"
-        dst: "/opt/tyk-gateway/policies"
-      - src: "coprocess/*"
-        dst: "/opt/tyk-gateway/coprocess"
-      - src: tyk.conf.example
-        dst: /opt/tyk-gateway/tyk.conf
-        type: "config|noreplace"
-    scripts:
-      preinstall: "ci/install/before_install.sh"
-      postinstall: "ci/install/post_install.sh"
-      postremove: "ci/install/post_remove.sh"
-    bindir: "/opt/tyk-gateway"
-    rpm:
-      scripts:
-        posttrans: ci/install/post_trans.sh
-      signature:
-        key_file: tyk.io.signing.key
-    deb:
-      signature:
-        key_file: tyk.io.signing.key
-        type: origin
   - id: std
     vendor: "Tyk Technologies Ltd"
     homepage: "https://tyk.io"
@@ -305,12 +231,6 @@ publishers:
   - name: ee
     ids:
       - ee
-    env:
-      - PACKAGECLOUD_TOKEN={{ .Env.PACKAGECLOUD_TOKEN }}
-    cmd: packagecloud publish --debvers "{{ .Env.DEBVERS }}" --rpmvers "{{ .Env.RPMVERS }}" tyk/tyk-ee-unstable {{ .ArtifactPath }}
-  - name: fips
-    ids:
-      - fips
     env:
       - PACKAGECLOUD_TOKEN={{ .Env.PACKAGECLOUD_TOKEN }}
     cmd: packagecloud publish --debvers "{{ .Env.DEBVERS }}" --rpmvers "{{ .Env.RPMVERS }}" tyk/tyk-ee-unstable {{ .ArtifactPath }}


### PR DESCRIPTION
## Description
Move fips images release steps to only lts branch currently release-5.8.


## Related Issue
[TT-16023](https://tyktech.atlassian.net/browse/TT-16023)

## Motivation and Context
removes the potential for unintended fips image releases

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


[TT-16023]: https://tyktech.atlassian.net/browse/TT-16023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ