### PR TITLE
[TT-16823] Filter MCP discovery with OAS middleware rules

### DIFF
--- a/gateway/mcp_discovery_rules.go
+++ b/gateway/mcp_discovery_rules.go
@@ -1,0 +1,155 @@
+package gateway
+
+import (
+	stdregexp "regexp"
+	"strings"
+
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/internal/jsonrpc"
+	"github.com/TykTechnologies/tyk/internal/mcp"
+	"github.com/TykTechnologies/tyk/user"
+)
+
+const oasJSONRPCMethodOperationPrefix = "json-rpc-method:"
+
+func effectiveMCPListRuleSets(spec *APISpec, ses *user.SessionState, cfg *mcp.ListFilterConfig) []user.AccessControlRules {
+	ruleSets := make([]user.AccessControlRules, 0, 2)
+
+	if rules := oasPrimitiveRules(spec, cfg); !rules.IsEmpty() {
+		ruleSets = append(ruleSets, rules)
+	}
+
+	if rules := sessionMCPRules(spec, ses, cfg); !rules.IsEmpty() {
+		ruleSets = append(ruleSets, rules)
+	}
+
+	return ruleSets
+}
+
+func effectiveJSONRPCMethodRuleSets(spec *APISpec, ses *user.SessionState) []user.AccessControlRules {
+	ruleSets := make([]user.AccessControlRules, 0, 2)
+
+	if rules := oasJSONRPCMethodRules(spec); !rules.IsEmpty() {
+		ruleSets = append(ruleSets, rules)
+	}
+
+	if rules := sessionJSONRPCMethodRules(spec, ses); !rules.IsEmpty() {
+		ruleSets = append(ruleSets, rules)
+	}
+
+	return ruleSets
+}
+
+func sessionMCPRules(spec *APISpec, ses *user.SessionState, cfg *mcp.ListFilterConfig) user.AccessControlRules {
+	if spec == nil || ses == nil {
+		return user.AccessControlRules{}
+	}
+
+	accessDef, ok := ses.AccessRights[spec.APIID]
+	if !ok || accessDef.MCPAccessRights.IsEmpty() {
+		return user.AccessControlRules{}
+	}
+
+	return cfg.RulesFrom(accessDef.MCPAccessRights)
+}
+
+func sessionJSONRPCMethodRules(spec *APISpec, ses *user.SessionState) user.AccessControlRules {
+	if spec == nil || ses == nil {
+		return user.AccessControlRules{}
+	}
+
+	accessDef, ok := ses.AccessRights[spec.APIID]
+	if !ok || accessDef.JSONRPCMethodsAccessRights.IsEmpty() {
+		return user.AccessControlRules{}
+	}
+
+	return accessDef.JSONRPCMethodsAccessRights
+}
+
+func oasPrimitiveRules(spec *APISpec, cfg *mcp.ListFilterConfig) user.AccessControlRules {
+	middleware := oasMiddleware(spec)
+	if middleware == nil {
+		return user.AccessControlRules{}
+	}
+
+	switch cfg.ArrayKey {
+	case "tools":
+		return rulesFromOASMCPPrimitives(middleware.McpTools, false)
+	case "prompts":
+		return rulesFromOASMCPPrimitives(middleware.McpPrompts, false)
+	case "resources", "resourceTemplates":
+		return rulesFromOASMCPPrimitives(middleware.McpResources, true)
+	default:
+		return user.AccessControlRules{}
+	}
+}
+
+func rulesFromOASMCPPrimitives(primitives oas.MCPPrimitives, resourcePatterns bool) user.AccessControlRules {
+	var rules user.AccessControlRules
+	for name, primitive := range primitives {
+		if primitive == nil {
+			continue
+		}
+
+		pattern := oasPrimitivePattern(name, resourcePatterns)
+		if primitive.Block != nil && primitive.Block.Enabled {
+			rules.Blocked = append(rules.Blocked, pattern)
+		}
+		if primitive.Allow != nil && primitive.Allow.Enabled {
+			rules.Allowed = append(rules.Allowed, pattern)
+		}
+	}
+	return rules
+}
+
+func oasPrimitivePattern(name string, resourcePatterns bool) string {
+	if resourcePatterns && strings.HasSuffix(name, "/*") {
+		return stdregexp.QuoteMeta(strings.TrimSuffix(name, "*")) + ".*"
+	}
+	return stdregexp.QuoteMeta(name)
+}
+
+func oasJSONRPCMethodRules(spec *APISpec) user.AccessControlRules {
+	middleware := oasMiddleware(spec)
+	if middleware == nil {
+		return user.AccessControlRules{}
+	}
+
+	var rules user.AccessControlRules
+	for operationID, operation := range middleware.Operations {
+		if operation == nil {
+			continue
+		}
+
+		method, ok := jsonRPCMethodFromOperationID(operationID)
+		if !ok {
+			continue
+		}
+
+		pattern := stdregexp.QuoteMeta(method)
+		if operation.Block != nil && operation.Block.Enabled {
+			rules.Blocked = append(rules.Blocked, pattern)
+		}
+		if operation.Allow != nil && operation.Allow.Enabled {
+			rules.Allowed = append(rules.Allowed, pattern)
+		}
+	}
+	return rules
+}
+
+func jsonRPCMethodFromOperationID(operationID string) (string, bool) {
+	if strings.HasPrefix(operationID, oasJSONRPCMethodOperationPrefix) {
+		return strings.TrimPrefix(operationID, oasJSONRPCMethodOperationPrefix), true
+	}
+	if strings.HasPrefix(operationID, jsonrpc.MethodVEMPrefix) {
+		return strings.TrimPrefix(operationID, jsonrpc.MethodVEMPrefix), true
+	}
+	return "", false
+}
+
+func oasMiddleware(spec *APISpec) *oas.Middleware {
+	if spec == nil {
+		return nil
+	}
+	return spec.OAS.GetTykMiddleware()
+}

--- a/gateway/mcp_discovery_rules.go
+++ b/gateway/mcp_discovery_rules.go
@@ -74,24 +74,24 @@ func oasPrimitiveRules(spec *APISpec, cfg *mcp.ListFilterConfig) user.AccessCont
 
 	switch cfg.ArrayKey {
 	case "tools":
-		return rulesFromOASMCPPrimitives(middleware.McpTools, false)
+		return rulesFromOASMCPPrimitives(middleware.McpTools)
 	case "prompts":
-		return rulesFromOASMCPPrimitives(middleware.McpPrompts, false)
+		return rulesFromOASMCPPrimitives(middleware.McpPrompts)
 	case "resources", "resourceTemplates":
-		return rulesFromOASMCPPrimitives(middleware.McpResources, true)
+		return rulesFromOASMCPPrimitives(middleware.McpResources)
 	default:
 		return user.AccessControlRules{}
 	}
 }
 
