### PR TITLE
[TT-17030] Fix git auth: use x-access-token prefix (release-5-lts)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
           cp -r ./* /go/src/github.com/TykTechnologies/tyk
           find /go/src -name vendor | xargs --no-run-if-empty -d'\n' rm -rf
           rm -rf vendor
-          git config --global url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf "https://github.com"
+          git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
           git config --global --add safe.directory /go/src/github.com/TykTechnologies/tyk
           goreleaser release --clean -f ${{ matrix.goreleaser }} ${{ !startsWith(github.ref, 'refs/tags/') && ' --snapshot --skip=sign' || '' }}' | tee /tmp/build.sh
           chmod +x /tmp/build.sh


### PR DESCRIPTION
## Summary
- Fix git config auth pattern in GitHub Actions workflow files to use `x-access-token:` prefix and trailing `/` on both URLs
- Changes `url."https://${TOKEN}@github.com".insteadOf "https://github.com"` to `url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"`
- 1 occurrence fixed in `release.yml`

## Jira
[TT-17030]

[TT-17030]: https://tyktech.atlassian.net/browse/TT-17030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