### PR TITLE
Implement response plugins to run on all responses, including error c…

### DIFF
--- a/gateway/handler_error.go
+++ b/gateway/handler_error.go
@@ -39,6 +39,10 @@ var errCustomBodyResponse = errors.New("errCustomBodyResponse")
 
 var TykErrors = make(map[string]config.TykError)
 
+type responseChainContextKey struct{}
+
+var responseChainContextKeyValue = responseChainContextKey{}
+
 func errorAndStatusCode(errType string) (error, int) {
 	err := TykErrors[errType]
 	return errors.New(err.Message), err.Code
@@ -68,6 +72,46 @@ func overrideTykErrors(gw *Gateway) {
 
 		TykErrors[id] = overridenErr
 	}
+}
+
+func applyResponseWriterHeaderDelta(before, after, target http.Header) {
+	if target == nil {
+		return
+	}
+
+	for key, afterValues := range after {
+		beforeValues, ok := before[key]
+		if !ok || !stringSliceEqual(beforeValues, afterValues) {
+			target[key] = cloneHeaderValues(afterValues)
+		}
+	}
+
+	for key := range before {
+		if _, ok := after[key]; !ok {
+			delete(target, key)
+		}
+	}
+}
+
+func stringSliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneHeaderValues(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	out := make([]string, len(values))
+	copy(out, values)
+	return out
 }
 
 // APIError is generic error object returned if there is something wrong with the request
@@ -110,8 +154,6 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 		}
 
 		w.Header().Set(header.ContentType, contentType)
-		response.Header = http.Header{}
-		response.Header.Set(header.ContentType, contentType)
 		templateName := "error_" + strconv.Itoa(errCode) + "." + templateExtension
 
 		// Try to use an error template that matches the HTTP error code and the content type: 500.json, 400.xml, etc.
@@ -128,27 +170,23 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 			templateName = defaultTemplateName + "." + defaultTemplateFormat
 			tmpl = e.Gw.templates.Lookup(templateName)
 			w.Header().Set(header.ContentType, defaultContentType)
-			response.Header.Set(header.ContentType, defaultContentType)
-
 		}
 
 		//If the config option is not set or is false, add the header
 		if !e.Spec.GlobalConfig.HideGeneratorHeader {
 			w.Header().Add(header.XGenerator, "tyk.io")
-			response.Header.Add(header.XGenerator, "tyk.io")
 		}
 
 		// Close connections
 		if e.Spec.GlobalConfig.CloseConnections {
 			w.Header().Add(header.Connection, "close")
-			response.Header.Add(header.Connection, "close")
 
 		}
 
+		response.Header = cloneHeader(w.Header())
+
 		// If error is not customized write error in default way
 		if errMsg != errCustomBodyResponse.Error() {
-			w.WriteHeader(errCode)
-			response.StatusCode = errCode
 			var tmplExecutor TemplateExecutor
 			tmplExecutor = tmpl
 
@@ -162,11 +200,52 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 				tmplExecutor = rawTmpl
 			}
 
-			var log bytes.Buffer
+			var errBody bytes.Buffer
 
-			rsp := io.MultiWriter(w, &log)
-			tmplExecutor.Execute(rsp, &apiError)
-			response.Body = ioutil.NopCloser(&log)
+			tmplExecutor.Execute(&errBody, &apiError)
+
+			response.StatusCode = errCode
+			response.Body = ioutil.NopCloser(bytes.NewReader(errBody.Bytes()))
+			response.Request = r
+
+			if len(e.Spec.ResponseChain) > 0 && r.Context().Value(responseChainContextKeyValue) != true {
+				writerHeadersBefore := cloneHeader(w.Header())
+
+				setCtxValue(r, responseChainContextKeyValue, true)
+				defer setCtxValue(r, responseChainContextKeyValue, false)
+
+				session := ctxGetSession(r)
+				handled, err := handleResponseChain(e.Spec.ResponseChain, w, response, r, session)
+				if handled {
+					// Custom response hook errors invoke their own ErrorHandler (with analytics).
+					return
+				}
+				if err != nil {
+					e.Logger().Error("Response chain failed! ", err)
+				}
+
+				errCode = response.StatusCode
+				if response.Body != nil {
+					if modifiedBody, err := io.ReadAll(response.Body); err == nil {
+						errBody.Reset()
+						errBody.Write(modifiedBody)
+					}
+					_ = response.Body.Close()
+				}
+
+				applyResponseWriterHeaderDelta(writerHeadersBefore, w.Header(), response.Header)
+
+				for k := range w.Header() {
+					w.Header().Del(k)
+				}
+				copyHeader(w.Header(), response.Header, e.Gw.GetConfig().IgnoreCanonicalMIMEHeaderKey)
+			}
+
+			w.WriteHeader(errCode)
+			response.StatusCode = errCode
+			w.Write(errBody.Bytes())
+			response.ContentLength = int64(errBody.Len())
+			response.Body = ioutil.NopCloser(bytes.NewReader(errBody.Bytes()))
 		}
 	}
 

