### PR TITLE
[TT-17173] OAuth2 scope check (API-level / global)

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -792,8 +792,26 @@ type APIDefinition struct {
 	UpstreamAuth UpstreamAuth `bson:"upstream_auth" json:"upstream_auth"`
 
 	// SecurityRequirements stores all OAS security requirements (auto-populated from OpenAPI description import)
-	// When len(SecurityRequirements) > 1, OR logic is automatically applied
-	SecurityRequirements [][]string `json:"security_requirements,omitempty" bson:"security_requirements,omitempty"`
+	// When len(SecurityRequirements) > 1, OR logic is automatically applied.
+	//
+	// Storage tag intentionally omits bson:",omitempty" — a nil here is
+	// the signal that the operator removed all security from the API
+	// and must overwrite any stored value, not be silently dropped from
+	// a $set update.
+	SecurityRequirements [][]string `json:"security_requirements,omitempty" bson:"security_requirements"`
+
+	// SecurityRequirementScopes preserves the per-scheme scope arrays from
+	// OAS root `security:` Security Requirement Objects. Aligned by index
+	// with SecurityRequirements: entry i carries the scope map for the
+	// schemes named in SecurityRequirements[i]. Scopes are honoured only
+	// for schemes whose OAS type is oauth2 or openIdConnect — other
+	// schemes always round-trip with an empty scope array (OAS 3.0
+	// §4.8.30.1).
+	//
+	// Storage tag intentionally omits bson:",omitempty" — see
+	// SecurityRequirements above. A nil after an operator edit must
+	// reach storage as null so the prior value is cleared.
+	SecurityRequirementScopes []map[string][]string `json:"security_requirement_scopes,omitempty" bson:"security_requirement_scopes"`
 
 	// ErrorOverrides contains the configurations for error response customization.
 	ErrorOverrides         ErrorOverridesMap `bson:"error_overrides" json:"error_overrides"`

--- a/apidef/mcp/schema/x-tyk-api-gateway.json
+++ b/apidef/mcp/schema/x-tyk-api-gateway.json
@@ -1965,10 +1965,22 @@
       "type": "object",
       "description": "OAuth 2.0 security scheme container.",
       "properties": {
-        "enabled": { "type": "boolean" },
-        "header":  { "$ref": "#/definitions/X-Tyk-AuthSource" },
-        "cookie":  { "$ref": "#/definitions/X-Tyk-AuthSource" },
-        "query":   { "$ref": "#/definitions/X-Tyk-AuthSource" }
+        "enabled":    { "type": "boolean" },
+        "header":     { "$ref": "#/definitions/X-Tyk-AuthSource" },
+        "cookie":     { "$ref": "#/definitions/X-Tyk-AuthSource" },
+        "query":      { "$ref": "#/definitions/X-Tyk-AuthSource" },
+        "scopeCheck": { "$ref": "#/definitions/X-Tyk-OAuth2-ScopeCheck" }
+      },
+      "required": ["enabled"]
+    },
+    "X-Tyk-OAuth2-ScopeCheck": {
+      "type": "object",
+      "description": "Token-side knobs for OAS-native scope enforcement. Required scopes themselves live in the OAS root security: array.",
+      "properties": {
+        "enabled":        { "type": "boolean" },
+        "claimNames":     { "type": "array", "items": { "type": "string" }, "description": "Ordered list of JWT claim names to read scopes from. The gateway reads each listed claim that is present and merges all scope values into one set. Alternatives drawn from OAS root security: are checked against this merged set. Defaults to [\"scope\", \"scp\"] when unset." },
+        "separator":      { "type": "string" },
+        "scopeSource":    { "type": "string", "enum": ["operation", "global", "union"], "description": "Selects whether enforcement reads per-operation security:, root security:, or both. Defaults to \"union\"." }
       },
       "required": ["enabled"]
     },

