### PR TITLE
[TT-17123] REST-as-MCP part 1: apidef marker and tool derivation

### DIFF
--- a/apidef/api_definitions.go
+++ b/apidef/api_definitions.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"text/template"
 	"time"
 
@@ -674,6 +675,10 @@ type APIDefinition struct {
 	EnableProxyProtocol bool           `bson:"enable_proxy_protocol" json:"enable_proxy_protocol"`
 	JsonRpcVersion      string         `bson:"json_rpc_version,omitempty" json:"json_rpc_version,omitempty"`
 	ApplicationProtocol string         `bson:"application_protocol,omitempty" json:"application_protocol,omitempty"`
+	// MCPExposure marks a REST API as MCP-callable. When Enabled is true the
+	// gateway loader synthesises a paired adapter spec (Layer B) so that an
+	// operator-managed MCP proxy can route agent tools/call into this API.
+	MCPExposure MCPExposureConfig `bson:"mcp_exposure,omitempty" json:"mcp_exposure,omitempty"`
 	APIID               string         `bson:"api_id" json:"api_id"`
 	OrgID               string         `bson:"org_id" json:"org_id"`
 	UseKeylessAccess    bool           `bson:"use_keyless" json:"use_keyless"`
@@ -1456,6 +1461,58 @@ func (a *APIDefinition) IsMCP() bool {
 // MarkAsMCP configures the API definition as a Model Context Protocol (MCP) API.
 func (a *APIDefinition) MarkAsMCP() {
 	a.SetProtocol(JsonRPC20, AppProtocolMCP)
+}
+
+// MCPExposureConfig is the apidef-side persistence of the OAS
+// `server.mcp` marker. It does not itself wire any middleware — the loader
+// reads Enabled and synthesises a paired Internal adapter spec at load time.
+type MCPExposureConfig struct {
+	// Enabled marks this REST API as MCP-callable. The loader emits a paired
+	// adapter spec with APIID "<this-apiid>__mcp-server".
+	Enabled bool `bson:"enabled,omitempty" json:"enabled,omitempty"`
+	// Expose is an optional allow-list of sanitised operationIds. When nil
+	// or empty, every operation in the source OAS becomes a tool ("expose
+	// all" default). When non-empty, only operations whose sanitised
+	// operationId appears in the list are exposed.
+	Expose []string `bson:"expose,omitempty" json:"expose,omitempty"`
+}
+
+// IsMCPExposed returns true if the REST API is marked for MCP exposure.
+func (a *APIDefinition) IsMCPExposed() bool {
+	return a.MCPExposure.Enabled
+}
+
+// IsPairedMCPAdapterProxy returns true if this API is a REST-as-MCP proxy
+// whose upstream loops into a synthetic adapter — recognised by a
+// `tyk://<rest-id>__mcp-server` upstream URL.
+//
+// REST-as-MCP proxies are *not* IsMCP() (the JSON-RPC middleware lives on
+// the adapter, not on the proxy itself), but they belong to the MCP
+// management surface — `/tyk/mcps` lists, gets, updates, and deletes
+// them alongside remote-MCP proxies.
+func (a *APIDefinition) IsPairedMCPAdapterProxy() bool {
+	if a == nil {
+		return false
+	}
+	t := strings.TrimSpace(a.Proxy.TargetURL)
+	const scheme = "tyk://"
+	if !strings.HasPrefix(t, scheme) {
+		return false
+	}
+	host := strings.TrimPrefix(t, scheme)
+	if i := strings.IndexAny(host, "/?"); i != -1 {
+		host = host[:i]
+	}
+	host = strings.TrimPrefix(host, "id:")
+	const adapterSuffix = "__mcp-server"
+	return strings.HasSuffix(host, adapterSuffix) && len(host) > len(adapterSuffix)
+}
+
+// IsMCPManaged returns true for APIs that belong to the MCP management
+// surface — both classic MCP proxies (IsMCP()) and REST-as-MCP proxies
+// that loop into a synthetic adapter.
+func (a *APIDefinition) IsMCPManaged() bool {
+	return a.IsMCP() || a.IsPairedMCPAdapterProxy()
 }
 
 // IsChildAPI returns true if this API is a child API in a versioning hierarchy.

--- a/apidef/oas/linter_test.go
+++ b/apidef/oas/linter_test.go
@@ -89,6 +89,9 @@ func TestXTykGateway_Lint(t *testing.T) {
 		}
 		settings.Server.Protocol = "http"
 		settings.Server.Port = 3000
+		if settings.Server.MCP != nil {
+			settings.Server.MCP.Expose = []string{"sample"}
+		}
 		for i := range settings.Server.EventHandlers {
 			settings.Server.EventHandlers[i].Kind = event.WebhookKind
 			settings.Server.EventHandlers[i].Webhook.Method = http.MethodPost

--- a/apidef/oas/mcp.go
+++ b/apidef/oas/mcp.go
@@ -1,0 +1,37 @@
+package oas
+
+import "github.com/TykTechnologies/tyk/apidef"
+
+// MCP is the OAS-side marker that this REST API should be exposed as MCP.
+//
+// When Enabled is true, the gateway loader will synthesise a paired
+// Internal adapter spec with APIID `<rest-apiid>__mcp-server`. The adapter
+// answers JSON-RPC `initialize`, `ping`, and `tools/list` inline, and
+// translates `tools/call` into an HTTP request that is looped back through
+// this REST API's full middleware chain.
+//
+// The actual MCP listener (auth, rate-limit, etc.) is a separate operator-
+// managed APIDef POSTed to /tyk/mcps whose upstream URL is
+// `tyk://<rest-apiid>__mcp-server`.
+type MCP struct {
+	// Enabled marks this REST API as MCP-callable.
+	Enabled bool `bson:"enabled" json:"enabled"`
+
+	// Expose is an optional allow-list of sanitised operationIds. When nil
+	// or empty, every operation in the source OAS becomes a tool ("expose
+	// all" default). When non-empty, only operations whose sanitised
+	// operationId appears in the list are exposed.
+	Expose []string `bson:"expose,omitempty" json:"expose,omitempty"`
+}
+
+// Fill fills *MCP from apidef.APIDefinition.
+func (m *MCP) Fill(api apidef.APIDefinition) {
+	m.Enabled = api.MCPExposure.Enabled
+	m.Expose = api.MCPExposure.Expose
+}
+
+// ExtractTo extracts *MCP into *apidef.APIDefinition.
+func (m *MCP) ExtractTo(api *apidef.APIDefinition) {
+	api.MCPExposure.Enabled = m.Enabled
+	api.MCPExposure.Expose = m.Expose
+}

--- a/apidef/oas/mcp_exposure_test.go
+++ b/apidef/oas/mcp_exposure_test.go
@@ -1,0 +1,241 @@
+package oas
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/apidef"
+)
+
+func TestMCP_FillExtractRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   MCP
+	}{
+		{name: "default-empty", in: MCP{}},
+		{name: "enabled-expose-all", in: MCP{Enabled: true}},
+		{name: "enabled-with-expose-list", in: MCP{Enabled: true, Expose: []string{"getOrder", "createOrder"}}},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var api apidef.APIDefinition
+			tc.in.ExtractTo(&api)
+
+			var got MCP
+			got.Fill(api)
+
+			assert.Equal(t, tc.in, got)
+		})
+	}
+}
+
+func TestServer_MCPRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := Server{
+		MCP: &MCP{Enabled: true, Expose: []string{"getOrder"}},
+	}
+
+	var api apidef.APIDefinition
+	original.ExtractTo(&api)
+
+	assert.True(t, api.MCPExposure.Enabled)
+	assert.Equal(t, []string{"getOrder"}, api.MCPExposure.Expose)
+	assert.True(t, api.IsMCPExposed())
+
+	var got Server
+	got.Fill(api)
+
+	require.NotNil(t, got.MCP)
+	assert.Equal(t, original.MCP, got.MCP)
+}
+
+func TestServer_MCPOmittedWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	// Disabled with no expose list should round-trip to nil MCP so the
+	// omitempty marshalling keeps the OAS document clean.
+	original := Server{MCP: &MCP{}}
+
+	var api apidef.APIDefinition
+	original.ExtractTo(&api)
+
+	var got Server
+	got.Fill(api)
+
+	assert.Nil(t, got.MCP)
+}
+
+func TestSanitizeToolName(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"":               "",
+		"getOrder":       "getOrder",
+		"get order":      "get_order",
+		"get  -- order":  "get_--_order", // dashes are valid MCP tool-name chars
+		"___strip___":    "strip",
+		"/v1/orders/{x}": "v1_orders_x",
+	}
+
+	for in, want := range cases {
+		assert.Equal(t, want, SanitizeToolName(in), "input=%q", in)
+	}
+}
+
+func TestAdapterAPIIDHelpers(t *testing.T) {
+	t.Parallel()
+
+	rest := "abc123"
+	adapter := AdapterAPIID(rest)
+	assert.Equal(t, "abc123__mcp-server", adapter)
+	assert.True(t, IsAdapterAPIID(adapter))
+	assert.False(t, IsAdapterAPIID(rest))
+	assert.False(t, IsAdapterAPIID(AdapterAPIIDSuffix))
+	assert.Equal(t, rest, AdapterSourceAPIID(adapter))
+	assert.Equal(t, "", AdapterSourceAPIID(rest))
+	assert.Equal(t, "abc123__mcp-server", AdapterLoopHost(rest))
+	assert.Equal(t, "tyk://abc123__mcp-server", AdapterLoopURL(rest))
+}
+
+func makeTestOAS(t *testing.T) *OAS {
+	t.Helper()
+
+	doc := &openapi3.T{
+		OpenAPI: "3.0.3",
+		Info:    &openapi3.Info{Title: "Orders", Version: "1.0"},
+		Paths:   openapi3.NewPaths(),
+	}
+
+	doc.Paths.Set("/orders/{id}", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			OperationID: "getOrder",
+			Summary:     "fetch an order by id",
+			Parameters: openapi3.Parameters{
+				{Value: &openapi3.Parameter{
+					Name:     "id",
+					In:       openapi3.ParameterInPath,
+					Required: true,
+					Schema:   &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"string"}}},
+				}},
+				{Value: &openapi3.Parameter{
+					Name:   "verbose",
+					In:     openapi3.ParameterInQuery,
+					Schema: &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"boolean"}}},
+				}},
+			},
+		},
+	})
+
+	doc.Paths.Set("/orders", &openapi3.PathItem{
+		Post: &openapi3.Operation{
+			OperationID: "createOrder",
+			Summary:     "create a new order",
+			RequestBody: &openapi3.RequestBodyRef{Value: &openapi3.RequestBody{
+				Required: true,
+				Content: openapi3.Content{
+					"application/json": &openapi3.MediaType{Schema: &openapi3.SchemaRef{Value: &openapi3.Schema{
+						Type: &openapi3.Types{"object"},
+						Properties: openapi3.Schemas{
+							"sku":    &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"string"}}},
+							"amount": &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"integer"}}},
+						},
+						Required: []string{"sku"},
+					}}},
+				},
+			}},
+		},
+	})
+
+	return &OAS{T: *doc}
+}
+
+func TestDeriveSourceTools_ExposeAll(t *testing.T) {
+	t.Parallel()
+
+	tools, warns, err := DeriveSourceTools(makeTestOAS(t), nil)
+	require.NoError(t, err)
+	assert.Empty(t, warns)
+	require.Len(t, tools, 2)
+
+	// Deterministic alphabetical order.
+	assert.Equal(t, "createOrder", tools[0].Name)
+	assert.Equal(t, "getOrder", tools[1].Name)
+
+	get := tools[1]
+	assert.Equal(t, "GET", get.Method)
+	assert.Equal(t, "/orders/{id}", get.PathTemplate)
+	assert.Equal(t, "path", get.ParamLocations["id"])
+	assert.Equal(t, "query", get.ParamLocations["verbose"])
+
+	create := tools[0]
+	assert.Equal(t, "POST", create.Method)
+	assert.Equal(t, "/orders", create.PathTemplate)
+	assert.Equal(t, "body.sku", create.ParamLocations["sku"])
+	assert.Equal(t, "body.amount", create.ParamLocations["amount"])
+}
+
+func TestDeriveSourceTools_ExposeList(t *testing.T) {
+	t.Parallel()
+
+	tools, _, err := DeriveSourceTools(makeTestOAS(t), []string{"getOrder"})
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+	assert.Equal(t, "getOrder", tools[0].Name)
+}
+
+func TestDeriveSourceTools_MissingOperationID(t *testing.T) {
+	t.Parallel()
+
+	doc := &openapi3.T{
+		OpenAPI: "3.0.3",
+		Info:    &openapi3.Info{Title: "X", Version: "1"},
+		Paths:   openapi3.NewPaths(),
+	}
+	doc.Paths.Set("/x", &openapi3.PathItem{Get: &openapi3.Operation{}})
+
+	tools, warns, err := DeriveSourceTools(&OAS{T: *doc}, nil)
+	require.NoError(t, err)
+	assert.Empty(t, tools)
+	require.Len(t, warns, 1)
+	assert.Contains(t, warns[0].Reason, "missing operationId")
+}
+
+func TestDeriveSourceTools_SkipsInternalOperations(t *testing.T) {
+	t.Parallel()
+
+	srcOAS := makeTestOAS(t)
+	xtyk := &XTykAPIGateway{
+		Middleware: &Middleware{
+			Operations: Operations{
+				"getOrder": &Operation{Internal: &Internal{Enabled: true}},
+			},
+		},
+	}
+	srcOAS.SetTykExtension(xtyk)
+
+	tools, warns, err := DeriveSourceTools(srcOAS, nil)
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+	assert.Equal(t, "createOrder", tools[0].Name)
+
+	require.Len(t, warns, 1)
+	assert.Equal(t, "getOrder", warns[0].Operation)
+	assert.Contains(t, warns[0].Reason, "internal")
+}
+
+func TestDeriveSourceTools_NilOAS(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := DeriveSourceTools(nil, nil)
+	assert.Error(t, err)
+}

