### PR TITLE
[TT-16951] fix: disable FIPS for release-5.13.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       (needs.dep-guard.result == 'success' || needs.dep-guard.result == 'skipped') &&
       github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
-    runs-on: ${{ vars.DEFAULT_RUNNER }}
+    runs-on: ${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
     permissions:
       id-token: write # AWS OIDC JWT
       contents: read # actions/checkout
@@ -61,7 +61,6 @@ jobs:
             debvers: 'ubuntu/xenial ubuntu/bionic ubuntu/focal ubuntu/jammy ubuntu/noble debian/jessie debian/buster debian/bullseye debian/bookworm debian/trixie'
     outputs:
       ee_tags: ${{ steps.ci_metadata_ee.outputs.tags }}
-      fips_tags: ${{ steps.ci_metadata_fips.outputs.tags }}
       std_tags: ${{ steps.ci_metadata_std.outputs.tags }}
       commit_author: ${{ steps.set_outputs.outputs.commit_author}}
     steps:
@@ -171,10 +170,9 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
-          sbom: true
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -186,6 +184,7 @@ jobs:
             NONROOT_CHOWN=true
       - name: Docker metadata for ee tag push
         id: tag_metadata_ee
+        if: startsWith(github.ref, 'refs/tags')
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
@@ -203,17 +202,15 @@ jobs:
             org.opencontainers.image.vendor=tyk.io
             org.opencontainers.image.version=${{ github.ref_name }}
       - name: push ee image to prod
-        if: ${{ matrix.golang_cross == '1.25-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.25-bullseye' && startsWith(github.ref, 'refs/tags') }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
           platforms: linux/amd64,linux/arm64
           file: ci/Dockerfile.distroless
           provenance: mode=max
-          sbom: true
           cache-from: type=gha
-          cache-to: type=gha,mode=max
-          push: ${{ startsWith(github.ref, 'refs/tags') }}
+          push: true
           tags: ${{ steps.tag_metadata_ee.outputs.tags }}
           labels: ${{ steps.tag_metadata_ee.outputs.labels }}
           build-args: |
@@ -235,90 +232,9 @@ jobs:
               --predicate /tmp/ee-vex.json \
               tykio/tyk-gateway-ee:${{ github.ref_name }} || true
           fi
-      - name: Docker metadata for fips CI
-        id: ci_metadata_fips
-        if: ${{ matrix.golang_cross == '1.25-bullseye' }}
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
-        with:
-          images: |
-            ${{ steps.ecr.outputs.registry }}/tyk-fips
-          flavor: |
-            latest=false
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=sha,format=long
-            type=semver,pattern={{major}},prefix=v
-            type=semver,pattern={{major}}.{{minor}},prefix=v
-            type=semver,pattern={{version}},prefix=v
-      - name: push fips image to CI
-        if: ${{ matrix.golang_cross == '1.25-bullseye' }}
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
-        with:
-          context: "dist"
-          platforms: linux/amd64,linux/arm64
-          file: ci/Dockerfile.distroless
-          provenance: mode=max
-          sbom: true
-          push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          tags: ${{ steps.ci_metadata_fips.outputs.tags }}
-          labels: ${{ steps.ci_metadata_fips.outputs.labels }}
-          build-args: |
-            BUILD_PACKAGE_NAME=tyk-gateway-fips
-            BASE_IMAGE=tykio/dhi-busybox:1.37-fips
-            NONROOT_CHOWN=true
-      - name: Docker metadata for fips tag push
-        id: tag_metadata_fips
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
-        with:
-          images: |
-            tykio/tyk-gateway-fips
-          flavor: |
-            latest=false
-            prefix=v
-          tags: |
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{version}}
-          labels: |
-            org.opencontainers.image.title=Tyk Gateway Enterprise Edition FIPS
-            org.opencontainers.image.description=Tyk API Gateway Enterprise Edition written in Go, supporting REST, GraphQL, TCP and gRPC protocols Built with FIPS 140-3 compliant cryptography
-            org.opencontainers.image.vendor=tyk.io
-            org.opencontainers.image.version=${{ github.ref_name }}
-      - name: push fips image to prod
-        if: ${{ matrix.golang_cross == '1.25-bullseye' }}
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
-        with:
-          context: "dist"
-          platforms: linux/amd64,linux/arm64
-          file: ci/Dockerfile.distroless
-          provenance: mode=max
-          sbom: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          push: ${{ startsWith(github.ref, 'refs/tags') }}
-          tags: ${{ steps.tag_metadata_fips.outputs.tags }}
-          labels: ${{ steps.tag_metadata_fips.outputs.labels }}
-          build-args: |
-            BUILD_PACKAGE_NAME=tyk-gateway-fips
-            BASE_IMAGE=tykio/dhi-busybox:1.37-fips
-            NONROOT_CHOWN=true
-      - name: Attach base image VEX to fips
-        if: ${{ matrix.golang_cross == '1.25-bullseye' && startsWith(github.ref, 'refs/tags') }}
-        run: |
-          # Install Docker Scout CLI
-          curl -fsSL https://raw.githubusercontent.com/docker/scout-cli/v1.20.4/install.sh -o /tmp/scout-install.sh && sh /tmp/scout-install.sh 2>/dev/null
-          # Extract VEX from the DHI base image
-          docker scout vex get --org tykio -o /tmp/fips-vex.json tykio/dhi-busybox:1.37-fips || true
-          if [ -f /tmp/fips-vex.json ]; then
-            cosign attest --yes --type openvex \
-              --predicate /tmp/fips-vex.json \
-              tykio/tyk-gateway-fips:${{ github.ref_name }} || true
-          fi
       - name: Docker metadata for std CI
         id: ci_metadata_std
-        if: ${{ matrix.golang_cross == '1.25-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.25-bullseye' && github.event_name != 'pull_request' }}
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
@@ -333,14 +249,13 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},prefix=v
             type=semver,pattern={{version}},prefix=v
       - name: push std image to CI
