### PR TITLE
[TT-16950] fix: sync security hardening from release-5.12 (#7956)

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -12,6 +12,7 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+      - labeled
   push:
     branches:
       - master
@@ -27,12 +28,19 @@ env:
   BRANCH_NAME: ${{ github.base_ref || github.ref_name }} # base_ref for PRs is 'master', but merges read in ref_name
 
 jobs:
+  dep-guard:
+    if: ${{ github.event_name == 'pull_request' }}
+    uses: TykTechnologies/github-actions/.github/workflows/dependency-guard.yml@2b35ab5dd4cfff21ced9d12446e9e27d10bf5785  # main
+    permissions:
+      contents: read
+
   lint:
+    needs: [dep-guard]
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft }}
     steps:
       - name: "Checkout PR"
-        uses: TykTechnologies/github-actions/.github/actions/checkout-pr@main
+        uses: TykTechnologies/github-actions/.github/actions/checkout-pr@2b35ab5dd4cfff21ced9d12446e9e27d10bf5785  # main
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
 
@@ -42,15 +50,15 @@ jobs:
           git rev-parse origin/${{ env.BRANCH_NAME }}
 
       - name: Setup Golang
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
 
       - name: Setup CI Tooling
-        uses: shrink/actions-docker-extract@v3
+        uses: shrink/actions-docker-extract@04c17c51a5b9fd93b7aed2e05e86c8fe2d90ee52  # v3
         with:
-          image: tykio/ci-tools:latest
+          image: tykio/ci-tools@sha256:1796c0938247f42c580c501f7cd04e1144a59a62c6d8ba743572ff40371e1306  # latest
           path: /usr/local/bin/.
           destination: /usr/local/bin
 
@@ -64,7 +72,7 @@ jobs:
           task --exit-code lint:check-git-state MESSAGE="task tidy made git state dirty, please run task lint locally and update PR"
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9  # v8
         timeout-minutes: 20
         with:
           version: v2.5.0
@@ -75,7 +83,7 @@ jobs:
           skip-cache: false
           skip-save-cache: false
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         if: ${{ always() }}
         with:
           name: golangcilint
@@ -102,7 +110,7 @@ jobs:
 
     steps:
       - name: Checkout Tyk
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: ${{ github.ref }}
 
@@ -114,7 +122,7 @@ jobs:
       # Regardless that the base image provides a python release, we need
       # setup-python so it properly configures the python3-venv.
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -125,14 +133,14 @@ jobs:
         run: pip -V && pip3 -V
 
       - name: Setup CI Tooling
-        uses: shrink/actions-docker-extract@v3
+        uses: shrink/actions-docker-extract@04c17c51a5b9fd93b7aed2e05e86c8fe2d90ee52  # v3
         with:
-          image: tykio/ci-tools:latest
+          image: tykio/ci-tools@sha256:1796c0938247f42c580c501f7cd04e1144a59a62c6d8ba743572ff40371e1306  # latest
           path: /usr/local/bin/.
           destination: /usr/local/bin
 
       - name: Setup Golang
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
@@ -142,10 +150,10 @@ jobs:
         run: |
           sudo apt-get install libluajit-5.1-dev
 
-          python -m pip install --upgrade pip
-          pip install setuptools
-          pip install google
-          pip install 'protobuf==4.24.4'
+          python -m pip install --no-deps --upgrade pip
+          pip install --no-deps setuptools
+          pip install --no-deps google
+          pip install --no-deps 'protobuf==4.24.4'
 
       - name: Bring up test services
         run: task services:up
@@ -160,14 +168,14 @@ jobs:
           task test:e2e-combined args="-race -timeout=15m"
           task test:coverage
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         if: ${{ always() }}
         with:
           name: coverage
           retention-days: 1
           path: coverage/gateway-all.cov
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         if: ${{ always() }}
         with:
           name: testjson
@@ -180,23 +188,23 @@ jobs:
     needs: [test, lint]
     steps:
       - name: "Checkout repository"
