### PR TITLE
[TT-17174] OAuth2 scope check (per-operation / per-MCP-primitive)

### DIFF
--- a/apidef/mcp/schema/x-tyk-api-gateway.json
+++ b/apidef/mcp/schema/x-tyk-api-gateway.json
@@ -1055,8 +1055,22 @@
         },
         "rateLimit": {
           "$ref": "#/definitions/X-Tyk-RateLimit"
+        },
+        "scopeCheck": {
+          "$ref": "#/definitions/X-Tyk-ScopeCheck"
         }
       }
+    },
+    "X-Tyk-ScopeCheck": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "enabled"
+      ]
     },
     "X-Tyk-Operations": {
       "type": "object",
@@ -1115,6 +1129,22 @@
         },
         "rateLimit": {
           "$ref": "#/definitions/X-Tyk-RateLimit"
+        },
+        "scopeCheck": {
+          "$ref": "#/definitions/X-Tyk-ScopeCheck"
+        },
+        "security": {
+          "type": "array",
+          "description": "Per-primitive OAS-style security requirements (OR-of-AND). Each item maps a security-scheme name to the list of scopes the inbound token must carry; the primitive is authorized when any one alternative is fully satisfied. Enforced by the oauth2 scope-check middleware when scopeSource resolves to \"operation\" or \"union\".",
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
         }
       }
     },

--- a/apidef/oas/mcp_primitive.go
+++ b/apidef/oas/mcp_primitive.go
@@ -1,11 +1,23 @@
 package oas
 
-import "github.com/TykTechnologies/tyk/apidef"
+import (
+	"github.com/getkin/kin-openapi/openapi3"
+
+	"github.com/TykTechnologies/tyk/apidef"
+)
 
 // MCPPrimitive holds middleware configuration for MCP primitives (tools, resources, prompts).
 // It embeds Operation to reuse all standard middleware (rate limiting, transforms, caching, etc.).
 type MCPPrimitive struct {
 	Operation
+
+	// Security mirrors the OAS `security:` array shape (one item per OR
+	// branch, each a map of scheme name → required scopes). It is the
+	// primitive-level equivalent of an OAS path operation's `security`
+	// field, since MCP primitives have no openapi3.Operation of their own.
+	// Read by the oauth2 scope-check middleware when scopeSource resolves
+	// to "operation" or "union".
+	Security openapi3.SecurityRequirements `bson:"security,omitempty" json:"security,omitempty"`
 }
 
 // extractTransformResponseBodyTo overrides Operation to disable response body transformation.

--- a/apidef/oas/oauth2.go
+++ b/apidef/oas/oauth2.go
@@ -1,6 +1,8 @@
 package oas
 
 import (
+	"sort"
+
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
@@ -75,6 +77,15 @@ type OAuth2ScopeCheck struct {
 	// `security:`, the OAS root `security:`, or both. Defaults to
 	// "union".
 	ScopeSource string `bson:"scopeSource,omitempty" json:"scopeSource,omitempty"`
+}
+
+// ScopeCheck toggles the operation-level OAuth 2.0 scope check on an
+// operation or MCP primitive. Omitted means enforced; the required
+// scopes themselves live in the OAS `security:` array.
+type ScopeCheck struct {
+	// Enabled enforces the operation's scope check when true. Set it
+	// false to exempt the operation (e.g. scopes enforced upstream).
+	Enabled bool `bson:"enabled" json:"enabled"`
 }
 
 // ScopeSource constants for OAuth2ScopeCheck.ScopeSource.
@@ -289,4 +300,95 @@ func (s *OAS) GetTykOAuth2Config(name string) *OAuth2 {
 // OAS-native OAuth2 scheme.
 func (s *OAS) IsOAuth2Scheme(name string) bool {
 	return s.GetTykOAuth2Config(name) != nil
+}
+
+// collectOAuth2SchemeNames returns the set of configured OAuth2
+// security-scheme names (in the new-style oauth2-block sense).
+func (s *OAS) collectOAuth2SchemeNames() map[string]struct{} {
+	names := map[string]struct{}{}
+	tykAuth := s.getTykAuthentication()
+	if tykAuth == nil || tykAuth.SecuritySchemes == nil {
+		return names
+	}
+	for name, scheme := range tykAuth.SecuritySchemes {
+		if asOAuth2Scheme(scheme) != nil {
+			names[name] = struct{}{}
+		}
+	}
+	return names
+}
+
+// DeriveOAuth2Scopes returns the set of scopes declared across the OAS
+// document's `security:` arrays for every configured oauth2 scheme:
+// the root-level `security:`, each path operation's `security:`, and
+// every MCP primitive's `security:` (tools, resources, prompts).
+// Entries referencing non-oauth2 schemes are ignored. The result is a
+// set; callers needing a stable order use SortedOAuth2Scopes.
+func (s *OAS) DeriveOAuth2Scopes() map[string]struct{} {
+	scopes := map[string]struct{}{}
+	oauth2Names := s.collectOAuth2SchemeNames()
+	if len(oauth2Names) == 0 {
+		return scopes
+	}
+
+	collect := func(reqs openapi3.SecurityRequirements) {
+		for _, req := range reqs {
+			for schemeName, scopeList := range req {
+				if _, ok := oauth2Names[schemeName]; !ok {
+					continue
+				}
+				for _, sc := range scopeList {
+					if sc == "" {
+						continue
+					}
+					scopes[sc] = struct{}{}
+				}
+			}
+		}
+	}
+
+	collect(s.Security)
+
+	if s.Paths != nil {
+		for _, pathItem := range s.Paths.Map() {
+			if pathItem == nil {
+				continue
+			}
+			for _, op := range pathItem.Operations() {
+				if op == nil || op.Security == nil {
+					continue
+				}
+				collect(*op.Security)
+			}
+		}
+	}
+
+	if mw := s.GetTykMiddleware(); mw != nil {
+		walk := func(prims MCPPrimitives) {
+			for _, prim := range prims {
+				if prim == nil {
+					continue
+				}
+				collect(prim.Security)
+			}
+		}
+		walk(mw.McpTools)
+		walk(mw.McpResources)
+		walk(mw.McpPrompts)
+	}
+
+	return scopes
+}
+
+// SortedOAuth2Scopes returns DeriveOAuth2Scopes as a sorted, stable
+// list. Used to populate read-only "scopes this API advertises"
+// previews and the OAS Components security-scheme scope vocabulary.
+func (s *OAS) SortedOAuth2Scopes() []string {
+	set := s.DeriveOAuth2Scopes()
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/apidef/oas/oauth2.go
+++ b/apidef/oas/oauth2.go
@@ -331,53 +331,67 @@ func (s *OAS) DeriveOAuth2Scopes() map[string]struct{} {
 		return scopes
 	}
 
-	collect := func(reqs openapi3.SecurityRequirements) {
-		for _, req := range reqs {
-			for schemeName, scopeList := range req {
-				if _, ok := oauth2Names[schemeName]; !ok {
-					continue
-				}
-				for _, sc := range scopeList {
-					if sc == "" {
-						continue
-					}
-					scopes[sc] = struct{}{}
-				}
-			}
-		}
-	}
-
-	collect(s.Security)
-
-	if s.Paths != nil {
-		for _, pathItem := range s.Paths.Map() {
-			if pathItem == nil {
-				continue
-			}
-			for _, op := range pathItem.Operations() {
-				if op == nil || op.Security == nil {
-					continue
-				}
-				collect(*op.Security)
-			}
-		}
-	}
-
-	if mw := s.GetTykMiddleware(); mw != nil {
-		walk := func(prims MCPPrimitives) {
-			for _, prim := range prims {
-				if prim == nil {
-					continue
-				}
-				collect(prim.Security)
-			}
-		}
-		walk(mw.McpTools)
-		walk(mw.McpResources)
-		walk(mw.McpPrompts)
-	}
+	addOAuth2Scopes(scopes, s.Security, oauth2Names)
+	s.addOAuth2ScopesFromPaths(scopes, oauth2Names)
+	s.addOAuth2ScopesFromMCPPrimitives(scopes, oauth2Names)
 
 	return scopes
+}
+
+// addOAuth2Scopes records every non-empty scope that reqs attaches to a
+// recognised oauth2 scheme into scopes.
+func addOAuth2Scopes(scopes map[string]struct{}, reqs openapi3.SecurityRequirements, oauth2Names map[string]struct{}) {
+	for _, req := range reqs {
+		for schemeName, scopeList := range req {
+			if _, ok := oauth2Names[schemeName]; !ok {
+				continue
+			}
+			addNonEmptyScopes(scopes, scopeList)
+		}
+	}
+}
+
+// addNonEmptyScopes records each non-empty entry of list into scopes.
+func addNonEmptyScopes(scopes map[string]struct{}, list []string) {
+	for _, sc := range list {
+		if sc != "" {
+			scopes[sc] = struct{}{}
+		}
+	}
+}
+
+// addOAuth2ScopesFromPaths collects oauth2 scopes from every path
+// operation's `security:` requirement.
+func (s *OAS) addOAuth2ScopesFromPaths(scopes map[string]struct{}, oauth2Names map[string]struct{}) {
+	if s.Paths == nil {
+		return
+	}
+	for _, pathItem := range s.Paths.Map() {
+		if pathItem == nil {
+			continue
+		}
+		for _, op := range pathItem.Operations() {
+			if op != nil && op.Security != nil {
+				addOAuth2Scopes(scopes, *op.Security, oauth2Names)
+			}
+		}
+	}
+}
+
+// addOAuth2ScopesFromMCPPrimitives collects oauth2 scopes from every MCP
+// primitive's `security:` requirement (tools, resources, prompts).
+func (s *OAS) addOAuth2ScopesFromMCPPrimitives(scopes map[string]struct{}, oauth2Names map[string]struct{}) {
+	mw := s.GetTykMiddleware()
+	if mw == nil {
+		return
+	}
+	for _, prims := range []MCPPrimitives{mw.McpTools, mw.McpResources, mw.McpPrompts} {
+		for _, prim := range prims {
+			if prim != nil {
+				addOAuth2Scopes(scopes, prim.Security, oauth2Names)
+			}
+		}
+	}
 }
 
 // SortedOAuth2Scopes returns DeriveOAuth2Scopes as a sorted, stable

--- a/apidef/oas/oauth2_test.go
+++ b/apidef/oas/oauth2_test.go
@@ -314,3 +314,72 @@ func TestOAuth2_FillExtractPreservesSchemeNameVerbatim(t *testing.T) {
 		assert.False(t, found, "fill must not materialise an aliased name %q", alias)
 	}
 }
+
+func TestOAS_DeriveOAuth2Scopes_NoOAuth2Scheme(t *testing.T) {
+	s := &OAS{}
+	s.T.OpenAPI = "3.0.3"
+	s.T.Info = &openapi3.Info{Title: "test", Version: "1.0"}
+	s.T.Security = openapi3.SecurityRequirements{{"jwtAuth": {"x"}}}
+	assert.Empty(t, s.SortedOAuth2Scopes())
+}
+
+func TestOAS_DeriveOAuth2Scopes_RootPerOpAndMCP(t *testing.T) {
+	s := newOAuth2Fixture("corpOAuth")
+	s.T.Security = openapi3.SecurityRequirements{
+		{"corpOAuth": {"api:access"}},
+		{"jwtAuth": {"ignored"}},
+	}
+
+	s.Paths = openapi3.NewPaths()
+	pi := &openapi3.PathItem{}
+	pi.Get = &openapi3.Operation{Security: &openapi3.SecurityRequirements{
+		{"corpOAuth": {"users:read"}},
+		{"corpOAuth": {"users:all"}},
+	}}
+	s.Paths.Set("/users", pi)
+
+	ext := s.GetTykExtension()
+	ext.Middleware = &Middleware{
+		McpTools: MCPPrimitives{
+			"create_user": {Security: openapi3.SecurityRequirements{{"corpOAuth": {"users:write"}}}},
+		},
+		McpResources: MCPPrimitives{
+			"file": {Security: openapi3.SecurityRequirements{{"corpOAuth": {"files:read"}}}},
+		},
+	}
+
+	assert.Equal(t, []string{"api:access", "files:read", "users:all", "users:read", "users:write"}, s.SortedOAuth2Scopes())
+}
+
+func TestMCPPrimitive_RoundTripJSONPreservesSecurity(t *testing.T) {
+	p := &MCPPrimitive{Security: openapi3.SecurityRequirements{
+		{"corpOAuth": {"users:write", "audit:write"}},
+		{"corpOAuth": {"admin"}},
+	}}
+	b, err := json.Marshal(p)
+	require.NoError(t, err)
+
+	var out MCPPrimitive
+	require.NoError(t, json.Unmarshal(b, &out))
+	require.Len(t, out.Security, 2)
+	assert.Equal(t, []string{"users:write", "audit:write"}, out.Security[0]["corpOAuth"])
+	assert.Equal(t, []string{"admin"}, out.Security[1]["corpOAuth"])
+}
+
+// TestScopeCheck_RoundTrip pins that the per-operation scopeCheck block
+// survives a JSON round-trip and is omitted when absent.
+func TestScopeCheck_RoundTrip(t *testing.T) {
+	op := Operation{ScopeCheck: &ScopeCheck{Enabled: false}}
+
+	data, err := json.Marshal(op)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"scopeCheck":{"enabled":false}`)
+
+	var got Operation
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, op.ScopeCheck, got.ScopeCheck)
+
+	empty, err := json.Marshal(Operation{})
+	require.NoError(t, err)
+	assert.NotContains(t, string(empty), "scopeCheck")
+}

--- a/apidef/oas/oauth2_test.go
+++ b/apidef/oas/oauth2_test.go
@@ -317,15 +317,15 @@ func TestOAuth2_FillExtractPreservesSchemeNameVerbatim(t *testing.T) {
 
 func TestOAS_DeriveOAuth2Scopes_NoOAuth2Scheme(t *testing.T) {
 	s := &OAS{}
-	s.T.OpenAPI = "3.0.3"
-	s.T.Info = &openapi3.Info{Title: "test", Version: "1.0"}
-	s.T.Security = openapi3.SecurityRequirements{{"jwtAuth": {"x"}}}
+	s.OpenAPI = "3.0.3"
+	s.Info = &openapi3.Info{Title: "test", Version: "1.0"}
+	s.Security = openapi3.SecurityRequirements{{"jwtAuth": {"x"}}}
 	assert.Empty(t, s.SortedOAuth2Scopes())
 }
 
 func TestOAS_DeriveOAuth2Scopes_RootPerOpAndMCP(t *testing.T) {
 	s := newOAuth2Fixture("corpOAuth")
-	s.T.Security = openapi3.SecurityRequirements{
+	s.Security = openapi3.SecurityRequirements{
 		{"corpOAuth": {"api:access"}},
 		{"jwtAuth": {"ignored"}},
 	}

--- a/apidef/oas/operation.go
+++ b/apidef/oas/operation.go
@@ -86,6 +86,9 @@ type Operation struct {
 
 	// RateLimit contains endpoint level rate limit configuration.
 	RateLimit *RateLimitEndpoint `bson:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+
+	// ScopeCheck toggles the operation-level OAuth 2.0 scope check.
+	ScopeCheck *ScopeCheck `bson:"scopeCheck,omitempty" json:"scopeCheck,omitempty"`
 }
 
 // ExtractToExtendedPaths extracts operation-level middleware configuration into a classic

--- a/apidef/oas/operation_test.go
+++ b/apidef/oas/operation_test.go
@@ -83,6 +83,7 @@ func TestOAS_PathsAndOperations(t *testing.T) {
 	operation.MockResponse = nil                      // This one also fills native part, let's skip it for this test.
 	operation.URLRewrite = nil                        // This one also fills native part, let's skip it for this test.
 	operation.Internal = nil                          // This one also fills native part, let's skip it for this test.
+	operation.ScopeCheck = nil                        // OAS-native; no classic ExtendedPaths equivalent.
 	operation.TransformRequestBody.Path = ""          // if `path` and `body` are present, `body` would take precedence, detailed tests can be found in middleware_test.go
 	operation.TransformResponseBody.Path = ""         // if `path` and `body` are present, `body` would take precedence, detailed tests can be found in middleware_test.go
 	operation.VirtualEndpoint.Path = ""               // if `path` and `body` are present, `body` would take precedence, detailed tests can be found in middleware_test.go

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -1064,8 +1064,22 @@
         },
         "rateLimit": {
           "$ref": "#/definitions/X-Tyk-RateLimit"
+        },
+        "scopeCheck": {
+          "$ref": "#/definitions/X-Tyk-ScopeCheck"
         }
       }
