### PR TITLE
fix: backport #7972 — [TT-16890] validate request middleware regression

### DIFF
--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync/atomic"
 	texttemplate "text/template"
@@ -21,6 +22,7 @@ import (
 	"github.com/TykTechnologies/tyk/storage/kv"
 
 	"github.com/TykTechnologies/tyk/internal/httputil"
+	"github.com/TykTechnologies/tyk/internal/oasutil"
 
 	"github.com/getkin/kin-openapi/routers/gorillamux"
 
@@ -1343,7 +1345,6 @@ func (a APIDefinitionLoader) compileOASValidateRequestPathSpec(apiSpec *APISpec,
 			continue
 		}
 
-		// Find the path and method for this operation
 		path, method := a.findPathAndMethodForOperation(apiSpec, operationID)
 		if path == "" || method == "" {
 			continue
@@ -1355,13 +1356,19 @@ func (a APIDefinitionLoader) compileOASValidateRequestPathSpec(apiSpec *APISpec,
 			OASPath:                path,
 		}
 
-		// The path in OAS is relative to the server URL (listenPath)
-		// For regex matching, we don't prepend listenPath because URLSpec.matchesPath
-		// will strip the listenPath before matching
-		// Use standard regex generation with gateway config
 		a.generateRegex(path, &newSpec, OASValidateRequest, conf)
 		urlSpec = append(urlSpec, newSpec)
 	}
+
+	urlSpec = a.addStaticPathShields(apiSpec, conf, urlSpec, OASValidateRequest, func(path, method string) URLSpec {
+		return URLSpec{
+			OASValidateRequestMeta: &oas.ValidateRequest{Enabled: false},
+			OASMethod:              method,
+			OASPath:                path,
+		}
+	})
+
+	sortURLSpecsByPathPriority(urlSpec)
 
 	return urlSpec
 }
@@ -1388,7 +1395,6 @@ func (a APIDefinitionLoader) compileOASMockResponsePathSpec(apiSpec *APISpec, co
 			continue
 		}
 
-		// Find the path and method for this operation
 		path, method := a.findPathAndMethodForOperation(apiSpec, operationID)
 		if path == "" || method == "" {
 			continue
@@ -1400,12 +1406,76 @@ func (a APIDefinitionLoader) compileOASMockResponsePathSpec(apiSpec *APISpec, co
 			OASPath:             path,
 		}
 
-		// Use standard regex generation with gateway config
 		a.generateRegex(path, &newSpec, OASMockResponse, conf)
 		urlSpec = append(urlSpec, newSpec)
 	}
 
+	urlSpec = a.addStaticPathShields(apiSpec, conf, urlSpec, OASMockResponse, func(path, method string) URLSpec {
+		return URLSpec{
+			OASMockResponseMeta: &oas.MockResponse{Enabled: false},
+			OASMethod:           method,
+			OASPath:             path,
+		}
+	})
+
+	sortURLSpecsByPathPriority(urlSpec)
+
 	return urlSpec
+}
+
+// addStaticPathShields adds synthetic disabled URLSpec entries for static OAS paths
+// that don't already have an entry in urlSpec. These entries act as shields: when the
+// middleware scans the path list, a static shield entry matches before any parameterised
+// regex, and the middleware sees Enabled=false and skips it. This prevents parameterised
+// paths (e.g. /employees/{id}) from incorrectly matching static paths (e.g. /employees/static).
+//
+// Shield entries are only added when urlSpec contains at least one parameterised path,
+// since without parameterised paths there is no cross-matching risk.
+func (a APIDefinitionLoader) addStaticPathShields(
+	apiSpec *APISpec,
+	conf config.Config,
+	urlSpec []URLSpec,
+	status URLStatus,
+	newDisabledSpec func(path, method string) URLSpec,
+) []URLSpec {
+	if apiSpec.OAS.Paths == nil {
+		return urlSpec
+	}
+
+	existing, hasParameterised := indexURLSpecs(urlSpec)
+	if !hasParameterised {
+		return urlSpec
+	}
+
+	for path, pathItem := range apiSpec.OAS.Paths.Map() {
+		if httputil.IsMuxTemplate(path) {
+			continue
+		}
+		for method := range pathItem.Operations() {
+			method = strings.ToUpper(method)
+			if _, exists := existing[path+":"+method]; exists {
+				continue
+			}
+			newSpec := newDisabledSpec(path, method)
+			a.generateRegex(path, &newSpec, status, conf)
+			urlSpec = append(urlSpec, newSpec)
+		}
+	}
+
+	return urlSpec
+}
+
+// indexURLSpecs builds a set of "path:METHOD" keys from the given specs and reports
+// whether any spec uses a parameterised (mux-template) path.
+func indexURLSpecs(specs []URLSpec) (existing map[string]struct{}, hasParameterised bool) {
+	existing = make(map[string]struct{}, len(specs))
+	for _, spec := range specs {
+		existing[spec.OASPath+":"+spec.OASMethod] = struct{}{}
+		if httputil.IsMuxTemplate(spec.OASPath) {
+			hasParameterised = true
+		}
+	}
+	return
 }
 
 // findPathAndMethodForOperation finds the path and method for a given operation ID
