### PR TITLE
[TT-16613] Propagate OTEL span attributes from multi-auth

### DIFF
--- a/ci/tests/tracing/Taskfile.yml
+++ b/ci/tests/tracing/Taskfile.yml
@@ -37,6 +37,7 @@ tasks:
       - tracetest run test -f ./scenarios/tyk_test_500.yml -o pretty
       - tracetest run test -f ./scenarios/tyk_testauth_401.yml -o pretty
       - tracetest run test -f ./scenarios/tyk_jwt_200.yml -o pretty
+      - tracetest run test -f ./scenarios/tyk_multiauth_jwt_200.yml -o pretty
       - tracetest run test -f ./scenarios/tyk_tykprotocol_200.yml -o pretty
       - tracetest run test -f ./scenarios/tyk_tykprotocol-auth_401.yml -o pretty
       - tracetest run test -f ./scenarios/tyk_grpcapi_200.yml -o pretty

--- a/ci/tests/tracing/apps/test-multiauth-oas.json
+++ b/ci/tests/tracing/apps/test-multiauth-oas.json
@@ -1,0 +1,90 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "MultiAuthTestAPI",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/anything": {
+            "get": {
+                "operationId": "getAnything",
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "securitySchemes": {
+            "jwt": {
+                "type": "http",
+                "scheme": "bearer",
+                "bearerFormat": "JWT"
+            },
+            "authToken": {
+                "type": "apiKey",
+                "in": "header",
+                "name": "X-API-Key"
+            }
+        }
+    },
+    "security": [
+        {"jwt": []},
+        {"authToken": []}
+    ],
+    "x-tyk-api-gateway": {
+        "info": {
+            "id": "multiauth-test-api",
+            "name": "MultiAuthTestAPI",
+            "orgId": "default",
+            "state": {
+                "active": true
+            }
+        },
+        "server": {
+            "listenPath": {
+                "value": "/test-multiauth/",
+                "strip": true
+            },
+            "detailedTracing": {
+                "enabled": true
+            },
+            "authentication": {
+                "enabled": true,
+                "securityProcessingMode": "compliant",
+                "securitySchemes": {
+                    "jwt": {
+                        "enabled": true,
+                        "source": "dHlrLWp3dC10ZXN0LXNlY3JldA==",
+                        "signingMethod": "hmac",
+                        "identityBaseField": "sub",
+                        "defaultPolicies": ["multiauth-test-policy"],
+                        "header": {
+                            "enabled": true,
+                            "name": "Authorization"
+                        }
+                    },
+                    "authToken": {
+                        "enabled": true,
+                        "header": {
+                            "enabled": true,
+                            "name": "X-API-Key"
+                        }
+                    }
+                }
+            }
+        },
+        "upstream": {
+            "url": "http://httpbin:80/"
+        },
+        "middleware": {
+            "global": {
+                "contextVariables": {
+                    "enabled": true
+                }
+            }
+        }
+    }
+}

--- a/ci/tests/tracing/apps/test-multiauth.json
+++ b/ci/tests/tracing/apps/test-multiauth.json
@@ -1,0 +1,52 @@
+{
+    "name": "MultiAuthTestAPI",
+    "api_id": "multiauth-test-api",
+    "org_id": "default",
+    "is_oas": true,
+    "definition": {
+        "location": "header",
+        "key": "version"
+    },
+    "auth": {
+        "auth_header_name": "Authorization"
+    },
+    "auth_configs": {
+        "authToken": {
+            "auth_header_name": "X-API-Key",
+            "use_param": false,
+            "use_cookie": false
+        }
+    },
+    "version_data": {
+        "not_versioned": true,
+        "versions": {
+            "Default": {
+                "name": "Default",
+                "expires": "3000-01-02 15:04",
+                "use_extended_paths": true,
+                "extended_paths": {
+                    "ignored": [],
+                    "white_list": [],
+                    "black_list": []
+                }
+            }
+        }
+    },
+    "proxy": {
+        "listen_path": "/test-multiauth/",
+        "target_url": "http://httpbin:80/",
+        "strip_listen_path": true
+    },
+    "enable_jwt": true,
+    "jwt_signing_method": "hmac",
+    "jwt_source": "dHlrLWp3dC10ZXN0LXNlY3JldA==",
+    "jwt_identity_base_field": "sub",
+    "jwt_default_policies": ["multiauth-test-policy"],
+    "use_standard_auth": true,
+    "base_identity_provided_by": "jwt_claim",
+    "security_requirements": [
+        ["jwt"],
+        ["authToken"]
+    ],
+    "detailed_tracing": true
+}

