### PR TITLE
[TT-17177] OAuth2 Token Exchange — core flow (RFC 8693), EE/OSS split

### DIFF
--- a/apidef/mcp/schema/x-tyk-api-gateway.json
+++ b/apidef/mcp/schema/x-tyk-api-gateway.json
@@ -1399,6 +1399,8 @@
     },
     "X-Tyk-ProtectedResourceMetadata": {
       "type": "object",
+      "deprecated": true,
+      "description": "Deprecated. Use securitySchemes[<name>].oauth2.protectedResourceMetadata (X-Tyk-OAuth2-PRM) instead. The legacy top-level block is kept for downgrade safety and will be removed in a future major version.",
       "properties": {
         "enabled": {
           "type": "boolean"

--- a/apidef/mcp/schema/x-tyk-api-gateway.json
+++ b/apidef/mcp/schema/x-tyk-api-gateway.json
@@ -220,7 +220,9 @@
         },
         "claims": {
           "type": "array",
-          "items": {"type": "string"}
+          "items": {
+            "type": "string"
+          }
         },
         "scopeToPolicyMapping": {
           "type": "array",
@@ -1056,6 +1058,9 @@
         "rateLimit": {
           "$ref": "#/definitions/X-Tyk-RateLimit"
         },
+        "exchange": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-Exchange"
+        },
         "scopeCheck": {
           "$ref": "#/definitions/X-Tyk-ScopeCheck"
         }
@@ -1552,10 +1557,14 @@
       },
       "anyOf": [
         {
-          "required": ["url"]
+          "required": [
+            "url"
+          ]
         },
         {
-          "required": ["loadBalancing"]
+          "required": [
+            "loadBalancing"
+          ]
         }
       ]
     },
@@ -1618,13 +1627,24 @@
       "anyOf": [
         {
           "properties": {
-            "location": { "enum": ["header", "url-param"] }
+            "location": {
+              "enum": [
+                "header",
+                "url-param"
+              ]
+            }
           },
-          "required": ["key"]
+          "required": [
+            "key"
+          ]
         },
         {
           "properties": {
-            "location": { "enum": ["url"] }
+            "location": {
+              "enum": [
+                "url"
+              ]
+            }
           }
         }
       ]
@@ -1787,7 +1807,9 @@
         },
         "subjectClaims": {
           "type": "array",
-          "items": {"type": "string"}
+          "items": {
+            "type": "string"
+          }
         },
         "jwksURIs": {
           "type": [
@@ -1805,7 +1827,9 @@
                 "$ref": "#/definitions/X-Tyk-ReadableDuration"
               }
             },
-            "required": ["url"]
+            "required": [
+              "url"
+            ]
           }
         },
         "skipKid": {
@@ -1816,15 +1840,21 @@
         },
         "basePolicyClaims": {
           "type": "array",
-          "items": {"type": "string"}
+          "items": {
+            "type": "string"
+          }
         },
         "allowedIssuers": {
           "type": "array",
-          "items": {"type": "string"}
+          "items": {
+            "type": "string"
+          }
         },
         "allowedAudiences": {
           "type": "array",
-          "items": {"type": "string"}
+          "items": {
+            "type": "string"
+          }
         },
         "jtiValidation": {
           "type": "object",
@@ -1839,7 +1869,9 @@
         },
         "allowedSubjects": {
           "type": "array",
-          "items": {"type": "string"}
+          "items": {
+            "type": "string"
+          }
         },
         "clientBaseField": {
           "type": "string"
@@ -1878,7 +1910,11 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": ["required", "exact_match", "contains"]
+              "enum": [
+                "required",
+                "exact_match",
+                "contains"
+              ]
             },
             "allowedValues": {
               "type": "array",
@@ -1889,7 +1925,9 @@
               "default": false
             }
           },
-          "required": ["type"]
+          "required": [
+            "type"
+          ]
         }
       },
       "required": [
@@ -1997,37 +2035,162 @@
       "type": "object",
       "description": "OAuth 2.0 security scheme container.",
       "properties": {
-        "enabled":    { "type": "boolean" },
-        "header":     { "$ref": "#/definitions/X-Tyk-AuthSource" },
-        "cookie":     { "$ref": "#/definitions/X-Tyk-AuthSource" },
-        "query":      { "$ref": "#/definitions/X-Tyk-AuthSource" },
-        "scopeCheck": { "$ref": "#/definitions/X-Tyk-OAuth2-ScopeCheck" },
-        "protectedResourceMetadata": { "$ref": "#/definitions/X-Tyk-OAuth2-PRM" }
+        "enabled": {
+          "type": "boolean"
+        },
+        "header": {
+          "$ref": "#/definitions/X-Tyk-AuthSource"
+        },
+        "cookie": {
+          "$ref": "#/definitions/X-Tyk-AuthSource"
+        },
+        "query": {
+          "$ref": "#/definitions/X-Tyk-AuthSource"
+        },
+        "scopeCheck": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-ScopeCheck"
+        },
+        "tokenExchange": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-TokenExchange"
+        }
       },
-      "required": ["enabled"]
-    },
-    "X-Tyk-OAuth2-PRM": {
-      "type": "object",
-      "description": "OAuth 2.0 Protected Resource Metadata (RFC 9728) published for this API. New home for PRM; the deprecated top-level authentication.protectedResourceMetadata still works but this one wins when both are set.",
-      "properties": {
-        "enabled":              { "type": "boolean" },
-        "wellKnownPath":        { "type": "string", "description": "Path under the API listen path where the PRM document is served. Defaults to .well-known/oauth-protected-resource." },
-        "resource":             { "type": "string", "description": "Canonical resource identifier this gateway protects. Surfaced as the `resource` field of the PRM document." },
-        "authorizationServers": { "type": "array", "items": { "type": "string" }, "description": "Issuer URLs published in the PRM document. At least one entry is required for MCP-proxy APIs." },
-        "autoDeriveScopes":     { "type": "boolean", "description": "When unset or true (default), PRM `scopes_supported` is unioned at serve time with every scope referenced by any `security:` array (root, operations, MCP primitives). Set to false to advertise only the OpenAPI flows.scopes catalog." }
-      },
-      "required": ["enabled"]
+      "required": [
+        "enabled"
+      ]
     },
     "X-Tyk-OAuth2-ScopeCheck": {
       "type": "object",
       "description": "Token-side knobs for OAS-native scope enforcement. Required scopes themselves live in the OAS root security: array.",
       "properties": {
-        "enabled":        { "type": "boolean" },
-        "claimNames":     { "type": "array", "items": { "type": "string" }, "description": "Ordered list of JWT claim names to read scopes from. The gateway reads each listed claim that is present and merges all scope values into one set. Alternatives drawn from OAS root security: are checked against this merged set. Defaults to [\"scope\", \"scp\"] when unset." },
-        "separator":      { "type": "string" },
-        "scopeSource":    { "type": "string", "enum": ["operation", "global", "union"], "description": "Selects whether enforcement reads per-operation security:, root security:, or both. Defaults to \"union\"." }
+        "enabled": {
+          "type": "boolean"
+        },
+        "claimNames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Ordered list of JWT claim names to read scopes from. The gateway reads each listed claim that is present and merges all scope values into one set. Alternatives drawn from OAS root security: are checked against this merged set. Defaults to [\"scope\", \"scp\"] when unset."
+        },
+        "separator": {
+          "type": "string"
+        },
+        "scopeSource": {
+          "type": "string",
+          "enum": [
+            "operation",
+            "global",
+            "union"
+          ],
+          "description": "Selects whether enforcement reads per-operation security:, root security:, or both. Defaults to \"union\"."
+        }
       },
-      "required": ["enabled"]
+      "required": [
+        "enabled"
+      ]
+    },
+    "X-Tyk-OAuth2-TokenExchange": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "providers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/X-Tyk-OAuth2-Provider"
+          }
+        }
+      },
+      "required": [
+        "enabled"
+      ]
+    },
+    "X-Tyk-OAuth2-Provider": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "issuers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tokenEndpoint": {
+          "type": "string"
+        },
+        "clientAuth": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-ClientAuth"
+        },
+        "defaultTarget": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-DefaultTarget"
+        },
+        "timeout": {
+          "type": "string",
+          "description": "Per-call timeout for the RFC 8693 exchange request, Tyk ReadableDuration (e.g. \"100ms\", \"5s\"). Defaults to 15s when zero/unset."
+        },
+        "customParams": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Operator-supplied form parameters appended to every RFC 8693 exchange request. Reserved RFC 8693 / OAuth2 wire keys (grant_type, subject_token, audience, scope, actor_token, client_id, ...) are rejected at API-load time."
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "X-Tyk-OAuth2-ClientAuth": {
+      "type": "object",
+      "properties": {
+        "method": {
+          "type": "string",
+          "enum": [
+            "client_secret_basic",
+            "client_secret_post"
+          ]
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "clientSecret": {
+          "type": "string"
+        }
+      }
+    },
+    "X-Tyk-OAuth2-DefaultTarget": {
+      "type": "object",
+      "properties": {
+        "audience": {
+          "type": "string"
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "X-Tyk-OAuth2-Exchange": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "audience": {
+          "type": "string"
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "X-Tyk-OAuthProvider": {
       "type": "object",
@@ -2730,7 +2893,9 @@
         {
           "if": {
             "properties": {
-              "enabled": { "const": true }
+              "enabled": {
+                "const": true
+              }
             }
           },
           "then": {
@@ -2739,7 +2904,9 @@
                 "minItems": 1
               }
             },
-            "required": ["targets"]
+            "required": [
+              "targets"
+            ]
           }
         }
       ]
@@ -2758,11 +2925,21 @@
         },
         "minVersion": {
           "type": "string",
-          "enum": ["1.0", "1.1", "1.2", "1.3"]
+          "enum": [
+            "1.0",
+            "1.1",
+            "1.2",
+            "1.3"
+          ]
         },
         "maxVersion": {
           "type": "string",
-          "enum": ["1.0", "1.1", "1.2", "1.3"]
+          "enum": [
+            "1.0",
+            "1.1",
+            "1.2",
+            "1.3"
+          ]
         },
         "forceCommonNameCheck": {
           "type": "boolean"
@@ -2779,7 +2956,9 @@
           "type": "string"
         }
       },
-      "required": ["enabled"]
+      "required": [
+        "enabled"
+      ]
     },
     "X-Tyk-PreserveHostHeader": {
       "type": "object",
@@ -2874,7 +3053,7 @@
     },
     "X-Tyk-ReadableDuration": {
       "type": "string",
-      "pattern": "^(\\d+h)?(\\d+m)?(\\d+s)?(\\d+ms)?(\\d+µs)?(\\d+ns)?$"
+      "pattern": "^(\\d+h)?(\\d+m)?(\\d+s)?(\\d+ms)?(\\d+\u00b5s)?(\\d+ns)?$"
     },
     "X-Tyk-LoadBalancingTarget": {
       "type": "object",

--- a/apidef/oas/authentication.go
+++ b/apidef/oas/authentication.go
@@ -94,6 +94,10 @@ type Authentication struct {
 	// This can be used to combine any declared securitySchemes including Tyk proprietary auth methods.
 	Security [][]string `bson:"security,omitempty" json:"security,omitempty"`
 
+	// Deprecated: Use SecuritySchemes[<name>].OAuth2.ProtectedResourceMetadata instead.
+	// The new per-scheme location is the runtime source of truth; this top-level
+	// field is kept for downgrade safety and will be removed in a future major version.
+	//
 	// ProtectedResourceMetadata configures OAuth 2.0 Protected Resource Metadata (RFC 9728)
 	// for authorization server discovery. This is used by MCP clients to discover which
 	// authorization server to use for accessing the API.
@@ -103,6 +107,11 @@ type Authentication struct {
 	CertificateAuth *CertificateAuth `bson:"certificateAuth,omitempty" json:"certificateAuth,omitempty"`
 }
 
+// Deprecated: Use OAuth2PRM (under SecuritySchemes[<name>].OAuth2) instead.
+// This type backs the legacy top-level Authentication.ProtectedResourceMetadata
+// field; the new per-scheme location is the runtime source of truth and the
+// legacy block is kept only for downgrade safety.
+//
 // ProtectedResourceMetadata holds the configuration for OAuth 2.0 Protected Resource Metadata (RFC 9728).
 // It enables MCP clients to discover which authorization server protects this API resource.
 //

--- a/apidef/oas/authentication_test.go
+++ b/apidef/oas/authentication_test.go
@@ -2,6 +2,7 @@ package oas
 
 import (
 	"encoding/json"
+	"os"
 	"testing"
 	"time"
 
@@ -967,4 +968,80 @@ func TestProtectedResourceMetadata_JSON(t *testing.T) {
 		assert.NotContains(t, raw, "authorizationServers")
 		assert.NotContains(t, raw, "scopesSupported")
 	})
+}
+
+// TestProtectedResourceMetadata_SchemaMarkedDeprecated pins that every
+// x-tyk-api-gateway schema variant flags the legacy top-level PRM type
+// `X-Tyk-ProtectedResourceMetadata` as deprecated. The new home is the
+// per-scheme `securitySchemes[<name>].oauth2.protectedResourceMetadata`
+// (`X-Tyk-OAuth2-PRM`), and tooling that reads the schema needs the
+// signal to render the deprecation to operators.
+func TestProtectedResourceMetadata_SchemaMarkedDeprecated(t *testing.T) {
+	t.Parallel()
+
+	schemas := []string{
+		"schema/x-tyk-api-gateway.json",
+		"schema/x-tyk-api-gateway.strict.json",
+		"../mcp/schema/x-tyk-api-gateway.json",
+		"../streams/schema/x-tyk-api-gateway.json",
+	}
+	for _, path := range schemas {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+			data, err := os.ReadFile(path)
+			assert.NoError(t, err, "read schema")
+
+			var doc map[string]interface{}
+			assert.NoError(t, json.Unmarshal(data, &doc))
+
+			defs, ok := doc["definitions"].(map[string]interface{})
+			assert.True(t, ok, "schema must have a definitions block")
+			prm, ok := defs["X-Tyk-ProtectedResourceMetadata"].(map[string]interface{})
+			assert.True(t, ok, "schema must define X-Tyk-ProtectedResourceMetadata")
+			assert.Equal(t, true, prm["deprecated"],
+				"X-Tyk-ProtectedResourceMetadata must be marked deprecated; new home is securitySchemes[<name>].oauth2.protectedResourceMetadata")
+		})
+	}
+}
+
+// TestOAS_PRMBothBlocksRoundTrip pins that an OAS document carrying both
+// the deprecated top-level protectedResourceMetadata block and the new
+// per-scheme oauth2.protectedResourceMetadata block round-trips through
+// JSON marshal/unmarshal with both intact and with the OAuth2 master
+// switch staying disabled. This is the persistence shape the dashboard
+// writes after running the PRM auto-migration (non-destructive copy from
+// the legacy location to the new one, both kept in place for downgrade
+// safety).
+func TestOAS_PRMBothBlocksRoundTrip(t *testing.T) {
+	t.Parallel()
+	s := newOAuth2Fixture("oauth2")
+	auth := s.GetTykExtension().Server.Authentication
+	// PRM publishing is independent of the OAuth2 master switch — see
+	// TestOAuth2PRM_ServesWhenOAuth2MasterDisabled in the gateway tests.
+	auth.SecuritySchemes["oauth2"].(*OAuth2).Enabled = false
+	auth.SecuritySchemes["oauth2"].(*OAuth2).ProtectedResourceMetadata = &OAuth2PRM{
+		Enabled:              true,
+		AuthorizationServers: []string{"https://new.example.com"},
+	}
+	//nolint:staticcheck // intentional: the legacy block must round-trip alongside the new one.
+	auth.ProtectedResourceMetadata = &ProtectedResourceMetadata{
+		Enabled:              true,
+		AuthorizationServers: []string{"https://old.example.com"},
+	}
+
+	data, err := json.Marshal(s)
+	assert.NoError(t, err)
+
+	var decoded OAS
+	assert.NoError(t, json.Unmarshal(data, &decoded))
+
+	gotAuth := decoded.GetTykExtension().Server.Authentication
+	assert.NotNil(t, gotAuth.ProtectedResourceMetadata, "legacy block must survive (downgrade safety)")          //nolint:staticcheck
+	assert.Equal(t, []string{"https://old.example.com"}, gotAuth.ProtectedResourceMetadata.AuthorizationServers) //nolint:staticcheck
+	gotOAuth2 := decoded.GetTykOAuth2Config("oauth2")
+	assert.NotNil(t, gotOAuth2)
+	assert.NotNil(t, gotOAuth2.ProtectedResourceMetadata)
+	assert.Equal(t, []string{"https://new.example.com"}, gotOAuth2.ProtectedResourceMetadata.AuthorizationServers)
+	assert.False(t, gotOAuth2.Enabled,
+		"migration must not auto-enable OAuth2 authentication — only the PRM sub-block")
 }

--- a/apidef/oas/oas.go
+++ b/apidef/oas/oas.go
@@ -567,8 +567,9 @@ func (s *OAS) Validate(ctx context.Context, opts ...openapi3.ValidationOption) e
 	securityErr := s.validateSecurity()
 	compliantModeErr := s.validateCompliantModeAuthentication()
 	prmErr := s.validatePRM()
+	oauth2Err := s.ValidateOAuth2Schemes()
 
-	return errors.Join(validationErr, securityErr, compliantModeErr, prmErr)
+	return errors.Join(validationErr, securityErr, compliantModeErr, prmErr, oauth2Err)
 }
 
 // Normalize converts the OAS api to a normalized state.
@@ -758,13 +759,14 @@ func (s *OAS) ValidateForMCP(ctx context.Context, opts ...openapi3.ValidationOpt
 	validationErr := s.T.Validate(ctx, validationOpts...)
 	securityErr := s.validateSecurity()
 	compliantModeErr := s.validateCompliantModeAuthentication()
+	oauth2Err := s.ValidateOAuth2Schemes()
 
 	var prmErr error
 	if tykAuth := s.getTykAuthentication(); tykAuth != nil {
 		prmErr = tykAuth.ProtectedResourceMetadata.Validate(true)
 	}
 
-	return errors.Join(validationErr, securityErr, compliantModeErr, prmErr)
+	return errors.Join(validationErr, securityErr, compliantModeErr, prmErr, oauth2Err)
 }
 
 // APIDef holds both OAS and Classic forms of an API definition.