-        uses: TykTechnologies/github-actions/.github/actions/checkout-pr@main
+        uses: TykTechnologies/github-actions/.github/actions/checkout-pr@2b35ab5dd4cfff21ced9d12446e9e27d10bf5785  # main
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
 
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: coverage
 
       - name: Download golangcilint artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: golangcilint
 
       - name: Check reports existence
         id: check_files
-        uses: andstor/file-existence-action@v3
+        uses: andstor/file-existence-action@076e0072799f4942c8bc574a82233e1e4d13e9d6  # v3
         with:
           files: 'gateway-all.cov, golangci-lint-report.json'
           fail: true
@@ -230,7 +238,7 @@ jobs:
 
       - name: Scan
         if: always()
-        uses: sonarsource/sonarqube-scan-action@master
+        uses: sonarsource/sonarqube-scan-action@3988e54db2467c7e9583a4af619c3f5647d6b8ad  # master
         with:
           args: ${{ steps.sonar_params.outputs.sonar_args }}
         env:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,6 +8,12 @@ name: "CodeQL"
 on:
   pull_request:
     branches: [master]
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - labeled
   schedule:
     - cron: '0 18 * * 4'
 
@@ -16,7 +22,14 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  dep-guard:
+    if: ${{ github.event_name == 'pull_request' }}
+    uses: TykTechnologies/github-actions/.github/workflows/dependency-guard.yml@2b35ab5dd4cfff21ced9d12446e9e27d10bf5785  # main
+    permissions:
+      contents: read
+
   analyze:
+    needs: [dep-guard]
     name: Analyze
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
@@ -32,7 +45,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
@@ -44,13 +57,13 @@ jobs:
       if: ${{ github.event_name == 'pull_request' }}
 
     - name: Install Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
       with:
         go-version-file: go.mod
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@b8d3b6e8af63cde30bdc382c0bc28114f4346c88  # v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -61,7 +74,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@b8d3b6e8af63cde30bdc382c0bc28114f4346c88  # v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -75,4 +88,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@b8d3b6e8af63cde30bdc382c0bc28114f4346c88  # v2

--- a/.github/workflows/force-merge.yaml
+++ b/.github/workflows/force-merge.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   call_force_merge:
-    uses: TykTechnologies/github-actions/.github/workflows/force-merge.yaml@main
+    uses: TykTechnologies/github-actions/.github/workflows/force-merge.yaml@2b35ab5dd4cfff21ced9d12446e9e27d10bf5785  # main
     secrets:
       ADMIN_PAT: ${{ secrets.ORG_GH_TOKEN }}
       SLACK_WEBHOOK_URL: ${{ secrets.FORCE_MERGE_SLACK_WEBHOOK }}

--- a/.github/workflows/intelligent-branch-recomendations.yml
+++ b/.github/workflows/intelligent-branch-recomendations.yml
@@ -12,7 +12,14 @@ permissions:
   contents: read
 
 jobs:
+  dep-guard:
+    if: ${{ github.event_name == 'pull_request' }}
+    uses: TykTechnologies/github-actions/.github/workflows/dependency-guard.yml@2b35ab5dd4cfff21ced9d12446e9e27d10bf5785  # main
+    permissions:
+      contents: read
+
   branch-suggestions:
-    uses: TykTechnologies/github-actions/.github/workflows/branch-suggestion.yml@main
+    needs: [dep-guard]
+    uses: TykTechnologies/github-actions/.github/workflows/branch-suggestion.yml@2b35ab5dd4cfff21ced9d12446e9e27d10bf5785  # main
     secrets:
       JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}

--- a/.github/workflows/jira-pr-validator.yaml
+++ b/.github/workflows/jira-pr-validator.yaml
@@ -9,12 +9,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  dep-guard:
+    if: ${{ github.event_name == 'pull_request' }}
+    uses: TykTechnologies/github-actions/.github/workflows/dependency-guard.yml@2b35ab5dd4cfff21ced9d12446e9e27d10bf5785  # main
+    permissions:
+      contents: read
+
   validate:
