### PR TITLE
fix(goplugin): capture plugin response for analytics RawResponse

### DIFF
--- a/ctx/ctx.go
+++ b/ctx/ctx.go
@@ -75,6 +75,12 @@ const (
 	MCPPrimitiveName
 	// JSONRPCErrorCode stores the JSON-RPC error code for metrics dimensions.
 	JSONRPCErrorCode
+	// CapturedResponse holds a *http.Response that was constructed by an
+	// upstream middleware (currently goplugin) from a wrapped ResponseWriter.
+	// ErrorHandler.HandleError reads this when writeResponse=false to populate
+	// the analytics RawResponse, instead of serializing a zero-value
+	// http.Response (which renders as "HTTP/0.0 000 status code 0").
+	CapturedResponse
 )
 
 func ctxSetSession(r *http.Request, s *user.SessionState, scheduleUpdate bool, hashKey bool) {

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -3298,6 +3298,22 @@ func ctxGetCacheOptions(r *http.Request) *cacheOptions {
 	return key
 }
 
+// ctxSetCapturedResponse stashes a *http.Response built from a wrapped
+// ResponseWriter so a downstream consumer (currently ErrorHandler.HandleError)
+// can use it for analytics RawResponse when writeResponse=false.
+func ctxSetCapturedResponse(r *http.Request, resp *http.Response) {
+	setCtxValue(r, ctx.CapturedResponse, resp)
+}
+
+// ctxGetCapturedResponse returns a *http.Response previously stashed via
+// ctxSetCapturedResponse, or nil if none.
+func ctxGetCapturedResponse(r *http.Request) *http.Response {
+	if v, ok := r.Context().Value(ctx.CapturedResponse).(*http.Response); ok {
+		return v
+	}
+	return nil
+}
+
 func ctxGetSession(r *http.Request) *user.SessionState {
 	return ctx.GetSession(r)
 }

--- a/gateway/handler_error.go
+++ b/gateway/handler_error.go
@@ -108,6 +108,12 @@ func (e *ErrorHandler) HandleError(w http.ResponseWriter, r *http.Request, errMs
 		} else {
 			response = e.writeTemplateErrorResponse(w, r, errMsg, errCode)
 		}
+	} else if captured := ctxGetCapturedResponse(r); captured != nil {
+		// An upstream middleware (currently goplugin) already wrote the wire
+		// response and stashed its captured *http.Response. Use it so the
+		// analytics RawResponse reflects the real bytes the client received
+		// instead of the zero-value sentinel "HTTP/0.0 000 status code 0".
+		response = captured
 	}
 
 	// Calculate latency for error responses (needed for both API metrics and analytics).

--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -305,6 +305,13 @@ func (m *GoPluginMiddleware) handlePluginResponse(
 
 	// check if response code was an error one
 	if rw.statusCodeSent >= http.StatusBadRequest {
+		// Stash the wrapped writer's *http.Response so ErrorHandler.HandleError
+		// can use it for the analytics RawResponse. Without this, HandleError
+		// runs with writeResponse=false (so it won't clobber the plugin's wire
+		// response, see #7985) and serializes a zero-value *http.Response
+		// into RawResponse: "HTTP/0.0 000 status code 0\r\nContent-Length: 0".
+		// See gateway/handler_error.go for the consumer side.
+		ctxSetCapturedResponse(r, rw.getHttpResponse(r))
 		return m.handleErrorResponse(r, rw, logger)
 	}
 

--- a/goplugin/mw_go_plugin_test.go
+++ b/goplugin/mw_go_plugin_test.go
@@ -5,10 +5,15 @@ package goplugin_test
 
 import (
 	"context"
+	"encoding/base64"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/TykTechnologies/tyk/user"
+
+	"github.com/TykTechnologies/tyk-pump/analytics"
+	"github.com/TykTechnologies/tyk-pump/serializer"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/stretchr/testify/assert"
@@ -19,6 +24,8 @@ import (
 	"github.com/TykTechnologies/tyk/gateway"
 	"github.com/TykTechnologies/tyk/test"
 )
+
+const analyticsKeyName = "tyk-system-analytics"
 
 func goPluginFilename() string {
 	if test.IsRaceEnabled() {
@@ -884,4 +891,73 @@ func TestGoPlugin_DontWriteBodyInCaseIfPluginRespondsWith4xxOrHigher(t *testing.
 			}...)
 		})
 	})
