### PR TITLE
[TT-16977] fix: trigger release workflow on PR labeled event

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ on:
   schedule:
     - cron: "0 0 * * 1"
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
   push:
     branches:
       - master


### PR DESCRIPTION
## Summary
- Add `labeled` to pull_request trigger types so dep-guard re-evaluates when `deps-reviewed` label is added.

## Test plan
- [ ] Adding deps-reviewed label triggers a new release workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)