### PR TITLE
fix: backport tslib dependency for portman contract tests

### DIFF
--- a/ci/tests/specs/package.json
+++ b/ci/tests/specs/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@apideck/portman": "1.30.7"
+    "@apideck/portman": "1.30.7",
+    "tslib": "^2.6.2"
   }
 }


### PR DESCRIPTION
## Summary

- Backport of #7995 — adds `tslib` as an explicit dependency in `ci/tests/specs/package.json`
- `@apideck/portman` requires `tslib` at runtime but doesn't declare it as a direct dependency, causing portman contract tests to fail
- Adds `"tslib": "^2.6.2"` to the dependencies section

## Test plan

- [ ] Verify portman contract tests pass in CI on the `release-5.12.1` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)