--- a/gateway/handler_error_test.go
+++ b/gateway/handler_error_test.go
@@ -2,15 +2,20 @@ package gateway
 
 import (
 	"bytes"
+	"errors"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/header"
 	"github.com/TykTechnologies/tyk/test"
+	"github.com/TykTechnologies/tyk/user"
+	"github.com/TykTechnologies/tyk-pump/analytics"
 )
 
 func (s *Test) TestHandleError_text_xml(t *testing.T) {
@@ -121,4 +126,456 @@ func TestHandleDefaultErrorJSON(t *testing.T) {
 		},
 	})
 
+}
+
+type responseChainErrorHandler struct {
+	BaseTykResponseHandler
+	base          *BaseMiddleware
+	responseCalls int
+	errorCalls    int
+}
+
+func (h *responseChainErrorHandler) Base() *BaseTykResponseHandler {
+	return &h.BaseTykResponseHandler
+}
+
+func (h *responseChainErrorHandler) Name() string {
+	return "CustomMiddlewareResponseHook"
+}
+
+func (h *responseChainErrorHandler) HandleResponse(rw http.ResponseWriter, res *http.Response, req *http.Request, ses *user.SessionState) error {
+	h.responseCalls++
+	return errors.New("response hook error")
+}
+
+func (h *responseChainErrorHandler) HandleError(rw http.ResponseWriter, req *http.Request) {
+	h.errorCalls++
+	handler := ErrorHandler{h.base.Copy()}
+	handler.HandleError(rw, req, "Middleware error", http.StatusInternalServerError, true)
+}
+
+type responseChainModifier struct {
+	BaseTykResponseHandler
+	newStatus int
+	newBody   string
+}
+
+func (h *responseChainModifier) Base() *BaseTykResponseHandler {
+	return &h.BaseTykResponseHandler
+}
+
+func (h *responseChainModifier) Name() string {
+	return "ResponseModifier"
+}
+
+func (h *responseChainModifier) HandleResponse(rw http.ResponseWriter, res *http.Response, req *http.Request, ses *user.SessionState) error {
+	if h.newStatus != 0 {
+		res.StatusCode = h.newStatus
+	}
+	if h.newBody != "" {
+		res.Body = ioutil.NopCloser(strings.NewReader(h.newBody))
+	}
+	return nil
+}
+
+func (h *responseChainModifier) HandleError(rw http.ResponseWriter, req *http.Request) {}
+
+func TestHandleError_ResponseChainHeaders(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	specs := ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/"
+		spec.UseKeylessAccess = false
+		UpdateAPIVersion(spec, "v1", func(v *apidef.VersionInfo) {
+			v.GlobalResponseHeaders = map[string]string{
+				"X-Test": "1",
+			}
+			v.GlobalResponseHeadersRemove = []string{header.XGenerator}
+		})
+	})
+	spec := specs[0]
+
+	handler := ErrorHandler{&BaseMiddleware{Spec: spec, Gw: ts.Gw}}
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	recorder := httptest.NewRecorder()
+
+	handler.HandleError(recorder, req, MsgAuthFieldMissing, http.StatusUnauthorized, true)
+
+	resp := recorder.Result()
+	if got := resp.Header.Get("X-Test"); got != "1" {
+		t.Fatalf("expected X-Test header to be set, got %q", got)
+	}
+	if got := resp.Header.Get(header.XGenerator); got != "" {
+		t.Fatalf("expected %s header to be removed, got %q", header.XGenerator, got)
+	}
+}
+
+func TestHandleError_ResponseChainGuard(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	specs := ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/"
+	})
+	spec := specs[0]
+
+	base := NewBaseMiddleware(ts.Gw, spec, nil, nil)
+	handler := &responseChainErrorHandler{
+		BaseTykResponseHandler: BaseTykResponseHandler{Spec: spec, Gw: ts.Gw},
+		base:                   base,
+	}
+	spec.ResponseChain = []TykResponseHandler{handler}
+
+	errHandler := ErrorHandler{base}
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	recorder := httptest.NewRecorder()
+
+	errHandler.HandleError(recorder, req, "Initial error", http.StatusBadRequest, true)
+
+	if handler.responseCalls != 1 {
+		t.Fatalf("expected response chain to run once, got %d", handler.responseCalls)
+	}
+	if handler.errorCalls != 1 {
+		t.Fatalf("expected response hook error to be handled once, got %d", handler.errorCalls)
+	}
+}
+
+type responseChainWriterHeaderHandler struct {
+	BaseTykResponseHandler
+}
+
+func (h *responseChainWriterHeaderHandler) Base() *BaseTykResponseHandler {
+	return &h.BaseTykResponseHandler
+}
+
+func (h *responseChainWriterHeaderHandler) Name() string {
+	return "ResponseWriterHeaderHandler"
+}
+
+func (h *responseChainWriterHeaderHandler) HandleResponse(rw http.ResponseWriter, res *http.Response, req *http.Request, ses *user.SessionState) error {
+	rw.Header().Set("X-Writer", "1")
+	return nil
+}
+
+type responseChainCountHandler struct {
+	BaseTykResponseHandler
+	responseCalls int
+}
+
+func (h *responseChainCountHandler) Base() *BaseTykResponseHandler {
+	return &h.BaseTykResponseHandler
+}
+
+func (h *responseChainCountHandler) Name() string {
+	return "ResponseCountHandler"
+}
+
+func (h *responseChainCountHandler) HandleResponse(rw http.ResponseWriter, res *http.Response, req *http.Request, ses *user.SessionState) error {
+	h.responseCalls++
+	return nil
+}
+
+func (h *responseChainCountHandler) HandleError(rw http.ResponseWriter, req *http.Request) {}
+
+func TestHandleError_ResponseChainWriterHeaders(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	specs := ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/"
+	})
+	spec := specs[0]
+
+	handler := &responseChainWriterHeaderHandler{
+		BaseTykResponseHandler: BaseTykResponseHandler{Spec: spec, Gw: ts.Gw},
+	}
+	spec.ResponseChain = []TykResponseHandler{handler}
+
+	errHandler := ErrorHandler{NewBaseMiddleware(ts.Gw, spec, nil, nil)}
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	recorder := httptest.NewRecorder()
+
+	errHandler.HandleError(recorder, req, "Initial error", http.StatusBadRequest, true)
+
+	resp := recorder.Result()
+	if got := resp.Header.Get("X-Writer"); got != "1" {
+		t.Fatalf("expected X-Writer header to be preserved, got %q", got)
+	}
+}
+
+func TestHandleError_CustomBodyResponseSkipsResponseChain(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	specs := ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/"
+	})
+	spec := specs[0]
+
+	handler := &responseChainCountHandler{
+		BaseTykResponseHandler: BaseTykResponseHandler{Spec: spec, Gw: ts.Gw},
+	}
+	spec.ResponseChain = []TykResponseHandler{handler}
+
+	errHandler := ErrorHandler{NewBaseMiddleware(ts.Gw, spec, nil, nil)}
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	recorder := httptest.NewRecorder()
+
+	recorder.WriteHeader(http.StatusTeapot)
+	_, _ = recorder.WriteString("custom body")
+
+	errHandler.HandleError(recorder, req, errCustomBodyResponse.Error(), http.StatusBadRequest, true)
+
+	if handler.responseCalls != 0 {
+		t.Fatalf("expected response chain to be skipped, got %d", handler.responseCalls)
+	}
+
+	resp := recorder.Result()
+	defer resp.Body.Close()
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+	if resp.StatusCode != http.StatusTeapot {
+		t.Fatalf("expected status %d, got %d", http.StatusTeapot, resp.StatusCode)
+	}
+	if string(bodyBytes) != "custom body" {
+		t.Fatalf("expected body %q, got %q", "custom body", string(bodyBytes))
+	}
+}
+
+type responseChainNoopHandler struct {
+	BaseTykResponseHandler
+}
+
+func (h *responseChainNoopHandler) Base() *BaseTykResponseHandler {
+	return &h.BaseTykResponseHandler
+}
+
+func (h *responseChainNoopHandler) Name() string {
+	return "NoopResponseHandler"
+}
+
+func (h *responseChainNoopHandler) HandleResponse(rw http.ResponseWriter, res *http.Response, req *http.Request, ses *user.SessionState) error {
+	return nil
+}
+
+type responseChainMutatingHandler struct {
+	BaseTykResponseHandler
+}
+
+func (h *responseChainMutatingHandler) Base() *BaseTykResponseHandler {
+	return &h.BaseTykResponseHandler
+}
+
+func (h *responseChainMutatingHandler) Name() string {
+	return "MutatingResponseHandler"
+}
+
+func (h *responseChainMutatingHandler) HandleResponse(rw http.ResponseWriter, res *http.Response, req *http.Request, ses *user.SessionState) error {
+	overrideBody := `{"override":"1"}`
+	res.StatusCode = http.StatusTeapot
+	res.Body = ioutil.NopCloser(strings.NewReader(overrideBody))
+	return nil
+}
+
+func TestHandleError_ResponseChainNoopPreservesBodyAndStatus(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	specs := ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/"
+	})
+	spec := specs[0]
+
+	handler := &responseChainNoopHandler{
+		BaseTykResponseHandler: BaseTykResponseHandler{Spec: spec, Gw: ts.Gw},
+	}
+	spec.ResponseChain = []TykResponseHandler{handler}
+
+	errHandler := ErrorHandler{NewBaseMiddleware(ts.Gw, spec, nil, nil)}
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	recorder := httptest.NewRecorder()
+
+	errHandler.HandleError(recorder, req, "Initial error", http.StatusBadRequest, true)
+
+	resp := recorder.Result()
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+	body := string(bodyBytes)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, resp.StatusCode)
+	}
+	if !strings.Contains(body, "Initial error") {
+		t.Fatalf("expected response body to contain error message, got %q", body)
+	}
+}
+
+func TestHandleError_ResponseChainMutatesBodyAndStatus(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	specs := ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/"
+	})
+	spec := specs[0]
+
+	handler := &responseChainMutatingHandler{
+		BaseTykResponseHandler: BaseTykResponseHandler{Spec: spec, Gw: ts.Gw},
+	}
+	spec.ResponseChain = []TykResponseHandler{handler}
+
+	errHandler := ErrorHandler{NewBaseMiddleware(ts.Gw, spec, nil, nil)}
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	recorder := httptest.NewRecorder()
+
+	errHandler.HandleError(recorder, req, "Initial error", http.StatusBadRequest, true)
+
+	resp := recorder.Result()
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+	body := string(bodyBytes)
+	if resp.StatusCode != http.StatusTeapot {
+		t.Fatalf("expected status %d, got %d", http.StatusTeapot, resp.StatusCode)
+	}
+	if !strings.Contains(body, `"override":"1"`) {
+		t.Fatalf("expected response body override, got %q", body)
+	}
+}
+
+func TestHandleError_ResponseChainGuardRecordsAnalytics(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	specs := ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/"
+	})
+	spec := specs[0]
+
+	base := NewBaseMiddleware(ts.Gw, spec, nil, nil)
+	handler := &responseChainErrorHandler{
+		BaseTykResponseHandler: BaseTykResponseHandler{Spec: spec, Gw: ts.Gw},
+		base:                   base,
+	}
+	spec.ResponseChain = []TykResponseHandler{handler}
+
+	var (
+		recordCount int
+		recordCode  int
+	)
+	ts.Gw.Analytics.mockEnabled = true
+	ts.Gw.Analytics.mockRecordHit = func(record *analytics.AnalyticsRecord) {
+		recordCount++
+		recordCode = record.ResponseCode
+	}
+
+	errHandler := ErrorHandler{base}
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	recorder := httptest.NewRecorder()
+
+	errHandler.HandleError(recorder, req, "Initial error", http.StatusBadRequest, true)
+
+	if recordCount != 1 {
+		t.Fatalf("expected 1 analytics record, got %d", recordCount)
+	}
+	if recordCode != http.StatusInternalServerError {
+		t.Fatalf("expected analytics status %d, got %d", http.StatusInternalServerError, recordCode)
+	}
+}
+
+func TestHandleError_ResponseChainModifiesStatusCode(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	specs := ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/"
+	})
+	spec := specs[0]
+
+	modifier := &responseChainModifier{
+		BaseTykResponseHandler: BaseTykResponseHandler{Spec: spec, Gw: ts.Gw},
+		newStatus:              http.StatusTeapot, // 418
+	}
+	spec.ResponseChain = []TykResponseHandler{modifier}
+
+	base := NewBaseMiddleware(ts.Gw, spec, nil, nil)
+	errHandler := ErrorHandler{base}
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	recorder := httptest.NewRecorder()
+
+	errHandler.HandleError(recorder, req, MsgAuthFieldMissing, http.StatusUnauthorized, true)
+
+	resp := recorder.Result()
+	if resp.StatusCode != http.StatusTeapot {
+		t.Fatalf("expected status %d, got %d", http.StatusTeapot, resp.StatusCode)
+	}
+}
+
+func TestHandleError_ResponseChainModifiesBody(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	specs := ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/"
+	})
+	spec := specs[0]
+
+	customBody := `{"error":"custom error","request_id":"abc123"}`
+	modifier := &responseChainModifier{
+		BaseTykResponseHandler: BaseTykResponseHandler{Spec: spec, Gw: ts.Gw},
+		newBody:                customBody,
+	}
+	spec.ResponseChain = []TykResponseHandler{modifier}
+
+	base := NewBaseMiddleware(ts.Gw, spec, nil, nil)
+	errHandler := ErrorHandler{base}
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	recorder := httptest.NewRecorder()
+
+	errHandler.HandleError(recorder, req, MsgAuthFieldMissing, http.StatusUnauthorized, true)
+
+	resp := recorder.Result()
+	body, _ := ioutil.ReadAll(resp.Body)
+	if string(body) != customBody {
+		t.Fatalf("expected body %q, got %q", customBody, string(body))
+	}
+}
+
+func TestHandleError_ResponseChainModifiesStatusAndBody(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	specs := ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Proxy.ListenPath = "/"
+	})
+	spec := specs[0]
+
+	customBody := `{"error":"forbidden","code":403}`
+	modifier := &responseChainModifier{
+		BaseTykResponseHandler: BaseTykResponseHandler{Spec: spec, Gw: ts.Gw},
+		newStatus:              http.StatusForbidden,
+		newBody:                customBody,
+	}
+	spec.ResponseChain = []TykResponseHandler{modifier}
+
+	base := NewBaseMiddleware(ts.Gw, spec, nil, nil)
+	errHandler := ErrorHandler{base}
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	recorder := httptest.NewRecorder()
+
+	errHandler.HandleError(recorder, req, MsgAuthFieldMissing, http.StatusUnauthorized, true)
+
+	resp := recorder.Result()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected status %d, got %d", http.StatusForbidden, resp.StatusCode)
+	}
+	body, _ := ioutil.ReadAll(resp.Body)
+	if string(body) != customBody {
+		t.Fatalf("expected body %q, got %q", customBody, string(body))
+	}
 }