--- a/apidef/oas/oauth2.go
+++ b/apidef/oas/oauth2.go
@@ -248,33 +248,28 @@ type OAuth2DefaultTarget struct {
 //
 // Resolution chain at request time (most-specific wins):
 //
-//  1. ex.Scopes (explicit per-op list) — used as-is.
+//  1. ex.Enabled == true && len(Scopes) > 0 — explicit per-op list.
 //  2. ex.Enabled == true && len(Scopes) == 0 — inferred from the
 //     matched operation's `security:` requirement (the oauth2 scope
 //     list the inbound check enforces). Kills the duplication for the
 //     "exchange asks for the same authority the caller proved" case
 //     (RFC 8693 §4.5.5).
-//  3. provider.DefaultTarget.Scopes — fallback when neither above
-//     applies. Audience is resolved the same way (op override →
-//     provider default).
+//  3. provider.DefaultTarget — fallback when no per-op block is active.
+//     Audience is resolved the same way (op override → provider default).
 //
-// Enabled is *bool to preserve back-compat:
-//   - nil (field absent in JSON) — pre-existing behavior: explicit
-//     Audience / Scopes are used; no inference.
-//   - true — opt in to the inferred-scopes fallback above.
-//   - false — block is inactive; resolution falls through to the
-//     provider's defaultTarget.
+// Enabled must be explicitly set to true to activate the block.
+// Absent (nil) or false both mean inactive, consistent with all other
+// per-operation middleware in Tyk.
 type OAuth2Exchange struct {
 	Enabled  *bool    `bson:"enabled,omitempty" json:"enabled,omitempty"`
 	Audience string   `bson:"audience,omitempty" json:"audience,omitempty"`
 	Scopes   []string `bson:"scopes,omitempty" json:"scopes,omitempty"`
 }
 
-// IsActive reports whether this per-op exchange block should
-// participate in resolution. A block is active unless the operator
-// explicitly set Enabled=false.
+// IsActive reports whether this per-op exchange block is active.
+// Requires explicit Enabled=true; nil or false both mean inactive.
 func (e *OAuth2Exchange) IsActive() bool {
-	return e != nil && (e.Enabled == nil || *e.Enabled)
+	return e != nil && e.Enabled != nil && *e.Enabled
 }
 
 // InfersScopesFromSecurity reports whether the block opts into the

--- a/apidef/oas/oauth2.go
+++ b/apidef/oas/oauth2.go
@@ -169,19 +169,14 @@ type OAuth2TokenExchange struct {
 	Providers []OAuth2TokenExchangeProvider `bson:"providers,omitempty" json:"providers,omitempty"`
 }
 
-// OAuth2TokenExchangeProvider configures a single IdP provider entry.
-// Multi-provider per API is supported via a list of entries; selection
-// at request time is by inbound `iss` claim match against Issuers.
+// OAuth2TokenExchangeProvider configures one IdP entry. Provider selection
+// is by inbound `iss` claim match against Issuers; must be unique across Providers.
 type OAuth2TokenExchangeProvider struct {
-	// Name is an operator-chosen identifier for this provider. Used in
-	// audit logs. Must be non-empty and unique within Providers.
+	// Name is an operator-chosen identifier used in audit logs. Unique within Providers.
 	Name string `bson:"name" json:"name"`
 
-	// Issuers is the set of inbound token `iss` values routed to this
-	// provider. Multi-realm Keycloak, multi-tenant Auth0, and
-	// URL-synonym deployments all benefit from listing several issuers
-	// on one provider. Issuers must be unique across the whole
-	// Providers list so dispatch is deterministic.
+	// Issuers is the set of inbound token `iss` values routed to this provider.
+	// Must not overlap with issuers on other providers — dispatch would be non-deterministic.
 	Issuers []string `bson:"issuers,omitempty" json:"issuers,omitempty"`
 
 	// TokenEndpoint is the IdP token endpoint where Tyk POSTs the
@@ -197,31 +192,18 @@ type OAuth2TokenExchangeProvider struct {
 	// when the matched operation has no per-op exchange override.
 	DefaultTarget *OAuth2DefaultTarget `bson:"defaultTarget,omitempty" json:"defaultTarget,omitempty"`
 
-	// Timeout caps each HTTP call to this provider's tokenEndpoint.
-	// Format is Tyk's standard ReadableDuration ("100ms", "5s", "30s").
-	// When zero/unset the runtime applies a 15-second default.
+	// Timeout caps each call to TokenEndpoint. Uses Tyk's ReadableDuration ("5s", "100ms").
+	// Defaults to 15s when unset.
 	Timeout tyktime.ReadableDuration `bson:"timeout,omitempty" json:"timeout,omitempty"`
 
-	// CustomParams are operator-supplied form parameters appended to
-	// every RFC 8693 exchange request to this provider's tokenEndpoint.
-	// Useful for IdP-specific extensions like Keycloak Identity
-	// Brokering's `requested_issuer`.
-	//
-	// Keys that would shadow gateway-managed RFC 8693 / OAuth2 wire
-	// values (grant_type, subject_token, audience, scope, …) are
-	// rejected at API-load time — see ValidateOAuth2Schemes and
-	// oauth2ReservedExchangeFormKeys.
-	//
-	// Values accept env://, secrets://, vault://, consul:// prefixes
-	// resolved at gateway runtime.
+	// CustomParams are extra form parameters appended to the exchange request.
+	// Keys in oauth2ReservedExchangeFormKeys are rejected at API-load time.
+	// Values accept env://, secrets://, vault://, consul:// prefixes.
 	CustomParams map[string]string `bson:"customParams,omitempty" json:"customParams,omitempty"`
 }
 
-// OAuth2ClientAuth describes how Tyk authenticates as a confidential
-// client to the IdP token endpoint.
-//
-// ClientSecret accepts env://, secrets://, vault://, consul:// prefixes
-// resolved at gateway runtime via gateway/api_definition.go.
+// OAuth2ClientAuth describes how Tyk authenticates to the IdP token endpoint.
+// ClientSecret accepts env://, secrets://, vault://, consul:// prefixes.
 type OAuth2ClientAuth struct {
 	// Method selects the client-auth scheme. Supported values:
 	//   - "client_secret_basic" (RFC 6749 §2.3.1) — credentials in the
@@ -235,46 +217,30 @@ type OAuth2ClientAuth struct {
 	ClientSecret string `bson:"clientSecret,omitempty" json:"clientSecret,omitempty"`
 }
 
-// OAuth2DefaultTarget is the fallback (audience, scopes) the exchange
-// uses when an operation omits its own exchange.audience or
-// exchange.scopes.
+// OAuth2DefaultTarget is the fallback audience and scopes when no per-op override is set.
 type OAuth2DefaultTarget struct {
 	Audience string   `bson:"audience,omitempty" json:"audience,omitempty"`
 	Scopes   []string `bson:"scopes,omitempty" json:"scopes,omitempty"`
 }
 
-// OAuth2Exchange is the per-operation override for the outbound
-// exchanged token's audience and scopes.
+// OAuth2Exchange is the per-operation audience/scopes override for token exchange.
 //
-// Resolution chain at request time (most-specific wins):
-//
-//  1. ex.Enabled == true && len(Scopes) > 0 — explicit per-op list.
-//  2. ex.Enabled == true && len(Scopes) == 0 — inferred from the
-//     matched operation's `security:` requirement (the oauth2 scope
-//     list the inbound check enforces). Kills the duplication for the
-//     "exchange asks for the same authority the caller proved" case
-//     (RFC 8693 §4.5.5).
-//  3. provider.DefaultTarget — fallback when no per-op block is active.
-//     Audience is resolved the same way (op override → provider default).
-//
-// Enabled must be explicitly set to true to activate the block.
-// Absent (nil) or false both mean inactive, consistent with all other
-// per-operation middleware in Tyk.
+// Scope resolution (most-specific wins):
+//  1. Enabled=true, Scopes non-empty — explicit per-op list.
+//  2. Enabled=true, Scopes empty — inferred from the operation's security: requirement (RFC 8693 §4.5.5).
+//  3. provider.DefaultTarget — used when no per-op block is active (Enabled nil or false).
 type OAuth2Exchange struct {
 	Enabled  *bool    `bson:"enabled,omitempty" json:"enabled,omitempty"`
 	Audience string   `bson:"audience,omitempty" json:"audience,omitempty"`
 	Scopes   []string `bson:"scopes,omitempty" json:"scopes,omitempty"`
 }
 
-// IsActive reports whether this per-op exchange block is active.
-// Requires explicit Enabled=true; nil or false both mean inactive.
+// IsActive reports whether this per-op exchange block is active (requires explicit Enabled=true).
 func (e *OAuth2Exchange) IsActive() bool {
 	return e != nil && e.Enabled != nil && *e.Enabled
 }
 
-// InfersScopesFromSecurity reports whether the block opts into the
-// "infer scopes from inbound `security:` requirement when Scopes is
-// empty" fallback. Requires explicit Enabled=true.
+// InfersScopesFromSecurity reports whether the block uses the inbound security: scopes as fallback.
 func (e *OAuth2Exchange) InfersScopesFromSecurity() bool {
 	return e != nil && e.Enabled != nil && *e.Enabled && len(e.Scopes) == 0
 }
@@ -286,29 +252,22 @@ const (
 	OAuth2ScopeSourceUnion     = "union"
 )
 
-// Wire-protocol constants used in WWW-Authenticate challenges and JSON
-// failure bodies emitted by the oauth2 middleware, plus RFC 8693 form
-// keys / grant URNs / token-type URNs used by the token-exchange
-// runtime in internal/oauth2common and
-// ee/middleware/oauth2tokenexchange. apidef/oas owns these because it
-// is the upstream-most package — those packages import apidef/oas,
-// which forbids the reverse arrow.
+// Wire-protocol constants for WWW-Authenticate challenges, JSON error bodies,
+// and RFC 8693 form fields. Owned here so downstream packages (internal/oauth2common,
+// ee/middleware/oauth2tokenexchange) can import them without a circular dependency.
 const (
 	// RFC 6750 §3.1 error codes.
 	OAuth2ErrInsufficientScope = "insufficient_scope"
 	OAuth2ErrInvalidToken      = "invalid_token"
 
-	// Token-exchange and provider-dispatch error codes (used in
-	// WWW-Authenticate challenges and JSON bodies).
+	// Token-exchange error codes.
 	OAuth2ErrExchangeFailed     = "exchange_failed"
 	OAuth2ErrNoMatchingProvider = "no_matching_provider"
 	OAuth2ErrMisconfigured      = "misconfigured"
 
-	// OAuth2AuthSchemeBearer is the authorization scheme prefix per
-	// RFC 6750 §2.1.
-	OAuth2AuthSchemeBearer = "Bearer"
+	OAuth2AuthSchemeBearer = "Bearer" // RFC 6750 §2.1
 
-	// RFC 8693 token-exchange + OAuth2 client-auth form keys.
+	// RFC 8693 form keys.
 	OAuth2FormGrantType           = "grant_type"
 	OAuth2FormSubjectToken        = "subject_token"
 	OAuth2FormSubjectTokenType    = "subject_token_type"
@@ -323,22 +282,30 @@ const (
 	OAuth2FormClientAssertion     = "client_assertion"
 	OAuth2FormClientAssertionType = "client_assertion_type"
 
-	// RFC 8693 grant URN.
+	// RFC 8693 URNs.
 	OAuth2GrantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange"
-
-	// RFC 8693 token-type URNs.
-	OAuth2TokenTypeAccessToken = "urn:ietf:params:oauth:token-type:access_token"
-	OAuth2TokenTypeJWT         = "urn:ietf:params:oauth:token-type:jwt"
+	OAuth2TokenTypeAccessToken   = "urn:ietf:params:oauth:token-type:access_token"
+	OAuth2TokenTypeJWT           = "urn:ietf:params:oauth:token-type:jwt"
 
 	// OAuth2ClientAuth.Method values.
 	OAuth2ClientAuthBasic = "client_secret_basic"
 	OAuth2ClientAuthPost  = "client_secret_post"
+
+	// JWT standard claim key.
+	OAuth2ClaimIss = "iss"
+
+	// OAuth2 response / WWW-Authenticate field names.
+	OAuth2FieldError            = "error"
+	OAuth2FieldErrorDescription = "error_description"
+	OAuth2FieldResourceMetadata = "resource_metadata"
+
+	// Tyk-extended IdP error body fields.
+	OAuth2FieldIdpError            = "idp_error"
+	OAuth2FieldIdpErrorDescription = "idp_error_description"
 )
 
-// oauth2ReservedExchangeFormKeys are the RFC 8693 / OAuth2 client-auth
-// form parameters Tyk owns on the wire. Operators cannot override them
-// via Provider.CustomParams — doing so would break the standard wire
-// shape and could be used to forge subject_token / audience values.
+// oauth2ReservedExchangeFormKeys are RFC 8693 / OAuth2 form parameters Tyk
+// sets itself. CustomParams may not shadow them — it would corrupt the wire shape.
 var oauth2ReservedExchangeFormKeys = map[string]struct{}{
 	OAuth2FormGrantType:           {},
 	OAuth2FormSubjectToken:        {},
@@ -355,19 +322,9 @@ var oauth2ReservedExchangeFormKeys = map[string]struct{}{
 	OAuth2FormClientAssertionType: {},
 }
 
-// ValidateOAuth2Schemes enforces invariants on every configured
-// new-style oauth2 scheme. Called at API-load time so misconfigured
-// definitions fail loud at startup rather than at first request.
-//
-// Token-exchange invariants:
-//   - When tokenExchange.enabled is true, providers[] must be non-empty.
-//   - Provider names are non-empty and unique within the scheme.
-//   - Provider.CustomParams cannot shadow reserved wire keys.
-//   - Issuers must not overlap across providers — dispatch by inbound
-//     `iss` would otherwise be non-deterministic.
-//   - Every provider has a non-empty tokenEndpoint and a non-empty
-//     clientAuth.clientId; an empty row at save time indicates the
-//     operator forgot to fill it in.
+// ValidateOAuth2Schemes enforces token-exchange invariants across all configured
+// oauth2 schemes: non-empty providers when enabled, unique names, no overlapping
+// issuers within a scheme, non-empty tokenEndpoint and clientId, no reserved customParams keys.
 func (s *OAS) ValidateOAuth2Schemes() error {
 	tykAuth := s.getTykAuthentication()
 	if tykAuth == nil || tykAuth.SecuritySchemes == nil {

--- a/apidef/oas/oauth2.go
+++ b/apidef/oas/oauth2.go
@@ -1,9 +1,12 @@
 package oas
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/getkin/kin-openapi/openapi3"
+
+	tyktime "github.com/TykTechnologies/tyk/internal/time"
 )
 
 // OAuth2 is the container for the OAS-native OAuth 2.0 security scheme.
@@ -30,6 +33,12 @@ type OAuth2 struct {
 	// New home for PRM; wins over the deprecated top-level
 	// authentication.protectedResourceMetadata when both are set.
 	ProtectedResourceMetadata *OAuth2PRM `bson:"protectedResourceMetadata,omitempty" json:"protectedResourceMetadata,omitempty"`
+
+	// TokenExchange enables RFC 8693 token exchange. Inbound user
+	// tokens are exchanged at the matched provider's IdP for a
+	// backend-audienced token before being forwarded upstream. See
+	// OAuth2TokenExchange for the full configuration contract.
+	TokenExchange *OAuth2TokenExchange `bson:"tokenExchange,omitempty" json:"tokenExchange,omitempty"`
 }
 
 // OAuth2PRM configures the RFC 9728 Protected Resource Metadata
@@ -142,6 +151,139 @@ type ScopeCheck struct {
 	Enabled bool `bson:"enabled" json:"enabled"`
 }
 
+// OAuth2TokenExchange holds RFC 8693 token exchange configuration for
+// this scheme. When Enabled, the gateway dispatches inbound tokens to
+// one of the configured providers based on the inbound `iss` claim and
+// posts an RFC 8693 token-exchange request to that provider's
+// tokenEndpoint. The exchanged token replaces the Authorization header
+// on the request before it is forwarded upstream.
+type OAuth2TokenExchange struct {
+	// Enabled is the master switch for token exchange on this scheme.
+	// When false, the block is inert.
+	Enabled bool `bson:"enabled" json:"enabled"`
+
+	// Providers is the list of IdP entries this scheme can exchange
+	// against. Provider selection at request time is by inbound `iss`
+	// claim match against Providers[i].Issuers — see SelectExchangeProvider
+	// in internal/oauth2common.
+	Providers []OAuth2TokenExchangeProvider `bson:"providers,omitempty" json:"providers,omitempty"`
+}
+
+// OAuth2TokenExchangeProvider configures a single IdP provider entry.
+// Multi-provider per API is supported via a list of entries; selection
+// at request time is by inbound `iss` claim match against Issuers.
+type OAuth2TokenExchangeProvider struct {
+	// Name is an operator-chosen identifier for this provider. Used in
+	// audit logs. Must be non-empty and unique within Providers.
+	Name string `bson:"name" json:"name"`
+
+	// Issuers is the set of inbound token `iss` values routed to this
+	// provider. Multi-realm Keycloak, multi-tenant Auth0, and
+	// URL-synonym deployments all benefit from listing several issuers
+	// on one provider. Issuers must be unique across the whole
+	// Providers list so dispatch is deterministic.
+	Issuers []string `bson:"issuers,omitempty" json:"issuers,omitempty"`
+
+	// TokenEndpoint is the IdP token endpoint where Tyk POSTs the
+	// RFC 8693 exchange request. Must accept
+	// `grant_type=urn:ietf:params:oauth:grant-type:token-exchange`.
+	TokenEndpoint string `bson:"tokenEndpoint,omitempty" json:"tokenEndpoint,omitempty"`
+
+	// ClientAuth selects how Tyk authenticates as a confidential
+	// client to the IdP on the exchange call.
+	ClientAuth *OAuth2ClientAuth `bson:"clientAuth,omitempty" json:"clientAuth,omitempty"`
+
+	// DefaultTarget is the fallback target (audience + scopes) used
+	// when the matched operation has no per-op exchange override.
+	DefaultTarget *OAuth2DefaultTarget `bson:"defaultTarget,omitempty" json:"defaultTarget,omitempty"`
+
+	// Timeout caps each HTTP call to this provider's tokenEndpoint.
+	// Format is Tyk's standard ReadableDuration ("100ms", "5s", "30s").
+	// When zero/unset the runtime applies a 15-second default.
+	Timeout tyktime.ReadableDuration `bson:"timeout,omitempty" json:"timeout,omitempty"`
+
+	// CustomParams are operator-supplied form parameters appended to
+	// every RFC 8693 exchange request to this provider's tokenEndpoint.
+	// Useful for IdP-specific extensions like Keycloak Identity
+	// Brokering's `requested_issuer`.
+	//
+	// Keys that would shadow gateway-managed RFC 8693 / OAuth2 wire
+	// values (grant_type, subject_token, audience, scope, …) are
+	// rejected at API-load time — see ValidateOAuth2Schemes and
+	// oauth2ReservedExchangeFormKeys.
+	//
+	// Values accept env://, secrets://, vault://, consul:// prefixes
+	// resolved at gateway runtime.
+	CustomParams map[string]string `bson:"customParams,omitempty" json:"customParams,omitempty"`
+}
+
+// OAuth2ClientAuth describes how Tyk authenticates as a confidential
+// client to the IdP token endpoint.
+//
+// ClientSecret accepts env://, secrets://, vault://, consul:// prefixes
+// resolved at gateway runtime via gateway/api_definition.go.
+type OAuth2ClientAuth struct {
+	// Method selects the client-auth scheme. Supported values:
+	//   - "client_secret_basic" (RFC 6749 §2.3.1) — credentials in the
+	//     HTTP Authorization header.
+	//   - "client_secret_post" (RFC 6749 §2.3.1) — credentials in the
+	//     form body.
+	// Empty string defaults to client_secret_basic.
+	Method   string `bson:"method,omitempty" json:"method,omitempty"`
+	ClientID string `bson:"clientId,omitempty" json:"clientId,omitempty"`
+	// ClientSecret accepts env://, secrets://, vault://, consul:// prefixes.
+	ClientSecret string `bson:"clientSecret,omitempty" json:"clientSecret,omitempty"`
+}
+
+// OAuth2DefaultTarget is the fallback (audience, scopes) the exchange
+// uses when an operation omits its own exchange.audience or
+// exchange.scopes.
+type OAuth2DefaultTarget struct {
+	Audience string   `bson:"audience,omitempty" json:"audience,omitempty"`
+	Scopes   []string `bson:"scopes,omitempty" json:"scopes,omitempty"`
+}
+
+// OAuth2Exchange is the per-operation override for the outbound
+// exchanged token's audience and scopes.
+//
+// Resolution chain at request time (most-specific wins):
+//
+//  1. ex.Scopes (explicit per-op list) — used as-is.
+//  2. ex.Enabled == true && len(Scopes) == 0 — inferred from the
+//     matched operation's `security:` requirement (the oauth2 scope
+//     list the inbound check enforces). Kills the duplication for the
+//     "exchange asks for the same authority the caller proved" case
+//     (RFC 8693 §4.5.5).
+//  3. provider.DefaultTarget.Scopes — fallback when neither above
+//     applies. Audience is resolved the same way (op override →
+//     provider default).
+//
+// Enabled is *bool to preserve back-compat:
+//   - nil (field absent in JSON) — pre-existing behavior: explicit
+//     Audience / Scopes are used; no inference.
+//   - true — opt in to the inferred-scopes fallback above.
+//   - false — block is inactive; resolution falls through to the
+//     provider's defaultTarget.
+type OAuth2Exchange struct {
+	Enabled  *bool    `bson:"enabled,omitempty" json:"enabled,omitempty"`
+	Audience string   `bson:"audience,omitempty" json:"audience,omitempty"`
+	Scopes   []string `bson:"scopes,omitempty" json:"scopes,omitempty"`
+}
+
+// IsActive reports whether this per-op exchange block should
+// participate in resolution. A block is active unless the operator
+// explicitly set Enabled=false.
+func (e *OAuth2Exchange) IsActive() bool {
+	return e != nil && (e.Enabled == nil || *e.Enabled)
+}
+
+// InfersScopesFromSecurity reports whether the block opts into the
+// "infer scopes from inbound `security:` requirement when Scopes is
+// empty" fallback. Requires explicit Enabled=true.
+func (e *OAuth2Exchange) InfersScopesFromSecurity() bool {
+	return e != nil && e.Enabled != nil && *e.Enabled && len(e.Scopes) == 0
+}
+
 // ScopeSource constants for OAuth2ScopeCheck.ScopeSource.
 const (
 	OAuth2ScopeSourceOperation = "operation"
@@ -150,21 +292,145 @@ const (
 )
 
 // Wire-protocol constants used in WWW-Authenticate challenges and JSON
-// failure bodies emitted by the oauth2 middleware.
+// failure bodies emitted by the oauth2 middleware, plus RFC 8693 form
+// keys / grant URNs / token-type URNs used by the token-exchange
+// runtime in internal/oauth2common and
+// ee/middleware/oauth2tokenexchange. apidef/oas owns these because it
+// is the upstream-most package — those packages import apidef/oas,
+// which forbids the reverse arrow.
 const (
-	// OAuth2ErrInsufficientScope is the RFC 6750 §3.1 error code
-	// returned when the token authenticated but lacks scopes required
-	// by the request.
+	// RFC 6750 §3.1 error codes.
 	OAuth2ErrInsufficientScope = "insufficient_scope"
+	OAuth2ErrInvalidToken      = "invalid_token"
 
-	// OAuth2ErrInvalidToken is the RFC 6750 §3.1 error code used when
-	// the token cannot be parsed or is otherwise unusable.
-	OAuth2ErrInvalidToken = "invalid_token"
+	// Token-exchange and provider-dispatch error codes (used in
+	// WWW-Authenticate challenges and JSON bodies).
+	OAuth2ErrExchangeFailed     = "exchange_failed"
+	OAuth2ErrNoMatchingProvider = "no_matching_provider"
+	OAuth2ErrMisconfigured      = "misconfigured"
 
 	// OAuth2AuthSchemeBearer is the authorization scheme prefix per
 	// RFC 6750 §2.1.
 	OAuth2AuthSchemeBearer = "Bearer"
+
+	// RFC 8693 token-exchange + OAuth2 client-auth form keys.
+	OAuth2FormGrantType           = "grant_type"
+	OAuth2FormSubjectToken        = "subject_token"
+	OAuth2FormSubjectTokenType    = "subject_token_type"
+	OAuth2FormRequestedTokenType  = "requested_token_type"
+	OAuth2FormAudience            = "audience"
+	OAuth2FormResource            = "resource"
+	OAuth2FormScope               = "scope"
+	OAuth2FormActorToken          = "actor_token"
+	OAuth2FormActorTokenType      = "actor_token_type"
+	OAuth2FormClientID            = "client_id"
+	OAuth2FormClientSecret        = "client_secret"
+	OAuth2FormClientAssertion     = "client_assertion"
+	OAuth2FormClientAssertionType = "client_assertion_type"
+
+	// RFC 8693 grant URN.
+	OAuth2GrantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange"
+
+	// RFC 8693 token-type URNs.
+	OAuth2TokenTypeAccessToken = "urn:ietf:params:oauth:token-type:access_token"
+	OAuth2TokenTypeJWT         = "urn:ietf:params:oauth:token-type:jwt"
+
+	// OAuth2ClientAuth.Method values.
+	OAuth2ClientAuthBasic = "client_secret_basic"
+	OAuth2ClientAuthPost  = "client_secret_post"
 )
+
+// oauth2ReservedExchangeFormKeys are the RFC 8693 / OAuth2 client-auth
+// form parameters Tyk owns on the wire. Operators cannot override them
+// via Provider.CustomParams — doing so would break the standard wire
+// shape and could be used to forge subject_token / audience values.
+var oauth2ReservedExchangeFormKeys = map[string]struct{}{
+	OAuth2FormGrantType:           {},
+	OAuth2FormSubjectToken:        {},
+	OAuth2FormSubjectTokenType:    {},
+	OAuth2FormRequestedTokenType:  {},
+	OAuth2FormAudience:            {},
+	OAuth2FormResource:            {},
+	OAuth2FormScope:               {},
+	OAuth2FormActorToken:          {},
+	OAuth2FormActorTokenType:      {},
+	OAuth2FormClientID:            {},
+	OAuth2FormClientSecret:        {},
+	OAuth2FormClientAssertion:     {},
+	OAuth2FormClientAssertionType: {},
+}
+
+// ValidateOAuth2Schemes enforces invariants on every configured
+// new-style oauth2 scheme. Called at API-load time so misconfigured
+// definitions fail loud at startup rather than at first request.
+//
+// Token-exchange invariants:
+//   - When tokenExchange.enabled is true, providers[] must be non-empty.
+//   - Provider names are non-empty and unique within the scheme.
+//   - Provider.CustomParams cannot shadow reserved wire keys.
+//   - Issuers must not overlap across providers — dispatch by inbound
+//     `iss` would otherwise be non-deterministic.
+//   - Every provider has a non-empty tokenEndpoint and a non-empty
+//     clientAuth.clientId; an empty row at save time indicates the
+//     operator forgot to fill it in.
+func (s *OAS) ValidateOAuth2Schemes() error {
+	tykAuth := s.getTykAuthentication()
+	if tykAuth == nil || tykAuth.SecuritySchemes == nil {
+		return nil
+	}
+	for name, scheme := range tykAuth.SecuritySchemes {
+		cfg := asOAuth2Scheme(scheme)
+		if cfg == nil || cfg.IsEmpty() {
+			continue
+		}
+		if err := validateOAuth2TokenExchange(name, cfg.TokenExchange); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateOAuth2TokenExchange(schemeName string, te *OAuth2TokenExchange) error {
+	if te == nil || !te.Enabled {
+		return nil
+	}
+	if len(te.Providers) == 0 {
+		return fmt.Errorf("oauth2 scheme %q: tokenExchange.enabled is true but providers[] is empty", schemeName)
+	}
+	seenNames := make(map[string]struct{}, len(te.Providers))
+	issuerOwner := make(map[string]string, len(te.Providers))
+	for i := range te.Providers {
+		p := &te.Providers[i]
+		if p.Name == "" {
+			return fmt.Errorf("oauth2 scheme %q: tokenExchange.providers[%d].name is required", schemeName, i)
+		}
+		if _, dup := seenNames[p.Name]; dup {
+			return fmt.Errorf("oauth2 scheme %q: duplicate tokenExchange.provider name %q", schemeName, p.Name)
+		}
+		seenNames[p.Name] = struct{}{}
+		if p.TokenEndpoint == "" {
+			return fmt.Errorf("oauth2 scheme %q: tokenExchange.provider %q has empty tokenEndpoint", schemeName, p.Name)
+		}
+		if p.ClientAuth == nil || p.ClientAuth.ClientID == "" {
+			return fmt.Errorf("oauth2 scheme %q: tokenExchange.provider %q has empty clientAuth.clientId", schemeName, p.Name)
+		}
+		for _, iss := range p.Issuers {
+			if iss == "" {
+				continue
+			}
+			if owner, dup := issuerOwner[iss]; dup {
+				return fmt.Errorf("oauth2 scheme %q: duplicate issuer %q configured on tokenExchange.providers %q and %q", schemeName, iss, owner, p.Name)
+			}
+			issuerOwner[iss] = p.Name
+		}
+		for key := range p.CustomParams {
+			if _, reserved := oauth2ReservedExchangeFormKeys[key]; reserved {
+				return fmt.Errorf("oauth2 scheme %q: tokenExchange.provider %q customParams cannot override reserved RFC 8693 wire key %q", schemeName, p.Name, key)
+			}
+		}
+	}
+	return nil
+}
 
 // HasContent reports whether the OAuth2 block carries operator
 // configuration. The master Enabled toggle qualifies, as does any
@@ -178,7 +444,7 @@ func (o *OAuth2) HasContent() bool {
 	if o.Enabled {
 		return true
 	}
-	return o.ScopeCheck != nil || o.ProtectedResourceMetadata != nil
+	return o.ScopeCheck != nil || o.ProtectedResourceMetadata != nil || o.TokenExchange != nil
 }
 
 // IsEmpty is the inverse of HasContent. Used at fill time to decide
@@ -267,6 +533,8 @@ func mapHasOAuth2SubBlock(m map[string]interface{}) bool {
 var oauth2SubBlockKeys = []string{
 	"scopeCheck",
 	"protectedResourceMetadata",
+	"tokenExchange",
+	// "introspection"             — TT-17187 (Story 10)
 }
 
 // fillOAuth2OASScheme ensures an OAS Components security-scheme entry

--- a/apidef/oas/oauth2_token_exchange_test.go
+++ b/apidef/oas/oauth2_token_exchange_test.go
@@ -1,0 +1,307 @@
+package oas
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOAuth2_HasContentRecognisesTokenExchange(t *testing.T) {
+	o := &OAuth2{TokenExchange: &OAuth2TokenExchange{Enabled: true}}
+	assert.True(t, o.HasContent())
+
+	o = &OAuth2{}
+	assert.False(t, o.HasContent())
+}
+
+func TestOAuth2TokenExchange_RoundTripPreservesAllFields(t *testing.T) {
+	te := &OAuth2TokenExchange{
+		Enabled: true,
+		Providers: []OAuth2TokenExchangeProvider{
+			{
+				Name:          "primary",
+				Issuers:       []string{"https://idp.example.com", "https://idp-realm-2.example.com"},
+				TokenEndpoint: "https://idp.example.com/oauth/token",
+				ClientAuth: &OAuth2ClientAuth{
+					Method:       OAuth2ClientAuthBasic,
+					ClientID:     "tyk-gateway",
+					ClientSecret: "vault://kv/tyk/exchange",
+				},
+				DefaultTarget: &OAuth2DefaultTarget{
+					Audience: "https://upstream.example.com",
+					Scopes:   []string{"read:billing", "write:billing"},
+				},
+				CustomParams: map[string]string{"requested_issuer": "broker"},
+			},
+		},
+	}
+
+	b, err := json.Marshal(te)
+	require.NoError(t, err)
+
+	var out OAuth2TokenExchange
+	require.NoError(t, json.Unmarshal(b, &out))
+
+	require.Len(t, out.Providers, 1)
+	p := out.Providers[0]
+	assert.Equal(t, "primary", p.Name)
+	assert.Equal(t, []string{"https://idp.example.com", "https://idp-realm-2.example.com"}, p.Issuers)
+	assert.Equal(t, "https://idp.example.com/oauth/token", p.TokenEndpoint)
+	require.NotNil(t, p.ClientAuth)
+	assert.Equal(t, OAuth2ClientAuthBasic, p.ClientAuth.Method)
+	assert.Equal(t, "tyk-gateway", p.ClientAuth.ClientID)
+	assert.Equal(t, "vault://kv/tyk/exchange", p.ClientAuth.ClientSecret)
+	require.NotNil(t, p.DefaultTarget)
+	assert.Equal(t, "https://upstream.example.com", p.DefaultTarget.Audience)
+	assert.Equal(t, []string{"read:billing", "write:billing"}, p.DefaultTarget.Scopes)
+	assert.Equal(t, "broker", p.CustomParams["requested_issuer"])
+}
+
+func TestOAuth2TokenExchange_OmitEmpty(t *testing.T) {
+	te := &OAuth2TokenExchange{}
+	b, err := json.Marshal(te)
+	require.NoError(t, err)
+	// `enabled` is always emitted (master toggle), but providers must not appear.
+	assert.JSONEq(t, `{"enabled":false}`, string(b))
+}
+
+func TestOAuth2TokenExchange_TwoProvidersPreserveOrder(t *testing.T) {
+	te := &OAuth2TokenExchange{
+		Enabled: true,
+		Providers: []OAuth2TokenExchangeProvider{
+			{Name: "primary", Issuers: []string{"https://primary"}, TokenEndpoint: "https://primary/token", ClientAuth: &OAuth2ClientAuth{ClientID: "p"}},
+			{Name: "alt", Issuers: []string{"https://alt"}, TokenEndpoint: "https://alt/token", ClientAuth: &OAuth2ClientAuth{ClientID: "a"}},
+		},
+	}
+	b, err := json.Marshal(te)
+	require.NoError(t, err)
+
+	var out OAuth2TokenExchange
+	require.NoError(t, json.Unmarshal(b, &out))
+
+	require.Len(t, out.Providers, 2)
+	assert.Equal(t, "primary", out.Providers[0].Name)
+	assert.Equal(t, "alt", out.Providers[1].Name)
+}
+
+func TestOperation_RoundTripJSONPreservesExchange(t *testing.T) {
+	enabled := true
+	op := &Operation{Exchange: &OAuth2Exchange{
+		Enabled:  &enabled,
+		Audience: "https://upstream",
+		Scopes:   []string{"users:read"},
+	}}
+	b, err := json.Marshal(op)
+	require.NoError(t, err)
+
+	var out Operation
+	require.NoError(t, json.Unmarshal(b, &out))
+
+	require.NotNil(t, out.Exchange)
+	require.NotNil(t, out.Exchange.Enabled)
+	assert.True(t, *out.Exchange.Enabled)
+	assert.Equal(t, "https://upstream", out.Exchange.Audience)
+	assert.Equal(t, []string{"users:read"}, out.Exchange.Scopes)
+}
+
+func TestOAuth2Exchange_IsActive(t *testing.T) {
+	cases := []struct {
+		name string
+		ex   *OAuth2Exchange
+		want bool
+	}{
+		{"nil", nil, false},
+		{"absent enabled defaults to active", &OAuth2Exchange{}, true},
+		{"explicit true", &OAuth2Exchange{Enabled: boolPtr(true)}, true},
+		{"explicit false", &OAuth2Exchange{Enabled: boolPtr(false)}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.ex.IsActive())
+		})
+	}
+}
+
+func TestOAuth2Exchange_InfersScopesFromSecurity(t *testing.T) {
+	cases := []struct {
+		name string
+		ex   *OAuth2Exchange
+		want bool
+	}{
+		{"nil block", nil, false},
+		{"enabled absent — inference off", &OAuth2Exchange{}, false},
+		{"explicit true + empty scopes — infer", &OAuth2Exchange{Enabled: boolPtr(true)}, true},
+		{"explicit true + non-empty scopes — no infer", &OAuth2Exchange{Enabled: boolPtr(true), Scopes: []string{"x"}}, false},
+		{"explicit false — no infer regardless of scopes", &OAuth2Exchange{Enabled: boolPtr(false)}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.ex.InfersScopesFromSecurity())
+		})
+	}
+}
+
+func TestValidateOAuth2Schemes_DisabledExchange_NoCheck(t *testing.T) {
+	s := newOAuth2WithTokenExchange("corpOAuth", &OAuth2TokenExchange{
+		Enabled: false,
+		// Empty providers would be invalid if Enabled=true; with
+		// Enabled=false the block is inert and must not error.
+	})
+	assert.NoError(t, s.ValidateOAuth2Schemes())
+}
+
+func TestValidateOAuth2Schemes_EnabledWithoutProviders(t *testing.T) {
+	s := newOAuth2WithTokenExchange("corpOAuth", &OAuth2TokenExchange{Enabled: true})
+	err := s.ValidateOAuth2Schemes()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "providers[] is empty")
+}
+
+func TestValidateOAuth2Schemes_EmptyProviderName(t *testing.T) {
+	s := newOAuth2WithTokenExchange("corpOAuth", &OAuth2TokenExchange{
+		Enabled: true,
+		Providers: []OAuth2TokenExchangeProvider{
+			{TokenEndpoint: "https://idp/token", ClientAuth: &OAuth2ClientAuth{ClientID: "c"}},
+		},
+	})
+	err := s.ValidateOAuth2Schemes()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "providers[0].name is required")
+}
+
+func TestValidateOAuth2Schemes_DuplicateProviderName(t *testing.T) {
+	s := newOAuth2WithTokenExchange("corpOAuth", &OAuth2TokenExchange{
+		Enabled: true,
+		Providers: []OAuth2TokenExchangeProvider{
+			{Name: "p", Issuers: []string{"https://a"}, TokenEndpoint: "https://a/token", ClientAuth: &OAuth2ClientAuth{ClientID: "ca"}},
+			{Name: "p", Issuers: []string{"https://b"}, TokenEndpoint: "https://b/token", ClientAuth: &OAuth2ClientAuth{ClientID: "cb"}},
+		},
+	})
+	err := s.ValidateOAuth2Schemes()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `duplicate tokenExchange.provider name "p"`)
+}
+
+func TestValidateOAuth2Schemes_OverlappingIssuers(t *testing.T) {
+	s := newOAuth2WithTokenExchange("corpOAuth", &OAuth2TokenExchange{
+		Enabled: true,
+		Providers: []OAuth2TokenExchangeProvider{
+			{Name: "p1", Issuers: []string{"https://shared"}, TokenEndpoint: "https://a/token", ClientAuth: &OAuth2ClientAuth{ClientID: "ca"}},
+			{Name: "p2", Issuers: []string{"https://shared"}, TokenEndpoint: "https://b/token", ClientAuth: &OAuth2ClientAuth{ClientID: "cb"}},
+		},
+	})
+	err := s.ValidateOAuth2Schemes()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `duplicate issuer "https://shared"`)
+	assert.Contains(t, err.Error(), `"p1"`)
+	assert.Contains(t, err.Error(), `"p2"`)
+}
+
+func TestValidateOAuth2Schemes_EmptyTokenEndpoint(t *testing.T) {
+	s := newOAuth2WithTokenExchange("corpOAuth", &OAuth2TokenExchange{
+		Enabled: true,
+		Providers: []OAuth2TokenExchangeProvider{
+			{Name: "p", Issuers: []string{"https://a"}, ClientAuth: &OAuth2ClientAuth{ClientID: "ca"}},
+		},
+	})
+	err := s.ValidateOAuth2Schemes()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `empty tokenEndpoint`)
+}
+
+func TestValidateOAuth2Schemes_EmptyClientId(t *testing.T) {
+	s := newOAuth2WithTokenExchange("corpOAuth", &OAuth2TokenExchange{
+		Enabled: true,
+		Providers: []OAuth2TokenExchangeProvider{
+			{Name: "p", Issuers: []string{"https://a"}, TokenEndpoint: "https://a/token"},
+		},
+	})
+	err := s.ValidateOAuth2Schemes()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty clientAuth.clientId")
+}
+
+func TestValidateOAuth2Schemes_RejectsReservedCustomParams(t *testing.T) {
+	reserved := []string{
+		OAuth2FormGrantType, OAuth2FormSubjectToken, OAuth2FormSubjectTokenType,
+		OAuth2FormRequestedTokenType, OAuth2FormAudience, OAuth2FormResource,
+		OAuth2FormScope, OAuth2FormActorToken, OAuth2FormActorTokenType,
+		OAuth2FormClientID, OAuth2FormClientSecret,
+		OAuth2FormClientAssertion, OAuth2FormClientAssertionType,
+	}
+	for _, key := range reserved {
+		t.Run(key, func(t *testing.T) {
+			s := newOAuth2WithTokenExchange("corpOAuth", &OAuth2TokenExchange{
+				Enabled: true,
+				Providers: []OAuth2TokenExchangeProvider{
+					{
+						Name:          "p",
+						Issuers:       []string{"https://a"},
+						TokenEndpoint: "https://a/token",
+						ClientAuth:    &OAuth2ClientAuth{ClientID: "ca"},
+						CustomParams:  map[string]string{key: "x"},
+					},
+				},
+			})
+			err := s.ValidateOAuth2Schemes()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "customParams cannot override reserved")
+			assert.Contains(t, err.Error(), key)
+		})
+	}
+}
+
+func TestValidateOAuth2Schemes_HappyMultiProvider(t *testing.T) {
+	s := newOAuth2WithTokenExchange("corpOAuth", &OAuth2TokenExchange{
+		Enabled: true,
+		Providers: []OAuth2TokenExchangeProvider{
+			{Name: "primary", Issuers: []string{"https://idp-1"}, TokenEndpoint: "https://idp-1/token", ClientAuth: &OAuth2ClientAuth{ClientID: "c1"}, CustomParams: map[string]string{"requested_issuer": "broker"}},
+			{Name: "alt", Issuers: []string{"https://idp-2", "https://idp-2-canonical"}, TokenEndpoint: "https://idp-2/token", ClientAuth: &OAuth2ClientAuth{ClientID: "c2"}},
+		},
+	})
+	assert.NoError(t, s.ValidateOAuth2Schemes())
+}
+
+func TestOAuth2_RawMapWithTokenExchangePromotesToTypedScheme(t *testing.T) {
+	raw := map[string]interface{}{
+		"tokenExchange": map[string]interface{}{
+			"enabled": true,
+			"providers": []interface{}{
+				map[string]interface{}{
+					"name":          "primary",
+					"issuers":       []interface{}{"https://idp"},
+					"tokenEndpoint": "https://idp/token",
+					"clientAuth":    map[string]interface{}{"clientId": "tyk-gateway"},
+				},
+			},
+		},
+	}
+	o := asOAuth2Scheme(raw)
+	require.NotNil(t, o)
+	require.NotNil(t, o.TokenExchange)
+	assert.True(t, o.TokenExchange.Enabled)
+	require.Len(t, o.TokenExchange.Providers, 1)
+	assert.Equal(t, "primary", o.TokenExchange.Providers[0].Name)
+}
+
+// newOAuth2WithTokenExchange builds a minimal OAS with the new oauth2
+// scheme carrying just the given tokenExchange block.
+func newOAuth2WithTokenExchange(name string, te *OAuth2TokenExchange) *OAS {
+	s := newOAuth2Fixture(name)
+	o := s.GetTykOAuth2Config(name)
+	require := func() *OAuth2 {
+		if o != nil {
+			return o
+		}
+		return &OAuth2{}
+	}
+	got := require()
+	got.TokenExchange = te
+	// Stuff back into the tyk-extension via the same getter so the
+	// validation walk sees it.
+	tykAuth := s.getTykAuthentication()
+	tykAuth.SecuritySchemes[name] = got
+	return s
+}

