### PR TITLE
[TT-16712] fix: preserve VEM path in VersionCheck for undefined MCP primitives

### DIFF
--- a/gateway/mw_version_check.go
+++ b/gateway/mw_version_check.go
@@ -205,21 +205,15 @@ func (v *VersionCheck) handleMCPPrimitiveNotFound(r *http.Request) (error, int) 
 			return errors.New("access to this resource has been disallowed"), http.StatusForbidden
 		}
 
-		// No allow-list: reset routing and proxy request to upstream
 		resetJSONRPCRoutingAndProxyUpstream(r, state)
 		return nil, http.StatusOK
 	}
-	// Scenario 1: Direct access to VEM path without JSON-RPC routing
 	return errors.New(http.StatusText(http.StatusNotFound)), http.StatusNotFound
 }
 
-// resetJSONRPCRoutingAndProxyUpstream clears the JSON-RPC routing state and resets
-// the request URL to its original path, preparing it to be proxied to the upstream.
 func resetJSONRPCRoutingAndProxyUpstream(r *http.Request, state *httpctx.JSONRPCRoutingState) {
 	state.NextVEM = ""
 	httpctx.SetJSONRPCRoutingState(r, state)
-	r.URL.Path = state.OriginalPath
-	r.URL.RawQuery = ""
 }
 
 // getPrimitiveAllowListFlag returns the allowlist flag for a given MCP primitive VEM path.


### PR DESCRIPTION
resetJSONRPCRoutingAndProxyUpstream was resetting r.URL.Path back to the listen path (e.g. /mcp) mid-chain when an undefined MCP primitive was encountered. This caused all subsequent path-sensitive middleware — including RateLimitForAPI with synthesized per-primitive endpoint entries — to see the wrong path, silently bypassing rate limits and double-firing listen-path middleware.

The fix removes the two URL-mutating lines from resetJSONRPCRoutingAndProxyUpstream. The function now only clears state.NextVEM to signal end-of-VEM-chain. Path restoration is left entirely to MCPVEMContinuationMiddleware, which already handles it correctly at the tail of the chain for all cases.

<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-16712" title="TT-16712" target="_blank">TT-16712</a>
</summary>

|         |    |
|---------|----|
| Status  | In Code Review |
| Summary |  VEM path prematurely reset for undefined primitives |

Generated at: 2026-02-25 10:18:04

</details>

<!---TykTechnologies/jira-linter ends here-->

