### PR TITLE
[TT-16977] fix: dashboard resolver credential fix (release-5.12)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -390,6 +390,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Check for relevant package changes in PR
         id: check_changes


### PR DESCRIPTION
## Summary

- Adds `persist-credentials: false` to the `actions/checkout` step in the `resolve-dashboard-image` job
- The checkout step sets an AUTHORIZATION header with the limited GITHUB_TOKEN which overrides ORG_GH_TOKEN credentials used by `git ls-remote` for cross-repo branch checking against tyk-analytics
- This causes the resolver to silently fail the branch existence check and fall back to master/gromit-default dashboard image

## Test plan

- [ ] Verify `resolve-dashboard-image` job correctly detects matching branches in tyk-analytics when they exist
- [ ] Verify the resolver falls back to gromit-default when no matching branch exists (expected behavior)
- [ ] Check workflow YAML is valid

Generated with [Claude Code](https://claude.com/claude-code)