### PR TITLE
[TT-16694] Fix TestCertificateExpiryCheckBatcher$ racy tests

### DIFF
--- a/internal/certcheck/batcher_test.go
+++ b/internal/certcheck/batcher_test.go
@@ -128,13 +128,13 @@ func TestCertificateExpiryCheckBatcher(t *testing.T) {
 				Return(true, nil)
 
 			ctx, cancel := context.WithCancel(context.Background())
-			go batcher.RunInBackground(ctx)
-
+			done := make(chan struct{})
+			go func() {
+				batcher.RunInBackground(ctx)
+				close(done)
+			}()
 			cancel()
-			require.Eventuallyf(t, func() bool {
-				<-ctx.Done()
-				return true
-			}, 5*time.Second, 100*time.Millisecond, "batcher background context was not canceled")
+			<-done
 		})
 
 		t.Run("Should fallback if local cache check fails on initial key check", func(t *testing.T) {
@@ -164,13 +164,13 @@ func TestCertificateExpiryCheckBatcher(t *testing.T) {
 				Return(true, nil)
 
 			ctx, cancel := context.WithCancel(context.Background())
-			go batcher.RunInBackground(ctx)
-
+			done := make(chan struct{})
+			go func() {
+				batcher.RunInBackground(ctx)
+				close(done)
+			}()
 			cancel()
-			require.Eventuallyf(t, func() bool {
-				<-ctx.Done()
-				return true
-			}, 5*time.Second, 100*time.Millisecond, "batcher background context was not canceled")
+			<-done
 		})
 
 		t.Run("Should fallback if local cache check fails on actual value check", func(t *testing.T) {
@@ -203,13 +203,13 @@ func TestCertificateExpiryCheckBatcher(t *testing.T) {
 				Return(true, nil)
 
 			ctx, cancel := context.WithCancel(context.Background())
-			go batcher.RunInBackground(ctx)
-
+			done := make(chan struct{})
+			go func() {
+				batcher.RunInBackground(ctx)
+				close(done)
+			}()
 			cancel()
-			require.Eventuallyf(t, func() bool {
-				<-ctx.Done()
-				return true
-			}, 5*time.Second, 100*time.Millisecond, "batcher background context was not canceled")
+			<-done
 		})
 
 		t.Run("Should skip certificate if fallback fails too", func(t *testing.T) {
@@ -239,13 +239,13 @@ func TestCertificateExpiryCheckBatcher(t *testing.T) {
 				Return(false, errors.New("fallback cache error"))
 
 			ctx, cancel := context.WithCancel(context.Background())
-			go batcher.RunInBackground(ctx)
-
+			done := make(chan struct{})
+			go func() {
+				batcher.RunInBackground(ctx)
+				close(done)
+			}()
 			cancel()
-			require.Eventuallyf(t, func() bool {
-				<-ctx.Done()
-				return true
-			}, 5*time.Second, 100*time.Millisecond, "batcher background context was not canceled")
+			<-done
 		})
 	})
 
@@ -290,13 +290,13 @@ func TestCertificateExpiryCheckBatcher(t *testing.T) {
 					Return(nil)
 
 				ctx, cancel := context.WithCancel(context.Background())
-				go batcher.RunInBackground(ctx)
-
+				done := make(chan struct{})
+				go func() {
+					batcher.RunInBackground(ctx)
+					close(done)
+				}()
 				cancel()
-				require.Eventuallyf(t, func() bool {
-					<-ctx.Done()
-					return true
-				}, 5*time.Second, 100*time.Millisecond, "batcher background context was not canceled")
+				<-done
 			})
 
 			t.Run("Should skip event firing but check for its cooldown in fallback cache when initial lookup in local cache fails", func(t *testing.T) {
@@ -338,13 +338,13 @@ func TestCertificateExpiryCheckBatcher(t *testing.T) {
 					Return(nil)
 
 				ctx, cancel := context.WithCancel(context.Background())
-				go batcher.RunInBackground(ctx)
-
+				done := make(chan struct{})
+				go func() {
+					batcher.RunInBackground(ctx)
+					close(done)
+				}()
 				cancel()
-				require.Eventuallyf(t, func() bool {
-					<-ctx.Done()
-					return true
-				}, 5*time.Second, 100*time.Millisecond, "batcher background context was not canceled")
+				<-done
 			})
 
 			t.Run("Should skip event firing but check for its cooldown in fallback cache when value retrieval in local cache fails", func(t *testing.T) {
@@ -389,13 +389,13 @@ func TestCertificateExpiryCheckBatcher(t *testing.T) {
 					Return(nil)
 
 				ctx, cancel := context.WithCancel(context.Background())
-				go batcher.RunInBackground(ctx)
-
+				done := make(chan struct{})
+				go func() {
+					batcher.RunInBackground(ctx)
+					close(done)
+				}()
 				cancel()
-				require.Eventuallyf(t, func() bool {
-					<-ctx.Done()
-					return true
-				}, 5*time.Second, 100*time.Millisecond, "batcher background context was not canceled")
+				<-done
 			})
 
 			t.Run("Should skip event firing when local cache and fallback cache fail", func(t *testing.T) {
@@ -440,13 +440,13 @@ func TestCertificateExpiryCheckBatcher(t *testing.T) {
 					Return(nil)
 
 				ctx, cancel := context.WithCancel(context.Background())
-				go batcher.RunInBackground(ctx)
-
+				done := make(chan struct{})
+				go func() {
+					batcher.RunInBackground(ctx)
+					close(done)
+				}()
 				cancel()
-				require.Eventuallyf(t, func() bool {
-					<-ctx.Done()
-					return true
-				}, 5*time.Second, 100*time.Millisecond, "batcher background context was not canceled")
+				<-done
 			})
 		})
 
@@ -491,13 +491,13 @@ func TestCertificateExpiryCheckBatcher(t *testing.T) {
 					Return(nil)
 
 				ctx, cancel := context.WithCancel(context.Background())
-				go batcher.RunInBackground(ctx)
-
+				done := make(chan struct{})
+				go func() {
+					batcher.RunInBackground(ctx)
+					close(done)
+				}()
 				cancel()
-				require.Eventuallyf(t, func() bool {
-					<-ctx.Done()
-					return true
-				}, 5*time.Second, 100*time.Millisecond, "batcher background context was not canceled")
+				<-done
 			})
 
 			t.Run("Should fire event when certificate is expired", func(t *testing.T) {
@@ -559,13 +559,13 @@ func TestCertificateExpiryCheckBatcher(t *testing.T) {
 					Return(nil)
 
 				ctx, cancel := context.WithCancel(context.Background())
-				go batcher.RunInBackground(ctx)
-
+				done := make(chan struct{})
+				go func() {
+					batcher.RunInBackground(ctx)
+					close(done)
+				}()
 				cancel()
-				require.Eventuallyf(t, func() bool {
-					<-ctx.Done()
-					return true
-				}, 5*time.Second, 100*time.Millisecond, "batcher background context was not canceled")
+				<-done
 
 				assert.Equal(t, event.CertificateExpired, actualFiredEvent)
 				assert.Equal(t, EventCertificateExpiredMeta{
@@ -640,13 +640,13 @@ func TestCertificateExpiryCheckBatcher(t *testing.T) {
 					Return(nil)
 
 				ctx, cancel := context.WithCancel(context.Background())
-				go batcher.RunInBackground(ctx)
-
+				done := make(chan struct{})
+				go func() {
+					batcher.RunInBackground(ctx)
+					close(done)
+				}()
 				cancel()
-				require.Eventuallyf(t, func() bool {
-					<-ctx.Done()
-					return true
-				}, 5*time.Second, 100*time.Millisecond, "batcher background context was not canceled")
+				<-done
 
 				assert.Equal(t, event.CertificateExpiringSoon, actualFiredEvent)
 				assert.Equal(t, EventCertificateExpiringSoonMeta{
@@ -721,13 +721,13 @@ func TestCertificateExpiryCheckBatcher(t *testing.T) {
 					Return(errors.New("set fire event cooldown in fallback cache failed"))
 
 				ctx, cancel := context.WithCancel(context.Background())
-				go batcher.RunInBackground(ctx)
-
+				done := make(chan struct{})
+				go func() {
+					batcher.RunInBackground(ctx)
+					close(done)
+				}()
 				cancel()
-				require.Eventuallyf(t, func() bool {
-					<-ctx.Done()
-					return true
-				}, 5*time.Second, 100*time.Millisecond, "batcher background context was not canceled")
+				<-done
 
 				assert.Equal(t, event.CertificateExpiringSoon, actualFiredEvent)
 				assert.Equal(t, EventCertificateExpiringSoonMeta{


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->
- Fix flaky TestCertificateExpiryCheckBatcher tests caused by a goroutine synchronization bug that has been present since PR #7332
- All 12 test cases launched RunInBackground in a goroutine, immediately cancelled the context, then used require.Eventuallyf(<-ctx.Done()) which returns instantly (context is already cancelled) providing no synchronization with the goroutine
- This caused two issues: data races on captured variables (confirmed by -race detector) and gomock missing call(s) errors when ctrl.Finish() ran before the goroutine completed


Replaced the broken pattern in all 12 test cases:
  ```go
// Before: no synchronization - Eventuallyf on ctx.Done() is a no-op after cancel()
  go batcher.RunInBackground(ctx)
  cancel()
  require.Eventuallyf(t, func() bool {
      <-ctx.Done()
      return true
  }, 5*time.Second, 100*time.Millisecond, "...")

  // After: wait for the goroutine to actually finish
  done := make(chan struct{})
  go func() {
      batcher.RunInBackground(ctx)
      close(done)
  }()
  cancel()
  <-done

```
 
## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->



go test -race -run TestCertificateExpiryCheckBatcher -count=1  <- failed before fix, passes after
go test -race -run TestCertificateExpiryCheckBatcher -count=50 <- 50/50 passes with race detector

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