+    },
+    "X-Tyk-ScopeCheck": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "enabled"
+      ]
     },
     "X-Tyk-Operations": {
       "type": "object",

--- a/apidef/oas/schema/x-tyk-api-gateway.strict.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.strict.json
@@ -1109,8 +1109,23 @@
         },
         "rateLimit": {
           "$ref": "#/definitions/X-Tyk-RateLimit"
+        },
+        "scopeCheck": {
+          "$ref": "#/definitions/X-Tyk-ScopeCheck"
         }
       },
+      "additionalProperties": false
+    },
+    "X-Tyk-ScopeCheck": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     },
     "X-Tyk-Operations": {

--- a/apidef/streams/schema/x-tyk-api-gateway.json
+++ b/apidef/streams/schema/x-tyk-api-gateway.json
@@ -1018,8 +1018,22 @@
         },
         "rateLimit": {
           "$ref": "#/definitions/X-Tyk-RateLimit"
+        },
+        "scopeCheck": {
+          "$ref": "#/definitions/X-Tyk-ScopeCheck"
         }
       }
+    },
+    "X-Tyk-ScopeCheck": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "enabled"
+      ]
     },
     "X-Tyk-Operations": {
       "type": "object",

--- a/gateway/model_apispec.go
+++ b/gateway/model_apispec.go
@@ -268,15 +268,12 @@ func (a *APISpec) injectIntoReqContext(req *http.Request) {
 	}
 }
 
