### PR TITLE
[TT-16951] fix: plugin compiler FIPS support + goplugin tag

### DIFF
--- a/.github/workflows/plugin-compiler-build.yml
+++ b/.github/workflows/plugin-compiler-build.yml
@@ -125,3 +125,36 @@ jobs:
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             BUILD_TAG=ee
+
+      - name: Set docker metadata FIPS
+        id: set-metadata-fips
+        uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175  # v4
+        with:
+          images: |
+            tykio/tyk-plugin-compiler-fips,enable=${{ startsWith(github.ref, 'refs/tags') }}
+            ${{ steps.login-ecr.outputs.registry }}/tyk-plugin-compiler-fips
+          labels: |
+            org.opencontainers.image.title=tyk-plugin-compiler-fips
+            org.opencontainers.image.description=Plugin compiler for the Tyk API Gateway FIPS Edition
+          tags: |
+            type=ref,event=pr
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern={{raw}}
+            type=sha,format=long
+
+      - name: Build and push to dockerhub/ECR FIPS
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9  # v4
+        with:
+          context: .
+          file: ci/images/plugin-compiler/Dockerfile
+          platforms: linux/amd64
+          push: true
+          labels: ${{ steps.set-metadata-fips.outputs.labels }}
+          tags: ${{ steps.set-metadata-fips.outputs.tags }}
+          build-args: |
+            BASE_IMAGE=tykio/golang-cross:${{ env.GOLANG_CROSS }}
+            GITHUB_SHA=${{ github.sha }}
+            GITHUB_TAG=${{ github.ref_name }}
+            BUILD_TAG=ee,fips
+            GOFIPS140=v1.0.0

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -76,9 +76,9 @@ tasks:
   test:plugin-compiler:
     desc: "Plugin compiler local build/test"
     cmds:
-      - docker build --build-arg GO_VERSION=1.22 --build-arg BASE_IMAGE=tykio/golang-cross:1.22-bullseye --build-arg GITHUB_TAG=v5.1.0-alpha18 --build-arg GITHUB_SHA=$(git rev-parse HEAD) --platform=linux/amd64 --rm -t internal/plugin-compiler -f ci/images/plugin-compiler/Dockerfile .
+      - docker build --build-arg GO_VERSION=1.24 --build-arg BASE_IMAGE=tykio/golang-cross:1.24-bullseye --build-arg GITHUB_TAG=v5.1.0-alpha18 --build-arg GITHUB_SHA=$(git rev-parse HEAD) --platform=linux/amd64 --rm -t internal/plugin-compiler -f ci/images/plugin-compiler/Dockerfile .
       - docker run -it -e GOARCH=arm64 -e GOOS=linux --rm -v $(readlink -f .)/ci/images/plugin-compiler/data/basic-plugin:/plugin-source internal/plugin-compiler basic-plugin.so
-      - docker run -it --rm -v $PWD:/go/src/github.com/TykTechnologies/tyk -w /go/src/github.com/TykTechnologies/tyk tykio/golang-cross:1.22-bullseye go build -trimpath -tags=goplugin .
+      - docker run -it --rm -v $PWD:/go/src/github.com/TykTechnologies/tyk -w /go/src/github.com/TykTechnologies/tyk tykio/golang-cross:1.24-bullseye go build -trimpath -tags=goplugin .
       - ./tyk plugin load -f ./ci/images/plugin-compiler/data/basic-plugin/basic-plugin*.so -s MyPluginPre
       - docker rmi internal/plugin-compiler
 

--- a/ci/images/plugin-compiler/Dockerfile
+++ b/ci/images/plugin-compiler/Dockerfile
@@ -26,11 +26,6 @@ RUN --mount=type=cache,mode=0755,target=/go/pkg/mod \
 
 ADD . $TYK_GW_PATH
 
-# Provide a gateway test binary for testing plugin loading.
-RUN --mount=type=cache,mode=0755,target=/go/pkg/mod \
-    --mount=type=cache,mode=0755,target=/root/.cache/go-build \
-    GOBIN=/usr/local/bin go install -tags=goplugin -trimpath .
-
 ARG GITHUB_SHA
 ARG GITHUB_TAG
 ENV GITHUB_SHA=${GITHUB_SHA}
@@ -38,6 +33,14 @@ ENV GITHUB_TAG=${GITHUB_TAG}
 
 ARG BUILD_TAG
 ENV BUILD_TAG=${BUILD_TAG}
+
+ARG GOFIPS140
+ENV GOFIPS140=${GOFIPS140}
+
+# Provide a gateway test binary for testing plugin loading.
+RUN --mount=type=cache,mode=0755,target=/go/pkg/mod \
+    --mount=type=cache,mode=0755,target=/root/.cache/go-build \
+    GOBIN=/usr/local/bin go install -tags=goplugin${BUILD_TAG:+,$BUILD_TAG} -trimpath .
 
 COPY ci/images/plugin-compiler/data/build.sh /build.sh
 RUN chmod +x /build.sh

--- a/ci/images/plugin-compiler/data/build.sh
+++ b/ci/images/plugin-compiler/data/build.sh
@@ -145,11 +145,7 @@ if [[ "$DEBUG" == "1" ]] ; then
 	git diff --cached
 fi
 
-if [ -n "$BUILD_TAG" ]; then
-    CC=$CC CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH go build -buildmode=plugin -trimpath -tags=$BUILD_TAG -o $plugin_name
-else
-    CC=$CC CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH go build -buildmode=plugin -trimpath -o $plugin_name
-fi
+CC=$CC CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH go build -buildmode=plugin -trimpath -tags=goplugin${BUILD_TAG:+,$BUILD_TAG} -o $plugin_name
 
 set +x
 


### PR DESCRIPTION
## Summary
- **FIPS plugin compiler**: Add `tykio/tyk-plugin-compiler-fips` image with `GOFIPS140=v1.0.0` and `-tags=goplugin,ee,fips`
- **goplugin tag**: `build.sh` now always includes `goplugin` in build tags (was missing for EE/FIPS builds)
- **Embedded test binary**: Now includes `BUILD_TAG` for proper validation
- **Taskfile**: Update `golang-cross` references from 1.22 to 1.24

### Plugin compiler image matrix:
| Image | Tags | GOFIPS140 |
|-------|------|-----------|
| `tykio/tyk-plugin-compiler` | `goplugin` | - |
| `tykio/tyk-plugin-compiler-ee` | `goplugin,ee` | - |
| `tykio/tyk-plugin-compiler-fips` | `goplugin,ee,fips` | `v1.0.0` |

## Test plan
- [ ] Verify plugin compiler CI workflow runs all 3 image builds
- [ ] Verify FIPS image builds with correct GOFIPS140 setting
- [ ] Verify goplugin tag is included in all plugin builds

Generated with [Claude Code](https://claude.com/claude-code)