### PR TITLE
[TT-16342] fix: use Go 1.25 for dashboard builder step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -713,7 +713,7 @@ jobs:
             -e GOMODCACHE=/go/pkg/mod \
             -v /tmp/build-dashboard.sh:/tmp/build-dashboard.sh \
             -w /go/src/github.com/TykTechnologies/tyk-analytics \
-            tykio/golang-cross:1.24-bookworm /tmp/build-dashboard.sh
+            tykio/golang-cross:1.25-bullseye /tmp/build-dashboard.sh
 
           echo "✅ Packages built successfully for $GOARCH"
       - name: Detect platform for Docker build


### PR DESCRIPTION
## Summary
- The build-dashboard-image step used `golang-cross:1.24-bookworm` while everything else uses `1.25-bullseye`
- Updated to match the `golang_cross` matrix value

## Test plan
- [ ] build-dashboard-image step works when triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)