+    needs: [dep-guard]
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     steps:
       - name: Validate Jira ticket
-        uses: TykTechnologies/jira-linter@main
+        uses: TykTechnologies/jira-linter@38a9cabef56171c4e52ea698fa7be3db5fca3a49  # main
         with:
           jira-base-url: 'https://tyktech.atlassian.net'
           jira-user-email: ${{ secrets.JIRA_USER_EMAIL }}

--- a/.github/workflows/lint-swagger.yml
+++ b/.github/workflows/lint-swagger.yml
@@ -4,6 +4,12 @@ name: "Lint swagger schema"
 
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - labeled
     paths:
       - 'swagger.yml'
 
@@ -12,21 +18,28 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  dep-guard:
+    uses: TykTechnologies/github-actions/.github/workflows/dependency-guard.yml@2b35ab5dd4cfff21ced9d12446e9e27d10bf5785  # main
+    permissions:
+      contents: read
+
   redocly_validator:
+    needs: [dep-guard]
     runs-on: ubuntu-latest
     name: Validate the swagger with redocly cli
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: 20
       - name: Validate OpenAPI definition with redocly
         run: |
-          npm install @redocly/cli -g
+          npm install --ignore-scripts @redocly/cli@1.34.3 -g
           redocly lint swagger.yml --config=redocly.yml
 
   diff_swagger:
+    needs: [dep-guard]
     name: Diff swagger yaml for comment
     runs-on: ubuntu-latest
 
@@ -38,12 +51,12 @@ jobs:
           git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"
 
       - name: Checkout repo
-        uses: TykTechnologies/github-actions/.github/actions/checkout-pr@main
+        uses: TykTechnologies/github-actions/.github/actions/checkout-pr@2b35ab5dd4cfff21ced9d12446e9e27d10bf5785  # main
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
 
       - name: Setup Golang
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version: stable
 
@@ -87,7 +100,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Find Comment
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@a54c31d7fa095754bfef525c0c8e5e5674c4b4b1  # v2
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -95,7 +108,7 @@ jobs:
           body-includes: Swagger Changes
 
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@23ff15729ef2fc348714a3bb66d2f655ca9066f2  # v3
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,9 +13,16 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  dep-guard:
+    if: ${{ github.event_name == 'pull_request' }}
+    uses: TykTechnologies/github-actions/.github/workflows/dependency-guard.yml@2b35ab5dd4cfff21ced9d12446e9e27d10bf5785  # main
+    permissions:
+      contents: read
+
   godoc:
+    needs: [dep-guard]
     if: ${{ !github.event.pull_request.draft }}
-    uses: TykTechnologies/github-actions/.github/workflows/godoc.yml@main
+    uses: TykTechnologies/github-actions/.github/workflows/godoc.yml@2b35ab5dd4cfff21ced9d12446e9e27d10bf5785  # main
     secrets:
       ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
     with:

--- a/.github/workflows/plugin-compiler-build.yml
+++ b/.github/workflows/plugin-compiler-build.yml
@@ -3,6 +3,12 @@ name: Plugin-compiler build
 
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - labeled
   push:
     branches:
       - master
@@ -18,7 +24,14 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  dep-guard:
+    if: ${{ github.event_name == 'pull_request' }}
+    uses: TykTechnologies/github-actions/.github/workflows/dependency-guard.yml@2b35ab5dd4cfff21ced9d12446e9e27d10bf5785  # main
+    permissions:
+      contents: read
+
   docker-build:
+    needs: [dep-guard]
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft }}
     permissions:
