### PR TITLE
[TT-17173] apidef classic schema: declare security_requirement_scopes

### DIFF
--- a/apidef/api_definitions_test.go
+++ b/apidef/api_definitions_test.go
@@ -250,6 +250,28 @@ func TestSchema(t *testing.T) {
 	}
 }
 
+func TestSchema_SecurityRequirementScopes(t *testing.T) {
+	schemaLoader := gojsonschema.NewBytesLoader([]byte(Schema))
+
+	spec := DummyAPI()
+	spec.SecurityRequirementScopes = []map[string][]string{
+		{"jwt1": {}, "oauth2_scheme": {"read:pets", "write:pets"}},
+		{"oauth2_scheme": {"admin"}},
+	}
+
+	goLoader := gojsonschema.NewGoLoader(spec)
+	result, err := gojsonschema.Validate(schemaLoader, goLoader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result.Valid() {
+		for _, e := range result.Errors() {
+			t.Error(e)
+		}
+	}
+}
+
 func TestStringRegexMap(t *testing.T) {
 	var v StringRegexMap
 	assert.True(t, v.Empty())

--- a/apidef/schema.json
+++ b/apidef/schema.json
@@ -1185,6 +1185,24 @@
         }
       }
     },
+    "security_requirement_scopes": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "object",
+        "additionalProperties": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "error_overrides_disabled": {
       "type": "boolean"
     },


### PR DESCRIPTION
## Summary

The `APIDefinition` struct emits `security_requirement_scopes` (json tag on `[]map[string][]string`, paired by index with `security_requirements` to preserve per-scheme scope arrays from OAS root `security:`). The classic apidef JSON schema didn't declare the property, and the root carries `additionalProperties: false`, so every API definition carrying the field was rejected by the dashboard's `PUT/POST /api/apis` validator with:

```
API object validation failed.
Errors: ["security_requirement_scopes: Additional property security_requirement_scopes is not allowed"]
```

This blocks the [TT-17173 dashboard companion PR](https://github.com/TykTechnologies/tyk-analytics/pull/5629) — `TestAPIContext_OAS/update/oas_api/with_oas`, `…/with_old`, `…/with_old/bad_oas` all fail post-merge for that reason.

## Change

- `apidef/schema.json` — declare `security_requirement_scopes` as `type: [array, null]` of objects whose `additionalProperties` is a `[array, null]` of strings (matches the Go field shape `[]map[string][]string`).
- `apidef/api_definitions_test.go` — `TestSchema_SecurityRequirementScopes` pins a populated `DummyAPI()` through `Validate(Schema, …)`, so future schema/struct drift fails fast.

## Story

- JIRA: [TT-17173](https://tyktech.atlassian.net/browse/TT-17173)

## Companion PRs

- tyk-analytics: https://github.com/TykTechnologies/tyk-analytics/pull/5629 — needs a follow-up go.mod bump to this commit before its CI goes green.

## Test plan

- [x] `go test ./apidef/...` — clean across all 10 packages
- [x] `TestSchema_SecurityRequirementScopes` fails on pre-fix tree with the same `Additional property … is not allowed` message the dashboard CI surfaces, passes after the schema delta

## Risk

Additive schema entry; no behaviour change for callers that don't populate the field. The `[array, null]` typing and `additionalProperties` shape mirror the neighbouring `security_requirements` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TT-17173]: https://tyktech.atlassian.net/browse/TT-17173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-17173" title="TT-17173" target="_blank">TT-17173</a>
</summary>

|         |    |
|---------|----|
| Status  | Merge |
| Summary | OAuth2 scope check — global / API level |

Generated at: 2026-05-27 12:18:28

</details>

<!---TykTechnologies/jira-linter ends here-->