@@ -1424,6 +1494,14 @@ func (a APIDefinitionLoader) findPathAndMethodForOperation(apiSpec *APISpec, ope
 	}
 
 	return "", ""
+}
+
+// sortURLSpecsByPathPriority sorts URLSpec entries using the same path priority
+// rules as oasutil.SortByPathLength, ensuring consistent ordering across the gateway.
+func sortURLSpecsByPathPriority(specs []URLSpec) {
+	sort.Slice(specs, func(i, j int) bool {
+		return oasutil.PathLess(specs[i].OASPath, specs[j].OASPath)
+	})
 }
 
 func (a APIDefinitionLoader) getExtendedPathSpecs(apiVersionDef apidef.VersionInfo, apiSpec *APISpec, conf config.Config) ([]URLSpec, bool) {

--- a/gateway/mw_oas_validate_request_benchmark_test.go
+++ b/gateway/mw_oas_validate_request_benchmark_test.go
@@ -1,0 +1,154 @@
+package gateway
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/apidef/oas"
+)
+
+// BenchmarkSortURLSpecsByPathPriority measures the overhead of sorting URLSpec entries.
+func BenchmarkSortURLSpecsByPathPriority(b *testing.B) {
+	for _, n := range []int{10, 50, 200} {
+		b.Run(fmt.Sprintf("paths=%d", n), func(b *testing.B) {
+			// Build a mix of static and parameterised paths
+			template := make([]URLSpec, n)
+			for i := 0; i < n; i++ {
+				if i%3 == 0 {
+					template[i] = URLSpec{OASPath: fmt.Sprintf("/api/v1/resource%d/{id}", i)}
+				} else {
+					template[i] = URLSpec{OASPath: fmt.Sprintf("/api/v1/resource%d/static", i)}
+				}
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				specs := make([]URLSpec, n)
+				copy(specs, template)
+				sortURLSpecsByPathPriority(specs)
+			}
+		})
+	}
+}
+
+// BenchmarkOASValidateRequestStaticVsParameterized measures request-time performance
+// for static and parameterised paths with the shield mechanism.
+func BenchmarkOASValidateRequestStaticVsParameterized(b *testing.B) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	// Parameterised path with validation
+	paths.Set("/users/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getUserById",
+			Parameters: openapi3.Parameters{
+				&openapi3.ParameterRef{
+					Value: &openapi3.Parameter{
+						Name:     "id",
+						In:       "path",
+						Required: true,
+						Schema: &openapi3.SchemaRef{
+							Value: &openapi3.Schema{
+								Type: &openapi3.Types{"integer"},
+							},
+						},
+					},
+				},
+			},
+			Responses: openapi3.NewResponses(
+				openapi3.WithStatus(200, &openapi3.ResponseRef{
+					Value: &openapi3.Response{
+						Description: stringPtrHelper("Success"),
+					},
+				}),
+			),
+		},
+	})
+
+	// Static path without validation
+	paths.Set("/users/admin", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getAdminUser",
+			Responses: openapi3.NewResponses(
+				openapi3.WithStatus(200, &openapi3.ResponseRef{
+					Value: &openapi3.Response{
+						Description: stringPtrHelper("Success"),
+					},
+				}),
+			),
+		},
+	})
+
+	// Add extra static paths to test scaling
+	for i := 0; i < 50; i++ {
+		opID := fmt.Sprintf("getResource%d", i)
+		paths.Set(fmt.Sprintf("/resources/item%d", i), &openapi3.PathItem{
+			Get: &openapi3.Operation{
+				OperationID: opID,
+				Responses: openapi3.NewResponses(
+					openapi3.WithStatus(200, &openapi3.ResponseRef{
+						Value: &openapi3.Response{
+							Description: stringPtrHelper("Success"),
+						},
+					}),
+				),
+			},
+		})
+	}
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Benchmark API", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getUserById": {
+					ValidateRequest: &oas.ValidateRequest{Enabled: true},
+				},
+			},
+		},
+	})
+
+	api := ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Benchmark API"
+		spec.APIID = "benchmark-api"
+		spec.Proxy.ListenPath = "/api/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})[0]
+
+	require.NotNil(b, api)
+
+	b.Run("StaticPath_ShieldHit", func(b *testing.B) {
+		req := httptest.NewRequest(http.MethodGet, "/api/users/admin", nil)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			rec := httptest.NewRecorder()
+			ts.TestServerRouter.ServeHTTP(rec, req)
+		}
+	})
+
+	b.Run("ParameterizedPath_ValidationHit", func(b *testing.B) {
+		req := httptest.NewRequest(http.MethodGet, "/api/users/123", nil)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			rec := httptest.NewRecorder()
+			ts.TestServerRouter.ServeHTTP(rec, req)
+		}
+	})
+}

