### PR TITLE
[TT-16408] update kin-openapi

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -572,4 +572,4 @@ require (
 
 replace go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.54.0 => go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0
 
-replace github.com/getkin/kin-openapi => github.com/TykTechnologies/kin-openapi v0.92.1-0.20260121113356-cca35373e785
+replace github.com/getkin/kin-openapi => github.com/TykTechnologies/kin-openapi v0.92.1-0.20260211103127-0004a8367058

--- a/go.sum
+++ b/go.sum
@@ -820,8 +820,8 @@ github.com/TykTechnologies/graphql-go-tools/v2 v2.0.0-20250926102005-c54e73aae17
 github.com/TykTechnologies/graphql-go-tools/v2 v2.0.0-20250926102005-c54e73aae17d/go.mod h1:XM1owY0ZCJ1Rai64Q1UKXZYNDkWikZDojgefZw8raPk=
 github.com/TykTechnologies/graphql-translator v0.0.0-20250602105400-41c2e7514a36 h1:7nNsyocI/RKBqo73RR9G/SiFMZ8w2sN+HMsQXYp9wPI=
 github.com/TykTechnologies/graphql-translator v0.0.0-20250602105400-41c2e7514a36/go.mod h1:qiglVaUPPOWET4bQsBmsAaLiCml20a01REQSi7TSUa0=
-github.com/TykTechnologies/kin-openapi v0.92.1-0.20260121113356-cca35373e785 h1:5Cc/pWOLB2Ut3TW/XNAdFeoO0BSG5jrZ9qDd8jvnz4Q=
-github.com/TykTechnologies/kin-openapi v0.92.1-0.20260121113356-cca35373e785/go.mod h1:3pqbPy/0LpJMt23YKflHgbObwLW8bURrTefKuo7SVp8=
+github.com/TykTechnologies/kin-openapi v0.92.1-0.20260211103127-0004a8367058 h1:XqbXHTcoUwv4WA66DJz1jr11OqZMUj+OPeW7ufmZdT4=
+github.com/TykTechnologies/kin-openapi v0.92.1-0.20260211103127-0004a8367058/go.mod h1:3pqbPy/0LpJMt23YKflHgbObwLW8bURrTefKuo7SVp8=
 github.com/TykTechnologies/murmur3 v0.0.0-20230310161213-aad17efd5632 h1:T5NWziFusj8au5nxAqMMh/bZyX9CAyYnBkaMSsfH6BA=
 github.com/TykTechnologies/murmur3 v0.0.0-20230310161213-aad17efd5632/go.mod h1:UsPYgOFBpNzDXLEti7MKOwHLpVSqdzuNGkVFPspQmnQ=
 github.com/TykTechnologies/openid2go v0.1.2 h1:WXctksOahA/epTVVvbn9iNUuMXKRr0ksrF4dY9KW8o8=


### PR DESCRIPTION
This pull request updates a dependency override in the `go.mod` file, specifically for the `github.com/getkin/kin-openapi` package. The new replacement points to a more recent commit from the `TykTechnologies/kin-openapi` fork.
<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-16408" title="TT-16408" target="_blank">TT-16408</a>
</summary>

|         |    |
|---------|----|
| Status  | In Code Review |
| Summary | OAS 3.1: Add support for exclusiveMinimum/ exclusiveMaximum |

Generated at: 2026-02-11 10:42:42

</details>

<!---TykTechnologies/jira-linter ends here-->
