### PR TITLE
[TT-16951] fix: use separate ECR repo for FIPS CI images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,7 +231,7 @@ jobs:
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
-            ${{ steps.ecr.outputs.registry }}/tyk
+            ${{ steps.ecr.outputs.registry }}/tyk-fips
           flavor: |
             latest=false
           tags: |


### PR DESCRIPTION
## Summary
- FIPS CI images were pushing to the same ECR repo as std, causing overwrites
- Changed FIPS cirepo from `tyk` to `tyk-fips`

## Test plan
- [ ] Verify FIPS CI image push targets `tyk-fips` ECR repo
- [ ] Verify std CI image push still targets `tyk` ECR repo

Generated with [Claude Code](https://claude.com/claude-code)