### PR TITLE
[TT-16342] fix: update OTel tracing test scenarios for Go 1.25

### DIFF
--- a/ci/tests/tracing/scenarios/tyk_body_size_200.yaml
+++ b/ci/tests/tracing/scenarios/tyk_body_size_200.yaml
@@ -12,7 +12,7 @@ spec:
         - key: Content-Type
           value: application/json
   specs:
-    - selector: span[tracetest.span.type="http" name="GET /test/" http.method="GET"]
+    - selector: span[tracetest.span.type="http" name="GET /test/" http.request.method="GET"]
       name: Checking request and response body sizes
       assertions:
         - attr:http.request.body.size = 15 # {"foo": "bar"} = 15 bytes

--- a/ci/tests/tracing/scenarios/tyk_grpcapi_200.yml
+++ b/ci/tests/tracing/scenarios/tyk_grpcapi_200.yml
@@ -38,12 +38,12 @@ spec:
       request: "{\n  \"name\": \"tom\"\n}"
       auth: {}
   specs:
-  - selector: span[tracetest.span.type="http" name="POST /helloworld.Greeter/SayHello" http.method="POST"]
+  - selector: span[tracetest.span.type="http" name="POST /helloworld.Greeter/SayHello" http.request.method="POST"]
     name: Check http span attributes
     assertions:
-    - attr:http.status_code = 200
-    - attr:http.scheme = "http"
-    - attr:http.method = "POST"
+    - attr:http.response.status_code = 200
+    - attr:url.scheme = "http"
+    - attr:http.request.method = "POST"
     - attr:tracetest.span.type = "http"
   - selector: |-
       span[name = "POST /helloworld.Greeter/SayHello"] 
@@ -51,8 +51,8 @@ spec:
     name: Check the middlewares executed
     assertions:
     - attr:tracetest.selected_spans.count  =  4
-  - selector: span[tracetest.span.type="http" name="HTTP POST" http.method="POST"]
+  - selector: span[tracetest.span.type="http" name="HTTP POST" http.request.method="POST"]
     name: Checking the h2c proxying  
     assertions:
-    - attr:http.method = "POST"
-    - attr:http.url = "http://grpcapi:50051/helloworld.Greeter/SayHello"
+    - attr:http.request.method = "POST"
+    - attr:url.full = "http://grpcapi:50051/helloworld.Greeter/SayHello"

--- a/ci/tests/tracing/scenarios/tyk_jwt_200.yml
+++ b/ci/tests/tracing/scenarios/tyk_jwt_200.yml
@@ -14,10 +14,10 @@ spec:
         value: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0LXVzZXItYWxpYXMiLCJpYXQiOjE3MDAwMDAwMDAsImV4cCI6MzI1MDM2ODAwMDB9.E8aStwqiSQPAvQN80UboJBEWsSazDU_gEMqHNqeXPbc
   specs:
   - name: Test main span attributes
-    selector: span[tracetest.span.type="http" name="GET /test-jwt/ip" http.method="GET"]
+    selector: span[tracetest.span.type="http" name="GET /test-jwt/ip" http.request.method="GET"]
     assertions:
-    - attr:http.method = "GET"
-    - attr:http.status_code = 200
+    - attr:http.request.method = "GET"
+    - attr:http.response.status_code = 200
     - attr:tyk.api.id = "jwt-test-api"
     - attr:tyk.api.name = "JWTTestAPI"
     - attr:tyk.api.orgid = "default"

--- a/ci/tests/tracing/scenarios/tyk_multiauth_jwt_200.yml
+++ b/ci/tests/tracing/scenarios/tyk_multiauth_jwt_200.yml
@@ -14,10 +14,10 @@ spec:
         value: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0LXVzZXItYWxpYXMiLCJpYXQiOjE3MDAwMDAwMDAsImV4cCI6MzI1MDM2ODAwMDB9.E8aStwqiSQPAvQN80UboJBEWsSazDU_gEMqHNqeXPbc
   specs:
   - name: Test main span attributes
-    selector: span[tracetest.span.type="http" name="GET /test-multiauth/ip" http.method="GET"]
+    selector: span[tracetest.span.type="http" name="GET /test-multiauth/ip" http.request.method="GET"]
     assertions:
-    - attr:http.method = "GET"
-    - attr:http.status_code = 200
+    - attr:http.request.method = "GET"
+    - attr:http.response.status_code = 200
     - attr:tyk.api.id = "multiauth-test-api"
     - attr:tyk.api.name = "MultiAuthTestAPI"
   - name: Verify AuthORWrapper span has alias attribute from JWT

