### PR TITLE
[TT-16977] fix: prevent dep-guard from skipping downstream jobs on push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,7 @@ jobs:
       contents: read
 
   goreleaser:
-    needs: [dep-guard]
-    if: ${{ always() && github.event.pull_request.draft == false && (needs.dep-guard.result == 'success' || needs.dep-guard.result == 'skipped') }}
+    if: github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
     runs-on: ubuntu-latest-m
     permissions:
@@ -448,7 +447,7 @@ jobs:
     name: Aggregated CI Status
     runs-on: ubuntu-latest
     # Dynamically determine which jobs to depend on based on repository configuration
-    needs: [goreleaser, api-tests]
+    needs: [goreleaser, api-tests, dep-guard]
     if: ${{ always() && github.event_name == 'pull_request' }}
     steps:
       - name: Aggregate results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,12 @@ jobs:
       contents: read
 
   goreleaser:
-    if: github.event.pull_request.draft == false
+    needs:
+      - dep-guard
+    if: |
+      !cancelled() &&
+      (needs.dep-guard.result == 'success' || needs.dep-guard.result == 'skipped') &&
+      github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
     runs-on: ubuntu-latest-m
     permissions:
@@ -357,9 +362,12 @@ jobs:
             !dist/*PAYG*.rpm
             !dist/*fips*.rpm
   test-controller-api:
-    if: github.event.pull_request.draft == false
     needs:
       - goreleaser
+    if: |
+      !cancelled() &&
+      needs.goreleaser.result == 'success' &&
+      github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     outputs:
       envfiles: ${{ steps.params.outputs.envfiles }}
@@ -377,6 +385,10 @@ jobs:
     needs:
       - test-controller-api
       - goreleaser
+    if: |
+      !cancelled() &&
+      needs.goreleaser.result == 'success' &&
+      needs.test-controller-api.result == 'success'
     runs-on: ubuntu-latest-m-2
     env:
       XUNIT_REPORT_PATH: ${{ github.workspace}}/test-results.xml
@@ -474,9 +486,12 @@ jobs:
 
           echo "✅ All required jobs succeeded"
   test-controller-distros:
-    if: github.event.pull_request.draft == false
     needs:
       - goreleaser
+    if: |
+      !cancelled() &&
+      needs.goreleaser.result == 'success' &&
+      github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     outputs:
       deb: ${{ steps.params.outputs.deb }}
@@ -501,6 +516,9 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - test-controller-distros
+    if: |
+      !cancelled() &&
+      needs.test-controller-distros.result == 'success'
     strategy:
       fail-fast: true
       matrix:
@@ -560,6 +578,9 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - test-controller-distros
+    if: |
+      !cancelled() &&
+      needs.test-controller-distros.result == 'success'
     strategy:
       fail-fast: true
       matrix:
@@ -613,6 +634,9 @@ jobs:
   release-tests:
     needs:
       - goreleaser
+    if: |
+      !cancelled() &&
+      needs.goreleaser.result == 'success'
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read # This is required for actions/checkout
@@ -621,6 +645,9 @@ jobs:
     secrets: inherit
   sbom:
     needs: goreleaser
+    if: |
+      !cancelled() &&
+      needs.goreleaser.result == 'success'
     uses: TykTechnologies/github-actions/.github/workflows/sbom.yaml@2b35ab5dd4cfff21ced9d12446e9e27d10bf5785  # main
     secrets:
       DEPDASH_URL: ${{ secrets.DEPDASH_URL }}


### PR DESCRIPTION
## Summary
Remove goreleaser's dependency on dep-guard to prevent GitHub Actions' transitive skip propagation from skipping all test jobs on push/tag events.

dep-guard still gates PR merges via the aggregator job.

## Root cause
dep-guard has `if: github.event_name == 'pull_request'` → skipped on push → goreleaser depends on it → all downstream jobs transitively skipped.

## Test plan
- [ ] Push to release branch triggers all test jobs (not skipped)
- [ ] PR still runs dep-guard and gates merge via aggregator

🤖 Generated with [Claude Code](https://claude.com/claude-code)