+}
+
+// TestGoPlugin_AnalyticsRawResponseCapturesPluginResponse pins the fix for
+// https://github.com/TykTechnologies/tyk/issues/8242.
+//
+// Before the fix: when a goplugin "pre" middleware writes a >= 400 status with
+// a body, the request is correctly served on the wire but the resulting
+// analytics record's RawResponse is the base64 of a zero-value *http.Response,
+// which decodes to the sentinel string "HTTP/0.0 000 status code 0\r\n
+// Content-Length: 0\r\n\r\n". The 2xx admit path captures the real response
+// via customResponseWriter.getHttpResponse; the 4xx reject path used to drop
+// it. ErrorHandler.HandleError now reads the captured response from the
+// request context when writeResponse=false, so RawResponse reflects the real
+// status/headers/body the plugin emitted.
+func TestGoPlugin_AnalyticsRawResponseCapturesPluginResponse(t *testing.T) {
+	ts := gateway.StartTest(nil)
+	t.Cleanup(ts.Close)
+
+	ts.Gw.BuildAndLoadAPI(func(spec *gateway.APISpec) {
+		spec.Proxy.ListenPath = "/test-api/"
+		spec.UseKeylessAccess = true
+		spec.UseStandardAuth = false
+		spec.EnableDetailedRecording = true
+		spec.CustomMiddleware = apidef.MiddlewareSection{
+			Driver: apidef.GoPluginDriver,
+			Pre: []apidef.MiddlewareDefinition{
+				{
+					Name: "RejectWithBody",
+					Path: goPluginFilename(),
+				},
+			},
+		}
+	})
+
+	// The test gateway defaults to the msgpack serializer (empty SerializerType),
+	// whose key suffix is "". Use the public NewAnalyticsSerializer to decode
+	// records since the gateway's instance is package-private.
+	analyticsSerializer := serializer.NewAnalyticsSerializer("")
+	redisAnalyticsKeyName := analyticsKeyName + analyticsSerializer.GetSuffix()
+
+	// Drain any records from earlier subtests.
+	_ = ts.Gw.Analytics.Store.GetAndDeleteSet(redisAnalyticsKeyName)
+
+	_, err := ts.Run(t, test.TestCase{
+		Path: "/test-api/get",
+		Code: http.StatusForbidden,
+	})
+	require.NoError(t, err)
+
+	ts.Gw.Analytics.Flush()
+	results := ts.Gw.Analytics.Store.GetAndDeleteSet(redisAnalyticsKeyName)
+	require.Len(t, results, 1, "expected exactly one analytics record")
+
+	var record analytics.AnalyticsRecord
+	require.NoError(t, analyticsSerializer.Decode([]byte(results[0].(string)), &record))
+
+	assert.Equal(t, http.StatusForbidden, record.ResponseCode,
+		"analytics ResponseCode should reflect the plugin's status")
+
+	raw, err := base64.StdEncoding.DecodeString(record.RawResponse)
+	require.NoError(t, err)
+
+	rawStr := string(raw)
+	assert.False(t, strings.HasPrefix(rawStr, "HTTP/0.0 000"),
+		"RawResponse must not be the zero-value sentinel, got: %q", rawStr)
+	assert.True(t, strings.HasPrefix(rawStr, "HTTP/1.1 403 "),
+		"RawResponse should start with the plugin's HTTP/1.1 403 status line, got: %q", rawStr)
+	assert.Contains(t, rawStr, "hello",
+		"RawResponse should contain the body the plugin wrote, got: %q", rawStr)
 }


### PR DESCRIPTION
## Description