-        if: ${{ matrix.golang_cross == '1.25-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.25-bullseye' && github.event_name != 'pull_request' }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: linux/amd64,linux/arm64,linux/s390x
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/s390x' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
-          sbom: true
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -350,6 +265,7 @@ jobs:
             BUILD_PACKAGE_NAME=tyk-gateway
       - name: Docker metadata for std tag push
         id: tag_metadata_std
+        if: startsWith(github.ref, 'refs/tags')
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
@@ -367,17 +283,15 @@ jobs:
             org.opencontainers.image.vendor=tyk.io
             org.opencontainers.image.version=${{ github.ref_name }}
       - name: push std image to prod
-        if: ${{ matrix.golang_cross == '1.25-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.25-bullseye' && startsWith(github.ref, 'refs/tags') }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
           platforms: linux/amd64,linux/arm64,linux/s390x
           file: ci/Dockerfile.distroless
           provenance: mode=max
-          sbom: true
           cache-from: type=gha
-          cache-to: type=gha,mode=max
-          push: ${{ startsWith(github.ref, 'refs/tags') }}
+          push: true
           tags: ${{ steps.tag_metadata_std.outputs.tags }}
           labels: ${{ steps.tag_metadata_std.outputs.labels }}
           build-args: |
@@ -539,7 +453,7 @@ jobs:
           COMMIT_SHA: ${{ github.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HAS_RELEVANT_CHANGES: ${{ steps.check_changes.outputs.has_relevant_changes }}
-          ORG_GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
         run: |
           echo "=================================="
           echo "📊 Dashboard Image Resolution"
@@ -615,11 +529,8 @@ jobs:
           echo "✅ Resolution complete"
           echo "=================================="
   build-dashboard-image:
+    if: needs.resolve-dashboard-image.outputs.needs_build == 'true'
     needs: resolve-dashboard-image
-    if: |
-      !cancelled() &&
-      needs.resolve-dashboard-image.result == 'success' &&
-      needs.resolve-dashboard-image.outputs.needs_build == 'true'
     runs-on: ${{ vars.DEFAULT_RUNNER }}
     permissions:
       id-token: write
@@ -901,7 +812,7 @@ jobs:
           org_gh_token: ${{ steps.app-token.outputs.token }}
       - name: Run API tests
         uses: TykTechnologies/github-actions/.github/actions/tests/api-tests@42304edda365365e0a887cf018d8edc34b960b82 # main
-        timeout-minutes: 40
+        timeout-minutes: 30
         id: test_execution
         with:
           user_api_secret: ${{ steps.env_up.outputs.USER_API_SECRET }}
@@ -915,7 +826,7 @@ jobs:
     name: Aggregated CI Status
     runs-on: ${{ vars.DEFAULT_RUNNER }}
     # Dynamically determine which jobs to depend on based on repository configuration
-    needs: [goreleaser, api-tests, dep-guard]
+    needs: [dep-guard, goreleaser, api-tests]
     if: ${{ always() && github.event_name == 'pull_request' }}
     steps:
       - name: Aggregate results
@@ -972,9 +883,6 @@ jobs:
     runs-on: ${{ vars.DEFAULT_RUNNER }}
     needs:
       - test-controller-distros
-    if: |
-      !cancelled() &&
-      needs.test-controller-distros.result == 'success'
     strategy:
       fail-fast: true
       matrix:
@@ -1034,9 +942,6 @@ jobs:
     runs-on: ${{ vars.DEFAULT_RUNNER }}
     needs:
       - test-controller-distros
-    if: |
-      !cancelled() &&
-      needs.test-controller-distros.result == 'success'
     strategy:
       fail-fast: true
       matrix:

--- a/ci/goreleaser/goreleaser.yml
+++ b/ci/goreleaser/goreleaser.yml
@@ -57,60 +57,6 @@ builds:
     goarch:
       - s390x
     binary: tyk
-  - id: fips-amd64
-    flags:
-      - -tags=goplugin,ee,fips
-      - -trimpath
-    env:
-      - NOP=nop # ignore this, it is jsut to avoid a complex conditional in the templates
-      - CC=gcc
-      - GOFIPS140=v1.0.0
-    ldflags:
-      - -X github.com/TykTechnologies/tyk/internal/build.Version={{.Version}}
-      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
-      - -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
-      - -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
-    goos:
-      - linux
-    goarch:
-      - amd64
-    binary: tyk
-  - id: fips-arm64
-    flags:
-      - -tags=goplugin,ee,fips
-      - -trimpath
-    env:
-      - NOP=nop # ignore this, it is jsut to avoid a complex conditional in the templates
-      - CC=aarch64-linux-gnu-gcc
-      - GOFIPS140=v1.0.0
-    ldflags:
-      - -X github.com/TykTechnologies/tyk/internal/build.Version={{.Version}}
-      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
-      - -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
-      - -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
-    goos:
-      - linux
-    goarch:
-      - arm64
-    binary: tyk
-  - id: fips-s390x
-    flags:
-      - -tags=goplugin,ee,fips
-      - -trimpath
-    env:
-      - NOP=nop # ignore this, it is jsut to avoid a complex conditional in the templates
-      - CC=s390x-linux-gnu-gcc
-      - GOFIPS140=v1.0.0
-    ldflags:
-      - -X github.com/TykTechnologies/tyk/internal/build.Version={{.Version}}
-      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
-      - -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
-      - -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
-    goos:
-      - linux
-    goarch:
-      - s390x
-    binary: tyk
   - id: std-amd64
     flags:
       - -tags=goplugin
@@ -222,65 +168,6 @@ nfpms:
       signature:
         key_file: tyk.io.signing.key
         type: origin
-  - id: fips
-    vendor: "Tyk Technologies Ltd"
-    homepage: "https://tyk.io"
-    maintainer: "Tyk <info@tyk.io>"
-    description: Tyk API Gateway Enterprise Edition written in Go, supporting REST, GraphQL, TCP and gRPC protocols Built with FIPS 140-3 compliant cryptography
-    package_name: tyk-gateway-fips
-    file_name_template: "{{ .ConventionalFileName }}"
-    ids:
-      - fips-amd64
-      - fips-arm64
-      - fips-s390x
-    formats:
-      - deb
-      - rpm
-    contents:
-      - src: "README.md"
-        dst: "/opt/share/docs/tyk-gateway/README.md"
-      - src: "ci/install/*"
-        dst: "/opt/tyk-gateway/install"
-      - src: ci/install/inits/systemd/system/tyk-gateway.service
-        dst: /lib/systemd/system/tyk-gateway.service
-      - src: ci/install/inits/sysv/init.d/tyk-gateway
-        dst: /etc/init.d/tyk-gateway
-      - src: /opt/tyk-gateway
-        dst: /opt/tyk
-        type: "symlink"
-      - src: "LICENSE.md"
-        dst: "/opt/share/docs/tyk-gateway/LICENSE.md"
-      - src: "apps/app_sample.*"
-        dst: "/opt/tyk-gateway/apps"
-      - src: "templates/*.json"
-        dst: "/opt/tyk-gateway/templates"
-      - src: "templates/playground/*"
-        dst: "/opt/tyk-gateway/templates/playground"
-      - src: "middleware/*.js"
-        dst: "/opt/tyk-gateway/middleware"
-      - src: "event_handlers/sample/*.js"
-        dst: "/opt/tyk-gateway/event_handlers/sample"
-      - src: "policies/*.json"
-        dst: "/opt/tyk-gateway/policies"
-      - src: "coprocess/*"
-        dst: "/opt/tyk-gateway/coprocess"
-      - src: tyk.conf.example
-        dst: /opt/tyk-gateway/tyk.conf
-        type: "config|noreplace"
-    scripts:
-      preinstall: "ci/install/before_install.sh"
-      postinstall: "ci/install/post_install.sh"
-      postremove: "ci/install/post_remove.sh"
-    bindir: "/opt/tyk-gateway"
-    rpm:
-      scripts:
-        posttrans: ci/install/post_trans.sh
-      signature:
-        key_file: tyk.io.signing.key
-    deb:
-      signature:
-        key_file: tyk.io.signing.key
-        type: origin
   - id: std
     vendor: "Tyk Technologies Ltd"
     homepage: "https://tyk.io"
@@ -344,12 +231,6 @@ publishers:
   - name: ee
     ids:
       - ee
-    env:
-      - PACKAGECLOUD_TOKEN={{ .Env.PACKAGECLOUD_TOKEN }}
-    cmd: packagecloud publish --debvers "{{ .Env.DEBVERS }}" --rpmvers "{{ .Env.RPMVERS }}" tyk/tyk-ee-unstable {{ .ArtifactPath }}
-  - name: fips
-    ids:
-      - fips
     env:
       - PACKAGECLOUD_TOKEN={{ .Env.PACKAGECLOUD_TOKEN }}
     cmd: packagecloud publish --debvers "{{ .Env.DEBVERS }}" --rpmvers "{{ .Env.RPMVERS }}" tyk/tyk-ee-unstable {{ .ArtifactPath }}


### PR DESCRIPTION
## Summary
Auto-generated by gromit policy sync. FIPS feature removed for release-5.13.0.

Removes:
- FIPS Docker image build steps
- FIPS deb/rpm package builds (goreleaser)
- FIPS plugin compiler builds

Source-of-truth gromit config: TykTechnologies/gromit#464

## Test plan
- [ ] Release workflow completes without FIPS Docker steps
- [ ] No FIPS deb/rpm packages produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)