### PR TITLE
fix: move Benthos dependencies behind ee build flag to reduce CE binary size

### DIFF
--- a/apidef/streams/bento/schema/generate_bento_config_schema.go
+++ b/apidef/streams/bento/schema/generate_bento_config_schema.go
@@ -1,3 +1,5 @@
+//go:build ee || dev
+
 package main
 
 import (

--- a/apidef/streams/bento/schema/generate_bento_config_schema_ce.go
+++ b/apidef/streams/bento/schema/generate_bento_config_schema_ce.go
@@ -1,0 +1,5 @@
+//go:build !ee && !dev
+
+package main
+
+func main() {}

--- a/apidef/streams/bento/schema/generate_bento_config_schema_test.go
+++ b/apidef/streams/bento/schema/generate_bento_config_schema_test.go
@@ -1,3 +1,5 @@
+//go:build ee || dev
+
 package main
 
 import (

--- a/ee/middleware/streams/stream.go
+++ b/ee/middleware/streams/stream.go
@@ -1,3 +1,5 @@
+//go:build ee || dev
+
 package streams
 
 import (

--- a/ee/middleware/streams/stream_ce.go
+++ b/ee/middleware/streams/stream_ce.go
@@ -1,0 +1,49 @@
+//go:build !ee && !dev
+
+package streams
+
+import (
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+)
+
+// httpMultiplexer mirrors the bento service.HTTPMultiplexer interface
+// so that CE builds compile without importing bento.
+type httpMultiplexer interface {
+	HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request))
+}
+
+// Stream is a wrapper around stream
+type Stream struct {
+	allowedUnsafe []string
+	streamConfig  string
+	logger        *logrus.Entry
+}
+
+// NewStream creates a new stream without initializing it
+func NewStream(_ []string, logger *logrus.Entry) *Stream {
+	return &Stream{
+		logger: logger,
+	}
+}
+
+// Start is a no-op in CE builds.
+func (s *Stream) Start(_ map[string]interface{}, _ httpMultiplexer) error {
+	return nil
+}
+
+// Stop is a no-op in CE builds.
+func (s *Stream) Stop() error {
+	return nil
+}
+
+// GetConfig returns the configuration of the stream
+func (s *Stream) GetConfig() string {
+	return s.streamConfig
+}
+
+// Reset stops the stream
+func (s *Stream) Reset() error {
+	return s.Stop()
+}

--- a/ee/middleware/streams/stream_test.go
+++ b/ee/middleware/streams/stream_test.go
@@ -1,3 +1,5 @@
+//go:build ee || dev
+
 package streams
 
 import (

--- a/internal/portal/portal_output.go
+++ b/internal/portal/portal_output.go
@@ -1,3 +1,5 @@
+//go:build ee || dev
+
 package portal
 
 import (

--- a/internal/portal/portal_output_test.go
+++ b/internal/portal/portal_output_test.go
@@ -1,3 +1,5 @@
+//go:build ee || dev
+
 package portal
 
 import (


### PR DESCRIPTION
## Summary

- Add `//go:build ee || dev` build tags to files importing Benthos (bento) libraries, preventing heavy dependencies from being linked into Community Edition builds
- Create CE stub files with `//go:build !ee && !dev` to maintain compilation compatibility
- Reduces CE binary size from ~313MB to ~104MB (~67% reduction) while EE binary remains unchanged

## Details

The following files imported Benthos libraries without being gated by an EE build tag, causing the full Benthos dependency tree to be included in CE builds:

| File | Bento Import | Impact |
|------|-------------|--------|
| `ee/middleware/streams/stream.go` | `bento/public/components/all` | Heaviest - pulls in ALL bento components |
| `internal/portal/portal_output.go` | `bento/public/components/pure` + `bento/public/service` | Registers portal webhook output plugin |
| `apidef/streams/bento/schema/generate_bento_config_schema.go` | Multiple bento component imports | Schema generation tool |

### CE stub files created

- `ee/middleware/streams/stream_ce.go` — provides no-op `Stream` type and methods so the package compiles without bento
- `apidef/streams/bento/schema/generate_bento_config_schema_ce.go` — empty `main()` function

### Binary size comparison

| Build | Size | Change |
|-------|------|--------|
| CE (no tags) | ~104MB | **-67%** |
| EE (`-tags ee`) | ~313MB | unchanged |

## Test plan

- [x] CE build (`go build .`) succeeds
- [x] EE build (`go build -tags ee .`) succeeds
- [x] `go vet` passes for affected packages in both CE and EE modes
- [x] Schema generator builds in both CE and EE modes
- [ ] CI pipeline passes
- [ ] Verify EE tests still pass with `-tags ee`

---
Requested by: @U3P2L4XNE | Trace: 6b4afaa8c649772938c1a32b14cecdd4
🤖 Generated with Tyk AI Assistant