### PR TITLE
[TT-16977] fix: prevent dep-guard from skipping plugin compiler build on push

### DIFF
--- a/.github/workflows/plugin-compiler-build.yml
+++ b/.github/workflows/plugin-compiler-build.yml
@@ -26,8 +26,11 @@ jobs:
 
   docker-build:
     needs: [dep-guard]
+    if: |
+      !cancelled() &&
+      (needs.dep-guard.result == 'success' || needs.dep-guard.result == 'skipped') &&
+      !github.event.pull_request.draft
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.draft }}
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
## Summary
The `docker-build` job in `plugin-compiler-build.yml` has `needs: [dep-guard]` but no `!cancelled()` guard. Since dep-guard only runs on PRs, the plugin compiler image is never built on push events, causing CI Tests to fail with "manifest not found".

Same fix pattern as release.yml (#8075-#8078).

## Test plan
- [ ] Plugin compiler image is built on push to release branch
- [ ] CI Tests can pull the plugin compiler image

🤖 Generated with [Claude Code](https://claude.com/claude-code)