### PR TITLE
[TT-16950] fix: create writable directories for nonroot gateway in tests

### DIFF
--- a/ci/tests/metrics/Taskfile.yml
+++ b/ci/tests/metrics/Taskfile.yml
@@ -34,6 +34,8 @@ tasks:
       vars: [GW_PROFILE]
     cmds:
       - echo "=== Setting up profile {{.GW_PROFILE}} ==="
+      # Ensure mount directories are writable by nonroot gateway (uid 65532)
+      - mkdir -p apps 2>/dev/null; chmod 777 apps 2>/dev/null; true
       - GW_PROFILE={{.GW_PROFILE}} docker compose -p metrics-{{.GW_PROFILE}} up -d --wait
       - GW_PROFILE={{.GW_PROFILE}} docker compose -p metrics-{{.GW_PROFILE}} logs -f > /tmp/metrics-{{.GW_PROFILE}}.log 2>&1 &
 

--- a/ci/tests/specs/test.sh
+++ b/ci/tests/specs/test.sh
@@ -16,6 +16,11 @@ trap "task down" EXIT
 echo "Creating .env file..."
 echo "PORTMAN_API_Key=example_gateway_secret" > ".env"
 
+# Create mount directories with world-writable permissions so the
+# nonroot gateway (uid 65532) can write API definitions and policies.
+mkdir -p apps policies 2>/dev/null
+chmod 777 apps policies 2>/dev/null
+
 task up
 
 task tests

--- a/ci/tests/tracing/Taskfile.yml
+++ b/ci/tests/tracing/Taskfile.yml
@@ -25,6 +25,8 @@ tasks:
   setup:
     desc: "setup e2e opentelemetry tests"
     cmds:
+      # Ensure mount directories are writable by nonroot gateway (uid 65532)
+      - mkdir -p apps policies 2>/dev/null; chmod 777 apps policies 2>/dev/null; true
       - docker compose up -d --wait
       - task: tracetest:configure
 


### PR DESCRIPTION
## Summary
- The gateway base image now runs as `nonroot` (uid 65532) instead of root
- Test docker-compose files mount host directories (`apps`, `policies`) into `/opt/tyk-gateway/`, but Docker creates these as root when they don't exist, causing permission denied errors
- Adds `mkdir -p && chmod 777` for mounted directories before `docker compose up` in three test suites: specs, tracing, and metrics

## Test plan
- [ ] Verify specs contract tests pass in CI (apps/policies dirs created writable)
- [ ] Verify tracing e2e tests pass in CI
- [ ] Verify metrics e2e tests pass in CI

### Related Tickets
- https://tyktech.atlassian.net/browse/TT-16950