### PR TITLE
TT-17896: add ability to turn off transfer encoding to specific API targets

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -1026,6 +1026,8 @@ type RequestSigningMeta struct {
 
 type ProxyConfig struct {
 	PreserveHostHeader          bool                          `bson:"preserve_host_header" json:"preserve_host_header"`
+	DisableChunkedEncoding      bool                          `bson:"disable_chunked_encoding" json:"disable_chunked_encoding"`
+	ChunkedEncodingMaxBodySize  int64                         `bson:"chunked_encoding_max_body_size" json:"chunked_encoding_max_body_size"`
 	ListenPath                  string                        `bson:"listen_path" json:"listen_path"`
 	TargetURL                   string                        `bson:"target_url" json:"target_url"`
 	DisableStripSlash           bool                          `bson:"disable_strip_slash" json:"disable_strip_slash"`


### PR DESCRIPTION
## Description

Add an opt-in, per-API capability to avoid chunked transfer encoding to upstreams by buffering eligible request bodies in Tyk and forwarding with `Content-Length`.

The change also introduces stronger safeguards for this buffering path, including bounded body-size handling and a default safety limit when no explicit limit is configured.

## Related Issue

Closes #7754

## Motivation and Context

Some upstreams/proxies/WAFs do not reliably handle chunked request bodies. The current workaround is often to add another proxy tier between Tyk and upstream purely for request normalization, which increases complexity and latency.

This PR allows that compatibility behavior to be configured directly in Tyk at API level while preserving default behavior for APIs that do not opt in.

## How This Has Been Tested

- Unit tests (targeted):
  - `go test ./gateway -run "TestDisableChunkedEncodingForUpstream|TestDeepCopyBody"`
  - `go test ./apidef/oas -run "TestDisableChunkedEncoding|TestPreserveHostHeader"`
- Lint/tooling:
  - `task lint`

All commands above completed successfully in this branch.

## Screenshots (if appropriate)

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

- [x] I ensured that the documentation is up to date
- [x] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why

Additional notes:
- This PR does not intentionally introduce persistent `go.mod`/`go.sum` changes.
- No code coverage gate exception is requested.