### PR TITLE
Retry failed integration tests using gotestsum

### DIFF
--- a/.taskfiles/test.yml
+++ b/.taskfiles/test.yml
@@ -66,7 +66,7 @@ tasks:
       - defer: { task: services:down }
       - defer: { task: report }
       - rm -rf coverage && mkdir -p coverage
-      - go test -p 1 -parallel 1 -json {{.testArgs}} -coverprofile=coverage/{{.product}}-all.cov -count=1 -v ./... > coverage/{{.product}}-all.json
+      - gotestsum --jsonfile coverage/{{.product}}-all.json --rerun-fails=2 -- -p 1 -parallel 1 {{.testArgs}} -coverprofile=coverage/{{.product}}-all.cov -count=1 -v ./...
 
   plugin:race:
     dir: '{{.dir}}'


### PR DESCRIPTION
## Summary

- Replace direct `go test` invocation with `gotestsum` in the `integration-combined` task to automatically retry flaky test failures
- Each failed test is re-run up to **2 additional times** (3 total attempts) before the CI run is marked as failed
- If a test still fails after all 3 attempts, the GitHub Action exits with a non-zero code, failing the workflow immediately

## Motivation

Flaky integration tests cause unnecessary CI failures that waste developer time with manual re-runs. By wrapping the test execution with `gotestsum --rerun-fails=2`, individual failed tests are automatically retried in isolation without re-running the entire test suite. This significantly reduces false-negative CI failures while still catching genuine test regressions.

## What Changed

**File:** `.taskfiles/test.yml` — `integration-combined` task

| Before | After |
|--------|-------|
| `go test -p 1 -parallel 1 -json ... > coverage/gateway-all.json` | `gotestsum --jsonfile coverage/gateway-all.json --rerun-fails=2 -- -p 1 -parallel 1 ...` |

### Key differences:

1. **Test runner**: `go test` → `gotestsum` (already installed via the `deps` task)
2. **JSON output**: Shell redirect (`> file.json`) → `gotestsum --jsonfile` flag (gotestsum automatically adds `-json` to the underlying `go test` call)
3. **Retry logic**: `--rerun-fails=2` causes gotestsum to re-run each failed test individually up to 2 more times. If the test passes on a subsequent attempt, it is considered successful. If it still fails after 3 total attempts, the run fails.

### How gotestsum retry works:

```
Initial run: all tests execute normally
  ↓
Test X fails
  ↓
Rerun 1: gotestsum runs ONLY Test X with -run=TestX
  ↓
Test X fails again
  ↓
Rerun 2: gotestsum runs ONLY Test X with -run=TestX
  ↓
Test X still fails → gotestsum exits non-zero → CI fails
```

- Only failed tests are rerun, not the entire suite
- The rerun uses the same flags (`-p 1 -parallel 1`, timeouts, coverage, etc.)
- If too many tests fail initially (>10 by default via `--rerun-fails-max-failures`), reruns are skipped entirely to avoid wasting time on a fundamentally broken build

## Compatibility

- `gotestsum` is already a dependency installed by the `deps` task (`.taskfiles/deps.yml`)
- The `integration` task (per-package variant) already uses `gotestsum` — this change brings `integration-combined` in line
- The `report` task (deferred cleanup) continues to work as before since `--jsonfile` produces the same JSON format as `go test -json`
- All existing test flags (`-timeout`, `-coverpkg`, `-coverprofile`, `-tags`, etc.) are preserved and passed through to `go test` via the `--` separator

## Test plan

- [ ] Verify `integration-combined` task runs successfully with gotestsum
- [ ] Verify that a flaky test is automatically retried (can be simulated with a test that fails intermittently)
- [ ] Verify that a persistently failing test causes the workflow to fail after 3 attempts
- [ ] Verify JSON output file and coverage profile are correctly generated
- [ ] Verify the `report` task still works with the gotestsum-produced JSON output

---
🤖 Generated with Tyk AI Assistant