### PR TITLE
fix(cert-sync): catch-up cert sync after loadApps populates tracker

### DIFF
--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
+	"runtime"
 	"runtime/debug"
 	"sort"
 	"strconv"
@@ -28,6 +29,7 @@ import (
 	"github.com/TykTechnologies/tyk/storage"
 	"github.com/TykTechnologies/tyk/trace"
 
+	"github.com/TykTechnologies/tyk/certs"
 	"github.com/TykTechnologies/tyk/internal/httpctx"
 	"github.com/TykTechnologies/tyk/internal/httputil"
 	"github.com/TykTechnologies/tyk/internal/otel"
@@ -1097,6 +1099,12 @@ func (gw *Gateway) loadApps(specs []*APISpec) {
 				"api_count":  len(specs),
 			}).Info("sync used certs only enabled")
 		}
+
+		// Catch-up sync for certs missed during startup race:
+		// CertificateAdded keyspace events may have fired before the tracker was
+		// populated, so we pro-actively fetch any required certs that are absent
+		// from local Redis now that the tracker is up-to-date.
+		gw.syncRequiredCertificates()
 	}
 
 	tmpSpecRegister := make(map[string]*APISpec)
@@ -1270,4 +1278,67 @@ func WithQuotaKey(key string) option.Option[ProcessSpecOptions] {
 	return func(p *ProcessSpecOptions) {
 		p.quotaKey = key
 	}
+}
+
+// certSyncWorkers is the maximum number of concurrent GetRaw calls issued
+// during catch-up sync. Mirrors the host-checker default (host_checker.go:37).
+var certSyncWorkers = runtime.NumCPU()
+
+// syncRequiredCertificates fetches any required certs not yet in local Redis.
+// Called after loadApps populates certUsageTracker to handle the startup race
+// where CertificateAdded keyspace events fire before the tracker is ready.
+// Fetches are issued concurrently, bounded by certSyncWorkers, and the
+// function blocks until all fetches complete.
+func (gw *Gateway) syncRequiredCertificates() {
+	if gw.certUsageTracker == nil {
+		return
+	}
+	if !gw.GetConfig().SlaveOptions.UseRPC || !gw.GetConfig().SlaveOptions.SyncUsedCertsOnly {
+		return
+	}
+
+	required := gw.certUsageTracker.Certs()
+	if len(required) == 0 {
+		return
+	}
+
+	mainLog.WithField("cert_count", len(required)).Info("syncing required certificates")
+
+	// Semaphore: limits concurrent MDCB round-trips to certSyncWorkers.
+	sem := make(chan struct{}, certSyncWorkers)
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		synced  int
+		failed  int
+	)
+
+	for _, certID := range required {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(id string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			// GetRaw checks local storage first (MdcbStorage.GetKey:40-47),
+			// only pulls from MDCB if missing. Safe to call unconditionally.
+			if _, err := gw.CertificateManager.GetRaw(id); err != nil {
+				mainLog.WithField("cert_id", certs.MaskCertID(id)).
+					WithError(err).Warning("failed to sync required certificate")
+				mu.Lock()
+				failed++
+				mu.Unlock()
+			} else {
+				mu.Lock()
+				synced++
+				mu.Unlock()
+			}
+		}(certID)
+	}
+	wg.Wait()
+
+	mainLog.WithFields(logrus.Fields{
+		"synced": synced,
+		"failed": failed,
+	}).Info("certificate sync complete")
 }