--- a/apidef/oas/oas.go
+++ b/apidef/oas/oas.go
@@ -253,14 +253,28 @@ func (s *OAS) Initialize() {
 		case typeAPIKey:
 			s.getTykTokenAuth(name)
 		case typeOAuth2:
-			// For OAuth2, we need to check the Tyk extension data to determine
-			// if it is a standard OAuth or external OAuth provider.
+			// The OAS-side type discriminator `oauth2` is shared by three
+			// Tyk-side schemes: legacy `*OAuth` (Tyk's own OAuth2 server),
+			// `*ExternalOAuth` (introspection / providers), and the new
+			// `*OAuth2` (this scheme). Disambiguate by inspecting the
+			// Tyk-extension shape, in priority order:
+			//   1) If already typed, use it directly.
+			//   2) If the map carries a new oauth2 sub-block (e.g.
+			//      scopeCheck), bind to *OAuth2 — without this branch
+			//      the legacy fallback would convert the new scheme's
+			//      map into a *OAuth and silently drop the sub-block.
+			//   3) Else if it has providers[] like ExternalOAuth, bind there.
+			//   4) Otherwise treat as legacy *OAuth.
 			securityScheme := s.getTykSecurityScheme(name)
 			if securityScheme == nil {
 				continue
 			}
 
-			// Check if the scheme has providers configured (indicates ExternalOAuth)
+			if oauth2 := asOAuth2Scheme(securityScheme); oauth2 != nil {
+				s.getTykSecuritySchemes()[name] = oauth2
+				continue
+			}
+
 			externalOAuth := &ExternalOAuth{}
 			if _, ok := securityScheme.(*ExternalOAuth); ok {
 				s.getTykExternalOAuthAuth(name)

--- a/apidef/oas/oas_test.go
+++ b/apidef/oas/oas_test.go
@@ -399,7 +399,6 @@ func TestOAS_ExtractTo_ResetAPIDefinition(t *testing.T) {
 		"APIDefinition.AnalyticsPlugin.Enabled",
 		"APIDefinition.AnalyticsPlugin.PluginPath",
 		"APIDefinition.AnalyticsPlugin.FuncName",
-		"APIDefinition.SecurityRequirements[0]",
 	}
 
 	assert.Equal(t, expectedFields, noOASSupportFields)

--- a/apidef/oas/oauth2.go
+++ b/apidef/oas/oauth2.go
@@ -4,9 +4,10 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
-// OAuth2 is the container for the new-style OAuth 2.0 security scheme.
-// It carries the master Enabled toggle and inherits the AuthSources
-// contract used by every Tyk security scheme.
+// OAuth2 is the container for the OAS-native OAuth 2.0 security scheme.
+// It holds the master Enabled toggle, the AuthSources inheritance from
+// the standard Tyk security-scheme contract, and optional sub-blocks
+// (currently ScopeCheck) that enable specific OAuth-flow features.
 //
 // Stored under
 // x-tyk-api-gateway.server.authentication.securitySchemes[name].
@@ -18,13 +19,101 @@ type OAuth2 struct {
 	// AuthSources configures where the bearer token is read from
 	// (Authorization header by default; cookie / query alternatives).
 	AuthSources `bson:",inline" json:",inline"`
+
+	// ScopeCheck enables OAS-native scope enforcement. See
+	// OAuth2ScopeCheck for the full configuration contract.
+	ScopeCheck *OAuth2ScopeCheck `bson:"scopeCheck,omitempty" json:"scopeCheck,omitempty"`
 }
 
+// OAuth2ScopeCheck holds OAS-native scope enforcement configuration.
+//
+// The required scopes themselves live in the OAS root `security:`
+// array (standard OpenAPI). Each entry in `security:` that lists this
+// scheme contributes one alternative; the scopes within an entry are
+// AND-required; multiple entries are OR. This sub-block carries only
+// the token-side knobs (where to read scopes from the JWT, which
+// alternatives to read) — it does not redeclare the scope policy.
+//
+// Tyk supports three enforcement modes via ScopeSource:
+//
+//   - "union" (default): per-operation `security:` ∪ root `security:`.
+//     With per-operation declarations empty, this collapses to the
+//     root-only model. With both set, every request must satisfy at
+//     least one alternative drawn from the combined set.
+//   - "operation": only the matched OAS operation's `security:` array
+//     drives the required-scope set; root `security:` is ignored.
+//   - "global": only the OAS root `security:` array applies, uniformly
+//     to every request on this API.
+type OAuth2ScopeCheck struct {
+	// Enabled toggles scope enforcement for this scheme. When false the
+	// scope-check sub-block is inert and the oauth2 scheme is treated as
+	// authentication-only.
+	Enabled bool `bson:"enabled" json:"enabled"`
+
+	// ClaimNames is the ordered list of JWT claim names to read scopes
+	// from. The gateway reads the value of every listed claim that is
+	// present on the token, parses each value into individual scopes
+	// (per Separator / JSON-array / comma-separated rules), and
+	// **merges** the results into one normalized scope set. The
+	// alternatives drawn from OAS `security:` are checked against the
+	// merged set — a scope is considered present if it appears in any
+	// listed claim.
+	//
+	// When ClaimNames is empty the gateway uses the default
+	// `["scope", "scp"]` so OAuth and OIDC tokens are both honored
+	// without operator config. There is no singular ClaimName field —
+	// callers always express the source as a list, even when it has
+	// one entry.
+	ClaimNames []string `bson:"claimNames,omitempty" json:"claimNames,omitempty"`
+
+	// Separator splits the claim's string value into individual
+	// scopes. Defaults to a single space (RFC 6749 §3.3). Set to ","
+	// for comma-separated IdPs.
+	Separator string `bson:"separator,omitempty" json:"separator,omitempty"`
+
+	// ScopeSource selects whether enforcement reads from per-operation
+	// `security:`, the OAS root `security:`, or both. Defaults to
+	// "union".
+	ScopeSource string `bson:"scopeSource,omitempty" json:"scopeSource,omitempty"`
+}
+
+// ScopeSource constants for OAuth2ScopeCheck.ScopeSource.
+const (
+	OAuth2ScopeSourceOperation = "operation"
+	OAuth2ScopeSourceGlobal    = "global"
+	OAuth2ScopeSourceUnion     = "union"
+)
+
+// Wire-protocol constants used in WWW-Authenticate challenges and JSON
+// failure bodies emitted by the oauth2 middleware.
+const (
+	// OAuth2ErrInsufficientScope is the RFC 6750 §3.1 error code
+	// returned when the token authenticated but lacks scopes required
+	// by the request.
+	OAuth2ErrInsufficientScope = "insufficient_scope"
+
+	// OAuth2ErrInvalidToken is the RFC 6750 §3.1 error code used when
+	// the token cannot be parsed or is otherwise unusable.
+	OAuth2ErrInvalidToken = "invalid_token"
+
+	// OAuth2AuthSchemeBearer is the authorization scheme prefix per
+	// RFC 6750 §2.1.
+	OAuth2AuthSchemeBearer = "Bearer"
+)
+
 // HasContent reports whether the OAuth2 block carries operator
-// configuration. With only the master toggle defined here, the toggle
-// state is the entire signal.
+// configuration. The master Enabled toggle qualifies, as does any
+// configured sub-block (e.g. scopeCheck). Sub-block presence lets the
+// map-probe disambiguator distinguish this scheme from a legacy OAuth
+// or ExternalOAuth scheme stored as a raw map.
 func (o *OAuth2) HasContent() bool {
-	return o != nil && o.Enabled
+	if o == nil {
+		return false
+	}
+	if o.Enabled {
+		return true
+	}
+	return o.ScopeCheck != nil
 }
 
 // IsEmpty is the inverse of HasContent. Used at fill time to decide
@@ -34,7 +123,9 @@ func (o *OAuth2) IsEmpty() bool {
 }
 
 // fillOAuth2 walks the configured Tyk security schemes and materialises
-// any pre-typed *OAuth2 entries into the public OAS document.
+// any *OAuth2 entries (typed or stored as a raw map after JSON round
+// trip) into the public OAS document. Raw maps are recognised by the
+// presence of an oauth2 sub-block key (see mapHasOAuth2SubBlock).
 func (s *OAS) fillOAuth2() {
 	tykAuth := s.getTykAuthentication()
 	if tykAuth == nil || tykAuth.SecuritySchemes == nil {
@@ -42,8 +133,8 @@ func (s *OAS) fillOAuth2() {
 	}
 
 	for name, scheme := range tykAuth.SecuritySchemes {
-		oauth2, ok := scheme.(*OAuth2)
-		if !ok {
+		oauth2 := asOAuth2Scheme(scheme)
+		if oauth2 == nil {
 			continue
 		}
 		if oauth2.IsEmpty() {
@@ -66,9 +157,54 @@ func (s *OAS) fillOAuth2() {
 	}
 }
 
-// fillOAuth2OASScheme materialises a minimal oauth2 OAS Components
-// entry for the named scheme with an empty
-// `flows.authorizationCode.scopes` map.
+// asOAuth2Scheme returns the typed *OAuth2 view of a raw security
+// scheme entry, or nil if the entry is not a OAS-native oauth2 scheme.
+// Distinguishing it from a legacy OAuth / ExternalOAuth map relies on
+// the presence of a sub-block key (e.g. scopeCheck). A raw
+// `{enabled:true}` map alone is shape-ambiguous with legacy schemes
+// and is not recognised here — operators who want the OAS-native oauth2
+// scheme must configure at least one sub-block.
+func asOAuth2Scheme(scheme interface{}) *OAuth2 {
+	if scheme == nil {
+		return nil
+	}
+	if v, ok := scheme.(*OAuth2); ok {
+		return v
+	}
+	m, ok := scheme.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	if !mapHasOAuth2SubBlock(m) {
+		return nil
+	}
+	out := &OAuth2{}
+	toStructIfMap(m, out)
+	return out
+}
+
+// mapHasOAuth2SubBlock reports whether a raw scheme map carries a
+// OAS-native oauth2 sub-block. Used by the map-probe disambiguator at
+// JSON round-trip time to distinguish the OAS-native scheme from a
+// legacy *OAuth map with no sub-blocks. Extend oauth2SubBlockKeys
+// when adding a sub-block — forgetting silently drops the typed view.
+func mapHasOAuth2SubBlock(m map[string]interface{}) bool {
+	for _, key := range oauth2SubBlockKeys {
+		if _, ok := m[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// oauth2SubBlockKeys lists the JSON keys that mark a raw scheme map
+// as a OAS-native oauth2 scheme.
+var oauth2SubBlockKeys = []string{
+	"scopeCheck",
+}
+
+// fillOAuth2OASScheme materialises the oauth2 OAS Components entry
+// for the named scheme.
 //
 // The OAS spec requires at least one flow on an oauth2 scheme, and
 // authorizationCode requires both authorizationUrl and tokenUrl. We
@@ -76,6 +212,12 @@ func (s *OAS) fillOAuth2() {
 // `https://example.com/…` URLs so the saved document doesn't claim
 // an unrelated host. Sub-blocks that bring real endpoints (token
 // exchange, introspection) override these at materialise time.
+//
+// The `flows.authorizationCode.scopes` vocabulary is aggregated from
+// every scope name referenced for this scheme by the OAS root
+// `security:` array, so the catalog stays consistent with what the
+// gateway enforces. Preserves any existing operator-supplied
+// descriptions.
 func (s *OAS) fillOAuth2OASScheme(name string, _ *OAuth2) {
 	if s.Components == nil {
 		s.Components = &openapi3.Components{}
@@ -83,6 +225,25 @@ func (s *OAS) fillOAuth2OASScheme(name string, _ *OAuth2) {
 	if s.Components.SecuritySchemes == nil {
 		s.Components.SecuritySchemes = make(openapi3.SecuritySchemes)
 	}
+
+	existing := map[string]string{}
+	if ref, ok := s.Components.SecuritySchemes[name]; ok && ref != nil && ref.Value != nil &&
+		ref.Value.Flows != nil && ref.Value.Flows.AuthorizationCode != nil {
+		for k, v := range ref.Value.Flows.AuthorizationCode.Scopes {
+			existing[k] = v
+		}
+	}
+
+	scopes := map[string]string{}
+	for _, req := range s.Security {
+		for _, sc := range req[name] {
+			if sc == "" {
+				continue
+			}
+			scopes[sc] = existing[sc]
+		}
+	}
+
 	s.Components.SecuritySchemes[name] = &openapi3.SecuritySchemeRef{
 		Value: &openapi3.SecurityScheme{
 			Type: typeOAuth2,
@@ -90,7 +251,7 @@ func (s *OAS) fillOAuth2OASScheme(name string, _ *OAuth2) {
 				AuthorizationCode: &openapi3.OAuthFlow{
 					AuthorizationURL: "/oauth/authorize",
 					TokenURL:         "/oauth/token",
-					Scopes:           map[string]string{},
+					Scopes:           scopes,
 				},
 			},
 		},
@@ -99,7 +260,12 @@ func (s *OAS) fillOAuth2OASScheme(name string, _ *OAuth2) {
 
 // GetTykOAuth2Config returns the typed *OAuth2 configuration for the
 // named security scheme, or nil when the scheme is not configured under
-// x-tyk-api-gateway as a new-style OAuth2 scheme.
+// x-tyk-api-gateway as an OAS-native OAuth2 scheme.
+//
+// When the scheme entry is still a raw map (post-JSON round-trip and
+// pre-fill), this method materialises the typed view via the same
+// map-probe used by fillOAuth2 and caches the typed value back into
+// the map so subsequent calls are O(1).
 func (s *OAS) GetTykOAuth2Config(name string) *OAuth2 {
 	tykAuth := s.getTykAuthentication()
 	if tykAuth == nil || tykAuth.SecuritySchemes == nil {
@@ -109,15 +275,18 @@ func (s *OAS) GetTykOAuth2Config(name string) *OAuth2 {
 	if !ok {
 		return nil
 	}
-	oauth2, ok := scheme.(*OAuth2)
-	if !ok {
+	oauth2 := asOAuth2Scheme(scheme)
+	if oauth2 == nil {
 		return nil
+	}
+	if _, alreadyTyped := scheme.(*OAuth2); !alreadyTyped {
+		tykAuth.SecuritySchemes[name] = oauth2
 	}
 	return oauth2
 }
 
 // IsOAuth2Scheme reports whether the named security scheme is a Tyk
-// new-style OAuth2 scheme.
+// OAS-native OAuth2 scheme.
 func (s *OAS) IsOAuth2Scheme(name string) bool {
 	return s.GetTykOAuth2Config(name) != nil
 }

--- a/apidef/oas/oauth2_test.go
+++ b/apidef/oas/oauth2_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/TykTechnologies/tyk/apidef"
 )
 
-// newOAuth2Fixture builds a minimal OAS document with the new oauth2
-// scheme configured with just the master Enabled toggle.
+// newOAuth2Fixture builds a minimal OAS document with the OAS-native
+// oauth2 scheme configured with just the master Enabled toggle.
 func newOAuth2Fixture(name string) *OAS {
 	s := &OAS{}
 	s.OpenAPI = "3.0.3"
@@ -74,8 +74,8 @@ func TestOAuth2_FillAddsOASComponentForEnabledScheme(t *testing.T) {
 // least one flow per the OAS spec, and authorizationCode requires both
 // authorizationUrl and tokenUrl — relative paths are used as
 // stand-in values so the saved document doesn't claim an external
-// "https://example.com/…" URL. Operator-configured endpoints (in
-// follow-up sub-blocks) will override these.
+// "https://example.com/…" URL. Operator-configured endpoints (from
+// sub-blocks that bring real endpoints) override these.
 func TestOAuth2_FillUsesRelativeURLPlaceholders(t *testing.T) {
 	s := newOAuth2Fixture("corpOAuth")
 	api := apidef.APIDefinition{AuthConfigs: map[string]apidef.AuthConfig{}}
@@ -118,11 +118,12 @@ func TestOAuth2_RoundTripJSONPreservesEnabled(t *testing.T) {
 	raw, err := json.Marshal(original)
 	require.NoError(t, err)
 
-	// On unmarshal, the Tyk extension comes back as a raw map until the
-	// OAS is reconstituted via NewOASFromBytes / Initialize. With only
-	// the master Enabled toggle set, the scheme is shape-ambiguous with
-	// a legacy OAuth scheme so no map-probe disambiguator recognises
-	// it; this test asserts on the on-the-wire JSON shape directly.
+	// On unmarshal, the Tyk extension comes back as a raw map until
+	// the OAS is reconstituted via NewOASFromBytes / Initialize. With
+	// only the master Enabled toggle set, the scheme is shape-ambiguous
+	// with a legacy OAuth scheme, so the map-probe disambiguator does
+	// not recognise it. This test asserts on the on-the-wire JSON
+	// shape directly.
 	assert.Contains(t, string(raw), `"corpOAuth":{"enabled":true}`,
 		"the Tyk extension should serialise the oauth2 scheme with master Enabled set under its scheme name")
 }
@@ -181,4 +182,135 @@ func TestOAuth2_FillOAuth2OASSchemeCreatesComponents(t *testing.T) {
 	ref, ok := s.Components.SecuritySchemes["corpOAuth"]
 	require.True(t, ok)
 	assert.Equal(t, typeOAuth2, ref.Value.Type)
+}
+
+func TestOAuth2_HasContentRecognisesScopeCheck(t *testing.T) {
+	// A scheme with Enabled=false but ScopeCheck configured still
+	// counts as "has content" so map-probe disambiguation can detect
+	// it as an OAS-native oauth2 scheme rather than a legacy OAuth one.
+	o := &OAuth2{ScopeCheck: &OAuth2ScopeCheck{Enabled: true}}
+	assert.True(t, o.HasContent())
+}
+
+// TestOAuth2_FillAggregatesFlowScopesFromRootSecurity pins that the
+// scope vocabulary on the materialised OAS scheme is aggregated from
+// every scope referenced for this scheme by the root `security:`
+// array. Operators declare required scopes once (in `security:`) and
+// OAS tooling sees the same vocabulary.
+func TestOAuth2_FillAggregatesFlowScopesFromRootSecurity(t *testing.T) {
+	s := newOAuth2Fixture("corpOAuth")
+	s.Security = openapi3.SecurityRequirements{
+		{"corpOAuth": []string{"read:billing", "write:billing"}},
+		{"corpOAuth": []string{"admin"}},
+	}
+
+	api := apidef.APIDefinition{AuthConfigs: map[string]apidef.AuthConfig{}}
+	s.fillSecurity(api)
+
+	ref := s.Components.SecuritySchemes["corpOAuth"]
+	require.NotNil(t, ref.Value.Flows)
+	require.NotNil(t, ref.Value.Flows.AuthorizationCode)
+	scopes := ref.Value.Flows.AuthorizationCode.Scopes
+	require.NotNil(t, scopes)
+	_, hasRead := scopes["read:billing"]
+	_, hasWrite := scopes["write:billing"]
+	_, hasAdmin := scopes["admin"]
+	assert.True(t, hasRead, "flows.scopes should contain read:billing from the first requirement")
+	assert.True(t, hasWrite, "flows.scopes should contain write:billing from the first requirement")
+	assert.True(t, hasAdmin, "flows.scopes should contain admin from the second requirement")
+}
+
+// TestOAuth2_FillPreservesExistingScopeDescriptions pins that operator-
+// authored scope descriptions on the OAS scheme survive fill — only
+// the scope-name set is reconciled with `security:`.
+func TestOAuth2_FillPreservesExistingScopeDescriptions(t *testing.T) {
+	s := newOAuth2Fixture("corpOAuth")
+	s.Components = &openapi3.Components{
+		SecuritySchemes: openapi3.SecuritySchemes{
+			"corpOAuth": &openapi3.SecuritySchemeRef{
+				Value: &openapi3.SecurityScheme{
+					Type: typeOAuth2,
+					Flows: &openapi3.OAuthFlows{
+						AuthorizationCode: &openapi3.OAuthFlow{
+							AuthorizationURL: "/oauth/authorize",
+							TokenURL:         "/oauth/token",
+							Scopes: map[string]string{
+								"read:billing": "Read billing records",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	s.Security = openapi3.SecurityRequirements{
+		{"corpOAuth": []string{"read:billing", "admin"}},
+	}
+
+	api := apidef.APIDefinition{AuthConfigs: map[string]apidef.AuthConfig{}}
+	s.fillSecurity(api)
+
+	scopes := s.Components.SecuritySchemes["corpOAuth"].Value.Flows.AuthorizationCode.Scopes
+	assert.Equal(t, "Read billing records", scopes["read:billing"], "existing description should survive fill")
+	assert.Equal(t, "", scopes["admin"], "newly added scope gets an empty description")
+}
+
+func TestOAuth2ScopeCheck_RoundTripJSONPreservesAllFields(t *testing.T) {
+	original := newOAuth2Fixture("corpOAuth")
+	cfg := original.GetTykExtension().Server.Authentication.SecuritySchemes["corpOAuth"].(*OAuth2)
+	cfg.ScopeCheck = &OAuth2ScopeCheck{
+		Enabled:     true,
+		ClaimNames:  []string{"scope", "scp", "permissions"},
+		Separator:   ",",
+		ScopeSource: OAuth2ScopeSourceUnion,
+	}
+
+	raw, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	// scopeCheck serialises every token-side field operator-set.
+	// Required scopes live in OAS root `security:`, not on the scheme.
+	str := string(raw)
+	assert.Contains(t, str, `"scopeCheck"`)
+	assert.Contains(t, str, `"claimNames":["scope","scp","permissions"]`)
+	assert.Contains(t, str, `"separator":","`)
+	assert.Contains(t, str, `"scopeSource":"union"`)
+	assert.NotContains(t, str, `"scopes":[[`, "scopeCheck must not carry a scopes array — required scopes live in OAS root security:")
+}
+
+// TestOAuth2_FillExtractPreservesSchemeNameVerbatim pins the contract
+// that the scheme name (the key under components.securitySchemes and
+// the Tyk extension securitySchemes map) is treated as opaque data
+// and round-trips byte-for-byte. The contract is name-agnostic per
+// the OpenAPI 3.x spec, so dashes, mixed casing, and prefix-like
+// substrings of "oauth2" must all survive without normalisation.
+// Pair with the gateway side `TestOAuth2Middleware_NameAgnostic`.
+func TestOAuth2_FillExtractPreservesSchemeNameVerbatim(t *testing.T) {
+	const exotic = "Prct-OAuth2-Edge_42"
+
+	s := newOAuth2Fixture(exotic)
+	cfg := s.GetTykExtension().Server.Authentication.SecuritySchemes[exotic].(*OAuth2)
+	cfg.ScopeCheck = &OAuth2ScopeCheck{
+		Enabled:     true,
+		ScopeSource: OAuth2ScopeSourceGlobal,
+	}
+
+	api := apidef.APIDefinition{AuthConfigs: map[string]apidef.AuthConfig{}}
+	s.fillSecurity(api)
+
+	// Fill side: the OAS Components and root security: reference the
+	// scheme under the exotic name exactly.
+	require.NotNil(t, s.Components, "components should be created during fill")
+	_, ok := s.Components.SecuritySchemes[exotic]
+	assert.True(t, ok, "expected fill to materialise components.securitySchemes[%q]", exotic)
+
+	require.NotEmpty(t, s.Security, "fill should add a root security: requirement")
+	_, ok = s.Security[0][exotic]
+	assert.True(t, ok, "expected root security[0] to reference %q", exotic)
+
+	// No accidental normalisation — neither lowercased nor stripped.
+	for _, alias := range []string{"oauth2", "prct-oauth2-edge_42", "Prct-OAuth2-Edge42"} {
+		_, found := s.Components.SecuritySchemes[alias]
+		assert.False(t, found, "fill must not materialise an aliased name %q", alias)
+	}
 }

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -1908,10 +1908,22 @@
       "type": "object",
       "description": "OAuth 2.0 security scheme container.",
       "properties": {
-        "enabled": { "type": "boolean" },
-        "header":  { "$ref": "#/definitions/X-Tyk-AuthSource" },
-        "cookie":  { "$ref": "#/definitions/X-Tyk-AuthSource" },
-        "query":   { "$ref": "#/definitions/X-Tyk-AuthSource" }
+        "enabled":    { "type": "boolean" },
+        "header":     { "$ref": "#/definitions/X-Tyk-AuthSource" },
+        "cookie":     { "$ref": "#/definitions/X-Tyk-AuthSource" },
+        "query":      { "$ref": "#/definitions/X-Tyk-AuthSource" },
+        "scopeCheck": { "$ref": "#/definitions/X-Tyk-OAuth2-ScopeCheck" }
+      },
+      "required": ["enabled"]
+    },
+    "X-Tyk-OAuth2-ScopeCheck": {
+      "type": "object",
+      "description": "Token-side knobs for OAS-native scope enforcement. Required scopes themselves live in the OAS root security: array.",
+      "properties": {
+        "enabled":        { "type": "boolean" },
+        "claimNames":     { "type": "array", "items": { "type": "string" }, "description": "Ordered list of JWT claim names to read scopes from. The gateway reads each listed claim that is present and merges all scope values into one set. Alternatives drawn from OAS root security: are checked against this merged set. Defaults to [\"scope\", \"scp\"] when unset." },
+        "separator":      { "type": "string" },
+        "scopeSource":    { "type": "string", "enum": ["operation", "global", "union"], "description": "Selects whether enforcement reads per-operation security:, root security:, or both. Defaults to \"union\"." }
       },
       "required": ["enabled"]
     },

--- a/apidef/oas/schema/x-tyk-api-gateway.strict.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.strict.json
@@ -2022,6 +2022,41 @@
         },
         "query": {
           "$ref": "#/definitions/X-Tyk-AuthSource"
+        },
+        "scopeCheck": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-ScopeCheck"
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "additionalProperties": false
+    },
+    "X-Tyk-OAuth2-ScopeCheck": {
+      "type": "object",
+      "description": "Token-side knobs for OAS-native scope enforcement. Required scopes themselves live in the OAS root security: array.",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "claimNames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Ordered list of JWT claim names to read scopes from. The gateway reads each listed claim that is present and merges all scope values into one set. Alternatives drawn from OAS root security: are checked against this merged set. Defaults to [\"scope\", \"scp\"] when unset."
+        },
+        "separator": {
+          "type": "string"
+        },
+        "scopeSource": {
+          "type": "string",
+          "enum": [
+            "operation",
+            "global",
+            "union"
+          ],
+          "description": "Selects whether enforcement reads per-operation security:, root security:, or both. Defaults to \"union\"."
         }
       },
       "required": [

--- a/apidef/oas/security.go
+++ b/apidef/oas/security.go
@@ -1089,6 +1089,15 @@ func (s *OAS) fillSecurity(api apidef.APIDefinition) {
 		s.GetTykExtension().Server.Authentication = tykAuthentication
 	}
 
+	// SecurityRequirementScopes is the source of truth for OAS root
+	// security: shape. Mongo's omitempty semantics don't clear stored
+	// fields when an update sends nil, so a prior multi-requirement
+	// extract can leave SecurityRequirements at a stale length even
+	// after the operator shrinks the policy. Normalize here so fill
+	// emits exactly the alternatives the operator declared on the
+	// most recent save.
+	api.SecurityRequirements = normalizeSecurityRequirements(api.SecurityRequirements, api.SecurityRequirementScopes)
+
 	// Detect existing contract before Fill to preserve backwards compatibility
 	// Old contract: token.enableClientCertificate; New contract: certificateAuth.enabled
 	tokenSchemeName := api.AuthConfigs[apidef.AuthTokenType].Name
@@ -1132,7 +1141,7 @@ func (s *OAS) fillSecurity(api apidef.APIDefinition) {
 		vendorSecurity := [][]string{}
 
 		if len(api.SecurityRequirements) > 0 {
-			for _, requirement := range api.SecurityRequirements {
+			for i, requirement := range api.SecurityRequirements {
 				hasProprietaryAuth := false
 				hasStandardAuth := false
 				oasReq := openapi3.NewSecurityRequirement()
@@ -1145,7 +1154,7 @@ func (s *OAS) fillSecurity(api apidef.APIDefinition) {
 						vendorReq = append(vendorReq, schemeName)
 					} else {
 						hasStandardAuth = true
-						oasReq[schemeName] = []string{}
+						oasReq[schemeName] = s.requirementScopes(api.SecurityRequirementScopes, i, schemeName)
 					}
 				}
 
@@ -1186,7 +1195,7 @@ func (s *OAS) fillSecurity(api apidef.APIDefinition) {
 			s.Security = make(openapi3.SecurityRequirements, 0, len(api.SecurityRequirements))
 			vendorSecurity := [][]string{}
 
-			for _, requirement := range api.SecurityRequirements {
+			for i, requirement := range api.SecurityRequirements {
 				secReq := openapi3.NewSecurityRequirement()
 				vendorReq := []string{}
 
@@ -1194,7 +1203,7 @@ func (s *OAS) fillSecurity(api apidef.APIDefinition) {
 					if s.isProprietaryAuthScheme(schemeName) {
 						vendorReq = append(vendorReq, schemeName)
 					} else {
-						secReq[schemeName] = []string{}
+						secReq[schemeName] = s.requirementScopes(api.SecurityRequirementScopes, i, schemeName)
 					}
 				}
 
@@ -1210,12 +1219,14 @@ func (s *OAS) fillSecurity(api apidef.APIDefinition) {
 				tykAuthentication.Security = vendorSecurity
 			}
 		} else if len(tykAuthentication.SecuritySchemes) > 0 {
-			// When no explicit requirements, create from schemes
-			// Only add non-proprietary schemes to OAS security
+			// When no explicit requirements, create from schemes. Restore
+			// per-scheme scope arrays from the single-requirement entry in
+			// SecurityRequirementScopes when present so legacy-mode APIs
+			// with one OAS Security Requirement still round-trip scopes.
 			secReq := openapi3.NewSecurityRequirement()
 			for name := range tykAuthentication.SecuritySchemes {
 				if !s.isProprietaryAuthScheme(name) {
-					secReq[name] = []string{}
+					secReq[name] = s.requirementScopes(api.SecurityRequirementScopes, 0, name)
 				}
 			}
 			if len(secReq) > 0 {
@@ -1249,6 +1260,13 @@ func (s *OAS) extractSecurityTo(api *apidef.APIDefinition) {
 		api.AuthConfigs = make(map[string]apidef.AuthConfig)
 	}
 
+	// The OAS document is the source of truth for these two fields.
+	// Reset before rebuilding so a removed security: block clears
+	// prior state instead of inheriting it from the API definition
+	// the dashboard hydrated from storage.
+	api.SecurityRequirements = nil
+	api.SecurityRequirementScopes = nil
+
 	// Extract security requirements based on processing mode (OAS-only feature)
 	processingMode := SecurityProcessingModeLegacy
 	tykAuth := s.getTykAuthentication()
@@ -1269,25 +1287,54 @@ func (s *OAS) extractSecurityTo(api *apidef.APIDefinition) {
 	if processingMode == SecurityProcessingModeCompliant {
 		// Concatenate OAS security with vendor extension security
 		api.SecurityRequirements = make([][]string, 0)
+		scopesAccum := make([]map[string][]string, 0)
 
 		// Identify standard auth schemes that appear in mixed vendor requirements
 		// to avoid duplicating them in OAS security
 		mixedVendorSchemes := s.identifyMixedVendorAuthSchemes()
 
 		// Add OAS security requirements, filtering out duplicates
-		s.appendFilteredOASSecurityRequirements(&api.SecurityRequirements, mixedVendorSchemes)
+		s.appendFilteredOASSecurityRequirements(&api.SecurityRequirements, &scopesAccum, mixedVendorSchemes)
 
 		// Add vendor extension security requirements
-		s.appendVendorSecurityRequirements(&api.SecurityRequirements)
+		s.appendVendorSecurityRequirements(&api.SecurityRequirements, &scopesAccum)
+
+		api.SecurityRequirementScopes = scopesAccum
 	} else if len(s.Security) > 1 {
 		api.SecurityRequirements = make([][]string, 0, len(s.Security))
+		scopesAccum := make([]map[string][]string, 0, len(s.Security))
 		for _, requirement := range s.Security {
 			schemes := make([]string, 0, len(requirement))
-			for schemeName := range requirement {
+			scopes := make(map[string][]string, len(requirement))
+			for schemeName, schemeScopes := range requirement {
 				schemes = append(schemes, schemeName)
+				scopes[schemeName] = append([]string{}, schemeScopes...)
 			}
 			api.SecurityRequirements = append(api.SecurityRequirements, schemes)
+			scopesAccum = append(scopesAccum, scopes)
 		}
+		api.SecurityRequirementScopes = scopesAccum
+	} else if len(s.Security) == 1 {
+		requirement := s.Security[0]
+		scopes := make(map[string][]string, len(requirement))
+		schemes := make([]string, 0, len(requirement))
+		for schemeName, schemeScopes := range requirement {
+			schemes = append(schemes, schemeName)
+			scopes[schemeName] = append([]string{}, schemeScopes...)
+		}
+		if len(requirement) > 1 {
+			// Multi-scheme single requirement: enumerate every scheme in
+			// SecurityRequirements so fill emits the same AND shape.
+			// normalizeSecurityRequirements would otherwise drop schemes
+			// with empty scopes by rebuilding from scope-map keys alone.
+			api.SecurityRequirements = [][]string{schemes}
+		} else {
+			// Single-scheme single requirement: fill rebuilds via the
+			// scheme's own appendSecurity call, so SecurityRequirements
+			// stays nil.
+			api.SecurityRequirements = nil
+		}
+		api.SecurityRequirementScopes = []map[string][]string{scopes}
 	}
 
 	// Process security requirements based on processing mode:
@@ -1366,6 +1413,17 @@ func (s *OAS) extractSecurityTo(api *apidef.APIDefinition) {
 					case v.Type == typeOAuth2:
 						securityScheme := s.getTykSecurityScheme(schemeName)
 						if securityScheme == nil {
+							continue
+						}
+
+						// The new oauth2 scheme is OAS-native and has no
+						// classic extraction; the gateway middleware reads
+						// it from OAS directly. Promote a raw-map entry to
+						// the typed view here so subsequent OAS reads (and
+						// the marshal-back-to-DB step) see the same shape,
+						// and skip the legacy OAuth / ExternalOAuth fallback.
+						if oauth2 := asOAuth2Scheme(securityScheme); oauth2 != nil {
+							s.getTykSecuritySchemes()[schemeName] = oauth2
 							continue
 						}
 
@@ -1751,13 +1809,15 @@ func (s *OAS) identifyMixedVendorAuthSchemes() map[string]bool {
 // skipping any single-scheme requirements that are already part of mixed vendor requirements.
 // This prevents duplication when a scheme like "jwtAuth" appears both in OAS security
 // as a single requirement and in vendor security as part of a mixed requirement.
-func (s *OAS) appendFilteredOASSecurityRequirements(apiSecurityReqs *[][]string, mixedVendorSchemes map[string]bool) {
+func (s *OAS) appendFilteredOASSecurityRequirements(apiSecurityReqs *[][]string, apiSecurityScopes *[]map[string][]string, mixedVendorSchemes map[string]bool) {
 	for _, requirement := range s.Security {
 		schemes := make([]string, 0, len(requirement))
+		scopes := make(map[string][]string, len(requirement))
 		skip := false
 
-		for schemeName := range requirement {
+		for schemeName, schemeScopes := range requirement {
 			schemes = append(schemes, schemeName)
+			scopes[schemeName] = append([]string{}, schemeScopes...)
 			// Skip single-scheme requirements that are in mixed vendor requirements
 			if len(requirement) == 1 && mixedVendorSchemes[schemeName] {
 				skip = true
@@ -1767,15 +1827,84 @@ func (s *OAS) appendFilteredOASSecurityRequirements(apiSecurityReqs *[][]string,
 
 		if !skip {
 			*apiSecurityReqs = append(*apiSecurityReqs, schemes)
+			*apiSecurityScopes = append(*apiSecurityScopes, scopes)
 		}
 	}
 }
 
+// normalizeSecurityRequirements realigns SecurityRequirements when it
+// disagrees with SecurityRequirementScopes on the alternative count
+// — the case where the operator shrinks a multi-requirement policy
+// down to fewer alternatives and a stale SecurityRequirements value
+// would otherwise leak through fill as extra empty alternatives.
+//
+// The helper only enriches an existing requirement list. When the
+// list is empty it returns nil unchanged: a stale scope map must not
+// be allowed to manufacture a requirement that the current OAS no
+// longer declares, otherwise a single leftover scope entry would
+// resurrect a deleted scheme on the next fill.
+func normalizeSecurityRequirements(reqs [][]string, scopes []map[string][]string) [][]string {
+	if len(reqs) == 0 || len(scopes) == 0 || len(reqs) == len(scopes) {
+		return reqs
+	}
+	out := make([][]string, 0, len(scopes))
+	for _, scopeMap := range scopes {
+		schemes := make([]string, 0, len(scopeMap))
+		for name := range scopeMap {
+			schemes = append(schemes, name)
+		}
+		out = append(out, schemes)
+	}
+	return out
+}
+
+// requirementScopes returns the scope array to emit on the OAS Security
+// Requirement Object for the named scheme at requirement index i. OAS 3.0
+// §4.8.30.1 restricts non-empty scope arrays to oauth2 and openIdConnect
+// schemes; anything else round-trips with an empty array even if upstream
+// data nominally carries scopes. When SecurityRequirementScopes is empty
+// or has no entry for this scheme/index, an empty array is returned —
+// matching the contract of every other auth scheme that has no scope
+// concept.
+func (s *OAS) requirementScopes(scopes []map[string][]string, i int, schemeName string) []string {
+	if !s.schemeUsesScopes(schemeName) {
+		return []string{}
+	}
+	if i < 0 || i >= len(scopes) {
+		return []string{}
+	}
+	out := scopes[i][schemeName]
+	if out == nil {
+		return []string{}
+	}
+	return append([]string{}, out...)
+}
+
+// schemeUsesScopes reports whether the OAS security scheme with the given
+// name is an oauth2 or openIdConnect scheme, the only two types for which
+// OAS permits non-empty scope arrays on a Security Requirement Object.
+func (s *OAS) schemeUsesScopes(schemeName string) bool {
+	if s.Components == nil || s.Components.SecuritySchemes == nil {
+		return false
+	}
+	ref, ok := s.Components.SecuritySchemes[schemeName]
+	if !ok || ref == nil || ref.Value == nil {
+		return false
+	}
+	return ref.Value.Type == typeOAuth2 || ref.Value.Type == "openIdConnect"
+}
+
 // appendVendorSecurityRequirements adds vendor extension security requirements
-// to the API definition if they exist.
-func (s *OAS) appendVendorSecurityRequirements(apiSecurityReqs *[][]string) {
+// to the API definition if they exist. Vendor entries do not carry OAS scope
+// arrays, so an empty scope map is appended to keep index-alignment with the
+// scheme-name slice.
+func (s *OAS) appendVendorSecurityRequirements(apiSecurityReqs *[][]string, apiSecurityScopes *[]map[string][]string) {
 	tykAuth := s.getTykAuthentication()
-	if tykAuth != nil && len(tykAuth.Security) > 0 {
-		*apiSecurityReqs = append(*apiSecurityReqs, tykAuth.Security...)
+	if tykAuth == nil {
+		return
+	}
+	for _, vendorReq := range tykAuth.Security {
+		*apiSecurityReqs = append(*apiSecurityReqs, vendorReq)
+		*apiSecurityScopes = append(*apiSecurityScopes, map[string][]string{})
 	}
 }

--- a/apidef/oas/security_test.go
+++ b/apidef/oas/security_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/TykTechnologies/tyk/apidef"
 )
@@ -106,7 +107,13 @@ func TestOAS_Security(t *testing.T) {
 	var convertedAPI apidef.APIDefinition // bundle enabled
 	oas.extractSecurityTo(&convertedAPI)
 
+	// SecurityRequirements / SecurityRequirementScopes mirror the OAS
+	// shape; fill builds an empty-scope requirement for every scheme
+	// in AuthConfigs, so the round-trip from a bare api into one with
+	// security context is asymmetric by design. Reset the two fields
+	// to compare the rest of the definition.
 	convertedAPI.SecurityRequirements = nil
+	convertedAPI.SecurityRequirementScopes = nil
 	assert.Equal(t, api, convertedAPI)
 }
 
@@ -1123,7 +1130,10 @@ func TestOAS_extractSecurityTo_ORLogic(t *testing.T) {
 		var api apidef.APIDefinition
 		oas.extractSecurityTo(&api)
 
-		assert.Nil(t, api.SecurityRequirements)
+		// Single requirement (AND): both schemes must appear in the one
+		// requirement entry so fill can re-emit them on round-trip.
+		require.Len(t, api.SecurityRequirements, 1)
+		assert.ElementsMatch(t, []string{"token-auth", "jwt-auth"}, api.SecurityRequirements[0])
 	})
 
 	t.Run("should handle empty Security", func(t *testing.T) {
@@ -1500,8 +1510,595 @@ func TestOAS_SecurityRequirements_RoundTrip(t *testing.T) {
 		var extractedAPI apidef.APIDefinition
 		oas.extractSecurityTo(&extractedAPI)
 
-		// Single requirement (AND logic) doesn't need explicit SecurityRequirements
-		assert.Nil(t, extractedAPI.SecurityRequirements)
+		// Single requirement (AND): SecurityRequirements lists every
+		// scheme in that one entry — fill needs this to preserve all
+		// schemes through the round-trip (without it, schemes with
+		// empty scopes get dropped by normalizeSecurityRequirements).
+		require.Len(t, extractedAPI.SecurityRequirements, 1)
+		assert.ElementsMatch(t, []string{"token-auth", "jwt-auth"}, extractedAPI.SecurityRequirements[0])
+	})
+}
+
+// TestOAS_SecurityScopes_RoundTrip pins that OAS Security Requirement
+// Objects preserve per-scheme scope arrays end-to-end through the
+// extract→fill cycle. The oauth2 scope-check middleware reads these
+// scopes from the OAS document to enforce required-scope coverage,
+// so dropping them would silently turn enforcement into a no-op.
+func TestOAS_SecurityScopes_RoundTrip(t *testing.T) {
+	buildOAS := func() OAS {
+		o := OAS{}
+		o.OpenAPI = "3.0.3"
+		o.Info = &openapi3.Info{Title: "scope-roundtrip", Version: "1.0"}
+		o.Paths = openapi3.NewPaths()
+		o.Components = &openapi3.Components{
+			SecuritySchemes: openapi3.SecuritySchemes{
+				"corpOAuth": &openapi3.SecuritySchemeRef{
+					Value: &openapi3.SecurityScheme{
+						Type: typeOAuth2,
+						Flows: &openapi3.OAuthFlows{
+							AuthorizationCode: &openapi3.OAuthFlow{
+								AuthorizationURL: "/oauth/authorize",
+								TokenURL:         "/oauth/token",
+								Scopes:           map[string]string{},
+							},
+						},
+					},
+				},
+				"jwtAuth": &openapi3.SecuritySchemeRef{
+					Value: &openapi3.SecurityScheme{
+						Type:         "http",
+						Scheme:       "bearer",
+						BearerFormat: "JWT",
+					},
+				},
+			},
+		}
+		o.Security = openapi3.SecurityRequirements{
+			{"jwtAuth": []string{}, "corpOAuth": []string{"api:access", "users:read"}},
+			{"jwtAuth": []string{}, "corpOAuth": []string{"admin"}},
+		}
+		o.SetTykExtension(&XTykAPIGateway{
+			Server: Server{
+				Authentication: &Authentication{
+					Enabled: true,
+					SecuritySchemes: SecuritySchemes{
+						"jwtAuth":   &JWT{Enabled: true, AuthSources: AuthSources{Header: &AuthSource{Enabled: true, Name: "Authorization"}}, SigningMethod: "rsa", Source: "anything", IdentityBaseField: "sub"},
+						"corpOAuth": &OAuth2{Enabled: true, ScopeCheck: &OAuth2ScopeCheck{Enabled: true, ScopeSource: OAuth2ScopeSourceGlobal}},
+					},
+				},
+			},
+		})
+		return o
+	}
+
+	t.Run("scopes survive extract→fill on an oauth2 scheme", func(t *testing.T) {
+		original := buildOAS()
+		var api apidef.APIDefinition
+		original.extractSecurityTo(&api)
+
+		require.NotEmpty(t, api.SecurityRequirementScopes,
+			"extractSecurityTo must populate SecurityRequirementScopes so scope arrays survive the round-trip")
+		require.Len(t, api.SecurityRequirementScopes, 2)
+		assert.Equal(t, []string{"api:access", "users:read"}, api.SecurityRequirementScopes[0]["corpOAuth"])
+		assert.Equal(t, []string{"admin"}, api.SecurityRequirementScopes[1]["corpOAuth"])
+
+		// Now fill back into a fresh OAS — the scope arrays must reappear verbatim.
+		var rebuilt OAS
+		rebuilt.OpenAPI = "3.0.3"
+		rebuilt.Info = &openapi3.Info{Title: "scope-roundtrip", Version: "1.0"}
+		rebuilt.Paths = openapi3.NewPaths()
+		rebuilt.Components = &openapi3.Components{SecuritySchemes: openapi3.SecuritySchemes{
+			"corpOAuth": original.Components.SecuritySchemes["corpOAuth"],
+			"jwtAuth":   original.Components.SecuritySchemes["jwtAuth"],
+		}}
+		rebuilt.SetTykExtension(&XTykAPIGateway{
+			Server: Server{Authentication: original.GetTykExtension().Server.Authentication},
+		})
+		rebuilt.fillSecurity(api)
+
+		require.Len(t, rebuilt.Security, 2,
+			"fillSecurity must emit one OAS Security Requirement per extracted requirement")
+		assert.Equal(t, []string{"api:access", "users:read"}, rebuilt.Security[0]["corpOAuth"],
+			"first alternative must restore its full scope array — losing scopes turns scope-check into a no-op")
+		assert.Equal(t, []string{"admin"}, rebuilt.Security[1]["corpOAuth"],
+			"second alternative must restore its scope")
+	})
+
+	t.Run("non-oauth schemes get empty scope arrays per OAS spec", func(t *testing.T) {
+		// OAS 3.0 §4.8.30.1: the scope list MUST be empty for security
+		// schemes other than oauth2 / openIdConnect. Even if upstream
+		// data nominally carries scopes for a JWT scheme, fill must
+		// emit the empty array.
+		original := buildOAS()
+		var api apidef.APIDefinition
+		original.extractSecurityTo(&api)
+
+		var rebuilt OAS
+		rebuilt.OpenAPI = "3.0.3"
+		rebuilt.Info = &openapi3.Info{Title: "scope-roundtrip", Version: "1.0"}
+		rebuilt.Paths = openapi3.NewPaths()
+		rebuilt.Components = &openapi3.Components{SecuritySchemes: openapi3.SecuritySchemes{
+			"corpOAuth": original.Components.SecuritySchemes["corpOAuth"],
+			"jwtAuth":   original.Components.SecuritySchemes["jwtAuth"],
+		}}
+		rebuilt.SetTykExtension(&XTykAPIGateway{
+			Server: Server{Authentication: original.GetTykExtension().Server.Authentication},
+		})
+		rebuilt.fillSecurity(api)
+
+		assert.Equal(t, []string{}, rebuilt.Security[0]["jwtAuth"],
+			"jwt scheme must emit an empty scope array — OAS forbids scopes on non-oauth schemes")
+	})
+
+	t.Run("legacy data without SecurityRequirementScopes falls back to empty scope arrays", func(t *testing.T) {
+		// Forward-compat: APIDefinition records written before this
+		// field existed have only SecurityRequirements set. Fill must
+		// still produce a valid OAS document (with empty scope arrays)
+		// rather than panic or drop the requirement entirely.
+		api := apidef.APIDefinition{
+			SecurityRequirements: [][]string{
+				{"jwtAuth", "corpOAuth"},
+			},
+		}
+		var rebuilt OAS
+		rebuilt.OpenAPI = "3.0.3"
+		rebuilt.Info = &openapi3.Info{Title: "legacy", Version: "1.0"}
+		rebuilt.Paths = openapi3.NewPaths()
+		rebuilt.Components = &openapi3.Components{SecuritySchemes: openapi3.SecuritySchemes{
+			"corpOAuth": &openapi3.SecuritySchemeRef{Value: &openapi3.SecurityScheme{Type: typeOAuth2,
+				Flows: &openapi3.OAuthFlows{AuthorizationCode: &openapi3.OAuthFlow{AuthorizationURL: "/oauth/authorize", TokenURL: "/oauth/token", Scopes: map[string]string{}}}}},
+			"jwtAuth": &openapi3.SecuritySchemeRef{Value: &openapi3.SecurityScheme{Type: "http", Scheme: "bearer"}},
+		}}
+		rebuilt.SetTykExtension(&XTykAPIGateway{
+			Server: Server{Authentication: &Authentication{
+				Enabled: true,
+				SecuritySchemes: SecuritySchemes{
+					"jwtAuth":   &JWT{Enabled: true},
+					"corpOAuth": &OAuth2{Enabled: true, ScopeCheck: &OAuth2ScopeCheck{Enabled: true}},
+				},
+			}},
+		})
+		require.NotPanics(t, func() { rebuilt.fillSecurity(api) })
+
+		require.Len(t, rebuilt.Security, 1)
+		assert.Equal(t, []string{}, rebuilt.Security[0]["jwtAuth"])
+		assert.Equal(t, []string{}, rebuilt.Security[0]["corpOAuth"])
+	})
+}
+
+// TestOAS_SecurityScopes_StalePersistence pins that extractSecurityTo
+// always reflects the current OAS Security shape — never a stale value
+// inherited from the APIDefinition it is writing into. The dashboard
+// hydrates the APIDefinition from Mongo before applying the operator's
+// edit, so SecurityRequirements and SecurityRequirementScopes both
+// carry the previous state on entry. Combined with bson:",omitempty",
+// any code path that fails to overwrite these fields lets a prior
+// value persist on disk and surface as enforced scopes the operator
+// just deleted.
+func TestOAS_SecurityScopes_StalePersistence(t *testing.T) {
+	// oauth2-only security scheme — keeps the test focused on the
+	// scope-array contract that the new SecurityRequirementScopes
+	// field is supposed to preserve.
+	buildOAS := func(security openapi3.SecurityRequirements) OAS {
+		o := OAS{}
+		o.OpenAPI = "3.0.3"
+		o.Info = &openapi3.Info{Title: "stale-scopes", Version: "1.0"}
+		o.Paths = openapi3.NewPaths()
+		o.Components = &openapi3.Components{
+			SecuritySchemes: openapi3.SecuritySchemes{
+				"corpOAuth": &openapi3.SecuritySchemeRef{
+					Value: &openapi3.SecurityScheme{
+						Type: typeOAuth2,
+						Flows: &openapi3.OAuthFlows{
+							AuthorizationCode: &openapi3.OAuthFlow{
+								AuthorizationURL: "/oauth/authorize",
+								TokenURL:         "/oauth/token",
+								Scopes:           map[string]string{},
+							},
+						},
+					},
+				},
+				"jwtAuth": &openapi3.SecuritySchemeRef{
+					Value: &openapi3.SecurityScheme{
+						Type: "http", Scheme: "bearer", BearerFormat: "JWT",
+					},
+				},
+			},
+		}
+		o.Security = security
+		o.SetTykExtension(&XTykAPIGateway{
+			Server: Server{
+				Authentication: &Authentication{
+					Enabled: true,
+					SecuritySchemes: SecuritySchemes{
+						"corpOAuth": &OAuth2{Enabled: true, ScopeCheck: &OAuth2ScopeCheck{Enabled: true, ScopeSource: OAuth2ScopeSourceGlobal}},
+						"jwtAuth":   &JWT{Enabled: true, AuthSources: AuthSources{Header: &AuthSource{Enabled: true, Name: "Authorization"}}, SigningMethod: "rsa", Source: "anything", IdentityBaseField: "sub"},
+					},
+				},
+			},
+		})
+		return o
+	}
+
+	// Scenario C — single-scheme, single-requirement: operator clears
+	// the scope from ["api:access"] to []. With the bug, the
+	// single-requirement branch assigns nil when scopes are empty;
+	// bson:",omitempty" then drops the field from the update payload
+	// and the stale stored value persists on disk.
+	t.Run("single-scheme single-requirement: cleared scope must not retain stale value", func(t *testing.T) {
+		original := buildOAS(openapi3.SecurityRequirements{
+			{"corpOAuth": []string{}},
+		})
+		api := apidef.APIDefinition{
+			SecurityRequirementScopes: []map[string][]string{
+				{"corpOAuth": {"api:access"}},
+			},
+		}
+
+		original.extractSecurityTo(&api)
+
+		require.Len(t, api.SecurityRequirementScopes, 1,
+			"extract must emit an explicit scope entry for the current OAS Security Requirement so the serialized payload overwrites any stale stored value")
+		assert.Empty(t, api.SecurityRequirementScopes[0]["corpOAuth"],
+			"scope was cleared in the OAS; the rebuilt scope map must reflect that — never the prior ['api:access']")
+	})
+
+	// Scenario E — operator removes the security block entirely. The
+	// stored APIDefinition still carries SecurityRequirementScopes from
+	// the previous save; without an explicit reset at the top of
+	// extractSecurityTo, the no-security early-return leaves that
+	// stale field untouched.
+	t.Run("security block removed: stale scopes must be cleared", func(t *testing.T) {
+		original := buildOAS(nil)
+		api := apidef.APIDefinition{
+			SecurityRequirements: [][]string{{"corpOAuth"}},
+			SecurityRequirementScopes: []map[string][]string{
+				{"corpOAuth": {"api:access"}},
+			},
+		}
+
+		original.extractSecurityTo(&api)
+
+		assert.Empty(t, api.SecurityRequirements,
+			"removing the OAS security block must clear SecurityRequirements")
+		assert.Empty(t, api.SecurityRequirementScopes,
+			"removing the OAS security block must clear SecurityRequirementScopes; otherwise the prior policy persists on disk")
+	})
+
+	// Scenario G — multi-requirement, lengths still match but every
+	// scope array is now empty. The reviewer's worst case: today the
+	// anyRequirementHasScopes guard skips the assignment when all
+	// scopes are empty, so stale per-alternative scopes are preserved
+	// on disk while the in-memory normalize helper cannot detect the
+	// mismatch.
+	t.Run("multi-requirement scopes cleared: stale per-alternative scopes must be cleared", func(t *testing.T) {
+		original := buildOAS(openapi3.SecurityRequirements{
+			{"corpOAuth": []string{}},
+			{"jwtAuth": []string{}},
+		})
+		api := apidef.APIDefinition{
+			SecurityRequirements: [][]string{{"corpOAuth"}, {"jwtAuth"}},
+			SecurityRequirementScopes: []map[string][]string{
+				{"corpOAuth": {"api:access"}},
+				{"jwtAuth": {}},
+			},
+		}
+
+		original.extractSecurityTo(&api)
+
+		require.Len(t, api.SecurityRequirementScopes, 2,
+			"extract must emit one scope entry per OAS Security Requirement")
+		assert.Empty(t, api.SecurityRequirementScopes[0]["corpOAuth"],
+			"alternative 0 lost its scope in OAS; extract must not retain the stale ['api:access']")
+		assert.Empty(t, api.SecurityRequirementScopes[1]["jwtAuth"],
+			"alternative 1 has no scopes in OAS; extract must reflect that")
+	})
+
+	// Scenario D — operator swaps one scope for another within the same
+	// single-scheme requirement. Extract must reflect the new scope; the
+	// prior value must not bleed through.
+	t.Run("single-scheme single-requirement: scope replaced must surface the new value", func(t *testing.T) {
+		original := buildOAS(openapi3.SecurityRequirements{
+			{"corpOAuth": []string{"users:read"}},
+		})
+		api := apidef.APIDefinition{
+			SecurityRequirementScopes: []map[string][]string{
+				{"corpOAuth": {"api:access"}},
+			},
+		}
+
+		original.extractSecurityTo(&api)
+
+		require.Len(t, api.SecurityRequirementScopes, 1)
+		assert.Equal(t, []string{"users:read"}, api.SecurityRequirementScopes[0]["corpOAuth"],
+			"extract must reflect the new scope, never the prior ['api:access']")
+	})
+
+	// Scenario F — operator shrinks a multi-requirement policy to a
+	// single-scheme single-requirement. Extract must reset the stale
+	// SecurityRequirements and shrink SecurityRequirementScopes to the
+	// new shape so the on-disk payload no longer carries the dropped
+	// alternative.
+	t.Run("multi-requirement shrunk to single: stale alternative cleared from both fields", func(t *testing.T) {
+		original := buildOAS(openapi3.SecurityRequirements{
+			{"corpOAuth": []string{"api:access"}},
+		})
+		api := apidef.APIDefinition{
+			SecurityRequirements: [][]string{{"corpOAuth"}, {"jwtAuth"}},
+			SecurityRequirementScopes: []map[string][]string{
+				{"corpOAuth": {"api:access"}},
+				{"jwtAuth": {}},
+			},
+		}
+
+		original.extractSecurityTo(&api)
+
+		assert.Empty(t, api.SecurityRequirements,
+			"single-scheme single-requirement leaves SecurityRequirements nil; fill rebuilds it from the scheme map at load time")
+		require.Len(t, api.SecurityRequirementScopes, 1,
+			"shrinking to one alternative must shrink SecurityRequirementScopes to match — the stale second entry must not survive")
+		assert.Equal(t, []string{"api:access"}, api.SecurityRequirementScopes[0]["corpOAuth"])
+	})
+
+	// Scenario H — operator extends a single-requirement policy into
+	// two alternatives. Extract emits the new multi-requirement shape;
+	// the previously-single SecurityRequirementScopes entry must not
+	// bleed into the new layout.
+	t.Run("single-requirement extended to multi: extract reflects the new shape", func(t *testing.T) {
+		original := buildOAS(openapi3.SecurityRequirements{
+			{"corpOAuth": []string{"api:access"}},
+			{"jwtAuth": []string{}},
+		})
+		api := apidef.APIDefinition{
+			SecurityRequirementScopes: []map[string][]string{
+				{"corpOAuth": {"api:access"}},
+			},
+		}
+
+		original.extractSecurityTo(&api)
+
+		require.Len(t, api.SecurityRequirements, 2)
+		require.Len(t, api.SecurityRequirementScopes, 2)
+		assert.Equal(t, []string{"api:access"}, api.SecurityRequirementScopes[0]["corpOAuth"])
+		assert.Empty(t, api.SecurityRequirementScopes[1]["jwtAuth"],
+			"the new second alternative carries no scopes")
+	})
+}
+
+// TestOAS_SecurityScopes_CompliantMode pins the save/load contract under
+// SecurityProcessingMode=compliant. Compliant mode (a) processes every
+// alternative in the OAS root `security:` array (not just the first like
+// legacy mode), (b) splits standard OAS auth and proprietary vendor auth
+// into two storage locations (s.Security vs Authentication.Security),
+// and (c) reconcatenates them on extract through the
+// appendFilteredOASSecurityRequirements / appendVendorSecurityRequirements
+// helpers. The tests below cover both the staleness contract introduced
+// in this story and the existing compliant-mode shape contract, to
+// guarantee the two interact correctly.
+func TestOAS_SecurityScopes_CompliantMode(t *testing.T) {
+	// buildCompliantOAS sets the authentication processing mode to
+	// compliant so extract takes the OAS+vendor split path
+	// (security.go::extractSecurityTo, "if processingMode ==
+	// SecurityProcessingModeCompliant" branch). The vendorSecurity
+	// slot is exposed so individual tests can mix proprietary
+	// (hmac / oauth) and standard schemes.
+	buildCompliantOAS := func(oasSecurity openapi3.SecurityRequirements, vendorSecurity [][]string) OAS {
+		o := OAS{}
+		o.OpenAPI = "3.0.3"
+		o.Info = &openapi3.Info{Title: "compliant-mode", Version: "1.0"}
+		o.Paths = openapi3.NewPaths()
+		o.Components = &openapi3.Components{
+			SecuritySchemes: openapi3.SecuritySchemes{
+				"corpOAuth": &openapi3.SecuritySchemeRef{
+					Value: &openapi3.SecurityScheme{
+						Type: typeOAuth2,
+						Flows: &openapi3.OAuthFlows{
+							AuthorizationCode: &openapi3.OAuthFlow{
+								AuthorizationURL: "/oauth/authorize",
+								TokenURL:         "/oauth/token",
+								Scopes:           map[string]string{},
+							},
+						},
+					},
+				},
+				"jwtAuth": &openapi3.SecuritySchemeRef{
+					Value: &openapi3.SecurityScheme{
+						Type: "http", Scheme: "bearer", BearerFormat: "JWT",
+					},
+				},
+			},
+		}
+		o.Security = oasSecurity
+		o.SetTykExtension(&XTykAPIGateway{
+			Server: Server{
+				Authentication: &Authentication{
+					Enabled:                true,
+					SecurityProcessingMode: SecurityProcessingModeCompliant,
+					Security:               vendorSecurity,
+					SecuritySchemes: SecuritySchemes{
+						"corpOAuth": &OAuth2{Enabled: true, ScopeCheck: &OAuth2ScopeCheck{Enabled: true, ScopeSource: OAuth2ScopeSourceGlobal}},
+						"jwtAuth":   &JWT{Enabled: true, AuthSources: AuthSources{Header: &AuthSource{Enabled: true, Name: "Authorization"}}, SigningMethod: "rsa", Source: "anything", IdentityBaseField: "sub"},
+					},
+				},
+			},
+		})
+		return o
+	}
+
+	// Compliant-mode early-return: extractSecurityTo must reset both
+	// fields even when neither s.Security nor tykAuthentication.Security
+	// carries any entries, otherwise the prior stored values inherited
+	// from the dashboard's hydrated APIDefinition would resurface on
+	// reload. The legacy-mode equivalent is covered by
+	// TestOAS_SecurityScopes_StalePersistence/"security_block_removed";
+	// this case pins the same invariant for compliant mode.
+	t.Run("no security: stale fields cleared under compliant mode", func(t *testing.T) {
+		original := buildCompliantOAS(nil, nil)
+		api := apidef.APIDefinition{
+			SecurityRequirements: [][]string{{"corpOAuth"}, {"jwtAuth"}},
+			SecurityRequirementScopes: []map[string][]string{
+				{"corpOAuth": {"api:access"}},
+				{"jwtAuth": {}},
+			},
+		}
+
+		original.extractSecurityTo(&api)
+
+		assert.Empty(t, api.SecurityRequirements,
+			"compliant-mode early-return must clear SecurityRequirements")
+		assert.Empty(t, api.SecurityRequirementScopes,
+			"compliant-mode early-return must clear SecurityRequirementScopes")
+	})
+
+	// Compliant-mode multi-requirement OR: extract emits one scope
+	// entry per OAS Security Requirement, index-aligned with
+	// SecurityRequirements. The order of alternatives is preserved so
+	// the WWW-Authenticate challenge cites the first as authored.
+	t.Run("multi-requirement OR: scope-array order preserved through extract", func(t *testing.T) {
+		original := buildCompliantOAS(openapi3.SecurityRequirements{
+			{"corpOAuth": []string{"users:read"}},
+			{"corpOAuth": []string{"admin"}},
+		}, nil)
+		var api apidef.APIDefinition
+
+		original.extractSecurityTo(&api)
+
+		require.Len(t, api.SecurityRequirements, 2)
+		require.Len(t, api.SecurityRequirementScopes, 2)
+		assert.Equal(t, []string{"users:read"}, api.SecurityRequirementScopes[0]["corpOAuth"])
+		assert.Equal(t, []string{"admin"}, api.SecurityRequirementScopes[1]["corpOAuth"])
+	})
+
+	// Compliant-mode scope-cleared-on-all-alternatives: analog of
+	// scenario G in legacy mode. Lengths match, every scope is empty,
+	// so the old anyRequirementHasScopes guard would have skipped the
+	// SecurityRequirementScopes assignment and let the stale value
+	// persist on disk. Pins that compliant mode also writes the
+	// empty-shape slice.
+	t.Run("multi-requirement all scopes cleared: stale per-alternative scopes cleared", func(t *testing.T) {
+		original := buildCompliantOAS(openapi3.SecurityRequirements{
+			{"corpOAuth": []string{}},
+			{"jwtAuth": []string{}},
+		}, nil)
+		api := apidef.APIDefinition{
+			SecurityRequirements: [][]string{{"corpOAuth"}, {"jwtAuth"}},
+			SecurityRequirementScopes: []map[string][]string{
+				{"corpOAuth": {"api:access"}},
+				{"jwtAuth": {}},
+			},
+		}
+
+		original.extractSecurityTo(&api)
+
+		require.Len(t, api.SecurityRequirementScopes, 2,
+			"extract must emit one scope entry per OAS Security Requirement")
+		assert.Empty(t, api.SecurityRequirementScopes[0]["corpOAuth"],
+			"alternative 0's scope was cleared in OAS; extract must not retain ['api:access']")
+		assert.Empty(t, api.SecurityRequirementScopes[1]["jwtAuth"])
+	})
+
+	// Compliant-mode vendor-only: when the OAS root security: array
+	// is empty but tykAuthentication.Security carries proprietary
+	// requirements, extract emits the vendor entries with empty scope
+	// maps (vendor entries do not carry OAS scopes — see
+	// appendVendorSecurityRequirements). SecurityRequirementScopes
+	// stays index-aligned with SecurityRequirements.
+	t.Run("vendor-only security: scopes slice is index-aligned with empty maps", func(t *testing.T) {
+		original := buildCompliantOAS(nil, [][]string{{"hmac"}, {"oauth"}})
+		api := apidef.APIDefinition{
+			SecurityRequirementScopes: []map[string][]string{
+				{"corpOAuth": {"api:access"}},
+			},
+		}
+
+		original.extractSecurityTo(&api)
+
+		require.Len(t, api.SecurityRequirements, 2,
+			"vendor entries must appear in SecurityRequirements")
+		assert.Equal(t, []string{"hmac"}, api.SecurityRequirements[0])
+		assert.Equal(t, []string{"oauth"}, api.SecurityRequirements[1])
+		require.Len(t, api.SecurityRequirementScopes, 2,
+			"SecurityRequirementScopes must stay index-aligned with vendor entries")
+		assert.Empty(t, api.SecurityRequirementScopes[0],
+			"vendor entries carry no OAS scopes")
+		assert.Empty(t, api.SecurityRequirementScopes[1])
+	})
+
+	// Compliant-mode mixed (proprietary AND standard): when a vendor
+	// requirement bundles a proprietary scheme with a standard one
+	// (e.g. [hmac, jwtAuth]), the standard scheme must not be
+	// duplicated as a single-scheme OAS requirement. extract's
+	// appendFilteredOASSecurityRequirements drops the duplicate.
+	t.Run("mixed vendor AND standard: standard scheme not duplicated", func(t *testing.T) {
+		original := buildCompliantOAS(openapi3.SecurityRequirements{
+			{"jwtAuth": []string{}},
+		}, [][]string{{"hmac", "jwtAuth"}})
+		var api apidef.APIDefinition
+
+		original.extractSecurityTo(&api)
+
+		require.Len(t, api.SecurityRequirements, 1,
+			"the single-scheme OAS entry for jwtAuth must be filtered as a duplicate of the mixed vendor requirement")
+		assert.ElementsMatch(t, []string{"hmac", "jwtAuth"}, api.SecurityRequirements[0])
+		require.Len(t, api.SecurityRequirementScopes, 1,
+			"SecurityRequirementScopes must stay index-aligned with SecurityRequirements after filtering")
+		assert.Empty(t, api.SecurityRequirementScopes[0],
+			"vendor-mixed entry carries no OAS scopes")
+	})
+
+	// Compliant-mode OAS + vendor combined: pure OAS entries are
+	// appended first, then vendor entries. SecurityRequirementScopes
+	// carries the OAS scopes for the OAS entries and empty maps for
+	// the vendor entries.
+	t.Run("oas with scopes plus vendor: ordering and scope alignment preserved", func(t *testing.T) {
+		original := buildCompliantOAS(openapi3.SecurityRequirements{
+			{"corpOAuth": []string{"users:read"}},
+		}, [][]string{{"hmac"}})
+		var api apidef.APIDefinition
+
+		original.extractSecurityTo(&api)
+
+		require.Len(t, api.SecurityRequirements, 2)
+		assert.Equal(t, []string{"corpOAuth"}, api.SecurityRequirements[0])
+		assert.Equal(t, []string{"hmac"}, api.SecurityRequirements[1])
+		require.Len(t, api.SecurityRequirementScopes, 2)
+		assert.Equal(t, []string{"users:read"}, api.SecurityRequirementScopes[0]["corpOAuth"],
+			"OAS entry retains its scope")
+		assert.Empty(t, api.SecurityRequirementScopes[1],
+			"vendor entry has no OAS scope")
+	})
+
+	// Compliant-mode round-trip: extract → fill → extract on a
+	// non-trivial OR-of-AND policy produces the same in-memory shape.
+	// This pins that the fill side respects SecurityRequirementScopes
+	// alignment under compliant mode just as it does under legacy
+	// mode.
+	t.Run("round-trip preserves OR-of-AND shape and scopes", func(t *testing.T) {
+		original := buildCompliantOAS(openapi3.SecurityRequirements{
+			{"corpOAuth": []string{"users:read"}, "jwtAuth": []string{}},
+			{"corpOAuth": []string{"admin"}},
+		}, nil)
+		var api apidef.APIDefinition
+
+		original.extractSecurityTo(&api)
+
+		var rebuilt OAS
+		rebuilt.OpenAPI = "3.0.3"
+		rebuilt.Info = &openapi3.Info{Title: "compliant-mode", Version: "1.0"}
+		rebuilt.Paths = openapi3.NewPaths()
+		rebuilt.Components = &openapi3.Components{SecuritySchemes: original.Components.SecuritySchemes}
+		rebuilt.SetTykExtension(&XTykAPIGateway{
+			Server: Server{Authentication: original.GetTykExtension().Server.Authentication},
+		})
+		rebuilt.fillSecurity(api)
+
+		require.Len(t, rebuilt.Security, 2)
+		// The AND alternative must contain both schemes with the
+		// declared scopes — jwtAuth always with an empty array (OAS
+		// 3.0 §4.8.30.1 forbids scopes on non-oauth schemes).
+		assert.Equal(t, []string{"users:read"}, rebuilt.Security[0]["corpOAuth"])
+		assert.Equal(t, []string{}, rebuilt.Security[0]["jwtAuth"])
+		assert.Equal(t, []string{"admin"}, rebuilt.Security[1]["corpOAuth"])
 	})
 }
 
@@ -3542,4 +4139,68 @@ func TestTokenHasCertificateEnabled(t *testing.T) {
 		assert.False(t, oas.tokenHasCertificateEnabled("authToken1"))
 		assert.True(t, oas.tokenHasCertificateEnabled("authToken2"))
 	})
+}
+
+// TestExtractFillRoundTrip_SingleAlternativePreservesAllSchemes pins
+// that a single-alternative root `security:` with multiple schemes
+// (jwtAuth + corpOAuth, AND-required) survives extract→fill without
+// dropping schemes that carry empty scope lists. Regression: the
+// dashboard PUT round-trip saved
+// `[{jwtAuth: [], corpOAuth: [api:access]}]` but read back
+// `[{corpOAuth: [api:access]}]` — the gateway then wired AuthKey
+// instead of JWT and rejected every JWT-bearer request.
+func TestExtractFillRoundTrip_SingleAlternativePreservesAllSchemes(t *testing.T) {
+	s := &OAS{}
+	s.OpenAPI = "3.0.3"
+	s.Info = &openapi3.Info{Title: "rt", Version: "1.0"}
+	s.Paths = openapi3.NewPaths()
+	s.Components = &openapi3.Components{
+		SecuritySchemes: openapi3.SecuritySchemes{
+			"jwtAuth": &openapi3.SecuritySchemeRef{
+				Value: &openapi3.SecurityScheme{Type: "http", Scheme: "bearer", BearerFormat: "JWT"},
+			},
+			"corpOAuth": &openapi3.SecuritySchemeRef{
+				Value: &openapi3.SecurityScheme{
+					Type: "oauth2",
+					Flows: &openapi3.OAuthFlows{
+						AuthorizationCode: &openapi3.OAuthFlow{
+							AuthorizationURL: "/oauth/authorize",
+							TokenURL:         "/oauth/token",
+							Scopes:           map[string]string{"api:access": ""},
+						},
+					},
+				},
+			},
+		},
+	}
+	s.Security = openapi3.SecurityRequirements{
+		{"jwtAuth": []string{}, "corpOAuth": []string{"api:access"}},
+	}
+	s.SetTykExtension(&XTykAPIGateway{
+		Server: Server{
+			Authentication: &Authentication{
+				Enabled: true,
+				SecuritySchemes: SecuritySchemes{
+					"jwtAuth":   &JWT{Enabled: true, Source: "aHR0cDovL2tjL2NlcnRz"},
+					"corpOAuth": &OAuth2{Enabled: true, ScopeCheck: &OAuth2ScopeCheck{Enabled: true, ScopeSource: OAuth2ScopeSourceGlobal}},
+				},
+			},
+		},
+	})
+
+	api := apidef.APIDefinition{}
+	s.extractSecurityTo(&api)
+	// Wipe s.Security so fill rebuilds from api fields — mirrors the
+	// dashboard's GET-then-PUT-then-GET cycle.
+	s.Security = nil
+	s.fillSecurity(api)
+
+	require.Len(t, s.Security, 1, "single-alternative requirement must round-trip as one entry")
+	got := s.Security[0]
+	_, hasJWT := got["jwtAuth"]
+	_, hasOAuth := got["corpOAuth"]
+	assert.True(t, hasJWT, "jwtAuth must survive the round-trip — without it the gateway falls back to AuthKey")
+	assert.True(t, hasOAuth, "corpOAuth must survive the round-trip")
+	assert.Equal(t, []string{"api:access"}, got["corpOAuth"], "corpOAuth's scope list must be preserved")
+	assert.Empty(t, got["jwtAuth"], "jwtAuth's empty-scope shape must be preserved")
 }

--- a/apidef/streams/schema/x-tyk-api-gateway.json
+++ b/apidef/streams/schema/x-tyk-api-gateway.json
@@ -1676,10 +1676,22 @@
       "type": "object",
       "description": "OAuth 2.0 security scheme container.",
       "properties": {
-        "enabled": { "type": "boolean" },
-        "header":  { "$ref": "#/definitions/X-Tyk-AuthSource" },
-        "cookie":  { "$ref": "#/definitions/X-Tyk-AuthSource" },
-        "query":   { "$ref": "#/definitions/X-Tyk-AuthSource" }
+        "enabled":    { "type": "boolean" },
+        "header":     { "$ref": "#/definitions/X-Tyk-AuthSource" },
+        "cookie":     { "$ref": "#/definitions/X-Tyk-AuthSource" },
+        "query":      { "$ref": "#/definitions/X-Tyk-AuthSource" },
+        "scopeCheck": { "$ref": "#/definitions/X-Tyk-OAuth2-ScopeCheck" }
+      },
+      "required": ["enabled"]
+    },
+    "X-Tyk-OAuth2-ScopeCheck": {
+      "type": "object",
+      "description": "Token-side knobs for OAS-native scope enforcement. Required scopes themselves live in the OAS root security: array.",
+      "properties": {
+        "enabled":        { "type": "boolean" },
+        "claimNames":     { "type": "array", "items": { "type": "string" }, "description": "Ordered list of JWT claim names to read scopes from. The gateway reads each listed claim that is present and merges all scope values into one set. Alternatives drawn from OAS root security: are checked against this merged set. Defaults to [\"scope\", \"scp\"] when unset." },
+        "separator":      { "type": "string" },
+        "scopeSource":    { "type": "string", "enum": ["operation", "global", "union"], "description": "Selects whether enforcement reads per-operation security:, root security:, or both. Defaults to \"union\"." }
       },
       "required": ["enabled"]
     },

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -525,6 +525,8 @@ func (gw *Gateway) processSpec(
 		gw.mwAppendEnabled(&chainArray, &MCPAccessControlMiddleware{baseMid.Copy()})
 	}
 
+	gw.mwAppendEnabled(&chainArray, &OAuth2Middleware{BaseMiddleware: baseMid.Copy()})
+
 	gw.mwAppendEnabled(&chainArray, &RateLimitForAPI{BaseMiddleware: baseMid.Copy(), quotaKey: options.quotaKey})
 	gw.mwAppendEnabled(&chainArray, &GraphQLMiddleware{BaseMiddleware: baseMid.Copy()})
 

--- a/gateway/mw_oauth2.go
+++ b/gateway/mw_oauth2.go
@@ -1,0 +1,330 @@
+package gateway
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/golang-jwt/jwt/v4"
+
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/internal/event"
+	"github.com/TykTechnologies/tyk/internal/middleware"
+	"github.com/TykTechnologies/tyk/internal/oauth2common"
+)
+
+const (
+	oauth2DefaultScopeSeparator = " "
+	oauth2DefaultScopeClaim     = "scope"
+	oauth2FallbackScopeClaim    = "scp"
+)
+
+// OAuth2Middleware enforces OAS-native scope checks for the new
+// oauth2 security scheme. When scopeCheck is enabled and the
+// configured scopeSource reads the OAS root `security:` array, every
+// request hitting the API must present a token whose merged scope
+// set (across the configured ClaimNames) satisfies at least one
+// Security Requirement Object that references the scheme. Per-OAS:
+// outer entries are OR-alternatives; scopes within an entry are
+// AND-required.
+type OAuth2Middleware struct {
+	*BaseMiddleware
+}
+
+func (m *OAuth2Middleware) Name() string {
+	return "OAuth2Middleware"
+}
+
+func (m *OAuth2Middleware) EnabledForSpec() bool {
+	if m.Spec == nil || !m.Spec.IsOAS {
+		return false
+	}
+	ext := m.Spec.OAS.GetTykExtension()
+	if ext == nil || ext.Server.Authentication == nil || !ext.Server.Authentication.Enabled {
+		return false
+	}
+	_, cfg := m.Spec.GetOAuth2Config()
+	if cfg == nil || !cfg.Enabled {
+		return false
+	}
+	return cfg.ScopeCheck != nil && cfg.ScopeCheck.Enabled
+}
+
+func (m *OAuth2Middleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
+	if ctxGetRequestStatus(r) == StatusOkAndIgnore {
+		return nil, http.StatusOK
+	}
+
+	schemeName, cfg := m.Spec.GetOAuth2Config()
+	if cfg == nil || cfg.ScopeCheck == nil || !cfg.ScopeCheck.Enabled {
+		return nil, http.StatusOK
+	}
+
+	alternatives := rootSecurityAlternatives(m.Spec.OAS.Security, schemeName, cfg.ScopeCheck)
+	if len(alternatives) == 0 {
+		// Root security has nothing to enforce for this scheme.
+		return nil, http.StatusOK
+	}
+
+	rawToken := stripBearer(r.Header.Get(header.Authorization))
+	if rawToken == "" {
+		m.setWWWAuthenticateInsufficientToken(w, oas.OAuth2ErrInvalidToken, "missing bearer token")
+		return errors.New("authorization field missing"), http.StatusUnauthorized
+	}
+
+	claims, err := oauth2common.ParseUnverifiedClaims(rawToken)
+	if err != nil {
+		m.setWWWAuthenticateInsufficientToken(w, oas.OAuth2ErrInvalidToken, "token is not a parseable JWT")
+		return fmt.Errorf("parsing inbound token claims: %w", err), http.StatusUnauthorized
+	}
+
+	if !tokenSatisfiesAnyAlternative(claims, cfg.ScopeCheck, alternatives) {
+		// First alternative is cited on the challenge — listing every
+		// alternative would leak intent (a service-account scope
+		// shouldn't be advertised to a user-token caller).
+		cited := alternatives[0]
+		citedScopes := strings.Join(cited, " ")
+		m.fireScopeCheckFailedEvent(r, claims, alternatives, cited, cfg.ScopeCheck)
+		m.setWWWAuthenticateInsufficientScope(w, cited)
+		body, err := json.Marshal(map[string]interface{}{
+			"error":             oas.OAuth2ErrInsufficientScope,
+			"error_description": "token does not satisfy required scopes: " + citedScopes,
+			"scope":             citedScopes,
+		})
+		if err != nil {
+			m.Logger().WithError(err).Error("oauth2: marshal scope-check response body")
+			w.WriteHeader(http.StatusForbidden)
+			return nil, middleware.StatusRespond
+		}
+		w.Header().Set(header.ContentType, header.ApplicationJSON)
+		w.WriteHeader(http.StatusForbidden)
+		if _, err := w.Write(body); err != nil {
+			m.Logger().WithError(err).Debug("oauth2: write scope-check response body")
+		}
+		return nil, middleware.StatusRespond
+	}
+
+	return nil, http.StatusOK
+}
+
+// rootSecurityAlternatives returns the OR-of-AND list of alternatives
+// to enforce, drawn from the OAS root `security:` array. Each entry
+// in `security:` that references the named scheme contributes one
+// alternative; the scopes within that entry are the AND set. Declared
+// order is preserved end-to-end so the operator sees their authored
+// form on the failure challenge.
+//
+// Returns nil when ScopeSource is "operation" — operation-level
+// enforcement is handled by a separate middleware. An entry that
+// lists the scheme with an empty scope list (the OAS shape for "auth
+// required, no specific scope") is preserved as an empty alternative
+// — vacuously satisfied, which short-circuits the OR to "pass".
+func rootSecurityAlternatives(security openapi3.SecurityRequirements, schemeName string, sc *oas.OAuth2ScopeCheck) [][]string {
+	if sc == nil || schemeName == "" {
+		return nil
+	}
+	switch sc.ScopeSource {
+	case oas.OAuth2ScopeSourceOperation:
+		return nil
+	case oas.OAuth2ScopeSourceGlobal, oas.OAuth2ScopeSourceUnion, "":
+	default:
+		return nil
+	}
+	out := make([][]string, 0, len(security))
+	for _, req := range security {
+		scopes, present := req[schemeName]
+		if !present {
+			continue
+		}
+		ordered := dedupePreserveOrder(scopes)
+		if ordered == nil {
+			ordered = []string{}
+		}
+		out = append(out, ordered)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// dedupePreserveOrder returns the input slice with empty entries removed
+// and duplicates dropped, preserving the declared order of first
+// occurrence.
+func dedupePreserveOrder(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if s == "" {
+			continue
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
+// tokenSatisfiesAnyAlternative reports whether the token's merged
+// scope set fully covers at least one of the configured alternatives
+// (OR-of-AND).
+func tokenSatisfiesAnyAlternative(claims jwt.MapClaims, sc *oas.OAuth2ScopeCheck, alternatives [][]string) bool {
+	separator := sc.Separator
+	if separator == "" {
+		separator = oauth2DefaultScopeSeparator
+	}
+	have := make(map[string]struct{})
+	for _, s := range lookupScopes(claims, sc, separator) {
+		have[s] = struct{}{}
+	}
+	for _, alt := range alternatives {
+		if alternativeCovered(have, alt) {
+			return true
+		}
+	}
+	return false
+}
+
+func alternativeCovered(have map[string]struct{}, alt []string) bool {
+	for _, want := range alt {
+		if _, ok := have[want]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// lookupScopes resolves the token's scope set by reading every
+// configured claim name and merging the parsed scope values into one
+// deduplicated list. A scope is considered present if it appears in
+// any listed claim — there is no precedence between claim names.
+func lookupScopes(claims jwt.MapClaims, sc *oas.OAuth2ScopeCheck, separator string) []string {
+	seen := map[string]struct{}{}
+	merged := make([]string, 0, 4)
+	for _, name := range scopeClaimCandidates(sc) {
+		for _, s := range extractScopes(claims, name, separator) {
+			if _, ok := seen[s]; ok {
+				continue
+			}
+			seen[s] = struct{}{}
+			merged = append(merged, s)
+		}
+	}
+	if len(merged) == 0 {
+		return nil
+	}
+	return merged
+}
+
+// scopeClaimCandidates returns the ordered list of claim names to read
+// scopes from. The operator-supplied ClaimNames list is used verbatim
+// when set; otherwise the default `["scope", "scp"]` is returned so
+// that OAuth (`scope`) and OIDC / Microsoft Entra (`scp`) tokens are
+// both honored without operator config.
+func scopeClaimCandidates(sc *oas.OAuth2ScopeCheck) []string {
+	if sc != nil && len(sc.ClaimNames) > 0 {
+		return sc.ClaimNames
+	}
+	return []string{oauth2DefaultScopeClaim, oauth2FallbackScopeClaim}
+}
+
+func extractScopes(claims jwt.MapClaims, claimName, separator string) []string {
+	v, ok := claims[claimName]
+	if !ok {
+		return nil
+	}
+	switch tv := v.(type) {
+	case string:
+		return splitNonEmpty(tv, separator)
+	case []interface{}:
+		out := make([]string, 0, len(tv))
+		for _, e := range tv {
+			if s, ok := e.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	case []string:
+		return tv
+	}
+	return nil
+}
+
+func splitNonEmpty(s, sep string) []string {
+	parts := strings.Split(s, sep)
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// setWWWAuthenticate emits an RFC 6750 §3 Bearer challenge with the
+// supplied error parameters. Per RFC 6750 §3 the scheme name is
+// separated from the auth-params by 1*SP (no comma); auth-params are
+// then 1#auth-param (comma-delimited). Parameter order on the wire
+// matches the input order — RFC 6750 doesn't constrain it, but
+// stability makes assertions easier.
+func (m *OAuth2Middleware) setWWWAuthenticate(w http.ResponseWriter, params [][2]string) {
+	authParams := make([]string, 0, len(params))
+	for _, kv := range params {
+		authParams = append(authParams, fmt.Sprintf("%s=%q", kv[0], kv[1]))
+	}
+	w.Header().Set(header.WWWAuthenticate, oas.OAuth2AuthSchemeBearer+" "+strings.Join(authParams, ", "))
+}
+
+// setWWWAuthenticateInsufficientScope emits the RFC 6750 §3.1 challenge
+// for a scope-check rejection. The `scope=` parameter advertises the
+// required scope set so RFC 6750 / MCP-aware clients can step up.
+func (m *OAuth2Middleware) setWWWAuthenticateInsufficientScope(w http.ResponseWriter, scopes []string) {
+	scopesValue := strings.Join(scopes, " ")
+	m.setWWWAuthenticate(w, [][2]string{
+		{"error", oas.OAuth2ErrInsufficientScope},
+		{"error_description", "missing required scope: " + scopesValue},
+		{"scope", scopesValue},
+	})
+}
+
+func (m *OAuth2Middleware) setWWWAuthenticateInsufficientToken(w http.ResponseWriter, code, desc string) {
+	m.setWWWAuthenticate(w, [][2]string{
+		{"error", code},
+		{"error_description", desc},
+	})
+}
+
+// fireScopeCheckFailedEvent emits the OAuth2ScopeCheckFailed audit
+// event with non-secret claim identifiers + scope context. Token bytes
+// are never emitted. `cited` is the alternative advertised on the
+// failure challenge (the first declared alternative); `alternatives`
+// is the full OR-of-AND list the request failed against.
+func (m *OAuth2Middleware) fireScopeCheckFailedEvent(r *http.Request, claims jwt.MapClaims, alternatives [][]string, cited []string, sc *oas.OAuth2ScopeCheck) {
+	separator := oauth2DefaultScopeSeparator
+	if sc != nil && sc.Separator != "" {
+		separator = sc.Separator
+	}
+	granted := lookupScopes(claims, sc, separator)
+	meta := map[string]interface{}{
+		"oauth2_subject_jti":    oauth2common.StringClaim(claims, "jti"),
+		"oauth2_subject_azp":    oauth2common.StringClaim(claims, "azp"),
+		"required_scopes":       cited,
+		"required_alternatives": alternatives,
+		"granted_scopes":        granted,
+		"path":                  r.URL.Path,
+		"method":                r.Method,
+		"oauth2_api_id":         m.Spec.APIID,
+	}
+	m.FireEvent(apidef.TykEvent(event.OAuth2ScopeCheckFailed), meta)
+}

--- a/gateway/mw_oauth2_test.go
+++ b/gateway/mw_oauth2_test.go
@@ -1,0 +1,631 @@
+package gateway
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/test"
+)
+
+// ----------------------------------------------------------------------------
+// Pure-function helpers
+// ----------------------------------------------------------------------------
+
+func TestOAuth2_SplitNonEmpty(t *testing.T) {
+	assert.Nil(t, splitNonEmptyOrNil(splitNonEmpty("", " ")))
+	assert.Equal(t, []string{"a", "b"}, splitNonEmpty("a b", " "))
+	assert.Equal(t, []string{"a", "b"}, splitNonEmpty("a, b", ","))
+	assert.Equal(t, []string{"a"}, splitNonEmpty(" a ", " "))
+	assert.Equal(t, []string{"a", "b"}, splitNonEmpty("a  b", " "), "double-space tolerated")
+}
+
+func splitNonEmptyOrNil(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	return in
+}
+
+func TestOAuth2_ExtractScopes(t *testing.T) {
+	t.Run("string claim with default separator", func(t *testing.T) {
+		got := extractScopes(jwt.MapClaims{"scope": "read write"}, "scope", " ")
+		assert.Equal(t, []string{"read", "write"}, got)
+	})
+
+	t.Run("string claim with custom separator", func(t *testing.T) {
+		got := extractScopes(jwt.MapClaims{"scope": "read,write"}, "scope", ",")
+		assert.Equal(t, []string{"read", "write"}, got)
+	})
+
+	t.Run("array of interface", func(t *testing.T) {
+		got := extractScopes(jwt.MapClaims{"scope": []interface{}{"read", "write", ""}}, "scope", " ")
+		assert.Equal(t, []string{"read", "write"}, got)
+	})
+
+	t.Run("array of string", func(t *testing.T) {
+		got := extractScopes(jwt.MapClaims{"scope": []string{"read", "write"}}, "scope", " ")
+		assert.Equal(t, []string{"read", "write"}, got)
+	})
+
+	t.Run("absent claim returns nil", func(t *testing.T) {
+		got := extractScopes(jwt.MapClaims{}, "scope", " ")
+		assert.Nil(t, got)
+	})
+
+	t.Run("non-stringy claim returns nil", func(t *testing.T) {
+		got := extractScopes(jwt.MapClaims{"scope": 42}, "scope", " ")
+		assert.Nil(t, got)
+	})
+}
+
+func TestOAuth2_ScopeClaimCandidates(t *testing.T) {
+	t.Run("nil config falls back to default scope/scp", func(t *testing.T) {
+		assert.Equal(t, []string{"scope", "scp"}, scopeClaimCandidates(nil))
+	})
+
+	t.Run("empty ClaimNames falls back to default", func(t *testing.T) {
+		assert.Equal(t, []string{"scope", "scp"}, scopeClaimCandidates(&oas.OAuth2ScopeCheck{}))
+	})
+
+	t.Run("operator-supplied ClaimNames is used verbatim", func(t *testing.T) {
+		got := scopeClaimCandidates(&oas.OAuth2ScopeCheck{ClaimNames: []string{"permissions", "scope"}})
+		assert.Equal(t, []string{"permissions", "scope"}, got)
+	})
+}
+
+// TestOAuth2_LookupScopes_MergesAcrossClaims pins the merge semantics:
+// values from every listed claim contribute to a single deduplicated
+// scope set. There is no first-non-empty-wins precedence.
+func TestOAuth2_LookupScopes_MergesAcrossClaims(t *testing.T) {
+	sc := &oas.OAuth2ScopeCheck{ClaimNames: []string{"scope", "scp"}}
+
+	t.Run("merges scope and scp into one set", func(t *testing.T) {
+		claims := jwt.MapClaims{
+			"scope": "read",
+			"scp":   []interface{}{"write"},
+		}
+		got := lookupScopes(claims, sc, " ")
+		assert.ElementsMatch(t, []string{"read", "write"}, got)
+	})
+
+	t.Run("dedups across claims", func(t *testing.T) {
+		claims := jwt.MapClaims{
+			"scope": "read write",
+			"scp":   []interface{}{"write", "delete"},
+		}
+		got := lookupScopes(claims, sc, " ")
+		assert.ElementsMatch(t, []string{"read", "write", "delete"}, got)
+	})
+
+	t.Run("missing claim contributes nothing", func(t *testing.T) {
+		got := lookupScopes(jwt.MapClaims{"scope": "read"}, sc, " ")
+		assert.Equal(t, []string{"read"}, got)
+	})
+
+	t.Run("default fallback honors both scope and scp claims", func(t *testing.T) {
+		claims := jwt.MapClaims{
+			"scope": "read",
+			"scp":   "write",
+		}
+		got := lookupScopes(claims, &oas.OAuth2ScopeCheck{}, " ")
+		assert.ElementsMatch(t, []string{"read", "write"}, got)
+	})
+}
+
+func TestOAuth2_RootSecurityAlternatives(t *testing.T) {
+	req := func(scheme string, scopes ...string) openapi3.SecurityRequirement {
+		out := openapi3.NewSecurityRequirement()
+		out[scheme] = append([]string{}, scopes...)
+		return out
+	}
+
+	cases := []struct {
+		name     string
+		security openapi3.SecurityRequirements
+		scheme   string
+		sc       *oas.OAuth2ScopeCheck
+		expected [][]string
+	}{
+		{"nil config", nil, "oauth2", nil, nil},
+		{"empty scheme name", openapi3.SecurityRequirements{req("oauth2", "x")}, "", &oas.OAuth2ScopeCheck{}, nil},
+		{"empty security", nil, "oauth2", &oas.OAuth2ScopeCheck{}, nil},
+		{
+			"global mode reads root security",
+			openapi3.SecurityRequirements{req("oauth2", "read", "write")},
+			"oauth2",
+			&oas.OAuth2ScopeCheck{ScopeSource: oas.OAuth2ScopeSourceGlobal},
+			[][]string{{"read", "write"}},
+		},
+		{
+			"union mode reads root security",
+			openapi3.SecurityRequirements{req("oauth2", "a", "b")},
+			"oauth2",
+			&oas.OAuth2ScopeCheck{ScopeSource: oas.OAuth2ScopeSourceUnion},
+			[][]string{{"a", "b"}},
+		},
+		{
+			"empty scopeSource defaults to union",
+			openapi3.SecurityRequirements{req("oauth2", "x")},
+			"oauth2",
+			&oas.OAuth2ScopeCheck{},
+			[][]string{{"x"}},
+		},
+		{
+			"operation suppresses root security",
+			openapi3.SecurityRequirements{req("oauth2", "x")},
+			"oauth2",
+			&oas.OAuth2ScopeCheck{ScopeSource: oas.OAuth2ScopeSourceOperation},
+			nil,
+		},
+		{
+			"OR across requirements — declared order preserved (first cited on failure)",
+			openapi3.SecurityRequirements{req("oauth2", "api:access"), req("oauth2", "admin")},
+			"oauth2",
+			&oas.OAuth2ScopeCheck{},
+			[][]string{{"api:access"}, {"admin"}},
+		},
+		{
+			"OR-of-AND general — inner dedup preserves declared order",
+			openapi3.SecurityRequirements{req("oauth2", "b", "a", "b", ""), req("oauth2", "admin")},
+			"oauth2",
+			&oas.OAuth2ScopeCheck{},
+			[][]string{{"b", "a"}, {"admin"}},
+		},
+		{
+			"requirements that don't reference the scheme drop out",
+			openapi3.SecurityRequirements{req("jwtAuth", "x"), req("oauth2", "y")},
+			"oauth2",
+			&oas.OAuth2ScopeCheck{},
+			[][]string{{"y"}},
+		},
+		{
+			"empty scope list on the scheme is preserved — vacuously satisfied per OAS",
+			openapi3.SecurityRequirements{req("oauth2")},
+			"oauth2",
+			&oas.OAuth2ScopeCheck{},
+			[][]string{{}},
+		},
+		{
+			// Pins the name-agnostic contract. OpenAPI 3.x lets the
+			// operator name security schemes freely; the helper must
+			// filter strictly by the supplied schemeName and ignore
+			// every other key, including ones that look oauth2-ish
+			// (e.g. literal "oauth2"). The shape under the key is data.
+			"filters strictly by the supplied scheme name (custom name with mixed casing)",
+			openapi3.SecurityRequirements{
+				req("oauth2", "ignored"),
+				req("prctOauth", "abc", "def"),
+				req("jwtAuth", "ignored-too"),
+				req("prctOauth", "ghi"),
+			},
+			"prctOauth",
+			&oas.OAuth2ScopeCheck{},
+			[][]string{{"abc", "def"}, {"ghi"}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, rootSecurityAlternatives(tc.security, tc.scheme, tc.sc))
+		})
+	}
+}
+
+func TestOAuth2_TokenSatisfiesAnyAlternative(t *testing.T) {
+	sc := &oas.OAuth2ScopeCheck{ClaimNames: []string{"scope", "scp"}}
+
+	t.Run("single alternative — all required present passes", func(t *testing.T) {
+		claims := jwt.MapClaims{"scope": "read write delete"}
+		assert.True(t, tokenSatisfiesAnyAlternative(claims, sc, [][]string{{"read", "write"}}))
+	})
+
+	t.Run("single alternative — missing one scope fails", func(t *testing.T) {
+		claims := jwt.MapClaims{"scope": "read"}
+		assert.False(t, tokenSatisfiesAnyAlternative(claims, sc, [][]string{{"read", "write"}}))
+	})
+
+	t.Run("scopes spread across claims pass", func(t *testing.T) {
+		claims := jwt.MapClaims{"scope": "read", "scp": []interface{}{"write"}}
+		assert.True(t, tokenSatisfiesAnyAlternative(claims, sc, [][]string{{"read", "write"}}))
+	})
+
+	t.Run("OR — second alternative satisfied passes", func(t *testing.T) {
+		claims := jwt.MapClaims{"scope": "admin"}
+		assert.True(t, tokenSatisfiesAnyAlternative(claims, sc, [][]string{{"api:access"}, {"admin"}}))
+	})
+
+	t.Run("OR — neither alternative satisfied fails", func(t *testing.T) {
+		claims := jwt.MapClaims{"scope": "other"}
+		assert.False(t, tokenSatisfiesAnyAlternative(claims, sc, [][]string{{"api:access"}, {"admin"}}))
+	})
+
+	t.Run("OR-of-AND — first alternative (AND of two) satisfied passes", func(t *testing.T) {
+		claims := jwt.MapClaims{"scope": "api:access tenant:read"}
+		assert.True(t, tokenSatisfiesAnyAlternative(claims, sc, [][]string{{"api:access", "tenant:read"}, {"admin"}}))
+	})
+
+	t.Run("OR-of-AND — first AND partial, second OR alone satisfies", func(t *testing.T) {
+		claims := jwt.MapClaims{"scope": "api:access admin"}
+		assert.True(t, tokenSatisfiesAnyAlternative(claims, sc, [][]string{{"api:access", "tenant:read"}, {"admin"}}))
+	})
+
+	t.Run("OR-of-AND — partial coverage of both alternatives fails", func(t *testing.T) {
+		claims := jwt.MapClaims{"scope": "api:access"}
+		assert.False(t, tokenSatisfiesAnyAlternative(claims, sc, [][]string{{"api:access", "tenant:read"}, {"admin"}}))
+	})
+}
+
+// ----------------------------------------------------------------------------
+// WWW-Authenticate header shape — RFC 6750 §3
+// ----------------------------------------------------------------------------
+
+// rfc6750BearerHeader pins the on-the-wire form: scheme `Bearer`,
+// SP, then comma-delimited auth-params with quoted values. We shipped
+// `Bearer, error=...` in a past regression, so this regex assertion is
+// load-bearing and cannot be relaxed.
+var rfc6750BearerHeader = regexp.MustCompile(`^Bearer ([a-z_]+="[^"]*")(, [a-z_]+="[^"]*")*$`)
+
+func TestOAuth2_SetWWWAuthenticateInsufficientScope_HeaderShape(t *testing.T) {
+	m := &OAuth2Middleware{}
+	w := httptest.NewRecorder()
+	m.setWWWAuthenticateInsufficientScope(w, []string{"read:billing", "write:billing"})
+
+	got := w.Header().Get(header.WWWAuthenticate)
+	require.True(t, rfc6750BearerHeader.MatchString(got), "header %q must match RFC 6750 §3 form", got)
+	assert.Contains(t, got, `error="insufficient_scope"`)
+	assert.Contains(t, got, `scope="read:billing write:billing"`)
+	assert.Contains(t, got, `error_description="missing required scope: read:billing write:billing"`)
+}
+
+func TestOAuth2_SetWWWAuthenticateInsufficientToken_HeaderShape(t *testing.T) {
+	m := &OAuth2Middleware{}
+	w := httptest.NewRecorder()
+	m.setWWWAuthenticateInsufficientToken(w, oas.OAuth2ErrInvalidToken, "missing bearer token")
+
+	got := w.Header().Get(header.WWWAuthenticate)
+	require.True(t, rfc6750BearerHeader.MatchString(got), "header %q must match RFC 6750 §3 form", got)
+	assert.Contains(t, got, `error="invalid_token"`)
+	assert.Contains(t, got, `error_description="missing bearer token"`)
+}
+
+// ----------------------------------------------------------------------------
+// End-to-end via StartTest — global scope check enforcement
+// ----------------------------------------------------------------------------
+
+// makeUnverifiedJWT signs a JWT with the supplied claims using HS256
+// and a fixed test secret. Signature is not verified by the oauth2
+// middleware (it reads claims unverified — JWT signature verification
+// is the JWT middleware's job).
+func makeUnverifiedJWT(t *testing.T, claims jwt.MapClaims) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := tok.SignedString([]byte("test-secret"))
+	require.NoError(t, err)
+	return signed
+}
+
+// newOAuth2GlobalScopeCheckOAS builds an OAS document with a single
+// OAS-native oauth2 scheme named "corpOAuth" and the supplied required
+// scopes expressed as OAS root `security:` Security Requirement
+// Objects. Each inner slice is one Security Requirement (AND across
+// its scopes); outer entries are OR alternatives. The scheme is also
+// declared in Components.SecuritySchemes so the document validates
+// against the OAS spec.
+func newOAuth2GlobalScopeCheckOAS(listenPath string, scopeAlternatives [][]string) oas.OAS {
+	return newOAuth2GlobalScopeCheckOASNamed(listenPath, "corpOAuth", scopeAlternatives)
+}
+
+// newOAuth2GlobalScopeCheckOASNamed is the name-parameterised variant.
+// OpenAPI 3.x lets the operator name security schemes freely, so the
+// middleware contract is name-agnostic — this helper lets the test
+// suite exercise that contract under non-default names.
+func newOAuth2GlobalScopeCheckOASNamed(listenPath, schemeName string, scopeAlternatives [][]string) oas.OAS {
+	security := openapi3.SecurityRequirements{}
+	for _, alt := range scopeAlternatives {
+		req := openapi3.NewSecurityRequirement()
+		req[schemeName] = append([]string{}, alt...)
+		security = append(security, req)
+	}
+	doc := oas.OAS{
+		T: openapi3.T{
+			OpenAPI:  "3.0.3",
+			Info:     &openapi3.Info{Title: "oauth2-scope-check", Version: "1.0"},
+			Paths:    openapi3.NewPaths(),
+			Security: security,
+			Components: &openapi3.Components{
+				SecuritySchemes: openapi3.SecuritySchemes{
+					schemeName: &openapi3.SecuritySchemeRef{
+						Value: &openapi3.SecurityScheme{
+							Type: "oauth2",
+							Flows: &openapi3.OAuthFlows{
+								AuthorizationCode: &openapi3.OAuthFlow{
+									AuthorizationURL: "/oauth/authorize",
+									TokenURL:         "/oauth/token",
+									Scopes:           map[string]string{},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	doc.SetTykExtension(&oas.XTykAPIGateway{
+		Info: oas.Info{
+			Name:  "oauth2-scope-check",
+			State: oas.State{Active: true},
+		},
+		Upstream: oas.Upstream{URL: TestHttpAny},
+		Server: oas.Server{
+			ListenPath: oas.ListenPath{Value: listenPath, Strip: true},
+			Authentication: &oas.Authentication{
+				Enabled: true,
+				SecuritySchemes: oas.SecuritySchemes{
+					schemeName: &oas.OAuth2{
+						Enabled: true,
+						ScopeCheck: &oas.OAuth2ScopeCheck{
+							Enabled:     true,
+							ScopeSource: oas.OAuth2ScopeSourceGlobal,
+						},
+					},
+				},
+			},
+		},
+	})
+	return doc
+}
+
+func TestOAuth2Middleware_GlobalScopeCheck_EndToEnd(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	doc := newOAuth2GlobalScopeCheckOAS("/scope/", [][]string{{"read:billing", "write:billing"}})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.UseKeylessAccess = true
+		spec.Proxy.ListenPath = "/scope/"
+		spec.IsOAS = true
+		spec.OAS = doc
+	})
+
+	t.Run("token with required scopes passes", func(t *testing.T) {
+		token := makeUnverifiedJWT(t, jwt.MapClaims{"scope": "read:billing write:billing"})
+		ts.Run(t, test.TestCase{
+			Method:  http.MethodGet,
+			Path:    "/scope/anything",
+			Headers: map[string]string{"Authorization": "Bearer " + token},
+			Code:    http.StatusOK,
+		})
+	})
+
+	t.Run("token missing one scope fails 403 with insufficient_scope challenge", func(t *testing.T) {
+		token := makeUnverifiedJWT(t, jwt.MapClaims{"scope": "read:billing"})
+		ts.Run(t, test.TestCase{
+			Method:  http.MethodGet,
+			Path:    "/scope/anything",
+			Headers: map[string]string{"Authorization": "Bearer " + token},
+			Code:    http.StatusForbidden,
+			// JSON body shape — `error_description` is space-joined,
+			// not Go-slice-formatted (`[read:billing write:billing]`).
+			// `scope` matches the header-side advertised set verbatim.
+			BodyMatch: `"error":"insufficient_scope","error_description":"token does not satisfy required scopes: read:billing write:billing","scope":"read:billing write:billing"`,
+			HeadersMatch: map[string]string{
+				header.WWWAuthenticate: `Bearer error="insufficient_scope", error_description="missing required scope: read:billing write:billing", scope="read:billing write:billing"`,
+			},
+		})
+	})
+
+	t.Run("scopes spread across scope and scp claims pass", func(t *testing.T) {
+		token := makeUnverifiedJWT(t, jwt.MapClaims{
+			"scope": "read:billing",
+			"scp":   []string{"write:billing"},
+		})
+		ts.Run(t, test.TestCase{
+			Method:  http.MethodGet,
+			Path:    "/scope/anything",
+			Headers: map[string]string{"Authorization": "Bearer " + token},
+			Code:    http.StatusOK,
+		})
+	})
+
+	t.Run("missing token fails 401 with invalid_token challenge", func(t *testing.T) {
+		ts.Run(t, test.TestCase{
+			Method: http.MethodGet,
+			Path:   "/scope/anything",
+			Code:   http.StatusUnauthorized,
+			HeadersMatch: map[string]string{
+				header.WWWAuthenticate: `Bearer error="invalid_token", error_description="missing bearer token"`,
+			},
+		})
+	})
+
+	t.Run("malformed token fails 401 with invalid_token challenge", func(t *testing.T) {
+		ts.Run(t, test.TestCase{
+			Method:  http.MethodGet,
+			Path:    "/scope/anything",
+			Headers: map[string]string{"Authorization": "Bearer not-a-jwt"},
+			Code:    http.StatusUnauthorized,
+			HeadersMatch: map[string]string{
+				header.WWWAuthenticate: `Bearer error="invalid_token", error_description="token is not a parseable JWT"`,
+			},
+		})
+	})
+}
+
+// TestOAuth2Middleware_DisabledScopeCheck_NoEnforcement verifies the
+// middleware short-circuits when scopeCheck is not enabled — the
+// request is not gated even if no token is presented.
+func TestOAuth2Middleware_DisabledScopeCheck_NoEnforcement(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	doc := newOAuth2GlobalScopeCheckOAS("/scope-off/", [][]string{{"read"}})
+	cfg := doc.GetTykExtension().Server.Authentication.SecuritySchemes["corpOAuth"].(*oas.OAuth2)
+	cfg.ScopeCheck.Enabled = false
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.UseKeylessAccess = true
+		spec.Proxy.ListenPath = "/scope-off/"
+		spec.IsOAS = true
+		spec.OAS = doc
+	})
+
+	ts.Run(t, test.TestCase{
+		Method: http.MethodGet,
+		Path:   "/scope-off/anything",
+		Code:   http.StatusOK,
+	})
+}
+
+// TestOAuth2Middleware_EmptyRequiredScopes_NoEnforcement verifies the
+// middleware short-circuits when scopeCheck is enabled but the global
+// path has nothing to enforce (RequiredScopes empty under
+// global/union).
+func TestOAuth2Middleware_EmptyRequiredScopes_NoEnforcement(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	doc := newOAuth2GlobalScopeCheckOAS("/scope-empty/", nil)
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.UseKeylessAccess = true
+		spec.Proxy.ListenPath = "/scope-empty/"
+		spec.IsOAS = true
+		spec.OAS = doc
+	})
+
+	ts.Run(t, test.TestCase{
+		Method: http.MethodGet,
+		Path:   "/scope-empty/anything",
+		Code:   http.StatusOK,
+	})
+}
+
+// TestOAuth2Middleware_CitedAlternativePreservesDeclaredOrder pins
+// that an operator who declared their AND-row scopes in a specific
+// order sees that same order on the failure challenge — both in the
+// JSON body's `scope` field and in the WWW-Authenticate `scope=`
+// parameter. Sorting would silently rewrite their authored form on
+// the wire; a past PoC of this middleware did exactly that, so this
+// is a regression guard.
+func TestOAuth2Middleware_CitedAlternativePreservesDeclaredOrder(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	doc := newOAuth2GlobalScopeCheckOAS("/scope-order/", [][]string{{"write:billing", "read:billing"}})
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.UseKeylessAccess = true
+		spec.Proxy.ListenPath = "/scope-order/"
+		spec.IsOAS = true
+		spec.OAS = doc
+	})
+
+	token := makeUnverifiedJWT(t, jwt.MapClaims{"scope": "openid"})
+	ts.Run(t, test.TestCase{
+		Method:    http.MethodGet,
+		Path:      "/scope-order/anything",
+		Headers:   map[string]string{"Authorization": "Bearer " + token},
+		Code:      http.StatusForbidden,
+		BodyMatch: `"scope":"write:billing read:billing"`,
+		HeadersMatch: map[string]string{
+			header.WWWAuthenticate: `Bearer error="insufficient_scope", error_description="missing required scope: write:billing read:billing", scope="write:billing read:billing"`,
+		},
+	})
+}
+
+// TestOAuth2Middleware_CitesFirstDeclaredAlternativeOnly pins that
+// an OR-of-AND policy with multiple alternatives cites ONLY the first
+// alternative on the failure challenge — listing every alternative
+// would leak intent (e.g. advertising a service-account scope to a
+// user-token caller). The behavior is documented as a security
+// tradeoff in mw_oauth2.go; this test pins it.
+func TestOAuth2Middleware_CitesFirstDeclaredAlternativeOnly(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	doc := newOAuth2GlobalScopeCheckOAS("/scope-or/", [][]string{{"api:access"}, {"admin"}})
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.UseKeylessAccess = true
+		spec.Proxy.ListenPath = "/scope-or/"
+		spec.IsOAS = true
+		spec.OAS = doc
+	})
+
+	token := makeUnverifiedJWT(t, jwt.MapClaims{"scope": "openid"})
+	ts.Run(t, test.TestCase{
+		Method:       http.MethodGet,
+		Path:         "/scope-or/anything",
+		Headers:      map[string]string{"Authorization": "Bearer " + token},
+		Code:         http.StatusForbidden,
+		BodyMatch:    `"scope":"api:access"`,
+		BodyNotMatch: `admin`,
+		HeadersMatch: map[string]string{
+			header.WWWAuthenticate: `Bearer error="insufficient_scope", error_description="missing required scope: api:access", scope="api:access"`,
+		},
+	})
+}
+
+// TestOAuth2Middleware_NameAgnostic pins the contract that enforcement
+// works regardless of what the operator named the security scheme in
+// OpenAPI components — `prctOauth`, `oauth2`, or any other valid
+// identifier. The other end-to-end tests in this file happen to all
+// use `corpOAuth`; this test deliberately picks a different name to
+// make name-agnosticism an explicit guarantee rather than an incidental
+// coincidence of test data. Pair with the dashboard webclient
+// `resolveSchemeName` contract — both sides must agree on the name.
+func TestOAuth2Middleware_NameAgnostic(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	doc := newOAuth2GlobalScopeCheckOASNamed("/scope-named/", "prctOauth", [][]string{{"abc", "def"}, {"ghi"}})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.UseKeylessAccess = true
+		spec.Proxy.ListenPath = "/scope-named/"
+		spec.IsOAS = true
+		spec.OAS = doc
+	})
+
+	t.Run("token satisfying first AND alternative passes", func(t *testing.T) {
+		token := makeUnverifiedJWT(t, jwt.MapClaims{"scope": "abc def"})
+		ts.Run(t, test.TestCase{
+			Method:  http.MethodGet,
+			Path:    "/scope-named/anything",
+			Headers: map[string]string{"Authorization": "Bearer " + token},
+			Code:    http.StatusOK,
+		})
+	})
+
+	t.Run("token satisfying second OR alternative passes", func(t *testing.T) {
+		token := makeUnverifiedJWT(t, jwt.MapClaims{"scope": "ghi"})
+		ts.Run(t, test.TestCase{
+			Method:  http.MethodGet,
+			Path:    "/scope-named/anything",
+			Headers: map[string]string{"Authorization": "Bearer " + token},
+			Code:    http.StatusOK,
+		})
+	})
+
+	t.Run("token satisfying neither alternative fails 403 citing the first one", func(t *testing.T) {
+		token := makeUnverifiedJWT(t, jwt.MapClaims{"scope": "unrelated"})
+		ts.Run(t, test.TestCase{
+			Method:    http.MethodGet,
+			Path:      "/scope-named/anything",
+			Headers:   map[string]string{"Authorization": "Bearer " + token},
+			Code:      http.StatusForbidden,
+			BodyMatch: `"scope":"abc def"`,
+			HeadersMatch: map[string]string{
+				header.WWWAuthenticate: `Bearer error="insufficient_scope", error_description="missing required scope: abc def", scope="abc def"`,
+			},
+		})
+	})
+}

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -48,6 +48,10 @@ const (
 	CertificateExpiringSoon Event = "CertificateExpiringSoon"
 	// CertificateExpired is the event triggered when a certificate is expired.
 	CertificateExpired Event = "CertificateExpired"
+
+	// OAuth2ScopeCheckFailed fires when an OAS-native scope check
+	// rejects a request (insufficient_scope per RFC 6750 §3.1).
+	OAuth2ScopeCheckFailed Event = "OAuth2ScopeCheckFailed"
 )
 
 // Rate limiter events

--- a/internal/oauth2common/claims.go
+++ b/internal/oauth2common/claims.go
@@ -1,0 +1,60 @@
+// Package oauth2common holds the pure-function helpers used by the
+// gateway-side oauth2 security scheme to read and reason about JWT
+// claims without depending on gateway concrete types.
+//
+// The package depends only on apidef/oas, the JWT library, and the
+// standard library. The dependency arrow flows one direction:
+// gateway/ depends on oauth2common, never the reverse.
+package oauth2common
+
+import (
+	"fmt"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+// ParseUnverifiedClaims parses a JWT *without* verifying its signature
+// or claims, returning the claim set as a map. Used for log/audit field
+// extraction, cache-key derivation, and scope-check field reads. Never
+// returns the token bytes.
+//
+// Security model: callers must ensure the token has been authenticated
+// upstream (e.g. by the JWT or external OAuth introspection middleware).
+// This function intentionally does not verify the JWT signature — the
+// new oauth2 scheme relies on the existing authentication chain for
+// token trust and only consults claim values here. Adding signature
+// verification at this layer would require key material this layer does
+// not own and would duplicate the upstream verifier.
+func ParseUnverifiedClaims(token string) (jwt.MapClaims, error) {
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	parsed, _, err := parser.ParseUnverified(token, jwt.MapClaims{})
+	if err != nil {
+		return nil, err
+	}
+	claims, ok := parsed.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, fmt.Errorf("unexpected claim type %T", parsed.Claims)
+	}
+	return claims, nil
+}
+
+// StringClaim returns the string value at `key` or "" when the claim is
+// absent or has a non-string shape.
+func StringClaim(claims jwt.MapClaims, key string) string {
+	if claims == nil {
+		return ""
+	}
+	if v, ok := claims[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// StringFromAny returns the string value of v or "" when v isn't a
+// string.
+func StringFromAny(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}

--- a/internal/oauth2common/oauth2common_test.go
+++ b/internal/oauth2common/oauth2common_test.go
@@ -1,0 +1,89 @@
+package oauth2common
+
+import (
+	"testing"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringClaim_NilSafe(t *testing.T) {
+	assert.Equal(t, "", StringClaim(nil, "azp"))
+	assert.Equal(t, "", StringClaim(jwt.MapClaims{}, "azp"))
+	assert.Equal(t, "client-1", StringClaim(jwt.MapClaims{"azp": "client-1"}, "azp"))
+}
+
+func TestStringClaim_WrongType(t *testing.T) {
+	// Non-string claims must return "" rather than a stringified form.
+	assert.Equal(t, "", StringClaim(jwt.MapClaims{"azp": 42}, "azp"))
+	assert.Equal(t, "", StringClaim(jwt.MapClaims{"azp": []string{"x"}}, "azp"))
+	assert.Equal(t, "", StringClaim(jwt.MapClaims{"azp": nil}, "azp"))
+}
+
+func TestStringFromAny(t *testing.T) {
+	assert.Equal(t, "", StringFromAny(nil))
+	assert.Equal(t, "", StringFromAny(42))
+	assert.Equal(t, "hello", StringFromAny("hello"))
+}
+
+func TestParseUnverifiedClaims_RoundTrip(t *testing.T) {
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub":   "user-1",
+		"scope": "read write",
+		"azp":   "client-1",
+	})
+	signed, err := tok.SignedString([]byte("test-secret"))
+	require.NoError(t, err)
+
+	claims, err := ParseUnverifiedClaims(signed)
+	require.NoError(t, err)
+	assert.Equal(t, "user-1", StringClaim(claims, "sub"))
+	assert.Equal(t, "read write", StringClaim(claims, "scope"))
+	assert.Equal(t, "client-1", StringClaim(claims, "azp"))
+}
+
+func TestParseUnverifiedClaims_RejectsMalformed(t *testing.T) {
+	_, err := ParseUnverifiedClaims("not-a-jwt")
+	require.Error(t, err)
+}
+
+// TestParseUnverifiedClaims_IgnoresSignature pins the documented
+// security model: ParseUnverifiedClaims must succeed regardless of
+// signature validity. Token authentication is the upstream JWT /
+// introspection middleware's responsibility — this helper only reads
+// claim fields and must not couple to a verifier or a key. If a future
+// "fix" adds signature verification here, this test fails and the
+// reviewer is forced to revisit the godoc and the won't-fix rationale.
+func TestParseUnverifiedClaims_IgnoresSignature(t *testing.T) {
+	t.Run("token signed with arbitrary secret parses fine", func(t *testing.T) {
+		tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"sub": "alice"})
+		signed, err := tok.SignedString([]byte("some-secret-the-gateway-does-not-know"))
+		require.NoError(t, err)
+
+		claims, err := ParseUnverifiedClaims(signed)
+		require.NoError(t, err)
+		assert.Equal(t, "alice", StringClaim(claims, "sub"))
+	})
+
+	t.Run("token with a tampered signature still parses", func(t *testing.T) {
+		tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"sub": "bob"})
+		signed, err := tok.SignedString([]byte("k"))
+		require.NoError(t, err)
+		tampered := signed[:len(signed)-4] + "AAAA"
+
+		claims, err := ParseUnverifiedClaims(tampered)
+		require.NoError(t, err)
+		assert.Equal(t, "bob", StringClaim(claims, "sub"))
+	})
+
+	t.Run("alg=none token parses (verifier elsewhere is responsible for rejecting it)", func(t *testing.T) {
+		tok := jwt.NewWithClaims(jwt.SigningMethodNone, jwt.MapClaims{"sub": "carol"})
+		signed, err := tok.SignedString(jwt.UnsafeAllowNoneSignatureType)
+		require.NoError(t, err)
+
+		claims, err := ParseUnverifiedClaims(signed)
+		require.NoError(t, err)
+		assert.Equal(t, "carol", StringClaim(claims, "sub"))
+	})
+}


### PR DESCRIPTION
## Summary

Adds the OAS-native OAuth 2.0 `scopeCheck` sub-block on the new `oauth2` security scheme and the gateway middleware that enforces it. Required scopes live in the **OAS root `security:` array** — standard OpenAPI Security Requirement Objects, OR-of-AND across entries. The `scopeCheck` block on the Tyk extension carries only the token-side knobs: which JWT claims to read scopes from, how to split string-form values, and which scope-source mode is active. Validation, scope merging across claims, and the RFC 6750 §3 `Bearer SP 1#auth-param` failure challenge all live here.

The scheme is name-agnostic — operators can name the OAS `securitySchemes` entry anything (`oauth2`, `prctOauth`, `corpOAuth`, …); enforcement uses whatever name the document declares.

## Story

- JIRA: https://tyktech.atlassian.net/browse/TT-17173

## Stacked on

This PR is stacked on TT-17172 — TykTechnologies/tyk#8198. Review/merge that first; once it merges this can be retargeted to `master`.

## Companion PRs

These three ship together — please block until all three are green:

- `tyk`: this PR
- `tyk-analytics`: TykTechnologies/tyk-analytics#5629
- `tyk-analytics-ui`: TykTechnologies/tyk-analytics-ui#4370

## Behaviour

### Apidef (`apidef/oas/`)

- `OAuth2ScopeCheck`: `Enabled`, `ClaimNames []string`, `Separator string`, `ScopeSource string`. There is no `Scopes` field — scope policy lives in OAS root `security:`.
- `ScopeSource` constants: `operation`, `global`, `union` (default).
- Map-probe disambiguator (`asOAuth2Scheme` + `mapHasOAuth2SubBlock`) tells the OAS-native `OAuth2` scheme apart from legacy `*OAuth` / `*ExternalOAuth` schemes after JSON round-trip — recognised by presence of an oauth2 sub-block key.
- `SecurityRequirementScopes [][]map[string][]string` sibling field on `apidef.APIDefinition` preserves per-scheme scope arrays across the extract/fill round-trip (omitempty; forward-compatible).
- `extractSecurityTo` single-alternative branch: populates `SecurityRequirements` with every scheme in the requirement (including empty-scope ones like `jwtAuth: []`) so multi-scheme single-AND security policies (JWT + OAuth2 in one entry) survive round-trip without silently dropping the JWT scheme.
- Validator rejects an unknown `scopeSource` at API load with a clear error.
- Strict + non-strict OAS schemas declare `X-Tyk-OAuth2-ScopeCheck` with the four token-side fields.

### Gateway (`gateway/mw_oauth2.go`)

- `OAuth2Middleware` enforces scope check when `oauth2.enabled` and `scopeCheck.enabled` are both true.
- `rootSecurityAlternatives(security, schemeName, scopeCheck)` reads root `security:` and returns the OR-of-AND list of alternatives drawn from entries that reference the configured scheme. Declared order is preserved end-to-end so the operator sees their authored form on the failure challenge.
- Token's scope set is the **merged union** across every claim in `ClaimNames` (default `["scope", "scp"]`). Each claim value is parsed by `Separator` (default single space), JSON array form, or comma-separated form per RFC 6749 §3.3.
- On insufficient scope: 403, RFC 6750 §3 `WWW-Authenticate: Bearer error="insufficient_scope" …` challenge citing the **first** declared alternative only (intentionally — listing every alternative would leak that the API has a service-account path and a user path), JSON body with `error` / `error_description` / `scope`, and an `OAuth2ScopeCheckFailed` audit event carrying the cited alternative + full alternative list.
- An entry that lists the scheme with an empty scope list (`security: - oauth2: []`) is treated as "auth required, no specific scope" — vacuously satisfied, short-circuits the OR to pass.

### Wire-protocol constants

- `OAuth2ErrInsufficientScope` = `"insufficient_scope"` (RFC 6750 §3.1)
- `OAuth2ErrInvalidToken` = `"invalid_token"` (RFC 6750 §3.1)

## Test plan

- [x] `go test ./apidef/oas/ ./gateway/ ./internal/oauth2common/` — unit tests cover: nil/empty/operation-suppression, single-AND, OR-across, OR-of-AND, sort+dedup, vacuous-satisfaction, multi-scheme single-alternative round-trip preservation, name-agnostic enforcement (`TestOAuth2Middleware_NameAgnostic`), RFC 6750 §3 challenge header form
- [x] Python e2e — runs in the dashboard companion PR
- [ ] Postman collection via newman
- [ ] Manual smoke

## Risk

Failure-challenge form cites only the first declared alternative — deliberate, regression-tested. The strict-schema deltas across four schema files must stay in sync. The map-probe disambiguator's sub-block key list (`oauth2SubBlockKeys`) needs an entry added whenever a new OAuth2 sub-block is introduced, otherwise the typed view is silently dropped on JSON round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-17173" title="TT-17173" target="_blank">TT-17173</a>
</summary>

|         |    |
|---------|----|
| Status  | Merge |
| Summary | OAuth2 scope check — global / API level |

Generated at: 2026-05-26 15:20:57

</details>

<!---TykTechnologies/jira-linter ends here-->



