### PR TITLE
perf: skip prod Docker steps on PRs, use larger runner

### DIFF
--- a/.github/workflows/jira-pr-validator.yaml
+++ b/.github/workflows/jira-pr-validator.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate Jira ticket
-        uses: TykTechnologies/jira-linter@main
+        uses: TykTechnologies/jira-linter@d4f84b2ca8520dbb52971fbdc8c82a91dbaf18d5
         with:
           jira-base-url: 'https://tyktech.atlassian.net'
           jira-api-token: ${{ secrets.JIRA_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,7 +163,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: linux/amd64,linux/arm64,linux/s390x
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/s390x' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           sbom: true
@@ -210,7 +210,7 @@ jobs:
             BUILD_PACKAGE_NAME=tyk-gateway-ee
       - name: Docker metadata for fips CI
         id: ci_metadata_fips
-        if: ${{ matrix.golang_cross == '1.25-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.25-bullseye' && github.event_name != 'pull_request' }}
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
@@ -225,7 +225,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},prefix=v
             type=semver,pattern={{version}},prefix=v
       - name: push fips image to CI
-        if: ${{ matrix.golang_cross == '1.25-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.25-bullseye' && github.event_name != 'pull_request' }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -289,7 +289,7 @@ jobs:
           fi
       - name: Docker metadata for std CI
         id: ci_metadata_std
-        if: ${{ matrix.golang_cross == '1.25-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.25-bullseye' && github.event_name != 'pull_request' }}
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
@@ -304,7 +304,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},prefix=v
             type=semver,pattern={{version}},prefix=v
       - name: push std image to CI
-        if: ${{ matrix.golang_cross == '1.25-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.25-bullseye' && github.event_name != 'pull_request' }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       (needs.dep-guard.result == 'success' || needs.dep-guard.result == 'skipped') &&
       github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
-    runs-on: ${{ vars.DEFAULT_RUNNER }}
+    runs-on: ${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
     permissions:
       id-token: write # AWS OIDC JWT
       contents: read # actions/checkout
@@ -176,6 +176,7 @@ jobs:
             BUILD_PACKAGE_NAME=tyk-gateway-ee
       - name: Docker metadata for ee tag push
         id: tag_metadata_ee
+        if: startsWith(github.ref, 'refs/tags')
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
@@ -193,7 +194,7 @@ jobs:
             org.opencontainers.image.vendor=tyk.io
             org.opencontainers.image.version=${{ github.ref_name }}
       - name: push ee image to prod
-        if: ${{ matrix.golang_cross == '1.25-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.25-bullseye' && startsWith(github.ref, 'refs/tags') }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -202,8 +203,7 @@ jobs:
           provenance: mode=max
           sbom: true
           cache-from: type=gha
-          cache-to: type=gha,mode=max
-          push: ${{ startsWith(github.ref, 'refs/tags') }}
+          push: true
           tags: ${{ steps.tag_metadata_ee.outputs.tags }}
           labels: ${{ steps.tag_metadata_ee.outputs.labels }}
           build-args: |
@@ -243,6 +243,7 @@ jobs:
             BASE_IMAGE=tykio/dhi-busybox:1.37-fips
       - name: Docker metadata for fips tag push
         id: tag_metadata_fips
+        if: startsWith(github.ref, 'refs/tags')
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
@@ -259,7 +260,7 @@ jobs:
             org.opencontainers.image.vendor=tyk.io
             org.opencontainers.image.version=${{ github.ref_name }}
       - name: push fips image to prod
-        if: ${{ matrix.golang_cross == '1.25-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.25-bullseye' && startsWith(github.ref, 'refs/tags') }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -268,8 +269,7 @@ jobs:
           provenance: mode=max
           sbom: true
           cache-from: type=gha
-          cache-to: type=gha,mode=max
-          push: ${{ startsWith(github.ref, 'refs/tags') }}
+          push: true
           tags: ${{ steps.tag_metadata_fips.outputs.tags }}
           labels: ${{ steps.tag_metadata_fips.outputs.labels }}
           build-args: |
@@ -321,6 +321,7 @@ jobs:
             BUILD_PACKAGE_NAME=tyk-gateway
       - name: Docker metadata for std tag push
         id: tag_metadata_std
+        if: startsWith(github.ref, 'refs/tags')
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
@@ -338,7 +339,7 @@ jobs:
             org.opencontainers.image.vendor=tyk.io
             org.opencontainers.image.version=${{ github.ref_name }}
       - name: push std image to prod
-        if: ${{ matrix.golang_cross == '1.25-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.25-bullseye' && startsWith(github.ref, 'refs/tags') }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -347,8 +348,7 @@ jobs:
           provenance: mode=max
           sbom: true
           cache-from: type=gha
-          cache-to: type=gha,mode=max
-          push: ${{ startsWith(github.ref, 'refs/tags') }}
+          push: true
           tags: ${{ steps.tag_metadata_std.outputs.tags }}
           labels: ${{ steps.tag_metadata_std.outputs.labels }}
           build-args: |

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync/atomic"
 	texttemplate "text/template"
@@ -23,6 +24,7 @@ import (
 	"github.com/TykTechnologies/tyk/internal/httpctx"
 	"github.com/TykTechnologies/tyk/internal/httputil"
 	"github.com/TykTechnologies/tyk/internal/mcp"
+	"github.com/TykTechnologies/tyk/internal/oasutil"
 
 	"github.com/getkin/kin-openapi/routers/gorillamux"
 
@@ -1372,7 +1374,6 @@ func (a APIDefinitionLoader) compileOASValidateRequestPathSpec(apiSpec *APISpec,
 			continue
 		}
 
-		// Find the path and method for this operation
 		path, method := a.findPathAndMethodForOperation(apiSpec, operationID)
 		if path == "" || method == "" {
 			continue
@@ -1384,13 +1385,19 @@ func (a APIDefinitionLoader) compileOASValidateRequestPathSpec(apiSpec *APISpec,
 			OASPath:                path,
 		}
 
-		// The path in OAS is relative to the server URL (listenPath)
-		// For regex matching, we don't prepend listenPath because URLSpec.matchesPath
-		// will strip the listenPath before matching
-		// Use standard regex generation with gateway config
 		a.generateRegex(path, &newSpec, OASValidateRequest, conf)
 		urlSpec = append(urlSpec, newSpec)
 	}
+
+	urlSpec = a.addStaticPathShields(apiSpec, conf, urlSpec, OASValidateRequest, func(path, method string) URLSpec {
+		return URLSpec{
+			OASValidateRequestMeta: &oas.ValidateRequest{Enabled: false},
+			OASMethod:              method,
+			OASPath:                path,
+		}
+	})
+
+	sortURLSpecsByPathPriority(urlSpec)
 
 	return urlSpec
 }
@@ -1417,7 +1424,6 @@ func (a APIDefinitionLoader) compileOASMockResponsePathSpec(apiSpec *APISpec, co
 			continue
 		}
 
-		// Find the path and method for this operation
 		path, method := a.findPathAndMethodForOperation(apiSpec, operationID)
 		if path == "" || method == "" {
 			continue
@@ -1429,12 +1435,76 @@ func (a APIDefinitionLoader) compileOASMockResponsePathSpec(apiSpec *APISpec, co
 			OASPath:             path,
 		}
 
-		// Use standard regex generation with gateway config
 		a.generateRegex(path, &newSpec, OASMockResponse, conf)
 		urlSpec = append(urlSpec, newSpec)
 	}
 
+	urlSpec = a.addStaticPathShields(apiSpec, conf, urlSpec, OASMockResponse, func(path, method string) URLSpec {
+		return URLSpec{
+			OASMockResponseMeta: &oas.MockResponse{Enabled: false},
+			OASMethod:           method,
+			OASPath:             path,
+		}
+	})
+
+	sortURLSpecsByPathPriority(urlSpec)
+
 	return urlSpec
+}
+
+// addStaticPathShields adds synthetic disabled URLSpec entries for static OAS paths
+// that don't already have an entry in urlSpec. These entries act as shields: when the
+// middleware scans the path list, a static shield entry matches before any parameterised
+// regex, and the middleware sees Enabled=false and skips it. This prevents parameterised
+// paths (e.g. /employees/{id}) from incorrectly matching static paths (e.g. /employees/static).
+//
+// Shield entries are only added when urlSpec contains at least one parameterised path,
+// since without parameterised paths there is no cross-matching risk.
+func (a APIDefinitionLoader) addStaticPathShields(
+	apiSpec *APISpec,
+	conf config.Config,
+	urlSpec []URLSpec,
+	status URLStatus,
+	newDisabledSpec func(path, method string) URLSpec,
+) []URLSpec {
+	if apiSpec.OAS.Paths == nil {
+		return urlSpec
+	}
+
+	existing, hasParameterised := indexURLSpecs(urlSpec)
+	if !hasParameterised {
+		return urlSpec
+	}
+
+	for path, pathItem := range apiSpec.OAS.Paths.Map() {
+		if httputil.IsMuxTemplate(path) {
+			continue
+		}
+		for method := range pathItem.Operations() {
+			method = strings.ToUpper(method)
+			if _, exists := existing[path+":"+method]; exists {
+				continue
+			}
+			newSpec := newDisabledSpec(path, method)
+			a.generateRegex(path, &newSpec, status, conf)
+			urlSpec = append(urlSpec, newSpec)
+		}
+	}
+
+	return urlSpec
+}
+
+// indexURLSpecs builds a set of "path:METHOD" keys from the given specs and reports
+// whether any spec uses a parameterised (mux-template) path.
+func indexURLSpecs(specs []URLSpec) (existing map[string]struct{}, hasParameterised bool) {
+	existing = make(map[string]struct{}, len(specs))
+	for _, spec := range specs {
+		existing[spec.OASPath+":"+spec.OASMethod] = struct{}{}
+		if httputil.IsMuxTemplate(spec.OASPath) {
+			hasParameterised = true
+		}
+	}
+	return
 }
 
 // findPathAndMethodForOperation finds the path and method for a given operation ID
@@ -1453,6 +1523,14 @@ func (a APIDefinitionLoader) findPathAndMethodForOperation(apiSpec *APISpec, ope
 	}
 
 	return "", ""
+}
+
+// sortURLSpecsByPathPriority sorts URLSpec entries using the same path priority
+// rules as oasutil.SortByPathLength, ensuring consistent ordering across the gateway.
+func sortURLSpecsByPathPriority(specs []URLSpec) {
+	sort.Slice(specs, func(i, j int) bool {
+		return oasutil.PathLess(specs[i].OASPath, specs[j].OASPath)
+	})
 }
 
 // extractMCPPrimitivesToPaths extracts MCP primitives (tools, resources, prompts) from the OAS

--- a/gateway/mw_oas_validate_request_benchmark_test.go
+++ b/gateway/mw_oas_validate_request_benchmark_test.go
@@ -1,0 +1,154 @@
+package gateway
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/apidef/oas"
+)
+
+// BenchmarkSortURLSpecsByPathPriority measures the overhead of sorting URLSpec entries.
+func BenchmarkSortURLSpecsByPathPriority(b *testing.B) {
+	for _, n := range []int{10, 50, 200} {
+		b.Run(fmt.Sprintf("paths=%d", n), func(b *testing.B) {
+			// Build a mix of static and parameterised paths
+			template := make([]URLSpec, n)
+			for i := 0; i < n; i++ {
+				if i%3 == 0 {
+					template[i] = URLSpec{OASPath: fmt.Sprintf("/api/v1/resource%d/{id}", i)}
+				} else {
+					template[i] = URLSpec{OASPath: fmt.Sprintf("/api/v1/resource%d/static", i)}
+				}
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				specs := make([]URLSpec, n)
+				copy(specs, template)
+				sortURLSpecsByPathPriority(specs)
+			}
+		})
+	}
+}
+
+// BenchmarkOASValidateRequestStaticVsParameterized measures request-time performance
+// for static and parameterised paths with the shield mechanism.
+func BenchmarkOASValidateRequestStaticVsParameterized(b *testing.B) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	// Parameterised path with validation
+	paths.Set("/users/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getUserById",
+			Parameters: openapi3.Parameters{
+				&openapi3.ParameterRef{
+					Value: &openapi3.Parameter{
+						Name:     "id",
+						In:       "path",
+						Required: true,
+						Schema: &openapi3.SchemaRef{
+							Value: &openapi3.Schema{
+								Type: &openapi3.Types{"integer"},
+							},
+						},
+					},
+				},
+			},
+			Responses: openapi3.NewResponses(
+				openapi3.WithStatus(200, &openapi3.ResponseRef{
+					Value: &openapi3.Response{
+						Description: stringPtrHelper("Success"),
+					},
+				}),
+			),
+		},
+	})
+
+	// Static path without validation
+	paths.Set("/users/admin", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getAdminUser",
+			Responses: openapi3.NewResponses(
+				openapi3.WithStatus(200, &openapi3.ResponseRef{
+					Value: &openapi3.Response{
+						Description: stringPtrHelper("Success"),
+					},
+				}),
+			),
+		},
+	})
+
+	// Add extra static paths to test scaling
+	for i := 0; i < 50; i++ {
+		opID := fmt.Sprintf("getResource%d", i)
+		paths.Set(fmt.Sprintf("/resources/item%d", i), &openapi3.PathItem{
+			Get: &openapi3.Operation{
+				OperationID: opID,
+				Responses: openapi3.NewResponses(
+					openapi3.WithStatus(200, &openapi3.ResponseRef{
+						Value: &openapi3.Response{
+							Description: stringPtrHelper("Success"),
+						},
+					}),
+				),
+			},
+		})
+	}
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Benchmark API", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getUserById": {
+					ValidateRequest: &oas.ValidateRequest{Enabled: true},
+				},
+			},
+		},
+	})
+
+	api := ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Benchmark API"
+		spec.APIID = "benchmark-api"
+		spec.Proxy.ListenPath = "/api/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})[0]
+
+	require.NotNil(b, api)
+
+	b.Run("StaticPath_ShieldHit", func(b *testing.B) {
+		req := httptest.NewRequest(http.MethodGet, "/api/users/admin", nil)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			rec := httptest.NewRecorder()
+			ts.TestServerRouter.ServeHTTP(rec, req)
+		}
+	})
+
+	b.Run("ParameterizedPath_ValidationHit", func(b *testing.B) {
+		req := httptest.NewRequest(http.MethodGet, "/api/users/123", nil)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			rec := httptest.NewRecorder()
+			ts.TestServerRouter.ServeHTTP(rec, req)
+		}
+	})
+}