When a Go plugin running as a `pre`/`auth_check`/`post_key_auth`/`post` middleware writes an error response (status `>= 400`) with a body, the wire response delivered to the client is correct, but the resulting analytics record's `RawResponse` is the base64 encoding of a zero-value `*http.Response`, which decodes to the sentinel string:

```
HTTP/0.0 000 status code 0\r\nContent-Length: 0\r\n\r\n
```

This PR stashes the wrapped writer's `*http.Response` in the request context inside `handlePluginResponse`, and has `ErrorHandler.HandleError` use it when `writeResponse=false` (instead of serializing the zero-value placeholder into `RawResponse`).

## Related Issue

Fixes #8242

## Motivation and Context

The 2xx admit branch in `handlePluginResponse` records analytics via `SuccessHandler.RecordHit` using `customResponseWriter.getHttpResponse(r)` — the wrapped writer's real captured response (status, headers, body). The `>= 400` reject branch returns to the base middleware which routes through `HandleError` with `writeResponse=false` (added in #7985 to prevent `HandleError` from clobbering the plugin's wire body). With `writeResponse=false`, `HandleError` leaves `response` as the zero-value `&http.Response{}` and serializes that into `record.RawResponse`.

As a result, any downstream that parses `AnalyticsRecord.RawResponse` (response-header dashboards, body inspection, response-size analytics) gets malformed data for every plugin-rejected request, even though the wire response itself is healthy.

The fix mirrors the 2xx path: both branches now use `rw.getHttpResponse(r)` as the source of truth for the analytics record's response shape.

### Why this approach

- **Strictly additive.** Any middleware path that doesn't stash a captured response sees the existing zero-value behavior — no regression for non-goplugin error paths.
- **No new sentinel error types, no signature changes** on `HandleError`, no semantic overload of `DoNotTrack` or `ErrResponseErrorSent`.
- **Reuses existing wrapped-writer machinery** — `customResponseWriter.getHttpResponse(r)` is the same constructor the 2xx admit path uses.
- The `responseCode` fallback at `handler_error.go` (`if response.StatusCode != 0`) already handles the captured response's real status code.

## How This Has Been Tested

Added `TestGoPlugin_AnalyticsRawResponseCapturesPluginResponse` in `goplugin/mw_go_plugin_test.go`, mirroring the `RejectWithBody` test added in #7985. The test:

1. Builds an API with a goplugin `pre` middleware (`RejectWithBody`, which writes 403 + body `"hello"`).
2. Enables detailed recording so `RawResponse` is captured.
3. Flushes analytics and decodes the record's `RawResponse`.
4. Asserts:
   - It does **not** start with `HTTP/0.0 000` (the zero-value sentinel — inversion-witness).
   - It starts with `HTTP/1.1 403 ` (the plugin's real status line).
   - It contains the body bytes the plugin wrote (`hello`).

Verified red/green locally:

- **Without the fix**, the test fails with the exact sentinel:
  ```
  RawResponse must not be the zero-value sentinel,
  got: "HTTP/0.0 000 status code 0\r\nContent-Length: 0\r\n\r\n"
  ```
- **With the fix**, the test passes.

Also re-ran the sibling tests from #7985 (`TestGoPlugin_DontWriteBodyInCaseIfPluginRespondsWith4xxOrHigher` — all four subtests across api-level and endpoint-level plugins) and the existing analytics tests (`TestAnalytics_Write` with `CI=true` to skip the marked-flaky latency subtest) — all green.

Reproduction command:

```bash
make build-plugins
TYK_LOGLEVEL=error go test -tags goplugin \
  -run TestGoPlugin_AnalyticsRawResponseCapturesPluginResponse \
  -count=1 ./goplugin/
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

- [x] I ensured that the documentation is up to date (no doc changes required — bug fix preserves existing analytics contract)
- [x] I explained why this PR updates go.mod in detail with reasoning why it's required (n/a — no go.mod changes)
- [ ] I would like a code coverage CI quality gate exception and have explained why