### PR TITLE
[TT-16951] fix: restore EE Docker build steps in release-5.13.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
             rpmvers: 'el/7 el/8 el/9 amazon/2 amazon/2023'
             debvers: 'ubuntu/xenial ubuntu/bionic ubuntu/focal ubuntu/jammy ubuntu/noble debian/jessie debian/buster debian/bullseye debian/bookworm debian/trixie'
     outputs:
+      ee_tags: ${{ steps.ci_metadata_ee.outputs.tags }}
       fips_tags: ${{ steps.ci_metadata_fips.outputs.tags }}
       std_tags: ${{ steps.ci_metadata_std.outputs.tags }}
       commit_author: ${{ steps.set_outputs.outputs.commit_author}}
@@ -149,9 +150,92 @@ jobs:
           -v /tmp/build.sh:/tmp/build.sh                                         \
           -w /go/src/github.com/TykTechnologies/tyk                      \
           tykio/golang-cross:${{ matrix.golang_cross }} /tmp/build.sh
+      - name: Docker metadata for ee CI
+        id: ci_metadata_ee
+        if: ${{ matrix.golang_cross == '1.25-bullseye' }}
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        with:
+          images: |
+            ${{ steps.ecr.outputs.registry }}/tyk-ee
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,format=long
+            type=semver,pattern={{major}},prefix=v
+            type=semver,pattern={{major}}.{{minor}},prefix=v
+            type=semver,pattern={{version}},prefix=v
+      - name: push ee image to CI
+        if: ${{ matrix.golang_cross == '1.25-bullseye' }}
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: "dist"
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          file: ci/Dockerfile.distroless
+          provenance: mode=max
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ${{ steps.ci_metadata_ee.outputs.tags }}
+          labels: ${{ steps.ci_metadata_ee.outputs.labels }}
+          build-args: |
+            BUILD_PACKAGE_NAME=tyk-gateway-ee
+            BASE_IMAGE=tykio/dhi-busybox:1.37-fips
+            NONROOT_CHOWN=true
+      - name: Docker metadata for ee tag push
+        id: tag_metadata_ee
+        if: startsWith(github.ref, 'refs/tags')
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        with:
+          images: |
+            docker.tyk.io/tyk-gateway/tyk-gateway-ee
+            tykio/tyk-gateway-ee
+          flavor: |
+            latest=false
+            prefix=v
+          tags: |
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}}
+          labels: |
+            org.opencontainers.image.title=Tyk Gateway Enterprise Edition
+            org.opencontainers.image.description=Tyk API Gateway Enterprise Edition written in Go, supporting REST, GraphQL, TCP and gRPC protocols
+            org.opencontainers.image.vendor=tyk.io
+            org.opencontainers.image.version=${{ github.ref_name }}
+      - name: push ee image to prod
+        if: ${{ matrix.golang_cross == '1.25-bullseye' && startsWith(github.ref, 'refs/tags') }}
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: "dist"
+          platforms: linux/amd64,linux/arm64
+          file: ci/Dockerfile.distroless
+          provenance: mode=max
+          cache-from: type=gha
+          push: true
+          tags: ${{ steps.tag_metadata_ee.outputs.tags }}
+          labels: ${{ steps.tag_metadata_ee.outputs.labels }}
+          build-args: |
+            BUILD_PACKAGE_NAME=tyk-gateway-ee
+            BASE_IMAGE=tykio/dhi-busybox:1.37-fips
+            NONROOT_CHOWN=true
+      - name: Attach base image VEX to ee
+        if: ${{ matrix.golang_cross == '1.25-bullseye' && startsWith(github.ref, 'refs/tags') }}
+        run: |
+          # Install Docker Scout CLI
+          curl -fsSL https://raw.githubusercontent.com/docker/scout-cli/v1.20.4/install.sh -o /tmp/scout-install.sh && sh /tmp/scout-install.sh 2>/dev/null
+          # Extract VEX from the DHI base image
+          docker scout vex get --org tykio -o /tmp/ee-vex.json tykio/dhi-busybox:1.37-fips || true
+          if [ -f /tmp/ee-vex.json ]; then
+            cosign attest --yes --type openvex \
+              --predicate /tmp/ee-vex.json \
+              docker.tyk.io/tyk-gateway/tyk-gateway-ee:${{ github.ref_name }} || true
+            cosign attest --yes --type openvex \
+              --predicate /tmp/ee-vex.json \
+              tykio/tyk-gateway-ee:${{ github.ref_name }} || true
+          fi
       - name: Docker metadata for fips CI
         id: ci_metadata_fips