--- a/apidef/oas/oauth2_token_exchange_test.go
+++ b/apidef/oas/oauth2_token_exchange_test.go
@@ -113,7 +113,7 @@ func TestOAuth2Exchange_IsActive(t *testing.T) {
 		want bool
 	}{
 		{"nil", nil, false},
-		{"absent enabled defaults to active", &OAuth2Exchange{}, true},
+		{"absent enabled is inactive", &OAuth2Exchange{}, false},
 		{"explicit true", &OAuth2Exchange{Enabled: boolPtr(true)}, true},
 		{"explicit false", &OAuth2Exchange{Enabled: boolPtr(false)}, false},
 	}

--- a/apidef/oas/oauth2_token_exchange_test.go
+++ b/apidef/oas/oauth2_token_exchange_test.go
@@ -1,6 +1,7 @@
 package oas
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -304,4 +305,105 @@ func newOAuth2WithTokenExchange(name string, te *OAuth2TokenExchange) *OAS {
 	tykAuth := s.getTykAuthentication()
 	tykAuth.SecuritySchemes[name] = got
 	return s
+}
+
+// TestOAS_Validate_TokenExchange and TestOAS_ValidateForMCP_TokenExchange pin
+// that token-exchange validation errors surface through the top-level
+// OAS.Validate and OAS.ValidateForMCP chains respectively — not only when
+// ValidateOAuth2Schemes is called directly. They would fail if the
+// ValidateOAuth2Schemes() call was removed from either chain.
+func TestOAS_Validate_TokenExchange(t *testing.T) {
+	validProvider := OAuth2TokenExchangeProvider{
+		Name:          "primary",
+		Issuers:       []string{"https://idp.example.com"},
+		TokenEndpoint: "https://idp.example.com/token",
+		ClientAuth:    &OAuth2ClientAuth{ClientID: "tyk-gw"},
+	}
+
+	tests := []struct {
+		name      string
+		te        *OAuth2TokenExchange
+		wantErr   string
+	}{
+		{
+			name:    "valid single provider passes",
+			te:      &OAuth2TokenExchange{Enabled: true, Providers: []OAuth2TokenExchangeProvider{validProvider}},
+			wantErr: "",
+		},
+		{
+			name:    "disabled block with no providers passes",
+			te:      &OAuth2TokenExchange{Enabled: false},
+			wantErr: "",
+		},
+		{
+			name:    "enabled with no providers is rejected",
+			te:      &OAuth2TokenExchange{Enabled: true},
+			wantErr: "providers[] is empty",
+		},
+		{
+			name: "duplicate provider name is rejected",
+			te: &OAuth2TokenExchange{
+				Enabled: true,
+				Providers: []OAuth2TokenExchangeProvider{
+					{Name: "dup", Issuers: []string{"https://a"}, TokenEndpoint: "https://a/token", ClientAuth: &OAuth2ClientAuth{ClientID: "c"}},
+					{Name: "dup", Issuers: []string{"https://b"}, TokenEndpoint: "https://b/token", ClientAuth: &OAuth2ClientAuth{ClientID: "c"}},
+				},
+			},
+			wantErr: `duplicate tokenExchange.provider name "dup"`,
+		},
+		{
+			name: "overlapping issuers across providers is rejected",
+			te: &OAuth2TokenExchange{
+				Enabled: true,
+				Providers: []OAuth2TokenExchangeProvider{
+					{Name: "a", Issuers: []string{"https://shared"}, TokenEndpoint: "https://a/token", ClientAuth: &OAuth2ClientAuth{ClientID: "c"}},
+					{Name: "b", Issuers: []string{"https://shared"}, TokenEndpoint: "https://b/token", ClientAuth: &OAuth2ClientAuth{ClientID: "c"}},
+				},
+			},
+			wantErr: "duplicate issuer",
+		},
+		{
+			name: "reserved customParams key is rejected",
+			te: &OAuth2TokenExchange{
+				Enabled: true,
+				Providers: []OAuth2TokenExchangeProvider{
+					{Name: "p", TokenEndpoint: "https://a/token", ClientAuth: &OAuth2ClientAuth{ClientID: "c"},
+						CustomParams: map[string]string{OAuth2FormGrantType: "bad"}},
+				},
+			},
+			wantErr: "reserved RFC 8693 wire key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newOAuth2WithTokenExchange("corpOAuth", tt.te)
+			err := s.Validate(context.Background())
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestOAS_ValidateForMCP_TokenExchange(t *testing.T) {
+	t.Run("misconfigured token exchange is also rejected by ValidateForMCP", func(t *testing.T) {
+		s := newOAuth2WithTokenExchange("corpOAuth", &OAuth2TokenExchange{Enabled: true})
+		err := s.ValidateForMCP(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "providers[] is empty")
+	})
+
+	t.Run("valid token exchange passes ValidateForMCP", func(t *testing.T) {
+		s := newOAuth2WithTokenExchange("corpOAuth", &OAuth2TokenExchange{
+			Enabled: true,
+			Providers: []OAuth2TokenExchangeProvider{
+				{Name: "p", Issuers: []string{"https://idp"}, TokenEndpoint: "https://idp/token", ClientAuth: &OAuth2ClientAuth{ClientID: "c"}},
+			},
+		})
+		assert.NoError(t, s.ValidateForMCP(context.Background()))
+	})
 }

--- a/apidef/oas/operation.go
+++ b/apidef/oas/operation.go
@@ -89,6 +89,11 @@ type Operation struct {
 
 	// ScopeCheck toggles the operation-level OAuth 2.0 scope check.
 	ScopeCheck *ScopeCheck `bson:"scopeCheck,omitempty" json:"scopeCheck,omitempty"`
+
+	// Exchange overrides the matched OAuth 2.0 token-exchange provider's
+	// default target for this operation. Read by the EE token-exchange
+	// middleware; not propagated to the classic apidef (OAS-native field).
+	Exchange *OAuth2Exchange `bson:"exchange,omitempty" json:"exchange,omitempty"`
 }
 
 // ExtractToExtendedPaths extracts operation-level middleware configuration into a classic

--- a/apidef/oas/operation_test.go
+++ b/apidef/oas/operation_test.go
@@ -91,6 +91,7 @@ func TestOAS_PathsAndOperations(t *testing.T) {
 	operation.PostPlugins = operation.PostPlugins[:1] // only 1 post plugin is considered at this point, ignore others.
 	operation.PostPlugins[0].Name = ""                // Name is deprecated.
 	operation.EnforceTimeout.Value = 1                // Enforced timeout value is deprecated. We set value of 1 due to new field Timeout that alters deprecated value (rounds up to one second).
+	operation.Exchange = nil                          // OAS-native; not propagated to classic apidef.
 
 	operation.RateLimit.Per = ReadableDuration(time.Minute)
 

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -1323,6 +1323,8 @@
     },
     "X-Tyk-ProtectedResourceMetadata": {
       "type": "object",
+      "deprecated": true,
+      "description": "Deprecated. Use securitySchemes[<name>].oauth2.protectedResourceMetadata (X-Tyk-OAuth2-PRM) instead. The legacy top-level block is kept for downgrade safety and will be removed in a future major version.",
       "properties": {
         "enabled": {
           "type": "boolean"

--- a/apidef/oas/schema/x-tyk-api-gateway.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.json
@@ -223,7 +223,9 @@
         },
         "claims": {
           "type": "array",
-          "items": {"type": "string"}
+          "items": {
+            "type": "string"
+          }
         },
         "scopeToPolicyMapping": {
           "type": "array",
@@ -1067,6 +1069,9 @@
         },
         "scopeCheck": {
           "$ref": "#/definitions/X-Tyk-ScopeCheck"
+        },
+        "exchange": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-Exchange"
         }
       }
     },
@@ -1479,10 +1484,14 @@
       },
       "anyOf": [
         {
-          "required": ["url"]
+          "required": [
+            "url"
+          ]
         },
         {
-          "required": ["loadBalancing"]
+          "required": [
+            "loadBalancing"
+          ]
         }
       ]
     },
@@ -1545,13 +1554,24 @@
       "anyOf": [
         {
           "properties": {
-            "location": { "enum": ["header", "url-param"] }
+            "location": {
+              "enum": [
+                "header",
+                "url-param"
+              ]
+            }
           },
-          "required": ["key"]
+          "required": [
+            "key"
+          ]
         },
         {
           "properties": {
-            "location": { "enum": ["url"] }
+            "location": {
+              "enum": [
+                "url"
+              ]
+            }
           }
         }
       ]
@@ -1714,7 +1734,9 @@
         },
         "subjectClaims": {
           "type": "array",
-          "items": {"type": "string"}
+          "items": {
+            "type": "string"
+          }
         },
         "jwksURIs": {
           "type": [
@@ -1732,7 +1754,9 @@
                 "$ref": "#/definitions/X-Tyk-ReadableDuration"
               }
             },
-            "required": ["url"]
+            "required": [
+              "url"
+            ]
           }
         },
         "skipKid": {
@@ -1743,15 +1767,21 @@
         },
         "basePolicyClaims": {
           "type": "array",
-          "items": {"type": "string"}
+          "items": {
+            "type": "string"
+          }
         },
         "allowedIssuers": {
           "type": "array",
-          "items": {"type": "string"}
+          "items": {
+            "type": "string"
+          }
         },
         "allowedAudiences": {
           "type": "array",
-          "items": {"type": "string"}
+          "items": {
+            "type": "string"
+          }
         },
         "jtiValidation": {
           "type": "object",
@@ -1766,7 +1796,9 @@
         },
         "allowedSubjects": {
           "type": "array",
-          "items": {"type": "string"}
+          "items": {
+            "type": "string"
+          }
         },
         "clientBaseField": {
           "type": "string"
@@ -1805,7 +1837,11 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": ["required", "exact_match", "contains"]
+              "enum": [
+                "required",
+                "exact_match",
+                "contains"
+              ]
             },
             "allowedValues": {
               "type": "array",
@@ -1816,7 +1852,9 @@
               "default": false
             }
           },
