### PR TITLE
[TT-16865]: Gateway reads node id and nonce on 409

### DIFF
--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -1705,7 +1705,7 @@ func TestFromDashboardServiceAutoRecovery(t *testing.T) {
 		if strings.Contains(r.URL.Path, "/register/node") {
 			registrationCount++
 			w.Header().Set("Content-Type", "application/json")
-			response := NodeResponseOK{
+			response := NodeResponse{
 				Status:  "ok",
 				Message: map[string]string{"NodeID": "test-node-id"},
 				Nonce:   fmt.Sprintf("nonce-%d", registrationCount),
@@ -1893,7 +1893,7 @@ func TestFromDashboardServiceNoNodeIDFound(t *testing.T) {
 		if strings.Contains(r.URL.Path, "/register/node") {
 			registrationCount++
 			w.Header().Set("Content-Type", "application/json")
-			response := NodeResponseOK{
+			response := NodeResponse{
 				Status:  "ok",
 				Message: map[string]string{"NodeID": "test-node-id"},
 				Nonce:   fmt.Sprintf("nonce-%d", registrationCount),
@@ -2079,7 +2079,7 @@ func TestFromDashboardServiceNetworkErrorRecovery(t *testing.T) {
 		if strings.Contains(r.URL.Path, "/register/node") {
 			registrationCount++
 			w.Header().Set("Content-Type", "application/json")
-			response := NodeResponseOK{
+			response := NodeResponse{
 				Status:  "ok",
 				Message: map[string]string{"NodeID": "test-node-id"},
 				Nonce:   fmt.Sprintf("nonce-%d", registrationCount),

--- a/gateway/dashboard_recovery.go
+++ b/gateway/dashboard_recovery.go
@@ -2,13 +2,11 @@ package gateway
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
-	"time"
 )
 
 // DashboardAuthError represents a non-nonce authentication failure
@@ -112,10 +110,7 @@ func (gw *Gateway) attemptDashboardRecovery() error {
 		return errors.New("dashboard service not available for recovery")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	return gw.DashService.Register(ctx)
+	return gw.DashService.Register()
 }
 
 // shouldRetryOnNetworkError checks if an error is a network error that might benefit from retry

--- a/gateway/dashboard_recovery.go
+++ b/gateway/dashboard_recovery.go
@@ -2,7 +2,6 @@ package gateway
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -105,13 +104,15 @@ func (gw *Gateway) HandleDashboardResponseReadError(err error, errorContext stri
 	return false
 }
 
-// attemptDashboardRecovery attempts to re-register the node with the dashboard
+// attemptDashboardRecovery attempts to re-register the node with the dashboard.
+// It uses gw.ctx so that recovery is cancelled when the Gateway receives a shutdown
+// signal (SIGTERM/SIGINT), preventing goroutines from blocking indefinitely.
 func (gw *Gateway) attemptDashboardRecovery() error {
 	if gw.DashService == nil {
 		return errors.New("dashboard service not available for recovery")
 	}
 
-	return gw.DashService.Register(context.Background())
+	return gw.DashService.Register(gw.ctx)
 }
 
 // shouldRetryOnNetworkError checks if an error is a network error that might benefit from retry

--- a/gateway/dashboard_recovery.go
+++ b/gateway/dashboard_recovery.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -110,7 +111,7 @@ func (gw *Gateway) attemptDashboardRecovery() error {
 		return errors.New("dashboard service not available for recovery")
 	}
 
-	return gw.DashService.Register()
+	return gw.DashService.Register(context.Background())
 }
 
 // shouldRetryOnNetworkError checks if an error is a network error that might benefit from retry

--- a/gateway/dashboard_recovery_test.go
+++ b/gateway/dashboard_recovery_test.go
@@ -1,0 +1,79 @@
+package gateway
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDashboardAuthError_Error(t *testing.T) {
+	err := &DashboardAuthError{StatusCode: 403, Body: "Nonce failed"}
+	assert.Equal(t, "dashboard authentication failed (status 403): Nonce failed", err.Error())
+}
+
+func Test_shouldRetryOnNetworkError(t *testing.T) {
+	tests := []struct {
+		name  string
+		err   error
+		retry bool
+	}{
+		{"nil error", nil, false},
+		{"io.EOF", io.EOF, true},
+		{"io.ErrUnexpectedEOF", io.ErrUnexpectedEOF, true},
+		{"string EOF", errors.New("read tcp: EOF"), true},
+		{"connection refused", errors.New("dial tcp: connection refused"), true},
+		{"connection reset", errors.New("read tcp: connection reset by peer"), true},
+		{"broken pipe", errors.New("write tcp: broken pipe"), true},
+		{"i/o timeout", errors.New("dial tcp: i/o timeout"), true},
+		{"no such host", errors.New("dial tcp: no such host"), true},
+		{"network is unreachable", errors.New("connect: network is unreachable"), true},
+		{"unrelated error", errors.New("something else entirely"), false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.retry, shouldRetryOnNetworkError(tc.err))
+		})
+	}
+}
+
+func Test_isNonceRelatedError(t *testing.T) {
+	tests := []struct {
+		msg   string
+		match bool
+	}{
+		{"Nonce failed", true},
+		{"nonce mismatch detected", true},
+		{"No node ID Found", true},
+		{"dashboard is down", false},
+		{"", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%q", tc.msg), func(t *testing.T) {
+			assert.Equal(t, tc.match, isNonceRelatedError(tc.msg))
+		})
+	}
+}
+
+func Test_isEOFError(t *testing.T) {
+	tests := []struct {
+		name  string
+		err   error
+		match bool
+	}{
+		{"io.EOF", io.EOF, true},
+		{"io.ErrUnexpectedEOF", io.ErrUnexpectedEOF, true},
+		{"string containing EOF", errors.New("read tcp: EOF"), true},
+		{"unrelated error", errors.New("some other error"), false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.match, isEOFError(tc.err))
+		})
+	}
+}

--- a/gateway/dashboard_register.go
+++ b/gateway/dashboard_register.go
@@ -24,7 +24,7 @@ type NodeResponse struct {
 
 type DashboardServiceSender interface {
 	Init() error
-	Register() error
+	Register(ctx context.Context) error
 	DeRegister() error
 	StartBeating(ctx context.Context) error
 	StopBeating()
@@ -107,7 +107,7 @@ func (gw *Gateway) reLogin() {
 
 	time.Sleep(5 * time.Second)
 
-	if err := gw.DashService.Register(); err != nil {
+	if err := gw.DashService.Register(context.Background()); err != nil {
 		dashLog.Error("Could not register: ", err)
 	} else {
 		go func() {
@@ -189,7 +189,7 @@ func (h *HTTPDashboardHandler) NotifyDashboardOfEvent(event interface{}) error {
 	return nil
 }
 
-func (h *HTTPDashboardHandler) Register() error {
+func (h *HTTPDashboardHandler) Register(ctx context.Context) error {
 	dashLog.Info("Registering gateway node with Dashboard")
 
 	for {
@@ -201,14 +201,22 @@ func (h *HTTPDashboardHandler) Register() error {
 
 		if err != nil {
 			dashLog.Errorf("Request failed with error %v; retrying in 5s", err)
-			time.Sleep(5 * time.Second)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(5 * time.Second):
+			}
 			continue
 		}
 
 		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusConflict {
 			resp.Body.Close()
 			dashLog.Errorf("Response failed with code %d; retrying in 5s", resp.StatusCode)
-			time.Sleep(5 * time.Second)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(5 * time.Second):
+			}
 			continue
 		}
 
@@ -222,7 +230,11 @@ func (h *HTTPDashboardHandler) Register() error {
 		// 409 with Status != "OK" means lock contention or Redis failure — retry.
 		if resp.StatusCode == http.StatusConflict && val.Status != "OK" {
 			dashLog.Warning("Registration deferred (409 with status: ", val.Status, "); retrying in 5s")
-			time.Sleep(5 * time.Second)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(5 * time.Second):
+			}
 			continue
 		}
 
@@ -230,13 +242,21 @@ func (h *HTTPDashboardHandler) Register() error {
 		msgMap, ok := val.Message.(map[string]interface{})
 		if !ok {
 			dashLog.Error("Failed to register node, retrying in 5s")
-			time.Sleep(5 * time.Second)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(5 * time.Second):
+			}
 			continue
 		}
 		nodeID, ok := msgMap["NodeID"].(string)
 		if !ok || nodeID == "" {
 			dashLog.Error("Failed to register node, retrying in 5s")
-			time.Sleep(5 * time.Second)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(5 * time.Second):
+			}
 			continue
 		}
 
@@ -317,7 +337,7 @@ func (h *HTTPDashboardHandler) sendHeartBeat(req *http.Request, client *http.Cli
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusForbidden {
-		return h.Gw.DashService.Register()
+		return h.Gw.DashService.Register(ctx)
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/gateway/dashboard_register.go
+++ b/gateway/dashboard_register.go
@@ -201,75 +201,43 @@ func (h *HTTPDashboardHandler) Register(ctx context.Context) error {
 
 		if err != nil {
 			dashLog.Errorf("Request failed with error %v; retrying in 5s", err)
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(5 * time.Second):
-			}
-			continue
-		}
-
-		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusConflict {
+		} else if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusConflict {
 			resp.Body.Close()
 			dashLog.Errorf("Response failed with code %d; retrying in 5s", resp.StatusCode)
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(5 * time.Second):
+		} else {
+			val := NodeResponse{}
+			if err := json.NewDecoder(resp.Body).Decode(&val); err != nil {
+				resp.Body.Close()
+				return err
 			}
-			continue
-		}
-
-		val := NodeResponse{}
-		if err := json.NewDecoder(resp.Body).Decode(&val); err != nil {
 			resp.Body.Close()
-			return err
-		}
-		resp.Body.Close()
 
-		// 409 with Status != "OK" means lock contention or Redis failure — retry.
-		if resp.StatusCode == http.StatusConflict && val.Status != "OK" {
-			dashLog.Warning("Registration deferred (409 with status: ", val.Status, "); retrying in 5s")
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(5 * time.Second):
+			// 409 with Status != "OK" means lock contention or Redis failure — retry.
+			if resp.StatusCode == http.StatusConflict && val.Status != "OK" {
+				dashLog.Warning("Registration deferred (409 with status: ", val.Status, "); retrying in 5s")
+			} else if msgMap, ok := val.Message.(map[string]interface{}); !ok {
+				dashLog.Error("Failed to register node, retrying in 5s")
+			} else if nodeID, ok := msgMap["NodeID"].(string); !ok || nodeID == "" {
+				dashLog.Error("Failed to register node, retrying in 5s")
+			} else {
+				h.Gw.SetNodeID(nodeID)
+				dashLog.WithField("id", h.Gw.GetNodeID()).Info("Node Registered")
+
+				h.Gw.ServiceNonceMutex.Lock()
+				h.Gw.ServiceNonce = val.Nonce
+				h.Gw.ServiceNonceMutex.Unlock()
+				dashLog.Debug("Registration Finished: Nonce Set: ", val.Nonce)
+				h.Gw.DoReloadWithRetry(context.Background())
+
+				return nil
 			}
-			continue
 		}
 
-		// Both 200 and duplicate-session 409 (Status=="OK") carry a NodeID.
-		msgMap, ok := val.Message.(map[string]interface{})
-		if !ok {
-			dashLog.Error("Failed to register node, retrying in 5s")
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(5 * time.Second):
-			}
-			continue
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(5 * time.Second):
 		}
-		nodeID, ok := msgMap["NodeID"].(string)
-		if !ok || nodeID == "" {
-			dashLog.Error("Failed to register node, retrying in 5s")
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(5 * time.Second):
-			}
-			continue
-		}
-
-		h.Gw.SetNodeID(nodeID)
-		dashLog.WithField("id", h.Gw.GetNodeID()).Info("Node Registered")
-
-		h.Gw.ServiceNonceMutex.Lock()
-		h.Gw.ServiceNonce = val.Nonce
-		h.Gw.ServiceNonceMutex.Unlock()
-		dashLog.Debug("Registration Finished: Nonce Set: ", val.Nonce)
-		h.Gw.DoReloadWithRetry(context.Background())
-
-		return nil
 	}
 }
 

--- a/gateway/dashboard_register.go
+++ b/gateway/dashboard_register.go
@@ -206,10 +206,7 @@ func (h *HTTPDashboardHandler) Register(ctx context.Context) error {
 		case <-time.After(5 * time.Second):
 		}
 		return h.Register(ctx)
-	} else if resp.StatusCode == http.StatusConflict {
-		dashLog.Debug("Node is already registered")
-		return nil
-	} else if resp != nil && resp.StatusCode != 200 {
+	} else if resp != nil && resp.StatusCode != 200 && resp.StatusCode != http.StatusConflict {
 		dashLog.Errorf("Response failed with code %d; retrying in 5s", resp.StatusCode)
 		select {
 		case <-ctx.Done():

--- a/gateway/dashboard_register.go
+++ b/gateway/dashboard_register.go
@@ -16,9 +16,9 @@ import (
 
 var dashLog = log.WithField("prefix", "dashboard")
 
-type NodeResponseOK struct {
+type NodeResponse struct {
 	Status  string
-	Message map[string]string
+	Message any
 	Nonce   string
 }
 
@@ -177,7 +177,7 @@ func (h *HTTPDashboardHandler) NotifyDashboardOfEvent(event interface{}) error {
 		return err
 	}
 
-	val := NodeResponseOK{}
+	val := NodeResponse{}
 	if err := json.NewDecoder(resp.Body).Decode(&val); err != nil {
 		return err
 	}
@@ -218,7 +218,7 @@ func (h *HTTPDashboardHandler) Register(ctx context.Context) error {
 
 	defer resp.Body.Close()
 
-	val := NodeResponseOK{}
+	val := NodeResponse{}
 	if err := json.NewDecoder(resp.Body).Decode(&val); err != nil {
 		return err
 	}
@@ -236,8 +236,18 @@ func (h *HTTPDashboardHandler) Register(ctx context.Context) error {
 	}
 
 	// Both 200 and duplicate-session 409 (Status=="OK") carry a NodeID.
-	nodeID, found := val.Message["NodeID"]
-	if !found || nodeID == "" {
+	msgMap, ok := val.Message.(map[string]interface{})
+	if !ok {
+		dashLog.Error("Failed to register node, retrying in 5s")
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(5 * time.Second):
+		}
+		return h.Register(ctx)
+	}
+	nodeID, _ := msgMap["NodeID"].(string)
+	if nodeID == "" {
 		dashLog.Error("Failed to register node, retrying in 5s")
 		select {
 		case <-ctx.Done():
@@ -330,7 +340,7 @@ func (h *HTTPDashboardHandler) sendHeartBeat(req *http.Request, client *http.Cli
 	if resp.StatusCode != http.StatusOK {
 		return errors.New("dashboard is down? Heartbeat non-200 response")
 	}
-	val := NodeResponseOK{}
+	val := NodeResponse{}
 	if err := json.NewDecoder(resp.Body).Decode(&val); err != nil {
 		return err
 	}
@@ -363,7 +373,7 @@ func (h *HTTPDashboardHandler) DeRegister() error {
 		return fmt.Errorf("deregister request failed with status %d", resp.StatusCode)
 	}
 
-	val := NodeResponseOK{}
+	val := NodeResponse{}
 	if err := json.NewDecoder(resp.Body).Decode(&val); err != nil {
 		return err
 	}

--- a/gateway/dashboard_register.go
+++ b/gateway/dashboard_register.go
@@ -107,11 +107,11 @@ func (gw *Gateway) reLogin() {
 
 	time.Sleep(5 * time.Second)
 
-	if err := gw.DashService.Register(context.Background()); err != nil {
+	if err := gw.DashService.Register(gw.ctx); err != nil {
 		dashLog.Error("Could not register: ", err)
 	} else {
 		go func() {
-			beatErr := gw.DashService.StartBeating(context.Background())
+			beatErr := gw.DashService.StartBeating(gw.ctx)
 			if beatErr != nil {
 				dashLog.Error("Could not start beating. ", beatErr.Error())
 			}
@@ -227,7 +227,7 @@ func (h *HTTPDashboardHandler) Register(ctx context.Context) error {
 				h.Gw.ServiceNonce = val.Nonce
 				h.Gw.ServiceNonceMutex.Unlock()
 				dashLog.Debug("Registration Finished: Nonce Set: ", val.Nonce)
-				h.Gw.DoReloadWithRetry(context.Background())
+				h.Gw.DoReloadWithRetry(ctx)
 
 				return nil
 			}

--- a/gateway/dashboard_register.go
+++ b/gateway/dashboard_register.go
@@ -217,16 +217,27 @@ func (h *HTTPDashboardHandler) Register(ctx context.Context) error {
 	}
 
 	defer resp.Body.Close()
+
 	val := NodeResponseOK{}
 	if err := json.NewDecoder(resp.Body).Decode(&val); err != nil {
 		return err
 	}
 
-	// Set the NodeID
-	var found bool
+	// Any 409 whose Status is not "OK" means the gateway has not been assigned a node yet
+	// (lock contention, Redis failure, etc). Retry after backoff.
+	if resp.StatusCode == http.StatusConflict && val.Status != "OK" {
+		dashLog.Warning("Registration deferred (409 with status: ", val.Status, "); retrying in 5s")
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(5 * time.Second):
+		}
+		return h.Register(ctx)
+	}
+
+	// Both 200 and duplicate-session 409 (Status=="OK") carry a NodeID.
 	nodeID, found := val.Message["NodeID"]
-	h.Gw.SetNodeID(nodeID)
-	if !found {
+	if !found || nodeID == "" {
 		dashLog.Error("Failed to register node, retrying in 5s")
 		select {
 		case <-ctx.Done():
@@ -236,6 +247,7 @@ func (h *HTTPDashboardHandler) Register(ctx context.Context) error {
 		return h.Register(ctx)
 	}
 
+	h.Gw.SetNodeID(nodeID)
 	dashLog.WithField("id", h.Gw.GetNodeID()).Info("Node Registered")
 
 	// Set the nonce

--- a/gateway/dashboard_register.go
+++ b/gateway/dashboard_register.go
@@ -24,7 +24,7 @@ type NodeResponse struct {
 
 type DashboardServiceSender interface {
 	Init() error
-	Register(ctx context.Context) error
+	Register() error
 	DeRegister() error
 	StartBeating(ctx context.Context) error
 	StopBeating()
@@ -107,7 +107,7 @@ func (gw *Gateway) reLogin() {
 
 	time.Sleep(5 * time.Second)
 
-	if err := gw.DashService.Register(context.Background()); err != nil {
+	if err := gw.DashService.Register(); err != nil {
 		dashLog.Error("Could not register: ", err)
 	} else {
 		go func() {
@@ -189,85 +189,68 @@ func (h *HTTPDashboardHandler) NotifyDashboardOfEvent(event interface{}) error {
 	return nil
 }
 
-func (h *HTTPDashboardHandler) Register(ctx context.Context) error {
+func (h *HTTPDashboardHandler) Register() error {
 	dashLog.Info("Registering gateway node with Dashboard")
-	req := h.newRequest(http.MethodGet, h.RegistrationEndpoint)
-	req.Header.Set(header.XTykSessionID, h.Gw.SessionID)
 
-	c := h.Gw.initialiseClient()
+	for {
+		req := h.newRequest(http.MethodGet, h.RegistrationEndpoint)
+		req.Header.Set(header.XTykSessionID, h.Gw.SessionID)
 
-	resp, err := c.Do(req)
+		c := h.Gw.initialiseClient()
+		resp, err := c.Do(req)
 
-	if err != nil {
-		dashLog.Errorf("Request failed with error %v; retrying in 5s", err)
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(5 * time.Second):
+		if err != nil {
+			dashLog.Errorf("Request failed with error %v; retrying in 5s", err)
+			time.Sleep(5 * time.Second)
+			continue
 		}
-		return h.Register(ctx)
-	} else if resp != nil && resp.StatusCode != 200 && resp.StatusCode != http.StatusConflict {
-		dashLog.Errorf("Response failed with code %d; retrying in 5s", resp.StatusCode)
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(5 * time.Second):
+
+		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusConflict {
+			resp.Body.Close()
+			dashLog.Errorf("Response failed with code %d; retrying in 5s", resp.StatusCode)
+			time.Sleep(5 * time.Second)
+			continue
 		}
-		return h.Register(ctx)
-	}
 
-	defer resp.Body.Close()
-
-	val := NodeResponse{}
-	if err := json.NewDecoder(resp.Body).Decode(&val); err != nil {
-		return err
-	}
-
-	// Any 409 whose Status is not "OK" means the gateway has not been assigned a node yet
-	// (lock contention, Redis failure, etc). Retry after backoff.
-	if resp.StatusCode == http.StatusConflict && val.Status != "OK" {
-		dashLog.Warning("Registration deferred (409 with status: ", val.Status, "); retrying in 5s")
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(5 * time.Second):
+		val := NodeResponse{}
+		if err := json.NewDecoder(resp.Body).Decode(&val); err != nil {
+			resp.Body.Close()
+			return err
 		}
-		return h.Register(ctx)
-	}
+		resp.Body.Close()
 
-	// Both 200 and duplicate-session 409 (Status=="OK") carry a NodeID.
-	msgMap, ok := val.Message.(map[string]interface{})
-	if !ok {
-		dashLog.Error("Failed to register node, retrying in 5s")
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(5 * time.Second):
+		// 409 with Status != "OK" means lock contention or Redis failure — retry.
+		if resp.StatusCode == http.StatusConflict && val.Status != "OK" {
+			dashLog.Warning("Registration deferred (409 with status: ", val.Status, "); retrying in 5s")
+			time.Sleep(5 * time.Second)
+			continue
 		}
-		return h.Register(ctx)
-	}
-	nodeID, _ := msgMap["NodeID"].(string)
-	if nodeID == "" {
-		dashLog.Error("Failed to register node, retrying in 5s")
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(5 * time.Second):
+
+		// Both 200 and duplicate-session 409 (Status=="OK") carry a NodeID.
+		msgMap, ok := val.Message.(map[string]interface{})
+		if !ok {
+			dashLog.Error("Failed to register node, retrying in 5s")
+			time.Sleep(5 * time.Second)
+			continue
 		}
-		return h.Register(ctx)
+		nodeID, ok := msgMap["NodeID"].(string)
+		if !ok || nodeID == "" {
+			dashLog.Error("Failed to register node, retrying in 5s")
+			time.Sleep(5 * time.Second)
+			continue
+		}
+
+		h.Gw.SetNodeID(nodeID)
+		dashLog.WithField("id", h.Gw.GetNodeID()).Info("Node Registered")
+
+		h.Gw.ServiceNonceMutex.Lock()
+		h.Gw.ServiceNonce = val.Nonce
+		h.Gw.ServiceNonceMutex.Unlock()
+		dashLog.Debug("Registration Finished: Nonce Set: ", val.Nonce)
+		h.Gw.DoReloadWithRetry(context.Background())
+
+		return nil
 	}
-
-	h.Gw.SetNodeID(nodeID)
-	dashLog.WithField("id", h.Gw.GetNodeID()).Info("Node Registered")
-
-	// Set the nonce
-	h.Gw.ServiceNonceMutex.Lock()
-	h.Gw.ServiceNonce = val.Nonce
-	h.Gw.ServiceNonceMutex.Unlock()
-	dashLog.Debug("Registration Finished: Nonce Set: ", val.Nonce)
-	h.Gw.DoReloadWithRetry(ctx)
-
-	return nil
 }
 
 func (h *HTTPDashboardHandler) Ping() error {
@@ -334,7 +317,7 @@ func (h *HTTPDashboardHandler) sendHeartBeat(req *http.Request, client *http.Cli
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusForbidden {
-		return h.Gw.DashService.Register(ctx)
+		return h.Gw.DashService.Register()
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/gateway/dashboard_register.go
+++ b/gateway/dashboard_register.go
@@ -189,48 +189,40 @@ func (h *HTTPDashboardHandler) NotifyDashboardOfEvent(event interface{}) error {
 	return nil
 }
 
+// parseRegistrationResponse extracts the NodeID from a successful registration
+// response body. It returns ("", false) when a retry should be attempted.
+func parseRegistrationResponse(statusCode int, val NodeResponse) (nodeID string, ok bool) {
+	// 409 with Status != "OK" means lock contention or Redis failure — retry.
+	if statusCode == http.StatusConflict && val.Status != "OK" {
+		dashLog.Warning("Registration deferred (409 with status: ", val.Status, "); retrying in 5s")
+		return "", false
+	}
+
+	msgMap, ok := val.Message.(map[string]interface{})
+	if !ok {
+		dashLog.Error("Failed to register node, retrying in 5s")
+		return "", false
+	}
+
+	nodeID, ok = msgMap["NodeID"].(string)
+	if !ok || nodeID == "" {
+		dashLog.Error("Failed to register node, retrying in 5s")
+		return "", false
+	}
+
+	return nodeID, true
+}
+
 func (h *HTTPDashboardHandler) Register(ctx context.Context) error {
 	dashLog.Info("Registering gateway node with Dashboard")
 
 	for {
-		req := h.newRequestWithContext(ctx, http.MethodGet, h.RegistrationEndpoint)
-		req.Header.Set(header.XTykSessionID, h.Gw.SessionID)
-
-		c := h.Gw.initialiseClient()
-		resp, err := c.Do(req)
-
+		registered, err := h.attemptRegistration(ctx)
 		if err != nil {
-			dashLog.Errorf("Request failed with error %v; retrying in 5s", err)
-		} else if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusConflict {
-			resp.Body.Close()
-			dashLog.Errorf("Response failed with code %d; retrying in 5s", resp.StatusCode)
-		} else {
-			val := NodeResponse{}
-			if err := json.NewDecoder(resp.Body).Decode(&val); err != nil {
-				resp.Body.Close()
-				return err
-			}
-			resp.Body.Close()
-
-			// 409 with Status != "OK" means lock contention or Redis failure — retry.
-			if resp.StatusCode == http.StatusConflict && val.Status != "OK" {
-				dashLog.Warning("Registration deferred (409 with status: ", val.Status, "); retrying in 5s")
-			} else if msgMap, ok := val.Message.(map[string]interface{}); !ok {
-				dashLog.Error("Failed to register node, retrying in 5s")
-			} else if nodeID, ok := msgMap["NodeID"].(string); !ok || nodeID == "" {
-				dashLog.Error("Failed to register node, retrying in 5s")
-			} else {
-				h.Gw.SetNodeID(nodeID)
-				dashLog.WithField("id", h.Gw.GetNodeID()).Info("Node Registered")
-
-				h.Gw.ServiceNonceMutex.Lock()
-				h.Gw.ServiceNonce = val.Nonce
-				h.Gw.ServiceNonceMutex.Unlock()
-				dashLog.Debug("Registration Finished: Nonce Set: ", val.Nonce)
-				h.Gw.DoReloadWithRetry(ctx)
-
-				return nil
-			}
+			return err
+		}
+		if registered {
+			return nil
 		}
 
 		select {
@@ -239,6 +231,44 @@ func (h *HTTPDashboardHandler) Register(ctx context.Context) error {
 		case <-time.After(5 * time.Second):
 		}
 	}
+}
+
+func (h *HTTPDashboardHandler) attemptRegistration(ctx context.Context) (registered bool, err error) {
+	req := h.newRequestWithContext(ctx, http.MethodGet, h.RegistrationEndpoint)
+	req.Header.Set(header.XTykSessionID, h.Gw.SessionID)
+
+	resp, err := h.Gw.initialiseClient().Do(req)
+	if err != nil {
+		dashLog.Errorf("Request failed with error %v; retrying in 5s", err)
+		return false, nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusConflict {
+		dashLog.Errorf("Response failed with code %d; retrying in 5s", resp.StatusCode)
+		return false, nil
+	}
+
+	var val NodeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&val); err != nil {
+		return false, err
+	}
+
+	nodeID, ok := parseRegistrationResponse(resp.StatusCode, val)
+	if !ok {
+		return false, nil
+	}
+
+	h.Gw.SetNodeID(nodeID)
+	dashLog.WithField("id", h.Gw.GetNodeID()).Info("Node Registered")
+
+	h.Gw.ServiceNonceMutex.Lock()
+	h.Gw.ServiceNonce = val.Nonce
+	h.Gw.ServiceNonceMutex.Unlock()
+	dashLog.Debug("Registration Finished: Nonce Set: ", val.Nonce)
+	h.Gw.DoReloadWithRetry(ctx)
+
+	return true, nil
 }
 
 func (h *HTTPDashboardHandler) Ping() error {

--- a/gateway/dashboard_register.go
+++ b/gateway/dashboard_register.go
@@ -193,7 +193,7 @@ func (h *HTTPDashboardHandler) Register(ctx context.Context) error {
 	dashLog.Info("Registering gateway node with Dashboard")
 
 	for {
-		req := h.newRequest(http.MethodGet, h.RegistrationEndpoint)
+		req := h.newRequestWithContext(ctx, http.MethodGet, h.RegistrationEndpoint)
 		req.Header.Set(header.XTykSessionID, h.Gw.SessionID)
 
 		c := h.Gw.initialiseClient()
@@ -285,10 +285,24 @@ func (h *HTTPDashboardHandler) newRequest(method, endpoint string) *http.Request
 	if err != nil {
 		panic(err)
 	}
+	h.addHeaderToRequest(req)
+	return req
+}
+
+func (h *HTTPDashboardHandler) newRequestWithContext(ctx context.Context, method, endpoint string) *http.Request {
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	h.addHeaderToRequest(req)
+	return req
+}
+
+func (h *HTTPDashboardHandler) addHeaderToRequest(req *http.Request) {
 	req.Header.Set("authorization", h.Secret)
 	req.Header.Set(header.XTykHostname, h.Gw.hostDetails.Hostname)
 	req.Header.Set(header.XTykSessionID, h.Gw.SessionID)
-	return req
 }
 
 func (h *HTTPDashboardHandler) sendHeartBeat(req *http.Request, client *http.Client, ctx context.Context) error {

--- a/gateway/dashboard_register_test.go
+++ b/gateway/dashboard_register_test.go
@@ -118,6 +118,25 @@ func TestRegister_DuplicateSession409(t *testing.T) {
 	assert.Equal(t, int32(1), atomic.LoadInt32(&callCount))
 }
 
+// retryTestHandler returns an httptest handler that responds with firstStatus/firstBody
+// on the first call, then with a successful registration response on subsequent calls.
+func retryTestHandler(t *testing.T, callCount *int32, firstStatus int, firstBody string) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if atomic.AddInt32(callCount, 1) == 1 {
+			w.WriteHeader(firstStatus)
+			if firstBody != "" {
+				if _, err := w.Write([]byte(firstBody)); err != nil {
+					t.Errorf("failed to write response body: %v", err)
+				}
+			}
+			return
+		}
+		writeJSON(t, w, okResponse("node-after-retry", "nonce-after-retry"))
+	})
+}
+
 // TestRegister_Retries verifies that non-successful responses trigger a retry and the
 // gateway correctly registers on the subsequent successful response.
 func TestRegister_Retries(t *testing.T) {
@@ -141,20 +160,7 @@ func TestRegister_Retries(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			var callCount int32
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				call := atomic.AddInt32(&callCount, 1)
-				w.Header().Set("Content-Type", "application/json")
-				if call == 1 {
-					w.WriteHeader(tc.firstStatus)
-					if tc.firstBody != "" {
-						if _, err := w.Write([]byte(tc.firstBody)); err != nil {
-							t.Errorf("failed to write response body: %v", err)
-						}
-					}
-					return
-				}
-				writeJSON(t, w, okResponse("node-after-retry", "nonce-after-retry"))
-			}))
+			srv := httptest.NewServer(retryTestHandler(t, &callCount, tc.firstStatus, tc.firstBody))
 			defer srv.Close()
 
 			h, close := newTestDashboardHandler(t, srv.URL)

--- a/gateway/dashboard_register_test.go
+++ b/gateway/dashboard_register_test.go
@@ -60,10 +60,10 @@ func writeJSON(t *testing.T, w http.ResponseWriter, v interface{}) {
 	}
 }
 
-func okResponse(nodeID, nonce string) NodeResponseOK {
-	return NodeResponseOK{
+func okResponse(nodeID, nonce string) NodeResponse {
+	return NodeResponse{
 		Status:  "OK",
-		Message: map[string]string{"NodeID": nodeID},
+		Message: map[string]any{"NodeID": nodeID},
 		Nonce:   nonce,
 	}
 }

--- a/gateway/dashboard_register_test.go
+++ b/gateway/dashboard_register_test.go
@@ -1,10 +1,16 @@
 package gateway
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/TykTechnologies/tyk/config"
 )
@@ -27,6 +33,148 @@ func Test_BuildDashboardConnStr(t *testing.T) {
 	connStr := ts.Gw.buildDashboardConnStr("/test")
 
 	assert.Equal(t, connStr, "http://localhost/test")
+}
+
+func newTestDashboardHandler(t *testing.T, serverURL string) (*HTTPDashboardHandler, func()) {
+	t.Helper()
+	conf := func(c *config.Config) {
+		c.UseDBAppConfigs = false
+		c.NodeSecret = "test-secret"
+		c.DBAppConfOptions.ConnectionTimeout = 2
+		c.DisableDashboardZeroConf = true
+	}
+	g := StartTest(conf)
+	handler := &HTTPDashboardHandler{
+		Gw:                   g.Gw,
+		Secret:               "test-secret",
+		RegistrationEndpoint: serverURL + "/register/node",
+	}
+	g.Gw.DashService = handler
+	return handler, g.Close
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, v interface{}) {
+	t.Helper()
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Fatalf("failed to write JSON response: %v", err)
+	}
+}
+
+func okResponse(nodeID, nonce string) NodeResponseOK {
+	return NodeResponseOK{
+		Status:  "OK",
+		Message: map[string]string{"NodeID": nodeID},
+		Nonce:   nonce,
+	}
+}
+
+// TestRegister_Success verifies a 200 response sets NodeID and Nonce.
+func TestRegister_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		writeJSON(t, w, okResponse("node-abc-123", "nonce-1"))
+	}))
+	defer srv.Close()
+
+	h, close := newTestDashboardHandler(t, srv.URL)
+	defer close()
+
+	require.NoError(t, h.Register(context.Background()))
+
+	assert.Equal(t, "node-abc-123", h.Gw.GetNodeID())
+
+	h.Gw.ServiceNonceMutex.RLock()
+	gotNonce := h.Gw.ServiceNonce
+	h.Gw.ServiceNonceMutex.RUnlock()
+	assert.Equal(t, "nonce-1", gotNonce)
+}
+
+// TestRegister_DuplicateSession409 verifies that a 409 with Status "OK" is treated as a
+// successful registration — NodeID and Nonce are set and no retry is made.
+// The old code returned nil on any 409 without reading the body, leaving NodeID and Nonce
+// empty and causing the 403 -> 409 infinite loop.
+func TestRegister_DuplicateSession409(t *testing.T) {
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		writeJSON(t, w, okResponse("node-already-registered", "fresh-nonce-from-409"))
+	}))
+	defer srv.Close()
+
+	h, close := newTestDashboardHandler(t, srv.URL)
+	defer close()
+
+	require.NoError(t, h.Register(context.Background()))
+
+	assert.Equal(t, "node-already-registered", h.Gw.GetNodeID())
+
+	h.Gw.ServiceNonceMutex.RLock()
+	gotNonce := h.Gw.ServiceNonce
+	h.Gw.ServiceNonceMutex.RUnlock()
+	assert.Equal(t, "fresh-nonce-from-409", gotNonce)
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&callCount))
+}
+
+// TestRegister_Retries verifies that non-successful responses trigger a retry and the
+// gateway correctly registers on the subsequent successful response.
+func TestRegister_Retries(t *testing.T) {
+	tests := []struct {
+		name        string
+		firstStatus int
+		firstBody   string
+	}{
+		{
+			name:        "lock contention 409",
+			firstStatus: http.StatusConflict,
+			firstBody:   `{"Status":"Error","Message":"Another registration operation in progress"}`,
+		},
+		{
+			name:        "service unavailable 503",
+			firstStatus: http.StatusServiceUnavailable,
+			firstBody:   "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var callCount int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				call := atomic.AddInt32(&callCount, 1)
+				w.Header().Set("Content-Type", "application/json")
+				if call == 1 {
+					w.WriteHeader(tc.firstStatus)
+					if tc.firstBody != "" {
+						if _, err := w.Write([]byte(tc.firstBody)); err != nil {
+							t.Errorf("failed to write response body: %v", err)
+						}
+					}
+					return
+				}
+				writeJSON(t, w, okResponse("node-after-retry", "nonce-after-retry"))
+			}))
+			defer srv.Close()
+
+			h, close := newTestDashboardHandler(t, srv.URL)
+			defer close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+
+			require.NoError(t, h.Register(ctx))
+
+			assert.Equal(t, "node-after-retry", h.Gw.GetNodeID())
+
+			h.Gw.ServiceNonceMutex.RLock()
+			gotNonce := h.Gw.ServiceNonce
+			h.Gw.ServiceNonceMutex.RUnlock()
+			assert.Equal(t, "nonce-after-retry", gotNonce)
+
+			assert.Equal(t, int32(2), atomic.LoadInt32(&callCount))
+		})
+	}
 }
 
 func Test_DashboardLifecycle(t *testing.T) {

--- a/gateway/dashboard_register_test.go
+++ b/gateway/dashboard_register_test.go
@@ -1,7 +1,6 @@
 package gateway
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -79,7 +78,7 @@ func TestRegister_Success(t *testing.T) {
 	h, close := newTestDashboardHandler(t, srv.URL)
 	defer close()
 
-	require.NoError(t, h.Register(context.Background()))
+	require.NoError(t, h.Register())
 
 	assert.Equal(t, "node-abc-123", h.Gw.GetNodeID())
 
@@ -106,7 +105,7 @@ func TestRegister_DuplicateSession409(t *testing.T) {
 	h, close := newTestDashboardHandler(t, srv.URL)
 	defer close()
 
-	require.NoError(t, h.Register(context.Background()))
+	require.NoError(t, h.Register())
 
 	assert.Equal(t, "node-already-registered", h.Gw.GetNodeID())
 
@@ -160,10 +159,7 @@ func TestRegister_Retries(t *testing.T) {
 			h, close := newTestDashboardHandler(t, srv.URL)
 			defer close()
 
-			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-			defer cancel()
-
-			require.NoError(t, h.Register(ctx))
+			require.NoError(t, h.Register())
 
 			assert.Equal(t, "node-after-retry", h.Gw.GetNodeID())
 

--- a/gateway/dashboard_register_test.go
+++ b/gateway/dashboard_register_test.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -78,7 +79,7 @@ func TestRegister_Success(t *testing.T) {
 	h, close := newTestDashboardHandler(t, srv.URL)
 	defer close()
 
-	require.NoError(t, h.Register())
+	require.NoError(t, h.Register(context.Background()))
 
 	assert.Equal(t, "node-abc-123", h.Gw.GetNodeID())
 
@@ -105,7 +106,7 @@ func TestRegister_DuplicateSession409(t *testing.T) {
 	h, close := newTestDashboardHandler(t, srv.URL)
 	defer close()
 
-	require.NoError(t, h.Register())
+	require.NoError(t, h.Register(context.Background()))
 
 	assert.Equal(t, "node-already-registered", h.Gw.GetNodeID())
 
@@ -159,7 +160,10 @@ func TestRegister_Retries(t *testing.T) {
 			h, close := newTestDashboardHandler(t, srv.URL)
 			defer close()
 
-			require.NoError(t, h.Register())
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+
+			require.NoError(t, h.Register(ctx))
 
 			assert.Equal(t, "node-after-retry", h.Gw.GetNodeID())
 

--- a/gateway/dashboard_register_test.go
+++ b/gateway/dashboard_register_test.go
@@ -183,6 +183,101 @@ func TestRegister_Retries(t *testing.T) {
 	}
 }
 
+func Test_parseRegistrationResponse(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		val        NodeResponse
+		wantNodeID string
+		wantOK     bool
+	}{
+		{
+			name:       "200 with valid NodeID",
+			statusCode: http.StatusOK,
+			val:        NodeResponse{Status: "OK", Message: map[string]any{"NodeID": "node-1"}},
+			wantNodeID: "node-1",
+			wantOK:     true,
+		},
+		{
+			name:       "409 with Status OK and valid NodeID",
+			statusCode: http.StatusConflict,
+			val:        NodeResponse{Status: "OK", Message: map[string]any{"NodeID": "node-already"}},
+			wantNodeID: "node-already",
+			wantOK:     true,
+		},
+		{
+			name:       "409 with Status not OK triggers retry",
+			statusCode: http.StatusConflict,
+			val:        NodeResponse{Status: "Error", Message: "lock contention"},
+			wantNodeID: "",
+			wantOK:     false,
+		},
+		{
+			name:       "non-map Message triggers retry",
+			statusCode: http.StatusOK,
+			val:        NodeResponse{Status: "OK", Message: "unexpected string"},
+			wantNodeID: "",
+			wantOK:     false,
+		},
+		{
+			name:       "nil Message triggers retry",
+			statusCode: http.StatusOK,
+			val:        NodeResponse{Status: "OK", Message: nil},
+			wantNodeID: "",
+			wantOK:     false,
+		},
+		{
+			name:       "map Message missing NodeID triggers retry",
+			statusCode: http.StatusOK,
+			val:        NodeResponse{Status: "OK", Message: map[string]any{"Other": "value"}},
+			wantNodeID: "",
+			wantOK:     false,
+		},
+		{
+			name:       "map Message with empty NodeID triggers retry",
+			statusCode: http.StatusOK,
+			val:        NodeResponse{Status: "OK", Message: map[string]any{"NodeID": ""}},
+			wantNodeID: "",
+			wantOK:     false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotNodeID, gotOK := parseRegistrationResponse(tc.statusCode, tc.val)
+			assert.Equal(t, tc.wantOK, gotOK)
+			assert.Equal(t, tc.wantNodeID, gotNodeID)
+		})
+	}
+}
+
+func TestAttemptRegistration_InvalidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte("not-valid-json"))
+		require.NoError(t, err)
+	}))
+	defer srv.Close()
+
+	h, close := newTestDashboardHandler(t, srv.URL)
+	defer close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	err := h.Register(ctx)
+	assert.Error(t, err)
+}
+
+func TestNewRequestWithContext_InvalidURL_Panics(t *testing.T) {
+	h, close := newTestDashboardHandler(t, "http://localhost")
+	defer close()
+
+	assert.Panics(t, func() {
+		h.newRequestWithContext(context.Background(), "INVALID METHOD", "://bad-url")
+	})
+}
+
 func Test_DashboardLifecycle(t *testing.T) {
 	var handler HTTPDashboardHandler
 

--- a/gateway/policy_test.go
+++ b/gateway/policy_test.go
@@ -677,7 +677,7 @@ func TestLoadPoliciesFromDashboardAutoRecovery(t *testing.T) {
 		if strings.Contains(r.URL.Path, "/register/node") {
 			registrationCount++
 			w.Header().Set("Content-Type", "application/json")
-			response := NodeResponseOK{
+			response := NodeResponse{
 				Status:  "ok",
 				Message: map[string]string{"NodeID": "test-node-id"},
 				Nonce:   fmt.Sprintf("nonce-%d", registrationCount),
@@ -879,7 +879,7 @@ func TestLoadPoliciesFromDashboardTimeoutSimulation(t *testing.T) {
 		if strings.Contains(r.URL.Path, "/register/node") {
 			registrationCount++
 			w.Header().Set("Content-Type", "application/json")
-			response := NodeResponseOK{
+			response := NodeResponse{
 				Status:  "ok",
 				Message: map[string]string{"NodeID": "test-node-id"},
 				Nonce:   fmt.Sprintf("nonce-%d", registrationCount),
@@ -984,7 +984,7 @@ func TestLoadPoliciesFromDashboardNoNodeIDFound(t *testing.T) {
 		if strings.Contains(r.URL.Path, "/register/node") {
 			registrationCount++
 			w.Header().Set("Content-Type", "application/json")
-			response := NodeResponseOK{
+			response := NodeResponse{
 				Status:  "ok",
 				Message: map[string]string{"NodeID": "test-node-id"},
 				Nonce:   fmt.Sprintf("nonce-%d", registrationCount),
@@ -1170,7 +1170,7 @@ func TestLoadPoliciesFromDashboardNetworkErrorRecovery(t *testing.T) {
 		if strings.Contains(r.URL.Path, "/register/node") {
 			registrationCount++
 			w.Header().Set("Content-Type", "application/json")
-			response := NodeResponseOK{
+			response := NodeResponse{
 				Status:  "ok",
 				Message: map[string]string{"NodeID": "test-node-id"},
 				Nonce:   fmt.Sprintf("nonce-%d", registrationCount),
@@ -1299,7 +1299,7 @@ func TestLoadPoliciesFromDashboardLoadBalancerDrain(t *testing.T) {
 				if strings.Contains(r.URL.Path, "/register/node") {
 					registrationCount++
 					w.Header().Set("Content-Type", "application/json")
-					response := NodeResponseOK{
+					response := NodeResponse{
 						Status:  "ok",
 						Message: map[string]string{"NodeID": "test-node-id"},
 						Nonce:   fmt.Sprintf("nonce-%d", registrationCount),

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -2373,7 +2373,7 @@ func handleDashboardRegistration(gw *Gateway) {
 	dashboardServiceInit(gw)
 
 	// connStr := buildDashboardConnStr("/register/node")
-	if err := gw.DashService.Register(); err != nil {
+	if err := gw.DashService.Register(gw.ctx); err != nil {
 		dashLog.Error("Registration failed: ", err)
 	}
 

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -2373,7 +2373,7 @@ func handleDashboardRegistration(gw *Gateway) {
 	dashboardServiceInit(gw)
 
 	// connStr := buildDashboardConnStr("/register/node")
-	if err := gw.DashService.Register(gw.ctx); err != nil {
+	if err := gw.DashService.Register(); err != nil {
 		dashLog.Error("Registration failed: ", err)
 	}
 

--- a/gateway/server_test.go
+++ b/gateway/server_test.go
@@ -2117,7 +2117,10 @@ func TestRegister_DoReloadWithRetry_OnStartup(t *testing.T) {
 	}
 	ts.Gw.performedSuccessfulReload = false
 
-	err := ts.Gw.DashService.Register()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := ts.Gw.DashService.Register(ctx)
 
 	assert.NoError(t, err, "Register should not return an error")
 	assert.True(t, ts.Gw.performedSuccessfulReload,

--- a/gateway/server_test.go
+++ b/gateway/server_test.go
@@ -2059,7 +2059,7 @@ func TestRegister_DoReloadWithRetry_OnStartup(t *testing.T) {
 		case strings.Contains(r.URL.Path, "/register/node"):
 			registerCount++
 			w.Header().Set("Content-Type", "application/json")
-			err := json.NewEncoder(w).Encode(NodeResponseOK{
+			err := json.NewEncoder(w).Encode(NodeResponse{
 				Status:  "ok",
 				Message: map[string]string{"NodeID": "test-node-id"},
 				Nonce:   fmt.Sprintf("nonce-%d", registerCount),
@@ -2117,10 +2117,7 @@ func TestRegister_DoReloadWithRetry_OnStartup(t *testing.T) {
 	}
 	ts.Gw.performedSuccessfulReload = false
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	err := ts.Gw.DashService.Register(ctx)
+	err := ts.Gw.DashService.Register()
 
 	assert.NoError(t, err, "Register should not return an error")
 	assert.True(t, ts.Gw.performedSuccessfulReload,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
[TT-16865](https://tyktech.atlassian.net/browse/TT-16865)
<!-- Describe your changes in detail -->

## Related Issue

<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- OSS: Please link to the issue here. Tyk: please create/link the JIRA ticket. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested

<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests -->
<!-- you ran to see how your change affects other areas of the code, etc. -->
<!-- This information is helpful for reviewers and QA. -->

## Screenshots (if appropriate)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If there are no documentation updates required, mark the item as checked. -->
<!-- Raise up any additional concerns not covered by the checklist. -->

- [ ] I ensured that the documentation is up to date
- [ ] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why


[TT-16865]: https://tyktech.atlassian.net/browse/TT-16865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