### PR DESCRIPTION
Response Plugins Run on All Responses

## Problem Statement

Response middleware only executes on successful upstream responses. When Tyk returns errors (401 auth, 429 rate limit, etc.), response middleware is bypassed. Customers want to customize responses on a per-API basis for both success and error cases.

## Solution: Response Plugins Always Run

Extend response middleware to run on all responses, not just upstream success. The plugin sees every response and decides what to do based on status code.

```
Success (upstream 2xx)  -> Response Plugin -> Client
Upstream error (5xx)    -> Response Plugin -> Client  (already works)
Tyk error (401/429)     -> Response Plugin -> Client  (NEW)
```

One plugin, all responses.

## Implementation

### Primary change: `gateway/handler_error.go`

In `HandleError()`, build the error body into a buffer, run the response chain on a constructed `http.Response`, and only then write the response.

Key points:
- Create `response` with status, cloned headers, body, and request.
- Run `handleResponseChain` only when configured and not already in an error-response chain (guard).
- If a custom response hook fails, let its own ErrorHandler response stand and return early.
- Log response chain errors when not handled.
- Sync headers by clearing `w.Header()` and copying from `response.Header` so deletions apply.
- Reset `response.Body` to the final buffer so analytics can read it.

### Guard: prevent recursion

When ErrorHandler is invoked from a response hook failure, skip re-running the response chain by setting a request-context flag while the chain is executing.

### Edge case: `errCustomBodyResponse`

Keep existing behavior. GraphQL and similar flows already wrote to the response writer, so there is nothing to intercept.

## Tests

- `gateway/handler_error_test.go`: global response header add/remove is applied to gateway errors (ex: 401). Confirms response chain runs and header removals are respected.
- `gateway/handler_error_test.go`: response hook failure does not re-enter the response chain. Confirms recursion guard and single response write.

## Considerations / Follow-ups

- Ensure `response.Body` is closed after reading from the response chain in case a hook swaps in a streaming body.
- Add a regression test for the `errCustomBodyResponse` path to confirm it bypasses the response chain as intended.
- Document the behavior change: response plugins now run on gateway-generated errors (401/429/etc.) and can alter status/body/headers.

## Summary

| What | Change |
|------|--------|
| Files modified | 1 to 3 (handler + tests + plan) |
| New config | None |
| New plugin type | None |

Response plugins become universal response interceptors with safe recursion guards.
