### PR TITLE
Fix nil pointer dereference in Connect

### DIFF
--- a/storage/connection_handler.go
+++ b/storage/connection_handler.go
@@ -129,6 +129,10 @@ func (rc *ConnectionHandler) recoverLoop(ctx context.Context, onReconnect func()
 //
 // onConnect will be called when we have established a successful storage reconnection
 func (rc *ConnectionHandler) Connect(ctx context.Context, onConnect func(), conf *config.Config) {
+	if onConnect == nil {
+		onConnect = func() {}
+	}
+
 	err := rc.initConnection(*conf)
 	if err != nil {
 		log.WithError(err).Error("Could not initialize connection to Redis cluster")


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes a nil pointer dereference panic in recoverLoop that occurs when Connect() is called with a nil onConnect callback and a Redis reconnection event is triggered.

The fix normalizes a nil onConnect parameter to a no-op function at the API boundary in Connect(), preventing the panic in recoverLoop when it attempts to invoke the callback.

<!-- Describe your changes in detail -->

### Changes:
* `storage/connection_handler.go`: Add nil check in Connect() to normalize nil callback to func() {}
* `storage/connection_handler_test.go`: Add two regression tests:
* `TestConnectWithNilOnConnect`: Verifies recoverLoop processes reconnect signals without panic
* `TestConnectNormalizesNilCallback`: Verifies Connect() with nil callback doesn't panic on reconnect

## Related Issue
https://github.com/TykTechnologies/tyk/issues/7355
<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
Several code paths call Connect() with a nil callback because they don't need reconnection notifications:
* `gateway/coprocess_api.go` (production code)
* Various test files

When Redis experiences a failover (e.g., Sentinel switching masters), statusCheck() detects the reconnection and sends a signal to recoverLoop(), which then attempts to call the nil callback, causing a panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
goroutine 216 [running]:
github.com/TykTechnologies/tyk/storage.(*ConnectionHandler).recoverLoop(...)
    github.com/TykTechnologies/tyk/storage/connection_handler.go:122 +0x33
```

This fix ensures the API handles nil gracefully, which is the expected behavior for optional callbacks in Go.

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->
1. Unit tests: Added two new tests that verify nil callback handling
2. Existing tests: All storage package tests pass (100+ tests)
3. Linting: golangci-lint passes with 0 issues

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [x] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
