### PR TITLE
[TT-16342] fix: align plugin compiler Go version with gateway (1.25)

### DIFF
--- a/.github/workflows/plugin-compiler-build.yml
+++ b/.github/workflows/plugin-compiler-build.yml
@@ -11,7 +11,7 @@ on:
       - "v*"
 
 env:
-  GOLANG_CROSS: 1.24-bullseye
+  GOLANG_CROSS: 1.25-bullseye
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/ci/images/plugin-compiler/Dockerfile
+++ b/ci/images/plugin-compiler/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=tykio/golang-cross:1.24-bullseye
+ARG BASE_IMAGE=tykio/golang-cross:1.25-bullseye
 FROM ${BASE_IMAGE}
 
 LABEL description="Image for plugin development"


### PR DESCRIPTION
## Summary

- The gateway goreleaser uses `golang-cross:1.25-bullseye` but the plugin compiler was still on `1.24-bullseye`
- This causes `plugin.Open` failures due to Go version mismatch (`internal/goarch`)
- Updated both `plugin-compiler-build.yml` and the plugin compiler `Dockerfile` to use `1.25-bullseye`

## Test plan

- [ ] Verify plugin compiler CI builds successfully with the new Go version
- [ ] Build a test plugin and confirm `plugin.Open` works against a gateway built with 1.25

🤖 Generated with [Claude Code](https://claude.com/claude-code)