### PR TITLE
[TT-17030] Remove unused sbom job from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1099,14 +1099,3 @@ jobs:
       actions: read # This is required for the report_logs job in the called workflow
     uses: ./.github/workflows/release-tests.yml
     secrets: inherit
-  sbom:
-    needs: goreleaser
-    if: |
-      !cancelled() &&
-      needs.goreleaser.result == 'success'
-    uses: TykTechnologies/github-actions/.github/workflows/sbom.yaml@42304edda365365e0a887cf018d8edc34b960b82 # main
-    secrets:
-      DEPDASH_URL: ${{ secrets.DEPDASH_URL }}
-      DEPDASH_KEY: ${{ secrets.DEPDASH_KEY }}
-      PROBE_APP_ID: ${{ secrets.PROBE_APP_ID }}
-      PROBE_APP_PRIVATE_KEY: ${{ secrets.PROBE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- Removes the unused `sbom` reusable workflow job from `.github/workflows/release.yml`
- The job called `TykTechnologies/github-actions/.github/workflows/sbom.yaml` and is no longer needed
- Docker BuildKit SBOM attestation parameters (`sbom: true`) are **not** affected

## Test plan
- [ ] Verify release workflow still passes without the sbom job
- [ ] Confirm `sbom: true` params on docker/build-push-action steps are still present

Jira: TT-17030