### PR TITLE
[TT-17030] Fix git auth: use x-access-token prefix for GitHub App tokens

### DIFF
--- a/.github/workflows/lint-swagger.yml
+++ b/.github/workflows/lint-swagger.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           TOKEN: ${{ steps.app-token.outputs.token }}
         run: >
-          git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
 
       - name: Checkout repo
         uses: TykTechnologies/github-actions/.github/actions/checkout-pr@d3fa20888fa2878e877e22bb7702141217290e7c  # main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
         run: |
           echo '#!/bin/sh
           ci/bin/unlock-agent.sh
-          git config --global url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf "https://github.com"
+          git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
           git config --global --add safe.directory /go/src/github.com/TykTechnologies/tyk
           goreleaser release --clean -f ${{ matrix.goreleaser }} ${{ !startsWith(github.ref, 'refs/tags/') && ' --snapshot --skip=sign,docker' || '--skip=docker' }}' | tee /tmp/build.sh
           chmod +x /tmp/build.sh
@@ -651,7 +651,7 @@ jobs:
           echo "📦 Updating tyk-gateway dependency to branch: $GATEWAY_BRANCH"
 
           # Configure git for go get
-          git config --global url."https://${ORG_GH_TOKEN}@github.com".insteadOf "https://github.com"
+          git config --global url."https://x-access-token:${ORG_GH_TOKEN}@github.com/".insteadOf "https://github.com/"
 
           # Update dependency using branch name
           go get github.com/TykTechnologies/tyk@$GATEWAY_BRANCH
@@ -733,7 +733,7 @@ jobs:
           cat > /tmp/build-dashboard.sh <<'EOF'
           #!/bin/sh
           set -eax
-          git config --global url."https://${ORG_GH_TOKEN}@github.com".insteadOf "https://github.com"
+          git config --global url."https://x-access-token:${ORG_GH_TOKEN}@github.com/".insteadOf "https://github.com/"
           git config --global --add safe.directory /go/src/github.com/TykTechnologies/tyk-analytics
 
           # Build packages for current platform (GOOS and GOARCH are set via docker -e)


### PR DESCRIPTION
## Summary

- Adds `x-access-token:` prefix to all `git config url.insteadOf` patterns in CI workflow files
- Adds trailing `/` to both the URL and the insteadOf target for proper matching
- This ensures git treats the token as a proper credential that takes precedence over credential helpers set by `actions/checkout`

## Problem

After migrating from PAT to GitHub App tokens, the `insteadOf` URL rewrite pattern stopped working because `actions/checkout` sets a credential helper that overrides plain token-in-URL authentication, causing:
```
fatal: could not read Password for 'https://***@github.com': terminal prompts disabled
```

## Files changed (4 replacements)

| File | Replacements |
|------|-------------|
| `release.yml` | 3 (app-token + 2x ORG_GH_TOKEN) |
| `lint-swagger.yml` | 1 (TOKEN) |

## Test plan

- [ ] Verify CI workflows can clone private TykTechnologies repos
- [ ] Verify `go get` for private modules works in release and lint jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)