--- a/gateway/api_loader_cert_sync_test.go
+++ b/gateway/api_loader_cert_sync_test.go
@@ -1,0 +1,136 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/TykTechnologies/tyk/certs/mock"
+	"github.com/TykTechnologies/tyk/config"
+)
+
+// newSyncTestGateway builds a minimal Gateway (no Redis) suitable for
+// testing syncRequiredCertificates.
+func newSyncTestGateway(t *testing.T, useRPC, syncUsedCertsOnly bool) *Gateway {
+	t.Helper()
+	cfg := config.Config{}
+	cfg.SlaveOptions.UseRPC = useRPC
+	cfg.SlaveOptions.SyncUsedCertsOnly = syncUsedCertsOnly
+	return NewGateway(cfg, context.Background())
+}
+
+// TestSyncRequiredCertificates_Unit tests the catch-up cert sync logic without Redis.
+func TestSyncRequiredCertificates_Unit(t *testing.T) {
+	t.Run("no-op when tracker is nil", func(t *testing.T) {
+		gw := newSyncTestGateway(t, true, true)
+		gw.certUsageTracker = nil
+		// Should not panic
+		assert.NotPanics(t, func() {
+			gw.syncRequiredCertificates()
+		})
+	})
+
+	t.Run("no-op when UseRPC is false", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		gw := newSyncTestGateway(t, false, true)
+		gw.certUsageTracker = newUsageTracker()
+		gw.certUsageTracker.ReplaceAll(map[string]map[string]struct{}{
+			"cert1": {"api1": {}},
+		})
+
+		mockCertMgr := mock.NewMockCertificateManager(ctrl)
+		gw.CertificateManager = mockCertMgr
+
+		// GetRaw must NOT be called
+		mockCertMgr.EXPECT().GetRaw(gomock.Any()).Times(0)
+
+		gw.syncRequiredCertificates()
+	})
+
+	t.Run("no-op when SyncUsedCertsOnly is false", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		gw := newSyncTestGateway(t, true, false)
+		gw.certUsageTracker = newUsageTracker()
+		gw.certUsageTracker.ReplaceAll(map[string]map[string]struct{}{
+			"cert1": {"api1": {}},
+		})
+
+		mockCertMgr := mock.NewMockCertificateManager(ctrl)
+		gw.CertificateManager = mockCertMgr
+
+		// GetRaw must NOT be called
+		mockCertMgr.EXPECT().GetRaw(gomock.Any()).Times(0)
+
+		gw.syncRequiredCertificates()
+	})
+
+	t.Run("no-op when tracker is empty", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		gw := newSyncTestGateway(t, true, true)
+		gw.certUsageTracker = newUsageTracker()
+
+		mockCertMgr := mock.NewMockCertificateManager(ctrl)
+		gw.CertificateManager = mockCertMgr
+
+		// GetRaw must NOT be called
+		mockCertMgr.EXPECT().GetRaw(gomock.Any()).Times(0)
+
+		gw.syncRequiredCertificates()
+	})
+
+	t.Run("calls GetRaw for each required cert", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		gw := newSyncTestGateway(t, true, true)
+		gw.certUsageTracker = newUsageTracker()
+		gw.certUsageTracker.ReplaceAll(map[string]map[string]struct{}{
+			"cert1": {"api1": {}},
+			"cert2": {"api1": {}, "api2": {}},
+			"cert3": {"api2": {}},
+		})
+
+		mockCertMgr := mock.NewMockCertificateManager(ctrl)
+		gw.CertificateManager = mockCertMgr
+
+		// Each cert should trigger exactly one GetRaw call
+		mockCertMgr.EXPECT().GetRaw("cert1").Return("raw-cert1", nil).Times(1)
+		mockCertMgr.EXPECT().GetRaw("cert2").Return("raw-cert2", nil).Times(1)
+		mockCertMgr.EXPECT().GetRaw("cert3").Return("raw-cert3", nil).Times(1)
+
+		gw.syncRequiredCertificates()
+	})
+
+	t.Run("continues on GetRaw error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		gw := newSyncTestGateway(t, true, true)
+		gw.certUsageTracker = newUsageTracker()
+		gw.certUsageTracker.ReplaceAll(map[string]map[string]struct{}{
+			"cert1": {"api1": {}},
+			"cert2": {"api1": {}},
+		})
+
+		mockCertMgr := mock.NewMockCertificateManager(ctrl)
+		gw.CertificateManager = mockCertMgr
+
+		// cert1 fails, cert2 succeeds — both must be attempted
+		mockCertMgr.EXPECT().GetRaw("cert1").Return("", errors.New("not found")).AnyTimes()
+		mockCertMgr.EXPECT().GetRaw("cert2").Return("raw-cert2", nil).AnyTimes()
+
+		// Should not panic despite the error
+		assert.NotPanics(t, func() {
+			gw.syncRequiredCertificates()
+		})
+	})
+}


### PR DESCRIPTION
## Summary

- Fixes startup race in `sync_used_certs_only` mode where `CertificateAdded` keyspace events from MDCB fire before `certUsageTracker` is populated by `loadApps`, causing all certs to be skipped and never pulled into data plane Redis
- Adds `syncRequiredCertificates()` called at the end of the tracker update block in `loadApps`, pro-actively fetching any required certs absent from local Redis via `CertificateManager.GetRaw`
- `GetRaw` goes through `MdcbStorage` which checks local Redis first — the call is idempotent for already-cached certs

## Root cause

1. `start()` launches `StartRPCLoopCheck` goroutine — fires `CheckForKeyspaceChanges` immediately with `ForceSync=true`
2. MDCB responds by pushing `CertificateAdded` events for all pre-existing certs
3. `ProcessKeySpaceChanges` checks `certUsageTracker.Required()` — tracker is **empty** at this point → all certs skipped
4. ~1s later `reloadLoop` ticks → `DoReload()` → `loadApps()` → tracker populated
5. No further `CertificateAdded` events fire → certs never pulled

## Test plan

- [ ] `go test ./gateway/... -run TestSyncRequiredCertificates_Unit -v` — all 6 subtests pass without Redis
- [ ] `go test ./gateway/... -run TestCollectCertUsageMap -v` — existing tests unaffected
- [ ] Deploy data plane with `sync_used_certs_only: true` against MDCB and confirm certs appear in data plane Redis after startup