### PR TITLE
[TT-16977] fix: goreleaser skipped on push/tag when dep-guard is skipped

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,10 @@ jobs:
   goreleaser:
     needs:
       - dep-guard
-    if: github.event.pull_request.draft == false
+    if: |
+      !cancelled() &&
+      (needs.dep-guard.result == 'success' || needs.dep-guard.result == 'skipped') &&
+      github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
     runs-on: ${{ vars.DEFAULT_RUNNER }}
     permissions:


### PR DESCRIPTION
$(gh pr view 8009 --repo TykTechnologies/tyk --json body -q .body)

### Related Tickets
- https://tyktech.atlassian.net/browse/TT-16977