--- a/gateway/mw_oas_validate_request_path_priority_test.go
+++ b/gateway/mw_oas_validate_request_path_priority_test.go
@@ -1,0 +1,383 @@
+package gateway
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/test"
+)
+
+func TestSortURLSpecsByPathPriority(t *testing.T) {
+	tests := []struct {
+		name     string
+		paths    []string
+		expected []string
+	}{
+		{
+			name:     "static path before parameterised",
+			paths:    []string{"/employees/{id}", "/employees/static"},
+			expected: []string{"/employees/static", "/employees/{id}"},
+		},
+		{
+			name:     "more segments first",
+			paths:    []string{"/a/b", "/a/b/c"},
+			expected: []string{"/a/b/c", "/a/b"},
+		},
+		{
+			name:     "longer path first",
+			paths:    []string{"/api/user", "/api/user-access"},
+			expected: []string{"/api/user-access", "/api/user"},
+		},
+		{
+			name:     "alphabetical for equal length",
+			paths:    []string{"/api/abc", "/api/aba"},
+			expected: []string{"/api/aba", "/api/abc"},
+		},
+		{
+			name: "multiple mixed paths",
+			paths: []string{
+				"/users/{id}",
+				"/users/me",
+				"/users/{id}/reports",
+				"/departments/{deptId}",
+			},
+			expected: []string{
+				"/users/{id}/reports",
+				"/departments/{deptId}",
+				"/users/me",
+				"/users/{id}",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			specs := make([]URLSpec, len(tc.paths))
+			for i, p := range tc.paths {
+				specs[i] = URLSpec{OASPath: p}
+			}
+
+			sortURLSpecsByPathPriority(specs)
+
+			got := make([]string, len(specs))
+			for i, s := range specs {
+				got[i] = s.OASPath
+			}
+
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestStaticPathTakesPrecedenceOverParameterised(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/static", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getStaticEmployee",
+			Responses: openapi3.NewResponses(
+				openapi3.WithStatus(200, &openapi3.ResponseRef{
+					Value: &openapi3.Response{
+						Description: stringPtrHelper("Success"),
+					},
+				}),
+			),
+		},
+	})
+
+	paths.Set("/employees/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getEmployeeById",
+			Parameters: openapi3.Parameters{
+				&openapi3.ParameterRef{
+					Value: &openapi3.Parameter{
+						Name:     "id",
+						In:       "path",
+						Required: true,
+						Schema: &openapi3.SchemaRef{
+							Value: &openapi3.Schema{
+								Type:    &openapi3.Types{"string"},
+								Pattern: "^[a-zA-Z]+$",
+							},
+						},
+					},
+				},
+			},
+			Responses: openapi3.NewResponses(
+				openapi3.WithStatus(200, &openapi3.ResponseRef{
+					Value: &openapi3.Response{
+						Description: stringPtrHelper("Success"),
+					},
+				}),
+			),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Validate Request Priority Test", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getStaticEmployee": {},
+				"getEmployeeById": {
+					ValidateRequest: &oas.ValidateRequest{Enabled: true},
+				},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Validate Request Priority API"
+		spec.APIID = "validate-request-priority"
+		spec.Proxy.ListenPath = "/api/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			Method: http.MethodGet,
+			Path:   "/api/employees/static",
+			Code:   http.StatusOK,
+		},
+		{
+			Method: http.MethodGet,
+			Path:   "/api/employees/john",
+			Code:   http.StatusOK,
+		},
+		{
+			Method: http.MethodGet,
+			Path:   "/api/employees/123",
+			Code:   http.StatusUnprocessableEntity,
+		},
+	}...)
+}
+
+func TestMockResponseStaticPathPriority(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/items/special", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getSpecialItem",
+			Responses: openapi3.NewResponses(
+				openapi3.WithStatus(200, &openapi3.ResponseRef{
+					Value: &openapi3.Response{
+						Description: stringPtrHelper("Success"),
+					},
+				}),
+			),
+		},
+	})
+
+	paths.Set("/items/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getItemById",
+			Parameters: openapi3.Parameters{
+				&openapi3.ParameterRef{
+					Value: &openapi3.Parameter{
+						Name:     "id",
+						In:       "path",
+						Required: true,
+						Schema: &openapi3.SchemaRef{
+							Value: &openapi3.Schema{
+								Type: &openapi3.Types{"string"},
+							},
+						},
+					},
+				},
+			},
+			Responses: openapi3.NewResponses(
+				openapi3.WithStatus(200, &openapi3.ResponseRef{
+					Value: &openapi3.Response{
+						Description: stringPtrHelper("Success"),
+					},
+				}),
+			),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Mock Response Priority Test", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getSpecialItem": {},
+				"getItemById": {
+					MockResponse: &oas.MockResponse{Enabled: true, Code: 200, Body: "mocked"},
+				},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Mock Response Priority API"
+		spec.APIID = "mock-response-priority"
+		spec.Proxy.ListenPath = "/api/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			// Static path should NOT get mock response — the mock is only on {id}
+			Method:       http.MethodGet,
+			Path:         "/api/items/special",
+			BodyNotMatch: "mocked",
+		},
+		{
+			// Parameterised path should get mock response
+			Method:    http.MethodGet,
+			Path:      "/api/items/123",
+			Code:      http.StatusOK,
+			BodyMatch: "mocked",
+		},
+	}...)
+}
+
+func TestStaticPathPriorityWithPrefixMatching(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	// Enable prefix matching at gateway level
+	conf := ts.Gw.GetConfig()
+	conf.HttpServerOptions.EnablePathPrefixMatching = true
+	ts.Gw.SetConfig(conf)
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/static", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getStaticEmployee",
+			Parameters: openapi3.Parameters{
+				&openapi3.ParameterRef{
+					Value: &openapi3.Parameter{
+						Name:     "X-Custom-Header",
+						In:       "header",
+						Required: true,
+						Schema: &openapi3.SchemaRef{
+							Value: &openapi3.Schema{
+								Type: &openapi3.Types{"string"},
+							},
+						},
+					},
+				},
+			},
+			Responses: openapi3.NewResponses(
+				openapi3.WithStatus(200, &openapi3.ResponseRef{
+					Value: &openapi3.Response{
+						Description: stringPtrHelper("Success"),
+					},
+				}),
+			),
+		},
+	})
+
+	paths.Set("/employees/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getEmployeeById",
+			Parameters: openapi3.Parameters{
+				&openapi3.ParameterRef{
+					Value: &openapi3.Parameter{
+						Name:     "id",
+						In:       "path",
+						Required: true,
+						Schema: &openapi3.SchemaRef{
+							Value: &openapi3.Schema{
+								Type:    &openapi3.Types{"string"},
+								Pattern: "^[a-zA-Z]+$",
+							},
+						},
+					},
+				},
+			},
+			Responses: openapi3.NewResponses(
+				openapi3.WithStatus(200, &openapi3.ResponseRef{
+					Value: &openapi3.Response{
+						Description: stringPtrHelper("Success"),
+					},
+				}),
+			),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Prefix Matching Priority Test", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getStaticEmployee": {
+					ValidateRequest: &oas.ValidateRequest{Enabled: true},
+				},
+				"getEmployeeById": {
+					ValidateRequest: &oas.ValidateRequest{Enabled: true},
+				},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Prefix Matching Priority API"
+		spec.APIID = "prefix-matching-priority"
+		spec.Proxy.ListenPath = "/api/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			// Static path without required header should fail its OWN validation,
+			// proving it matched /employees/static and not /employees/{id}
+			Method:    http.MethodGet,
+			Path:      "/api/employees/static",
+			Code:      http.StatusUnprocessableEntity,
+			BodyMatch: "X-Custom-Header",
+		},
+		{
+			// Static path with required header should pass validation
+			Method:  http.MethodGet,
+			Path:    "/api/employees/static",
+			Code:    http.StatusOK,
+			Headers: map[string]string{"X-Custom-Header": "value"},
+		},
+		{
+			// Parameterised path with valid id should pass
+			Method: http.MethodGet,
+			Path:   "/api/employees/john",
+			Code:   http.StatusOK,
+		},
+		{
+			// Parameterised path with invalid id should fail
+			Method: http.MethodGet,
+			Path:   "/api/employees/123",
+			Code:   http.StatusUnprocessableEntity,
+		},
+	}...)
+}

