### PR TITLE
[TT-17030] Migrate remaining workflows from PAT to GitHub App token

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -38,10 +38,18 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft }}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: "Checkout PR"
         uses: TykTechnologies/github-actions/.github/actions/checkout-pr@d3fa20888fa2878e877e22bb7702141217290e7c  # main
         with:
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: "Get base ref"
         run: |
@@ -187,10 +195,18 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     needs: [test, lint]
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: "Checkout repository"
         uses: TykTechnologies/github-actions/.github/actions/checkout-pr@d3fa20888fa2878e877e22bb7702141217290e7c  # main
         with:
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Download coverage artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4


### PR DESCRIPTION
## Summary
- Replace `secrets.ORG_GH_TOKEN` (PAT) with GitHub App token (`actions/create-github-app-token`) in `ci-tests.yml`
- Added app-token generation step to `lint` and `sonar-cloud-analysis` jobs

## Test plan
- [ ] Verify CI tests workflow runs successfully on a test PR
- [ ] Confirm the GitHub App token has sufficient permissions for checkout-pr action

🤖 Generated with [Claude Code](https://claude.com/claude-code)