-func rulesFromOASMCPPrimitives(primitives oas.MCPPrimitives, resourcePatterns bool) user.AccessControlRules {
+func rulesFromOASMCPPrimitives(primitives oas.MCPPrimitives) user.AccessControlRules {
 	var rules user.AccessControlRules
 	for name, primitive := range primitives {
 		if primitive == nil {
 			continue
 		}
 
-		pattern := oasPrimitivePattern(name, resourcePatterns)
+		pattern := oasPrimitivePattern(name)
 		if primitive.Block != nil && primitive.Block.Enabled {
 			rules.Blocked = append(rules.Blocked, pattern)
 		}
@@ -102,11 +102,20 @@ func rulesFromOASMCPPrimitives(primitives oas.MCPPrimitives, resourcePatterns bo
 	return rules
 }
 
-func oasPrimitivePattern(name string, resourcePatterns bool) string {
-	if resourcePatterns && strings.HasSuffix(name, "/*") {
-		return stdregexp.QuoteMeta(strings.TrimSuffix(name, "*")) + ".*"
+func oasPrimitivePattern(name string) string {
+	if !strings.Contains(name, "*") {
+		return stdregexp.QuoteMeta(name)
 	}
-	return stdregexp.QuoteMeta(name)
+
+	parts := strings.Split(name, "*")
+	var pattern strings.Builder
+	for i, part := range parts {
+		if i > 0 {
+			pattern.WriteString(".*")
+		}
+		pattern.WriteString(stdregexp.QuoteMeta(part))
+	}
+	return pattern.String()
 }
 
 func oasJSONRPCMethodRules(spec *APISpec) user.AccessControlRules {

--- a/gateway/res_handler_mcp_list_filter.go
+++ b/gateway/res_handler_mcp_list_filter.go
@@ -48,7 +48,25 @@ func (h *MCPListFilterResponseHandler) HandleResponse(_ http.ResponseWriter, res
 	}
 
 	listCfg := h.listConfig(state.Method)
-	if listCfg == nil {
+	var filter func([]byte) ([]byte, bool)
+	switch {
+	case listCfg != nil:
+		ruleSets := effectiveMCPListRuleSets(h.Spec, ses, listCfg)
+		if len(ruleSets) == 0 {
+			return nil
+		}
+		filter = func(body []byte) ([]byte, bool) {
+			return mcp.FilterJSONRPCBodyWithRuleSets(body, listCfg, ruleSets)
+		}
+	case state.Method == mcp.MethodInitialize:
+		ruleSets := effectiveJSONRPCMethodRuleSets(h.Spec, ses)
+		if len(ruleSets) == 0 {
+			return nil
+		}
+		filter = func(body []byte) ([]byte, bool) {
+			return mcp.FilterInitializeCapabilitiesBody(body, ruleSets)
+		}
+	default:
 		return nil
 	}
 
@@ -59,17 +77,12 @@ func (h *MCPListFilterResponseHandler) HandleResponse(_ http.ResponseWriter, res
 		return nil
 	}
 
-	rules := h.rulesForAPI(ses, listCfg)
-	if rules.IsEmpty() {
-		return nil
-	}
-
 	body, err := readAndCloseBody(res)
 	if err != nil || len(body) == 0 {
 		return nil //nolint:nilerr // fail-open: pass through on read error
 	}
 
-	newBody, ok := mcp.FilterJSONRPCBody(body, listCfg, rules)
+	newBody, ok := filter(body)
 	if !ok {
 		res.Body = io.NopCloser(bytes.NewReader(body))
 		return nil
@@ -80,21 +93,6 @@ func (h *MCPListFilterResponseHandler) HandleResponse(_ http.ResponseWriter, res
 	res.Header.Set("Content-Length", strconv.Itoa(len(newBody)))
 
 	return nil
-}
-
-// rulesForAPI extracts the access control rules for the current API from the
-// session, returning empty rules if the session has no applicable restrictions.
-func (h *MCPListFilterResponseHandler) rulesForAPI(ses *user.SessionState, cfg *mcp.ListFilterConfig) user.AccessControlRules {
-	if ses == nil {
-		return user.AccessControlRules{}
-	}
-
-	accessDef, ok := ses.AccessRights[h.Spec.APIID]
-	if !ok || accessDef.MCPAccessRights.IsEmpty() {
-		return user.AccessControlRules{}
-	}
-
-	return cfg.RulesFrom(accessDef.MCPAccessRights)
 }
 
 // listConfig returns the filter configuration for a given JSON-RPC method,

--- a/gateway/res_handler_mcp_list_filter_test.go
+++ b/gateway/res_handler_mcp_list_filter_test.go
@@ -623,6 +623,20 @@ func TestMCPListFilterResponseHandler_HandleResponse_MiddlewarePrimitiveFilterin
 			},
 			want: []string{"get_weather"},
 		},
+		{
+			name: "allow wildcard star discovers all tools",
+			primitives: oas.MCPPrimitives{
+				"*": {Operation: oas.Operation{Allow: &oas.Allowance{Enabled: true}}},
+			},
+			want: []string{"get_weather", "get_forecast", "execute_query", "admin_reset"},
+		},
+		{
+			name: "allow wildcard suffix discovers matching tools",
+			primitives: oas.MCPPrimitives{
+				"get_*": {Operation: oas.Operation{Allow: &oas.Allowance{Enabled: true}}},
+			},
+			want: []string{"get_weather", "get_forecast"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/gateway/res_handler_mcp_list_filter_test.go
+++ b/gateway/res_handler_mcp_list_filter_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/apidef/oas"
 	"github.com/TykTechnologies/tyk/internal/httpctx"
 	"github.com/TykTechnologies/tyk/internal/mcp"
 	"github.com/TykTechnologies/tyk/user"
@@ -34,6 +35,14 @@ func buildMCPListFilterHandler(apiID string, isMCP bool) *MCPListFilterResponseH
 			},
 		},
 	}
+}
+
+func buildMCPListFilterHandlerWithMiddleware(apiID string, middleware *oas.Middleware) *MCPListFilterResponseHandler {
+	h := buildMCPListFilterHandler(apiID, true)
+	h.Spec.OAS.SetTykExtension(&oas.XTykAPIGateway{
+		Middleware: middleware,
+	})
+	return h
 }
 
 // makeToolsListResponse builds a JSON-RPC 2.0 response with a tools/list result.
@@ -575,6 +584,258 @@ func TestMCPListFilterResponseHandler_HandleResponse(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMCPListFilterResponseHandler_HandleResponse_MiddlewarePrimitiveFiltering(t *testing.T) {
+	tools := []map[string]any{
+		{"name": "get_weather"},
+		{"name": "get_forecast"},
+		{"name": "execute_query"},
+		{"name": "admin_reset"},
+	}
+
+	tests := []struct {
+		name       string
+		primitives oas.MCPPrimitives
+		want       []string
+	}{
+		{
+			name: "allow rules limit tools/list discovery",
+			primitives: oas.MCPPrimitives{
+				"get_weather":   {Operation: oas.Operation{Allow: &oas.Allowance{Enabled: true}}},
+				"get_forecast":  {Operation: oas.Operation{Allow: &oas.Allowance{Enabled: true}}},
+				"execute_query": {Operation: oas.Operation{Allow: &oas.Allowance{Enabled: true}}},
+			},
+			want: []string{"get_weather", "get_forecast", "execute_query"},
+		},
+		{
+			name: "block rules remove tools/list discovery entries",
+			primitives: oas.MCPPrimitives{
+				"admin_reset": {Operation: oas.Operation{Block: &oas.Allowance{Enabled: true}}},
+			},
+			want: []string{"get_weather", "get_forecast", "execute_query"},
+		},
+		{
+			name: "block takes precedence over allow for middleware rules",
+			primitives: oas.MCPPrimitives{
+				"get_weather": {Operation: oas.Operation{Allow: &oas.Allowance{Enabled: true}}},
+				"admin_reset": {Operation: oas.Operation{Allow: &oas.Allowance{Enabled: true}, Block: &oas.Allowance{Enabled: true}}},
+			},
+			want: []string{"get_weather"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := buildMCPListFilterHandlerWithMiddleware("api-1", &oas.Middleware{
+				McpTools: tt.primitives,
+			})
+			rw := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+			httpctx.SetJSONRPCRoutingState(req, &httpctx.JSONRPCRoutingState{
+				Method: mcp.MethodToolsList,
+				ID:     1,
+			})
+
+			res := makeHTTPResponse(makeToolsListResponse(tools, ""))
+			require.NoError(t, h.HandleResponse(rw, res, req, nil))
+
+			body := readResponseBody(t, res)
+			assert.Equal(t, tt.want, extractToolNames(t, body))
+		})
+	}
+}
+
+func TestMCPListFilterResponseHandler_HandleResponse_MiddlewareResourceAndPromptFiltering(t *testing.T) {
+	t.Run("resources/list applies middleware resource wildcard", func(t *testing.T) {
+		h := buildMCPListFilterHandlerWithMiddleware("api-1", &oas.Middleware{
+			McpResources: oas.MCPPrimitives{
+				"file:///public/*": {Operation: oas.Operation{Allow: &oas.Allowance{Enabled: true}}},
+			},
+		})
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		httpctx.SetJSONRPCRoutingState(req, &httpctx.JSONRPCRoutingState{
+			Method: mcp.MethodResourcesList,
+			ID:     1,
+		})
+
+		res := makeHTTPResponse(makeResourcesListResponse([]map[string]any{
+			{"uri": "file:///public/readme.md"},
+			{"uri": "file:///private/keys.txt"},
+		}))
+		require.NoError(t, h.HandleResponse(rw, res, req, nil))
+
+		body := readResponseBody(t, res)
+		assert.Equal(t, []string{"file:///public/readme.md"}, extractResourceURIs(t, body))
+	})
+
+	t.Run("resources/templates/list applies exact middleware resource names", func(t *testing.T) {
+		h := buildMCPListFilterHandlerWithMiddleware("api-1", &oas.Middleware{
+			McpResources: oas.MCPPrimitives{
+				"file://{path}": {Operation: oas.Operation{Allow: &oas.Allowance{Enabled: true}}},
+			},
+		})
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		httpctx.SetJSONRPCRoutingState(req, &httpctx.JSONRPCRoutingState{
+			Method: mcp.MethodResourcesTemplatesList,
+			ID:     1,
+		})
+
+		res := makeHTTPResponse(makeResourceTemplatesListResponse([]map[string]any{
+			{"uriTemplate": "file://{path}"},
+			{"uriTemplate": "db://{schema}/{table}"},
+		}))
+		require.NoError(t, h.HandleResponse(rw, res, req, nil))
+
+		body := readResponseBody(t, res)
+		assert.Equal(t, []string{"file://{path}"}, extractResourceTemplateURIs(t, body))
+	})
+
+	t.Run("prompts/list applies middleware prompt rules", func(t *testing.T) {
+		h := buildMCPListFilterHandlerWithMiddleware("api-1", &oas.Middleware{
+			McpPrompts: oas.MCPPrimitives{
+				"summarise": {Operation: oas.Operation{Allow: &oas.Allowance{Enabled: true}}},
+			},
+		})
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		httpctx.SetJSONRPCRoutingState(req, &httpctx.JSONRPCRoutingState{
+			Method: mcp.MethodPromptsList,
+			ID:     1,
+		})
+
+		res := makeHTTPResponse(makePromptsListResponse([]map[string]any{
+			{"name": "summarise"},
+			{"name": "translate"},
+		}))
+		require.NoError(t, h.HandleResponse(rw, res, req, nil))
+
+		body := readResponseBody(t, res)
+		assert.Equal(t, []string{"summarise"}, extractPromptNames(t, body))
+	})
+}
+
+func TestMCPListFilterResponseHandler_HandleResponse_MiddlewareAndPolicyCompose(t *testing.T) {
+	h := buildMCPListFilterHandlerWithMiddleware("api-1", &oas.Middleware{
+		McpTools: oas.MCPPrimitives{
+			"get_weather":   {Operation: oas.Operation{Allow: &oas.Allowance{Enabled: true}}},
+			"get_forecast":  {Operation: oas.Operation{Allow: &oas.Allowance{Enabled: true}}},
+			"execute_query": {Operation: oas.Operation{Allow: &oas.Allowance{Enabled: true}}},
+		},
+	})
+	rw := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	httpctx.SetJSONRPCRoutingState(req, &httpctx.JSONRPCRoutingState{
+		Method: mcp.MethodToolsList,
+		ID:     1,
+	})
+
+	session := &user.SessionState{
+		AccessRights: map[string]user.AccessDefinition{
+			"api-1": {
+				APIID: "api-1",
+				MCPAccessRights: user.MCPAccessRights{
+					Tools: user.AccessControlRules{
+						Allowed: []string{"get_weather", "get_forecast"},
+					},
+				},
+			},
+		},
+	}
+
+	res := makeHTTPResponse(makeToolsListResponse([]map[string]any{
+		{"name": "get_weather"},
+		{"name": "get_forecast"},
+		{"name": "execute_query"},
+		{"name": "admin_reset"},
+	}, ""))
+	require.NoError(t, h.HandleResponse(rw, res, req, session))
+
+	body := readResponseBody(t, res)
+	assert.Equal(t, []string{"get_weather", "get_forecast"}, extractToolNames(t, body))
+}
+
+func TestMCPListFilterResponseHandler_HandleResponse_InitializeCapabilitiesFiltering(t *testing.T) {
+	makeInitializeResponse := func() []byte {
+		return makeJSONRPCResponse(1, map[string]any{
+			"protocolVersion": "2025-03-26",
+			"capabilities": map[string]any{
+				"tools":     map[string]any{"listChanged": true},
+				"resources": map[string]any{"subscribe": true},
+				"prompts":   map[string]any{},
+				"sampling":  map[string]any{},
+			},
+			"serverInfo": map[string]any{
+				"name":    "test",
+				"version": "1.0.0",
+			},
+		})
+	}
+
+	extractCapabilityKeys := func(t *testing.T, body []byte) map[string]json.RawMessage {
+		t.Helper()
+		var envelope mcp.JSONRPCResponse
+		require.NoError(t, json.Unmarshal(body, &envelope))
+
+		var result map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(envelope.Result, &result))
+
+		var capabilities map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(result["capabilities"], &capabilities))
+		return capabilities
+	}
+
+	t.Run("session method block removes sampling capability", func(t *testing.T) {
+		h := buildMCPListFilterHandler("api-1", true)
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		httpctx.SetJSONRPCRoutingState(req, &httpctx.JSONRPCRoutingState{
+			Method: "initialize",
+			ID:     1,
+		})
+		session := &user.SessionState{
+			AccessRights: map[string]user.AccessDefinition{
+				"api-1": {
+					APIID: "api-1",
+					JSONRPCMethodsAccessRights: user.AccessControlRules{
+						Blocked: []string{mcp.MethodSamplingCreate},
+					},
+				},
+			},
+		}
+
+		res := makeHTTPResponse(makeInitializeResponse())
+		require.NoError(t, h.HandleResponse(rw, res, req, session))
+
+		capabilities := extractCapabilityKeys(t, readResponseBody(t, res))
+		assert.NotContains(t, capabilities, "sampling")
+		assert.Contains(t, capabilities, "tools")
+	})
+
+	t.Run("OAS method block removes tools capability", func(t *testing.T) {
+		h := buildMCPListFilterHandlerWithMiddleware("api-1", &oas.Middleware{
+			Operations: oas.Operations{
+				"json-rpc-method:" + mcp.MethodToolsList: {
+					Block: &oas.Allowance{Enabled: true},
+				},
+			},
+		})
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		httpctx.SetJSONRPCRoutingState(req, &httpctx.JSONRPCRoutingState{
+			Method: "initialize",
+			ID:     1,
+		})
+
+		res := makeHTTPResponse(makeInitializeResponse())
+		require.NoError(t, h.HandleResponse(rw, res, req, nil))
+
+		capabilities := extractCapabilityKeys(t, readResponseBody(t, res))
+		assert.NotContains(t, capabilities, "tools")
+		assert.Contains(t, capabilities, "sampling")
+	})
 }
 
 func TestMCPListFilterResponseHandler_HandleResponse_PromptsListFiltering(t *testing.T) {

--- a/gateway/reverse_proxy.go
+++ b/gateway/reverse_proxy.go
@@ -1469,7 +1469,7 @@ func (p *ReverseProxy) WrappedServeHTTP(rw http.ResponseWriter, req *http.Reques
 		if p.logger.Logger.IsLevelEnabled(logrus.DebugLevel) {
 			hooks = append(hooks, NewLoggingSSEHook(p.logger))
 		}
-		if filterHook := NewMCPListFilterSSEHook(p.TykAPISpec.APIID, ses); filterHook != nil {
+		if filterHook := NewMCPListFilterSSEHook(p.TykAPISpec, ses); filterHook != nil {
 			hooks = append(hooks, filterHook)
 		}
 		res.Body = NewSSETap(res.Body, hooks...)

--- a/gateway/sse_hook_mcp_list_filter.go
+++ b/gateway/sse_hook_mcp_list_filter.go
@@ -17,22 +17,22 @@ import (
 // This hook intercepts those events and applies the same access-control
 // filtering as MCPListFilterResponseHandler does for regular HTTP responses.
 type MCPListFilterSSEHook struct {
-	apiID string
-	ses   *user.SessionState
+	spec *APISpec
+	ses  *user.SessionState
 }
 
 // NewMCPListFilterSSEHook creates a hook that filters list response events
-// based on the session's MCPAccessRights for the given API.
-// Returns nil if no filtering is needed (nil session or no ACL rules).
-func NewMCPListFilterSSEHook(apiID string, ses *user.SessionState) *MCPListFilterSSEHook {
-	if ses == nil {
+// based on OAS middleware rules and session access rights for the given API.
+// Returns nil if no filtering is needed.
+func NewMCPListFilterSSEHook(spec *APISpec, ses *user.SessionState) *MCPListFilterSSEHook {
+	if spec == nil {
 		return nil
 	}
-	accessDef, ok := ses.AccessRights[apiID]
-	if !ok || accessDef.MCPAccessRights.IsEmpty() {
+
+	if !hasMCPDiscoveryFiltering(spec, ses) {
 		return nil
 	}
-	return &MCPListFilterSSEHook{apiID: apiID, ses: ses}
+	return &MCPListFilterSSEHook{spec: spec, ses: ses}
 }
 
 // FilterEvent inspects an SSE event. If it contains a JSON-RPC list response,
@@ -93,15 +93,38 @@ func (h *MCPListFilterSSEHook) filterSSEData(data []byte) ([]byte, bool) {
 	}
 
 	cfg := mcp.InferListConfigFromResult(result)
-	if cfg == nil {
-		return nil, false
+	if cfg != nil {
+		ruleSets := effectiveMCPListRuleSets(h.spec, h.ses, cfg)
+		if len(ruleSets) == 0 {
+			return nil, false
+		}
+		return mcp.FilterParsedJSONRPCWithRuleSets(&envelope, result, cfg, ruleSets)
 	}
 
-	accessDef := h.ses.AccessRights[h.apiID]
-	rules := cfg.RulesFrom(accessDef.MCPAccessRights)
-	if rules.IsEmpty() {
+	ruleSets := effectiveJSONRPCMethodRuleSets(h.spec, h.ses)
+	if len(ruleSets) == 0 {
 		return nil, false
 	}
+	return mcp.FilterInitializeCapabilitiesParsed(&envelope, result, ruleSets)
+}
 
-	return mcp.FilterParsedJSONRPC(&envelope, result, cfg, rules)
+func hasMCPDiscoveryFiltering(spec *APISpec, ses *user.SessionState) bool {
+	if !oasPrimitiveRules(spec, mcp.ListFilterConfigs["tools"]).IsEmpty() ||
+		!oasPrimitiveRules(spec, mcp.ListFilterConfigs["prompts"]).IsEmpty() ||
+		!oasPrimitiveRules(spec, mcp.ListFilterConfigs["resources"]).IsEmpty() ||
+		!oasJSONRPCMethodRules(spec).IsEmpty() {
+
+		return true
+	}
+
+	if spec == nil || ses == nil {
+		return false
+	}
+
+	accessDef, ok := ses.AccessRights[spec.APIID]
+	if !ok {
+		return false
+	}
+
+	return !accessDef.MCPAccessRights.IsEmpty() || !accessDef.JSONRPCMethodsAccessRights.IsEmpty()
 }

--- a/gateway/sse_hook_mcp_list_filter_test.go
+++ b/gateway/sse_hook_mcp_list_filter_test.go
@@ -11,15 +11,30 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/apidef/oas"
 	"github.com/TykTechnologies/tyk/internal/mcp"
 	"github.com/TykTechnologies/tyk/user"
 )
+
+func buildMCPListFilterSSESpec(apiID string, middleware *oas.Middleware) *APISpec {
+	spec := &APISpec{
+		APIDefinition: &apidef.APIDefinition{
+			APIID:               apiID,
+			ApplicationProtocol: apidef.AppProtocolMCP,
+		},
+	}
+	if middleware != nil {
+		spec.OAS.SetTykExtension(&oas.XTykAPIGateway{Middleware: middleware})
+	}
+	return spec
+}
 
 func TestNewMCPListFilterSSEHook(t *testing.T) {
 	apiID := "test-api"
 
 	t.Run("nil session returns nil", func(t *testing.T) {
-		hook := NewMCPListFilterSSEHook(apiID, nil)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), nil)
 		assert.Nil(t, hook)
 	})
 
@@ -29,7 +44,7 @@ func TestNewMCPListFilterSSEHook(t *testing.T) {
 				apiID: {},
 			},
 		}
-		hook := NewMCPListFilterSSEHook(apiID, ses)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 		assert.Nil(t, hook)
 	})
 
@@ -43,7 +58,7 @@ func TestNewMCPListFilterSSEHook(t *testing.T) {
 				},
 			},
 		}
-		hook := NewMCPListFilterSSEHook(apiID, ses)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 		assert.Nil(t, hook)
 	})
 
@@ -57,9 +72,87 @@ func TestNewMCPListFilterSSEHook(t *testing.T) {
 				},
 			},
 		}