-func (a *APISpec) findOperation(r *http.Request) *Operation {
-	middleware := a.OAS.GetTykMiddleware()
-	if middleware == nil {
-		return nil
-	}
-
+// findOASRoute matches the request to an OAS route via the API's OAS
+// router (path templates included). Returns nil when none matches.
+func (a *APISpec) findOASRoute(r *http.Request) (*routers.Route, map[string]string) {
 	if a.oasRouter == nil {
 		log.Warningf("OAS router not initialized properly. Unable to find route for %s %v", r.Method, r.URL)
-		return nil
+		return nil, nil
 	}
 
 	rClone := *r
@@ -286,11 +283,25 @@ func (a *APISpec) findOperation(r *http.Request) *Operation {
 
 	if errors.Is(err, routers.ErrPathNotFound) {
 		log.Tracef("Unable to find route for %s %v at spec %v", r.Method, r.URL, a.Id)
-		return nil
+		return nil, nil
 	}
 
 	if err != nil {
 		log.Errorf("Error finding route: %v", err)
+		return nil, nil
+	}
+
+	return route, pathParams
+}
+
+func (a *APISpec) findOperation(r *http.Request) *Operation {
+	middleware := a.OAS.GetTykMiddleware()
+	if middleware == nil {
+		return nil
+	}
+
+	route, pathParams := a.findOASRoute(r)
+	if route == nil {
 		return nil
 	}
 

--- a/gateway/mw_oauth2.go
+++ b/gateway/mw_oauth2.go
@@ -14,6 +14,7 @@ import (
 	"github.com/TykTechnologies/tyk/apidef/oas"
 	"github.com/TykTechnologies/tyk/header"
 	"github.com/TykTechnologies/tyk/internal/event"
+	"github.com/TykTechnologies/tyk/internal/httpctx"
 	"github.com/TykTechnologies/tyk/internal/middleware"
 	"github.com/TykTechnologies/tyk/internal/oauth2common"
 )
@@ -25,13 +26,12 @@ const (
 )
 
 // OAuth2Middleware enforces OAS-native scope checks for the new
-// oauth2 security scheme. When scopeCheck is enabled and the
-// configured scopeSource reads the OAS root `security:` array, every
-// request hitting the API must present a token whose merged scope
-// set (across the configured ClaimNames) satisfies at least one
-// Security Requirement Object that references the scheme. Per-OAS:
-// outer entries are OR-alternatives; scopes within an entry are
-// AND-required.
+// oauth2 security scheme. When scopeCheck is enabled, the required
+// scope set for a request is resolved from the matched OAS operation's
+// (or matched MCP primitive's) `security:` array and/or the OAS root
+// `security:` array, depending on scopeSource. The request authorizes
+// when the token's merged scope set (across the configured ClaimNames)
+// satisfies at least one of the resolved OR-of-AND alternatives.
 type OAuth2Middleware struct {
 	*BaseMiddleware
 }
@@ -60,14 +60,15 @@ func (m *OAuth2Middleware) ProcessRequest(w http.ResponseWriter, r *http.Request
 		return nil, http.StatusOK
 	}
 
-	schemeName, cfg := m.Spec.GetOAuth2Config()
+	_, cfg := m.Spec.GetOAuth2Config()
 	if cfg == nil || cfg.ScopeCheck == nil || !cfg.ScopeCheck.Enabled {
 		return nil, http.StatusOK
 	}
 
-	alternatives := rootSecurityAlternatives(m.Spec.OAS.Security, schemeName, cfg.ScopeCheck)
+	alternatives := m.requiredScopeAlternativesForRequest(r)
 	if len(alternatives) == 0 {
-		// Root security has nothing to enforce for this scheme.
+		// Nothing to enforce for this request (no per-op `security:`,
+		// no root `security:`, or the resolved requirement is vacuous).
 		return nil, http.StatusOK
 	}
 
@@ -83,33 +84,236 @@ func (m *OAuth2Middleware) ProcessRequest(w http.ResponseWriter, r *http.Request
 		return fmt.Errorf("parsing inbound token claims: %w", err), http.StatusUnauthorized
 	}
 
-	if !tokenSatisfiesAnyAlternative(claims, cfg.ScopeCheck, alternatives) {
-		// First alternative is cited on the challenge — listing every
-		// alternative would leak intent (a service-account scope
-		// shouldn't be advertised to a user-token caller).
-		cited := alternatives[0]
-		citedScopes := strings.Join(cited, " ")
-		m.fireScopeCheckFailedEvent(r, claims, alternatives, cited, cfg.ScopeCheck)
-		m.setWWWAuthenticateInsufficientScope(w, cited)
-		body, err := json.Marshal(map[string]interface{}{
-			"error":             oas.OAuth2ErrInsufficientScope,
-			"error_description": "token does not satisfy required scopes: " + citedScopes,
-			"scope":             citedScopes,
-		})
-		if err != nil {
-			m.Logger().WithError(err).Error("oauth2: marshal scope-check response body")
-			w.WriteHeader(http.StatusForbidden)
-			return nil, middleware.StatusRespond
-		}
-		w.Header().Set(header.ContentType, header.ApplicationJSON)
-		w.WriteHeader(http.StatusForbidden)
-		if _, err := w.Write(body); err != nil {
-			m.Logger().WithError(err).Debug("oauth2: write scope-check response body")
-		}
-		return nil, middleware.StatusRespond
+	if tokenSatisfiesAnyAlternative(claims, cfg.ScopeCheck, alternatives) {
+		return nil, http.StatusOK
 	}
 
-	return nil, http.StatusOK
+	// The first declared alternative is cited on the challenge — listing
+	// every alternative would leak intent (a service-account scope
+	// shouldn't be advertised to a user-token caller).
+	cited := alternatives[0]
+	citedScopes := strings.Join(cited, " ")
+	m.fireScopeCheckFailedEvent(r, claims, alternatives, cited, cfg.ScopeCheck)
+	m.setWWWAuthenticateInsufficientScope(w, cited)
+
+	// MCP / JSON-RPC routes get the failure wrapped in a JSON-RPC 2.0
+	// error envelope by the chain's error handler (which keys off the
+	// routing state). REST routes get the RFC 6750-style JSON body
+	// written inline.
+	if m.Spec.IsMCP() && httpctx.GetJSONRPCRoutingState(r) != nil {
+		return errors.New(oas.OAuth2ErrInsufficientScope), http.StatusForbidden
+	}
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"error":             oas.OAuth2ErrInsufficientScope,
+		"error_description": "token does not satisfy required scopes: " + citedScopes,
+		"scope":             citedScopes,
+	})
+	w.Header().Set(header.ContentType, header.ApplicationJSON)
+	w.WriteHeader(http.StatusForbidden)
+	_, _ = w.Write(body)
+	return nil, middleware.StatusRespond
+}
+
+// requiredScopeAlternativesForRequest resolves the OR-of-AND scope
+// requirement for this request. Each inner slice is one AND-group
+// (alternative); the request authorizes when at least one alternative
+// is fully satisfied. Composition depends on scopeSource:
+//
+//   - "global": the global Scopes alternatives only; per-op/primitive
+//     `security:` is ignored.
+//   - "operation": the matched OAS operation's (or matched MCP
+//     primitive's) `security:` alternatives only.
+//   - "union" (default): both — every request must satisfy at least
+//     one per-op alternative AND at least one global alternative. This
+//     is expressed as the cross-product (each per-op alternative ANDed
+//     with each global alternative). With no per-op `security:`, it
+//     collapses to the global list; with no global Scopes, to the
+//     per-op list.
+//
+// An empty AND-group in the resolved set means "this alternative
+// requires no oauth2 scope" — that makes the whole requirement
+// trivially satisfiable, so nil is returned and the scope-check gate
+// (including the missing-token check) is skipped entirely. This is how
+// an operation guarded by another scheme (e.g. JWT) coexists with an
+// API that also configures oauth2 scope check.
+func (m *OAuth2Middleware) requiredScopeAlternativesForRequest(r *http.Request) [][]string {
+	schemeName, cfg := m.Spec.GetOAuth2Config()
+	if cfg == nil || cfg.ScopeCheck == nil || !cfg.ScopeCheck.Enabled {
+		return nil
+	}
+	source := oauth2ScopeSource(cfg)
+
+	var perOp [][]string
+	if source == oas.OAuth2ScopeSourceOperation || source == oas.OAuth2ScopeSourceUnion {
+		perOp = m.perOperationScopeAlternatives(r)
+	}
+	var global [][]string
+	if source == oas.OAuth2ScopeSourceGlobal || source == oas.OAuth2ScopeSourceUnion {
+		global = rootSecurityAlternatives(m.Spec.OAS.Security, schemeName, cfg.ScopeCheck)
+	}
+
+	var combined [][]string
+	switch source {
+	case oas.OAuth2ScopeSourceGlobal:
+		combined = global
+	case oas.OAuth2ScopeSourceOperation:
+		combined = perOp
+	default: // union
+		combined = unionScopeAlternatives(perOp, global)
+	}
+
+	if len(combined) == 0 {
+		return nil
+	}
+	for _, alt := range combined {
+		if len(alt) == 0 {
+			// A trivially-satisfiable alternative makes the whole
+			// OR-of-AND requirement vacuous.
+			return nil
+		}
+	}
+	return combined
+}
+
+// perOperationScopeAlternatives gathers the OR-of-AND scope
+// alternatives declared on the matched MCP primitive and/or the
+// matched OAS REST operation, restricted to this API's oauth2
+// scheme(s). An OAS `security:` entry that doesn't reference an oauth2
+// scheme contributes the empty AND-group (it's authorized by some
+// other scheme), preserving coexistence.
+func (m *OAuth2Middleware) perOperationScopeAlternatives(r *http.Request) [][]string {
+	oauth2Names := m.oauth2SchemeNames()
+	if len(oauth2Names) == 0 {
+		return nil
+	}
+
+	mw := m.Spec.OAS.GetTykMiddleware()
+	var out [][]string
+
+	// MCP primitive scopes — the JSONRPC middleware resolves the
+	// primitive name before the auth chain runs and stashes it in the
+	// routing state. Non-tools/call methods (e.g. initialize) leave it
+	// empty, so no per-primitive enforcement runs for them. A primitive
+	// whose scopeCheck is disabled contributes nothing.
+	if state := httpctx.GetJSONRPCRoutingState(r); state != nil && state.PrimitiveName != "" && mw != nil {
+		for _, prims := range []oas.MCPPrimitives{mw.McpTools, mw.McpResources, mw.McpPrompts} {
+			if prim, ok := prims[state.PrimitiveName]; ok && prim != nil && scopeCheckEnabled(prim.ScopeCheck) {
+				out = appendOAuth2Alternatives(out, prim.Security, oauth2Names)
+			}
+		}
+	}
+
+	// REST operation `security:` from the matched OAS operation, unless
+	// the operation's scopeCheck is disabled.
+	if op := m.findOASOperation(r); op != nil && op.Security != nil &&
+		scopeCheckEnabled(tykOperationScopeCheck(mw, op.OperationID)) {
+		out = appendOAuth2Alternatives(out, *op.Security, oauth2Names)
+	}
+
+	return out
+}
+
+// scopeCheckEnabled reports whether the operation-level scope check is
+// switched on. It is opt-in: the scopeCheck block must be present and
+// enabled. An absent block, or enabled:false, leaves it off.
+func scopeCheckEnabled(sc *oas.ScopeCheck) bool {
+	return sc != nil && sc.Enabled
+}
+
+// tykOperationScopeCheck returns the scopeCheck block for the x-tyk
+// operation with the given ID, or nil when none is configured.
+func tykOperationScopeCheck(mw *oas.Middleware, operationID string) *oas.ScopeCheck {
+	if mw == nil || operationID == "" {
+		return nil
+	}
+	if op, ok := mw.Operations[operationID]; ok && op != nil {
+		return op.ScopeCheck
+	}
+	return nil
+}
+
+// unionScopeAlternatives combines two OR-of-AND alternative lists for
+// scopeSource "union": the request must satisfy at least one per-op
+// alternative AND at least one global alternative, which is the
+// cross-product (each per-op alternative ANDed with each global
+// alternative, per-op scopes first then global, deduplicated). When
+// either side is empty the other passes through unchanged.
+func unionScopeAlternatives(perOp, global [][]string) [][]string {
+	switch {
+	case len(perOp) == 0:
+		return global
+	case len(global) == 0:
+		return perOp
+	}
+	out := make([][]string, 0, len(perOp)*len(global))
+	for _, p := range perOp {
+		for _, g := range global {
+			merged := make([]string, 0, len(p)+len(g))
+			merged = append(merged, p...)
+			merged = append(merged, g...)
+			out = append(out, dedupePreserveOrder(merged))
+		}
+	}
+	return out
+}
+
+// appendOAuth2Alternatives converts an OAS SecurityRequirements list
+// (OR of alternatives, each AND across schemes) into one AND-group per
+// alternative, keeping only the scopes attached to a recognised oauth2
+// scheme. Declared scope order is preserved; duplicates are dropped.
+func appendOAuth2Alternatives(out [][]string, reqs openapi3.SecurityRequirements, oauth2Names map[string]struct{}) [][]string {
+	for _, req := range reqs {
+		var alt []string
+		for schemeName, scopes := range req {
+			if _, ok := oauth2Names[schemeName]; !ok {
+				continue
+			}
+			alt = append(alt, scopes...)
+		}
+		out = append(out, dedupePreserveOrder(alt))
+	}
+	return out
+}
+
+// oauth2ScopeSource resolves the configured ScopeSource, defaulting to
+// "union" (and treating any unrecognised value as "union" — the
+// validator rejects bad values at API-load, so this only guards
+// runtime defaults).
+func oauth2ScopeSource(cfg *oas.OAuth2) string {
+	if cfg == nil || cfg.ScopeCheck == nil {
+		return oas.OAuth2ScopeSourceUnion
+	}
+	switch cfg.ScopeCheck.ScopeSource {
+	case oas.OAuth2ScopeSourceGlobal, oas.OAuth2ScopeSourceOperation, oas.OAuth2ScopeSourceUnion:
+		return cfg.ScopeCheck.ScopeSource
+	default:
+		return oas.OAuth2ScopeSourceUnion
+	}
+}
+
+func (m *OAuth2Middleware) oauth2SchemeNames() map[string]struct{} {
+	names := map[string]struct{}{}
+	ext := m.Spec.OAS.GetTykExtension()
+	if ext == nil || ext.Server.Authentication == nil {
+		return names
+	}
+	for name := range ext.Server.Authentication.SecuritySchemes {
+		if m.Spec.OAS.IsOAuth2Scheme(name) {
+			names[name] = struct{}{}
+		}
+	}
+	return names
+}
+
+// findOASOperation returns the OAS operation matched for this request
+// via the router, or nil. Router-based so path templates resolve.
+func (m *OAuth2Middleware) findOASOperation(r *http.Request) *openapi3.Operation {
+	route, _ := m.Spec.findOASRoute(r)
+	if route == nil {
+		return nil
+	}
+	return route.Operation
 }
 
 // rootSecurityAlternatives returns the OR-of-AND list of alternatives
@@ -153,9 +357,11 @@ func rootSecurityAlternatives(security openapi3.SecurityRequirements, schemeName
 	return out
 }
 
-// dedupePreserveOrder returns the input slice with empty entries removed
-// and duplicates dropped, preserving the declared order of first
-// occurrence.
+// dedupePreserveOrder returns the input slice with empty entries
+// removed and later duplicates dropped, preserving the declared order
+// of first occurrence. Returns nil when the result has no elements so
+// callers can distinguish "no scopes survived filtering" from a
+// well-formed empty alternative.
 func dedupePreserveOrder(in []string) []string {
 	if len(in) == 0 {
 		return nil
@@ -171,6 +377,9 @@ func dedupePreserveOrder(in []string) []string {
 		}
 		seen[s] = struct{}{}
 		out = append(out, s)
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	return out
 }

--- a/gateway/mw_oauth2.go
+++ b/gateway/mw_oauth2.go
@@ -105,14 +105,20 @@ func (m *OAuth2Middleware) ProcessRequest(w http.ResponseWriter, r *http.Request
 		return errors.New(oas.OAuth2ErrInsufficientScope), http.StatusForbidden
 	}
 
-	body, _ := json.Marshal(map[string]interface{}{
+	body, err := json.Marshal(map[string]interface{}{
 		"error":             oas.OAuth2ErrInsufficientScope,
 		"error_description": "token does not satisfy required scopes: " + citedScopes,
 		"scope":             citedScopes,
 	})
+	if err != nil {
+		m.Logger().WithError(err).Error("failed to marshal scope-check error body")
+		return errors.New(oas.OAuth2ErrInsufficientScope), http.StatusForbidden
+	}
 	w.Header().Set(header.ContentType, header.ApplicationJSON)
 	w.WriteHeader(http.StatusForbidden)
-	_, _ = w.Write(body)
+	if _, err := w.Write(body); err != nil {
+		m.Logger().WithError(err).Warning("failed to write scope-check error response")
+	}
 	return nil, middleware.StatusRespond
 }
 

--- a/gateway/mw_oauth2.go
+++ b/gateway/mw_oauth2.go
@@ -15,6 +15,7 @@ import (
 	"github.com/TykTechnologies/tyk/header"
 	"github.com/TykTechnologies/tyk/internal/event"
 	"github.com/TykTechnologies/tyk/internal/httpctx"
+	"github.com/TykTechnologies/tyk/internal/mcp"
 	"github.com/TykTechnologies/tyk/internal/middleware"
 	"github.com/TykTechnologies/tyk/internal/oauth2common"
 )
@@ -197,10 +198,12 @@ func (m *OAuth2Middleware) perOperationScopeAlternatives(r *http.Request) [][]st
 	// empty, so no per-primitive enforcement runs for them. A primitive
 	// whose scopeCheck is disabled contributes nothing.
 	if state := httpctx.GetJSONRPCRoutingState(r); state != nil && state.PrimitiveName != "" && mw != nil {
-		for _, prims := range []oas.MCPPrimitives{mw.McpTools, mw.McpResources, mw.McpPrompts} {
-			if prim, ok := prims[state.PrimitiveName]; ok && prim != nil && scopeCheckEnabled(prim.ScopeCheck) {
-				out = appendOAuth2Alternatives(out, prim.Security, oauth2Names)
-			}
+		// Keyed by type as well as name — tool/resource/prompt names
+		// share no namespace, so a same-named primitive of another
+		// type must not contribute its scopes here.
+		prims := mcpPrimitivesForType(mw, state.PrimitiveType)
+		if prim, ok := prims[state.PrimitiveName]; ok && prim != nil && scopeCheckEnabled(prim.ScopeCheck) {
+			out = appendOAuth2Alternatives(out, prim.Security, oauth2Names)
 		}
 	}
 
@@ -212,6 +215,21 @@ func (m *OAuth2Middleware) perOperationScopeAlternatives(r *http.Request) [][]st
 	}
 
 	return out
+}
+
+// mcpPrimitivesForType returns the primitive map matching the routing
+// state's primitive type, or nil for a non-primitive method.
+func mcpPrimitivesForType(mw *oas.Middleware, primitiveType string) oas.MCPPrimitives {
+	switch primitiveType {
+	case mcp.PrimitiveTypeTool:
+		return mw.McpTools
+	case mcp.PrimitiveTypeResource:
+		return mw.McpResources
+	case mcp.PrimitiveTypePrompt:
+		return mw.McpPrompts
+	default:
+		return nil
+	}
 }
 
 // scopeCheckEnabled reports whether the operation-level scope check is

--- a/gateway/mw_oauth2_test.go
+++ b/gateway/mw_oauth2_test.go
@@ -7,12 +7,15 @@ import (
 	"testing"
 
 	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/getkin/kin-openapi/routers/gorillamux"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/apidef/oas"
 	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/internal/httpctx"
 	"github.com/TykTechnologies/tyk/test"
 )
 
@@ -510,6 +513,34 @@ func TestOAuth2Middleware_EmptyRequiredScopes_NoEnforcement(t *testing.T) {
 	})
 }
 