-        if: ${{ matrix.golang_cross == '1.25-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.25-bullseye' && github.event_name != 'pull_request' }}
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
@@ -166,7 +250,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},prefix=v
             type=semver,pattern={{version}},prefix=v
       - name: push fips image to CI
-        if: ${{ matrix.golang_cross == '1.25-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.25-bullseye' && github.event_name != 'pull_request' }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -230,7 +314,7 @@ jobs:
           fi
       - name: Docker metadata for std CI
         id: ci_metadata_std
-        if: ${{ matrix.golang_cross == '1.25-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.25-bullseye' && github.event_name != 'pull_request' }}
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
@@ -245,7 +329,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},prefix=v
             type=semver,pattern={{version}},prefix=v
       - name: push std image to CI
-        if: ${{ matrix.golang_cross == '1.25-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.25-bullseye' && github.event_name != 'pull_request' }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -312,6 +396,405 @@ jobs:
             dist/*.rpm
             !dist/*PAYG*.rpm
             !dist/*fips*.rpm
+  resolve-dashboard-image:
+    needs: goreleaser
+    if: |
+      !cancelled() &&
+      needs.goreleaser.result == 'success' &&
+      github.event.pull_request.draft == false
+    runs-on: ${{ vars.DEFAULT_RUNNER }}
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      dashboard_image: ${{ steps.resolve.outputs.dashboard_image }}
+      needs_build: ${{ steps.resolve.outputs.needs_build }}
+      dashboard_branch: ${{ steps.resolve.outputs.dashboard_branch }}
+      strategy: ${{ steps.resolve.outputs.strategy }}
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+      - name: Checkout tyk repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Check for relevant package changes in PR
+        id: check_changes
+        shell: bash
+        env:
+          RELEVANT_PACKAGES: ${{ vars.DASHBOARD_DEPENDENCY_PACKAGES || 'pkg apidef lib common certs log config test user header' }}
+        run: |
+          echo "Checking PR for changes in packages: $RELEVANT_PACKAGES"
+          echo "Comparing PR against base branch: ${{ env.BASE_REF }}"
+
+          # Compare entire PR against base branch
+          git fetch origin ${{ env.BASE_REF }} 2>/dev/null || true
+          CHANGED_FILES=$(git diff --name-only origin/${{ env.BASE_REF }}...HEAD 2>/dev/null || echo "")
+
+          echo "Changed files in PR:"
+          echo "$CHANGED_FILES"
+
+          # Check if any changed files are in relevant packages
+          HAS_RELEVANT_CHANGES=false
+          for pkg in $RELEVANT_PACKAGES; do
+            if echo "$CHANGED_FILES" | grep -q "^${pkg}/"; then
+              echo "✓ Found changes in package: $pkg"
+              HAS_RELEVANT_CHANGES=true
+            fi
+          done
+
+          if [ "$HAS_RELEVANT_CHANGES" = "true" ]; then
+            echo "has_relevant_changes=true" >> $GITHUB_OUTPUT
+            echo "📦 Relevant package changes in PR - will build dashboard"
+          else
+            echo "has_relevant_changes=false" >> $GITHUB_OUTPUT
+            echo "ℹ️ No relevant package changes in PR"
+          fi
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
+        with:
+          role-to-assume: arn:aws:iam::754489498669:role/ecr_rw_tyk
+          role-session-name: cipush
+          aws-region: eu-central-1
+          mask-aws-account-id: false
+      - name: Login to Amazon ECR
+        id: ecr
+        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2
+        with:
+          mask-password: 'true'
+      - name: Check if tyk-analytics branch exists
+        id: check_branch
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          if [ -z "$HEAD_REF" ]; then
+            echo "Not a pull request, skipping branch check"
+            echo "branch_exists=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          BRANCH=${HEAD_REF##*/}
+          echo "Checking for branch: $BRANCH in tyk-analytics"
+
+          if git ls-remote --heads https://$GITHUB_TOKEN@github.com/TykTechnologies/tyk-analytics.git refs/heads/$BRANCH | grep -q .; then
+            echo "✓ Branch '$BRANCH' exists in tyk-analytics"
+            echo "branch_exists=true" >> $GITHUB_OUTPUT
+            echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          else
+            echo "✗ Branch '$BRANCH' not found in tyk-analytics"
+            echo "branch_exists=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Check if ECR image exists for this PR
+        id: check_ecr
+        shell: bash
+        env:
+          REGISTRY: ${{ steps.ecr.outputs.registry }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [ -z "$PR_NUMBER" ]; then
+            echo "Not a pull request, skipping ECR check"
+            echo "image_exists=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          IMAGE_TAG="tyk-${PR_NUMBER}"
+          echo "Checking for ECR image: tyk-analytics:${IMAGE_TAG}"
+
+          if aws ecr describe-images \
+            --repository-name tyk-analytics \
+            --image-ids imageTag=${IMAGE_TAG} \
+            --region eu-central-1 2>/dev/null | grep -q imageId; then
+            echo "✓ ECR image exists: ${IMAGE_TAG}"
+            echo "image_exists=true" >> $GITHUB_OUTPUT
+            echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
+          else
+            echo "✗ ECR image not found: ${IMAGE_TAG}"
+            echo "image_exists=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Resolve dashboard image strategy
+        id: resolve
+        shell: bash
+        env:
+          REGISTRY: ${{ steps.ecr.outputs.registry }}
+          BRANCH_EXISTS: ${{ steps.check_branch.outputs.branch_exists }}
+          IMAGE_EXISTS: ${{ steps.check_ecr.outputs.image_exists }}
+          BRANCH: ${{ steps.check_branch.outputs.branch }}
+          IMAGE_TAG: ${{ steps.check_ecr.outputs.image_tag }}
+          BASE_REF: ${{ env.BASE_REF }}
+          COMMIT_SHA: ${{ github.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HAS_RELEVANT_CHANGES: ${{ steps.check_changes.outputs.has_relevant_changes }}
+          ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+        run: |
+          echo "=================================="
+          echo "📊 Dashboard Image Resolution"
+          echo "=================================="
+          echo "PR number: $PR_NUMBER"
+          echo "Base ref: $BASE_REF"
+          echo "Branch exists: $BRANCH_EXISTS"
+          echo "PR image exists: $IMAGE_EXISTS"
+          echo "Branch name: $BRANCH"
+          echo "PR image tag: $IMAGE_TAG"
+          echo "Commit SHA: $COMMIT_SHA"
+          echo "Has relevant changes in PR: $HAS_RELEVANT_CHANGES"
+          echo "=================================="
+
+          # For non-master base branches, check if the same branch exists in tyk-analytics
+          if [ "$BASE_REF" != "master" ]; then
+            if git ls-remote --exit-code --heads "https://x-access-token:${ORG_GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" "refs/heads/$BASE_REF" > /dev/null 2>&1; then
+              echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
+              echo "    → Base branch exists in tyk-analytics, using it directly"
+              echo "dashboard_image=${REGISTRY}/tyk-analytics:${BASE_REF}" >> $GITHUB_OUTPUT
+              echo "needs_build=false" >> $GITHUB_OUTPUT
+              echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
+              echo "strategy=release-branch-match" >> $GITHUB_OUTPUT
+            else
+              echo "ℹ️ Strategy: Use gromit default (base branch '$BASE_REF' not found in tyk-analytics)"
+              echo "    → Falling back to gromit default"
+              echo "dashboard_image=" >> $GITHUB_OUTPUT
+              echo "needs_build=false" >> $GITHUB_OUTPUT
+              echo "dashboard_branch=" >> $GITHUB_OUTPUT
+              echo "strategy=gromit-default" >> $GITHUB_OUTPUT
+            fi
+
+          # Strategy 1: Matching branch exists in tyk-analytics → use gromit
+          elif [ "$BRANCH_EXISTS" = "true" ]; then
+            echo "📋 Strategy: Use matching branch '$BRANCH' via gromit"
+            echo "    → No override needed, gromit will handle it"
+            echo "dashboard_image=" >> $GITHUB_OUTPUT
+            echo "needs_build=false" >> $GITHUB_OUTPUT
+            echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
+            echo "strategy=gromit-branch" >> $GITHUB_OUTPUT
+
+          # Strategy 2a: PR has relevant changes → build new image
+          elif [ "$HAS_RELEVANT_CHANGES" = "true" ]; then
+            PR_IMAGE_TAG="tyk-${PR_NUMBER}"
+            echo "🔨 Strategy: Build dashboard (PR has relevant package changes)"
+            echo "    → Will update gateway ref to $COMMIT_SHA"
+            echo "    → Will push to: ${REGISTRY}/tyk-analytics:${PR_IMAGE_TAG}"
+            echo "dashboard_image=${REGISTRY}/tyk-analytics:${PR_IMAGE_TAG}" >> $GITHUB_OUTPUT
+            echo "needs_build=true" >> $GITHUB_OUTPUT
+            echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
+            echo "strategy=build-required" >> $GITHUB_OUTPUT
+
+          # Strategy 2b: PR image exists and no relevant changes → reuse existing image
+          elif [ "$IMAGE_EXISTS" = "true" ]; then
+            echo "🐳 Strategy: Reuse existing PR image (no relevant package changes in PR)"
+            echo "    → Image: ${REGISTRY}/tyk-analytics:${IMAGE_TAG}"
+            echo "dashboard_image=${REGISTRY}/tyk-analytics:${IMAGE_TAG}" >> $GITHUB_OUTPUT
+            echo "needs_build=false" >> $GITHUB_OUTPUT
+            echo "dashboard_branch=" >> $GITHUB_OUTPUT
+            echo "strategy=reuse-pr-image" >> $GITHUB_OUTPUT
+
+          # Strategy 3: Fallback to gromit default
+          else
+            echo "ℹ️ Strategy: Use gromit default"
+            echo "    → No matching branch, no existing PR image, no relevant changes"
+            echo "dashboard_image=" >> $GITHUB_OUTPUT
+            echo "needs_build=false" >> $GITHUB_OUTPUT
+            echo "dashboard_branch=" >> $GITHUB_OUTPUT
+            echo "strategy=gromit-default" >> $GITHUB_OUTPUT
+          fi
+
+          echo "=================================="
+          echo "✅ Resolution complete"
+          echo "=================================="
+  build-dashboard-image:
+    if: needs.resolve-dashboard-image.outputs.needs_build == 'true'
+    needs: resolve-dashboard-image
+    runs-on: ${{ vars.DEFAULT_RUNNER }}
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      dashboard_image: ${{ steps.output.outputs.image }}
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+      - name: Checkout tyk-analytics
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: TykTechnologies/tyk-analytics
+          ref: ${{ needs.resolve-dashboard-image.outputs.dashboard_branch }}
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 1
+          submodules: true
+      - name: Update gateway reference to PR branch
+        shell: bash
+        env:
+          GATEWAY_BRANCH: ${{ github.head_ref }}
+          ORG_GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          echo "📦 Updating tyk-gateway dependency to branch: $GATEWAY_BRANCH"
+
+          # Configure git for go get
+          git config --global url."https://x-access-token:${ORG_GH_TOKEN}@github.com/".insteadOf "https://github.com/"
+
+          # Update dependency using branch name
+          go get github.com/TykTechnologies/tyk@$GATEWAY_BRANCH
+
+          # Update replace directive if present
+          go mod edit -replace github.com/TykTechnologies/tyk=github.com/TykTechnologies/tyk@$GATEWAY_BRANCH
+
+          go mod tidy
+
+          echo "✅ Updated go.mod:"
+          grep "github.com/TykTechnologies/tyk" go.mod
+      - name: Fetch pre-built UI assets from S3
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_BINDATA_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_BINDATA_SECRET_ACCESS_KEY }}
+          AWS_REGION: eu-central-1
+          AWS_SESSION_TOKEN: ""
+        run: |
+          # Read the vendored commit SHA
+          ASSETS_COMMIT=$(cat .assets_vendor | head -n 1 | tr -d '\n')
+
+          echo "Fetching UI assets for commit: ${ASSETS_COMMIT}"
+          aws s3 sync s3://tyk-dashboard-assets-ci/commits/${ASSETS_COMMIT}/ internal/uiassets/dist/
+
+          if [ ! -f internal/uiassets/dist/_index.html ]; then
+            echo "❌ Failed to fetch assets: _index.html not found"
+            exit 1
+          fi
+
+          echo "✓ Assets fetched successfully to internal/uiassets/dist/"
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
+        with:
+          role-to-assume: arn:aws:iam::754489498669:role/ecr_rw_tyk
+          role-session-name: cipush
+          aws-region: eu-central-1
+      - name: Login to Amazon ECR
+        id: ecr
+        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2
+        with:
+          mask-password: 'true'
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: WarpBuilds/cache@f643a1ba29942d56621d07fc2d4284c7219868ad # v1
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-dashboard-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-dashboard-
+      - name: Build dashboard packages for current architecture
+        shell: bash
+        env:
+          ECR_REGISTRY: ${{ steps.ecr.outputs.registry }}
+          IMAGE_TAG: tyk-${{ github.event.pull_request.number }}
+          GOPRIVATE: github.com/TykTechnologies
+          ORG_GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          # Detect current architecture
+          ARCH=$(uname -m)
+          case $ARCH in
+            x86_64)
+              GOARCH=amd64
+              ;;
+            aarch64)
+              GOARCH=arm64
+              ;;
+            *)
+              echo "Unsupported architecture: $ARCH"
+              exit 1
+              ;;
+          esac
+
+          echo "🔨 Building tyk-analytics packages for linux/$GOARCH"
+          echo "   Target image: ${ECR_REGISTRY}/tyk-analytics:${IMAGE_TAG}"
+
+          # Build using goreleaser for current platform only
+          cat > /tmp/build-dashboard.sh <<'EOF'
+          #!/bin/sh
+          set -eax
+          git config --global url."https://x-access-token:${ORG_GH_TOKEN}@github.com/".insteadOf "https://github.com/"
+          git config --global --add safe.directory /go/src/github.com/TykTechnologies/tyk-analytics
+
+          # Build packages for current platform (GOOS and GOARCH are set via docker -e)
+          goreleaser release --clean -f ci/goreleaser/goreleaser.yml --snapshot --skip=sign,docker
+          EOF
+
+          chmod +x /tmp/build-dashboard.sh
+
+          # Build in golang-cross container
+          docker run --rm --privileged -e GITHUB_TOKEN=${ORG_GH_TOKEN} \
+            -e GOPRIVATE=github.com/TykTechnologies \
+            -e CGO_ENABLED=1 \
+            -e GOOS=linux \
+            -e GOARCH=$GOARCH \
+            -v ${{ github.workspace }}:/go/src/github.com/TykTechnologies/tyk-analytics \
+            -v ~/.cache/go-build:/cache/go-build \
+            -v ~/go/pkg/mod:/go/pkg/mod \
+            -e GOCACHE=/cache/go-build \
+            -e GOMODCACHE=/go/pkg/mod \
+            -v /tmp/build-dashboard.sh:/tmp/build-dashboard.sh \
+            -w /go/src/github.com/TykTechnologies/tyk-analytics \
+            tykio/golang-cross:1.25-bullseye /tmp/build-dashboard.sh
+
+          echo "✅ Packages built successfully for $GOARCH"
+      - name: Detect platform for Docker build
+        id: platform
+        shell: bash
+        run: |
+          ARCH=$(uname -m)
+          case $ARCH in
+            x86_64)
+              PLATFORM=linux/amd64
+              ;;
+            aarch64)
+              PLATFORM=linux/arm64
+              ;;
+            *)
+              echo "Unsupported architecture: $ARCH"
+              exit 1
+              ;;
+          esac
+          echo "platform=$PLATFORM" >> $GITHUB_OUTPUT
+          echo "Building for platform: $PLATFORM"
+      - name: Build and push dashboard Docker image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: dist
+          file: ci/Dockerfile.distroless
+          platforms: ${{ steps.platform.outputs.platform }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ${{ steps.ecr.outputs.registry }}/tyk-analytics:tyk-${{ github.event.pull_request.number }}
+          labels: |
+            org.opencontainers.image.title=Tyk Dashboard (Custom Build for PR)
+            org.opencontainers.image.description=Built from ${{ needs.resolve-dashboard-image.outputs.dashboard_branch }} with gateway branch ${{ github.head_ref }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=https://github.com/TykTechnologies/tyk-analytics
+            tyk.gateway.branch=${{ github.head_ref }}
+            tyk.gateway.pr=${{ github.event.pull_request.number }}
+            tyk.dashboard.branch=${{ needs.resolve-dashboard-image.outputs.dashboard_branch }}
+          build-args: |
+            BUILD_PACKAGE_NAME=tyk-dashboard
+      - name: Output image reference
+        id: output
+        shell: bash
+        run: |
+          IMAGE="${{ steps.ecr.outputs.registry }}/tyk-analytics:tyk-${{ github.event.pull_request.number }}"
+          echo "image=$IMAGE" >> $GITHUB_OUTPUT
+          echo "✅ Dashboard image built and pushed: $IMAGE"
   test-controller-api:
     needs:
       - goreleaser
@@ -336,9 +819,15 @@ jobs:
     needs:
       - test-controller-api
       - goreleaser
+      - resolve-dashboard-image
+      - build-dashboard-image
+    # build-dashboard-image may be skipped, so use !cancelled() to run regardless
     if: |
       !cancelled() &&
-      needs.goreleaser.result == 'success'
+      needs.test-controller-api.result == 'success' &&
+      needs.goreleaser.result == 'success' &&
+      needs.resolve-dashboard-image.result == 'success' &&
+      (needs.build-dashboard-image.result == 'success' || needs.build-dashboard-image.result == 'skipped')
     runs-on: ${{ vars.DEFAULT_RUNNER }}
     env:
       XUNIT_REPORT_PATH: ${{ github.workspace}}/test-results.xml
@@ -392,6 +881,7 @@ jobs:
         with:
           base_ref: ${{ env.BASE_REF }}
           tags: ${{ needs.goreleaser.outputs.ee_tags || needs.goreleaser.outputs.std_tags || format('{0}/tyk-ee:master', steps.ecr.outputs.registry) }}
+          dashboard_image: ${{ needs.resolve-dashboard-image.outputs.dashboard_image }}
           github_token: ${{ steps.app-token.outputs.token }}
           TYK_DB_LICENSEKEY: ${{ secrets.DASH_LICENSE }}
           TYK_MDCB_LICENSE: ${{ secrets.MDCB_LICENSE }}

--- a/ci/goreleaser/goreleaser.yml
+++ b/ci/goreleaser/goreleaser.yml
@@ -6,6 +6,57 @@
 # - amd64
 version: 2
 builds:
+  - id: ee-amd64
+    flags:
+      - -tags=goplugin,ee
+      - -trimpath
+    env:
+      - NOP=nop # ignore this, it is jsut to avoid a complex conditional in the templates
+      - CC=gcc
+    ldflags:
+      - -X github.com/TykTechnologies/tyk/internal/build.Version={{.Version}}
+      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
+    goos:
+      - linux
+    goarch:
+      - amd64
+    binary: tyk
+  - id: ee-arm64
+    flags:
+      - -tags=goplugin,ee
+      - -trimpath
+    env:
+      - NOP=nop # ignore this, it is jsut to avoid a complex conditional in the templates
+      - CC=aarch64-linux-gnu-gcc
+    ldflags:
+      - -X github.com/TykTechnologies/tyk/internal/build.Version={{.Version}}
+      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
+    goos:
+      - linux
+    goarch:
+      - arm64
+    binary: tyk
+  - id: ee-s390x
+    flags:
+      - -tags=goplugin,ee
+      - -trimpath
+    env:
+      - NOP=nop # ignore this, it is jsut to avoid a complex conditional in the templates
+      - CC=s390x-linux-gnu-gcc
+    ldflags:
+      - -X github.com/TykTechnologies/tyk/internal/build.Version={{.Version}}
+      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
+      - -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
+    goos:
+      - linux
+    goarch:
+      - s390x
+    binary: tyk
   - id: fips-amd64
     flags:
       - -tags=goplugin,ee,fips
@@ -112,6 +163,65 @@ builds:
       - s390x
     binary: tyk
 nfpms:
+  - id: ee
+    vendor: "Tyk Technologies Ltd"
+    homepage: "https://tyk.io"
+    maintainer: "Tyk <info@tyk.io>"
+    description: Tyk API Gateway Enterprise Edition written in Go, supporting REST, GraphQL, TCP and gRPC protocols
+    package_name: tyk-gateway-ee
+    file_name_template: "{{ .ConventionalFileName }}"
+    ids:
+      - ee-amd64
+      - ee-arm64
+      - ee-s390x
+    formats:
+      - deb
+      - rpm
+    contents:
+      - src: "README.md"
+        dst: "/opt/share/docs/tyk-gateway/README.md"
+      - src: "ci/install/*"
+        dst: "/opt/tyk-gateway/install"
+      - src: ci/install/inits/systemd/system/tyk-gateway.service
+        dst: /lib/systemd/system/tyk-gateway.service
+      - src: ci/install/inits/sysv/init.d/tyk-gateway
+        dst: /etc/init.d/tyk-gateway
+      - src: /opt/tyk-gateway
+        dst: /opt/tyk
+        type: "symlink"
+      - src: "LICENSE.md"
+        dst: "/opt/share/docs/tyk-gateway/LICENSE.md"
+      - src: "apps/app_sample.*"
+        dst: "/opt/tyk-gateway/apps"
+      - src: "templates/*.json"
+        dst: "/opt/tyk-gateway/templates"
+      - src: "templates/playground/*"
+        dst: "/opt/tyk-gateway/templates/playground"
+      - src: "middleware/*.js"
+        dst: "/opt/tyk-gateway/middleware"
+      - src: "event_handlers/sample/*.js"
+        dst: "/opt/tyk-gateway/event_handlers/sample"
+      - src: "policies/*.json"
+        dst: "/opt/tyk-gateway/policies"
+      - src: "coprocess/*"
+        dst: "/opt/tyk-gateway/coprocess"
+      - src: tyk.conf.example
+        dst: /opt/tyk-gateway/tyk.conf
+        type: "config|noreplace"
+    scripts:
+      preinstall: "ci/install/before_install.sh"
+      postinstall: "ci/install/post_install.sh"
+      postremove: "ci/install/post_remove.sh"
+    bindir: "/opt/tyk-gateway"
+    rpm:
+      scripts:
+        posttrans: ci/install/post_trans.sh
+      signature:
+        key_file: tyk.io.signing.key
+    deb:
+      signature:
+        key_file: tyk.io.signing.key
+        type: origin
   - id: fips
     vendor: "Tyk Technologies Ltd"
     homepage: "https://tyk.io"
@@ -231,6 +341,12 @@ nfpms:
         key_file: tyk.io.signing.key
         type: origin
 publishers:
+  - name: ee
+    ids:
+      - ee
+    env:
+      - PACKAGECLOUD_TOKEN={{ .Env.PACKAGECLOUD_TOKEN }}
+    cmd: packagecloud publish --debvers "{{ .Env.DEBVERS }}" --rpmvers "{{ .Env.RPMVERS }}" tyk/tyk-ee-unstable {{ .ArtifactPath }}
   - name: fips
     ids:
       - fips


### PR DESCRIPTION
## Summary

- Restores the `push ee image to CI` and `push ee image to prod` steps in `.github/workflows/release.yml` and the EE goreleaser build entries in `ci/goreleaser/goreleaser.yml`, which were inadvertently dropped by PR #8237.
- Root cause: gromit config (PR #473, fixed in gromit PR #474) listed only `release-test, distroless, fips` for tyk's `release-5.13.0`, missing `ee` and `resolve-dashboard`. Since the `ee` build has `feature: ee`, this removed all EE Docker build/push steps.
- After the fix, the regenerated `release.yml` contains 4 push image steps: ee CI, ee prod, fips CI, fips prod.

See https://github.com/TykTechnologies/tyk/commit/1d51bf98dc9862b26f5a48320bd8586ffb93d7e4 for the broken state (only `push fips image to CI`, no `push ee image to CI`).

## Test plan

- [x] `grep -c "push ee image\|push fips image" .github/workflows/release.yml` returns 4
- [ ] CI for release-5.13.0 runs and pushes both EE and FIPS Docker images
- [ ] gromit PR #474 merged so future regenerations stay correct