### PR TITLE
[TT-17030] Update reusable workflow secrets to use GitHub App

### DIFF
--- a/.github/workflows/force-merge.yaml
+++ b/.github/workflows/force-merge.yaml
@@ -8,5 +8,6 @@ jobs:
   call_force_merge:
     uses: TykTechnologies/github-actions/.github/workflows/force-merge.yaml@d3fa20888fa2878e877e22bb7702141217290e7c  # main
     secrets:
-      ADMIN_PAT: ${{ secrets.ORG_GH_TOKEN }}
+      PROBE_APP_ID: ${{ secrets.PROBE_APP_ID }}
+      PROBE_APP_PRIVATE_KEY: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
       SLACK_WEBHOOK_URL: ${{ secrets.FORCE_MERGE_SLACK_WEBHOOK }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,7 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     uses: TykTechnologies/github-actions/.github/workflows/godoc.yml@d3fa20888fa2878e877e22bb7702141217290e7c  # main
     secrets:
-      ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+      PROBE_APP_ID: ${{ secrets.PROBE_APP_ID }}
+      PROBE_APP_PRIVATE_KEY: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
     with:
       go-version: stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1080,4 +1080,5 @@ jobs:
     secrets:
       DEPDASH_URL: ${{ secrets.DEPDASH_URL }}
       DEPDASH_KEY: ${{ secrets.DEPDASH_KEY }}
-      ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+      PROBE_APP_ID: ${{ secrets.PROBE_APP_ID }}
+      PROBE_APP_PRIVATE_KEY: ${{ secrets.PROBE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- Update caller workflows to pass `PROBE_APP_ID` and `PROBE_APP_PRIVATE_KEY` instead of `ORG_GH_TOKEN` / `ADMIN_PAT` to reusable workflows in `github-actions`
- **lint.yml**: godoc caller -- replace `ORG_GH_TOKEN` with app secrets
- **release.yml**: sbom caller -- replace `ORG_GH_TOKEN` with app secrets
- **force-merge.yaml**: force-merge caller -- replace `ADMIN_PAT` (was `ORG_GH_TOKEN`) with app secrets

## Test plan
- [ ] Verify godoc workflow still runs on PRs
- [ ] Verify sbom workflow still runs on releases
- [ ] Verify force-merge still works via `/force-merge` comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)