### PR TITLE
[TT-16950] fix: dashboard resolver matches release branches (release-5.12.1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -499,6 +499,7 @@ jobs:
           COMMIT_SHA: ${{ github.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HAS_RELEVANT_CHANGES: ${{ steps.check_changes.outputs.has_relevant_changes }}
+          ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
         run: |
           echo "=================================="
           echo "📊 Dashboard Image Resolution"
@@ -513,14 +514,23 @@ jobs:
           echo "Has relevant changes in PR: $HAS_RELEVANT_CHANGES"
           echo "=================================="
 
-          # Only use custom build strategies for PRs targeting master
+          # For non-master base branches, check if the same branch exists in tyk-analytics
           if [ "$BASE_REF" != "master" ]; then
-            echo "ℹ️ Strategy: Use gromit default (base branch is not master)"
-            echo "    → Custom builds only for master branch PRs"
-            echo "dashboard_image=" >> $GITHUB_OUTPUT
-            echo "needs_build=false" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=" >> $GITHUB_OUTPUT
-            echo "strategy=gromit-default" >> $GITHUB_OUTPUT
+            if git ls-remote --exit-code --heads "https://x-access-token:${ORG_GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" "refs/heads/$BASE_REF" > /dev/null 2>&1; then
+              echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
+              echo "    → Base branch exists in tyk-analytics, using it directly"
+              echo "dashboard_image=${REGISTRY}/tyk-analytics:${BASE_REF}" >> $GITHUB_OUTPUT
+              echo "needs_build=false" >> $GITHUB_OUTPUT
+              echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
+              echo "strategy=release-branch-match" >> $GITHUB_OUTPUT
+            else
+              echo "ℹ️ Strategy: Use gromit default (base branch '$BASE_REF' not found in tyk-analytics)"
+              echo "    → Falling back to gromit default"
+              echo "dashboard_image=" >> $GITHUB_OUTPUT
+              echo "needs_build=false" >> $GITHUB_OUTPUT
+              echo "dashboard_branch=" >> $GITHUB_OUTPUT
+              echo "strategy=gromit-default" >> $GITHUB_OUTPUT
+            fi
 
           # Strategy 1: Matching branch exists in tyk-analytics → use gromit
           elif [ "$BRANCH_EXISTS" = "true" ]; then


### PR DESCRIPTION
## Summary

- For PRs targeting release branches, the dashboard resolver now checks if the base branch exists in `tyk-analytics` and uses it directly via ECR image
- Previously always fell back to gromit-default (master), causing test failures due to dashboard/gateway version mismatch
- Adds `ORG_GH_TOKEN` to the resolve step's env block for authenticated `git ls-remote` against private `tyk-analytics` repo

Same fix as #8043 (master) and #8044 (release-5.12).

## Test plan

- [ ] CI passes on this PR
- [ ] Verify that PRs targeting `release-5.12.1` correctly resolve dashboard image from tyk-analytics `release-5.12.1` branch

Generated with [Claude Code](https://claude.com/claude-code)