+// TestOAuth2Middleware_MasterDisabled_OverridesScopeCheck pins that
+// the scheme's master `oauth2.enabled: false` short-circuits scope
+// enforcement even when `scopeCheck.enabled: true` and the OAS root
+// `security:` array would otherwise require a scope. The master
+// toggle is the API-wide kill switch for the scheme.
+func TestOAuth2Middleware_MasterDisabled_OverridesScopeCheck(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	doc := newOAuth2GlobalScopeCheckOAS("/master-off/", [][]string{{"required:scope"}})
+	cfg := doc.GetTykExtension().Server.Authentication.SecuritySchemes["corpOAuth"].(*oas.OAuth2)
+	cfg.Enabled = false
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.UseKeylessAccess = true
+		spec.Proxy.ListenPath = "/master-off/"
+		spec.IsOAS = true
+		spec.OAS = doc
+	})
+
+	// No token at all — would 401 if scope-check were attached.
+	ts.Run(t, test.TestCase{
+		Method: http.MethodGet,
+		Path:   "/master-off/anything",
+		Code:   http.StatusOK,
+	})
+}
+
 // TestOAuth2Middleware_CitedAlternativePreservesDeclaredOrder pins
 // that an operator who declared their AND-row scopes in a specific
 // order sees that same order on the failure challenge — both in the
