### PR TITLE
Merging to release-5.13: [TT-17154] Bump opentelemetry to post-v0.0.25 doc-comment fixes (#8240)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	github.com/IBM/sarama v1.46.3
 	github.com/Jeffail/gabs/v2 v2.7.0
 	github.com/TykTechnologies/graphql-go-tools/v2 v2.0.0-20250926102005-c54e73aae17d
-	github.com/TykTechnologies/opentelemetry v0.0.25
+	github.com/TykTechnologies/opentelemetry v0.0.26-0.20260521112223-3b0d024e6090
 	github.com/TykTechnologies/structviewer v1.2.0
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/eclipse/paho.mqtt.golang v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -183,8 +183,8 @@ github.com/TykTechnologies/murmur3 v0.0.0-20230310161213-aad17efd5632 h1:T5NWziF
 github.com/TykTechnologies/murmur3 v0.0.0-20230310161213-aad17efd5632/go.mod h1:UsPYgOFBpNzDXLEti7MKOwHLpVSqdzuNGkVFPspQmnQ=
 github.com/TykTechnologies/openid2go v0.1.2 h1:WXctksOahA/epTVVvbn9iNUuMXKRr0ksrF4dY9KW8o8=
 github.com/TykTechnologies/openid2go v0.1.2/go.mod h1:gYfkqeWa+lY3Xz/Z2xYtIzmYXynlgKZaBIbPCqdcdMA=
-github.com/TykTechnologies/opentelemetry v0.0.25 h1:Qen0fTy8EZHY7my1fokOrm0vcyOsBHwnyvXBG/bS87A=
-github.com/TykTechnologies/opentelemetry v0.0.25/go.mod h1:FoJH6aRf8W+Rs9/Csvayfy3U2p4+vp46dj0CuGMBLSU=
+github.com/TykTechnologies/opentelemetry v0.0.26-0.20260521112223-3b0d024e6090 h1:RPNAul+EgeebSF/+WhCMYsQ9ngWGeHIpxelszLoPlU0=
+github.com/TykTechnologies/opentelemetry v0.0.26-0.20260521112223-3b0d024e6090/go.mod h1:FoJH6aRf8W+Rs9/Csvayfy3U2p4+vp46dj0CuGMBLSU=
 github.com/TykTechnologies/storage v1.3.1 h1:UzfrAillaXXe5AHeIGUHVf/1niLPNJChMWrqgjCiAjY=
 github.com/TykTechnologies/storage v1.3.1/go.mod h1:fw7yR9/LgVFVAlaQFLypFnfsIP/JOkF/tAsgAwMkKj0=
 github.com/TykTechnologies/structviewer v1.2.0 h1:wV3AyTmWCZ3n7/llp+6xuDjnS/EJ/Ct/HG2pPE9+VX8=


### PR DESCRIPTION
## Summary

Cherry-pick of #8240 onto `release-5.13`.

Bumps `github.com/TykTechnologies/opentelemetry` from `v0.0.25` to `v0.0.26-0.20260521112223-3b0d024e6090`, pulling in doc-comment fixes (TykTechnologies/opentelemetry#69). Documentation-only upstream change — no behavior, API, or default changes.

- Original PR: #8240
- Original commit: 8a9a180f4798b3d0e1f5cabf9b703d1b9d120c75
- Files changed: `go.mod` (2 lines), `go.sum` (4 lines)

## Test plan

- [ ] CI green on this branch

<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-17154" title="TT-17154" target="_blank">TT-17154</a>
</summary>

|         |    |
|---------|----|
| Status  | In Code Review |
| Summary | Gateway API + config 5.13.0 |

Generated at: 2026-05-28 11:48:52

</details>

<!---TykTechnologies/jira-linter ends here-->