-          "required": ["type"]
+          "required": [
+            "type"
+          ]
         }
       },
       "required": [
@@ -1924,37 +1962,203 @@
       "type": "object",
       "description": "OAuth 2.0 security scheme container.",
       "properties": {
-        "enabled":    { "type": "boolean" },
-        "header":     { "$ref": "#/definitions/X-Tyk-AuthSource" },
-        "cookie":     { "$ref": "#/definitions/X-Tyk-AuthSource" },
-        "query":      { "$ref": "#/definitions/X-Tyk-AuthSource" },
-        "scopeCheck": { "$ref": "#/definitions/X-Tyk-OAuth2-ScopeCheck" },
-        "protectedResourceMetadata": { "$ref": "#/definitions/X-Tyk-OAuth2-PRM" }
+        "enabled": {
+          "type": "boolean"
+        },
+        "header": {
+          "$ref": "#/definitions/X-Tyk-AuthSource"
+        },
+        "cookie": {
+          "$ref": "#/definitions/X-Tyk-AuthSource"
+        },
+        "query": {
+          "$ref": "#/definitions/X-Tyk-AuthSource"
+        },
+        "scopeCheck": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-ScopeCheck"
+        },
+        "protectedResourceMetadata": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-PRM"
+        },
+        "tokenExchange": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-TokenExchange"
+        }
       },
-      "required": ["enabled"]
+      "required": [
+        "enabled"
+      ]
     },
     "X-Tyk-OAuth2-PRM": {
       "type": "object",
       "description": "OAuth 2.0 Protected Resource Metadata (RFC 9728) published for this API. New home for PRM; the deprecated top-level authentication.protectedResourceMetadata still works but this one wins when both are set.",
       "properties": {
-        "enabled":              { "type": "boolean" },
-        "wellKnownPath":        { "type": "string", "description": "Path under the API listen path where the PRM document is served. Defaults to .well-known/oauth-protected-resource." },
-        "resource":             { "type": "string", "description": "Canonical resource identifier this gateway protects. Surfaced as the `resource` field of the PRM document." },
-        "authorizationServers": { "type": "array", "items": { "type": "string" }, "description": "Issuer URLs published in the PRM document. At least one entry is required for MCP-proxy APIs." },
-        "autoDeriveScopes":     { "type": "boolean", "description": "When unset or true (default), PRM `scopes_supported` is unioned at serve time with every scope referenced by any `security:` array (root, operations, MCP primitives). Set to false to advertise only the OpenAPI flows.scopes catalog." }
+        "enabled": {
+          "type": "boolean"
+        },
+        "wellKnownPath": {
+          "type": "string",
+          "description": "Path under the API listen path where the PRM document is served. Defaults to .well-known/oauth-protected-resource."
+        },
+        "resource": {
+          "type": "string",
+          "description": "Canonical resource identifier this gateway protects. Surfaced as the `resource` field of the PRM document."
+        },
+        "authorizationServers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Issuer URLs published in the PRM document. At least one entry is required for MCP-proxy APIs."
+        },
+        "scopesSupported": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Scopes advertised in PRM `scopes_supported` that aren't referenced by any operation's `security:` array. Merged with the scopeCheck.scopes baseline and the auto-derived set."
+        },
+        "autoDeriveScopes": {
+          "type": "boolean",
+          "description": "When unset or true (default), the union of all `security:` scopes declared on operations and MCP primitives is added to PRM `scopes_supported`. Set to false to advertise only the manual list."
+        }
       },
-      "required": ["enabled"]
+      "required": [
+        "enabled"
+      ]
     },
     "X-Tyk-OAuth2-ScopeCheck": {
       "type": "object",
       "description": "Token-side knobs for OAS-native scope enforcement. Required scopes themselves live in the OAS root security: array.",
       "properties": {
-        "enabled":        { "type": "boolean" },
-        "claimNames":     { "type": "array", "items": { "type": "string" }, "description": "Ordered list of JWT claim names to read scopes from. The gateway reads each listed claim that is present and merges all scope values into one set. Alternatives drawn from OAS root security: are checked against this merged set. Defaults to [\"scope\", \"scp\"] when unset." },
-        "separator":      { "type": "string" },
-        "scopeSource":    { "type": "string", "enum": ["operation", "global", "union"], "description": "Selects whether enforcement reads per-operation security:, root security:, or both. Defaults to \"union\"." }
+        "enabled": {
+          "type": "boolean"
+        },
+        "claimNames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Ordered list of JWT claim names to read scopes from. The gateway reads each listed claim that is present and merges all scope values into one set. Alternatives drawn from OAS root security: are checked against this merged set. Defaults to [\"scope\", \"scp\"] when unset."
+        },
+        "separator": {
+          "type": "string"
+        },
+        "scopeSource": {
+          "type": "string",
+          "enum": [
+            "operation",
+            "global",
+            "union"
+          ],
+          "description": "Selects whether enforcement reads per-operation security:, root security:, or both. Defaults to \"union\"."
+        }
       },
-      "required": ["enabled"]
+      "required": [
+        "enabled"
+      ]
+    },
+    "X-Tyk-OAuth2-TokenExchange": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "providers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/X-Tyk-OAuth2-Provider"
+          }
+        }
+      },
+      "required": [
+        "enabled"
+      ]
+    },
+    "X-Tyk-OAuth2-Provider": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "issuers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tokenEndpoint": {
+          "type": "string"
+        },
+        "clientAuth": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-ClientAuth"
+        },
+        "defaultTarget": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-DefaultTarget"
+        },
+        "timeout": {
+          "type": "string",
+          "description": "Per-call timeout for the RFC 8693 exchange request, Tyk ReadableDuration (e.g. \"100ms\", \"5s\"). Defaults to 15s when zero/unset."
+        },
+        "customParams": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Operator-supplied form parameters appended to every RFC 8693 exchange request. Reserved RFC 8693 / OAuth2 wire keys (grant_type, subject_token, audience, scope, actor_token, client_id, ...) are rejected at API-load time."
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "X-Tyk-OAuth2-ClientAuth": {
+      "type": "object",
+      "properties": {
+        "method": {
+          "type": "string",
+          "enum": [
+            "client_secret_basic",
+            "client_secret_post"
+          ]
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "clientSecret": {
+          "type": "string"
+        }
+      }
+    },
+    "X-Tyk-OAuth2-DefaultTarget": {
+      "type": "object",
+      "properties": {
+        "audience": {
+          "type": "string"
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "X-Tyk-OAuth2-Exchange": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "audience": {
+          "type": "string"
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "X-Tyk-OAuthProvider": {
       "type": "object",
@@ -2657,7 +2861,9 @@
         {
           "if": {
             "properties": {
-              "enabled": { "const": true }
+              "enabled": {
+                "const": true
+              }
             }
           },
           "then": {
@@ -2666,7 +2872,9 @@
                 "minItems": 1
               }
             },
-            "required": ["targets"]
+            "required": [
+              "targets"
+            ]
           }
         }
       ]
@@ -2685,11 +2893,21 @@
         },
         "minVersion": {
           "type": "string",
-          "enum": ["1.0", "1.1", "1.2", "1.3"]
+          "enum": [
+            "1.0",
+            "1.1",
+            "1.2",
+            "1.3"
+          ]
         },
         "maxVersion": {
           "type": "string",
-          "enum": ["1.0", "1.1", "1.2", "1.3"]
+          "enum": [
+            "1.0",
+            "1.1",
+            "1.2",
+            "1.3"
+          ]
         },
         "forceCommonNameCheck": {
           "type": "boolean"
@@ -2706,7 +2924,9 @@
           "type": "string"
         }
       },
-      "required": ["enabled"]
+      "required": [
+        "enabled"
+      ]
     },
     "X-Tyk-PreserveHostHeader": {
       "type": "object",
@@ -2801,7 +3021,7 @@
     },
     "X-Tyk-ReadableDuration": {
       "type": "string",
-      "pattern": "^(\\d+h)?(\\d+m)?(\\d+s)?(\\d+ms)?(\\d+µs)?(\\d+ns)?$"
+      "pattern": "^(\\d+h)?(\\d+m)?(\\d+s)?(\\d+ms)?(\\d+\u00b5s)?(\\d+ns)?$"
     },
     "X-Tyk-LoadBalancingTarget": {
       "type": "object",
@@ -2813,7 +3033,10 @@
           "type": "number"
         }
       },
-      "required": ["url", "weight"]
+      "required": [
+        "url",
+        "weight"
+      ]
     },
     "X-Tyk-ErrorOverrides": {
       "type": "object",
@@ -2831,7 +3054,9 @@
           }
         }
       },
-      "required": ["enabled"]
+      "required": [
+        "enabled"
+      ]
     },
     "X-Tyk-ErrorOverride": {
       "type": "object",
@@ -2843,7 +3068,9 @@
           "$ref": "#/definitions/X-Tyk-ErrorResponse"
         }
       },
-      "required": ["response"]
+      "required": [
+        "response"
+      ]
     },
     "X-Tyk-ErrorMatcher": {
       "type": "object",

--- a/apidef/oas/schema/x-tyk-api-gateway.strict.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.strict.json
@@ -1112,6 +1112,9 @@
         },
         "scopeCheck": {
           "$ref": "#/definitions/X-Tyk-ScopeCheck"
+        },
+        "exchange": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-Exchange"
         }
       },
       "additionalProperties": false
@@ -1125,8 +1128,7 @@
       },
       "required": [
         "enabled"
-      ],
-      "additionalProperties": false
+      ]
     },
     "X-Tyk-Operations": {
       "type": "object",
@@ -2045,6 +2047,9 @@
         },
         "protectedResourceMetadata": {
           "$ref": "#/definitions/X-Tyk-OAuth2-PRM"
+        },
+        "tokenExchange": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-TokenExchange"
         }
       },
       "required": [
@@ -2074,9 +2079,16 @@
           },
           "description": "Issuer URLs published in the PRM document. At least one entry is required for MCP-proxy APIs."
         },