@@ -627,5 +658,491 @@ func TestOAuth2Middleware_NameAgnostic(t *testing.T) {
 				header.WWWAuthenticate: `Bearer error="insufficient_scope", error_description="missing required scope: abc def", scope="abc def"`,
 			},
 		})
+	})
+}
+
+// ----------------------------------------------------------------------------
+// Per-operation / per-MCP-primitive scope check
+// ----------------------------------------------------------------------------
+
+func TestOAuth2_DedupPreserveOrder(t *testing.T) {
+	assert.Nil(t, dedupePreserveOrder(nil))
+	assert.Nil(t, dedupePreserveOrder([]string{"", ""}))
+	assert.Equal(t, []string{"b", "a", "c"}, dedupePreserveOrder([]string{"b", "a", "b", "", "c", "a"}))
+}
+
+func TestOAuth2_ScopeSource(t *testing.T) {
+	assert.Equal(t, oas.OAuth2ScopeSourceUnion, oauth2ScopeSource(nil))
+	assert.Equal(t, oas.OAuth2ScopeSourceUnion, oauth2ScopeSource(&oas.OAuth2{}))
+	assert.Equal(t, oas.OAuth2ScopeSourceUnion, oauth2ScopeSource(&oas.OAuth2{ScopeCheck: &oas.OAuth2ScopeCheck{ScopeSource: "bogus"}}))
+	assert.Equal(t, oas.OAuth2ScopeSourceGlobal, oauth2ScopeSource(&oas.OAuth2{ScopeCheck: &oas.OAuth2ScopeCheck{ScopeSource: oas.OAuth2ScopeSourceGlobal}}))
+	assert.Equal(t, oas.OAuth2ScopeSourceOperation, oauth2ScopeSource(&oas.OAuth2{ScopeCheck: &oas.OAuth2ScopeCheck{ScopeSource: oas.OAuth2ScopeSourceOperation}}))
+}
+
+func TestOAuth2_AppendOAuth2Alternatives(t *testing.T) {
+	names := map[string]struct{}{"corpOAuth": {}}
+	reqs := openapi3.SecurityRequirements{
+		{"corpOAuth": {"users:write", "audit:write"}},
+		{"corpOAuth": {"admin"}},
+		{"jwtAuth": {}}, // referenced by another scheme — contributes the empty AND-group
+	}
+	got := appendOAuth2Alternatives(nil, reqs, names)
+	require.Len(t, got, 3)
+	assert.Equal(t, []string{"users:write", "audit:write"}, got[0])
+	assert.Equal(t, []string{"admin"}, got[1])
+	assert.Nil(t, got[2])
+}
+
+// oauth2PerOpMW builds an OAuth2Middleware backed by an in-memory OAS
+// doc with a single oauth2 scheme ("corpOAuth"), the given scopeSource
+// and global Scopes, and listen path "/". Caller mutates doc.Paths /
+// the middleware block for per-op / per-primitive scenarios.
+func oauth2PerOpMW(scopeSource string, globalScopes [][]string) (*OAuth2Middleware, *oas.OAS) {
+	doc := oas.OAS{T: openapi3.T{
+		OpenAPI: "3.0.3",
+		Info:    &openapi3.Info{Title: "per-op", Version: "1.0"},
+		Paths:   openapi3.NewPaths(),
+	}}
+	sc := &oas.OAuth2ScopeCheck{Enabled: true, ScopeSource: scopeSource}
+	for _, alt := range globalScopes {
+		req := openapi3.NewSecurityRequirement()
+		req["corpOAuth"] = append([]string{}, alt...)
+		doc.Security = append(doc.Security, req)
+	}
+	doc.SetTykExtension(&oas.XTykAPIGateway{
+		Server: oas.Server{
+			Authentication: &oas.Authentication{
+				Enabled: true,
+				SecuritySchemes: oas.SecuritySchemes{
+					"corpOAuth": &oas.OAuth2{Enabled: true, ScopeCheck: sc},
+				},
+			},
+			ListenPath: oas.ListenPath{Value: "/", Strip: true},
+		},
+		Middleware: &oas.Middleware{},
+	})
+	spec := &APISpec{APIDefinition: &apidef.APIDefinition{}}
+	spec.IsOAS = true
+	spec.OAS = doc
+	spec.Proxy.ListenPath = "/"
+	return &OAuth2Middleware{BaseMiddleware: &BaseMiddleware{Spec: spec}}, &spec.OAS
+}
+
+func reqWithPrimitive(method, path, primitiveName string) *http.Request {
+	r := httptest.NewRequest(method, path, nil)
+	if primitiveName != "" {
+		httpctx.SetJSONRPCRoutingState(r, &httpctx.JSONRPCRoutingState{PrimitiveName: primitiveName})
+	}
+	return r
+}
+
+func secReq(scopes ...string) openapi3.SecurityRequirement {
+	return openapi3.SecurityRequirement{"corpOAuth": scopes}
+}
+
+// buildOASRouterForTest wires an OAS router onto the middleware's spec
+// so findOASOperation resolves operations through real route matching
+// (path templates included). Call after doc.Paths has been populated.
+func buildOASRouterForTest(t *testing.T, mw *OAuth2Middleware) {
+	t.Helper()
+	oasSpec := mw.Spec.OAS.T
+	oasSpec.Servers = openapi3.Servers{{URL: mw.Spec.Proxy.ListenPath}}
+	router, err := gorillamux.NewRouter(&oasSpec)
+	require.NoError(t, err)
+	mw.Spec.oasRouter = router
+}
+
+// enablePerOpScopeCheck opts the named x-tyk operations into the
+// per-operation scope check. The check is opt-in: an operation enforces
+// its `security:` only when its scopeCheck block is present and on.
+func enablePerOpScopeCheck(doc *oas.OAS, operationIDs ...string) {
+	mw := doc.GetTykMiddleware()
+	if mw.Operations == nil {
+		mw.Operations = oas.Operations{}
+	}
+	for _, id := range operationIDs {
+		mw.Operations[id] = &oas.Operation{ScopeCheck: &oas.ScopeCheck{Enabled: true}}
+	}
+}
+
+// TestOAuth2_PerOperationScopeAlternatives_Coexistence pins that an
+// OAS operation whose `security:` lists only non-oauth2 schemes (e.g.
+// `[{jwtAuth: []}]`) contributes an empty AND-group, which makes the
+// resolved OR-of-AND requirement trivially satisfiable and stands the
+// oauth2 scope-check middleware down for that route. Without this
+// behaviour an oauth2-protected API that also exposes JWT-only routes
+// would reject those routes with 401-missing-token.
+func TestOAuth2_PerOperationScopeAlternatives_Coexistence(t *testing.T) {
+	mw, doc := oauth2PerOpMW(oas.OAuth2ScopeSourceOperation, nil)
+	doc.Paths.Set("/jwt-only", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "jwtOnly",
+			Security:    &openapi3.SecurityRequirements{{"jwtAuth": []string{}}},
+			Responses:   openapi3.NewResponses(),
+		},
+	})
+	doc.Paths.Set("/mixed", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "mixed",
+			// One alternative requires oauth2 scopes, another is jwt-only.
+			// The jwt-only alternative is vacuously satisfied for oauth2
+			// scope check, so the whole requirement is.
+			Security: &openapi3.SecurityRequirements{
+				secReq("users:read"),
+				{"jwtAuth": []string{}},
+			},
+			Responses: openapi3.NewResponses(),
+		},
+	})
+	enablePerOpScopeCheck(doc, "jwtOnly", "mixed")
+	buildOASRouterForTest(t, mw)
+
+	assert.Nil(t, mw.requiredScopeAlternativesForRequest(httptest.NewRequest(http.MethodGet, "/jwt-only", nil)),
+		"operation guarded only by another scheme must yield a vacuous oauth2 requirement")
+	assert.Nil(t, mw.requiredScopeAlternativesForRequest(httptest.NewRequest(http.MethodGet, "/mixed", nil)),
+		"a jwt-only alternative anywhere in the per-op list short-circuits oauth2 enforcement")
+}
+
+func TestOAuth2_RequiredScopeAlternatives_RESTOperation(t *testing.T) {
+	mw, doc := oauth2PerOpMW(oas.OAuth2ScopeSourceOperation, nil)
+	doc.Paths.Set("/users", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getUsers",
+			Security:    &openapi3.SecurityRequirements{secReq("users:read")},
+			Responses:   openapi3.NewResponses(),
+		},
+		Post: &openapi3.Operation{
+			OperationID: "createUser",
+			Security:    &openapi3.SecurityRequirements{secReq("users:write"), secReq("users:all")},
+			Responses:   openapi3.NewResponses(),
+		},
+	})
+	doc.Paths.Set("/open", &openapi3.PathItem{Get: &openapi3.Operation{Responses: openapi3.NewResponses()}})
+	enablePerOpScopeCheck(doc, "getUsers", "createUser")
+	buildOASRouterForTest(t, mw)
+
+	assert.Equal(t, [][]string{{"users:read"}}, mw.requiredScopeAlternativesForRequest(httptest.NewRequest(http.MethodGet, "/users", nil)))
+	assert.Equal(t, [][]string{{"users:write"}, {"users:all"}}, mw.requiredScopeAlternativesForRequest(httptest.NewRequest(http.MethodPost, "/users", nil)))
+	// Operation without `security:` → nothing enforced under "operation".
+	assert.Nil(t, mw.requiredScopeAlternativesForRequest(httptest.NewRequest(http.MethodGet, "/open", nil)))
+	// Unmatched path → nothing enforced.
+	assert.Nil(t, mw.requiredScopeAlternativesForRequest(httptest.NewRequest(http.MethodGet, "/missing", nil)))
+}
+
+// TestOAuth2_RequiredScopeAlternatives_TemplatedPath pins that a
+// concrete request path resolves to an OAS operation declared with a
+// path template (e.g. "/users/{userId}"). A literal path-key lookup
+// misses the template, leaving the per-operation scope check
+// unenforced — an authorization bypass under scopeSource "operation".
+func TestOAuth2_RequiredScopeAlternatives_TemplatedPath(t *testing.T) {
+	mw, doc := oauth2PerOpMW(oas.OAuth2ScopeSourceOperation, nil)
+	doc.Paths.Set("/users/{userId}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getUser",
+			Security:    &openapi3.SecurityRequirements{secReq("users:read")},
+			Responses:   openapi3.NewResponses(),
+		},
+	})
+	enablePerOpScopeCheck(doc, "getUser")
+	buildOASRouterForTest(t, mw)
+
+	assert.Equal(t, [][]string{{"users:read"}},
+		mw.requiredScopeAlternativesForRequest(httptest.NewRequest(http.MethodGet, "/users/123", nil)))
+}
+
+func TestOAuth2_RequiredScopeAlternatives_MCPPrimitive(t *testing.T) {
+	mw, doc := oauth2PerOpMW(oas.OAuth2ScopeSourceOperation, nil)
+	doc.GetTykMiddleware().McpTools = oas.MCPPrimitives{
+		"create_user": {
+			Operation: oas.Operation{ScopeCheck: &oas.ScopeCheck{Enabled: true}},
+			Security:  openapi3.SecurityRequirements{secReq("users:write"), secReq("users:all")},
+		},
+	}
+	doc.GetTykMiddleware().McpResources = oas.MCPPrimitives{
+		"file": {
+			Operation: oas.Operation{ScopeCheck: &oas.ScopeCheck{Enabled: true}},
+			Security:  openapi3.SecurityRequirements{secReq("files:read")},
+		},
+	}
+	buildOASRouterForTest(t, mw)
+
+	assert.Equal(t, [][]string{{"users:write"}, {"users:all"}},
+		mw.requiredScopeAlternativesForRequest(reqWithPrimitive(http.MethodPost, "/", "create_user")))
+	assert.Equal(t, [][]string{{"files:read"}},
+		mw.requiredScopeAlternativesForRequest(reqWithPrimitive(http.MethodPost, "/", "file")))
+	// Non-tools/call (no primitive name) → nothing enforced.
+	assert.Nil(t, mw.requiredScopeAlternativesForRequest(reqWithPrimitive(http.MethodPost, "/", "")))
+	// Undeclared primitive → nothing enforced (no security: array).
+	assert.Nil(t, mw.requiredScopeAlternativesForRequest(reqWithPrimitive(http.MethodPost, "/", "delete_user")))
+}
+
+func TestOAuth2_RequiredScopeAlternatives_UnionAndOperationAndGlobal(t *testing.T) {
+	t.Run("union ANDs the global baseline onto each per-op alternative", func(t *testing.T) {
+		mw, doc := oauth2PerOpMW(oas.OAuth2ScopeSourceUnion, [][]string{{"api:access"}})
+		doc.Paths.Set("/users", &openapi3.PathItem{Get: &openapi3.Operation{
+			OperationID: "getUsers",
+			Security:    &openapi3.SecurityRequirements{secReq("users:read"), secReq("users:all")},
+			Responses:   openapi3.NewResponses(),
+		}})
+		enablePerOpScopeCheck(doc, "getUsers")
+		buildOASRouterForTest(t, mw)
+		assert.Equal(t, [][]string{{"users:read", "api:access"}, {"users:all", "api:access"}},
+			mw.requiredScopeAlternativesForRequest(httptest.NewRequest(http.MethodGet, "/users", nil)))
+	})
+	t.Run("union with no per-op security falls back to the global list", func(t *testing.T) {
+		mw, doc := oauth2PerOpMW(oas.OAuth2ScopeSourceUnion, [][]string{{"api:access"}})
+		doc.Paths.Set("/open", &openapi3.PathItem{Get: &openapi3.Operation{Responses: openapi3.NewResponses()}})
+		buildOASRouterForTest(t, mw)
+		assert.Equal(t, [][]string{{"api:access"}},
+			mw.requiredScopeAlternativesForRequest(httptest.NewRequest(http.MethodGet, "/open", nil)))
+	})
+	t.Run("operation ignores the global baseline", func(t *testing.T) {
+		mw, doc := oauth2PerOpMW(oas.OAuth2ScopeSourceOperation, [][]string{{"api:access"}})
+		doc.Paths.Set("/users", &openapi3.PathItem{Get: &openapi3.Operation{
+			OperationID: "getUsers",
+			Security:    &openapi3.SecurityRequirements{secReq("users:read")},
+			Responses:   openapi3.NewResponses(),
+		}})
+		enablePerOpScopeCheck(doc, "getUsers")
+		buildOASRouterForTest(t, mw)
+		assert.Equal(t, [][]string{{"users:read"}},
+			mw.requiredScopeAlternativesForRequest(httptest.NewRequest(http.MethodGet, "/users", nil)))
+	})
+	t.Run("global ignores per-op security", func(t *testing.T) {
+		mw, doc := oauth2PerOpMW(oas.OAuth2ScopeSourceGlobal, [][]string{{"api:access"}})
+		doc.Paths.Set("/users", &openapi3.PathItem{Get: &openapi3.Operation{
+			Security:  &openapi3.SecurityRequirements{secReq("users:read")},
+			Responses: openapi3.NewResponses(),
+		}})
+		buildOASRouterForTest(t, mw)
+		assert.Equal(t, [][]string{{"api:access"}},
+			mw.requiredScopeAlternativesForRequest(httptest.NewRequest(http.MethodGet, "/users", nil)))
+	})
+}
+
+// TestOAuth2_PerOperationScopeCheckDisabled pins that an operation
+// whose x-tyk scopeCheck block is disabled drops its operation-level
+// scope requirement, while the API-level baseline still applies.
+func TestOAuth2_PerOperationScopeCheckDisabled(t *testing.T) {
+	setup := func(source string, global [][]string) (*OAuth2Middleware, *oas.OAS) {
+		mw, doc := oauth2PerOpMW(source, global)
+		doc.Paths.Set("/users", &openapi3.PathItem{Get: &openapi3.Operation{
+			OperationID: "getUsers",
+			Security:    &openapi3.SecurityRequirements{secReq("users:read")},
+			Responses:   openapi3.NewResponses(),
+		}})
+		return mw, doc
+	}
+	getUsers := httptest.NewRequest(http.MethodGet, "/users", nil)
+
+	t.Run("operation source — disabled operation drops its requirement", func(t *testing.T) {
+		mw, doc := setup(oas.OAuth2ScopeSourceOperation, nil)
+		doc.GetTykMiddleware().Operations = oas.Operations{"getUsers": {ScopeCheck: &oas.ScopeCheck{Enabled: false}}}
+		buildOASRouterForTest(t, mw)
+		assert.Nil(t, mw.requiredScopeAlternativesForRequest(getUsers))
+	})
+	t.Run("union source — disabled operation still enforces the global baseline", func(t *testing.T) {
+		mw, doc := setup(oas.OAuth2ScopeSourceUnion, [][]string{{"api:access"}})
+		doc.GetTykMiddleware().Operations = oas.Operations{"getUsers": {ScopeCheck: &oas.ScopeCheck{Enabled: false}}}
+		buildOASRouterForTest(t, mw)
+		assert.Equal(t, [][]string{{"api:access"}}, mw.requiredScopeAlternativesForRequest(getUsers))
+	})
+	t.Run("scopeCheck enabled:true enforces normally", func(t *testing.T) {
+		mw, doc := setup(oas.OAuth2ScopeSourceOperation, nil)
+		doc.GetTykMiddleware().Operations = oas.Operations{"getUsers": {ScopeCheck: &oas.ScopeCheck{Enabled: true}}}
+		buildOASRouterForTest(t, mw)
+		assert.Equal(t, [][]string{{"users:read"}}, mw.requiredScopeAlternativesForRequest(getUsers))
+	})
+	t.Run("no scopeCheck block — not enforced (opt-in)", func(t *testing.T) {
+		mw, _ := setup(oas.OAuth2ScopeSourceOperation, nil)
+		buildOASRouterForTest(t, mw)
+		assert.Nil(t, mw.requiredScopeAlternativesForRequest(getUsers))
+	})
+}
+
+// TestOAuth2_PerMCPPrimitiveScopeCheckDisabled pins the same exemption
+// for an MCP primitive.
+func TestOAuth2_PerMCPPrimitiveScopeCheckDisabled(t *testing.T) {
+	mw, doc := oauth2PerOpMW(oas.OAuth2ScopeSourceOperation, nil)
+	doc.GetTykMiddleware().McpTools = oas.MCPPrimitives{
+		"create_user": {
+			Operation: oas.Operation{ScopeCheck: &oas.ScopeCheck{Enabled: false}},
+			Security:  openapi3.SecurityRequirements{secReq("users:write")},
+		},
+	}
+	buildOASRouterForTest(t, mw)
+	assert.Nil(t, mw.requiredScopeAlternativesForRequest(reqWithPrimitive(http.MethodPost, "/", "create_user")))
+}
+
+// newOAuth2PerOpScopeCheckOAS builds an OAS API for end-to-end
+// per-operation scope-check tests: a "/users" path with GET and POST
+// operations and a templated "/accounts/{accountId}" path, all
+// carrying `security:` arrays for the "corpOAuth" oauth2 scheme.
+func newOAuth2PerOpScopeCheckOAS(listenPath, scopeSource string, globalScopes [][]string) oas.OAS {
+	doc := oas.OAS{T: openapi3.T{
+		OpenAPI: "3.0.3",
+		Info:    &openapi3.Info{Title: "oauth2-per-op", Version: "1.0"},
+		Paths:   openapi3.NewPaths(),
+		Components: &openapi3.Components{
+			SecuritySchemes: openapi3.SecuritySchemes{
+				"corpOAuth": &openapi3.SecuritySchemeRef{
+					Value: &openapi3.SecurityScheme{
+						Type: "oauth2",
+						Flows: &openapi3.OAuthFlows{
+							AuthorizationCode: &openapi3.OAuthFlow{
+								AuthorizationURL: "/oauth/authorize",
+								TokenURL:         "/oauth/token",
+								Scopes:           map[string]string{},
+							},
+						},
+					},
+				},
+			},
+		},
+	}}
+	doc.Paths.Set("/users", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getUsers",
+			Security:    &openapi3.SecurityRequirements{secReq("users:read")},
+			Responses:   openapi3.NewResponses(),
+		},
+		Post: &openapi3.Operation{
+			OperationID: "createUser",
+			Security:    &openapi3.SecurityRequirements{secReq("users:write"), secReq("users:all")},
+			Responses:   openapi3.NewResponses(),
+		},
+	})
+	doc.Paths.Set("/open", &openapi3.PathItem{Get: &openapi3.Operation{Responses: openapi3.NewResponses()}})
+	doc.Paths.Set("/accounts/{accountId}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getAccount",
+			Parameters: openapi3.Parameters{
+				{Value: &openapi3.Parameter{
+					Name: "accountId", In: "path", Required: true,
+					Schema: &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"string"}}},
+				}},
+			},
+			Security:  &openapi3.SecurityRequirements{secReq("users:read")},
+			Responses: openapi3.NewResponses(),
+		},
+	})
+	sc := &oas.OAuth2ScopeCheck{Enabled: true, ScopeSource: scopeSource}
+	for _, alt := range globalScopes {
+		req := openapi3.NewSecurityRequirement()
+		req["corpOAuth"] = append([]string{}, alt...)
+		doc.Security = append(doc.Security, req)
+	}
+	doc.SetTykExtension(&oas.XTykAPIGateway{
+		Info:     oas.Info{Name: "oauth2-per-op", State: oas.State{Active: true}},
+		Upstream: oas.Upstream{URL: TestHttpAny},
+		Middleware: &oas.Middleware{
+			Operations: oas.Operations{
+				"getUsers":   {ScopeCheck: &oas.ScopeCheck{Enabled: true}},
+				"createUser": {ScopeCheck: &oas.ScopeCheck{Enabled: true}},
+				"getAccount": {ScopeCheck: &oas.ScopeCheck{Enabled: true}},
+			},
+		},
+		Server: oas.Server{
+			ListenPath: oas.ListenPath{Value: listenPath, Strip: true},
+			Authentication: &oas.Authentication{
+				Enabled: true,
+				SecuritySchemes: oas.SecuritySchemes{
+					"corpOAuth": &oas.OAuth2{Enabled: true, ScopeCheck: sc},
+				},
+			},
+		},
+	})
+	return doc
+}
+
+func TestOAuth2Middleware_PerOperationScopeCheck_EndToEnd(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	loadAPI := func(listenPath, source string, global [][]string, mutate ...func(*oas.OAS)) {
+		doc := newOAuth2PerOpScopeCheckOAS(listenPath, source, global)
+		for _, m := range mutate {
+			m(&doc)
+		}
+		ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+			spec.UseKeylessAccess = true
+			spec.Proxy.ListenPath = listenPath
+			spec.IsOAS = true
+			spec.OAS = doc
+		})
+	}
+	bearer := func(scopes string) map[string]string {
+		return map[string]string{"Authorization": "Bearer " + makeUnverifiedJWT(t, jwt.MapClaims{"scope": scopes})}
+	}
+
+	t.Run("operation source — token has the operation scope", func(t *testing.T) {
+		loadAPI("/op1/", oas.OAuth2ScopeSourceOperation, nil)
+		ts.Run(t, test.TestCase{Method: http.MethodGet, Path: "/op1/users", Headers: bearer("users:read"), Code: http.StatusOK})
+	})
+	t.Run("operation source — token missing the operation scope → 403 cites it", func(t *testing.T) {
+		loadAPI("/op2/", oas.OAuth2ScopeSourceOperation, nil)
+		ts.Run(t, test.TestCase{
+			Method: http.MethodGet, Path: "/op2/users", Headers: bearer("other"), Code: http.StatusForbidden,
+			BodyMatch: `"error":"insufficient_scope".*"scope":"users:read"`,
+			HeadersMatch: map[string]string{
+				header.WWWAuthenticate: `Bearer error="insufficient_scope", error_description="missing required scope: users:read", scope="users:read"`,
+			},
+		})
+	})
+	t.Run("operation source — OR-of-AND alternatives", func(t *testing.T) {
+		loadAPI("/op3/", oas.OAuth2ScopeSourceOperation, nil)
+		ts.Run(t, test.TestCase{Method: http.MethodPost, Path: "/op3/users", Headers: bearer("users:write"), Code: http.StatusOK})
+		ts.Run(t, test.TestCase{Method: http.MethodPost, Path: "/op3/users", Headers: bearer("users:all"), Code: http.StatusOK})
+		ts.Run(t, test.TestCase{Method: http.MethodPost, Path: "/op3/users", Headers: bearer("users:write users:all"), Code: http.StatusOK})
+		ts.Run(t, test.TestCase{
+			Method: http.MethodPost, Path: "/op3/users", Headers: bearer("users:read"), Code: http.StatusForbidden,
+			BodyMatch:    `"scope":"users:write"`,
+			BodyNotMatch: `users:all`,
+		})
+	})
+	t.Run("operation source — operation with no security: is not enforced", func(t *testing.T) {
+		loadAPI("/op4/", oas.OAuth2ScopeSourceOperation, [][]string{{"api:access"}})
+		ts.Run(t, test.TestCase{Method: http.MethodGet, Path: "/op4/open", Code: http.StatusOK})
+	})
+	t.Run("union source — per-op AND global baseline both enforced", func(t *testing.T) {
+		loadAPI("/op5/", oas.OAuth2ScopeSourceUnion, [][]string{{"api:access"}})
+		ts.Run(t, test.TestCase{Method: http.MethodGet, Path: "/op5/users", Headers: bearer("api:access users:read"), Code: http.StatusOK})
+		ts.Run(t, test.TestCase{Method: http.MethodGet, Path: "/op5/users", Headers: bearer("api:access"), Code: http.StatusForbidden})
+		ts.Run(t, test.TestCase{Method: http.MethodGet, Path: "/op5/users", Headers: bearer("users:read"), Code: http.StatusForbidden})
+	})
+	t.Run("operation source — global baseline ignored", func(t *testing.T) {
+		loadAPI("/op6/", oas.OAuth2ScopeSourceOperation, [][]string{{"api:access"}})
+		ts.Run(t, test.TestCase{Method: http.MethodGet, Path: "/op6/users", Headers: bearer("users:read"), Code: http.StatusOK})
+	})
+	t.Run("global source — per-op ignored", func(t *testing.T) {
+		loadAPI("/op7/", oas.OAuth2ScopeSourceGlobal, [][]string{{"api:access"}})
+		ts.Run(t, test.TestCase{Method: http.MethodGet, Path: "/op7/users", Headers: bearer("api:access"), Code: http.StatusOK})
+	})
+	t.Run("operation source — templated path resolves to its operation", func(t *testing.T) {
+		loadAPI("/op8/", oas.OAuth2ScopeSourceOperation, nil)
+		// A concrete path must map to the templated OAS operation; a
+		// literal lookup would miss it and skip the scope check entirely.
+		ts.Run(t, test.TestCase{Method: http.MethodGet, Path: "/op8/accounts/42", Headers: bearer("users:read"), Code: http.StatusOK})
+		ts.Run(t, test.TestCase{
+			Method: http.MethodGet, Path: "/op8/accounts/42", Headers: bearer("other"), Code: http.StatusForbidden,
+			BodyMatch: `"error":"insufficient_scope"`,
+		})
+	})
+	t.Run("operation source — disabled operation lets the request through", func(t *testing.T) {
+		loadAPI("/op9/", oas.OAuth2ScopeSourceOperation, nil, func(doc *oas.OAS) {
+			doc.GetTykMiddleware().Operations = oas.Operations{
+				"getUsers": {ScopeCheck: &oas.ScopeCheck{Enabled: false}},
+			}
+		})
+		ts.Run(t, test.TestCase{Method: http.MethodGet, Path: "/op9/users", Headers: bearer("nothing"), Code: http.StatusOK})
+	})
+	t.Run("union source — disabled operation still enforces the global baseline", func(t *testing.T) {
+		loadAPI("/op10/", oas.OAuth2ScopeSourceUnion, [][]string{{"api:access"}}, func(doc *oas.OAS) {
+			doc.GetTykMiddleware().Operations = oas.Operations{
+				"getUsers": {ScopeCheck: &oas.ScopeCheck{Enabled: false}},
+			}
+		})
+		ts.Run(t, test.TestCase{Method: http.MethodGet, Path: "/op10/users", Headers: bearer("api:access"), Code: http.StatusOK})
+		ts.Run(t, test.TestCase{Method: http.MethodGet, Path: "/op10/users", Headers: bearer("nothing"), Code: http.StatusForbidden})
 	})
 }

