### PR TITLE
TT-16445 Fix response flags: TKE, NHU, TLN

### DIFF
--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -259,6 +259,7 @@ func (gw *Gateway) TykNewSingleHostReverseProxy(target *url.URL, spec *APISpec, 
 			if err != nil {
 				logger.Error("[PROXY] [LOAD BALANCING] ", err)
 				host = allHostsDownURL
+				ctx.SetErrorClassification(req, tykerrors.ClassifyNoHealthyUpstreamsError(target.Host))
 			}
 			lbRemote, err := url.Parse(host)
 			if err != nil {

--- a/internal/errors/classification.go
+++ b/internal/errors/classification.go
@@ -11,7 +11,7 @@ const (
 	TLE ResponseFlag = "TLE" // TLS certificate expired
 	TLI ResponseFlag = "TLI" // TLS certificate invalid
 	TLM ResponseFlag = "TLM" // TLS certificate mismatch (hostname)
-	TLN ResponseFlag = "TLN" // TLS not configured
+	TLN ResponseFlag = "TLN" // TLS not trusted (unknown authority)
 	TLH ResponseFlag = "TLH" // TLS handshake failed
 	TLP ResponseFlag = "TLP" // TLS protocol error
 	TLA ResponseFlag = "TLA" // TLS alert (handshake failure, version mismatch)
@@ -93,6 +93,7 @@ const (
 
 	// JWT error types
 	ErrTypeClaimsInvalid           = "claims_invalid"
+	ErrTypeTokenExpired            = "token_expired"
 	ErrTypeTokenInvalid            = "token_invalid"
 	ErrTypeUnexpectedSigningMethod = "unexpected_signing_method"
 
@@ -143,6 +144,7 @@ const (
 	// JWT details
 	detailJWTFieldMissing            = "jwt_field_missing"
 	detailJWTClaimsInvalid           = "jwt_claims_invalid"
+	detailJWTTokenExpired            = "jwt_token_expired"
 	detailJWTTokenInvalid            = "jwt_token_invalid"
 	detailJWTUnexpectedSigningMethod = "jwt_unexpected_signing_method"
 

--- a/internal/errors/classifier.go
+++ b/internal/errors/classifier.go
@@ -124,7 +124,7 @@ func classifyTLSError(err error, target string) *ErrorClassification {
 	// Check for unknown authority
 	var unknownAuthErr x509.UnknownAuthorityError
 	if As(err, &unknownAuthErr) {
-		return NewErrorClassification(TLI, "tls_unknown_authority").
+		return NewErrorClassification(TLN, "tls_unknown_authority").
 			WithSource(sourceReverseProxy).
 			WithTarget(target)
 	}
@@ -385,6 +385,8 @@ func ClassifyJWTError(errorType string, source string) *ErrorClassification {
 		return NewErrorClassification(AMF, detailJWTFieldMissing).WithSource(source)
 	case ErrTypeClaimsInvalid:
 		return NewErrorClassification(TCV, detailJWTClaimsInvalid).WithSource(source)
+	case ErrTypeTokenExpired:
+		return NewErrorClassification(TKE, detailJWTTokenExpired).WithSource(source)
 	case ErrTypeTokenInvalid:
 		return NewErrorClassification(TKI, detailJWTTokenInvalid).WithSource(source)
 	case ErrTypeUnexpectedSigningMethod:

--- a/internal/errors/classifier_test.go
+++ b/internal/errors/classifier_test.go
@@ -67,7 +67,7 @@ func TestClassifyUpstreamError_TLSErrors(t *testing.T) {
 		{
 			name:           "unknown authority",
 			err:            x509.UnknownAuthorityError{},
-			expectedFlag:   TLI,
+			expectedFlag:   TLN,
 			expectedDetail: "tls_unknown_authority",
 		},
 		{
@@ -899,6 +899,13 @@ func TestClassifyJWTError(t *testing.T) {
 			source:       "JWTMiddleware",
 			expectedFlag: TCV,
 			expectedDet:  "jwt_claims_invalid",
+		},
+		{
+			name:         "token_expired",
+			errorType:    ErrTypeTokenExpired,
+			source:       "JWTMiddleware",
+			expectedFlag: TKE,
+			expectedDet:  "jwt_token_expired",
 		},
 		{
 			name:         "token_invalid",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->
This PR improves the accuracy of the gateway's error classification by fixing three response flags: TKE (JWT Token Expired), NHU (No Healthy Upstreams), and TLN (TLS Not Trusted).


## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-16445" title="TT-16445" target="_blank">TT-16445</a>
</summary>

|         |    |
|---------|----|
| Status  | In Test |
| Summary | Improve AccessLogs Error observability 4XX |

Generated at: 2026-02-09 16:40:37

</details>

<!---TykTechnologies/jira-linter ends here-->

