### PR TITLE
fix: backport #7974 — [TT-16890] validate middleware collapsed path fix

### DIFF
--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -1360,6 +1360,8 @@ func (a APIDefinitionLoader) compileOASValidateRequestPathSpec(apiSpec *APISpec,
 		urlSpec = append(urlSpec, newSpec)
 	}
 
+	urlSpec = groupCollapsedValidateRequestSpecs(urlSpec, apiSpec.OAS.Paths)
+
 	urlSpec = a.addStaticPathShields(apiSpec, conf, urlSpec, OASValidateRequest, func(path, method string) URLSpec {
 		return URLSpec{
 			OASValidateRequestMeta: &oas.ValidateRequest{Enabled: false},
@@ -1371,6 +1373,240 @@ func (a APIDefinitionLoader) compileOASValidateRequestPathSpec(apiSpec *APISpec,
 	sortURLSpecsByPathPriority(urlSpec)
 
 	return urlSpec
+}
+
+// groupCollapsedValidateRequestSpecs detects URLSpec entries that compile to the same
+// regex+method pair and groups them as candidates on a single representative URLSpec.
+// Candidates are sorted so that more restrictive path parameter schemas are tried first.
+func groupCollapsedValidateRequestSpecs(specs []URLSpec, oasPaths *openapi3.Paths) []URLSpec {
+	return groupCollapsedSpecs(specs, oasPaths, OASValidateRequest, func(indices []int, specs []URLSpec, toRemove map[int]bool) {
+		mergeGroupIntoPrimary(indices, specs, toRemove)
+	})
+}
+
+// groupCollapsedMockResponseSpecs is the mock response equivalent of
+// groupCollapsedValidateRequestSpecs.
+func groupCollapsedMockResponseSpecs(specs []URLSpec, oasPaths *openapi3.Paths) []URLSpec {
+	return groupCollapsedSpecs(specs, oasPaths, OASMockResponse, func(indices []int, specs []URLSpec, toRemove map[int]bool) {
+		mergeMockGroupIntoPrimary(indices, specs, toRemove)
+	})
+}
+
+// groupCollapsedSpecs is the shared grouping logic for both validate request and mock
+// response. It finds URLSpec entries with the same compiled regex+method, sorts them
+// by restrictiveness, and calls the provided merge function to build candidates.
+func groupCollapsedSpecs(
+	specs []URLSpec,
+	oasPaths *openapi3.Paths,
+	status URLStatus,
+	merge func(indices []int, specs []URLSpec, toRemove map[int]bool),
+) []URLSpec {
+	type key struct {
+		regex  string
+		method string
+	}
+
+	groups := make(map[key][]int)
+	var order []key
+	for i, s := range specs {
+		if s.Status != status || s.spec == nil {
+			continue
+		}
+		k := key{regex: s.spec.String(), method: s.OASMethod}
+		if _, exists := groups[k]; !exists {
+			order = append(order, k)
+		}
+		groups[k] = append(groups[k], i)
+	}
+
+	toRemove := make(map[int]bool)
+	for _, k := range order {
+		indices := groups[k]
+		if len(indices) < 2 {
+			continue
+		}
+		sortByRestrictiveness(indices, specs, oasPaths)
+		merge(indices, specs, toRemove)
+	}
+
+	return removeIndices(specs, toRemove)
+}
+
+// mergeMockGroupIntoPrimary builds MockResponseCandidates from the sorted indices
+// and assigns them to the primary (first) spec.
+func mergeMockGroupIntoPrimary(indices []int, specs []URLSpec, toRemove map[int]bool) {
+	primary := indices[0]
+	candidates := make([]MockResponseCandidate, len(indices))
+	for ci, idx := range indices {
+		candidates[ci] = MockResponseCandidate{
+			OASMockResponseMeta: specs[idx].OASMockResponseMeta,
+			OASMethod:           specs[idx].OASMethod,
+			OASPath:             specs[idx].OASPath,
+		}
+		if idx != primary {
+			toRemove[idx] = true
+		}
+	}
+
+	specs[primary].OASMockResponseMeta = candidates[0].OASMockResponseMeta
+	specs[primary].OASMethod = candidates[0].OASMethod
+	specs[primary].OASPath = candidates[0].OASPath
+	specs[primary].OASMockResponseCandidates = candidates
+}
+
+// sortByRestrictiveness sorts spec indices so that more restrictive path parameter
+// schemas come first. Ties in restrictiveness score are broken by total pattern length
+// (longer patterns are more specific, e.g., ^\d+$ before .*), then alphabetically.
+func sortByRestrictiveness(indices []int, specs []URLSpec, oasPaths *openapi3.Paths) {
+	sort.Slice(indices, func(a, b int) bool {
+		scoreA := pathParamRestrictiveness(specs[indices[a]].OASPath, specs[indices[a]].OASMethod, oasPaths)
+		scoreB := pathParamRestrictiveness(specs[indices[b]].OASPath, specs[indices[b]].OASMethod, oasPaths)
+		if scoreA != scoreB {
+			return scoreA > scoreB
+		}
+		lenA := pathParamPatternLength(specs[indices[a]].OASPath, specs[indices[a]].OASMethod, oasPaths)
+		lenB := pathParamPatternLength(specs[indices[b]].OASPath, specs[indices[b]].OASMethod, oasPaths)
+		if lenA != lenB {
+			return lenA > lenB
+		}
+		return specs[indices[a]].OASPath < specs[indices[b]].OASPath
+	})
+}
+
+// mergeGroupIntoPrimary takes a sorted list of spec indices that share the same
+// regex+method, builds ValidateRequestCandidates from them, and assigns them to
+// the primary (first) spec. Non-primary indices are marked for removal.
+func mergeGroupIntoPrimary(indices []int, specs []URLSpec, toRemove map[int]bool) {
+	primary := indices[0]
+	candidates := make([]ValidateRequestCandidate, len(indices))
+	for ci, idx := range indices {
+		candidates[ci] = ValidateRequestCandidate{
+			OASValidateRequestMeta: specs[idx].OASValidateRequestMeta,
+			OASMethod:              specs[idx].OASMethod,
+			OASPath:                specs[idx].OASPath,
+		}
+		if idx != primary {
+			toRemove[idx] = true
+		}
+	}
+
+	specs[primary].OASValidateRequestMeta = candidates[0].OASValidateRequestMeta
+	specs[primary].OASMethod = candidates[0].OASMethod
+	specs[primary].OASPath = candidates[0].OASPath
+	specs[primary].OASValidateRequestCandidates = candidates
+}
+
+// removeIndices returns a new slice with entries at the given indices removed.
+func removeIndices(specs []URLSpec, toRemove map[int]bool) []URLSpec {
+	if len(toRemove) == 0 {
+		return specs
+	}
+	result := make([]URLSpec, 0, len(specs)-len(toRemove))
+	for i, s := range specs {
+		if !toRemove[i] {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+// pathParamRestrictiveness returns a score indicating how restrictive the path parameter
+// schemas are for a given OAS path+method. Higher scores mean more restrictive. A plain
+// type:string with no constraints scores 0 (catch-all), while type:number, type:integer,
+// type:boolean, or any parameter with a pattern/enum/format scores higher.
+func pathParamRestrictiveness(oasPath, method string, oasPaths *openapi3.Paths) int {
+	if oasPaths == nil {
+		return 0
+	}
+	pathItem := oasPaths.Value(oasPath)
+	if pathItem == nil {
+		return 0
+	}
+	op := pathItem.GetOperation(method)
+	if op == nil {
+		return 0
+	}
+
+	score := 0
+	for _, paramRef := range op.Parameters {
+		if paramRef == nil || paramRef.Value == nil || paramRef.Value.In != "path" {
+			continue
+		}
+		param := paramRef.Value
+		if param.Schema == nil || param.Schema.Value == nil {
+			continue
+		}
+		score += schemaRestrictiveness(param.Schema.Value)
+	}
+	return score
+}
+
+// schemaRestrictiveness returns a score for how restrictive a single path parameter
+// schema is. The hierarchy from most to least restrictive:
+//
+//	integer (7) > number (6) > boolean (5) > array (4) > object (3)
+//	> string with constraints (2) > unconstrained string (0)
+//
+// This ensures that integer parameters are tried before number (since every integer
+// is a valid number but not vice versa), and all typed parameters are tried before
+// string which accepts everything.
+func schemaRestrictiveness(s *openapi3.Schema) int {
+	if s.Type != nil {
+		switch {
+		case s.Type.Is("integer"):
+			return 7
+		case s.Type.Is("number"):
+			return 6
+		case s.Type.Is("boolean"):
+			return 5
+		case s.Type.Is("array"):
+			return 4
+		case s.Type.Is("object"):
+			return 3
+		}
+	}
+
+	// type:string or untyped — check for constraints.
+	hasPattern := s.Pattern != ""
+	hasEnum := len(s.Enum) > 0
+	hasFormat := s.Format != ""
+	hasMinLen := s.MinLength != 0
+	hasMaxLen := s.MaxLength != nil
+
+	if hasPattern || hasEnum || hasFormat || hasMinLen || hasMaxLen {
+		return 2
+	}
+
+	// Unconstrained string — matches everything.
+	return 0
+}
+
+// pathParamPatternLength returns the total length of all path parameter pattern strings
+// for a given OAS path+method. Used as a tie-breaker when restrictiveness scores are
+// equal — longer patterns tend to be more specific (e.g., ^\d+$ vs .*).
+func pathParamPatternLength(oasPath, method string, oasPaths *openapi3.Paths) int {
+	if oasPaths == nil {
+		return 0
+	}
+	pathItem := oasPaths.Value(oasPath)
+	if pathItem == nil {
+		return 0
+	}
+	op := pathItem.GetOperation(method)
+	if op == nil {
+		return 0
+	}
+
+	total := 0
+	for _, paramRef := range op.Parameters {
+		if paramRef == nil || paramRef.Value == nil || paramRef.Value.In != "path" {
+			continue
+		}
+		if paramRef.Value.Schema != nil && paramRef.Value.Schema.Value != nil {
+			total += len(paramRef.Value.Schema.Value.Pattern)
+		}
+	}
+	return total
 }
 
 // compileOASMockResponsePathSpec extracts MockResponse operations from OAS middleware
@@ -1409,6 +1645,8 @@ func (a APIDefinitionLoader) compileOASMockResponsePathSpec(apiSpec *APISpec, co
 		a.generateRegex(path, &newSpec, OASMockResponse, conf)
 		urlSpec = append(urlSpec, newSpec)
 	}
+
+	urlSpec = groupCollapsedMockResponseSpecs(urlSpec, apiSpec.OAS.Paths)
 
 	urlSpec = a.addStaticPathShields(apiSpec, conf, urlSpec, OASMockResponse, func(path, method string) URLSpec {
 		return URLSpec{

--- a/gateway/model_apispec.go
+++ b/gateway/model_apispec.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/routers"
 
 	"github.com/TykTechnologies/tyk-pump/analytics"
@@ -226,6 +227,29 @@ func (a *APISpec) findRouteForOASPath(oasPath, method, actualPath, fullRequestPa
 	pathParams := extractPathParams(oasPath, actualPath)
 
 	return route, pathParams, nil
+}
+
+// matchCandidatePath looks up the path item and operation from the OAS spec for a
+// candidate path+method, extracts path parameters from the actual request path, and
+// validates them against the operation's path parameter schemas. Returns the operation,
+// path params, and true if the candidate matches; false otherwise.
+// This is the shared disambiguation logic used by both validate request and mock response.
+func (a *APISpec) matchCandidatePath(oasPath, oasMethod, strippedPath string) (*openapi3.PathItem, *openapi3.Operation, map[string]string, bool) {
+	pathItem := a.OAS.Paths.Value(oasPath)
+	if pathItem == nil {
+		return nil, nil, nil, false
+	}
+	operation := pathItem.GetOperation(oasMethod)
+	if operation == nil {
+		return nil, nil, nil, false
+	}
+
+	pathParams := extractPathParams(oasPath, strippedPath)
+	if !pathParamsMatchOperation(pathParams, operation) {
+		return nil, nil, nil, false
+	}
+
+	return pathItem, operation, pathParams, true
 }
 
 // extractPathParams extracts path parameter values from actualPath based on the

--- a/gateway/model_urlspec.go
+++ b/gateway/model_urlspec.go
@@ -41,6 +41,16 @@ type URLSpec struct {
 	OASValidateRequestMeta    *oas.ValidateRequest
 	OASMockResponseMeta       *oas.MockResponse
 
+	// OASValidateRequestCandidates holds multiple OAS endpoints that compile to the
+	// same regex pattern. When non-empty, the validate request middleware must
+	// disambiguate by checking path parameter schemas against each candidate.
+	OASValidateRequestCandidates []ValidateRequestCandidate
+
+	// OASMockResponseCandidates holds multiple OAS endpoints that compile to the
+	// same regex pattern. When non-empty, the mock response middleware must
+	// disambiguate by checking path parameter schemas against each candidate.
+	OASMockResponseCandidates []MockResponseCandidate
+
 	IgnoreCase bool
 	// OASMethod stores the HTTP method for OAS-specific middleware
 	// This is needed because OAS operations are method-specific
@@ -48,6 +58,23 @@ type URLSpec struct {
 	// OASPath stores the original OAS path pattern (e.g., "/users/{id}")
 	// This is used for matching against the OAS router when needed
 	OASPath string
+}
+
+// ValidateRequestCandidate represents one OAS endpoint that maps to the same
+// compiled regex pattern. Used for disambiguation when multiple parameterized
+// paths collapse to the same regex (e.g., /employees/{prct} and /employees/{zd}).
+type ValidateRequestCandidate struct {
+	OASValidateRequestMeta *oas.ValidateRequest
+	OASMethod              string
+	OASPath                string
+}
+
+// MockResponseCandidate represents one OAS endpoint that maps to the same
+// compiled regex pattern for mock response disambiguation.
+type MockResponseCandidate struct {
+	OASMockResponseMeta *oas.MockResponse
+	OASMethod           string
+	OASPath             string
 }
 
 // modeSpecificSpec returns the respective field of URLSpec if it matches the given mode.

--- a/gateway/mw_mock_response.go
+++ b/gateway/mw_mock_response.go
@@ -103,7 +103,9 @@ func (m *mockResponseMiddleware) mockResponse(r *http.Request) (*http.Response, 
 		return nil, nil
 	}
 
-	mockResponse := urlSpec.OASMockResponseMeta
+	// Resolve the mock response config and OAS path. When multiple candidates
+	// exist (collapsed parameterized paths), disambiguate using path param schemas.
+	mockResponse, oasPath := m.resolveMockCandidate(r, urlSpec)
 	if mockResponse == nil || !mockResponse.Enabled {
 		return nil, nil
 	}
@@ -120,9 +122,9 @@ func (m *mockResponseMiddleware) mockResponse(r *http.Request) (*http.Response, 
 		// Find the route using the OAS path from URLSpec, not the actual request path.
 		// This allows prefix/suffix matching to work correctly.
 		strippedPath := m.Spec.StripListenPath(r.URL.Path)
-		route, _, routeErr := m.Spec.findRouteForOASPath(urlSpec.OASPath, urlSpec.OASMethod, strippedPath, r.URL.Path)
+		route, _, routeErr := m.Spec.findRouteForOASPath(oasPath, urlSpec.OASMethod, strippedPath, r.URL.Path)
 		if routeErr != nil || route == nil {
-			log.Tracef("URL spec matched for mock response but route not found for OAS path %s: %v", urlSpec.OASPath, routeErr)
+			log.Tracef("URL spec matched for mock response but route not found for OAS path %s: %v", oasPath, routeErr)
 			return nil, nil
 		}
 		code, contentType, body, headers, err = mockFromOAS(r, route.Operation, mockResponse.FromOASExamples)
@@ -150,6 +152,30 @@ func (m *mockResponseMiddleware) mockResponse(r *http.Request) (*http.Response, 
 	m.Spec.sendRateLimitHeaders(ctxGetSession(r), res)
 
 	return res, nil
+}
+
+// resolveMockCandidate returns the mock response config and OAS path to use.
+// When the URLSpec has collapsed candidates, it disambiguates using matchCandidatePath.
+// When there are no candidates, it returns the URLSpec's own config.
+func (m *mockResponseMiddleware) resolveMockCandidate(r *http.Request, urlSpec *URLSpec) (*oas.MockResponse, string) {
+	if len(urlSpec.OASMockResponseCandidates) == 0 {
+		return urlSpec.OASMockResponseMeta, urlSpec.OASPath
+	}
+
+	strippedPath := m.Spec.StripListenPath(r.URL.Path)
+
+	for _, candidate := range urlSpec.OASMockResponseCandidates {
+		if candidate.OASMockResponseMeta == nil || !candidate.OASMockResponseMeta.Enabled {
+			continue
+		}
+
+		if _, _, _, ok := m.Spec.matchCandidatePath(candidate.OASPath, candidate.OASMethod, strippedPath); ok {
+			return candidate.OASMockResponseMeta, candidate.OASPath
+		}
+	}
+
+	// No candidate matched — don't mock.
+	return nil, ""
 }
 
 func mockFromConfig(tykMockRespOp *oas.MockResponse) (int, []byte, []oas.Header) {

--- a/gateway/mw_mock_response_collapsed_test.go
+++ b/gateway/mw_mock_response_collapsed_test.go
@@ -1,0 +1,291 @@
+package gateway
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/test"
+)
+
+// TestMockResponseCollapsedParamsByType tests that two parameterized paths with
+// different mock responses are disambiguated by path parameter type.
+// /employees/{id} (type:integer) should return "numeric" mock,
+// /employees/{name} (type:string, pattern:^[a-z]+$) should return "alpha" mock.
+func TestMockResponseCollapsedParamsByType(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getById",
+			Parameters: openapi3.Parameters{
+				{Value: &openapi3.Parameter{
+					Name: "id", In: "path", Required: true,
+					Schema: &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"integer"}}},
+				}},
+			},
+			Responses: openapi3.NewResponses(openapi3.WithStatus(200, &openapi3.ResponseRef{
+				Value: &openapi3.Response{Description: stringPtrHelper("OK")},
+			})),
+		},
+	})
+
+	paths.Set("/employees/{name}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByName",
+			Parameters: openapi3.Parameters{
+				{Value: &openapi3.Parameter{
+					Name: "name", In: "path", Required: true,
+					Schema: &openapi3.SchemaRef{Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"}, Pattern: `^[a-z]+$`,
+					}},
+				}},
+			},
+			Responses: openapi3.NewResponses(openapi3.WithStatus(200, &openapi3.ResponseRef{
+				Value: &openapi3.Response{Description: stringPtrHelper("OK")},
+			})),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Mock Collapsed By Type", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getById": {
+					MockResponse: &oas.MockResponse{Enabled: true, Code: 200, Body: `{"source":"numeric"}`},
+				},
+				"getByName": {
+					MockResponse: &oas.MockResponse{Enabled: true, Code: 200, Body: `{"source":"alpha"}`},
+				},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Mock Collapsed By Type"
+		spec.APIID = "mock-collapsed-type"
+		spec.Proxy.ListenPath = "/test-mock-type/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			// 42 is an integer -> should return "numeric" mock
+			Method:    http.MethodGet,
+			Path:      "/test-mock-type/employees/42",
+			Code:      http.StatusOK,
+			BodyMatch: `"source":"numeric"`,
+		},
+		{
+			// "alice" matches ^[a-z]+$ -> should return "alpha" mock
+			Method:    http.MethodGet,
+			Path:      "/test-mock-type/employees/alice",
+			Code:      http.StatusOK,
+			BodyMatch: `"source":"alpha"`,
+		},
+	}...)
+}
+
+// TestMockResponseCollapsedParamsByPattern tests that two string-typed parameterized
+// paths with different patterns return the correct mock response.
+func TestMockResponseCollapsedParamsByPattern(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/{code}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByCode",
+			Parameters: openapi3.Parameters{
+				{Value: &openapi3.Parameter{
+					Name: "code", In: "path", Required: true,
+					Schema: &openapi3.SchemaRef{Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"}, Pattern: `^[A-Z]{3}$`,
+					}},
+				}},
+			},
+			Responses: openapi3.NewResponses(openapi3.WithStatus(200, &openapi3.ResponseRef{
+				Value: &openapi3.Response{Description: stringPtrHelper("OK")},
+			})),
+		},
+	})
+
+	paths.Set("/employees/{slug}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getBySlug",
+			Parameters: openapi3.Parameters{
+				{Value: &openapi3.Parameter{
+					Name: "slug", In: "path", Required: true,
+					Schema: &openapi3.SchemaRef{Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+					}},
+				}},
+			},
+			Responses: openapi3.NewResponses(openapi3.WithStatus(200, &openapi3.ResponseRef{
+				Value: &openapi3.Response{Description: stringPtrHelper("OK")},
+			})),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Mock Collapsed By Pattern", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getByCode": {
+					MockResponse: &oas.MockResponse{Enabled: true, Code: 200, Body: `{"source":"code"}`},
+				},
+				"getBySlug": {
+					MockResponse: &oas.MockResponse{Enabled: true, Code: 200, Body: `{"source":"slug"}`},
+				},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Mock Collapsed By Pattern"
+		spec.APIID = "mock-collapsed-pattern"
+		spec.Proxy.ListenPath = "/test-mock-pattern/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			// "ABC" matches ^[A-Z]{3}$ -> should return "code" mock
+			Method:    http.MethodGet,
+			Path:      "/test-mock-pattern/employees/ABC",
+			Code:      http.StatusOK,
+			BodyMatch: `"source":"code"`,
+		},
+		{
+			// "hello" doesn't match ^[A-Z]{3}$ -> falls to unconstrained string -> "slug" mock
+			Method:    http.MethodGet,
+			Path:      "/test-mock-pattern/employees/hello",
+			Code:      http.StatusOK,
+			BodyMatch: `"source":"slug"`,
+		},
+	}...)
+}
+
+// TestMockResponseCollapsedWithStaticPath tests that the static path shield still
+// works when two parameterized paths collapse to the same regex with different mocks.
+func TestMockResponseCollapsedWithStaticPath(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getById",
+			Parameters: openapi3.Parameters{
+				{Value: &openapi3.Parameter{
+					Name: "id", In: "path", Required: true,
+					Schema: &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"integer"}}},
+				}},
+			},
+			Responses: openapi3.NewResponses(openapi3.WithStatus(200, &openapi3.ResponseRef{
+				Value: &openapi3.Response{Description: stringPtrHelper("OK")},
+			})),
+		},
+	})
+
+	paths.Set("/employees/{slug}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getBySlug",
+			Parameters: openapi3.Parameters{
+				{Value: &openapi3.Parameter{
+					Name: "slug", In: "path", Required: true,
+					Schema: &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"string"}}},
+				}},
+			},
+			Responses: openapi3.NewResponses(openapi3.WithStatus(200, &openapi3.ResponseRef{
+				Value: &openapi3.Response{Description: stringPtrHelper("OK")},
+			})),
+		},
+	})
+
+	paths.Set("/employees/static", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getStatic",
+			Responses: openapi3.NewResponses(openapi3.WithStatus(200, &openapi3.ResponseRef{
+				Value: &openapi3.Response{Description: stringPtrHelper("OK")},
+			})),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Mock Collapsed With Static", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getById": {
+					MockResponse: &oas.MockResponse{Enabled: true, Code: 200, Body: `{"source":"numeric"}`},
+				},
+				"getBySlug": {
+					MockResponse: &oas.MockResponse{Enabled: true, Code: 200, Body: `{"source":"slug"}`},
+				},
+				"getStatic": {},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Mock Collapsed With Static"
+		spec.APIID = "mock-collapsed-static"
+		spec.Proxy.ListenPath = "/test-mock-static/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			// Static path — no mock, proxies to upstream
+			Method:       http.MethodGet,
+			Path:         "/test-mock-static/employees/static",
+			Code:         http.StatusOK,
+			BodyNotMatch: `"source"`,
+		},
+		{
+			// 42 is integer -> "numeric" mock
+			Method:    http.MethodGet,
+			Path:      "/test-mock-static/employees/42",
+			Code:      http.StatusOK,
+			BodyMatch: `"source":"numeric"`,
+		},
+		{
+			// "hello" -> falls to unconstrained string -> "slug" mock
+			Method:    http.MethodGet,
+			Path:      "/test-mock-static/employees/hello",
+			Code:      http.StatusOK,
+			BodyMatch: `"source":"slug"`,
+		},
+	}...)
+}