--- a/gateway/mw_oauth2_test.go
+++ b/gateway/mw_oauth2_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/TykTechnologies/tyk/apidef/oas"
 	"github.com/TykTechnologies/tyk/header"
 	"github.com/TykTechnologies/tyk/internal/httpctx"
+	"github.com/TykTechnologies/tyk/internal/mcp"
 	"github.com/TykTechnologies/tyk/test"
 )
 
@@ -728,10 +729,13 @@ func oauth2PerOpMW(scopeSource string, globalScopes [][]string) (*OAuth2Middlewa
 	return &OAuth2Middleware{BaseMiddleware: &BaseMiddleware{Spec: spec}}, &spec.OAS
 }
 
-func reqWithPrimitive(method, path, primitiveName string) *http.Request {
-	r := httptest.NewRequest(method, path, nil)
+func reqWithTypedPrimitive(primitiveType, primitiveName string) *http.Request {
+	r := httptest.NewRequest(http.MethodPost, "/", nil)
 	if primitiveName != "" {
-		httpctx.SetJSONRPCRoutingState(r, &httpctx.JSONRPCRoutingState{PrimitiveName: primitiveName})
+		httpctx.SetJSONRPCRoutingState(r, &httpctx.JSONRPCRoutingState{
+			PrimitiveType: primitiveType,
+			PrimitiveName: primitiveName,
+		})
 	}
 	return r
 }
@@ -867,13 +871,41 @@ func TestOAuth2_RequiredScopeAlternatives_MCPPrimitive(t *testing.T) {
 	buildOASRouterForTest(t, mw)
 
 	assert.Equal(t, [][]string{{"users:write"}, {"users:all"}},
-		mw.requiredScopeAlternativesForRequest(reqWithPrimitive(http.MethodPost, "/", "create_user")))
+		mw.requiredScopeAlternativesForRequest(reqWithTypedPrimitive(mcp.PrimitiveTypeTool, "create_user")))
 	assert.Equal(t, [][]string{{"files:read"}},
-		mw.requiredScopeAlternativesForRequest(reqWithPrimitive(http.MethodPost, "/", "file")))
+		mw.requiredScopeAlternativesForRequest(reqWithTypedPrimitive(mcp.PrimitiveTypeResource, "file")))
 	// Non-tools/call (no primitive name) → nothing enforced.
