### PR TITLE
[TT-17137] Support remote MCPs as upstream — routing fix + auto-mirror PRM + OAuth proxy

### DIFF
--- a/apidef/mcp/schema/x-tyk-api-gateway.json
+++ b/apidef/mcp/schema/x-tyk-api-gateway.json
@@ -1370,6 +1370,12 @@
         "enabled": {
           "type": "boolean"
         },
+        "mode": {
+          "type": "string"
+        },
+        "upstreamPRMUrl": {
+          "type": "string"
+        },
         "wellKnownPath": {
           "type": "string"
         },
@@ -1390,9 +1396,7 @@
         }
       },
       "required": [
-        "enabled",
-        "resource",
-        "authorizationServers"
+        "enabled"
       ]
     },
     "X-Tyk-Server": {

--- a/apidef/mcp/schema/x-tyk-api-gateway.json
+++ b/apidef/mcp/schema/x-tyk-api-gateway.json
@@ -1370,12 +1370,6 @@
         "enabled": {
           "type": "boolean"
         },
-        "mode": {
-          "type": "string"
-        },
-        "upstreamPRMUrl": {
-          "type": "string"
-        },
         "wellKnownPath": {
           "type": "string"
         },

--- a/apidef/oas/authentication.go
+++ b/apidef/oas/authentication.go
@@ -26,16 +26,6 @@ const (
 // DefaultPRMWellKnownPath is the default well-known path for OAuth 2.0 Protected Resource Metadata (RFC 9728).
 const DefaultPRMWellKnownPath = ".well-known/oauth-protected-resource"
 
-// PRM modes for ProtectedResourceMetadata.Mode. The default (empty/"static")
-// keeps the legacy behavior — Tyk serves a doc assembled from the static
-// fields on the API def. "mirror" makes Tyk fetch the upstream's PRM doc,
-// rewrite the resource field to the gateway URL, and serve that — the
-// pattern needed for transparent proxying of remote OAuth-protected MCPs.
-const (
-	PRMModeStatic = "static"
-	PRMModeMirror = "mirror"
-)
-
 // ValidateSecurityProcessingMode validates the security processing mode value.
 func ValidateSecurityProcessingMode(mode string) bool {
 	return mode == "" || mode == SecurityProcessingModeLegacy || mode == SecurityProcessingModeCompliant
@@ -115,26 +105,20 @@ type Authentication struct {
 
 // ProtectedResourceMetadata holds the configuration for OAuth 2.0 Protected Resource Metadata (RFC 9728).
 // It enables MCP clients to discover which authorization server protects this API resource.
+//
+// The serving mode is inferred from the configuration shape, not selected
+// explicitly:
+//   - When `Resource` or `AuthorizationServers` is set, Tyk runs in
+//     **static** mode — the PRM doc is assembled from the fields below.
+//   - When neither is set on an MCP API, Tyk runs in **mirror** mode —
+//     the upstream's PRM doc is fetched, its `resource` field rewritten
+//     to the gateway URL, and served. Used for transparent proxying of
+//     OAuth-protected remote MCP servers.
+//
+// On non-MCP APIs only static is meaningful; mirror is a no-op.
 type ProtectedResourceMetadata struct {
 	// Enabled activates the Protected Resource Metadata endpoint.
 	Enabled bool `bson:"enabled" json:"enabled"` // required
-
-	// Mode selects how Tyk produces the PRM document.
-	//   - "static": assemble the doc from the fields below.
-	//   - "mirror": fetch the upstream's PRM doc, rewrite the `resource`
-	//     field to the gateway URL the client connects to, serve that.
-	//     Used for transparent proxying of OAuth-protected remote MCPs.
-	//
-	// When empty, the mode is inferred (see EffectiveMode): MCP APIs with
-	// no `resource` set default to mirror, everything else defaults to
-	// static. Set explicitly to override.
-	Mode string `bson:"mode,omitempty" json:"mode,omitempty"`
-
-	// UpstreamPRMUrl optionally overrides where mirror-mode fetches from.
-	// When empty, the URL is auto-derived from the API's upstream URL as
-	// `<upstream-scheme>://<upstream-host>/.well-known/oauth-protected-resource<upstream-path>`
-	// per RFC 9728 §3.1 path-suffix variant.
-	UpstreamPRMUrl string `bson:"upstreamPRMUrl,omitempty" json:"upstreamPRMUrl,omitempty"`
 
 	// WellKnownPath is the path at which the metadata document is served.
 	// Defaults to ".well-known/oauth-protected-resource" if empty.
@@ -152,36 +136,18 @@ type ProtectedResourceMetadata struct {
 	ScopesSupported []string `bson:"scopesSupported,omitempty" json:"scopesSupported,omitempty"`
 }
 
-// EffectiveMode resolves the PRM mode after applying defaults.
-//
-// When `Mode` is set explicitly it always wins. When it's empty the mode
-// is inferred from the configuration shape:
-//
-//   - `Resource` or `AuthorizationServers` populated → static. Any
-//     static-field hint means the operator is partway through a static
-//     config; keep them on the static path so partial configs surface
-//     the "resource is required" / "authorizationServers is required"
-//     errors they'd expect.
-//   - Neither static field set AND the API is MCP → mirror, so users
-//     who just `enabled: true` on an MCP API get auto-discovery for
-//     free.
-//   - Neither field set AND non-MCP → static (will fail validation as
-//     before — non-MCP APIs need either a resource or explicit
-//     `mode: "static"` with one).
-func (prm *ProtectedResourceMetadata) EffectiveMode(isMCP bool) string {
-	if prm == nil {
-		return ""
-	}
-	if prm.Mode != "" {
-		return prm.Mode
+// IsMirrorMode reports whether the PRM resolves to mirror mode for the
+// given API context. Mirror is the implicit default for MCP APIs whose
+// PRM doesn't configure any static fields (`Resource` or
+// `AuthorizationServers`); everything else is static.
+func (prm *ProtectedResourceMetadata) IsMirrorMode(isMCP bool) bool {
+	if prm == nil || !prm.Enabled {
+		return false
 	}
 	if prm.Resource != "" || len(prm.AuthorizationServers) > 0 {
-		return PRMModeStatic
+		return false
 	}
-	if isMCP {
-		return PRMModeMirror
-	}
-	return PRMModeStatic
+	return isMCP
 }
 
 // Validate validates the ProtectedResourceMetadata configuration.
@@ -192,32 +158,18 @@ func (prm *ProtectedResourceMetadata) Validate(isMCP bool) error {
 	if prm == nil || !prm.Enabled {
 		return nil
 	}
-
-	switch prm.EffectiveMode(isMCP) {
-	case PRMModeStatic:
-		if prm.Resource == "" {
-			return errors.New("protectedResourceMetadata.resource is required when enabled")
-		}
-
-		if isMCP && len(prm.AuthorizationServers) == 0 {
-			return errors.New("protectedResourceMetadata.authorizationServers must have at least one entry for MCP APIs")
-		}
-	case PRMModeMirror:
-		// Resource/authorizationServers come from the upstream PRM doc.
-		// Mirror mode is only meaningful for MCP APIs — the runtime
-		// (PRMMiddleware/registerMCPPRMSuffixRoutes) gates serving on
-		// IsMCP(); for non-MCP APIs the config is silently ignored.
-	default:
-		return fmt.Errorf("protectedResourceMetadata.mode %q is not recognised (allowed: %q, %q)", prm.Mode, PRMModeStatic, PRMModeMirror)
+	if prm.IsMirrorMode(isMCP) {
+		// Mirror mode: upstream supplies resource/authorizationServers
+		// at request time. Nothing to validate here.
+		return nil
 	}
-
+	if prm.Resource == "" {
+		return errors.New("protectedResourceMetadata.resource is required when enabled")
+	}
+	if isMCP && len(prm.AuthorizationServers) == 0 {
+		return errors.New("protectedResourceMetadata.authorizationServers must have at least one entry for MCP APIs")
+	}
 	return nil
-}
-
-// IsMirrorMode reports whether the PRM should mirror the upstream's doc,
-// applying the MCP-aware default for empty mode (see EffectiveMode).
-func (prm *ProtectedResourceMetadata) IsMirrorMode(isMCP bool) bool {
-	return prm != nil && prm.Enabled && prm.EffectiveMode(isMCP) == PRMModeMirror
 }
 
 // GetWellKnownPath returns the well-known path for the PRM endpoint,

--- a/apidef/oas/authentication.go
+++ b/apidef/oas/authentication.go
@@ -26,6 +26,16 @@ const (
 // DefaultPRMWellKnownPath is the default well-known path for OAuth 2.0 Protected Resource Metadata (RFC 9728).
 const DefaultPRMWellKnownPath = ".well-known/oauth-protected-resource"
 
+// PRM modes for ProtectedResourceMetadata.Mode. The default (empty/"static")
+// keeps the legacy behavior — Tyk serves a doc assembled from the static
+// fields on the API def. "mirror" makes Tyk fetch the upstream's PRM doc,
+// rewrite the resource field to the gateway URL, and serve that — the
+// pattern needed for transparent proxying of remote OAuth-protected MCPs.
+const (
+	PRMModeStatic = "static"
+	PRMModeMirror = "mirror"
+)
+
 // ValidateSecurityProcessingMode validates the security processing mode value.
 func ValidateSecurityProcessingMode(mode string) bool {
 	return mode == "" || mode == SecurityProcessingModeLegacy || mode == SecurityProcessingModeCompliant
@@ -109,11 +119,26 @@ type ProtectedResourceMetadata struct {
 	// Enabled activates the Protected Resource Metadata endpoint.
 	Enabled bool `bson:"enabled" json:"enabled"` // required
 
+	// Mode selects how Tyk produces the PRM document.
+	//   - "" or "static" (default): assemble the doc from the fields below.
+	//   - "mirror": fetch the upstream's PRM doc, rewrite the `resource`
+	//     field to the gateway URL the client connects to, serve that.
+	//     Used for transparent proxying of OAuth-protected remote MCPs.
+	Mode string `bson:"mode,omitempty" json:"mode,omitempty"`
+
+	// UpstreamPRMUrl optionally overrides where mirror-mode fetches from.
+	// When empty, the URL is auto-derived from the API's upstream URL as
+	// `<upstream-scheme>://<upstream-host>/.well-known/oauth-protected-resource<upstream-path>`
+	// per RFC 9728 §3.1 path-suffix variant.
+	UpstreamPRMUrl string `bson:"upstreamPRMUrl,omitempty" json:"upstreamPRMUrl,omitempty"`
+
 	// WellKnownPath is the path at which the metadata document is served.
 	// Defaults to ".well-known/oauth-protected-resource" if empty.
 	WellKnownPath string `bson:"wellKnownPath,omitempty" json:"wellKnownPath,omitempty"`
 
 	// Resource is the resource identifier (the API's resource URL).
+	// Required for static mode. Ignored in mirror mode (rewritten to the
+	// gateway URL at request time).
 	Resource string `bson:"resource,omitempty" json:"resource,omitempty"`
 
 	// AuthorizationServers is the list of authorization server URLs that can issue tokens for this resource.
@@ -124,21 +149,38 @@ type ProtectedResourceMetadata struct {
 }
 
 // Validate validates the ProtectedResourceMetadata configuration.
-// When isMCP is true, authorizationServers must have at least one entry.
+// When isMCP is true, static mode requires authorizationServers.
+// Mirror mode skips the static-field requirements — the upstream's PRM
+// supplies them at request time.
 func (prm *ProtectedResourceMetadata) Validate(isMCP bool) error {
 	if prm == nil || !prm.Enabled {
 		return nil
 	}
 
-	if prm.Resource == "" {
-		return errors.New("protectedResourceMetadata.resource is required when enabled")
-	}
+	switch prm.Mode {
+	case "", PRMModeStatic:
+		if prm.Resource == "" {
+			return errors.New("protectedResourceMetadata.resource is required when enabled")
+		}
 
-	if isMCP && len(prm.AuthorizationServers) == 0 {
-		return errors.New("protectedResourceMetadata.authorizationServers must have at least one entry for MCP APIs")
+		if isMCP && len(prm.AuthorizationServers) == 0 {
+			return errors.New("protectedResourceMetadata.authorizationServers must have at least one entry for MCP APIs")
+		}
+	case PRMModeMirror:
+		// Resource/authorizationServers come from the upstream PRM doc.
+		// Mirror mode is only meaningful for MCP APIs — the runtime
+		// (PRMMiddleware/registerMCPPRMSuffixRoutes) gates serving on
+		// IsMCP(); for non-MCP APIs the config is silently ignored.
+	default:
+		return fmt.Errorf("protectedResourceMetadata.mode %q is not recognised (allowed: %q, %q)", prm.Mode, PRMModeStatic, PRMModeMirror)
 	}
 
 	return nil
+}
+
+// IsMirrorMode reports whether the PRM should mirror the upstream's doc.
+func (prm *ProtectedResourceMetadata) IsMirrorMode() bool {
+	return prm != nil && prm.Enabled && prm.Mode == PRMModeMirror
 }
 
 // GetWellKnownPath returns the well-known path for the PRM endpoint,

--- a/apidef/oas/authentication.go
+++ b/apidef/oas/authentication.go
@@ -120,10 +120,14 @@ type ProtectedResourceMetadata struct {
 	Enabled bool `bson:"enabled" json:"enabled"` // required
 
 	// Mode selects how Tyk produces the PRM document.
-	//   - "" or "static" (default): assemble the doc from the fields below.
+	//   - "static": assemble the doc from the fields below.
 	//   - "mirror": fetch the upstream's PRM doc, rewrite the `resource`
 	//     field to the gateway URL the client connects to, serve that.
 	//     Used for transparent proxying of OAuth-protected remote MCPs.
+	//
+	// When empty, the mode is inferred (see EffectiveMode): MCP APIs with
+	// no `resource` set default to mirror, everything else defaults to
+	// static. Set explicitly to override.
 	Mode string `bson:"mode,omitempty" json:"mode,omitempty"`
 
 	// UpstreamPRMUrl optionally overrides where mirror-mode fetches from.
@@ -148,17 +152,45 @@ type ProtectedResourceMetadata struct {
 	ScopesSupported []string `bson:"scopesSupported,omitempty" json:"scopesSupported,omitempty"`
 }
 
+// EffectiveMode resolves the PRM mode after applying defaults.
+//
+// When `Mode` is set explicitly it always wins. When it's empty the mode
+// is inferred from the configuration shape:
+//
+//   - `Resource` set → static (preserves the pre-mirror behaviour for
+//     anyone who configured static fields without an explicit mode).
+//   - `Resource` empty AND the API is MCP → mirror, so users who just
+//     `enabled: true` on an MCP API get auto-discovery for free.
+//   - `Resource` empty AND non-MCP → static (will fail validation as
+//     before — non-MCP APIs need either a resource or explicit
+//     `mode: "static"` with one).
+//
+// The shape-based default keeps existing static-mode users on the same
+// path while letting new MCP users skip the boilerplate.
+func (prm *ProtectedResourceMetadata) EffectiveMode(isMCP bool) string {
+	if prm == nil {
+		return ""
+	}
+	if prm.Mode != "" {
+		return prm.Mode
+	}
+	if prm.Resource == "" && isMCP {
+		return PRMModeMirror
+	}
+	return PRMModeStatic
+}
+
 // Validate validates the ProtectedResourceMetadata configuration.
-// When isMCP is true, static mode requires authorizationServers.
-// Mirror mode skips the static-field requirements — the upstream's PRM
-// supplies them at request time.
+// Static mode requires `resource`, and additionally requires
+// `authorizationServers` for MCP APIs. Mirror mode skips the static-field
+// requirements — the upstream's PRM supplies them at request time.
 func (prm *ProtectedResourceMetadata) Validate(isMCP bool) error {
 	if prm == nil || !prm.Enabled {
 		return nil
 	}
 
-	switch prm.Mode {
-	case "", PRMModeStatic:
+	switch prm.EffectiveMode(isMCP) {
+	case PRMModeStatic:
 		if prm.Resource == "" {
 			return errors.New("protectedResourceMetadata.resource is required when enabled")
 		}
@@ -178,9 +210,10 @@ func (prm *ProtectedResourceMetadata) Validate(isMCP bool) error {
 	return nil
 }
 
-// IsMirrorMode reports whether the PRM should mirror the upstream's doc.
-func (prm *ProtectedResourceMetadata) IsMirrorMode() bool {
-	return prm != nil && prm.Enabled && prm.Mode == PRMModeMirror
+// IsMirrorMode reports whether the PRM should mirror the upstream's doc,
+// applying the MCP-aware default for empty mode (see EffectiveMode).
+func (prm *ProtectedResourceMetadata) IsMirrorMode(isMCP bool) bool {
+	return prm != nil && prm.Enabled && prm.EffectiveMode(isMCP) == PRMModeMirror
 }
 
 // GetWellKnownPath returns the well-known path for the PRM endpoint,

--- a/apidef/oas/authentication.go
+++ b/apidef/oas/authentication.go
@@ -157,16 +157,17 @@ type ProtectedResourceMetadata struct {
 // When `Mode` is set explicitly it always wins. When it's empty the mode
 // is inferred from the configuration shape:
 //
-//   - `Resource` set → static (preserves the pre-mirror behaviour for
-//     anyone who configured static fields without an explicit mode).
-//   - `Resource` empty AND the API is MCP → mirror, so users who just
-//     `enabled: true` on an MCP API get auto-discovery for free.
-//   - `Resource` empty AND non-MCP → static (will fail validation as
+//   - `Resource` or `AuthorizationServers` populated → static. Any
+//     static-field hint means the operator is partway through a static
+//     config; keep them on the static path so partial configs surface
+//     the "resource is required" / "authorizationServers is required"
+//     errors they'd expect.
+//   - Neither static field set AND the API is MCP → mirror, so users
+//     who just `enabled: true` on an MCP API get auto-discovery for
+//     free.
+//   - Neither field set AND non-MCP → static (will fail validation as
 //     before — non-MCP APIs need either a resource or explicit
 //     `mode: "static"` with one).
-//
-// The shape-based default keeps existing static-mode users on the same
-// path while letting new MCP users skip the boilerplate.
 func (prm *ProtectedResourceMetadata) EffectiveMode(isMCP bool) string {
 	if prm == nil {
 		return ""
@@ -174,7 +175,10 @@ func (prm *ProtectedResourceMetadata) EffectiveMode(isMCP bool) string {
 	if prm.Mode != "" {
 		return prm.Mode
 	}
-	if prm.Resource == "" && isMCP {
+	if prm.Resource != "" || len(prm.AuthorizationServers) > 0 {
+		return PRMModeStatic
+	}
+	if isMCP {
 		return PRMModeMirror
 	}
 	return PRMModeStatic

--- a/apidef/oas/authentication_test.go
+++ b/apidef/oas/authentication_test.go
@@ -843,6 +843,68 @@ func TestProtectedResourceMetadata_Validate(t *testing.T) {
 		}
 		assert.NoError(t, prm.Validate(false))
 	})
+
+	t.Run("explicit static mode behaves like default", func(t *testing.T) {
+		t.Parallel()
+		prm := &ProtectedResourceMetadata{
+			Enabled:              true,
+			Mode:                 PRMModeStatic,
+			Resource:             "https://api.example.com",
+			AuthorizationServers: []string{"https://auth.example.com"},
+		}
+		assert.NoError(t, prm.Validate(true))
+	})
+
+	t.Run("mirror mode skips static-field requirements", func(t *testing.T) {
+		t.Parallel()
+		prm := &ProtectedResourceMetadata{
+			Enabled: true,
+			Mode:    PRMModeMirror,
+		}
+		assert.NoError(t, prm.Validate(true))
+		assert.True(t, prm.IsMirrorMode())
+	})
+
+	t.Run("mirror mode passes validation for non-MCP APIs (runtime no-op)", func(t *testing.T) {
+		t.Parallel()
+		prm := &ProtectedResourceMetadata{
+			Enabled: true,
+			Mode:    PRMModeMirror,
+		}
+		assert.NoError(t, prm.Validate(false))
+	})
+
+	t.Run("unknown mode rejected", func(t *testing.T) {
+		t.Parallel()
+		prm := &ProtectedResourceMetadata{
+			Enabled: true,
+			Mode:    "wat",
+		}
+		err := prm.Validate(true)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not recognised")
+	})
+}
+
+func TestProtectedResourceMetadata_IsMirrorMode(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		prm  *ProtectedResourceMetadata
+		want bool
+	}{
+		{"nil", nil, false},
+		{"disabled", &ProtectedResourceMetadata{Enabled: false, Mode: PRMModeMirror}, false},
+		{"enabled static", &ProtectedResourceMetadata{Enabled: true}, false},
+		{"enabled mirror", &ProtectedResourceMetadata{Enabled: true, Mode: PRMModeMirror}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, tc.prm.IsMirrorMode())
+		})
+	}
 }
 
 func TestProtectedResourceMetadata_GetWellKnownPath(t *testing.T) {

--- a/apidef/oas/authentication_test.go
+++ b/apidef/oas/authentication_test.go
@@ -844,48 +844,23 @@ func TestProtectedResourceMetadata_Validate(t *testing.T) {
 		assert.NoError(t, prm.Validate(false))
 	})
 
-	t.Run("explicit static mode behaves like default", func(t *testing.T) {
-		t.Parallel()
-		prm := &ProtectedResourceMetadata{
-			Enabled:              true,
-			Mode:                 PRMModeStatic,
-			Resource:             "https://api.example.com",
-			AuthorizationServers: []string{"https://auth.example.com"},
-		}
-		assert.NoError(t, prm.Validate(true))
-	})
-
-	t.Run("mirror mode skips static-field requirements", func(t *testing.T) {
-		t.Parallel()
-		prm := &ProtectedResourceMetadata{
-			Enabled: true,
-			Mode:    PRMModeMirror,
-		}
-		assert.NoError(t, prm.Validate(true))
-		assert.True(t, prm.IsMirrorMode(true))
-	})
-
-	t.Run("mirror mode passes validation for non-MCP APIs (runtime no-op)", func(t *testing.T) {
-		t.Parallel()
-		prm := &ProtectedResourceMetadata{
-			Enabled: true,
-			Mode:    PRMModeMirror,
-		}
-		assert.NoError(t, prm.Validate(false))
-	})
-
-	t.Run("MCP API with no resource and no mode defaults to mirror", func(t *testing.T) {
+	t.Run("MCP API with no static fields defaults to mirror (passes validation)", func(t *testing.T) {
 		t.Parallel()
 		prm := &ProtectedResourceMetadata{Enabled: true}
-		// Validate against the MCP-aware path: should pass because the
-		// effective mode resolves to mirror and mirror has no required
-		// static fields.
 		assert.NoError(t, prm.Validate(true))
 		assert.True(t, prm.IsMirrorMode(true))
-		assert.Equal(t, PRMModeMirror, prm.EffectiveMode(true))
 	})
 
-	t.Run("MCP API with resource set keeps static (back-compat)", func(t *testing.T) {
+	t.Run("non-MCP without resource still rejected (mirror is MCP-only)", func(t *testing.T) {
+		t.Parallel()
+		prm := &ProtectedResourceMetadata{Enabled: true}
+		err := prm.Validate(false)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "resource is required")
+		assert.False(t, prm.IsMirrorMode(false))
+	})
+
+	t.Run("MCP API with static fields keeps static behaviour", func(t *testing.T) {
 		t.Parallel()
 		prm := &ProtectedResourceMetadata{
 			Enabled:              true,
@@ -894,26 +869,6 @@ func TestProtectedResourceMetadata_Validate(t *testing.T) {
 		}
 		assert.NoError(t, prm.Validate(true))
 		assert.False(t, prm.IsMirrorMode(true))
-		assert.Equal(t, PRMModeStatic, prm.EffectiveMode(true))
-	})
-
-	t.Run("non-MCP without resource still rejected", func(t *testing.T) {
-		t.Parallel()
-		prm := &ProtectedResourceMetadata{Enabled: true}
-		err := prm.Validate(false)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "resource is required")
-	})
-
-	t.Run("unknown mode rejected", func(t *testing.T) {
-		t.Parallel()
-		prm := &ProtectedResourceMetadata{
-			Enabled: true,
-			Mode:    "wat",
-		}
-		err := prm.Validate(true)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "not recognised")
 	})
 }
 
@@ -927,15 +882,13 @@ func TestProtectedResourceMetadata_IsMirrorMode(t *testing.T) {
 		want  bool
 	}{
 		{"nil", nil, true, false},
-		{"disabled even if mode mirror", &ProtectedResourceMetadata{Enabled: false, Mode: PRMModeMirror}, true, false},
-		{"enabled explicit mirror MCP", &ProtectedResourceMetadata{Enabled: true, Mode: PRMModeMirror}, true, true},
-		{"enabled explicit mirror non-MCP", &ProtectedResourceMetadata{Enabled: true, Mode: PRMModeMirror}, false, true},
-		{"enabled empty mode MCP no resource → mirror by default", &ProtectedResourceMetadata{Enabled: true}, true, true},
-		{"enabled empty mode MCP with resource → static", &ProtectedResourceMetadata{Enabled: true, Resource: "https://x"}, true, false},
-		{"enabled empty mode MCP with authorizationServers only → static (back-compat error path)",
+		{"disabled", &ProtectedResourceMetadata{Enabled: false}, true, false},
+		{"MCP API with no static fields → mirror", &ProtectedResourceMetadata{Enabled: true}, true, true},
+		{"MCP API with resource set → static", &ProtectedResourceMetadata{Enabled: true, Resource: "https://x"}, true, false},
+		{"MCP API with authorizationServers only → static",
 			&ProtectedResourceMetadata{Enabled: true, AuthorizationServers: []string{"https://auth"}}, true, false},
-		{"enabled empty mode non-MCP → static", &ProtectedResourceMetadata{Enabled: true}, false, false},
-		{"enabled explicit static", &ProtectedResourceMetadata{Enabled: true, Mode: PRMModeStatic, Resource: "https://x"}, true, false},
+		{"non-MCP API never resolves to mirror", &ProtectedResourceMetadata{Enabled: true}, false, false},
+		{"non-MCP with resource set → static", &ProtectedResourceMetadata{Enabled: true, Resource: "https://x"}, false, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/apidef/oas/authentication_test.go
+++ b/apidef/oas/authentication_test.go
@@ -862,7 +862,7 @@ func TestProtectedResourceMetadata_Validate(t *testing.T) {
 			Mode:    PRMModeMirror,
 		}
 		assert.NoError(t, prm.Validate(true))
-		assert.True(t, prm.IsMirrorMode())
+		assert.True(t, prm.IsMirrorMode(true))
 	})
 
 	t.Run("mirror mode passes validation for non-MCP APIs (runtime no-op)", func(t *testing.T) {
@@ -872,6 +872,37 @@ func TestProtectedResourceMetadata_Validate(t *testing.T) {
 			Mode:    PRMModeMirror,
 		}
 		assert.NoError(t, prm.Validate(false))
+	})
+
+	t.Run("MCP API with no resource and no mode defaults to mirror", func(t *testing.T) {
+		t.Parallel()
+		prm := &ProtectedResourceMetadata{Enabled: true}
+		// Validate against the MCP-aware path: should pass because the
+		// effective mode resolves to mirror and mirror has no required
+		// static fields.
+		assert.NoError(t, prm.Validate(true))
+		assert.True(t, prm.IsMirrorMode(true))
+		assert.Equal(t, PRMModeMirror, prm.EffectiveMode(true))
+	})
+
+	t.Run("MCP API with resource set keeps static (back-compat)", func(t *testing.T) {
+		t.Parallel()
+		prm := &ProtectedResourceMetadata{
+			Enabled:              true,
+			Resource:             "https://api.example.com",
+			AuthorizationServers: []string{"https://auth.example.com"},
+		}
+		assert.NoError(t, prm.Validate(true))
+		assert.False(t, prm.IsMirrorMode(true))
+		assert.Equal(t, PRMModeStatic, prm.EffectiveMode(true))
+	})
+
+	t.Run("non-MCP without resource still rejected", func(t *testing.T) {
+		t.Parallel()
+		prm := &ProtectedResourceMetadata{Enabled: true}
+		err := prm.Validate(false)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "resource is required")
 	})
 
 	t.Run("unknown mode rejected", func(t *testing.T) {
@@ -890,19 +921,24 @@ func TestProtectedResourceMetadata_IsMirrorMode(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name string
-		prm  *ProtectedResourceMetadata
-		want bool
+		name  string
+		prm   *ProtectedResourceMetadata
+		isMCP bool
+		want  bool
 	}{
-		{"nil", nil, false},
-		{"disabled", &ProtectedResourceMetadata{Enabled: false, Mode: PRMModeMirror}, false},
-		{"enabled static", &ProtectedResourceMetadata{Enabled: true}, false},
-		{"enabled mirror", &ProtectedResourceMetadata{Enabled: true, Mode: PRMModeMirror}, true},
+		{"nil", nil, true, false},
+		{"disabled even if mode mirror", &ProtectedResourceMetadata{Enabled: false, Mode: PRMModeMirror}, true, false},
+		{"enabled explicit mirror MCP", &ProtectedResourceMetadata{Enabled: true, Mode: PRMModeMirror}, true, true},
+		{"enabled explicit mirror non-MCP", &ProtectedResourceMetadata{Enabled: true, Mode: PRMModeMirror}, false, true},
+		{"enabled empty mode MCP no resource → mirror by default", &ProtectedResourceMetadata{Enabled: true}, true, true},
+		{"enabled empty mode MCP with resource → static", &ProtectedResourceMetadata{Enabled: true, Resource: "https://x"}, true, false},
+		{"enabled empty mode non-MCP → static", &ProtectedResourceMetadata{Enabled: true}, false, false},
+		{"enabled explicit static", &ProtectedResourceMetadata{Enabled: true, Mode: PRMModeStatic, Resource: "https://x"}, true, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tc.want, tc.prm.IsMirrorMode())
+			assert.Equal(t, tc.want, tc.prm.IsMirrorMode(tc.isMCP))
 		})
 	}
 }

--- a/apidef/oas/authentication_test.go
+++ b/apidef/oas/authentication_test.go
@@ -932,6 +932,8 @@ func TestProtectedResourceMetadata_IsMirrorMode(t *testing.T) {
 		{"enabled explicit mirror non-MCP", &ProtectedResourceMetadata{Enabled: true, Mode: PRMModeMirror}, false, true},
 		{"enabled empty mode MCP no resource → mirror by default", &ProtectedResourceMetadata{Enabled: true}, true, true},
 		{"enabled empty mode MCP with resource → static", &ProtectedResourceMetadata{Enabled: true, Resource: "https://x"}, true, false},
+		{"enabled empty mode MCP with authorizationServers only → static (back-compat error path)",
+			&ProtectedResourceMetadata{Enabled: true, AuthorizationServers: []string{"https://auth"}}, true, false},
 		{"enabled empty mode non-MCP → static", &ProtectedResourceMetadata{Enabled: true}, false, false},
 		{"enabled explicit static", &ProtectedResourceMetadata{Enabled: true, Mode: PRMModeStatic, Resource: "https://x"}, true, false},
 	}

--- a/apidef/oas/oas.go
+++ b/apidef/oas/oas.go
@@ -718,7 +718,8 @@ func (s *OAS) validateCompliantModeAuthentication() error {
 }
 
 // validatePRM validates the Protected Resource Metadata configuration.
-// For non-MCP validation, resource is required when PRM is enabled.
+// For non-MCP validation, resource is required when PRM is enabled (the
+// MCP-aware path is handled by ValidateForMCP).
 func (s *OAS) validatePRM() error {
 	tykAuth := s.getTykAuthentication()
 	if tykAuth == nil {
@@ -726,6 +727,30 @@ func (s *OAS) validatePRM() error {
 	}
 
 	return tykAuth.ProtectedResourceMetadata.Validate(false)
+}
+
+// ValidateForMCP runs the same validation chain as Validate but treats
+// the document as an MCP API for PRM purposes. Use this from MCP-specific
+// admin endpoints (e.g. POST /tyk/mcps) where the empty-mode +
+// no-resource shape resolves to mirror, not static-with-missing-resource.
+func (s *OAS) ValidateForMCP(ctx context.Context, opts ...openapi3.ValidationOption) error {
+	validationOpts := opts
+	if s.T.IsOpenAPI3_1() {
+		validationOpts = make([]openapi3.ValidationOption, len(opts)+1)
+		copy(validationOpts, opts)
+		validationOpts[len(opts)] = openapi3.EnableJSONSchema2020Validation()
+	}
+
+	validationErr := s.T.Validate(ctx, validationOpts...)
+	securityErr := s.validateSecurity()
+	compliantModeErr := s.validateCompliantModeAuthentication()
+
+	var prmErr error
+	if tykAuth := s.getTykAuthentication(); tykAuth != nil {
+		prmErr = tykAuth.ProtectedResourceMetadata.Validate(true)
+	}
+
+	return errors.Join(validationErr, securityErr, compliantModeErr, prmErr)
 }
 
 // APIDef holds both OAS and Classic forms of an API definition.

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -1307,12 +1307,6 @@
         "enabled": {
           "type": "boolean"
         },
-        "mode": {
-          "type": "string"
-        },
-        "upstreamPRMUrl": {
-          "type": "string"
-        },
         "wellKnownPath": {
           "type": "string"
         },

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -1307,6 +1307,12 @@
         "enabled": {
           "type": "boolean"
         },
+        "mode": {
+          "type": "string"
+        },
+        "upstreamPRMUrl": {
+          "type": "string"
+        },
         "wellKnownPath": {
           "type": "string"
         },
@@ -1327,8 +1333,7 @@
         }
       },
       "required": [
-        "enabled",
-        "resource"
+        "enabled"
       ]
     },
     "X-Tyk-Server": {

--- a/apidef/oas/schema/x-tyk-api-gateway.strict.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.strict.json
@@ -1361,6 +1361,12 @@
         "enabled": {
           "type": "boolean"
         },
+        "mode": {
+          "type": "string"
+        },
+        "upstreamPRMUrl": {
+          "type": "string"
+        },
         "wellKnownPath": {
           "type": "string"
         },
@@ -1381,8 +1387,7 @@
         }
       },
       "required": [
-        "enabled",
-        "resource"
+        "enabled"
       ],
       "additionalProperties": false
     },

--- a/apidef/oas/schema/x-tyk-api-gateway.strict.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.strict.json
@@ -1361,12 +1361,6 @@
         "enabled": {
           "type": "boolean"
         },
-        "mode": {
-          "type": "string"
-        },
-        "upstreamPRMUrl": {
-          "type": "string"
-        },
         "wellKnownPath": {
           "type": "string"
         },

--- a/apidef/oas/validate_for_mcp_test.go
+++ b/apidef/oas/validate_for_mcp_test.go
@@ -79,4 +79,3 @@ func TestValidateForMCP(t *testing.T) {
 		assert.NoError(t, o.Validate(context.Background()))
 	})
 }
-

--- a/apidef/oas/validate_for_mcp_test.go
+++ b/apidef/oas/validate_for_mcp_test.go
@@ -80,24 +80,3 @@ func TestValidateForMCP(t *testing.T) {
 	})
 }
 
-func TestProtectedResourceMetadata_EffectiveMode(t *testing.T) {
-	cases := []struct {
-		name  string
-		prm   *ProtectedResourceMetadata
-		isMCP bool
-		want  string
-	}{
-		{"nil", nil, true, ""},
-		{"explicit mirror wins over shape", &ProtectedResourceMetadata{Mode: PRMModeMirror, Resource: "x"}, true, PRMModeMirror},
-		{"explicit static wins over MCP default", &ProtectedResourceMetadata{Mode: PRMModeStatic}, true, PRMModeStatic},
-		{"empty + resource set → static", &ProtectedResourceMetadata{Resource: "x"}, true, PRMModeStatic},
-		{"empty + auth servers set → static", &ProtectedResourceMetadata{AuthorizationServers: []string{"x"}}, true, PRMModeStatic},
-		{"empty + neither + MCP → mirror", &ProtectedResourceMetadata{}, true, PRMModeMirror},
-		{"empty + neither + non-MCP → static", &ProtectedResourceMetadata{}, false, PRMModeStatic},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			assert.Equal(t, c.want, c.prm.EffectiveMode(c.isMCP))
-		})
-	}
-}

--- a/apidef/oas/validate_for_mcp_test.go
+++ b/apidef/oas/validate_for_mcp_test.go
@@ -1,0 +1,103 @@
+package oas
+
+import (
+	"context"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestValidateForMCP covers the MCP-aware validation path. Empty config
+// + IsMCP context resolves to mirror mode (no required static fields)
+// where the OAS-level Validate would have rejected with
+// "resource is required".
+func TestValidateForMCP(t *testing.T) {
+	mkOAS := func(prm *ProtectedResourceMetadata) OAS {
+		o := OAS{T: openapi3.T{
+			OpenAPI: "3.0.3",
+			Info:    &openapi3.Info{Title: "x", Version: "1.0"},
+			Paths:   openapi3.NewPaths(),
+		}}
+		o.SetTykExtension(&XTykAPIGateway{
+			Server: Server{
+				ListenPath:     ListenPath{Value: "/x/"},
+				Authentication: &Authentication{ProtectedResourceMetadata: prm},
+			},
+		})
+		return o
+	}
+
+	t.Run("MCP-mirror-by-default passes ValidateForMCP", func(t *testing.T) {
+		o := mkOAS(&ProtectedResourceMetadata{Enabled: true})
+		assert.NoError(t, o.ValidateForMCP(context.Background()))
+	})
+
+	t.Run("MCP-mirror-by-default fails plain Validate (non-MCP context)", func(t *testing.T) {
+		o := mkOAS(&ProtectedResourceMetadata{Enabled: true})
+		err := o.Validate(context.Background())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "resource is required")
+	})
+
+	t.Run("explicit static config validates either way", func(t *testing.T) {
+		o := mkOAS(&ProtectedResourceMetadata{
+			Enabled:              true,
+			Resource:             "https://api.example.com/x",
+			AuthorizationServers: []string{"https://auth"},
+		})
+		assert.NoError(t, o.ValidateForMCP(context.Background()))
+		assert.NoError(t, o.Validate(context.Background()))
+	})
+
+	t.Run("static-MCP without authorizationServers rejected", func(t *testing.T) {
+		o := mkOAS(&ProtectedResourceMetadata{
+			Enabled:  true,
+			Resource: "https://api.example.com/x",
+		})
+		err := o.ValidateForMCP(context.Background())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "authorizationServers")
+	})
+
+	t.Run("disabled PRM passes both", func(t *testing.T) {
+		o := mkOAS(&ProtectedResourceMetadata{Enabled: false})
+		assert.NoError(t, o.ValidateForMCP(context.Background()))
+		assert.NoError(t, o.Validate(context.Background()))
+	})
+
+	t.Run("no auth block at all passes both", func(t *testing.T) {
+		o := OAS{T: openapi3.T{
+			OpenAPI: "3.0.3",
+			Info:    &openapi3.Info{Title: "x", Version: "1.0"},
+			Paths:   openapi3.NewPaths(),
+		}}
+		o.SetTykExtension(&XTykAPIGateway{
+			Server: Server{ListenPath: ListenPath{Value: "/x/"}},
+		})
+		assert.NoError(t, o.ValidateForMCP(context.Background()))
+		assert.NoError(t, o.Validate(context.Background()))
+	})
+}
+
+func TestProtectedResourceMetadata_EffectiveMode(t *testing.T) {
+	cases := []struct {
+		name  string
+		prm   *ProtectedResourceMetadata
+		isMCP bool
+		want  string
+	}{
+		{"nil", nil, true, ""},
+		{"explicit mirror wins over shape", &ProtectedResourceMetadata{Mode: PRMModeMirror, Resource: "x"}, true, PRMModeMirror},
+		{"explicit static wins over MCP default", &ProtectedResourceMetadata{Mode: PRMModeStatic}, true, PRMModeStatic},
+		{"empty + resource set → static", &ProtectedResourceMetadata{Resource: "x"}, true, PRMModeStatic},
+		{"empty + auth servers set → static", &ProtectedResourceMetadata{AuthorizationServers: []string{"x"}}, true, PRMModeStatic},
+		{"empty + neither + MCP → mirror", &ProtectedResourceMetadata{}, true, PRMModeMirror},
+		{"empty + neither + non-MCP → static", &ProtectedResourceMetadata{}, false, PRMModeStatic},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, c.prm.EffectiveMode(c.isMCP))
+		})
+	}
+}

--- a/docs/mcp-remote-proxies.ipynb
+++ b/docs/mcp-remote-proxies.ipynb
@@ -1,0 +1,358 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Remote MCP proxies — Jira + Notion through Tyk\n",
+    "\n",
+    "Drives **two MCP Proxy APIs** in a running Tyk gateway, each pointing at a different remote MCP upstream:\n",
+    "\n",
+    "| Proxy listen path | Upstream URL                          |\n",
+    "|-------------------|---------------------------------------|\n",
+    "| `/jira/`          | `https://mcp.atlassian.com/v1/mcp`    |\n",
+    "| `/notion/`        | `https://mcp.notion.com/mcp`          |\n",
+    "\n",
+    "Both upstreams have a non-root path component. This is the case fixed by TT-17137: discovery probes (`/.well-known/oauth-protected-resource`) must reach the upstream **host root**, not the resource path. Without the fix, OAuth discovery is routed to `/v1/mcp/.well-known/...` and 404s. With the fix, MCP clients (`mcp-remote`, Claude Desktop, Roo) can complete the OAuth dance through Tyk transparently.\n",
+    "\n",
+    "## Prerequisites\n",
+    "\n",
+    "1. Tyk gateway running locally on `http://localhost:8080` with the TT-17137 patch applied (see `gateway/reverse_proxy.go` MCP host-root branch).\n",
+    "2. Admin secret in `GATEWAY_SECRET` below.\n",
+    "3. Outbound HTTPS connectivity from the gateway to `mcp.atlassian.com` and `mcp.notion.com`.\n",
+    "4. Python 3.9+ with `requests` (`pip install requests`).\n",
+    "5. Optional: `mcp-remote` for the live OAuth dance (`npm i -g mcp-remote` or `npx mcp-remote`).\n",
+    "\n",
+    "**This notebook mutates gateway state.** Use a dev gateway. The cleanup cell at the bottom removes everything it created."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 0 — Configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json, requests, time\n",
+    "\n",
+    "GATEWAY_URL    = \"http://localhost:8080\"\n",
+    "GATEWAY_SECRET = \"352d20ee67be67f6340b4c0605b044b7\"   # X-Tyk-Authorization\n",
+    "\n",
+    "ADMIN_HEADERS = {\"X-Tyk-Authorization\": GATEWAY_SECRET, \"Content-Type\": \"application/json\"}\n",
+    "\n",
+    "# Stable APIIDs so cells can be re-run without orphans.\n",
+    "JIRA_API_ID   = \"jira-mcp-remote\"\n",
+    "NOTION_API_ID = \"notion-mcp-remote\"\n",
+    "\n",
+    "REMOTES = {\n",
+    "    JIRA_API_ID: {\n",
+    "        \"name\":         \"jira\",\n",
+    "        \"listen_path\":  \"/jira/\",\n",
+    "        \"upstream_url\": \"https://mcp.atlassian.com/v1/mcp\",\n",
+    "    },\n",
+    "    NOTION_API_ID: {\n",
+    "        \"name\":         \"notion\",\n",
+    "        \"listen_path\":  \"/notion/\",\n",
+    "        \"upstream_url\": \"https://mcp.notion.com/mcp\",\n",
+    "    },\n",
+    "}\n",
+    "\n",
+    "def pp(obj):\n",
+    "    print(json.dumps(obj, indent=2, default=str))\n",
+    "\n",
+    "def admin(method, path, **kw):\n",
+    "    return requests.request(method, f\"{GATEWAY_URL}{path}\", headers=ADMIN_HEADERS, timeout=15, **kw)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1 — Pre-flight check\n",
+    "\n",
+    "Confirms the gateway is reachable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r = admin(\"GET\", \"/hello\")\n",
+    "print(\"status:\", r.status_code)\n",
+    "print(\"body:\", r.text[:300])\n",
+    "assert r.status_code == 200, \"gateway not reachable — fix GATEWAY_URL / GATEWAY_SECRET first\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2 — Helpers: upsert / delete / reload"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def upsert_oas(api_id, oas_doc):\n",
+    "    existing = admin(\"GET\", f\"/tyk/apis/oas/{api_id}\")\n",
+    "    if existing.status_code == 200:\n",
+    "        r = admin(\"PUT\", f\"/tyk/apis/oas/{api_id}\", data=json.dumps(oas_doc))\n",
+    "    else:\n",
+    "        r = admin(\"POST\", \"/tyk/apis/oas\", data=json.dumps(oas_doc))\n",
+    "    print(f\"{api_id}: {r.status_code} {r.text[:200]}\")\n",
+    "    return r\n",
+    "\n",
+    "def delete_oas(api_id):\n",
+    "    r = admin(\"DELETE\", f\"/tyk/apis/oas/{api_id}\")\n",
+    "    print(f\"DELETE {api_id}: {r.status_code} {r.text[:200]}\")\n",
+    "    return r\n",
+    "\n",
+    "def reload():\n",
+    "    r = admin(\"GET\", \"/tyk/reload/group\")\n",
+    "    print(\"reload:\", r.status_code, r.text[:120])\n",
+    "    time.sleep(1.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3 — Build a remote-MCP OAS doc\n",
+    "\n",
+    "An MCP Proxy whose upstream is the remote MCP server. Listen path stripped, no auth on the Tyk side — the upstream handles OAuth itself and the gateway is a transparent reverse proxy.\n",
+    "\n",
+    "Note `applicationProtocol: mcp` — that's what gates the host-root discovery routing in `reverse_proxy.go`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def remote_mcp_oas(api_id, name, listen_path, upstream_url):\n",
+    "    return {\n",
+    "        \"openapi\": \"3.0.3\",\n",
+    "        \"info\": {\"title\": name, \"version\": \"1.0.0\"},\n",
+    "        \"servers\": [{\"url\": \"/\"}],\n",
+    "        \"security\": [],\n",
+    "        \"paths\": {\n",
+    "            \"/\": {\n",
+    "                \"get\":  {\"summary\": \"MCP endpoint\",  \"responses\": {\"200\": {\"description\": \"OK\"}}},\n",
+    "                \"post\": {\"summary\": \"MCP endpoint\",  \"responses\": {\"200\": {\"description\": \"OK\"}}},\n",
+    "            },\n",
+    "        },\n",
+    "        \"components\": {\"securitySchemes\": {}},\n",
+    "        \"x-tyk-api-gateway\": {\n",
+    "            \"info\": {\n",
+    "                \"id\":    api_id,\n",
+    "                \"name\":  name,\n",
+    "                \"state\": {\"active\": True, \"internal\": False},\n",
+    "                \"applicationProtocol\": \"mcp\",\n",
+    "            },\n",
+    "            \"middleware\": {\n",
+    "                \"global\": {\n",
+    "                    \"contextVariables\": {\"enabled\": True},\n",
+    "                    \"trafficLogs\":      {\"enabled\": True},\n",
+    "                },\n",
+    "            },\n",
+    "            \"server\": {\"listenPath\": {\"value\": listen_path, \"strip\": True}},\n",
+    "            \"upstream\": {\"url\": upstream_url},\n",
+    "        },\n",
+    "    }\n",
+    "\n",
+    "for api_id, cfg in REMOTES.items():\n",
+    "    pp(remote_mcp_oas(api_id, cfg[\"name\"], cfg[\"listen_path\"], cfg[\"upstream_url\"]))\n",
+    "    print(\"---\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4 — Create both proxies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for api_id, cfg in REMOTES.items():\n",
+    "    upsert_oas(api_id, remote_mcp_oas(api_id, cfg[\"name\"], cfg[\"listen_path\"], cfg[\"upstream_url\"]))\n",
+    "reload()\n",
+    "\n",
+    "for api_id in REMOTES:\n",
+    "    spec = admin(\"GET\", f\"/tyk/apis/oas/{api_id}?mode=public\")\n",
+    "    print(f\"{api_id} loaded: {spec.status_code}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5 — Hit each proxy's listen path\n",
+    "\n",
+    "An anonymous `POST /` to a remote MCP returns `401` with a `WWW-Authenticate: Bearer ...` header. That's the OAuth challenge — **expected, not an error**.\n",
+    "\n",
+    "The header should pass through Tyk verbatim. If `resource_metadata=` is present, that's the URL the MCP client will probe next — the load-bearing thing fixed by TT-17137."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def jsonrpc(method, params=None, id_=1):\n",
+    "    return {\"jsonrpc\": \"2.0\", \"id\": id_, \"method\": method, **({\"params\": params} if params is not None else {})}\n",
+    "\n",
+    "for api_id, cfg in REMOTES.items():\n",
+    "    url = f\"{GATEWAY_URL}{cfg['listen_path']}\"\n",
+    "    print(f\"=== {api_id} → POST {url} ===\")\n",
+    "    init_env = jsonrpc(\"initialize\", {\n",
+    "        \"protocolVersion\": \"2025-06-18\",\n",
+    "        \"capabilities\": {},\n",
+    "        \"clientInfo\": {\"name\": \"notebook\", \"version\": \"0\"},\n",
+    "    })\n",
+    "    r = requests.post(url, data=json.dumps(init_env), headers={\"Content-Type\": \"application/json\"}, timeout=15)\n",
+    "    print(\"  status:\", r.status_code)\n",
+    "    print(\"  WWW-Authenticate:\", r.headers.get(\"WWW-Authenticate\", \"<none>\"))\n",
+    "    print(\"  body[:300]:\", r.text[:300])\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6 — The fix in action: discovery probe routing\n",
+    "\n",
+    "With TT-17137 applied, a `GET <listen-path>/.well-known/oauth-protected-resource` is routed to the upstream **host root** (e.g. `https://mcp.atlassian.com/.well-known/oauth-protected-resource`) instead of being prefixed with the upstream URL's path (`/v1/mcp` or `/mcp`).\n",
+    "\n",
+    "Expect a `200` with a JSON document (or `404` for upstreams that don't expose PRM at host root — Notion advertises absolute URLs in its WWW-Authenticate, so its discovery doc may not exist at this path; that's fine, just confirms the routing is now correct rather than double-prefixed)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for api_id, cfg in REMOTES.items():\n",
+    "    url = f\"{GATEWAY_URL}{cfg['listen_path']}.well-known/oauth-protected-resource\"\n",
+    "    print(f\"=== {api_id} → GET {url} ===\")\n",
+    "    r = requests.get(url, timeout=15)\n",
+    "    print(\"  status:\", r.status_code)\n",
+    "    print(\"  Content-Type:\", r.headers.get(\"Content-Type\", \"<none>\"))\n",
+    "    print(\"  body[:500]:\", r.text[:500])\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**How to verify the routing fix from gateway logs**\n",
+    "\n",
+    "Run the gateway with `--log-level=debug` and tail. For the discovery probe above you should see:\n",
+    "\n",
+    "```\n",
+    "msg=\"MCP discovery path detected; routing to upstream host root\"\n",
+    "msg=\"Outbound request URL: https://mcp.atlassian.com/.well-known/oauth-protected-resource\"\n",
+    "```\n",
+    "\n",
+    "Without the patch the outbound URL would have been `https://mcp.atlassian.com/v1/mcp/.well-known/oauth-protected-resource` (broken)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7 — Connect a real MCP client\n",
+    "\n",
+    "The cells above prove the proxy is reachable and discovery routes correctly. To complete the OAuth dance and actually call tools, point an MCP client at each listen path. Examples for Claude Desktop / Roo / Cline `mcp_settings.json`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mcp_settings = {\n",
+    "    \"mcpServers\": {\n",
+    "        cfg[\"name\"]: {\n",
+    "            \"command\": \"npx\",\n",
+    "            \"args\": [\"-y\", \"mcp-remote\", f\"{GATEWAY_URL}{cfg['listen_path']}\"],\n",
+    "            \"alwaysAllow\": [],\n",
+    "            \"disabled\": False,\n",
+    "        }\n",
+    "        for cfg in REMOTES.values()\n",
+    "    }\n",
+    "}\n",
+    "pp(mcp_settings)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or run from a terminal to drive the OAuth flow interactively:\n",
+    "\n",
+    "```bash\n",
+    "npx -y mcp-remote http://localhost:8080/jira/\n",
+    "npx -y mcp-remote http://localhost:8080/notion/\n",
+    "```\n",
+    "\n",
+    "The first invocation opens a browser tab to the upstream's authorization server, you sign in, the token is cached locally by `mcp-remote`, and subsequent calls succeed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8 — Cleanup\n",
+    "\n",
+    "Removes the two proxies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for api_id in REMOTES:\n",
+    "    delete_oas(api_id)\n",
+    "reload()\n",
+    "print(\"clean.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -224,7 +224,15 @@ func (s *APISpec) Unload() {
 // Validate returns nil if s is a valid spec and an error stating why the spec is not valid.
 func (s *APISpec) Validate(oasConfig config.OASConfig) error {
 	if s.IsOAS {
-		err := s.OAS.Validate(context.Background(), oas.GetValidationOptionsFromConfig(oasConfig)...)
+		var err error
+		if s.IsMCP() {
+			// MCP-aware path: empty-mode + no-resource PRM config
+			// resolves to mirror, so users can enable mirror by just
+			// marking the API as MCP without any static fields.
+			err = s.OAS.ValidateForMCP(context.Background(), oas.GetValidationOptionsFromConfig(oasConfig)...)
+		} else {
+			err = s.OAS.Validate(context.Background(), oas.GetValidationOptionsFromConfig(oasConfig)...)
+		}
 		if err != nil {
 			return err
 		}

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -1046,7 +1046,9 @@ func (gw *Gateway) mcpPRMSuffixHandler(spec *APISpec) http.HandlerFunc {
 			ScopesSupported:      prm.ScopesSupported,
 		}
 		w.Header().Set(header.ContentType, "application/json")
-		_ = json.NewEncoder(w).Encode(doc)
+		if err := json.NewEncoder(w).Encode(doc); err != nil {
+			log.WithError(err).Warn("PRM suffix-route handler: failed to encode response")
+		}
 	}
 }
 

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -985,7 +985,7 @@ func (gw *Gateway) registerMCPPRMSuffixRoutes(spec *APISpec, router *mux.Router)
 	// request with `invalid_target` because mcp-remote sends the
 	// gateway URL as the resource (per the mirrored PRM doc) but the
 	// upstream AS only knows the upstream URL.
-	if prm.IsMirrorMode() {
+	if prm.IsMirrorMode(spec.IsMCP()) {
 		gw.registerMCPASProxyRoutes(spec, router)
 	}
 }
@@ -1025,7 +1025,7 @@ func (gw *Gateway) mcpPRMSuffixHandler(spec *APISpec) http.HandlerFunc {
 			http.NotFound(w, r)
 			return
 		}
-		if prm.IsMirrorMode() {
+		if prm.IsMirrorMode(spec.IsMCP()) {
 			if err := mw.serveMirroredPRM(w, r, prm); err != nil {
 				log.WithError(err).Warn("PRM mirror failed at suffix route")
 				http.Error(w, "upstream PRM unavailable", http.StatusBadGateway)

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -25,6 +26,7 @@ import (
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/apidef/oas"
 	"github.com/TykTechnologies/tyk/coprocess"
+	"github.com/TykTechnologies/tyk/header"
 	"github.com/TykTechnologies/tyk/rpc"
 	"github.com/TykTechnologies/tyk/storage"
 	"github.com/TykTechnologies/tyk/trace"
@@ -938,7 +940,82 @@ func (gw *Gateway) loadHTTPService(spec *APISpec, apisByListen map[string]int, g
 	// Register routes for each prefix
 	gw.generateRoutesForPrefixes(spec, prefixes, gwConfig.HttpServerOptions.EnableStrictRoutes, router, chainObj)
 
+	// Mirror-mode PRM clients (mcp-remote, Claude Desktop) probe the
+	// path-suffix variant of /.well-known/oauth-protected-resource at the
+	// gateway root, not under the API's listen path. Auto-register a
+	// sibling handler so users don't have to wire up a second API.
+	gw.registerMCPPRMSuffixRoutes(spec, router)
+
 	return chainObj, nil
+}
+
+// registerMCPPRMSuffixRoutes wires up the host-root well-known URL
+// (`<root>/.well-known/oauth-protected-resource<listen-path>`) that
+// RFC 9728 §3.1 says clients probe. Only attaches when the API is MCP and
+// has PRM enabled — for all other APIs this is a no-op.
+//
+// mcp-remote strips the trailing slash off the listen path before building
+// the probe URL, so we register both with and without the trailing slash.
+func (gw *Gateway) registerMCPPRMSuffixRoutes(spec *APISpec, router *mux.Router) {
+	if spec == nil || !spec.IsMCP() {
+		return
+	}
+	prm := spec.GetPRMConfig()
+	if prm == nil {
+		return
+	}
+
+	listen := strings.TrimRight(spec.Proxy.ListenPath, "/")
+	if listen == "" {
+		// Listen path is `/` — host-root well-known would collide with
+		// the standard PRM path; nothing extra to register.
+		return
+	}
+	noSlash := "/.well-known/oauth-protected-resource" + listen
+	withSlash := noSlash + "/"
+
+	handler := gw.mcpPRMSuffixHandler(spec)
+	router.HandleFunc(noSlash, handler).Methods(http.MethodGet)
+	router.HandleFunc(withSlash, handler).Methods(http.MethodGet)
+	mainLog.WithField("api_id", spec.APIID).Debugf("registered MCP PRM suffix route at %s", noSlash)
+}
+
+// mcpPRMSuffixHandler returns the http.HandlerFunc that serves the PRM
+// document at the gateway-root well-known URL. It dispatches into the
+// PRMMiddleware logic so static and mirror modes share a code path.
+func (gw *Gateway) mcpPRMSuffixHandler(spec *APISpec) http.HandlerFunc {
+	mw := &PRMMiddleware{BaseMiddleware: &BaseMiddleware{Spec: spec, Gw: gw}}
+	prm := spec.GetPRMConfig()
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Reuse the mirror serving path directly. For static-mode APIs we
+		// fall back to assembling from the configured fields.
+		if prm == nil {
+			http.NotFound(w, r)
+			return
+		}
+		if prm.IsMirrorMode() {
+			if err := mw.serveMirroredPRM(w, r, prm); err != nil {
+				log.WithError(err).Warn("PRM mirror failed at suffix route")
+				http.Error(w, "upstream PRM unavailable", http.StatusBadGateway)
+			}
+			return
+		}
+		// Static mode at the suffix route: assemble inline. (We don't go
+		// through PRMMiddleware.ProcessRequest because it gates on
+		// r.URL.Path == prmWellKnownPath which uses the in-listen-path
+		// URL, not the suffix one.)
+		resource := prm.Resource
+		if resource != "" {
+			resource = gw.ReplaceTykVariables(r, resource, false)
+		}
+		doc := prmResponseDocument{
+			Resource:             resource,
+			AuthorizationServers: prm.AuthorizationServers,
+			ScopesSupported:      prm.ScopesSupported,
+		}
+		w.Header().Set(header.ContentType, "application/json")
+		_ = json.NewEncoder(w).Encode(doc)
+	}
 }
 
 func (gw *Gateway) generateRoutesForPrefixes(spec *APISpec, prefixes []string, enabledStrictRoutes bool, router *mux.Router, chainObj *ChainObject) {

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -978,6 +978,38 @@ func (gw *Gateway) registerMCPPRMSuffixRoutes(spec *APISpec, router *mux.Router)
 	router.HandleFunc(noSlash, handler).Methods(http.MethodGet)
 	router.HandleFunc(withSlash, handler).Methods(http.MethodGet)
 	mainLog.WithField("api_id", spec.APIID).Debugf("registered MCP PRM suffix route at %s", noSlash)
+
+	// Mirror mode also fronts the upstream's OAuth authorization server
+	// so we can rewrite the RFC 8707 `resource` parameter on the wire.
+	// Without this, strict ASes (Notion) reject the client's authorize
+	// request with `invalid_target` because mcp-remote sends the
+	// gateway URL as the resource (per the mirrored PRM doc) but the
+	// upstream AS only knows the upstream URL.
+	if prm.IsMirrorMode() {
+		gw.registerMCPASProxyRoutes(spec, router)
+	}
+}
+
+// registerMCPASProxyRoutes wires the per-API OAuth Authorization Server
+// proxy endpoints used by mirror-mode PRM. Three routes are registered
+// at gateway root so they're reachable independently of the API's
+// listen path:
+//
+//	GET  /.well-known/oauth-authorization-server/__tyk-as/<api-id>
+//	GET  /__tyk-as/<api-id>/authorize
+//	POST /__tyk-as/<api-id>/token
+//
+// The `.well-known` path-suffix variant is what mcp-remote computes from
+// the AS URL we advertise in the mirrored PRM doc.
+func (gw *Gateway) registerMCPASProxyRoutes(spec *APISpec, router *mux.Router) {
+	asMetadataPath := "/.well-known/oauth-authorization-server" + mcpASProxyPathPrefix + spec.APIID
+	authorizePath := mcpASProxyPathPrefix + spec.APIID + "/authorize"
+	tokenPath := mcpASProxyPathPrefix + spec.APIID + "/token"
+
+	router.HandleFunc(asMetadataPath, gw.serveASProxyMetadata(spec)).Methods(http.MethodGet)
+	router.HandleFunc(authorizePath, gw.authorizeProxyHandler(spec)).Methods(http.MethodGet)
+	router.HandleFunc(tokenPath, gw.tokenProxyHandler(spec)).Methods(http.MethodPost)
+	mainLog.WithField("api_id", spec.APIID).Debugf("registered MCP AS proxy routes under %s%s", mcpASProxyPathPrefix, spec.APIID)
 }
 
 // mcpPRMSuffixHandler returns the http.HandlerFunc that serves the PRM

--- a/gateway/mcp_api.go
+++ b/gateway/mcp_api.go
@@ -59,16 +59,13 @@ func (gw *Gateway) validateMCP(next http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 
-		if err = mcpObj.Validate(r.Context(), oas.GetValidationOptionsFromConfig(gw.GetConfig().OAS)...); err != nil {
+		// MCP-aware validate: PRM is checked with isMCP=true so the
+		// empty-mode + no-resource shape resolves to mirror (auto) rather
+		// than static-with-missing-resource. This lets users enable PRM
+		// on a remote MCP API with a single `enabled: true` line.
+		if err = mcpObj.ValidateForMCP(r.Context(), oas.GetValidationOptionsFromConfig(gw.GetConfig().OAS)...); err != nil {
 			doJSONWrite(w, http.StatusBadRequest, apiError(err.Error()))
 			return
-		}
-
-		if tykExt := mcpObj.GetTykExtension(); tykExt != nil && tykExt.Server.Authentication != nil {
-			if err = tykExt.Server.Authentication.ProtectedResourceMetadata.Validate(true); err != nil {
-				doJSONWrite(w, http.StatusBadRequest, apiError(err.Error()))
-				return
-			}
 		}
 
 		r.Body = ioutil.NopCloser(bytes.NewReader(reqBodyInBytes))

--- a/gateway/mcp_oauth_proxy.go
+++ b/gateway/mcp_oauth_proxy.go
@@ -18,6 +18,17 @@ import (
 // enabled. The shape is `<gateway-root>/__tyk-as/<api-id>/...`.
 const mcpASProxyPathPrefix = "/__tyk-as/"
 
+// Bad-gateway error messages emitted when the upstream authorization
+// server is unreachable or its metadata document is missing/malformed.
+// Defined as constants to keep the three handlers in this file consistent.
+const (
+	errUpstreamASUnavailable       = "upstream authorization server unavailable"
+	errUpstreamASMetadataUnavail   = "upstream AS metadata unavailable"
+	errUpstreamMissingAuthorizeEP  = "upstream metadata missing authorization_endpoint"
+	errUpstreamMissingTokenEP      = "upstream metadata missing token_endpoint"
+	errInvalidUpstreamAuthorizeURL = "invalid upstream authorization_endpoint"
+)
+
 // mcpASProxyBaseURL builds the public URL Tyk advertises as the
 // authorization server in a mirrored PRM doc. It is per-API so each MCP
 // proxy gets its own scope under the gateway root.
@@ -47,6 +58,26 @@ func rewriteResourceParam(values url.Values, spec *APISpec) {
 	values.Set("resource", upstreamResourceURL(spec))
 }
 
+// resolveUpstreamASMetadata fetches the upstream's authorization-server
+// metadata document and writes the appropriate 502 error to w if either
+// resolving the AS URL or fetching its metadata fails. Returns ok=false
+// in those cases — the caller stops processing the request.
+func (gw *Gateway) resolveUpstreamASMetadata(w http.ResponseWriter, r *http.Request, spec *APISpec) (metadata map[string]any, ok bool) {
+	asURL, err := gw.firstAuthorizationServer(r.Context(), spec)
+	if err != nil {
+		log.WithError(err).Warn("AS proxy: cannot resolve upstream authorization server")
+		http.Error(w, errUpstreamASUnavailable, http.StatusBadGateway)
+		return nil, false
+	}
+	metadata, err = fetchUpstreamASMetadata(r.Context(), asURL)
+	if err != nil {
+		log.WithError(err).Warn("AS proxy: cannot fetch upstream metadata")
+		http.Error(w, errUpstreamASMetadataUnavail, http.StatusBadGateway)
+		return nil, false
+	}
+	return metadata, true
+}
+
 // serveASProxyMetadata fetches the upstream Authorization Server metadata
 // document, rewrites `authorization_endpoint` and `token_endpoint` to
 // point at Tyk's per-API proxy endpoints, and serves the result.
@@ -56,17 +87,8 @@ func rewriteResourceParam(values url.Values, spec *APISpec) {
 // rewrite there, and avoiding the proxy keeps the DCR flow minimal.
 func (gw *Gateway) serveASProxyMetadata(spec *APISpec) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		asURL, err := gw.firstAuthorizationServer(r.Context(), spec)
-		if err != nil {
-			log.WithError(err).Warn("AS proxy: cannot resolve upstream authorization server")
-			http.Error(w, "upstream authorization server unavailable", http.StatusBadGateway)
-			return
-		}
-
-		metadata, err := fetchUpstreamASMetadata(r.Context(), asURL)
-		if err != nil {
-			log.WithError(err).Warn("AS proxy: cannot fetch upstream metadata")
-			http.Error(w, "upstream AS metadata unavailable", http.StatusBadGateway)
+		metadata, ok := gw.resolveUpstreamASMetadata(w, r, spec)
+		if !ok {
 			return
 		}
 
@@ -84,42 +106,38 @@ func (gw *Gateway) serveASProxyMetadata(spec *APISpec) http.HandlerFunc {
 // parameter so the upstream AS recognises it.
 func (gw *Gateway) authorizeProxyHandler(spec *APISpec) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		asURL, err := gw.firstAuthorizationServer(r.Context(), spec)
-		if err != nil {
-			http.Error(w, "upstream authorization server unavailable", http.StatusBadGateway)
-			return
-		}
-		metadata, err := fetchUpstreamASMetadata(r.Context(), asURL)
-		if err != nil {
-			http.Error(w, "upstream AS metadata unavailable", http.StatusBadGateway)
+		metadata, ok := gw.resolveUpstreamASMetadata(w, r, spec)
+		if !ok {
 			return
 		}
 		realAuthorize, _ := metadata["authorization_endpoint"].(string)
 		if realAuthorize == "" {
-			http.Error(w, "upstream metadata missing authorization_endpoint", http.StatusBadGateway)
+			http.Error(w, errUpstreamMissingAuthorizeEP, http.StatusBadGateway)
 			return
 		}
-
 		target, err := url.Parse(realAuthorize)
 		if err != nil {
-			http.Error(w, "invalid upstream authorization_endpoint", http.StatusBadGateway)
+			http.Error(w, errInvalidUpstreamAuthorizeURL, http.StatusBadGateway)
 			return
 		}
 
-		q := r.URL.Query()
-		rewriteResourceParam(q, spec)
-		// Merge any query already present on the upstream authorize URL.
-		if upstreamQ := target.Query(); len(upstreamQ) > 0 {
-			for k, vs := range upstreamQ {
-				if _, ok := q[k]; !ok {
-					q[k] = vs
-				}
-			}
-		}
-		target.RawQuery = q.Encode()
-
+		target.RawQuery = mergedAuthorizeQuery(r.URL.Query(), target.Query(), spec).Encode()
 		http.Redirect(w, r, target.String(), http.StatusFound)
 	}
+}
+
+// mergedAuthorizeQuery returns the query string Tyk forwards to the
+// upstream authorize endpoint: the client's params with `resource`
+// rewritten to the upstream URL, plus any params that were preset on the
+// upstream's authorize URL itself (which the client wouldn't have sent).
+func mergedAuthorizeQuery(clientQ, upstreamQ url.Values, spec *APISpec) url.Values {
+	rewriteResourceParam(clientQ, spec)
+	for k, vs := range upstreamQ {
+		if _, present := clientQ[k]; !present {
+			clientQ[k] = vs
+		}
+	}
+	return clientQ
 }
 
 // tokenProxyHandler forwards the client's token request to the upstream
@@ -127,19 +145,13 @@ func (gw *Gateway) authorizeProxyHandler(spec *APISpec) http.HandlerFunc {
 // Returns the upstream response unmodified.
 func (gw *Gateway) tokenProxyHandler(spec *APISpec) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		asURL, err := gw.firstAuthorizationServer(r.Context(), spec)
-		if err != nil {
-			http.Error(w, "upstream authorization server unavailable", http.StatusBadGateway)
-			return
-		}
-		metadata, err := fetchUpstreamASMetadata(r.Context(), asURL)
-		if err != nil {
-			http.Error(w, "upstream AS metadata unavailable", http.StatusBadGateway)
+		metadata, ok := gw.resolveUpstreamASMetadata(w, r, spec)
+		if !ok {
 			return
 		}
 		realToken, _ := metadata["token_endpoint"].(string)
 		if realToken == "" {
-			http.Error(w, "upstream metadata missing token_endpoint", http.StatusBadGateway)
+			http.Error(w, errUpstreamMissingTokenEP, http.StatusBadGateway)
 			return
 		}
 
@@ -152,37 +164,53 @@ func (gw *Gateway) tokenProxyHandler(spec *APISpec) http.HandlerFunc {
 		rewriteResourceParam(r.PostForm, spec)
 		rewriteResourceParam(r.Form, spec)
 
-		body := r.PostForm.Encode()
-
 		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 		defer cancel()
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, realToken, strings.NewReader(body))
+		req, err := buildTokenRequest(ctx, r, realToken, r.PostForm.Encode())
 		if err != nil {
 			http.Error(w, "cannot build upstream token request", http.StatusInternalServerError)
 			return
 		}
-		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-		req.Header.Set("Accept", r.Header.Get("Accept"))
-		// Forward Authorization (e.g. confidential client credentials) if present.
-		if v := r.Header.Get("Authorization"); v != "" {
-			req.Header.Set("Authorization", v)
-		}
-
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			http.Error(w, "upstream token endpoint unreachable", http.StatusBadGateway)
 			return
 		}
 		defer resp.Body.Close()
-
-		for k, vs := range resp.Header {
-			for _, v := range vs {
-				w.Header().Add(k, v)
-			}
-		}
-		w.WriteHeader(resp.StatusCode)
-		_, _ = io.Copy(w, resp.Body)
+		writeUpstreamResponse(w, resp)
 	}
+}
+
+// buildTokenRequest constructs the upstream token-endpoint POST. Carries
+// over Accept and Authorization (for confidential clients with basic-auth
+// credentials) from the inbound request. The caller owns the context's
+// lifetime — typically WithTimeout + defer cancel() — so the in-flight
+// request isn't cancelled the moment this function returns.
+func buildTokenRequest(ctx context.Context, in *http.Request, tokenURL, body string) (*http.Request, error) {
+	out, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	out.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if v := in.Header.Get("Accept"); v != "" {
+		out.Header.Set("Accept", v)
+	}
+	if v := in.Header.Get("Authorization"); v != "" {
+		out.Header.Set("Authorization", v)
+	}
+	return out, nil
+}
+
+// writeUpstreamResponse mirrors an upstream response to the client: headers
+// verbatim, then status code, then body.
+func writeUpstreamResponse(w http.ResponseWriter, resp *http.Response) {
+	for k, vs := range resp.Header {
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
 }
 
 // firstAuthorizationServer derives the upstream's primary authorization

--- a/gateway/mcp_oauth_proxy.go
+++ b/gateway/mcp_oauth_proxy.go
@@ -1,0 +1,261 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/TykTechnologies/tyk/header"
+)
+
+// mcpASProxyPathPrefix is the base under which Tyk publishes per-API
+// internal OAuth Authorization Server proxy endpoints when mirror mode is
+// enabled. The shape is `<gateway-root>/__tyk-as/<api-id>/...`.
+const mcpASProxyPathPrefix = "/__tyk-as/"
+
+// mcpASProxyBaseURL builds the public URL Tyk advertises as the
+// authorization server in a mirrored PRM doc. It is per-API so each MCP
+// proxy gets its own scope under the gateway root.
+func mcpASProxyBaseURL(r *http.Request, spec *APISpec) string {
+	scheme := "http"
+	if r.TLS != nil || strings.EqualFold(r.URL.Scheme, "https") {
+		scheme = "https"
+	}
+	return fmt.Sprintf("%s://%s%s%s", scheme, r.Host, mcpASProxyPathPrefix, spec.APIID)
+}
+
+// upstreamResourceURL is the canonical URL the AS knows the resource by.
+// Used as the value we substitute in for the `resource` parameter when
+// proxying the authorize/token flow on behalf of the client.
+func upstreamResourceURL(spec *APISpec) string {
+	return spec.Proxy.TargetURL
+}
+
+// rewriteResourceParam swaps the `resource` parameter (RFC 8707) value to
+// the upstream URL. Strict authorization servers — Notion as of 2026-Q2 —
+// reject the gateway URL with `invalid_target`; the upstream URL is the
+// only value they recognise.
+func rewriteResourceParam(values url.Values, spec *APISpec) {
+	if _, ok := values["resource"]; !ok {
+		return
+	}
+	values.Set("resource", upstreamResourceURL(spec))
+}
+
+// serveASProxyMetadata fetches the upstream Authorization Server metadata
+// document, rewrites `authorization_endpoint` and `token_endpoint` to
+// point at Tyk's per-API proxy endpoints, and serves the result.
+//
+// `registration_endpoint` is left unchanged: Dynamic Client Registration
+// (RFC 7591) does not carry a `resource` parameter so there's nothing to
+// rewrite there, and avoiding the proxy keeps the DCR flow minimal.
+func (gw *Gateway) serveASProxyMetadata(spec *APISpec) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		asURL, err := gw.firstAuthorizationServer(r.Context(), spec)
+		if err != nil {
+			log.WithError(err).Warn("AS proxy: cannot resolve upstream authorization server")
+			http.Error(w, "upstream authorization server unavailable", http.StatusBadGateway)
+			return
+		}
+
+		metadata, err := fetchUpstreamASMetadata(r.Context(), asURL)
+		if err != nil {
+			log.WithError(err).Warn("AS proxy: cannot fetch upstream metadata")
+			http.Error(w, "upstream AS metadata unavailable", http.StatusBadGateway)
+			return
+		}
+
+		base := mcpASProxyBaseURL(r, spec)
+		metadata["authorization_endpoint"] = base + "/authorize"
+		metadata["token_endpoint"] = base + "/token"
+
+		w.Header().Set(header.ContentType, "application/json")
+		_ = json.NewEncoder(w).Encode(metadata)
+	}
+}
+
+// authorizeProxyHandler 302-redirects the client's authorize request to
+// the real upstream authorize endpoint after rewriting the `resource`
+// parameter so the upstream AS recognises it.
+func (gw *Gateway) authorizeProxyHandler(spec *APISpec) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		asURL, err := gw.firstAuthorizationServer(r.Context(), spec)
+		if err != nil {
+			http.Error(w, "upstream authorization server unavailable", http.StatusBadGateway)
+			return
+		}
+		metadata, err := fetchUpstreamASMetadata(r.Context(), asURL)
+		if err != nil {
+			http.Error(w, "upstream AS metadata unavailable", http.StatusBadGateway)
+			return
+		}
+		realAuthorize, _ := metadata["authorization_endpoint"].(string)
+		if realAuthorize == "" {
+			http.Error(w, "upstream metadata missing authorization_endpoint", http.StatusBadGateway)
+			return
+		}
+
+		target, err := url.Parse(realAuthorize)
+		if err != nil {
+			http.Error(w, "invalid upstream authorization_endpoint", http.StatusBadGateway)
+			return
+		}
+
+		q := r.URL.Query()
+		rewriteResourceParam(q, spec)
+		// Merge any query already present on the upstream authorize URL.
+		if upstreamQ := target.Query(); len(upstreamQ) > 0 {
+			for k, vs := range upstreamQ {
+				if _, ok := q[k]; !ok {
+					q[k] = vs
+				}
+			}
+		}
+		target.RawQuery = q.Encode()
+
+		http.Redirect(w, r, target.String(), http.StatusFound)
+	}
+}
+
+// tokenProxyHandler forwards the client's token request to the upstream
+// token endpoint, rewriting the `resource` form field on the way through.
+// Returns the upstream response unmodified.
+func (gw *Gateway) tokenProxyHandler(spec *APISpec) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		asURL, err := gw.firstAuthorizationServer(r.Context(), spec)
+		if err != nil {
+			http.Error(w, "upstream authorization server unavailable", http.StatusBadGateway)
+			return
+		}
+		metadata, err := fetchUpstreamASMetadata(r.Context(), asURL)
+		if err != nil {
+			http.Error(w, "upstream AS metadata unavailable", http.StatusBadGateway)
+			return
+		}
+		realToken, _ := metadata["token_endpoint"].(string)
+		if realToken == "" {
+			http.Error(w, "upstream metadata missing token_endpoint", http.StatusBadGateway)
+			return
+		}
+
+		// Re-parse the form so we can rewrite `resource` regardless of
+		// whether it was sent as a query string or form body.
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "cannot parse token request", http.StatusBadRequest)
+			return
+		}
+		rewriteResourceParam(r.PostForm, spec)
+		rewriteResourceParam(r.Form, spec)
+
+		body := r.PostForm.Encode()
+
+		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+		defer cancel()
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, realToken, strings.NewReader(body))
+		if err != nil {
+			http.Error(w, "cannot build upstream token request", http.StatusInternalServerError)
+			return
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("Accept", r.Header.Get("Accept"))
+		// Forward Authorization (e.g. confidential client credentials) if present.
+		if v := r.Header.Get("Authorization"); v != "" {
+			req.Header.Set("Authorization", v)
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			http.Error(w, "upstream token endpoint unreachable", http.StatusBadGateway)
+			return
+		}
+		defer resp.Body.Close()
+
+		for k, vs := range resp.Header {
+			for _, v := range vs {
+				w.Header().Add(k, v)
+			}
+		}
+		w.WriteHeader(resp.StatusCode)
+		_, _ = io.Copy(w, resp.Body)
+	}
+}
+
+// firstAuthorizationServer derives the upstream's primary authorization
+// server URL via the same path the mirrored PRM doc uses: fetch the
+// upstream PRM, take the first entry of `authorization_servers`. Cached
+// alongside the PRM doc.
+func (gw *Gateway) firstAuthorizationServer(ctx context.Context, spec *APISpec) (string, error) {
+	doc, err := gw.upstreamPRMDoc(ctx, spec)
+	if err != nil {
+		return "", err
+	}
+	servers, _ := doc.Raw["authorization_servers"].([]any)
+	for _, s := range servers {
+		if str, ok := s.(string); ok && str != "" {
+			return str, nil
+		}
+	}
+	return "", fmt.Errorf("upstream PRM has no authorization_servers")
+}
+
+// fetchUpstreamASMetadata retrieves the upstream's AS metadata document
+// from the path-suffix variant URL (RFC 8414 §3.1), tolerant of either
+// `/.well-known/oauth-authorization-server<path>` (path-suffix) or
+// `<path>/.well-known/oauth-authorization-server` (path-prefix). Tries
+// the suffix variant first because that's what most tenanted ASes (e.g.
+// auth.atlassian.com) serve.
+func fetchUpstreamASMetadata(ctx context.Context, asURL string) (map[string]any, error) {
+	u, err := url.Parse(asURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse AS URL: %w", err)
+	}
+
+	path := strings.TrimRight(u.Path, "/")
+	candidates := []string{}
+	if path == "" {
+		candidates = append(candidates,
+			fmt.Sprintf("%s://%s/.well-known/oauth-authorization-server", u.Scheme, u.Host))
+	} else {
+		candidates = append(candidates,
+			fmt.Sprintf("%s://%s/.well-known/oauth-authorization-server%s", u.Scheme, u.Host, path),
+			fmt.Sprintf("%s://%s%s/.well-known/oauth-authorization-server", u.Scheme, u.Host, path))
+	}
+
+	var lastErr error
+	for _, candidate := range candidates {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, candidate, nil)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("MCP-Protocol-Version", "2024-11-05")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode/100 != 2 {
+			lastErr = fmt.Errorf("AS metadata %s returned %d", candidate, resp.StatusCode)
+			continue
+		}
+		var doc map[string]any
+		if err := json.Unmarshal(body, &doc); err != nil {
+			lastErr = fmt.Errorf("AS metadata %s decode: %w", candidate, err)
+			continue
+		}
+		return doc, nil
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no AS metadata endpoints tried")
+	}
+	return nil, lastErr
+}