--- a/ci/tests/tracing/scenarios/tyk_test-graphql-detailed-tracing-disabled_200.yaml
+++ b/ci/tests/tracing/scenarios/tyk_test-graphql-detailed-tracing-disabled_200.yaml
@@ -13,12 +13,12 @@ spec:
         - key: Content-Type
           value: application/json
   specs:
-    - selector: span[tracetest.span.type = "general" name="GraphqlEngine"] span[tracetest.span.type="http" name="HTTP POST" http.method="POST"]
+    - selector: span[tracetest.span.type = "general" name="GraphqlEngine"] span[tracetest.span.type="http" name="HTTP POST" http.request.method="POST"]
       name: Upstream Request is valid
       assertions:
-        - attr:http.status_code     =     200
-        - attr:http.url   =   "https://countries.trevorblades.com/"
-        - attr:http.method  =  "POST"
+        - attr:http.response.status_code     =     200
+        - attr:url.full   =   "https://countries.trevorblades.com/"
+        - attr:http.request.method  =  "POST"
     - selector: span[tracetest.span.type="general" name="GraphqlEngine"] span[tracetest.span.type="general"]
       name: Make sure there is no subspan for graphql engine
       assertions:

--- a/ci/tests/tracing/scenarios/tyk_test-graphql-tracing-invalid_404.yml
+++ b/ci/tests/tracing/scenarios/tyk_test-graphql-tracing-invalid_404.yml
@@ -13,11 +13,11 @@ spec:
         - key: Content-Type
           value: application/json
   specs:
-    - selector: span[tracetest.span.type = "general" name = "ResolvePlan"] span[tracetest.span.type="http" name="HTTP POST" http.method="POST"]
+    - selector: span[tracetest.span.type = "general" name = "ResolvePlan"] span[tracetest.span.type="http" name="HTTP POST" http.request.method="POST"]
       name: Should return 404 for upstream
       assertions:
-        - attr:http.status_code  =   404
-        - attr:http.url  =     "http://httpbin:80/status/404"
+        - attr:http.response.status_code  =   404
+        - attr:url.full  =     "http://httpbin:80/status/404"
     - selector: span[tracetest.span.type = "general" name = "GraphqlMiddleware Validation"] span[tracetest.span.type="general" name="GraphqlEngine"]
       name: Make sure Graphql Engine is a child of GraphqlMiddleware Validation
       assertions:

--- a/ci/tests/tracing/scenarios/tyk_test-graphql-tracing_200.yml
+++ b/ci/tests/tracing/scenarios/tyk_test-graphql-tracing_200.yml
@@ -13,12 +13,12 @@ spec:
         - key: Content-Type
           value: application/json
   specs:
-    - selector: span[tracetest.span.type = "general" name="ResolvePlan"] span[tracetest.span.type="http" name="HTTP POST" http.method="POST"]
+    - selector: span[tracetest.span.type = "general" name="ResolvePlan"] span[tracetest.span.type="http" name="HTTP POST" http.request.method="POST"]
       name: Upstream Request is valid
       assertions:
-        - attr:http.status_code     =     200
-        - attr:http.url   =   "https://countries.trevorblades.com/"
-        - attr:http.method  =  "POST"
+        - attr:http.response.status_code     =     200
+        - attr:url.full   =   "https://countries.trevorblades.com/"
+        - attr:http.request.method  =  "POST"
     - selector: span[tracetest.span.type="general" name="GraphqlEngine"] span[tracetest.span.type="general"]
       name: Make sure there are 3 subspans for graphql engine
       assertions:

--- a/ci/tests/tracing/scenarios/tyk_test_200.yml
+++ b/ci/tests/tracing/scenarios/tyk_test_200.yml
@@ -13,13 +13,13 @@ spec:
   - key: User-Agent
     value: Go-http-client/1.1
   specs:
-  - selector: span[tracetest.span.type="http" name="GET /test/ip" http.method="GET"]
+  - selector: span[tracetest.span.type="http" name="GET /test/ip" http.request.method="GET"]
     name: Test main span attributes
     assertions:
-    - attr:http.method         =         "GET"
-    - attr:http.status_code         =         200
-    - attr:http.user_agent         =         "Go-http-client/1.1"
-    - attr:http.wrote_bytes         !=         0
+    - attr:http.request.method         =         "GET"
+    - attr:http.response.status_code         =         200
+    - attr:user_agent.original         =         "Go-http-client/1.1"
+    - attr:http.response.body.size         !=         0
     - attr:tracetest.span.type         =         "http"
     - attr:tyk.api.id       =       "3"
     - attr:tyk.api.name       =       "TestAPI"

--- a/ci/tests/tracing/scenarios/tyk_test_500.yml
+++ b/ci/tests/tracing/scenarios/tyk_test_500.yml
@@ -13,11 +13,11 @@ spec:
         value: application/json
   specs:
   - name: Check main span http attributes