-	assert.Nil(t, mw.requiredScopeAlternativesForRequest(reqWithPrimitive(http.MethodPost, "/", "")))
+	assert.Nil(t, mw.requiredScopeAlternativesForRequest(reqWithTypedPrimitive(mcp.PrimitiveTypeTool, "")))
 	// Undeclared primitive → nothing enforced (no security: array).
-	assert.Nil(t, mw.requiredScopeAlternativesForRequest(reqWithPrimitive(http.MethodPost, "/", "delete_user")))
+	assert.Nil(t, mw.requiredScopeAlternativesForRequest(reqWithTypedPrimitive(mcp.PrimitiveTypeTool, "delete_user")))
+}
+
+// TestOAuth2_RequiredScopeAlternatives_MCPPrimitiveTypeCollision pins
+// that a primitive resolves by name AND type: tool/resource/prompt
+// names share no namespace, so name-only matching leaks scopes across.
+func TestOAuth2_RequiredScopeAlternatives_MCPPrimitiveTypeCollision(t *testing.T) {
+	mw, doc := oauth2PerOpMW(oas.OAuth2ScopeSourceOperation, nil)
+	mwBlock := doc.GetTykMiddleware()
+	mwBlock.McpTools = oas.MCPPrimitives{
+		"search": {
+			Operation: oas.Operation{ScopeCheck: &oas.ScopeCheck{Enabled: true}},
+			Security:  openapi3.SecurityRequirements{secReq("tools:exec")},
+		},
+	}
+	mwBlock.McpResources = oas.MCPPrimitives{
+		"search": {
+			Operation: oas.Operation{ScopeCheck: &oas.ScopeCheck{Enabled: true}},
+			Security:  openapi3.SecurityRequirements{secReq("files:read")},
+		},
+	}
+	buildOASRouterForTest(t, mw)
+
+	assert.Equal(t, [][]string{{"tools:exec"}},
+		mw.requiredScopeAlternativesForRequest(reqWithTypedPrimitive(mcp.PrimitiveTypeTool, "search")),
+		"a tools/call must enforce only the tool's scopes, not the same-named resource's")
+	assert.Equal(t, [][]string{{"files:read"}},
+		mw.requiredScopeAlternativesForRequest(reqWithTypedPrimitive(mcp.PrimitiveTypeResource, "search")),
+		"a resources/read must enforce only the resource's scopes")
 }
 
 func TestOAuth2_RequiredScopeAlternatives_UnionAndOperationAndGlobal(t *testing.T) {
@@ -971,7 +1003,7 @@ func TestOAuth2_PerMCPPrimitiveScopeCheckDisabled(t *testing.T) {
 		},
 	}
 	buildOASRouterForTest(t, mw)