--- a/gateway/mw_oas_validate_request_path_priority_test.go
+++ b/gateway/mw_oas_validate_request_path_priority_test.go
@@ -1,0 +1,383 @@
+package gateway
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/test"
+)
+
+func TestSortURLSpecsByPathPriority(t *testing.T) {
+	tests := []struct {
+		name     string
+		paths    []string
+		expected []string
+	}{
+		{
+			name:     "static path before parameterised",
+			paths:    []string{"/employees/{id}", "/employees/static"},
+			expected: []string{"/employees/static", "/employees/{id}"},
+		},
+		{
+			name:     "more segments first",
+			paths:    []string{"/a/b", "/a/b/c"},
+			expected: []string{"/a/b/c", "/a/b"},
+		},
+		{
+			name:     "longer path first",
+			paths:    []string{"/api/user", "/api/user-access"},
+			expected: []string{"/api/user-access", "/api/user"},
+		},
+		{
+			name:     "alphabetical for equal length",
+			paths:    []string{"/api/abc", "/api/aba"},
+			expected: []string{"/api/aba", "/api/abc"},
+		},
+		{
+			name: "multiple mixed paths",
+			paths: []string{
+				"/users/{id}",
+				"/users/me",
+				"/users/{id}/reports",
+				"/departments/{deptId}",
+			},
+			expected: []string{
+				"/users/{id}/reports",
+				"/departments/{deptId}",
+				"/users/me",
+				"/users/{id}",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			specs := make([]URLSpec, len(tc.paths))
+			for i, p := range tc.paths {
+				specs[i] = URLSpec{OASPath: p}
+			}
+
+			sortURLSpecsByPathPriority(specs)
+
+			got := make([]string, len(specs))
+			for i, s := range specs {
+				got[i] = s.OASPath
+			}
+
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestStaticPathTakesPrecedenceOverParameterised(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/static", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getStaticEmployee",
+			Responses: openapi3.NewResponses(
+				openapi3.WithStatus(200, &openapi3.ResponseRef{
+					Value: &openapi3.Response{
+						Description: stringPtrHelper("Success"),
+					},
+				}),
+			),
+		},
+	})
+
+	paths.Set("/employees/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getEmployeeById",
+			Parameters: openapi3.Parameters{
+				&openapi3.ParameterRef{
+					Value: &openapi3.Parameter{
+						Name:     "id",
+						In:       "path",
+						Required: true,
+						Schema: &openapi3.SchemaRef{
+							Value: &openapi3.Schema{
+								Type:    &openapi3.Types{"string"},
+								Pattern: "^[a-zA-Z]+$",
+							},
+						},
+					},
+				},
+			},
+			Responses: openapi3.NewResponses(
+				openapi3.WithStatus(200, &openapi3.ResponseRef{
+					Value: &openapi3.Response{
+						Description: stringPtrHelper("Success"),
+					},
+				}),
+			),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Validate Request Priority Test", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getStaticEmployee": {},
+				"getEmployeeById": {
+					ValidateRequest: &oas.ValidateRequest{Enabled: true},
+				},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Validate Request Priority API"
+		spec.APIID = "validate-request-priority"
+		spec.Proxy.ListenPath = "/api/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			Method: http.MethodGet,
+			Path:   "/api/employees/static",
+			Code:   http.StatusOK,
+		},
+		{
+			Method: http.MethodGet,
+			Path:   "/api/employees/john",
+			Code:   http.StatusOK,
+		},
+		{
+			Method: http.MethodGet,
+			Path:   "/api/employees/123",
+			Code:   http.StatusUnprocessableEntity,
+		},
+	}...)
+}
+
+func TestMockResponseStaticPathPriority(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/items/special", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getSpecialItem",
+			Responses: openapi3.NewResponses(
+				openapi3.WithStatus(200, &openapi3.ResponseRef{
+					Value: &openapi3.Response{
+						Description: stringPtrHelper("Success"),
+					},
+				}),
+			),
+		},
+	})
+
+	paths.Set("/items/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getItemById",
+			Parameters: openapi3.Parameters{
+				&openapi3.ParameterRef{
+					Value: &openapi3.Parameter{
+						Name:     "id",
+						In:       "path",
+						Required: true,
+						Schema: &openapi3.SchemaRef{
+							Value: &openapi3.Schema{
+								Type: &openapi3.Types{"string"},
+							},
+						},
+					},
+				},
+			},
+			Responses: openapi3.NewResponses(
+				openapi3.WithStatus(200, &openapi3.ResponseRef{
+					Value: &openapi3.Response{
+						Description: stringPtrHelper("Success"),
+					},
+				}),
+			),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Mock Response Priority Test", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getSpecialItem": {},
+				"getItemById": {
+					MockResponse: &oas.MockResponse{Enabled: true, Code: 200, Body: "mocked"},
+				},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Mock Response Priority API"
+		spec.APIID = "mock-response-priority"
+		spec.Proxy.ListenPath = "/api/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			// Static path should NOT get mock response — the mock is only on {id}
+			Method:       http.MethodGet,
+			Path:         "/api/items/special",
+			BodyNotMatch: "mocked",
+		},
+		{
+			// Parameterised path should get mock response
+			Method:    http.MethodGet,
+			Path:      "/api/items/123",
+			Code:      http.StatusOK,
+			BodyMatch: "mocked",
+		},
+	}...)
+}
+
+func TestStaticPathPriorityWithPrefixMatching(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	// Enable prefix matching at gateway level
+	conf := ts.Gw.GetConfig()
+	conf.HttpServerOptions.EnablePathPrefixMatching = true
+	ts.Gw.SetConfig(conf)
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/static", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getStaticEmployee",
+			Parameters: openapi3.Parameters{
+				&openapi3.ParameterRef{
+					Value: &openapi3.Parameter{
+						Name:     "X-Custom-Header",
+						In:       "header",
+						Required: true,
+						Schema: &openapi3.SchemaRef{
+							Value: &openapi3.Schema{
+								Type: &openapi3.Types{"string"},
+							},
+						},
+					},
+				},
+			},
+			Responses: openapi3.NewResponses(
+				openapi3.WithStatus(200, &openapi3.ResponseRef{
+					Value: &openapi3.Response{
+						Description: stringPtrHelper("Success"),
+					},
+				}),
+			),
+		},
+	})
+
+	paths.Set("/employees/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getEmployeeById",
+			Parameters: openapi3.Parameters{
+				&openapi3.ParameterRef{
+					Value: &openapi3.Parameter{
+						Name:     "id",
+						In:       "path",
+						Required: true,
+						Schema: &openapi3.SchemaRef{
+							Value: &openapi3.Schema{
+								Type:    &openapi3.Types{"string"},
+								Pattern: "^[a-zA-Z]+$",
+							},
+						},
+					},
+				},
+			},
+			Responses: openapi3.NewResponses(
+				openapi3.WithStatus(200, &openapi3.ResponseRef{
+					Value: &openapi3.Response{
+						Description: stringPtrHelper("Success"),
+					},
+				}),
+			),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Prefix Matching Priority Test", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getStaticEmployee": {
+					ValidateRequest: &oas.ValidateRequest{Enabled: true},
+				},
+				"getEmployeeById": {
+					ValidateRequest: &oas.ValidateRequest{Enabled: true},
+				},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Prefix Matching Priority API"
+		spec.APIID = "prefix-matching-priority"
+		spec.Proxy.ListenPath = "/api/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			// Static path without required header should fail its OWN validation,
+			// proving it matched /employees/static and not /employees/{id}
+			Method:    http.MethodGet,
+			Path:      "/api/employees/static",
+			Code:      http.StatusUnprocessableEntity,
+			BodyMatch: "X-Custom-Header",
+		},
+		{
+			// Static path with required header should pass validation
+			Method:  http.MethodGet,
+			Path:    "/api/employees/static",
+			Code:    http.StatusOK,
+			Headers: map[string]string{"X-Custom-Header": "value"},
+		},
+		{
+			// Parameterised path with valid id should pass
+			Method: http.MethodGet,
+			Path:   "/api/employees/john",
+			Code:   http.StatusOK,
+		},
+		{
+			// Parameterised path with invalid id should fail
+			Method: http.MethodGet,
+			Path:   "/api/employees/123",
+			Code:   http.StatusUnprocessableEntity,
+		},
+	}...)
+}

