### PR TITLE
[TT-17312] Gateway: client-IdP registry for JWT key & scope resolution

### DIFF
--- a/ctx/ctx.go
+++ b/ctx/ctx.go
@@ -75,6 +75,10 @@ const (
 	MCPPrimitiveName
 	// JSONRPCErrorCode stores the JSON-RPC error code for metrics dimensions.
 	JSONRPCErrorCode
+	// MatchedIdPBinding holds the per-request client-IdP registry binding matched
+	// in the JWT middleware. The value (a *gateway.Binding) is type-asserted on
+	// the gateway side; only the key lives here to avoid an import cycle.
+	MatchedIdPBinding
 )
 
 func ctxSetSession(r *http.Request, s *user.SessionState, scheduleUpdate bool, hashKey bool) {

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -3299,9 +3299,9 @@ func ctxGetCacheOptions(r *http.Request) *cacheOptions {
 }
 
 // ctxSetMatchedBinding stores the client-IdP registry binding matched for this
-// request. JWTMiddleware is a single shared instance per API (api_loader.go:403)
-// and its ProcessRequest runs concurrently, so per-request state must live on
-// the context, not the middleware struct.
+// request. JWTMiddleware is a single shared instance per API and its
+// ProcessRequest runs concurrently, so per-request state must live on the
+// context, not the middleware struct.
 func ctxSetMatchedBinding(r *http.Request, b *Binding) {
 	setCtxValue(r, ctx.MatchedIdPBinding, b)
 }

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -3298,6 +3298,23 @@ func ctxGetCacheOptions(r *http.Request) *cacheOptions {
 	return key
 }
 
+// ctxSetMatchedBinding stores the client-IdP registry binding matched for this
+// request. JWTMiddleware is a single shared instance per API (api_loader.go:403)
+// and its ProcessRequest runs concurrently, so per-request state must live on
+// the context, not the middleware struct.
+func ctxSetMatchedBinding(r *http.Request, b *Binding) {
+	setCtxValue(r, ctx.MatchedIdPBinding, b)
+}
+
+// ctxGetMatchedBinding returns the matched binding for this request, or nil.
+func ctxGetMatchedBinding(r *http.Request) *Binding {
+	b, ok := r.Context().Value(ctx.MatchedIdPBinding).(*Binding)
+	if !ok {
+		return nil
+	}
+	return b
+}
+
 func ctxGetSession(r *http.Request) *user.SessionState {
 	return ctx.GetSession(r)
 }

--- a/gateway/api_definition_test.go
+++ b/gateway/api_definition_test.go
@@ -856,6 +856,9 @@ func TestSyncAPISpecsDashboardSuccess(t *testing.T) {
 	tsDash := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/system/apis" {
 			w.Write([]byte(`{"Status": "OK", "Nonce": "1", "Message": [{"api_definition": {}}]}`))
+		} else if r.URL.Path == "/system/clientidps" {
+			// The reload also refreshes the client-IdP registry; return an empty feed.
+			mustWriteJSON(t, w, `{"Status": "OK", "Nonce": "1", "Message": []}`)
 		} else {
 			t.Fatal("Unknown dashboard API request", r)
 		}
@@ -1209,6 +1212,9 @@ func TestSyncAPISpecsDashboardJSONFailure(t *testing.T) {
 			}
 
 			callNum += 1
+		} else if r.URL.Path == "/system/clientidps" {
+			// The reload also refreshes the client-IdP registry; return an empty feed.
+			mustWriteJSON(t, w, `{"Status": "OK", "Nonce": "1", "Message": []}`)
 		} else {
 			t.Fatal("Unknown dashboard API request", r)
 		}