--- a/gateway/rpc_storage_handler_test.go
+++ b/gateway/rpc_storage_handler_test.go
@@ -2,16 +2,20 @@ package gateway
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/lonelycode/osin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/TykTechnologies/gorpc"
@@ -20,6 +24,7 @@ import (
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/header"
 	"github.com/TykTechnologies/tyk/internal/model"
+	"github.com/TykTechnologies/tyk/regexp"
 	"github.com/TykTechnologies/tyk/rpc"
 	"github.com/TykTechnologies/tyk/storage"
 	"github.com/TykTechnologies/tyk/test"
@@ -60,6 +65,88 @@ func getAccessToken(td tokenData) string {
 
 func getRefreshToken(td tokenData) string {
 	return td.RefreshToken
+}
+
+type dispatcherOption func() (string, any)
+
+func withFunc(name string, f any) dispatcherOption {
+	return func() (string, any) {
+		return name, f
+	}
+}
+
+// newDispatcher creates a minimal RPC dispatcher with required handlers for gateway startup.
+// It establishes a set of default handlers that can be overridden by providing
+// dispatcherOptions. This ensures the gateway can start cleanly for tests without
+// causing delays or failures from RPC retries if emergency mode is initially disabled.
+func newDispatcher(opts ...dispatcherOption) *gorpc.Dispatcher {
+	dispatcher := gorpc.NewDispatcher()
+
+	funcs := map[string]any{
+		"Login": func(_, _ string) bool {
+			return true
+		},
+		"Disconnect": func(_ string, _ *model.GroupLoginRequest) error {
+			return nil
+		},
+		"GetApiDefinitions": func(_ string, _ interface{}) (string, error) {
+			return "[]", nil
+		},
+		"GetPolicies": func(_ string, _ interface{}) (string, error) {
+			return "[]", nil
+		},
+	}
+
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+
+		name, f := opt()
+
+		if name == "" {
+			panic("dispatcher function name cannot be empty")
+		}
+		if f == nil {
+			panic("dispatcher function cannot be nil")
+		}
+
+		funcs[name] = f
+	}
+
+	for name, f := range funcs {
+		dispatcher.AddFunc(name, f)
+	}
+
+	return dispatcher
+}
+
+var nonAlphanumericRegex = regexp.MustCompile(`[^a-zA-Z0-9 ]+`)
+
+// generateUniqueTestTag creates a sanitized, unique tag from a test name to be used
+// for isolating tests that interact with Redis.
+func generateUniqueTestTag(testName string) (string, error) {
+	const defaultName = "test"
+
+	cleanName := strings.ToLower(testName)
+	cleanName = nonAlphanumericRegex.ReplaceAllString(cleanName, "")
+	cleanName = strings.ReplaceAll(cleanName, " ", "-")
+
+	if cleanName == "" {
+		cleanName = defaultName
+	}
+
+	cleanName = strings.Trim(cleanName, "-")
+	if cleanName == "" {
+		cleanName = defaultName
+	}
+
+	suffix := make([]byte, 8)
+	if _, err := rand.Read(suffix); err != nil {
+		return "", fmt.Errorf("failed to generate unique test tag: %w", err)
+	}
+
+	return fmt.Sprintf("%s-%s", cleanName, hex.EncodeToString(suffix)), nil
 }
 
 func TestProcessKeySpaceChangesForOauth(t *testing.T) {
@@ -756,22 +843,20 @@ func TestProcessKeySpaceChanges_UserKeyReset(t *testing.T) {
 	oldKey := "old-api-key"
 	newKey := "new-api-key"
 
-	dispatcher := gorpc.NewDispatcher()
-	dispatcher.AddFunc("Login", func(_, _ string) bool {
-		return true
-	})
-	dispatcher.AddFunc("Disconnect", func(_ string, _ *model.GroupLoginRequest) error {
-		return nil
-	})
-	dispatcher.AddFunc("GetKeySpaceUpdate", func(_, _ string) ([]string, error) {
-		return []string{}, nil
-	})
-	dispatcher.AddFunc("GetGroupKeySpaceUpdate", func(_ string, _ string) ([]string, error) {
-		return []string{}, nil
-	})
+	dispatcher := newDispatcher(
+		withFunc("GetKeySpaceUpdate", func(_, _ string) ([]string, error) {
+			return []string{}, nil
+		}),
+		withFunc("GetGroupKeySpaceUpdate", func(_, _ string) ([]string, error) {
+			return []string{}, nil
+		}),
+	)
 
 	rpcMock, connectionString := startRPCMock(dispatcher)
 	defer stopRPCMock(rpcMock)
+
+	uniqueTag, err := generateUniqueTestTag(t.Name())
+	require.NoError(t, err)
 
 	g := StartTest(func(globalConf *config.Config) {
 		globalConf.SlaveOptions.UseRPC = true
@@ -781,6 +866,7 @@ func TestProcessKeySpaceChanges_UserKeyReset(t *testing.T) {
 		globalConf.SlaveOptions.CallTimeout = 1
 		globalConf.SlaveOptions.RPCPoolSize = 2
 		globalConf.SlaveOptions.DisableKeySpaceSync = true
+		globalConf.DBAppConfOptions.Tags = []string{uniqueTag}
 	})
 	defer g.Close()
 
@@ -845,20 +931,18 @@ func TestGetApiDefinitions_Fails_With_Timeout(t *testing.T) {
 		close(wait)
 	}()
 
-	dispatcher := gorpc.NewDispatcher()
-	dispatcher.AddFunc("Login", func(_, _ string) bool {
-		return true
-	})
-	dispatcher.AddFunc("Disconnect", func(_ string, _ *model.GroupLoginRequest) error {
-		return nil
-	})
-	dispatcher.AddFunc("GetApiDefinitions", func(_ string, _ interface{}) (string, error) {
-		<-wait // wait until the defer method is called
-		return "sample-response", nil
-	})
+	dispatcher := newDispatcher(
+		withFunc("GetApiDefinitions", func(_ string, _ any) (string, error) {
+			<-wait // wait until the defer method is called
+			return "[]", nil
+		}),
+	)
 
 	rpcMock, connectionString := startRPCMock(dispatcher)
 	defer stopRPCMock(rpcMock)
+
+	uniqueTag, err := generateUniqueTestTag(t.Name())
+	require.NoError(t, err)
 
 	g := StartTest(func(globalConf *config.Config) {
 		globalConf.SlaveOptions.UseRPC = true
@@ -868,6 +952,7 @@ func TestGetApiDefinitions_Fails_With_Timeout(t *testing.T) {
 		globalConf.SlaveOptions.CallTimeout = 1
 		globalConf.SlaveOptions.RPCPoolSize = 2
 		globalConf.SlaveOptions.DisableKeySpaceSync = true
+		globalConf.DBAppConfOptions.Tags = []string{uniqueTag}
 	})
 	g.Gw.afterConfSetup() // sets SlaveOptions.CallTimeout to GlobalRPCCallTimeout
 
@@ -889,26 +974,24 @@ func TestGetApiDefinitions_Fails_With_Timeout(t *testing.T) {
 	// GetApiDefinitions calls rpc.FuncClientSingleton with a backoff algorithm.
 	// The algorithm tries to call the RPC method 3 times with a 10-millisecond interval.
 	// So the "GetApiDefinitions" method will be called 4 times, including the first try.
-	// It should return an empty string instead of "sample-response".
+	// It should return an empty string instead of "[]".
 	assert.Equal(t, "", rpcListener.GetApiDefinitions("test_org", nil))
 }
 
 func TestGetApiDefinitions(t *testing.T) {
-	var GetApiDefinitionsResponse = "sample-response"
+	var GetApiDefinitionsResponse = "[]"
 
-	dispatcher := gorpc.NewDispatcher()
-	dispatcher.AddFunc("Login", func(_, _ string) bool {
-		return true
-	})
-	dispatcher.AddFunc("Disconnect", func(_ string, _ *model.GroupLoginRequest) error {
-		return nil
-	})
-	dispatcher.AddFunc("GetApiDefinitions", func(_ string, _ interface{}) (string, error) {
-		return GetApiDefinitionsResponse, nil
-	})
+	dispatcher := newDispatcher(
+		withFunc("GetApiDefinitions", func(_ string, _ any) (string, error) {
+			return GetApiDefinitionsResponse, nil
+		}),
+	)
 
 	rpcMock, connectionString := startRPCMock(dispatcher)
 	defer stopRPCMock(rpcMock)
+
+	uniqueTag, err := generateUniqueTestTag(t.Name())
+	require.NoError(t, err)
 
 	g := StartTest(func(globalConf *config.Config) {
 		globalConf.SlaveOptions.UseRPC = true
@@ -918,6 +1001,7 @@ func TestGetApiDefinitions(t *testing.T) {
 		globalConf.SlaveOptions.CallTimeout = 1
 		globalConf.SlaveOptions.RPCPoolSize = 2
 		globalConf.SlaveOptions.DisableKeySpaceSync = true
+		globalConf.DBAppConfOptions.Tags = []string{uniqueTag}
 	})
 	g.Gw.afterConfSetup() // sets SlaveOptions.CallTimeout to GlobalRPCCallTimeout
 
@@ -940,21 +1024,19 @@ func TestGetApiDefinitions(t *testing.T) {
 }
 
 func TestGetPolicies(t *testing.T) {
-	var GetPoliciesResponse = "sample-response"
+	var GetPoliciesResponse = "[]"
 
-	dispatcher := gorpc.NewDispatcher()
-	dispatcher.AddFunc("Login", func(_, _ string) bool {
-		return true
-	})
-	dispatcher.AddFunc("Disconnect", func(_ string, _ *model.GroupLoginRequest) error {
-		return nil
-	})
-	dispatcher.AddFunc("GetPolicies", func(_ string, _ interface{}) (string, error) {
-		return GetPoliciesResponse, nil
-	})
+	dispatcher := newDispatcher(
+		withFunc("GetPolicies", func(_ string, _ any) (string, error) {
+			return GetPoliciesResponse, nil
+		}),
+	)
 
 	rpcMock, connectionString := startRPCMock(dispatcher)
 	defer stopRPCMock(rpcMock)
+
+	uniqueTag, err := generateUniqueTestTag(t.Name())
+	require.NoError(t, err)
 
 	g := StartTest(func(globalConf *config.Config) {
 		globalConf.SlaveOptions.UseRPC = true
@@ -964,6 +1046,7 @@ func TestGetPolicies(t *testing.T) {
 		globalConf.SlaveOptions.CallTimeout = 1
 		globalConf.SlaveOptions.RPCPoolSize = 2
 		globalConf.SlaveOptions.DisableKeySpaceSync = true
+		globalConf.DBAppConfOptions.Tags = []string{uniqueTag}
 	})
 	g.Gw.afterConfSetup() // sets SlaveOptions.CallTimeout to GlobalRPCCallTimeout
 
@@ -991,20 +1074,18 @@ func TestGetPolicies_Fails_With_Timeout(t *testing.T) {
 		close(wait)
 	}()
 
-	dispatcher := gorpc.NewDispatcher()
-	dispatcher.AddFunc("Login", func(_, _ string) bool {
-		return true
-	})
-	dispatcher.AddFunc("Disconnect", func(_ string, _ *model.GroupLoginRequest) error {
-		return nil
-	})
-	dispatcher.AddFunc("GetPolicies", func(_ string, _ interface{}) (string, error) {
-		<-wait // wait until the defer method is called
-		return "sample-response", nil
-	})
+	dispatcher := newDispatcher(
+		withFunc("GetPolicies", func(_ string, _ any) (string, error) {
+			<-wait // wait until the defer method is called
+			return "[]", nil
+		}),
+	)
 
 	rpcMock, connectionString := startRPCMock(dispatcher)
 	defer stopRPCMock(rpcMock)
+
+	uniqueTag, err := generateUniqueTestTag(t.Name())
+	require.NoError(t, err)
 
 	g := StartTest(func(globalConf *config.Config) {
 		globalConf.SlaveOptions.UseRPC = true
@@ -1014,6 +1095,7 @@ func TestGetPolicies_Fails_With_Timeout(t *testing.T) {
 		globalConf.SlaveOptions.CallTimeout = 1
 		globalConf.SlaveOptions.RPCPoolSize = 2
 		globalConf.SlaveOptions.DisableKeySpaceSync = true
+		globalConf.DBAppConfOptions.Tags = []string{uniqueTag}
 	})
 	g.Gw.afterConfSetup() // sets SlaveOptions.CallTimeout to GlobalRPCCallTimeout
 
@@ -1035,7 +1117,7 @@ func TestGetPolicies_Fails_With_Timeout(t *testing.T) {
 	// GetPolicies calls rpc.FuncClientSingleton with a backoff algorithm.
 	// The algorithm tries to call the RPC method 3 times with a 10-millisecond interval.
 	// So the "GetPolicies" method will be called 4 times, including the first try.
-	// It should return an empty string instead of "sample-response".
+	// It should return an empty string instead of "[]".
 	assert.Equal(t, "", rpcListener.GetPolicies("test_org"))
 }
 

--- a/internal/oasutil/paths.go
+++ b/internal/oasutil/paths.go
@@ -17,7 +17,8 @@ type PathItem struct {
 	Path string
 }
 
-var pathParamRegex = regexp.MustCompile(`\{[^}]+\}`)
+// PathParamRegex matches path parameters like {id} or {employeeId} in OAS paths.
+var PathParamRegex = regexp.MustCompile(`\{[^}]+\}`)
 
 // ExtractPaths will extract paths with the given order.
 func ExtractPaths(in openapi3.Paths, order []string) []PathItem {
@@ -35,6 +36,37 @@ func ExtractPaths(in openapi3.Paths, order []string) []PathItem {
 	return result
 }
 
+// PathLess reports whether pathA should sort before pathB using the
+// standard Tyk path priority rules:
+//   - Strip path parameters {…} before comparing
+//   - If two paths are equal after stripping, the non-parameterised one goes first
+//   - Sort by number of "/" segments (more segments first)
+//   - Sort by string length (longer first)
+//   - Alphabetical for equal length
+func PathLess(pathA, pathB string) bool {
+	a := PathParamRegex.ReplaceAllString(pathA, "")
+	b := PathParamRegex.ReplaceAllString(pathB, "")
+
+	// handle /sub and /sub{id} order with raw path.
+	if a == b {
+		// we're reversing paths here so path with
+		// parameter is sorted after the literal.
+		a, b = pathB, pathA
+	}
+
+	// sort by number of path fragments
+	ka, kb := strings.Count(a, "/"), strings.Count(b, "/")
+	if ka != kb {
+		return ka > kb
+	}
+
+	la, lb := len(a), len(b)
+	if la == lb {
+		return a < b
+	}
+	return la > lb
+}
+
 // SortByPathLength decomposes an openapi3.Paths to a sorted []PathItem.
 // The sorting takes the length of the paths into account, as well as
 // path parameters, sorting them by length descending, and ordering
@@ -49,29 +81,8 @@ func SortByPathLength(in openapi3.Paths) []PathItem {
 		paths = append(paths, k)
 	}
 
-	// sort by length and lexicographically
 	sort.Slice(paths, func(i, j int) bool {
-		pathI := pathParamRegex.ReplaceAllString(paths[i], "")
-		pathJ := pathParamRegex.ReplaceAllString(paths[j], "")
-
-		// handle /sub and /sub{id} order with raw path.
-		if pathI == pathJ {
-			// we're reversing indexes here so path with
-			// parameter is sorted after the literal.
-			pathI, pathJ = paths[j], paths[i]
-		}
-
-		// sort by number of path fragments
-		k, v := strings.Count(pathI, "/"), strings.Count(pathJ, "/")
-		if k != v {
-			return k > v
-		}
-
-		il, jl := len(pathI), len(pathJ)
-		if il == jl {
-			return pathI < pathJ
-		}
-		return il > jl
+		return PathLess(paths[i], paths[j])
 	})
 
 	return ExtractPaths(in, paths)


### PR DESCRIPTION
## Summary
Built on top of #8029 to test goreleaser performance optimizations before rolling them out via gromit.

### Commit 1: skip prod Docker steps, larger runner
- **Larger runner**: `vars.BUILD_RUNNER || vars.DEFAULT_RUNNER` — set `BUILD_RUNNER=warp-8x-x64` in repo variables to use 8 vCPUs for goreleaser (currently 4)
- **Skip prod Docker steps on PRs**: tag metadata, prod build-push, and cache export for all 3 variants (ee, fips, std) are now completely skipped on non-tag builds
- **Remove redundant `cache-to`**: prod steps no longer export GHA cache (CI steps already do)

### Commit 2: skip fips/std CI Docker pushes on PRs, amd64-only for ee
- **Skip fips and std Docker metadata + CI push steps on PRs** since no downstream PR gate job consumes those ECR images
- **Build ee Docker image as amd64-only on PRs** since downstream tests only run on amd64
- Full multi-arch builds still run on branch pushes and tag pushes

## Expected savings
| Change | Estimated savings |
|---|---|
| Skip 3 prod Docker steps (build + SBOM + provenance + cache export) | ~9 min |
| Remove 3 redundant cache exports | ~4-8 min |
| Skip fips + std CI Docker pushes on PRs | ~6-10 min |
| amd64-only ee CI image on PRs (skip arm64 + s390x) | ~4-6 min |
| Larger runner (if BUILD_RUNNER set) | ~10-15 min |

CI/ECR ee image still builds on every PR (amd64-only) — fips and std CI images are skipped on PRs entirely. All images build fully on branch pushes and tag pushes.

## Test plan
- [ ] Verify goreleaser job completes successfully on this PR
- [ ] Compare goreleaser duration vs #8029 (expect ~15-20 min shorter)
- [ ] Verify CI/ECR ee image is still pushed (check downstream test jobs)
- [ ] Verify fips/std CI images are NOT pushed on PR (expected, no downstream consumers)
- [ ] Verify prod steps and full multi-arch builds still run on tags (conditional logic)

Gromit template PR: https://github.com/TykTechnologies/gromit/pull/453

🤖 Generated with [Claude Code](https://claude.com/claude-code)