### PR TITLE
[TT-17030] Fix git auth: use x-access-token prefix (release-5.8)

### DIFF
--- a/.github/workflows/lint-swagger.yml
+++ b/.github/workflows/lint-swagger.yml
@@ -51,7 +51,7 @@ jobs:
         env:
           TOKEN: ${{ steps.app-token.outputs.token }}
         run: >
-          git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
 
       - name: Checkout repo
         uses: TykTechnologies/github-actions/.github/actions/checkout-pr@2b35ab5dd4cfff21ced9d12446e9e27d10bf5785  # main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
         run: |
           echo '#!/bin/sh
           ci/bin/unlock-agent.sh
-          git config --global url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf "https://github.com"
+          git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
           git config --global --add safe.directory /go/src/github.com/TykTechnologies/tyk
           goreleaser release --clean -f ${{ matrix.goreleaser }} ${{ !startsWith(github.ref, 'refs/tags/') && ' --snapshot --skip=sign,docker' || '--skip=docker' }}' | tee /tmp/build.sh
           chmod +x /tmp/build.sh


### PR DESCRIPTION
## Summary
- Fix git config auth pattern in GitHub Actions workflow files to use `x-access-token:` prefix and trailing `/` on both URLs
- Changes `url."https://${TOKEN}@github.com".insteadOf "https://github.com"` to `url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"`
- 2 occurrences fixed across `release.yml` and `lint-swagger.yml`

## Jira
[TT-17030]

[TT-17030]: https://tyktech.atlassian.net/browse/TT-17030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