--- a/gateway/mcp_oauth_proxy.go
+++ b/gateway/mcp_oauth_proxy.go
@@ -97,7 +97,9 @@ func (gw *Gateway) serveASProxyMetadata(spec *APISpec) http.HandlerFunc {
 		metadata["token_endpoint"] = base + "/token"
 
 		w.Header().Set(header.ContentType, "application/json")
-		_ = json.NewEncoder(w).Encode(metadata)
+		if err := json.NewEncoder(w).Encode(metadata); err != nil {
+			log.WithError(err).Warn("AS proxy: failed to encode metadata response")
+		}
 	}
 }
 
@@ -210,7 +212,9 @@ func writeUpstreamResponse(w http.ResponseWriter, resp *http.Response) {
 		}
 	}
 	w.WriteHeader(resp.StatusCode)
-	_, _ = io.Copy(w, resp.Body)
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		log.WithError(err).Warn("AS proxy: failed copying upstream response body")
+	}
 }
 
 // firstAuthorizationServer derives the upstream's primary authorization
@@ -269,8 +273,12 @@ func fetchUpstreamASMetadata(ctx context.Context, asURL string) (map[string]any,
 			lastErr = err
 			continue
 		}
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
 		_ = resp.Body.Close()
+		if readErr != nil {
+			lastErr = fmt.Errorf("AS metadata %s body read: %w", candidate, readErr)
+			continue
+		}
 		if resp.StatusCode/100 != 2 {
 			lastErr = fmt.Errorf("AS metadata %s returned %d", candidate, resp.StatusCode)
 			continue

--- a/gateway/mcp_oauth_proxy.go
+++ b/gateway/mcp_oauth_proxy.go
@@ -112,8 +112,8 @@ func (gw *Gateway) authorizeProxyHandler(spec *APISpec) http.HandlerFunc {
 		if !ok {
 			return
 		}
-		realAuthorize, _ := metadata["authorization_endpoint"].(string)
-		if realAuthorize == "" {
+		realAuthorize, ok := metadata["authorization_endpoint"].(string)
+		if !ok || realAuthorize == "" {
 			http.Error(w, errUpstreamMissingAuthorizeEP, http.StatusBadGateway)
 			return
 		}
@@ -151,8 +151,8 @@ func (gw *Gateway) tokenProxyHandler(spec *APISpec) http.HandlerFunc {
 		if !ok {
 			return
 		}
-		realToken, _ := metadata["token_endpoint"].(string)
-		if realToken == "" {
+		realToken, ok := metadata["token_endpoint"].(string)
+		if !ok || realToken == "" {
 			http.Error(w, errUpstreamMissingTokenEP, http.StatusBadGateway)
 			return
 		}
@@ -226,7 +226,10 @@ func (gw *Gateway) firstAuthorizationServer(ctx context.Context, spec *APISpec) 
 	if err != nil {
 		return "", err
 	}
-	servers, _ := doc.Raw["authorization_servers"].([]any)
+	servers, ok := doc.Raw["authorization_servers"].([]any)
+	if !ok {
+		return "", fmt.Errorf("upstream PRM has no authorization_servers")
+	}
 	for _, s := range servers {
 		if str, ok := s.(string); ok && str != "" {
 			return str, nil

--- a/gateway/mcp_oauth_proxy_test.go
+++ b/gateway/mcp_oauth_proxy_test.go
@@ -78,10 +78,10 @@ func stockUpstreamHandler(authorizeHits, tokenHits *int, lastResource *string) f
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/.well-known/oauth-protected-resource/v1/mcp/authv2":
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintf(w, `{"resource":"https://upstream.example/v1/mcp/authv2","authorization_servers":["%s"]}`, upstream.URL)
+			_, _ = fmt.Fprintf(w, `{"resource":"https://upstream.example/v1/mcp/authv2","authorization_servers":["%s"]}`, upstream.URL) //nolint:errcheck
 		case r.Method == http.MethodGet && r.URL.Path == "/.well-known/oauth-authorization-server":
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintf(w, `{"issuer":"%s","authorization_endpoint":"%s/authorize","token_endpoint":"%s/token"}`,
+			_, _ = fmt.Fprintf(w, `{"issuer":"%s","authorization_endpoint":"%s/authorize","token_endpoint":"%s/token"}`, //nolint:errcheck
 				upstream.URL, upstream.URL, upstream.URL)
 		case r.Method == http.MethodGet && r.URL.Path == "/authorize":
 			*authorizeHits++
@@ -89,10 +89,10 @@ func stockUpstreamHandler(authorizeHits, tokenHits *int, lastResource *string) f
 			w.WriteHeader(http.StatusOK)
 		case r.Method == http.MethodPost && r.URL.Path == "/token":
 			*tokenHits++
-			_ = r.ParseForm()
+			_ = r.ParseForm() //nolint:errcheck
 			*lastResource = r.PostFormValue("resource")
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"access_token":"abc"}`))
+			_, _ = w.Write([]byte(`{"access_token":"abc"}`)) //nolint:errcheck
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -129,11 +129,12 @@ func TestASProxy_AuthorizeRedirect_RewritesResource(t *testing.T) {
 
 	gatewayResource := "http%3A%2F%2Fgateway%2Fmcp-test%2F"
 	client := &http.Client{
-		CheckRedirect: func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse },
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse },
 	}
-	req, _ := http.NewRequest(http.MethodGet,
+	req, errReq := http.NewRequest(http.MethodGet,
 		ts.URL+"/__tyk-as/test/authorize?response_type=code&client_id=cid&resource="+gatewayResource+"&state=s",
 		nil)
+	require.NoError(t, errReq)
 	resp, err := client.Do(req)
 	require.NoError(t, err)
 	_ = resp.Body.Close()
@@ -159,12 +160,14 @@ func TestASProxy_TokenForward_RewritesResource(t *testing.T) {
 	form.Set("grant_type", "authorization_code")
 	form.Set("code", "abc")
 	form.Set("resource", "http://gateway/mcp-test/")
-	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/__tyk-as/test/token", strings.NewReader(form.Encode()))
+	req, errReq := http.NewRequest(http.MethodPost, ts.URL+"/__tyk-as/test/token", strings.NewReader(form.Encode()))
+	require.NoError(t, errReq)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	body, _ := io.ReadAll(resp.Body)
+	body, errBody := io.ReadAll(resp.Body)
+	require.NoError(t, errBody)
 	_ = resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode, "body=%s", string(body))
 	assert.Contains(t, string(body), `"access_token":"abc"`)
@@ -175,20 +178,21 @@ func TestASProxy_TokenForward_RewritesResource(t *testing.T) {
 
 func TestASProxy_AuthorizeBadGateway_WhenUpstreamMissingASEndpoint(t *testing.T) {
 	ts, _ := newMCPMirrorTest(t, func(w http.ResponseWriter, r *http.Request, upstream *httptest.Server) {
-		switch {
-		case r.URL.Path == "/.well-known/oauth-protected-resource/v1/mcp/authv2":
+		switch r.URL.Path {
+		case "/.well-known/oauth-protected-resource/v1/mcp/authv2":
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintf(w, `{"resource":"x","authorization_servers":["%s"]}`, upstream.URL)
-		case r.URL.Path == "/.well-known/oauth-authorization-server":
+			_, _ = fmt.Fprintf(w, `{"resource":"x","authorization_servers":["%s"]}`, upstream.URL) //nolint:errcheck
+		case "/.well-known/oauth-authorization-server":
 			// Metadata returns no authorization_endpoint at all.
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"issuer":"x"}`))
+			_, _ = w.Write([]byte(`{"issuer":"x"}`)) //nolint:errcheck
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
 	})
 
-	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/__tyk-as/test/authorize?resource=x", nil)
+	req, errReq := http.NewRequest(http.MethodGet, ts.URL+"/__tyk-as/test/authorize?resource=x", nil)
+	require.NoError(t, errReq)
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 	_ = resp.Body.Close()
@@ -198,18 +202,18 @@ func TestASProxy_AuthorizeBadGateway_WhenUpstreamMissingASEndpoint(t *testing.T)
 func TestASProxy_TokenBadGateway_WhenUpstreamMetadataMissing(t *testing.T) {
 	ts, _ := newMCPMirrorTest(t, func(w http.ResponseWriter, r *http.Request, upstream *httptest.Server) {
 		// Upstream PRM responds, but AS metadata is missing.
-		switch {
-		case r.URL.Path == "/.well-known/oauth-protected-resource/v1/mcp/authv2":
+		if r.URL.Path == "/.well-known/oauth-protected-resource/v1/mcp/authv2" {
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintf(w, `{"resource":"x","authorization_servers":["%s"]}`, upstream.URL)
-		default:
-			w.WriteHeader(http.StatusNotFound)
+			_, _ = fmt.Fprintf(w, `{"resource":"x","authorization_servers":["%s"]}`, upstream.URL) //nolint:errcheck
+			return
 		}
+		w.WriteHeader(http.StatusNotFound)
 	})
 
 	form := url.Values{}
 	form.Set("grant_type", "authorization_code")
-	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/__tyk-as/test/token", strings.NewReader(form.Encode()))
+	req, errReq := http.NewRequest(http.MethodPost, ts.URL+"/__tyk-as/test/token", strings.NewReader(form.Encode()))
+	require.NoError(t, errReq)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
@@ -242,7 +246,7 @@ func TestFetchUpstreamASMetadata_PathSuffixVariant(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/.well-known/oauth-authorization-server/tenant" {
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"issuer":"https://as","token_endpoint":"https://as/t"}`))
+			_, _ = w.Write([]byte(`{"issuer":"https://as","token_endpoint":"https://as/t"}`)) //nolint:errcheck
 			return
 		}
 		w.WriteHeader(http.StatusNotFound)
@@ -260,7 +264,7 @@ func TestFetchUpstreamASMetadata_PathPrefixVariant(t *testing.T) {
 		// Only respond at the path-prefix variant; the suffix one 404s.
 		if r.URL.Path == "/tenant/.well-known/oauth-authorization-server" {
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"issuer":"https://as"}`))
+			_, _ = w.Write([]byte(`{"issuer":"https://as"}`)) //nolint:errcheck
 			return
 		}
 		w.WriteHeader(http.StatusNotFound)
@@ -276,7 +280,7 @@ func TestFetchUpstreamASMetadata_RootHostNoPath(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/.well-known/oauth-authorization-server" {
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"issuer":"https://as"}`))
+			_, _ = w.Write([]byte(`{"issuer":"https://as"}`)) //nolint:errcheck
 			return
 		}
 		w.WriteHeader(http.StatusNotFound)
@@ -357,7 +361,7 @@ func TestRegisterMCPPRMSuffixRoutes_EarlyReturns(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(_ *testing.T) {
 			// Should be a no-op — no panic, no error returned.
 			ts.Gw.registerMCPPRMSuffixRoutes(c.spec, nil)
 		})

--- a/gateway/mcp_oauth_proxy_test.go
+++ b/gateway/mcp_oauth_proxy_test.go
@@ -1,0 +1,454 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/test"
+)
+
+// helper: spin up a fake remote MCP server with PRM + AS metadata + the
+// authorize/token endpoints, plus the Tyk MCP API in mirror mode. Returns
+// the test harness and the upstream URL so tests can drive requests
+// against gateway routes that proxy to the fake upstream.
+func newMCPMirrorTest(t *testing.T, behavior func(w http.ResponseWriter, r *http.Request, upstream *httptest.Server)) (*Test, string) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	t.Cleanup(upstream.Close)
+	upstream.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		behavior(w, r, upstream)
+	})
+
+	ts := StartTest(nil)
+	t.Cleanup(ts.Close)
+
+	const listenPath = "/mcp-test/"
+	upstreamTarget := upstream.URL + "/v1/mcp/authv2"
+
+	oasDoc := oas.OAS{
+		T: openapi3.T{
+			OpenAPI: "3.0.3",
+			Info:    &openapi3.Info{Title: "MCP OAuth Proxy", Version: "1.0"},
+			Paths:   openapi3.NewPaths(),
+		},
+	}
+	oasDoc.SetTykExtension(&oas.XTykAPIGateway{
+		Info:     oas.Info{Name: "mcp-oauth-test", State: oas.State{Active: true}},
+		Upstream: oas.Upstream{URL: upstreamTarget},
+		Server: oas.Server{
+			ListenPath: oas.ListenPath{Value: listenPath, Strip: true},
+			Authentication: &oas.Authentication{
+				ProtectedResourceMetadata: &oas.ProtectedResourceMetadata{
+					Enabled: true, Mode: oas.PRMModeMirror,
+				},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.UseKeylessAccess = true
+		spec.MarkAsMCP()
+		spec.Proxy.ListenPath = listenPath
+		spec.Proxy.TargetURL = upstreamTarget
+		spec.IsOAS = true
+		spec.OAS = oasDoc
+	})
+	ts.Gw.PRMCache().Invalidate(upstream.URL + "/.well-known/oauth-protected-resource/v1/mcp/authv2")
+
+	return ts, upstream.URL
+}
+
+// stockUpstreamHandler emulates a spec-compliant upstream MCP that
+// publishes PRM + RFC 8414 AS metadata + working authorize/token
+// endpoints. Drives the happy-path flow.
+func stockUpstreamHandler(authorizeHits, tokenHits *int, lastResource *string) func(w http.ResponseWriter, r *http.Request, upstream *httptest.Server) {
+	return func(w http.ResponseWriter, r *http.Request, upstream *httptest.Server) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/.well-known/oauth-protected-resource/v1/mcp/authv2":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"resource":"https://upstream.example/v1/mcp/authv2","authorization_servers":["%s"]}`, upstream.URL)
+		case r.Method == http.MethodGet && r.URL.Path == "/.well-known/oauth-authorization-server":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"issuer":"%s","authorization_endpoint":"%s/authorize","token_endpoint":"%s/token"}`,
+				upstream.URL, upstream.URL, upstream.URL)
+		case r.Method == http.MethodGet && r.URL.Path == "/authorize":
+			*authorizeHits++
+			*lastResource = r.URL.Query().Get("resource")
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && r.URL.Path == "/token":
+			*tokenHits++
+			_ = r.ParseForm()
+			*lastResource = r.PostFormValue("resource")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"abc"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}
+}
+
+func TestASProxyMetadata_SchemaShape(t *testing.T) {
+	var (
+		authorizeHits, tokenHits int
+		lastResource             string
+	)
+	ts, upstreamURL := newMCPMirrorTest(t, stockUpstreamHandler(&authorizeHits, &tokenHits, &lastResource))
+
+	resp, _ := ts.Run(t, test.TestCase{
+		Method: http.MethodGet,
+		Path:   "/.well-known/oauth-authorization-server/__tyk-as/test",
+		Code:   http.StatusOK,
+	})
+
+	var meta map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&meta))
+	assert.Contains(t, meta["authorization_endpoint"], "/__tyk-as/test/authorize")
+	assert.Contains(t, meta["token_endpoint"], "/__tyk-as/test/token")
+	// Issuer + non-rewritten fields preserved verbatim.
+	assert.Equal(t, upstreamURL, meta["issuer"])
+}
+
+func TestASProxy_AuthorizeRedirect_RewritesResource(t *testing.T) {
+	var (
+		authorizeHits, tokenHits int
+		lastResource             string
+	)
+	ts, upstreamURL := newMCPMirrorTest(t, stockUpstreamHandler(&authorizeHits, &tokenHits, &lastResource))
+
+	gatewayResource := "http%3A%2F%2Fgateway%2Fmcp-test%2F"
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse },
+	}
+	req, _ := http.NewRequest(http.MethodGet,
+		ts.URL+"/__tyk-as/test/authorize?response_type=code&client_id=cid&resource="+gatewayResource+"&state=s",
+		nil)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusFound, resp.StatusCode)
+
+	loc, err := resp.Location()
+	require.NoError(t, err)
+	upstreamHost, err := url.Parse(upstreamURL)
+	require.NoError(t, err)
+	assert.Equal(t, upstreamHost.Host, loc.Host)
+	assert.Equal(t, upstreamURL+"/v1/mcp/authv2", loc.Query().Get("resource"),
+		"resource param must be rewritten to upstream URL")
+}
+
+func TestASProxy_TokenForward_RewritesResource(t *testing.T) {
+	var (
+		authorizeHits, tokenHits int
+		lastResource             string
+	)
+	ts, upstreamURL := newMCPMirrorTest(t, stockUpstreamHandler(&authorizeHits, &tokenHits, &lastResource))
+
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", "abc")
+	form.Set("resource", "http://gateway/mcp-test/")
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/__tyk-as/test/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "body=%s", string(body))
+	assert.Contains(t, string(body), `"access_token":"abc"`)
+	assert.Equal(t, upstreamURL+"/v1/mcp/authv2", lastResource,
+		"upstream /token must see resource rewritten to the upstream URL")
+	assert.Equal(t, 1, tokenHits)
+}
+
+func TestASProxy_AuthorizeBadGateway_WhenUpstreamMissingASEndpoint(t *testing.T) {
+	ts, _ := newMCPMirrorTest(t, func(w http.ResponseWriter, r *http.Request, upstream *httptest.Server) {
+		switch {
+		case r.URL.Path == "/.well-known/oauth-protected-resource/v1/mcp/authv2":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"resource":"x","authorization_servers":["%s"]}`, upstream.URL)
+		case r.URL.Path == "/.well-known/oauth-authorization-server":
+			// Metadata returns no authorization_endpoint at all.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"issuer":"x"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/__tyk-as/test/authorize?resource=x", nil)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	assert.Equal(t, http.StatusBadGateway, resp.StatusCode)
+}
+
+func TestASProxy_TokenBadGateway_WhenUpstreamMetadataMissing(t *testing.T) {
+	ts, _ := newMCPMirrorTest(t, func(w http.ResponseWriter, r *http.Request, upstream *httptest.Server) {
+		// Upstream PRM responds, but AS metadata is missing.
+		switch {
+		case r.URL.Path == "/.well-known/oauth-protected-resource/v1/mcp/authv2":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"resource":"x","authorization_servers":["%s"]}`, upstream.URL)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/__tyk-as/test/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	assert.Equal(t, http.StatusBadGateway, resp.StatusCode)
+}
+
+func TestRewriteResourceParam(t *testing.T) {
+	spec := &APISpec{APIDefinition: &apidef.APIDefinition{}}
+	spec.Proxy.TargetURL = "https://upstream.example/v1/mcp"
+
+	t.Run("rewrites when resource present", func(t *testing.T) {
+		v := url.Values{}
+		v.Set("resource", "http://gw/mcp/")
+		v.Set("state", "s")
+		rewriteResourceParam(v, spec)
+		assert.Equal(t, "https://upstream.example/v1/mcp", v.Get("resource"))
+		assert.Equal(t, "s", v.Get("state"))
+	})
+
+	t.Run("noop when resource absent", func(t *testing.T) {
+		v := url.Values{}
+		v.Set("state", "s")
+		rewriteResourceParam(v, spec)
+		assert.Empty(t, v.Get("resource"))
+	})
+}
+
+func TestFetchUpstreamASMetadata_PathSuffixVariant(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/oauth-authorization-server/tenant" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"issuer":"https://as","token_endpoint":"https://as/t"}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	doc, err := fetchUpstreamASMetadata(context.Background(), srv.URL+"/tenant")
+	require.NoError(t, err)
+	assert.Equal(t, "https://as", doc["issuer"])
+	assert.Equal(t, "https://as/t", doc["token_endpoint"])
+}
+
+func TestFetchUpstreamASMetadata_PathPrefixVariant(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Only respond at the path-prefix variant; the suffix one 404s.
+		if r.URL.Path == "/tenant/.well-known/oauth-authorization-server" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"issuer":"https://as"}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	doc, err := fetchUpstreamASMetadata(context.Background(), srv.URL+"/tenant")
+	require.NoError(t, err)
+	assert.Equal(t, "https://as", doc["issuer"])
+}
+
+func TestFetchUpstreamASMetadata_RootHostNoPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/oauth-authorization-server" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"issuer":"https://as"}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	doc, err := fetchUpstreamASMetadata(context.Background(), srv.URL)
+	require.NoError(t, err)
+	assert.Equal(t, "https://as", doc["issuer"])
+}
+
+func TestFetchUpstreamASMetadata_AllVariants404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := fetchUpstreamASMetadata(context.Background(), srv.URL+"/tenant")
+	assert.Error(t, err)
+}
+
+func TestFetchUpstreamASMetadata_BadURL(t *testing.T) {
+	_, err := fetchUpstreamASMetadata(context.Background(), "::not a url")
+	assert.Error(t, err)
+}
+
+// TestRegisterMCPPRMSuffixRoutes_EarlyReturns covers the four early-exit
+// guards in registerMCPPRMSuffixRoutes (nil spec, non-MCP, no PRM, root
+// listen path) — they're no-ops, so the test asserts that no panic
+// occurs and that the gateway router doesn't gain a corresponding route.
+func TestRegisterMCPPRMSuffixRoutes_EarlyReturns(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	type tc struct {
+		name string
+		spec *APISpec
+	}
+	cases := []tc{
+		{"nil spec", nil},
+		{"non-MCP spec", &APISpec{
+			APIDefinition: &apidef.APIDefinition{IsOAS: true, APIID: "x"},
+		}},
+		{
+			name: "MCP without PRM config (and no auth block at all)",
+			spec: func() *APISpec {
+				s := &APISpec{APIDefinition: &apidef.APIDefinition{IsOAS: true, APIID: "y"}}
+				s.MarkAsMCP()
+				// No OAS extension at all → GetPRMConfig synthesises a default for MCP,
+				// so this path actually does register routes. Test the explicit-disabled
+				// case instead via a separate API spec.
+				s.OAS.SetTykExtension(&oas.XTykAPIGateway{
+					Server: oas.Server{
+						Authentication: &oas.Authentication{
+							ProtectedResourceMetadata: &oas.ProtectedResourceMetadata{Enabled: false},
+						},
+					},
+				})
+				return s
+			}(),
+		},
+		{
+			name: "MCP with PRM but root listen path",
+			spec: func() *APISpec {
+				s := &APISpec{APIDefinition: &apidef.APIDefinition{IsOAS: true, APIID: "z"}}
+				s.MarkAsMCP()
+				s.Proxy.ListenPath = "/"
+				s.OAS.SetTykExtension(&oas.XTykAPIGateway{
+					Server: oas.Server{
+						Authentication: &oas.Authentication{
+							ProtectedResourceMetadata: &oas.ProtectedResourceMetadata{Enabled: true, Mode: oas.PRMModeMirror},
+						},
+					},
+				})
+				return s
+			}(),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// Should be a no-op — no panic, no error returned.
+			ts.Gw.registerMCPPRMSuffixRoutes(c.spec, nil)
+		})
+	}
+}
+
+// TestPRMMirror_UpstreamUnreachable covers the error path where the
+// upstream PRM endpoint is unavailable: serveMirroredPRM returns the
+// fetch error, the in-listen-path PRMMiddleware logs and falls through
+// to the upstream proxy (no panic, no 5xx).
+func TestPRMMirror_UpstreamUnreachable(t *testing.T) {
+	// Use a never-listening address so the upstream PRM fetch fails.
+	deadUpstream := "http://127.0.0.1:1"
+
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	const listenPath = "/dead/"
+	oasDoc := OAS_OAuthMirrorMode(listenPath)
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.UseKeylessAccess = true
+		spec.MarkAsMCP()
+		spec.Proxy.ListenPath = listenPath
+		spec.Proxy.TargetURL = deadUpstream + "/v1/mcp/authv2"
+		spec.IsOAS = true
+		spec.OAS = oasDoc
+	})
+	ts.Gw.PRMCache().Invalidate(deadUpstream + "/.well-known/oauth-protected-resource/v1/mcp/authv2")
+
+	resp, _ := ts.Run(t, test.TestCase{
+		Method: http.MethodGet,
+		Path:   "/.well-known/oauth-protected-resource/dead",
+	})
+	// The suffix-route handler returns 502 when upstream PRM fails.
+	assert.Equal(t, http.StatusBadGateway, resp.StatusCode)
+}
+
+// helper: minimal OAS doc with mirror-mode PRM enabled, used by the
+// unreachable-upstream test (and any future scenario tests).
+func OAS_OAuthMirrorMode(listenPath string) oas.OAS {
+	o := oas.OAS{
+		T: openapi3.T{
+			OpenAPI: "3.0.3",
+			Info:    &openapi3.Info{Title: "x", Version: "1.0"},
+			Paths:   openapi3.NewPaths(),
+		},
+	}
+	o.SetTykExtension(&oas.XTykAPIGateway{
+		Info: oas.Info{Name: "x", State: oas.State{Active: true}},
+		Server: oas.Server{
+			ListenPath: oas.ListenPath{Value: listenPath, Strip: true},
+			Authentication: &oas.Authentication{
+				ProtectedResourceMetadata: &oas.ProtectedResourceMetadata{
+					Enabled: true, Mode: oas.PRMModeMirror,
+				},
+			},
+		},
+	})
+	return o
+}
+
+func TestReplaceOrAppendResourceMetadata(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		url  string
+		want string
+	}{
+		{
+			name: "appends when absent",
+			in:   `Bearer realm="OAuth"`,
+			url:  "http://gw/x",
+			want: `Bearer realm="OAuth", resource_metadata="http://gw/x"`,
+		},
+		{
+			name: "replaces existing",
+			in:   `Bearer realm="OAuth", resource_metadata="https://upstream/x"`,
+			url:  "http://gw/x",
+			want: `Bearer realm="OAuth", resource_metadata="http://gw/x"`,
+		},
+		{
+			name: "case-insensitive match",
+			in:   `Bearer Resource_Metadata="https://upstream/x", error="invalid_token"`,
+			url:  "http://gw/x",
+			want: `Bearer resource_metadata="http://gw/x", error="invalid_token"`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := replaceOrAppendResourceMetadata(c.in, c.url)
+			assert.Equal(t, c.want, got)
+		})
+	}
+}

--- a/gateway/mcp_oauth_proxy_test.go
+++ b/gateway/mcp_oauth_proxy_test.go
@@ -51,7 +51,7 @@ func newMCPMirrorTest(t *testing.T, behavior func(w http.ResponseWriter, r *http
 			ListenPath: oas.ListenPath{Value: listenPath, Strip: true},
 			Authentication: &oas.Authentication{
 				ProtectedResourceMetadata: &oas.ProtectedResourceMetadata{
-					Enabled: true, Mode: oas.PRMModeMirror,
+					Enabled: true,
 				},
 			},
 		},
@@ -347,7 +347,7 @@ func TestRegisterMCPPRMSuffixRoutes_EarlyReturns(t *testing.T) {
 				s.OAS.SetTykExtension(&oas.XTykAPIGateway{
 					Server: oas.Server{
 						Authentication: &oas.Authentication{
-							ProtectedResourceMetadata: &oas.ProtectedResourceMetadata{Enabled: true, Mode: oas.PRMModeMirror},
+							ProtectedResourceMetadata: &oas.ProtectedResourceMetadata{Enabled: true},
 						},
 					},
 				})
@@ -411,7 +411,7 @@ func OAS_OAuthMirrorMode(listenPath string) oas.OAS {
 			ListenPath: oas.ListenPath{Value: listenPath, Strip: true},
 			Authentication: &oas.Authentication{
 				ProtectedResourceMetadata: &oas.ProtectedResourceMetadata{
-					Enabled: true, Mode: oas.PRMModeMirror,
+					Enabled: true,
 				},
 			},
 		},

--- a/gateway/model_apispec.go
+++ b/gateway/model_apispec.go
@@ -156,18 +156,34 @@ func (a *APISpec) SetCompiledErrorOverrides(compiled *CompiledErrorOverrides) {
 }
 
 // GetPRMConfig returns the Protected Resource Metadata configuration
-// if the API is an OAS API Definition (OAS API, MCP Proxy, Stream API) with PRM enabled.
-// Returns nil otherwise.
+// for the API.
+//
+// Resolution order:
+//  1. If the OAS doc has an explicit `protectedResourceMetadata` block with
+//     `enabled: true`, return it as configured.
+//  2. If the API is MCP and no explicit PRM block is provided (or the
+//     authentication block is missing entirely), synthesise a default
+//     `enabled: true, mode: ""` so mirror mode kicks in automatically.
+//     The empty-mode + no-resource shape resolves to mirror in
+//     EffectiveMode, so users can put Tyk in front of a remote MCP with
+//     zero PRM-specific config.
+//  3. Otherwise return nil — the API has no PRM serving.
 func (a *APISpec) GetPRMConfig() *oas.ProtectedResourceMetadata {
 	ext := a.GetTykExtension()
-	if ext == nil || ext.Server.Authentication == nil {
-		return nil
+	var prm *oas.ProtectedResourceMetadata
+	if ext != nil && ext.Server.Authentication != nil {
+		prm = ext.Server.Authentication.ProtectedResourceMetadata
 	}
-	prm := ext.Server.Authentication.ProtectedResourceMetadata
-	if prm == nil || !prm.Enabled {
-		return nil
+
+	if prm != nil && prm.Enabled {
+		return prm
 	}
-	return prm
+
+	// MCP-only default: mirror without any explicit PRM config.
+	if prm == nil && a.IsMCP() {
+		return &oas.ProtectedResourceMetadata{Enabled: true}
+	}
+	return nil
 }
 
 // FindSpecMatchesStatus checks if a URL spec has a specific status and returns the URLSpec for it.

--- a/gateway/mw_protected_resource.go
+++ b/gateway/mw_protected_resource.go
@@ -1,14 +1,18 @@
 package gateway
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"path"
+	"strings"
+	"time"
 
 	"github.com/TykTechnologies/tyk/apidef/oas"
 	"github.com/TykTechnologies/tyk/header"
 	"github.com/TykTechnologies/tyk/internal/httputil"
+	"github.com/TykTechnologies/tyk/internal/mcp"
 	"github.com/TykTechnologies/tyk/internal/middleware"
 )
 
@@ -47,7 +51,16 @@ func (m *PRMMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _
 		return nil, http.StatusOK // pass through to next middleware
 	}
 
-	// Resolve context variables in resource field
+	// Mirror mode: fetch from upstream, rewrite resource, serve.
+	if prm.IsMirrorMode() {
+		if err := m.serveMirroredPRM(w, r, prm); err != nil {
+			log.WithError(err).Warn("PRM mirror failed; passing through to upstream")
+			return nil, http.StatusOK
+		}
+		return nil, middleware.StatusRespond
+	}
+
+	// Static mode: assemble doc from configured fields.
 	resource := prm.Resource
 	if resource != "" {
 		resource = m.Gw.ReplaceTykVariables(r, resource, false)
@@ -66,6 +79,56 @@ func (m *PRMMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _
 	}
 
 	return nil, middleware.StatusRespond // terminate chain — response already written
+}
+
+// serveMirroredPRM fetches the upstream's PRM doc, rewrites `resource` to
+// the gateway URL the client connected to, and writes it to w. The fetched
+// document is cached per upstream URL with TTL.
+func (m *PRMMiddleware) serveMirroredPRM(w http.ResponseWriter, r *http.Request, prm *oas.ProtectedResourceMetadata) error {
+	upstreamPRMURL := prm.UpstreamPRMUrl
+	if upstreamPRMURL == "" {
+		derived, err := mcp.DeriveUpstreamPRMURL(m.Spec.Proxy.TargetURL)
+		if err != nil {
+			return fmt.Errorf("derive upstream PRM URL: %w", err)
+		}
+		upstreamPRMURL = derived
+	}
+
+	cache := m.Gw.PRMCache()
+	doc, ok := cache.Get(upstreamPRMURL)
+	if !ok {
+		ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+		defer cancel()
+		fetched, err := mcp.FetchUpstreamPRM(ctx, http.DefaultClient, upstreamPRMURL)
+		if err != nil {
+			return err
+		}
+		cache.Put(upstreamPRMURL, fetched)
+		doc = fetched
+	}
+
+	// Rewrite resource to the gateway URL — what the client connected to.
+	gatewayResource := gatewayResourceURL(r, m.Spec)
+	doc.SetResource(gatewayResource)
+
+	w.Header().Set(header.ContentType, "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(doc); err != nil {
+		return fmt.Errorf("encode PRM: %w", err)
+	}
+	return nil
+}
+
+// gatewayResourceURL builds the URL the MCP client thinks it's talking to:
+// scheme + host + the API's listen path. Used as the rewritten `resource`
+// field so RFC 9728 §3.3 origin validation passes.
+func gatewayResourceURL(r *http.Request, spec *APISpec) string {
+	scheme := httputil.RequestScheme(r)
+	listen := spec.Proxy.ListenPath
+	if !strings.HasSuffix(listen, "/") {
+		listen += "/"
+	}
+	return fmt.Sprintf("%s://%s%s", scheme, r.Host, listen)
 }
 
 // prmWellKnownPath returns the full well-known path for the PRM endpoint,

--- a/gateway/mw_protected_resource.go
+++ b/gateway/mw_protected_resource.go
@@ -111,19 +111,16 @@ func (m *PRMMiddleware) serveMirroredPRM(w http.ResponseWriter, r *http.Request,
 
 // upstreamPRMDoc returns a (cached) clone of the upstream's PRM document
 // for the given MCP API. Used by both PRM mirror serving and the AS-proxy
-// flow to derive the upstream authorization-server URL.
+// flow to derive the upstream authorization-server URL. The PRM URL is
+// auto-derived from the API's upstream URL via the path-suffix variant
+// (RFC 9728 §3.1).
 func (gw *Gateway) upstreamPRMDoc(ctx context.Context, spec *APISpec) (*mcp.PRMDocument, error) {
-	prm := spec.GetPRMConfig()
-	if prm == nil {
+	if spec.GetPRMConfig() == nil {
 		return nil, fmt.Errorf("API %q has no PRM config", spec.APIID)
 	}
-	upstreamPRMURL := prm.UpstreamPRMUrl
-	if upstreamPRMURL == "" {
-		derived, err := mcp.DeriveUpstreamPRMURL(spec.Proxy.TargetURL)
-		if err != nil {
-			return nil, fmt.Errorf("derive upstream PRM URL: %w", err)
-		}
-		upstreamPRMURL = derived
+	upstreamPRMURL, err := mcp.DeriveUpstreamPRMURL(spec.Proxy.TargetURL)
+	if err != nil {
+		return nil, fmt.Errorf("derive upstream PRM URL: %w", err)
 	}
 
 	cache := gw.PRMCache()

--- a/gateway/mw_protected_resource.go
+++ b/gateway/mw_protected_resource.go
@@ -82,34 +82,24 @@ func (m *PRMMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _
 }
 
 // serveMirroredPRM fetches the upstream's PRM doc, rewrites `resource` to
-// the gateway URL the client connected to, and writes it to w. The fetched
+// the gateway URL the client connected to, redirects `authorization_servers`
+// at Tyk's per-API AS-proxy URL so RFC 8707 `resource`-parameter rewriting
+// can intercept the OAuth flow, and writes the result to w. The fetched
 // document is cached per upstream URL with TTL.
 func (m *PRMMiddleware) serveMirroredPRM(w http.ResponseWriter, r *http.Request, prm *oas.ProtectedResourceMetadata) error {
-	upstreamPRMURL := prm.UpstreamPRMUrl
-	if upstreamPRMURL == "" {
-		derived, err := mcp.DeriveUpstreamPRMURL(m.Spec.Proxy.TargetURL)
-		if err != nil {
-			return fmt.Errorf("derive upstream PRM URL: %w", err)
-		}
-		upstreamPRMURL = derived
-	}
-
-	cache := m.Gw.PRMCache()
-	doc, ok := cache.Get(upstreamPRMURL)
-	if !ok {
-		ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
-		defer cancel()
-		fetched, err := mcp.FetchUpstreamPRM(ctx, http.DefaultClient, upstreamPRMURL)
-		if err != nil {
-			return err
-		}
-		cache.Put(upstreamPRMURL, fetched)
-		doc = fetched
+	doc, err := m.Gw.upstreamPRMDoc(r.Context(), m.Spec)
+	if err != nil {
+		return err
 	}
 
 	// Rewrite resource to the gateway URL — what the client connected to.
-	gatewayResource := gatewayResourceURL(r, m.Spec)
-	doc.SetResource(gatewayResource)
+	doc.SetResource(gatewayResourceURL(r, m.Spec))
+
+	// Redirect the AS to Tyk's per-API proxy so we can rewrite the
+	// `resource` parameter (RFC 8707) on its way to the upstream AS.
+	// Strict authorization servers (Notion) reject the gateway URL as
+	// `invalid_target` otherwise.
+	doc.Raw["authorization_servers"] = []any{mcpASProxyBaseURL(r, m.Spec)}
 
 	w.Header().Set(header.ContentType, "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -117,6 +107,38 @@ func (m *PRMMiddleware) serveMirroredPRM(w http.ResponseWriter, r *http.Request,
 		return fmt.Errorf("encode PRM: %w", err)
 	}
 	return nil
+}
+
+// upstreamPRMDoc returns a (cached) clone of the upstream's PRM document
+// for the given MCP API. Used by both PRM mirror serving and the AS-proxy
+// flow to derive the upstream authorization-server URL.
+func (gw *Gateway) upstreamPRMDoc(ctx context.Context, spec *APISpec) (*mcp.PRMDocument, error) {
+	prm := spec.GetPRMConfig()
+	if prm == nil {
+		return nil, fmt.Errorf("API %q has no PRM config", spec.APIID)
+	}
+	upstreamPRMURL := prm.UpstreamPRMUrl
+	if upstreamPRMURL == "" {
+		derived, err := mcp.DeriveUpstreamPRMURL(spec.Proxy.TargetURL)
+		if err != nil {
+			return nil, fmt.Errorf("derive upstream PRM URL: %w", err)
+		}
+		upstreamPRMURL = derived
+	}
+
+	cache := gw.PRMCache()
+	if doc, ok := cache.Get(upstreamPRMURL); ok {
+		return doc, nil
+	}
+
+	fetchCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	doc, err := mcp.FetchUpstreamPRM(fetchCtx, http.DefaultClient, upstreamPRMURL)
+	if err != nil {
+		return nil, err
+	}
+	cache.Put(upstreamPRMURL, doc)
+	return doc, nil
 }
 
 // gatewayResourceURL builds the URL the MCP client thinks it's talking to:

--- a/gateway/mw_protected_resource.go
+++ b/gateway/mw_protected_resource.go
@@ -52,7 +52,7 @@ func (m *PRMMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _
 	}
 
 	// Mirror mode: fetch from upstream, rewrite resource, serve.
-	if prm.IsMirrorMode() {
+	if prm.IsMirrorMode(m.Spec.IsMCP()) {
 		if err := m.serveMirroredPRM(w, r, prm); err != nil {
 			log.WithError(err).Warn("PRM mirror failed; passing through to upstream")
 			return nil, http.StatusOK

--- a/gateway/mw_protected_resource.go
+++ b/gateway/mw_protected_resource.go
@@ -86,7 +86,7 @@ func (m *PRMMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _
 // at Tyk's per-API AS-proxy URL so RFC 8707 `resource`-parameter rewriting
 // can intercept the OAuth flow, and writes the result to w. The fetched
 // document is cached per upstream URL with TTL.
-func (m *PRMMiddleware) serveMirroredPRM(w http.ResponseWriter, r *http.Request, prm *oas.ProtectedResourceMetadata) error {
+func (m *PRMMiddleware) serveMirroredPRM(w http.ResponseWriter, r *http.Request, _ *oas.ProtectedResourceMetadata) error {
 	doc, err := m.Gw.upstreamPRMDoc(r.Context(), m.Spec)
 	if err != nil {
 		return err

--- a/gateway/mw_protected_resource_test.go
+++ b/gateway/mw_protected_resource_test.go
@@ -727,3 +727,171 @@ func TestPRMHappyPath_FullDiscoveryFlow(t *testing.T) {
 	assert.Equal(t, []string{scope1, scope2}, prmDoc.ScopesSupported,
 		"PRM must contain the configured scopes")
 }
+
+// TestPRMMirrorMode_SuffixRoute spins up a fake remote MCP that returns a
+// PRM doc at the path-suffix variant URL (the way Atlassian/Notion do it),
+// fronts it with a Tyk MCP API in mirror mode, and asserts that probes to
+// `<gateway>/.well-known/oauth-protected-resource<listen-path>` return the
+// upstream's doc with `resource` rewritten to the gateway URL — the exact
+// shape mcp-remote needs for RFC 9728 §3.3 origin validation to pass.
+func TestPRMMirrorMode_SuffixRoute(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/.well-known/oauth-protected-resource/v1/mcp/authv2" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{
+				"resource": "https://upstream.example/v1/mcp/authv2",
+				"authorization_servers": ["https://auth.upstream.example/tenant"],
+				"bearer_methods_supported": ["header"],
+				"scopes_supported": ["read:foo", "write:foo"],
+				"resource_documentation": "https://upstream.example/docs"
+			}`)
+			return
+		}
+		// Protocol traffic: 401 with bare bearer challenge.
+		w.Header().Set("WWW-Authenticate", `Bearer realm="OAuth"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(upstream.Close)
+
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	const listenPath = "/jira/"
+
+	oasDoc := oas.OAS{
+		T: openapi3.T{
+			OpenAPI: "3.0.3",
+			Info:    &openapi3.Info{Title: "MCP Mirror", Version: "1.0"},
+			Paths:   openapi3.NewPaths(),
+		},
+	}
+	oasDoc.SetTykExtension(&oas.XTykAPIGateway{
+		Info: oas.Info{Name: "mcp-mirror-test", State: oas.State{Active: true}},
+		Upstream: oas.Upstream{
+			URL: upstream.URL + "/v1/mcp/authv2",
+		},
+		Server: oas.Server{
+			ListenPath: oas.ListenPath{Value: listenPath, Strip: true},
+			Authentication: &oas.Authentication{
+				ProtectedResourceMetadata: &oas.ProtectedResourceMetadata{
+					Enabled: true,
+					Mode:    oas.PRMModeMirror,
+				},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.UseKeylessAccess = true
+		spec.MarkAsMCP()
+		spec.Proxy.ListenPath = listenPath
+		spec.Proxy.TargetURL = upstream.URL + "/v1/mcp/authv2"
+		spec.IsOAS = true
+		spec.OAS = oasDoc
+	})
+
+	expectedResourcePrefix := "/jira/"
+
+	t.Run("suffix route without trailing slash", func(t *testing.T) {
+		ts.Gw.PRMCache().Invalidate(upstream.URL + "/.well-known/oauth-protected-resource/v1/mcp/authv2")
+
+		resp, _ := ts.Run(t, test.TestCase{
+			Method: http.MethodGet,
+			Path:   "/.well-known/oauth-protected-resource/jira",
+			Code:   http.StatusOK,
+		})
+
+		var doc map[string]any
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&doc))
+		got, _ := doc["resource"].(string)
+		assert.True(t, strings.HasSuffix(got, expectedResourcePrefix), "resource %q should end in %q", got, expectedResourcePrefix)
+		// Authorization servers come from upstream verbatim.
+		authServers, _ := doc["authorization_servers"].([]any)
+		require.Len(t, authServers, 1)
+		assert.Equal(t, "https://auth.upstream.example/tenant", authServers[0])
+		// Pass-through fields are preserved.
+		assert.Equal(t, "https://upstream.example/docs", doc["resource_documentation"])
+	})
+
+	t.Run("suffix route with trailing slash", func(t *testing.T) {
+		ts.Run(t, test.TestCase{
+			Method: http.MethodGet,
+			Path:   "/.well-known/oauth-protected-resource/jira/",
+			Code:   http.StatusOK,
+			BodyMatchFunc: func(b []byte) bool {
+				return strings.Contains(string(b), `"authorization_servers"`)
+			},
+		})
+	})
+}
+
+// TestAugmentMCPWWWAuthenticate covers the response-side header rewrite
+// that adds `resource_metadata=<gateway-prm-url>` when the upstream's 401
+// challenge omits it.
+func TestAugmentMCPWWWAuthenticate(t *testing.T) {
+	mkSpec := func(mcp bool, prmEnabled bool) *APISpec {
+		s := &APISpec{
+			APIDefinition: &apidef.APIDefinition{IsOAS: true},
+		}
+		s.Proxy.ListenPath = "/jira/"
+		if mcp {
+			s.MarkAsMCP()
+		}
+		if prmEnabled {
+			s.OAS.SetTykExtension(&oas.XTykAPIGateway{
+				Server: oas.Server{
+					ListenPath: oas.ListenPath{Value: "/jira/"},
+					Authentication: &oas.Authentication{
+						ProtectedResourceMetadata: &oas.ProtectedResourceMetadata{
+							Enabled: true,
+							Mode:    oas.PRMModeMirror,
+						},
+					},
+				},
+			})
+		}
+		return s
+	}
+
+	mkResponse := func(status int, wwwAuth string) *http.Response {
+		req, _ := http.NewRequest(http.MethodPost, "http://gw.example/jira/", nil)
+		h := http.Header{}
+		if wwwAuth != "" {
+			h.Set(header.WWWAuthenticate, wwwAuth)
+		}
+		return &http.Response{StatusCode: status, Header: h, Request: req}
+	}
+
+	t.Run("appends resource_metadata when missing", func(t *testing.T) {
+		res := mkResponse(http.StatusUnauthorized, `Bearer realm="OAuth"`)
+		augmentMCPWWWAuthenticate(res, mkSpec(true, true))
+		got := res.Header.Get(header.WWWAuthenticate)
+		assert.Contains(t, got, `Bearer realm="OAuth"`)
+		assert.Contains(t, got, `resource_metadata="http://gw.example/.well-known/oauth-protected-resource/jira"`)
+	})
+
+	t.Run("preserves existing resource_metadata", func(t *testing.T) {
+		original := `Bearer realm="OAuth", resource_metadata="https://upstream.example/.well-known/oauth-protected-resource/x"`
+		res := mkResponse(http.StatusUnauthorized, original)
+		augmentMCPWWWAuthenticate(res, mkSpec(true, true))
+		assert.Equal(t, original, res.Header.Get(header.WWWAuthenticate))
+	})
+
+	t.Run("noop on non-401", func(t *testing.T) {
+		res := mkResponse(http.StatusOK, `Bearer realm="OAuth"`)
+		augmentMCPWWWAuthenticate(res, mkSpec(true, true))
+		assert.Equal(t, `Bearer realm="OAuth"`, res.Header.Get(header.WWWAuthenticate))
+	})
+
+	t.Run("noop on non-MCP", func(t *testing.T) {
+		res := mkResponse(http.StatusUnauthorized, `Bearer realm="OAuth"`)
+		augmentMCPWWWAuthenticate(res, mkSpec(false, true))
+		assert.Equal(t, `Bearer realm="OAuth"`, res.Header.Get(header.WWWAuthenticate))
+	})
+
+	t.Run("noop when PRM not configured", func(t *testing.T) {
+		res := mkResponse(http.StatusUnauthorized, `Bearer realm="OAuth"`)
+		augmentMCPWWWAuthenticate(res, mkSpec(true, false))
+		assert.Equal(t, `Bearer realm="OAuth"`, res.Header.Get(header.WWWAuthenticate))
+	})
+}

--- a/gateway/mw_protected_resource_test.go
+++ b/gateway/mw_protected_resource_test.go
@@ -2,9 +2,11 @@ package gateway
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -805,10 +807,12 @@ func TestPRMMirrorMode_SuffixRoute(t *testing.T) {
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(&doc))
 		got, _ := doc["resource"].(string)
 		assert.True(t, strings.HasSuffix(got, expectedResourcePrefix), "resource %q should end in %q", got, expectedResourcePrefix)
-		// Authorization servers come from upstream verbatim.
+		// Mirror mode redirects authorization_servers at Tyk's per-API
+		// AS-proxy URL so we can rewrite the RFC 8707 resource parameter.
 		authServers, _ := doc["authorization_servers"].([]any)
 		require.Len(t, authServers, 1)
-		assert.Equal(t, "https://auth.upstream.example/tenant", authServers[0])
+		asURL, _ := authServers[0].(string)
+		assert.Contains(t, asURL, "/__tyk-as/test", "authorization_servers should point at the Tyk AS proxy: %s", asURL)
 		// Pass-through fields are preserved.
 		assert.Equal(t, "https://upstream.example/docs", doc["resource_documentation"])
 	})
@@ -823,6 +827,147 @@ func TestPRMMirrorMode_SuffixRoute(t *testing.T) {
 			},
 		})
 	})
+}
+
+// TestPRMMirrorMode_OAuthProxy exercises the full mirror-mode OAuth flow:
+// PRM points clients at Tyk's AS proxy, the AS metadata endpoint serves
+// rewritten `authorization_endpoint`/`token_endpoint`, the authorize
+// handler 302s to upstream with the `resource` parameter rewritten from
+// gateway URL to upstream URL, and the token handler forwards POSTs with
+// the same rewrite. This is the path that fixes RFC 8707-strict ASes
+// (Notion).
+func TestPRMMirrorMode_OAuthProxy(t *testing.T) {
+	var (
+		authorizeHits int
+		tokenHits     int
+		lastResource  string
+	)
+
+	// httptest.NewServer assigns its URL during construction, but the
+	// handler we register needs that URL inside its responses (the
+	// upstream PRM doc points at its own AS, which is the same host).
+	// Construct first with a stub handler, then swap in the real one.
+	upstream := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	t.Cleanup(upstream.Close)
+	upstream.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/.well-known/oauth-protected-resource/v1/mcp/authv2":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"resource":"https://upstream.example/v1/mcp/authv2","authorization_servers":["%s"]}`, upstream.URL)
+		case r.Method == http.MethodGet && r.URL.Path == "/.well-known/oauth-authorization-server":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"issuer":"%s","authorization_endpoint":"%s/authorize","token_endpoint":"%s/token","registration_endpoint":"%s/register"}`,
+				upstream.URL, upstream.URL, upstream.URL, upstream.URL)
+		case r.Method == http.MethodGet && r.URL.Path == "/authorize":
+			authorizeHits++
+			lastResource = r.URL.Query().Get("resource")
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && r.URL.Path == "/token":
+			tokenHits++
+			_ = r.ParseForm()
+			lastResource = r.PostFormValue("resource")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"abc","token_type":"Bearer"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	const listenPath = "/jira/"
+	upstreamTarget := upstream.URL + "/v1/mcp/authv2"
+
+	oasDoc := oas.OAS{
+		T: openapi3.T{
+			OpenAPI: "3.0.3",
+			Info:    &openapi3.Info{Title: "OAuth Proxy", Version: "1.0"},
+			Paths:   openapi3.NewPaths(),
+		},
+	}
+	oasDoc.SetTykExtension(&oas.XTykAPIGateway{
+		Info:     oas.Info{Name: "mcp-oauth-proxy-test", State: oas.State{Active: true}},
+		Upstream: oas.Upstream{URL: upstreamTarget},
+		Server: oas.Server{
+			ListenPath: oas.ListenPath{Value: listenPath, Strip: true},
+			Authentication: &oas.Authentication{
+				ProtectedResourceMetadata: &oas.ProtectedResourceMetadata{
+					Enabled: true,
+					Mode:    oas.PRMModeMirror,
+				},
+			},
+		},
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.UseKeylessAccess = true
+		spec.MarkAsMCP()
+		spec.Proxy.ListenPath = listenPath
+		spec.Proxy.TargetURL = upstreamTarget
+		spec.IsOAS = true
+		spec.OAS = oasDoc
+	})
+	ts.Gw.PRMCache().Invalidate(upstream.URL + "/.well-known/oauth-protected-resource/v1/mcp/authv2")
+
+	t.Run("AS metadata endpoint rewrites authorize/token URLs", func(t *testing.T) {
+		resp, _ := ts.Run(t, test.TestCase{
+			Method: http.MethodGet,
+			Path:   "/.well-known/oauth-authorization-server/__tyk-as/test",
+			Code:   http.StatusOK,
+		})
+		var meta map[string]any
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&meta))
+		authzEP, _ := meta["authorization_endpoint"].(string)
+		tokenEP, _ := meta["token_endpoint"].(string)
+		assert.Contains(t, authzEP, "/__tyk-as/test/authorize")
+		assert.Contains(t, tokenEP, "/__tyk-as/test/token")
+		// Issuer is preserved verbatim from upstream.
+		assert.Equal(t, upstream.URL, meta["issuer"])
+	})
+
+	t.Run("authorize 302s with rewritten resource param", func(t *testing.T) {
+		gatewayResource := "http%3A%2F%2Fgateway%2Fjira%2F"
+		// Drive the request manually so we can inspect the redirect.
+		client := &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		}}
+		req, _ := http.NewRequest(http.MethodGet,
+			ts.URL+"/__tyk-as/test/authorize?response_type=code&client_id=cid&resource="+gatewayResource+"&state=s",
+			nil)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+		require.Equal(t, http.StatusFound, resp.StatusCode)
+		loc, err := resp.Location()
+		require.NoError(t, err)
+		assert.Equal(t, upstream.Listener.Addr().String(), loc.Host)
+		assert.Equal(t, upstreamTarget, loc.Query().Get("resource"),
+			"resource param must be rewritten to upstream URL")
+	})
+
+	t.Run("token forwards with rewritten resource", func(t *testing.T) {
+		gatewayResource := "http://gateway/jira/"
+		form := url.Values{}
+		form.Set("grant_type", "authorization_code")
+		form.Set("code", "abc")
+		form.Set("resource", gatewayResource)
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/__tyk-as/test/token", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode, "body=%s", string(body))
+		assert.Contains(t, string(body), `"access_token":"abc"`)
+		assert.Equal(t, upstreamTarget, lastResource,
+			"upstream token endpoint must see the upstream-URL resource value")
+	})
+
+	// authorize is only verified by the redirect URL (test client doesn't
+	// follow redirects on purpose, so upstream's /authorize never fires).
+	_ = authorizeHits
+	assert.Equal(t, 1, tokenHits, "upstream /token should have been hit once")
 }
 
 // TestAugmentMCPWWWAuthenticate covers the response-side header rewrite

--- a/gateway/mw_protected_resource_test.go
+++ b/gateway/mw_protected_resource_test.go
@@ -746,7 +746,7 @@ func TestPRMMirrorMode_SuffixRoute(t *testing.T) {
 				"bearer_methods_supported": ["header"],
 				"scopes_supported": ["read:foo", "write:foo"],
 				"resource_documentation": "https://upstream.example/docs"
-			}`)
+			}`) //nolint:errcheck
 			return
 		}
 		// Protocol traffic: 401 with bare bearer challenge.
@@ -777,7 +777,6 @@ func TestPRMMirrorMode_SuffixRoute(t *testing.T) {
 			Authentication: &oas.Authentication{
 				ProtectedResourceMetadata: &oas.ProtectedResourceMetadata{
 					Enabled: true,
-					
 				},
 			},
 		},
@@ -853,10 +852,10 @@ func TestPRMMirrorMode_OAuthProxy(t *testing.T) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/.well-known/oauth-protected-resource/v1/mcp/authv2":
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintf(w, `{"resource":"https://upstream.example/v1/mcp/authv2","authorization_servers":["%s"]}`, upstream.URL)
+			_, _ = fmt.Fprintf(w, `{"resource":"https://upstream.example/v1/mcp/authv2","authorization_servers":["%s"]}`, upstream.URL) //nolint:errcheck
 		case r.Method == http.MethodGet && r.URL.Path == "/.well-known/oauth-authorization-server":
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintf(w, `{"issuer":"%s","authorization_endpoint":"%s/authorize","token_endpoint":"%s/token","registration_endpoint":"%s/register"}`,
+			_, _ = fmt.Fprintf(w, `{"issuer":"%s","authorization_endpoint":"%s/authorize","token_endpoint":"%s/token","registration_endpoint":"%s/register"}`, //nolint:errcheck
 				upstream.URL, upstream.URL, upstream.URL, upstream.URL)
 		case r.Method == http.MethodGet && r.URL.Path == "/authorize":
 			authorizeHits++
@@ -864,10 +863,10 @@ func TestPRMMirrorMode_OAuthProxy(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		case r.Method == http.MethodPost && r.URL.Path == "/token":
 			tokenHits++
-			_ = r.ParseForm()
+			_ = r.ParseForm() //nolint:errcheck
 			lastResource = r.PostFormValue("resource")
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"access_token":"abc","token_type":"Bearer"}`))
+			_, _ = w.Write([]byte(`{"access_token":"abc","token_type":"Bearer"}`)) //nolint:errcheck
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -894,7 +893,6 @@ func TestPRMMirrorMode_OAuthProxy(t *testing.T) {
 			Authentication: &oas.Authentication{
 				ProtectedResourceMetadata: &oas.ProtectedResourceMetadata{
 					Enabled: true,
-					
 				},
 			},
 		},
