### PR TITLE
Merging to release-5.8.11: [TT-16554]: Change bundle loading logic when reloaded (#7745)

### DIFF
--- a/gateway/coprocess_bundle.go
+++ b/gateway/coprocess_bundle.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -24,8 +25,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 
-	"github.com/TykTechnologies/goverify"
-
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/internal/sanitize"
 )
@@ -34,6 +33,40 @@ var (
 	bundleBackoffMultiplier float64 = 2
 	bundleMaxBackoffRetries uint64  = 4
 )
+
+type bundleChecksumVerifyFunction func(bundle *Bundle, bundleFs afero.Fs) (sha256Hash hash.Hash, err error)
+
+func defaultBundleVerifyFunction(b *Bundle, bundleFs afero.Fs) (sha256Hash hash.Hash, err error) {
+	md5Hash := md5.New()
+	sha256Hash = sha256.New()
+
+	w := io.MultiWriter(sha256Hash, md5Hash)
+	buf, ok := bundleVerifyPool.Get().(*[]byte)
+	if !ok {
+		return nil, errors.New("error verifying bundle, please try again")
+	}
+	defer bundleVerifyPool.Put(buf)
+
+	for _, f := range b.Manifest.FileList {
+		extractedPath := filepath.Join(b.Path, f)
+		file, err := bundleFs.Open(extractedPath)
+		if err != nil {
+			return nil, err
+		}
+		_, err = io.CopyBuffer(w, file, *buf)
+		file.Close()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	checksum := fmt.Sprintf("%x", md5Hash.Sum(nil))
+	if checksum != b.Manifest.Checksum {
+		return nil, errors.New("invalid checksum")
+	}
+
+	return sha256Hash, nil
+}
 
 // Bundle is the basic bundle data structure, it holds the bundle name and the data.
 type Bundle struct {
@@ -52,67 +85,73 @@ var bundleVerifyPool = sync.Pool{
 	},
 }
 
-// Verify performs signature verification on the bundle file.
-func (b *Bundle) Verify(bundleFs afero.Fs) error {
+func (b *Bundle) DeepVerify(bundleFs afero.Fs) error {
 	log.WithFields(logrus.Fields{
 		"prefix": "main",
 	}).Info("----> Verifying bundle: ", b.Spec.CustomMiddlewareBundle)
+	hasKey := b.Gw.GetConfig().PublicKeyPath != ""
+	hasSignature := b.Manifest.Signature != ""
 
-	var useSignature = b.Gw.GetConfig().PublicKeyPath != ""
+	if hasKey && !hasSignature {
+		return errors.New("Bundle isn't signed")
+	}
 
-	var (
-		verifier goverify.Verifier
-		err      error
-	)
-
-	if useSignature {
-		// Perform signature verification if a public key path is set:
-		if b.Manifest.Signature == "" {
-			// Error: A public key is set, but the bundle isn't signed.
-			return errors.New("Bundle isn't signed")
-		}
-		verifier, err = b.Gw.SignatureVerifier()
+	// check hash first then check signature
+	sha256Hash, err := b.Gw.BundleChecksumVerifier(b, bundleFs)
+	if err != nil {
+		return err
+	}
+	if hasKey {
+		verifier, err := b.Gw.SignatureVerifier()
 		if err != nil {
 			return err
 		}
-	}
-
-	md5Hash := md5.New()
-	sha256Hash := sha256.New()
-
-	var w io.Writer = md5Hash
-	if useSignature {
-		w = io.MultiWriter(md5Hash, sha256Hash)
-	}
-
-	buf := bundleVerifyPool.Get().(*[]byte)
-	defer bundleVerifyPool.Put(buf)
-
-	for _, f := range b.Manifest.FileList {
-		extractedPath := filepath.Join(b.Path, f)
-		file, err := bundleFs.Open(extractedPath)
-		if err != nil {
-			return err
-		}
-		_, err = io.CopyBuffer(w, file, *buf)
-		file.Close()
-		if err != nil {
-			return err
-		}
-	}
-
-	checksum := fmt.Sprintf("%x", md5Hash.Sum(nil))
-	if checksum != b.Manifest.Checksum {
-		return errors.New("Invalid checksum")
-	}
-
-	if useSignature {
 		signed, err := base64.StdEncoding.DecodeString(b.Manifest.Signature)
 		if err != nil {
 			return err
 		}
-		return verifier.VerifyHash(sha256Hash.Sum(nil), signed)
+		if err := verifier.VerifyHash(sha256Hash.Sum(nil), signed); err != nil {
+			return err
+		}
 	}
+	return nil
+}
+
+func (b *Bundle) PartialVerify(bundleFs afero.Fs, skipVerify bool) error {
+	if skipVerify {
+		return nil
+	}
+
+	hasKey := b.Gw.GetConfig().PublicKeyPath != ""
+	hasSignature := b.Manifest.Signature != ""
+
+	if !hasSignature {
+		return nil
+	}
+
+	log.WithFields(logrus.Fields{
+		"prefix": "main",
+	}).Info("----> Verifying bundle: ", b.Spec.CustomMiddlewareBundle)
+	// Make a single call to compute both hashes if needed
+	sha256Hash, err := b.Gw.BundleChecksumVerifier(b, bundleFs)
+	if err != nil {
+		return err
+	}
+
+	if hasKey {
+		verifier, err := b.Gw.SignatureVerifier()
+		if err != nil {
+			return err
+		}
+		signed, err := base64.StdEncoding.DecodeString(b.Manifest.Signature)
+		if err != nil {
+			return err
+		}
+		if err := verifier.VerifyHash(sha256Hash.Sum(nil), signed); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -352,7 +391,7 @@ func saveBundle(bundleFs afero.Fs, bundle *Bundle, destPath string, spec *APISpe
 }
 
 // loadBundleManifest will parse the manifest file and return the bundle parameters.
-func loadBundleManifest(bundleFs afero.Fs, bundle *Bundle, spec *APISpec, skipVerification bool) error {
+func loadBundleManifest(bundleFs afero.Fs, bundle *Bundle, spec *APISpec, partial bool, skipVerification bool) error {
 	log.WithFields(logrus.Fields{
 		"prefix": "main",
 	}).Info("----> Loading bundle: ", spec.CustomMiddlewareBundle)
@@ -371,16 +410,18 @@ func loadBundleManifest(bundleFs afero.Fs, bundle *Bundle, spec *APISpec, skipVe
 		return err
 	}
 
-	if skipVerification {
-		return nil
+	if partial {
+		err = bundle.PartialVerify(bundleFs, skipVerification)
+	} else {
+		err = bundle.DeepVerify(bundleFs)
 	}
-
-	if err := bundle.Verify(bundleFs); err != nil {
+	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": "main",
 		}).Info("----> Bundle verification failed: ", spec.CustomMiddlewareBundle)
 		return err
 	}
+
 	return nil
 }
 
@@ -442,7 +483,7 @@ func (gw *Gateway) loadBundleWithFs(spec *APISpec, bundleFs afero.Fs) error {
 			Gw:   gw,
 		}
 
-		err = loadBundleManifest(bundleFs, &bundle, spec, gw.GetConfig().SkipVerifyExistingPluginBundle)
+		err = loadBundleManifest(bundleFs, &bundle, spec, true, gw.GetConfig().SkipVerifyExistingPluginBundle)
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"prefix": "main",
@@ -483,7 +524,7 @@ func (gw *Gateway) loadBundleWithFs(spec *APISpec, bundleFs afero.Fs) error {
 	// Set the destination path:
 	bundle.Path = destPath
 
-	if err := loadBundleManifest(bundleFs, &bundle, spec, false); err != nil {
+	if err := loadBundleManifest(bundleFs, &bundle, spec, false, false); err != nil {
 		bundleError(spec, err, "Couldn't load bundle")
 
 		if removeErr := bundleFs.RemoveAll(bundle.Path); removeErr != nil {

--- a/gateway/coprocess_bundle_test.go
+++ b/gateway/coprocess_bundle_test.go
@@ -503,11 +503,13 @@ func TestBundle_Verify(t *testing.T) {
 		bundle         Bundle
 		setupFs        func(afero.Fs, string)
 		usePublicKey   bool
+		partialVerify  bool
+		skipVerifCheck bool
 		wantErr        bool
 		wantErrContain string
 	}{
 		{
-			name: "bundle with invalid public key path",
+			name: "bundle with invalid public key path using DeepVerify",
 			bundle: Bundle{
 				Name: "test",
 				Data: []byte("test"),
@@ -521,11 +523,12 @@ func TestBundle_Verify(t *testing.T) {
 				},
 				Gw: &Gateway{},
 			},
-			usePublicKey: true,
-			wantErr:      true,
+			usePublicKey:  true,
+			partialVerify: false,
+			wantErr:       true,
 		},
 		{
-			name: "bundle without signature",
+			name: "bundle without signature using DeepVerify",
 			bundle: Bundle{
 				Name: "test",
 				Data: []byte("test"),
@@ -539,11 +542,13 @@ func TestBundle_Verify(t *testing.T) {
 				},
 				Gw: &Gateway{},
 			},
-			usePublicKey: true,
-			wantErr:      true,
+			usePublicKey:   true,
+			partialVerify:  false,
+			wantErr:        true,
+			wantErrContain: "Bundle isn't signed",
 		},
 		{
-			name: "valid checksum with empty file list",
+			name: "valid checksum with empty file list using DeepVerify",
 			bundle: Bundle{
 				Name: "test",
 				Spec: &APISpec{
@@ -557,11 +562,12 @@ func TestBundle_Verify(t *testing.T) {
 				},
 				Gw: &Gateway{},
 			},
-			usePublicKey: false,
-			wantErr:      false,
+			usePublicKey:  false,
+			partialVerify: false,
+			wantErr:       false,
 		},
 		{
-			name: "invalid checksum returns error",
+			name: "invalid checksum returns error using DeepVerify",
 			bundle: Bundle{
 				Name: "test",
 				Spec: &APISpec{
@@ -576,11 +582,12 @@ func TestBundle_Verify(t *testing.T) {
 				Gw: &Gateway{},
 			},
 			usePublicKey:   false,
+			partialVerify:  false,
 			wantErr:        true,
-			wantErrContain: "Invalid checksum",
+			wantErrContain: "invalid checksum",
 		},
 		{
-			name: "file not found in file list",
+			name: "file not found in file list using DeepVerify",
 			bundle: Bundle{
 				Name: "test",
 				Spec: &APISpec{
@@ -594,12 +601,13 @@ func TestBundle_Verify(t *testing.T) {
 				},
 				Gw: &Gateway{},
 			},
-			setupFs:      func(fs afero.Fs, bundlePath string) {},
-			usePublicKey: false,
-			wantErr:      true,
+			setupFs:       func(_ afero.Fs, _ string) {},
+			usePublicKey:  false,
+			partialVerify: false,
+			wantErr:       true,
 		},
 		{
-			name: "valid checksum with multiple files",
+			name: "valid checksum with multiple files using DeepVerify",
 			bundle: Bundle{
 				Name: "test",
 				Spec: &APISpec{
@@ -618,11 +626,12 @@ func TestBundle_Verify(t *testing.T) {
 				assert.NoError(t, afero.WriteFile(fs, filepath.Join(bundlePath, "file1.py"), []byte("file1 content"), 0644))
 				assert.NoError(t, afero.WriteFile(fs, filepath.Join(bundlePath, "file2.py"), []byte("file2 content"), 0644))
 			},
-			usePublicKey: false,
-			wantErr:      false,
+			usePublicKey:  false,
+			partialVerify: false,
+			wantErr:       false,
 		},
 		{
-			name: "invalid base64 signature returns error",
+			name: "invalid base64 signature returns error using DeepVerify",
 			bundle: Bundle{
 				Name: "test",
 				Spec: &APISpec{
@@ -637,13 +646,138 @@ func TestBundle_Verify(t *testing.T) {
 				},
 				Gw: &Gateway{},
 			},
-			usePublicKey: true,
-			wantErr:      true,
+			usePublicKey:  true,
+			partialVerify: false,
+			wantErr:       true,
+		},
+		{
+			name: "partial verify skips checksum when specified",
+			bundle: Bundle{
+				Name: "test",
+				Spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddlewareBundle: "test-mw-bundle",
+					},
+				},
+				Manifest: apidef.BundleManifest{
+					Checksum: "invalidchecksum",
+					FileList: []string{},
+				},
+				Gw: &Gateway{},
+			},
+			usePublicKey:   true,
+			partialVerify:  true,
+			skipVerifCheck: true,
+			wantErr:        false,
+		},
+		{
+			name: "bundle signed but no public key path using PartialVerify",
+			bundle: Bundle{
+				Name: "test",
+				Spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddlewareBundle: "test-mw-bundle",
+					},
+				},
+				Manifest: apidef.BundleManifest{
+					Checksum:  "invalidchecksum",
+					FileList:  []string{},
+					Signature: "test-signature",
+				},
+				Gw: &Gateway{},
+			},
+			usePublicKey:   false,
+			partialVerify:  true,
+			skipVerifCheck: false,
+			wantErr:        true,
+		},
+		{
+			name: "partial verify skips signature check on skip check",
+			bundle: Bundle{
+				Name: "test",
+				Spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddlewareBundle: "test-mw-bundle",
+					},
+				},
+				Manifest: apidef.BundleManifest{
+					Checksum: "invalidchecksum",
+					FileList: []string{},
+				},
+				Gw: &Gateway{},
+			},
+			usePublicKey:   true,
+			partialVerify:  true,
+			skipVerifCheck: true,
+			wantErr:        false,
+		},
+		{
+			name: "partial verify fails signature check on proper check",
+			bundle: Bundle{
+				Name: "test",
+				Spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddlewareBundle: "test-mw-bundle",
+					},
+				},
+				Manifest: apidef.BundleManifest{
+					Checksum: "invalidchecksum",
+					FileList: []string{},
+				},
+				Gw: &Gateway{},
+			},
+			usePublicKey:   true,
+			partialVerify:  true,
+			skipVerifCheck: false,
+		},
+		{
+			name: "partial verify: no signature with public key set, should pass",
+			bundle: Bundle{
+				Name: "test",
+				Spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddlewareBundle: "test-mw-bundle",
+					},
+				},
+				Manifest: apidef.BundleManifest{
+					Checksum: "invalidchecksum",
+					FileList: []string{},
+				},
+				Gw: &Gateway{},
+			},
+			usePublicKey:   true,
+			partialVerify:  true,
+			skipVerifCheck: false,
+			wantErr:        false,
+		},
+		{
+			name: "partial verify: signature and no public key, fail checksum validation",
+			bundle: Bundle{
+				Name: "test",
+				Spec: &APISpec{
+					APIDefinition: &apidef.APIDefinition{
+						CustomMiddlewareBundle: "test-mw-bundle",
+					},
+				},
+				Manifest: apidef.BundleManifest{
+					Checksum:  "invalidchecksum",
+					FileList:  []string{},
+					Signature: "test-signature",
+				},
+				Gw: &Gateway{},
+			},
+			usePublicKey:   false,
+			partialVerify:  true,
+			skipVerifCheck: false,
+			wantErr:        true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b := tt.bundle
+
+			// Set up Gateway with BundleChecksumVerifier
+			b.Gw.BundleChecksumVerifier = defaultBundleVerifyFunction
 
 			globalConf := config.Config{}
 			if tt.usePublicKey {
@@ -668,7 +802,13 @@ func TestBundle_Verify(t *testing.T) {
 				tt.setupFs(fs, bundlePath)
 			}
 
-			err := b.Verify(fs)
+			var err error
+			if tt.partialVerify {
+				err = b.PartialVerify(fs, tt.skipVerifCheck)
+			} else {
+				err = b.DeepVerify(fs)
+			}
+
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Bundle.Verify() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -778,11 +918,15 @@ func BenchmarkBundle_Verify(b *testing.B) {
 			// Configure GW with no public key (no signature verification)
 			bundle.Gw.SetConfig(config.Config{})
 
+			// Initialize BundleChecksumVerifier
+			bundle.Gw.BundleChecksumVerifier = defaultBundleVerifyFunction
+
 			b.ResetTimer()
 			b.ReportAllocs()
 
 			for i := 0; i < b.N; i++ {
-				_ = bundle.Verify(fs)
+				err := bundle.PartialVerify(fs, false)
+				assert.NoError(b, err)
 			}
 		})
 	}

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -206,6 +206,8 @@ type Gateway struct {
 	healthCheckInfo atomic.Value
 
 	dialCtxFn test.DialContext
+
+	BundleChecksumVerifier bundleChecksumVerifyFunction
 }
 
 func NewGateway(config config.Config, ctx context.Context) *Gateway {
@@ -246,6 +248,8 @@ func NewGateway(config config.Config, ctx context.Context) *Gateway {
 
 	gw.SetNodeID("solo-" + uuid.New())
 	gw.SessionID = uuid.New()
+
+	gw.BundleChecksumVerifier = defaultBundleVerifyFunction
 
 	return gw
 }

--- a/tests/coprocess/bundle_loading_test.go
+++ b/tests/coprocess/bundle_loading_test.go
@@ -1,8 +1,12 @@
 package coprocess_test
 
 import (
+	"hash"
 	"net/http"
 	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/gateway"
@@ -27,13 +31,24 @@ func TestBundleLoading(t *testing.T) {
 		spec := specs[0]
 		_ = spec
 
-		//		bundle, err := ts.Gw.FetchBundle(spec)
-		//		assert.NotNil(t, bundle)
-		//		assert.NoError(t, err)
-
 		ts.Run(t, []test.TestCase{
 			{Path: "/test/", Code: http.StatusOK, BodyMatch: `New Request body`},
 		}...)
+
+		t.Run("signed bundle should not verify checksum on reload", func(t *testing.T) {
+			cfg := ts.Gw.GetConfig()
+			cfg.SkipVerifyExistingPluginBundle = true
+			ts.Gw.SetConfig(cfg)
+
+			var verifierCalled bool
+			ts.Gw.BundleChecksumVerifier = func(_ *gateway.Bundle, _ afero.Fs) (sha256Hash hash.Hash, err error) {
+				verifierCalled = true
+				return sha256Hash, nil
+			}
+			ts.Gw.DoReload()
+			ts.Gw.LoadAPI(spec)
+			assert.False(t, verifierCalled)
+		})
 	})
 
 	t.Run("Invalid bundle signature should error", func(t *testing.T) {
@@ -95,4 +110,62 @@ func TestBundleLoading(t *testing.T) {
 			{Path: "/test/", Code: http.StatusNotFound},
 		}...)
 	})
+}
+
+func BenchmarkBundleLoading(b *testing.B) {
+	bundleID := "bundle.zip"
+	ts := gateway.StartTest(func(c *config.Config) {
+		c.PublicKeyPath = "testdata/server.pub"
+		c.BundleBaseURL = "file://testdata/"
+	})
+	defer ts.Close()
+	specs := ts.Gw.BuildAndLoadAPI(func(spec *gateway.APISpec) {
+		spec.CustomMiddlewareBundle = bundleID
+		spec.UseKeylessAccess = true
+		spec.Proxy.ListenPath = "/test/"
+	})
+	spec := specs[0]
+	_ = spec
+
+	benchmarks := []struct {
+		name         string
+		skipVerify   bool
+		hasPublicKey bool //setting this to false, simulates signature=false
+	}{
+		{
+			name:         "skip verify=true hasSignature=true",
+			skipVerify:   true,
+			hasPublicKey: true,
+		},
+		{
+			name:         "skip verify=false,hasSignature=true",
+			skipVerify:   false,
+			hasPublicKey: true,
+		},
+		{
+			name:         "skip verify=false,hasSignature=false",
+			skipVerify:   false,
+			hasPublicKey: false,
+		},
+		{
+			name:         "skip verify=true,hasSignature=false",
+			skipVerify:   true,
+			hasPublicKey: false,
+		},
+	}
+	for _, bm := range benchmarks {
+		cfg := ts.Gw.GetConfig()
+		cfg.SkipVerifyExistingPluginBundle = bm.skipVerify
+		if bm.hasPublicKey {
+			cfg.PublicKeyPath = "testdata/server.pub"
+		} else {
+			cfg.PublicKeyPath = ""
+		}
+		ts.Gw.SetConfig(cfg)
+		ts.Gw.DoReload()
+
+		b.Run(bm.name, func(_ *testing.B) {
+			ts.Gw.LoadAPI(spec)
+		})
+	}
 }


### PR DESCRIPTION
### **User description**
Cherry-pick of `756e53cd32ff8340b528750bdc14287d049d9f26` from `master` to `release-5.8.11`.

Original PR: https://github.com/TykTechnologies/tyk/pull/7761
Original commit: https://github.com/TykTechnologies/tyk/commit/756e53cd32ff8340b528750bdc14287d049d9f26

**Conflicts detected:** None - cherry-pick applied cleanly.

---

### Description

This PR cherry-picks the bundle loading logic changes from PR #7761 (originally #7745) into `release-5.8.11`.

Changes:
- Split bundle verification into `DeepVerify` (checksum + signature) and `PartialVerify` (optional skip)
- Make reload path optionally skip verification using `skip_verify_existing_plugin_bundle` config
- Inject `BundleChecksumVerifier` for performance/tests
- Add unit tests and benchmarks

### Files Changed
- `gateway/coprocess_bundle.go` - Split verification into deep/partial modes
- `gateway/coprocess_bundle_test.go` - Expanded verification tests
- `gateway/server.go` - Add `BundleChecksumVerifier` field to Gateway
- `tests/coprocess/bundle_loading_test.go` - Add reload behavior tests and benchmarks

### Ticket
[TT-16554](https://tyktech.atlassian.net/browse/TT-16554)

[TT-16554]: https://tyktech.atlassian.net/browse/TT-16554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Split bundle verification: deep vs partial

- Allow reload loads to skip verification

- Inject checksum verifier for hashing

- Add verification tests and benchmarks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  n1["Bundle manifest loading"]
  n2["DeepVerify: checksum + signature"]
  n3["PartialVerify: optional skip"]
  n4["Injected BundleChecksumVerifier"]
  n5["Gateway reload/load bundle path"]
  n6["Tests & benchmarks"]
  n1 -- "select verify mode" --> n2
  n1 -- "select verify mode" --> n3
  n4 -- "compute hashes" --> n2
  n4 -- "compute hashes" --> n3
  n5 -- "uses partial verification" --> n3
  n6 -- "covers verification behaviors" --> n1
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coprocess_bundle.go</strong><dd><code>Split bundle verification and inject hashing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/coprocess_bundle.go

<ul><li>Add <code>bundleChecksumVerifyFunction</code> and default implementation<br> <li> Replace <code>Verify</code> with <code>DeepVerify</code> and <code>PartialVerify</code><br> <li> Update manifest loader to choose verify mode<br> <li> Use partial verification for disk reloads</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7769/files#diff-72df0cbfd3765a5d0bff62196c11008596608a21a53dbb9c65bfc6f008dbfa29">+87/-46</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>server.go</strong><dd><code>Add gateway checksum verifier dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/server.go

<ul><li>Add <code>BundleChecksumVerifier</code> field to <code>Gateway</code><br> <li> Initialize verifier to <code>defaultBundleVerifyFunction</code> in <code>NewGateway</code></ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7769/files#diff-4652d1bf175a0be8f5e61ef7177c9666f23e077d8626b73ac9d13358fa8b525b">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coprocess_bundle_test.go</strong><dd><code>Extend tests for deep/partial verification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/coprocess_bundle_test.go

<ul><li>Add DeepVerify-focused verification test cases<br> <li> Add PartialVerify scenarios with skip flag<br> <li> Inject <code>defaultBundleVerifyFunction</code> into test gateway<br> <li> Update benchmark to use <code>PartialVerify</code></ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7769/files#diff-7fded1570c90f7be73d562f3ebcbb32fe4d50548dc5e959d8ecadddef13941fa">+167/-23</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bundle_loading_test.go</strong><dd><code>Test reload skip behavior and add benchmarks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/coprocess/bundle_loading_test.go

<ul><li>Add reload test asserting checksum verifier not called<br> <li> Override <code>Gateway.BundleChecksumVerifier</code> to detect calls<br> <li> Add benchmark matrix across skip/signature configurations</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/tyk/pull/7769/files#diff-743842ed3aa0d00e7be35109c4a1f02b26882c145ccc3e2099cd4830f14852c7">+77/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

