### PR TITLE
[TT-17077] Restore API tests timeout to 40m on release-5.13.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -892,7 +892,7 @@ jobs:
           org_gh_token: ${{ steps.app-token.outputs.token }}
       - name: Run API tests
         uses: TykTechnologies/github-actions/.github/actions/tests/api-tests@42304edda365365e0a887cf018d8edc34b960b82 # main
-        timeout-minutes: 30
+        timeout-minutes: 40
         id: test_execution
         with:
           user_api_secret: ${{ steps.env_up.outputs.USER_API_SECRET }}


### PR DESCRIPTION
## Summary

Re-applies the one-line workflow timeout bump from Ilija's #8156 (commit `edfe152a0`) which is currently regressed on `release-5.13.0`.

| Branch | `Run API tests` `timeout-minutes` |
|---|---|
| `release-5.13` | 40 |
| `release-5.13.0` | 30 (regressed) |
| `master` | 40 |

`edfe152a0` is present in `release-5.13.0`'s history, but later FIPS-related PRs (`9d14d228b` disable FIPS / `1d51bf98d` re-enable FIPS) rewrote the workflow and ended up restoring 30m.

## Evidence

api-tests on PR #8250 currently fail with `##[error]The action has timed out.` after exactly 30 minutes. Tests took 32-33min on that run — they would have passed under 40m.

## Test plan

- [ ] CI green on this branch
- [ ] api-tests step on dependent PRs (#8250 etc) completes without timeout
<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-17077" title="TT-17077" target="_blank">TT-17077</a>
</summary>

|         |    |
|---------|----|
| Status  | Closed |
| Summary | CI/CD: Increase timeout for API tests job |

Generated at: 2026-05-28 15:49:07

</details>

<!---TykTechnologies/jira-linter ends here-->