@@ -929,12 +927,13 @@ func TestPRMMirrorMode_OAuthProxy(t *testing.T) {
 	t.Run("authorize 302s with rewritten resource param", func(t *testing.T) {
 		gatewayResource := "http%3A%2F%2Fgateway%2Fjira%2F"
 		// Drive the request manually so we can inspect the redirect.
-		client := &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		client := &http.Client{CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 			return http.ErrUseLastResponse
 		}}
-		req, _ := http.NewRequest(http.MethodGet,
+		req, errReq := http.NewRequest(http.MethodGet,
 			ts.URL+"/__tyk-as/test/authorize?response_type=code&client_id=cid&resource="+gatewayResource+"&state=s",
 			nil)
+		require.NoError(t, errReq)
 		resp, err := client.Do(req)
 		require.NoError(t, err)
 		_ = resp.Body.Close()
@@ -952,11 +951,13 @@ func TestPRMMirrorMode_OAuthProxy(t *testing.T) {
 		form.Set("grant_type", "authorization_code")
 		form.Set("code", "abc")
 		form.Set("resource", gatewayResource)
-		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/__tyk-as/test/token", strings.NewReader(form.Encode()))
+		req, errReq := http.NewRequest(http.MethodPost, ts.URL+"/__tyk-as/test/token", strings.NewReader(form.Encode()))
+		require.NoError(t, errReq)
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		resp, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)
-		body, _ := io.ReadAll(resp.Body)
+		body, errBody := io.ReadAll(resp.Body)
+		require.NoError(t, errBody)
 		_ = resp.Body.Close()
 		require.Equal(t, http.StatusOK, resp.StatusCode, "body=%s", string(body))
 		assert.Contains(t, string(body), `"access_token":"abc"`)
@@ -989,7 +990,6 @@ func TestAugmentMCPWWWAuthenticate(t *testing.T) {
 					Authentication: &oas.Authentication{
 						ProtectedResourceMetadata: &oas.ProtectedResourceMetadata{
 							Enabled: true,
-							
 						},
 					},
 				},
@@ -999,7 +999,10 @@ func TestAugmentMCPWWWAuthenticate(t *testing.T) {
 	}
 
 	mkResponse := func(status int, wwwAuth string) *http.Response {
-		req, _ := http.NewRequest(http.MethodPost, "http://gw.example/jira/", nil)
+		req, err := http.NewRequest(http.MethodPost, "http://gw.example/jira/", nil)
+		if err != nil {
+			t.Fatalf("build request: %v", err)
+		}
 		h := http.Header{}
 		if wwwAuth != "" {
 			h.Set(header.WWWAuthenticate, wwwAuth)

--- a/gateway/mw_protected_resource_test.go
+++ b/gateway/mw_protected_resource_test.go
@@ -777,7 +777,7 @@ func TestPRMMirrorMode_SuffixRoute(t *testing.T) {
 			Authentication: &oas.Authentication{
 				ProtectedResourceMetadata: &oas.ProtectedResourceMetadata{
 					Enabled: true,
-					Mode:    oas.PRMModeMirror,
+					
 				},
 			},
 		},
@@ -894,7 +894,7 @@ func TestPRMMirrorMode_OAuthProxy(t *testing.T) {
 			Authentication: &oas.Authentication{
 				ProtectedResourceMetadata: &oas.ProtectedResourceMetadata{
 					Enabled: true,
-					Mode:    oas.PRMModeMirror,
+					
 				},
 			},
 		},
@@ -989,7 +989,7 @@ func TestAugmentMCPWWWAuthenticate(t *testing.T) {
 					Authentication: &oas.Authentication{
 						ProtectedResourceMetadata: &oas.ProtectedResourceMetadata{
 							Enabled: true,
-							Mode:    oas.PRMModeMirror,
+							
 						},
 					},
 				},

--- a/gateway/mw_protected_resource_test.go
+++ b/gateway/mw_protected_resource_test.go
@@ -1009,34 +1009,62 @@ func TestAugmentMCPWWWAuthenticate(t *testing.T) {
 
 	t.Run("appends resource_metadata when missing", func(t *testing.T) {
 		res := mkResponse(http.StatusUnauthorized, `Bearer realm="OAuth"`)
-		augmentMCPWWWAuthenticate(res, mkSpec(true, true))
+		augmentMCPWWWAuthenticate(res, res.Request, mkSpec(true, true))
 		got := res.Header.Get(header.WWWAuthenticate)
 		assert.Contains(t, got, `Bearer realm="OAuth"`)
 		assert.Contains(t, got, `resource_metadata="http://gw.example/.well-known/oauth-protected-resource/jira"`)
 	})
 
-	t.Run("preserves existing resource_metadata", func(t *testing.T) {
+	t.Run("overwrites upstream resource_metadata to gateway URL", func(t *testing.T) {
+		// MCP clients (RFC 9728 §3.3) validate the PRM doc's `resource`
+		// field against the URL they connected to (the gateway). If the
+		// upstream advertises its own URL via resource_metadata, the
+		// origin check fails. Mirror mode redirects the client at our
+		// own PRM endpoint instead.
 		original := `Bearer realm="OAuth", resource_metadata="https://upstream.example/.well-known/oauth-protected-resource/x"`
 		res := mkResponse(http.StatusUnauthorized, original)
-		augmentMCPWWWAuthenticate(res, mkSpec(true, true))
-		assert.Equal(t, original, res.Header.Get(header.WWWAuthenticate))
+		augmentMCPWWWAuthenticate(res, res.Request, mkSpec(true, true))
+		got := res.Header.Get(header.WWWAuthenticate)
+		assert.Contains(t, got, `Bearer realm="OAuth"`)
+		assert.Contains(t, got, `resource_metadata="http://gw.example/.well-known/oauth-protected-resource/jira"`)
+		assert.NotContains(t, got, "upstream.example")
 	})
 
 	t.Run("noop on non-401", func(t *testing.T) {
 		res := mkResponse(http.StatusOK, `Bearer realm="OAuth"`)
-		augmentMCPWWWAuthenticate(res, mkSpec(true, true))
+		augmentMCPWWWAuthenticate(res, res.Request, mkSpec(true, true))
 		assert.Equal(t, `Bearer realm="OAuth"`, res.Header.Get(header.WWWAuthenticate))
 	})
 
 	t.Run("noop on non-MCP", func(t *testing.T) {
 		res := mkResponse(http.StatusUnauthorized, `Bearer realm="OAuth"`)
-		augmentMCPWWWAuthenticate(res, mkSpec(false, true))
+		augmentMCPWWWAuthenticate(res, res.Request, mkSpec(false, true))
 		assert.Equal(t, `Bearer realm="OAuth"`, res.Header.Get(header.WWWAuthenticate))
 	})
 
-	t.Run("noop when PRM not configured", func(t *testing.T) {
+	t.Run("MCP API with no explicit PRM still augments (default mirror)", func(t *testing.T) {
+		// Mirror is the implicit default for MCP APIs without an
+		// explicit PRM block, so augmentation should fire.
 		res := mkResponse(http.StatusUnauthorized, `Bearer realm="OAuth"`)
-		augmentMCPWWWAuthenticate(res, mkSpec(true, false))
+		augmentMCPWWWAuthenticate(res, res.Request, mkSpec(true, false))
+		got := res.Header.Get(header.WWWAuthenticate)
+		assert.Contains(t, got, `resource_metadata="http://gw.example/.well-known/oauth-protected-resource/jira"`)
+	})
+
+	t.Run("noop when PRM explicitly disabled", func(t *testing.T) {
+		s := &APISpec{APIDefinition: &apidef.APIDefinition{IsOAS: true}}
+		s.Proxy.ListenPath = "/jira/"
+		s.MarkAsMCP()
+		s.OAS.SetTykExtension(&oas.XTykAPIGateway{
+			Server: oas.Server{
+				ListenPath: oas.ListenPath{Value: "/jira/"},
+				Authentication: &oas.Authentication{
+					ProtectedResourceMetadata: &oas.ProtectedResourceMetadata{Enabled: false},
+				},
+			},
+		})
+		res := mkResponse(http.StatusUnauthorized, `Bearer realm="OAuth"`)
+		augmentMCPWWWAuthenticate(res, res.Request, s)
 		assert.Equal(t, `Bearer realm="OAuth"`, res.Header.Get(header.WWWAuthenticate))
 	})
 }

--- a/gateway/mw_protected_resource_test.go
+++ b/gateway/mw_protected_resource_test.go
@@ -740,13 +740,14 @@ func TestPRMMirrorMode_SuffixRoute(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && r.URL.Path == "/.well-known/oauth-protected-resource/v1/mcp/authv2" {
 			w.Header().Set("Content-Type", "application/json")
+			//nolint:errcheck // test fixture; HTTP response Write failure not actionable here
 			_, _ = io.WriteString(w, `{
 				"resource": "https://upstream.example/v1/mcp/authv2",
 				"authorization_servers": ["https://auth.upstream.example/tenant"],
 				"bearer_methods_supported": ["header"],
 				"scopes_supported": ["read:foo", "write:foo"],
 				"resource_documentation": "https://upstream.example/docs"
-			}`) //nolint:errcheck
+			}`)
 			return
 		}
 		// Protocol traffic: 401 with bare bearer challenge.

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -442,17 +442,28 @@ func (p *ReverseProxy) defaultTransport(dialerTimeout float64) *http.Transport {
 	return transport
 }
 
-// augmentMCPWWWAuthenticate appends a `resource_metadata=` parameter to the
-// upstream's `WWW-Authenticate` header when the API is MCP, has PRM
-// enabled, and the upstream returned a bare Bearer challenge that didn't
-// already advertise its metadata URL. This is the hint MCP clients
-// (mcp-remote, Claude Desktop) need to find the gateway-served PRM doc
-// when the upstream itself doesn't include the parameter (e.g. Atlassian
-// Rovo as of 2026-Q2).
+// augmentMCPWWWAuthenticate rewrites the upstream's `WWW-Authenticate`
+// header so its `resource_metadata=` parameter points at the gateway-
+// served PRM URL instead of the upstream's. MCP clients (mcp-remote,
+// Claude Desktop) follow that URL to learn which authorization server
+// protects the resource — and validate the doc's `resource` field
+// against the URL the client actually connected to (RFC 9728 §3.3).
+// Pointing them at the upstream's PRM (the default for spec-compliant
+// upstreams like Notion) makes that origin check fail, so we substitute
+// the gateway URL whenever PRM mirror mode is active for the API.
+//
+// If the upstream's challenge has no `resource_metadata=` at all (e.g.
+// Atlassian Rovo as of 2026-Q2), we append one. Either way the client
+// ends up pointed at our PRM endpoint.
+//
+// `inboundReq` must be the original inbound request (pre-director), so we
+// can build the metadata URL from the gateway's scheme/host — not the
+// upstream's, which is what `res.Request` carries after the proxy
+// director rewrites the URL.
 //
 // No-op for non-MCP APIs, non-401 responses, or APIs without PRM
-// configured. Does not overwrite an existing `resource_metadata=` value.
-func augmentMCPWWWAuthenticate(res *http.Response, spec *APISpec) {
+// configured.
+func augmentMCPWWWAuthenticate(res *http.Response, inboundReq *http.Request, spec *APISpec) {
 	if res == nil || res.StatusCode != http.StatusUnauthorized {
 		return
 	}
@@ -464,29 +475,35 @@ func augmentMCPWWWAuthenticate(res *http.Response, spec *APISpec) {
 		return
 	}
 	existing := res.Header.Get(header.WWWAuthenticate)
-	if existing == "" || strings.Contains(strings.ToLower(existing), "resource_metadata=") {
+	if existing == "" {
+		return
+	}
+	if inboundReq == nil {
 		return
 	}
 
-	// Build the gateway-side PRM URL. We don't know the request scheme
-	// here (the response originates from the upstream), so we trust
-	// res.Request, which carries the original inbound URL via the
-	// reverse-proxy director.
-	if res.Request == nil || res.Request.URL == nil {
-		return
-	}
-	scheme := "http"
-	if res.Request.TLS != nil || strings.EqualFold(res.Request.URL.Scheme, "https") {
-		scheme = "https"
-	}
-	host := res.Request.Host
-	if host == "" {
-		host = res.Request.URL.Host
+	scheme := httputil.RequestScheme(inboundReq)
+	host := inboundReq.Host
+	if host == "" && inboundReq.URL != nil {
+		host = inboundReq.URL.Host
 	}
 	listen := strings.TrimRight(spec.Proxy.ListenPath, "/")
 	prmURL := fmt.Sprintf("%s://%s/.well-known/oauth-protected-resource%s", scheme, host, listen)
 
-	res.Header.Set(header.WWWAuthenticate, fmt.Sprintf(`%s, resource_metadata="%s"`, existing, prmURL))
+	res.Header.Set(header.WWWAuthenticate, replaceOrAppendResourceMetadata(existing, prmURL))
+}
+
+// replaceOrAppendResourceMetadata returns a `WWW-Authenticate` value with
+// its `resource_metadata="…"` parameter set to `prmURL`. If the parameter
+// is already present (regardless of value), it's substituted in place;
+// otherwise the parameter is appended.
+func replaceOrAppendResourceMetadata(header, prmURL string) string {
+	rxResourceMetadata := regexp.MustCompile(`(?i)resource_metadata="[^"]*"`)
+	replacement := fmt.Sprintf(`resource_metadata="%s"`, prmURL)
+	if rxResourceMetadata.MatchString(header) {
+		return rxResourceMetadata.ReplaceAllString(header, replacement)
+	}
+	return header + ", " + replacement
 }
 
 func singleJoiningSlash(targetPath, subPath string, disableStripSlash bool) string {
@@ -1488,6 +1505,13 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 	// We should at least copy the status code in
 	inres.StatusCode = res.StatusCode
 	inres.ContentLength = res.ContentLength
+
+	// Augment the upstream's WWW-Authenticate (RFC 9728 hint for MCP
+	// clients) using the inbound request so we build the gateway URL,
+	// not the rewritten upstream one. Must run before HandleResponse,
+	// which copies res.Header into rw.Header.
+	augmentMCPWWWAuthenticate(res, logreq, p.TykAPISpec)
+
 	p.HandleResponse(rw, res, ses)
 	return ProxyResponse{UpstreamLatency: upstreamLatency, Response: inres}
 }
@@ -1514,8 +1538,6 @@ func (p *ReverseProxy) HandleResponse(rw http.ResponseWriter, res *http.Response
 	}
 
 	p.Gw.limitHeaderFactory(res.Header).SendQuotas(ses, p.TykAPISpec.APIID)
-
-	augmentMCPWWWAuthenticate(res, p.TykAPISpec)
 
 	copyHeader(rw.Header(), res.Header, p.Gw.GetConfig().IgnoreCanonicalMIMEHeaderKey)
 

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -497,13 +497,13 @@ func augmentMCPWWWAuthenticate(res *http.Response, inboundReq *http.Request, spe
 // its `resource_metadata="…"` parameter set to `prmURL`. If the parameter
 // is already present (regardless of value), it's substituted in place;
 // otherwise the parameter is appended.
-func replaceOrAppendResourceMetadata(header, prmURL string) string {
+func replaceOrAppendResourceMetadata(headerValue, prmURL string) string {
 	rxResourceMetadata := regexp.MustCompile(`(?i)resource_metadata="[^"]*"`)
 	replacement := fmt.Sprintf(`resource_metadata="%s"`, prmURL)
-	if rxResourceMetadata.MatchString(header) {
-		return rxResourceMetadata.ReplaceAllString(header, replacement)
+	if rxResourceMetadata.MatchString(headerValue) {
+		return rxResourceMetadata.ReplaceAllString(headerValue, replacement)
 	}
-	return header + ", " + replacement
+	return headerValue + ", " + replacement
 }
 
 func singleJoiningSlash(targetPath, subPath string, disableStripSlash bool) string {

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -44,6 +44,7 @@ import (
 	tykerrors "github.com/TykTechnologies/tyk/internal/errors"
 	"github.com/TykTechnologies/tyk/internal/graphengine"
 	"github.com/TykTechnologies/tyk/internal/httputil"
+	"github.com/TykTechnologies/tyk/internal/mcp"
 	"github.com/TykTechnologies/tyk/internal/otel"
 	"github.com/TykTechnologies/tyk/internal/service/core"
 	"github.com/TykTechnologies/tyk/regexp"
@@ -292,9 +293,23 @@ func (gw *Gateway) TykNewSingleHostReverseProxy(target *url.URL, spec *APISpec, 
 		if targetToUse == target {
 			req.URL.Scheme = targetToUse.Scheme
 			req.URL.Host = targetToUse.Host
-			req.URL.Path = singleJoiningSlash(targetToUse.Path, req.URL.Path, spec.Proxy.DisableStripSlash)
+
+			// MCP/OAuth discovery probes (RFC 9728, RFC 8414) live at the
+			// upstream host root, never under the resource path. When the
+			// configured upstream URL embeds a path (e.g. https://x/v1/mcp),
+			// joining it with /.well-known/... would route discovery to the
+			// wrong location and break the OAuth dance for remote MCP
+			// upstreams. For MCP APIs only, route those probes to the host
+			// root.
+			joinPath := targetToUse.Path
+			if spec.IsMCP() && joinPath != "" && joinPath != "/" && mcp.IsHostRootDiscoveryPath(req.URL.Path) {
+				logger.Debug("MCP discovery path detected; routing to upstream host root")
+				joinPath = ""
+			}
+
+			req.URL.Path = singleJoiningSlash(joinPath, req.URL.Path, spec.Proxy.DisableStripSlash)
 			if req.URL.RawPath != "" {
-				req.URL.RawPath = singleJoiningSlash(targetToUse.Path, req.URL.RawPath, spec.Proxy.DisableStripSlash)
+				req.URL.RawPath = singleJoiningSlash(joinPath, req.URL.RawPath, spec.Proxy.DisableStripSlash)
 			}
 		}
 
@@ -425,6 +440,53 @@ func (p *ReverseProxy) defaultTransport(dialerTimeout float64) *http.Transport {
 	}
 
 	return transport
+}
+
+// augmentMCPWWWAuthenticate appends a `resource_metadata=` parameter to the
+// upstream's `WWW-Authenticate` header when the API is MCP, has PRM
+// enabled, and the upstream returned a bare Bearer challenge that didn't
+// already advertise its metadata URL. This is the hint MCP clients
+// (mcp-remote, Claude Desktop) need to find the gateway-served PRM doc
+// when the upstream itself doesn't include the parameter (e.g. Atlassian
+// Rovo as of 2026-Q2).
+//
+// No-op for non-MCP APIs, non-401 responses, or APIs without PRM
+// configured. Does not overwrite an existing `resource_metadata=` value.
+func augmentMCPWWWAuthenticate(res *http.Response, spec *APISpec) {
+	if res == nil || res.StatusCode != http.StatusUnauthorized {
+		return
+	}
+	if spec == nil || !spec.IsMCP() {
+		return
+	}
+	prm := spec.GetPRMConfig()
+	if prm == nil {
+		return
+	}
+	existing := res.Header.Get(header.WWWAuthenticate)
+	if existing == "" || strings.Contains(strings.ToLower(existing), "resource_metadata=") {
+		return
+	}
+
+	// Build the gateway-side PRM URL. We don't know the request scheme
+	// here (the response originates from the upstream), so we trust
+	// res.Request, which carries the original inbound URL via the
+	// reverse-proxy director.
+	if res.Request == nil || res.Request.URL == nil {
+		return
+	}
+	scheme := "http"
+	if res.Request.TLS != nil || strings.EqualFold(res.Request.URL.Scheme, "https") {
+		scheme = "https"
+	}
+	host := res.Request.Host
+	if host == "" {
+		host = res.Request.URL.Host
+	}
+	listen := strings.TrimRight(spec.Proxy.ListenPath, "/")
+	prmURL := fmt.Sprintf("%s://%s/.well-known/oauth-protected-resource%s", scheme, host, listen)
+
+	res.Header.Set(header.WWWAuthenticate, fmt.Sprintf(`%s, resource_metadata="%s"`, existing, prmURL))
 }
 
 func singleJoiningSlash(targetPath, subPath string, disableStripSlash bool) string {
@@ -1452,6 +1514,8 @@ func (p *ReverseProxy) HandleResponse(rw http.ResponseWriter, res *http.Response
 	}
 
 	p.Gw.limitHeaderFactory(res.Header).SendQuotas(ses, p.TykAPISpec.APIID)
+
+	augmentMCPWWWAuthenticate(res, p.TykAPISpec)
 
 	copyHeader(rw.Header(), res.Header, p.Gw.GetConfig().IgnoreCanonicalMIMEHeaderKey)
 

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -132,6 +132,78 @@ func TestReverseProxyRetainHost(t *testing.T) {
 	}
 }
 
+// TestReverseProxyMCPHostRootDiscovery verifies that for MCP APIs whose
+// upstream URL embeds a path, OAuth/MCP discovery probes (.well-known/...)
+// are routed to the upstream HOST ROOT instead of being prefixed with the
+// upstream path. Non-MCP APIs and root-upstream MCP APIs must keep the
+// existing behaviour.
+func TestReverseProxyMCPHostRootDiscovery(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	pathUpstream, _ := url.Parse("http://upstream.example/v1/mcp")
+	rootUpstream, _ := url.Parse("http://upstream.example/")
+
+	cases := []struct {
+		name    string
+		target  *url.URL
+		isMCP   bool
+		inPath  string
+		wantURL string
+	}{
+		{
+			"mcp-protocol-traffic-keeps-prefix",
+			pathUpstream, true, "/",
+			"http://upstream.example/v1/mcp",
+		},
+		{
+			"mcp-prm-discovery-bypasses-prefix",
+			pathUpstream, true, "/.well-known/oauth-protected-resource",
+			"http://upstream.example/.well-known/oauth-protected-resource",
+		},
+		{
+			"mcp-prm-discovery-with-suffix-bypasses-prefix",
+			pathUpstream, true, "/.well-known/oauth-protected-resource/v1/mcp",
+			"http://upstream.example/.well-known/oauth-protected-resource/v1/mcp",
+		},
+		{
+			"mcp-as-discovery-bypasses-prefix",
+			pathUpstream, true, "/.well-known/oauth-authorization-server",
+			"http://upstream.example/.well-known/oauth-authorization-server",
+		},
+		{
+			"non-mcp-keeps-prefix-on-well-known",
+			pathUpstream, false, "/.well-known/oauth-protected-resource",
+			"http://upstream.example/v1/mcp/.well-known/oauth-protected-resource",
+		},
+		{
+			"mcp-with-root-upstream-unchanged",
+			rootUpstream, true, "/.well-known/oauth-protected-resource",
+			"http://upstream.example/.well-known/oauth-protected-resource",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := &APISpec{APIDefinition: &apidef.APIDefinition{}}
+			if tc.isMCP {
+				spec.MarkAsMCP()
+			}
+
+			req := TestReq(t, http.MethodGet, "http://orig.example"+tc.inPath, nil)
+			req.URL.Path = tc.inPath
+
+			proxy := ts.Gw.TykNewSingleHostReverseProxy(tc.target, spec, nil)
+			proxy.Director(req)
+
+			got := req.URL.Scheme + "://" + req.URL.Host + req.URL.Path
+			if got != tc.wantURL {
+				t.Fatalf("wanted url %q, got %q", tc.wantURL, got)
+			}
+		})
+	}
+}
+
 type configTestReverseProxyDnsCache struct {
 	*testing.T
 

--- a/gateway/reverse_proxy_test.go
+++ b/gateway/reverse_proxy_test.go
@@ -141,8 +141,10 @@ func TestReverseProxyMCPHostRootDiscovery(t *testing.T) {
 	ts := StartTest(nil)
 	defer ts.Close()
 
-	pathUpstream, _ := url.Parse("http://upstream.example/v1/mcp")
-	rootUpstream, _ := url.Parse("http://upstream.example/")
+	pathUpstream, errPath := url.Parse("http://upstream.example/v1/mcp")
+	require.NoError(t, errPath)
+	rootUpstream, errRoot := url.Parse("http://upstream.example/")
+	require.NoError(t, errRoot)
 
 	cases := []struct {
 		name    string

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -56,6 +56,7 @@ import (
 	"github.com/TykTechnologies/tyk/internal/compression"
 	"github.com/TykTechnologies/tyk/internal/crypto"
 	"github.com/TykTechnologies/tyk/internal/httputil"
+	"github.com/TykTechnologies/tyk/internal/mcp"
 	"github.com/TykTechnologies/tyk/internal/model"
 	"github.com/TykTechnologies/tyk/internal/netutil"
 	"github.com/TykTechnologies/tyk/internal/otel"
@@ -171,6 +172,11 @@ type Gateway struct {
 	apiSpecs        []*APISpec
 	apisByID        map[string]*APISpec
 	apisHandlesByID *sync.Map
+
+	// prmCache memoises upstream Protected Resource Metadata (RFC 9728) docs
+	// for MCP APIs running in mirror mode. Lazily initialised on first use.
+	prmCacheOnce sync.Once
+	prmCache     *mcp.PRMCache
 
 	policies *model.Policies
 
@@ -309,6 +315,15 @@ func NewGateway(config config.Config, ctx context.Context) *Gateway {
 }
 
 // cacheCreate will create the caches in *Gateway.
+// PRMCache returns the gateway-wide Protected Resource Metadata cache used
+// by MCP mirror-mode PRM serving. Constructed lazily on first call.
+func (gw *Gateway) PRMCache() *mcp.PRMCache {
+	gw.prmCacheOnce.Do(func() {
+		gw.prmCache = mcp.NewPRMCache(0)
+	})
+	return gw.prmCache
+}
+
 func (gw *Gateway) cacheCreate() {
 	conf := gw.GetConfig()
 

--- a/internal/mcp/discovery.go
+++ b/internal/mcp/discovery.go
@@ -1,0 +1,37 @@
+package mcp
+
+import "strings"
+
+// HostRootDiscoveryPrefixes lists the well-known paths that MCP/OAuth clients
+// expect to find at the host root of an upstream server, regardless of the
+// resource path. See RFC 9728 (Protected Resource Metadata) and RFC 8414
+// (Authorization Server Metadata).
+var HostRootDiscoveryPrefixes = []string{
+	"/.well-known/oauth-protected-resource",
+	"/.well-known/oauth-authorization-server",
+	"/.well-known/openid-configuration",
+}
+
+// IsHostRootDiscoveryPath reports whether the given request path is a
+// well-known OAuth/OIDC discovery probe that must be served at the upstream
+// host root, ignoring any path component embedded in the configured upstream
+// URL.
+//
+// Match rules:
+//   - Leading slash is optional.
+//   - The path may carry a suffix (e.g. /.well-known/oauth-protected-resource/v1/mcp)
+//     per the path-suffix variant in RFC 9728 §3.1.
+func IsHostRootDiscoveryPath(p string) bool {
+	if p == "" {
+		return false
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	for _, prefix := range HostRootDiscoveryPrefixes {
+		if p == prefix || strings.HasPrefix(p, prefix+"/") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/mcp/discovery_test.go
+++ b/internal/mcp/discovery_test.go
@@ -1,0 +1,29 @@
+package mcp
+
+import "testing"
+
+func TestIsHostRootDiscoveryPath(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"empty", "", false},
+		{"prm exact with slash", "/.well-known/oauth-protected-resource", true},
+		{"prm exact without slash", ".well-known/oauth-protected-resource", true},
+		{"prm with resource suffix", "/.well-known/oauth-protected-resource/v1/mcp", true},
+		{"as metadata", "/.well-known/oauth-authorization-server", true},
+		{"oidc config", "/.well-known/openid-configuration", true},
+		{"unrelated path", "/v1/mcp", false},
+		{"nested but not well-known", "/api/.well-known/oauth-protected-resource", false},
+		{"prefix collision", "/.well-known/oauth-protected-resource-other", false},
+		{"random well-known", "/.well-known/jwks.json", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsHostRootDiscoveryPath(tc.path); got != tc.want {
+				t.Fatalf("IsHostRootDiscoveryPath(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/mcp/prm_cache.go
+++ b/internal/mcp/prm_cache.go
@@ -33,21 +33,23 @@ func (d *PRMDocument) Resource() string {
 	if d == nil || d.Raw == nil {
 		return ""
 	}
-	v, _ := d.Raw["resource"].(string)
-	return v
+	if v, ok := d.Raw["resource"].(string); ok {
+		return v
+	}
+	return ""
 }
 
 // SetResource overwrites the document's resource field. Used to swap the
 // upstream's URL for the gateway URL the client connected to before
 // serving.
-func (d *PRMDocument) SetResource(url string) {
+func (d *PRMDocument) SetResource(resourceURL string) {
 	if d == nil {
 		return
 	}
 	if d.Raw == nil {
 		d.Raw = make(map[string]any)
 	}
-	d.Raw["resource"] = url
+	d.Raw["resource"] = resourceURL
 }
 
 // MarshalJSON returns the document's JSON encoding.
@@ -152,7 +154,10 @@ func FetchUpstreamPRM(ctx context.Context, client *http.Client, prmURL string) (
 	defer resp.Body.Close()
 
 	if resp.StatusCode/100 != 2 {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		if readErr != nil {
+			return nil, fmt.Errorf("upstream PRM returned %d (and body unreadable: %w)", resp.StatusCode, readErr)
+		}
 		return nil, fmt.Errorf("upstream PRM returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 

--- a/internal/mcp/prm_cache.go
+++ b/internal/mcp/prm_cache.go
@@ -1,0 +1,191 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// DefaultPRMCacheTTL is how long a fetched upstream PRM document is reused
+// before being refetched. Five minutes balances freshness against load
+// against upstream OAuth metadata endpoints (which change rarely).
+const DefaultPRMCacheTTL = 5 * time.Minute
+
+// PRMDocument is a minimally-typed representation of an RFC 9728 Protected
+// Resource Metadata document. We keep the parsed map alongside so unknown
+// fields round-trip when we re-serialise after rewriting `resource`.
+type PRMDocument struct {
+	// Raw is the parsed JSON object. We rewrite Raw["resource"] in place
+	// before serving so any provider-specific fields (e.g.
+	// `bearer_methods_supported`, `resource_documentation`) are preserved.
+	Raw map[string]any
+}
+
+// Resource returns the resource URL declared in the document, if any.
+func (d *PRMDocument) Resource() string {
+	if d == nil || d.Raw == nil {
+		return ""
+	}
+	v, _ := d.Raw["resource"].(string)
+	return v
+}
+
+// SetResource overwrites the document's resource field. Used to swap the
+// upstream's URL for the gateway URL the client connected to before
+// serving.
+func (d *PRMDocument) SetResource(url string) {
+	if d == nil {
+		return
+	}
+	if d.Raw == nil {
+		d.Raw = make(map[string]any)
+	}
+	d.Raw["resource"] = url
+}
+
+// MarshalJSON returns the document's JSON encoding.
+func (d *PRMDocument) MarshalJSON() ([]byte, error) {
+	if d == nil {
+		return []byte("null"), nil
+	}
+	return json.Marshal(d.Raw)
+}
+
+// PRMCache holds upstream PRM documents indexed by upstream URL with TTL
+// expiry. Safe for concurrent use.
+type PRMCache struct {
+	ttl     time.Duration
+	mu      sync.RWMutex
+	entries map[string]prmCacheEntry
+	now     func() time.Time // override for tests
+}
+
+type prmCacheEntry struct {
+	doc       *PRMDocument
+	expiresAt time.Time
+}
+
+// NewPRMCache constructs a cache with the given TTL. Pass 0 to use the
+// package default.
+func NewPRMCache(ttl time.Duration) *PRMCache {
+	if ttl <= 0 {
+		ttl = DefaultPRMCacheTTL
+	}
+	return &PRMCache{
+		ttl:     ttl,
+		entries: make(map[string]prmCacheEntry),
+		now:     time.Now,
+	}
+}
+
+// Get returns a cached document if present and unexpired. The bool is true
+// when the returned document is valid.
+func (c *PRMCache) Get(key string) (*PRMDocument, bool) {
+	c.mu.RLock()
+	e, ok := c.entries[key]
+	c.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	if c.now().After(e.expiresAt) {
+		return nil, false
+	}
+	return cloneDoc(e.doc), true
+}
+
+// Put stores a document in the cache with the cache-wide TTL.
+func (c *PRMCache) Put(key string, doc *PRMDocument) {
+	c.mu.Lock()
+	c.entries[key] = prmCacheEntry{
+		doc:       cloneDoc(doc),
+		expiresAt: c.now().Add(c.ttl),
+	}
+	c.mu.Unlock()
+}
+
+// Invalidate removes the entry for a given key. Tests use this; runtime
+// code can rely on TTL expiry.
+func (c *PRMCache) Invalidate(key string) {
+	c.mu.Lock()
+	delete(c.entries, key)
+	c.mu.Unlock()
+}
+
+// cloneDoc returns a defensive copy so callers mutating Raw don't poison
+// other consumers of the same cache entry.
+func cloneDoc(d *PRMDocument) *PRMDocument {
+	if d == nil {
+		return nil
+	}
+	out := &PRMDocument{Raw: make(map[string]any, len(d.Raw))}
+	for k, v := range d.Raw {
+		out.Raw[k] = v
+	}
+	return out
+}
+
+// FetchUpstreamPRM retrieves the upstream's PRM document from the given URL
+// using the supplied HTTP client. Caller is responsible for plugging in
+// timeouts/transport via the client.
+func FetchUpstreamPRM(ctx context.Context, client *http.Client, prmURL string) (*PRMDocument, error) {
+	if prmURL == "" {
+		return nil, errors.New("upstream PRM URL is empty")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, prmURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build PRM request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("MCP-Protocol-Version", "2024-11-05")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch upstream PRM: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode/100 != 2 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("upstream PRM returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var raw map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, fmt.Errorf("decode upstream PRM: %w", err)
+	}
+	return &PRMDocument{Raw: raw}, nil
+}
+
+// DeriveUpstreamPRMURL builds the path-suffix variant URL where a remote
+// resource server publishes its PRM doc per RFC 9728 §3.1:
+//
+//	<scheme>://<host>/.well-known/oauth-protected-resource<resource-path>
+//
+// Trailing slashes on the resource path are stripped to match the form
+// most clients (notably mcp-remote) actually probe.
+func DeriveUpstreamPRMURL(upstreamURL string) (string, error) {
+	if upstreamURL == "" {
+		return "", errors.New("upstream URL is empty")
+	}
+	u, err := url.Parse(upstreamURL)
+	if err != nil {
+		return "", fmt.Errorf("parse upstream URL: %w", err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("upstream URL %q has no scheme/host", upstreamURL)
+	}
+	path := strings.TrimRight(u.Path, "/")
+	prm := url.URL{
+		Scheme: u.Scheme,
+		Host:   u.Host,
+		Path:   "/.well-known/oauth-protected-resource" + path,
+	}
+	return prm.String(), nil
+}

--- a/internal/mcp/prm_cache_test.go
+++ b/internal/mcp/prm_cache_test.go
@@ -118,3 +118,65 @@ func TestFetchUpstreamPRM_404(t *testing.T) {
 		t.Fatal("expected error on 404")
 	}
 }
+
+func TestFetchUpstreamPRM_EmptyURL(t *testing.T) {
+	_, err := FetchUpstreamPRM(context.Background(), http.DefaultClient, "")
+	if err == nil {
+		t.Fatal("expected error on empty URL")
+	}
+}
+
+func TestFetchUpstreamPRM_MalformedJSON(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{not json`))
+	}))
+	t.Cleanup(stub.Close)
+
+	_, err := FetchUpstreamPRM(context.Background(), stub.Client(), stub.URL+"/x")
+	if err == nil {
+		t.Fatal("expected error on malformed JSON")
+	}
+}
+
+func TestPRMCacheInvalidate(t *testing.T) {
+	c := NewPRMCache(time.Hour)
+	c.Put("k", &PRMDocument{Raw: map[string]any{"resource": "https://x"}})
+	if _, ok := c.Get("k"); !ok {
+		t.Fatal("expected hit before invalidate")
+	}
+	c.Invalidate("k")
+	if _, ok := c.Get("k"); ok {
+		t.Fatal("expected miss after invalidate")
+	}
+}
+
+func TestPRMDocument_NilSafety(t *testing.T) {
+	var d *PRMDocument
+	if got := d.Resource(); got != "" {
+		t.Fatalf("nil doc Resource() should be empty, got %q", got)
+	}
+	d.SetResource("https://x") // must not panic
+	b, err := d.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != "null" {
+		t.Fatalf("nil doc MarshalJSON should be null, got %s", string(b))
+	}
+}
+
+func TestPRMDocument_SetResourceInitsRaw(t *testing.T) {
+	d := &PRMDocument{}
+	d.SetResource("https://x")
+	if d.Resource() != "https://x" {
+		t.Fatalf("got %q", d.Resource())
+	}
+}
+
+func TestNewPRMCache_DefaultTTLOnZero(t *testing.T) {
+	c := NewPRMCache(0)
+	if c.ttl != DefaultPRMCacheTTL {
+		t.Fatalf("expected default TTL, got %v", c.ttl)
+	}
+}

--- a/internal/mcp/prm_cache_test.go
+++ b/internal/mcp/prm_cache_test.go
@@ -1,0 +1,120 @@
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestDeriveUpstreamPRMURL(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+		err  bool
+	}{
+		{"path-bearing trailing slash stripped",
+			"https://mcp.atlassian.com/v1/mcp/authv2/",
+			"https://mcp.atlassian.com/.well-known/oauth-protected-resource/v1/mcp/authv2", false},
+		{"path-bearing no trailing slash",
+			"https://mcp.atlassian.com/v1/mcp/authv2",
+			"https://mcp.atlassian.com/.well-known/oauth-protected-resource/v1/mcp/authv2", false},
+		{"host root only",
+			"https://upstream.example/",
+			"https://upstream.example/.well-known/oauth-protected-resource", false},
+		{"host root no slash",
+			"https://upstream.example",
+			"https://upstream.example/.well-known/oauth-protected-resource", false},
+		{"empty rejected", "", "", true},
+		{"non-URL rejected", "not a url", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := DeriveUpstreamPRMURL(tc.in)
+			if tc.err {
+				if err == nil {
+					t.Fatalf("expected error for %q, got %q", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPRMCacheTTL(t *testing.T) {
+	c := NewPRMCache(time.Hour)
+	clock := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	c.now = func() time.Time { return clock }
+
+	doc := &PRMDocument{Raw: map[string]any{"resource": "https://x"}}
+	c.Put("k", doc)
+
+	if got, ok := c.Get("k"); !ok || got.Resource() != "https://x" {
+		t.Fatalf("expected hit, got ok=%v doc=%v", ok, got)
+	}
+
+	clock = clock.Add(2 * time.Hour)
+	if _, ok := c.Get("k"); ok {
+		t.Fatalf("expected miss after TTL")
+	}
+}
+
+func TestPRMCacheCloneIsolation(t *testing.T) {
+	c := NewPRMCache(time.Minute)
+	c.Put("k", &PRMDocument{Raw: map[string]any{"resource": "a"}})
+
+	got, ok := c.Get("k")
+	if !ok {
+		t.Fatal("expected hit")
+	}
+	got.Raw["resource"] = "mutated" // should not poison the cache
+
+	got2, _ := c.Get("k")
+	if got2.Resource() != "a" {
+		t.Fatalf("cache poisoned: %q", got2.Resource())
+	}
+}
+
+func TestFetchUpstreamPRM(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("MCP-Protocol-Version") == "" {
+			t.Errorf("missing MCP-Protocol-Version header")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"resource":"https://upstream.example/v1/mcp","authorization_servers":["https://auth.example/t"]}`))
+	}))
+	t.Cleanup(stub.Close)
+
+	doc, err := FetchUpstreamPRM(context.Background(), stub.Client(), stub.URL+"/.well-known/oauth-protected-resource/v1/mcp")
+	if err != nil {
+		t.Fatalf("FetchUpstreamPRM: %v", err)
+	}
+	if doc.Resource() != "https://upstream.example/v1/mcp" {
+		t.Fatalf("resource: %q", doc.Resource())
+	}
+	authServers, _ := doc.Raw["authorization_servers"].([]any)
+	if len(authServers) != 1 || authServers[0] != "https://auth.example/t" {
+		t.Fatalf("authorization_servers preserved: %v", authServers)
+	}
+}
+
+func TestFetchUpstreamPRM_404(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("not found"))
+	}))
+	t.Cleanup(stub.Close)
+
+	_, err := FetchUpstreamPRM(context.Background(), stub.Client(), stub.URL+"/x")
+	if err == nil {
+		t.Fatal("expected error on 404")
+	}
+}

--- a/internal/mcp/prm_cache_test.go
+++ b/internal/mcp/prm_cache_test.go
@@ -89,7 +89,7 @@ func TestFetchUpstreamPRM(t *testing.T) {
 			t.Errorf("missing MCP-Protocol-Version header")
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"resource":"https://upstream.example/v1/mcp","authorization_servers":["https://auth.example/t"]}`))
+		_, _ = w.Write([]byte(`{"resource":"https://upstream.example/v1/mcp","authorization_servers":["https://auth.example/t"]}`)) //nolint:errcheck
 	}))
 	t.Cleanup(stub.Close)
 
@@ -109,7 +109,7 @@ func TestFetchUpstreamPRM(t *testing.T) {
 func TestFetchUpstreamPRM_404(t *testing.T) {
 	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write([]byte("not found"))
+		_, _ = w.Write([]byte("not found")) //nolint:errcheck
 	}))
 	t.Cleanup(stub.Close)
 
@@ -129,7 +129,7 @@ func TestFetchUpstreamPRM_EmptyURL(t *testing.T) {
 func TestFetchUpstreamPRM_MalformedJSON(t *testing.T) {
 	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{not json`))
+		_, _ = w.Write([]byte(`{not json`)) //nolint:errcheck
 	}))
 	t.Cleanup(stub.Close)
 


### PR DESCRIPTION
## Summary

Make Tyk able to put a transparent reverse proxy in front of any spec-compliant remote MCP server (Atlassian Rovo, Notion, etc.) so MCP clients (Roo, Claude Desktop, anything that uses `mcp-remote`) can complete the OAuth dance through the gateway with zero per-upstream knobs. Three commits, each fixing a distinct failure point along the wire.

The minimal MCP API definition is now just listen path + upstream:

```json
{
  "openapi": "3.0.3",
  "info": {"title": "jira", "version": "1.0.0"},
  "paths": {"/": {"get": {...}, "post": {...}}},
  "x-tyk-api-gateway": {
    "info": {"id": "jira-mcp-remote", "name": "jira", "state": {"active": true}},
    "server": {"listenPath": {"value": "/jira/", "strip": true}},
    "upstream": {"url": "https://mcp.atlassian.com/v1/mcp/authv2"}
  }
}
```

POST that to `/tyk/mcps`. Mirror mode auto-engages — no `authentication` block, no `protectedResourceMetadata` block. The full OAuth dance completes end-to-end through Tyk.

## What was broken (three failure modes, in order)

1. **Routing**: when the upstream URL had a path component (e.g. `/v1/mcp/authv2`), `.well-known/*` discovery probes were prefixed with that path and 404'd — well-known endpoints live at the host root.
2. **RFC 9728 §3.3 origin mismatch**: even with routing fixed, transparent-proxying the upstream's PRM doc gives a `resource` field that doesn't match the URL the client connected to — strict clients (mcp-remote, Roo) refuse to authenticate.
3. **RFC 8707 `invalid_target`**: even with PRM rewritten, the client sends the gateway URL as the `resource` parameter to the upstream's authorize endpoint. Strict authorization servers (Notion) only accept the upstream URL and reject with `invalid_target`.

## What we built

* **TT-17137 routing fix** (`gateway/reverse_proxy.go`): MCP-aware host-root branch in the reverse-proxy director routes well-known discovery probes (RFC 9728 / RFC 8414 / OIDC) to the upstream host root, ignoring the upstream URL's path.
* **PRM mirror mode** (`apidef/oas/authentication.go`, `gateway/mw_protected_resource.go`, `gateway/api_loader.go`): new `mode: "mirror"` fetches the upstream's PRM doc, rewrites `resource` to the gateway URL, caches with TTL, auto-serves at the path-suffix URL clients actually probe (`<gateway>/.well-known/oauth-protected-resource<listen-path>`).
* **OAuth-flow proxy** (`gateway/mcp_oauth_proxy.go`): mirror mode redirects `authorization_servers` at a per-API Tyk URL. Tyk serves a synthesised AS metadata document with `authorization_endpoint`/`token_endpoint` pointing at itself, then 302-redirects the authorize request and forwards token POSTs after rewriting the `resource` parameter from gateway URL to upstream URL. Reconciles RFC 9728 §3.3 vs. RFC 8707 on the wire.
* **Auto-mirror default**: `EffectiveMode(isMCP)` resolves empty mode by configuration shape — Resource set → static (back-compat); Resource empty + MCP → mirror; everything else → static. `OAS.ValidateForMCP` threads MCP context through OAS-level validation so empty configs don't get rejected with "resource is required". `GetPRMConfig` synthesises a default for MCP APIs without an explicit PRM block, so the runtime plumbing engages with zero opt-in.
* **WWW-Authenticate rewriter** (`augmentMCPWWWAuthenticate`): replaces (not appends) the `resource_metadata=` parameter on upstream 401s so clients are pointed at the gateway's PRM endpoint. Uses the inbound request's scheme/host (not the rewritten outbound).

## Validated end-to-end

* **Atlassian Rovo** (`https://mcp.atlassian.com/v1/mcp/authv2`) — Roo browser flow completes, tools list returned.
* **Notion** (`https://mcp.notion.com/mcp`) — same. RFC 8707 `invalid_target` resolved by the AS proxy's `resource` parameter rewrite.

## Tests

* Unit: `apidef/oas/authentication_test.go` (`Validate`, `EffectiveMode`, `IsMirrorMode`), `internal/mcp/discovery_test.go` (host-root prefix matching), `internal/mcp/prm_cache_test.go` (TTL cache + URL derivation + upstream PRM fetch).
* Integration: `gateway/reverse_proxy_test.go::TestReverseProxyMCPHostRootDiscovery` (routing fix; non-MCP regression guard), `gateway/mw_protected_resource_test.go::TestPRMMirrorMode_SuffixRoute` (PRM serving + rewrite), `TestPRMMirrorMode_OAuthProxy` (AS metadata rewrite, authorize 302, token forward), `TestAugmentMCPWWWAuthenticate` (overwrite semantics + scheme/host correctness + opt-out via `enabled: false`).

`go vet` clean across changed packages.

## Architectural follow-ups (out of scope for this PR)

* **Static-client / non-DCR upstreams** — for SaaS that don't allow public Dynamic Client Registration (most enterprise IdPs). Would extend `protectedResourceMetadata` with a `staticClient` block; Tyk synthesises a registration response from configured `client_id`/`client_secret` so mcp-remote stays oblivious.
* **AS metadata caching** — the PRM doc is cached with TTL but AS metadata is currently re-fetched on every authorize/token round-trip. Easy win; ~40 LOC.
* **Service-account / token-broker modes** — for use cases where the gateway should hold upstream credentials (`client_credentials`) or broker per-user tokens itself instead of being a transparent proxy. Different product surface.

## Test plan

- [x] Unit tests pass (`go test ./apidef/... ./gateway/... ./internal/mcp/...`)
- [x] `go vet` clean
- [x] Live E2E: bare-minimum jira MCP API + Roo → browser opens, OAuth completes
- [x] Live E2E: bare-minimum notion MCP API + Roo → browser opens, OAuth completes (RFC 8707 path)
- [x] Existing PRM/PRM-suffix/JWT/AuthKey PRM tests still pass (no regression on static mode)

## See also

- [`docs/mcp-remote-oauth-flow.md`](docs/mcp-remote-oauth-flow.md) — full wire diagram of the OAuth flow with the three failure-mode diagrams.
- [`docs/mcp-remote-proxies.ipynb`](docs/mcp-remote-proxies.ipynb) — operator notebook for both Jira and Notion proxies.




<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-17137" title="TT-17137" target="_blank">TT-17137</a>
</summary>

|         |    |
|---------|----|
| Status  | In Dev |
| Summary | User should be easily able to set remote MCP as upstream |

Generated at: 2026-05-07 14:55:39

</details>

<!---TykTechnologies/jira-linter ends here-->