@@ -28,13 +41,13 @@ jobs:
         run: sudo rm -rf /usr/local/bin/* /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 1
 
       - name: Configure AWS Credentials
         id: configure-aws
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355  # v2
         with:
           role-to-assume: arn:aws:iam::754489498669:role/ecr_rw_tyk
           role-session-name: ci-plugin-compiler-push
@@ -42,11 +55,11 @@ jobs:
 
       - name: Login to AWS ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@5a88a04c91d5c6f97aae0d9be790e64d9b1d47b7  # v1
 
       - name: Set docker metadata
         id: set-metadata
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175  # v4
         with:
           images: |
             tykio/tyk-plugin-compiler,enable=${{ startsWith(github.ref, 'refs/tags') }}
@@ -62,13 +75,13 @@ jobs:
             type=sha,format=long
 
       - name: Login to Dockerhub
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc  # v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push to dockerhub/ECR
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9  # v4
         with:
           context: .
           file: ci/images/plugin-compiler/Dockerfile
@@ -83,7 +96,7 @@ jobs:
 
       - name: Set docker metadata EE
         id: set-metadata-ee
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175  # v4
         with:
           images: |
             tykio/tyk-plugin-compiler-ee,enable=${{ startsWith(github.ref, 'refs/tags') }}
@@ -99,7 +112,7 @@ jobs:
             type=sha,format=long
 
       - name: Build and push to dockerhub/ECR EE
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9  # v4
         with:
           context: .
           file: ci/images/plugin-compiler/Dockerfile

--- a/.github/workflows/release-bot.yaml
+++ b/.github/workflows/release-bot.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release_bot:
-    uses: TykTechnologies/github-actions/.github/workflows/release-bot.yaml@main
+    uses: TykTechnologies/github-actions/.github/workflows/release-bot.yaml@2b35ab5dd4cfff21ced9d12446e9e27d10bf5785  # main
     secrets:
       APP_ID: ${{ secrets.PROBE_APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.PROBE_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -10,12 +10,12 @@ jobs:
     name: Opentelemetry e2e
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 1
 
       - name: Install Task
-        uses: arduino/setup-task@v1
+        uses: arduino/setup-task@accf38bba955639d21816bb68775e5c48c482182  # v1
         with:
           version: 3
 
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 1
 
@@ -40,9 +40,9 @@ jobs:
         uses: ./.github/actions/ecr-login
 
       - name: Setup CI Tooling
-        uses: shrink/actions-docker-extract@v3
+        uses: shrink/actions-docker-extract@04c17c51a5b9fd93b7aed2e05e86c8fe2d90ee52  # v3
         with:
-          image: tykio/ci-tools:latest
+          image: tykio/ci-tools@sha256:1796c0938247f42c580c501f7cd04e1144a59a62c6d8ba743572ff40371e1306  # latest
           path: /usr/local/bin/.
           destination: /usr/local/bin
 
@@ -70,7 +70,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags')
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 1
 

--- a/.github/workflows/remove_old_draft_releases.yaml
+++ b/.github/workflows/remove_old_draft_releases.yaml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Delete drafts
-        uses: hugo19941994/delete-draft-releases@v1.0.0
+        uses: hugo19941994/delete-draft-releases@f962e497fe892965a04b2266b3b865e1a59ecd06  # v1.0.0
         with:
           threshold: 5d
         env:

--- a/.github/workflows/s1-cns-scans.yml
+++ b/.github/workflows/s1-cns-scans.yml
@@ -7,8 +7,15 @@ on:  # yamllint disable-line rule:truthy
     branches: [master]
 
 jobs:
+  dep-guard:
+    if: ${{ github.event_name == 'pull_request' }}
+    uses: TykTechnologies/github-actions/.github/workflows/dependency-guard.yml@2b35ab5dd4cfff21ced9d12446e9e27d10bf5785  # main
+    permissions:
+      contents: read
+
   s1_scanner:
-    uses: TykTechnologies/github-actions/.github/workflows/s1-cns-scan.yml@main
+    needs: [dep-guard]
+    uses: TykTechnologies/github-actions/.github/workflows/s1-cns-scan.yml@2b35ab5dd4cfff21ced9d12446e9e27d10bf5785  # main
     permissions:
       contents: read
     with:

--- a/.github/workflows/update-tyk-analytics.yml
+++ b/.github/workflows/update-tyk-analytics.yml
@@ -14,13 +14,13 @@ jobs:
     name: tyk-analytics
     runs-on: ubuntu-latest
     steps:
-      - uses: peter-evans/repository-dispatch@v1
+      - uses: peter-evans/repository-dispatch@ce5485de42c9b2622d2ed064be479e8ed65e76f4  # v1
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
           repository: TykTechnologies/tyk-analytics
           event-type: new-tyk
           client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
-      - uses: peter-evans/repository-dispatch@v1
+      - uses: peter-evans/repository-dispatch@ce5485de42c9b2622d2ed064be479e8ed65e76f4  # v1
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
           repository: TykTechnologies/tyk-sink

--- a/.github/workflows/visor.yaml
+++ b/.github/workflows/visor.yaml
@@ -15,12 +15,19 @@ permissions:
   checks: write
 
 jobs:
+  dep-guard:
+    if: ${{ github.event_name == 'pull_request' }}
+    uses: TykTechnologies/github-actions/.github/workflows/dependency-guard.yml@2b35ab5dd4cfff21ced9d12446e9e27d10bf5785  # main
+    permissions:
+      contents: read
+
   visor:
+    needs: [dep-guard]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-      - uses: probelabs/visor@main
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: probelabs/visor@02e893ad11b66319b0fca1a43622038171c1a159  # main
         with:
           app-id: ${{ secrets.PROBE_APP_ID }}
           private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}

--- a/.taskfiles/deps.yml
+++ b/.taskfiles/deps.yml
@@ -21,7 +21,7 @@ tasks:
     status:
       - type mockgen
     cmds:
-      - go install go.uber.org/mock/mockgen@v0.6.0
+      - go install go.uber.org/mock/mockgen@2d1c58167e30f380cf78e44a43b100a14767e817  # v0.6.0
 
   gotestsum:
     internal: true
@@ -29,7 +29,7 @@ tasks:
     status:
       - type gotestsum
     cmds:
-      - go install gotest.tools/gotestsum@latest
+      - go install gotest.tools/gotestsum@c4a0df2e75a225d979a444342dd3db752b53619f  # v1.13.0
 
   golangci-lint:
     internal: true
@@ -37,7 +37,7 @@ tasks:
     status:
       - type golangci-lint
     cmds:
-      - go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0
+      - go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@ff63786c30d6c2926f99d677ab2ecf089e9390ad  # v2.5.0
 
   lefthook:
     internal: true
@@ -45,7 +45,7 @@ tasks:
     status:
       - type lefthook
     cmds:
-      - go install github.com/evilmartians/lefthook@latest
+      - go install github.com/evilmartians/lefthook@83ec3a9212b41d20576c45a4b5dc5bccff2d5e8a  # v2.1.4
 
   exp:
     internal: true
@@ -55,4 +55,4 @@ tasks:
     status:
       - type {{.name}}
     cmds:
-      - go install github.com/TykTechnologies/exp/cmd/{{.name}}@main
+      - go install github.com/TykTechnologies/exp/cmd/{{.name}}@49245597f0620ef8460735bb0ae6e93be5f8ca51  # main

--- a/apidef/oas/Taskfile.yml
+++ b/apidef/oas/Taskfile.yml
@@ -30,4 +30,4 @@ tasks:
   deps:
     desc: "Update deps"
     cmds:
-      - go install github.com/TykTechnologies/exp/cmd/schema-gen@main
+      - go install github.com/TykTechnologies/exp/cmd/schema-gen@49245597f0620ef8460735bb0ae6e93be5f8ca51  # main

--- a/config/Taskfile.yml
+++ b/config/Taskfile.yml
@@ -23,4 +23,4 @@ tasks:
   deps:
     desc: "Update deps"
     cmds:
-      - go install github.com/TykTechnologies/exp/cmd/schema-gen@main
+      - go install github.com/TykTechnologies/exp/cmd/schema-gen@49245597f0620ef8460735bb0ae6e93be5f8ca51  # main

--- a/coprocess/Taskfile.yml
+++ b/coprocess/Taskfile.yml
@@ -33,4 +33,4 @@ tasks:
   deps:
     desc: "Update deps"
     cmds:
-      - go install github.com/TykTechnologies/exp/cmd/schema-gen@main
+      - go install github.com/TykTechnologies/exp/cmd/schema-gen@49245597f0620ef8460735bb0ae6e93be5f8ca51  # main

--- a/internal/event/Taskfile.yml
+++ b/internal/event/Taskfile.yml
@@ -36,4 +36,4 @@ tasks:
     env:
       GOBIN: /usr/local/bin
     cmds:
-      - go install github.com/gregoryv/uncover/...@latest
+      - go install github.com/gregoryv/uncover/...@81f45634c118c2b72e7f104f38a803181e307ad6  # latest

--- a/internal/httputil/Taskfile.yml
+++ b/internal/httputil/Taskfile.yml
@@ -47,4 +47,4 @@ tasks:
     env:
       GOBIN: /usr/local/bin
     cmds:
-      - go install github.com/gregoryv/uncover/...@latest
+      - go install github.com/gregoryv/uncover/...@81f45634c118c2b72e7f104f38a803181e307ad6  # latest

--- a/internal/policy/Taskfile.yml
+++ b/internal/policy/Taskfile.yml
@@ -46,4 +46,4 @@ tasks:
     env:
       GOBIN: /usr/local/bin
     cmds:
-      - go install github.com/gregoryv/uncover/...@latest
+      - go install github.com/gregoryv/uncover/...@81f45634c118c2b72e7f104f38a803181e307ad6  # latest

--- a/internal/rate/Taskfile.yml
+++ b/internal/rate/Taskfile.yml
@@ -47,4 +47,4 @@ tasks:
     env:
       GOBIN: /usr/local/bin
     cmds:
-      - go install github.com/gregoryv/uncover/...@latest
+      - go install github.com/gregoryv/uncover/...@81f45634c118c2b72e7f104f38a803181e307ad6  # latest

--- a/log/Taskfile.yml
+++ b/log/Taskfile.yml
@@ -47,4 +47,4 @@ tasks:
     env:
       GOBIN: /usr/local/bin
     cmds:
-      - go install github.com/gregoryv/uncover/...@latest
+      - go install github.com/gregoryv/uncover/...@81f45634c118c2b72e7f104f38a803181e307ad6  # latest

--- a/tests/lifecycle/Taskfile.yml
+++ b/tests/lifecycle/Taskfile.yml
@@ -53,4 +53,4 @@ tasks:
     env:
       GOBIN: /usr/local/bin
     cmds:
-      - go install github.com/gregoryv/uncover/...@latest
+      - go install github.com/gregoryv/uncover/...@81f45634c118c2b72e7f104f38a803181e307ad6  # latest

--- a/tests/policy/Taskfile.yml
+++ b/tests/policy/Taskfile.yml
@@ -50,4 +50,4 @@ tasks:
     env:
       GOBIN: /usr/local/bin
     cmds:
-      - go install github.com/gregoryv/uncover/...@latest
+      - go install github.com/gregoryv/uncover/...@81f45634c118c2b72e7f104f38a803181e307ad6  # latest

--- a/tests/quota/Taskfile.yml
+++ b/tests/quota/Taskfile.yml
@@ -50,4 +50,4 @@ tasks:
     env:
       GOBIN: /usr/local/bin
     cmds:
-      - go install github.com/gregoryv/uncover/...@latest
+      - go install github.com/gregoryv/uncover/...@81f45634c118c2b72e7f104f38a803181e307ad6  # latest


### PR DESCRIPTION
## Summary
Sync security hardening commit #7956 from release-5.12 to release-5.12.1.

Changes include:
- Pinned GitHub Actions to commit SHAs across workflow files
- Added dep guard workflow
- Fixed installs in Taskfiles

**Conflict resolution:** `release.yml` had 47 conflict blocks because release-5.12.1 already had actions pinned independently (with slightly different SHAs). Resolved by keeping the release-5.12.1 versions since they were already pinned. All other workflow and Taskfile changes applied cleanly.

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)