### PR TITLE
[TT-16453] Add config inspection endpoints for runtime troubleshooting

### DIFF
--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -491,6 +491,9 @@
     "bundle_insecure_skip_verify": {
       "type": "boolean"
     },
+    "enable_config_inspection": {
+      "type": "boolean"
+    },
     "enable_custom_domains": {
       "type": "boolean"
     },

--- a/config/config.go
+++ b/config/config.go
@@ -112,7 +112,7 @@ type PoliciesConfig struct {
 
 	// This option is required if `policies.policy_source` is set to `service`.
 	// Set this to the URL of your Tyk Dashboard installation. The URL needs to be formatted as: http://dashboard_host:port.
-	PolicyConnectionString string `json:"policy_connection_string"`
+	PolicyConnectionString string `json:"policy_connection_string" structviewer:"obfuscate"`
 
 	// This option only applies in OSS deployment when the `policies.policy_source` is either set
 	// to `file` or an empty string. If `policies.policy_path` is not set, then Tyk will load policies
@@ -137,7 +137,7 @@ type PoliciesConfig struct {
 
 type DBAppConfOptionsConfig struct {
 	// Set the URL to your Dashboard instance (or a load balanced instance). The URL needs to be formatted as: `http://dashboard_host:port`
-	ConnectionString string `json:"connection_string"`
+	ConnectionString string `json:"connection_string" structviewer:"obfuscate"`
 
 	// Set a timeout value, in seconds, for your Dashboard connection. Default value is 30.
 	ConnectionTimeout int `json:"connection_timeout"`
@@ -163,11 +163,11 @@ type StorageOptionsConf struct {
 	// Redis sentinel master name
 	MasterName string `json:"master_name"`
 	// Redis sentinel password
-	SentinelPassword string `json:"sentinel_password"`
+	SentinelPassword string `json:"sentinel_password" structviewer:"obfuscate"`
 	// Redis user name
 	Username string `json:"username"`
 	// If your Redis instance has a password set for access, you can set it here.
-	Password string `json:"password"`
+	Password string `json:"password" structviewer:"obfuscate"`
 	// Redis database
 	Database int `json:"database"`
 	// Set the number of maximum idle connections in the Redis connection pool, which defaults to 100. Set to a higher value if you are expecting more traffic.
@@ -398,15 +398,15 @@ type SlaveOptionsConfig struct {
 	SSLInsecureSkipVerify bool `json:"ssl_insecure_skip_verify"`
 
 	// Use this setting to add the URL for your MDCB or load balancer host.
-	ConnectionString string `json:"connection_string"`
+	ConnectionString string `json:"connection_string" structviewer:"obfuscate"`
 
 	// Your organization ID to connect to the MDCB installation.
 	RPCKey string `json:"rpc_key"`
 
-	// This the API key of a user used to authenticate and authorize the Gateway’s access through MDCB.
+	// This the API key of a user used to authenticate and authorize the Gateway's access through MDCB.
 	// The user should be a standard Dashboard user with minimal privileges so as to reduce any risk if the user is compromised.
 	// The suggested security settings are read for Real-time notifications and the remaining options set to deny.
-	APIKey string `json:"api_key"`
+	APIKey string `json:"api_key" structviewer:"obfuscate"`
 
 	// Set this option to `true` to enable RPC caching for keys.
 	EnableRPCCache bool `json:"enable_rpc_cache"`
@@ -692,7 +692,7 @@ type CertificateExpiryMonitorConfig struct {
 
 type SecurityConfig struct {
 	// Set the AES256 secret which is used to encode certificate private keys when they uploaded via certificate storage
-	PrivateCertificateEncodingSecret string `json:"private_certificate_encoding_secret"`
+	PrivateCertificateEncodingSecret string `json:"private_certificate_encoding_secret" structviewer:"obfuscate"`
 
 	// Enable Gateway Control API to use Mutual TLS. Certificates can be set via `security.certificates.control_api` section
 	ControlAPIUseMutualTLS bool `json:"control_api_use_mutual_tls"`
@@ -715,7 +715,7 @@ type NewRelicConfig struct {
 	// New Relic Application name
 	AppName string `json:"app_name"`
 	// New Relic License key
-	LicenseKey string `json:"license_key"`
+	LicenseKey string `json:"license_key" structviewer:"obfuscate"`
 	// Enable distributed tracing
 	EnableDistributedTracing bool `json:"enable_distributed_tracing"`
 }
@@ -812,10 +812,10 @@ type Config struct {
 	// This should be changed as soon as Tyk is installed on your system.
 	// This value is used in every interaction with the Tyk Gateway API. It should be passed along as the X-Tyk-Authorization header in any requests made.
 	// Tyk assumes that you are sensible enough not to expose the management endpoints publicly and to keep this configuration value to yourself.
-	Secret string `json:"secret"`
+	Secret string `json:"secret" structviewer:"obfuscate"`
 
 	// The shared secret between the Gateway and the Dashboard to ensure that API Definition downloads, heartbeat and Policy loads are from a valid source.
-	NodeSecret string `json:"node_secret"`
+	NodeSecret string `json:"node_secret" structviewer:"obfuscate"`
 
 	// Linux PID file location. Do not change unless you know what you are doing. Default: /var/run/tyk/tyk-gateway.pid
 	PIDFileLocation string `json:"pid_file_location"`
@@ -828,6 +828,11 @@ type Config struct {
 
 	// Allow your Dashboard to remotely set Gateway configuration via the Nodes screen.
 	AllowRemoteConfig bool `bson:"allow_remote_config" json:"allow_remote_config"`
+
+	// Set to true to enable the /config and /env endpoints for configuration inspection.
+	// These endpoints require X-Tyk-Authorization header with the secret value.
+	// Default: false
+	EnableConfigInspection bool `json:"enable_config_inspection"`
 
 	// Global Certificate configuration
 	Security SecurityConfig `json:"security"`
@@ -1357,7 +1362,7 @@ type VaultConfig struct {
 	Timeout time.Duration `json:"timeout"`
 
 	// Token is the vault root token
-	Token string `json:"token"`
+	Token string `json:"token" structviewer:"obfuscate"`
 
 	// KVVersion is the version number of Vault. Usually defaults to 2
 	KVVersion int `json:"kv_version"`
@@ -1381,7 +1386,7 @@ type ConsulConfig struct {
 		Username string `json:"username"`
 
 		// Password to use for HTTP Basic Authentication
-		Password string `json:"password"`
+		Password string `json:"password" structviewer:"obfuscate"`
 	} `json:"http_auth"`
 
 	// WaitTime limits how long a Watch will block. If not provided,
@@ -1390,7 +1395,7 @@ type ConsulConfig struct {
 
 	// Token is used to provide a per-request ACL token
 	// which overrides the agent's default token.
-	Token string `json:"token"`
+	Token string `json:"token" structviewer:"obfuscate"`
 
 	// TLS configuration
 	TLSConfig struct {

--- a/gateway/api_config.go
+++ b/gateway/api_config.go
@@ -1,0 +1,44 @@
+package gateway
+
+import (
+	"net/http"
+
+	"github.com/TykTechnologies/structviewer"
+)
+
+// initConfigViewer creates a new structviewer.Viewer for the current gateway configuration.
+// A new viewer is created per-request to ensure hot-reloaded config is reflected immediately.
+func (gw *Gateway) initConfigViewer() (*structviewer.Viewer, error) {
+	cfg := gw.GetConfig()
+	viewerCfg := &structviewer.Config{
+		Object:        &cfg,
+		ParseComments: false,
+	}
+	return structviewer.New(viewerCfg, "TYK_GW_")
+}
+
+// configHandler handles GET /config requests.
+// Returns the full gateway configuration as JSON, or a specific field if ?field=<path> is provided.
+// Sensitive fields are automatically redacted based on structviewer:"obfuscate" tags.
+func (gw *Gateway) configHandler(w http.ResponseWriter, r *http.Request) {
+	viewer, err := gw.initConfigViewer()
+	if err != nil {
+		mainLog.WithError(err).Error("Failed to initialize config viewer")
+		doJSONWrite(w, http.StatusInternalServerError, apiError("Failed to initialize config viewer"))
+		return
+	}
+	viewer.ConfigHandler(w, r)
+}
+
+// envHandler handles GET /env requests.
+// Returns all environment variable mappings, or a specific one if ?env=<ENV_VAR> is provided.
+// Sensitive fields are automatically redacted based on structviewer:"obfuscate" tags.
+func (gw *Gateway) envHandler(w http.ResponseWriter, r *http.Request) {
+	viewer, err := gw.initConfigViewer()
+	if err != nil {
+		mainLog.WithError(err).Error("Failed to initialize config viewer")
+		doJSONWrite(w, http.StatusInternalServerError, apiError("Failed to initialize config viewer"))
+		return
+	}
+	viewer.EnvsHandler(w, r)
+}

--- a/gateway/api_config_test.go
+++ b/gateway/api_config_test.go
@@ -1,0 +1,329 @@
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/test"
+)
+
+func TestConfigInspectionEndpoints_Disabled(t *testing.T) {
+	ts := StartTest(func(cnf *config.Config) {
+		cnf.EnableConfigInspection = false
+	})
+	defer ts.Close()
+
+	// /config should return 404 when disabled
+	_, _ = ts.Run(t, test.TestCase{
+		Method:    http.MethodGet,
+		Path:      "/config",
+		AdminAuth: true,
+		Code:      http.StatusNotFound,
+	})
+
+	// /env should return 404 when disabled
+	_, _ = ts.Run(t, test.TestCase{
+		Method:    http.MethodGet,
+		Path:      "/env",
+		AdminAuth: true,
+		Code:      http.StatusNotFound,
+	})
+}
+
+func TestConfigInspectionEndpoints_EnabledWithoutSecret(t *testing.T) {
+	ts := StartTest(func(cnf *config.Config) {
+		cnf.EnableConfigInspection = true
+		cnf.Secret = ""
+	})
+	defer ts.Close()
+
+	// /config should return 404 when secret is not set (endpoints not registered)
+	_, _ = ts.Run(t, test.TestCase{
+		Method:    http.MethodGet,
+		Path:      "/config",
+		AdminAuth: true,
+		Code:      http.StatusNotFound,
+	})
+}
+
+func TestConfigInspectionEndpoints_AuthRequired(t *testing.T) {
+	ts := StartTest(func(cnf *config.Config) {
+		cnf.EnableConfigInspection = true
+		cnf.Secret = "test-secret"
+	})
+	defer ts.Close()
+
+	// /config without auth header should return 403
+	_, _ = ts.Run(t, test.TestCase{
+		Method:    http.MethodGet,
+		Path:      "/config",
+		AdminAuth: false,
+		Code:      http.StatusForbidden,
+	})
+
+	// /config with wrong auth header should return 403
+	_, _ = ts.Run(t, test.TestCase{
+		Method:  http.MethodGet,
+		Path:    "/config",
+		Headers: map[string]string{"X-Tyk-Authorization": "wrong-secret"},
+		Code:    http.StatusForbidden,
+	})
+
+	// /env without auth header should return 403
+	_, _ = ts.Run(t, test.TestCase{
+		Method:    http.MethodGet,
+		Path:      "/env",
+		AdminAuth: false,
+		Code:      http.StatusForbidden,
+	})
+}
+
+func TestConfigHandler_FullConfig(t *testing.T) {
+	ts := StartTest(func(cnf *config.Config) {
+		cnf.EnableConfigInspection = true
+		cnf.Secret = "test-secret"
+		cnf.ListenPort = 9999
+	})
+	defer ts.Close()
+
+	_, _ = ts.Run(t, test.TestCase{
+		Method:    http.MethodGet,
+		Path:      "/config",
+		AdminAuth: true,
+		Code:      http.StatusOK,
+		BodyMatchFunc: func(resp []byte) bool {
+			var configResp map[string]interface{}
+			err := json.Unmarshal(resp, &configResp)
+			assert.NoError(t, err)
+
+			// Verify listen_port is in response
+			assert.Equal(t, float64(9999), configResp["listen_port"])
+
+			// Verify secret is redacted (should be empty string or redacted marker)
+			secret, ok := configResp["secret"]
+			assert.True(t, ok, "secret field should be present")
+			// structviewer redacts string fields by setting them to empty or "*REDACTED*"
+			assert.NotEqual(t, "test-secret", secret, "secret should be redacted")
+			return true
+		},
+	})
+}
+
+func TestConfigHandler_SingleField(t *testing.T) {
+	ts := StartTest(func(cnf *config.Config) {
+		cnf.EnableConfigInspection = true
+		cnf.Secret = "test-secret"
+		cnf.ListenPort = 8888
+	})
+	defer ts.Close()
+
+	_, _ = ts.Run(t, test.TestCase{
+		Method:    http.MethodGet,
+		Path:      "/config?field=listen_port",
+		AdminAuth: true,
+		Code:      http.StatusOK,
+		BodyMatchFunc: func(resp []byte) bool {
+			var fieldResp map[string]interface{}
+			err := json.Unmarshal(resp, &fieldResp)
+			assert.NoError(t, err)
+
+			// Verify response contains expected fields
+			assert.Equal(t, "listen_port", fieldResp["config_field"])
+			assert.Equal(t, "TYK_GW_LISTENPORT", fieldResp["env"])
+			// structviewer returns values as strings
+			assert.Equal(t, "8888", fieldResp["value"])
+			assert.Equal(t, false, fieldResp["obfuscated"])
+			return true
+		},
+	})
+}
+
+func TestConfigHandler_SingleField_NotFound(t *testing.T) {
+	ts := StartTest(func(cnf *config.Config) {
+		cnf.EnableConfigInspection = true
+		cnf.Secret = "test-secret"
+	})
+	defer ts.Close()
+
+	_, _ = ts.Run(t, test.TestCase{
+		Method:    http.MethodGet,
+		Path:      "/config?field=nonexistent_field",
+		AdminAuth: true,
+		Code:      http.StatusNotFound,
+		BodyMatchFunc: func(resp []byte) bool {
+			var errResp map[string]string
+			err := json.Unmarshal(resp, &errResp)
+			assert.NoError(t, err)
+			assert.Equal(t, "field not found", errResp["error"])
+			return true
+		},
+	})
+}
+
+func TestConfigHandler_SensitiveFieldRedacted(t *testing.T) {
+	ts := StartTest(func(cnf *config.Config) {
+		cnf.EnableConfigInspection = true
+		cnf.Secret = "super-secret-value"
+	})
+	defer ts.Close()
+
+	_, _ = ts.Run(t, test.TestCase{
+		Method:    http.MethodGet,
+		Path:      "/config?field=secret",
+		AdminAuth: true,
+		Code:      http.StatusOK,
+		BodyMatchFunc: func(resp []byte) bool {
+			var fieldResp map[string]interface{}
+			err := json.Unmarshal(resp, &fieldResp)
+			assert.NoError(t, err)
+
+			// Verify field is marked as obfuscated
+			assert.Equal(t, true, fieldResp["obfuscated"])
+			// Value should NOT be the actual secret
+			assert.NotEqual(t, "super-secret-value", fieldResp["value"])
+			return true
+		},
+	})
+}
+
+func TestEnvHandler_AllEnvVars(t *testing.T) {
+	ts := StartTest(func(cnf *config.Config) {
+		cnf.EnableConfigInspection = true
+		cnf.Secret = "test-secret"
+	})
+	defer ts.Close()
+
+	_, _ = ts.Run(t, test.TestCase{
+		Method:    http.MethodGet,
+		Path:      "/env",
+		AdminAuth: true,
+		Code:      http.StatusOK,
+		BodyMatchFunc: func(resp []byte) bool {
+			// The /env endpoint returns an array of env var strings like "TYK_GW_VAR=value"
+			var envResp []string
+			err := json.Unmarshal(resp, &envResp)
+			assert.NoError(t, err)
+
+			// Should return an array of env var mappings
+			assert.Greater(t, len(envResp), 0, "should have at least one env var mapping")
+
+			// Verify we have TYK_GW_ prefix env vars (structviewer generates these)
+			var foundTykGwEnvVar bool
+			for _, env := range envResp {
+				if len(env) > 7 && env[:7] == "TYK_GW_" {
+					foundTykGwEnvVar = true
+					break
+				}
+			}
+			assert.True(t, foundTykGwEnvVar, "Should have at least one TYK_GW_* env var")
+			return true
+		},
+	})
+}
+
+func TestEnvHandler_SingleEnvVar(t *testing.T) {
+	ts := StartTest(func(cnf *config.Config) {
+		cnf.EnableConfigInspection = true
+		cnf.Secret = "test-secret"
+		cnf.ListenPort = 7777
+	})
+	defer ts.Close()
+
+	_, _ = ts.Run(t, test.TestCase{
+		Method:    http.MethodGet,
+		Path:      "/env?env=TYK_GW_LISTENPORT",
+		AdminAuth: true,
+		Code:      http.StatusOK,
+		BodyMatchFunc: func(resp []byte) bool {
+			var envResp map[string]interface{}
+			err := json.Unmarshal(resp, &envResp)
+			assert.NoError(t, err)
+
+			assert.Equal(t, "listen_port", envResp["config_field"])
+			assert.Equal(t, "TYK_GW_LISTENPORT", envResp["env"])
+			// structviewer returns values as strings
+			assert.Equal(t, "7777", envResp["value"])
+			assert.Equal(t, false, envResp["obfuscated"])
+			return true
+		},
+	})
+}
+
+func TestEnvHandler_SingleEnvVar_NotFound(t *testing.T) {
+	ts := StartTest(func(cnf *config.Config) {
+		cnf.EnableConfigInspection = true
+		cnf.Secret = "test-secret"
+	})
+	defer ts.Close()
+
+	_, _ = ts.Run(t, test.TestCase{
+		Method:    http.MethodGet,
+		Path:      "/env?env=TYK_GW_NONEXISTENT",
+		AdminAuth: true,
+		Code:      http.StatusNotFound,
+		BodyMatchFunc: func(resp []byte) bool {
+			var errResp map[string]string
+			err := json.Unmarshal(resp, &errResp)
+			assert.NoError(t, err)
+			assert.Equal(t, "environment variable not found", errResp["error"])
+			return true
+		},
+	})
+}
+
+func TestEnvHandler_SensitiveEnvVarRedacted(t *testing.T) {
+	ts := StartTest(func(cnf *config.Config) {
+		cnf.EnableConfigInspection = true
+		cnf.Secret = "super-secret-value"
+	})
+	defer ts.Close()
+
+	_, _ = ts.Run(t, test.TestCase{
+		Method:    http.MethodGet,
+		Path:      "/env?env=TYK_GW_SECRET",
+		AdminAuth: true,
+		Code:      http.StatusOK,
+		BodyMatchFunc: func(resp []byte) bool {
+			var envResp map[string]interface{}
+			err := json.Unmarshal(resp, &envResp)
+			assert.NoError(t, err)
+
+			// Verify env var is marked as obfuscated
+			assert.Equal(t, true, envResp["obfuscated"])
+			// Value should NOT be the actual secret
+			assert.NotEqual(t, "super-secret-value", envResp["value"])
+			return true
+		},
+	})
+}
+
+func TestConfigHandler_StoragePasswordRedacted(t *testing.T) {
+	ts := StartTest(func(cnf *config.Config) {
+		cnf.EnableConfigInspection = true
+		cnf.Secret = "test-secret"
+		cnf.Storage.Password = "redis-password"
+	})
+	defer ts.Close()
+
+	_, _ = ts.Run(t, test.TestCase{
+		Method:    http.MethodGet,
+		Path:      "/config?field=storage.password",
+		AdminAuth: true,
+		Code:      http.StatusOK,
+		BodyMatchFunc: func(resp []byte) bool {
+			var fieldResp map[string]interface{}
+			err := json.Unmarshal(resp, &fieldResp)
+			assert.NoError(t, err)
+
+			// Verify field is marked as obfuscated
+			assert.Equal(t, true, fieldResp["obfuscated"])
+			// Value should NOT be the actual password
+			assert.NotEqual(t, "redis-password", fieldResp["value"])
+			return true
+		},
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -97,6 +97,7 @@ require (
 	github.com/Jeffail/gabs/v2 v2.7.0
 	github.com/TykTechnologies/graphql-go-tools/v2 v2.0.0-20250926102005-c54e73aae17d
 	github.com/TykTechnologies/opentelemetry v0.0.23-0.20260129122518-ff7800760c0d
+	github.com/TykTechnologies/structviewer v1.2.0
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/eclipse/paho.mqtt.golang v1.4.3
 	github.com/getkin/kin-openapi v0.133.0

--- a/go.sum
+++ b/go.sum
@@ -830,6 +830,8 @@ github.com/TykTechnologies/opentelemetry v0.0.23-0.20260129122518-ff7800760c0d h
 github.com/TykTechnologies/opentelemetry v0.0.23-0.20260129122518-ff7800760c0d/go.mod h1:O5Fh2KKeno6IEHvIhWlmpf+MHSj5sjSGCpxbo2nqSaU=
 github.com/TykTechnologies/storage v1.3.0 h1:y/ORW7hSZHw8Pr0aSaxN1bXH/u7tuhOW/RRiPkaQNLo=
 github.com/TykTechnologies/storage v1.3.0/go.mod h1:psPnFQBWQ/gBQKGHrviJqXQ5HCz8EwTWm41RWpunosM=
+github.com/TykTechnologies/structviewer v1.2.0 h1:wV3AyTmWCZ3n7/llp+6xuDjnS/EJ/Ct/HG2pPE9+VX8=
+github.com/TykTechnologies/structviewer v1.2.0/go.mod h1:XKJbqX8Q7n9FUrqTK58yVZUi5zWAkeRcULcPLDoWvvY=
 github.com/TykTechnologies/tyk-pump v1.13.0-rc2.0.20251023125113-bc7641d42e63 h1:6n4yFtsBhcQayXzY8AdTKlmaJGw2Z3Uqm6ARIETmiVA=
 github.com/TykTechnologies/tyk-pump v1.13.0-rc2.0.20251023125113-bc7641d42e63/go.mod h1:oTgH2TL6Qjon1Sh3PmcijwOxLetcyu+7DohJr4VwM+c=
 github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=


### PR DESCRIPTION
## Summary

Add `/config` and `/env` Control API endpoints that expose the gateway's runtime configuration and environment variable mappings. This enables operators to troubleshoot configuration issues without SSH access.

### Features

- **GET /config**: Returns the full gateway configuration as JSON
  - Query param `?field=<path>` returns a specific field (e.g., `?field=storage.password`)
- **GET /env**: Returns all environment variable mappings
  - Query param `?env=<VAR>` returns a specific env var (e.g., `?env=TYK_GW_LISTENPORT`)
- **Opt-in**: Enabled via `enable_config_inspection` config option (default: `false`)
- **Auth required**: Uses `X-Tyk-Authorization` header (same as other Control API endpoints)
- **Sensitive data protection**: Fields with `structviewer:"obfuscate"` tags are automatically redacted

### Obfuscated sensitive fields

| Field | Env Var |
|-------|---------|
| `secret` | `TYK_GW_SECRET` |
| `node_secret` | `TYK_GW_NODESECRET` |
| `storage.password` | `TYK_GW_STORAGE_PASSWORD` |
| `storage.sentinel_password` | `TYK_GW_STORAGE_SENTINELPASSWORD` |
| `db_app_conf_options.connection_string` | `TYK_GW_DBAPPCONFOPTIONS_CONNECTIONSTRING` |
| `policies.policy_connection_string` | `TYK_GW_POLICIES_POLICYCONNECTIONSTRING` |
| `slave_options.api_key` | `TYK_GW_SLAVEOPTIONS_APIKEY` |
| `slave_options.connection_string` | `TYK_GW_SLAVEOPTIONS_CONNECTIONSTRING` |
| `security.private_certificate_encoding_secret` | `TYK_GW_SECURITY_PRIVATECERTIFICATEENCODINGSECRET` |
| `newrelic.license_key` | `TYK_GW_NEWRELIC_LICENSEKEY` |
| `kv.vault.token` | `TYK_GW_KV_VAULT_TOKEN` |
| `kv.consul.token` | `TYK_GW_KV_CONSUL_TOKEN` |
| `kv.consul.http_auth.password` | `TYK_GW_KV_CONSUL_HTTPAUTH_PASSWORD` |

### Example usage

```bash
# Enable the feature
export TYK_GW_ENABLECONFIGINSPECTION=true

# Get full config (sensitive fields redacted)
curl -H "X-Tyk-Authorization: $SECRET" "http://localhost:8080/config"

# Get specific field
curl -H "X-Tyk-Authorization: $SECRET" "http://localhost:8080/config?field=listen_port"
# Response: {"config_field":"listen_port","env":"TYK_GW_LISTENPORT","value":"8080","obfuscated":false}

# Get env var mapping
curl -H "X-Tyk-Authorization: $SECRET" "http://localhost:8080/env?env=TYK_GW_SECRET"
# Response: {"config_field":"secret","env":"TYK_GW_SECRET","value":"*REDACTED*","obfuscated":true}
```

## Test plan

- [x] Unit tests added (`gateway/api_config_test.go`)
- [x] Manual testing with local gateway
- [x] Verify endpoints return 404 when `enable_config_inspection=false`
- [x] Verify 403 returned without valid `X-Tyk-Authorization` header
- [x] Verify sensitive fields show `*REDACTED*` and `"obfuscated":true`
- [x] Verify non-sensitive fields return actual values