### PR TITLE
[TT-16342] fix: update test files for opentelemetry v0.0.25 struct layout

### DIFF
--- a/gateway/middleware_test.go
+++ b/gateway/middleware_test.go
@@ -661,9 +661,11 @@ func TestRecordAccessLog_TraceID(t *testing.T) {
 			if tc.hasTraceCtx && tc.otelEnabled {
 				// Create a real OTel provider and span
 				otelCfg := &otel.OpenTelemetry{
-					Enabled:  true,
-					Exporter: "http",
-					Endpoint: "http://localhost:4318", // Won't actually connect
+					Enabled: true,
+					ExporterConfig: otel.ExporterConfig{
+						Exporter: "http",
+						Endpoint: "http://localhost:4318", // Won't actually connect
+					},
 				}
 				provider := otel.InitOpenTelemetry(context.Background(), logger, otelCfg, "test-gw", "v1.0.0", false, "", false, nil)
 				_, span := provider.Tracer().Start(context.Background(), "test-span")

--- a/gateway/server_test.go
+++ b/gateway/server_test.go
@@ -78,12 +78,19 @@ func TestGateway_afterConfSetup(t *testing.T) {
 			},
 			expectedConfig: config.Config{
 				OpenTelemetry: otel.OpenTelemetry{
-					Enabled:            true,
-					Exporter:           "grpc",
-					Endpoint:           "localhost:4317",
-					ResourceName:       "tyk-gateway",
-					SpanProcessorType:  "batch",
-					ConnectionTimeout:  1,
+					Enabled: true,
+					ExporterConfig: otel.ExporterConfig{
+						Exporter:          "grpc",
+						Endpoint:          "localhost:4317",
+						ResourceName:      "tyk-gateway",
+						ConnectionTimeout: 1,
+					},
+					SpanProcessorType: "batch",
+					SpanBatchConfig: otel.SpanBatchConfig{
+						MaxQueueSize:       2048,
+						MaxExportBatchSize: 512,
+						BatchTimeout:       5,
+					},
 					ContextPropagation: "tracecontext",
 					Sampling: otel.Sampling{
 						Type: "AlwaysOn",

--- a/internal/otel/otel.go
+++ b/internal/otel/otel.go
@@ -18,7 +18,11 @@ type (
 
 	OpenTelemetry = otelconfig.OpenTelemetry
 
+	ExporterConfig = otelconfig.ExporterConfig
+
 	Sampling = otelconfig.Sampling
+
+	SpanBatchConfig = otelconfig.SpanBatchConfig
 
 	SpanAttribute = tyktrace.Attribute
 


### PR DESCRIPTION
## Summary
- Add `ExporterConfig` and `SpanBatchConfig` type aliases to `internal/otel/otel.go`
- Update `gateway/middleware_test.go` to use nested `ExporterConfig` struct
- Update `gateway/server_test.go` to use nested `ExporterConfig` and `SpanBatchConfig` structs

The opentelemetry library v0.0.25 restructured `OpenTelemetry` to embed
`ExporterConfig` (with `json:",inline"`) instead of having flat fields.
Struct literal initialization in test files must use the embedded struct name.

## Test plan
- [x] `go vet ./gateway/...` passes
- [x] Test compilation passes (`go test -run "^$" -count=0 ./gateway/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)