--- a/ci/tests/tracing/policies/multiauth-test-policy.json
+++ b/ci/tests/tracing/policies/multiauth-test-policy.json
@@ -1,0 +1,17 @@
+{
+    "id": "multiauth-test-policy",
+    "name": "MultiAuth Test Policy",
+    "org_id": "default",
+    "rate": 1000,
+    "per": 60,
+    "quota_max": -1,
+    "state": "active",
+    "access_rights": {
+        "multiauth-test-api": {
+            "api_id": "multiauth-test-api",
+            "api_name": "MultiAuthTestAPI",
+            "versions": ["Default"]
+        }
+    },
+    "active": true
+}

--- a/ci/tests/tracing/scenarios/tyk_multiauth_jwt_200.yml
+++ b/ci/tests/tracing/scenarios/tyk_multiauth_jwt_200.yml
@@ -1,0 +1,27 @@
+type: Test
+spec:
+  id: multiauthJwt200
+  name: MultiAuth API - verify alias in AuthORWrapper span with JWT
+  trigger:
+    type: http
+    httpRequest:
+      url: tyk:8080/test-multiauth/ip
+      method: GET
+      headers:
+      - key: Content-Type
+        value: application/json
+      - key: Authorization
+        value: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0LXVzZXItYWxpYXMiLCJpYXQiOjE3MDAwMDAwMDAsImV4cCI6MzI1MDM2ODAwMDB9.E8aStwqiSQPAvQN80UboJBEWsSazDU_gEMqHNqeXPbc
+  specs:
+  - name: Test main span attributes
+    selector: span[tracetest.span.type="http" name="GET /test-multiauth/ip" http.method="GET"]
+    assertions:
+    - attr:http.method = "GET"
+    - attr:http.status_code = 200
+    - attr:tyk.api.id = "multiauth-test-api"
+    - attr:tyk.api.name = "MultiAuthTestAPI"
+  - name: Verify AuthORWrapper span has alias attribute from JWT
+    selector: span[tracetest.span.type="general" name="AuthORWrapper"]
+    assertions:
+    - attr:name = "AuthORWrapper"
+    - attr:tyk.api.apikey.alias = "test-user-alias"


### PR DESCRIPTION
Ensure OTEL spans include the `tyk.api.apikey.alias` attribute when requests are authenticated through multi-auth (compliant mode) APIs using the `AuthORWrapper`. Currently, alias is correctly set in OTEL spans for single-auth APIs (Scenario 1 fix) but missing when `AuthORWrapper` orchestrates authentication.

In multi-auth (OR) scenarios, inner middlewares like JWTMiddleware store span attributes under their own name, but TraceMiddleware looks them up under "AuthORWrapper". This copies attributes from the successful inner middleware to the wrapper, preserving alias and other attributes in traces. Adds unit tests and integration tracing scenario for multi-auth with JWT.

TT-15424


<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-15424" title="TT-15424" target="_blank">TT-15424</a>
</summary>

|         |    |
|---------|----|
| Status  | In Dev |
| Summary | [Innersource] Identity source not available in OTEL when using JWT protected APIs |

Generated at: 2026-02-10 14:48:59

</details>

<!---TykTechnologies/jira-linter ends here-->




## Integration test

passes!

```
tracetest run test -f ./scenarios/tyk_multiauth_jwt_200.yml -o pretty
✔ MultiAuth API - verify alias in AuthORWrapper span with JWT (http://localhost:11633/test/multiauthJwt200/run/1/test) - trace id: bb4580118aa1510943695c65961308a8
        ✔ Test main span attributes
        ✔ Verify AuthORWrapper span has alias attribute from JWT
```