-	assert.Nil(t, mw.requiredScopeAlternativesForRequest(reqWithPrimitive(http.MethodPost, "/", "create_user")))
+	assert.Nil(t, mw.requiredScopeAlternativesForRequest(reqWithTypedPrimitive(mcp.PrimitiveTypeTool, "create_user")))
 }
 
 // newOAuth2PerOpScopeCheckOAS builds an OAS API for end-to-end


### PR DESCRIPTION
## Summary

Extends the new `oauth2` security scheme's scope check (TT-17173 added the API-level baseline) to read per-operation OAS `security:` declarations and per-MCP-primitive `security` arrays. Operators declare required scopes once in the OAS document; the gateway enforces them per request. Grammar is OR-of-AND (`security:` is OR across alternatives, AND across the scopes within an alternative). `scopeSource` composes the two paths: `union` (default) requires both, `operation` ignores the global baseline, `global` ignores per-op. On a missing scope the 403 cites the first declared alternative in the RFC 6750 `WWW-Authenticate: Bearer error="insufficient_scope" scope="…"` challenge; MCP/JSON-RPC routes get the failure wrapped in a JSON-RPC 2.0 error envelope. An operation guarded by another scheme (e.g. JWT) contributes an empty AND-group, so the oauth2 middleware stands down for that route — preserving coexistence. The whole check is gated on `oauth2.scopeCheck.enabled` (default off), so existing APIs are unaffected.

apidef: `MCPPrimitive.Security` (`openapi3.SecurityRequirements`), `DeriveOAuth2Scopes` / `SortedOAuth2Scopes` (walk root + per-op + per-MCP-primitive `security:`), `mcpTools[].security` schema delta. gateway: `requiredScopeAlternativesForRequest` (per-op + global composition per `scopeSource`, union as cross-product via `unionScopeAlternatives`), `perOperationScopeAlternatives` (MCP primitive via JSONRPC routing state + REST op via OAS path lookup), `appendOAuth2Alternatives`, `oauth2ScopeSource`, `dedupPreserveOrder`. Unit + `StartTest` end-to-end tests.

## Story

- JIRA: [TT-17174](https://tyktech.atlassian.net/browse/TT-17174)

## Companion PRs

This story spans three repos and ships together:

- tyk: <THIS PR>
- tyk-analytics: https://github.com/TykTechnologies/tyk-analytics/pull/5648
- tyk-analytics-ui (webclient): https://github.com/TykTechnologies/tyk-analytics-ui/pull/4373

Reviewers: please block until all three are green.

## Stacked on

Base is `TT-17173-scope-check-api-level` (Story 02 / [TT-17173](https://tyktech.atlassian.net/browse/TT-17173)). Review/merge TT-17173 first, then this can be retargeted to `master`.

## Test plan

- [x] `go test ./apidef/oas/ -run 'OAuth2|MCPPrimitive'` and `go test ./gateway/ -run OAuth2` — green locally
- [x] Python e2e (in the tyk-analytics PR): `pytest tests/api/tests/mcp/mcp_oauth2_per_op_scope_check_test.py` — 15/15 against a live dashboard + gateway + Keycloak
- [x] `newman run` on the Story-03 Postman collection — 17/17 against the live stack
- [x] Playwright lifecycle (in the tyk-analytics PR), `--repeat-each=5 --workers=1` — 5/5 chromium + 5/5 firefox
- [ ] Manual walk of the manual-test guide

Note: pre-existing unrelated failure `apidef/oas TestAPIContext_getValidationOptionsFromConfig` panics on the parent branch too.

## Risk

Schema delta is confined to `apidef/mcp/schema/x-tyk-api-gateway.json` (`mcpTools[].security`) — per-op REST `security:` is native OpenAPI, read at runtime with no x-tyk-extension delta. The map-probe disambiguator and the new helpers extend Story 02's structures without changing existing paths. Coexistence is covered by tests (an op secured by another scheme is not blocked by oauth2). Default-off gating means a no-op for any API that doesn't opt into `scopeCheck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[TT-17174]: https://tyktech.atlassian.net/browse/TT-17174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
















<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-17174" title="TT-17174" target="_blank">TT-17174</a>
</summary>

|         |    |
|---------|----|
| Status  | Merge |
| Summary | OAuth2 scope check — per-operation and per-MCP-primitive |

Generated at: 2026-06-03 11:30:32

</details>

<!---TykTechnologies/jira-linter ends here-->
















