### PR TITLE
[TT-16950, TT-17009] fix: make Docker images backward compatible with runAsUser: 1000

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,6 +176,7 @@ jobs:
           build-args: |
             BUILD_PACKAGE_NAME=tyk-gateway-ee
             BASE_IMAGE=tykio/dhi-busybox:1.37-fips
+            NONROOT_CHOWN=true
       - name: Docker metadata for ee tag push
         id: tag_metadata_ee
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
@@ -211,6 +212,7 @@ jobs:
           build-args: |
             BUILD_PACKAGE_NAME=tyk-gateway-ee
             BASE_IMAGE=tykio/dhi-busybox:1.37-fips
+            NONROOT_CHOWN=true
       - name: Attach base image VEX to ee
         if: ${{ matrix.golang_cross == '1.25-bullseye' && startsWith(github.ref, 'refs/tags') }}
         run: |
@@ -259,6 +261,7 @@ jobs:
           build-args: |
             BUILD_PACKAGE_NAME=tyk-gateway-fips
             BASE_IMAGE=tykio/dhi-busybox:1.37-fips
+            NONROOT_CHOWN=true
       - name: Docker metadata for fips tag push
         id: tag_metadata_fips
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
@@ -293,6 +296,7 @@ jobs:
           build-args: |
             BUILD_PACKAGE_NAME=tyk-gateway-fips
             BASE_IMAGE=tykio/dhi-busybox:1.37-fips
+            NONROOT_CHOWN=true
       - name: Attach base image VEX to fips
         if: ${{ matrix.golang_cross == '1.25-bullseye' && startsWith(github.ref, 'refs/tags') }}
         run: |

--- a/ci/Dockerfile.distroless
+++ b/ci/Dockerfile.distroless
@@ -10,11 +10,14 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # The _ after the pkg name is to match tyk-gateway strictly and not tyk-gateway-fips (for example)
 COPY ${BUILD_PACKAGE_NAME}_*${TARGETARCH}.deb /
-RUN dpkg -i /${BUILD_PACKAGE_NAME}_*${TARGETARCH}.deb && rm /*.deb
+ARG NONROOT_CHOWN=false
+RUN dpkg -i /${BUILD_PACKAGE_NAME}_*${TARGETARCH}.deb && rm /*.deb \
+    && chmod -R a+rX /opt/tyk-gateway/ \
+    && if [ "$NONROOT_CHOWN" = "true" ]; then chown -R 65532:65532 /opt/tyk-gateway/; fi
 
 FROM ${BASE_IMAGE}
 
-COPY --chown=65532:65532 --from=deb /opt/tyk-gateway /opt/tyk-gateway
+COPY --from=deb /opt/tyk-gateway /opt/tyk-gateway
 
 ARG PORTS
 EXPOSE $PORTS


### PR DESCRIPTION
## Summary
- Remove `--chown=65532:65532` from non-FIPS Dockerfile builds to restore backward compatibility with helm charts using `runAsUser: 1000`
- Files are made world-readable via `chmod -R a+rX`
- FIPS/DHI builds still get proper 65532 ownership via `NONROOT_CHOWN` build arg

## Test plan
- [ ] Gateway starts with `runAsUser: 1000` (old helm default)
- [ ] Gateway starts with `runAsUser: 65532`
- [ ] FIPS image still has proper nonroot ownership

🤖 Generated with [Claude Code](https://claude.com/claude-code)