-    selector: span[tracetest.span.type="http" name="GET /test/status/500" http.method="GET"]
+    selector: span[tracetest.span.type="http" name="GET /test/status/500" http.request.method="GET"]
     assertions:
-    - attr:http.method    =    "GET"
-    - attr:http.scheme    =    "http"
-    - attr:http.status_code    =    500
+    - attr:http.request.method    =    "GET"
+    - attr:url.scheme    =    "http"
+    - attr:http.response.status_code    =    500
     - attr:tyk.api.id  =  "3"
     - attr:tyk.api.name  =  "TestAPI"
     - attr:tyk.api.orgid  =  "default"
@@ -29,8 +29,8 @@ spec:
     assertions:
     - attr:tracetest.selected_spans.count = 4
   - name: Check the proxying request span
-    selector: span[tracetest.span.type="http" name="HTTP GET" http.method="GET"]
+    selector: span[tracetest.span.type="http" name="HTTP GET" http.request.method="GET"]
     assertions:
-    - attr:http.status_code = 500
-    - attr:http.url = "http://httpbin:80/status/500"
+    - attr:http.response.status_code = 500
+    - attr:url.full = "http://httpbin:80/status/500"
     - attr:tracetest.span.parent_id != ""

--- a/ci/tests/tracing/scenarios/tyk_testauth_401.yml
+++ b/ci/tests/tracing/scenarios/tyk_testauth_401.yml
@@ -12,7 +12,7 @@ spec:
         value: application/json
   specs:
   - name: Check if the main span executed 3 middleware
