### PR TITLE
[TT-16266] Add debug logging to API definition compression logic

### DIFF
--- a/gateway/rpc_backup_handlers.go
+++ b/gateway/rpc_backup_handlers.go
@@ -57,6 +57,7 @@ func (gw *Gateway) LoadDefinitionsFromRPCBackup() ([]*APISpec, error) {
 }
 
 func (gw *Gateway) saveRPCDefinitionsBackup(list string) error {
+	log.Debug("[RPC-DEBUG] ==> Entered saveRPCDefinitionsBackup")
 	if !json.Valid([]byte(list)) {
 		return errors.New("--> RPC Backup save failure: wrong format, skipping.")
 	}
@@ -76,6 +77,7 @@ func (gw *Gateway) saveRPCDefinitionsBackup(list string) error {
 	}
 
 	secret := crypto.GetPaddedString(gw.GetConfig().Secret)
+	log.Debugf("[RPC-DEBUG] ==> Calling compressAPIBackup with CompressAPIDefinitions flag set to: %v", gw.GetConfig().Storage.CompressAPIDefinitions)
 	dataToEncrypt := gw.compressAPIBackup(list)
 
 	cryptoText := crypto.Encrypt(secret, dataToEncrypt)
@@ -88,6 +90,7 @@ func (gw *Gateway) saveRPCDefinitionsBackup(list string) error {
 
 // compressAPIBackup compresses API backup data if compression is enabled
 func (gw *Gateway) compressAPIBackup(list string) string {
+	log.Debug("[RPC-DEBUG] ==> Entered compressAPIBackup")
 	if !gw.GetConfig().Storage.CompressAPIDefinitions {
 		log.Debug("[RPC] --> API definition compression disabled")
 		return list


### PR DESCRIPTION
## Summary
- Add verbose debug logging to trace execution path in API definition compression feature
- New `[RPC-DEBUG]` log messages at entry points of `saveRPCDefinitionsBackup` and `compressAPIBackup` functions
- Log the runtime value of `CompressAPIDefinitions` flag to help diagnose configuration issues

## Context
This addresses customer troubleshooting needs for the `compress_api_definitions` feature (TT-16266). Users have reported that the feature does not appear to be triggered in their local environments, with no debug logs appearing even when the feature is enabled.

The new logs will help determine:
1. Whether `saveRPCDefinitionsBackup` is being called during API reloads
2. The actual runtime value of the `CompressAPIDefinitions` configuration flag
3. Whether `compressAPIBackup` is being invoked

## Test plan
- [ ] Build gateway with changes
- [ ] Configure `log_level: "debug"` and `compress_api_definitions: true` in tyk.conf
- [ ] Create or reload an API
- [ ] Verify the following log messages appear:
  - `[RPC-DEBUG] ==> Entered saveRPCDefinitionsBackup`
  - `[RPC-DEBUG] ==> Calling compressAPIBackup with CompressAPIDefinitions flag set to: true`
  - `[RPC-DEBUG] ==> Entered compressAPIBackup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-16266" title="TT-16266" target="_blank">TT-16266</a>
</summary>

|         |    |
|---------|----|
| Status  | In Test |
| Summary | Implement compression of API definitions to reduce Redis usage |

Generated at: 2026-01-31 18:37:44

</details>

<!---TykTechnologies/jira-linter ends here-->
