### PR TITLE
[TT-17176] PRM auto-migration — tolerate marker on API definition

### DIFF
--- a/apidef/mcp/schema/x-tyk-api-gateway.json
+++ b/apidef/mcp/schema/x-tyk-api-gateway.json
@@ -1278,6 +1278,9 @@
         "enabled": {
           "type": "boolean"
         },
+        "prmMigratedToOAuth2": {
+          "type": "boolean"
+        },
         "stripAuthorizationData": {
           "type": "boolean"
         },

--- a/apidef/oas/authentication.go
+++ b/apidef/oas/authentication.go
@@ -99,6 +99,16 @@ type Authentication struct {
 	// authorization server to use for accessing the API.
 	ProtectedResourceMetadata *ProtectedResourceMetadata `bson:"protectedResourceMetadata,omitempty" json:"protectedResourceMetadata,omitempty"`
 
+	// PRMMigratedToOAuth2 is a dashboard-managed marker recording that
+	// the one-shot migration copying the deprecated top-level
+	// `protectedResourceMetadata` block into the new
+	// `securitySchemes[<name>].oauth2.protectedResourceMetadata` location
+	// has been applied to this API definition. The gateway ignores it;
+	// it exists solely to make the dashboard migration idempotent and
+	// to honour an operator who has deleted the new block (the marker
+	// prevents the migration from re-populating it on the next restart).
+	PRMMigratedToOAuth2 bool `bson:"prmMigratedToOAuth2,omitempty" json:"prmMigratedToOAuth2,omitempty"`
+
 	// CertificateAuth represents certificate-based authentication configuration.
 	CertificateAuth *CertificateAuth `bson:"certificateAuth,omitempty" json:"certificateAuth,omitempty"`
 }

--- a/apidef/oas/authentication_test.go
+++ b/apidef/oas/authentication_test.go
@@ -968,3 +968,43 @@ func TestProtectedResourceMetadata_JSON(t *testing.T) {
 		assert.NotContains(t, raw, "scopesSupported")
 	})
 }
+
+func TestAuthentication_PRMMigratedToOAuth2_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	t.Run("survives marshal/unmarshal", func(t *testing.T) {
+		t.Parallel()
+		auth := &Authentication{PRMMigratedToOAuth2: true}
+
+		data, err := json.Marshal(auth)
+		assert.NoError(t, err)
+
+		var decoded Authentication
+		assert.NoError(t, json.Unmarshal(data, &decoded))
+		assert.True(t, decoded.PRMMigratedToOAuth2)
+	})
+
+	t.Run("omitted when zero", func(t *testing.T) {
+		t.Parallel()
+		auth := &Authentication{Enabled: true}
+
+		data, err := json.Marshal(auth)
+		assert.NoError(t, err)
+
+		var raw map[string]interface{}
+		assert.NoError(t, json.Unmarshal(data, &raw))
+		assert.NotContains(t, raw, "prmMigratedToOAuth2")
+	})
+
+	t.Run("forward-compat: unknown adjacent field is ignored", func(t *testing.T) {
+		t.Parallel()
+		// Simulates a newer dashboard writing a marker field that an
+		// older gateway has never seen.
+		payload := []byte(`{"enabled":true,"prmMigratedToOAuth2":true,"somethingNewerStillUnknownToUs":42}`)
+
+		var decoded Authentication
+		assert.NoError(t, json.Unmarshal(payload, &decoded))
+		assert.True(t, decoded.Enabled)
+		assert.True(t, decoded.PRMMigratedToOAuth2)
+	})
+}

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -1202,6 +1202,9 @@
         "enabled": {
           "type": "boolean"
         },
+        "prmMigratedToOAuth2": {
+          "type": "boolean"
+        },
         "stripAuthorizationData": {
           "type": "boolean"
         },

--- a/apidef/oas/schema/x-tyk-api-gateway.strict.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.strict.json
@@ -1255,6 +1255,9 @@
         "enabled": {
           "type": "boolean"
         },
+        "prmMigratedToOAuth2": {
+          "type": "boolean"
+        },
         "stripAuthorizationData": {
           "type": "boolean"
         },

--- a/apidef/streams/schema/x-tyk-api-gateway.json
+++ b/apidef/streams/schema/x-tyk-api-gateway.json
@@ -1158,6 +1158,9 @@
         "enabled": {
           "type": "boolean"
         },
+        "prmMigratedToOAuth2": {
+          "type": "boolean"
+        },
         "stripAuthorizationData": {
           "type": "boolean"
         },


### PR DESCRIPTION
## Summary

- Adds `Authentication.PRMMigratedToOAuth2` — an `omitempty` boolean the dashboard sets after copying the deprecated top-level `protectedResourceMetadata` block into the new `securitySchemes[<name>].oauth2.protectedResourceMetadata` location (Story 05 / TT-17176).
- Gateway treats the field as opaque metadata. Older gateways tolerate it via the omitempty + adjacent-unknown-fields-ignored property pinned by `TestAuthentication_PRMMigratedToOAuth2_RoundTrip`.
- No runtime behaviour change. The "new wins over old" / "fall back to old when new absent" runtime priority is already in place from Story 04 (TT-17175).

## Story

- JIRA: [TT-17176](https://tyktech.atlassian.net/browse/TT-17176)

## Companion PRs

- `tyk-analytics`: the primary work for this story — migration job + Python integration coverage.

## Test plan

- [x] `go test ./apidef/oas/ -run TestAuthentication_PRMMigratedToOAuth2_RoundTrip` — 3/3 (round-trip + omitempty + forward-compat with adjacent unknown field).
- [x] Existing `apidef/oas` suite — no regressions on the marker field's presence.

## Risk

Single struct field with `omitempty` + a round-trip test. Forward-compat across gateway versions verified. No runtime path touches the field.


[TT-17176]: https://tyktech.atlassian.net/browse/TT-17176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-17176" title="TT-17176" target="_blank">TT-17176</a>
</summary>

|         |    |
|---------|----|
| Status  | Open |
| Summary | Protected Resource Metadata — auto-migration of existing customers |

Generated at: 2026-05-13 14:35:54

</details>

<!---TykTechnologies/jira-linter ends here-->



