### PR TITLE
[TT-17176] PRM auto-migration — deprecate legacy struct, pin runtime guarantees

### DIFF
--- a/apidef/mcp/schema/x-tyk-api-gateway.json
+++ b/apidef/mcp/schema/x-tyk-api-gateway.json
@@ -1399,6 +1399,8 @@
     },
     "X-Tyk-ProtectedResourceMetadata": {
       "type": "object",
+      "deprecated": true,
+      "description": "Deprecated. Use securitySchemes[<name>].oauth2.protectedResourceMetadata (X-Tyk-OAuth2-PRM) instead. The legacy top-level block is kept for downgrade safety and will be removed in a future major version.",
       "properties": {
         "enabled": {
           "type": "boolean"

--- a/apidef/oas/authentication.go
+++ b/apidef/oas/authentication.go
@@ -94,24 +94,19 @@ type Authentication struct {
 	// This can be used to combine any declared securitySchemes including Tyk proprietary auth methods.
 	Security [][]string `bson:"security,omitempty" json:"security,omitempty"`
 
-	// Deprecated: Use SecuritySchemes[<name>].OAuth2.ProtectedResourceMetadata instead.
-	// The new per-scheme location is the runtime source of truth; this top-level
-	// field is kept for downgrade safety and will be removed in a future major version.
-	//
 	// ProtectedResourceMetadata configures OAuth 2.0 Protected Resource Metadata (RFC 9728)
 	// for authorization server discovery. This is used by MCP clients to discover which
 	// authorization server to use for accessing the API.
+	//
+	// Deprecated: Use SecuritySchemes[<name>].OAuth2.ProtectedResourceMetadata instead.
+	// The new per-scheme location is the runtime source of truth; this top-level
+	// field is kept for downgrade safety and will be removed in a future major version.
 	ProtectedResourceMetadata *ProtectedResourceMetadata `bson:"protectedResourceMetadata,omitempty" json:"protectedResourceMetadata,omitempty"`
 
 	// CertificateAuth represents certificate-based authentication configuration.
 	CertificateAuth *CertificateAuth `bson:"certificateAuth,omitempty" json:"certificateAuth,omitempty"`
 }
 
-// Deprecated: Use OAuth2PRM (under SecuritySchemes[<name>].OAuth2) instead.
-// This type backs the legacy top-level Authentication.ProtectedResourceMetadata
-// field; the new per-scheme location is the runtime source of truth and the
-// legacy block is kept only for downgrade safety.
-//
 // ProtectedResourceMetadata holds the configuration for OAuth 2.0 Protected Resource Metadata (RFC 9728).
 // It enables MCP clients to discover which authorization server protects this API resource.
 //
@@ -125,6 +120,11 @@ type Authentication struct {
 //     OAuth-protected remote MCP servers.
 //
 // On non-MCP APIs only static is meaningful; mirror is a no-op.
+//
+// Deprecated: Use OAuth2PRM (under SecuritySchemes[<name>].OAuth2) instead.
+// This type backs the legacy top-level Authentication.ProtectedResourceMetadata
+// field; the new per-scheme location is the runtime source of truth and the
+// legacy block is kept only for downgrade safety.
 type ProtectedResourceMetadata struct {
 	// Enabled activates the Protected Resource Metadata endpoint.
 	Enabled bool `bson:"enabled" json:"enabled"` // required

--- a/apidef/oas/authentication.go
+++ b/apidef/oas/authentication.go
@@ -94,6 +94,10 @@ type Authentication struct {
 	// This can be used to combine any declared securitySchemes including Tyk proprietary auth methods.
 	Security [][]string `bson:"security,omitempty" json:"security,omitempty"`
 
+	// Deprecated: Use SecuritySchemes[<name>].OAuth2.ProtectedResourceMetadata instead.
+	// The new per-scheme location is the runtime source of truth; this top-level
+	// field is kept for downgrade safety and will be removed in a future major version.
+	//
 	// ProtectedResourceMetadata configures OAuth 2.0 Protected Resource Metadata (RFC 9728)
 	// for authorization server discovery. This is used by MCP clients to discover which
 	// authorization server to use for accessing the API.
@@ -103,6 +107,11 @@ type Authentication struct {
 	CertificateAuth *CertificateAuth `bson:"certificateAuth,omitempty" json:"certificateAuth,omitempty"`
 }
 
+// Deprecated: Use OAuth2PRM (under SecuritySchemes[<name>].OAuth2) instead.
+// This type backs the legacy top-level Authentication.ProtectedResourceMetadata
+// field; the new per-scheme location is the runtime source of truth and the
+// legacy block is kept only for downgrade safety.
+//
 // ProtectedResourceMetadata holds the configuration for OAuth 2.0 Protected Resource Metadata (RFC 9728).
 // It enables MCP clients to discover which authorization server protects this API resource.
 //

--- a/apidef/oas/authentication_test.go
+++ b/apidef/oas/authentication_test.go
@@ -2,6 +2,7 @@ package oas
 
 import (
 	"encoding/json"
+	"os"
 	"testing"
 	"time"
 
@@ -967,4 +968,80 @@ func TestProtectedResourceMetadata_JSON(t *testing.T) {
 		assert.NotContains(t, raw, "authorizationServers")
 		assert.NotContains(t, raw, "scopesSupported")
 	})
+}
+
+// TestProtectedResourceMetadata_SchemaMarkedDeprecated pins that every
+// x-tyk-api-gateway schema variant flags the legacy top-level PRM type
+// `X-Tyk-ProtectedResourceMetadata` as deprecated. The new home is the
+// per-scheme `securitySchemes[<name>].oauth2.protectedResourceMetadata`
+// (`X-Tyk-OAuth2-PRM`), and tooling that reads the schema needs the
+// signal to render the deprecation to operators.
+func TestProtectedResourceMetadata_SchemaMarkedDeprecated(t *testing.T) {
+	t.Parallel()
+
+	schemas := []string{
+		"schema/x-tyk-api-gateway.json",
+		"schema/x-tyk-api-gateway.strict.json",
+		"../mcp/schema/x-tyk-api-gateway.json",
+		"../streams/schema/x-tyk-api-gateway.json",
+	}
+	for _, path := range schemas {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+			data, err := os.ReadFile(path)
+			assert.NoError(t, err, "read schema")
+
+			var doc map[string]interface{}
+			assert.NoError(t, json.Unmarshal(data, &doc))
+
+			defs, ok := doc["definitions"].(map[string]interface{})
+			assert.True(t, ok, "schema must have a definitions block")
+			prm, ok := defs["X-Tyk-ProtectedResourceMetadata"].(map[string]interface{})
+			assert.True(t, ok, "schema must define X-Tyk-ProtectedResourceMetadata")
+			assert.Equal(t, true, prm["deprecated"],
+				"X-Tyk-ProtectedResourceMetadata must be marked deprecated; new home is securitySchemes[<name>].oauth2.protectedResourceMetadata")
+		})
+	}
+}
+
+// TestOAS_PRMBothBlocksRoundTrip pins that an OAS document carrying both
+// the deprecated top-level protectedResourceMetadata block and the new
+// per-scheme oauth2.protectedResourceMetadata block round-trips through
+// JSON marshal/unmarshal with both intact and with the OAuth2 master
+// switch staying disabled. This is the persistence shape the dashboard
+// writes after running the PRM auto-migration (non-destructive copy from
+// the legacy location to the new one, both kept in place for downgrade
+// safety).
+func TestOAS_PRMBothBlocksRoundTrip(t *testing.T) {
+	t.Parallel()
+	s := newOAuth2Fixture("oauth2")
+	auth := s.GetTykExtension().Server.Authentication
+	// PRM publishing is independent of the OAuth2 master switch — see
+	// TestOAuth2PRM_ServesWhenOAuth2MasterDisabled in the gateway tests.
+	auth.SecuritySchemes["oauth2"].(*OAuth2).Enabled = false
+	auth.SecuritySchemes["oauth2"].(*OAuth2).ProtectedResourceMetadata = &OAuth2PRM{
+		Enabled:              true,
+		AuthorizationServers: []string{"https://new.example.com"},
+	}
+	//nolint:staticcheck // intentional: the legacy block must round-trip alongside the new one.
+	auth.ProtectedResourceMetadata = &ProtectedResourceMetadata{
+		Enabled:              true,
+		AuthorizationServers: []string{"https://old.example.com"},
+	}
+
+	data, err := json.Marshal(s)
+	assert.NoError(t, err)
+
+	var decoded OAS
+	assert.NoError(t, json.Unmarshal(data, &decoded))
+
+	gotAuth := decoded.GetTykExtension().Server.Authentication
+	assert.NotNil(t, gotAuth.ProtectedResourceMetadata, "legacy block must survive (downgrade safety)")          //nolint:staticcheck
+	assert.Equal(t, []string{"https://old.example.com"}, gotAuth.ProtectedResourceMetadata.AuthorizationServers) //nolint:staticcheck
+	gotOAuth2 := decoded.GetTykOAuth2Config("oauth2")
+	assert.NotNil(t, gotOAuth2)
+	assert.NotNil(t, gotOAuth2.ProtectedResourceMetadata)
+	assert.Equal(t, []string{"https://new.example.com"}, gotOAuth2.ProtectedResourceMetadata.AuthorizationServers)
+	assert.False(t, gotOAuth2.Enabled,
+		"migration must not auto-enable OAuth2 authentication — only the PRM sub-block")
 }

--- a/apidef/oas/oauth2.go
+++ b/apidef/oas/oauth2.go
@@ -56,10 +56,9 @@ type OAuth2PRM struct {
 	// token. At least one entry is required for MCP-proxy APIs.
 	AuthorizationServers []string `bson:"authorizationServers,omitempty" json:"authorizationServers,omitempty"`
 
-	// AutoDeriveScopes, when nil or true (default), unions the served
-	// scopes_supported with scopes from every `security:` array; false
-	// advertises only the `flows.<flow>.scopes` catalog. See
-	// OAuth2PRMScopesSupported.
+	// AutoDeriveScopes unions the served scopes_supported with scopes from
+	// every `security:` array when nil or true (default); false advertises
+	// only the `flows.<flow>.scopes` catalog. See OAuth2PRMScopesSupported.
 	AutoDeriveScopes *bool `bson:"autoDeriveScopes,omitempty" json:"autoDeriveScopes,omitempty"`
 }
 

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -1323,6 +1323,8 @@
     },
     "X-Tyk-ProtectedResourceMetadata": {
       "type": "object",
+      "deprecated": true,
+      "description": "Deprecated. Use securitySchemes[<name>].oauth2.protectedResourceMetadata (X-Tyk-OAuth2-PRM) instead. The legacy top-level block is kept for downgrade safety and will be removed in a future major version.",
       "properties": {
         "enabled": {
           "type": "boolean"

--- a/apidef/oas/schema/x-tyk-api-gateway.strict.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.strict.json
@@ -1378,6 +1378,8 @@
     },
     "X-Tyk-ProtectedResourceMetadata": {
       "type": "object",
+      "deprecated": true,
+      "description": "Deprecated. Use securitySchemes[<name>].oauth2.protectedResourceMetadata (X-Tyk-OAuth2-PRM) instead. The legacy top-level block is kept for downgrade safety and will be removed in a future major version.",
       "properties": {
         "enabled": {
           "type": "boolean"

--- a/apidef/streams/schema/x-tyk-api-gateway.json
+++ b/apidef/streams/schema/x-tyk-api-gateway.json
@@ -1237,6 +1237,8 @@
     },
     "X-Tyk-ProtectedResourceMetadata": {
       "type": "object",
+      "deprecated": true,
+      "description": "Deprecated. Use securitySchemes[<name>].oauth2.protectedResourceMetadata (X-Tyk-OAuth2-PRM) instead. The legacy top-level block is kept for downgrade safety and will be removed in a future major version.",
       "properties": {
         "enabled": {
           "type": "boolean"

--- a/gateway/mw_protected_resource_oauth2_test.go
+++ b/gateway/mw_protected_resource_oauth2_test.go
@@ -197,6 +197,62 @@ func TestOAuth2PRM_NewWinsOverOld(t *testing.T) {
 	})
 }
 
+// TestOAuth2PRM_ServesWhenOAuth2MasterDisabled pins the migration's
+// safety hatch: PRM publishing is independent of OAuth2 authentication
+// enforcement. The dashboard migration creates the new oauth2 scheme
+// with oauth2.enabled=false (so it doesn't silently turn on auth that
+// wasn't there before) but oauth2.protectedResourceMetadata.enabled=true
+// so the new PRM document is served. If a refactor ever wires
+// GetOAuth2PRMConfig to check oauth2.enabled, every migrated customer
+// stops publishing PRM until they manually flip the master switch.
+func TestOAuth2PRM_ServesWhenOAuth2MasterDisabled(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	doc := newOAuth2PRMOAS("/prm-master-off/", &oas.OAuth2PRM{
+		Enabled:              true,
+		Resource:             "https://api.example.com/",
+		AuthorizationServers: []string{"https://as.example.com/"},
+	}, nil)
+	doc.GetTykExtension().Server.Authentication.SecuritySchemes["corpOAuth"].(*oas.OAuth2).Enabled = false
+	loadOAuth2PRMAPI(ts, "/prm-master-off/", doc)
+
+	ts.Run(t, test.TestCase{
+		Method:    http.MethodGet,
+		Path:      "/prm-master-off/.well-known/oauth-protected-resource",
+		Code:      http.StatusOK,
+		BodyMatch: `"authorization_servers":\["https://as.example.com/"\]`,
+	})
+}
+
+// TestOAuth2PRM_FallsBackToLegacyWhenNewBlockAbsent pins the legacy
+// fallback path that the migration relies on: after the dashboard
+// non-destructively copies the legacy top-level
+// authentication.protectedResourceMetadata block to the new per-scheme
+// oauth2.protectedResourceMetadata location, an operator may later
+// remove the new block (reverting to the old location). The gateway
+// must continue to serve PRM from the legacy block in that state.
+func TestOAuth2PRM_FallsBackToLegacyWhenNewBlockAbsent(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	doc := newOAuth2PRMOAS("/prm-fallback/", nil, nil)
+	//nolint:staticcheck // intentional: pinning the legacy block's runtime fallback.
+	doc.GetTykExtension().Server.Authentication.ProtectedResourceMetadata = &oas.ProtectedResourceMetadata{
+		Enabled:              true,
+		Resource:             "https://api.example.com/legacy",
+		AuthorizationServers: []string{"https://old-as.example.com/"},
+	}
+	loadOAuth2PRMAPI(ts, "/prm-fallback/", doc)
+
+	ts.Run(t, test.TestCase{
+		Method:    http.MethodGet,
+		Path:      "/prm-fallback/.well-known/oauth-protected-resource",
+		Code:      http.StatusOK,
+		BodyMatch: `"authorization_servers":\["https://old-as.example.com/"\]`,
+	})
+}
+
 // TestOAuth2PRM_ResourceMetadataOnChallenge verifies the scope-check
 // middleware appends an RFC 9728 §5.1 resource_metadata= parameter to
 // its Bearer challenges when the API publishes a PRM document, and omits


### PR DESCRIPTION
## Summary

Companion gateway PR for the Story 05 PRM auto-migration in tyk-analytics. The dashboard migration ([TT-17176 PR #5657](https://github.com/TykTechnologies/tyk-analytics/pull/5657)) is non-destructive — it leaves the deprecated top-level `authentication.protectedResourceMetadata` in place and adds the new `securitySchemes[<name>].oauth2.protectedResourceMetadata` alongside, so the gateway must continue to honour both shapes during the transition.

This PR:

- **Marks the legacy struct deprecated** at both Go and JSON-Schema level so IDEs, `staticcheck SA1019`, OpenAPI Generator, Stoplight, Redocly, and the dashboard form generator all surface the deprecation. `Authentication.ProtectedResourceMetadata` and the `ProtectedResourceMetadata` type each carry `// Deprecated:` doc comments; all four `x-tyk-api-gateway` schema variants (`apidef/oas/schema/x-tyk-api-gateway.json`, `…strict.json`, `apidef/mcp/schema/x-tyk-api-gateway.json`, `apidef/streams/schema/x-tyk-api-gateway.json`) carry `"deprecated": true` on the legacy type definition.
- **Pins runtime guarantees** the migration depends on:
  - PRM serves when the OAuth2 master is disabled — what lets the dashboard produce `oauth2.enabled: false` + `oauth2.protectedResourceMetadata.enabled: true` without silently turning on authentication that wasn't there before.
  - Legacy block fallback when the new per-scheme PRM sub-block is absent — what makes downgrade safe (operator removes the new block → gateway serves from the legacy top-level block).

No behaviour change. Pure backwards-compatible documentation + test surface.

## Story

- JIRA: [TT-17176](https://tyktech.atlassian.net/browse/TT-17176)

## Companion PRs

- `tyk-analytics` — [#5657](https://github.com/TykTechnologies/tyk-analytics/pull/5657) — dashboard startup migration + Python e2e.
- `tyk-analytics-ui` (webclient) — no PR for this story; the optional UI banner / read-only legacy form is deferred.

## Test plan

- [x] `go test ./apidef/oas/... -run TestProtectedResourceMetadata_SchemaMarkedDeprecated -count=1`
- [x] `go test ./apidef/oas/... -run TestOAS_PRMBothBlocksRoundTrip -count=1` — both blocks survive marshal/unmarshal with the OAuth2 master staying `false`.
- [x] `go test ./gateway/... -run TestOAuth2PRM_ServesWhenOAuth2MasterDisabled -count=1`
- [x] `go test ./gateway/... -run TestOAuth2PRM_FallsBackToLegacyWhenNewBlockAbsent -count=1`

## Risk

- **Behaviour-neutral.** No runtime code path changes — the new tests pin existing behaviour the migration relies on. Schema-level `"deprecated": true` is advisory metadata; clients that don't read it see no change.
- The earlier [#8212](https://github.com/TykTechnologies/tyk/pull/8212) on this branch carried an `Authentication.PRMMigratedToOAuth2` marker field that has since been removed in favour of presence-based idempotency on the dashboard side — that PR was closed; this PR replaces it with a strictly narrower scope (deprecation + runtime-guarantee tests, no marker field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[TT-17176]: https://tyktech.atlassian.net/browse/TT-17176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-17176" title="TT-17176" target="_blank">TT-17176</a>
</summary>

|         |    |
|---------|----|
| Status  | Ready for Testing |
| Summary | Protected Resource Metadata — auto-migration of existing customers |

Generated at: 2026-05-27 18:07:46

</details>

<!---TykTechnologies/jira-linter ends here-->

