### PR TITLE
[TT-16529] Add cache_hit field to Gateway access logs

### DIFF
--- a/ctx/ctx.go
+++ b/ctx/ctx.go
@@ -55,6 +55,8 @@ const (
 	SelfLooping
 	// RequestStartTime holds the time when the request entered the middleware chain
 	RequestStartTime
+	// CacheHit indicates whether the response was served from the cache
+	CacheHit
 )
 
 func ctxSetSession(r *http.Request, s *user.SessionState, scheduleUpdate bool, hashKey bool) {

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -3176,6 +3176,21 @@ func ctxGetRequestStartTime(r *http.Request) time.Time {
 	return time.Time{}
 }
 
+// ctxSetCacheHit sets the cache hit flag in the request context
+func ctxSetCacheHit(r *http.Request, hit bool) {
+	setCtxValue(r, ctx.CacheHit, hit)
+}
+
+// ctxGetCacheHit returns the cache hit flag from the request context
+func ctxGetCacheHit(r *http.Request) bool {
+	if v := r.Context().Value(ctx.CacheHit); v != nil {
+		if hit, ok := v.(bool); ok {
+			return hit
+		}
+	}
+	return false
+}
+
 func ctxGetVersionInfo(r *http.Request) *apidef.VersionInfo {
 	if v := r.Context().Value(ctx.VersionData); v != nil {
 		return v.(*apidef.VersionInfo)

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -457,6 +457,7 @@ func (t *BaseMiddleware) RecordAccessLog(req *http.Request, resp *http.Response,
 	accessLog.WithApiKey(req, hashKeys, gw.obfuscateKey)
 	accessLog.WithRequest(req, latency)
 	accessLog.WithResponse(resp)
+	accessLog.WithCacheHit(ctxGetCacheHit(req))
 
 	logFields := accessLog.Fields(allowedFields)
 

--- a/internal/httputil/accesslog/record.go
+++ b/internal/httputil/accesslog/record.go
@@ -69,6 +69,12 @@ func (a *Record) WithResponse(resp *http.Response) *Record {
 	return a
 }
 
+// WithCacheHit sets the cache_hit field indicating if the response was served from cache.
+func (a *Record) WithCacheHit(hit bool) *Record {
+	a.fields["cache_hit"] = hit
+	return a
+}
+
 // Fields returns a logrus.Fields intended for logging.
 func (a *Record) Fields(allowedKeys []string) logrus.Fields {
 	return Filter(a.fields, allowedKeys)


### PR DESCRIPTION
## Summary

Adds a new `cache_hit` field to the Tyk Gateway access logs that indicates whether a response was served from the cache.

- Adds `CacheHit` context key for passing cache status through request context
- Sets `cache_hit=true` in Redis cache middleware when serving cached responses
- Includes `cache_hit` field in all access log entries (defaults to `false` for non-cached responses)
- Adds access log recording for cached responses (previously missing)
- Adds table-driven unit tests for the new functionality

## Test plan

- [x] Unit tests pass for the accesslog package (`go test ./internal/httputil/accesslog/...`)
- [x] Code compiles without errors (`go build ./ctx/... ./gateway/... ./internal/httputil/accesslog/...`)
- [x] Go vet passes (`go vet ./gateway/...`)
- [ ] Integration tests with Redis should verify:
  - Access logs contain `cache_hit=true` when response is served from cache
  - Access logs contain `cache_hit=false` when response is from upstream

## Related Issues

- Jira: [TT-16529](https://tyktech.atlassian.net/browse/TT-16529)
- Parent Epic: [TT-9786](https://tyktech.atlassian.net/browse/TT-9786)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TT-16529]: https://tyktech.atlassian.net/browse/TT-16529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