--- a/gateway/mw_oas_validate_request.go
+++ b/gateway/mw_oas_validate_request.go
@@ -4,15 +4,20 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/openapi3filter"
+	"github.com/getkin/kin-openapi/routers"
 	"github.com/sirupsen/logrus"
 
+	"github.com/TykTechnologies/tyk/apidef/oas"
 	"github.com/TykTechnologies/tyk/header"
 	"github.com/TykTechnologies/tyk/internal/httputil"
+
+	tykregexp "github.com/TykTechnologies/tyk/regexp"
 )
 
 var (
@@ -98,6 +103,13 @@ func (k *ValidateRequest) ProcessRequest(w http.ResponseWriter, r *http.Request,
 		return nil, http.StatusOK
 	}
 
+	// If this URLSpec has multiple candidates (collapsed parameterized paths),
+	// disambiguate using path parameter schema validation.
+	if len(urlSpec.OASValidateRequestCandidates) > 0 {
+		code, err := k.processRequestWithCandidates(r, urlSpec)
+		return err, code
+	}
+
 	validateRequest := urlSpec.OASValidateRequestMeta
 	if validateRequest == nil || !validateRequest.Enabled {
 		return nil, http.StatusOK
@@ -145,6 +157,196 @@ func (k *ValidateRequest) ProcessRequest(w http.ResponseWriter, r *http.Request,
 
 	// Handle Success
 	return nil, http.StatusOK
+}
+
+// processRequestWithCandidates handles validation when multiple OAS endpoints collapse
+// to the same regex pattern (e.g., /employees/{prct} and /employees/{zd} both become
+// /employees/([^/]+)). Candidates are sorted most-restrictive-first. For each candidate:
+//   - Phase 1: check if the path parameter values satisfy the candidate's path param schemas.
+//   - Phase 2: if path params match, commit to this candidate and run full validation.
+//     Do NOT fall through to less restrictive candidates.
+//
+// This prevents a catch-all type:string candidate from stealing requests that belong to
+// a more restrictive type:number candidate.
+func (k *ValidateRequest) processRequestWithCandidates(r *http.Request, urlSpec *URLSpec) (int, error) {
+	normalizeHeaders(r.Header)
+	strippedPath := k.Spec.StripListenPath(r.URL.Path)
+
+	for _, candidate := range urlSpec.OASValidateRequestCandidates {
+		if candidate.OASValidateRequestMeta == nil || !candidate.OASValidateRequestMeta.Enabled {
+			continue
+		}
+
+		route, pathParams, ok := k.resolveCandidate(candidate, strippedPath)
+		if !ok {
+			continue
+		}
+
+		// Path params matched — commit to this candidate and return regardless of outcome.
+		return k.validateRoute(r, route, pathParams, candidate.OASValidateRequestMeta)
+	}
+
+	return candidatesErrorResponseCode(urlSpec.OASValidateRequestCandidates),
+		fmt.Errorf("request validation error: path parameter doesn't match any endpoint")
+}
+
+// resolveCandidate uses matchCandidatePath to check if the candidate's path param
+// schemas match the request, then builds a routers.Route for full validation.
+func (k *ValidateRequest) resolveCandidate(candidate ValidateRequestCandidate, strippedPath string) (*routers.Route, map[string]string, bool) {
+	pathItem, operation, pathParams, ok := k.Spec.matchCandidatePath(candidate.OASPath, candidate.OASMethod, strippedPath)
+	if !ok {
+		return nil, nil, false
+	}
+
+	route := &routers.Route{
+		Spec:      &k.Spec.OAS.T,
+		Path:      candidate.OASPath,
+		PathItem:  pathItem,
+		Method:    candidate.OASMethod,
+		Operation: operation,
+	}
+	return route, pathParams, true
+}
+
+// validateRoute runs openapi3filter.ValidateRequest against a resolved route and returns
+// the appropriate error/status pair.
+func (k *ValidateRequest) validateRoute(r *http.Request, route *routers.Route, pathParams map[string]string, meta *oas.ValidateRequest) (int, error) {
+	errResponseCode := http.StatusUnprocessableEntity
+	if meta != nil && meta.ErrorResponseCode != 0 {
+		errResponseCode = meta.ErrorResponseCode
+	}
+
+	input := &openapi3filter.RequestValidationInput{
+		Request:    r,
+		PathParams: pathParams,
+		Route:      route,
+		Options: &openapi3filter.Options{
+			AuthenticationFunc: func(ctx context.Context, input *openapi3filter.AuthenticationInput) error {
+				return nil
+			},
+		},
+	}
+
+	if err := openapi3filter.ValidateRequest(r.Context(), input); err != nil {
+		return errResponseCode, fmt.Errorf("request validation error: %w", err)
+	}
+	return http.StatusOK, nil
+}
+
+// candidatesErrorResponseCode returns the error response code from the first enabled
+// candidate that has a custom code configured, defaulting to 422.
+func candidatesErrorResponseCode(candidates []ValidateRequestCandidate) int {
+	for _, c := range candidates {
+		if c.OASValidateRequestMeta != nil && c.OASValidateRequestMeta.ErrorResponseCode != 0 {
+			return c.OASValidateRequestMeta.ErrorResponseCode
+		}
+	}
+	return http.StatusUnprocessableEntity
+}
+
+// pathParamsMatchOperation checks whether the given path parameter values satisfy
+// the path parameter schemas defined in the OAS operation. This is used as a quick
+// pre-filter before committing to full request validation.
+func pathParamsMatchOperation(pathParams map[string]string, operation *openapi3.Operation) bool {
+	for _, paramRef := range operation.Parameters {
+		if paramRef == nil || paramRef.Value == nil || paramRef.Value.In != "path" {
+			continue
+		}
+		param := paramRef.Value
+		if param.Schema == nil || param.Schema.Value == nil {
+			continue
+		}
+
+		value, exists := pathParams[param.Name]
+		if !exists {
+			return false
+		}
+
+		if !valueMatchesSchema(value, param.Schema.Value) {
+			return false
+		}
+	}
+	return true
+}
+
+// valueMatchesSchema checks if a path parameter string value satisfies the schema's
+// type, pattern, and enum constraints. This mirrors kin-openapi's parsing behavior
+// for path parameters.
+func valueMatchesSchema(value string, s *openapi3.Schema) bool {
+	// Check type constraints.
+	if s.Type != nil {
+		if s.Type.Is("integer") {
+			if _, err := strconv.ParseInt(value, 10, 64); err != nil {
+				return false
+			}
+		} else if s.Type.Is("number") {
+			if _, err := strconv.ParseFloat(value, 64); err != nil {
+				return false
+			}
+		} else if s.Type.Is("boolean") {
+			if _, err := strconv.ParseBool(value); err != nil {
+				return false
+			}
+		}
+	}
+
+	// Check pattern constraint.
+	if s.Pattern != "" {
+		matched, err := tykregexp.MatchString(s.Pattern, value)
+		if err != nil || !matched {
+			return false
+		}
+	}
+
+	// Check enum constraint.
+	if len(s.Enum) > 0 {
+		found := false
+		for _, e := range s.Enum {
+			if fmt.Sprintf("%v", e) == value {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	// Check minLength/maxLength constraints.
+	if s.MinLength != 0 && uint64(len(value)) < s.MinLength {
+		return false
+	}
+	if s.MaxLength != nil && uint64(len(value)) > *s.MaxLength {
+		return false
+	}
+
+	// Check format constraint.
+	if s.Format != "" && !valueMatchesFormat(value, s.Format) {
+		return false
+	}
+
+	return true
+}
+
+// valueMatchesFormat checks if a string value satisfies the given OAS format constraint.
+func valueMatchesFormat(value, format string) bool {
+	switch format {
+	case "date":
+		_, err := time.Parse(time.DateOnly, value)
+		return err == nil
+	case "date-time":
+		_, err := time.Parse(time.RFC3339, value)
+		return err == nil
+	case "email":
+		return strings.Contains(value, "@")
+	case "uuid":
+		// UUID: 8-4-4-4-12 hex chars
+		matched, err := tykregexp.MatchString(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`, value)
+		return err == nil && matched
+	default:
+		// Unknown format — don't reject, let full validation handle it.
+		return true
+	}
 }
 
 // processRequestWithFindOperation is the original implementation that uses findOperation

--- a/gateway/mw_oas_validate_request_path_priority_test.go
+++ b/gateway/mw_oas_validate_request_path_priority_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/regexp"
 	"github.com/TykTechnologies/tyk/test"
 )
 
@@ -254,6 +255,451 @@ func TestMockResponseStaticPathPriority(t *testing.T) {
 			BodyMatch: "mocked",
 		},
 	}...)
+}
+
+func TestSameBasePathDifferentParamSchemas(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	// First endpoint: /employees/{prct} where prct must match ^[a-z]$, requires header "def"
+	paths.Set("/employees/{prct}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getEmployeeByPrct",
+			Parameters: openapi3.Parameters{
+				{
+					Value: &openapi3.Parameter{
+						Name: "prct", In: "path", Required: true,
+						Schema: &openapi3.SchemaRef{
+							Value: &openapi3.Schema{
+								Type:    &openapi3.Types{"string"},
+								Pattern: "^[a-z]$",
+							},
+						},
+					},
+				},
+				{
+					Value: &openapi3.Parameter{
+						Name: "def", In: "header", Required: true,
+						Schema: &openapi3.SchemaRef{
+							Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
+						},
+					},
+				},
+			},
+			Responses: openapi3.NewResponses(
+				openapi3.WithStatus(200, &openapi3.ResponseRef{
+					Value: &openapi3.Response{Description: stringPtrHelper("Success")},
+				}),
+			),
+		},
+	})
+
+	// Second endpoint: /employees/{zd} where zd must match [1-9], requires header "abc"
+	paths.Set("/employees/{zd}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getEmployeeByZd",
+			Parameters: openapi3.Parameters{
+				{
+					Value: &openapi3.Parameter{
+						Name: "zd", In: "path", Required: true,
+						Schema: &openapi3.SchemaRef{
+							Value: &openapi3.Schema{
+								Type:    &openapi3.Types{"string"},
+								Pattern: "[1-9]",
+							},
+						},
+					},
+				},
+				{
+					Value: &openapi3.Parameter{
+						Name: "abc", In: "header", Required: true,
+						Schema: &openapi3.SchemaRef{
+							Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
+						},
+					},
+				},
+			},
+			Responses: openapi3.NewResponses(
+				openapi3.WithStatus(200, &openapi3.ResponseRef{
+					Value: &openapi3.Response{Description: stringPtrHelper("Success")},
+				}),
+			),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Same Base Path Test", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getEmployeeByPrct": {
+					ValidateRequest: &oas.ValidateRequest{Enabled: true},
+				},
+				"getEmployeeByZd": {
+					ValidateRequest: &oas.ValidateRequest{Enabled: true},
+				},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Same Base Path API"
+		spec.APIID = "same-base-path"
+		spec.Proxy.ListenPath = "/api/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			// /employees/a matches {prct} (^[a-z]$), with correct header "def" -> 200
+			Method:  http.MethodGet,
+			Path:    "/api/employees/a",
+			Headers: map[string]string{"def": "value"},
+			Code:    http.StatusOK,
+		},
+		{
+			// /employees/5 matches {zd} ([1-9]), with correct header "abc" -> 200
+			Method:  http.MethodGet,
+			Path:    "/api/employees/5",
+			Headers: map[string]string{"abc": "value"},
+			Code:    http.StatusOK,
+		},
+		{
+			// /employees/a matches {prct} but missing required header "def" -> 422
+			Method: http.MethodGet,
+			Path:   "/api/employees/a",
+			Code:   http.StatusUnprocessableEntity,
+		},
+		{
+			// /employees/5 matches {zd} but missing required header "abc" -> 422
+			Method: http.MethodGet,
+			Path:   "/api/employees/5",
+			Code:   http.StatusUnprocessableEntity,
+		},
+		{
+			// /employees/!!! matches neither param schema -> 422
+			Method: http.MethodGet,
+			Path:   "/api/employees/!!!",
+			Code:   http.StatusUnprocessableEntity,
+		},
+	}...)
+}
+
+// TestDualValidateRequestWithStaticPath mirrors the python integration test
+// test_dual_validate_request_on_overlapping_parameterized: two parameterized paths
+// with validateRequest plus a static path without validateRequest.
+func TestDualValidateRequestWithStaticPath(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getById",
+			Parameters: openapi3.Parameters{
+				{Value: &openapi3.Parameter{
+					Name: "id", In: "path", Required: true,
+					Schema: &openapi3.SchemaRef{Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"}, Pattern: `^\d+$`,
+					}},
+				}},
+				{Value: &openapi3.Parameter{
+					Name: "X-Id-Header", In: "header", Required: true,
+					Schema: &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"string"}}},
+				}},
+			},
+			Responses: openapi3.NewResponses(openapi3.WithStatus(200, &openapi3.ResponseRef{
+				Value: &openapi3.Response{Description: stringPtrHelper("Success")},
+			})),
+		},
+	})
+
+	paths.Set("/employees/{name}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByName",
+			Parameters: openapi3.Parameters{
+				{Value: &openapi3.Parameter{
+					Name: "name", In: "path", Required: true,
+					Schema: &openapi3.SchemaRef{Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"}, Pattern: `^[a-z]+$`,
+					}},
+				}},
+				{Value: &openapi3.Parameter{
+					Name: "X-Name-Header", In: "header", Required: true,
+					Schema: &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"string"}}},
+				}},
+			},
+			Responses: openapi3.NewResponses(openapi3.WithStatus(200, &openapi3.ResponseRef{
+				Value: &openapi3.Response{Description: stringPtrHelper("Success")},
+			})),
+		},
+	})
+
+	paths.Set("/employees/static", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getStatic",
+			Responses: openapi3.NewResponses(openapi3.WithStatus(200, &openapi3.ResponseRef{
+				Value: &openapi3.Response{Description: stringPtrHelper("Success")},
+			})),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Dual VR + Static Test", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getById":   {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 400}},
+				"getByName": {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 422}},
+				"getStatic": {},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Dual VR Static API"
+		spec.APIID = "dual-vr-static"
+		spec.Proxy.ListenPath = "/api/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			// Static path — no validateRequest, should pass through
+			Method: http.MethodGet,
+			Path:   "/api/employees/static",
+			Code:   http.StatusOK,
+		},
+		{
+			// "123" matches ^\d+$ ({id}), no X-Id-Header -> 400
+			Method: http.MethodGet,
+			Path:   "/api/employees/123",
+			Code:   http.StatusBadRequest,
+		},
+		{
+			// "123" matches ^\d+$ ({id}), with both headers -> 200
+			Method:  http.MethodGet,
+			Path:    "/api/employees/123",
+			Headers: map[string]string{"X-Id-Header": "v", "X-Name-Header": "v"},
+			Code:    http.StatusOK,
+		},
+		{
+			// "abc" matches ^[a-z]+$ ({name}), no X-Name-Header -> 422
+			Method: http.MethodGet,
+			Path:   "/api/employees/abc",
+			Code:   http.StatusUnprocessableEntity,
+		},
+		{
+			// "abc" matches ^[a-z]+$ ({name}), with header -> 200
+			Method:  http.MethodGet,
+			Path:    "/api/employees/abc",
+			Headers: map[string]string{"X-Name-Header": "v"},
+			Code:    http.StatusOK,
+		},
+	}...)
+}
+
+// TestSameBasePathStringCatchAll reproduces the exampleOas.yaml scenario where
+// type:string (no pattern) sorts alphabetically BEFORE type:number, proving that
+// the string candidate steals numeric path values.
+func TestSameBasePathStringCatchAll(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	// /employees/{prct} — type:string (catch-all), requires header "def"
+	// Alphabetically {prct} < {zd}, so this candidate is tried first.
+	paths.Set("/employees/{prct}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getEmployeeByPrct",
+			Parameters: openapi3.Parameters{
+				{
+					Value: &openapi3.Parameter{
+						Name: "prct", In: "path", Required: true,
+						Schema: &openapi3.SchemaRef{
+							Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
+						},
+					},
+				},
+				{
+					Value: &openapi3.Parameter{
+						Name: "def", In: "header", Required: true,
+						Schema: &openapi3.SchemaRef{
+							Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
+						},
+					},
+				},
+			},
+			Responses: openapi3.NewResponses(
+				openapi3.WithStatus(200, &openapi3.ResponseRef{
+					Value: &openapi3.Response{Description: stringPtrHelper("Success")},
+				}),
+			),
+		},
+	})
+
+	// /employees/{zd} — type:number, requires header "abc"
+	// Alphabetically {zd} > {prct}, so this candidate is tried second.
+	paths.Set("/employees/{zd}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getEmployeeByZd",
+			Parameters: openapi3.Parameters{
+				{
+					Value: &openapi3.Parameter{
+						Name: "zd", In: "path", Required: true,
+						Schema: &openapi3.SchemaRef{
+							Value: &openapi3.Schema{Type: &openapi3.Types{"number"}},
+						},
+					},
+				},
+				{
+					Value: &openapi3.Parameter{
+						Name: "abc", In: "header", Required: true,
+						Schema: &openapi3.SchemaRef{
+							Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
+						},
+					},
+				},
+			},
+			Responses: openapi3.NewResponses(
+				openapi3.WithStatus(200, &openapi3.ResponseRef{
+					Value: &openapi3.Response{Description: stringPtrHelper("Success")},
+				}),
+			),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "String Catch-All Test", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getEmployeeByPrct": {
+					ValidateRequest: &oas.ValidateRequest{Enabled: true},
+				},
+				"getEmployeeByZd": {
+					ValidateRequest: &oas.ValidateRequest{Enabled: true},
+				},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "String Catch-All API"
+		spec.APIID = "string-catch-all"
+		spec.Proxy.ListenPath = "/api/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			// /employees/5 with header "abc" should match {zd} (type:number) -> 200
+			// BUG: {prct} (type:string) is tried first alphabetically,
+			// "5" is a valid string, but header "def" is missing -> fails,
+			// then {zd} is tried -> passes. This case works by accident.
+			Method:  http.MethodGet,
+			Path:    "/api/employees/5",
+			Headers: map[string]string{"abc": "value"},
+			Code:    http.StatusOK,
+		},
+		{
+			// /employees/5 with header "def" should ideally NOT match {prct}
+			// since "5" is a number and {zd} is the number endpoint.
+			// BUG: {prct} (type:string) is tried first, "5" is a valid string,
+			// header "def" is present -> validation passes -> 200 on WRONG endpoint.
+			// This should match {zd} which requires header "abc", not "def".
+			Method:  http.MethodGet,
+			Path:    "/api/employees/5",
+			Headers: map[string]string{"def": "value"},
+			Code:    http.StatusUnprocessableEntity,
+		},
+	}...)
+}
+
+func TestGroupCollapsedValidateRequestSpecs(t *testing.T) {
+	makeSpec := func(path, method, regex string) URLSpec {
+		return URLSpec{
+			Status:                 OASValidateRequest,
+			OASValidateRequestMeta: &oas.ValidateRequest{Enabled: true},
+			OASMethod:              method,
+			OASPath:                path,
+			spec:                   regexp.MustCompile(regex),
+		}
+	}
+
+	t.Run("no collision leaves specs unchanged", func(t *testing.T) {
+		specs := []URLSpec{
+			makeSpec("/users/{id}", "GET", `^/users/([^/]+)$`),
+			makeSpec("/items/{id}", "GET", `^/items/([^/]+)$`),
+		}
+		result := groupCollapsedValidateRequestSpecs(specs, nil)
+		assert.Len(t, result, 2)
+		assert.Nil(t, result[0].OASValidateRequestCandidates)
+		assert.Nil(t, result[1].OASValidateRequestCandidates)
+	})
+
+	t.Run("same regex same method groups into candidates", func(t *testing.T) {
+		specs := []URLSpec{
+			makeSpec("/employees/{prct}", "GET", `^/employees/([^/]+)$`),
+			makeSpec("/employees/{zd}", "GET", `^/employees/([^/]+)$`),
+		}
+		result := groupCollapsedValidateRequestSpecs(specs, nil)
+		assert.Len(t, result, 1)
+		assert.Len(t, result[0].OASValidateRequestCandidates, 2)
+		// Candidates are sorted by OASPath
+		assert.Equal(t, "/employees/{prct}", result[0].OASValidateRequestCandidates[0].OASPath)
+		assert.Equal(t, "/employees/{zd}", result[0].OASValidateRequestCandidates[1].OASPath)
+	})
+
+	t.Run("same regex different methods are not grouped", func(t *testing.T) {
+		specs := []URLSpec{
+			makeSpec("/employees/{id}", "GET", `^/employees/([^/]+)$`),
+			makeSpec("/employees/{id}", "POST", `^/employees/([^/]+)$`),
+		}
+		result := groupCollapsedValidateRequestSpecs(specs, nil)
+		assert.Len(t, result, 2)
+		assert.Nil(t, result[0].OASValidateRequestCandidates)
+		assert.Nil(t, result[1].OASValidateRequestCandidates)
+	})
+
+	t.Run("three specs with same regex and method all grouped", func(t *testing.T) {
+		specs := []URLSpec{
+			makeSpec("/employees/{a}", "GET", `^/employees/([^/]+)$`),
+			makeSpec("/employees/{b}", "GET", `^/employees/([^/]+)$`),
+			makeSpec("/employees/{c}", "GET", `^/employees/([^/]+)$`),
+		}
+		result := groupCollapsedValidateRequestSpecs(specs, nil)
+		assert.Len(t, result, 1)
+		assert.Len(t, result[0].OASValidateRequestCandidates, 3)
+		assert.Equal(t, "/employees/{a}", result[0].OASValidateRequestCandidates[0].OASPath)
+		assert.Equal(t, "/employees/{b}", result[0].OASValidateRequestCandidates[1].OASPath)
+		assert.Equal(t, "/employees/{c}", result[0].OASValidateRequestCandidates[2].OASPath)
+	})
 }
 
 func TestStaticPathPriorityWithPrefixMatching(t *testing.T) {

--- a/gateway/mw_oas_validate_request_scenarios_test.go
+++ b/gateway/mw_oas_validate_request_scenarios_test.go
@@ -1,0 +1,2524 @@
+package gateway
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/test"
+)
+
+// helper to build a standard openapi3 response set for 200.
+func oasResponse200() *openapi3.Responses {
+	return openapi3.NewResponses(
+		openapi3.WithStatus(200, &openapi3.ResponseRef{
+			Value: &openapi3.Response{Description: stringPtrHelper("Success")},
+		}),
+	)
+}
+
+// helper to build a path parameter.
+func pathParam(name string, schema *openapi3.Schema) *openapi3.ParameterRef {
+	return &openapi3.ParameterRef{
+		Value: &openapi3.Parameter{
+			Name: name, In: "path", Required: true,
+			Schema: &openapi3.SchemaRef{Value: schema},
+		},
+	}
+}
+
+// helper to build a required header parameter.
+func headerParam(name string) *openapi3.ParameterRef {
+	return &openapi3.ParameterRef{
+		Value: &openapi3.Parameter{
+			Name: name, In: "header", Required: true,
+			Schema: &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"string"}}},
+		},
+	}
+}
+
+func TestScenario9_NestedParameterizedRoutes(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/departments/{dept}/employees/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getNestedParam",
+			Parameters: openapi3.Parameters{
+				pathParam("dept", &openapi3.Schema{Type: &openapi3.Types{"string"}}),
+				pathParam("id", &openapi3.Schema{Type: &openapi3.Types{"string"}}),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/departments/{dept}/employees/static", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getNestedStatic",
+			Parameters: openapi3.Parameters{
+				pathParam("dept", &openapi3.Schema{Type: &openapi3.Types{"string"}}),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 9", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getNestedParam": {
+					MockResponse: &oas.MockResponse{Enabled: true, Code: 200, Body: `{"message": "nested-param"}`},
+				},
+				"getNestedStatic": {
+					MockResponse: &oas.MockResponse{Enabled: true, Code: 200, Body: `{"message": "nested-static"}`},
+				},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 9 API"
+		spec.APIID = "scenario-9"
+		spec.Proxy.ListenPath = "/test-9/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			Method:    http.MethodGet,
+			Path:      "/test-9/departments/sales/employees/static",
+			Code:      http.StatusOK,
+			BodyMatch: "nested-static",
+		},
+		{
+			Method:    http.MethodGet,
+			Path:      "/test-9/departments/sales/employees/42",
+			Code:      http.StatusOK,
+			BodyMatch: "nested-param",
+		},
+	}...)
+}
+
+func TestScenario10_CrossMethodNoInterference(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getEmployeeById",
+			Parameters: openapi3.Parameters{
+				pathParam("id", &openapi3.Schema{Type: &openapi3.Types{"string"}}),
+				headerParam("X-Get-Header"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/employees/static", &openapi3.PathItem{
+		Post: &openapi3.Operation{
+			OperationID: "postStaticEmployee",
+			Responses:   oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 10", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getEmployeeById": {
+					ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 422},
+				},
+				"postStaticEmployee": {},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 10 API"
+		spec.APIID = "scenario-10"
+		spec.Proxy.ListenPath = "/test-10/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			Method: http.MethodPost,
+			Path:   "/test-10/employees/static",
+			Code:   http.StatusOK,
+		},
+		{
+			Method: http.MethodGet,
+			Path:   "/test-10/employees/123",
+			Code:   http.StatusUnprocessableEntity,
+		},
+	}...)
+}
+
+func TestScenario11_MultipleStaticPathsShielded(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/users/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getUserById",
+			Parameters: openapi3.Parameters{
+				pathParam("id", &openapi3.Schema{Type: &openapi3.Types{"string"}}),
+				headerParam("X-Auth"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	for _, static := range []struct {
+		path string
+		opID string
+	}{
+		{"/users/admin", "getUserAdmin"},
+		{"/users/me", "getUserMe"},
+		{"/users/status", "getUserStatus"},
+	} {
+		paths.Set(static.path, &openapi3.PathItem{
+			Get: &openapi3.Operation{
+				OperationID: static.opID,
+				Responses:   oasResponse200(),
+			},
+		})
+	}
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 11", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getUserById": {
+					ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 422},
+				},
+				"getUserAdmin":  {},
+				"getUserMe":     {},
+				"getUserStatus": {},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 11 API"
+		spec.APIID = "scenario-11"
+		spec.Proxy.ListenPath = "/test-11/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{Method: http.MethodGet, Path: "/test-11/users/admin", Code: http.StatusOK},
+		{Method: http.MethodGet, Path: "/test-11/users/me", Code: http.StatusOK},
+		{Method: http.MethodGet, Path: "/test-11/users/status", Code: http.StatusOK},
+		{Method: http.MethodGet, Path: "/test-11/users/42", Code: http.StatusUnprocessableEntity},
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-11/users/42",
+			Headers: map[string]string{"X-Auth": "val"},
+			Code:    http.StatusOK,
+		},
+	}...)
+}
+
+func TestScenario12_NonConflictingStaticPathUnaffected(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/users/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getUserById",
+			Parameters: openapi3.Parameters{
+				pathParam("id", &openapi3.Schema{Type: &openapi3.Types{"string"}}),
+				headerParam("X-Auth"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/health", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getHealth",
+			Responses:   oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 12", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getUserById": {
+					ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 422},
+				},
+				"getHealth": {},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 12 API"
+		spec.APIID = "scenario-12"
+		spec.Proxy.ListenPath = "/test-12/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{Method: http.MethodGet, Path: "/test-12/health", Code: http.StatusOK},
+		{Method: http.MethodGet, Path: "/test-12/users/42", Code: http.StatusUnprocessableEntity},
+	}...)
+}
+
+func TestScenario14_POSTWithRequestBodySchemaValidation(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/{id}", &openapi3.PathItem{
+		Post: &openapi3.Operation{
+			OperationID: "postEmployeeById",
+			Parameters: openapi3.Parameters{
+				pathParam("id", &openapi3.Schema{Type: &openapi3.Types{"string"}}),
+			},
+			RequestBody: &openapi3.RequestBodyRef{
+				Value: &openapi3.RequestBody{
+					Required: true,
+					Content: openapi3.NewContentWithJSONSchema(&openapi3.Schema{
+						Type:     &openapi3.Types{"object"},
+						Required: []string{"name"},
+						Properties: openapi3.Schemas{
+							"name": &openapi3.SchemaRef{
+								Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
+							},
+						},
+					}),
+				},
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/employees/static", &openapi3.PathItem{
+		Post: &openapi3.Operation{
+			OperationID: "postStaticEmployee",
+			Responses:   oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 14", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"postEmployeeById": {
+					ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 422},
+				},
+				"postStaticEmployee": {},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 14 API"
+		spec.APIID = "scenario-14"
+		spec.Proxy.ListenPath = "/test-14/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			Method: http.MethodPost,
+			Path:   "/test-14/employees/static",
+			Code:   http.StatusOK,
+		},
+		{
+			Method: http.MethodPost,
+			Path:   "/test-14/employees/123",
+			Data:   `{}`,
+			Code:   http.StatusUnprocessableEntity,
+		},
+		{
+			Method: http.MethodPost,
+			Path:   "/test-14/employees/123",
+			Data:   `{"name": "Alice"}`,
+			Code:   http.StatusOK,
+		},
+	}...)
+}
+
+func TestScenario16_ThreeLevelPathHierarchy(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/a/{b}/c", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getBc",
+			Parameters: openapi3.Parameters{
+				pathParam("b", &openapi3.Schema{Type: &openapi3.Types{"string"}}),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/a/static/c", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getStaticC",
+			Responses:   oasResponse200(),
+		},
+	})
+
+	paths.Set("/a/{b}/{c}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getBcWild",
+			Parameters: openapi3.Parameters{
+				pathParam("b", &openapi3.Schema{Type: &openapi3.Types{"string"}}),
+				pathParam("c", &openapi3.Schema{Type: &openapi3.Types{"string"}}),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 16", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getBc": {
+					MockResponse: &oas.MockResponse{Enabled: true, Code: 200, Body: `{"message": "b-c"}`},
+				},
+				"getStaticC": {
+					MockResponse: &oas.MockResponse{Enabled: true, Code: 200, Body: `{"message": "static-c"}`},
+				},
+				"getBcWild": {
+					MockResponse: &oas.MockResponse{Enabled: true, Code: 200, Body: `{"message": "b-c-wild"}`},
+				},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 16 API"
+		spec.APIID = "scenario-16"
+		spec.Proxy.ListenPath = "/test-16/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			Method:    http.MethodGet,
+			Path:      "/test-16/a/static/c",
+			Code:      http.StatusOK,
+			BodyMatch: "static-c",
+		},
+		{
+			Method:    http.MethodGet,
+			Path:      "/test-16/a/foo/c",
+			Code:      http.StatusOK,
+			BodyMatch: `"b-c"`,
+		},
+		{
+			Method:    http.MethodGet,
+			Path:      "/test-16/a/foo/bar",
+			Code:      http.StatusOK,
+			BodyMatch: "b-c-wild",
+		},
+	}...)
+}
+
+func TestScenario17_RootListenPathWithMockResponse(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getEmployeeById",
+			Parameters: openapi3.Parameters{
+				pathParam("id", &openapi3.Schema{Type: &openapi3.Types{"string"}}),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/employees/static", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getStaticEmployee",
+			Responses:   oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 17", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getEmployeeById": {
+					MockResponse: &oas.MockResponse{Enabled: true, Code: 200, Body: `{"message": "parameterized"}`},
+				},
+				"getStaticEmployee": {
+					MockResponse: &oas.MockResponse{Enabled: true, Code: 200, Body: `{"message": "static"}`},
+				},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 17 API"
+		spec.APIID = "scenario-17"
+		spec.Proxy.ListenPath = "/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			Method:    http.MethodGet,
+			Path:      "/employees/static",
+			Code:      http.StatusOK,
+			BodyMatch: `"static"`,
+		},
+		{
+			Method:    http.MethodGet,
+			Path:      "/employees/123",
+			Code:      http.StatusOK,
+			BodyMatch: "parameterized",
+		},
+	}...)
+}
+
+func TestScenario18_RootListenPathWithValidateRequest(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getEmployeeById",
+			Parameters: openapi3.Parameters{
+				pathParam("id", &openapi3.Schema{Type: &openapi3.Types{"string"}, Pattern: `^\d+$`}),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/employees/static", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getStaticEmployee",
+			Responses:   oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 18", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getEmployeeById": {
+					ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 422},
+				},
+				"getStaticEmployee": {},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 18 API"
+		spec.APIID = "scenario-18"
+		spec.Proxy.ListenPath = "/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{Method: http.MethodGet, Path: "/employees/static", Code: http.StatusOK},
+		{Method: http.MethodGet, Path: "/employees/123", Code: http.StatusOK},
+		{Method: http.MethodGet, Path: "/employees/abc", Code: http.StatusUnprocessableEntity},
+	}...)
+}
+
+func TestScenario21_MultiSegmentListenPath(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getEmployeeById",
+			Parameters: openapi3.Parameters{
+				pathParam("id", &openapi3.Schema{Type: &openapi3.Types{"string"}}),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/employees/static", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getStaticEmployee",
+			Responses:   oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 21", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getEmployeeById": {
+					MockResponse: &oas.MockResponse{Enabled: true, Code: 200, Body: `{"message": "parameterized"}`},
+				},
+				"getStaticEmployee": {
+					MockResponse: &oas.MockResponse{Enabled: true, Code: 200, Body: `{"message": "static"}`},
+				},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 21 API"
+		spec.APIID = "scenario-21"
+		spec.Proxy.ListenPath = "/api/v2/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			Method:    http.MethodGet,
+			Path:      "/api/v2/employees/static",
+			Code:      http.StatusOK,
+			BodyMatch: `"static"`,
+		},
+		{
+			Method:    http.MethodGet,
+			Path:      "/api/v2/employees/123",
+			Code:      http.StatusOK,
+			BodyMatch: "parameterized",
+		},
+	}...)
+}
+
+func TestScenario24_ThreeCollapsedParameterizedPaths(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getById",
+			Parameters: openapi3.Parameters{
+				pathParam("id", &openapi3.Schema{Type: &openapi3.Types{"integer"}}),
+				headerParam("X-Id"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/employees/{code}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByCode",
+			Parameters: openapi3.Parameters{
+				pathParam("code", &openapi3.Schema{Type: &openapi3.Types{"string"}, Pattern: `^[A-Z]{3}$`}),
+				headerParam("X-Code"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/employees/{slug}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getBySlug",
+			Parameters: openapi3.Parameters{
+				pathParam("slug", &openapi3.Schema{Type: &openapi3.Types{"string"}}),
+				headerParam("X-Slug"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 24", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getById":   {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 400}},
+				"getByCode": {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 422}},
+				"getBySlug": {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 409}},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 24 API"
+		spec.APIID = "scenario-24"
+		spec.Proxy.ListenPath = "/test-24/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-24/employees/42",
+			Headers: map[string]string{"X-Id": "v"},
+			Code:    http.StatusOK,
+		},
+		{
+			Method: http.MethodGet,
+			Path:   "/test-24/employees/42",
+			Code:   http.StatusBadRequest,
+		},
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-24/employees/ABC",
+			Headers: map[string]string{"X-Code": "v"},
+			Code:    http.StatusOK,
+		},
+		{
+			Method: http.MethodGet,
+			Path:   "/test-24/employees/ABC",
+			Code:   http.StatusUnprocessableEntity,
+		},
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-24/employees/hello",
+			Headers: map[string]string{"X-Slug": "v"},
+			Code:    http.StatusOK,
+		},
+		{
+			Method: http.MethodGet,
+			Path:   "/test-24/employees/hello",
+			Code:   http.StatusConflict,
+		},
+	}...)
+}
+
+func TestScenario26_SameBasePathDifferentMethodsNoGrouping(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getById",
+			Parameters: openapi3.Parameters{
+				pathParam("id", &openapi3.Schema{Type: &openapi3.Types{"string"}, Pattern: `^\d+$`}),
+			},
+			Responses: oasResponse200(),
+		},
+		Post: &openapi3.Operation{
+			OperationID: "postById",
+			Parameters: openapi3.Parameters{
+				pathParam("id", &openapi3.Schema{Type: &openapi3.Types{"string"}}),
+			},
+			RequestBody: &openapi3.RequestBodyRef{
+				Value: &openapi3.RequestBody{
+					Required: true,
+					Content: openapi3.NewContentWithJSONSchema(&openapi3.Schema{
+						Type:     &openapi3.Types{"object"},
+						Required: []string{"name"},
+						Properties: openapi3.Schemas{
+							"name": &openapi3.SchemaRef{
+								Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
+							},
+						},
+					}),
+				},
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 26", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getById":  {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 400}},
+				"postById": {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 422}},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 26 API"
+		spec.APIID = "scenario-26"
+		spec.Proxy.ListenPath = "/test-26/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{Method: http.MethodGet, Path: "/test-26/employees/abc", Code: http.StatusBadRequest},
+		{Method: http.MethodGet, Path: "/test-26/employees/123", Code: http.StatusOK},
+		{
+			Method: http.MethodPost,
+			Path:   "/test-26/employees/123",
+			Data:   `{}`,
+			Code:   http.StatusUnprocessableEntity,
+		},
+		{
+			Method: http.MethodPost,
+			Path:   "/test-26/employees/123",
+			Data:   `{"name":"Alice"}`,
+			Code:   http.StatusOK,
+		},
+	}...)
+}
+
+func TestScenario27_EnumBasedParamDisambiguation(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/{role}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByRole",
+			Parameters: openapi3.Parameters{
+				pathParam("role", &openapi3.Schema{
+					Type: &openapi3.Types{"string"},
+					Enum: []interface{}{"admin", "manager"},
+				}),
+				headerParam("X-Role"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/employees/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getById",
+			Parameters: openapi3.Parameters{
+				pathParam("id", &openapi3.Schema{Type: &openapi3.Types{"integer"}}),
+				headerParam("X-Id"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 27", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getByRole": {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 422}},
+				"getById":   {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 400}},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 27 API"
+		spec.APIID = "scenario-27"
+		spec.Proxy.ListenPath = "/test-27/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-27/employees/admin",
+			Headers: map[string]string{"X-Role": "v"},
+			Code:    http.StatusOK,
+		},
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-27/employees/42",
+			Headers: map[string]string{"X-Id": "v"},
+			Code:    http.StatusOK,
+		},
+		{
+			Method: http.MethodGet,
+			Path:   "/test-27/employees/admin",
+			Code:   http.StatusUnprocessableEntity,
+		},
+	}...)
+}
+
+func TestScenario28_DotstarPatternVsSpecificPattern(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getById",
+			Parameters: openapi3.Parameters{
+				pathParam("id", &openapi3.Schema{Type: &openapi3.Types{"string"}, Pattern: `^\d+$`}),
+				headerParam("X-Id"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/employees/{fallback}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByFallback",
+			Parameters: openapi3.Parameters{
+				pathParam("fallback", &openapi3.Schema{Type: &openapi3.Types{"string"}, Pattern: `.*`}),
+				headerParam("X-Fallback"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 28", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getById":       {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 400}},
+				"getByFallback": {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 422}},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 28 API"
+		spec.APIID = "scenario-28"
+		spec.Proxy.ListenPath = "/test-28/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-28/employees/123",
+			Headers: map[string]string{"X-Id": "v"},
+			Code:    http.StatusOK,
+		},
+		{
+			Method: http.MethodGet,
+			Path:   "/test-28/employees/123",
+			Code:   http.StatusBadRequest,
+		},
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-28/employees/abc",
+			Headers: map[string]string{"X-Fallback": "v"},
+			Code:    http.StatusOK,
+		},
+		{
+			Method: http.MethodGet,
+			Path:   "/test-28/employees/abc",
+			Code:   http.StatusUnprocessableEntity,
+		},
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-28/employees/hello-world",
+			Headers: map[string]string{"X-Fallback": "v"},
+			Code:    http.StatusOK,
+		},
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-28/employees/!!!",
+			Headers: map[string]string{"X-Fallback": "v"},
+			Code:    http.StatusOK,
+		},
+		{
+			Method: http.MethodGet,
+			Path:   "/test-28/employees/!!!",
+			Code:   http.StatusUnprocessableEntity,
+		},
+	}...)
+}
+
+func TestScenario29_DotstarVsUnconstrainedString(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/{wild}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByWild",
+			Parameters: openapi3.Parameters{
+				pathParam("wild", &openapi3.Schema{Type: &openapi3.Types{"string"}, Pattern: `.*`}),
+				headerParam("X-Wild"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/employees/{any}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByAny",
+			Parameters: openapi3.Parameters{
+				pathParam("any", &openapi3.Schema{Type: &openapi3.Types{"string"}}),
+				headerParam("X-Any"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 29", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getByWild": {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 422}},
+				"getByAny":  {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 409}},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 29 API"
+		spec.APIID = "scenario-29"
+		spec.Proxy.ListenPath = "/test-29/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-29/employees/foo",
+			Headers: map[string]string{"X-Wild": "v"},
+			Code:    http.StatusOK,
+		},
+		{
+			// wild commits first, so X-Any alone triggers wild's 422
+			Method:  http.MethodGet,
+			Path:    "/test-29/employees/foo",
+			Headers: map[string]string{"X-Any": "v"},
+			Code:    http.StatusUnprocessableEntity,
+		},
+		{
+			Method: http.MethodGet,
+			Path:   "/test-29/employees/foo",
+			Code:   http.StatusUnprocessableEntity,
+		},
+	}...)
+}
+
+func TestScenario30_DotstarWithStaticPath(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/{fallback}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByFallback",
+			Parameters: openapi3.Parameters{
+				pathParam("fallback", &openapi3.Schema{Type: &openapi3.Types{"string"}, Pattern: `.*`}),
+				headerParam("X-Fallback"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/employees/static", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getStatic",
+			Responses:   oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 30", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getByFallback": {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 422}},
+				"getStatic":     {},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 30 API"
+		spec.APIID = "scenario-30"
+		spec.Proxy.ListenPath = "/test-30/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{Method: http.MethodGet, Path: "/test-30/employees/static", Code: http.StatusOK},
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-30/employees/anything",
+			Headers: map[string]string{"X-Fallback": "v"},
+			Code:    http.StatusOK,
+		},
+		{
+			Method: http.MethodGet,
+			Path:   "/test-30/employees/anything",
+			Code:   http.StatusUnprocessableEntity,
+		},
+	}...)
+}
+
+func TestScenario31_DotstarIntegerStaticThreeWay(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getById",
+			Parameters: openapi3.Parameters{
+				pathParam("id", &openapi3.Schema{Type: &openapi3.Types{"integer"}}),
+				headerParam("X-Id"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/employees/{fallback}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByFallback",
+			Parameters: openapi3.Parameters{
+				pathParam("fallback", &openapi3.Schema{Type: &openapi3.Types{"string"}, Pattern: `.*`}),
+				headerParam("X-Fallback"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/employees/static", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getStatic",
+			Responses:   oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 31", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getById":       {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 400}},
+				"getByFallback": {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 422}},
+				"getStatic":     {},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 31 API"
+		spec.APIID = "scenario-31"
+		spec.Proxy.ListenPath = "/test-31/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{Method: http.MethodGet, Path: "/test-31/employees/static", Code: http.StatusOK},
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-31/employees/42",
+			Headers: map[string]string{"X-Id": "v"},
+			Code:    http.StatusOK,
+		},
+		{
+			Method: http.MethodGet,
+			Path:   "/test-31/employees/42",
+			Code:   http.StatusBadRequest,
+		},
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-31/employees/abc",
+			Headers: map[string]string{"X-Fallback": "v"},
+			Code:    http.StatusOK,
+		},
+		{
+			Method: http.MethodGet,
+			Path:   "/test-31/employees/abc",
+			Code:   http.StatusUnprocessableEntity,
+		},
+	}...)
+}
+
+func TestScenario32_IntegerVsNumberPriority(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getById",
+			Parameters: openapi3.Parameters{
+				pathParam("id", &openapi3.Schema{Type: &openapi3.Types{"integer"}}),
+				headerParam("X-Id"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/employees/{amt}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByAmt",
+			Parameters: openapi3.Parameters{
+				pathParam("amt", &openapi3.Schema{Type: &openapi3.Types{"number"}}),
+				headerParam("X-Amt"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 32", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getById":  {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 400}},
+				"getByAmt": {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 422}},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 32 API"
+		spec.APIID = "scenario-32"
+		spec.Proxy.ListenPath = "/test-32/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-32/employees/42",
+			Headers: map[string]string{"X-Id": "v"},
+			Code:    http.StatusOK,
+		},
+		{
+			Method: http.MethodGet,
+			Path:   "/test-32/employees/42",
+			Code:   http.StatusBadRequest,
+		},
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-32/employees/3.14",
+			Headers: map[string]string{"X-Amt": "v"},
+			Code:    http.StatusOK,
+		},
+		{
+			Method: http.MethodGet,
+			Path:   "/test-32/employees/3.14",
+			Code:   http.StatusUnprocessableEntity,
+		},
+	}...)
+}
+
+func TestScenario33_NumberVsBooleanPriority(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/{amt}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByAmt",
+			Parameters: openapi3.Parameters{
+				pathParam("amt", &openapi3.Schema{Type: &openapi3.Types{"number"}}),
+				headerParam("X-Amt"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/employees/{flag}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByFlag",
+			Parameters: openapi3.Parameters{
+				pathParam("flag", &openapi3.Schema{Type: &openapi3.Types{"boolean"}}),
+				headerParam("X-Flag"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 33", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getByAmt":  {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 400}},
+				"getByFlag": {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 422}},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 33 API"
+		spec.APIID = "scenario-33"
+		spec.Proxy.ListenPath = "/test-33/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-33/employees/42",
+			Headers: map[string]string{"X-Amt": "v"},
+			Code:    http.StatusOK,
+		},
+		{
+			Method: http.MethodGet,
+			Path:   "/test-33/employees/42",
+			Code:   http.StatusBadRequest,
+		},
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-33/employees/true",
+			Headers: map[string]string{"X-Flag": "v"},
+			Code:    http.StatusOK,
+		},
+		{
+			Method: http.MethodGet,
+			Path:   "/test-33/employees/true",
+			Code:   http.StatusUnprocessableEntity,
+		},
+	}...)
+}
+
+func TestScenario34_BooleanVsStringWithPattern(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/{flag}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByFlag",
+			Parameters: openapi3.Parameters{
+				pathParam("flag", &openapi3.Schema{Type: &openapi3.Types{"boolean"}}),
+				headerParam("X-Flag"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/employees/{code}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByCode",
+			Parameters: openapi3.Parameters{
+				pathParam("code", &openapi3.Schema{Type: &openapi3.Types{"string"}, Pattern: `^[A-Z]{3}$`}),
+				headerParam("X-Code"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 34", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getByFlag": {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 400}},
+				"getByCode": {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 422}},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 34 API"
+		spec.APIID = "scenario-34"
+		spec.Proxy.ListenPath = "/test-34/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-34/employees/true",
+			Headers: map[string]string{"X-Flag": "v"},
+			Code:    http.StatusOK,
+		},
+		{
+			Method: http.MethodGet,
+			Path:   "/test-34/employees/true",
+			Code:   http.StatusBadRequest,
+		},
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-34/employees/ABC",
+			Headers: map[string]string{"X-Code": "v"},
+			Code:    http.StatusOK,
+		},
+		{
+			Method: http.MethodGet,
+			Path:   "/test-34/employees/ABC",
+			Code:   http.StatusUnprocessableEntity,
+		},
+	}...)
+}
+
+func TestScenario35_IntegerNumberBooleanFullHierarchy(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getById",
+			Parameters: openapi3.Parameters{
+				pathParam("id", &openapi3.Schema{Type: &openapi3.Types{"integer"}}),
+				headerParam("X-Id"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/employees/{amt}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByAmt",
+			Parameters: openapi3.Parameters{
+				pathParam("amt", &openapi3.Schema{Type: &openapi3.Types{"number"}}),
+				headerParam("X-Amt"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/employees/{flag}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByFlag",
+			Parameters: openapi3.Parameters{
+				pathParam("flag", &openapi3.Schema{Type: &openapi3.Types{"boolean"}}),
+				headerParam("X-Flag"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 35", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getById":   {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 400}},
+				"getByAmt":  {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 422}},
+				"getByFlag": {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 409}},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 35 API"
+		spec.APIID = "scenario-35"
+		spec.Proxy.ListenPath = "/test-35/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-35/employees/42",
+			Headers: map[string]string{"X-Id": "v"},
+			Code:    http.StatusOK,
+		},
+		{Method: http.MethodGet, Path: "/test-35/employees/42", Code: http.StatusBadRequest},
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-35/employees/3.14",
+			Headers: map[string]string{"X-Amt": "v"},
+			Code:    http.StatusOK,
+		},
+		{Method: http.MethodGet, Path: "/test-35/employees/3.14", Code: http.StatusUnprocessableEntity},
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-35/employees/true",
+			Headers: map[string]string{"X-Flag": "v"},
+			Code:    http.StatusOK,
+		},
+		{Method: http.MethodGet, Path: "/test-35/employees/true", Code: http.StatusConflict},
+	}...)
+}
+
+func TestScenario36_StringPatternLengthOrdering(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/{code}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByCode",
+			Parameters: openapi3.Parameters{
+				pathParam("code", &openapi3.Schema{Type: &openapi3.Types{"string"}, Pattern: `^[A-Z]{2,4}$`}),
+				headerParam("X-Code"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/employees/{tag}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByTag",
+			Parameters: openapi3.Parameters{
+				pathParam("tag", &openapi3.Schema{Type: &openapi3.Types{"string"}, Pattern: `^[a-z]$`}),
+				headerParam("X-Tag"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 36", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getByCode": {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 400}},
+				"getByTag":  {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 422}},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 36 API"
+		spec.APIID = "scenario-36"
+		spec.Proxy.ListenPath = "/test-36/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-36/employees/ABC",
+			Headers: map[string]string{"X-Code": "v"},
+			Code:    http.StatusOK,
+		},
+		{Method: http.MethodGet, Path: "/test-36/employees/ABC", Code: http.StatusBadRequest},
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-36/employees/a",
+			Headers: map[string]string{"X-Tag": "v"},
+			Code:    http.StatusOK,
+		},
+		{Method: http.MethodGet, Path: "/test-36/employees/a", Code: http.StatusUnprocessableEntity},
+	}...)
+}
+
+func TestScenario37_ThreeStringPatternsByLength(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/{uuid}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByUUID",
+			Parameters: openapi3.Parameters{
+				pathParam("uuid", &openapi3.Schema{
+					Type:    &openapi3.Types{"string"},
+					Pattern: `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`,
+				}),
+				headerParam("X-UUID"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/employees/{code}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByCode",
+			Parameters: openapi3.Parameters{
+				pathParam("code", &openapi3.Schema{Type: &openapi3.Types{"string"}, Pattern: `^[A-Z]{3}$`}),
+				headerParam("X-Code"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/employees/{fallback}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByFb",
+			Parameters: openapi3.Parameters{
+				pathParam("fallback", &openapi3.Schema{Type: &openapi3.Types{"string"}, Pattern: `.*`}),
+				headerParam("X-Fb"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 37", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getByUUID": {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 400}},
+				"getByCode": {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 422}},
+				"getByFb":   {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 409}},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 37 API"
+		spec.APIID = "scenario-37"
+		spec.Proxy.ListenPath = "/test-37/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-37/employees/550e8400-e29b-41d4-a716-446655440000",
+			Headers: map[string]string{"X-UUID": "v"},
+			Code:    http.StatusOK,
+		},
+		{
+			Method: http.MethodGet,
+			Path:   "/test-37/employees/550e8400-e29b-41d4-a716-446655440000",
+			Code:   http.StatusBadRequest,
+		},
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-37/employees/ABC",
+			Headers: map[string]string{"X-Code": "v"},
+			Code:    http.StatusOK,
+		},
+		{Method: http.MethodGet, Path: "/test-37/employees/ABC", Code: http.StatusUnprocessableEntity},
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-37/employees/anything",
+			Headers: map[string]string{"X-Fb": "v"},
+			Code:    http.StatusOK,
+		},
+		{Method: http.MethodGet, Path: "/test-37/employees/anything", Code: http.StatusConflict},
+	}...)
+}
+
+func TestScenario38_StringPatternVsEnum(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/{code}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByCode",
+			Parameters: openapi3.Parameters{
+				pathParam("code", &openapi3.Schema{Type: &openapi3.Types{"string"}, Pattern: `^[A-Z]{3}$`}),
+				headerParam("X-Code"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/employees/{role}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByRole",
+			Parameters: openapi3.Parameters{
+				pathParam("role", &openapi3.Schema{
+					Type: &openapi3.Types{"string"},
+					Enum: []interface{}{"admin", "manager", "viewer"},
+				}),
+				headerParam("X-Role"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 38", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getByCode": {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 400}},
+				"getByRole": {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 422}},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 38 API"
+		spec.APIID = "scenario-38"
+		spec.Proxy.ListenPath = "/test-38/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-38/employees/ABC",
+			Headers: map[string]string{"X-Code": "v"},
+			Code:    http.StatusOK,
+		},
+		{Method: http.MethodGet, Path: "/test-38/employees/ABC", Code: http.StatusBadRequest},
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-38/employees/admin",
+			Headers: map[string]string{"X-Role": "v"},
+			Code:    http.StatusOK,
+		},
+		{Method: http.MethodGet, Path: "/test-38/employees/admin", Code: http.StatusUnprocessableEntity},
+	}...)
+}
+
+func TestScenario41_MultiParamCumulativeScoring(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/departments/{dept_id}/employees/{emp_id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getTyped",
+			Parameters: openapi3.Parameters{
+				pathParam("dept_id", &openapi3.Schema{Type: &openapi3.Types{"integer"}}),
+				pathParam("emp_id", &openapi3.Schema{Type: &openapi3.Types{"integer"}}),
+				headerParam("X-Typed"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/departments/{dept_name}/employees/{emp_name}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getMixed",
+			Parameters: openapi3.Parameters{
+				pathParam("dept_name", &openapi3.Schema{Type: &openapi3.Types{"string"}, Pattern: `^[a-z]+$`}),
+				pathParam("emp_name", &openapi3.Schema{Type: &openapi3.Types{"string"}}),
+				headerParam("X-Mixed"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 41", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getTyped": {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 400}},
+				"getMixed": {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 422}},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 41 API"
+		spec.APIID = "scenario-41"
+		spec.Proxy.ListenPath = "/test-41/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-41/departments/1/employees/42",
+			Headers: map[string]string{"X-Typed": "v"},
+			Code:    http.StatusOK,
+		},
+		{
+			Method: http.MethodGet,
+			Path:   "/test-41/departments/1/employees/42",
+			Code:   http.StatusBadRequest,
+		},
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-41/departments/engineering/employees/alice",
+			Headers: map[string]string{"X-Mixed": "v"},
+			Code:    http.StatusOK,
+		},
+		{
+			Method: http.MethodGet,
+			Path:   "/test-41/departments/engineering/employees/alice",
+			Code:   http.StatusUnprocessableEntity,
+		},
+	}...)
+}
+
+func TestScenario43_FullTypeHierarchy(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/items/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getById",
+			Parameters: openapi3.Parameters{
+				pathParam("id", &openapi3.Schema{Type: &openapi3.Types{"integer"}}),
+				headerParam("X-Id"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/items/{price}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByPrice",
+			Parameters: openapi3.Parameters{
+				pathParam("price", &openapi3.Schema{Type: &openapi3.Types{"number"}}),
+				headerParam("X-Price"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/items/{flag}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByFlag",
+			Parameters: openapi3.Parameters{
+				pathParam("flag", &openapi3.Schema{Type: &openapi3.Types{"boolean"}}),
+				headerParam("X-Flag"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/items/{code}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByCode",
+			Parameters: openapi3.Parameters{
+				pathParam("code", &openapi3.Schema{Type: &openapi3.Types{"string"}, Pattern: `^[A-Z]{3}$`}),
+				headerParam("X-Code"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/items/{slug}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getBySlug",
+			Parameters: openapi3.Parameters{
+				pathParam("slug", &openapi3.Schema{Type: &openapi3.Types{"string"}}),
+				headerParam("X-Slug"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 43", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getById":    {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 400}},
+				"getByPrice": {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 422}},
+				"getByFlag":  {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 409}},
+				"getByCode":  {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 415}},
+				"getBySlug":  {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 406}},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 43 API"
+		spec.APIID = "scenario-43"
+		spec.Proxy.ListenPath = "/test-43/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-43/items/42",
+			Headers: map[string]string{"X-Id": "v"},
+			Code:    http.StatusOK,
+		},
+		{Method: http.MethodGet, Path: "/test-43/items/42", Code: http.StatusBadRequest},
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-43/items/3.14",
+			Headers: map[string]string{"X-Price": "v"},
+			Code:    http.StatusOK,
+		},
+		{Method: http.MethodGet, Path: "/test-43/items/3.14", Code: http.StatusUnprocessableEntity},
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-43/items/true",
+			Headers: map[string]string{"X-Flag": "v"},
+			Code:    http.StatusOK,
+		},
+		{Method: http.MethodGet, Path: "/test-43/items/true", Code: http.StatusConflict},
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-43/items/ABC",
+			Headers: map[string]string{"X-Code": "v"},
+			Code:    http.StatusOK,
+		},
+		{Method: http.MethodGet, Path: "/test-43/items/ABC", Code: http.StatusUnsupportedMediaType},
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-43/items/hello",
+			Headers: map[string]string{"X-Slug": "v"},
+			Code:    http.StatusOK,
+		},
+		{Method: http.MethodGet, Path: "/test-43/items/hello", Code: http.StatusNotAcceptable},
+	}...)
+}
+
+func TestScenario44_FullHierarchyWithStaticPath(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/items/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getById",
+			Parameters: openapi3.Parameters{
+				pathParam("id", &openapi3.Schema{Type: &openapi3.Types{"integer"}}),
+				headerParam("X-Id"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/items/{price}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByPrice",
+			Parameters: openapi3.Parameters{
+				pathParam("price", &openapi3.Schema{Type: &openapi3.Types{"number"}}),
+				headerParam("X-Price"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/items/{flag}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByFlag",
+			Parameters: openapi3.Parameters{
+				pathParam("flag", &openapi3.Schema{Type: &openapi3.Types{"boolean"}}),
+				headerParam("X-Flag"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/items/{code}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByCode",
+			Parameters: openapi3.Parameters{
+				pathParam("code", &openapi3.Schema{Type: &openapi3.Types{"string"}, Pattern: `^[A-Z]{3}$`}),
+				headerParam("X-Code"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/items/{slug}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getBySlug",
+			Parameters: openapi3.Parameters{
+				pathParam("slug", &openapi3.Schema{Type: &openapi3.Types{"string"}}),
+				headerParam("X-Slug"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/items/featured", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getFeatured",
+			Responses:   oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 44", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getById":     {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 400}},
+				"getByPrice":  {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 422}},
+				"getByFlag":   {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 409}},
+				"getByCode":   {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 415}},
+				"getBySlug":   {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 406}},
+				"getFeatured": {},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 44 API"
+		spec.APIID = "scenario-44"
+		spec.Proxy.ListenPath = "/test-44/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{Method: http.MethodGet, Path: "/test-44/items/featured", Code: http.StatusOK},
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-44/items/42",
+			Headers: map[string]string{"X-Id": "v"},
+			Code:    http.StatusOK,
+		},
+		{Method: http.MethodGet, Path: "/test-44/items/42", Code: http.StatusBadRequest},
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-44/items/3.14",
+			Headers: map[string]string{"X-Price": "v"},
+			Code:    http.StatusOK,
+		},
+		{Method: http.MethodGet, Path: "/test-44/items/3.14", Code: http.StatusUnprocessableEntity},
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-44/items/true",
+			Headers: map[string]string{"X-Flag": "v"},
+			Code:    http.StatusOK,
+		},
+		{Method: http.MethodGet, Path: "/test-44/items/true", Code: http.StatusConflict},
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-44/items/ABC",
+			Headers: map[string]string{"X-Code": "v"},
+			Code:    http.StatusOK,
+		},
+		{Method: http.MethodGet, Path: "/test-44/items/ABC", Code: http.StatusUnsupportedMediaType},
+		{
+			Method:  http.MethodGet,
+			Path:    "/test-44/items/hello",
+			Headers: map[string]string{"X-Slug": "v"},
+			Code:    http.StatusOK,
+		},
+		{Method: http.MethodGet, Path: "/test-44/items/hello", Code: http.StatusNotAcceptable},
+	}...)
+}
+
+func TestScenario6_AllowListBlocksUnknownPaths(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getById",
+			Parameters: openapi3.Parameters{
+				pathParam("id", &openapi3.Schema{Type: &openapi3.Types{"string"}, Pattern: `^\d+$`}),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/employees/static", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getStatic",
+			Responses:   oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 6", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getById": {
+					Allow:           &oas.Allowance{Enabled: true},
+					ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 422},
+				},
+				"getStatic": {
+					Allow: &oas.Allowance{Enabled: true},
+				},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 6 API"
+		spec.APIID = "scenario-6"
+		spec.Proxy.ListenPath = "/test-6/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{Method: http.MethodGet, Path: "/test-6/employees/static", Code: http.StatusOK},
+		{Method: http.MethodGet, Path: "/test-6/employees/123", Code: http.StatusOK},
+		{Method: http.MethodGet, Path: "/test-6/employees/abc", Code: http.StatusUnprocessableEntity},
+		// NOTE: AllowList blocking of unknown paths (403) depends on OAS allowList
+		// middleware configuration which is outside the scope of validate request.
+		// The unknown path passes through because no validateRequest matches it.
+		{Method: http.MethodGet, Path: "/test-6/unknown/path", Code: http.StatusOK},
+	}...)
+}
+
+func TestScenario15_MixedAlphanumericWithAllowList(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getById",
+			Parameters: openapi3.Parameters{
+				pathParam("id", &openapi3.Schema{Type: &openapi3.Types{"string"}, Pattern: `^\d+$`}),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/employees/static", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getStatic",
+			Responses:   oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 15", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getById": {
+					Allow:           &oas.Allowance{Enabled: true},
+					ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 422},
+				},
+				"getStatic": {
+					Allow: &oas.Allowance{Enabled: true},
+				},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 15 API"
+		spec.APIID = "scenario-15"
+		spec.Proxy.ListenPath = "/test-15/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		{Method: http.MethodGet, Path: "/test-15/employees/static", Code: http.StatusOK},
+		{Method: http.MethodGet, Path: "/test-15/employees/123", Code: http.StatusOK},
+		{Method: http.MethodGet, Path: "/test-15/employees/asd123", Code: http.StatusUnprocessableEntity},
+	}...)
+}
+
+// Scenario 39: String with format:date vs unconstrained string.
+// format:date scores higher and valueMatchesSchema checks the date format,
+// so non-date values fall through to the unconstrained candidate.
+func TestScenario39_StringFormatVsUnconstrained(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/employees/{date}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByDate",
+			Parameters: openapi3.Parameters{
+				{Value: &openapi3.Parameter{
+					Name: "date", In: "path", Required: true,
+					Schema: &openapi3.SchemaRef{Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"}, Format: "date",
+					}},
+				}},
+				headerParam("X-Date"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/employees/{any}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByAny",
+			Parameters: openapi3.Parameters{
+				pathParam("any", &openapi3.Schema{Type: &openapi3.Types{"string"}}),
+				headerParam("X-Any"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 39", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getByDate": {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 400}},
+				"getByAny":  {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 422}},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 39 API"
+		spec.APIID = "scenario-39"
+		spec.Proxy.ListenPath = "/test-39/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		// Valid date + correct header -> 200
+		{Method: http.MethodGet, Path: "/test-39/employees/2026-01-15", Headers: map[string]string{"X-Date": "v"}, Code: http.StatusOK},
+		// Valid date, no header -> 400 (commits to date candidate, missing header)
+		{Method: http.MethodGet, Path: "/test-39/employees/2026-01-15", Code: http.StatusBadRequest},
+		// Non-date value + X-Any header -> 200 (fails date format, falls to unconstrained)
+		{Method: http.MethodGet, Path: "/test-39/employees/hello", Headers: map[string]string{"X-Any": "v"}, Code: http.StatusOK},
+		// Non-date value, no header -> 422 (falls to unconstrained, missing header)
+		{Method: http.MethodGet, Path: "/test-39/employees/hello", Code: http.StatusUnprocessableEntity},
+	}...)
+}
+
+// Scenario 40: String with minLength/maxLength vs unconstrained string.
+// Length constraints are checked in valueMatchesSchema, so values outside the
+// range fall through to the unconstrained candidate.
+func TestScenario40_StringMinLengthVsUnconstrained(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	maxLen := uint64(5)
+	paths.Set("/employees/{short}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByShort",
+			Parameters: openapi3.Parameters{
+				{Value: &openapi3.Parameter{
+					Name: "short", In: "path", Required: true,
+					Schema: &openapi3.SchemaRef{Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"}, MinLength: 2, MaxLength: &maxLen,
+					}},
+				}},
+				headerParam("X-Short"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/employees/{any}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getByAny",
+			Parameters: openapi3.Parameters{
+				pathParam("any", &openapi3.Schema{Type: &openapi3.Types{"string"}}),
+				headerParam("X-Any"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 40", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getByShort": {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 400}},
+				"getByAny":   {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 422}},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 40 API"
+		spec.APIID = "scenario-40"
+		spec.Proxy.ListenPath = "/test-40/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		// "abc" (3 chars, in range 2-5) + correct header -> 200
+		{Method: http.MethodGet, Path: "/test-40/employees/abc", Headers: map[string]string{"X-Short": "v"}, Code: http.StatusOK},
+		// "abc" no header -> 400 (commits to short, missing header)
+		{Method: http.MethodGet, Path: "/test-40/employees/abc", Code: http.StatusBadRequest},
+		// "a" (1 char, below minLength 2) + X-Any -> 200 (falls to unconstrained)
+		{Method: http.MethodGet, Path: "/test-40/employees/a", Headers: map[string]string{"X-Any": "v"}, Code: http.StatusOK},
+		// "toolongstring" (13 chars, above maxLength 5) + X-Any -> 200 (falls to unconstrained)
+		{Method: http.MethodGet, Path: "/test-40/employees/toolongstring", Headers: map[string]string{"X-Any": "v"}, Code: http.StatusOK},
+	}...)
+}
+
+// Scenario 42: Two path params — integer+unconstrained vs pattern+pattern.
+// Cumulative scores tie (7+0=7 vs 2+2=4), so typed path wins.
+// But the key test is that when dept is non-integer, the patterned path matches.
+func TestScenario42_MultiParamMixedTypeAndPattern(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	paths := openapi3.NewPaths()
+
+	paths.Set("/departments/{dept_id}/employees/{emp_any}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getTyped",
+			Parameters: openapi3.Parameters{
+				{Value: &openapi3.Parameter{
+					Name: "dept_id", In: "path", Required: true,
+					Schema: &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"integer"}}},
+				}},
+				pathParam("emp_any", &openapi3.Schema{Type: &openapi3.Types{"string"}}),
+				headerParam("X-Typed"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	paths.Set("/departments/{dept_code}/employees/{emp_code}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getPatterned",
+			Parameters: openapi3.Parameters{
+				{Value: &openapi3.Parameter{
+					Name: "dept_code", In: "path", Required: true,
+					Schema: &openapi3.SchemaRef{Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"}, Pattern: `^[A-Z]{3}$`,
+					}},
+				}},
+				{Value: &openapi3.Parameter{
+					Name: "emp_code", In: "path", Required: true,
+					Schema: &openapi3.SchemaRef{Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"}, Pattern: `^[A-Z]{3}$`,
+					}},
+				}},
+				headerParam("X-Patterned"),
+			},
+			Responses: oasResponse200(),
+		},
+	})
+
+	doc := openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Scenario 42", Version: "1.0.0"},
+		Paths:   paths,
+	}
+
+	oasAPI := oas.OAS{T: doc}
+	oasAPI.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getTyped":     {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 400}},
+				"getPatterned": {ValidateRequest: &oas.ValidateRequest{Enabled: true, ErrorResponseCode: 422}},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.Name = "Scenario 42 API"
+		spec.APIID = "scenario-42"
+		spec.Proxy.ListenPath = "/test-42/"
+		spec.UseKeylessAccess = true
+		spec.IsOAS = true
+		spec.OAS = oasAPI
+	})
+
+	_, _ = ts.Run(t, []test.TestCase{
+		// dept_id=1 (integer), emp_any=alice -> typed path matches, header satisfied
+		{Method: http.MethodGet, Path: "/test-42/departments/1/employees/alice", Headers: map[string]string{"X-Typed": "v"}, Code: http.StatusOK},
+		// dept_code=ENG, emp_code=MGR (both ^[A-Z]{3}$) -> patterned path matches, header satisfied
+		{Method: http.MethodGet, Path: "/test-42/departments/ENG/employees/MGR", Headers: map[string]string{"X-Patterned": "v"}, Code: http.StatusOK},
+	}...)
+}


### PR DESCRIPTION
## Summary
Backport of #7974 to release-5.8.13. Follow-up fix for collapsed parameterized path disambiguation.

- Adds `groupCollapsedValidateRequestSpecs` and `groupCollapsedMockResponseSpecs` to detect and group URLSpec entries with identical compiled regex patterns
- Adds candidate-based disambiguation using path parameter schema validation
- Adds `matchCandidatePath` for shared disambiguation logic
- Removes `lib.RestoreUnicodeEscapesInError` reference (not available on this branch)

**Note:** This PR includes the #7972 backport commit as a prerequisite (stacked PR). Merge #7972 backport first: https://github.com/TykTechnologies/tyk/pull/8072

## Test plan
- [ ] Unit Tests & Linting passes
- [ ] `go build ./gateway/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)