--- a/internal/oasutil/paths.go
+++ b/internal/oasutil/paths.go
@@ -17,7 +17,8 @@ type PathItem struct {
 	Path string
 }
 
-var pathParamRegex = regexp.MustCompile(`\{[^}]+\}`)
+// PathParamRegex matches path parameters like {id} or {employeeId} in OAS paths.
+var PathParamRegex = regexp.MustCompile(`\{[^}]+\}`)
 
 // ExtractPaths will extract paths with the given order.
 func ExtractPaths(in openapi3.Paths, order []string) []PathItem {
@@ -35,6 +36,37 @@ func ExtractPaths(in openapi3.Paths, order []string) []PathItem {
 	return result
 }
 
+// PathLess reports whether pathA should sort before pathB using the
+// standard Tyk path priority rules:
+//   - Strip path parameters {…} before comparing
+//   - If two paths are equal after stripping, the non-parameterised one goes first
+//   - Sort by number of "/" segments (more segments first)
+//   - Sort by string length (longer first)
+//   - Alphabetical for equal length
+func PathLess(pathA, pathB string) bool {
+	a := PathParamRegex.ReplaceAllString(pathA, "")
+	b := PathParamRegex.ReplaceAllString(pathB, "")
+
+	// handle /sub and /sub{id} order with raw path.
+	if a == b {
+		// we're reversing paths here so path with
+		// parameter is sorted after the literal.
+		a, b = pathB, pathA
+	}
+
+	// sort by number of path fragments
+	ka, kb := strings.Count(a, "/"), strings.Count(b, "/")
+	if ka != kb {
+		return ka > kb
+	}
+
+	la, lb := len(a), len(b)
+	if la == lb {
+		return a < b
+	}
+	return la > lb
+}
+
 // SortByPathLength decomposes an openapi3.Paths to a sorted []PathItem.
 // The sorting takes the length of the paths into account, as well as
 // path parameters, sorting them by length descending, and ordering
@@ -49,29 +81,8 @@ func SortByPathLength(in openapi3.Paths) []PathItem {
 		paths = append(paths, k)
 	}
 
-	// sort by length and lexicographically
 	sort.Slice(paths, func(i, j int) bool {
-		pathI := pathParamRegex.ReplaceAllString(paths[i], "")
-		pathJ := pathParamRegex.ReplaceAllString(paths[j], "")
-
-		// handle /sub and /sub{id} order with raw path.
-		if pathI == pathJ {
-			// we're reversing indexes here so path with
-			// parameter is sorted after the literal.
-			pathI, pathJ = paths[j], paths[i]
-		}
-
-		// sort by number of path fragments
-		k, v := strings.Count(pathI, "/"), strings.Count(pathJ, "/")
-		if k != v {
-			return k > v
-		}
-
-		il, jl := len(pathI), len(pathJ)
-		if il == jl {
-			return pathI < pathJ
-		}
-		return il > jl
+		return PathLess(paths[i], paths[j])
 	})
 
 	return ExtractPaths(in, paths)


### PR DESCRIPTION
## Summary
Backport of #7972 to release-5.8. Critical regression fix for validate request middleware.

Cherry-pick of a48ebe56d51335fd2348abc2f377e69ec6ec227b with conflict resolution:
- Removed `internal/mcp` import (not present on release-5.8)
- Removed MCP-related functions from conflict resolution (not present on release-5.8)
- Added `internal/oasutil` import and `sort` import
- Added `sortURLSpecsByPathPriority`, `addStaticPathShields`, `indexURLSpecs` functions
- Added `PathLess` and exported `PathParamRegex` to `internal/oasutil/paths.go`

## Test plan
- [ ] Unit Tests & Linting passes
- [ ] `go build ./gateway/...` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)