### PR TITLE
[TT-17030] Migrate workflows from PAT to GitHub App token (release-5.8)

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -39,10 +39,18 @@ jobs:
     if: ${{ always() && !github.event.pull_request.draft && (needs.dep-guard.result == 'success' || needs.dep-guard.result == 'skipped') }}
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: "Checkout PR"
         uses: TykTechnologies/github-actions/.github/actions/checkout-pr@2b35ab5dd4cfff21ced9d12446e9e27d10bf5785  # main
         with:
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: "Get base ref"
         run: |
@@ -187,10 +195,18 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     needs: [test, lint]
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: "Checkout repository"
         uses: TykTechnologies/github-actions/.github/actions/checkout-pr@2b35ab5dd4cfff21ced9d12446e9e27d10bf5785  # main
         with:
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Download coverage artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4

--- a/.github/workflows/lint-swagger.yml
+++ b/.github/workflows/lint-swagger.yml
@@ -39,16 +39,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: Use GitHub Token
         env:
-          TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          TOKEN: ${{ steps.app-token.outputs.token }}
         run: >
           git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"
 
       - name: Checkout repo
         uses: TykTechnologies/github-actions/.github/actions/checkout-pr@2b35ab5dd4cfff21ced9d12446e9e27d10bf5785  # main
         with:
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Golang
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,11 +19,24 @@ jobs:
     permissions:
       contents: read
 
+  generate-token:
+    runs-on: ubuntu-latest
+    outputs:
+      token: ${{ steps.app-token.outputs.token }}
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
   godoc:
-    needs: [dep-guard]
+    needs: [dep-guard, generate-token]
     if: ${{ !github.event.pull_request.draft }}
     uses: TykTechnologies/github-actions/.github/workflows/godoc.yml@2b35ab5dd4cfff21ced9d12446e9e27d10bf5785  # main
     secrets:
-      ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+      ORG_GH_TOKEN: ${{ needs.generate-token.outputs.token }}
     with:
       go-version: stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,14 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: Build
         env:
           NFPM_PASSPHRASE: ${{ secrets.SIGNING_KEY_PASSPHRASE }}
@@ -109,7 +117,7 @@ jobs:
         run: |
           echo '#!/bin/sh
           ci/bin/unlock-agent.sh
-          git config --global url."https://${{ secrets.ORG_GH_TOKEN }}@github.com".insteadOf "https://github.com"
+          git config --global url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf "https://github.com"
           git config --global --add safe.directory /go/src/github.com/TykTechnologies/tyk
           goreleaser release --clean -f ${{ matrix.goreleaser }} ${{ !startsWith(github.ref, 'refs/tags/') && ' --snapshot --skip=sign,docker' || '--skip=docker' }}' | tee /tmp/build.sh
           chmod +x /tmp/build.sh
@@ -418,6 +426,14 @@ jobs:
         uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896  # v2
         with:
           mask-password: 'true'
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: Setup tmate session only in debug mode
         uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101  # v3
         if: runner.debug == '1'
@@ -437,14 +453,14 @@ jobs:
         with:
           base_ref: ${{ env.BASE_REF }}
           tags: ${{ needs.goreleaser.outputs.ee_tags || needs.goreleaser.outputs.std_tags || format('{0}/tyk-ee:master', steps.ecr.outputs.registry) }}
-          github_token: ${{ secrets.ORG_GH_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           TYK_DB_LICENSEKEY: ${{ secrets.DASH_LICENSE }}
           TYK_MDCB_LICENSE: ${{ secrets.MDCB_LICENSE }}
       - name: Choose test code branch
         uses: TykTechnologies/github-actions/.github/actions/tests/choose-test-branch@2b35ab5dd4cfff21ced9d12446e9e27d10bf5785  # main
         with:
           test_folder: api
-          org_gh_token: ${{ secrets.ORG_GH_TOKEN }}
+          org_gh_token: ${{ steps.app-token.outputs.token }}
       - name: Run API tests
         uses: TykTechnologies/github-actions/.github/actions/tests/api-tests@2b35ab5dd4cfff21ced9d12446e9e27d10bf5785  # main
         timeout-minutes: 30
@@ -645,8 +661,21 @@ jobs:
       actions: read # This is required for the report_logs job in the called workflow
     uses: ./.github/workflows/release-tests.yml
     secrets: inherit
+  generate-token:
+    runs-on: ubuntu-latest
+    outputs:
+      token: ${{ steps.app-token.outputs.token }}
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
   sbom:
-    needs: goreleaser
+    needs: [goreleaser, generate-token]
     if: |
       !cancelled() &&
       needs.goreleaser.result == 'success'
@@ -654,4 +683,4 @@ jobs:
     secrets:
       DEPDASH_URL: ${{ secrets.DEPDASH_URL }}
       DEPDASH_KEY: ${{ secrets.DEPDASH_KEY }}
-      ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+      ORG_GH_TOKEN: ${{ needs.generate-token.outputs.token }}

--- a/.github/workflows/update-tyk-analytics.yml
+++ b/.github/workflows/update-tyk-analytics.yml
@@ -14,15 +14,23 @@ jobs:
     name: tyk-analytics
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - uses: peter-evans/repository-dispatch@ce5485de42c9b2622d2ed064be479e8ed65e76f4  # v1
         with:
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           repository: TykTechnologies/tyk-analytics
           event-type: new-tyk
           client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
       - uses: peter-evans/repository-dispatch@ce5485de42c9b2622d2ed064be479e8ed65e76f4  # v1
         with:
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           repository: TykTechnologies/tyk-sink
           event-type: new-tyk
           client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
## Summary
- Replace all `secrets.ORG_GH_TOKEN` (PAT) references with GitHub App tokens generated via `actions/create-github-app-token`
- Each job that needs the token gets its own `app-token` step; reusable workflow calls use a `generate-token` helper job
- Files modified: `ci-tests.yml`, `lint-swagger.yml`, `lint.yml`, `release.yml`, `update-tyk-analytics.yml`

## Test plan
- [ ] Verify CI workflows trigger correctly on a test PR to release-5.8
- [ ] Confirm the GitHub App token has sufficient permissions for all operations (checkout, repository-dispatch, etc.)
- [ ] Validate that reusable workflow calls (godoc, sbom) receive the token correctly

Jira: [TT-17030](https://tyktech.atlassian.net/browse/TT-17030)

[TT-17030]: https://tyktech.atlassian.net/browse/TT-17030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