-    selector: "span[tracetest.span.type=\"http\" name=\"GET /test-auth/ip\" http.method=\"GET\"]
+    selector: "span[tracetest.span.type=\"http\" name=\"GET /test-auth/ip\" http.request.method=\"GET\"]
       \nspan[tracetest.span.type = \"general\"]"
     assertions:
     - attr:tracetest.selected_spans.count  =  3
@@ -22,10 +22,10 @@ spec:
     assertions:
     - attr:tracetest.selected_spans.count =   0
   - name: Check if the main attributes
-    selector: span[tracetest.span.type="http" name="GET /test-auth/ip" http.method="GET"]
+    selector: span[tracetest.span.type="http" name="GET /test-auth/ip" http.request.method="GET"]
     assertions:
-    - attr:http.method = "GET"
-    - attr:http.status_code = 401
+    - attr:http.request.method = "GET"
+    - attr:http.response.status_code = 401
     - attr:tyk.api.id  =  "1"
     - attr:tyk.api.name  =  "AuthAPI"
     - attr:tyk.api.orgid  =  "default"

--- a/ci/tests/tracing/scenarios/tyk_tykprotocol-auth_401.yml
+++ b/ci/tests/tracing/scenarios/tyk_tykprotocol-auth_401.yml
@@ -14,11 +14,11 @@ spec:
         value: application/json
   specs:
   - name: http attributes
-    selector: span[tracetest.span.type="http" name="GET /tykprotocol-auth/ip" http.method="GET"]
+    selector: span[tracetest.span.type="http" name="GET /tykprotocol-auth/ip" http.request.method="GET"]
     assertions:
-    - attr:http.method = "GET"
-    - attr:http.status_code = 401
-    - attr:http.wrote_bytes != 0
+    - attr:http.request.method = "GET"
+    - attr:http.response.status_code = 401
+    - attr:http.response.body.size != 0
   - name: We should have double VersionCheck spans
     selector: span[tracetest.span.type="general" name="VersionCheck"]
     assertions:

--- a/ci/tests/tracing/scenarios/tyk_tykprotocol_200.yml
+++ b/ci/tests/tracing/scenarios/tyk_tykprotocol_200.yml
@@ -13,12 +13,12 @@ spec:
         value: application/json
   specs:
   - name: /tykprotocol/ip http attributes
-    selector: span[tracetest.span.type="http" name="GET /tykprotocol/ip" http.method="GET"]
+    selector: span[tracetest.span.type="http" name="GET /tykprotocol/ip" http.request.method="GET"]
     assertions:
-    - attr:http.status_code = 200
+    - attr:http.response.status_code = 200
     - attr:tracetest.span.type = "http"
-    - attr:http.method = "GET"
-    - attr:http.wrote_bytes != 0
+    - attr:http.request.method = "GET"
+    - attr:http.response.body.size != 0
   - name: We should have double VersionCheck spans
     selector: span[tracetest.span.type="general" name="VersionCheck"]
     assertions:
@@ -28,7 +28,7 @@ spec:
     assertions:
     - attr:tracetest.selected_spans.count = 2
   - name: We should have only 1 proxy to httpbin
-    selector: span[tracetest.span.type="http" name="HTTP GET" http.method="GET"]
+    selector: span[tracetest.span.type="http" name="HTTP GET" http.request.method="GET"]
     assertions:
-    - attr:net.peer.name = "httpbin"
+    - attr:server.address = "httpbin"
     - attr:tracetest.selected_spans.count = 1

--- a/ci/tests/tracing/scenarios/tyk_versioned_200.yml
+++ b/ci/tests/tracing/scenarios/tyk_versioned_200.yml
@@ -18,7 +18,7 @@ spec:
     name: Checking version attribute
     assertions:
     - attr:tyk.api.version = "v1"
-  - selector: span[tracetest.span.type="http" name="GET /versioned/ip" http.method="GET"]
+  - selector: span[tracetest.span.type="http" name="GET /versioned/ip" http.request.method="GET"]
     name: Checking API attributes
     assertions:
     - attr:tyk.api.id = 6

--- a/ci/tests/tracing/scenarios/tyk_versioned_403.yml
+++ b/ci/tests/tracing/scenarios/tyk_versioned_403.yml
@@ -12,7 +12,7 @@ spec:
         value: application/json
   specs:
   - selector: |-
-      span[tracetest.span.type="http" name="GET /versioned/ip" http.method="GET"] 
+      span[tracetest.span.type="http" name="GET /versioned/ip" http.request.method="GET"] 
       span[tracetest.span.type = "general"]
     name: Checking if it's failing in the VersionCheck MW
     assertions:
@@ -21,7 +21,7 @@ spec:
     name: Checking if the version is "Non versioned"
     assertions:
     - attr:tyk.api.version = "Non Versioned"
-  - selector: span[tracetest.span.type="http" name="GET /versioned/ip" http.method="GET"]
+  - selector: span[tracetest.span.type="http" name="GET /versioned/ip" http.request.method="GET"]
     name: Checking the HTTP status code
     assertions:
-    - attr:http.status_code = 403
+    - attr:http.response.status_code = 403

--- a/ci/tests/tracing/scenarios/tyk_versioned_not_detailed_200.yml
+++ b/ci/tests/tracing/scenarios/tyk_versioned_not_detailed_200.yml
@@ -11,7 +11,7 @@ spec:
         - key: Content-Type
           value: application/json
   specs:
-    - selector: span[tracetest.span.type="http" name="GET /versioned-not-detailed/ip" http.method="GET"]
+    - selector: span[tracetest.span.type="http" name="GET /versioned-not-detailed/ip" http.request.method="GET"]
       name: Checking API attributes + version
       assertions:
         - attr:tyk.api.id   =   7

--- a/ci/tests/tracing/scenarios/tyk_versioned_not_detailed_403.yml
+++ b/ci/tests/tracing/scenarios/tyk_versioned_not_detailed_403.yml
@@ -11,11 +11,11 @@ spec:
         - key: Content-Type
           value: application/json
   specs:
-    - selector: span[tracetest.span.type="http" name="GET /versioned-not-detailed/ip" http.method="GET"]
+    - selector: span[tracetest.span.type="http" name="GET /versioned-not-detailed/ip" http.request.method="GET"]
       name: Checking attributes + wrong version in attributes
       assertions:
         - attr:tyk.api.version = "v3"
-        - attr:http.status_code = 403
+        - attr:http.response.status_code = 403
         - attr:tyk.api.id = 7
         - attr:tyk.api.name = "VersionedNotDetailedAPI"
         - attr:tyk.api.orgid = "default"


### PR DESCRIPTION
## Summary

- Update 16 OTel tracing test scenario files to use new semantic convention attribute names
- Go 1.25 + otelhttp v0.60.0 emits new attribute names (e.g., `http.response.status_code` instead of `http.status_code`, `http.request.method` instead of `http.method`, `url.full` instead of `http.url`, `server.address` instead of `net.peer.name`, etc.)
- Backport scenario updates from master to fix CI failures on release-5.12

## Attribute mapping

| Old (pre-Go 1.25) | New (Go 1.25+) |
|---|---|
| `http.status_code` | `http.response.status_code` |
| `http.method` | `http.request.method` |
| `http.url` | `url.full` |
| `http.scheme` | `url.scheme` |
| `http.wrote_bytes` | `http.response.body.size` |
| `http.user_agent` | `user_agent.original` |
| `net.peer.name` | `server.address` |

## Test plan

- [ ] OTel tracing CI tests pass with updated scenario files
- [ ] No regressions in other tracing-related tests

Generated with [Claude Code](https://claude.com/claude-code)