+        "scopesSupported": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Scopes advertised in PRM `scopes_supported` that aren't referenced by any operation's `security:` array. Merged with the scopeCheck.scopes baseline and the auto-derived set."
+        },
         "autoDeriveScopes": {
           "type": "boolean",
-          "description": "When unset or true (default), PRM `scopes_supported` is unioned at serve time with every scope referenced by any `security:` array (root, operations, MCP primitives). Set to false to advertise only the OpenAPI flows.scopes catalog."
+          "description": "When unset or true (default), the union of all `security:` scopes declared on operations and MCP primitives is added to PRM `scopes_supported`. Set to false to advertise only the manual list."
         }
       },
       "required": [
@@ -2114,6 +2126,114 @@
       "required": [
         "enabled"
       ],
+      "additionalProperties": false
+    },
+    "X-Tyk-OAuth2-TokenExchange": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "providers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/X-Tyk-OAuth2-Provider"
+          }
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "additionalProperties": false
+    },
+    "X-Tyk-OAuth2-Provider": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "issuers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tokenEndpoint": {
+          "type": "string"
+        },
+        "clientAuth": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-ClientAuth"
+        },
+        "defaultTarget": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-DefaultTarget"
+        },
+        "timeout": {
+          "type": "string",
+          "description": "Per-call timeout for the RFC 8693 exchange request, Tyk ReadableDuration (e.g. \"100ms\", \"5s\"). Defaults to 15s when zero/unset."
+        },
+        "customParams": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Operator-supplied form parameters appended to every RFC 8693 exchange request. Reserved RFC 8693 / OAuth2 wire keys (grant_type, subject_token, audience, scope, actor_token, client_id, ...) are rejected at API-load time."
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "X-Tyk-OAuth2-ClientAuth": {
+      "type": "object",
+      "properties": {
+        "method": {
+          "type": "string",
+          "enum": [
+            "client_secret_basic",
+            "client_secret_post"
+          ]
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "clientSecret": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "X-Tyk-OAuth2-DefaultTarget": {
+      "type": "object",
+      "properties": {
+        "audience": {
+          "type": "string"
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "X-Tyk-OAuth2-Exchange": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "audience": {
+          "type": "string"
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
       "additionalProperties": false
     },
     "X-Tyk-OAuthProvider": {
@@ -3015,7 +3135,7 @@
     },
     "X-Tyk-ReadableDuration": {
       "type": "string",
-      "pattern": "^(\\d+h)?(\\d+m)?(\\d+s)?(\\d+ms)?(\\d+µs)?(\\d+ns)?$",
+      "pattern": "^(\\d+h)?(\\d+m)?(\\d+s)?(\\d+ms)?(\\d+\u00b5s)?(\\d+ns)?$",
       "additionalProperties": false
     },
     "X-Tyk-LoadBalancingTarget": {

--- a/apidef/oas/schema/x-tyk-api-gateway.strict.json
+++ b/apidef/oas/schema/x-tyk-api-gateway.strict.json
@@ -1378,6 +1378,8 @@
     },
     "X-Tyk-ProtectedResourceMetadata": {
       "type": "object",
+      "deprecated": true,
+      "description": "Deprecated. Use securitySchemes[<name>].oauth2.protectedResourceMetadata (X-Tyk-OAuth2-PRM) instead. The legacy top-level block is kept for downgrade safety and will be removed in a future major version.",
       "properties": {
         "enabled": {
           "type": "boolean"

--- a/apidef/streams/schema/x-tyk-api-gateway.json
+++ b/apidef/streams/schema/x-tyk-api-gateway.json
@@ -1237,6 +1237,8 @@
     },
     "X-Tyk-ProtectedResourceMetadata": {
       "type": "object",
+      "deprecated": true,
+      "description": "Deprecated. Use securitySchemes[<name>].oauth2.protectedResourceMetadata (X-Tyk-OAuth2-PRM) instead. The legacy top-level block is kept for downgrade safety and will be removed in a future major version.",
       "properties": {
         "enabled": {
           "type": "boolean"

--- a/apidef/streams/schema/x-tyk-api-gateway.json
+++ b/apidef/streams/schema/x-tyk-api-gateway.json
@@ -1021,6 +1021,9 @@
         },
         "scopeCheck": {
           "$ref": "#/definitions/X-Tyk-ScopeCheck"
+        },
+        "exchange": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-Exchange"
         }
       }
     },
@@ -1692,37 +1695,162 @@
       "type": "object",
       "description": "OAuth 2.0 security scheme container.",
       "properties": {
-        "enabled":    { "type": "boolean" },
-        "header":     { "$ref": "#/definitions/X-Tyk-AuthSource" },
-        "cookie":     { "$ref": "#/definitions/X-Tyk-AuthSource" },
-        "query":      { "$ref": "#/definitions/X-Tyk-AuthSource" },
-        "scopeCheck": { "$ref": "#/definitions/X-Tyk-OAuth2-ScopeCheck" },
-        "protectedResourceMetadata": { "$ref": "#/definitions/X-Tyk-OAuth2-PRM" }
+        "enabled": {
+          "type": "boolean"
+        },
+        "header": {
+          "$ref": "#/definitions/X-Tyk-AuthSource"
+        },
+        "cookie": {
+          "$ref": "#/definitions/X-Tyk-AuthSource"
+        },
+        "query": {
+          "$ref": "#/definitions/X-Tyk-AuthSource"
+        },
+        "scopeCheck": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-ScopeCheck"
+        },
+        "tokenExchange": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-TokenExchange"
+        }
       },
-      "required": ["enabled"]
-    },
-    "X-Tyk-OAuth2-PRM": {
-      "type": "object",
-      "description": "OAuth 2.0 Protected Resource Metadata (RFC 9728) published for this API. New home for PRM; the deprecated top-level authentication.protectedResourceMetadata still works but this one wins when both are set.",
-      "properties": {
-        "enabled":              { "type": "boolean" },
-        "wellKnownPath":        { "type": "string", "description": "Path under the API listen path where the PRM document is served. Defaults to .well-known/oauth-protected-resource." },
-        "resource":             { "type": "string", "description": "Canonical resource identifier this gateway protects. Surfaced as the `resource` field of the PRM document." },
-        "authorizationServers": { "type": "array", "items": { "type": "string" }, "description": "Issuer URLs published in the PRM document. At least one entry is required for MCP-proxy APIs." },
-        "autoDeriveScopes":     { "type": "boolean", "description": "When unset or true (default), PRM `scopes_supported` is unioned at serve time with every scope referenced by any `security:` array (root, operations, MCP primitives). Set to false to advertise only the OpenAPI flows.scopes catalog." }
-      },
-      "required": ["enabled"]
+      "required": [
+        "enabled"
+      ]
     },
     "X-Tyk-OAuth2-ScopeCheck": {
       "type": "object",
       "description": "Token-side knobs for OAS-native scope enforcement. Required scopes themselves live in the OAS root security: array.",
       "properties": {
-        "enabled":        { "type": "boolean" },
-        "claimNames":     { "type": "array", "items": { "type": "string" }, "description": "Ordered list of JWT claim names to read scopes from. The gateway reads each listed claim that is present and merges all scope values into one set. Alternatives drawn from OAS root security: are checked against this merged set. Defaults to [\"scope\", \"scp\"] when unset." },
-        "separator":      { "type": "string" },
-        "scopeSource":    { "type": "string", "enum": ["operation", "global", "union"], "description": "Selects whether enforcement reads per-operation security:, root security:, or both. Defaults to \"union\"." }
+        "enabled": {
+          "type": "boolean"
+        },
+        "claimNames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Ordered list of JWT claim names to read scopes from. The gateway reads each listed claim that is present and merges all scope values into one set. Alternatives drawn from OAS root security: are checked against this merged set. Defaults to [\"scope\", \"scp\"] when unset."
+        },
+        "separator": {
+          "type": "string"
+        },
+        "scopeSource": {
+          "type": "string",
+          "enum": [
+            "operation",
+            "global",
+            "union"
+          ],
+          "description": "Selects whether enforcement reads per-operation security:, root security:, or both. Defaults to \"union\"."
+        }
       },
-      "required": ["enabled"]
+      "required": [
+        "enabled"
+      ]
+    },
+    "X-Tyk-OAuth2-TokenExchange": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "providers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/X-Tyk-OAuth2-Provider"
+          }
+        }
+      },
+      "required": [
+        "enabled"
+      ]
+    },
+    "X-Tyk-OAuth2-Provider": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "issuers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tokenEndpoint": {
+          "type": "string"
+        },
+        "clientAuth": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-ClientAuth"
+        },
+        "defaultTarget": {
+          "$ref": "#/definitions/X-Tyk-OAuth2-DefaultTarget"
+        },
+        "timeout": {
+          "type": "string",
+          "description": "Per-call timeout for the RFC 8693 exchange request, Tyk ReadableDuration (e.g. \"100ms\", \"5s\"). Defaults to 15s when zero/unset."
+        },
+        "customParams": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Operator-supplied form parameters appended to every RFC 8693 exchange request. Reserved RFC 8693 / OAuth2 wire keys (grant_type, subject_token, audience, scope, actor_token, client_id, ...) are rejected at API-load time."
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "X-Tyk-OAuth2-ClientAuth": {
+      "type": "object",
+      "properties": {
+        "method": {
+          "type": "string",
+          "enum": [
+            "client_secret_basic",
+            "client_secret_post"
+          ]
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "clientSecret": {
+          "type": "string"
+        }
+      }
+    },
+    "X-Tyk-OAuth2-DefaultTarget": {
+      "type": "object",
+      "properties": {
+        "audience": {
+          "type": "string"
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "X-Tyk-OAuth2-Exchange": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "audience": {
+          "type": "string"
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "X-Tyk-OAuthProvider": {
       "type": "object",
@@ -2080,7 +2208,9 @@
           }
         }
       },
-      "required": ["enabled"]
+      "required": [
+        "enabled"
+      ]
     },
     "X-Tyk-ErrorOverride": {
       "type": "object",
@@ -2092,7 +2222,9 @@
           "$ref": "#/definitions/X-Tyk-ErrorResponse"
         }
       },
-      "required": ["response"]
+      "required": [
+        "response"
+      ]
     },
     "X-Tyk-ErrorMatcher": {
       "type": "object",

--- a/ee/middleware/oauth2tokenexchange/exchange.go
+++ b/ee/middleware/oauth2tokenexchange/exchange.go
@@ -182,7 +182,6 @@ func (m *Middleware) exchangeAtIdP(ctx context.Context, provider *oas.OAuth2Toke
 
 	var parsed struct {
 		AccessToken string `json:"access_token"`
-		ExpiresIn   int64  `json:"expires_in"`
 	}
 	if err := json.Unmarshal(body, &parsed); err != nil {
 		return "", fmt.Errorf("decoding exchange response: %w", err)

--- a/ee/middleware/oauth2tokenexchange/exchange.go
+++ b/ee/middleware/oauth2tokenexchange/exchange.go
@@ -1,0 +1,273 @@
+//go:build ee || dev
+
+package oauth2tokenexchange
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/internal/httputil"
+	"github.com/TykTechnologies/tyk/internal/oauth2common"
+)
+
+// runExchange performs the RFC 8693 exchange for the matched request.
+func (m *Middleware) runExchange(r *http.Request, st *oauth2common.State) (oauth2common.Outcome, error) {
+	out := oauth2common.Outcome{}
+	cfg := st.OASConfig
+	if cfg.TokenExchange == nil || len(cfg.TokenExchange.Providers) == 0 {
+		return out, nil
+	}
+
+	// Gate provider matching per RFC 8693 §4.8 — no 403 if no exchange would fire.
+	if !m.exchangeWouldFire(st, cfg) {
+		return out, nil
+	}
+
+	iss, _ := st.Claims["iss"].(string)
+	provider := oauth2common.SelectExchangeProvider(cfg.TokenExchange.Providers, iss)
+	if provider == nil {
+		return out, &oauth2common.NoMatchingProviderError{Iss: iss}
+	}
+	out.ProviderName = provider.Name
+
+	target := m.resolveExchangeTarget(st, provider)
+	if target == nil {
+		return out, &oauth2common.MisconfigError{
+			Reason: fmt.Sprintf("token exchange is configured for this request but audience could not be resolved (per-op exchange.audience and provider %q defaultTarget.audience are both empty)", provider.Name),
+		}
+	}
+	out.Audience = target.Audience
+	out.Scopes = target.Scopes
+
+	exchanged, err := m.exchangeAtIdP(r.Context(), provider, st.RawToken, target)
+	if err != nil {
+		return out, err
+	}
+	out.ExchangedToken = exchanged
+	r.Header.Set(header.Authorization, oas.OAuth2AuthSchemeBearer+" "+exchanged)
+	return out, nil
+}
+
+// findActivePrimitive returns the first primitive in tools/resources/prompts with the given name and active exchange.
+func findActivePrimitive(mw *oas.Middleware, name string) *oas.MCPPrimitive {
+	for _, prims := range []oas.MCPPrimitives{mw.McpTools, mw.McpResources, mw.McpPrompts} {
+		if prim, ok := prims[name]; ok && prim != nil && prim.Exchange.IsActive() {
+			return prim
+		}
+	}
+	return nil
+}
+
+// exchangeWouldFire reports whether an exchange target exists for this request (RFC 8693 §4.8).
+func (m *Middleware) exchangeWouldFire(st *oauth2common.State, cfg *oas.OAuth2) bool {
+	if mw := m.Spec.OAS.GetTykMiddleware(); mw != nil {
+		if st.MatchedPrimitiveName != "" && findActivePrimitive(mw, st.MatchedPrimitiveName) != nil {
+			return true
+		}
+		if st.MatchedOperationID != "" {
+			if tykOp, ok := mw.Operations[st.MatchedOperationID]; ok && tykOp != nil && tykOp.Exchange.IsActive() {
+				return true
+			}
+		}
+	}
+	for _, p := range cfg.TokenExchange.Providers {
+		if p.DefaultTarget != nil && p.DefaultTarget.Audience != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveExchangeTarget resolves the audience+scopes pair for the matched provider.
+// Resolution priority: per-primitive exchange > per-operation exchange > provider defaultTarget.
+// A block with exchange.enabled=false is skipped; resolution falls through to the provider default.
+func (m *Middleware) resolveExchangeTarget(st *oauth2common.State, provider *oas.OAuth2TokenExchangeProvider) *oauth2common.Target {
+	if mw := m.Spec.OAS.GetTykMiddleware(); mw != nil {
+		if st.MatchedPrimitiveName != "" {
+			if prim := findActivePrimitive(mw, st.MatchedPrimitiveName); prim != nil {
+				return oauth2common.MergeTargetForProvider(prim.Exchange, provider, st.InferredScopes)
+			}
+		}
+		if st.MatchedOperationID != "" {
+			if tykOp, ok := mw.Operations[st.MatchedOperationID]; ok && tykOp != nil && tykOp.Exchange.IsActive() {
+				return oauth2common.MergeTargetForProvider(tykOp.Exchange, provider, st.InferredScopes)
+			}
+		}
+	}
+	if provider.DefaultTarget != nil && provider.DefaultTarget.Audience != "" {
+		return &oauth2common.Target{
+			Audience: provider.DefaultTarget.Audience,
+			Scopes:   append([]string(nil), provider.DefaultTarget.Scopes...),
+		}
+	}
+	return nil
+}
+
+// exchangeAtIdP posts the RFC 8693 exchange form to the provider's token endpoint.
+func (m *Middleware) exchangeAtIdP(ctx context.Context, provider *oas.OAuth2TokenExchangeProvider, subjectToken string, target *oauth2common.Target) (string, error) {
+	if provider.TokenEndpoint == "" {
+		return "", errors.New("provider tokenEndpoint is empty")
+	}
+
+	method := ""
+	if provider.ClientAuth != nil {
+		method = provider.ClientAuth.Method
+	}
+
+	form := url.Values{}
+	form.Set(oas.OAuth2FormGrantType, oas.OAuth2GrantTypeTokenExchange)
+	form.Set(oas.OAuth2FormSubjectToken, subjectToken)
+	form.Set(oas.OAuth2FormSubjectTokenType, oas.OAuth2TokenTypeAccessToken)
+	if target.Audience != "" {
+		form.Set(oas.OAuth2FormAudience, target.Audience)
+		form.Set(oas.OAuth2FormResource, target.Audience)
+	}
+	if len(target.Scopes) > 0 {
+		form.Set(oas.OAuth2FormScope, strings.Join(target.Scopes, " "))
+	}
+	for k, v := range provider.CustomParams {
+		form.Set(k, v)
+	}
+	if method == oas.OAuth2ClientAuthPost && provider.ClientAuth != nil {
+		if provider.ClientAuth.ClientID != "" {
+			form.Set(oas.OAuth2FormClientID, provider.ClientAuth.ClientID)
+		}
+		if provider.ClientAuth.ClientSecret != "" {
+			form.Set(oas.OAuth2FormClientSecret, provider.ClientAuth.ClientSecret)
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.TokenEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("building exchange request: %w", err)
+	}
+	req.Header.Set(header.ContentType, header.ApplicationFormURLEncoded)
+
+	switch method {
+	case oas.OAuth2ClientAuthPost:
+		// credentials already injected into form above
+	case "", oas.OAuth2ClientAuthBasic:
+		if provider.ClientAuth != nil && provider.ClientAuth.ClientID != "" {
+			req.SetBasicAuth(provider.ClientAuth.ClientID, provider.ClientAuth.ClientSecret)
+		}
+	default:
+		return "", fmt.Errorf("unsupported clientAuth.method %q", method)
+	}
+
+	client := oauth2common.NewIdPHTTPClient(EffectiveIdPTimeout(time.Duration(provider.Timeout)))
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("exchange call failed: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, oauth2common.MaxIdPResponseBytes))
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		idpErr, idpDesc := oauth2common.DecodeIdPError(body)
+		return "", &oauth2common.ExchangeFailedError{
+			Status:      resp.StatusCode,
+			IdpError:    idpErr,
+			Description: idpDesc,
+		}
+	}
+
+	var parsed struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int64  `json:"expires_in"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", fmt.Errorf("decoding exchange response: %w", err)
+	}
+	if parsed.AccessToken == "" {
+		return "", errors.New("exchange response missing access_token")
+	}
+	return parsed.AccessToken, nil
+}
+
+// writeJSONError writes a JSON error response with the given status and Bearer challenge.
+func (m *Middleware) writeJSONError(w http.ResponseWriter, r *http.Request, status int, wwwParams [][2]string, body map[string]string) {
+	enc, _ := json.Marshal(body)
+	m.setExchangeWWWAuthenticate(w, r, wwwParams)
+	w.Header().Set(header.ContentType, header.ApplicationJSON)
+	w.WriteHeader(status)
+	_, _ = w.Write(enc)
+}
+
+// writeExchangeFailedResponse renders a 502 for an IdP-side exchange failure.
+func (m *Middleware) writeExchangeFailedResponse(w http.ResponseWriter, r *http.Request, err error) {
+	body := map[string]string{"error": oas.OAuth2ErrExchangeFailed}
+	if oe, ok := err.(*oauth2common.ExchangeFailedError); ok {
+		if oe.IdpError != "" {
+			body["idp_error"] = oe.IdpError
+		}
+		if oe.Description != "" {
+			body["idp_error_description"] = oe.Description
+		}
+	} else {
+		body["idp_error_description"] = err.Error()
+	}
+	m.writeJSONError(w, r, http.StatusBadGateway, [][2]string{
+		{"error", oas.OAuth2ErrExchangeFailed},
+		{"error_description", body["idp_error_description"]},
+	}, body)
+}
+
+// writeNoMatchingProviderResponse renders a 403 when no provider matches the inbound iss.
+func (m *Middleware) writeNoMatchingProviderResponse(w http.ResponseWriter, r *http.Request, oe *oauth2common.NoMatchingProviderError) {
+	m.writeJSONError(w, r, http.StatusForbidden, [][2]string{
+		{"error", oas.OAuth2ErrNoMatchingProvider},
+		{"error_description", oe.Error()},
+	}, map[string]string{
+		"error":             oas.OAuth2ErrNoMatchingProvider,
+		"error_description": oe.Error(),
+		"iss":               oe.Iss,
+	})
+}
+
+// writeMisconfigResponse renders a 500 for an incomplete exchange configuration.
+func (m *Middleware) writeMisconfigResponse(w http.ResponseWriter, r *http.Request, me *oauth2common.MisconfigError) {
+	m.writeJSONError(w, r, http.StatusInternalServerError, [][2]string{
+		{"error", oas.OAuth2ErrMisconfigured},
+		{"error_description", me.Error()},
+	}, map[string]string{
+		"error":             oas.OAuth2ErrMisconfigured,
+		"error_description": me.Error(),
+	})
+}
+
+// setExchangeWWWAuthenticate writes an RFC 6750 Bearer challenge with the given params.
+func (m *Middleware) setExchangeWWWAuthenticate(w http.ResponseWriter, r *http.Request, params [][2]string) {
+	authParams := make([]string, 0, len(params)+1)
+	for _, kv := range params {
+		authParams = append(authParams, fmt.Sprintf("%s=%q", kv[0], kv[1]))
+	}
+	if u := m.prmAbsoluteURL(r); u != "" {
+		authParams = append(authParams, fmt.Sprintf("resource_metadata=%q", u))
+	}
+	w.Header().Set(header.WWWAuthenticate, oas.OAuth2AuthSchemeBearer+" "+strings.Join(authParams, ", "))
+}
+
+// prmAbsoluteURL returns the PRM well-known URL for this API, or "" if PRM is not configured.
+func (m *Middleware) prmAbsoluteURL(r *http.Request) string {
+	cfg := m.lookupOAuth2Config()
+	if cfg == nil || cfg.ProtectedResourceMetadata == nil || !cfg.ProtectedResourceMetadata.Enabled {
+		return ""
+	}
+	wellKnown := cfg.ProtectedResourceMetadata.GetWellKnownPath()
+	if wellKnown == "" {
+		return ""
+	}
+	scheme := httputil.RequestScheme(r)
+	listenPath := m.Spec.APIDefinition.Proxy.ListenPath
+	full := strings.TrimSuffix(listenPath, "/") + wellKnown
+	return fmt.Sprintf("%s://%s%s", scheme, r.Host, full)
+}

--- a/ee/middleware/oauth2tokenexchange/exchange.go
+++ b/ee/middleware/oauth2tokenexchange/exchange.go
@@ -32,7 +32,7 @@ func (m *Middleware) runExchange(r *http.Request, st *oauth2common.State) (oauth
 		return out, nil
 	}
 
-	iss, _ := st.Claims["iss"].(string)
+	iss, _ := st.Claims[oas.OAuth2ClaimIss].(string)
 	provider := oauth2common.SelectExchangeProvider(cfg.TokenExchange.Providers, iss)
 	if provider == nil {
 		return out, &oauth2common.NoMatchingProviderError{Iss: iss}
@@ -203,43 +203,43 @@ func (m *Middleware) writeJSONError(w http.ResponseWriter, r *http.Request, stat
 
 // writeExchangeFailedResponse renders a 502 for an IdP-side exchange failure.
 func (m *Middleware) writeExchangeFailedResponse(w http.ResponseWriter, r *http.Request, err error) {
-	body := map[string]string{"error": oas.OAuth2ErrExchangeFailed}
+	body := map[string]string{oas.OAuth2FieldError: oas.OAuth2ErrExchangeFailed}
 	if oe, ok := err.(*oauth2common.ExchangeFailedError); ok {
 		if oe.IdpError != "" {
-			body["idp_error"] = oe.IdpError
+			body[oas.OAuth2FieldIdpError] = oe.IdpError
 		}
 		if oe.Description != "" {
-			body["idp_error_description"] = oe.Description
+			body[oas.OAuth2FieldIdpErrorDescription] = oe.Description
 		}
 	} else {
-		body["idp_error_description"] = err.Error()
+		body[oas.OAuth2FieldIdpErrorDescription] = err.Error()
 	}
 	m.writeJSONError(w, r, http.StatusBadGateway, [][2]string{
-		{"error", oas.OAuth2ErrExchangeFailed},
-		{"error_description", body["idp_error_description"]},
+		{oas.OAuth2FieldError, oas.OAuth2ErrExchangeFailed},
+		{oas.OAuth2FieldErrorDescription, body[oas.OAuth2FieldIdpErrorDescription]},
 	}, body)
 }
 
 // writeNoMatchingProviderResponse renders a 403 when no provider matches the inbound iss.
 func (m *Middleware) writeNoMatchingProviderResponse(w http.ResponseWriter, r *http.Request, oe *oauth2common.NoMatchingProviderError) {
 	m.writeJSONError(w, r, http.StatusForbidden, [][2]string{
-		{"error", oas.OAuth2ErrNoMatchingProvider},
-		{"error_description", oe.Error()},
+		{oas.OAuth2FieldError, oas.OAuth2ErrNoMatchingProvider},
+		{oas.OAuth2FieldErrorDescription, oe.Error()},
 	}, map[string]string{
-		"error":             oas.OAuth2ErrNoMatchingProvider,
-		"error_description": oe.Error(),
-		"iss":               oe.Iss,
+		oas.OAuth2FieldError:            oas.OAuth2ErrNoMatchingProvider,
+		oas.OAuth2FieldErrorDescription: oe.Error(),
+		oas.OAuth2ClaimIss:              oe.Iss,
 	})
 }
 
 // writeMisconfigResponse renders a 500 for an incomplete exchange configuration.
 func (m *Middleware) writeMisconfigResponse(w http.ResponseWriter, r *http.Request, me *oauth2common.MisconfigError) {
 	m.writeJSONError(w, r, http.StatusInternalServerError, [][2]string{
-		{"error", oas.OAuth2ErrMisconfigured},
-		{"error_description", me.Error()},
+		{oas.OAuth2FieldError, oas.OAuth2ErrMisconfigured},
+		{oas.OAuth2FieldErrorDescription, me.Error()},
 	}, map[string]string{
-		"error":             oas.OAuth2ErrMisconfigured,
-		"error_description": me.Error(),
+		oas.OAuth2FieldError:            oas.OAuth2ErrMisconfigured,
+		oas.OAuth2FieldErrorDescription: me.Error(),
 	})
 }
 
@@ -250,7 +250,7 @@ func (m *Middleware) setExchangeWWWAuthenticate(w http.ResponseWriter, r *http.R
 		authParams = append(authParams, fmt.Sprintf("%s=%q", kv[0], kv[1]))
 	}
 	if u := m.prmAbsoluteURL(r); u != "" {
-		authParams = append(authParams, fmt.Sprintf("resource_metadata=%q", u))
+		authParams = append(authParams, fmt.Sprintf("%s=%q", oas.OAuth2FieldResourceMetadata, u))
 	}
 	w.Header().Set(header.WWWAuthenticate, oas.OAuth2AuthSchemeBearer+" "+strings.Join(authParams, ", "))
 }

--- a/ee/middleware/oauth2tokenexchange/exchange.go
+++ b/ee/middleware/oauth2tokenexchange/exchange.go
@@ -16,6 +16,7 @@ import (
 	"github.com/TykTechnologies/tyk/apidef/oas"
 	"github.com/TykTechnologies/tyk/header"
 	"github.com/TykTechnologies/tyk/internal/httputil"
+	"github.com/TykTechnologies/tyk/internal/mcp"
 	"github.com/TykTechnologies/tyk/internal/oauth2common"
 )
 
@@ -57,12 +58,28 @@ func (m *Middleware) runExchange(r *http.Request, st *oauth2common.State) (oauth
 	return out, nil
 }
 
-// findActivePrimitive returns the first primitive in tools/resources/prompts with the given name and active exchange.
-func findActivePrimitive(mw *oas.Middleware, name string) *oas.MCPPrimitive {
-	for _, prims := range []oas.MCPPrimitives{mw.McpTools, mw.McpResources, mw.McpPrompts} {
-		if prim, ok := prims[name]; ok && prim != nil && prim.Exchange.IsActive() {
-			return prim
+// findActivePrimitive returns the primitive with the given name and active exchange
+// from the map that matches primitiveType. Tool, resource, and prompt names occupy
+// independent namespaces; lookup without a type falls back to searching all maps.
+func findActivePrimitive(mw *oas.Middleware, name, primitiveType string) *oas.MCPPrimitive {
+	var prims oas.MCPPrimitives
+	switch primitiveType {
+	case mcp.PrimitiveTypeTool:
+		prims = mw.McpTools
+	case mcp.PrimitiveTypeResource:
+		prims = mw.McpResources
+	case mcp.PrimitiveTypePrompt:
+		prims = mw.McpPrompts
+	default:
+		for _, ps := range []oas.MCPPrimitives{mw.McpTools, mw.McpResources, mw.McpPrompts} {
+			if prim, ok := ps[name]; ok && prim != nil && prim.Exchange.IsActive() {
+				return prim
+			}
 		}
+		return nil
+	}
+	if prim, ok := prims[name]; ok && prim != nil && prim.Exchange.IsActive() {
+		return prim
 	}
 	return nil
 }
@@ -70,7 +87,7 @@ func findActivePrimitive(mw *oas.Middleware, name string) *oas.MCPPrimitive {
 // exchangeWouldFire reports whether an exchange target exists for this request (RFC 8693 §4.8).
 func (m *Middleware) exchangeWouldFire(st *oauth2common.State, cfg *oas.OAuth2) bool {
 	if mw := m.Spec.OAS.GetTykMiddleware(); mw != nil {
-		if st.MatchedPrimitiveName != "" && findActivePrimitive(mw, st.MatchedPrimitiveName) != nil {
+		if st.MatchedPrimitiveName != "" && findActivePrimitive(mw, st.MatchedPrimitiveName, st.MatchedPrimitiveType) != nil {
 			return true
 		}
 		if st.MatchedOperationID != "" {
@@ -93,7 +110,7 @@ func (m *Middleware) exchangeWouldFire(st *oauth2common.State, cfg *oas.OAuth2) 
 func (m *Middleware) resolveExchangeTarget(st *oauth2common.State, provider *oas.OAuth2TokenExchangeProvider) *oauth2common.Target {
 	if mw := m.Spec.OAS.GetTykMiddleware(); mw != nil {
 		if st.MatchedPrimitiveName != "" {
-			if prim := findActivePrimitive(mw, st.MatchedPrimitiveName); prim != nil {
+			if prim := findActivePrimitive(mw, st.MatchedPrimitiveName, st.MatchedPrimitiveType); prim != nil {
 				return oauth2common.MergeTargetForProvider(prim.Exchange, provider, st.InferredScopes)
 			}
 		}

--- a/ee/middleware/oauth2tokenexchange/exchange_test.go
+++ b/ee/middleware/oauth2tokenexchange/exchange_test.go
@@ -1,0 +1,77 @@
+//go:build ee || dev
+
+package oauth2tokenexchange
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/internal/mcp"
+)
+
+func activePrimitive(audience string) *oas.MCPPrimitive {
+	enabled := true
+	p := &oas.MCPPrimitive{}
+	p.Exchange = &oas.OAuth2Exchange{Enabled: &enabled, Audience: audience}
+	return p
+}
+
+func TestFindActivePrimitive_ToolLookup(t *testing.T) {
+	mw := &oas.Middleware{
+		McpTools: oas.MCPPrimitives{"search": activePrimitive("https://tool-api")},
+	}
+	got := findActivePrimitive(mw, "search", mcp.PrimitiveTypeTool)
+	require.NotNil(t, got)
+	assert.Equal(t, "https://tool-api", got.Exchange.Audience)
+}
+
+func TestFindActivePrimitive_PromptLookup(t *testing.T) {
+	mw := &oas.Middleware{
+		McpPrompts: oas.MCPPrimitives{"search": activePrimitive("https://prompt-api")},
+	}
+	got := findActivePrimitive(mw, "search", mcp.PrimitiveTypePrompt)
+	require.NotNil(t, got)
+	assert.Equal(t, "https://prompt-api", got.Exchange.Audience)
+}
+
+// TestFindActivePrimitive_SameNameCollision is the regression guard for the bug
+// Andrei identified: a tool and a prompt sharing the same name must not collide.
+// Querying by type "prompt" must return nil when only the tool has active exchange.
+func TestFindActivePrimitive_SameNameCollision(t *testing.T) {
+	mw := &oas.Middleware{
+		McpTools:   oas.MCPPrimitives{"search": activePrimitive("https://tool-api")},
+		McpPrompts: oas.MCPPrimitives{"search": &oas.MCPPrimitive{}}, // no active exchange
+	}
+
+	tool := findActivePrimitive(mw, "search", mcp.PrimitiveTypeTool)
+	require.NotNil(t, tool, "tool lookup must return the tool primitive")
+
+	prompt := findActivePrimitive(mw, "search", mcp.PrimitiveTypePrompt)
+	assert.Nil(t, prompt, "prompt lookup must not return the tool primitive")
+}
+
+func TestFindActivePrimitive_BothActive_TypeSelects(t *testing.T) {
+	mw := &oas.Middleware{
+		McpTools:   oas.MCPPrimitives{"search": activePrimitive("https://tool-api")},
+		McpPrompts: oas.MCPPrimitives{"search": activePrimitive("https://prompt-api")},
+	}
+
+	tool := findActivePrimitive(mw, "search", mcp.PrimitiveTypeTool)
+	require.NotNil(t, tool)
+	assert.Equal(t, "https://tool-api", tool.Exchange.Audience)
+
+	prompt := findActivePrimitive(mw, "search", mcp.PrimitiveTypePrompt)
+	require.NotNil(t, prompt)
+	assert.Equal(t, "https://prompt-api", prompt.Exchange.Audience)
+}
+
+func TestFindActivePrimitive_UnknownType_FallbackSearchesAll(t *testing.T) {
+	mw := &oas.Middleware{
+		McpTools: oas.MCPPrimitives{"search": activePrimitive("https://tool-api")},
+	}
+	got := findActivePrimitive(mw, "search", "")
+	require.NotNil(t, got, "unknown type falls back to searching all maps")
+}

--- a/ee/middleware/oauth2tokenexchange/middleware.go
+++ b/ee/middleware/oauth2tokenexchange/middleware.go
@@ -1,0 +1,107 @@
+//go:build ee || dev
+
+// Package oauth2tokenexchange is the EE runtime for RFC 8693 token exchange.
+// It reads oauth2common.State set by the OSS OAuth2Middleware and replaces
+// the Authorization header with the exchanged token on success.
+package oauth2tokenexchange
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/internal/middleware"
+	"github.com/TykTechnologies/tyk/internal/model"
+	"github.com/TykTechnologies/tyk/internal/oauth2common"
+)
+
+// Middleware implements the EE-side TokenExchangeMiddleware.
+type Middleware struct {
+	Spec model.MergedAPI
+	Base BaseMiddleware
+}
+
+// NewMiddleware returns a new Middleware.
+func NewMiddleware(base BaseMiddleware, spec model.MergedAPI) *Middleware {
+	return &Middleware{Base: base, Spec: spec}
+}
+
+// Logger returns a logger with the middleware name attached.
+func (m *Middleware) Logger() *logrus.Entry {
+	return m.Base.Logger().WithField("mw", m.Name())
+}
+
+// Name returns the canonical name for this middleware.
+func (m *Middleware) Name() string {
+	return MiddlewareName
+}
+
+// Init is required by model.Middleware.
+func (m *Middleware) Init() {}
+
+// Unload is required by model.Middleware.
+func (m *Middleware) Unload() {}
+
+// EnabledForSpec reports whether the EE exchange runtime should run for this spec.
+func (m *Middleware) EnabledForSpec() bool {
+	cfg := m.lookupOAuth2Config()
+	if cfg == nil {
+		return false
+	}
+	return cfg.TokenExchange != nil && cfg.TokenExchange.Enabled
+}
+
+// lookupOAuth2Config returns the first oauth2 scheme config in the OAS Tyk extension.
+func (m *Middleware) lookupOAuth2Config() *oas.OAuth2 {
+	ext := m.Spec.OAS.GetTykExtension()
+	if ext == nil {
+		return nil
+	}
+	if ext.Server.Authentication == nil {
+		return nil
+	}
+	for name := range ext.Server.Authentication.SecuritySchemes {
+		if cfg := m.Spec.OAS.GetTykOAuth2Config(name); cfg != nil {
+			return cfg
+		}
+	}
+	return nil
+}
+
+// errExchangeRendered wraps middleware.ErrResponseRendered so the gateway
+// chain dispatcher skips HandleError after the exchange middleware already
+// wrote a structured JSON error body.
+var errExchangeRendered = fmt.Errorf("%w: oauth2 exchange failure response written", middleware.ErrResponseRendered)
+
+// ProcessRequest runs the RFC 8693 exchange; no-ops when no State is set or exchange is disabled.
+func (m *Middleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
+	if oauth2common.IsExchangeDone(r) {
+		return nil, http.StatusOK
+	}
+
+	st := oauth2common.GetState(r)
+	if st == nil || st.OASConfig == nil {
+		return nil, http.StatusOK
+	}
+	if st.OASConfig.TokenExchange == nil || !st.OASConfig.TokenExchange.Enabled {
+		return nil, http.StatusOK
+	}
+
+	_, err := m.runExchange(r, st)
+	if err != nil {
+		switch e := err.(type) {
+		case *oauth2common.NoMatchingProviderError:
+			m.writeNoMatchingProviderResponse(w, r, e)
+		case *oauth2common.MisconfigError:
+			m.writeMisconfigResponse(w, r, e)
+		default:
+			m.writeExchangeFailedResponse(w, r, err)
+		}
+		return errExchangeRendered, middleware.StatusRespond
+	}
+
+	oauth2common.MarkExchangeDone(r)
+	return nil, http.StatusOK
+}

--- a/ee/middleware/oauth2tokenexchange/middleware.go
+++ b/ee/middleware/oauth2tokenexchange/middleware.go
@@ -17,23 +17,19 @@ import (
 	"github.com/TykTechnologies/tyk/internal/oauth2common"
 )
 
-// Middleware implements the EE-side TokenExchangeMiddleware.
 type Middleware struct {
 	Spec model.MergedAPI
 	Base BaseMiddleware
 }
 
-// NewMiddleware returns a new Middleware.
 func NewMiddleware(base BaseMiddleware, spec model.MergedAPI) *Middleware {
 	return &Middleware{Base: base, Spec: spec}
 }
 
-// Logger returns a logger with the middleware name attached.
 func (m *Middleware) Logger() *logrus.Entry {
 	return m.Base.Logger().WithField("mw", m.Name())
 }
 
-// Name returns the canonical name for this middleware.
 func (m *Middleware) Name() string {
 	return MiddlewareName
 }
@@ -70,10 +66,7 @@ func (m *Middleware) lookupOAuth2Config() *oas.OAuth2 {
 	return nil
 }
 
-// errExchangeRendered wraps middleware.ErrResponseRendered so the gateway
-// chain dispatcher skips HandleError after the exchange middleware already
-// wrote a structured JSON error body.
-var errExchangeRendered = fmt.Errorf("%w: oauth2 exchange failure response written", middleware.ErrResponseRendered)
+var errExchangeRendered = fmt.Errorf("%w: oauth2 exchange", middleware.ErrResponseRendered)
 
 // ProcessRequest runs the RFC 8693 exchange; no-ops when no State is set or exchange is disabled.
 func (m *Middleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {

--- a/ee/middleware/oauth2tokenexchange/model.go
+++ b/ee/middleware/oauth2tokenexchange/model.go
@@ -16,8 +16,7 @@ const (
 	DefaultIdPTimeout = 15 * time.Second
 )
 
-// BaseMiddleware is the subset of the gateway's BaseMiddleware that
-// this package needs. Defined as an interface to avoid importing gateway (circular import).
+// BaseMiddleware is the gateway.BaseMiddleware surface this package needs (avoids circular import).
 type BaseMiddleware interface {
 	model.LoggerProvider
 }

--- a/ee/middleware/oauth2tokenexchange/model.go
+++ b/ee/middleware/oauth2tokenexchange/model.go
@@ -1,0 +1,31 @@
+//go:build ee || dev
+
+package oauth2tokenexchange
+
+import (
+	"time"
+
+	"github.com/TykTechnologies/tyk/internal/model"
+)
+
+const (
+	// MiddlewareName is the identifier emitted in logs.
+	MiddlewareName = "OAuth2TokenExchangeMiddleware"
+
+	// DefaultIdPTimeout is the per-call timeout when the operator leaves Timeout unset.
+	DefaultIdPTimeout = 15 * time.Second
+)
+
+// BaseMiddleware is the subset of the gateway's BaseMiddleware that
+// this package needs. Defined as an interface to avoid importing gateway (circular import).
+type BaseMiddleware interface {
+	model.LoggerProvider
+}
+
+// EffectiveIdPTimeout returns d, falling back to DefaultIdPTimeout when d is zero.
+func EffectiveIdPTimeout(d time.Duration) time.Duration {
+	if d > 0 {
+		return d
+	}
+	return DefaultIdPTimeout
+}

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -236,9 +236,6 @@ func (s *APISpec) Validate(oasConfig config.OASConfig) error {
 		if err != nil {
 			return err
 		}
-		if err := s.OAS.ValidateOAuth2Schemes(); err != nil {
-			return err
-		}
 	}
 
 	// For tcp services we need to make sure we can bind to the port.

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -773,20 +773,10 @@ func (a APIDefinitionLoader) loadDefFromFilePath(filePath string) (*APISpec, err
 	nestDef := model.MergedAPI{APIDefinition: &def}
 	if def.IsOAS {
 		loader := openapi3.NewLoader()
-		// Wrap the URI reader so replaceSecrets runs on the OAS bytes
-		// before the openapi3 loader parses them. Without this wrap,
-		// `env://` / `secrets://` / `vault://` / `consul://` prefixes
-		// inside the x-tyk-api-gateway extension (e.g. on the new
-		// oauth2 scheme's clientSecret fields) would land in the
-		// in-memory struct unresolved. The classic apidef file already
-		// gets replaceSecrets applied above; this extends the same
-		// coverage to the OAS companion file.
-		//
-		// Scoped to local-file reads (empty or "file" scheme): a
-		// remote `$ref` URL points at content the operator does NOT
-		// necessarily trust to dereference into their own secret
-		// store, so resolving `vault://...` in remote-fetched bytes
-		// would be an injection vector.
+		// Apply replaceSecrets to OAS bytes before parsing so secret prefixes
+		// (vault://, env://, etc.) in the x-tyk-api-gateway extension are resolved.
+		// Scoped to local-file reads only — resolving remote $ref content would be
+		// an injection vector for operator-untrusted bytes.
 		loader.ReadFromURIFunc = func(l *openapi3.Loader, uri *url.URL) ([]byte, error) {
 			b, err := openapi3.ReadFromFile(l, uri)
 			if err != nil {

--- a/gateway/api_definition.go
+++ b/gateway/api_definition.go
@@ -236,6 +236,9 @@ func (s *APISpec) Validate(oasConfig config.OASConfig) error {
 		if err != nil {
 			return err
 		}
+		if err := s.OAS.ValidateOAuth2Schemes(); err != nil {
+			return err
+		}
 	}
 
 	// For tcp services we need to make sure we can bind to the port.
@@ -770,8 +773,30 @@ func (a APIDefinitionLoader) loadDefFromFilePath(filePath string) (*APISpec, err
 	nestDef := model.MergedAPI{APIDefinition: &def}
 	if def.IsOAS {
 		loader := openapi3.NewLoader()
-		// use openapi3.ReadFromFile as ReadFromURIFunc since the default implementation cache spec based on file path.
-		loader.ReadFromURIFunc = openapi3.ReadFromFile
+		// Wrap the URI reader so replaceSecrets runs on the OAS bytes
+		// before the openapi3 loader parses them. Without this wrap,
+		// `env://` / `secrets://` / `vault://` / `consul://` prefixes
+		// inside the x-tyk-api-gateway extension (e.g. on the new
+		// oauth2 scheme's clientSecret fields) would land in the
+		// in-memory struct unresolved. The classic apidef file already
+		// gets replaceSecrets applied above; this extends the same
+		// coverage to the OAS companion file.
+		//
+		// Scoped to local-file reads (empty or "file" scheme): a
+		// remote `$ref` URL points at content the operator does NOT
+		// necessarily trust to dereference into their own secret
+		// store, so resolving `vault://...` in remote-fetched bytes
+		// would be an injection vector.
+		loader.ReadFromURIFunc = func(l *openapi3.Loader, uri *url.URL) ([]byte, error) {
+			b, err := openapi3.ReadFromFile(l, uri)
+			if err != nil {
+				return nil, err
+			}
+			if uri == nil || uri.Scheme == "" || uri.Scheme == "file" {
+				return a.replaceSecrets(b), nil
+			}
+			return b, nil
+		}
 
 		var oasFilepath string
 		if def.IsMCP() {

--- a/gateway/api_loader.go
+++ b/gateway/api_loader.go
@@ -526,6 +526,7 @@ func (gw *Gateway) processSpec(
 	}
 
 	gw.mwAppendEnabled(&chainArray, &OAuth2Middleware{BaseMiddleware: baseMid.Copy()})
+	gw.mwAppendEnabled(&chainArray, getOAuth2ExchangeMw(baseMid.Copy()))
 
 	gw.mwAppendEnabled(&chainArray, &RateLimitForAPI{BaseMiddleware: baseMid.Copy(), quotaKey: options.quotaKey})
 	gw.mwAppendEnabled(&chainArray, &GraphQLMiddleware{BaseMiddleware: baseMid.Copy()})

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -190,7 +190,7 @@ func (gw *Gateway) createMiddleware(actualMW TykMiddleware) func(http.Handler) h
 			if err != nil {
 				// Prevent double error write
 				writeResponse := true
-				if goPlugin, isGoPlugin := actualMW.(*GoPluginMiddleware); isGoPlugin && goPlugin.handler != nil || errors.Is(err, ErrResponseErrorSent) {
+				if goPlugin, isGoPlugin := actualMW.(*GoPluginMiddleware); isGoPlugin && goPlugin.handler != nil || errors.Is(err, ErrResponseErrorSent) || errors.Is(err, middleware.ErrResponseRendered) {
 					writeResponse = false
 				}
 

--- a/gateway/mw_oauth2.go
+++ b/gateway/mw_oauth2.go
@@ -53,7 +53,13 @@ func (m *OAuth2Middleware) EnabledForSpec() bool {
 	if cfg == nil || !cfg.Enabled {
 		return false
 	}
-	return cfg.ScopeCheck != nil && cfg.ScopeCheck.Enabled
+	if cfg.ScopeCheck != nil && cfg.ScopeCheck.Enabled {
+		return true
+	}
+	if cfg.TokenExchange != nil && cfg.TokenExchange.Enabled {
+		return true
+	}
+	return false
 }
 
 func (m *OAuth2Middleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _ interface{}) (error, int) {
@@ -62,58 +68,151 @@ func (m *OAuth2Middleware) ProcessRequest(w http.ResponseWriter, r *http.Request
 	}
 
 	_, cfg := m.Spec.GetOAuth2Config()
-	if cfg == nil || cfg.ScopeCheck == nil || !cfg.ScopeCheck.Enabled {
+	if cfg == nil {
+		return nil, http.StatusOK
+	}
+	scopeCheckActive := cfg.ScopeCheck != nil && cfg.ScopeCheck.Enabled
+	exchangeActive := cfg.TokenExchange != nil && cfg.TokenExchange.Enabled
+	if !scopeCheckActive && !exchangeActive {
 		return nil, http.StatusOK
 	}
 
-	alternatives := m.requiredScopeAlternativesForRequest(r)
-	if len(alternatives) == 0 {
-		// Nothing to enforce for this request (no per-op `security:`,
-		// no root `security:`, or the resolved requirement is vacuous).
-		return nil, http.StatusOK
+	var alternatives [][]string
+	if scopeCheckActive {
+		alternatives = m.requiredScopeAlternativesForRequest(r)
 	}
 
+	// Both gates read the inbound Bearer + parsed claims. A request
+	// needs a usable bearer when scope-check is enforcing (has at
+	// least one alternative) OR when exchange is enabled — passing an
+	// empty / unparseable subject_token to the IdP would surface as a
+	// confusing 502 exchange_failed instead of an honest 401 missing
+	// bearer. Reject missing / malformed tokens before reaching the
+	// downstream EE middleware.
+	needsBearer := exchangeActive || (scopeCheckActive && len(alternatives) > 0)
 	rawToken := stripBearer(r.Header.Get(header.Authorization))
+	var claims jwt.MapClaims
 	if rawToken == "" {
-		m.setWWWAuthenticateInsufficientToken(w, r, oas.OAuth2ErrInvalidToken, "missing bearer token")
-		return errors.New("Authorization field missing"), http.StatusUnauthorized
+		if needsBearer {
+			m.setWWWAuthenticateInsufficientToken(w, r, oas.OAuth2ErrInvalidToken, "missing bearer token")
+			return errors.New("Authorization field missing"), http.StatusUnauthorized
+		}
+	} else {
+		c, err := oauth2common.ParseUnverifiedClaims(rawToken)
+		if err != nil {
+			if needsBearer {
+				m.setWWWAuthenticateInsufficientToken(w, r, oas.OAuth2ErrInvalidToken, "token is not a parseable JWT")
+				return fmt.Errorf("parsing inbound token claims: %w", err), http.StatusUnauthorized
+			}
+		} else {
+			claims = c
+		}
 	}
 
-	claims, err := oauth2common.ParseUnverifiedClaims(rawToken)
-	if err != nil {
-		m.setWWWAuthenticateInsufficientToken(w, r, oas.OAuth2ErrInvalidToken, "token is not a parseable JWT")
-		return fmt.Errorf("parsing inbound token claims: %w", err), http.StatusUnauthorized
+	if scopeCheckActive && len(alternatives) > 0 && !tokenSatisfiesAnyAlternative(claims, cfg.ScopeCheck, alternatives) {
+		// The first declared alternative is cited on the challenge —
+		// listing every alternative would leak intent (a
+		// service-account scope shouldn't be advertised to a
+		// user-token caller).
+		cited := alternatives[0]
+		citedScopes := strings.Join(cited, " ")
+		m.fireScopeCheckFailedEvent(r, claims, alternatives, cited, cfg.ScopeCheck)
+		m.setWWWAuthenticateInsufficientScope(w, r, cited)
+
+		// MCP / JSON-RPC routes get the failure wrapped in a JSON-RPC
+		// 2.0 error envelope by the chain's error handler (which keys
+		// off the routing state). REST routes get the RFC 6750-style
+		// JSON body written inline.
+		if m.Spec.IsMCP() && httpctx.GetJSONRPCRoutingState(r) != nil {
+			return errors.New(oas.OAuth2ErrInsufficientScope), http.StatusForbidden
+		}
+
+		body, _ := json.Marshal(map[string]interface{}{
+			"error":             oas.OAuth2ErrInsufficientScope,
+			"error_description": "token does not satisfy required scopes: " + citedScopes,
+			"scope":             citedScopes,
+		})
+		w.Header().Set(header.ContentType, header.ApplicationJSON)
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write(body)
+		return nil, middleware.StatusRespond
 	}
 
-	if tokenSatisfiesAnyAlternative(claims, cfg.ScopeCheck, alternatives) {
-		return nil, http.StatusOK
+	// Hand off to the EE TokenExchangeMiddleware (when configured) via
+	// request-context state. The chain runs the EE middleware after
+	// this one; on OSS builds it is replaced with a noop that prints a
+	// one-time warning when an operator has configured
+	// tokenExchange.enabled=true.
+	if exchangeActive {
+		oauth2common.SetState(r, &oauth2common.State{
+			Claims:               claims,
+			RawToken:             rawToken,
+			OASConfig:            cfg,
+			APIID:                m.Spec.APIID,
+			MatchedOperationID:   m.matchedOperationIDForRequest(r),
+			MatchedPrimitiveName: matchedPrimitiveNameForRequest(r),
+			InferredScopes:       m.inferredScopesForRequest(r),
+		})
 	}
+	return nil, http.StatusOK
+}
 
-	// The first declared alternative is cited on the challenge — listing
-	// every alternative would leak intent (a service-account scope
-	// shouldn't be advertised to a user-token caller).
-	cited := alternatives[0]
-	citedScopes := strings.Join(cited, " ")
-	m.fireScopeCheckFailedEvent(r, claims, alternatives, cited, cfg.ScopeCheck)
-	m.setWWWAuthenticateInsufficientScope(w, r, cited)
-
-	// MCP / JSON-RPC routes get the failure wrapped in a JSON-RPC 2.0
-	// error envelope by the chain's error handler (which keys off the
-	// routing state). REST routes get the RFC 6750-style JSON body
-	// written inline.
-	if m.Spec.IsMCP() && httpctx.GetJSONRPCRoutingState(r) != nil {
-		return errors.New(oas.OAuth2ErrInsufficientScope), http.StatusForbidden
+// matchedOperationIDForRequest returns the OAS operationId that the
+// gateway's router resolved for this request, or "" when no path/method
+// matched (or this isn't an OAS API).
+func (m *OAuth2Middleware) matchedOperationIDForRequest(r *http.Request) string {
+	if op := m.findOASOperation(r); op != nil {
+		return op.OperationID
 	}
+	return ""
+}
 
-	body, _ := json.Marshal(map[string]interface{}{
-		"error":             oas.OAuth2ErrInsufficientScope,
-		"error_description": "token does not satisfy required scopes: " + citedScopes,
-		"scope":             citedScopes,
-	})
-	w.Header().Set(header.ContentType, header.ApplicationJSON)
-	w.WriteHeader(http.StatusForbidden)
-	_, _ = w.Write(body)
-	return nil, middleware.StatusRespond
+// matchedPrimitiveNameForRequest returns the JSONRPC primitive name
+// (MCP tool / resource / prompt) resolved upstream by the JSONRPC
+// middleware, or "" when this isn't a JSONRPC request.
+func matchedPrimitiveNameForRequest(r *http.Request) string {
+	if state := httpctx.GetJSONRPCRoutingState(r); state != nil {
+		return state.PrimitiveName
+	}
+	return ""
+}
+
+// inferredScopesForRequest returns the union of all scope alternatives
+// for the request — used for outbound exchange.scopes inference per
+// RFC 8693 §4.5.5: multiple alternatives in `security:` (OR-of-AND)
+// all contribute, since the gateway already passes the inbound check
+// on at least one alternative and can't tell at exchange time which
+// alternative the caller satisfied.
+func (m *OAuth2Middleware) inferredScopesForRequest(r *http.Request) []string {
+	return flattenScopeAlternatives(m.requiredScopeAlternativesForRequest(r))
+}
+
+// flattenScopeAlternatives merges every alternative of the OR-of-AND
+// requirement into one deduplicated flat list, preserving first-seen
+// order across alternatives.
+func flattenScopeAlternatives(alts [][]string) []string {
+	if len(alts) == 0 {
+		return nil
+	}
+	var merged []string
+	for _, alt := range alts {
+		merged = append(merged, alt...)
+	}
+	return dedupPreserveOrder(merged)
+}
+
+// dedupPreserveOrder returns s with duplicates removed, preserving
+// first-seen order.
+func dedupPreserveOrder(s []string) []string {
+	seen := make(map[string]struct{}, len(s))
+	out := s[:0:0]
+	for _, v := range s {
+		if _, ok := seen[v]; !ok {
+			seen[v] = struct{}{}
+			out = append(out, v)
+		}
+	}
+	return out
 }
 
 // requiredScopeAlternativesForRequest resolves the OR-of-AND scope

--- a/gateway/mw_oauth2.go
+++ b/gateway/mw_oauth2.go
@@ -82,67 +82,21 @@ func (m *OAuth2Middleware) ProcessRequest(w http.ResponseWriter, r *http.Request
 		alternatives = m.requiredScopeAlternativesForRequest(r)
 	}
 
-	// Both gates read the inbound Bearer + parsed claims. A request
-	// needs a usable bearer when scope-check is enforcing (has at
-	// least one alternative) OR when exchange is enabled — passing an
-	// empty / unparseable subject_token to the IdP would surface as a
-	// confusing 502 exchange_failed instead of an honest 401 missing
-	// bearer. Reject missing / malformed tokens before reaching the
-	// downstream EE middleware.
+	// Both gates read the inbound Bearer + parsed claims. Reject missing /
+	// malformed tokens before reaching the downstream EE middleware — passing
+	// an empty subject_token would surface as a confusing 502 exchange_failed
+	// instead of an honest 401 missing bearer.
 	needsBearer := exchangeActive || (scopeCheckActive && len(alternatives) > 0)
-	rawToken := stripBearer(r.Header.Get(header.Authorization))
-	var claims jwt.MapClaims
-	if rawToken == "" {
-		if needsBearer {
-			m.setWWWAuthenticateInsufficientToken(w, r, oas.OAuth2ErrInvalidToken, "missing bearer token")
-			return errors.New("Authorization field missing"), http.StatusUnauthorized
-		}
-	} else {
-		c, err := oauth2common.ParseUnverifiedClaims(rawToken)
-		if err != nil {
-			if needsBearer {
-				m.setWWWAuthenticateInsufficientToken(w, r, oas.OAuth2ErrInvalidToken, "token is not a parseable JWT")
-				return fmt.Errorf("parsing inbound token claims: %w", err), http.StatusUnauthorized
-			}
-		} else {
-			claims = c
-		}
+	rawToken, claims, err, status := m.parseBearerClaims(w, r, needsBearer)
+	if err != nil {
+		return err, status
 	}
 
 	if scopeCheckActive && len(alternatives) > 0 && !tokenSatisfiesAnyAlternative(claims, cfg.ScopeCheck, alternatives) {
-		// The first declared alternative is cited on the challenge —
-		// listing every alternative would leak intent (a
-		// service-account scope shouldn't be advertised to a
-		// user-token caller).
-		cited := alternatives[0]
-		citedScopes := strings.Join(cited, " ")
-		m.fireScopeCheckFailedEvent(r, claims, alternatives, cited, cfg.ScopeCheck)
-		m.setWWWAuthenticateInsufficientScope(w, r, cited)
-
-		// MCP / JSON-RPC routes get the failure wrapped in a JSON-RPC
-		// 2.0 error envelope by the chain's error handler (which keys
-		// off the routing state). REST routes get the RFC 6750-style
-		// JSON body written inline.
-		if m.Spec.IsMCP() && httpctx.GetJSONRPCRoutingState(r) != nil {
-			return errors.New(oas.OAuth2ErrInsufficientScope), http.StatusForbidden
-		}
-
-		body, _ := json.Marshal(map[string]interface{}{
-			oas.OAuth2FieldError:            oas.OAuth2ErrInsufficientScope,
-			oas.OAuth2FieldErrorDescription: "token does not satisfy required scopes: " + citedScopes,
-			"scope":                         citedScopes,
-		})
-		w.Header().Set(header.ContentType, header.ApplicationJSON)
-		w.WriteHeader(http.StatusForbidden)
-		_, _ = w.Write(body)
-		return nil, middleware.StatusRespond
+		return m.handleScopeCheckFailure(w, r, claims, alternatives, cfg)
 	}
 
-	// Hand off to the EE TokenExchangeMiddleware (when configured) via
-	// request-context state. The chain runs the EE middleware after
-	// this one; on OSS builds it is replaced with a noop that prints a
-	// one-time warning when an operator has configured
-	// tokenExchange.enabled=true.
+	// Hand off to the EE TokenExchangeMiddleware via request-context state.
 	if exchangeActive {
 		oauth2common.SetState(r, &oauth2common.State{
 			Claims:               claims,
@@ -151,10 +105,61 @@ func (m *OAuth2Middleware) ProcessRequest(w http.ResponseWriter, r *http.Request
 			APIID:                m.Spec.APIID,
 			MatchedOperationID:   m.matchedOperationIDForRequest(r),
 			MatchedPrimitiveName: matchedPrimitiveNameForRequest(r),
+			MatchedPrimitiveType: matchedPrimitiveTypeForRequest(r),
 			InferredScopes:       m.inferredScopesForRequest(r),
 		})
 	}
 	return nil, http.StatusOK
+}
+
+// parseBearerClaims extracts and parses the inbound Bearer token.
+// When needsBearer is true and the token is absent or unparseable, it writes
+// the appropriate WWW-Authenticate challenge and returns a non-nil error.
+func (m *OAuth2Middleware) parseBearerClaims(w http.ResponseWriter, r *http.Request, needsBearer bool) (rawToken string, claims jwt.MapClaims, err error, status int) {
+	rawToken = stripBearer(r.Header.Get(header.Authorization))
+	if rawToken == "" {
+		if needsBearer {
+			m.setWWWAuthenticateInsufficientToken(w, r, oas.OAuth2ErrInvalidToken, "missing bearer token")
+			return "", nil, errors.New("Authorization field missing"), http.StatusUnauthorized
+		}
+		return "", nil, nil, 0
+	}
+	c, parseErr := oauth2common.ParseUnverifiedClaims(rawToken)
+	if parseErr != nil {
+		if needsBearer {
+			m.setWWWAuthenticateInsufficientToken(w, r, oas.OAuth2ErrInvalidToken, "token is not a parseable JWT")
+			return "", nil, fmt.Errorf("parsing inbound token claims: %w", parseErr), http.StatusUnauthorized
+		}
+		return rawToken, nil, nil, 0
+	}
+	return rawToken, c, nil, 0
+}
+
+// handleScopeCheckFailure writes the RFC 6750 scope rejection and returns the
+// appropriate error. The first declared alternative is cited on the challenge —
+// listing every alternative would leak intent.
+func (m *OAuth2Middleware) handleScopeCheckFailure(w http.ResponseWriter, r *http.Request, claims jwt.MapClaims, alternatives [][]string, cfg *oas.OAuth2) (error, int) {
+	cited := alternatives[0]
+	citedScopes := strings.Join(cited, " ")
+	m.fireScopeCheckFailedEvent(r, claims, alternatives, cited, cfg.ScopeCheck)
+	m.setWWWAuthenticateInsufficientScope(w, r, cited)
+
+	// MCP / JSON-RPC routes get the failure wrapped in a JSON-RPC 2.0 error
+	// envelope by the chain's error handler. REST routes get the RFC 6750-style
+	// JSON body written inline.
+	if m.Spec.IsMCP() && httpctx.GetJSONRPCRoutingState(r) != nil {
+		return errors.New(oas.OAuth2ErrInsufficientScope), http.StatusForbidden
+	}
+
+	body, _ := json.Marshal(map[string]interface{}{
+		oas.OAuth2FieldError:            oas.OAuth2ErrInsufficientScope,
+		oas.OAuth2FieldErrorDescription: "token does not satisfy required scopes: " + citedScopes,
+		"scope":                         citedScopes,
+	})
+	w.Header().Set(header.ContentType, header.ApplicationJSON)
+	w.WriteHeader(http.StatusForbidden)
+	_, _ = w.Write(body)
+	return nil, middleware.StatusRespond
 }
 
 // matchedOperationIDForRequest returns the OAS operationId that the
@@ -167,12 +172,22 @@ func (m *OAuth2Middleware) matchedOperationIDForRequest(r *http.Request) string 
 	return ""
 }
 
-// matchedPrimitiveNameForRequest returns the JSONRPC primitive name
-// (MCP tool / resource / prompt) resolved upstream by the JSONRPC
-// middleware, or "" when this isn't a JSONRPC request.
+// matchedPrimitiveNameForRequest returns the MCP primitive name resolved
+// upstream by the JSONRPC middleware, or "" when this isn't a JSONRPC request.
 func matchedPrimitiveNameForRequest(r *http.Request) string {
 	if state := httpctx.GetJSONRPCRoutingState(r); state != nil {
 		return state.PrimitiveName
+	}
+	return ""
+}
+
+// matchedPrimitiveTypeForRequest returns the MCP primitive type ("tool",
+// "resource", "prompt") resolved upstream by the JSONRPC middleware, or ""
+// when this isn't a JSONRPC request. Must be paired with
+// matchedPrimitiveNameForRequest — tool and prompt names share no namespace.
+func matchedPrimitiveTypeForRequest(r *http.Request) string {
+	if state := httpctx.GetJSONRPCRoutingState(r); state != nil {
+		return state.PrimitiveType
 	}
 	return ""
 }

--- a/gateway/mw_oauth2.go
+++ b/gateway/mw_oauth2.go
@@ -128,9 +128,9 @@ func (m *OAuth2Middleware) ProcessRequest(w http.ResponseWriter, r *http.Request
 		}
 
 		body, _ := json.Marshal(map[string]interface{}{
-			"error":             oas.OAuth2ErrInsufficientScope,
-			"error_description": "token does not satisfy required scopes: " + citedScopes,
-			"scope":             citedScopes,
+			oas.OAuth2FieldError:            oas.OAuth2ErrInsufficientScope,
+			oas.OAuth2FieldErrorDescription: "token does not satisfy required scopes: " + citedScopes,
+			"scope":                         citedScopes,
 		})
 		w.Header().Set(header.ContentType, header.ApplicationJSON)
 		w.WriteHeader(http.StatusForbidden)
@@ -618,8 +618,8 @@ func (m *OAuth2Middleware) setWWWAuthenticate(w http.ResponseWriter, params [][2
 func (m *OAuth2Middleware) setWWWAuthenticateInsufficientScope(w http.ResponseWriter, r *http.Request, scopes []string) {
 	scopesValue := strings.Join(scopes, " ")
 	params := [][2]string{
-		{"error", oas.OAuth2ErrInsufficientScope},
-		{"error_description", "missing required scope: " + scopesValue},
+		{oas.OAuth2FieldError, oas.OAuth2ErrInsufficientScope},
+		{oas.OAuth2FieldErrorDescription, "missing required scope: " + scopesValue},
 		{"scope", scopesValue},
 	}
 	m.setWWWAuthenticate(w, m.appendResourceMetadataParam(r, params))
@@ -627,8 +627,8 @@ func (m *OAuth2Middleware) setWWWAuthenticateInsufficientScope(w http.ResponseWr
 
 func (m *OAuth2Middleware) setWWWAuthenticateInsufficientToken(w http.ResponseWriter, r *http.Request, code, desc string) {
 	params := [][2]string{
-		{"error", code},
-		{"error_description", desc},
+		{oas.OAuth2FieldError, code},
+		{oas.OAuth2FieldErrorDescription, desc},
 	}
 	m.setWWWAuthenticate(w, m.appendResourceMetadataParam(r, params))
 }
@@ -638,7 +638,7 @@ func (m *OAuth2Middleware) setWWWAuthenticateInsufficientToken(w http.ResponseWr
 // document (see prmMetadataURL); no-op otherwise.
 func (m *OAuth2Middleware) appendResourceMetadataParam(r *http.Request, params [][2]string) [][2]string {
 	if url := prmMetadataURL(r, m.Spec); url != "" {
-		params = append(params, [2]string{"resource_metadata", url})
+		params = append(params, [2]string{oas.OAuth2FieldResourceMetadata, url})
 	}
 	return params
 }

--- a/gateway/mw_oauth2_exchange.go
+++ b/gateway/mw_oauth2_exchange.go
@@ -1,0 +1,39 @@
+//go:build !ee && !dev
+
+package gateway
+
+import (
+	"net/http"
+	"sync"
+)
+
+// getOAuth2ExchangeMw returns a noop shim on OSS builds (mirrors mw_oauth2_auth.go / mw_streaming.go).
+func getOAuth2ExchangeMw(base *BaseMiddleware) TykMiddleware {
+	return &noopOAuth2Exchange{BaseMiddleware: base}
+}
+
+type noopOAuth2Exchange struct {
+	*BaseMiddleware
+	logOnce sync.Once
+}
+
+func (d *noopOAuth2Exchange) ProcessRequest(_ http.ResponseWriter, _ *http.Request, _ interface{}) (error, int) {
+	return nil, http.StatusOK
+}
+
+// EnabledForSpec always returns false but logs once when tokenExchange.enabled=true on an OSS build.
+func (d *noopOAuth2Exchange) EnabledForSpec() bool {
+	if d.Spec == nil || !d.Spec.IsOAS {
+		return false
+	}
+	if _, cfg := d.Spec.GetOAuth2Config(); cfg != nil && cfg.TokenExchange != nil && cfg.TokenExchange.Enabled {
+		d.logOnce.Do(func() {
+			d.Logger().Error("OAuth2 token exchange is supported only in Tyk Enterprise Edition; the configured tokenExchange block is being ignored on this build")
+		})
+	}
+	return false
+}
+
+func (d *noopOAuth2Exchange) Name() string {
+	return "NoopOAuth2Exchange"
+}

--- a/gateway/mw_oauth2_exchange_ee.go
+++ b/gateway/mw_oauth2_exchange_ee.go
@@ -1,0 +1,24 @@
+//go:build ee || dev
+
+package gateway
+
+import (
+	"github.com/TykTechnologies/tyk/ee/middleware/oauth2tokenexchange"
+	"github.com/TykTechnologies/tyk/internal/model"
+)
+
+// EE-build factory for the TokenExchangeMiddleware. Constructs the
+// real EE middleware backed by ee/middleware/oauth2tokenexchange.
+//
+// Story 06 wires no Redis caches and no actor token — those come in
+// Stories 07 / 08. The EE factory grows in those stories.
+func getOAuth2ExchangeMw(base *BaseMiddleware) TykMiddleware {
+	// Both APIDefinition AND OAS are required: the EE middleware reads
+	// per-operation exchange overrides off Spec.OAS via
+	// GetTykMiddleware(). Passing nil OAS would nil-deref at the first
+	// request.
+	mwSpec := model.MergedAPI{APIDefinition: base.Spec.APIDefinition, OAS: &base.Spec.OAS}
+
+	mw := oauth2tokenexchange.NewMiddleware(base, mwSpec)
+	return WrapMiddleware(base, mw)
+}

--- a/gateway/mw_oauth2_exchange_ee.go
+++ b/gateway/mw_oauth2_exchange_ee.go
@@ -7,16 +7,9 @@ import (
 	"github.com/TykTechnologies/tyk/internal/model"
 )
 
-// EE-build factory for the TokenExchangeMiddleware. Constructs the
-// real EE middleware backed by ee/middleware/oauth2tokenexchange.
-//
-// Story 06 wires no Redis caches and no actor token — those come in
-// Stories 07 / 08. The EE factory grows in those stories.
 func getOAuth2ExchangeMw(base *BaseMiddleware) TykMiddleware {
-	// Both APIDefinition AND OAS are required: the EE middleware reads
-	// per-operation exchange overrides off Spec.OAS via
-	// GetTykMiddleware(). Passing nil OAS would nil-deref at the first
-	// request.
+	// OAS is required: the EE middleware reads per-operation exchange
+	// overrides off Spec.OAS; nil OAS would panic on the first request.
 	mwSpec := model.MergedAPI{APIDefinition: base.Spec.APIDefinition, OAS: &base.Spec.OAS}
 
 	mw := oauth2tokenexchange.NewMiddleware(base, mwSpec)

--- a/gateway/mw_oauth2_gating_test.go
+++ b/gateway/mw_oauth2_gating_test.go
@@ -119,7 +119,7 @@ func buildOAuth2ExchangeAPI(idpIss, idpEndpoint string, listenPath string) strin
 			},
 			"middleware": {
 				"operations": {
-					"getMail": {"exchange": {"scopes": ["users:read"]}}
+					"getMail": {"exchange": {"enabled": true, "scopes": ["users:read"]}}
 				}
 			}
 		}

--- a/gateway/mw_oauth2_gating_test.go
+++ b/gateway/mw_oauth2_gating_test.go
@@ -44,7 +44,7 @@ func fakeIdP(t *testing.T, requireBasic bool) (*httptest.Server, *int32) {
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"access_token":      access,
 			"issued_token_type": oas.OAuth2TokenTypeAccessToken,
-			"token_type":        "Bearer",
+			"token_type":        oas.OAuth2AuthSchemeBearer,
 			"expires_in":        300,
 		})
 	}))

--- a/gateway/mw_oauth2_gating_test.go
+++ b/gateway/mw_oauth2_gating_test.go
@@ -1,0 +1,269 @@
+package gateway
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/test"
+)
+
+// fakeIdP returns a test IdP that mints a deterministic base64url-encoded exchanged token.
+func fakeIdP(t *testing.T, requireBasic bool) (*httptest.Server, *int32) {
+	t.Helper()
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		if requireBasic {
+			user, pass, ok := r.BasicAuth()
+			if !ok || user == "" || pass == "" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+		}
+		_ = r.ParseForm()
+		aud := r.PostForm.Get(oas.OAuth2FormAudience)
+		scope := r.PostForm.Get(oas.OAuth2FormScope)
+		payload := map[string]interface{}{"aud": aud, "scope": scope, "iss": "https://exchanged-idp", "sub": "alice"}
+		payloadJSON, _ := json.Marshal(payload)
+		header64 := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+		payload64 := base64.RawURLEncoding.EncodeToString(payloadJSON)
+		access := header64 + "." + payload64 + ".sig"
+		w.Header().Set(header.ContentType, header.ApplicationJSON)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token":      access,
+			"issued_token_type": oas.OAuth2TokenTypeAccessToken,
+			"token_type":        "Bearer",
+			"expires_in":        300,
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &callCount
+}
+
+// mintInboundUnverifiedJWT returns an unsigned JWT triple with iss and sub claims.
+func mintInboundUnverifiedJWT(t *testing.T, iss string) string {
+	t.Helper()
+	payload := map[string]string{"iss": iss, "sub": "alice", "azp": "mcp-client"}
+	pj, _ := json.Marshal(payload)
+	header64 := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payload64 := base64.RawURLEncoding.EncodeToString(pj)
+	return header64 + "." + payload64 + ".sig"
+}
+
+// echoUpstream records the Authorization header it receives so the
+// test can assert which token was forwarded.
+type echoUpstream struct {
+	authHeader atomic.Value // string
+}
+
+func (u *echoUpstream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	u.authHeader.Store(r.Header.Get(header.Authorization))
+	w.Header().Set(header.ContentType, header.ApplicationJSON)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"headers": map[string]string{header.Authorization: r.Header.Get(header.Authorization)},
+	})
+}
+
+func (u *echoUpstream) ReceivedBearer() string {
+	v, _ := u.authHeader.Load().(string)
+	return v
+}
+
+func buildOAuth2ExchangeAPI(idpIss, idpEndpoint string, listenPath string) string {
+	return fmt.Sprintf(`{
+		"openapi": "3.0.3",
+		"info": {"title": "story06", "version": "1.0.0"},
+		"paths": {
+			"/mail": {"get": {"operationId": "getMail", "responses": {"200": {"description": "ok"}}}}
+		},
+		"components": {
+			"securitySchemes": {
+				"corpOAuth": {"type": "oauth2", "flows": {"authorizationCode": {"authorizationUrl": "x", "tokenUrl": "x", "scopes": {}}}}
+			}
+		},
+		"security": [{"corpOAuth": []}],
+		"x-tyk-api-gateway": {
+			"info": {"name": "story06"},
+			"server": {
+				"listenPath": {"value": %q, "strip": true},
+				"authentication": {
+					"enabled": true,
+					"securitySchemes": {
+						"corpOAuth": {
+							"enabled": true,
+							"tokenExchange": {
+								"enabled": true,
+								"providers": [{
+									"name": "primary",
+									"issuers": [%q],
+									"tokenEndpoint": %q,
+									"clientAuth": {"method": "client_secret_basic", "clientId": "tyk-gateway", "clientSecret": "shh"},
+									"defaultTarget": {"audience": "upstream-api"}
+								}]
+							}
+						}
+					}
+				}
+			},
+			"middleware": {
+				"operations": {
+					"getMail": {"exchange": {"scopes": ["users:read"]}}
+				}
+			}
+		}
+	}`, listenPath, idpIss, idpEndpoint)
+}
+
+func decodeExchangedToken(t *testing.T, bearer string) map[string]interface{} {
+	t.Helper()
+	parts := strings.Split(bearer, ".")
+	require.Len(t, parts, 3, "expected 3 JWT segments, got %d in %q", len(parts), bearer)
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(payload, &m))
+	return m
+}
+
+// TestOAuth2Gating_BuildFlavorParity verifies EE exchanges the token while OSS forwards it unchanged.
+func TestOAuth2Gating_BuildFlavorParity(t *testing.T) {
+	idp, idpCalls := fakeIdP(t, true)
+	upstream := &echoUpstream{}
+	upstreamSrv := httptest.NewServer(upstream)
+	t.Cleanup(upstreamSrv.Close)
+
+	ts := StartTest(nil)
+	t.Cleanup(ts.Close)
+
+	const listenPath = "/story06/"
+	oasJSON := buildOAuth2ExchangeAPI(idp.URL, idp.URL+"/token", listenPath)
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.IsOAS = true
+		require.NoError(t, spec.OAS.UnmarshalJSON([]byte(oasJSON)))
+		spec.OAS.ExtractTo(spec.APIDefinition)
+		spec.APIID = "story06-gating"
+		spec.Proxy.ListenPath = listenPath
+		spec.Proxy.TargetURL = upstreamSrv.URL
+		spec.Proxy.StripListenPath = true
+		spec.Name = "story06-gating"
+		// Tyk's auth-method discovery treats the OAS oauth2 scheme as
+		// "auth happens here" but the new-style block does not (yet)
+		// introspect inbound tokens — leaving UseKeylessAccess off
+		// would cause the auth chain to 403 the request before either
+		// the scope-check or the exchange middleware runs.
+		spec.UseKeylessAccess = true
+	})
+
+	inbound := mintInboundUnverifiedJWT(t, idp.URL)
+
+	resp, err := ts.Run(t, test.TestCase{
+		Path:    "/story06/mail",
+		Method:  http.MethodGet,
+		Headers: map[string]string{header.Authorization: oas.OAuth2AuthSchemeBearer + " " + inbound},
+		Code:    http.StatusOK,
+	})
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.ReadAll(resp.Body)
+
+	upstreamSawBearer := strings.TrimPrefix(upstream.ReceivedBearer(), oas.OAuth2AuthSchemeBearer+" ")
+	upstreamSawBearer = strings.TrimSpace(upstreamSawBearer)
+
+	if oauth2BuildIsEE {
+		// EE: the IdP was called, the upstream saw the exchanged token.
+		assert.Equal(t, int32(1), atomic.LoadInt32(idpCalls), "EE build should call the IdP")
+		assert.NotEqual(t, inbound, upstreamSawBearer, "EE build should forward the exchanged token, not the inbound")
+		claims := decodeExchangedToken(t, upstreamSawBearer)
+		assert.Equal(t, "upstream-api", claims["aud"])
+		assert.Equal(t, "users:read", claims["scope"])
+	} else {
+		// OSS: IdP not called; the upstream sees the inbound token unchanged.
+		assert.Equal(t, int32(0), atomic.LoadInt32(idpCalls), "OSS build must not call the IdP")
+		assert.Equal(t, inbound, upstreamSawBearer, "OSS build must forward the inbound token unchanged")
+	}
+}
+
+// TestOAuth2Gating_NoMatchingProvider verifies EE returns 403 with a structured body when iss matches no provider.
+func TestOAuth2Gating_NoMatchingProvider(t *testing.T) {
+	idp, _ := fakeIdP(t, false)
+	upstream := &echoUpstream{}
+	upstreamSrv := httptest.NewServer(upstream)
+	t.Cleanup(upstreamSrv.Close)
+
+	ts := StartTest(nil)
+	t.Cleanup(ts.Close)
+
+	const listenPath = "/story06-nomatch/"
+	// Provider only accepts tokens issued by idp.URL; inbound token has
+	// a different iss so the exchange runtime cannot find a match.
+	oasJSON := buildOAuth2ExchangeAPI(idp.URL, idp.URL+"/token", listenPath)
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.IsOAS = true
+		require.NoError(t, spec.OAS.UnmarshalJSON([]byte(oasJSON)))
+		spec.OAS.ExtractTo(spec.APIDefinition)
+		spec.APIID = "story06-nomatch"
+		spec.Proxy.ListenPath = listenPath
+		spec.Proxy.TargetURL = upstreamSrv.URL
+		spec.Proxy.StripListenPath = true
+		spec.Name = "story06-nomatch"
+		spec.UseKeylessAccess = true
+	})
+
+	wrongIss := "https://evil-idp.example.com"
+	inbound := mintInboundUnverifiedJWT(t, wrongIss)
+
+	resp, err := ts.Run(t, test.TestCase{
+		Path:    "/story06-nomatch/mail",
+		Method:  http.MethodGet,
+		Headers: map[string]string{header.Authorization: oas.OAuth2AuthSchemeBearer + " " + inbound},
+		// OSS noop passes through; EE returns 403.
+		Code: func() int {
+			if oauth2BuildIsEE {
+				return http.StatusForbidden
+			}
+			return http.StatusOK
+		}(),
+	})
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	if !oauth2BuildIsEE {
+		return
+	}
+
+	// EE: verify the structured error body and WWW-Authenticate challenge.
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var errBody map[string]string
+	require.NoError(t, json.Unmarshal(body, &errBody), "response must be valid JSON, got: %s", body)
+	assert.Equal(t, oas.OAuth2ErrNoMatchingProvider, errBody["error"])
+	assert.Equal(t, wrongIss, errBody["iss"], "iss echo in body lets MCP clients surface a meaningful step-up hint")
+	assert.NotEmpty(t, errBody["error_description"])
+
+	// Content-Type must be JSON (not a gateway-default HTML error).
+	assert.Equal(t, header.ApplicationJSON, resp.Header.Get(header.ContentType))
+
+	// WWW-Authenticate must carry the Bearer challenge with error params.
+	wwwAuth := resp.Header.Get(header.WWWAuthenticate)
+	assert.Contains(t, wwwAuth, oas.OAuth2AuthSchemeBearer)
+	assert.Contains(t, wwwAuth, oas.OAuth2ErrNoMatchingProvider)
+
+	// The upstream must NOT have been called — the exchange middleware
+	// short-circuited before forwarding.
+	assert.Empty(t, upstream.ReceivedBearer(), "upstream must not be reached on exchange error")
+}

--- a/gateway/mw_protected_resource_oauth2_test.go
+++ b/gateway/mw_protected_resource_oauth2_test.go
@@ -197,6 +197,62 @@ func TestOAuth2PRM_NewWinsOverOld(t *testing.T) {
 	})
 }
 
+// TestOAuth2PRM_ServesWhenOAuth2MasterDisabled pins the migration's
+// safety hatch: PRM publishing is independent of OAuth2 authentication
+// enforcement. The dashboard migration creates the new oauth2 scheme
+// with oauth2.enabled=false (so it doesn't silently turn on auth that
+// wasn't there before) but oauth2.protectedResourceMetadata.enabled=true
+// so the new PRM document is served. If a refactor ever wires
+// GetOAuth2PRMConfig to check oauth2.enabled, every migrated customer
+// stops publishing PRM until they manually flip the master switch.
+func TestOAuth2PRM_ServesWhenOAuth2MasterDisabled(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	doc := newOAuth2PRMOAS("/prm-master-off/", &oas.OAuth2PRM{
+		Enabled:              true,
+		Resource:             "https://api.example.com/",
+		AuthorizationServers: []string{"https://as.example.com/"},
+	}, nil)
+	doc.GetTykExtension().Server.Authentication.SecuritySchemes["corpOAuth"].(*oas.OAuth2).Enabled = false
+	loadOAuth2PRMAPI(ts, "/prm-master-off/", doc)
+
+	ts.Run(t, test.TestCase{
+		Method:    http.MethodGet,
+		Path:      "/prm-master-off/.well-known/oauth-protected-resource",
+		Code:      http.StatusOK,
+		BodyMatch: `"authorization_servers":\["https://as.example.com/"\]`,
+	})
+}
+
+// TestOAuth2PRM_FallsBackToLegacyWhenNewBlockAbsent pins the legacy
+// fallback path that the migration relies on: after the dashboard
+// non-destructively copies the legacy top-level
+// authentication.protectedResourceMetadata block to the new per-scheme
+// oauth2.protectedResourceMetadata location, an operator may later
+// remove the new block (reverting to the old location). The gateway
+// must continue to serve PRM from the legacy block in that state.
+func TestOAuth2PRM_FallsBackToLegacyWhenNewBlockAbsent(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	doc := newOAuth2PRMOAS("/prm-fallback/", nil, nil)
+	//nolint:staticcheck // intentional: pinning the legacy block's runtime fallback.
+	doc.GetTykExtension().Server.Authentication.ProtectedResourceMetadata = &oas.ProtectedResourceMetadata{
+		Enabled:              true,
+		Resource:             "https://api.example.com/legacy",
+		AuthorizationServers: []string{"https://old-as.example.com/"},
+	}
+	loadOAuth2PRMAPI(ts, "/prm-fallback/", doc)
+
+	ts.Run(t, test.TestCase{
+		Method:    http.MethodGet,
+		Path:      "/prm-fallback/.well-known/oauth-protected-resource",
+		Code:      http.StatusOK,
+		BodyMatch: `"authorization_servers":\["https://old-as.example.com/"\]`,
+	})
+}
+
 // TestOAuth2PRM_ResourceMetadataOnChallenge verifies the scope-check
 // middleware appends an RFC 9728 §5.1 resource_metadata= parameter to
 // its Bearer challenges when the API publishes a PRM document, and omits

--- a/gateway/oauth2_build_flavor_ee.go
+++ b/gateway/oauth2_build_flavor_ee.go
@@ -1,0 +1,8 @@
+//go:build ee || dev
+
+package gateway
+
+// oauth2BuildIsEE reports whether the current build includes the
+// EE-only RFC 8693 token exchange runtime. Used by the EE/OSS gating
+// regression tests to skip OSS-only or EE-only scenarios.
+const oauth2BuildIsEE = true

--- a/gateway/oauth2_build_flavor_oss.go
+++ b/gateway/oauth2_build_flavor_oss.go
@@ -1,0 +1,8 @@
+//go:build !ee && !dev
+
+package gateway
+
+// oauth2BuildIsEE reports whether the current build includes the
+// EE-only RFC 8693 token exchange runtime. Used by the EE/OSS gating
+// regression tests to skip OSS-only or EE-only scenarios.
+const oauth2BuildIsEE = false

--- a/header/header.go
+++ b/header/header.go
@@ -21,11 +21,12 @@ const (
 )
 
 const (
-	TykHookshot        = "Tyk-Hookshot"
-	ApplicationJSON    = "application/json"
-	ApplicationXML     = "application/xml"
-	ApplicationSoapXML = "application/soap+xml"
-	TextXML            = "text/xml"
+	TykHookshot               = "Tyk-Hookshot"
+	ApplicationJSON           = "application/json"
+	ApplicationXML            = "application/xml"
+	ApplicationSoapXML        = "application/soap+xml"
+	ApplicationFormURLEncoded = "application/x-www-form-urlencoded"
+	TextXML                   = "text/xml"
 )
 
 const (

--- a/internal/middleware/const.go
+++ b/internal/middleware/const.go
@@ -6,9 +6,6 @@ import "errors"
 // further middleware from the middleware chain.
 const StatusRespond = 666
 
-// ErrResponseRendered signals that a middleware has already written
-// the full response (status, headers, body) and the chain's default
-// error handler must not overlay an additional template / JSON-RPC
-// envelope on top. Wrap the actual middleware error with `%w` so the
-// dispatcher's `errors.Is` check can detect it.
+// ErrResponseRendered signals that a middleware already wrote the full response;
+// the chain dispatcher must not overlay another error body on top.
 var ErrResponseRendered = errors.New("response already rendered by middleware")

--- a/internal/middleware/const.go
+++ b/internal/middleware/const.go
@@ -1,5 +1,14 @@
 package middleware
 
+import "errors"
+
 // StatusRespond should be returned by a middleware to stop processing
 // further middleware from the middleware chain.
 const StatusRespond = 666
+
+// ErrResponseRendered signals that a middleware has already written
+// the full response (status, headers, body) and the chain's default
+// error handler must not overlay an additional template / JSON-RPC
+// envelope on top. Wrap the actual middleware error with `%w` so the
+// dispatcher's `errors.Is` check can detect it.
+var ErrResponseRendered = errors.New("response already rendered by middleware")

--- a/internal/oauth2common/errors.go
+++ b/internal/oauth2common/errors.go
@@ -1,0 +1,58 @@
+package oauth2common
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// MisconfigError is raised when exchange is configured but the audience cannot be resolved.
+type MisconfigError struct {
+	Reason string
+}
+
+func (e *MisconfigError) Error() string { return e.Reason }
+
+// NoMatchingProviderError is raised when no configured provider matches the inbound iss.
+type NoMatchingProviderError struct {
+	Iss string
+}
+
+func (e *NoMatchingProviderError) Error() string {
+	if e.Iss == "" {
+		return "no token-exchange provider configured for inbound token (missing iss claim)"
+	}
+	return fmt.Sprintf("no token-exchange provider configured for issuer %s", e.Iss)
+}
+
+// ExchangeFailedError represents a non-2xx IdP token-endpoint response.
+type ExchangeFailedError struct {
+	Status      int
+	IdpError    string
+	Description string
+}
+
+func (e *ExchangeFailedError) Error() string {
+	if e.Description != "" {
+		return fmt.Sprintf("exchange_failed: idp_error=%s: %s", e.IdpError, e.Description)
+	}
+	return fmt.Sprintf("exchange_failed: idp_error=%s (status %d)", e.IdpError, e.Status)
+}
+
+// MaxIdPErrorBodyBytes caps the raw snippet captured from a non-JSON IdP error body.
+const MaxIdPErrorBodyBytes = 256
+
+// DecodeIdPError parses the OAuth2 error/error_description from an IdP error response.
+func DecodeIdPError(body []byte) (idpErr, description string) {
+	var p struct {
+		Error            string `json:"error"`
+		ErrorDescription string `json:"error_description"`
+	}
+	if err := json.Unmarshal(body, &p); err == nil && p.Error != "" {
+		return p.Error, p.ErrorDescription
+	}
+	snippet := string(body)
+	if len(snippet) > MaxIdPErrorBodyBytes {
+		snippet = snippet[:MaxIdPErrorBodyBytes] + "...(truncated)"
+	}
+	return "unknown", snippet
+}

--- a/internal/oauth2common/outcome.go
+++ b/internal/oauth2common/outcome.go
@@ -1,0 +1,16 @@
+package oauth2common
+
+// Outcome captures the result of one RFC 8693 exchange attempt for structured logging.
+type Outcome struct {
+	// ProviderName is the matched provider; empty when no exchange ran.
+	ProviderName string
+
+	// Audience is the resolved audience sent to the IdP.
+	Audience string
+
+	// Scopes is the resolved scope list sent to the IdP.
+	Scopes []string
+
+	// ExchangedToken is the IdP's exchanged access token; empty on failure.
+	ExchangedToken string
+}

--- a/internal/oauth2common/state_ctx.go
+++ b/internal/oauth2common/state_ctx.go
@@ -51,13 +51,11 @@ func GetState(r *http.Request) *State {
 type exchangeDoneCtxKey struct{}
 
 // MarkExchangeDone prevents re-running the exchange for MCP fan-out sub-requests.
-// Same shared-pointer contract as SetState.
 func MarkExchangeDone(r *http.Request) {
 	ctx := context.WithValue(r.Context(), exchangeDoneCtxKey{}, true)
 	*r = *r.WithContext(ctx)
 }
 
-// IsExchangeDone reports whether the flag is set on the request's context.
 func IsExchangeDone(r *http.Request) bool {
 	v, _ := r.Context().Value(exchangeDoneCtxKey{}).(bool)
 	return v

--- a/internal/oauth2common/state_ctx.go
+++ b/internal/oauth2common/state_ctx.go
@@ -1,0 +1,64 @@
+package oauth2common
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/golang-jwt/jwt/v4"
+
+	"github.com/TykTechnologies/tyk/apidef/oas"
+)
+
+// State carries the context set by OSS OAuth2Middleware for the EE exchange.
+type State struct {
+	// Claims is the JWT-parsed claim set on the inbound token.
+	Claims jwt.MapClaims
+
+	// RawToken is the inbound Bearer (after stripping the prefix).
+	RawToken string
+
+	// OASConfig is the resolved OAS-side oauth2 block.
+	OASConfig *oas.OAuth2
+
+	// APIID is the matched API definition ID.
+	APIID string
+
+	// MatchedOperationID is the OAS operationId for the request, if any.
+	MatchedOperationID string
+
+	// MatchedPrimitiveName is the MCP primitive name the request resolved to, if any.
+	MatchedPrimitiveName string
+
+	// InferredScopes is the flattened union of OR-of-AND scope alternatives for the request.
+	InferredScopes []string
+}
+
+type stateCtxKey struct{}
+
+// SetState attaches s to the request's context.
+// Mutates *r in-place (shared-pointer chain contract); cloning r mid-chain breaks the handoff.
+func SetState(r *http.Request, s *State) {
+	ctx := context.WithValue(r.Context(), stateCtxKey{}, s)
+	*r = *r.WithContext(ctx)
+}
+
+// GetState returns the request's State or nil when none was set.
+func GetState(r *http.Request) *State {
+	v, _ := r.Context().Value(stateCtxKey{}).(*State)
+	return v
+}
+
+type exchangeDoneCtxKey struct{}
+
+// MarkExchangeDone prevents re-running the exchange for MCP fan-out sub-requests.
+// Same shared-pointer contract as SetState.
+func MarkExchangeDone(r *http.Request) {
+	ctx := context.WithValue(r.Context(), exchangeDoneCtxKey{}, true)
+	*r = *r.WithContext(ctx)
+}
+
+// IsExchangeDone reports whether the flag is set on the request's context.
+func IsExchangeDone(r *http.Request) bool {
+	v, _ := r.Context().Value(exchangeDoneCtxKey{}).(bool)
+	return v
+}

--- a/internal/oauth2common/state_ctx.go
+++ b/internal/oauth2common/state_ctx.go
@@ -29,6 +29,11 @@ type State struct {
 	// MatchedPrimitiveName is the MCP primitive name the request resolved to, if any.
 	MatchedPrimitiveName string
 
+	// MatchedPrimitiveType is the MCP primitive type ("tool", "resource", "prompt").
+	// Required alongside MatchedPrimitiveName to avoid collision when tool and prompt
+	// share the same name.
+	MatchedPrimitiveType string
+
 	// InferredScopes is the flattened union of OR-of-AND scope alternatives for the request.
 	InferredScopes []string
 }

--- a/internal/oauth2common/target.go
+++ b/internal/oauth2common/target.go
@@ -1,0 +1,55 @@
+package oauth2common
+
+import "github.com/TykTechnologies/tyk/apidef/oas"
+
+// Target is the (audience, scopes) pair sent to the IdP.
+// Nil means no exchange target could be resolved.
+type Target struct {
+	Audience string
+	Scopes   []string
+}
+
+// SelectExchangeProvider returns the provider whose Issuers contains iss,
+// or the sole provider when iss is empty and only one is configured.
+func SelectExchangeProvider(providers []oas.OAuth2TokenExchangeProvider, iss string) *oas.OAuth2TokenExchangeProvider {
+	if iss != "" {
+		for i := range providers {
+			p := &providers[i]
+			for _, allowed := range p.Issuers {
+				if allowed == iss {
+					return p
+				}
+			}
+		}
+		return nil
+	}
+	if len(providers) == 1 {
+		return &providers[0]
+	}
+	return nil
+}
+
+// MergeTargetForProvider merges the per-op exchange override with the provider
+// defaultTarget (most-specific wins). Returns nil when no audience can be resolved.
+func MergeTargetForProvider(ex *oas.OAuth2Exchange, provider *oas.OAuth2TokenExchangeProvider, inferredScopes []string) *Target {
+	t := &Target{}
+	if ex != nil {
+		t.Audience = ex.Audience
+		t.Scopes = append([]string(nil), ex.Scopes...)
+		if len(t.Scopes) == 0 && ex.InfersScopesFromSecurity() && len(inferredScopes) > 0 {
+			t.Scopes = append([]string(nil), inferredScopes...)
+		}
+	}
+	if (t.Audience == "" || len(t.Scopes) == 0) && provider != nil && provider.DefaultTarget != nil {
+		if t.Audience == "" {
+			t.Audience = provider.DefaultTarget.Audience
+		}
+		if len(t.Scopes) == 0 {
+			t.Scopes = append([]string(nil), provider.DefaultTarget.Scopes...)
+		}
+	}
+	if t.Audience == "" {
+		return nil
+	}
+	return t
+}

--- a/internal/oauth2common/token_exchange_test.go
+++ b/internal/oauth2common/token_exchange_test.go
@@ -118,11 +118,13 @@ func TestMergeTargetForProvider_NilWhenNoAudienceResolvable(t *testing.T) {
 func TestState_RoundTripsThroughRequestContext(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
 	state := &State{
-		Claims:             jwt.MapClaims{"iss": "https://idp"},
-		RawToken:           "abc.def.ghi",
-		APIID:              "api-1",
-		MatchedOperationID: "getMail",
-		InferredScopes:     []string{"users:read"},
+		Claims:               jwt.MapClaims{"iss": "https://idp"},
+		RawToken:             "abc.def.ghi",
+		APIID:                "api-1",
+		MatchedOperationID:   "getMail",
+		MatchedPrimitiveName: "search",
+		MatchedPrimitiveType: "tool",
+		InferredScopes:       []string{"users:read"},
 	}
 	SetState(r, state)
 
@@ -131,6 +133,8 @@ func TestState_RoundTripsThroughRequestContext(t *testing.T) {
 	assert.Equal(t, "abc.def.ghi", got.RawToken)
 	assert.Equal(t, "api-1", got.APIID)
 	assert.Equal(t, "getMail", got.MatchedOperationID)
+	assert.Equal(t, "search", got.MatchedPrimitiveName)
+	assert.Equal(t, "tool", got.MatchedPrimitiveType)
 	assert.Equal(t, []string{"users:read"}, got.InferredScopes)
 	assert.Equal(t, "https://idp", got.Claims["iss"])
 }

--- a/internal/oauth2common/token_exchange_test.go
+++ b/internal/oauth2common/token_exchange_test.go
@@ -1,0 +1,194 @@
+package oauth2common
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/tyk/apidef/oas"
+)
+
+func providerFixture(name, iss, endpoint string, target *oas.OAuth2DefaultTarget) oas.OAuth2TokenExchangeProvider {
+	return oas.OAuth2TokenExchangeProvider{
+		Name:          name,
+		Issuers:       []string{iss},
+		TokenEndpoint: endpoint,
+		ClientAuth:    &oas.OAuth2ClientAuth{ClientID: "c-" + name},
+		DefaultTarget: target,
+	}
+}
+
+func TestSelectExchangeProvider_MatchByIss(t *testing.T) {
+	providers := []oas.OAuth2TokenExchangeProvider{
+		providerFixture("primary", "https://idp-a", "https://idp-a/token", nil),
+		providerFixture("alt", "https://idp-b", "https://idp-b/token", nil),
+	}
+	p := SelectExchangeProvider(providers, "https://idp-b")
+	require.NotNil(t, p)
+	assert.Equal(t, "alt", p.Name)
+}
+
+func TestSelectExchangeProvider_NoMatch_ReturnsNil(t *testing.T) {
+	providers := []oas.OAuth2TokenExchangeProvider{
+		providerFixture("primary", "https://idp-a", "https://idp-a/token", nil),
+	}
+	assert.Nil(t, SelectExchangeProvider(providers, "https://idp-rogue"))
+}
+
+func TestSelectExchangeProvider_EmptyIss_SingleProviderFallback(t *testing.T) {
+	providers := []oas.OAuth2TokenExchangeProvider{
+		providerFixture("only", "https://idp-a", "https://idp-a/token", nil),
+	}
+	p := SelectExchangeProvider(providers, "")
+	require.NotNil(t, p)
+	assert.Equal(t, "only", p.Name)
+}
+
+func TestSelectExchangeProvider_EmptyIss_MultiProvider_ReturnsNil(t *testing.T) {
+	// Two or more providers and an empty iss must NOT silently pick one
+	// — pinning the security guard.
+	providers := []oas.OAuth2TokenExchangeProvider{
+		providerFixture("primary", "https://idp-a", "https://idp-a/token", nil),
+		providerFixture("alt", "https://idp-b", "https://idp-b/token", nil),
+	}
+	assert.Nil(t, SelectExchangeProvider(providers, ""))
+}
+
+func TestSelectExchangeProvider_MultiIssuerOnOneProvider(t *testing.T) {
+	p := oas.OAuth2TokenExchangeProvider{
+		Name:          "broker",
+		Issuers:       []string{"https://realm-a", "https://realm-b", "https://realm-c"},
+		TokenEndpoint: "https://idp/token",
+		ClientAuth:    &oas.OAuth2ClientAuth{ClientID: "c"},
+	}
+	providers := []oas.OAuth2TokenExchangeProvider{p}
+	match := SelectExchangeProvider(providers, "https://realm-b")
+	require.NotNil(t, match)
+	assert.Equal(t, "broker", match.Name)
+}
+
+func TestMergeTargetForProvider_PerOpAudienceWins(t *testing.T) {
+	ex := &oas.OAuth2Exchange{Audience: "https://override", Scopes: []string{"x"}}
+	prov := providerFixture("p", "https://idp", "https://idp/token", &oas.OAuth2DefaultTarget{Audience: "https://default", Scopes: []string{"def"}})
+	got := MergeTargetForProvider(ex, &prov, nil)
+	require.NotNil(t, got)
+	assert.Equal(t, "https://override", got.Audience)
+	assert.Equal(t, []string{"x"}, got.Scopes)
+}
+
+func TestMergeTargetForProvider_DefaultsFallback(t *testing.T) {
+	ex := &oas.OAuth2Exchange{}
+	prov := providerFixture("p", "https://idp", "https://idp/token", &oas.OAuth2DefaultTarget{Audience: "https://default", Scopes: []string{"def"}})
+	got := MergeTargetForProvider(ex, &prov, nil)
+	require.NotNil(t, got)
+	assert.Equal(t, "https://default", got.Audience)
+	assert.Equal(t, []string{"def"}, got.Scopes)
+}
+
+func TestMergeTargetForProvider_InferredScopesFromSecurity(t *testing.T) {
+	enabled := true
+	ex := &oas.OAuth2Exchange{Enabled: &enabled}
+	prov := providerFixture("p", "https://idp", "https://idp/token", &oas.OAuth2DefaultTarget{Audience: "https://default", Scopes: []string{"fallback"}})
+	got := MergeTargetForProvider(ex, &prov, []string{"inferred:scope"})
+	require.NotNil(t, got)
+	assert.Equal(t, "https://default", got.Audience)
+	assert.Equal(t, []string{"inferred:scope"}, got.Scopes, "inferred scopes should pre-empt provider defaults")
+}
+
+func TestMergeTargetForProvider_InferredScopesIgnoredWhenEnabledNil(t *testing.T) {
+	ex := &oas.OAuth2Exchange{}
+	prov := providerFixture("p", "https://idp", "https://idp/token", &oas.OAuth2DefaultTarget{Audience: "https://default", Scopes: []string{"fallback"}})
+	got := MergeTargetForProvider(ex, &prov, []string{"inferred:scope"})
+	require.NotNil(t, got)
+	assert.Equal(t, []string{"fallback"}, got.Scopes, "inferred scopes require explicit Enabled=true on the exchange block")
+}
+
+func TestMergeTargetForProvider_NilWhenNoAudienceResolvable(t *testing.T) {
+	ex := &oas.OAuth2Exchange{Scopes: []string{"x"}}
+	prov := providerFixture("p", "https://idp", "https://idp/token", nil)
+	got := MergeTargetForProvider(ex, &prov, nil)
+	assert.Nil(t, got, "no audience anywhere = no target")
+}
+
+func TestState_RoundTripsThroughRequestContext(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	state := &State{
+		Claims:             jwt.MapClaims{"iss": "https://idp"},
+		RawToken:           "abc.def.ghi",
+		APIID:              "api-1",
+		MatchedOperationID: "getMail",
+		InferredScopes:     []string{"users:read"},
+	}
+	SetState(r, state)
+
+	got := GetState(r)
+	require.NotNil(t, got)
+	assert.Equal(t, "abc.def.ghi", got.RawToken)
+	assert.Equal(t, "api-1", got.APIID)
+	assert.Equal(t, "getMail", got.MatchedOperationID)
+	assert.Equal(t, []string{"users:read"}, got.InferredScopes)
+	assert.Equal(t, "https://idp", got.Claims["iss"])
+}
+
+func TestState_GetStateNilWhenAbsent(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	assert.Nil(t, GetState(r))
+}
+
+func TestExchangeDoneFlag(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	assert.False(t, IsExchangeDone(r))
+	MarkExchangeDone(r)
+	assert.True(t, IsExchangeDone(r))
+}
+
+func TestNoMatchingProviderError_Message(t *testing.T) {
+	e := &NoMatchingProviderError{Iss: "https://idp"}
+	assert.Contains(t, e.Error(), "https://idp")
+	missing := &NoMatchingProviderError{}
+	assert.Contains(t, missing.Error(), "missing iss")
+}
+
+func TestExchangeFailedError_Message(t *testing.T) {
+	e := &ExchangeFailedError{Status: 400, IdpError: "invalid_grant", Description: "user not found"}
+	assert.Contains(t, e.Error(), "invalid_grant")
+	assert.Contains(t, e.Error(), "user not found")
+
+	noDesc := &ExchangeFailedError{Status: 500, IdpError: "server_error"}
+	assert.Contains(t, noDesc.Error(), "server_error")
+	assert.Contains(t, noDesc.Error(), "500")
+}
+
+func TestExchangeFailedError_ErrorsIs(t *testing.T) {
+	e := &ExchangeFailedError{Status: 500}
+	var target *ExchangeFailedError
+	assert.True(t, errors.As(e, &target))
+}
+
+func TestDecodeIdPError_StandardJSON(t *testing.T) {
+	idpErr, desc := DecodeIdPError([]byte(`{"error":"invalid_grant","error_description":"user not found"}`))
+	assert.Equal(t, "invalid_grant", idpErr)
+	assert.Equal(t, "user not found", desc)
+}
+
+func TestDecodeIdPError_NonJSONFallbackTruncates(t *testing.T) {
+	body := make([]byte, MaxIdPErrorBodyBytes+50)
+	for i := range body {
+		body[i] = 'a'
+	}
+	idpErr, desc := DecodeIdPError(body)
+	assert.Equal(t, "unknown", idpErr)
+	assert.Less(t, len(desc), len(body)+1, "expected truncation")
+	assert.Contains(t, desc, "...(truncated)")
+}
+
+func TestNewIdPHTTPClient_HonoursTimeout(t *testing.T) {
+	client := NewIdPHTTPClient(7)
+	assert.Equal(t, 7, int(client.Timeout))
+	assert.NotNil(t, client.Transport)
+}

--- a/internal/oauth2common/transport.go
+++ b/internal/oauth2common/transport.go
@@ -1,0 +1,17 @@
+package oauth2common
+
+import (
+	"net/http"
+	"time"
+)
+
+// MaxIdPResponseBytes caps the response body read from the IdP to prevent memory abuse.
+const MaxIdPResponseBytes = 1 << 20
+
+// NewIdPHTTPClient returns an HTTP client for IdP calls with the given timeout.
+func NewIdPHTTPClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: http.DefaultTransport,
+	}
+}


### PR DESCRIPTION
## Summary

- EE-only `TokenExchangeMiddleware` wraps every OAuth2-authenticated request: reads `oauth2common.State` from context (set by introspection+scope-check), posts RFC 8693 form to the matched provider's `tokenEndpoint`, replaces `Authorization: Bearer` with the exchanged token before forwarding upstream.
- OSS noop stub logs a one-shot warning; `oauth2BuildIsEE` constant lets gating tests assert the correct boundary without live requests.
- `ValidateOAuth2Schemes` enforces at API-load time: no reserved `customParams` keys, unique provider names per scheme, no issuer overlap across providers, non-empty `tokenEndpoint` + `clientAuth.clientId`.
- Per-operation `OAuth2Exchange` override (`audience`, `scopes`) lets individual routes narrow the exchanged token scope beyond the provider default.
- All four JSON schemas (`x-tyk-api-gateway`, strict, streams, mcp) updated with `tokenExchange` + `X-Tyk-OAuth2-Exchange` type definitions.

## Test plan

- [ ] `go test ./internal/oauth2common/ ./apidef/oas/ -count=1` — unit + round-trip + validation tests pass
- [ ] `go test -run "TestOAuth2|TestTokenExchange|TestFlatten|TestDedup|TestGating" ./gateway/ -count=1` — OSS/EE boundary + gating tests pass
- [ ] `go test ./apidef/oas/ -run TestXTykGateway_Lint -count=1` — all four schemas lint clean
- [ ] `go build ./... && go build -tags "ee dev" ./...` — both build flavors compile
- [ ] Python e2e: `mcp_oauth2_token_exchange_core_test.py` against live stack (see companion tyk-analytics PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-17177" title="TT-17177" target="_blank">TT-17177</a>
</summary>

|         |    |
|---------|----|
| Status  | In Code Review |
| Summary | Token Exchange — core flow (RFC 8693) |

Generated at: 2026-05-29 17:44:14

</details>

<!---TykTechnologies/jira-linter ends here-->







