### PR TITLE
[TT-17339 release-5.13] Implement Floating tags in github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ env:
 jobs:
   dep-guard:
     if: github.event_name == 'pull_request'
-    uses: TykTechnologies/github-actions/.github/workflows/dependency-guard.yml@186b3eafdbda5d8ed71646c00e2bfd9893c88aaf
+    uses: TykTechnologies/github-actions/.github/workflows/dependency-guard.yml@production
     permissions:
       contents: read
   goreleaser:
@@ -44,7 +44,7 @@ jobs:
       (needs.dep-guard.result == 'success' || needs.dep-guard.result == 'skipped') &&
       github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
-    runs-on: ${{ vars.DEFAULT_RUNNER }}
+    runs-on: ${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
     permissions:
       id-token: write # AWS OIDC JWT
       contents: read # actions/checkout
@@ -61,7 +61,6 @@ jobs:
             debvers: 'ubuntu/xenial ubuntu/bionic ubuntu/focal ubuntu/jammy ubuntu/noble debian/jessie debian/buster debian/bullseye debian/bookworm debian/trixie'
     outputs:
       ee_tags: ${{ steps.ci_metadata_ee.outputs.tags }}
-      fips_tags: ${{ steps.ci_metadata_fips.outputs.tags }}
       std_tags: ${{ steps.ci_metadata_std.outputs.tags }}
       commit_author: ${{ steps.set_outputs.outputs.commit_author}}
     steps:
@@ -171,10 +170,9 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/s390x' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
-          sbom: true
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -182,10 +180,9 @@ jobs:
           labels: ${{ steps.ci_metadata_ee.outputs.labels }}
           build-args: |
             BUILD_PACKAGE_NAME=tyk-gateway-ee
-            BASE_IMAGE=tykio/dhi-busybox:1.37-fips
-            NONROOT_CHOWN=true
       - name: Docker metadata for ee tag push
         id: tag_metadata_ee
+        if: startsWith(github.ref, 'refs/tags')
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
@@ -203,119 +200,19 @@ jobs:
             org.opencontainers.image.vendor=tyk.io
             org.opencontainers.image.version=${{ github.ref_name }}
       - name: push ee image to prod
-        if: ${{ matrix.golang_cross == '1.25-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.25-bullseye' && startsWith(github.ref, 'refs/tags') }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/s390x
           file: ci/Dockerfile.distroless
           provenance: mode=max
-          sbom: true
           cache-from: type=gha
-          cache-to: type=gha,mode=max
-          push: ${{ startsWith(github.ref, 'refs/tags') }}
+          push: true
           tags: ${{ steps.tag_metadata_ee.outputs.tags }}
           labels: ${{ steps.tag_metadata_ee.outputs.labels }}
           build-args: |
             BUILD_PACKAGE_NAME=tyk-gateway-ee
-            BASE_IMAGE=tykio/dhi-busybox:1.37-fips
-            NONROOT_CHOWN=true
-      - name: Attach base image VEX to ee
-        if: ${{ matrix.golang_cross == '1.25-bullseye' && startsWith(github.ref, 'refs/tags') }}
-        run: |
-          # Install Docker Scout CLI
-          curl -fsSL https://raw.githubusercontent.com/docker/scout-cli/v1.20.4/install.sh -o /tmp/scout-install.sh && sh /tmp/scout-install.sh 2>/dev/null
-          # Extract VEX from the DHI base image
-          docker scout vex get --org tykio -o /tmp/ee-vex.json tykio/dhi-busybox:1.37-fips || true
-          if [ -f /tmp/ee-vex.json ]; then
-            cosign attest --yes --type openvex \
-              --predicate /tmp/ee-vex.json \
-              docker.tyk.io/tyk-gateway/tyk-gateway-ee:${{ github.ref_name }} || true
-            cosign attest --yes --type openvex \
-              --predicate /tmp/ee-vex.json \
-              tykio/tyk-gateway-ee:${{ github.ref_name }} || true
-          fi
-      - name: Docker metadata for fips CI
-        id: ci_metadata_fips
-        if: ${{ matrix.golang_cross == '1.25-bullseye' }}
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
-        with:
-          images: |
-            ${{ steps.ecr.outputs.registry }}/tyk-fips
-          flavor: |
-            latest=false
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=sha,format=long
-            type=semver,pattern={{major}},prefix=v
-            type=semver,pattern={{major}}.{{minor}},prefix=v
-            type=semver,pattern={{version}},prefix=v
-      - name: push fips image to CI
-        if: ${{ matrix.golang_cross == '1.25-bullseye' }}
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
-        with:
-          context: "dist"
-          platforms: linux/amd64,linux/arm64
-          file: ci/Dockerfile.distroless
-          provenance: mode=max
-          sbom: true
-          push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          tags: ${{ steps.ci_metadata_fips.outputs.tags }}
-          labels: ${{ steps.ci_metadata_fips.outputs.labels }}
-          build-args: |
-            BUILD_PACKAGE_NAME=tyk-gateway-fips
-            BASE_IMAGE=tykio/dhi-busybox:1.37-fips
-            NONROOT_CHOWN=true
-      - name: Docker metadata for fips tag push
-        id: tag_metadata_fips
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
-        with:
-          images: |
-            tykio/tyk-gateway-fips
-          flavor: |
-            latest=false
-            prefix=v
-          tags: |
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{version}}
-          labels: |
-            org.opencontainers.image.title=Tyk Gateway Enterprise Edition FIPS
-            org.opencontainers.image.description=Tyk API Gateway Enterprise Edition written in Go, supporting REST, GraphQL, TCP and gRPC protocols Built with FIPS 140-3 compliant cryptography
-            org.opencontainers.image.vendor=tyk.io
-            org.opencontainers.image.version=${{ github.ref_name }}
-      - name: push fips image to prod
-        if: ${{ matrix.golang_cross == '1.25-bullseye' }}
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
-        with:
-          context: "dist"
-          platforms: linux/amd64,linux/arm64
-          file: ci/Dockerfile.distroless
-          provenance: mode=max
-          sbom: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          push: ${{ startsWith(github.ref, 'refs/tags') }}
-          tags: ${{ steps.tag_metadata_fips.outputs.tags }}
-          labels: ${{ steps.tag_metadata_fips.outputs.labels }}
-          build-args: |
-            BUILD_PACKAGE_NAME=tyk-gateway-fips
-            BASE_IMAGE=tykio/dhi-busybox:1.37-fips
-            NONROOT_CHOWN=true
-      - name: Attach base image VEX to fips
-        if: ${{ matrix.golang_cross == '1.25-bullseye' && startsWith(github.ref, 'refs/tags') }}
-        run: |
-          # Install Docker Scout CLI
-          curl -fsSL https://raw.githubusercontent.com/docker/scout-cli/v1.20.4/install.sh -o /tmp/scout-install.sh && sh /tmp/scout-install.sh 2>/dev/null
-          # Extract VEX from the DHI base image
-          docker scout vex get --org tykio -o /tmp/fips-vex.json tykio/dhi-busybox:1.37-fips || true
-          if [ -f /tmp/fips-vex.json ]; then
-            cosign attest --yes --type openvex \
-              --predicate /tmp/fips-vex.json \
-              tykio/tyk-gateway-fips:${{ github.ref_name }} || true
-          fi
       - name: Docker metadata for std CI
         id: ci_metadata_std
         if: ${{ matrix.golang_cross == '1.25-bullseye' }}
@@ -337,10 +234,9 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: linux/amd64,linux/arm64,linux/s390x
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/s390x' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
-          sbom: true
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -350,6 +246,7 @@ jobs:
             BUILD_PACKAGE_NAME=tyk-gateway
       - name: Docker metadata for std tag push
         id: tag_metadata_std
+        if: startsWith(github.ref, 'refs/tags')
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
@@ -367,17 +264,15 @@ jobs:
             org.opencontainers.image.vendor=tyk.io
             org.opencontainers.image.version=${{ github.ref_name }}
       - name: push std image to prod
-        if: ${{ matrix.golang_cross == '1.25-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.25-bullseye' && startsWith(github.ref, 'refs/tags') }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
           platforms: linux/amd64,linux/arm64,linux/s390x
           file: ci/Dockerfile.distroless
           provenance: mode=max
-          sbom: true
           cache-from: type=gha
-          cache-to: type=gha,mode=max
-          push: ${{ startsWith(github.ref, 'refs/tags') }}
+          push: true
           tags: ${{ steps.tag_metadata_std.outputs.tags }}
           labels: ${{ steps.tag_metadata_std.outputs.labels }}
           build-args: |
@@ -539,7 +434,7 @@ jobs:
           COMMIT_SHA: ${{ github.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HAS_RELEVANT_CHANGES: ${{ steps.check_changes.outputs.has_relevant_changes }}
-          ORG_GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
         run: |
           echo "=================================="
           echo "📊 Dashboard Image Resolution"
@@ -615,11 +510,8 @@ jobs:
           echo "✅ Resolution complete"
           echo "=================================="
   build-dashboard-image:
+    if: needs.resolve-dashboard-image.outputs.needs_build == 'true'
     needs: resolve-dashboard-image
-    if: |
-      !cancelled() &&
-      needs.resolve-dashboard-image.result == 'success' &&
-      needs.resolve-dashboard-image.outputs.needs_build == 'true'
     runs-on: ${{ vars.DEFAULT_RUNNER }}
     permissions:
       id-token: write
@@ -818,7 +710,7 @@ jobs:
       sink: ${{ steps.params.outputs.sink }}
     steps:
       - name: Set test parameters
-        uses: TykTechnologies/github-actions/.github/actions/tests/test-controller@42304edda365365e0a887cf018d8edc34b960b82 # main
+        uses: TykTechnologies/github-actions/.github/actions/tests/test-controller@production
         id: params
         with:
           variation: ${{ env.VARIATION }}
@@ -880,11 +772,11 @@ jobs:
           # Only ${{ github.actor }} has access
           # See https://github.com/mxschmitt/action-tmate#use-registered-public-ssh-keys
       - name: Fetch environment from tyk-pro
-        uses: TykTechnologies/github-actions/.github/actions/tests/checkout-tyk-pro@42304edda365365e0a887cf018d8edc34b960b82 # main
+        uses: TykTechnologies/github-actions/.github/actions/tests/checkout-tyk-pro@production
         with:
-          org_gh_token: ${{ github.token }}
+          org_gh_token: ${{ steps.app-token.outputs.token }}
       - name: Set up test environment
-        uses: TykTechnologies/github-actions/.github/actions/tests/env-up@42304edda365365e0a887cf018d8edc34b960b82 # main
+        uses: TykTechnologies/github-actions/.github/actions/tests/env-up@production
         timeout-minutes: 5
         id: env_up
         with:
@@ -895,18 +787,18 @@ jobs:
           TYK_DB_LICENSEKEY: ${{ secrets.DASH_LICENSE }}
           TYK_MDCB_LICENSE: ${{ secrets.MDCB_LICENSE }}
       - name: Choose test code branch
-        uses: TykTechnologies/github-actions/.github/actions/tests/choose-test-branch@42304edda365365e0a887cf018d8edc34b960b82 # main
+        uses: TykTechnologies/github-actions/.github/actions/tests/choose-test-branch@production
         with:
           test_folder: api
           org_gh_token: ${{ steps.app-token.outputs.token }}
       - name: Run API tests
-        uses: TykTechnologies/github-actions/.github/actions/tests/api-tests@42304edda365365e0a887cf018d8edc34b960b82 # main
-        timeout-minutes: 40
+        uses: TykTechnologies/github-actions/.github/actions/tests/api-tests@production
+        timeout-minutes: 45
         id: test_execution
         with:
           user_api_secret: ${{ steps.env_up.outputs.USER_API_SECRET }}
       - name: Generate test reports and collect logs
-        uses: TykTechnologies/github-actions/.github/actions/tests/reporting@42304edda365365e0a887cf018d8edc34b960b82 # main
+        uses: TykTechnologies/github-actions/.github/actions/tests/reporting@production
         if: always() && (steps.test_execution.conclusion != 'skipped')
         with:
           report_xml: 'true'
@@ -915,7 +807,7 @@ jobs:
     name: Aggregated CI Status
     runs-on: ${{ vars.DEFAULT_RUNNER }}
     # Dynamically determine which jobs to depend on based on repository configuration
-    needs: [goreleaser, api-tests, dep-guard]
+    needs: [dep-guard, goreleaser, api-tests]
     if: ${{ always() && github.event_name == 'pull_request' }}
     steps:
       - name: Aggregate results
@@ -972,9 +864,6 @@ jobs:
     runs-on: ${{ vars.DEFAULT_RUNNER }}
     needs:
       - test-controller-distros
-    if: |
-      !cancelled() &&
-      needs.test-controller-distros.result == 'success'
     strategy:
       fail-fast: true
       matrix:
@@ -1034,9 +923,6 @@ jobs:
     runs-on: ${{ vars.DEFAULT_RUNNER }}
     needs:
       - test-controller-distros
-    if: |
-      !cancelled() &&
-      needs.test-controller-distros.result == 'success'
     strategy:
       fail-fast: true
       matrix:

--- a/ci/goreleaser/goreleaser.yml
+++ b/ci/goreleaser/goreleaser.yml
@@ -57,60 +57,6 @@ builds:
     goarch:
       - s390x
     binary: tyk
-  - id: fips-amd64
-    flags:
-      - -tags=goplugin,ee,fips
-      - -trimpath
-    env:
-      - NOP=nop # ignore this, it is jsut to avoid a complex conditional in the templates
-      - CC=gcc
-      - GOFIPS140=v1.0.0
-    ldflags:
-      - -X github.com/TykTechnologies/tyk/internal/build.Version={{.Version}}
-      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
-      - -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
-      - -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
-    goos:
-      - linux
-    goarch:
-      - amd64
-    binary: tyk
-  - id: fips-arm64
-    flags:
-      - -tags=goplugin,ee,fips
-      - -trimpath
-    env:
-      - NOP=nop # ignore this, it is jsut to avoid a complex conditional in the templates
-      - CC=aarch64-linux-gnu-gcc
-      - GOFIPS140=v1.0.0
-    ldflags:
-      - -X github.com/TykTechnologies/tyk/internal/build.Version={{.Version}}
-      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
-      - -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
-      - -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
-    goos:
-      - linux
-    goarch:
-      - arm64
-    binary: tyk
-  - id: fips-s390x
-    flags:
-      - -tags=goplugin,ee,fips
-      - -trimpath
-    env:
-      - NOP=nop # ignore this, it is jsut to avoid a complex conditional in the templates
-      - CC=s390x-linux-gnu-gcc
-      - GOFIPS140=v1.0.0
-    ldflags:
-      - -X github.com/TykTechnologies/tyk/internal/build.Version={{.Version}}
-      - -X github.com/TykTechnologies/tyk/internal/build.Commit={{.FullCommit}}
-      - -X github.com/TykTechnologies/tyk/internal/build.BuildDate={{.Date}}
-      - -X github.com/TykTechnologies/tyk/internal/build.BuiltBy=goreleaser
-    goos:
-      - linux
-    goarch:
-      - s390x
-    binary: tyk
   - id: std-amd64
     flags:
       - -tags=goplugin
@@ -222,65 +168,6 @@ nfpms:
       signature:
         key_file: tyk.io.signing.key
         type: origin
-  - id: fips
-    vendor: "Tyk Technologies Ltd"
-    homepage: "https://tyk.io"
-    maintainer: "Tyk <info@tyk.io>"
-    description: Tyk API Gateway Enterprise Edition written in Go, supporting REST, GraphQL, TCP and gRPC protocols Built with FIPS 140-3 compliant cryptography
-    package_name: tyk-gateway-fips
-    file_name_template: "{{ .ConventionalFileName }}"
-    ids:
-      - fips-amd64
-      - fips-arm64
-      - fips-s390x
-    formats:
-      - deb
-      - rpm
-    contents:
-      - src: "README.md"
-        dst: "/opt/share/docs/tyk-gateway/README.md"
-      - src: "ci/install/*"
-        dst: "/opt/tyk-gateway/install"
-      - src: ci/install/inits/systemd/system/tyk-gateway.service
-        dst: /lib/systemd/system/tyk-gateway.service
-      - src: ci/install/inits/sysv/init.d/tyk-gateway
-        dst: /etc/init.d/tyk-gateway
-      - src: /opt/tyk-gateway
-        dst: /opt/tyk
-        type: "symlink"
-      - src: "LICENSE.md"
-        dst: "/opt/share/docs/tyk-gateway/LICENSE.md"
-      - src: "apps/app_sample.*"
-        dst: "/opt/tyk-gateway/apps"
-      - src: "templates/*.json"
-        dst: "/opt/tyk-gateway/templates"
-      - src: "templates/playground/*"
-        dst: "/opt/tyk-gateway/templates/playground"
-      - src: "middleware/*.js"
-        dst: "/opt/tyk-gateway/middleware"
-      - src: "event_handlers/sample/*.js"
-        dst: "/opt/tyk-gateway/event_handlers/sample"
-      - src: "policies/*.json"
-        dst: "/opt/tyk-gateway/policies"
-      - src: "coprocess/*"
-        dst: "/opt/tyk-gateway/coprocess"
-      - src: tyk.conf.example
-        dst: /opt/tyk-gateway/tyk.conf
-        type: "config|noreplace"
-    scripts:
-      preinstall: "ci/install/before_install.sh"
-      postinstall: "ci/install/post_install.sh"
-      postremove: "ci/install/post_remove.sh"
-    bindir: "/opt/tyk-gateway"
-    rpm:
-      scripts:
-        posttrans: ci/install/post_trans.sh
-      signature:
-        key_file: tyk.io.signing.key
-    deb:
-      signature:
-        key_file: tyk.io.signing.key
-        type: origin
   - id: std
     vendor: "Tyk Technologies Ltd"
     homepage: "https://tyk.io"
@@ -344,12 +231,6 @@ publishers:
   - name: ee
     ids:
       - ee
-    env:
-      - PACKAGECLOUD_TOKEN={{ .Env.PACKAGECLOUD_TOKEN }}
-    cmd: packagecloud publish --debvers "{{ .Env.DEBVERS }}" --rpmvers "{{ .Env.RPMVERS }}" tyk/tyk-ee-unstable {{ .ArtifactPath }}
-  - name: fips
-    ids:
-      - fips
     env:
       - PACKAGECLOUD_TOKEN={{ .Env.PACKAGECLOUD_TOKEN }}
     cmd: packagecloud publish --debvers "{{ .Env.DEBVERS }}" --rpmvers "{{ .Env.RPMVERS }}" tyk/tyk-ee-unstable {{ .ArtifactPath }}


### PR DESCRIPTION
Maintain a mutable tag (e.g. production) in the GitHub Actions repo, moved to the latest commit. Product repos reference @production and pick up updates automatically.
This is a follow up of the Spike ticket: https://tyktech.atlassian.net/jira/software/c/projects/TT/boards/451?assignee=5ed4afcb53ec400c2c067d80&selectedIssue=TT-17303 
