### PR TITLE
[TT-17030] Remove unused sbom job from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -993,26 +993,3 @@ jobs:
       actions: read # This is required for the report_logs job in the called workflow
     uses: ./.github/workflows/release-tests.yml
     secrets: inherit
-  generate-token:
-    runs-on: ubuntu-latest
-    outputs:
-      token: ${{ steps.app-token.outputs.token }}
-    steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
-        with:
-          app-id: ${{ secrets.PROBE_APP_ID }}
-          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
-          owner: TykTechnologies
-
-  sbom:
-    needs: [goreleaser, generate-token]
-    if: |
-      !cancelled() &&
-      needs.goreleaser.result == 'success'
-    uses: TykTechnologies/github-actions/.github/workflows/sbom.yaml@42304edda365365e0a887cf018d8edc34b960b82 # main
-    secrets:
-      DEPDASH_URL: ${{ secrets.DEPDASH_URL }}
-      DEPDASH_KEY: ${{ secrets.DEPDASH_KEY }}
-      ORG_GH_TOKEN: ${{ needs.generate-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Removes the unused `sbom` reusable workflow job and its supporting `generate-token` job from `.github/workflows/release.yml`
- Both jobs are no longer needed as the sbom.yaml reusable workflow has been deprecated
- Docker BuildKit SBOM attestation parameters (`sbom: true`) are **not** affected

## Test plan
- [ ] Verify release workflow still passes without the sbom/generate-token jobs
- [ ] Confirm `sbom: true` params on docker/build-push-action steps are still present

Jira: TT-17030