### PR TITLE
Remove mercurial from plugin compiler Dockerfile

### DIFF
--- a/ci/images/plugin-compiler/Dockerfile
+++ b/ci/images/plugin-compiler/Dockerfile
@@ -14,7 +14,7 @@ ENV PLUGIN_SOURCE_PATH=/plugin-source
 RUN mkdir -p $TYK_GW_PATH $PLUGIN_SOURCE_PATH
 
 # remove for avoiding CVEs
-RUN apt-get purge -y --allow-remove-essential --auto-remove mercurial wget curl automake cmake python* docker* libsqlite* qemu* \
+RUN apt-get purge -y --allow-remove-essential --auto-remove wget curl automake cmake python* docker* libsqlite* qemu* \
 	&& rm -f /usr/bin/passwd /usr/sbin/adduser /usr/bin/goreleaser
 
 ADD go.mod go.sum $TYK_GW_PATH


### PR DESCRIPTION
## Description

Removes mercurial from the list of packages being purged in the plugin compiler Docker image. This package is no longer needed and removing it reduces dependencies and potential CVE exposure.

## Related Issue

N/A - Cleanup/maintenance change

## Motivation and Context

Mercurial is not required for the plugin compiler functionality and can be safely removed to reduce the image's attack surface and dependency footprint.

## How This Has Been Tested

- [ ] Verify Docker image builds successfully
- [ ] Verify plugin compilation still works as expected

## Screenshots (if appropriate)

N/A

## Types of changes

- [x] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

- [x] I ensured that the documentation is up to date
- [x] I explained why this PR updates go.mod in detail with reasoning why it's required
- [x] I would like a code coverage CI quality gate exception and have explained why