--- a/gateway/idp_registry.go
+++ b/gateway/idp_registry.go
@@ -196,7 +196,7 @@ func (r *IdPRegistry) fetchFromDashboard() ([]IdP, error) {
 	endpoint := r.gw.buildDashboardConnStr("/system/clientidps")
 
 	buildReq := func() (*http.Request, error) {
-		req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+		req, err := http.NewRequestWithContext(r.gw.ctx, http.MethodGet, endpoint, nil)
 		if err != nil {
 			return nil, fmt.Errorf("build client-idps request: %w", err)
 		}

--- a/gateway/idp_registry.go
+++ b/gateway/idp_registry.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/rpc"
 )
 
 const idpRefreshDebounce = 100 * time.Millisecond
@@ -242,8 +243,14 @@ func (r *IdPRegistry) fetchFromDashboard() ([]IdP, error) {
 }
 
 // fetchFromRPC pulls the registry over RPC (MDCB/edge). The payload is a bare
-// JSON array; an empty string is a no-op.
+// JSON array; an empty string is a no-op. In emergency mode (MDCB unreachable)
+// it restores the registry from the Redis backup instead — mirroring how APIs
+// and policies recover — and on a successful sync it refreshes that backup.
 func (r *IdPRegistry) fetchFromRPC() ([]IdP, error) {
+	if rpc.IsEmergencyMode() {
+		return r.gw.LoadIdPsFromRPCBackup()
+	}
+
 	conf := r.gw.GetConfig()
 	var tags []string
 	if conf.DBAppConfOptions.NodeIsSegmented {
@@ -252,6 +259,9 @@ func (r *IdPRegistry) fetchFromRPC() ([]IdP, error) {
 	payload := r.rpcLoaderFn().GetClientIdPs(conf.SlaveOptions.RPCKey, tags)
 	if payload == "" {
 		return nil, nil
+	}
+	if err := r.gw.saveRPCIdPsBackup(payload); err != nil {
+		log.WithError(err).Warning("Failed to back up client-IdP registry to Redis")
 	}
 	return unmarshalIdPs([]byte(payload))
 }

--- a/gateway/idp_registry.go
+++ b/gateway/idp_registry.go
@@ -1,0 +1,301 @@
+package gateway
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/TykTechnologies/tyk/header"
+)
+
+const idpRefreshDebounce = 100 * time.Millisecond
+
+// IdP is a client auth IdP stored beside the API definition, joined to APIs by
+// api_id. The wire shape is identical across the direct-Dashboard HTTP feed
+// (GET /system/clientidps) and the MDCB/edge RPC feed (GetClientIdPs); the JSON
+// tags mirror the dashboard's model.ClientIdP.
+type IdP struct {
+	ID          string                  `json:"client_idp_id"`
+	OrgID       string                  `json:"org_id"`
+	Name        string                  `json:"name"`
+	Issuer      string                  `json:"issuer"`
+	JWKSURI     string                  `json:"jwks_uri"`
+	APIMappings map[string]ScopeMapping `json:"api_mappings"`
+}
+
+// ScopeMapping is the value type of IdP.APIMappings; the map key is the api_id.
+type ScopeMapping struct {
+	ScopeToPolicy map[string]string `json:"scope_to_policy"`
+}
+
+// idpFeedEnvelope is the NodeResponseOK wrapper the dashboard /system/clientidps
+// HTTP feed returns ({"Status","Message":[...],"Nonce":"..."}). The RPC feed
+// sends a bare array, so Nonce is only populated on the HTTP path.
+type idpFeedEnvelope struct {
+	Message []IdP  `json:"Message"`
+	Nonce   string `json:"Nonce"`
+}
+
+// Binding is the reverse-index value: the registry maps an api_id to the set of
+// IdPs bound to it, each carrying that API's scope_to_policy overrides.
+type Binding struct {
+	ScopeToPolicy map[string]string
+	IdPID         string
+}
+
+// IdPRegistry is an in-memory, request-time join of APIs to their client IdPs.
+// It is a separate global on the Gateway struct, never merged into
+// apidef.APIDefinition or APISpec. Its refresh mimics the API-definition load
+// path across modes; the JWT path reads only the bindingsByAPI reverse index.
+type IdPRegistry struct {
+	gw *Gateway
+
+	mu            sync.RWMutex // OWN mutex — never apisMu
+	idpsByID      map[string]IdP
+	bindingsByAPI map[string][]Binding // only index the JWT path reads
+
+	debounceMu    sync.Mutex
+	debounceTimer *time.Timer
+	refreshMu     sync.Mutex // serializes doRefresh
+
+	rpcLoaderFn func() RPCDataLoader // injectable
+}
+
+func newIdPRegistry(gw *Gateway) *IdPRegistry {
+	return &IdPRegistry{
+		gw:            gw,
+		idpsByID:      map[string]IdP{},
+		bindingsByAPI: map[string][]Binding{},
+		rpcLoaderFn:   func() RPCDataLoader { return &RPCStorageHandler{Gw: gw} },
+	}
+}
+
+// BindingsForAPI is the hot path on JWT requests: a single RLock + map probe.
+func (r *IdPRegistry) BindingsForAPI(apiID string) []Binding {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.bindingsByAPI[apiID]
+}
+
+func (r *IdPRegistry) IdP(idpID string) (IdP, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	idp, ok := r.idpsByID[idpID]
+	return idp, ok
+}
+
+// rebuild builds the reverse index, then swaps it in (build-then-swap).
+//  1. Snapshot apisByID keys under a brief apisMu RLock, then RELEASE apisMu
+//     before iterating idps — the hold time is O(len(apisByID)), not the full
+//     rebuild cost, so it never blocks a concurrent loadApps swap or reader.
+//  2. Segment-aware backstop: drop bindings whose api_id is not in the loaded
+//     set, making stale/renamed api_ids inert and keeping other segments' IdP
+//     detail out of memory (IdPs with zero surviving mappings are omitted).
+//  3. Swap both maps under r.mu.Lock() — mirrors loadApps swapping apisByID.
+func (r *IdPRegistry) rebuild(idps []IdP) {
+	r.gw.apisMu.RLock()
+	loaded := make(map[string]struct{}, len(r.gw.apisByID))
+	for id := range r.gw.apisByID {
+		loaded[id] = struct{}{}
+	}
+	r.gw.apisMu.RUnlock()
+
+	idpsByID := make(map[string]IdP, len(idps))
+	bindingsByAPI := make(map[string][]Binding, len(loaded))
+
+	for _, idp := range idps {
+		var indexed bool
+		for apiID, sm := range idp.APIMappings {
+			if _, ok := loaded[apiID]; !ok {
+				continue
+			}
+			bindingsByAPI[apiID] = append(bindingsByAPI[apiID], Binding{
+				IdPID:         idp.ID,
+				ScopeToPolicy: sm.ScopeToPolicy,
+			})
+			indexed = true
+		}
+		if indexed {
+			idpsByID[idp.ID] = idp
+		}
+	}
+
+	r.mu.Lock()
+	r.idpsByID, r.bindingsByAPI = idpsByID, bindingsByAPI
+	r.mu.Unlock()
+}
+
+// refreshIdPRegistry triggers a debounced client-IdP registry refresh, guarding
+// against an uninitialised registry. Used by the NoticeClientIdPChanged signal.
+func (gw *Gateway) refreshIdPRegistry() {
+	if gw.idpRegistry != nil {
+		gw.idpRegistry.Refresh()
+	}
+}
+
+// Refresh debounces a registry rebuild ~100 ms via time.AfterFunc, coalescing
+// signal bursts without a goroutine/channel/library. Failures log; the previous
+// snapshot stays in place.
+func (r *IdPRegistry) Refresh() {
+	r.debounceMu.Lock()
+	defer r.debounceMu.Unlock()
+	if r.debounceTimer != nil {
+		r.debounceTimer.Stop()
+	}
+	r.debounceTimer = time.AfterFunc(idpRefreshDebounce, func() {
+		if err := r.doRefresh(); err != nil {
+			log.WithError(err).Error("IdP registry refresh failed")
+		}
+	})
+}
+
+// doRefresh is synchronous and serialized by refreshMu (debounced timers can't
+// duplicate work). A cancelled gw.ctx makes a timer popping during shutdown a
+// no-op. Used directly by the startup reload so the registry is ready before
+// serving.
+func (r *IdPRegistry) doRefresh() error {
+	r.refreshMu.Lock()
+	defer r.refreshMu.Unlock()
+	if r.gw != nil && r.gw.ctx != nil && r.gw.ctx.Err() != nil {
+		return nil
+	}
+	idps, err := r.fetch()
+	if err != nil {
+		return err
+	}
+	r.rebuild(idps)
+	return nil
+}
+
+// fetch branches on mode exactly like syncAPISpecs.
+func (r *IdPRegistry) fetch() ([]IdP, error) {
+	conf := r.gw.GetConfig()
+	switch {
+	case conf.UseDBAppConfigs:
+		return r.fetchFromDashboard()
+	case conf.SlaveOptions.UseRPC:
+		return r.fetchFromRPC()
+	default:
+		return nil, nil // file mode deferred
+	}
+}
+
+// fetchFromDashboard performs GET /system/clientidps via the shared dashboard
+// request path (executeDashboardRequestWithRecovery), so it inherits the same
+// nonce-failure re-registration and client config as FromDashboardService — the
+// registry is a first-class /system/* citizen, not a fragile passive reader.
+// The response is a NodeResponseOK envelope {"Status","Message":[...],"Nonce"};
+// the Nonce is captured into gw.ServiceNonce so the node stays in sync — the
+// dashboard rotates the node's stored nonce on every /system/* call.
+func (r *IdPRegistry) fetchFromDashboard() ([]IdP, error) {
+	endpoint := r.gw.buildDashboardConnStr("/system/clientidps")
+
+	buildReq := func() (*http.Request, error) {
+		req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+		if err != nil {
+			return nil, fmt.Errorf("build client-idps request: %w", err)
+		}
+		gwConfig := r.gw.GetConfig()
+		req.Header.Set("authorization", gwConfig.NodeSecret)
+		req.Header.Set(header.XTykNodeID, r.gw.GetNodeID())
+		r.gw.ServiceNonceMutex.RLock()
+		req.Header.Set(header.XTykNonce, r.gw.ServiceNonce)
+		r.gw.ServiceNonceMutex.RUnlock()
+		req.Header.Set(header.XTykSessionID, r.gw.SessionID)
+		return req, nil
+	}
+
+	resp, err := r.gw.executeDashboardRequestWithRecovery(buildReq, "client-idps fetch")
+	if err != nil {
+		return nil, fmt.Errorf("client-idps fetch: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusForbidden {
+		// Do not log the raw body of an auth failure — it may carry sensitive
+		// detail. The node recovers via executeDashboardRequestWithRecovery.
+		return nil, errors.New("client-idps login failure (403 Forbidden)")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("client-idps dashboard error: status %d", resp.StatusCode)
+	}
+
+	// Stream-decode straight off the response body to avoid buffering the whole
+	// payload in memory (the registry can be large in big deployments). This path
+	// can't reuse unmarshalIdPs: it must also capture the rotating Nonce, which
+	// that helper deliberately drops, and it decodes from the stream rather than
+	// a []byte.
+	var feed idpFeedEnvelope
+	if err := json.NewDecoder(resp.Body).Decode(&feed); err != nil {
+		return nil, fmt.Errorf("unmarshal client-idps payload: %w", err)
+	}
+
+	r.gw.ServiceNonceMutex.Lock()
+	r.gw.ServiceNonce = feed.Nonce
+	r.gw.ServiceNonceMutex.Unlock()
+
+	return feed.Message, nil
+}
+
+// fetchFromRPC pulls the registry over RPC (MDCB/edge). The payload is a bare
+// JSON array; an empty string is a no-op.
+func (r *IdPRegistry) fetchFromRPC() ([]IdP, error) {
+	conf := r.gw.GetConfig()
+	var tags []string
+	if conf.DBAppConfOptions.NodeIsSegmented {
+		tags = conf.DBAppConfOptions.Tags
+	}
+	payload := r.rpcLoaderFn().GetClientIdPs(conf.SlaveOptions.RPCKey, tags)
+	if payload == "" {
+		return nil, nil
+	}
+	return unmarshalIdPs([]byte(payload))
+}
+
+// scopeToPolicyMapForRequest merges the manual API-def scope map with the matched
+// registry binding. Manual config is authoritative: on a scope-name collision
+// the manual value wins, and the binding only fills scopes the manual map does
+// not define. With no binding (or an empty one) the manual map is returned
+// unchanged — zero allocation, byte-identical behaviour for manual APIs.
+func scopeToPolicyMapForRequest(manual map[string]string, binding *Binding) map[string]string {
+	if binding == nil || len(binding.ScopeToPolicy) == 0 {
+		return manual
+	}
+	merged := make(map[string]string, len(binding.ScopeToPolicy)+len(manual))
+	for s, p := range binding.ScopeToPolicy {
+		merged[s] = p
+	}
+	for s, p := range manual {
+		merged[s] = p
+	}
+	return merged
+}
+
+// unmarshalIdPs decodes the gateway feed payload into IdP records. It tolerates
+// both transports: the RPC feed delivers a bare JSON array, while the direct-
+// Dashboard HTTP feed wraps it in a NodeResponseOK envelope
+// {"Status","Message":[...],"Nonce":"..."}. Empty input is a no-op.
+func unmarshalIdPs(b []byte) ([]IdP, error) {
+	trimmed := bytes.TrimSpace(b)
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+
+	if trimmed[0] == '{' {
+		var feed idpFeedEnvelope
+		if err := json.Unmarshal(trimmed, &feed); err != nil {
+			return nil, fmt.Errorf("unmarshal client-idps envelope: %w", err)
+		}
+		return feed.Message, nil
+	}
+
+	var out []IdP
+	if err := json.Unmarshal(trimmed, &out); err != nil {
+		return nil, fmt.Errorf("unmarshal client-idps payload: %w", err)
+	}
+	return out, nil
+}

--- a/gateway/idp_registry_test.go
+++ b/gateway/idp_registry_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/header"
 	"github.com/TykTechnologies/tyk/internal/cache"
+	"github.com/TykTechnologies/tyk/rpc"
 	"github.com/TykTechnologies/tyk/test"
 	"github.com/TykTechnologies/tyk/user"
 )
@@ -849,5 +850,62 @@ func TestFetchJWKSKey_FetchError(t *testing.T) {
 	k := newTestJWTMiddleware("api-a")
 	if got := k.fetchJWKSKey("http://127.0.0.1:1/jwks", "kid-1"); got != nil {
 		t.Errorf("unreachable JWKS must return nil, got %v", got)
+	}
+}
+
+// The client-IdP registry is backed up to Redis on RPC sync and restored from
+// that backup in emergency mode, mirroring API/policy recovery.
+func TestIdPRegistry_RPCBackup(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	const payload = `[{"client_idp_id":"idp-1","issuer":"https://i1",` +
+		`"api_mappings":{"api-a":{"scope_to_policy":{"read":"pol-read"}}}}]`
+
+	t.Run("save then load round-trips", func(t *testing.T) {
+		if err := ts.Gw.saveRPCIdPsBackup(payload); err != nil {
+			t.Fatalf("saveRPCIdPsBackup: %v", err)
+		}
+		idps, err := ts.Gw.LoadIdPsFromRPCBackup()
+		if err != nil {
+			t.Fatalf("LoadIdPsFromRPCBackup: %v", err)
+		}
+		if len(idps) != 1 || idps[0].ID != "idp-1" {
+			t.Fatalf("backup round-trip wrong: %#v", idps)
+		}
+		if idps[0].APIMappings["api-a"].ScopeToPolicy["read"] != "pol-read" {
+			t.Errorf("mappings lost in backup: %#v", idps[0].APIMappings)
+		}
+	})
+
+	t.Run("malformed payload is not stored", func(t *testing.T) {
+		if err := ts.Gw.saveRPCIdPsBackup("{not json"); err == nil {
+			t.Error("expected error for malformed backup payload")
+		}
+	})
+}
+
+// In emergency mode fetchFromRPC restores the registry from the Redis backup
+// instead of calling MDCB.
+func TestIdPRegistry_FetchFromRPC_EmergencyMode(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	const payload = `[{"client_idp_id":"idp-1",` +
+		`"api_mappings":{"api-a":{"scope_to_policy":{"read":"pol-read"}}}}]`
+	if err := ts.Gw.saveRPCIdPsBackup(payload); err != nil {
+		t.Fatalf("seed backup: %v", err)
+	}
+
+	rpc.SetEmergencyMode(t, true)
+	defer rpc.SetEmergencyMode(t, false)
+
+	r := newIdPRegistry(ts.Gw)
+	idps, err := r.fetchFromRPC()
+	if err != nil {
+		t.Fatalf("fetchFromRPC (emergency): %v", err)
+	}
+	if len(idps) != 1 || idps[0].ID != "idp-1" {
+		t.Fatalf("emergency mode must load from backup, got %#v", idps)
 	}
 }

--- a/gateway/idp_registry_test.go
+++ b/gateway/idp_registry_test.go
@@ -792,7 +792,7 @@ func TestFetchJWKSKey_CacheHit(t *testing.T) {
 	k.loadOrCreateJWKCache().Set("https://jwks", set, cache.DefaultExpiration)
 
 	// Cache hit: returns the key without any network fetch.
-	if got := k.fetchJWKSKey("https://jwks", "kid-1"); got == nil {
+	if k.fetchJWKSKey("https://jwks", "kid-1") == nil {
 		t.Fatal("cache hit should return the key")
 	}
 }

--- a/gateway/idp_registry_test.go
+++ b/gateway/idp_registry_test.go
@@ -1,0 +1,633 @@
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+
+	"github.com/TykTechnologies/tyk/apidef"
+	"github.com/TykTechnologies/tyk/apidef/oas"
+	"github.com/TykTechnologies/tyk/config"
+	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/test"
+	"github.com/TykTechnologies/tyk/user"
+)
+
+// fakeRPCLoader is a hand-written RPCDataLoader for exercising the registry's
+// RPC branch without a live MDCB connection.
+type fakeRPCLoader struct {
+	payload     string
+	gotOrgID    string
+	gotTags     []string
+	callerCount int
+}
+
+func (f *fakeRPCLoader) Connect() bool                                 { return true }
+func (f *fakeRPCLoader) GetApiDefinitions(_ string, _ []string) string { return "" }
+func (f *fakeRPCLoader) GetPolicies(_ string) string                   { return "" }
+func (f *fakeRPCLoader) GetClientIdPs(orgID string, tags []string) string {
+	f.callerCount++
+	f.gotOrgID = orgID
+	f.gotTags = tags
+	return f.payload
+}
+
+// mustWriteJSON writes a mock HTTP response body, failing the test on error.
+// Runs in the httptest server goroutine, so it uses Errorf (not Fatalf).
+func mustWriteJSON(t *testing.T, w http.ResponseWriter, body string) {
+	t.Helper()
+	if _, err := w.Write([]byte(body)); err != nil {
+		t.Errorf("mock write failed: %v", err)
+	}
+}
+
+// The gateway feed (RPC GetClientIdPs) delivers a bare JSON array of records
+// using the dashboard wire field names (client_idp_id, org_id, jwks_uri, ...).
+func TestUnmarshalIdPs_BareArray(t *testing.T) {
+	payload := []byte(`[
+	  {
+	    "client_idp_id": "idp-1",
+	    "org_id": "org-1",
+	    "name": "keycloak",
+	    "issuer": "https://issuer.example",
+	    "jwks_uri": "https://issuer.example/jwks",
+	    "api_mappings": {
+	      "api-a": { "scope_to_policy": { "read": "pol-read", "write": "pol-write" } }
+	    }
+	  }
+	]`)
+
+	idps, err := unmarshalIdPs(payload)
+	if err != nil {
+		t.Fatalf("unmarshalIdPs returned error: %v", err)
+	}
+	if len(idps) != 1 {
+		t.Fatalf("expected 1 IdP, got %d", len(idps))
+	}
+
+	idp := idps[0]
+	if idp.ID != "idp-1" {
+		t.Errorf("ID: want idp-1, got %q", idp.ID)
+	}
+	if idp.OrgID != "org-1" {
+		t.Errorf("OrgID: want org-1, got %q", idp.OrgID)
+	}
+	if idp.Name != "keycloak" {
+		t.Errorf("Name: want keycloak, got %q", idp.Name)
+	}
+	if idp.Issuer != "https://issuer.example" {
+		t.Errorf("Issuer: want https://issuer.example, got %q", idp.Issuer)
+	}
+	if idp.JWKSURI != "https://issuer.example/jwks" {
+		t.Errorf("JWKSURI: want https://issuer.example/jwks, got %q", idp.JWKSURI)
+	}
+	sm, ok := idp.APIMappings["api-a"]
+	if !ok {
+		t.Fatalf("APIMappings missing api-a: %#v", idp.APIMappings)
+	}
+	if sm.ScopeToPolicy["read"] != "pol-read" || sm.ScopeToPolicy["write"] != "pol-write" {
+		t.Errorf("ScopeToPolicy mismatch: %#v", sm.ScopeToPolicy)
+	}
+}
+
+// The direct-Dashboard HTTP feed wraps the array in a NodeResponseOK envelope
+// {"Status","Message":[...],"Nonce":"..."}. unmarshalIdPs must tolerate it too.
+func TestUnmarshalIdPs_Envelope(t *testing.T) {
+	payload := []byte(`{
+	  "Status": "OK",
+	  "Nonce": "abc123",
+	  "Message": [
+	    { "client_idp_id": "idp-2", "issuer": "https://i2", "jwks_uri": "https://i2/jwks" }
+	  ]
+	}`)
+
+	idps, err := unmarshalIdPs(payload)
+	if err != nil {
+		t.Fatalf("unmarshalIdPs returned error: %v", err)
+	}
+	if len(idps) != 1 {
+		t.Fatalf("expected 1 IdP, got %d", len(idps))
+	}
+	if idps[0].ID != "idp-2" {
+		t.Errorf("ID: want idp-2, got %q", idps[0].ID)
+	}
+}
+
+// Empty input is a no-op, not an error (mirrors empty RPC payloads).
+func TestUnmarshalIdPs_Empty(t *testing.T) {
+	idps, err := unmarshalIdPs(nil)
+	if err != nil {
+		t.Fatalf("nil input should not error, got %v", err)
+	}
+	if idps != nil {
+		t.Errorf("nil input should return nil slice, got %#v", idps)
+	}
+}
+
+// With no matched binding, the manual scope map is returned verbatim — the same
+// reference, so manual APIs allocate nothing and behave byte-identically.
+func TestScopeToPolicyMapForRequest_NoBinding(t *testing.T) {
+	manual := map[string]string{"read": "pol-read"}
+
+	got := scopeToPolicyMapForRequest(manual, nil)
+	if len(got) != 1 || got["read"] != "pol-read" {
+		t.Fatalf("nil binding should return manual unchanged, got %#v", got)
+	}
+
+	empty := scopeToPolicyMapForRequest(manual, &Binding{})
+	if len(empty) != 1 || empty["read"] != "pol-read" {
+		t.Fatalf("empty binding should return manual unchanged, got %#v", empty)
+	}
+}
+
+// Manual config is authoritative: on a scope-name collision manual wins, and the
+// binding only fills scopes the manual map does not define.
+func TestScopeToPolicyMapForRequest_ManualWinsBindingFills(t *testing.T) {
+	manual := map[string]string{"read": "pol-manual"}
+	binding := &Binding{
+		IdPID: "idp-1",
+		ScopeToPolicy: map[string]string{
+			"read":  "pol-binding", // collides with manual -> manual must win
+			"write": "pol-write",   // absent from manual -> binding fills it
+		},
+	}
+
+	got := scopeToPolicyMapForRequest(manual, binding)
+	if got["read"] != "pol-manual" {
+		t.Errorf("collision: manual must win, got read=%q", got["read"])
+	}
+	if got["write"] != "pol-write" {
+		t.Errorf("fill: binding must fill absent scope, got write=%q", got["write"])
+	}
+	// The merge must not mutate the caller's manual map.
+	if len(manual) != 1 {
+		t.Errorf("manual map was mutated: %#v", manual)
+	}
+}
+
+// A binding with no manual map returns the binding's mapping.
+func TestScopeToPolicyMapForRequest_BindingOnly(t *testing.T) {
+	binding := &Binding{ScopeToPolicy: map[string]string{"read": "pol-read"}}
+
+	got := scopeToPolicyMapForRequest(nil, binding)
+	if len(got) != 1 || got["read"] != "pol-read" {
+		t.Fatalf("binding-only mapping wrong: %#v", got)
+	}
+}
+
+// rebuild builds the reverse index, but the segment-aware backstop drops any
+// binding whose api_id is not in the loaded API set, and omits IdPs that retain
+// zero surviving mappings entirely.
+func TestIdPRegistry_RebuildSegmentBackstop(t *testing.T) {
+	gw := &Gateway{
+		apisByID: map[string]*APISpec{
+			"api-a": {},
+			"api-b": {},
+		},
+	}
+	r := newIdPRegistry(gw)
+
+	idps := []IdP{
+		{
+			ID:     "idp-1",
+			Issuer: "https://i1",
+			APIMappings: map[string]ScopeMapping{
+				"api-a": {ScopeToPolicy: map[string]string{"read": "pol-read"}}, // loaded
+				"api-c": {ScopeToPolicy: map[string]string{"x": "pol-x"}},       // NOT loaded -> dropped
+			},
+		},
+		{
+			ID:     "idp-2",
+			Issuer: "https://i2",
+			APIMappings: map[string]ScopeMapping{
+				"api-z": {ScopeToPolicy: map[string]string{"y": "pol-y"}}, // NOT loaded -> idp omitted
+			},
+		},
+	}
+
+	r.rebuild(idps)
+
+	// api-a is loaded and bound by idp-1.
+	bindingsA := r.BindingsForAPI("api-a")
+	if len(bindingsA) != 1 {
+		t.Fatalf("api-a: want 1 binding, got %d", len(bindingsA))
+	}
+	if bindingsA[0].IdPID != "idp-1" {
+		t.Errorf("api-a binding IdPID: want idp-1, got %q", bindingsA[0].IdPID)
+	}
+	if bindingsA[0].ScopeToPolicy["read"] != "pol-read" {
+		t.Errorf("api-a binding scope map wrong: %#v", bindingsA[0].ScopeToPolicy)
+	}
+
+	// api-c was mapped by idp-1 but is not loaded -> no binding.
+	if got := r.BindingsForAPI("api-c"); got != nil {
+		t.Errorf("api-c: unloaded api must have no bindings, got %#v", got)
+	}
+	// api-b is loaded but unbound -> no binding.
+	if got := r.BindingsForAPI("api-b"); got != nil {
+		t.Errorf("api-b: unbound api must have no bindings, got %#v", got)
+	}
+
+	// idp-1 retained a mapping -> present. idp-2 had zero surviving -> omitted.
+	if _, ok := r.IdP("idp-1"); !ok {
+		t.Errorf("idp-1 should be retained")
+	}
+	if _, ok := r.IdP("idp-2"); ok {
+		t.Errorf("idp-2 had zero surviving mappings and must be omitted")
+	}
+}
+
+// rebuild is build-then-swap: a previous snapshot must be fully replaced.
+func TestIdPRegistry_RebuildReplacesSnapshot(t *testing.T) {
+	gw := &Gateway{apisByID: map[string]*APISpec{"api-a": {}}}
+	r := newIdPRegistry(gw)
+
+	r.rebuild([]IdP{{ID: "old", APIMappings: map[string]ScopeMapping{"api-a": {}}}})
+	r.rebuild([]IdP{{ID: "new", APIMappings: map[string]ScopeMapping{"api-a": {}}}})
+
+	if _, ok := r.IdP("old"); ok {
+		t.Errorf("old IdP must be gone after rebuild")
+	}
+	if _, ok := r.IdP("new"); !ok {
+		t.Errorf("new IdP must be present after rebuild")
+	}
+	if b := r.BindingsForAPI("api-a"); len(b) != 1 || b[0].IdPID != "new" {
+		t.Errorf("api-a should bind only the new IdP, got %#v", b)
+	}
+}
+
+// fetchFromRPC calls the injected loader with the RPC key and decodes the array.
+func TestIdPRegistry_FetchFromRPC(t *testing.T) {
+	gw := &Gateway{apisByID: map[string]*APISpec{}}
+	conf := config.Config{}
+	conf.SlaveOptions.UseRPC = true
+	conf.SlaveOptions.RPCKey = "org-1"
+	gw.SetConfig(conf)
+
+	fake := &fakeRPCLoader{payload: `[{"client_idp_id":"idp-1","issuer":"https://i1"}]`}
+	r := newIdPRegistry(gw)
+	r.rpcLoaderFn = func() RPCDataLoader { return fake }
+
+	idps, err := r.fetchFromRPC()
+	if err != nil {
+		t.Fatalf("fetchFromRPC error: %v", err)
+	}
+	if len(idps) != 1 || idps[0].ID != "idp-1" {
+		t.Fatalf("decoded IdPs wrong: %#v", idps)
+	}
+	if fake.gotOrgID != "org-1" {
+		t.Errorf("RPC key: want org-1, got %q", fake.gotOrgID)
+	}
+	if fake.gotTags != nil {
+		t.Errorf("non-segmented node must pass no tags, got %#v", fake.gotTags)
+	}
+}
+
+// A segmented node forwards its tags so MDCB can pre-filter the payload.
+func TestIdPRegistry_FetchFromRPC_Segmented(t *testing.T) {
+	gw := &Gateway{apisByID: map[string]*APISpec{}}
+	conf := config.Config{}
+	conf.SlaveOptions.UseRPC = true
+	conf.SlaveOptions.RPCKey = "org-1"
+	conf.DBAppConfOptions.NodeIsSegmented = true
+	conf.DBAppConfOptions.Tags = []string{"edge-eu"}
+	gw.SetConfig(conf)
+
+	fake := &fakeRPCLoader{payload: ""}
+	r := newIdPRegistry(gw)
+	r.rpcLoaderFn = func() RPCDataLoader { return fake }
+
+	idps, err := r.fetchFromRPC()
+	if err != nil {
+		t.Fatalf("fetchFromRPC error: %v", err)
+	}
+	if idps != nil {
+		t.Errorf("empty payload must decode to nil, got %#v", idps)
+	}
+	if len(fake.gotTags) != 1 || fake.gotTags[0] != "edge-eu" {
+		t.Errorf("segmented node must forward tags, got %#v", fake.gotTags)
+	}
+}
+
+// fetchFromDashboard hits GET /system/clientidps with the gateway auth headers,
+// decodes the NodeResponseOK envelope, returns Message, and captures the Nonce.
+func TestIdPRegistry_FetchFromDashboard(t *testing.T) {
+	var gotPath, gotAuth, gotNodeID, gotSession string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("authorization")
+		gotNodeID = r.Header.Get(header.XTykNodeID)
+		gotSession = r.Header.Get(header.XTykSessionID)
+		w.Header().Set("Content-Type", "application/json")
+		mustWriteJSON(t, w, `{"Status":"OK","Nonce":"nonce-new","Message":[`+
+			`{"client_idp_id":"idp-1","issuer":"https://i1","jwks_uri":"https://i1/jwks"}]}`)
+	}))
+	defer srv.Close()
+
+	gw := &Gateway{apisByID: map[string]*APISpec{}}
+	conf := config.Config{}
+	conf.UseDBAppConfigs = true
+	conf.DisableDashboardZeroConf = true
+	conf.DBAppConfOptions.ConnectionString = srv.URL
+	conf.NodeSecret = "node-secret-xyz"
+	gw.SetConfig(conf)
+	gw.SetNodeID("node-1")
+	gw.SessionID = "session-1"
+	gw.ServiceNonce = "nonce-old"
+
+	r := newIdPRegistry(gw)
+
+	idps, err := r.fetchFromDashboard()
+	if err != nil {
+		t.Fatalf("fetchFromDashboard error: %v", err)
+	}
+	if len(idps) != 1 || idps[0].ID != "idp-1" {
+		t.Fatalf("decoded IdPs wrong: %#v", idps)
+	}
+	if gotPath != "/system/clientidps" {
+		t.Errorf("endpoint path: want /system/clientidps, got %q", gotPath)
+	}
+	if gotAuth != "node-secret-xyz" {
+		t.Errorf("authorization header: want node secret, got %q", gotAuth)
+	}
+	if gotNodeID != "node-1" {
+		t.Errorf("node id header: want node-1, got %q", gotNodeID)
+	}
+	if gotSession != "session-1" {
+		t.Errorf("session id header: want session-1, got %q", gotSession)
+	}
+	// The returned nonce must be captured so the node stays in sync — discarding
+	// it would desync against the dashboard's per-call createNonce.
+	if gw.ServiceNonce != "nonce-new" {
+		t.Errorf("ServiceNonce: want nonce-new, got %q", gw.ServiceNonce)
+	}
+}
+
+// A 403 from the dashboard is a login failure, surfaced as an error so the
+// previous registry snapshot is kept.
+func TestIdPRegistry_FetchFromDashboard_Forbidden(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		mustWriteJSON(t, w, "nope")
+	}))
+	defer srv.Close()
+
+	gw := &Gateway{apisByID: map[string]*APISpec{}}
+	conf := config.Config{}
+	conf.UseDBAppConfigs = true
+	conf.DisableDashboardZeroConf = true
+	conf.DBAppConfOptions.ConnectionString = srv.URL
+	gw.SetConfig(conf)
+	gw.SetNodeID("node-1")
+
+	r := newIdPRegistry(gw)
+	_, err := r.fetchFromDashboard()
+	if err == nil {
+		t.Fatal("expected error on 403, got nil")
+	}
+	// The raw response body of a failed auth attempt must not leak into the error
+	// (and thus the logs).
+	if strings.Contains(err.Error(), "nope") {
+		t.Errorf("403 error must not include the raw response body: %v", err)
+	}
+}
+
+// fetchJWKSKey must reject a non-HTTP(S) jwks_uri before building any client or
+// issuing a request — guards against non-HTTP SSRF vectors (file://, gopher://).
+func TestFetchJWKSKey_RejectsNonHTTPScheme(t *testing.T) {
+	spec := &APISpec{APIDefinition: &apidef.APIDefinition{}}
+	k := &JWTMiddleware{BaseMiddleware: &BaseMiddleware{Spec: spec}}
+
+	for _, url := range []string{"file:///etc/passwd", "gopher://127.0.0.1", "ftp://host/jwks"} {
+		if got := k.fetchJWKSKey(url, "kid"); got != nil {
+			t.Errorf("non-HTTP scheme %q must be rejected, got %v", url, got)
+		}
+	}
+}
+
+// doRefresh fetches and rebuilds end-to-end (RPC mode via injected loader).
+func TestIdPRegistry_DoRefresh(t *testing.T) {
+	gw := &Gateway{apisByID: map[string]*APISpec{"api-a": {}}}
+	conf := config.Config{}
+	conf.SlaveOptions.UseRPC = true
+	conf.SlaveOptions.RPCKey = "org-1"
+	gw.SetConfig(conf)
+
+	r := newIdPRegistry(gw)
+	r.rpcLoaderFn = func() RPCDataLoader {
+		return &fakeRPCLoader{payload: `[{"client_idp_id":"idp-1","issuer":"https://i1",` +
+			`"api_mappings":{"api-a":{"scope_to_policy":{"read":"pol-read"}}}}]`}
+	}
+
+	if err := r.doRefresh(); err != nil {
+		t.Fatalf("doRefresh error: %v", err)
+	}
+	b := r.BindingsForAPI("api-a")
+	if len(b) != 1 || b[0].IdPID != "idp-1" || b[0].ScopeToPolicy["read"] != "pol-read" {
+		t.Fatalf("registry not populated after doRefresh: %#v", b)
+	}
+}
+
+// doRefresh is a no-op once the gateway context is cancelled (shutdown), so a
+// debounced timer popping during shutdown cannot fetch.
+func TestIdPRegistry_DoRefresh_ShutdownNoOp(t *testing.T) {
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	gw := &Gateway{apisByID: map[string]*APISpec{"api-a": {}}, ctx: cancelledCtx}
+	conf := config.Config{}
+	conf.SlaveOptions.UseRPC = true
+	gw.SetConfig(conf)
+
+	called := false
+	r := newIdPRegistry(gw)
+	r.rpcLoaderFn = func() RPCDataLoader {
+		called = true
+		return &fakeRPCLoader{}
+	}
+
+	if err := r.doRefresh(); err != nil {
+		t.Fatalf("doRefresh error: %v", err)
+	}
+	if called {
+		t.Error("doRefresh must not fetch after context cancellation")
+	}
+}
+
+// The matched binding travels via the request context (not the shared
+// middleware struct), so per-request state cannot race across concurrent
+// ProcessRequest calls.
+func TestCtxMatchedBinding_Roundtrip(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	if got := ctxGetMatchedBinding(r); got != nil {
+		t.Fatalf("empty request must have no matched binding, got %#v", got)
+	}
+
+	b := &Binding{IdPID: "idp-1", ScopeToPolicy: map[string]string{"read": "pol"}}
+	ctxSetMatchedBinding(r, b)
+
+	got := ctxGetMatchedBinding(r)
+	if got == nil || got.IdPID != "idp-1" || got.ScopeToPolicy["read"] != "pol" {
+		t.Fatalf("matched binding roundtrip failed: %#v", got)
+	}
+}
+
+// In file mode (no DB, no RPC) fetch is deferred — returns no IdPs, no error.
+func TestIdPRegistry_FetchFileMode(t *testing.T) {
+	gw := &Gateway{apisByID: map[string]*APISpec{}}
+	gw.SetConfig(config.Config{})
+
+	r := newIdPRegistry(gw)
+	idps, err := r.fetch()
+	if err != nil {
+		t.Fatalf("file mode fetch error: %v", err)
+	}
+	if idps != nil {
+		t.Errorf("file mode must return no IdPs, got %#v", idps)
+	}
+}
+
+// A registry-only OAS API has no JWT configuration in its OAS definition, so
+// GetJWTConfiguration() returns nil. getScopeClaimNameOAS must not nil-deref
+// when scope mapping comes from the registry rather than the OAS def.
+func TestGetScopeClaimNameOAS_NilJWTConfig(t *testing.T) {
+	spec := &APISpec{APIDefinition: &apidef.APIDefinition{}, OAS: oas.OAS{}}
+	k := &JWTMiddleware{BaseMiddleware: &BaseMiddleware{Spec: spec}}
+
+	got := k.getScopeClaimNameOAS(jwt.MapClaims{"scope": "read"})
+	if got != "" {
+		t.Fatalf("expected empty claim name for OAS API with no JWT config, got %q", got)
+	}
+}
+
+// AC3: NoticeClientIdPChanged refreshes only the registry — it must be handled
+// (so the registry refreshes) but must NOT trigger a router rebuild / API reload
+// (the reloaded callback is never invoked).
+func TestIdPRegistry_NoticeClientIdPChanged_NoReload(t *testing.T) {
+	ts := StartTest(nil)
+	t.Cleanup(ts.Close)
+
+	conf := ts.Gw.GetConfig()
+	conf.AllowInsecureConfigs = true
+	ts.Gw.SetConfig(conf)
+
+	// Payload is the {org_id, client_idp_id} JSON contract; the direct-Dashboard
+	// handler refreshes the whole registry, so it doesn't parse the payload.
+	msg := testMessageAdapter{Msg: `{"Command": "ClientIdPChanged", "Payload": "{\"org_id\":\"org-1\",\"client_idp_id\":\"keycloak-prod\"}"}`}
+
+	var handledCmd NotificationCommand
+	handled := func(got NotificationCommand) { handledCmd = got }
+	reloaded := func() { t.Fatal("ClientIdPChanged must NOT trigger an API reload") }
+
+	ts.Gw.handleRedisEvent(&msg, handled, reloaded)
+
+	if handledCmd != NoticeClientIdPChanged {
+		t.Fatalf("want handled %q, got %q", NoticeClientIdPChanged, handledCmd)
+	}
+}
+
+// AC1: a JWT API with no JWTSource/JWTJwksURIs but a registry binding resolves
+// the signing key from the IdP's JWKS and maps the token scope to the bound
+// policy — returning 200.
+func TestIdPRegistry_JWT_ResolvesKeyAndScope(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	const apiID = "idp-reg-api"
+
+	pID := ts.CreatePolicy(func(p *user.Policy) {
+		p.ID = "idp-reg-policy"
+		p.AccessRights = map[string]user.AccessDefinition{apiID: {APIName: "idp-reg-api"}}
+		p.Partitions = user.PolicyPartitions{Acl: true}
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.APIID = apiID
+		spec.UseKeylessAccess = false
+		spec.EnableJWT = true
+		spec.JWTSigningMethod = RSASign
+		spec.JWTSource = "" // registry-only: no manual JWKS source
+		spec.JWTIdentityBaseField = "user_id"
+		spec.Proxy.ListenPath = "/idp-reg/"
+		spec.OrgID = "default"
+	})
+
+	// rebuild AFTER load so apisByID contains apiID (else the segment backstop
+	// drops the binding).
+	ts.Gw.idpRegistry.rebuild([]IdP{{
+		ID:      "idp-1",
+		Issuer:  "my-issuer",
+		JWKSURI: testHttpJWK,
+		APIMappings: map[string]ScopeMapping{
+			apiID: {ScopeToPolicy: map[string]string{"read": pID}},
+		},
+	}})
+
+	jwtToken := CreateJWKToken(func(tok *jwt.Token) {
+		tok.Header["kid"] = "12345"
+		tok.Claims.(jwt.MapClaims)["user_id"] = "user"
+		tok.Claims.(jwt.MapClaims)["iss"] = "my-issuer"
+		tok.Claims.(jwt.MapClaims)["scope"] = "read"
+		tok.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(72 * time.Hour).Unix()
+	})
+
+	_, _ = ts.Run(t, test.TestCase{
+		Path:    "/idp-reg/",
+		Headers: map[string]string{"authorization": jwtToken},
+		Code:    http.StatusOK,
+	})
+}
+
+// AC2: setting a manual JWTSource on the same API bypasses the registry entirely
+// (manual config wins — the probe never runs), still returning 200.
+func TestIdPRegistry_JWT_ManualSourceWins(t *testing.T) {
+	ts := StartTest(nil)
+	defer ts.Close()
+
+	const apiID = "idp-reg-manual-api"
+
+	pID := ts.CreatePolicy(func(p *user.Policy) {
+		p.ID = "idp-reg-manual-policy"
+		p.AccessRights = map[string]user.AccessDefinition{apiID: {APIName: "idp-reg-manual-api"}}
+	})
+
+	ts.Gw.BuildAndLoadAPI(func(spec *APISpec) {
+		spec.APIID = apiID
+		spec.UseKeylessAccess = false
+		spec.EnableJWT = true
+		spec.JWTSigningMethod = RSASign
+		spec.JWTSource = testHttpJWK // manual JWKS source
+		spec.JWTIdentityBaseField = "user_id"
+		spec.JWTPolicyFieldName = "policy_id"
+		spec.Proxy.ListenPath = "/idp-reg-manual/"
+		spec.OrgID = "default"
+	})
+
+	// A registry binding pointing at a BOGUS JWKS URL — if the probe ran it would
+	// fail; manual must win so this is never consulted.
+	ts.Gw.idpRegistry.rebuild([]IdP{{
+		ID:      "idp-bogus",
+		JWKSURI: "http://127.0.0.1:1/nope.json",
+		APIMappings: map[string]ScopeMapping{
+			apiID: {ScopeToPolicy: map[string]string{"read": "nonexistent-policy"}},
+		},
+	}})
+
+	jwtToken := CreateJWKToken(func(tok *jwt.Token) {
+		tok.Header["kid"] = "12345"
+		tok.Claims.(jwt.MapClaims)["user_id"] = "user"
+		tok.Claims.(jwt.MapClaims)["policy_id"] = pID
+		tok.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(72 * time.Hour).Unix()
+	})
+
+	_, _ = ts.Run(t, test.TestCase{
+		Path:    "/idp-reg-manual/",
+		Headers: map[string]string{"authorization": jwtToken},
+		Code:    http.StatusOK,
+	})
+}

