### PR TITLE
[TT-17030] Fix git auth: use x-access-token prefix (release-5.12)

### DIFF
--- a/.github/workflows/lint-swagger.yml
+++ b/.github/workflows/lint-swagger.yml
@@ -56,7 +56,7 @@ jobs:
         env:
           TOKEN: ${{ steps.app-token.outputs.token }}
         run: >
-          git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
 
       - name: Checkout repo
         uses: TykTechnologies/github-actions/.github/actions/checkout-pr@2b35ab5dd4cfff21ced9d12446e9e27d10bf5785  # main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
         run: |
           echo '#!/bin/sh
           ci/bin/unlock-agent.sh
-          git config --global url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf "https://github.com"
+          git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
           git config --global --add safe.directory /go/src/github.com/TykTechnologies/tyk
           goreleaser release --clean -f ${{ matrix.goreleaser }} ${{ !startsWith(github.ref, 'refs/tags/') && ' --snapshot --skip=sign,docker' || '--skip=docker' }}' | tee /tmp/build.sh
           chmod +x /tmp/build.sh
@@ -550,7 +550,7 @@ jobs:
           echo "📦 Updating tyk-gateway dependency to branch: $GATEWAY_BRANCH"
 
           # Configure git for go get
-          git config --global url."https://${ORG_GH_TOKEN}@github.com".insteadOf "https://github.com"
+          git config --global url."https://x-access-token:${ORG_GH_TOKEN}@github.com/".insteadOf "https://github.com/"
 
           # Update dependency using branch name
           go get github.com/TykTechnologies/tyk@$GATEWAY_BRANCH
@@ -632,7 +632,7 @@ jobs:
           cat > /tmp/build-dashboard.sh <<'EOF'
           #!/bin/sh
           set -eax
-          git config --global url."https://${ORG_GH_TOKEN}@github.com".insteadOf "https://github.com"
+          git config --global url."https://x-access-token:${ORG_GH_TOKEN}@github.com/".insteadOf "https://github.com/"
           git config --global --add safe.directory /go/src/github.com/TykTechnologies/tyk-analytics
 
           # Build packages for current platform (GOOS and GOARCH are set via docker -e)


### PR DESCRIPTION
## Summary
- Fix git config auth pattern in GitHub Actions workflow files to use `x-access-token:` prefix and trailing `/` on both URLs
- Changes `url."https://${TOKEN}@github.com".insteadOf "https://github.com"` to `url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"`
- 4 occurrences fixed across `release.yml` and `lint-swagger.yml`

## Jira
[TT-17030]

[TT-17030]: https://tyktech.atlassian.net/browse/TT-17030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