--- a/apidef/oas/mcp_proxy_derive.go
+++ b/apidef/oas/mcp_proxy_derive.go
@@ -1,0 +1,404 @@
+package oas
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// DerivedTool is the runtime descriptor the adapter needs to translate
+// a `tools/call` JSON-RPC envelope into an HTTP request against the
+// source REST API.
+//
+// It carries everything the adapter middleware needs — method, path
+// template, where each argument lives (path / query / header / body /
+// body.<field>), and the synthesised input JSON schema that is served
+// back on `tools/list`.
+type DerivedTool struct {
+	// Name is the sanitised operationId — the tool name agents call.
+	Name string `json:"name"`
+
+	// Description is taken from the OAS operation summary or description.
+	Description string `json:"description,omitempty"`
+
+	// Method is the HTTP method (GET, POST, ...).
+	Method string `json:"-"`
+
+	// PathTemplate is the OAS path template (e.g. "/orders/{id}").
+	PathTemplate string `json:"-"`
+
+	// ParamLocations maps each argument name to its source location.
+	// Recognised values:
+	//   - "path"
+	//   - "query"
+	//   - "header"
+	//   - "body"          (the whole JSON body)
+	//   - "body.<field>"  (a single JSON body field)
+	ParamLocations map[string]string `json:"-"`
+
+	// InputSchema is the JSON schema published in tools/list to describe
+	// the tool's accepted arguments. Built from the operation's
+	// parameters + requestBody.
+	InputSchema map[string]any `json:"inputSchema"`
+}
+
+// DeriveWarning describes a non-fatal issue encountered while deriving
+// tools — for example, a collision between two operationIds after
+// sanitisation, or a parameter type that could not be represented.
+type DeriveWarning struct {
+	Operation string
+	Reason    string
+}
+
+// DeriveSourceTools walks a REST OAS document and produces a runtime
+// tool catalogue for the synthetic MCP adapter.
+//
+// The function is pure and gateway-agnostic; the same inputs always
+// yield the same outputs. It is called fresh on every reload — no
+// snapshot is persisted.
+//
+// Exposure rules:
+//   - If expose is nil or empty, every operation becomes a tool (default).
+//   - Otherwise, only operations whose sanitised name appears in expose
+//     are emitted.
+//
+// Tools are returned in deterministic (alphabetical-by-name) order so
+// reload-to-reload diffs are stable.
+func DeriveSourceTools(srcOAS *OAS, expose []string) ([]DerivedTool, []DeriveWarning, error) {
+	var exposeSet map[string]struct{}
+	if len(expose) > 0 {
+		exposeSet = make(map[string]struct{}, len(expose))
+		for _, name := range expose {
+			exposeSet[SanitizeToolName(name)] = struct{}{}
+		}
+	}
+	if srcOAS == nil {
+		return nil, nil, fmt.Errorf("source OAS is nil")
+	}
+
+	var (
+		tools    []DerivedTool
+		warnings []DeriveWarning
+		seen     = map[string]bool{}
+	)
+
+	if srcOAS.Paths == nil {
+		return tools, warnings, nil
+	}
+
+	// Operations marked `internal.enabled: true` in the Tyk extension are
+	// hidden from the public listenPath; the adapter loop bypasses that
+	// check, so we must filter them out at derivation time.
+	var internalOps map[string]bool
+	if ext := srcOAS.GetTykExtension(); ext != nil && ext.Middleware != nil {
+		for opID, op := range ext.Middleware.Operations {
+			if op != nil && op.Internal != nil && op.Internal.Enabled {
+				if internalOps == nil {
+					internalOps = map[string]bool{}
+				}
+				internalOps[opID] = true
+			}
+		}
+	}
+
+	type pathOp struct {
+		path string
+		item *openapi3.PathItem
+	}
+
+	pathKeys := make([]string, 0, len(srcOAS.Paths.Map()))
+	for k := range srcOAS.Paths.Map() {
+		pathKeys = append(pathKeys, k)
+	}
+	sort.Strings(pathKeys)
+
+	for _, p := range pathKeys {
+		item := srcOAS.Paths.Map()[p]
+		if item == nil {
+			continue
+		}
+
+		for _, mo := range methodOperations(p, item) {
+			rawName := mo.op.OperationID
+			if rawName == "" {
+				warnings = append(warnings, DeriveWarning{
+					Operation: fmt.Sprintf("%s %s", mo.method, mo.path),
+					Reason:    "missing operationId",
+				})
+				continue
+			}
+
+			if internalOps[rawName] {
+				warnings = append(warnings, DeriveWarning{
+					Operation: rawName,
+					Reason:    "operation marked internal — skipped",
+				})
+				continue
+			}
+
+			name := SanitizeToolName(rawName)
+			if name == "" {
+				warnings = append(warnings, DeriveWarning{
+					Operation: rawName,
+					Reason:    "operationId sanitises to empty string",
+				})
+				continue
+			}
+
+			if seen[name] {
+				warnings = append(warnings, DeriveWarning{
+					Operation: rawName,
+					Reason:    "tool name collision after sanitisation",
+				})
+				continue
+			}
+
+			if exposeSet != nil {
+				if _, ok := exposeSet[name]; !ok {
+					continue
+				}
+			}
+
+			seen[name] = true
+
+			locs, schema := deriveParams(item, mo.op)
+
+			tools = append(tools, DerivedTool{
+				Name:           name,
+				Description:    operationDescription(mo.op),
+				Method:         mo.method,
+				PathTemplate:   mo.path,
+				ParamLocations: locs,
+				InputSchema:    schema,
+			})
+		}
+	}
+
+	sort.Slice(tools, func(i, j int) bool { return tools[i].Name < tools[j].Name })
+
+	return tools, warnings, nil
+}
+
+type derivedOp struct {
+	method string
+	path   string
+	op     *openapi3.Operation
+}
+
+func methodOperations(p string, item *openapi3.PathItem) []derivedOp {
+	ops := []derivedOp{}
+	add := func(method string, op *openapi3.Operation) {
+		if op != nil {
+			ops = append(ops, derivedOp{method: method, path: p, op: op})
+		}
+	}
+	add("GET", item.Get)
+	add("PUT", item.Put)
+	add("POST", item.Post)
+	add("DELETE", item.Delete)
+	add("OPTIONS", item.Options)
+	add("HEAD", item.Head)
+	add("PATCH", item.Patch)
+	add("TRACE", item.Trace)
+	return ops
+}
+
+func operationDescription(op *openapi3.Operation) string {
+	if op.Summary != "" {
+		return op.Summary
+	}
+	return op.Description
+}
+
+var toolNameInvalid = regexp.MustCompile(`[^A-Za-z0-9_.-]`)
+
+// SanitizeToolName lowercases and strips characters MCP clients dislike.
+// The result is restricted to [A-Za-z0-9_.-]; consecutive runs of invalid
+// characters collapse into a single underscore. Leading/trailing
+// underscores are trimmed.
+func SanitizeToolName(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	cleaned := toolNameInvalid.ReplaceAllString(raw, "_")
+	// collapse repeated underscores
+	for strings.Contains(cleaned, "__") {
+		cleaned = strings.ReplaceAll(cleaned, "__", "_")
+	}
+	return strings.Trim(cleaned, "_")
+}
+
+// deriveParams walks an operation's parameters and requestBody and
+// returns (paramLocations, inputSchema). The schema follows the JSON
+// Schema draft-07 dialect that MCP clients expect for tool inputs.
+func deriveParams(item *openapi3.PathItem, op *openapi3.Operation) (map[string]string, map[string]any) {
+	locs := map[string]string{}
+	props := map[string]any{}
+	required := []string{}
+
+	addParam := func(param *openapi3.Parameter) {
+		if param == nil || param.Name == "" {
+			return
+		}
+		var loc string
+		switch param.In {
+		case openapi3.ParameterInPath:
+			loc = "path"
+		case openapi3.ParameterInQuery:
+			loc = "query"
+		case openapi3.ParameterInHeader:
+			loc = "header"
+		default:
+			return
+		}
+		locs[param.Name] = loc
+
+		schema := map[string]any{"type": "string"}
+		if param.Schema != nil && param.Schema.Value != nil {
+			if t := schemaType(param.Schema.Value); t != "" {
+				schema["type"] = t
+			}
+			if d := param.Description; d != "" {
+				schema["description"] = d
+			}
+		}
+		props[param.Name] = schema
+		if param.Required {
+			required = append(required, param.Name)
+		}
+	}
+
+	for _, p := range item.Parameters {
+		if p != nil {
+			addParam(p.Value)
+		}
+	}
+	for _, p := range op.Parameters {
+		if p != nil {
+			addParam(p.Value)
+		}
+	}
+
+	if op.RequestBody != nil && op.RequestBody.Value != nil {
+		rb := op.RequestBody.Value
+		// Pick first JSON-ish content type.
+		var media *openapi3.MediaType
+		for ct, m := range rb.Content {
+			if strings.Contains(ct, "json") {
+				media = m
+				break
+			}
+		}
+		if media != nil && media.Schema != nil && media.Schema.Value != nil {
+			body := media.Schema.Value
+			if body.Type != nil && body.Type.Is("object") && len(body.Properties) > 0 {
+				bodyRequired := map[string]bool{}
+				for _, name := range body.Required {
+					bodyRequired[name] = true
+				}
+				for name, ref := range body.Properties {
+					if _, clash := locs[name]; clash {
+						continue
+					}
+					locs[name] = "body." + name
+					field := map[string]any{"type": "string"}
+					if ref != nil && ref.Value != nil {
+						if t := schemaType(ref.Value); t != "" {
+							field["type"] = t
+						}
+						if ref.Value.Description != "" {
+							field["description"] = ref.Value.Description
+						}
+					}
+					props[name] = field
+					if bodyRequired[name] {
+						required = append(required, name)
+					}
+				}
+			} else {
+				locs["body"] = "body"
+				props["body"] = map[string]any{"type": "object"}
+				if rb.Required {
+					required = append(required, "body")
+				}
+			}
+		}
+	}
+
+	sort.Strings(required)
+
+	schema := map[string]any{
+		"type":       "object",
+		"properties": props,
+	}
+	if len(required) > 0 {
+		schema["required"] = required
+	}
+	return locs, schema
+}
+
+func schemaType(s *openapi3.Schema) string {
+	if s == nil || s.Type == nil {
+		return ""
+	}
+	switch {
+	case s.Type.Is("string"):
+		return "string"
+	case s.Type.Is("integer"):
+		return "integer"
+	case s.Type.Is("number"):
+		return "number"
+	case s.Type.Is("boolean"):
+		return "boolean"
+	case s.Type.Is("array"):
+		return "array"
+	case s.Type.Is("object"):
+		return "object"
+	}
+	return ""
+}
+
+// AdapterAPIIDSuffix is the deterministic suffix appended to the source
+// REST APIID to form the synthetic adapter APIID, e.g.
+// "abc123" -> "abc123__mcp-server".
+const AdapterAPIIDSuffix = "__mcp-server"
+
+// AdapterAPIID returns the deterministic APIID for the synthetic adapter
+// paired with the given REST API.
+func AdapterAPIID(restAPIID string) string {
+	return restAPIID + AdapterAPIIDSuffix
+}
+
+// IsAdapterAPIID reports whether an APIID is the deterministic adapter
+// ID derived from some REST APIID via AdapterAPIID.
+func IsAdapterAPIID(id string) bool {
+	return strings.HasSuffix(id, AdapterAPIIDSuffix) && len(id) > len(AdapterAPIIDSuffix)
+}
+
+// AdapterSourceAPIID returns the REST APIID corresponding to an adapter
+// APIID, or "" if id is not an adapter ID.
+func AdapterSourceAPIID(id string) string {
+	if !IsAdapterAPIID(id) {
+		return ""
+	}
+	return strings.TrimSuffix(id, AdapterAPIIDSuffix)
+}
+
+// AdapterLoopHost returns the host portion of the tyk:// URL used by an
+// MCP proxy to address its paired adapter unambiguously, e.g.
+// "abc123__mcp-server". The deterministic AdapterAPIIDSuffix ensures
+// exact-APIID matching in the gateway's loopback resolver wins before
+// any fuzzy name-based match could collide.
+func AdapterLoopHost(restAPIID string) string {
+	return AdapterAPIID(restAPIID)
+}
+
+// AdapterLoopURL returns the full tyk:// URL an MCP proxy should set as
+// its upstream to dispatch into the paired adapter.
+func AdapterLoopURL(restAPIID string) string {
+	return "tyk://" + AdapterLoopHost(restAPIID)
+}
+

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -1375,6 +1375,9 @@
         "batchProcessing": {
           "$ref": "#/definitions/X-Tyk-BatchProcessing"
         },
