### PR TITLE
[TT-16977] fix: prevent dep-guard from skipping downstream jobs on push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,12 +36,7 @@ jobs:
     permissions:
       contents: read
   goreleaser:
-    needs:
-      - dep-guard
-    if: |
-      !cancelled() &&
-      (needs.dep-guard.result == 'success' || needs.dep-guard.result == 'skipped') &&
-      github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
     runs-on: ${{ vars.DEFAULT_RUNNER }}
     permissions:
@@ -873,7 +868,7 @@ jobs:
     name: Aggregated CI Status
     runs-on: ${{ vars.DEFAULT_RUNNER }}
     # Dynamically determine which jobs to depend on based on repository configuration
-    needs: [goreleaser, api-tests]
+    needs: [goreleaser, api-tests, dep-guard]
     if: ${{ always() && github.event_name == 'pull_request' }}
     steps:
       - name: Aggregate results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,12 @@ jobs:
     permissions:
       contents: read
   goreleaser:
-    if: github.event.pull_request.draft == false
+    needs:
+      - dep-guard
+    if: |
+      !cancelled() &&
+      (needs.dep-guard.result == 'success' || needs.dep-guard.result == 'skipped') &&
+      github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
     runs-on: ${{ vars.DEFAULT_RUNNER }}
     permissions:
@@ -386,8 +391,11 @@ jobs:
             !dist/*PAYG*.rpm
             !dist/*fips*.rpm
   resolve-dashboard-image:
-    if: github.event.pull_request.draft == false
     needs: goreleaser
+    if: |
+      !cancelled() &&
+      needs.goreleaser.result == 'success' &&
+      github.event.pull_request.draft == false
     runs-on: ${{ vars.DEFAULT_RUNNER }}
     permissions:
       id-token: write
@@ -588,8 +596,11 @@ jobs:
           echo "✅ Resolution complete"
           echo "=================================="
   build-dashboard-image:
-    if: needs.resolve-dashboard-image.outputs.needs_build == 'true'
     needs: resolve-dashboard-image
+    if: |
+      !cancelled() &&
+      needs.resolve-dashboard-image.result == 'success' &&
+      needs.resolve-dashboard-image.outputs.needs_build == 'true'
     runs-on: ${{ vars.DEFAULT_RUNNER }}
     permissions:
       id-token: write
@@ -768,9 +779,12 @@ jobs:
           echo "image=$IMAGE" >> $GITHUB_OUTPUT
           echo "✅ Dashboard image built and pushed: $IMAGE"
   test-controller-api:
-    if: github.event.pull_request.draft == false
     needs:
       - goreleaser
+    if: |
+      !cancelled() &&
+      needs.goreleaser.result == 'success' &&
+      github.event.pull_request.draft == false
     runs-on: ${{ vars.DEFAULT_RUNNER }}
     outputs:
       envfiles: ${{ steps.params.outputs.envfiles }}
@@ -790,9 +804,9 @@ jobs:
       - goreleaser
       - resolve-dashboard-image
       - build-dashboard-image
-    # build-dashboard-image may be skipped, so use if: always() to run regardless
+    # build-dashboard-image may be skipped, so use !cancelled() to run regardless
     if: |
-      always() &&
+      !cancelled() &&
       needs.test-controller-api.result == 'success' &&
       needs.goreleaser.result == 'success' &&
       needs.resolve-dashboard-image.result == 'success' &&
@@ -895,9 +909,12 @@ jobs:
 
           echo "✅ All required jobs succeeded"
   test-controller-distros:
-    if: github.event.pull_request.draft == false
     needs:
       - goreleaser
+    if: |
+      !cancelled() &&
+      needs.goreleaser.result == 'success' &&
+      github.event.pull_request.draft == false
     runs-on: ${{ vars.DEFAULT_RUNNER }}
     outputs:
       deb: ${{ steps.params.outputs.deb }}
@@ -922,6 +939,9 @@ jobs:
     runs-on: ${{ vars.DEFAULT_RUNNER }}
     needs:
       - test-controller-distros
+    if: |
+      !cancelled() &&
+      needs.test-controller-distros.result == 'success'
     strategy:
       fail-fast: true
       matrix:
@@ -981,6 +1001,9 @@ jobs:
     runs-on: ${{ vars.DEFAULT_RUNNER }}
     needs:
       - test-controller-distros
+    if: |
+      !cancelled() &&
+      needs.test-controller-distros.result == 'success'
     strategy:
       fail-fast: true
       matrix:
@@ -1034,6 +1057,9 @@ jobs:
   release-tests:
     needs:
       - goreleaser
+    if: |
+      !cancelled() &&
+      needs.goreleaser.result == 'success'
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read # This is required for actions/checkout
@@ -1042,6 +1068,9 @@ jobs:
     secrets: inherit
   sbom:
     needs: goreleaser
+    if: |
+      !cancelled() &&
+      needs.goreleaser.result == 'success'
     uses: TykTechnologies/github-actions/.github/workflows/sbom.yaml@42304edda365365e0a887cf018d8edc34b960b82 # main
     secrets:
       DEPDASH_URL: ${{ secrets.DEPDASH_URL }}


### PR DESCRIPTION
## Summary
Remove goreleaser's dependency on dep-guard to prevent GitHub Actions' transitive skip propagation from skipping all test jobs on push/tag events.

dep-guard still gates PR merges via the aggregator job.

## Root cause
dep-guard has `if: github.event_name == 'pull_request'` → skipped on push → goreleaser depends on it → all downstream jobs transitively skipped.

## Test plan
- [ ] Push to release branch triggers all test jobs (not skipped)
- [ ] PR still runs dep-guard and gates merge via aggregator

🤖 Generated with [Claude Code](https://claude.com/claude-code)