### PR TITLE
TT-16716 fix regression in hostname handling

### DIFF
--- a/apidef/oas/servers_regeneration.go
+++ b/apidef/oas/servers_regeneration.go
@@ -248,27 +248,31 @@ func determineHosts(apiData *apidef.APIDefinition, config ServerRegenerationConf
 
 // determineHostsWithEdgeSupport determines hosts based on edge endpoints and API tags.
 func determineHostsWithEdgeSupport(apiData *apidef.APIDefinition, config ServerRegenerationConfig) []string {
-	if apiData.TagsDisabled {
-		if config.HybridEnabled {
-			return []string{""}
-		}
-		return []string{config.DefaultHost}
-	}
-
-	if len(apiData.Tags) == 0 {
-		if config.HybridEnabled {
+	if apiData.TagsDisabled || len(apiData.Tags) == 0 {
+		// Only suppress DefaultHost in favour of relative paths when hybrid mode is active
+		// AND edge endpoints are configured. Without edge endpoints, the gateway's own host
+		// is the correct URL.
+		if config.HybridEnabled && len(config.EdgeEndpoints) > 0 {
 			return []string{""}
 		}
 		return []string{config.DefaultHost}
 	}
 
 	if len(config.EdgeEndpoints) == 0 {
-		return []string{""}
+		// No edge endpoints configured — DefaultHost is always correct regardless of
+		// hybrid mode, since there are no edge gateways to resolve against.
+		return []string{config.DefaultHost}
 	}
 
 	matchingHosts := findEndpointsMatchingTags(apiData.Tags, config.EdgeEndpoints)
 	if len(matchingHosts) == 0 {
-		return []string{""}
+		// Tags didn't match any edge endpoint. In hybrid/MDCB mode we can't know which
+		// edge gateway will serve this API, so return a relative path. In standard mode
+		// the gateway's own host is correct.
+		if config.HybridEnabled {
+			return []string{""}
+		}
+		return []string{config.DefaultHost}
 	}
 
 	return appendRelativePathIfNotPresent(matchingHosts)

--- a/apidef/oas/servers_regeneration_test.go
+++ b/apidef/oas/servers_regeneration_test.go
@@ -288,7 +288,7 @@ func TestDetermineHosts(t *testing.T) {
 			expected: []string{"localhost:8080", ""},
 		},
 		{
-			name: "edge endpoints but no matching tags → relative paths",
+			name: "edge endpoints but no matching tags → DefaultHost + relative path",
 			apiData: &apidef.APIDefinition{
 				Tags: []string{"dev"},
 			},
@@ -298,7 +298,7 @@ func TestDetermineHosts(t *testing.T) {
 					{Endpoint: "http://edge1.example.com", Tags: []string{"prod"}},
 				},
 			},
-			expected: []string{""},
+			expected: []string{"localhost:8080", ""},
 		},
 		{
 			name: "gateway tags disabled with tags and edge endpoints → default host + relative path",
@@ -2646,8 +2646,8 @@ func TestDetermineHosts_MDCB(t *testing.T) {
 				HybridEnabled: true,
 				EdgeEndpoints: []EdgeEndpoint{},
 			},
-			expected: []string{""},
-			comment:  "Scenario 1: No edge endpoints, should return relative path",
+			expected: []string{"localhost:8080", ""},
+			comment:  "Scenario 1: No edge endpoints, should return DefaultHost + relative path",
 		},
 		{
 			name: "MDCB: API has no tags → relative path",
@@ -2758,8 +2758,8 @@ func TestDetermineHosts_MDCB(t *testing.T) {
 					{Endpoint: "http://edge1.example.com", Tags: []string{"prod"}},
 				},
 			},
-			expected: []string{""},
-			comment:  "Standard mode with no tag matches should return relative paths",
+			expected: []string{"localhost:8080", ""},
+			comment:  "Standard mode with no tag matches should return DefaultHost + relative path",
 		},
 		{
 			name: "Standard mode: some tags match, some don't → endpoints + relative paths",
@@ -2775,6 +2775,48 @@ func TestDetermineHosts_MDCB(t *testing.T) {
 			},
 			expected: []string{"http://ddd", ""},
 			comment:  "Standard mode with mixed tag matches should return matching endpoints + relative paths",
+		},
+		{
+			name: "Standard mode: has tags, no edge endpoints → DefaultHost",
+			apiData: &apidef.APIDefinition{
+				Tags: []string{"prod"},
+			},
+			config: ServerRegenerationConfig{
+				DefaultHost:   "localhost:8080",
+				HybridEnabled: false,
+				EdgeEndpoints: []EdgeEndpoint{},
+			},
+			expected: []string{"localhost:8080", ""},
+			comment:  "Non-hybrid with tags but no edge endpoints should return DefaultHost + relative path",
+		},
+		{
+			name: "MDCB: no tags, edge endpoints configured → relative path",
+			apiData: &apidef.APIDefinition{
+				Tags: []string{},
+			},
+			config: ServerRegenerationConfig{
+				DefaultHost:   "localhost:8080",
+				HybridEnabled: true,
+				EdgeEndpoints: []EdgeEndpoint{
+					{Endpoint: "http://edge1.example.com", Tags: []string{"prod"}},
+				},
+			},
+			expected: []string{""},
+			comment:  "Hybrid with no tags but edge endpoints configured should return relative path",
+		},
+		{
+			name: "MDCB: tags disabled, no edge endpoints → DefaultHost",
+			apiData: &apidef.APIDefinition{
+				TagsDisabled: true,
+				Tags:         []string{"prod"},
+			},
+			config: ServerRegenerationConfig{
+				DefaultHost:   "localhost:8080",
+				HybridEnabled: true,
+				EdgeEndpoints: []EdgeEndpoint{},
+			},
+			expected: []string{"localhost:8080", ""},
+			comment:  "Hybrid with tags disabled and no edge endpoints should return DefaultHost + relative path",
 		},
 	}
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why

<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-16716" title="TT-16716" target="_blank">TT-16716</a>
</summary>

|         |    |
|---------|----|
| Status  | Open |
| Summary | [regression] OAS APIs: hostname being stripped from servers.url |

Generated at: 2026-02-24 14:56:56

</details>

<!---TykTechnologies/jira-linter ends here-->