+        "mcp": {
+          "$ref": "#/definitions/X-Tyk-MCP"
+        },
         "port": {
           "type": "integer",
           "minimum": 1,
@@ -2568,6 +2571,21 @@
       "properties": {
         "enabled": {
           "type": "boolean"
+        }
+      },
+      "required": [
+        "enabled"
+      ]
+    },
+    "X-Tyk-MCP": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "expose": {
+          "type": "array",
+          "items": { "type": "string" }
         }
       },
       "required": [

--- a/apidef/oas/schema/x-tyk-api-gateway.strict.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.strict.json
@@ -1430,6 +1430,9 @@
         "batchProcessing": {
           "$ref": "#/definitions/X-Tyk-BatchProcessing"
         },
+        "mcp": {
+          "$ref": "#/definitions/X-Tyk-MCP"
+        },
         "port": {
           "type": "integer",
           "minimum": 1,
@@ -2700,6 +2703,22 @@
       "properties": {
         "enabled": {
           "type": "boolean"
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "additionalProperties": false
+    },
+    "X-Tyk-MCP": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "expose": {
+          "type": "array",
+          "items": { "type": "string" }
         }
       },
       "required": [

--- a/apidef/oas/server.go
+++ b/apidef/oas/server.go
@@ -49,6 +49,14 @@ type Server struct {
 	// Tyk classic API definition: `enable_batch_request_support`.
 	BatchProcessing *BatchProcessing `bson:"batchProcessing,omitempty" json:"batchProcessing,omitempty"`
 
+	// MCP marks a REST API as MCP-callable. When MCP.Enabled is true the
+	// gateway loader synthesises a paired Internal adapter spec; an
+	// operator-managed MCP proxy APIDef (POSTed to /tyk/mcps) then routes
+	// agent tools/call into this API.
+	//
+	// Tyk classic API definition: `mcp_exposure`.
+	MCP *MCP `bson:"mcp,omitempty" json:"mcp,omitempty"`
+
 	// Protocol configures the HTTP protocol used by the API.
 	// Possible values are:
 	// - "http": Standard HTTP/1.1 protocol
@@ -123,6 +131,7 @@ func (s *Server) Fill(api apidef.APIDefinition) {
 
 	s.fillIPAccessControl(api)
 	s.fillBatchProcessing(api)
+	s.fillMCP(api)
 }
 
 // ExtractTo extracts *Server into *apidef.APIDefinition.
@@ -187,6 +196,7 @@ func (s *Server) ExtractTo(api *apidef.APIDefinition) {
 
 	s.extractIPAccessControlTo(api)
 	s.extractBatchProcessingTo(api)
+	s.extractMCPTo(api)
 }
 
 // ListenPath is the base path on Tyk to which requests for this API
@@ -431,4 +441,27 @@ func (s *Server) extractBatchProcessingTo(api *apidef.APIDefinition) {
 	}
 
 	s.BatchProcessing.ExtractTo(api)
+}
+
+func (s *Server) fillMCP(api apidef.APIDefinition) {
+	if s.MCP == nil {
+		s.MCP = &MCP{}
+	}
+
+	s.MCP.Fill(api)
+
+	if ShouldOmit(s.MCP) {
+		s.MCP = nil
+	}
+}
+
+func (s *Server) extractMCPTo(api *apidef.APIDefinition) {
+	if s.MCP == nil {
+		s.MCP = &MCP{}
+		defer func() {
+			s.MCP = nil
+		}()
+	}
+
+	s.MCP.ExtractTo(api)
 }

--- a/apidef/schema.json
+++ b/apidef/schema.json
@@ -10,6 +10,25 @@
     "is_site": {
       "type": "boolean"
     },
+    "mcp_exposure": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "expose": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": { "type": "string" }
+        }
+      }
+    },
     "uptime_tests": {
       "type": [
         "object",


### PR DESCRIPTION
## Summary

First of three stacked PRs implementing REST-as-MCP (TT-17123). This part introduces the OAS marker, its classic-APIDef projection, and the pure tool-derivation logic. **No runtime behaviour change** — the gateway wiring that actually exposes a REST API as MCP lands in parts 2 and 3.

- **`server.mcp` OAS marker** (`apidef/oas/mcp.go`, `apidef/oas/server.go`). Fields: `enabled` plus an optional `expose: []string` allow-list of operationIds. Empty `expose` = expose every operation in the source OAS.
- **Classic-APIDef projection** (`apidef/api_definitions.go`): `MCPExposureConfig`, `IsMCPExposed()`, `IsPairedMCPAdapterProxy()` (recognises `tyk://*__mcp-server` upstreams), `IsMCPManaged()`.
- **Tool derivation** (`apidef/oas/mcp_proxy_derive.go`): gateway-free `DeriveSourceTools(*OAS, []string)` walks the source OAS into `[]DerivedTool` carrying method, path template, per-arg location (path/query/header/body/body.<field>), and a synthesised JSON input schema. Operations marked `middleware.operations[<id>].internal.enabled: true` are unconditionally skipped — the operator's internal-only declaration outranks `expose`. Also exposes the `__mcp-server` adapter-APIID helpers (`AdapterAPIID`, `IsAdapterAPIID`, `AdapterSourceAPIID`, `AdapterLoopHost`, `AdapterLoopURL`).
- **Schemas**: `apidef/schema.json` (classic) and `apidef/oas/schema/x-tyk-api-gateway[.strict].json` so Dashboard-side validation accepts the new fields. This unblocks the failing `tests/dashboard_api/api_ownership_test.py` cases in tyk-analytics CI.

## Stacked branches

- **This PR** — `part-1 → master`
- Next — `part-2 → part-1` (internal helpers: pairing index, adapter envelopes, trust descriptor)
- Last — `part-3 → part-2` (gateway wiring: synthesis, middlewares, validateMCP, e2e)

## Test plan

- [x] `go test ./apidef/oas/...` green (round-trip, derive, internal-skip, expose-list, sanitisation, suffix helpers)
- [x] `go build ./apidef/...` clean
- [ ] Roll the updated `apidef.Schema` into tyk-analytics so Dashboard validation accepts `mcp_exposure` / `X-Tyk-MCP`
<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-17123" title="TT-17123" target="_blank">TT-17123</a>
</summary>

|         |    |
|---------|----|
| Status  | Open |
| Summary | POC - API to MCP |

Generated at: 2026-05-13 08:19:37

</details>

<!---TykTechnologies/jira-linter ends here-->