-		hook := NewMCPListFilterSSEHook(apiID, ses)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 		assert.NotNil(t, hook)
 	})
+}
+
+func TestMCPListFilterSSEHook_MiddlewarePrimitiveFiltering(t *testing.T) {
+	spec := buildMCPListFilterSSESpec("test-api", &oas.Middleware{
+		McpTools: oas.MCPPrimitives{
+			"get_weather":   {Operation: oas.Operation{Allow: &oas.Allowance{Enabled: true}}},
+			"get_forecast":  {Operation: oas.Operation{Allow: &oas.Allowance{Enabled: true}}},
+			"execute_query": {Operation: oas.Operation{Allow: &oas.Allowance{Enabled: true}}},
+		},
+	})
+	hook := NewMCPListFilterSSEHook(spec, nil)
+	require.NotNil(t, hook)
+
+	event := &SSEEvent{
+		Event: "message",
+		Data:  []string{`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"get_weather"},{"name":"get_forecast"},{"name":"execute_query"},{"name":"admin_reset"}]}}`},
+	}
+
+	allowed, modified := hook.FilterEvent(event)
+	assert.True(t, allowed)
+	require.NotNil(t, modified)
+
+	var envelope mcp.JSONRPCResponse
+	require.NoError(t, json.Unmarshal([]byte(modified.Data[0]), &envelope))
+	var result map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(envelope.Result, &result))
+	var tools []map[string]any
+	require.NoError(t, json.Unmarshal(result["tools"], &tools))
+
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		names = append(names, tool["name"].(string))
+	}
+	assert.Equal(t, []string{"get_weather", "get_forecast", "execute_query"}, names)
+}
+
+func TestMCPListFilterSSEHook_MiddlewareAndPolicyCompose(t *testing.T) {
+	apiID := "test-api"
+	spec := buildMCPListFilterSSESpec(apiID, &oas.Middleware{
+		McpTools: oas.MCPPrimitives{
+			"get_weather":   {Operation: oas.Operation{Allow: &oas.Allowance{Enabled: true}}},
+			"get_forecast":  {Operation: oas.Operation{Allow: &oas.Allowance{Enabled: true}}},
+			"execute_query": {Operation: oas.Operation{Allow: &oas.Allowance{Enabled: true}}},
+		},
+	})
+	ses := &user.SessionState{
+		AccessRights: map[string]user.AccessDefinition{
+			apiID: {
+				MCPAccessRights: user.MCPAccessRights{
+					Tools: user.AccessControlRules{Allowed: []string{"get_weather", "get_forecast"}},
+				},
+			},
+		},
+	}
+	hook := NewMCPListFilterSSEHook(spec, ses)
+	require.NotNil(t, hook)
+
+	event := &SSEEvent{
+		Event: "message",
+		Data:  []string{`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"get_weather"},{"name":"get_forecast"},{"name":"execute_query"},{"name":"admin_reset"}]}}`},
+	}
+
+	allowed, modified := hook.FilterEvent(event)
+	assert.True(t, allowed)
+	require.NotNil(t, modified)
+
+	var envelope mcp.JSONRPCResponse
+	require.NoError(t, json.Unmarshal([]byte(modified.Data[0]), &envelope))
+	var result map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(envelope.Result, &result))
+	var tools []map[string]any
+	require.NoError(t, json.Unmarshal(result["tools"], &tools))
+
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		names = append(names, tool["name"].(string))
+	}
+	assert.Equal(t, []string{"get_weather", "get_forecast"}, names)
 }
 
 func TestMCPListFilterSSEHook_FilterEvent(t *testing.T) {
@@ -116,7 +209,7 @@ func TestMCPListFilterSSEHook_FilterEvent(t *testing.T) {
 		ses := makeSession(user.AccessControlRules{
 			Allowed: []string{"get_weather", "get_forecast"},
 		})
-		hook := NewMCPListFilterSSEHook(apiID, ses)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 		require.NotNil(t, hook)
 
 		event := &SSEEvent{
@@ -136,7 +229,7 @@ func TestMCPListFilterSSEHook_FilterEvent(t *testing.T) {
 		ses := makeSession(user.AccessControlRules{
 			Blocked: []string{"set_alert", "delete_alert"},
 		})
-		hook := NewMCPListFilterSSEHook(apiID, ses)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 		require.NotNil(t, hook)
 
 		event := &SSEEvent{
@@ -155,7 +248,7 @@ func TestMCPListFilterSSEHook_FilterEvent(t *testing.T) {
 		ses := makeSession(user.AccessControlRules{
 			Allowed: []string{"get_.*"},
 		})
-		hook := NewMCPListFilterSSEHook(apiID, ses)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 		require.NotNil(t, hook)
 
 		event := &SSEEvent{
@@ -176,7 +269,7 @@ func TestMCPListFilterSSEHook_FilterEvent(t *testing.T) {
 			Allowed: []string{"set_alert"},
 			Blocked: []string{"set_alert"},
 		})
-		hook := NewMCPListFilterSSEHook(apiID, ses)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 		require.NotNil(t, hook)
 
 		event := &SSEEvent{
@@ -196,7 +289,7 @@ func TestMCPListFilterSSEHook_FilterEvent(t *testing.T) {
 		ses := makeSession(user.AccessControlRules{
 			Allowed: []string{"get_weather"},
 		})
-		hook := NewMCPListFilterSSEHook(apiID, ses)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 
 		result := map[string]any{
 			"tools":      []map[string]any{{"name": "get_weather"}, {"name": "set_alert"}},
@@ -224,7 +317,7 @@ func TestMCPListFilterSSEHook_FilterEvent(t *testing.T) {
 
 	t.Run("passes through non-message event types", func(t *testing.T) {
 		ses := makeSession(user.AccessControlRules{Allowed: []string{"get_weather"}})
-		hook := NewMCPListFilterSSEHook(apiID, ses)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 
 		event := &SSEEvent{
 			Event: "error",
@@ -238,7 +331,7 @@ func TestMCPListFilterSSEHook_FilterEvent(t *testing.T) {
 
 	t.Run("passes through non-list JSON-RPC responses", func(t *testing.T) {
 		ses := makeSession(user.AccessControlRules{Allowed: []string{"get_weather"}})
-		hook := NewMCPListFilterSSEHook(apiID, ses)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 
 		// A tools/call response has "content", not "tools"
 		result := map[string]any{
@@ -264,7 +357,7 @@ func TestMCPListFilterSSEHook_FilterEvent(t *testing.T) {
 
 	t.Run("passes through error responses", func(t *testing.T) {
 		ses := makeSession(user.AccessControlRules{Allowed: []string{"get_weather"}})
-		hook := NewMCPListFilterSSEHook(apiID, ses)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 
 		errObj := map[string]any{"code": -32600, "message": "invalid request"}
 		errBytes, _ := json.Marshal(errObj) //nolint:errcheck
@@ -284,7 +377,7 @@ func TestMCPListFilterSSEHook_FilterEvent(t *testing.T) {
 
 	t.Run("passes through empty data", func(t *testing.T) {
 		ses := makeSession(user.AccessControlRules{Allowed: []string{"get_weather"}})
-		hook := NewMCPListFilterSSEHook(apiID, ses)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 
 		event := &SSEEvent{Data: []string{}}
 		allowed, modified := hook.FilterEvent(event)
@@ -294,7 +387,7 @@ func TestMCPListFilterSSEHook_FilterEvent(t *testing.T) {
 
 	t.Run("passes through malformed JSON", func(t *testing.T) {
 		ses := makeSession(user.AccessControlRules{Allowed: []string{"get_weather"}})
-		hook := NewMCPListFilterSSEHook(apiID, ses)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 
 		event := &SSEEvent{Data: []string{`{not valid json`}}
 		allowed, modified := hook.FilterEvent(event)
@@ -306,7 +399,7 @@ func TestMCPListFilterSSEHook_FilterEvent(t *testing.T) {
 		ses := makeSession(user.AccessControlRules{
 			Allowed: []string{"get_weather"},
 		})
-		hook := NewMCPListFilterSSEHook(apiID, ses)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 		require.NotNil(t, hook)
 
 		event := &SSEEvent{
@@ -328,7 +421,7 @@ func TestMCPListFilterSSEHook_FilterEvent(t *testing.T) {
 		ses := makeSession(user.AccessControlRules{
 			Allowed: []string{"get_weather"},
 		})
-		hook := NewMCPListFilterSSEHook(apiID, ses)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 		require.NotNil(t, hook)
 
 		event := &SSEEvent{
@@ -345,7 +438,7 @@ func TestMCPListFilterSSEHook_FilterEvent(t *testing.T) {
 
 	t.Run("empty result object passes through", func(t *testing.T) {
 		ses := makeSession(user.AccessControlRules{Allowed: []string{"get_weather"}})
-		hook := NewMCPListFilterSSEHook(apiID, ses)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 
 		// Result exists but has no list key.
 		envelope := map[string]any{
@@ -365,7 +458,7 @@ func TestMCPListFilterSSEHook_FilterEvent(t *testing.T) {
 		ses := makeSession(user.AccessControlRules{
 			Allowed: []string{"get_weather"},
 		})
-		hook := NewMCPListFilterSSEHook(apiID, ses)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 
 		// Split JSON across multiple data: lines (valid per SSE spec)
 		fullJSON := makeToolsListData([]string{"get_weather", "set_alert"})
@@ -395,7 +488,7 @@ func TestMCPListFilterSSEHook_PromptFiltering(t *testing.T) {
 			},
 		},
 	}
-	hook := NewMCPListFilterSSEHook(apiID, ses)
+	hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 	require.NotNil(t, hook)
 
 	result := map[string]any{
@@ -435,7 +528,7 @@ func TestMCPListFilterSSEHook_ResourceTemplateFiltering(t *testing.T) {
 			},
 		},
 	}
-	hook := NewMCPListFilterSSEHook(apiID, ses)
+	hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 	require.NotNil(t, hook)
 
 	result := map[string]any{
@@ -502,7 +595,7 @@ func TestMCPListFilterSSEHook_OutOfOrderFrames(t *testing.T) {
 			user.AccessControlRules{Allowed: []string{"allowed_tool"}},
 			user.AccessControlRules{Allowed: []string{"allowed_prompt"}},
 		)
-		hook := NewMCPListFilterSSEHook(apiID, ses)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 		require.NotNil(t, hook)
 
 		toolsData := makeJSONRPCResponse(1, "tools", []map[string]any{
@@ -536,7 +629,7 @@ func TestMCPListFilterSSEHook_OutOfOrderFrames(t *testing.T) {
 			user.AccessControlRules{Allowed: []string{"get_weather"}},
 			user.AccessControlRules{},
 		)
-		hook := NewMCPListFilterSSEHook(apiID, ses)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 		require.NotNil(t, hook)
 
 		// Non-list response (tools/call result)
@@ -586,7 +679,7 @@ func TestMCPListFilterSSEHook_OutOfOrderFrames(t *testing.T) {
 			user.AccessControlRules{Allowed: []string{"tool_a"}},
 			user.AccessControlRules{},
 		)
-		hook := NewMCPListFilterSSEHook(apiID, ses)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 		require.NotNil(t, hook)
 
 		toolsData := makeJSONRPCResponse(1, "tools", []map[string]any{
@@ -612,7 +705,7 @@ func TestMCPListFilterSSEHook_OutOfOrderFrames(t *testing.T) {
 			user.AccessControlRules{Allowed: []string{"allowed"}},
 			user.AccessControlRules{},
 		)
-		hook := NewMCPListFilterSSEHook(apiID, ses)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 		require.NotNil(t, hook)
 
 		toolsData := makeJSONRPCResponse(1, "tools", []map[string]any{
@@ -637,7 +730,7 @@ func TestMCPListFilterSSEHook_OutOfOrderFrames(t *testing.T) {
 			user.AccessControlRules{Allowed: []string{"tool_.*"}},
 			user.AccessControlRules{},
 		)
-		hook := NewMCPListFilterSSEHook(apiID, ses)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 		require.NotNil(t, hook)
 
 		// Events with non-sequential IDs (could happen with reconnection)
@@ -687,7 +780,7 @@ func TestMCPListFilterSSEHook_OutOfOrderFrames(t *testing.T) {
 			user.AccessControlRules{Allowed: []string{"allowed"}},
 			user.AccessControlRules{},
 		)
-		hook := NewMCPListFilterSSEHook(apiID, ses)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 		require.NotNil(t, hook)
 
 		toolsData := makeJSONRPCResponse(1, "tools", []map[string]any{
@@ -721,7 +814,7 @@ func TestMCPListFilterSSEHook_OutOfOrderFrames(t *testing.T) {
 			user.AccessControlRules{Allowed: []string{"tool_1"}},
 			user.AccessControlRules{},
 		)
-		hook := NewMCPListFilterSSEHook(apiID, ses)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 		require.NotNil(t, hook)
 
 		tools1 := makeJSONRPCResponse(1, "tools", []map[string]any{
@@ -760,7 +853,7 @@ func TestMCPListFilterSSEHook_OutOfOrderFrames(t *testing.T) {
 				},
 			},
 		}
-		hook := NewMCPListFilterSSEHook(apiID, ses)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 		require.NotNil(t, hook)
 
 		toolsData := makeJSONRPCResponse(1, "tools", []map[string]any{
@@ -804,7 +897,7 @@ func TestMCPListFilterSSEHook_OutOfOrderFrames(t *testing.T) {
 			user.AccessControlRules{Allowed: []string{"first_.*"}},
 			user.AccessControlRules{},
 		)
-		hook := NewMCPListFilterSSEHook(apiID, ses)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 		require.NotNil(t, hook)
 
 		// Both use JSON-RPC id: 1
@@ -838,7 +931,7 @@ func TestMCPListFilterSSEHook_OutOfOrderFrames(t *testing.T) {
 			user.AccessControlRules{Allowed: []string{"tiny"}},
 			user.AccessControlRules{},
 		)
-		hook := NewMCPListFilterSSEHook(apiID, ses)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 		require.NotNil(t, hook)
 
 		toolsData := makeJSONRPCResponse(1, "tools", []map[string]any{
@@ -864,7 +957,7 @@ func TestMCPListFilterSSEHook_OutOfOrderFrames(t *testing.T) {
 			user.AccessControlRules{Allowed: []string{"allowed"}},
 			user.AccessControlRules{},
 		)
-		hook := NewMCPListFilterSSEHook(apiID, ses)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 		require.NotNil(t, hook)
 
 		toolsData := makeJSONRPCResponse(1, "tools", []map[string]any{
@@ -892,7 +985,7 @@ func TestMCPListFilterSSEHook_OutOfOrderFrames(t *testing.T) {
 			user.AccessControlRules{Allowed: []string{"page_.*"}},
 			user.AccessControlRules{},
 		)
-		hook := NewMCPListFilterSSEHook(apiID, ses)
+		hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 		require.NotNil(t, hook)
 
 		// First page
@@ -967,7 +1060,7 @@ func benchmarkSSEHook(b *testing.B, numTools int, rules user.AccessControlRules)
 			},
 		},
 	}
-	hook := NewMCPListFilterSSEHook(apiID, ses)
+	hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 	event := generateSSEToolsEvent(numTools)
 
 	b.ResetTimer()
@@ -1016,7 +1109,7 @@ func BenchmarkSSEHook_NonListEvent(b *testing.B) {
 			},
 		},
 	}
-	hook := NewMCPListFilterSSEHook(apiID, ses)
+	hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 	// A tools/call result — should pass through without parsing.
 	result := map[string]any{"content": []map[string]any{{"type": "text", "text": "hello"}}}
 	resultBytes, _ := json.Marshal(result) //nolint:errcheck
@@ -1043,7 +1136,7 @@ func benchmarkSSETapEndToEnd(b *testing.B, numTools int, rules user.AccessContro
 			},
 		},
 	}
-	hook := NewMCPListFilterSSEHook(apiID, ses)
+	hook := NewMCPListFilterSSEHook(buildMCPListFilterSSESpec(apiID, nil), ses)
 
 	// Build the raw SSE bytes as the upstream would send them.
 	event := generateSSEToolsEvent(numTools)

--- a/internal/mcp/jsonrpc.go
+++ b/internal/mcp/jsonrpc.go
@@ -17,6 +17,8 @@ const (
 
 // MCP JSON-RPC method names as defined in the Model Context Protocol specification.
 const (
+	MethodInitialize = "initialize"
+
 	// Tool methods
 	MethodToolsCall = "tools/call"
 	MethodToolsList = "tools/list"
@@ -29,6 +31,9 @@ const (
 	// Prompt methods
 	MethodPromptsGet  = "prompts/get"
 	MethodPromptsList = "prompts/list"
+
+	// Client capability methods
+	MethodSamplingCreate = "sampling/create"
 )
 
 // JSON-RPC parameter keys used across MCP methods

--- a/internal/mcp/list_filter.go
+++ b/internal/mcp/list_filter.go
@@ -73,6 +73,13 @@ func ExtractStringField(raw json.RawMessage, field string) string {
 // only items that are permitted. Items whose name field cannot be extracted are
 // included (fail-open for malformed data).
 func FilterItems(items []json.RawMessage, nameField string, rules user.AccessControlRules) []json.RawMessage {
+	return FilterItemsWithRuleSets(items, nameField, []user.AccessControlRules{rules})
+}
+
+// FilterItemsWithRuleSets applies multiple access-control rule sets to a slice
+// of JSON items. An item is included only when every non-empty rule set permits
+// it. This composes allow lists as an intersection and block lists as a union.
+func FilterItemsWithRuleSets(items []json.RawMessage, nameField string, ruleSets []user.AccessControlRules) []json.RawMessage {
 	filtered := make([]json.RawMessage, 0, len(items))
 	for _, item := range items {
 		name := ExtractStringField(item, nameField)
@@ -82,8 +89,7 @@ func FilterItems(items []json.RawMessage, nameField string, rules user.AccessCon
 			continue
 		}
 
-		// CheckAccessControlRules returns true if denied.
-		if !CheckAccessControlRules(rules, name) {
+		if !CheckAccessControlRuleSets(ruleSets, name) {
 			filtered = append(filtered, item)
 		}
 	}
@@ -115,6 +121,13 @@ func ReencodeEnvelope(envelope *JSONRPCResponse, result map[string]json.RawMessa
 // Returns (nil, false) when any parsing or marshalling step fails, signalling
 // that the caller should pass through the original body unmodified.
 func FilterJSONRPCBody(body []byte, cfg *ListFilterConfig, rules user.AccessControlRules) ([]byte, bool) {
+	return FilterJSONRPCBodyWithRuleSets(body, cfg, []user.AccessControlRules{rules})
+}
+
+// FilterJSONRPCBodyWithRuleSets parses a JSON-RPC response body, filters the
+// list items according to the given config and rule sets, and returns the
+// re-encoded body.
+func FilterJSONRPCBodyWithRuleSets(body []byte, cfg *ListFilterConfig, ruleSets []user.AccessControlRules) ([]byte, bool) {
 	var envelope JSONRPCResponse
 	if err := json.Unmarshal(body, &envelope); err != nil {
 		return nil, false
@@ -129,13 +142,19 @@ func FilterJSONRPCBody(body []byte, cfg *ListFilterConfig, rules user.AccessCont
 		return nil, false
 	}
 
-	return FilterParsedJSONRPC(&envelope, result, cfg, rules)
+	return FilterParsedJSONRPCWithRuleSets(&envelope, result, cfg, ruleSets)
 }
 
 // FilterParsedJSONRPC filters items in an already-parsed JSON-RPC result and
 // re-encodes the envelope. Returns (nil, false) when the array key is missing,
 // items cannot be parsed, or re-encoding fails.
 func FilterParsedJSONRPC(envelope *JSONRPCResponse, result map[string]json.RawMessage, cfg *ListFilterConfig, rules user.AccessControlRules) ([]byte, bool) {
+	return FilterParsedJSONRPCWithRuleSets(envelope, result, cfg, []user.AccessControlRules{rules})
+}
+
+// FilterParsedJSONRPCWithRuleSets filters items in an already-parsed JSON-RPC
+// result using multiple rule sets and re-encodes the envelope.
+func FilterParsedJSONRPCWithRuleSets(envelope *JSONRPCResponse, result map[string]json.RawMessage, cfg *ListFilterConfig, ruleSets []user.AccessControlRules) ([]byte, bool) {
 	itemsRaw, exists := result[cfg.ArrayKey]
 	if !exists {
 		return nil, false
@@ -146,7 +165,7 @@ func FilterParsedJSONRPC(envelope *JSONRPCResponse, result map[string]json.RawMe
 		return nil, false
 	}
 
-	filtered := FilterItems(items, cfg.NameField, rules)
+	filtered := FilterItemsWithRuleSets(items, cfg.NameField, ruleSets)
 
 	newBody, err := ReencodeEnvelope(envelope, result, cfg.ArrayKey, filtered)
 	if err != nil {
@@ -169,6 +188,108 @@ func InferListConfigFromResult(result map[string]json.RawMessage) *ListFilterCon
 		}
 	}
 	return nil
+}
+
+// InitializeCapabilityMethods maps initialize response capability keys to the
+// JSON-RPC methods that make the capability usable.
+var InitializeCapabilityMethods = map[string][]string{
+	"tools":     {MethodToolsList, MethodToolsCall},
+	"resources": {MethodResourcesList, MethodResourcesTemplatesList, MethodResourcesRead},
+	"prompts":   {MethodPromptsList, MethodPromptsGet},
+	"sampling":  {MethodSamplingCreate},
+}
+
+// FilterInitializeCapabilitiesBody removes initialize response capabilities
+// whose backing JSON-RPC methods are denied by any rule set.
+func FilterInitializeCapabilitiesBody(body []byte, ruleSets []user.AccessControlRules) ([]byte, bool) {
+	var envelope JSONRPCResponse
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, false
+	}
+
+	if envelope.Result == nil {
+		return nil, false
+	}
+
+	var result map[string]json.RawMessage
+	if err := json.Unmarshal(envelope.Result, &result); err != nil {
+		return nil, false
+	}
+
+	return FilterInitializeCapabilitiesParsed(&envelope, result, ruleSets)
+}
+
+// FilterInitializeCapabilitiesParsed removes denied capabilities in an
+// already-parsed initialize result and re-encodes the response envelope.
+func FilterInitializeCapabilitiesParsed(envelope *JSONRPCResponse, result map[string]json.RawMessage, ruleSets []user.AccessControlRules) ([]byte, bool) {
+	capabilitiesRaw, exists := result["capabilities"]
+	if !exists {
+		return nil, false
+	}
+
+	var capabilities map[string]json.RawMessage
+	if err := json.Unmarshal(capabilitiesRaw, &capabilities); err != nil {
+		return nil, false
+	}
+
+	changed := false
+	for capability, methods := range InitializeCapabilityMethods {
+		if _, exists := capabilities[capability]; !exists {
+			continue
+		}
+
+		if AnyMethodDenied(ruleSets, methods) {
+			delete(capabilities, capability)
+			changed = true
+		}
+	}
+
+	if !changed {
+		return nil, false
+	}
+
+	capabilitiesBytes, err := json.Marshal(capabilities)
+	if err != nil {
+		return nil, false
+	}
+	result["capabilities"] = capabilitiesBytes
+
+	resultBytes, err := json.Marshal(result)
+	if err != nil {
+		return nil, false
+	}
+	envelope.Result = resultBytes
+
+	newBody, err := json.Marshal(envelope)
+	if err != nil {
+		return nil, false
+	}
+	return newBody, true
+}
+
+// AnyMethodDenied returns true when any of the provided methods is denied by
+// any non-empty rule set.
+func AnyMethodDenied(ruleSets []user.AccessControlRules, methods []string) bool {
+	for _, method := range methods {
+		if CheckAccessControlRuleSets(ruleSets, method) {
+			return true
+		}
+	}
+	return false
+}
+
+// CheckAccessControlRuleSets evaluates multiple allow/block rule sets against
+// a name. It returns true if any non-empty rule set denies the name.
+func CheckAccessControlRuleSets(ruleSets []user.AccessControlRules, name string) bool {
+	for _, rules := range ruleSets {
+		if rules.IsEmpty() {
+			continue
+		}
+		if CheckAccessControlRules(rules, name) {
+			return true
+		}
+	}
+	return false
 }
 
 // CheckAccessControlRules evaluates allow/block lists against a name.

--- a/internal/mcp/list_filter_test.go
+++ b/internal/mcp/list_filter_test.go
@@ -234,6 +234,41 @@ func TestFilterItems(t *testing.T) {
 	})
 }
 
+func TestFilterItemsWithRuleSets(t *testing.T) {
+	items := []json.RawMessage{
+		json.RawMessage(`{"name":"get_weather"}`),
+		json.RawMessage(`{"name":"get_forecast"}`),
+		json.RawMessage(`{"name":"execute_query"}`),
+		json.RawMessage(`{"name":"admin_reset"}`),
+	}
+
+	t.Run("allow lists compose as intersection", func(t *testing.T) {
+		result := FilterItemsWithRuleSets(items, "name", []user.AccessControlRules{
+			{Allowed: []string{"get_weather", "get_forecast", "execute_query"}},
+			{Allowed: []string{"get_weather", "get_forecast"}},
+		})
+
+		names := make([]string, 0, len(result))
+		for _, item := range result {
+			names = append(names, ExtractStringField(item, "name"))
+		}
+		assert.Equal(t, []string{"get_weather", "get_forecast"}, names)
+	})
+
+	t.Run("block lists compose as union", func(t *testing.T) {
+		result := FilterItemsWithRuleSets(items, "name", []user.AccessControlRules{
+			{Blocked: []string{"admin_reset"}},
+			{Blocked: []string{"execute_query"}},
+		})
+
+		names := make([]string, 0, len(result))
+		for _, item := range result {
+			names = append(names, ExtractStringField(item, "name"))
+		}
+		assert.Equal(t, []string{"get_weather", "get_forecast"}, names)
+	})
+}
+
 func TestFilterJSONRPCBody(t *testing.T) {
 	t.Run("batch JSON-RPC array passes through (returns false)", func(t *testing.T) {
 		// JSON-RPC batch = top-level array. Not supported for filtering.
@@ -281,6 +316,29 @@ func TestFilterJSONRPCBody(t *testing.T) {
 		assert.Contains(t, names, "résumé_tool")
 		assert.Contains(t, names, "normal_tool")
 	})
+}
+
+func TestFilterInitializeCapabilitiesBody(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26","capabilities":{"tools":{"listChanged":true},"resources":{"subscribe":true},"prompts":{},"sampling":{}},"serverInfo":{"name":"test","version":"1.0.0"}}}`)
+
+	result, ok := FilterInitializeCapabilitiesBody(body, []user.AccessControlRules{
+		{Blocked: []string{MethodSamplingCreate, MethodToolsList}},
+	})
+	require.True(t, ok)
+
+	var envelope JSONRPCResponse
+	require.NoError(t, json.Unmarshal(result, &envelope))
+
+	var responseResult map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(envelope.Result, &responseResult))
+
+	var capabilities map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(responseResult["capabilities"], &capabilities))
+
+	assert.NotContains(t, capabilities, "sampling")
+	assert.NotContains(t, capabilities, "tools")
+	assert.Contains(t, capabilities, "resources")
+	assert.Contains(t, capabilities, "prompts")
 }
 
 func TestInferListConfigFromResult(t *testing.T) {


### PR DESCRIPTION
## Summary
- Applies OAS MCP middleware allow/block rules to MCP discovery responses.
- Composes middleware and session/policy discovery filters as intersection for allow lists and union for block lists.
- Filters initialize capabilities when method-level JSON-RPC access rules deny backing methods such as sampling/create.

## Root Cause
MCP primitive invocation rules were enforced for tools/call, resources/read, and prompts/get, but discovery responses only considered session MCPAccessRights and ignored OAS middleware rules. As a result, tools/list could advertise primitives that tools/call later denied.

## Validation
- GOCACHE=/private/tmp/tyk-go-cache go test -count=1 ./internal/mcp
- GOCACHE=/private/tmp/tyk-go-cache go test -count=1 ./gateway -run 'MCPListFilter|MCPAccessControl|JSONRPCAccessControl'
- Pre-commit/pre-push hooks: golangci-lint, import lint, schema lint, go build, gateway test compile
- Live curl validation: tools/list returned only permitted tools; denied tools/call returned JSON-RPC 403; allowed tools/call succeeded



<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-16823" title="TT-16823" target="_blank">TT-16823</a>
</summary>

|         |    |
|---------|----|
| Status  | Ready for Testing |
| Summary | Filter Middleware Allow Block Lists in the capability handshake |

Generated at: 2026-05-27 10:48:54

</details>

<!---TykTechnologies/jira-linter ends here-->