--- a/gateway/idp_registry_test.go
+++ b/gateway/idp_registry_test.go
@@ -2,18 +2,22 @@ package gateway
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/go-jose/go-jose/v3"
 	"github.com/golang-jwt/jwt/v4"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/apidef/oas"
 	"github.com/TykTechnologies/tyk/config"
 	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/internal/cache"
 	"github.com/TykTechnologies/tyk/test"
 	"github.com/TykTechnologies/tyk/user"
 )
@@ -630,4 +634,220 @@ func TestIdPRegistry_JWT_ManualSourceWins(t *testing.T) {
 		Headers: map[string]string{"authorization": jwtToken},
 		Code:    http.StatusOK,
 	})
+}
+
+// --- focused unit coverage for the non-RPC helpers ---
+
+func newTestJWTMiddleware(apiID string) *JWTMiddleware {
+	gw := &Gateway{apisByID: map[string]*APISpec{}}
+	gw.SetConfig(config.Config{})
+	gw.idpRegistry = newIdPRegistry(gw)
+	spec := &APISpec{APIDefinition: &apidef.APIDefinition{APIID: apiID}}
+	return &JWTMiddleware{BaseMiddleware: &BaseMiddleware{Spec: spec, Gw: gw}}
+}
+
+func TestUnverifiedIssuerHint(t *testing.T) {
+	withIss := &jwt.Token{Claims: jwt.MapClaims{ISS: "https://issuer"}}
+	if got := unverifiedIssuerHint(withIss); got != "https://issuer" {
+		t.Errorf("iss present: want https://issuer, got %q", got)
+	}
+	noIss := &jwt.Token{Claims: jwt.MapClaims{"sub": "x"}}
+	if got := unverifiedIssuerHint(noIss); got != "" {
+		t.Errorf("no iss claim: want empty, got %q", got)
+	}
+	notMap := &jwt.Token{Claims: jwt.RegisteredClaims{}}
+	if got := unverifiedIssuerHint(notMap); got != "" {
+		t.Errorf("non-MapClaims: want empty, got %q", got)
+	}
+}
+
+func TestKeyFromJWKSet(t *testing.T) {
+	if got := keyFromJWKSet(nil, "kid"); got != nil {
+		t.Errorf("nil set must return nil, got %v", got)
+	}
+	if got := keyFromJWKSet(&jose.JSONWebKeySet{}, "kid"); got != nil {
+		t.Errorf("set without kid must return nil, got %v", got)
+	}
+}
+
+func TestCachedJWKSet(t *testing.T) {
+	k := newTestJWTMiddleware("api-a")
+	jwkCache := k.loadOrCreateJWKCache()
+
+	if got := cachedJWKSet(jwkCache, "https://miss"); got != nil {
+		t.Errorf("cache miss must return nil, got %v", got)
+	}
+
+	set := &jose.JSONWebKeySet{}
+	jwkCache.Set("https://hit", set, cache.DefaultExpiration)
+	if got := cachedJWKSet(jwkCache, "https://hit"); got != set {
+		t.Errorf("cache hit must return the set, got %v", got)
+	}
+
+	jwkCache.Set("https://wrong", 1234, cache.DefaultExpiration)
+	if got := cachedJWKSet(jwkCache, "https://wrong"); got != nil {
+		t.Errorf("unexpected cache value type must return nil, got %v", got)
+	}
+}
+
+func TestSecretFromIdPRegistry_EarlyReturns(t *testing.T) {
+	tok := &jwt.Token{Header: map[string]interface{}{KID: "kid-1"}, Claims: jwt.MapClaims{}}
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	// Gw nil.
+	kNoGw := &JWTMiddleware{BaseMiddleware: &BaseMiddleware{Spec: &APISpec{APIDefinition: &apidef.APIDefinition{}}}}
+	if got := kNoGw.secretFromIdPRegistry(r, tok); got != nil {
+		t.Errorf("nil Gw must return nil, got %v", got)
+	}
+
+	// Gw set but registry nil.
+	gw := &Gateway{}
+	gw.SetConfig(config.Config{})
+	kNoReg := &JWTMiddleware{BaseMiddleware: &BaseMiddleware{Spec: &APISpec{APIDefinition: &apidef.APIDefinition{}}, Gw: gw}}
+	if got := kNoReg.secretFromIdPRegistry(r, tok); got != nil {
+		t.Errorf("nil registry must return nil, got %v", got)
+	}
+
+	// Registry present but no bindings for this API.
+	k := newTestJWTMiddleware("api-a")
+	if got := k.secretFromIdPRegistry(r, tok); got != nil {
+		t.Errorf("no bindings must return nil, got %v", got)
+	}
+
+	// Binding exists but the token has no kid.
+	k.Gw.apisMu.Lock()
+	k.Gw.apisByID["api-a"] = &APISpec{}
+	k.Gw.apisMu.Unlock()
+	k.Gw.idpRegistry.rebuild([]IdP{{
+		ID: "idp-1", JWKSURI: "https://i1/jwks",
+		APIMappings: map[string]ScopeMapping{"api-a": {}},
+	}})
+	noKid := &jwt.Token{Header: map[string]interface{}{}, Claims: jwt.MapClaims{}}
+	if got := k.secretFromIdPRegistry(r, noKid); got != nil {
+		t.Errorf("missing kid must return nil, got %v", got)
+	}
+}
+
+func TestKeyForBinding_SkipBranches(t *testing.T) {
+	k := newTestJWTMiddleware("api-a")
+	k.Gw.idpRegistry.rebuild([]IdP{}) // empty registry
+
+	// Unknown IdP id -> nil (no fetch).
+	if got := k.keyForBinding(Binding{IdPID: "missing"}, "", "kid"); got != nil {
+		t.Errorf("unknown IdP must return nil, got %v", got)
+	}
+
+	// Known IdP but issuer hint mismatches -> nil (no fetch).
+	k.Gw.apisMu.Lock()
+	k.Gw.apisByID["api-a"] = &APISpec{}
+	k.Gw.apisMu.Unlock()
+	k.Gw.idpRegistry.rebuild([]IdP{{
+		ID: "idp-1", Issuer: "https://real", JWKSURI: "https://i1/jwks",
+		APIMappings: map[string]ScopeMapping{"api-a": {}},
+	}})
+	if got := k.keyForBinding(Binding{IdPID: "idp-1"}, "https://other", "kid"); got != nil {
+		t.Errorf("issuer mismatch must return nil, got %v", got)
+	}
+}
+
+func TestUnmarshalIdPs_InvalidJSON(t *testing.T) {
+	if _, err := unmarshalIdPs([]byte(`{not json`)); err == nil {
+		t.Error("expected error for malformed envelope")
+	}
+	if _, err := unmarshalIdPs([]byte(`[not json`)); err == nil {
+		t.Error("expected error for malformed array")
+	}
+}
+
+func TestIdPRegistry_FetchFromDashboard_Non200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	gw := &Gateway{apisByID: map[string]*APISpec{}}
+	conf := config.Config{}
+	conf.UseDBAppConfigs = true
+	conf.DisableDashboardZeroConf = true
+	conf.DBAppConfOptions.ConnectionString = srv.URL
+	gw.SetConfig(conf)
+	gw.SetNodeID("node-1")
+
+	r := newIdPRegistry(gw)
+	if _, err := r.fetchFromDashboard(); err == nil {
+		t.Fatal("expected error on non-200 dashboard response")
+	}
+}
+
+func TestFetchJWKSKey_CacheHit(t *testing.T) {
+	k := newTestJWTMiddleware("api-a")
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	set := &jose.JSONWebKeySet{Keys: []jose.JSONWebKey{
+		{Key: &priv.PublicKey, KeyID: "kid-1", Algorithm: "RS256", Use: "sig"},
+	}}
+	k.loadOrCreateJWKCache().Set("https://jwks", set, cache.DefaultExpiration)
+
+	// Cache hit: returns the key without any network fetch.
+	if got := k.fetchJWKSKey("https://jwks", "kid-1"); got == nil {
+		t.Fatal("cache hit should return the key")
+	}
+}
+
+// fetchFromRPC with the default loader (a real RPCStorageHandler) exercises the
+// newIdPRegistry rpcLoaderFn closure; with the RPC client down it yields nil.
+func TestIdPRegistry_FetchFromRPC_DefaultLoader(t *testing.T) {
+	gw := &Gateway{apisByID: map[string]*APISpec{}}
+	conf := config.Config{}
+	conf.SlaveOptions.UseRPC = true
+	conf.SlaveOptions.RPCKey = "org"
+	gw.SetConfig(conf)
+
+	r := newIdPRegistry(gw) // default rpcLoaderFn
+	idps, err := r.fetchFromRPC()
+	if err != nil {
+		t.Fatalf("fetchFromRPC error: %v", err)
+	}
+	if idps != nil {
+		t.Errorf("RPC down should yield nil IdPs, got %#v", idps)
+	}
+}
+
+// Refresh debounces and then rebuilds via doRefresh on the timer.
+func TestIdPRegistry_Refresh_DebouncedRebuild(t *testing.T) {
+	gw := &Gateway{apisByID: map[string]*APISpec{"api-a": {}}}
+	conf := config.Config{}
+	conf.SlaveOptions.UseRPC = true
+	gw.SetConfig(conf)
+
+	r := newIdPRegistry(gw)
+	r.rpcLoaderFn = func() RPCDataLoader {
+		return &fakeRPCLoader{payload: `[{"client_idp_id":"idp-1",` +
+			`"api_mappings":{"api-a":{"scope_to_policy":{"read":"pol-read"}}}}]`}
+	}
+
+	r.Refresh()
+	r.Refresh() // second call stops + reschedules the debounce timer
+
+	var b []Binding
+	for i := 0; i < 30; i++ {
+		time.Sleep(20 * time.Millisecond)
+		if b = r.BindingsForAPI("api-a"); len(b) > 0 {
+			break
+		}
+	}
+	if len(b) != 1 || b[0].IdPID != "idp-1" {
+		t.Fatalf("Refresh did not rebuild the registry: %#v", b)
+	}
+}
+
+// fetchJWKSKey returns nil when every fetch path fails (factory client, plain
+// client, and the x5c legacy fallback) — covers the error + legacy branches.
+func TestFetchJWKSKey_FetchError(t *testing.T) {
+	k := newTestJWTMiddleware("api-a")
+	if got := k.fetchJWKSKey("http://127.0.0.1:1/jwks", "kid-1"); got != nil {
+		t.Errorf("unreachable JWKS must return nil, got %v", got)
+	}
 }

