### PR TITLE
[TT-16342] fix: update cert_test.go TLS error strings for Go 1.25

### DIFF
--- a/gateway/cert_test.go
+++ b/gateway/cert_test.go
@@ -39,10 +39,15 @@ import (
 )
 
 const (
-	internalTLSErr          = "tls: unrecognized name"
-	badcertErr              = "tls: bad certificate"
-	certNotMatchErr         = "Client TLS certificate is required"
-	unknownCertAuthorityErr = "unknown certificate authority"
+	internalTLSErr  = "tls: unrecognized name"
+	certNotMatchErr = "Client TLS certificate is required"
+	// Go 1.25 TLS error strings for mutual TLS scenarios:
+	// When ClientCA is announced: no cert -> handshake failure, wrong cert -> unknown certificate authority
+	// When ClientCA is skipped:   no cert -> bad certificate,   wrong cert -> bad certificate
+	noCertAnnounceErr        = "tls: handshake failure"
+	wrongCertAnnounceErr     = "tls: unknown certificate authority"
+	noCertSkipAnnounceErr    = "tls: bad certificate"
+	wrongCertSkipAnnounceErr = "tls: bad certificate"
 )
 
 func TestGatewayTLS(t *testing.T) {
@@ -207,7 +212,7 @@ func TestGatewayControlAPIMutualTLS(t *testing.T) {
 			// Should raise error for ControlAPI without certificate
 			{ControlRequest: true, ErrorMatch: unknownErr},
 			// Should raise error for unknown certificate
-			{ControlRequest: true, ErrorMatch: unknownCertAuthorityErr, Client: clientWithCert},
+			{ControlRequest: true, ErrorMatch: wrongCertAnnounceErr, Client: clientWithCert},
 		}...)
 	})
 
@@ -259,7 +264,7 @@ func TestGatewayControlAPIMutualTLS(t *testing.T) {
 
 		// Should fail as no valid cert IDs exist in Certificates.ControlAPI
 		_, _ = ts.Run(t, test.TestCase{
-			Path: "/tyk/certs", Code: http.StatusForbidden, ErrorMatch: unknownCertAuthorityErr, ControlRequest: true, AdminAuth: true, Client: clientWithCert,
+			Path: "/tyk/certs", Code: http.StatusForbidden, ErrorMatch: wrongCertAnnounceErr, ControlRequest: true, AdminAuth: true, Client: clientWithCert,
 		})
 	})
 
@@ -378,9 +383,11 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 	serverCertPem, _, combinedPEM, _ := crypto.GenServerCertificate()
 	certID, _, _ := certs.GetCertIDAndChainPEM(combinedPEM, "")
 
-	expectedCertErr := unknownCertAuthorityErr
+	expectedNoCertErr := noCertAnnounceErr
+	expectedWrongCertErr := wrongCertAnnounceErr
 	if skipCAAnnounce {
-		expectedCertErr = badcertErr
+		expectedNoCertErr = noCertSkipAnnounceErr
+		expectedWrongCertErr = wrongCertSkipAnnounceErr
 	}
 
 	conf := func(globalConf *config.Config) {
@@ -465,7 +472,7 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 			})
 
 			_, _ = ts.Run(t, test.TestCase{
-				ErrorMatch: badcertErr,
+				ErrorMatch: expectedNoCertErr,
 				Client:     client,
 				Domain:     "localhost",
 			})
@@ -492,7 +499,7 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 
 			client = GetTLSClient(&clientCert, serverCertPem)
 			_, _ = ts.Run(t, test.TestCase{
-				Client: client, Domain: "localhost", ErrorMatch: expectedCertErr,
+				Client: client, Domain: "localhost", ErrorMatch: expectedWrongCertErr,
 			})
 		})
 
@@ -511,7 +518,7 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 			})
 
 			_, _ = ts.Run(t, test.TestCase{
-				Client: client, ErrorMatch: expectedCertErr, Domain: "localhost",
+				Client: client, ErrorMatch: expectedWrongCertErr, Domain: "localhost",
 			})
 		})
 	})
@@ -633,13 +640,13 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 						Path:       "/with_mutual",
 						Client:     clientWithoutCert,
 						Domain:     domain,
-						ErrorMatch: badcertErr,
+						ErrorMatch: expectedNoCertErr,
 					},
 					{
 						Path:       "/with_mutual_2",
 						Client:     clientWithoutCert,
 						Domain:     domain,
-						ErrorMatch: badcertErr,
+						ErrorMatch: expectedNoCertErr,
 					},
 				}...)
 			})
@@ -653,14 +660,14 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 					Path:       "/with_mutual",
 					Client:     client,
 					Domain:     domain,
-					ErrorMatch: expectedCertErr,
+					ErrorMatch: expectedWrongCertErr,
 				})
 
 				_, _ = ts.Run(t, test.TestCase{
 					Path:       "/with_mutual_2",
 					Client:     client,
 					Domain:     domain,
-					ErrorMatch: expectedCertErr,
+					ErrorMatch: expectedWrongCertErr,
 				})
 			})
 
@@ -749,7 +756,7 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 						Path:       "/with_mutual",
 						Client:     clientWithoutCert,
 						Domain:     domain,
-						ErrorMatch: badcertErr,
+						ErrorMatch: expectedNoCertErr,
 					})
 				}
 
@@ -779,7 +786,7 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 						Path:       "/with_mutual",
 						Client:     client,
 						Domain:     domain,
-						ErrorMatch: expectedCertErr,
+						ErrorMatch: expectedWrongCertErr,
 					})
 				}
 			})
@@ -842,7 +849,7 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 					_, _ = ts.Run(t, test.TestCase{
 						Path:       "/with_mutual",
 						Client:     clientWithoutCert,
-						ErrorMatch: badcertErr,
+						ErrorMatch: expectedNoCertErr,
 					})
 				}
 
@@ -871,7 +878,7 @@ func testAPIMutualTLSHelper(t *testing.T, skipCAAnnounce bool) {
 					_, _ = ts.Run(t, test.TestCase{
 						Path:       "/with_mutual",
 						Client:     client,
-						ErrorMatch: expectedCertErr,
+						ErrorMatch: expectedWrongCertErr,
 					})
 				}
 			})
@@ -1886,7 +1893,7 @@ func TestCipherSuites(t *testing.T) {
 			MaxVersion:         tls.VersionTLS12,
 		}}}
 
-		_, _ = ts.Run(t, test.TestCase{Client: client, Path: "/", ErrorMatch: "tls: handshake failure"})
+		_, _ = ts.Run(t, test.TestCase{Client: client, Path: "/", ErrorMatch: noCertAnnounceErr})
 	})
 }
 
@@ -2004,7 +2011,7 @@ func TestClientCertificates_WithProtocolTLS(t *testing.T) {
 	// client
 	t.Run("bad certificate", func(t *testing.T) {
 		_, err := tls.Dial("tcp", apiAddr, mTLSConfig)
-		assert.ErrorContains(t, err, badcertErr)
+		assert.ErrorContains(t, err, noCertAnnounceErr)
 	})
 
 	t.Run("correct certificate", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Go 1.25 changed mutual TLS error messages causing 17 test failures
- Backport cert_test.go fix from PR #8080 (release-5.8.13)
- Updates TLS error constants to distinguish announce vs skip-announce scenarios

## Test plan
- [ ] TestAPIMutualTLS passes
- [ ] TestClientCertificates_WithProtocolTLS passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)