--- a/gateway/idp_registry_test.go
+++ b/gateway/idp_registry_test.go
@@ -334,7 +334,7 @@ func TestIdPRegistry_FetchFromDashboard(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	gw := &Gateway{apisByID: map[string]*APISpec{}}
+	gw := &Gateway{apisByID: map[string]*APISpec{}, ctx: context.Background()}
 	conf := config.Config{}
 	conf.UseDBAppConfigs = true
 	conf.DisableDashboardZeroConf = true
@@ -382,7 +382,7 @@ func TestIdPRegistry_FetchFromDashboard_Forbidden(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	gw := &Gateway{apisByID: map[string]*APISpec{}}
+	gw := &Gateway{apisByID: map[string]*APISpec{}, ctx: context.Background()}
 	conf := config.Config{}
 	conf.UseDBAppConfigs = true
 	conf.DisableDashboardZeroConf = true
@@ -766,7 +766,7 @@ func TestIdPRegistry_FetchFromDashboard_Non200(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	gw := &Gateway{apisByID: map[string]*APISpec{}}
+	gw := &Gateway{apisByID: map[string]*APISpec{}, ctx: context.Background()}
 	conf := config.Config{}
 	conf.UseDBAppConfigs = true
 	conf.DisableDashboardZeroConf = true

--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -21,6 +21,7 @@ import (
 	"github.com/lonelycode/osin"
 	"github.com/ohler55/ojg/jp"
 	"github.com/tidwall/gjson"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/apidef/oas"
@@ -358,9 +359,161 @@ func (k *JWTMiddleware) getSecretToVerifySignature(r *http.Request, token *jwt.T
 	session, rawKeyExists := k.CheckSessionAndIdentityForValidKey(tykId, r)
 	tykId = session.KeyID
 	if !rawKeyExists {
+		// Last fallback: the client-IdP registry. Branches 1 (OAS JWTJwksURIs)
+		// and 2 (JWTSource) return earlier when manual config is set, so manual
+		// APIs never reach this path — manual config always wins.
+		if key := k.secretFromIdPRegistry(r, token); key != nil {
+			return key, nil
+		}
 		return nil, errors.New("token invalid, key not found")
 	}
 	return []byte(session.JWTData.Secret), nil
+}
+
+// secretFromIdPRegistry resolves the signing key from the client-IdP registry.
+// It probes the per-API reverse index, picks a candidate IdP by the (unverified)
+// iss hint, and fetches the matching JWKS key by kid. On a match it records the
+// binding on the request context (never on the shared middleware struct) so the
+// scope-resolution branch can apply the binding's overrides.
+func (k *JWTMiddleware) secretFromIdPRegistry(r *http.Request, token *jwt.Token) interface{} {
+	if k.Gw == nil || k.Gw.idpRegistry == nil {
+		return nil
+	}
+	bindings := k.Gw.idpRegistry.BindingsForAPI(k.Spec.APIID)
+	if len(bindings) == 0 {
+		return nil
+	}
+
+	kid, ok := token.Header[KID].(string)
+	if !ok || kid == "" {
+		return nil // JWKS lookup needs a kid
+	}
+
+	var iss string
+	if claims, isMap := token.Claims.(jwt.MapClaims); isMap {
+		if issStr, isString := claims[ISS].(string); isString {
+			iss = issStr // hint only, UNVERIFIED — selects which JWKS to try
+		}
+	}
+
+	for i := range bindings {
+		b := bindings[i]
+		idp, ok := k.Gw.idpRegistry.IdP(b.IdPID)
+		if !ok {
+			continue
+		}
+		if iss != "" && idp.Issuer != iss {
+			continue // empty iss → walk all candidates
+		}
+		if key := k.fetchJWKSKey(idp.JWKSURI, kid); key != nil {
+			ctxSetMatchedBinding(r, &b) // request context — never k
+			return key
+		}
+	}
+	return nil
+}
+
+// fetchJWKSKey resolves a JWKS key by kid, keyed purely on the URL. It is
+// deliberately not getSecretFromURL: that function's cache-hit path is gated on
+// decode(Spec.JWTSource) == url, which is always false for a registry URL
+// (Spec.JWTSource == ""), so it would refetch the JWKS on every request.
+//
+// Security: url is the IdP's jwks_uri from the admin-controlled client-IdP
+// registry (Dashboard/MDCB) — the same trust domain and HTTP client
+// (ExternalHTTPClientFactory) as the existing JWTSource/JWTJwksURIs fetches, so
+// it inherits their SSRF posture rather than introducing a new one. We require
+// an http(s) scheme here to reject non-HTTP vectors (file://, gopher://, ...);
+// host-level egress restrictions are intentionally NOT applied because DCR IdPs
+// (e.g. an internal Keycloak) legitimately live on private networks.
+func (k *JWTMiddleware) fetchJWKSKey(url, kid string) interface{} {
+	if url == "" || kid == "" {
+		return nil
+	}
+	if !httpScheme.MatchString(url) {
+		k.Logger().Warnf("Ignoring non-HTTP client-IdP JWKS URI")
+		return nil
+	}
+	jwkCache := k.loadOrCreateJWKCache() // per-API cache; URL-keyed inside
+
+	if key := keyFromJWKSet(cachedJWKSet(jwkCache, url), kid); key != nil {
+		return key
+	}
+
+	// Coalesce concurrent fetches for the same (API, URL) so a burst of requests
+	// on a cold/expired cache triggers a single network fetch instead of a
+	// thundering herd against the IdP's JWKS endpoint. Keyed by APIID so each
+	// API's per-API cache stays coherent.
+	res, err, _ := jwksFetchGroup.Do(k.Spec.APIID+"|"+url, func() (interface{}, error) {
+		set, fetchErr := k.fetchAndCacheJWKS(url, jwkCache)
+		return set, fetchErr
+	})
+
+	if err != nil {
+		// x5c PEM fallback (mirrors getSecretFromMultipleJWKURIs); rare error path.
+		if key, legacyErr := k.legacyGetSecretFromURL(url, kid, k.Spec.JWTSigningMethod); legacyErr == nil {
+			return key
+		}
+		k.Gw.logJWKError(k.Logger(), url, err)
+		return nil
+	}
+
+	set, ok := res.(*jose.JSONWebKeySet)
+	if !ok {
+		return nil
+	}
+	return keyFromJWKSet(set, kid)
+}
+
+// jwksFetchGroup coalesces concurrent client-IdP JWKS fetches per (API, URL).
+var jwksFetchGroup singleflight.Group
+
+// keyFromJWKSet returns the public key for kid from set, or nil if set is nil or
+// the kid is absent (e.g. JWKS cached before a key rotation).
+func keyFromJWKSet(set *jose.JSONWebKeySet, kid string) interface{} {
+	if set == nil {
+		return nil
+	}
+	if keys := set.Key(kid); len(keys) > 0 {
+		return keys[0].Key
+	}
+	return nil
+}
+
+// cachedJWKSet returns the cached JWKS for url, or nil on a miss / unexpected
+// cache value type.
+func cachedJWKSet(jwkCache cache.Repository, url string) *jose.JSONWebKeySet {
+	if raw, ok := jwkCache.Get(url); ok {
+		if set, isSet := raw.(*jose.JSONWebKeySet); isSet {
+			return set
+		}
+	}
+	return nil
+}
+
+// fetchAndCacheJWKS fetches the JWKS at url (factory client, then plain-client
+// fallback) and caches it. Runs inside the single-flight, so it re-checks the
+// cache first in case a prior in-flight fetch already populated it.
+func (k *JWTMiddleware) fetchAndCacheJWKS(url string, jwkCache cache.Repository) (*jose.JSONWebKeySet, error) {
+	if set := cachedJWKSet(jwkCache, url); set != nil {
+		return set, nil
+	}
+
+	var (
+		jwkSet *jose.JSONWebKeySet
+		err    error
+	)
+	client, clientErr := NewExternalHTTPClientFactory(k.Gw).CreateJWKClient()
+	if clientErr == nil {
+		jwkSet, err = getJWKWithClient(url, client)
+	}
+	if clientErr != nil || err != nil {
+		jwkSet, err = GetJWK(url, k.Gw.GetConfig().JWTSSLInsecureSkipVerify)
+	}
+	if err != nil {
+		return nil, err
+	}
+	jwkCache.Set(url, jwkSet, cache.DefaultExpiration)
+	return jwkSet, nil
 }
 
 var GetJWK = getJWK
@@ -855,8 +1008,12 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 		}
 	}
 
-	// apply policies from scope if scope-to-policy mapping is specified for this API
-	if len(k.Spec.GetScopeToPolicyMapping()) != 0 {
+	// apply policies from scope if scope-to-policy mapping is specified for this
+	// API. The manual API-def map is merged with any matched registry binding
+	// (manual wins on collision, binding fills gaps). With no binding this
+	// returns the manual map unchanged — byte-identical for manual APIs.
+	scopeMap := scopeToPolicyMapForRequest(k.Spec.GetScopeToPolicyMapping(), ctxGetMatchedBinding(r))
+	if len(scopeMap) != 0 {
 		scopeClaimName := k.Spec.GetScopeClaimName()
 		if k.Spec.IsOAS {
 			scopeClaimName = k.getScopeClaimNameOAS(claims)
@@ -878,7 +1035,7 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 			}
 
 			// add all policies matched from scope-policy mapping
-			mappedPolIDs := mapScopeToPolicies(k.Spec.GetScopeToPolicyMapping(), scope)
+			mappedPolIDs := mapScopeToPolicies(scopeMap, scope)
 			if len(mappedPolIDs) > 0 {
 				k.Logger().Debugf("Identified policy(s) to apply to this token from scope claim: %s", scopeClaimName)
 			} else {
@@ -920,7 +1077,7 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 			k.reportLoginFailure(baseFieldData, r)
 			k.Logger().Error("No policies could be determined from token (no base policy, no valid scopes)")
 			return errors.New("key not authorized: no matching policy found"), http.StatusForbidden
-		} else if exists && len(k.Spec.GetScopeToPolicyMapping()) == 0 {
+		} else if exists && len(scopeMap) == 0 {
 			k.reportLoginFailure(baseFieldData, r)
 			k.Logger().Error("Existing session requires policy in token when no defaults configured")
 			return errors.New("key not authorized: no matching policy found"), http.StatusForbidden
@@ -999,9 +1156,17 @@ func (k *JWTMiddleware) processCentralisedJWT(r *http.Request, token *jwt.Token)
 }
 
 func (k *JWTMiddleware) getScopeClaimNameOAS(claims jwt.MapClaims) string {
-	claimNames := k.Spec.OAS.GetJWTConfiguration().Scopes.Claims
-	if len(claimNames) == 0 && k.Spec.OAS.GetJWTConfiguration().Scopes.ClaimName != "" {
-		claimNames = []string{k.Spec.OAS.GetJWTConfiguration().Scopes.ClaimName}
+	// A registry-resolved OAS API has no JWT configuration in its OAS def, so
+	// GetJWTConfiguration() (and its Scopes) can be nil — the scope claim name
+	// then falls back to the default ("scope") in the caller.
+	jwtConfig := k.Spec.OAS.GetJWTConfiguration()
+	if jwtConfig == nil || jwtConfig.Scopes == nil {
+		return ""
+	}
+
+	claimNames := jwtConfig.Scopes.Claims
+	if len(claimNames) == 0 && jwtConfig.Scopes.ClaimName != "" {
+		claimNames = []string{jwtConfig.Scopes.ClaimName}
 	}
 	for _, claimName := range claimNames {
 		for k := range claims {
@@ -1111,8 +1276,13 @@ func (k *JWTMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _
 		// Are we mapping to a central JWT Secret?
 		hasJWTSource := k.Spec.JWTSource != ""
 		hasJwksURIs := len(k.Spec.JWTJwksURIs) > 0
+		// Registry-resolved tokens are conceptually centralised (external IdP);
+		// without this third condition a registry-only API would fall to
+		// processOneToOneTokenMap and the binding's scope→policy overrides would
+		// never apply.
+		hasRegistryBinding := ctxGetMatchedBinding(r) != nil
 
-		if hasJWTSource || hasJwksURIs {
+		if hasJWTSource || hasJwksURIs || hasRegistryBinding {
 			return k.processCentralisedJWT(r, token)
 		}
 

--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -388,29 +388,43 @@ func (k *JWTMiddleware) secretFromIdPRegistry(r *http.Request, token *jwt.Token)
 	if !ok || kid == "" {
 		return nil // JWKS lookup needs a kid
 	}
-
-	var iss string
-	if claims, isMap := token.Claims.(jwt.MapClaims); isMap {
-		if issStr, isString := claims[ISS].(string); isString {
-			iss = issStr // hint only, UNVERIFIED — selects which JWKS to try
-		}
-	}
+	iss := unverifiedIssuerHint(token)
 
 	for i := range bindings {
 		b := bindings[i]
-		idp, ok := k.Gw.idpRegistry.IdP(b.IdPID)
-		if !ok {
-			continue
-		}
-		if iss != "" && idp.Issuer != iss {
-			continue // empty iss → walk all candidates
-		}
-		if key := k.fetchJWKSKey(idp.JWKSURI, kid); key != nil {
+		if key := k.keyForBinding(b, iss, kid); key != nil {
 			ctxSetMatchedBinding(r, &b) // request context — never k
 			return key
 		}
 	}
 	return nil
+}
+
+// unverifiedIssuerHint reads the iss claim WITHOUT verification — used only to
+// choose which IdP's JWKS to try; signature verification + validateIssuer run
+// afterwards. Returns "" when there's no usable iss (then all IdPs are tried).
+func unverifiedIssuerHint(token *jwt.Token) string {
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return ""
+	}
+	if iss, ok := claims[ISS].(string); ok {
+		return iss
+	}
+	return ""
+}
+
+// keyForBinding resolves the JWKS key for a single registry binding, or nil to
+// skip it: unknown IdP, iss mismatch (empty iss walks all), or no matching kid.
+func (k *JWTMiddleware) keyForBinding(b Binding, iss, kid string) interface{} {
+	idp, ok := k.Gw.idpRegistry.IdP(b.IdPID)
+	if !ok {
+		return nil
+	}
+	if iss != "" && idp.Issuer != iss {
+		return nil
+	}
+	return k.fetchJWKSKey(idp.JWKSURI, kid)
 }
 
 // fetchJWKSKey resolves a JWKS key by kid, keyed purely on the URL. It is

--- a/gateway/redis_signals.go
+++ b/gateway/redis_signals.go
@@ -44,6 +44,7 @@ const (
 	NoticeDeleteAPICache            NotificationCommand = "DeleteAPICache"
 	NoticeUserKeyReset              NotificationCommand = "UserKeyReset"
 	NoticeInvalidateJWKSCacheForAPI NotificationCommand = "InvalidateJWKSCacheForAPI"
+	NoticeClientIdPChanged          NotificationCommand = "ClientIdPChanged"
 )
 
 // Notification is a type that encodes a message published to a pub sub channel (shared between implementations)
@@ -160,6 +161,12 @@ func (gw *Gateway) handleRedisEvent(v interface{}, handled func(NotificationComm
 		}
 	case NoticeInvalidateJWKSCacheForAPI:
 		gw.invalidateJWKSCacheByAPIID(notif.Payload)
+	case NoticeClientIdPChanged:
+		// Refresh only the registry — deliberately NOT bundled with NoticeApi*/
+		// NoticePolicyChanged: no router rebuild, no APISpec reload. Debounced,
+		// so a burst of signals coalesces into one rebuild. Direct-Dashboard
+		// mode only; RPC-mode edges refresh on their existing poll/reload tick.
+		gw.refreshIdPRegistry()
 	case NoticeUserKeyReset:
 		gw.handleUserKeyReset(notif.Payload)
 	default:

--- a/gateway/rpc_backup_handlers.go
+++ b/gateway/rpc_backup_handlers.go
@@ -189,7 +189,7 @@ func (gw *Gateway) LoadIdPsFromRPCBackup() ([]IdP, error) {
 // saveRPCDefinitionsBackup.
 func (gw *Gateway) saveRPCIdPsBackup(list string) error {
 	if !json.Valid([]byte(list)) {
-		return errors.New("--> RPC Client-IdP Backup save failure: wrong format, skipping.")
+		return errors.New("--> RPC Client-IdP Backup save failure: wrong format, skipping")
 	}
 	if gw.StorageConnectionHandler == nil {
 		return errors.New("--> RPC Client-IdP Backup save failed: no storage connection handler")
@@ -206,7 +206,7 @@ func (gw *Gateway) saveRPCIdPsBackup(list string) error {
 	secret := crypto.GetPaddedString(gw.GetConfig().Secret)
 	cryptoText := crypto.Encrypt(secret, list) // stored raw (small payload, no compression)
 	if err := store.SetKey(BackupClientIdPKeyBase+tagList, cryptoText, -1); err != nil {
-		return errors.New("Failed to store node client-idp backup: " + err.Error())
+		return errors.New("failed to store node client-idp backup: " + err.Error())
 	}
 
 	return nil

--- a/gateway/rpc_backup_handlers.go
+++ b/gateway/rpc_backup_handlers.go
@@ -17,6 +17,7 @@ import (
 const RPCKeyPrefix = "rpc:"
 const BackupApiKeyBase = "node-definition-backup:"
 const BackupPolicyKeyBase = "node-policy-backup:"
+const BackupClientIdPKeyBase = "node-clientidp-backup:"
 
 // backupKind identifies the type of data being compressed or decompressed,
 // used for log and error messages. Defining it as a named type lets the
@@ -26,6 +27,7 @@ type backupKind string
 const (
 	backupKindAPIDefinitions backupKind = "API Definitions"
 	backupKindPolicies       backupKind = "Policies"
+	backupKindClientIdPs     backupKind = "Client IdPs"
 )
 
 func getTagListAsString(tags []string) string {
@@ -150,6 +152,80 @@ func (gw *Gateway) compressPolicyBackup(list string) string {
 
 func (gw *Gateway) decompressPolicyBackup(decrypted string) (string, error) {
 	return gw.decompressBackup(decrypted, backupKindPolicies)
+}
+
+// The client-IdP registry payload is small (one record per org IdP), so it is
+// stored uncompressed; decompressBackup still auto-detects on load.
+func (gw *Gateway) compressClientIdPBackup(list string) string {
+	return gw.compressBackup(list, false, backupKindClientIdPs)
+}
+
+func (gw *Gateway) decompressClientIdPBackup(decrypted string) (string, error) {
+	return gw.decompressBackup(decrypted, backupKindClientIdPs)
+}
+
+// LoadIdPsFromRPCBackup restores the client-IdP registry payload saved on the
+// last successful RPC sync, used when the edge gateway is in emergency mode and
+// MDCB is unreachable — the sibling of LoadDefinitionsFromRPCBackup.
+func (gw *Gateway) LoadIdPsFromRPCBackup() ([]IdP, error) {
+	if gw.StorageConnectionHandler == nil {
+		return nil, errors.New("[RPC] --> RPC Client-IdP Backup recovery failed: no storage connection handler")
+	}
+
+	tagList := getTagListAsString(gw.GetConfig().DBAppConfOptions.Tags)
+	checkKey := BackupClientIdPKeyBase + tagList
+
+	store := &storage.RedisCluster{KeyPrefix: RPCKeyPrefix, ConnectionHandler: gw.StorageConnectionHandler}
+	connected := store.Connect()
+
+	log.Info("[RPC] --> Loading client IdPs from backup")
+
+	if !connected {
+		return nil, errors.New("[RPC] --> RPC Client-IdP Backup recovery failed: redis connection failed")
+	}
+
+	secret := crypto.GetPaddedString(gw.GetConfig().Secret)
+	cryptoText, err := store.GetKey(checkKey)
+	if err != nil {
+		return nil, errors.New("[RPC] --> Failed to get node client-idp backup (" + checkKey + "): " + err.Error())
+	}
+
+	decrypted := crypto.Decrypt(secret, cryptoText)
+
+	listAsString, err := gw.decompressClientIdPBackup(decrypted)
+	if err != nil {
+		return nil, err
+	}
+
+	return unmarshalIdPs([]byte(listAsString))
+}
+
+// saveRPCIdPsBackup stores the raw GetClientIdPs payload (a JSON array) to Redis
+// so emergency mode can restore the registry — the sibling of
+// saveRPCDefinitionsBackup.
+func (gw *Gateway) saveRPCIdPsBackup(list string) error {
+	if !json.Valid([]byte(list)) {
+		return errors.New("--> RPC Client-IdP Backup save failure: wrong format, skipping.")
+	}
+	if gw.StorageConnectionHandler == nil {
+		return errors.New("--> RPC Client-IdP Backup save failed: no storage connection handler")
+	}
+
+	tagList := getTagListAsString(gw.GetConfig().DBAppConfOptions.Tags)
+
+	store := storage.RedisCluster{KeyPrefix: RPCKeyPrefix, ConnectionHandler: gw.StorageConnectionHandler}
+	connected := store.Connect()
+	if !connected {
+		return errors.New("--> RPC Client-IdP Backup save failed: redis connection failed")
+	}
+
+	secret := crypto.GetPaddedString(gw.GetConfig().Secret)
+	cryptoText := crypto.Encrypt(secret, gw.compressClientIdPBackup(list))
+	if err := store.SetKey(BackupClientIdPKeyBase+tagList, cryptoText, -1); err != nil {
+		return errors.New("Failed to store node client-idp backup: " + err.Error())
+	}
+
+	return nil
 }
 
 func (gw *Gateway) LoadPoliciesFromRPCBackup() ([]user.Policy, error) {

--- a/gateway/rpc_backup_handlers.go
+++ b/gateway/rpc_backup_handlers.go
@@ -27,7 +27,6 @@ type backupKind string
 const (
 	backupKindAPIDefinitions backupKind = "API Definitions"
 	backupKindPolicies       backupKind = "Policies"
-	backupKindClientIdPs     backupKind = "Client IdPs"
 )
 
 func getTagListAsString(tags []string) string {
@@ -154,16 +153,6 @@ func (gw *Gateway) decompressPolicyBackup(decrypted string) (string, error) {
 	return gw.decompressBackup(decrypted, backupKindPolicies)
 }
 
-// The client-IdP registry payload is small (one record per org IdP), so it is
-// stored uncompressed; decompressBackup still auto-detects on load.
-func (gw *Gateway) compressClientIdPBackup(list string) string {
-	return gw.compressBackup(list, false, backupKindClientIdPs)
-}
-
-func (gw *Gateway) decompressClientIdPBackup(decrypted string) (string, error) {
-	return gw.decompressBackup(decrypted, backupKindClientIdPs)
-}
-
 // LoadIdPsFromRPCBackup restores the client-IdP registry payload saved on the
 // last successful RPC sync, used when the edge gateway is in emergency mode and
 // MDCB is unreachable — the sibling of LoadDefinitionsFromRPCBackup.
@@ -190,14 +179,9 @@ func (gw *Gateway) LoadIdPsFromRPCBackup() ([]IdP, error) {
 		return nil, errors.New("[RPC] --> Failed to get node client-idp backup (" + checkKey + "): " + err.Error())
 	}
 
+	// The payload is small, so it is stored raw (encrypted only, no compression).
 	decrypted := crypto.Decrypt(secret, cryptoText)
-
-	listAsString, err := gw.decompressClientIdPBackup(decrypted)
-	if err != nil {
-		return nil, err
-	}
-
-	return unmarshalIdPs([]byte(listAsString))
+	return unmarshalIdPs([]byte(decrypted))
 }
 
 // saveRPCIdPsBackup stores the raw GetClientIdPs payload (a JSON array) to Redis
@@ -220,7 +204,7 @@ func (gw *Gateway) saveRPCIdPsBackup(list string) error {
 	}
 
 	secret := crypto.GetPaddedString(gw.GetConfig().Secret)
-	cryptoText := crypto.Encrypt(secret, gw.compressClientIdPBackup(list))
+	cryptoText := crypto.Encrypt(secret, list) // stored raw (small payload, no compression)
 	if err := store.SetKey(BackupClientIdPKeyBase+tagList, cryptoText, -1); err != nil {
 		return errors.New("Failed to store node client-idp backup: " + err.Error())
 	}

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -905,8 +905,8 @@ func (r *RPCStorageHandler) CheckForIdPReload(orgId string) bool {
 		return true
 	}
 
-	changedIDs, _ := changed.([]string)
-	if len(changedIDs) > 0 && r.Gw.idpRegistry != nil {
+	changedIDs, ok := changed.([]string)
+	if ok && len(changedIDs) > 0 && r.Gw.idpRegistry != nil {
 		log.Infof("[RPC STORE] %d client-IdP change(s) signalled; refreshing registry", len(changedIDs))
 		if refreshErr := r.Gw.idpRegistry.doRefresh(); refreshErr != nil {
 			log.WithError(refreshErr).Error("client-IdP registry refresh failed; keeping previous snapshot")

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -73,6 +73,9 @@ var (
 		"GetApiDefinitions": func(dr *model.DefRequest) (string, error) {
 			return "", nil
 		},
+		"GetClientIdPs": func(dr *model.DefRequest) (string, error) {
+			return "", nil
+		},
 		"GetPolicies": func(orgId string) (string, error) {
 			return "", nil
 		},
@@ -80,6 +83,9 @@ var (
 			return nil
 		},
 		"CheckReload": func(clientAddr, orgId string) (bool, error) {
+			return false, nil
+		},
+		"CheckIdPReload": func(clientAddr, orgId string) (bool, error) {
 			return false, nil
 		},
 		"GetKeySpaceUpdate": func(clientAddr, orgId string) ([]string, error) {
@@ -124,6 +130,10 @@ type RPCDataLoader interface {
 	Connect() bool
 	GetApiDefinitions(orgId string, tags []string) string
 	GetPolicies(orgId string) string
+	// GetClientIdPs is the sibling of GetApiDefinitions for the client-IdP
+	// registry. The JSON-array envelope is identical to the dashboard's
+	// /system/clientidps payload — both decoded by unmarshalIdPs.
+	GetClientIdPs(orgId string, tags []string) string
 }
 
 // Connect will establish a connection to the RPC
@@ -772,6 +782,32 @@ func (r *RPCStorageHandler) GetApiDefinitions(orgId string, tags []string) strin
 	return defString.(string)
 }
 
+// GetClientIdPs pulls the client-IdP registry from the RPC server. The payload
+// is already tag-filtered and api_mappings-pruned by MDCB; the segment backstop
+// in IdPRegistry.rebuild is defensive safety.
+func (r *RPCStorageHandler) GetClientIdPs(orgId string, tags []string) string {
+	dr := model.DefRequest{OrgId: orgId, Tags: tags}
+	defString, err := rpc.FuncClientSingleton("GetClientIdPs", dr)
+	if err != nil {
+		rpc.EmitErrorEventKv(
+			rpc.FuncClientSingletonCall,
+			"GetClientIdPs",
+			err,
+			map[string]string{
+				"orgId": orgId,
+				"tags":  strings.Join(tags, ","),
+			},
+		)
+		// FuncClientSingleton already retries with backoff; on hard failure the
+		// registry refresh logs and leaves the previous index in place.
+		return ""
+	}
+	if defString == nil {
+		return ""
+	}
+	return defString.(string)
+}
+
 // GetPolicies will pull Policies from the RPC server
 func (r *RPCStorageHandler) GetPolicies(orgId string) string {
 	defString, err := rpc.FuncClientSingleton("GetPolicies", orgId)
@@ -835,6 +871,42 @@ func (r *RPCStorageHandler) CheckForReload(orgId string) bool {
 		go func() {
 			r.Gw.MainNotifier.Notify(Notification{Command: NoticeGroupReload, Gw: r.Gw})
 		}()
+	}
+	return true
+}
+
+// CheckForIdPReload is the client-IdP sibling of CheckForReload: a long poll on
+// the dedicated CheckIdPReload RPC. On a reload signal it refreshes ONLY the
+// client-IdP registry (a single GetClientIdPs RPC) — deliberately NOT a full
+// API/policy resync. Errors are logged and the loop continues; the registry
+// keeps its previous snapshot. Returns false only on shutdown to stop the loop.
+func (r *RPCStorageHandler) CheckForIdPReload(orgId string) bool {
+	select {
+	case <-r.Gw.ctx.Done():
+		return false
+	default:
+	}
+
+	reload, err := rpc.FuncClientSingleton("CheckIdPReload", orgId)
+	if err != nil {
+		rpc.EmitErrorEventKv(
+			rpc.FuncClientSingletonCall,
+			"CheckIdPReload",
+			err,
+			map[string]string{"orgId": orgId},
+		)
+		// Unlike CheckForReload we do not force a re-sync here: an IdP reload
+		// check is auxiliary and must not disturb the main RPC sync state. The
+		// main reload loop owns re-login/recovery.
+		time.Sleep(1 * time.Second)
+		return true
+	}
+
+	if reload == true && r.Gw.idpRegistry != nil {
+		log.Info("[RPC STORE] Received client-IdP reload instruction!")
+		if refreshErr := r.Gw.idpRegistry.doRefresh(); refreshErr != nil {
+			log.WithError(refreshErr).Error("client-IdP registry refresh failed; keeping previous snapshot")
+		}
 	}
 	return true
 }

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -85,8 +85,8 @@ var (
 		"CheckReload": func(clientAddr, orgId string) (bool, error) {
 			return false, nil
 		},
-		"CheckIdPReload": func(clientAddr, orgId string) (bool, error) {
-			return false, nil
+		"CheckIdPReload": func(clientAddr, orgId string) ([]string, error) {
+			return nil, nil
 		},
 		"GetKeySpaceUpdate": func(clientAddr, orgId string) ([]string, error) {
 			return nil, nil
@@ -876,10 +876,13 @@ func (r *RPCStorageHandler) CheckForReload(orgId string) bool {
 }
 
 // CheckForIdPReload is the client-IdP sibling of CheckForReload: a long poll on
-// the dedicated CheckIdPReload RPC. On a reload signal it refreshes ONLY the
-// client-IdP registry (a single GetClientIdPs RPC) — deliberately NOT a full
-// API/policy resync. Errors are logged and the loop continues; the registry
-// keeps its previous snapshot. Returns false only on shutdown to stop the loop.
+// the dedicated CheckIdPReload RPC. MDCB returns the list of client_idp_id values
+// that changed for this node's group (empty when nothing pending); the list is
+// used purely as a "something changed" signal — on a non-empty result we refresh
+// the whole registry once via doRefresh (a single GetClientIdPs RPC), which also
+// handles deletes for free. This is deliberately NOT a full API/policy resync.
+// Errors are logged and the loop continues; the registry keeps its previous
+// snapshot. Returns false only on shutdown to stop the loop.
 func (r *RPCStorageHandler) CheckForIdPReload(orgId string) bool {
 	select {
 	case <-r.Gw.ctx.Done():
@@ -887,7 +890,7 @@ func (r *RPCStorageHandler) CheckForIdPReload(orgId string) bool {
 	default:
 	}
 
-	reload, err := rpc.FuncClientSingleton("CheckIdPReload", orgId)
+	changed, err := rpc.FuncClientSingleton("CheckIdPReload", orgId)
 	if err != nil {
 		rpc.EmitErrorEventKv(
 			rpc.FuncClientSingletonCall,
@@ -902,8 +905,9 @@ func (r *RPCStorageHandler) CheckForIdPReload(orgId string) bool {
 		return true
 	}
 
-	if reload == true && r.Gw.idpRegistry != nil {
-		log.Info("[RPC STORE] Received client-IdP reload instruction!")
+	changedIDs, _ := changed.([]string)
+	if len(changedIDs) > 0 && r.Gw.idpRegistry != nil {
+		log.Infof("[RPC STORE] %d client-IdP change(s) signalled; refreshing registry", len(changedIDs))
 		if refreshErr := r.Gw.idpRegistry.doRefresh(); refreshErr != nil {
 			log.WithError(refreshErr).Error("client-IdP registry refresh failed; keeping previous snapshot")
 		}

--- a/gateway/rpc_test.go
+++ b/gateway/rpc_test.go
@@ -2,6 +2,7 @@
 package gateway
 
 import (
+	"context"
 	"net/http"
 	_ "net/http"
 	"testing"
@@ -54,6 +55,39 @@ func stopRPCMock(server *gorpc.Server) {
 	}
 
 	rpc.Reset()
+}
+
+// The gorpc client can only call RPCs that are registered in dispatcherFuncs;
+// the client-IdP path adds two. (GetClientIdPs was missing originally, which
+// would have failed every edge fetch.)
+func TestDispatcherFuncs_RegistersClientIdPRPCs(t *testing.T) {
+	for _, fn := range []string{"GetClientIdPs", "CheckIdPReload"} {
+		if _, ok := dispatcherFuncs[fn]; !ok {
+			t.Errorf("dispatcherFuncs must register %q so the gorpc client can call it", fn)
+		}
+	}
+}
+
+// idpReloadLoop is the parallel client-IdP poll loop; it must exit when the
+// gateway context is cancelled (shutdown) rather than spin forever.
+func TestGateway_idpReloadLoop_StopsOnShutdown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancelled up front: CheckForIdPReload returns false immediately
+
+	gw := &Gateway{ctx: ctx}
+	gw.RPCListener = RPCStorageHandler{Gw: gw}
+
+	done := make(chan struct{})
+	go func() {
+		gw.idpReloadLoop("org")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("idpReloadLoop did not exit after context cancellation")
+	}
 }
 
 const apiDefListTest = `[{

--- a/gateway/rpc_test.go
+++ b/gateway/rpc_test.go
@@ -87,7 +87,7 @@ func TestRPCStorageHandler_CheckForIdPReload_RPCDown(t *testing.T) {
 	gw.SetConfig(config.Config{})
 	store := RPCStorageHandler{Gw: gw}
 
-	if ok := store.CheckForIdPReload("org"); !ok {
+	if !store.CheckForIdPReload("org") {
 		t.Fatal("CheckForIdPReload should return true to keep the loop running on RPC error")
 	}
 }

--- a/gateway/rpc_test.go
+++ b/gateway/rpc_test.go
@@ -68,6 +68,30 @@ func TestDispatcherFuncs_RegistersClientIdPRPCs(t *testing.T) {
 	}
 }
 
+// With the RPC client down, GetClientIdPs logs the error and returns an empty
+// payload (the registry then keeps its previous snapshot).
+func TestRPCStorageHandler_GetClientIdPs_RPCDown(t *testing.T) {
+	gw := &Gateway{}
+	gw.SetConfig(config.Config{})
+	store := RPCStorageHandler{Gw: gw}
+
+	if got := store.GetClientIdPs("org", []string{"tag-a"}); got != "" {
+		t.Fatalf("RPC down should yield empty payload, got %q", got)
+	}
+}
+
+// CheckForIdPReload keeps the loop alive (returns true) when the RPC client is
+// down, logging the error without disturbing the main sync.
+func TestRPCStorageHandler_CheckForIdPReload_RPCDown(t *testing.T) {
+	gw := &Gateway{ctx: context.Background()}
+	gw.SetConfig(config.Config{})
+	store := RPCStorageHandler{Gw: gw}
+
+	if ok := store.CheckForIdPReload("org"); !ok {
+		t.Fatal("CheckForIdPReload should return true to keep the loop running on RPC error")
+	}
+}
+
 // idpReloadLoop is the parallel client-IdP poll loop; it must exit when the
 // gateway context is cancelled (shutdown) rather than spin forever.
 func TestGateway_idpReloadLoop_StopsOnShutdown(t *testing.T) {

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -244,6 +244,10 @@ type Gateway struct {
 	// apiJWKCaches cache per api entity
 	apiJWKCaches sync.Map
 
+	// idpRegistry is the in-memory client-IdP registry, a sibling dataset of the
+	// API definitions consulted only as a last fallback in the JWT path.
+	idpRegistry *IdPRegistry
+
 	limitHeaderFactory rate.HeaderSenderFactory
 
 	BundleChecksumVerifier bundleChecksumVerifyFunction
@@ -310,6 +314,7 @@ func NewGateway(config config.Config, ctx context.Context) *Gateway {
 	}
 
 	gw.jwkCache = buildJWKSCache(config)
+	gw.idpRegistry = newIdPRegistry(gw)
 	gw.BundleChecksumVerifier = defaultBundleVerifyFunction
 
 	return gw
@@ -1243,6 +1248,17 @@ func (gw *Gateway) rpcReloadLoop(rpcKey string) {
 	}
 }
 
+// idpReloadLoop long-polls the dedicated CheckIdPReload RPC. It runs parallel to
+// rpcReloadLoop so a client-IdP change refreshes ONLY the registry (one
+// GetClientIdPs RPC) without a full API/policy resync. Exits on shutdown.
+func (gw *Gateway) idpReloadLoop(rpcKey string) {
+	for {
+		if ok := gw.RPCListener.CheckForIdPReload(rpcKey); !ok {
+			return
+		}
+	}
+}
+
 // DoReloadWithError performs a full reload of APIs and policies, returning any
 // sync error that prevented a successful reload. The reloadMu mutex is acquired
 // for the duration of the reload, so each call is safe to make concurrently.
@@ -1295,6 +1311,18 @@ func (gw *Gateway) DoReloadWithError() error {
 	}
 
 	gw.loadGlobalApps()
+
+	// Refresh the client-IdP registry AFTER loadGlobalApps populates apisByID.
+	// The segment-aware backstop indexes only bindings whose api_id is present
+	// in apisByID — sequencing this before loadGlobalApps would drop every
+	// binding and 401 registry-only APIs from boot. Every DoReload (startup,
+	// reloadLoop drain, /tyk/reload, RPC NoticeGroupReload) refreshes the
+	// registry as a side effect, giving operators IdP refresh "for free".
+	if gw.idpRegistry != nil {
+		if err := gw.idpRegistry.doRefresh(); err != nil {
+			mainLog.WithError(err).Warn("IdP registry refresh failed during reload — keeping previous snapshot")
+		}
+	}
 
 	gw.MetricInstruments.RecordReload(gw.ctx, time.Since(start))
 
@@ -2341,6 +2369,7 @@ func (gw *Gateway) start() {
 
 		gw.RPCListener.Connect()
 		go gw.rpcReloadLoop(slaveOptions.RPCKey)
+		go gw.idpReloadLoop(slaveOptions.RPCKey)
 		go gw.RPCListener.StartRPCKeepaliveWatcher()
 		go gw.RPCListener.StartRPCLoopCheck(slaveOptions.RPCKey)
 	}

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -1253,7 +1253,7 @@ func (gw *Gateway) rpcReloadLoop(rpcKey string) {
 // GetClientIdPs RPC) without a full API/policy resync. Exits on shutdown.
 func (gw *Gateway) idpReloadLoop(rpcKey string) {
 	for {
-		if ok := gw.RPCListener.CheckForIdPReload(rpcKey); !ok {
+		if !gw.RPCListener.CheckForIdPReload(rpcKey) {
 			return
 		}
 	}

--- a/internal/policy/rpc.go
+++ b/internal/policy/rpc.go
@@ -12,6 +12,9 @@ type RPCDataLoaderMock struct {
 	ShouldConnect bool
 	Policies      []user.Policy
 	Apis          []model.MergedAPI
+	// ClientIdPs is the raw client-IdP registry payload (decoded gateway-side);
+	// kept as an opaque value since the IdP type lives in the gateway package.
+	ClientIdPs interface{}
 }
 
 // Connect will return the connection status.
@@ -39,4 +42,16 @@ func (s *RPCDataLoaderMock) GetPolicies(_ string) string {
 		return ""
 	}
 	return string(policyList)
+}
+
+// GetClientIdPs returns the internal ClientIdPs as a json string.
+func (s *RPCDataLoaderMock) GetClientIdPs(_ string, _ []string) string {
+	if s.ClientIdPs == nil {
+		return ""
+	}
+	idpList, err := json.Marshal(s.ClientIdPs)
+	if err != nil {
+		return ""
+	}
+	return string(idpList)
 }

--- a/internal/policy/store_mock.gen.go
+++ b/internal/policy/store_mock.gen.go
@@ -115,6 +115,44 @@ func (c *MockRPCDataLoaderGetApiDefinitionsCall) DoAndReturn(f func(string, []st
 	return c
 }
 
+// GetClientIdPs mocks base method.
+func (m *MockRPCDataLoader) GetClientIdPs(orgId string, tags []string) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClientIdPs", orgId, tags)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetClientIdPs indicates an expected call of GetClientIdPs.
+func (mr *MockRPCDataLoaderMockRecorder) GetClientIdPs(orgId, tags any) *MockRPCDataLoaderGetClientIdPsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClientIdPs", reflect.TypeOf((*MockRPCDataLoader)(nil).GetClientIdPs), orgId, tags)
+	return &MockRPCDataLoaderGetClientIdPsCall{Call: call}
+}
+
+// MockRPCDataLoaderGetClientIdPsCall wrap *gomock.Call
+type MockRPCDataLoaderGetClientIdPsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockRPCDataLoaderGetClientIdPsCall) Return(arg0 string) *MockRPCDataLoaderGetClientIdPsCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockRPCDataLoaderGetClientIdPsCall) Do(f func(string, []string) string) *MockRPCDataLoaderGetClientIdPsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockRPCDataLoaderGetClientIdPsCall) DoAndReturn(f func(string, []string) string) *MockRPCDataLoaderGetClientIdPsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetPolicies mocks base method.
 func (m *MockRPCDataLoader) GetPolicies(orgId string) string {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Summary

Adds an in-memory **`IdPRegistry`** (`gateway/idp_registry.go`) that joins an API to its client IdPs **at request time**, as a sibling dataset of the API definition travelling the same transports. The JWT middleware consults it **only as a last fallback** after the existing manual API-def branches, so DCR IdPs resolve without ever entering the API def, manual config stays authoritative, and a registry change refreshes just the registry — no router rebuild, no fleet-wide reload.

Pairs with the dashboard side (`TykTechnologies/tyk-analytics#5756`, the `/system/clientidps` feed + `NoticeClientIdPChanged` signal) and the MDCB `GetClientIdPs` RPC handler (separate ticket).

## What changed

- **`gateway/idp_registry.go`** (new) — registry with debounced (~100ms) `Refresh`, mode-branching `fetch` (direct-Dashboard HTTP `/system/clientidps`, RPC `GetClientIdPs`, file-deferred), build-then-swap `rebuild` with a **segment-aware backstop** keyed on `apisByID`, and `scopeToPolicyMapForRequest` (manual wins on collision, binding fills gaps).
- **`gateway/mw_jwt.go`** — `secretFromIdPRegistry` last-fallback probe in `getSecretToVerifySignature`; URL-keyed `fetchJWKSKey` (avoids `getSecretFromURL`'s `JWTSource`-gated cache miss); manual-first scope resolution in `processCentralisedJWT`; `hasRegistryBinding` routing gate in `ProcessRequest`.
- **`ctx/ctx.go` + `gateway/api.go`** — `MatchedIdPBinding` context key + helpers. Per-request binding lives on the **request context, never the shared middleware struct** (one `JWTMiddleware` per API, `ProcessRequest` runs concurrently).
- **`gateway/rpc_storage_handler.go` + `internal/policy/{rpc.go,store_mock.gen.go}`** — `GetClientIdPs` on `RPCDataLoader` + impl + regenerated/handwritten mocks.
- **`gateway/redis_signals.go`** — `NoticeClientIdPChanged` (registry-only refresh).
- **`gateway/server.go`** — `idpRegistry` field, init in `NewGateway`, `doRefresh` after `loadGlobalApps` in `DoReloadWithError`.

## Key properties

- **Manual config is authoritative** — appended as the last branch; an admin's `JWTSource`/`JWTJwksURIs`/scope map always wins. For manual APIs the probe never runs (cost zero, byte-identical behaviour).
- **`iss` is an unverified hint** — only selects which JWKS to try; signature verification + `validateIssuer` still run afterward.
- **Per-binding `scope_to_policy`** makes scope-name collisions between IdPs structurally impossible.
- Works for **both classic and OAS** APIs.
- HTTP fetch goes through `executeDashboardRequestWithRecovery`, inheriting nonce-failure re-registration and client config like `FromDashboardService`.

## Testing

- New unit/integration tests (all green, incl. `-race`): decoder envelope/bare-array tolerance, scope-merge collision/fill, segment backstop, build-then-swap, RPC + Dashboard fetch (incl. nonce capture), ctx roundtrip, shutdown no-op, and the three acceptance criteria — AC1 registry resolves key+scope (200), AC2 manual `JWTSource` wins, AC3 `NoticeClientIdPChanged` refreshes registry without an API reload.
- `go build ./...` + `go vet` clean; existing `TestJWT*`/`TestJWKS*`/`TestJWTScopeToPolicyMapping`/`TestManagementNodeRedisEvents` pass (no regressions).
- E2E framework available (dashboard-direct, portal DCR, MDCB) covering the full round-trip.

## Acceptance criteria

- [x] **AC1** — JWT API with no `JWTSource`/`JWTJwksURIs` + a registry binding returns 200; token scope maps to the bound policy.
- [x] **AC2** — Setting `JWTSource` bypasses the registry; manual wins on collision, binding fills absent scopes.
- [x] **AC3** — A registry change refreshes the registry with no "Reloading endpoints"/`loadGlobalApps`.

## Notes / follow-ups

- The `GetClientIdPs` RPC call on edge nodes requires the MDCB-side handler (parallel ticket); they ship coordinated. Against an older sink the call errors and is swallowed (previous snapshot kept).
- Code review flagged JWKS fan-out for tokens with absent/non-matching `iss` (walk-all per spec). Bounded by binding count (typically 1) and on par with existing manual-JWKS refetch behaviour; negative-caching is a possible future hardening.


















<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-17312" title="TT-17312" target="_blank">TT-17312</a>
</summary>

|         |    |
|---------|----|
| Status  | In Code Review |
| Summary | Gateway: client IdP registry + JWT integration |

Generated at: 2026-06-05 14:28:38

</details>

<!---TykTechnologies/jira-linter ends here-->


















